### PR TITLE
PSR-7 Part 3: Post Bugfix & HTTPRequestOptions

### DIFF
--- a/mod/match.php
+++ b/mod/match.php
@@ -83,7 +83,7 @@ function match_content(App $a)
 			continue;
 		}
 
-		$msearch = json_decode(DI::httpRequest()->post($server . '/msearch', $params)->getBody());
+		$msearch = json_decode(DI::httpClient()->post($server . '/msearch', $params)->getBody());
 		if (!empty($msearch)) {
 			$entries = match_get_contacts($msearch, $entries, $limit);
 		}

--- a/mod/ostatus_subscribe.php
+++ b/mod/ostatus_subscribe.php
@@ -57,7 +57,7 @@ function ostatus_subscribe_content(App $a)
 			$api = $contact['baseurl'] . '/api/';
 
 			// Fetching friends
-			$curlResult = DI::httpRequest()->get($api . 'statuses/friends.json?screen_name=' . $contact['nick']);
+			$curlResult = DI::httpClient()->get($api . 'statuses/friends.json?screen_name=' . $contact['nick']);
 
 			if (!$curlResult->isSuccess()) {
 				DI::pConfig()->delete($uid, 'ostatus', 'legacy_contact');

--- a/mod/pubsubhubbub.php
+++ b/mod/pubsubhubbub.php
@@ -125,7 +125,7 @@ function pubsubhubbub_init(App $a) {
 		$hub_callback = rtrim($hub_callback, ' ?&#');
 		$separator = parse_url($hub_callback, PHP_URL_QUERY) === null ? '?' : '&';
 
-		$fetchResult = DI::httpRequest()->fetchFull($hub_callback . $separator . $params);
+		$fetchResult = DI::httpClient()->fetchFull($hub_callback . $separator . $params);
 		$body = $fetchResult->getBody();
 		$ret = $fetchResult->getReturnCode();
 

--- a/mod/redir.php
+++ b/mod/redir.php
@@ -142,7 +142,7 @@ function redir_magic($a, $cid, $url)
 	}
 
 	// Test for magic auth on the target system
-	$serverret = DI::httpRequest()->get($basepath . '/magic');
+	$serverret = DI::httpClient()->get($basepath . '/magic');
 	if ($serverret->isSuccess()) {
 		$separator = strpos($target_url, '?') ? '&' : '?';
 		$target_url .= $separator . 'zrl=' . urlencode($visitor) . '&addr=' . urlencode($contact_url);

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -97,7 +97,7 @@ class OEmbed
 
 			if (!in_array($ext, $noexts)) {
 				// try oembed autodiscovery
-				$html_text = DI::httpRequest()->fetch($embedurl, 15, 'text/*');
+				$html_text = DI::httpClient()->fetch($embedurl, 15, 'text/*');
 				if (!empty($html_text)) {
 					$dom = new DOMDocument();
 					if (@$dom->loadHTML($html_text)) {
@@ -111,7 +111,7 @@ class OEmbed
 							// but their OEmbed endpoint is only accessible by HTTPS ¯\_(ツ)_/¯
 							$href = str_replace(['http://www.youtube.com/', 'http://player.vimeo.com/'],
 								['https://www.youtube.com/', 'https://player.vimeo.com/'], $href);
-							$result = DI::httpRequest()->fetchFull($href . '&maxwidth=' . $a->getThemeInfoValue('videowidth'));
+							$result = DI::httpClient()->fetchFull($href . '&maxwidth=' . $a->getThemeInfoValue('videowidth'));
 							if ($result->getReturnCode() === 200) {
 								$json_string = $result->getBody();
 								break;

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -494,7 +494,7 @@ class BBCode
 					continue;
 				}
 
-				$curlResult = DI::httpRequest()->get($mtch[1]);
+				$curlResult = DI::httpClient()->get($mtch[1]);
 				if (!$curlResult->isSuccess()) {
 					continue;
 				}
@@ -1194,7 +1194,7 @@ class BBCode
 		$text = DI::cache()->get($cache_key);
 
 		if (is_null($text)) {
-			$curlResult = DI::httpRequest()->head($match[1], [HTTPClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
+			$curlResult = DI::httpClient()->head($match[1], [HTTPClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
 			if ($curlResult->isSuccess()) {
 				$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 			} else {
@@ -1207,7 +1207,7 @@ class BBCode
 				$text = "[url=" . $match[2] . ']' . $match[2] . "[/url]";
 
 				// if its not a picture then look if its a page that contains a picture link
-				$body = DI::httpRequest()->fetch($match[1]);
+				$body = DI::httpClient()->fetch($match[1]);
 				if (empty($body)) {
 					DI::cache()->set($cache_key, $text);
 					return $text;
@@ -1265,7 +1265,7 @@ class BBCode
 			return $text;
 		}
 
-		$curlResult = DI::httpRequest()->head($match[1], [HTTPClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
+		$curlResult = DI::httpClient()->head($match[1], [HTTPClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
 		if ($curlResult->isSuccess()) {
 			$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 		} else {
@@ -1283,7 +1283,7 @@ class BBCode
 			}
 
 			// if its not a picture then look if its a page that contains a picture link
-			$body = DI::httpRequest()->fetch($match[1]);
+			$body = DI::httpClient()->fetch($match[1]);
 			if (empty($body)) {
 				DI::cache()->set($cache_key, $text);
 				return $text;

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -39,6 +39,7 @@ use Friendica\Model\Event;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
+use Friendica\Network\HTTPRequestOptions;
 use Friendica\Object\Image;
 use Friendica\Protocol\Activity;
 use Friendica\Util\Images;
@@ -1193,7 +1194,7 @@ class BBCode
 		$text = DI::cache()->get($cache_key);
 
 		if (is_null($text)) {
-			$curlResult = DI::httpRequest()->head($match[1], ['timeout' => DI::config()->get('system', 'xrd_timeout')]);
+			$curlResult = DI::httpRequest()->head($match[1], [HTTPRequestOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
 			if ($curlResult->isSuccess()) {
 				$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 			} else {
@@ -1264,7 +1265,7 @@ class BBCode
 			return $text;
 		}
 
-		$curlResult = DI::httpRequest()->head($match[1], ['timeout' => DI::config()->get('system', 'xrd_timeout')]);
+		$curlResult = DI::httpRequest()->head($match[1], [HTTPRequestOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
 		if ($curlResult->isSuccess()) {
 			$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 		} else {

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -39,7 +39,7 @@ use Friendica\Model\Event;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
-use Friendica\Network\HTTPRequestOptions;
+use Friendica\Network\HTTPClientOptions;
 use Friendica\Object\Image;
 use Friendica\Protocol\Activity;
 use Friendica\Util\Images;
@@ -1194,7 +1194,7 @@ class BBCode
 		$text = DI::cache()->get($cache_key);
 
 		if (is_null($text)) {
-			$curlResult = DI::httpRequest()->head($match[1], [HTTPRequestOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
+			$curlResult = DI::httpRequest()->head($match[1], [HTTPClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
 			if ($curlResult->isSuccess()) {
 				$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 			} else {
@@ -1265,7 +1265,7 @@ class BBCode
 			return $text;
 		}
 
-		$curlResult = DI::httpRequest()->head($match[1], [HTTPRequestOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
+		$curlResult = DI::httpRequest()->head($match[1], [HTTPClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
 		if ($curlResult->isSuccess()) {
 			$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 		} else {

--- a/src/Core/Installer.php
+++ b/src/Core/Installer.php
@@ -557,11 +557,11 @@ class Installer
 		$help = "";
 		$error_msg = "";
 		if (function_exists('curl_init')) {
-			$fetchResult = DI::httpRequest()->fetchFull($baseurl . "/install/testrewrite");
+			$fetchResult = DI::httpClient()->fetchFull($baseurl . "/install/testrewrite");
 
 			$url = Strings::normaliseLink($baseurl . "/install/testrewrite");
 			if ($fetchResult->getReturnCode() != 204) {
-				$fetchResult = DI::httpRequest()->fetchFull($url);
+				$fetchResult = DI::httpClient()->fetchFull($url);
 			}
 
 			if ($fetchResult->getReturnCode() != 204) {

--- a/src/Core/Protocol.php
+++ b/src/Core/Protocol.php
@@ -122,7 +122,7 @@ class Protocol
 		if (preg_match('=https?://(.*)/user/(.*)=ism', $profile_url, $matches)) {
 			$statusnet_host = $matches[1];
 			$statusnet_user = $matches[2];
-			$UserData = DI::httpRequest()->fetch('http://' . $statusnet_host . '/api/users/show.json?user_id=' . $statusnet_user);
+			$UserData = DI::httpClient()->fetch('http://' . $statusnet_host . '/api/users/show.json?user_id=' . $statusnet_user);
 			$user = json_decode($UserData);
 			if ($user) {
 				$matches[2] = $user->screen_name;

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -122,7 +122,7 @@ class Search
 			$searchUrl .= '&page=' . $page;
 		}
 
-		$resultJson = DI::httpRequest()->fetch($searchUrl, 0, 'application/json');
+		$resultJson = DI::httpClient()->fetch($searchUrl, 0, 'application/json');
 
 		$results = json_decode($resultJson, true);
 
@@ -228,7 +228,7 @@ class Search
 			$return = Contact::searchByName($search, $mode);
 		} else {
 			$p = $page > 1 ? 'p=' . $page : '';
-			$curlResult = DI::httpRequest()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), [HTTPClientOptions::ACCEPT_CONTENT => ['application/json']]);
+			$curlResult = DI::httpClient()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), [HTTPClientOptions::ACCEPT_CONTENT => ['application/json']]);
 			if ($curlResult->isSuccess()) {
 				$searchResult = json_decode($curlResult->getBody(), true);
 				if (!empty($searchResult['profiles'])) {

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -24,7 +24,7 @@ namespace Friendica\Core;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Network\HTTPException;
-use Friendica\Network\HTTPRequestOptions;
+use Friendica\Network\HTTPClientOptions;
 use Friendica\Object\Search\ContactResult;
 use Friendica\Object\Search\ResultList;
 use Friendica\Util\Network;
@@ -228,7 +228,7 @@ class Search
 			$return = Contact::searchByName($search, $mode);
 		} else {
 			$p = $page > 1 ? 'p=' . $page : '';
-			$curlResult = DI::httpRequest()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), [HTTPRequestOptions::ACCEPT_CONTENT => ['application/json']]);
+			$curlResult = DI::httpRequest()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), [HTTPClientOptions::ACCEPT_CONTENT => ['application/json']]);
 			if ($curlResult->isSuccess()) {
 				$searchResult = json_decode($curlResult->getBody(), true);
 				if (!empty($searchResult['profiles'])) {

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -24,6 +24,7 @@ namespace Friendica\Core;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Network\HTTPException;
+use Friendica\Network\HTTPRequestOptions;
 use Friendica\Object\Search\ContactResult;
 use Friendica\Object\Search\ResultList;
 use Friendica\Util\Network;
@@ -227,7 +228,7 @@ class Search
 			$return = Contact::searchByName($search, $mode);
 		} else {
 			$p = $page > 1 ? 'p=' . $page : '';
-			$curlResult = DI::httpRequest()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), ['accept_content' => ['application/json']]);
+			$curlResult = DI::httpRequest()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), [HTTPRequestOptions::ACCEPT_CONTENT => ['application/json']]);
 			if ($curlResult->isSuccess()) {
 				$searchResult = json_decode($curlResult->getBody(), true);
 				if (!empty($searchResult['profiles'])) {

--- a/src/DI.php
+++ b/src/DI.php
@@ -420,7 +420,7 @@ abstract class DI
 	/**
 	 * @return Network\IHTTPClient
 	 */
-	public static function httpRequest()
+	public static function httpClient()
 	{
 		return self::$dice->create(Network\IHTTPClient::class);
 	}

--- a/src/Factory/HTTPClientFactory.php
+++ b/src/Factory/HTTPClientFactory.php
@@ -5,9 +5,12 @@ namespace Friendica\Factory;
 use Friendica\App;
 use Friendica\BaseFactory;
 use Friendica\Core\Config\IConfig;
+use Friendica\Core\System;
 use Friendica\Network\HTTPClient;
 use Friendica\Network\IHTTPClient;
+use Friendica\Util\Crypto;
 use Friendica\Util\Profiler;
+use Friendica\Util\Strings;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\RequestOptions;
@@ -103,7 +106,7 @@ class HTTPClientFactory extends BaseFactory
 		$resolver->setMaxResponseDataSize(1000000);
 		// Designate a temporary file that will store cookies during the session.
 		// Some websites test the browser for cookie support, so this enhances results.
-		$resolver->setCookieJar(tempnam(get_temppath(), 'resolver-cookie-'));
+		$resolver->setCookieJar(get_temppath() .'/resolver-cookie-' . Strings::getRandomName(10));
 
 		return new HTTPClient($logger, $this->profiler, $guzzle, $resolver);
 	}

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -32,6 +32,7 @@ use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Module\Register;
+use Friendica\Network\HTTPRequestOptions;
 use Friendica\Network\IHTTPResult;
 use Friendica\Protocol\Relay;
 use Friendica\Util\DateTimeFormat;
@@ -314,7 +315,7 @@ class GServer
 
 		// When a nodeinfo is present, we don't need to dig further
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpRequest()->get($url . '/.well-known/nodeinfo', ['timeout' => $xrd_timeout]);
+		$curlResult = DI::httpRequest()->get($url . '/.well-known/nodeinfo', [HTTPRequestOptions::TIMEOUT => $xrd_timeout]);
 		if ($curlResult->isTimeout()) {
 			self::setFailure($url);
 			return false;
@@ -322,7 +323,7 @@ class GServer
 
 		// On a redirect follow the new host but mark the old one as failure
 		if ($curlResult->isSuccess() && (parse_url($url, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST))) {
-			$curlResult = DI::httpRequest()->get($url, ['timeout' => $xrd_timeout]);
+			$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::TIMEOUT => $xrd_timeout]);
 			if (parse_url($url, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST)) {
 				Logger::info('Found redirect. Mark old entry as failure', ['old' => $url, 'new' => $curlResult->getRedirectUrl()]);
 				self::setFailure($url);
@@ -358,7 +359,7 @@ class GServer
 					$basedata = ['detection-method' => self::DETECT_MANUAL];
 				}
 
-				$curlResult = DI::httpRequest()->get($baseurl, ['timeout' => $xrd_timeout]);
+				$curlResult = DI::httpRequest()->get($baseurl, [HTTPRequestOptions::TIMEOUT => $xrd_timeout]);
 				if ($curlResult->isSuccess()) {
 					if ((parse_url($baseurl, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST))) {
 						Logger::info('Found redirect. Mark old entry as failure', ['old' => $url, 'new' => $curlResult->getRedirectUrl()]);
@@ -382,7 +383,7 @@ class GServer
 					// When the base path doesn't seem to contain a social network we try the complete path.
 					// Most detectable system have to be installed in the root directory.
 					// We checked the base to avoid false positives.
-					$curlResult = DI::httpRequest()->get($url, ['timeout' => $xrd_timeout]);
+					$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::TIMEOUT => $xrd_timeout]);
 					if ($curlResult->isSuccess()) {
 						$urldata = self::analyseRootHeader($curlResult, $serverdata);
 						$urldata = self::analyseRootBody($curlResult, $urldata, $url);
@@ -958,7 +959,7 @@ class GServer
 	private static function validHostMeta(string $url)
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpRequest()->get($url . '/.well-known/host-meta', ['timeout' => $xrd_timeout]);
+		$curlResult = DI::httpRequest()->get($url . '/.well-known/host-meta', [HTTPRequestOptions::TIMEOUT => $xrd_timeout]);
 		if (!$curlResult->isSuccess()) {
 			return false;
 		}
@@ -1728,7 +1729,7 @@ class GServer
 
 		if (!empty($accesstoken)) {
 			$api = 'https://instances.social/api/1.0/instances/list?count=0';
-			$curlResult = DI::httpRequest()->get($api, ['header' => ['Authorization' => ['Bearer ' . $accesstoken]]]);
+			$curlResult = DI::httpRequest()->get($api, [HTTPRequestOptions::HEADERS => ['Authorization' => ['Bearer ' . $accesstoken]]]);
 
 			if ($curlResult->isSuccess()) {
 				$servers = json_decode($curlResult->getBody(), true);

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -32,7 +32,7 @@ use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Module\Register;
-use Friendica\Network\HTTPRequestOptions;
+use Friendica\Network\HTTPClientOptions;
 use Friendica\Network\IHTTPResult;
 use Friendica\Protocol\Relay;
 use Friendica\Util\DateTimeFormat;
@@ -315,7 +315,7 @@ class GServer
 
 		// When a nodeinfo is present, we don't need to dig further
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpRequest()->get($url . '/.well-known/nodeinfo', [HTTPRequestOptions::TIMEOUT => $xrd_timeout]);
+		$curlResult = DI::httpRequest()->get($url . '/.well-known/nodeinfo', [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
 		if ($curlResult->isTimeout()) {
 			self::setFailure($url);
 			return false;
@@ -323,7 +323,7 @@ class GServer
 
 		// On a redirect follow the new host but mark the old one as failure
 		if ($curlResult->isSuccess() && (parse_url($url, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST))) {
-			$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::TIMEOUT => $xrd_timeout]);
+			$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
 			if (parse_url($url, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST)) {
 				Logger::info('Found redirect. Mark old entry as failure', ['old' => $url, 'new' => $curlResult->getRedirectUrl()]);
 				self::setFailure($url);
@@ -359,7 +359,7 @@ class GServer
 					$basedata = ['detection-method' => self::DETECT_MANUAL];
 				}
 
-				$curlResult = DI::httpRequest()->get($baseurl, [HTTPRequestOptions::TIMEOUT => $xrd_timeout]);
+				$curlResult = DI::httpRequest()->get($baseurl, [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
 				if ($curlResult->isSuccess()) {
 					if ((parse_url($baseurl, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST))) {
 						Logger::info('Found redirect. Mark old entry as failure', ['old' => $url, 'new' => $curlResult->getRedirectUrl()]);
@@ -383,7 +383,7 @@ class GServer
 					// When the base path doesn't seem to contain a social network we try the complete path.
 					// Most detectable system have to be installed in the root directory.
 					// We checked the base to avoid false positives.
-					$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::TIMEOUT => $xrd_timeout]);
+					$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
 					if ($curlResult->isSuccess()) {
 						$urldata = self::analyseRootHeader($curlResult, $serverdata);
 						$urldata = self::analyseRootBody($curlResult, $urldata, $url);
@@ -959,7 +959,7 @@ class GServer
 	private static function validHostMeta(string $url)
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpRequest()->get($url . '/.well-known/host-meta', [HTTPRequestOptions::TIMEOUT => $xrd_timeout]);
+		$curlResult = DI::httpRequest()->get($url . '/.well-known/host-meta', [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
 		if (!$curlResult->isSuccess()) {
 			return false;
 		}
@@ -1729,7 +1729,7 @@ class GServer
 
 		if (!empty($accesstoken)) {
 			$api = 'https://instances.social/api/1.0/instances/list?count=0';
-			$curlResult = DI::httpRequest()->get($api, [HTTPRequestOptions::HEADERS => ['Authorization' => ['Bearer ' . $accesstoken]]]);
+			$curlResult = DI::httpRequest()->get($api, [HTTPClientOptions::HEADERS => ['Authorization' => ['Bearer ' . $accesstoken]]]);
 
 			if ($curlResult->isSuccess()) {
 				$servers = json_decode($curlResult->getBody(), true);

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -315,7 +315,7 @@ class GServer
 
 		// When a nodeinfo is present, we don't need to dig further
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpRequest()->get($url . '/.well-known/nodeinfo', [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
+		$curlResult = DI::httpClient()->get($url . '/.well-known/nodeinfo', [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
 		if ($curlResult->isTimeout()) {
 			self::setFailure($url);
 			return false;
@@ -323,7 +323,7 @@ class GServer
 
 		// On a redirect follow the new host but mark the old one as failure
 		if ($curlResult->isSuccess() && (parse_url($url, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST))) {
-			$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
+			$curlResult = DI::httpClient()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
 			if (parse_url($url, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST)) {
 				Logger::info('Found redirect. Mark old entry as failure', ['old' => $url, 'new' => $curlResult->getRedirectUrl()]);
 				self::setFailure($url);
@@ -359,7 +359,7 @@ class GServer
 					$basedata = ['detection-method' => self::DETECT_MANUAL];
 				}
 
-				$curlResult = DI::httpRequest()->get($baseurl, [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
+				$curlResult = DI::httpClient()->get($baseurl, [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
 				if ($curlResult->isSuccess()) {
 					if ((parse_url($baseurl, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST))) {
 						Logger::info('Found redirect. Mark old entry as failure', ['old' => $url, 'new' => $curlResult->getRedirectUrl()]);
@@ -383,7 +383,7 @@ class GServer
 					// When the base path doesn't seem to contain a social network we try the complete path.
 					// Most detectable system have to be installed in the root directory.
 					// We checked the base to avoid false positives.
-					$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
+					$curlResult = DI::httpClient()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
 					if ($curlResult->isSuccess()) {
 						$urldata = self::analyseRootHeader($curlResult, $serverdata);
 						$urldata = self::analyseRootBody($curlResult, $urldata, $url);
@@ -527,7 +527,7 @@ class GServer
 	{
 		Logger::info('Discover relay data', ['server' => $server_url]);
 
-		$curlResult = DI::httpRequest()->get($server_url . '/.well-known/x-social-relay');
+		$curlResult = DI::httpClient()->get($server_url . '/.well-known/x-social-relay');
 		if (!$curlResult->isSuccess()) {
 			return;
 		}
@@ -622,7 +622,7 @@ class GServer
 	 */
 	private static function fetchStatistics(string $url)
 	{
-		$curlResult = DI::httpRequest()->get($url . '/statistics.json');
+		$curlResult = DI::httpClient()->get($url . '/statistics.json');
 		if (!$curlResult->isSuccess()) {
 			return [];
 		}
@@ -733,7 +733,7 @@ class GServer
 	 */
 	private static function parseNodeinfo1(string $nodeinfo_url)
 	{
-		$curlResult = DI::httpRequest()->get($nodeinfo_url);
+		$curlResult = DI::httpClient()->get($nodeinfo_url);
 
 		if (!$curlResult->isSuccess()) {
 			return [];
@@ -811,7 +811,7 @@ class GServer
 	 */
 	private static function parseNodeinfo2(string $nodeinfo_url)
 	{
-		$curlResult = DI::httpRequest()->get($nodeinfo_url);
+		$curlResult = DI::httpClient()->get($nodeinfo_url);
 		if (!$curlResult->isSuccess()) {
 			return [];
 		}
@@ -890,7 +890,7 @@ class GServer
 	 */
 	private static function fetchSiteinfo(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpRequest()->get($url . '/siteinfo.json');
+		$curlResult = DI::httpClient()->get($url . '/siteinfo.json');
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
 		}
@@ -959,7 +959,7 @@ class GServer
 	private static function validHostMeta(string $url)
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpRequest()->get($url . '/.well-known/host-meta', [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
+		$curlResult = DI::httpClient()->get($url . '/.well-known/host-meta', [HTTPClientOptions::TIMEOUT => $xrd_timeout]);
 		if (!$curlResult->isSuccess()) {
 			return false;
 		}
@@ -1049,7 +1049,7 @@ class GServer
 	{
 		$serverdata['poco'] = '';
 
-		$curlResult = DI::httpRequest()->get($url . '/poco');
+		$curlResult = DI::httpClient()->get($url . '/poco');
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
 		}
@@ -1079,7 +1079,7 @@ class GServer
 	 */
 	public static function checkMastodonDirectory(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpRequest()->get($url . '/api/v1/directory?limit=1');
+		$curlResult = DI::httpClient()->get($url . '/api/v1/directory?limit=1');
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
 		}
@@ -1106,7 +1106,7 @@ class GServer
 	 */
 	private static function detectPeertube(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpRequest()->get($url . '/api/v1/config');
+		$curlResult = DI::httpClient()->get($url . '/api/v1/config');
 
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
@@ -1154,7 +1154,7 @@ class GServer
 	 */
 	private static function detectNextcloud(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpRequest()->get($url . '/status.php');
+		$curlResult = DI::httpClient()->get($url . '/status.php');
 
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
@@ -1188,7 +1188,7 @@ class GServer
 	 */
 	private static function detectMastodonAlikes(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpRequest()->get($url . '/api/v1/instance');
+		$curlResult = DI::httpClient()->get($url . '/api/v1/instance');
 
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
@@ -1254,7 +1254,7 @@ class GServer
 	 */
 	private static function detectHubzilla(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpRequest()->get($url . '/api/statusnet/config.json');
+		$curlResult = DI::httpClient()->get($url . '/api/statusnet/config.json');
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
 		}
@@ -1352,7 +1352,7 @@ class GServer
 	private static function detectGNUSocial(string $url, array $serverdata)
 	{
 		// Test for GNU Social
-		$curlResult = DI::httpRequest()->get($url . '/api/gnusocial/version.json');
+		$curlResult = DI::httpClient()->get($url . '/api/gnusocial/version.json');
 		if ($curlResult->isSuccess() && ($curlResult->getBody() != '{"error":"not implemented"}') &&
 			($curlResult->getBody() != '') && (strlen($curlResult->getBody()) < 30)) {
 			$serverdata['platform'] = 'gnusocial';
@@ -1370,7 +1370,7 @@ class GServer
 		}
 
 		// Test for Statusnet
-		$curlResult = DI::httpRequest()->get($url . '/api/statusnet/version.json');
+		$curlResult = DI::httpClient()->get($url . '/api/statusnet/version.json');
 		if ($curlResult->isSuccess() && ($curlResult->getBody() != '{"error":"not implemented"}') &&
 			($curlResult->getBody() != '') && (strlen($curlResult->getBody()) < 30)) {
 
@@ -1406,9 +1406,9 @@ class GServer
 	 */
 	private static function detectFriendica(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpRequest()->get($url . '/friendica/json');
+		$curlResult = DI::httpClient()->get($url . '/friendica/json');
 		if (!$curlResult->isSuccess()) {
-			$curlResult = DI::httpRequest()->get($url . '/friendika/json');
+			$curlResult = DI::httpClient()->get($url . '/friendika/json');
 			$friendika = true;
 			$platform = 'Friendika';
 		} else {
@@ -1712,7 +1712,7 @@ class GServer
 		$protocols = ['activitypub', 'diaspora', 'dfrn', 'ostatus'];
 		foreach ($protocols as $protocol) {
 			$query = '{nodes(protocol:"' . $protocol . '"){host}}';
-			$curlResult = DI::httpRequest()->fetch('https://the-federation.info/graphql?query=' . urlencode($query));
+			$curlResult = DI::httpClient()->fetch('https://the-federation.info/graphql?query=' . urlencode($query));
 			if (!empty($curlResult)) {
 				$data = json_decode($curlResult, true);
 				if (!empty($data['data']['nodes'])) {
@@ -1729,7 +1729,7 @@ class GServer
 
 		if (!empty($accesstoken)) {
 			$api = 'https://instances.social/api/1.0/instances/list?count=0';
-			$curlResult = DI::httpRequest()->get($api, [HTTPClientOptions::HEADERS => ['Authorization' => ['Bearer ' . $accesstoken]]]);
+			$curlResult = DI::httpClient()->get($api, [HTTPClientOptions::HEADERS => ['Authorization' => ['Bearer ' . $accesstoken]]]);
 
 			if ($curlResult->isSuccess()) {
 				$servers = json_decode($curlResult->getBody(), true);

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -490,7 +490,7 @@ class Photo
 
 		$filename = basename($image_url);
 		if (!empty($image_url)) {
-			$ret = DI::httpRequest()->get($image_url);
+			$ret = DI::httpClient()->get($image_url);
 			$img_str = $ret->getBody();
 			$type = $ret->getContentType();
 		} else {

--- a/src/Model/Post/Link.php
+++ b/src/Model/Post/Link.php
@@ -88,7 +88,7 @@ class Link
 	{
 		$timeout = DI::config()->get('system', 'xrd_timeout');
 
-		$curlResult = DI::httpRequest()->head($url, [HTTPClientOptions::TIMEOUT => $timeout]);
+		$curlResult = DI::httpClient()->head($url, [HTTPClientOptions::TIMEOUT => $timeout]);
 		if ($curlResult->isSuccess()) {
 			if (empty($media['mimetype'])) {
 				return $curlResult->getHeader('Content-Type')[0] ?? '';

--- a/src/Model/Post/Link.php
+++ b/src/Model/Post/Link.php
@@ -26,7 +26,7 @@ use Friendica\Core\System;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Network\HTTPRequestOptions;
+use Friendica\Network\HTTPClientOptions;
 use Friendica\Util\Proxy;
 
 /**
@@ -88,7 +88,7 @@ class Link
 	{
 		$timeout = DI::config()->get('system', 'xrd_timeout');
 
-		$curlResult = DI::httpRequest()->head($url, [HTTPRequestOptions::TIMEOUT => $timeout]);
+		$curlResult = DI::httpRequest()->head($url, [HTTPClientOptions::TIMEOUT => $timeout]);
 		if ($curlResult->isSuccess()) {
 			if (empty($media['mimetype'])) {
 				return $curlResult->getHeader('Content-Type')[0] ?? '';

--- a/src/Model/Post/Link.php
+++ b/src/Model/Post/Link.php
@@ -26,6 +26,7 @@ use Friendica\Core\System;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Network\HTTPRequestOptions;
 use Friendica\Util\Proxy;
 
 /**
@@ -87,7 +88,7 @@ class Link
 	{
 		$timeout = DI::config()->get('system', 'xrd_timeout');
 
-		$curlResult = DI::httpRequest()->head($url, ['timeout' => $timeout]);
+		$curlResult = DI::httpRequest()->head($url, [HTTPRequestOptions::TIMEOUT => $timeout]);
 		if ($curlResult->isSuccess()) {
 			if (empty($media['mimetype'])) {
 				return $curlResult->getHeader('Content-Type')[0] ?? '';

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -30,6 +30,7 @@ use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
+use Friendica\Network\HTTPRequestOptions;
 use Friendica\Util\Images;
 use Friendica\Util\Network;
 use Friendica\Util\ParseUrl;
@@ -167,7 +168,7 @@ class Media
 		// Fetch the mimetype or size if missing.
 		if (empty($media['mimetype']) || empty($media['size'])) {
 			$timeout = DI::config()->get('system', 'xrd_timeout');
-			$curlResult = DI::httpRequest()->head($media['url'], ['timeout' => $timeout]);
+			$curlResult = DI::httpRequest()->head($media['url'], [HTTPRequestOptions::TIMEOUT => $timeout]);
 			if ($curlResult->isSuccess()) {
 				if (empty($media['mimetype'])) {
 					$media['mimetype'] = $curlResult->getHeader('Content-Type')[0] ?? '';

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -168,7 +168,7 @@ class Media
 		// Fetch the mimetype or size if missing.
 		if (empty($media['mimetype']) || empty($media['size'])) {
 			$timeout = DI::config()->get('system', 'xrd_timeout');
-			$curlResult = DI::httpRequest()->head($media['url'], [HTTPClientOptions::TIMEOUT => $timeout]);
+			$curlResult = DI::httpClient()->head($media['url'], [HTTPClientOptions::TIMEOUT => $timeout]);
 			if ($curlResult->isSuccess()) {
 				if (empty($media['mimetype'])) {
 					$media['mimetype'] = $curlResult->getHeader('Content-Type')[0] ?? '';

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -30,7 +30,7 @@ use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
-use Friendica\Network\HTTPRequestOptions;
+use Friendica\Network\HTTPClientOptions;
 use Friendica\Util\Images;
 use Friendica\Util\Network;
 use Friendica\Util\ParseUrl;
@@ -168,7 +168,7 @@ class Media
 		// Fetch the mimetype or size if missing.
 		if (empty($media['mimetype']) || empty($media['size'])) {
 			$timeout = DI::config()->get('system', 'xrd_timeout');
-			$curlResult = DI::httpRequest()->head($media['url'], [HTTPRequestOptions::TIMEOUT => $timeout]);
+			$curlResult = DI::httpRequest()->head($media['url'], [HTTPClientOptions::TIMEOUT => $timeout]);
 			if ($curlResult->isSuccess()) {
 				if (empty($media['mimetype'])) {
 					$media['mimetype'] = $curlResult->getHeader('Content-Type')[0] ?? '';

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -742,7 +742,7 @@ class Profile
 			$magic_path = $basepath . '/magic' . '?owa=1&dest=' . $dest . '&' . $addr_request;
 
 			// We have to check if the remote server does understand /magic without invoking something
-			$serverret = DI::httpRequest()->get($basepath . '/magic');
+			$serverret = DI::httpClient()->get($basepath . '/magic');
 			if ($serverret->isSuccess()) {
 				Logger::log('Doing magic auth for visitor ' . $my_url . ' to ' . $magic_path, Logger::DEBUG);
 				System::externalRedirect($magic_path);

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1098,7 +1098,7 @@ class User
 			$photo_failure = false;
 
 			$filename = basename($photo);
-			$curlResult = DI::httpRequest()->get($photo);
+			$curlResult = DI::httpClient()->get($photo);
 			if ($curlResult->isSuccess()) {
 				$img_str = $curlResult->getBody();
 				$type = $curlResult->getContentType();

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -248,7 +248,7 @@ class Summary extends BaseAdmin
 	private static function checkSelfHostMeta()
 	{
 		// Fetch the host-meta to check if this really is a vital server
-		return DI::httpRequest()->get(DI::baseUrl()->get() . '/.well-known/host-meta')->isSuccess();
+		return DI::httpClient()->get(DI::baseUrl()->get() . '/.well-known/host-meta')->isSuccess();
 	}
 
 }

--- a/src/Module/Debug/Feed.php
+++ b/src/Module/Debug/Feed.php
@@ -48,7 +48,7 @@ class Feed extends BaseModule
 
 			$contact = Model\Contact::getByURLForUser($url, local_user(), null);
 
-			$xml = DI::httpRequest()->fetch($contact['poll']);
+			$xml = DI::httpClient()->fetch($contact['poll']);
 
 			$import_result = Protocol\Feed::import($xml);
 

--- a/src/Module/Magic.php
+++ b/src/Module/Magic.php
@@ -102,7 +102,7 @@ class Magic extends BaseModule
 			);
 
 			// Try to get an authentication token from the other instance.
-			$curlResult = DI::httpRequest()->get($basepath . '/owa', [HTTPClientOptions::HEADERS => $header]);
+			$curlResult = DI::httpClient()->get($basepath . '/owa', [HTTPClientOptions::HEADERS => $header]);
 
 			if ($curlResult->isSuccess()) {
 				$j = json_decode($curlResult->getBody(), true);

--- a/src/Module/Magic.php
+++ b/src/Module/Magic.php
@@ -28,6 +28,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\User;
+use Friendica\Network\HTTPRequestOptions;
 use Friendica\Util\HTTPSignature;
 use Friendica\Util\Strings;
 
@@ -101,7 +102,7 @@ class Magic extends BaseModule
 			);
 
 			// Try to get an authentication token from the other instance.
-			$curlResult = DI::httpRequest()->get($basepath . '/owa', ['header' => $header]);
+			$curlResult = DI::httpRequest()->get($basepath . '/owa', [HTTPRequestOptions::HEADERS => $header]);
 
 			if ($curlResult->isSuccess()) {
 				$j = json_decode($curlResult->getBody(), true);

--- a/src/Module/Magic.php
+++ b/src/Module/Magic.php
@@ -28,7 +28,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\User;
-use Friendica\Network\HTTPRequestOptions;
+use Friendica\Network\HTTPClientOptions;
 use Friendica\Util\HTTPSignature;
 use Friendica\Util\Strings;
 
@@ -102,7 +102,7 @@ class Magic extends BaseModule
 			);
 
 			// Try to get an authentication token from the other instance.
-			$curlResult = DI::httpRequest()->get($basepath . '/owa', [HTTPRequestOptions::HEADERS => $header]);
+			$curlResult = DI::httpRequest()->get($basepath . '/owa', [HTTPClientOptions::HEADERS => $header]);
 
 			if ($curlResult->isSuccess()) {
 				$j = json_decode($curlResult->getBody(), true);

--- a/src/Network/HTTPClient.php
+++ b/src/Network/HTTPClient.php
@@ -185,14 +185,14 @@ class HTTPClient implements IHTTPClient
 	{
 		$opts = [];
 
-		$opts[RequestOptions::BODY] = $params;
+		$opts[HTTPRequestOptions::BODY] = $params;
 
 		if (!empty($headers)) {
-			$opts[RequestOptions::HEADERS] = $headers;
+			$opts[HTTPRequestOptions::HEADERS] = $headers;
 		}
 
 		if (!empty($timeout)) {
-			$opts[RequestOptions::TIMEOUT] = $timeout;
+			$opts[HTTPRequestOptions::TIMEOUT] = $timeout;
 		}
 
 		return $this->request('post', $url, $opts);

--- a/src/Network/HTTPClient.php
+++ b/src/Network/HTTPClient.php
@@ -59,7 +59,7 @@ class HTTPClient implements IHTTPClient
 	/**
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	protected function request(string $method, string $url, array $opts = []): IHTTPResult
+	public function request(string $method, string $url, array $opts = []): IHTTPResult
 	{
 		$this->profiler->startRecording('network');
 		$this->logger->debug('Request start.', ['url' => $url, 'method' => $method]);

--- a/src/Network/HTTPClient.php
+++ b/src/Network/HTTPClient.php
@@ -95,39 +95,39 @@ class HTTPClient implements IHTTPClient
 
 		$conf = [];
 
-		if (!empty($opts[HTTPRequestOptions::COOKIEJAR])) {
-			$jar                           = new FileCookieJar($opts[HTTPRequestOptions::COOKIEJAR]);
+		if (!empty($opts[HTTPClientOptions::COOKIEJAR])) {
+			$jar                           = new FileCookieJar($opts[HTTPClientOptions::COOKIEJAR]);
 			$conf[RequestOptions::COOKIES] = $jar;
 		}
 
 		$headers = [];
 
-		if (!empty($opts[HTTPRequestOptions::ACCEPT_CONTENT])) {
-			$headers['Accept'] = $opts[HTTPRequestOptions::ACCEPT_CONTENT];
+		if (!empty($opts[HTTPClientOptions::ACCEPT_CONTENT])) {
+			$headers['Accept'] = $opts[HTTPClientOptions::ACCEPT_CONTENT];
 		}
 
-		if (!empty($opts[HTTPRequestOptions::LEGACY_HEADER])) {
+		if (!empty($opts[HTTPClientOptions::LEGACY_HEADER])) {
 			$this->logger->notice('Wrong option \'headers\' used.');
-			$headers = array_merge($opts[HTTPRequestOptions::LEGACY_HEADER], $headers);
+			$headers = array_merge($opts[HTTPClientOptions::LEGACY_HEADER], $headers);
 		}
 
-		if (!empty($opts[HTTPRequestOptions::HEADERS])) {
-			$headers = array_merge($opts[HTTPRequestOptions::HEADERS], $headers);
+		if (!empty($opts[HTTPClientOptions::HEADERS])) {
+			$headers = array_merge($opts[HTTPClientOptions::HEADERS], $headers);
 		}
 
 		$conf[RequestOptions::HEADERS] = array_merge($this->client->getConfig(RequestOptions::HEADERS), $headers);
 
-		if (!empty($opts[HTTPRequestOptions::TIMEOUT])) {
-			$conf[RequestOptions::TIMEOUT] = $opts[HTTPRequestOptions::TIMEOUT];
+		if (!empty($opts[HTTPClientOptions::TIMEOUT])) {
+			$conf[RequestOptions::TIMEOUT] = $opts[HTTPClientOptions::TIMEOUT];
 		}
 
-		if (!empty($opts[HTTPRequestOptions::BODY])) {
-			$conf[RequestOptions::BODY] = $opts[HTTPRequestOptions::BODY];
+		if (!empty($opts[HTTPClientOptions::BODY])) {
+			$conf[RequestOptions::BODY] = $opts[HTTPClientOptions::BODY];
 		}
 
 		$conf[RequestOptions::ON_HEADERS] = function (ResponseInterface $response) use ($opts) {
-			if (!empty($opts[HTTPRequestOptions::CONTENT_LENGTH]) &&
-				(int)$response->getHeaderLine('Content-Length') > $opts[HTTPRequestOptions::CONTENT_LENGTH]) {
+			if (!empty($opts[HTTPClientOptions::CONTENT_LENGTH]) &&
+				(int)$response->getHeaderLine('Content-Length') > $opts[HTTPClientOptions::CONTENT_LENGTH]) {
 				throw new TransferException('The file is too big!');
 			}
 		};
@@ -185,14 +185,14 @@ class HTTPClient implements IHTTPClient
 	{
 		$opts = [];
 
-		$opts[HTTPRequestOptions::BODY] = $params;
+		$opts[HTTPClientOptions::BODY] = $params;
 
 		if (!empty($headers)) {
-			$opts[HTTPRequestOptions::HEADERS] = $headers;
+			$opts[HTTPClientOptions::HEADERS] = $headers;
 		}
 
 		if (!empty($timeout)) {
-			$opts[HTTPRequestOptions::TIMEOUT] = $timeout;
+			$opts[HTTPClientOptions::TIMEOUT] = $timeout;
 		}
 
 		return $this->request('post', $url, $opts);

--- a/src/Network/HTTPClientOptions.php
+++ b/src/Network/HTTPClientOptions.php
@@ -7,7 +7,7 @@ use GuzzleHttp\RequestOptions;
 /**
  * This class contains a list of possible HTTPClient request options.
  */
-class HTTPRequestOptions
+class HTTPClientOptions
 {
 	/**
 	 * accept_content: (array) supply Accept: header with 'accept_content' as the value

--- a/src/Network/HTTPRequestOptions.php
+++ b/src/Network/HTTPRequestOptions.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Friendica\Network;
+
+use GuzzleHttp\RequestOptions;
+
+/**
+ * This class contains a list of possible HTTPClient request options.
+ */
+class HTTPRequestOptions
+{
+	/**
+	 * accept_content: (array) supply Accept: header with 'accept_content' as the value
+	 */
+	const ACCEPT_CONTENT = 'accept_content';
+	/**
+	 * timeout: (int) out in seconds, default system config value or 60 seconds
+	 */
+	const TIMEOUT = RequestOptions::TIMEOUT;
+	/**
+	 * cookiejar: (string) path to cookie jar file
+	 */
+	const COOKIEJAR = 'cookiejar';
+	/**
+	 * headers: (array) header array
+	 */
+	const HEADERS = RequestOptions::HEADERS;
+	/**
+	 * header: (array) header array (legacy version)
+	 */
+	const LEGACY_HEADER = 'header';
+	/**
+	 * content_length: (int) maximum File content length
+	 */
+	const CONTENT_LENGTH = 'content_length';
+	/**
+	 * body: (mixed) Setting the body for sending data
+	 */
+	const BODY = RequestOptions::BODY;
+}

--- a/src/Network/IHTTPClient.php
+++ b/src/Network/IHTTPClient.php
@@ -86,6 +86,17 @@ interface IHTTPClient
 	public function get(string $url, array $opts = []);
 
 	/**
+	 * Sends a HTTP request to a given url
+	 *
+	 * @param string $method A HTTP request ()
+	 * @param string $url    Url to send to
+	 * @param array  $opts   parameters
+	 *
+	 * @return IHTTPResult
+	 */
+	public function request(string $method, string $url, array $opts = []);
+
+	/**
 	 * Send POST request to an URL
 	 *
 	 * @param string $url     URL to post

--- a/src/Network/IHTTPClient.php
+++ b/src/Network/IHTTPClient.php
@@ -88,9 +88,15 @@ interface IHTTPClient
 	/**
 	 * Sends a HTTP request to a given url
 	 *
-	 * @param string $method A HTTP request ()
+	 * @param string $method A HTTP request
 	 * @param string $url    Url to send to
-	 * @param array  $opts   parameters
+	 * @param array  $opts   (optional parameters) associative array with:
+	 *                       	 'body' => (mixed) setting the body for sending data
+	 *                           'accept_content' => (string array) supply Accept: header with 'accept_content' as the value
+	 *                           'timeout' => int Timeout in seconds, default system config value or 60 seconds
+	 *                           'cookiejar' => path to cookie jar file
+	 *                           'header' => header array
+	 *                           'content_length' => int maximum File content length
 	 *
 	 * @return IHTTPResult
 	 */

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -170,7 +170,7 @@ class Probe
 		Logger::info('Probing', ['host' => $host, 'ssl_url' => $ssl_url, 'url' => $url, 'callstack' => System::callstack(20)]);
 		$xrd = null;
 
-		$curlResult = DI::httpRequest()->get($ssl_url, ['timeout' => $xrd_timeout, 'accept_content' => ['application/xrd+xml']]);
+		$curlResult = DI::httpRequest()->get($ssl_url, [HTTPRequestOptions::TIMEOUT => $xrd_timeout, HTTPRequestOptions::ACCEPT_CONTENT => ['application/xrd+xml']]);
 		$ssl_connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 		if ($curlResult->isSuccess()) {
 			$xml = $curlResult->getBody();
@@ -187,7 +187,7 @@ class Probe
 		}
 
 		if (!is_object($xrd) && !empty($url)) {
-			$curlResult = DI::httpRequest()->get($url, ['timeout' => $xrd_timeout, 'accept_content' => ['application/xrd+xml']]);
+			$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::TIMEOUT => $xrd_timeout, HTTPRequestOptions::ACCEPT_CONTENT => ['application/xrd+xml']]);
 			$connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 			if ($curlResult->isTimeout()) {
 				Logger::info('Probing timeout', ['url' => $url]);
@@ -424,7 +424,7 @@ class Probe
 	 */
 	private static function getHideStatus($url)
 	{
-		$curlResult = DI::httpRequest()->get($url, ['content_length' => 1000000]);
+		$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::CONTENT_LENGTH => 1000000]);
 		if (!$curlResult->isSuccess()) {
 			return false;
 		}
@@ -940,7 +940,7 @@ class Probe
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout', 20);
 
-		$curlResult = DI::httpRequest()->get($url, ['timeout' => $xrd_timeout, 'accept_content' => [$type]]);
+		$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::TIMEOUT => $xrd_timeout, HTTPRequestOptions::ACCEPT_CONTENT => [$type]]);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -170,7 +170,7 @@ class Probe
 		Logger::info('Probing', ['host' => $host, 'ssl_url' => $ssl_url, 'url' => $url, 'callstack' => System::callstack(20)]);
 		$xrd = null;
 
-		$curlResult = DI::httpRequest()->get($ssl_url, [HTTPClientOptions::TIMEOUT => $xrd_timeout, HTTPClientOptions::ACCEPT_CONTENT => ['application/xrd+xml']]);
+		$curlResult = DI::httpClient()->get($ssl_url, [HTTPClientOptions::TIMEOUT => $xrd_timeout, HTTPClientOptions::ACCEPT_CONTENT => ['application/xrd+xml']]);
 		$ssl_connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 		if ($curlResult->isSuccess()) {
 			$xml = $curlResult->getBody();
@@ -187,7 +187,7 @@ class Probe
 		}
 
 		if (!is_object($xrd) && !empty($url)) {
-			$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout, HTTPClientOptions::ACCEPT_CONTENT => ['application/xrd+xml']]);
+			$curlResult = DI::httpClient()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout, HTTPClientOptions::ACCEPT_CONTENT => ['application/xrd+xml']]);
 			$connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 			if ($curlResult->isTimeout()) {
 				Logger::info('Probing timeout', ['url' => $url]);
@@ -424,7 +424,7 @@ class Probe
 	 */
 	private static function getHideStatus($url)
 	{
-		$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::CONTENT_LENGTH => 1000000]);
+		$curlResult = DI::httpClient()->get($url, [HTTPClientOptions::CONTENT_LENGTH => 1000000]);
 		if (!$curlResult->isSuccess()) {
 			return false;
 		}
@@ -843,7 +843,7 @@ class Probe
 
 	public static function pollZot($url, $data)
 	{
-		$curlResult = DI::httpRequest()->get($url);
+		$curlResult = DI::httpClient()->get($url);
 		if ($curlResult->isTimeout()) {
 			return $data;
 		}
@@ -940,7 +940,7 @@ class Probe
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout', 20);
 
-		$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout, HTTPClientOptions::ACCEPT_CONTENT => [$type]]);
+		$curlResult = DI::httpClient()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout, HTTPClientOptions::ACCEPT_CONTENT => [$type]]);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];
@@ -1009,7 +1009,7 @@ class Probe
 	 */
 	private static function pollNoscrape($noscrape_url, $data)
 	{
-		$curlResult = DI::httpRequest()->get($noscrape_url);
+		$curlResult = DI::httpClient()->get($noscrape_url);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return $data;
@@ -1275,7 +1275,7 @@ class Probe
 	 */
 	private static function pollHcard($hcard_url, $data, $dfrn = false)
 	{
-		$curlResult = DI::httpRequest()->get($hcard_url);
+		$curlResult = DI::httpClient()->get($hcard_url);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];
@@ -1536,7 +1536,7 @@ class Probe
 							$pubkey = substr($pubkey, 5);
 						}
 					} elseif (Strings::normaliseLink($pubkey) == 'http://') {
-						$curlResult = DI::httpRequest()->get($pubkey);
+						$curlResult = DI::httpClient()->get($pubkey);
 						if ($curlResult->isTimeout()) {
 							self::$istimeout = true;
 							return $short ? false : [];
@@ -1570,7 +1570,7 @@ class Probe
 		}
 
 		// Fetch all additional data from the feed
-		$curlResult = DI::httpRequest()->get($data["poll"]);
+		$curlResult = DI::httpClient()->get($data["poll"]);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];
@@ -1622,7 +1622,7 @@ class Probe
 	 */
 	private static function pumpioProfileData($profile_link)
 	{
-		$curlResult = DI::httpRequest()->get($profile_link);
+		$curlResult = DI::httpClient()->get($profile_link);
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return [];
 		}
@@ -1862,7 +1862,7 @@ class Probe
 	 */
 	private static function feed($url, $probe = true)
 	{
-		$curlResult = DI::httpRequest()->get($url);
+		$curlResult = DI::httpClient()->get($url);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];
@@ -2086,7 +2086,7 @@ class Probe
 			return '';
 		}
 
-		$curlResult = DI::httpRequest()->get($gserver['noscrape'] . '/' . $data['nick']);
+		$curlResult = DI::httpClient()->get($gserver['noscrape'] . '/' . $data['nick']);
 
 		if ($curlResult->isSuccess() && !empty($curlResult->getBody())) {
 			$noscrape = json_decode($curlResult->getBody(), true);
@@ -2161,7 +2161,7 @@ class Probe
 	private static function updateFromFeed(array $data)
 	{
 		// Search for the newest entry in the feed
-		$curlResult = DI::httpRequest()->get($data['poll']);
+		$curlResult = DI::httpClient()->get($data['poll']);
 		if (!$curlResult->isSuccess() || !$curlResult->getBody()) {
 			return '';
 		}

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -170,7 +170,7 @@ class Probe
 		Logger::info('Probing', ['host' => $host, 'ssl_url' => $ssl_url, 'url' => $url, 'callstack' => System::callstack(20)]);
 		$xrd = null;
 
-		$curlResult = DI::httpRequest()->get($ssl_url, [HTTPRequestOptions::TIMEOUT => $xrd_timeout, HTTPRequestOptions::ACCEPT_CONTENT => ['application/xrd+xml']]);
+		$curlResult = DI::httpRequest()->get($ssl_url, [HTTPClientOptions::TIMEOUT => $xrd_timeout, HTTPClientOptions::ACCEPT_CONTENT => ['application/xrd+xml']]);
 		$ssl_connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 		if ($curlResult->isSuccess()) {
 			$xml = $curlResult->getBody();
@@ -187,7 +187,7 @@ class Probe
 		}
 
 		if (!is_object($xrd) && !empty($url)) {
-			$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::TIMEOUT => $xrd_timeout, HTTPRequestOptions::ACCEPT_CONTENT => ['application/xrd+xml']]);
+			$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout, HTTPClientOptions::ACCEPT_CONTENT => ['application/xrd+xml']]);
 			$connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 			if ($curlResult->isTimeout()) {
 				Logger::info('Probing timeout', ['url' => $url]);
@@ -424,7 +424,7 @@ class Probe
 	 */
 	private static function getHideStatus($url)
 	{
-		$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::CONTENT_LENGTH => 1000000]);
+		$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::CONTENT_LENGTH => 1000000]);
 		if (!$curlResult->isSuccess()) {
 			return false;
 		}
@@ -940,7 +940,7 @@ class Probe
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout', 20);
 
-		$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::TIMEOUT => $xrd_timeout, HTTPRequestOptions::ACCEPT_CONTENT => [$type]]);
+		$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::TIMEOUT => $xrd_timeout, HTTPClientOptions::ACCEPT_CONTENT => [$type]]);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -976,7 +976,7 @@ class DFRN
 
 		$content_type = ($public_batch ? "application/magic-envelope+xml" : "application/json");
 
-		$postResult = DI::httpRequest()->post($dest_url, $envelope, ['Content-Type' => $content_type]);
+		$postResult = DI::httpClient()->post($dest_url, $envelope, ['Content-Type' => $content_type]);
 		$xml = $postResult->getBody();
 
 		$curl_stat = $postResult->getReturnCode();

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1077,7 +1077,7 @@ class Diaspora
 
 		Logger::log("Fetch post from ".$source_url, Logger::DEBUG);
 
-		$envelope = DI::httpRequest()->fetch($source_url);
+		$envelope = DI::httpClient()->fetch($source_url);
 		if ($envelope) {
 			Logger::log("Envelope was fetched.", Logger::DEBUG);
 			$x = self::verifyMagicEnvelope($envelope);
@@ -3022,7 +3022,7 @@ class Diaspora
 		if (!intval(DI::config()->get("system", "diaspora_test"))) {
 			$content_type = (($public_batch) ? "application/magic-envelope+xml" : "application/json");
 
-			$postResult = DI::httpRequest()->post($dest_url . "/", $envelope, ['Content-Type' => $content_type]);
+			$postResult = DI::httpClient()->post($dest_url . "/", $envelope, ['Content-Type' => $content_type]);
 			$return_code = $postResult->getReturnCode();
 		} else {
 			Logger::log("test_mode");
@@ -3933,7 +3933,7 @@ class Diaspora
 			$dob = '';
 
 			if ($profile['dob'] && ($profile['dob'] > '0000-00-00')) {
-				list($year, $month, $day) = sscanf($profile['dob'], '%4d-%2d-%2d');
+				[$year, $month, $day] = sscanf($profile['dob'], '%4d-%2d-%2d');
 				if ($year < 1004) {
 					$year = 1004;
 				}

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -297,7 +297,7 @@ class Feed
 
 			$orig_plink = $item["plink"];
 
-			$item["plink"] = DI::httpRequest()->finalUrl($item["plink"]);
+			$item["plink"] = DI::httpClient()->finalUrl($item["plink"]);
 
 			$item["title"] = XML::getFirstNodeValue($xpath, 'atom:title/text()', $entry);
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -728,7 +728,7 @@ class OStatus
 
 		self::$conv_list[$conversation] = true;
 
-		$curlResult = DI::httpRequest()->get($conversation, [HTTPClientOptions::ACCEPT_CONTENT => ['application/atom+xml', 'text/html']]);
+		$curlResult = DI::httpClient()->get($conversation, [HTTPClientOptions::ACCEPT_CONTENT => ['application/atom+xml', 'text/html']]);
 
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return;
@@ -758,7 +758,7 @@ class OStatus
 					}
 				}
 				if ($file != '') {
-					$conversation_atom = DI::httpRequest()->get($attribute['href']);
+					$conversation_atom = DI::httpClient()->get($attribute['href']);
 
 					if ($conversation_atom->isSuccess()) {
 						$xml = $conversation_atom->getBody();
@@ -872,7 +872,7 @@ class OStatus
 			return;
 		}
 
-		$curlResult = DI::httpRequest()->get($self);
+		$curlResult = DI::httpClient()->get($self);
 
 		if (!$curlResult->isSuccess()) {
 			return;
@@ -922,7 +922,7 @@ class OStatus
 		}
 
 		$stored = false;
-		$curlResult = DI::httpRequest()->get($related, [HTTPClientOptions::ACCEPT_CONTENT => ['application/atom+xml', 'text/html']]);
+		$curlResult = DI::httpClient()->get($related, [HTTPClientOptions::ACCEPT_CONTENT => ['application/atom+xml', 'text/html']]);
 
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return;
@@ -954,7 +954,7 @@ class OStatus
 					}
 				}
 				if ($atom_file != '') {
-					$curlResult = DI::httpRequest()->get($atom_file);
+					$curlResult = DI::httpClient()->get($atom_file);
 
 					if ($curlResult->isSuccess()) {
 						Logger::log('Fetched XML for URI ' . $related_uri, Logger::DEBUG);
@@ -966,7 +966,7 @@ class OStatus
 
 		// Workaround for older GNU Social servers
 		if (($xml == '') && strstr($related, '/notice/')) {
-			$curlResult = DI::httpRequest()->get(str_replace('/notice/', '/api/statuses/show/', $related) . '.atom');
+			$curlResult = DI::httpClient()->get(str_replace('/notice/', '/api/statuses/show/', $related) . '.atom');
 
 			if ($curlResult->isSuccess()) {
 				Logger::log('GNU Social workaround to fetch XML for URI ' . $related_uri, Logger::DEBUG);
@@ -977,7 +977,7 @@ class OStatus
 		// Even more worse workaround for GNU Social ;-)
 		if ($xml == '') {
 			$related_guess = self::convertHref($related_uri);
-			$curlResult = DI::httpRequest()->get(str_replace('/notice/', '/api/statuses/show/', $related_guess) . '.atom');
+			$curlResult = DI::httpClient()->get(str_replace('/notice/', '/api/statuses/show/', $related_guess) . '.atom');
 
 			if ($curlResult->isSuccess()) {
 				Logger::log('GNU Social workaround 2 to fetch XML for URI ' . $related_uri, Logger::DEBUG);

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -38,7 +38,7 @@ use Friendica\Model\ItemURI;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
-use Friendica\Network\HTTPRequestOptions;
+use Friendica\Network\HTTPClientOptions;
 use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
@@ -728,7 +728,7 @@ class OStatus
 
 		self::$conv_list[$conversation] = true;
 
-		$curlResult = DI::httpRequest()->get($conversation, [HTTPRequestOptions::ACCEPT_CONTENT => ['application/atom+xml', 'text/html']]);
+		$curlResult = DI::httpRequest()->get($conversation, [HTTPClientOptions::ACCEPT_CONTENT => ['application/atom+xml', 'text/html']]);
 
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return;
@@ -922,7 +922,7 @@ class OStatus
 		}
 
 		$stored = false;
-		$curlResult = DI::httpRequest()->get($related, [HTTPRequestOptions::ACCEPT_CONTENT => ['application/atom+xml', 'text/html']]);
+		$curlResult = DI::httpRequest()->get($related, [HTTPClientOptions::ACCEPT_CONTENT => ['application/atom+xml', 'text/html']]);
 
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return;

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -38,6 +38,7 @@ use Friendica\Model\ItemURI;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
+use Friendica\Network\HTTPRequestOptions;
 use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
@@ -727,7 +728,7 @@ class OStatus
 
 		self::$conv_list[$conversation] = true;
 
-		$curlResult = DI::httpRequest()->get($conversation, ['accept_content' => ['application/atom+xml', 'text/html']]);
+		$curlResult = DI::httpRequest()->get($conversation, [HTTPRequestOptions::ACCEPT_CONTENT => ['application/atom+xml', 'text/html']]);
 
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return;
@@ -921,7 +922,7 @@ class OStatus
 		}
 
 		$stored = false;
-		$curlResult = DI::httpRequest()->get($related, ['accept_content' => ['application/atom+xml', 'text/html']]);
+		$curlResult = DI::httpRequest()->get($related, [HTTPRequestOptions::ACCEPT_CONTENT => ['application/atom+xml', 'text/html']]);
 
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return;

--- a/src/Protocol/Salmon.php
+++ b/src/Protocol/Salmon.php
@@ -72,7 +72,7 @@ class Salmon
 						$ret[$x] = substr($ret[$x], 5);
 					}
 				} elseif (Strings::normaliseLink($ret[$x]) == 'http://') {
-					$ret[$x] = DI::httpRequest()->fetch($ret[$x]);
+					$ret[$x] = DI::httpClient()->fetch($ret[$x]);
 				}
 			}
 		}
@@ -155,7 +155,7 @@ class Salmon
 		$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 
 		// slap them
-		$postResult = DI::httpRequest()->post($url, $salmon, [
+		$postResult = DI::httpClient()->post($url, $salmon, [
 			'Content-type' => 'application/magic-envelope+xml',
 			'Content-length' => strlen($salmon),
 		]);
@@ -180,7 +180,7 @@ class Salmon
 			$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 
 			// slap them
-			$postResult = DI::httpRequest()->post($url, $salmon, [
+			$postResult = DI::httpClient()->post($url, $salmon, [
 				'Content-type' => 'application/magic-envelope+xml',
 				'Content-length' => strlen($salmon),
 			]);
@@ -203,7 +203,7 @@ class Salmon
 			$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 
 			// slap them
-			$postResult = DI::httpRequest()->post($url, $salmon, [
+			$postResult = DI::httpClient()->post($url, $salmon, [
 				'Content-type' => 'application/magic-envelope+xml',
 				'Content-length' => strlen($salmon)]);
 			$return_code = $postResult->getReturnCode();

--- a/src/Security/ExAuth.php
+++ b/src/Security/ExAuth.php
@@ -222,7 +222,7 @@ class ExAuth
 
 		$url = ($ssl ? 'https' : 'http') . '://' . $host . '/noscrape/' . $user;
 
-		$curlResult = DI::httpRequest()->get($url);
+		$curlResult = DI::httpClient()->get($url);
 
 		if (!$curlResult->isSuccess()) {
 			return false;

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -305,7 +305,7 @@ class HTTPSignature
 
 		$headers['Content-Type'] = 'application/activity+json';
 
-		$postResult = DI::httpRequest()->post($target, $content, $headers);
+		$postResult = DI::httpClient()->post($target, $content, $headers);
 		$return_code = $postResult->getReturnCode();
 
 		Logger::log('Transmit to ' . $target . ' returned ' . $return_code, Logger::DEBUG);
@@ -453,9 +453,9 @@ class HTTPSignature
 		$curl_opts[HTTPClientOptions::HEADERS] = $header;
 
 		if (!empty($opts['nobody'])) {
-			$curlResult = DI::httpRequest()->head($request, $curl_opts);
+			$curlResult = DI::httpClient()->head($request, $curl_opts);
 		} else {
-			$curlResult = DI::httpRequest()->get($request, $curl_opts);
+			$curlResult = DI::httpClient()->get($request, $curl_opts);
 		}
 		$return_code = $curlResult->getReturnCode();
 

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -29,6 +29,7 @@ use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Model\User;
 use Friendica\Network\CurlResult;
+use Friendica\Network\HTTPRequestOptions;
 use Friendica\Network\IHTTPResult;
 
 /**
@@ -449,7 +450,7 @@ class HTTPSignature
 		}
 
 		$curl_opts = $opts;
-		$curl_opts['header'] = $header;
+		$curl_opts[HTTPRequestOptions::HEADERS] = $header;
 
 		if (!empty($opts['nobody'])) {
 			$curlResult = DI::httpRequest()->head($request, $curl_opts);

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -29,7 +29,7 @@ use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Model\User;
 use Friendica\Network\CurlResult;
-use Friendica\Network\HTTPRequestOptions;
+use Friendica\Network\HTTPClientOptions;
 use Friendica\Network\IHTTPResult;
 
 /**
@@ -449,8 +449,8 @@ class HTTPSignature
 			$header['Signature'] = 'keyId="' . $owner['url'] . '#main-key' . '",algorithm="rsa-sha256",headers="(request-target) date host",signature="' . $signature . '"';
 		}
 
-		$curl_opts = $opts;
-		$curl_opts[HTTPRequestOptions::HEADERS] = $header;
+		$curl_opts                             = $opts;
+		$curl_opts[HTTPClientOptions::HEADERS] = $header;
 
 		if (!empty($opts['nobody'])) {
 			$curlResult = DI::httpRequest()->head($request, $curl_opts);

--- a/src/Util/Images.php
+++ b/src/Util/Images.php
@@ -193,7 +193,7 @@ class Images
 		}
 
 		if (empty($img_str)) {
-			$img_str = DI::httpRequest()->fetch($url, 4);
+			$img_str = DI::httpClient()->fetch($url, 4);
 		}
 
 		if (!$img_str) {

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -30,6 +30,7 @@ use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Network\HTTPException;
+use Friendica\Network\HTTPRequestOptions;
 
 /**
  * Get information about a given URL
@@ -213,7 +214,7 @@ class ParseUrl
 			return $siteinfo;
 		}
 
-		$curlResult = DI::httpRequest()->get($url, ['content_length' => 1000000]);
+		$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::CONTENT_LENGTH => 1000000]);
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return $siteinfo;
 		}

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -30,7 +30,7 @@ use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Network\HTTPException;
-use Friendica\Network\HTTPRequestOptions;
+use Friendica\Network\HTTPClientOptions;
 
 /**
  * Get information about a given URL
@@ -214,7 +214,7 @@ class ParseUrl
 			return $siteinfo;
 		}
 
-		$curlResult = DI::httpRequest()->get($url, [HTTPRequestOptions::CONTENT_LENGTH => 1000000]);
+		$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::CONTENT_LENGTH => 1000000]);
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return $siteinfo;
 		}

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -59,7 +59,7 @@ class ParseUrl
 	 */
 	public static function getContentType(string $url)
 	{
-		$curlResult = DI::httpRequest()->head($url);
+		$curlResult = DI::httpClient()->head($url);
 		if (!$curlResult->isSuccess()) {
 			return [];
 		}
@@ -214,7 +214,7 @@ class ParseUrl
 			return $siteinfo;
 		}
 
-		$curlResult = DI::httpRequest()->get($url, [HTTPClientOptions::CONTENT_LENGTH => 1000000]);
+		$curlResult = DI::httpClient()->get($url, [HTTPClientOptions::CONTENT_LENGTH => 1000000]);
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return $siteinfo;
 		}

--- a/src/Worker/CheckVersion.php
+++ b/src/Worker/CheckVersion.php
@@ -54,7 +54,7 @@ class CheckVersion
 		Logger::log("Checking VERSION from: ".$checked_url, Logger::DEBUG);
 
 		// fetch the VERSION file
-		$gitversion = DBA::escape(trim(DI::httpRequest()->fetch($checked_url)));
+		$gitversion = DBA::escape(trim(DI::httpClient()->fetch($checked_url)));
 		Logger::log("Upstream VERSION is: ".$gitversion, Logger::DEBUG);
 
 		DI::config()->set('system', 'git_friendica_version', $gitversion);

--- a/src/Worker/Directory.php
+++ b/src/Worker/Directory.php
@@ -53,7 +53,7 @@ class Directory
 
 		Logger::log('Updating directory: ' . $arr['url'], Logger::DEBUG);
 		if (strlen($arr['url'])) {
-			DI::httpRequest()->fetch($dir . '?url=' . bin2hex($arr['url']));
+			DI::httpClient()->fetch($dir . '?url=' . bin2hex($arr['url']));
 		}
 
 		return;

--- a/src/Worker/NodeInfo.php
+++ b/src/Worker/NodeInfo.php
@@ -34,7 +34,7 @@ class NodeInfo
 		// Now trying to register
 		$url = 'http://the-federation.info/register/' . DI::baseUrl()->getHostname();
 		Logger::debug('Check registering url', ['url' => $url]);
-		$ret = DI::httpRequest()->fetch($url);
+		$ret = DI::httpClient()->fetch($url);
 		Logger::debug('Check registering answer', ['answer' => $ret]);
 		Logger::info('end');
 	}

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -29,6 +29,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Model\User;
+use Friendica\Network\HTTPRequestOptions;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\Email;
@@ -152,7 +153,7 @@ class OnePoll
 		}
 
 		$cookiejar = tempnam(get_temppath(), 'cookiejar-onepoll-');
-		$curlResult = DI::httpRequest()->get($contact['poll'], ['cookiejar' => $cookiejar]);
+		$curlResult = DI::httpRequest()->get($contact['poll'], [HTTPRequestOptions::COOKIEJAR => $cookiejar]);
 		unlink($cookiejar);
 
 		if ($curlResult->isTimeout()) {

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -29,7 +29,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Model\User;
-use Friendica\Network\HTTPRequestOptions;
+use Friendica\Network\HTTPClientOptions;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\Email;
@@ -153,7 +153,7 @@ class OnePoll
 		}
 
 		$cookiejar = tempnam(get_temppath(), 'cookiejar-onepoll-');
-		$curlResult = DI::httpRequest()->get($contact['poll'], [HTTPRequestOptions::COOKIEJAR => $cookiejar]);
+		$curlResult = DI::httpRequest()->get($contact['poll'], [HTTPClientOptions::COOKIEJAR => $cookiejar]);
 		unlink($cookiejar);
 
 		if ($curlResult->isTimeout()) {

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -153,7 +153,7 @@ class OnePoll
 		}
 
 		$cookiejar = tempnam(get_temppath(), 'cookiejar-onepoll-');
-		$curlResult = DI::httpRequest()->get($contact['poll'], [HTTPClientOptions::COOKIEJAR => $cookiejar]);
+		$curlResult = DI::httpClient()->get($contact['poll'], [HTTPClientOptions::COOKIEJAR => $cookiejar]);
 		unlink($cookiejar);
 
 		if ($curlResult->isTimeout()) {
@@ -459,7 +459,7 @@ class OnePoll
 			DBA::update('contact', ['hub-verify' => $verify_token], ['id' => $contact['id']]);
 		}
 
-		$postResult = DI::httpRequest()->post($url, $params);
+		$postResult = DI::httpClient()->post($url, $params);
 
 		Logger::info('Hub subscription done', ['result' => $postResult->getReturnCode()]);
 

--- a/src/Worker/PubSubPublish.php
+++ b/src/Worker/PubSubPublish.php
@@ -68,7 +68,7 @@ class PubSubPublish
 
 		Logger::log('POST ' . print_r($headers, true) . "\n" . $params, Logger::DATA);
 
-		$postResult = DI::httpRequest()->post($subscriber['callback_url'], $params, $headers);
+		$postResult = DI::httpClient()->post($subscriber['callback_url'], $params, $headers);
 		$ret = $postResult->getReturnCode();
 
 		if ($ret >= 200 && $ret <= 299) {

--- a/src/Worker/PullDirectory.php
+++ b/src/Worker/PullDirectory.php
@@ -47,7 +47,7 @@ class PullDirectory
 
 		Logger::info('Synchronization started.', ['now' => $now, 'directory' => $directory]);
 
-		$result = DI::httpRequest()->fetch($directory . '/sync/pull/since/' . $now);
+		$result = DI::httpClient()->fetch($directory . '/sync/pull/since/' . $now);
 		if (empty($result)) {
 			Logger::info('Directory server return empty result.', ['directory' => $directory]);
 			return;

--- a/src/Worker/SearchDirectory.php
+++ b/src/Worker/SearchDirectory.php
@@ -46,7 +46,7 @@ class SearchDirectory
 			}
 		}
 
-		$x = DI::httpRequest()->fetch(Search::getGlobalDirectory() . '/lsearch?p=1&n=500&search=' . urlencode($search));
+		$x = DI::httpClient()->fetch(Search::getGlobalDirectory() . '/lsearch?p=1&n=500&search=' . urlencode($search));
 		$j = json_decode($x);
 
 		if (!empty($j->results)) {

--- a/src/Worker/UpdateServerDirectory.php
+++ b/src/Worker/UpdateServerDirectory.php
@@ -45,7 +45,7 @@ class UpdateServerDirectory
 
 	private static function discoverPoCo(array $gserver)
 	{
-		$result = DI::httpRequest()->fetch($gserver['poco'] . '?fields=urls');
+		$result = DI::httpClient()->fetch($gserver['poco'] . '?fields=urls');
 		if (empty($result)) {
 			Logger::info('Empty result', ['url' => $gserver['url']]);
 			return;
@@ -78,7 +78,7 @@ class UpdateServerDirectory
 
 	private static function discoverMastodonDirectory(array $gserver)
 	{		
-		$result = DI::httpRequest()->fetch($gserver['url'] . '/api/v1/directory?order=new&local=true&limit=200&offset=0');
+		$result = DI::httpClient()->fetch($gserver['url'] . '/api/v1/directory?order=new&local=true&limit=200&offset=0');
 		if (empty($result)) {
 			Logger::info('Empty result', ['url' => $gserver['url']]);
 			return;

--- a/src/Worker/UpdateServerPeers.php
+++ b/src/Worker/UpdateServerPeers.php
@@ -35,7 +35,7 @@ class UpdateServerPeers
 	 */
 	public static function execute(string $url)
 	{
-		$ret = DI::httpRequest()->get($url . '/api/v1/instance/peers');
+		$ret = DI::httpClient()->get($url . '/api/v1/instance/peers');
 		if (!$ret->isSuccess() || empty($ret->getBody())) {
 			Logger::info('Server is not reachable or does not offer the "peers" endpoint', ['url' => $url]);
 			return;


### PR DESCRIPTION
FollowUp #10633 

- Bugfix `IHTTPClient::post()` (used wrong option for sending data in case it's XML instead of JSON ..)
- Introduce `HTTPRequestOptions` constants (because I always had to do deep-searches for finding all usages and references ...)
- Rename `DI::httpRequest()` into `DI::httpClient()`
- **Really** fixes https://github.com/friendica/friendica/issues/10475#issuecomment-905754227

Needs https://github.com/friendica/friendica-addons/pull/1161 as well