### PR TITLE
Avoid notices

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2102,7 +2102,7 @@ class Contact
 		$updated = DateTimeFormat::utcNow();
 
 		if (Strings::normaliseLink($contact['url']) != Strings::normaliseLink($ret['url'])) {
-			Logger::notice('New URL differs from old URL', ['id' => $id, 'uid' => $contact['uid'], 'old' => $contact['url'], 'new' => $ret['url']]);
+			Logger::notice('New URL differs from old URL', ['id' => $id, 'uid' => $uid, 'old' => $contact['url'], 'new' => $ret['url']]);
 			self::updateContact($id, $uid, $contact['url'], $ret['url'], ['failed' => true, 'last-update' => $updated, 'failure_update' => $updated]);
 			return false;
 		}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -877,6 +877,9 @@ class Transmitter
 		}
 
 		$reply = DBA::selectFirst('mail', ['uri', 'uri-id', 'from-url'], ['parent-uri' => $mail['parent-uri'], 'reply' => false]);
+		if (!DBA::isResult($reply)) {
+			$reply = $mail;
+		}
 
 		// Making the post more compatible for Mastodon by:
 		// - Making it a note and not an article (no title)


### PR DESCRIPTION
This avoids a notice in the logging that is caused by some cleared variable. Also this fixes another notice when a mail parent couldn't be found.