### PR TITLE
Fix translations for singular/plural strings

### DIFF
--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -314,7 +314,7 @@ class L10n
 
 		if (is_null($s) && $this->stringPluralSelectDefault($count)) {
 			$s = $plural;
-		} else {
+		} elseif (is_null($s)) {
 			$s = $singular;
 		}
 


### PR DESCRIPTION
This fixes the problem that translations with different values for singular and plural had only returned the untranslated singular.