### PR TITLE
Issue 10651: remote comments appeared as own posts

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3614,7 +3614,7 @@ class Diaspora
 	 * @return array|false The data for a comment
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	private static function constructComment(array $item, array $owner)
+	public static function constructComment(array $item, array $owner)
 	{
 		$cachekey = "diaspora:constructComment:".$item['guid'];
 


### PR DESCRIPTION
Fixes #10651. Remote comments on own posts falsely had been transmitted as own posts when fetched via "fetch".