### PR TITLE
Add GPG signing for drone artifacts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -398,6 +398,18 @@ steps:
       - # output the sha256 sum for checking
       - cat "$ARTIFACT.sum256"
       - sha256sum "$ARTIFACT"
+  - name: Sign artifacts
+    image: plugins/gpgsign
+    settings:
+      key:
+        from_secret: gpg_key
+      passphrase:
+        from_secret: gpg_password
+      files:
+        - build/*
+      exclude:
+        - build/*.sum256
+      detach_sign: true
   - name: Upload artifacts
     image: alpine
     environment:
@@ -479,8 +491,6 @@ steps:
       - apt-get install bzip2
       - mkdir ./build
       - export VERSION="$(cat VERSION)"
-      - mkdir ./build
-      - export VERSION="$(cat VERSION)"
       - # Create artifact
       - export RELEASE="friendica-full-$VERSION"
       - export ARTIFACT="$RELEASE.tar.gz"
@@ -496,6 +506,18 @@ steps:
       - # output the sha256 sum for checking
       - cat "$ARTIFACT.sum256"
       - sha256sum "$ARTIFACT"
+  - name: Sign artifacts
+    image: plugins/gpgsign
+    settings:
+      key:
+        from_secret: gpg_key
+      passphrase:
+        from_secret: gpg_password
+      files:
+        - build/*
+      exclude:
+        - build/*.sum256
+      detach_sign: true
   - name: Upload artifacts
     image: alpine
     environment:


### PR DESCRIPTION
<strike>- Replace SHA256 with SHA512</strike> (nope)
- Sign artifacts per GPG (newly created private key was added as encrypted secret at drone)

Public key can be found at https://files.friendi.ca/friendica.asc