### PR TITLE
Fix drone artifact compression parameter

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -390,7 +390,7 @@ steps:
         --transform "s,^,$RELEASE/,"
         -X mods/release-list-exclude.txt
         -T mods/release-list-include.txt
-        -cvjf ./build/$ARTIFACT
+        -cvzf ./build/$ARTIFACT
       - # calculate SHA256 checksum
       - cd ./build
       - sha256sum "$ARTIFACT" > "$ARTIFACT.sum256"
@@ -498,7 +498,7 @@ steps:
         --transform "s,^,$RELEASE/,"
         -X mods/release-list-exclude.txt
         -T mods/release-list-include.txt
-        -cvjf ./build/$ARTIFACT
+        -cvzf ./build/$ARTIFACT
       - # calculate SHA256 checksum
       - cd ./build
       - sha256sum "$ARTIFACT" > "$ARTIFACT.sum256"


### PR DESCRIPTION
There was a parameter mismatching :-)
I created a *.tar.gz file with `-j` parameter, which means bzip2 compression ;-)

This explains the strange behavior, that sometimes I couldn't automatically extract the files ...