### PR TITLE
Use post type "photo" for multiple photos as well

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -327,8 +327,13 @@ class BBCode
 						}
 					}
 				} elseif (count($pictures) > 0) {
-					$post['type'] = 'link';
-					$post['url'] = $plink;
+					if (count($pictures) > 4) {
+						$post['type'] = 'link';
+						$post['url'] = $plink;
+					} else {
+						$post['type'] = 'photo';
+					}
+
 					$post['image'] = $pictures[0][2];
 					$post['text'] = $body;
 


### PR DESCRIPTION
This fixes the problem that posts to Twitter with multiple photos always contained the link to the Friendica post s well - in difference to posts with a single picture.