### PR TITLE
Prevent expandTags to be performed on existing links in Module\Api\Mastodon\Statuses

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2289,14 +2289,14 @@ class BBCode
 	}
 
 	/**
-	 * Expand tags to URLs
+	 * Expand tags to URLs, checks the tag is at the start of a line or preceded by a non-word character
 	 *
 	 * @param string $body
 	 * @return string body with expanded tags
 	 */
 	public static function expandTags(string $body)
 	{
-		return preg_replace_callback("/([!#@])([^\^ \x0D\x0A,;:?\']*[^\^ \x0D\x0A,;:?!\'.])/",
+		return preg_replace_callback("/(?<=\W|^)([!#@])([^\^ \x0D\x0A,;:?'\"]*[^\^ \x0D\x0A,;:?!'\".])/",
 			function ($match) {
 				switch ($match[1]) {
 					case '!':
@@ -2309,6 +2309,7 @@ class BBCode
 						}
 						break;
 					case '#':
+					default:
 						return $match[1] . '[url=' . 'https://' . DI::baseUrl() . '/search?tag=' . $match[2] . ']' . $match[2] . '[/url]';
 				}
 			}, $body);

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -63,7 +63,10 @@ class Statuses extends BaseApi
 		// The imput is defined as text. So we can use Markdown for some enhancements
 		$body = Markdown::toBBCode($request['status']);
 
-		$body = BBCode::expandTags($body);
+		// Avoids potential double expansion of existing links
+		$body = BBCode::performWithEscapedTags($body, ['url'], function ($body) {
+			return BBCode::expandTags($body);
+		});
 
 		$item = [];
 		$item['uid']        = $uid;

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -75,6 +75,7 @@ class BBCodeTest extends MockedTest
 		           ->andReturn($baseUrlMock);
 		$baseUrlMock->shouldReceive('getHostname')->withNoArgs()->andReturn('friendica.local');
 		$baseUrlMock->shouldReceive('getUrlPath')->withNoArgs()->andReturn('');
+		$baseUrlMock->shouldReceive('__toString')->withNoArgs()->andReturn('friendica.local');
 
 		$config = \HTMLPurifier_HTML5Config::createDefault();
 		$config->set('HTML.Doctype', 'HTML5');
@@ -336,6 +337,33 @@ class BBCodeTest extends MockedTest
 	public function testToMarkdown(string $expected, string $text, $for_diaspora = false)
 	{
 		$actual = BBCode::toMarkdown($text, $for_diaspora);
+
+		self::assertEquals($expected, $actual);
+	}
+
+	public function dataExpandTags()
+	{
+		return [
+			'bug-10692-non-word' => [
+				'[url=https://github.com/friendica/friendica/blob/2021.09-rc/src/Util/Logger/StreamLogger.php#L160]https://github.com/friendica/friendica/blob/2021.09-rc/src/Util/Logger/StreamLogger.php#L160[/url]',
+				'[url=https://github.com/friendica/friendica/blob/2021.09-rc/src/Util/Logger/StreamLogger.php#L160]https://github.com/friendica/friendica/blob/2021.09-rc/src/Util/Logger/StreamLogger.php#L160[/url]',
+			],
+			'bug-10692-start-line' => [
+				'#[url=https://friendica.local/search?tag=L160]L160[/url]',
+				'#L160',
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider dataExpandTags
+	 *
+	 * @param string $expected Expected BBCode output
+	 * @param string $text     Input text
+	 */
+	public function testExpandTags(string $expected, string $text)
+	{
+		$actual = BBCode::expandTags($text);
 
 		self::assertEquals($expected, $actual);
 	}


### PR DESCRIPTION
Fixes #10692 twice

I had two independent ideas for fixing this bug:
- Refining the `BBCode::expandTags` regular expression to exclude URL fragments (among others)
- Prevent the execution of `BBCode::expandTags` on existing BBCode links

In the end I implemented both since they both cover the reported bug but they also independently cover unreported edge cases as well.

Plus, tests!