### PR TITLE
Issue 10706: Publish public custom fields in AP

### DIFF
--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -64,10 +64,14 @@ class ActivityPub
 		'diaspora' => 'https://diasporafoundation.org/ns/',
 		'litepub' => 'http://litepub.social/ns#',
 		'toot' => 'http://joinmastodon.org/ns#',
+		'schema' => 'http://schema.org#',
 		'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
 		'sensitive' => 'as:sensitive', 'Hashtag' => 'as:Hashtag',
 		'directMessage' => 'litepub:directMessage',
-		'discoverable' => 'toot:discoverable']];
+		'discoverable' => 'toot:discoverable',
+		'PropertyValue' => 'schema:PropertyValue',
+		'value' => 'schema:value',
+]];
 	const ACCOUNT_TYPES = ['Person', 'Organization', 'Service', 'Group', 'Application', 'Tombstone'];
 	/**
 	 * Checks if the web request is done for the AP protocol

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -394,7 +394,7 @@ class Transmitter
 
 		$custom_fields = [];
 
-		foreach (DI::profileField()->selectByContactId(0, 1) as $profile_field) {
+		foreach (DI::profileField()->selectByContactId(0, $uid) as $profile_field) {
 			$custom_fields[] = [
 				'type' => 'PropertyValue',
 				'name' => $profile_field->label,

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -392,6 +392,20 @@ class Transmitter
 			}
 		}
 
+		$custom_fields = [];
+
+		foreach (DI::profileField()->selectByContactId(0, 1) as $profile_field) {
+			$custom_fields[] = [
+				'type' => 'PropertyValue',
+				'name' => $profile_field->label,
+				'value' => BBCode::convertForUriId($owner['uri-id'], $profile_field->value)
+			];
+		};
+
+		if (!empty($custom_fields)) {
+			$data['attachment'] = $custom_fields;
+		}
+
 		$data['generator'] = self::getService();
 
 		// tags: https://kitty.town/@inmysocks/100656097926961126.json


### PR DESCRIPTION
Fixes #10706

We will now publish the public custom profile fields via the ActivityPub actor endpoint as well. This is an extension made by Mastodon.