### PR TITLE
Better handling of displaying peertube videos

### DIFF
--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -547,7 +547,6 @@ class Media
 			return $attachments;
 		}
 
-		$height = 0;
 		$heights = [];
 		$selected = '';
 		$previews = [];


### PR DESCRIPTION
There had been the problem that Peertube videos doesn't always seem to provide the post guid in the video link anymore. This resulted in duplicate videos. Also the selection of the "perfect" resolution seemed to make problems so it had been reworked.