### PR TITLE
Simplify max_data parameter for Temporal::getDateTimeField in include/conversation

### DIFF
--- a/include/conversation.php
+++ b/include/conversation.php
@@ -1147,10 +1147,10 @@ function status_editor(App $a, array $x = [], $notes_cid = 0, $popup = false)
 		'$placeholdercategory' => Feature::isEnabled(local_user(), 'categories') ? DI::l10n()->t("Categories \x28comma-separated list\x29") : '',
 		'$scheduled_at' => Temporal::getDateTimeField(
 			new DateTime(),
-			DateTime::createFromFormat(DateTimeFormat::MYSQL, DateTimeFormat::local('now + 6 months')),
+			new DateTime('now + 6 months'),
 			null,
 			DI::l10n()->t('Scheduled at'),
-			'scheduled_at',
+			'scheduled_at'
 		),
 		'$wait'         => DI::l10n()->t('Please wait'),
 		'$permset'      => DI::l10n()->t('Permission settings'),

--- a/src/Module/Item/Compose.php
+++ b/src/Module/Item/Compose.php
@@ -167,12 +167,11 @@ class Compose extends BaseModule
 			'$placeholdercategory' => (Feature::isEnabled(local_user(),'categories') ? DI::l10n()->t('Categories (comma-separated list)') : ''),
 			'$scheduled_at' => Temporal::getDateTimeField(
 				new DateTime(),
-				DateTime::createFromFormat(DateTimeFormat::MYSQL, DateTimeFormat::local('now + 6 months')),
+				new DateTime('now + 6 months'),
 				null,
 				DI::l10n()->t('Scheduled at'),
-				'scheduled_at',
+				'scheduled_at'
 			),
-
 
 			'$title'        => $title,
 			'$category'     => $category,


### PR DESCRIPTION
Related to #10691

No timezone information is needed at this point.

Additionally, I removed a comma that would make the current minimum PHP version supported lie. Additional commas in function parameters list is only supported from PHP 7.3 onwards. I'm happy this hasn't been reported before, it means most active Friendica admins are running at least PHP 7.3 which they absolutely should.