### PR TITLE
Bugfix Drone/Docker: forgot a file

### DIFF
--- a/mods/release-list-include.txt
+++ b/mods/release-list-include.txt
@@ -5,6 +5,7 @@ bin/console.bat
 bin/console.php
 bin/daemon.php
 bin/testargs.php
+bin/wait-for-connection
 bin/worker.php
 config/
 doc/


### PR DESCRIPTION
**Self-Merging**

because without this file, the docker cron doesn't work anymore ...