### PR TITLE
Issue 10720: Use different path scheme for user avatars

### DIFF
--- a/mod/msearch.php
+++ b/mod/msearch.php
@@ -22,6 +22,8 @@
 use Friendica\App;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Model\User;
+use Friendica\Util\Proxy;
 
 function msearch_post(App $a)
 {
@@ -72,7 +74,7 @@ function msearch_post(App $a)
 		$results[] = [
 			'name'  => $search_result['name'],
 			'url'   => DI::baseUrl() . '/profile/' . $search_result['nickname'],
-			'photo' => DI::baseUrl() . '/photo/avatar/' . $search_result['uid'] . '.jpg',
+			'photo' => User::getAvatarUrlForId($search_result['uid'], Proxy::SIZE_THUMB),
 			'tags'  => str_replace([',', '  '], [' ', ' '], $search_result['pub_keywords'])
 		];
 	}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -627,9 +627,9 @@ class Contact
 			'nick'        => $user['nickname'],
 			'pubkey'      => $user['pubkey'],
 			'prvkey'      => $user['prvkey'],
-			'photo'       => DI::baseUrl() . '/photo/profile/' . $user['uid'] . '.jpg',
-			'thumb'       => DI::baseUrl() . '/photo/avatar/'  . $user['uid'] . '.jpg',
-			'micro'       => DI::baseUrl() . '/photo/micro/'   . $user['uid'] . '.jpg',
+			'photo'       => User::getAvatarUrlForId($user['uid']),
+			'thumb'       => User::getAvatarUrlForId($user['uid'], Proxy::SIZE_THUMB),
+			'micro'       => User::getAvatarUrlForId($user['uid'], Proxy::SIZE_MICRO),
 			'blocked'     => 0,
 			'pending'     => 0,
 			'url'         => DI::baseUrl() . '/profile/' . $user['nickname'],
@@ -742,7 +742,7 @@ class Contact
 			$fields['micro'] = self::getDefaultAvatar($fields, Proxy::SIZE_MICRO);
 		}
 
-		$fields['avatar'] = DI::baseUrl() . '/photo/profile/' .$uid . '.' . $file_suffix;
+		$fields['avatar'] = User::getAvatarUrlForId($uid);
 		$fields['forum'] = $user['page-flags'] == User::PAGE_FLAGS_COMMUNITY;
 		$fields['prv'] = $user['page-flags'] == User::PAGE_FLAGS_PRVGROUP;
 		$fields['unsearchable'] = !$profile['net-publish'];
@@ -768,8 +768,11 @@ class Contact
 			DBA::update('contact', $fields, ['uid' => 0, 'nurl' => $self['nurl']]);
 
 			// Update the profile
-			$fields = ['photo' => DI::baseUrl() . '/photo/profile/' .$uid . '.' . $file_suffix,
-				'thumb' => DI::baseUrl() . '/photo/avatar/' . $uid .'.' . $file_suffix];
+			$fields = [
+				'photo' => User::getAvatarUrlForId($uid),
+				'thumb' => User::getAvatarUrlForId($uid, Proxy::SIZE_THUMB)
+			];
+
 			DBA::update('profile', $fields, ['uid' => $uid]);
 		}
 
@@ -2355,7 +2358,7 @@ class Contact
 			$probed = false;
 			$ret = $arr['contact'];
 		} else {
-			$probed = true;			
+			$probed = true;
 			$ret = Probe::uri($url, $network, $uid);
 		}
 

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -841,6 +841,57 @@ class User
 	}
 
 	/**
+	 * Get avatar link for given user id
+	 *
+	 * @param integer $uid     user id
+	 * @param string  $size    One of the ProxyUtils::SIZE_* constants
+	 * @return string avatar link
+	 */
+	public static function getAvatarUrlForId(int $uid, string $size = ''):string
+	{
+		$url = DI::baseUrl() . '/photo/';
+
+		switch ($size) {
+			case Proxy::SIZE_MICRO:
+				$url .= 'micro/';
+				$scale = 6;
+				break;
+			case Proxy::SIZE_THUMB:
+				$url .= 'avatar/';
+				$scale = 5;
+				break;
+			default:
+				$url .= 'profile/';
+				$scale = 4;
+				break;
+		}
+
+		$updated =  '';
+		$imagetype = IMAGETYPE_JPEG;
+
+		$photo = Photo::selectFirst(['type', 'created', 'edited', 'updated'], ["scale" => $scale, 'uid' => $uid, 'profile' => true]);
+		if (!empty($photo)) {
+			$updated = max($photo['created'], $photo['edited'], $photo['updated']);
+
+			switch ($photo['type']) {
+				case 'image/png':
+					$imagetype = IMAGETYPE_PNG;
+					break;
+
+				case 'image/gif':
+					$imagetype = IMAGETYPE_PNG;
+					break;
+
+				default:
+					$imagetype = IMAGETYPE_JPEG;
+					break;
+			}
+		}
+
+		return $url . $uid . image_type_to_extension($imagetype) . ($updated ? '?ts=' . strtotime($updated) : '');
+	}
+
+	/**
 	 * Catch-all user creation function
 	 *
 	 * Creates a user from the provided data array, either form fields or OpenID.
@@ -1054,8 +1105,8 @@ class User
 		$insert_result = DBA::insert('profile', [
 			'uid' => $uid,
 			'name' => $username,
-			'photo' => DI::baseUrl() . "/photo/profile/{$uid}.jpg",
-			'thumb' => DI::baseUrl() . "/photo/avatar/{$uid}.jpg",
+			'photo' => self::getAvatarUrlForId($uid),
+			'thumb' => self::getAvatarUrlForId($uid, Proxy::SIZE_THUMB),
 			'publish' => $publish,
 			'net-publish' => $netpublish,
 		]);
@@ -1585,8 +1636,8 @@ class User
 	/**
 	 * Check if the given user id has delegations or is delegated
 	 *
-	 * @param int $uid 
-	 * @return bool 
+	 * @param int $uid
+	 * @return bool
 	 */
 	public static function hasIdentities(int $uid):bool
 	{

--- a/src/Module/Delegation.php
+++ b/src/Module/Delegation.php
@@ -27,7 +27,6 @@ use Friendica\Core\Renderer;
 use Friendica\Core\Session;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Model\Contact;
 use Friendica\Model\Notification;
 use Friendica\Model\User;
 use Friendica\Network\HTTPException\ForbiddenException;
@@ -123,12 +122,7 @@ class Delegation extends BaseModule
 
 		//getting additinal information for each identity
 		foreach ($identities as $key => $identity) {
-			$self = Contact::selectFirst(['id', 'updated'], ['uid' => $identity['uid'], 'self' => true]);
-			if (!DBA::isResult($self)) {
-				continue;
-			}
-
-			$identities[$key]['thumb'] = Contact::getAvatarUrlForId($self['id'], Proxy::SIZE_THUMB, $self['updated']);
+			$identities[$key]['thumb'] = User::getAvatarUrlForId($identity['uid'], Proxy::SIZE_THUMB);
 
 			$identities[$key]['selected'] = ($identity['nickname'] === DI::app()->getLoggedInUserNickname());
 

--- a/src/Module/NoScrape.php
+++ b/src/Module/NoScrape.php
@@ -26,7 +26,6 @@ use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Model\Contact;
 use Friendica\Model\User;
 
 /**
@@ -81,7 +80,7 @@ class NoScrape extends BaseModule
 		$keywords = explode(',', $keywords);
 
 		$json_info['fn']       = $profile['name'];
-		$json_info['photo']    = Contact::getAvatarUrlForUrl($profile['url'], $profile['uid']);
+		$json_info['photo']    = User::getAvatarUrlForId($profile['uid']);
 		$json_info['tags']     = $keywords;
 		$json_info['language'] = $profile['language'];
 

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -31,6 +31,8 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model;
+use Friendica\Model\User;
+use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 
 /**
@@ -372,7 +374,7 @@ class Register extends BaseModule
 					'source_mail'  => $user['email'],
 					'source_nick'  => $user['nickname'],
 					'source_link'  => $base_url . '/admin/users/',
-					'source_photo' => $base_url . '/photo/avatar/' . $user['uid'] . '.jpg',
+					'source_photo' => User::getAvatarUrlForId($user['uid'], Proxy::SIZE_THUMB),
 					'show_in_notification_page' => false
 				]);
 			}

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -26,7 +26,6 @@ use Friendica\Core\Hook;
 use Friendica\Core\Renderer;
 use Friendica\Core\System;
 use Friendica\DI;
-use Friendica\Model\Contact;
 use Friendica\Model\Photo;
 use Friendica\Model\User;
 use Friendica\Protocol\ActivityNamespace;
@@ -197,7 +196,7 @@ class Xrd extends BaseModule
 				[
 					'rel'  => 'http://webfinger.net/rel/avatar',
 					'type' => $avatar['type'],
-					'href' => Contact::getAvatarUrlForUrl($owner['url'], $owner['uid']),
+					'href' => User::getAvatarUrlForId($owner['uid']),
 				],
 				[
 					'rel'  => 'http://joindiaspora.com/seed_location',
@@ -253,7 +252,7 @@ class Xrd extends BaseModule
 			'$hcard_url'   => $baseURL . '/hcard/' . $owner['nickname'],
 			'$atom'        => $owner['poll'],
 			'$poco_url'    => $owner['poco'],
-			'$photo'       => Contact::getAvatarUrlForUrl($owner['url'], $owner['uid']),
+			'$photo'       => User::getAvatarUrlForId($owner['uid']),
 			'$type'        => $avatar['type'],
 			'$salmon'      => $baseURL . '/salmon/' . $owner['nickname'],
 			'$salmen'      => $baseURL . '/salmon/' . $owner['nickname'] . '/mention',

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -101,7 +101,7 @@ class Probe
 			if (isset($data[$field])) {
 				if (in_array($field, $numeric_fields)) {
 					$newdata[$field] = (int)$data[$field];
-				} else {	
+				} else {
 					$newdata[$field] = $data[$field];
 				}
 			} elseif (!in_array($field, $numeric_fields)) {
@@ -2229,11 +2229,11 @@ class Probe
 			$data = [
 				'name' => $profile['name'], 'nick' => $profile['nick'], 'guid' => $approfile['diaspora:guid'] ?? '',
 				'url' => $profile['url'], 'addr' => $profile['addr'], 'alias' => $profile['alias'],
-				'photo' => Contact::getAvatarUrlForId($profile['id'], '', $profile['updated']),
+				'photo' => User::getAvatarUrlForId($uid),
 				'header' => $profile['header'] ? Contact::getHeaderUrlForId($profile['id'], $profile['updated']) : '',
 				'account-type' => $profile['contact-type'], 'community' => ($profile['contact-type'] == User::ACCOUNT_TYPE_COMMUNITY),
 				'keywords' => $profile['keywords'], 'location' => $profile['location'], 'about' => $profile['about'],
-				'xmpp' => $profile['xmpp'], 'matrix' => $profile['matrix'], 
+				'xmpp' => $profile['xmpp'], 'matrix' => $profile['matrix'],
 				'hide' => !$profile['net-publish'], 'batch' => '', 'notify' => $profile['notify'],
 				'poll' => $profile['poll'], 'request' => $profile['request'], 'confirm' => $profile['confirm'],
 				'subscribe' => $approfile['generator']['url'] . '/follow?url={uri}', 'poco' => $profile['poco'],

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -370,7 +370,7 @@ class Transmitter
 			'owner' => $owner['url'],
 			'publicKeyPem' => $owner['pubkey']];
 		$data['endpoints'] = ['sharedInbox' => DI::baseUrl() . '/inbox'];
-		$data['icon'] = ['type' => 'Image', 'url' => Contact::getAvatarUrlForId($owner['id'], '', $owner['updated'])];
+		$data['icon'] = ['type' => 'Image', 'url' => User::getAvatarUrlForId($uid)];
 
 		$resourceid = Photo::ridFromURI($owner['photo']);
 		if (!empty($resourceid)) {

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -449,7 +449,7 @@ class DFRN
 
 		$attributes = ["rel" => "photo", "type" => "image/jpeg",
 					"media:width" => Proxy::PIXEL_SMALL, "media:height" => Proxy::PIXEL_SMALL,
-					"href" => Contact::getAvatarUrlForId($owner['id'], Proxy::SIZE_SMALL, $owner['updated'])];
+					"href" => User::getAvatarUrlForId($owner['uid'], Proxy::SIZE_SMALL)];
 
 		if (!$public || !$hide) {
 			$attributes["dfrn:updated"] = $picdate;

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -965,7 +965,7 @@ class Feed
 		XML::addElement($doc, $root, "id", DI::baseUrl() . "/profile/" . $owner["nick"]);
 		XML::addElement($doc, $root, "title", $title);
 		XML::addElement($doc, $root, "subtitle", sprintf("Updates from %s on %s", $owner["name"], DI::config()->get('config', 'sitename')));
-		XML::addElement($doc, $root, "logo", Contact::getAvatarUrlForId($owner['id'], Proxy::SIZE_SMALL, $owner['updated']));
+		XML::addElement($doc, $root, "logo", User::getAvatarUrlForId($owner['uid'], Proxy::SIZE_SMALL));
 		XML::addElement($doc, $root, "updated", DateTimeFormat::utcNow(DateTimeFormat::ATOM));
 
 		$author = self::addAuthor($doc, $owner);

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1275,7 +1275,7 @@ class OStatus
 		XML::addElement($doc, $root, "id", DI::baseUrl() . "/profile/" . $owner["nick"]);
 		XML::addElement($doc, $root, "title", $title);
 		XML::addElement($doc, $root, "subtitle", sprintf("Updates from %s on %s", $owner["name"], DI::config()->get('config', 'sitename')));
-		XML::addElement($doc, $root, "logo", Contact::getAvatarUrlForId($owner['id'], ProxyUtils::SIZE_SMALL, $owner['updated']));
+		XML::addElement($doc, $root, "logo", User::getAvatarUrlForId($owner['uid'], ProxyUtils::SIZE_SMALL));
 		XML::addElement($doc, $root, "updated", DateTimeFormat::utcNow(DateTimeFormat::ATOM));
 
 		$author = self::addAuthor($doc, $owner, true);
@@ -1432,7 +1432,7 @@ class OStatus
 				"type" => "image/jpeg", // To-Do?
 				"media:width" => ProxyUtils::PIXEL_SMALL,
 				"media:height" => ProxyUtils::PIXEL_SMALL,
-				"href" => Contact::getAvatarUrlForId($owner['id'], ProxyUtils::SIZE_SMALL, $owner['updated'])];
+				"href" => User::getAvatarUrlForId($owner['uid'], ProxyUtils::SIZE_SMALL)];
 		XML::addElement($doc, $author, "link", "", $attributes);
 
 		if (isset($owner["thumb"])) {
@@ -1441,7 +1441,7 @@ class OStatus
 					"type" => "image/jpeg", // To-Do?
 					"media:width" => ProxyUtils::PIXEL_THUMB,
 					"media:height" => ProxyUtils::PIXEL_THUMB,
-					"href" => Contact::getAvatarUrlForId($owner['id'], ProxyUtils::SIZE_THUMB, $owner['updated'])];
+					"href" => User::getAvatarUrlForId($owner['uid'], ProxyUtils::SIZE_THUMB)];
 			XML::addElement($doc, $author, "link", "", $attributes);
 		}
 


### PR DESCRIPTION
Possibly helps with issue #10720

It seems to be better when we had different path schemes for user avatars and contact avatars. This should help in debugging avatar issues as well.

Also this PR helped to get rid of several places in the code where the avatar path had been hard coded. It is now replaced with a single function.