### PR TITLE
Issue 9871: Deletion of photos is now possible again

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -1025,6 +1025,7 @@ function photos_content(App $a)
 				'$confirm' => DI::l10n()->t('Delete Album'),
 				'$confirm_url' => $drop_url,
 				'$confirm_name' => 'dropalbum',
+				'$confirm_value' => 'dropalbum',
 				'$cancel' => DI::l10n()->t('Cancel'),
 			]);
 		}
@@ -1131,6 +1132,7 @@ function photos_content(App $a)
 				'$confirm' => DI::l10n()->t('Delete Photo'),
 				'$confirm_url' => $drop_url,
 				'$confirm_name' => 'delete',
+				'$confirm_value' => 'delete',
 				'$cancel' => DI::l10n()->t('Cancel'),
 			]);
 		}

--- a/view/theme/frio/templates/confirm.tpl
+++ b/view/theme/frio/templates/confirm.tpl
@@ -3,7 +3,7 @@
 	<div id="confirm-message">{{$message}}</div>
 
 	<div class="form-group pull-right settings-submit-wrapper">
-		<button type="submit" name="{{$confirm_name}}" id="confirm-submit-button" class="btn btn-primary confirm-button" value="{{$confirm_value}}">{{$confirm}}</button>
-		<button type="submit" name="canceled" id="confirm-cancel-button" class="btn confirm-button" data-dismiss="modal">{{$cancel}}</button>
+		<button type="submit" name="{{$confirm_name}}" value="{{$confirm_value}}" id="confirm-submit-button" class="btn btn-primary confirm-button" value="{{$confirm_value}}">{{$confirm}}</button>
+		<button type="submit" name="canceled" value="{{$cancel}} id="confirm-cancel-button" class="btn confirm-button" data-dismiss="modal">{{$cancel}}</button>
 	</div>
 </form>

--- a/view/theme/frio/templates/confirm.tpl
+++ b/view/theme/frio/templates/confirm.tpl
@@ -3,7 +3,7 @@
 	<div id="confirm-message">{{$message}}</div>
 
 	<div class="form-group pull-right settings-submit-wrapper">
-		<button type="submit" name="{{$confirm_name}}" value="{{$confirm_value}}" id="confirm-submit-button" class="btn btn-primary confirm-button" value="{{$confirm_value}}">{{$confirm}}</button>
+		<button type="submit" name="{{$confirm_name}}" id="confirm-submit-button" class="btn btn-primary confirm-button" value="{{$confirm_value}}">{{$confirm}}</button>
 		<button type="submit" name="canceled" value="{{$cancel}} id="confirm-cancel-button" class="btn confirm-button" data-dismiss="modal">{{$cancel}}</button>
 	</div>
 </form>


### PR DESCRIPTION
Fixes #9871 by adding a missing parameter to the "confirm" template. This prevented the deletion from being processed.