### PR TITLE
Display the public contacts for profile visitors

### DIFF
--- a/src/Content/Widget/ContactBlock.php
+++ b/src/Content/Widget/ContactBlock.php
@@ -99,10 +99,10 @@ class ContactBlock
 				'network' => Protocol::FEDERATED,
 			], ['limit' => $shown]);
 
-			$contact_ids = array_column($personal_contacts, 'uri-id');
+			$contact_uriids = array_column($personal_contacts, 'uri-id');
 
-			if (!empty($contact_ids)) {
-				$contacts_stmt = DBA::select('contact', ['id', 'uid', 'addr', 'url', 'name', 'thumb', 'avatar', 'network'], ['uri-id' => $contact_ids, 'uid' => $contact_uid]);
+			if (!empty($contact_uriids)) {
+				$contacts_stmt = DBA::select('contact', ['id', 'uid', 'addr', 'url', 'name', 'thumb', 'avatar', 'network'], ['uri-id' => $contact_uriids, 'uid' => $contact_uid]);
 
 				if (DBA::isResult($contacts_stmt)) {
 					$contacts_title = DI::l10n()->tt('%d Contact', '%d Contacts', $total);

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -406,7 +406,7 @@ class Profile
 		}
 
 		if (!$block && $show_contacts) {
-			$contact_block = ContactBlock::getHTML($profile);
+			$contact_block = ContactBlock::getHTML($profile, local_user());
 
 			if (is_array($profile) && !$profile['hide-friends']) {
 				$contact_count = DBA::count('contact', [


### PR DESCRIPTION
This fixes the problem that we displayed the ids of the personal contacts in the contact widget. This is fine when you have got a look at your own profile - but visitors will get an error when trying to follow the contacts. So we now display the public contacts when a visitor is visiting the profile.