### PR TITLE
Improve compacting error logging in Util\JsonLD

### DIFF
--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -165,7 +165,7 @@ class JsonLD
 		}
 		catch (Exception $e) {
 			$compacted = false;
-			Logger::error('compacting error', ['line' => $e->getLine(), 'message' => $e->getMessage()]);
+			Logger::notice('compacting error', ['line' => $e->getLine(), 'exception' => $e]);
 		}
 
 		$json = json_decode(json_encode($compacted, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE), true);


### PR DESCRIPTION
Sparked by #10740 
- Exceptions thrown by `friendica/json-ld` are nested and their string representation shows all the exception chain