### PR TITLE
Remove contact drop feature

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -963,7 +963,6 @@ class Contact
 		$pm_url = '';
 		$status_link = '';
 		$photos_link = '';
-		$contact_drop_link = '';
 		$poke_link = '';
 
 		if ($uid == 0) {
@@ -1015,10 +1014,6 @@ class Contact
 
 		$posts_link = DI::baseUrl() . '/contact/' . $contact['id'] . '/conversations';
 
-		if (!$contact['self']) {
-			$contact_drop_link = DI::baseUrl() . '/contact/' . $contact['id'] . '/drop?confirm=1';
-		}
-
 		$follow_link = '';
 		$unfollow_link = '';
 		if (!$contact['self'] && in_array($contact['network'], Protocol::NATIVE_SUPPORT)) {
@@ -1027,10 +1022,6 @@ class Contact
 			} elseif(!$contact['pending']) {
 				$follow_link = 'follow?url=' . urlencode($contact['url']) . '&auto=1';
 			}
-		}
-
-		if (!empty($follow_link) || !empty($unfollow_link)) {
-			$contact_drop_link = '';
 		}
 
 		/**
@@ -1052,7 +1043,6 @@ class Contact
 				'photos'  => [DI::l10n()->t('View Photos')   , $photos_link      , true],
 				'network' => [DI::l10n()->t('Network Posts') , $posts_link       , false],
 				'edit'    => [DI::l10n()->t('View Contact')  , $contact_url      , false],
-				'drop'    => [DI::l10n()->t('Drop Contact')  , $contact_drop_link, false],
 				'pm'      => [DI::l10n()->t('Send PM')       , $pm_url           , false],
 				'poke'    => [DI::l10n()->t('Poke')          , $poke_link        , false],
 				'follow'  => [DI::l10n()->t('Connect/Follow'), $follow_link      , true],

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -87,12 +87,6 @@ class Contact extends BaseModule
 				self::toggleIgnoreContact($cdata['public']);
 				$count_actions++;
 			}
-
-			if (!empty($_POST['contacts_batch_drop']) && $cdata['user']
-				&& self::dropContact($cdata['user'], local_user())
-			) {
-				$count_actions++;
-			}
 		}
 		if ($count_actions > 0) {
 			info(DI::l10n()->tt('%d contact edited.', '%d contacts edited.', $count_actions));
@@ -239,31 +233,6 @@ class Contact extends BaseModule
 	{
 		$ignored = !Model\Contact\User::isIgnored($contact_id, local_user());
 		Model\Contact\User::setIgnored($contact_id, local_user(), $ignored);
-	}
-
-	/**
-	 * @param int $contact_id Id for contact with uid != 0
-	 * @param int $uid        Id for user we want to drop the contact for
-	 * @return bool
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
-	 */
-	private static function dropContact(int $contact_id, int $uid): bool
-	{
-		$contact = Model\Contact::getContactForUser($contact_id, $uid);
-		if (!DBA::isResult($contact)) {
-			return false;
-		}
-
-		$owner = Model\User::getOwnerDataById($uid);
-		if (!DBA::isResult($owner)) {
-			return false;
-		}
-
-		Model\Contact::terminateFriendship($owner, $contact, true);
-		Model\Contact::remove($contact['id']);
-
-		return true;
 	}
 
 	public static function content(array $parameters = [], $update = 0)
@@ -435,36 +404,6 @@ class Contact extends BaseModule
 				info(($ignored ? DI::l10n()->t('Contact has been ignored') : DI::l10n()->t('Contact has been unignored')));
 
 				DI::baseUrl()->redirect('contact/' . $cdata['public']);
-				// NOTREACHED
-			}
-
-			if ($cmd === 'drop' && $cdata['user']) {
-				// Check if we should do HTML-based delete confirmation
-				if (!empty($_REQUEST['confirm'])) {
-					DI::page()['aside'] = '';
-
-					return Renderer::replaceMacros(Renderer::getMarkupTemplate('contact_drop_confirm.tpl'), [
-						'$header' => DI::l10n()->t('Drop contact'),
-						'$contact' => self::getContactTemplateVars($orig_record),
-						'$method' => 'get',
-						'$message' => DI::l10n()->t('Do you really want to delete this contact?'),
-						'$confirm' => DI::l10n()->t('Yes'),
-						'$confirm_url' => DI::args()->getCommand(),
-						'$confirm_name' => 't',
-						'$confirm_value' => BaseModule::getFormSecurityToken('contact_action'),
-						'$cancel' => DI::l10n()->t('Cancel'),
-					]);
-				}
-				// Now check how the user responded to the confirmation query
-				if (!empty($_REQUEST['canceled'])) {
-					DI::baseUrl()->redirect('contact');
-				}
-
-				if (self::dropContact($cdata['user'], local_user())) {
-					info(DI::l10n()->t('Contact has been removed.'));
-				}
-
-				DI::baseUrl()->redirect('contact');
 				// NOTREACHED
 			}
 		}
@@ -868,13 +807,11 @@ class Contact extends BaseModule
 			'$cmd'        => DI::args()->getCommand(),
 			'$contacts'   => $contacts,
 			'$form_security_token'  => BaseModule::getFormSecurityToken('contact_batch_actions'),
-			'$contact_drop_confirm' => DI::l10n()->t('Do you really want to delete this contact?'),
 			'multiselect' => 1,
 			'$batch_actions' => [
 				'contacts_batch_update'  => DI::l10n()->t('Update'),
 				'contacts_batch_block'   => DI::l10n()->t('Block') . '/' . DI::l10n()->t('Unblock'),
 				'contacts_batch_ignore'  => DI::l10n()->t('Ignore') . '/' . DI::l10n()->t('Unignore'),
-				'contacts_batch_drop'    => DI::l10n()->t('Delete'),
 			],
 			'$h_batch_actions' => DI::l10n()->t('Batch Actions'),
 			'$paginate'   => $pager->renderFull($total),
@@ -1156,16 +1093,6 @@ class Contact extends BaseModule
 			'sel'   => (intval($contact['readonly']) ? 'active' : ''),
 			'id'    => 'toggle-ignore',
 		];
-
-		if ($contact['uid'] != 0) {
-			$contact_actions['delete'] = [
-				'label' => DI::l10n()->t('Delete'),
-				'url'   => 'contact/' . $contact['id'] . '/drop?t=' . $formSecurityToken,
-				'title' => DI::l10n()->t('Delete contact'),
-				'sel'   => '',
-				'id'    => 'delete',
-			];
-		}
 
 		return $contact_actions;
 	}

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -235,7 +235,6 @@ return [
 		'/{id:\d+}/block'             => [Module\Contact::class,           [R::GET]],
 		'/{id:\d+}/conversations'     => [Module\Contact::class,           [R::GET]],
 		'/{id:\d+}/contacts[/{type}]' => [Module\Contact\Contacts::class,  [R::GET]],
-		'/{id:\d+}/drop'              => [Module\Contact::class,           [R::GET]],
 		'/{id:\d+}/ignore'            => [Module\Contact::class,           [R::GET]],
 		'/{id:\d+}/poke'              => [Module\Contact\Poke::class,      [R::GET, R::POST]],
 		'/{id:\d+}/posts'             => [Module\Contact::class,           [R::GET]],

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2021.09-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-10 00:27+0000\n"
+"POT-Creation-Date: 2021-09-25 12:54-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,8 +38,8 @@ msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgstr ""
 
 #: include/api.php:4437 mod/photos.php:89 mod/photos.php:198 mod/photos.php:626
-#: mod/photos.php:1034 mod/photos.php:1051 mod/photos.php:1597
-#: src/Model/User.php:1118 src/Model/User.php:1126 src/Model/User.php:1134
+#: mod/photos.php:1035 mod/photos.php:1052 mod/photos.php:1599
+#: src/Model/User.php:1169 src/Model/User.php:1177 src/Model/User.php:1185
 #: src/Module/Settings/Profile/Photo/Crop.php:101
 #: src/Module/Settings/Profile/Photo/Crop.php:117
 #: src/Module/Settings/Profile/Photo/Crop.php:133
@@ -49,455 +49,454 @@ msgstr ""
 msgid "Profile Photos"
 msgstr ""
 
-#: include/conversation.php:109
+#: include/conversation.php:110
 #, php-format
 msgid "%1$s poked %2$s"
 msgstr ""
 
-#: include/conversation.php:142 src/Model/Item.php:2609
+#: include/conversation.php:143 src/Model/Item.php:2622
 msgid "event"
 msgstr ""
 
-#: include/conversation.php:145 include/conversation.php:154 mod/tagger.php:90
+#: include/conversation.php:146 include/conversation.php:155 mod/tagger.php:90
 msgid "status"
 msgstr ""
 
-#: include/conversation.php:150 mod/tagger.php:90 src/Model/Item.php:2611
+#: include/conversation.php:151 mod/tagger.php:90 src/Model/Item.php:2624
 msgid "photo"
 msgstr ""
 
-#: include/conversation.php:164 mod/tagger.php:123
+#: include/conversation.php:165 mod/tagger.php:123
 #, php-format
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: include/conversation.php:467 mod/photos.php:1459 src/Object/Post.php:226
+#: include/conversation.php:476 mod/photos.php:1461 src/Object/Post.php:227
 msgid "Select"
 msgstr ""
 
-#: include/conversation.php:468 mod/photos.php:1460 mod/settings.php:573
+#: include/conversation.php:477 mod/photos.php:1462 mod/settings.php:573
 #: src/Module/Admin/Users/Active.php:139 src/Module/Admin/Users/Blocked.php:140
-#: src/Module/Admin/Users/Index.php:153 src/Module/Contact.php:849
-#: src/Module/Contact.php:1132
+#: src/Module/Admin/Users/Index.php:153
 msgid "Delete"
 msgstr ""
 
-#: include/conversation.php:503 src/Object/Post.php:453 src/Object/Post.php:454
+#: include/conversation.php:512 src/Object/Post.php:454 src/Object/Post.php:455
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: include/conversation.php:516 src/Object/Post.php:441
+#: include/conversation.php:525 src/Object/Post.php:442
 msgid "Categories:"
 msgstr ""
 
-#: include/conversation.php:517 src/Object/Post.php:442
+#: include/conversation.php:526 src/Object/Post.php:443
 msgid "Filed under:"
 msgstr ""
 
-#: include/conversation.php:524 src/Object/Post.php:467
+#: include/conversation.php:533 src/Object/Post.php:468
 #, php-format
 msgid "%s from %s"
 msgstr ""
 
-#: include/conversation.php:539
+#: include/conversation.php:548
 msgid "View in context"
 msgstr ""
 
-#: include/conversation.php:541 include/conversation.php:1146
+#: include/conversation.php:550 include/conversation.php:1155
 #: mod/editpost.php:107 mod/message.php:203 mod/message.php:368
-#: mod/photos.php:1524 mod/wallmessage.php:155 src/Module/Item/Compose.php:165
-#: src/Object/Post.php:501
+#: mod/photos.php:1526 mod/wallmessage.php:155 src/Module/Item/Compose.php:165
+#: src/Object/Post.php:502
 msgid "Please wait"
 msgstr ""
 
-#: include/conversation.php:605
+#: include/conversation.php:614
 msgid "remove"
 msgstr ""
 
-#: include/conversation.php:609
+#: include/conversation.php:618
 msgid "Delete Selected Items"
 msgstr ""
 
-#: include/conversation.php:647 include/conversation.php:650
-#: include/conversation.php:653 include/conversation.php:656
+#: include/conversation.php:656 include/conversation.php:659
+#: include/conversation.php:662 include/conversation.php:665
 #, php-format
 msgid "You had been addressed (%s)."
 msgstr ""
 
-#: include/conversation.php:659
+#: include/conversation.php:668
 #, php-format
 msgid "You are following %s."
 msgstr ""
 
-#: include/conversation.php:662
+#: include/conversation.php:671
 msgid "Tagged"
 msgstr ""
 
-#: include/conversation.php:675 include/conversation.php:1013
-#: include/conversation.php:1051
+#: include/conversation.php:684 include/conversation.php:1022
+#: include/conversation.php:1060
 #, php-format
 msgid "%s reshared this."
 msgstr ""
 
-#: include/conversation.php:677
+#: include/conversation.php:686
 msgid "Reshared"
 msgstr ""
 
-#: include/conversation.php:677
+#: include/conversation.php:686
 #, php-format
 msgid "Reshared by %s <%s>"
 msgstr ""
 
-#: include/conversation.php:680
+#: include/conversation.php:689
 #, php-format
 msgid "%s is participating in this thread."
 msgstr ""
 
-#: include/conversation.php:683
+#: include/conversation.php:692
 msgid "Stored"
 msgstr ""
 
-#: include/conversation.php:686
+#: include/conversation.php:695
 msgid "Global"
 msgstr ""
 
-#: include/conversation.php:689
+#: include/conversation.php:698
 msgid "Relayed"
 msgstr ""
 
-#: include/conversation.php:689
+#: include/conversation.php:698
 #, php-format
 msgid "Relayed by %s <%s>"
 msgstr ""
 
-#: include/conversation.php:692
+#: include/conversation.php:701
 msgid "Fetched"
 msgstr ""
 
-#: include/conversation.php:692
+#: include/conversation.php:701
 #, php-format
 msgid "Fetched because of %s <%s>"
 msgstr ""
 
-#: include/conversation.php:844 view/theme/frio/theme.php:323
+#: include/conversation.php:853 view/theme/frio/theme.php:323
 msgid "Follow Thread"
 msgstr ""
 
-#: include/conversation.php:845 src/Model/Contact.php:1050
+#: include/conversation.php:854 src/Model/Contact.php:1041
 msgid "View Status"
 msgstr ""
 
-#: include/conversation.php:846 include/conversation.php:868
-#: src/Model/Contact.php:976 src/Model/Contact.php:1042
-#: src/Model/Contact.php:1051 src/Module/Directory.php:160
+#: include/conversation.php:855 include/conversation.php:877
+#: src/Model/Contact.php:975 src/Model/Contact.php:1033
+#: src/Model/Contact.php:1042 src/Module/Directory.php:160
 #: src/Module/Settings/Profile/Index.php:223
 msgid "View Profile"
 msgstr ""
 
-#: include/conversation.php:847 src/Model/Contact.php:1052
+#: include/conversation.php:856 src/Model/Contact.php:1043
 msgid "View Photos"
 msgstr ""
 
-#: include/conversation.php:848 src/Model/Contact.php:1043
-#: src/Model/Contact.php:1053
+#: include/conversation.php:857 src/Model/Contact.php:1034
+#: src/Model/Contact.php:1044
 msgid "Network Posts"
 msgstr ""
 
-#: include/conversation.php:849 src/Model/Contact.php:1044
-#: src/Model/Contact.php:1054
+#: include/conversation.php:858 src/Model/Contact.php:1035
+#: src/Model/Contact.php:1045
 msgid "View Contact"
 msgstr ""
 
-#: include/conversation.php:850 src/Model/Contact.php:1056
+#: include/conversation.php:859 src/Model/Contact.php:1046
 msgid "Send PM"
 msgstr ""
 
-#: include/conversation.php:851 src/Module/Admin/Blocklist/Contact.php:84
+#: include/conversation.php:860 src/Module/Admin/Blocklist/Contact.php:84
 #: src/Module/Admin/Users/Active.php:140 src/Module/Admin/Users/Index.php:154
-#: src/Module/Contact.php:587 src/Module/Contact.php:847
-#: src/Module/Contact.php:1115
+#: src/Module/Contact.php:553 src/Module/Contact.php:813
+#: src/Module/Contact.php:1082
 msgid "Block"
 msgstr ""
 
-#: include/conversation.php:852 src/Module/Contact.php:588
-#: src/Module/Contact.php:848 src/Module/Contact.php:1123
+#: include/conversation.php:861 src/Module/Contact.php:554
+#: src/Module/Contact.php:814 src/Module/Contact.php:1090
 #: src/Module/Notifications/Introductions.php:113
 #: src/Module/Notifications/Introductions.php:185
 #: src/Module/Notifications/Notification.php:59
 msgid "Ignore"
 msgstr ""
 
-#: include/conversation.php:856 src/Object/Post.php:428
+#: include/conversation.php:865 src/Object/Post.php:429
 msgid "Languages"
 msgstr ""
 
-#: include/conversation.php:860 src/Model/Contact.php:1057
+#: include/conversation.php:869 src/Model/Contact.php:1047
 msgid "Poke"
 msgstr ""
 
-#: include/conversation.php:865 mod/follow.php:138 src/Content/Widget.php:76
-#: src/Model/Contact.php:1045 src/Model/Contact.php:1058
+#: include/conversation.php:874 mod/follow.php:138 src/Content/Widget.php:76
+#: src/Model/Contact.php:1036 src/Model/Contact.php:1048
 #: view/theme/vier/theme.php:172
 msgid "Connect/Follow"
 msgstr ""
 
-#: include/conversation.php:998
+#: include/conversation.php:1007
 #, php-format
 msgid "%s likes this."
 msgstr ""
 
-#: include/conversation.php:1001
+#: include/conversation.php:1010
 #, php-format
 msgid "%s doesn't like this."
 msgstr ""
 
-#: include/conversation.php:1004
+#: include/conversation.php:1013
 #, php-format
 msgid "%s attends."
 msgstr ""
 
-#: include/conversation.php:1007
+#: include/conversation.php:1016
 #, php-format
 msgid "%s doesn't attend."
 msgstr ""
 
-#: include/conversation.php:1010
+#: include/conversation.php:1019
 #, php-format
 msgid "%s attends maybe."
 msgstr ""
 
-#: include/conversation.php:1019
+#: include/conversation.php:1028
 msgid "and"
-msgstr ""
-
-#: include/conversation.php:1022
-#, php-format
-msgid "and %d other people"
-msgstr ""
-
-#: include/conversation.php:1030
-#, php-format
-msgid "<span  %1$s>%2$d people</span> like this"
 msgstr ""
 
 #: include/conversation.php:1031
 #, php-format
-msgid "%s like this."
-msgstr ""
-
-#: include/conversation.php:1034
-#, php-format
-msgid "<span  %1$s>%2$d people</span> don't like this"
-msgstr ""
-
-#: include/conversation.php:1035
-#, php-format
-msgid "%s don't like this."
-msgstr ""
-
-#: include/conversation.php:1038
-#, php-format
-msgid "<span  %1$s>%2$d people</span> attend"
+msgid "and %d other people"
 msgstr ""
 
 #: include/conversation.php:1039
 #, php-format
-msgid "%s attend."
+msgid "<span  %1$s>%2$d people</span> like this"
 msgstr ""
 
-#: include/conversation.php:1042
+#: include/conversation.php:1040
 #, php-format
-msgid "<span  %1$s>%2$d people</span> don't attend"
+msgid "%s like this."
 msgstr ""
 
 #: include/conversation.php:1043
 #, php-format
-msgid "%s don't attend."
+msgid "<span  %1$s>%2$d people</span> don't like this"
 msgstr ""
 
-#: include/conversation.php:1046
+#: include/conversation.php:1044
 #, php-format
-msgid "<span  %1$s>%2$d people</span> attend maybe"
+msgid "%s don't like this."
 msgstr ""
 
 #: include/conversation.php:1047
 #, php-format
+msgid "<span  %1$s>%2$d people</span> attend"
+msgstr ""
+
+#: include/conversation.php:1048
+#, php-format
+msgid "%s attend."
+msgstr ""
+
+#: include/conversation.php:1051
+#, php-format
+msgid "<span  %1$s>%2$d people</span> don't attend"
+msgstr ""
+
+#: include/conversation.php:1052
+#, php-format
+msgid "%s don't attend."
+msgstr ""
+
+#: include/conversation.php:1055
+#, php-format
+msgid "<span  %1$s>%2$d people</span> attend maybe"
+msgstr ""
+
+#: include/conversation.php:1056
+#, php-format
 msgid "%s attend maybe."
 msgstr ""
 
-#: include/conversation.php:1050
+#: include/conversation.php:1059
 #, php-format
 msgid "<span  %1$s>%2$d people</span> reshared this"
 msgstr ""
 
-#: include/conversation.php:1098
+#: include/conversation.php:1107
 msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
-#: include/conversation.php:1099 src/Module/Item/Compose.php:159
-#: src/Object/Post.php:972
+#: include/conversation.php:1108 src/Module/Item/Compose.php:159
+#: src/Object/Post.php:973
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
-#: include/conversation.php:1100
+#: include/conversation.php:1109
 msgid "Tag term:"
 msgstr ""
 
-#: include/conversation.php:1101 src/Module/Filer/SaveTag.php:68
+#: include/conversation.php:1110 src/Module/Filer/SaveTag.php:68
 msgid "Save to Folder:"
 msgstr ""
 
-#: include/conversation.php:1102
+#: include/conversation.php:1111
 msgid "Where are you right now?"
 msgstr ""
 
-#: include/conversation.php:1103
+#: include/conversation.php:1112
 msgid "Delete item(s)?"
 msgstr ""
 
-#: include/conversation.php:1113
+#: include/conversation.php:1122
 msgid "New Post"
 msgstr ""
 
-#: include/conversation.php:1116
+#: include/conversation.php:1125
 msgid "Share"
 msgstr ""
 
-#: include/conversation.php:1117 mod/editpost.php:92 mod/photos.php:1373
-#: src/Module/Contact/Poke.php:157 src/Object/Post.php:963
+#: include/conversation.php:1126 mod/editpost.php:92 mod/photos.php:1375
+#: src/Module/Contact/Poke.php:157 src/Object/Post.php:964
 msgid "Loading..."
 msgstr ""
 
-#: include/conversation.php:1118 mod/editpost.php:93 mod/message.php:201
+#: include/conversation.php:1127 mod/editpost.php:93 mod/message.php:201
 #: mod/message.php:365 mod/wallmessage.php:153
 msgid "Upload photo"
 msgstr ""
 
-#: include/conversation.php:1119 mod/editpost.php:94
+#: include/conversation.php:1128 mod/editpost.php:94
 msgid "upload photo"
 msgstr ""
 
-#: include/conversation.php:1120 mod/editpost.php:95
+#: include/conversation.php:1129 mod/editpost.php:95
 msgid "Attach file"
 msgstr ""
 
-#: include/conversation.php:1121 mod/editpost.php:96
+#: include/conversation.php:1130 mod/editpost.php:96
 msgid "attach file"
 msgstr ""
 
-#: include/conversation.php:1122 src/Module/Item/Compose.php:151
-#: src/Object/Post.php:964
+#: include/conversation.php:1131 src/Module/Item/Compose.php:151
+#: src/Object/Post.php:965
 msgid "Bold"
 msgstr ""
 
-#: include/conversation.php:1123 src/Module/Item/Compose.php:152
-#: src/Object/Post.php:965
+#: include/conversation.php:1132 src/Module/Item/Compose.php:152
+#: src/Object/Post.php:966
 msgid "Italic"
 msgstr ""
 
-#: include/conversation.php:1124 src/Module/Item/Compose.php:153
-#: src/Object/Post.php:966
+#: include/conversation.php:1133 src/Module/Item/Compose.php:153
+#: src/Object/Post.php:967
 msgid "Underline"
 msgstr ""
 
-#: include/conversation.php:1125 src/Module/Item/Compose.php:154
-#: src/Object/Post.php:967
+#: include/conversation.php:1134 src/Module/Item/Compose.php:154
+#: src/Object/Post.php:968
 msgid "Quote"
 msgstr ""
 
-#: include/conversation.php:1126 src/Module/Item/Compose.php:155
-#: src/Object/Post.php:968
+#: include/conversation.php:1135 src/Module/Item/Compose.php:155
+#: src/Object/Post.php:969
 msgid "Code"
 msgstr ""
 
-#: include/conversation.php:1127 src/Module/Item/Compose.php:156
-#: src/Object/Post.php:969
+#: include/conversation.php:1136 src/Module/Item/Compose.php:156
+#: src/Object/Post.php:970
 msgid "Image"
 msgstr ""
 
-#: include/conversation.php:1128 src/Module/Item/Compose.php:157
-#: src/Object/Post.php:970
+#: include/conversation.php:1137 src/Module/Item/Compose.php:157
+#: src/Object/Post.php:971
 msgid "Link"
 msgstr ""
 
-#: include/conversation.php:1129 src/Module/Item/Compose.php:158
-#: src/Object/Post.php:971
+#: include/conversation.php:1138 src/Module/Item/Compose.php:158
+#: src/Object/Post.php:972
 msgid "Link or Media"
 msgstr ""
 
-#: include/conversation.php:1130
+#: include/conversation.php:1139
 msgid "Video"
 msgstr ""
 
-#: include/conversation.php:1131 mod/editpost.php:103
+#: include/conversation.php:1140 mod/editpost.php:103
 #: src/Module/Item/Compose.php:161
 msgid "Set your location"
 msgstr ""
 
-#: include/conversation.php:1132 mod/editpost.php:104
+#: include/conversation.php:1141 mod/editpost.php:104
 msgid "set location"
 msgstr ""
 
-#: include/conversation.php:1133 mod/editpost.php:105
+#: include/conversation.php:1142 mod/editpost.php:105
 msgid "Clear browser location"
 msgstr ""
 
-#: include/conversation.php:1134 mod/editpost.php:106
+#: include/conversation.php:1143 mod/editpost.php:106
 msgid "clear location"
 msgstr ""
 
-#: include/conversation.php:1136 mod/editpost.php:120
+#: include/conversation.php:1145 mod/editpost.php:120
 #: src/Module/Item/Compose.php:166
 msgid "Set title"
 msgstr ""
 
-#: include/conversation.php:1138 mod/editpost.php:122
+#: include/conversation.php:1147 mod/editpost.php:122
 #: src/Module/Item/Compose.php:167
 msgid "Categories (comma-separated list)"
 msgstr ""
 
-#: include/conversation.php:1143 src/Module/Item/Compose.php:172
+#: include/conversation.php:1152 src/Module/Item/Compose.php:172
 msgid "Scheduled at"
 msgstr ""
 
-#: include/conversation.php:1147 mod/editpost.php:108
+#: include/conversation.php:1156 mod/editpost.php:108
 msgid "Permission settings"
 msgstr ""
 
-#: include/conversation.php:1148 mod/editpost.php:136 mod/events.php:583
-#: mod/photos.php:965 mod/photos.php:1326
+#: include/conversation.php:1157 mod/editpost.php:136 mod/events.php:583
+#: mod/photos.php:965 mod/photos.php:1328
 msgid "Permissions"
 msgstr ""
 
-#: include/conversation.php:1157 mod/editpost.php:117
+#: include/conversation.php:1166 mod/editpost.php:117
 msgid "Public post"
 msgstr ""
 
-#: include/conversation.php:1161 mod/editpost.php:128 mod/events.php:578
-#: mod/photos.php:1372 mod/photos.php:1428 mod/photos.php:1502
-#: src/Module/Item/Compose.php:160 src/Object/Post.php:973
+#: include/conversation.php:1170 mod/editpost.php:128 mod/events.php:578
+#: mod/photos.php:1374 mod/photos.php:1430 mod/photos.php:1504
+#: src/Module/Item/Compose.php:160 src/Object/Post.php:974
 msgid "Preview"
 msgstr ""
 
-#: include/conversation.php:1164 mod/editpost.php:130 mod/fbrowser.php:105
-#: mod/fbrowser.php:134 mod/follow.php:144 mod/photos.php:1028
-#: mod/photos.php:1134 mod/tagrm.php:37 mod/tagrm.php:129 mod/unfollow.php:97
-#: src/Module/Contact.php:422 src/Module/RemoteFollow.php:116
+#: include/conversation.php:1173 mod/editpost.php:130 mod/fbrowser.php:105
+#: mod/fbrowser.php:134 mod/follow.php:144 mod/photos.php:1029
+#: mod/photos.php:1136 mod/tagrm.php:37 mod/tagrm.php:129 mod/unfollow.php:97
+#: src/Module/RemoteFollow.php:116
 msgid "Cancel"
 msgstr ""
 
-#: include/conversation.php:1171 mod/editpost.php:134
+#: include/conversation.php:1180 mod/editpost.php:134
 #: src/Content/Widget/VCard.php:107 src/Model/Profile.php:459
 msgid "Message"
 msgstr ""
 
-#: include/conversation.php:1172 mod/editpost.php:135
+#: include/conversation.php:1181 mod/editpost.php:135
 #: src/Module/Settings/TwoFactor/Trusted.php:101
 msgid "Browser"
 msgstr ""
 
-#: include/conversation.php:1174 mod/editpost.php:138
+#: include/conversation.php:1183 mod/editpost.php:138
 msgid "Open Compose page"
 msgstr ""
 
@@ -763,16 +762,16 @@ msgstr ""
 #: mod/wallmessage.php:96 mod/wallmessage.php:120 src/Module/Attach.php:55
 #: src/Module/BaseApi.php:79 src/Module/BaseApi.php:88
 #: src/Module/BaseApi.php:97 src/Module/BaseApi.php:106
-#: src/Module/BaseNotifications.php:88 src/Module/Contact.php:346
-#: src/Module/Contact/Advanced.php:44 src/Module/Delegation.php:119
+#: src/Module/BaseNotifications.php:88 src/Module/Contact.php:337
+#: src/Module/Contact/Advanced.php:44 src/Module/Delegation.php:118
 #: src/Module/FollowConfirm.php:16 src/Module/FriendSuggest.php:44
 #: src/Module/Group.php:45 src/Module/Group.php:90 src/Module/Invite.php:41
 #: src/Module/Invite.php:130 src/Module/Notifications/Notification.php:47
 #: src/Module/Notifications/Notification.php:76
 #: src/Module/Profile/Common.php:56 src/Module/Profile/Contacts.php:56
 #: src/Module/Profile/Schedule.php:39 src/Module/Profile/Schedule.php:56
-#: src/Module/Register.php:62 src/Module/Register.php:75
-#: src/Module/Register.php:193 src/Module/Register.php:232
+#: src/Module/Register.php:64 src/Module/Register.php:77
+#: src/Module/Register.php:195 src/Module/Register.php:234
 #: src/Module/Search/Directory.php:38 src/Module/Settings/Delegation.php:42
 #: src/Module/Settings/Delegation.php:70 src/Module/Settings/Display.php:43
 #: src/Module/Settings/Display.php:121
@@ -799,7 +798,7 @@ msgstr ""
 #: src/Model/Profile.php:228 src/Module/HCard.php:52
 #: src/Module/Profile/Common.php:41 src/Module/Profile/Common.php:52
 #: src/Module/Profile/Contacts.php:40 src/Module/Profile/Contacts.php:50
-#: src/Module/Profile/Status.php:58 src/Module/Register.php:254
+#: src/Module/Profile/Status.php:58 src/Module/Register.php:256
 #: src/Module/RemoteFollow.php:49
 msgid "User not found."
 msgstr ""
@@ -967,7 +966,7 @@ msgstr ""
 #: src/Module/Install.php:268 src/Module/Install.php:273
 #: src/Module/Install.php:279 src/Module/Install.php:284
 #: src/Module/Install.php:298 src/Module/Install.php:313
-#: src/Module/Install.php:340 src/Module/Register.php:135
+#: src/Module/Install.php:340 src/Module/Register.php:137
 #: src/Module/Security/TwoFactor/Verify.php:100
 #: src/Module/Settings/TwoFactor/Index.php:133
 #: src/Module/Settings/TwoFactor/Verify.php:141
@@ -993,7 +992,7 @@ msgstr ""
 
 #: mod/events.php:568 src/Content/Widget/VCard.php:98 src/Model/Event.php:86
 #: src/Model/Event.php:113 src/Model/Event.php:483 src/Model/Event.php:969
-#: src/Model/Profile.php:367 src/Module/Contact.php:608
+#: src/Model/Profile.php:367 src/Module/Contact.php:574
 #: src/Module/Directory.php:150 src/Module/Notifications/Introductions.php:166
 #: src/Module/Profile/Profile.php:194
 msgid "Location:"
@@ -1008,18 +1007,18 @@ msgid "Share this event"
 msgstr ""
 
 #: mod/events.php:580 mod/message.php:204 mod/message.php:367
-#: mod/photos.php:947 mod/photos.php:1045 mod/photos.php:1330
-#: mod/photos.php:1371 mod/photos.php:1427 mod/photos.php:1501
-#: src/Module/Admin/Item/Source.php:65 src/Module/Contact.php:566
+#: mod/photos.php:947 mod/photos.php:1046 mod/photos.php:1332
+#: mod/photos.php:1373 mod/photos.php:1429 mod/photos.php:1503
+#: src/Module/Admin/Item/Source.php:65 src/Module/Contact.php:532
 #: src/Module/Contact/Advanced.php:133 src/Module/Contact/Poke.php:158
 #: src/Module/Debug/ActivityPubConversion.php:141
 #: src/Module/Debug/Babel.php:313 src/Module/Debug/Localtime.php:64
 #: src/Module/Debug/Probe.php:56 src/Module/Debug/WebFinger.php:53
-#: src/Module/Delegation.php:153 src/Module/FriendSuggest.php:129
+#: src/Module/Delegation.php:147 src/Module/FriendSuggest.php:129
 #: src/Module/Install.php:245 src/Module/Install.php:287
 #: src/Module/Install.php:324 src/Module/Invite.php:177
 #: src/Module/Item/Compose.php:150 src/Module/Profile/Profile.php:247
-#: src/Module/Settings/Profile/Index.php:220 src/Object/Post.php:962
+#: src/Module/Settings/Profile/Index.php:220 src/Object/Post.php:963
 #: view/theme/duepuntozero/config.php:69 view/theme/frio/config.php:160
 #: view/theme/quattro/config.php:71 view/theme/vier/config.php:119
 msgid "Submit"
@@ -1029,7 +1028,7 @@ msgstr ""
 msgid "Basic"
 msgstr ""
 
-#: mod/events.php:582 src/Module/Admin/Site.php:505 src/Module/Contact.php:916
+#: mod/events.php:582 src/Module/Admin/Site.php:505 src/Module/Contact.php:881
 #: src/Module/Profile/Profile.php:249
 msgid "Advanced"
 msgstr ""
@@ -1081,13 +1080,13 @@ msgid "Your Identity Address:"
 msgstr ""
 
 #: mod/follow.php:141 mod/unfollow.php:100
-#: src/Module/Admin/Blocklist/Contact.php:100 src/Module/Contact.php:604
+#: src/Module/Admin/Blocklist/Contact.php:100 src/Module/Contact.php:570
 #: src/Module/Notifications/Introductions.php:108
 #: src/Module/Notifications/Introductions.php:177
 msgid "Profile URL"
 msgstr ""
 
-#: mod/follow.php:142 src/Module/Contact.php:616
+#: mod/follow.php:142 src/Module/Contact.php:582
 #: src/Module/Notifications/Introductions.php:170
 #: src/Module/Profile/Profile.php:207
 msgid "Tags:"
@@ -1103,7 +1102,7 @@ msgid "Add a personal note:"
 msgstr ""
 
 #: mod/follow.php:163 mod/unfollow.php:109 src/Module/BaseProfile.php:59
-#: src/Module/Contact.php:894
+#: src/Module/Contact.php:859
 msgid "Status Messages and Posts"
 msgstr ""
 
@@ -1462,11 +1461,11 @@ msgstr ""
 msgid "Photo Albums"
 msgstr ""
 
-#: mod/photos.php:112 mod/photos.php:1626
+#: mod/photos.php:112 mod/photos.php:1628
 msgid "Recent Photos"
 msgstr ""
 
-#: mod/photos.php:114 mod/photos.php:1096 mod/photos.php:1628
+#: mod/photos.php:114 mod/photos.php:1097 mod/photos.php:1630
 msgid "Upload New Photos"
 msgstr ""
 
@@ -1549,7 +1548,7 @@ msgstr ""
 msgid "Upload Photos"
 msgstr ""
 
-#: mod/photos.php:961 mod/photos.php:1041
+#: mod/photos.php:961 mod/photos.php:1042
 msgid "New album name: "
 msgstr ""
 
@@ -1565,138 +1564,138 @@ msgstr ""
 msgid "Do you really want to delete this photo album and all its photos?"
 msgstr ""
 
-#: mod/photos.php:1025 mod/photos.php:1046
+#: mod/photos.php:1025 mod/photos.php:1047
 msgid "Delete Album"
 msgstr ""
 
-#: mod/photos.php:1052
+#: mod/photos.php:1053
 msgid "Edit Album"
 msgstr ""
 
-#: mod/photos.php:1053
+#: mod/photos.php:1054
 msgid "Drop Album"
 msgstr ""
 
-#: mod/photos.php:1058
+#: mod/photos.php:1059
 msgid "Show Newest First"
 msgstr ""
 
-#: mod/photos.php:1060
+#: mod/photos.php:1061
 msgid "Show Oldest First"
 msgstr ""
 
-#: mod/photos.php:1081 mod/photos.php:1611
+#: mod/photos.php:1082 mod/photos.php:1613
 msgid "View Photo"
 msgstr ""
 
-#: mod/photos.php:1118
+#: mod/photos.php:1119
 msgid "Permission denied. Access to this item may be restricted."
 msgstr ""
 
-#: mod/photos.php:1120
+#: mod/photos.php:1121
 msgid "Photo not available"
 msgstr ""
 
-#: mod/photos.php:1130
+#: mod/photos.php:1131
 msgid "Do you really want to delete this photo?"
 msgstr ""
 
-#: mod/photos.php:1131 mod/photos.php:1331
+#: mod/photos.php:1132 mod/photos.php:1333
 msgid "Delete Photo"
 msgstr ""
 
-#: mod/photos.php:1222
+#: mod/photos.php:1224
 msgid "View photo"
 msgstr ""
 
-#: mod/photos.php:1224
+#: mod/photos.php:1226
 msgid "Edit photo"
 msgstr ""
 
-#: mod/photos.php:1225
+#: mod/photos.php:1227
 msgid "Delete photo"
 msgstr ""
 
-#: mod/photos.php:1226
+#: mod/photos.php:1228
 msgid "Use as profile photo"
 msgstr ""
 
-#: mod/photos.php:1233
+#: mod/photos.php:1235
 msgid "Private Photo"
 msgstr ""
 
-#: mod/photos.php:1239
+#: mod/photos.php:1241
 msgid "View Full Size"
 msgstr ""
 
-#: mod/photos.php:1299
+#: mod/photos.php:1301
 msgid "Tags: "
 msgstr ""
 
-#: mod/photos.php:1302
+#: mod/photos.php:1304
 msgid "[Select tags to remove]"
 msgstr ""
 
-#: mod/photos.php:1317
+#: mod/photos.php:1319
 msgid "New album name"
 msgstr ""
 
-#: mod/photos.php:1318
+#: mod/photos.php:1320
 msgid "Caption"
 msgstr ""
 
-#: mod/photos.php:1319
+#: mod/photos.php:1321
 msgid "Add a Tag"
 msgstr ""
 
-#: mod/photos.php:1319
+#: mod/photos.php:1321
 msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
 msgstr ""
 
-#: mod/photos.php:1320
+#: mod/photos.php:1322
 msgid "Do not rotate"
 msgstr ""
 
-#: mod/photos.php:1321
+#: mod/photos.php:1323
 msgid "Rotate CW (right)"
 msgstr ""
 
-#: mod/photos.php:1322
+#: mod/photos.php:1324
 msgid "Rotate CCW (left)"
 msgstr ""
 
-#: mod/photos.php:1368 mod/photos.php:1424 mod/photos.php:1498
-#: src/Module/Contact.php:1046 src/Module/Item/Compose.php:148
-#: src/Object/Post.php:959
+#: mod/photos.php:1370 mod/photos.php:1426 mod/photos.php:1500
+#: src/Module/Contact.php:1011 src/Module/Item/Compose.php:148
+#: src/Object/Post.php:960
 msgid "This is you"
 msgstr ""
 
-#: mod/photos.php:1370 mod/photos.php:1426 mod/photos.php:1500
-#: src/Object/Post.php:495 src/Object/Post.php:961
+#: mod/photos.php:1372 mod/photos.php:1428 mod/photos.php:1502
+#: src/Object/Post.php:496 src/Object/Post.php:962
 msgid "Comment"
 msgstr ""
 
-#: mod/photos.php:1521 src/Object/Post.php:348
+#: mod/photos.php:1523 src/Object/Post.php:349
 msgid "Like"
 msgstr ""
 
-#: mod/photos.php:1522 src/Object/Post.php:348
+#: mod/photos.php:1524 src/Object/Post.php:349
 msgid "I like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1523 src/Object/Post.php:349
+#: mod/photos.php:1525 src/Object/Post.php:350
 msgid "Dislike"
 msgstr ""
 
-#: mod/photos.php:1525 src/Object/Post.php:349
+#: mod/photos.php:1527 src/Object/Post.php:350
 msgid "I don't like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1547
+#: mod/photos.php:1549
 msgid "Map"
 msgstr ""
 
-#: mod/photos.php:1617 mod/videos.php:243
+#: mod/photos.php:1619 mod/videos.php:243
 msgid "View Album"
 msgstr ""
 
@@ -2177,7 +2176,7 @@ msgstr ""
 msgid "Password Settings"
 msgstr ""
 
-#: mod/settings.php:719 src/Module/Register.php:149
+#: mod/settings.php:719 src/Module/Register.php:151
 msgid "New Password:"
 msgstr ""
 
@@ -2187,7 +2186,7 @@ msgid ""
 "spaces, accentuated letters and colon (:)."
 msgstr ""
 
-#: mod/settings.php:720 src/Module/Register.php:150
+#: mod/settings.php:720 src/Module/Register.php:152
 msgid "Confirm:"
 msgstr ""
 
@@ -2562,13 +2561,13 @@ msgstr ""
 msgid "User imports on closed servers can only be done by an administrator."
 msgstr ""
 
-#: mod/uimport.php:54 src/Module/Register.php:84
+#: mod/uimport.php:54 src/Module/Register.php:86
 msgid ""
 "This site has exceeded the number of allowed daily account registrations. "
 "Please try again tomorrow."
 msgstr ""
 
-#: mod/uimport.php:61 src/Module/Register.php:160
+#: mod/uimport.php:61 src/Module/Register.php:162
 msgid "Import"
 msgstr ""
 
@@ -2678,7 +2677,7 @@ msgid ""
 "your site allow private mail from unknown senders."
 msgstr ""
 
-#: src/App.php:452
+#: src/App.php:453
 msgid "No system theme config value set."
 msgstr ""
 
@@ -2720,16 +2719,16 @@ msgid "All contacts"
 msgstr ""
 
 #: src/BaseModule.php:212 src/Content/Widget.php:238 src/Core/ACL.php:195
-#: src/Module/Contact.php:816 src/Module/PermissionTooltip.php:77
+#: src/Module/Contact.php:782 src/Module/PermissionTooltip.php:77
 #: src/Module/PermissionTooltip.php:99
 msgid "Followers"
 msgstr ""
 
-#: src/BaseModule.php:217 src/Content/Widget.php:239 src/Module/Contact.php:817
+#: src/BaseModule.php:217 src/Content/Widget.php:239 src/Module/Contact.php:783
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:222 src/Content/Widget.php:240 src/Module/Contact.php:818
+#: src/BaseModule.php:222 src/Content/Widget.php:240 src/Module/Contact.php:784
 msgid "Mutual friends"
 msgstr ""
 
@@ -3086,7 +3085,7 @@ msgid "Sign in"
 msgstr ""
 
 #: src/Content/Nav.php:190 src/Module/BaseProfile.php:56
-#: src/Module/Contact.php:619 src/Module/Contact.php:883
+#: src/Module/Contact.php:585 src/Module/Contact.php:848
 #: src/Module/Settings/TwoFactor/Index.php:112 view/theme/frio/theme.php:226
 msgid "Status"
 msgstr ""
@@ -3097,8 +3096,8 @@ msgid "Your posts and conversations"
 msgstr ""
 
 #: src/Content/Nav.php:191 src/Module/BaseProfile.php:48
-#: src/Module/BaseSettings.php:57 src/Module/Contact.php:621
-#: src/Module/Contact.php:899 src/Module/Profile/Profile.php:241
+#: src/Module/BaseSettings.php:57 src/Module/Contact.php:587
+#: src/Module/Contact.php:864 src/Module/Profile/Profile.php:241
 #: src/Module/Welcome.php:57 view/theme/frio/theme.php:227
 msgid "Profile"
 msgstr ""
@@ -3135,7 +3134,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/Content/Nav.php:216 src/Module/Register.php:155
+#: src/Content/Nav.php:216 src/Module/Register.php:157
 #: src/Module/Security/Login.php:106
 msgid "Register"
 msgstr ""
@@ -3184,8 +3183,8 @@ msgstr ""
 
 #: src/Content/Nav.php:235 src/Content/Nav.php:294
 #: src/Content/Text/HTML.php:902 src/Module/BaseProfile.php:126
-#: src/Module/BaseProfile.php:129 src/Module/Contact.php:819
-#: src/Module/Contact.php:906 view/theme/frio/theme.php:237
+#: src/Module/BaseProfile.php:129 src/Module/Contact.php:785
+#: src/Module/Contact.php:871 view/theme/frio/theme.php:237
 msgid "Contacts"
 msgstr ""
 
@@ -3219,7 +3218,7 @@ msgid "Information about this friendica instance"
 msgstr ""
 
 #: src/Content/Nav.php:266 src/Module/Admin/Tos.php:59
-#: src/Module/BaseAdmin.php:96 src/Module/Register.php:163
+#: src/Module/BaseAdmin.php:96 src/Module/Register.php:165
 #: src/Module/Tos.php:84
 msgid "Terms of Service"
 msgstr ""
@@ -3331,39 +3330,39 @@ msgstr ""
 msgid "last"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:980 src/Content/Text/BBCode.php:1768
-#: src/Content/Text/BBCode.php:1769
+#: src/Content/Text/BBCode.php:985 src/Content/Text/BBCode.php:1773
+#: src/Content/Text/BBCode.php:1774
 msgid "Image/photo"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1153
+#: src/Content/Text/BBCode.php:1158
 #, php-format
 msgid ""
 "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1178 src/Model/Item.php:3139
-#: src/Model/Item.php:3145 src/Model/Item.php:3146
+#: src/Content/Text/BBCode.php:1183 src/Model/Item.php:3152
+#: src/Model/Item.php:3158 src/Model/Item.php:3159
 msgid "Link to source"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1686 src/Content/Text/HTML.php:943
+#: src/Content/Text/BBCode.php:1691 src/Content/Text/HTML.php:943
 msgid "Click to open/close"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1717
+#: src/Content/Text/BBCode.php:1722
 msgid "$1 wrote:"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1773 src/Content/Text/BBCode.php:1774
+#: src/Content/Text/BBCode.php:1778 src/Content/Text/BBCode.php:1779
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1990
+#: src/Content/Text/BBCode.php:1995
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2005
+#: src/Content/Text/BBCode.php:2010
 msgid "Invalid link protocol"
 msgstr ""
 
@@ -3415,7 +3414,7 @@ msgstr ""
 msgid "Examples: Robert Morgenstein, Fishing"
 msgstr ""
 
-#: src/Content/Widget.php:78 src/Module/Contact.php:840
+#: src/Content/Widget.php:78 src/Module/Contact.php:806
 #: src/Module/Directory.php:99 view/theme/vier/theme.php:174
 msgid "Find"
 msgstr ""
@@ -3442,7 +3441,7 @@ msgid "Local Directory"
 msgstr ""
 
 #: src/Content/Widget.php:214 src/Model/Group.php:535
-#: src/Module/Contact.php:803 src/Module/Welcome.php:76
+#: src/Module/Contact.php:769 src/Module/Welcome.php:76
 msgid "Groups"
 msgstr ""
 
@@ -3454,7 +3453,7 @@ msgstr ""
 msgid "Relationships"
 msgstr ""
 
-#: src/Content/Widget.php:247 src/Module/Contact.php:755
+#: src/Content/Widget.php:247 src/Module/Contact.php:721
 #: src/Module/Group.php:292
 msgid "All Contacts"
 msgstr ""
@@ -3498,7 +3497,7 @@ msgstr ""
 msgid "Organisations"
 msgstr ""
 
-#: src/Content/Widget.php:529 src/Model/Contact.php:1474
+#: src/Content/Widget.php:529 src/Model/Contact.php:1464
 msgid "News"
 msgstr ""
 
@@ -3518,18 +3517,18 @@ msgstr ""
 msgid "Export calendar as csv"
 msgstr ""
 
-#: src/Content/Widget/ContactBlock.php:73
+#: src/Content/Widget/ContactBlock.php:79
 msgid "No contacts"
 msgstr ""
 
-#: src/Content/Widget/ContactBlock.php:105
+#: src/Content/Widget/ContactBlock.php:108
 #, php-format
 msgid "%d Contact"
 msgid_plural "%d Contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/Widget/ContactBlock.php:124
+#: src/Content/Widget/ContactBlock.php:125
 msgid "View Contacts"
 msgstr ""
 
@@ -3553,12 +3552,12 @@ msgid "More Trending Tags"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:96 src/Model/Profile.php:372
-#: src/Module/Contact.php:610 src/Module/Profile/Profile.php:176
+#: src/Module/Contact.php:576 src/Module/Profile/Profile.php:176
 msgid "XMPP:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:97 src/Model/Profile.php:373
-#: src/Module/Contact.php:612 src/Module/Profile/Profile.php:180
+#: src/Module/Contact.php:578 src/Module/Profile/Profile.php:180
 msgid "Matrix:"
 msgstr ""
 
@@ -4362,85 +4361,81 @@ msgstr ""
 msgid "Legacy module file not found: %s"
 msgstr ""
 
-#: src/Model/Contact.php:1046 src/Model/Contact.php:1059
+#: src/Model/Contact.php:1037 src/Model/Contact.php:1049
 msgid "UnFollow"
 msgstr ""
 
-#: src/Model/Contact.php:1055
-msgid "Drop Contact"
-msgstr ""
-
-#: src/Model/Contact.php:1065 src/Module/Admin/Users/Pending.php:107
+#: src/Model/Contact.php:1055 src/Module/Admin/Users/Pending.php:107
 #: src/Module/Notifications/Introductions.php:111
 #: src/Module/Notifications/Introductions.php:183
 msgid "Approve"
 msgstr ""
 
-#: src/Model/Contact.php:1470
+#: src/Model/Contact.php:1460
 msgid "Organisation"
 msgstr ""
 
-#: src/Model/Contact.php:1478
+#: src/Model/Contact.php:1468
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:2334
+#: src/Model/Contact.php:2324
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:2339 src/Module/Friendica.php:81
+#: src/Model/Contact.php:2329 src/Module/Friendica.php:81
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:2344
+#: src/Model/Contact.php:2334
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:2353
+#: src/Model/Contact.php:2343
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:2390
+#: src/Model/Contact.php:2380
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:2392
+#: src/Model/Contact.php:2382
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:2395
+#: src/Model/Contact.php:2385
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:2398
+#: src/Model/Contact.php:2388
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:2401
+#: src/Model/Contact.php:2391
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:2402
+#: src/Model/Contact.php:2392
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:2408
+#: src/Model/Contact.php:2398
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:2413
+#: src/Model/Contact.php:2403
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:2472
+#: src/Model/Contact.php:2462
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -4557,33 +4552,33 @@ msgstr ""
 msgid "Edit groups"
 msgstr ""
 
-#: src/Model/Item.php:1663
+#: src/Model/Item.php:1676
 #, php-format
 msgid "Detected languages in this post:\\n%s"
 msgstr ""
 
-#: src/Model/Item.php:2613
+#: src/Model/Item.php:2626
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2615
+#: src/Model/Item.php:2628
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2618
+#: src/Model/Item.php:2631
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:2755
+#: src/Model/Item.php:2768
 #, php-format
 msgid "Content warning: %s"
 msgstr ""
 
-#: src/Model/Item.php:3104
+#: src/Model/Item.php:3117
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3133 src/Model/Item.php:3134
+#: src/Model/Item.php:3146 src/Model/Item.php:3147
 msgid "View on separate page"
 msgstr ""
 
@@ -4710,7 +4705,7 @@ msgstr ""
 msgid "Homepage:"
 msgstr ""
 
-#: src/Model/Profile.php:371 src/Module/Contact.php:614
+#: src/Model/Profile.php:371 src/Module/Contact.php:580
 #: src/Module/Notifications/Introductions.php:168
 msgid "About:"
 msgstr ""
@@ -4770,7 +4765,7 @@ msgstr ""
 msgid "Enter a valid existing folder"
 msgstr ""
 
-#: src/Model/User.php:208 src/Model/User.php:1004
+#: src/Model/User.php:208 src/Model/User.php:1055
 msgid "SERIOUS ERROR: Generation of security keys failed."
 msgstr ""
 
@@ -4801,107 +4796,107 @@ msgid ""
 "The password can't contain accentuated letters, white spaces or colons (:)"
 msgstr ""
 
-#: src/Model/User.php:884
+#: src/Model/User.php:935
 msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
-#: src/Model/User.php:891
+#: src/Model/User.php:942
 msgid "An invitation is required."
 msgstr ""
 
-#: src/Model/User.php:895
+#: src/Model/User.php:946
 msgid "Invitation could not be verified."
 msgstr ""
 
-#: src/Model/User.php:903
+#: src/Model/User.php:954
 msgid "Invalid OpenID url"
 msgstr ""
 
-#: src/Model/User.php:916 src/Security/Authentication.php:223
+#: src/Model/User.php:967 src/Security/Authentication.php:223
 msgid ""
 "We encountered a problem while logging in with the OpenID you provided. "
 "Please check the correct spelling of the ID."
 msgstr ""
 
-#: src/Model/User.php:916 src/Security/Authentication.php:223
+#: src/Model/User.php:967 src/Security/Authentication.php:223
 msgid "The error message was:"
 msgstr ""
 
-#: src/Model/User.php:922
+#: src/Model/User.php:973
 msgid "Please enter the required information."
 msgstr ""
 
-#: src/Model/User.php:936
+#: src/Model/User.php:987
 #, php-format
 msgid ""
 "system.username_min_length (%s) and system.username_max_length (%s) are "
 "excluding each other, swapping values."
 msgstr ""
 
-#: src/Model/User.php:943
+#: src/Model/User.php:994
 #, php-format
 msgid "Username should be at least %s character."
 msgid_plural "Username should be at least %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:947
+#: src/Model/User.php:998
 #, php-format
 msgid "Username should be at most %s character."
 msgid_plural "Username should be at most %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:955
+#: src/Model/User.php:1006
 msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Model/User.php:960
+#: src/Model/User.php:1011
 msgid "Your email domain is not among those allowed on this site."
 msgstr ""
 
-#: src/Model/User.php:964
+#: src/Model/User.php:1015
 msgid "Not a valid email address."
 msgstr ""
 
-#: src/Model/User.php:967
+#: src/Model/User.php:1018
 msgid "The nickname was blocked from registration by the nodes admin."
 msgstr ""
 
-#: src/Model/User.php:971 src/Model/User.php:979
+#: src/Model/User.php:1022 src/Model/User.php:1030
 msgid "Cannot use that email."
 msgstr ""
 
-#: src/Model/User.php:986
+#: src/Model/User.php:1037
 msgid "Your nickname can only contain a-z, 0-9 and _."
 msgstr ""
 
-#: src/Model/User.php:994 src/Model/User.php:1051
+#: src/Model/User.php:1045 src/Model/User.php:1102
 msgid "Nickname is already registered. Please choose another."
 msgstr ""
 
-#: src/Model/User.php:1038 src/Model/User.php:1042
+#: src/Model/User.php:1089 src/Model/User.php:1093
 msgid "An error occurred during registration. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1065
+#: src/Model/User.php:1116
 msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1072
+#: src/Model/User.php:1123
 msgid "An error occurred creating your self contact. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1077
+#: src/Model/User.php:1128
 msgid "Friends"
 msgstr ""
 
-#: src/Model/User.php:1081
+#: src/Model/User.php:1132
 msgid ""
 "An error occurred creating your default contact group. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1310
+#: src/Model/User.php:1361
 #, php-format
 msgid ""
 "\n"
@@ -4909,7 +4904,7 @@ msgid ""
 "\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: src/Model/User.php:1313
+#: src/Model/User.php:1364
 #, php-format
 msgid ""
 "\n"
@@ -4946,12 +4941,12 @@ msgid ""
 "\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: src/Model/User.php:1346 src/Model/User.php:1453
+#: src/Model/User.php:1397 src/Model/User.php:1504
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
-#: src/Model/User.php:1366
+#: src/Model/User.php:1417
 #, php-format
 msgid ""
 "\n"
@@ -4967,12 +4962,12 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:1385
+#: src/Model/User.php:1436
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: src/Model/User.php:1409
+#: src/Model/User.php:1460
 #, php-format
 msgid ""
 "\n"
@@ -4981,7 +4976,7 @@ msgid ""
 "\t\t\t"
 msgstr ""
 
-#: src/Model/User.php:1417
+#: src/Model/User.php:1468
 #, php-format
 msgid ""
 "\n"
@@ -5050,7 +5045,7 @@ msgstr ""
 #: src/Module/Admin/Item/Delete.php:65 src/Module/Admin/Logs/Settings.php:80
 #: src/Module/Admin/Logs/View.php:84 src/Module/Admin/Queue.php:72
 #: src/Module/Admin/Site.php:497 src/Module/Admin/Storage.php:131
-#: src/Module/Admin/Summary.php:232 src/Module/Admin/Themes/Details.php:90
+#: src/Module/Admin/Summary.php:233 src/Module/Admin/Themes/Details.php:90
 #: src/Module/Admin/Themes/Index.php:111 src/Module/Admin/Tos.php:58
 #: src/Module/Admin/Users/Active.php:136 src/Module/Admin/Users/Blocked.php:137
 #: src/Module/Admin/Users/Create.php:61 src/Module/Admin/Users/Deleted.php:85
@@ -5111,8 +5106,8 @@ msgstr ""
 msgid "List of active accounts"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:66 src/Module/Contact.php:763
-#: src/Module/Contact.php:823
+#: src/Module/Admin/BaseUsers.php:66 src/Module/Contact.php:729
+#: src/Module/Contact.php:789
 msgid "Pending"
 msgstr ""
 
@@ -5120,8 +5115,8 @@ msgstr ""
 msgid "List of pending registrations"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:74 src/Module/Contact.php:771
-#: src/Module/Contact.php:824
+#: src/Module/Admin/BaseUsers.php:74 src/Module/Contact.php:737
+#: src/Module/Contact.php:790
 msgid "Blocked"
 msgstr ""
 
@@ -5178,8 +5173,8 @@ msgstr ""
 
 #: src/Module/Admin/Blocklist/Contact.php:85
 #: src/Module/Admin/Users/Blocked.php:142 src/Module/Admin/Users/Index.php:156
-#: src/Module/Contact.php:587 src/Module/Contact.php:847
-#: src/Module/Contact.php:1115
+#: src/Module/Contact.php:553 src/Module/Contact.php:813
+#: src/Module/Contact.php:1082
 msgid "Unblock"
 msgstr ""
 
@@ -5696,7 +5691,7 @@ msgstr ""
 msgid "Republish users to directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:502 src/Module/Register.php:139
+#: src/Module/Admin/Site.php:502 src/Module/Register.php:141
 msgid "Registration"
 msgstr ""
 
@@ -6464,7 +6459,7 @@ msgid ""
 "received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:609 src/Module/Contact.php:516
+#: src/Module/Admin/Site.php:609 src/Module/Contact.php:482
 #: src/Module/Settings/TwoFactor/Index.php:118
 msgid "Disabled"
 msgstr ""
@@ -6553,12 +6548,12 @@ msgstr ""
 msgid "Database (legacy)"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:53
+#: src/Module/Admin/Summary.php:54
 #, php-format
 msgid "Template engine (%s) error: %s"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:57
+#: src/Module/Admin/Summary.php:58
 #, php-format
 msgid ""
 "Your DB still runs with MyISAM tables. You should change the engine type to "
@@ -6569,7 +6564,7 @@ msgid ""
 "automatic conversion.<br />"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:62
+#: src/Module/Admin/Summary.php:63
 #, php-format
 msgid ""
 "Your DB still runs with InnoDB tables in the Antelope file format. You "
@@ -6580,7 +6575,7 @@ msgid ""
 "installation for an automatic conversion.<br />"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:72
+#: src/Module/Admin/Summary.php:73
 #, php-format
 msgid ""
 "Your table_definition_cache is too low (%d). This can lead to the database "
@@ -6588,39 +6583,39 @@ msgid ""
 "to %d. See <a href=\"%s\">here</a> for more information.<br />"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:82
+#: src/Module/Admin/Summary.php:83
 #, php-format
 msgid ""
 "There is a new version of Friendica available for download. Your current "
 "version is %1$s, upstream version is %2$s"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:91
+#: src/Module/Admin/Summary.php:92
 msgid ""
 "The database update failed. Please run \"php bin/console.php dbstructure "
 "update\" from the command line and have a look at the errors that might "
 "appear."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:95
+#: src/Module/Admin/Summary.php:96
 msgid ""
 "The last update failed. Please run \"php bin/console.php dbstructure update"
 "\" from the command line and have a look at the errors that might appear. "
 "(Some of the errors are possibly inside the logfile.)"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:100
+#: src/Module/Admin/Summary.php:101
 msgid "The worker was never executed. Please check your database structure!"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:102
+#: src/Module/Admin/Summary.php:103
 #, php-format
 msgid ""
 "The last worker execution was on %s UTC. This is older than one hour. Please "
 "check your crontab settings."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:107
+#: src/Module/Admin/Summary.php:108
 #, php-format
 msgid ""
 "Friendica's configuration now is stored in config/local.config.php, please "
@@ -6629,7 +6624,7 @@ msgid ""
 "with the transition."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:111
+#: src/Module/Admin/Summary.php:112
 #, php-format
 msgid ""
 "Friendica's configuration now is stored in config/local.config.php, please "
@@ -6638,7 +6633,7 @@ msgid ""
 "with the transition."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:117
+#: src/Module/Admin/Summary.php:118
 #, php-format
 msgid ""
 "<a href=\"%s\">%s</a> is not reachable on your system. This is a severe "
@@ -6646,86 +6641,86 @@ msgid ""
 "href=\"%s\">the installation page</a> for help."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:135
+#: src/Module/Admin/Summary.php:136
 #, php-format
 msgid "The logfile '%s' is not usable. No logging possible (error: '%s')"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:149
+#: src/Module/Admin/Summary.php:150
 #, php-format
 msgid "The debug logfile '%s' is not usable. No logging possible (error: '%s')"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:165
+#: src/Module/Admin/Summary.php:166
 #, php-format
 msgid ""
 "Friendica's system.basepath was updated from '%s' to '%s'. Please remove the "
 "system.basepath from your db to avoid differences."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:173
+#: src/Module/Admin/Summary.php:174
 #, php-format
 msgid ""
 "Friendica's current system.basepath '%s' is wrong and the config file '%s' "
 "isn't used."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:181
+#: src/Module/Admin/Summary.php:182
 #, php-format
 msgid ""
 "Friendica's current system.basepath '%s' is not equal to the config file "
 "'%s'. Please fix your configuration."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:188
+#: src/Module/Admin/Summary.php:189
 msgid "Normal Account"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:189
+#: src/Module/Admin/Summary.php:190
 msgid "Automatic Follower Account"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:190
+#: src/Module/Admin/Summary.php:191
 msgid "Public Forum Account"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:191
+#: src/Module/Admin/Summary.php:192
 msgid "Automatic Friend Account"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:192
+#: src/Module/Admin/Summary.php:193
 msgid "Blog Account"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:193
+#: src/Module/Admin/Summary.php:194
 msgid "Private Forum Account"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:213
+#: src/Module/Admin/Summary.php:214
 msgid "Message queues"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:219
+#: src/Module/Admin/Summary.php:220
 msgid "Server Settings"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:233 src/Repository/ProfileField.php:285
+#: src/Module/Admin/Summary.php:234 src/Repository/ProfileField.php:285
 msgid "Summary"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:235
+#: src/Module/Admin/Summary.php:236
 msgid "Registered users"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:237
+#: src/Module/Admin/Summary.php:238
 msgid "Pending registrations"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:238
+#: src/Module/Admin/Summary.php:239
 msgid "Version"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:242
+#: src/Module/Admin/Summary.php:243
 msgid "Active addons"
 msgstr ""
 
@@ -7035,8 +7030,8 @@ msgstr ""
 msgid "Posts from %s can't be unshared"
 msgstr ""
 
-#: src/Module/Api/Twitter/ContactEndpoint.php:63 src/Module/Contact.php:361
-#: src/Module/Contact.php:366
+#: src/Module/Api/Twitter/ContactEndpoint.php:63 src/Module/Contact.php:352
+#: src/Module/Contact.php:367
 msgid "Contact not found"
 msgstr ""
 
@@ -7157,7 +7152,7 @@ msgstr ""
 msgid "Too Many Requests"
 msgstr ""
 
-#: src/Module/BaseProfile.php:51 src/Module/Contact.php:902
+#: src/Module/BaseProfile.php:51 src/Module/Contact.php:867
 msgid "Profile Details"
 msgstr ""
 
@@ -7224,366 +7219,345 @@ msgstr ""
 msgid "The post was created"
 msgstr ""
 
-#: src/Module/Contact.php:93
+#: src/Module/Contact.php:92
 #, php-format
 msgid "%d contact edited."
 msgid_plural "%d contacts edited."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact.php:118
+#: src/Module/Contact.php:117
 msgid "Could not access contact record."
 msgstr ""
 
-#: src/Module/Contact.php:154
+#: src/Module/Contact.php:153
 msgid "Failed to update contact record."
 msgstr ""
 
-#: src/Module/Contact.php:383
+#: src/Module/Contact.php:384
 msgid "You can't block yourself"
 msgstr ""
 
-#: src/Module/Contact.php:389
+#: src/Module/Contact.php:390
 msgid "Contact has been blocked"
 msgstr ""
 
-#: src/Module/Contact.php:389
+#: src/Module/Contact.php:390
 msgid "Contact has been unblocked"
 msgstr ""
 
-#: src/Module/Contact.php:397
+#: src/Module/Contact.php:398
 msgid "You can't ignore yourself"
 msgstr ""
 
-#: src/Module/Contact.php:403
+#: src/Module/Contact.php:404
 msgid "Contact has been ignored"
 msgstr ""
 
-#: src/Module/Contact.php:403
+#: src/Module/Contact.php:404
 msgid "Contact has been unignored"
 msgstr ""
 
-#: src/Module/Contact.php:415
-msgid "Drop contact"
-msgstr ""
-
-#: src/Module/Contact.php:418 src/Module/Contact.php:843
-msgid "Do you really want to delete this contact?"
-msgstr ""
-
-#: src/Module/Contact.php:419 src/Module/Notifications/Introductions.php:123
-#: src/Module/OAuth/Acknowledge.php:47 src/Module/Register.php:115
-msgid "Yes"
-msgstr ""
-
-#: src/Module/Contact.php:431
-msgid "Contact has been removed."
-msgstr ""
-
-#: src/Module/Contact.php:458
+#: src/Module/Contact.php:424
 #, php-format
 msgid "You are mutual friends with %s"
 msgstr ""
 
-#: src/Module/Contact.php:462
+#: src/Module/Contact.php:428
 #, php-format
 msgid "You are sharing with %s"
 msgstr ""
 
-#: src/Module/Contact.php:466
+#: src/Module/Contact.php:432
 #, php-format
 msgid "%s is sharing with you"
 msgstr ""
 
-#: src/Module/Contact.php:490
+#: src/Module/Contact.php:456
 msgid "Private communications are not available for this contact."
 msgstr ""
 
-#: src/Module/Contact.php:492
+#: src/Module/Contact.php:458
 msgid "Never"
 msgstr ""
 
-#: src/Module/Contact.php:495
+#: src/Module/Contact.php:461
 msgid "(Update was not successful)"
 msgstr ""
 
-#: src/Module/Contact.php:495
+#: src/Module/Contact.php:461
 msgid "(Update was successful)"
 msgstr ""
 
-#: src/Module/Contact.php:497 src/Module/Contact.php:1086
+#: src/Module/Contact.php:463 src/Module/Contact.php:1053
 msgid "Suggest friends"
 msgstr ""
 
-#: src/Module/Contact.php:501
+#: src/Module/Contact.php:467
 #, php-format
 msgid "Network type: %s"
 msgstr ""
 
-#: src/Module/Contact.php:506
+#: src/Module/Contact.php:472
 msgid "Communications lost with this contact!"
 msgstr ""
 
-#: src/Module/Contact.php:512
+#: src/Module/Contact.php:478
 msgid "Fetch further information for feeds"
 msgstr ""
 
-#: src/Module/Contact.php:514
+#: src/Module/Contact.php:480
 msgid ""
 "Fetch information like preview pictures, title and teaser from the feed "
 "item. You can activate this if the feed doesn't contain much text. Keywords "
 "are taken from the meta header in the feed item and are posted as hash tags."
 msgstr ""
 
-#: src/Module/Contact.php:517
+#: src/Module/Contact.php:483
 msgid "Fetch information"
 msgstr ""
 
-#: src/Module/Contact.php:518
+#: src/Module/Contact.php:484
 msgid "Fetch keywords"
 msgstr ""
 
-#: src/Module/Contact.php:519
+#: src/Module/Contact.php:485
 msgid "Fetch information and keywords"
 msgstr ""
 
-#: src/Module/Contact.php:531 src/Module/Contact.php:535
-#: src/Module/Contact.php:538 src/Module/Contact.php:542
+#: src/Module/Contact.php:497 src/Module/Contact.php:501
+#: src/Module/Contact.php:504 src/Module/Contact.php:508
 msgid "No mirroring"
 msgstr ""
 
-#: src/Module/Contact.php:532
+#: src/Module/Contact.php:498
 msgid "Mirror as forwarded posting"
 msgstr ""
 
-#: src/Module/Contact.php:533 src/Module/Contact.php:539
-#: src/Module/Contact.php:543
+#: src/Module/Contact.php:499 src/Module/Contact.php:505
+#: src/Module/Contact.php:509
 msgid "Mirror as my own posting"
 msgstr ""
 
-#: src/Module/Contact.php:536 src/Module/Contact.php:540
+#: src/Module/Contact.php:502 src/Module/Contact.php:506
 msgid "Native reshare"
 msgstr ""
 
-#: src/Module/Contact.php:555
+#: src/Module/Contact.php:521
 msgid "Contact Information / Notes"
 msgstr ""
 
-#: src/Module/Contact.php:556
+#: src/Module/Contact.php:522
 msgid "Contact Settings"
 msgstr ""
 
-#: src/Module/Contact.php:564
+#: src/Module/Contact.php:530
 msgid "Contact"
 msgstr ""
 
-#: src/Module/Contact.php:568
+#: src/Module/Contact.php:534
 msgid "Their personal note"
 msgstr ""
 
-#: src/Module/Contact.php:570
+#: src/Module/Contact.php:536
 msgid "Edit contact notes"
 msgstr ""
 
-#: src/Module/Contact.php:573 src/Module/Contact.php:1054
+#: src/Module/Contact.php:539 src/Module/Contact.php:1019
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr ""
 
-#: src/Module/Contact.php:574
+#: src/Module/Contact.php:540
 msgid "Block/Unblock contact"
 msgstr ""
 
-#: src/Module/Contact.php:575
+#: src/Module/Contact.php:541
 msgid "Ignore contact"
 msgstr ""
 
-#: src/Module/Contact.php:576
+#: src/Module/Contact.php:542
 msgid "View conversations"
 msgstr ""
 
-#: src/Module/Contact.php:581
+#: src/Module/Contact.php:547
 msgid "Last update:"
 msgstr ""
 
-#: src/Module/Contact.php:583
+#: src/Module/Contact.php:549
 msgid "Update public posts"
 msgstr ""
 
-#: src/Module/Contact.php:585 src/Module/Contact.php:1096
+#: src/Module/Contact.php:551 src/Module/Contact.php:1063
 msgid "Update now"
 msgstr ""
 
-#: src/Module/Contact.php:588 src/Module/Contact.php:848
-#: src/Module/Contact.php:1123
+#: src/Module/Contact.php:554 src/Module/Contact.php:814
+#: src/Module/Contact.php:1090
 msgid "Unignore"
 msgstr ""
 
-#: src/Module/Contact.php:592
+#: src/Module/Contact.php:558
 msgid "Currently blocked"
 msgstr ""
 
-#: src/Module/Contact.php:593
+#: src/Module/Contact.php:559
 msgid "Currently ignored"
 msgstr ""
 
-#: src/Module/Contact.php:594
+#: src/Module/Contact.php:560
 msgid "Currently archived"
 msgstr ""
 
-#: src/Module/Contact.php:595
+#: src/Module/Contact.php:561
 msgid "Awaiting connection acknowledge"
 msgstr ""
 
-#: src/Module/Contact.php:596 src/Module/Notifications/Introductions.php:171
+#: src/Module/Contact.php:562 src/Module/Notifications/Introductions.php:171
 msgid "Hide this contact from others"
 msgstr ""
 
-#: src/Module/Contact.php:596
+#: src/Module/Contact.php:562
 msgid ""
 "Replies/likes to your public posts <strong>may</strong> still be visible"
 msgstr ""
 
-#: src/Module/Contact.php:597
+#: src/Module/Contact.php:563
 msgid "Notification for new posts"
 msgstr ""
 
-#: src/Module/Contact.php:597
+#: src/Module/Contact.php:563
 msgid "Send a notification of every new post of this contact"
 msgstr ""
 
-#: src/Module/Contact.php:599
+#: src/Module/Contact.php:565
 msgid "Keyword Deny List"
 msgstr ""
 
-#: src/Module/Contact.php:599
+#: src/Module/Contact.php:565
 msgid ""
 "Comma separated list of keywords that should not be converted to hashtags, "
 "when \"Fetch information and keywords\" is selected"
 msgstr ""
 
-#: src/Module/Contact.php:617 src/Module/Settings/TwoFactor/Index.php:132
+#: src/Module/Contact.php:583 src/Module/Settings/TwoFactor/Index.php:132
 msgid "Actions"
 msgstr ""
 
-#: src/Module/Contact.php:624
+#: src/Module/Contact.php:590
 msgid "Mirror postings from this contact"
 msgstr ""
 
-#: src/Module/Contact.php:626
+#: src/Module/Contact.php:592
 msgid ""
 "Mark this contact as remote_self, this will cause friendica to repost new "
 "entries from this contact."
 msgstr ""
 
-#: src/Module/Contact.php:758
+#: src/Module/Contact.php:724
 msgid "Show all contacts"
 msgstr ""
 
-#: src/Module/Contact.php:766
+#: src/Module/Contact.php:732
 msgid "Only show pending contacts"
 msgstr ""
 
-#: src/Module/Contact.php:774
+#: src/Module/Contact.php:740
 msgid "Only show blocked contacts"
 msgstr ""
 
-#: src/Module/Contact.php:779 src/Module/Contact.php:826
-#: src/Object/Post.php:308
+#: src/Module/Contact.php:745 src/Module/Contact.php:792
+#: src/Object/Post.php:309
 msgid "Ignored"
 msgstr ""
 
-#: src/Module/Contact.php:782
+#: src/Module/Contact.php:748
 msgid "Only show ignored contacts"
 msgstr ""
 
-#: src/Module/Contact.php:787 src/Module/Contact.php:827
+#: src/Module/Contact.php:753 src/Module/Contact.php:793
 msgid "Archived"
 msgstr ""
 
-#: src/Module/Contact.php:790
+#: src/Module/Contact.php:756
 msgid "Only show archived contacts"
 msgstr ""
 
-#: src/Module/Contact.php:795 src/Module/Contact.php:825
+#: src/Module/Contact.php:761 src/Module/Contact.php:791
 msgid "Hidden"
 msgstr ""
 
-#: src/Module/Contact.php:798
+#: src/Module/Contact.php:764
 msgid "Only show hidden contacts"
 msgstr ""
 
-#: src/Module/Contact.php:806
+#: src/Module/Contact.php:772
 msgid "Organize your contact groups"
 msgstr ""
 
-#: src/Module/Contact.php:838
+#: src/Module/Contact.php:804
 msgid "Search your contacts"
 msgstr ""
 
-#: src/Module/Contact.php:839 src/Module/Search/Index.php:194
+#: src/Module/Contact.php:805 src/Module/Search/Index.php:194
 #, php-format
 msgid "Results for: %s"
 msgstr ""
 
-#: src/Module/Contact.php:846
+#: src/Module/Contact.php:812
 msgid "Update"
 msgstr ""
 
-#: src/Module/Contact.php:851
+#: src/Module/Contact.php:816
 msgid "Batch Actions"
 msgstr ""
 
-#: src/Module/Contact.php:886
+#: src/Module/Contact.php:851
 msgid "Conversations started by this contact"
 msgstr ""
 
-#: src/Module/Contact.php:891
+#: src/Module/Contact.php:856
 msgid "Posts and Comments"
 msgstr ""
 
-#: src/Module/Contact.php:909
+#: src/Module/Contact.php:874
 msgid "View all known contacts"
 msgstr ""
 
-#: src/Module/Contact.php:919
+#: src/Module/Contact.php:884
 msgid "Advanced Contact Settings"
 msgstr ""
 
-#: src/Module/Contact.php:1013
+#: src/Module/Contact.php:978
 msgid "Mutual Friendship"
 msgstr ""
 
-#: src/Module/Contact.php:1017
+#: src/Module/Contact.php:982
 msgid "is a fan of yours"
 msgstr ""
 
-#: src/Module/Contact.php:1021
+#: src/Module/Contact.php:986
 msgid "you are a fan of"
 msgstr ""
 
-#: src/Module/Contact.php:1039
+#: src/Module/Contact.php:1004
 msgid "Pending outgoing contact request"
 msgstr ""
 
-#: src/Module/Contact.php:1041
+#: src/Module/Contact.php:1006
 msgid "Pending incoming contact request"
 msgstr ""
 
-#: src/Module/Contact.php:1106
+#: src/Module/Contact.php:1073
 msgid "Refetch contact data"
 msgstr ""
 
-#: src/Module/Contact.php:1117
+#: src/Module/Contact.php:1084
 msgid "Toggle Blocked status"
 msgstr ""
 
-#: src/Module/Contact.php:1125
+#: src/Module/Contact.php:1092
 msgid "Toggle Ignored status"
-msgstr ""
-
-#: src/Module/Contact.php:1134
-msgid "Delete contact"
 msgstr ""
 
 #: src/Module/Contact/Advanced.php:93
@@ -7806,7 +7780,7 @@ msgstr ""
 msgid "Posts that mention or involve you"
 msgstr ""
 
-#: src/Module/Conversation/Network.php:258 src/Object/Post.php:320
+#: src/Module/Conversation/Network.php:258 src/Object/Post.php:321
 msgid "Starred"
 msgstr ""
 
@@ -8083,21 +8057,21 @@ msgstr ""
 msgid "Lookup address:"
 msgstr ""
 
-#: src/Module/Delegation.php:148
+#: src/Module/Delegation.php:142
 msgid "Switch between your accounts"
 msgstr ""
 
-#: src/Module/Delegation.php:149
+#: src/Module/Delegation.php:143
 msgid "Manage your accounts"
 msgstr ""
 
-#: src/Module/Delegation.php:150
+#: src/Module/Delegation.php:144
 msgid ""
 "Toggle between different identities or community/group pages which share "
 "your account details or which you have been granted \"manage\" permissions"
 msgstr ""
 
-#: src/Module/Delegation.php:151
+#: src/Module/Delegation.php:145
 msgid "Select an identity to manage: "
 msgstr ""
 
@@ -8629,7 +8603,12 @@ msgid "Claims to be known to you: "
 msgstr ""
 
 #: src/Module/Notifications/Introductions.php:123
-#: src/Module/OAuth/Acknowledge.php:48 src/Module/Register.php:116
+#: src/Module/OAuth/Acknowledge.php:47 src/Module/Register.php:117
+msgid "Yes"
+msgstr ""
+
+#: src/Module/Notifications/Introductions.php:123
+#: src/Module/OAuth/Acknowledge.php:48 src/Module/Register.php:118
 msgid "No"
 msgstr ""
 
@@ -8845,137 +8824,137 @@ msgstr ""
 msgid "Remove post"
 msgstr ""
 
-#: src/Module/Register.php:69
+#: src/Module/Register.php:71
 msgid "Only parent users can create additional accounts."
 msgstr ""
 
-#: src/Module/Register.php:101
+#: src/Module/Register.php:103
 msgid ""
 "You may (optionally) fill in this form via OpenID by supplying your OpenID "
 "and clicking \"Register\"."
 msgstr ""
 
-#: src/Module/Register.php:102
+#: src/Module/Register.php:104
 msgid ""
 "If you are not familiar with OpenID, please leave that field blank and fill "
 "in the rest of the items."
 msgstr ""
 
-#: src/Module/Register.php:103
+#: src/Module/Register.php:105
 msgid "Your OpenID (optional): "
 msgstr ""
 
-#: src/Module/Register.php:112
+#: src/Module/Register.php:114
 msgid "Include your profile in member directory?"
 msgstr ""
 
-#: src/Module/Register.php:135
+#: src/Module/Register.php:137
 msgid "Note for the admin"
 msgstr ""
 
-#: src/Module/Register.php:135
+#: src/Module/Register.php:137
 msgid "Leave a message for the admin, why you want to join this node"
 msgstr ""
 
-#: src/Module/Register.php:136
+#: src/Module/Register.php:138
 msgid "Membership on this site is by invitation only."
 msgstr ""
 
-#: src/Module/Register.php:137
+#: src/Module/Register.php:139
 msgid "Your invitation code: "
 msgstr ""
 
-#: src/Module/Register.php:145
+#: src/Module/Register.php:147
 msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
 msgstr ""
 
-#: src/Module/Register.php:146
+#: src/Module/Register.php:148
 msgid ""
 "Your Email Address: (Initial information will be send there, so this has to "
 "be an existing address.)"
 msgstr ""
 
-#: src/Module/Register.php:147
+#: src/Module/Register.php:149
 msgid "Please repeat your e-mail address:"
 msgstr ""
 
-#: src/Module/Register.php:149
+#: src/Module/Register.php:151
 msgid "Leave empty for an auto generated password."
 msgstr ""
 
-#: src/Module/Register.php:151
+#: src/Module/Register.php:153
 #, php-format
 msgid ""
 "Choose a profile nickname. This must begin with a text character. Your "
 "profile address on this site will then be \"<strong>nickname@%s</strong>\"."
 msgstr ""
 
-#: src/Module/Register.php:152
+#: src/Module/Register.php:154
 msgid "Choose a nickname: "
 msgstr ""
 
-#: src/Module/Register.php:161
+#: src/Module/Register.php:163
 msgid "Import your profile to this friendica instance"
 msgstr ""
 
-#: src/Module/Register.php:168
+#: src/Module/Register.php:170
 msgid "Note: This node explicitly contains adult content"
 msgstr ""
 
-#: src/Module/Register.php:170 src/Module/Settings/Delegation.php:155
+#: src/Module/Register.php:172 src/Module/Settings/Delegation.php:155
 msgid "Parent Password:"
 msgstr ""
 
-#: src/Module/Register.php:170 src/Module/Settings/Delegation.php:155
+#: src/Module/Register.php:172 src/Module/Settings/Delegation.php:155
 msgid ""
 "Please enter the password of the parent account to legitimize your request."
 msgstr ""
 
-#: src/Module/Register.php:199
+#: src/Module/Register.php:201
 msgid "Password doesn't match."
 msgstr ""
 
-#: src/Module/Register.php:205
+#: src/Module/Register.php:207
 msgid "Please enter your password."
 msgstr ""
 
-#: src/Module/Register.php:247
+#: src/Module/Register.php:249
 msgid "You have entered too much information."
 msgstr ""
 
-#: src/Module/Register.php:270
+#: src/Module/Register.php:272
 msgid "Please enter the identical mail address in the second field."
 msgstr ""
 
-#: src/Module/Register.php:297
+#: src/Module/Register.php:299
 msgid "The additional account was created."
 msgstr ""
 
-#: src/Module/Register.php:322
+#: src/Module/Register.php:324
 msgid ""
 "Registration successful. Please check your email for further instructions."
 msgstr ""
 
-#: src/Module/Register.php:326
+#: src/Module/Register.php:328
 #, php-format
 msgid ""
 "Failed to send email message. Here your accout details:<br> login: %s<br> "
 "password: %s<br><br>You can change your password after login."
 msgstr ""
 
-#: src/Module/Register.php:332
+#: src/Module/Register.php:334
 msgid "Registration successful."
 msgstr ""
 
-#: src/Module/Register.php:337 src/Module/Register.php:344
+#: src/Module/Register.php:339 src/Module/Register.php:346
 msgid "Your registration can not be processed."
 msgstr ""
 
-#: src/Module/Register.php:343
+#: src/Module/Register.php:345
 msgid "You have to leave a request note for the admin."
 msgstr ""
 
-#: src/Module/Register.php:389
+#: src/Module/Register.php:391
 msgid "Your registration is pending approval by the site owner."
 msgstr ""
 
@@ -10176,197 +10155,197 @@ msgstr ""
 msgid "%s posted an update."
 msgstr ""
 
-#: src/Object/Post.php:148
+#: src/Object/Post.php:149
 msgid "This entry was edited"
 msgstr ""
 
-#: src/Object/Post.php:176
+#: src/Object/Post.php:177
 msgid "Private Message"
 msgstr ""
 
-#: src/Object/Post.php:192 src/Object/Post.php:194
+#: src/Object/Post.php:193 src/Object/Post.php:195
 msgid "Edit"
 msgstr ""
 
-#: src/Object/Post.php:214
+#: src/Object/Post.php:215
 msgid "Pinned item"
 msgstr ""
 
-#: src/Object/Post.php:218
+#: src/Object/Post.php:219
 msgid "Delete globally"
 msgstr ""
 
-#: src/Object/Post.php:218
+#: src/Object/Post.php:219
 msgid "Remove locally"
 msgstr ""
 
-#: src/Object/Post.php:234
+#: src/Object/Post.php:235
 #, php-format
 msgid "Block %s"
 msgstr ""
 
-#: src/Object/Post.php:239
+#: src/Object/Post.php:240
 msgid "Save to folder"
 msgstr ""
 
-#: src/Object/Post.php:273
+#: src/Object/Post.php:274
 msgid "I will attend"
 msgstr ""
 
-#: src/Object/Post.php:273
+#: src/Object/Post.php:274
 msgid "I will not attend"
 msgstr ""
 
-#: src/Object/Post.php:273
+#: src/Object/Post.php:274
 msgid "I might attend"
 msgstr ""
 
-#: src/Object/Post.php:303
+#: src/Object/Post.php:304
 msgid "Ignore thread"
 msgstr ""
 
-#: src/Object/Post.php:304
+#: src/Object/Post.php:305
 msgid "Unignore thread"
 msgstr ""
 
-#: src/Object/Post.php:305
+#: src/Object/Post.php:306
 msgid "Toggle ignore status"
 msgstr ""
 
-#: src/Object/Post.php:315
+#: src/Object/Post.php:316
 msgid "Add star"
 msgstr ""
 
-#: src/Object/Post.php:316
+#: src/Object/Post.php:317
 msgid "Remove star"
 msgstr ""
 
-#: src/Object/Post.php:317
+#: src/Object/Post.php:318
 msgid "Toggle star status"
 msgstr ""
 
-#: src/Object/Post.php:328
+#: src/Object/Post.php:329
 msgid "Pin"
 msgstr ""
 
-#: src/Object/Post.php:329
+#: src/Object/Post.php:330
 msgid "Unpin"
 msgstr ""
 
-#: src/Object/Post.php:330
+#: src/Object/Post.php:331
 msgid "Toggle pin status"
 msgstr ""
 
-#: src/Object/Post.php:333
+#: src/Object/Post.php:334
 msgid "Pinned"
 msgstr ""
 
-#: src/Object/Post.php:338
+#: src/Object/Post.php:339
 msgid "Add tag"
 msgstr ""
 
-#: src/Object/Post.php:351
+#: src/Object/Post.php:352
 msgid "Quote share this"
 msgstr ""
 
-#: src/Object/Post.php:351
+#: src/Object/Post.php:352
 msgid "Quote Share"
 msgstr ""
 
-#: src/Object/Post.php:354
+#: src/Object/Post.php:355
 msgid "Reshare this"
 msgstr ""
 
-#: src/Object/Post.php:354
+#: src/Object/Post.php:355
 msgid "Reshare"
 msgstr ""
 
-#: src/Object/Post.php:355
+#: src/Object/Post.php:356
 msgid "Cancel your Reshare"
 msgstr ""
 
-#: src/Object/Post.php:355
+#: src/Object/Post.php:356
 msgid "Unshare"
 msgstr ""
 
-#: src/Object/Post.php:400
+#: src/Object/Post.php:401
 #, php-format
 msgid "%s (Received %s)"
 msgstr ""
 
-#: src/Object/Post.php:405
+#: src/Object/Post.php:406
 msgid "Comment this item on your system"
 msgstr ""
 
-#: src/Object/Post.php:405
+#: src/Object/Post.php:406
 msgid "Remote comment"
 msgstr ""
 
-#: src/Object/Post.php:421
+#: src/Object/Post.php:422
 msgid "Pushed"
 msgstr ""
 
-#: src/Object/Post.php:421
+#: src/Object/Post.php:422
 msgid "Pulled"
 msgstr ""
 
-#: src/Object/Post.php:455
+#: src/Object/Post.php:456
 msgid "to"
 msgstr ""
 
-#: src/Object/Post.php:456
+#: src/Object/Post.php:457
 msgid "via"
 msgstr ""
 
-#: src/Object/Post.php:457
+#: src/Object/Post.php:458
 msgid "Wall-to-Wall"
 msgstr ""
 
-#: src/Object/Post.php:458
+#: src/Object/Post.php:459
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: src/Object/Post.php:496
+#: src/Object/Post.php:497
 #, php-format
 msgid "Reply to %s"
 msgstr ""
 
-#: src/Object/Post.php:499
+#: src/Object/Post.php:500
 msgid "More"
 msgstr ""
 
-#: src/Object/Post.php:517
+#: src/Object/Post.php:518
 msgid "Notifier task is pending"
 msgstr ""
 
-#: src/Object/Post.php:518
+#: src/Object/Post.php:519
 msgid "Delivery to remote servers is pending"
 msgstr ""
 
-#: src/Object/Post.php:519
+#: src/Object/Post.php:520
 msgid "Delivery to remote servers is underway"
 msgstr ""
 
-#: src/Object/Post.php:520
+#: src/Object/Post.php:521
 msgid "Delivery to remote servers is mostly done"
 msgstr ""
 
-#: src/Object/Post.php:521
+#: src/Object/Post.php:522
 msgid "Delivery to remote servers is done"
 msgstr ""
 
-#: src/Object/Post.php:541
+#: src/Object/Post.php:542
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Object/Post.php:542
+#: src/Object/Post.php:543
 msgid "Show more"
 msgstr ""
 
-#: src/Object/Post.php:543
+#: src/Object/Post.php:544
 msgid "Show fewer"
 msgstr ""
 

--- a/view/templates/contact_drop_confirm.tpl
+++ b/view/templates/contact_drop_confirm.tpl
@@ -1,8 +1,0 @@
-<h1>{{$header}}</h1>
-
-{{include file="contact_template.tpl" no_contacts_checkbox=True}}
-
-{{include file="confirm.tpl"}}
-
-
-<div class="clear"></div>

--- a/view/templates/contacts-template.tpl
+++ b/view/templates/contacts-template.tpl
@@ -38,20 +38,6 @@
      return false;
     }
   });
- 
-  // add javascript confirm dialog to "drop" links. Plain html url have "?confirm=1" to show confirmation form, we need to remove it
-  $(".drop").each(function() {
-   $(this).attr('href', $(this).attr('href').replace("confirm=1","") );
-   $(this).click(function(e){
-    if (confirm("{{$contact_drop_confirm}}")) {
-     return true;
-    } else {
-     e.preventDefault();
-     return false;
-    }
-   });
-   
-  });
  });
  </script>
 

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2504,14 +2504,6 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 #directory-search-wrapper {
 	padding: 10px 0;
 }
-#contact-drop-confirm .contact-actions,
-#contact-drop-confirm .contact-photo-overlay,
-#contact-drop-confirm .contact-photo-menu {
-	display: none;
-}
-#contact-drop-confirm #confirm-form {
-	margin-top: 20px;
-}
 
 /* contact-edit */
 #contact-edit-actions {

--- a/view/theme/frio/templates/contact_drop_confirm.tpl
+++ b/view/theme/frio/templates/contact_drop_confirm.tpl
@@ -1,9 +1,0 @@
-<div id="contact-drop-confirm">
-	<h2 class="heading">{{$header}}</h2>
-
-	{{include file="contact_template.tpl" no_contacts_checkbox=True}}
-
-	{{include file="confirm.tpl"}}
-
-	<div class="clear"></div>
-</div>

--- a/view/theme/frio/templates/contact_template.tpl
+++ b/view/theme/frio/templates/contact_template.tpl
@@ -65,11 +65,6 @@
 					<i class="fa fa-user" aria-hidden="true"></i>
 				</a>
 				{{/if}}
-				{{if $contact.photo_menu.drop}}
-				<button type="button" class="contact-action-link btn-link" onclick="addToModal('{{$contact.photo_menu.drop.1}}'); return false;" data-toggle="tooltip" title="{{$contact.photo_menu.drop.0}}">
-					<i class="fa fa-user-times" aria-hidden="true"></i>
-				</button>
-				{{/if}}
 				{{if $contact.photo_menu.follow}}
 				<a class="contact-action-link btn-link" href="{{$contact.photo_menu.follow.1}}" data-toggle="tooltip" title="{{$contact.photo_menu.follow.0}}">
 					<i class="fa fa-user-plus" aria-hidden="true"></i>
@@ -196,11 +191,6 @@ We use this part to filter the contacts with jquery.textcomplete *}}
 				{if $photo_menu.edit}
 				<a class="contact-action-link btn-link" href="{$photo_menu.edit.1}" data-toggle="tooltip" title="{$photo_menu.edit.0}">
 					<i class="fa fa-user" aria-hidden="true"></i>
-				</a>
-				{/if}
-				{if $photo_menu.drop}
-				<a class="contact-action-link btn-link" href="{$photo_menu.drop.1}" data-toggle="tooltip" title="{$photo_menu.drop.0}">
-					<i class="fa fa-user-times" aria-hidden="true"></i>
 				</a>
 				{/if}
 				{if $photo_menu.follow}

--- a/view/theme/frio/templates/contacts-template.tpl
+++ b/view/theme/frio/templates/contacts-template.tpl
@@ -1,8 +1,4 @@
 
-<script type="text/javascript">
-	var dropContact = "{{$contact_drop_confirm}}";
-</script>
-
 {{$tabs nofilter}}
 
 <div id="contacts" class="generic-page-wrapper">


### PR DESCRIPTION
Closes #10729 

Additionally, this PR adds contact relationship termination to block action to be more consistent with other social media platforms.