### PR TITLE
Remove contact drop feature

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -994,7 +994,6 @@ class Contact
 		$pm_url = '';
 		$status_link = '';
 		$photos_link = '';
-		$contact_drop_link = '';
 		$poke_link = '';
 
 		if ($uid == 0) {
@@ -1046,10 +1045,6 @@ class Contact
 
 		$posts_link = DI::baseUrl() . '/contact/' . $contact['id'] . '/conversations';
 
-		if (!$contact['self']) {
-			$contact_drop_link = DI::baseUrl() . '/contact/' . $contact['id'] . '/drop?confirm=1';
-		}
-
 		$follow_link = '';
 		$unfollow_link = '';
 		if (!$contact['self'] && Protocol::supportsFollow($contact['network'])) {
@@ -1058,10 +1053,6 @@ class Contact
 			} elseif(!$contact['pending']) {
 				$follow_link = 'follow?url=' . urlencode($contact['url']) . '&auto=1';
 			}
-		}
-
-		if (!empty($follow_link) || !empty($unfollow_link)) {
-			$contact_drop_link = '';
 		}
 
 		/**
@@ -1083,7 +1074,6 @@ class Contact
 				'photos'  => [DI::l10n()->t('View Photos')   , $photos_link      , true],
 				'network' => [DI::l10n()->t('Network Posts') , $posts_link       , false],
 				'edit'    => [DI::l10n()->t('View Contact')  , $contact_url      , false],
-				'drop'    => [DI::l10n()->t('Drop Contact')  , $contact_drop_link, false],
 				'pm'      => [DI::l10n()->t('Send PM')       , $pm_url           , false],
 				'poke'    => [DI::l10n()->t('Poke')          , $poke_link        , false],
 				'follow'  => [DI::l10n()->t('Connect/Follow'), $follow_link      , true],

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -87,12 +87,6 @@ class Contact extends BaseModule
 				self::toggleIgnoreContact($cdata['public']);
 				$count_actions++;
 			}
-
-			if (!empty($_POST['contacts_batch_drop']) && $cdata['user']
-				&& self::dropContact($cdata['user'], local_user())
-			) {
-				$count_actions++;
-			}
 		}
 		if ($count_actions > 0) {
 			info(DI::l10n()->tt('%d contact edited.', '%d contacts edited.', $count_actions));
@@ -228,31 +222,6 @@ class Contact extends BaseModule
 	{
 		$ignored = !Model\Contact\User::isIgnored($contact_id, local_user());
 		Model\Contact\User::setIgnored($contact_id, local_user(), $ignored);
-	}
-
-	/**
-	 * @param int $contact_id Id for contact with uid != 0
-	 * @param int $uid        Id for user we want to drop the contact for
-	 * @return bool
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
-	 * @throws \ImagickException
-	 */
-	private static function dropContact(int $contact_id, int $uid): bool
-	{
-		$contact = Model\Contact::getContactForUser($contact_id, $uid);
-		if (!DBA::isResult($contact)) {
-			return false;
-		}
-
-		$owner = Model\User::getOwnerDataById($uid);
-		if (!DBA::isResult($owner)) {
-			return false;
-		}
-
-		Model\Contact::terminateFriendship($owner, $contact, true);
-		Model\Contact::remove($contact['id']);
-
-		return true;
 	}
 
 	public static function content(array $parameters = [], $update = 0)
@@ -424,38 +393,6 @@ class Contact extends BaseModule
 				info(($ignored ? DI::l10n()->t('Contact has been ignored') : DI::l10n()->t('Contact has been unignored')));
 
 				DI::baseUrl()->redirect('contact/' . $cdata['public']);
-				// NOTREACHED
-			}
-
-			if ($cmd === 'drop' && $cdata['user']) {
-				// Check if we should do HTML-based delete confirmation
-				if (!empty($_REQUEST['confirm'])) {
-					DI::page()['aside'] = '';
-
-					return Renderer::replaceMacros(Renderer::getMarkupTemplate('contact_drop_confirm.tpl'), [
-						'$l10n' => [
-							'header' => DI::l10n()->t('Drop contact'),
-							'message' => DI::l10n()->t('Do you really want to delete this contact?'),
-							'confirm' => DI::l10n()->t('Yes'),
-							'cancel' => DI::l10n()->t('Cancel'),
-						],
-						'$contact' => self::getContactTemplateVars($orig_record),
-						'$method' => 'get',
-						'$confirm_url' => DI::args()->getCommand(),
-						'$confirm_name' => 't',
-						'$confirm_value' => BaseModule::getFormSecurityToken('contact_action'),
-					]);
-				}
-				// Now check how the user responded to the confirmation query
-				if (!empty($_REQUEST['canceled'])) {
-					DI::baseUrl()->redirect('contact');
-				}
-
-				if (self::dropContact($cdata['user'], local_user())) {
-					info(DI::l10n()->t('Contact has been removed.'));
-				}
-
-				DI::baseUrl()->redirect('contact');
 				// NOTREACHED
 			}
 		}
@@ -859,13 +796,11 @@ class Contact extends BaseModule
 			'$cmd'        => DI::args()->getCommand(),
 			'$contacts'   => $contacts,
 			'$form_security_token'  => BaseModule::getFormSecurityToken('contact_batch_actions'),
-			'$contact_drop_confirm' => DI::l10n()->t('Do you really want to delete this contact?'),
 			'multiselect' => 1,
 			'$batch_actions' => [
 				'contacts_batch_update'  => DI::l10n()->t('Update'),
 				'contacts_batch_block'   => DI::l10n()->t('Block') . '/' . DI::l10n()->t('Unblock'),
 				'contacts_batch_ignore'  => DI::l10n()->t('Ignore') . '/' . DI::l10n()->t('Unignore'),
-				'contacts_batch_drop'    => DI::l10n()->t('Delete'),
 			],
 			'$h_batch_actions' => DI::l10n()->t('Batch Actions'),
 			'$paginate'   => $pager->renderFull($total),
@@ -1156,23 +1091,13 @@ class Contact extends BaseModule
 			'id'    => 'toggle-ignore',
 		];
 
-		if ($contact['uid'] != 0) {
-			if (Protocol::supportsRevokeFollow($contact['network']) && in_array($contact['rel'], [Model\Contact::FOLLOWER, Model\Contact::FRIEND])) {
-				$contact_actions['revoke_follow'] = [
-					'label' => DI::l10n()->t('Revoke Follow'),
-					'url'   => 'contact/' . $contact['id'] . '/revoke',
-					'title' => DI::l10n()->t('Revoke the follow from this contact'),
-					'sel'   => '',
-					'id'    => 'revoke_follow',
-				];
-			}
-
-			$contact_actions['delete'] = [
-				'label' => DI::l10n()->t('Delete'),
-				'url'   => 'contact/' . $contact['id'] . '/drop?t=' . $formSecurityToken,
-				'title' => DI::l10n()->t('Delete contact'),
+		if ($contact['uid'] != 0 && Protocol::supportsRevokeFollow($contact['network']) && in_array($contact['rel'], [Model\Contact::FOLLOWER, Model\Contact::FRIEND])) {
+			$contact_actions['revoke_follow'] = [
+				'label' => DI::l10n()->t('Revoke Follow'),
+				'url'   => 'contact/' . $contact['id'] . '/revoke',
+				'title' => DI::l10n()->t('Revoke the follow from this contact'),
 				'sel'   => '',
-				'id'    => 'delete',
+				'id'    => 'revoke_follow',
 			];
 		}
 

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -236,7 +236,6 @@ return [
 		'/{id:\d+}/block'             => [Module\Contact::class,           [R::GET]],
 		'/{id:\d+}/conversations'     => [Module\Contact::class,           [R::GET]],
 		'/{id:\d+}/contacts[/{type}]' => [Module\Contact\Contacts::class,  [R::GET]],
-		'/{id:\d+}/drop'              => [Module\Contact::class,           [R::GET]],
 		'/{id:\d+}/ignore'            => [Module\Contact::class,           [R::GET]],
 		'/{id:\d+}/media'             => [Module\Contact\Media::class,     [R::GET]],
 		'/{id:\d+}/poke'              => [Module\Contact\Poke::class,      [R::GET, R::POST]],

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2021.12-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-02 19:18+0000\n"
+"POT-Creation-Date: 2021-10-02 16:06-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,8 +37,8 @@ msgstr[1] ""
 msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgstr ""
 
-#: include/api.php:4430 mod/photos.php:89 mod/photos.php:198 mod/photos.php:626
-#: mod/photos.php:1037 mod/photos.php:1054 mod/photos.php:1603
+#: include/api.php:4430 mod/photos.php:89 mod/photos.php:198 mod/photos.php:621
+#: mod/photos.php:1032 mod/photos.php:1049 mod/photos.php:1598
 #: src/Model/User.php:1169 src/Model/User.php:1177 src/Model/User.php:1185
 #: src/Module/Settings/Profile/Photo/Crop.php:101
 #: src/Module/Settings/Profile/Photo/Crop.php:117
@@ -302,7 +302,7 @@ msgstr ""
 #: mod/api.php:30 mod/editpost.php:38 mod/events.php:236 mod/follow.php:56
 #: mod/follow.php:130 mod/item.php:185 mod/item.php:190 mod/item.php:936
 #: mod/message.php:69 mod/message.php:111 mod/notes.php:44
-#: mod/ostatus_subscribe.php:32 mod/photos.php:163 mod/photos.php:917
+#: mod/ostatus_subscribe.php:32 mod/photos.php:163 mod/photos.php:912
 #: mod/repair_ostatus.php:31 mod/settings.php:47 mod/settings.php:57
 #: mod/settings.php:417 mod/suggest.php:34 mod/uimport.php:32
 #: mod/unfollow.php:35 mod/unfollow.php:50 mod/unfollow.php:82
@@ -311,7 +311,7 @@ msgstr ""
 #: mod/wallmessage.php:96 mod/wallmessage.php:120 src/Module/Attach.php:55
 #: src/Module/BaseApi.php:79 src/Module/BaseApi.php:88
 #: src/Module/BaseApi.php:97 src/Module/BaseApi.php:106
-#: src/Module/BaseNotifications.php:88 src/Module/Contact.php:357
+#: src/Module/BaseNotifications.php:88 src/Module/Contact.php:326
 #: src/Module/Contact/Advanced.php:44 src/Module/Delegation.php:118
 #: src/Module/FollowConfirm.php:16 src/Module/FriendSuggest.php:44
 #: src/Module/Group.php:45 src/Module/Group.php:90 src/Module/Invite.php:41
@@ -343,7 +343,7 @@ msgid "Access denied."
 msgstr ""
 
 #: mod/cal.php:61 mod/cal.php:78 mod/photos.php:69 mod/photos.php:143
-#: mod/photos.php:824 src/Model/Profile.php:228 src/Module/HCard.php:52
+#: mod/photos.php:819 src/Model/Profile.php:228 src/Module/HCard.php:52
 #: src/Module/Profile/Common.php:41 src/Module/Profile/Common.php:52
 #: src/Module/Profile/Contacts.php:40 src/Module/Profile/Contacts.php:50
 #: src/Module/Profile/Media.php:38 src/Module/Profile/Status.php:58
@@ -357,45 +357,45 @@ msgstr ""
 msgid "Access to this profile has been restricted."
 msgstr ""
 
-#: mod/cal.php:251 mod/events.php:422 src/Content/Nav.php:194
+#: mod/cal.php:251 mod/events.php:416 src/Content/Nav.php:194
 #: src/Content/Nav.php:258 src/Module/BaseProfile.php:84
 #: src/Module/BaseProfile.php:95 view/theme/frio/theme.php:230
 #: view/theme/frio/theme.php:234
 msgid "Events"
 msgstr ""
 
-#: mod/cal.php:252 mod/events.php:423
+#: mod/cal.php:252 mod/events.php:417
 msgid "View"
 msgstr ""
 
-#: mod/cal.php:253 mod/events.php:425
+#: mod/cal.php:253 mod/events.php:419
 msgid "Previous"
 msgstr ""
 
-#: mod/cal.php:254 mod/events.php:426 src/Module/Install.php:207
+#: mod/cal.php:254 mod/events.php:420 src/Module/Install.php:207
 msgid "Next"
 msgstr ""
 
-#: mod/cal.php:257 mod/events.php:431 src/Model/Event.php:474
+#: mod/cal.php:257 mod/events.php:425 src/Model/Event.php:474
 msgid "today"
 msgstr ""
 
-#: mod/cal.php:258 mod/events.php:432 src/Model/Event.php:475
+#: mod/cal.php:258 mod/events.php:426 src/Model/Event.php:475
 #: src/Util/Temporal.php:330
 msgid "month"
 msgstr ""
 
-#: mod/cal.php:259 mod/events.php:433 src/Model/Event.php:476
+#: mod/cal.php:259 mod/events.php:427 src/Model/Event.php:476
 #: src/Util/Temporal.php:331
 msgid "week"
 msgstr ""
 
-#: mod/cal.php:260 mod/events.php:434 src/Model/Event.php:477
+#: mod/cal.php:260 mod/events.php:428 src/Model/Event.php:477
 #: src/Util/Temporal.php:332
 msgid "day"
 msgstr ""
 
-#: mod/cal.php:261 mod/events.php:435
+#: mod/cal.php:261 mod/events.php:429
 msgid "list"
 msgstr ""
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "calendar"
 msgstr ""
 
-#: mod/display.php:165 mod/photos.php:828
+#: mod/display.php:165 mod/photos.php:823
 #: src/Module/Conversation/Community.php:176 src/Module/Debug/Probe.php:39
 #: src/Module/Debug/WebFinger.php:38 src/Module/Directory.php:49
 #: src/Module/Search/Index.php:50 src/Module/Search/Index.php:55
@@ -446,12 +446,12 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: mod/editpost.php:92 mod/photos.php:1379 src/Content/Conversation.php:326
+#: mod/editpost.php:92 mod/photos.php:1374 src/Content/Conversation.php:326
 #: src/Module/Contact/Poke.php:157 src/Object/Post.php:964
 msgid "Loading..."
 msgstr ""
 
-#: mod/editpost.php:93 mod/message.php:201 mod/message.php:365
+#: mod/editpost.php:93 mod/message.php:198 mod/message.php:362
 #: mod/wallmessage.php:153 src/Content/Conversation.php:327
 msgid "Upload photo"
 msgstr ""
@@ -468,7 +468,7 @@ msgstr ""
 msgid "attach file"
 msgstr ""
 
-#: mod/editpost.php:97 mod/message.php:202 mod/message.php:366
+#: mod/editpost.php:97 mod/message.php:199 mod/message.php:363
 #: mod/wallmessage.php:154
 msgid "Insert web link"
 msgstr ""
@@ -510,8 +510,8 @@ msgstr ""
 msgid "clear location"
 msgstr ""
 
-#: mod/editpost.php:107 mod/message.php:203 mod/message.php:368
-#: mod/photos.php:1530 mod/wallmessage.php:155 src/Content/Conversation.php:355
+#: mod/editpost.php:107 mod/message.php:200 mod/message.php:365
+#: mod/photos.php:1525 mod/wallmessage.php:155 src/Content/Conversation.php:355
 #: src/Content/Conversation.php:689 src/Module/Item/Compose.php:165
 #: src/Object/Post.php:502
 msgid "Please wait"
@@ -543,17 +543,16 @@ msgstr ""
 msgid "Example: bob@example.com, mary@example.com"
 msgstr ""
 
-#: mod/editpost.php:128 mod/events.php:578 mod/photos.php:1378
-#: mod/photos.php:1434 mod/photos.php:1508 src/Content/Conversation.php:370
+#: mod/editpost.php:128 mod/events.php:566 mod/photos.php:1373
+#: mod/photos.php:1429 mod/photos.php:1503 src/Content/Conversation.php:370
 #: src/Module/Item/Compose.php:160 src/Object/Post.php:974
 msgid "Preview"
 msgstr ""
 
 #: mod/editpost.php:130 mod/fbrowser.php:105 mod/fbrowser.php:134
-#: mod/follow.php:144 mod/photos.php:1026 mod/photos.php:1135 mod/tagrm.php:37
+#: mod/follow.php:144 mod/photos.php:1021 mod/photos.php:1130 mod/tagrm.php:37
 #: mod/tagrm.php:129 mod/unfollow.php:97 src/Content/Conversation.php:373
-#: src/Module/Contact.php:440 src/Module/Contact/Revoke.php:99
-#: src/Module/RemoteFollow.php:116
+#: src/Module/Contact/Revoke.php:99 src/Module/RemoteFollow.php:116
 msgid "Cancel"
 msgstr ""
 
@@ -568,8 +567,8 @@ msgstr ""
 msgid "Browser"
 msgstr ""
 
-#: mod/editpost.php:136 mod/events.php:583 mod/photos.php:965
-#: mod/photos.php:1332 src/Content/Conversation.php:357
+#: mod/editpost.php:136 mod/events.php:571 mod/photos.php:960
+#: mod/photos.php:1327 src/Content/Conversation.php:357
 msgid "Permissions"
 msgstr ""
 
@@ -585,23 +584,23 @@ msgstr ""
 msgid "Event title and start time are required."
 msgstr ""
 
-#: mod/events.php:424
+#: mod/events.php:418
 msgid "Create New Event"
 msgstr ""
 
-#: mod/events.php:536 src/Module/Admin/Logs/View.php:96
+#: mod/events.php:524 src/Module/Admin/Logs/View.php:96
 msgid "Event details"
 msgstr ""
 
-#: mod/events.php:537
+#: mod/events.php:525
 msgid "Starting date and Title are required."
 msgstr ""
 
-#: mod/events.php:538 mod/events.php:543
+#: mod/events.php:526 mod/events.php:531
 msgid "Event Starts:"
 msgstr ""
 
-#: mod/events.php:538 mod/events.php:570
+#: mod/events.php:526 mod/events.php:558
 #: src/Module/Admin/Blocklist/Server.php:79
 #: src/Module/Admin/Blocklist/Server.php:80
 #: src/Module/Admin/Blocklist/Server.php:99
@@ -619,43 +618,43 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: mod/events.php:551 mod/events.php:576
+#: mod/events.php:539 mod/events.php:564
 msgid "Finish date/time is not known or not relevant"
 msgstr ""
 
-#: mod/events.php:553 mod/events.php:558
+#: mod/events.php:541 mod/events.php:546
 msgid "Event Finishes:"
 msgstr ""
 
-#: mod/events.php:564 mod/events.php:577
+#: mod/events.php:552 mod/events.php:565
 msgid "Adjust for viewer timezone"
 msgstr ""
 
-#: mod/events.php:566 src/Module/Profile/Profile.php:172
+#: mod/events.php:554 src/Module/Profile/Profile.php:172
 #: src/Module/Settings/Profile/Index.php:236
 msgid "Description:"
 msgstr ""
 
-#: mod/events.php:568 src/Content/Widget/VCard.php:98 src/Model/Event.php:86
+#: mod/events.php:556 src/Content/Widget/VCard.php:98 src/Model/Event.php:86
 #: src/Model/Event.php:113 src/Model/Event.php:483 src/Model/Event.php:969
-#: src/Model/Profile.php:367 src/Module/Contact.php:626
+#: src/Model/Profile.php:367 src/Module/Contact.php:563
 #: src/Module/Directory.php:150 src/Module/Notifications/Introductions.php:166
 #: src/Module/Profile/Profile.php:194
 msgid "Location:"
 msgstr ""
 
-#: mod/events.php:570 mod/events.php:572
+#: mod/events.php:558 mod/events.php:560
 msgid "Title:"
 msgstr ""
 
-#: mod/events.php:573 mod/events.php:574
+#: mod/events.php:561 mod/events.php:562
 msgid "Share this event"
 msgstr ""
 
-#: mod/events.php:580 mod/message.php:204 mod/message.php:367
-#: mod/photos.php:947 mod/photos.php:1048 mod/photos.php:1336
-#: mod/photos.php:1377 mod/photos.php:1433 mod/photos.php:1507
-#: src/Module/Admin/Item/Source.php:65 src/Module/Contact.php:584
+#: mod/events.php:568 mod/message.php:201 mod/message.php:364
+#: mod/photos.php:942 mod/photos.php:1043 mod/photos.php:1331
+#: mod/photos.php:1372 mod/photos.php:1428 mod/photos.php:1502
+#: src/Module/Admin/Item/Source.php:65 src/Module/Contact.php:521
 #: src/Module/Contact/Advanced.php:133 src/Module/Contact/Poke.php:158
 #: src/Module/Debug/ActivityPubConversion.php:141
 #: src/Module/Debug/Babel.php:313 src/Module/Debug/Localtime.php:64
@@ -670,16 +669,16 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: mod/events.php:581 src/Module/Profile/Profile.php:248
+#: mod/events.php:569 src/Module/Profile/Profile.php:248
 msgid "Basic"
 msgstr ""
 
-#: mod/events.php:582 src/Module/Admin/Site.php:505 src/Module/Contact.php:943
+#: mod/events.php:570 src/Module/Admin/Site.php:505 src/Module/Contact.php:878
 #: src/Module/Profile/Profile.php:249
 msgid "Advanced"
 msgstr ""
 
-#: mod/events.php:599
+#: mod/events.php:587
 msgid "Failed to remove event"
 msgstr ""
 
@@ -718,7 +717,7 @@ msgid "OStatus support is disabled. Contact can't be added."
 msgstr ""
 
 #: mod/follow.php:138 src/Content/Item.php:463 src/Content/Widget.php:76
-#: src/Model/Contact.php:1076 src/Model/Contact.php:1089
+#: src/Model/Contact.php:1067 src/Model/Contact.php:1079
 #: view/theme/vier/theme.php:172
 msgid "Connect/Follow"
 msgstr ""
@@ -732,13 +731,13 @@ msgid "Your Identity Address:"
 msgstr ""
 
 #: mod/follow.php:141 mod/unfollow.php:100
-#: src/Module/Admin/Blocklist/Contact.php:100 src/Module/Contact.php:622
+#: src/Module/Admin/Blocklist/Contact.php:100 src/Module/Contact.php:559
 #: src/Module/Notifications/Introductions.php:108
 #: src/Module/Notifications/Introductions.php:177
 msgid "Profile URL"
 msgstr ""
 
-#: mod/follow.php:142 src/Module/Contact.php:634
+#: mod/follow.php:142 src/Module/Contact.php:571
 #: src/Module/Notifications/Introductions.php:170
 #: src/Module/Profile/Profile.php:207
 msgid "Tags:"
@@ -754,7 +753,7 @@ msgid "Add a personal note:"
 msgstr ""
 
 #: mod/follow.php:163 mod/unfollow.php:109 src/Module/BaseProfile.php:59
-#: src/Module/Contact.php:913
+#: src/Module/Contact.php:848
 msgid "Status Messages and Posts"
 msgstr ""
 
@@ -976,77 +975,77 @@ msgstr ""
 msgid "Message was not deleted."
 msgstr ""
 
-#: mod/message.php:169
+#: mod/message.php:166
 msgid "Conversation was not removed."
 msgstr ""
 
-#: mod/message.php:183 mod/message.php:296 mod/wallmessage.php:137
+#: mod/message.php:180 mod/message.php:293 mod/wallmessage.php:137
 msgid "Please enter a link URL:"
 msgstr ""
 
-#: mod/message.php:192 mod/wallmessage.php:142
+#: mod/message.php:189 mod/wallmessage.php:142
 msgid "Send Private Message"
 msgstr ""
 
-#: mod/message.php:193 mod/message.php:357 mod/wallmessage.php:144
+#: mod/message.php:190 mod/message.php:354 mod/wallmessage.php:144
 msgid "To:"
 msgstr ""
 
-#: mod/message.php:194 mod/message.php:358 mod/wallmessage.php:145
+#: mod/message.php:191 mod/message.php:355 mod/wallmessage.php:145
 msgid "Subject:"
 msgstr ""
 
-#: mod/message.php:198 mod/message.php:361 mod/wallmessage.php:151
+#: mod/message.php:195 mod/message.php:358 mod/wallmessage.php:151
 #: src/Module/Invite.php:170
 msgid "Your message:"
 msgstr ""
 
-#: mod/message.php:232
+#: mod/message.php:229
 msgid "No messages."
 msgstr ""
 
-#: mod/message.php:288
+#: mod/message.php:285
 msgid "Message not available."
 msgstr ""
 
-#: mod/message.php:333
+#: mod/message.php:330
 msgid "Delete message"
 msgstr ""
 
-#: mod/message.php:335 mod/message.php:467
+#: mod/message.php:332 mod/message.php:464
 msgid "D, d M Y - g:i A"
 msgstr ""
 
-#: mod/message.php:350 mod/message.php:464
+#: mod/message.php:347 mod/message.php:461
 msgid "Delete conversation"
 msgstr ""
 
-#: mod/message.php:352
+#: mod/message.php:349
 msgid ""
 "No secure communications available. You <strong>may</strong> be able to "
 "respond from the sender's profile page."
 msgstr ""
 
-#: mod/message.php:356
+#: mod/message.php:353
 msgid "Send Reply"
 msgstr ""
 
-#: mod/message.php:438
+#: mod/message.php:435
 #, php-format
 msgid "Unknown sender - %s"
 msgstr ""
 
-#: mod/message.php:440
+#: mod/message.php:437
 #, php-format
 msgid "You and %s"
 msgstr ""
 
-#: mod/message.php:442
+#: mod/message.php:439
 #, php-format
 msgid "%s and You"
 msgstr ""
 
-#: mod/message.php:470
+#: mod/message.php:467
 #, php-format
 msgid "%d message"
 msgid_plural "%d messages"
@@ -1113,11 +1112,11 @@ msgstr ""
 msgid "Photo Albums"
 msgstr ""
 
-#: mod/photos.php:112 mod/photos.php:1632
+#: mod/photos.php:112 mod/photos.php:1627
 msgid "Recent Photos"
 msgstr ""
 
-#: mod/photos.php:114 mod/photos.php:1099 mod/photos.php:1634
+#: mod/photos.php:114 mod/photos.php:1094 mod/photos.php:1629
 msgid "Upload New Photos"
 msgstr ""
 
@@ -1129,236 +1128,235 @@ msgstr ""
 msgid "Contact information unavailable"
 msgstr ""
 
-#: mod/photos.php:209
+#: mod/photos.php:204
 msgid "Album not found."
 msgstr ""
 
-#: mod/photos.php:267
+#: mod/photos.php:262
 msgid "Album successfully deleted"
 msgstr ""
 
-#: mod/photos.php:269
+#: mod/photos.php:264
 msgid "Album was empty."
 msgstr ""
 
-#: mod/photos.php:301
+#: mod/photos.php:296
 msgid "Failed to delete the photo."
 msgstr ""
 
-#: mod/photos.php:576
+#: mod/photos.php:571
 msgid "a photo"
 msgstr ""
 
-#: mod/photos.php:576
+#: mod/photos.php:571
 #, php-format
 msgid "%1$s was tagged in %2$s by %3$s"
 msgstr ""
 
-#: mod/photos.php:659 mod/photos.php:662 mod/photos.php:689
+#: mod/photos.php:654 mod/photos.php:657 mod/photos.php:684
 #: mod/wall_upload.php:216 src/Module/Settings/Profile/Photo/Index.php:60
 #, php-format
 msgid "Image exceeds size limit of %s"
 msgstr ""
 
-#: mod/photos.php:665
+#: mod/photos.php:660
 msgid "Image upload didn't complete, please try again"
 msgstr ""
 
-#: mod/photos.php:668
+#: mod/photos.php:663
 msgid "Image file is missing"
 msgstr ""
 
-#: mod/photos.php:673
+#: mod/photos.php:668
 msgid ""
 "Server can't accept new file upload at this time, please contact your "
 "administrator"
 msgstr ""
 
-#: mod/photos.php:697
+#: mod/photos.php:692
 msgid "Image file is empty."
 msgstr ""
 
-#: mod/photos.php:712 mod/wall_upload.php:175
+#: mod/photos.php:707 mod/wall_upload.php:175
 #: src/Module/Settings/Profile/Photo/Index.php:69
 msgid "Unable to process image."
 msgstr ""
 
-#: mod/photos.php:741 mod/wall_upload.php:241
+#: mod/photos.php:736 mod/wall_upload.php:241
 #: src/Module/Settings/Profile/Photo/Index.php:96
 msgid "Image upload failed."
 msgstr ""
 
-#: mod/photos.php:833
+#: mod/photos.php:828
 msgid "No photos selected"
 msgstr ""
 
-#: mod/photos.php:902
+#: mod/photos.php:897
 msgid "Access to this item is restricted."
 msgstr ""
 
-#: mod/photos.php:957
+#: mod/photos.php:952
 msgid "Upload Photos"
 msgstr ""
 
-#: mod/photos.php:961 mod/photos.php:1044
+#: mod/photos.php:956 mod/photos.php:1039
 msgid "New album name: "
 msgstr ""
 
-#: mod/photos.php:962
+#: mod/photos.php:957
 msgid "or select existing album:"
 msgstr ""
 
-#: mod/photos.php:963
+#: mod/photos.php:958
 msgid "Do not show a status post for this upload"
 msgstr ""
 
-#: mod/photos.php:1024
+#: mod/photos.php:1019
 msgid "Do you really want to delete this photo album and all its photos?"
 msgstr ""
 
-#: mod/photos.php:1025 mod/photos.php:1049
+#: mod/photos.php:1020 mod/photos.php:1044
 msgid "Delete Album"
 msgstr ""
 
-#: mod/photos.php:1055
+#: mod/photos.php:1050
 msgid "Edit Album"
 msgstr ""
 
-#: mod/photos.php:1056
+#: mod/photos.php:1051
 msgid "Drop Album"
 msgstr ""
 
-#: mod/photos.php:1061
+#: mod/photos.php:1056
 msgid "Show Newest First"
 msgstr ""
 
-#: mod/photos.php:1063
+#: mod/photos.php:1058
 msgid "Show Oldest First"
 msgstr ""
 
-#: mod/photos.php:1084 mod/photos.php:1617
+#: mod/photos.php:1079 mod/photos.php:1612
 msgid "View Photo"
 msgstr ""
 
-#: mod/photos.php:1121
+#: mod/photos.php:1116
 msgid "Permission denied. Access to this item may be restricted."
 msgstr ""
 
-#: mod/photos.php:1123
+#: mod/photos.php:1118
 msgid "Photo not available"
 msgstr ""
 
-#: mod/photos.php:1133
+#: mod/photos.php:1128
 msgid "Do you really want to delete this photo?"
 msgstr ""
 
-#: mod/photos.php:1134 mod/photos.php:1337
+#: mod/photos.php:1129 mod/photos.php:1332
 msgid "Delete Photo"
 msgstr ""
 
-#: mod/photos.php:1228
+#: mod/photos.php:1223
 msgid "View photo"
 msgstr ""
 
-#: mod/photos.php:1230
+#: mod/photos.php:1225
 msgid "Edit photo"
 msgstr ""
 
-#: mod/photos.php:1231
+#: mod/photos.php:1226
 msgid "Delete photo"
 msgstr ""
 
-#: mod/photos.php:1232
+#: mod/photos.php:1227
 msgid "Use as profile photo"
 msgstr ""
 
-#: mod/photos.php:1239
+#: mod/photos.php:1234
 msgid "Private Photo"
 msgstr ""
 
-#: mod/photos.php:1245
+#: mod/photos.php:1240
 msgid "View Full Size"
 msgstr ""
 
-#: mod/photos.php:1305
+#: mod/photos.php:1300
 msgid "Tags: "
 msgstr ""
 
-#: mod/photos.php:1308
+#: mod/photos.php:1303
 msgid "[Select tags to remove]"
 msgstr ""
 
-#: mod/photos.php:1323
+#: mod/photos.php:1318
 msgid "New album name"
 msgstr ""
 
-#: mod/photos.php:1324
+#: mod/photos.php:1319
 msgid "Caption"
 msgstr ""
 
-#: mod/photos.php:1325
+#: mod/photos.php:1320
 msgid "Add a Tag"
 msgstr ""
 
-#: mod/photos.php:1325
+#: mod/photos.php:1320
 msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
 msgstr ""
 
-#: mod/photos.php:1326
+#: mod/photos.php:1321
 msgid "Do not rotate"
 msgstr ""
 
-#: mod/photos.php:1327
+#: mod/photos.php:1322
 msgid "Rotate CW (right)"
 msgstr ""
 
-#: mod/photos.php:1328
+#: mod/photos.php:1323
 msgid "Rotate CCW (left)"
 msgstr ""
 
-#: mod/photos.php:1374 mod/photos.php:1430 mod/photos.php:1504
-#: src/Module/Contact.php:1073 src/Module/Item/Compose.php:148
+#: mod/photos.php:1369 mod/photos.php:1425 mod/photos.php:1499
+#: src/Module/Contact.php:1008 src/Module/Item/Compose.php:148
 #: src/Object/Post.php:960
 msgid "This is you"
 msgstr ""
 
-#: mod/photos.php:1376 mod/photos.php:1432 mod/photos.php:1506
+#: mod/photos.php:1371 mod/photos.php:1427 mod/photos.php:1501
 #: src/Object/Post.php:496 src/Object/Post.php:962
 msgid "Comment"
 msgstr ""
 
-#: mod/photos.php:1465 src/Content/Conversation.php:615 src/Object/Post.php:227
+#: mod/photos.php:1460 src/Content/Conversation.php:615 src/Object/Post.php:227
 msgid "Select"
 msgstr ""
 
-#: mod/photos.php:1466 mod/settings.php:573 src/Content/Conversation.php:616
+#: mod/photos.php:1461 mod/settings.php:573 src/Content/Conversation.php:616
 #: src/Module/Admin/Users/Active.php:139 src/Module/Admin/Users/Blocked.php:140
-#: src/Module/Admin/Users/Index.php:153 src/Module/Contact.php:868
-#: src/Module/Contact.php:1171
+#: src/Module/Admin/Users/Index.php:153
 msgid "Delete"
 msgstr ""
 
-#: mod/photos.php:1527 src/Object/Post.php:349
+#: mod/photos.php:1522 src/Object/Post.php:349
 msgid "Like"
 msgstr ""
 
-#: mod/photos.php:1528 src/Object/Post.php:349
+#: mod/photos.php:1523 src/Object/Post.php:349
 msgid "I like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1529 src/Object/Post.php:350
+#: mod/photos.php:1524 src/Object/Post.php:350
 msgid "Dislike"
 msgstr ""
 
-#: mod/photos.php:1531 src/Object/Post.php:350
+#: mod/photos.php:1526 src/Object/Post.php:350
 msgid "I don't like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1553
+#: mod/photos.php:1548
 msgid "Map"
 msgstr ""
 
-#: mod/photos.php:1623
+#: mod/photos.php:1618
 msgid "View Album"
 msgstr ""
 
@@ -2397,16 +2395,16 @@ msgid "All contacts"
 msgstr ""
 
 #: src/BaseModule.php:212 src/Content/Widget.php:238 src/Core/ACL.php:195
-#: src/Module/Contact.php:834 src/Module/PermissionTooltip.php:77
+#: src/Module/Contact.php:771 src/Module/PermissionTooltip.php:77
 #: src/Module/PermissionTooltip.php:99
 msgid "Followers"
 msgstr ""
 
-#: src/BaseModule.php:217 src/Content/Widget.php:239 src/Module/Contact.php:835
+#: src/BaseModule.php:217 src/Content/Widget.php:239 src/Module/Contact.php:772
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:222 src/Content/Widget.php:240 src/Module/Contact.php:836
+#: src/BaseModule.php:222 src/Content/Widget.php:240 src/Module/Contact.php:773
 msgid "Mutual friends"
 msgstr ""
 
@@ -3004,43 +3002,43 @@ msgstr ""
 msgid "Follow Thread"
 msgstr ""
 
-#: src/Content/Item.php:443 src/Model/Contact.php:1081
+#: src/Content/Item.php:443 src/Model/Contact.php:1072
 msgid "View Status"
 msgstr ""
 
-#: src/Content/Item.php:444 src/Content/Item.php:466 src/Model/Contact.php:1007
-#: src/Model/Contact.php:1073 src/Model/Contact.php:1082
+#: src/Content/Item.php:444 src/Content/Item.php:466 src/Model/Contact.php:1006
+#: src/Model/Contact.php:1064 src/Model/Contact.php:1073
 #: src/Module/Directory.php:160 src/Module/Settings/Profile/Index.php:223
 msgid "View Profile"
 msgstr ""
 
-#: src/Content/Item.php:445 src/Model/Contact.php:1083
+#: src/Content/Item.php:445 src/Model/Contact.php:1074
 msgid "View Photos"
 msgstr ""
 
-#: src/Content/Item.php:446 src/Model/Contact.php:1074
-#: src/Model/Contact.php:1084
+#: src/Content/Item.php:446 src/Model/Contact.php:1065
+#: src/Model/Contact.php:1075
 msgid "Network Posts"
 msgstr ""
 
-#: src/Content/Item.php:447 src/Model/Contact.php:1075
-#: src/Model/Contact.php:1085
+#: src/Content/Item.php:447 src/Model/Contact.php:1066
+#: src/Model/Contact.php:1076
 msgid "View Contact"
 msgstr ""
 
-#: src/Content/Item.php:448 src/Model/Contact.php:1087
+#: src/Content/Item.php:448 src/Model/Contact.php:1077
 msgid "Send PM"
 msgstr ""
 
 #: src/Content/Item.php:449 src/Module/Admin/Blocklist/Contact.php:84
 #: src/Module/Admin/Users/Active.php:140 src/Module/Admin/Users/Index.php:154
-#: src/Module/Contact.php:605 src/Module/Contact.php:866
-#: src/Module/Contact.php:1144
+#: src/Module/Contact.php:542 src/Module/Contact.php:802
+#: src/Module/Contact.php:1079
 msgid "Block"
 msgstr ""
 
-#: src/Content/Item.php:450 src/Module/Contact.php:606
-#: src/Module/Contact.php:867 src/Module/Contact.php:1152
+#: src/Content/Item.php:450 src/Module/Contact.php:543
+#: src/Module/Contact.php:803 src/Module/Contact.php:1087
 #: src/Module/Notifications/Introductions.php:113
 #: src/Module/Notifications/Introductions.php:185
 #: src/Module/Notifications/Notification.php:59
@@ -3051,7 +3049,7 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
-#: src/Content/Item.php:458 src/Model/Contact.php:1088
+#: src/Content/Item.php:458 src/Model/Contact.php:1078
 msgid "Poke"
 msgstr ""
 
@@ -3089,7 +3087,7 @@ msgid "Sign in"
 msgstr ""
 
 #: src/Content/Nav.php:190 src/Module/BaseProfile.php:56
-#: src/Module/Contact.php:637 src/Module/Contact.php:902
+#: src/Module/Contact.php:574 src/Module/Contact.php:837
 #: src/Module/Settings/TwoFactor/Index.php:112 view/theme/frio/theme.php:226
 msgid "Status"
 msgstr ""
@@ -3100,8 +3098,8 @@ msgid "Your posts and conversations"
 msgstr ""
 
 #: src/Content/Nav.php:191 src/Module/BaseProfile.php:48
-#: src/Module/BaseSettings.php:57 src/Module/Contact.php:639
-#: src/Module/Contact.php:926 src/Module/Profile/Profile.php:241
+#: src/Module/BaseSettings.php:57 src/Module/Contact.php:576
+#: src/Module/Contact.php:861 src/Module/Profile/Profile.php:241
 #: src/Module/Welcome.php:57 view/theme/frio/theme.php:227
 msgid "Profile"
 msgstr ""
@@ -3187,8 +3185,8 @@ msgstr ""
 
 #: src/Content/Nav.php:235 src/Content/Nav.php:294
 #: src/Content/Text/HTML.php:902 src/Module/BaseProfile.php:125
-#: src/Module/BaseProfile.php:128 src/Module/Contact.php:837
-#: src/Module/Contact.php:933 view/theme/frio/theme.php:237
+#: src/Module/BaseProfile.php:128 src/Module/Contact.php:774
+#: src/Module/Contact.php:868 view/theme/frio/theme.php:237
 msgid "Contacts"
 msgstr ""
 
@@ -3418,7 +3416,7 @@ msgstr ""
 msgid "Examples: Robert Morgenstein, Fishing"
 msgstr ""
 
-#: src/Content/Widget.php:78 src/Module/Contact.php:858
+#: src/Content/Widget.php:78 src/Module/Contact.php:795
 #: src/Module/Directory.php:99 view/theme/vier/theme.php:174
 msgid "Find"
 msgstr ""
@@ -3445,7 +3443,7 @@ msgid "Local Directory"
 msgstr ""
 
 #: src/Content/Widget.php:214 src/Model/Group.php:535
-#: src/Module/Contact.php:821 src/Module/Welcome.php:76
+#: src/Module/Contact.php:758 src/Module/Welcome.php:76
 msgid "Groups"
 msgstr ""
 
@@ -3457,7 +3455,7 @@ msgstr ""
 msgid "Relationships"
 msgstr ""
 
-#: src/Content/Widget.php:247 src/Module/Contact.php:773
+#: src/Content/Widget.php:247 src/Module/Contact.php:710
 #: src/Module/Group.php:292
 msgid "All Contacts"
 msgstr ""
@@ -3501,7 +3499,7 @@ msgstr ""
 msgid "Organisations"
 msgstr ""
 
-#: src/Content/Widget.php:529 src/Model/Contact.php:1509
+#: src/Content/Widget.php:529 src/Model/Contact.php:1499
 msgid "News"
 msgstr ""
 
@@ -3556,12 +3554,12 @@ msgid "More Trending Tags"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:96 src/Model/Profile.php:372
-#: src/Module/Contact.php:628 src/Module/Profile/Profile.php:176
+#: src/Module/Contact.php:565 src/Module/Profile/Profile.php:176
 msgid "XMPP:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:97 src/Model/Profile.php:373
-#: src/Module/Contact.php:630 src/Module/Profile/Profile.php:180
+#: src/Module/Contact.php:567 src/Module/Profile/Profile.php:180
 msgid "Matrix:"
 msgstr ""
 
@@ -4365,85 +4363,81 @@ msgstr ""
 msgid "Legacy module file not found: %s"
 msgstr ""
 
-#: src/Model/Contact.php:1077 src/Model/Contact.php:1090
+#: src/Model/Contact.php:1068 src/Model/Contact.php:1080
 msgid "UnFollow"
 msgstr ""
 
-#: src/Model/Contact.php:1086
-msgid "Drop Contact"
-msgstr ""
-
-#: src/Model/Contact.php:1096 src/Module/Admin/Users/Pending.php:107
+#: src/Model/Contact.php:1086 src/Module/Admin/Users/Pending.php:107
 #: src/Module/Notifications/Introductions.php:111
 #: src/Module/Notifications/Introductions.php:183
 msgid "Approve"
 msgstr ""
 
-#: src/Model/Contact.php:1505
+#: src/Model/Contact.php:1495
 msgid "Organisation"
 msgstr ""
 
-#: src/Model/Contact.php:1513
+#: src/Model/Contact.php:1503
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:2369
+#: src/Model/Contact.php:2359
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:2374 src/Module/Friendica.php:81
+#: src/Model/Contact.php:2364 src/Module/Friendica.php:81
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:2379
+#: src/Model/Contact.php:2369
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:2388
+#: src/Model/Contact.php:2378
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:2425
+#: src/Model/Contact.php:2415
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:2427
+#: src/Model/Contact.php:2417
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:2430
+#: src/Model/Contact.php:2420
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:2433
+#: src/Model/Contact.php:2423
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:2436
+#: src/Model/Contact.php:2426
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:2437
+#: src/Model/Contact.php:2427
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:2443
+#: src/Model/Contact.php:2433
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:2448
+#: src/Model/Contact.php:2438
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:2507
+#: src/Model/Contact.php:2497
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -4713,7 +4707,7 @@ msgstr ""
 msgid "Homepage:"
 msgstr ""
 
-#: src/Model/Profile.php:371 src/Module/Contact.php:632
+#: src/Model/Profile.php:371 src/Module/Contact.php:569
 #: src/Module/Notifications/Introductions.php:168
 msgid "About:"
 msgstr ""
@@ -5114,8 +5108,8 @@ msgstr ""
 msgid "List of active accounts"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:66 src/Module/Contact.php:781
-#: src/Module/Contact.php:841
+#: src/Module/Admin/BaseUsers.php:66 src/Module/Contact.php:718
+#: src/Module/Contact.php:778
 msgid "Pending"
 msgstr ""
 
@@ -5123,8 +5117,8 @@ msgstr ""
 msgid "List of pending registrations"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:74 src/Module/Contact.php:789
-#: src/Module/Contact.php:842
+#: src/Module/Admin/BaseUsers.php:74 src/Module/Contact.php:726
+#: src/Module/Contact.php:779
 msgid "Blocked"
 msgstr ""
 
@@ -5181,8 +5175,8 @@ msgstr ""
 
 #: src/Module/Admin/Blocklist/Contact.php:85
 #: src/Module/Admin/Users/Blocked.php:142 src/Module/Admin/Users/Index.php:156
-#: src/Module/Contact.php:605 src/Module/Contact.php:866
-#: src/Module/Contact.php:1144
+#: src/Module/Contact.php:542 src/Module/Contact.php:802
+#: src/Module/Contact.php:1079
 msgid "Unblock"
 msgstr ""
 
@@ -6528,7 +6522,7 @@ msgid ""
 "received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:609 src/Module/Contact.php:534
+#: src/Module/Admin/Site.php:609 src/Module/Contact.php:471
 #: src/Module/Settings/TwoFactor/Index.php:118
 msgid "Disabled"
 msgstr ""
@@ -7099,8 +7093,8 @@ msgstr ""
 msgid "Posts from %s can't be unshared"
 msgstr ""
 
-#: src/Module/Api/Twitter/ContactEndpoint.php:63 src/Module/Contact.php:372
-#: src/Module/Contact.php:387
+#: src/Module/Api/Twitter/ContactEndpoint.php:63 src/Module/Contact.php:341
+#: src/Module/Contact.php:356
 msgid "Contact not found"
 msgstr ""
 
@@ -7221,12 +7215,12 @@ msgstr ""
 msgid "Too Many Requests"
 msgstr ""
 
-#: src/Module/BaseProfile.php:51 src/Module/Contact.php:929
+#: src/Module/BaseProfile.php:51 src/Module/Contact.php:864
 msgid "Profile Details"
 msgstr ""
 
 #: src/Module/BaseProfile.php:72 src/Module/BaseProfile.php:75
-#: src/Module/Contact.php:918
+#: src/Module/Contact.php:853
 msgid "Media"
 msgstr ""
 
@@ -7293,379 +7287,357 @@ msgstr ""
 msgid "The post was created"
 msgstr ""
 
-#: src/Module/Contact.php:98
+#: src/Module/Contact.php:92
 #, php-format
 msgid "%d contact edited."
 msgid_plural "%d contacts edited."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact.php:123
+#: src/Module/Contact.php:117
 msgid "Could not access contact record."
 msgstr ""
 
-#: src/Module/Contact.php:159
+#: src/Module/Contact.php:153
 msgid "Failed to update contact record."
 msgstr ""
 
-#: src/Module/Contact.php:404
+#: src/Module/Contact.php:373
 msgid "You can't block yourself"
 msgstr ""
 
-#: src/Module/Contact.php:410
+#: src/Module/Contact.php:379
 msgid "Contact has been blocked"
 msgstr ""
 
-#: src/Module/Contact.php:410
+#: src/Module/Contact.php:379
 msgid "Contact has been unblocked"
 msgstr ""
 
-#: src/Module/Contact.php:418
+#: src/Module/Contact.php:387
 msgid "You can't ignore yourself"
 msgstr ""
 
-#: src/Module/Contact.php:424
+#: src/Module/Contact.php:393
 msgid "Contact has been ignored"
 msgstr ""
 
-#: src/Module/Contact.php:424
+#: src/Module/Contact.php:393
 msgid "Contact has been unignored"
 msgstr ""
 
-#: src/Module/Contact.php:437
-msgid "Drop contact"
-msgstr ""
-
-#: src/Module/Contact.php:438 src/Module/Contact.php:862
-msgid "Do you really want to delete this contact?"
-msgstr ""
-
-#: src/Module/Contact.php:439 src/Module/Contact/Revoke.php:98
-#: src/Module/Notifications/Introductions.php:123
-#: src/Module/OAuth/Acknowledge.php:47 src/Module/Register.php:117
-msgid "Yes"
-msgstr ""
-
-#: src/Module/Contact.php:455
-msgid "Contact has been removed."
-msgstr ""
-
-#: src/Module/Contact.php:476
+#: src/Module/Contact.php:413
 #, php-format
 msgid "You are mutual friends with %s"
 msgstr ""
 
-#: src/Module/Contact.php:480
+#: src/Module/Contact.php:417
 #, php-format
 msgid "You are sharing with %s"
 msgstr ""
 
-#: src/Module/Contact.php:484
+#: src/Module/Contact.php:421
 #, php-format
 msgid "%s is sharing with you"
 msgstr ""
 
-#: src/Module/Contact.php:508
+#: src/Module/Contact.php:445
 msgid "Private communications are not available for this contact."
 msgstr ""
 
-#: src/Module/Contact.php:510
+#: src/Module/Contact.php:447
 msgid "Never"
 msgstr ""
 
-#: src/Module/Contact.php:513
+#: src/Module/Contact.php:450
 msgid "(Update was not successful)"
 msgstr ""
 
-#: src/Module/Contact.php:513
+#: src/Module/Contact.php:450
 msgid "(Update was successful)"
 msgstr ""
 
-#: src/Module/Contact.php:515 src/Module/Contact.php:1115
+#: src/Module/Contact.php:452 src/Module/Contact.php:1050
 msgid "Suggest friends"
 msgstr ""
 
-#: src/Module/Contact.php:519
+#: src/Module/Contact.php:456
 #, php-format
 msgid "Network type: %s"
 msgstr ""
 
-#: src/Module/Contact.php:524
+#: src/Module/Contact.php:461
 msgid "Communications lost with this contact!"
 msgstr ""
 
-#: src/Module/Contact.php:530
+#: src/Module/Contact.php:467
 msgid "Fetch further information for feeds"
 msgstr ""
 
-#: src/Module/Contact.php:532
+#: src/Module/Contact.php:469
 msgid ""
 "Fetch information like preview pictures, title and teaser from the feed "
 "item. You can activate this if the feed doesn't contain much text. Keywords "
 "are taken from the meta header in the feed item and are posted as hash tags."
 msgstr ""
 
-#: src/Module/Contact.php:535
+#: src/Module/Contact.php:472
 msgid "Fetch information"
 msgstr ""
 
-#: src/Module/Contact.php:536
+#: src/Module/Contact.php:473
 msgid "Fetch keywords"
 msgstr ""
 
-#: src/Module/Contact.php:537
+#: src/Module/Contact.php:474
 msgid "Fetch information and keywords"
 msgstr ""
 
-#: src/Module/Contact.php:549 src/Module/Contact.php:553
-#: src/Module/Contact.php:556 src/Module/Contact.php:560
+#: src/Module/Contact.php:486 src/Module/Contact.php:490
+#: src/Module/Contact.php:493 src/Module/Contact.php:497
 msgid "No mirroring"
 msgstr ""
 
-#: src/Module/Contact.php:550
+#: src/Module/Contact.php:487
 msgid "Mirror as forwarded posting"
 msgstr ""
 
-#: src/Module/Contact.php:551 src/Module/Contact.php:557
-#: src/Module/Contact.php:561
+#: src/Module/Contact.php:488 src/Module/Contact.php:494
+#: src/Module/Contact.php:498
 msgid "Mirror as my own posting"
 msgstr ""
 
-#: src/Module/Contact.php:554 src/Module/Contact.php:558
+#: src/Module/Contact.php:491 src/Module/Contact.php:495
 msgid "Native reshare"
 msgstr ""
 
-#: src/Module/Contact.php:573
+#: src/Module/Contact.php:510
 msgid "Contact Information / Notes"
 msgstr ""
 
-#: src/Module/Contact.php:574
+#: src/Module/Contact.php:511
 msgid "Contact Settings"
 msgstr ""
 
-#: src/Module/Contact.php:582
+#: src/Module/Contact.php:519
 msgid "Contact"
 msgstr ""
 
-#: src/Module/Contact.php:586
+#: src/Module/Contact.php:523
 msgid "Their personal note"
 msgstr ""
 
-#: src/Module/Contact.php:588
+#: src/Module/Contact.php:525
 msgid "Edit contact notes"
 msgstr ""
 
-#: src/Module/Contact.php:591 src/Module/Contact.php:1081
+#: src/Module/Contact.php:528 src/Module/Contact.php:1016
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr ""
 
-#: src/Module/Contact.php:592
+#: src/Module/Contact.php:529
 msgid "Block/Unblock contact"
 msgstr ""
 
-#: src/Module/Contact.php:593
+#: src/Module/Contact.php:530
 msgid "Ignore contact"
 msgstr ""
 
-#: src/Module/Contact.php:594
+#: src/Module/Contact.php:531
 msgid "View conversations"
 msgstr ""
 
-#: src/Module/Contact.php:599
+#: src/Module/Contact.php:536
 msgid "Last update:"
 msgstr ""
 
-#: src/Module/Contact.php:601
+#: src/Module/Contact.php:538
 msgid "Update public posts"
 msgstr ""
 
-#: src/Module/Contact.php:603 src/Module/Contact.php:1125
+#: src/Module/Contact.php:540 src/Module/Contact.php:1060
 msgid "Update now"
 msgstr ""
 
-#: src/Module/Contact.php:606 src/Module/Contact.php:867
-#: src/Module/Contact.php:1152
+#: src/Module/Contact.php:543 src/Module/Contact.php:803
+#: src/Module/Contact.php:1087
 msgid "Unignore"
 msgstr ""
 
-#: src/Module/Contact.php:610
+#: src/Module/Contact.php:547
 msgid "Currently blocked"
 msgstr ""
 
-#: src/Module/Contact.php:611
+#: src/Module/Contact.php:548
 msgid "Currently ignored"
 msgstr ""
 
-#: src/Module/Contact.php:612
+#: src/Module/Contact.php:549
 msgid "Currently archived"
 msgstr ""
 
-#: src/Module/Contact.php:613
+#: src/Module/Contact.php:550
 msgid "Awaiting connection acknowledge"
 msgstr ""
 
-#: src/Module/Contact.php:614 src/Module/Notifications/Introductions.php:171
+#: src/Module/Contact.php:551 src/Module/Notifications/Introductions.php:171
 msgid "Hide this contact from others"
 msgstr ""
 
-#: src/Module/Contact.php:614
+#: src/Module/Contact.php:551
 msgid ""
 "Replies/likes to your public posts <strong>may</strong> still be visible"
 msgstr ""
 
-#: src/Module/Contact.php:615
+#: src/Module/Contact.php:552
 msgid "Notification for new posts"
 msgstr ""
 
-#: src/Module/Contact.php:615
+#: src/Module/Contact.php:552
 msgid "Send a notification of every new post of this contact"
 msgstr ""
 
-#: src/Module/Contact.php:617
+#: src/Module/Contact.php:554
 msgid "Keyword Deny List"
 msgstr ""
 
-#: src/Module/Contact.php:617
+#: src/Module/Contact.php:554
 msgid ""
 "Comma separated list of keywords that should not be converted to hashtags, "
 "when \"Fetch information and keywords\" is selected"
 msgstr ""
 
-#: src/Module/Contact.php:635 src/Module/Settings/TwoFactor/Index.php:132
+#: src/Module/Contact.php:572 src/Module/Settings/TwoFactor/Index.php:132
 msgid "Actions"
 msgstr ""
 
-#: src/Module/Contact.php:642
+#: src/Module/Contact.php:579
 msgid "Mirror postings from this contact"
 msgstr ""
 
-#: src/Module/Contact.php:644
+#: src/Module/Contact.php:581
 msgid ""
 "Mark this contact as remote_self, this will cause friendica to repost new "
 "entries from this contact."
 msgstr ""
 
-#: src/Module/Contact.php:776
+#: src/Module/Contact.php:713
 msgid "Show all contacts"
 msgstr ""
 
-#: src/Module/Contact.php:784
+#: src/Module/Contact.php:721
 msgid "Only show pending contacts"
 msgstr ""
 
-#: src/Module/Contact.php:792
+#: src/Module/Contact.php:729
 msgid "Only show blocked contacts"
 msgstr ""
 
-#: src/Module/Contact.php:797 src/Module/Contact.php:844
+#: src/Module/Contact.php:734 src/Module/Contact.php:781
 #: src/Object/Post.php:309
 msgid "Ignored"
 msgstr ""
 
-#: src/Module/Contact.php:800
+#: src/Module/Contact.php:737
 msgid "Only show ignored contacts"
 msgstr ""
 
-#: src/Module/Contact.php:805 src/Module/Contact.php:845
+#: src/Module/Contact.php:742 src/Module/Contact.php:782
 msgid "Archived"
 msgstr ""
 
-#: src/Module/Contact.php:808
+#: src/Module/Contact.php:745
 msgid "Only show archived contacts"
 msgstr ""
 
-#: src/Module/Contact.php:813 src/Module/Contact.php:843
+#: src/Module/Contact.php:750 src/Module/Contact.php:780
 msgid "Hidden"
 msgstr ""
 
-#: src/Module/Contact.php:816
+#: src/Module/Contact.php:753
 msgid "Only show hidden contacts"
 msgstr ""
 
-#: src/Module/Contact.php:824
+#: src/Module/Contact.php:761
 msgid "Organize your contact groups"
 msgstr ""
 
-#: src/Module/Contact.php:856
+#: src/Module/Contact.php:793
 msgid "Search your contacts"
 msgstr ""
 
-#: src/Module/Contact.php:857 src/Module/Search/Index.php:194
+#: src/Module/Contact.php:794 src/Module/Search/Index.php:194
 #, php-format
 msgid "Results for: %s"
 msgstr ""
 
-#: src/Module/Contact.php:865
+#: src/Module/Contact.php:801
 msgid "Update"
 msgstr ""
 
-#: src/Module/Contact.php:870
+#: src/Module/Contact.php:805
 msgid "Batch Actions"
 msgstr ""
 
-#: src/Module/Contact.php:905
+#: src/Module/Contact.php:840
 msgid "Conversations started by this contact"
 msgstr ""
 
-#: src/Module/Contact.php:910
+#: src/Module/Contact.php:845
 msgid "Posts and Comments"
 msgstr ""
 
-#: src/Module/Contact.php:921
+#: src/Module/Contact.php:856
 msgid "Posts containing media objects"
 msgstr ""
 
-#: src/Module/Contact.php:936
+#: src/Module/Contact.php:871
 msgid "View all known contacts"
 msgstr ""
 
-#: src/Module/Contact.php:946
+#: src/Module/Contact.php:881
 msgid "Advanced Contact Settings"
 msgstr ""
 
-#: src/Module/Contact.php:1040
+#: src/Module/Contact.php:975
 msgid "Mutual Friendship"
 msgstr ""
 
-#: src/Module/Contact.php:1044
+#: src/Module/Contact.php:979
 msgid "is a fan of yours"
 msgstr ""
 
-#: src/Module/Contact.php:1048
+#: src/Module/Contact.php:983
 msgid "you are a fan of"
 msgstr ""
 
-#: src/Module/Contact.php:1066
+#: src/Module/Contact.php:1001
 msgid "Pending outgoing contact request"
 msgstr ""
 
-#: src/Module/Contact.php:1068
+#: src/Module/Contact.php:1003
 msgid "Pending incoming contact request"
 msgstr ""
 
-#: src/Module/Contact.php:1135
+#: src/Module/Contact.php:1070
 msgid "Refetch contact data"
 msgstr ""
 
-#: src/Module/Contact.php:1146
+#: src/Module/Contact.php:1081
 msgid "Toggle Blocked status"
 msgstr ""
 
-#: src/Module/Contact.php:1154
+#: src/Module/Contact.php:1089
 msgid "Toggle Ignored status"
 msgstr ""
 
-#: src/Module/Contact.php:1162 src/Module/Contact/Revoke.php:96
+#: src/Module/Contact.php:1096 src/Module/Contact/Revoke.php:96
 msgid "Revoke Follow"
 msgstr ""
 
-#: src/Module/Contact.php:1164
+#: src/Module/Contact.php:1098
 msgid "Revoke the follow from this contact"
-msgstr ""
-
-#: src/Module/Contact.php:1173
-msgid "Delete contact"
 msgstr ""
 
 #: src/Module/Contact/Advanced.php:93
@@ -7838,6 +7810,12 @@ msgstr ""
 msgid ""
 "Do you really want to revoke this contact's follow? This cannot be undone "
 "and they will have to manually follow you back again."
+msgstr ""
+
+#: src/Module/Contact/Revoke.php:98
+#: src/Module/Notifications/Introductions.php:123
+#: src/Module/OAuth/Acknowledge.php:47 src/Module/Register.php:117
+msgid "Yes"
 msgstr ""
 
 #: src/Module/Conversation/Community.php:68

--- a/view/templates/contact_edit.tpl
+++ b/view/templates/contact_edit.tpl
@@ -22,7 +22,6 @@
 							<li role="menuitem"><a href="#" title="{{$contact_actions.block.title}}" onclick="window.location.href='{{$contact_actions.block.url}}'; return false;">{{$contact_actions.block.label}}</a></li>
 							<li role="menuitem"><a href="#" title="{{$contact_actions.ignore.title}}" onclick="window.location.href='{{$contact_actions.ignore.url}}'; return false;">{{$contact_actions.ignore.label}}</a></li>
 							{{if $contact_actions.revoke_follow.url}}<li role="menuitem"><a href="{{$contact_actions.revoke_follow.url}}" title="{{$contact_actions.revoke_follow.title}}">{{$contact_actions.revoke_follow.label}}</a></li>{{/if}}
-							{{if $contact_actions.delete.url}}<li role="menuitem"><a href="{{$contact_actions.delete.url}}" title="{{$contact_actions.delete.title}}" onclick="return confirmDelete();">{{$contact_actions.delete.label}}</a></li> {{/if}}
 						</ul>
 					</div>
 

--- a/view/templates/contacts-template.tpl
+++ b/view/templates/contacts-template.tpl
@@ -38,20 +38,6 @@
      return false;
     }
   });
- 
-  // add javascript confirm dialog to "drop" links. Plain html url have "?confirm=1" to show confirmation form, we need to remove it
-  $(".drop").each(function() {
-   $(this).attr('href', $(this).attr('href').replace("confirm=1","") );
-   $(this).click(function(e){
-    if (confirm("{{$contact_drop_confirm}}")) {
-     return true;
-    } else {
-     e.preventDefault();
-     return false;
-    }
-   });
-   
-  });
  });
  </script>
 

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2504,14 +2504,6 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 #directory-search-wrapper {
 	padding: 10px 0;
 }
-#contact-drop-confirm .contact-actions,
-#contact-drop-confirm .contact-photo-overlay,
-#contact-drop-confirm .contact-photo-menu {
-	display: none;
-}
-#contact-drop-confirm #confirm-form {
-	margin-top: 20px;
-}
 
 /* contact-edit */
 #contact-edit-actions {

--- a/view/theme/frio/templates/contact_edit.tpl
+++ b/view/theme/frio/templates/contact_edit.tpl
@@ -28,7 +28,6 @@
 							<li role="presentation"><a role="menuitem" href="{{$contact_actions.block.url}}" title="{{$contact_actions.block.title}}">{{$contact_actions.block.label}}</a></li>
 							<li role="presentation"><a role="menuitem" href="{{$contact_actions.ignore.url}}" title="{{$contact_actions.ignore.title}}">{{$contact_actions.ignore.label}}</a></li>
                             {{if $contact_actions.revoke_follow.url}}<li role="presentation"><button role="menuitem" type="button" class="btn-link" title="{{$contact_actions.revoke_follow.title}}" onclick="addToModal('{{$contact_actions.revoke_follow.url}}');">{{$contact_actions.revoke_follow.label}}</button></li>{{/if}}
-							{{if $contact_actions.delete.url}}<li role="presentation"><button role="menuitem" type="button" class="btn-link" title="{{$contact_actions.delete.title}}" onclick="addToModal('{{$contact_actions.delete.url}}&confirm=1');">{{$contact_actions.delete.label}}</button></li>{{/if}}
 						</ul>
 					</li>
 				</ul>

--- a/view/theme/frio/templates/contact_template.tpl
+++ b/view/theme/frio/templates/contact_template.tpl
@@ -65,11 +65,6 @@
 					<i class="fa fa-user" aria-hidden="true"></i>
 				</a>
 				{{/if}}
-				{{if $contact.photo_menu.drop}}
-				<button type="button" class="contact-action-link btn-link" onclick="addToModal('{{$contact.photo_menu.drop.1}}'); return false;" data-toggle="tooltip" title="{{$contact.photo_menu.drop.0}}">
-					<i class="fa fa-user-times" aria-hidden="true"></i>
-				</button>
-				{{/if}}
 				{{if $contact.photo_menu.follow}}
 				<a class="contact-action-link btn-link" href="{{$contact.photo_menu.follow.1}}" data-toggle="tooltip" title="{{$contact.photo_menu.follow.0}}">
 					<i class="fa fa-user-plus" aria-hidden="true"></i>
@@ -196,11 +191,6 @@ We use this part to filter the contacts with jquery.textcomplete *}}
 				{if $photo_menu.edit}
 				<a class="contact-action-link btn-link" href="{$photo_menu.edit.1}" data-toggle="tooltip" title="{$photo_menu.edit.0}">
 					<i class="fa fa-user" aria-hidden="true"></i>
-				</a>
-				{/if}
-				{if $photo_menu.drop}
-				<a class="contact-action-link btn-link" href="{$photo_menu.drop.1}" data-toggle="tooltip" title="{$photo_menu.drop.0}">
-					<i class="fa fa-user-times" aria-hidden="true"></i>
 				</a>
 				{/if}
 				{if $photo_menu.follow}

--- a/view/theme/frio/templates/contacts-template.tpl
+++ b/view/theme/frio/templates/contacts-template.tpl
@@ -1,8 +1,4 @@
 
-<script type="text/javascript">
-	var dropContact = "{{$contact_drop_confirm}}";
-</script>
-
 {{$tabs nofilter}}
 
 <div id="contacts" class="generic-page-wrapper">

--- a/view/theme/vier/templates/contact_edit.tpl
+++ b/view/theme/vier/templates/contact_edit.tpl
@@ -23,7 +23,6 @@
 							<li role="menuitem"><a href="#" title="{{$contact_actions.block.title}}" onclick="window.location.href='{{$contact_actions.block.url}}'; return false;">{{$contact_actions.block.label}}</a></li>
 							<li role="menuitem"><a href="#" title="{{$contact_actions.ignore.title}}" onclick="window.location.href='{{$contact_actions.ignore.url}}'; return false;">{{$contact_actions.ignore.label}}</a></li>
 							{{if $contact_actions.revoke_follow.url}}<li role="menuitem"><a href="{{$contact_actions.revoke_follow.url}}" title="{{$contact_actions.revoke_follow.title}}">{{$contact_actions.revoke_follow.label}}</a></li>{{/if}}
-							{{if $contact_actions.delete.url}}<li role="menuitem"><a href="{{$contact_actions.delete.url}}" title="{{$contact_actions.delete.title}}" onclick="return confirmDelete();">{{$contact_actions.delete.label}}</a></li>{{/if}}
 						</ul>
 					</div>
 


### PR DESCRIPTION
Redux of #10751 (for conversation)
Closes #10729 
Depends on #10796

Additionally, this PR adds contact relationship termination to block action to be more consistent with other social media platforms.