### PR TITLE
Mark string translatable in View logs

### DIFF
--- a/src/Module/Admin/Logs/View.php
+++ b/src/Module/Admin/Logs/View.php
@@ -108,7 +108,6 @@ class View extends BaseAdmin
 			'$filters'       => $filters,
 			'$filtersvalues' => $filters_valid_values,
 			'$error'         => $error,
-			'$baseurl'       => DI::baseUrl()->get(true),
 			'$logname'       => DI::config()->get('system', 'logfile'),
 		]);
 	}

--- a/src/Module/Admin/Logs/View.php
+++ b/src/Module/Admin/Logs/View.php
@@ -25,7 +25,6 @@ use Friendica\DI;
 use Friendica\Core\Renderer;
 use Friendica\Core\Theme;
 use Friendica\Module\BaseAdmin;
-use Friendica\Model\Log\ParsedLogIterator;
 use Psr\Log\LogLevel;
 
 class View extends BaseAdmin
@@ -81,13 +80,35 @@ class View extends BaseAdmin
 			}
 		}
 		return Renderer::replaceMacros($t, [
-			'$title'         => DI::l10n()->t('Administration'),
-			'$page'          => DI::l10n()->t('View Logs'),
+			'$title' => DI::l10n()->t('Administration'),
+			'$page'  => DI::l10n()->t('View Logs'),
+			'$l10n'  => [
+				'Search'                => DI::l10n()->t('Search'),
+				'Search_in_logs'        => DI::l10n()->t('Search in logs'),
+				'Show_all'              => DI::l10n()->t('Show all'),
+				'Date'                  => DI::l10n()->t('Date'),
+				'Level'                 => DI::l10n()->t('Level'),
+				'Context'               => DI::l10n()->t('Context'),
+				'Message'               => DI::l10n()->t('Message'),
+				'ALL'                   => DI::l10n()->t('ALL'),
+				'View_details'          => DI::l10n()->t('View details'),
+				'Click_to_view_details' => DI::l10n()->t('Click to view details'),
+				'Event_details'         => DI::l10n()->t('Event details'),
+				'Data'                  => DI::l10n()->t('Data'),
+				'Source'                => DI::l10n()->t('Source'),
+				'File'                  => DI::l10n()->t('File'),
+				'Line'                  => DI::l10n()->t('Line'),
+				'Function'              => DI::l10n()->t('Function'),
+				'UID'                   => DI::l10n()->t('UID'),
+				'Process_ID'            => DI::l10n()->t('Process ID'),
+				'Close'                 => DI::l10n()->t('Close'),
+			],
 			'$data'          => $data,
 			'$q'             => $search,
 			'$filters'       => $filters,
 			'$filtersvalues' => $filters_valid_values,
 			'$error'         => $error,
+			'$baseurl'       => DI::baseUrl()->get(true),
 			'$logname'       => DI::config()->get('system', 'logfile'),
 		]);
 	}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2021.12-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-01 13:53+0200\n"
+"POT-Creation-Date: 2021-10-01 16:40+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -559,6 +559,7 @@ msgstr ""
 
 #: mod/editpost.php:134 src/Content/Conversation.php:380
 #: src/Content/Widget/VCard.php:107 src/Model/Profile.php:459
+#: src/Module/Admin/Logs/View.php:93
 msgid "Message"
 msgstr ""
 
@@ -588,7 +589,7 @@ msgstr ""
 msgid "Create New Event"
 msgstr ""
 
-#: mod/events.php:536
+#: mod/events.php:536 src/Module/Admin/Logs/View.php:97
 msgid "Event details"
 msgstr ""
 
@@ -3165,7 +3166,7 @@ msgid "Addon applications, utilities, games"
 msgstr ""
 
 #: src/Content/Nav.php:230 src/Content/Text/HTML.php:891
-#: src/Module/Search/Index.php:99
+#: src/Module/Admin/Logs/View.php:87 src/Module/Search/Index.php:99
 msgid "Search"
 msgstr ""
 
@@ -5483,7 +5484,7 @@ msgstr ""
 msgid "Implicit Mention"
 msgstr ""
 
-#: src/Module/Admin/Item/Source.php:73
+#: src/Module/Admin/Item/Source.php:73 src/Module/Admin/Logs/View.php:99
 #: src/Module/Debug/ActivityPubConversion.php:62
 msgid "Source"
 msgstr ""
@@ -5557,6 +5558,67 @@ msgstr ""
 
 #: src/Module/Admin/Logs/View.php:85 src/Module/BaseAdmin.php:110
 msgid "View Logs"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:88
+msgid "Search in logs"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:89
+#: src/Module/Notifications/Notifications.php:138
+msgid "Show all"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:90
+msgid "Date"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:91
+msgid "Level"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:92
+msgid "Context"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:94
+msgid "ALL"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:95
+msgid "View details"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:96
+msgid "Click to view details"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:98
+msgid "Data"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:100
+msgid "File"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:101
+msgid "Line"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:102
+msgid "Function"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:103
+msgid "UID"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:104
+msgid "Process ID"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:105
+msgid "Close"
 msgstr ""
 
 #: src/Module/Admin/Queue.php:50
@@ -8691,10 +8753,6 @@ msgstr ""
 
 #: src/Module/Notifications/Notifications.php:138
 msgid "Show unread"
-msgstr ""
-
-#: src/Module/Notifications/Notifications.php:138
-msgid "Show all"
 msgstr ""
 
 #: src/Module/OAuth/Acknowledge.php:44

--- a/view/templates/admin/logs/view.tpl
+++ b/view/templates/admin/logs/view.tpl
@@ -9,16 +9,16 @@
 	{{else}}
 		<form>
 			<p>
-				<input type="search" name="q" value="{{$q}}" placeholder="search"></input>
-				<input type="Submit" value="search">
-				<a href="/admin/logs/view">clear</a>
+				<input type="search" name="q" value="{{$q}}" placeholder="{{$l10n.Search}}"></input>
+				<input type="submit" value="{{$l10n.Search}}">
+				<a href="/admin/logs/view">{{$l10n.Show_all}}</a>
 			</p>
 
 
 			<table>
 				<thead>
 					<tr>
-						<th>Date</th>
+						<th>{{$l10n.Date}}</th>
 						<th>
 							<select name="level" onchange="this.form.submit()">
 								{{foreach $filtersvalues.level as $v }}
@@ -39,22 +39,22 @@
 								{{/foreach}}
 							</select>
 						</th>
-						<th>Message</th>
+						<th>{{$l10n.Message}}</th>
 					</tr>
 				</thead>
 				<tbody>
 					{{foreach $data as $row}}
 						<tr id="ev-{{$row->id}}" class="log-event"
 						 role="button" tabIndex="0"
-						 aria-label="View details" aria-haspopup="true" aria-expanded="false"
+						 aria-label="{{$l10n.View_details}}" aria-haspopup="true" aria-expanded="false"
 						 style="cursor:pointer;"
-						 title="Click to view details">
+						 title="{{$l10n.Click_to_view_details}}">
 							<td>{{$row->date}}</td>
 							<td>{{$row->level}}</td>
 							<td>{{$row->context}}</td>
 							<td>{{$row->message}}</td>
 						</tr>
-						<tr class="hidden" data-id="ev-{{$row->id}}"><th colspan="4">Data</th></tr>
+						<tr class="hidden" data-id="ev-{{$row->id}}"><th colspan="4">{{$l10n.Event_details}}</th></tr>
 						{{foreach $row->getData() as $k=>$v}}
 							<tr class="hidden" data-id="ev-{{$row->id}}">
 								<th>{{$k}}</th>
@@ -63,7 +63,7 @@
 								</td>
 							</tr>
 						{{/foreach}}
-						<tr class="hidden" data-id="ev-{{$row->id}}"><th colspan="4">Source</th></tr>
+						<tr class="hidden" data-id="ev-{{$row->id}}"><th colspan="4">{{$l10n.Source}}</th></tr>
 						{{foreach $row->getSource() as $k=>$v}}
 							<tr class="hidden" data-id="ev-{{$row->id}}">
 								<th>{{$k}}</th>

--- a/view/theme/frio/templates/admin/logs/view.tpl
+++ b/view/theme/frio/templates/admin/logs/view.tpl
@@ -8,33 +8,33 @@
 		</div>
 	{{else}}
 		<form method="get" class="row">
-			<div class="col-xs-10">
+			<div class="col-xs-8">
 				<div class="form-group form-group-search">
 					<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
-						type="text" name="q" data-toggle="tooltip" title="Search in logs"
-						placeholder="Search" value="{{$q}}">
+						type="text" name="q" data-toggle="tooltip" title="{{$l10n.Search_in_logs}}"
+						placeholder="{{$l10n.Search}}" value="{{$q}}">
 					<button class="btn btn-default btn-sm form-button-search"
-						type="submit">Search</button>
+						type="submit">{{$l10n.Search}}</button>
 				</div>
 			</div>
-			<div class="xol-xs-2">
-				<a href="/admin/logs/view" class="btn btn-default">Show all</a>
+			<div class="xol-xs-4">
+				<a href="/admin/logs/view" class="btn btn-default">{{$l10n.Show_all}}</a>
 			</div>
 		</form>
 
 		<table class="table table-hover">
 			<thead>
 				<tr>
-					<th>Date</th>
+					<th>{{$l10n.Date}}</th>
 					<th class="dropdown">
 						<a class="dropdown-toggle text-nowrap" type="button" id="level" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-							Level {{if $filters.level}}({{$filters.level}}){{/if}}<span class="caret"></span>
+							{{$l10n.Level}} {{if $filters.level}}({{$filters.level}}){{/if}}<span class="caret"></span>
 						</a>
 						<ul class="dropdown-menu" aria-labelledby="level">
 							{{foreach $filtersvalues.level as $v }}
 								<li {{if $filters.level == $v}}class="active"{{/if}}>
 									<a href="/admin/logs/view?level={{$v}}" data-filter="level" data-filter-value="{{$v}}">
-										{{if $v == ""}}ALL{{/if}}{{$v}}
+										{{if $v == ""}}{{$l10n.ALL}}{{/if}}{{$v}}
 									</a>
 								</li>
 							{{/foreach}}
@@ -42,26 +42,26 @@
 					</th>
 					<th class="dropdown">
 						<a class="dropdown-toggle text-nowrap" type="button" id="context" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-							Context {{if $filters.context}}({{$filters.context}}){{/if}}<span class="caret"></span>
+							{{$l10n.Context}} {{if $filters.context}}({{$filters.context}}){{/if}}<span class="caret"></span>
 						</a>
 						<ul class="dropdown-menu" aria-labelledby="context">
 							{{foreach $filtersvalues.context as $v }}
 								<li {{if $filters.context == $v}}class="active"{{/if}}>
 									<a href="/admin/logs/view?context={{$v}}" data-filter="context" data-filter-value="{{$v}}">
-										{{if $v == ""}}ALL{{/if}}{{$v}}
+										{{if $v == ""}}{{$l10n.ALL}}{{/if}}{{$v}}
 									</a>
 								</li>
 							{{/foreach}}
 						</ul>
 					</th>
-					<th>Message</th>
+					<th>{{$l10n.Message}}</th>
 				</tr>
 			</thead>
 			<tbody>
 				{{foreach $data as $row}}
 				<tr id="ev-{{$row->id}}" class="log-event" 
 					role="button" tabIndex="0"
-					aria-label="View details" aria-haspopup="true" aria-expanded="false"
+					aria-label="{{$l10n.View_details}}" aria-haspopup="true" aria-expanded="false"
 					data-data="{{$row->data}}" data-source="{{$row->source}}">
 					<td>{{$row->date}}</td>
 					<td class="
@@ -86,16 +86,16 @@
 		<div class="modal-content">
 			<div class="modal-header">
 				<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-				<h4 class="modal-title">Event details</h4>
+				<h4 class="modal-title">{{$l10n.Event_details}}</h4>
 			</div>
 			<div class="modal-body">
 				<table class="table main-data">
 					<thead>
 						<tr>
-							<th>Date</th>
-							<th>Level</th>
-							<th>Context</th>
-							<th>Message</th>
+							<th>{{$l10n.Date}}</th>
+							<th>{{$l10n.Level}}</th>
+							<th>{{$l10n.Context}}</th>
+							<th>{{$l10n.Message}}</th>
 						</tr>
 					</thead>
 					<tbody><tr></tr></tbody>
@@ -103,11 +103,11 @@
 				<table class="table source-data">
 					<thead>
 						<tr>
-							<th>File</th>
-							<th>Line</th>
-							<th>Function</th>
-							<th>UID</th>
-							<th>Process ID</th>
+							<th>{{$l10n.File}}</th>
+							<th>{{$l10n.Line}}</th>
+							<th>{{$l10n.Function}}</th>
+							<th>{{$l10n.UID}}</th>
+							<th>{{$l10n.Process_ID}}</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -131,7 +131,7 @@
 			<div class="modal-footer">
 				<button type="button" class="btn btn-default" data-previous>&lt;</button>
 				<button type="button" class="btn btn-default" data-next>&gt;</button>
-				<button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+				<button type="button" class="btn btn-primary" data-dismiss="modal">{{$l10n.Close}}</button>
 			</div>
 		</div><!-- /.modal-content -->
 	</div><!-- /.modal-dialog -->


### PR DESCRIPTION
and update messages.po

should fix #10767 

level and context filters values are not translated , because they are as they appear in log messages (which are not translated, also...)