### PR TITLE
Don't store emoji images as media but links

### DIFF
--- a/src/Model/Post/Link.php
+++ b/src/Model/Post/Link.php
@@ -36,6 +36,18 @@ use Friendica\Util\Proxy;
  */
 class Link
 {
+	/**
+	 * Check if the link is stored
+	 *
+	 * @param int $uri_id
+	 * @param string $url
+	 * @return bool
+	 */
+	public static function exists(int $uri_id, string $url)
+	{
+		return DBA::exists('post-link', ['uri-id' => $uri_id, 'url' => $url]);
+	}
+
 	public static function getByLink(int $uri_id, string $url, $size = '')
 	{
 		if (empty($uri_id) || empty($url) || Proxy::isLocalImage($url)) {

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -388,6 +388,10 @@ class Media
 		}
 
 		foreach ($attachments as $attachment) {
+			if (Post\Link::exists($uriid, $attachment['preview'] ?? $attachment['url'])) {
+				continue;
+			}
+
 			// Only store attachments that are part of the unshared body
 			if (Item::containsLink($unshared_body, $attachment['preview'] ?? $attachment['url'], $attachment['type'])) {
 				self::insert($attachment);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -90,7 +90,7 @@ class Processor
 	 *
 	 * @return string with replaced emojis
 	 */
-	private static function replaceEmojis($body, array $emojis)
+	private static function replaceEmojis(int $uri_id, $body, array $emojis)
 	{
 		$body = strtr($body,
 			array_combine(
@@ -101,6 +101,10 @@ class Processor
 			)
 		);
 
+		// We store the emoji here to be able to avoid storing it in the media
+		foreach ($emojis as $emoji) {
+			Post\Link::getByLink($uri_id, $emoji['href']);
+		}
 		return $body;
 	}
 
@@ -392,7 +396,7 @@ class Processor
 	 *
 	 * @param array $activity Activity array
 	 * @param array $item
-	 * 
+	 *
 	 * @return int event id
 	 * @throws \Exception
 	 */
@@ -456,7 +460,7 @@ class Processor
 		}
 
 		if (!empty($activity['emojis'])) {
-			$content = self::replaceEmojis($content, $activity['emojis']);
+			$content = self::replaceEmojis($item['uri-id'], $content, $activity['emojis']);
 		}
 
 		$content = self::addMentionLinks($content, $activity['tags']);


### PR DESCRIPTION
This avoids that the emojis are displayed when searching for posts with media.