### PR TITLE
Check if the string representation of Notify->link is empty in Module\Notifications\Notification

### DIFF
--- a/src/Module/Notifications/Notification.php
+++ b/src/Module/Notifications/Notification.php
@@ -124,7 +124,7 @@ class Notification extends BaseModule
 				DI::notify()->setAllSeenForRelatedNotify($Notify);
 			}
 
-			if ($Notify->link) {
+			if ((string)$Notify->link) {
 				System::externalRedirect($Notify->link);
 			}
 


### PR DESCRIPTION
Follow-up #10722

- The property is a Url object which will always return true when tested for truthy value