### PR TITLE
Drone - Don't deploy artifacts with config files

### DIFF
--- a/mods/release-list-include.txt
+++ b/mods/release-list-include.txt
@@ -7,7 +7,8 @@ bin/daemon.php
 bin/testargs.php
 bin/wait-for-connection
 bin/worker.php
-config/
+config/addon-sample.config.php
+config/local-sample.config.php
 doc/
 images/
 include/


### PR DESCRIPTION
Closes #10829 

In fact this only happens in case Sombody(TM) uses the include/exclude list locally.. But nobody should do that.. *hust hust*