### PR TITLE
Fix overly strict return value for terminateFriendship methods

### DIFF
--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -137,21 +137,14 @@ function unfollow_process(string $url)
 		// NOTREACHED
 	}
 
-	$notice_message = '';
 	$return_path = $base_return_path . '/' . $contact['id'];
 
 	try {
 		$result = Contact::terminateFriendship($owner, $contact);
 
-		if ($result === null) {
-			$notice_message = DI::l10n()->t('Unfollowing is currently not supported by this contact\'s network.');
-		}
-
 		if ($result === false) {
 			$notice_message = DI::l10n()->t('Unable to unfollow this contact, please retry in a few minutes or contact your administrator.');
-		}
-
-		if ($result === true) {
+		} else {
 			$notice_message = DI::l10n()->t('Contact was successfully unfollowed');
 		}
 	} catch (Exception $e) {

--- a/src/Core/Protocol.php
+++ b/src/Core/Protocol.php
@@ -213,11 +213,11 @@ class Protocol
 	 *
 	 * @param array   $user    User unfriending
 	 * @param array   $contact Contact unfriended
-	 * @return bool|null true if successful, false if not, null if no action was performed
+	 * @return bool|null true if successful, false if not, null if no remote action was performed
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function terminateFriendship(array $user, array $contact): bool
+	public static function terminateFriendship(array $user, array $contact): ?bool
 	{
 		if (empty($contact['network'])) {
 			throw new \InvalidArgumentException('Missing network key in contact array');

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -832,11 +832,11 @@ class Contact
 	 * @param array   $user    User unfriending
 	 * @param array   $contact Contact (uid != 0) unfriended
 	 * @param boolean $two_way Revoke eventual inbound follow as well
-	 * @return bool|null true if successful, false if not, null if no action was performed
+	 * @return bool|null true if successful, false if not, null if no remote action was performed
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function terminateFriendship(array $user, array $contact): bool
+	public static function terminateFriendship(array $user, array $contact): ?bool
 	{
 		$result = Protocol::terminateFriendship($user, $contact);
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2021.12-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-04 06:26+0000\n"
+"POT-Creation-Date: 2021-10-07 11:32-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -442,7 +442,7 @@ msgid "Edit post"
 msgstr ""
 
 #: mod/editpost.php:91 mod/notes.php:56 src/Content/Text/HTML.php:885
-#: src/Module/Admin/Storage.php:135 src/Module/Filer/SaveTag.php:69
+#: src/Module/Admin/Storage.php:143 src/Module/Filer/SaveTag.php:69
 msgid "Save"
 msgstr ""
 
@@ -2284,21 +2284,17 @@ msgstr ""
 msgid "Disconnect/Unfollow"
 msgstr ""
 
-#: mod/unfollow.php:147
-msgid "Unfollowing is currently not supported by this contact's network."
-msgstr ""
-
-#: mod/unfollow.php:151
+#: mod/unfollow.php:146
 msgid ""
 "Unable to unfollow this contact, please retry in a few minutes or contact "
 "your administrator."
 msgstr ""
 
-#: mod/unfollow.php:155
+#: mod/unfollow.php:148
 msgid "Contact was successfully unfollowed"
 msgstr ""
 
-#: mod/unfollow.php:159
+#: mod/unfollow.php:152
 msgid "Unable to unfollow this contact, please contact your administrator"
 msgstr ""
 
@@ -4324,63 +4320,63 @@ msgstr ""
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:2370
+#: src/Model/Contact.php:2366
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:2375 src/Module/Friendica.php:81
+#: src/Model/Contact.php:2371 src/Module/Friendica.php:81
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:2380
+#: src/Model/Contact.php:2376
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:2389
+#: src/Model/Contact.php:2385
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:2426
+#: src/Model/Contact.php:2422
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:2428
+#: src/Model/Contact.php:2424
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:2431
+#: src/Model/Contact.php:2427
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:2434
+#: src/Model/Contact.php:2430
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:2437
+#: src/Model/Contact.php:2433
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:2438
+#: src/Model/Contact.php:2434
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:2444
+#: src/Model/Contact.php:2440
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:2449
+#: src/Model/Contact.php:2445
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:2508
+#: src/Model/Contact.php:2504
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -4591,17 +4587,17 @@ msgstr ""
 msgid "OpenWebAuth: %1$s welcomes %2$s"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:187
+#: src/Model/Storage/FilesystemConfig.php:77
 msgid "Storage base path"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:189
+#: src/Model/Storage/FilesystemConfig.php:79
 msgid ""
 "Folder where uploaded files are saved. For maximum security, This should be "
 "a path outside web server folder tree"
 msgstr ""
 
-#: src/Model/Storage/Filesystem.php:202
+#: src/Model/Storage/FilesystemConfig.php:92
 msgid "Enter a valid existing folder"
 msgstr ""
 
@@ -4884,7 +4880,7 @@ msgstr ""
 #: src/Module/Admin/Blocklist/Server.php:88 src/Module/Admin/Federation.php:159
 #: src/Module/Admin/Item/Delete.php:65 src/Module/Admin/Logs/Settings.php:80
 #: src/Module/Admin/Logs/View.php:83 src/Module/Admin/Queue.php:72
-#: src/Module/Admin/Site.php:497 src/Module/Admin/Storage.php:131
+#: src/Module/Admin/Site.php:497 src/Module/Admin/Storage.php:139
 #: src/Module/Admin/Summary.php:233 src/Module/Admin/Themes/Details.php:90
 #: src/Module/Admin/Themes/Index.php:111 src/Module/Admin/Tos.php:58
 #: src/Module/Admin/Users/Active.php:136 src/Module/Admin/Users/Blocked.php:137
@@ -6403,49 +6399,49 @@ msgstr ""
 msgid "Start Relocation"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:45
+#: src/Module/Admin/Storage.php:46
 #, php-format
 msgid "Storage backend, %s is invalid."
 msgstr ""
 
-#: src/Module/Admin/Storage.php:71
+#: src/Module/Admin/Storage.php:73
 #, php-format
 msgid "Storage backend %s error: %s"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:82 src/Module/Admin/Storage.php:85
+#: src/Module/Admin/Storage.php:85 src/Module/Admin/Storage.php:88
 msgid "Invalid storage backend setting value."
 msgstr ""
 
-#: src/Module/Admin/Storage.php:132
+#: src/Module/Admin/Storage.php:140
 msgid "Current Storage Backend"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:133
+#: src/Module/Admin/Storage.php:141
 msgid "Storage Configuration"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:134 src/Module/BaseAdmin.php:91
+#: src/Module/Admin/Storage.php:142 src/Module/BaseAdmin.php:91
 msgid "Storage"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:136
+#: src/Module/Admin/Storage.php:144
 msgid "Save & Use storage backend"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:137
+#: src/Module/Admin/Storage.php:145
 msgid "Use storage backend"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:138
+#: src/Module/Admin/Storage.php:146
 msgid "Save & Reload"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:139
+#: src/Module/Admin/Storage.php:147
 msgid "This backend doesn't have custom settings"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:142
+#: src/Module/Admin/Storage.php:150
 msgid "Database (legacy)"
 msgstr ""
 
@@ -8666,21 +8662,21 @@ msgstr ""
 msgid "Visible to:"
 msgstr ""
 
-#: src/Module/Photo.php:117
+#: src/Module/Photo.php:122
 msgid "The Photo is not available."
 msgstr ""
 
-#: src/Module/Photo.php:130
+#: src/Module/Photo.php:135
 #, php-format
 msgid "The Photo with id %s is not available."
 msgstr ""
 
-#: src/Module/Photo.php:163
+#: src/Module/Photo.php:168
 #, php-format
 msgid "Invalid external resource with url %s."
 msgstr ""
 
-#: src/Module/Photo.php:165
+#: src/Module/Photo.php:170
 #, php-format
 msgid "Invalid photo with id %s."
 msgstr ""
@@ -8743,19 +8739,19 @@ msgstr ""
 
 #: src/Module/Profile/Profile.php:326 src/Module/Profile/Profile.php:329
 #: src/Module/Profile/Status.php:65 src/Module/Profile/Status.php:68
-#: src/Protocol/Feed.php:953 src/Protocol/OStatus.php:1259
+#: src/Protocol/Feed.php:953 src/Protocol/OStatus.php:1242
 #, php-format
 msgid "%s's timeline"
 msgstr ""
 
 #: src/Module/Profile/Profile.php:327 src/Module/Profile/Status.php:66
-#: src/Protocol/Feed.php:957 src/Protocol/OStatus.php:1263
+#: src/Protocol/Feed.php:957 src/Protocol/OStatus.php:1246
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
 #: src/Module/Profile/Profile.php:328 src/Module/Profile/Status.php:67
-#: src/Protocol/Feed.php:960 src/Protocol/OStatus.php:1266
+#: src/Protocol/Feed.php:960 src/Protocol/OStatus.php:1249
 #, php-format
 msgid "%s's comments"
 msgstr ""
@@ -10459,21 +10455,21 @@ msgstr ""
 msgid "Attachments:"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1761
+#: src/Protocol/OStatus.php:1645
 #, php-format
 msgid "%s is now following %s."
 msgstr ""
 
-#: src/Protocol/OStatus.php:1762
+#: src/Protocol/OStatus.php:1646
 msgid "following"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1765
+#: src/Protocol/OStatus.php:1649
 #, php-format
 msgid "%s stopped following %s."
 msgstr ""
 
-#: src/Protocol/OStatus.php:1766
+#: src/Protocol/OStatus.php:1650
 msgid "stopped following"
 msgstr ""
 


### PR DESCRIPTION
Part of #10844

@copiis Once you pull this, please try to unfollow your Twitter contact again and report any error.