### PR TITLE
Replace remaining explicit network value checks by Protocol::supportsFollow calls

### DIFF
--- a/mod/unfollow.php
+++ b/mod/unfollow.php
@@ -67,7 +67,7 @@ function unfollow_content(App $a)
 		// NOTREACHED
 	}
 
-	if (!in_array($contact['network'], Protocol::NATIVE_SUPPORT)) {
+	if (!Protocol::supportsFollow($contact['network'])) {
 		notice(DI::l10n()->t('Unfollowing is currently not supported by your network.'));
 		DI::baseUrl()->redirect($base_return_path . '/' . $contact['id']);
 		// NOTREACHED

--- a/src/Console/Contact.php
+++ b/src/Console/Contact.php
@@ -203,10 +203,6 @@ HELP;
 
 		try {
 			$result = ContactModel::terminateFriendship($user, $contact);
-			if ($result === null) {
-				throw new RuntimeException('Unfollowing is currently not supported by this contact\'s network.');
-			}
-
 			if ($result === false) {
 				throw new RuntimeException('Unable to unfollow this contact, please retry in a few minutes or check the logs.');
 			}
@@ -222,8 +218,6 @@ HELP;
 
 	/**
 	 * Marks a contact for removal
-	 *
-	 * @return bool True, if the command was successful
 	 */
 	private function removeContact()
 	{
@@ -236,7 +230,7 @@ HELP;
 			}
 		}
 
-		$result = ContactModel::remove($cid);
+		ContactModel::remove($cid);
 	}
 
 	/**

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -75,7 +75,7 @@ class VCard
 				$pending = $pcontact['pending'] ?? false;
 			}
 
-			if (!$contact['self'] && in_array($contact['network'], Protocol::NATIVE_SUPPORT)) {
+			if (!$contact['self'] && Protocol::supportsFollow($contact['network'])) {
 				if (in_array($rel, [Contact::SHARING, Contact::FRIEND])) {
 					$unfollow_link = 'unfollow?url=' . urlencode($contact['url']) . '&auto=1';
 				} elseif (!$pending) {

--- a/src/Model/Contact/User.php
+++ b/src/Model/Contact/User.php
@@ -148,9 +148,9 @@ class User
 
 		$contact = Contact::getById($cdata['public']);
 		if ($blocked) {
-			Protocol::block($contact);
+			Protocol::block($contact, $uid);
 		} else {
-			Protocol::unblock($contact);
+			Protocol::unblock($contact, $uid);
 		}
 
 		if ($cdata['user'] != 0) {


### PR DESCRIPTION
Part of https://github.com/friendica/friendica/issues/10844

Related to https://github.com/friendica/friendica-addons/pull/1186

Additionally, it fixes the block/unblock actions and removes a confusing message in the contact console command.