### PR TITLE
replace "p" with higher level database functions

### DIFF
--- a/mod/msearch.php
+++ b/mod/msearch.php
@@ -45,20 +45,6 @@ function msearch_post(App $a)
 
 	$condition = ["`net-publish` AND MATCH(`pub_keywords`) AGAINST (?)", $search];
 	$total = DBA::count('owner-view', $condition);
-	$count_stmt = DBA::p(
-		"SELECT COUNT(*) AS `total`
-			FROM `profile`
-		  	JOIN `user` ON `user`.`uid` = `profile`.`uid`
-			WHERE `profile`.`net-publish`
-		  	AND MATCH(`pub_keywords`) AGAINST (?)",
-		$search
-	);
-	if (DBA::isResult($count_stmt)) {
-		$row = DBA::fetch($count_stmt);
-		$total = $row['total'];
-	}
-
-	DBA::close($count_stmt);
 
 	$search_stmt = DBA::select('owner-view', ['pub_keywords', 'name', 'nickname', 'uid'], $condition, ['limit' => [$startrec, $perpage]]);
 	while ($search_result = DBA::fetch($search_stmt)) {

--- a/mod/msearch.php
+++ b/mod/msearch.php
@@ -43,6 +43,8 @@ function msearch_post(App $a)
 
 	$total = 0;
 
+	$condition = ["`net-publish` AND MATCH(`pub_keywords`) AGAINST (?)", $search];
+	$total = DBA::count('owner-view', $condition);
 	$count_stmt = DBA::p(
 		"SELECT COUNT(*) AS `total`
 			FROM `profile`
@@ -58,18 +60,7 @@ function msearch_post(App $a)
 
 	DBA::close($count_stmt);
 
-	$search_stmt = DBA::p(
-		"SELECT `pub_keywords`, `username`, `nickname`, `user`.`uid`
-			FROM `user`
-			JOIN `profile` ON `user`.`uid` = `profile`.`uid`
-			WHERE `profile`.`net-publish`
-			AND MATCH(`pub_keywords`) AGAINST (?)
-			LIMIT ?, ?",
-		$search,
-		$startrec,
-		$perpage
-	);
-
+	$search_stmt = DBA::select('owner-view', ['pub_keywords', 'name', 'nickname', 'uid'], $condition, ['limit' => [$startrec, $perpage]]);
 	while ($search_result = DBA::fetch($search_stmt)) {
 		$results[] = [
 			'name'  => $search_result['name'],

--- a/src/Console/FixAPDeliveryWorkerTaskParameters.php
+++ b/src/Console/FixAPDeliveryWorkerTaskParameters.php
@@ -106,7 +106,7 @@ HELP;
 		$this->errored = 0;
 
 		do {
-			$result = $this->dba->p('SELECT `id`, `parameter` FROM `workerqueue` WHERE `command` = "APDelivery" AND `parameter` LIKE "[\"%\",\"\",%" LIMIT ' . $this->examined . ', 100');
+			$result = $this->dba->select('workerqueue', ['id', 'parameter'], ["`command` = ? AND `parameter` LIKE ?", "APDelivery", "[\"%\",\"\",%"], ['limit' => [$this->examined, 100]]);
 			while ($row = $this->dba->fetch($result)) {
 				$this->examined++;
 				$this->processRow($row);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -3022,7 +3022,7 @@ class Contact
 			$networks[] = Protocol::OSTATUS;
 		}
 
-		$condition = ['network' => $networks, 'failed' => false, 'uid' => $uid];
+		$condition = ['network' => $networks, 'failed' => false, 'deleted' => false, 'uid' => $uid];
 
 		// check if we search only communities or every contact
 		if ($mode === 'community') {
@@ -3032,7 +3032,7 @@ class Contact
 		$search .= '%';
 
 		$condition = DBA::mergeConditions($condition,
-			["(NOT `unsearchable` OR `nurl` IN (SELECT `nurl` FROM `owner-view` where `publish` OR `net-publish`))
+			["(NOT `unsearchable` OR `nurl` IN (SELECT `nurl` FROM `owner-view` WHERE `publish` OR `net-publish`))
 			AND (`addr` LIKE ? OR `name` LIKE ? OR `nick` LIKE ?)", $search, $search, $search]);
 
 		$contacts = self::selectToArray([], $condition);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -3013,37 +3013,29 @@ class Contact
 		}
 
 		// check supported networks
+		$networks = [Protocol::DFRN, Protocol::ACTIVITYPUB];
 		if (DI::config()->get('system', 'diaspora_enabled')) {
-			$diaspora = Protocol::DIASPORA;
-		} else {
-			$diaspora = Protocol::DFRN;
+			$networks[] = Protocol::DIASPORA;
 		}
 
 		if (!DI::config()->get('system', 'ostatus_disabled')) {
-			$ostatus = Protocol::OSTATUS;
-		} else {
-			$ostatus = Protocol::DFRN;
+			$networks[] = Protocol::OSTATUS;
 		}
+
+		$condition = ['network' => $networks, 'failed' => false, 'uid' => $uid];
 
 		// check if we search only communities or every contact
 		if ($mode === 'community') {
-			$extra_sql = sprintf(' AND `contact-type` = %d', self::TYPE_COMMUNITY);
-		} else {
-			$extra_sql = '';
+			$condition['contact-type'] = self::TYPE_COMMUNITY;
 		}
 
 		$search .= '%';
 
-		$results = DBA::p("SELECT * FROM `contact`
-			WHERE (NOT `unsearchable` OR `nurl` IN (SELECT `nurl` FROM `owner-view` where `publish` OR `net-publish`))
-				AND `network` IN (?, ?, ?, ?) AND
-				NOT `failed` AND `uid` = ? AND
-				(`addr` LIKE ? OR `name` LIKE ? OR `nick` LIKE ?) $extra_sql
-				ORDER BY `nurl` DESC LIMIT 1000",
-			Protocol::DFRN, Protocol::ACTIVITYPUB, $ostatus, $diaspora, $uid, $search, $search, $search
-		);
+		$condition = DBA::mergeConditions($condition,
+			["(NOT `unsearchable` OR `nurl` IN (SELECT `nurl` FROM `owner-view` where `publish` OR `net-publish`))
+			AND (`addr` LIKE ? OR `name` LIKE ? OR `nick` LIKE ?)", $search, $search, $search]);
 
-		$contacts = DBA::toArray($results);
+		$contacts = self::selectToArray([], $condition);
 		return $contacts;
 	}
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -3024,6 +3024,10 @@ class Contact
 
 		$condition = ['network' => $networks, 'failed' => false, 'deleted' => false, 'uid' => $uid];
 
+		if ($uid == 0) {
+			$condition['blocked'] = false;
+		}
+
 		// check if we search only communities or every contact
 		if ($mode === 'community') {
 			$condition['contact-type'] = self::TYPE_COMMUNITY;

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -1667,14 +1667,10 @@ class GServer
 
 		$last_update = date('c', time() - (60 * 60 * 24 * $requery_days));
 
-		$gservers = DBA::p("SELECT `id`, `url`, `nurl`, `network`, `poco`, `directory-type`
-			FROM `gserver`
-			WHERE NOT `failed`
-			AND `directory-type` != ?
-			AND `last_poco_query` < ?
-			ORDER BY RAND()", self::DT_NONE, $last_update
-		);
-
+		$gservers = DBA::select('gserver', ['id', 'url', 'nurl', 'network', 'poco', 'directory-type'],
+			["NOT `failed` AND `directory-type` != ? AND `last_poco_query` < ?", GServer::DT_NONE, $last_update],
+			['order' => ['RAND()']]);
+	
 		while ($gserver = DBA::fetch($gservers)) {
 			Logger::info('Update peer list', ['server' => $gserver['url'], 'id' => $gserver['id']]);
 			Worker::add(PRIORITY_LOW, 'UpdateServerPeers', $gserver['url']);

--- a/src/Worker/ExpireConversations.php
+++ b/src/Worker/ExpireConversations.php
@@ -36,7 +36,6 @@ class ExpireConversations
 			return;
 		}
 
-		DBA::e("DELETE FROM `conversation` WHERE `received` < UTC_TIMESTAMP() - INTERVAL ? DAY", $days);
-
+		DBA::delete('conversation', ["`received` < UTC_TIMESTAMP() - INTERVAL ? DAY", $days]);
 	}
 }

--- a/tests/DatabaseTestTrait.php
+++ b/tests/DatabaseTestTrait.php
@@ -68,7 +68,7 @@ trait DatabaseTestTrait
 			}
 
 			if (!is_array($rows)) {
-				$dba->p('TRUNCATE TABLE `' . $tableName . '``');
+				$dba->e('TRUNCATE TABLE `' . $tableName . '``');
 				continue;
 			}
 


### PR DESCRIPTION
The database function `p` is really low level. We should when possible always use the higher level database calls. This will help on the way to support more databases. Also it unifies the code.