### PR TITLE
Ignore max_id when it's 0 or less in BaseDepository->_selectByBoundaries

### DIFF
--- a/src/BaseDepository.php
+++ b/src/BaseDepository.php
@@ -87,7 +87,7 @@ abstract class BaseDepository
 			}
 		}
 
-		if (isset($max_id)) {
+		if (isset($max_id) && $max_id > 0) {
 			$boundCondition = DBA::mergeConditions($boundCondition, ['`id` < ?', $max_id]);
 			if (!isset($min_id) && (!isset($params['order']['id']) || $params['order']['id'] === false || $params['order']['id'] === 'ASC')) {
 				$reverseOrder = true;

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -124,8 +124,8 @@ class Notifications extends BaseApi
 		$Notifications = DI::notification()->selectByBoundaries(
 			$condition,
 			$params,
-			$request['min_id'] ?? null,
-			$request['min_id'] ?? $request['since_id'] ?? null,
+			$request['min_id'] ?: $request['since_id'],
+			$request['max_id'],
 			$request['limit']
 		);
 


### PR DESCRIPTION
Fixes #10868

This one was fun to debug. It boiled down to a conflict of expectations. `BaseDepository->_selectByBoundaries` expect `min_id` and `max_id` to be `null` when they aren't set.

However, the `BaseApi::getRequest` method doesn't handle `null` as a default value, it must be a typed value, either `''` for strings, `0` for integers, `0.0` for floats, `[]` for arrays, or `false` for boolean values.

So the `Module\Api\Mastodon\Notifications` class was feeding `0` as default values for `min_id` and `max_id` which `BaseDepository->_selectByBoundaries` was using as actual values, creating a SQL condition that amounted to ``AND `id` > 0 AND `id` <= 0`` which always returned an empty set. The count query done in the same method was returning the correct amount of notifications because it doesn't use the boundaries by design.

The fix was to expect `0` as a default value for `min_id` and `max_id` in `BaseDepository->_selectByBoundaries` and while it didn't need any change for `min_id`, the `max_id` condition needed to be excluded for this particular value.

Additionally, it seems the request parameters weren't correctly assigned to the parameters of `Navigation\Notifications\Depository\Notification::selectByBoundaries` which would have prevented the correct usage of the previous/next page link. Of course nobody could have witnessed this additional problem since the notification endpoint was systematically returning an empty set because of the quirk described above.