### PR TITLE
Account for the PUBLIC value for id parameter in Depository\PermissionSet::selectOneById

### DIFF
--- a/src/Model/ProfileField.php
+++ b/src/Model/ProfileField.php
@@ -65,7 +65,7 @@ class ProfileField extends BaseModel
 		switch ($name) {
 			case 'permissionSet':
 				if (empty($this->permissionSet)) {
-					$permissionSet = $this->permissionSetDepository->selectOneById($this->psid);
+					$permissionSet = $this->permissionSetDepository->selectOneById($this->psid, $this->uid);
 					if ($permissionSet->uid !== $this->uid) {
 						throw new NotFoundException(sprintf('PermissionSet %d (user-id: %d) for ProfileField %d (user-id: %d) is invalid.', $permissionSet->id, $permissionSet->uid, $this->id, $this->uid));
 					}

--- a/src/Module/PermissionTooltip.php
+++ b/src/Module/PermissionTooltip.php
@@ -39,7 +39,7 @@ class PermissionTooltip extends \Friendica\BaseModule
 		}
 
 		if (isset($model['psid'])) {
-			$permissionSet = DI::permissionSet()->selectOneById($model['psid']);
+			$permissionSet = DI::permissionSet()->selectOneById($model['psid'], $model['uid']);
 			$model['allow_cid'] = $permissionSet->allow_cid;
 			$model['allow_gid'] = $permissionSet->allow_gid;
 			$model['deny_cid']  = $permissionSet->deny_cid;

--- a/src/Security/PermissionSet/Depository/PermissionSet.php
+++ b/src/Security/PermissionSet/Depository/PermissionSet.php
@@ -89,13 +89,21 @@ class PermissionSet extends BaseDepository
 	}
 
 	/**
-	 * @param int $id
-	 *
+	 * @param int      $id A permissionset table row id or self::PUBLIC
+	 * @param int|null $uid Should be provided when id can be self::PUBLIC
 	 * @return Entity\PermissionSet
 	 * @throws NotFoundException
 	 */
-	public function selectOneById(int $id): Entity\PermissionSet
+	public function selectOneById(int $id, int $uid = null): Entity\PermissionSet
 	{
+		if ($id === self::PUBLIC) {
+			if (empty($uid)) {
+				throw new \InvalidArgumentException('Missing uid for Public permission set instantiation');
+			}
+
+			return $this->factory->createFromString($uid);
+		}
+
 		return $this->selectOne(['id' => $id]);
 	}
 

--- a/tests/src/Security/PermissionSet/Depository/PermissionSetTest.php
+++ b/tests/src/Security/PermissionSet/Depository/PermissionSetTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Friendica\Test\src\Security\PermissionSet\Depository;
+
+use Dice\Dice;
+use Friendica\Database\Database;
+use Friendica\DI;
+use Friendica\Security\PermissionSet\Depository\PermissionSet;
+use Friendica\Test\MockedTest;
+use Friendica\Test\Util\Database\StaticDatabase;
+
+class PermissionSetTest extends MockedTest
+{
+	/** @var PermissionSet */
+	private $depository;
+
+	public function setUp(): void
+	{
+		$dice = (new Dice())
+			->addRules(include __DIR__ . '/../../../../../static/dependencies.config.php')
+			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true]);
+		DI::init($dice);
+
+		$this->depository = DI::permissionSet();
+	}
+
+	public function testSelectOneByIdPublicMissingUid()
+	{
+		$this->expectException(\InvalidArgumentException::class);
+
+		$this->depository->selectOneById(PermissionSet::PUBLIC);
+	}
+
+	public function testSelectOneByIdPublic()
+	{
+		$permissionSet = $this->depository->selectOneById(PermissionSet::PUBLIC, 1);
+
+		$this->assertInstanceOf(\Friendica\Security\PermissionSet\Entity\PermissionSet::class, $permissionSet);
+	}
+}


### PR DESCRIPTION
Fixes #10876 