### PR TITLE
Add PHP8 to Vagrant

### DIFF
--- a/bin/dev/vagrant_provision.sh
+++ b/bin/dev/vagrant_provision.sh
@@ -54,6 +54,14 @@ echo ">>> Installing PHP7"
 apt-get install -qq php libapache2-mod-php php-cli php-mysql php-curl php-gd php-mbstring php-xml imagemagick php-imagick php-zip
 systemctl restart apache2
 
+echo ">>> Installing PHP8"
+apt-get install -qq -y lsb-release ca-certificates apt-transport-https software-properties-common gnupg
+echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/sury-php.list
+wget -qO - https://packages.sury.org/php/apt.gpg | sudo apt-key add -
+apt update
+apt-get install -qq php8.0 php8.0-cli php8.0-mysql php8.0-curl php8.0-gd php8.0-mbstring php8.0-xml php8.0-imagick php8.0-zip
+systemctl restart apache2
+
 #Install mysql
 echo ">>> Installing Mysql"
 debconf-set-selections <<< "mariadb-server mariadb-server/root_password password root"


### PR DESCRIPTION
@tobiasd - Is this OK for you?

I do need PHP8 for unit-tests very often and now you can easily switch between PHP8 and PHP7 during local test installations.