### PR TITLE
Use router parameters in Diaspora\Receive

### DIFF
--- a/src/Console/Test.php
+++ b/src/Console/Test.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2021, the Friendica project
+ *
+ * @license   GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Console;
+
+class Test extends \Asika\SimpleConsole\Console
+{
+	protected $helpOptions = ['h', 'help', '?'];
+
+	protected function getHelp()
+	{
+		$help = <<<HELP
+console test - Placeholder console command
+Usage
+	bin/console test [-h|--help|-?] [-v]
+
+Description
+	Placeholder console command for developer tests
+
+Options
+    -h|--help|-? Show help information
+    -v           Show more debug information.
+HELP;
+		return $help;
+	}
+
+	protected function doExecute()
+	{
+		if ($this->getOption('v')) {
+			$this->out('Class: ' . __CLASS__);
+			$this->out('Arguments: ' . var_export($this->args, true));
+			$this->out('Options: ' . var_export($this->options, true));
+		}
+
+		/*
+		 * Please use this console command for your CLI tests, do not commit anything inside this method.
+		 */
+
+		return 0;
+	}
+}

--- a/src/Core/Console.php
+++ b/src/Core/Console.php
@@ -77,6 +77,8 @@ HELP;
 
 	protected $subConsoles = [
 		'addon'                  => Friendica\Console\Addon::class,
+		'archivecontact'         => Friendica\Console\ArchiveContact::class,
+		'autoinstall'            => Friendica\Console\AutomaticInstallation::class,
 		'cache'                  => Friendica\Console\Cache::class,
 		'config'                 => Friendica\Console\Config::class,
 		'contact'                => Friendica\Console\Contact::class,
@@ -84,21 +86,20 @@ HELP;
 		'docbloxerrorchecker'    => Friendica\Console\DocBloxErrorChecker::class,
 		'dbstructure'            => Friendica\Console\DatabaseStructure::class,
 		'extract'                => Friendica\Console\Extract::class,
+		'fixapdeliveryworkertaskparameters' => Friendica\Console\FixAPDeliveryWorkerTaskParameters::class,
 		'globalcommunityblock'   => Friendica\Console\GlobalCommunityBlock::class,
 		'globalcommunitysilence' => Friendica\Console\GlobalCommunitySilence::class,
-		'archivecontact'         => Friendica\Console\ArchiveContact::class,
-		'autoinstall'            => Friendica\Console\AutomaticInstallation::class,
 		'lock'                   => Friendica\Console\Lock::class,
 		'maintenance'            => Friendica\Console\Maintenance::class,
-		'user'                   => Friendica\Console\User::class,
 		'php2po'                 => Friendica\Console\PhpToPo::class,
-		'po2php'                 => Friendica\Console\PoToPhp::class,
-		'typo'                   => Friendica\Console\Typo::class,
 		'postupdate'             => Friendica\Console\PostUpdate::class,
+		'po2php'                 => Friendica\Console\PoToPhp::class,
+		'relay'                  => Friendica\Console\Relay::class,
 		'serverblock'            => Friendica\Console\ServerBlock::class,
 		'storage'                => Friendica\Console\Storage::class,
-		'relay'                  => Friendica\Console\Relay::class,
-		'fixapdeliveryworkertaskparameters' => Friendica\Console\FixAPDeliveryWorkerTaskParameters::class,
+		'test'                   => Friendica\Console\Test::class,
+		'typo'                   => Friendica\Console\Typo::class,
+		'user'                   => Friendica\Console\User::class,
 	];
 
 	/**

--- a/src/Module/Diaspora/Receive.php
+++ b/src/Module/Diaspora/Receive.php
@@ -51,21 +51,10 @@ class Receive extends BaseModule
 			throw new HTTPException\ForbiddenException(DI::l10n()->t('Access denied.'));
 		}
 
-		$args = DI::args();
-
-		$type = $args->get(1);
-
-		switch ($type) {
-			case 'public':
-				self::receivePublic();
-				break;
-			case 'users':
-				self::receiveUser($args->get(2));
-				break;
-			default:
-				self::$logger->info('Wrong call.');
-				throw new HTTPException\BadRequestException('wrong call.');
-				break;
+		if ($parameters['type'] === 'public') {
+			self::receivePublic();
+		} else if ($parameters['type'] === 'users') {
+			self::receiveUser($parameters['guid']);
 		}
 	}
 

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -409,8 +409,8 @@ return [
 	],
 
 	'/receive' => [
-		'/public'       => [Module\Diaspora\Receive::class, [R::POST]],
-		'/users/{guid}' => [Module\Diaspora\Receive::class, [R::POST]],
+		'/{type:public}'       => [Module\Diaspora\Receive::class, [        R::POST]],
+		'/{type:users}/{guid}' => [Module\Diaspora\Receive::class, [        R::POST]],
 	],
 
 	'/settings' => [


### PR DESCRIPTION
During my tests for #10928, I couldn't help improving a couple parts of the code base:
- Use router parameters in Diaspora\Receive
- Add new developer test console command