### PR TITLE
fix link to media tab in navigation

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -190,7 +190,7 @@ class Nav
 			$nav['usermenu'][] = ['profile/' . $a->getLoggedInUserNickname(), DI::l10n()->t('Status'), '', DI::l10n()->t('Your posts and conversations')];
 			$nav['usermenu'][] = ['profile/' . $a->getLoggedInUserNickname() . '/profile', DI::l10n()->t('Profile'), '', DI::l10n()->t('Your profile page')];
 			$nav['usermenu'][] = ['photos/' . $a->getLoggedInUserNickname(), DI::l10n()->t('Photos'), '', DI::l10n()->t('Your photos')];
-			$nav['usermenu'][] = ['media/' . $a->getLoggedInUserNickname(), DI::l10n()->t('Media'), '', DI::l10n()->t('Your postings with media')];
+			$nav['usermenu'][] = ['profile/' . $a->getLoggedInUserNickname() . '/media', DI::l10n()->t('Media'), '', DI::l10n()->t('Your postings with media')];
 			$nav['usermenu'][] = ['events/', DI::l10n()->t('Events'), '', DI::l10n()->t('Your events')];
 			$nav['usermenu'][] = ['notes/', DI::l10n()->t('Personal notes'), '', DI::l10n()->t('Your personal notes')];
 

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -225,7 +225,7 @@ function frio_remote_nav(App $a, array &$nav_info)
 		$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'], DI::l10n()->t('Status'), '', DI::l10n()->t('Your posts and conversations')];
 		$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'] . '/profile', DI::l10n()->t('Profile'), '', DI::l10n()->t('Your profile page')];
 		$nav_info['nav']['usermenu'][] = [$server_url . '/photos/' . $remoteUser['nick'], DI::l10n()->t('Photos'), '', DI::l10n()->t('Your photos')];
-		$nav_info['nav']['usermenu'][] = [$server_url . '/media/' . $remoteUser['nick'], DI::l10n()->t('Media'), '', DI::l10n()->t('Your postings with media')];
+		$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'] . '/media', DI::l10n()->t('Media'), '', DI::l10n()->t('Your postings with media')];
 		$nav_info['nav']['usermenu'][] = [$server_url . '/events/', DI::l10n()->t('Events'), '', DI::l10n()->t('Your events')];
 
 		// navbar links


### PR DESCRIPTION
In #10904 the wrong link was set, this PR should fix it and really point towards the media tab of the profiles.