### PR TITLE
Add default value for PermissionSet Regex

### DIFF
--- a/src/Security/PermissionSet/Exception/PermissionSetNotFoundException.php
+++ b/src/Security/PermissionSet/Exception/PermissionSetNotFoundException.php
@@ -8,6 +8,6 @@ class PermissionSetNotFoundException extends \RuntimeException
 {
 	public function __construct($message = '', Exception $previous = null)
 	{
-		parent::__construct($message, 500, $previous);
+		parent::__construct($message, 404, $previous);
 	}
 }

--- a/src/Security/PermissionSet/Exception/PermissionSetNotFoundException.php
+++ b/src/Security/PermissionSet/Exception/PermissionSetNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Friendica\Security\PermissionSet\Exception;
+
+use Exception;
+
+class PermissionSetNotFoundException extends \RuntimeException
+{
+	public function __construct($message = '', Exception $previous = null)
+	{
+		parent::__construct($message, 500, $previous);
+	}
+}

--- a/src/Security/PermissionSet/Exception/PermissionSetPersistenceException.php
+++ b/src/Security/PermissionSet/Exception/PermissionSetPersistenceException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Friendica\Security\PermissionSet\Exception;
+
+use Throwable;
+
+class PermissionSetPersistenceException extends \RuntimeException
+{
+	public function __construct($message = "", Throwable $previous = null)
+	{
+		parent::__construct($message, 500, $previous);
+	}
+}

--- a/src/Security/PermissionSet/Repository/PermissionSet.php
+++ b/src/Security/PermissionSet/Repository/PermissionSet.php
@@ -137,7 +137,7 @@ class PermissionSet extends BaseRepository
 				$cid                = $cdata['user'];
 			} else {
 				$public_contact_str = $this->aclFormatter->toString($cid);
-				$user_contact_str   = '<<>>';
+				$user_contact_str   = '';
 			}
 
 			$groups = [];
@@ -155,13 +155,13 @@ class PermissionSet extends BaseRepository
 			}
 
 			if (!empty($user_contact_str)) {
-				$condition = ["`uid` = ? AND (NOT (`deny_cid` REGEXP ? OR `deny_cid` REGEXP ? OR deny_gid REGEXP ?)
-				AND (allow_cid REGEXP ? OR allow_cid REGEXP ? OR allow_gid REGEXP ? OR (allow_cid = '' AND allow_gid = '')))",
+				$condition = ["`uid` = ? AND (NOT (LOCATE(?, `deny_cid`) OR LOCATE(?, `deny_cid`) OR deny_gid REGEXP ?)
+				AND (LOCATE(?, allow_cid) OR LOCATE(?, allow_cid) OR allow_gid REGEXP ? OR (allow_cid = '' AND allow_gid = '')))",
 					$uid, $user_contact_str, $public_contact_str, $group_str,
 					$user_contact_str, $public_contact_str, $group_str];
 			} else {
-				$condition = ["`uid` = ? AND (NOT (`deny_cid` REGEXP ? OR deny_gid REGEXP ?)
-				AND (allow_cid REGEXP ? OR allow_gid REGEXP ? OR (allow_cid = '' AND allow_gid = '')))",
+				$condition = ["`uid` = ? AND (NOT (LOCATE(?, `deny_cid`) OR deny_gid REGEXP ?)
+				AND (LOCATE(?, allow_cid) OR allow_gid REGEXP ? OR (allow_cid = '' AND allow_gid = '')))",
 					$uid, $public_contact_str, $group_str, $public_contact_str, $group_str];
 			}
 

--- a/src/Security/PermissionSet/Repository/PermissionSet.php
+++ b/src/Security/PermissionSet/Repository/PermissionSet.php
@@ -153,7 +153,7 @@ class PermissionSet extends BaseRepository
 				$cid                = $cdata['user'];
 			} else {
 				$public_contact_str = $this->aclFormatter->toString($cid);
-				$user_contact_str   = '';
+				$user_contact_str   = '<<>>';
 			}
 
 			$groups = [];

--- a/src/Security/PermissionSet/Repository/PermissionSet.php
+++ b/src/Security/PermissionSet/Repository/PermissionSet.php
@@ -56,22 +56,6 @@ class PermissionSet extends BaseRepository
 	}
 
 	/**
-	 * replaces the PUBLIC id for the public permissionSet
-	 * (no need to create the default permission set over and over again)
-	 *
-	 * @param $condition
-	 */
-	private function checkPublicSelect(&$condition)
-	{
-		if (empty($condition['allow_cid']) &&
-			empty($condition['allow_gid']) &&
-			empty($condition['deny_cid']) &&
-			empty($condition['deny_gid'])) {
-			$condition['uid'] = self::PUBLIC;
-		}
-	}
-
-	/**
 	 * @param array $condition
 	 * @param array $params
 	 *

--- a/tests/src/Security/PermissionSet/Repository/PermissionSetTest.php
+++ b/tests/src/Security/PermissionSet/Repository/PermissionSetTest.php
@@ -4,6 +4,7 @@ namespace Friendica\Test\src\Security\PermissionSet\Repository;
 
 use Friendica\Database\Database;
 use Friendica\Security\PermissionSet\Collection\PermissionSets;
+use Friendica\Security\PermissionSet\Exception\PermissionSetNotFoundException;
 use Friendica\Security\PermissionSet\Repository\PermissionSet as PermissionSetRepository;
 use Friendica\Security\PermissionSet\Entity\PermissionSet;
 use Friendica\Security\PermissionSet\Factory\PermissionSet as PermissionSetFactory;
@@ -198,7 +199,6 @@ class PermissionSetTest extends FixtureTest
 		/** @var Database $db */
 		$db = $this->dice->create(Database::class);
 
-
 		foreach ($inputPermissionSets as $inputPermissionSet) {
 			$db->insert('permissionset', $inputPermissionSet);
 		}
@@ -207,6 +207,30 @@ class PermissionSetTest extends FixtureTest
 			$permissionSets = $this->repository->selectByContactId($assertion['input']['cid'], $assertion['input']['uid']);
 			self::assertInstanceOf(PermissionSets::class, $permissionSets);
 			self::assertEqualPermissionSets($assertion['output'], $permissionSets);
+		}
+	}
+
+	public function testSelectOneByIdInvalid()
+	{
+		self::expectException(PermissionSetNotFoundException::class);
+		self::expectExceptionMessage('PermissionSet with id -1 for user 42 doesn\'t exist.');
+
+		$this->repository->selectOneById(-1, 42);
+	}
+
+	/**
+	 * @dataProvider dataSet
+	 */
+	public function testSelectOneById(array $inputPermissionSets, array $assertions)
+	{
+		/** @var Database $db */
+		$db = $this->dice->create(Database::class);
+
+		foreach ($inputPermissionSets as $inputPermissionSet) {
+			$db->insert('permissionset', $inputPermissionSet);
+			$id = $db->lastInsertId();
+
+			self::assertInstanceOf(PermissionSet::class, $this->repository->selectOneById($id, $inputPermissionSet['uid']));
 		}
 	}
 }

--- a/tests/src/Security/PermissionSet/Repository/PermissionSetTest.php
+++ b/tests/src/Security/PermissionSet/Repository/PermissionSetTest.php
@@ -105,7 +105,7 @@ class PermissionSetTest extends FixtureTest
 					[
 						'uid'       => 42,
 						'allow_cid' => '',
-						'allow_gid' => '<<>>',
+						'allow_gid' => '',
 						'deny_cid'  => '',
 						'deny_gid'  => '',
 					],
@@ -155,7 +155,7 @@ class PermissionSetTest extends FixtureTest
 					[
 						'uid'       => 42,
 						'allow_cid' => '',
-						'allow_gid' => '<<>>',
+						'allow_gid' => '',
 						'deny_cid'  => '',
 						'deny_gid'  => '',
 					],
@@ -247,7 +247,7 @@ class PermissionSetTest extends FixtureTest
 					[
 						'uid'       => 42,
 						'allow_cid' => '',
-						'allow_gid' => '<<>>',
+						'allow_gid' => '',
 						'deny_cid'  => '',
 						'deny_gid'  => '<2>',
 					],


### PR DESCRIPTION
Closes #10943 

Adds the default value "<<>>" in case we search per regex empty contact-ids.
This is a fix for `mysql 5.7.36`