### PR TITLE
Issue 10947: Send correct accept-header for AP

### DIFF
--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Protocol;
 
+use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Model\APContact;
 use Friendica\Model\User;
@@ -80,9 +81,15 @@ class ActivityPub
 	 */
 	public static function isRequest()
 	{
-		return stristr($_SERVER['HTTP_ACCEPT'] ?? '', 'application/activity+json') ||
+		$isrequest = stristr($_SERVER['HTTP_ACCEPT'] ?? '', 'application/activity+json') ||
 			stristr($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json') ||
 			stristr($_SERVER['HTTP_ACCEPT'] ?? '', 'application/ld+json');
+
+		if ($isrequest) {
+			Logger::debug('Is AP request', ['accept' => $_SERVER['HTTP_ACCEPT'], 'agent' => $_SERVER['HTTP_USER_AGENT'] ?? '']);
+		}
+
+		return $isrequest;
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -69,17 +69,6 @@ class Receiver
 	const TARGET_GLOBAL = 7;
 
 	/**
-	 * Checks if the web request is done for the AP protocol
-	 *
-	 * @return bool is it AP?
-	 */
-	public static function isRequest()
-	{
-		return stristr($_SERVER['HTTP_ACCEPT'] ?? '', 'application/activity+json') ||
-			stristr($_SERVER['HTTP_ACCEPT'] ?? '', 'application/ld+json');
-	}
-
-	/**
 	 * Checks incoming message from the inbox
 	 *
 	 * @param         $body

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -417,7 +417,7 @@ class HTTPSignature
 	 * @return \Friendica\Network\HTTPClient\Capability\ICanHandleHttpResponses CurlResult
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function fetchRaw($request, $uid = 0, $opts = ['accept_content' => ['application/activity+json', 'application/ld+json']])
+	public static function fetchRaw($request, $uid = 0, $opts = ['accept_content' => ['application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"']])
 	{
 		$header = [];
 


### PR DESCRIPTION
Fixes #10947

We now send the correct `accept` header. Also we send it as a single string. It seems as if we sent this as two headers - which could create problems under certain cicrumstances.