### PR TITLE
Drone | check database.sql

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -164,16 +164,6 @@ steps:
       - if ! bin/wait-for-connection $MYSQL_HOST $MYSQL_PORT 300; then echo "[ERROR] Waited 300 seconds, no response" >&2; exit 1; fi
       - mysql -h$MYSQL_HOST -P$MYSQL_PORT -p$MYSQL_PASSWORD -u$MYSQL_USER $MYSQL_DATABASE < database.sql
       - php ./bin/console.php dbstructure dumpsql > database.sql
-  - name: Codecov
-    image: plugins/codecov
-    when:
-      repo:
-        - friendica/friendica
-    settings:
-      token:
-        from_secret: codecov-token
-      files:
-        - clover.xml
   - name: Check database.sql
     image: alpine/git
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -146,7 +146,7 @@ steps:
     volumes:
       - name: cache
         path: /tmp/cache
-  - name: Test Friendica
+  - name: Recreate database.sql
     image: friendicaci/php7.4:php7.4.18
     environment:
       MYSQL_HOST: "mariadb"
@@ -183,6 +183,22 @@ steps:
         echo "database.sql mismatch.";
         exit 1;
         fi
+
+services:
+  - name: mariadb
+    image: mariadb:latest
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+      MYSQL_DATABASE: "test"
+      MYSQL_PASSWORD: "test"
+      MYSQL_USER: "test"
+    tmpfs:
+      - /var/lib/mysql
+
+volumes:
+  - name: cache
+    host:
+      path: /tmp/drone-cache
 ---
 kind: pipeline
 type: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -175,13 +175,13 @@ steps:
       files:
         - clover.xml
   - name: Check database.sql
-    image: alpine
+    image: alpine/git
     commands:
       - git update-index --refresh
       - git diff-index --quiet HEAD --
       - if [[ $? -ne 0 ]]; then
-        echo "database.sql mismatch.";
-        exit 1;
+          echo "database.sql mismatch.";
+          exit 1;
         fi
 
 services:

--- a/.drone.yml
+++ b/.drone.yml
@@ -110,6 +110,82 @@ volumes:
 ---
 kind: pipeline
 type: docker
+name: php7.4-database-check
+
+depends_on:
+  - Integrity checks
+
+steps:
+  - name: Restore cache
+    image: meltwater/drone-cache:dev
+    settings:
+      backend: "filesystem"
+      restore: true
+      cache_key: '{{ .Repo.Name }}_php74_{{ arch }}_{{ os }}'
+      archive_format: "gzip"
+      mount:
+        - '.composer'
+    volumes:
+      - name: cache
+        path: /tmp/cache
+  - name: Composer install
+    image: friendicaci/php7.4:php7.4.18
+    commands:
+      - export COMPOSER_HOME=.composer
+      - ./bin/composer.phar validate
+      - ./bin/composer.phar install --prefer-dist
+  - name: Rebuild cache
+    image: meltwater/drone-cache:dev
+    settings:
+      backend: "filesystem"
+      rebuild: true
+      cache_key: '{{ .Repo.Name }}_php74_{{ arch }}_{{ os }}'
+      archive_format: "gzip"
+      mount:
+        - '.composer'
+    volumes:
+      - name: cache
+        path: /tmp/cache
+  - name: Test Friendica
+    image: friendicaci/php7.4:php7.4.18
+    environment:
+      MYSQL_HOST: "mariadb"
+      MYSQL_PORT: 3306
+      MYSQL_DATABASE: "test"
+      MYSQL_PASSWORD: "test"
+      MYSQL_USER: "test"
+      REDIS_HOST: "redis"
+      MEMCACHED_HOST: "memcached"
+      MEMCACHE_HOST: "memcached"
+      XDEBUG_MODE: "coverage"
+    commands:
+      - phpenmod xdebug
+      - cp config/local-sample.config.php config/local.config.php
+      - if ! bin/wait-for-connection $MYSQL_HOST $MYSQL_PORT 300; then echo "[ERROR] Waited 300 seconds, no response" >&2; exit 1; fi
+      - mysql -h$MYSQL_HOST -P$MYSQL_PORT -p$MYSQL_PASSWORD -u$MYSQL_USER $MYSQL_DATABASE < database.sql
+      - php ./bin/console.php dbstructure dumpsql > database.sql
+  - name: Codecov
+    image: plugins/codecov
+    when:
+      repo:
+        - friendica/friendica
+    settings:
+      token:
+        from_secret: codecov-token
+      files:
+        - clover.xml
+  - name: Check database.sql
+    image: alpine
+    commands:
+      - git update-index --refresh
+      - git diff-index --quiet HEAD --
+      - if [[ $? -ne 0 ]]; then
+        echo "database.sql mismatch.";
+        exit 1;
+        fi
+---
+kind: pipeline
+type: docker
 name: php7.3-mariadb
 
 depends_on:

--- a/database.sql
+++ b/database.sql
@@ -2,6 +2,9 @@
 -- Friendica 2021.12-dev (Siberian Iris)
 -- DB_UPDATE_VERSION 1443
 -- ------------------------------------------
+
+
+--
 -- TABLE gserver
 --
 CREATE TABLE IF NOT EXISTS `gserver` (

--- a/database.sql
+++ b/database.sql
@@ -2,9 +2,6 @@
 -- Friendica 2021.12-dev (Siberian Iris)
 -- DB_UPDATE_VERSION 1443
 -- ------------------------------------------
-
-
---
 -- TABLE gserver
 --
 CREATE TABLE IF NOT EXISTS `gserver` (


### PR DESCRIPTION
Added a drone check, which compares the committed `database.sql` file with the re-created one based on `php ./bin/console.php dbstructure dumpsql > database.sql`