### PR TITLE
Replace Module::init() with Constructors

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -40,7 +40,7 @@ use Friendica\Protocol\DFRN;
 function display_init(App $a)
 {
 	if (ActivityPub::isRequest()) {
-		(new Objects(['guid' => DI::args()->getArgv()[1] ?? null]))->rawContent();
+		(new Objects(DI::l10n(), ['guid' => DI::args()->getArgv()[1] ?? null]))->rawContent();
 	}
 
 	if (DI::config()->get('system', 'block_public') && !Session::isAuthenticated()) {

--- a/src/App/ModuleController.php
+++ b/src/App/ModuleController.php
@@ -81,7 +81,7 @@ class ModuleController
 	private $moduleName;
 
 	/**
-	 * @var ICanHandleRequests The module object
+	 * @var ?ICanHandleRequests The module object
 	 */
 	private $module;
 
@@ -104,9 +104,9 @@ class ModuleController
 	}
 
 	/**
-	 * @return ICanHandleRequests The base module object
+	 * @return ?ICanHandleRequests The base module object
 	 */
-	public function getModule(): ICanHandleRequests
+	public function getModule(): ?ICanHandleRequests
 	{
 		return $this->module;
 	}
@@ -120,12 +120,10 @@ class ModuleController
 		return $this->isBackend;
 	}
 
-	public function __construct(string $moduleName = self::DEFAULT, ICanHandleRequests $module = null, bool $isBackend = false, bool $printNotAllowedAddon = false)
+	public function __construct(string $moduleName = self::DEFAULT, ?ICanHandleRequests $module = null, bool $isBackend = false, bool $printNotAllowedAddon = false)
 	{
-		$defaultClass = static::DEFAULT_CLASS;
-
 		$this->moduleName           = $moduleName;
-		$this->module               = $module ?? new $defaultClass();
+		$this->module               = $module;
 		$this->isBackend            = $isBackend;
 		$this->printNotAllowedAddon = $printNotAllowedAddon;
 	}
@@ -296,8 +294,6 @@ class ModuleController
 		$timestamp = microtime(true);
 
 		Core\Hook::callAll($this->moduleName . '_mod_init', $placeholder);
-
-		$this->module->init();
 
 		$profiler->set(microtime(true) - $timestamp, 'init');
 

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -22,6 +22,7 @@
 namespace Friendica;
 
 use Friendica\Capabilities\ICanHandleRequests;
+use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Model\User;
 
@@ -39,16 +40,13 @@ abstract class BaseModule implements ICanHandleRequests
 	/** @var array */
 	protected $parameters = [];
 
-	public function __construct(array $parameters = [])
+	/** @var L10n */
+	protected $l10n;
+
+	public function __construct(L10n $l10n, array $parameters = [])
 	{
 		$this->parameters = $parameters;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function init()
-	{
+		$this->l10n       = $l10n;
 	}
 
 	/**

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -50,6 +50,26 @@ abstract class BaseModule implements ICanHandleRequests
 	}
 
 	/**
+	 * Wraps the L10n::t() function for Modules
+	 *
+	 * @see L10n::t()
+	 */
+	protected function t(string $s, ...$args): string
+	{
+		return $this->l10n->t($s, $args);
+	}
+
+	/**
+	 * Wraps the L10n::tt() function for Modules
+	 *
+	 * @see L10n::tt()
+	 */
+	protected function tt(string $singular, string $plurarl, int $count): string
+	{
+		return $this->l10n->tt($singular, $plurarl, $count);
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function rawContent()

--- a/src/Capabilities/ICanHandleRequests.php
+++ b/src/Capabilities/ICanHandleRequests.php
@@ -8,14 +8,6 @@ namespace Friendica\Capabilities;
 interface ICanHandleRequests
 {
 	/**
-	 * Initialization method common to both content() and post()
-	 *
-	 * Extend this method if you need to do any shared processing before either
-	 * content() or post()
-	 */
-	public function init();
-
-	/**
 	 * Module GET method to display raw content from technical endpoints
 	 *
 	 * Extend this method if the module is supposed to return communication data,

--- a/src/LegacyModule.php
+++ b/src/LegacyModule.php
@@ -21,6 +21,8 @@
 
 namespace Friendica;
 
+use Friendica\Core\L10n;
+
 /**
  * This mock module enable class encapsulation of legacy global function modules.
  * After having provided the module file name, all the methods will behave like a normal Module class.
@@ -37,11 +39,13 @@ class LegacyModule extends BaseModule
 	 */
 	private $moduleName = '';
 
-	public function __construct(string $file_path = '', array $parameters = [])
+	public function __construct(L10n $l10n, string $file_path = '', array $parameters = [])
 	{
-		parent::__construct($parameters);
+		parent::__construct($l10n, $parameters);
 
 		$this->setModuleFile($file_path);
+
+		$this->runModuleFunction('init');
 	}
 
 	/**
@@ -59,11 +63,6 @@ class LegacyModule extends BaseModule
 		$this->moduleName = basename($file_path, '.php');
 
 		require_once $file_path;
-	}
-
-	public function init()
-	{
-		$this->runModuleFunction('init');
 	}
 
 	public function content(): string

--- a/src/Module/Admin/Themes/Embed.php
+++ b/src/Module/Admin/Themes/Embed.php
@@ -21,18 +21,32 @@
 
 namespace Friendica\Module\Admin\Themes;
 
+use Friendica\App;
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\DI;
 use Friendica\Module\BaseAdmin;
 use Friendica\Util\Strings;
 
 class Embed extends BaseAdmin
 {
-	public function init()
+	/** @var App */
+	protected $app;
+	/** @var App\BaseURL */
+	protected $baseUrl;
+	/** @var App\Mode */
+	protected $mode;
+
+	public function __construct(App $app, App\BaseURL $baseUrl, App\Mode $mode, L10n $l10n, array $parameters = [])
 	{
+		parent::__construct($l10n, $parameters);
+
+		$this->app     = $app;
+		$this->baseUrl = $baseUrl;
+		$this->mode    = $mode;
+
 		$theme = Strings::sanitizeFilePathItem($this->parameters['theme']);
 		if (is_file("view/theme/$theme/config.php")) {
-			DI::app()->setCurrentTheme($theme);
+			$this->app->setCurrentTheme($theme);
 		}
 	}
 
@@ -45,15 +59,15 @@ class Embed extends BaseAdmin
 			require_once "view/theme/$theme/config.php";
 			if (function_exists('theme_admin_post')) {
 				self::checkFormSecurityTokenRedirectOnError('/admin/themes/' . $theme . '/embed?mode=minimal', 'admin_theme_settings');
-				theme_admin_post(DI::app());
+				theme_admin_post($this->app);
 			}
 		}
 
-		if (DI::mode()->isAjax()) {
+		if ($this->mode->isAjax()) {
 			return;
 		}
 
-		DI::baseUrl()->redirect('admin/themes/' . $theme . '/embed?mode=minimal');
+		$this->baseUrl->redirect('admin/themes/' . $theme . '/embed?mode=minimal');
 	}
 
 	public function content(): string
@@ -62,7 +76,7 @@ class Embed extends BaseAdmin
 
 		$theme = Strings::sanitizeFilePathItem($this->parameters['theme']);
 		if (!is_dir("view/theme/$theme")) {
-			notice(DI::l10n()->t('Unknown theme.'));
+			notice($this->l10n->t('Unknown theme.'));
 			return '';
 		}
 
@@ -71,7 +85,7 @@ class Embed extends BaseAdmin
 			require_once "view/theme/$theme/config.php";
 
 			if (function_exists('theme_admin')) {
-				$admin_form = theme_admin(DI::app());
+				$admin_form = theme_admin($this->app);
 			}
 		}
 

--- a/src/Module/Admin/Themes/Embed.php
+++ b/src/Module/Admin/Themes/Embed.php
@@ -76,7 +76,7 @@ class Embed extends BaseAdmin
 
 		$theme = Strings::sanitizeFilePathItem($this->parameters['theme']);
 		if (!is_dir("view/theme/$theme")) {
-			notice($this->l10n->t('Unknown theme.'));
+			notice($this->t('Unknown theme.'));
 			return '';
 		}
 

--- a/src/Module/Admin/Tos.php
+++ b/src/Module/Admin/Tos.php
@@ -72,15 +72,15 @@ class Tos extends BaseAdmin
 
 		$t = Renderer::getMarkupTemplate('admin/tos.tpl');
 		return Renderer::replaceMacros($t, [
-			'$title' => $this->l10n->t('Administration'),
-			'$page' => $this->l10n->t('Terms of Service'),
-			'$displaytos' => ['displaytos', $this->l10n->t('Display Terms of Service'), $this->config->get('system', 'tosdisplay'), $this->l10n->t('Enable the Terms of Service page. If this is enabled a link to the terms will be added to the registration form and the general information page.')],
-			'$displayprivstatement' => ['displayprivstatement', $this->l10n->t('Display Privacy Statement'), $this->config->get('system', 'tosprivstatement'), $this->l10n->t('Show some informations regarding the needed information to operate the node according e.g. to <a href="%s" target="_blank" rel="noopener noreferrer">EU-GDPR</a>.', 'https://en.wikipedia.org/wiki/General_Data_Protection_Regulation')],
-			'$preview' => $this->l10n->t('Privacy Statement Preview'),
+			'$title' => $this->t('Administration'),
+			'$page' => $this->t('Terms of Service'),
+			'$displaytos' => ['displaytos', $this->t('Display Terms of Service'), $this->config->get('system', 'tosdisplay'), $this->t('Enable the Terms of Service page. If this is enabled a link to the terms will be added to the registration form and the general information page.')],
+			'$displayprivstatement' => ['displayprivstatement', $this->t('Display Privacy Statement'), $this->config->get('system', 'tosprivstatement'), $this->t('Show some informations regarding the needed information to operate the node according e.g. to <a href="%s" target="_blank" rel="noopener noreferrer">EU-GDPR</a>.', 'https://en.wikipedia.org/wiki/General_Data_Protection_Regulation')],
+			'$preview' => $this->t('Privacy Statement Preview'),
 			'$privtext' => $this->tos->privacy_complete,
-			'$tostext' => ['tostext', $this->l10n->t('The Terms of Service'), $this->config->get('system', 'tostext'), $this->l10n->t('Enter the Terms of Service for your node here. You can use BBCode. Headers of sections should be [h2] and below.')],
+			'$tostext' => ['tostext', $this->t('The Terms of Service'), $this->config->get('system', 'tostext'), $this->t('Enter the Terms of Service for your node here. You can use BBCode. Headers of sections should be [h2] and below.')],
 			'$form_security_token' => self::getFormSecurityToken('admin_tos'),
-			'$submit' => $this->l10n->t('Save Settings'),
+			'$submit' => $this->t('Save Settings'),
 		]);
 	}
 }

--- a/src/Module/Admin/Tos.php
+++ b/src/Module/Admin/Tos.php
@@ -21,12 +21,30 @@
 
 namespace Friendica\Module\Admin;
 
+use Friendica\App\BaseURL;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\DI;
 use Friendica\Module\BaseAdmin;
 
 class Tos extends BaseAdmin
 {
+	/** @var \Friendica\Module\Tos */
+	protected $tos;
+	/** @var IManageConfigValues */
+	protected $config;
+	/** @var BaseURL */
+	protected $baseUrl;
+
+	public function __construct(\Friendica\Module\Tos $tos, IManageConfigValues $config, BaseURL $baseUrl, L10n $l10n, array $parameters = [])
+	{
+		parent::__construct($l10n, $parameters);
+
+		$this->tos     = $tos;
+		$this->config  = $config;
+		$this->baseUrl = $baseUrl;
+	}
+
 	public function post()
 	{
 		self::checkAdminAccess();
@@ -41,29 +59,28 @@ class Tos extends BaseAdmin
 		$displayprivstatement = !empty($_POST['displayprivstatement']);
 		$tostext = (!empty($_POST['tostext']) ? strip_tags(trim($_POST['tostext'])) : '');
 
-		DI::config()->set('system', 'tosdisplay', $displaytos);
-		DI::config()->set('system', 'tosprivstatement', $displayprivstatement);
-		DI::config()->set('system', 'tostext', $tostext);
+		$this->config->set('system', 'tosdisplay', $displaytos);
+		$this->config->set('system', 'tosprivstatement', $displayprivstatement);
+		$this->config->set('system', 'tostext', $tostext);
 
-		DI::baseUrl()->redirect('admin/tos');
+		$this->baseUrl->redirect('admin/tos');
 	}
 
 	public function content(): string
 	{
 		parent::content();
 
-		$tos = new \Friendica\Module\Tos($this->parameters);
 		$t = Renderer::getMarkupTemplate('admin/tos.tpl');
 		return Renderer::replaceMacros($t, [
-			'$title' => DI::l10n()->t('Administration'),
-			'$page' => DI::l10n()->t('Terms of Service'),
-			'$displaytos' => ['displaytos', DI::l10n()->t('Display Terms of Service'), DI::config()->get('system', 'tosdisplay'), DI::l10n()->t('Enable the Terms of Service page. If this is enabled a link to the terms will be added to the registration form and the general information page.')],
-			'$displayprivstatement' => ['displayprivstatement', DI::l10n()->t('Display Privacy Statement'), DI::config()->get('system', 'tosprivstatement'), DI::l10n()->t('Show some informations regarding the needed information to operate the node according e.g. to <a href="%s" target="_blank" rel="noopener noreferrer">EU-GDPR</a>.', 'https://en.wikipedia.org/wiki/General_Data_Protection_Regulation')],
-			'$preview' => DI::l10n()->t('Privacy Statement Preview'),
-			'$privtext' => $tos->privacy_complete,
-			'$tostext' => ['tostext', DI::l10n()->t('The Terms of Service'), DI::config()->get('system', 'tostext'), DI::l10n()->t('Enter the Terms of Service for your node here. You can use BBCode. Headers of sections should be [h2] and below.')],
+			'$title' => $this->l10n->t('Administration'),
+			'$page' => $this->l10n->t('Terms of Service'),
+			'$displaytos' => ['displaytos', $this->l10n->t('Display Terms of Service'), $this->config->get('system', 'tosdisplay'), $this->l10n->t('Enable the Terms of Service page. If this is enabled a link to the terms will be added to the registration form and the general information page.')],
+			'$displayprivstatement' => ['displayprivstatement', $this->l10n->t('Display Privacy Statement'), $this->config->get('system', 'tosprivstatement'), $this->l10n->t('Show some informations regarding the needed information to operate the node according e.g. to <a href="%s" target="_blank" rel="noopener noreferrer">EU-GDPR</a>.', 'https://en.wikipedia.org/wiki/General_Data_Protection_Regulation')],
+			'$preview' => $this->l10n->t('Privacy Statement Preview'),
+			'$privtext' => $this->tos->privacy_complete,
+			'$tostext' => ['tostext', $this->l10n->t('The Terms of Service'), $this->config->get('system', 'tostext'), $this->l10n->t('Enter the Terms of Service for your node here. You can use BBCode. Headers of sections should be [h2] and below.')],
 			'$form_security_token' => self::getFormSecurityToken('admin_tos'),
-			'$submit' => DI::l10n()->t('Save Settings'),
+			'$submit' => $this->l10n->t('Save Settings'),
 		]);
 	}
 }

--- a/src/Module/Api/Twitter/ContactEndpoint.php
+++ b/src/Module/Api/Twitter/ContactEndpoint.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Module\Api\Twitter;
 
+use Friendica\Core\L10n;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Profile;
@@ -35,9 +36,9 @@ abstract class ContactEndpoint extends BaseApi
 	const DEFAULT_COUNT = 20;
 	const MAX_COUNT = 200;
 
-	public function init()
+	public function __construct(L10n $l10n, array $parameters = [])
 	{
-		parent::init();
+		parent::__construct($l10n, $parameters);
 
 		self::checkAllowedScope(self::SCOPE_READ);
 	}

--- a/src/Module/Apps.php
+++ b/src/Module/Apps.php
@@ -21,21 +21,25 @@
 
 namespace Friendica\Module;
 
+use Friendica\App\BaseURL;
 use Friendica\BaseModule;
 use Friendica\Content\Nav;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\DI;
 
 /**
  * Shows the App menu
  */
 class Apps extends BaseModule
 {
-	public function init()
+	public function __construct(L10n $l10n, IManageConfigValues $config, BaseURL $baseUrl, array $parameters = [])
 	{
-		$privateaddons = DI::config()->get('config', 'private_addons');
+		parent::__construct($l10n, $parameters);
+
+		$privateaddons = $config->get('config', 'private_addons');
 		if ($privateaddons === "1" && !local_user()) {
-			DI::baseUrl()->redirect();
+			$baseUrl->redirect();
 		}
 	}
 
@@ -44,12 +48,12 @@ class Apps extends BaseModule
 		$apps = Nav::getAppMenu();
 
 		if (count($apps) == 0) {
-			notice(DI::l10n()->t('No installed applications.'));
+			notice($this->l10n->t('No installed applications.'));
 		}
 
 		$tpl = Renderer::getMarkupTemplate('apps.tpl');
 		return Renderer::replaceMacros($tpl, [
-			'$title' => DI::l10n()->t('Applications'),
+			'$title' => $this->l10n->t('Applications'),
 			'$apps'  => $apps,
 		]);
 	}

--- a/src/Module/Apps.php
+++ b/src/Module/Apps.php
@@ -48,12 +48,12 @@ class Apps extends BaseModule
 		$apps = Nav::getAppMenu();
 
 		if (count($apps) == 0) {
-			notice($this->l10n->t('No installed applications.'));
+			notice($this->t('No installed applications.'));
 		}
 
 		$tpl = Renderer::getMarkupTemplate('apps.tpl');
 		return Renderer::replaceMacros($tpl, [
-			'$title' => $this->l10n->t('Applications'),
+			'$title' => $this->t('Applications'),
 			'$apps'  => $apps,
 		]);
 	}

--- a/src/Module/BaseNotifications.php
+++ b/src/Module/BaseNotifications.php
@@ -91,7 +91,7 @@ abstract class BaseNotifications extends BaseModule
 		parent::__construct($l10n, $parameters);
 
 		if (!local_user()) {
-			throw new ForbiddenException($this->l10n->t('Permission denied.'));
+			throw new ForbiddenException($this->t('Permission denied.'));
 		}
 
 		$page = ($_REQUEST['page'] ?? 0) ?: 1;
@@ -144,7 +144,7 @@ abstract class BaseNotifications extends BaseModule
 
 		$notif_tpl = Renderer::getMarkupTemplate('notifications/notifications.tpl');
 		return Renderer::replaceMacros($notif_tpl, [
-			'$header'        => $header ?? $this->l10n->t('Notifications'),
+			'$header'        => $header ?? $this->t('Notifications'),
 			'$tabs'          => $tabs,
 			'$notifications' => $notifications,
 			'$noContent'     => $noContent,
@@ -167,7 +167,7 @@ abstract class BaseNotifications extends BaseModule
 
 		foreach (self::URL_TYPES as $type => $url) {
 			$tabs[] = [
-				'label'     => $this->l10n->t(self::PRINT_TYPES[$type]),
+				'label'     => $this->t(self::PRINT_TYPES[$type]),
 				'url'       => 'notifications/' . $url,
 				'sel'       => (($selected == $url) ? 'active' : ''),
 				'id'        => $type . '-tab',

--- a/src/Module/BaseNotifications.php
+++ b/src/Module/BaseNotifications.php
@@ -28,7 +28,6 @@ use Friendica\Content\Pager;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Core\System;
-use Friendica\DI;
 use Friendica\Navigation\Notifications\ValueObject\FormattedNotification;
 use Friendica\Network\HTTPException\ForbiddenException;
 
@@ -138,14 +137,14 @@ abstract class BaseNotifications extends BaseModule
 	protected function printContent(string $header, array $notifications, string $noContent, array $showLink)
 	{
 		// Get the nav tabs for the notification pages
-		$tabs = self::getTabs();
+		$tabs = $this->getTabs();
 
 		// Set the pager
-		$pager = new Pager(DI::l10n(), DI::args()->getQueryString(), self::ITEMS_PER_PAGE);
+		$pager = new Pager($this->l10n, $this->args->getQueryString(), self::ITEMS_PER_PAGE);
 
 		$notif_tpl = Renderer::getMarkupTemplate('notifications/notifications.tpl');
 		return Renderer::replaceMacros($notif_tpl, [
-			'$header'        => $header ?? DI::l10n()->t('Notifications'),
+			'$header'        => $header ?? $this->l10n->t('Notifications'),
 			'$tabs'          => $tabs,
 			'$notifications' => $notifications,
 			'$noContent'     => $noContent,
@@ -160,15 +159,15 @@ abstract class BaseNotifications extends BaseModule
 	 * @return array with with notifications TabBar data
 	 * @throws Exception
 	 */
-	private static function getTabs()
+	private function getTabs()
 	{
-		$selected = DI::args()->get(1, '');
+		$selected = $this->args->get(1, '');
 
 		$tabs = [];
 
 		foreach (self::URL_TYPES as $type => $url) {
 			$tabs[] = [
-				'label'     => DI::l10n()->t(self::PRINT_TYPES[$type]),
+				'label'     => $this->l10n->t(self::PRINT_TYPES[$type]),
 				'url'       => 'notifications/' . $url,
 				'sel'       => (($selected == $url) ? 'active' : ''),
 				'id'        => $type . '-tab',

--- a/src/Module/Contact/Advanced.php
+++ b/src/Module/Contact/Advanced.php
@@ -57,7 +57,7 @@ class Advanced extends BaseModule
 		$this->page   = $page;
 
 		if (!Session::isAuthenticated()) {
-			throw new ForbiddenException($this->l10n->t('Permission denied.'));
+			throw new ForbiddenException($this->t('Permission denied.'));
 		}
 	}
 
@@ -67,7 +67,7 @@ class Advanced extends BaseModule
 
 		$contact = Model\Contact::selectFirst([], ['id' => $cid, 'uid' => local_user()]);
 		if (empty($contact)) {
-			throw new BadRequestException($this->l10n->t('Contact not found.'));
+			throw new BadRequestException($this->t('Contact not found.'));
 		}
 
 		$name        = ($_POST['name'] ?? '') ?: $contact['name'];
@@ -106,7 +106,7 @@ class Advanced extends BaseModule
 		}
 
 		if (!$r) {
-			notice($this->l10n->t('Contact update failed.'));
+			notice($this->t('Contact update failed.'));
 		}
 	}
 
@@ -116,13 +116,13 @@ class Advanced extends BaseModule
 
 		$contact = Model\Contact::selectFirst([], ['id' => $cid, 'uid' => local_user()]);
 		if (empty($contact)) {
-			throw new BadRequestException($this->l10n->t('Contact not found.'));
+			throw new BadRequestException($this->t('Contact not found.'));
 		}
 
 		$this->page['aside'] = Widget\VCard::getHTML($contact);
 
-		$warning = $this->l10n->t('<strong>WARNING: This is highly advanced</strong> and if you enter incorrect information your communications with this contact may stop working.');
-		$info    = $this->l10n->t('Please use your browser \'Back\' button <strong>now</strong> if you are uncertain what to do on this page.');
+		$warning = $this->t('<strong>WARNING: This is highly advanced</strong> and if you enter incorrect information your communications with this contact may stop working.');
+		$info    = $this->t('Please use your browser \'Back\' button <strong>now</strong> if you are uncertain what to do on this page.');
 
 		$returnaddr = "contact/$cid";
 
@@ -142,20 +142,20 @@ class Advanced extends BaseModule
 			'$warning'           => $warning,
 			'$info'              => $info,
 			'$returnaddr'        => $returnaddr,
-			'$return'            => $this->l10n->t('Return to contact editor'),
+			'$return'            => $this->t('Return to contact editor'),
 			'$contact_id'        => $contact['id'],
-			'$lbl_submit'        => $this->l10n->t('Submit'),
+			'$lbl_submit'        => $this->t('Submit'),
 
-			'$name'    => ['name', $this->l10n->t('Name'), $contact['name'], '', '', $readonly],
-			'$nick'    => ['nick', $this->l10n->t('Account Nickname'), $contact['nick'], '', '', $readonly],
-			'$attag'   => ['attag', $this->l10n->t('@Tagname - overrides Name/Nickname'), $contact['attag']],
-			'$url'     => ['url', $this->l10n->t('Account URL'), $contact['url'], '', '', $readonly],
-			'$alias'   => ['alias', $this->l10n->t('Account URL Alias'), $contact['alias'], '', '', $readonly],
-			'$request' => ['request', $this->l10n->t('Friend Request URL'), $contact['request'], '', '', $readonly],
-			'confirm'  => ['confirm', $this->l10n->t('Friend Confirm URL'), $contact['confirm'], '', '', $readonly],
-			'notify'   => ['notify', $this->l10n->t('Notification Endpoint URL'), $contact['notify'], '', '', $readonly],
-			'poll'     => ['poll', $this->l10n->t('Poll/Feed URL'), $contact['poll'], '', '', $readonly],
-			'photo'    => ['photo', $this->l10n->t('New photo from this URL'), '', '', '', $readonly],
+			'$name'    => ['name', $this->t('Name'), $contact['name'], '', '', $readonly],
+			'$nick'    => ['nick', $this->t('Account Nickname'), $contact['nick'], '', '', $readonly],
+			'$attag'   => ['attag', $this->t('@Tagname - overrides Name/Nickname'), $contact['attag']],
+			'$url'     => ['url', $this->t('Account URL'), $contact['url'], '', '', $readonly],
+			'$alias'   => ['alias', $this->t('Account URL Alias'), $contact['alias'], '', '', $readonly],
+			'$request' => ['request', $this->t('Friend Request URL'), $contact['request'], '', '', $readonly],
+			'confirm'  => ['confirm', $this->t('Friend Confirm URL'), $contact['confirm'], '', '', $readonly],
+			'notify'   => ['notify', $this->t('Notification Endpoint URL'), $contact['notify'], '', '', $readonly],
+			'poll'     => ['poll', $this->t('Poll/Feed URL'), $contact['poll'], '', '', $readonly],
+			'photo'    => ['photo', $this->t('New photo from this URL'), '', '', '', $readonly],
 		]);
 	}
 }

--- a/src/Module/Contact/Revoke.php
+++ b/src/Module/Contact/Revoke.php
@@ -60,7 +60,7 @@ class Revoke extends BaseModule
 
 		$data = Model\Contact::getPublicAndUserContactID($this->parameters['id'], local_user());
 		if (!$this->dba->isResult($data)) {
-			throw new HTTPException\NotFoundException($this->l10n->t('Unknown contact.'));
+			throw new HTTPException\NotFoundException($this->t('Unknown contact.'));
 		}
 
 		if (empty($data['user'])) {
@@ -70,11 +70,11 @@ class Revoke extends BaseModule
 		$this->contact = Model\Contact::getById($data['user']);
 
 		if ($this->contact['deleted']) {
-			throw new HTTPException\NotFoundException($this->l10n->t('Contact is deleted.'));
+			throw new HTTPException\NotFoundException($this->t('Contact is deleted.'));
 		}
 
 		if (!empty($this->contact['network']) && $this->contact['network'] == Protocol::PHANTOM) {
-			throw new HTTPException\NotFoundException($this->l10n->t('Contact is being deleted.'));
+			throw new HTTPException\NotFoundException($this->t('Contact is being deleted.'));
 		}
 	}
 
@@ -88,11 +88,11 @@ class Revoke extends BaseModule
 
 		$result = Model\Contact::revokeFollow($this->contact);
 		if ($result === true) {
-			notice($this->l10n->t('Follow was successfully revoked.'));
+			notice($this->t('Follow was successfully revoked.'));
 		} elseif ($result === null) {
-			notice($this->l10n->t('Follow was successfully revoked, however the remote contact won\'t be aware of this revokation.'));
+			notice($this->t('Follow was successfully revoked, however the remote contact won\'t be aware of this revokation.'));
 		} else {
-			notice($this->l10n->t('Unable to revoke follow, please try again later or contact the administrator.'));
+			notice($this->t('Unable to revoke follow, please try again later or contact the administrator.'));
 		}
 
 		$this->baseUrl->redirect('contact/' . $this->parameters['id']);
@@ -108,10 +108,10 @@ class Revoke extends BaseModule
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('contact_drop_confirm.tpl'), [
 			'$l10n' => [
-				'header'  => $this->l10n->t('Revoke Follow'),
-				'message' => $this->l10n->t('Do you really want to revoke this contact\'s follow? This cannot be undone and they will have to manually follow you back again.'),
-				'confirm' => $this->l10n->t('Yes'),
-				'cancel'  => $this->l10n->t('Cancel'),
+				'header'  => $this->t('Revoke Follow'),
+				'message' => $this->t('Do you really want to revoke this contact\'s follow? This cannot be undone and they will have to manually follow you back again.'),
+				'confirm' => $this->t('Yes'),
+				'cancel'  => $this->t('Cancel'),
 			],
 			'$contact'       => Contact::getContactTemplateVars($this->contact),
 			'$method'        => 'post',

--- a/src/Module/Contact/Revoke.php
+++ b/src/Module/Contact/Revoke.php
@@ -21,12 +21,14 @@
 
 namespace Friendica\Module\Contact;
 
+use Friendica\App\Arguments;
+use Friendica\App\BaseURL;
 use Friendica\BaseModule;
 use Friendica\Content\Nav;
+use Friendica\Core\L10n;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
-use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Database\Database;
 use Friendica\Model;
 use Friendica\Module\Contact;
 use Friendica\Module\Security\Login;
@@ -35,31 +37,44 @@ use Friendica\Network\HTTPException;
 class Revoke extends BaseModule
 {
 	/** @var array */
-	private static $contact;
-
-	public function init()
+	protected $contact;
+	
+	/** @var Database */
+	protected $dba;
+	/** @var BaseURL */
+	protected $baseUrl;
+	/** @var Arguments */
+	protected $args;
+	
+	public function __construct(Database $dba, BaseURL $baseUrl, Arguments $args, L10n $l10n, array $parameters = [])
 	{
+		parent::__construct($l10n, $parameters);
+
+		$this->dba     = $dba;
+		$this->baseUrl = $baseUrl;
+		$this->args    = $args;
+
 		if (!local_user()) {
 			return;
 		}
 
 		$data = Model\Contact::getPublicAndUserContactID($this->parameters['id'], local_user());
-		if (!DBA::isResult($data)) {
-			throw new HTTPException\NotFoundException(DI::l10n()->t('Unknown contact.'));
+		if (!$this->dba->isResult($data)) {
+			throw new HTTPException\NotFoundException($this->l10n->t('Unknown contact.'));
 		}
 
 		if (empty($data['user'])) {
 			throw new HTTPException\ForbiddenException();
 		}
 
-		self::$contact = Model\Contact::getById($data['user']);
+		$this->contact = Model\Contact::getById($data['user']);
 
-		if (self::$contact['deleted']) {
-			throw new HTTPException\NotFoundException(DI::l10n()->t('Contact is deleted.'));
+		if ($this->contact['deleted']) {
+			throw new HTTPException\NotFoundException($this->l10n->t('Contact is deleted.'));
 		}
 
-		if (!empty(self::$contact['network']) && self::$contact['network'] == Protocol::PHANTOM) {
-			throw new HTTPException\NotFoundException(DI::l10n()->t('Contact is being deleted.'));
+		if (!empty($this->contact['network']) && $this->contact['network'] == Protocol::PHANTOM) {
+			throw new HTTPException\NotFoundException($this->l10n->t('Contact is being deleted.'));
 		}
 	}
 
@@ -71,16 +86,16 @@ class Revoke extends BaseModule
 
 		self::checkFormSecurityTokenRedirectOnError('contact/' . $this->parameters['id'], 'contact_revoke');
 
-		$result = Model\Contact::revokeFollow(self::$contact);
+		$result = Model\Contact::revokeFollow($this->contact);
 		if ($result === true) {
-			notice(DI::l10n()->t('Follow was successfully revoked.'));
+			notice($this->l10n->t('Follow was successfully revoked.'));
 		} elseif ($result === null) {
-			notice(DI::l10n()->t('Follow was successfully revoked, however the remote contact won\'t be aware of this revokation.'));
+			notice($this->l10n->t('Follow was successfully revoked, however the remote contact won\'t be aware of this revokation.'));
 		} else {
-			notice(DI::l10n()->t('Unable to revoke follow, please try again later or contact the administrator.'));
+			notice($this->l10n->t('Unable to revoke follow, please try again later or contact the administrator.'));
 		}
 
-		DI::baseUrl()->redirect('contact/' . $this->parameters['id']);
+		$this->baseUrl->redirect('contact/' . $this->parameters['id']);
 	}
 
 	public function content(): string
@@ -93,14 +108,14 @@ class Revoke extends BaseModule
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('contact_drop_confirm.tpl'), [
 			'$l10n' => [
-				'header'  => DI::l10n()->t('Revoke Follow'),
-				'message' => DI::l10n()->t('Do you really want to revoke this contact\'s follow? This cannot be undone and they will have to manually follow you back again.'),
-				'confirm' => DI::l10n()->t('Yes'),
-				'cancel'  => DI::l10n()->t('Cancel'),
+				'header'  => $this->l10n->t('Revoke Follow'),
+				'message' => $this->l10n->t('Do you really want to revoke this contact\'s follow? This cannot be undone and they will have to manually follow you back again.'),
+				'confirm' => $this->l10n->t('Yes'),
+				'cancel'  => $this->l10n->t('Cancel'),
 			],
-			'$contact'       => Contact::getContactTemplateVars(self::$contact),
+			'$contact'       => Contact::getContactTemplateVars($this->contact),
 			'$method'        => 'post',
-			'$confirm_url'   => DI::args()->getCommand(),
+			'$confirm_url'   => $this->args->getCommand(),
 			'$confirm_name'  => 'form_security_token',
 			'$confirm_value' => BaseModule::getFormSecurityToken('contact_revoke'),
 		]);

--- a/src/Module/Debug/Feed.php
+++ b/src/Module/Debug/Feed.php
@@ -44,7 +44,7 @@ class Feed extends BaseModule
 		$this->httpClient = $httpClient;
 
 		if (!local_user()) {
-			notice($this->l10n->t('You must be logged in to use this module'));
+			notice($this->t('You must be logged in to use this module'));
 			$baseUrl->redirect();
 		}
 	}
@@ -69,7 +69,7 @@ class Feed extends BaseModule
 
 		$tpl = Renderer::getMarkupTemplate('feedtest.tpl');
 		return Renderer::replaceMacros($tpl, [
-			'$url'    => ['url', $this->l10n->t('Source URL'), $_REQUEST['url'] ?? '', ''],
+			'$url'    => ['url', $this->t('Source URL'), $_REQUEST['url'] ?? '', ''],
 			'$result' => $result
 		]);
 	}

--- a/src/Module/Diaspora/Receive.php
+++ b/src/Module/Diaspora/Receive.php
@@ -54,7 +54,7 @@ class Receive extends BaseModule
 		$enabled = $this->config->get('system', 'diaspora_enabled', false);
 		if (!$enabled) {
 			$this->logger->info('Diaspora disabled.');
-			throw new HTTPException\ForbiddenException($this->l10n->t('Access denied.'));
+			throw new HTTPException\ForbiddenException($this->t('Access denied.'));
 		}
 
 		if ($this->parameters['type'] === 'public') {

--- a/src/Module/Filer/SaveTag.php
+++ b/src/Module/Filer/SaveTag.php
@@ -46,7 +46,7 @@ class SaveTag extends BaseModule
 		$this->logger = $logger;
 		
 		if (!local_user()) {
-			notice($this->l10n->t('You must be logged in to use this module'));
+			notice($this->t('You must be logged in to use this module'));
 			$baseUrl->redirect();
 		}
 	}
@@ -72,8 +72,8 @@ class SaveTag extends BaseModule
 
 		$tpl = Renderer::getMarkupTemplate("filer_dialog.tpl");
 		echo Renderer::replaceMacros($tpl, [
-			'$field' => ['term', $this->l10n->t("Save to Folder:"), '', '', $filetags, $this->l10n->t('- select -')],
-			'$submit' => $this->l10n->t('Save'),
+			'$field' => ['term', $this->t("Save to Folder:"), '', '', $filetags, $this->t('- select -')],
+			'$submit' => $this->t('Save'),
 		]);
 
 		exit;

--- a/src/Module/Filer/SaveTag.php
+++ b/src/Module/Filer/SaveTag.php
@@ -21,36 +21,43 @@
 
 namespace Friendica\Module\Filer;
 
+use Friendica\App\BaseURL;
 use Friendica\BaseModule;
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Model;
 use Friendica\Network\HTTPException;
 use Friendica\Util\XML;
+use Psr\Log\LoggerInterface;
 
 /**
  * Shows a dialog for adding tags to a file
  */
 class SaveTag extends BaseModule
 {
-	public function init()
+	/** @var LoggerInterface */
+	protected $logger;
+	
+	public function __construct(LoggerInterface $logger, BaseURL $baseUrl, L10n $l10n, array $parameters = [])
 	{
+		parent::__construct($l10n, $parameters);
+		
+		$this->logger = $logger;
+		
 		if (!local_user()) {
-			notice(DI::l10n()->t('You must be logged in to use this module'));
-			DI::baseUrl()->redirect();
+			notice($this->l10n->t('You must be logged in to use this module'));
+			$baseUrl->redirect();
 		}
 	}
 
 	public function rawContent()
 	{
-		$logger = DI::logger();
-
 		$term = XML::unescape(trim($_GET['term'] ?? ''));
 
 		$item_id = $this->parameters['id'] ?? 0;
 
-		$logger->info('filer', ['tag' => $term, 'item' => $item_id]);
+		$this->logger->info('filer', ['tag' => $term, 'item' => $item_id]);
 
 		if ($item_id && strlen($term)) {
 			$item = Model\Post::selectFirst(['uri-id'], ['id' => $item_id]);
@@ -65,8 +72,8 @@ class SaveTag extends BaseModule
 
 		$tpl = Renderer::getMarkupTemplate("filer_dialog.tpl");
 		echo Renderer::replaceMacros($tpl, [
-			'$field' => ['term', DI::l10n()->t("Save to Folder:"), '', '', $filetags, DI::l10n()->t('- select -')],
-			'$submit' => DI::l10n()->t('Save'),
+			'$field' => ['term', $this->l10n->t("Save to Folder:"), '', '', $filetags, $this->l10n->t('- select -')],
+			'$submit' => $this->l10n->t('Save'),
 		]);
 
 		exit;

--- a/src/Module/FriendSuggest.php
+++ b/src/Module/FriendSuggest.php
@@ -53,7 +53,7 @@ class FriendSuggest extends BaseModule
 		parent::__construct($l10n, $parameters);
 
 		if (!local_user()) {
-			throw new ForbiddenException($this->l10n->t('Permission denied.'));
+			throw new ForbiddenException($this->t('Permission denied.'));
 		}
 
 		$this->baseUrl           = $baseUrl;
@@ -68,7 +68,7 @@ class FriendSuggest extends BaseModule
 
 		// We do query the "uid" as well to ensure that it is our contact
 		if (!$this->dba->exists('contact', ['id' => $cid, 'uid' => local_user()])) {
-			throw new NotFoundException($this->l10n->t('Contact not found.'));
+			throw new NotFoundException($this->t('Contact not found.'));
 		}
 
 		$suggest_contact_id = intval($_POST['suggest']);
@@ -79,7 +79,7 @@ class FriendSuggest extends BaseModule
 		// We do query the "uid" as well to ensure that it is our contact
 		$contact = $this->dba->selectFirst('contact', ['name', 'url', 'request', 'avatar'], ['id' => $suggest_contact_id, 'uid' => local_user()]);
 		if (empty($contact)) {
-			notice($this->l10n->t('Suggested contact not found.'));
+			notice($this->t('Suggested contact not found.'));
 			return;
 		}
 
@@ -97,7 +97,7 @@ class FriendSuggest extends BaseModule
 
 		Worker::add(PRIORITY_HIGH, 'Notifier', Delivery::SUGGESTION, $suggest->id);
 
-		info($this->l10n->t('Friend suggestion sent.'));
+		info($this->t('Friend suggestion sent.'));
 	}
 
 	public function content(): string
@@ -106,7 +106,7 @@ class FriendSuggest extends BaseModule
 
 		$contact = $this->dba->selectFirst('contact', [], ['id' => $cid, 'uid' => local_user()]);
 		if (empty($contact)) {
-			notice($this->l10n->t('Contact not found.'));
+			notice($this->t('Contact not found.'));
 			$this->baseUrl->redirect();
 		}
 
@@ -134,15 +134,15 @@ class FriendSuggest extends BaseModule
 		$tpl = Renderer::getMarkupTemplate('fsuggest.tpl');
 		return Renderer::replaceMacros($tpl, [
 			'$contact_id'      => $cid,
-			'$fsuggest_title'  => $this->l10n->t('Suggest Friends'),
+			'$fsuggest_title'  => $this->t('Suggest Friends'),
 			'$fsuggest_select' => [
 				'suggest',
-				$this->l10n->t('Suggest a friend for %s', $contact['name']),
+				$this->t('Suggest a friend for %s', $contact['name']),
 				'',
 				'',
 				$formattedContacts,
 			],
-			'$submit'          => $this->l10n->t('Submit'),
+			'$submit'          => $this->t('Submit'),
 		]);
 	}
 }

--- a/src/Module/FriendSuggest.php
+++ b/src/Module/FriendSuggest.php
@@ -21,15 +21,16 @@
 
 namespace Friendica\Module;
 
+use Friendica\App\BaseURL;
 use Friendica\BaseModule;
+use Friendica\Core\L10n;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Core\Worker;
-use Friendica\DI;
+use Friendica\Database\Database;
 use Friendica\Model\Contact as ContactModel;
 use Friendica\Network\HTTPException\ForbiddenException;
 use Friendica\Network\HTTPException\NotFoundException;
-use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
 use Friendica\Worker\Delivery;
 
@@ -38,11 +39,27 @@ use Friendica\Worker\Delivery;
  */
 class FriendSuggest extends BaseModule
 {
-	public function init()
+	/** @var BaseURL */
+	protected $baseUrl;
+	/** @var Database */
+	protected $dba;
+	/** @var \Friendica\Contact\FriendSuggest\Repository\FriendSuggest */
+	protected $friendSuggestRepo;
+	/** @var \Friendica\Contact\FriendSuggest\Factory\FriendSuggest */
+	protected $friendSuggestFac;
+
+	public function __construct(BaseURL $baseUrl, Database $dba, \Friendica\Contact\FriendSuggest\Repository\FriendSuggest $friendSuggestRepo, \Friendica\Contact\FriendSuggest\Factory\FriendSuggest $friendSuggestFac, L10n $l10n, array $parameters = [])
 	{
+		parent::__construct($l10n, $parameters);
+
 		if (!local_user()) {
-			throw new ForbiddenException(DI::l10n()->t('Permission denied.'));
+			throw new ForbiddenException($this->l10n->t('Permission denied.'));
 		}
+
+		$this->baseUrl           = $baseUrl;
+		$this->dba               = $dba;
+		$this->friendSuggestRepo = $friendSuggestRepo;
+		$this->friendSuggestFac  = $friendSuggestFac;
 	}
 
 	public function post()
@@ -50,8 +67,8 @@ class FriendSuggest extends BaseModule
 		$cid = intval($this->parameters['contact']);
 
 		// We do query the "uid" as well to ensure that it is our contact
-		if (!DI::dba()->exists('contact', ['id' => $cid, 'uid' => local_user()])) {
-			throw new NotFoundException(DI::l10n()->t('Contact not found.'));
+		if (!$this->dba->exists('contact', ['id' => $cid, 'uid' => local_user()])) {
+			throw new NotFoundException($this->l10n->t('Contact not found.'));
 		}
 
 		$suggest_contact_id = intval($_POST['suggest']);
@@ -60,15 +77,15 @@ class FriendSuggest extends BaseModule
 		}
 
 		// We do query the "uid" as well to ensure that it is our contact
-		$contact = DI::dba()->selectFirst('contact', ['name', 'url', 'request', 'avatar'], ['id' => $suggest_contact_id, 'uid' => local_user()]);
+		$contact = $this->dba->selectFirst('contact', ['name', 'url', 'request', 'avatar'], ['id' => $suggest_contact_id, 'uid' => local_user()]);
 		if (empty($contact)) {
-			notice(DI::l10n()->t('Suggested contact not found.'));
+			notice($this->l10n->t('Suggested contact not found.'));
 			return;
 		}
 
 		$note = Strings::escapeHtml(trim($_POST['note'] ?? ''));
 
-		$suggest = DI::fsuggest()->save(DI::fsuggestFactory()->createNew(
+		$suggest = $this->friendSuggestRepo->save($this->friendSuggestFac->createNew(
 			local_user(),
 			$cid,
 			$contact['name'],
@@ -80,17 +97,17 @@ class FriendSuggest extends BaseModule
 
 		Worker::add(PRIORITY_HIGH, 'Notifier', Delivery::SUGGESTION, $suggest->id);
 
-		info(DI::l10n()->t('Friend suggestion sent.'));
+		info($this->l10n->t('Friend suggestion sent.'));
 	}
 
 	public function content(): string
 	{
 		$cid = intval($this->parameters['contact']);
 
-		$contact = DI::dba()->selectFirst('contact', [], ['id' => $cid, 'uid' => local_user()]);
+		$contact = $this->dba->selectFirst('contact', [], ['id' => $cid, 'uid' => local_user()]);
 		if (empty($contact)) {
-			notice(DI::l10n()->t('Contact not found.'));
-			DI::baseUrl()->redirect();
+			notice($this->l10n->t('Contact not found.'));
+			$this->baseUrl->redirect();
 		}
 
 		$suggestableContacts = ContactModel::selectToArray(['id', 'name'], [
@@ -117,15 +134,15 @@ class FriendSuggest extends BaseModule
 		$tpl = Renderer::getMarkupTemplate('fsuggest.tpl');
 		return Renderer::replaceMacros($tpl, [
 			'$contact_id'      => $cid,
-			'$fsuggest_title'  => DI::l10n()->t('Suggest Friends'),
+			'$fsuggest_title'  => $this->l10n->t('Suggest Friends'),
 			'$fsuggest_select' => [
 				'suggest',
-				DI::l10n()->t('Suggest a friend for %s', $contact['name']),
+				$this->l10n->t('Suggest a friend for %s', $contact['name']),
 				'',
 				'',
 				$formattedContacts,
 			],
-			'$submit'          => DI::l10n()->t('Submit'),
+			'$submit'          => $this->l10n->t('Submit'),
 		]);
 	}
 }

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -25,6 +25,7 @@ use Friendica\App;
 use Friendica\BaseModule;
 use Friendica\Core;
 use Friendica\Core\Config\ValueObject\Cache;
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Core\Theme;
 use Friendica\DI;
@@ -58,110 +59,119 @@ class Install extends BaseModule
 	/**
 	 * @var int The current step of the wizard
 	 */
-	private static $currentWizardStep;
+	private $currentWizardStep;
 
 	/**
 	 * @var Core\Installer The installer
 	 */
-	private static $installer;
+	private $installer;
+	
+	/** @var App */
+	protected $app;
+	/** @var App\Mode */
+	protected $mode;
+	/** @var App\BaseURL */
+	protected $baseUrl;
 
-	public function init()
+	public function __construct(App $app, App\Mode $mode, App\BaseURL $baseUrl, App\Arguments $args, Core\Installer $installer, L10n $l10n, array $parameters = [])
 	{
-		$a = DI::app();
+		parent::__construct($l10n, $parameters);
 
-		if (!DI::mode()->isInstall()) {
+		$this->app       = $app;
+		$this->mode      = $mode;
+		$this->baseUrl   = $baseUrl;
+		$this->installer = $installer;
+
+		if (!$this->mode->isInstall()) {
 			throw new HTTPException\ForbiddenException();
 		}
 
 		// route: install/testrwrite
 		// $baseurl/install/testrwrite to test if rewrite in .htaccess is working
-		if (DI::args()->get(1, '') == 'testrewrite') {
+		if ($args->get(1, '') == 'testrewrite') {
 			// Status Code 204 means that it worked without content
 			throw new HTTPException\NoContentException();
 		}
 
-		self::$installer = new Core\Installer();
-
 		// get basic installation information and save them to the config cache
-		$configCache = $a->getConfigCache();
-		$basePath = new BasePath($a->getBasePath());
-		self::$installer->setUpCache($configCache, $basePath->getPath());
+		$configCache = $this->app->getConfigCache();
+		$basePath = new BasePath($this->app->getBasePath());
+		$this->installer->setUpCache($configCache, $basePath->getPath());
 
 		// We overwrite current theme css, because during install we may not have a working mod_rewrite
 		// so we may not have a css at all. Here we set a static css file for the install procedure pages
-		Renderer::$theme['stylesheet'] = DI::baseUrl()->get() . '/view/install/style.css';
+		Renderer::$theme['stylesheet'] = $this->baseUrl->get() . '/view/install/style.css';
 
-		self::$currentWizardStep = ($_POST['pass'] ?? '') ?: self::SYSTEM_CHECK;
+		$this->currentWizardStep = ($_POST['pass'] ?? '') ?: self::SYSTEM_CHECK;
 	}
 
 	public function post()
 	{
-		$a           = DI::app();
-		$configCache = $a->getConfigCache();
+		$configCache = $this->app->getConfigCache();
 
-		switch (self::$currentWizardStep) {
+		switch ($this->currentWizardStep) {
 			case self::SYSTEM_CHECK:
 			case self::BASE_CONFIG:
-				self::checkSetting($configCache, $_POST, 'config', 'php_path');
+				$this->checkSetting($configCache, $_POST, 'config', 'php_path');
 				break;
 
 			case self::DATABASE_CONFIG:
-				self::checkSetting($configCache, $_POST, 'config', 'php_path');
+				$this->checkSetting($configCache, $_POST, 'config', 'php_path');
 
-				self::checkSetting($configCache, $_POST, 'config', 'hostname');
-				self::checkSetting($configCache, $_POST, 'system', 'ssl_policy');
-				self::checkSetting($configCache, $_POST, 'system', 'basepath');
-				self::checkSetting($configCache, $_POST, 'system', 'urlpath');
+				$this->checkSetting($configCache, $_POST, 'config', 'hostname');
+				$this->checkSetting($configCache, $_POST, 'system', 'ssl_policy');
+				$this->checkSetting($configCache, $_POST, 'system', 'basepath');
+				$this->checkSetting($configCache, $_POST, 'system', 'urlpath');
 				break;
 
 			case self::SITE_SETTINGS:
-				self::checkSetting($configCache, $_POST, 'config', 'php_path');
+				$this->checkSetting($configCache, $_POST, 'config', 'php_path');
 
-				self::checkSetting($configCache, $_POST, 'config', 'hostname');
-				self::checkSetting($configCache, $_POST, 'system', 'ssl_policy');
-				self::checkSetting($configCache, $_POST, 'system', 'basepath');
-				self::checkSetting($configCache, $_POST, 'system', 'urlpath');
+				$this->checkSetting($configCache, $_POST, 'config', 'hostname');
+				$this->checkSetting($configCache, $_POST, 'system', 'ssl_policy');
+				$this->checkSetting($configCache, $_POST, 'system', 'basepath');
+				$this->checkSetting($configCache, $_POST, 'system', 'urlpath');
 
-				self::checkSetting($configCache, $_POST, 'database', 'hostname', Core\Installer::DEFAULT_HOST);
-				self::checkSetting($configCache, $_POST, 'database', 'username', '');
-				self::checkSetting($configCache, $_POST, 'database', 'password', '');
-				self::checkSetting($configCache, $_POST, 'database', 'database', '');
+				$this->checkSetting($configCache, $_POST, 'database', 'hostname', Core\Installer::DEFAULT_HOST);
+				$this->checkSetting($configCache, $_POST, 'database', 'username', '');
+				$this->checkSetting($configCache, $_POST, 'database', 'password', '');
+				$this->checkSetting($configCache, $_POST, 'database', 'database', '');
 
 				// If we cannot connect to the database, return to the previous step
-				if (!self::$installer->checkDB(DI::dba())) {
-					self::$currentWizardStep = self::DATABASE_CONFIG;
+				if (!$this->installer->checkDB(DI::dba())) {
+					$this->currentWizardStep = self::DATABASE_CONFIG;
 				}
 
 				break;
 
 			case self::FINISHED:
-				self::checkSetting($configCache, $_POST, 'config', 'php_path');
+				$this->checkSetting($configCache, $_POST, 'config', 'php_path');
 
-				self::checkSetting($configCache, $_POST, 'config', 'hostname');
-				self::checkSetting($configCache, $_POST, 'system', 'ssl_policy');
-				self::checkSetting($configCache, $_POST, 'system', 'basepath');
-				self::checkSetting($configCache, $_POST, 'system', 'urlpath');
+				$this->checkSetting($configCache, $_POST, 'config', 'hostname');
+				$this->checkSetting($configCache, $_POST, 'system', 'ssl_policy');
+				$this->checkSetting($configCache, $_POST, 'system', 'basepath');
+				$this->checkSetting($configCache, $_POST, 'system', 'urlpath');
 
-				self::checkSetting($configCache, $_POST, 'database', 'hostname', Core\Installer::DEFAULT_HOST);
-				self::checkSetting($configCache, $_POST, 'database', 'username', '');
-				self::checkSetting($configCache, $_POST, 'database', 'password', '');
-				self::checkSetting($configCache, $_POST, 'database', 'database', '');
+				$this->checkSetting($configCache, $_POST, 'database', 'hostname', Core\Installer::DEFAULT_HOST);
+				$this->checkSetting($configCache, $_POST, 'database', 'username', '');
+				$this->checkSetting($configCache, $_POST, 'database', 'password', '');
+				$this->checkSetting($configCache, $_POST, 'database', 'database', '');
 
-				self::checkSetting($configCache, $_POST, 'system', 'default_timezone', Core\Installer::DEFAULT_TZ);
-				self::checkSetting($configCache, $_POST, 'system', 'language', Core\Installer::DEFAULT_LANG);
-				self::checkSetting($configCache, $_POST, 'config', 'admin_email', '');
+				$this->checkSetting($configCache, $_POST, 'system', 'default_timezone', Core\Installer::DEFAULT_TZ);
+				$this->checkSetting($configCache, $_POST, 'system', 'language', Core\Installer::DEFAULT_LANG);
+				$this->checkSetting($configCache, $_POST, 'config', 'admin_email', '');
 
 				// If we cannot connect to the database, return to the Database config wizard
-				if (!self::$installer->checkDB(DI::dba())) {
-					self::$currentWizardStep = self::DATABASE_CONFIG;
+				if (!$this->installer->checkDB(DI::dba())) {
+					$this->currentWizardStep = self::DATABASE_CONFIG;
 					return;
 				}
 
-				if (!self::$installer->createConfig($configCache)) {
+				if (!$this->installer->createConfig($configCache)) {
 					return;
 				}
 
-				self::$installer->installDatabase($configCache->get('system', 'basepath'));
+				$this->installer->installDatabase($configCache->get('system', 'basepath'));
 			
 				// install allowed themes to register theme hooks
 				// this is same as "Reload active theme" in /admin/themes
@@ -179,69 +189,68 @@ class Install extends BaseModule
 
 	public function content(): string
 	{
-		$a           = DI::app();
-		$configCache = $a->getConfigCache();
+		$configCache = $this->app->getConfigCache();
 
 		$output = '';
 
-		$install_title = DI::l10n()->t('Friendica Communications Server - Setup');
+		$install_title = $this->l10n->t('Friendica Communications Server - Setup');
 
-		switch (self::$currentWizardStep) {
+		switch ($this->currentWizardStep) {
 			case self::SYSTEM_CHECK:
 				$php_path = $configCache->get('config', 'php_path');
 
-				$status = self::$installer->checkEnvironment(DI::baseUrl()->get(), $php_path);
+				$status = $this->installer->checkEnvironment($this->baseUrl->get(), $php_path);
 
 				$tpl    = Renderer::getMarkupTemplate('install_checks.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
 					'$title'       => $install_title,
-					'$pass'        => DI::l10n()->t('System check'),
-					'$required'    => DI::l10n()->t('Required'),
-					'$requirement_not_satisfied' => DI::l10n()->t('Requirement not satisfied'),
-					'$optional_requirement_not_satisfied' => DI::l10n()->t('Optional requirement not satisfied'),
-					'$ok'          => DI::l10n()->t('OK'),
-					'$checks'      => self::$installer->getChecks(),
+					'$pass'        => $this->l10n->t('System check'),
+					'$required'    => $this->l10n->t('Required'),
+					'$requirement_not_satisfied' => $this->l10n->t('Requirement not satisfied'),
+					'$optional_requirement_not_satisfied' => $this->l10n->t('Optional requirement not satisfied'),
+					'$ok'          => $this->l10n->t('OK'),
+					'$checks'      => $this->installer->getChecks(),
 					'$passed'      => $status,
-					'$see_install' => DI::l10n()->t('Please see the file "doc/INSTALL.md".'),
-					'$next'        => DI::l10n()->t('Next'),
-					'$reload'      => DI::l10n()->t('Check again'),
+					'$see_install' => $this->l10n->t('Please see the file "doc/INSTALL.md".'),
+					'$next'        => $this->l10n->t('Next'),
+					'$reload'      => $this->l10n->t('Check again'),
 					'$php_path'    => $php_path,
 				]);
 				break;
 
 			case self::BASE_CONFIG:
 				$ssl_choices = [
-					App\BaseURL::SSL_POLICY_NONE     => DI::l10n()->t("No SSL policy, links will track page SSL state"),
-					App\BaseURL::SSL_POLICY_FULL     => DI::l10n()->t("Force all links to use SSL"),
-					App\BaseURL::SSL_POLICY_SELFSIGN => DI::l10n()->t("Self-signed certificate, use SSL for local links only \x28discouraged\x29")
+					App\BaseURL::SSL_POLICY_NONE     => $this->l10n->t("No SSL policy, links will track page SSL state"),
+					App\BaseURL::SSL_POLICY_FULL     => $this->l10n->t("Force all links to use SSL"),
+					App\BaseURL::SSL_POLICY_SELFSIGN => $this->l10n->t("Self-signed certificate, use SSL for local links only \x28discouraged\x29")
 				];
 
 				$tpl    = Renderer::getMarkupTemplate('install_base.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
 					'$title'      => $install_title,
-					'$pass'       => DI::l10n()->t('Base settings'),
+					'$pass'       => $this->l10n->t('Base settings'),
 					'$ssl_policy' => ['system-ssl_policy',
-						DI::l10n()->t("SSL link policy"),
+						$this->l10n->t("SSL link policy"),
 						$configCache->get('system', 'ssl_policy'),
-						DI::l10n()->t("Determines whether generated links should be forced to use SSL"),
+						$this->l10n->t("Determines whether generated links should be forced to use SSL"),
 						$ssl_choices],
 					'$hostname'   => ['config-hostname',
-						DI::l10n()->t('Host name'),
+						$this->l10n->t('Host name'),
 						$configCache->get('config', 'hostname'),
-						DI::l10n()->t('Overwrite this field in case the determinated hostname isn\'t right, otherweise leave it as is.'),
-						DI::l10n()->t('Required')],
+						$this->l10n->t('Overwrite this field in case the determinated hostname isn\'t right, otherweise leave it as is.'),
+						$this->l10n->t('Required')],
 					'$basepath'   => ['system-basepath',
-						DI::l10n()->t("Base path to installation"),
+						$this->l10n->t("Base path to installation"),
 						$configCache->get('system', 'basepath'),
-						DI::l10n()->t("If the system cannot detect the correct path to your installation, enter the correct path here. This setting should only be set if you are using a restricted system and symbolic links to your webroot."),
-						DI::l10n()->t('Required')],
+						$this->l10n->t("If the system cannot detect the correct path to your installation, enter the correct path here. This setting should only be set if you are using a restricted system and symbolic links to your webroot."),
+						$this->l10n->t('Required')],
 					'$urlpath'    => ['system-urlpath',
-						DI::l10n()->t('Sub path of the URL'),
+						$this->l10n->t('Sub path of the URL'),
 						$configCache->get('system', 'urlpath'),
-						DI::l10n()->t('Overwrite this field in case the sub path determination isn\'t right, otherwise leave it as is. Leaving this field blank means the installation is at the base URL without sub path.'),
+						$this->l10n->t('Overwrite this field in case the sub path determination isn\'t right, otherwise leave it as is. Leaving this field blank means the installation is at the base URL without sub path.'),
 						''],
 					'$php_path'   => $configCache->get('config', 'php_path'),
-					'$submit'     => DI::l10n()->t('Submit'),
+					'$submit'     => $this->l10n->t('Submit'),
 				]);
 				break;
 
@@ -249,54 +258,54 @@ class Install extends BaseModule
 				$tpl    = Renderer::getMarkupTemplate('install_db.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
 					'$title'      => $install_title,
-					'$pass'       => DI::l10n()->t('Database connection'),
-					'$info_01'    => DI::l10n()->t('In order to install Friendica we need to know how to connect to your database.'),
-					'$info_02'    => DI::l10n()->t('Please contact your hosting provider or site administrator if you have questions about these settings.'),
-					'$info_03'    => DI::l10n()->t('The database you specify below should already exist. If it does not, please create it before continuing.'),
-					'$required'   => DI::l10n()->t('Required'),
-					'$requirement_not_satisfied' => DI::l10n()->t('Requirement not satisfied'),
-					'$checks'     => self::$installer->getChecks(),
+					'$pass'       => $this->l10n->t('Database connection'),
+					'$info_01'    => $this->l10n->t('In order to install Friendica we need to know how to connect to your database.'),
+					'$info_02'    => $this->l10n->t('Please contact your hosting provider or site administrator if you have questions about these settings.'),
+					'$info_03'    => $this->l10n->t('The database you specify below should already exist. If it does not, please create it before continuing.'),
+					'$required'   => $this->l10n->t('Required'),
+					'$requirement_not_satisfied' => $this->l10n->t('Requirement not satisfied'),
+					'$checks'     => $this->installer->getChecks(),
 					'$hostname'   => $configCache->get('config', 'hostname'),
 					'$ssl_policy' => $configCache->get('system', 'ssl_policy'),
 					'$basepath'   => $configCache->get('system', 'basepath'),
 					'$urlpath'    => $configCache->get('system', 'urlpath'),
 					'$dbhost'     => ['database-hostname',
-						DI::l10n()->t('Database Server Name'),
+						$this->l10n->t('Database Server Name'),
 						$configCache->get('database', 'hostname'),
 						'',
-						DI::l10n()->t('Required')],
+						$this->l10n->t('Required')],
 					'$dbuser'     => ['database-username',
-						DI::l10n()->t('Database Login Name'),
+						$this->l10n->t('Database Login Name'),
 						$configCache->get('database', 'username'),
 						'',
-						DI::l10n()->t('Required'),
+						$this->l10n->t('Required'),
 						'autofocus'],
 					'$dbpass'     => ['database-password',
-						DI::l10n()->t('Database Login Password'),
+						$this->l10n->t('Database Login Password'),
 						$configCache->get('database', 'password'),
-						DI::l10n()->t("For security reasons the password must not be empty"),
-						DI::l10n()->t('Required')],
+						$this->l10n->t("For security reasons the password must not be empty"),
+						$this->l10n->t('Required')],
 					'$dbdata'     => ['database-database',
-						DI::l10n()->t('Database Name'),
+						$this->l10n->t('Database Name'),
 						$configCache->get('database', 'database'),
 						'',
-						DI::l10n()->t('Required')],
-					'$lbl_10'     => DI::l10n()->t('Please select a default timezone for your website'),
+						$this->l10n->t('Required')],
+					'$lbl_10'     => $this->l10n->t('Please select a default timezone for your website'),
 					'$php_path'   => $configCache->get('config', 'php_path'),
-					'$submit'     => DI::l10n()->t('Submit')
+					'$submit'     => $this->l10n->t('Submit')
 				]);
 				break;
 
 			case self::SITE_SETTINGS:
 				/* Installed langs */
-				$lang_choices = DI::l10n()->getAvailableLanguages();
+				$lang_choices = $this->l10n->getAvailableLanguages();
 
 				$tpl    = Renderer::getMarkupTemplate('install_settings.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
 					'$title'      => $install_title,
-					'$required'   => DI::l10n()->t('Required'),
-					'$checks'     => self::$installer->getChecks(),
-					'$pass'       => DI::l10n()->t('Site settings'),
+					'$required'   => $this->l10n->t('Required'),
+					'$checks'     => $this->installer->getChecks(),
+					'$pass'       => $this->l10n->t('Site settings'),
 					'$hostname'   => $configCache->get('config', 'hostname'),
 					'$ssl_policy' => $configCache->get('system', 'ssl_policy'),
 					'$basepath'   => $configCache->get('system', 'basepath'),
@@ -306,41 +315,41 @@ class Install extends BaseModule
 					'$dbpass'     => $configCache->get('database', 'password'),
 					'$dbdata'     => $configCache->get('database', 'database'),
 					'$adminmail'  => ['config-admin_email',
-						DI::l10n()->t('Site administrator email address'),
+						$this->l10n->t('Site administrator email address'),
 						$configCache->get('config', 'admin_email'),
-						DI::l10n()->t('Your account email address must match this in order to use the web admin panel.'),
-						DI::l10n()->t('Required'), 'autofocus', 'email'],
+						$this->l10n->t('Your account email address must match this in order to use the web admin panel.'),
+						$this->l10n->t('Required'), 'autofocus', 'email'],
 					'$timezone'   => Temporal::getTimezoneField('system-default_timezone',
-						DI::l10n()->t('Please select a default timezone for your website'),
+						$this->l10n->t('Please select a default timezone for your website'),
 						$configCache->get('system', 'default_timezone'),
 						''),
 					'$language'   => ['system-language',
-						DI::l10n()->t('System Language:'),
+						$this->l10n->t('System Language:'),
 						$configCache->get('system', 'language'),
-						DI::l10n()->t('Set the default language for your Friendica installation interface and to send emails.'),
+						$this->l10n->t('Set the default language for your Friendica installation interface and to send emails.'),
 						$lang_choices],
 					'$php_path'   => $configCache->get('config', 'php_path'),
-					'$submit'     => DI::l10n()->t('Submit')
+					'$submit'     => $this->l10n->t('Submit')
 				]);
 				break;
 
 			case self::FINISHED:
 				$db_return_text = "";
 
-				if (count(self::$installer->getChecks()) == 0) {
+				if (count($this->installer->getChecks()) == 0) {
 					$txt            = '<p style="font-size: 130%;">';
-					$txt            .= DI::l10n()->t('Your Friendica site database has been installed.') . EOL;
+					$txt            .= $this->l10n->t('Your Friendica site database has been installed.') . EOL;
 					$db_return_text .= $txt;
 				}
 
 				$tpl    = Renderer::getMarkupTemplate('install_finished.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
 					'$title'    => $install_title,
-					'$required' => DI::l10n()->t('Required'),
-					'$requirement_not_satisfied' => DI::l10n()->t('Requirement not satisfied'),
-					'$checks'   => self::$installer->getChecks(),
-					'$pass'     => DI::l10n()->t('Installation finished'),
-					'$text'     => $db_return_text . self::whatNext(),
+					'$required' => $this->l10n->t('Required'),
+					'$requirement_not_satisfied' => $this->l10n->t('Requirement not satisfied'),
+					'$checks'   => $this->installer->getChecks(),
+					'$pass'     => $this->l10n->t('Installation finished'),
+					'$text'     => $db_return_text . $this->whatNext(),
 				]);
 
 				break;
@@ -355,15 +364,15 @@ class Install extends BaseModule
 	 * @return string The text for the next steps
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	private static function whatNext()
+	private function whatNext()
 	{
-		$baseurl = DI::baseUrl()->get();
+		$baseurl = $this->baseUrl->get();
 		return
-			DI::l10n()->t('<h1>What next</h1>')
-			. "<p>" . DI::l10n()->t('IMPORTANT: You will need to [manually] setup a scheduled task for the worker.')
-			. DI::l10n()->t('Please see the file "doc/INSTALL.md".')
+			$this->l10n->t('<h1>What next</h1>')
+			. "<p>" . $this->l10n->t('IMPORTANT: You will need to [manually] setup a scheduled task for the worker.')
+			. $this->l10n->t('Please see the file "doc/INSTALL.md".')
 			. "</p><p>"
-			. DI::l10n()->t('Go to your new Friendica node <a href="%s/register">registration page</a> and register as new user. Remember to use the same email you have entered as administrator email. This will allow you to enter the site admin panel.', $baseurl)
+			. $this->l10n->t('Go to your new Friendica node <a href="%s/register">registration page</a> and register as new user. Remember to use the same email you have entered as administrator email. This will allow you to enter the site admin panel.', $baseurl)
 			. "</p>";
 	}
 
@@ -376,7 +385,7 @@ class Install extends BaseModule
 	 * @param string                                   $key         The key of the setting
 	 * @param null|string                              $default     The default value
 	 */
-	private static function checkSetting(Cache $configCache, array $post, $cat, $key, $default = null)
+	private function checkSetting(Cache $configCache, array $post, $cat, $key, $default = null)
 	{
 		$configCache->set($cat, $key,
 			trim(($post[sprintf('%s-%s', $cat, $key)] ?? '') ?:

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -193,7 +193,7 @@ class Install extends BaseModule
 
 		$output = '';
 
-		$install_title = $this->l10n->t('Friendica Communications Server - Setup');
+		$install_title = $this->t('Friendica Communications Server - Setup');
 
 		switch ($this->currentWizardStep) {
 			case self::SYSTEM_CHECK:
@@ -204,53 +204,53 @@ class Install extends BaseModule
 				$tpl    = Renderer::getMarkupTemplate('install_checks.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
 					'$title'       => $install_title,
-					'$pass'        => $this->l10n->t('System check'),
-					'$required'    => $this->l10n->t('Required'),
-					'$requirement_not_satisfied' => $this->l10n->t('Requirement not satisfied'),
-					'$optional_requirement_not_satisfied' => $this->l10n->t('Optional requirement not satisfied'),
-					'$ok'          => $this->l10n->t('OK'),
+					'$pass'        => $this->t('System check'),
+					'$required'    => $this->t('Required'),
+					'$requirement_not_satisfied' => $this->t('Requirement not satisfied'),
+					'$optional_requirement_not_satisfied' => $this->t('Optional requirement not satisfied'),
+					'$ok'          => $this->t('OK'),
 					'$checks'      => $this->installer->getChecks(),
 					'$passed'      => $status,
-					'$see_install' => $this->l10n->t('Please see the file "doc/INSTALL.md".'),
-					'$next'        => $this->l10n->t('Next'),
-					'$reload'      => $this->l10n->t('Check again'),
+					'$see_install' => $this->t('Please see the file "doc/INSTALL.md".'),
+					'$next'        => $this->t('Next'),
+					'$reload'      => $this->t('Check again'),
 					'$php_path'    => $php_path,
 				]);
 				break;
 
 			case self::BASE_CONFIG:
 				$ssl_choices = [
-					App\BaseURL::SSL_POLICY_NONE     => $this->l10n->t("No SSL policy, links will track page SSL state"),
-					App\BaseURL::SSL_POLICY_FULL     => $this->l10n->t("Force all links to use SSL"),
-					App\BaseURL::SSL_POLICY_SELFSIGN => $this->l10n->t("Self-signed certificate, use SSL for local links only \x28discouraged\x29")
+					App\BaseURL::SSL_POLICY_NONE     => $this->t("No SSL policy, links will track page SSL state"),
+					App\BaseURL::SSL_POLICY_FULL     => $this->t("Force all links to use SSL"),
+					App\BaseURL::SSL_POLICY_SELFSIGN => $this->t("Self-signed certificate, use SSL for local links only \x28discouraged\x29")
 				];
 
 				$tpl    = Renderer::getMarkupTemplate('install_base.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
 					'$title'      => $install_title,
-					'$pass'       => $this->l10n->t('Base settings'),
+					'$pass'       => $this->t('Base settings'),
 					'$ssl_policy' => ['system-ssl_policy',
-						$this->l10n->t("SSL link policy"),
+						$this->t("SSL link policy"),
 						$configCache->get('system', 'ssl_policy'),
-						$this->l10n->t("Determines whether generated links should be forced to use SSL"),
+						$this->t("Determines whether generated links should be forced to use SSL"),
 						$ssl_choices],
 					'$hostname'   => ['config-hostname',
-						$this->l10n->t('Host name'),
+						$this->t('Host name'),
 						$configCache->get('config', 'hostname'),
-						$this->l10n->t('Overwrite this field in case the determinated hostname isn\'t right, otherweise leave it as is.'),
-						$this->l10n->t('Required')],
+						$this->t('Overwrite this field in case the determinated hostname isn\'t right, otherweise leave it as is.'),
+						$this->t('Required')],
 					'$basepath'   => ['system-basepath',
-						$this->l10n->t("Base path to installation"),
+						$this->t("Base path to installation"),
 						$configCache->get('system', 'basepath'),
-						$this->l10n->t("If the system cannot detect the correct path to your installation, enter the correct path here. This setting should only be set if you are using a restricted system and symbolic links to your webroot."),
-						$this->l10n->t('Required')],
+						$this->t("If the system cannot detect the correct path to your installation, enter the correct path here. This setting should only be set if you are using a restricted system and symbolic links to your webroot."),
+						$this->t('Required')],
 					'$urlpath'    => ['system-urlpath',
-						$this->l10n->t('Sub path of the URL'),
+						$this->t('Sub path of the URL'),
 						$configCache->get('system', 'urlpath'),
-						$this->l10n->t('Overwrite this field in case the sub path determination isn\'t right, otherwise leave it as is. Leaving this field blank means the installation is at the base URL without sub path.'),
+						$this->t('Overwrite this field in case the sub path determination isn\'t right, otherwise leave it as is. Leaving this field blank means the installation is at the base URL without sub path.'),
 						''],
 					'$php_path'   => $configCache->get('config', 'php_path'),
-					'$submit'     => $this->l10n->t('Submit'),
+					'$submit'     => $this->t('Submit'),
 				]);
 				break;
 
@@ -258,41 +258,41 @@ class Install extends BaseModule
 				$tpl    = Renderer::getMarkupTemplate('install_db.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
 					'$title'      => $install_title,
-					'$pass'       => $this->l10n->t('Database connection'),
-					'$info_01'    => $this->l10n->t('In order to install Friendica we need to know how to connect to your database.'),
-					'$info_02'    => $this->l10n->t('Please contact your hosting provider or site administrator if you have questions about these settings.'),
-					'$info_03'    => $this->l10n->t('The database you specify below should already exist. If it does not, please create it before continuing.'),
-					'$required'   => $this->l10n->t('Required'),
-					'$requirement_not_satisfied' => $this->l10n->t('Requirement not satisfied'),
+					'$pass'       => $this->t('Database connection'),
+					'$info_01'    => $this->t('In order to install Friendica we need to know how to connect to your database.'),
+					'$info_02'    => $this->t('Please contact your hosting provider or site administrator if you have questions about these settings.'),
+					'$info_03'    => $this->t('The database you specify below should already exist. If it does not, please create it before continuing.'),
+					'$required'   => $this->t('Required'),
+					'$requirement_not_satisfied' => $this->t('Requirement not satisfied'),
 					'$checks'     => $this->installer->getChecks(),
 					'$hostname'   => $configCache->get('config', 'hostname'),
 					'$ssl_policy' => $configCache->get('system', 'ssl_policy'),
 					'$basepath'   => $configCache->get('system', 'basepath'),
 					'$urlpath'    => $configCache->get('system', 'urlpath'),
 					'$dbhost'     => ['database-hostname',
-						$this->l10n->t('Database Server Name'),
+						$this->t('Database Server Name'),
 						$configCache->get('database', 'hostname'),
 						'',
-						$this->l10n->t('Required')],
+						$this->t('Required')],
 					'$dbuser'     => ['database-username',
-						$this->l10n->t('Database Login Name'),
+						$this->t('Database Login Name'),
 						$configCache->get('database', 'username'),
 						'',
-						$this->l10n->t('Required'),
+						$this->t('Required'),
 						'autofocus'],
 					'$dbpass'     => ['database-password',
-						$this->l10n->t('Database Login Password'),
+						$this->t('Database Login Password'),
 						$configCache->get('database', 'password'),
-						$this->l10n->t("For security reasons the password must not be empty"),
-						$this->l10n->t('Required')],
+						$this->t("For security reasons the password must not be empty"),
+						$this->t('Required')],
 					'$dbdata'     => ['database-database',
-						$this->l10n->t('Database Name'),
+						$this->t('Database Name'),
 						$configCache->get('database', 'database'),
 						'',
-						$this->l10n->t('Required')],
-					'$lbl_10'     => $this->l10n->t('Please select a default timezone for your website'),
+						$this->t('Required')],
+					'$lbl_10'     => $this->t('Please select a default timezone for your website'),
 					'$php_path'   => $configCache->get('config', 'php_path'),
-					'$submit'     => $this->l10n->t('Submit')
+					'$submit'     => $this->t('Submit')
 				]);
 				break;
 
@@ -303,9 +303,9 @@ class Install extends BaseModule
 				$tpl    = Renderer::getMarkupTemplate('install_settings.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
 					'$title'      => $install_title,
-					'$required'   => $this->l10n->t('Required'),
+					'$required'   => $this->t('Required'),
 					'$checks'     => $this->installer->getChecks(),
-					'$pass'       => $this->l10n->t('Site settings'),
+					'$pass'       => $this->t('Site settings'),
 					'$hostname'   => $configCache->get('config', 'hostname'),
 					'$ssl_policy' => $configCache->get('system', 'ssl_policy'),
 					'$basepath'   => $configCache->get('system', 'basepath'),
@@ -315,21 +315,21 @@ class Install extends BaseModule
 					'$dbpass'     => $configCache->get('database', 'password'),
 					'$dbdata'     => $configCache->get('database', 'database'),
 					'$adminmail'  => ['config-admin_email',
-						$this->l10n->t('Site administrator email address'),
+						$this->t('Site administrator email address'),
 						$configCache->get('config', 'admin_email'),
-						$this->l10n->t('Your account email address must match this in order to use the web admin panel.'),
-						$this->l10n->t('Required'), 'autofocus', 'email'],
+						$this->t('Your account email address must match this in order to use the web admin panel.'),
+						$this->t('Required'), 'autofocus', 'email'],
 					'$timezone'   => Temporal::getTimezoneField('system-default_timezone',
-						$this->l10n->t('Please select a default timezone for your website'),
+						$this->t('Please select a default timezone for your website'),
 						$configCache->get('system', 'default_timezone'),
 						''),
 					'$language'   => ['system-language',
-						$this->l10n->t('System Language:'),
+						$this->t('System Language:'),
 						$configCache->get('system', 'language'),
-						$this->l10n->t('Set the default language for your Friendica installation interface and to send emails.'),
+						$this->t('Set the default language for your Friendica installation interface and to send emails.'),
 						$lang_choices],
 					'$php_path'   => $configCache->get('config', 'php_path'),
-					'$submit'     => $this->l10n->t('Submit')
+					'$submit'     => $this->t('Submit')
 				]);
 				break;
 
@@ -338,17 +338,17 @@ class Install extends BaseModule
 
 				if (count($this->installer->getChecks()) == 0) {
 					$txt            = '<p style="font-size: 130%;">';
-					$txt            .= $this->l10n->t('Your Friendica site database has been installed.') . EOL;
+					$txt            .= $this->t('Your Friendica site database has been installed.') . EOL;
 					$db_return_text .= $txt;
 				}
 
 				$tpl    = Renderer::getMarkupTemplate('install_finished.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
 					'$title'    => $install_title,
-					'$required' => $this->l10n->t('Required'),
-					'$requirement_not_satisfied' => $this->l10n->t('Requirement not satisfied'),
+					'$required' => $this->t('Required'),
+					'$requirement_not_satisfied' => $this->t('Requirement not satisfied'),
 					'$checks'   => $this->installer->getChecks(),
-					'$pass'     => $this->l10n->t('Installation finished'),
+					'$pass'     => $this->t('Installation finished'),
 					'$text'     => $db_return_text . $this->whatNext(),
 				]);
 
@@ -368,11 +368,11 @@ class Install extends BaseModule
 	{
 		$baseurl = $this->baseUrl->get();
 		return
-			$this->l10n->t('<h1>What next</h1>')
-			. "<p>" . $this->l10n->t('IMPORTANT: You will need to [manually] setup a scheduled task for the worker.')
-			. $this->l10n->t('Please see the file "doc/INSTALL.md".')
+			$this->t('<h1>What next</h1>')
+			. "<p>" . $this->t('IMPORTANT: You will need to [manually] setup a scheduled task for the worker.')
+			. $this->t('Please see the file "doc/INSTALL.md".')
 			. "</p><p>"
-			. $this->l10n->t('Go to your new Friendica node <a href="%s/register">registration page</a> and register as new user. Remember to use the same email you have entered as administrator email. This will allow you to enter the site admin panel.', $baseurl)
+			. $this->t('Go to your new Friendica node <a href="%s/register">registration page</a> and register as new user. Remember to use the same email you have entered as administrator email. This will allow you to enter the site admin panel.', $baseurl)
 			. "</p>";
 	}
 

--- a/src/Module/Notifications/Introductions.php
+++ b/src/Module/Notifications/Introductions.php
@@ -66,7 +66,7 @@ class Introductions extends BaseNotifications
 		];
 
 		return [
-			'header'        => $this->l10n->t('Notifications'),
+			'header'        => $this->t('Notifications'),
 			'notifications' => $notifications,
 		];
 	}
@@ -90,7 +90,7 @@ class Introductions extends BaseNotifications
 		// The link to switch between ignored and normal connection requests
 		$notificationShowLink = [
 			'href' => (!$all ? 'notifications/intros/all' : 'notifications/intros'),
-			'text' => (!$all ? $this->l10n->t('Show Ignored Requests') : $this->l10n->t('Hide Ignored Requests')),
+			'text' => (!$all ? $this->t('Show Ignored Requests') : $this->t('Hide Ignored Requests')),
 		];
 
 		$owner = User::getOwnerDataById(local_user());
@@ -106,10 +106,10 @@ class Introductions extends BaseNotifications
 				case 'friend_suggestion':
 					$notificationContent[] = Renderer::replaceMacros($notificationSuggestions, [
 						'$type'                  => $Introduction->getLabel(),
-						'$str_notification_type' => $this->l10n->t('Notification type:'),
+						'$str_notification_type' => $this->t('Notification type:'),
 						'$str_type'              => $Introduction->getType(),
 						'$intro_id'              => $Introduction->getIntroId(),
-						'$lbl_madeby'            => $this->l10n->t('Suggested by:'),
+						'$lbl_madeby'            => $this->t('Suggested by:'),
 						'$madeby'                => $Introduction->getMadeBy(),
 						'$madeby_url'            => $Introduction->getMadeByUrl(),
 						'$madeby_zrl'            => $Introduction->getMadeByZrl(),
@@ -120,13 +120,13 @@ class Introductions extends BaseNotifications
 						'$dfrn_url'              => $owner['url'],
 						'$url'                   => $Introduction->getUrl(),
 						'$zrl'                   => $Introduction->getZrl(),
-						'$lbl_url'               => $this->l10n->t('Profile URL'),
+						'$lbl_url'               => $this->t('Profile URL'),
 						'$addr'                  => $Introduction->getAddr(),
 						'$action'                => 'follow',
-						'$approve'               => $this->l10n->t('Approve'),
+						'$approve'               => $this->t('Approve'),
 						'$note'                  => $Introduction->getNote(),
-						'$ignore'                => $this->l10n->t('Ignore'),
-						'$discard'               => $this->l10n->t('Discard'),
+						'$ignore'                => $this->t('Ignore'),
+						'$discard'               => $this->t('Discard'),
 						'$is_mobile'             => $this->mode->isMobile(),
 					]);
 					break;
@@ -134,8 +134,8 @@ class Introductions extends BaseNotifications
 				// Normal connection requests
 				default:
 					if ($Introduction->getNetwork() === Protocol::DFRN) {
-						$lbl_knowyou = $this->l10n->t('Claims to be known to you: ');
-						$knowyou     = ($Introduction->getKnowYou() ? $this->l10n->t('Yes') : $this->l10n->t('No'));
+						$lbl_knowyou = $this->t('Claims to be known to you: ');
+						$knowyou     = ($Introduction->getKnowYou() ? $this->t('Yes') : $this->t('No'));
 					} else {
 						$lbl_knowyou = '';
 						$knowyou = '';
@@ -143,12 +143,12 @@ class Introductions extends BaseNotifications
 
 					$convertedName = BBCode::convert($Introduction->getName());
 
-					$helptext  = $this->l10n->t('Shall your connection be bidirectional or not?');
-					$helptext2 = $this->l10n->t('Accepting %s as a friend allows %s to subscribe to your posts, and you will also receive updates from them in your news feed.', $convertedName, $convertedName);
-					$helptext3 = $this->l10n->t('Accepting %s as a subscriber allows them to subscribe to your posts, but you will not receive updates from them in your news feed.', $convertedName);
+					$helptext  = $this->t('Shall your connection be bidirectional or not?');
+					$helptext2 = $this->t('Accepting %s as a friend allows %s to subscribe to your posts, and you will also receive updates from them in your news feed.', $convertedName, $convertedName);
+					$helptext3 = $this->t('Accepting %s as a subscriber allows them to subscribe to your posts, but you will not receive updates from them in your news feed.', $convertedName);
 		
-					$friend = ['duplex', $this->l10n->t('Friend'), '1', $helptext2, true];
-					$follower = ['duplex', $this->l10n->t('Subscriber'), '0', $helptext3, false];
+					$friend = ['duplex', $this->t('Friend'), '1', $helptext2, true];
+					$follower = ['duplex', $this->t('Subscriber'), '0', $helptext3, false];
 
 					$action = 'follow_confirm';
 
@@ -161,7 +161,7 @@ class Introductions extends BaseNotifications
 					$header .= ' (' . ContactSelector::networkToName($Introduction->getNetwork(), $Introduction->getUrl()) . ')';
 
 					if ($Introduction->getNetwork() != Protocol::DIASPORA) {
-						$discard = $this->l10n->t('Discard');
+						$discard = $this->t('Discard');
 					} else {
 						$discard = '';
 					}
@@ -169,7 +169,7 @@ class Introductions extends BaseNotifications
 					$notificationContent[] = Renderer::replaceMacros($notificationTemplate, [
 						'$type'                  => $Introduction->getLabel(),
 						'$header'                => $header,
-						'$str_notification_type' => $this->l10n->t('Notification type:'),
+						'$str_notification_type' => $this->t('Notification type:'),
 						'$str_type'              => $Introduction->getType(),
 						'$dfrn_id'               => $Introduction->getDfrnId(),
 						'$uid'                   => $Introduction->getUid(),
@@ -178,26 +178,26 @@ class Introductions extends BaseNotifications
 						'$photo'                 => $Introduction->getPhoto(),
 						'$fullname'              => $Introduction->getName(),
 						'$location'              => $Introduction->getLocation(),
-						'$lbl_location'          => $this->l10n->t('Location:'),
+						'$lbl_location'          => $this->t('Location:'),
 						'$about'                 => $Introduction->getAbout(),
-						'$lbl_about'             => $this->l10n->t('About:'),
+						'$lbl_about'             => $this->t('About:'),
 						'$keywords'              => $Introduction->getKeywords(),
-						'$lbl_keywords'          => $this->l10n->t('Tags:'),
-						'$hidden'                => ['hidden', $this->l10n->t('Hide this contact from others'), $Introduction->isHidden(), ''],
+						'$lbl_keywords'          => $this->t('Tags:'),
+						'$hidden'                => ['hidden', $this->t('Hide this contact from others'), $Introduction->isHidden(), ''],
 						'$lbl_connection_type'   => $helptext,
 						'$friend'                => $friend,
 						'$follower'              => $follower,
 						'$url'                   => $Introduction->getUrl(),
 						'$zrl'                   => $Introduction->getZrl(),
-						'$lbl_url'               => $this->l10n->t('Profile URL'),
+						'$lbl_url'               => $this->t('Profile URL'),
 						'$addr'                  => $Introduction->getAddr(),
 						'$lbl_knowyou'           => $lbl_knowyou,
-						'$lbl_network'           => $this->l10n->t('Network:'),
+						'$lbl_network'           => $this->t('Network:'),
 						'$network'               => ContactSelector::networkToName($Introduction->getNetwork(), $Introduction->getUrl()),
 						'$knowyou'               => $knowyou,
-						'$approve'               => $this->l10n->t('Approve'),
+						'$approve'               => $this->t('Approve'),
 						'$note'                  => $Introduction->getNote(),
-						'$ignore'                => $this->l10n->t('Ignore'),
+						'$ignore'                => $this->t('Ignore'),
 						'$discard'               => $discard,
 						'$action'                => $action,
 						'$is_mobile'             => $this->mode->isMobile(),
@@ -207,8 +207,8 @@ class Introductions extends BaseNotifications
 		}
 
 		if (count($notifications['notifications']) == 0) {
-			notice($this->l10n->t('No introductions.'));
-			$notificationNoContent = $this->l10n->t('No more %s notifications.', $notifications['ident']);
+			notice($this->t('No introductions.'));
+			$notificationNoContent = $this->t('No more %s notifications.', $notifications['ident']);
 		}
 
 		return $this->printContent($notificationHeader, $notificationContent, $notificationNoContent, $notificationShowLink);

--- a/src/Module/Notifications/Introductions.php
+++ b/src/Module/Notifications/Introductions.php
@@ -21,14 +21,17 @@
 
 namespace Friendica\Module\Notifications;
 
+use Friendica\App\Arguments;
+use Friendica\App\Mode;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Nav;
 use Friendica\Content\Text\BBCode;
+use Friendica\Core\L10n;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
-use Friendica\DI;
 use Friendica\Model\User;
 use Friendica\Module\BaseNotifications;
+use Friendica\Navigation\Notifications\Factory\Introduction as IntroductionFactory;
 use Friendica\Navigation\Notifications\ValueObject\Introduction;
 
 /**
@@ -36,21 +39,34 @@ use Friendica\Navigation\Notifications\ValueObject\Introduction;
  */
 class Introductions extends BaseNotifications
 {
+	/** @var IntroductionFactory */
+	protected $notificationIntro;
+	/** @var Mode */
+	protected $mode;
+
+	public function __construct(Mode $mode, IntroductionFactory $notificationIntro, Arguments $args, L10n $l10n, array $parameters = [])
+	{
+		parent::__construct($args, $l10n, $parameters);
+
+		$this->notificationIntro = $notificationIntro;
+		$this->mode              = $mode;
+	}
+
 	/**
 	 * @inheritDoc
 	 */
-	public static function getNotifications()
+	public function getNotifications()
 	{
-		$id  = (int)DI::args()->get(2, 0);
-		$all = DI::args()->get(2) == 'all';
+		$id  = (int)$this->args->get(2, 0);
+		$all = $this->args->get(2) == 'all';
 
 		$notifications = [
 			'ident'         => 'introductions',
-			'notifications' => DI::notificationIntro()->getList($all, self::$firstItemNum, self::ITEMS_PER_PAGE, $id),
+			'notifications' => $this->notificationIntro->getList($all, $this->firstItemNum, self::ITEMS_PER_PAGE, $id),
 		];
 
 		return [
-			'header'        => DI::l10n()->t('Notifications'),
+			'header'        => $this->l10n->t('Notifications'),
 			'notifications' => $notifications,
 		];
 	}
@@ -59,12 +75,12 @@ class Introductions extends BaseNotifications
 	{
 		Nav::setSelected('introductions');
 
-		$all = DI::args()->get(2) == 'all';
+		$all = $this->args->get(2) == 'all';
 
 		$notificationContent   = [];
 		$notificationNoContent = '';
 
-		$notificationResult = self::getNotifications();
+		$notificationResult = $this->getNotifications();
 		$notifications      = $notificationResult['notifications'] ?? [];
 		$notificationHeader = $notificationResult['header'] ?? '';
 
@@ -74,7 +90,7 @@ class Introductions extends BaseNotifications
 		// The link to switch between ignored and normal connection requests
 		$notificationShowLink = [
 			'href' => (!$all ? 'notifications/intros/all' : 'notifications/intros'),
-			'text' => (!$all ? DI::l10n()->t('Show Ignored Requests') : DI::l10n()->t('Hide Ignored Requests')),
+			'text' => (!$all ? $this->l10n->t('Show Ignored Requests') : $this->l10n->t('Hide Ignored Requests')),
 		];
 
 		$owner = User::getOwnerDataById(local_user());
@@ -90,10 +106,10 @@ class Introductions extends BaseNotifications
 				case 'friend_suggestion':
 					$notificationContent[] = Renderer::replaceMacros($notificationSuggestions, [
 						'$type'                  => $Introduction->getLabel(),
-						'$str_notification_type' => DI::l10n()->t('Notification type:'),
+						'$str_notification_type' => $this->l10n->t('Notification type:'),
 						'$str_type'              => $Introduction->getType(),
 						'$intro_id'              => $Introduction->getIntroId(),
-						'$lbl_madeby'            => DI::l10n()->t('Suggested by:'),
+						'$lbl_madeby'            => $this->l10n->t('Suggested by:'),
 						'$madeby'                => $Introduction->getMadeBy(),
 						'$madeby_url'            => $Introduction->getMadeByUrl(),
 						'$madeby_zrl'            => $Introduction->getMadeByZrl(),
@@ -104,22 +120,22 @@ class Introductions extends BaseNotifications
 						'$dfrn_url'              => $owner['url'],
 						'$url'                   => $Introduction->getUrl(),
 						'$zrl'                   => $Introduction->getZrl(),
-						'$lbl_url'               => DI::l10n()->t('Profile URL'),
+						'$lbl_url'               => $this->l10n->t('Profile URL'),
 						'$addr'                  => $Introduction->getAddr(),
 						'$action'                => 'follow',
-						'$approve'               => DI::l10n()->t('Approve'),
+						'$approve'               => $this->l10n->t('Approve'),
 						'$note'                  => $Introduction->getNote(),
-						'$ignore'                => DI::l10n()->t('Ignore'),
-						'$discard'               => DI::l10n()->t('Discard'),
-						'$is_mobile'             => DI::mode()->isMobile(),
+						'$ignore'                => $this->l10n->t('Ignore'),
+						'$discard'               => $this->l10n->t('Discard'),
+						'$is_mobile'             => $this->mode->isMobile(),
 					]);
 					break;
 
 				// Normal connection requests
 				default:
 					if ($Introduction->getNetwork() === Protocol::DFRN) {
-						$lbl_knowyou = DI::l10n()->t('Claims to be known to you: ');
-						$knowyou     = ($Introduction->getKnowYou() ? DI::l10n()->t('Yes') : DI::l10n()->t('No'));
+						$lbl_knowyou = $this->l10n->t('Claims to be known to you: ');
+						$knowyou     = ($Introduction->getKnowYou() ? $this->l10n->t('Yes') : $this->l10n->t('No'));
 					} else {
 						$lbl_knowyou = '';
 						$knowyou = '';
@@ -127,12 +143,12 @@ class Introductions extends BaseNotifications
 
 					$convertedName = BBCode::convert($Introduction->getName());
 
-					$helptext  = DI::l10n()->t('Shall your connection be bidirectional or not?');
-					$helptext2 = DI::l10n()->t('Accepting %s as a friend allows %s to subscribe to your posts, and you will also receive updates from them in your news feed.', $convertedName, $convertedName);
-					$helptext3 = DI::l10n()->t('Accepting %s as a subscriber allows them to subscribe to your posts, but you will not receive updates from them in your news feed.', $convertedName);
+					$helptext  = $this->l10n->t('Shall your connection be bidirectional or not?');
+					$helptext2 = $this->l10n->t('Accepting %s as a friend allows %s to subscribe to your posts, and you will also receive updates from them in your news feed.', $convertedName, $convertedName);
+					$helptext3 = $this->l10n->t('Accepting %s as a subscriber allows them to subscribe to your posts, but you will not receive updates from them in your news feed.', $convertedName);
 		
-					$friend = ['duplex', DI::l10n()->t('Friend'), '1', $helptext2, true];
-					$follower = ['duplex', DI::l10n()->t('Subscriber'), '0', $helptext3, false];
+					$friend = ['duplex', $this->l10n->t('Friend'), '1', $helptext2, true];
+					$follower = ['duplex', $this->l10n->t('Subscriber'), '0', $helptext3, false];
 
 					$action = 'follow_confirm';
 
@@ -145,7 +161,7 @@ class Introductions extends BaseNotifications
 					$header .= ' (' . ContactSelector::networkToName($Introduction->getNetwork(), $Introduction->getUrl()) . ')';
 
 					if ($Introduction->getNetwork() != Protocol::DIASPORA) {
-						$discard = DI::l10n()->t('Discard');
+						$discard = $this->l10n->t('Discard');
 					} else {
 						$discard = '';
 					}
@@ -153,7 +169,7 @@ class Introductions extends BaseNotifications
 					$notificationContent[] = Renderer::replaceMacros($notificationTemplate, [
 						'$type'                  => $Introduction->getLabel(),
 						'$header'                => $header,
-						'$str_notification_type' => DI::l10n()->t('Notification type:'),
+						'$str_notification_type' => $this->l10n->t('Notification type:'),
 						'$str_type'              => $Introduction->getType(),
 						'$dfrn_id'               => $Introduction->getDfrnId(),
 						'$uid'                   => $Introduction->getUid(),
@@ -162,39 +178,39 @@ class Introductions extends BaseNotifications
 						'$photo'                 => $Introduction->getPhoto(),
 						'$fullname'              => $Introduction->getName(),
 						'$location'              => $Introduction->getLocation(),
-						'$lbl_location'          => DI::l10n()->t('Location:'),
+						'$lbl_location'          => $this->l10n->t('Location:'),
 						'$about'                 => $Introduction->getAbout(),
-						'$lbl_about'             => DI::l10n()->t('About:'),
+						'$lbl_about'             => $this->l10n->t('About:'),
 						'$keywords'              => $Introduction->getKeywords(),
-						'$lbl_keywords'          => DI::l10n()->t('Tags:'),
-						'$hidden'                => ['hidden', DI::l10n()->t('Hide this contact from others'), $Introduction->isHidden(), ''],
+						'$lbl_keywords'          => $this->l10n->t('Tags:'),
+						'$hidden'                => ['hidden', $this->l10n->t('Hide this contact from others'), $Introduction->isHidden(), ''],
 						'$lbl_connection_type'   => $helptext,
 						'$friend'                => $friend,
 						'$follower'              => $follower,
 						'$url'                   => $Introduction->getUrl(),
 						'$zrl'                   => $Introduction->getZrl(),
-						'$lbl_url'               => DI::l10n()->t('Profile URL'),
+						'$lbl_url'               => $this->l10n->t('Profile URL'),
 						'$addr'                  => $Introduction->getAddr(),
 						'$lbl_knowyou'           => $lbl_knowyou,
-						'$lbl_network'           => DI::l10n()->t('Network:'),
+						'$lbl_network'           => $this->l10n->t('Network:'),
 						'$network'               => ContactSelector::networkToName($Introduction->getNetwork(), $Introduction->getUrl()),
 						'$knowyou'               => $knowyou,
-						'$approve'               => DI::l10n()->t('Approve'),
+						'$approve'               => $this->l10n->t('Approve'),
 						'$note'                  => $Introduction->getNote(),
-						'$ignore'                => DI::l10n()->t('Ignore'),
+						'$ignore'                => $this->l10n->t('Ignore'),
 						'$discard'               => $discard,
 						'$action'                => $action,
-						'$is_mobile'              => DI::mode()->isMobile(),
+						'$is_mobile'             => $this->mode->isMobile(),
 					]);
 					break;
 			}
 		}
 
 		if (count($notifications['notifications']) == 0) {
-			notice(DI::l10n()->t('No introductions.'));
-			$notificationNoContent = DI::l10n()->t('No more %s notifications.', $notifications['ident']);
+			notice($this->l10n->t('No introductions.'));
+			$notificationNoContent = $this->l10n->t('No more %s notifications.', $notifications['ident']);
 		}
 
-		return self::printContent($notificationHeader, $notificationContent, $notificationNoContent, $notificationShowLink);
+		return $this->printContent($notificationHeader, $notificationContent, $notificationNoContent, $notificationShowLink);
 	}
 }

--- a/src/Module/Notifications/Notifications.php
+++ b/src/Module/Notifications/Notifications.php
@@ -63,25 +63,25 @@ class Notifications extends BaseNotifications
 		$factory = $this->formattedNotificationFactory;
 
 		if (($this->args->get(1) == 'network')) {
-			$notificationHeader = $this->l10n->t('Network Notifications');
+			$notificationHeader = $this->t('Network Notifications');
 			$notifications      = [
 				'ident'        => FormattedNotification::NETWORK,
 				'notifications' => $factory->getNetworkList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
 		} elseif (($this->args->get(1) == 'system')) {
-			$notificationHeader = $this->l10n->t('System Notifications');
+			$notificationHeader = $this->t('System Notifications');
 			$notifications      = [
 				'ident'        => FormattedNotification::SYSTEM,
 				'notifications' => $factory->getSystemList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
 		} elseif (($this->args->get(1) == 'personal')) {
-			$notificationHeader = $this->l10n->t('Personal Notifications');
+			$notificationHeader = $this->t('Personal Notifications');
 			$notifications      = [
 				'ident'        => FormattedNotification::PERSONAL,
 				'notifications' => $factory->getPersonalList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
 		} elseif (($this->args->get(1) == 'home')) {
-			$notificationHeader = $this->l10n->t('Home Notifications');
+			$notificationHeader = $this->t('Home Notifications');
 			$notifications      = [
 				'ident'        => FormattedNotification::HOME,
 				'notifications' => $factory->getHomeList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
@@ -132,12 +132,12 @@ class Notifications extends BaseNotifications
 				]);
 			}
 		} else {
-			$notificationNoContent = $this->l10n->t('No more %s notifications.', $notificationResult['ident']);
+			$notificationNoContent = $this->t('No more %s notifications.', $notificationResult['ident']);
 		}
 
 		$notificationShowLink = [
 			'href' => ($this->showAll ? 'notifications/' . $notifications['ident'] : 'notifications/' . $notifications['ident'] . '?show=all'),
-			'text' => ($this->showAll ? $this->l10n->t('Show unread') : $this->l10n->t('Show all')),
+			'text' => ($this->showAll ? $this->t('Show unread') : $this->t('Show all')),
 		];
 
 		return $this->printContent($notificationHeader, $notificationContent, $notificationNoContent, $notificationShowLink);

--- a/src/Module/Notifications/Notifications.php
+++ b/src/Module/Notifications/Notifications.php
@@ -21,13 +21,13 @@
 
 namespace Friendica\Module\Notifications;
 
+use Friendica\App\Arguments;
+use Friendica\App\BaseURL;
 use Friendica\Content\Nav;
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\DI;
 use Friendica\Module\BaseNotifications;
-use Friendica\Navigation\Notifications\Collection\FormattedNotifications;
 use Friendica\Navigation\Notifications\ValueObject\FormattedNotification;
-use Friendica\Network\HTTPException\InternalServerErrorException;
 
 /**
  * Prints all notification types except introduction:
@@ -38,42 +38,56 @@ use Friendica\Network\HTTPException\InternalServerErrorException;
  */
 class Notifications extends BaseNotifications
 {
+	/** @var \Friendica\Navigation\Notifications\Factory\FormattedNotification */
+	protected $formattedNotificationFactory;
+
+	/** @var BaseURL */
+	protected $baseUrl;
+
+	public function __construct(BaseURL $baseUrl, \Friendica\Navigation\Notifications\Factory\FormattedNotification $formattedNotificationFactory, Arguments $args, L10n $l10n, array $parameters = [])
+	{
+		parent::__construct($args, $l10n, $parameters);
+
+		$this->formattedNotificationFactory = $formattedNotificationFactory;
+		$this->baseUrl                      = $baseUrl;
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */
-	public static function getNotifications()
+	public function getNotifications()
 	{
 		$notificationHeader = '';
 		$notifications = [];
 
-		$factory = DI::formattedNotificationFactory();
+		$factory = $this->formattedNotificationFactory;
 
-		if ((DI::args()->get(1) == 'network')) {
-			$notificationHeader = DI::l10n()->t('Network Notifications');
+		if (($this->args->get(1) == 'network')) {
+			$notificationHeader = $this->l10n->t('Network Notifications');
 			$notifications      = [
 				'ident'        => FormattedNotification::NETWORK,
-				'notifications' => $factory->getNetworkList(self::$showAll, self::$firstItemNum, self::ITEMS_PER_PAGE),
+				'notifications' => $factory->getNetworkList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
-		} elseif ((DI::args()->get(1) == 'system')) {
-			$notificationHeader = DI::l10n()->t('System Notifications');
+		} elseif (($this->args->get(1) == 'system')) {
+			$notificationHeader = $this->l10n->t('System Notifications');
 			$notifications      = [
 				'ident'        => FormattedNotification::SYSTEM,
-				'notifications' => $factory->getSystemList(self::$showAll, self::$firstItemNum, self::ITEMS_PER_PAGE),
+				'notifications' => $factory->getSystemList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
-		} elseif ((DI::args()->get(1) == 'personal')) {
-			$notificationHeader = DI::l10n()->t('Personal Notifications');
+		} elseif (($this->args->get(1) == 'personal')) {
+			$notificationHeader = $this->l10n->t('Personal Notifications');
 			$notifications      = [
 				'ident'        => FormattedNotification::PERSONAL,
-				'notifications' => $factory->getPersonalList(self::$showAll, self::$firstItemNum, self::ITEMS_PER_PAGE),
+				'notifications' => $factory->getPersonalList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
-		} elseif ((DI::args()->get(1) == 'home')) {
-			$notificationHeader = DI::l10n()->t('Home Notifications');
+		} elseif (($this->args->get(1) == 'home')) {
+			$notificationHeader = $this->l10n->t('Home Notifications');
 			$notifications      = [
 				'ident'        => FormattedNotification::HOME,
-				'notifications' => $factory->getHomeList(self::$showAll, self::$firstItemNum, self::ITEMS_PER_PAGE),
+				'notifications' => $factory->getHomeList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
 		} else {
-			DI::baseUrl()->redirect('notifications');
+			$this->baseUrl->redirect('notifications');
 		}
 
 		return [
@@ -89,7 +103,7 @@ class Notifications extends BaseNotifications
 		$notificationContent   = [];
 		$notificationNoContent = '';
 
-		$notificationResult = self::getNotifications();
+		$notificationResult = $this->getNotifications();
 		$notifications      = $notificationResult['notifications'] ?? [];
 		$notificationHeader = $notificationResult['header'] ?? '';
 
@@ -118,14 +132,14 @@ class Notifications extends BaseNotifications
 				]);
 			}
 		} else {
-			$notificationNoContent = DI::l10n()->t('No more %s notifications.', $notificationResult['ident']);
+			$notificationNoContent = $this->l10n->t('No more %s notifications.', $notificationResult['ident']);
 		}
 
 		$notificationShowLink = [
-			'href' => (self::$showAll ? 'notifications/' . $notifications['ident'] : 'notifications/' . $notifications['ident'] . '?show=all'),
-			'text' => (self::$showAll ? DI::l10n()->t('Show unread') : DI::l10n()->t('Show all')),
+			'href' => ($this->showAll ? 'notifications/' . $notifications['ident'] : 'notifications/' . $notifications['ident'] . '?show=all'),
+			'text' => ($this->showAll ? $this->l10n->t('Show unread') : $this->l10n->t('Show all')),
 		];
 
-		return self::printContent($notificationHeader, $notificationContent, $notificationNoContent, $notificationShowLink);
+		return $this->printContent($notificationHeader, $notificationContent, $notificationNoContent, $notificationShowLink);
 	}
 }

--- a/src/Module/Owa.php
+++ b/src/Module/Owa.php
@@ -44,9 +44,8 @@ use Friendica\Util\Strings;
  */
 class Owa extends BaseModule
 {
-	public function init()
+	public function rawContent()
 	{
-
 		$ret = [ 'success' => false ];
 
 		foreach (['REDIRECT_REMOTE_USER', 'HTTP_AUTHORIZATION'] as $head) {

--- a/src/Module/Profile/Index.php
+++ b/src/Module/Profile/Index.php
@@ -35,11 +35,6 @@ use Friendica\Core\L10n;
  */
 class Index extends BaseModule
 {
-	public function __construct(L10n $l10n, array $parameters = [])
-	{
-		parent::__construct($l10n, $parameters);
-	}
-
 	public function rawContent()
 	{
 		(new Profile($this->l10n, $this->parameters))->rawContent();

--- a/src/Module/Profile/Index.php
+++ b/src/Module/Profile/Index.php
@@ -22,6 +22,7 @@
 namespace Friendica\Module\Profile;
 
 use Friendica\BaseModule;
+use Friendica\Core\L10n;
 
 /**
  * Profile index router
@@ -34,13 +35,18 @@ use Friendica\BaseModule;
  */
 class Index extends BaseModule
 {
+	public function __construct(L10n $l10n, array $parameters = [])
+	{
+		parent::__construct($l10n, $parameters);
+	}
+
 	public function rawContent()
 	{
-		(new Profile($this->parameters))->rawContent();
+		(new Profile($this->l10n, $this->parameters))->rawContent();
 	}
 
 	public function content(): string
 	{
-		return (new Status($this->parameters))->content();
+		return (new Status($this->l10n, $this->parameters))->content();
 	}
 }

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -33,7 +33,6 @@ use Friendica\DI;
 use Friendica\Model;
 use Friendica\Model\User;
 use Friendica\Util\Proxy;
-use Friendica\Util\Strings;
 
 /**
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
@@ -43,6 +42,16 @@ class Register extends BaseModule
 	const CLOSED  = 0;
 	const APPROVE = 1;
 	const OPEN    = 2;
+
+	/** @var Tos */
+	protected $tos;
+
+	public function __construct(Tos $tos, L10n $l10n, array $parameters = [])
+	{
+		parent::__construct($l10n, $parameters);
+
+		$this->tos = $tos;
+	}
 
 	/**
 	 * Module GET method to display any content
@@ -129,8 +138,6 @@ class Register extends BaseModule
 
 		$tpl = $arr['template'];
 
-		$tos = new Tos($this->parameters);
-
 		$o = Renderer::replaceMacros($tpl, [
 			'$invitations'  => DI::config()->get('system', 'invitation_only'),
 			'$permonly'     => intval(DI::config()->get('config', 'register_policy')) === self::APPROVE,
@@ -164,7 +171,7 @@ class Register extends BaseModule
 			'$showtoslink'  => DI::config()->get('system', 'tosdisplay'),
 			'$tostext'      => DI::l10n()->t('Terms of Service'),
 			'$showprivstatement' => DI::config()->get('system', 'tosprivstatement'),
-			'$privstatement'=> $tos->privacy_complete,
+			'$privstatement'=> $this->tos->privacy_complete,
 			'$form_security_token' => BaseModule::getFormSecurityToken('register'),
 			'$explicit_content' => DI::config()->get('system', 'explicit_content', false),
 			'$explicit_content_note' => DI::l10n()->t('Note: This node explicitly contains adult content'),

--- a/src/Module/RemoteFollow.php
+++ b/src/Module/RemoteFollow.php
@@ -59,8 +59,7 @@ class RemoteFollow extends BaseModule
 		}
 
 		$this->baseUrl = $baseUrl;
-
-		$page['aside'] = Widget\VCard::getHTML($this->owner);
+		$this->page    = $page;
 	}
 
 	public function post()
@@ -112,7 +111,9 @@ class RemoteFollow extends BaseModule
 		if (empty($this->owner)) {
 			return '';
 		}
-	
+
+		$this->page['aside'] = Widget\VCard::getHTML($this->owner);
+
 		$target_addr = $this->owner['addr'];
 		$target_url = $this->owner['url'];
 

--- a/src/Module/RemoteFollow.php
+++ b/src/Module/RemoteFollow.php
@@ -21,9 +21,11 @@
 
 namespace Friendica\Module;
 
+use Friendica\App\BaseURL;
+use Friendica\App\Page;
 use Friendica\BaseModule;
 use Friendica\Content\Widget;
-use Friendica\DI;
+use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
@@ -40,56 +42,65 @@ use Friendica\Network\Probe;
  */
 class RemoteFollow extends BaseModule
 {
-	static $owner;
+	/** @var array */
+	protected $owner;
+	/** @var Page */
+	protected $page;
+	/** @var BaseURL */
+	protected $baseUrl;
 
-	public function init()
+	public function __construct(L10n $l10n, Page $page, BaseURL $baseUrl, array $parameters = [])
 	{
-		self::$owner = User::getOwnerDataByNick($this->parameters['profile']);
-		if (!self::$owner) {
-			throw new HTTPException\NotFoundException(DI::l10n()->t('User not found.'));
+		parent::__construct($l10n, $parameters);
+
+		$this->owner = User::getOwnerDataByNick($this->parameters['profile']);
+		if (!$this->owner) {
+			throw new HTTPException\NotFoundException($this->l10n->t('User not found.'));
 		}
 
-		DI::page()['aside'] = Widget\VCard::getHTML(self::$owner);
+		$this->baseUrl = $baseUrl;
+
+		$page['aside'] = Widget\VCard::getHTML($this->owner);
 	}
 
 	public function post()
 	{
 		if (!empty($_POST['cancel']) || empty($_POST['dfrn_url'])) {
-			DI::baseUrl()->redirect();
+			$this->baseUrl->redirect();
 		}
 	
-		if (empty(self::$owner)) {
-			notice(DI::l10n()->t('Profile unavailable.'));
+		if (empty($this->owner)) {
+			notice($this->l10n->t('Profile unavailable.'));
 			return;
 		}
 		
 		$url = Probe::cleanURI($_POST['dfrn_url']);
 		if (!strlen($url)) {
-			notice(DI::l10n()->t("Invalid locator"));
+			notice($this->l10n->t("Invalid locator"));
 			return;
 		}
 
 		// Detect the network, make sure the provided URL is valid
 		$data = Contact::getByURL($url);
 		if (!$data) {
-			notice(DI::l10n()->t("The provided profile link doesn't seem to be valid"));
+			notice($this->l10n->t("The provided profile link doesn't seem to be valid"));
 			return;
 		}
 
 		if (empty($data['subscribe'])) {
-			notice(DI::l10n()->t("Remote subscription can't be done for your network. Please subscribe directly on your system."));
+			notice($this->l10n->t("Remote subscription can't be done for your network. Please subscribe directly on your system."));
 			return;
 		}
 
-		Logger::notice('Remote request', ['url' => $url, 'follow' => self::$owner['url'], 'remote' => $data['subscribe']]);
+		Logger::notice('Remote request', ['url' => $url, 'follow' => $this->owner['url'], 'remote' => $data['subscribe']]);
 		
 		// Substitute our user's feed URL into $data['subscribe']
 		// Send the subscriber home to subscribe
 		// Diaspora needs the uri in the format user@domain.tld
 		if ($data['network'] == Protocol::DIASPORA) {
-			$uri = urlencode(self::$owner['addr']);
+			$uri = urlencode($this->owner['addr']);
 		} else {
-			$uri = urlencode(self::$owner['url']);
+			$uri = urlencode($this->owner['url']);
 		}
 	
 		$follow_link = str_replace('{uri}', $uri, $data['subscribe']);
@@ -98,25 +109,25 @@ class RemoteFollow extends BaseModule
 
 	public function content(): string
 	{
-		if (empty(self::$owner)) {
+		if (empty($this->owner)) {
 			return '';
 		}
 	
-		$target_addr = self::$owner['addr'];
-		$target_url = self::$owner['url'];
+		$target_addr = $this->owner['addr'];
+		$target_url = $this->owner['url'];
 
 		$tpl = Renderer::getMarkupTemplate('auto_request.tpl');
 		$o = Renderer::replaceMacros($tpl, [
-			'$header'        => DI::l10n()->t('Friend/Connection Request'),
-			'$page_desc'     => DI::l10n()->t('Enter your Webfinger address (user@domain.tld) or profile URL here. If this isn\'t supported by your system, you have to subscribe to <strong>%s</strong> or <strong>%s</strong> directly on your system.', $target_addr, $target_url),
-			'$invite_desc'   => DI::l10n()->t('If you are not yet a member of the free social web, <a href="%s">follow this link to find a public Friendica node and join us today</a>.', Search::getGlobalDirectory() . '/servers'),
-			'$your_address'  => DI::l10n()->t('Your Webfinger address or profile URL:'),
-			'$pls_answer'    => DI::l10n()->t('Please answer the following:'),
-			'$submit'        => DI::l10n()->t('Submit Request'),
-			'$cancel'        => DI::l10n()->t('Cancel'),
+			'$header'        => $this->l10n->t('Friend/Connection Request'),
+			'$page_desc'     => $this->l10n->t('Enter your Webfinger address (user@domain.tld) or profile URL here. If this isn\'t supported by your system, you have to subscribe to <strong>%s</strong> or <strong>%s</strong> directly on your system.', $target_addr, $target_url),
+			'$invite_desc'   => $this->l10n->t('If you are not yet a member of the free social web, <a href="%s">follow this link to find a public Friendica node and join us today</a>.', Search::getGlobalDirectory() . '/servers'),
+			'$your_address'  => $this->l10n->t('Your Webfinger address or profile URL:'),
+			'$pls_answer'    => $this->l10n->t('Please answer the following:'),
+			'$submit'        => $this->l10n->t('Submit Request'),
+			'$cancel'        => $this->l10n->t('Cancel'),
 
 			'$request'       => 'remote_follow/' . $this->parameters['profile'],
-			'$name'          => self::$owner['name'],
+			'$name'          => $this->owner['name'],
 			'$myaddr'        => Profile::getMyURL(),
 		]);
 		return $o;

--- a/src/Module/RemoteFollow.php
+++ b/src/Module/RemoteFollow.php
@@ -55,7 +55,7 @@ class RemoteFollow extends BaseModule
 
 		$this->owner = User::getOwnerDataByNick($this->parameters['profile']);
 		if (!$this->owner) {
-			throw new HTTPException\NotFoundException($this->l10n->t('User not found.'));
+			throw new HTTPException\NotFoundException($this->t('User not found.'));
 		}
 
 		$this->baseUrl = $baseUrl;
@@ -69,25 +69,25 @@ class RemoteFollow extends BaseModule
 		}
 	
 		if (empty($this->owner)) {
-			notice($this->l10n->t('Profile unavailable.'));
+			notice($this->t('Profile unavailable.'));
 			return;
 		}
 		
 		$url = Probe::cleanURI($_POST['dfrn_url']);
 		if (!strlen($url)) {
-			notice($this->l10n->t("Invalid locator"));
+			notice($this->t("Invalid locator"));
 			return;
 		}
 
 		// Detect the network, make sure the provided URL is valid
 		$data = Contact::getByURL($url);
 		if (!$data) {
-			notice($this->l10n->t("The provided profile link doesn't seem to be valid"));
+			notice($this->t("The provided profile link doesn't seem to be valid"));
 			return;
 		}
 
 		if (empty($data['subscribe'])) {
-			notice($this->l10n->t("Remote subscription can't be done for your network. Please subscribe directly on your system."));
+			notice($this->t("Remote subscription can't be done for your network. Please subscribe directly on your system."));
 			return;
 		}
 
@@ -119,13 +119,13 @@ class RemoteFollow extends BaseModule
 
 		$tpl = Renderer::getMarkupTemplate('auto_request.tpl');
 		$o = Renderer::replaceMacros($tpl, [
-			'$header'        => $this->l10n->t('Friend/Connection Request'),
-			'$page_desc'     => $this->l10n->t('Enter your Webfinger address (user@domain.tld) or profile URL here. If this isn\'t supported by your system, you have to subscribe to <strong>%s</strong> or <strong>%s</strong> directly on your system.', $target_addr, $target_url),
-			'$invite_desc'   => $this->l10n->t('If you are not yet a member of the free social web, <a href="%s">follow this link to find a public Friendica node and join us today</a>.', Search::getGlobalDirectory() . '/servers'),
-			'$your_address'  => $this->l10n->t('Your Webfinger address or profile URL:'),
-			'$pls_answer'    => $this->l10n->t('Please answer the following:'),
-			'$submit'        => $this->l10n->t('Submit Request'),
-			'$cancel'        => $this->l10n->t('Cancel'),
+			'$header'        => $this->t('Friend/Connection Request'),
+			'$page_desc'     => $this->t('Enter your Webfinger address (user@domain.tld) or profile URL here. If this isn\'t supported by your system, you have to subscribe to <strong>%s</strong> or <strong>%s</strong> directly on your system.', $target_addr, $target_url),
+			'$invite_desc'   => $this->t('If you are not yet a member of the free social web, <a href="%s">follow this link to find a public Friendica node and join us today</a>.', Search::getGlobalDirectory() . '/servers'),
+			'$your_address'  => $this->t('Your Webfinger address or profile URL:'),
+			'$pls_answer'    => $this->t('Please answer the following:'),
+			'$submit'        => $this->t('Submit Request'),
+			'$cancel'        => $this->t('Cancel'),
 
 			'$request'       => 'remote_follow/' . $this->parameters['profile'],
 			'$name'          => $this->owner['name'],

--- a/src/Module/Search/Saved.php
+++ b/src/Module/Search/Saved.php
@@ -59,16 +59,16 @@ class Saved extends BaseModule
 					$fields = ['uid' => local_user(), 'term' => $search];
 					if (!$this->dba->exists('search', $fields)) {
 						if (!$this->dba->insert('search', $fields)) {
-							notice($this->l10n->t('Search term was not saved.'));
+							notice($this->t('Search term was not saved.'));
 						}
 					} else {
-						notice($this->l10n->t('Search term already saved.'));
+						notice($this->t('Search term already saved.'));
 					}
 					break;
 
 				case 'remove':
 					if (!$this->dba->delete('search', ['uid' => local_user(), 'term' => $search])) {
-						notice($this->l10n->t('Search term was not removed.'));
+						notice($this->t('Search term was not removed.'));
 					}
 					break;
 			}

--- a/src/Module/Security/Logout.php
+++ b/src/Module/Security/Logout.php
@@ -21,11 +21,15 @@
 
 namespace Friendica\Module\Security;
 
+use Friendica\App\BaseURL;
 use Friendica\BaseModule;
+use Friendica\Core\Cache\Capability\ICanCache;
 use Friendica\Core\Hook;
+use Friendica\Core\L10n;
+use Friendica\Core\Session\Capability\IHandleSessions;
 use Friendica\Core\System;
-use Friendica\DI;
 use Friendica\Model\Profile;
+use Friendica\Model\User\Cookie;
 use Friendica\Security\TwoFactor;
 
 /**
@@ -33,33 +37,55 @@ use Friendica\Security\TwoFactor;
  */
 class Logout extends BaseModule
 {
+	/** @var ICanCache */
+	protected $cache;
+	/** @var Cookie */
+	protected $cookie;
+	/** @var IHandleSessions */
+	protected $session;
+	/** @var BaseURL */
+	protected $baseUrl;
+	/** @var TwoFactor\Repository\TrustedBrowser */
+	protected $trustedBrowserRepo;
+
+	public function __construct(TwoFactor\Repository\TrustedBrowser $trustedBrowserRepo, ICanCache $cache, Cookie $cookie, IHandleSessions $session, BaseURL $baseUrl, L10n $l10n, array $parameters = [])
+	{
+		parent::__construct($l10n, $parameters);
+
+		$this->cache              = $cache;
+		$this->cookie             = $cookie;
+		$this->session            = $session;
+		$this->baseUrl            = $baseUrl;
+		$this->trustedBrowserRepo = $trustedBrowserRepo;
+	}
+
+
 	/**
 	 * Process logout requests
 	 */
-	public function init()
+	public function rawContent()
 	{
 		$visitor_home = null;
 		if (remote_user()) {
 			$visitor_home = Profile::getMyURL();
-			DI::cache()->delete('zrlInit:' . $visitor_home);
+			$this->cache->delete('zrlInit:' . $visitor_home);
 		}
 
 		Hook::callAll("logging_out");
 
 		// Remove this trusted browser as it won't be able to be used ever again after the cookie is cleared
-		if (DI::cookie()->get('trusted')) {
-			$trustedBrowserRepository = new TwoFactor\Repository\TrustedBrowser(DI::dba(), DI::logger());
-			$trustedBrowserRepository->removeForUser(local_user(), DI::cookie()->get('trusted'));
+		if ($this->cookie->get('trusted')) {
+			$this->trustedBrowserRepo->removeForUser(local_user(), $this->cookie->get('trusted'));
 		}
 
-		DI::cookie()->clear();
-		DI::session()->clear();
+		$this->cookie->clear();
+		$this->session->clear();
 
 		if ($visitor_home) {
 			System::externalRedirect($visitor_home);
 		} else {
-			info(DI::l10n()->t('Logged out.'));
-			DI::baseUrl()->redirect();
+			info($this->l10n->t('Logged out.'));
+			$this->baseUrl->redirect();
 		}
 	}
 }

--- a/src/Module/Security/Logout.php
+++ b/src/Module/Security/Logout.php
@@ -84,7 +84,7 @@ class Logout extends BaseModule
 		if ($visitor_home) {
 			System::externalRedirect($visitor_home);
 		} else {
-			info($this->l10n->t('Logged out.'));
+			info($this->t('Logged out.'));
 			$this->baseUrl->redirect();
 		}
 	}

--- a/src/Module/Security/TwoFactor/Recovery.php
+++ b/src/Module/Security/TwoFactor/Recovery.php
@@ -70,11 +70,11 @@ class Recovery extends BaseModule
 			if (RecoveryCode::existsForUser(local_user(), $recovery_code)) {
 				RecoveryCode::markUsedForUser(local_user(), $recovery_code);
 				$this->session->set('2fa', true);
-				info($this->l10n->t('Remaining recovery codes: %d', RecoveryCode::countValidForUser(local_user())));
+				info($this->t('Remaining recovery codes: %d', RecoveryCode::countValidForUser(local_user())));
 
 				$this->auth->setForUser($this->app, User::getById($this->app->getLoggedInUserId()), true, true);
 			} else {
-				notice($this->l10n->t('Invalid code, please retry.'));
+				notice($this->t('Invalid code, please retry.'));
 			}
 		}
 	}
@@ -93,11 +93,11 @@ class Recovery extends BaseModule
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('twofactor/recovery.tpl'), [
 			'$form_security_token' => self::getFormSecurityToken('twofactor_recovery'),
 
-			'$title'            => $this->l10n->t('Two-factor recovery'),
-			'$message'          => $this->l10n->t('<p>You can enter one of your one-time recovery codes in case you lost access to your mobile device.</p>'),
-			'$recovery_message' => $this->l10n->t('Don’t have your phone? <a href="%s">Enter a two-factor recovery code</a>', '2fa/recovery'),
-			'$recovery_code'    => ['recovery_code', $this->l10n->t('Please enter a recovery code'), '', '', '', 'placeholder="000000-000000"'],
-			'$recovery_label'   => $this->l10n->t('Submit recovery code and complete login'),
+			'$title'            => $this->t('Two-factor recovery'),
+			'$message'          => $this->t('<p>You can enter one of your one-time recovery codes in case you lost access to your mobile device.</p>'),
+			'$recovery_message' => $this->t('Don’t have your phone? <a href="%s">Enter a two-factor recovery code</a>', '2fa/recovery'),
+			'$recovery_code'    => ['recovery_code', $this->t('Please enter a recovery code'), '', '', '', 'placeholder="000000-000000"'],
+			'$recovery_label'   => $this->t('Submit recovery code and complete login'),
 		]);
 	}
 }

--- a/src/Module/Security/TwoFactor/Recovery.php
+++ b/src/Module/Security/TwoFactor/Recovery.php
@@ -21,11 +21,13 @@
 
 namespace Friendica\Module\Security\TwoFactor;
 
+use Friendica\App;
 use Friendica\BaseModule;
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\Core\Session;
-use Friendica\DI;
+use Friendica\Core\Session\Capability\IHandleSessions;
 use Friendica\Model\User;
+use Friendica\Security\Authentication;
 use Friendica\Security\TwoFactor\Model\RecoveryCode;
 
 /**
@@ -35,11 +37,23 @@ use Friendica\Security\TwoFactor\Model\RecoveryCode;
  */
 class Recovery extends BaseModule
 {
-	public function init()
+	/** @var IHandleSessions */
+	protected $session;
+	/** @var App */
+	protected $app;
+	/** @var App\BaseURL */
+	protected $baseUrl;
+	/** @var Authentication */
+	protected $auth;
+
+	public function __construct(App $app, App\BaseURL $baseUrl, Authentication $auth, IHandleSessions $session, L10n $l10n, array $parameters = [])
 	{
-		if (!local_user()) {
-			return;
-		}
+		parent::__construct($l10n, $parameters);
+
+		$this->app     = $app;
+		$this->baseUrl = $baseUrl;
+		$this->auth    = $auth;
+		$this->session = $session;
 	}
 
 	public function post()
@@ -51,18 +65,16 @@ class Recovery extends BaseModule
 		if (($_POST['action'] ?? '') == 'recover') {
 			self::checkFormSecurityTokenRedirectOnError('2fa', 'twofactor_recovery');
 
-			$a = DI::app();
-
 			$recovery_code = $_POST['recovery_code'] ?? '';
 
 			if (RecoveryCode::existsForUser(local_user(), $recovery_code)) {
 				RecoveryCode::markUsedForUser(local_user(), $recovery_code);
-				Session::set('2fa', true);
-				info(DI::l10n()->t('Remaining recovery codes: %d', RecoveryCode::countValidForUser(local_user())));
+				$this->session->set('2fa', true);
+				info($this->l10n->t('Remaining recovery codes: %d', RecoveryCode::countValidForUser(local_user())));
 
-				DI::auth()->setForUser($a, User::getById($a->getLoggedInUserId()), true, true);
+				$this->auth->setForUser($this->app, User::getById($this->app->getLoggedInUserId()), true, true);
 			} else {
-				notice(DI::l10n()->t('Invalid code, please retry.'));
+				notice($this->l10n->t('Invalid code, please retry.'));
 			}
 		}
 	}
@@ -70,22 +82,22 @@ class Recovery extends BaseModule
 	public function content(): string
 	{
 		if (!local_user()) {
-			DI::baseUrl()->redirect();
+			$this->baseUrl->redirect();
 		}
 
 		// Already authenticated with 2FA token
-		if (Session::get('2fa')) {
-			DI::baseUrl()->redirect();
+		if ($this->session->get('2fa')) {
+			$this->baseUrl->redirect();
 		}
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('twofactor/recovery.tpl'), [
 			'$form_security_token' => self::getFormSecurityToken('twofactor_recovery'),
 
-			'$title'            => DI::l10n()->t('Two-factor recovery'),
-			'$message'          => DI::l10n()->t('<p>You can enter one of your one-time recovery codes in case you lost access to your mobile device.</p>'),
-			'$recovery_message' => DI::l10n()->t('Don’t have your phone? <a href="%s">Enter a two-factor recovery code</a>', '2fa/recovery'),
-			'$recovery_code'    => ['recovery_code', DI::l10n()->t('Please enter a recovery code'), '', '', '', 'placeholder="000000-000000"'],
-			'$recovery_label'   => DI::l10n()->t('Submit recovery code and complete login'),
+			'$title'            => $this->l10n->t('Two-factor recovery'),
+			'$message'          => $this->l10n->t('<p>You can enter one of your one-time recovery codes in case you lost access to your mobile device.</p>'),
+			'$recovery_message' => $this->l10n->t('Don’t have your phone? <a href="%s">Enter a two-factor recovery code</a>', '2fa/recovery'),
+			'$recovery_code'    => ['recovery_code', $this->l10n->t('Please enter a recovery code'), '', '', '', 'placeholder="000000-000000"'],
+			'$recovery_label'   => $this->l10n->t('Submit recovery code and complete login'),
 		]);
 	}
 }

--- a/src/Module/Settings/TwoFactor/AppSpecific.php
+++ b/src/Module/Settings/TwoFactor/AppSpecific.php
@@ -61,7 +61,7 @@ class AppSpecific extends BaseSettings
 		}
 
 		if (!self::checkFormSecurityToken('settings_2fa_password', 't')) {
-			notice($this->l10n->t('Please enter your password to access this page.'));
+			notice($this->t('Please enter your password to access this page.'));
 			$this->baseUrl->redirect('settings/2fa');
 		}
 	}
@@ -79,20 +79,20 @@ class AppSpecific extends BaseSettings
 				case 'generate':
 					$description = $_POST['description'] ?? '';
 					if (empty($description)) {
-						notice($this->l10n->t('App-specific password generation failed: The description is empty.'));
+						notice($this->t('App-specific password generation failed: The description is empty.'));
 						$this->baseUrl->redirect('settings/2fa/app_specific?t=' . self::getFormSecurityToken('settings_2fa_password'));
 					} elseif (AppSpecificPassword::checkDuplicateForUser(local_user(), $description)) {
-						notice($this->l10n->t('App-specific password generation failed: This description already exists.'));
+						notice($this->t('App-specific password generation failed: This description already exists.'));
 						$this->baseUrl->redirect('settings/2fa/app_specific?t=' . self::getFormSecurityToken('settings_2fa_password'));
 					} else {
 						$this->appSpecificPassword = AppSpecificPassword::generateForUser(local_user(), $_POST['description'] ?? '');
-						info($this->l10n->t('New app-specific password generated.'));
+						info($this->t('New app-specific password generated.'));
 					}
 
 					break;
 				case 'revoke_all' :
 					AppSpecificPassword::deleteAllForUser(local_user());
-					info($this->l10n->t('App-specific passwords successfully revoked.'));
+					info($this->t('App-specific passwords successfully revoked.'));
 					$this->baseUrl->redirect('settings/2fa/app_specific?t=' . self::getFormSecurityToken('settings_2fa_password'));
 					break;
 			}
@@ -102,7 +102,7 @@ class AppSpecific extends BaseSettings
 			self::checkFormSecurityTokenRedirectOnError('settings/2fa/app_specific', 'settings_2fa_app_specific');
 
 			if (AppSpecificPassword::deleteForUser(local_user(), $_POST['revoke_id'])) {
-				info($this->l10n->t('App-specific password successfully revoked.'));
+				info($this->t('App-specific password successfully revoked.'));
 			}
 
 			$this->baseUrl->redirect('settings/2fa/app_specific?t=' . self::getFormSecurityToken('settings_2fa_password'));
@@ -123,22 +123,22 @@ class AppSpecific extends BaseSettings
 			'$form_security_token'     => self::getFormSecurityToken('settings_2fa_app_specific'),
 			'$password_security_token' => self::getFormSecurityToken('settings_2fa_password'),
 
-			'$title'                  => $this->l10n->t('Two-factor app-specific passwords'),
-			'$help_label'             => $this->l10n->t('Help'),
-			'$message'                => $this->l10n->t('<p>App-specific passwords are randomly generated passwords used instead your regular password to authenticate your account on third-party applications that don\'t support two-factor authentication.</p>'),
-			'$generated_message'      => $this->l10n->t('Make sure to copy your new app-specific password now. You won’t be able to see it again!'),
+			'$title'                  => $this->t('Two-factor app-specific passwords'),
+			'$help_label'             => $this->t('Help'),
+			'$message'                => $this->t('<p>App-specific passwords are randomly generated passwords used instead your regular password to authenticate your account on third-party applications that don\'t support two-factor authentication.</p>'),
+			'$generated_message'      => $this->t('Make sure to copy your new app-specific password now. You won’t be able to see it again!'),
 			'$generated_app_specific_password' => $this->appSpecificPassword,
 
-			'$description_label'      => $this->l10n->t('Description'),
-			'$last_used_label'        => $this->l10n->t('Last Used'),
-			'$revoke_label'           => $this->l10n->t('Revoke'),
-			'$revoke_all_label'       => $this->l10n->t('Revoke All'),
+			'$description_label'      => $this->t('Description'),
+			'$last_used_label'        => $this->t('Last Used'),
+			'$revoke_label'           => $this->t('Revoke'),
+			'$revoke_all_label'       => $this->t('Revoke All'),
 
 			'$app_specific_passwords' => $appSpecificPasswords,
-			'$generate_message'       => $this->l10n->t('When you generate a new app-specific password, you must use it right away, it will be shown to you once after you generate it.'),
-			'$generate_title'         => $this->l10n->t('Generate new app-specific password'),
-			'$description_placeholder_label' => $this->l10n->t('Friendiqa on my Fairphone 2...'),
-			'$generate_label' => $this->l10n->t('Generate'),
+			'$generate_message'       => $this->t('When you generate a new app-specific password, you must use it right away, it will be shown to you once after you generate it.'),
+			'$generate_title'         => $this->t('Generate new app-specific password'),
+			'$description_placeholder_label' => $this->t('Friendiqa on my Fairphone 2...'),
+			'$generate_label' => $this->t('Generate'),
 		]);
 	}
 }

--- a/src/Module/Settings/TwoFactor/Recovery.php
+++ b/src/Module/Settings/TwoFactor/Recovery.php
@@ -59,7 +59,7 @@ class Recovery extends BaseSettings
 		}
 
 		if (!self::checkFormSecurityToken('settings_2fa_password', 't')) {
-			notice($this->l10n->t('Please enter your password to access this page.'));
+			notice($this->t('Please enter your password to access this page.'));
 			$this->baseUrl->redirect('settings/2fa');
 		}
 	}
@@ -75,7 +75,7 @@ class Recovery extends BaseSettings
 
 			if ($_POST['action'] == 'regenerate') {
 				RecoveryCode::regenerateForUser(local_user());
-				info($this->l10n->t('New recovery codes successfully generated.'));
+				info($this->t('New recovery codes successfully generated.'));
 				$this->baseUrl->redirect('settings/2fa/recovery?t=' . self::getFormSecurityToken('settings_2fa_password'));
 			}
 		}
@@ -101,14 +101,14 @@ class Recovery extends BaseSettings
 			'$form_security_token'     => self::getFormSecurityToken('settings_2fa_recovery'),
 			'$password_security_token' => self::getFormSecurityToken('settings_2fa_password'),
 
-			'$title'              => $this->l10n->t('Two-factor recovery codes'),
-			'$help_label'         => $this->l10n->t('Help'),
-			'$message'            => $this->l10n->t('<p>Recovery codes can be used to access your account in the event you lose access to your device and cannot receive two-factor authentication codes.</p><p><strong>Put these in a safe spot!</strong> If you lose your device and don’t have the recovery codes you will lose access to your account.</p>'),
+			'$title'              => $this->t('Two-factor recovery codes'),
+			'$help_label'         => $this->t('Help'),
+			'$message'            => $this->t('<p>Recovery codes can be used to access your account in the event you lose access to your device and cannot receive two-factor authentication codes.</p><p><strong>Put these in a safe spot!</strong> If you lose your device and don’t have the recovery codes you will lose access to your account.</p>'),
 			'$recovery_codes'     => $recoveryCodes,
-			'$regenerate_message' => $this->l10n->t('When you generate new recovery codes, you must copy the new codes. Your old codes won’t work anymore.'),
-			'$regenerate_label'   => $this->l10n->t('Generate new recovery codes'),
+			'$regenerate_message' => $this->t('When you generate new recovery codes, you must copy the new codes. Your old codes won’t work anymore.'),
+			'$regenerate_label'   => $this->t('Generate new recovery codes'),
 			'$verified'           => $verified,
-			'$verify_label'       => $this->l10n->t('Next: Verification'),
+			'$verify_label'       => $this->t('Next: Verification'),
 		]);
 	}
 }

--- a/src/Module/Settings/TwoFactor/Recovery.php
+++ b/src/Module/Settings/TwoFactor/Recovery.php
@@ -21,8 +21,10 @@
 
 namespace Friendica\Module\Settings\TwoFactor;
 
+use Friendica\App\BaseURL;
+use Friendica\Core\L10n;
+use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
 use Friendica\Core\Renderer;
-use Friendica\DI;
 use Friendica\Security\TwoFactor\Model\RecoveryCode;
 use Friendica\Module\BaseSettings;
 use Friendica\Module\Security\Login;
@@ -34,21 +36,31 @@ use Friendica\Module\Security\Login;
  */
 class Recovery extends BaseSettings
 {
-	public function init()
+	/** @var IManagePersonalConfigValues */
+	protected $pConfig;
+	/** @var BaseURL */
+	protected $baseUrl;
+
+	public function __construct(IManagePersonalConfigValues $pConfig, BaseURL $baseUrl, L10n $l10n, array $parameters = [])
 	{
+		parent::__construct($l10n, $parameters);
+
+		$this->pConfig = $pConfig;
+		$this->baseUrl = $baseUrl;
+
 		if (!local_user()) {
 			return;
 		}
 
-		$secret = DI::pConfig()->get(local_user(), '2fa', 'secret');
+		$secret = $this->pConfig->get(local_user(), '2fa', 'secret');
 
 		if (!$secret) {
-			DI::baseUrl()->redirect('settings/2fa');
+			$this->baseUrl->redirect('settings/2fa');
 		}
 
 		if (!self::checkFormSecurityToken('settings_2fa_password', 't')) {
-			notice(DI::l10n()->t('Please enter your password to access this page.'));
-			DI::baseUrl()->redirect('settings/2fa');
+			notice($this->l10n->t('Please enter your password to access this page.'));
+			$this->baseUrl->redirect('settings/2fa');
 		}
 	}
 
@@ -63,8 +75,8 @@ class Recovery extends BaseSettings
 
 			if ($_POST['action'] == 'regenerate') {
 				RecoveryCode::regenerateForUser(local_user());
-				info(DI::l10n()->t('New recovery codes successfully generated.'));
-				DI::baseUrl()->redirect('settings/2fa/recovery?t=' . self::getFormSecurityToken('settings_2fa_password'));
+				info($this->l10n->t('New recovery codes successfully generated.'));
+				$this->baseUrl->redirect('settings/2fa/recovery?t=' . self::getFormSecurityToken('settings_2fa_password'));
 			}
 		}
 	}
@@ -83,20 +95,20 @@ class Recovery extends BaseSettings
 
 		$recoveryCodes = RecoveryCode::getListForUser(local_user());
 
-		$verified = DI::pConfig()->get(local_user(), '2fa', 'verified');
+		$verified = $this->pConfig->get(local_user(), '2fa', 'verified');
 		
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('settings/twofactor/recovery.tpl'), [
 			'$form_security_token'     => self::getFormSecurityToken('settings_2fa_recovery'),
 			'$password_security_token' => self::getFormSecurityToken('settings_2fa_password'),
 
-			'$title'              => DI::l10n()->t('Two-factor recovery codes'),
-			'$help_label'         => DI::l10n()->t('Help'),
-			'$message'            => DI::l10n()->t('<p>Recovery codes can be used to access your account in the event you lose access to your device and cannot receive two-factor authentication codes.</p><p><strong>Put these in a safe spot!</strong> If you lose your device and don’t have the recovery codes you will lose access to your account.</p>'),
+			'$title'              => $this->l10n->t('Two-factor recovery codes'),
+			'$help_label'         => $this->l10n->t('Help'),
+			'$message'            => $this->l10n->t('<p>Recovery codes can be used to access your account in the event you lose access to your device and cannot receive two-factor authentication codes.</p><p><strong>Put these in a safe spot!</strong> If you lose your device and don’t have the recovery codes you will lose access to your account.</p>'),
 			'$recovery_codes'     => $recoveryCodes,
-			'$regenerate_message' => DI::l10n()->t('When you generate new recovery codes, you must copy the new codes. Your old codes won’t work anymore.'),
-			'$regenerate_label'   => DI::l10n()->t('Generate new recovery codes'),
+			'$regenerate_message' => $this->l10n->t('When you generate new recovery codes, you must copy the new codes. Your old codes won’t work anymore.'),
+			'$regenerate_label'   => $this->l10n->t('Generate new recovery codes'),
 			'$verified'           => $verified,
-			'$verify_label'       => DI::l10n()->t('Next: Verification'),
+			'$verify_label'       => $this->l10n->t('Next: Verification'),
 		]);
 	}
 }

--- a/src/Module/Settings/TwoFactor/Trusted.php
+++ b/src/Module/Settings/TwoFactor/Trusted.php
@@ -42,7 +42,7 @@ class Trusted extends BaseSettings
 		}
 
 		if (!self::checkFormSecurityToken('settings_2fa_password', 't')) {
-			notice($this->l10n->t('Please enter your password to access this page.'));
+			notice($this->t('Please enter your password to access this page.'));
 			$this->baseUrl->redirect('settings/2fa');
 		}
 	}
@@ -59,7 +59,7 @@ class Trusted extends BaseSettings
 			switch ($_POST['action']) {
 				case 'remove_all' :
 					$this->trustedBrowserRepo->removeAllForUser(local_user());
-					info($this->l10n->t('Trusted browsers successfully removed.'));
+					info($this->t('Trusted browsers successfully removed.'));
 					$this->baseUrl->redirect('settings/2fa/trusted?t=' . self::getFormSecurityToken('settings_2fa_password'));
 					break;
 			}
@@ -69,7 +69,7 @@ class Trusted extends BaseSettings
 			self::checkFormSecurityTokenRedirectOnError('settings/2fa/trusted', 'settings_2fa_trusted');
 
 			if ($this->trustedBrowserRepo->removeForUser(local_user(), $_POST['remove_id'])) {
-				info($this->l10n->t('Trusted browser successfully removed.'));
+				info($this->t('Trusted browser successfully removed.'));
 			}
 
 			$this->baseUrl->redirect('settings/2fa/trusted?t=' . self::getFormSecurityToken('settings_2fa_password'));
@@ -106,15 +106,15 @@ class Trusted extends BaseSettings
 			'$form_security_token' => self::getFormSecurityToken('settings_2fa_trusted'),
 			'$password_security_token' => self::getFormSecurityToken('settings_2fa_password'),
 
-			'$title'               => $this->l10n->t('Two-factor Trusted Browsers'),
-			'$message'             => $this->l10n->t('Trusted browsers are individual browsers you chose to skip two-factor authentication to access Friendica. Please use this feature sparingly, as it can negate the benefit of two-factor authentication.'),
-			'$device_label'        => $this->l10n->t('Device'),
-			'$os_label'            => $this->l10n->t('OS'),
-			'$browser_label'       => $this->l10n->t('Browser'),
-			'$created_label'       => $this->l10n->t('Trusted'),
-			'$last_used_label'     => $this->l10n->t('Last Use'),
-			'$remove_label'        => $this->l10n->t('Remove'),
-			'$remove_all_label'    => $this->l10n->t('Remove All'),
+			'$title'               => $this->t('Two-factor Trusted Browsers'),
+			'$message'             => $this->t('Trusted browsers are individual browsers you chose to skip two-factor authentication to access Friendica. Please use this feature sparingly, as it can negate the benefit of two-factor authentication.'),
+			'$device_label'        => $this->t('Device'),
+			'$os_label'            => $this->t('OS'),
+			'$browser_label'       => $this->t('Browser'),
+			'$created_label'       => $this->t('Trusted'),
+			'$last_used_label'     => $this->t('Last Use'),
+			'$remove_label'        => $this->t('Remove'),
+			'$remove_all_label'    => $this->t('Remove All'),
 
 			'$trusted_browsers'    => $trustedBrowserDisplay,
 		]);

--- a/src/Module/Settings/TwoFactor/Trusted.php
+++ b/src/Module/Settings/TwoFactor/Trusted.php
@@ -2,8 +2,10 @@
 
 namespace Friendica\Module\Settings\TwoFactor;
 
+use Friendica\App\BaseURL;
+use Friendica\Core\L10n;
+use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
 use Friendica\Core\Renderer;
-use Friendica\DI;
 use Friendica\Module\BaseSettings;
 use Friendica\Security\TwoFactor;
 use Friendica\Util\Temporal;
@@ -14,21 +16,34 @@ use UAParser\Parser;
  */
 class Trusted extends BaseSettings
 {
-	public function init()
+	/** @var IManagePersonalConfigValues */
+	protected $pConfig;
+	/** @var BaseURL */
+	protected $baseUrl;
+	/** @var TwoFactor\Repository\TrustedBrowser */
+	protected $trustedBrowserRepo;
+
+	public function __construct(IManagePersonalConfigValues $pConfig, BaseURL $baseUrl, TwoFactor\Repository\TrustedBrowser $trustedBrowserRepo, L10n $l10n, array $parameters = [])
 	{
+		parent::__construct($l10n, $parameters);
+
+		$this->pConfig            = $pConfig;
+		$this->baseUrl            = $baseUrl;
+		$this->trustedBrowserRepo = $trustedBrowserRepo;
+
 		if (!local_user()) {
 			return;
 		}
 
-		$verified = DI::pConfig()->get(local_user(), '2fa', 'verified');
+		$verified = $this->pConfig->get(local_user(), '2fa', 'verified');
 
 		if (!$verified) {
-			DI::baseUrl()->redirect('settings/2fa');
+			$this->baseUrl->redirect('settings/2fa');
 		}
 
 		if (!self::checkFormSecurityToken('settings_2fa_password', 't')) {
-			notice(DI::l10n()->t('Please enter your password to access this page.'));
-			DI::baseUrl()->redirect('settings/2fa');
+			notice($this->l10n->t('Please enter your password to access this page.'));
+			$this->baseUrl->redirect('settings/2fa');
 		}
 	}
 
@@ -38,16 +53,14 @@ class Trusted extends BaseSettings
 			return;
 		}
 
-		$trustedBrowserRepository = new TwoFactor\Repository\TrustedBrowser(DI::dba(), DI::logger());
-
 		if (!empty($_POST['action'])) {
 			self::checkFormSecurityTokenRedirectOnError('settings/2fa/trusted', 'settings_2fa_trusted');
 
 			switch ($_POST['action']) {
 				case 'remove_all' :
-					$trustedBrowserRepository->removeAllForUser(local_user());
-					info(DI::l10n()->t('Trusted browsers successfully removed.'));
-					DI::baseUrl()->redirect('settings/2fa/trusted?t=' . self::getFormSecurityToken('settings_2fa_password'));
+					$this->trustedBrowserRepo->removeAllForUser(local_user());
+					info($this->l10n->t('Trusted browsers successfully removed.'));
+					$this->baseUrl->redirect('settings/2fa/trusted?t=' . self::getFormSecurityToken('settings_2fa_password'));
 					break;
 			}
 		}
@@ -55,11 +68,11 @@ class Trusted extends BaseSettings
 		if (!empty($_POST['remove_id'])) {
 			self::checkFormSecurityTokenRedirectOnError('settings/2fa/trusted', 'settings_2fa_trusted');
 
-			if ($trustedBrowserRepository->removeForUser(local_user(), $_POST['remove_id'])) {
-				info(DI::l10n()->t('Trusted browser successfully removed.'));
+			if ($this->trustedBrowserRepo->removeForUser(local_user(), $_POST['remove_id'])) {
+				info($this->l10n->t('Trusted browser successfully removed.'));
 			}
 
-			DI::baseUrl()->redirect('settings/2fa/trusted?t=' . self::getFormSecurityToken('settings_2fa_password'));
+			$this->baseUrl->redirect('settings/2fa/trusted?t=' . self::getFormSecurityToken('settings_2fa_password'));
 		}
 	}
 
@@ -68,8 +81,7 @@ class Trusted extends BaseSettings
 	{
 		parent::content();
 
-		$trustedBrowserRepository = new TwoFactor\Repository\TrustedBrowser(DI::dba(), DI::logger());
-		$trustedBrowsers = $trustedBrowserRepository->selectAllByUid(local_user());
+		$trustedBrowsers = $this->trustedBrowserRepo->selectAllByUid(local_user());
 
 		$parser = Parser::create();
 
@@ -94,15 +106,15 @@ class Trusted extends BaseSettings
 			'$form_security_token' => self::getFormSecurityToken('settings_2fa_trusted'),
 			'$password_security_token' => self::getFormSecurityToken('settings_2fa_password'),
 
-			'$title'               => DI::l10n()->t('Two-factor Trusted Browsers'),
-			'$message'             => DI::l10n()->t('Trusted browsers are individual browsers you chose to skip two-factor authentication to access Friendica. Please use this feature sparingly, as it can negate the benefit of two-factor authentication.'),
-			'$device_label'        => DI::l10n()->t('Device'),
-			'$os_label'            => DI::l10n()->t('OS'),
-			'$browser_label'       => DI::l10n()->t('Browser'),
-			'$created_label'       => DI::l10n()->t('Trusted'),
-			'$last_used_label'     => DI::l10n()->t('Last Use'),
-			'$remove_label'        => DI::l10n()->t('Remove'),
-			'$remove_all_label'    => DI::l10n()->t('Remove All'),
+			'$title'               => $this->l10n->t('Two-factor Trusted Browsers'),
+			'$message'             => $this->l10n->t('Trusted browsers are individual browsers you chose to skip two-factor authentication to access Friendica. Please use this feature sparingly, as it can negate the benefit of two-factor authentication.'),
+			'$device_label'        => $this->l10n->t('Device'),
+			'$os_label'            => $this->l10n->t('OS'),
+			'$browser_label'       => $this->l10n->t('Browser'),
+			'$created_label'       => $this->l10n->t('Trusted'),
+			'$last_used_label'     => $this->l10n->t('Last Use'),
+			'$remove_label'        => $this->l10n->t('Remove'),
+			'$remove_all_label'    => $this->l10n->t('Remove All'),
 
 			'$trusted_browsers'    => $trustedBrowserDisplay,
 		]);

--- a/src/Module/Settings/TwoFactor/Verify.php
+++ b/src/Module/Settings/TwoFactor/Verify.php
@@ -65,7 +65,7 @@ class Verify extends BaseSettings
 		}
 
 		if (!self::checkFormSecurityToken('settings_2fa_password', 't')) {
-			notice($this->l10n->t('Please enter your password to access this page.'));
+			notice($this->t('Please enter your password to access this page.'));
 			$this->baseUrl->redirect('settings/2fa');
 		}
 	}
@@ -87,11 +87,11 @@ class Verify extends BaseSettings
 				$this->pConfig->set(local_user(), '2fa', 'verified', true);
 				Session::set('2fa', true);
 
-				info($this->l10n->t('Two-factor authentication successfully activated.'));
+				info($this->t('Two-factor authentication successfully activated.'));
 
 				$this->baseUrl->redirect('settings/2fa');
 			} else {
-				notice($this->l10n->t('Invalid code, please retry.'));
+				notice($this->t('Invalid code, please retry.'));
 			}
 		}
 	}
@@ -120,7 +120,7 @@ class Verify extends BaseSettings
 
 		$shortOtpauthUrl = explode('?', $otpauthUrl)[0];
 
-		$manual_message = $this->l10n->t('<p>Or you can submit the authentication settings manually:</p>
+		$manual_message = $this->t('<p>Or you can submit the authentication settings manually:</p>
 <dl>
 	<dt>Issuer</dt>
 	<dd>%s</dd>
@@ -140,18 +140,18 @@ class Verify extends BaseSettings
 			'$form_security_token'     => self::getFormSecurityToken('settings_2fa_verify'),
 			'$password_security_token' => self::getFormSecurityToken('settings_2fa_password'),
 
-			'$title'              => $this->l10n->t('Two-factor code verification'),
-			'$help_label'         => $this->l10n->t('Help'),
-			'$message'            => $this->l10n->t('<p>Please scan this QR Code with your authenticator app and submit the provided code.</p>'),
+			'$title'              => $this->t('Two-factor code verification'),
+			'$help_label'         => $this->t('Help'),
+			'$message'            => $this->t('<p>Please scan this QR Code with your authenticator app and submit the provided code.</p>'),
 			'$qrcode_image'       => $qrcode_image,
-			'$qrcode_url_message' => $this->l10n->t('<p>Or you can open the following URL in your mobile device:</p><p><a href="%s">%s</a></p>', $otpauthUrl, $shortOtpauthUrl),
+			'$qrcode_url_message' => $this->t('<p>Or you can open the following URL in your mobile device:</p><p><a href="%s">%s</a></p>', $otpauthUrl, $shortOtpauthUrl),
 			'$manual_message'     => $manual_message,
 			'$company'            => $company,
 			'$holder'             => $holder,
 			'$secret'             => $secret,
 
-			'$verify_code'  => ['verify_code', $this->l10n->t('Please enter a code from your authentication app'), '', '', $this->l10n->t('Required'), 'autofocus autocomplete="off" placeholder="000000"'],
-			'$verify_label' => $this->l10n->t('Verify code and enable two-factor authentication'),
+			'$verify_code'  => ['verify_code', $this->t('Please enter a code from your authentication app'), '', '', $this->t('Required'), 'autofocus autocomplete="off" placeholder="000000"'],
+			'$verify_label' => $this->t('Verify code and enable two-factor authentication'),
 		]);
 	}
 }

--- a/src/Module/Settings/TwoFactor/Verify.php
+++ b/src/Module/Settings/TwoFactor/Verify.php
@@ -25,9 +25,11 @@ use BaconQrCode\Renderer\Image\SvgImageBackEnd;
 use BaconQrCode\Renderer\ImageRenderer;
 use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Writer;
+use Friendica\App\BaseURL;
+use Friendica\Core\L10n;
+use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session;
-use Friendica\DI;
 use Friendica\Module\BaseSettings;
 use Friendica\Module\Security\Login;
 use PragmaRX\Google2FA\Google2FA;
@@ -39,22 +41,32 @@ use PragmaRX\Google2FA\Google2FA;
  */
 class Verify extends BaseSettings
 {
-	public function init()
+	/** @var IManagePersonalConfigValues */
+	protected $pConfig;
+	/** @var BaseURL */
+	protected $baseUrl;
+
+	public function __construct(IManagePersonalConfigValues $pConfig, BaseURL $baseUrl, L10n $l10n, array $parameters = [])
 	{
+		parent::__construct($l10n, $parameters);
+
+		$this->pConfig = $pConfig;
+		$this->baseUrl = $baseUrl;
+
 		if (!local_user()) {
 			return;
 		}
 
-		$secret = DI::pConfig()->get(local_user(), '2fa', 'secret');
-		$verified = DI::pConfig()->get(local_user(), '2fa', 'verified');
+		$secret   = $this->pConfig->get(local_user(), '2fa', 'secret');
+		$verified = $this->pConfig->get(local_user(), '2fa', 'verified');
 
 		if ($secret && $verified) {
-			DI::baseUrl()->redirect('settings/2fa');
+			$this->baseUrl->redirect('settings/2fa');
 		}
 
 		if (!self::checkFormSecurityToken('settings_2fa_password', 't')) {
-			notice(DI::l10n()->t('Please enter your password to access this page.'));
-			DI::baseUrl()->redirect('settings/2fa');
+			notice($this->l10n->t('Please enter your password to access this page.'));
+			$this->baseUrl->redirect('settings/2fa');
 		}
 	}
 
@@ -69,17 +81,17 @@ class Verify extends BaseSettings
 
 			$google2fa = new Google2FA();
 
-			$valid = $google2fa->verifyKey(DI::pConfig()->get(local_user(), '2fa', 'secret'), $_POST['verify_code'] ?? '');
+			$valid = $google2fa->verifyKey($this->pConfig->get(local_user(), '2fa', 'secret'), $_POST['verify_code'] ?? '');
 
 			if ($valid) {
-				DI::pConfig()->set(local_user(), '2fa', 'verified', true);
+				$this->pConfig->set(local_user(), '2fa', 'verified', true);
 				Session::set('2fa', true);
 
-				info(DI::l10n()->t('Two-factor authentication successfully activated.'));
+				info($this->l10n->t('Two-factor authentication successfully activated.'));
 
-				DI::baseUrl()->redirect('settings/2fa');
+				$this->baseUrl->redirect('settings/2fa');
 			} else {
-				notice(DI::l10n()->t('Invalid code, please retry.'));
+				notice($this->l10n->t('Invalid code, please retry.'));
 			}
 		}
 	}
@@ -94,7 +106,7 @@ class Verify extends BaseSettings
 
 		$company = 'Friendica';
 		$holder = Session::get('my_address');
-		$secret = DI::pConfig()->get(local_user(), '2fa', 'secret');
+		$secret = $this->pConfig->get(local_user(), '2fa', 'secret');
 
 		$otpauthUrl = (new Google2FA())->getQRCodeUrl($company, $holder, $secret);
 
@@ -108,7 +120,7 @@ class Verify extends BaseSettings
 
 		$shortOtpauthUrl = explode('?', $otpauthUrl)[0];
 
-		$manual_message = DI::l10n()->t('<p>Or you can submit the authentication settings manually:</p>
+		$manual_message = $this->l10n->t('<p>Or you can submit the authentication settings manually:</p>
 <dl>
 	<dt>Issuer</dt>
 	<dd>%s</dd>
@@ -128,18 +140,18 @@ class Verify extends BaseSettings
 			'$form_security_token'     => self::getFormSecurityToken('settings_2fa_verify'),
 			'$password_security_token' => self::getFormSecurityToken('settings_2fa_password'),
 
-			'$title'              => DI::l10n()->t('Two-factor code verification'),
-			'$help_label'         => DI::l10n()->t('Help'),
-			'$message'            => DI::l10n()->t('<p>Please scan this QR Code with your authenticator app and submit the provided code.</p>'),
+			'$title'              => $this->l10n->t('Two-factor code verification'),
+			'$help_label'         => $this->l10n->t('Help'),
+			'$message'            => $this->l10n->t('<p>Please scan this QR Code with your authenticator app and submit the provided code.</p>'),
 			'$qrcode_image'       => $qrcode_image,
-			'$qrcode_url_message' => DI::l10n()->t('<p>Or you can open the following URL in your mobile device:</p><p><a href="%s">%s</a></p>', $otpauthUrl, $shortOtpauthUrl),
+			'$qrcode_url_message' => $this->l10n->t('<p>Or you can open the following URL in your mobile device:</p><p><a href="%s">%s</a></p>', $otpauthUrl, $shortOtpauthUrl),
 			'$manual_message'     => $manual_message,
 			'$company'            => $company,
 			'$holder'             => $holder,
 			'$secret'             => $secret,
 
-			'$verify_code'  => ['verify_code', DI::l10n()->t('Please enter a code from your authentication app'), '', '', DI::l10n()->t('Required'), 'autofocus autocomplete="off" placeholder="000000"'],
-			'$verify_label' => DI::l10n()->t('Verify code and enable two-factor authentication'),
+			'$verify_code'  => ['verify_code', $this->l10n->t('Please enter a code from your authentication app'), '', '', $this->l10n->t('Required'), 'autofocus autocomplete="off" placeholder="000000"'],
+			'$verify_label' => $this->l10n->t('Verify code and enable two-factor authentication'),
 		]);
 	}
 }

--- a/src/Module/Statistics.php
+++ b/src/Module/Statistics.php
@@ -23,26 +23,35 @@ namespace Friendica\Module;
 
 use Friendica\BaseModule;
 use Friendica\Core\Addon;
-use Friendica\DI;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\L10n;
 use Friendica\Network\HTTPException\NotFoundException;
+use Psr\Log\LoggerInterface;
 
 class Statistics extends BaseModule
 {
-	public function init()
+	/** @var IManageConfigValues */
+	protected $config;
+	/** @var LoggerInterface */
+	protected $logger;
+
+	public function __construct(IManageConfigValues $config, LoggerInterface $logger, L10n $l10n, array $parameters = [])
 	{
-		if (!DI::config()->get("system", "nodeinfo")) {
+		parent::__construct($l10n, $parameters);
+
+		$this->logger = $logger;
+		$this->config = $config;
+
+		if (!$this->config->get("system", "nodeinfo")) {
 			throw new NotFoundException();
 		}
 	}
 
 	public function rawContent()
 	{
-		$config = DI::config();
-		$logger = DI::logger();
-
 		$registration_open =
-			intval($config->get('config', 'register_policy')) !== Register::CLOSED
-			&& !$config->get('config', 'invitation_only');
+			intval($this->config->get('config', 'register_policy')) !== Register::CLOSED
+			&& !$this->config->get('config', 'invitation_only');
 
 		/// @todo mark the "service" addons and load them dynamically here
 		$services = [
@@ -59,20 +68,20 @@ class Statistics extends BaseModule
 		];
 
 		$statistics = array_merge([
-			'name'                  => $config->get('config', 'sitename'),
+			'name'                  => $this->config->get('config', 'sitename'),
 			'network'               => FRIENDICA_PLATFORM,
 			'version'               => FRIENDICA_VERSION . '-' . DB_UPDATE_VERSION,
 			'registrations_open'    => $registration_open,
-			'total_users'           => $config->get('nodeinfo', 'total_users'),
-			'active_users_halfyear' => $config->get('nodeinfo', 'active_users_halfyear'),
-			'active_users_monthly'  => $config->get('nodeinfo', 'active_users_monthly'),
-			'local_posts'           => $config->get('nodeinfo', 'local_posts'),
+			'total_users'           => $this->config->get('nodeinfo', 'total_users'),
+			'active_users_halfyear' => $this->config->get('nodeinfo', 'active_users_halfyear'),
+			'active_users_monthly'  => $this->config->get('nodeinfo', 'active_users_monthly'),
+			'local_posts'           => $this->config->get('nodeinfo', 'local_posts'),
 			'services'              => $services,
 		], $services);
 
 		header("Content-Type: application/json");
 		echo json_encode($statistics, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-		$logger->debug("statistics.", ['statistics' => $statistics]);
+		$this->logger->debug("statistics.", ['statistics' => $statistics]);
 		exit();
 	}
 }

--- a/src/Module/Tos.php
+++ b/src/Module/Tos.php
@@ -55,12 +55,12 @@ class Tos extends BaseModule
 		$this->config  = $config;
 		$this->baseUrl = $baseUrl;
 
-		$this->privacy_operate    = $this->l10n->t('At the time of registration, and for providing communications between the user account and their contacts, the user has to provide a display name (pen name), an username (nickname) and a working email address. The names will be accessible on the profile page of the account by any visitor of the page, even if other profile details are not displayed. The email address will only be used to send the user notifications about interactions, but wont be visibly displayed. The listing of an account in the node\'s user directory or the global user directory is optional and can be controlled in the user settings, it is not necessary for communication.');
-		$this->privacy_distribute = $this->l10n->t('This data is required for communication and is passed on to the nodes of the communication partners and is stored there. Users can enter additional private data that may be transmitted to the communication partners accounts.');
-		$this->privacy_delete     = $this->l10n->t('At any point in time a logged in user can export their account data from the <a href="%1$s/settings/userexport">account settings</a>. If the user wants to delete their account they can do so at <a href="%1$s/removeme">%1$s/removeme</a>. The deletion of the account will be permanent. Deletion of the data will also be requested from the nodes of the communication partners.', $this->baseUrl);
+		$this->privacy_operate    = $this->t('At the time of registration, and for providing communications between the user account and their contacts, the user has to provide a display name (pen name), an username (nickname) and a working email address. The names will be accessible on the profile page of the account by any visitor of the page, even if other profile details are not displayed. The email address will only be used to send the user notifications about interactions, but wont be visibly displayed. The listing of an account in the node\'s user directory or the global user directory is optional and can be controlled in the user settings, it is not necessary for communication.');
+		$this->privacy_distribute = $this->t('This data is required for communication and is passed on to the nodes of the communication partners and is stored there. Users can enter additional private data that may be transmitted to the communication partners accounts.');
+		$this->privacy_delete     = $this->t('At any point in time a logged in user can export their account data from the <a href="%1$s/settings/userexport">account settings</a>. If the user wants to delete their account they can do so at <a href="%1$s/removeme">%1$s/removeme</a>. The deletion of the account will be permanent. Deletion of the data will also be requested from the nodes of the communication partners.', $this->baseUrl);
 		// In some cases we don't need every single one of the above separate, but all in one block.
 		// So here is an array to look over
-		$this->privacy_complete = [$this->l10n->t('Privacy Statement'), $this->privacy_operate,
+		$this->privacy_complete = [$this->t('Privacy Statement'), $this->privacy_operate,
 								   $this->privacy_distribute, $this->privacy_delete];
 	}
 
@@ -85,13 +85,13 @@ class Tos extends BaseModule
 		$tpl = Renderer::getMarkupTemplate('tos.tpl');
 		if ($this->config->get('system', 'tosdisplay')) {
 			return Renderer::replaceMacros($tpl, [
-				'$title'                => $this->l10n->t('Terms of Service'),
+				'$title'                => $this->t('Terms of Service'),
 				'$tostext'              => BBCode::convert($this->config->get('system', 'tostext')),
 				'$displayprivstatement' => $this->config->get('system', 'tosprivstatement'),
-				'$privstatementtitle'   => $this->l10n->t('Privacy Statement'),
-				'$privacy_operate'      => $this->l10n->t('At the time of registration, and for providing communications between the user account and their contacts, the user has to provide a display name (pen name), an username (nickname) and a working email address. The names will be accessible on the profile page of the account by any visitor of the page, even if other profile details are not displayed. The email address will only be used to send the user notifications about interactions, but wont be visibly displayed. The listing of an account in the node\'s user directory or the global user directory is optional and can be controlled in the user settings, it is not necessary for communication.'),
-				'$privacy_distribute'   => $this->l10n->t('This data is required for communication and is passed on to the nodes of the communication partners and is stored there. Users can enter additional private data that may be transmitted to the communication partners accounts.'),
-				'$privacy_delete'       => $this->l10n->t('At any point in time a logged in user can export their account data from the <a href="%1$s/settings/userexport">account settings</a>. If the user wants to delete their account they can do so at <a href="%1$s/removeme">%1$s/removeme</a>. The deletion of the account will be permanent. Deletion of the data will also be requested from the nodes of the communication partners.', $this->baseUrl)
+				'$privstatementtitle'   => $this->t('Privacy Statement'),
+				'$privacy_operate'      => $this->t('At the time of registration, and for providing communications between the user account and their contacts, the user has to provide a display name (pen name), an username (nickname) and a working email address. The names will be accessible on the profile page of the account by any visitor of the page, even if other profile details are not displayed. The email address will only be used to send the user notifications about interactions, but wont be visibly displayed. The listing of an account in the node\'s user directory or the global user directory is optional and can be controlled in the user settings, it is not necessary for communication.'),
+				'$privacy_distribute'   => $this->t('This data is required for communication and is passed on to the nodes of the communication partners and is stored there. Users can enter additional private data that may be transmitted to the communication partners accounts.'),
+				'$privacy_delete'       => $this->t('At any point in time a logged in user can export their account data from the <a href="%1$s/settings/userexport">account settings</a>. If the user wants to delete their account they can do so at <a href="%1$s/removeme">%1$s/removeme</a>. The deletion of the account will be permanent. Deletion of the data will also be requested from the nodes of the communication partners.', $this->baseUrl)
 			]);
 		} else {
 			return '';

--- a/src/Module/Tos.php
+++ b/src/Module/Tos.php
@@ -21,10 +21,12 @@
 
 namespace Friendica\Module;
 
+use Friendica\App\BaseURL;
 use Friendica\BaseModule;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Content\Text\BBCode;
-use Friendica\DI;
 
 class Tos extends BaseModule
 {
@@ -34,6 +36,11 @@ class Tos extends BaseModule
 	public $privacy_delete;
 	public $privacy_complete;
 
+	/** @var IManageConfigValues */
+	protected $config;
+	/** @var BaseURL */
+	protected $baseUrl;
+
 	/**
 	 * constructor for the module, initializing the text variables
 	 *
@@ -41,30 +48,20 @@ class Tos extends BaseModule
 	 * be properties of the class, however cannot be set directly as the property
 	 * cannot depend on a function result when declaring the variable.
 	 **/
-	public function __construct(array $parameters = [])
+	public function __construct(IManageConfigValues $config, BaseURL $baseUrl, L10n $l10n, array $parameters = [])
 	{
-		parent::__construct($parameters);
+		parent::__construct($l10n, $parameters);
 
-		$this->privacy_operate = DI::l10n()->t('At the time of registration, and for providing communications between the user account and their contacts, the user has to provide a display name (pen name), an username (nickname) and a working email address. The names will be accessible on the profile page of the account by any visitor of the page, even if other profile details are not displayed. The email address will only be used to send the user notifications about interactions, but wont be visibly displayed. The listing of an account in the node\'s user directory or the global user directory is optional and can be controlled in the user settings, it is not necessary for communication.');
-		$this->privacy_distribute = DI::l10n()->t('This data is required for communication and is passed on to the nodes of the communication partners and is stored there. Users can enter additional private data that may be transmitted to the communication partners accounts.');
-		$this->privacy_delete = DI::l10n()->t('At any point in time a logged in user can export their account data from the <a href="%1$s/settings/userexport">account settings</a>. If the user wants to delete their account they can do so at <a href="%1$s/removeme">%1$s/removeme</a>. The deletion of the account will be permanent. Deletion of the data will also be requested from the nodes of the communication partners.', DI::baseUrl());
+		$this->config  = $config;
+		$this->baseUrl = $baseUrl;
+
+		$this->privacy_operate    = $this->l10n->t('At the time of registration, and for providing communications between the user account and their contacts, the user has to provide a display name (pen name), an username (nickname) and a working email address. The names will be accessible on the profile page of the account by any visitor of the page, even if other profile details are not displayed. The email address will only be used to send the user notifications about interactions, but wont be visibly displayed. The listing of an account in the node\'s user directory or the global user directory is optional and can be controlled in the user settings, it is not necessary for communication.');
+		$this->privacy_distribute = $this->l10n->t('This data is required for communication and is passed on to the nodes of the communication partners and is stored there. Users can enter additional private data that may be transmitted to the communication partners accounts.');
+		$this->privacy_delete     = $this->l10n->t('At any point in time a logged in user can export their account data from the <a href="%1$s/settings/userexport">account settings</a>. If the user wants to delete their account they can do so at <a href="%1$s/removeme">%1$s/removeme</a>. The deletion of the account will be permanent. Deletion of the data will also be requested from the nodes of the communication partners.', $this->baseUrl);
 		// In some cases we don't need every single one of the above separate, but all in one block.
 		// So here is an array to look over
-		$this->privacy_complete = [DI::l10n()->t('Privacy Statement'), $this->privacy_operate, $this->privacy_distribute, $this->privacy_delete];
-	}
-
-	/**
-	 * initialize the TOS module.
-	 *
-	 * If this is a single user instance, we expect the user to know their
-	 * dealings with their own node so a TOS is not necessary.
-	 *
-	 **/
-	public function init()
-	{
-		if (strlen(DI::config()->get('system','singleuser'))) {
-			DI::baseUrl()->redirect('profile/' . DI::config()->get('system','singleuser'));
-		}
+		$this->privacy_complete = [$this->l10n->t('Privacy Statement'), $this->privacy_operate,
+								   $this->privacy_distribute, $this->privacy_delete];
 	}
 
 	/**
@@ -79,17 +76,22 @@ class Tos extends BaseModule
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function content(): string {
+	public function content(): string
+	{
+		if (strlen($this->config->get('system', 'singleuser'))) {
+			$this->baseUrl->redirect('profile/' . $this->config->get('system', 'singleuser'));
+		}
+
 		$tpl = Renderer::getMarkupTemplate('tos.tpl');
-		if (DI::config()->get('system', 'tosdisplay')) {
+		if ($this->config->get('system', 'tosdisplay')) {
 			return Renderer::replaceMacros($tpl, [
-				'$title' => DI::l10n()->t('Terms of Service'),
-				'$tostext' => BBCode::convert(DI::config()->get('system', 'tostext')),
-				'$displayprivstatement' => DI::config()->get('system', 'tosprivstatement'),
-				'$privstatementtitle' => DI::l10n()->t('Privacy Statement'),
-				'$privacy_operate' => DI::l10n()->t('At the time of registration, and for providing communications between the user account and their contacts, the user has to provide a display name (pen name), an username (nickname) and a working email address. The names will be accessible on the profile page of the account by any visitor of the page, even if other profile details are not displayed. The email address will only be used to send the user notifications about interactions, but wont be visibly displayed. The listing of an account in the node\'s user directory or the global user directory is optional and can be controlled in the user settings, it is not necessary for communication.'),
-				'$privacy_distribute' => DI::l10n()->t('This data is required for communication and is passed on to the nodes of the communication partners and is stored there. Users can enter additional private data that may be transmitted to the communication partners accounts.'),
-				'$privacy_delete' => DI::l10n()->t('At any point in time a logged in user can export their account data from the <a href="%1$s/settings/userexport">account settings</a>. If the user wants to delete their account they can do so at <a href="%1$s/removeme">%1$s/removeme</a>. The deletion of the account will be permanent. Deletion of the data will also be requested from the nodes of the communication partners.', DI::baseUrl())
+				'$title'                => $this->l10n->t('Terms of Service'),
+				'$tostext'              => BBCode::convert($this->config->get('system', 'tostext')),
+				'$displayprivstatement' => $this->config->get('system', 'tosprivstatement'),
+				'$privstatementtitle'   => $this->l10n->t('Privacy Statement'),
+				'$privacy_operate'      => $this->l10n->t('At the time of registration, and for providing communications between the user account and their contacts, the user has to provide a display name (pen name), an username (nickname) and a working email address. The names will be accessible on the profile page of the account by any visitor of the page, even if other profile details are not displayed. The email address will only be used to send the user notifications about interactions, but wont be visibly displayed. The listing of an account in the node\'s user directory or the global user directory is optional and can be controlled in the user settings, it is not necessary for communication.'),
+				'$privacy_distribute'   => $this->l10n->t('This data is required for communication and is passed on to the nodes of the communication partners and is stored there. Users can enter additional private data that may be transmitted to the communication partners accounts.'),
+				'$privacy_delete'       => $this->l10n->t('At any point in time a logged in user can export their account data from the <a href="%1$s/settings/userexport">account settings</a>. If the user wants to delete their account they can do so at <a href="%1$s/removeme">%1$s/removeme</a>. The deletion of the account will be permanent. Deletion of the data will also be requested from the nodes of the communication partners.', $this->baseUrl)
 			]);
 		} else {
 			return '';

--- a/tests/src/App/ModuleControllerTest.php
+++ b/tests/src/App/ModuleControllerTest.php
@@ -54,7 +54,7 @@ class ModuleControllerTest extends DatabaseTest
 		self::assertModule([
 			'isBackend' => false,
 			'name'      => App\ModuleController::DEFAULT,
-			'class'     => new $defaultClass(),
+			'class'     => null,
 		], $module);
 	}
 
@@ -146,28 +146,28 @@ class ModuleControllerTest extends DatabaseTest
 				'name'    => App\ModuleController::DEFAULT,
 				'command' => App\ModuleController::DEFAULT,
 				'privAdd' => false,
-				'args'    => [],
+				'args'    => [Mockery::mock(L10n::class)],
 			],
 			'legacy'  => [
 				'assert'  => LegacyModule::class,
 				'name'    => 'display',
 				'command' => 'display/test/it',
 				'privAdd' => false,
-				'args'    => [__DIR__ . '/../../datasets/legacy/legacy.php'],
+				'args'    => [Mockery::mock(L10n::class), __DIR__ . '/../../datasets/legacy/legacy.php'],
 			],
 			'new'     => [
 				'assert'  => HostMeta::class,
 				'not_required',
 				'command' => '.well-known/host-meta',
 				'privAdd' => false,
-				'args'    => [],
+				'args'    => [Mockery::mock(L10n::class)],
 			],
 			'404'     => [
 				'assert'  => PageNotFound::class,
 				'name'    => 'invalid',
 				'command' => 'invalid',
 				'privAdd' => false,
-				'args'    => [],
+				'args'    => [Mockery::mock(L10n::class)],
 			]
 		];
 	}

--- a/tests/src/Module/Api/Friendica/NotificationTest.php
+++ b/tests/src/Module/Api/Friendica/NotificationTest.php
@@ -67,7 +67,7 @@ class NotificationTest extends ApiTest
 </notes>
 XML;
 
-		$notification = new Notification(['extension' => 'xml']);
+		$notification = new Notification(DI::l10n(), ['extension' => 'xml']);
 		$notification->rawContent();
 
 		self::assertXmlStringEqualsXmlString($assertXml, ApiResponseDouble::getOutput());
@@ -75,7 +75,7 @@ XML;
 
 	public function testWithJsonResult()
 	{
-		$notification = new Notification(['parameter' => 'json']);
+		$notification = new Notification(DI::l10n(),['parameter' => 'json']);
 		$notification->rawContent();
 
 		$result = json_encode(ApiResponseDouble::getOutput());

--- a/tests/src/Module/Api/Friendica/Photo/DeleteTest.php
+++ b/tests/src/Module/Api/Friendica/Photo/DeleteTest.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Test\src\Module\Api\Friendica\Photo;
 
+use Friendica\DI;
 use Friendica\Module\Api\Friendica\Photo\Delete;
 use Friendica\Network\HTTPException\BadRequestException;
 use Friendica\Test\src\Module\Api\ApiTest;
@@ -30,7 +31,7 @@ class DeleteTest extends ApiTest
 	public function testEmpty()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete())->rawContent();
+		(new Delete(DI::l10n()))->rawContent();
 	}
 
 	public function testWithoutAuthenticatedUser()
@@ -41,7 +42,7 @@ class DeleteTest extends ApiTest
 	public function testWrong()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete(['photo_id' => 1]))->rawContent();
+		(new Delete(DI::l10n(), ['photo_id' => 1]))->rawContent();
 	}
 
 	public function testWithCorrectPhotoId()

--- a/tests/src/Module/Api/Friendica/Photoalbum/DeleteTest.php
+++ b/tests/src/Module/Api/Friendica/Photoalbum/DeleteTest.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Test\src\Module\Api\Friendica\Photoalbum;
 
+use Friendica\DI;
 use Friendica\Module\Api\Friendica\Photoalbum\Delete;
 use Friendica\Network\HTTPException\BadRequestException;
 use Friendica\Test\src\Module\Api\ApiTest;
@@ -30,13 +31,13 @@ class DeleteTest extends ApiTest
 	public function testEmpty()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete())->rawContent();
+		(new Delete(DI::l10n()))->rawContent();
 	}
 
 	public function testWrong()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete(['album' => 'album_name']))->rawContent();
+		(new Delete(DI::l10n(), ['album' => 'album_name']))->rawContent();
 	}
 
 	public function testValid()

--- a/tests/src/Module/Api/Friendica/Photoalbum/UpdateTest.php
+++ b/tests/src/Module/Api/Friendica/Photoalbum/UpdateTest.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Test\src\Module\Api\Friendica\Photoalbum;
 
+use Friendica\DI;
 use Friendica\Module\Api\Friendica\Photoalbum\Update;
 use Friendica\Network\HTTPException\BadRequestException;
 use Friendica\Test\src\Module\Api\ApiTest;
@@ -30,19 +31,19 @@ class UpdateTest extends ApiTest
 	public function testEmpty()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Update())->rawContent();
+		(new Update(DI::l10n()))->rawContent();
 	}
 
 	public function testTooFewArgs()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Update(['album' => 'album_name']))->rawContent();
+		(new Update(DI::l10n(), ['album' => 'album_name']))->rawContent();
 	}
 
 	public function testWrongUpdate()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Update(['album' => 'album_name', 'album_new' => 'album_name']))->rawContent();
+		(new Update(DI::l10n(), ['album' => 'album_name', 'album_new' => 'album_name']))->rawContent();
 	}
 
 	public function testWithoutAuthenticatedUser()

--- a/tests/src/Module/Api/GnuSocial/GnuSocial/VersionTest.php
+++ b/tests/src/Module/Api/GnuSocial/GnuSocial/VersionTest.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Test\src\Module\Api\GnuSocial\GnuSocial;
 
+use Friendica\DI;
 use Friendica\Module\Api\GNUSocial\GNUSocial\Version;
 use Friendica\Test\src\Module\Api\ApiTest;
 use Friendica\Test\Util\ApiResponseDouble;
@@ -10,7 +11,7 @@ class VersionTest extends ApiTest
 {
 	public function test()
 	{
-		$version = new Version(['extension' => 'json']);
+		$version = new Version(DI::l10n(), ['extension' => 'json']);
 		$version->rawContent();
 
 		$result = json_decode(ApiResponseDouble::getOutput());

--- a/tests/src/Module/Api/GnuSocial/Help/TestTest.php
+++ b/tests/src/Module/Api/GnuSocial/Help/TestTest.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Test\src\Module\Api\GnuSocial\Help;
 
+use Friendica\DI;
 use Friendica\Module\Api\GNUSocial\Help\Test;
 use Friendica\Test\src\Module\Api\ApiTest;
 use Friendica\Test\Util\ApiResponseDouble;
@@ -10,7 +11,7 @@ class TestTest extends ApiTest
 {
 	public function testJson()
 	{
-		$test = new Test(['extension' => 'json']);
+		$test = new Test(DI::l10n(), ['extension' => 'json']);
 		$test->rawContent();
 
 		self::assertEquals('"ok"', ApiResponseDouble::getOutput());
@@ -18,7 +19,7 @@ class TestTest extends ApiTest
 
 	public function testXml()
 	{
-		$test = new Test(['extension' => 'xml']);
+		$test = new Test(DI::l10n(), ['extension' => 'xml']);
 		$test->rawContent();
 
 		self::assertxml(ApiResponseDouble::getOutput(), 'ok');

--- a/tests/src/Module/Api/Twitter/Account/RateLimitStatusTest.php
+++ b/tests/src/Module/Api/Twitter/Account/RateLimitStatusTest.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Test\src\Module\Api\Twitter\Account;
 
+use Friendica\DI;
 use Friendica\Module\Api\Twitter\Account\RateLimitStatus;
 use Friendica\Test\src\Module\Api\ApiTest;
 use Friendica\Test\Util\ApiResponseDouble;
@@ -10,7 +11,7 @@ class RateLimitStatusTest extends ApiTest
 {
 	public function testWithJson()
 	{
-		$rateLimitStatus = new RateLimitStatus(['extension' => 'json']);
+		$rateLimitStatus = new RateLimitStatus(DI::l10n(), ['extension' => 'json']);
 		$rateLimitStatus->rawContent();
 
 		$result = json_decode(ApiResponseDouble::getOutput());
@@ -22,7 +23,7 @@ class RateLimitStatusTest extends ApiTest
 
 	public function testWithXml()
 	{
-		$rateLimitStatus = new RateLimitStatus(['extension' => 'xml']);
+		$rateLimitStatus = new RateLimitStatus(DI::l10n(),['extension' => 'xml']);
 		$rateLimitStatus->rawContent();
 
 		self::assertXml(ApiResponseDouble::getOutput(), 'hash');

--- a/tests/src/Module/Api/Twitter/SavedSearchesTest.php
+++ b/tests/src/Module/Api/Twitter/SavedSearchesTest.php
@@ -2,6 +2,7 @@
 
 namespace Friendica\Test\src\Module\Api\Twitter;
 
+use Friendica\DI;
 use Friendica\Module\Api\Twitter\SavedSearches;
 use Friendica\Test\src\Module\Api\ApiTest;
 use Friendica\Test\Util\ApiResponseDouble;
@@ -10,7 +11,7 @@ class SavedSearchesTest extends ApiTest
 {
 	public function test()
 	{
-		$savedSearch = new SavedSearches(['extension' => 'json']);
+		$savedSearch = new SavedSearches(DI::l10n(), ['extension' => 'json']);
 		$savedSearch->rawContent();
 
 		$result = json_decode(ApiResponseDouble::getOutput());

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2021.12-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-15 19:02-0500\n"
+"POT-Creation-Date: 2021-11-18 21:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 
-#: include/api.php:860 src/Module/BaseApi.php:260
+#: include/api.php:860 src/Module/BaseApi.php:259
 #, php-format
 msgid "Daily posting limit of %d post reached. The post was rejected."
 msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/api.php:874 src/Module/BaseApi.php:276
+#: include/api.php:874 src/Module/BaseApi.php:275
 #, php-format
 msgid "Weekly posting limit of %d post reached. The post was rejected."
 msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/api.php:888 src/Module/BaseApi.php:292
+#: include/api.php:888 src/Module/BaseApi.php:291
 #, php-format
 msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgstr ""
 
 #: mod/cal.php:44 mod/cal.php:48 mod/follow.php:39 mod/redir.php:34
-#: mod/redir.php:175 src/Module/Conversation/Community.php:182
-#: src/Module/Debug/ItemBody.php:37 src/Module/Diaspora/Receive.php:51
+#: mod/redir.php:175 src/Module/Conversation/Community.php:181
+#: src/Module/Debug/ItemBody.php:37 src/Module/Diaspora/Receive.php:57
 #: src/Module/Item/Follow.php:42 src/Module/Item/Ignore.php:41
 #: src/Module/Item/Pin.php:42 src/Module/Item/Pin.php:57
 #: src/Module/Item/Star.php:43
@@ -51,7 +51,7 @@ msgstr ""
 #: src/Module/Profile/Common.php:41 src/Module/Profile/Common.php:52
 #: src/Module/Profile/Contacts.php:40 src/Module/Profile/Contacts.php:50
 #: src/Module/Profile/Media.php:38 src/Module/Profile/Status.php:58
-#: src/Module/Register.php:256 src/Module/RemoteFollow.php:49
+#: src/Module/Register.php:263 src/Module/RemoteFollow.php:58
 msgid "User not found."
 msgstr ""
 
@@ -76,7 +76,7 @@ msgstr ""
 msgid "Previous"
 msgstr ""
 
-#: mod/cal.php:245 mod/events.php:381 src/Module/Install.php:206
+#: mod/cal.php:245 mod/events.php:381 src/Module/Install.php:215
 msgid "Next"
 msgstr ""
 
@@ -106,7 +106,7 @@ msgstr ""
 #: mod/cal.php:265 src/Console/User.php:182 src/Model/User.php:660
 #: src/Module/Admin/Users/Active.php:73 src/Module/Admin/Users/Blocked.php:74
 #: src/Module/Admin/Users/Index.php:80 src/Module/Admin/Users/Pending.php:71
-#: src/Module/Api/Twitter/ContactEndpoint.php:71
+#: src/Module/Api/Twitter/ContactEndpoint.php:72
 msgid "User not found"
 msgstr ""
 
@@ -123,7 +123,7 @@ msgid "calendar"
 msgstr ""
 
 #: mod/display.php:165 mod/photos.php:808
-#: src/Module/Conversation/Community.php:176 src/Module/Directory.php:48
+#: src/Module/Conversation/Community.php:175 src/Module/Directory.php:48
 #: src/Module/Search/Index.php:49
 msgid "Public access denied."
 msgstr ""
@@ -147,26 +147,26 @@ msgstr ""
 #: mod/wallmessage.php:36 mod/wallmessage.php:55 mod/wallmessage.php:89
 #: mod/wallmessage.php:109 src/Module/Attach.php:55 src/Module/BaseApi.php:61
 #: src/Module/BaseApi.php:70 src/Module/BaseApi.php:79
-#: src/Module/BaseApi.php:88 src/Module/BaseNotifications.php:88
-#: src/Module/Contact.php:328 src/Module/Contact/Advanced.php:44
+#: src/Module/BaseApi.php:88 src/Module/BaseNotifications.php:94
+#: src/Module/Contact.php:328 src/Module/Contact/Advanced.php:60
 #: src/Module/Delegation.php:118 src/Module/FollowConfirm.php:17
-#: src/Module/FriendSuggest.php:44 src/Module/Group.php:44
+#: src/Module/FriendSuggest.php:56 src/Module/Group.php:44
 #: src/Module/Group.php:89 src/Module/Invite.php:41 src/Module/Invite.php:130
 #: src/Module/Notifications/Notification.php:48
 #: src/Module/Notifications/Notification.php:79
 #: src/Module/Profile/Common.php:56 src/Module/Profile/Contacts.php:56
 #: src/Module/Profile/Schedule.php:39 src/Module/Profile/Schedule.php:56
-#: src/Module/Register.php:64 src/Module/Register.php:77
-#: src/Module/Register.php:195 src/Module/Register.php:234
+#: src/Module/Register.php:73 src/Module/Register.php:86
+#: src/Module/Register.php:202 src/Module/Register.php:241
 #: src/Module/Search/Directory.php:37 src/Module/Settings/Delegation.php:42
 #: src/Module/Settings/Delegation.php:70 src/Module/Settings/Display.php:42
 #: src/Module/Settings/Display.php:120
 #: src/Module/Settings/Profile/Photo/Crop.php:166
 #: src/Module/Settings/Profile/Photo/Index.php:112
-#: src/Module/Settings/UserExport.php:58 src/Module/Settings/UserExport.php:93
-#: src/Module/Settings/UserExport.php:198
-#: src/Module/Settings/UserExport.php:218
-#: src/Module/Settings/UserExport.php:283
+#: src/Module/Settings/UserExport.php:57 src/Module/Settings/UserExport.php:91
+#: src/Module/Settings/UserExport.php:196
+#: src/Module/Settings/UserExport.php:216
+#: src/Module/Settings/UserExport.php:281
 msgid "Permission denied."
 msgstr ""
 
@@ -179,7 +179,7 @@ msgid "Edit post"
 msgstr ""
 
 #: mod/editpost.php:91 mod/notes.php:56 src/Content/Text/HTML.php:875
-#: src/Module/Admin/Storage.php:142 src/Module/Filer/SaveTag.php:69
+#: src/Module/Admin/Storage.php:142 src/Module/Filer/SaveTag.php:76
 msgid "Save"
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr ""
 #: mod/editpost.php:130 mod/fbrowser.php:100 mod/fbrowser.php:127
 #: mod/follow.php:144 mod/photos.php:1010 mod/photos.php:1111 mod/tagrm.php:35
 #: mod/tagrm.php:127 mod/unfollow.php:97 src/Content/Conversation.php:373
-#: src/Module/Contact/Revoke.php:99 src/Module/RemoteFollow.php:116
+#: src/Module/Contact/Revoke.php:114 src/Module/RemoteFollow.php:128
 msgid "Cancel"
 msgstr ""
 
@@ -335,7 +335,7 @@ msgid "Message"
 msgstr ""
 
 #: mod/editpost.php:144 src/Content/Conversation.php:381
-#: src/Module/Settings/TwoFactor/Trusted.php:101
+#: src/Module/Settings/TwoFactor/Trusted.php:113
 msgid "Browser"
 msgstr ""
 
@@ -379,15 +379,15 @@ msgstr ""
 #: src/Module/Admin/Blocklist/Server/Index.php:69
 #: src/Module/Admin/Blocklist/Server/Index.php:96
 #: src/Module/Admin/Item/Delete.php:70 src/Module/Debug/Probe.php:59
-#: src/Module/Install.php:199 src/Module/Install.php:232
-#: src/Module/Install.php:237 src/Module/Install.php:256
-#: src/Module/Install.php:267 src/Module/Install.php:272
-#: src/Module/Install.php:278 src/Module/Install.php:283
-#: src/Module/Install.php:297 src/Module/Install.php:312
-#: src/Module/Install.php:339 src/Module/Register.php:137
+#: src/Module/Install.php:208 src/Module/Install.php:241
+#: src/Module/Install.php:246 src/Module/Install.php:265
+#: src/Module/Install.php:276 src/Module/Install.php:281
+#: src/Module/Install.php:287 src/Module/Install.php:292
+#: src/Module/Install.php:306 src/Module/Install.php:321
+#: src/Module/Install.php:348 src/Module/Register.php:144
 #: src/Module/Security/TwoFactor/Verify.php:100
 #: src/Module/Settings/TwoFactor/Index.php:133
-#: src/Module/Settings/TwoFactor/Verify.php:141
+#: src/Module/Settings/TwoFactor/Verify.php:153
 msgid "Required"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 #: mod/events.php:508 src/Content/Widget/VCard.php:98 src/Model/Event.php:80
 #: src/Model/Event.php:107 src/Model/Event.php:466 src/Model/Event.php:915
 #: src/Model/Profile.php:368 src/Module/Contact.php:565
-#: src/Module/Directory.php:147 src/Module/Notifications/Introductions.php:165
+#: src/Module/Directory.php:147 src/Module/Notifications/Introductions.php:181
 #: src/Module/Profile/Profile.php:194
 msgid "Location:"
 msgstr ""
@@ -424,13 +424,13 @@ msgstr ""
 #: mod/photos.php:927 mod/photos.php:1031 mod/photos.php:1301
 #: mod/photos.php:1342 mod/photos.php:1398 mod/photos.php:1472
 #: src/Module/Admin/Item/Source.php:65 src/Module/Contact.php:523
-#: src/Module/Contact/Advanced.php:133 src/Module/Contact/Poke.php:158
+#: src/Module/Contact/Advanced.php:147 src/Module/Contact/Poke.php:158
 #: src/Module/Debug/ActivityPubConversion.php:141
 #: src/Module/Debug/Babel.php:313 src/Module/Debug/Localtime.php:64
 #: src/Module/Debug/Probe.php:54 src/Module/Debug/WebFinger.php:51
-#: src/Module/Delegation.php:147 src/Module/FriendSuggest.php:128
-#: src/Module/Install.php:244 src/Module/Install.php:286
-#: src/Module/Install.php:323 src/Module/Invite.php:177
+#: src/Module/Delegation.php:147 src/Module/FriendSuggest.php:145
+#: src/Module/Install.php:253 src/Module/Install.php:295
+#: src/Module/Install.php:332 src/Module/Invite.php:177
 #: src/Module/Item/Compose.php:150 src/Module/Profile/Profile.php:247
 #: src/Module/Settings/Profile/Index.php:222 src/Object/Post.php:963
 #: view/theme/duepuntozero/config.php:69 view/theme/frio/config.php:160
@@ -465,7 +465,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: mod/follow.php:74 mod/unfollow.php:96 src/Module/RemoteFollow.php:115
+#: mod/follow.php:74 mod/unfollow.php:96 src/Module/RemoteFollow.php:127
 msgid "Submit Request"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Connect/Follow"
 msgstr ""
 
-#: mod/follow.php:139 src/Module/RemoteFollow.php:114
+#: mod/follow.php:139 src/Module/RemoteFollow.php:126
 msgid "Please answer the following:"
 msgstr ""
 
@@ -501,13 +501,13 @@ msgstr ""
 
 #: mod/follow.php:141 mod/unfollow.php:100
 #: src/Module/Admin/Blocklist/Contact.php:116 src/Module/Contact.php:561
-#: src/Module/Notifications/Introductions.php:107
-#: src/Module/Notifications/Introductions.php:176
+#: src/Module/Notifications/Introductions.php:123
+#: src/Module/Notifications/Introductions.php:192
 msgid "Profile URL"
 msgstr ""
 
 #: mod/follow.php:142 src/Module/Contact.php:573
-#: src/Module/Notifications/Introductions.php:169
+#: src/Module/Notifications/Introductions.php:185
 #: src/Module/Profile/Profile.php:207
 msgid "Tags:"
 msgstr ""
@@ -726,8 +726,8 @@ msgstr ""
 msgid "Message collection failure."
 msgstr ""
 
-#: mod/message.php:120 src/Module/Notifications/Introductions.php:113
-#: src/Module/Notifications/Introductions.php:148
+#: mod/message.php:120 src/Module/Notifications/Introductions.php:129
+#: src/Module/Notifications/Introductions.php:164
 #: src/Module/Notifications/Notification.php:57
 msgid "Discard"
 msgstr ""
@@ -1146,10 +1146,10 @@ msgstr ""
 msgid "Bad Request."
 msgstr ""
 
-#: mod/redir.php:55 mod/redir.php:129 src/Module/Contact/Advanced.php:54
-#: src/Module/Contact/Advanced.php:105 src/Module/Contact/Contacts.php:36
-#: src/Module/Contact/Media.php:43 src/Module/FriendSuggest.php:54
-#: src/Module/FriendSuggest.php:92 src/Module/Group.php:104
+#: mod/redir.php:55 mod/redir.php:129 src/Module/Contact/Advanced.php:70
+#: src/Module/Contact/Advanced.php:119 src/Module/Contact/Contacts.php:36
+#: src/Module/Contact/Media.php:43 src/Module/FriendSuggest.php:71
+#: src/Module/FriendSuggest.php:109 src/Module/Group.php:104
 msgid "Contact not found."
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgstr ""
 #: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
 #: src/Module/Admin/Users/Create.php:71 src/Module/Admin/Users/Deleted.php:88
 #: src/Module/Admin/Users/Index.php:142 src/Module/Admin/Users/Index.php:162
-#: src/Module/Admin/Users/Pending.php:104 src/Module/Contact/Advanced.php:135
+#: src/Module/Admin/Users/Pending.php:104 src/Module/Contact/Advanced.php:149
 msgid "Name"
 msgstr ""
 
@@ -1300,7 +1300,7 @@ msgstr ""
 #: mod/settings.php:475 mod/settings.php:566 mod/settings.php:703
 #: src/Module/Admin/Addons/Index.php:69 src/Module/Admin/Features.php:87
 #: src/Module/Admin/Logs/Settings.php:82 src/Module/Admin/Site.php:501
-#: src/Module/Admin/Themes/Index.php:113 src/Module/Admin/Tos.php:66
+#: src/Module/Admin/Themes/Index.php:113 src/Module/Admin/Tos.php:83
 #: src/Module/Settings/Delegation.php:170 src/Module/Settings/Display.php:193
 msgid "Save Settings"
 msgstr ""
@@ -1610,7 +1610,7 @@ msgstr ""
 msgid "Password Settings"
 msgstr ""
 
-#: mod/settings.php:710 src/Module/Register.php:151
+#: mod/settings.php:710 src/Module/Register.php:158
 msgid "New Password:"
 msgstr ""
 
@@ -1620,7 +1620,7 @@ msgid ""
 "spaces, accentuated letters and colon (:)."
 msgstr ""
 
-#: mod/settings.php:711 src/Module/Register.php:152
+#: mod/settings.php:711 src/Module/Register.php:159
 msgid "Confirm:"
 msgstr ""
 
@@ -2000,7 +2000,7 @@ msgid "Select a tag to remove: "
 msgstr ""
 
 #: mod/tagrm.php:126 src/Module/Settings/Delegation.php:179
-#: src/Module/Settings/TwoFactor/Trusted.php:104
+#: src/Module/Settings/TwoFactor/Trusted.php:116
 msgid "Remove"
 msgstr ""
 
@@ -2008,13 +2008,13 @@ msgstr ""
 msgid "User imports on closed servers can only be done by an administrator."
 msgstr ""
 
-#: mod/uimport.php:55 src/Module/Register.php:86
+#: mod/uimport.php:55 src/Module/Register.php:95
 msgid ""
 "This site has exceeded the number of allowed daily account registrations. "
 "Please try again tomorrow."
 msgstr ""
 
-#: mod/uimport.php:62 src/Module/Register.php:162
+#: mod/uimport.php:62 src/Module/Register.php:169
 msgid "Import"
 msgstr ""
 
@@ -2122,11 +2122,11 @@ msgid ""
 "your site allow private mail from unknown senders."
 msgstr ""
 
-#: src/App.php:469
+#: src/App.php:470
 msgid "No system theme config value set."
 msgstr ""
 
-#: src/App/Module.php:242
+#: src/App/ModuleController.php:233
 msgid "You must be logged in to use addons. "
 msgstr ""
 
@@ -2153,31 +2153,31 @@ msgstr ""
 msgid "Page not found."
 msgstr ""
 
-#: src/BaseModule.php:180
+#: src/BaseModule.php:158
 msgid ""
 "The form security token was not correct. This probably happened because the "
 "form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
-#: src/BaseModule.php:207
+#: src/BaseModule.php:185
 msgid "All contacts"
 msgstr ""
 
-#: src/BaseModule.php:212 src/Content/Widget.php:231 src/Core/ACL.php:193
+#: src/BaseModule.php:190 src/Content/Widget.php:231 src/Core/ACL.php:193
 #: src/Module/Contact.php:756 src/Module/PermissionTooltip.php:79
 #: src/Module/PermissionTooltip.php:101
 msgid "Followers"
 msgstr ""
 
-#: src/BaseModule.php:217 src/Content/Widget.php:232 src/Module/Contact.php:757
+#: src/BaseModule.php:195 src/Content/Widget.php:232 src/Module/Contact.php:757
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:222 src/Content/Widget.php:233 src/Module/Contact.php:758
+#: src/BaseModule.php:200 src/Content/Widget.php:233 src/Module/Contact.php:758
 msgid "Mutual friends"
 msgstr ""
 
-#: src/BaseModule.php:230
+#: src/BaseModule.php:208
 msgid "Common"
 msgstr ""
 
@@ -2499,7 +2499,7 @@ msgstr ""
 msgid "Tag term:"
 msgstr ""
 
-#: src/Content/Conversation.php:310 src/Module/Filer/SaveTag.php:68
+#: src/Content/Conversation.php:310 src/Module/Filer/SaveTag.php:75
 msgid "Save to Folder:"
 msgstr ""
 
@@ -2773,8 +2773,8 @@ msgstr ""
 
 #: src/Content/Item.php:450 src/Module/Contact.php:545
 #: src/Module/Contact.php:788 src/Module/Contact.php:1072
-#: src/Module/Notifications/Introductions.php:112
-#: src/Module/Notifications/Introductions.php:184
+#: src/Module/Notifications/Introductions.php:128
+#: src/Module/Notifications/Introductions.php:200
 #: src/Module/Notifications/Notification.php:61
 msgid "Ignore"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/Content/Nav.php:216 src/Module/Register.php:157
+#: src/Content/Nav.php:216 src/Module/Register.php:164
 #: src/Module/Security/Login.php:105
 msgid "Register"
 msgstr ""
@@ -2881,11 +2881,11 @@ msgstr ""
 msgid "Create an account"
 msgstr ""
 
-#: src/Content/Nav.php:222 src/Module/Help.php:68
-#: src/Module/Settings/TwoFactor/AppSpecific.php:115
+#: src/Content/Nav.php:222 src/Module/Help.php:67
+#: src/Module/Settings/TwoFactor/AppSpecific.php:127
 #: src/Module/Settings/TwoFactor/Index.php:111
-#: src/Module/Settings/TwoFactor/Recovery.php:93
-#: src/Module/Settings/TwoFactor/Verify.php:132 view/theme/vier/theme.php:217
+#: src/Module/Settings/TwoFactor/Recovery.php:105
+#: src/Module/Settings/TwoFactor/Verify.php:144 view/theme/vier/theme.php:217
 msgid "Help"
 msgstr ""
 
@@ -2955,9 +2955,9 @@ msgstr ""
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:266 src/Module/Admin/Tos.php:59
-#: src/Module/BaseAdmin.php:96 src/Module/Register.php:165
-#: src/Module/Tos.php:84
+#: src/Content/Nav.php:266 src/Module/Admin/Tos.php:76
+#: src/Module/BaseAdmin.php:96 src/Module/Register.php:172
+#: src/Module/Tos.php:88
 msgid "Terms of Service"
 msgstr ""
 
@@ -2981,8 +2981,8 @@ msgstr ""
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:278 src/Module/BaseNotifications.php:139
-#: src/Module/Notifications/Introductions.php:53
+#: src/Content/Nav.php:278 src/Module/BaseNotifications.php:147
+#: src/Module/Notifications/Introductions.php:69
 msgid "Notifications"
 msgstr ""
 
@@ -3300,7 +3300,7 @@ msgid "Matrix:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:101 src/Model/Profile.php:466
-#: src/Module/Notifications/Introductions.php:179
+#: src/Module/Notifications/Introductions.php:195
 msgid "Network:"
 msgstr ""
 
@@ -3367,8 +3367,8 @@ msgid ""
 "or mysql."
 msgstr ""
 
-#: src/Core/Installer.php:203 src/Module/Install.php:205
-#: src/Module/Install.php:364
+#: src/Core/Installer.php:203 src/Module/Install.php:214
+#: src/Module/Install.php:373
 msgid "Please see the file \"doc/INSTALL.md\"."
 msgstr ""
 
@@ -4053,7 +4053,7 @@ msgstr ""
 msgid "Internal Server Error"
 msgstr ""
 
-#: src/LegacyModule.php:49
+#: src/LegacyModule.php:60
 #, php-format
 msgid "Legacy module file not found: %s"
 msgstr ""
@@ -4063,8 +4063,8 @@ msgid "UnFollow"
 msgstr ""
 
 #: src/Model/Contact.php:1061 src/Module/Admin/Users/Pending.php:107
-#: src/Module/Notifications/Introductions.php:110
-#: src/Module/Notifications/Introductions.php:182
+#: src/Module/Notifications/Introductions.php:126
+#: src/Module/Notifications/Introductions.php:198
 msgid "Approve"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgid "Homepage:"
 msgstr ""
 
 #: src/Model/Profile.php:372 src/Module/Contact.php:571
-#: src/Module/Notifications/Introductions.php:167
+#: src/Module/Notifications/Introductions.php:183
 msgid "About:"
 msgstr ""
 
@@ -4713,7 +4713,7 @@ msgstr ""
 #: src/Module/Admin/Queue.php:72 src/Module/Admin/Site.php:498
 #: src/Module/Admin/Storage.php:138 src/Module/Admin/Summary.php:232
 #: src/Module/Admin/Themes/Details.php:90 src/Module/Admin/Themes/Index.php:111
-#: src/Module/Admin/Tos.php:58 src/Module/Admin/Users/Active.php:136
+#: src/Module/Admin/Tos.php:75 src/Module/Admin/Users/Active.php:136
 #: src/Module/Admin/Users/Blocked.php:137 src/Module/Admin/Users/Create.php:61
 #: src/Module/Admin/Users/Deleted.php:85 src/Module/Admin/Users/Index.php:149
 #: src/Module/Admin/Users/Pending.php:101
@@ -5303,7 +5303,7 @@ msgid "Search in logs"
 msgstr ""
 
 #: src/Module/Admin/Logs/View.php:88
-#: src/Module/Notifications/Notifications.php:126
+#: src/Module/Notifications/Notifications.php:140
 msgid "Show all"
 msgstr ""
 
@@ -5448,15 +5448,15 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: src/Module/Admin/Site.php:475 src/Module/Install.php:214
+#: src/Module/Admin/Site.php:475 src/Module/Install.php:223
 msgid "No SSL policy, links will track page SSL state"
 msgstr ""
 
-#: src/Module/Admin/Site.php:476 src/Module/Install.php:215
+#: src/Module/Admin/Site.php:476 src/Module/Install.php:224
 msgid "Force all links to use SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:477 src/Module/Install.php:216
+#: src/Module/Admin/Site.php:477 src/Module/Install.php:225
 msgid "Self-signed certificate, use SSL for local links only (discouraged)"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Republish users to directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:503 src/Module/Register.php:141
+#: src/Module/Admin/Site.php:503 src/Module/Register.php:148
 msgid "Registration"
 msgstr ""
 
@@ -5629,11 +5629,11 @@ msgstr ""
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:531 src/Module/Install.php:224
+#: src/Module/Admin/Site.php:531 src/Module/Install.php:233
 msgid "SSL link policy"
 msgstr ""
 
-#: src/Module/Admin/Site.php:531 src/Module/Install.php:226
+#: src/Module/Admin/Site.php:531 src/Module/Install.php:235
 msgid "Determines whether generated links should be forced to use SSL"
 msgstr ""
 
@@ -6551,7 +6551,7 @@ msgstr ""
 msgid "Themes"
 msgstr ""
 
-#: src/Module/Admin/Themes/Embed.php:65
+#: src/Module/Admin/Themes/Embed.php:79
 msgid "Unknown theme."
 msgstr ""
 
@@ -6576,21 +6576,21 @@ msgstr ""
 msgid "[Unsupported]"
 msgstr ""
 
-#: src/Module/Admin/Tos.php:60
+#: src/Module/Admin/Tos.php:77
 msgid "Display Terms of Service"
 msgstr ""
 
-#: src/Module/Admin/Tos.php:60
+#: src/Module/Admin/Tos.php:77
 msgid ""
 "Enable the Terms of Service page. If this is enabled a link to the terms "
 "will be added to the registration form and the general information page."
 msgstr ""
 
-#: src/Module/Admin/Tos.php:61
+#: src/Module/Admin/Tos.php:78
 msgid "Display Privacy Statement"
 msgstr ""
 
-#: src/Module/Admin/Tos.php:61
+#: src/Module/Admin/Tos.php:78
 #, php-format
 msgid ""
 "Show some informations regarding the needed information to operate the node "
@@ -6598,15 +6598,15 @@ msgid ""
 "\">EU-GDPR</a>."
 msgstr ""
 
-#: src/Module/Admin/Tos.php:62
+#: src/Module/Admin/Tos.php:79
 msgid "Privacy Statement Preview"
 msgstr ""
 
-#: src/Module/Admin/Tos.php:64
+#: src/Module/Admin/Tos.php:81
 msgid "The Terms of Service"
 msgstr ""
 
-#: src/Module/Admin/Tos.php:64
+#: src/Module/Admin/Tos.php:81
 msgid ""
 "Enter the Terms of Service for your node here. You can use BBCode. Headers "
 "of sections should be [h2] and below."
@@ -6808,7 +6808,7 @@ msgid ""
 "The API endpoint is currently not implemented but might be in the future."
 msgstr ""
 
-#: src/Module/Api/Mastodon/Apps.php:58
+#: src/Module/Api/Mastodon/Apps.php:57
 msgid "Missing parameters"
 msgstr ""
 
@@ -6843,20 +6843,20 @@ msgstr ""
 msgid "Posts from %s can't be unshared"
 msgstr ""
 
-#: src/Module/Api/Twitter/ContactEndpoint.php:63 src/Module/Contact.php:343
+#: src/Module/Api/Twitter/ContactEndpoint.php:64 src/Module/Contact.php:343
 #: src/Module/Contact.php:358
 msgid "Contact not found"
 msgstr ""
 
-#: src/Module/Api/Twitter/ContactEndpoint.php:133
+#: src/Module/Api/Twitter/ContactEndpoint.php:134
 msgid "Profile not found"
 msgstr ""
 
-#: src/Module/Apps.php:47
+#: src/Module/Apps.php:51
 msgid "No installed applications."
 msgstr ""
 
-#: src/Module/Apps.php:52
+#: src/Module/Apps.php:56
 msgid "Applications"
 msgstr ""
 
@@ -6950,8 +6950,8 @@ msgstr ""
 msgid "User registrations waiting for confirmation"
 msgstr ""
 
-#: src/Module/BaseApi.php:259 src/Module/BaseApi.php:275
-#: src/Module/BaseApi.php:291
+#: src/Module/BaseApi.php:258 src/Module/BaseApi.php:274
+#: src/Module/BaseApi.php:290
 msgid "Too Many Requests"
 msgstr ""
 
@@ -7006,7 +7006,7 @@ msgstr ""
 msgid "Connected apps"
 msgstr ""
 
-#: src/Module/BaseSettings.php:108 src/Module/Settings/UserExport.php:76
+#: src/Module/BaseSettings.php:108 src/Module/Settings/UserExport.php:75
 msgid "Export personal data"
 msgstr ""
 
@@ -7216,7 +7216,7 @@ msgstr ""
 msgid "Awaiting connection acknowledge"
 msgstr ""
 
-#: src/Module/Contact.php:553 src/Module/Notifications/Introductions.php:170
+#: src/Module/Contact.php:553 src/Module/Notifications/Introductions.php:186
 msgid "Hide this contact from others"
 msgstr ""
 
@@ -7367,7 +7367,7 @@ msgstr ""
 msgid "Toggle Ignored status"
 msgstr ""
 
-#: src/Module/Contact.php:1081 src/Module/Contact/Revoke.php:96
+#: src/Module/Contact.php:1081 src/Module/Contact/Revoke.php:111
 msgid "Revoke Follow"
 msgstr ""
 
@@ -7375,59 +7375,59 @@ msgstr ""
 msgid "Revoke the follow from this contact"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:93
+#: src/Module/Contact/Advanced.php:109
 msgid "Contact update failed."
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:110
+#: src/Module/Contact/Advanced.php:124
 msgid ""
 "<strong>WARNING: This is highly advanced</strong> and if you enter incorrect "
 "information your communications with this contact may stop working."
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:111
+#: src/Module/Contact/Advanced.php:125
 msgid ""
 "Please use your browser 'Back' button <strong>now</strong> if you are "
 "uncertain what to do on this page."
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:131
+#: src/Module/Contact/Advanced.php:145
 msgid "Return to contact editor"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:136
+#: src/Module/Contact/Advanced.php:150
 msgid "Account Nickname"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:137
+#: src/Module/Contact/Advanced.php:151
 msgid "@Tagname - overrides Name/Nickname"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:138
+#: src/Module/Contact/Advanced.php:152
 msgid "Account URL"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:139
+#: src/Module/Contact/Advanced.php:153
 msgid "Account URL Alias"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:140
+#: src/Module/Contact/Advanced.php:154
 msgid "Friend Request URL"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:141
+#: src/Module/Contact/Advanced.php:155
 msgid "Friend Confirm URL"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:142
+#: src/Module/Contact/Advanced.php:156
 msgid "Notification Endpoint URL"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:143
+#: src/Module/Contact/Advanced.php:157
 msgid "Poll/Feed URL"
 msgstr ""
 
-#: src/Module/Contact/Advanced.php:144
+#: src/Module/Contact/Advanced.php:158
 msgid "New photo from this URL"
 msgstr ""
 
@@ -7514,42 +7514,42 @@ msgstr ""
 msgid "Make this post private"
 msgstr ""
 
-#: src/Module/Contact/Revoke.php:48
+#: src/Module/Contact/Revoke.php:63
 msgid "Unknown contact."
 msgstr ""
 
-#: src/Module/Contact/Revoke.php:58 src/Module/Group.php:108
+#: src/Module/Contact/Revoke.php:73 src/Module/Group.php:108
 msgid "Contact is deleted."
 msgstr ""
 
-#: src/Module/Contact/Revoke.php:62
+#: src/Module/Contact/Revoke.php:77
 msgid "Contact is being deleted."
 msgstr ""
 
-#: src/Module/Contact/Revoke.php:76
+#: src/Module/Contact/Revoke.php:91
 msgid "Follow was successfully revoked."
 msgstr ""
 
-#: src/Module/Contact/Revoke.php:78
+#: src/Module/Contact/Revoke.php:93
 msgid ""
 "Follow was successfully revoked, however the remote contact won't be aware "
 "of this revokation."
 msgstr ""
 
-#: src/Module/Contact/Revoke.php:80
+#: src/Module/Contact/Revoke.php:95
 msgid ""
 "Unable to revoke follow, please try again later or contact the administrator."
 msgstr ""
 
-#: src/Module/Contact/Revoke.php:97
+#: src/Module/Contact/Revoke.php:112
 msgid ""
 "Do you really want to revoke this contact's follow? This cannot be undone "
 "and they will have to manually follow you back again."
 msgstr ""
 
-#: src/Module/Contact/Revoke.php:98
-#: src/Module/Notifications/Introductions.php:122
-#: src/Module/OAuth/Acknowledge.php:47 src/Module/Register.php:117
+#: src/Module/Contact/Revoke.php:113
+#: src/Module/Notifications/Introductions.php:138
+#: src/Module/OAuth/Acknowledge.php:47 src/Module/Register.php:126
 msgid "Yes"
 msgstr ""
 
@@ -7592,11 +7592,11 @@ msgid ""
 "not reflect the opinions of this node’s users."
 msgstr ""
 
-#: src/Module/Conversation/Community.php:200
+#: src/Module/Conversation/Community.php:199
 msgid "Community option not available."
 msgstr ""
 
-#: src/Module/Conversation/Community.php:216
+#: src/Module/Conversation/Community.php:215
 msgid "Not available."
 msgstr ""
 
@@ -7849,12 +7849,12 @@ msgstr ""
 msgid "Twitter Source / Tweet URL (requires API key)"
 msgstr ""
 
-#: src/Module/Debug/Feed.php:38 src/Module/Filer/SaveTag.php:40
+#: src/Module/Debug/Feed.php:47 src/Module/Filer/SaveTag.php:49
 #: src/Module/Settings/Profile/Index.php:141
 msgid "You must be logged in to use this module"
 msgstr ""
 
-#: src/Module/Debug/Feed.php:63
+#: src/Module/Debug/Feed.php:72
 msgid "Source URL"
 msgstr ""
 
@@ -7953,23 +7953,23 @@ msgstr ""
 msgid "Item was not deleted"
 msgstr ""
 
-#: src/Module/Filer/SaveTag.php:68
+#: src/Module/Filer/SaveTag.php:75
 msgid "- select -"
 msgstr ""
 
-#: src/Module/FriendSuggest.php:65
+#: src/Module/FriendSuggest.php:82
 msgid "Suggested contact not found."
 msgstr ""
 
-#: src/Module/FriendSuggest.php:83
+#: src/Module/FriendSuggest.php:100
 msgid "Friend suggestion sent."
 msgstr ""
 
-#: src/Module/FriendSuggest.php:120
+#: src/Module/FriendSuggest.php:137
 msgid "Suggest Friends"
 msgstr ""
 
-#: src/Module/FriendSuggest.php:123
+#: src/Module/FriendSuggest.php:140
 #, php-format
 msgid "Suggest a friend for %s"
 msgstr ""
@@ -8109,7 +8109,7 @@ msgstr ""
 msgid "Method Not Allowed."
 msgstr ""
 
-#: src/Module/Help.php:61
+#: src/Module/Help.php:60
 msgid "Help:"
 msgstr ""
 
@@ -8118,155 +8118,155 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: src/Module/Install.php:187
+#: src/Module/Install.php:196
 msgid "Friendica Communications Server - Setup"
 msgstr ""
 
-#: src/Module/Install.php:198
+#: src/Module/Install.php:207
 msgid "System check"
 msgstr ""
 
-#: src/Module/Install.php:200 src/Module/Install.php:257
-#: src/Module/Install.php:340
+#: src/Module/Install.php:209 src/Module/Install.php:266
+#: src/Module/Install.php:349
 msgid "Requirement not satisfied"
 msgstr ""
 
-#: src/Module/Install.php:201
+#: src/Module/Install.php:210
 msgid "Optional requirement not satisfied"
 msgstr ""
 
-#: src/Module/Install.php:202
+#: src/Module/Install.php:211
 msgid "OK"
 msgstr ""
 
-#: src/Module/Install.php:207
+#: src/Module/Install.php:216
 msgid "Check again"
 msgstr ""
 
-#: src/Module/Install.php:222
+#: src/Module/Install.php:231
 msgid "Base settings"
 msgstr ""
 
-#: src/Module/Install.php:229
+#: src/Module/Install.php:238
 msgid "Host name"
 msgstr ""
 
-#: src/Module/Install.php:231
+#: src/Module/Install.php:240
 msgid ""
 "Overwrite this field in case the determinated hostname isn't right, "
 "otherweise leave it as is."
 msgstr ""
 
-#: src/Module/Install.php:234
+#: src/Module/Install.php:243
 msgid "Base path to installation"
 msgstr ""
 
-#: src/Module/Install.php:236
+#: src/Module/Install.php:245
 msgid ""
 "If the system cannot detect the correct path to your installation, enter the "
 "correct path here. This setting should only be set if you are using a "
 "restricted system and symbolic links to your webroot."
 msgstr ""
 
-#: src/Module/Install.php:239
+#: src/Module/Install.php:248
 msgid "Sub path of the URL"
 msgstr ""
 
-#: src/Module/Install.php:241
+#: src/Module/Install.php:250
 msgid ""
 "Overwrite this field in case the sub path determination isn't right, "
 "otherwise leave it as is. Leaving this field blank means the installation is "
 "at the base URL without sub path."
 msgstr ""
 
-#: src/Module/Install.php:252
+#: src/Module/Install.php:261
 msgid "Database connection"
 msgstr ""
 
-#: src/Module/Install.php:253
+#: src/Module/Install.php:262
 msgid ""
 "In order to install Friendica we need to know how to connect to your "
 "database."
 msgstr ""
 
-#: src/Module/Install.php:254
+#: src/Module/Install.php:263
 msgid ""
 "Please contact your hosting provider or site administrator if you have "
 "questions about these settings."
 msgstr ""
 
-#: src/Module/Install.php:255
+#: src/Module/Install.php:264
 msgid ""
 "The database you specify below should already exist. If it does not, please "
 "create it before continuing."
 msgstr ""
 
-#: src/Module/Install.php:264
+#: src/Module/Install.php:273
 msgid "Database Server Name"
 msgstr ""
 
-#: src/Module/Install.php:269
+#: src/Module/Install.php:278
 msgid "Database Login Name"
 msgstr ""
 
-#: src/Module/Install.php:275
+#: src/Module/Install.php:284
 msgid "Database Login Password"
 msgstr ""
 
-#: src/Module/Install.php:277
+#: src/Module/Install.php:286
 msgid "For security reasons the password must not be empty"
 msgstr ""
 
-#: src/Module/Install.php:280
+#: src/Module/Install.php:289
 msgid "Database Name"
 msgstr ""
 
-#: src/Module/Install.php:284 src/Module/Install.php:314
+#: src/Module/Install.php:293 src/Module/Install.php:323
 msgid "Please select a default timezone for your website"
 msgstr ""
 
-#: src/Module/Install.php:299
+#: src/Module/Install.php:308
 msgid "Site settings"
 msgstr ""
 
-#: src/Module/Install.php:309
+#: src/Module/Install.php:318
 msgid "Site administrator email address"
 msgstr ""
 
-#: src/Module/Install.php:311
+#: src/Module/Install.php:320
 msgid ""
 "Your account email address must match this in order to use the web admin "
 "panel."
 msgstr ""
 
-#: src/Module/Install.php:318
+#: src/Module/Install.php:327
 msgid "System Language:"
 msgstr ""
 
-#: src/Module/Install.php:320
+#: src/Module/Install.php:329
 msgid ""
 "Set the default language for your Friendica installation interface and to "
 "send emails."
 msgstr ""
 
-#: src/Module/Install.php:332
+#: src/Module/Install.php:341
 msgid "Your Friendica site database has been installed."
 msgstr ""
 
-#: src/Module/Install.php:342
+#: src/Module/Install.php:351
 msgid "Installation finished"
 msgstr ""
 
-#: src/Module/Install.php:362
+#: src/Module/Install.php:371
 msgid "<h1>What next</h1>"
 msgstr ""
 
-#: src/Module/Install.php:363
+#: src/Module/Install.php:372
 msgid ""
 "IMPORTANT: You will need to [manually] setup a scheduled task for the worker."
 msgstr ""
 
-#: src/Module/Install.php:366
+#: src/Module/Install.php:375
 #, php-format
 msgid ""
 "Go to your new Friendica node <a href=\"%s/register\">registration page</a> "
@@ -8431,64 +8431,64 @@ msgstr ""
 msgid "A Decentralized Social Network"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:77
+#: src/Module/Notifications/Introductions.php:93
 msgid "Show Ignored Requests"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:77
+#: src/Module/Notifications/Introductions.php:93
 msgid "Hide Ignored Requests"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:93
-#: src/Module/Notifications/Introductions.php:156
+#: src/Module/Notifications/Introductions.php:109
+#: src/Module/Notifications/Introductions.php:172
 msgid "Notification type:"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:96
+#: src/Module/Notifications/Introductions.php:112
 msgid "Suggested by:"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:121
+#: src/Module/Notifications/Introductions.php:137
 msgid "Claims to be known to you: "
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:122
-#: src/Module/OAuth/Acknowledge.php:48 src/Module/Register.php:118
+#: src/Module/Notifications/Introductions.php:138
+#: src/Module/OAuth/Acknowledge.php:48 src/Module/Register.php:127
 msgid "No"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:130
+#: src/Module/Notifications/Introductions.php:146
 msgid "Shall your connection be bidirectional or not?"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:131
+#: src/Module/Notifications/Introductions.php:147
 #, php-format
 msgid ""
 "Accepting %s as a friend allows %s to subscribe to your posts, and you will "
 "also receive updates from them in your news feed."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:132
+#: src/Module/Notifications/Introductions.php:148
 #, php-format
 msgid ""
 "Accepting %s as a subscriber allows them to subscribe to your posts, but you "
 "will not receive updates from them in your news feed."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:134
+#: src/Module/Notifications/Introductions.php:150
 msgid "Friend"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:135
+#: src/Module/Notifications/Introductions.php:151
 msgid "Subscriber"
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:194
+#: src/Module/Notifications/Introductions.php:210
 msgid "No introductions."
 msgstr ""
 
-#: src/Module/Notifications/Introductions.php:195
-#: src/Module/Notifications/Notifications.php:121
+#: src/Module/Notifications/Introductions.php:211
+#: src/Module/Notifications/Notifications.php:135
 #, php-format
 msgid "No more %s notifications."
 msgstr ""
@@ -8497,23 +8497,23 @@ msgstr ""
 msgid "You must be logged in to show this page."
 msgstr ""
 
-#: src/Module/Notifications/Notifications.php:52
+#: src/Module/Notifications/Notifications.php:66
 msgid "Network Notifications"
 msgstr ""
 
-#: src/Module/Notifications/Notifications.php:58
+#: src/Module/Notifications/Notifications.php:72
 msgid "System Notifications"
 msgstr ""
 
-#: src/Module/Notifications/Notifications.php:64
+#: src/Module/Notifications/Notifications.php:78
 msgid "Personal Notifications"
 msgstr ""
 
-#: src/Module/Notifications/Notifications.php:70
+#: src/Module/Notifications/Notifications.php:84
 msgid "Home Notifications"
 msgstr ""
 
-#: src/Module/Notifications/Notifications.php:126
+#: src/Module/Notifications/Notifications.php:140
 msgid "Show unread"
 msgstr ""
 
@@ -8527,15 +8527,15 @@ msgid ""
 "and/or create new posts for you?"
 msgstr ""
 
-#: src/Module/OAuth/Authorize.php:55
+#: src/Module/OAuth/Authorize.php:54
 msgid "Unsupported or missing response type"
 msgstr ""
 
-#: src/Module/OAuth/Authorize.php:60 src/Module/OAuth/Token.php:65
+#: src/Module/OAuth/Authorize.php:59 src/Module/OAuth/Token.php:65
 msgid "Incomplete request data"
 msgstr ""
 
-#: src/Module/OAuth/Authorize.php:107
+#: src/Module/OAuth/Authorize.php:106
 #, php-format
 msgid ""
 "Please copy the following authentication code into your application and "
@@ -8669,163 +8669,163 @@ msgstr ""
 msgid "Remove post"
 msgstr ""
 
-#: src/Module/Register.php:71
+#: src/Module/Register.php:80
 msgid "Only parent users can create additional accounts."
 msgstr ""
 
-#: src/Module/Register.php:103
+#: src/Module/Register.php:112
 msgid ""
 "You may (optionally) fill in this form via OpenID by supplying your OpenID "
 "and clicking \"Register\"."
 msgstr ""
 
-#: src/Module/Register.php:104
+#: src/Module/Register.php:113
 msgid ""
 "If you are not familiar with OpenID, please leave that field blank and fill "
 "in the rest of the items."
 msgstr ""
 
-#: src/Module/Register.php:105
+#: src/Module/Register.php:114
 msgid "Your OpenID (optional): "
 msgstr ""
 
-#: src/Module/Register.php:114
+#: src/Module/Register.php:123
 msgid "Include your profile in member directory?"
 msgstr ""
 
-#: src/Module/Register.php:137
+#: src/Module/Register.php:144
 msgid "Note for the admin"
 msgstr ""
 
-#: src/Module/Register.php:137
+#: src/Module/Register.php:144
 msgid "Leave a message for the admin, why you want to join this node"
 msgstr ""
 
-#: src/Module/Register.php:138
+#: src/Module/Register.php:145
 msgid "Membership on this site is by invitation only."
 msgstr ""
 
-#: src/Module/Register.php:139
+#: src/Module/Register.php:146
 msgid "Your invitation code: "
 msgstr ""
 
-#: src/Module/Register.php:147
+#: src/Module/Register.php:154
 msgid "Your Full Name (e.g. Joe Smith, real or real-looking): "
 msgstr ""
 
-#: src/Module/Register.php:148
+#: src/Module/Register.php:155
 msgid ""
 "Your Email Address: (Initial information will be send there, so this has to "
 "be an existing address.)"
 msgstr ""
 
-#: src/Module/Register.php:149
+#: src/Module/Register.php:156
 msgid "Please repeat your e-mail address:"
 msgstr ""
 
-#: src/Module/Register.php:151
+#: src/Module/Register.php:158
 msgid "Leave empty for an auto generated password."
 msgstr ""
 
-#: src/Module/Register.php:153
+#: src/Module/Register.php:160
 #, php-format
 msgid ""
 "Choose a profile nickname. This must begin with a text character. Your "
 "profile address on this site will then be \"<strong>nickname@%s</strong>\"."
 msgstr ""
 
-#: src/Module/Register.php:154
+#: src/Module/Register.php:161
 msgid "Choose a nickname: "
 msgstr ""
 
-#: src/Module/Register.php:163
+#: src/Module/Register.php:170
 msgid "Import your profile to this friendica instance"
 msgstr ""
 
-#: src/Module/Register.php:170
+#: src/Module/Register.php:177
 msgid "Note: This node explicitly contains adult content"
 msgstr ""
 
-#: src/Module/Register.php:172 src/Module/Settings/Delegation.php:155
+#: src/Module/Register.php:179 src/Module/Settings/Delegation.php:155
 msgid "Parent Password:"
 msgstr ""
 
-#: src/Module/Register.php:172 src/Module/Settings/Delegation.php:155
+#: src/Module/Register.php:179 src/Module/Settings/Delegation.php:155
 msgid ""
 "Please enter the password of the parent account to legitimize your request."
 msgstr ""
 
-#: src/Module/Register.php:201
+#: src/Module/Register.php:208
 msgid "Password doesn't match."
 msgstr ""
 
-#: src/Module/Register.php:207
+#: src/Module/Register.php:214
 msgid "Please enter your password."
 msgstr ""
 
-#: src/Module/Register.php:249
+#: src/Module/Register.php:256
 msgid "You have entered too much information."
 msgstr ""
 
-#: src/Module/Register.php:272
+#: src/Module/Register.php:279
 msgid "Please enter the identical mail address in the second field."
 msgstr ""
 
-#: src/Module/Register.php:299
+#: src/Module/Register.php:306
 msgid "The additional account was created."
 msgstr ""
 
-#: src/Module/Register.php:324
+#: src/Module/Register.php:331
 msgid ""
 "Registration successful. Please check your email for further instructions."
 msgstr ""
 
-#: src/Module/Register.php:328
+#: src/Module/Register.php:335
 #, php-format
 msgid ""
 "Failed to send email message. Here your accout details:<br> login: %s<br> "
 "password: %s<br><br>You can change your password after login."
 msgstr ""
 
-#: src/Module/Register.php:334
+#: src/Module/Register.php:341
 msgid "Registration successful."
 msgstr ""
 
-#: src/Module/Register.php:339 src/Module/Register.php:346
+#: src/Module/Register.php:346 src/Module/Register.php:353
 msgid "Your registration can not be processed."
 msgstr ""
 
-#: src/Module/Register.php:345
+#: src/Module/Register.php:352
 msgid "You have to leave a request note for the admin."
 msgstr ""
 
-#: src/Module/Register.php:391
+#: src/Module/Register.php:398
 msgid "Your registration is pending approval by the site owner."
 msgstr ""
 
-#: src/Module/RemoteFollow.php:62
+#: src/Module/RemoteFollow.php:72
 msgid "Profile unavailable."
 msgstr ""
 
-#: src/Module/RemoteFollow.php:68
+#: src/Module/RemoteFollow.php:78
 msgid "Invalid locator"
 msgstr ""
 
-#: src/Module/RemoteFollow.php:75
+#: src/Module/RemoteFollow.php:85
 msgid "The provided profile link doesn't seem to be valid"
 msgstr ""
 
-#: src/Module/RemoteFollow.php:80
+#: src/Module/RemoteFollow.php:90
 msgid ""
 "Remote subscription can't be done for your network. Please subscribe "
 "directly on your system."
 msgstr ""
 
-#: src/Module/RemoteFollow.php:110
+#: src/Module/RemoteFollow.php:122
 msgid "Friend/Connection Request"
 msgstr ""
 
-#: src/Module/RemoteFollow.php:111
+#: src/Module/RemoteFollow.php:123
 #, php-format
 msgid ""
 "Enter your Webfinger address (user@domain.tld) or profile URL here. If this "
@@ -8833,14 +8833,14 @@ msgid ""
 "or <strong>%s</strong> directly on your system."
 msgstr ""
 
-#: src/Module/RemoteFollow.php:112
+#: src/Module/RemoteFollow.php:124
 #, php-format
 msgid ""
 "If you are not yet a member of the free social web, <a href=\"%s\">follow "
 "this link to find a public Friendica node and join us today</a>."
 msgstr ""
 
-#: src/Module/RemoteFollow.php:113
+#: src/Module/RemoteFollow.php:125
 msgid "Your Webfinger address or profile URL:"
 msgstr ""
 
@@ -8857,15 +8857,15 @@ msgstr ""
 msgid "Items tagged with: %s"
 msgstr ""
 
-#: src/Module/Search/Saved.php:44
+#: src/Module/Search/Saved.php:62
 msgid "Search term was not saved."
 msgstr ""
 
-#: src/Module/Search/Saved.php:47
+#: src/Module/Search/Saved.php:65
 msgid "Search term already saved."
 msgstr ""
 
-#: src/Module/Search/Saved.php:53
+#: src/Module/Search/Saved.php:71
 msgid "Search term was not removed."
 msgstr ""
 
@@ -8915,7 +8915,7 @@ msgstr ""
 msgid "privacy policy"
 msgstr ""
 
-#: src/Module/Security/Logout.php:61
+#: src/Module/Security/Logout.php:87
 msgid "Logged out."
 msgstr ""
 
@@ -8935,39 +8935,39 @@ msgid ""
 "account to add the OpenID to it."
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:61
+#: src/Module/Security/TwoFactor/Recovery.php:73
 #, php-format
 msgid "Remaining recovery codes: %d"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:65
+#: src/Module/Security/TwoFactor/Recovery.php:77
 #: src/Module/Security/TwoFactor/Verify.php:76
-#: src/Module/Settings/TwoFactor/Verify.php:82
+#: src/Module/Settings/TwoFactor/Verify.php:94
 msgid "Invalid code, please retry."
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:84
+#: src/Module/Security/TwoFactor/Recovery.php:96
 msgid "Two-factor recovery"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:85
+#: src/Module/Security/TwoFactor/Recovery.php:97
 msgid ""
 "<p>You can enter one of your one-time recovery codes in case you lost access "
 "to your mobile device.</p>"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:86
+#: src/Module/Security/TwoFactor/Recovery.php:98
 #: src/Module/Security/TwoFactor/Verify.php:99
 #, php-format
 msgid ""
 "Don’t have your phone? <a href=\"%s\">Enter a two-factor recovery code</a>"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:87
+#: src/Module/Security/TwoFactor/Recovery.php:99
 msgid "Please enter a recovery code"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Recovery.php:88
+#: src/Module/Security/TwoFactor/Recovery.php:100
 msgid "Submit recovery code and complete login"
 msgstr ""
 
@@ -8978,7 +8978,7 @@ msgid ""
 msgstr ""
 
 #: src/Module/Security/TwoFactor/Verify.php:100
-#: src/Module/Settings/TwoFactor/Verify.php:141
+#: src/Module/Settings/TwoFactor/Verify.php:153
 msgid "Please enter a code from your authentication app"
 msgstr ""
 
@@ -9401,82 +9401,82 @@ msgstr ""
 msgid "select a photo from your photo albums"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:52
-#: src/Module/Settings/TwoFactor/Recovery.php:50
-#: src/Module/Settings/TwoFactor/Trusted.php:30
-#: src/Module/Settings/TwoFactor/Verify.php:56
+#: src/Module/Settings/TwoFactor/AppSpecific.php:64
+#: src/Module/Settings/TwoFactor/Recovery.php:62
+#: src/Module/Settings/TwoFactor/Trusted.php:45
+#: src/Module/Settings/TwoFactor/Verify.php:68
 msgid "Please enter your password to access this page."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:70
+#: src/Module/Settings/TwoFactor/AppSpecific.php:82
 msgid "App-specific password generation failed: The description is empty."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:73
+#: src/Module/Settings/TwoFactor/AppSpecific.php:85
 msgid ""
 "App-specific password generation failed: This description already exists."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:77
+#: src/Module/Settings/TwoFactor/AppSpecific.php:89
 msgid "New app-specific password generated."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:83
+#: src/Module/Settings/TwoFactor/AppSpecific.php:95
 msgid "App-specific passwords successfully revoked."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:93
+#: src/Module/Settings/TwoFactor/AppSpecific.php:105
 msgid "App-specific password successfully revoked."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:114
+#: src/Module/Settings/TwoFactor/AppSpecific.php:126
 msgid "Two-factor app-specific passwords"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:116
+#: src/Module/Settings/TwoFactor/AppSpecific.php:128
 msgid ""
 "<p>App-specific passwords are randomly generated passwords used instead your "
 "regular password to authenticate your account on third-party applications "
 "that don't support two-factor authentication.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:117
+#: src/Module/Settings/TwoFactor/AppSpecific.php:129
 msgid ""
 "Make sure to copy your new app-specific password now. You won’t be able to "
 "see it again!"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:120
+#: src/Module/Settings/TwoFactor/AppSpecific.php:132
 msgid "Description"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:121
+#: src/Module/Settings/TwoFactor/AppSpecific.php:133
 msgid "Last Used"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:122
+#: src/Module/Settings/TwoFactor/AppSpecific.php:134
 msgid "Revoke"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:123
+#: src/Module/Settings/TwoFactor/AppSpecific.php:135
 msgid "Revoke All"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:126
+#: src/Module/Settings/TwoFactor/AppSpecific.php:138
 msgid ""
 "When you generate a new app-specific password, you must use it right away, "
 "it will be shown to you once after you generate it."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:127
+#: src/Module/Settings/TwoFactor/AppSpecific.php:139
 msgid "Generate new app-specific password"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:128
+#: src/Module/Settings/TwoFactor/AppSpecific.php:140
 msgid "Friendiqa on my Fairphone 2..."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:129
+#: src/Module/Settings/TwoFactor/AppSpecific.php:141
 msgid "Generate"
 msgstr ""
 
@@ -9576,15 +9576,15 @@ msgstr ""
 msgid "Finish app configuration"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:66
+#: src/Module/Settings/TwoFactor/Recovery.php:78
 msgid "New recovery codes successfully generated."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:92
+#: src/Module/Settings/TwoFactor/Recovery.php:104
 msgid "Two-factor recovery codes"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:94
+#: src/Module/Settings/TwoFactor/Recovery.php:106
 msgid ""
 "<p>Recovery codes can be used to access your account in the event you lose "
 "access to your device and cannot receive two-factor authentication codes.</"
@@ -9592,64 +9592,64 @@ msgid ""
 "don’t have the recovery codes you will lose access to your account.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:96
+#: src/Module/Settings/TwoFactor/Recovery.php:108
 msgid ""
 "When you generate new recovery codes, you must copy the new codes. Your old "
 "codes won’t work anymore."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:97
+#: src/Module/Settings/TwoFactor/Recovery.php:109
 msgid "Generate new recovery codes"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:99
+#: src/Module/Settings/TwoFactor/Recovery.php:111
 msgid "Next: Verification"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:49
+#: src/Module/Settings/TwoFactor/Trusted.php:62
 msgid "Trusted browsers successfully removed."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:59
+#: src/Module/Settings/TwoFactor/Trusted.php:72
 msgid "Trusted browser successfully removed."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:97
+#: src/Module/Settings/TwoFactor/Trusted.php:109
 msgid "Two-factor Trusted Browsers"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:98
+#: src/Module/Settings/TwoFactor/Trusted.php:110
 msgid ""
 "Trusted browsers are individual browsers you chose to skip two-factor "
 "authentication to access Friendica. Please use this feature sparingly, as it "
 "can negate the benefit of two-factor authentication."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:99
+#: src/Module/Settings/TwoFactor/Trusted.php:111
 msgid "Device"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:100
+#: src/Module/Settings/TwoFactor/Trusted.php:112
 msgid "OS"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:102
+#: src/Module/Settings/TwoFactor/Trusted.php:114
 msgid "Trusted"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:103
+#: src/Module/Settings/TwoFactor/Trusted.php:115
 msgid "Last Use"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:105
+#: src/Module/Settings/TwoFactor/Trusted.php:117
 msgid "Remove All"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:78
+#: src/Module/Settings/TwoFactor/Verify.php:90
 msgid "Two-factor authentication successfully activated."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:111
+#: src/Module/Settings/TwoFactor/Verify.php:123
 #, php-format
 msgid ""
 "<p>Or you can submit the authentication settings manually:</p>\n"
@@ -9669,53 +9669,53 @@ msgid ""
 "</dl>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:131
+#: src/Module/Settings/TwoFactor/Verify.php:143
 msgid "Two-factor code verification"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:133
+#: src/Module/Settings/TwoFactor/Verify.php:145
 msgid ""
 "<p>Please scan this QR Code with your authenticator app and submit the "
 "provided code.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:135
+#: src/Module/Settings/TwoFactor/Verify.php:147
 #, php-format
 msgid ""
 "<p>Or you can open the following URL in your mobile device:</p><p><a href="
 "\"%s\">%s</a></p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:142
+#: src/Module/Settings/TwoFactor/Verify.php:154
 msgid "Verify code and enable two-factor authentication"
 msgstr ""
 
-#: src/Module/Settings/UserExport.php:68
+#: src/Module/Settings/UserExport.php:67
 msgid "Export account"
 msgstr ""
 
-#: src/Module/Settings/UserExport.php:68
+#: src/Module/Settings/UserExport.php:67
 msgid ""
 "Export your account info and contacts. Use this to make a backup of your "
 "account and/or to move it to another server."
 msgstr ""
 
-#: src/Module/Settings/UserExport.php:69
+#: src/Module/Settings/UserExport.php:68
 msgid "Export all"
 msgstr ""
 
-#: src/Module/Settings/UserExport.php:69
+#: src/Module/Settings/UserExport.php:68
 msgid ""
 "Export your account info, contacts and all your items as json. Could be a "
 "very big file, and could take a lot of time. Use this to make a full backup "
 "of your account (photos are not exported)"
 msgstr ""
 
-#: src/Module/Settings/UserExport.php:70
+#: src/Module/Settings/UserExport.php:69
 msgid "Export Contacts to CSV"
 msgstr ""
 
-#: src/Module/Settings/UserExport.php:70
+#: src/Module/Settings/UserExport.php:69
 msgid ""
 "Export the list of the accounts you are following as CSV file. Compatible to "
 "e.g. Mastodon."
@@ -9730,7 +9730,7 @@ msgstr ""
 msgid "Exception thrown in %s:%d"
 msgstr ""
 
-#: src/Module/Tos.php:46 src/Module/Tos.php:88
+#: src/Module/Tos.php:58 src/Module/Tos.php:92
 msgid ""
 "At the time of registration, and for providing communications between the "
 "user account and their contacts, the user has to provide a display name (pen "
@@ -9743,14 +9743,14 @@ msgid ""
 "settings, it is not necessary for communication."
 msgstr ""
 
-#: src/Module/Tos.php:47 src/Module/Tos.php:89
+#: src/Module/Tos.php:59 src/Module/Tos.php:93
 msgid ""
 "This data is required for communication and is passed on to the nodes of the "
 "communication partners and is stored there. Users can enter additional "
 "private data that may be transmitted to the communication partners accounts."
 msgstr ""
 
-#: src/Module/Tos.php:48 src/Module/Tos.php:90
+#: src/Module/Tos.php:60 src/Module/Tos.php:94
 #, php-format
 msgid ""
 "At any point in time a logged in user can export their account data from the "
@@ -9760,7 +9760,7 @@ msgid ""
 "data will also be requested from the nodes of the communication partners."
 msgstr ""
 
-#: src/Module/Tos.php:51 src/Module/Tos.php:87
+#: src/Module/Tos.php:63 src/Module/Tos.php:91
 msgid "Privacy Statement"
 msgstr ""
 


### PR DESCRIPTION
FollowUp #10977 
Addresses feedback https://github.com/friendica/friendica/pull/10977#discussion_r748934818

All `Module::init()` methods are now replaced with the `__constructor()` method and directly uses now Dependency Injection per constructor. So no `DI::` calls are now necessary inside the Module classes anymore.