### PR TITLE
re-add gnusocial to FAQ Client API info

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -171,7 +171,7 @@ Example: Friendica Support
 <a name="clients"></a>
 ### What friendica clients can I use?
 
-Friendica supports [Mastodon API](help/API-Mastodon) and [Twitter API](help/api). This means you can use some of the Mastodon and Twitter clients for Friendica. The available features are client specific and may differ.
+Friendica supports [Mastodon API](help/API-Mastodon) and [Twitter API | gnusocial](help/api). This means you can use some of the Mastodon and Twitter clients for Friendica. The available features are client specific and may differ.
 
 #### Android
 

--- a/doc/de/FAQ.md
+++ b/doc/de/FAQ.md
@@ -203,7 +203,7 @@ Friendica unterstützt [Mastodon API](help/API-Mastodon) und [Twitter API | gnus
 #### SailfishOS
 
 * [Friendly](https://openrepos.net/content/fabrixxm/friendly#comment-form)
-~
+
 #### iOS
 
 * [B4X for Pleroma & Mastodon](https://www.b4x.com/) ([AppStore](https://apps.apple.com/app/b4x-pleroma/id1538396871), [GitHub](https://github.com/AnywhereSoftware/B4X-Pleroma))

--- a/doc/de/FAQ.md
+++ b/doc/de/FAQ.md
@@ -180,7 +180,7 @@ Beispiel: Friendica Support
 <a name="clients">
 ### Gibt es Clients für Friendica?
 
-Friendica unterstützt [Mastodon API](help/API-Mastodon) und [Twitter API](help/api). Das bedeutet, du kannst einge der Mastodon und Twitter Clients für Friendica verwenden. Die verfügbaren Features sind Abhängig vom Client, so dass diese teils unterschiedlich sein können.
+Friendica unterstützt [Mastodon API](help/API-Mastodon) und [Twitter API | gnusocial](help/api). Das bedeutet, du kannst einge der Mastodon und Twitter Clients für Friendica verwenden. Die verfügbaren Features sind Abhängig vom Client, so dass diese teils unterschiedlich sein können.
 
 #### Android
 
@@ -203,7 +203,7 @@ Friendica unterstützt [Mastodon API](help/API-Mastodon) und [Twitter API](help/
 #### SailfishOS
 
 * [Friendly](https://openrepos.net/content/fabrixxm/friendly#comment-form)
-
+~
 #### iOS
 
 * [B4X for Pleroma & Mastodon](https://www.b4x.com/) ([AppStore](https://apps.apple.com/app/b4x-pleroma/id1538396871), [GitHub](https://github.com/AnywhereSoftware/B4X-Pleroma))


### PR DESCRIPTION
They are not dead and their repo can be reached again. Their website does not show any version, releases or blog info and yesterday both install and repo link went to internal server error.