### PR TITLE
[frio] Make accordions keyboard actionable

### DIFF
--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -298,6 +298,62 @@ $data = [
 Called when the Addon Settings pages are submitted.
 `$b` is the $_POST array.
 
+### connector_settings
+Called when generating the HTML for a connector addon settings page.
+`$data` is an array containing:
+
+- **connector** (output): Required. The addon folder name.
+- **title** (output): Required. The addon settings panel title.
+- **image** (output): Required. The relative path of the logo image of the platform/protocol this addon is connecting to, max size 48x48px.
+- **enabled** (output): Optional. If set to a falsy value, the connector image will be dimmed.
+- **html** (output): Optional. Raw HTML of the addon form elements. Both the `<form>` tags and the submit buttons are taken care of elsewhere.
+- **submit** (output): Optional. If unset, a default submit button with `name="<addon name>-submit"` will be generated.
+  Can take different value types:
+    - **string**: The label to replace the default one.
+      - **associative array**: A list of submit button, the key is the value of the `name` attribute, the value is the displayed label.
+        The first submit button in this list is considered the main one and themes might emphasize its display.
+
+#### Examples
+
+##### With default submit button
+```php
+$data = [
+	'connector' => 'diaspora',
+	'title'     => DI::l10n()->t('Diaspora Export'),
+	'image'     => 'images/diaspora-logo.png',
+	'enabled'   => $enabled,
+	'html'      => $html,
+];
+```
+
+##### With custom submit button label and no logo dim
+```php
+$data = [
+	'connector' => 'ifttt',
+	'title'     => DI::l10n()->t('IFTTT Mirror'),
+	'image'     => 'addon/ifttt/ifttt.png',
+	'html'      => $html,
+	'submit'    => DI::l10n()->t('Generate new key'),
+];
+```
+
+##### With conditional submit buttons
+```php
+$submit = ['pumpio-submit' => DI::l10n()->t('Save Settings')];
+if ($oauth_token && $oauth_token_secret) {
+	$submit['pumpio-delete'] = DI::l10n()->t('Delete this preset');
+}
+
+$data = [
+	'connector' => 'pumpio',
+	'title'     => DI::l10n()->t('Pump.io Import/Export/Mirror'),
+	'image'     => 'images/pumpio.png',
+	'enabled'   => $enabled,
+	'html'      => $html,
+	'submit'    => $submit,
+];
+```
+
 ### profile_post
 Called when posting a profile page.
 `$b` is the $_POST array.

--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -242,7 +242,57 @@ Called when the Settings pages are submitted.
 
 ### addon_settings
 Called when generating the HTML for the addon settings page.
-`$b` is the (string) HTML of the addon settings page before the final `</form>` tag.
+`$data` is an array containing:
+
+- **addon** (output): Required. The addon folder name.
+- **title** (output): Required. The addon settings panel title.
+- **href** (output): Optional. If set, will reduce the panel to a link pointing to this URL, can be relative. Incompatible with the following keys.
+- **html** (output): Optional. Raw HTML of the addon form elements. Both the `<form>` tags and the submit buttons are taken care of elsewhere.
+- **submit** (output): Optional. If unset, a default submit button with `name="<addon name>-submit"` will be generated.
+  Can take different value types:
+  - **string**: The label to replace the default one.
+  - **associative array**: A list of submit button, the key is the value of the `name` attribute, the value is the displayed label.
+    The first submit button in this list is considered the main one and themes might emphasize its display.
+
+#### Examples
+
+##### With link
+```php
+$data = [
+	'addon' => 'advancedcontentfilter',
+	'title' => DI::l10n()->t('Advanced Content Filter'),
+	'href'  => 'advancedcontentfilter',
+];
+```
+##### With default submit button
+```php
+$data = [
+	'addon' => 'fromapp',
+	'title' => DI::l10n()->t('FromApp Settings'),
+	'html'  => $html,
+];
+```
+##### With no HTML, just a submit button
+```php
+$data = [
+	'addon'  => 'opmlexport',
+	'title'  => DI::l10n()->t('OPML Export'),
+	'submit' => DI::l10n()->t('Export RSS/Atom contacts'),
+];
+```
+##### With multiple submit buttons
+```php
+$data = [
+	'addon'  => 'catavar',
+	'title'  => DI::l10n()->t('Cat Avatar Settings'),
+	'html'   => $html,
+	'submit' => [
+		'catavatar-usecat'   => DI::l10n()->t('Use Cat as Avatar'),
+		'catavatar-morecat'  => DI::l10n()->t('Another random Cat!'),
+		'catavatar-emailcat' => DI::pConfig()->get(local_user(), 'catavatar', 'seed', false) ? DI::l10n()->t('Reset to email Cat') : null,
+	],
+];
+```
 
 ### addon_settings_post
 Called when the Addon Settings pages are submitted.

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2021.12-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-28 12:50+0100\n"
+"POT-Creation-Date: 2021-11-29 06:06-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,21 +18,21 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 
-#: include/api.php:720 src/Module/BaseApi.php:279
+#: include/api.php:720 src/Module/BaseApi.php:281
 #, php-format
 msgid "Daily posting limit of %d post reached. The post was rejected."
 msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/api.php:734 src/Module/BaseApi.php:295
+#: include/api.php:734 src/Module/BaseApi.php:297
 #, php-format
 msgid "Weekly posting limit of %d post reached. The post was rejected."
 msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: include/api.php:748 src/Module/BaseApi.php:311
+#: include/api.php:748 src/Module/BaseApi.php:313
 #, php-format
 msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgstr ""
@@ -140,14 +140,14 @@ msgstr ""
 #: mod/item.php:185 mod/item.php:190 mod/item.php:937 mod/message.php:69
 #: mod/message.php:111 mod/notes.php:44 mod/ostatus_subscribe.php:32
 #: mod/photos.php:160 mod/photos.php:897 mod/repair_ostatus.php:31
-#: mod/settings.php:46 mod/settings.php:56 mod/settings.php:410
+#: mod/settings.php:46 mod/settings.php:56 mod/settings.php:412
 #: mod/suggest.php:34 mod/uimport.php:33 mod/unfollow.php:35
 #: mod/unfollow.php:50 mod/unfollow.php:82 mod/wall_attach.php:68
 #: mod/wall_attach.php:71 mod/wall_upload.php:90 mod/wall_upload.php:93
 #: mod/wallmessage.php:36 mod/wallmessage.php:55 mod/wallmessage.php:89
-#: mod/wallmessage.php:109 src/Module/Attach.php:55 src/Module/BaseApi.php:77
-#: src/Module/BaseApi.php:86 src/Module/BaseApi.php:95
-#: src/Module/BaseApi.php:104 src/Module/BaseNotifications.php:97
+#: mod/wallmessage.php:109 src/Module/Attach.php:55 src/Module/BaseApi.php:79
+#: src/Module/BaseApi.php:88 src/Module/BaseApi.php:97
+#: src/Module/BaseApi.php:106 src/Module/BaseNotifications.php:97
 #: src/Module/Contact/Advanced.php:60 src/Module/Delegation.php:118
 #: src/Module/FollowConfirm.php:18 src/Module/FriendSuggest.php:56
 #: src/Module/Group.php:42 src/Module/Group.php:85 src/Module/Invite.php:41
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: mod/photos.php:1431 mod/settings.php:564 src/Content/Conversation.php:616
+#: mod/photos.php:1431 mod/settings.php:596 src/Content/Conversation.php:616
 #: src/Module/Admin/Users/Active.php:139 src/Module/Admin/Users/Blocked.php:140
 #: src/Module/Admin/Users/Index.php:153
 msgid "Delete"
@@ -1203,75 +1203,75 @@ msgid_plural "Errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/settings.php:127
+#: mod/settings.php:128
 msgid "Failed to connect with email account using the settings provided."
 msgstr ""
 
-#: mod/settings.php:156
+#: mod/settings.php:158
 msgid "Contact CSV file upload error"
 msgstr ""
 
-#: mod/settings.php:175
+#: mod/settings.php:177
 msgid "Importing Contacts done"
 msgstr ""
 
-#: mod/settings.php:188
+#: mod/settings.php:190
 msgid "Relocate message has been send to your contacts"
 msgstr ""
 
-#: mod/settings.php:200
+#: mod/settings.php:202
 msgid "Passwords do not match."
 msgstr ""
 
-#: mod/settings.php:208 src/Console/User.php:210
+#: mod/settings.php:210 src/Console/User.php:210
 msgid "Password update failed. Please try again."
 msgstr ""
 
-#: mod/settings.php:211 src/Console/User.php:213
+#: mod/settings.php:213 src/Console/User.php:213
 msgid "Password changed."
 msgstr ""
 
-#: mod/settings.php:214
+#: mod/settings.php:216
 msgid "Password unchanged."
 msgstr ""
 
-#: mod/settings.php:302
+#: mod/settings.php:304
 msgid "Please use a shorter name."
 msgstr ""
 
-#: mod/settings.php:305
+#: mod/settings.php:307
 msgid "Name too short."
 msgstr ""
 
-#: mod/settings.php:314
+#: mod/settings.php:316
 msgid "Wrong Password."
 msgstr ""
 
-#: mod/settings.php:319
+#: mod/settings.php:321
 msgid "Invalid email."
 msgstr ""
 
-#: mod/settings.php:325
+#: mod/settings.php:327
 msgid "Cannot change to that email."
 msgstr ""
 
-#: mod/settings.php:366
+#: mod/settings.php:368
 msgid "Private forum has no privacy permissions. Using default privacy group."
 msgstr ""
 
-#: mod/settings.php:369
+#: mod/settings.php:371
 msgid "Private forum has no privacy permissions and no default privacy group."
 msgstr ""
 
-#: mod/settings.php:388
+#: mod/settings.php:390
 msgid "Settings were not updated."
 msgstr ""
 
-#: mod/settings.php:429
+#: mod/settings.php:431
 msgid "Connected Apps"
 msgstr ""
 
-#: mod/settings.php:430 src/Module/Admin/Blocklist/Contact.php:106
+#: mod/settings.php:432 src/Module/Admin/Blocklist/Contact.php:106
 #: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
 #: src/Module/Admin/Users/Create.php:71 src/Module/Admin/Users/Deleted.php:88
 #: src/Module/Admin/Users/Index.php:142 src/Module/Admin/Users/Index.php:162
@@ -1279,31 +1279,20 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: mod/settings.php:431 src/Content/Nav.php:212
+#: mod/settings.php:433 src/Content/Nav.php:212
 msgid "Home Page"
 msgstr ""
 
-#: mod/settings.php:432 src/Module/Admin/Queue.php:78
+#: mod/settings.php:434 src/Module/Admin/Queue.php:78
 msgid "Created"
 msgstr ""
 
-#: mod/settings.php:433
+#: mod/settings.php:435
 msgid "Remove authorization"
 msgstr ""
 
-#: mod/settings.php:451
-msgid "Addon Settings"
-msgstr ""
-
-#: mod/settings.php:452
-msgid "No Addon settings configured"
-msgstr ""
-
-#: mod/settings.php:473
-msgid "Additional Features"
-msgstr ""
-
-#: mod/settings.php:475 mod/settings.php:566 mod/settings.php:703
+#: mod/settings.php:461 mod/settings.php:493 mod/settings.php:524
+#: mod/settings.php:598 mod/settings.php:735
 #: src/Module/Admin/Addons/Index.php:69 src/Module/Admin/Features.php:87
 #: src/Module/Admin/Logs/Settings.php:82 src/Module/Admin/Site.php:501
 #: src/Module/Admin/Themes/Index.php:113 src/Module/Admin/Tos.php:83
@@ -1311,48 +1300,60 @@ msgstr ""
 msgid "Save Settings"
 msgstr ""
 
-#: mod/settings.php:497
+#: mod/settings.php:469
+msgid "Addon Settings"
+msgstr ""
+
+#: mod/settings.php:470
+msgid "No Addon settings configured"
+msgstr ""
+
+#: mod/settings.php:491
+msgid "Additional Features"
+msgstr ""
+
+#: mod/settings.php:529
 msgid "Diaspora (Socialhome, Hubzilla)"
 msgstr ""
 
-#: mod/settings.php:497 mod/settings.php:498
+#: mod/settings.php:529 mod/settings.php:530
 msgid "enabled"
 msgstr ""
 
-#: mod/settings.php:497 mod/settings.php:498
+#: mod/settings.php:529 mod/settings.php:530
 msgid "disabled"
 msgstr ""
 
-#: mod/settings.php:497 mod/settings.php:498
+#: mod/settings.php:529 mod/settings.php:530
 #, php-format
 msgid "Built-in support for %s connectivity is %s"
 msgstr ""
 
-#: mod/settings.php:498
+#: mod/settings.php:530
 msgid "OStatus (GNU Social)"
 msgstr ""
 
-#: mod/settings.php:524
+#: mod/settings.php:556
 msgid "Email access is disabled on this site."
 msgstr ""
 
-#: mod/settings.php:529 mod/settings.php:564
+#: mod/settings.php:561 mod/settings.php:596
 msgid "None"
 msgstr ""
 
-#: mod/settings.php:535 src/Module/BaseSettings.php:78
+#: mod/settings.php:567 src/Module/BaseSettings.php:78
 msgid "Social Networks"
 msgstr ""
 
-#: mod/settings.php:540
+#: mod/settings.php:572
 msgid "General Social Media Settings"
 msgstr ""
 
-#: mod/settings.php:541
+#: mod/settings.php:573
 msgid "Accept only top level posts by contacts you follow"
 msgstr ""
 
-#: mod/settings.php:541
+#: mod/settings.php:573
 msgid ""
 "The system does an auto completion of threads when a comment arrives. This "
 "has got the side effect that you can receive posts that had been started by "
@@ -1361,11 +1362,11 @@ msgid ""
 "posts from people you really do follow."
 msgstr ""
 
-#: mod/settings.php:542
+#: mod/settings.php:574
 msgid "Enable Content Warning"
 msgstr ""
 
-#: mod/settings.php:542
+#: mod/settings.php:574
 msgid ""
 "Users on networks like Mastodon or Pleroma are able to set a content warning "
 "field which collapse their post by default. This enables the automatic "
@@ -1373,222 +1374,222 @@ msgid ""
 "affect any other content filtering you eventually set up."
 msgstr ""
 
-#: mod/settings.php:543
+#: mod/settings.php:575
 msgid "Enable intelligent shortening"
 msgstr ""
 
-#: mod/settings.php:543
+#: mod/settings.php:575
 msgid ""
 "Normally the system tries to find the best link to add to shortened posts. "
 "If disabled, every shortened post will always point to the original "
 "friendica post."
 msgstr ""
 
-#: mod/settings.php:544
+#: mod/settings.php:576
 msgid "Enable simple text shortening"
 msgstr ""
 
-#: mod/settings.php:544
+#: mod/settings.php:576
 msgid ""
 "Normally the system shortens posts at the next line feed. If this option is "
 "enabled then the system will shorten the text at the maximum character limit."
 msgstr ""
 
-#: mod/settings.php:545
+#: mod/settings.php:577
 msgid "Attach the link title"
 msgstr ""
 
-#: mod/settings.php:545
+#: mod/settings.php:577
 msgid ""
 "When activated, the title of the attached link will be added as a title on "
 "posts to Diaspora. This is mostly helpful with \"remote-self\" contacts that "
 "share feed content."
 msgstr ""
 
-#: mod/settings.php:546
+#: mod/settings.php:578
 msgid "Your legacy ActivityPub/GNU Social account"
 msgstr ""
 
-#: mod/settings.php:546
+#: mod/settings.php:578
 msgid ""
 "If you enter your old account name from an ActivityPub based system or your "
 "GNU Social/Statusnet account name here (in the format user@domain.tld), your "
 "contacts will be added automatically. The field will be emptied when done."
 msgstr ""
 
-#: mod/settings.php:549
+#: mod/settings.php:581
 msgid "Repair OStatus subscriptions"
 msgstr ""
 
-#: mod/settings.php:553
+#: mod/settings.php:585
 msgid "Email/Mailbox Setup"
 msgstr ""
 
-#: mod/settings.php:554
+#: mod/settings.php:586
 msgid ""
 "If you wish to communicate with email contacts using this service "
 "(optional), please specify how to connect to your mailbox."
 msgstr ""
 
-#: mod/settings.php:555
+#: mod/settings.php:587
 msgid "Last successful email check:"
 msgstr ""
 
-#: mod/settings.php:557
+#: mod/settings.php:589
 msgid "IMAP server name:"
 msgstr ""
 
-#: mod/settings.php:558
+#: mod/settings.php:590
 msgid "IMAP port:"
 msgstr ""
 
-#: mod/settings.php:559
+#: mod/settings.php:591
 msgid "Security:"
 msgstr ""
 
-#: mod/settings.php:560
+#: mod/settings.php:592
 msgid "Email login name:"
 msgstr ""
 
-#: mod/settings.php:561
+#: mod/settings.php:593
 msgid "Email password:"
 msgstr ""
 
-#: mod/settings.php:562
+#: mod/settings.php:594
 msgid "Reply-to address:"
 msgstr ""
 
-#: mod/settings.php:563
+#: mod/settings.php:595
 msgid "Send public posts to all email contacts:"
 msgstr ""
 
-#: mod/settings.php:564
+#: mod/settings.php:596
 msgid "Action after import:"
 msgstr ""
 
-#: mod/settings.php:564 src/Content/Nav.php:280
+#: mod/settings.php:596 src/Content/Nav.php:280
 msgid "Mark as seen"
 msgstr ""
 
-#: mod/settings.php:564
+#: mod/settings.php:596
 msgid "Move to folder"
 msgstr ""
 
-#: mod/settings.php:565
+#: mod/settings.php:597
 msgid "Move to folder:"
 msgstr ""
 
-#: mod/settings.php:579
+#: mod/settings.php:611
 msgid "Unable to find your profile. Please contact your admin."
 msgstr ""
 
-#: mod/settings.php:617 src/Content/Widget.php:526
+#: mod/settings.php:649 src/Content/Widget.php:526
 msgid "Account Types"
 msgstr ""
 
-#: mod/settings.php:618
+#: mod/settings.php:650
 msgid "Personal Page Subtypes"
 msgstr ""
 
-#: mod/settings.php:619
+#: mod/settings.php:651
 msgid "Community Forum Subtypes"
 msgstr ""
 
-#: mod/settings.php:626 src/Module/Admin/BaseUsers.php:106
+#: mod/settings.php:658 src/Module/Admin/BaseUsers.php:106
 msgid "Personal Page"
 msgstr ""
 
-#: mod/settings.php:627
+#: mod/settings.php:659
 msgid "Account for a personal profile."
 msgstr ""
 
-#: mod/settings.php:630 src/Module/Admin/BaseUsers.php:107
+#: mod/settings.php:662 src/Module/Admin/BaseUsers.php:107
 msgid "Organisation Page"
 msgstr ""
 
-#: mod/settings.php:631
+#: mod/settings.php:663
 msgid ""
 "Account for an organisation that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:634 src/Module/Admin/BaseUsers.php:108
+#: mod/settings.php:666 src/Module/Admin/BaseUsers.php:108
 msgid "News Page"
 msgstr ""
 
-#: mod/settings.php:635
+#: mod/settings.php:667
 msgid ""
 "Account for a news reflector that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:638 src/Module/Admin/BaseUsers.php:109
+#: mod/settings.php:670 src/Module/Admin/BaseUsers.php:109
 msgid "Community Forum"
 msgstr ""
 
-#: mod/settings.php:639
+#: mod/settings.php:671
 msgid "Account for community discussions."
 msgstr ""
 
-#: mod/settings.php:642 src/Module/Admin/BaseUsers.php:99
+#: mod/settings.php:674 src/Module/Admin/BaseUsers.php:99
 msgid "Normal Account Page"
 msgstr ""
 
-#: mod/settings.php:643
+#: mod/settings.php:675
 msgid ""
 "Account for a regular personal profile that requires manual approval of "
 "\"Friends\" and \"Followers\"."
 msgstr ""
 
-#: mod/settings.php:646 src/Module/Admin/BaseUsers.php:100
+#: mod/settings.php:678 src/Module/Admin/BaseUsers.php:100
 msgid "Soapbox Page"
 msgstr ""
 
-#: mod/settings.php:647
+#: mod/settings.php:679
 msgid ""
 "Account for a public profile that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:650 src/Module/Admin/BaseUsers.php:101
+#: mod/settings.php:682 src/Module/Admin/BaseUsers.php:101
 msgid "Public Forum"
 msgstr ""
 
-#: mod/settings.php:651
+#: mod/settings.php:683
 msgid "Automatically approves all contact requests."
 msgstr ""
 
-#: mod/settings.php:654 src/Module/Admin/BaseUsers.php:102
+#: mod/settings.php:686 src/Module/Admin/BaseUsers.php:102
 msgid "Automatic Friend Page"
 msgstr ""
 
-#: mod/settings.php:655
+#: mod/settings.php:687
 msgid ""
 "Account for a popular profile that automatically approves contact requests "
 "as \"Friends\"."
 msgstr ""
 
-#: mod/settings.php:658
+#: mod/settings.php:690
 msgid "Private Forum [Experimental]"
 msgstr ""
 
-#: mod/settings.php:659
+#: mod/settings.php:691
 msgid "Requires manual approval of contact requests."
 msgstr ""
 
-#: mod/settings.php:670
+#: mod/settings.php:702
 msgid "OpenID:"
 msgstr ""
 
-#: mod/settings.php:670
+#: mod/settings.php:702
 msgid "(Optional) Allow this OpenID to login to this account."
 msgstr ""
 
-#: mod/settings.php:678
+#: mod/settings.php:710
 msgid "Publish your profile in your local site directory?"
 msgstr ""
 
-#: mod/settings.php:678
+#: mod/settings.php:710
 #, php-format
 msgid ""
 "Your profile will be published in this node's <a href=\"%s\">local "
@@ -1596,115 +1597,115 @@ msgid ""
 "system settings."
 msgstr ""
 
-#: mod/settings.php:684
+#: mod/settings.php:716
 #, php-format
 msgid ""
 "Your profile will also be published in the global friendica directories (e."
 "g. <a href=\"%s\">%s</a>)."
 msgstr ""
 
-#: mod/settings.php:690
+#: mod/settings.php:722
 #, php-format
 msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
 msgstr ""
 
-#: mod/settings.php:701
+#: mod/settings.php:733
 msgid "Account Settings"
 msgstr ""
 
-#: mod/settings.php:709
+#: mod/settings.php:741
 msgid "Password Settings"
 msgstr ""
 
-#: mod/settings.php:710 src/Module/Register.php:162
+#: mod/settings.php:742 src/Module/Register.php:162
 msgid "New Password:"
 msgstr ""
 
-#: mod/settings.php:710
+#: mod/settings.php:742
 msgid ""
 "Allowed characters are a-z, A-Z, 0-9 and special characters except white "
 "spaces, accentuated letters and colon (:)."
 msgstr ""
 
-#: mod/settings.php:711 src/Module/Register.php:163
+#: mod/settings.php:743 src/Module/Register.php:163
 msgid "Confirm:"
 msgstr ""
 
-#: mod/settings.php:711
+#: mod/settings.php:743
 msgid "Leave password fields blank unless changing"
 msgstr ""
 
-#: mod/settings.php:712
+#: mod/settings.php:744
 msgid "Current Password:"
 msgstr ""
 
-#: mod/settings.php:712
+#: mod/settings.php:744
 msgid "Your current password to confirm the changes"
 msgstr ""
 
-#: mod/settings.php:713
+#: mod/settings.php:745
 msgid "Password:"
 msgstr ""
 
-#: mod/settings.php:713
+#: mod/settings.php:745
 msgid "Your current password to confirm the changes of the email address"
 msgstr ""
 
-#: mod/settings.php:716
+#: mod/settings.php:748
 msgid "Delete OpenID URL"
 msgstr ""
 
-#: mod/settings.php:718
+#: mod/settings.php:750
 msgid "Basic Settings"
 msgstr ""
 
-#: mod/settings.php:719 src/Module/Profile/Profile.php:144
+#: mod/settings.php:751 src/Module/Profile/Profile.php:144
 msgid "Full Name:"
 msgstr ""
 
-#: mod/settings.php:720
+#: mod/settings.php:752
 msgid "Email Address:"
 msgstr ""
 
-#: mod/settings.php:721
+#: mod/settings.php:753
 msgid "Your Timezone:"
 msgstr ""
 
-#: mod/settings.php:722
+#: mod/settings.php:754
 msgid "Your Language:"
 msgstr ""
 
-#: mod/settings.php:722
+#: mod/settings.php:754
 msgid ""
 "Set the language we use to show you friendica interface and to send you "
 "emails"
 msgstr ""
 
-#: mod/settings.php:723
+#: mod/settings.php:755
 msgid "Default Post Location:"
 msgstr ""
 
-#: mod/settings.php:724
+#: mod/settings.php:756
 msgid "Use Browser Location:"
 msgstr ""
 
-#: mod/settings.php:726
+#: mod/settings.php:758
 msgid "Security and Privacy Settings"
 msgstr ""
 
-#: mod/settings.php:728
+#: mod/settings.php:760
 msgid "Maximum Friend Requests/Day:"
 msgstr ""
 
-#: mod/settings.php:728 mod/settings.php:738
+#: mod/settings.php:760 mod/settings.php:770
 msgid "(to prevent spam abuse)"
 msgstr ""
 
-#: mod/settings.php:730
+#: mod/settings.php:762
 msgid "Allow your profile to be searchable globally?"
 msgstr ""
 
-#: mod/settings.php:730
+#: mod/settings.php:762
 msgid ""
 "Activate this setting if you want others to easily find and follow you. Your "
 "profile will be searchable on remote systems. This setting also determines "
@@ -1712,43 +1713,43 @@ msgid ""
 "indexed or not."
 msgstr ""
 
-#: mod/settings.php:731
+#: mod/settings.php:763
 msgid "Hide your contact/friend list from viewers of your profile?"
 msgstr ""
 
-#: mod/settings.php:731
+#: mod/settings.php:763
 msgid ""
 "A list of your contacts is displayed on your profile page. Activate this "
 "option to disable the display of your contact list."
 msgstr ""
 
-#: mod/settings.php:732
+#: mod/settings.php:764
 msgid "Hide your profile details from anonymous viewers?"
 msgstr ""
 
-#: mod/settings.php:732
+#: mod/settings.php:764
 msgid ""
 "Anonymous visitors will only see your profile picture, your display name and "
 "the nickname you are using on your profile page. Your public posts and "
 "replies will still be accessible by other means."
 msgstr ""
 
-#: mod/settings.php:733
+#: mod/settings.php:765
 msgid "Make public posts unlisted"
 msgstr ""
 
-#: mod/settings.php:733
+#: mod/settings.php:765
 msgid ""
 "Your public posts will not appear on the community pages or in search "
 "results, nor be sent to relay servers. However they can still appear on "
 "public feeds on remote servers."
 msgstr ""
 
-#: mod/settings.php:734
+#: mod/settings.php:766
 msgid "Make all posted pictures accessible"
 msgstr ""
 
-#: mod/settings.php:734
+#: mod/settings.php:766
 msgid ""
 "This option makes every posted picture accessible via the direct link. This "
 "is a workaround for the problem that most other networks can't handle "
@@ -1756,221 +1757,221 @@ msgid ""
 "public on your photo albums though."
 msgstr ""
 
-#: mod/settings.php:735
+#: mod/settings.php:767
 msgid "Allow friends to post to your profile page?"
 msgstr ""
 
-#: mod/settings.php:735
+#: mod/settings.php:767
 msgid ""
 "Your contacts may write posts on your profile wall. These posts will be "
 "distributed to your contacts"
 msgstr ""
 
-#: mod/settings.php:736
+#: mod/settings.php:768
 msgid "Allow friends to tag your posts?"
 msgstr ""
 
-#: mod/settings.php:736
+#: mod/settings.php:768
 msgid "Your contacts can add additional tags to your posts."
 msgstr ""
 
-#: mod/settings.php:737
+#: mod/settings.php:769
 msgid "Permit unknown people to send you private mail?"
 msgstr ""
 
-#: mod/settings.php:737
+#: mod/settings.php:769
 msgid ""
 "Friendica network users may send you private messages even if they are not "
 "in your contact list."
 msgstr ""
 
-#: mod/settings.php:738
+#: mod/settings.php:770
 msgid "Maximum private messages per day from unknown people:"
 msgstr ""
 
-#: mod/settings.php:740
+#: mod/settings.php:772
 msgid "Default Post Permissions"
 msgstr ""
 
-#: mod/settings.php:744
+#: mod/settings.php:776
 msgid "Expiration settings"
 msgstr ""
 
-#: mod/settings.php:745
+#: mod/settings.php:777
 msgid "Automatically expire posts after this many days:"
 msgstr ""
 
-#: mod/settings.php:745
+#: mod/settings.php:777
 msgid "If empty, posts will not expire. Expired posts will be deleted"
 msgstr ""
 
-#: mod/settings.php:746
+#: mod/settings.php:778
 msgid "Expire posts"
 msgstr ""
 
-#: mod/settings.php:746
+#: mod/settings.php:778
 msgid "When activated, posts and comments will be expired."
 msgstr ""
 
-#: mod/settings.php:747
+#: mod/settings.php:779
 msgid "Expire personal notes"
 msgstr ""
 
-#: mod/settings.php:747
+#: mod/settings.php:779
 msgid ""
 "When activated, the personal notes on your profile page will be expired."
 msgstr ""
 
-#: mod/settings.php:748
+#: mod/settings.php:780
 msgid "Expire starred posts"
 msgstr ""
 
-#: mod/settings.php:748
+#: mod/settings.php:780
 msgid ""
 "Starring posts keeps them from being expired. That behaviour is overwritten "
 "by this setting."
 msgstr ""
 
-#: mod/settings.php:749
+#: mod/settings.php:781
 msgid "Expire photos"
 msgstr ""
 
-#: mod/settings.php:749
+#: mod/settings.php:781
 msgid "When activated, photos will be expired."
 msgstr ""
 
-#: mod/settings.php:750
+#: mod/settings.php:782
 msgid "Only expire posts by others"
 msgstr ""
 
-#: mod/settings.php:750
+#: mod/settings.php:782
 msgid ""
 "When activated, your own posts never expire. Then the settings above are "
 "only valid for posts you received."
 msgstr ""
 
-#: mod/settings.php:753
+#: mod/settings.php:785
 msgid "Notification Settings"
 msgstr ""
 
-#: mod/settings.php:754
+#: mod/settings.php:786
 msgid "Send a notification email when:"
 msgstr ""
 
-#: mod/settings.php:755
+#: mod/settings.php:787
 msgid "You receive an introduction"
 msgstr ""
 
-#: mod/settings.php:756
+#: mod/settings.php:788
 msgid "Your introductions are confirmed"
 msgstr ""
 
-#: mod/settings.php:757
+#: mod/settings.php:789
 msgid "Someone writes on your profile wall"
 msgstr ""
 
-#: mod/settings.php:758
+#: mod/settings.php:790
 msgid "Someone writes a followup comment"
 msgstr ""
 
-#: mod/settings.php:759
+#: mod/settings.php:791
 msgid "You receive a private message"
 msgstr ""
 
-#: mod/settings.php:760
+#: mod/settings.php:792
 msgid "You receive a friend suggestion"
 msgstr ""
 
-#: mod/settings.php:761
+#: mod/settings.php:793
 msgid "You are tagged in a post"
 msgstr ""
 
-#: mod/settings.php:762
+#: mod/settings.php:794
 msgid "You are poked/prodded/etc. in a post"
 msgstr ""
 
-#: mod/settings.php:764
+#: mod/settings.php:796
 msgid "Create a desktop notification when:"
 msgstr ""
 
-#: mod/settings.php:765
+#: mod/settings.php:797
 msgid "Someone liked your content"
 msgstr ""
 
-#: mod/settings.php:766
+#: mod/settings.php:798
 msgid "Someone shared your content"
 msgstr ""
 
-#: mod/settings.php:768
+#: mod/settings.php:800
 msgid "Activate desktop notifications"
 msgstr ""
 
-#: mod/settings.php:768
+#: mod/settings.php:800
 msgid "Show desktop popup on new notifications"
 msgstr ""
 
-#: mod/settings.php:770
+#: mod/settings.php:802
 msgid "Text-only notification emails"
 msgstr ""
 
-#: mod/settings.php:772
+#: mod/settings.php:804
 msgid "Send text only notification emails, without the html part"
 msgstr ""
 
-#: mod/settings.php:774
+#: mod/settings.php:806
 msgid "Show detailled notifications"
 msgstr ""
 
-#: mod/settings.php:776
+#: mod/settings.php:808
 msgid ""
 "Per default, notifications are condensed to a single notification per item. "
 "When enabled every notification is displayed."
 msgstr ""
 
-#: mod/settings.php:778
+#: mod/settings.php:810
 msgid "Show notifications of ignored contacts"
 msgstr ""
 
-#: mod/settings.php:780
+#: mod/settings.php:812
 msgid ""
 "You don't see posts from ignored contacts. But you still see their comments. "
 "This setting controls if you want to still receive regular notifications "
 "that are caused by ignored contacts or not."
 msgstr ""
 
-#: mod/settings.php:782
+#: mod/settings.php:814
 msgid "Advanced Account/Page Type Settings"
 msgstr ""
 
-#: mod/settings.php:783
+#: mod/settings.php:815
 msgid "Change the behaviour of this account for special situations"
 msgstr ""
 
-#: mod/settings.php:786
+#: mod/settings.php:818
 msgid "Import Contacts"
 msgstr ""
 
-#: mod/settings.php:787
+#: mod/settings.php:819
 msgid ""
 "Upload a CSV file that contains the handle of your followed accounts in the "
 "first column you exported from the old account."
 msgstr ""
 
-#: mod/settings.php:788
+#: mod/settings.php:820
 msgid "Upload File"
 msgstr ""
 
-#: mod/settings.php:790
+#: mod/settings.php:822
 msgid "Relocate"
 msgstr ""
 
-#: mod/settings.php:791
+#: mod/settings.php:823
 msgid ""
 "If you have moved this profile from another server, and some of your "
 "contacts don't receive your updates, try pushing this button."
 msgstr ""
 
-#: mod/settings.php:792
+#: mod/settings.php:824
 msgid "Resend relocate message to contacts"
 msgstr ""
 
@@ -6951,8 +6952,8 @@ msgstr ""
 msgid "User registrations waiting for confirmation"
 msgstr ""
 
-#: src/Module/BaseApi.php:278 src/Module/BaseApi.php:294
-#: src/Module/BaseApi.php:310
+#: src/Module/BaseApi.php:280 src/Module/BaseApi.php:296
+#: src/Module/BaseApi.php:312
 msgid "Too Many Requests"
 msgstr ""
 

--- a/view/templates/settings/addon/connector.tpl
+++ b/view/templates/settings/addon/connector.tpl
@@ -1,0 +1,34 @@
+<span id="settings_{{$connector}}_inflated" class="settings-block fakelink" style="display: {{if $open}}none{{else}}block{{/if}};" onclick="openClose('settings_{{$connector}}_expanded'); openClose('settings_{{$connector}}_inflated');">
+	<img class="connector{{if !$enabled}}-disabled{{/if}}" src="{{$image}}" /><h3 class="connector">{{$title}}</h3>
+</span>
+<div id="settings_{{$connector}}_expanded" class="settings-block" style="display: {{if $open}}block{{else}}none{{/if}};">
+	<span class="fakelink" onclick="openClose('settings_{{$connector}}_expanded'); openClose('settings_{{$connector}}_inflated');">
+		<img class="connector{{if !$enabled}}-disabled{{/if}}" src="{{$image}}" /><h3 class="connector">{{$title}}</h3>
+	</span>
+	{{$html nofilter}}
+	<div class="clear"></div>
+{{if $submit}}
+	<div class="settings-submit-wrapper panel-footer">
+    {{if $submit|is_string}}
+		<button type="submit" name="{{$connector}}-submit" class="btn btn-primary settings-submit" value="{{$submit}}">{{$submit}}</button>
+    {{else}}
+        {{$count = 1}}
+		{{foreach $submit as $name => $label}}{{if $label}}
+			{{if $count == 1}}
+		<button type="submit" name="{{$name}}" class="btn btn-primary settings-submit" value="{{$label}}">{{$label}}</button>
+            {{/if}}
+            {{if $count == 2}}
+		<div class="btn-group" role="group" aria-label="...">
+			{{/if}}
+            {{if $count != 1}}
+			<button type="submit" name="{{$name}}" class="btn btn-default settings-submit" value="{{$label}}">{{$label}}</button>
+            {{/if}}
+            {{$count = $count + 1}}
+        {{/if}}{{/foreach}}
+		{{if $submit|count > 1}}
+		</div>
+		{{/if}}
+    {{/if}}
+	</div>
+{{/if}}
+</div>

--- a/view/templates/settings/addon/link.tpl
+++ b/view/templates/settings/addon/link.tpl
@@ -1,0 +1,1 @@
+<span class="settings-block fakelink" style="display: block;"><h3><a href="{{$href}}">{{$title}} <i class="glyphicon glyphicon-share"></i></a></h3></span>

--- a/view/templates/settings/addon/panel.tpl
+++ b/view/templates/settings/addon/panel.tpl
@@ -1,0 +1,33 @@
+<span id="settings_{{$addon}}_inflated" class="settings-block fakelink" style="display: {{if $open}}none{{else}}block{{/if}};" onclick="openClose('settings_{{$addon}}_expanded'); openClose('settings_{{$addon}}_inflated');">
+	<h3>{{$title}}</h3>
+</span>
+<div id="settings_{{$addon}}_expanded" class="settings-block" style="display: {{if $open}}block{{else}}none{{/if}};">
+	<span class="fakelink" onclick="openClose('settings_{{$addon}}_expanded'); openClose('settings_{{$addon}}_inflated');">
+		<h3>{{$title}}</h3>
+	</span>
+	{{$html nofilter}}
+{{if $submit}}
+	<div class="settings-submit-wrapper panel-footer">
+    {{if $submit|is_string}}
+		<button type="submit" name="{{$addon}}-submit" class="btn btn-primary settings-submit" value="{{$submit}}">{{$submit}}</button>
+    {{else}}
+        {{$count = 1}}
+		{{foreach $submit as $name => $label}}{{if $label}}
+			{{if $count == 1}}
+		<button type="submit" name="{{$name}}" class="btn btn-primary settings-submit" value="{{$label}}">{{$label}}</button>
+            {{/if}}
+            {{if $count == 2}}
+		<div class="btn-group" role="group" aria-label="...">
+			{{/if}}
+            {{if $count != 1}}
+			<button type="submit" name="{{$name}}" class="btn btn-default settings-submit" value="{{$label}}">{{$label}}</button>
+            {{/if}}
+            {{$count = $count + 1}}
+        {{/if}}{{/foreach}}
+		{{if $submit|count > 1}}
+		</div>
+		{{/if}}
+    {{/if}}
+	</div>
+{{/if}}
+</div>

--- a/view/templates/settings/addons.tpl
+++ b/view/templates/settings/addons.tpl
@@ -1,8 +1,8 @@
 <h1>{{$title}}</h1>
 
-{{foreach $addon_settings_forms as $addon_settings_form}}
+{{foreach $addon_settings_forms as $addon => $addon_settings_form}}
 
-<form action="settings/addon" method="post" autocomplete="off">
+<form action="settings/addon/{{$addon}}" method="post" autocomplete="off">
 	<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
 	{{$addon_settings_form nofilter}}
 </form>

--- a/view/templates/settings/connectors.tpl
+++ b/view/templates/settings/connectors.tpl
@@ -24,36 +24,43 @@
 			<input type="submit" id="general-submit" name="general-submit" class="settings-submit" value="{{$submit}}"/>
 		</div>
 	</div>
-	<div class="clear"></div>
-
-	{{$settings_connectors nofilter}}
-
-	{{if $mail_disabled}}
-
-	{{else}}
-		<span id="settings_mail_inflated" class="settings-block fakelink" style="display: block;"
-		      onclick="openClose('settings_mail_expanded'); openClose('settings_mail_inflated');">
-		<img class="connector" src="images/mail.png"/><h3 class="settings-heading connector">{{$h_imap}}</h3>
-	</span>
-		<div id="settings_mail_expanded" class="settings-block" style="display: none;">
-	<span class="fakelink" onclick="openClose('settings_mail_expanded'); openClose('settings_mail_inflated');">
-		<img class="connector" src="images/mail.png"/><h3 class="settings-heading connector">{{$h_imap}}</h3>
-	</span>
-			<p>{{$imap_desc nofilter}}</p>
-			{{include file="field_custom.tpl" field=$imap_lastcheck}}
-			{{include file="field_input.tpl" field=$mail_server}}
-			{{include file="field_input.tpl" field=$mail_port}}
-			{{include file="field_select.tpl" field=$mail_ssl}}
-			{{include file="field_input.tpl" field=$mail_user}}
-			{{include file="field_password.tpl" field=$mail_pass}}
-			{{include file="field_input.tpl" field=$mail_replyto}}
-			{{include file="field_checkbox.tpl" field=$mail_pubmail}}
-			{{include file="field_select.tpl" field=$mail_action}}
-			{{include file="field_input.tpl" field=$mail_movetofolder}}
-
-			<div class="settings-submit-wrapper">
-				<input type="submit" id="imap-submit" name="imap-submit" class="settings-submit" value="{{$submit}}"/>
-			</div>
-		</div>
-	{{/if}}
 </form>
+<div class="clear"></div>
+
+{{if !$mail_disabled}}
+<form action="settings/connectors" method="post" autocomplete="off">
+	<input type='hidden' name='form_security_token' value='{{$form_security_token}}'>
+	<span id="settings_mail_inflated" class="settings-block fakelink" style="display: block;"
+	      onclick="openClose('settings_mail_expanded'); openClose('settings_mail_inflated');">
+		<img class="connector" src="images/mail.png"/><h3 class="settings-heading connector">{{$h_mail}}</h3>
+	</span>
+	<div id="settings_mail_expanded" class="settings-block" style="display: none;">
+		<span class="fakelink" onclick="openClose('settings_mail_expanded'); openClose('settings_mail_inflated');">
+			<img class="connector" src="images/mail.png"/><h3 class="settings-heading connector">{{$h_mail}}</h3>
+		</span>
+		<p>{{$mail_desc nofilter}}</p>
+		{{include file="field_custom.tpl" field=$mail_lastcheck}}
+		{{include file="field_input.tpl" field=$mail_server}}
+		{{include file="field_input.tpl" field=$mail_port}}
+		{{include file="field_select.tpl" field=$mail_ssl}}
+		{{include file="field_input.tpl" field=$mail_user}}
+		{{include file="field_password.tpl" field=$mail_pass}}
+		{{include file="field_input.tpl" field=$mail_replyto}}
+		{{include file="field_checkbox.tpl" field=$mail_pubmail}}
+		{{include file="field_select.tpl" field=$mail_action}}
+		{{include file="field_input.tpl" field=$mail_movetofolder}}
+
+		<div class="settings-submit-wrapper">
+			<input type="submit" id="mail-submit" name="mail-submit" class="settings-submit" value="{{$submit}}"/>
+		</div>
+	</div>
+</form>
+{{/if}}
+
+{{foreach $connector_settings_forms as $addon => $connector_settings_form}}
+<form action="settings/connectors/{{$addon}}" method="post" autocomplete="off">
+	<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+    {{$connector_settings_form nofilter}}
+	<div class="clear"></div>
+</form>
+{{/foreach}}

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2974,14 +2974,12 @@ details.profile-jot-net[open] summary:before {
 .fakelink > h3:before {
 	padding-right: 10px;
 }
-.widget.fakelink > h3:before,
-.settings-block.fakelink > h3:before {
+.widget.fakelink > h3:before {
 	font-family: ForkAwesome;
 	content: "\f0da"; /* Right Plain Pointer */
 }
 .widget > .fakelink > h3:before,
-#sidebar-group-header > .fakelink > h3:before,
-.settings-block > .fakelink > h3:before {
+#sidebar-group-header > .fakelink > h3:before {
 	font-family: ForkAwesome;
 	content: "\f0d7"; /* Bottom Plain Pointer */
 }

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2901,13 +2901,13 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 	padding: 1px 10px;
 }
 details.profile-jot-net[open] summary:before,
-.panel .section-subtitle-wrapper a.accordion-toggle:before {
+.panel .section-subtitle-wrapper .accordion-toggle:before {
 	font-family: ForkAwesome;
 	content: "\f0d7";
 	padding-right: 5px;
 }
 details.profile-jot-net summary:before,
-.panel .section-subtitle-wrapper a.accordion-toggle.collapsed:before {
+.panel .section-subtitle-wrapper .accordion-toggle.collapsed:before {
 	font-family: ForkAwesome;
 	content: "\f0da";
 }
@@ -2963,6 +2963,12 @@ details.profile-jot-net[open] summary:before {
 	font-size: 18px;
 	margin-top: 10px;
 	margin-bottom: 10px;
+}
+
+.section-subtitle-wrapper > h3 {
+	font-size: 16px;
+	margin-top: 8px;
+	margin-bottom: 8px;
 }
 
 .fakelink > h3:before {

--- a/view/theme/frio/templates/admin/blocklist/contact.tpl
+++ b/view/theme/frio/templates/admin/blocklist/contact.tpl
@@ -11,9 +11,9 @@
 		<div class="panel">
 			<div class="panel-heading section-subtitle-wrapper" role="tab" id="admin-settings-contactblock-block">
 				<h4>
-					<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-contactblock-block-collapse" aria-expanded="false" aria-controls="admin-settings-contactblock-block-collapse">
+					<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-contactblock-block-collapse" aria-expanded="false" aria-controls="admin-settings-contactblock-block-collapse">
 						{{$h_newblock}}
-					</a>
+					</button>
 				</h4>
 			</div>
 
@@ -37,9 +37,9 @@
 		<div class="panel">
 			<div class="panel-heading section-subtitle-wrapper" role="tab" id="admin-settings-contactblock-blocked">
 				<h4>
-					<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-contactblock-blocked-collapse" aria-expanded="{{if count($contacts) > 0}}true{{else}}false{{/if}}" aria-controls="admin-settings-contactblock-blocked-collapse">
+					<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-contactblock-blocked-collapse" aria-expanded="{{if count($contacts) > 0}}true{{else}}false{{/if}}" aria-controls="admin-settings-contactblock-blocked-collapse">
 						{{$h_contacts}} ({{$total_contacts}})
-					</a>
+					</button>
 				</h4>
 			</div>
 

--- a/view/theme/frio/templates/admin/features.tpl
+++ b/view/theme/frio/templates/admin/features.tpl
@@ -8,9 +8,9 @@
 				<div class="panel">
 					<div class="section-subtitle-wrapper panel-heading" role="tab" id="{{$g}}-settings-title">
 						<h2>
-							<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#{{$g}}-settings-content" aria-expanded="true" aria-controls="{{$g}}-settings-content">
+							<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#{{$g}}-settings-content" aria-expanded="true" aria-controls="{{$g}}-settings-content">
 								{{$f.0}}
-							</a>
+							</button>
 						</h2>
 					</div>
 					<div id="{{$g}}-settings-content" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{$g}}-settings-title">

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -29,9 +29,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-general">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-general-collapse" aria-expanded="false" aria-controls="admin-settings-general-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-general-collapse" aria-expanded="false" aria-controls="admin-settings-general-collapse">
 							{{$general_info}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="admin-settings-general-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-general">
@@ -64,9 +64,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-registration">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-registration-collapse" aria-expanded="false" aria-controls="admin-settings-registration-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-registration-collapse" aria-expanded="false" aria-controls="admin-settings-registration-collapse">
 							{{$registration}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="admin-settings-registration-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-registration">
@@ -93,9 +93,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-upload">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-upload-collapse" aria-expanded="false" aria-controls="admin-settings-upload-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-upload-collapse" aria-expanded="false" aria-controls="admin-settings-upload-collapse">
 							{{$upload}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="admin-settings-upload-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-upload">
@@ -118,9 +118,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-corporate">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-corporate-collapse" aria-expanded="false" aria-controls="admin-settings-corporate-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-corporate-collapse" aria-expanded="false" aria-controls="admin-settings-corporate-collapse">
 							{{$corporate}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="admin-settings-corporate-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-corporate">
@@ -179,9 +179,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-$dvanced">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-advanced-collapse" aria-expanded="false" aria-controls="admin-settings-advanced-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-advanced-collapse" aria-expanded="false" aria-controls="admin-settings-advanced-collapse">
 							{{$advanced}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="admin-settings-advanced-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-advanced">
@@ -209,9 +209,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-contacts">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-contacts-collapse" aria-expanded="false" aria-controls="admin-settings-contacts-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-contacts-collapse" aria-expanded="false" aria-controls="admin-settings-contacts-collapse">
 							{{$portable_contacts}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="admin-settings-contacts-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-cocontactsrporate">
@@ -235,9 +235,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-performance">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-performance-collapse" aria-expanded="false" aria-controls="admin-settings-performance-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-performance-collapse" aria-expanded="false" aria-controls="admin-settings-performance-collapse">
 							{{$performance}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="admin-settings-performance-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-performance">
@@ -265,9 +265,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-worker">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-worker-collapse" aria-expanded="false" aria-controls="admin-settings-worker-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-worker-collapse" aria-expanded="false" aria-controls="admin-settings-worker-collapse">
 							{{$worker_title}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="admin-settings-worker-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-worker">
@@ -290,9 +290,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-relay-corporate">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-relay-collapse" aria-expanded="false" aria-controls="admin-settings-relay-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-relay-collapse" aria-expanded="false" aria-controls="admin-settings-relay-collapse">
 							{{$relay_title}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="admin-settings-relay-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-relay">
@@ -331,9 +331,9 @@
 			<input type="hidden" name="active_panel" value="admin-settings-relocate-collapse">
 			<div class="section-subtitle-wrapper panel-heading" role="tab" id="admin-settings-relocate">
 				<h2>
-					<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-relocate-collapse" aria-expanded="false" aria-controls="admin-settings-relocate-collapse">
+					<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-relocate-collapse" aria-expanded="false" aria-controls="admin-settings-relocate-collapse">
 						{{$relocate}}
-					</a>
+					</button>
 				</h2>
 			</div>
 			<div id="admin-settings-relocate-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-relocate">

--- a/view/theme/frio/templates/admin/storage.tpl
+++ b/view/theme/frio/templates/admin/storage.tpl
@@ -15,9 +15,9 @@
 		<div class="panel">
 			<div class="section-subtitle-wrapper panel-title" role="tab" id="admin-settings-{{$storage.prefix}}">
 				<h3>
-					<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-{{$storage.prefix}}-collapse" aria-expanded="false" aria-controls="admin-settings-{{$storage.prefix}}-collapse">
+					<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#admin-settings" href="#admin-settings-{{$storage.prefix}}-collapse" aria-expanded="false" aria-controls="admin-settings-{{$storage.prefix}}-collapse">
 						{{$storage.name}}
-					</a>
+					</button>
 				</h3>
 			</div>
 			<div id="admin-settings-{{$storage.prefix}}-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-{{$storage.prefix}}">

--- a/view/theme/frio/templates/contact_edit.tpl
+++ b/view/theme/frio/templates/contact_edit.tpl
@@ -68,9 +68,9 @@
 					<div class="panel">
 						<div class="section-subtitle-wrapper panel-heading" role="tab" id="contact-edit-profile">
 							<h4>
-								<a class="accordion-toggle" data-toggle="collapse" data-parent="#contact-edit-tools" href="#contact-edit-profile-collapse" aria-expanded="true" aria-controls="contact-edit-profile-collapse">
+								<button class="btn-link accordion-toggle" data-toggle="collapse" data-parent="#contact-edit-tools" href="#contact-edit-profile-collapse" aria-expanded="true" aria-controls="contact-edit-profile-collapse">
 									{{$contact_profile_label}}
-								</a>
+								</button>
 							</h4>
 						</div>
 						<div id="contact-edit-profile-collapse" class="panel-body panel-collapse collapse in" role="tabpanel" aria-labelledby="contact-edit-profile">
@@ -127,9 +127,9 @@
 					<div class="panel">
 						<div class="section-subtitle-wrapper panel-heading" role="tab" id="contact-edit-settings">
 							<h4>
-								<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#contact-edit-tools" href="#contact-edit-settings-collapse" aria-expanded="false" aria-controls="contact-edit-settings-collapse">
+								<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#contact-edit-tools" href="#contact-edit-settings-collapse" aria-expanded="false" aria-controls="contact-edit-settings-collapse">
 									{{$contact_settings_label}}
-								</a>
+								</button>
 							</h4>
 						</div>
 						<div id="contact-edit-settings-collapse" class="panel-body panel-collapse collapse" role="tabpanel" aria-labelledby="contact-edit-settings">
@@ -161,9 +161,9 @@
 					<div class="panel">
 						<div class="section-subtitle-wrapper panel-heading" role="tab" id="contact-edit-info">
 							<h4>
-								<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#contact-edit-tools" href="#contact-edit-info-collapse" aria-expanded="false" aria-controls="contact-edit-info-collapse">
+								<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#contact-edit-tools" href="#contact-edit-info-collapse" aria-expanded="false" aria-controls="contact-edit-info-collapse">
 									{{$lbl_info1}}
-								</a>
+								</button>
 							</h4>
 						</div>
 						<div id="contact-edit-info-collapse" class="panel-body panel-collapse collapse" role="tabpanel" aria-labelledby="contact-edit-info">

--- a/view/theme/frio/templates/settings/addon/connector.tpl
+++ b/view/theme/frio/templates/settings/addon/connector.tpl
@@ -1,0 +1,36 @@
+	<div class="section-subtitle-wrapper panel-heading" role="tab" id="{{$connector}}-settings-title">
+		<h2>
+			<button class="btn-link accordion-toggle{{if !$open}} collapsed{{/if}}" data-toggle="collapse" data-parent="#settings-connectors" href="#{{$connector}}-settings-content" aria-expanded="false" aria-controls="{{$connector}}-settings-content">
+				<img class="connector{{if !$enabled}}-disabled{{/if}}" src="{{$image}}" /> {{$title}}
+			</button>
+		</h2>
+	</div>
+	<div id="{{$connector}}-settings-content" class="panel-collapse collapse{{if $open}} in{{/if}}" role="tabpanel" aria-labelledby="{{$connector}}-settings-title">
+		<div class="panel-body">
+			{{$html nofilter}}
+		</div>
+		<div class="panel-footer">
+{{if $submit}}
+    {{if $submit|is_string}}
+			<button type="submit" name="{{$connector}}-submit" class="btn btn-primary settings-submit" value="{{$submit}}">{{$submit}}</button>
+    {{else}}
+        {{$count = 1}}
+        {{foreach $submit as $name => $label}}{{if $label}}
+            {{if $count == 1}}
+			<button type="submit" name="{{$name}}" class="btn btn-primary settings-submit" value="{{$label}}">{{$label}}</button>
+            {{/if}}
+            {{if $count == 2}}
+			<div class="btn-group" role="group" aria-label="...">
+            {{/if}}
+            {{if $count != 1}}
+				<button type="submit" name="{{$name}}" class="btn btn-default settings-submit" value="{{$label}}">{{$label}}</button>
+            {{/if}}
+            {{$count = $count + 1}}
+        {{/if}}{{/foreach}}
+        {{if $submit|count > 1}}
+			</div>
+        {{/if}}
+	{{/if}}
+{{/if}}
+		</div>
+	</div>

--- a/view/theme/frio/templates/settings/addon/link.tpl
+++ b/view/theme/frio/templates/settings/addon/link.tpl
@@ -1,0 +1,1 @@
+<div class="settings-block"><h3><a href="{{$href}}">{{$title}} <i class="glyphicon glyphicon-share"></i></a></h3></div>

--- a/view/theme/frio/templates/settings/addon/panel.tpl
+++ b/view/theme/frio/templates/settings/addon/panel.tpl
@@ -1,0 +1,36 @@
+	<div class="section-subtitle-wrapper panel-heading" role="tab" id="{{$addon}}-settings-title">
+		<h2>
+			<button class="btn-link accordion-toggle{{if !$open}} collapsed{{/if}}" data-toggle="collapse" data-parent="#settings-addons" href="#{{$addon}}-settings-content" aria-expanded="false" aria-controls="{{$addon}}-settings-content">
+				{{$title}}
+			</button>
+		</h2>
+	</div>
+	<div id="{{$addon}}-settings-content" class="panel-collapse collapse{{if $open}} in{{/if}}" role="tabpanel" aria-labelledby="{{$addon}}-settings-title">
+		<div class="panel-body">
+            {{$html nofilter}}
+		</div>
+		<div class="panel-footer">
+{{if $submit}}
+    {{if $submit|is_string}}
+			<button type="submit" name="{{$addon}}-submit" class="btn btn-primary settings-submit" value="{{$submit}}">{{$submit}}</button>
+    {{else}}
+        {{$count = 1}}
+        {{foreach $submit as $name => $label}}{{if $label}}
+            {{if $count == 1}}
+			<button type="submit" name="{{$name}}" class="btn btn-primary settings-submit" value="{{$label}}">{{$label}}</button>
+            {{/if}}
+            {{if $count == 2}}
+			<div class="btn-group" role="group" aria-label="...">
+            {{/if}}
+            {{if $count != 1}}
+				<button type="submit" name="{{$name}}" class="btn btn-default settings-submit" value="{{$label}}">{{$label}}</button>
+            {{/if}}
+            {{$count = $count + 1}}
+        {{/if}}{{/foreach}}
+        {{if $submit|count > 1}}
+			</div>
+        {{/if}}
+    {{/if}}
+{{/if}}
+		</div>
+	</div>

--- a/view/theme/frio/templates/settings/addons.tpl
+++ b/view/theme/frio/templates/settings/addons.tpl
@@ -2,17 +2,15 @@
 	{{* include the title template for the settings title *}}
 	{{include file="section_title.tpl" title=$title}}
 
-{{foreach $addon_settings_forms as $addon_settings_form}}
-
-	<form action="settings/addon" method="post" autocomplete="off">
-		<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
-		{{$addon_settings_form nofilter}}
-	</form>
-
+	<div class="panel-group panel-group-settings" id="settings-addons" role="tablist" aria-multiselectable="true">
+{{foreach $addon_settings_forms as $addon => $addon_settings_form}}
+		<form action="settings/addon/{{$addon}}" method="post" autocomplete="off" class="panel">
+			<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+			{{$addon_settings_form nofilter}}
+		</form>
 {{foreachelse}}
-
-	<div class="alert alert-info" role="alert">{{$no_addon_settings_configured}}</div>
-
+		<div class="alert alert-info" role="alert">{{$no_addon_settings_configured}}</div>
 {{/foreach}}
+	</div>
 
 </div>

--- a/view/theme/frio/templates/settings/connectors.tpl
+++ b/view/theme/frio/templates/settings/connectors.tpl
@@ -11,9 +11,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="content-settings-title">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#content-settings-content" aria-expanded="false" aria-controls="content-settings-content">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#content-settings-content" aria-expanded="false" aria-controls="content-settings-content">
 							{{$general_settings}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="content-settings-content" class="panel-collapse collapse" role="tabpanel" aria-labelledby="content-settings">

--- a/view/theme/frio/templates/settings/connectors.tpl
+++ b/view/theme/frio/templates/settings/connectors.tpl
@@ -1,72 +1,83 @@
 <div class="generic-page-wrapper">
-	<h1>{{$title}}</h1>
+    {{include file="section_title.tpl" title=$title}}
 
 	<p class="connector_statusmsg">{{$diasp_enabled}}</p>
 	<p class="connector_statusmsg">{{$ostat_enabled}}</p>
 
-	<form action="settings/connectors" method="post" autocomplete="off">
-		<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+	<div class="panel-group panel-group-settings" id="settings-connectors" role="tablist" aria-multiselectable="true">
 
-		<div class="panel-group panel-group-settings" id="settings" role="tablist" aria-multiselectable="true">
-			<div class="panel">
-				<div class="section-subtitle-wrapper panel-heading" role="tab" id="content-settings-title">
-					<h2>
-						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#content-settings-content" aria-expanded="false" aria-controls="content-settings-content">
-							{{$general_settings}}
-						</button>
-					</h2>
+		<form action="settings/connectors" method="post" autocomplete="off" class="panel">
+			<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+
+			<div class="section-subtitle-wrapper panel-heading" role="tab" id="content-settings-title">
+				<h2>
+					<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings-connectors" href="#content-settings-content" aria-expanded="false" aria-controls="content-settings-content">
+						{{$general_settings}}
+					</button>
+				</h2>
+			</div>
+			<div id="content-settings-content" class="panel-collapse collapse" role="tabpanel" aria-labelledby="content-settings-title">
+				<div class="panel-body">
+					{{include file="field_checkbox.tpl" field=$accept_only_sharer}}
+
+					{{include file="field_checkbox.tpl" field=$enable_cw}}
+
+					{{include file="field_checkbox.tpl" field=$enable_smart_shortening}}
+
+					{{include file="field_checkbox.tpl" field=$simple_shortening}}
+
+					{{include file="field_checkbox.tpl" field=$attach_link_title}}
+
+					{{include file="field_input.tpl" field=$legacy_contact}}
+
+					<p><a href="{{$repair_ostatus_url}}">{{$repair_ostatus_text}}</a></p>
 				</div>
-				<div id="content-settings-content" class="panel-collapse collapse" role="tabpanel" aria-labelledby="content-settings">
-					<div class="panel-body">
-						{{include file="field_checkbox.tpl" field=$accept_only_sharer}}
-
-						{{include file="field_checkbox.tpl" field=$enable_cw}}
-
-						{{include file="field_checkbox.tpl" field=$enable_smart_shortening}}
-
-						{{include file="field_checkbox.tpl" field=$simple_shortening}}
-
-						{{include file="field_checkbox.tpl" field=$attach_link_title}}
-
-						{{include file="field_input.tpl" field=$legacy_contact}}
-
-						<p><a href="{{$repair_ostatus_url}}">{{$repair_ostatus_text}}</a></p>
-					</div>
-					<div class="panel-footer">
-						<button type="submit" id="general-submit" name="general-submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
-					</div>
+				<div class="panel-footer">
+					<button type="submit" id="general-submit" name="general-submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
 				</div>
 			</div>
-		</div>
-
-		{{$settings_connectors nofilter}}
+		</form>
 
 {{if !$mail_disabled}}
-		<span id="settings_mail_inflated" class="settings-block fakelink" style="display: block;" onclick="openClose('settings_mail_expanded'); openClose('settings_mail_inflated');">
-			<img class="connector" src="images/mail.png" /><h3 class="settings-heading connector">{{$h_imap}}</h3>
-		</span>
-		<div id="settings_mail_expanded" class="settings-block" style="display: none;">
-			<span class="fakelink" onclick="openClose('settings_mail_expanded'); openClose('settings_mail_inflated');">
-				<img class="connector" src="images/mail.png" /><h3 class="settings-heading connector">{{$h_imap}}</h3>
-			</span>
-			<p>{{$imap_desc nofilter}}</p>
 
-			{{include file="field_custom.tpl" field=$imap_lastcheck}}
-			{{include file="field_input.tpl" field=$mail_server}}
-			{{include file="field_input.tpl" field=$mail_port}}
-			{{include file="field_select.tpl" field=$mail_ssl}}
-			{{include file="field_input.tpl" field=$mail_user}}
-			{{include file="field_password.tpl" field=$mail_pass}}
-			{{include file="field_input.tpl" field=$mail_replyto}}
-			{{include file="field_checkbox.tpl" field=$mail_pubmail}}
-			{{include file="field_select.tpl" field=$mail_action}}
-			{{include file="field_input.tpl" field=$mail_movetofolder}}
+		<form action="settings/connectors" method="post" autocomplete="off" class="panel">
+			<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
 
-			<div class="settings-submit-wrapper">
-				<input type="submit" id="imap-submit" name="imap-submit" class="settings-submit" value="{{$submit}}" />
+			<div class="section-subtitle-wrapper panel-heading" role="tab" id="mail-settings-title">
+				<h2>
+					<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings-connectors" href="#mail-settings-content" aria-expanded="false" aria-controls="mail-settings-content">
+						<img class="connector" src="images/mail.png" /> {{$h_mail}}
+					</button>
+				</h2>
 			</div>
-		</div>
+			<div id="mail-settings-content" class="panel-collapse collapse" role="tabpanel" aria-labelledby="mail-settings-title">
+				<div class="panel-body">
+
+					<p>{{$mail_desc nofilter}}</p>
+
+					{{include file="field_custom.tpl" field=$mail_lastcheck}}
+					{{include file="field_input.tpl" field=$mail_server}}
+					{{include file="field_input.tpl" field=$mail_port}}
+					{{include file="field_select.tpl" field=$mail_ssl}}
+					{{include file="field_input.tpl" field=$mail_user}}
+					{{include file="field_password.tpl" field=$mail_pass}}
+					{{include file="field_input.tpl" field=$mail_replyto}}
+					{{include file="field_checkbox.tpl" field=$mail_pubmail}}
+					{{include file="field_select.tpl" field=$mail_action}}
+					{{include file="field_input.tpl" field=$mail_movetofolder}}
+				</div>
+				<div class="panel-footer">
+					<button type="submit" id="mail-submit" name="mail-submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
+				</div>
+			</div>
+		</form>
 {{/if}}
 
-	</form>
+{{foreach $connector_settings_forms as $addon => $connector_settings_form}}
+		<form action="settings/connectors/{{$addon}}" method="post" autocomplete="off" class="panel">
+			<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+	        {{$connector_settings_form nofilter}}
+		</form>
+{{/foreach}}
+	</div>
 </div>

--- a/view/theme/frio/templates/settings/display.tpl
+++ b/view/theme/frio/templates/settings/display.tpl
@@ -7,9 +7,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="theme-settings-title">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#theme-settings-content" aria-expanded="true" aria-controls="theme-settings-content">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#theme-settings-content" aria-expanded="true" aria-controls="theme-settings-content">
 							{{$d_tset}}
-						</a>
+						</button>
 					</h2>
 				</div>
 
@@ -31,9 +31,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="custom-settings-title">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#custom-settings-content" aria-expanded="false" aria-controls="custom-settings-content">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#custom-settings-content" aria-expanded="false" aria-controls="custom-settings-content">
 							{{$d_ctset}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="custom-settings-content" class="panel-collapse collapse{{if !$theme && !$mobile_theme}} in{{/if}}" role="tabpanel" aria-labelledby="custom-settings">
@@ -50,9 +50,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="content-settings-title">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#content-settings-content" aria-expanded="false" aria-controls="content-settings-content">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#content-settings-content" aria-expanded="false" aria-controls="content-settings-content">
 							{{$d_cset}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="content-settings-content" class="panel-collapse collapse{{if !$theme && !$mobile_theme && !$theme_config}} in{{/if}}" role="tabpanel" aria-labelledby="content-settings">
@@ -77,9 +77,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="calendar-settings-title">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#calendar-settings-content" aria-expanded="false" aria-controls="calendar-settings-content">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#calendar-settings-content" aria-expanded="false" aria-controls="calendar-settings-content">
 							{{$calendar_title}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="calendar-settings-content" class="panel-collapse collapse{{if !$theme && !$mobile_theme && !$theme_config}} in{{/if}}" role="tabpanel" aria-labelledby="calendar-settings">

--- a/view/theme/frio/templates/settings/features.tpl
+++ b/view/theme/frio/templates/settings/features.tpl
@@ -8,9 +8,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="{{$g}}-settings-title">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#{{$g}}-settings-content" aria-expanded="true" aria-controls="{{$g}}-settings-content">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#{{$g}}-settings-content" aria-expanded="true" aria-controls="{{$g}}-settings-content">
 							{{$f.0}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="{{$g}}-settings-content" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{$g}}-settings-title">

--- a/view/theme/frio/templates/settings/profile/index.tpl
+++ b/view/theme/frio/templates/settings/profile/index.tpl
@@ -52,9 +52,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="personal">
 					<h2>
-						<a class="accordion-toggle" data-toggle="collapse" data-parent="#profile-edit-wrapper" href="#personal-collapse" aria-expanded="true" aria-controls="personal-collapse">
+						<button class="btn-link accordion-toggle" data-toggle="collapse" data-parent="#profile-edit-wrapper" href="#personal-collapse" aria-expanded="true" aria-controls="personal-collapse">
 							{{$lbl_personal_section}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				{{* for the $detailed_profile we use bootstraps collapsable panel-groups to have expandable groups *}}
@@ -78,9 +78,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="location">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#profile-edit-wrapper" href="#location-collapse" aria-expanded="false" aria-controls="location-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#profile-edit-wrapper" href="#location-collapse" aria-expanded="false" aria-controls="location-collapse">
 							{{$lbl_location_section}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="location-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="location">
@@ -118,9 +118,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="miscellaneous">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#profile-edit-wrapper" href="#miscellaneous-collapse" aria-expanded="false" aria-controls="miscellaneous-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#profile-edit-wrapper" href="#miscellaneous-collapse" aria-expanded="false" aria-controls="miscellaneous-collapse">
 							{{$lbl_miscellaneous_section}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="miscellaneous-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="miscellaneous">
@@ -145,9 +145,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="custom-fields">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#profile-edit-wrapper" href="#custom-fields-collapse" aria-expanded="false" aria-controls="custom-fields-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#profile-edit-wrapper" href="#custom-fields-collapse" aria-expanded="false" aria-controls="custom-fields-collapse">
 							{{$lbl_custom_fields_section}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="custom-fields-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="custom-fields">

--- a/view/theme/frio/templates/settings/settings.tpl
+++ b/view/theme/frio/templates/settings/settings.tpl
@@ -12,9 +12,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="password-settings">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#password-settings-collapse" aria-expanded="false" aria-controls="password-settings-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#password-settings-collapse" aria-expanded="false" aria-controls="password-settings-collapse">
 							{{$h_pass}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="password-settings-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="password-settings">
@@ -38,9 +38,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="basic-settings">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#basic-settings-collapse" aria-expanded="false" aria-controls="basic-settings-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#basic-settings-collapse" aria-expanded="false" aria-controls="basic-settings-collapse">
 							{{$h_basic}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="basic-settings-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="basic-settings">
@@ -63,9 +63,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="privacy-settings">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#privacy-settings-collapse" aria-expanded="false" aria-controls="privacy-settings-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#privacy-settings-collapse" aria-expanded="false" aria-controls="privacy-settings-collapse">
 							{{$h_prv}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="privacy-settings-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="privacy-settings">
@@ -102,9 +102,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="expire-settings">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#expire-settings-collapse" aria-expanded="false" aria-controls="expire-settings-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#expire-settings-collapse" aria-expanded="false" aria-controls="expire-settings-collapse">
 							{{$expire.label}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="expire-settings-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="expire-settings">
@@ -126,9 +126,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="notification-settings">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#notification-settings-collapse" aria-expanded="false" aria-controls="notification-settings-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#notification-settings-collapse" aria-expanded="false" aria-controls="notification-settings-collapse">
 							{{$h_not}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="notification-settings-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="notification-settings">
@@ -210,9 +210,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="additional-account-settings">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#additional-account-settings-collapse" aria-expanded="false" aria-controls="additional-account-settings-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#additional-account-settings-collapse" aria-expanded="false" aria-controls="additional-account-settings-collapse">
 							{{$h_advn}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="additional-account-settings-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="additional-account-settings">
@@ -231,9 +231,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="importcontact-settings">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#importcontact-settings-collapse" aria-expanded="false" aria-controls="importcontact-settings-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#importcontact-settings-collapse" aria-expanded="false" aria-controls="importcontact-settings-collapse">
 							{{$importcontact}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="importcontact-settings-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="importcontact-settings">
@@ -252,9 +252,9 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="relocate-settings">
 					<h2>
-						<a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#relocate-settings-collapse" aria-expanded="false" aria-controls="relocate-settings-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#relocate-settings-collapse" aria-expanded="false" aria-controls="relocate-settings-collapse">
 							{{$relocate}}
-						</a>
+						</button>
 					</h2>
 				</div>
 				<div id="relocate-settings-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="relocate-settings">


### PR DESCRIPTION
Closes #10978 

When you try to make something accessible, it benefits everyone, and this time was no different. While working on making the settings panel through the site keyboard actionable, I also improved the overall UX of the addons and connectors settings page.

Necessary addon pendant: https://github.com/friendica/friendica-addons/pull/1210