### PR TITLE
Improve connector hooks

### DIFF
--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -479,6 +479,17 @@ Hook data:
 - **uid** (input): the user to return the contact data for (can be empty for public contacts).
 - **result** (output): Leave null if address isn't relevant to the connector, set to contact array if probe is successful, false otherwise.
 
+### item_by_link
+
+Called when trying to probe an item from a given URI.
+If any registered hook function sets the `item_id` key of the hook data array, it will be returned immediately.
+Hook functions should also return immediately if the hook data contains an existing `item_id`.
+
+Hook data:
+- **uri** (input): the item URI.
+- **uid** (input): the user to return the item data for (can be empty for public contacts).
+- **item_id** (output): Leave null if URI isn't relevant to the connector, set to created item array if probe is successful, false otherwise.
+
 ### support_follow
 
 Called to assert whether a connector addon provides follow capabilities.

--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -477,7 +477,7 @@ Hook data:
 - **uri** (input): the profile URI.
 - **network** (input): the target network (can be empty for auto-detection).
 - **uid** (input): the user to return the contact data for (can be empty for public contacts).
-- **result** (output): Set by the hook function to indicate a successful detection.
+- **result** (output): Leave null if address isn't relevant to the connector, set to contact array if probe is successful, false otherwise.
 
 ### support_follow
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3262,6 +3262,18 @@ class Item
 			return $item_id;
 		}
 
+		$hookData = [
+			'uri'     => $uri,
+			'uid'     => $uid,
+			'item_id' => null,
+		];
+
+		Hook::callAll('item_by_link', $hookData);
+
+		if (isset($hookData['item_id'])) {
+			return is_numeric($hookData['item_id']) ? $hookData['item_id'] : 0;
+		}
+
 		if ($fetched_uri = ActivityPub\Processor::fetchMissingActivity($uri)) {
 			$item_id = self::searchByLink($fetched_uri, $uid);
 		} else {


### PR DESCRIPTION
Part of #11022 

- Remove Twitter probe from core
- Allow hook function to better abort the `probe_detect` process
- Add `item_by_link` hook to allow connectors to import remote posts

Related addon PR: https://github.com/friendica/friendica-addons/pull/1211