### PR TITLE
Add missing variable argument operator in BaseModule->t

### DIFF
--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -56,7 +56,7 @@ abstract class BaseModule implements ICanHandleRequests
 	 */
 	protected function t(string $s, ...$args): string
 	{
-		return $this->l10n->t($s, $args);
+		return $this->l10n->t($s, ...$args);
 	}
 
 	/**


### PR DESCRIPTION
Closes https://github.com/friendica/friendica/issues/11021
Address https://github.com/friendica/friendica/issues/10757#issuecomment-976235950
Address https://github.com/friendica/friendica/issues/10757#issuecomment-976236351
Address https://github.com/friendica/friendica/issues/10755#issuecomment-974624099

- This was causing to wrongly pass the variable arguments as an array of variable arguments to L10n->t