### PR TITLE
Fix remaining references to BaseModule->parameters

### DIFF
--- a/src/Module/Api/Friendica/Group/Delete.php
+++ b/src/Module/Api/Friendica/Group/Delete.php
@@ -70,7 +70,7 @@ class Delete extends BaseApi
 		if ($ret) {
 			// return success
 			$success = ['success' => $ret, 'gid' => $request['gid'], 'name' => $request['name'], 'status' => 'deleted', 'wrong users' => []];
-			$this->response->exit('group_delete', ['$result' => $success], $parameters['extension'] ?? null);
+			$this->response->exit('group_delete', ['$result' => $success], $this->parameters['extension'] ?? null);
 		} else {
 			throw new BadRequestException('other API error');
 		}

--- a/src/Module/Api/Friendica/Group/Update.php
+++ b/src/Module/Api/Friendica/Group/Update.php
@@ -84,6 +84,6 @@ class Update extends BaseApi
 		// return success message incl. missing users in array
 		$status  = ($erroraddinguser ? 'missing user' : 'ok');
 		$success = ['success' => true, 'gid' => $gid, 'name' => $name, 'status' => $status, 'wrong users' => $errorusers];
-		DI::apiResponse()->exit('group_update', ['$result' => $success], $parameters['extension'] ?? null);
+		DI::apiResponse()->exit('group_update', ['$result' => $success], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Contact/Profile.php
+++ b/src/Module/Contact/Profile.php
@@ -157,10 +157,10 @@ class Profile extends BaseModule
 			$this->baseUrl->redirect('profile/' . $contact['nick'] . '/profile');
 		}
 
-		if (isset($parameters['action'])) {
+		if (isset($this->parameters['action'])) {
 			self::checkFormSecurityTokenRedirectOnError('contact/' . $contact['id'], 'contact_action', 't');
 
-			$cmd = $parameters['action'];
+			$cmd = $this->parameters['action'];
 			if ($cmd === 'update' && $localRelationship->rel !== Contact::NOTHING) {
 				Module\Contact::updateContactFromPoll($contact['id']);
 			}


### PR DESCRIPTION
While investigating #11040 I found some remaining references to the removed `$parameters` module parameter that needed to be converted to references to `BaseModule->parameters`.

This allows to block a contact from the contact page again.

Maybe this is why your blocked list seemed shorter than you thought it would be @AlfredSK?