### PR TITLE
Fix URI structure condition in Probe::detect

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -44,6 +44,7 @@ use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
+use GuzzleHttp\Psr7\Uri;
 
 /**
  * This class contain functions for probing URL
@@ -58,26 +59,23 @@ class Probe
 	/**
 	 * Remove stuff from an URI that doesn't belong there
 	 *
-	 * @param string $URI
+	 * @param string $rawUri
 	 * @return string Cleaned URI
 	 */
-	public static function cleanURI(string $URI)
+	public static function cleanURI(string $rawUri): string
 	{
 		// At first remove leading and trailing junk
-		$URI = trim($URI, "@#?:/ \t\n\r\0\x0B");
+		$rawUri = trim($rawUri, "@#?:/ \t\n\r\0\x0B");
 
-		$parts = parse_url($URI);
-
-		if (empty($parts['scheme'])) {
-			return $URI;
+		$uri = new Uri($rawUri);
+		if (!$uri->getScheme()) {
+			return $uri->__toString();
 		}
 
 		// Remove the URL fragment, since these shouldn't be part of any profile URL
-		unset($parts['fragment']);
+		$uri = $uri->withFragment('');
 
-		$URI = Network::unparseURL($parts);
-
-		return $URI;
+		return $uri->__toString();
 	}
 
 	/**

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -686,20 +686,19 @@ class Probe
 		}
 
 		$parts = parse_url($uri);
-
-		if (empty($parts['scheme']) || !empty($parts['host']) && strstr($uri, '@')) {
-			// If the URI starts with "mailto:" then jump directly to the mail detection
-			if (strpos($uri, 'mailto:') !== false) {
-				$uri = str_replace('mailto:', '', $uri);
-				return self::mail($uri, $uid);
-			}
-
-			if ($network == Protocol::MAIL) {
-				return self::mail($uri, $uid);
-			}
-		} else {
+		if (empty($parts['scheme']) && empty($parts['host']) && !strstr($parts['path'], '@')) {
 			Logger::info('URI was not detectable', ['uri' => $uri]);
 			return [];
+		}
+
+		// If the URI starts with "mailto:" then jump directly to the mail detection
+		if (strpos($uri, 'mailto:') !== false) {
+			$uri = str_replace('mailto:', '', $uri);
+			return self::mail($uri, $uid);
+		}
+
+		if ($network == Protocol::MAIL) {
+			return self::mail($uri, $uid);
 		}
 
 		Logger::info('Probing start', ['uri' => $uri]);

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -435,7 +435,8 @@ class Network
 	 *
 	 * @param array $parsed URL parts
 	 *
-	 * @return string The glued URL
+	 * @return string The glued URL.
+	 * @deprecated since version 2021.12, use a UriInterface object like GuzzleHttp\Psr7\Uri instead
 	 */
 	public static function unparseURL(array $parsed)
 	{


### PR DESCRIPTION
Fix #11055 

Additionally, this PR deprecates `Network::unparseURL` since we now can do it with `Guzzle\Psr7\Uri`.