### PR TITLE
Replace references to UTC_TIMESTAMP()/NOW() in SQL queries with a DateTimeFormat generated parameter

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -604,7 +604,7 @@ function photos_post(App $a)
 	 * they acquire comments, likes, dislikes, and/or tags
 	 */
 
-	$r = Photo::selectToArray([], ['`album` = ? AND `uid` = ? AND `created` > UTC_TIMESTAMP() - INTERVAL 3 HOUR', $album, $page_owner_uid]);
+	$r = Photo::selectToArray([], ['`album` = ? AND `uid` = ? AND `created` > ?', $album, $page_owner_uid, DateTimeFormat::utc('now - 3 hours')]);
 
 	if (!DBA::isResult($r) || ($album == DI::l10n()->t(Photo::PROFILE_PHOTOS))) {
 		$visible = 1;

--- a/mod/wallmessage.php
+++ b/mod/wallmessage.php
@@ -27,6 +27,7 @@ use Friendica\DI;
 use Friendica\Model\Mail;
 use Friendica\Model\Profile;
 use Friendica\Model\User;
+use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
 
 function wallmessage_post(App $a) {
@@ -56,7 +57,7 @@ function wallmessage_post(App $a) {
 		return;
 	}
 
-	$total = DBA::count('mail', ["`uid` = ? AND `created` > UTC_TIMESTAMP() - INTERVAL 1 DAY AND `unknown`", $user['uid']]);
+	$total = DBA::count('mail', ["`uid` = ? AND `created` > ? AND `unknown`", $user['uid'], DateTimeFormat::utc('now - 1 day')]);
 	if ($total > $user['cntunkmail']) {
 		notice(DI::l10n()->t('Number of daily wall messages for %s exceeded. Message failed.', $user['username']));
 		return;
@@ -110,7 +111,7 @@ function wallmessage_content(App $a) {
 		return;
 	}
 
-	$total = DBA::count('mail', ["`uid` = ? AND `created` > UTC_TIMESTAMP() - INTERVAL 1 DAY AND `unknown`", $user['uid']]);
+	$total = DBA::count('mail', ["`uid` = ? AND `created` > ? AND `unknown`", $user['uid'], DateTimeFormat::utc('now - 1 day')]);
 	if ($total > $user['cntunkmail']) {
 		notice(DI::l10n()->t('Number of daily wall messages for %s exceeded. Message failed.', $user['username']));
 		return;

--- a/src/Core/Cache/Type/DatabaseCache.php
+++ b/src/Core/Cache/Type/DatabaseCache.php
@@ -146,7 +146,7 @@ class DatabaseCache extends AbstractCache implements ICanCache
 	{
 		try {
 			if ($outdated) {
-				return $this->dba->delete('cache', ['`expires` < NOW()']);
+				return $this->dba->delete('cache', ['`expires` < ?', DateTimeFormat::utcNow()]);
 			} else {
 				return $this->dba->delete('cache', ['`k` IS NOT NULL ']);
 			}

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -754,7 +754,7 @@ class Worker
 					}
 
 					$stamp = (float)microtime(true);
-					$jobs = DBA::count('workerqueue', ["`done` AND `executed` > UTC_TIMESTAMP() - INTERVAL ? MINUTE", $interval]);
+					$jobs = DBA::count('workerqueue', ["`done` AND `executed` > ?", DateTimeFormat::utc('now - ' . $interval . ' minute')]);
 					self::$db_duration += (microtime(true) - $stamp);
 					self::$db_duration_stat += (microtime(true) - $stamp);
 					$jobs_per_minute[$interval] = number_format($jobs / $interval, 0);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2258,8 +2258,8 @@ class Item
 			$condition[] = $network;
 		}
 
-		$condition[0] .= " AND `received` < UTC_TIMESTAMP() - INTERVAL ? DAY";
-		$condition[] = $days;
+		$condition[0] .= " AND `received` < ?";
+		$condition[] = DateTimeFormat::utc('now - ' . $days . ' day');
 
 		$items = Post::select(['resource-id', 'starred', 'id', 'post-type', 'uid', 'uri-id'], $condition);
 

--- a/src/Model/PushSubscriber.php
+++ b/src/Model/PushSubscriber.php
@@ -54,7 +54,7 @@ class PushSubscriber
 	{
 		// We'll push to each subscriber that has push > 0,
 		// i.e. there has been an update (set in notifier.php).
-		$subscribers = DBA::select('push_subscriber', ['id', 'push', 'callback_url', 'nickname'], ["`push` > 0 AND `next_try` < UTC_TIMESTAMP()"]);
+		$subscribers = DBA::select('push_subscriber', ['id', 'push', 'callback_url', 'nickname'], ["`push` > 0 AND `next_try` < ?", DateTimeFormat::utcNow()]);
 
 		while ($subscriber = DBA::fetch($subscribers)) {
 			// We always handle retries with low priority

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -29,6 +29,7 @@ use Friendica\Core\System;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
 
 /**
@@ -547,7 +548,7 @@ class Tag
 	{
 		// Get a uri-id that is at least X hours old.
 		// We use the uri-id in the query for the hash tags since this is much faster
-		$post = Post::selectFirstThread(['uri-id'], ["`uid` = ? AND `received` < UTC_TIMESTAMP() - INTERVAL ? HOUR", 0, $period],
+		$post = Post::selectFirstThread(['uri-id'], ["`uid` = ? AND `received` < ?", 0, DateTimeFormat::utc('now - ' . $period . ' hour')],
 			['order' => ['received' => true]]);
 		if (empty($post['uri-id'])) {
 			return [];
@@ -600,7 +601,7 @@ class Tag
 	{
 		// Get a uri-id that is at least X hours old.
 		// We use the uri-id in the query for the hash tags since this is much faster
-		$post = Post::selectFirstThread(['uri-id'], ["`uid` = ? AND `received` < UTC_TIMESTAMP() - INTERVAL ? HOUR", 0, $period],
+		$post = Post::selectFirstThread(['uri-id'], ["`uid` = ? AND `received` < ?", 0, DateTimeFormat::utc('now - ' . $period . ' hour')],
 			['order' => ['received' => true]]);
 		if (empty($post['uri-id'])) {
 			return [];

--- a/src/Module/Api/ApiResponse.php
+++ b/src/Module/Api/ApiResponse.php
@@ -103,7 +103,7 @@ class ApiResponse extends Response
 			'alternate'    => $user_info['url'],
 			'self'         => $this->baseUrl . '/' . $this->args->getQueryString(),
 			'base'         => $this->baseUrl,
-			'updated'      => DateTimeFormat::utc(null, DateTimeFormat::API),
+			'updated'      => DateTimeFormat::utcNow(DateTimeFormat::API),
 			'atom_updated' => DateTimeFormat::utcNow(DateTimeFormat::ATOM),
 			'language'     => $user_info['lang'],
 			'logo'         => $this->baseUrl . '/images/friendica-32.png',

--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -27,6 +27,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Module\BaseApi;
 use Friendica\Security\OAuth;
+use Friendica\Util\DateTimeFormat;
 
 /**
  * @see https://docs.joinmastodon.org/spec/oauth/
@@ -76,8 +77,8 @@ class Token extends BaseApi
 			$token = OAuth::createTokenForUser($application, 0, '');
 		} elseif ($request['grant_type'] == 'authorization_code') {
 			// For security reasons only allow freshly created tokens
-			$condition = ["`redirect_uri` = ? AND `id` = ? AND `code` = ? AND `created_at` > UTC_TIMESTAMP() - INTERVAL ? MINUTE",
-				$request['redirect_uri'], $application['id'], $request['code'], 5];
+			$condition = ["`redirect_uri` = ? AND `id` = ? AND `code` = ? AND `created_at` > ?",
+				$request['redirect_uri'], $application['id'], $request['code'], DateTimeFormat::utc('now - 5 minutes')];
 
 			$token = DBA::selectFirst('application-view', ['access_token', 'created_at'], $condition);
 			if (!DBA::isResult($token)) {

--- a/src/Security/OAuth.php
+++ b/src/Security/OAuth.php
@@ -176,7 +176,7 @@ class OAuth
 			'write'          => (stripos($scope, BaseApi::SCOPE_WRITE) !== false),
 			'follow'         => (stripos($scope, BaseApi::SCOPE_FOLLOW) !== false),
 			'push'           => (stripos($scope, BaseApi::SCOPE_PUSH) !== false),
-			'created_at'     => DateTimeFormat::utcNow(DateTimeFormat::MYSQL)];
+			'created_at'     => DateTimeFormat::utcNow()];
 
 		foreach ([BaseApi::SCOPE_READ, BaseApi::SCOPE_WRITE, BaseApi::SCOPE_WRITE, BaseApi::SCOPE_PUSH] as $scope) {
 			if ($fields[$scope] && !$application[$scope]) {

--- a/src/Util/DateTimeFormat.php
+++ b/src/Util/DateTimeFormat.php
@@ -52,7 +52,7 @@ class DateTimeFormat
 	 * @return string
 	 * @throws Exception
 	 */
-	public static function utc($time, $format = self::MYSQL)
+	public static function utc(string $time, string $format = self::MYSQL): string
 	{
 		return self::convert($time, 'UTC', 'UTC', $format);
 	}
@@ -102,7 +102,7 @@ class DateTimeFormat
 	 * @return string
 	 * @throws Exception
 	 */
-	public static function utcNow($format = self::MYSQL)
+	public static function utcNow(string $format = self::MYSQL): string
 	{
 		return self::utc('now', $format);
 	}

--- a/src/Worker/CleanWorkerQueue.php
+++ b/src/Worker/CleanWorkerQueue.php
@@ -24,6 +24,7 @@ namespace Friendica\Worker;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Util\DateTimeFormat;
 
 /**
  * Delete all done workerqueue entries
@@ -32,7 +33,7 @@ class CleanWorkerQueue
 {
 	public static function execute()
 	{
-		DBA::delete('workerqueue', ['`done` AND `executed` < UTC_TIMESTAMP() - INTERVAL 1 HOUR']);
+		DBA::delete('workerqueue', ["`done` AND `executed` < ?", DateTimeFormat::utc('now - 1 hour')]);
 
 		// Optimizing this table only last seconds
 		if (DI::config()->get('system', 'optimize_tables')) {

--- a/src/Worker/ClearCache.php
+++ b/src/Worker/ClearCache.php
@@ -23,6 +23,7 @@ namespace Friendica\Worker;
 
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Util\DateTimeFormat;
 
 /**
  * Clear cache entries
@@ -31,15 +32,13 @@ class ClearCache
 {
 	public static function execute()
 	{
-		$a = DI::app();
-
 		// clear old cache
 		DI::cache()->clear();
 
 		// Delete the cached OEmbed entries that are older than three month
-		DBA::delete('oembed', ["`created` < NOW() - INTERVAL 3 MONTH"]);
+		DBA::delete('oembed', ["`created` < ?", DateTimeFormat::utc('now - 3 months')]);
 
 		// Delete the cached "parsed_url" entries that are expired
-		DBA::delete('parsed_url', ["`expires` < NOW()"]);
+		DBA::delete('parsed_url', ["`expires` < ?", DateTimeFormat::utcNow()]);
 	}
 }

--- a/src/Worker/ExpireConversations.php
+++ b/src/Worker/ExpireConversations.php
@@ -23,6 +23,7 @@ namespace Friendica\Worker;
 
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Util\DateTimeFormat;
 
 class ExpireConversations
 {
@@ -36,6 +37,6 @@ class ExpireConversations
 			return;
 		}
 
-		DBA::delete('conversation', ["`received` < UTC_TIMESTAMP() - INTERVAL ? DAY", $days]);
+		DBA::delete('conversation', ["`received` < ?", DateTimeFormat::utc('now - ' . $days . ' days')]);
 	}
 }

--- a/src/Worker/PollContacts.php
+++ b/src/Worker/PollContacts.php
@@ -45,7 +45,7 @@ class PollContacts
 
 		if (!empty($abandon_days)) {
 			$condition = DBA::mergeConditions($condition,
-				["`uid` != ? AND `uid` IN (SELECT `uid` FROM `user` WHERE NOT `account_expired` AND NOT `account_removed`  AND `login_date` > UTC_TIMESTAMP() - INTERVAL ? DAY)", 0, $abandon_days]);
+				["`uid` != ? AND `uid` IN (SELECT `uid` FROM `user` WHERE NOT `account_expired` AND NOT `account_removed`  AND `login_date` > ?)", 0, DateTimeFormat::utc('now - ' . $abandon_days . ' days')]);
 		} else 	{
 			$condition = DBA::mergeConditions($condition,
 				["`uid` != ? AND `uid` IN (SELECT `uid` FROM `user` WHERE NOT `account_expired` AND NOT `account_removed`)", 0]);

--- a/src/Worker/RemoveUnusedContacts.php
+++ b/src/Worker/RemoveUnusedContacts.php
@@ -26,6 +26,7 @@ use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\Model\Photo;
+use Friendica\Util\DateTimeFormat;
 
 /**
  * Removes public contacts that aren't in use
@@ -35,13 +36,13 @@ class RemoveUnusedContacts
 	public static function execute()
 	{
 		$condition = ["`id` != ? AND `uid` = ? AND NOT `self` AND NOT `nurl` IN (SELECT `nurl` FROM `contact` WHERE `uid` != ?)
-			AND (NOT `network` IN (?, ?, ?, ?, ?, ?) OR (`archive` AND `success_update` < UTC_TIMESTAMP() - INTERVAL ? DAY))
+			AND (NOT `network` IN (?, ?, ?, ?, ?, ?) OR (`archive` AND `success_update` < ?))
 			AND NOT `id` IN (SELECT `author-id` FROM `post-user`) AND NOT `id` IN (SELECT `owner-id` FROM `post-user`)
 			AND NOT `id` IN (SELECT `causer-id` FROM `post-user`) AND NOT `id` IN (SELECT `cid` FROM `post-tag`)
 			AND NOT `id` IN (SELECT `contact-id` FROM `post-user`) AND NOT `id` IN (SELECT `cid` FROM `user-contact`)
 			AND NOT `id` IN (SELECT `cid` FROM `event`) AND NOT `id` IN (SELECT `contact-id` FROM `group_member`)
-			AND `created` < UTC_TIMESTAMP() - INTERVAL ? DAY",
-			0, 0, 0, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, Protocol::FEED, Protocol::MAIL, Protocol::ACTIVITYPUB, 365, 30];
+			AND `created` < ?",
+			0, 0, 0, Protocol::DFRN, Protocol::DIASPORA, Protocol::OSTATUS, Protocol::FEED, Protocol::MAIL, Protocol::ACTIVITYPUB, DateTimeFormat::utc('now - 365 days'), DateTimeFormat::utc('now - 30 days')];
 
 		$total = DBA::count('contact', $condition);
 		Logger::notice('Starting removal', ['total' => $total]);

--- a/src/Worker/UpdateGServers.php
+++ b/src/Worker/UpdateGServers.php
@@ -25,6 +25,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
 
 class UpdateGServers
@@ -47,7 +48,7 @@ class UpdateGServers
 		}
 
 		$total = DBA::count('gserver');
-		$condition = ["`next_contact` < UTC_TIMESTAMP() AND (`nurl` != ? OR `url` != ?)", '', ''];
+		$condition = ["`next_contact` < ? AND (`nurl` != ? OR `url` != ?)",  DateTimeFormat::utcNow(), '', ''];
 		$outdated = DBA::count('gserver', $condition);
 		Logger::info('Server status', ['total' => $total, 'outdated' => $outdated, 'updating' => $limit]);
 


### PR DESCRIPTION
Fixes #10955 

Add-on pendant: https://github.com/friendica/friendica-addons/pull/1216

All time checks with database records are now done on PHP time.