### PR TITLE
Suppress notice messages related to the VCard::getHTML call in mod/display

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -121,7 +121,7 @@ function display_fetchauthor($item)
 	$shared = Item::getShareArray($item);
 	if (!empty($shared) && empty($shared['comment'])) {
 		$profiledata = [
-			'uid' => -1,
+			'uid' => 0,
 			'id' => -1,
 			'nickname' => '',
 			'name' => '',

--- a/mod/display.php
+++ b/mod/display.php
@@ -40,7 +40,7 @@ use Friendica\Protocol\DFRN;
 function display_init(App $a)
 {
 	if (ActivityPub::isRequest()) {
-		(new Objects(DI::l10n(), ['guid' => DI::args()->getArgv()[1] ?? null]))->rawContent();
+		(new Objects(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), $_SERVER, ['guid' => DI::args()->getArgv()[1] ?? null]))->run();
 	}
 
 	if (DI::config()->get('system', 'block_public') && !Session::isAuthenticated()) {

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -75,7 +75,7 @@ class VCard
 				$pending = $pcontact['pending'] ?? false;
 			}
 
-			if (!$contact['self'] && Protocol::supportsFollow($contact['network'])) {
+			if (empty($contact['self']) && Protocol::supportsFollow($contact['network'])) {
 				if (in_array($rel, [Contact::SHARING, Contact::FRIEND])) {
 					$unfollow_link = 'unfollow?url=' . urlencode($contact['url']) . '&auto=1';
 				} elseif (!$pending) {


### PR DESCRIPTION
- Address https://soc.schuerz.at/display/4edd2508-6661-a8d1-f168-b2a245440386

Also the AP endpoint for items was unavailable because the instantiation of the API module object hadn't been updated to the new format.