### PR TITLE
Fix media handling upon creation and display

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2990,8 +2990,9 @@ class Item
 	private static function addLinkAttachment(int $uriid, array $attachments, string $body, string $content, bool $shared, array $ignore_links)
 	{
 		DI::profiler()->startRecording('rendering');
-		// @ToDo Check only for audio and video
-		$preview = empty($attachments['visual']);
+		// Don't show a preview when there is a visual attachment (audio or video)
+		$types = array_column($attachments['visual'], 'type');
+		$preview = !in_array(Post\Media::IMAGE, $types) && !in_array(Post\Media::VIDEO, $types);
 
 		if (!empty($attachments['link'])) {
 			foreach ($attachments['link'] as $link) {

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -525,6 +525,29 @@ class Feed
 					$taglist = $contact["fetch_further_information"] == 2 ? PageInfo::getTagsFromUrl($item["plink"], $preview, $contact["ffi_keyword_denylist"] ?? '') : [];
 					$item["object-type"] = Activity\ObjectType::BOOKMARK;
 					$attachments = [];
+
+					foreach (['audio', 'video'] as $elementname) {
+						if (!empty($data[$elementname])) {
+							foreach ($data[$elementname] as $element) {
+								if (!empty($element['src'])) {
+									$src = $element['src'];
+								} elseif (!empty($element['content'])) {
+									$src = $element['content'];
+								} else {
+									continue;
+								}
+
+								$attachments[] = [
+									'type'        => ($elementname == 'audio') ? Post\Media::AUDIO : Post\Media::VIDEO,
+									'url'         => $src,
+									'preview'     => $element['image']       ?? null,
+									'mimetype'    => $element['contenttype'] ?? null,
+									'name'        => $element['name']        ?? null,
+									'description' => $element['description'] ?? null,
+								];
+							}
+						}
+					}
 				}
 			} else {
 				if (!empty($summary)) {
@@ -541,7 +564,7 @@ class Feed
 				}
 
 				// Add the link to the original feed entry if not present in feed
-				if (($item['plink'] != '') && !strstr($item["body"], $item['plink'])) {
+				if (($item['plink'] != '') && !strstr($item["body"], $item['plink']) && !in_array($item['plink'], array_column($attachments, 'url'))) {
 					$item["body"] .= "[hr][url]" . $item['plink'] . "[/url]";
 				}
 			}


### PR DESCRIPTION
This fixes the problem that audio links hadn't been shown for podcast feeds. Also we now add media attachments when fetching more information upon feed creation.