### PR TITLE
Issue 11063: Fix check for current user

### DIFF
--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -88,7 +88,7 @@ class BaseApi extends BaseModule
 			case Router::PUT:
 				self::checkAllowedScope(self::SCOPE_WRITE);
 
-				if (!$this->app->isLoggedIn()) {
+				if (!self::getCurrentUserID()) {
 					throw new HTTPException\ForbiddenException($this->t('Permission denied.'));
 				}
 				break;


### PR DESCRIPTION
Fixes #11063. API users aren't logged in so we have to check differently if the access is allowed.