### PR TITLE
Fix attachment handling

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1293,7 +1293,7 @@ class Transmitter
 
 		$urls = [];
 		foreach ($uriids as $uriid) {
-			foreach (Post\Media::getByURIId($uriid, [Post\Media::DOCUMENT, Post\Media::TORRENT]) as $attachment) {
+			foreach (Post\Media::getByURIId($uriid, [Post\Media::AUDIO, Post\Media::IMAGE, Post\Media::VIDEO, Post\Media::DOCUMENT, Post\Media::TORRENT]) as $attachment) {
 				if (in_array($attachment['url'], $urls)) {
 					continue;
 				}
@@ -1318,52 +1318,6 @@ class Transmitter
 
 				$attachments[] = $attach;
 			}
-		}
-
-		if ($type != 'Note') {
-			return $attachments;
-		}
-
-		foreach ($uriids as $uriid) {
-			foreach (Post\Media::getByURIId($uriid, [Post\Media::AUDIO, Post\Media::IMAGE, Post\Media::VIDEO]) as $attachment) {
-				if (in_array($attachment['url'], $urls)) {
-					continue;
-				}
-				$urls[] = $attachment['url'];
-
-				$attach = ['type' => 'Document',
-					'mediaType' => $attachment['mimetype'],
-					'url' => $attachment['url'],
-					'name' => $attachment['description']];
-
-				if (!empty($attachment['height'])) {
-					$attach['height'] = $attachment['height'];
-				}
-
-				if (!empty($attachment['width'])) {
-					$attach['width'] = $attachment['width'];
-				}
-
-				if (!empty($attachment['preview'])) {
-					$attach['image'] = $attachment['preview'];
-				}
-
-				$attachments[] = $attach;
-			}
-			// Currently deactivated, since it creates side effects on Mastodon and Pleroma.
-			// It will be activated, once this cleared.
-			/*
-			foreach (Post\Media::getByURIId($uriid, [Post\Media::HTML]) as $attachment) {
-				if (in_array($attachment['url'], $urls)) {
-					continue;
-				}
-				$urls[] = $attachment['url'];
-
-				$attachments[] = ['type' => 'Page',
-					'mediaType' => $attachment['mimetype'],
-					'url' => $attachment['url'],
-					'name' => $attachment['description']];
-			}*/
 		}
 
 		return $attachments;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3411,7 +3411,7 @@ class Diaspora
 
 			$attachments = Post\Media::getByURIId($item['uri-id'], [Post\Media::DOCUMENT, Post\Media::TORRENT, Post\Media::UNKNOWN]);
 			if (!empty($attachments)) {
-				$body .= "\n".DI::l10n()->t("Attachments:")."\n";
+				$body .= "\n[hr]\n";
 				foreach ($attachments as $attachment) {
 					$body .= "[" . $attachment['description'] . "](" . $attachment['url'] . ")\n";
 				}

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -401,7 +401,16 @@ class Feed
 				}
 
 				if (!empty($href)) {
-					$attachments[] = ['type' => Post\Media::DOCUMENT, 'url' => $href, 'mimetype' => $type, 'size' => $length];
+					$attachment = ['type' => Post\Media::UNKNOWN, 'url' => $href, 'mimetype' => $type, 'size' => $length];
+
+					$attachment = Post\Media::fetchAdditionalData($attachment);
+
+					// By now we separate the visible media types (audio, video, image) from the rest
+					// In the future we should try to avoid the DOCUMENT type and only use the real one - but not in the RC phase.
+					if (!in_array($attachment['type'], [Post\Media::AUDIO, Post\Media::IMAGE, Post\Media::VIDEO])) {
+						$attachment['type'] = Post\Media::DOCUMENT;
+					}
+					$attachments[] = $attachment;
 				}
 			}
 

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -451,6 +451,12 @@ class ParseUrl
 					case 'og:site_name':
 						$siteinfo['publisher_name'] = trim($meta_tag['content']);
 						break;
+					case 'og:locale':
+						$siteinfo['language'] = trim($meta_tag['content']);
+						break;
+					case 'og:type':
+						$siteinfo['type'] = trim($meta_tag['content']);
+						break;
 					case 'twitter:description':
 						$siteinfo['text'] = trim($meta_tag['content']);
 						break;
@@ -521,7 +527,7 @@ class ParseUrl
 	 *
 	 * @param string $page_url
 	 * @param array $siteinfo
-	 * @return void
+	 * @return array
 	 */
 	private static function checkMedia(string $page_url, array $siteinfo) : array
 	{
@@ -965,6 +971,16 @@ class ParseUrl
 			if (!empty($content) && is_array($content)) {
 				$jsonldinfo['keywords'] = $content;
 			}
+		}
+
+		$content = JsonLD::fetchElement($jsonld, 'datePublished');
+		if (!empty($content) && is_string($content)) {
+			$jsonldinfo['published'] = DateTimeFormat::utc($content);
+		}
+
+		$content = JsonLD::fetchElement($jsonld, 'dateModified');
+		if (!empty($content) && is_string($content)) {
+			$jsonldinfo['modified'] = DateTimeFormat::utc($content);
 		}
 
 		$jsonldinfo = self::parseJsonLdAuthor($jsonldinfo, $jsonld);

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2021.12-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-07 16:06+0100\n"
+"POT-Creation-Date: 2021-12-08 13:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -8628,19 +8628,19 @@ msgstr ""
 
 #: src/Module/Profile/Profile.php:326 src/Module/Profile/Profile.php:329
 #: src/Module/Profile/Status.php:65 src/Module/Profile/Status.php:68
-#: src/Protocol/Feed.php:976 src/Protocol/OStatus.php:1242
+#: src/Protocol/Feed.php:985 src/Protocol/OStatus.php:1242
 #, php-format
 msgid "%s's timeline"
 msgstr ""
 
 #: src/Module/Profile/Profile.php:327 src/Module/Profile/Status.php:66
-#: src/Protocol/Feed.php:980 src/Protocol/OStatus.php:1246
+#: src/Protocol/Feed.php:989 src/Protocol/OStatus.php:1246
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
 #: src/Module/Profile/Profile.php:328 src/Module/Profile/Status.php:67
-#: src/Protocol/Feed.php:983 src/Protocol/OStatus.php:1249
+#: src/Protocol/Feed.php:992 src/Protocol/OStatus.php:1249
 #, php-format
 msgid "%s's comments"
 msgstr ""
@@ -10545,10 +10545,6 @@ msgstr ""
 
 #: src/Object/Post.php:544
 msgid "Show fewer"
-msgstr ""
-
-#: src/Protocol/Diaspora.php:3414
-msgid "Attachments:"
 msgstr ""
 
 #: src/Protocol/OStatus.php:1645


### PR DESCRIPTION
For historical reasons we hadn't transmitted several media types via AP when the post wasn't a note. This is fixed now. Also we falsely stored every attachment in feeds as "Document". Media attachments (audio, video, images) should be treated differently.