### PR TITLE
Fix for ParseUrl ('type' was already in use)

### DIFF
--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -455,7 +455,7 @@ class ParseUrl
 						$siteinfo['language'] = trim($meta_tag['content']);
 						break;
 					case 'og:type':
-						$siteinfo['type'] = trim($meta_tag['content']);
+						$siteinfo['pagetype'] = trim($meta_tag['content']);
 						break;
 					case 'twitter:description':
 						$siteinfo['text'] = trim($meta_tag['content']);


### PR DESCRIPTION
This is a quickfix to prevent not generating preview data