### PR TITLE
Add Dice logging for Module creation

### DIFF
--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -41,6 +41,7 @@ use Friendica\Network\HTTPException;
 use Friendica\Network\HTTPException\MethodNotAllowedException;
 use Friendica\Network\HTTPException\NoContentException;
 use Friendica\Network\HTTPException\NotFoundException;
+use Psr\Log\LoggerInterface;
 
 /**
  * Wrapper for FastRoute\Router
@@ -98,6 +99,12 @@ class Router
 	/** @var IManageConfigValues */
 	private $config;
 
+	/** @var LoggerInterface */
+	private $logger;
+
+	/** @var float */
+	private $dice_profiler_threshold;
+
 	/** @var Dice */
 	private $dice;
 
@@ -115,10 +122,11 @@ class Router
 	 * @param ICanLock            $lock
 	 * @param IManageConfigValues $config
 	 * @param Arguments           $args
+	 * @param LoggerInterface     $logger
 	 * @param Dice                $dice
 	 * @param RouteCollector|null $routeCollector
 	 */
-	public function __construct(array $server, string $baseRoutesFilepath, L10n $l10n, ICanCache $cache, ICanLock $lock, IManageConfigValues $config, Arguments $args, Dice $dice, RouteCollector $routeCollector = null)
+	public function __construct(array $server, string $baseRoutesFilepath, L10n $l10n, ICanCache $cache, ICanLock $lock, IManageConfigValues $config, Arguments $args, LoggerInterface $logger, Dice $dice, RouteCollector $routeCollector = null)
 	{
 		$this->baseRoutesFilepath = $baseRoutesFilepath;
 		$this->l10n = $l10n;
@@ -128,6 +136,8 @@ class Router
 		$this->config = $config;
 		$this->dice = $dice;
 		$this->server = $server;
+		$this->logger = $logger;
+		$this->dice_profiler_threshold = $config->get('system', 'dice_profiler_threshold', 0);
 
 		$httpMethod = $this->server['REQUEST_METHOD'] ?? self::GET;
 
@@ -323,8 +333,19 @@ class Router
 			$module_class = $module_class ?: PageNotFound::class;
 		}
 
-		/** @var ICanHandleRequests $module */
-		return $this->dice->create($module_class, $module_parameters);
+		$stamp = microtime(true);
+
+		try {
+			/** @var ICanHandleRequests $module */
+			return $this->dice->create($module_class, $module_parameters);
+		} finally {
+			if ($this->dice_profiler_threshold > 0) {
+				$dur = floatval(microtime(true) - $stamp);
+				if ($dur >= $this->dice_profiler_threshold) {
+					$this->logger->warning('Dice module creation lasts too long.', ['duration' => $dur, 'module' => $module_class, 'parameters' => $module_parameters]);
+				}
+			}
+		}
 	}
 
 	/**

--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -342,7 +342,7 @@ class Router
 			if ($this->dice_profiler_threshold > 0) {
 				$dur = floatval(microtime(true) - $stamp);
 				if ($dur >= $this->dice_profiler_threshold) {
-					$this->logger->warning('Dice module creation lasts too long.', ['duration' => $dur, 'module' => $module_class, 'parameters' => $module_parameters]);
+					$this->logger->warning('Dice module creation lasts too long.', ['duration' => round($dur, 3), 'module' => $module_class, 'parameters' => $module_parameters]);
 				}
 			}
 		}

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -202,6 +202,10 @@ return [
 		// Periodically delete waiting database processes.
 		'delete_sleeping_processes' => false,
 
+		// dice_profiler_threshold (Float)
+		// For profiling Dice class creation (0 = disabled, >0 = seconds threshold for profiling)
+		'dice_profiler_threshold' => 0.5,
+
 		// diaspora_test (Boolean)
 		// For development only. Disables the message transfer.
 		'diaspora_test' => false,


### PR DESCRIPTION
Addresses the problem at https://pirati.ca/display/ec054ce7-1961-b290-28b2-c73708494309

At least we can now detected DI-problems...  

Example:
```
2021-12-10T20:14:13Z index [WARNING]: Dice module creation lasts too long. {"duration":0.00031113624572753906,"module":"Friendica\\Module\\Conversation\\Network","parameters":[{"REDIRECT_REMOTE_USER":"","REDIRECT_STATUS":"200","HTTP_HOST":"friendica.local","HTTP_USER_AGENT":"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0","HTTP_ACCEPT":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8","HTTP_ACCEPT_LANGUAGE":"de,en-US;q=0.7,en;q=0.3","HTTP_ACCEPT_ENCODING":"gzip, deflate","HTTP_REFERER":"http://friendica.local/network","HTTP_DNT":"1","HTTP_CONNECTION":"keep-alive","HTTP_COOKIE":"XDEBUG_SESSION=XDEBUG_ECLIPSE; PHPSESSID=1usjplt8lnkgf6bmgjr0p6pcc5","HTTP_UPGRADE_INSECURE_REQUESTS":"1","HTTP_CACHE_CONTROL":"max-age=0","PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","SERVER_SIGNATURE":"<address>Apache/2.4.51 (Debian) Server at friendica.local Port 80</address>\n","SERVER_SOFTWARE":"Apache/2.4.51 (Debian)","SERVER_NAME":"friendica.local","SERVER_ADDR":"192.168.22.10","SERVER_PORT":"80","REMOTE_ADDR":"192.168.22.1","DOCUMENT_ROOT":"/var/www","REQUEST_SCHEME":"http","CONTEXT_PREFIX":"","CONTEXT_DOCUMENT_ROOT":"/var/www","SERVER_ADMIN":"webmaster@localhost","SCRIPT_FILENAME":"/var/www/index.php","REMOTE_PORT":"56932","REDIRECT_URL":"/network","REDIRECT_QUERY_STRING":"pagename=network","GATEWAY_INTERFACE":"CGI/1.1","SERVER_PROTOCOL":"HTTP/1.1","REQUEST_METHOD":"GET","QUERY_STRING":"pagename=network","REQUEST_URI":"/network","SCRIPT_NAME":"/index.php","PHP_SELF":"/index.php","REQUEST_TIME_FLOAT":1639167253.863551,"REQUEST_TIME":1639167253},[]]} - {"file":"Router.php","line":345,"function":"getModule","uid":"ca7d2b","process_id":6017}
```