### PR TITLE
Use 100% width for audio elements

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -666,3 +666,7 @@ body.dragging, body.dragging * {
 span.required {
 	color: #c80000;
 }
+
+audio {
+  width: 100%;
+}


### PR DESCRIPTION
It just looks better