### PR TITLE
Add own distribution cache for Sessions

### DIFF
--- a/src/Core/Cache/Factory/Cache.php
+++ b/src/Core/Cache/Factory/Cache.php
@@ -81,7 +81,7 @@ class Cache
 	}
 
 	/**
-	 * This method creates a CacheDriver for the given cache driver name
+	 * This method creates a CacheDriver for distributed caching with the given cache driver name
 	 *
 	 * @param string|null $type The cache type to create (default is per config)
 	 *
@@ -90,12 +90,42 @@ class Cache
 	 * @throws InvalidCacheDriverException In case the underlying cache driver isn't valid or not configured properly
 	 * @throws CachePersistenceException In case the underlying cache has errors during persistence
 	 */
-	public function create(string $type = null): ICanCache
+	public function createDistributed(string $type = null): ICanCache
 	{
-		if (empty($type)) {
-			$type = $this->config->get('system', 'cache_driver', self::DEFAULT_TYPE);
+		if ($type === Enum\Type::APCU) {
+			throw new InvalidCacheDriverException('apcu doesn\'t support distributed caching.');
 		}
 
+		return $this->create($type ?? $this->config->get('system', 'distributed_cache_driver', self::DEFAULT_TYPE));
+	}
+
+	/**
+	 * This method creates a CacheDriver for local caching with the given cache driver name
+	 *
+	 * @param string|null $type The cache type to create (default is per config)
+	 *
+	 * @return ICanCache  The instance of the CacheDriver
+	 *
+	 * @throws InvalidCacheDriverException In case the underlying cache driver isn't valid or not configured properly
+	 * @throws CachePersistenceException In case the underlying cache has errors during persistence
+	 */
+	public function createLocal(string $type = null): ICanCache
+	{
+		return $this->create($type ?? $this->config->get('system', 'cache_driver', self::DEFAULT_TYPE));
+	}
+
+	/**
+	 * Creates a new Cache instance
+	 *
+	 * @param string $type The type of cache
+	 *
+	 * @return ICanCache
+	 *
+	 * @throws InvalidCacheDriverException In case the underlying cache driver isn't valid or not configured properly
+	 * @throws CachePersistenceException In case the underlying cache has errors during persistence
+	 */
+	protected function create(string $type): ICanCache
+	{
 		switch ($type) {
 			case Enum\Type::MEMCACHE:
 				$cache = new Type\MemcacheCache($this->hostname, $this->config);

--- a/src/Core/Lock/Factory/Lock.php
+++ b/src/Core/Lock/Factory/Lock.php
@@ -82,22 +82,16 @@ class Lock
 				case Enum\Type::MEMCACHED:
 				case Enum\Type::REDIS:
 				case Enum\Type::APCU:
-					$cache = $this->cacheFactory->create($lock_type);
+					$cache = $this->cacheFactory->createLocal($lock_type);
 					if ($cache instanceof ICanCacheInMemory) {
 						return new Type\CacheLock($cache);
 					} else {
 						throw new \Exception(sprintf('Incompatible cache driver \'%s\' for lock used', $lock_type));
 					}
-					break;
-
 				case 'database':
 					return new Type\DatabaseLock($this->dba);
-					break;
-
 				case 'semaphore':
 					return new Type\SemaphoreLock();
-					break;
-
 				default:
 					return self::useAutoDriver();
 			}
@@ -132,7 +126,7 @@ class Lock
 		$cache_type = $this->config->get('system', 'cache_driver', 'database');
 		if ($cache_type != Enum\Type::DATABASE) {
 			try {
-				$cache = $this->cacheFactory->create($cache_type);
+				$cache = $this->cacheFactory->createLocal($cache_type);
 				if ($cache instanceof ICanCacheInMemory) {
 					return new Type\CacheLock($cache);
 				}

--- a/src/Core/Session/Factory/Session.php
+++ b/src/Core/Session/Factory/Session.php
@@ -22,8 +22,8 @@
 namespace Friendica\Core\Session\Factory;
 
 use Friendica\App;
-use Friendica\Core\Cache\Capability\ICanCache;
 use Friendica\Core\Cache\Enum;
+use Friendica\Core\Cache\Factory\Cache;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Session\Capability\IHandleSessions;
 use Friendica\Core\Session\Type;
@@ -51,14 +51,14 @@ class Session
 	 * @param App\BaseURL         $baseURL
 	 * @param IManageConfigValues $config
 	 * @param Database            $dba
-	 * @param ICanCache           $cache
+	 * @param Cache               $cacheFactory
 	 * @param LoggerInterface     $logger
 	 * @param Profiler            $profiler
 	 * @param array               $server
 	 *
 	 * @return IHandleSessions
 	 */
-	public function createSession(App\Mode $mode, App\BaseURL $baseURL, IManageConfigValues $config, Database $dba, ICanCache $cache, LoggerInterface $logger, Profiler $profiler, array $server = [])
+	public function createSession(App\Mode $mode, App\BaseURL $baseURL, IManageConfigValues $config, Database $dba, Cache $cacheFactory, LoggerInterface $logger, Profiler $profiler, array $server = [])
 	{
 		$profiler->startRecording('session');
 		$session = null;
@@ -75,6 +75,8 @@ class Session
 						$handler = new Handler\Database($dba, $logger, $server);
 						break;
 					case self::HANDLER_CACHE:
+						$cache = $cacheFactory->createDistributed();
+
 						// In case we're using the db as cache driver, use the native db session, not the cache
 						if ($config->get('system', 'cache_driver') === Enum\Type::DATABASE) {
 							$handler = new Handler\Database($dba, $logger, $server);

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -141,6 +141,10 @@ return [
 		// Whether to use Memcache, Memcached, Redis or APCu to store temporary cache.
 		'cache_driver' => 'database',
 
+		// distributed_cache_driver (database|memcache|memcached|redis)
+		// Whether to use database, Memcache, Memcached or Redis as a distributed cache.
+		'distributed_cache_driver' => 'database',
+
 		// config_adapter (jit|preload)
 		// Allow to switch the configuration adapter to improve performances at the cost of memory consumption.
 		'config_adapter' => 'jit',

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -160,13 +160,13 @@ return [
 	Cache\Capability\ICanCache::class => [
 		'instanceOf' => Cache\Factory\Cache::class,
 		'call'       => [
-			['create', [], Dice::CHAIN_CALL],
+			['createLocal', [], Dice::CHAIN_CALL],
 		],
 	],
 	Cache\Capability\ICanCacheInMemory::class => [
 		'instanceOf' => Cache\Factory\Cache::class,
 		'call'       => [
-			['create', [], Dice::CHAIN_CALL],
+			['createLocal', [], Dice::CHAIN_CALL],
 		],
 	],
 	Lock\Capability\ICanLock::class => [

--- a/static/env.config.php
+++ b/static/env.config.php
@@ -22,41 +22,42 @@
  */
 
 return [
-	'MYSQL_HOST' => ['database', 'hostname'],
+	'MYSQL_HOST'     => ['database', 'hostname'],
 	'MYSQL_USERNAME' => ['database', 'username'],
-	'MYSQL_USER' => ['database', 'username'],
-	'MYSQL_PORT' => ['database', 'port'],
+	'MYSQL_USER'     => ['database', 'username'],
+	'MYSQL_PORT'     => ['database', 'port'],
 	'MYSQL_PASSWORD' => ['database', 'password'],
 	'MYSQL_DATABASE' => ['database', 'database'],
 
 	// Core variables
 	'FRIENDICA_ADMIN_MAIL' => ['config', 'admin_email'],
-	'FRIENDICA_URL' => ['system', 'url'],
-	'FRIENDICA_TZ' => ['config', 'timezone'],
-	'FRIENDICA_LANG' => ['config', 'language'],
-	'FRIENDICA_SITENAME' => ['config', 'sitename'],
+	'FRIENDICA_URL'        => ['system', 'url'],
+	'FRIENDICA_TZ'         => ['config', 'timezone'],
+	'FRIENDICA_LANG'       => ['config', 'language'],
+	'FRIENDICA_SITENAME'   => ['config', 'sitename'],
 
 	// Storage
-	'FRIENDICA_DATA' => ['storage', 'name'],
+	'FRIENDICA_DATA'     => ['storage', 'name'],
 	'FRIENDICA_DATA_DIR' => ['storage', 'filesystem_path'],
 
 	// Debugging/Profiling
-	'FRIENDICA_DEBUGGING' => ['system', 'debugging'],
-	'FRIENDICA_LOGFILE' => ['system', 'logfile'],
-	'FRIENDICA_LOGLEVEL'=> ['system', 'loglevel'],
-	'FRIENDICA_PROFILING' => ['system', 'profiler'],
-	'FRIENDICA_LOGGER' => ['system', 'logger_config'],
-	'FRIENDICA_SYSLOG_FLAGS' => ['system', 'syslog_flags'],
+	'FRIENDICA_DEBUGGING'       => ['system', 'debugging'],
+	'FRIENDICA_LOGFILE'         => ['system', 'logfile'],
+	'FRIENDICA_LOGLEVEL'        => ['system', 'loglevel'],
+	'FRIENDICA_PROFILING'       => ['system', 'profiler'],
+	'FRIENDICA_LOGGER'          => ['system', 'logger_config'],
+	'FRIENDICA_SYSLOG_FLAGS'    => ['system', 'syslog_flags'],
 	'FRIENDICA_SYSLOG_FACILITY' => ['system', 'syslog_facility'],
 
 	// Caching
-	'FRIENDICA_CACHE_DRIVER' => ['system', 'cache_driver'],
-	'FRIENDICA_SESSION_HANDLER' => ['system', 'session_handler'],
-	'FRIENDICA_LOCK_DRIVER' => ['system', 'lock_driver'],
+	'FRIENDICA_CACHE_DRIVER'             => ['system', 'cache_driver'],
+	'FRIENDICA_SESSION_HANDLER'          => ['system', 'session_handler'],
+	'FRIENDICA_DISTRIBUTED_CACHE_DRIVER' => ['system', 'distributed_cache_driver'],
+	'FRIENDICA_LOCK_DRIVER'              => ['system', 'lock_driver'],
 
 	// Redis Config
 	'REDIS_HOST' => ['system', 'redis_host'],
 	'REDIS_PORT' => ['system', 'redis_port'],
-	'REDIS_PW' => ['system', 'redis_password'],
-	'REDIS_DB' => ['system', 'redis_db'],
+	'REDIS_PW'   => ['system', 'redis_password'],
+	'REDIS_DB'   => ['system', 'redis_db'],
 ];


### PR DESCRIPTION
This one was on my todo list for a looong time.

Currently, we reuse the same cache for "normal" content and for sessions as well.
For local caches, `apcu` is the most fast one, but it's not possible to use it as a distributed cache.

But for Sessions, we **need** a distributed cache, which stores the session data even in cases of restarts.

Tested this branch at https://friendica.philipp.info and finally, I don't loose my Sessions after each restart anymore :D