### PR TITLE
API: Fix for OAuth endpoints that mustn't be authorized

### DIFF
--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -37,6 +37,7 @@ class Apps extends BaseApi
 	{
 		return parent::run($request, false);
 	}
+
 	/**
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */

--- a/src/Module/OAuth/Acknowledge.php
+++ b/src/Module/OAuth/Acknowledge.php
@@ -24,12 +24,18 @@ namespace Friendica\Module\OAuth;
 use Friendica\Core\Renderer;
 use Friendica\DI;
 use Friendica\Module\BaseApi;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Acknowledgement of OAuth requests
  */
 class Acknowledge extends BaseApi
 {
+	public function run(array $request = [], bool $scopecheck = true): ResponseInterface
+	{
+		return parent::run($request, false);
+	}
+
 	protected function post(array $request = [])
 	{
 		DI::session()->set('oauth_acknowledge', true);

--- a/src/Module/OAuth/Revoke.php
+++ b/src/Module/OAuth/Revoke.php
@@ -26,12 +26,18 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Module\BaseApi;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @see https://docs.joinmastodon.org/spec/oauth/
  */
 class Revoke extends BaseApi
 {
+	public function run(array $request = [], bool $scopecheck = true): ResponseInterface
+	{
+		return parent::run($request, false);
+	}
+
 	protected function post(array $request = [])
 	{
 		$request = $this->getRequest([

--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -28,6 +28,7 @@ use Friendica\DI;
 use Friendica\Module\BaseApi;
 use Friendica\Security\OAuth;
 use Friendica\Util\DateTimeFormat;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @see https://docs.joinmastodon.org/spec/oauth/
@@ -35,6 +36,11 @@ use Friendica\Util\DateTimeFormat;
  */
 class Token extends BaseApi
 {
+	public function run(array $request = [], bool $scopecheck = true): ResponseInterface
+	{
+		return parent::run($request, false);
+	}
+
 	protected function post(array $request = [])
 	{
 		$request = $this->getRequest([


### PR DESCRIPTION
This is a follow up for the fix for issue #11101