### PR TITLE
Issue 11104: Don't execute the addons on Diaspora reshare

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -949,7 +949,9 @@ class Item
 			$item['parent'] = $parent_id;
 
 			// Trigger automatic reactions for addons
-			$item['api_source'] = true;
+			if (!isset($item['api_source'])) {
+				$item['api_source'] = true;
+			}
 
 			// We have to tell the hooks who we are - this really should be improved
 			if (!local_user()) {

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -4100,6 +4100,9 @@ class Diaspora
 			$item['private'] = Item::PUBLIC;
 		}
 
+		// Don't trigger the addons
+		$item['api_source'] = false;
+
 		return Item::insert($item, true);
 	}
 }


### PR DESCRIPTION
This fixes #11104