### PR TITLE
API: Set "dismissed" instead of "seen"

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2021.12-rc (Siberian Iris)
--- DB_UPDATE_VERSION 1446
+-- DB_UPDATE_VERSION 1447
 -- ------------------------------------------
 
 
@@ -824,7 +824,8 @@ CREATE TABLE IF NOT EXISTS `notification` (
 	`target-uri-id` int unsigned COMMENT 'Item-uri id of the related post',
 	`parent-uri-id` int unsigned COMMENT 'Item-uri id of the parent of the related post',
 	`created` datetime COMMENT '',
-	`seen` boolean DEFAULT '0' COMMENT '',
+	`seen` boolean DEFAULT '0' COMMENT 'Seen on the desktop',
+	`dismissed` boolean DEFAULT '0' COMMENT 'Dismissed via the API',
 	 PRIMARY KEY(`id`),
 	 UNIQUE INDEX `uid_vid_type_actor-id_target-uri-id` (`uid`,`vid`,`type`,`actor-id`,`target-uri-id`),
 	 INDEX `vid` (`vid`),

--- a/doc/database/db_notification.md
+++ b/doc/database/db_notification.md
@@ -16,7 +16,8 @@ Fields
 | target-uri-id | Item-uri id of the related post                                                | int unsigned       | YES  |     | NULL    |                |
 | parent-uri-id | Item-uri id of the parent of the related post                                  | int unsigned       | YES  |     | NULL    |                |
 | created       |                                                                                | datetime           | YES  |     | NULL    |                |
-| seen          |                                                                                | boolean            | YES  |     | 0       |                |
+| seen          | Seen on the desktop                                                            | boolean            | YES  |     | 0       |                |
+| dismissed     | Dismissed via the API                                                          | boolean            | YES  |     | 0       |                |
 
 Indexes
 ------------

--- a/include/api.php
+++ b/include/api.php
@@ -24,8 +24,6 @@
  */
 
 use Friendica\App;
-use Friendica\Content\Text\BBCode;
-use Friendica\Content\Text\HTML;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
@@ -33,7 +31,6 @@ use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
-use Friendica\Model\Mail;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
 use Friendica\Model\Profile;
@@ -45,7 +42,6 @@ use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Network\HTTPException\NotFoundException;
 use Friendica\Network\HTTPException\UnauthorizedException;
 use Friendica\Object\Image;
-use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
 use Friendica\Util\Strings;
 

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -68,7 +68,7 @@ class Notifications extends BaseApi
 
 		$params = ['order' => ['id' => true]];
 
-		$condition = ['uid' => $uid, 'seen' => false];
+		$condition = ['uid' => $uid, 'dismissed' => false];
 
 		if (!empty($request['account_id'])) {
 			$contact = Contact::getById($request['account_id'], ['url']);

--- a/src/Module/Api/Mastodon/Notifications/Clear.php
+++ b/src/Module/Api/Mastodon/Notifications/Clear.php
@@ -35,7 +35,7 @@ class Clear extends BaseApi
 		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
-		DI::notification()->setAllSeenForUser($uid);
+		DI::notification()->setAllDismissedForUser($uid);
 
 		System::jsonExit([]);
 	}

--- a/src/Module/Api/Mastodon/Notifications/Dismiss.php
+++ b/src/Module/Api/Mastodon/Notifications/Dismiss.php
@@ -42,7 +42,7 @@ class Dismiss extends BaseApi
 		}
 
 		$Notification = DI::notification()->selectOneForUser($uid, $this->parameters['id']);
-		$Notification->setSeen();
+		$Notification->setDismissed();
 		DI::notification()->save($Notification);
 
 		System::jsonExit([]);

--- a/src/Navigation/Notifications/Collection/Notifications.php
+++ b/src/Navigation/Notifications/Collection/Notifications.php
@@ -40,4 +40,11 @@ class Notifications extends BaseCollection
 			$Notification->setSeen();
 		});
 	}
+
+	public function setDismissed(): Notifications
+	{
+		return $this->map(function (Entity\Notification $Notification) {
+			$Notification->setDismissed();
+		});
+	}
 }

--- a/src/Navigation/Notifications/Entity/Notification.php
+++ b/src/Navigation/Notifications/Entity/Notification.php
@@ -39,6 +39,8 @@ class Notification extends BaseEntity
 	protected $created;
 	/** @var bool */
 	protected $seen;
+	/** @var bool */
+	protected $dismissed;
 
 	/**
 	 * Please do not use this constructor directly, instead use one of the method of the Notification factory.
@@ -52,9 +54,10 @@ class Notification extends BaseEntity
 	 * @param DateTime|null $created
 	 * @param bool          $seen
 	 * @param int|null      $id
+	 * @param bool          $dismissed
 	 * @see \Friendica\Navigation\Notifications\Factory\Notification
 	 */
-	public function __construct(int $uid, string $verb, int $type, int $actorId, int $targetUriId = null, int $parentUriId = null, DateTime $created = null, bool $seen = false, int $id = null)
+	public function __construct(int $uid, string $verb, int $type, int $actorId, int $targetUriId = null, int $parentUriId = null, DateTime $created = null, bool $seen = false, int $id = null, bool $dismissed = false)
 	{
 		$this->uid         = $uid;
 		$this->verb        = $verb;
@@ -65,10 +68,16 @@ class Notification extends BaseEntity
 		$this->created     = $created;
 		$this->seen        = $seen;
 		$this->id          = $id;
+		$this->dismissed   = $dismissed;
 	}
 
 	public function setSeen()
 	{
 		$this->seen = true;
+	}
+
+	public function setDismissed()
+	{
+		$this->dismissed = true;
 	}
 }

--- a/src/Navigation/Notifications/Repository/Notification.php
+++ b/src/Navigation/Notifications/Repository/Notification.php
@@ -110,6 +110,13 @@ class Notification extends BaseRepository
 		return $this->db->update(self::$table_name, ['seen' => true], $condition);
 	}
 
+	public function setAllDismissedForUser(int $uid, array $condition = []): bool
+	{
+		$condition = DBA::mergeConditions($condition, ['uid' => $uid]);
+
+		return $this->db->update(self::$table_name, ['dismissed' => true], $condition);
+	}
+
 	/**
 	 * @param Entity\Notification $Notification
 	 * @return Entity\Notification
@@ -125,6 +132,7 @@ class Notification extends BaseRepository
 			'target-uri-id' => $Notification->targetUriId,
 			'parent-uri-id' => $Notification->parentUriId,
 			'seen'          => $Notification->seen,
+			'dismissed'     => $Notification->dismissed,
 		];
 
 		if ($Notification->id) {

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1446);
+	define('DB_UPDATE_VERSION', 1447);
 }
 
 return [
@@ -880,7 +880,8 @@ return [
 			"target-uri-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Item-uri id of the related post"],
 			"parent-uri-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Item-uri id of the parent of the related post"],
 			"created" => ["type" => "datetime", "comment" => ""],
-			"seen" => ["type" => "boolean", "default" => "0", "comment" => ""],
+			"seen" => ["type" => "boolean", "default" => "0", "comment" => "Seen on the desktop"],
+			"dismissed" => ["type" => "boolean", "default" => "0", "comment" => "Dismissed via the API"],
 		],
 		"indexes" => [
 			"PRIMARY" => ["id"],


### PR DESCRIPTION
By now we only displayed notifications via API that hadn't been seen on the frontend.