### PR TITLE
Add native language names to language selector & fix config during install

### DIFF
--- a/src/Core/Config/Repository/Config.php
+++ b/src/Core/Config/Repository/Config.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Core\Config\Repository;
 
+use Friendica\App\Mode;
 use Friendica\Core\Config\Exception\ConfigPersistenceException;
 use Friendica\Core\Config\Util\ValueConversion;
 use Friendica\Database\Database;
@@ -32,10 +33,13 @@ class Config
 {
 	/** @var Database */
 	protected $db;
+	/** @var Mode */
+	protected $mode;
 
-	public function __construct(Database $db)
+	public function __construct(Database $db, Mode $mode)
 	{
-		$this->db = $db;
+		$this->db   = $db;
+		$this->mode = $mode;
 	}
 
 	protected static $table_name = 'config';
@@ -47,7 +51,7 @@ class Config
 	 */
 	public function isConnected(): bool
 	{
-		return $this->db->isConnected();
+		return $this->db->isConnected() && !$this->mode->isInstall();
 	}
 
 	/**

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -25,7 +25,6 @@ use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Session\Capability\IHandleSessions;
 use Friendica\Database\Database;
 use Friendica\Util\Strings;
-use Psr\Log\LoggerInterface;
 
 /**
  * Provide Language, Translation, and Localization functions to the application
@@ -85,15 +84,9 @@ class L10n
 	 */
 	private $dba;
 
-	/**
-	 * @var LoggerInterface
-	 */
-	private $logger;
-
-	public function __construct(IManageConfigValues $config, Database $dba, LoggerInterface $logger, IHandleSessions $session, array $server, array $get)
+	public function __construct(IManageConfigValues $config, Database $dba, IHandleSessions $session, array $server, array $get)
 	{
 		$this->dba    = $dba;
-		$this->logger = $logger;
 
 		$this->loadTranslationTable(L10n::detectLanguage($server, $get, $config->get('system', 'language', self::DEFAULT)));
 		$this->setSessionVariable($session);

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -35,6 +35,34 @@ class L10n
 {
 	/** @var string The default language */
 	const DEFAULT = 'en';
+	/** @var string[] The language names in their language */
+	const LANG_NAMES = [
+		'ar'    => 'العربية',
+		'bg'    => 'Български',
+		'ca'    => 'Català',
+		'cs'    => 'Česky',
+		'de'    => 'Deutsch',
+		'en-gb' => 'English (United Kingdom)',
+		'en-us' => 'English (United States)',
+		'en'    => 'English (Default)',
+		'eo'    => 'Esperanto',
+		'es'    => 'Español',
+		'et'    => 'Eesti',
+		'fi-fi' => 'Suomi',
+		'fr'    => 'Français',
+		'hu'    => 'Magyar',
+		'is'    => 'Íslenska',
+		'it'    => 'Italiano',
+		'ja'    => '日本語',
+		'nb-no' => 'Norsk bokmål',
+		'nl'    => 'Nederlands',
+		'pl'    => 'Polski',
+		'pt-br' => 'Português Brasileiro',
+		'ro'    => 'Română',
+		'ru'    => 'Русский',
+		'sv'    => 'Svenska',
+		'zh-cn' => '简体中文',
+	];
 
 	/**
 	 * A string indicating the current language used for translation:
@@ -351,33 +379,6 @@ class L10n
 	{
 		$langs              = [];
 		$strings_file_paths = glob('view/lang/*/strings.php');
-		$lang_names = [
-			'ar'    => 'العربية',
-			'bg'    => 'Български',
-			'ca'    => 'Català',
-			'cs'    => 'Česky',
-			'de'    => 'Deutsch',
-			'en-gb' => 'English (United Kingdom)',
-			'en-us' => 'English (United States)',
-			'en'    => 'English (Default)',
-			'eo'    => 'Esperanto',
-			'es'    => 'Español',
-			'et'    => 'Eesti',
-			'fi-fi' => 'Suomi',
-			'fr'    => 'Français',
-			'hu'    => 'Magyar',
-			'is'    => 'Íslenska',
-			'it'    => 'Italiano',
-			'ja'    => '日本語',
-			'nb-no' => 'Norsk bokmål',
-			'nl'    => 'Nederlands',
-			'pl'    => 'Polski',
-			'pt-br' => 'Português Brasileiro',
-			'ro'    => 'Română',
-			'ru'    => 'Русский',
-			'sv'    => 'Svenska',
-			'zh-cn' => '简体中文',
-		];
 
 		if (is_array($strings_file_paths) && count($strings_file_paths)) {
 			if (!in_array('view/lang/en/strings.php', $strings_file_paths)) {
@@ -386,7 +387,7 @@ class L10n
 			asort($strings_file_paths);
 			foreach ($strings_file_paths as $strings_file_path) {
 				$path_array            = explode('/', $strings_file_path);
-				$langs[$path_array[2]] = isset($lang_names[$path_array[2]]) ? $lang_names[$path_array[2]] : $path_array[2];
+				$langs[$path_array[2]] = self::LANG_NAMES[$path_array[2]] ?? $path_array[2];
 			}
 		}
 		return $langs;

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -340,9 +340,10 @@ class L10n
 	 *
 	 * Scans the view/lang directory for the existence of "strings.php" files, and
 	 * returns an alphabetical list of their folder names (@-char language codes).
-	 * Adds the english language if it's missing from the list.
+	 * Adds the english language if it's missing from the list. Folder names are
+	 * replaced by nativ language names.
 	 *
-	 * Ex: array('de' => 'de', 'en' => 'en', 'fr' => 'fr', ...)
+	 * Ex: array('de' => 'Deutsch', 'en' => 'English', 'fr' => 'Français', ...)
 	 *
 	 * @return array
 	 */
@@ -350,6 +351,33 @@ class L10n
 	{
 		$langs              = [];
 		$strings_file_paths = glob('view/lang/*/strings.php');
+		$lang_names = [
+			'ar'    => 'العربية',
+			'bg'    => 'Български',
+			'ca'    => 'Català',
+			'cs'    => 'Česky',
+			'de'    => 'Deutsch',
+			'en-gb' => 'English (United Kingdom)',
+			'en-us' => 'English (United States)',
+			'en'    => 'English (Default)',
+			'eo'    => 'Esperanto',
+			'es'    => 'Español',
+			'et'    => 'Eesti',
+			'fi-fi' => 'Suomi',
+			'fr'    => 'Français',
+			'hu'    => 'Magyar',
+			'is'    => 'Íslenska',
+			'it'    => 'Italiano',
+			'ja'    => '日本語',
+			'nb-no' => 'Norsk bokmål',
+			'nl'    => 'Nederlands',
+			'pl'    => 'Polski',
+			'pt-br' => 'Português Brasileiro',
+			'ro'    => 'Română',
+			'ru'    => 'Русский',
+			'sv'    => 'Svenska',
+			'zh-cn' => '简体中文',
+		];
 
 		if (is_array($strings_file_paths) && count($strings_file_paths)) {
 			if (!in_array('view/lang/en/strings.php', $strings_file_paths)) {
@@ -358,7 +386,7 @@ class L10n
 			asort($strings_file_paths);
 			foreach ($strings_file_paths as $strings_file_path) {
 				$path_array            = explode('/', $strings_file_path);
-				$langs[$path_array[2]] = $path_array[2];
+				$langs[$path_array[2]] = isset($lang_names[$path_array[2]]) ? $lang_names[$path_array[2]] : $path_array[2];
 			}
 		}
 		return $langs;

--- a/src/Core/PConfig/Repository/PConfig.php
+++ b/src/Core/PConfig/Repository/PConfig.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Core\PConfig\Repository;
 
+use Friendica\App\Mode;
 use Friendica\Core\Config\Util\ValueConversion;
 use Friendica\Core\PConfig\Exception\PConfigPersistenceException;
 use Friendica\Database\Database;
@@ -34,10 +35,13 @@ class PConfig
 
 	/** @var Database */
 	protected $db;
+	/** @var Mode */
+	protected $mode;
 
-	public function __construct(Database $db)
+	public function __construct(Database $db, Mode $mode)
 	{
-		$this->db = $db;
+		$this->db   = $db;
+		$this->mode = $mode;
 	}
 
 	/**
@@ -47,7 +51,7 @@ class PConfig
 	 */
 	public function isConnected(): bool
 	{
-		return $this->db->isConnected();
+		return $this->db->isConnected() & !$this->mode->isInstall();
 	}
 
 	/**

--- a/tests/src/Core/Storage/Repository/StorageManagerTest.php
+++ b/tests/src/Core/Storage/Repository/StorageManagerTest.php
@@ -22,6 +22,7 @@
 namespace Friendica\Test\src\Core\Storage\Repository;
 
 use Dice\Dice;
+use Friendica\App\Mode;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Config\Type\PreloadConfig;
 use Friendica\Core\Hook;
@@ -86,7 +87,7 @@ class StorageManagerTest extends DatabaseTest
 
 		$this->dba = new StaticDatabase($configCache, $profiler, $this->logger);
 
-		$configModel  = new Repository\Config($this->dba);
+		$configModel  = new Repository\Config($this->dba, new Mode(Mode::DBCONFIGAVAILABLE));
 		$this->config = new PreloadConfig($configCache, $configModel);
 		$this->config->set('storage', 'name', 'Database');
 		$this->config->set('storage', 'filesystem_path', $this->root->getChild(Type\FilesystemConfig::DEFAULT_BASE_FOLDER)->url());


### PR DESCRIPTION
This is an idea how to improve the language selector fields. Now the drop-down fields contain native language names instead of language codes.

I tested this only in Profile -> Settings -> Account Settings -> Basic Settings and it works fine. However, this function is used in other parts of the framework. Please make sure before merging that this patch will not break anything.