### PR TITLE
Bump smarty/smarty from 3.1.40 to 3.1.43

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3647,16 +3647,16 @@
         },
         {
             "name": "smarty/smarty",
-            "version": "v3.1.40",
+            "version": "v3.1.43",
             "source": {
                 "type": "git",
                 "url": "https://github.com/smarty-php/smarty.git",
-                "reference": "9d4f8309ed49702e0d7152f9983c3a9c4b98eb9d"
+                "reference": "273f7e00fec034f6d61112552e9caf08d19565b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/9d4f8309ed49702e0d7152f9983c3a9c4b98eb9d",
-                "reference": "9d4f8309ed49702e0d7152f9983c3a9c4b98eb9d",
+                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/273f7e00fec034f6d61112552e9caf08d19565b7",
+                "reference": "273f7e00fec034f6d61112552e9caf08d19565b7",
                 "shasum": ""
             },
             "require": {
@@ -3700,7 +3700,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2021-10-13T10:04:31+00:00"
+            "time": "2022-01-10T09:52:40+00:00"
         },
         {
             "name": "spomky-labs/base64url",


### PR DESCRIPTION
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/smarty-php/smarty/blob/v3.1.43/CHANGELOG.md">smarty/smarty's changelog</a>.</em></p>
<blockquote>
<h2>[3.1.43] - 2022-01-10</h2>
<h3>Security</h3>
<ul>
<li>Prevent evasion of the <code>static_classes</code> security policy. This addresses CVE-2021-21408</li>
</ul>
<h2>[3.1.42] - 2022-01-10</h2>
<h3>Security</h3>
<ul>
<li>Prevent arbitrary PHP code execution through maliciously crafted expression for the math function. This addresses CVE-2021-29454</li>
</ul>
<h2>[3.1.41] - 2022-01-09</h2>
<h3>Security</h3>
<ul>
<li>Rewrote the mailto function to not use <code>eval</code> when encoding with javascript</li>
</ul>
<h2>[3.1.40] - 2021-10-13</h2>
<h3>Changed</h3>
<ul>
<li>modifier escape now triggers a E_USER_NOTICE when an unsupported escape type is used <a href="https://github-redirect.dependabot.com/smarty-php/smarty/pull/649">smarty-php/smarty#649</a></li>
</ul>
<h3>Security</h3>
<ul>
<li>More advanced javascript escaping to handle <a href="https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements">https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements</a> thanks to m-haritonov</li>
</ul>
</blockquote>

See https://github.com/nupplaphil/friendica/pull/4 for more details
