### PR TITLE
Fix wrong default value in Module\Api\Friendica\Photo\Create::post

### DIFF
--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -973,10 +973,17 @@ class Photo
 	}
 
 	/**
-	 *
-	 * @param int   $uid   User ID
-	 * @param array $files uploaded file array
+	 * @param int         $uid   User ID
+	 * @param array       $files uploaded file array
+	 * @param string      $album
+	 * @param string|null $allow_cid
+	 * @param string|null $allow_gid
+	 * @param string      $deny_cid
+	 * @param string      $deny_gid
+	 * @param string      $desc
+	 * @param string      $resource_id
 	 * @return array photo record
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public static function upload(int $uid, array $files, string $album = '', string $allow_cid = null, string $allow_gid = null, string $deny_cid = '', string $deny_gid = '', string $desc = '', string $resource_id = ''): array
 	{

--- a/src/Module/Api/Friendica/Photo/Create.php
+++ b/src/Module/Api/Friendica/Photo/Create.php
@@ -55,7 +55,7 @@ class Create extends BaseApi
 		$type = $this->getRequestValue($this->parameters, 'extension', 'json');
 
 		// input params
-		$desc      = $this->getRequestValue($request, 'desc');
+		$desc      = $this->getRequestValue($request, 'desc') ?? '';
 		$album     = $this->getRequestValue($request, 'album');
 		$allow_cid = $this->getRequestValue($request, 'allow_cid');
 		$deny_cid  = $this->getRequestValue($request, 'deny_cid');


### PR DESCRIPTION
Fix #11163 

- The underlying Model\Photo::upload doesn't accept a null value for description