### PR TITLE
Handle null value for last_used fields in TrustedBrowsers and AppSpecificPassword

### DIFF
--- a/src/Module/Settings/TwoFactor/Trusted.php
+++ b/src/Module/Settings/TwoFactor/Trusted.php
@@ -107,12 +107,12 @@ class Trusted extends BaseSettings
 
 		$trustedBrowserDisplay = array_map(function (TwoFactor\Model\TrustedBrowser $trustedBrowser) use ($parser) {
 			$dates = [
-				'created_ago' => Temporal::getRelativeDate($trustedBrowser->created),
-				'created_utc' => DateTimeFormat::utc($trustedBrowser->created, 'c'),
-				'created_local' => DateTimeFormat::local($trustedBrowser->created, 'r'),
-				'last_used_ago' => Temporal::getRelativeDate($trustedBrowser->last_used),
-				'last_used_utc' => DateTimeFormat::utc($trustedBrowser->last_used, 'c'),
-				'last_used_local' => DateTimeFormat::local($trustedBrowser->last_used, 'r'),
+				'created_ago'     => Temporal::getRelativeDate($trustedBrowser->created),
+				'created_utc'     => DateTimeFormat::utc($trustedBrowser->created, 'c'),
+				'created_local'   => DateTimeFormat::local($trustedBrowser->created, 'r'),
+				'last_used_ago'   => Temporal::getRelativeDate($trustedBrowser->last_used),
+				'last_used_utc'   => $trustedBrowser->last_used ? DateTimeFormat::utc($trustedBrowser->last_used, 'c') : '',
+				'last_used_local' => $trustedBrowser->last_used ? DateTimeFormat::local($trustedBrowser->last_used, 'r') : '',
 			];
 
 			$result = $parser->parse($trustedBrowser->user_agent);

--- a/src/Security/TwoFactor/Model/AppSpecificPassword.php
+++ b/src/Security/TwoFactor/Model/AppSpecificPassword.php
@@ -86,11 +86,9 @@ class AppSpecificPassword
 		$appSpecificPasswords = DBA::toArray($appSpecificPasswordsStmt);
 
 		array_walk($appSpecificPasswords, function (&$value) {
-			$last_used = $value['last_used'] ?? DBA::NULL_DATETIME;
-
-			$value['ago'] = Temporal::getRelativeDate($last_used);
-			$value['utc'] = DateTimeFormat::utc($last_used, 'c');
-			$value['local'] = DateTimeFormat::local($last_used, 'r');
+			$value['ago']   = Temporal::getRelativeDate($value['last_used']);
+			$value['utc']   = $value['last_used'] ? DateTimeFormat::utc($value['last_used'], 'c') : '';
+			$value['local'] = $value['last_used'] ? DateTimeFormat::local($value['last_used'], 'r') : '';
 		});
 
 		return $appSpecificPasswords;


### PR DESCRIPTION
- Remove obsolete reference to DBA::NULL_DATETIME

Fix #11169 
Supersedes #11172