### PR TITLE
Improve contact search speed / assume octet-stream on missing content type

### DIFF
--- a/src/Module/Search/Acl.php
+++ b/src/Module/Search/Acl.php
@@ -110,7 +110,7 @@ class Acl extends BaseModule
 			$search = $_REQUEST['query'];
 		}
 
-		Logger::info('ACL {action} - {subaction}', ['module' => 'acl', 'action' => 'content', 'subaction' => 'search', 'search' => $search, 'type' => $type, 'conversation' => $conv_id]);
+		Logger::info('ACL {action} - {subaction} - start', ['module' => 'acl', 'action' => 'content', 'subaction' => 'search', 'search' => $search, 'type' => $type, 'conversation' => $conv_id]);
 
 		$sql_extra = '';
 		$condition       = ["`uid` = ? AND NOT `deleted` AND NOT `pending` AND NOT `archive`", local_user()];
@@ -207,7 +207,7 @@ class Acl extends BaseModule
 			foreach ($r as $g) {
 				$entry = [
 					'type'    => 'c',
-					'photo'   => Contact::getMicro($g),
+					'photo'   => Contact::getMicro($g, true),
 					'name'    => htmlspecialchars($g['name']),
 					'id'      => intval($g['id']),
 					'network' => $g['network'],
@@ -268,7 +268,7 @@ class Acl extends BaseModule
 				if (count($contact) > 0) {
 					$unknown_contacts[] = [
 						'type'    => 'c',
-						'photo'   => Contact::getMicro($contact),
+						'photo'   => Contact::getMicro($contact, true),
 						'name'    => htmlspecialchars($contact['name']),
 						'id'      => intval($contact['id']),
 						'network' => $contact['network'],
@@ -304,6 +304,7 @@ class Acl extends BaseModule
 			'items' => $results['items'],
 		];
 
+		Logger::info('ACL {action} - {subaction} - done', ['module' => 'acl', 'action' => 'content', 'subaction' => 'search', 'search' => $search, 'type' => $type, 'conversation' => $conv_id]);
 		return $o;
 	}
 }

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -72,7 +72,7 @@ class ParseUrl
 
 		$contenttype =  $curlResult->getHeader('Content-Type')[0] ?? '';
 		if (empty($contenttype)) {
-			return [];
+			return ['application', 'octet-stream'];
 		}
 
 		return explode('/', current(explode(';', $contenttype)));


### PR DESCRIPTION
This PR handles two different issues. The contact search in the composer had been really slow under cterain condition. This was caused by the contact update that's periodically executed when fetching contact data. This is now deactivated at this place.

And the second issue has to do with fetching avatar pictures when the remote server is responding but doesn't provide a content type. We now just assume "octect-stream" under this circumstances.