### PR TITLE
Issue 10966: Perform forum handling with the unified format

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -422,7 +422,7 @@ function item_post(App $a) {
 
 		// Search for forum mentions
 		if (!$toplevel_item_id) {
-			foreach (Tag::getFromBody($body) as $tag) {
+			foreach (Tag::getFromBody($body, Tag::TAG_CHARACTER[Tag::MENTION] . Tag::TAG_CHARACTER[Tag::EXCLUSIVE_MENTION]) as $tag) {
 				$contact = Contact::getByURL($tag[2], false, [], $profile_uid);
 				if ($contact['contact-type'] != Contact::TYPE_COMMUNITY) {
 					continue;

--- a/mod/item.php
+++ b/mod/item.php
@@ -398,13 +398,13 @@ function item_post(App $a) {
 
 		// Search for forum mentions
 		foreach (Tag::getFromBody($body, Tag::TAG_CHARACTER[Tag::MENTION] . Tag::TAG_CHARACTER[Tag::EXCLUSIVE_MENTION]) as $tag) {
-			$contact = Contact::getByURL($tag[2], false, [], $profile_uid);
+			$contact = Contact::getByURLForUser($tag[2], $profile_uid);
 			if (!empty($inform)) {
 				$inform .= ',';
 			}
 			$inform .= 'cid:' . $contact['id'];
 
-			if (!$toplevel_item_id || ($contact['contact-type'] != Contact::TYPE_COMMUNITY)) {
+			if (!$toplevel_item_id || empty($contact['cid']) || ($contact['contact-type'] != Contact::TYPE_COMMUNITY)) {
 				continue;
 			}
 

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -135,7 +135,6 @@ class Item
 	 * the appropriate link.
 	 *
 	 * @param string  $body        the text to replace the tag in
-	 * @param string  $inform      a comma-seperated string containing everybody to inform
 	 * @param integer $profile_uid the user id to replace the tag for (0 = anyone)
 	 * @param string  $tag         the tag to replace
 	 * @param string  $network     The network of the post
@@ -144,7 +143,7 @@ class Item
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function replaceTag(&$body, &$inform, $profile_uid, $tag, $network = '')
+	public static function replaceTag(&$body, $profile_uid, $tag, $network = '')
 	{
 		$replaced = false;
 
@@ -218,16 +217,6 @@ class Item
 
 			// Check if $contact has been successfully loaded
 			if (DBA::isResult($contact)) {
-				if (strlen($inform) && (isset($contact['notify']) || isset($contact['id']))) {
-					$inform .= ',';
-				}
-
-				if (isset($contact['id'])) {
-					$inform .= 'cid:' . $contact['id'];
-				} elseif (isset($contact['notify'])) {
-					$inform  .= $contact['notify'];
-				}
-
 				$profile = $contact['url'];
 				$newname = ($contact['name'] ?? '') ?: $contact['nick'];
 			}

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2358,11 +2358,10 @@ class BBCode
 	public static function setMentions($body, $profile_uid = 0, $network = '')
 	{
 		DI::profiler()->startRecording('rendering');
-		self::performWithEscapedTags($body, ['noparse', 'pre', 'code', 'img'], function ($body) use ($profile_uid, $network) {
+		$body = self::performWithEscapedTags($body, ['noparse', 'pre', 'code', 'img'], function ($body) use ($profile_uid, $network) {
 			$tags = self::getTags($body);
 
 			$tagged = [];
-			$inform = '';
 
 			foreach ($tags as $tag) {
 				$tag_type = substr($tag, 0, 1);
@@ -2381,7 +2380,7 @@ class BBCode
 					}
 				}
 
-				if (($success = Item::replaceTag($body, $inform, $profile_uid, $tag, $network)) && $success['replaced']) {
+				if (($success = Item::replaceTag($body, $profile_uid, $tag, $network)) && $success['replaced']) {
 					$tagged[] = $tag;
 				}
 			}

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2346,7 +2346,7 @@ class BBCode
 	}
 
 	/**
-	 * Replaces mentions in the provided message body for the provided user and network if any
+	 * Replaces mentions in the provided message body in BBCode links for the provided user and network if any
 	 *
 	 * @param $body
 	 * @param $profile_uid

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -207,6 +207,27 @@ class Tag
 	}
 
 	/**
+	 * Get tags and mentions from the body
+	 * 
+	 * @param string  $body    Body of the post
+	 * @param string  $tags    Accepted tags
+	 *
+	 * @return array Tag list
+	 */
+	public static function getFromBody(string $body, string $tags = null)
+	{
+		if (is_null($tags)) {
+			$tags =  self::TAG_CHARACTER[self::HASHTAG] . self::TAG_CHARACTER[self::MENTION] . self::TAG_CHARACTER[self::EXCLUSIVE_MENTION];
+		}
+
+		if (!preg_match_all("/([" . $tags . "])\[url\=([^\[\]]*)\]([^\[\]]*)\[\/url\]/ism", $body, $result, PREG_SET_ORDER)) {
+			return [];
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Store tags and mentions from the body
 	 * 
 	 * @param integer $uriid   URI-Id
@@ -216,13 +237,10 @@ class Tag
 	 */
 	public static function storeFromBody(int $uriid, string $body, string $tags = null, $probing = true)
 	{
-		if (is_null($tags)) {
-			$tags =  self::TAG_CHARACTER[self::HASHTAG] . self::TAG_CHARACTER[self::MENTION] . self::TAG_CHARACTER[self::EXCLUSIVE_MENTION];
-		}
-
 		Logger::info('Check for tags', ['uri-id' => $uriid, 'hash' => $tags, 'callstack' => System::callstack()]);
 
-		if (!preg_match_all("/([" . $tags . "])\[url\=([^\[\]]*)\]([^\[\]]*)\[\/url\]/ism", $body, $result, PREG_SET_ORDER)) {
+		$result = self::getFromBody($body, $tags);
+		if (empty($result)) {
 			return;
 		}
 

--- a/tests/src/Model/TagTest.php
+++ b/tests/src/Model/TagTest.php
@@ -36,5 +36,4 @@ class TagTest extends TestCase
 		// Some expectations here
 		self::markTestIncomplete('Needs knowledge.');
 	}
-
 }

--- a/tests/src/Model/TagTest.php
+++ b/tests/src/Model/TagTest.php
@@ -26,15 +26,15 @@ use PHPUnit\Framework\TestCase;
 
 class TagTest extends TestCase
 {
-    /**
-     *
-     */
-    public function testGetFromBody()
-    {
-        $body = '![url=https://pirati.ca/profile/test1]Testgruppe 1b[/url] Test, please ignore';
-        $tags = Tag::getFromBody($body);
-        // Some expectations here
-        self::markTestIncomplete('Needs knowledge.');
-    }
+	/**
+	 *
+	 */
+	public function testGetFromBody()
+	{
+		$body = '![url=https://pirati.ca/profile/test1]Testgruppe 1b[/url] Test, please ignore';
+		$tags = Tag::getFromBody($body);
+		// Some expectations here
+		self::markTestIncomplete('Needs knowledge.');
+	}
 
 }

--- a/tests/src/Model/TagTest.php
+++ b/tests/src/Model/TagTest.php
@@ -33,15 +33,15 @@ class TagTest extends TestCase
 	{
 		$body = '![url=https://pirati.ca/profile/test1]Testgruppe 1b[/url] Test, please ignore';
 		$tags = Tag::getFromBody($body);
-        $expected = [
-            [
-                '![url=https://pirati.ca/profile/test1]Testgruppe 1b[/url]',
-                '!',
-                'https://pirati.ca/profile/test1',
-                'Testgruppe 1b'
-            ]
-        ];
+		$expected = [
+			[
+				'![url=https://pirati.ca/profile/test1]Testgruppe 1b[/url]',
+				'!',
+				'https://pirati.ca/profile/test1',
+				'Testgruppe 1b'
+			]
+		];
 
-        self::assertEquals($expected, $tags);
+		self::assertEquals($expected, $tags);
 	}
 }

--- a/tests/src/Model/TagTest.php
+++ b/tests/src/Model/TagTest.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Test\src\Model;
 
+use Friendica\Model\Tag;
 use PHPUnit\Framework\TestCase;
 
 class TagTest extends TestCase
@@ -30,6 +31,9 @@ class TagTest extends TestCase
      */
     public function testGetFromBody()
     {
+        $body = '![url=https://pirati.ca/profile/test1]Testgruppe 1b[/url] Test, please ignore';
+        $tags = Tag::getFromBody($body);
+        // Some expectations here
         self::markTestIncomplete('Needs knowledge.');
     }
 

--- a/tests/src/Model/TagTest.php
+++ b/tests/src/Model/TagTest.php
@@ -32,7 +32,9 @@ class TagTest extends TestCase
 	public function testGetFromBody()
 	{
 		$body = '![url=https://pirati.ca/profile/test1]Testgruppe 1b[/url] Test, please ignore';
+
 		$tags = Tag::getFromBody($body);
+
 		$expected = [
 			[
 				'![url=https://pirati.ca/profile/test1]Testgruppe 1b[/url]',

--- a/tests/src/Model/TagTest.php
+++ b/tests/src/Model/TagTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Test\src\Model;
+
+use PHPUnit\Framework\TestCase;
+
+class TagTest extends TestCase
+{
+    /**
+     * 
+     */
+    public function testGetFromBody()
+    {
+        self::markTestIncomplete('Needs knowledge.');
+    }
+
+}

--- a/tests/src/Model/TagTest.php
+++ b/tests/src/Model/TagTest.php
@@ -33,7 +33,15 @@ class TagTest extends TestCase
 	{
 		$body = '![url=https://pirati.ca/profile/test1]Testgruppe 1b[/url] Test, please ignore';
 		$tags = Tag::getFromBody($body);
-		// Some expectations here
-		self::markTestIncomplete('Needs knowledge.');
+        $expected = [
+            [
+                '![url=https://pirati.ca/profile/test1]Testgruppe 1b[/url]',
+                '!',
+                'https://pirati.ca/profile/test1',
+                'Testgruppe 1b'
+            ]
+        ];
+
+        self::assertEquals($expected, $tags);
 	}
 }

--- a/tests/src/Model/TagTest.php
+++ b/tests/src/Model/TagTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
 class TagTest extends TestCase
 {
     /**
-     * 
+     *
      */
     public function testGetFromBody()
     {


### PR DESCRIPTION
See #10966.

To ensure a reliable forum handling, the system now first converts the mentions to a unified format and then does check them for forum mentions.