### PR TITLE
Issue 11156: Display "49+" notifications if there are 50 or more

### DIFF
--- a/mod/ping.php
+++ b/mod/ping.php
@@ -350,9 +350,11 @@ function ping_init(App $a)
 	}
 
 	if ($format == 'json') {
+		$notification_count = $sysnotify_count + $intro_count + $register_count;
+		
 		$data['groups'] = $groups_unseen;
 		$data['forums'] = $forums_unseen;
-		$data['notification'] = $sysnotify_count + $intro_count + $register_count;
+		$data['notification'] = ($notification_count < 50) ? $notification_count : '49+';
 		$data['notifications'] = $notifications;
 		$data['sysmsgs'] = [
 			'notice' => $sysmsgs,


### PR DESCRIPTION
Fixes #11156.

For performance reasons we only fetch the first 50 notifications. For a user it can be confusing that the number doesn't decrease, so we now show a "49+" instead, which should make it clear that there possibly are a lot more unread notifications.