### PR TITLE
Add rel="tag" to the HTML Purifier allow list in BBCode::convert

### DIFF
--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -984,6 +984,7 @@ class HTML
 		$config->set('Attr.AllowedRel', [
 			'noreferrer' => true,
 			'noopener' => true,
+			'tag' => true,
 		]);
 		$config->set('Attr.AllowedFrameTargets', [
 			'_blank' => true,


### PR DESCRIPTION
Fix #10060 

- This enables Mastodon to recognize hashtag links and prevent unwarranted link previews