### PR TITLE
Issue 10966: Ignore "only sharer" setting for forum accounts

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2947,7 +2947,7 @@ class Contact
 	 */
 	public static function isForum($contactid)
 	{
-		$fields = ['forum', 'prv'];
+		$fields = ['contact-type', 'forum', 'prv'];
 		$condition = ['id' => $contactid];
 		$contact = DBA::selectFirst('contact', $fields, $condition);
 		if (!DBA::isResult($contact)) {
@@ -2955,7 +2955,7 @@ class Contact
 		}
 
 		// Is it a forum?
-		return ($contact['forum'] || $contact['prv']);
+		return (($contact['contact-type'] == self::TYPE_COMMUNITY) || $contact['forum'] || $contact['prv']);
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -619,7 +619,7 @@ class Processor
 				continue;
 			}
 
-			if (DI::pConfig()->get($receiver, 'system', 'accept_only_sharer', false) && ($receiver != 0) && ($item['gravity'] == GRAVITY_PARENT)) {
+			if (!Contact::isForum($receiver) && DI::pConfig()->get($receiver, 'system', 'accept_only_sharer', false) && ($receiver != 0) && ($item['gravity'] == GRAVITY_PARENT)) {
 				$skip = !Contact::isSharingByURL($activity['author'], $receiver);
 
 				if ($skip && (($activity['type'] == 'as:Announce') || ($item['isForum'] ?? false))) {


### PR DESCRIPTION
Fixes #10966
The setting "accept_only_sharer" must not be used for forum accounts because it rejects every incoming forum post.