### PR TITLE
Platforms:  only use and show trusted detections

### DIFF
--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -1566,6 +1566,10 @@ class GServer
 			return $serverdata;
 		}
 
+		// Using only body information we cannot safely detect a lot of systems.
+		// So we define a list of platforms that we can detect safely.
+		$valid_platforms = ['friendica', 'friendika', 'hubzilla', 'misskey', 'peertube', 'wordpress', 'write.as'];
+
 		$doc = new DOMDocument();
 		@$doc->loadHTML($curlResult->getBody());
 		$xpath = new DOMXPath($doc);
@@ -1592,6 +1596,10 @@ class GServer
 				if (empty($attr['name']) || empty($attr['content'])) {
 					continue;
 				}
+			}
+
+			if (!in_array(strtolower($attr['content']), $valid_platforms)) {
+				continue;
 			}
 
 			if ($attr['name'] == 'description') {
@@ -1651,6 +1659,10 @@ class GServer
 				if (empty($attr['property']) || empty($attr['content'])) {
 					continue;
 				}
+			}
+
+			if (!in_array(strtolower($attr['content']), $valid_platforms)) {
+				continue;
 			}
 
 			if ($attr['property'] == 'og:site_name') {

--- a/src/Module/Admin/Federation.php
+++ b/src/Module/Admin/Federation.php
@@ -24,6 +24,7 @@ namespace Friendica\Module\Admin;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Model\GServer;
 use Friendica\Module\BaseAdmin;
 
 class Federation extends BaseAdmin
@@ -71,15 +72,15 @@ class Federation extends BaseAdmin
 
 		$gservers = DBA::p("SELECT COUNT(*) AS `total`, SUM(`registered-users`) AS `users`, `platform`,
 			ANY_VALUE(`network`) AS `network`, MAX(`version`) AS `version`
-			FROM `gserver` WHERE NOT `failed` GROUP BY `platform`");
+			FROM `gserver` WHERE NOT `failed` AND `detection-method` != ? GROUP BY `platform`", GServer::DETECT_MANUAL);
 		while ($gserver = DBA::fetch($gservers)) {
 			$total += $gserver['total'];
 			$users += $gserver['users'];
 
 			$versionCounts = [];
 			$versions = DBA::p("SELECT COUNT(*) AS `total`, `version` FROM `gserver`
-				WHERE NOT `failed` AND `platform` = ?
-				GROUP BY `version` ORDER BY `version`", $gserver['platform']);
+				WHERE NOT `failed` AND `platform` = ? AND `detection-method` != ?
+				GROUP BY `version` ORDER BY `version`", $gserver['platform'], GServer::DETECT_MANUAL);
 			while ($version = DBA::fetch($versions)) {
 				$version['version'] = str_replace(["\n", "\r", "\t"], " ", $version['version']);
 


### PR DESCRIPTION
The platform detection has got several layers of trust. With the "DETECT_BODY" method we had got a lot of trash detected. And the "DETECT_MANUAL" method simply is everything that we cannot detect safely.

So we now filter what we accept with "DETECT_BODY" and we don't show the "DETECT_MANUAL" servers anymore in the statistics.