### PR TITLE
Follow-up for PR #11213 - Improved server probing

### DIFF
--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -1050,14 +1050,14 @@ class GServer
 			return $serverdata;
 		}
 
-		$retrial = 0;
+		$time = time();
 		foreach ($contacts as $contact) {
 			$probed = Contact::getByURL($contact, true);
 			if (!empty($probed) && !$probed['failed'] && in_array($probed['network'], Protocol::FEDERATED)) {
 				$serverdata['network'] = $probed['network'];
 				break;
-			} elseif (++$retrial > 10) {
-				// To reduce the stress on remote systems we probe a maximum of 10 contacts
+			} elseif ((time() - $time) > 10) {
+				// To reduce the stress on remote systems we probe a maximum of 10 seconds
 				break;
 			}
 		}

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -496,7 +496,7 @@ class GServer
 		$serverdata['url'] = $url;
 		$serverdata['nurl'] = Strings::normaliseLink($url);
 
-		if ($serverdata['network'] == Protocol::PHANTOM) {
+		if (in_array($serverdata['network'], [Protocol::PHANTOM, Protocol::FEED])) {
 			$serverdata = self::detectNetworkViaContacts($url, $serverdata);
 		}
 
@@ -1617,11 +1617,8 @@ class GServer
 						$serverdata['version'] = $version_part[1];
 
 						// We still do need a reliable test if some AP plugin is activated
-						if (DBA::exists('apcontact', ['baseurl' => $url])) {
-							$serverdata['network'] = Protocol::ACTIVITYPUB;
-						} else {
-							$serverdata['network'] = Protocol::FEED;
-						}
+						// By now we just check in a later process for some known contacts
+						$serverdata['network'] = Protocol::FEED;
 
 						if ($serverdata['detection-method'] == self::DETECT_MANUAL) {
 							$serverdata['detection-method'] = self::DETECT_BODY;

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -1562,7 +1562,7 @@ class GServer
 
 		// Using only body information we cannot safely detect a lot of systems.
 		// So we define a list of platforms that we can detect safely.
-		$valid_platforms = ['friendica', 'friendika', 'hubzilla', 'misskey', 'peertube', 'wordpress', 'write.as'];
+		$valid_platforms = ['friendica', 'friendika', 'diaspora', 'mastodon', 'hubzilla', 'misskey', 'peertube', 'wordpress', 'write.as'];
 
 		$doc = new DOMDocument();
 		@$doc->loadHTML($curlResult->getBody());
@@ -1590,11 +1590,6 @@ class GServer
 				if (empty($attr['name']) || empty($attr['content'])) {
 					continue;
 				}
-			}
-
-			$platform = explode(' ', strtolower($attr['content']));
-			if (!in_array($platform[0], $valid_platforms)) {
-				continue;
 			}
 
 			if ($attr['name'] == 'description') {
@@ -1656,11 +1651,6 @@ class GServer
 				}
 			}
 
-			$platform = explode(' ', strtolower($attr['content']));
-			if (!in_array($platform[0], $valid_platforms)) {
-				continue;
-			}
-
 			if ($attr['property'] == 'og:site_name') {
 				$serverdata['site_name'] = $attr['content'];
 			}
@@ -1687,7 +1677,11 @@ class GServer
 			}
 		}
 
-		if (!empty($serverdata['network']) && ($serverdata['detection-method'] == self::DETECT_MANUAL)) {
+		if (!empty($serverdata['platform']) && in_array($serverdata['detection-method'], [self::DETECT_MANUAL, self::DETECT_BODY]) && !in_array($serverdata['platform'], $valid_platforms)) {
+			$serverdata['network'] = Protocol::PHANTOM;
+			$serverdata['version'] = '';
+			$serverdata['detection-method'] = self::DETECT_MANUAL;
+		} elseif (!empty($serverdata['network']) && ($serverdata['detection-method'] == self::DETECT_MANUAL)) {
 			$serverdata['detection-method'] = self::DETECT_BODY;
 		}
 

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -1050,10 +1050,14 @@ class GServer
 			return $serverdata;
 		}
 
+		$retrial = 0;
 		foreach ($contacts as $contact) {
-			$probed = Contact::getByURL($contact);
+			$probed = Contact::getByURL($contact, true);
 			if (!empty($probed) && !$probed['failed'] && in_array($probed['network'], Protocol::FEDERATED)) {
 				$serverdata['network'] = $probed['network'];
+				break;
+			} elseif (++$retrial > 10) {
+				// To reduce the stress on remote systems we probe a maximum of 10 contacts
 				break;
 			}
 		}

--- a/src/Module/Admin/Federation.php
+++ b/src/Module/Admin/Federation.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Module\Admin;
 
+use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\DI;
@@ -72,15 +73,15 @@ class Federation extends BaseAdmin
 
 		$gservers = DBA::p("SELECT COUNT(*) AS `total`, SUM(`registered-users`) AS `users`, `platform`,
 			ANY_VALUE(`network`) AS `network`, MAX(`version`) AS `version`
-			FROM `gserver` WHERE NOT `failed` AND `detection-method` != ? GROUP BY `platform`", GServer::DETECT_MANUAL);
+			FROM `gserver` WHERE NOT `failed` AND `detection-method` != ? AND NOT `network` IN (?, ?) GROUP BY `platform`", GServer::DETECT_MANUAL, Protocol::PHANTOM, Protocol::FEED);
 		while ($gserver = DBA::fetch($gservers)) {
 			$total += $gserver['total'];
 			$users += $gserver['users'];
 
 			$versionCounts = [];
 			$versions = DBA::p("SELECT COUNT(*) AS `total`, `version` FROM `gserver`
-				WHERE NOT `failed` AND `platform` = ? AND `detection-method` != ?
-				GROUP BY `version` ORDER BY `version`", $gserver['platform'], GServer::DETECT_MANUAL);
+				WHERE NOT `failed` AND `platform` = ? AND `detection-method` != ? AND NOT `network` IN (?, ?)
+				GROUP BY `version` ORDER BY `version`", $gserver['platform'], GServer::DETECT_MANUAL, Protocol::PHANTOM, Protocol::FEED);
 			while ($version = DBA::fetch($versions)) {
 				$version['version'] = str_replace(["\n", "\r", "\t"], " ", $version['version']);
 


### PR DESCRIPTION
This PR contains some further enhancements to the PR #11213:

- The number of registered users is now set to "0" for Feeds and invalid servers
- The protocol detection via their contacts now performs a real probing to ensure that the probed data is valid
- Unknown systems in the body detection are now set to a lower detection level but stay valid
- Don't show feeds and undetected systems in the statistics