### PR TITLE
Use a thousands_separator to improve readability of the federation statistics

### DIFF
--- a/src/Module/Admin/Federation.php
+++ b/src/Module/Admin/Federation.php
@@ -164,19 +164,19 @@ class Federation extends BaseAdmin
 			}
 
 			$gserver['platform']    = $systems[$platform]['name'];
-			$gserver['totallbl']    = DI::l10n()->t('%d total systems', $gserver['total']);
-			$gserver['monthlbl']    = DI::l10n()->t('%d active users last month', $gserver['month']);
-			$gserver['halfyearlbl'] = DI::l10n()->t('%d active users last six month', $gserver['halfyear']);
-			$gserver['userslbl']    = DI::l10n()->t('%d registered users', $gserver['users']);
-			$gserver['postslbl']    = DI::l10n()->t('%d local posts', $gserver['posts']);
+			$gserver['totallbl']    = DI::l10n()->t('%s total systems', number_format($gserver['total']));
+			$gserver['monthlbl']    = DI::l10n()->t('%s active users last month', number_format($gserver['month']));
+			$gserver['halfyearlbl'] = DI::l10n()->t('%s active users last six month', number_format($gserver['halfyear']));
+			$gserver['userslbl']    = DI::l10n()->t('%s registered users', number_format($gserver['users']));
+			$gserver['postslbl']    = DI::l10n()->t('%s local posts', number_format($gserver['posts']));
 
 			if (($gserver['users'] > 0) && ($gserver['posts'] > 0)) {
-				$gserver['postsuserlbl'] = DI::l10n()->t('%d posts per user', $gserver['posts'] / $gserver['users']);
+				$gserver['postsuserlbl'] = DI::l10n()->t('%s posts per user', number_format($gserver['posts'] / $gserver['users'], 1));
 			} else {
 				$gserver['postsuserlbl'] = '';
 			}
 			if (($gserver['users'] > 0) && ($gserver['total'] > 0)) {
-				$gserver['userssystemlbl'] = DI::l10n()->t('%d users per system', $gserver['users'] / $gserver['total']);
+				$gserver['userssystemlbl'] = DI::l10n()->t('%s users per system', number_format($gserver['users'] / $gserver['total'], 1));
 			} else {
 				$gserver['userssystemlbl'] = '';
 			}
@@ -196,7 +196,7 @@ class Federation extends BaseAdmin
 			'$intro' => $intro,
 			'$counts' => $counts,
 			'$version' => FRIENDICA_VERSION,
-			'$legendtext' => DI::l10n()->t('Currently this node is aware of %d nodes (%d active users last month, %d active users last six month, %d registered users in total) from the following platforms:', $total, $month, $halfyear, $users),
+			'$legendtext' => DI::l10n()->t('Currently this node is aware of %s nodes (%s active users last month, %s active users last six month, %s registered users in total) from the following platforms:', number_format($total), number_format($month), number_format($halfyear), number_format($users)),
 		]);
 	}
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.05-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-07 06:23+0000\n"
+"POT-Creation-Date: 2022-02-07 19:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -5119,37 +5119,37 @@ msgstr ""
 
 #: src/Module/Admin/Federation.php:167
 #, php-format
-msgid "%d total systems"
+msgid "%s total systems"
 msgstr ""
 
 #: src/Module/Admin/Federation.php:168
 #, php-format
-msgid "%d active users last month"
+msgid "%s active users last month"
 msgstr ""
 
 #: src/Module/Admin/Federation.php:169
 #, php-format
-msgid "%d active users last six month"
+msgid "%s active users last six month"
 msgstr ""
 
 #: src/Module/Admin/Federation.php:170
 #, php-format
-msgid "%d registered users"
+msgid "%s registered users"
 msgstr ""
 
 #: src/Module/Admin/Federation.php:171
 #, php-format
-msgid "%d local posts"
+msgid "%s local posts"
 msgstr ""
 
 #: src/Module/Admin/Federation.php:174
 #, php-format
-msgid "%d posts per user"
+msgid "%s posts per user"
 msgstr ""
 
 #: src/Module/Admin/Federation.php:179
 #, php-format
-msgid "%d users per system"
+msgid "%s users per system"
 msgstr ""
 
 #: src/Module/Admin/Federation.php:189
@@ -5166,8 +5166,8 @@ msgstr ""
 #: src/Module/Admin/Federation.php:199
 #, php-format
 msgid ""
-"Currently this node is aware of %d nodes (%d active users last month, %d "
-"active users last six month, %d registered users in total) from the "
+"Currently this node is aware of %s nodes (%s active users last month, %s "
+"active users last six month, %s registered users in total) from the "
 "following platforms:"
 msgstr ""
 


### PR DESCRIPTION
This improves the federation statistics since longer numbers are hard to read without a separator.