### PR TITLE
Don't throw an exception when the database query fails

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -138,6 +138,7 @@ class Database
 			try {
 				$this->connection = @new PDO($connect, $user, $pass, [PDO::ATTR_PERSISTENT => $persistent]);
 				$this->connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, $this->pdo_emulate_prepares);
+				$this->connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 				$this->connected = true;
 			} catch (PDOException $e) {
 				$this->connected = false;


### PR DESCRIPTION
This fixes a problem that caused #11223. Normally that update command can fail (it's no problem when it does). But since PDO now seems to throw an exception on database problems the database upgrade does come to stop there.