### PR TITLE
Avoid thread completion on activities

### DIFF
--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -515,6 +515,9 @@ class Receiver
 		if (!empty($activity['thread-completion'])) {
 			$object_data['thread-completion'] = $activity['thread-completion'];
 		}
+		if (!empty($activity['thread-children-type'])) {
+			$object_data['thread-children-type'] = $activity['thread-children-type'];
+		}
 
 		// Internal flag for posts that arrived via relay
 		if (!empty($activity['from-relay'])) {


### PR DESCRIPTION
The system has got the option to complete threads when it receives only the comment of a follower. This should be limited to comments only, not to activities like "like". 