### PR TITLE
Workaround for timing problems / Avoid a notice in the scheduled posts

### DIFF
--- a/src/Object/Api/Mastodon/ScheduledStatus.php
+++ b/src/Object/Api/Mastodon/ScheduledStatus.php
@@ -71,7 +71,7 @@ class ScheduledStatus extends BaseDataTransferObject
 			'media_ids'      => $media_ids,
 			'sensitive'      => null,
 			'spoiler_text'   => $parameters['item']['title'] ?? '',
-			'visibility'     => $visibility[$parameters['item']['private']],
+			'visibility'     => $visibility[$parameters['item']['private'] ?? 1],
 			'scheduled_at'   => $this->scheduled_at,
 			'poll'           => null,
 			'idempotency'    => null,

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -627,7 +627,8 @@ class HTTPSignature
 		if (!empty($created)) {
 			$current = time();
 
-			if ($created > $current) {
+			// Calculate with a grace period of 60 seconds to avoid slight time differences between the servers
+			if (($created - 60) > $current) {
 				Logger::notice('Signature created in the future', ['created' => date(DateTimeFormat::MYSQL, $created), 'expired' => date(DateTimeFormat::MYSQL, $expired), 'current' => date(DateTimeFormat::MYSQL, $current)]);
 				return false;
 			}


### PR DESCRIPTION
There are possible timing problems when a server is a little bit ahead of its time. This change introduces a grace period of 60 seconds which should be enough.

Also this PR includes a small fix for a notice.