### PR TITLE
Expand system.accept_only_sharer pconfig value to include previous behavior with likes

### DIFF
--- a/mod/settings.php
+++ b/mod/settings.php
@@ -31,6 +31,7 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Group;
+use Friendica\Model\Item;
 use Friendica\Model\Notification;
 use Friendica\Model\Profile;
 use Friendica\Model\User;
@@ -570,7 +571,17 @@ function settings_content(App $a)
 			'$ostat_enabled' => $ostat_enabled,
 
 			'$general_settings' => DI::l10n()->t('General Social Media Settings'),
-			'$accept_only_sharer' => ['accept_only_sharer', DI::l10n()->t('Accept only top level posts by contacts you follow'), $accept_only_sharer, DI::l10n()->t('The system does an auto completion of threads when a comment arrives. This has got the side effect that you can receive posts that had been started by a non-follower but had been commented by someone you follow. This setting deactivates this behaviour. When activated, you strictly only will receive posts from people you really do follow.')],
+			'$accept_only_sharer' => [
+				'accept_only_sharer',
+				DI::l10n()->t('Followed content scope'),
+				$accept_only_sharer,
+				DI::l10n()->t('By default, conversations in which your follows participated but didn\'t start will be shown in your timeline. You can turn this behavior off, or expand it to the conversations in which your follows liked a post.'),
+				[
+					Item::COMPLETION_NONE    => DI::l10n()->t('Only conversations my follows started'),
+					Item::COMPLETION_COMMENT => DI::l10n()->t('Conversations my follows started or commented on (default)'),
+					Item::COMPLETION_LIKE    => DI::l10n()->t('Any conversation my follows interacted with, including likes'),
+				]
+			],
 			'$enable_cw' => ['enable_cw', DI::l10n()->t('Enable Content Warning'), $enable_cw, DI::l10n()->t('Users on networks like Mastodon or Pleroma are able to set a content warning field which collapse their post by default. This enables the automatic collapsing instead of setting the content warning as the post title. Doesn\'t affect any other content filtering you eventually set up.')],
 			'$enable_smart_shortening' => ['enable_smart_shortening', DI::l10n()->t('Enable intelligent shortening'), $enable_smart_shortening, DI::l10n()->t('Normally the system tries to find the best link to add to shortened posts. If disabled, every shortened post will always point to the original friendica post.')],
 			'$simple_shortening' => ['simple_shortening', DI::l10n()->t('Enable simple text shortening'), $simple_shortening, DI::l10n()->t('Normally the system shortens posts at the next line feed. If this option is enabled then the system will shorten the text at the maximum character limit.')],

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -74,6 +74,11 @@ class Item
 	const PR_RELAY = 74;
 	const PR_FETCHED = 75;
 
+	// system.accept_only_sharer setting values
+	const COMPLETION_NONE    = 1;
+	const COMPLETION_COMMENT = 0;
+	const COMPLETION_LIKE    = 2;
+
 	// Field list that is used to display the items
 	const DISPLAY_FIELDLIST = [
 		'uid', 'id', 'parent', 'guid', 'network', 'gravity',
@@ -1403,7 +1408,7 @@ class Item
 		$is_reshare = ($item['gravity'] == GRAVITY_ACTIVITY) && ($item['verb'] == Activity::ANNOUNCE);
 
 		if ((($item['gravity'] == GRAVITY_PARENT) || $is_reshare) &&
-			DI::pConfig()->get($uid, 'system', 'accept_only_sharer') &&
+			DI::pConfig()->get($uid, 'system', 'accept_only_sharer') === self::COMPLETION_NONE &&
 			!Contact::isSharingByURL($item['author-link'], $uid) &&
 			!Contact::isSharingByURL($item['owner-link'], $uid)) {
 			Logger::info('Contact is not a follower, thread will not be stored', ['author' => $item['author-link'], 'uid' => $uid]);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -647,7 +647,12 @@ class Processor
 					Logger::info('Top level post via BCC from a non sharer, ignoring', ['uid' => $receiver, 'contact' => $item['contact-id']]);
 					continue;
 				}
-				if (!empty($activity['thread-children-type']) && in_array($activity['thread-children-type'], Receiver::ACTIVITY_TYPES)) {
+
+				if (
+					!empty($activity['thread-children-type'])
+					&& in_array($activity['thread-children-type'], Receiver::ACTIVITY_TYPES)
+					&& DI::pConfig()->get($receiver, 'system', 'accept_only_sharer', Item::COMPLETION_COMMENT) !== Item::COMPLETION_LIKE
+				) {
 					Logger::info('Top level post from thread completion from a non sharer had been initiated via an activity, ignoring',
 						['type' => $activity['thread-children-type'], 'user' => $item['uid'], 'causer' => $item['causer-link'], 'author' => $activity['author'], 'url' => $item['uri']]);
 					continue;
@@ -663,7 +668,7 @@ class Processor
 				}
 			}
 
-			if (!$is_forum && DI::pConfig()->get($receiver, 'system', 'accept_only_sharer', false) && ($receiver != 0) && ($item['gravity'] == GRAVITY_PARENT)) {
+			if (!$is_forum && DI::pConfig()->get($receiver, 'system', 'accept_only_sharer', Item::COMPLETION_COMMENT) === Item::COMPLETION_NONE && ($receiver != 0) && ($item['gravity'] == GRAVITY_PARENT)) {
 				$skip = !Contact::isSharingByURL($activity['author'], $receiver);
 
 				if ($skip && (($activity['type'] == 'as:Announce') || ($item['isForum'] ?? false))) {

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -494,19 +494,22 @@ class OStatus
 
 			if ($initialize && (count(self::$itemlist) > 0)) {
 				if (self::$itemlist[0]['uri'] == self::$itemlist[0]['thr-parent']) {
+					$uid = self::$itemlist[0]['uid'];
 					// We will import it everytime, when it is started by our contacts
-					$valid = Contact::isSharingByURL(self::$itemlist[0]['author-link'], self::$itemlist[0]['uid']);
+					$valid = Contact::isSharingByURL(self::$itemlist[0]['author-link'], $uid);
 
 					if (!$valid) {
 						// If not, then it depends on this setting
-						$valid = ((self::$itemlist[0]['uid'] == 0) || !DI::pConfig()->get(self::$itemlist[0]['uid'], 'system', 'accept_only_sharer', false));
+						$valid = !$uid || DI::pConfig()->get($uid, 'system', 'accept_only_sharer', Item::COMPLETION_COMMENT) !== Item::COMPLETION_NONE;
+
 						if ($valid) {
 							Logger::info("Item with uri ".self::$itemlist[0]['uri']." will be imported due to the system settings.");
 						}
 					} else {
 						Logger::info("Item with uri ".self::$itemlist[0]['uri']." belongs to a contact (".self::$itemlist[0]['contact-id']."). It will be imported.");
 					}
-					if ($valid) {
+
+					if ($valid && DI::pConfig()->get($uid, 'system', 'accept_only_sharer', Item::COMPLETION_COMMENT) !== Item::COMPLETION_LIKE) {
 						// Never post a thread when the only interaction by our contact was a like
 						$valid = false;
 						$verbs = [Activity::POST, Activity::SHARE];

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.05-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-10 09:02+0100\n"
+"POT-Creation-Date: 2022-02-15 15:52-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -36,7 +36,7 @@ msgstr ""
 msgid "User not found."
 msgstr ""
 
-#: mod/cal.php:120 mod/display.php:270 src/Module/Profile/Profile.php:94
+#: mod/cal.php:120 mod/display.php:238 src/Module/Profile/Profile.php:94
 #: src/Module/Profile/Profile.php:109 src/Module/Profile/Status.php:109
 #: src/Module/Update/Profile.php:56
 msgid "Access to this profile has been restricted."
@@ -103,25 +103,25 @@ msgstr ""
 msgid "calendar"
 msgstr ""
 
-#: mod/display.php:165 mod/photos.php:808
+#: mod/display.php:133 mod/photos.php:808
 #: src/Module/Conversation/Community.php:175 src/Module/Directory.php:48
 #: src/Module/Search/Index.php:49
 msgid "Public access denied."
 msgstr ""
 
-#: mod/display.php:221 mod/display.php:295
+#: mod/display.php:189 mod/display.php:263
 msgid "The requested item doesn't exist or has been deleted."
 msgstr ""
 
-#: mod/display.php:375
+#: mod/display.php:343
 msgid "The feed for this item is unavailable."
 msgstr ""
 
 #: mod/editpost.php:38 mod/events.php:220 mod/follow.php:56 mod/follow.php:130
-#: mod/item.php:185 mod/item.php:190 mod/item.php:930 mod/message.php:69
+#: mod/item.php:184 mod/item.php:189 mod/item.php:918 mod/message.php:69
 #: mod/message.php:111 mod/notes.php:44 mod/ostatus_subscribe.php:32
 #: mod/photos.php:160 mod/photos.php:897 mod/repair_ostatus.php:31
-#: mod/settings.php:46 mod/settings.php:56 mod/settings.php:412
+#: mod/settings.php:47 mod/settings.php:57 mod/settings.php:413
 #: mod/suggest.php:34 mod/uimport.php:33 mod/unfollow.php:35
 #: mod/unfollow.php:50 mod/unfollow.php:82 mod/wall_attach.php:68
 #: mod/wall_attach.php:71 mod/wall_upload.php:90 mod/wall_upload.php:93
@@ -465,7 +465,7 @@ msgid "OStatus support is disabled. Contact can't be added."
 msgstr ""
 
 #: mod/follow.php:138 src/Content/Item.php:452 src/Content/Widget.php:76
-#: src/Model/Contact.php:1056 src/Model/Contact.php:1068
+#: src/Model/Contact.php:1057 src/Model/Contact.php:1069
 #: view/theme/vier/theme.php:172
 msgid "Connect/Follow"
 msgstr ""
@@ -510,27 +510,27 @@ msgstr ""
 msgid "The contact could not be added."
 msgstr ""
 
-#: mod/item.php:135 mod/item.php:139
+#: mod/item.php:134 mod/item.php:138
 msgid "Unable to locate original post."
 msgstr ""
 
-#: mod/item.php:341 mod/item.php:346
+#: mod/item.php:340 mod/item.php:345
 msgid "Empty post discarded."
 msgstr ""
 
-#: mod/item.php:736
+#: mod/item.php:724
 msgid "Post updated."
 msgstr ""
 
-#: mod/item.php:746 mod/item.php:751
+#: mod/item.php:734 mod/item.php:739
 msgid "Item wasn't stored."
 msgstr ""
 
-#: mod/item.php:762
+#: mod/item.php:750
 msgid "Item couldn't be fetched."
 msgstr ""
 
-#: mod/item.php:908 src/Module/Admin/Themes/Details.php:39
+#: mod/item.php:896 src/Module/Admin/Themes/Details.php:39
 #: src/Module/Admin/Themes/Index.php:59 src/Module/Debug/ItemBody.php:41
 #: src/Module/Debug/ItemBody.php:56
 msgid "Item not found."
@@ -1079,7 +1079,7 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: mod/photos.php:1431 mod/settings.php:596 src/Content/Conversation.php:616
+#: mod/photos.php:1431 mod/settings.php:607 src/Content/Conversation.php:616
 #: src/Module/Admin/Users/Active.php:139 src/Module/Admin/Users/Blocked.php:140
 #: src/Module/Admin/Users/Index.php:153
 msgid "Delete"
@@ -1183,75 +1183,75 @@ msgid_plural "Errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/settings.php:128
+#: mod/settings.php:129
 msgid "Failed to connect with email account using the settings provided."
 msgstr ""
 
-#: mod/settings.php:158
+#: mod/settings.php:159
 msgid "Contact CSV file upload error"
 msgstr ""
 
-#: mod/settings.php:177
+#: mod/settings.php:178
 msgid "Importing Contacts done"
 msgstr ""
 
-#: mod/settings.php:190
+#: mod/settings.php:191
 msgid "Relocate message has been send to your contacts"
 msgstr ""
 
-#: mod/settings.php:202
+#: mod/settings.php:203
 msgid "Passwords do not match."
 msgstr ""
 
-#: mod/settings.php:210 src/Console/User.php:210
+#: mod/settings.php:211 src/Console/User.php:210
 msgid "Password update failed. Please try again."
 msgstr ""
 
-#: mod/settings.php:213 src/Console/User.php:213
+#: mod/settings.php:214 src/Console/User.php:213
 msgid "Password changed."
 msgstr ""
 
-#: mod/settings.php:216
+#: mod/settings.php:217
 msgid "Password unchanged."
 msgstr ""
 
-#: mod/settings.php:304
+#: mod/settings.php:305
 msgid "Please use a shorter name."
 msgstr ""
 
-#: mod/settings.php:307
+#: mod/settings.php:308
 msgid "Name too short."
 msgstr ""
 
-#: mod/settings.php:316
+#: mod/settings.php:317
 msgid "Wrong Password."
 msgstr ""
 
-#: mod/settings.php:321
+#: mod/settings.php:322
 msgid "Invalid email."
 msgstr ""
 
-#: mod/settings.php:327
+#: mod/settings.php:328
 msgid "Cannot change to that email."
 msgstr ""
 
-#: mod/settings.php:368
+#: mod/settings.php:369
 msgid "Private forum has no privacy permissions. Using default privacy group."
 msgstr ""
 
-#: mod/settings.php:371
+#: mod/settings.php:372
 msgid "Private forum has no privacy permissions and no default privacy group."
 msgstr ""
 
-#: mod/settings.php:390
+#: mod/settings.php:391
 msgid "Settings were not updated."
 msgstr ""
 
-#: mod/settings.php:431
+#: mod/settings.php:432
 msgid "Connected Apps"
 msgstr ""
 
-#: mod/settings.php:432 src/Module/Admin/Blocklist/Contact.php:106
+#: mod/settings.php:433 src/Module/Admin/Blocklist/Contact.php:106
 #: src/Module/Admin/Users/Active.php:129 src/Module/Admin/Users/Blocked.php:130
 #: src/Module/Admin/Users/Create.php:71 src/Module/Admin/Users/Deleted.php:88
 #: src/Module/Admin/Users/Index.php:142 src/Module/Admin/Users/Index.php:162
@@ -1259,20 +1259,20 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: mod/settings.php:433 src/Content/Nav.php:212
+#: mod/settings.php:434 src/Content/Nav.php:212
 msgid "Home Page"
 msgstr ""
 
-#: mod/settings.php:434 src/Module/Admin/Queue.php:78
+#: mod/settings.php:435 src/Module/Admin/Queue.php:78
 msgid "Created"
 msgstr ""
 
-#: mod/settings.php:435
+#: mod/settings.php:436
 msgid "Remove authorization"
 msgstr ""
 
-#: mod/settings.php:461 mod/settings.php:493 mod/settings.php:524
-#: mod/settings.php:598 mod/settings.php:735
+#: mod/settings.php:462 mod/settings.php:494 mod/settings.php:525
+#: mod/settings.php:609 mod/settings.php:746
 #: src/Module/Admin/Addons/Index.php:69 src/Module/Admin/Features.php:87
 #: src/Module/Admin/Logs/Settings.php:81 src/Module/Admin/Site.php:501
 #: src/Module/Admin/Themes/Index.php:113 src/Module/Admin/Tos.php:83
@@ -1280,73 +1280,83 @@ msgstr ""
 msgid "Save Settings"
 msgstr ""
 
-#: mod/settings.php:469
+#: mod/settings.php:470
 msgid "Addon Settings"
 msgstr ""
 
-#: mod/settings.php:470
+#: mod/settings.php:471
 msgid "No Addon settings configured"
 msgstr ""
 
-#: mod/settings.php:491
+#: mod/settings.php:492
 msgid "Additional Features"
 msgstr ""
 
-#: mod/settings.php:529
+#: mod/settings.php:530
 msgid "Diaspora (Socialhome, Hubzilla)"
 msgstr ""
 
-#: mod/settings.php:529 mod/settings.php:530
+#: mod/settings.php:530 mod/settings.php:531
 msgid "enabled"
 msgstr ""
 
-#: mod/settings.php:529 mod/settings.php:530
+#: mod/settings.php:530 mod/settings.php:531
 msgid "disabled"
 msgstr ""
 
-#: mod/settings.php:529 mod/settings.php:530
+#: mod/settings.php:530 mod/settings.php:531
 #, php-format
 msgid "Built-in support for %s connectivity is %s"
 msgstr ""
 
-#: mod/settings.php:530
+#: mod/settings.php:531
 msgid "OStatus (GNU Social)"
 msgstr ""
 
-#: mod/settings.php:556
+#: mod/settings.php:557
 msgid "Email access is disabled on this site."
 msgstr ""
 
-#: mod/settings.php:561 mod/settings.php:596
+#: mod/settings.php:562 mod/settings.php:607
 msgid "None"
 msgstr ""
 
-#: mod/settings.php:567 src/Module/BaseSettings.php:78
+#: mod/settings.php:568 src/Module/BaseSettings.php:78
 msgid "Social Networks"
 msgstr ""
 
-#: mod/settings.php:572
+#: mod/settings.php:573
 msgid "General Social Media Settings"
 msgstr ""
 
-#: mod/settings.php:573
-msgid "Accept only top level posts by contacts you follow"
+#: mod/settings.php:576
+msgid "Followed content scope"
 msgstr ""
 
-#: mod/settings.php:573
+#: mod/settings.php:578
 msgid ""
-"The system does an auto completion of threads when a comment arrives. This "
-"has got the side effect that you can receive posts that had been started by "
-"a non-follower but had been commented by someone you follow. This setting "
-"deactivates this behaviour. When activated, you strictly only will receive "
-"posts from people you really do follow."
+"By default, conversations in which your follows participated but didn't "
+"start will be shown in your timeline. You can turn this behavior off, or "
+"expand it to the conversations in which your follows liked a post."
 msgstr ""
 
-#: mod/settings.php:574
+#: mod/settings.php:580
+msgid "Only conversations my follows started"
+msgstr ""
+
+#: mod/settings.php:581
+msgid "Conversations my follows started or commented on (default)"
+msgstr ""
+
+#: mod/settings.php:582
+msgid "Any conversation my follows interacted with, including likes"
+msgstr ""
+
+#: mod/settings.php:585
 msgid "Enable Content Warning"
 msgstr ""
 
-#: mod/settings.php:574
+#: mod/settings.php:585
 msgid ""
 "Users on networks like Mastodon or Pleroma are able to set a content warning "
 "field which collapse their post by default. This enables the automatic "
@@ -1354,222 +1364,222 @@ msgid ""
 "affect any other content filtering you eventually set up."
 msgstr ""
 
-#: mod/settings.php:575
+#: mod/settings.php:586
 msgid "Enable intelligent shortening"
 msgstr ""
 
-#: mod/settings.php:575
+#: mod/settings.php:586
 msgid ""
 "Normally the system tries to find the best link to add to shortened posts. "
 "If disabled, every shortened post will always point to the original "
 "friendica post."
 msgstr ""
 
-#: mod/settings.php:576
+#: mod/settings.php:587
 msgid "Enable simple text shortening"
 msgstr ""
 
-#: mod/settings.php:576
+#: mod/settings.php:587
 msgid ""
 "Normally the system shortens posts at the next line feed. If this option is "
 "enabled then the system will shorten the text at the maximum character limit."
 msgstr ""
 
-#: mod/settings.php:577
+#: mod/settings.php:588
 msgid "Attach the link title"
 msgstr ""
 
-#: mod/settings.php:577
+#: mod/settings.php:588
 msgid ""
 "When activated, the title of the attached link will be added as a title on "
 "posts to Diaspora. This is mostly helpful with \"remote-self\" contacts that "
 "share feed content."
 msgstr ""
 
-#: mod/settings.php:578
+#: mod/settings.php:589
 msgid "Your legacy ActivityPub/GNU Social account"
 msgstr ""
 
-#: mod/settings.php:578
+#: mod/settings.php:589
 msgid ""
 "If you enter your old account name from an ActivityPub based system or your "
 "GNU Social/Statusnet account name here (in the format user@domain.tld), your "
 "contacts will be added automatically. The field will be emptied when done."
 msgstr ""
 
-#: mod/settings.php:581
+#: mod/settings.php:592
 msgid "Repair OStatus subscriptions"
 msgstr ""
 
-#: mod/settings.php:585
+#: mod/settings.php:596
 msgid "Email/Mailbox Setup"
 msgstr ""
 
-#: mod/settings.php:586
+#: mod/settings.php:597
 msgid ""
 "If you wish to communicate with email contacts using this service "
 "(optional), please specify how to connect to your mailbox."
 msgstr ""
 
-#: mod/settings.php:587
+#: mod/settings.php:598
 msgid "Last successful email check:"
 msgstr ""
 
-#: mod/settings.php:589
+#: mod/settings.php:600
 msgid "IMAP server name:"
 msgstr ""
 
-#: mod/settings.php:590
+#: mod/settings.php:601
 msgid "IMAP port:"
 msgstr ""
 
-#: mod/settings.php:591
+#: mod/settings.php:602
 msgid "Security:"
 msgstr ""
 
-#: mod/settings.php:592
+#: mod/settings.php:603
 msgid "Email login name:"
 msgstr ""
 
-#: mod/settings.php:593
+#: mod/settings.php:604
 msgid "Email password:"
 msgstr ""
 
-#: mod/settings.php:594
+#: mod/settings.php:605
 msgid "Reply-to address:"
 msgstr ""
 
-#: mod/settings.php:595
+#: mod/settings.php:606
 msgid "Send public posts to all email contacts:"
 msgstr ""
 
-#: mod/settings.php:596
+#: mod/settings.php:607
 msgid "Action after import:"
 msgstr ""
 
-#: mod/settings.php:596 src/Content/Nav.php:280
+#: mod/settings.php:607 src/Content/Nav.php:280
 msgid "Mark as seen"
 msgstr ""
 
-#: mod/settings.php:596
+#: mod/settings.php:607
 msgid "Move to folder"
 msgstr ""
 
-#: mod/settings.php:597
+#: mod/settings.php:608
 msgid "Move to folder:"
 msgstr ""
 
-#: mod/settings.php:611
+#: mod/settings.php:622
 msgid "Unable to find your profile. Please contact your admin."
 msgstr ""
 
-#: mod/settings.php:649 src/Content/Widget.php:526
+#: mod/settings.php:660 src/Content/Widget.php:526
 msgid "Account Types"
 msgstr ""
 
-#: mod/settings.php:650
+#: mod/settings.php:661
 msgid "Personal Page Subtypes"
 msgstr ""
 
-#: mod/settings.php:651
+#: mod/settings.php:662
 msgid "Community Forum Subtypes"
 msgstr ""
 
-#: mod/settings.php:658 src/Module/Admin/BaseUsers.php:107
+#: mod/settings.php:669 src/Module/Admin/BaseUsers.php:107
 msgid "Personal Page"
 msgstr ""
 
-#: mod/settings.php:659
+#: mod/settings.php:670
 msgid "Account for a personal profile."
 msgstr ""
 
-#: mod/settings.php:662 src/Module/Admin/BaseUsers.php:108
+#: mod/settings.php:673 src/Module/Admin/BaseUsers.php:108
 msgid "Organisation Page"
 msgstr ""
 
-#: mod/settings.php:663
+#: mod/settings.php:674
 msgid ""
 "Account for an organisation that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:666 src/Module/Admin/BaseUsers.php:109
+#: mod/settings.php:677 src/Module/Admin/BaseUsers.php:109
 msgid "News Page"
 msgstr ""
 
-#: mod/settings.php:667
+#: mod/settings.php:678
 msgid ""
 "Account for a news reflector that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:670 src/Module/Admin/BaseUsers.php:110
+#: mod/settings.php:681 src/Module/Admin/BaseUsers.php:110
 msgid "Community Forum"
 msgstr ""
 
-#: mod/settings.php:671
+#: mod/settings.php:682
 msgid "Account for community discussions."
 msgstr ""
 
-#: mod/settings.php:674 src/Module/Admin/BaseUsers.php:100
+#: mod/settings.php:685 src/Module/Admin/BaseUsers.php:100
 msgid "Normal Account Page"
 msgstr ""
 
-#: mod/settings.php:675
+#: mod/settings.php:686
 msgid ""
 "Account for a regular personal profile that requires manual approval of "
 "\"Friends\" and \"Followers\"."
 msgstr ""
 
-#: mod/settings.php:678 src/Module/Admin/BaseUsers.php:101
+#: mod/settings.php:689 src/Module/Admin/BaseUsers.php:101
 msgid "Soapbox Page"
 msgstr ""
 
-#: mod/settings.php:679
+#: mod/settings.php:690
 msgid ""
 "Account for a public profile that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: mod/settings.php:682 src/Module/Admin/BaseUsers.php:102
+#: mod/settings.php:693 src/Module/Admin/BaseUsers.php:102
 msgid "Public Forum"
 msgstr ""
 
-#: mod/settings.php:683
+#: mod/settings.php:694
 msgid "Automatically approves all contact requests."
 msgstr ""
 
-#: mod/settings.php:686 src/Module/Admin/BaseUsers.php:103
+#: mod/settings.php:697 src/Module/Admin/BaseUsers.php:103
 msgid "Automatic Friend Page"
 msgstr ""
 
-#: mod/settings.php:687
+#: mod/settings.php:698
 msgid ""
 "Account for a popular profile that automatically approves contact requests "
 "as \"Friends\"."
 msgstr ""
 
-#: mod/settings.php:690
+#: mod/settings.php:701
 msgid "Private Forum [Experimental]"
 msgstr ""
 
-#: mod/settings.php:691
+#: mod/settings.php:702
 msgid "Requires manual approval of contact requests."
 msgstr ""
 
-#: mod/settings.php:702
+#: mod/settings.php:713
 msgid "OpenID:"
 msgstr ""
 
-#: mod/settings.php:702
+#: mod/settings.php:713
 msgid "(Optional) Allow this OpenID to login to this account."
 msgstr ""
 
-#: mod/settings.php:710
+#: mod/settings.php:721
 msgid "Publish your profile in your local site directory?"
 msgstr ""
 
-#: mod/settings.php:710
+#: mod/settings.php:721
 #, php-format
 msgid ""
 "Your profile will be published in this node's <a href=\"%s\">local "
@@ -1577,115 +1587,115 @@ msgid ""
 "system settings."
 msgstr ""
 
-#: mod/settings.php:716
+#: mod/settings.php:727
 #, php-format
 msgid ""
 "Your profile will also be published in the global friendica directories (e."
 "g. <a href=\"%s\">%s</a>)."
 msgstr ""
 
-#: mod/settings.php:722
+#: mod/settings.php:733
 #, php-format
 msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
 msgstr ""
 
-#: mod/settings.php:733
+#: mod/settings.php:744
 msgid "Account Settings"
 msgstr ""
 
-#: mod/settings.php:741
+#: mod/settings.php:752
 msgid "Password Settings"
 msgstr ""
 
-#: mod/settings.php:742 src/Module/Register.php:162
+#: mod/settings.php:753 src/Module/Register.php:162
 msgid "New Password:"
 msgstr ""
 
-#: mod/settings.php:742
+#: mod/settings.php:753
 msgid ""
 "Allowed characters are a-z, A-Z, 0-9 and special characters except white "
 "spaces, accentuated letters and colon (:)."
 msgstr ""
 
-#: mod/settings.php:743 src/Module/Register.php:163
+#: mod/settings.php:754 src/Module/Register.php:163
 msgid "Confirm:"
 msgstr ""
 
-#: mod/settings.php:743
+#: mod/settings.php:754
 msgid "Leave password fields blank unless changing"
 msgstr ""
 
-#: mod/settings.php:744
+#: mod/settings.php:755
 msgid "Current Password:"
 msgstr ""
 
-#: mod/settings.php:744
+#: mod/settings.php:755
 msgid "Your current password to confirm the changes"
 msgstr ""
 
-#: mod/settings.php:745
+#: mod/settings.php:756
 msgid "Password:"
 msgstr ""
 
-#: mod/settings.php:745
+#: mod/settings.php:756
 msgid "Your current password to confirm the changes of the email address"
 msgstr ""
 
-#: mod/settings.php:748
+#: mod/settings.php:759
 msgid "Delete OpenID URL"
 msgstr ""
 
-#: mod/settings.php:750
+#: mod/settings.php:761
 msgid "Basic Settings"
 msgstr ""
 
-#: mod/settings.php:751 src/Module/Profile/Profile.php:144
+#: mod/settings.php:762 src/Module/Profile/Profile.php:144
 msgid "Full Name:"
 msgstr ""
 
-#: mod/settings.php:752
+#: mod/settings.php:763
 msgid "Email Address:"
 msgstr ""
 
-#: mod/settings.php:753
+#: mod/settings.php:764
 msgid "Your Timezone:"
 msgstr ""
 
-#: mod/settings.php:754
+#: mod/settings.php:765
 msgid "Your Language:"
 msgstr ""
 
-#: mod/settings.php:754
+#: mod/settings.php:765
 msgid ""
 "Set the language we use to show you friendica interface and to send you "
 "emails"
 msgstr ""
 
-#: mod/settings.php:755
+#: mod/settings.php:766
 msgid "Default Post Location:"
 msgstr ""
 
-#: mod/settings.php:756
+#: mod/settings.php:767
 msgid "Use Browser Location:"
 msgstr ""
 
-#: mod/settings.php:758
+#: mod/settings.php:769
 msgid "Security and Privacy Settings"
 msgstr ""
 
-#: mod/settings.php:760
+#: mod/settings.php:771
 msgid "Maximum Friend Requests/Day:"
 msgstr ""
 
-#: mod/settings.php:760 mod/settings.php:770
+#: mod/settings.php:771 mod/settings.php:781
 msgid "(to prevent spam abuse)"
 msgstr ""
 
-#: mod/settings.php:762
+#: mod/settings.php:773
 msgid "Allow your profile to be searchable globally?"
 msgstr ""
 
-#: mod/settings.php:762
+#: mod/settings.php:773
 msgid ""
 "Activate this setting if you want others to easily find and follow you. Your "
 "profile will be searchable on remote systems. This setting also determines "
@@ -1693,43 +1703,43 @@ msgid ""
 "indexed or not."
 msgstr ""
 
-#: mod/settings.php:763
+#: mod/settings.php:774
 msgid "Hide your contact/friend list from viewers of your profile?"
 msgstr ""
 
-#: mod/settings.php:763
+#: mod/settings.php:774
 msgid ""
 "A list of your contacts is displayed on your profile page. Activate this "
 "option to disable the display of your contact list."
 msgstr ""
 
-#: mod/settings.php:764
+#: mod/settings.php:775
 msgid "Hide your profile details from anonymous viewers?"
 msgstr ""
 
-#: mod/settings.php:764
+#: mod/settings.php:775
 msgid ""
 "Anonymous visitors will only see your profile picture, your display name and "
 "the nickname you are using on your profile page. Your public posts and "
 "replies will still be accessible by other means."
 msgstr ""
 
-#: mod/settings.php:765
+#: mod/settings.php:776
 msgid "Make public posts unlisted"
 msgstr ""
 
-#: mod/settings.php:765
+#: mod/settings.php:776
 msgid ""
 "Your public posts will not appear on the community pages or in search "
 "results, nor be sent to relay servers. However they can still appear on "
 "public feeds on remote servers."
 msgstr ""
 
-#: mod/settings.php:766
+#: mod/settings.php:777
 msgid "Make all posted pictures accessible"
 msgstr ""
 
-#: mod/settings.php:766
+#: mod/settings.php:777
 msgid ""
 "This option makes every posted picture accessible via the direct link. This "
 "is a workaround for the problem that most other networks can't handle "
@@ -1737,221 +1747,221 @@ msgid ""
 "public on your photo albums though."
 msgstr ""
 
-#: mod/settings.php:767
+#: mod/settings.php:778
 msgid "Allow friends to post to your profile page?"
 msgstr ""
 
-#: mod/settings.php:767
+#: mod/settings.php:778
 msgid ""
 "Your contacts may write posts on your profile wall. These posts will be "
 "distributed to your contacts"
 msgstr ""
 
-#: mod/settings.php:768
+#: mod/settings.php:779
 msgid "Allow friends to tag your posts?"
 msgstr ""
 
-#: mod/settings.php:768
+#: mod/settings.php:779
 msgid "Your contacts can add additional tags to your posts."
 msgstr ""
 
-#: mod/settings.php:769
+#: mod/settings.php:780
 msgid "Permit unknown people to send you private mail?"
 msgstr ""
 
-#: mod/settings.php:769
+#: mod/settings.php:780
 msgid ""
 "Friendica network users may send you private messages even if they are not "
 "in your contact list."
 msgstr ""
 
-#: mod/settings.php:770
+#: mod/settings.php:781
 msgid "Maximum private messages per day from unknown people:"
 msgstr ""
 
-#: mod/settings.php:772
+#: mod/settings.php:783
 msgid "Default Post Permissions"
 msgstr ""
 
-#: mod/settings.php:776
+#: mod/settings.php:787
 msgid "Expiration settings"
 msgstr ""
 
-#: mod/settings.php:777
+#: mod/settings.php:788
 msgid "Automatically expire posts after this many days:"
 msgstr ""
 
-#: mod/settings.php:777
+#: mod/settings.php:788
 msgid "If empty, posts will not expire. Expired posts will be deleted"
 msgstr ""
 
-#: mod/settings.php:778
+#: mod/settings.php:789
 msgid "Expire posts"
 msgstr ""
 
-#: mod/settings.php:778
+#: mod/settings.php:789
 msgid "When activated, posts and comments will be expired."
 msgstr ""
 
-#: mod/settings.php:779
+#: mod/settings.php:790
 msgid "Expire personal notes"
 msgstr ""
 
-#: mod/settings.php:779
+#: mod/settings.php:790
 msgid ""
 "When activated, the personal notes on your profile page will be expired."
 msgstr ""
 
-#: mod/settings.php:780
+#: mod/settings.php:791
 msgid "Expire starred posts"
 msgstr ""
 
-#: mod/settings.php:780
+#: mod/settings.php:791
 msgid ""
 "Starring posts keeps them from being expired. That behaviour is overwritten "
 "by this setting."
 msgstr ""
 
-#: mod/settings.php:781
+#: mod/settings.php:792
 msgid "Expire photos"
 msgstr ""
 
-#: mod/settings.php:781
+#: mod/settings.php:792
 msgid "When activated, photos will be expired."
 msgstr ""
 
-#: mod/settings.php:782
+#: mod/settings.php:793
 msgid "Only expire posts by others"
 msgstr ""
 
-#: mod/settings.php:782
+#: mod/settings.php:793
 msgid ""
 "When activated, your own posts never expire. Then the settings above are "
 "only valid for posts you received."
 msgstr ""
 
-#: mod/settings.php:785
+#: mod/settings.php:796
 msgid "Notification Settings"
 msgstr ""
 
-#: mod/settings.php:786
+#: mod/settings.php:797
 msgid "Send a notification email when:"
 msgstr ""
 
-#: mod/settings.php:787
+#: mod/settings.php:798
 msgid "You receive an introduction"
 msgstr ""
 
-#: mod/settings.php:788
+#: mod/settings.php:799
 msgid "Your introductions are confirmed"
 msgstr ""
 
-#: mod/settings.php:789
+#: mod/settings.php:800
 msgid "Someone writes on your profile wall"
 msgstr ""
 
-#: mod/settings.php:790
+#: mod/settings.php:801
 msgid "Someone writes a followup comment"
 msgstr ""
 
-#: mod/settings.php:791
+#: mod/settings.php:802
 msgid "You receive a private message"
 msgstr ""
 
-#: mod/settings.php:792
+#: mod/settings.php:803
 msgid "You receive a friend suggestion"
 msgstr ""
 
-#: mod/settings.php:793
+#: mod/settings.php:804
 msgid "You are tagged in a post"
 msgstr ""
 
-#: mod/settings.php:794
+#: mod/settings.php:805
 msgid "You are poked/prodded/etc. in a post"
 msgstr ""
 
-#: mod/settings.php:796
+#: mod/settings.php:807
 msgid "Create a desktop notification when:"
 msgstr ""
 
-#: mod/settings.php:797
+#: mod/settings.php:808
 msgid "Someone liked your content"
 msgstr ""
 
-#: mod/settings.php:798
+#: mod/settings.php:809
 msgid "Someone shared your content"
 msgstr ""
 
-#: mod/settings.php:800
+#: mod/settings.php:811
 msgid "Activate desktop notifications"
 msgstr ""
 
-#: mod/settings.php:800
+#: mod/settings.php:811
 msgid "Show desktop popup on new notifications"
 msgstr ""
 
-#: mod/settings.php:802
+#: mod/settings.php:813
 msgid "Text-only notification emails"
 msgstr ""
 
-#: mod/settings.php:804
+#: mod/settings.php:815
 msgid "Send text only notification emails, without the html part"
 msgstr ""
 
-#: mod/settings.php:806
+#: mod/settings.php:817
 msgid "Show detailled notifications"
 msgstr ""
 
-#: mod/settings.php:808
+#: mod/settings.php:819
 msgid ""
 "Per default, notifications are condensed to a single notification per item. "
 "When enabled every notification is displayed."
 msgstr ""
 
-#: mod/settings.php:810
+#: mod/settings.php:821
 msgid "Show notifications of ignored contacts"
 msgstr ""
 
-#: mod/settings.php:812
+#: mod/settings.php:823
 msgid ""
 "You don't see posts from ignored contacts. But you still see their comments. "
 "This setting controls if you want to still receive regular notifications "
 "that are caused by ignored contacts or not."
 msgstr ""
 
-#: mod/settings.php:814
+#: mod/settings.php:825
 msgid "Advanced Account/Page Type Settings"
 msgstr ""
 
-#: mod/settings.php:815
+#: mod/settings.php:826
 msgid "Change the behaviour of this account for special situations"
 msgstr ""
 
-#: mod/settings.php:818
+#: mod/settings.php:829
 msgid "Import Contacts"
 msgstr ""
 
-#: mod/settings.php:819
+#: mod/settings.php:830
 msgid ""
 "Upload a CSV file that contains the handle of your followed accounts in the "
 "first column you exported from the old account."
 msgstr ""
 
-#: mod/settings.php:820
+#: mod/settings.php:831
 msgid "Upload File"
 msgstr ""
 
-#: mod/settings.php:822
+#: mod/settings.php:833
 msgid "Relocate"
 msgstr ""
 
-#: mod/settings.php:823
+#: mod/settings.php:834
 msgid ""
 "If you have moved this profile from another server, and some of your "
 "contacts don't receive your updates, try pushing this button."
 msgstr ""
 
-#: mod/settings.php:824
+#: mod/settings.php:835
 msgid "Resend relocate message to contacts"
 msgstr ""
 
@@ -1965,7 +1975,7 @@ msgstr ""
 msgid "Friend Suggestions"
 msgstr ""
 
-#: mod/tagger.php:78 src/Content/Item.php:335 src/Model/Item.php:2620
+#: mod/tagger.php:78 src/Content/Item.php:335 src/Model/Item.php:2662
 msgid "photo"
 msgstr ""
 
@@ -2719,7 +2729,7 @@ msgstr ""
 msgid "%1$s poked %2$s"
 msgstr ""
 
-#: src/Content/Item.php:327 src/Model/Item.php:2618
+#: src/Content/Item.php:327 src/Model/Item.php:2660
 msgid "event"
 msgstr ""
 
@@ -2727,31 +2737,31 @@ msgstr ""
 msgid "Follow Thread"
 msgstr ""
 
-#: src/Content/Item.php:432 src/Model/Contact.php:1061
+#: src/Content/Item.php:432 src/Model/Contact.php:1062
 msgid "View Status"
 msgstr ""
 
-#: src/Content/Item.php:433 src/Content/Item.php:455 src/Model/Contact.php:995
-#: src/Model/Contact.php:1053 src/Model/Contact.php:1062
+#: src/Content/Item.php:433 src/Content/Item.php:455 src/Model/Contact.php:996
+#: src/Model/Contact.php:1054 src/Model/Contact.php:1063
 #: src/Module/Directory.php:157 src/Module/Settings/Profile/Index.php:225
 msgid "View Profile"
 msgstr ""
 
-#: src/Content/Item.php:434 src/Model/Contact.php:1063
+#: src/Content/Item.php:434 src/Model/Contact.php:1064
 msgid "View Photos"
 msgstr ""
 
-#: src/Content/Item.php:435 src/Model/Contact.php:1054
-#: src/Model/Contact.php:1064
+#: src/Content/Item.php:435 src/Model/Contact.php:1055
+#: src/Model/Contact.php:1065
 msgid "Network Posts"
 msgstr ""
 
-#: src/Content/Item.php:436 src/Model/Contact.php:1055
-#: src/Model/Contact.php:1065
+#: src/Content/Item.php:436 src/Model/Contact.php:1056
+#: src/Model/Contact.php:1066
 msgid "View Contact"
 msgstr ""
 
-#: src/Content/Item.php:437 src/Model/Contact.php:1066
+#: src/Content/Item.php:437 src/Model/Contact.php:1067
 msgid "Send PM"
 msgstr ""
 
@@ -2774,7 +2784,7 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
-#: src/Content/Item.php:447 src/Model/Contact.php:1067
+#: src/Content/Item.php:447 src/Model/Contact.php:1068
 msgid "Poke"
 msgstr ""
 
@@ -3070,8 +3080,8 @@ msgid ""
 "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1185 src/Model/Item.php:3149
-#: src/Model/Item.php:3155 src/Model/Item.php:3156
+#: src/Content/Text/BBCode.php:1185 src/Model/Item.php:3191
+#: src/Model/Item.php:3197 src/Model/Item.php:3198
 msgid "Link to source"
 msgstr ""
 
@@ -3226,7 +3236,7 @@ msgstr ""
 msgid "Organisations"
 msgstr ""
 
-#: src/Content/Widget.php:522 src/Model/Contact.php:1471
+#: src/Content/Widget.php:522 src/Model/Contact.php:1472
 msgid "News"
 msgstr ""
 
@@ -4049,81 +4059,81 @@ msgstr ""
 msgid "Legacy module file not found: %s"
 msgstr ""
 
-#: src/Model/Contact.php:1057 src/Model/Contact.php:1069
+#: src/Model/Contact.php:1058 src/Model/Contact.php:1070
 msgid "UnFollow"
 msgstr ""
 
-#: src/Model/Contact.php:1075 src/Module/Admin/Users/Pending.php:107
+#: src/Model/Contact.php:1076 src/Module/Admin/Users/Pending.php:107
 #: src/Module/Notifications/Introductions.php:130
 #: src/Module/Notifications/Introductions.php:202
 msgid "Approve"
 msgstr ""
 
-#: src/Model/Contact.php:1467
+#: src/Model/Contact.php:1468
 msgid "Organisation"
 msgstr ""
 
-#: src/Model/Contact.php:1475
+#: src/Model/Contact.php:1476
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:2410
+#: src/Model/Contact.php:2411
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:2415 src/Module/Friendica.php:81
+#: src/Model/Contact.php:2416 src/Module/Friendica.php:81
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:2420
+#: src/Model/Contact.php:2421
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:2429
+#: src/Model/Contact.php:2430
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:2466
+#: src/Model/Contact.php:2467
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:2468
+#: src/Model/Contact.php:2469
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:2471
+#: src/Model/Contact.php:2472
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:2474
+#: src/Model/Contact.php:2475
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:2477
+#: src/Model/Contact.php:2478
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:2478
+#: src/Model/Contact.php:2479
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:2484
+#: src/Model/Contact.php:2485
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:2489
+#: src/Model/Contact.php:2490
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:2548
+#: src/Model/Contact.php:2549
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -4243,33 +4253,33 @@ msgstr ""
 msgid "Edit groups"
 msgstr ""
 
-#: src/Model/Item.php:1691
+#: src/Model/Item.php:1751
 #, php-format
 msgid "Detected languages in this post:\\n%s"
 msgstr ""
 
-#: src/Model/Item.php:2622
+#: src/Model/Item.php:2664
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2624
+#: src/Model/Item.php:2666
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2627
+#: src/Model/Item.php:2669
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:2764
+#: src/Model/Item.php:2806
 #, php-format
 msgid "Content warning: %s"
 msgstr ""
 
-#: src/Model/Item.php:3114
+#: src/Model/Item.php:3156
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3143 src/Model/Item.php:3144
+#: src/Model/Item.php:3185 src/Model/Item.php:3186
 msgid "View on separate page"
 msgstr ""
 
@@ -8651,19 +8661,19 @@ msgstr ""
 
 #: src/Module/Profile/Profile.php:326 src/Module/Profile/Profile.php:329
 #: src/Module/Profile/Status.php:65 src/Module/Profile/Status.php:68
-#: src/Protocol/Feed.php:990 src/Protocol/OStatus.php:1242
+#: src/Protocol/Feed.php:990 src/Protocol/OStatus.php:1245
 #, php-format
 msgid "%s's timeline"
 msgstr ""
 
 #: src/Module/Profile/Profile.php:327 src/Module/Profile/Status.php:66
-#: src/Protocol/Feed.php:994 src/Protocol/OStatus.php:1246
+#: src/Protocol/Feed.php:994 src/Protocol/OStatus.php:1249
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
 #: src/Module/Profile/Profile.php:328 src/Module/Profile/Status.php:67
-#: src/Protocol/Feed.php:997 src/Protocol/OStatus.php:1249
+#: src/Protocol/Feed.php:997 src/Protocol/OStatus.php:1252
 #, php-format
 msgid "%s's comments"
 msgstr ""
@@ -10593,21 +10603,21 @@ msgstr ""
 msgid "Show fewer"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1645
+#: src/Protocol/OStatus.php:1648
 #, php-format
 msgid "%s is now following %s."
 msgstr ""
 
-#: src/Protocol/OStatus.php:1646
+#: src/Protocol/OStatus.php:1649
 msgid "following"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1649
+#: src/Protocol/OStatus.php:1652
 #, php-format
 msgid "%s stopped following %s."
 msgstr ""
 
-#: src/Protocol/OStatus.php:1650
+#: src/Protocol/OStatus.php:1653
 msgid "stopped following"
 msgstr ""
 
@@ -10726,7 +10736,7 @@ msgstr ""
 msgid "%1$d %2$s ago"
 msgstr ""
 
-#: src/Worker/Delivery.php:525
+#: src/Worker/Delivery.php:524
 msgid "(no subject)"
 msgstr ""
 

--- a/view/templates/settings/connectors.tpl
+++ b/view/templates/settings/connectors.tpl
@@ -11,7 +11,7 @@
 
 	<div id="settings_general_expanded" class="settings-block" style="display: none;">
 
-		{{include file="field_checkbox.tpl" field=$accept_only_sharer}}
+		{{include file="field_select.tpl" field=$accept_only_sharer}}
 		{{include file="field_checkbox.tpl" field=$enable_cw}}
 		{{include file="field_checkbox.tpl" field=$enable_smart_shortening}}
 		{{include file="field_checkbox.tpl" field=$simple_shortening}}

--- a/view/theme/frio/templates/settings/connectors.tpl
+++ b/view/theme/frio/templates/settings/connectors.tpl
@@ -18,7 +18,7 @@
 			</div>
 			<div id="content-settings-content" class="panel-collapse collapse" role="tabpanel" aria-labelledby="content-settings-title">
 				<div class="panel-body">
-					{{include file="field_checkbox.tpl" field=$accept_only_sharer}}
+					{{include file="field_select.tpl" field=$accept_only_sharer}}
 
 					{{include file="field_checkbox.tpl" field=$enable_cw}}
 


### PR DESCRIPTION
Hopefully closes #11245

I found out that the existing but apparently unintended behavior with likes was only possible with AP since OStatus had a specific condition for it.

I kept the config key name which makes the resulting values unordered but with the constants it should hide the counter-intuitive values.

I also completely rewrote the setting help, let me know if it's unclear.