### PR TITLE
Hash the URL before using it as cache key in Util\Images::getInfoFromURLCached

### DIFF
--- a/src/Util/Images.php
+++ b/src/Util/Images.php
@@ -184,12 +184,14 @@ class Images
 			return $data;
 		}
 
-		$data = DI::cache()->get($url);
+		$cacheKey = 'getInfoFromURL:' . sha1($url);
+
+		$data = DI::cache()->get($cacheKey);
 
 		if (empty($data) || !is_array($data)) {
 			$data = self::getInfoFromURL($url);
 
-			DI::cache()->set($url, $data);
+			DI::cache()->set($cacheKey, $data);
 		}
 
 		return $data;


### PR DESCRIPTION
Fixes #11248 
- This prevents oversized URL from stunting the database cache