### PR TITLE
Don't use empty values for redis password and port

### DIFF
--- a/src/Console/Config.php
+++ b/src/Console/Config.php
@@ -151,7 +151,7 @@ HELP;
 					$this->out("{$cat}.{$key}[{$k}] => " . (is_array($v) ? implode(', ', $v) : $v));
 				}
 			} else {
-				$this->out("{$cat}.{$key} => " . $value);
+				$this->out("{$cat}.{$key} => " . ($value ?? 'NULL'));
 			}
 		}
 

--- a/src/Core/Cache/Type/RedisCache.php
+++ b/src/Core/Cache/Type/RedisCache.php
@@ -59,13 +59,13 @@ class RedisCache extends AbstractCache implements ICanCacheInMemory
 		$redis_pw   = $config->get('system', 'redis_password');
 		$redis_db   = $config->get('system', 'redis_db', 0);
 
-		if (isset($redis_port) && !@$this->redis->connect($redis_host, $redis_port)) {
+		if (!empty($redis_port) && !@$this->redis->connect($redis_host, $redis_port)) {
 			throw new CachePersistenceException('Expected Redis server at ' . $redis_host . ':' . $redis_port . ' isn\'t available');
 		} elseif (!@$this->redis->connect($redis_host)) {
 			throw new CachePersistenceException('Expected Redis server at ' . $redis_host . ' isn\'t available');
 		}
 
-		if (isset($redis_pw) && !$this->redis->auth($redis_pw)) {
+		if (!empty($redis_pw) && !$this->redis->auth($redis_pw)) {
 			throw new CachePersistenceException('Cannot authenticate redis server at ' . $redis_host . ':' . $redis_port);
 		}
 

--- a/tests/src/Console/ConfigConsoleTest.php
+++ b/tests/src/Console/ConfigConsoleTest.php
@@ -102,7 +102,7 @@ class ConfigConsoleTest extends ConsoleTest
 		$console->setArgument(0, 'config');
 		$console->setArgument(1, 'test');
 		$txt = $this->dumpExecute($console);
-		self::assertEquals("config.test => \n", $txt);
+		self::assertEquals("config.test => NULL\n", $txt);
 	}
 
 	public function testSetArrayValue()


### PR DESCRIPTION
longtime fix for https://github.com/friendica/docker/issues/194

And we now distinguish at the config output between "string emptry or whitespaces" and "not defined/null"