### PR TITLE
Note about breaking changes in private forums

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Version 2022.05 (unreleased)
   Friendica Core
+    Breaking: The distribution of _private forums_ was moved to ActivityPub, making them incompatible with older versions of Friendica [annando]
 
   Friendica Addons
 


### PR DESCRIPTION
This adds a note/reminder to the CHANGELOG file about the breaking changes introduced in this version regarding the _private forums_.

#11242 #11251