### PR TITLE
Relax comparison with pconfig system.accept_only_sharer value

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1408,7 +1408,7 @@ class Item
 		$is_reshare = ($item['gravity'] == GRAVITY_ACTIVITY) && ($item['verb'] == Activity::ANNOUNCE);
 
 		if ((($item['gravity'] == GRAVITY_PARENT) || $is_reshare) &&
-			DI::pConfig()->get($uid, 'system', 'accept_only_sharer') === self::COMPLETION_NONE &&
+			DI::pConfig()->get($uid, 'system', 'accept_only_sharer') == self::COMPLETION_NONE &&
 			!Contact::isSharingByURL($item['author-link'], $uid) &&
 			!Contact::isSharingByURL($item['owner-link'], $uid)) {
 			Logger::info('Contact is not a follower, thread will not be stored', ['author' => $item['author-link'], 'uid' => $uid]);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -651,7 +651,7 @@ class Processor
 				if (
 					!empty($activity['thread-children-type'])
 					&& in_array($activity['thread-children-type'], Receiver::ACTIVITY_TYPES)
-					&& DI::pConfig()->get($receiver, 'system', 'accept_only_sharer', Item::COMPLETION_COMMENT) !== Item::COMPLETION_LIKE
+					&& DI::pConfig()->get($receiver, 'system', 'accept_only_sharer') != Item::COMPLETION_LIKE
 				) {
 					Logger::info('Top level post from thread completion from a non sharer had been initiated via an activity, ignoring',
 						['type' => $activity['thread-children-type'], 'user' => $item['uid'], 'causer' => $item['causer-link'], 'author' => $activity['author'], 'url' => $item['uri']]);
@@ -668,7 +668,7 @@ class Processor
 				}
 			}
 
-			if (!$is_forum && DI::pConfig()->get($receiver, 'system', 'accept_only_sharer', Item::COMPLETION_COMMENT) === Item::COMPLETION_NONE && ($receiver != 0) && ($item['gravity'] == GRAVITY_PARENT)) {
+			if (!$is_forum && DI::pConfig()->get($receiver, 'system', 'accept_only_sharer') == Item::COMPLETION_NONE && ($receiver != 0) && ($item['gravity'] == GRAVITY_PARENT)) {
 				$skip = !Contact::isSharingByURL($activity['author'], $receiver);
 
 				if ($skip && (($activity['type'] == 'as:Announce') || ($item['isForum'] ?? false))) {

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -500,7 +500,7 @@ class OStatus
 
 					if (!$valid) {
 						// If not, then it depends on this setting
-						$valid = !$uid || DI::pConfig()->get($uid, 'system', 'accept_only_sharer', Item::COMPLETION_COMMENT) !== Item::COMPLETION_NONE;
+						$valid = !$uid || DI::pConfig()->get($uid, 'system', 'accept_only_sharer') != Item::COMPLETION_NONE;
 
 						if ($valid) {
 							Logger::info("Item with uri ".self::$itemlist[0]['uri']." will be imported due to the system settings.");
@@ -509,7 +509,7 @@ class OStatus
 						Logger::info("Item with uri ".self::$itemlist[0]['uri']." belongs to a contact (".self::$itemlist[0]['contact-id']."). It will be imported.");
 					}
 
-					if ($valid && DI::pConfig()->get($uid, 'system', 'accept_only_sharer', Item::COMPLETION_COMMENT) !== Item::COMPLETION_LIKE) {
+					if ($valid && DI::pConfig()->get($uid, 'system', 'accept_only_sharer') != Item::COMPLETION_LIKE) {
 						// Never post a thread when the only interaction by our contact was a like
 						$valid = false;
 						$verbs = [Activity::POST, Activity::SHARE];


### PR DESCRIPTION
Part of https://github.com/friendica/friendica/issues/11245
Follow-up to #11246, thanks to @tobiasd for the QA

- DI::pConfig()->get returns a string value, not an integer
- Removed superfluous default values now that we aren't doing strict type checking