### PR TITLE
Show only the user's categories on their profile

### DIFF
--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -318,23 +318,20 @@ class Widget
 	/**
 	 * Return categories widget
 	 *
-	 * @param string $baseurl  baseurl
-	 * @param string $selected optional, default empty
+	 * @param int    $uid      Id of the user owning the categories
+	 * @param string $baseurl  Base page URL
+	 * @param string $selected Selected category
 	 * @return string|void
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function categories($baseurl, $selected = '')
+	public static function categories(int $uid, string $baseurl, string $selected = '')
 	{
-		$a = DI::app();
-
-		$uid = intval($a->getProfileOwner());
-
 		if (!Feature::isEnabled($uid, 'categories')) {
 			return '';
 		}
 
 		$terms = array();
-		foreach (Post\Category::getArray(local_user(), Post\Category::CATEGORY) as $savedFolderName) {
+		foreach (Post\Category::getArray($uid, Post\Category::CATEGORY) as $savedFolderName) {
 			$terms[] = ['ref' => $savedFolderName, 'name' => $savedFolderName];
 		}
 

--- a/src/Module/Profile/Status.php
+++ b/src/Module/Profile/Status.php
@@ -118,7 +118,7 @@ class Status extends BaseProfile
 		$commvisitor = $commpage && $remote_contact;
 
 		DI::page()['aside'] .= Widget::postedByYear(DI::baseUrl() . '/profile/' . $profile['nickname'] . '/status', $profile['profile_uid'] ?? 0, true);
-		DI::page()['aside'] .= Widget::categories(DI::baseUrl() . '/profile/' . $profile['nickname'] . '/status', XML::escape($category));
+		DI::page()['aside'] .= Widget::categories($profile['uid'], DI::baseUrl() . '/profile/' . $profile['nickname'] . '/status', $category);
 		DI::page()['aside'] .= Widget::tagCloud($profile['uid']);
 
 		if (Security::canWriteToUserWall($profile['uid'])) {


### PR DESCRIPTION
Fixes #11234 

Long story short, we were using `local_user()` to filter the category list, which would only correctly show the user's categories on its own profile page. It would also show their own categories on every other profile, but only if the visited profile user activated the additional feature themselves.

To retrieve the categories, we perform a query on the `category-view` view and the condition on the integer `uid` field used the value `false` that `local_user()` returns for non-logged users. While I haven't been able to reproduce @SpcCw 's specific issue, I'm not surprised it failed spectacularly for them by showing only node-wide categories in which there were no posts at all (otherwise `uid` would be set).