### PR TITLE
API: Fix display of reshares / return value of activities

### DIFF
--- a/src/Factory/Api/Twitter/Status.php
+++ b/src/Factory/Api/Twitter/Status.php
@@ -27,6 +27,7 @@ use Friendica\Content\Text\HTML;
 use Friendica\Database\Database;
 use Friendica\Factory\Api\Friendica\Activities;
 use Friendica\Factory\Api\Twitter\User as TwitterUser;
+use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Model\Verb;
 use Friendica\Network\HTTPException;
@@ -76,8 +77,9 @@ class Status extends BaseFactory
 	 */
 	public function createFromItemId(int $id, int $uid, bool $include_entities = false): \Friendica\Object\Api\Twitter\Status
 	{
-		$fields = ['parent-uri-id', 'uri-id', 'uid', 'author-id', 'author-link', 'author-network', 'owner-id', 'starred', 'app', 'title', 'body', 'raw-body', 'created', 'network',
-			'thr-parent-id', 'parent-author-id', 'parent-author-nick', 'language', 'uri', 'plink', 'private', 'vid', 'gravity', 'coord'];
+		$fields = ['parent-uri-id', 'uri-id', 'uid', 'author-id', 'author-link', 'author-network', 'owner-id', 'causer-id',
+			'starred', 'app', 'title', 'body', 'raw-body', 'created', 'network','post-reason', 'language', 'gravity',
+			'thr-parent-id', 'parent-author-id', 'parent-author-nick', 'uri', 'plink', 'private', 'vid', 'coord'];
 		$item = Post::selectFirst($fields, ['id' => $id], ['order' => ['uid' => true]]);
 		if (!$item) {
 			throw new HTTPException\NotFoundException('Item with ID ' . $id . ' not found.');
@@ -95,8 +97,9 @@ class Status extends BaseFactory
 	 */
 	public function createFromUriId(int $uriId, $uid = 0, $include_entities = false): \Friendica\Object\Api\Twitter\Status
 	{
-		$fields = ['parent-uri-id', 'uri-id', 'uid', 'author-id', 'author-link', 'author-network', 'owner-id', 'starred', 'app', 'title', 'body', 'raw-body', 'created', 'network',
-			'thr-parent-id', 'parent-author-id', 'parent-author-nick', 'language', 'uri', 'plink', 'private', 'vid', 'gravity', 'coord'];
+		$fields = ['parent-uri-id', 'uri-id', 'uid', 'author-id', 'author-link', 'author-network', 'owner-id', 'causer-id',
+			'starred', 'app', 'title', 'body', 'raw-body', 'created', 'network','post-reason', 'language', 'gravity',
+			'thr-parent-id', 'parent-author-id', 'parent-author-nick', 'uri', 'plink', 'private', 'vid', 'coord'];
 		$item = Post::selectFirst($fields, ['uri-id' => $uriId, 'uid' => [0, $uid]], ['order' => ['uid' => true]]);
 		if (!$item) {
 			throw new HTTPException\NotFoundException('Item with URI ID ' . $uriId . ' not found' . ($uid ? ' for user ' . $uid : '.'));
@@ -115,7 +118,12 @@ class Status extends BaseFactory
 	private function createFromArray(array $item, int $uid, bool $include_entities): \Friendica\Object\Api\Twitter\Status
 	{
 		$author = $this->twitterUser->createFromContactId($item['author-id'], $uid, true);
-		$owner  = $this->twitterUser->createFromContactId($item['owner-id'], $uid, true);
+
+		if (!empty($item['causer-id']) && ($item['post-reason'] == Item::PR_ANNOUNCEMENT)) {
+			$owner = $this->twitterUser->createFromContactId($item['causer-id'], $uid, true);
+		} else {
+			$owner = $this->twitterUser->createFromContactId($item['owner-id'], $uid, true);
+		}
 
 		$friendica_comments = Post::countPosts(['thr-parent-id' => $item['uri-id'], 'deleted' => false, 'gravity' => GRAVITY_COMMENT]);
 

--- a/src/Module/Api/Friendica/Activity.php
+++ b/src/Module/Api/Friendica/Activity.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Module\Api\Friendica;
 
+use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Module\BaseApi;
@@ -58,12 +59,8 @@ class Activity extends BaseApi
 		$res = Item::performActivity($post['id'], $this->parameters['verb'], $uid);
 
 		if ($res) {
-			if (($this->parameters['extension'] ?? '') == 'xml') {
-				$ok = 'true';
-			} else {
-				$ok = 'ok';
-			}
-			$this->response->exit('ok', ['ok' => $ok], $this->parameters['extension'] ?? null);
+			$status_info = DI::twitterStatus()->createFromUriId($request['id'], $uid)->toArray();
+			$this->response->exit('status', ['status' => $status_info], $this->parameters['extension'] ?? null);
 		} else {
 			$this->response->error(500, 'Error adding activity', '', $this->parameters['extension'] ?? null);
 		}

--- a/src/Object/Api/Twitter/Status.php
+++ b/src/Object/Api/Twitter/Status.php
@@ -118,7 +118,7 @@ class Status extends BaseDataTransferObject
 		$this->friendica_title      = $item['title'];
 		$this->statusnet_html       = $statusnetHtml;
 		$this->friendica_html       = $friendicaHtml;
-		$this->user                 = $author->toArray();
+		$this->user                 = $owner->toArray();
 		$this->friendica_author     = $author->toArray();
 		$this->friendica_owner      = $owner->toArray();
 		$this->truncated            = false;


### PR DESCRIPTION
This adresses two issues of #11284. Reshared content is now display with diferent authors and owners. Creating favourites now return a records that seems to be expected via Friendiqa.