### PR TITLE
API: Only display active incoming contact requests

### DIFF
--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -21,8 +21,8 @@
 
 namespace Friendica\Module\Api\Mastodon;
 
-use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\Markdown;
+use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
@@ -63,12 +63,8 @@ class Statuses extends BaseApi
 		// The imput is defined as text. So we can use Markdown for some enhancements
 		$body = Markdown::toBBCode($request['status']);
 
-		// Avoids potential double expansion of existing links
-		$body = BBCode::performWithEscapedTags($body, ['url'], function ($body) {
-			return BBCode::expandTags($body);
-		});
-
-		$item = [];
+		$item               = [];
+		$item['network']    = Protocol::DFRN;
 		$item['uid']        = $uid;
 		$item['verb']       = Activity::POST;
 		$item['contact-id'] = $owner['id'];
@@ -148,6 +144,8 @@ class Statuses extends BaseApi
 			$item['gravity']     = GRAVITY_PARENT;
 			$item['object-type'] = Activity\ObjectType::NOTE;
 		}
+
+		$item = DI::contentItem()->expandTags($item);
 
 		if (!empty($request['media_ids'])) {
 			$item['object-type'] = Activity\ObjectType::IMAGE;

--- a/src/Module/Api/Twitter/Friendships/Incoming.php
+++ b/src/Module/Api/Twitter/Friendships/Incoming.php
@@ -46,32 +46,32 @@ class Incoming extends ContactEndpoint
 		$max_id   = $this->getRequestValue($request, 'max_id', 0, 0);
 		$min_id   = $this->getRequestValue($request, 'min_id', 0, 0);
 
-		$params = ['order' => ['cid' => true], 'limit' => $count];
+		$params = ['order' => ['contact-id' => true], 'limit' => $count];
 
-		$condition = ['uid' => $uid, 'pending' => true];
+		$condition = ["`uid` = ? AND NOT `blocked` AND NOT `ignore` AND `contact-id` != 0 AND (`suggest-cid` = 0 OR `suggest-cid` IS NULL)", $uid];
 
-		$total_count = (int)DBA::count('user-contact', $condition);
+		$total_count = (int)DBA::count('intro', $condition);
 
 		if (!empty($max_id)) {
-			$condition = DBA::mergeConditions($condition, ["`cid` < ?", $max_id]);
+			$condition = DBA::mergeConditions($condition, ["`contact-id` < ?", $max_id]);
 		}
 
 		if (!empty($since_id)) {
-			$condition = DBA::mergeConditions($condition, ["`cid` > ?", $since_id]);
+			$condition = DBA::mergeConditions($condition, ["`contact-id` > ?", $since_id]);
 		}
 
 		if (!empty($min_id)) {
-			$condition = DBA::mergeConditions($condition, ["`cid` > ?", $min_id]);
+			$condition = DBA::mergeConditions($condition, ["`contact-id` > ?", $min_id]);
 
-			$params['order'] = ['cid'];
+			$params['order'] = ['contact-id'];
 		}
 
 		$ids = [];
 
-		$contacts = DBA::select('user-contact', ['cid'], $condition, $params);
+		$contacts = DBA::select('intro', ['contact-id'], $condition, $params);
 		while ($contact = DBA::fetch($contacts)) {
-			self::setBoundaries($contact['cid']);
-			$ids[] = $contact['cid'];
+			self::setBoundaries($contact['contact-id']);
+			$ids[] = $contact['contact-id'];
 		}
 		DBA::close($contacts);
 

--- a/src/Module/Api/Twitter/Statuses/Update.php
+++ b/src/Module/Api/Twitter/Statuses/Update.php
@@ -21,9 +21,9 @@
 
 namespace Friendica\Module\Api\Twitter\Statuses;
 
-use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
 use Friendica\Content\Text\Markdown;
+use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
@@ -79,11 +79,11 @@ class Update extends BaseApi
 		}
 
 		$item               = [];
+		$item['network']    = Protocol::DFRN;
 		$item['uid']        = $uid;
 		$item['verb']       = Activity::POST;
 		$item['contact-id'] = $owner['id'];
-		$item['author-id']  = Contact::getPublicIdByUserId($uid);
-		$item['owner-id']   = $item['author-id'];
+		$item['author-id']  = $item['owner-id'] = Contact::getPublicIdByUserId($uid);
 		$item['title']      = $request['title'];
 		$item['body']       = $body;
 		$item['app']        = $request['source'];

--- a/src/Module/Api/Twitter/Statuses/Update.php
+++ b/src/Module/Api/Twitter/Statuses/Update.php
@@ -78,11 +78,6 @@ class Update extends BaseApi
 			$body = Markdown::toBBCode($request['status']);
 		}
 
-		// Avoids potential double expansion of existing links
-		$body = BBCode::performWithEscapedTags($body, ['url'], function ($body) {
-			return BBCode::expandTags($body);
-		});
-
 		$item               = [];
 		$item['uid']        = $uid;
 		$item['verb']       = Activity::POST;
@@ -126,6 +121,8 @@ class Update extends BaseApi
 			$item['gravity']     = GRAVITY_PARENT;
 			$item['object-type'] = Activity\ObjectType::NOTE;
 		}
+
+		$item = DI::contentItem()->expandTags($item);
 
 		if (!empty($request['media_ids'])) {
 			$ids = explode(',', $request['media_ids']);


### PR DESCRIPTION
See #11284

We now only display active incoming contact requests and not the ignored ones anymore.