### PR TITLE
Exclude symbolic links from tar transformation

### DIFF
--- a/.woodpecker/.continuous-deployment.yml
+++ b/.woodpecker/.continuous-deployment.yml
@@ -62,7 +62,7 @@ pipeline:
       - export RELEASE="friendica-full-$VERSION"
       - export ARTIFACT="$RELEASE.tar.gz"
       - tar
-        --transform "s,^,$RELEASE/,"
+        --transform "s,^,$RELEASE/,S"
         -X mods/release-list-exclude.txt
         -T mods/release-list-include.txt
         -cvzf ./build/$ARTIFACT

--- a/.woodpecker/.releaser.yml
+++ b/.woodpecker/.releaser.yml
@@ -60,7 +60,7 @@ pipeline:
       - export RELEASE="friendica-full-$VERSION"
       - export ARTIFACT="$RELEASE.tar.gz"
       - tar
-        --transform "s,^,$RELEASE/,"
+        --transform "s,^,$RELEASE/,S"
         -X mods/release-list-exclude.txt
         -T mods/release-list-include.txt
         -cvzf ./build/$ARTIFACT


### PR DESCRIPTION
Fixes #11219 

Seems like this issue isn't new
see http://www.gnu.org/software/tar/manual/html_section/transform.html 
flag `S` ... `Do not apply transformation to symbolic link targets.`