### PR TITLE
API: Improve support for the summary field

### DIFF
--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -76,8 +76,8 @@ class Status extends BaseFactory
 	 */
 	public function createFromUriId(int $uriId, $uid = 0): \Friendica\Object\Api\Mastodon\Status
 	{
-		$fields = ['uri-id', 'uid', 'author-id', 'author-link', 'starred', 'app', 'title', 'body', 'raw-body', 'created', 'network',
-			'thr-parent-id', 'parent-author-id', 'language', 'uri', 'plink', 'private', 'vid', 'gravity'];
+		$fields = ['uri-id', 'uid', 'author-id', 'author-link', 'starred', 'app', 'title', 'body', 'raw-body', 'content-warning',
+			'created', 'network', 'thr-parent-id', 'parent-author-id', 'language', 'uri', 'plink', 'private', 'vid', 'gravity'];
 		$item = Post::selectFirst($fields, ['uri-id' => $uriId, 'uid' => [0, $uid]], ['order' => ['uid' => true]]);
 		if (!$item) {
 			$mail = DBA::selectFirst('mail', ['id'], ['uri-id' => $uriId, 'uid' => $uid]);

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -69,7 +69,6 @@ class Statuses extends BaseApi
 		$item['verb']       = Activity::POST;
 		$item['contact-id'] = $owner['id'];
 		$item['author-id']  = $item['owner-id'] = Contact::getPublicIdByUserId($uid);
-		$item['title']      = $request['spoiler_text'];
 		$item['body']       = $body;
 
 		if (!empty(self::getCurrentApplication()['name'])) {
@@ -141,14 +140,17 @@ class Statuses extends BaseApi
 
 		if ($request['in_reply_to_id']) {
 			$parent = Post::selectFirst(['uri'], ['uri-id' => $request['in_reply_to_id'], 'uid' => [0, $uid]]);
+
 			$item['thr-parent']  = $parent['uri'];
 			$item['gravity']     = GRAVITY_COMMENT;
 			$item['object-type'] = Activity\ObjectType::COMMENT;
+			$item['body']        = '[abstract=' . Protocol::ACTIVITYPUB . ']' . $request['spoiler_text'] . "[/abstract]\n" . $item['body'];
 		} else {
 			self::checkThrottleLimit();
 
 			$item['gravity']     = GRAVITY_PARENT;
 			$item['object-type'] = Activity\ObjectType::NOTE;
+			$item['title']       = $request['spoiler_text'];
 		}
 
 		$item = DI::contentItem()->expandTags($item, $request['visibility'] == 'direct');

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -107,8 +107,8 @@ class Status extends BaseDataTransferObject
 			$this->in_reply_to_account_id = (string)$item['parent-author-id'];
 		}
 
-		$this->sensitive = $sensitive;
-		$this->spoiler_text = $item['title'];
+		$this->sensitive    = $sensitive;
+		$this->spoiler_text = $item['title'] ?: $item['content-warning'];
 
 		$visibility = ['public', 'private', 'unlisted'];
 		$this->visibility = $visibility[$item['private']];

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -911,6 +911,7 @@ class Transmitter
 			$mail['title']        = '';
 		}
 
+		$mail['content-warning']  = '';
 		$mail['author-link']      = $mail['owner-link'] = $mail['from-url'];
 		$mail['owner-id']         = $mail['author-id'];
 		$mail['allow_cid']        = '<'.$mail['contact-id'].'>';


### PR DESCRIPTION
By now we hadn't displayed the content of the summary field (which is used in Mastodon as content warning) via the API. Ths is now done.

To prevent display problems on replying to Mastodon messages with a summary we use the content of the field for sending it a summary and not as a title.