### PR TITLE
Replace abstract content with a space to prevent missing spaces

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2086,8 +2086,8 @@ class BBCode
 	public static function stripAbstract($text)
 	{
 		DI::profiler()->startRecording('rendering');
-		$text = preg_replace("/[\s|\n]*\[abstract\].*?\[\/abstract\][\s|\n]*/ism", '', $text);
-		$text = preg_replace("/[\s|\n]*\[abstract=.*?\].*?\[\/abstract][\s|\n]*/ism", '', $text);
+		$text = preg_replace("/[\s|\n]*\[abstract\].*?\[\/abstract\][\s|\n]*/ism", ' ', $text);
+		$text = preg_replace("/[\s|\n]*\[abstract=.*?\].*?\[\/abstract][\s|\n]*/ism", ' ', $text);
 
 		DI::profiler()->stopRecording();
 		return $text;


### PR DESCRIPTION
There can be problems with missing spaces when the abstract isn't at the start or end of the body.