### PR TITLE
API: Fix "in_reply_to_status_id"

### DIFF
--- a/src/Module/Api/Twitter/Statuses/Update.php
+++ b/src/Module/Api/Twitter/Statuses/Update.php
@@ -110,7 +110,7 @@ class Update extends BaseApi
 		}
 
 		if ($request['in_reply_to_status_id']) {
-			$parent = Post::selectFirst(['uri'], ['id' => $request['in_reply_to_status_id'], 'uid' => [0, $uid]]);
+			$parent = Post::selectFirst(['uri'], ['uri-id' => $request['in_reply_to_status_id'], 'uid' => [0, $uid]]);
 
 			$item['thr-parent']  = $parent['uri'];
 			$item['gravity']     = GRAVITY_COMMENT;


### PR DESCRIPTION
The parameter "in_reply_to_status_id" hadn't been converted to the `uri-id` based handling but still used the old `id` based handling that we previously used.