### PR TITLE
Issue 11309: Check if a post is wanted

### DIFF
--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1775,12 +1775,11 @@ class DFRN
 	{
 		if (DBA::exists('contact', ["`nurl` = ? AND `uid` != ? AND `rel` IN (?, ?)",
 			Strings::normaliseLink($item["author-link"]), 0, Contact::FRIEND, Contact::SHARING])) {
-			Logger::info('Author has got followers - accepted', ['uri' => $item['uri'], 'author' => $item["author-link"]]);
+			Logger::debug('Author has got followers - accepted', ['uri' => $item['uri'], 'author' => $item["author-link"]]);
 			return true;
 		}
 
-		$taglist = Tag::getByURIId($item['uri-id'], [Tag::HASHTAG]);
-		$tags = array_column($taglist, 'name');
+		$tags = array_column(Tag::getByURIId($item['uri-id'], [Tag::HASHTAG]), 'name');
 		return Relay::isSolicitedPost($tags, $item['body'], $item['author-id'], $item['uri'], Protocol::DFRN);
 	}
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2620,12 +2620,11 @@ class Diaspora
 		$contact = Contact::getByURL($author);
 		if (DBA::exists('contact', ["`nurl` = ? AND `uid` != ? AND `rel` IN (?, ?)",
 			$contact['nurl'], 0, Contact::FRIEND, Contact::SHARING])) {
-			Logger::info('Author has got followers - accepted', ['url' => $url, 'author' => $author]);
+			Logger::debug('Author has got followers - accepted', ['url' => $url, 'author' => $author]);
 			return true;
 		}
 
-		$taglist = Tag::getByURIId($uriid, [Tag::HASHTAG]);
-		$tags = array_column($taglist, 'name');
+		$tags = array_column(Tag::getByURIId($uriid, [Tag::HASHTAG]), 'name');
 		return Relay::isSolicitedPost($tags, $body, $contact['id'], $url, Protocol::DIASPORA);
 	}
 


### PR DESCRIPTION
This adresses the issue #11309. Diaspora and Friendica posts are already checked if they are really wanted on the receiving server. This check is now added to ActivityPub posts.