### PR TITLE
Issue 11315: Fix for all receivers in "to"

### DIFF
--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -27,6 +27,7 @@ use Friendica\Content\Text\BBCode;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\Model\Post;
+use Friendica\Model\Tag as TagModel;
 use Friendica\Model\Verb;
 use Friendica\Network\HTTPException;
 use Friendica\Protocol\Activity;
@@ -127,7 +128,7 @@ class Status extends BaseFactory
 			Post\ThreadUser::getPinned($uriId, $uid)
 		);
 
-		$sensitive   = $this->dba->exists('tag-view', ['uri-id' => $uriId, 'name' => 'nsfw']);
+		$sensitive   = $this->dba->exists('tag-view', ['uri-id' => $uriId, 'name' => 'nsfw', 'type' => TagModel::HASHTAG]);
 		$application = new \Friendica\Object\Api\Mastodon\Application($item['app'] ?: ContactSelector::networkToName($item['network'], $item['author-link']));
 
 		$mentions    = $this->mstdnMentionFactory->createFromUriId($uriId)->getArrayCopy();

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -60,8 +60,8 @@ class Tag
 	const TAG_CHARACTER = [
 		self::HASHTAG           => '#',
 		self::MENTION           => '@',
-		self::IMPLICIT_MENTION  => '%',
 		self::EXCLUSIVE_MENTION => '!',
+		self::IMPLICIT_MENTION  => '%',
 	];
 
 	/**
@@ -273,7 +273,7 @@ class Tag
 	 */
 	public static function existsForPost(int $uriid)
 	{
-		return DBA::exists('post-tag', ['uri-id' => $uriid, 'type' => [self::HASHTAG, self::MENTION, self::IMPLICIT_MENTION, self::EXCLUSIVE_MENTION]]);
+		return DBA::exists('post-tag', ['uri-id' => $uriid, 'type' => [self::HASHTAG, self::MENTION, self::EXCLUSIVE_MENTION, self::IMPLICIT_MENTION]]);
 	}
 
 	/**
@@ -355,7 +355,7 @@ class Tag
 			return;
 		}
 
-		$tags = DBA::select('tag-view', ['name', 'url'], ['uri-id' => $parent_uri_id]);
+		$tags = DBA::select('tag-view', ['name', 'url'], ['uri-id' => $parent_uri_id, 'type' => [self::MENTION, self::EXCLUSIVE_MENTION, self::IMPLICIT_MENTION]]);
 		while ($tag = DBA::fetch($tags)) {
 			self::store($uri_id, self::IMPLICIT_MENTION, $tag['name'], $tag['url']);
 		}
@@ -370,7 +370,7 @@ class Tag
 	 * @return array
 	 * @throws \Exception
 	 */
-	public static function getByURIId(int $uri_id, array $type = [self::HASHTAG, self::MENTION, self::IMPLICIT_MENTION, self::EXCLUSIVE_MENTION])
+	public static function getByURIId(int $uri_id, array $type = [self::HASHTAG, self::MENTION, self::EXCLUSIVE_MENTION, self::IMPLICIT_MENTION])
 	{
 		$condition = ['uri-id' => $uri_id, 'type' => $type];
 		return DBA::selectToArray('tag-view', ['type', 'name', 'url'], $condition);
@@ -384,7 +384,7 @@ class Tag
 	 * @return string tags and mentions
 	 * @throws \Exception
 	 */
-	public static function getCSVByURIId(int $uri_id, array $type = [self::HASHTAG, self::MENTION, self::IMPLICIT_MENTION, self::EXCLUSIVE_MENTION])
+	public static function getCSVByURIId(int $uri_id, array $type = [self::HASHTAG, self::MENTION, self::EXCLUSIVE_MENTION, self::IMPLICIT_MENTION])
 	{
 		$tag_list = [];
 		$tags = self::getByURIId($uri_id, $type);

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1408,7 +1408,7 @@ class Transmitter
 	 */
 	private static function isSensitive($uri_id)
 	{
-		return DBA::exists('tag-view', ['uri-id' => $uri_id, 'name' => 'nsfw']);
+		return DBA::exists('tag-view', ['uri-id' => $uri_id, 'name' => 'nsfw', 'type' => Tag::HASHTAG]);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #11315

When replying to your own post on a non public post then all your receivers had accidentally been put into the `to` value. This is fixed now.