### PR TITLE
Reduce amount of notifications by communities

### DIFF
--- a/src/Model/Post/UserNotification.php
+++ b/src/Model/Post/UserNotification.php
@@ -417,6 +417,14 @@ class UserNotification
 			return false;
 		}
 
+		// Don't notify about reshares by communities of our own posts or each time someone comments
+		if (($item['verb'] == Activity::ANNOUNCE) && DBA::exists('contact', ['id' => $item['contact-id'], 'contact-type' => Contact::TYPE_COMMUNITY])) {
+			$post = Post::selectFirst(['origin', 'gravity'], ['uri-id' => $item['thr-parent-id'], 'uid' => $uid]);
+			if ($post['origin'] || ($post['gravity'] != GRAVITY_PARENT)) {
+				return false;
+			}
+		}
+
 		// Check if the contact posted or shared something directly
 		if (DBA::exists('contact', ['id' => $item['contact-id'], 'notify_new_posts' => true])) {
 			return true;


### PR DESCRIPTION
You can be notified when an account creates a post or is sharing a message. This is interesting especially for community accounts, so that you don't miss a post.

But you don't need a notification when your own post was shared by a community. Also you don't need a notification with each comment.

This PR fixes this behaviour.