### PR TITLE
Issue 11309: improved check for wanted posts

### DIFF
--- a/src/Module/Debug/ActivityPubConversion.php
+++ b/src/Module/Debug/ActivityPubConversion.php
@@ -114,6 +114,10 @@ class ActivityPubConversion extends BaseModule
 					$object_data['thread-completion'] = $activity['thread-completion'];
 				}
 
+				if (!empty($activity['completion-mode'])) {
+					$object_data['completion-mode'] = $activity['completion-mode'];
+				}
+
 				$results[] = [
 					'title'   => DI::l10n()->t('Object data'),
 					'content' => visible_whitespace(var_export($object_data, true))

--- a/src/Module/Diaspora/Receive.php
+++ b/src/Module/Diaspora/Receive.php
@@ -78,7 +78,7 @@ class Receive extends BaseModule
 
 		$this->logger->info('Diaspora: Dispatching.');
 
-		Diaspora::dispatchPublic($msg);
+		Diaspora::dispatchPublic($msg, Diaspora::PUSHED);
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -898,6 +898,7 @@ class Processor
 	 * @param string $url         message URL
 	 * @param array  $child       activity array with the child of this message
 	 * @param string $relay_actor Relay actor
+	 * @param int    $completion  Completion mode, see Receiver::COMPLETION_*
 	 * @return string fetched message URL
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -192,8 +192,8 @@ class Processor
 	/**
 	 * Update an existing event
 	 *
-	 * @param int $event_id 
-	 * @param array $activity 
+	 * @param int $event_id
+	 * @param array $activity
 	 */
 	private static function updateEvent(int $event_id, array $activity)
 	{
@@ -593,7 +593,7 @@ class Processor
 			Logger::debug('Message is private - accepted', ['uri-id' => $item['uri-id'], 'guid' => $item['guid'], 'url' => $item['uri']]);
 			return true;
 		}
-		
+
 		if (!empty($activity['from-relay'])) {
 			// We check relay posts at another place. When it arrived here, the message is already checked.
 			Logger::debug('Message is a relay post that is already checked - accepted', ['uri-id' => $item['uri-id'], 'guid' => $item['guid'], 'url' => $item['uri']]);
@@ -616,7 +616,12 @@ class Processor
 		}
 
 		$tags = array_column(Tag::getByURIId($item['uri-id'], [Tag::HASHTAG]), 'name');
-		return Relay::isSolicitedPost($tags, $item['body'], $item['author-id'], $item['uri'], Protocol::ACTIVITYPUB);
+		if (Relay::isSolicitedPost($tags, $item['body'], $item['author-id'], $item['uri'], Protocol::ACTIVITYPUB)) {
+			Logger::debug('Post is accepted because of the relay settings', ['uri-id' => $item['uri-id'], 'guid' => $item['guid'], 'url' => $item['uri']]);
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -68,6 +68,12 @@ class Receiver
 	const TARGET_ANSWER = 6;
 	const TARGET_GLOBAL = 7;
 
+	const COMPLETION_NONE    = 0;
+	const COMPLETION_ANNOUCE = 1;
+	const COMPLETION_RELAY   = 2;
+	const COMPLETION_MANUAL  = 3;
+	const COMPLETION_AUTO    = 4;
+
 	/**
 	 * Checks incoming message from the inbox
 	 *
@@ -190,7 +196,7 @@ class Receiver
 			return;
 		}
 
-		$id = Processor::fetchMissingActivity($object_id, [], $actor);
+		$id = Processor::fetchMissingActivity($object_id, [], $actor, self::COMPLETION_RELAY);
 		if (empty($id)) {
 			Logger::notice('Relayed message had not been fetched', ['id' => $object_id]);
 			return;
@@ -529,6 +535,11 @@ class Receiver
 		if (!empty($activity['thread-completion'])) {
 			$object_data['thread-completion'] = $activity['thread-completion'];
 		}
+
+		if (!empty($activity['completion-mode'])) {
+			$object_data['completion-mode'] = $activity['completion-mode'];
+		}
+
 		if (!empty($activity['thread-children-type'])) {
 			$object_data['thread-children-type'] = $activity['thread-children-type'];
 		}
@@ -555,6 +566,7 @@ class Receiver
 			case 'as:Announce':
 				if (in_array($object_data['object_type'], self::CONTENT_TYPES)) {
 					$object_data['thread-completion'] = Contact::getIdForURL($actor);
+					$object_data['completion-mode']   = self::COMPLETION_ANNOUCE;
 
 					$item = ActivityPub\Processor::createItem($object_data);
 					if (empty($item)) {

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1776,7 +1776,7 @@ class DFRN
 	{
 		if (DBA::exists('contact', ["`nurl` = ? AND `uid` != ? AND `rel` IN (?, ?)",
 			Strings::normaliseLink($item["author-link"]), 0, Contact::FRIEND, Contact::SHARING])) {
-			Logger::debug('Author has got followers - accepted', ['uri' => $item['uri'], 'author' => $item["author-link"]]);
+			Logger::debug('Author has got followers - accepted', ['uri-id' => $item['uri-id'], 'guid' => $item['guid'], 'url' => $item['uri'], 'author' => $item["author-link"]]);
 			return true;
 		}
 
@@ -1792,7 +1792,7 @@ class DFRN
 
 		$tags = array_column(Tag::getByURIId($item['uri-id'], [Tag::HASHTAG]), 'name');
 		if (Relay::isSolicitedPost($tags, $item['body'], $item['author-id'], $item['uri'], Protocol::DFRN)) {
-			Logger::debug('Post is accepted because of the relay settings', ['uri' => $item['uri'], 'author' => $item["author-link"]]);
+			Logger::debug('Post is accepted because of the relay settings', ['uri-id' => $item['uri-id'], 'guid' => $item['guid'], 'url' => $item['uri'], 'author' => $item["author-link"]]);
 			return true;
 		} else {
 			return false;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2639,7 +2639,12 @@ class Diaspora
 		}
 
 		$tags = array_column(Tag::getByURIId($uriid, [Tag::HASHTAG]), 'name');
-		return Relay::isSolicitedPost($tags, $body, $contact['id'], $url, Protocol::DIASPORA);
+		if (Relay::isSolicitedPost($tags, $body, $contact['id'], $url, Protocol::DIASPORA)) {
+			Logger::debug('Post is accepted because of the relay settings', ['url' => $url, 'author' => $author]);
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	/**
@@ -2669,7 +2674,7 @@ class Diaspora
 	 * @param SimpleXMLElement $data      The message object
 	 * @param string           $xml       The original XML of the message
 	 * @param int              $direction Indicates if the message had been fetched or pushed
-	 * 
+	 *
 	 * @return int The message id of the newly created item
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -454,7 +454,7 @@ class Diaspora
 	 * Dispatches public messages and find the fitting receivers
 	 *
 	 * @param array $msg       The post that will be dispatched
-	 * @param int   $direction Indicates if the message had been fetched or pushed
+	 * @param int   $direction Indicates if the message had been fetched or pushed (self::PUSHED, self::FETCHED, self::FORCED_FETCH)
 	 *
 	 * @return int The message id of the generated message, "true" or "false" if there was an error
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
@@ -485,7 +485,7 @@ class Diaspora
 	 * @param array            $importer  Array of the importer user
 	 * @param array            $msg       The post that will be dispatched
 	 * @param SimpleXMLElement $fields    SimpleXML object that contains the message
-	 * @param int              $direction Indicates if the message had been fetched or pushed
+	 * @param int              $direction Indicates if the message had been fetched or pushed (self::PUSHED, self::FETCHED, self::FORCED_FETCH)
 	 *
 	 * @return int The message id of the generated message, "true" or "false" if there was an error
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
@@ -1449,7 +1449,7 @@ class Diaspora
 	 * @param string $sender    The sender of the message
 	 * @param object $data      The message object
 	 * @param string $xml       The original XML of the message
-	 * @param int    $direction Indicates if the message had been fetched or pushed
+	 * @param int    $direction Indicates if the message had been fetched or pushed (self::PUSHED, self::FETCHED, self::FORCED_FETCH)
 	 *
 	 * @return int The message id of the generated comment or "false" if there was an error
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
@@ -1705,7 +1705,7 @@ class Diaspora
 	 * @param array  $importer  Array of the importer user
 	 * @param string $sender    The sender of the message
 	 * @param object $data      The message object
-	 * @param int    $direction Indicates if the message had been fetched or pushed
+	 * @param int    $direction Indicates if the message had been fetched or pushed (self::PUSHED, self::FETCHED, self::FORCED_FETCH)
 	 *
 	 * @return int The message id of the generated like or "false" if there was an error
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
@@ -1892,7 +1892,7 @@ class Diaspora
 	 *
 	 * @param array  $importer  Array of the importer user
 	 * @param object $data      The message object
-	 * @param int    $direction Indicates if the message had been fetched or pushed
+	 * @param int    $direction Indicates if the message had been fetched or pushed (self::PUSHED, self::FETCHED, self::FORCED_FETCH)
 	 *
 	 * @return bool success
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
@@ -2385,7 +2385,7 @@ class Diaspora
 	 * @param array  $importer  Array of the importer user
 	 * @param object $data      The message object
 	 * @param string $xml       The original XML of the message
-	 * @param int    $direction Indicates if the message had been fetched or pushed
+	 * @param int    $direction Indicates if the message had been fetched or pushed (self::PUSHED, self::FETCHED, self::FORCED_FETCH)
 	 *
 	 * @return int the message id
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
@@ -2619,7 +2619,7 @@ class Diaspora
 	 * @param array  $item
 	 * @param string $author
 	 * @param string $body
-	 * @param int    $direction Indicates if the message had been fetched or pushed
+	 * @param int    $direction Indicates if the message had been fetched or pushed (self::PUSHED, self::FETCHED, self::FORCED_FETCH)
 	 *
 	 * @return boolean Is the message wanted?
 	 */
@@ -2672,7 +2672,7 @@ class Diaspora
 	 * @param array            $importer  Array of the importer user
 	 * @param SimpleXMLElement $data      The message object
 	 * @param string           $xml       The original XML of the message
-	 * @param int              $direction Indicates if the message had been fetched or pushed
+	 * @param int              $direction Indicates if the message had been fetched or pushed (self::PUSHED, self::FETCHED, self::FORCED_FETCH)
 	 *
 	 * @return int The message id of the newly created item
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException


### PR DESCRIPTION
Fixes #11309 by introducing two different levels that indicate why a post had been fetched. Also there is now a similar check for ActivityPub. And finally a lot of logging had been added or improved to improve the support.