### PR TITLE
Don't send notifications for activities caused by the community contact

### DIFF
--- a/src/Model/Post/UserNotification.php
+++ b/src/Model/Post/UserNotification.php
@@ -193,6 +193,8 @@ class UserNotification
 			$notification_type = $notification_type | self::TYPE_SHARED;
 			self::insertNotificationByItem(self::TYPE_SHARED, $uid, $item);
 			$notified = true;
+		} elseif ($author['contact-type'] == Contact::TYPE_COMMUNITY) {
+			return;
 		} else {
 			$notified = false;
 		}


### PR DESCRIPTION
This should help reducing the useless notifications caused by the cmmunity account.