### PR TITLE
Don't use the GUID value directly

### DIFF
--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -310,7 +310,9 @@ class Feed
 			$guid = XML::getFirstNodeValue($xpath, 'guid/text()', $entry);
 			if (!empty($guid)) {
 				$item["uri"] = $guid;
-				$item["guid"] = $guid;
+
+				// Don't use the GUID value directly but instead use it as a basis for the GUID
+				$item["guid"] = Item::guidFromUri($guid, parse_url($guid, PHP_URL_HOST) ?? parse_url($item["plink"], PHP_URL_HOST));
 			}
 
 			if (empty($item["uri"])) {


### PR DESCRIPTION
For the beauty of the GUID value we don't use the provided value directly but use it to create the GUID from it.