### PR TITLE
Add exception when message is empty in FormatteNavNotification::createFromNotification

### DIFF
--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -87,7 +87,7 @@ class Ping extends BaseModule
 
 		if (local_user()) {
 			if (DI::pConfig()->get(local_user(), 'system', 'detailed_notif')) {
-				$notifications = $this->notificationRepo->selectForUser(local_user(), [], ['limit' => 50]);
+				$notifications = $this->notificationRepo->selectForUser(local_user(), ['`vid` != ?', Verb::getID(\Friendica\Protocol\Activity::LIKE)], ['limit' => 50]);
 			} else {
 				$notifications = $this->notificationRepo->selectDigestForUser(local_user());
 			}

--- a/src/Navigation/Notifications/Exception/NoMessageException.php
+++ b/src/Navigation/Notifications/Exception/NoMessageException.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Navigation\Notifications\Exception;
+
+class NoMessageException extends \Exception
+{
+}

--- a/src/Navigation/Notifications/Factory/FormattedNavNotification.php
+++ b/src/Navigation/Notifications/Factory/FormattedNavNotification.php
@@ -25,6 +25,7 @@ use Friendica\BaseFactory;
 use Friendica\Core\Renderer;
 use Friendica\Model\Contact;
 use Friendica\Navigation\Notifications\Entity;
+use Friendica\Navigation\Notifications\Exception\NoMessageException;
 use Friendica\Navigation\Notifications\ValueObject;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy;
@@ -94,9 +95,21 @@ class FormattedNavNotification extends BaseFactory
 		);
 	}
 
+	/**
+	 * @param Entity\Notification $notification
+	 * @return ValueObject\FormattedNavNotification
+	 * @throws NoMessageException
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws \Friendica\Network\HTTPException\NotFoundException
+	 * @throws \Friendica\Network\HTTPException\ServiceUnavailableException
+	 */
 	public function createFromNotification(Entity\Notification $notification): ValueObject\FormattedNavNotification
 	{
 		$message = $this->notification->getMessageFromNotification($notification);
+
+		if (empty($message)) {
+			throw new NoMessageException();
+		}
 
 		if (!isset(self::$contacts[$notification->actorId])) {
 			self::$contacts[$notification->actorId] = Contact::getById($notification->actorId, ['name', 'url']);

--- a/src/Navigation/Notifications/Factory/Notification.php
+++ b/src/Navigation/Notifications/Factory/Notification.php
@@ -175,7 +175,7 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 				case Activity::LIKE:
 					switch ($Notification->type) {
 						case Post\UserNotification::TYPE_DIRECT_COMMENT:
-							$msg = $this->l10n->t('%1$s liked your comment %2$s');
+							$msg = $this->l10n->t('%1$s liked your comment on %2$s');
 							break;
 						case Post\UserNotification::TYPE_DIRECT_THREAD_COMMENT:
 							$msg = $this->l10n->t('%1$s liked your post %2$s');
@@ -185,7 +185,7 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 				case Activity::DISLIKE:
 					switch ($Notification->type) {
 						case Post\UserNotification::TYPE_DIRECT_COMMENT:
-							$msg = $this->l10n->t('%1$s disliked your comment %2$s');
+							$msg = $this->l10n->t('%1$s disliked your comment on %2$s');
 							break;
 						case Post\UserNotification::TYPE_DIRECT_THREAD_COMMENT:
 							$msg = $this->l10n->t('%1$s disliked your post %2$s');

--- a/src/Navigation/Notifications/Repository/Notification.php
+++ b/src/Navigation/Notifications/Repository/Notification.php
@@ -116,11 +116,12 @@ class Notification extends BaseRepository
 		    SELECT MAX(`id`)
 		    FROM notification
 		    WHERE uid = ?
+		    AND vid != ?
 		    GROUP BY IFNULL(`parent-uri-id`, `actor-id`)
 		)
 		ORDER BY `seen`, `id` DESC
 		LIMIT 50
-		", $uid);
+		", $uid, Verb::getID(\Friendica\Protocol\Activity::LIKE));
 
 		$Entities = new Collection\Notifications();
 		foreach ($rows as $fields) {

--- a/src/Navigation/Notifications/ValueObject/FormattedNavNotification.php
+++ b/src/Navigation/Notifications/ValueObject/FormattedNavNotification.php
@@ -21,12 +21,12 @@
 
 namespace Friendica\Navigation\Notifications\ValueObject;
 
-use Friendica\BaseDataTransferObject;
+use Friendica\BaseEntity;
 
 /**
  * A view-only object for printing item notifications to the frontend
  */
-class FormattedNavNotification extends BaseDataTransferObject
+class FormattedNavNotification extends BaseEntity
 {
 	/** @var array */
 	protected $contact;

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.05-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-14 08:01-0400\n"
+"POT-Creation-Date: 2022-03-14 22:29-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -8513,11 +8513,11 @@ msgstr ""
 msgid "Show unread"
 msgstr ""
 
-#: src/Module/Notifications/Ping.php:204
+#: src/Module/Notifications/Ping.php:211
 msgid "{0} requested registration"
 msgstr ""
 
-#: src/Module/Notifications/Ping.php:215
+#: src/Module/Notifications/Ping.php:222
 #, php-format
 msgid "{0} and %d others requested registration"
 msgstr ""
@@ -9963,7 +9963,7 @@ msgid ""
 "features and resources."
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/FormattedNavNotification.php:122
+#: src/Navigation/Notifications/Factory/FormattedNavNotification.php:135
 msgid "{0}} wants to follow you"
 msgstr ""
 
@@ -10032,7 +10032,7 @@ msgstr ""
 
 #: src/Navigation/Notifications/Factory/Notification.php:178
 #, php-format
-msgid "%1$s liked your comment %2$s"
+msgid "%1$s liked your comment on %2$s"
 msgstr ""
 
 #: src/Navigation/Notifications/Factory/Notification.php:181
@@ -10042,7 +10042,7 @@ msgstr ""
 
 #: src/Navigation/Notifications/Factory/Notification.php:188
 #, php-format
-msgid "%1$s disliked your comment %2$s"
+msgid "%1$s disliked your comment on %2$s"
 msgstr ""
 
 #: src/Navigation/Notifications/Factory/Notification.php:191


### PR DESCRIPTION
Follow-up to #11273
Fixes #11335 

- Filter out message less notifications in Ping