### PR TITLE
.htaccess-dist deny access to some backup files

### DIFF
--- a/.htaccess-dist
+++ b/.htaccess-dist
@@ -6,7 +6,20 @@ AddType application/x-java-archive .jar
 AddType audio/ogg .oga
 #AddHandler php53-cgi .php
 
+# deny access to log files (friendica.log or php.out)
 <FilesMatch "\.(out|log)$">
+  <IfModule authz_host_module>
+    #Apache 2.4
+    Require all denied
+  </IfModule>
+  <IfModule !authz_host_module>
+    #Apache 2.2
+    Deny from all
+  </IfModule>
+</FilesMatch>
+
+# deny access to backup files
+<FilesMatch "(~|\.bak|\.swp)$">
   <IfModule authz_host_module>
     #Apache 2.4
     Require all denied

--- a/.htaccess-dist
+++ b/.htaccess-dist
@@ -19,7 +19,7 @@ AddType audio/ogg .oga
 </FilesMatch>
 
 # deny access to backup files
-<FilesMatch "(~|\.bak|\.swp)$">
+<FilesMatch "(\~|\.bak|\.swp)$">
   <IfModule authz_host_module>
     #Apache 2.4
     Require all denied


### PR DESCRIPTION
this PR adds a filematch block to the distributed .htaccess file to deny access to backup files from emacs (~), vim (.swp) and other backup files (.bak).

addressing #11350