### PR TITLE
Add support for notification visibility settings

### DIFF
--- a/mod/settings.php
+++ b/mod/settings.php
@@ -35,8 +35,10 @@ use Friendica\Model\Item;
 use Friendica\Model\Notification;
 use Friendica\Model\Profile;
 use Friendica\Model\User;
+use Friendica\Model\Verb;
 use Friendica\Module\BaseSettings;
 use Friendica\Module\Security\Login;
+use Friendica\Protocol\Activity;
 use Friendica\Protocol\Email;
 use Friendica\Util\Temporal;
 use Friendica\Worker\Delivery;
@@ -352,7 +354,18 @@ function settings_post(App $a)
 	DI::pConfig()->set(local_user(), 'expire', 'photos', $expire_photos);
 	DI::pConfig()->set(local_user(), 'expire', 'network_only', $expire_network_only);
 
+	// Reset like notifications when they are going to be shown again
+	if (!DI::pConfig()->get(local_user(), 'system', 'notify_like') && $notify_like) {
+		DI::notification()->setAllSeenForUser(local_user(), ['vid' => Verb::getID(Activity::LIKE)]);
+	}
+
 	DI::pConfig()->set(local_user(), 'system', 'notify_like', $notify_like);
+
+	// Reset share notifications when they are going to be shown again
+	if (!DI::pConfig()->get(local_user(), 'system', 'notify_announce') && $notify_announce) {
+		DI::notification()->setAllSeenForUser(local_user(), ['vid' => Verb::getID(Activity::ANNOUNCE)]);
+	}
+
 	DI::pConfig()->set(local_user(), 'system', 'notify_announce', $notify_announce);
 
 	DI::pConfig()->set(local_user(), 'system', 'email_textonly', $email_textonly);

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -87,7 +87,7 @@ class Ping extends BaseModule
 
 		if (local_user()) {
 			if (DI::pConfig()->get(local_user(), 'system', 'detailed_notif')) {
-				$notifications = $this->notificationRepo->selectForUser(local_user(), ['`vid` != ?', Verb::getID(\Friendica\Protocol\Activity::LIKE)], ['limit' => 50, 'order' => ['id' => true]]);
+				$notifications = $this->notificationRepo->selectDetailedForUser(local_user());
 			} else {
 				$notifications = $this->notificationRepo->selectDigestForUser(local_user());
 			}


### PR DESCRIPTION
Follow-up to #11273 

Restore support to the notification visibility settings for likes and shares.