### PR TITLE
Fixes for the notifications

### DIFF
--- a/src/DI.php
+++ b/src/DI.php
@@ -537,6 +537,11 @@ abstract class DI
 		return self::$dice->create(Navigation\Notifications\Factory\FormattedNotify::class);
 	}
 
+	public static function formattedNavNotificationFactory(): Navigation\Notifications\Factory\FormattedNavNotification
+	{
+		return self::$dice->create(Navigation\Notifications\Factory\FormattedNavNotification::class);
+	}
+
 	//
 	// "Protocol" namespace instances
 	//

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -183,8 +183,6 @@ class Ping extends BaseModule
 				}
 			}
 
-			// Temporary workaround for notifications without messages like with the following verb:
-			// - \Friendica\Protocol\Activity::ANNOUNCE
 			$navNotifications = array_map(function (Entity\Notification $notification) {
 				try {
 					return $this->formattedNavNotification->createFromNotification($notification);

--- a/src/Navigation/Notifications/Factory/FormattedNavNotification.php
+++ b/src/Navigation/Notifications/Factory/FormattedNavNotification.php
@@ -133,7 +133,7 @@ class FormattedNavNotification extends BaseFactory
 		return $this->createFromParams(
 			self::$contacts[$intro->cid],
 			$this->l10n->t('{0} wants to follow you'),
-			new \DateTime($intro->datetime, new \DateTimeZone('UTC')),
+			$intro->datetime,
 			new Uri($this->baseUrl->get() . '/notifications/intros/' . $intro->id)
 		);
 	}

--- a/src/Navigation/Notifications/Factory/Notification.php
+++ b/src/Navigation/Notifications/Factory/Notification.php
@@ -107,6 +107,11 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 	{
 		$message = [];
 
+		if (Post\ThreadUser::getIgnored($Notification->parentUriId, $Notification->uid)) {
+			$this->logger->info('Thread is ignored', ['parent-uri-id' => $Notification->parentUriId, 'type' => $Notification->type]);
+			return $message;
+		}
+
 		$causer = $author = Contact::getById($Notification->actorId, ['id', 'name', 'url', 'contact-type', 'pending']);
 		if (empty($causer)) {
 			$this->logger->info('Causer not found', ['contact' => $Notification->actorId]);
@@ -128,27 +133,28 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 				return $message;
 			}
 
-			$item = Post::selectFirst([], ['uri-id' => $Notification->targetUriId, 'uid' => [0, $Notification->uid]], ['order' => ['uid' => true]]);
-			if (empty($item)) {
-				$this->logger->info('Post not found', ['uri-id' => $Notification->targetUriId]);
-				return $message;
-			}
-
-			if ($Notification->type == Post\UserNotification::TYPE_ACTIVITY_PARTICIPATION) {
-				$thrParentId = $item['thr-parent-id'];
-				$item = Post::selectFirst([], ['uri-id' => $thrParentId, 'uid' => [0, $Notification->uid]], ['order' => ['uid' => true]]);
+			if (in_array($Notification->type, [Post\UserNotification::TYPE_THREAD_COMMENT, Post\UserNotification::TYPE_COMMENT_PARTICIPATION, Post\UserNotification::TYPE_ACTIVITY_PARTICIPATION, Post\UserNotification::TYPE_EXPLICIT_TAGGED])) {
+				$item = Post::selectFirst([], ['uri-id' => $Notification->parentUriId, 'uid' => [0, $Notification->uid]], ['order' => ['uid' => true]]);
 				if (empty($item)) {
-					$this->logger->info('Thread parent post not found', ['uri-id' => $thrParentId]);
+					$this->logger->info('Parent post not found', ['uri-id' => $Notification->parentUriId]);
 					return $message;
 				}
-			}
-
-			$parent = $item;
-			if ($Notification->targetUriId != $Notification->parentUriId) {
-				$parent = Post::selectFirst([], ['uri-id' => $Notification->parentUriId, 'uid' => [0, $Notification->uid]], ['order' => ['uid' => true]]);
-				if (empty($parent)) {
-					$this->logger->info('Top level post not found', ['uri-id' => $Notification->parentUriId]);
+				if ($Notification->type == Post\UserNotification::TYPE_COMMENT_PARTICIPATION) {
+					$link_item = Post::selectFirst(['guid'], ['uri-id' => $Notification->targetUriId, 'uid' => [0, $Notification->uid]], ['order' => ['uid' => true]]);
+				}
+			} else {
+				$item = Post::selectFirst([], ['uri-id' => $Notification->targetUriId, 'uid' => [0, $Notification->uid]], ['order' => ['uid' => true]]);
+				if (empty($item)) {
+					$this->logger->info('Post not found', ['uri-id' => $Notification->targetUriId]);
 					return $message;
+				}
+
+				if (($Notification->verb == Activity::POST) || ($Notification->type === Post\UserNotification::TYPE_SHARED)) {
+					$item = Post::selectFirst([], ['uri-id' => $item['thr-parent-id'], 'uid' => [0, $Notification->uid]], ['order' => ['uid' => true]]);
+					if (empty($item)) {
+						$this->logger->info('Thread parent post not found', ['uri-id' => $item['thr-parent-id']]);
+						return $message;
+					}
 				}
 			}
 
@@ -160,9 +166,9 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 				}
 			}
 
-			$link = $this->baseUrl . '/display/' . urlencode($item['guid']);
+			$link = $this->baseUrl . '/display/' . urlencode($link_item['guid'] ?? $item['guid']);
 
-			$content = Plaintext::getPost($parent, 70);
+			$content = Plaintext::getPost($item, 70);
 			if (!empty($content['text'])) {
 				$title = '"' . trim(str_replace("\n", " ", $content['text'])) . '"';
 			} else {
@@ -298,6 +304,8 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 				'[url=' . $link . ']' . $title . '[/url]',
 				'[url=' . $author['url'] . ']' . $author['name'] . '[/url]');
 			$message['link'] = $link;
+		} else {
+			$this->logger->debug('Unhandled notification', ['notification' => $Notification]);
 		}
 
 		return $message;

--- a/src/Navigation/Notifications/Factory/Notification.php
+++ b/src/Navigation/Notifications/Factory/Notification.php
@@ -107,11 +107,6 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 	{
 		$message = [];
 
-		if (Post\ThreadUser::getIgnored($Notification->parentUriId, $Notification->uid)) {
-			$this->logger->info('Thread is ignored', ['parent-uri-id' => $Notification->parentUriId, 'type' => $Notification->type]);
-			return $message;
-		}
-
 		$causer = $author = Contact::getById($Notification->actorId, ['id', 'name', 'url', 'contact-type', 'pending']);
 		if (empty($causer)) {
 			$this->logger->info('Causer not found', ['contact' => $Notification->actorId]);
@@ -133,6 +128,11 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 				return $message;
 			}
 
+			if (Post\ThreadUser::getIgnored($Notification->parentUriId, $Notification->uid)) {
+				$this->logger->info('Thread is ignored', ['parent-uri-id' => $Notification->parentUriId, 'type' => $Notification->type]);
+				return $message;
+			}
+	
 			if (in_array($Notification->type, [Post\UserNotification::TYPE_THREAD_COMMENT, Post\UserNotification::TYPE_COMMENT_PARTICIPATION, Post\UserNotification::TYPE_ACTIVITY_PARTICIPATION, Post\UserNotification::TYPE_EXPLICIT_TAGGED])) {
 				$item = Post::selectFirst([], ['uri-id' => $Notification->parentUriId, 'uid' => [0, $Notification->uid]], ['order' => ['uid' => true]]);
 				if (empty($item)) {

--- a/src/Navigation/Notifications/Repository/Notification.php
+++ b/src/Navigation/Notifications/Repository/Notification.php
@@ -125,7 +125,7 @@ class Notification extends BaseRepository
 			$condition = DBA::mergeConditions($condition, ['`vid` != ?', Verb::getID(\Friendica\Protocol\Activity::ANNOUNCE)]);
 		}
 
-		return $this->selectForUser(local_user(), $condition, ['limit' => 50, 'order' => ['id' => true]]);
+		return $this->selectForUser($uid, $condition, ['limit' => 50, 'order' => ['id' => true]]);
 	}
 
 	/**


### PR DESCRIPTION
This fixes some small issues in the notifications:
- The notification for likes now refers to the correct item (the previous behaviour is restored)
- Ignored threads are ignored
- Removed comment concerning the "workaround" since it is expected that not every notification entry really causes a notification
- Fixed wrong parameter for "createFromIntro"
- `local_user()` call replaced by the correct variable