### PR TITLE
Don't create empty announce notifications

### DIFF
--- a/src/Model/Post/UserNotification.php
+++ b/src/Model/Post/UserNotification.php
@@ -220,7 +220,7 @@ class UserNotification
 			return;
 		}
 
-		if (self::checkExplicitMention($item, $profiles)) {
+		if (($item['verb'] != Activity::ANNOUNCE) && self::checkExplicitMention($item, $profiles)) {
 			$notification_type = $notification_type | self::TYPE_EXPLICIT_TAGGED;
 			if (!$notified) {
 				self::insertNotificationByItem(self::TYPE_EXPLICIT_TAGGED, $uid, $item);
@@ -228,7 +228,7 @@ class UserNotification
 			}
 		}
 
-		if (self::checkImplicitMention($item, $profiles)) {
+		if (($item['verb'] != Activity::ANNOUNCE) && self::checkImplicitMention($item, $profiles)) {
 			$notification_type = $notification_type | self::TYPE_IMPLICIT_TAGGED;
 			if (!$notified) {
 				self::insertNotificationByItem(self::TYPE_IMPLICIT_TAGGED, $uid, $item);
@@ -252,7 +252,7 @@ class UserNotification
 			}
 		}
 
-		if (self::checkCommentedThread($item, $contacts)) {
+		if (($item['verb'] != Activity::ANNOUNCE) && self::checkCommentedThread($item, $contacts)) {
 			$notification_type = $notification_type | self::TYPE_THREAD_COMMENT;
 			if (!$notified) {
 				self::insertNotificationByItem(self::TYPE_THREAD_COMMENT, $uid, $item);
@@ -260,7 +260,7 @@ class UserNotification
 			}
 		}
 
-		if (self::checkCommentedParticipation($item, $contacts)) {
+		if (($item['verb'] != Activity::ANNOUNCE) && self::checkCommentedParticipation($item, $contacts)) {
 			$notification_type = $notification_type | self::TYPE_COMMENT_PARTICIPATION;
 			if (!$notified) {
 				self::insertNotificationByItem(self::TYPE_COMMENT_PARTICIPATION, $uid, $item);
@@ -268,7 +268,7 @@ class UserNotification
 			}
 		}
 
-		if (self::checkActivityParticipation($item, $contacts)) {
+		if (($item['verb'] != Activity::ANNOUNCE) && self::checkActivityParticipation($item, $contacts)) {
 			$notification_type = $notification_type | self::TYPE_ACTIVITY_PARTICIPATION;
 			if (!$notified) {
 				self::insertNotificationByItem(self::TYPE_ACTIVITY_PARTICIPATION, $uid, $item);

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -33,6 +33,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Group;
 use Friendica\Model\Post;
+use Friendica\Model\User;
 use Friendica\Model\Verb;
 use Friendica\Module\Register;
 use Friendica\Module\Response;
@@ -183,7 +184,12 @@ class Ping extends BaseModule
 				}
 			}
 
-			$navNotifications = array_map(function (Entity\Notification $notification) {
+			$owner = User::getOwnerDataById(local_user());
+
+			$navNotifications = array_map(function (Entity\Notification $notification) use ($owner) {
+				if (($notification->type == Post\UserNotification::TYPE_NONE) && in_array($owner['page-flags'], [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_PRVGROUP])) {
+					return null;
+				}
 				try {
 					return $this->formattedNavNotification->createFromNotification($notification);
 				} catch (NoMessageException $e) {

--- a/src/Navigation/Notifications/Repository/Notification.php
+++ b/src/Navigation/Notifications/Repository/Notification.php
@@ -138,8 +138,7 @@ class Notification extends BaseRepository
 	 */
 	public function selectDigestForUser(int $uid): Collection\Notifications
 	{
-		$values = [$uid, Verb::getID(\Friendica\Protocol\Activity::ANNOUNCE),
-			UserNotification::TYPE_COMMENT_PARTICIPATION, UserNotification::TYPE_ACTIVITY_PARTICIPATION, UserNotification::TYPE_THREAD_COMMENT];
+		$values = [$uid];
 
 		$like_condition = '';
 		if (!$this->pconfig->get($uid, 'system', 'notify_like')) {
@@ -159,7 +158,7 @@ class Notification extends BaseRepository
 		WHERE `id` IN (
 		    SELECT MAX(`id`)
 		    FROM `notification`
-		    WHERE `uid` = ? AND NOT (`vid` = ? AND `type` IN (?, ?, ?))
+		    WHERE `uid` = ?
 		    $like_condition
 		    $announce_condition
 		    GROUP BY IFNULL(`parent-uri-id`, `actor-id`)


### PR DESCRIPTION
This fixes the problem that notifications for annouce had been created that don't result in notification messages.