### PR TITLE
Prioritize the title over the summary (content warning)

### DIFF
--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -631,10 +631,10 @@ class Conversation
 
 					[$categories, $folders] = $this->item->determineCategoriesTerms($item, local_user());
 
-					if (!empty($item['content-warning']) && $this->pConfig->get(local_user(), 'system', 'disable_cw', false)) {
-						$title = ucfirst($item['content-warning']);
-					} else {
+					if (!empty($item['title'])) {
 						$title = $item['title'];
+					} elseif (!empty($item['content-warning']) && $this->pConfig->get(local_user(), 'system', 'disable_cw', false)) {
+						$title = ucfirst($item['content-warning']);
 					}
 
 					$tmp_item = [

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -635,6 +635,8 @@ class Conversation
 						$title = $item['title'];
 					} elseif (!empty($item['content-warning']) && $this->pConfig->get(local_user(), 'system', 'disable_cw', false)) {
 						$title = ucfirst($item['content-warning']);
+					} else {
+						$title = '';
 					}
 
 					$tmp_item = [

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -393,6 +393,8 @@ class Post
 			$title = $item['title'];
 		} elseif (!empty($item['content-warning']) && DI::pConfig()->get(local_user(), 'system', 'disable_cw', false)) {
 			$title = ucfirst($item['content-warning']);
+		} else {
+			$title = '';
 		}
 
 		if (DI::pConfig()->get(local_user(), 'system', 'hide_dislike')) {

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -389,10 +389,10 @@ class Post
 
 		list($categories, $folders) = DI::contentItem()->determineCategoriesTerms($item, local_user());
 
-		if (!empty($item['content-warning']) && DI::pConfig()->get(local_user(), 'system', 'disable_cw', false)) {
-			$title = ucfirst($item['content-warning']);
-		} else {
+		if (!empty($item['title'])) {
 			$title = $item['title'];
+		} elseif (!empty($item['content-warning']) && DI::pConfig()->get(local_user(), 'system', 'disable_cw', false)) {
+			$title = ucfirst($item['content-warning']);
 		}
 
 		if (DI::pConfig()->get(local_user(), 'system', 'hide_dislike')) {


### PR DESCRIPTION
When a post has got both a title and a summary (which is used as a content warning) then we now display the title.

This mostly comes into effect with automated posts that had been created from feeds that provide summaries.