### PR TITLE
Avoid returning of the actor when requesting friendica/json

### DIFF
--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -112,7 +112,12 @@ class Friendica extends BaseModule
 
 	protected function rawContent(array $request = [])
 	{
-		if (ActivityPub::isRequest()) {
+		// @TODO: Replace with parameter from router
+		if (DI::args()->getArgc() <= 1 || (DI::args()->getArgv()[1] !== 'json')) {
+			if (!ActivityPub::isRequest()) {
+				return;
+			}
+
 			try {
 				$data = ActivityPub\Transmitter::getProfile(0);
 				header('Access-Control-Allow-Origin: *');
@@ -121,11 +126,6 @@ class Friendica extends BaseModule
 			} catch (HTTPException\NotFoundException $e) {
 				System::jsonError(404, ['error' => 'Record not found']);
 			}
-		}
-
-		// @TODO: Replace with parameter from router
-		if (DI::args()->getArgc() <= 1 || (DI::args()->getArgv()[1] !== 'json')) {
-			return;
 		}
 
 		$config = DI::config();


### PR DESCRIPTION
This fixes the bug that the system actor is returned when the url `friendica/json` is requested with the `Expect` value of `application/json`.