### PR TITLE
Introduce explicit HttpClient "Accept" parameter

### DIFF
--- a/mod/ostatus_subscribe.php
+++ b/mod/ostatus_subscribe.php
@@ -25,7 +25,6 @@ use Friendica\DI;
 use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
-use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Protocol\ActivityPub;
 
 function ostatus_subscribe_content(App $a)
@@ -59,7 +58,7 @@ function ostatus_subscribe_content(App $a)
 			$api = $contact['baseurl'] . '/api/';
 
 			// Fetching friends
-			$curlResult = DI::httpClient()->get($api . 'statuses/friends.json?screen_name=' . $contact['nick'], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+			$curlResult = DI::httpClient()->get($api . 'statuses/friends.json?screen_name=' . $contact['nick'], HttpClientAccept::JSON);
 
 			if (!$curlResult->isSuccess()) {
 				DI::pConfig()->delete($uid, 'ostatus', 'legacy_contact');

--- a/mod/ostatus_subscribe.php
+++ b/mod/ostatus_subscribe.php
@@ -24,7 +24,7 @@ use Friendica\Core\Protocol;
 use Friendica\DI;
 use Friendica\Model\APContact;
 use Friendica\Model\Contact;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Protocol\ActivityPub;
 
@@ -59,7 +59,7 @@ function ostatus_subscribe_content(App $a)
 			$api = $contact['baseurl'] . '/api/';
 
 			// Fetching friends
-			$curlResult = DI::httpClient()->get($api . 'statuses/friends.json?screen_name=' . $contact['nick'], [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+			$curlResult = DI::httpClient()->get($api . 'statuses/friends.json?screen_name=' . $contact['nick'], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 
 			if (!$curlResult->isSuccess()) {
 				DI::pConfig()->delete($uid, 'ostatus', 'legacy_contact');

--- a/mod/redir.php
+++ b/mod/redir.php
@@ -27,7 +27,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Profile;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Util\Strings;
 
@@ -144,7 +144,7 @@ function redir_magic($a, $cid, $url)
 	}
 
 	// Test for magic auth on the target system
-	$serverret = DI::httpClient()->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_HTML]);
+	$serverret = DI::httpClient()->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
 	if ($serverret->isSuccess()) {
 		$separator = strpos($target_url, '?') ? '&' : '?';
 		$target_url .= $separator . 'zrl=' . urlencode($visitor) . '&addr=' . urlencode($contact_url);

--- a/mod/redir.php
+++ b/mod/redir.php
@@ -27,7 +27,6 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Profile;
-use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Util\Strings;
 
 function redir_init(App $a) {
@@ -143,7 +142,7 @@ function redir_magic($a, $cid, $url)
 	}
 
 	// Test for magic auth on the target system
-	$serverret = DI::httpClient()->head($basepath . '/magic', HttpClientAccept::HTML);
+	$serverret = DI::httpClient()->head($basepath . '/magic');
 	if ($serverret->isSuccess()) {
 		$separator = strpos($target_url, '?') ? '&' : '?';
 		$target_url .= $separator . 'zrl=' . urlencode($visitor) . '&addr=' . urlencode($contact_url);

--- a/mod/redir.php
+++ b/mod/redir.php
@@ -27,6 +27,8 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Profile;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
+use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Util\Strings;
 
 function redir_init(App $a) {
@@ -142,7 +144,7 @@ function redir_magic($a, $cid, $url)
 	}
 
 	// Test for magic auth on the target system
-	$serverret = DI::httpClient()->head($basepath . '/magic');
+	$serverret = DI::httpClient()->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
 	if ($serverret->isSuccess()) {
 		$separator = strpos($target_url, '?') ? '&' : '?';
 		$target_url .= $separator . 'zrl=' . urlencode($visitor) . '&addr=' . urlencode($contact_url);

--- a/mod/redir.php
+++ b/mod/redir.php
@@ -28,7 +28,6 @@ use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Profile;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
-use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Util\Strings;
 
 function redir_init(App $a) {
@@ -144,7 +143,7 @@ function redir_magic($a, $cid, $url)
 	}
 
 	// Test for magic auth on the target system
-	$serverret = DI::httpClient()->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
+	$serverret = DI::httpClient()->head($basepath . '/magic', HttpClientAccept::HTML);
 	if ($serverret->isSuccess()) {
 		$separator = strpos($target_url, '?') ? '&' : '?';
 		$target_url .= $separator . 'zrl=' . urlencode($visitor) . '&addr=' . urlencode($contact_url);

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -32,7 +32,7 @@ use Friendica\Core\Renderer;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\ParseUrl;
@@ -98,7 +98,7 @@ class OEmbed
 
 			if (!in_array($ext, $noexts)) {
 				// try oembed autodiscovery
-				$html_text = DI::httpClient()->fetch($embedurl, 15, HttpClient::ACCEPT_HTML);
+				$html_text = DI::httpClient()->fetch($embedurl, 15, HttpClientAccept::HTML);
 				if (!empty($html_text)) {
 					$dom = new DOMDocument();
 					if (@$dom->loadHTML($html_text)) {

--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -98,7 +98,7 @@ class OEmbed
 
 			if (!in_array($ext, $noexts)) {
 				// try oembed autodiscovery
-				$html_text = DI::httpClient()->fetch($embedurl, 15, HttpClientAccept::HTML);
+				$html_text = DI::httpClient()->fetch($embedurl, HttpClientAccept::HTML, 15);
 				if (!empty($html_text)) {
 					$dom = new DOMDocument();
 					if (@$dom->loadHTML($html_text)) {

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -502,7 +502,7 @@ class BBCode
 					continue;
 				}
 
-				$curlResult = DI::httpClient()->get($mtch[1], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::IMAGE]);
+				$curlResult = DI::httpClient()->get($mtch[1], HttpClientAccept::IMAGE);
 				if (!$curlResult->isSuccess()) {
 					continue;
 				}
@@ -1204,7 +1204,7 @@ class BBCode
 		$text = DI::cache()->get($cache_key);
 
 		if (is_null($text)) {
-			$curlResult = DI::httpClient()->head($match[1], [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout'), HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
+			$curlResult = DI::httpClient()->head($match[1], HttpClientAccept::DEFAULT, [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
 			if ($curlResult->isSuccess()) {
 				$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 			} else {
@@ -1217,7 +1217,7 @@ class BBCode
 				$text = "[url=" . $match[2] . ']' . $match[2] . "[/url]";
 
 				// if its not a picture then look if its a page that contains a picture link
-				$body = DI::httpClient()->fetch($match[1], 0, HttpClientAccept::HTML);
+				$body = DI::httpClient()->fetch($match[1], HttpClientAccept::HTML, 0);
 				if (empty($body)) {
 					DI::cache()->set($cache_key, $text);
 					return $text;
@@ -1275,7 +1275,7 @@ class BBCode
 			return $text;
 		}
 
-		$curlResult = DI::httpClient()->head($match[1], [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout'), HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
+		$curlResult = DI::httpClient()->head($match[1], HttpClientAccept::DEFAULT, [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
 		if ($curlResult->isSuccess()) {
 			$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 		} else {
@@ -1293,7 +1293,7 @@ class BBCode
 			}
 
 			// if its not a picture then look if its a page that contains a picture link
-			$body = DI::httpClient()->fetch($match[1], 0, HttpClientAccept::HTML);
+			$body = DI::httpClient()->fetch($match[1], HttpClientAccept::HTML, 0);
 			if (empty($body)) {
 				DI::cache()->set($cache_key, $text);
 				return $text;

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1204,7 +1204,7 @@ class BBCode
 		$text = DI::cache()->get($cache_key);
 
 		if (is_null($text)) {
-			$curlResult = DI::httpClient()->head($match[1], HttpClientAccept::DEFAULT, [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
+			$curlResult = DI::httpClient()->head($match[1], [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
 			if ($curlResult->isSuccess()) {
 				$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 			} else {
@@ -1275,7 +1275,7 @@ class BBCode
 			return $text;
 		}
 
-		$curlResult = DI::httpClient()->head($match[1], HttpClientAccept::DEFAULT, [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
+		$curlResult = DI::httpClient()->head($match[1], [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout')]);
 		if ($curlResult->isSuccess()) {
 			$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 		} else {

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -39,7 +39,7 @@ use Friendica\Model\Event;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Object\Image;
 use Friendica\Protocol\Activity;
@@ -502,7 +502,7 @@ class BBCode
 					continue;
 				}
 
-				$curlResult = DI::httpClient()->get($mtch[1], [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_IMAGE]);
+				$curlResult = DI::httpClient()->get($mtch[1], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::IMAGE]);
 				if (!$curlResult->isSuccess()) {
 					continue;
 				}
@@ -1204,7 +1204,7 @@ class BBCode
 		$text = DI::cache()->get($cache_key);
 
 		if (is_null($text)) {
-			$curlResult = DI::httpClient()->head($match[1], [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout'), HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_DEFAULT]);
+			$curlResult = DI::httpClient()->head($match[1], [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout'), HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
 			if ($curlResult->isSuccess()) {
 				$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 			} else {
@@ -1217,7 +1217,7 @@ class BBCode
 				$text = "[url=" . $match[2] . ']' . $match[2] . "[/url]";
 
 				// if its not a picture then look if its a page that contains a picture link
-				$body = DI::httpClient()->fetch($match[1], 0, HttpClient::ACCEPT_HTML);
+				$body = DI::httpClient()->fetch($match[1], 0, HttpClientAccept::HTML);
 				if (empty($body)) {
 					DI::cache()->set($cache_key, $text);
 					return $text;
@@ -1275,7 +1275,7 @@ class BBCode
 			return $text;
 		}
 
-		$curlResult = DI::httpClient()->head($match[1], [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout'), HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_DEFAULT]);
+		$curlResult = DI::httpClient()->head($match[1], [HttpClientOptions::TIMEOUT => DI::config()->get('system', 'xrd_timeout'), HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
 		if ($curlResult->isSuccess()) {
 			$mimetype = $curlResult->getHeader('Content-Type')[0] ?? '';
 		} else {
@@ -1293,7 +1293,7 @@ class BBCode
 			}
 
 			// if its not a picture then look if its a page that contains a picture link
-			$body = DI::httpClient()->fetch($match[1], 0, HttpClient::ACCEPT_HTML);
+			$body = DI::httpClient()->fetch($match[1], 0, HttpClientAccept::HTML);
 			if (empty($body)) {
 				DI::cache()->set($cache_key, $text);
 				return $text;

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -25,7 +25,6 @@ use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException;
-use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Object\Search\ContactResult;
 use Friendica\Object\Search\ResultList;
 use Friendica\Util\Network;
@@ -123,7 +122,7 @@ class Search
 			$searchUrl .= '&page=' . $page;
 		}
 
-		$resultJson = DI::httpClient()->fetch($searchUrl, 0, HttpClientAccept::JSON);
+		$resultJson = DI::httpClient()->fetch($searchUrl, HttpClientAccept::JSON);
 
 		$results = json_decode($resultJson, true);
 
@@ -229,7 +228,7 @@ class Search
 			$return = Contact::searchByName($search, $mode);
 		} else {
 			$p = $page > 1 ? 'p=' . $page : '';
-			$curlResult = DI::httpClient()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+			$curlResult = DI::httpClient()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), HttpClientAccept::JSON);
 			if ($curlResult->isSuccess()) {
 				$searchResult = json_decode($curlResult->getBody(), true);
 				if (!empty($searchResult['profiles'])) {

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -23,7 +23,7 @@ namespace Friendica\Core;
 
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Object\Search\ContactResult;
@@ -123,7 +123,7 @@ class Search
 			$searchUrl .= '&page=' . $page;
 		}
 
-		$resultJson = DI::httpClient()->fetch($searchUrl, 0, HttpClient::ACCEPT_JSON);
+		$resultJson = DI::httpClient()->fetch($searchUrl, 0, HttpClientAccept::JSON);
 
 		$results = json_decode($resultJson, true);
 
@@ -229,7 +229,7 @@ class Search
 			$return = Contact::searchByName($search, $mode);
 		} else {
 			$p = $page > 1 ? 'p=' . $page : '';
-			$curlResult = DI::httpClient()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+			$curlResult = DI::httpClient()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 			if ($curlResult->isSuccess()) {
 				$searchResult = json_decode($curlResult->getBody(), true);
 				if (!empty($searchResult['profiles'])) {

--- a/src/Core/Storage/Type/ExternalResource.php
+++ b/src/Core/Storage/Type/ExternalResource.php
@@ -25,7 +25,7 @@ use Exception;
 use Friendica\Core\Logger;
 use Friendica\Core\Storage\Exception\ReferenceStorageException;
 use Friendica\Core\Storage\Capability\ICanReadFromStorage;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Util\HTTPSignature;
 
@@ -55,7 +55,7 @@ class ExternalResource implements ICanReadFromStorage
 		}
 
 		try {
-			$fetchResult = HTTPSignature::fetchRaw($data->url, $data->uid, [HttpClientOptions::ACCEPT_CONTENT => [HttpClient::ACCEPT_IMAGE]]);
+			$fetchResult = HTTPSignature::fetchRaw($data->url, $data->uid, [HttpClientOptions::ACCEPT_CONTENT => [HttpClientAccept::IMAGE]]);
 		} catch (Exception $exception) {
 			throw new ReferenceStorageException(sprintf('External resource failed to get %s', $reference), $exception->getCode(), $exception);
 		}

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -28,7 +28,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\DI;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException;
 use Friendica\Network\Probe;
 use Friendica\Protocol\ActivityNamespace;
@@ -72,10 +72,10 @@ class APContact
 
 		$data = ['addr' => $addr];
 		$template = 'https://' . $addr_parts[1] . '/.well-known/webfinger?resource=acct:' . urlencode($addr);
-		$webfinger = Probe::webfinger(str_replace('{uri}', urlencode($addr), $template), HttpClient::ACCEPT_JRD_JSON);
+		$webfinger = Probe::webfinger(str_replace('{uri}', urlencode($addr), $template), HttpClientAccept::JRD_JSON);
 		if (empty($webfinger['links'])) {
 			$template = 'http://' . $addr_parts[1] . '/.well-known/webfinger?resource=acct:' . urlencode($addr);
-			$webfinger = Probe::webfinger(str_replace('{uri}', urlencode($addr), $template), HttpClient::ACCEPT_JRD_JSON);
+			$webfinger = Probe::webfinger(str_replace('{uri}', urlencode($addr), $template), HttpClientAccept::JRD_JSON);
 			if (empty($webfinger['links'])) {
 				return [];
 			}

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -344,7 +344,7 @@ class GServer
 
 		// When a nodeinfo is present, we don't need to dig further
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpClient()->get($url . '/.well-known/nodeinfo', [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/.well-known/nodeinfo', HttpClientAccept::JSON, [HttpClientOptions::TIMEOUT => $xrd_timeout]);
 		if ($curlResult->isTimeout()) {
 			self::setFailure($url);
 			return false;
@@ -352,7 +352,7 @@ class GServer
 
 		// On a redirect follow the new host but mark the old one as failure
 		if ($curlResult->isSuccess() && !empty($curlResult->getRedirectUrl()) && (parse_url($url, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST))) {
-			$curlResult = DI::httpClient()->get($url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
+			$curlResult = DI::httpClient()->get($url, HttpClientAccept::HTML, [HttpClientOptions::TIMEOUT => $xrd_timeout]);
 			if (!empty($curlResult->getRedirectUrl()) && parse_url($url, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST)) {
 				Logger::info('Found redirect. Mark old entry as failure', ['old' => $url, 'new' => $curlResult->getRedirectUrl()]);
 				self::setFailure($url);
@@ -394,7 +394,7 @@ class GServer
 					$basedata = ['detection-method' => self::DETECT_MANUAL];
 				}
 
-				$curlResult = DI::httpClient()->get($baseurl, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
+				$curlResult = DI::httpClient()->get($baseurl, HttpClientAccept::HTML, [HttpClientOptions::TIMEOUT => $xrd_timeout]);
 				if ($curlResult->isSuccess()) {
 					if (!empty($curlResult->getRedirectUrl()) && (parse_url($baseurl, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST))) {
 						Logger::info('Found redirect. Mark old entry as failure', ['old' => $url, 'new' => $curlResult->getRedirectUrl()]);
@@ -418,7 +418,7 @@ class GServer
 					// When the base path doesn't seem to contain a social network we try the complete path.
 					// Most detectable system have to be installed in the root directory.
 					// We checked the base to avoid false positives.
-					$curlResult = DI::httpClient()->get($url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
+					$curlResult = DI::httpClient()->get($url, HttpClientAccept::HTML, [HttpClientOptions::TIMEOUT => $xrd_timeout]);
 					if ($curlResult->isSuccess()) {
 						$urldata = self::analyseRootHeader($curlResult, $serverdata);
 						$urldata = self::analyseRootBody($curlResult, $urldata, $url);
@@ -588,7 +588,7 @@ class GServer
 	{
 		Logger::info('Discover relay data', ['server' => $server_url]);
 
-		$curlResult = DI::httpClient()->get($server_url . '/.well-known/x-social-relay', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($server_url . '/.well-known/x-social-relay', HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess()) {
 			return;
 		}
@@ -683,7 +683,7 @@ class GServer
 	 */
 	private static function fetchStatistics(string $url)
 	{
-		$curlResult = DI::httpClient()->get($url . '/statistics.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/statistics.json', HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess()) {
 			return [];
 		}
@@ -809,7 +809,7 @@ class GServer
 	 */
 	private static function parseNodeinfo1(string $nodeinfo_url)
 	{
-		$curlResult = DI::httpClient()->get($nodeinfo_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($nodeinfo_url, HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess()) {
 			return [];
 		}
@@ -902,7 +902,7 @@ class GServer
 	 */
 	private static function parseNodeinfo2(string $nodeinfo_url)
 	{
-		$curlResult = DI::httpClient()->get($nodeinfo_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($nodeinfo_url, HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess()) {
 			return [];
 		}
@@ -997,7 +997,7 @@ class GServer
 	 */
 	private static function fetchSiteinfo(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/siteinfo.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/siteinfo.json', HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
 		}
@@ -1082,7 +1082,7 @@ class GServer
 	private static function validHostMeta(string $url)
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpClient()->get($url . '/.well-known/host-meta', [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::XRD_XML]);
+		$curlResult = DI::httpClient()->get($url . '/.well-known/host-meta', HttpClientAccept::XRD_XML, [HttpClientOptions::TIMEOUT => $xrd_timeout]);
 		if (!$curlResult->isSuccess()) {
 			return false;
 		}
@@ -1174,7 +1174,7 @@ class GServer
 	{
 		$serverdata['poco'] = '';
 
-		$curlResult = DI::httpClient()->get($url . '/poco', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/poco', HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
 		}
@@ -1204,7 +1204,7 @@ class GServer
 	 */
 	public static function checkMastodonDirectory(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/api/v1/directory?limit=1', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/v1/directory?limit=1', HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
 		}
@@ -1231,7 +1231,7 @@ class GServer
 	 */
 	private static function detectPeertube(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/api/v1/config', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/v1/config', HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
 		}
@@ -1278,7 +1278,7 @@ class GServer
 	 */
 	private static function detectNextcloud(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/status.php', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/status.php', HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
 		}
@@ -1302,7 +1302,7 @@ class GServer
 	}
 
 	private static function fetchWeeklyUsage(string $url, array $serverdata) {
-		$curlResult = DI::httpClient()->get($url . '/api/v1/instance/activity', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/v1/instance/activity', HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
 		}
@@ -1370,7 +1370,7 @@ class GServer
 	 */
 	private static function detectMastodonAlikes(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/api/v1/instance', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/v1/instance', HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
 		}
@@ -1435,7 +1435,7 @@ class GServer
 	 */
 	private static function detectHubzilla(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/api/statusnet/config.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/statusnet/config.json', HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
 		}
@@ -1532,7 +1532,7 @@ class GServer
 	 */
 	private static function detectPumpIO(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/.well-known/host-meta.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/.well-known/host-meta.json', HttpClientAccept::JSON);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
 		}
@@ -1583,7 +1583,7 @@ class GServer
 	private static function detectGNUSocial(string $url, array $serverdata)
 	{
 		// Test for GNU Social
-		$curlResult = DI::httpClient()->get($url . '/api/gnusocial/version.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/gnusocial/version.json', HttpClientAccept::JSON);
 		if ($curlResult->isSuccess() && ($curlResult->getBody() != '{"error":"not implemented"}') &&
 			($curlResult->getBody() != '') && (strlen($curlResult->getBody()) < 30)) {
 			$serverdata['platform'] = 'gnusocial';
@@ -1601,7 +1601,7 @@ class GServer
 		}
 
 		// Test for Statusnet
-		$curlResult = DI::httpClient()->get($url . '/api/statusnet/version.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/statusnet/version.json', HttpClientAccept::JSON);
 		if ($curlResult->isSuccess() && ($curlResult->getBody() != '{"error":"not implemented"}') &&
 			($curlResult->getBody() != '') && (strlen($curlResult->getBody()) < 30)) {
 
@@ -1639,9 +1639,9 @@ class GServer
 	{
 		// There is a bug in some versions of Friendica that will return an ActivityStream actor when the content type "application/json" is requested.
 		// Because of this me must not use ACCEPT_JSON here.
-		$curlResult = DI::httpClient()->get($url . '/friendica/json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
+		$curlResult = DI::httpClient()->get($url . '/friendica/json');
 		if (!$curlResult->isSuccess()) {
-			$curlResult = DI::httpClient()->get($url . '/friendika/json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
+			$curlResult = DI::httpClient()->get($url . '/friendika/json');
 			$friendika = true;
 			$platform = 'Friendika';
 		} else {
@@ -1946,7 +1946,7 @@ class GServer
 		$protocols = ['activitypub', 'diaspora', 'dfrn', 'ostatus'];
 		foreach ($protocols as $protocol) {
 			$query = '{nodes(protocol:"' . $protocol . '"){host}}';
-			$curlResult = DI::httpClient()->fetch('https://the-federation.info/graphql?query=' . urlencode($query), 0, HttpClientAccept::JSON);
+			$curlResult = DI::httpClient()->fetch('https://the-federation.info/graphql?query=' . urlencode($query), HttpClientAccept::JSON);
 			if (!empty($curlResult)) {
 				$data = json_decode($curlResult, true);
 				if (!empty($data['data']['nodes'])) {
@@ -1963,7 +1963,7 @@ class GServer
 
 		if (!empty($accesstoken)) {
 			$api = 'https://instances.social/api/1.0/instances/list?count=0';
-			$curlResult = DI::httpClient()->get($api, [HttpClientOptions::HEADERS => ['Authorization' => ['Bearer ' . $accesstoken]], HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+			$curlResult = DI::httpClient()->get($api, HttpClientAccept::JSON, [HttpClientOptions::HEADERS => ['Authorization' => ['Bearer ' . $accesstoken]]]);
 			if ($curlResult->isSuccess()) {
 				$servers = json_decode($curlResult->getBody(), true);
 

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -32,9 +32,9 @@ use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Module\Register;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\HTTPClient\Capability\ICanHandleHttpResponses;
-use Friendica\Network\HTTPClient\Client\HttpClient;
 use Friendica\Protocol\Relay;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
@@ -344,7 +344,7 @@ class GServer
 
 		// When a nodeinfo is present, we don't need to dig further
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpClient()->get($url . '/.well-known/nodeinfo', [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/.well-known/nodeinfo', [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if ($curlResult->isTimeout()) {
 			self::setFailure($url);
 			return false;
@@ -352,7 +352,7 @@ class GServer
 
 		// On a redirect follow the new host but mark the old one as failure
 		if ($curlResult->isSuccess() && !empty($curlResult->getRedirectUrl()) && (parse_url($url, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST))) {
-			$curlResult = DI::httpClient()->get($url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_HTML]);
+			$curlResult = DI::httpClient()->get($url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
 			if (!empty($curlResult->getRedirectUrl()) && parse_url($url, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST)) {
 				Logger::info('Found redirect. Mark old entry as failure', ['old' => $url, 'new' => $curlResult->getRedirectUrl()]);
 				self::setFailure($url);
@@ -394,7 +394,7 @@ class GServer
 					$basedata = ['detection-method' => self::DETECT_MANUAL];
 				}
 
-				$curlResult = DI::httpClient()->get($baseurl, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_HTML]);
+				$curlResult = DI::httpClient()->get($baseurl, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
 				if ($curlResult->isSuccess()) {
 					if (!empty($curlResult->getRedirectUrl()) && (parse_url($baseurl, PHP_URL_HOST) != parse_url($curlResult->getRedirectUrl(), PHP_URL_HOST))) {
 						Logger::info('Found redirect. Mark old entry as failure', ['old' => $url, 'new' => $curlResult->getRedirectUrl()]);
@@ -418,7 +418,7 @@ class GServer
 					// When the base path doesn't seem to contain a social network we try the complete path.
 					// Most detectable system have to be installed in the root directory.
 					// We checked the base to avoid false positives.
-					$curlResult = DI::httpClient()->get($url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_HTML]);
+					$curlResult = DI::httpClient()->get($url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
 					if ($curlResult->isSuccess()) {
 						$urldata = self::analyseRootHeader($curlResult, $serverdata);
 						$urldata = self::analyseRootBody($curlResult, $urldata, $url);
@@ -588,7 +588,7 @@ class GServer
 	{
 		Logger::info('Discover relay data', ['server' => $server_url]);
 
-		$curlResult = DI::httpClient()->get($server_url . '/.well-known/x-social-relay', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($server_url . '/.well-known/x-social-relay', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess()) {
 			return;
 		}
@@ -683,7 +683,7 @@ class GServer
 	 */
 	private static function fetchStatistics(string $url)
 	{
-		$curlResult = DI::httpClient()->get($url . '/statistics.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/statistics.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess()) {
 			return [];
 		}
@@ -809,7 +809,7 @@ class GServer
 	 */
 	private static function parseNodeinfo1(string $nodeinfo_url)
 	{
-		$curlResult = DI::httpClient()->get($nodeinfo_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($nodeinfo_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess()) {
 			return [];
 		}
@@ -902,7 +902,7 @@ class GServer
 	 */
 	private static function parseNodeinfo2(string $nodeinfo_url)
 	{
-		$curlResult = DI::httpClient()->get($nodeinfo_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($nodeinfo_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess()) {
 			return [];
 		}
@@ -997,7 +997,7 @@ class GServer
 	 */
 	private static function fetchSiteinfo(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/siteinfo.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/siteinfo.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
 		}
@@ -1082,7 +1082,7 @@ class GServer
 	private static function validHostMeta(string $url)
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
-		$curlResult = DI::httpClient()->get($url . '/.well-known/host-meta', [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_XRD_XML]);
+		$curlResult = DI::httpClient()->get($url . '/.well-known/host-meta', [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::XRD_XML]);
 		if (!$curlResult->isSuccess()) {
 			return false;
 		}
@@ -1174,7 +1174,7 @@ class GServer
 	{
 		$serverdata['poco'] = '';
 
-		$curlResult = DI::httpClient()->get($url . '/poco', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/poco', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
 		}
@@ -1204,7 +1204,7 @@ class GServer
 	 */
 	public static function checkMastodonDirectory(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/api/v1/directory?limit=1', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/v1/directory?limit=1', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
 		}
@@ -1231,7 +1231,7 @@ class GServer
 	 */
 	private static function detectPeertube(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/api/v1/config', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/v1/config', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
 		}
@@ -1278,7 +1278,7 @@ class GServer
 	 */
 	private static function detectNextcloud(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/status.php', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/status.php', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
 		}
@@ -1302,7 +1302,7 @@ class GServer
 	}
 
 	private static function fetchWeeklyUsage(string $url, array $serverdata) {
-		$curlResult = DI::httpClient()->get($url . '/api/v1/instance/activity', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/v1/instance/activity', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
 		}
@@ -1370,7 +1370,7 @@ class GServer
 	 */
 	private static function detectMastodonAlikes(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/api/v1/instance', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/v1/instance', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
 		}
@@ -1435,7 +1435,7 @@ class GServer
 	 */
 	private static function detectHubzilla(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/api/statusnet/config.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/statusnet/config.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess() || ($curlResult->getBody() == '')) {
 			return $serverdata;
 		}
@@ -1532,7 +1532,7 @@ class GServer
 	 */
 	private static function detectPumpIO(string $url, array $serverdata)
 	{
-		$curlResult = DI::httpClient()->get($url . '/.well-known/host-meta.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/.well-known/host-meta.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
 		}
@@ -1583,7 +1583,7 @@ class GServer
 	private static function detectGNUSocial(string $url, array $serverdata)
 	{
 		// Test for GNU Social
-		$curlResult = DI::httpClient()->get($url . '/api/gnusocial/version.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/gnusocial/version.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if ($curlResult->isSuccess() && ($curlResult->getBody() != '{"error":"not implemented"}') &&
 			($curlResult->getBody() != '') && (strlen($curlResult->getBody()) < 30)) {
 			$serverdata['platform'] = 'gnusocial';
@@ -1601,7 +1601,7 @@ class GServer
 		}
 
 		// Test for Statusnet
-		$curlResult = DI::httpClient()->get($url . '/api/statusnet/version.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url . '/api/statusnet/version.json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if ($curlResult->isSuccess() && ($curlResult->getBody() != '{"error":"not implemented"}') &&
 			($curlResult->getBody() != '') && (strlen($curlResult->getBody()) < 30)) {
 
@@ -1639,9 +1639,9 @@ class GServer
 	{
 		// There is a bug in some versions of Friendica that will return an ActivityStream actor when the content type "application/json" is requested.
 		// Because of this me must not use ACCEPT_JSON here.
-		$curlResult = DI::httpClient()->get($url . '/friendica/json', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_DEFAULT]);
+		$curlResult = DI::httpClient()->get($url . '/friendica/json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
 		if (!$curlResult->isSuccess()) {
-			$curlResult = DI::httpClient()->get($url . '/friendika/json', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_DEFAULT]);
+			$curlResult = DI::httpClient()->get($url . '/friendika/json', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
 			$friendika = true;
 			$platform = 'Friendika';
 		} else {
@@ -1946,7 +1946,7 @@ class GServer
 		$protocols = ['activitypub', 'diaspora', 'dfrn', 'ostatus'];
 		foreach ($protocols as $protocol) {
 			$query = '{nodes(protocol:"' . $protocol . '"){host}}';
-			$curlResult = DI::httpClient()->fetch('https://the-federation.info/graphql?query=' . urlencode($query), 0, HttpClient::ACCEPT_JSON);
+			$curlResult = DI::httpClient()->fetch('https://the-federation.info/graphql?query=' . urlencode($query), 0, HttpClientAccept::JSON);
 			if (!empty($curlResult)) {
 				$data = json_decode($curlResult, true);
 				if (!empty($data['data']['nodes'])) {
@@ -1963,7 +1963,7 @@ class GServer
 
 		if (!empty($accesstoken)) {
 			$api = 'https://instances.social/api/1.0/instances/list?count=0';
-			$curlResult = DI::httpClient()->get($api, [HttpClientOptions::HEADERS => ['Authorization' => ['Bearer ' . $accesstoken]], HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+			$curlResult = DI::httpClient()->get($api, [HttpClientOptions::HEADERS => ['Authorization' => ['Bearer ' . $accesstoken]], HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 			if ($curlResult->isSuccess()) {
 				$servers = json_decode($curlResult->getBody(), true);
 

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -33,7 +33,6 @@ use Friendica\Core\Storage\Exception\ReferenceStorageException;
 use Friendica\Core\Storage\Exception\StorageException;
 use Friendica\Core\Storage\Type\SystemResource;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
-use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Object\Image;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
@@ -499,7 +498,7 @@ class Photo
 
 		$filename = basename($image_url);
 		if (!empty($image_url)) {
-			$ret = DI::httpClient()->get($image_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::IMAGE]);
+			$ret = DI::httpClient()->get($image_url, HttpClientAccept::IMAGE);
 			Logger::debug('Got picture', ['Content-Type' => $ret->getHeader('Content-Type'), 'url' => $image_url]);
 			$img_str = $ret->getBody();
 			$type = $ret->getContentType();
@@ -915,7 +914,7 @@ class Photo
 	{
 		$filename = basename($image_url);
 		if (!empty($image_url)) {
-			$ret = DI::httpClient()->get($image_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::IMAGE]);
+			$ret = DI::httpClient()->get($image_url, HttpClientAccept::IMAGE);
 			Logger::debug('Got picture', ['Content-Type' => $ret->getHeader('Content-Type'), 'url' => $image_url]);
 			$img_str = $ret->getBody();
 			$type = $ret->getContentType();

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -32,7 +32,7 @@ use Friendica\Core\Storage\Exception\InvalidClassStorageException;
 use Friendica\Core\Storage\Exception\ReferenceStorageException;
 use Friendica\Core\Storage\Exception\StorageException;
 use Friendica\Core\Storage\Type\SystemResource;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Object\Image;
 use Friendica\Util\DateTimeFormat;
@@ -499,7 +499,7 @@ class Photo
 
 		$filename = basename($image_url);
 		if (!empty($image_url)) {
-			$ret = DI::httpClient()->get($image_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_IMAGE]);
+			$ret = DI::httpClient()->get($image_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::IMAGE]);
 			Logger::debug('Got picture', ['Content-Type' => $ret->getHeader('Content-Type'), 'url' => $image_url]);
 			$img_str = $ret->getBody();
 			$type = $ret->getContentType();
@@ -915,7 +915,7 @@ class Photo
 	{
 		$filename = basename($image_url);
 		if (!empty($image_url)) {
-			$ret = DI::httpClient()->get($image_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_IMAGE]);
+			$ret = DI::httpClient()->get($image_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::IMAGE]);
 			Logger::debug('Got picture', ['Content-Type' => $ret->getHeader('Content-Type'), 'url' => $image_url]);
 			$img_str = $ret->getBody();
 			$type = $ret->getContentType();

--- a/src/Model/Post/Link.php
+++ b/src/Model/Post/Link.php
@@ -101,7 +101,7 @@ class Link
 	{
 		$timeout = DI::config()->get('system', 'xrd_timeout');
 
-		$curlResult = DI::httpClient()->head($url, $accept, [HttpClientOptions::TIMEOUT => $timeout]);
+		$curlResult = DI::httpClient()->head($url, [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::ACCEPT_CONTENT => $accept]);
 		if ($curlResult->isSuccess()) {
 			if (empty($media['mimetype'])) {
 				return $curlResult->getHeader('Content-Type')[0] ?? '';

--- a/src/Model/Post/Link.php
+++ b/src/Model/Post/Link.php
@@ -26,7 +26,7 @@ use Friendica\Core\System;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Util\Proxy;
 
@@ -97,7 +97,7 @@ class Link
 		return $url . $id;
 	}
 
-	private static function fetchMimeType(string $url, string $accept = HttpClient::ACCEPT_DEFAULT)
+	private static function fetchMimeType(string $url, string $accept = HttpClientAccept::DEFAULT)
 	{
 		$timeout = DI::config()->get('system', 'xrd_timeout');
 

--- a/src/Model/Post/Link.php
+++ b/src/Model/Post/Link.php
@@ -101,7 +101,7 @@ class Link
 	{
 		$timeout = DI::config()->get('system', 'xrd_timeout');
 
-		$curlResult = DI::httpClient()->head($url, [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::ACCEPT_CONTENT => $accept]);
+		$curlResult = DI::httpClient()->head($url, $accept, [HttpClientOptions::TIMEOUT => $timeout]);
 		if ($curlResult->isSuccess()) {
 			if (empty($media['mimetype'])) {
 				return $curlResult->getHeader('Content-Type')[0] ?? '';

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -169,11 +169,11 @@ class Media
 		// Fetch the mimetype or size if missing.
 		if (empty($media['mimetype']) || empty($media['size'])) {
 			$timeout = DI::config()->get('system', 'xrd_timeout');
-			$curlResult = DI::httpClient()->head($media['url'], [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
+			$curlResult = DI::httpClient()->head($media['url'], HttpClientAccept::DEFAULT, [HttpClientOptions::TIMEOUT => $timeout]);
 
 			// Workaround for systems that can't handle a HEAD request
 			if (!$curlResult->isSuccess() && ($curlResult->getReturnCode() == 405)) {
-				$curlResult = DI::httpClient()->get($media['url'], [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
+				$curlResult = DI::httpClient()->get($media['url'], HttpClientAccept::DEFAULT, [HttpClientOptions::TIMEOUT => $timeout]);
 			}
 
 			if ($curlResult->isSuccess()) {

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -30,7 +30,7 @@ use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Util\Images;
 use Friendica\Util\Network;
@@ -169,11 +169,11 @@ class Media
 		// Fetch the mimetype or size if missing.
 		if (empty($media['mimetype']) || empty($media['size'])) {
 			$timeout = DI::config()->get('system', 'xrd_timeout');
-			$curlResult = DI::httpClient()->head($media['url'], [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_DEFAULT]);
+			$curlResult = DI::httpClient()->head($media['url'], [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
 
 			// Workaround for systems that can't handle a HEAD request
 			if (!$curlResult->isSuccess() && ($curlResult->getReturnCode() == 405)) {
-				$curlResult = DI::httpClient()->get($media['url'], [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_DEFAULT]);
+				$curlResult = DI::httpClient()->get($media['url'], [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::DEFAULT]);
 			}
 
 			if ($curlResult->isSuccess()) {

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -169,7 +169,7 @@ class Media
 		// Fetch the mimetype or size if missing.
 		if (empty($media['mimetype']) || empty($media['size'])) {
 			$timeout = DI::config()->get('system', 'xrd_timeout');
-			$curlResult = DI::httpClient()->head($media['url'], HttpClientAccept::DEFAULT, [HttpClientOptions::TIMEOUT => $timeout]);
+			$curlResult = DI::httpClient()->head($media['url'], [HttpClientOptions::TIMEOUT => $timeout]);
 
 			// Workaround for systems that can't handle a HEAD request
 			if (!$curlResult->isSuccess() && ($curlResult->getReturnCode() == 405)) {

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -35,7 +35,6 @@ use Friendica\Core\System;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\Diaspora;
@@ -750,7 +749,7 @@ class Profile
 			$magic_path = $basepath . '/magic' . '?owa=1&dest=' . $dest . '&' . $addr_request;
 
 			// We have to check if the remote server does understand /magic without invoking something
-			$serverret = DI::httpClient()->head($basepath . '/magic', HttpClientAccept::HTML);
+			$serverret = DI::httpClient()->head($basepath . '/magic');
 			if ($serverret->isSuccess()) {
 				Logger::info('Doing magic auth for visitor ' . $my_url . ' to ' . $magic_path);
 				System::externalRedirect($magic_path);

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -36,7 +36,6 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
-use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\HTTPException;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\Diaspora;
@@ -751,7 +750,7 @@ class Profile
 			$magic_path = $basepath . '/magic' . '?owa=1&dest=' . $dest . '&' . $addr_request;
 
 			// We have to check if the remote server does understand /magic without invoking something
-			$serverret = DI::httpClient()->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
+			$serverret = DI::httpClient()->head($basepath . '/magic', HttpClientAccept::HTML);
 			if ($serverret->isSuccess()) {
 				Logger::info('Doing magic auth for visitor ' . $my_url . ' to ' . $magic_path);
 				System::externalRedirect($magic_path);

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -35,6 +35,8 @@ use Friendica\Core\System;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
+use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\HTTPException;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\Diaspora;
@@ -749,7 +751,7 @@ class Profile
 			$magic_path = $basepath . '/magic' . '?owa=1&dest=' . $dest . '&' . $addr_request;
 
 			// We have to check if the remote server does understand /magic without invoking something
-			$serverret = DI::httpClient()->head($basepath . '/magic');
+			$serverret = DI::httpClient()->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
 			if ($serverret->isSuccess()) {
 				Logger::info('Doing magic auth for visitor ' . $my_url . ' to ' . $magic_path);
 				System::externalRedirect($magic_path);

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -35,7 +35,7 @@ use Friendica\Core\System;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\HTTPException;
 use Friendica\Protocol\Activity;
@@ -751,7 +751,7 @@ class Profile
 			$magic_path = $basepath . '/magic' . '?owa=1&dest=' . $dest . '&' . $addr_request;
 
 			// We have to check if the remote server does understand /magic without invoking something
-			$serverret = DI::httpClient()->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_HTML]);
+			$serverret = DI::httpClient()->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
 			if ($serverret->isSuccess()) {
 				Logger::info('Doing magic auth for visitor ' . $my_url . ' to ' . $magic_path);
 				System::externalRedirect($magic_path);

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -34,7 +34,7 @@ use Friendica\Core\System;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Security\TwoFactor\Model\AppSpecificPassword;
 use Friendica\Network\HTTPException;
@@ -1152,7 +1152,7 @@ class User
 			$photo_failure = false;
 
 			$filename = basename($photo);
-			$curlResult = DI::httpClient()->get($photo, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_IMAGE]);
+			$curlResult = DI::httpClient()->get($photo, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::IMAGE]);
 			if ($curlResult->isSuccess()) {
 				Logger::debug('Got picture', ['Content-Type' => $curlResult->getHeader('Content-Type'), 'url' => $photo]);
 				$img_str = $curlResult->getBody();

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -35,7 +35,6 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
-use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Security\TwoFactor\Model\AppSpecificPassword;
 use Friendica\Network\HTTPException;
 use Friendica\Object\Image;
@@ -1152,7 +1151,7 @@ class User
 			$photo_failure = false;
 
 			$filename = basename($photo);
-			$curlResult = DI::httpClient()->get($photo, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::IMAGE]);
+			$curlResult = DI::httpClient()->get($photo, HttpClientAccept::IMAGE);
 			if ($curlResult->isSuccess()) {
 				Logger::debug('Got picture', ['Content-Type' => $curlResult->getHeader('Content-Type'), 'url' => $photo]);
 				$img_str = $curlResult->getBody();

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -33,7 +33,6 @@ use Friendica\Core\Config\Factory\Config;
 use Friendica\Model\Register;
 use Friendica\Module\BaseAdmin;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
-use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\HTTPException\ServiceUnavailableException;
 use Friendica\Util\DateTimeFormat;
 
@@ -250,7 +249,7 @@ class Summary extends BaseAdmin
 	private static function checkSelfHostMeta()
 	{
 		// Fetch the host-meta to check if this really is a vital server
-		return DI::httpClient()->get(DI::baseUrl()->get() . '/.well-known/host-meta', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::XRD_XML])->isSuccess();
+		return DI::httpClient()->get(DI::baseUrl()->get() . '/.well-known/host-meta', HttpClientAccept::XRD_XML)->isSuccess();
 	}
 
 }

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -32,7 +32,7 @@ use Friendica\DI;
 use Friendica\Core\Config\Factory\Config;
 use Friendica\Model\Register;
 use Friendica\Module\BaseAdmin;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\HTTPException\ServiceUnavailableException;
 use Friendica\Util\DateTimeFormat;
@@ -250,7 +250,7 @@ class Summary extends BaseAdmin
 	private static function checkSelfHostMeta()
 	{
 		// Fetch the host-meta to check if this really is a vital server
-		return DI::httpClient()->get(DI::baseUrl()->get() . '/.well-known/host-meta', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_XRD_XML])->isSuccess();
+		return DI::httpClient()->get(DI::baseUrl()->get() . '/.well-known/host-meta', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::XRD_XML])->isSuccess();
 	}
 
 }

--- a/src/Module/Debug/Feed.php
+++ b/src/Module/Debug/Feed.php
@@ -28,7 +28,7 @@ use Friendica\Core\Renderer;
 use Friendica\Model;
 use Friendica\Module\Response;
 use Friendica\Network\HTTPClient\Capability\ICanSendHttpRequests;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Protocol;
 use Friendica\Util\Profiler;
 use Psr\Log\LoggerInterface;
@@ -61,7 +61,7 @@ class Feed extends BaseModule
 
 			$contact = Model\Contact::getByURLForUser($url, local_user(), null);
 
-			$xml = $this->httpClient->fetch($contact['poll'], 0, HttpClient::ACCEPT_FEED_XML);
+			$xml = $this->httpClient->fetch($contact['poll'], 0, HttpClientAccept::FEED_XML);
 
 			$import_result = Protocol\Feed::import($xml);
 

--- a/src/Module/Debug/Feed.php
+++ b/src/Module/Debug/Feed.php
@@ -61,7 +61,7 @@ class Feed extends BaseModule
 
 			$contact = Model\Contact::getByURLForUser($url, local_user(), null);
 
-			$xml = $this->httpClient->fetch($contact['poll'], 0, HttpClientAccept::FEED_XML);
+			$xml = $this->httpClient->fetch($contact['poll'], HttpClientAccept::FEED_XML);
 
 			$import_result = Protocol\Feed::import($xml);
 

--- a/src/Module/Magic.php
+++ b/src/Module/Magic.php
@@ -29,7 +29,7 @@ use Friendica\Database\Database;
 use Friendica\Model\Contact;
 use Friendica\Model\User;
 use Friendica\Network\HTTPClient\Capability\ICanSendHttpRequests;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Util\HTTPSignature;
 use Friendica\Util\Profiler;
@@ -113,7 +113,7 @@ class Magic extends BaseModule
 			);
 
 			// Try to get an authentication token from the other instance.
-			$curlResult = $this->httpClient->get($basepath . '/owa', [HttpClientOptions::HEADERS => $header]);
+			$curlResult = $this->httpClient->get($basepath . '/owa', HttpClientAccept::DEFAULT, [HttpClientOptions::HEADERS => $header]);
 
 			if ($curlResult->isSuccess()) {
 				$j = json_decode($curlResult->getBody(), true);

--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -32,7 +32,7 @@ use Friendica\Model\Profile;
 use Friendica\Core\Storage\Type\ExternalResource;
 use Friendica\Core\Storage\Type\SystemResource;
 use Friendica\Model\User;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException;
 use Friendica\Network\HTTPException\NotModifiedException;
 use Friendica\Object\Image;
@@ -309,7 +309,7 @@ class Photo extends BaseModule
 				}
 				$mimetext = '';
 				if (!empty($url)) {
-					$mime = ParseUrl::getContentType($url, HttpClient::ACCEPT_IMAGE);
+					$mime = ParseUrl::getContentType($url, HttpClientAccept::IMAGE);
 					if (!empty($mime)) {
 						$mimetext = $mime[0] . '/' . $mime[1];
 					} else {

--- a/src/Module/Proxy.php
+++ b/src/Module/Proxy.php
@@ -25,7 +25,7 @@ use Friendica\BaseModule;
 use Friendica\Core\Logger;
 use Friendica\Core\System;
 use Friendica\DI;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\HTTPException\NotModifiedException;
 use Friendica\Object\Image;
@@ -83,7 +83,7 @@ class Proxy extends BaseModule
 		$request['url'] = str_replace(' ', '+', $request['url']);
 
 		// Fetch the content with the local user
-		$fetchResult = HTTPSignature::fetchRaw($request['url'], local_user(), [HttpClientOptions::ACCEPT_CONTENT => [HttpClient::ACCEPT_IMAGE], 'timeout' => 10]);
+		$fetchResult = HTTPSignature::fetchRaw($request['url'], local_user(), [HttpClientOptions::ACCEPT_CONTENT => [HttpClientAccept::IMAGE], 'timeout' => 10]);
 		$img_str = $fetchResult->getBody();
 
 		if (!$fetchResult->isSuccess() || empty($img_str)) {

--- a/src/Network/HTTPClient/Capability/ICanSendHttpRequests.php
+++ b/src/Network/HTTPClient/Capability/ICanSendHttpRequests.php
@@ -79,7 +79,7 @@ interface ICanSendHttpRequests
 	 *
 	 * @param string $url            URL to fetch
 	 * @param array  $opts           (optional parameters) associative array with:
-	 *                                'accept_content' => (string array) supply Accept: header with 'accept_content' as the value (overrides default parameter)
+	 *                                'accept_content' => (string array) supply Accept: header with 'accept_content' as the value
 	 *                                'timeout' => int Timeout in seconds, default system config value or 60 seconds
 	 *                                'cookiejar' => path to cookie jar file
 	 *                                'header' => header array

--- a/src/Network/HTTPClient/Capability/ICanSendHttpRequests.php
+++ b/src/Network/HTTPClient/Capability/ICanSendHttpRequests.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Network\HTTPClient\Capability;
 
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use GuzzleHttp\Exception\TransferException;
 
 /**
@@ -35,13 +36,13 @@ interface ICanSendHttpRequests
 	 * to preserve cookies from one request to the next.
 	 *
 	 * @param string $url             URL to fetch
-	 * @param int    $timeout         Timeout in seconds, default system config value or 60 seconds
 	 * @param string $accept_content  supply Accept: header with 'accept_content' as the value
+	 * @param int    $timeout         Timeout in seconds, default system config value or 60 seconds
 	 * @param string $cookiejar       Path to cookie jar file
 	 *
 	 * @return string The fetched content
 	 */
-	public function fetch(string $url, int $timeout = 0, string $accept_content = '', string $cookiejar = ''): string;
+	public function fetch(string $url, string $accept_content = HttpClientAccept::DEFAULT, int $timeout = 0, string $cookiejar = ''): string;
 
 	/**
 	 * Fetches the whole response of an URL.
@@ -50,72 +51,75 @@ interface ICanSendHttpRequests
 	 * all the information collected during the fetch.
 	 *
 	 * @param string $url             URL to fetch
-	 * @param int    $timeout         Timeout in seconds, default system config value or 60 seconds
 	 * @param string $accept_content  supply Accept: header with 'accept_content' as the value
+	 * @param int    $timeout         Timeout in seconds, default system config value or 60 seconds
 	 * @param string $cookiejar       Path to cookie jar file
 	 *
 	 * @return ICanHandleHttpResponses With all relevant information, 'body' contains the actual fetched content.
 	 */
-	public function fetchFull(string $url, int $timeout = 0, string $accept_content = '', string $cookiejar = ''): ICanHandleHttpResponses;
+	public function fetchFull(string $url, string $accept_content = HttpClientAccept::DEFAULT, int $timeout = 0, string $cookiejar = ''): ICanHandleHttpResponses;
 
 	/**
 	 * Send a HEAD to a URL.
 	 *
-	 * @param string $url        URL to fetch
-	 * @param array  $opts       (optional parameters) associative array with:
-	 *                           'accept_content' => (string array) supply Accept: header with 'accept_content' as the value
-	 *                           'timeout' => int Timeout in seconds, default system config value or 60 seconds
-	 *                           'cookiejar' => path to cookie jar file
-	 *                           'header' => header array
+	 * @param string $url            URL to fetch
+	 * @param string $accept_content supply Accept: header with 'accept_content' as the value
+	 * @param array  $opts           (optional parameters) associative array with:
+	 *                                'accept_content' => (string array) supply Accept: header with 'accept_content' as the value (overrides default parameter)
+	 *                                'timeout' => int Timeout in seconds, default system config value or 60 seconds
+	 *                                'cookiejar' => path to cookie jar file
+	 *                                'header' => header array
 	 *
 	 * @return ICanHandleHttpResponses
 	 */
-	public function head(string $url, array $opts = []): ICanHandleHttpResponses;
+	public function head(string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses;
 
 	/**
-	 * Send a GET to an URL.
+	 * Send a GET to a URL.
 	 *
-	 * @param string $url        URL to fetch
-	 * @param array  $opts       (optional parameters) associative array with:
-	 *                           'accept_content' => (string array) supply Accept: header with 'accept_content' as the value
-	 *                           'timeout' => int Timeout in seconds, default system config value or 60 seconds
-	 *                           'cookiejar' => path to cookie jar file
-	 *                           'header' => header array
-	 *                           'content_length' => int maximum File content length
+	 * @param string $url            URL to get
+	 * @param string $accept_content supply Accept: header with 'accept_content' as the value
+	 * @param array  $opts           (optional parameters) associative array with:
+	 *                                'accept_content' => (string array) supply Accept: header with 'accept_content' as the value (overrides default parameter)
+	 *                                'timeout' => int Timeout in seconds, default system config value or 60 seconds
+	 *                                'cookiejar' => path to cookie jar file
+	 *                                'header' => header array
 	 *
 	 * @return ICanHandleHttpResponses
 	 */
-	public function get(string $url, array $opts = []): ICanHandleHttpResponses;
+	public function get(string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses;
 
 	/**
 	 * Sends a HTTP request to a given url
 	 *
-	 * @param string $method A HTTP request
-	 * @param string $url    Url to send to
-	 * @param array  $opts   (optional parameters) associative array with:
-	 *                       	 'body' => (mixed) setting the body for sending data
-	 *                           'accept_content' => (string array) supply Accept: header with 'accept_content' as the value
-	 *                           'timeout' => int Timeout in seconds, default system config value or 60 seconds
-	 *                           'cookiejar' => path to cookie jar file
-	 *                           'header' => header array
-	 *                           'content_length' => int maximum File content length
-	 *                           'auth' => array authentication settings
+	 * @param string $method         A HTTP request
+	 * @param string $url            Url to send to
+	 * @param string $accept_content supply Accept: header with 'accept_content' as the value
+	 * @param array  $opts           (optional parameters) associative array with:
+	 *                       	      'body' => (mixed) setting the body for sending data
+	 *                                'accept_content' => (string array) supply Accept: header with 'accept_content' as the value (overrides default parameter)
+	 *                                'timeout' => int Timeout in seconds, default system config value or 60 seconds
+	 *                                'cookiejar' => path to cookie jar file
+	 *                                'header' => header array
+	 *                                'content_length' => int maximum File content length
+	 *                                'auth' => array authentication settings
 	 *
 	 * @return ICanHandleHttpResponses
 	 */
-	public function request(string $method, string $url, array $opts = []): ICanHandleHttpResponses;
+	public function request(string $method, string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses;
 
 	/**
 	 * Send POST request to an URL
 	 *
-	 * @param string $url     URL to post
-	 * @param mixed  $params  array of POST variables
-	 * @param array  $headers HTTP headers
-	 * @param int    $timeout The timeout in seconds, default system config value or 60 seconds
+	 * @param string $url            URL to post
+	 * @param mixed  $params         array of POST variables
+	 * @param string $accept_content supply Accept: header with 'accept_content' as the value
+	 * @param array  $headers        HTTP headers
+	 * @param int    $timeout        The timeout in seconds, default system config value or 60 seconds
 	 *
 	 * @return ICanHandleHttpResponses The content
 	 */
-	public function post(string $url, $params, array $headers = [], int $timeout = 0): ICanHandleHttpResponses;
+	public function post(string $url, $params, string $accept_content = HttpClientAccept::DEFAULT, array $headers = [], int $timeout = 0): ICanHandleHttpResponses;
 
 	/**
 	 * Returns the original URL of the provided URL

--- a/src/Network/HTTPClient/Capability/ICanSendHttpRequests.php
+++ b/src/Network/HTTPClient/Capability/ICanSendHttpRequests.php
@@ -60,21 +60,6 @@ interface ICanSendHttpRequests
 	public function fetchFull(string $url, string $accept_content = HttpClientAccept::DEFAULT, int $timeout = 0, string $cookiejar = ''): ICanHandleHttpResponses;
 
 	/**
-	 * Send a HEAD to a URL.
-	 *
-	 * @param string $url            URL to fetch
-	 * @param string $accept_content supply Accept: header with 'accept_content' as the value
-	 * @param array  $opts           (optional parameters) associative array with:
-	 *                                'accept_content' => (string array) supply Accept: header with 'accept_content' as the value (overrides default parameter)
-	 *                                'timeout' => int Timeout in seconds, default system config value or 60 seconds
-	 *                                'cookiejar' => path to cookie jar file
-	 *                                'header' => header array
-	 *
-	 * @return ICanHandleHttpResponses
-	 */
-	public function head(string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses;
-
-	/**
 	 * Send a GET to a URL.
 	 *
 	 * @param string $url            URL to get
@@ -90,14 +75,39 @@ interface ICanSendHttpRequests
 	public function get(string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses;
 
 	/**
-	 * Sends a HTTP request to a given url
+	 * Send a HEAD to a URL.
+	 *
+	 * @param string $url            URL to fetch
+	 * @param array  $opts           (optional parameters) associative array with:
+	 *                                'accept_content' => (string array) supply Accept: header with 'accept_content' as the value (overrides default parameter)
+	 *                                'timeout' => int Timeout in seconds, default system config value or 60 seconds
+	 *                                'cookiejar' => path to cookie jar file
+	 *                                'header' => header array
+	 *
+	 * @return ICanHandleHttpResponses
+	 */
+	public function head(string $url, array $opts = []): ICanHandleHttpResponses;
+
+	/**
+	 * Send POST request to an URL
+	 *
+	 * @param string $url            URL to post
+	 * @param mixed  $params         array of POST variables
+	 * @param array  $headers        HTTP headers
+	 * @param int    $timeout        The timeout in seconds, default system config value or 60 seconds
+	 *
+	 * @return ICanHandleHttpResponses The content
+	 */
+	public function post(string $url, $params, array $headers = [], int $timeout = 0): ICanHandleHttpResponses;
+
+	/**
+	 * Sends an HTTP request to a given url
 	 *
 	 * @param string $method         A HTTP request
 	 * @param string $url            Url to send to
-	 * @param string $accept_content supply Accept: header with 'accept_content' as the value
 	 * @param array  $opts           (optional parameters) associative array with:
 	 *                       	      'body' => (mixed) setting the body for sending data
-	 *                                'accept_content' => (string array) supply Accept: header with 'accept_content' as the value (overrides default parameter)
+	 *                                'accept_content' => (string array) supply Accept: header with 'accept_content' as the value
 	 *                                'timeout' => int Timeout in seconds, default system config value or 60 seconds
 	 *                                'cookiejar' => path to cookie jar file
 	 *                                'header' => header array
@@ -106,20 +116,7 @@ interface ICanSendHttpRequests
 	 *
 	 * @return ICanHandleHttpResponses
 	 */
-	public function request(string $method, string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses;
-
-	/**
-	 * Send POST request to an URL
-	 *
-	 * @param string $url            URL to post
-	 * @param mixed  $params         array of POST variables
-	 * @param string $accept_content supply Accept: header with 'accept_content' as the value
-	 * @param array  $headers        HTTP headers
-	 * @param int    $timeout        The timeout in seconds, default system config value or 60 seconds
-	 *
-	 * @return ICanHandleHttpResponses The content
-	 */
-	public function post(string $url, $params, string $accept_content = HttpClientAccept::DEFAULT, array $headers = [], int $timeout = 0): ICanHandleHttpResponses;
+	public function request(string $method, string $url, array $opts = []): ICanHandleHttpResponses;
 
 	/**
 	 * Returns the original URL of the provided URL

--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -63,7 +63,7 @@ class HttpClient implements ICanSendHttpRequests
 	/**
 	 * {@inheritDoc}
 	 */
-	public function request(string $method, string $url, array $opts = []): ICanHandleHttpResponses
+	public function request(string $method, string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses
 	{
 		$this->profiler->startRecording('network');
 		$this->logger->debug('Request start.', ['url' => $url, 'method' => $method]);
@@ -141,7 +141,7 @@ class HttpClient implements ICanSendHttpRequests
 		};
 
 		if (empty($conf[HttpClientOptions::HEADERS]['Accept'])) {
-			$conf[HttpClientOptions::HEADERS]['Accept'] = HttpClientAccept::DEFAULT;
+			$conf[HttpClientOptions::HEADERS]['Accept'] = $accept_content;
 		}
 
 		try {
@@ -167,23 +167,23 @@ class HttpClient implements ICanSendHttpRequests
 
 	/** {@inheritDoc}
 	 */
-	public function head(string $url, array $opts = []): ICanHandleHttpResponses
+	public function head(string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses
 	{
-		return $this->request('head', $url, $opts);
+		return $this->request('head', $url, $accept_content, $opts);
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get(string $url, array $opts = []): ICanHandleHttpResponses
+	public function get(string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses
 	{
-		return $this->request('get', $url, $opts);
+		return $this->request('get', $url, $accept_content, $opts);
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function post(string $url, $params, array $headers = [], int $timeout = 0): ICanHandleHttpResponses
+	public function post(string $url, $params, string $accept_content = HttpClientAccept::DEFAULT, array $headers = [], int $timeout = 0): ICanHandleHttpResponses
 	{
 		$opts = [];
 
@@ -197,7 +197,7 @@ class HttpClient implements ICanSendHttpRequests
 			$opts[HttpClientOptions::TIMEOUT] = $timeout;
 		}
 
-		return $this->request('post', $url, $opts);
+		return $this->request('post', $url, $accept_content, $opts);
 	}
 
 	/**
@@ -237,9 +237,9 @@ class HttpClient implements ICanSendHttpRequests
 	/**
 	 * {@inheritDoc}
 	 */
-	public function fetch(string $url, int $timeout = 0, string $accept_content = '', string $cookiejar = ''): string
+	public function fetch(string $url, string $accept_content = HttpClientAccept::DEFAULT, int $timeout = 0, string $cookiejar = ''): string
 	{
-		$ret = $this->fetchFull($url, $timeout, $accept_content, $cookiejar);
+		$ret = $this->fetchFull($url, $accept_content, $timeout, $cookiejar);
 
 		return $ret->getBody();
 	}
@@ -247,14 +247,14 @@ class HttpClient implements ICanSendHttpRequests
 	/**
 	 * {@inheritDoc}
 	 */
-	public function fetchFull(string $url, int $timeout = 0, string $accept_content = '', string $cookiejar = ''): ICanHandleHttpResponses
+	public function fetchFull(string $url, string $accept_content = HttpClientAccept::DEFAULT, int $timeout = 0, string $cookiejar = ''): ICanHandleHttpResponses
 	{
 		return $this->get(
 			$url,
+			$accept_content,
 			[
-				HttpClientOptions::TIMEOUT        => $timeout,
-				HttpClientOptions::ACCEPT_CONTENT => $accept_content,
-				HttpClientOptions::COOKIEJAR      => $cookiejar
+				HttpClientOptions::TIMEOUT   => $timeout,
+				HttpClientOptions::COOKIEJAR => $cookiejar
 			]
 		);
 	}

--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -63,7 +63,7 @@ class HttpClient implements ICanSendHttpRequests
 	/**
 	 * {@inheritDoc}
 	 */
-	public function request(string $method, string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses
+	public function request(string $method, string $url, array $opts = []): ICanHandleHttpResponses
 	{
 		$this->profiler->startRecording('network');
 		$this->logger->debug('Request start.', ['url' => $url, 'method' => $method]);
@@ -141,7 +141,8 @@ class HttpClient implements ICanSendHttpRequests
 		};
 
 		if (empty($conf[HttpClientOptions::HEADERS]['Accept'])) {
-			$conf[HttpClientOptions::HEADERS]['Accept'] = $accept_content;
+			$this->logger->info('Accept header was missing, using default.', ['url' => $url, 'callstack' => System::callstack()]);
+			$conf[HttpClientOptions::HEADERS]['Accept'] = HttpClientAccept::DEFAULT;
 		}
 
 		try {
@@ -167,9 +168,9 @@ class HttpClient implements ICanSendHttpRequests
 
 	/** {@inheritDoc}
 	 */
-	public function head(string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses
+	public function head(string $url, array $opts = []): ICanHandleHttpResponses
 	{
-		return $this->request('head', $url, $accept_content, $opts);
+		return $this->request('head', $url, $opts);
 	}
 
 	/**
@@ -177,13 +178,16 @@ class HttpClient implements ICanSendHttpRequests
 	 */
 	public function get(string $url, string $accept_content = HttpClientAccept::DEFAULT, array $opts = []): ICanHandleHttpResponses
 	{
-		return $this->request('get', $url, $accept_content, $opts);
+		// In case there is no
+		$opts[HttpClientOptions::ACCEPT_CONTENT] = $opts[HttpClientOptions::ACCEPT_CONTENT] ?? $accept_content;
+
+		return $this->request('get', $url, $opts);
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function post(string $url, $params, string $accept_content = HttpClientAccept::DEFAULT, array $headers = [], int $timeout = 0): ICanHandleHttpResponses
+	public function post(string $url, $params, array $headers = [], int $timeout = 0): ICanHandleHttpResponses
 	{
 		$opts = [];
 
@@ -197,7 +201,7 @@ class HttpClient implements ICanSendHttpRequests
 			$opts[HttpClientOptions::TIMEOUT] = $timeout;
 		}
 
-		return $this->request('post', $url, $accept_content, $opts);
+		return $this->request('post', $url, $opts);
 	}
 
 	/**

--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -43,22 +43,6 @@ use Psr\Log\LoggerInterface;
  */
 class HttpClient implements ICanSendHttpRequests
 {
-	/** @var string Default value for "Accept" header */
-	const ACCEPT_DEFAULT   = '*/*';
-	const ACCEPT_ATOM_XML  = 'application/atom+xml,text/xml;q=0.9,*/*;q=0.8';
-	const ACCEPT_FEED_XML  = 'application/atom+xml,application/rss+xml;q=0.9,application/rdf+xml;q=0.8,text/xml;q=0.7,*/*;q=0.6';
-	const ACCEPT_HTML      = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8';
-	const ACCEPT_IMAGE     = 'image/png,image/jpeg,image/gif,image/*;q=0.9,*/*;q=0.8';
-	const ACCEPT_JRD_JSON  = 'application/jrd+json,application/json;q=0.9';
-	const ACCEPT_JSON      = 'application/json,*/*;q=0.9';
-	const ACCEPT_JSON_AS   = 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"';
-	const ACCEPT_MAGIC     = 'application/magic-envelope+xml';
-	const ACCEPT_MAGIC_KEY = 'application/magic-public-key';
-	const ACCEPT_RSS_XML   = 'application/rss+xml,text/xml;q=0.9,*/*;q=0.8';
-	const ACCEPT_TEXT      = 'text/plain,text/*;q=0.9,*/*;q=0.8';
-	const ACCEPT_VIDEO     = 'video/mp4,video/*;q=0.9,*/*;q=0.8';
-	const ACCEPT_XRD_XML   = 'application/xrd+xml,text/xml;q=0.9,*/*;q=0.8';
-
 	/** @var LoggerInterface */
 	private $logger;
 	/** @var Profiler */
@@ -157,7 +141,7 @@ class HttpClient implements ICanSendHttpRequests
 		};
 
 		if (empty($conf[HttpClientOptions::HEADERS]['Accept'])) {
-			$conf[HttpClientOptions::HEADERS]['Accept'] = static::ACCEPT_DEFAULT;
+			$conf[HttpClientOptions::HEADERS]['Accept'] = HttpClientAccept::DEFAULT;
 		}
 
 		try {

--- a/src/Network/HTTPClient/Client/HttpClientAccept.php
+++ b/src/Network/HTTPClient/Client/HttpClientAccept.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Friendica\Network\HTTPClient\Client;
+
+class HttpClientAccept
+{
+	/** @var string Default value for "Accept" header */
+	public const DEFAULT = '*/*';
+
+	public const ATOM_XML  = 'application/atom+xml,text/xml;q=0.9,*/*;q=0.8';
+	public const FEED_XML  = 'application/atom+xml,application/rss+xml;q=0.9,application/rdf+xml;q=0.8,text/xml;q=0.7,*/*;q=0.6';
+	public const HTML      = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8';
+	public const IMAGE     = 'image/png,image/jpeg,image/gif,image/*;q=0.9,*/*;q=0.8';
+	public const JRD_JSON  = 'application/jrd+json,application/json;q=0.9';
+	public const JSON      = 'application/json,*/*;q=0.9';
+	public const JSON_AS   = 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"';
+	public const MAGIC     = 'application/magic-envelope+xml';
+	public const MAGIC_KEY = 'application/magic-public-key';
+	public const RSS_XML   = 'application/rss+xml,text/xml;q=0.9,*/*;q=0.8';
+	public const TEXT      = 'text/plain,text/*;q=0.9,*/*;q=0.8';
+	public const VIDEO     = 'video/mp4,video/*;q=0.9,*/*;q=0.8';
+	public const XRD_XML   = 'application/xrd+xml,text/xml;q=0.9,*/*;q=0.8';
+}

--- a/src/Network/HTTPClient/Client/HttpClientAccept.php
+++ b/src/Network/HTTPClient/Client/HttpClientAccept.php
@@ -1,4 +1,23 @@
 <?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 
 namespace Friendica\Network\HTTPClient\Client;
 

--- a/src/Network/HTTPClient/Client/HttpClientAccept.php
+++ b/src/Network/HTTPClient/Client/HttpClientAccept.php
@@ -2,6 +2,9 @@
 
 namespace Friendica\Network\HTTPClient\Client;
 
+/**
+ * This class contains a list of possible HTTPClient ACCEPT options.
+ */
 class HttpClientAccept
 {
 	/** @var string Default value for "Accept" header */
@@ -20,4 +23,5 @@ class HttpClientAccept
 	public const TEXT      = 'text/plain,text/*;q=0.9,*/*;q=0.8';
 	public const VIDEO     = 'video/mp4,video/*;q=0.9,*/*;q=0.8';
 	public const XRD_XML   = 'application/xrd+xml,text/xml;q=0.9,*/*;q=0.8';
+	public const XML       = 'application/xml,text/xml;q=0.9,*/*;q=0.8';
 }

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -170,7 +170,7 @@ class Probe
 		Logger::info('Probing', ['host' => $host, 'ssl_url' => $ssl_url, 'url' => $url, 'callstack' => System::callstack(20)]);
 		$xrd = null;
 
-		$curlResult = DI::httpClient()->get($ssl_url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::XRD_XML]);
+		$curlResult = DI::httpClient()->get($ssl_url, HttpClientAccept::XRD_XML, [HttpClientOptions::TIMEOUT => $xrd_timeout]);
 		$ssl_connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 		if ($curlResult->isSuccess()) {
 			$xml = $curlResult->getBody();
@@ -187,7 +187,7 @@ class Probe
 		}
 
 		if (!is_object($xrd) && !empty($url)) {
-			$curlResult = DI::httpClient()->get($url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::XRD_XML]);
+			$curlResult = DI::httpClient()->get($url, HttpClientAccept::XRD_XML, [HttpClientOptions::TIMEOUT => $xrd_timeout]);
 			$connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 			if ($curlResult->isTimeout()) {
 				Logger::info('Probing timeout', ['url' => $url]);
@@ -429,7 +429,7 @@ class Probe
 	 */
 	private static function getHideStatus($url)
 	{
-		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::CONTENT_LENGTH => 1000000, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
+		$curlResult = DI::httpClient()->get($url, HttpClientAccept::HTML, [HttpClientOptions::CONTENT_LENGTH => 1000000]);
 		if (!$curlResult->isSuccess()) {
 			return false;
 		}
@@ -834,7 +834,7 @@ class Probe
 
 	public static function pollZot($url, $data)
 	{
-		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url, HttpClientAccept::JSON);
 		if ($curlResult->isTimeout()) {
 			return $data;
 		}
@@ -931,7 +931,7 @@ class Probe
 	{
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout', 20);
 
-		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => $type]);
+		$curlResult = DI::httpClient()->get($url, $type, [HttpClientOptions::TIMEOUT => $xrd_timeout]);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];
@@ -1000,7 +1000,7 @@ class Probe
 	 */
 	private static function pollNoscrape($noscrape_url, $data)
 	{
-		$curlResult = DI::httpClient()->get($noscrape_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($noscrape_url, HttpClientAccept::JSON);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return $data;
@@ -1266,7 +1266,7 @@ class Probe
 	 */
 	private static function pollHcard($hcard_url, $data, $dfrn = false)
 	{
-		$curlResult = DI::httpClient()->get($hcard_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
+		$curlResult = DI::httpClient()->get($hcard_url, HttpClientAccept::HTML);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];
@@ -1527,7 +1527,7 @@ class Probe
 							$pubkey = substr($pubkey, 5);
 						}
 					} elseif (Strings::normaliseLink($pubkey) == 'http://') {
-						$curlResult = DI::httpClient()->get($pubkey, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::MAGIC_KEY]);
+						$curlResult = DI::httpClient()->get($pubkey, HttpClientAccept::MAGIC_KEY);
 						if ($curlResult->isTimeout()) {
 							self::$istimeout = true;
 							return $short ? false : [];
@@ -1562,7 +1562,7 @@ class Probe
 		}
 
 		// Fetch all additional data from the feed
-		$curlResult = DI::httpClient()->get($data["poll"], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::FEED_XML]);
+		$curlResult = DI::httpClient()->get($data["poll"], HttpClientAccept::FEED_XML);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];
@@ -1614,7 +1614,7 @@ class Probe
 	 */
 	private static function pumpioProfileData($profile_link)
 	{
-		$curlResult = DI::httpClient()->get($profile_link, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
+		$curlResult = DI::httpClient()->get($profile_link, HttpClientAccept::HTML);
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return [];
 		}
@@ -1827,7 +1827,7 @@ class Probe
 	 */
 	private static function feed($url, $probe = true)
 	{
-		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::FEED_XML]);
+		$curlResult = DI::httpClient()->get($url, HttpClientAccept::FEED_XML);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];
@@ -2049,7 +2049,7 @@ class Probe
 			return '';
 		}
 
-		$curlResult = DI::httpClient()->get($gserver['noscrape'] . '/' . $data['nick'], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($gserver['noscrape'] . '/' . $data['nick'], HttpClientAccept::JSON);
 
 		if ($curlResult->isSuccess() && !empty($curlResult->getBody())) {
 			$noscrape = json_decode($curlResult->getBody(), true);
@@ -2124,7 +2124,7 @@ class Probe
 	private static function updateFromFeed(array $data)
 	{
 		// Search for the newest entry in the feed
-		$curlResult = DI::httpClient()->get($data['poll'], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
+		$curlResult = DI::httpClient()->get($data['poll'], HttpClientAccept::ATOM_XML);
 		if (!$curlResult->isSuccess() || !$curlResult->getBody()) {
 			return '';
 		}

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -34,7 +34,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\GServer;
 use Friendica\Model\Profile;
 use Friendica\Model\User;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Protocol\ActivityNamespace;
 use Friendica\Protocol\ActivityPub;
@@ -170,7 +170,7 @@ class Probe
 		Logger::info('Probing', ['host' => $host, 'ssl_url' => $ssl_url, 'url' => $url, 'callstack' => System::callstack(20)]);
 		$xrd = null;
 
-		$curlResult = DI::httpClient()->get($ssl_url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_XRD_XML]);
+		$curlResult = DI::httpClient()->get($ssl_url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::XRD_XML]);
 		$ssl_connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 		if ($curlResult->isSuccess()) {
 			$xml = $curlResult->getBody();
@@ -187,7 +187,7 @@ class Probe
 		}
 
 		if (!is_object($xrd) && !empty($url)) {
-			$curlResult = DI::httpClient()->get($url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_XRD_XML]);
+			$curlResult = DI::httpClient()->get($url, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::XRD_XML]);
 			$connection_error = ($curlResult->getErrorNumber() == CURLE_COULDNT_CONNECT) || ($curlResult->getReturnCode() == 0);
 			if ($curlResult->isTimeout()) {
 				Logger::info('Probing timeout', ['url' => $url]);
@@ -429,7 +429,7 @@ class Probe
 	 */
 	private static function getHideStatus($url)
 	{
-		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::CONTENT_LENGTH => 1000000, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_HTML]);
+		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::CONTENT_LENGTH => 1000000, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
 		if (!$curlResult->isSuccess()) {
 			return false;
 		}
@@ -531,7 +531,7 @@ class Probe
 				$addr = $nick . '@' . $host;
 			}
 
-			$webfinger = self::getWebfinger($parts['scheme'] . '://' . $host . self::WEBFINGER, HttpClient::ACCEPT_JRD_JSON, $uri, $addr);
+			$webfinger = self::getWebfinger($parts['scheme'] . '://' . $host . self::WEBFINGER, HttpClientAccept::JRD_JSON, $uri, $addr);
 			if (empty($webfinger)) {
 				$lrdd = self::hostMeta($host);
 			}
@@ -545,7 +545,7 @@ class Probe
 						$addr = $nick . '@' . $host;
 					}
 
-					$webfinger = self::getWebfinger($parts['scheme'] . '://' . $host . self::WEBFINGER, HttpClient::ACCEPT_JRD_JSON, $uri, $addr);
+					$webfinger = self::getWebfinger($parts['scheme'] . '://' . $host . self::WEBFINGER, HttpClientAccept::JRD_JSON, $uri, $addr);
 					if (empty($webfinger)) {
 						$lrdd = self::hostMeta($host);
 					}
@@ -563,13 +563,13 @@ class Probe
 			$nick = substr($uri, 0, strpos($uri, '@'));
 			$addr = $uri;
 
-			$webfinger = self::getWebfinger('https://' . $host . self::WEBFINGER, HttpClient::ACCEPT_JRD_JSON, $uri, $addr);
+			$webfinger = self::getWebfinger('https://' . $host . self::WEBFINGER, HttpClientAccept::JRD_JSON, $uri, $addr);
 			if (self::$istimeout) {
 				return [];
 			}
 
 			if (empty($webfinger)) {
-				$webfinger = self::getWebfinger('http://' . $host . self::WEBFINGER, HttpClient::ACCEPT_JRD_JSON, $uri, $addr);
+				$webfinger = self::getWebfinger('http://' . $host . self::WEBFINGER, HttpClientAccept::JRD_JSON, $uri, $addr);
 				if (self::$istimeout) {
 					return [];
 				}
@@ -834,7 +834,7 @@ class Probe
 
 	public static function pollZot($url, $data)
 	{
-		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if ($curlResult->isTimeout()) {
 			return $data;
 		}
@@ -1000,7 +1000,7 @@ class Probe
 	 */
 	private static function pollNoscrape($noscrape_url, $data)
 	{
-		$curlResult = DI::httpClient()->get($noscrape_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($noscrape_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return $data;
@@ -1266,7 +1266,7 @@ class Probe
 	 */
 	private static function pollHcard($hcard_url, $data, $dfrn = false)
 	{
-		$curlResult = DI::httpClient()->get($hcard_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_HTML]);
+		$curlResult = DI::httpClient()->get($hcard_url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];
@@ -1527,7 +1527,7 @@ class Probe
 							$pubkey = substr($pubkey, 5);
 						}
 					} elseif (Strings::normaliseLink($pubkey) == 'http://') {
-						$curlResult = DI::httpClient()->get($pubkey, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_MAGIC_KEY]);
+						$curlResult = DI::httpClient()->get($pubkey, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::MAGIC_KEY]);
 						if ($curlResult->isTimeout()) {
 							self::$istimeout = true;
 							return $short ? false : [];
@@ -1562,7 +1562,7 @@ class Probe
 		}
 
 		// Fetch all additional data from the feed
-		$curlResult = DI::httpClient()->get($data["poll"], [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_FEED_XML]);
+		$curlResult = DI::httpClient()->get($data["poll"], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::FEED_XML]);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];
@@ -1614,7 +1614,7 @@ class Probe
 	 */
 	private static function pumpioProfileData($profile_link)
 	{
-		$curlResult = DI::httpClient()->get($profile_link, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_HTML]);
+		$curlResult = DI::httpClient()->get($profile_link, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return [];
 		}
@@ -1827,7 +1827,7 @@ class Probe
 	 */
 	private static function feed($url, $probe = true)
 	{
-		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_FEED_XML]);
+		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::FEED_XML]);
 		if ($curlResult->isTimeout()) {
 			self::$istimeout = true;
 			return [];
@@ -2049,7 +2049,7 @@ class Probe
 			return '';
 		}
 
-		$curlResult = DI::httpClient()->get($gserver['noscrape'] . '/' . $data['nick'], [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($gserver['noscrape'] . '/' . $data['nick'], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 
 		if ($curlResult->isSuccess() && !empty($curlResult->getBody())) {
 			$noscrape = json_decode($curlResult->getBody(), true);
@@ -2124,7 +2124,7 @@ class Probe
 	private static function updateFromFeed(array $data)
 	{
 		// Search for the newest entry in the feed
-		$curlResult = DI::httpClient()->get($data['poll'], [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_ATOM_XML]);
+		$curlResult = DI::httpClient()->get($data['poll'], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
 		if (!$curlResult->isSuccess() || !$curlResult->getBody()) {
 			return '';
 		}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -42,6 +42,7 @@ use Friendica\Model\Post;
 use Friendica\Model\Profile;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\Probe;
 use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
@@ -1013,7 +1014,7 @@ class DFRN
 
 		$content_type = ($public_batch ? "application/magic-envelope+xml" : "application/json");
 
-		$postResult = DI::httpClient()->post($dest_url, $envelope, ['Content-Type' => $content_type]);
+		$postResult = DI::httpClient()->post($dest_url, $envelope, HttpClientAccept::DEFAULT, ['Content-Type' => $content_type]);
 		$xml = $postResult->getBody();
 
 		$curl_stat = $postResult->getReturnCode();

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -42,7 +42,6 @@ use Friendica\Model\Post;
 use Friendica\Model\Profile;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
-use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\Probe;
 use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
@@ -1014,7 +1013,7 @@ class DFRN
 
 		$content_type = ($public_batch ? "application/magic-envelope+xml" : "application/json");
 
-		$postResult = DI::httpClient()->post($dest_url, $envelope, HttpClientAccept::DEFAULT, ['Content-Type' => $content_type]);
+		$postResult = DI::httpClient()->post($dest_url, $envelope, ['Content-Type' => $content_type]);
 		$xml = $postResult->getBody();
 
 		$curl_stat = $postResult->getReturnCode();

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -41,7 +41,7 @@ use Friendica\Model\Mail;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\Probe;
 use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
@@ -1060,7 +1060,7 @@ class Diaspora
 
 		Logger::info("Fetch post from ".$source_url);
 
-		$envelope = DI::httpClient()->fetch($source_url, 0, HttpClient::ACCEPT_MAGIC);
+		$envelope = DI::httpClient()->fetch($source_url, 0, HttpClientAccept::MAGIC);
 		if ($envelope) {
 			Logger::info("Envelope was fetched.");
 			$x = self::verifyMagicEnvelope($envelope);

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3018,7 +3018,7 @@ class Diaspora
 		if (!intval(DI::config()->get("system", "diaspora_test"))) {
 			$content_type = (($public_batch) ? "application/magic-envelope+xml" : "application/json");
 
-			$postResult = DI::httpClient()->post($dest_url . "/", $envelope, HttpClientAccept::DEFAULT, ['Content-Type' => $content_type]);
+			$postResult = DI::httpClient()->post($dest_url . "/", $envelope, ['Content-Type' => $content_type]);
 			$return_code = $postResult->getReturnCode();
 		} else {
 			Logger::notice("test_mode");

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -1060,7 +1060,7 @@ class Diaspora
 
 		Logger::info("Fetch post from ".$source_url);
 
-		$envelope = DI::httpClient()->fetch($source_url, 0, HttpClientAccept::MAGIC);
+		$envelope = DI::httpClient()->fetch($source_url, HttpClientAccept::MAGIC);
 		if ($envelope) {
 			Logger::info("Envelope was fetched.");
 			$x = self::verifyMagicEnvelope($envelope);
@@ -3018,7 +3018,7 @@ class Diaspora
 		if (!intval(DI::config()->get("system", "diaspora_test"))) {
 			$content_type = (($public_batch) ? "application/magic-envelope+xml" : "application/json");
 
-			$postResult = DI::httpClient()->post($dest_url . "/", $envelope, ['Content-Type' => $content_type]);
+			$postResult = DI::httpClient()->post($dest_url . "/", $envelope, HttpClientAccept::DEFAULT, ['Content-Type' => $content_type]);
 			$return_code = $postResult->getReturnCode();
 		} else {
 			Logger::notice("test_mode");

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -39,7 +39,6 @@ use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
-use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
@@ -732,7 +731,7 @@ class OStatus
 
 		self::$conv_list[$conversation] = true;
 
-		$curlResult = DI::httpClient()->get($conversation, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
+		$curlResult = DI::httpClient()->get($conversation, HttpClientAccept::ATOM_XML);
 
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return;
@@ -762,7 +761,7 @@ class OStatus
 					}
 				}
 				if ($file != '') {
-					$conversation_atom = DI::httpClient()->get($attribute['href'], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
+					$conversation_atom = DI::httpClient()->get($attribute['href'], HttpClientAccept::ATOM_XML);
 
 					if ($conversation_atom->isSuccess()) {
 						$xml = $conversation_atom->getBody();
@@ -876,7 +875,7 @@ class OStatus
 			return;
 		}
 
-		$curlResult = DI::httpClient()->get($self, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
+		$curlResult = DI::httpClient()->get($self, HttpClientAccept::ATOM_XML);
 
 		if (!$curlResult->isSuccess()) {
 			return;
@@ -926,7 +925,7 @@ class OStatus
 		}
 
 		$stored = false;
-		$curlResult = DI::httpClient()->get($related, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
+		$curlResult = DI::httpClient()->get($related, HttpClientAccept::ATOM_XML);
 
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return;
@@ -958,7 +957,7 @@ class OStatus
 					}
 				}
 				if ($atom_file != '') {
-					$curlResult = DI::httpClient()->get($atom_file, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
+					$curlResult = DI::httpClient()->get($atom_file, HttpClientAccept::ATOM_XML);
 
 					if ($curlResult->isSuccess()) {
 						Logger::info('Fetched XML for URI ' . $related_uri);
@@ -970,7 +969,7 @@ class OStatus
 
 		// Workaround for older GNU Social servers
 		if (($xml == '') && strstr($related, '/notice/')) {
-			$curlResult = DI::httpClient()->get(str_replace('/notice/', '/api/statuses/show/', $related) . '.atom', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
+			$curlResult = DI::httpClient()->get(str_replace('/notice/', '/api/statuses/show/', $related) . '.atom', HttpClientAccept::ATOM_XML);
 
 			if ($curlResult->isSuccess()) {
 				Logger::info('GNU Social workaround to fetch XML for URI ' . $related_uri);
@@ -981,7 +980,7 @@ class OStatus
 		// Even more worse workaround for GNU Social ;-)
 		if ($xml == '') {
 			$related_guess = self::convertHref($related_uri);
-			$curlResult = DI::httpClient()->get(str_replace('/notice/', '/api/statuses/show/', $related_guess) . '.atom', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
+			$curlResult = DI::httpClient()->get(str_replace('/notice/', '/api/statuses/show/', $related_guess) . '.atom', HttpClientAccept::ATOM_XML);
 
 			if ($curlResult->isSuccess()) {
 				Logger::info('GNU Social workaround 2 to fetch XML for URI ' . $related_uri);

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -38,7 +38,7 @@ use Friendica\Model\ItemURI;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\Probe;
 use Friendica\Util\DateTimeFormat;
@@ -732,7 +732,7 @@ class OStatus
 
 		self::$conv_list[$conversation] = true;
 
-		$curlResult = DI::httpClient()->get($conversation, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_ATOM_XML]);
+		$curlResult = DI::httpClient()->get($conversation, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
 
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return;
@@ -762,7 +762,7 @@ class OStatus
 					}
 				}
 				if ($file != '') {
-					$conversation_atom = DI::httpClient()->get($attribute['href'], [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_ATOM_XML]);
+					$conversation_atom = DI::httpClient()->get($attribute['href'], [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
 
 					if ($conversation_atom->isSuccess()) {
 						$xml = $conversation_atom->getBody();
@@ -876,7 +876,7 @@ class OStatus
 			return;
 		}
 
-		$curlResult = DI::httpClient()->get($self, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_ATOM_XML]);
+		$curlResult = DI::httpClient()->get($self, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
 
 		if (!$curlResult->isSuccess()) {
 			return;
@@ -926,7 +926,7 @@ class OStatus
 		}
 
 		$stored = false;
-		$curlResult = DI::httpClient()->get($related, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_ATOM_XML]);
+		$curlResult = DI::httpClient()->get($related, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
 
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			return;
@@ -958,7 +958,7 @@ class OStatus
 					}
 				}
 				if ($atom_file != '') {
-					$curlResult = DI::httpClient()->get($atom_file, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_ATOM_XML]);
+					$curlResult = DI::httpClient()->get($atom_file, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
 
 					if ($curlResult->isSuccess()) {
 						Logger::info('Fetched XML for URI ' . $related_uri);
@@ -970,7 +970,7 @@ class OStatus
 
 		// Workaround for older GNU Social servers
 		if (($xml == '') && strstr($related, '/notice/')) {
-			$curlResult = DI::httpClient()->get(str_replace('/notice/', '/api/statuses/show/', $related) . '.atom', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_ATOM_XML]);
+			$curlResult = DI::httpClient()->get(str_replace('/notice/', '/api/statuses/show/', $related) . '.atom', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
 
 			if ($curlResult->isSuccess()) {
 				Logger::info('GNU Social workaround to fetch XML for URI ' . $related_uri);
@@ -981,7 +981,7 @@ class OStatus
 		// Even more worse workaround for GNU Social ;-)
 		if ($xml == '') {
 			$related_guess = self::convertHref($related_uri);
-			$curlResult = DI::httpClient()->get(str_replace('/notice/', '/api/statuses/show/', $related_guess) . '.atom', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_ATOM_XML]);
+			$curlResult = DI::httpClient()->get(str_replace('/notice/', '/api/statuses/show/', $related_guess) . '.atom', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::ATOM_XML]);
 
 			if ($curlResult->isSuccess()) {
 				Logger::info('GNU Social workaround 2 to fetch XML for URI ' . $related_uri);

--- a/src/Protocol/Salmon.php
+++ b/src/Protocol/Salmon.php
@@ -157,7 +157,7 @@ class Salmon
 		$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 
 		// slap them
-		$postResult = DI::httpClient()->post($url, $salmon, HttpClientAccept::DEFAULT, [
+		$postResult = DI::httpClient()->post($url, $salmon, [
 			'Content-type' => 'application/magic-envelope+xml',
 			'Content-length' => strlen($salmon),
 		]);
@@ -182,7 +182,7 @@ class Salmon
 			$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 
 			// slap them
-			$postResult = DI::httpClient()->post($url, $salmon, HttpClientAccept::DEFAULT, [
+			$postResult = DI::httpClient()->post($url, $salmon, [
 				'Content-type' => 'application/magic-envelope+xml',
 				'Content-length' => strlen($salmon),
 			]);
@@ -205,7 +205,7 @@ class Salmon
 			$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 
 			// slap them
-			$postResult = DI::httpClient()->post($url, $salmon, HttpClientAccept::DEFAULT, [
+			$postResult = DI::httpClient()->post($url, $salmon, [
 				'Content-type' => 'application/magic-envelope+xml',
 				'Content-length' => strlen($salmon)]);
 			$return_code = $postResult->getReturnCode();

--- a/src/Protocol/Salmon.php
+++ b/src/Protocol/Salmon.php
@@ -23,7 +23,7 @@ namespace Friendica\Protocol;
 
 use Friendica\Core\Logger;
 use Friendica\DI;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\Probe;
 use Friendica\Util\Crypto;
 use Friendica\Util\Strings;
@@ -73,7 +73,7 @@ class Salmon
 						$ret[$x] = substr($ret[$x], 5);
 					}
 				} elseif (Strings::normaliseLink($ret[$x]) == 'http://') {
-					$ret[$x] = DI::httpClient()->fetch($ret[$x], 0, HttpClient::ACCEPT_MAGIC_KEY);
+					$ret[$x] = DI::httpClient()->fetch($ret[$x], 0, HttpClientAccept::MAGIC_KEY);
 					Logger::debug('Fetched public key', ['url' => $ret[$x]]);
 				}
 			}

--- a/src/Protocol/Salmon.php
+++ b/src/Protocol/Salmon.php
@@ -73,7 +73,7 @@ class Salmon
 						$ret[$x] = substr($ret[$x], 5);
 					}
 				} elseif (Strings::normaliseLink($ret[$x]) == 'http://') {
-					$ret[$x] = DI::httpClient()->fetch($ret[$x], 0, HttpClientAccept::MAGIC_KEY);
+					$ret[$x] = DI::httpClient()->fetch($ret[$x], HttpClientAccept::MAGIC_KEY);
 					Logger::debug('Fetched public key', ['url' => $ret[$x]]);
 				}
 			}
@@ -157,7 +157,7 @@ class Salmon
 		$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 
 		// slap them
-		$postResult = DI::httpClient()->post($url, $salmon, [
+		$postResult = DI::httpClient()->post($url, $salmon, HttpClientAccept::DEFAULT, [
 			'Content-type' => 'application/magic-envelope+xml',
 			'Content-length' => strlen($salmon),
 		]);
@@ -182,7 +182,7 @@ class Salmon
 			$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 
 			// slap them
-			$postResult = DI::httpClient()->post($url, $salmon, [
+			$postResult = DI::httpClient()->post($url, $salmon, HttpClientAccept::DEFAULT, [
 				'Content-type' => 'application/magic-envelope+xml',
 				'Content-length' => strlen($salmon),
 			]);
@@ -205,7 +205,7 @@ class Salmon
 			$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 
 			// slap them
-			$postResult = DI::httpClient()->post($url, $salmon, [
+			$postResult = DI::httpClient()->post($url, $salmon, HttpClientAccept::DEFAULT, [
 				'Content-type' => 'application/magic-envelope+xml',
 				'Content-length' => strlen($salmon)]);
 			$return_code = $postResult->getReturnCode();

--- a/src/Security/ExAuth.php
+++ b/src/Security/ExAuth.php
@@ -57,7 +57,7 @@ use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
 use Friendica\Database\Database;
 use Friendica\DI;
 use Friendica\Model\User;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\HTTPException;
 use Friendica\Util\PidFile;
@@ -241,7 +241,7 @@ class ExAuth
 
 		$url = ($ssl ? 'https' : 'http') . '://' . $host . '/noscrape/' . $user;
 
-		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 
 		if (!$curlResult->isSuccess()) {
 			return false;

--- a/src/Security/ExAuth.php
+++ b/src/Security/ExAuth.php
@@ -58,7 +58,6 @@ use Friendica\Database\Database;
 use Friendica\DI;
 use Friendica\Model\User;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
-use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\HTTPException;
 use Friendica\Util\PidFile;
 
@@ -241,7 +240,7 @@ class ExAuth
 
 		$url = ($ssl ? 'https' : 'http') . '://' . $host . '/noscrape/' . $user;
 
-		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$curlResult = DI::httpClient()->get($url, HttpClientAccept::JSON);
 
 		if (!$curlResult->isSuccess()) {
 			return false;

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -304,7 +304,7 @@ class HTTPSignature
 
 		$headers['Content-Type'] = 'application/activity+json';
 
-		$postResult = DI::httpClient()->post($target, $content, HttpClientAccept::DEFAULT, $headers);
+		$postResult = DI::httpClient()->post($target, $content, $headers);
 		$return_code = $postResult->getReturnCode();
 
 		Logger::info('Transmit to ' . $target . ' returned ' . $return_code);
@@ -452,7 +452,7 @@ class HTTPSignature
 		$curl_opts[HttpClientOptions::HEADERS] = $header;
 
 		if (!empty($opts['nobody'])) {
-			$curlResult = DI::httpClient()->head($request, HttpClientAccept::JSON_AS, $curl_opts);
+			$curlResult = DI::httpClient()->head($request, $curl_opts);
 		} else {
 			$curlResult = DI::httpClient()->get($request, HttpClientAccept::JSON_AS, $curl_opts);
 		}

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -304,7 +304,7 @@ class HTTPSignature
 
 		$headers['Content-Type'] = 'application/activity+json';
 
-		$postResult = DI::httpClient()->post($target, $content, $headers);
+		$postResult = DI::httpClient()->post($target, $content, HttpClientAccept::DEFAULT, $headers);
 		$return_code = $postResult->getReturnCode();
 
 		Logger::info('Transmit to ' . $target . ' returned ' . $return_code);
@@ -452,9 +452,9 @@ class HTTPSignature
 		$curl_opts[HttpClientOptions::HEADERS] = $header;
 
 		if (!empty($opts['nobody'])) {
-			$curlResult = DI::httpClient()->head($request, $curl_opts);
+			$curlResult = DI::httpClient()->head($request, HttpClientAccept::JSON_AS, $curl_opts);
 		} else {
-			$curlResult = DI::httpClient()->get($request, $curl_opts);
+			$curlResult = DI::httpClient()->get($request, HttpClientAccept::JSON_AS, $curl_opts);
 		}
 		$return_code = $curlResult->getReturnCode();
 

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -28,7 +28,7 @@ use Friendica\DI;
 use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Model\User;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 
 /**
@@ -416,7 +416,7 @@ class HTTPSignature
 	 * @return \Friendica\Network\HTTPClient\Capability\ICanHandleHttpResponses CurlResult
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function fetchRaw($request, $uid = 0, $opts = [HttpClientOptions::ACCEPT_CONTENT => [HttpClient::ACCEPT_JSON_AS]])
+	public static function fetchRaw($request, $uid = 0, $opts = [HttpClientOptions::ACCEPT_CONTENT => [HttpClientAccept::JSON_AS]])
 	{
 		$header = [];
 

--- a/src/Util/Images.php
+++ b/src/Util/Images.php
@@ -24,7 +24,7 @@ namespace Friendica\Util;
 use Friendica\Core\Logger;
 use Friendica\DI;
 use Friendica\Model\Photo;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 
 /**
  * Image utilities
@@ -220,7 +220,7 @@ class Images
 		}
 
 		if (empty($img_str)) {
-			$img_str = DI::httpClient()->fetch($url, 4, HttpClient::ACCEPT_IMAGE);
+			$img_str = DI::httpClient()->fetch($url, 4, HttpClientAccept::IMAGE);
 		}
 
 		if (!$img_str) {

--- a/src/Util/Images.php
+++ b/src/Util/Images.php
@@ -220,7 +220,7 @@ class Images
 		}
 
 		if (empty($img_str)) {
-			$img_str = DI::httpClient()->fetch($url, 4, HttpClientAccept::IMAGE);
+			$img_str = DI::httpClient()->fetch($url, HttpClientAccept::IMAGE, 4);
 		}
 
 		if (!$img_str) {

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -29,7 +29,7 @@ use Friendica\Core\Logger;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 
@@ -59,7 +59,7 @@ class ParseUrl
 	 * @param string $accept content-type to accept
 	 * @return array content type
 	 */
-	public static function getContentType(string $url, string $accept = HttpClient::ACCEPT_DEFAULT)
+	public static function getContentType(string $url, string $accept = HttpClientAccept::DEFAULT)
 	{
 		$curlResult = DI::httpClient()->head($url, [HttpClientOptions::ACCEPT_CONTENT => $accept]);
 
@@ -222,7 +222,7 @@ class ParseUrl
 			return $siteinfo;
 		}
 
-		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::CONTENT_LENGTH => 1000000, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_HTML]);
+		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::CONTENT_LENGTH => 1000000, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			Logger::info('Empty body or error when fetching', ['url' => $url, 'success' => $curlResult->isSuccess(), 'code' => $curlResult->getReturnCode()]);
 			return $siteinfo;

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -61,7 +61,7 @@ class ParseUrl
 	 */
 	public static function getContentType(string $url, string $accept = HttpClientAccept::DEFAULT)
 	{
-		$curlResult = DI::httpClient()->head($url, $accept);
+		$curlResult = DI::httpClient()->head($url);
 
 		// Workaround for systems that can't handle a HEAD request
 		if (!$curlResult->isSuccess() && ($curlResult->getReturnCode() == 405)) {

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -61,11 +61,11 @@ class ParseUrl
 	 */
 	public static function getContentType(string $url, string $accept = HttpClientAccept::DEFAULT)
 	{
-		$curlResult = DI::httpClient()->head($url, [HttpClientOptions::ACCEPT_CONTENT => $accept]);
+		$curlResult = DI::httpClient()->head($url, $accept);
 
 		// Workaround for systems that can't handle a HEAD request
 		if (!$curlResult->isSuccess() && ($curlResult->getReturnCode() == 405)) {
-			$curlResult = DI::httpClient()->get($url, [HttpClientOptions::CONTENT_LENGTH => 1000000, HttpClientOptions::ACCEPT_CONTENT => $accept]);
+			$curlResult = DI::httpClient()->get($url, $accept, [HttpClientOptions::CONTENT_LENGTH => 1000000]);
 		}
 
 		if (!$curlResult->isSuccess()) {
@@ -222,7 +222,7 @@ class ParseUrl
 			return $siteinfo;
 		}
 
-		$curlResult = DI::httpClient()->get($url, [HttpClientOptions::CONTENT_LENGTH => 1000000, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
+		$curlResult = DI::httpClient()->get($url, HttpClientAccept::HTML, [HttpClientOptions::CONTENT_LENGTH => 1000000]);
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
 			Logger::info('Empty body or error when fetching', ['url' => $url, 'success' => $curlResult->isSuccess(), 'code' => $curlResult->getReturnCode()]);
 			return $siteinfo;

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -61,7 +61,7 @@ class ParseUrl
 	 */
 	public static function getContentType(string $url, string $accept = HttpClientAccept::DEFAULT)
 	{
-		$curlResult = DI::httpClient()->head($url);
+		$curlResult = DI::httpClient()->head($url, [HttpClientOptions::ACCEPT_CONTENT => $accept]);
 
 		// Workaround for systems that can't handle a HEAD request
 		if (!$curlResult->isSuccess() && ($curlResult->getReturnCode() == 405)) {

--- a/src/Worker/CheckVersion.php
+++ b/src/Worker/CheckVersion.php
@@ -24,7 +24,7 @@ namespace Friendica\Worker;
 use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 
 /**
  * Check the git repository VERSION file and save the version to the DB
@@ -55,7 +55,7 @@ class CheckVersion
 		Logger::info("Checking VERSION from: ".$checked_url);
 
 		// fetch the VERSION file
-		$gitversion = DBA::escape(trim(DI::httpClient()->fetch($checked_url, 0, HttpClient::ACCEPT_TEXT)));
+		$gitversion = DBA::escape(trim(DI::httpClient()->fetch($checked_url, 0, HttpClientAccept::TEXT)));
 		Logger::notice("Upstream VERSION is: ".$gitversion);
 
 		DI::config()->set('system', 'git_friendica_version', $gitversion);

--- a/src/Worker/CheckVersion.php
+++ b/src/Worker/CheckVersion.php
@@ -55,7 +55,7 @@ class CheckVersion
 		Logger::info("Checking VERSION from: ".$checked_url);
 
 		// fetch the VERSION file
-		$gitversion = DBA::escape(trim(DI::httpClient()->fetch($checked_url, 0, HttpClientAccept::TEXT)));
+		$gitversion = DBA::escape(trim(DI::httpClient()->fetch($checked_url, HttpClientAccept::TEXT)));
 		Logger::notice("Upstream VERSION is: ".$gitversion);
 
 		DI::config()->set('system', 'git_friendica_version', $gitversion);

--- a/src/Worker/Directory.php
+++ b/src/Worker/Directory.php
@@ -26,7 +26,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 
 /**
  * Sends updated profile data to the directory
@@ -54,7 +54,7 @@ class Directory
 
 		Logger::info('Updating directory: ' . $arr['url']);
 		if (strlen($arr['url'])) {
-			DI::httpClient()->fetch($dir . '?url=' . bin2hex($arr['url']), 0, HttpClient::ACCEPT_HTML);
+			DI::httpClient()->fetch($dir . '?url=' . bin2hex($arr['url']), 0, HttpClientAccept::HTML);
 		}
 
 		return;

--- a/src/Worker/Directory.php
+++ b/src/Worker/Directory.php
@@ -54,7 +54,7 @@ class Directory
 
 		Logger::info('Updating directory: ' . $arr['url']);
 		if (strlen($arr['url'])) {
-			DI::httpClient()->fetch($dir . '?url=' . bin2hex($arr['url']), 0, HttpClientAccept::HTML);
+			DI::httpClient()->fetch($dir . '?url=' . bin2hex($arr['url']), HttpClientAccept::HTML);
 		}
 
 		return;

--- a/src/Worker/NodeInfo.php
+++ b/src/Worker/NodeInfo.php
@@ -24,7 +24,7 @@ namespace Friendica\Worker;
 use Friendica\Core\Logger;
 use Friendica\DI;
 use Friendica\Model\Nodeinfo as ModelNodeInfo;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 
 class NodeInfo
 {
@@ -35,7 +35,7 @@ class NodeInfo
 		// Now trying to register
 		$url = 'http://the-federation.info/register/' . DI::baseUrl()->getHostname();
 		Logger::debug('Check registering url', ['url' => $url]);
-		$ret = DI::httpClient()->fetch($url, 0, HttpClient::ACCEPT_HTML);
+		$ret = DI::httpClient()->fetch($url, 0, HttpClientAccept::HTML);
 		Logger::debug('Check registering answer', ['answer' => $ret]);
 		Logger::info('end');
 	}

--- a/src/Worker/NodeInfo.php
+++ b/src/Worker/NodeInfo.php
@@ -35,7 +35,7 @@ class NodeInfo
 		// Now trying to register
 		$url = 'http://the-federation.info/register/' . DI::baseUrl()->getHostname();
 		Logger::debug('Check registering url', ['url' => $url]);
-		$ret = DI::httpClient()->fetch($url, 0, HttpClientAccept::HTML);
+		$ret = DI::httpClient()->fetch($url, HttpClientAccept::HTML);
 		Logger::debug('Check registering answer', ['answer' => $ret]);
 		Logger::info('end');
 	}

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -30,7 +30,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Model\User;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\ActivityPub;
@@ -155,7 +155,7 @@ class OnePoll
 		}
 
 		$cookiejar = tempnam(System::getTempPath(), 'cookiejar-onepoll-');
-		$curlResult = DI::httpClient()->get($contact['poll'], [HttpClientOptions::COOKIEJAR => $cookiejar, HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_FEED_XML]);
+		$curlResult = DI::httpClient()->get($contact['poll'], [HttpClientOptions::COOKIEJAR => $cookiejar, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::FEED_XML]);
 		unlink($cookiejar);
 
 		if ($curlResult->isTimeout()) {

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -155,7 +155,7 @@ class OnePoll
 		}
 
 		$cookiejar = tempnam(System::getTempPath(), 'cookiejar-onepoll-');
-		$curlResult = DI::httpClient()->get($contact['poll'], [HttpClientOptions::COOKIEJAR => $cookiejar, HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::FEED_XML]);
+		$curlResult = DI::httpClient()->get($contact['poll'], HttpClientAccept::FEED_XML, [HttpClientOptions::COOKIEJAR => $cookiejar]);
 		unlink($cookiejar);
 
 		if ($curlResult->isTimeout()) {

--- a/src/Worker/PubSubPublish.php
+++ b/src/Worker/PubSubPublish.php
@@ -25,7 +25,6 @@ use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\PushSubscriber;
-use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Protocol\OStatus;
 
 class PubSubPublish
@@ -69,7 +68,7 @@ class PubSubPublish
 
 		Logger::debug('POST', ['headers' => $headers, 'params' => $params]);
 
-		$postResult = DI::httpClient()->post($subscriber['callback_url'], $params, HttpClientAccept::DEFAULT, $headers);
+		$postResult = DI::httpClient()->post($subscriber['callback_url'], $params, $headers);
 		$ret = $postResult->getReturnCode();
 
 		if ($ret >= 200 && $ret <= 299) {

--- a/src/Worker/PubSubPublish.php
+++ b/src/Worker/PubSubPublish.php
@@ -25,6 +25,7 @@ use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\PushSubscriber;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Protocol\OStatus;
 
 class PubSubPublish
@@ -68,7 +69,7 @@ class PubSubPublish
 
 		Logger::debug('POST', ['headers' => $headers, 'params' => $params]);
 
-		$postResult = DI::httpClient()->post($subscriber['callback_url'], $params, $headers);
+		$postResult = DI::httpClient()->post($subscriber['callback_url'], $params, HttpClientAccept::DEFAULT, $headers);
 		$ret = $postResult->getReturnCode();
 
 		if ($ret >= 200 && $ret <= 299) {

--- a/src/Worker/PullDirectory.php
+++ b/src/Worker/PullDirectory.php
@@ -48,7 +48,7 @@ class PullDirectory
 
 		Logger::info('Synchronization started.', ['now' => $now, 'directory' => $directory]);
 
-		$result = DI::httpClient()->fetch($directory . '/sync/pull/since/' . $now, 0, HttpClientAccept::JSON);
+		$result = DI::httpClient()->fetch($directory . '/sync/pull/since/' . $now, HttpClientAccept::JSON);
 		if (empty($result)) {
 			Logger::info('Directory server return empty result.', ['directory' => $directory]);
 			return;

--- a/src/Worker/PullDirectory.php
+++ b/src/Worker/PullDirectory.php
@@ -24,7 +24,7 @@ namespace Friendica\Worker;
 use Friendica\Core\Logger;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 
 class PullDirectory
 {
@@ -48,7 +48,7 @@ class PullDirectory
 
 		Logger::info('Synchronization started.', ['now' => $now, 'directory' => $directory]);
 
-		$result = DI::httpClient()->fetch($directory . '/sync/pull/since/' . $now, 0, HttpClient::ACCEPT_JSON);
+		$result = DI::httpClient()->fetch($directory . '/sync/pull/since/' . $now, 0, HttpClientAccept::JSON);
 		if (empty($result)) {
 			Logger::info('Directory server return empty result.', ['directory' => $directory]);
 			return;

--- a/src/Worker/SearchDirectory.php
+++ b/src/Worker/SearchDirectory.php
@@ -47,7 +47,7 @@ class SearchDirectory
 			}
 		}
 
-		$x = DI::httpClient()->fetch(Search::getGlobalDirectory() . '/lsearch?p=1&n=500&search=' . urlencode($search), 0, HttpClientAccept::JSON);
+		$x = DI::httpClient()->fetch(Search::getGlobalDirectory() . '/lsearch?p=1&n=500&search=' . urlencode($search), HttpClientAccept::JSON);
 		$j = json_decode($x);
 
 		if (!empty($j->results)) {

--- a/src/Worker/SearchDirectory.php
+++ b/src/Worker/SearchDirectory.php
@@ -26,7 +26,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\Search;
 use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 
 class SearchDirectory
 {
@@ -47,7 +47,7 @@ class SearchDirectory
 			}
 		}
 
-		$x = DI::httpClient()->fetch(Search::getGlobalDirectory() . '/lsearch?p=1&n=500&search=' . urlencode($search), 0, HttpClient::ACCEPT_JSON);
+		$x = DI::httpClient()->fetch(Search::getGlobalDirectory() . '/lsearch?p=1&n=500&search=' . urlencode($search), 0, HttpClientAccept::JSON);
 		$j = json_decode($x);
 
 		if (!empty($j->results)) {

--- a/src/Worker/UpdateServerDirectory.php
+++ b/src/Worker/UpdateServerDirectory.php
@@ -22,11 +22,10 @@
 namespace Friendica\Worker;
 
 use Friendica\Core\Logger;
-use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\GServer;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 
 class UpdateServerDirectory
 {
@@ -46,7 +45,7 @@ class UpdateServerDirectory
 
 	private static function discoverPoCo(array $gserver)
 	{
-		$result = DI::httpClient()->fetch($gserver['poco'] . '?fields=urls', 0, HttpClient::ACCEPT_JSON);
+		$result = DI::httpClient()->fetch($gserver['poco'] . '?fields=urls', 0, HttpClientAccept::JSON);
 		if (empty($result)) {
 			Logger::info('Empty result', ['url' => $gserver['url']]);
 			return;
@@ -79,7 +78,7 @@ class UpdateServerDirectory
 
 	private static function discoverMastodonDirectory(array $gserver)
 	{		
-		$result = DI::httpClient()->fetch($gserver['url'] . '/api/v1/directory?order=new&local=true&limit=200&offset=0', 0, HttpClient::ACCEPT_JSON);
+		$result = DI::httpClient()->fetch($gserver['url'] . '/api/v1/directory?order=new&local=true&limit=200&offset=0', 0, HttpClientAccept::JSON);
 		if (empty($result)) {
 			Logger::info('Empty result', ['url' => $gserver['url']]);
 			return;

--- a/src/Worker/UpdateServerDirectory.php
+++ b/src/Worker/UpdateServerDirectory.php
@@ -45,7 +45,7 @@ class UpdateServerDirectory
 
 	private static function discoverPoCo(array $gserver)
 	{
-		$result = DI::httpClient()->fetch($gserver['poco'] . '?fields=urls', 0, HttpClientAccept::JSON);
+		$result = DI::httpClient()->fetch($gserver['poco'] . '?fields=urls', HttpClientAccept::JSON);
 		if (empty($result)) {
 			Logger::info('Empty result', ['url' => $gserver['url']]);
 			return;
@@ -78,7 +78,7 @@ class UpdateServerDirectory
 
 	private static function discoverMastodonDirectory(array $gserver)
 	{		
-		$result = DI::httpClient()->fetch($gserver['url'] . '/api/v1/directory?order=new&local=true&limit=200&offset=0', 0, HttpClientAccept::JSON);
+		$result = DI::httpClient()->fetch($gserver['url'] . '/api/v1/directory?order=new&local=true&limit=200&offset=0', HttpClientAccept::JSON);
 		if (empty($result)) {
 			Logger::info('Empty result', ['url' => $gserver['url']]);
 			return;

--- a/src/Worker/UpdateServerPeers.php
+++ b/src/Worker/UpdateServerPeers.php
@@ -26,7 +26,6 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\GServer;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
-use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Util\Strings;
 
 class UpdateServerPeers
@@ -37,7 +36,7 @@ class UpdateServerPeers
 	 */
 	public static function execute(string $url)
 	{
-		$ret = DI::httpClient()->get($url . '/api/v1/instance/peers', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
+		$ret = DI::httpClient()->get($url . '/api/v1/instance/peers', HttpClientAccept::JSON);
 		if (!$ret->isSuccess() || empty($ret->getBody())) {
 			Logger::info('Server is not reachable or does not offer the "peers" endpoint', ['url' => $url]);
 			return;

--- a/src/Worker/UpdateServerPeers.php
+++ b/src/Worker/UpdateServerPeers.php
@@ -25,7 +25,7 @@ use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\GServer;
-use Friendica\Network\HTTPClient\Client\HttpClient;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Util\Strings;
 
@@ -37,7 +37,7 @@ class UpdateServerPeers
 	 */
 	public static function execute(string $url)
 	{
-		$ret = DI::httpClient()->get($url . '/api/v1/instance/peers', [HttpClientOptions::ACCEPT_CONTENT => HttpClient::ACCEPT_JSON]);
+		$ret = DI::httpClient()->get($url . '/api/v1/instance/peers', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON]);
 		if (!$ret->isSuccess() || empty($ret->getBody())) {
 			Logger::info('Server is not reachable or does not offer the "peers" endpoint', ['url' => $url]);
 			return;


### PR DESCRIPTION
FollowUp #11382
Implementation based on https://github.com/friendica/friendica/pull/11382#issuecomment-1081616758

What's new:

- All `Accept` constants are now moved to the explicit "enum" class `HttpClientAccept` - So we're now decoupled from the current `HttpClient` class again :-)
- I introduced the `$accept_header` at all `ICanSendHttpRequest` methods and used classes

Needs https://github.com/friendica/friendica-addons/pull/1245 as well