### PR TITLE
Only use and accept valid http links as links to an external resource

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3191,6 +3191,12 @@ class Item
 	 */
 	public static function getPlink($item)
 	{
+		if (Network::isValidHttpUrl($item['plink'])) {
+			$plink = $item['plink'];
+		} elseif (Network::isValidHttpUrl($item['uri']) && !Network::isLocalLink($item['uri'])) {
+			$plink = $item['uri'];
+		}
+
 		if (local_user()) {
 			$ret = [
 				'href' => "display/" . $item['guid'],
@@ -3199,14 +3205,14 @@ class Item
 				'orig_title' => DI::l10n()->t('View on separate page'),
 			];
 
-			if (!empty($item['plink'])) {
-				$ret['href'] = DI::baseUrl()->remove($item['plink']);
+			if (!empty($plink)) {
+				$ret['href'] = DI::baseUrl()->remove($plink);
 				$ret['title'] = DI::l10n()->t('Link to source');
 			}
-		} elseif (!empty($item['plink']) && ($item['private'] != self::PRIVATE)) {
+		} elseif (!empty($plink) && ($item['private'] != self::PRIVATE)) {
 			$ret = [
-				'href' => $item['plink'],
-				'orig' => $item['plink'],
+				'href' => $plink,
+				'orig' => $plink,
 				'title' => DI::l10n()->t('Link to source'),
 				'orig_title' => DI::l10n()->t('Link to source'),
 			];

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -37,6 +37,7 @@ use Friendica\Protocol\ActivityPub;
 use Friendica\Util\HTTPSignature;
 use Friendica\Util\JsonLD;
 use Friendica\Util\LDSignature;
+use Friendica\Util\Network;
 use Friendica\Util\Strings;
 
 /**
@@ -1531,6 +1532,10 @@ class Receiver
 			if (!is_string($object_data['alternate-url'])) {
 				$object_data['alternate-url'] = JsonLD::fetchElement($object['as:url'], 'as:href', '@id');
 			}
+		}
+
+		if (!empty($object_data['alternate-url']) && !Network::isValidHttpUrl($object_data['alternate-url'])) {
+			$object_data['alternate-url'] = null;
 		}
 
 		if (in_array($object_data['object_type'], ['as:Audio', 'as:Video'])) {

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -569,6 +569,7 @@ class Network
 	 */
 	public static function isValidHttpUrl(string $url)
 	{
-		return in_array(parse_url($url, PHP_URL_SCHEME), ['http', 'https']) && parse_url($url, PHP_URL_HOST);
+		$scheme = parse_url($url, PHP_URL_SCHEME);
+		return !empty($scheme) && in_array($scheme, ['http', 'https']) && parse_url($url, PHP_URL_HOST);
 	}
 }

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -560,4 +560,15 @@ class Network
 	{
 		return (strpos(Strings::normaliseLink($url), Strings::normaliseLink(DI::baseUrl())) !== false);
 	}
+
+	/**
+	 * Check if the given URL is a valid HTTP/HTTPS URL
+	 *
+	 * @param string $url 
+	 * @return bool 
+	 */
+	public static function isValidHttpUrl(string $url)
+	{
+		return in_array(parse_url($url, PHP_URL_SCHEME), ['http', 'https']) && parse_url($url, PHP_URL_HOST);
+	}
 }


### PR DESCRIPTION
When displaying a post, we always want to provide a link to the external representation of the post as well. There are systems out that doesn't provide valid data, so we have to check in advance. Also when the `plink` field is not filled, we often can use the `uri` field as well - but we have to check if the `uri`is a valid link.