### PR TITLE
Fix: Webfinger returned xml when json has been requested and vice versa

### DIFF
--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -101,7 +101,7 @@ class Xrd extends BaseModule
 			$avatar = ['type' => 'image/jpeg'];
 		}
 
-		if ($mode == Response::TYPE_JSON) {
+		if ($mode == Response::TYPE_XML) {
 			self::printXML($alias, DI::baseUrl()->get(), $user, $owner, $avatar);
 		} else {
 			self::printJSON($alias, DI::baseUrl()->get(), $owner, $avatar);


### PR DESCRIPTION
Webfinger returned the opposite from what was requested. This is fixed.