### PR TITLE
Update FAQ.md

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -179,19 +179,17 @@ The available features are client specific and may differ.
 
 * [AndStatus](http://andstatus.org) ([F-Droid](https://f-droid.org/repository/browse/?fdid=org.andstatus.app), [Google Play](https://play.google.com/store/apps/details?id=org.andstatus.app))
 * [B4X for Pleroma & Mastodon](https://github.com/AnywhereSoftware/B4X-Pleroma)
-* DiCa ([Google Play](https://play.google.com/store/apps/details?id=cool.mixi.dica), last updated 2019)
 * [Fedi](https://play.google.com/store/apps/details?id=com.fediverse.app)
 * [Fedilab](https://fedilab.app) ([F-Droid](https://f-droid.org/app/fr.gouv.etalab.mastodon), [Google Play](https://play.google.com/store/apps/details?id=app.fedilab.android))
 * [Friendiqa](https://git.friendi.ca/lubuwest/Friendiqa) ([F-Droid](https://git.friendi.ca/lubuwest/Friendiqa#install), [Google Play](https://play.google.com/store/apps/details?id=org.qtproject.friendiqa))
 * [Husky](https://husky.fwgs.ru)
-* [Roma](https://play.google.com/store/apps/details?id=tech.bigfig.roma)
+* [Mastodon for Android](https://github.com/mastodon/mastodon-android) (F-Droid: Pending, [Google-Play](https://play.google.com/store/apps/details?id=org.joinmastodon.android))
 * [Subway Tooter](https://github.com/tateisu/SubwayTooter)
 * [Tooot](https://tooot.app/)
-* [Tusky](https://tusky.app)
-* [Twidere](https://dimension.im/) ([F-Droid](https://f-droid.org/repository/browse/?fdid=org.mariotaku.twidere), [Google Play](https://play.google.com/store/apps/details?id=com.twidere.twiderex), [GitHub](https://github.com/TwidereProject/Twidere-Android))
-* [TwidereX](https://github.com/TwidereProject/TwidereX-Android)
-* [twitlatte](https://github.com/moko256/twitlatte)
-* [Yuito](https://github.com/accelforce/Yuito)
+* [Tusky](https://tusky.app) ([F-Droid](https://f-droid.org/repository/browse/?fdid=com.keylesspalace.tusky), [Google Play](https://play.google.com/store/apps/details?id=com.keylesspalace.tusky))
+* [Twidere](https://github.com/TwidereProject/Twidere-Android) ([F-Droid](https://f-droid.org/repository/browse/?fdid=org.mariotaku.twidere), [Google Play](https://play.google.com/store/apps/details?id=com.twidere.twiderex))
+* [TwidereX](https://github.com/TwidereProject/TwidereX-Android) ([F-Droid](https://f-droid.org/en/packages/com.twidere.twiderex/), [Google Play](https://play.google.com/store/apps/details?id=com.twidere.twiderex))
+* [Yuito](https://github.com/accelforce/Yuito) ([Google Play](https://play.google.com/store/apps/details?id=net.accelf.yuito))
 
 #### SailfishOS
 
@@ -199,12 +197,12 @@ The available features are client specific and may differ.
 
 #### iOS
 
-* [B4X for Pleroma & Mastodon](https://www.b4x.com/) ([AppStore](https://apps.apple.com/app/b4x-pleroma/id1538396871), [GitHub](https://github.com/AnywhereSoftware/B4X-Pleroma))
+* [B4X for Pleroma & Mastodon](https://github.com/AnywhereSoftware/B4X-Pleroma) ([AppStore](https://apps.apple.com/app/b4x-pleroma/id1538396871))
 * [Fedi](https://fediapp.com) ([AppStore](https://apps.apple.com/de/app/fedi-for-pleroma-and-mastodon/id1478806281))
-* [Mastodon](https://joinmastodon.org/apps)([AppStore](https://apps.apple.com/us/app/mastodon-for-iphone/id1571998974))
-* [Roma](https://www.roma.rocks/)([AppStore](https://apps.apple.com/de/app/roma-for-pleroma-and-mastodon/id1445328699))
+* [Mastodon for iPhone and iPad](https://joinmastodon.org/apps) ([AppStore](https://apps.apple.com/us/app/mastodon-for-iphone/id1571998974))
+* [Roma](https://www.roma.rocks/) ([AppStore](https://apps.apple.com/de/app/roma-for-pleroma-and-mastodon/id1445328699))
 * [Stella*](https://www.stella-app.net/) ([AppStore](https://apps.apple.com/us/app/stella-for-mastodon-twitter/id921372048))
-* [Tooot](https://tooot.app/) ([AppStore](https://apps.apple.com/app/id1549772269), [GitHub](https://github.com/tooot-app)), Data collection (not linked to identity)
+* [Tooot](https://github.com/tooot-app) ([AppStore](https://apps.apple.com/app/id1549772269), Data collection (not linked to identity)
 * [Tootle](https://mastodon.cloud/@tootleapp) ([AppStore](https://apps.apple.com/de/app/tootle-for-mastodon/id1236013466)), last update: 2020
 
 #### Linux
@@ -217,8 +215,12 @@ The available features are client specific and may differ.
 
 #### macOS
 
-* [Mastonaut](https://mastonaut.app/) ([AppStore](https://apps.apple.com/us/app/mastonaut/id1450757574)), costs ~8€
+* [Mastonaut](https://mastonaut.app/) ([AppStore](https://apps.apple.com/us/app/mastonaut/id1450757574)), closed source
 * [Whalebird](https://whalebird.social/en/desktop/contents) ([AppStore](https://apps.apple.com/de/app/whalebird/id1378283354), [GitHub](https://github.com/h3poteto/whalebird-desktop))
+
+#### Windows
+
+* [Whalebird](https://whalebird.social/en/desktop/contents) ([Website Download](https://whalebird.social/en/desktop/contents/downloads#windows), [GitHub](https://github.com/h3poteto/whalebird-desktop))
 
 #### Web Frontend
 


### PR DESCRIPTION
- Mastonaut for macOS is now free, removed cost info and added close source info
- updated name for Mastodon client
- added Whalebird for Windows
- added Mastodon for Android
- removed Dica (last update Jan 2019, developer website, source code github and support forum link on Google Play site dead)
- added Tusky F-Droid and Google Play links
- removed twitlatte (This app was suspended by Twitter. Please use other app. as per repo info)
- Yuito added Google Play link
- Twidere X added F-Droid and Google Play links
- removed Roma (App will be removed from app store on 3/15/2021 and support ended, as per Google Play info)
- removed website links for tooot and b4x ios, twidere android for consistency - app name ideally always goes to source