### PR TITLE
Renamed "share" with "share via"

### DIFF
--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -249,7 +249,7 @@ class Post
 			];
 		}
 
-		if (!$item['self']) {
+		if (!$item['self'] && local_user()) {
 			$block = [
 				'blocking' => true,
 				'block'   => DI::l10n()->t('Block %s', $item['author-name']),
@@ -445,6 +445,10 @@ class Post
 			$languages = [DI::l10n()->t('Languages'), Item::getLanguageMessage($item)];
 		}
 
+		if (in_array($item['private'], [Item::PUBLIC, Item::UNLISTED]) && in_array($item['network'], Protocol::FEDERATED)) {
+			$browsershare = [DI::l10n()->t('Share via ...'), DI::l10n()->t('Share via external services')];
+		}
+
 		$tmp_item = [
 			'template'        => $this->getTemplate(),
 			'type'            => implode("", array_slice(explode("/", $item['verb']), -1)),
@@ -496,7 +500,7 @@ class Post
 			'owner_photo'     => DI::baseUrl()->remove(Contact::getAvatarUrlForUrl($item['owner-link'], $item['uid'], Proxy::SIZE_THUMB)),
 			'owner_name'      => $this->getOwnerName(),
 			'plink'           => Item::getPlink($item),
-			'browsershare'    => DI::l10n()->t('Share'),
+			'browsershare'    => $browsershare,
 			'edpost'          => $edpost,
 			'ispinned'        => $ispinned,
 			'pin'             => $pin,

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.05-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-13 05:30+0000\n"
+"POT-Creation-Date: 2022-04-19 19:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -163,7 +163,7 @@ msgid "Save"
 msgstr ""
 
 #: mod/editpost.php:92 mod/photos.php:1344 src/Content/Conversation.php:338
-#: src/Module/Contact/Poke.php:176 src/Object/Post.php:988
+#: src/Module/Contact/Poke.php:176 src/Object/Post.php:992
 msgid "Loading..."
 msgstr ""
 
@@ -229,7 +229,7 @@ msgstr ""
 #: mod/editpost.php:107 mod/message.php:200 mod/message.php:358
 #: mod/photos.php:1495 mod/wallmessage.php:142 src/Content/Conversation.php:368
 #: src/Content/Conversation.php:712 src/Module/Item/Compose.php:177
-#: src/Object/Post.php:522
+#: src/Object/Post.php:526
 msgid "Please wait"
 msgstr ""
 
@@ -261,7 +261,7 @@ msgstr ""
 
 #: mod/editpost.php:128 mod/events.php:513 mod/photos.php:1343
 #: mod/photos.php:1399 mod/photos.php:1473 src/Content/Conversation.php:383
-#: src/Module/Item/Compose.php:172 src/Object/Post.php:998
+#: src/Module/Item/Compose.php:172 src/Object/Post.php:1002
 msgid "Preview"
 msgstr ""
 
@@ -273,37 +273,37 @@ msgid "Cancel"
 msgstr ""
 
 #: mod/editpost.php:134 src/Content/Conversation.php:343
-#: src/Module/Item/Compose.php:163 src/Object/Post.php:989
+#: src/Module/Item/Compose.php:163 src/Object/Post.php:993
 msgid "Bold"
 msgstr ""
 
 #: mod/editpost.php:135 src/Content/Conversation.php:344
-#: src/Module/Item/Compose.php:164 src/Object/Post.php:990
+#: src/Module/Item/Compose.php:164 src/Object/Post.php:994
 msgid "Italic"
 msgstr ""
 
 #: mod/editpost.php:136 src/Content/Conversation.php:345
-#: src/Module/Item/Compose.php:165 src/Object/Post.php:991
+#: src/Module/Item/Compose.php:165 src/Object/Post.php:995
 msgid "Underline"
 msgstr ""
 
 #: mod/editpost.php:137 src/Content/Conversation.php:346
-#: src/Module/Item/Compose.php:166 src/Object/Post.php:992
+#: src/Module/Item/Compose.php:166 src/Object/Post.php:996
 msgid "Quote"
 msgstr ""
 
 #: mod/editpost.php:138 src/Content/Conversation.php:347
-#: src/Module/Item/Compose.php:167 src/Object/Post.php:993
+#: src/Module/Item/Compose.php:167 src/Object/Post.php:997
 msgid "Code"
 msgstr ""
 
 #: mod/editpost.php:139 src/Content/Conversation.php:349
-#: src/Module/Item/Compose.php:169 src/Object/Post.php:995
+#: src/Module/Item/Compose.php:169 src/Object/Post.php:999
 msgid "Link"
 msgstr ""
 
 #: mod/editpost.php:140 src/Content/Conversation.php:350
-#: src/Module/Item/Compose.php:170 src/Object/Post.php:996
+#: src/Module/Item/Compose.php:170 src/Object/Post.php:1000
 msgid "Link or Media"
 msgstr ""
 
@@ -411,7 +411,7 @@ msgstr ""
 #: src/Module/Install.php:252 src/Module/Install.php:294
 #: src/Module/Install.php:331 src/Module/Invite.php:177
 #: src/Module/Item/Compose.php:162 src/Module/Profile/Profile.php:247
-#: src/Module/Settings/Profile/Index.php:222 src/Object/Post.php:987
+#: src/Module/Settings/Profile/Index.php:222 src/Object/Post.php:991
 #: view/theme/duepuntozero/config.php:69 view/theme/frio/config.php:160
 #: view/theme/quattro/config.php:71 view/theme/vier/config.php:119
 msgid "Submit"
@@ -1066,12 +1066,12 @@ msgstr ""
 
 #: mod/photos.php:1339 mod/photos.php:1395 mod/photos.php:1469
 #: src/Module/Contact.php:544 src/Module/Item/Compose.php:160
-#: src/Object/Post.php:984
+#: src/Object/Post.php:988
 msgid "This is you"
 msgstr ""
 
 #: mod/photos.php:1341 mod/photos.php:1397 mod/photos.php:1471
-#: src/Object/Post.php:516 src/Object/Post.php:986
+#: src/Object/Post.php:520 src/Object/Post.php:990
 msgid "Comment"
 msgstr ""
 
@@ -2465,7 +2465,7 @@ msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
 #: src/Content/Conversation.php:308 src/Module/Item/Compose.php:171
-#: src/Object/Post.php:997
+#: src/Object/Post.php:1001
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
@@ -2493,12 +2493,12 @@ msgstr ""
 msgid "New Post"
 msgstr ""
 
-#: src/Content/Conversation.php:337 src/Object/Post.php:499
+#: src/Content/Conversation.php:337
 msgid "Share"
 msgstr ""
 
 #: src/Content/Conversation.php:348 src/Module/Item/Compose.php:168
-#: src/Object/Post.php:994
+#: src/Object/Post.php:998
 msgid "Image"
 msgstr ""
 
@@ -2514,21 +2514,21 @@ msgstr ""
 msgid "Pinned item"
 msgstr ""
 
-#: src/Content/Conversation.php:672 src/Object/Post.php:470
-#: src/Object/Post.php:471
+#: src/Content/Conversation.php:672 src/Object/Post.php:474
+#: src/Object/Post.php:475
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: src/Content/Conversation.php:685 src/Object/Post.php:458
+#: src/Content/Conversation.php:685 src/Object/Post.php:462
 msgid "Categories:"
 msgstr ""
 
-#: src/Content/Conversation.php:686 src/Object/Post.php:459
+#: src/Content/Conversation.php:686 src/Object/Post.php:463
 msgid "Filed under:"
 msgstr ""
 
-#: src/Content/Conversation.php:694 src/Object/Post.php:484
+#: src/Content/Conversation.php:694 src/Object/Post.php:488
 #, php-format
 msgid "%s from %s"
 msgstr ""
@@ -10559,63 +10559,71 @@ msgstr ""
 msgid "Remote comment"
 msgstr ""
 
-#: src/Object/Post.php:472
+#: src/Object/Post.php:449
+msgid "Share via ..."
+msgstr ""
+
+#: src/Object/Post.php:449
+msgid "Share via external services"
+msgstr ""
+
+#: src/Object/Post.php:476
 msgid "to"
 msgstr ""
 
-#: src/Object/Post.php:473
+#: src/Object/Post.php:477
 msgid "via"
 msgstr ""
 
-#: src/Object/Post.php:474
+#: src/Object/Post.php:478
 msgid "Wall-to-Wall"
 msgstr ""
 
-#: src/Object/Post.php:475
+#: src/Object/Post.php:479
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: src/Object/Post.php:517
+#: src/Object/Post.php:521
 #, php-format
 msgid "Reply to %s"
 msgstr ""
 
-#: src/Object/Post.php:520
+#: src/Object/Post.php:524
 msgid "More"
 msgstr ""
 
-#: src/Object/Post.php:538
+#: src/Object/Post.php:542
 msgid "Notifier task is pending"
 msgstr ""
 
-#: src/Object/Post.php:539
+#: src/Object/Post.php:543
 msgid "Delivery to remote servers is pending"
 msgstr ""
 
-#: src/Object/Post.php:540
+#: src/Object/Post.php:544
 msgid "Delivery to remote servers is underway"
 msgstr ""
 
-#: src/Object/Post.php:541
+#: src/Object/Post.php:545
 msgid "Delivery to remote servers is mostly done"
 msgstr ""
 
-#: src/Object/Post.php:542
+#: src/Object/Post.php:546
 msgid "Delivery to remote servers is done"
 msgstr ""
 
-#: src/Object/Post.php:562
+#: src/Object/Post.php:566
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Object/Post.php:563
+#: src/Object/Post.php:567
 msgid "Show more"
 msgstr ""
 
-#: src/Object/Post.php:564
+#: src/Object/Post.php:568
 msgid "Show fewer"
 msgstr ""
 

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -181,13 +181,8 @@
 						{{/if}}
 					{{/if}}
 
-                {{if !$item.lock && !$item.connector}}
-					<span role="presentation" class="separator button-browser-share"></span>
-					<button type="button" class="btn-link button-browser-share" onclick="navigator.share({url: '{{$item.plink.orig}}'})"><i class="fa fa-share-alt"></i> {{$item.browsershare}}</button>
-                {{/if}}
-
 				{{* Put additional actions in a dropdown menu *}}
-				{{if $item.menu && ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.ignore || $item.drop.dropping)}}
+				{{if $item.menu && ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.ignore || $item.drop.dropping || $item.browsershare)}}
 					<span role="presentation" class="separator"></span>
 					<span class="more-links btn-group{{if $item.thread_level> 1}} dropup{{/if}}">
 						<button type="button" class="btn-link dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="fa fa-ellipsis-h" aria-hidden="true"></i>&nbsp;{{$item.menu}}</button>
@@ -234,6 +229,12 @@
 						<li role="menuitem">
 							<a id="language-{{$item.id}}" href="javascript:alert('{{$item.language.1}}');" class="btn-link filer-item language-icon" title="{{$item.language.0}}"><i class="fa fa-language" aria-hidden="true"></i>&nbsp;{{$item.language.0}}</a>
 						</li>
+						{{/if}}
+
+						{{if $item.browsershare}}
+							<li role="menuitem" class="button-browser-share">
+								<a id="browser-share-{{$item.id}}" href="javascript:navigator.share({url: '{{$item.plink.orig}}'});" class="btn-link button-browser-share" title="{{$item.browsershare.1}}"><i class="fa fa-share-alt" aria-hidden="true"></i>&nbsp;{{$item.browsershare.0}}</a>
+							</li>
 						{{/if}}
 
 						{{if ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread) && ($item.ignore || $item.drop.dropping)}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -337,13 +337,8 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{/if}}
 			{{/if}}
 
-            {{if !$item.lock && !$item.connector}}
-				<span role="presentation" class="separator button-browser-share"></span>
-				<button type="button" class="btn-link button-browser-share" onclick="navigator.share({url: '{{$item.plink.orig}}'})"><i class="fa fa-share-alt"></i> {{$item.browsershare}}</button>
-			{{/if}}
-
 			{{* Put additional actions in a dropdown menu *}}
-			{{if $item.menu && ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.ignore || ($item.drop && $item.drop.dropping))}}
+			{{if $item.menu && ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.ignore || ($item.drop && $item.drop.dropping) || $item.browsershare)}}
 				<span role="presentation" class="separator"></span>
 				<span class="more-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}">
 					<button type="button" class="btn-link dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="fa fa-ellipsis-h" aria-hidden="true"></i>&nbsp;{{$item.menu}}</button>
@@ -390,6 +385,12 @@ as the value of $top_child_total (this is done at the end of this file)
 						<li role="menuitem">
 							<a id="language-{{$item.id}}" href="javascript:alert('{{$item.language.1}}');" class="btn-link filer-item language-icon" title="{{$item.language.0}}"><i class="fa fa-language" aria-hidden="true"></i>&nbsp;{{$item.language.0}}</a>
 						</li>
+						{{/if}}
+
+						{{if $item.browsershare}}
+							<li role="menuitem" class="button-browser-share">
+								<a id="browser-share-{{$item.id}}" href="javascript:navigator.share({url: '{{$item.plink.orig}}'})" class="btn-link button-browser-share" title="{{$item.browsershare.1}}"><i class="fa fa-share-alt" aria-hidden="true"></i>&nbsp;{{$item.browsershare.0}}</a>
+							</li>
 						{{/if}}
 
 						{{if ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread) && ($item.ignore || ($item.drop && $item.drop.dropping))}}
@@ -493,8 +494,8 @@ as the value of $top_child_total (this is done at the end of this file)
 				</div>
 			{{/if}}
 
-			{{if !$item.lock && !$item.connector}}
-				<button type="button" class="btn btn-sm button-browser-share" onclick="navigator.share({url: '{{$item.plink.orig}}'})" title="{{$item.browsershare}}"><i class="fa fa-share-alt"></i></button>
+			{{if $item.browsershare}}
+				<button type="button" class="btn btn-sm button-browser-share" onclick="navigator.share({url: '{{$item.plink.orig}}'})" title="{{$item.browsershare.1}}"><i class="fa fa-share-alt"></i></button>
 			{{/if}}
 
 			{{* Put additional actions in a dropdown menu *}}
@@ -552,6 +553,12 @@ as the value of $top_child_total (this is done at the end of this file)
 						{{if $item.follow_thread}}
 							<li role="menuitem">
 							<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="fa fa-plus" aria-hidden="true"></i>&nbsp;{{$item.follow_thread.title}}</a>
+						</li>
+						{{/if}}
+
+						{{if $item.language}}
+						<li role="menuitem">
+							<a id="language-{{$item.id}}" href="javascript:alert('{{$item.language.1}}');" class="btn-link filer-item language-icon" title="{{$item.language.0}}"><i class="fa fa-language" aria-hidden="true"></i>&nbsp;{{$item.language.0}}</a>
 						</li>
 						{{/if}}
 


### PR DESCRIPTION
This PR should clear some confusion concerning two buttons that both were named "share". Also the "share" now moved to the menu to avoid line breaks.