### PR TITLE
Removed unused tag entries

### DIFF
--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -201,7 +201,7 @@ class Tag
 			}
 		}
 
-		if (!empty($target) && !empty($tag['url']) && empty($tag['type'])) {
+		if (!empty($target) && !empty($tag['url']) && ($tag['type'] != $target)) {
 			DBA::update('tag', ['type' => $target], ['url' => $url]);
 		}
 

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -112,6 +112,8 @@ class Cron
 
 			Worker::add(PRIORITY_LOW, 'ExpireConversations');
 
+			Worker::add(PRIORITY_LOW, 'RemoveUnusedTags');
+
 			Worker::add(PRIORITY_LOW, 'RemoveUnusedContacts');
 
 			Worker::add(PRIORITY_LOW, 'RemoveUnusedAvatars');

--- a/src/Worker/RemoveUnusedTags.php
+++ b/src/Worker/RemoveUnusedTags.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Worker;
+
+use Friendica\Database\DBA;
+
+class RemoveUnusedTags
+{
+	/**
+	 * Delete tag entries that aren't used anymore
+	 */
+	public static function execute()
+	{
+		DBA::delete('tag', ["NOT `id` IN (SELECT `tid` FROM `post-category`) AND NOT `id` IN (SELECT `tid` FROM `post-tag`)"]);
+	}
+}


### PR DESCRIPTION
The "tag" table contains hashtags, mentions that we don't have a contact entry and collection target of posts.

We now removed the entries in the "tag" table, once they aren't in use anymore. This saves some space.