### PR TITLE
We now store uncommon endpoints

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2022.05-dev (Siberian Iris)
--- DB_UPDATE_VERSION 1459
+-- DB_UPDATE_VERSION 1460
 -- ------------------------------------------
 
 
@@ -553,6 +553,18 @@ CREATE TABLE IF NOT EXISTS `diaspora-interaction` (
 	 PRIMARY KEY(`uri-id`),
 	FOREIGN KEY (`uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Signed Diaspora Interaction';
+
+--
+-- TABLE endpoint
+--
+CREATE TABLE IF NOT EXISTS `endpoint` (
+	`url` varbinary(255) NOT NULL COMMENT 'URL of the contact',
+	`type` varchar(20) NOT NULL COMMENT '',
+	`owner-uri-id` int unsigned COMMENT 'Id of the item-uri table entry that contains the apcontact url',
+	 PRIMARY KEY(`url`),
+	 UNIQUE INDEX `owner-uri-id_type` (`owner-uri-id`,`type`),
+	FOREIGN KEY (`owner-uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
+) DEFAULT COLLATE utf8mb4_general_ci COMMENT='ActivityPub endpoints - used in the ActivityPub implementation';
 
 --
 -- TABLE event

--- a/doc/database.md
+++ b/doc/database.md
@@ -21,6 +21,7 @@ Database Tables
 | [conversation](help/database/db_conversation) | Raw data and structure information for messages |
 | [delayed-post](help/database/db_delayed-post) | Posts that are about to be distributed at a later time |
 | [diaspora-interaction](help/database/db_diaspora-interaction) | Signed Diaspora Interaction |
+| [endpoint](help/database/db_endpoint) | ActivityPub endpoints - used in the ActivityPub implementation |
 | [event](help/database/db_event) | Events |
 | [fcontact](help/database/db_fcontact) | Diaspora compatible contacts - used in the Diaspora implementation |
 | [fsuggest](help/database/db_fsuggest) | friend suggestion stuff |

--- a/doc/database/db_endpoint.md
+++ b/doc/database/db_endpoint.md
@@ -1,0 +1,30 @@
+Table endpoint
+===========
+
+ActivityPub endpoints - used in the ActivityPub implementation
+
+Fields
+------
+
+| Field        | Description                                                    | Type           | Null | Key | Default | Extra |
+| ------------ | -------------------------------------------------------------- | -------------- | ---- | --- | ------- | ----- |
+| url          | URL of the contact                                             | varbinary(255) | NO   | PRI | NULL    |       |
+| type         |                                                                | varchar(20)    | NO   |     | NULL    |       |
+| owner-uri-id | Id of the item-uri table entry that contains the apcontact url | int unsigned   | YES  |     | NULL    |       |
+
+Indexes
+------------
+
+| Name              | Fields                     |
+| ----------------- | -------------------------- |
+| PRIMARY           | url                        |
+| owner-uri-id_type | UNIQUE, owner-uri-id, type |
+
+Foreign Keys
+------------
+
+| Field | Target Table | Target Field |
+|-------|--------------|--------------|
+| owner-uri-id | [item-uri](help/database/db_item-uri) | id |
+
+Return to [database documentation](help/database)

--- a/src/Model/APContact/Endpoint.php
+++ b/src/Model/APContact/Endpoint.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Model\APContact;
+
+use Friendica\Database\DBA;
+
+class Endpoint
+{
+	// Mobilizon Endpoints
+	const DISCUSSIONS = 10;
+	const EVENTS = 11;
+	const MEMBERS = 12;
+	const POSTS = 13;
+	const RESOURCES = 14;
+	const TODOS = 15;
+
+	// Peertube Endpoints
+	const PLAYLISTS = 20;
+
+	// Mastodon Endpoints
+	const DEVICES = 30;
+
+	const ENDPOINT_NAMES = [
+		self::PLAYLISTS => 'pt:playlists',
+		self::DISCUSSIONS => 'mobilizon:discussions',
+		self::EVENTS => 'mobilizon:events',
+		self::MEMBERS => 'mobilizon:members',
+		self::POSTS => 'mobilizon:posts',
+		self::RESOURCES => 'mobilizon:resources',
+		self::TODOS => 'mobilizon:todos',
+		self::DEVICES => 'toot:devices',
+	];
+
+	/**
+	 * Update an apcontact endpoint
+	 *
+	 * @param int    $owner_uri_id
+	 * @param int    $type
+	 * @param string $url
+	 * @return bool
+	 */
+	public static function update(int $owner_uri_id, int $type, string $url)
+	{
+		if (empty($url) || empty($owner_uri_id)) {
+			return false;
+		}
+
+		$fields = ['owner-uri-id' => $owner_uri_id, 'type' => $type];
+
+		return DBA::update('endpoint', $fields, ['url' => $url], true);
+	}
+}

--- a/src/Model/APContact/Endpoint.php
+++ b/src/Model/APContact/Endpoint.php
@@ -27,11 +27,11 @@ class Endpoint
 {
 	// Mobilizon Endpoints
 	const DISCUSSIONS = 10;
-	const EVENTS = 11;
-	const MEMBERS = 12;
-	const POSTS = 13;
-	const RESOURCES = 14;
-	const TODOS = 15;
+	const EVENTS      = 11;
+	const MEMBERS     = 12;
+	const POSTS       = 13;
+	const RESOURCES   = 14;
+	const TODOS       = 15;
 
 	// Peertube Endpoints
 	const PLAYLISTS = 20;
@@ -40,14 +40,14 @@ class Endpoint
 	const DEVICES = 30;
 
 	const ENDPOINT_NAMES = [
-		self::PLAYLISTS => 'pt:playlists',
+		self::PLAYLISTS   => 'pt:playlists',
 		self::DISCUSSIONS => 'mobilizon:discussions',
-		self::EVENTS => 'mobilizon:events',
-		self::MEMBERS => 'mobilizon:members',
-		self::POSTS => 'mobilizon:posts',
-		self::RESOURCES => 'mobilizon:resources',
-		self::TODOS => 'mobilizon:todos',
-		self::DEVICES => 'toot:devices',
+		self::EVENTS      => 'mobilizon:events',
+		self::MEMBERS     => 'mobilizon:members',
+		self::POSTS       => 'mobilizon:posts',
+		self::RESOURCES   => 'mobilizon:resources',
+		self::TODOS       => 'mobilizon:todos',
+		self::DEVICES     => 'toot:devices',
 	];
 
 	/**

--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -139,7 +139,9 @@ class JsonLD
 			'toot' => (object)['@id' => 'http://joinmastodon.org/ns#', '@type' => '@id'],
 			'litepub' => (object)['@id' => 'http://litepub.social/ns#', '@type' => '@id'],
 			'sc' => (object)['@id' => 'http://schema.org#', '@type' => '@id'],
-			'pt' => (object)['@id' => 'https://joinpeertube.org/ns#', '@type' => '@id']];
+			'pt' => (object)['@id' => 'https://joinpeertube.org/ns#', '@type' => '@id'],
+			'mobilizon' => (object)['@id' => 'https://joinmobilizon.org/ns#', '@type' => '@id'],
+		];
 
 		// Preparation for adding possibly missing content to the context
 		if (!empty($json['@context']) && is_string($json['@context'])) {

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1459);
+	define('DB_UPDATE_VERSION', 1460);
 }
 
 return [
@@ -616,6 +616,18 @@ return [
 		],
 		"indexes" => [
 			"PRIMARY" => ["uri-id"]
+		]
+	],
+	"endpoint" => [
+		"comment" => "ActivityPub endpoints - used in the ActivityPub implementation",
+		"fields" => [
+			"url" => ["type" => "varbinary(255)", "not null" => "1", "primary" => "1", "comment" => "URL of the contact"],
+			"type" => ["type" => "varchar(20)", "not null" => "1", "comment" => ""],
+			"owner-uri-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the apcontact url"],
+		],
+		"indexes" => [
+			"PRIMARY" => ["url"],
+			"owner-uri-id_type" => ["UNIQUE", "owner-uri-id", "type"],
 		]
 	],
 	"event" => [


### PR DESCRIPTION
Many AP implementations have got some endpoints that are specific to their own solution. When they aren't commonly used, it doesn't make sense to store them in the `apcontact` table. So we store them in a side table.