### PR TITLE
Update contact when the avatar hadn't been found

### DIFF
--- a/src/Module/Contact/Profile.php
+++ b/src/Module/Contact/Profile.php
@@ -165,7 +165,7 @@ class Profile extends BaseModule
 				Module\Contact::updateContactFromPoll($contact['id']);
 			}
 
-			if ($cmd === 'updateprofile' && $localRelationship->rel !== Contact::NOTHING) {
+			if ($cmd === 'updateprofile') {
 				self::updateContactFromProbe($contact['id']);
 			}
 
@@ -481,7 +481,7 @@ class Profile extends BaseModule
 	 */
 	private static function updateContactFromProbe(int $contact_id)
 	{
-		$contact = DBA::selectFirst('contact', ['url'], ['id' => $contact_id, 'uid' => local_user(), 'deleted' => false]);
+		$contact = DBA::selectFirst('contact', ['url'], ['id' => $contact_id, 'uid' => [0, local_user()], 'deleted' => false]);
 		if (!DBA::isResult($contact)) {
 			return;
 		}

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -69,6 +69,7 @@ class ParseUrl
 		}
 
 		if (!$curlResult->isSuccess()) {
+			Logger::debug('Got HTTP Error', ['http error' => $curlResult->getReturnCode(), 'url' => $url]);
 			return [];
 		}
 


### PR DESCRIPTION
We now trigger a contact update when we want to display a contact avatar that doesn't exist anymore.