### PR TITLE
[frio] adding Feed link to vcard 

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1200,6 +1200,7 @@ aside .vcard .icon {
 	overflow: auto;
 	margin-bottom: 10px;
 }
+aside .vcard #subscribe-feed-link-button,
 aside .vcard #dfrn-request-link-button,
 aside .vcard #wallmessage-link-botton {
 	width: 50%;
@@ -1207,6 +1208,7 @@ aside .vcard #wallmessage-link-botton {
 	float: left;
 	padding: 0 5px;
 }
+aside .vcard #subscribe-feed-link,
 aside .vcard #dfrn-request-link,
 aside .vcard #wallmessage-link {
 	width: 100%;

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -54,6 +54,14 @@
 				{{/if}}
 			</div>
 			{{/if}}
+			{{if $subscribe_feed_link}}
+			<div id="subscribe-feed-link-button">
+				<a id="subscribe-feed-link" class="btn btn-labeled btn-primary btn-sm" href="{{$subscribe_feed_link}}">
+					<span class=""><i class="fa fa-rss"></i></span>
+					<span class="">{{$subscribe_feed}}</span>
+				</a>
+			</div>
+			{{/if}}
 			{{if $wallmessage_link}}
 			<div id="wallmessage-link-botton">
 				<button type="button" id="wallmessage-link" class="btn btn-labeled btn-primary btn-sm" onclick="openWallMessage('{{$wallmessage_link}}')">


### PR DESCRIPTION
This PR adds a link to the Atom Feed of a profile to the aside vcard in the Frio theme. The link is already in the other themes, so it only needs to be added to Frio.

fixes #10397