### PR TITLE
Add CONTRIBUTING note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# How to Contribute
+
+If you want to contribute to the project, you don’t need to have coding experience. There are a number of tasks listed in the issue tracker with the label “[Junior Jobs](https://github.com/friendica/friendica/issues?q=is%3Aopen+is%3Aissue+label%3A%22Junior+Jobs%22)” we think are good for new contributors. But you are by no means limited to these – if you find a solution to a problem (even a new one) please make a pull request at [github](https://github.com/friendica/friendica) or let us know in the [development forum](https://forum.friendi.ca/profile/developers).
+
+Contribution to Friendica is also not limited to coding. Any contribution to the [documentation](https://github.com/friendica/friendica/tree/develop/doc), the [translation](https://www.transifex.com/Friendica/friendica/dashboard/) or advertisement materials is welcome or reporting a problem. You don’t need to deal with Git(Hub) or Transifex if you don’t like to. Just [get in touch](https://forum.friendi.ca/profile/helpers) with us and we will get the materials to the appropriate places.


### PR DESCRIPTION
Most projects have a `CONTRIBUTING` file in their root project to make it easy for new developers to get started.

I found out later that you include this in your release notes, but I wasn't aware of that when I started working on the project, so I was working with zero information up until now. I think this will help others avoid the same problem :)