### PR TITLE
Add Danish language to list of native language names

### DIFF
--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -40,6 +40,7 @@ class L10n
 		'bg'    => 'Български',
 		'ca'    => 'Català',
 		'cs'    => 'Česky',
+		'da-dk' => 'Dansk (Danmark)',
 		'de'    => 'Deutsch',
 		'en-gb' => 'English (United Kingdom)',
 		'en-us' => 'English (United States)',


### PR DESCRIPTION
This is missing from https://github.com/friendica/friendica/commit/815b76db8b8924b26853933604629f8c377d41f7