### PR TITLE
Cache contact avatars locally as files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ venv/
 
 #Ignore cache file
 .php_cs.cache
+
+#ignore avatar picture cache path
+/avatar
+

--- a/src/Contact/Avatar.php
+++ b/src/Contact/Avatar.php
@@ -120,7 +120,7 @@ class Avatar
 		}
 
 		file_put_contents($filepath, $image->asString());
-		chmod($filepath, 0775);
+		chmod($filepath, 0664);
 
 		DI::profiler()->stopRecording();
 

--- a/src/Contact/Avatar.php
+++ b/src/Contact/Avatar.php
@@ -114,10 +114,14 @@ class Avatar
 		DI::profiler()->startRecording('file');
 
 		if (!file_exists($dirpath)) {
-			mkdir($dirpath, 0777, true);
+			mkdir($dirpath, 0775, true);
+		} else {
+			chmod($dirpath, 0775);
 		}
 
 		file_put_contents($filepath, $image->asString());
+		chmod($filepath, 0775);
+
 		DI::profiler()->stopRecording();
 
 		return DI::baseUrl() . $path;

--- a/src/Contact/Avatar.php
+++ b/src/Contact/Avatar.php
@@ -125,7 +125,7 @@ class Avatar
 		DI::profiler()->stopRecording();
 
 		if (!file_exists($filepath)) {
-			Logger::notice('Avatar cache file could not be stored', ['file' => $filepath]);
+			Logger::warning('Avatar cache file could not be stored', ['file' => $filepath]);
 			return '';
 		}
 

--- a/src/Contact/Avatar.php
+++ b/src/Contact/Avatar.php
@@ -124,6 +124,11 @@ class Avatar
 
 		DI::profiler()->stopRecording();
 
+		if (!file_exists($filepath)) {
+			Logger::notice('Avatar cache file could not be stored', ['file' => $filepath]);
+			return '';
+		}
+
 		return DI::baseUrl() . $path;
 	}
 

--- a/src/Contact/Avatar.php
+++ b/src/Contact/Avatar.php
@@ -129,7 +129,7 @@ class Avatar
 	 * @param string $avatar
 	 * @return boolean
 	 */
-	public static function isCacheFile(string $avatar): bool
+	private static function isCacheFile(string $avatar): bool
 	{
 		return !empty(self::getCacheFile($avatar));
 	}

--- a/src/Contact/Avatar.php
+++ b/src/Contact/Avatar.php
@@ -76,6 +76,7 @@ class Avatar
 			substr($guid, 9, 2) .'/' . substr($guid, 11, 2) . '/' . substr($guid, 13, 4). '/' . substr($guid, 18) . '-';
 
 		$fetchResult = HTTPSignature::fetchRaw($avatar, 0, [HttpClientOptions::ACCEPT_CONTENT => [HttpClientAccept::IMAGE]]);
+
 		$img_str = $fetchResult->getBody();
 		if (empty($img_str)) {
 			Logger::debug('Avatar is invalid', ['avatar' => $avatar]);

--- a/src/Contact/Contact.php
+++ b/src/Contact/Contact.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Contact;
+
+use Friendica\Core\Logger;
+use Friendica\DI;
+use Friendica\Model\Item;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
+use Friendica\Network\HTTPClient\Client\HttpClientOptions;
+use Friendica\Object\Image;
+use Friendica\Util\DateTimeFormat;
+use Friendica\Util\HTTPSignature;
+use Friendica\Util\Images;
+use Friendica\Util\Network;
+use Friendica\Util\Proxy;
+use Friendica\Util\Strings;
+
+/**
+ * functions for handling contact avatar caching
+ */
+class Avatar
+{
+	/**
+	 * Returns a field array with locally cached avatar pictures
+	 *
+	 * @param array $contact
+	 * @param string $avatar
+	 * @return array
+	 */
+	public static function fetchAvatarContact(array $contact, string $avatar): array
+	{
+		$fields = ['avatar' => $avatar, 'avatar-date' => DateTimeFormat::utcNow(), 'photo' => '', 'thumb' => '', 'micro' => ''];
+
+		if (!DI::config()->get('system', 'avatar_cache')) {
+			self::deleteCache($contact);
+			return $fields;
+		}
+
+		if (Network::isLocalLink($avatar)) {
+			return $fields;
+		}
+
+		if ($avatar != $contact['avatar']) {
+			self::deleteCache($contact);
+			Logger::debug('Avatar file name changed', ['new' => $avatar, 'old' => $contact['avatar']]);
+		} elseif (self::isCacheFile($contact['photo']) && self::isCacheFile($contact['thumb']) && self::isCacheFile($contact['micro'])) {
+			$fields['photo'] = $contact['photo'];
+			$fields['thumb'] = $contact['thumb'];
+			$fields['micro'] = $contact['micro'];
+			Logger::debug('Using existing cache files', ['uri-id' => $contact['uri-id'], 'fields' => $fields]);
+			return $fields;
+		}
+
+		$guid = Item::guidFromUri($contact['url'], parse_url($contact['url'], PHP_URL_HOST));
+
+		$filename = substr($guid, 0, 2) . '/' . substr($guid, 3, 2) . '/' . substr($guid, 5, 3) . '/' .
+			substr($guid, 9, 2) .'/' . substr($guid, 11, 2) . '/' . substr($guid, 13, 4). '/' . substr($guid, 18) . '-';
+
+		$fetchResult = HTTPSignature::fetchRaw($avatar, 0, [HttpClientOptions::ACCEPT_CONTENT => [HttpClientAccept::IMAGE]]);
+		$img_str = $fetchResult->getBody();
+		if (empty($img_str)) {
+			Logger::debug('Avatar is invalid', ['avatar' => $avatar]);
+			return $fields;
+		}
+
+		$image = new Image($img_str, Images::getMimeTypeByData($img_str));
+		if (!$image->isValid()) {
+			Logger::debug('Avatar picture is invalid', ['avatar' => $avatar]);
+			return $fields;
+		}
+
+		$fields['photo'] = self::storeAvatarCache($image, $filename, Proxy::PIXEL_SMALL);
+		$fields['thumb'] = self::storeAvatarCache($image, $filename, Proxy::PIXEL_THUMB);
+		$fields['micro'] = self::storeAvatarCache($image, $filename, Proxy::PIXEL_MICRO);
+
+		Logger::debug('Storing new avatar cache', ['uri-id' => $contact['uri-id'], 'fields' => $fields]);
+
+		return $fields;
+	}
+
+	private static function storeAvatarCache(Image $image, string $filename, int $size): string
+	{
+		$image->scaleDown($size);
+		if (is_null($image) || !$image->isValid()) {
+			return '';
+		}
+
+		$path = '/avatar/' . $filename . $size . '.' . $image->getExt();
+
+		$filepath = DI::basePath() . $path;
+
+		$dirpath = dirname($filepath);
+
+		DI::profiler()->startRecording('file');
+
+		if (!file_exists($dirpath)) {
+			mkdir($dirpath, 0777, true);
+		}
+
+		file_put_contents($filepath, $image->asString());
+		DI::profiler()->stopRecording();
+
+		return DI::baseUrl() . $path;
+	}
+
+	/**
+	 * Check if the avatar cache file is locally stored
+	 *
+	 * @param string $avatar
+	 * @return boolean
+	 */
+	public static function isCacheFile(string $avatar): bool
+	{
+		return !empty(self::getCacheFile($avatar));
+	}
+
+	/**
+	 * Fetch the name of locally cached avatar pictures
+	 *
+	 * @param string $avatar
+	 * @return string
+	 */
+	private static function getCacheFile(string $avatar): string
+	{
+		if (empty($avatar) || !Network::isLocalLink($avatar)) {
+			return '';
+		}
+
+		$path = Strings::normaliseLink(DI::baseUrl() . '/avatar');
+
+		if (Network::getUrlMatch($path, $avatar) != $path) {
+			return '';
+		}
+
+		$filename = str_replace($path, DI::basePath(). '/avatar/', Strings::normaliseLink($avatar));
+
+		DI::profiler()->startRecording('file');
+		$exists = file_exists($filename);
+		DI::profiler()->stopRecording();
+
+		if (!$exists) {
+			return '';
+		}
+		return $filename;
+	}
+
+	/**
+	 * Delete locally cached avatar pictures of a contact
+	 *
+	 * @param string $avatar
+	 * @return void
+	 */
+	public static function deleteCache(array $contact)
+	{
+		self::deleteCacheFile($contact['photo']);
+		self::deleteCacheFile($contact['thumb']);
+		self::deleteCacheFile($contact['micro']);
+	}
+
+	/**
+	 * Delete a locally cached avatar picture
+	 *
+	 * @param string $avatar
+	 * @return void
+	 */
+	private static function deleteCacheFile(string $avatar)
+	{
+		$localFile = self::getCacheFile($avatar);
+		if (!empty($localFile)) {
+			unlink($localFile);
+			Logger::debug('Unlink avatar', ['avatar' => $avatar]);
+		}
+	}
+}

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -37,6 +37,7 @@ use Friendica\Core\Theme;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\Item as ItemModel;
+use Friendica\Model\Photo;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
@@ -672,11 +673,11 @@ class Conversation
 						$author_thumb   = $item['author-avatar'];
 					}
 
-					if (!Contact::isAvatarFile($owner_thumb)) {
+					if (empty($owner_thumb) || Photo::isPhotoURI($owner_thumb)) {
 						$owner_thumb = Contact::getAvatarUrlForId($owner_avatar, Proxy::SIZE_THUMB, $owner_updated);
 					}
-
-					if (!Contact::isAvatarFile($author_thumb)) {
+			
+					if (empty($author_thumb) || Photo::isPhotoURI($author_thumb)) {
 						$author_thumb = Contact::getAvatarUrlForId($author_avatar, Proxy::SIZE_THUMB, $author_updated);
 					}
 

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -662,11 +662,22 @@ class Conversation
 					if (in_array($item['network'], [Protocol::FEED, Protocol::MAIL])) {
 						$owner_avatar  = $author_avatar  = $item['contact-id'];
 						$owner_updated = $author_updated = '';
+						$owner_thumb   = $author_thumb   = $item['contact-avatar'];
 					} else {
 						$owner_avatar   = $item['owner-id'];
 						$owner_updated  = $item['owner-updated'];
+						$owner_thumb    = $item['owner-avatar'];
 						$author_avatar  = $item['author-id'];
 						$author_updated = $item['author-updated'];
+						$author_thumb   = $item['author-avatar'];
+					}
+
+					if (!Contact::isAvatarFile($owner_thumb)) {
+						$owner_thumb = Contact::getAvatarUrlForId($owner_avatar, Proxy::SIZE_THUMB, $owner_updated);
+					}
+
+					if (!Contact::isAvatarFile($author_thumb)) {
+						$author_thumb = Contact::getAvatarUrlForId($author_avatar, Proxy::SIZE_THUMB, $author_updated);
 					}
 
 					$tmp_item = [
@@ -686,7 +697,7 @@ class Conversation
 						'name'                 => $profile_name,
 						'sparkle'              => $sparkle,
 						'lock'                 => false,
-						'thumb'                => $this->baseURL->remove(Contact::getAvatarUrlForId($author_avatar, Proxy::SIZE_THUMB, $author_updated)),
+						'thumb'                => $this->baseURL->remove($author_thumb),
 						'title'                => $title,
 						'body_html'            => $body_html,
 						'tags'                 => $tags['tags'],
@@ -707,7 +718,7 @@ class Conversation
 						'indent'               => '',
 						'owner_name'           => '',
 						'owner_url'            => '',
-						'owner_photo'          => $this->baseURL->remove(Contact::getAvatarUrlForId($owner_avatar, Proxy::SIZE_THUMB, $owner_updated)),
+						'owner_photo'          => $this->baseURL->remove($owner_thumb),
 						'plink'                => ItemModel::getPlink($item),
 						'edpost'               => false,
 						'pinned'               => $pinned,

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1587,7 +1587,7 @@ class Contact
 				self::updateAvatar($cid, $contact['avatar'], true);
 				return;
 			}
-		} elseif (!self::getAvatarFile($contact['photo']) || !self::getAvatarFile($contact['thumb']) || !self::getAvatarFile($contact['micro'])) {
+		} elseif (!self::isAvatarFile($contact['photo']) || !self::isAvatarFile($contact['thumb']) || !self::isAvatarFile($contact['micro'])) {
 			Logger::info('Removing/replacing avatar cache', ['id' => $cid, 'contact' => $contact]);
 			self::updateAvatar($cid, $contact['avatar'], true);
 			return;
@@ -1611,17 +1611,17 @@ class Contact
 		if (DI::config()->get('system', 'avatar_cache')) {
 			switch ($size) {
 				case Proxy::SIZE_MICRO:
-					if (self::getAvatarFile($contact['micro'])) {
+					if (self::isAvatarFile($contact['micro'])) {
 						return $contact['micro'];
 					}
 					break;
 				case Proxy::SIZE_THUMB:
-					if (self::getAvatarFile($contact['thumb'])) {
+					if (self::isAvatarFile($contact['thumb'])) {
 						return $contact['thumb'];
 					}
 					break;
 				case Proxy::SIZE_SMALL:
-					if (self::getAvatarFile($contact['photo'])) {
+					if (self::isAvatarFile($contact['photo'])) {
 						return $contact['photo'];
 					}
 					break;
@@ -2091,7 +2091,7 @@ class Contact
 			self::deleteAvatarCache($contact['thumb']);
 			self::deleteAvatarCache($contact['micro']);
 			Logger::debug('Avatar file name changed', ['new' => $avatar, 'old' => $contact['avatar']]);
-		} elseif (self::getAvatarFile($contact['photo']) && self::getAvatarFile($contact['thumb']) && self::getAvatarFile($contact['micro'])) {
+		} elseif (self::isAvatarFile($contact['photo']) && self::isAvatarFile($contact['thumb']) && self::isAvatarFile($contact['micro'])) {
 			$fields['photo'] = $contact['photo'];
 			$fields['thumb'] = $contact['thumb'];
 			$fields['micro'] = $contact['micro'];
@@ -2179,6 +2179,17 @@ class Contact
 			return '';
 		}
 		return $filename;
+	}
+
+	/**
+	 * Check if the avatar cache file is locally stored
+	 *
+	 * @param string $avatar
+	 * @return boolean
+	 */
+	public static function isAvatarFile(string $avatar): bool
+	{
+		return !empty(self::getAvatarFile($avatar));
 	}
 
 	/**

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1581,10 +1581,14 @@ class Contact
 				self::updateAvatar($cid, $contact['avatar'], true);
 				return;
 			}
-		} elseif (!Avatar::isCacheFile($contact['photo']) || !Avatar::isCacheFile($contact['thumb']) || !Avatar::isCacheFile($contact['micro'])) {
-			Logger::info('Removing/replacing avatar cache', ['id' => $cid, 'contact' => $contact]);
+		} elseif (Photo::isPhotoURI($contact['photo']) || Photo::isPhotoURI($contact['thumb']) || Photo::isPhotoURI($contact['micro'])) {
+			Logger::info('Replacing legacy avatar cache', ['id' => $cid, 'contact' => $contact]);
 			self::updateAvatar($cid, $contact['avatar'], true);
 			return;
+		} elseif (DI::config()->get('system', 'avatar_cache') && (empty($contact['photo']) || empty($contact['thumb']) || empty($contact['micro']))) {
+			Logger::info('Adding avatar cache file', ['id' => $cid, 'contact' => $contact]);
+			self::updateAvatar($cid, $contact['avatar'], true);
+		return;
 		}
 	}
 

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2094,7 +2094,7 @@ class Contact
 		} elseif (self::getAvatarFile($contact['photo']) && self::getAvatarFile($contact['thumb']) && self::getAvatarFile($contact['micro'])) {
 			$fields['photo'] = $contact['photo'];
 			$fields['thumb'] = $contact['thumb'];
-			$fields['thumb'] = $contact['thumb'];
+			$fields['micro'] = $contact['micro'];
 			Logger::debug('Using existing cache files', ['uri-id' => $contact['uri-id'], 'fields' => $fields]);
 			return $fields;
 		}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1611,17 +1611,17 @@ class Contact
 		if (DI::config()->get('system', 'avatar_cache')) {
 			switch ($size) {
 				case Proxy::SIZE_MICRO:
-					if (self::isAvatarFile($contact['micro'])) {
+					if (!empty($contact['micro']) && !Photo::isPhotoURI($contact['micro'])) {
 						return $contact['micro'];
 					}
 					break;
 				case Proxy::SIZE_THUMB:
-					if (self::isAvatarFile($contact['thumb'])) {
+					if (!empty($contact['thumb']) && !Photo::isPhotoURI($contact['thumb'])) {
 						return $contact['thumb'];
 					}
 					break;
 				case Proxy::SIZE_SMALL:
-					if (self::isAvatarFile($contact['photo'])) {
+					if (!empty($contact['photo']) && !Photo::isPhotoURI($contact['photo'])) {
 						return $contact['photo'];
 					}
 					break;
@@ -2187,7 +2187,7 @@ class Contact
 	 * @param string $avatar
 	 * @return boolean
 	 */
-	public static function isAvatarFile(string $avatar): bool
+	private static function isAvatarFile(string $avatar): bool
 	{
 		return !empty(self::getAvatarFile($avatar));
 	}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1608,7 +1608,7 @@ class Contact
 	{
 		$contact = self::checkAvatarCacheByArray($contact, $no_update);
 
-		if (!DI::config()->get('system', 'avatar_cache')) {
+		if (DI::config()->get('system', 'avatar_cache')) {
 			switch ($size) {
 				case Proxy::SIZE_MICRO:
 					if (self::getAvatarFile($contact['micro'])) {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2102,7 +2102,7 @@ class Contact
 		$filename = substr($guid, 0, 2) . '/' . substr($guid, 3, 2) . '/' . substr($guid, 5, 3) . '/' .
 			substr($guid, 9, 2) .'/' . substr($guid, 11, 2) . '/' . substr($guid, 13, 4). '/' . substr($guid, 18) . '-';
 
-		$fetchResult = HTTPSignature::fetchRaw($avatar, 0, [HttpClientOptions::ACCEPT_CONTENT => [HttpClientAccept::IMAGE], 'timeout' => 10]);
+		$fetchResult = HTTPSignature::fetchRaw($avatar, 0, [HttpClientOptions::ACCEPT_CONTENT => [HttpClientAccept::IMAGE]]);
 		$img_str = $fetchResult->getBody();
 		if (empty($img_str)) {
 			return $fields;

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -711,6 +711,18 @@ class Photo
 	}
 
 	/**
+	 * Checks if the given URL is a local photo.
+	 * Since it is meant for time critical occasions, the check is done without any database requests.
+	 *
+	 * @param string $url
+	 * @return boolean
+	 */
+	public static function isPhotoURI(string $url): bool
+	{
+		return !empty(self::ridFromURI($url));
+	}
+
+	/**
 	 * Changes photo permissions that had been embedded in a post
 	 *
 	 * @todo This function currently does have some flaws:

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -32,6 +32,7 @@ use Friendica\Core\Session;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Item;
+use Friendica\Model\Photo;
 use Friendica\Model\Post as PostModel;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
@@ -463,11 +464,11 @@ class Post
 			$author_thumb   = $item['author-avatar'];
 		}
 
-		if (!Contact::isAvatarFile($owner_thumb)) {
+		if (empty($owner_thumb) || Photo::isPhotoURI($owner_thumb)) {
 			$owner_thumb = Contact::getAvatarUrlForId($owner_avatar, Proxy::SIZE_THUMB, $owner_updated);
 		}
 
-		if (!Contact::isAvatarFile($author_thumb)) {
+		if (empty($author_thumb) || Photo::isPhotoURI($author_thumb)) {
 			$author_thumb = Contact::getAvatarUrlForId($author_avatar, Proxy::SIZE_THUMB, $author_updated);
 		}
 

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -123,8 +123,8 @@ class Post
 	/**
 	 * Fetch the privacy of the post
 	 *
-	 * @param array $item 
-	 * @return string 
+	 * @param array $item
+	 * @return string
 	 */
 	private function fetchPrivacy(array $item):string
 	{
@@ -453,11 +453,22 @@ class Post
 		if (in_array($item['network'], [Protocol::FEED, Protocol::MAIL])) {
 			$owner_avatar  = $author_avatar  = $item['contact-id'];
 			$owner_updated = $author_updated = '';
+			$owner_thumb   = $author_thumb   = $item['contact-avatar'];
 		} else {
 			$owner_avatar   = $item['owner-id'];
 			$owner_updated  = $item['owner-updated'];
+			$owner_thumb    = $item['owner-avatar'];
 			$author_avatar  = $item['author-id'];
 			$author_updated = $item['author-updated'];
+			$author_thumb   = $item['author-avatar'];
+		}
+
+		if (!Contact::isAvatarFile($owner_thumb)) {
+			$owner_thumb = Contact::getAvatarUrlForId($owner_avatar, Proxy::SIZE_THUMB, $owner_updated);
+		}
+
+		if (!Contact::isAvatarFile($author_thumb)) {
+			$author_thumb = Contact::getAvatarUrlForId($author_avatar, Proxy::SIZE_THUMB, $author_updated);
 		}
 
 		$tmp_item = [
@@ -491,7 +502,7 @@ class Post
 			'profile_url'     => $profile_link,
 			'name'            => $profile_name,
 			'item_photo_menu_html' => DI::contentItem()->photoMenu($item, $formSecurityToken),
-			'thumb'           => DI::baseUrl()->remove(Contact::getAvatarUrlForId($author_avatar, Proxy::SIZE_THUMB, $author_updated)),
+			'thumb'           => DI::baseUrl()->remove($author_thumb),
 			'osparkle'        => $osparkle,
 			'sparkle'         => $sparkle,
 			'title'           => $title,
@@ -508,7 +519,7 @@ class Post
 			'shiny'           => $shiny,
 			'owner_self'      => $item['author-link'] == Session::get('my_url'),
 			'owner_url'       => $this->getOwnerUrl(),
-			'owner_photo'     => DI::baseUrl()->remove(Contact::getAvatarUrlForId($owner_avatar, Proxy::SIZE_THUMB, $owner_updated)),
+			'owner_photo'     => DI::baseUrl()->remove($owner_thumb),
 			'owner_name'      => $this->getOwnerName(),
 			'plink'           => Item::getPlink($item),
 			'browsershare'    => $browsershare,

--- a/src/Worker/RemoveUnusedContacts.php
+++ b/src/Worker/RemoveUnusedContacts.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Worker;
 
+use Friendica\Contact\Avatar;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
@@ -51,9 +52,7 @@ class RemoveUnusedContacts
 		$contacts = DBA::select('contact', ['id', 'uid', 'photo', 'thumb', 'micro'], $condition);
 		while ($contact = DBA::fetch($contacts)) {
 			Photo::delete(['uid' => $contact['uid'], 'contact-id' => $contact['id']]);
-			Contact::deleteAvatarCache($contact['photo']);
-			Contact::deleteAvatarCache($contact['thumb']);
-			Contact::deleteAvatarCache($contact['micro']);
+			Avatar::deleteCache($contact);
 
 			if (DBStructure::existsTable('thread')) {
 				DBA::delete('thread', ['owner-id' => $contact['id']]);

--- a/src/Worker/RemoveUnusedContacts.php
+++ b/src/Worker/RemoveUnusedContacts.php
@@ -25,6 +25,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
+use Friendica\Model\Contact;
 use Friendica\Model\Photo;
 use Friendica\Util\DateTimeFormat;
 
@@ -47,37 +48,40 @@ class RemoveUnusedContacts
 		$total = DBA::count('contact', $condition);
 		Logger::notice('Starting removal', ['total' => $total]);
 		$count = 0;
-		$contacts = DBA::select('contact', ['id', 'uid'], $condition);
+		$contacts = DBA::select('contact', ['id', 'uid', 'photo', 'thumb', 'micro'], $condition);
 		while ($contact = DBA::fetch($contacts)) {
-			if (Photo::delete(['uid' => $contact['uid'], 'contact-id' => $contact['id']])) {
-				if (DBStructure::existsTable('thread')) {
-					DBA::delete('thread', ['owner-id' => $contact['id']]);
-					DBA::delete('thread', ['author-id' => $contact['id']]);
-				}
-				if (DBStructure::existsTable('item')) {
-					DBA::delete('item', ['owner-id' => $contact['id']]);
-					DBA::delete('item', ['author-id' => $contact['id']]);
-					DBA::delete('item', ['causer-id' => $contact['id']]);
-				}
+			Photo::delete(['uid' => $contact['uid'], 'contact-id' => $contact['id']]);
+			Contact::deleteAvatarCache($contact['photo']);
+			Contact::deleteAvatarCache($contact['thumb']);
+			Contact::deleteAvatarCache($contact['micro']);
 
-				// There should be none entry for the contact in these tables when none was found in "post-user".
-				// But we want to be sure since the foreign key prohibits deletion otherwise.
-				DBA::delete('post', ['owner-id' => $contact['id']]);
-				DBA::delete('post', ['author-id' => $contact['id']]);
-				DBA::delete('post', ['causer-id' => $contact['id']]);
-				
-				DBA::delete('post-thread', ['owner-id' => $contact['id']]);
-				DBA::delete('post-thread', ['author-id' => $contact['id']]);
-				DBA::delete('post-thread', ['causer-id' => $contact['id']]);
+			if (DBStructure::existsTable('thread')) {
+				DBA::delete('thread', ['owner-id' => $contact['id']]);
+				DBA::delete('thread', ['author-id' => $contact['id']]);
+			}
+			if (DBStructure::existsTable('item')) {
+				DBA::delete('item', ['owner-id' => $contact['id']]);
+				DBA::delete('item', ['author-id' => $contact['id']]);
+				DBA::delete('item', ['causer-id' => $contact['id']]);
+			}
 
-				DBA::delete('post-thread-user', ['owner-id' => $contact['id']]);
-				DBA::delete('post-thread-user', ['author-id' => $contact['id']]);
-				DBA::delete('post-thread-user', ['causer-id' => $contact['id']]);
+			// There should be none entry for the contact in these tables when none was found in "post-user".
+			// But we want to be sure since the foreign key prohibits deletion otherwise.
+			DBA::delete('post', ['owner-id' => $contact['id']]);
+			DBA::delete('post', ['author-id' => $contact['id']]);
+			DBA::delete('post', ['causer-id' => $contact['id']]);
+			
+			DBA::delete('post-thread', ['owner-id' => $contact['id']]);
+			DBA::delete('post-thread', ['author-id' => $contact['id']]);
+			DBA::delete('post-thread', ['causer-id' => $contact['id']]);
 
-				DBA::delete('contact', ['id' => $contact['id']]);
-				if ((++$count % 1000) == 0) {
-					Logger::notice('In removal', ['count' => $count, 'total' => $total]);
-				}
+			DBA::delete('post-thread-user', ['owner-id' => $contact['id']]);
+			DBA::delete('post-thread-user', ['author-id' => $contact['id']]);
+			DBA::delete('post-thread-user', ['causer-id' => $contact['id']]);
+
+			DBA::delete('contact', ['id' => $contact['id']]);
+			if ((++$count % 1000) == 0) {
+				Logger::notice('In removal', ['count' => $count, 'total' => $total]);
 			}
 		}
 		DBA::close($contacts);

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -118,6 +118,10 @@ return [
 		// chose "Remember me" when logging in is considered logged out.
 		'auth_cookie_lifetime' => 7,
 
+		// avatar_cache (Boolean)
+		// Cache avatar pictures as files (experimental)
+		'avatar_cache' => false,
+
 		// big_emojis (Boolean)
 		// Display "Emoji Only" posts in big.
 		'big_emojis' => false,


### PR DESCRIPTION
Currently we have got two ways accessing avatar pictures from remotes contacts. Either we store them in the database or we don't store them at all and just relay the access.

Not storing rhe saves a lot of database space. But the relaying doesn't seem to work reliably. Users often report that they see the default avatars.

To fix this problem a third way is introduced: We can now store the avatar pictures as files. Later they will be accessed directly via the web server, which reduces the overhead a lot.

This feature is meant as a fix but is still considered "experimental". In later versions this should be replaced with some option where admins can decide how to cache the avatars.