### PR TITLE
Inherit avatar cache file permissions

### DIFF
--- a/src/Contact/Avatar.php
+++ b/src/Contact/Avatar.php
@@ -124,19 +124,33 @@ class Avatar
 		foreach (explode('/', dirname($filename)) as $part) {
 			$dirpath .= $part . '/';
 			if (!file_exists($dirpath)) {
-				mkdir($dirpath, $dir_perm);
+				if (!mkdir($dirpath, $dir_perm)) {
+					Logger::warning('Directory could not be created', ['directory' => $dirpath]);
+				}
 			} elseif (fileperms($dirpath) & 0777 != $dir_perm) {
-				chmod($dirpath, $dir_perm);
+				if (!chmod($dirpath, $dir_perm)) {
+					Logger::warning('Directory permissions could not be changed', ['directory' => $dirpath]);
+				}
 			}
 
 			if (filegroup($dirpath) != $group) {
-				chgrp($dirpath, $group);
+				if (!chgrp($dirpath, $group)) {
+					Logger::warning('Directory group could not be changed', ['directory' => $dirpath]);
+				}
 			}
 		}
 
-		file_put_contents($filepath, $image->asString());
-		chmod($filepath, $file_perm);
-		chgrp($filepath, $group);
+		if (!file_put_contents($filepath, $image->asString())) {
+			Logger::warning('File could not be created', ['file' => $filepath]);
+		}
+
+		if (!chmod($filepath, $file_perm)) {
+			Logger::warning('File permissions could not be changed', ['file' => $filepath]);
+		}
+
+		if (!chgrp($filepath, $group)) {
+			Logger::warning('File group could not be changed', ['file' => $filepath]);
+		}
 
 		DI::profiler()->stopRecording();
 

--- a/src/Contact/Avatar.php
+++ b/src/Contact/Avatar.php
@@ -129,13 +129,13 @@ class Avatar
 				}
 			} elseif (fileperms($dirpath) & 0777 != $dir_perm) {
 				if (!chmod($dirpath, $dir_perm)) {
-					Logger::warning('Directory permissions could not be changed', ['directory' => $dirpath]);
+					Logger::info('Directory permissions could not be changed', ['directory' => $dirpath]);
 				}
 			}
 
 			if (filegroup($dirpath) != $group) {
 				if (!chgrp($dirpath, $group)) {
-					Logger::warning('Directory group could not be changed', ['directory' => $dirpath]);
+					Logger::info('Directory group could not be changed', ['directory' => $dirpath]);
 				}
 			}
 		}

--- a/src/Contact/Avatar.php
+++ b/src/Contact/Avatar.php
@@ -39,6 +39,8 @@ use Friendica\Util\Strings;
  */
 class Avatar
 {
+	const BASE_PATH = '/avatar/';
+
 	/**
 	 * Returns a field array with locally cached avatar pictures
 	 *
@@ -105,11 +107,11 @@ class Avatar
 			return '';
 		}
 
-		$path = '/avatar/' . $filename . $size . '.' . $image->getExt();
+		$path = self::BASE_PATH . $filename . $size . '.' . $image->getExt();
 
 		$filepath = DI::basePath() . $path;
 
-		$dirpath = DI::basePath() . '/avatar/';
+		$dirpath = DI::basePath() . self::BASE_PATH;
 
 		DI::profiler()->startRecording('file');
 
@@ -169,13 +171,13 @@ class Avatar
 			return '';
 		}
 
-		$path = Strings::normaliseLink(DI::baseUrl() . '/avatar');
+		$path = Strings::normaliseLink(DI::baseUrl() . self::BASE_PATH);
 
 		if (Network::getUrlMatch($path, $avatar) != $path) {
 			return '';
 		}
 
-		$filename = str_replace($path, DI::basePath(). '/avatar/', Strings::normaliseLink($avatar));
+		$filename = str_replace($path, DI::basePath(). self::BASE_PATH, Strings::normaliseLink($avatar));
 
 		DI::profiler()->startRecording('file');
 		$exists = file_exists($filename);


### PR DESCRIPTION
To avoid any problems with file permissions we now inherit the permissions for avatar cache files from the permission of the avatar folder.