### PR TITLE
Avoid endless loop when storing posts

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1442,7 +1442,7 @@ class Item
 			return 0;
 		}
 
-		if ((($item['gravity'] == GRAVITY_COMMENT) || $is_reshare) && !Post::exists(['uri-id' => $item['thr-parent-id'], 'uid' => $uid])) {
+		if (($uri_id != $item['thr-parent-id']) && (($item['gravity'] == GRAVITY_COMMENT) || $is_reshare) && !Post::exists(['uri-id' => $item['thr-parent-id'], 'uid' => $uid])) {
 			// Fetch the origin user for the post
 			$origin_uid = self::GetOriginUidForUriId($item['thr-parent-id'], $uid);
 			if (is_null($origin_uid)) {


### PR DESCRIPTION
Under certain circumstances there can be an endless loop when storing posts. This is now handled.