### PR TITLE
Fix local avatar, improve speed for fetching cached photos

### DIFF
--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -660,27 +660,6 @@ class Conversation
 						$pinned = '';
 					}
 
-					if (in_array($item['network'], [Protocol::FEED, Protocol::MAIL])) {
-						$owner_avatar  = $author_avatar  = $item['contact-id'];
-						$owner_updated = $author_updated = '';
-						$owner_thumb   = $author_thumb   = $item['contact-avatar'];
-					} else {
-						$owner_avatar   = $item['owner-id'];
-						$owner_updated  = $item['owner-updated'];
-						$owner_thumb    = $item['owner-avatar'];
-						$author_avatar  = $item['author-id'];
-						$author_updated = $item['author-updated'];
-						$author_thumb   = $item['author-avatar'];
-					}
-
-					if (empty($owner_thumb) || Photo::isPhotoURI($owner_thumb)) {
-						$owner_thumb = Contact::getAvatarUrlForId($owner_avatar, Proxy::SIZE_THUMB, $owner_updated);
-					}
-			
-					if (empty($author_thumb) || Photo::isPhotoURI($author_thumb)) {
-						$author_thumb = Contact::getAvatarUrlForId($author_avatar, Proxy::SIZE_THUMB, $author_updated);
-					}
-
 					$tmp_item = [
 						'template'             => $tpl,
 						'id'                   => ($preview ? 'P0' : $item['id']),
@@ -698,7 +677,7 @@ class Conversation
 						'name'                 => $profile_name,
 						'sparkle'              => $sparkle,
 						'lock'                 => false,
-						'thumb'                => $this->baseURL->remove($author_thumb),
+						'thumb'                => $this->baseURL->remove($this->item->getAuthorAvatar($item)),
 						'title'                => $title,
 						'body_html'            => $body_html,
 						'tags'                 => $tags['tags'],
@@ -719,7 +698,7 @@ class Conversation
 						'indent'               => '',
 						'owner_name'           => '',
 						'owner_url'            => '',
-						'owner_photo'          => $this->baseURL->remove($owner_thumb),
+						'owner_photo'          => $this->baseURL->remove($this->item->getOwnerAvatar($item)),
 						'plink'                => ItemModel::getPlink($item),
 						'edpost'               => false,
 						'pinned'               => $pinned,

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -26,15 +26,16 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
-use Friendica\Core\Session;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\Group;
 use Friendica\Model\Item as ModelItem;
+use Friendica\Model\Photo;
 use Friendica\Model\Tag;
 use Friendica\Model\Post;
 use Friendica\Protocol\Activity;
 use Friendica\Util\Profiler;
+use Friendica\Util\Proxy;
 use Friendica\Util\XML;
 
 /**
@@ -563,5 +564,44 @@ class Item
 			}
 		}
 		return $item;
+	}
+
+	public function getAuthorAvatar(array $item): string
+	{
+		if (in_array($item['network'], [Protocol::FEED, Protocol::MAIL])) {
+			$author_avatar  = $item['contact-id'];
+			$author_updated = '';
+			$author_thumb   = $item['contact-avatar'];
+		} else {
+			$author_avatar  = $item['author-id'];
+			$author_updated = $item['author-updated'];
+			$author_thumb   = $item['author-avatar'];
+		}
+
+
+		if (empty($author_thumb) || Photo::isPhotoURI($author_thumb)) {
+			$author_thumb = Contact::getAvatarUrlForId($author_avatar, Proxy::SIZE_THUMB, $author_updated);
+		}
+
+		return $author_thumb;
+	}
+
+	public function getOwnerAvatar(array $item): string
+	{
+		if (in_array($item['network'], [Protocol::FEED, Protocol::MAIL])) {
+			$owner_avatar  = $item['contact-id'];
+			$owner_updated = '';
+			$owner_thumb   = $item['contact-avatar'];
+		} else {
+			$owner_avatar   = $item['owner-id'];
+			$owner_updated  = $item['owner-updated'];
+			$owner_thumb    = $item['owner-avatar'];
+		}
+
+		if (empty($owner_thumb) || Photo::isPhotoURI($owner_thumb)) {
+			$owner_thumb = Contact::getAvatarUrlForId($owner_avatar, Proxy::SIZE_THUMB, $owner_updated);
+		}
+
+		return $owner_thumb;
 	}
 }

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1700,6 +1700,10 @@ class Contact
 			}
 		}
 
+		if (Network::isLocalLink($contact['url']) && !empty($contact['avatar'])) {
+			return $contact;
+		}
+
 		/// add the default avatars if the fields aren't filled
 		if (isset($contact['photo']) && empty($contact['photo'])) {
 			$contact['photo'] = self::getDefaultAvatar($contact, Proxy::SIZE_SMALL);

--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -342,7 +342,6 @@ class Photo extends BaseModule
 					}
 				}
 				if (empty($mimetext)) {
-					Logger::info('Blubb');
 					if ($customsize <= Proxy::PIXEL_MICRO) {
 						$url = Contact::getDefaultAvatar($contact, Proxy::SIZE_MICRO);
 					} elseif ($customsize <= Proxy::PIXEL_THUMB) {

--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -304,10 +304,12 @@ class Photo extends BaseModule
 						$photo = MPhoto::selectFirst([], ['resource-id' => $resourceid], ['order' => ['scale']]);
 						if (!empty($photo)) {
 							return $photo;
+						} else {
+							$url = $contact['avatar'];
 						}
+					} else {
+						$url = $contact['photo'];
 					}
-					// We continue with the avatar link when the photo link is invalid
-					$url = $contact['avatar'];
 				} elseif (!empty($contact['avatar'])) {
 					$url = $contact['avatar'];
 				}
@@ -340,6 +342,7 @@ class Photo extends BaseModule
 					}
 				}
 				if (empty($mimetext)) {
+					Logger::info('Blubb');
 					if ($customsize <= Proxy::PIXEL_MICRO) {
 						$url = Contact::getDefaultAvatar($contact, Proxy::SIZE_MICRO);
 					} elseif ($customsize <= Proxy::PIXEL_THUMB) {

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -451,27 +451,6 @@ class Post
 			$browsershare = null;
 		}
 
-		if (in_array($item['network'], [Protocol::FEED, Protocol::MAIL])) {
-			$owner_avatar  = $author_avatar  = $item['contact-id'];
-			$owner_updated = $author_updated = '';
-			$owner_thumb   = $author_thumb   = $item['contact-avatar'];
-		} else {
-			$owner_avatar   = $item['owner-id'];
-			$owner_updated  = $item['owner-updated'];
-			$owner_thumb    = $item['owner-avatar'];
-			$author_avatar  = $item['author-id'];
-			$author_updated = $item['author-updated'];
-			$author_thumb   = $item['author-avatar'];
-		}
-
-		if (empty($owner_thumb) || Photo::isPhotoURI($owner_thumb)) {
-			$owner_thumb = Contact::getAvatarUrlForId($owner_avatar, Proxy::SIZE_THUMB, $owner_updated);
-		}
-
-		if (empty($author_thumb) || Photo::isPhotoURI($author_thumb)) {
-			$author_thumb = Contact::getAvatarUrlForId($author_avatar, Proxy::SIZE_THUMB, $author_updated);
-		}
-
 		$tmp_item = [
 			'template'        => $this->getTemplate(),
 			'type'            => implode("", array_slice(explode("/", $item['verb']), -1)),
@@ -503,7 +482,7 @@ class Post
 			'profile_url'     => $profile_link,
 			'name'            => $profile_name,
 			'item_photo_menu_html' => DI::contentItem()->photoMenu($item, $formSecurityToken),
-			'thumb'           => DI::baseUrl()->remove($author_thumb),
+			'thumb'           => DI::baseUrl()->remove(DI::contentItem()->getAuthorAvatar($item)),
 			'osparkle'        => $osparkle,
 			'sparkle'         => $sparkle,
 			'title'           => $title,
@@ -520,7 +499,7 @@ class Post
 			'shiny'           => $shiny,
 			'owner_self'      => $item['author-link'] == Session::get('my_url'),
 			'owner_url'       => $this->getOwnerUrl(),
-			'owner_photo'     => DI::baseUrl()->remove($owner_thumb),
+			'owner_photo'     => DI::baseUrl()->remove(DI::contentItem()->getOwnerAvatar($item)),
 			'owner_name'      => $this->getOwnerName(),
 			'plink'           => Item::getPlink($item),
 			'browsershare'    => $browsershare,


### PR DESCRIPTION
For unknown reasons some local avatars had been replaced with the default avatar. Also the functionality to fetch the avatar url is moved to a central place.

And finally in the photo cac he mechanism we now use the local file if available.