### PR TITLE
[frio] import contacts form was missing the enctype

### DIFF
--- a/view/theme/frio/templates/settings/account.tpl
+++ b/view/theme/frio/templates/settings/account.tpl
@@ -237,7 +237,7 @@
 			</form>
 
 			{{* Import contacts CSV *}}
-			<form action="settings/account/importcontact" method="post" autocomplete="off" class="panel">
+			<form action="settings/account/importcontact" method="post" autocomplete="off" class="panel" enctype="multipart/form-data">
 				<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="importcontact-settings">
 					<h2>


### PR DESCRIPTION
fixes #11492 hopefully

For uploading files, the enctype for the form has to be set to `multipart/form-data`. Frio was missing this specification, other themes inherit it from the default template.