### PR TITLE
Fix workerqueue entries with wrong priority

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1322,7 +1322,7 @@ class Worker
 		$found = DBA::exists('workerqueue', ['command' => $command, 'parameter' => $parameters, 'done' => false]);
 		$added = 0;
 
-		if (!in_array($priority, PRIORITIES)) {
+		if (!is_int($priority) || !in_array($priority, PRIORITIES)) {
 			Logger::warning('Invalid priority', ['priority' => $priority, 'command' => $command, 'callstack' => System::callstack(20)]);
 			$priority = PRIORITY_MEDIUM;
 		}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -725,7 +725,7 @@ class Item
 		return GRAVITY_UNKNOWN;   // Should not happen
 	}
 
-	public static function insert(array $item, bool $notify = false, bool $post_local = true)
+	public static function insert(array $item, int $notify = 0, bool $post_local = true)
 	{
 		$orig_item = $item;
 
@@ -739,7 +739,7 @@ class Item
 			$item['protocol'] = Conversation::PARCEL_DIRECT;
 			$item['direction'] = Conversation::PUSH;
 
-			if (in_array($notify, PRIORITIES)) {
+			if (is_int($notify) && in_array($notify, PRIORITIES)) {
 				$priority = $notify;
 			}
 		} else {

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -29,6 +29,7 @@ use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Model\ItemURI;
 use Friendica\Model\User;
+use Friendica\Network\HTTPClient\Capability\ICanHandleHttpResponses;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 
@@ -264,21 +265,21 @@ class HTTPSignature
 	 */
 
 	/**
-	 * Transmit given data to a target for a user
+	 * Post given data to a target for a user, returns the result class
 	 *
 	 * @param array   $data   Data that is about to be send
 	 * @param string  $target The URL of the inbox
 	 * @param integer $uid    User id of the sender
 	 *
-	 * @return boolean Was the transmission successful?
+	 * @return ICanHandleHttpResponses
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function transmit($data, $target, $uid)
+	public static function post(array $data, string $target, int $uid): ICanHandleHttpResponses
 	{
 		$owner = User::getOwnerDataById($uid);
 
 		if (!$owner) {
-			return;
+			return null;
 		}
 
 		$content = json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
@@ -310,11 +311,27 @@ class HTTPSignature
 
 		Logger::info('Transmit to ' . $target . ' returned ' . $return_code);
 
-		$success = ($return_code >= 200) && ($return_code <= 299);
+		self::setInboxStatus($target, ($return_code >= 200) && ($return_code <= 299));
 
-		self::setInboxStatus($target, $success);
+		return $postResult;
+	}
 
-		return $success;
+	/**
+	 * Transmit given data to a target for a user
+	 *
+	 * @param array   $data   Data that is about to be send
+	 * @param string  $target The URL of the inbox
+	 * @param integer $uid    User id of the sender
+	 *
+	 * @return boolean Was the transmission successful?
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public static function transmit(array $data, string $target, int $uid): bool
+	{
+		$postResult = self::post($data, $target, $uid);
+		$return_code = $postResult->getReturnCode();
+
+		return ($return_code >= 200) && ($return_code <= 299);
 	}
 
 	/**

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -306,7 +306,7 @@ class HTTPSignature
 
 		$headers['Content-Type'] = 'application/activity+json';
 
-		$postResult = DI::httpClient()->post($target, $content, $headers);
+		$postResult = DI::httpClient()->post($target, $content, $headers, DI::config()->get('system', 'curl_timeout'));
 		$return_code = $postResult->getReturnCode();
 
 		Logger::info('Transmit to ' . $target . ' returned ' . $return_code);

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -153,7 +153,7 @@ class APDelivery
 				$success    = $response->isSuccess();
 				$serverfail = $response->isTimeout();
 				if (!$success) {
-					if (!$serverfail && ($response->getReturnCode() == 500)) {
+					if (!$serverfail && ($response->getReturnCode() >= 500) && ($response->getReturnCode() <= 599)) {
 						$serverfail = true;
 					}
 

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -23,6 +23,7 @@ namespace Friendica\Worker;
 
 use Friendica\Core\Logger;
 use Friendica\Core\Worker;
+use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\GServer;
 use Friendica\Model\Post;
@@ -152,6 +153,15 @@ class APDelivery
 				$success  = $response->isSuccess();
 				$timeout  = $response->isTimeout();
 				if (!$success) {
+					$xrd_timeout  = DI::config()->get('system', 'xrd_timeout');
+					if (!$timeout && $xrd_timeout && ($runtime > $xrd_timeout)) {
+						$timeout = true;
+					}
+					$curl_timeout = DI::config()->get('system', 'curl_timeout');
+					if (!$timeout && $curl_timeout && ($runtime > $curl_timeout)) {
+						$timeout = true;
+					}
+
 					Logger::debug('Delivery failed', ['retcode' => $response->getReturnCode(), 'timeout' => $timeout, 'runtime' => round($runtime, 3), 'uri-id' => $uri_id, 'uid' => $uid, 'item_id' => $item_id, 'cmd' => $cmd, 'inbox' => $inbox]);
 				}
 				if ($uri_id) {

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -146,11 +146,13 @@ class APDelivery
 		} else {
 			$data = ActivityPub\Transmitter::createCachedActivityFromItem($item_id);
 			if (!empty($data)) {
+				$timestamp = microtime(true);
 				$response = HTTPSignature::post($data, $inbox, $uid);
+				$runtime  = microtime(true) - $timestamp;
 				$success  = $response->isSuccess();
 				$timeout  = $response->isTimeout();
 				if (!$success) {
-					Logger::debug('Delivery failed', ['retcode' => $response->getReturnCode(), 'timeout' => $timeout, 'uri-id' => $uri_id, 'uid' => $uid, 'item_id' => $item_id, 'cmd' => $cmd, 'inbox' => $inbox]);
+					Logger::debug('Delivery failed', ['retcode' => $response->getReturnCode(), 'timeout' => $timeout, 'runtime' => round($runtime, 3), 'uri-id' => $uri_id, 'uid' => $uid, 'item_id' => $item_id, 'cmd' => $cmd, 'inbox' => $inbox]);
 				}
 				if ($uri_id) {
 					if ($success) {


### PR DESCRIPTION
While working at the bulk delivery, I found (a fixed) a bug that caused workerqueue entries with the priority `1`. Also this PR includes a small change to not to continue the bulk delivery when the target system is timed out.