### PR TITLE
Fetch featured posts through a worker

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2316,7 +2316,10 @@ class Contact
 
 		if ($uid == 0) {
 			if ($ret['network'] == Protocol::ACTIVITYPUB) {
-				ActivityPub\Processor::fetchFeaturedPosts($ret['url']);
+				$apcontact = APContact::getByURL($ret['url'], false);
+				if (!empty($apcontact['featured'])) {
+					Worker::add(PRIORITY_LOW, 'FetchFeaturedPosts', $ret['url']);
+				}
 			}
 	
 			$ret['last-item'] = Probe::getLastUpdate($ret);

--- a/src/Worker/FetchFeaturedPosts.php
+++ b/src/Worker/FetchFeaturedPosts.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Worker;
+
+use Friendica\Core\Logger;
+use Friendica\Protocol\ActivityPub;
+
+class FetchFeaturedPosts
+{
+	/**
+	 * Fetch featured posts from a contact with the given URL
+	 * @param string $url Contact URL
+	 */
+	public static function execute(string $url)
+	{
+		Logger::info('Start fetching featured posts', ['url' => $url]);
+		ActivityPub\Processor::fetchFeaturedPosts($url);
+		Logger::info('Finished fetching featured posts', ['url' => $url]);
+	}
+}


### PR DESCRIPTION
Fetch featured posts through a worker. This prevents possible endless loop. (the contact update can be called via the process that fetches posts, so this can cause a problem)