### PR TITLE
Prolonged cache lifetime for endpoints

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -797,10 +797,12 @@ class Contact
 	public static function remove($id)
 	{
 		// We want just to make sure that we don't delete our "self" contact
-		$contact = DBA::selectFirst('contact', ['uri-id', 'photo', 'thumb', 'micro'], ['id' => $id, 'self' => false]);
+		$contact = DBA::selectFirst('contact', ['uri-id', 'photo', 'thumb', 'micro', 'uid'], ['id' => $id, 'self' => false]);
 		if (!DBA::isResult($contact)) {
 			return;
 		}
+
+		self::clearFollowerFollowingEndpointCache($contact['uid']);
 
 		// Archive the contact
 		self::update(['archive' => true, 'network' => Protocol::PHANTOM, 'deleted' => true], ['id' => $id]);
@@ -899,6 +901,15 @@ class Contact
 		self::remove($contact['id']);
 	}
 
+	private static function clearFollowerFollowingEndpointCache(int $uid)
+	{
+		if (empty($uid)) {
+			return;
+		}
+
+		DI::cache()->delete(ActivityPub\Transmitter::CACHEKEY_CONTACTS . 'followers:' . $uid);
+		DI::cache()->delete(ActivityPub\Transmitter::CACHEKEY_CONTACTS . 'following:' . $uid);
+	}
 
 	/**
 	 * Marks a contact for archival after a communication issue delay
@@ -1764,7 +1775,7 @@ class Contact
 				break;
 			default:
 				/**
-				 * Use a random picture. 
+				 * Use a random picture.
 				 * The service provides random pictures from Unsplash.
 				 * @license https://unsplash.com/license
 				 */
@@ -2321,7 +2332,7 @@ class Contact
 					Worker::add(PRIORITY_LOW, 'FetchFeaturedPosts', $ret['url']);
 				}
 			}
-	
+
 			$ret['last-item'] = Probe::getLastUpdate($ret);
 			Logger::info('Fetched last item', ['id' => $id, 'probed_url' => $ret['url'], 'last-item' => $ret['last-item'], 'callstack' => System::callstack(20)]);
 		}
@@ -2707,6 +2718,8 @@ class Contact
 			$contact = DBA::selectFirst('contact', [], ['id' => $cid]);
 		}
 
+		self::clearFollowerFollowingEndpointCache($importer['uid']);
+
 		if (!empty($contact)) {
 			if (!empty($contact['pending'])) {
 				Logger::info('Pending contact request already exists.', ['url' => $url, 'uid' => $importer['uid']]);
@@ -2830,6 +2843,8 @@ class Contact
 			return;
 		}
 
+		self::clearFollowerFollowingEndpointCache($contact['uid']);
+
 		$cdata = self::getPublicAndUserContactID($contact['id'], $contact['uid']);
 
 		DI::notification()->deleteForUserByVerb($contact['uid'], Activity::FOLLOW, ['actor-id' => $cdata['public']]);
@@ -2844,6 +2859,8 @@ class Contact
 	 */
 	public static function removeSharer(array $contact)
 	{
+		self::clearFollowerFollowingEndpointCache($contact['uid']);
+
 		if ($contact['rel'] == self::SHARING || in_array($contact['network'], [Protocol::FEED, Protocol::MAIL])) {
 			self::remove($contact['id']);
 		} else {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -35,6 +35,7 @@ use Friendica\Core\Worker;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Module\NoScrape;
 use Friendica\Network\HTTPException;
 use Friendica\Network\Probe;
 use Friendica\Protocol\Activity;
@@ -909,6 +910,7 @@ class Contact
 
 		DI::cache()->delete(ActivityPub\Transmitter::CACHEKEY_CONTACTS . 'followers:' . $uid);
 		DI::cache()->delete(ActivityPub\Transmitter::CACHEKEY_CONTACTS . 'following:' . $uid);
+		DI::cache()->delete(NoScrape::CACHEKEY . $uid);
 	}
 
 	/**

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1225,7 +1225,6 @@ class Item
 
 		if ($posted_item['origin'] && ($posted_item['uid'] != 0) && in_array($posted_item['gravity'], [GRAVITY_PARENT, GRAVITY_COMMENT])) {
 			DI::cache()->delete(ActivityPub\Transmitter::CACHEKEY_OUTBOX . $posted_item['uid']);
-			DI::cache()->delete(ActivityPub\Transmitter::CACHEKEY_PROFILE . $posted_item['uid']);
 		}
 
 		return $post_user_id;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1225,6 +1225,7 @@ class Item
 
 		if ($posted_item['origin'] && ($posted_item['uid'] != 0) && in_array($posted_item['gravity'], [GRAVITY_PARENT, GRAVITY_COMMENT])) {
 			DI::cache()->delete(ActivityPub\Transmitter::CACHEKEY_OUTBOX . $posted_item['uid']);
+			DI::cache()->delete(ActivityPub\Transmitter::CACHEKEY_PROFILE . $posted_item['uid']);
 		}
 
 		return $post_user_id;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2793,7 +2793,7 @@ class Item
 			$shared_item = Post::selectFirst(['uri-id', 'plink', 'has-media'], ['guid' => $shared['guid']]);
 			$shared_uri_id = $shared_item['uri-id'] ?? 0;
 			$shared_links = [strtolower($shared_item['plink'] ?? '')];
-			$shared_attachments = Post\Media::splitAttachments($shared_uri_id, $shared['guid'], [], $shared_item['has-media']);
+			$shared_attachments = Post\Media::splitAttachments($shared_uri_id, $shared['guid'], [], $shared_item['has-media'] ?? false);
 			$shared_links = array_merge($shared_links, array_column($shared_attachments['visual'], 'url'));
 			$shared_links = array_merge($shared_links, array_column($shared_attachments['link'], 'url'));
 			$shared_links = array_merge($shared_links, array_column($shared_attachments['additional'], 'url'));

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1223,6 +1223,10 @@ class Item
 			self::updateDisplayCache($posted_item['uri-id']);
 		}
 
+		if ($posted_item['origin'] && ($posted_item['uid'] != 0) && in_array($posted_item['gravity'], [GRAVITY_PARENT, GRAVITY_COMMENT])) {
+			DI::cache()->delete(ActivityPub\Transmitter::CACHEKEY_OUTBOX . $posted_item['uid']);
+		}
+
 		return $post_user_id;
 	}
 

--- a/src/Model/Post/Collection.php
+++ b/src/Model/Post/Collection.php
@@ -24,6 +24,8 @@ namespace Friendica\Model\Post;
 use Friendica\Database\DBA;
 use BadMethodCallException;
 use Friendica\Database\Database;
+use Friendica\DI;
+use Friendica\Protocol\ActivityPub;
 
 class Collection
 {
@@ -34,14 +36,19 @@ class Collection
 	 *
 	 * @param integer $uri_id
 	 * @param integer $type
+	 * @param integer $cache_uid If set to a non zero value, the featured cache is cleared
 	 */
-	public static function add(int $uri_id, int $type)
+	public static function add(int $uri_id, int $type, int $cache_uid = 0)
 	{
 		if (empty($uri_id)) {
 			throw new BadMethodCallException('Empty URI_id');
 		}
 
 		DBA::insert('post-collection', ['uri-id' => $uri_id, 'type' => $type], Database::INSERT_IGNORE);
+
+		if (!empty($cache_uid) && ($type == self::FEATURED)) {
+			DI::cache()->delete(ActivityPub\Transmitter::CACHEKEY_FEATURED . $cache_uid);
+		}
 	}
 
 	/**
@@ -49,14 +56,19 @@ class Collection
 	 *
 	 * @param integer $uri_id
 	 * @param integer $type
+	 * @param integer $cache_uid If set to a non zero value, the featured cache is cleared
 	 */
-	public static function remove(int $uri_id, int $type)
+	public static function remove(int $uri_id, int $type, int $cache_uid = 0)
 	{
 		if (empty($uri_id)) {
 			throw new BadMethodCallException('Empty URI_id');
 		}
 
 		DBA::delete('post-collection', ['uri-id' => $uri_id, 'type' => $type]);
+
+		if (!empty($cache_uid) && ($type == self::FEATURED)) {
+			DI::cache()->delete(ActivityPub\Transmitter::CACHEKEY_FEATURED . $cache_uid);
+		}
 	}
 
 	/**

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -46,7 +46,7 @@ class Pin extends BaseApi
 			DI::mstdnError()->RecordNotFound();
 		}
 
-		Post\Collection::add($this->parameters['id'], Post\Collection::FEATURED);
+		Post\Collection::add($this->parameters['id'], Post\Collection::FEATURED, $uid);
 
 		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid)->toArray());
 	}

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -46,7 +46,7 @@ class Unpin extends BaseApi
 			DI::mstdnError()->RecordNotFound();
 		}
 
-		Post\Collection::remove($this->parameters['id'], Post\Collection::FEATURED);
+		Post\Collection::remove($this->parameters['id'], Post\Collection::FEATURED, $uid);
 
 		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid)->toArray());
 	}

--- a/src/Module/Item/Pin.php
+++ b/src/Module/Item/Pin.php
@@ -60,9 +60,9 @@ class Pin extends BaseModule
 		$pinned = !$item['featured'];
 
 		if ($pinned) {
-			Post\Collection::add($item['uri-id'], Post\Collection::FEATURED);
+			Post\Collection::add($item['uri-id'], Post\Collection::FEATURED, local_user());
 		} else {
-			Post\Collection::remove($item['uri-id'], Post\Collection::FEATURED);
+			Post\Collection::remove($item['uri-id'], Post\Collection::FEATURED, local_user());
 		}
 
 		// See if we've been passed a return path to redirect to

--- a/src/Module/NoScrape.php
+++ b/src/Module/NoScrape.php
@@ -22,6 +22,7 @@
 namespace Friendica\Module;
 
 use Friendica\BaseModule;
+use Friendica\Core\Cache\Enum\Duration;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
@@ -35,6 +36,8 @@ use Friendica\Model\User;
  */
 class NoScrape extends BaseModule
 {
+	const CACHEKEY = 'noscrape:';
+
 	protected function rawContent(array $request = [])
 	{
 		$a = DI::app();
@@ -53,6 +56,12 @@ class NoScrape extends BaseModule
 
 		if (empty($owner['uid'])) {
 			System::jsonError(404, 'Profile not found');
+		}
+
+		$cachekey = self::CACHEKEY . $owner['uid'];
+		$result = DI::cache()->get($cachekey);
+		if (!is_null($result)) {
+			System::jsonExit($result);
 		}
 
 		$json_info = [
@@ -125,6 +134,8 @@ class NoScrape extends BaseModule
 				$json_info["$field"] = $owner[$field];
 			}
 		}
+
+		DI::cache()->set($cachekey, $json_info, Duration::DAY);
 
 		System::jsonExit($json_info);
 	}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -205,7 +205,7 @@ class Transmitter
 
 		if (!$show_contacts) {
 			if (!empty($cachekey)) {
-				DI::cache()->set($cachekey, $data, Duration::QUARTER_HOUR);
+				DI::cache()->set($cachekey, $data, Duration::DAY);
 			}
 
 			return $data;
@@ -233,7 +233,7 @@ class Transmitter
 		}
 
 		if (!empty($cachekey)) {
-			DI::cache()->set($cachekey, $data, Duration::QUARTER_HOUR);
+			DI::cache()->set($cachekey, $data, Duration::DAY);
 		}
 
 		return $data;
@@ -323,7 +323,7 @@ class Transmitter
 		}
 
 		if (!empty($cachekey)) {
-			DI::cache()->set($cachekey, $data, Duration::QUARTER_HOUR);
+			DI::cache()->set($cachekey, $data, Duration::DAY);
 		}
 
 		return $data;
@@ -407,7 +407,7 @@ class Transmitter
 		$data['orderedItems'] = $list;
 
 		if (!empty($cachekey)) {
-			DI::cache()->set($cachekey, $data, Duration::QUARTER_HOUR);
+			DI::cache()->set($cachekey, $data, Duration::DAY);
 		}
 
 		return $data;

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -44,7 +44,6 @@ use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\Relay;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\HTTPSignature;
-use Friendica\Util\JsonLD;
 use Friendica\Util\LDSignature;
 use Friendica\Util\Map;
 use Friendica\Util\Network;
@@ -59,6 +58,10 @@ use Friendica\Util\XML;
  */
 class Transmitter
 {
+	const CACHEKEY_FEATURED = 'transmitter:getFeatured:';
+	const CACHEKEY_CONTACTS = 'transmitter:getContacts:';
+	const CACHEKEY_OUTBOX   = 'transmitter:getOutbox:';
+
 	/**
 	 * Add relay servers to the list of inboxes
 	 *
@@ -159,7 +162,7 @@ class Transmitter
 	public static function getContacts(array $owner, array $rel, string $module, int $page = null, string $requester = null, $nocache = false)
 	{
 		if (empty($page)) {
-			$cachekey = 'transmitter:getContacts:' . $module . ':'. $owner['uid'];
+			$cachekey = self::CACHEKEY_CONTACTS . $module . ':'. $owner['uid'];
 			$result = DI::cache()->get($cachekey);
 			if (!$nocache && !is_null($result)) {
 				return $result;
@@ -251,7 +254,7 @@ class Transmitter
 	public static function getOutbox(array $owner, int $page = null, string $requester = '', $nocache = false)
 	{
 		if (empty($page)) {
-			$cachekey = 'transmitter:getOutbox:' . $owner['uid'];
+			$cachekey = self::CACHEKEY_OUTBOX . $owner['uid'];
 			$result = DI::cache()->get($cachekey);
 			if (!$nocache && !is_null($result)) {
 				return $result;
@@ -339,14 +342,15 @@ class Transmitter
 	 */
 	public static function getFeatured(array $owner, int $page = null, $nocache = false)
 	{
-		$owner_cid = Contact::getIdForURL($owner['url'], 0, false);
 		if (empty($page)) {
-			$cachekey = 'transmitter:getFeatured:' . $owner_cid;
+			$cachekey = self::CACHEKEY_FEATURED . $owner['uid'];
 			$result = DI::cache()->get($cachekey);
 			if (!$nocache && !is_null($result)) {
 				return $result;
 			}
 		}
+
+		$owner_cid = Contact::getIdForURL($owner['url'], 0, false);
 
 		$condition = ["`uri-id` IN (SELECT `uri-id` FROM `collection-view` WHERE `cid` = ? AND `type` = ?)",
 			$owner_cid, Post\Collection::FEATURED];

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -61,7 +61,6 @@ class Transmitter
 	const CACHEKEY_FEATURED = 'transmitter:getFeatured:';
 	const CACHEKEY_CONTACTS = 'transmitter:getContacts:';
 	const CACHEKEY_OUTBOX   = 'transmitter:getOutbox:';
-	const CACHEKEY_PROFILE  = 'transmitter:getProfile:';
 
 	/**
 	 * Add relay servers to the list of inboxes
@@ -430,19 +429,12 @@ class Transmitter
 	 * Return the ActivityPub profile of the given user
 	 *
 	 * @param int $uid User ID
-	 * @param boolean $nocache   Wether to bypass caching
 	 * @return array with profile data
 	 * @throws HTTPException\NotFoundException
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public static function getProfile(int $uid, $nocache = false): array
+	public static function getProfile(int $uid): array
 	{
-		$cachekey = self::CACHEKEY_PROFILE . $uid;
-		$result = DI::cache()->get($cachekey);
-		if (!$nocache && !is_null($result)) {
-			return $result;
-		}
-
 		$owner = User::getOwnerDataById($uid);
 		if (!isset($owner['id'])) {
 			DI::logger()->error('Unable to find owner data for uid', ['uid' => $uid, 'callstack' => System::callstack(20)]);
@@ -535,8 +527,6 @@ class Transmitter
 		}
 
 		$data['generator'] = self::getService();
-
-		DI::cache()->set($cachekey, $data, Duration::DAY);
 
 		// tags: https://kitty.town/@inmysocks/100656097926961126.json
 		return $data;


### PR DESCRIPTION
The cache lifetime for several AP endpoints is prolonged to a day. Also the cache is cleared whenever there is a change.