### PR TITLE
Catch exceptions for Worker::AddContact()

### DIFF
--- a/src/Worker/AddContact.php
+++ b/src/Worker/AddContact.php
@@ -21,8 +21,10 @@
 
 namespace Friendica\Worker;
 
-use Friendica\Core\Logger;
+use Friendica\DI;
 use Friendica\Model\Contact;
+use Friendica\Network\HTTPException\InternalServerErrorException;
+use Friendica\Network\HTTPException\NotFoundException;
 
 class AddContact
 {
@@ -33,14 +35,22 @@ class AddContact
 	 */
 	public static function execute(int $uid, string $url)
 	{
-		if ($uid == 0) {
-			// Adding public contact
-			$result = Contact::getIdForURL($url);
-			Logger::info('Added public contact', ['url' => $url, 'result' => $result]);
-			return;
-		}
+		try {
+			if ($uid == 0) {
+				// Adding public contact
+				$result = Contact::getIdForURL($url);
+				DI::logger()->info('Added public contact', ['url' => $url, 'result' => $result]);
+				return;
+			}
 
-		$result = Contact::createFromProbeForUser($uid, $url);
-		Logger::info('Added contact for user', ['uid' => $uid, 'url' => $url, 'result' => $result]);
+			$result = Contact::createFromProbeForUser($uid, $url);
+			DI::logger()->info('Added contact for user', ['uid' => $uid, 'url' => $url, 'result' => $result]);
+		} catch (InternalServerErrorException $e) {
+			DI::logger()->warning('Internal server error.', ['exception' => $e, 'uid' => $uid, 'url' => $url]);
+		} catch (NotFoundException $e) {
+			DI::logger()->notice('uid not found.', ['exception' => $e, 'uid' => $uid, 'url' => $url]);
+		} catch (\ImagickException $e) {
+			DI::logger()->notice('Imagick not found.', ['exception' => $e, 'uid' => $uid, 'url' => $url]);
+		}
 	}
 }


### PR DESCRIPTION
closes #11507 (Root-Cause: This Exception stopped too many worker process in parallel so the queue becomes more and more)

there were two UIDs, which deleted themselves and the whole db purged these UIDs (at least I believe this has to had happened ...)
Nevertheless, at least the `AddContact` tried to add contacts for unknown UIDs. So it threws a `NotFoundException`, which wasn't catched until now :)