### PR TITLE
Only deliver own content to the relay (possibly fix relay problems)

### DIFF
--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -754,7 +754,6 @@ class Notifier
 
 			if (in_array($target_item['private'], [Item::PUBLIC])) {
 				$inboxes = ActivityPub\Transmitter::addRelayServerInboxesForItem($parent['id'], $inboxes);
-				$relay_inboxes = ActivityPub\Transmitter::addRelayServerInboxes([]);
 			}
 
 			Logger::info('Remote item ' . $target_item['id'] . ' with URL ' . $target_item['uri'] . ' will be distributed.');


### PR DESCRIPTION
While implementing the bulk delivery mode, I saw that many posts to the relay systems had been rejected via the relay with some 4xx error. I guess that the problem is that we also delivered content that was not ours. So we don't do that anymore.

Possibly this also fixes the problem that servers get unsubscribed after some time. We will see.