### PR TITLE
Avoid warning "Undefined namespace prefix"

### DIFF
--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -460,7 +460,7 @@ class XML
 
 	public static function getFirstNodeValue(DOMXPath $xpath, $element, $context = null)
 	{
-		$result = $xpath->evaluate($element, $context);
+		$result = @$xpath->evaluate($element, $context);
 		if (!is_object($result)) {
 			return '';
 		}


### PR DESCRIPTION
Avoids `PHP Warning: DOMXPath::evaluate(): Undefined namespace prefix in /src/Util/XML.php on line 463`, as reported here: https://forum.friendi.ca/display/b8c357bb-1462-887e-1f00-02e472764400