### PR TITLE
Only use proxied image links with images

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2930,9 +2930,17 @@ class Item
 
 		foreach ($attachments['visual'] as $attachment) {
 			if (!empty($attachment['preview'])) {
-				$body = str_replace($attachment['preview'], Post\Media::getPreviewUrlForId($attachment['id'], Proxy::SIZE_LARGE), $body);
+				$proxy   = Post\Media::getPreviewUrlForId($attachment['id'], Proxy::SIZE_LARGE);
+				$search  = ['[img=' . $attachment['preview'] . ']', ']' . $attachment['preview'] . '[/img]'];
+				$replace = ['[img=' . $proxy . ']', ']' . $proxy . '[/img]'];
+
+				$body = str_replace($search, $replace, $body);
 			} elseif ($attachment['filetype'] == 'image') {
-				$body = str_replace($attachment['url'], Post\Media::getUrlForId($attachment['id']), $body);
+				$proxy   = Post\Media::getUrlForId($attachment['id']);
+				$search  = ['[img=' . $attachment['url'] . ']', ']' . $attachment['url'] . '[/img]'];
+				$replace = ['[img=' . $proxy . ']', ']' . $proxy . '[/img]'];
+
+				$body = str_replace($search, $replace, $body);
 			}
 		}
 		DI::profiler()->stopRecording();


### PR DESCRIPTION
Until now every picture link had been converted into a link to the local image proxy. This is confusing for the users since they can easily believe that a remote user has access to some local file.

We now are using the image proxy only for pictures that are embedded via the image element.