### PR TITLE
Fix unsupported animated webp parsing

### DIFF
--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -173,7 +173,7 @@ class Image
 		} catch (\Throwable $error) {
 			/** @see https://github.com/php/doc-en/commit/d09a881a8e9059d11e756ee59d75bf404d6941ed */
 			if (strstr($error->getMessage(), "gd-webp cannot allocate temporary buffer")) {
-				DI::logger()->notice('Image is probably a kind of unsupported, animated GID', ['error' => $error]);
+				DI::logger()->notice('Image is probably animated and therefore unsupported', ['error' => $error]);
 			} else {
 				DI::logger()->warning('Unexpected throwable.', ['error' => $error]);
 			}

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -159,15 +159,24 @@ class Image
 		}
 
 		$this->valid = false;
-		$this->image = @imagecreatefromstring($data);
-		if ($this->image !== false) {
-			$this->width  = imagesx($this->image);
-			$this->height = imagesy($this->image);
-			$this->valid  = true;
-			imagealphablending($this->image, false);
-			imagesavealpha($this->image, true);
+		try {
+			$this->image = @imagecreatefromstring($data);
+			if ($this->image !== false) {
+				$this->width  = imagesx($this->image);
+				$this->height = imagesy($this->image);
+				$this->valid  = true;
+				imagealphablending($this->image, false);
+				imagesavealpha($this->image, true);
 
-			return true;
+				return true;
+			}
+		} catch (\Throwable $error) {
+			/** @see https://github.com/php/doc-en/commit/d09a881a8e9059d11e756ee59d75bf404d6941ed */
+			if (strstr($error->getMessage(), "gd-webp cannot allocate temporary buffer")) {
+				DI::logger()->notice('Image is probably a kind of unsupported, animated GID', ['error' => $error]);
+			} else {
+				DI::logger()->warning('Unexpected throwable.', ['error' => $error]);
+			}
 		}
 
 		return false;


### PR DESCRIPTION
Catches:
```console
cron_1   | Friendica[1257]: worker [ALERT]: Fatal Error (E_ERROR): gd-webp cannot allocate temporary buffer {"code":1,"message":"gd-webp cannot allocate temporary buffer","file":"/var/www/html/src/Object/Image.php","line":162,"trace":null} - {"file":null,"line":null,"function":null,"uid":"7a3db3"}
```
Probably caused by https://bugs.php.net/bug.php?id=79809
see https://github.com/libgd/libgd/issues/648