### PR TITLE
Improved Relay handling / better handling of receiver responses

### DIFF
--- a/src/Protocol/ActivityPub/Delivery.php
+++ b/src/Protocol/ActivityPub/Delivery.php
@@ -179,7 +179,8 @@ class Delivery
 	 */
 	private static function fetchActorForRelayInbox(string $inbox): string
 	{
-		$apcontact = DBA::selectFirst('apcontact', ['url'], ['sharedinbox' => $inbox, 'type' => 'Application']);
+		$apcontact = DBA::selectFirst('apcontact', ['url'], ["`sharedinbox` = ? AND `type` = ? AND `url` IN (SELECT `url` FROM `contact` WHERE `uid` = ? AND `rel` = ?)",
+			$inbox, 'Application', 0, Contact::FRIEND]);
 		return $apcontact['url'] ?? '';
 	}
 

--- a/src/Protocol/ActivityPub/Delivery.php
+++ b/src/Protocol/ActivityPub/Delivery.php
@@ -144,6 +144,11 @@ class Delivery
 						if (!empty($actor)) {
 							$drop = !ActivityPub\Transmitter::sendRelayFollow($actor);
 							Logger::notice('Resubscribed to relay', ['url' => $actor, 'success' => !$drop]);
+						} elseif ($cmd = WorkerDelivery::DELETION) {
+							// Remote systems not always accept our deletion requests, so we drop them if rejected.
+							// Situation is: In Friendica we allow the thread owner to delete foreign comments to their thread.
+							// Most AP systems don't allow this, so they will reject the deletion request.
+							$drop = true;
 						}
 
 					}

--- a/src/Protocol/ActivityPub/Delivery.php
+++ b/src/Protocol/ActivityPub/Delivery.php
@@ -167,9 +167,9 @@ class Delivery
 
 		self::setSuccess($receivers, $success);
 
-		Logger::debug('Delivered', ['uri-id' => $uri_id, 'uid' => $uid, 'item_id' => $item_id, 'cmd' => $cmd, 'inbox' => $inbox, 'success' => $success]);
+		Logger::debug('Delivered', ['uri-id' => $uri_id, 'uid' => $uid, 'item_id' => $item_id, 'cmd' => $cmd, 'inbox' => $inbox, 'success' => $success, 'serverfailure' => $serverfail, 'drop' => $drop]);
 
-		if ($success && in_array($cmd, [WorkerDelivery::POST])) {
+		if (($success || $drop) && in_array($cmd, [WorkerDelivery::POST])) {
 			Post\DeliveryData::incrementQueueDone($uri_id, Post\DeliveryData::ACTIVITYPUB);
 		}
 

--- a/src/Protocol/ActivityPub/Delivery.php
+++ b/src/Protocol/ActivityPub/Delivery.php
@@ -179,7 +179,8 @@ class Delivery
 	 */
 	private static function fetchActorForRelayInbox(string $inbox): string
 	{
-		return DBA::selectFirst('apcontact', ['url'], ['sharedinbox' => $inbox, 'type' => 'Application']) ?: '';
+		$apcontact = DBA::selectFirst('apcontact', ['url'], ['sharedinbox' => $inbox, 'type' => 'Application']);
+		return $apcontact['url'] ?? '';
 	}
 
 	/**

--- a/src/Protocol/Relay.php
+++ b/src/Protocol/Relay.php
@@ -341,4 +341,15 @@ class Relay
 		// It should never happen that we arrive here
 		return [];
 	}
+
+	/**
+	 * Resubscribe to all relay servers
+	 */
+	public static function reSubscribe()
+	{
+		foreach (self::getList() as $server) {
+			$success = ActivityPub\Transmitter::sendRelayFollow($server['url']);
+			Logger::debug('Resubscribed', ['profile' => $server['url'], 'success' => $success]);
+		}	
+	}
 }

--- a/src/Worker/APDelivery.php
+++ b/src/Worker/APDelivery.php
@@ -66,14 +66,16 @@ class APDelivery
 		if (empty($uri_id)) {
 			$result  = ActivityPub\Delivery::deliver($inbox);
 			$success = $result['success'];
+			$drop    = false;
 			$uri_ids = $result['uri_ids'];
 		} else {
 			$result  = ActivityPub\Delivery::deliverToInbox($cmd, $item_id, $inbox, $uid, $receivers, $uri_id);
 			$success = $result['success'];
+			$drop    = $result['drop'];
 			$uri_ids = [$uri_id];
 		}
 
-		if (!$success && !Worker::defer() && !empty($uri_ids)) {
+		if (!$drop && !$success && !Worker::defer() && !empty($uri_ids)) {
 			foreach ($uri_ids as $uri_id) {
 				Post\Delivery::remove($uri_id, $inbox);
 				Post\DeliveryData::incrementQueueFailed($uri_id);

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -27,6 +27,7 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Tag;
+use Friendica\Protocol\Relay;
 
 class Cron
 {
@@ -125,6 +126,9 @@ class Cron
 			}
 	
 			DI::config()->set('system', 'last_cron_daily', time());
+
+			// Resubscribe to relay servers
+			Relay::reSubscribe();
 		}
 
 		Logger::notice('end');


### PR DESCRIPTION
We now automatically resubscribe to relay servers when they answer with a 4xx error. Also "drop" messages will be dropped when the target system answers with a 4xx error since we assume that the remote system doesn't accept the deletion.

We also resubscribe to relay servers once a day.