### PR TITLE
Ensure that the public contact exists before adding a user contact

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2542,6 +2542,9 @@ class Contact
 		} else {
 			$probed = true;
 			$ret = Probe::uri($url, $network, $uid);
+
+			// Ensure that the public contact exists
+			self::getIdForURL($url);
 		}
 
 		if (($network != '') && ($ret['network'] != $network)) {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2544,7 +2544,9 @@ class Contact
 			$ret = Probe::uri($url, $network, $uid);
 
 			// Ensure that the public contact exists
-			self::getIdForURL($url);
+			if ($ret['network'] != Protocol::PHANTOM) {
+				self::getIdForURL($url);
+			}
 		}
 
 		if (($network != '') && ($ret['network'] != $network)) {


### PR DESCRIPTION
When adding a contact via a CSV import, it can happen that the contact isn't known at that time. But to make the system work correctly, a public contact is needed. So we now ensure that a public contact exists.