### PR TITLE
Fix: Use correct follow notification texts

### DIFF
--- a/src/Navigation/Notifications/Factory/FormattedNavNotification.php
+++ b/src/Navigation/Notifications/Factory/FormattedNavNotification.php
@@ -127,12 +127,18 @@ class FormattedNavNotification extends BaseFactory
 	public function createFromIntro(\Friendica\Contact\Introduction\Entity\Introduction $intro): ValueObject\FormattedNavNotification
 	{
 		if (!isset(self::$contacts[$intro->cid])) {
-			self::$contacts[$intro->cid] = Contact::getById($intro->cid, ['name', 'url']);
+			self::$contacts[$intro->cid] = Contact::getById($intro->cid, ['name', 'url', 'pending']);
+		}
+
+		if (self::$contacts[$intro->cid]['pending']) {
+			$msg = $this->l10n->t('{0} wants to follow you');
+		} else {
+			$msg = $this->l10n->t('{0} has started following you');
 		}
 
 		return $this->createFromParams(
 			self::$contacts[$intro->cid],
-			$this->l10n->t('{0} wants to follow you'),
+			$msg,
 			$intro->datetime,
 			new Uri($this->baseUrl->get() . '/notifications/intros/' . $intro->id)
 		);

--- a/src/Navigation/Notifications/Factory/Notification.php
+++ b/src/Navigation/Notifications/Factory/Notification.php
@@ -126,8 +126,7 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 		}
 
 		if ($Notification->type === Post\UserNotification::TYPE_NONE) {
-			$localRelationship = $this->localRelationshipRepo->getForUserContact($Notification->uid, $Notification->actorId);
-			if ($localRelationship->pending) {
+			if ($causer['pending']) {
 				$msg = $this->l10n->t('%1$s wants to follow you');
 			} else {
 				$msg = $this->l10n->t('%1$s has started following you');

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.05-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-29 13:18-0400\n"
+"POT-Creation-Date: 2022-05-31 13:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -467,7 +467,7 @@ msgid "OStatus support is disabled. Contact can't be added."
 msgstr ""
 
 #: mod/follow.php:138 src/Content/Item.php:443 src/Content/Widget.php:78
-#: src/Model/Contact.php:1101 src/Model/Contact.php:1113
+#: src/Model/Contact.php:1102 src/Model/Contact.php:1114
 #: view/theme/vier/theme.php:172
 msgid "Connect/Follow"
 msgstr ""
@@ -1006,27 +1006,27 @@ msgstr ""
 msgid "Delete Photo"
 msgstr ""
 
-#: mod/photos.php:1200
+#: mod/photos.php:1202
 msgid "View photo"
 msgstr ""
 
-#: mod/photos.php:1202
+#: mod/photos.php:1204
 msgid "Edit photo"
 msgstr ""
 
-#: mod/photos.php:1203
+#: mod/photos.php:1205
 msgid "Delete photo"
 msgstr ""
 
-#: mod/photos.php:1204
+#: mod/photos.php:1206
 msgid "Use as profile photo"
 msgstr ""
 
-#: mod/photos.php:1211
+#: mod/photos.php:1213
 msgid "Private Photo"
 msgstr ""
 
-#: mod/photos.php:1217
+#: mod/photos.php:1219
 msgid "View Full Size"
 msgstr ""
 
@@ -2220,31 +2220,31 @@ msgstr ""
 msgid "Follow Thread"
 msgstr ""
 
-#: src/Content/Item.php:423 src/Model/Contact.php:1106
+#: src/Content/Item.php:423 src/Model/Contact.php:1107
 msgid "View Status"
 msgstr ""
 
-#: src/Content/Item.php:424 src/Content/Item.php:446 src/Model/Contact.php:1040
-#: src/Model/Contact.php:1098 src/Model/Contact.php:1107
+#: src/Content/Item.php:424 src/Content/Item.php:446 src/Model/Contact.php:1041
+#: src/Model/Contact.php:1099 src/Model/Contact.php:1108
 #: src/Module/Directory.php:158 src/Module/Settings/Profile/Index.php:225
 msgid "View Profile"
 msgstr ""
 
-#: src/Content/Item.php:425 src/Model/Contact.php:1108
+#: src/Content/Item.php:425 src/Model/Contact.php:1109
 msgid "View Photos"
 msgstr ""
 
-#: src/Content/Item.php:426 src/Model/Contact.php:1099
-#: src/Model/Contact.php:1109
+#: src/Content/Item.php:426 src/Model/Contact.php:1100
+#: src/Model/Contact.php:1110
 msgid "Network Posts"
 msgstr ""
 
-#: src/Content/Item.php:427 src/Model/Contact.php:1100
-#: src/Model/Contact.php:1110
+#: src/Content/Item.php:427 src/Model/Contact.php:1101
+#: src/Model/Contact.php:1111
 msgid "View Contact"
 msgstr ""
 
-#: src/Content/Item.php:428 src/Model/Contact.php:1111
+#: src/Content/Item.php:428 src/Model/Contact.php:1112
 msgid "Send PM"
 msgstr ""
 
@@ -2267,7 +2267,7 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
-#: src/Content/Item.php:438 src/Model/Contact.php:1112
+#: src/Content/Item.php:438 src/Model/Contact.php:1113
 msgid "Poke"
 msgstr ""
 
@@ -2719,7 +2719,7 @@ msgstr ""
 msgid "Organisations"
 msgstr ""
 
-#: src/Content/Widget.php:521 src/Model/Contact.php:1536
+#: src/Content/Widget.php:521 src/Model/Contact.php:1537
 msgid "News"
 msgstr ""
 
@@ -3547,81 +3547,81 @@ msgstr ""
 msgid "Legacy module file not found: %s"
 msgstr ""
 
-#: src/Model/Contact.php:1102 src/Model/Contact.php:1114
+#: src/Model/Contact.php:1103 src/Model/Contact.php:1115
 msgid "UnFollow"
 msgstr ""
 
-#: src/Model/Contact.php:1120 src/Module/Admin/Users/Pending.php:107
+#: src/Model/Contact.php:1121 src/Module/Admin/Users/Pending.php:107
 #: src/Module/Notifications/Introductions.php:130
 #: src/Module/Notifications/Introductions.php:202
 msgid "Approve"
 msgstr ""
 
-#: src/Model/Contact.php:1532
+#: src/Model/Contact.php:1533
 msgid "Organisation"
 msgstr ""
 
-#: src/Model/Contact.php:1540
+#: src/Model/Contact.php:1541
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:2516
+#: src/Model/Contact.php:2517
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:2521 src/Module/Friendica.php:81
+#: src/Model/Contact.php:2522 src/Module/Friendica.php:81
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:2526
+#: src/Model/Contact.php:2527
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:2535
+#: src/Model/Contact.php:2536
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:2577
+#: src/Model/Contact.php:2578
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:2579
+#: src/Model/Contact.php:2580
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:2582
+#: src/Model/Contact.php:2583
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:2585
+#: src/Model/Contact.php:2586
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:2588
+#: src/Model/Contact.php:2589
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:2589
+#: src/Model/Contact.php:2590
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:2595
+#: src/Model/Contact.php:2596
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:2600
+#: src/Model/Contact.php:2601
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:2659
+#: src/Model/Contact.php:2660
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -3860,83 +3860,83 @@ msgstr ""
 msgid "OpenWebAuth: %1$s welcomes %2$s"
 msgstr ""
 
-#: src/Model/Profile.php:986
+#: src/Model/Profile.php:980
 msgid "Hometown:"
 msgstr ""
 
-#: src/Model/Profile.php:987
+#: src/Model/Profile.php:981
 msgid "Marital Status:"
 msgstr ""
 
-#: src/Model/Profile.php:988
+#: src/Model/Profile.php:982
 msgid "With:"
 msgstr ""
 
-#: src/Model/Profile.php:989
+#: src/Model/Profile.php:983
 msgid "Since:"
 msgstr ""
 
-#: src/Model/Profile.php:990
+#: src/Model/Profile.php:984
 msgid "Sexual Preference:"
 msgstr ""
 
-#: src/Model/Profile.php:991
+#: src/Model/Profile.php:985
 msgid "Political Views:"
 msgstr ""
 
-#: src/Model/Profile.php:992
+#: src/Model/Profile.php:986
 msgid "Religious Views:"
 msgstr ""
 
-#: src/Model/Profile.php:993
+#: src/Model/Profile.php:987
 msgid "Likes:"
 msgstr ""
 
-#: src/Model/Profile.php:994
+#: src/Model/Profile.php:988
 msgid "Dislikes:"
 msgstr ""
 
-#: src/Model/Profile.php:995
+#: src/Model/Profile.php:989
 msgid "Title/Description:"
 msgstr ""
 
-#: src/Model/Profile.php:996 src/Module/Admin/Summary.php:234
+#: src/Model/Profile.php:990 src/Module/Admin/Summary.php:234
 msgid "Summary"
 msgstr ""
 
-#: src/Model/Profile.php:997
+#: src/Model/Profile.php:991
 msgid "Musical interests"
 msgstr ""
 
-#: src/Model/Profile.php:998
+#: src/Model/Profile.php:992
 msgid "Books, literature"
 msgstr ""
 
-#: src/Model/Profile.php:999
+#: src/Model/Profile.php:993
 msgid "Television"
 msgstr ""
 
-#: src/Model/Profile.php:1000
+#: src/Model/Profile.php:994
 msgid "Film/dance/culture/entertainment"
 msgstr ""
 
-#: src/Model/Profile.php:1001
+#: src/Model/Profile.php:995
 msgid "Hobbies/Interests"
 msgstr ""
 
-#: src/Model/Profile.php:1002
+#: src/Model/Profile.php:996
 msgid "Love/romance"
 msgstr ""
 
-#: src/Model/Profile.php:1003
+#: src/Model/Profile.php:997
 msgid "Work/employment"
 msgstr ""
 
-#: src/Model/Profile.php:1004
+#: src/Model/Profile.php:998
 msgid "School/education"
 msgstr ""
 
-#: src/Model/Profile.php:1005
+#: src/Model/Profile.php:999
 msgid "Contact information and Social Networks"
 msgstr ""
 
@@ -10016,8 +10016,12 @@ msgid ""
 "features and resources."
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/FormattedNavNotification.php:135
+#: src/Navigation/Notifications/Factory/FormattedNavNotification.php:134
 msgid "{0} wants to follow you"
+msgstr ""
+
+#: src/Navigation/Notifications/Factory/FormattedNavNotification.php:136
+msgid "{0} has started following you"
 msgstr ""
 
 #: src/Navigation/Notifications/Factory/FormattedNotify.php:91
@@ -10073,126 +10077,126 @@ msgstr ""
 msgid "New Follower"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:131
+#: src/Navigation/Notifications/Factory/Notification.php:130
 #, php-format
 msgid "%1$s wants to follow you"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:133
+#: src/Navigation/Notifications/Factory/Notification.php:132
 #, php-format
 msgid "%1$s has started following you"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:197
+#: src/Navigation/Notifications/Factory/Notification.php:196
 #, php-format
 msgid "%1$s liked your comment on %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:200
+#: src/Navigation/Notifications/Factory/Notification.php:199
 #, php-format
 msgid "%1$s liked your post %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:207
+#: src/Navigation/Notifications/Factory/Notification.php:206
 #, php-format
 msgid "%1$s disliked your comment on %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:210
+#: src/Navigation/Notifications/Factory/Notification.php:209
 #, php-format
 msgid "%1$s disliked your post %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:217
+#: src/Navigation/Notifications/Factory/Notification.php:216
 #, php-format
 msgid "%1$s shared your comment %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:220
+#: src/Navigation/Notifications/Factory/Notification.php:219
 #, php-format
 msgid "%1$s shared your post %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:224
-#: src/Navigation/Notifications/Factory/Notification.php:293
+#: src/Navigation/Notifications/Factory/Notification.php:223
+#: src/Navigation/Notifications/Factory/Notification.php:292
 #, php-format
 msgid "%1$s shared the post %2$s from %3$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:226
-#: src/Navigation/Notifications/Factory/Notification.php:295
+#: src/Navigation/Notifications/Factory/Notification.php:225
+#: src/Navigation/Notifications/Factory/Notification.php:294
 #, php-format
 msgid "%1$s shared a post from %3$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:228
-#: src/Navigation/Notifications/Factory/Notification.php:297
+#: src/Navigation/Notifications/Factory/Notification.php:227
+#: src/Navigation/Notifications/Factory/Notification.php:296
 #, php-format
 msgid "%1$s shared the post %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:230
-#: src/Navigation/Notifications/Factory/Notification.php:299
+#: src/Navigation/Notifications/Factory/Notification.php:229
+#: src/Navigation/Notifications/Factory/Notification.php:298
 #, php-format
 msgid "%1$s shared a post"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:238
+#: src/Navigation/Notifications/Factory/Notification.php:237
 #, php-format
 msgid "%1$s wants to attend your event %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:245
+#: src/Navigation/Notifications/Factory/Notification.php:244
 #, php-format
 msgid "%1$s does not want to attend your event %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:252
+#: src/Navigation/Notifications/Factory/Notification.php:251
 #, php-format
 msgid "%1$s maybe wants to attend your event %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:259
+#: src/Navigation/Notifications/Factory/Notification.php:258
 #, php-format
 msgid "%1$s tagged you on %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:263
+#: src/Navigation/Notifications/Factory/Notification.php:262
 #, php-format
 msgid "%1$s replied to you on %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:267
+#: src/Navigation/Notifications/Factory/Notification.php:266
 #, php-format
 msgid "%1$s commented in your thread %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:271
+#: src/Navigation/Notifications/Factory/Notification.php:270
 #, php-format
 msgid "%1$s commented on your comment %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:277
+#: src/Navigation/Notifications/Factory/Notification.php:276
 #, php-format
 msgid "%1$s commented in their thread %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:279
+#: src/Navigation/Notifications/Factory/Notification.php:278
 #, php-format
 msgid "%1$s commented in their thread"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:281
+#: src/Navigation/Notifications/Factory/Notification.php:280
 #, php-format
 msgid "%1$s commented in the thread %2$s from %3$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:283
+#: src/Navigation/Notifications/Factory/Notification.php:282
 #, php-format
 msgid "%1$s commented in the thread from %3$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Factory/Notification.php:288
+#: src/Navigation/Notifications/Factory/Notification.php:287
 #, php-format
 msgid "%1$s commented on your thread %2$s"
 msgstr ""


### PR DESCRIPTION
This fixes the issue that we always send "wants to follow you" even with accounts who automatically accept new contact requests. We now send a different text if appropriate.