### PR TITLE
Fix: Like/Dislike/Reshare actions should now be visible

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -115,6 +115,7 @@ function display_init(App $a)
 	if (\Friendica\Util\Network::isLocalLink($author['url'])) {
 		\Friendica\Model\Profile::load(DI::app(), $author['nick'], false);
 	} else {
+		$a->setProfileOwner($item['uid']);
 		DI::page()['aside'] = Widget\VCard::getHTML($author);
 	}
 }

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -819,7 +819,7 @@ class Conversation
 	{
 		$this->profiler->startRecording('rendering');
 
-		if ($row['uid'] == 0) {
+		if (!$row['writable']) {
 			$row['writable'] = in_array($row['network'], Protocol::FEDERATED);
 		}
 


### PR DESCRIPTION
When we aren't loading the profile we haven't set the profile owner - which resulted in sometimes invisible likedislike/reshare buttons.

... hopefully.