### PR TITLE
Rearrange the notification settings

### DIFF
--- a/src/Module/Settings/Account.php
+++ b/src/Module/Settings/Account.php
@@ -253,20 +253,6 @@ class Account extends BaseSettings
 			$notify_like     = !empty($request['notify_like']);
 			$notify_announce = !empty($request['notify_announce']);
 
-			// Reset like notifications when they are going to be shown again
-			if (!DI::pConfig()->get(local_user(), 'system', 'notify_like') && $notify_like) {
-				DI::notification()->setAllSeenForUser(local_user(), ['vid' => Verb::getID(Activity::LIKE)]);
-			}
-
-			DI::pConfig()->set(local_user(), 'system', 'notify_like', $notify_like);
-
-			// Reset share notifications when they are going to be shown again
-			if (!DI::pConfig()->get(local_user(), 'system', 'notify_announce') && $notify_announce) {
-				DI::notification()->setAllSeenForUser(local_user(), ['vid' => Verb::getID(Activity::ANNOUNCE)]);
-			}
-
-			DI::pConfig()->set(local_user(), 'system', 'notify_announce', $notify_announce);
-
 			$notify_type = 0;
 
 			if (!empty($request['notify_tagged'])) {
@@ -285,6 +271,25 @@ class Account extends BaseSettings
 				$notify_type = $notify_type | 32;
 			}
 			DI::pConfig()->set(local_user(), 'system', 'notify_type', $notify_type);
+
+			if (!($notify_type & 72)) {
+				$notify_like     = false;
+				$notify_announce = false;
+			}
+
+			// Reset like notifications when they are going to be shown again
+			if (!DI::pConfig()->get(local_user(), 'system', 'notify_like') && $notify_like) {
+				DI::notification()->setAllSeenForUser(local_user(), ['vid' => Verb::getID(Activity::LIKE)]);
+			}
+
+			DI::pConfig()->set(local_user(), 'system', 'notify_like', $notify_like);
+
+			// Reset share notifications when they are going to be shown again
+			if (!DI::pConfig()->get(local_user(), 'system', 'notify_announce') && $notify_announce) {
+				DI::notification()->setAllSeenForUser(local_user(), ['vid' => Verb::getID(Activity::ANNOUNCE)]);
+			}
+
+			DI::pConfig()->set(local_user(), 'system', 'notify_announce', $notify_announce);
 
 			DI::pConfig()->set(local_user(), 'system', 'email_textonly', !empty($request['email_textonly']));
 			DI::pConfig()->set(local_user(), 'system', 'detailed_notif', !empty($request['detailed_notif']));
@@ -610,12 +615,11 @@ class Account extends BaseSettings
 			'$notify7' => ['notify7', DI::l10n()->t('You are tagged in a post'), ($notify & Notification\Type::TAG_SELF), Notification\Type::TAG_SELF, ''],
 			'$notify8' => ['notify8', DI::l10n()->t('You are poked/prodded/etc. in a post'), ($notify & Notification\Type::POKE), Notification\Type::POKE, ''],
 
-			'$lbl_notify'      => DI::l10n()->t('Create a desktop notification when:'),
-			'$notify_like'     => ['notify_like', DI::l10n()->t('Someone liked your content'), DI::pConfig()->get(local_user(), 'system', 'notify_like'), ''],
-			'$notify_announce' => ['notify_announce', DI::l10n()->t('Someone shared your content'), DI::pConfig()->get(local_user(), 'system', 'notify_announce'), ''],
-
+			'$lbl_notify'                    => DI::l10n()->t('Create a desktop notification when:'),
 			'$notify_tagged'                 => ['notify_tagged', DI::l10n()->t('Someone tagged you'), $notify_type & 3, ''],
 			'$notify_direct_comment'         => ['notify_direct_comment', DI::l10n()->t('Someone directly commented on your post'), $notify_type & 72, ''],
+			'$notify_like'                   => ['notify_like', DI::l10n()->t('Someone liked your content'), DI::pConfig()->get(local_user(), 'system', 'notify_like'), DI::l10n()->t('Can only be enabled, when the direct comment notification is enabled.')],
+			'$notify_announce'               => ['notify_announce', DI::l10n()->t('Someone shared your content'), DI::pConfig()->get(local_user(), 'system', 'notify_announce'), DI::l10n()->t('Can only be enabled, when the direct comment notification is enabled.')],
 			'$notify_thread_comment'         => ['notify_thread_comment', DI::l10n()->t('Someone commented on your thread'), $notify_type & 4, ''],
 			'$notify_comment_participation'  => ['notify_comment_participation', DI::l10n()->t('Someone commented in a thread where you commented'), $notify_type & 16, ''],
 			'$notify_activity_participation' => ['notify_activity_participation', DI::l10n()->t('Someone commented on a thread where you interacted'), $notify_type & 32, ''],

--- a/src/Module/Settings/Account.php
+++ b/src/Module/Settings/Account.php
@@ -257,10 +257,10 @@ class Account extends BaseSettings
 			$notify_type = 0;
 
 			if (!empty($request['notify_tagged'])) {
-				$notify_type = $notify_type | (UserNotification::TYPE_EXPLICIT_TAGGED + UserNotification::TYPE_IMPLICIT_TAGGED);
+				$notify_type = $notify_type | UserNotification::TYPE_EXPLICIT_TAGGED;
 			}
 			if (!empty($request['notify_direct_comment'])) {
-				$notify_type = $notify_type | (UserNotification::TYPE_DIRECT_COMMENT + UserNotification::TYPE_DIRECT_THREAD_COMMENT);
+				$notify_type = $notify_type | (UserNotification::TYPE_IMPLICIT_TAGGED + UserNotification::TYPE_DIRECT_COMMENT + UserNotification::TYPE_DIRECT_THREAD_COMMENT);
 			}
 			if (!empty($request['notify_thread_comment'])) {
 				$notify_type = $notify_type | UserNotification::TYPE_THREAD_COMMENT;
@@ -549,7 +549,7 @@ class Account extends BaseSettings
 		/* Installed langs */
 		$lang_choices = DI::l10n()->getAvailableLanguages();
 
-		$notify_type = DI::pConfig()->get(local_user(), 'system', 'notify_type', 3 | 72 | 4 | 16 | 32);
+		$notify_type = DI::pConfig()->get(local_user(), 'system', 'notify_type');
 
 		$tpl = Renderer::getMarkupTemplate('settings/account.tpl');
 		$o   = Renderer::replaceMacros($tpl, [
@@ -617,13 +617,13 @@ class Account extends BaseSettings
 			'$notify8' => ['notify8', DI::l10n()->t('You are poked/prodded/etc. in a post'), ($notify & Notification\Type::POKE), Notification\Type::POKE, ''],
 
 			'$lbl_notify'                    => DI::l10n()->t('Create a desktop notification when:'),
-			'$notify_tagged'                 => ['notify_tagged', DI::l10n()->t('Someone tagged you'), $notify_type & (UserNotification::TYPE_EXPLICIT_TAGGED + UserNotification::TYPE_IMPLICIT_TAGGED), ''],
-			'$notify_direct_comment'         => ['notify_direct_comment', DI::l10n()->t('Someone directly commented on your post'), $notify_type & (UserNotification::TYPE_DIRECT_COMMENT + UserNotification::TYPE_DIRECT_THREAD_COMMENT), ''],
+			'$notify_tagged'                 => ['notify_tagged', DI::l10n()->t('Someone tagged you'), is_null($notify_type) || $notify_type & UserNotification::TYPE_EXPLICIT_TAGGED, ''],
+			'$notify_direct_comment'         => ['notify_direct_comment', DI::l10n()->t('Someone directly commented on your post'), is_null($notify_type) || $notify_type & (UserNotification::TYPE_IMPLICIT_TAGGED + UserNotification::TYPE_DIRECT_COMMENT + UserNotification::TYPE_DIRECT_THREAD_COMMENT), ''],
 			'$notify_like'                   => ['notify_like', DI::l10n()->t('Someone liked your content'), DI::pConfig()->get(local_user(), 'system', 'notify_like'), DI::l10n()->t('Can only be enabled, when the direct comment notification is enabled.')],
 			'$notify_announce'               => ['notify_announce', DI::l10n()->t('Someone shared your content'), DI::pConfig()->get(local_user(), 'system', 'notify_announce'), DI::l10n()->t('Can only be enabled, when the direct comment notification is enabled.')],
-			'$notify_thread_comment'         => ['notify_thread_comment', DI::l10n()->t('Someone commented on your thread'), $notify_type & UserNotification::TYPE_THREAD_COMMENT, ''],
-			'$notify_comment_participation'  => ['notify_comment_participation', DI::l10n()->t('Someone commented in a thread where you commented'), $notify_type & UserNotification::TYPE_COMMENT_PARTICIPATION, ''],
-			'$notify_activity_participation' => ['notify_activity_participation', DI::l10n()->t('Someone commented on a thread where you interacted'), $notify_type & UserNotification::TYPE_ACTIVITY_PARTICIPATION, ''],
+			'$notify_thread_comment'         => ['notify_thread_comment', DI::l10n()->t('Someone commented in your thread'), is_null($notify_type) || $notify_type & UserNotification::TYPE_THREAD_COMMENT, ''],
+			'$notify_comment_participation'  => ['notify_comment_participation', DI::l10n()->t('Someone commented in a thread where you commented'), is_null($notify_type) || $notify_type & UserNotification::TYPE_COMMENT_PARTICIPATION, ''],
+			'$notify_activity_participation' => ['notify_activity_participation', DI::l10n()->t('Someone commented in a thread where you interacted'), is_null($notify_type) || $notify_type & UserNotification::TYPE_ACTIVITY_PARTICIPATION, ''],
 
 			'$desktop_notifications' => ['desktop_notifications', DI::l10n()->t('Activate desktop notifications'), false, DI::l10n()->t('Show desktop popup on new notifications')],
 

--- a/src/Module/Settings/Account.php
+++ b/src/Module/Settings/Account.php
@@ -31,6 +31,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Group;
 use Friendica\Model\Notification;
+use Friendica\Model\Post\UserNotification;
 use Friendica\Model\Profile;
 use Friendica\Model\User;
 use Friendica\Model\Verb;
@@ -256,23 +257,23 @@ class Account extends BaseSettings
 			$notify_type = 0;
 
 			if (!empty($request['notify_tagged'])) {
-				$notify_type = $notify_type | 3;
+				$notify_type = $notify_type | (UserNotification::TYPE_EXPLICIT_TAGGED + UserNotification::TYPE_IMPLICIT_TAGGED);
 			}
 			if (!empty($request['notify_direct_comment'])) {
-				$notify_type = $notify_type | 72;
+				$notify_type = $notify_type | (UserNotification::TYPE_DIRECT_COMMENT + UserNotification::TYPE_DIRECT_THREAD_COMMENT);
 			}
 			if (!empty($request['notify_thread_comment'])) {
-				$notify_type = $notify_type | 4;
+				$notify_type = $notify_type | UserNotification::TYPE_THREAD_COMMENT;
 			}
 			if (!empty($request['notify_comment_participation'])) {
-				$notify_type = $notify_type | 16;
+				$notify_type = $notify_type | UserNotification::TYPE_COMMENT_PARTICIPATION;
 			}
 			if (!empty($request['notify_activity_participation'])) {
-				$notify_type = $notify_type | 32;
+				$notify_type = $notify_type | UserNotification::TYPE_ACTIVITY_PARTICIPATION;
 			}
 			DI::pConfig()->set(local_user(), 'system', 'notify_type', $notify_type);
 
-			if (!($notify_type & 72)) {
+			if (!($notify_type & (UserNotification::TYPE_DIRECT_COMMENT + UserNotification::TYPE_DIRECT_THREAD_COMMENT))) {
 				$notify_like     = false;
 				$notify_announce = false;
 			}
@@ -616,13 +617,13 @@ class Account extends BaseSettings
 			'$notify8' => ['notify8', DI::l10n()->t('You are poked/prodded/etc. in a post'), ($notify & Notification\Type::POKE), Notification\Type::POKE, ''],
 
 			'$lbl_notify'                    => DI::l10n()->t('Create a desktop notification when:'),
-			'$notify_tagged'                 => ['notify_tagged', DI::l10n()->t('Someone tagged you'), $notify_type & 3, ''],
-			'$notify_direct_comment'         => ['notify_direct_comment', DI::l10n()->t('Someone directly commented on your post'), $notify_type & 72, ''],
+			'$notify_tagged'                 => ['notify_tagged', DI::l10n()->t('Someone tagged you'), $notify_type & (UserNotification::TYPE_EXPLICIT_TAGGED + UserNotification::TYPE_IMPLICIT_TAGGED), ''],
+			'$notify_direct_comment'         => ['notify_direct_comment', DI::l10n()->t('Someone directly commented on your post'), $notify_type & (UserNotification::TYPE_DIRECT_COMMENT + UserNotification::TYPE_DIRECT_THREAD_COMMENT), ''],
 			'$notify_like'                   => ['notify_like', DI::l10n()->t('Someone liked your content'), DI::pConfig()->get(local_user(), 'system', 'notify_like'), DI::l10n()->t('Can only be enabled, when the direct comment notification is enabled.')],
 			'$notify_announce'               => ['notify_announce', DI::l10n()->t('Someone shared your content'), DI::pConfig()->get(local_user(), 'system', 'notify_announce'), DI::l10n()->t('Can only be enabled, when the direct comment notification is enabled.')],
-			'$notify_thread_comment'         => ['notify_thread_comment', DI::l10n()->t('Someone commented on your thread'), $notify_type & 4, ''],
-			'$notify_comment_participation'  => ['notify_comment_participation', DI::l10n()->t('Someone commented in a thread where you commented'), $notify_type & 16, ''],
-			'$notify_activity_participation' => ['notify_activity_participation', DI::l10n()->t('Someone commented on a thread where you interacted'), $notify_type & 32, ''],
+			'$notify_thread_comment'         => ['notify_thread_comment', DI::l10n()->t('Someone commented on your thread'), $notify_type & UserNotification::TYPE_THREAD_COMMENT, ''],
+			'$notify_comment_participation'  => ['notify_comment_participation', DI::l10n()->t('Someone commented in a thread where you commented'), $notify_type & UserNotification::TYPE_COMMENT_PARTICIPATION, ''],
+			'$notify_activity_participation' => ['notify_activity_participation', DI::l10n()->t('Someone commented on a thread where you interacted'), $notify_type & UserNotification::TYPE_ACTIVITY_PARTICIPATION, ''],
 
 			'$desktop_notifications' => ['desktop_notifications', DI::l10n()->t('Activate desktop notifications'), false, DI::l10n()->t('Show desktop popup on new notifications')],
 

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -675,9 +675,14 @@ class Notify extends BaseRepository
 			return true;
 		}
 
-		$notify_type = $this->pConfig->get($Notification->uid, 'system', 'notify_type', 3 | 72 | 4 | 16 | 32);
+		$notify_type = $this->pConfig->get($Notification->uid, 'system', 'notify_type');
 
-		if ($notify_type & $Notification->type) {
+		// Fallback for the case when the notify type isn't set at all
+		if (is_null($notify_type) && !in_array($type, [Notification::TYPE_RESHARE, Notification::TYPE_LIKE])) {
+				return true;
+		}
+
+		if (!is_null($notify_type) && ($notify_type & $Notification->type)) {
 			return true;
 		}
 

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -677,19 +677,7 @@ class Notify extends BaseRepository
 
 		$notify_type = $this->pConfig->get($Notification->uid, 'system', 'notify_type', 3 | 72 | 4 | 16 | 32);
 
-		if (($notify_type & 3) && in_array($Notification->type, [Model\Post\UserNotification::TYPE_EXPLICIT_TAGGED, Model\Post\UserNotification::TYPE_IMPLICIT_TAGGED])) {
-			return true;
-		}
-		if (($notify_type & 72) && in_array($Notification->type, [Model\Post\UserNotification::TYPE_DIRECT_COMMENT, Model\Post\UserNotification::TYPE_DIRECT_THREAD_COMMENT])) {
-			return true;
-		}
-		if (($notify_type & 4) && in_array($Notification->type, [Model\Post\UserNotification::TYPE_THREAD_COMMENT])) {
-			return true;
-		}
-		if (($notify_type & 16) && in_array($Notification->type, [Model\Post\UserNotification::TYPE_COMMENT_PARTICIPATION])) {
-			return true;
-		}
-		if (($notify_type & 32) && in_array($Notification->type, [Model\Post\UserNotification::TYPE_ACTIVITY_PARTICIPATION])) {
+		if ($notify_type & $Notification->type) {
 			return true;
 		}
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.05-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-05 21:17+0000\n"
+"POT-Creation-Date: 2022-06-06 07:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -138,8 +138,8 @@ msgstr ""
 #: src/Module/Profile/Schedule.php:39 src/Module/Profile/Schedule.php:56
 #: src/Module/Register.php:77 src/Module/Register.php:90
 #: src/Module/Register.php:206 src/Module/Register.php:245
-#: src/Module/Search/Directory.php:37 src/Module/Settings/Account.php:48
-#: src/Module/Settings/Account.php:408 src/Module/Settings/Delegation.php:42
+#: src/Module/Search/Directory.php:37 src/Module/Settings/Account.php:49
+#: src/Module/Settings/Account.php:409 src/Module/Settings/Delegation.php:42
 #: src/Module/Settings/Delegation.php:70 src/Module/Settings/Display.php:42
 #: src/Module/Settings/Display.php:120
 #: src/Module/Settings/Profile/Photo/Crop.php:166
@@ -1204,7 +1204,7 @@ msgstr ""
 #: mod/settings.php:352 src/Module/Admin/Addons/Index.php:69
 #: src/Module/Admin/Features.php:87 src/Module/Admin/Logs/Settings.php:81
 #: src/Module/Admin/Site.php:434 src/Module/Admin/Themes/Index.php:113
-#: src/Module/Admin/Tos.php:83 src/Module/Settings/Account.php:558
+#: src/Module/Admin/Tos.php:83 src/Module/Settings/Account.php:559
 #: src/Module/Settings/Delegation.php:170 src/Module/Settings/Display.php:193
 msgid "Save Settings"
 msgstr ""
@@ -1759,11 +1759,11 @@ msgstr ""
 msgid "Enter new password: "
 msgstr ""
 
-#: src/Console/User.php:210 src/Module/Settings/Account.php:73
+#: src/Console/User.php:210 src/Module/Settings/Account.php:74
 msgid "Password update failed. Please try again."
 msgstr ""
 
-#: src/Console/User.php:213 src/Module/Settings/Account.php:76
+#: src/Console/User.php:213 src/Module/Settings/Account.php:77
 msgid "Password changed."
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "News"
 msgstr ""
 
-#: src/Content/Widget.php:525 src/Module/Settings/Account.php:454
+#: src/Content/Widget.php:525 src/Module/Settings/Account.php:455
 msgid "Account Types"
 msgstr ""
 
@@ -4373,19 +4373,19 @@ msgstr ""
 msgid "List of pending user deletions"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:100 src/Module/Settings/Account.php:492
+#: src/Module/Admin/BaseUsers.php:100 src/Module/Settings/Account.php:493
 msgid "Normal Account Page"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:101 src/Module/Settings/Account.php:499
+#: src/Module/Admin/BaseUsers.php:101 src/Module/Settings/Account.php:500
 msgid "Soapbox Page"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:102 src/Module/Settings/Account.php:506
+#: src/Module/Admin/BaseUsers.php:102 src/Module/Settings/Account.php:507
 msgid "Public Forum"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:103 src/Module/Settings/Account.php:513
+#: src/Module/Admin/BaseUsers.php:103 src/Module/Settings/Account.php:514
 msgid "Automatic Friend Page"
 msgstr ""
 
@@ -4393,19 +4393,19 @@ msgstr ""
 msgid "Private Forum"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:107 src/Module/Settings/Account.php:464
+#: src/Module/Admin/BaseUsers.php:107 src/Module/Settings/Account.php:465
 msgid "Personal Page"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:108 src/Module/Settings/Account.php:471
+#: src/Module/Admin/BaseUsers.php:108 src/Module/Settings/Account.php:472
 msgid "Organisation Page"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:109 src/Module/Settings/Account.php:478
+#: src/Module/Admin/BaseUsers.php:109 src/Module/Settings/Account.php:479
 msgid "News Page"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:110 src/Module/Settings/Account.php:485
+#: src/Module/Admin/BaseUsers.php:110 src/Module/Settings/Account.php:486
 msgid "Community Forum"
 msgstr ""
 
@@ -8246,7 +8246,7 @@ msgid ""
 "\"btn btn-sm pull-right\">Cancel</a>"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:144 src/Module/Settings/Account.php:574
+#: src/Module/Profile/Profile.php:144 src/Module/Settings/Account.php:575
 msgid "Full Name:"
 msgstr ""
 
@@ -8376,7 +8376,7 @@ msgstr ""
 msgid "Please repeat your e-mail address:"
 msgstr ""
 
-#: src/Module/Register.php:162 src/Module/Settings/Account.php:565
+#: src/Module/Register.php:162 src/Module/Settings/Account.php:566
 msgid "New Password:"
 msgstr ""
 
@@ -8384,7 +8384,7 @@ msgstr ""
 msgid "Leave empty for an auto generated password."
 msgstr ""
 
-#: src/Module/Register.php:163 src/Module/Settings/Account.php:566
+#: src/Module/Register.php:163 src/Module/Settings/Account.php:567
 msgid "Confirm:"
 msgstr ""
 
@@ -8651,127 +8651,127 @@ msgstr ""
 msgid "Verify code and complete login"
 msgstr ""
 
-#: src/Module/Settings/Account.php:65
+#: src/Module/Settings/Account.php:66
 msgid "Passwords do not match."
 msgstr ""
 
-#: src/Module/Settings/Account.php:79
+#: src/Module/Settings/Account.php:80
 msgid "Password unchanged."
 msgstr ""
 
-#: src/Module/Settings/Account.php:94
+#: src/Module/Settings/Account.php:95
 msgid "Please use a shorter name."
 msgstr ""
 
-#: src/Module/Settings/Account.php:97
+#: src/Module/Settings/Account.php:98
 msgid "Name too short."
 msgstr ""
 
-#: src/Module/Settings/Account.php:106
+#: src/Module/Settings/Account.php:107
 msgid "Wrong Password."
 msgstr ""
 
-#: src/Module/Settings/Account.php:111
+#: src/Module/Settings/Account.php:112
 msgid "Invalid email."
 msgstr ""
 
-#: src/Module/Settings/Account.php:117
+#: src/Module/Settings/Account.php:118
 msgid "Cannot change to that email."
 msgstr ""
 
-#: src/Module/Settings/Account.php:147 src/Module/Settings/Account.php:199
-#: src/Module/Settings/Account.php:219 src/Module/Settings/Account.php:303
-#: src/Module/Settings/Account.php:352
+#: src/Module/Settings/Account.php:148 src/Module/Settings/Account.php:200
+#: src/Module/Settings/Account.php:220 src/Module/Settings/Account.php:304
+#: src/Module/Settings/Account.php:353
 msgid "Settings were not updated."
 msgstr ""
 
-#: src/Module/Settings/Account.php:364
+#: src/Module/Settings/Account.php:365
 msgid "Contact CSV file upload error"
 msgstr ""
 
-#: src/Module/Settings/Account.php:383
+#: src/Module/Settings/Account.php:384
 msgid "Importing Contacts done"
 msgstr ""
 
-#: src/Module/Settings/Account.php:396
+#: src/Module/Settings/Account.php:397
 msgid "Relocate message has been send to your contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:413
+#: src/Module/Settings/Account.php:414
 msgid "Unable to find your profile. Please contact your admin."
 msgstr ""
 
-#: src/Module/Settings/Account.php:455
+#: src/Module/Settings/Account.php:456
 msgid "Personal Page Subtypes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:456
+#: src/Module/Settings/Account.php:457
 msgid "Community Forum Subtypes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:466
+#: src/Module/Settings/Account.php:467
 msgid "Account for a personal profile."
 msgstr ""
 
-#: src/Module/Settings/Account.php:473
+#: src/Module/Settings/Account.php:474
 msgid ""
 "Account for an organisation that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:480
+#: src/Module/Settings/Account.php:481
 msgid ""
 "Account for a news reflector that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:487
+#: src/Module/Settings/Account.php:488
 msgid "Account for community discussions."
 msgstr ""
 
-#: src/Module/Settings/Account.php:494
+#: src/Module/Settings/Account.php:495
 msgid ""
 "Account for a regular personal profile that requires manual approval of "
 "\"Friends\" and \"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:501
+#: src/Module/Settings/Account.php:502
 msgid ""
 "Account for a public profile that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:508
+#: src/Module/Settings/Account.php:509
 msgid "Automatically approves all contact requests."
 msgstr ""
 
-#: src/Module/Settings/Account.php:515
+#: src/Module/Settings/Account.php:516
 msgid ""
 "Account for a popular profile that automatically approves contact requests "
 "as \"Friends\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:520
+#: src/Module/Settings/Account.php:521
 msgid "Private Forum [Experimental]"
 msgstr ""
 
-#: src/Module/Settings/Account.php:522
+#: src/Module/Settings/Account.php:523
 msgid "Requires manual approval of contact requests."
 msgstr ""
 
-#: src/Module/Settings/Account.php:531
+#: src/Module/Settings/Account.php:532
 msgid "OpenID:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:531
+#: src/Module/Settings/Account.php:532
 msgid "(Optional) Allow this OpenID to login to this account."
 msgstr ""
 
-#: src/Module/Settings/Account.php:539
+#: src/Module/Settings/Account.php:540
 msgid "Publish your profile in your local site directory?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:539
+#: src/Module/Settings/Account.php:540
 #, php-format
 msgid ""
 "Your profile will be published in this node's <a href=\"%s\">local "
@@ -8779,103 +8779,103 @@ msgid ""
 "system settings."
 msgstr ""
 
-#: src/Module/Settings/Account.php:545
+#: src/Module/Settings/Account.php:546
 #, php-format
 msgid ""
 "Your profile will also be published in the global friendica directories (e."
 "g. <a href=\"%s\">%s</a>)."
 msgstr ""
 
-#: src/Module/Settings/Account.php:555
+#: src/Module/Settings/Account.php:556
 msgid "Account Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:556
+#: src/Module/Settings/Account.php:557
 #, php-format
 msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
 msgstr ""
 
-#: src/Module/Settings/Account.php:564
+#: src/Module/Settings/Account.php:565
 msgid "Password Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:565
+#: src/Module/Settings/Account.php:566
 msgid ""
 "Allowed characters are a-z, A-Z, 0-9 and special characters except white "
 "spaces, accentuated letters and colon (:)."
 msgstr ""
 
-#: src/Module/Settings/Account.php:566
+#: src/Module/Settings/Account.php:567
 msgid "Leave password fields blank unless changing"
 msgstr ""
 
-#: src/Module/Settings/Account.php:567
+#: src/Module/Settings/Account.php:568
 msgid "Current Password:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:567
+#: src/Module/Settings/Account.php:568
 msgid "Your current password to confirm the changes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:568
+#: src/Module/Settings/Account.php:569
 msgid "Password:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:568
+#: src/Module/Settings/Account.php:569
 msgid "Your current password to confirm the changes of the email address"
 msgstr ""
 
-#: src/Module/Settings/Account.php:571
+#: src/Module/Settings/Account.php:572
 msgid "Delete OpenID URL"
 msgstr ""
 
-#: src/Module/Settings/Account.php:573
+#: src/Module/Settings/Account.php:574
 msgid "Basic Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:575
+#: src/Module/Settings/Account.php:576
 msgid "Email Address:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:576
+#: src/Module/Settings/Account.php:577
 msgid "Your Timezone:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:577
+#: src/Module/Settings/Account.php:578
 msgid "Your Language:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:577
+#: src/Module/Settings/Account.php:578
 msgid ""
 "Set the language we use to show you friendica interface and to send you "
 "emails"
 msgstr ""
 
-#: src/Module/Settings/Account.php:578
+#: src/Module/Settings/Account.php:579
 msgid "Default Post Location:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:579
+#: src/Module/Settings/Account.php:580
 msgid "Use Browser Location:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:581
+#: src/Module/Settings/Account.php:582
 msgid "Security and Privacy Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:583
+#: src/Module/Settings/Account.php:584
 msgid "Maximum Friend Requests/Day:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:583 src/Module/Settings/Account.php:593
+#: src/Module/Settings/Account.php:584 src/Module/Settings/Account.php:594
 msgid "(to prevent spam abuse)"
 msgstr ""
 
-#: src/Module/Settings/Account.php:585
+#: src/Module/Settings/Account.php:586
 msgid "Allow your profile to be searchable globally?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:585
+#: src/Module/Settings/Account.php:586
 msgid ""
 "Activate this setting if you want others to easily find and follow you. Your "
 "profile will be searchable on remote systems. This setting also determines "
@@ -8883,43 +8883,43 @@ msgid ""
 "indexed or not."
 msgstr ""
 
-#: src/Module/Settings/Account.php:586
+#: src/Module/Settings/Account.php:587
 msgid "Hide your contact/friend list from viewers of your profile?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:586
+#: src/Module/Settings/Account.php:587
 msgid ""
 "A list of your contacts is displayed on your profile page. Activate this "
 "option to disable the display of your contact list."
 msgstr ""
 
-#: src/Module/Settings/Account.php:587
+#: src/Module/Settings/Account.php:588
 msgid "Hide your profile details from anonymous viewers?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:587
+#: src/Module/Settings/Account.php:588
 msgid ""
 "Anonymous visitors will only see your profile picture, your display name and "
 "the nickname you are using on your profile page. Your public posts and "
 "replies will still be accessible by other means."
 msgstr ""
 
-#: src/Module/Settings/Account.php:588
+#: src/Module/Settings/Account.php:589
 msgid "Make public posts unlisted"
 msgstr ""
 
-#: src/Module/Settings/Account.php:588
+#: src/Module/Settings/Account.php:589
 msgid ""
 "Your public posts will not appear on the community pages or in search "
 "results, nor be sent to relay servers. However they can still appear on "
 "public feeds on remote servers."
 msgstr ""
 
-#: src/Module/Settings/Account.php:589
+#: src/Module/Settings/Account.php:590
 msgid "Make all posted pictures accessible"
 msgstr ""
 
-#: src/Module/Settings/Account.php:589
+#: src/Module/Settings/Account.php:590
 msgid ""
 "This option makes every posted picture accessible via the direct link. This "
 "is a workaround for the problem that most other networks can't handle "
@@ -8927,237 +8927,237 @@ msgid ""
 "public on your photo albums though."
 msgstr ""
 
-#: src/Module/Settings/Account.php:590
+#: src/Module/Settings/Account.php:591
 msgid "Allow friends to post to your profile page?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:590
+#: src/Module/Settings/Account.php:591
 msgid ""
 "Your contacts may write posts on your profile wall. These posts will be "
 "distributed to your contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:591
+#: src/Module/Settings/Account.php:592
 msgid "Allow friends to tag your posts?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:591
+#: src/Module/Settings/Account.php:592
 msgid "Your contacts can add additional tags to your posts."
 msgstr ""
 
-#: src/Module/Settings/Account.php:592
+#: src/Module/Settings/Account.php:593
 msgid "Permit unknown people to send you private mail?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:592
+#: src/Module/Settings/Account.php:593
 msgid ""
 "Friendica network users may send you private messages even if they are not "
 "in your contact list."
 msgstr ""
 
-#: src/Module/Settings/Account.php:593
+#: src/Module/Settings/Account.php:594
 msgid "Maximum private messages per day from unknown people:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:595
+#: src/Module/Settings/Account.php:596
 msgid "Default Post Permissions"
 msgstr ""
 
-#: src/Module/Settings/Account.php:599
+#: src/Module/Settings/Account.php:600
 msgid "Expiration settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:600
+#: src/Module/Settings/Account.php:601
 msgid "Automatically expire posts after this many days:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:600
+#: src/Module/Settings/Account.php:601
 msgid "If empty, posts will not expire. Expired posts will be deleted"
 msgstr ""
 
-#: src/Module/Settings/Account.php:601
+#: src/Module/Settings/Account.php:602
 msgid "Expire posts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:601
+#: src/Module/Settings/Account.php:602
 msgid "When activated, posts and comments will be expired."
 msgstr ""
 
-#: src/Module/Settings/Account.php:602
+#: src/Module/Settings/Account.php:603
 msgid "Expire personal notes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:602
+#: src/Module/Settings/Account.php:603
 msgid ""
 "When activated, the personal notes on your profile page will be expired."
 msgstr ""
 
-#: src/Module/Settings/Account.php:603
+#: src/Module/Settings/Account.php:604
 msgid "Expire starred posts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:603
+#: src/Module/Settings/Account.php:604
 msgid ""
 "Starring posts keeps them from being expired. That behaviour is overwritten "
 "by this setting."
 msgstr ""
 
-#: src/Module/Settings/Account.php:604
+#: src/Module/Settings/Account.php:605
 msgid "Only expire posts by others"
 msgstr ""
 
-#: src/Module/Settings/Account.php:604
+#: src/Module/Settings/Account.php:605
 msgid ""
 "When activated, your own posts never expire. Then the settings above are "
 "only valid for posts you received."
 msgstr ""
 
-#: src/Module/Settings/Account.php:607
+#: src/Module/Settings/Account.php:608
 msgid "Notification Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:608
+#: src/Module/Settings/Account.php:609
 msgid "Send a notification email when:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:609
+#: src/Module/Settings/Account.php:610
 msgid "You receive an introduction"
 msgstr ""
 
-#: src/Module/Settings/Account.php:610
+#: src/Module/Settings/Account.php:611
 msgid "Your introductions are confirmed"
 msgstr ""
 
-#: src/Module/Settings/Account.php:611
+#: src/Module/Settings/Account.php:612
 msgid "Someone writes on your profile wall"
 msgstr ""
 
-#: src/Module/Settings/Account.php:612
+#: src/Module/Settings/Account.php:613
 msgid "Someone writes a followup comment"
 msgstr ""
 
-#: src/Module/Settings/Account.php:613
+#: src/Module/Settings/Account.php:614
 msgid "You receive a private message"
 msgstr ""
 
-#: src/Module/Settings/Account.php:614
+#: src/Module/Settings/Account.php:615
 msgid "You receive a friend suggestion"
 msgstr ""
 
-#: src/Module/Settings/Account.php:615
+#: src/Module/Settings/Account.php:616
 msgid "You are tagged in a post"
 msgstr ""
 
-#: src/Module/Settings/Account.php:616
+#: src/Module/Settings/Account.php:617
 msgid "You are poked/prodded/etc. in a post"
 msgstr ""
 
-#: src/Module/Settings/Account.php:618
+#: src/Module/Settings/Account.php:619
 msgid "Create a desktop notification when:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:619
+#: src/Module/Settings/Account.php:620
 msgid "Someone tagged you"
 msgstr ""
 
-#: src/Module/Settings/Account.php:620
+#: src/Module/Settings/Account.php:621
 msgid "Someone directly commented on your post"
 msgstr ""
 
-#: src/Module/Settings/Account.php:621
+#: src/Module/Settings/Account.php:622
 msgid "Someone liked your content"
 msgstr ""
 
-#: src/Module/Settings/Account.php:621 src/Module/Settings/Account.php:622
+#: src/Module/Settings/Account.php:622 src/Module/Settings/Account.php:623
 msgid "Can only be enabled, when the direct comment notification is enabled."
 msgstr ""
 
-#: src/Module/Settings/Account.php:622
+#: src/Module/Settings/Account.php:623
 msgid "Someone shared your content"
 msgstr ""
 
-#: src/Module/Settings/Account.php:623
-msgid "Someone commented on your thread"
-msgstr ""
-
 #: src/Module/Settings/Account.php:624
-msgid "Someone commented in a thread where you commented"
+msgid "Someone commented in your thread"
 msgstr ""
 
 #: src/Module/Settings/Account.php:625
-msgid "Someone commented on a thread where you interacted"
+msgid "Someone commented in a thread where you commented"
 msgstr ""
 
-#: src/Module/Settings/Account.php:627
+#: src/Module/Settings/Account.php:626
+msgid "Someone commented in a thread where you interacted"
+msgstr ""
+
+#: src/Module/Settings/Account.php:628
 msgid "Activate desktop notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:627
+#: src/Module/Settings/Account.php:628
 msgid "Show desktop popup on new notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:631
+#: src/Module/Settings/Account.php:632
 msgid "Text-only notification emails"
 msgstr ""
 
-#: src/Module/Settings/Account.php:633
+#: src/Module/Settings/Account.php:634
 msgid "Send text only notification emails, without the html part"
 msgstr ""
 
-#: src/Module/Settings/Account.php:637
+#: src/Module/Settings/Account.php:638
 msgid "Show detailled notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:639
+#: src/Module/Settings/Account.php:640
 msgid ""
 "Per default, notifications are condensed to a single notification per item. "
 "When enabled every notification is displayed."
 msgstr ""
 
-#: src/Module/Settings/Account.php:643
+#: src/Module/Settings/Account.php:644
 msgid "Show notifications of ignored contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:645
+#: src/Module/Settings/Account.php:646
 msgid ""
 "You don't see posts from ignored contacts. But you still see their comments. "
 "This setting controls if you want to still receive regular notifications "
 "that are caused by ignored contacts or not."
 msgstr ""
 
-#: src/Module/Settings/Account.php:648
+#: src/Module/Settings/Account.php:649
 msgid "Advanced Account/Page Type Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:649
+#: src/Module/Settings/Account.php:650
 msgid "Change the behaviour of this account for special situations"
 msgstr ""
 
-#: src/Module/Settings/Account.php:652
+#: src/Module/Settings/Account.php:653
 msgid "Import Contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:653
+#: src/Module/Settings/Account.php:654
 msgid ""
 "Upload a CSV file that contains the handle of your followed accounts in the "
 "first column you exported from the old account."
 msgstr ""
 
-#: src/Module/Settings/Account.php:654
+#: src/Module/Settings/Account.php:655
 msgid "Upload File"
 msgstr ""
 
-#: src/Module/Settings/Account.php:657
+#: src/Module/Settings/Account.php:658
 msgid "Relocate"
 msgstr ""
 
-#: src/Module/Settings/Account.php:658
+#: src/Module/Settings/Account.php:659
 msgid ""
 "If you have moved this profile from another server, and some of your "
 "contacts don't receive your updates, try pushing this button."
 msgstr ""
 
-#: src/Module/Settings/Account.php:659
+#: src/Module/Settings/Account.php:660
 msgid "Resend relocate message to contacts"
 msgstr ""
 
@@ -10286,7 +10286,7 @@ msgid "%1$s commented on your thread %2$s"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:221
-#: src/Navigation/Notifications/Repository/Notify.php:742
+#: src/Navigation/Notifications/Repository/Notify.php:735
 msgid "[Friendica:Notify]"
 msgstr ""
 
@@ -10330,7 +10330,7 @@ msgid "%1$s commented on their %2$s %3$s"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:333
-#: src/Navigation/Notifications/Repository/Notify.php:776
+#: src/Navigation/Notifications/Repository/Notify.php:769
 #, php-format
 msgid "%1$s Comment to conversation #%2$d by %3$s"
 msgstr ""
@@ -10343,7 +10343,7 @@ msgstr ""
 #: src/Navigation/Notifications/Repository/Notify.php:339
 #: src/Navigation/Notifications/Repository/Notify.php:354
 #: src/Navigation/Notifications/Repository/Notify.php:373
-#: src/Navigation/Notifications/Repository/Notify.php:791
+#: src/Navigation/Notifications/Repository/Notify.php:784
 #, php-format
 msgid "Please visit %s to view and/or reply to the conversation."
 msgstr ""
@@ -10531,12 +10531,12 @@ msgstr ""
 msgid "Please visit %s to approve or reject the request."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:770
+#: src/Navigation/Notifications/Repository/Notify.php:763
 #, php-format
 msgid "%s %s tagged you"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:773
+#: src/Navigation/Notifications/Repository/Notify.php:766
 #, php-format
 msgid "%s %s shared a new post"
 msgstr ""

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.05-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-05 18:14+0000\n"
+"POT-Creation-Date: 2022-06-05 21:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -139,7 +139,7 @@ msgstr ""
 #: src/Module/Register.php:77 src/Module/Register.php:90
 #: src/Module/Register.php:206 src/Module/Register.php:245
 #: src/Module/Search/Directory.php:37 src/Module/Settings/Account.php:48
-#: src/Module/Settings/Account.php:403 src/Module/Settings/Delegation.php:42
+#: src/Module/Settings/Account.php:408 src/Module/Settings/Delegation.php:42
 #: src/Module/Settings/Delegation.php:70 src/Module/Settings/Display.php:42
 #: src/Module/Settings/Display.php:120
 #: src/Module/Settings/Profile/Photo/Crop.php:166
@@ -1204,7 +1204,7 @@ msgstr ""
 #: mod/settings.php:352 src/Module/Admin/Addons/Index.php:69
 #: src/Module/Admin/Features.php:87 src/Module/Admin/Logs/Settings.php:81
 #: src/Module/Admin/Site.php:434 src/Module/Admin/Themes/Index.php:113
-#: src/Module/Admin/Tos.php:83 src/Module/Settings/Account.php:553
+#: src/Module/Admin/Tos.php:83 src/Module/Settings/Account.php:558
 #: src/Module/Settings/Delegation.php:170 src/Module/Settings/Display.php:193
 msgid "Save Settings"
 msgstr ""
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "News"
 msgstr ""
 
-#: src/Content/Widget.php:525 src/Module/Settings/Account.php:449
+#: src/Content/Widget.php:525 src/Module/Settings/Account.php:454
 msgid "Account Types"
 msgstr ""
 
@@ -4373,19 +4373,19 @@ msgstr ""
 msgid "List of pending user deletions"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:100 src/Module/Settings/Account.php:487
+#: src/Module/Admin/BaseUsers.php:100 src/Module/Settings/Account.php:492
 msgid "Normal Account Page"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:101 src/Module/Settings/Account.php:494
+#: src/Module/Admin/BaseUsers.php:101 src/Module/Settings/Account.php:499
 msgid "Soapbox Page"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:102 src/Module/Settings/Account.php:501
+#: src/Module/Admin/BaseUsers.php:102 src/Module/Settings/Account.php:506
 msgid "Public Forum"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:103 src/Module/Settings/Account.php:508
+#: src/Module/Admin/BaseUsers.php:103 src/Module/Settings/Account.php:513
 msgid "Automatic Friend Page"
 msgstr ""
 
@@ -4393,19 +4393,19 @@ msgstr ""
 msgid "Private Forum"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:107 src/Module/Settings/Account.php:459
+#: src/Module/Admin/BaseUsers.php:107 src/Module/Settings/Account.php:464
 msgid "Personal Page"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:108 src/Module/Settings/Account.php:466
+#: src/Module/Admin/BaseUsers.php:108 src/Module/Settings/Account.php:471
 msgid "Organisation Page"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:109 src/Module/Settings/Account.php:473
+#: src/Module/Admin/BaseUsers.php:109 src/Module/Settings/Account.php:478
 msgid "News Page"
 msgstr ""
 
-#: src/Module/Admin/BaseUsers.php:110 src/Module/Settings/Account.php:480
+#: src/Module/Admin/BaseUsers.php:110 src/Module/Settings/Account.php:485
 msgid "Community Forum"
 msgstr ""
 
@@ -8246,7 +8246,7 @@ msgid ""
 "\"btn btn-sm pull-right\">Cancel</a>"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:144 src/Module/Settings/Account.php:569
+#: src/Module/Profile/Profile.php:144 src/Module/Settings/Account.php:574
 msgid "Full Name:"
 msgstr ""
 
@@ -8376,7 +8376,7 @@ msgstr ""
 msgid "Please repeat your e-mail address:"
 msgstr ""
 
-#: src/Module/Register.php:162 src/Module/Settings/Account.php:560
+#: src/Module/Register.php:162 src/Module/Settings/Account.php:565
 msgid "New Password:"
 msgstr ""
 
@@ -8384,7 +8384,7 @@ msgstr ""
 msgid "Leave empty for an auto generated password."
 msgstr ""
 
-#: src/Module/Register.php:163 src/Module/Settings/Account.php:561
+#: src/Module/Register.php:163 src/Module/Settings/Account.php:566
 msgid "Confirm:"
 msgstr ""
 
@@ -8680,98 +8680,98 @@ msgid "Cannot change to that email."
 msgstr ""
 
 #: src/Module/Settings/Account.php:147 src/Module/Settings/Account.php:199
-#: src/Module/Settings/Account.php:219 src/Module/Settings/Account.php:298
-#: src/Module/Settings/Account.php:347
+#: src/Module/Settings/Account.php:219 src/Module/Settings/Account.php:303
+#: src/Module/Settings/Account.php:352
 msgid "Settings were not updated."
 msgstr ""
 
-#: src/Module/Settings/Account.php:359
+#: src/Module/Settings/Account.php:364
 msgid "Contact CSV file upload error"
 msgstr ""
 
-#: src/Module/Settings/Account.php:378
+#: src/Module/Settings/Account.php:383
 msgid "Importing Contacts done"
 msgstr ""
 
-#: src/Module/Settings/Account.php:391
+#: src/Module/Settings/Account.php:396
 msgid "Relocate message has been send to your contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:408
+#: src/Module/Settings/Account.php:413
 msgid "Unable to find your profile. Please contact your admin."
 msgstr ""
 
-#: src/Module/Settings/Account.php:450
+#: src/Module/Settings/Account.php:455
 msgid "Personal Page Subtypes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:451
+#: src/Module/Settings/Account.php:456
 msgid "Community Forum Subtypes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:461
+#: src/Module/Settings/Account.php:466
 msgid "Account for a personal profile."
 msgstr ""
 
-#: src/Module/Settings/Account.php:468
+#: src/Module/Settings/Account.php:473
 msgid ""
 "Account for an organisation that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:475
+#: src/Module/Settings/Account.php:480
 msgid ""
 "Account for a news reflector that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:482
+#: src/Module/Settings/Account.php:487
 msgid "Account for community discussions."
 msgstr ""
 
-#: src/Module/Settings/Account.php:489
+#: src/Module/Settings/Account.php:494
 msgid ""
 "Account for a regular personal profile that requires manual approval of "
 "\"Friends\" and \"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:496
+#: src/Module/Settings/Account.php:501
 msgid ""
 "Account for a public profile that automatically approves contact requests as "
 "\"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:503
+#: src/Module/Settings/Account.php:508
 msgid "Automatically approves all contact requests."
 msgstr ""
 
-#: src/Module/Settings/Account.php:510
+#: src/Module/Settings/Account.php:515
 msgid ""
 "Account for a popular profile that automatically approves contact requests "
 "as \"Friends\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:515
+#: src/Module/Settings/Account.php:520
 msgid "Private Forum [Experimental]"
 msgstr ""
 
-#: src/Module/Settings/Account.php:517
+#: src/Module/Settings/Account.php:522
 msgid "Requires manual approval of contact requests."
 msgstr ""
 
-#: src/Module/Settings/Account.php:526
+#: src/Module/Settings/Account.php:531
 msgid "OpenID:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:526
+#: src/Module/Settings/Account.php:531
 msgid "(Optional) Allow this OpenID to login to this account."
 msgstr ""
 
-#: src/Module/Settings/Account.php:534
+#: src/Module/Settings/Account.php:539
 msgid "Publish your profile in your local site directory?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:534
+#: src/Module/Settings/Account.php:539
 #, php-format
 msgid ""
 "Your profile will be published in this node's <a href=\"%s\">local "
@@ -8779,103 +8779,103 @@ msgid ""
 "system settings."
 msgstr ""
 
-#: src/Module/Settings/Account.php:540
+#: src/Module/Settings/Account.php:545
 #, php-format
 msgid ""
 "Your profile will also be published in the global friendica directories (e."
 "g. <a href=\"%s\">%s</a>)."
 msgstr ""
 
-#: src/Module/Settings/Account.php:550
+#: src/Module/Settings/Account.php:555
 msgid "Account Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:551
+#: src/Module/Settings/Account.php:556
 #, php-format
 msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
 msgstr ""
 
-#: src/Module/Settings/Account.php:559
+#: src/Module/Settings/Account.php:564
 msgid "Password Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:560
+#: src/Module/Settings/Account.php:565
 msgid ""
 "Allowed characters are a-z, A-Z, 0-9 and special characters except white "
 "spaces, accentuated letters and colon (:)."
 msgstr ""
 
-#: src/Module/Settings/Account.php:561
+#: src/Module/Settings/Account.php:566
 msgid "Leave password fields blank unless changing"
 msgstr ""
 
-#: src/Module/Settings/Account.php:562
+#: src/Module/Settings/Account.php:567
 msgid "Current Password:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:562
+#: src/Module/Settings/Account.php:567
 msgid "Your current password to confirm the changes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:563
+#: src/Module/Settings/Account.php:568
 msgid "Password:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:563
+#: src/Module/Settings/Account.php:568
 msgid "Your current password to confirm the changes of the email address"
 msgstr ""
 
-#: src/Module/Settings/Account.php:566
+#: src/Module/Settings/Account.php:571
 msgid "Delete OpenID URL"
 msgstr ""
 
-#: src/Module/Settings/Account.php:568
+#: src/Module/Settings/Account.php:573
 msgid "Basic Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:570
+#: src/Module/Settings/Account.php:575
 msgid "Email Address:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:571
+#: src/Module/Settings/Account.php:576
 msgid "Your Timezone:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:572
+#: src/Module/Settings/Account.php:577
 msgid "Your Language:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:572
+#: src/Module/Settings/Account.php:577
 msgid ""
 "Set the language we use to show you friendica interface and to send you "
 "emails"
 msgstr ""
 
-#: src/Module/Settings/Account.php:573
+#: src/Module/Settings/Account.php:578
 msgid "Default Post Location:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:574
+#: src/Module/Settings/Account.php:579
 msgid "Use Browser Location:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:576
+#: src/Module/Settings/Account.php:581
 msgid "Security and Privacy Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:578
+#: src/Module/Settings/Account.php:583
 msgid "Maximum Friend Requests/Day:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:578 src/Module/Settings/Account.php:588
+#: src/Module/Settings/Account.php:583 src/Module/Settings/Account.php:593
 msgid "(to prevent spam abuse)"
 msgstr ""
 
-#: src/Module/Settings/Account.php:580
+#: src/Module/Settings/Account.php:585
 msgid "Allow your profile to be searchable globally?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:580
+#: src/Module/Settings/Account.php:585
 msgid ""
 "Activate this setting if you want others to easily find and follow you. Your "
 "profile will be searchable on remote systems. This setting also determines "
@@ -8883,43 +8883,43 @@ msgid ""
 "indexed or not."
 msgstr ""
 
-#: src/Module/Settings/Account.php:581
+#: src/Module/Settings/Account.php:586
 msgid "Hide your contact/friend list from viewers of your profile?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:581
+#: src/Module/Settings/Account.php:586
 msgid ""
 "A list of your contacts is displayed on your profile page. Activate this "
 "option to disable the display of your contact list."
 msgstr ""
 
-#: src/Module/Settings/Account.php:582
+#: src/Module/Settings/Account.php:587
 msgid "Hide your profile details from anonymous viewers?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:582
+#: src/Module/Settings/Account.php:587
 msgid ""
 "Anonymous visitors will only see your profile picture, your display name and "
 "the nickname you are using on your profile page. Your public posts and "
 "replies will still be accessible by other means."
 msgstr ""
 
-#: src/Module/Settings/Account.php:583
+#: src/Module/Settings/Account.php:588
 msgid "Make public posts unlisted"
 msgstr ""
 
-#: src/Module/Settings/Account.php:583
+#: src/Module/Settings/Account.php:588
 msgid ""
 "Your public posts will not appear on the community pages or in search "
 "results, nor be sent to relay servers. However they can still appear on "
 "public feeds on remote servers."
 msgstr ""
 
-#: src/Module/Settings/Account.php:584
+#: src/Module/Settings/Account.php:589
 msgid "Make all posted pictures accessible"
 msgstr ""
 
-#: src/Module/Settings/Account.php:584
+#: src/Module/Settings/Account.php:589
 msgid ""
 "This option makes every posted picture accessible via the direct link. This "
 "is a workaround for the problem that most other networks can't handle "
@@ -8927,233 +8927,237 @@ msgid ""
 "public on your photo albums though."
 msgstr ""
 
-#: src/Module/Settings/Account.php:585
+#: src/Module/Settings/Account.php:590
 msgid "Allow friends to post to your profile page?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:585
+#: src/Module/Settings/Account.php:590
 msgid ""
 "Your contacts may write posts on your profile wall. These posts will be "
 "distributed to your contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:586
+#: src/Module/Settings/Account.php:591
 msgid "Allow friends to tag your posts?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:586
+#: src/Module/Settings/Account.php:591
 msgid "Your contacts can add additional tags to your posts."
 msgstr ""
 
-#: src/Module/Settings/Account.php:587
+#: src/Module/Settings/Account.php:592
 msgid "Permit unknown people to send you private mail?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:587
+#: src/Module/Settings/Account.php:592
 msgid ""
 "Friendica network users may send you private messages even if they are not "
 "in your contact list."
 msgstr ""
 
-#: src/Module/Settings/Account.php:588
+#: src/Module/Settings/Account.php:593
 msgid "Maximum private messages per day from unknown people:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:590
+#: src/Module/Settings/Account.php:595
 msgid "Default Post Permissions"
 msgstr ""
 
-#: src/Module/Settings/Account.php:594
+#: src/Module/Settings/Account.php:599
 msgid "Expiration settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:595
+#: src/Module/Settings/Account.php:600
 msgid "Automatically expire posts after this many days:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:595
+#: src/Module/Settings/Account.php:600
 msgid "If empty, posts will not expire. Expired posts will be deleted"
 msgstr ""
 
-#: src/Module/Settings/Account.php:596
+#: src/Module/Settings/Account.php:601
 msgid "Expire posts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:596
+#: src/Module/Settings/Account.php:601
 msgid "When activated, posts and comments will be expired."
 msgstr ""
 
-#: src/Module/Settings/Account.php:597
+#: src/Module/Settings/Account.php:602
 msgid "Expire personal notes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:597
+#: src/Module/Settings/Account.php:602
 msgid ""
 "When activated, the personal notes on your profile page will be expired."
 msgstr ""
 
-#: src/Module/Settings/Account.php:598
+#: src/Module/Settings/Account.php:603
 msgid "Expire starred posts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:598
+#: src/Module/Settings/Account.php:603
 msgid ""
 "Starring posts keeps them from being expired. That behaviour is overwritten "
 "by this setting."
 msgstr ""
 
-#: src/Module/Settings/Account.php:599
+#: src/Module/Settings/Account.php:604
 msgid "Only expire posts by others"
 msgstr ""
 
-#: src/Module/Settings/Account.php:599
+#: src/Module/Settings/Account.php:604
 msgid ""
 "When activated, your own posts never expire. Then the settings above are "
 "only valid for posts you received."
 msgstr ""
 
-#: src/Module/Settings/Account.php:602
+#: src/Module/Settings/Account.php:607
 msgid "Notification Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:603
+#: src/Module/Settings/Account.php:608
 msgid "Send a notification email when:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:604
+#: src/Module/Settings/Account.php:609
 msgid "You receive an introduction"
 msgstr ""
 
-#: src/Module/Settings/Account.php:605
+#: src/Module/Settings/Account.php:610
 msgid "Your introductions are confirmed"
 msgstr ""
 
-#: src/Module/Settings/Account.php:606
+#: src/Module/Settings/Account.php:611
 msgid "Someone writes on your profile wall"
 msgstr ""
 
-#: src/Module/Settings/Account.php:607
+#: src/Module/Settings/Account.php:612
 msgid "Someone writes a followup comment"
 msgstr ""
 
-#: src/Module/Settings/Account.php:608
+#: src/Module/Settings/Account.php:613
 msgid "You receive a private message"
 msgstr ""
 
-#: src/Module/Settings/Account.php:609
+#: src/Module/Settings/Account.php:614
 msgid "You receive a friend suggestion"
 msgstr ""
 
-#: src/Module/Settings/Account.php:610
+#: src/Module/Settings/Account.php:615
 msgid "You are tagged in a post"
 msgstr ""
 
-#: src/Module/Settings/Account.php:611
+#: src/Module/Settings/Account.php:616
 msgid "You are poked/prodded/etc. in a post"
 msgstr ""
 
-#: src/Module/Settings/Account.php:613
+#: src/Module/Settings/Account.php:618
 msgid "Create a desktop notification when:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:614
-msgid "Someone liked your content"
-msgstr ""
-
-#: src/Module/Settings/Account.php:615
-msgid "Someone shared your content"
-msgstr ""
-
-#: src/Module/Settings/Account.php:617
+#: src/Module/Settings/Account.php:619
 msgid "Someone tagged you"
 msgstr ""
 
-#: src/Module/Settings/Account.php:618
+#: src/Module/Settings/Account.php:620
 msgid "Someone directly commented on your post"
 msgstr ""
 
-#: src/Module/Settings/Account.php:619
+#: src/Module/Settings/Account.php:621
+msgid "Someone liked your content"
+msgstr ""
+
+#: src/Module/Settings/Account.php:621 src/Module/Settings/Account.php:622
+msgid "Can only be enabled, when the direct comment notification is enabled."
+msgstr ""
+
+#: src/Module/Settings/Account.php:622
+msgid "Someone shared your content"
+msgstr ""
+
+#: src/Module/Settings/Account.php:623
 msgid "Someone commented on your thread"
 msgstr ""
 
-#: src/Module/Settings/Account.php:620
+#: src/Module/Settings/Account.php:624
 msgid "Someone commented in a thread where you commented"
 msgstr ""
 
-#: src/Module/Settings/Account.php:621
+#: src/Module/Settings/Account.php:625
 msgid "Someone commented on a thread where you interacted"
 msgstr ""
 
-#: src/Module/Settings/Account.php:623
+#: src/Module/Settings/Account.php:627
 msgid "Activate desktop notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:623
+#: src/Module/Settings/Account.php:627
 msgid "Show desktop popup on new notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:627
+#: src/Module/Settings/Account.php:631
 msgid "Text-only notification emails"
 msgstr ""
 
-#: src/Module/Settings/Account.php:629
+#: src/Module/Settings/Account.php:633
 msgid "Send text only notification emails, without the html part"
 msgstr ""
 
-#: src/Module/Settings/Account.php:633
+#: src/Module/Settings/Account.php:637
 msgid "Show detailled notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:635
+#: src/Module/Settings/Account.php:639
 msgid ""
 "Per default, notifications are condensed to a single notification per item. "
 "When enabled every notification is displayed."
 msgstr ""
 
-#: src/Module/Settings/Account.php:639
+#: src/Module/Settings/Account.php:643
 msgid "Show notifications of ignored contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:641
+#: src/Module/Settings/Account.php:645
 msgid ""
 "You don't see posts from ignored contacts. But you still see their comments. "
 "This setting controls if you want to still receive regular notifications "
 "that are caused by ignored contacts or not."
 msgstr ""
 
-#: src/Module/Settings/Account.php:644
+#: src/Module/Settings/Account.php:648
 msgid "Advanced Account/Page Type Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:645
+#: src/Module/Settings/Account.php:649
 msgid "Change the behaviour of this account for special situations"
 msgstr ""
 
-#: src/Module/Settings/Account.php:648
+#: src/Module/Settings/Account.php:652
 msgid "Import Contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:649
+#: src/Module/Settings/Account.php:653
 msgid ""
 "Upload a CSV file that contains the handle of your followed accounts in the "
 "first column you exported from the old account."
 msgstr ""
 
-#: src/Module/Settings/Account.php:650
+#: src/Module/Settings/Account.php:654
 msgid "Upload File"
 msgstr ""
 
-#: src/Module/Settings/Account.php:653
+#: src/Module/Settings/Account.php:657
 msgid "Relocate"
 msgstr ""
 
-#: src/Module/Settings/Account.php:654
+#: src/Module/Settings/Account.php:658
 msgid ""
 "If you have moved this profile from another server, and some of your "
 "contacts don't receive your updates, try pushing this button."
 msgstr ""
 
-#: src/Module/Settings/Account.php:655
+#: src/Module/Settings/Account.php:659
 msgid "Resend relocate message to contacts"
 msgstr ""
 

--- a/view/templates/settings/account.tpl
+++ b/view/templates/settings/account.tpl
@@ -107,10 +107,10 @@
 			<div id="settings-notify-desc">{{$lbl_notify}}</div>
 
 			<div class="group">
-				{{include file="field_checkbox.tpl" field=$notify_like}}
-				{{include file="field_checkbox.tpl" field=$notify_announce}}
 				{{include file="field_checkbox.tpl" field=$notify_tagged}}
 				{{include file="field_checkbox.tpl" field=$notify_direct_comment}}
+				{{include file="field_checkbox.tpl" field=$notify_like}}
+				{{include file="field_checkbox.tpl" field=$notify_announce}}
 				{{include file="field_checkbox.tpl" field=$notify_thread_comment}}
 				{{include file="field_checkbox.tpl" field=$notify_comment_participation}}
 				{{include file="field_checkbox.tpl" field=$notify_activity_participation}}

--- a/view/theme/frio/templates/settings/account.tpl
+++ b/view/theme/frio/templates/settings/account.tpl
@@ -158,10 +158,10 @@
 						<div id="settings-notify-desc">{{$lbl_notify}}</div>
 
 						<div class="group">
-							{{include file="field_checkbox.tpl" field=$notify_like}}
-							{{include file="field_checkbox.tpl" field=$notify_announce}}
 							{{include file="field_checkbox.tpl" field=$notify_tagged}}
 							{{include file="field_checkbox.tpl" field=$notify_direct_comment}}
+							{{include file="field_checkbox.tpl" field=$notify_like}}
+							{{include file="field_checkbox.tpl" field=$notify_announce}}
 							{{include file="field_checkbox.tpl" field=$notify_thread_comment}}
 							{{include file="field_checkbox.tpl" field=$notify_comment_participation}}
 							{{include file="field_checkbox.tpl" field=$notify_activity_participation}}


### PR DESCRIPTION
The notification for a "like" or a reshare does only work when the notification for direct comments is enabled.