### PR TITLE
Only update when new content arrives

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -38,6 +38,7 @@ use Friendica\Network\HTTPException;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\DFRN;
 use Friendica\Protocol\Diaspora;
+use Friendica\Util\DateTimeFormat;
 
 function display_init(App $a)
 {
@@ -115,9 +116,9 @@ function display_init(App $a)
 	if (\Friendica\Util\Network::isLocalLink($author['url'])) {
 		\Friendica\Model\Profile::load(DI::app(), $author['nick'], false);
 	} else {
-		$a->setProfileOwner($item['uid']);
 		DI::page()['aside'] = Widget\VCard::getHTML($author);
 	}
+	$a->setProfileOwner($item['uid']);
 }
 
 function display_fetchauthor($item)
@@ -158,6 +159,16 @@ function display_content(App $a, $update = false, $update_uid = 0)
 				$a->setProfileOwner($update_uid);
 			}
 			$parent_uri_id = $item['parent-uri-id'];
+		}
+		$browser_update = intval(DI::pConfig()->get($update_uid, 'system', 'update_interval'));
+		if (!empty($browser_update)) {
+			$update_date = date(DateTimeFormat::MYSQL, time() - ($browser_update / 500));
+			if (!Post::exists(["`parent-uri-id` = ? AND `uid` IN (?, ?) AND `received` > ?", $parent_uri_id, 0, $update_uid, $update_date])) {
+				Logger::debug('No updated content', ['uri-id' => $uri_id, 'uid' => $update_uid, 'updated' => $update_date]);
+				return '';
+			} else {
+				Logger::debug('Updated content found', ['uri-id' => $uri_id, 'uid' => $update_uid, 'updated' => $update_date]);
+			}
 		}
 	} else {
 		$uri_id = ((DI::args()->getArgc() > 2) ? DI::args()->getArgv()[2] : 0);


### PR DESCRIPTION
We should only update content on the 'display' page when there is new content. Also this fixes the issue with the "reshare" button on content from users from the same system.