### PR TITLE
API: Use the type field in the query for pinned posts

### DIFF
--- a/src/Module/Api/Mastodon/Accounts/Statuses.php
+++ b/src/Module/Api/Mastodon/Accounts/Statuses.php
@@ -68,7 +68,7 @@ class Statuses extends BaseApi
 		$params = ['order' => ['uri-id' => true], 'limit' => $request['limit']];
 
 		if ($request['pinned']) {
-			$condition = ['author-id' => $id, 'private' => [Item::PUBLIC, Item::UNLISTED]];
+			$condition = ['author-id' => $id, 'private' => [Item::PUBLIC, Item::UNLISTED], 'type' => Post\Collection::FEATURED];
 		} elseif (!$uid) {
 			$condition = ['author-id' => $id, 'private' => [Item::PUBLIC, Item::UNLISTED],
 				'uid' => 0, 'network' => Protocol::FEDERATED];


### PR DESCRIPTION
This is just a small addition to the previous PR. Currently the collection table only contains featured posts. But we should use the `type` variable anyway.