### PR TITLE
Accesskey was used twice

### DIFF
--- a/doc/Accesskeys.md
+++ b/doc/Accesskeys.md
@@ -82,6 +82,7 @@ General
 ../settings
 ---------
 * o - Account
+* 2 - Two-factor authentication
 * p - Profiles
 * t - Additional features
 * w - Social Networks

--- a/src/Module/BaseSettings.php
+++ b/src/Module/BaseSettings.php
@@ -48,7 +48,7 @@ class BaseSettings extends BaseModule
 			'label' => DI::l10n()->t('Two-factor authentication'),
 			'url' => 'settings/2fa',
 			'selected' => ((DI::args()->getArgc() > 1) && (DI::args()->getArgv()[1] === '2fa') ? 'active' : ''),
-			'accesskey' => 'o',
+			'accesskey' => '2',
 		];
 
 		$tabs[] = [


### PR DESCRIPTION
The accesskey on the User Settings pages for the _account settings_ and the _two factor authentication_ were the same. This PR is assinging a new one to the 2FA.