### PR TITLE
Add missing identifier quote in Database->replaceInTableFields

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1820,7 +1820,7 @@ class Database
 
 		$upds = implode(', ', $upd);
 
-		$r = $this->e(sprintf("UPDATE %s SET %s;", $table_name, $upds));
+		$r = $this->e(sprintf("UPDATE %s SET %s;", DBA::quoteIdentifier($table_name), $upds));
 		if (!$this->isResult($r)) {
 			throw new \RuntimeException("Failed updating `$table_name`: " . $this->errorMessage());
 		}


### PR DESCRIPTION
- This caused hyphenated table names to fail the replace query

Address https://github.com/friendica/friendica/issues/11511#issuecomment-1159777175

Thanks @ThRPctmylSgltwH for the report!