### PR TITLE
Renamings in logger class to make them more clear

### DIFF
--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -47,7 +47,7 @@ class Logger
 	/**
 	 * @return LoggerInterface
 	 */
-	private static function getWorker()
+	private static function getLogger()
 	{
 		if (self::$type === self::TYPE_LOGGER) {
 			return DI::logger();
@@ -66,7 +66,7 @@ class Logger
 	public static function enableWorker(string $functionName)
 	{
 		self::$type = self::TYPE_WORKER;
-		self::getWorker()->setFunctionName($functionName);
+		self::getLogger()->setFunctionName($functionName);
 	}
 
 	/**
@@ -82,15 +82,14 @@ class Logger
 	 *
 	 * @see LoggerInterface::emergency()
 	 *
-	 * @param string $message
-	 * @param array  $context
-	 *
+	 * @param string $message Message to log
+	 * @param array  $context Optional variables
 	 * @return void
 	 * @throws \Exception
 	 */
-	public static function emergency($message, $context = [])
+	public static function emergency(string $message, array $context = [])
 	{
-		self::getWorker()->emergency($message, $context);
+		self::getLogger()->emergency($message, $context);
 	}
 
 	/**
@@ -100,15 +99,14 @@ class Logger
 	 * Example: Entire website down, database unavailable, etc. This should
 	 * trigger the SMS alerts and wake you up.
 	 *
-	 * @param string $message
-	 * @param array  $context
-	 *
+	 * @param string $message Message to log
+	 * @param array  $context Optional variables
 	 * @return void
 	 * @throws \Exception
 	 */
-	public static function alert($message, $context = [])
+	public static function alert(string $message, array $context = [])
 	{
-		self::getWorker()->alert($message, $context);
+		self::getLogger()->alert($message, $context);
 	}
 
 	/**
@@ -117,15 +115,14 @@ class Logger
 	 *
 	 * Example: Application component unavailable, unexpected exception.
 	 *
-	 * @param string $message
-	 * @param array  $context
-	 *
+	 * @param string $message Message to log
+	 * @param array  $context Optional variables
 	 * @return void
 	 * @throws \Exception
 	 */
-	public static function critical($message, $context = [])
+	public static function critical(string $message, array $context = [])
 	{
-		self::getWorker()->critical($message, $context);
+		self::getLogger()->critical($message, $context);
 	}
 
 	/**
@@ -133,15 +130,14 @@ class Logger
 	 * be logged and monitored.
 	 * @see LoggerInterface::error()
 	 *
-	 * @param string $message
-	 * @param array  $context
-	 *
+	 * @param string $message Message to log
+	 * @param array  $context Optional variables
 	 * @return void
 	 * @throws \Exception
 	 */
-	public static function error($message, $context = [])
+	public static function error(string $message, array $context = [])
 	{
-		self::getWorker()->error($message, $context);
+		self::getLogger()->error($message, $context);
 	}
 
 	/**
@@ -151,30 +147,28 @@ class Logger
 	 * Example: Use of deprecated APIs, poor use of an API, undesirable things
 	 * that are not necessarily wrong.
 	 *
-	 * @param string $message
-	 * @param array  $context
-	 *
+	 * @param string $message Message to log
+	 * @param array  $context Optional variables
 	 * @return void
 	 * @throws \Exception
 	 */
-	public static function warning($message, $context = [])
+	public static function warning(string $message, array $context = [])
 	{
-		self::getWorker()->warning($message, $context);
+		self::getLogger()->warning($message, $context);
 	}
 
 	/**
 	 * Normal but significant events.
 	 * @see LoggerInterface::notice()
 	 *
-	 * @param string $message
-	 * @param array  $context
-	 *
+	 * @param string $message Message to log
+	 * @param array  $context Optional variables
 	 * @return void
 	 * @throws \Exception
 	 */
-	public static function notice($message, $context = [])
+	public static function notice(string $message, array $context = [])
 	{
-		self::getWorker()->notice($message, $context);
+		self::getLogger()->notice($message, $context);
 	}
 
 	/**
@@ -189,24 +183,23 @@ class Logger
 	 * @return void
 	 * @throws \Exception
 	 */
-	public static function info($message, $context = [])
+	public static function info(string $message, array $context = [])
 	{
-		self::getWorker()->info($message, $context);
+		self::getLogger()->info($message, $context);
 	}
 
 	/**
 	 * Detailed debug information.
 	 * @see LoggerInterface::debug()
 	 *
-	 * @param string $message
-	 * @param array  $context
-	 *
+	 * @param string $message Message to log
+	 * @param array  $context Optional variables
 	 * @return void
 	 * @throws \Exception
 	 */
-	public static function debug($message, $context = [])
+	public static function debug(string $message, array $context = [])
 	{
-		self::getWorker()->debug($message, $context);
+		self::getLogger()->debug($message, $context);
 	}
 
 	/**
@@ -216,12 +209,13 @@ class Logger
 	 * to isolate particular elements they are targetting
 	 * personally without background noise
 	 *
-	 * @param string $msg
-	 * @param string $level
+	 * @param string $message Message to log
+	 * @param string $level Logging level
+	 * @return void
 	 * @throws \Exception
 	 */
-	public static function devLog($msg, $level = LogLevel::DEBUG)
+	public static function devLog(string $message, string $level = LogLevel::DEBUG)
 	{
-		DI::devLogger()->log($level, $msg);
+		DI::devLogger()->log($level, $message);
 	}
 }

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -47,7 +47,7 @@ class Logger
 	/**
 	 * @return LoggerInterface
 	 */
-	private static function getLogger()
+	private static function getInstance()
 	{
 		if (self::$type === self::TYPE_LOGGER) {
 			return DI::logger();
@@ -66,7 +66,7 @@ class Logger
 	public static function enableWorker(string $functionName)
 	{
 		self::$type = self::TYPE_WORKER;
-		self::getLogger()->setFunctionName($functionName);
+		self::getInstance()->setFunctionName($functionName);
 	}
 
 	/**
@@ -89,7 +89,7 @@ class Logger
 	 */
 	public static function emergency(string $message, array $context = [])
 	{
-		self::getLogger()->emergency($message, $context);
+		self::getInstance()->emergency($message, $context);
 	}
 
 	/**
@@ -106,7 +106,7 @@ class Logger
 	 */
 	public static function alert(string $message, array $context = [])
 	{
-		self::getLogger()->alert($message, $context);
+		self::getInstance()->alert($message, $context);
 	}
 
 	/**
@@ -122,7 +122,7 @@ class Logger
 	 */
 	public static function critical(string $message, array $context = [])
 	{
-		self::getLogger()->critical($message, $context);
+		self::getInstance()->critical($message, $context);
 	}
 
 	/**
@@ -137,7 +137,7 @@ class Logger
 	 */
 	public static function error(string $message, array $context = [])
 	{
-		self::getLogger()->error($message, $context);
+		self::getInstance()->error($message, $context);
 	}
 
 	/**
@@ -154,7 +154,7 @@ class Logger
 	 */
 	public static function warning(string $message, array $context = [])
 	{
-		self::getLogger()->warning($message, $context);
+		self::getInstance()->warning($message, $context);
 	}
 
 	/**
@@ -168,7 +168,7 @@ class Logger
 	 */
 	public static function notice(string $message, array $context = [])
 	{
-		self::getLogger()->notice($message, $context);
+		self::getInstance()->notice($message, $context);
 	}
 
 	/**
@@ -185,7 +185,7 @@ class Logger
 	 */
 	public static function info(string $message, array $context = [])
 	{
-		self::getLogger()->info($message, $context);
+		self::getInstance()->info($message, $context);
 	}
 
 	/**
@@ -199,7 +199,7 @@ class Logger
 	 */
 	public static function debug(string $message, array $context = [])
 	{
-		self::getLogger()->debug($message, $context);
+		self::getInstance()->debug($message, $context);
 	}
 
 	/**

--- a/tests/Util/Database/StaticDatabase.php
+++ b/tests/Util/Database/StaticDatabase.php
@@ -129,6 +129,9 @@ class StaticDatabase extends Database
 	 */
 	public static function statConnect(array $server)
 	{
+		// Init variables
+		$db_host = $db_user = $db_data = $db_pw = '';
+
 		// Use environment variables for mysql if they are set beforehand
 		if (!empty($server['MYSQL_HOST'])
 		    && (!empty($server['MYSQL_USERNAME']) || !empty($server['MYSQL_USER']))
@@ -158,14 +161,14 @@ class StaticDatabase extends Database
 		$serverdata = explode(':', $serveraddr);
 		$server     = $serverdata[0];
 		if (count($serverdata) > 1) {
-			$port = trim($serverdata[1]);
+			$port = (int) trim($serverdata[1]);
 		}
 		$server  = trim($server);
 		$user    = trim($db_user);
-		$pass    = trim($db_pw ?? '');
+		$pass    = trim($db_pw);
 		$db      = trim($db_data);
 
-		if (!(strlen($server) && strlen($user))) {
+		if (!(strlen($server) && strlen($user) && strlen($db))) {
 			return;
 		}
 


### PR DESCRIPTION
Changes:
- added type-hints
- added missing documentation
- renamed `Logger::getWorker()` to `Logger::getLogger()` as there is no worker class returned but the actual (inner) logger