### PR TITLE
Enabled sub-directories for compiled/cache Smarty3 files

### DIFF
--- a/src/Render/FriendicaSmarty.php
+++ b/src/Render/FriendicaSmarty.php
@@ -39,12 +39,12 @@ class FriendicaSmarty extends Smarty
 
 		// setTemplateDir can be set to an array, which Smarty will parse in order.
 		// The order is thus very important here
-		$template_dirs = ['theme' => "view/theme/$theme/" . self::SMARTY3_TEMPLATE_FOLDER . "/"];
+		$template_dirs = ['theme' => 'view/theme/$theme/' . self::SMARTY3_TEMPLATE_FOLDER . '/'];
 		if (!empty($theme_info['extends'])) {
-			$template_dirs = $template_dirs + ['extends' => "view/theme/" . $theme_info["extends"] . "/" . self::SMARTY3_TEMPLATE_FOLDER . "/"];
+			$template_dirs = $template_dirs + ['extends' => 'view/theme/' . $theme_info['extends'] . '/' . self::SMARTY3_TEMPLATE_FOLDER . '/'];
 		}
 
-		$template_dirs = $template_dirs + ['base' => "view/" . self::SMARTY3_TEMPLATE_FOLDER . "/"];
+		$template_dirs = $template_dirs + ['base' => 'view/' . self::SMARTY3_TEMPLATE_FOLDER . '/'];
 		$this->setTemplateDir($template_dirs);
 
 		$this->setCompileDir('view/smarty3/compiled/');

--- a/src/Render/FriendicaSmarty.php
+++ b/src/Render/FriendicaSmarty.php
@@ -39,7 +39,7 @@ class FriendicaSmarty extends Smarty
 
 		// setTemplateDir can be set to an array, which Smarty will parse in order.
 		// The order is thus very important here
-		$template_dirs = ['theme' => 'view/theme/$theme/' . self::SMARTY3_TEMPLATE_FOLDER . '/'];
+		$template_dirs = ['theme' => "view/theme/$theme/" . self::SMARTY3_TEMPLATE_FOLDER . '/'];
 		if (!empty($theme_info['extends'])) {
 			$template_dirs = $template_dirs + ['extends' => 'view/theme/' . $theme_info['extends'] . '/' . self::SMARTY3_TEMPLATE_FOLDER . '/'];
 		}

--- a/src/Render/FriendicaSmartyEngine.php
+++ b/src/Render/FriendicaSmartyEngine.php
@@ -48,6 +48,19 @@ final class FriendicaSmartyEngine extends TemplateEngine
 		$this->theme_info = $theme_info;
 		$this->smarty = new FriendicaSmarty($this->theme, $this->theme_info);
 
+		/*
+		 * Enable sub-directory splitting for reducing directory descriptor
+		 * size. The default behavior is to put all compiled/cached files into
+		 * one single directory. Under Linux and EXT4 (and maybe other FS) this
+		 * will increase the descriptor's size (which contains information
+		 * about entries inside the described directory. If the descriptor is
+		 * getting to big, the system will slow down as it has to read the
+		 * whole directory descriptor all over again (unless you have tons of
+		 * RAM available + have enabled caching inode tables (aka.
+		 * "descriptors"). Still it won't hurt you.
+		 */
+		$this->smarty->setUseSubDirs(true);
+
 		if (!is_writable(DI::basePath() . '/view/smarty3')) {
 			$admin_message = DI::l10n()->t('The folder view/smarty3/ must be writable by webserver.');
 			DI::logger()->critical($admin_message);


### PR DESCRIPTION
Changes:
- enabled sub-directories for compiled/cached files which avoids large+slow directory descriptors
- changed some double-quotes to single

Please see `src/Render/FriendicaSmartyEngine.php` for a longer description why this change improve performance. Please do a `rm -rf view/smarty3/compiled/` and `mkdir view/smarty3/compiled/` to reduce the descriptor's size to 4k again.