### PR TITLE
Fix for Transmitter::sendContactAccept() wrong 2nd parameter type

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1267,8 +1267,10 @@ class Processor
 			Contact::update(['hub-verify' => $activity['id'], 'protocol' => Protocol::ACTIVITYPUB], ['id' => $cid]);
 		}
 
-		$item = ['author-id' => Contact::getIdForURL($activity['actor']),
-			'author-link' => $activity['actor']];
+		$item = [
+			'author-id' => Contact::getIdForURL($activity['actor']),
+			'author-link' => $activity['actor'],
+		];
 
 		// Ensure that the contact has got the right network type
 		self::switchContact($item['author-id']);

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -2116,13 +2116,13 @@ class Transmitter
 	 * Transmit a message that the contact request had been accepted
 	 *
 	 * @param string  $target Target profile
-	 * @param integer $id Object id
+	 * @param string  $id Object id
 	 * @param integer $uid    User ID
 	 * @return void
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function sendContactAccept(string $target, int $id, int $uid)
+	public static function sendContactAccept(string $target, string $id, int $uid)
 	{
 		$profile = APContact::getByURL($target);
 		if (empty($profile['inbox'])) {
@@ -2137,7 +2137,7 @@ class Transmitter
 			'type' => 'Accept',
 			'actor' => $owner['url'],
 			'object' => [
-				'id' => (string)$id,
+				'id' => $id,
 				'type' => 'Follow',
 				'actor' => $profile['url'],
 				'object' => $owner['url']


### PR DESCRIPTION
`$id` must be a string, I got confused by `$activity['id']` and thought it was an integer, while it origins from `Introduction` class and is an output of `trim()` which is always `string`.