### PR TITLE
Rewrote GServer::getProtocol()

### DIFF
--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -1357,14 +1357,15 @@ class GServer
 	private static function detectFromContacts(string $url, array $serverdata): array
 	{
 		$gserver = DBA::selectFirst('gserver', ['id'], ['nurl' => Strings::normaliseLink($url)]);
-		if (empty($gserver)) {
-			return $serverdata;	
+
+		if (!DBA::isResult($gserver)) {
+			return $serverdata;
 		}
 
 		$contact = Contact::selectFirst(['id'], ['uid' => 0, 'failed' => false, 'gsid' => $gserver['id']]);
 
 		// Via probing we can be sure that the server is responding
-		if (!empty($contact['id']) && Contact::updateFromProbe($contact['id'])) {
+		if (DBA::isResult($contact) && ($contact['id'] > 0) && Contact::updateFromProbe($contact['id'])) {
 			$contact = Contact::selectFirst(['network', 'failed'], ['id' => $contact['id']]);
 			if (!$contact['failed'] && in_array($contact['network'], Protocol::FEDERATED)) {
 				$serverdata['network'] = $contact['network'];


### PR DESCRIPTION
Changes:
- added `ResultException` which should be thrown if an expected record (e.g. because an id is provided) isn't found in database but SHOULD be there
- Rewrote `GServer::getProtocol()` to throw exceptions on invalid `$gsid` (<1) or when a corresponding record wasn't found
- normally these exceptions should NOT happen but might when somewhere a logic error is
- this addresses an issue in #11630\

These thrown exceptions can then also be unit-tested very easily.