### PR TITLE
Fix a couple Fatal Errors

### DIFF
--- a/src/Contact/LocalRelationship/Factory/LocalRelationship.php
+++ b/src/Contact/LocalRelationship/Factory/LocalRelationship.php
@@ -52,7 +52,7 @@ class LocalRelationship extends BaseFactory implements ICanCreateFromTableRow
 			$row['hub-verify'] ?? '',
 			$row['protocol'] ?? Protocol::PHANTOM,
 			$row['rating'] ?? null,
-			$row['priority'] ?? null
+			$row['priority'] ?? 0
 		);
 	}
 }

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -2047,10 +2047,10 @@ class GServer
 	 * Fetch the protocol of the given server
 	 *
 	 * @param int $gsid Server id
-	 * @return int
+	 * @return ?int One of Post\DeliveryData protocol constants or null if unknown or gserver is missing
 	 * @throws Exception
 	 */
-	public static function getProtocol(int $gsid): int
+	public static function getProtocol(int $gsid): ?int
 	{
 		if (empty($gsid)) {
 			return null;

--- a/src/Worker/Delivery.php
+++ b/src/Worker/Delivery.php
@@ -257,19 +257,19 @@ class Delivery
 	/**
 	 * Deliver content via DFRN
 	 *
-	 * @param string  $cmd             Command
-	 * @param array   $contact         Contact record of the receiver
-	 * @param array   $owner           Owner record of the sender
-	 * @param array   $items           Item record of the content and the parent
-	 * @param array   $target_item     Item record of the content
-	 * @param boolean $public_message  Is the content public?
-	 * @param boolean $top_level       Is it a thread starter?
-	 * @param boolean $followup        Is it an answer to a remote post?
-	 * @param int     $server_protocol The protocol of the server
+	 * @param string   $cmd             Command
+	 * @param array    $contact         Contact record of the receiver
+	 * @param array    $owner           Owner record of the sender
+	 * @param array    $items           Item record of the content and the parent
+	 * @param array    $target_item     Item record of the content
+	 * @param boolean  $public_message  Is the content public?
+	 * @param boolean  $top_level       Is it a thread starter?
+	 * @param boolean  $followup        Is it an answer to a remote post?
+	 * @param int|null $server_protocol The protocol of the server
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	private static function deliverDFRN(string $cmd, array $contact, array $owner, array $items, array $target_item, bool $public_message, bool $top_level, bool $followup, int $server_protocol)
+	private static function deliverDFRN(string $cmd, array $contact, array $owner, array $items, array $target_item, bool $public_message, bool $top_level, bool $followup, int $server_protocol = null)
 	{
 		// Transmit Diaspora reshares via Diaspora if the Friendica contact support Diaspora
 		if (Diaspora::isReshare($target_item['body'] ?? '') && !empty(FContact::getByURL($contact['addr'], false))) {


### PR DESCRIPTION
- Address https://github.com/friendica/friendica/issues/11630#issuecomment-1164880874
- Address https://github.com/friendica/friendica/issues/11630#issuecomment-1166192993

The `protocol` value can be null even if the gserver record exists in the database, there's no need for exceptions.