### PR TITLE
Create ActivityPub\FetchQueue and ActivityPub\FetchQueueItem classes

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3411,7 +3411,11 @@ class Item
 			return is_numeric($hookData['item_id']) ? $hookData['item_id'] : 0;
 		}
 
-		if ($fetched_uri = ActivityPub\Processor::fetchMissingActivity($uri)) {
+		$fetchQueue = new ActivityPub\FetchQueue();
+		$fetched_uri = ActivityPub\Processor::fetchMissingActivity($fetchQueue, $uri);
+		$fetchQueue->process();
+
+		if ($fetched_uri) {
 			$item_id = self::searchByLink($fetched_uri, $uid);
 		} else {
 			$item_id = Diaspora::fetchByURL($uri);

--- a/src/Module/Debug/ActivityPubConversion.php
+++ b/src/Module/Debug/ActivityPubConversion.php
@@ -123,7 +123,7 @@ class ActivityPubConversion extends BaseModule
 					'content' => visible_whitespace(var_export($object_data, true))
 				];
 
-				$item = ActivityPub\Processor::createItem($object_data);
+				$item = ActivityPub\Processor::createItem(new ActivityPub\FetchQueue(), $object_data);
 
 				$results[] = [
 					'title'   => DI::l10n()->t('Result Item'),

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -25,6 +25,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Model\APContact;
 use Friendica\Model\User;
+use Friendica\Protocol\ActivityPub\FetchQueue;
 use Friendica\Util\HTTPSignature;
 use Friendica\Util\JsonLD;
 
@@ -223,10 +224,14 @@ class ActivityPub
 			$items = [];
 		}
 
+		$fetchQueue = new FetchQueue();
+
 		foreach ($items as $activity) {
 			$ldactivity = JsonLD::compact($activity);
-			ActivityPub\Receiver::processActivity($ldactivity, '', $uid, true);
+			ActivityPub\Receiver::processActivity($fetchQueue, $ldactivity, '', $uid, true);
 		}
+
+		$fetchQueue->process();
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/FetchQueue.php
+++ b/src/Protocol/ActivityPub/FetchQueue.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Protocol\ActivityPub;
+
+/**
+ * This class prevents maximum function nesting errors by flattening recursive calls to Processor::fetchMissingActivity
+ */
+class FetchQueue
+{
+	/** @var FetchQueueItem[] */
+	protected $queue = [];
+
+	public function push(FetchQueueItem $item)
+	{
+		array_push($this->queue, $item);
+	}
+
+	/**
+	 * Processes missing activities one by one. It is possible that a processing call will add additional missing
+	 * activities, they will be processed in subsequent iterations of the loop.
+	 *
+	 * Since this process is self-contained, it isn't suitable to retrieve the URI of a single activity.
+	 *
+	 * The simplest way to get the URI of the first activity and ensures all the parents are fetched is this way:
+	 *
+	 * $fetchQueue = new ActivityPub\FetchQueue();
+	 * $fetchedUri = ActivityPub\Processor::fetchMissingActivity($fetchQueue, $activityUri);
+	 * $fetchQueue->process();
+	 */
+	public function process()
+	{
+		while (count($this->queue)) {
+			$fetchQueueItem = array_pop($this->queue);
+
+			call_user_func_array([Processor::class, 'fetchMissingActivity'], array_merge([$this], $fetchQueueItem->toParameters()));
+		}
+	}
+}

--- a/src/Protocol/ActivityPub/FetchQueueItem.php
+++ b/src/Protocol/ActivityPub/FetchQueueItem.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Protocol\ActivityPub;
+
+class FetchQueueItem
+{
+	/** @var string */
+	private $url;
+	/** @var array */
+	private $child;
+	/** @var string */
+	private $relay_actor;
+	/** @var int */
+	private $completion;
+
+	/**
+	 * This constructor matches the signature of Processor::fetchMissingActivity except for the default $completion value
+	 *
+	 * @param string $url
+	 * @param array  $child
+	 * @param string $relay_actor
+	 * @param int    $completion
+	 */
+	public function __construct(string $url, array $child = [], string $relay_actor = '', int $completion = Receiver::COMPLETION_AUTO)
+	{
+		$this->url         = $url;
+		$this->child       = $child;
+		$this->relay_actor = $relay_actor;
+		$this->completion  = $completion;
+	}
+
+	/**
+	 * Array meant to be used in call_user_function_array([Processor::class, 'fetchMissingActivity']). Caller needs to
+	 * provide an instance of a FetchQueue that isn't included in these parameters.
+	 *
+	 * @see FetchQueue::process()
+	 * @return array
+	 */
+	public function toParameters(): array
+	{
+		return [$this->url, $this->child, $this->relay_actor, $this->completion];
+	}
+}


### PR DESCRIPTION
- These classes are used to flatten the recursive missing activity fetch that can hit PHP's maximum function nesting limit
- The original caller is responsible for processing the remaining queue once the original activity has been fetched

Fixes #11651 

Ran on my production server to clear my `fetchFeaturedPost` tasks that were stuck because of the nesting limit.

The remaining error in my log is fixed by https://github.com/friendica/friendica/pull/11683, sadly I can't run both branches on my server at the same time.