### PR TITLE
Use labels for woodpecker continuous deployments

### DIFF
--- a/.woodpecker/.continuous-deployment.yml
+++ b/.woodpecker/.continuous-deployment.yml
@@ -9,7 +9,10 @@ depends_on:
   - database_checks
   - messages.po_check
 
-platform: releaser/release # This prevents executing this pipeline at other servers than ci.friendi.ca
+# This prevents executing this pipeline at other servers than ci.friendi.ca
+labels:
+  location: friendica
+  type: releaser
 
 skip_clone: true
 

--- a/.woodpecker/.releaser.yml
+++ b/.woodpecker/.releaser.yml
@@ -7,7 +7,10 @@ depends_on:
   - phpunit
   - code_standards_check
 
-platform: releaser/release # This prevents executing this pipeline at other servers than ci.friendi.ca
+# This prevents executing this pipeline at other servers than ci.friendi.ca
+labels:
+  location: friendica
+  type: releaser
 
 skip_clone: true
 


### PR DESCRIPTION
This solves the dependency lock for woodpecker