### PR TITLE
Fixed "Argument 1 passed to Friendica\Content\Text\BBCode::toPlaintext() must be of the type string, null given"

### DIFF
--- a/src/Object/Api/Twitter/User.php
+++ b/src/Object/Api/Twitter/User.php
@@ -119,7 +119,7 @@ class User extends BaseDataTransferObject
 		if (!$include_user_entities) {
 			unset($this->entities);
 		}
-		$this->description             = BBCode::toPlaintext($publicContact['about']);
+		$this->description             = (!empty($publicContact['about']) ? BBCode::toPlaintext($publicContact['about']) : '');
 		$this->profile_image_url_https = Contact::getAvatarUrlForUrl($publicContact['url'], $uid, Proxy::SIZE_MICRO);
 		$this->protected               = false;
 		$this->followers_count         = $apcontact['followers_count'] ?? 0;


### PR DESCRIPTION
Changes:
- `$publicContact['about']` can be NULL, causing following error:

`Argument 1 passed to Friendica\Content\Text\BBCode::toPlaintext() must be of the type string, null given, called in /.../src/Object/Api/Twitter/User.php`

The "expensive" code there can be avoided by checking if an empty string or null is given.