### PR TITLE
Fixed: TypeError: "Return value of Friendica\Model\Contact\User::isBlocked() must be of the type bool, null returned"

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1180,7 +1180,7 @@ class Contact
 		$contact = self::getByURL($url, false, ['id', 'network', 'uri-id'], $uid);
 
 		if (!empty($contact)) {
-			$contact_id = $contact["id"];
+			$contact_id = $contact['id'];
 
 			if (empty($update) && (!empty($contact['uri-id']) || is_bool($update))) {
 				Logger::debug('Contact found', ['url' => $url, 'uid' => $uid, 'update' => $update, 'cid' => $contact_id]);
@@ -1197,10 +1197,10 @@ class Contact
 		$data = [];
 
 		if (empty($default['network']) || $update) {
-			$data = Probe::uri($url, "", $uid);
+			$data = Probe::uri($url, '', $uid);
 
 			// Take the default values when probing failed
-			if (!empty($default) && !in_array($data["network"], array_merge(Protocol::NATIVE_SUPPORT, [Protocol::PUMPIO]))) {
+			if (!empty($default) && !in_array($data['network'], array_merge(Protocol::NATIVE_SUPPORT, [Protocol::PUMPIO]))) {
 				$data = array_merge($data, $default);
 			}
 		} elseif (!empty($default['network'])) {

--- a/src/Model/Contact/User.php
+++ b/src/Model/Contact/User.php
@@ -183,7 +183,7 @@ class User
 		if (!empty($cdata['public'])) {
 			$public_contact = DBA::selectFirst('user-contact', ['blocked'], ['cid' => $cdata['public'], 'uid' => $uid]);
 			if (DBA::isResult($public_contact)) {
-				$public_blocked = $public_contact['blocked'];
+				$public_blocked = (bool) $public_contact['blocked'];
 			}
 		}
 
@@ -192,7 +192,7 @@ class User
 		if (!empty($cdata['user'])) {
 			$user_contact = DBA::selectFirst('contact', ['blocked'], ['id' => $cdata['user'], 'pending' => false]);
 			if (DBA::isResult($user_contact)) {
-				$user_blocked = $user_contact['blocked'];
+				$user_blocked = (bool) $user_contact['blocked'];
 			}
 		}
 

--- a/src/Model/Contact/User.php
+++ b/src/Model/Contact/User.php
@@ -246,7 +246,7 @@ class User
 		if (!empty($cdata['public'])) {
 			$public_contact = DBA::selectFirst('user-contact', ['ignored'], ['cid' => $cdata['public'], 'uid' => $uid]);
 			if (DBA::isResult($public_contact)) {
-				$public_ignored = $public_contact['ignored'];
+				$public_ignored = (bool) $public_contact['ignored'];
 			}
 		}
 
@@ -255,7 +255,7 @@ class User
 		if (!empty($cdata['user'])) {
 			$user_contact = DBA::selectFirst('contact', ['readonly'], ['id' => $cdata['user'], 'pending' => false]);
 			if (DBA::isResult($user_contact)) {
-				$user_ignored = $user_contact['readonly'];
+				$user_ignored = (bool) $user_contact['readonly'];
 			}
 		}
 
@@ -306,7 +306,7 @@ class User
 		if (!empty($cdata['public'])) {
 			$public_contact = DBA::selectFirst('user-contact', ['collapsed'], ['cid' => $cdata['public'], 'uid' => $uid]);
 			if (DBA::isResult($public_contact)) {
-				$collapsed = $public_contact['collapsed'];
+				$collapsed = (bool) $public_contact['collapsed'];
 			}
 		}
 


### PR DESCRIPTION
Fixed:
- `Contact/User::isBlocked()` needs to return boolean, but sometimes (strangely) a` NULL` can come from database, so let's cast it

This tries to fix:
`TypeError: "Return value of Friendica\Model\Contact\User::isBlocked() must be of the type bool, null returned"`

Please note that this method is updating the blocked status if `$user_blocked` and `$public_blocked` differ.