### PR TITLE
Added missing type-hints

### DIFF
--- a/src/Content/BoundariesPager.php
+++ b/src/Content/BoundariesPager.php
@@ -73,12 +73,12 @@ class BoundariesPager extends Pager
 		}
 	}
 
-	public function getStart()
+	public function getStart(): int
 	{
 		throw new \BadMethodCallException();
 	}
 
-	public function getPage()
+	public function getPage(): int
 	{
 		throw new \BadMethodCallException();
 	}


### PR DESCRIPTION
These type-hints need to be added so they can be overwritten by `BoundariesPager`. Fixes #11700 