### PR TITLE
Fix for "Argument 1 passed to Friendica\Content\Text\BBCode::toPlaintext() must be of the type string, null given"

### DIFF
--- a/mod/display.php
+++ b/mod/display.php
@@ -302,7 +302,7 @@ function display_content(App $a, $update = false, $update_uid = 0)
 
 	// Preparing the meta header
 	$description = trim(BBCode::toPlaintext($item['body']));
-	$title = trim(BBCode::toPlaintext($item['title']));
+	$title = trim(BBCode::toPlaintext($item['title'] ?? ''));
 	$author_name = $item['author-name'];
 
 	$image = DI::baseUrl()->remove($item['author-avatar']);

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -424,7 +424,6 @@ class BBCode
 	 *
 	 * @param string  $body
 	 * @param boolean $no_link_desc No link description
-	 *
 	 * @return string with replaced body
 	 */
 	public static function removeAttachment(string $body, bool $no_link_desc = false): string
@@ -449,7 +448,6 @@ class BBCode
 	 *
 	 * @param string $text
 	 * @param bool $keep_urls Whether to keep URLs in the resulting plaintext
-	 *
 	 * @return string
 	 */
 	public static function toPlaintext(string $text, bool $keep_urls = true): string


### PR DESCRIPTION
This fixes an error message I found in my `friendica.log` file:

`Argument 1 passed to Friendica\Content\Text\BBCode::toPlaintext() must be of the type string, null given, called in /var/www/.../htdocs/mod/display.php on line 305`

PS: Yes, we need more unit tests!!!