### PR TITLE
Feature optional network group count

### DIFF
--- a/src/Module/Admin/Site.php
+++ b/src/Module/Admin/Site.php
@@ -134,6 +134,7 @@ class Site extends BaseAdmin
 		$temppath               = (!empty($_POST['temppath'])               ? trim($_POST['temppath'])   : '');
 		$singleuser             = (!empty($_POST['singleuser'])             ? trim($_POST['singleuser']) : '');
 		$only_tag_search        = !empty($_POST['only_tag_search']);
+		$compute_group_counts   = !empty($_POST['compute_group_counts']);
 		$check_new_version_url  = (!empty($_POST['check_new_version_url'])  ? trim($_POST['check_new_version_url']) : 'none');
 
 		$worker_queues    = (!empty($_POST['worker_queues'])                ? intval($_POST['worker_queues'])                 : 10);
@@ -304,6 +305,7 @@ class Site extends BaseAdmin
 		DI::config()->set('system', 'temppath', $temppath);
 
 		DI::config()->set('system', 'only_tag_search'  , $only_tag_search);
+		DI::config()->set('system', 'compute_group_counts', $compute_group_counts);
 
 		DI::config()->set('system', 'worker_queues'    , $worker_queues);
 		DI::config()->set('system', 'worker_fastlane'  , $worker_fastlane);
@@ -534,6 +536,7 @@ class Site extends BaseAdmin
 			'$max_display_comments'   => ['max_display_comments', DI::l10n()->t('Maximum numbers of comments per post on the display page'), DI::config()->get('system', 'max_display_comments'), DI::l10n()->t('How many comments should be shown on the single view for each post? Default value is 1000.')],
 			'$temppath'               => ['temppath', DI::l10n()->t('Temp path'), DI::config()->get('system', 'temppath'), DI::l10n()->t('If you have a restricted system where the webserver can\'t access the system temp path, enter another path here.')],
 			'$only_tag_search'        => ['only_tag_search', DI::l10n()->t('Only search in tags'), DI::config()->get('system', 'only_tag_search'), DI::l10n()->t('On large systems the text search can slow down the system extremely.')],
+			'$compute_group_counts'   => ['compute_group_counts', DI::l10n()->t('Generate counts per contact group when calculating network count'), DI::config()->get('system', 'compute_group_counts'), DI::l10n()->t('On systems with users that heavily use contact groups the query can be very expensive.')],
 
 			'$worker_queues'          => ['worker_queues', DI::l10n()->t('Maximum number of parallel workers'), DI::config()->get('system', 'worker_queues'), DI::l10n()->t('On shared hosters set this to %d. On larger systems, values of %d are great. Default value is %d.', 5, 20, 10)],
 			'$worker_fastlane'        => ['worker_fastlane', DI::l10n()->t('Enable fastlane'), DI::config()->get('system', 'worker_fastlane'), DI::l10n()->t('When enabed, the fastlane mechanism starts an additional worker if processes with higher priority are blocked by processes of lower priority.')],

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -113,7 +113,8 @@ class Ping extends BaseModule
 			}
 			DBA::close($items);
 
-			if ($network_count) {
+			$compute_group_counts = DI::config()->get('system','compute_group_counts');
+			if ($network_count && $compute_group_counts) {
 				// Find out how unseen network posts are spread across groups
 				$group_counts = Group::countUnseen();
 				if (DBA::isResult($group_counts)) {

--- a/static/settings.config.php
+++ b/static/settings.config.php
@@ -114,6 +114,10 @@ return [
 		// Default value comprises classic role names from RFC 2142.
 		'forbidden_nicknames' => 'info, marketing, sales, support, abuse, noc, security, postmaster, hostmaster, usenet, news, webmaster, www, uucp, ftp, root, sysop',
 
+		// compute_group_counts (Boolean)
+		// Compute contact group level when counting unseen network posts.
+		'compute_group_counts' => true,
+
 		// jpeg_quality (Integer)
 		// Sets the ImageMagick quality level for JPEG images. Values ranges from 50 (awful) to 100 (near perfect).
 		'jpeg_quality' => 100,

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.09-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-25 22:37+0200\n"
+"POT-Creation-Date: 2022-07-07 17:00-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,8 +43,8 @@ msgstr ""
 msgid "Access to this profile has been restricted."
 msgstr ""
 
-#: mod/cal.php:243 mod/events.php:374 src/Content/Nav.php:194
-#: src/Content/Nav.php:258 src/Module/BaseProfile.php:84
+#: mod/cal.php:243 mod/events.php:374 src/Content/Nav.php:196
+#: src/Content/Nav.php:260 src/Module/BaseProfile.php:84
 #: src/Module/BaseProfile.php:95 view/theme/frio/theme.php:229
 #: view/theme/frio/theme.php:233
 msgid "Events"
@@ -119,7 +119,7 @@ msgid "The feed for this item is unavailable."
 msgstr ""
 
 #: mod/editpost.php:38 mod/events.php:217 mod/follow.php:56 mod/follow.php:130
-#: mod/item.php:181 mod/item.php:186 mod/item.php:875 mod/message.php:69
+#: mod/item.php:181 mod/item.php:186 mod/item.php:880 mod/message.php:69
 #: mod/message.php:111 mod/notes.php:44 mod/ostatus_subscribe.php:33
 #: mod/photos.php:160 mod/photos.php:891 mod/repair_ostatus.php:31
 #: mod/settings.php:40 mod/settings.php:50 mod/settings.php:156
@@ -271,7 +271,7 @@ msgstr ""
 #: mod/follow.php:144 mod/photos.php:1004 mod/photos.php:1105 mod/tagrm.php:35
 #: mod/tagrm.php:127 mod/unfollow.php:97 src/Content/Conversation.php:386
 #: src/Module/Contact/Revoke.php:108 src/Module/RemoteFollow.php:127
-#: src/Module/Security/TwoFactor/Signout.php:125
+#: src/Module/Security/TwoFactor/SignOut.php:125
 msgid "Cancel"
 msgstr ""
 
@@ -368,7 +368,7 @@ msgstr ""
 #: src/Module/Install.php:305 src/Module/Install.php:320
 #: src/Module/Install.php:347 src/Module/Register.php:148
 #: src/Module/Security/TwoFactor/Verify.php:101
-#: src/Module/Settings/TwoFactor/Index.php:136
+#: src/Module/Settings/TwoFactor/Index.php:141
 #: src/Module/Settings/TwoFactor/Verify.php:154
 msgid "Required"
 msgstr ""
@@ -433,7 +433,7 @@ msgstr ""
 msgid "Failed to remove event"
 msgstr ""
 
-#: mod/fbrowser.php:61 src/Content/Nav.php:192 src/Module/BaseProfile.php:64
+#: mod/fbrowser.php:61 src/Content/Nav.php:194 src/Module/BaseProfile.php:64
 #: view/theme/frio/theme.php:227
 msgid "Photos"
 msgstr ""
@@ -467,8 +467,8 @@ msgstr ""
 msgid "OStatus support is disabled. Contact can't be added."
 msgstr ""
 
-#: mod/follow.php:138 src/Content/Item.php:443 src/Content/Widget.php:80
-#: src/Model/Contact.php:1103 src/Model/Contact.php:1115
+#: mod/follow.php:138 src/Content/Item.php:459 src/Content/Widget.php:80
+#: src/Model/Contact.php:1104 src/Model/Contact.php:1116
 #: view/theme/vier/theme.php:172
 msgid "Connect/Follow"
 msgstr ""
@@ -521,19 +521,19 @@ msgstr ""
 msgid "Empty post discarded."
 msgstr ""
 
-#: mod/item.php:687
+#: mod/item.php:692
 msgid "Post updated."
 msgstr ""
 
-#: mod/item.php:697 mod/item.php:702
+#: mod/item.php:702 mod/item.php:707
 msgid "Item wasn't stored."
 msgstr ""
 
-#: mod/item.php:713
+#: mod/item.php:718
 msgid "Item couldn't be fetched."
 msgstr ""
 
-#: mod/item.php:853 src/Module/Admin/Themes/Details.php:39
+#: mod/item.php:858 src/Module/Admin/Themes/Details.php:39
 #: src/Module/Admin/Themes/Index.php:59 src/Module/Debug/ItemBody.php:42
 #: src/Module/Debug/ItemBody.php:57
 msgid "Item not found."
@@ -689,7 +689,7 @@ msgstr ""
 msgid "Profile Match"
 msgstr ""
 
-#: mod/message.php:46 mod/message.php:126 src/Content/Nav.php:286
+#: mod/message.php:46 mod/message.php:126 src/Content/Nav.php:288
 msgid "New Message"
 msgstr ""
 
@@ -715,7 +715,7 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: mod/message.php:133 src/Content/Nav.php:283 view/theme/frio/theme.php:234
+#: mod/message.php:133 src/Content/Nav.php:285 view/theme/frio/theme.php:234
 msgid "Messages"
 msgstr ""
 
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: mod/settings.php:177 src/Content/Nav.php:212
+#: mod/settings.php:177 src/Content/Nav.php:214
 msgid "Home Page"
 msgstr ""
 
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "Action after import:"
 msgstr ""
 
-#: mod/settings.php:350 src/Content/Nav.php:280
+#: mod/settings.php:350 src/Content/Nav.php:282
 msgid "Mark as seen"
 msgstr ""
 
@@ -1409,15 +1409,15 @@ msgstr ""
 msgid "Friend Suggestions"
 msgstr ""
 
-#: mod/tagger.php:78 src/Content/Item.php:342 src/Model/Item.php:2728
+#: mod/tagger.php:78 src/Content/Item.php:354 src/Model/Item.php:2728
 msgid "photo"
 msgstr ""
 
-#: mod/tagger.php:78 src/Content/Item.php:337 src/Content/Item.php:346
+#: mod/tagger.php:78 src/Content/Item.php:348 src/Content/Item.php:358
 msgid "status"
 msgstr ""
 
-#: mod/tagger.php:111 src/Content/Item.php:356
+#: mod/tagger.php:111 src/Content/Item.php:368
 #, php-format
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
@@ -1523,7 +1523,7 @@ msgstr ""
 msgid "File upload failed."
 msgstr ""
 
-#: mod/wall_upload.php:218 src/Model/Photo.php:1085
+#: mod/wall_upload.php:218 src/Model/Photo.php:1087
 msgid "Wall Photos"
 msgstr ""
 
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "Display membership date in profile"
 msgstr ""
 
-#: src/Content/ForumManager.php:151 src/Content/Nav.php:239
+#: src/Content/ForumManager.php:151 src/Content/Nav.php:241
 #: src/Content/Text/HTML.php:903 src/Content/Widget.php:524
 msgid "Forums"
 msgstr ""
@@ -2268,55 +2268,55 @@ msgstr ""
 msgid "show more"
 msgstr ""
 
-#: src/Content/Item.php:301
+#: src/Content/Item.php:306
 #, php-format
 msgid "%1$s poked %2$s"
 msgstr ""
 
-#: src/Content/Item.php:334 src/Model/Item.php:2726
+#: src/Content/Item.php:345 src/Model/Item.php:2726
 msgid "event"
 msgstr ""
 
-#: src/Content/Item.php:422 view/theme/frio/theme.php:254
+#: src/Content/Item.php:438 view/theme/frio/theme.php:254
 msgid "Follow Thread"
 msgstr ""
 
-#: src/Content/Item.php:423 src/Model/Contact.php:1108
+#: src/Content/Item.php:439 src/Model/Contact.php:1109
 msgid "View Status"
 msgstr ""
 
-#: src/Content/Item.php:424 src/Content/Item.php:446 src/Model/Contact.php:1042
-#: src/Model/Contact.php:1100 src/Model/Contact.php:1109
+#: src/Content/Item.php:440 src/Content/Item.php:462 src/Model/Contact.php:1043
+#: src/Model/Contact.php:1101 src/Model/Contact.php:1110
 #: src/Module/Directory.php:158 src/Module/Settings/Profile/Index.php:225
 msgid "View Profile"
 msgstr ""
 
-#: src/Content/Item.php:425 src/Model/Contact.php:1110
+#: src/Content/Item.php:441 src/Model/Contact.php:1111
 msgid "View Photos"
 msgstr ""
 
-#: src/Content/Item.php:426 src/Model/Contact.php:1101
-#: src/Model/Contact.php:1111
+#: src/Content/Item.php:442 src/Model/Contact.php:1102
+#: src/Model/Contact.php:1112
 msgid "Network Posts"
 msgstr ""
 
-#: src/Content/Item.php:427 src/Model/Contact.php:1102
-#: src/Model/Contact.php:1112
+#: src/Content/Item.php:443 src/Model/Contact.php:1103
+#: src/Model/Contact.php:1113
 msgid "View Contact"
 msgstr ""
 
-#: src/Content/Item.php:428 src/Model/Contact.php:1113
+#: src/Content/Item.php:444 src/Model/Contact.php:1114
 msgid "Send PM"
 msgstr ""
 
-#: src/Content/Item.php:429 src/Module/Admin/Blocklist/Contact.php:100
+#: src/Content/Item.php:445 src/Module/Admin/Blocklist/Contact.php:100
 #: src/Module/Admin/Users/Active.php:140 src/Module/Admin/Users/Index.php:154
 #: src/Module/Contact.php:398 src/Module/Contact/Profile.php:348
 #: src/Module/Contact/Profile.php:449
 msgid "Block"
 msgstr ""
 
-#: src/Content/Item.php:430 src/Module/Contact.php:399
+#: src/Content/Item.php:446 src/Module/Contact.php:399
 #: src/Module/Contact/Profile.php:349 src/Module/Contact/Profile.php:457
 #: src/Module/Notifications/Introductions.php:132
 #: src/Module/Notifications/Introductions.php:204
@@ -2324,11 +2324,11 @@ msgstr ""
 msgid "Ignore"
 msgstr ""
 
-#: src/Content/Item.php:434 src/Object/Post.php:455
+#: src/Content/Item.php:450 src/Object/Post.php:455
 msgid "Languages"
 msgstr ""
 
-#: src/Content/Item.php:438 src/Model/Contact.php:1114
+#: src/Content/Item.php:454 src/Model/Contact.php:1115
 msgid "Poke"
 msgstr ""
 
@@ -2348,252 +2348,252 @@ msgstr ""
 msgid "@name, !forum, #tags, content"
 msgstr ""
 
-#: src/Content/Nav.php:183 src/Module/Security/Login.php:144
+#: src/Content/Nav.php:185 src/Module/Security/Login.php:144
 msgid "Logout"
 msgstr ""
 
-#: src/Content/Nav.php:183
+#: src/Content/Nav.php:185
 msgid "End this session"
 msgstr ""
 
-#: src/Content/Nav.php:185 src/Module/Bookmarklet.php:44
+#: src/Content/Nav.php:187 src/Module/Bookmarklet.php:44
 #: src/Module/Security/Login.php:145
 msgid "Login"
 msgstr ""
 
-#: src/Content/Nav.php:185
+#: src/Content/Nav.php:187
 msgid "Sign in"
 msgstr ""
 
-#: src/Content/Nav.php:190 src/Module/BaseProfile.php:56
+#: src/Content/Nav.php:192 src/Module/BaseProfile.php:56
 #: src/Module/Contact.php:433 src/Module/Contact/Profile.php:380
-#: src/Module/Settings/TwoFactor/Index.php:115 view/theme/frio/theme.php:225
+#: src/Module/Settings/TwoFactor/Index.php:120 view/theme/frio/theme.php:225
 msgid "Status"
 msgstr ""
 
-#: src/Content/Nav.php:190 src/Content/Nav.php:273
+#: src/Content/Nav.php:192 src/Content/Nav.php:275
 #: view/theme/frio/theme.php:225
 msgid "Your posts and conversations"
 msgstr ""
 
-#: src/Content/Nav.php:191 src/Module/BaseProfile.php:48
+#: src/Content/Nav.php:193 src/Module/BaseProfile.php:48
 #: src/Module/BaseSettings.php:55 src/Module/Contact.php:457
 #: src/Module/Contact/Profile.php:382 src/Module/Profile/Profile.php:241
 #: src/Module/Welcome.php:57 view/theme/frio/theme.php:226
 msgid "Profile"
 msgstr ""
 
-#: src/Content/Nav.php:191 view/theme/frio/theme.php:226
+#: src/Content/Nav.php:193 view/theme/frio/theme.php:226
 msgid "Your profile page"
 msgstr ""
 
-#: src/Content/Nav.php:192 view/theme/frio/theme.php:227
+#: src/Content/Nav.php:194 view/theme/frio/theme.php:227
 msgid "Your photos"
 msgstr ""
 
-#: src/Content/Nav.php:193 src/Module/BaseProfile.php:72
+#: src/Content/Nav.php:195 src/Module/BaseProfile.php:72
 #: src/Module/BaseProfile.php:75 src/Module/Contact.php:449
 #: view/theme/frio/theme.php:228
 msgid "Media"
 msgstr ""
 
-#: src/Content/Nav.php:193 view/theme/frio/theme.php:228
+#: src/Content/Nav.php:195 view/theme/frio/theme.php:228
 msgid "Your postings with media"
 msgstr ""
 
-#: src/Content/Nav.php:194 view/theme/frio/theme.php:229
+#: src/Content/Nav.php:196 view/theme/frio/theme.php:229
 msgid "Your events"
 msgstr ""
 
-#: src/Content/Nav.php:195
+#: src/Content/Nav.php:197
 msgid "Personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:195
+#: src/Content/Nav.php:197
 msgid "Your personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:212 src/Content/Nav.php:273
+#: src/Content/Nav.php:214 src/Content/Nav.php:275
 msgid "Home"
 msgstr ""
 
-#: src/Content/Nav.php:216 src/Module/Register.php:168
+#: src/Content/Nav.php:218 src/Module/Register.php:168
 #: src/Module/Security/Login.php:105
 msgid "Register"
 msgstr ""
 
-#: src/Content/Nav.php:216
+#: src/Content/Nav.php:218
 msgid "Create an account"
 msgstr ""
 
-#: src/Content/Nav.php:222 src/Module/Help.php:67
+#: src/Content/Nav.php:224 src/Module/Help.php:67
 #: src/Module/Settings/TwoFactor/AppSpecific.php:127
-#: src/Module/Settings/TwoFactor/Index.php:114
+#: src/Module/Settings/TwoFactor/Index.php:119
 #: src/Module/Settings/TwoFactor/Recovery.php:105
 #: src/Module/Settings/TwoFactor/Verify.php:145 view/theme/vier/theme.php:217
 msgid "Help"
 msgstr ""
 
-#: src/Content/Nav.php:222
+#: src/Content/Nav.php:224
 msgid "Help and documentation"
 msgstr ""
 
-#: src/Content/Nav.php:226
+#: src/Content/Nav.php:228
 msgid "Apps"
 msgstr ""
 
-#: src/Content/Nav.php:226
+#: src/Content/Nav.php:228
 msgid "Addon applications, utilities, games"
 msgstr ""
 
-#: src/Content/Nav.php:230 src/Content/Text/HTML.php:888
+#: src/Content/Nav.php:232 src/Content/Text/HTML.php:888
 #: src/Module/Admin/Logs/View.php:87 src/Module/Search/Index.php:112
 msgid "Search"
 msgstr ""
 
-#: src/Content/Nav.php:230
+#: src/Content/Nav.php:232
 msgid "Search site content"
 msgstr ""
 
-#: src/Content/Nav.php:233 src/Content/Text/HTML.php:897
+#: src/Content/Nav.php:235 src/Content/Text/HTML.php:897
 msgid "Full Text"
 msgstr ""
 
-#: src/Content/Nav.php:234 src/Content/Text/HTML.php:898
+#: src/Content/Nav.php:236 src/Content/Text/HTML.php:898
 #: src/Content/Widget/TagCloud.php:68
 msgid "Tags"
 msgstr ""
 
-#: src/Content/Nav.php:235 src/Content/Nav.php:294
+#: src/Content/Nav.php:237 src/Content/Nav.php:296
 #: src/Content/Text/HTML.php:899 src/Module/BaseProfile.php:125
 #: src/Module/BaseProfile.php:128 src/Module/Contact.php:370
 #: src/Module/Contact.php:464 view/theme/frio/theme.php:236
 msgid "Contacts"
 msgstr ""
 
-#: src/Content/Nav.php:254
+#: src/Content/Nav.php:256
 msgid "Community"
 msgstr ""
 
-#: src/Content/Nav.php:254
+#: src/Content/Nav.php:256
 msgid "Conversations on this and other servers"
 msgstr ""
 
-#: src/Content/Nav.php:258 src/Module/BaseProfile.php:87
+#: src/Content/Nav.php:260 src/Module/BaseProfile.php:87
 #: src/Module/BaseProfile.php:98 view/theme/frio/theme.php:233
 msgid "Events and Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:261
+#: src/Content/Nav.php:263
 msgid "Directory"
 msgstr ""
 
-#: src/Content/Nav.php:261
+#: src/Content/Nav.php:263
 msgid "People directory"
 msgstr ""
 
-#: src/Content/Nav.php:263 src/Module/BaseAdmin.php:88
+#: src/Content/Nav.php:265 src/Module/BaseAdmin.php:88
 msgid "Information"
 msgstr ""
 
-#: src/Content/Nav.php:263
+#: src/Content/Nav.php:265
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:266 src/Module/Admin/Tos.php:76
+#: src/Content/Nav.php:268 src/Module/Admin/Tos.php:76
 #: src/Module/BaseAdmin.php:99 src/Module/Register.php:176
 #: src/Module/Tos.php:87
 msgid "Terms of Service"
 msgstr ""
 
-#: src/Content/Nav.php:266
+#: src/Content/Nav.php:268
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:271 view/theme/frio/theme.php:232
+#: src/Content/Nav.php:273 view/theme/frio/theme.php:232
 msgid "Network"
 msgstr ""
 
-#: src/Content/Nav.php:271 view/theme/frio/theme.php:232
+#: src/Content/Nav.php:273 view/theme/frio/theme.php:232
 msgid "Conversations from your friends"
 msgstr ""
 
-#: src/Content/Nav.php:277
+#: src/Content/Nav.php:279
 msgid "Introductions"
 msgstr ""
 
-#: src/Content/Nav.php:277
+#: src/Content/Nav.php:279
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:278 src/Module/BaseNotifications.php:148
+#: src/Content/Nav.php:280 src/Module/BaseNotifications.php:148
 #: src/Module/Notifications/Introductions.php:73
 msgid "Notifications"
 msgstr ""
 
-#: src/Content/Nav.php:279
+#: src/Content/Nav.php:281
 msgid "See all notifications"
 msgstr ""
 
-#: src/Content/Nav.php:280
+#: src/Content/Nav.php:282
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:283 view/theme/frio/theme.php:234
+#: src/Content/Nav.php:285 view/theme/frio/theme.php:234
 msgid "Private mail"
 msgstr ""
 
-#: src/Content/Nav.php:284
+#: src/Content/Nav.php:286
 msgid "Inbox"
 msgstr ""
 
-#: src/Content/Nav.php:285
+#: src/Content/Nav.php:287
 msgid "Outbox"
 msgstr ""
 
-#: src/Content/Nav.php:289
+#: src/Content/Nav.php:291
 msgid "Accounts"
 msgstr ""
 
-#: src/Content/Nav.php:289
+#: src/Content/Nav.php:291
 msgid "Manage other pages"
 msgstr ""
 
-#: src/Content/Nav.php:292 src/Module/Admin/Addons/Details.php:114
+#: src/Content/Nav.php:294 src/Module/Admin/Addons/Details.php:114
 #: src/Module/Admin/Themes/Details.php:93 src/Module/BaseSettings.php:122
 #: src/Module/Welcome.php:52 view/theme/frio/theme.php:235
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:292 view/theme/frio/theme.php:235
+#: src/Content/Nav.php:294 view/theme/frio/theme.php:235
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:294 view/theme/frio/theme.php:236
+#: src/Content/Nav.php:296 view/theme/frio/theme.php:236
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:299 src/Module/BaseAdmin.php:129
+#: src/Content/Nav.php:301 src/Module/BaseAdmin.php:129
 msgid "Admin"
 msgstr ""
 
-#: src/Content/Nav.php:299
+#: src/Content/Nav.php:301
 msgid "Site setup and configuration"
 msgstr ""
 
-#: src/Content/Nav.php:302
+#: src/Content/Nav.php:304
 msgid "Navigation"
 msgstr ""
 
-#: src/Content/Nav.php:302
+#: src/Content/Nav.php:304
 msgid "Site map"
 msgstr ""
 
-#: src/Content/OEmbed.php:299
+#: src/Content/OEmbed.php:317
 msgid "Embedding disabled"
 msgstr ""
 
-#: src/Content/OEmbed.php:417
+#: src/Content/OEmbed.php:441
 msgid "Embedded content"
 msgstr ""
 
@@ -2613,39 +2613,39 @@ msgstr ""
 msgid "last"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:990 src/Content/Text/BBCode.php:1808
-#: src/Content/Text/BBCode.php:1809
+#: src/Content/Text/BBCode.php:998 src/Content/Text/BBCode.php:1833
+#: src/Content/Text/BBCode.php:1834
 msgid "Image/photo"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1163
+#: src/Content/Text/BBCode.php:1188
 #, php-format
 msgid ""
 "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1188 src/Model/Item.php:3301
+#: src/Content/Text/BBCode.php:1213 src/Model/Item.php:3301
 #: src/Model/Item.php:3307 src/Model/Item.php:3308
 msgid "Link to source"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1726 src/Content/Text/HTML.php:940
+#: src/Content/Text/BBCode.php:1751 src/Content/Text/HTML.php:940
 msgid "Click to open/close"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1757
+#: src/Content/Text/BBCode.php:1782
 msgid "$1 wrote:"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1813 src/Content/Text/BBCode.php:1814
+#: src/Content/Text/BBCode.php:1838 src/Content/Text/BBCode.php:1839
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2032
+#: src/Content/Text/BBCode.php:2057
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2047
+#: src/Content/Text/BBCode.php:2072
 msgid "Invalid link protocol"
 msgstr ""
 
@@ -2780,7 +2780,7 @@ msgstr ""
 msgid "Organisations"
 msgstr ""
 
-#: src/Content/Widget.php:523 src/Model/Contact.php:1538
+#: src/Content/Widget.php:523 src/Model/Contact.php:1537
 msgid "News"
 msgstr ""
 
@@ -3455,12 +3455,12 @@ msgid ""
 "to version 2021.01 and wait until the postupdate finished version 1383."
 msgstr ""
 
-#: src/Core/Update.php:152
+#: src/Core/Update.php:153
 #, php-format
 msgid "%s: executing pre update %d"
 msgstr ""
 
-#: src/Core/Update.php:190
+#: src/Core/Update.php:191
 #, php-format
 msgid "%s: executing post update %d"
 msgstr ""
@@ -3470,7 +3470,7 @@ msgstr ""
 msgid "Update %s failed. See error logs."
 msgstr ""
 
-#: src/Core/Update.php:314
+#: src/Core/Update.php:315
 #, php-format
 msgid ""
 "\n"
@@ -3482,16 +3482,16 @@ msgid ""
 "might be invalid."
 msgstr ""
 
-#: src/Core/Update.php:320
+#: src/Core/Update.php:321
 #, php-format
 msgid "The error message is\\n[pre]%s[/pre]"
 msgstr ""
 
-#: src/Core/Update.php:324 src/Core/Update.php:366
+#: src/Core/Update.php:325 src/Core/Update.php:367
 msgid "[Friendica Notify] Database update"
 msgstr ""
 
-#: src/Core/Update.php:360
+#: src/Core/Update.php:361
 #, php-format
 msgid ""
 "\n"
@@ -3608,81 +3608,81 @@ msgstr ""
 msgid "Legacy module file not found: %s"
 msgstr ""
 
-#: src/Model/Contact.php:1104 src/Model/Contact.php:1116
+#: src/Model/Contact.php:1105 src/Model/Contact.php:1117
 msgid "UnFollow"
 msgstr ""
 
-#: src/Model/Contact.php:1122 src/Module/Admin/Users/Pending.php:107
+#: src/Model/Contact.php:1123 src/Module/Admin/Users/Pending.php:107
 #: src/Module/Notifications/Introductions.php:130
 #: src/Module/Notifications/Introductions.php:202
 msgid "Approve"
 msgstr ""
 
-#: src/Model/Contact.php:1534
+#: src/Model/Contact.php:1533
 msgid "Organisation"
 msgstr ""
 
-#: src/Model/Contact.php:1542
+#: src/Model/Contact.php:1541
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:2625
+#: src/Model/Contact.php:2630
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:2630 src/Module/Friendica.php:81
+#: src/Model/Contact.php:2635 src/Module/Friendica.php:81
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:2635
+#: src/Model/Contact.php:2640
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:2644
+#: src/Model/Contact.php:2649
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:2686
+#: src/Model/Contact.php:2691
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:2688
+#: src/Model/Contact.php:2693
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:2691
+#: src/Model/Contact.php:2696
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:2694
+#: src/Model/Contact.php:2699
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:2697
+#: src/Model/Contact.php:2702
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:2698
+#: src/Model/Contact.php:2703
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:2704
+#: src/Model/Contact.php:2709
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:2709
+#: src/Model/Contact.php:2714
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:2768
+#: src/Model/Contact.php:2773
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -5866,87 +5866,97 @@ msgstr ""
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: src/Module/Admin/Site.php:538
+#: src/Module/Admin/Site.php:537
+msgid "Generate counts per contact group when calculating network count"
+msgstr ""
+
+#: src/Module/Admin/Site.php:537
+msgid ""
+"On systems with users that heavily use contact groups the query can be very "
+"expensive."
+msgstr ""
+
+#: src/Module/Admin/Site.php:539
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:538
+#: src/Module/Admin/Site.php:539
 #, php-format
 msgid ""
 "On shared hosters set this to %d. On larger systems, values of %d are great. "
 "Default value is %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:539
+#: src/Module/Admin/Site.php:540
 msgid "Enable fastlane"
 msgstr ""
 
-#: src/Module/Admin/Site.php:539
+#: src/Module/Admin/Site.php:540
 msgid ""
 "When enabed, the fastlane mechanism starts an additional worker if processes "
 "with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: src/Module/Admin/Site.php:541
+#: src/Module/Admin/Site.php:542
 msgid "Direct relay transfer"
 msgstr ""
 
-#: src/Module/Admin/Site.php:541
+#: src/Module/Admin/Site.php:542
 msgid ""
 "Enables the direct transfer to other servers without using the relay servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:543
 msgid "Relay scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:543
 msgid ""
 "Can be \"all\" or \"tags\". \"all\" means that every public post should be "
 "received. \"tags\" means that only posts with selected tags should be "
 "received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:542 src/Module/Contact/Profile.php:273
-#: src/Module/Settings/TwoFactor/Index.php:121
+#: src/Module/Admin/Site.php:543 src/Module/Contact/Profile.php:273
+#: src/Module/Settings/TwoFactor/Index.php:126
 msgid "Disabled"
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:543
 msgid "all"
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:543
 msgid "tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:543
+#: src/Module/Admin/Site.php:544
 msgid "Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:543
+#: src/Module/Admin/Site.php:544
 msgid "Comma separated list of tags for the \"tags\" subscription."
 msgstr ""
 
-#: src/Module/Admin/Site.php:544
+#: src/Module/Admin/Site.php:545
 msgid "Deny Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:544
+#: src/Module/Admin/Site.php:545
 msgid "Comma separated list of tags that are rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:546
 msgid "Allow user tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:546
 msgid ""
 "If enabled, the tags from the saved searches will used for the \"tags\" "
 "subscription in addition to the \"relay_server_tags\"."
 msgstr ""
 
-#: src/Module/Admin/Site.php:548
+#: src/Module/Admin/Site.php:549
 msgid "Start Relocation"
 msgstr ""
 
@@ -6640,7 +6650,7 @@ msgid "Account"
 msgstr ""
 
 #: src/Module/BaseSettings.php:48 src/Module/Security/TwoFactor/Verify.php:96
-#: src/Module/Settings/TwoFactor/Index.php:113
+#: src/Module/Settings/TwoFactor/Index.php:118
 msgid "Two-factor authentication"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 msgstr ""
 
 #: src/Module/Contact/Profile.php:378
-#: src/Module/Settings/TwoFactor/Index.php:135
+#: src/Module/Settings/TwoFactor/Index.php:140
 msgid "Actions"
 msgstr ""
 
@@ -8580,10 +8590,10 @@ msgid "privacy policy"
 msgstr ""
 
 #: src/Module/Security/Logout.php:83
-#: src/Module/Security/TwoFactor/Signout.php:78
-#: src/Module/Security/TwoFactor/Signout.php:86
-#: src/Module/Security/TwoFactor/Signout.php:108
-#: src/Module/Security/TwoFactor/Signout.php:115
+#: src/Module/Security/TwoFactor/SignOut.php:78
+#: src/Module/Security/TwoFactor/SignOut.php:86
+#: src/Module/Security/TwoFactor/SignOut.php:108
+#: src/Module/Security/TwoFactor/SignOut.php:115
 msgid "Logged out."
 msgstr ""
 
@@ -8638,21 +8648,21 @@ msgstr ""
 msgid "Submit recovery code and complete login"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Signout.php:122
+#: src/Module/Security/TwoFactor/SignOut.php:122
 msgid "Sign out of this browser?"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Signout.php:123
+#: src/Module/Security/TwoFactor/SignOut.php:123
 msgid ""
 "<p>If you trust this browser, you will not be asked for verification code "
 "the next time you sign in.</p>"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Signout.php:124
+#: src/Module/Security/TwoFactor/SignOut.php:124
 msgid "Sign out"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/Signout.php:126
+#: src/Module/Security/TwoFactor/SignOut.php:126
 msgid "Trust and sign out"
 msgstr ""
 
@@ -9704,95 +9714,95 @@ msgstr ""
 msgid "Generate"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:68
+#: src/Module/Settings/TwoFactor/Index.php:69
 msgid "Two-factor authentication successfully disabled."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:116
+#: src/Module/Settings/TwoFactor/Index.php:121
 msgid ""
 "<p>Use an application on a mobile device to get two-factor authentication "
 "codes when prompted on login.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:120
+#: src/Module/Settings/TwoFactor/Index.php:125
 msgid "Authenticator app"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:121
+#: src/Module/Settings/TwoFactor/Index.php:126
 msgid "Configured"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:121
+#: src/Module/Settings/TwoFactor/Index.php:126
 msgid "Not Configured"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:122
+#: src/Module/Settings/TwoFactor/Index.php:127
 msgid "<p>You haven't finished configuring your authenticator app.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:123
+#: src/Module/Settings/TwoFactor/Index.php:128
 msgid "<p>Your authenticator app is correctly configured.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:125
+#: src/Module/Settings/TwoFactor/Index.php:130
 msgid "Recovery codes"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:126
+#: src/Module/Settings/TwoFactor/Index.php:131
 msgid "Remaining valid codes"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:128
+#: src/Module/Settings/TwoFactor/Index.php:133
 msgid ""
 "<p>These one-use codes can replace an authenticator app code in case you "
 "have lost access to it.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:130
+#: src/Module/Settings/TwoFactor/Index.php:135
 msgid "App-specific passwords"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:131
+#: src/Module/Settings/TwoFactor/Index.php:136
 msgid "Generated app-specific passwords"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:133
+#: src/Module/Settings/TwoFactor/Index.php:138
 msgid ""
 "<p>These randomly generated passwords allow you to authenticate on apps not "
 "supporting two-factor authentication.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:136
+#: src/Module/Settings/TwoFactor/Index.php:141
 msgid "Current password:"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:136
+#: src/Module/Settings/TwoFactor/Index.php:141
 msgid ""
 "You need to provide your current password to change two-factor "
 "authentication settings."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:137
+#: src/Module/Settings/TwoFactor/Index.php:142
 msgid "Enable two-factor authentication"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:138
+#: src/Module/Settings/TwoFactor/Index.php:143
 msgid "Disable two-factor authentication"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:139
+#: src/Module/Settings/TwoFactor/Index.php:144
 msgid "Show recovery codes"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:140
+#: src/Module/Settings/TwoFactor/Index.php:145
 msgid "Manage app-specific passwords"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:141
+#: src/Module/Settings/TwoFactor/Index.php:146
 msgid "Manage trusted browsers"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Index.php:142
+#: src/Module/Settings/TwoFactor/Index.php:147
 msgid "Finish app configuration"
 msgstr ""
 

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -107,6 +107,7 @@
 		<div class="submit"><input type="submit" name="page_site" value="{{$submit}}"/></div>
 
 		<h2>{{$performance}}</h2>
+		{{include file="field_checkbox.tpl" field=$compute_group_counts}}
 		{{include file="field_checkbox.tpl" field=$only_tag_search}}
 		{{include file="field_input.tpl" field=$max_comments}}
 		{{include file="field_input.tpl" field=$max_display_comments}}

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -242,6 +242,7 @@
 				</div>
 				<div id="admin-settings-performance-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-performance">
 					<div class="panel-body">
+						{{include file="field_checkbox.tpl" field=$compute_group_counts}}
 						{{include file="field_checkbox.tpl" field=$only_tag_search}}
 						{{include file="field_input.tpl" field=$max_comments}}
 						{{include file="field_input.tpl" field=$max_display_comments}}


### PR DESCRIPTION
Servers with users that heavily use the contacts group severely tax the server with each Ping request from the UI (which updates notifications, new posts in the user's network, etc.). This adds a system level toggle that the admin can use to make it so that only top level network counts are computed and returned. This defaults the value to "true" thus behavior for existing servers ill be unchanged unless the admin explicitly disables this computation.