### PR TITLE
Remove item creation abortion when parent doesn't exist

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3410,9 +3410,9 @@ class Item
 			return is_numeric($hookData['item_id']) ? $hookData['item_id'] : 0;
 		}
 
-		$fetchQueue = new ActivityPub\FetchQueue();
-		$fetched_uri = ActivityPub\Processor::fetchMissingActivity($fetchQueue, $uri);
-		$fetchQueue->process();
+		$fetchQueue = new ActivityPub\FetchQueue(DI::logger());
+		$fetchQueue->push(new ActivityPub\FetchQueueItem($uri));
+		$fetched_uri = $fetchQueue->process();
 
 		if ($fetched_uri) {
 			$item_id = self::searchByLink($fetched_uri, $uid);

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -23,9 +23,11 @@ namespace Friendica\Protocol;
 
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
+use Friendica\DI;
 use Friendica\Model\APContact;
 use Friendica\Model\User;
 use Friendica\Protocol\ActivityPub\FetchQueue;
+use Friendica\Protocol\ActivityPub\FetchQueueItem;
 use Friendica\Util\HTTPSignature;
 use Friendica\Util\JsonLD;
 
@@ -224,11 +226,14 @@ class ActivityPub
 			$items = [];
 		}
 
-		$fetchQueue = new FetchQueue();
+		$fetchQueue = new FetchQueue(DI::logger());
 
 		foreach ($items as $activity) {
-			$ldactivity = JsonLD::compact($activity);
-			ActivityPub\Receiver::processActivity($fetchQueue, $ldactivity, '', $uid, true);
+			// This should replace the below commented out code but I'm not sure it can be replaced as is.
+			$fetchQueue->push(new FetchQueueItem($activity['id']));
+
+			//$ldactivity = JsonLD::compact($activity);
+			//ActivityPub\Receiver::processActivity($fetchQueue, $ldactivity, '', $uid, true);
 		}
 
 		$fetchQueue->process();

--- a/src/Protocol/ActivityPub/FetchQueueItem.php
+++ b/src/Protocol/ActivityPub/FetchQueueItem.php
@@ -48,6 +48,11 @@ class FetchQueueItem
 		$this->completion  = $completion;
 	}
 
+	public function getUrl(): string
+	{
+		return $this->url;
+	}
+
 	/**
 	 * Array meant to be used in call_user_function_array([Processor::class, 'fetchMissingActivity']). Caller needs to
 	 * provide an instance of a FetchQueue that isn't included in these parameters.

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -291,13 +291,6 @@ class Processor
 		}
 
 		$item['diaspora_signed_text'] = $activity['diaspora:comment'] ?? '';
-
-		/// @todo What to do with $activity['context']?
-		if (empty($activity['directmessage']) && ($item['gravity'] != GRAVITY_PARENT) && !Post::exists(['uri' => $item['thr-parent']])) {
-			Logger::info('Parent not found, message will be discarded.', ['thr-parent' => $item['thr-parent']]);
-			return [];
-		}
-
 		$item['network'] = Protocol::ACTIVITYPUB;
 		$item['author-link'] = $activity['author'];
 		$item['author-id'] = Contact::getIdForURL($activity['author']);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -288,6 +288,10 @@ class Processor
 			 * caller is responsible for processing the remaining queue once the original activity has been processed.
 			 */
 			$fetchQueue->push(new FetchQueueItem($activity['reply-to-id'], $activity));
+
+			// We exit here because we need the parent later, so the item creation would fail anyway. The ancestors will
+			// be processed in FetchQueue->process()
+			return [];
 		}
 
 		$item['diaspora_signed_text'] = $activity['diaspora:comment'] ?? '';

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -271,10 +271,10 @@ class HTTPSignature
 	 * @param string  $target The URL of the inbox
 	 * @param integer $uid    User id of the sender
 	 *
-	 * @return ICanHandleHttpResponses
+	 * @return ?ICanHandleHttpResponses
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function post(array $data, string $target, int $uid): ICanHandleHttpResponses
+	public static function post(array $data, string $target, int $uid): ?ICanHandleHttpResponses
 	{
 		$owner = User::getOwnerDataById($uid);
 


### PR DESCRIPTION
Address #11716 

- Asynchronous parent fetching means parent won't be available immediately
- Added orphan cleanup in FetchQueue::process as a replacement