### PR TITLE
Fix frio settings display error setting scheme to custom type if null

### DIFF
--- a/view/theme/frio/php/scheme.php
+++ b/view/theme/frio/php/scheme.php
@@ -42,7 +42,7 @@ function get_scheme_info($scheme)
 	$theme = DI::app()->getCurrentTheme();
 	$themepath = 'view/theme/' . $theme . '/';
 	if (empty($scheme)) {
-		$scheme = DI::pConfig()->get(local_user(), 'frio', 'scheme', DI::pConfig()->get(local_user(), 'frio', 'schema'));
+		$scheme = DI::pConfig()->get(local_user(), 'frio', 'scheme', DI::pConfig()->get(local_user(), 'frio', 'schema', '---'));
 	}
 
 	$scheme = Strings::sanitizeFilePathItem($scheme);
@@ -56,7 +56,9 @@ function get_scheme_info($scheme)
 		'accented' => false,
 	];
 
-	if (!is_file($themepath . 'scheme/' . $scheme . '.php')) return $info;
+	if (!is_file($themepath . 'scheme/' . $scheme . '.php')) {
+		return $info;
+	}
 
 	$f = file_get_contents($themepath . 'scheme/' . $scheme . '.php');
 


### PR DESCRIPTION
The Frio theme's settings/display page throws a 500 error because the scheme variable was coming back as null when it had never been set before. The original code seemed to do the call twice when trying to pull the value from `pConfig`. With the new call to `Strings::sanitizeFilePathItem` a null value throws an exception. There is a magic string for the default custom scheme of `---`. I therefore made that the result of the second call to try to get the setting. Since the value isn't set on either call I'm thinking perhaps I should just make it the default value from the first call but I didn't want to change that code since it has been there since April 2018.