### PR TITLE
$link_item might be boolean (no record found) under rare conditions

### DIFF
--- a/src/Navigation/Notifications/Factory/Notification.php
+++ b/src/Navigation/Notifications/Factory/Notification.php
@@ -183,6 +183,13 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 				}
 			}
 
+			// Final check on $link_item
+			// @see https://github.com/friendica/friendica/issues/11632#issuecomment-1183365937
+			if (empty($link_item)) {
+				$this->logger->info('Link item is still empty. Dumping whole Notification object:', [$Notification]);
+				return $message;
+			}
+
 			$link = $this->baseUrl . '/display/' . urlencode($link_item['guid']);
 
 			$body = BBCode::toPlaintext($item['body'], false);


### PR DESCRIPTION
Changed:
- added a final check on `$link_item`, as it might not be initialized or no record was found, thanks to @AlfredSK for reporting this
- address https://github.com/friendica/friendica/issues/11632#issuecomment-1183365937