### PR TITLE
Emergency fixes to fix a bunch of fatal errors

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -359,7 +359,7 @@ class Contact
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function isFollowerByURL(string $url, uid $uid): bool
+	public static function isFollowerByURL(string $url, int $uid): bool
 	{
 		$cid = self::getIdForURL($url, $uid);
 
@@ -1169,11 +1169,11 @@ class Contact
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function getIdForURL(string $url, int $uid = 0, $update = null, array $default = []): int
+	public static function getIdForURL(string $url = null, int $uid = 0, $update = null, array $default = []): int
 	{
 		$contact_id = 0;
 
-		if ($url == '') {
+		if (empty($url)) {
 			Logger::notice('Empty url, quitting', ['url' => $url, 'user' => $uid, 'default' => $default]);
 			return 0;
 		}

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -900,7 +900,7 @@ class Processor
 		}
 
 		// Store send a follow request for every reshare - but only when the item had been stored
-		if ($stored && ($item['private'] != Item::PRIVATE) && ($item['gravity'] == GRAVITY_PARENT) && ($item['author-link'] != $item['owner-link'])) {
+		if ($stored && ($item['private'] != Item::PRIVATE) && ($item['gravity'] == GRAVITY_PARENT) && !empty($item['author-link']) && ($item['author-link'] != $item['owner-link'])) {
 			$author = APContact::getByURL($item['owner-link'], false);
 			// We send automatic follow requests for reshared messages. (We don't need though for forum posts)
 			if ($author['type'] != 'Group') {

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -48,10 +48,10 @@ use Friendica\Network\Probe;
 use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
-use Friendica\Util\Network;
 use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
+use GuzzleHttp\Psr7\Uri;
 
 /**
  * This class contain functions to create and send DFRN XML files
@@ -1013,7 +1013,7 @@ class DFRN
 			$path_parts = explode('/', $parts['path']);
 			array_pop($path_parts);
 			$parts['path'] =  implode('/', $path_parts);
-			$contact['batch'] = Network::unparseURL($parts);
+			$contact['batch'] = Uri::fromParts($parts);
 		}
 
 		$dest_url = ($public_batch ? $contact['batch'] : $contact['notify']);

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -50,6 +50,7 @@ use Friendica\Util\Network;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
 use Friendica\Worker\Delivery;
+use GuzzleHttp\Psr7\Uri;
 use SimpleXMLElement;
 
 /**
@@ -755,14 +756,14 @@ class Diaspora
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	private static function key(string $handle): string
+	private static function key(string $handle = null): string
 	{
 		$handle = strval($handle);
 
 		Logger::notice("Fetching diaspora key for: " . $handle);
 
 		$fcontact = FContact::getByURL($handle);
-		if ($fcontact) {
+		if (!empty($fcontact['pubkey'])) {
 			return $fcontact['pubkey'];
 		}
 
@@ -1417,7 +1418,7 @@ class Diaspora
 
 			$parts = parse_url($person['url']);
 			unset($parts['path']);
-			$host_url = Network::unparseURL($parts);
+			$host_url = Uri::fromParts($parts);
 
 			return $host_url . '/objects/' . $guid;
 		}
@@ -4006,12 +4007,12 @@ class Diaspora
 	/**
 	 * Sends profile data
 	 *
-	 * @param int  $uid    The user id
-	 * @param bool $recips optional, default false
+	 * @param int   $uid    The user id
+	 * @param array $recips optional, default empty array
 	 * @return void
 	 * @throws \Exception
 	 */
-	public static function sendProfile(int $uid, bool $recips = false)
+	public static function sendProfile(int $uid, array $recips = [])
 	{
 		if (!$uid) {
 			return;

--- a/src/Protocol/Email.php
+++ b/src/Protocol/Email.php
@@ -570,7 +570,7 @@ class Email
 	 * Removes signature from message
 	 *
 	 * @param string $message Unfiltered message
-	 * @return string Message with no signature
+	 * @return array Message array with no signature (elements "body" and "sig")
 	 */
 	private static function removeSig(string $message): array
 	{

--- a/src/Protocol/Email.php
+++ b/src/Protocol/Email.php
@@ -115,13 +115,13 @@ class Email
 	}
 
 	/**
-	 * @param Connection|resource $mbox mailbox
-	 * @param integer             $uid  user id
+	 * @param Connection|resource $mbox     mailbox
+	 * @param string              $sequence
 	 * @return mixed
 	 */
-	public static function messageMeta($mbox, int $uid)
+	public static function messageMeta($mbox, string $sequence)
 	{
-		$ret = (($mbox && $uid) ? @imap_fetch_overview($mbox, $uid, FT_UID) : [[]]); // POSSIBLE CLEANUP --> array(array()) is probably redundant now
+		$ret = (($mbox && $sequence) ? @imap_fetch_overview($mbox, $sequence, FT_UID) : [[]]); // POSSIBLE CLEANUP --> array(array()) is probably redundant now
 		return (count($ret)) ? $ret : [];
 	}
 
@@ -296,6 +296,7 @@ class Email
 			}
 			return $x;
 		}
+		return '';
 	}
 
 	/**
@@ -571,7 +572,7 @@ class Email
 	 * @param string $message Unfiltered message
 	 * @return string Message with no signature
 	 */
-	private static function removeSig(string $message): string
+	private static function removeSig(string $message): array
 	{
 		$sigpos = strrpos($message, "\n-- \n");
 		$quotepos = strrpos($message, "[/quote]");
@@ -662,7 +663,7 @@ class Email
 		return implode("\n", $lines);
 	}
 
-	private static function convertQuote(strng $body, string $reply): string
+	private static function convertQuote(string $body, string $reply): string
 	{
 		// Convert Quotes
 		$arrbody = explode("\n", trim($body));

--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -42,9 +42,9 @@ class XML
 	 * @param bool   $remove_header Should the XML header be removed or not?
 	 * @param array  $namespaces    List of namespaces
 	 * @param bool   $root          interally used parameter. Mustn't be used from outside.
-	 * @return void
+	 * @return string
 	 */
-	public static function fromArray(array $array, &$xml, bool $remove_header = false, array $namespaces = [], bool $root = true)
+	public static function fromArray(array $array, &$xml, bool $remove_header = false, array $namespaces = [], bool $root = true): string
 	{
 		if ($root) {
 			foreach ($array as $key => $value) {
@@ -130,6 +130,7 @@ class XML
 				self::fromArray($value, $element, $remove_header, $namespaces, false);
 			}
 		}
+		return '';
 	}
 
 	/**
@@ -142,7 +143,7 @@ class XML
 	 */
 	public static function copy(&$source, &$target, string $elementname)
 	{
-		if (count($source->children()) == 0) {
+		if (is_string($source) && count($source->children()) == 0) {
 			$target->addChild($elementname, self::escape($source));
 		} else {
 			$child = $target->addChild($elementname);
@@ -184,9 +185,9 @@ class XML
 	 * @param array       $attributes Array containing the attributes
 	 * @return void
 	 */
-	public static function addElement(DOMDocument $doc, DOMElement &$parent, string $element, string $value = '', array $attributes = [])
+	public static function addElement(DOMDocument $doc, DOMElement &$parent, string $element, string $value = null, array $attributes = [])
 	{
-		$element = self::createElement($doc, $element, $value, $attributes);
+		$element = self::createElement($doc, $element, $value ?? '', $attributes);
 		$parent->appendChild($element);
 	}
 
@@ -273,6 +274,7 @@ class XML
 			return [];
 		}
 
+		$parent = [];
 
 		libxml_use_internal_errors(true);
 		libxml_clear_errors();

--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -136,14 +136,14 @@ class XML
 	/**
 	 * Copies an XML object
 	 *
-	 * @param object $source      The XML source
-	 * @param object $target      The XML target
-	 * @param string $elementname Name of the XML element of the target
+	 * @param object|string $source      The XML source
+	 * @param object        $target      The XML target
+	 * @param string        $elementname Name of the XML element of the target
 	 * @return void
 	 */
 	public static function copy(&$source, &$target, string $elementname)
 	{
-		if (is_string($source) && count($source->children()) == 0) {
+		if (is_string($source)) {
 			$target->addChild($elementname, self::escape($source));
 		} else {
 			$child = $target->addChild($elementname);


### PR DESCRIPTION
This PR fixes a bunch of fatal errors that occur during the transmitting or receiving of posts and some other background tasks.

They can be spotted by looking into the log file for entries with `Uncaught Exception`.