### PR TITLE
Fixes/type hints doctag

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -65,7 +65,7 @@ function photos_init(App $a) {
 
 	if (DI::args()->getArgc() > 1) {
 		$owner = User::getOwnerDataByNick(DI::args()->getArgv()[1]);
-		if (empty($owner) || $owner['account_removed']) {
+		if (!isset($owner['account_removed']) || $owner['account_removed']) {
 			throw new HTTPException\NotFoundException(DI::l10n()->t('User not found.'));
 		}
 

--- a/src/Console/User.php
+++ b/src/Console/User.php
@@ -310,7 +310,7 @@ HELP;
 	 * @return bool True, if the delete was successful
 	 * @throws \Exception
 	 */
-	private function deleteUser()
+	private function deleteUser(): bool
 	{
 		$user = $this->getUserByNick(1);
 

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -54,19 +54,19 @@ class Search
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function getContactsFromProbe($user)
+	public static function getContactsFromProbe(string $user): ResultList
 	{
 		$emptyResultList = new ResultList(1, 0, 1);
 
 		if ((filter_var($user, FILTER_VALIDATE_EMAIL) && Network::isEmailDomainValid($user)) ||
-		    (substr(Strings::normaliseLink($user), 0, 7) == "http://")) {
+		    (substr(Strings::normaliseLink($user), 0, 7) == 'http://')) {
 
 			$user_data = Contact::getByURL($user);
 			if (empty($user_data)) {
 				return $emptyResultList;
 			}
 
-			if (!in_array($user_data["network"], Protocol::FEDERATED)) {
+			if (!in_array($user_data['network'], Protocol::FEDERATED)) {
 				return $emptyResultList;
 			}
 
@@ -102,7 +102,7 @@ class Search
 	 * @return ResultList
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public static function getContactsFromGlobalDirectory($search, $type = self::TYPE_ALL, $page = 1)
+	public static function getContactsFromGlobalDirectory(string $search, int$type = self::TYPE_ALL, int $page = 1): ResultList
 	{
 		$server = self::getGlobalDirectory();
 
@@ -167,7 +167,7 @@ class Search
 	 * @return ResultList
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public static function getContactsFromLocalDirectory($search, $type = self::TYPE_ALL, $start = 0, $itemPage = 80)
+	public static function getContactsFromLocalDirectory(string $search, int $type = self::TYPE_ALL, int $start = 0, int $itemPage = 80): ResultList
 	{
 		Logger::info('Searching', ['search' => $search, 'type' => $type, 'start' => $start, 'itempage' => $itemPage]);
 
@@ -177,15 +177,15 @@ class Search
 
 		foreach ($contacts as $contact) {
 			$result = new ContactResult(
-				$contact["name"],
-				$contact["addr"],
-				$contact["addr"],
-				$contact["url"],
-				$contact["photo"],
-				$contact["network"],
-				$contact["cid"] ?? 0,
-				$contact["zid"] ?? 0,
-				$contact["keywords"]
+				$contact['name'],
+				$contact['addr'],
+				$contact['addr'],
+				$contact['url'],
+				$contact['photo'],
+				$contact['network'],
+				$contact['cid'] ?? 0,
+				$contact['zid'] ?? 0,
+				$contact['keywords']
 			);
 
 			$resultList->addResult($result);
@@ -203,10 +203,11 @@ class Search
 	 * @param string $search Name or part of a name or nick
 	 * @param string $mode   Search mode (e.g. "community")
 	 * @param int    $page   Page number (starts at 1)
-	 * @return array with the search results
+	 *
+	 * @return array with the search results or empty if error or nothing found
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public static function searchContact($search, $mode, int $page = 1)
+	public static function searchContact(string $search, string $mode, int $page = 1): array
 	{
 		Logger::info('Searching', ['search' => $search, 'mode' => $mode, 'page' => $page]);
 
@@ -245,7 +246,7 @@ class Search
 	 *
 	 * @return string
 	 */
-	public static function getGlobalDirectory()
+	public static function getGlobalDirectory(): string
 	{
 		return DI::config()->get('system', 'directory', self::DEFAULT_DIRECTORY);
 	}
@@ -254,9 +255,10 @@ class Search
 	 * Return the search path (either fulltext search or tag search)
 	 *
 	 * @param string $search
+	 *
 	 * @return string search path
 	 */
-	public static function getSearchPath(string $search)
+	public static function getSearchPath(string $search): string
 	{
 		if (substr($search, 0, 1) == '#') {
 			return 'search?tag=' . urlencode(substr($search, 1));

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -102,7 +102,7 @@ class Search
 	 * @return ResultList
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public static function getContactsFromGlobalDirectory(string $search, int$type = self::TYPE_ALL, int $page = 1): ResultList
+	public static function getContactsFromGlobalDirectory(string $search, int $type = self::TYPE_ALL, int $page = 1): ResultList
 	{
 		$server = self::getGlobalDirectory();
 

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -221,7 +221,7 @@ class Profile
 	public static function load(App $a, string $nickname, bool $show_contacts = true)
 	{
 		$profile = User::getOwnerDataByNick($nickname);
-		if (empty($profile) || !isset($profile['account_removed']) || $profile['account_removed']) {
+		if (!isset($profile['account_removed']) || $profile['account_removed']) {
 			Logger::info('profile error: ' . DI::args()->getQueryString());
 			return [];
 		}

--- a/src/Module/BaseSearch.php
+++ b/src/Module/BaseSearch.php
@@ -47,7 +47,7 @@ class BaseSearch extends BaseModule
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function performContactSearch($search, $prefix = '')
+	public static function performContactSearch(string $search, string $prefix = ''): string
 	{
 		$config = DI::config();
 
@@ -113,7 +113,7 @@ class BaseSearch extends BaseModule
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	protected static function printResult(ResultList $results, Pager $pager, $header = '')
+	protected static function printResult(ResultList $results, Pager $pager, string $header = ''): string
 	{
 		if ($results->getTotal() == 0) {
 			notice(DI::l10n()->t('No matches'));

--- a/src/Module/Search/Acl.php
+++ b/src/Module/Search/Acl.php
@@ -65,7 +65,7 @@ class Acl extends BaseModule
 		System::jsonExit($o);
 	}
 
-	private static function globalContactSearch()
+	private static function globalContactSearch(): array
 	{
 		// autocomplete for global contact search (e.g. navbar search)
 		$search = trim($_REQUEST['search']);
@@ -95,7 +95,7 @@ class Acl extends BaseModule
 		return $o;
 	}
 
-	private static function regularContactSearch(string $type)
+	private static function regularContactSearch(string $type): array
 	{
 		$start   = $_REQUEST['start']        ?? 0;
 		$count   = $_REQUEST['count']        ?? 100;


### PR DESCRIPTION
This PR adds some type-hints and corrects some documentation tags. It also changes checking on `$foo['account_removed']`, thanks to @MrPetovan 's suggestion.