### PR TITLE
Fixed missing $contact array, at least initialize it empty

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -4081,6 +4081,7 @@ class Diaspora
 	 */
 	public static function createCommentSignature(array $item)
 	{
+		$contact = [];
 		if (!empty($item['author-link'])) {
 			$url = $item['author-link'];
 		} else {
@@ -4094,7 +4095,7 @@ class Diaspora
 
 		$uid = User::getIdForURL($url);
 		if (empty($uid)) {
-			Logger::info('No owner post, so not storing signature', ['url' => $contact['url']]);
+			Logger::info('No owner post, so not storing signature', ['url' => $contact['url'] ?? 'No contact loaded']);
 			return false;
 		}
 


### PR DESCRIPTION
Fixed:
 - "Undefined variable: contact in .../src/Protocol/Diaspora.php on line 4097
Trying to access array offset on value of type null in .../src/Protocol/Diaspora.php on line 4097"
- see https://github.com/friendica/friendica/issues/11632#issuecomment-1189465336