### PR TITLE
Added logging of unsupported meta-tag records

### DIFF
--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -425,6 +425,8 @@ class ParseUrl
 				case 'news_keywords':
 					$keywords = explode(',', $meta_tag['content']);
 					break;
+				default:
+					Logger::debug('Unsupported meta-tag found', ['meta-tag' => $meta_tag]);
 			}
 		}
 


### PR DESCRIPTION
This small change logs unsupported meta tags. At least they should be logged.