### PR TITLE
Replace SFTP-publish with docker-publish

### DIFF
--- a/.woodpecker/.continuous-deployment.yml
+++ b/.woodpecker/.continuous-deployment.yml
@@ -90,37 +90,12 @@ pipeline:
       repo: friendica/friendica
       branch: [ develop, '*-rc' ]
       event: push
-  upload_artifacts:
+  publish_artifacts:
     image: alpine
-    secrets:
-      - source: sftp_host
-        target: lftp_host
-      - source: sftp_user
-        target: lftp_user
-      - source: ssh_key
-        target: lftp_key
-    environment:
-      LFTP_PORT: "22"
-      LFTP_SOURCE: "build"
-      LFTP_TARGET: "/http"
-    volumes:
-      - /etc/hosts:/etc/hosts
     commands:
-      - apk add lftp openssh openssl
-      - touch drone.key
-      - chmod 400 drone.key
-      - echo "$LFTP_KEY" | openssl base64 -A -d > drone.key
-      - lftp -c "
-        set net:timeout 5;
-        set net:max-retries 2;
-        set net:reconnect-interval-base 5;
-        set sftp:auto-confirm true;
-        set sftp:connect-program 'ssh -q -a -x -i drone.key';
-        connect sftp://$LFTP_USER:@$LFTP_HOST:$LFTP_PORT;
-        cd $LFTP_TARGET;
-        mput $LFTP_SOURCE/*;
-        "
-      - rm drone.key
+      - cp -fr build/* /tmp/friendica_files/
+    volumes:
+      - files:/tmp/friendica_files
     when:
       repo: friendica/friendica
       branch: [ develop, '*-rc' ]

--- a/.woodpecker/.releaser.yml
+++ b/.woodpecker/.releaser.yml
@@ -88,37 +88,12 @@ pipeline:
       repo: friendica/friendica
       branch: stable
       event: tag
-  upload_artifacts:
+  publish_artifacts:
     image: alpine
-    secrets:
-      - source: sftp_host
-        target: lftp_host
-      - source: sftp_user
-        target: lftp_user
-      - source: ssh_key
-        target: lftp_key
-    environment:
-      LFTP_PORT: "22"
-      LFTP_SOURCE: "build"
-      LFTP_TARGET: "/http"
-    volumes:
-      - /etc/hosts:/etc/hosts
     commands:
-      - apk add lftp openssh openssl
-      - touch drone.key
-      - chmod 400 drone.key
-      - echo "$LFTP_KEY" | openssl base64 -A -d > drone.key
-      - lftp -c "
-        set net:timeout 5;
-        set net:max-retries 2;
-        set net:reconnect-interval-base 5;
-        set sftp:auto-confirm true;
-        set sftp:connect-program 'ssh -q -a -x -i drone.key';
-        connect sftp://$LFTP_USER:@$LFTP_HOST:$LFTP_PORT;
-        cd $LFTP_TARGET;
-        mput $LFTP_SOURCE/*;
-        "
-      - rm drone.key
+      - cp -fr build/* /tmp/friendica_files/
+    volumes:
+      - files:/tmp/friendica_files
     when:
       repo: friendica/friendica
       branch: stable


### PR DESCRIPTION
Replaces SFTP Login process with easy publishing per shared docker volume :)

https://files.friendi.ca already points to this directory (thx @utzer)

Needs https://github.com/friendica/friendica-addons/pull/1277 as well