### PR TITLE
Wrong variable name fixed (maybe copy-paste mistake) + used method instead of direct array access

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2969,7 +2969,7 @@ class Contact
 
 		$cdata = self::getPublicAndUserContactID($contact['id'], $contact['uid']);
 
-		DI::notification()->deleteForUserByVerb($contact['uid'], Activity::FOLLOW, ['actor-id' => $cdata['public']]);
+		DI::notification()->deleteForUserByVerb($contact['uid'], Activity::FOLLOW, ['actor-id' => $contact['public']]);
 	}
 
 	/**

--- a/src/Module/Api/Friendica/DirectMessages/Search.php
+++ b/src/Module/Api/Friendica/DirectMessages/Search.php
@@ -77,7 +77,7 @@ class Search extends BaseApi
 		} else {
 			$ret = [];
 			foreach ($mails as $mail) {
-				$ret[] = $this->directMessage->createFromMailId($mail['id'], $uid, $request['getText'] ?? '');
+				$ret[] = $this->directMessage->createFromMailId($mail['id'], $uid, $this->getRequestValue($request, 'getText', ''));
 			}
 			$success = ['success' => true, 'search_results' => $ret];
 		}

--- a/src/Module/Api/Friendica/Group/Delete.php
+++ b/src/Module/Api/Friendica/Group/Delete.php
@@ -44,7 +44,7 @@ class Delete extends BaseApi
 		// params
 
 		// error if no gid specified
-		if ($request['gid'] == 0 || $request['name'] == "") {
+		if ($request['gid'] == 0 || $request['name'] == '') {
 			throw new BadRequestException('gid or name not specified');
 		}
 

--- a/src/Module/Api/Friendica/Notification/Seen.php
+++ b/src/Module/Api/Friendica/Notification/Seen.php
@@ -47,7 +47,7 @@ class Seen extends BaseApi
 			throw new BadRequestException('Invalid argument count');
 		}
 
-		$id = intval($request['id'] ?? 0);
+		$id = intval($this->getRequestValue($request, 'id', 0));
 
 		$include_entities = $this->getRequestValue($request, 'include_entities', false);
 

--- a/src/Module/Api/GNUSocial/Statusnet/Conversation.php
+++ b/src/Module/Api/GNUSocial/Statusnet/Conversation.php
@@ -50,7 +50,7 @@ class Conversation extends BaseApi
 		$start = max(0, ($page - 1) * $count);
 
 		if ($id == 0) {
-			$id = $request['id'] ?? 0;
+			$id = $this->getRequestValue($request, 'id', 0);
 		}
 
 		Logger::info(BaseApi::LOG_PREFIX . '{subaction}', ['module' => 'api', 'action' => 'conversation', 'subaction' => 'show', 'id' => $id]);

--- a/src/Module/Api/Twitter/Account/RateLimitStatus.php
+++ b/src/Module/Api/Twitter/Account/RateLimitStatus.php
@@ -34,13 +34,13 @@ class RateLimitStatus extends BaseApi
 		if (($this->parameters['extension'] ?? '') == 'xml') {
 			$hash = [
 				'remaining-hits'        => '150',
-				'@attributes'           => ["type" => "integer"],
+				'@attributes'           => ['type' => 'integer'],
 				'hourly-limit'          => '150',
-				'@attributes2'          => ["type" => "integer"],
+				'@attributes2'          => ['type' => 'integer'],
 				'reset-time'            => DateTimeFormat::utc('now + 1 hour', DateTimeFormat::ATOM),
-				'@attributes3'          => ["type" => "datetime"],
+				'@attributes3'          => ['type' => 'datetime'],
 				'reset_time_in_seconds' => strtotime('now + 1 hour'),
-				'@attributes4'          => ["type" => "integer"],
+				'@attributes4'          => ['type' => 'integer'],
 			];
 		} else {
 			$hash = [

--- a/src/Module/Api/Twitter/DirectMessages/Conversation.php
+++ b/src/Module/Api/Twitter/DirectMessages/Conversation.php
@@ -34,6 +34,6 @@ class Conversation extends DirectMessagesEndpoint
 		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
-		$this->getMessages($request, $uid, ["`parent-uri` = ?", $request['uri'] ?? '']);
+		$this->getMessages($request, $uid, ["`parent-uri` = ?", $this->getRequestValue($request, 'uri', '')]);
 	}
 }

--- a/src/Module/Api/Twitter/DirectMessages/Destroy.php
+++ b/src/Module/Api/Twitter/DirectMessages/Destroy.php
@@ -55,9 +55,8 @@ class Destroy extends BaseApi
 		$id = $this->getRequestValue($request, 'id', 0);
 		$id = $this->getRequestValue($this->parameters, 'id', $id);
 
-		$verbose = $this->getRequestValue($request, 'friendica_verbose', false);
-
-		$parenturi = $request['friendica_parenturi'] ?? '';
+		$verbose   = $this->getRequestValue($request, 'friendica_verbose', false);
+		$parenturi = $this->getRequestValue($request, 'friendica_parenturi', '');
 
 		// error if no id or parenturi specified (for clients posting parent-uri as well)
 		if ($verbose && $id == 0 && $parenturi == "") {

--- a/src/Module/Api/Twitter/DirectMessages/NewDM.php
+++ b/src/Module/Api/Twitter/DirectMessages/NewDM.php
@@ -63,7 +63,7 @@ class NewDM extends BaseApi
 			return;
 		}
 
-		$cid = BaseApi::getContactIDForSearchterm($request['screen_name'] ?? '', $request['profileurl'] ?? '', $request['user_id'] ?? 0, 0);
+		$cid = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'screen_name', ''), $this->getRequestValue($request, 'profileurl', ''), $this->getRequestValue($request, 'user_id', 0), 0);
 		if (empty($cid)) {
 			throw new NotFoundException('Recipient not found');
 		}
@@ -86,7 +86,7 @@ class NewDM extends BaseApi
 		$id = Mail::send($cdata['user'], $request['text'], $sub, $replyto);
 
 		if ($id > -1) {
-			$ret = $this->directMessage->createFromMailId($id, $uid, $request['getText'] ?? '');
+			$ret = $this->directMessage->createFromMailId($id, $uid, $this->getRequestValue($request, 'getText', ''));
 		} else {
 			$ret = ['error' => $id];
 		}

--- a/src/Module/Api/Twitter/DirectMessagesEndpoint.php
+++ b/src/Module/Api/Twitter/DirectMessagesEndpoint.php
@@ -84,7 +84,7 @@ abstract class DirectMessagesEndpoint extends BaseApi
 			$params['order'] = ['id'];
 		}
 
-		$cid = BaseApi::getContactIDForSearchterm($request['screen_name'] ?? '', $request['profileurl'] ?? '', $request['user_id'] ?? 0, 0);
+		$cid = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'screen_name', ''), $this->getRequestValue($request, 'profileurl', ''), $this->getRequestValue($request, 'user_id', 0), 0);
 		if (!empty($cid)) {
 			$cdata = Contact::getPublicAndUserContactID($cid, $uid);
 			if (!empty($cdata['user'])) {
@@ -109,7 +109,7 @@ abstract class DirectMessagesEndpoint extends BaseApi
 
 		$ret = [];
 		foreach ($ids as $id) {
-			$ret[] = $this->directMessage->createFromMailId($id, $uid, $request['getText'] ?? '');
+			$ret[] = $this->directMessage->createFromMailId($id, $uid, $this->getRequestValue($request, 'getText', ''));
 		}
 
 		self::setLinkHeader();

--- a/src/Module/Api/Twitter/Favorites/Create.php
+++ b/src/Module/Api/Twitter/Favorites/Create.php
@@ -37,7 +37,7 @@ class Create extends BaseApi
 		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
-		$id = $request['id'] ?? 0;
+		$id = $this->getRequestValue($request, 'id', 0);
 
 		if (empty($id)) {
 			throw new BadRequestException('Item id not specified');

--- a/src/Module/Api/Twitter/Favorites/Destroy.php
+++ b/src/Module/Api/Twitter/Favorites/Destroy.php
@@ -37,7 +37,7 @@ class Destroy extends BaseApi
 		self::checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
-		$id = $request['id'] ?? 0;
+		$id = $this->getRequestValue($request, 'id', 0);
 
 		if (empty($id)) {
 			throw new BadRequestException('Item id not specified');

--- a/src/Module/Api/Twitter/Followers/Ids.php
+++ b/src/Module/Api/Twitter/Followers/Ids.php
@@ -37,7 +37,7 @@ class Ids extends ContactEndpoint
 		$uid = BaseApi::getCurrentUserID();
 
 		// Expected value for user_id parameter: public/user contact id
-		$cid           = BaseApi::getContactIDForSearchterm($request['screen_name'] ?? '', $request['profileurl'] ?? '', $request['user_id'] ?? 0, $uid);
+		$cid           = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'screen_name', ''), $this->getRequestValue($request, 'profileurl', ''), $this->getRequestValue($request, 'user_id', 0), $uid);
 		$cursor        = $this->getRequestValue($request, 'cursor', -1);
 		$stringify_ids = $this->getRequestValue($request, 'stringify_ids', false);
 		$count         = $this->getRequestValue($request, 'count', self::DEFAULT_COUNT, 1, self::MAX_COUNT);

--- a/src/Module/Api/Twitter/Followers/Lists.php
+++ b/src/Module/Api/Twitter/Followers/Lists.php
@@ -37,7 +37,7 @@ class Lists extends ContactEndpoint
 		$uid = BaseApi::getCurrentUserID();
 
 		// Expected value for user_id parameter: public/user contact id
-		$cid                   = BaseApi::getContactIDForSearchterm($request['screen_name'] ?? '', $request['profileurl'] ?? '', $request['user_id'] ?? 0, $uid);
+		$cid                   = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'screen_name', ''), $this->getRequestValue($request, 'profileurl', ''), $this->getRequestValue($request, 'user_id', 0), $uid);
 		$cursor                = $this->getRequestValue($request, 'cursor', -1);
 		$skip_status           = $this->getRequestValue($request, 'skip_status', false);
 		$include_user_entities = $this->getRequestValue($request, 'include_user_entities', false);

--- a/src/Module/Api/Twitter/Friends/Ids.php
+++ b/src/Module/Api/Twitter/Friends/Ids.php
@@ -37,7 +37,7 @@ class Ids extends ContactEndpoint
 		$uid = BaseApi::getCurrentUserID();
 
 		// Expected value for user_id parameter: public/user contact id
-		$cid           = BaseApi::getContactIDForSearchterm($request['screen_name'] ?? '', $request['profileurl'] ?? '', $request['user_id'] ?? 0, $uid);
+		$cid           = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'screen_name', ''), $this->getRequestValue($request, 'profileurl', ''), $this->getRequestValue($request, 'user_id', 0), $uid);
 		$cursor        = $this->getRequestValue($request, 'cursor', -1);
 		$stringify_ids = $this->getRequestValue($request, 'stringify_ids', false);
 		$count         = $this->getRequestValue($request, 'count', self::DEFAULT_COUNT, 1, self::MAX_COUNT);

--- a/src/Module/Api/Twitter/Friends/Lists.php
+++ b/src/Module/Api/Twitter/Friends/Lists.php
@@ -37,7 +37,7 @@ class Lists extends ContactEndpoint
 		$uid = BaseApi::getCurrentUserID();
 
 		// Expected value for user_id parameter: public/user contact id
-		$cid                   = BaseApi::getContactIDForSearchterm($request['screen_name'] ?? '', $request['profileurl'] ?? '', $request['user_id'] ?? 0, $uid);
+		$cid                   = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'screen_name', ''), $this->getRequestValue($request, 'profileurl', ''), $this->getRequestValue($request, 'user_id', 0), $uid);
 		$cursor                = $this->getRequestValue($request, 'cursor', -1);
 		$skip_status           = $this->getRequestValue($request, 'skip_status', false);
 		$include_user_entities = $this->getRequestValue($request, 'include_user_entities', false);

--- a/src/Module/Api/Twitter/Friendships/Destroy.php
+++ b/src/Module/Api/Twitter/Friendships/Destroy.php
@@ -63,7 +63,7 @@ class Destroy extends ContactEndpoint
 			throw new HTTPException\NotFoundException('Error Processing Request');
 		}
 
-		$contact_id = BaseApi::getContactIDForSearchterm($request['screen_name'] ?? '', $request['profileurl'] ?? '', $request['user_id'] ?? 0, 0);
+		$contact_id = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'screen_name', ''), $this->getRequestValue($request, 'profileurl', ''), $this->getRequestValue($request, 'user_id', 0), 0);
 
 		if (empty($contact_id)) {
 			Logger::notice(BaseApi::LOG_PREFIX . 'No user_id specified', ['module' => 'api', 'action' => 'friendships_destroy']);

--- a/src/Module/Api/Twitter/Friendships/Show.php
+++ b/src/Module/Api/Twitter/Friendships/Show.php
@@ -38,9 +38,8 @@ class Show extends ContactEndpoint
 		self::checkAllowedScope(self::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
-		$source_cid = BaseApi::getContactIDForSearchterm($request['source_screen_name'] ?? '', '', $request['source_id'] ?? 0, $uid);
-
-		$target_cid = BaseApi::getContactIDForSearchterm($request['target_screen_name'] ?? '', '', $request['target_id'] ?? 0, $uid);
+		$source_cid = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'source_screen_name', ''), '', $this->getRequestValue($request, 'source_id', 0), $uid);
+		$target_cid = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'target_screen_name', ''), '', $this->getRequestValue($request, 'target_id', 0), $uid);
 
 		$source = Contact::getById($source_cid);
 		if (empty($source)) {

--- a/src/Module/Api/Twitter/Statuses/UserTimeline.php
+++ b/src/Module/Api/Twitter/Statuses/UserTimeline.php
@@ -42,7 +42,7 @@ class UserTimeline extends BaseApi
 
 		Logger::info('api_statuses_user_timeline', ['api_user' => $uid, '_REQUEST' => $request]);
 
-		$cid              = BaseApi::getContactIDForSearchterm($request['screen_name'] ?? '', $request['profileurl'] ?? '', $request['user_id'] ?? 0, $uid);
+		$cid              = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'screen_name', ''), $this->getRequestValue($request, 'profileurl', ''), $this->getRequestValue($request, 'user_id', 0), $uid);
 		$count            = $this->getRequestValue($request, 'count', 20, 1, 100);
 		$page             = $this->getRequestValue($request, 'page', 1, 1);
 		$since_id         = $this->getRequestValue($request, 'since_id', 0, 0);

--- a/src/Module/Api/Twitter/Users/Show.php
+++ b/src/Module/Api/Twitter/Users/Show.php
@@ -38,7 +38,7 @@ class Show extends BaseApi
 		$uid = BaseApi::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$cid = BaseApi::getContactIDForSearchterm($request['screen_name'] ?? '', $request['profileurl'] ?? '', $request['user_id'] ?? 0, $uid);
+			$cid = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'screen_name', ''), $this->getRequestValue($request, 'profileurl', ''), $this->getRequestValue($request, 'user_id', 0), $uid);
 		} else {
 			$cid = (int)$this->parameters['id'];
 		}

--- a/src/Module/Feed.php
+++ b/src/Module/Feed.php
@@ -45,7 +45,7 @@ class Feed extends BaseModule
 {
 	protected function rawContent(array $request = [])
 	{
-		$last_update = $request['last_update'] ?? '';
+		$last_update = $this->getRequestValue($request, 'last_update', '');
 		$nocache     = !empty($request['nocache']) && local_user();
 
 		$type = null;


### PR DESCRIPTION
Changed:
- used `$this->getRequestValue($request, 'foo', <bar>)` instead of `$request['foo'] ?? <bar>`
- fixed wrong variable naming
- changed double-quotes to single
- see https://github.com/friendica/friendica/issues/11631#issuecomment-1196410497