### PR TITLE
New option to disable the fetching of parents

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -706,7 +706,7 @@ class Item
 		}
 
 		if (!DBA::isResult($parent)) {
-			Logger::notice('item parent was not found - ignoring item', ['thr-parent-id' => $item['thr-parent-id'], 'uid' => $item['uid']]);
+			Logger::notice('item parent was not found - ignoring item', ['uri-id' => $item['uri-id'], 'thr-parent-id' => $item['thr-parent-id'], 'uid' => $item['uid'], 'callstack' => System::callstack(20)]);
 			return [];
 		}
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -308,6 +308,10 @@ class Processor
 			return [];
 		}
 
+		if (!DI::config()->get('system', 'fetch_parents')) {
+			$fetch_parents = false;
+		}
+
 		if ($fetch_parents && empty($activity['directmessage']) && ($activity['id'] != $activity['reply-to-id']) && !Post::exists(['uri' => $activity['reply-to-id']])) {
 			$result = self::fetchParent($activity);
 			if (!empty($result)) {

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -172,6 +172,10 @@ return [
 		// Whether to use database, Memcache, Memcached or Redis as a distributed cache.
 		'distributed_cache_driver' => 'database',
 
+		// fetch_parents (Boolean)
+		// Fetch missing parent posts
+		'fetch_parents' => true,
+
 		// config_adapter (jit|preload)
 		// Allow to switch the configuration adapter to improve performances at the cost of memory consumption.
 		'config_adapter' => 'jit',


### PR DESCRIPTION
There is now some kind of "kill switch" to disable the fetching of missing posts. This is usable for single user systems where the single user just wants to read the stuff that is directly delivered.

Also this PR contains a fix so that the local delivery is only done on items that need to be delivered locally.