### PR TITLE
Use L10n->tt instead of t() for plural strings

### DIFF
--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -303,11 +303,12 @@ class L10n
 	 * @param string $singular
 	 * @param string $plural
 	 * @param int    $count
+	 * @param array  $vars Variables to interpolate in the translation string
 	 *
 	 * @return string
 	 * @throws \Exception
 	 */
-	public function tt(string $singular, string $plural, int $count): string
+	public function tt(string $singular, string $plural, int $count, ...$vars): string
 	{
 		$s = null;
 
@@ -340,7 +341,9 @@ class L10n
 			$s = $singular;
 		}
 
-		$s = @sprintf($s, $count);
+		// We mute errors here because the translation strings may not be referencing the count at all,
+		// but we still have to try the interpolation just in case it is indeed referenced.
+		$s = @sprintf($s, $count, ...$vars);
 
 		return $s;
 	}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3281,21 +3281,18 @@ class Item
 
 			$options = Post\QuestionOption::getByURIId($item['uri-id']);
 			foreach ($options as $key => $option) {
-				$percent = $question['voters'] ? ($option['replies'] / $question['voters'] * 100) : 0;
-
-				$options[$key]['percent'] = $percent;
-
 				if ($question['voters'] > 0) {
-					$options[$key]['vote'] = DI::l10n()->t('%s (%d%s, %d votes)', $option['name'], round($percent, 1), '%', $option['replies']);
+					$percent = $option['replies'] / $question['voters'] * 100;
+					$options[$key]['vote'] = DI::l10n()->tt('%2$s (%3$d%%, %1$d vote)', '%2$s (%3$d%%, %1$d votes)', $option['replies'], $option['name'], round($percent, 1));
 				} else {
-					$options[$key]['vote'] = DI::l10n()->t('%s (%d votes)', $option['name'], $option['replies']);
+					$options[$key]['vote'] = DI::l10n()->tt('%2$s (%1$d vote)', '%2$s (%1$d votes)', $option['replies'], $option['name'], );
 				}
 			}
 
 			if (!empty($question['voters']) && !empty($question['endtime'])) {
-				$summary = DI::l10n()->t('%d voters. Poll end: %s', $question['voters'], Temporal::getRelativeDate($question['endtime']));
+				$summary = DI::l10n()->tt('%d voter. Poll end: %s', '%d voters. Poll end: %s', $question['voters'], Temporal::getRelativeDate($question['endtime']));
 			} elseif (!empty($question['voters'])) {
-				$summary = DI::l10n()->t('%d voters.', $question['voters']);
+				$summary = DI::l10n()->tt('%d voter.', '%d voters.', $question['voters']);
 			} elseif (!empty($question['endtime'])) {
 				$summary = DI::l10n()->t('Poll end: %s', Temporal::getRelativeDate($question['endtime']));
 		 	} else {

--- a/src/Module/Admin/Federation.php
+++ b/src/Module/Admin/Federation.php
@@ -170,26 +170,26 @@ class Federation extends BaseAdmin
 			}
 
 			$gserver['platform']    = $systems[$platform]['name'];
-			$gserver['totallbl']    = DI::l10n()->t('%s total systems', number_format($gserver['total']));
-			$gserver['monthlbl']    = DI::l10n()->t('%s active users last month', number_format($gserver['month']));
-			$gserver['halfyearlbl'] = DI::l10n()->t('%s active users last six months', number_format($gserver['halfyear']));
-			$gserver['userslbl']    = DI::l10n()->t('%s registered users', number_format($gserver['users']));
-			$gserver['postslbl']    = DI::l10n()->t('%s locally created posts and comments', number_format($gserver['posts']));
+			$gserver['totallbl']    = DI::l10n()->tt('%2$s total system'                   , '%2$s total systems'                     , $gserver['total'], number_format($gserver['total']));
+			$gserver['monthlbl']    = DI::l10n()->tt('%2$s active user last month'         , '%2$s active users last month'           , $gserver['month'] ?? 0, number_format($gserver['month']));
+			$gserver['halfyearlbl'] = DI::l10n()->tt('%2$s active user last six months'    , '%2$s active users last six months'      , $gserver['halfyear'] ?? 0, number_format($gserver['halfyear']));
+			$gserver['userslbl']    = DI::l10n()->tt('%2$s registered user'                , '%2$s registered users'                  , $gserver['users'], number_format($gserver['users']));
+			$gserver['postslbl']    = DI::l10n()->tt('%2$s locally created post or comment', '%2$s locally created posts and comments', $gserver['posts'], number_format($gserver['posts']));
 
 			if (($gserver['users'] > 0) && ($gserver['posts'] > 0)) {
-				$gserver['postsuserlbl'] = DI::l10n()->t('%s posts per user', number_format($gserver['posts'] / $gserver['users'], 1));
+				$gserver['postsuserlbl'] = DI::l10n()->tt('%2$s post per user', '%2$s posts per user', $gserver['posts'] / $gserver['users'], number_format($gserver['posts'] / $gserver['users'], 1));
 			} else {
 				$gserver['postsuserlbl'] = '';
 			}
 			if (($gserver['users'] > 0) && ($gserver['total'] > 0)) {
-				$gserver['userssystemlbl'] = DI::l10n()->t('%s users per system', number_format($gserver['users'] / $gserver['total'], 1));
+				$gserver['userssystemlbl'] = DI::l10n()->tt('%2$s user per system', '%2$s users per system', $gserver['users'] / $gserver['total'], number_format($gserver['users'] / $gserver['total'], 1));
 			} else {
 				$gserver['userssystemlbl'] = '';
 			}
 
 			$counts[$platform] = [$gserver, $versionCounts, str_replace([' ', '%', '.'], '', $platform), $systems[$platform]['color']];
 		}
-		DBA::close($gserver);
+		DBA::close($gservers);
 
 		// some helpful text
 		$intro = DI::l10n()->t('This page offers you some numbers to the known part of the federated social network your Friendica node is part of. These numbers are not complete but only reflect the part of the network your node is aware of.');
@@ -202,7 +202,7 @@ class Federation extends BaseAdmin
 			'$intro' => $intro,
 			'$counts' => $counts,
 			'$version' => FRIENDICA_VERSION,
-			'$legendtext' => DI::l10n()->t('Currently this node is aware of %s nodes (%s active users last month, %s active users last six months, %s registered users in total) from the following platforms:', number_format($total), number_format($month), number_format($halfyear), number_format($users)),
+			'$legendtext' => DI::l10n()->tt('Currently this node is aware of %2$s node (%3$s active users last month, %4$s active users last six months, %5$s registered users in total) from the following platforms:', 'Currently this node is aware of %2$s nodes (%3$s active users last month, %4$s active users last six months, %5$s registered users in total) from the following platforms:', $total, number_format($total), number_format($month), number_format($halfyear), number_format($users)),
 		]);
 	}
 

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -271,7 +271,7 @@ class BaseApi extends BaseModule
 			if ($posts_month > $throttle_month) {
 				Logger::info('Monthly posting limit reached', ['uid' => $uid, 'posts' => $posts_month, 'limit' => $throttle_month]);
 				$error = DI::l10n()->t('Too Many Requests');
-				$error_description = DI::l10n()->t("Monthly posting limit of %d post reached. The post was rejected.", "Monthly posting limit of %d posts reached. The post was rejected.", $throttle_month);
+				$error_description = DI::l10n()->tt('Monthly posting limit of %d post reached. The post was rejected.', 'Monthly posting limit of %d posts reached. The post was rejected.', $throttle_month);
 				$errorobj = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 				System::jsonError(429, $errorobj->toArray());
 			}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.09-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-05 15:51+0200\n"
+"POT-Creation-Date: 2022-08-08 02:12-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -409,7 +409,7 @@ msgstr ""
 #: mod/photos.php:1336 mod/photos.php:1392 mod/photos.php:1466
 #: src/Module/Admin/Item/Source.php:60 src/Module/Contact/Advanced.php:132
 #: src/Module/Contact/Poke.php:177 src/Module/Contact/Profile.php:327
-#: src/Module/Debug/ActivityPubConversion.php:145
+#: src/Module/Debug/ActivityPubConversion.php:140
 #: src/Module/Debug/Babel.php:313 src/Module/Debug/Localtime.php:64
 #: src/Module/Debug/Probe.php:54 src/Module/Debug/WebFinger.php:51
 #: src/Module/Delegation.php:148 src/Module/FriendSuggest.php:144
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Resubscribing to OStatus contacts"
 msgstr ""
 
-#: mod/repair_ostatus.php:46 src/Module/Debug/ActivityPubConversion.php:134
+#: mod/repair_ostatus.php:46 src/Module/Debug/ActivityPubConversion.php:129
 #: src/Module/Debug/Babel.php:293 src/Module/Security/TwoFactor/Verify.php:98
 msgid "Error"
 msgid_plural "Errors"
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Friend Suggestions"
 msgstr ""
 
-#: mod/tagger.php:78 src/Content/Item.php:354 src/Model/Item.php:2754
+#: mod/tagger.php:78 src/Content/Item.php:354 src/Model/Item.php:2769
 msgid "photo"
 msgstr ""
 
@@ -2297,7 +2297,7 @@ msgstr ""
 msgid "%1$s poked %2$s"
 msgstr ""
 
-#: src/Content/Item.php:345 src/Model/Item.php:2752
+#: src/Content/Item.php:345 src/Model/Item.php:2767
 msgid "event"
 msgstr ""
 
@@ -2648,8 +2648,8 @@ msgid ""
 "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1213 src/Model/Item.php:3331
-#: src/Model/Item.php:3337 src/Model/Item.php:3338
+#: src/Content/Text/BBCode.php:1213 src/Model/Item.php:3343
+#: src/Model/Item.php:3349 src/Model/Item.php:3350
 msgid "Link to source"
 msgstr ""
 
@@ -3246,201 +3246,201 @@ msgstr ""
 msgid "Could not connect to database."
 msgstr ""
 
-#: src/Core/L10n.php:399 src/Model/Event.php:428
+#: src/Core/L10n.php:402 src/Model/Event.php:428
 #: src/Module/Settings/Display.php:182
 msgid "Monday"
 msgstr ""
 
-#: src/Core/L10n.php:399 src/Model/Event.php:429
+#: src/Core/L10n.php:402 src/Model/Event.php:429
 msgid "Tuesday"
 msgstr ""
 
-#: src/Core/L10n.php:399 src/Model/Event.php:430
+#: src/Core/L10n.php:402 src/Model/Event.php:430
 msgid "Wednesday"
 msgstr ""
 
-#: src/Core/L10n.php:399 src/Model/Event.php:431
+#: src/Core/L10n.php:402 src/Model/Event.php:431
 msgid "Thursday"
 msgstr ""
 
-#: src/Core/L10n.php:399 src/Model/Event.php:432
+#: src/Core/L10n.php:402 src/Model/Event.php:432
 msgid "Friday"
 msgstr ""
 
-#: src/Core/L10n.php:399 src/Model/Event.php:433
+#: src/Core/L10n.php:402 src/Model/Event.php:433
 msgid "Saturday"
 msgstr ""
 
-#: src/Core/L10n.php:399 src/Model/Event.php:427
+#: src/Core/L10n.php:402 src/Model/Event.php:427
 #: src/Module/Settings/Display.php:182
 msgid "Sunday"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Model/Event.php:448
+#: src/Core/L10n.php:406 src/Model/Event.php:448
 msgid "January"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Model/Event.php:449
+#: src/Core/L10n.php:406 src/Model/Event.php:449
 msgid "February"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Model/Event.php:450
+#: src/Core/L10n.php:406 src/Model/Event.php:450
 msgid "March"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Model/Event.php:451
+#: src/Core/L10n.php:406 src/Model/Event.php:451
 msgid "April"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Core/L10n.php:422 src/Model/Event.php:439
+#: src/Core/L10n.php:406 src/Core/L10n.php:425 src/Model/Event.php:439
 msgid "May"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Model/Event.php:452
+#: src/Core/L10n.php:406 src/Model/Event.php:452
 msgid "June"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Model/Event.php:453
+#: src/Core/L10n.php:406 src/Model/Event.php:453
 msgid "July"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Model/Event.php:454
+#: src/Core/L10n.php:406 src/Model/Event.php:454
 msgid "August"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Model/Event.php:455
+#: src/Core/L10n.php:406 src/Model/Event.php:455
 msgid "September"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Model/Event.php:456
+#: src/Core/L10n.php:406 src/Model/Event.php:456
 msgid "October"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Model/Event.php:457
+#: src/Core/L10n.php:406 src/Model/Event.php:457
 msgid "November"
 msgstr ""
 
-#: src/Core/L10n.php:403 src/Model/Event.php:458
+#: src/Core/L10n.php:406 src/Model/Event.php:458
 msgid "December"
 msgstr ""
 
-#: src/Core/L10n.php:418 src/Model/Event.php:420
+#: src/Core/L10n.php:421 src/Model/Event.php:420
 msgid "Mon"
 msgstr ""
 
-#: src/Core/L10n.php:418 src/Model/Event.php:421
+#: src/Core/L10n.php:421 src/Model/Event.php:421
 msgid "Tue"
 msgstr ""
 
-#: src/Core/L10n.php:418 src/Model/Event.php:422
+#: src/Core/L10n.php:421 src/Model/Event.php:422
 msgid "Wed"
 msgstr ""
 
-#: src/Core/L10n.php:418 src/Model/Event.php:423
+#: src/Core/L10n.php:421 src/Model/Event.php:423
 msgid "Thu"
 msgstr ""
 
-#: src/Core/L10n.php:418 src/Model/Event.php:424
+#: src/Core/L10n.php:421 src/Model/Event.php:424
 msgid "Fri"
 msgstr ""
 
-#: src/Core/L10n.php:418 src/Model/Event.php:425
+#: src/Core/L10n.php:421 src/Model/Event.php:425
 msgid "Sat"
 msgstr ""
 
-#: src/Core/L10n.php:418 src/Model/Event.php:419
+#: src/Core/L10n.php:421 src/Model/Event.php:419
 msgid "Sun"
 msgstr ""
 
-#: src/Core/L10n.php:422 src/Model/Event.php:435
+#: src/Core/L10n.php:425 src/Model/Event.php:435
 msgid "Jan"
 msgstr ""
 
-#: src/Core/L10n.php:422 src/Model/Event.php:436
+#: src/Core/L10n.php:425 src/Model/Event.php:436
 msgid "Feb"
 msgstr ""
 
-#: src/Core/L10n.php:422 src/Model/Event.php:437
+#: src/Core/L10n.php:425 src/Model/Event.php:437
 msgid "Mar"
 msgstr ""
 
-#: src/Core/L10n.php:422 src/Model/Event.php:438
+#: src/Core/L10n.php:425 src/Model/Event.php:438
 msgid "Apr"
 msgstr ""
 
-#: src/Core/L10n.php:422 src/Model/Event.php:440
+#: src/Core/L10n.php:425 src/Model/Event.php:440
 msgid "Jun"
 msgstr ""
 
-#: src/Core/L10n.php:422 src/Model/Event.php:441
+#: src/Core/L10n.php:425 src/Model/Event.php:441
 msgid "Jul"
 msgstr ""
 
-#: src/Core/L10n.php:422 src/Model/Event.php:442
+#: src/Core/L10n.php:425 src/Model/Event.php:442
 msgid "Aug"
 msgstr ""
 
-#: src/Core/L10n.php:422
+#: src/Core/L10n.php:425
 msgid "Sep"
 msgstr ""
 
-#: src/Core/L10n.php:422 src/Model/Event.php:444
+#: src/Core/L10n.php:425 src/Model/Event.php:444
 msgid "Oct"
 msgstr ""
 
-#: src/Core/L10n.php:422 src/Model/Event.php:445
+#: src/Core/L10n.php:425 src/Model/Event.php:445
 msgid "Nov"
 msgstr ""
 
-#: src/Core/L10n.php:422 src/Model/Event.php:446
+#: src/Core/L10n.php:425 src/Model/Event.php:446
 msgid "Dec"
 msgstr ""
 
-#: src/Core/L10n.php:441
+#: src/Core/L10n.php:444
 msgid "poke"
 msgstr ""
 
-#: src/Core/L10n.php:441
+#: src/Core/L10n.php:444
 msgid "poked"
 msgstr ""
 
-#: src/Core/L10n.php:442
+#: src/Core/L10n.php:445
 msgid "ping"
 msgstr ""
 
-#: src/Core/L10n.php:442
+#: src/Core/L10n.php:445
 msgid "pinged"
 msgstr ""
 
-#: src/Core/L10n.php:443
+#: src/Core/L10n.php:446
 msgid "prod"
 msgstr ""
 
-#: src/Core/L10n.php:443
+#: src/Core/L10n.php:446
 msgid "prodded"
 msgstr ""
 
-#: src/Core/L10n.php:444
+#: src/Core/L10n.php:447
 msgid "slap"
 msgstr ""
 
-#: src/Core/L10n.php:444
+#: src/Core/L10n.php:447
 msgid "slapped"
 msgstr ""
 
-#: src/Core/L10n.php:445
+#: src/Core/L10n.php:448
 msgid "finger"
 msgstr ""
 
-#: src/Core/L10n.php:445
+#: src/Core/L10n.php:448
 msgid "fingered"
 msgstr ""
 
-#: src/Core/L10n.php:446
+#: src/Core/L10n.php:449
 msgid "rebuff"
 msgstr ""
 
-#: src/Core/L10n.php:446
+#: src/Core/L10n.php:449
 msgid "rebuffed"
 msgstr ""
 
@@ -3834,58 +3834,66 @@ msgstr ""
 msgid "Edit groups"
 msgstr ""
 
-#: src/Model/Item.php:1850
+#: src/Model/Item.php:1865
 #, php-format
 msgid "Detected languages in this post:\\n%s"
 msgstr ""
 
-#: src/Model/Item.php:2756
+#: src/Model/Item.php:2771
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2758
+#: src/Model/Item.php:2773
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2761
+#: src/Model/Item.php:2776
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:2877
+#: src/Model/Item.php:2892
 #, php-format
 msgid "Content warning: %s"
 msgstr ""
 
-#: src/Model/Item.php:3240
+#: src/Model/Item.php:3255
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3274
+#: src/Model/Item.php:3286
 #, php-format
-msgid "%s (%d%s, %d votes)"
-msgstr ""
+msgid "%2$s (%3$d%%, %1$d vote)"
+msgid_plural "%2$s (%3$d%%, %1$d votes)"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/Model/Item.php:3276
+#: src/Model/Item.php:3288
 #, php-format
-msgid "%s (%d votes)"
-msgstr ""
+msgid "%2$s (%1$d vote)"
+msgid_plural "%2$s (%1$d votes)"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/Model/Item.php:3281
+#: src/Model/Item.php:3293
 #, php-format
-msgid "%d voters. Poll end: %s"
-msgstr ""
+msgid "%d voter. Poll end: %s"
+msgid_plural "%d voters. Poll end: %s"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/Model/Item.php:3283
+#: src/Model/Item.php:3295
 #, php-format
-msgid "%d voters."
-msgstr ""
+msgid "%d voter."
+msgid_plural "%d voters."
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/Model/Item.php:3285
+#: src/Model/Item.php:3297
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3319 src/Model/Item.php:3320
+#: src/Model/Item.php:3331 src/Model/Item.php:3332
 msgid "View on separate page"
 msgstr ""
 
@@ -4875,38 +4883,52 @@ msgstr ""
 
 #: src/Module/Admin/Federation.php:173
 #, php-format
-msgid "%s total systems"
-msgstr ""
+msgid "%2$s total system"
+msgid_plural "%2$s total systems"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/Module/Admin/Federation.php:174
 #, php-format
-msgid "%s active users last month"
-msgstr ""
+msgid "%2$s active user last month"
+msgid_plural "%2$s active users last month"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/Module/Admin/Federation.php:175
 #, php-format
-msgid "%s active users last six months"
-msgstr ""
+msgid "%2$s active user last six months"
+msgid_plural "%2$s active users last six months"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/Module/Admin/Federation.php:176
 #, php-format
-msgid "%s registered users"
-msgstr ""
+msgid "%2$s registered user"
+msgid_plural "%2$s registered users"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/Module/Admin/Federation.php:177
 #, php-format
-msgid "%s locally created posts and comments"
-msgstr ""
+msgid "%2$s locally created post or comment"
+msgid_plural "%2$s locally created posts and comments"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/Module/Admin/Federation.php:180
 #, php-format
-msgid "%s posts per user"
-msgstr ""
+msgid "%2$s post per user"
+msgid_plural "%2$s posts per user"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/Module/Admin/Federation.php:185
 #, php-format
-msgid "%s users per system"
-msgstr ""
+msgid "%2$s user per system"
+msgid_plural "%2$s users per system"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/Module/Admin/Federation.php:195
 msgid ""
@@ -4922,10 +4944,15 @@ msgstr ""
 #: src/Module/Admin/Federation.php:205
 #, php-format
 msgid ""
-"Currently this node is aware of %s nodes (%s active users last month, %s "
-"active users last six months, %s registered users in total) from the "
+"Currently this node is aware of %2$s node (%3$s active users last month, "
+"%4$s active users last six months, %5$s registered users in total) from the "
 "following platforms:"
-msgstr ""
+msgid_plural ""
+"Currently this node is aware of %2$s nodes (%3$s active users last month, "
+"%4$s active users last six months, %5$s registered users in total) from the "
+"following platforms:"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/Module/Admin/Item/Delete.php:53
 msgid "Item marked for deletion."
@@ -5114,7 +5141,7 @@ msgid "Data"
 msgstr ""
 
 #: src/Module/Admin/Logs/View.php:99
-#: src/Module/Debug/ActivityPubConversion.php:62
+#: src/Module/Debug/ActivityPubConversion.php:57
 msgid "Source"
 msgstr ""
 
@@ -6719,7 +6746,7 @@ msgstr ""
 msgid "Babel"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:121 src/Module/Debug/ActivityPubConversion.php:142
+#: src/Module/BaseAdmin.php:121 src/Module/Debug/ActivityPubConversion.php:137
 msgid "ActivityPub Conversion"
 msgstr ""
 
@@ -6753,7 +6780,10 @@ msgstr[1] ""
 #: src/Module/BaseApi.php:274
 #, php-format
 msgid "Monthly posting limit of %d post reached. The post was rejected."
-msgstr ""
+msgid_plural ""
+"Monthly posting limit of %d posts reached. The post was rejected."
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/Module/BaseProfile.php:51 src/Module/Contact.php:460
 msgid "Profile Details"
@@ -7410,23 +7440,23 @@ msgid ""
 "code or the translation of Friendica. Thank you all!"
 msgstr ""
 
-#: src/Module/Debug/ActivityPubConversion.php:58
+#: src/Module/Debug/ActivityPubConversion.php:53
 msgid "Formatted"
 msgstr ""
 
-#: src/Module/Debug/ActivityPubConversion.php:70
+#: src/Module/Debug/ActivityPubConversion.php:65
 msgid "Activity"
 msgstr ""
 
-#: src/Module/Debug/ActivityPubConversion.php:122
+#: src/Module/Debug/ActivityPubConversion.php:117
 msgid "Object data"
 msgstr ""
 
-#: src/Module/Debug/ActivityPubConversion.php:129
+#: src/Module/Debug/ActivityPubConversion.php:124
 msgid "Result Item"
 msgstr ""
 
-#: src/Module/Debug/ActivityPubConversion.php:143
+#: src/Module/Debug/ActivityPubConversion.php:138
 msgid "Source activity"
 msgstr ""
 


### PR DESCRIPTION
Close #11824
Address the initial reports in #11826

In all but one case, `L10n->tt()` wasn't used because it didn't allow additional interpolated variables. This is now supported which allows us to pick the plural form based on the numeric variable and interpolate the formatted number string in the same call. Please note that this requires to use numbered placeholders to skip the first interpolated variable which is always the numerical count.