### PR TITLE
Reformatting and using [] instead of discouraged array()

### DIFF
--- a/src/Console/Extract.php
+++ b/src/Console/Extract.php
@@ -21,6 +21,9 @@
 
 namespace Friendica\Console;
 
+use \RecursiveDirectoryIterator;
+use \RecursiveIteratorIterator;
+
 /**
  * Extracts translation strings from the Friendica project's files to be exported
  * to Transifex for translation.
@@ -120,10 +123,10 @@ HELP;
 
 						$arr[] = $matchtkns[0];
 
-						$s .= '$a->strings[' . $matchtkns[0] . "] = array(\n";
+						$s .= '$a->strings[' . $matchtkns[0] . "] = [\n";
 						$s .= "\t0 => " . $matchtkns[0] . ",\n";
 						$s .= "\t1 => " . $matchtkns[1] . ",\n";
-						$s .= ");\n";
+						$s .= "];\n";
 					}
 				}
 			}
@@ -141,9 +144,17 @@ HELP;
 		return 0;
 	}
 
-	private function globRecursive($path) {
-		$dir_iterator = new \RecursiveDirectoryIterator($path);
-		$iterator = new \RecursiveIteratorIterator($dir_iterator, \RecursiveIteratorIterator::SELF_FIRST);
+	/**
+	 * Returns an array with found files and directories including their paths.
+	 *
+	 * @param string $path Base path to scan
+	 *
+	 * @return array A flat array with found files and directories
+	 */
+	private function globRecursive(string $path): array
+	{
+		$dir_iterator = new RecursiveDirectoryIterator($path);
+		$iterator = new RecursiveIteratorIterator($dir_iterator, RecursiveIteratorIterator::SELF_FIRST);
 
 		$return = [];
 		foreach ($iterator as $file) {

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -268,7 +268,7 @@ class Widget
 
 		$r = DBA::select('contact', ['network'], $condition, ['group_by' => ['network'], 'order' => ['network']]);
 
-		$nets = array();
+		$nets = [];
 		while ($rr = DBA::fetch($r)) {
 			$nets[] = ['ref' => $rr['network'], 'name' => ContactSelector::networkToName($rr['network'])];
 		}
@@ -334,7 +334,7 @@ class Widget
 			return '';
 		}
 
-		$terms = array();
+		$terms = [];
 		foreach (Post\Category::getArray($uid, Post\Category::CATEGORY) as $savedFolderName) {
 			$terms[] = ['ref' => $savedFolderName, 'name' => $savedFolderName];
 		}

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -1738,7 +1738,7 @@ class Probe
 				// Resolve arbitrary relative path
 				// Lifted from https://www.php.net/manual/en/function.realpath.php#84012
 				$parts = array_filter(explode('/', $path), 'strlen');
-				$absolutes = array();
+				$absolutes = [];
 				foreach ($parts as $part) {
 					if ('.' == $part) continue;
 					if ('..' == $part) {


### PR DESCRIPTION
Changes:
- reformatted and documented private method
- used [] instead of deprecated/discouraged array()