### PR TITLE
Cleanups/type hints + documentation

### DIFF
--- a/src/Factory/Api/Friendica/Activities.php
+++ b/src/Factory/Api/Friendica/Activities.php
@@ -42,11 +42,16 @@ class Activities extends BaseFactory
 	}
 
 	/**
+	 * Creates activities array from URI id, user id
+	 *
 	 * @param int $uriId Uri-ID of the item
-	 * @return Array
+	 * @param int $uid User id
+	 * @param string $type Type of returned activities, can be 'json' or 'xml', default: json
+	 *
+	 * @return array Array of found activities
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public function createFromUriId(int $uriId, int $uid, $type = 'json'): array
+	public function createFromUriId(int $uriId, int $uid, string $type = 'json'): array
 	{
 		$activities = [
 			'like'        => [],
@@ -68,22 +73,29 @@ class Activities extends BaseFactory
 				case Activity::LIKE:
 					$activities['like'][] = $user;
 					break;
+
 				case Activity::DISLIKE:
 					$activities['dislike'][] = $user;
 					break;
+
 				case Activity::ATTEND:
 					$activities['attendyes'][] = $user;
 					break;
+
 				case Activity::ATTENDNO:
 					$activities['attendno'][] = $user;
 					break;
+
 				case Activity::ATTENDMAYBE:
 					$activities['attendmaybe'][] = $user;
 					break;
+
 				case Activity::ANNOUNCE:
 					$activities['announce'][] = $user;
 					break;
+
 				default:
+					$this->logger->warning('Unsupported verb in parent item:', ['parent_item' => $parent_item]);
 					break;
 			}
 		}
@@ -94,7 +106,7 @@ class Activities extends BaseFactory
 			$xml_activities = [];
 			foreach ($activities as $k => $v) {
 				// change xml element from "like" to "friendica:like"
-				$xml_activities["friendica:".$k] = $v;
+				$xml_activities['friendica:' . $k] = $v;
 				// add user data into xml output
 				$k_user = 0;
 				foreach ($v as $user) {

--- a/src/Factory/Api/Mastodon/Application.php
+++ b/src/Factory/Api/Mastodon/Application.php
@@ -41,7 +41,6 @@ class Application extends BaseFactory
 	 * @param int $id Application ID
 	 *
 	 * @return \Friendica\Object\Api\Mastodon\Application
-	 *
 	 * @throws UnprocessableEntityException
 	 */
 	public function createFromApplicationId(int $id): \Friendica\Object\Api\Mastodon\Application

--- a/src/Factory/Api/Mastodon/Conversation.php
+++ b/src/Factory/Api/Mastodon/Conversation.php
@@ -46,9 +46,12 @@ class Conversation extends BaseFactory
 	}
 
 	/**
+	 * @param int $id Conversation id
+	 *
+	 * @return \Friendica\Object\Api\Mastodon\Conversation
 	 * @throws ImagickException|HTTPException\InternalServerErrorException|HTTPException\NotFoundException
 	 */
-	public function CreateFromConvId(int $id): \Friendica\Object\Api\Mastodon\Conversation
+	public function createFromConvId(int $id): \Friendica\Object\Api\Mastodon\Conversation
 	{
 		$accounts    = [];
 		$unread      = false;

--- a/src/Factory/Api/Mastodon/Emoji.php
+++ b/src/Factory/Api/Mastodon/Emoji.php
@@ -33,6 +33,7 @@ class Emoji extends BaseFactory
 
 	/**
 	 * @param array $smilies
+	 *
 	 * @return Emojis
 	 */
 	public function createCollectionFromSmilies(array $smilies): Emojis

--- a/src/Factory/Api/Mastodon/Field.php
+++ b/src/Factory/Api/Mastodon/Field.php
@@ -43,6 +43,7 @@ class Field extends BaseFactory
 
 	/**
 	 * @param ProfileFields $profileFields
+	 *
 	 * @return Fields
 	 * @throws HTTPException\InternalServerErrorException
 	 */

--- a/src/Factory/Api/Mastodon/Notification.php
+++ b/src/Factory/Api/Mastodon/Notification.php
@@ -45,6 +45,12 @@ class Notification extends BaseFactory
 		$this->mstdnStatusFactory  = $mstdnStatusFactoryFactory;
 	}
 
+	/**
+	 * @param Notifications\Entity\Notification $Notification
+	 *
+	 * @return MstdnNotification
+	 * @throws UnexpectedNotificationTypeException
+	 */
 	public function createFromNotification(Notifications\Entity\Notification $Notification): MstdnNotification
 	{
 		$type = self::getType($Notification);

--- a/src/Factory/Api/Mastodon/Poll.php
+++ b/src/Factory/Api/Mastodon/Poll.php
@@ -31,8 +31,11 @@ class Poll extends BaseFactory
 	/**
 	 * @param int $id  Id the question
 	 * @param int $uid Item user
+	 *
+	 * @return \Friendica\Object\Api\Mastodon\Poll
+	 * @throws HTTPException\NotFoundException
 	 */
-	public function createFromId(int $id, $uid = 0): \Friendica\Object\Api\Mastodon\Poll
+	public function createFromId(int $id, int $uid = 0): \Friendica\Object\Api\Mastodon\Poll
 	{
 		$question = Post\Question::getById($id);
 		if (empty($question)) {

--- a/src/Factory/Api/Mastodon/Relationship.php
+++ b/src/Factory/Api/Mastodon/Relationship.php
@@ -31,6 +31,7 @@ class Relationship extends BaseFactory
 	/**
 	 * @param int $contactId Contact ID (public or user contact)
 	 * @param int $uid User ID
+	 *
 	 * @return RelationshipEntity
 	 * @throws Exception
 	 */

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -78,7 +78,7 @@ class Status extends BaseFactory
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws ImagickException|HTTPException\NotFoundException
 	 */
-	public function createFromUriId(int $uriId, $uid = 0): \Friendica\Object\Api\Mastodon\Status
+	public function createFromUriId(int $uriId, int $uid = 0): \Friendica\Object\Api\Mastodon\Status
 	{
 		$fields = ['uri-id', 'uid', 'author-id', 'author-uri-id', 'author-link', 'starred', 'app', 'title', 'body', 'raw-body', 'content-warning', 'question-id',
 			'created', 'network', 'thr-parent-id', 'parent-author-id', 'language', 'uri', 'plink', 'private', 'vid', 'gravity', 'featured', 'has-media'];

--- a/src/Factory/Api/Mastodon/Tag.php
+++ b/src/Factory/Api/Mastodon/Tag.php
@@ -41,6 +41,7 @@ class Tag extends BaseFactory
 
 	/**
 	 * @param int $uriId Uri-ID of the item
+	 *
 	 * @return array
 	 * @throws HTTPException\InternalServerErrorException
 	 */

--- a/src/Factory/Api/Twitter/Attachment.php
+++ b/src/Factory/Api/Twitter/Attachment.php
@@ -35,6 +35,7 @@ class Attachment extends BaseFactory
 
 	/**
 	 * @param int $uriId Uri-ID of the attachments
+	 *
 	 * @return array
 	 * @throws HTTPException\InternalServerErrorException
 	 */

--- a/src/Factory/Api/Twitter/Hashtag.php
+++ b/src/Factory/Api/Twitter/Hashtag.php
@@ -35,6 +35,8 @@ class Hashtag extends BaseFactory
 
 	/**
 	 * @param int $uriId Uri-ID of the attachments
+	 * @param string $text
+	 *
 	 * @return array
 	 * @throws HTTPException\InternalServerErrorException
 	 */

--- a/src/Factory/Api/Twitter/Media.php
+++ b/src/Factory/Api/Twitter/Media.php
@@ -41,6 +41,8 @@ class Media extends BaseFactory
 
 	/**
 	 * @param int $uriId Uri-ID of the attachments
+	 * @param string $text
+	 *
 	 * @return array
 	 * @throws HTTPException\InternalServerErrorException
 	 */

--- a/src/Factory/Api/Twitter/User.php
+++ b/src/Factory/Api/Twitter/User.php
@@ -47,11 +47,12 @@ class User extends BaseFactory
 	 * @param int  $uid Public contact (=0) or owner user id
 	 * @param bool $skip_status
 	 * @param bool $include_user_entities
+	 *
 	 * @return \Friendica\Object\Api\Twitter\User
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public function createFromContactId(int $contactId, int $uid = 0, bool $skip_status = true, bool $include_user_entities = true)
+	public function createFromContactId(int $contactId, int $uid = 0, bool $skip_status = true, bool $include_user_entities = true): \Friendica\Object\Api\Twitter\User
 	{
 		$cdata = Contact::getPublicAndUserContactID($contactId, $uid);
 		if (!empty($cdata)) {
@@ -78,7 +79,14 @@ class User extends BaseFactory
 		return new \Friendica\Object\Api\Twitter\User($publicContact, $apcontact, $userContact, $status, $include_user_entities);
 	}
 
-	public function createFromUserId(int $uid, bool $skip_status = true, bool $include_user_entities = true)
+	/**
+	 * @param int  $uid Public contact (=0) or owner user id
+	 * @param bool $skip_status
+	 * @param bool $include_user_entities
+	 *
+	 * @return \Friendica\Object\Api\Twitter\User
+	 */
+	public function createFromUserId(int $uid, bool $skip_status = true, bool $include_user_entities = true): \Friendica\Object\Api\Twitter\User
 	{
 		return $this->createFromContactId(Contact::getPublicIdByUserId($uid), $uid, $skip_status, $include_user_entities);
 	}

--- a/src/Moderation/DomainPatternBlocklist.php
+++ b/src/Moderation/DomainPatternBlocklist.php
@@ -73,6 +73,7 @@ class DomainPatternBlocklist
 	/**
 	 * @param string $pattern
 	 * @param string $reason
+	 *
 	 * @return int 0 if the block list couldn't be saved, 1 if the pattern was added, 2 if it was updated in place
 	 */
 	public function addPattern(string $pattern, string $reason): int
@@ -105,6 +106,7 @@ class DomainPatternBlocklist
 
 	/**
 	 * @param string $pattern
+	 *
 	 * @return int 0 if the block list couldn't be saved, 1 if the pattern wasn't found, 2 if it was removed
 	 */
 	public function removePattern(string $pattern): int
@@ -123,6 +125,13 @@ class DomainPatternBlocklist
 		return $found ? ($this->set($blocklist) ? 2 : 0) : 1;
 	}
 
+	/**
+	 * @param string $filename
+	 *
+	 * @return void
+	 * @throws Exception
+	 * @todo maybe throw more explicit exception
+	 */
 	public function exportToFile(string $filename)
 	{
 		$fp = fopen($filename, 'w');
@@ -165,6 +174,7 @@ class DomainPatternBlocklist
 	 * Extracts a server domain pattern block list from the provided CSV file name. Deduplicates the list based on patterns.
 	 *
 	 * @param string $filename
+	 *
 	 * @return array
 	 * @throws Exception
 	 */

--- a/src/Moderation/DomainPatternBlocklist.php
+++ b/src/Moderation/DomainPatternBlocklist.php
@@ -130,7 +130,6 @@ class DomainPatternBlocklist
 	 *
 	 * @return void
 	 * @throws Exception
-	 * @todo maybe throw more explicit exception
 	 */
 	public function exportToFile(string $filename)
 	{
@@ -148,6 +147,7 @@ class DomainPatternBlocklist
 	 * Appends to the local block list all the patterns from the provided list that weren't already present.
 	 *
 	 * @param array $blocklist
+	 *
 	 * @return int The number of patterns actually added to the block list
 	 */
 	public function append(array $blocklist): int

--- a/src/Module/Api/ApiResponse.php
+++ b/src/Module/Api/ApiResponse.php
@@ -109,7 +109,7 @@ class ApiResponse extends Response
 	 * @param int   $cid Contact ID of template
 	 * @return array
 	 */
-	private function addRSSValues(array $arr, int $cid)
+	private function addRSSValues(array $arr, int $cid): array
 	{
 		if (empty($cid)) {
 			return $arr;
@@ -244,6 +244,8 @@ class ApiResponse extends Response
 	 * Wrapper around exit() for JSON only responses
 	 *
 	 * @param array $data
+	 *
+	 * @return void
 	 */
 	public function exitWithJson(array $data)
 	{

--- a/src/Module/Api/Friendica/Profile/Show.php
+++ b/src/Module/Api/Friendica/Profile/Show.php
@@ -68,10 +68,11 @@ class Show extends BaseApi
 	/**
 	 * @param array         $profile_row array containing data from db table 'profile'
 	 * @param ProfileFields $profileFields
+	 *
 	 * @return array
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	private static function formatProfile($profile_row, ProfileFields $profileFields)
+	private static function formatProfile($profile_row, ProfileFields $profileFields): array
 	{
 		$custom_fields = [];
 		foreach ($profileFields as $profileField) {

--- a/src/Module/Api/Mastodon/Conversations.php
+++ b/src/Module/Api/Mastodon/Conversations.php
@@ -85,7 +85,7 @@ class Conversations extends BaseApi
 
 		while ($conv = DBA::fetch($convs)) {
 			self::setBoundaries($conv['id']);
-			$conversations[] = DI::mstdnConversation()->CreateFromConvId($conv['id']);
+			$conversations[] = DI::mstdnConversation()->createFromConvId($conv['id']);
 		}
 
 		DBA::close($convs);

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -42,6 +42,6 @@ class Read extends BaseApi
 
 		DBA::update('mail', ['seen' => true], ['convid' => $this->parameters['id'], 'uid' => $uid]);
 
-		System::jsonExit(DI::mstdnConversation()->CreateFromConvId($this->parameters['id'])->toArray());
+		System::jsonExit(DI::mstdnConversation()->createFromConvId($this->parameters['id'])->toArray());
 	}
 }

--- a/src/Module/Api/Twitter/ContactEndpoint.php
+++ b/src/Module/Api/Twitter/ContactEndpoint.php
@@ -95,7 +95,7 @@ abstract class ContactEndpoint extends BaseApi
 	 * @throws HTTPException\NotFoundException
 	 * @throws \ImagickException
 	 */
-	protected static function list(array $ids, int $total_count, int $uid, int $cursor = -1, int $count = self::DEFAULT_COUNT, bool $skip_status = false, bool $include_user_entities = true)
+	protected static function list(array $ids, int $total_count, int $uid, int $cursor = -1, int $count = self::DEFAULT_COUNT, bool $skip_status = false, bool $include_user_entities = true): array
 	{
 		$return = self::ids($ids, $total_count, $cursor, $count, false);
 
@@ -128,7 +128,7 @@ abstract class ContactEndpoint extends BaseApi
 	 * @return array
 	 * @throws HTTPException\NotFoundException
 	 */
-	protected static function ids(array $ids, int $total_count, int $cursor = -1, int $count = self::DEFAULT_COUNT, bool $stringify_ids = false)
+	protected static function ids(array $ids, int $total_count, int $cursor = -1, int $count = self::DEFAULT_COUNT, bool $stringify_ids = false): array
 	{
 		$next_cursor = 0;
 		$previous_cursor = 0;

--- a/src/Module/Api/Twitter/DirectMessagesEndpoint.php
+++ b/src/Module/Api/Twitter/DirectMessagesEndpoint.php
@@ -54,6 +54,8 @@ abstract class DirectMessagesEndpoint extends BaseApi
 	 * @param array $request
 	 * @param int   $uid
 	 * @param array $condition
+	 *
+	 * @return void
 	 */
 	protected function getMessages(array $request, int $uid, array $condition)
 	{

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -102,9 +102,9 @@ class Xrd extends BaseModule
 		}
 
 		if ($mode == Response::TYPE_XML) {
-			self::printXML($alias, DI::baseUrl()->get(), $user, $owner, $avatar);
+			self::printXML($alias, $user, $owner, $avatar);
 		} else {
-			self::printJSON($alias, DI::baseUrl()->get(), $owner, $avatar);
+			self::printJSON($alias, $owner, $avatar);
 		}
 	}
 
@@ -153,8 +153,9 @@ class Xrd extends BaseModule
 		System::jsonExit($json, 'application/jrd+json; charset=utf-8');
 	}
 
-	private static function printJSON($alias, $baseURL, $owner, $avatar)
+	private static function printJSON(string $alias, array $owner, array $avatar)
 	{
+		$baseURL = DI::baseUrl()->get();
 		$salmon_key = Salmon::salmonKey($owner['spubkey']);
 
 		$json = [
@@ -234,8 +235,9 @@ class Xrd extends BaseModule
 		System::jsonExit($json, 'application/jrd+json; charset=utf-8');
 	}
 
-	private static function printXML($alias, $baseURL, $user, $owner, $avatar)
+	private static function printXML(string $alias, array $user, array $owner, array $avatar)
 	{
+		$baseURL = DI::baseUrl()->get();
 		$salmon_key = Salmon::salmonKey($owner['spubkey']);
 
 		$tpl = Renderer::getMarkupTemplate('xrd_person.tpl');

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -110,6 +110,7 @@ class Xrd extends BaseModule
 
 	private static function printSystemJSON(array $owner)
 	{
+		$baseURL = $this->baseurl->get();
 		$json = [
 			'subject' => 'acct:' . $owner['addr'],
 			'aliases' => [$owner['url']],
@@ -126,26 +127,26 @@ class Xrd extends BaseModule
 				],
 				[
 					'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
-					'template' => DI::baseUrl()->get() . '/follow?url={uri}',
+					'template' => $baseURL . '/follow?url={uri}',
 				],
 				[
 					'rel'  => ActivityNamespace::FEED,
 					'type' => 'application/atom+xml',
-					'href' => $owner['poll'] ?? DI::baseUrl()->get(),
+					'href' => $owner['poll'] ?? $baseURL,
 				],
 				[
 					'rel'  => 'salmon',
-					'href' => DI::baseUrl()->get() . '/salmon/' . $owner['nickname'],
+					'href' => $baseURL . '/salmon/' . $owner['nickname'],
 				],
 				[
 					'rel'  => 'http://microformats.org/profile/hcard',
 					'type' => 'text/html',
-					'href' => DI::baseUrl()->get() . '/hcard/' . $owner['nickname'],
+					'href' => $baseURL . '/hcard/' . $owner['nickname'],
 				],
 				[
 					'rel'  => 'http://joindiaspora.com/seed_location',
 					'type' => 'text/html',
-					'href' => DI::baseUrl()->get(),
+					'href' => $baseURL,
 				],
 			]
 		];
@@ -155,7 +156,7 @@ class Xrd extends BaseModule
 
 	private static function printJSON(string $alias, array $owner, array $avatar)
 	{
-		$baseURL = DI::baseUrl()->get();
+		$baseURL = $this->baseurl->get();
 		$salmon_key = Salmon::salmonKey($owner['spubkey']);
 
 		$json = [
@@ -237,7 +238,7 @@ class Xrd extends BaseModule
 
 	private static function printXML(string $alias, array $user, array $owner, array $avatar)
 	{
-		$baseURL = DI::baseUrl()->get();
+		$baseURL = $this->baseurl->get();
 		$salmon_key = Salmon::salmonKey($owner['spubkey']);
 
 		$tpl = Renderer::getMarkupTemplate('xrd_person.tpl');

--- a/src/Navigation/Notifications/Repository/Notification.php
+++ b/src/Navigation/Notifications/Repository/Notification.php
@@ -112,6 +112,7 @@ class Notification extends BaseRepository
 	 * Returns only the most recent notifications for the same conversation or contact
 	 *
 	 * @param int $uid
+	 *
 	 * @return Collection\Notifications
 	 * @throws Exception
 	 */
@@ -139,6 +140,7 @@ class Notification extends BaseRepository
 	 * Returns only the most recent notifications for the same conversation or contact
 	 *
 	 * @param int $uid
+	 *
 	 * @return Collection\Notifications
 	 * @throws Exception
 	 */
@@ -201,6 +203,7 @@ class Notification extends BaseRepository
 	 * @param int|null $min_id Retrieve models with an id no fewer than this, as close to it as possible
 	 * @param int|null $max_id Retrieve models with an id no greater than this, as close to it as possible
 	 * @param int      $limit
+	 *
 	 * @return BaseCollection
 	 * @throws Exception
 	 * @see _selectByBoundaries

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -480,7 +480,7 @@ class Notify extends BaseRepository
 
 						$sitelink = $l10n->t('Please visit %s to approve or reject the request.');
 						$tsitelink = sprintf($sitelink, $params['link']);
-						$hsitelink = sprintf($sitelink, '<a href="'.$params['link'].'">'.$sitename.'</a><br><br>');
+						$hsitelink = sprintf($sitelink, '<a href="' . $params['link'] . '">' . $sitename . '</a><br><br>');
 						break;
 
 					case 'SYSTEM_DB_UPDATE_FAIL': // @TODO Unused (only here)

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -88,6 +88,7 @@ class Notify extends BaseRepository
 	/**
 	 * @param array $condition
 	 * @param array $params
+	 *
 	 * @return Entity\Notify
 	 * @throws HTTPException\NotFoundException
 	 */
@@ -117,6 +118,7 @@ class Notify extends BaseRepository
 
 	/**
 	 * @param int $id
+	 *
 	 * @return Entity\Notify
 	 * @throws HTTPException\NotFoundException
 	 */
@@ -153,6 +155,7 @@ class Notify extends BaseRepository
 
 	/**
 	 * @param Entity\Notify $Notify
+	 *
 	 * @return Entity\Notify
 	 * @throws HTTPException\NotFoundException
 	 * @throws HTTPException\InternalServerErrorException
@@ -459,7 +462,7 @@ class Notify extends BaseRepository
 
 			case Model\Notification\Type::SYSTEM:
 				switch($params['event']) {
-					case "SYSTEM_REGISTER_REQUEST":
+					case 'SYSTEM_REGISTER_REQUEST':
 						$itemlink =  $params['link'];
 						$subject = $l10n->t('[Friendica System Notify]') . ' ' . $l10n->t('registration request');
 
@@ -479,7 +482,8 @@ class Notify extends BaseRepository
 						$tsitelink = sprintf($sitelink, $params['link']);
 						$hsitelink = sprintf($sitelink, '<a href="'.$params['link'].'">'.$sitename.'</a><br><br>');
 						break;
-					case "SYSTEM_DB_UPDATE_FAIL":
+
+					case 'SYSTEM_DB_UPDATE_FAIL': // @TODO Unused (only here)
 						break;
 				}
 				break;
@@ -492,7 +496,7 @@ class Notify extends BaseRepository
 		return $this->storeAndSend($params, $sitelink, $tsitelink, $hsitelink, $title, $subject, $preamble, $epreamble, $body, $itemlink, $show_in_notification_page);
 	}
 
-	private function storeAndSend($params, $sitelink, $tsitelink, $hsitelink, $title, $subject, $preamble, $epreamble, $body, $itemlink, $show_in_notification_page)
+	private function storeAndSend(array $params, string $sitelink, string $tsitelink, string $hsitelink, string $title, string $subject, string $preamble, string $epreamble, string $body, string $itemlink, bool $show_in_notification_page): bool
 	{
 		$item_id = $params['item']['id'] ?? 0;
 		$uri_id = $params['item']['uri-id'] ?? null;
@@ -671,7 +675,7 @@ class Notify extends BaseRepository
 		return false;
 	}
 
-	public function createFromNotification(Entity\Notification $Notification)
+	public function createFromNotification(Entity\Notification $Notification): bool
 	{
 		$this->logger->info('Start', ['uid' => $Notification->uid, 'id' => $Notification->id, 'type' => $Notification->type]);
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -128,7 +128,7 @@ class Diaspora
 			return false;
 		}
 
-		$children = $basedom->children('http://salmon-protocol.org/ns/magic-env');
+		$children = $basedom->children(ActivityNamespace::SALMON_ME);
 
 		if (sizeof($children) == 0) {
 			Logger::notice('XML has no children');
@@ -2969,7 +2969,7 @@ class Diaspora
 			]
 		];
 
-		$namespaces = ['me' => 'http://salmon-protocol.org/ns/magic-env'];
+		$namespaces = ['me' => ActivityNamespace::SALMON_ME];
 
 		return XML::fromArray($xmldata, $xml, false, $namespaces);
 	}

--- a/src/Protocol/Salmon.php
+++ b/src/Protocol/Salmon.php
@@ -145,14 +145,18 @@ class Salmon
 		$signature3  = Strings::base64UrlEncode(Crypto::rsaSign($data, $owner['sprvkey']));
 
 		// At first try the non compliant method that works for GNU Social
-		$xmldata = ["me:env" => ["me:data" => $data,
-				"@attributes" => ["type" => $data_type],
-				"me:encoding" => $encoding,
-				"me:alg" => $algorithm,
-				"me:sig" => $signature,
-				"@attributes2" => ["key_id" => $keyhash]]];
+		$xmldata = [
+			'me:env' => [
+				'me:data' => $data,
+				'@attributes' => ['type' => $data_type],
+				'me:encoding' => $encoding,
+				'me:alg' => $algorithm,
+				'me:sig' => $signature,
+				'@attributes2' => ['key_id' => $keyhash],
+			]
+		];
 
-		$namespaces = ["me" => "http://salmon-protocol.org/ns/magic-env"];
+		$namespaces = ['me' => ActivityNamespace::SALMON_ME];
 
 		$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 
@@ -170,14 +174,18 @@ class Salmon
 			Logger::notice('GNU Social salmon failed. Falling back to compliant mode');
 
 			// Now try the compliant mode that normally isn't used for GNU Social
-			$xmldata = ["me:env" => ["me:data" => $data,
-					"@attributes" => ["type" => $data_type],
-					"me:encoding" => $encoding,
-					"me:alg" => $algorithm,
-					"me:sig" => $signature2,
-					"@attributes2" => ["key_id" => $keyhash]]];
+			$xmldata = [
+				'me:env' => [
+					'me:data' => $data,
+					'@attributes' => ['type' => $data_type],
+					'me:encoding' => $encoding,
+					'me:alg' => $algorithm,
+					'me:sig' => $signature2,
+					'@attributes2' => ['key_id' => $keyhash]
+				]
+			];
 
-			$namespaces = ["me" => "http://salmon-protocol.org/ns/magic-env"];
+			$namespaces = ['me' => ActivityNamespace::SALMON_ME];
 
 			$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 
@@ -193,14 +201,18 @@ class Salmon
 			Logger::notice('compliant salmon failed. Falling back to old status.net');
 
 			// Last try. This will most likely fail as well.
-			$xmldata = ["me:env" => ["me:data" => $data,
-					"@attributes" => ["type" => $data_type],
-					"me:encoding" => $encoding,
-					"me:alg" => $algorithm,
-					"me:sig" => $signature3,
-					"@attributes2" => ["key_id" => $keyhash]]];
+			$xmldata = [
+				'me:env' => [
+					'me:data' => $data,
+					'@attributes' => ['type' => $data_type],
+					'me:encoding' => $encoding,
+					'me:alg' => $algorithm,
+					'me:sig' => $signature3,
+					'@attributes2' => ['key_id' => $keyhash],
+				]
+			];
 
-			$namespaces = ["me" => "http://salmon-protocol.org/ns/magic-env"];
+			$namespaces = ['me' => ActivityNamespace::SALMON_ME];
 
 			$salmon = XML::fromArray($xmldata, $xml, false, $namespaces);
 

--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -290,7 +290,7 @@ class XML
 			return [];
 		}
 
-		xml_parser_set_option($parser, XML_OPTION_TARGET_ENCODING, "UTF-8");
+		xml_parser_set_option($parser, XML_OPTION_TARGET_ENCODING, 'UTF-8');
 		// http://minutillo.com/steve/weblog/2004/6/17/php-xml-and-character-encodings-a-tale-of-sadness-rage-and-data-loss
 		xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0);
 		xml_parser_set_option($parser, XML_OPTION_SKIP_WHITE, 1);
@@ -300,7 +300,7 @@ class XML
 		if (! $xml_values) {
 			Logger::debug('Xml::toArray: libxml: parse error: ' . $contents);
 			foreach (libxml_get_errors() as $err) {
-				Logger::debug('libxml: parse: ' . $err->code . " at " . $err->line . ":" . $err->column . " : " . $err->message);
+				Logger::debug('libxml: parse: ' . $err->code . ' at ' . $err->line . ':' . $err->column . ' : ' . $err->message);
 			}
 			libxml_clear_errors();
 			return [];
@@ -350,38 +350,38 @@ class XML
 			}
 			$tag = strtolower($tag);
 
-			if ($type == "open") {   // The starting of the tag '<tag>'
+			if ($type == 'open') {   // The starting of the tag '<tag>'
 				$parent[$level-1] = &$current;
 				if (!is_array($current) || (!in_array($tag, array_keys($current)))) { // Insert New tag
 					$current[$tag] = $result;
 					if ($attributes_data) {
 						$current[$tag. '_attr'] = $attributes_data;
 					}
-					$repeated_tag_index[$tag.'_'.$level] = 1;
+					$repeated_tag_index[$tag . '_' . $level] = 1;
 
 					$current = &$current[$tag];
 				} else { // There was another element with the same tag name
 
 					if (isset($current[$tag][0])) { // If there is a 0th element it is already an array
-						$current[$tag][$repeated_tag_index[$tag.'_'.$level]] = $result;
-						$repeated_tag_index[$tag.'_'.$level]++;
+						$current[$tag][$repeated_tag_index[$tag . '_' . $level]] = $result;
+						$repeated_tag_index[$tag . '_' . $level]++;
 					} else { // This section will make the value an array if multiple tags with the same name appear together
 						$current[$tag] = [$current[$tag], $result]; // This will combine the existing item and the new item together to make an array
-						$repeated_tag_index[$tag.'_'.$level] = 2;
+						$repeated_tag_index[$tag . '_' . $level] = 2;
 
 						if (isset($current[$tag.'_attr'])) { // The attribute of the last(0th) tag must be moved as well
 							$current[$tag]['0_attr'] = $current[$tag.'_attr'];
 							unset($current[$tag.'_attr']);
 						}
 					}
-					$last_item_index = $repeated_tag_index[$tag.'_'.$level]-1;
+					$last_item_index = $repeated_tag_index[$tag . '_' . $level]-1;
 					$current = &$current[$tag][$last_item_index];
 				}
-			} elseif ($type == "complete") { // Tags that ends in 1 line '<tag />'
+			} elseif ($type == 'complete') { // Tags that ends in 1 line '<tag />'
 				//See if the key is already taken.
 				if (!isset($current[$tag])) { //New Key
 					$current[$tag] = $result;
-					$repeated_tag_index[$tag.'_'.$level] = 1;
+					$repeated_tag_index[$tag . '_' . $level] = 1;
 					if ($priority == 'tag' and $attributes_data) {
 						$current[$tag. '_attr'] = $attributes_data;
 					}
@@ -389,15 +389,15 @@ class XML
 					if (isset($current[$tag][0]) and is_array($current[$tag])) { // If it is already an array...
 
 						// ...push the new element into that array.
-						$current[$tag][$repeated_tag_index[$tag.'_'.$level]] = $result;
+						$current[$tag][$repeated_tag_index[$tag . '_' . $level]] = $result;
 
 						if ($priority == 'tag' and $get_attributes and $attributes_data) {
-							$current[$tag][$repeated_tag_index[$tag.'_'.$level] . '_attr'] = $attributes_data;
+							$current[$tag][$repeated_tag_index[$tag . '_' . $level] . '_attr'] = $attributes_data;
 						}
-						$repeated_tag_index[$tag.'_'.$level]++;
+						$repeated_tag_index[$tag . '_' . $level]++;
 					} else { // If it is not an array...
 						$current[$tag] = [$current[$tag], $result]; //...Make it an array using using the existing value and the new value
-						$repeated_tag_index[$tag.'_'.$level] = 1;
+						$repeated_tag_index[$tag . '_' . $level] = 1;
 						if ($priority == 'tag' and $get_attributes) {
 							if (isset($current[$tag.'_attr'])) { // The attribute of the last(0th) tag must be moved as well
 
@@ -406,10 +406,10 @@ class XML
 							}
 
 							if ($attributes_data) {
-								$current[$tag][$repeated_tag_index[$tag.'_'.$level] . '_attr'] = $attributes_data;
+								$current[$tag][$repeated_tag_index[$tag . '_' . $level] . '_attr'] = $attributes_data;
 							}
 						}
-						$repeated_tag_index[$tag.'_'.$level]++; // 0 and 1 indexes are already taken
+						$repeated_tag_index[$tag . '_' . $level]++; // 0 and 1 indexes are already taken
 					}
 				}
 			} elseif ($type == 'close') { // End of tag '</tag>'
@@ -452,7 +452,7 @@ class XML
 			if (!$suppress_log) {
 				Logger::error('Error(s) while parsing XML string.', ['callstack' => System::callstack()]);
 				foreach (libxml_get_errors() as $err) {
-					Logger::info('libxml error', ['code' => $err->code, 'position' => $err->line . ":" . $err->column, 'message' => $err->message]);
+					Logger::info('libxml error', ['code' => $err->code, 'position' => $err->line . ':' . $err->column, 'message' => $err->message]);
 				}
 				Logger::debug('Erroring XML string', ['xml' => $s]);
 			}


### PR DESCRIPTION
Changes:
- added missing type-hints
- added documentation
- removed parameter $baseURL while it can be locally get the same way but lesser parameter
- used `ActivityNamespace::SALMON_ME` instead of direct string
- changed double-quotes to single