### PR TITLE
Improved performance when updating contacts

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2022.09-dev (Giant Rhubarb)
--- DB_UPDATE_VERSION 1479
+-- DB_UPDATE_VERSION 1480
 -- ------------------------------------------
 
 
@@ -141,12 +141,14 @@ CREATE TABLE IF NOT EXISTS `contact` (
 	`poll` varchar(255) COMMENT '',
 	`subscribe` varchar(255) COMMENT '',
 	`last-update` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'Date of the last try to update the contact info',
+	`next-update` datetime COMMENT 'Next connection request',
 	`success_update` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'Date of the last successful contact update',
 	`failure_update` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'Date of the last failed update',
 	`failed` boolean COMMENT 'Connection failed',
 	`term-date` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
 	`last-item` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'date of the last post',
 	`last-discovery` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'date of the last follower discovery',
+	`local-data` boolean COMMENT 'Is true when there are posts with this contact on the system',
 	`blocked` boolean NOT NULL DEFAULT '1' COMMENT 'Node-wide block status',
 	`block_reason` text COMMENT 'Node-wide block reason',
 	`readonly` boolean NOT NULL DEFAULT '0' COMMENT 'posts of the contact are readonly',
@@ -213,6 +215,8 @@ CREATE TABLE IF NOT EXISTS `contact` (
 	 INDEX `attag_uid` (`attag`(96),`uid`),
 	 INDEX `network_uid_lastupdate` (`network`,`uid`,`last-update`),
 	 INDEX `uid_network_self_lastupdate` (`uid`,`network`,`self`,`last-update`),
+	 INDEX `next-update` (`next-update`),
+	 INDEX `local-data-next-update` (`local-data`,`next-update`),
 	 INDEX `uid_lastitem` (`uid`,`last-item`),
 	 INDEX `baseurl` (`baseurl`(64)),
 	 INDEX `uid_contact-type` (`uid`,`contact-type`),

--- a/doc/database/db_contact.md
+++ b/doc/database/db_contact.md
@@ -34,12 +34,14 @@ Fields
 | poll                      |                                                                                                                | varchar(255)       | YES  |     | NULL                |                |
 | subscribe                 |                                                                                                                | varchar(255)       | YES  |     | NULL                |                |
 | last-update               | Date of the last try to update the contact info                                                                | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
+| next-update               | Next connection request                                                                                        | datetime           | YES  |     | NULL                |                |
 | success_update            | Date of the last successful contact update                                                                     | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
 | failure_update            | Date of the last failed update                                                                                 | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
 | failed                    | Connection failed                                                                                              | boolean            | YES  |     | NULL                |                |
 | term-date                 |                                                                                                                | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
 | last-item                 | date of the last post                                                                                          | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
 | last-discovery            | date of the last follower discovery                                                                            | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
+| local-data                | Is true when there are posts with this contact on the system                                                   | boolean            | YES  |     | NULL                |                |
 | blocked                   | Node-wide block status                                                                                         | boolean            | NO   |     | 1                   |                |
 | block_reason              | Node-wide block reason                                                                                         | text               | YES  |     | NULL                |                |
 | readonly                  | posts of the contact are readonly                                                                              | boolean            | NO   |     | 0                   |                |
@@ -112,6 +114,8 @@ Indexes
 | attag_uid                   | attag(96), uid                       |
 | network_uid_lastupdate      | network, uid, last-update            |
 | uid_network_self_lastupdate | uid, network, self, last-update      |
+| next-update                 | next-update                          |
+| local-data-next-update      | local-data, next-update              |
 | uid_lastitem                | uid, last-item                       |
 | baseurl                     | baseurl(64)                          |
 | uid_contact-type            | uid, contact-type                    |

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1948,15 +1948,15 @@ class Item
 			} else {
 				$condition = ['id' => $arr['contact-id'], 'self' => false];
 			}
-			Contact::update(['failed' => false, 'success_update' => $arr['received'], 'last-item' => $arr['received']], $condition);
+			Contact::update(['failed' => false, 'local-data' => true, 'success_update' => $arr['received'], 'last-item' => $arr['received']], $condition);
 		}
 		// Now do the same for the system wide contacts with uid=0
 		if ($arr['private'] != self::PRIVATE) {
-			Contact::update(['failed' => false, 'success_update' => $arr['received'], 'last-item' => $arr['received']],
+			Contact::update(['failed' => false, 'local-data' => true, 'success_update' => $arr['received'], 'last-item' => $arr['received']],
 				['id' => $arr['owner-id']]);
 
 			if ($arr['owner-id'] != $arr['author-id']) {
-				Contact::update(['failed' => false, 'success_update' => $arr['received'], 'last-item' => $arr['received']],
+				Contact::update(['failed' => false, 'local-data' => true, 'success_update' => $arr['received'], 'last-item' => $arr['received']],
 					['id' => $arr['author-id']]);
 			}
 		}

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -565,6 +565,12 @@ class Post
 			$posts = DBA::select('post-user-view', ['uri-id'], $condition, ['group_by' => ['uri-id']]);
 			while ($rows = DBA::toArray($posts, false, 100)) {
 				$uriids = array_column($rows, 'uri-id');
+
+				// Only delete the "post" entry when all "post-user" entries are deleted
+				if (!empty($update_fields['deleted']) && DBA::exists('post-user', ['uri-id' => $uriids, 'deleted' => false])) {
+					unset($update_fields['deleted']);
+				}
+
 				if (!DBA::update('post', $update_fields, ['uri-id' => $uriids])) {
 					DBA::rollback();
 					Logger::notice('Updating post failed', ['fields' => $update_fields, 'condition' => $condition]);

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1479);
+	define('DB_UPDATE_VERSION', 1480);
 }
 
 return [
@@ -198,12 +198,14 @@ return [
 			"poll" => ["type" => "varchar(255)", "comment" => ""],
 			"subscribe" => ["type" => "varchar(255)", "comment" => ""],
 			"last-update" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "Date of the last try to update the contact info"],
+			"next-update" => ["type" => "datetime", "comment" => "Next connection request"],
 			"success_update" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "Date of the last successful contact update"],
 			"failure_update" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "Date of the last failed update"],
 			"failed" => ["type" => "boolean", "comment" => "Connection failed"],
 			"term-date" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => ""],
 			"last-item" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "date of the last post"],
 			"last-discovery" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "date of the last follower discovery"],
+			"local-data" => ["type" => "boolean", "comment" => "Is true when there are posts with this contact on the system"],
 			"blocked" => ["type" => "boolean", "not null" => "1", "default" => "1", "comment" => "Node-wide block status"],
 			"block_reason" => ["type" => "text", "comment" => "Node-wide block reason"],
 			"readonly" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => "posts of the contact are readonly"],
@@ -275,6 +277,8 @@ return [
 			"attag_uid" => ["attag(96)", "uid"],
 			"network_uid_lastupdate" => ["network", "uid", "last-update"],
 			"uid_network_self_lastupdate" => ["uid", "network", "self", "last-update"],
+			"next-update" => ["next-update"],
+			"local-data-next-update" => ["local-data", "next-update"],
 			"uid_lastitem" => ["uid", "last-item"],
 			"baseurl" => ["baseurl(64)"],
 			"uid_contact-type" => ["uid", "contact-type"],

--- a/update.php
+++ b/update.php
@@ -1112,4 +1112,5 @@ function update_1457()
 function update_1480()
 {
 	DBA::update('contact', ['next-update' => DBA::NULL_DATETIME], ['network' => Protocol::FEDERATED]);
+	return Update::SUCCESS;
 }

--- a/update.php
+++ b/update.php
@@ -1112,5 +1112,6 @@ function update_1457()
 function update_1480()
 {
 	DBA::update('contact', ['next-update' => DBA::NULL_DATETIME], ['network' => Protocol::FEDERATED]);
+	DBA::update('post', ['deleted' => false], ["`uri-id` IN (SELECT `uri-id` FROM `post-user` WHERE NOT `deleted`)"]);
 	return Update::SUCCESS;
 }

--- a/update.php
+++ b/update.php
@@ -42,6 +42,7 @@
 
 use Friendica\Core\Config\ValueObject\Cache;
 use Friendica\Core\Logger;
+use Friendica\Core\Protocol;
 use Friendica\Core\Storage\Capability\ICanReadFromStorage;
 use Friendica\Core\Storage\Type\Database as DatabaseStorage;
 use Friendica\Core\Update;
@@ -1106,4 +1107,9 @@ function update_1457()
 	DBA::close($pinned);
 
 	return Update::SUCCESS;
+}
+
+function update_1480()
+{
+	DBA::update('contact', ['next-update' => DBA::NULL_DATETIME], ['network' => Protocol::FEDERATED]);
 }


### PR DESCRIPTION
The previous "update contacts"  function used a query that ran for several seconds. 

The functionality to define the date range between update events has now moved to the update contact functionality.

Edit: This PR now also contains a (hopefully) small bugfix where `post` entries received the `deleted` flag although there had been `post-user` entries that were undeleted.