### PR TITLE
Fixed "get() on NULL", PHP is case-sensitive here

### DIFF
--- a/src/Console/MoveToAvatarCache.php
+++ b/src/Console/MoveToAvatarCache.php
@@ -46,7 +46,7 @@ class MoveToAvatarCache extends \Asika\SimpleConsole\Console
 	/**
 	 * @var $baseurl Friendica\App\BaseURL
 	 */
-	private $baseurl;
+	private $baseUrl;
 
 	/**
 	 * @var L10n
@@ -75,12 +75,12 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(\Friendica\Database\Database $dba, BaseURL $baseurl, L10n $l10n, IManageConfigValues $config, array $argv = null)
+	public function __construct(\Friendica\Database\Database $dba, BaseURL $baseUrl, L10n $l10n, IManageConfigValues $config, array $argv = null)
 	{
 		parent::__construct($argv);
 
 		$this->dba     = $dba;
-		$this->baseurl = $baseurl;
+		$this->baseUrl = $baseUrl;
 		$this->l10n    = $l10n;
 		$this->config = $config;
 	}
@@ -94,7 +94,7 @@ HELP;
 
 		$fields = ['id', 'avatar', 'photo', 'thumb', 'micro', 'uri-id', 'url', 'avatar', 'network'];
 		$condition = ["NOT `self` AND `avatar` != ? AND `photo` LIKE ? AND `uid` = ? AND `uri-id` != ? AND NOT `uri-id` IS NULL AND NOT `network` IN (?, ?)",
-			'', $this->baseurl->get() . '/photo/%', 0, 0, Protocol::MAIL, Protocol::FEED];
+			'', $this->baseUrl->get() . '/photo/%', 0, 0, Protocol::MAIL, Protocol::FEED];
 
 		$count    = 0;
 		$total    = $this->dba->count('contact', $condition);

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -111,7 +111,7 @@ class Xrd extends BaseModule
 
 	private function printSystemJSON(array $owner)
 	{
-		$baseURL = $this->baseurl->get();
+		$baseURL = $this->baseUrl->get();
 		$json = [
 			'subject' => 'acct:' . $owner['addr'],
 			'aliases' => [$owner['url']],
@@ -157,7 +157,7 @@ class Xrd extends BaseModule
 
 	private function printJSON(string $alias, array $owner, array $avatar)
 	{
-		$baseURL = $this->baseurl->get();
+		$baseURL = $this->baseUrl->get();
 		$salmon_key = Salmon::salmonKey($owner['spubkey']);
 
 		$json = [
@@ -239,7 +239,7 @@ class Xrd extends BaseModule
 
 	private function printXML(string $alias, array $user, array $owner, array $avatar)
 	{
-		$baseURL = $this->baseurl->get();
+		$baseURL = $this->baseUrl->get();
 		$salmon_key = Salmon::salmonKey($owner['spubkey']);
 
 		$tpl = Renderer::getMarkupTemplate('xrd_person.tpl');

--- a/src/Render/FriendicaSmartyEngine.php
+++ b/src/Render/FriendicaSmartyEngine.php
@@ -31,7 +31,7 @@ use Friendica\Util\Strings;
  */
 final class FriendicaSmartyEngine extends TemplateEngine
 {
-	static $name = "smarty3";
+	static $name = 'smarty3';
 
 	const FILE_PREFIX = 'file:';
 	const STRING_PREFIX = 'string:';


### PR DESCRIPTION
Fixes:
- fixed "get() on NULL invocation, PHP is case-sensitive here
- renamed `$this->baseurl` to `$this->baseUrl` (instance) in `MoveToAvatarCache` to make it same as everywhere else
- this is a follow-up PR to #11843 