### PR TITLE
Smarty: Configuration added to store without sub directories

### DIFF
--- a/src/Render/FriendicaSmarty.php
+++ b/src/Render/FriendicaSmarty.php
@@ -23,7 +23,6 @@ namespace Friendica\Render;
 
 use Smarty;
 use Friendica\Core\Renderer;
-use Friendica\DI;
 
 /**
  * Friendica extension of the Smarty3 template engine
@@ -34,7 +33,7 @@ class FriendicaSmarty extends Smarty
 
 	public $filename;
 
-	public function __construct(string $theme, array $theme_info, string $work_dir)
+	public function __construct(string $theme, array $theme_info, string $work_dir, bool $use_sub_dirs)
 	{
 		parent::__construct();
 
@@ -65,7 +64,7 @@ class FriendicaSmarty extends Smarty
 		 * RAM available + have enabled caching inode tables (aka.
 		 * "descriptors"). Still it won't hurt you.
 		 */
-		$this->setUseSubDirs(DI::config()->get('smarty3', 'use_sub_dirs'));
+		$this->setUseSubDirs($use_sub_dirs);
 
 		$this->left_delimiter  = Renderer::getTemplateLeftDelimiter();
 		$this->right_delimiter = Renderer::getTemplateRightDelimiter();

--- a/src/Render/FriendicaSmarty.php
+++ b/src/Render/FriendicaSmarty.php
@@ -23,6 +23,7 @@ namespace Friendica\Render;
 
 use Smarty;
 use Friendica\Core\Renderer;
+use Friendica\DI;
 
 /**
  * Friendica extension of the Smarty3 template engine
@@ -64,7 +65,7 @@ class FriendicaSmarty extends Smarty
 		 * RAM available + have enabled caching inode tables (aka.
 		 * "descriptors"). Still it won't hurt you.
 		 */
-		$this->setUseSubDirs(true);
+		$this->setUseSubDirs(DI::config()->get('smarty3', 'use_sub_dirs'));
 
 		$this->left_delimiter  = Renderer::getTemplateLeftDelimiter();
 		$this->right_delimiter = Renderer::getTemplateRightDelimiter();

--- a/src/Render/FriendicaSmartyEngine.php
+++ b/src/Render/FriendicaSmartyEngine.php
@@ -44,10 +44,13 @@ final class FriendicaSmartyEngine extends TemplateEngine
 	 */
 	public function __construct(string $theme, array $theme_info)
 	{
-		$this->theme = $theme;
+		$this->theme      = $theme;
 		$this->theme_info = $theme_info;
-		$work_dir = DI::config()->get('smarty3', 'config_dir');
-		$this->smarty = new FriendicaSmarty($this->theme, $this->theme_info, $work_dir);
+
+		$work_dir     = DI::config()->get('smarty3', 'config_dir');
+		$use_sub_dirs = DI::config()->get('smarty3', 'use_sub_dirs');
+
+		$this->smarty = new FriendicaSmarty($this->theme, $this->theme_info, $work_dir, $use_sub_dirs);
 
 		if (!is_writable($work_dir)) {
 			$admin_message = DI::l10n()->t('The folder %s must be writable by webserver.', $work_dir);

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -714,5 +714,10 @@ return [
 		// config_dir (String)
 		// Base working directory for the templating engine, must be writeable by the webserver user
 		'config_dir' => 'view/smarty3',
+
+		// use_sub_dirs (Boolean)
+		// By default the template cache is stored in several sub directories.
+		// 
+		'use_sub_dirs' => true,
 	],
 ];


### PR DESCRIPTION
Storing the template cache into several sub directories is supposed to increase the performance. However this can cause permission issues when the system uses different users for front end and worker. With this configuration we can restore the old behaviour.