### PR TITLE
The fcontact table is now updated in the background to improve performance

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2022.09-rc (Giant Rhubarb)
--- DB_UPDATE_VERSION 1482
+-- DB_UPDATE_VERSION 1483
 -- ------------------------------------------
 
 
@@ -625,6 +625,7 @@ CREATE TABLE IF NOT EXISTS `fcontact` (
 	`network` char(4) NOT NULL DEFAULT '' COMMENT '',
 	`alias` varbinary(383) NOT NULL DEFAULT '' COMMENT '',
 	`pubkey` text COMMENT '',
+	`created` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
 	`updated` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
 	`interacting_count` int unsigned DEFAULT 0 COMMENT 'Number of contacts this contact interactes with',
 	`interacted_count` int unsigned DEFAULT 0 COMMENT 'Number of contacts that interacted with this contact',

--- a/doc/database/db_fcontact.md
+++ b/doc/database/db_fcontact.md
@@ -25,6 +25,7 @@ Fields
 | network           |                                                               | char(4)          | NO   |     |                     |                |
 | alias             |                                                               | varbinary(383)   | NO   |     |                     |                |
 | pubkey            |                                                               | text             | YES  |     | NULL                |                |
+| created           |                                                               | datetime         | NO   |     | 0001-01-01 00:00:00 |                |
 | updated           |                                                               | datetime         | NO   |     | 0001-01-01 00:00:00 |                |
 | interacting_count | Number of contacts this contact interactes with               | int unsigned     | YES  |     | 0                   |                |
 | interacted_count  | Number of contacts that interacted with this contact          | int unsigned     | YES  |     | 0                   |                |

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -66,7 +66,6 @@ class Probe
 	public static function isProbable(string $network): bool
 	{
 		return (in_array($network, array_merge(Protocol::FEDERATED, [Protocol::ZOT, Protocol::PHANTOM])));
-
 	}
 
 	/**

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -58,6 +58,18 @@ class Probe
 	private static $istimeout;
 
 	/**
+	 * Checks if the provided network can be probed
+	 *
+	 * @param string $network
+	 * @return boolean
+	 */
+	public static function isProbable(string $network): bool
+	{
+		return (in_array($network, array_merge(Protocol::FEDERATED, [Protocol::ZOT, Protocol::PHANTOM])));
+
+	}
+
+	/**
 	 * Remove stuff from an URI that doesn't belong there
 	 *
 	 * @param string $rawUri

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1482);
+	define('DB_UPDATE_VERSION', 1483);
 }
 
 return [
@@ -684,6 +684,7 @@ return [
 			"network" => ["type" => "char(4)", "not null" => "1", "default" => "", "comment" => ""],
 			"alias" => ["type" => "varbinary(383)", "not null" => "1", "default" => "", "comment" => ""],
 			"pubkey" => ["type" => "text", "comment" => ""],
+			"created" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => ""],
 			"updated" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => ""],
 			"interacting_count" => ["type" => "int unsigned", "default" => 0, "comment" => "Number of contacts this contact interactes with"],
 			"interacted_count" => ["type" => "int unsigned", "default" => 0, "comment" => "Number of contacts that interacted with this contact"],


### PR DESCRIPTION
This PR touches an performance loss where we update the `contact` or `fcontact` table while receiving or transmitting data. This is a task that is better done in the background.