### PR TITLE
Allow to reject specific languages on receiving posts via the relay

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1870,7 +1870,7 @@ class Item
 			return '';
 		}
 
-		$languages = self::getLanguageArray(trim($item['title'] . "\n" . $item['body']));
+		$languages = self::getLanguageArray(trim($item['title'] . "\n" . $item['body']), 3);
 		if (empty($languages)) {
 			return '';
 		}
@@ -1878,7 +1878,7 @@ class Item
 		return json_encode($languages);
 	}
 
-	public static function getLanguageArray(string $body): array
+	public static function getLanguageArray(string $body, int $count): array
 	{
 		// Convert attachments to links
 		$naked_body = BBCode::removeAttachment($body);
@@ -1908,7 +1908,7 @@ class Item
 		$availableLanguages['fa'] = 'fa';
 
 		$ld = new Language(array_keys($availableLanguages));
-		return $ld->detect($naked_body)->limit(0, 3)->close() ?: [];
+		return $ld->detect($naked_body)->limit(0, $count)->close() ?: [];
 	}
 
 	/**

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1878,6 +1878,13 @@ class Item
 		return json_encode($languages);
 	}
 
+	/**
+	 * Get a language array from a given text
+	 *
+	 * @param string  $body
+	 * @param integer $count
+	 * @return array
+	 */
 	public static function getLanguageArray(string $body, int $count): array
 	{
 		// Convert attachments to links

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1870,23 +1870,33 @@ class Item
 			return '';
 		}
 
-		// Convert attachments to links
-		$naked_body = BBCode::removeAttachment($item['body']);
-		if (empty($naked_body)) {
+		$languages = self::getLanguageArray(trim($item['title'] . "\n" . $item['body']));
+		if (empty($languages)) {
 			return '';
+		}
+
+		return json_encode($languages);
+	}
+
+	public static function getLanguageArray(string $body): array
+	{
+		// Convert attachments to links
+		$naked_body = BBCode::removeAttachment($body);
+		if (empty($naked_body)) {
+			return [];
 		}
 
 		// Remove links and pictures
 		$naked_body = BBCode::removeLinks($naked_body);
 
 		// Convert the title and the body to plain text
-		$naked_body = trim($item['title'] . "\n" . BBCode::toPlaintext($naked_body));
+		$naked_body = BBCode::toPlaintext($naked_body);
 
 		// Remove possibly remaining links
 		$naked_body = preg_replace(Strings::autoLinkRegEx(), '', $naked_body);
 
 		if (empty($naked_body)) {
-			return '';
+			return [];
 		}
 
 		$naked_body = self::getDominantLanguage($naked_body);
@@ -1898,12 +1908,7 @@ class Item
 		$availableLanguages['fa'] = 'fa';
 
 		$ld = new Language(array_keys($availableLanguages));
-		$languages = $ld->detect($naked_body)->limit(0, 3)->close();
-		if (is_array($languages)) {
-			return json_encode($languages);
-		}
-
-		return '';
+		return $ld->detect($naked_body)->limit(0, 3)->close() ?: [];
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -91,7 +91,7 @@ class Processor
 	 * @param string $body
 	 * @return string
 	 */
-	protected static function normalizeMentionLinks(string $body): string
+	public static function normalizeMentionLinks(string $body): string
 	{
 		return preg_replace('%\[url=([^\[\]]*)]([#@!])(.*?)\[/url]%ism', '$2[url=$1]$3[/url]', $body);
 	}

--- a/src/Protocol/Relay.php
+++ b/src/Protocol/Relay.php
@@ -129,7 +129,7 @@ class Relay
 		}
 
 		$languages = [];
-		foreach (Item::getLanguageArray($body) as $language => $reliability) {
+		foreach (Item::getLanguageArray($body, 10) as $language => $reliability) {
 			if ($reliability > 0) {
 				$languages[] = $language;
 			}

--- a/src/Protocol/Relay.php
+++ b/src/Protocol/Relay.php
@@ -29,6 +29,7 @@ use Friendica\DI;
 use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Model\GServer;
+use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Model\Search;
 use Friendica\Model\Tag;
@@ -75,6 +76,8 @@ class Relay
 			Logger::info('Author is hidden - rejected', ['author' => $authorid, 'network' => $network, 'url' => $url]);
 			return false;
 		}
+
+		$body = ActivityPub\Processor::normalizeMentionLinks($body);
 
 		$systemTags = [];
 		$userTags = [];
@@ -123,6 +126,25 @@ class Relay
 					return true;
 				}
 			}
+		}
+
+		$languages = [];
+		foreach (Item::getLanguageArray($body) as $language => $reliability) {
+			if ($reliability > 0) {
+				$languages[] = $language;
+			}
+		}
+
+		Logger::debug('Got languages', ['languages' => $languages, 'body' => $body]);
+
+		if (!empty($languages)) {
+			if (in_array($languages[0], $config->get('system', 'relay_deny_languages'))) {
+				Logger::info('Unwanted language found - rejected', ['language' => $languages[0], 'network' => $network, 'url' => $url]);
+				return false;
+			}
+		} elseif ($config->get('system', 'relay_deny_undetected_language')) {
+			Logger::info('Undetected language found - rejected', ['body' => $body, 'network' => $network, 'url' => $url]);
+			return false;
 		}
 
 		if ($scope == self::SCOPE_ALL) {

--- a/src/Util/Profiler.php
+++ b/src/Util/Profiler.php
@@ -152,13 +152,13 @@ class Profiler implements ContainerInterface
 	 * Saves a timestamp for a value - f.e. a call
 	 * Necessary for profiling Friendica
 	 *
-	 * @param int    $timestamp the Timestamp
+	 * @param float  $timestamp the Timestamp
 	 * @param string $value     A value to profile
 	 * @param string $callstack A callstack string, generated if absent
 	 *
 	 * @return void
 	 */
-	public function saveTimestamp(int $timestamp, string $value, string $callstack = '')
+	public function saveTimestamp(float $timestamp, string $value, string $callstack = '')
 	{
 		if (!$this->enabled) {
 			return;
@@ -358,9 +358,9 @@ class Profiler implements ContainerInterface
 	 * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
 	 * @throws ContainerExceptionInterface Error while retrieving the entry.
 	 *
-	 * @return int Entry.
+	 * @return float Entry.
 	 */
-	public function get(string $id): int
+	public function get(string $id): float
 	{
 		if (!$this->has($id)) {
 			return 0;

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -526,7 +526,7 @@ return [
 		'redis_password' => null,
 
 		// relay_deny_languages (Array)
-		// Array of languages that are rejected.
+		// Array of languages (two digit format) that are rejected.
 		'relay_deny_languages' => [],
 
 		// relay_deny_undetected_language (Boolean)

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -525,6 +525,14 @@ return [
 		// The authentication password for the redis database
 		'redis_password' => null,
 
+		// relay_deny_languages (Array)
+		// Array of languages that are rejected.
+		'relay_deny_languages' => [],
+
+		// relay_deny_undetected_language (Boolean)
+		// Deny undetected languages
+		'relay_deny_undetected_language' => false,
+
 		// session_handler (database|cache|native)
 		// Whether to use Cache to store session data or to use PHP native session storage.
 		'session_handler' => 'database',


### PR DESCRIPTION
When receiving posts via the relay, we receive posts in many different languages. We now can reject specific languages. Since many European languages are really similar, this will not work great on removing a specific language from that group of languages. But it helps with - for example - rejecting posts in Japanese when you don't have got a Japanese audience on your system.