### PR TITLE
Fix forum delivery in case of being addressed via "@"

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -765,7 +765,7 @@ class Transmitter
 								$data['to'][] = $profile['url'];
 							} else {
 								$data['cc'][] = $profile['url'];
-								if (($item['private'] != Item::PRIVATE) && !empty($actor_profile['followers'])&& !$is_forum_thread) {
+								if (($item['private'] != Item::PRIVATE) && !empty($actor_profile['followers']) && (!$exclusive || !$is_forum_thread)) {
 									$data['cc'][] = $actor_profile['followers'];
 								}
 							}


### PR DESCRIPTION
Possibly related to https://github.com/friendica/friendica/issues/11876

When a forum had been addressed via `!` everything went well. But when a forum had been addressed via `@` then the post was not distributed to the forum followers.