### PR TITLE
More cooldown calls for worker processes

### DIFF
--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -76,8 +76,8 @@ DI::config()->load();
 if (empty(DI::config()->get('system', 'pidfile'))) {
 	die(<<<TXT
 Please set system.pidfile in config/local.config.php. For example:
-
-    'system' => [
+    
+    'system' => [ 
         'pidfile' => '/path/to/daemon.pid',
     ],
 TXT

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -199,7 +199,6 @@ while (true) {
 	}
 
 	if ($do_cron || (!DI::system()->isMaxLoadReached() && Worker::entriesExists() && Worker::isReady())) {
-		Worker::coolDown();
 		Worker::spawnWorker($do_cron);
 	} else {
 		Logger::info('Cool down for 5 seconds', ['pid' => $pid]);

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -76,8 +76,8 @@ DI::config()->load();
 if (empty(DI::config()->get('system', 'pidfile'))) {
 	die(<<<TXT
 Please set system.pidfile in config/local.config.php. For example:
-    
-    'system' => [ 
+
+    'system' => [
         'pidfile' => '/path/to/daemon.pid',
     ],
 TXT
@@ -199,6 +199,7 @@ while (true) {
 	}
 
 	if ($do_cron || (!DI::system()->isMaxLoadReached() && Worker::entriesExists() && Worker::isReady())) {
+		Worker::coolDown();
 		Worker::spawnWorker($do_cron);
 	} else {
 		Logger::info('Cool down for 5 seconds', ['pid' => $pid]);

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -442,17 +442,24 @@ class System
 	 */
 	public static function getLoadAvg(): array
 	{
-		$content = file_get_contents('/proc/loadavg');
+		$content = @file_get_contents('/proc/loadavg');
 		if (empty($content)) {
 			$content = shell_exec('cat /proc/loadavg');
 		}
-		if (empty($content)) {
-			return [];
+		if (empty($content) || !preg_match("#([.\d]+)\s([.\d]+)\s([.\d]+)\s(\d+)/(\d+)#", $content, $matches)) {
+			$load_arr = sys_getloadavg();
+			if (empty($load_arr)) {
+				return [];
+			}
+			return [
+				'average1'  => $load_arr[0],
+				'average5'  => $load_arr[1],
+				'average15' => $load_arr[2],
+				'runnable'  => 0,
+				'scheduled' => 0
+			];
 		}
 
-		if (!preg_match("#([.\d]+)\s([.\d]+)\s([.\d]+)\s(\d+)/(\d+)#", $content, $matches)) {
-			return [];
-		}
 		return [
 			'average1'  => (float)$matches[1],
 			'average5'  => (float)$matches[2],

--- a/src/Protocol/ActivityPub/Delivery.php
+++ b/src/Protocol/ActivityPub/Delivery.php
@@ -22,6 +22,7 @@
 namespace Friendica\Protocol\ActivityPub;
 
 use Friendica\Core\Logger;
+use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
@@ -55,6 +56,7 @@ class Delivery
 					Logger::notice('Inbox delivery has a server failure', ['inbox' => $inbox]);
 					$serverfail = true;
 				}
+				Worker::coolDown();
 			}
 
 			if ($serverfail || (!$result['success'] && !$result['drop'])) {

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -573,6 +573,7 @@ class Notifier
 			if (Worker::add($deliver_options, 'Delivery', $cmd, $post_uriid, (int)$contact['id'], $sender_uid)) {
 				$delivery_queue_count++;
 			}
+			Worker::coolDown();
 		}
 		return $delivery_queue_count;
 	}
@@ -695,6 +696,7 @@ class Notifier
 			Logger::info('Account removal via ActivityPub', ['uid' => $self_user_id, 'inbox' => $inbox]);
 			Worker::add(['priority' => PRIORITY_NEGLIGIBLE, 'created' => $created, 'dont_fork' => true],
 				'APDelivery', Delivery::REMOVAL, 0, $inbox, $self_user_id, $receivers);
+			Worker::coolDown();
 		}
 
 		return true;
@@ -818,6 +820,7 @@ class Notifier
 					$delivery_queue_count++;
 				}
 			}
+			Worker::coolDown();
 		}
 
 		// We deliver posts to relay servers slightly delayed to priorize the direct delivery
@@ -833,6 +836,7 @@ class Notifier
 					$delivery_queue_count++;
 				}
 			}
+			Worker::coolDown();
 		}
 
 		return ['count' => $delivery_queue_count, 'contacts' => $contacts];

--- a/src/Worker/PollContacts.php
+++ b/src/Worker/PollContacts.php
@@ -81,6 +81,7 @@ class PollContacts
 			Logger::notice("Polling " . $contact["network"] . " " . $contact["id"] . " " . $contact['priority'] . " " . $contact["nick"] . " " . $contact["name"]);
 
 			Worker::add(['priority' => $priority, 'dont_fork' => true, 'force_priority' => true], 'OnePoll', (int)$contact['id']);
+			Worker::coolDown();
 		}
 		DBA::close($contacts);
 	}

--- a/src/Worker/UpdateContacts.php
+++ b/src/Worker/UpdateContacts.php
@@ -62,6 +62,7 @@ class UpdateContacts
 			if (Worker::add(['priority' => PRIORITY_LOW, 'dont_fork' => true], "UpdateContact", $contact['id'])) {
 				++$count;
 			}
+			Worker::coolDown();
 		}
 		DBA::close($contacts);
 

--- a/src/Worker/UpdateGServers.php
+++ b/src/Worker/UpdateGServers.php
@@ -72,6 +72,7 @@ class UpdateGServers
 					$count++;
 				}
 			}
+			Worker::coolDown();
 		}
 		DBA::close($gservers);
 		Logger::info('Updated servers', ['count' => $count]);

--- a/src/Worker/UpdateServerPeers.php
+++ b/src/Worker/UpdateServerPeers.php
@@ -63,6 +63,7 @@ class UpdateServerPeers
 			// This endpoint doesn't offer the schema. So we assume that it is HTTPS.
 			GServer::add('https://' . $peer);
 			++$added;
+			Worker::coolDown();
 		}
 		Logger::info('Server peer update ended', ['total' => $total, 'added' => $added, 'url' => $url]);
 	}

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -615,7 +615,7 @@ return [
 		// Minimum for this config value is 1. Maximum is 64 as the resulting profile URL mustn't be longer than 255 chars.
 		'username_max_length' => 48,
 
-		// worker_cooldown (Integer)
+		// worker_cooldown (Float)
 		// Cooldown period in seconds before each worker function call.
 		'worker_cooldown' => 0,
 


### PR DESCRIPTION
Some days ago a check was added to the worker to delay the processing when the load is too high. This check is now done at several other places. This should help to keep the system load under a given value.