### PR TITLE
Fix error "Class 'Friendica\Worker\Worker' not found"

### DIFF
--- a/src/Worker/UpdateServerPeers.php
+++ b/src/Worker/UpdateServerPeers.php
@@ -22,6 +22,7 @@
 namespace Friendica\Worker;
 
 use Friendica\Core\Logger;
+use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\GServer;


### PR DESCRIPTION
The `use Friendica\Core\Worker;` was missing