### PR TITLE
Do not remove trailing slash from URIs

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -66,7 +66,7 @@ class Probe
 	public static function cleanURI(string $rawUri): string
 	{
 		// At first remove leading and trailing junk
-		$rawUri = trim($rawUri, "@#?:/ \t\n\r\0\x0B");
+		$rawUri = trim($rawUri, "@#?: \t\n\r\0\x0B");
 
 		$rawUri = Network::convertToIdn($rawUri);
 


### PR DESCRIPTION
This code makes it impossible to add the RSS feed at https://www.jwz.org/blog/ as a contact.  The feed link requires a slash at the end.

I can't imagine why a slash is considered "junk", but perhaps there's a good reason.

I've tried and can't figure out how to run the unit tests locally, so I'm going to let github run them for me.