### PR TITLE
Fix removing falsy text nodes in HTML::tagToBBCodeSub

### DIFF
--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -114,7 +114,7 @@ class HTML
 					/** @var \DOMNode $child */
 					foreach ($node->childNodes as $key => $child) {
 						/* Remove empty text nodes at the start or at the end of the children list */
-						if ($key > 0 && $key < $node->childNodes->length - 1 || $child->nodeName != '#text' || trim($child->nodeValue)) {
+						if ($key > 0 && $key < $node->childNodes->length - 1 || $child->nodeName != '#text' || trim($child->nodeValue) !== '') {
 							$newNode = $child->cloneNode(true);
 							$node->parentNode->insertBefore($newNode, $node);
 						}
@@ -144,10 +144,10 @@ class HTML
 	public static function toBBCode(string $message, string $basepath = ''): string
 	{
 		/*
-		 * Check if message is empty to prevent a lot code below being executed
+		 * Check if message is empty to prevent a lot of code below from being executed
 		 * for just an empty message.
 		 */
-		if (empty($message)) {
+		if ($message === '') {
 			return '';
 		}
 

--- a/tests/src/Content/Text/HTMLTest.php
+++ b/tests/src/Content/Text/HTMLTest.php
@@ -82,6 +82,10 @@ its surprisingly good",
 				'html' => "<p>Now playing</p><pre><code>echo &quot;main(i){for(i=0;;i++)putchar(((i*(i&gt;&gt;8|i&gt;&gt;9)&amp;46&amp;i&gt;&gt;8))^(i&amp;i&gt;&gt;13|i&gt;&gt;6));}&quot; | gcc -o a.out -x c - 2&gt; /dev/null
 ./a.out | aplay -q 2&gt; /dev/null</code></pre><p>its surprisingly good</p>",
 			],
+			'bug-11851-content-0' => [
+				'expectedBBCode' => '[url=https://dev-friendica.mrpetovan.com/profile/hypolite]@hypolite[/url] 0',
+				'html' => '<p><span class="h-card"><a href="https://dev-friendica.mrpetovan.com/profile/hypolite" class="u-url mention">@<span>hypolite</span></a></span> 0</p>',
+			],
 		];
 	}
 


### PR DESCRIPTION
Fixes #11851 

- This wrongly removed text nodes containing just '0'