### PR TITLE
Support for quoted links is added

### DIFF
--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -157,6 +157,8 @@ class JsonLD
 			'sc' => (object)['@id' => 'http://schema.org#', '@type' => '@id'],
 			'pt' => (object)['@id' => 'https://joinpeertube.org/ns#', '@type' => '@id'],
 			'mobilizon' => (object)['@id' => 'https://joinmobilizon.org/ns#', '@type' => '@id'],
+			'fedibird' => (object)['@id' => 'http://fedibird.com/ns#', '@type' => '@id'],
+			'misskey' => (object)['@id' => 'https://misskey-hub.net/ns#', '@type' => '@id'],
 		];
 
 		$orig_json = $json;

--- a/static/litepub-0.1.jsonld
+++ b/static/litepub-0.1.jsonld
@@ -17,6 +17,7 @@
             "ostatus": "http://ostatus.org#",
             "schema": "http://schema.org#",
             "toot": "http://joinmastodon.org/ns#",
+            "fedibird": "http://fedibird.com/ns#",
             "value": "schema:value",
             "sensitive": "as:sensitive",
             "litepub": "http://litepub.social/ns#",
@@ -26,6 +27,8 @@
                 "@id": "litepub:listMessage",
                 "@type": "@id"
             },
+            "quoteUrl": "as:quoteUrl",
+            "quoteUri": "fedibird:quoteUri",
             "oauthRegistrationEndpoint": {
                 "@id": "litepub:oauthRegistrationEndpoint",
                 "@type": "@id"
@@ -35,7 +38,8 @@
             "alsoKnownAs": {
                 "@id": "as:alsoKnownAs",
                 "@type": "@id"
-            }
+            },
+            "vcard": "http://www.w3.org/2006/vcard/ns#"
         }
     ]
 }


### PR DESCRIPTION
Some systems (Misskey, Fedibird and Pleroma) now support quoted posts. So we now support them too:
![image](https://user-images.githubusercontent.com/844208/193084158-46a7aaa6-30d8-49c8-b657-edcd80bc2e2c.png)

This PR doesn't change how we transmit these quoted posts since compatibility has to be checked.