### PR TITLE
Support for transmitting quoted posts

### DIFF
--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -72,6 +72,8 @@ class ActivityPub
 		'schema' => 'http://schema.org#',
 		'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',
 		'sensitive' => 'as:sensitive', 'Hashtag' => 'as:Hashtag',
+		'quoteUrl' => 'as:quoteUrl',
+		'conversation' => 'ostatus:conversation',
 		'directMessage' => 'litepub:directMessage',
 		'discoverable' => 'toot:discoverable',
 		'PropertyValue' => 'schema:PropertyValue',

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1397,7 +1397,7 @@ class Transmitter
 			//	'type'      => 'Link',
 			//	'mediaType' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
 			//	'href'      => $quote_url,
-			//	'name'      => BBCode::convertForUriId($item['uri-id'], $quote_url, BBCode::ACTIVITYPUB)
+			//	'name'      => '♲ ' . BBCode::convertForUriId($item['uri-id'], $quote_url, BBCode::ACTIVITYPUB)
 			//];
 		}
 
@@ -1721,7 +1721,7 @@ class Transmitter
 		return BBCode::convertShare(
 			$body,
 			function (array $attributes) {
-				return $attributes['link'];
+				return '♲ ' . $attributes['link'];
 			}
 		);
 	}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1392,12 +1392,13 @@ class Transmitter
 
 		// @see https://codeberg.org/fediverse/fep/src/branch/main/feps/fep-e232.md
 		if (!empty($quote_url)) {
-			$tags[] = [
-				'type'      => 'Link',
-				'mediaType' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
-				'href'      => $quote_url,
-				'name'      => BBCode::convertForUriId($item['uri-id'], $quote_url, BBCode::ACTIVITYPUB)
-			];
+			// Currently deactivated because of compatibility issues with Pleroma
+			//$tags[] = [
+			//	'type'      => 'Link',
+			//	'mediaType' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+			//	'href'      => $quote_url,
+			//	'name'      => BBCode::convertForUriId($item['uri-id'], $quote_url, BBCode::ACTIVITYPUB)
+			//];
 		}
 
 		return $tags;
@@ -1694,7 +1695,7 @@ class Transmitter
 		}
 
 		$data['attachment'] = self::createAttachmentList($item);
-		$data['tag'] = self::createTagList($item, ''); // $data['quoteUrl'] ?? 
+		$data['tag'] = self::createTagList($item, $data['quoteUrl'] ?? '');  
 
 		if (empty($data['location']) && (!empty($item['coord']) || !empty($item['location']))) {
 			$data['location'] = self::createLocation($item);

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1664,7 +1664,7 @@ class Transmitter
 
 			$shared = BBCode::fetchShareAttributes($body);
 			if (!empty($shared['link']) && !empty($shared['guid']) && !empty($shared['comment'])) {
-				$body = self::ReplaceSharedData($body);
+				$body = self::replaceSharedData($body);
 				$data['quoteUrl'] = $shared['link'];
 			}
 
@@ -1680,7 +1680,7 @@ class Transmitter
 
 			$shared = BBCode::fetchShareAttributes($richbody);
 			if (!empty($shared['link']) && !empty($shared['guid']) && !empty($shared['comment'])) {
-				$richbody = self::ReplaceSharedData($richbody);
+				$richbody = self::replaceSharedData($richbody);
 			}
 
 			$richbody = BBCode::removeAttachment($richbody);
@@ -1716,7 +1716,7 @@ class Transmitter
 	 * @param string $body
 	 * @return string
 	 */
-	private static function ReplaceSharedData(string $body): string
+	private static function replaceSharedData(string $body): string
 	{
 		return BBCode::convertShare(
 			$body,


### PR DESCRIPTION
This PR adds support for tramsmitting quoted posts. We are using two different methods here. One is supported by Misskey and some Pleroma forks and Mastodon forks. And the other one is this proposal https://codeberg.org/fediverse/fep/src/branch/main/feps/fep-e232.md

It is currently a draft since at least the latter method seems to cause problems with Pleroma.

This mechanism is fully compatible with previous Friendica versions: 
![image](https://user-images.githubusercontent.com/844208/193213973-0ea0ad63-17ae-4809-8b56-4b538ad6385e.png)

On other systems it will look differently:

Pleroma:
![image](https://user-images.githubusercontent.com/844208/193213910-85520ae2-9522-475c-ab1b-ac113c9f90e7.png)

Mastodon: 
![image](https://user-images.githubusercontent.com/844208/193213667-6797e61d-2ffc-4431-acb8-b4e074b57dee.png)
