### PR TITLE
Issue 11952: Avoid to send AP related comments to Diaspora

### DIFF
--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -4133,6 +4133,17 @@ class Diaspora
 			return false;
 		}
 
+		$parent_post = Post::selectFirstPost(['gravity', 'signed_text', 'author-link'], ['uri-id' => $item['thr-parent-id']]);
+		if (empty(FContact::getByURL($parent_post['author-link'], false))) {
+			Logger::info('Parent author is no Diaspora contact. A signature will not be created.', ['uri-id' => $item['uri-id'], 'guid' => $item['guid']]);
+			return false;
+		}
+
+		if (($parent_post['gravity'] == GRAVITY_COMMENT) && empty($parent_post['signed_text'])) {
+			Logger::info('Parent comment has got no Diaspora signature. A signature will not be created.', ['uri-id' => $item['uri-id'], 'guid' => $item['guid']]);
+			return false;
+		}
+
 		$message = self::constructComment($item, $owner);
 		if ($message === false) {
 			return false;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -4134,7 +4134,7 @@ class Diaspora
 		}
 
 		if (!self::parentSupportDiaspora($item['thr-parent-id'])) {
-			Logger::info('One of the parents does not support. A signature will not be created.', ['uri-id' => $item['uri-id'], 'guid' => $item['guid']]);
+			Logger::info('One of the parents does not support Diaspora. A signature will not be created.', ['uri-id' => $item['uri-id'], 'guid' => $item['guid']]);
 			return false;
 		}
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -4133,14 +4133,8 @@ class Diaspora
 			return false;
 		}
 
-		$parent_post = Post::selectFirstPost(['gravity', 'signed_text', 'author-link'], ['uri-id' => $item['thr-parent-id']]);
-		if (empty(FContact::getByURL($parent_post['author-link'], false))) {
-			Logger::info('Parent author is no Diaspora contact. A signature will not be created.', ['uri-id' => $item['uri-id'], 'guid' => $item['guid']]);
-			return false;
-		}
-
-		if (($parent_post['gravity'] == GRAVITY_COMMENT) && empty($parent_post['signed_text'])) {
-			Logger::info('Parent comment has got no Diaspora signature. A signature will not be created.', ['uri-id' => $item['uri-id'], 'guid' => $item['guid']]);
+		if (!self::parentSupportDiaspora($item['thr-parent-id'])) {
+			Logger::info('One of the parents does not support. A signature will not be created.', ['uri-id' => $item['uri-id'], 'guid' => $item['guid']]);
 			return false;
 		}
 
@@ -4152,6 +4146,37 @@ class Diaspora
 		$message['author_signature'] = self::signature($owner, $message);
 
 		return $message;
+	}
+
+	/**
+	 * Check if the parent and their parents support Diaspora
+	 *
+	 * @param integer $parent_id
+	 * @return boolean
+	 */
+	private static function parentSupportDiaspora(int $parent_id): bool
+	{
+		$parent_post = Post::selectFirstPost(['gravity', 'signed_text', 'author-link', 'thr-parent-id'], ['uri-id' => $parent_id]);
+		if (empty($parent_post['thr-parent-id'])) {
+			Logger::warning('Parent post does not exist.', ['parent-id' => $parent_id]);
+			return false;
+		}
+
+		if (empty(FContact::getByURL($parent_post['author-link'], false))) {
+			Logger::info('Parent author is no Diaspora contact.', ['parent-id' => $parent_id]);
+			return false;
+		}
+
+		if (($parent_post['gravity'] == GRAVITY_COMMENT) && empty($parent_post['signed_text'])) {
+			Logger::info('Parent comment has got no Diaspora signature.', ['parent-id' => $parent_id]);
+			return false;
+		}
+
+		if ($parent_post['gravity'] == GRAVITY_COMMENT) {
+			return self::parentSupportDiaspora($parent_post['thr-parent-id']);
+		}
+
+		return true;
 	}
 
 	public static function performReshare(int $UriId, int $uid): int

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -191,6 +191,10 @@ class Notifier
 			// when the original comment author does support the Diaspora protocol.
 			if ($thr_parent['author-link'] && $target_item['parent-uri'] != $target_item['thr-parent']) {
 				$diaspora_delivery = Diaspora::isSupportedByContactUrl($thr_parent['author-link']);
+				if ($diaspora_delivery &&  empty($target_item['signed_text'])) {
+					Logger::debug('Post has got no Diaspora signature, so there will be no Diaspora delivery', ['guid' => $target_item['guid'], 'uri-id' => $target_item['uri-id']]);
+					$diaspora_delivery = false;
+				}
 				Logger::info('Threaded comment', ['diaspora_delivery' => (int)$diaspora_delivery]);
 			}
 


### PR DESCRIPTION
Fixes #11952

With this PR we only create Diaspora signatures if the comment's parent is a contact that "speaks" Diaspora and if we received a Diaspora signature when we comment on a comment.