### PR TITLE
Improve quote share ("message_id" added)

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -621,6 +621,7 @@ function item_post(App $a) {
 		$datarray["author-uri-id"] = ItemURI::getIdByURI($datarray["author-link"]);
 		$datarray["owner-updated"] = '';
 		$datarray["has-media"] = false;
+		$datarray['body'] = Item::improveSharedDataInBody($datarray);
 
 		$o = DI::conversation()->create([array_merge($contact_record, $datarray)], 'search', false, true);
 
@@ -661,6 +662,7 @@ function item_post(App $a) {
 	}
 
 	$datarray['uri-id'] = ItemURI::getIdByURI($datarray['uri']);
+	$datarray['body']   = Item::improveSharedDataInBody($datarray);
 
 	if ($orig_post)	{
 		$fields = [

--- a/mod/item.php
+++ b/mod/item.php
@@ -401,7 +401,7 @@ function item_post(App $a) {
 		$body              = $item['body'];
 		$inform            = $item['inform'];
 		$postopts          = $item['postopts'];
-		$private           = $item['private']; 
+		$private           = $item['private'];
 		$str_contact_allow = $item['allow_cid'];
 		$str_group_allow   = $item['allow_gid'];
 		$str_contact_deny  = $item['deny_cid'];

--- a/mod/share.php
+++ b/mod/share.php
@@ -44,7 +44,7 @@ function share_init(App $a) {
 		$pos = strpos($item['body'], "[share");
 		$o = substr($item['body'], $pos);
 	} else {
-		$o = "[share message_id='" . $item['uri'] . "'][/share]";
+		$o = "[share]" . $item['uri'] . "[/share]";
 	}
 
 	echo $o;

--- a/mod/share.php
+++ b/mod/share.php
@@ -20,7 +20,6 @@
  */
 
 use Friendica\App;
-use Friendica\Content\Text\BBCode;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
@@ -34,8 +33,7 @@ function share_init(App $a) {
 		System::exit();
 	}
 
-	$fields = ['private', 'body', 'author-name', 'author-link', 'author-avatar',
-		'guid', 'created', 'plink', 'title'];
+	$fields = ['private', 'body', 'uri'];
 	$item = Post::selectFirst($fields, ['id' => $post_id]);
 
 	if (!DBA::isResult($item) || $item['private'] == Item::PRIVATE) {
@@ -46,14 +44,7 @@ function share_init(App $a) {
 		$pos = strpos($item['body'], "[share");
 		$o = substr($item['body'], $pos);
 	} else {
-		$o = BBCode::getShareOpeningTag($item['author-name'], $item['author-link'], $item['author-avatar'], $item['plink'], $item['created'], $item['guid']);
-
-		if ($item['title']) {
-			$o .= '[h3]'.$item['title'].'[/h3]'."\n";
-		}
-
-		$o .= $item['body'];
-		$o .= "[/share]";
+		$o = "[share message_id='" . $item['uri'] . "'][/share]";
 	}
 
 	echo $o;

--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -339,7 +339,7 @@ class Router
 			if ($this->dice_profiler_threshold > 0) {
 				$dur = floatval(microtime(true) - $stamp);
 				if ($dur >= $this->dice_profiler_threshold) {
-					$this->logger->warning('Dice module creation lasts too long.', ['duration' => round($dur, 3), 'module' => $module_class, 'parameters' => $module_parameters]);
+					$this->logger->notice('Dice module creation lasts too long.', ['duration' => round($dur, 3), 'module' => $module_class, 'parameters' => $module_parameters]);
 				}
 			}
 		}

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1029,7 +1029,7 @@ class BBCode
 				'link'       => '',
 				'posted'     => '',
 				'guid'       => '',
-				'message_id' => $matches[2],
+				'message_id' => trim($matches[2]),
 				'comment'    => trim($matches[1]),
 				'shared'     => '',
 			];

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1021,7 +1021,7 @@ class BBCode
 	public static function fetchShareAttributes(string $text): array
 	{
 		DI::profiler()->startRecording('rendering');
-		if (preg_match('#(.*?)\[share](.*)\[/share]#', $text, $matches)) {
+		if (preg_match('~(.*?)\[share](.*)\[/share]~ism', $text, $matches)) {
 			return [
 				'author'     => '',
 				'profile'    => '',

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1021,6 +1021,19 @@ class BBCode
 	public static function fetchShareAttributes(string $text): array
 	{
 		DI::profiler()->startRecording('rendering');
+		if (preg_match('#(.*?)\[share](.*)\[/share]#', $text, $matches)) {
+			return [
+				'author'     => '',
+				'profile'    => '',
+				'avatar'     => '',
+				'link'       => '',
+				'posted'     => '',
+				'guid'       => '',
+				'message_id' => $matches[2],
+				'comment'    => trim($matches[1]),
+				'shared'     => '',
+			];
+		}
 		// See Issue https://github.com/friendica/friendica/issues/10454
 		// Hashtags in usernames are expanded to links. This here is a quick fix.
 		$text = preg_replace('~([@!#])\[url=.*?](.*?)\[/url]~ism', '$1$2', $text);

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -294,7 +294,7 @@ class BBCode
 		// Simplify image codes
 		$post['text'] = preg_replace("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/ism", '[img]$3[/img]', $post['text']);
 		$post['text'] = preg_replace("/\[img\=(.*?)\](.*?)\[\/img\]/ism", '[img]$1[/img]', $post['text']);
-		
+
 		// if nothing is found, it maybe having an image.
 		if (!isset($post['type'])) {
 			if (preg_match_all("#\[url=([^\]]+?)\]\s*\[img\]([^\[]+?)\[/img\]\s*\[/url\]#ism", $post['text'], $pictures, PREG_SET_ORDER)) {

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1047,7 +1047,7 @@ class BBCode
 	private static function extractShareAttributes(string $shareString): array
 	{
 		$attributes = [];
-		foreach (['author', 'profile', 'avatar', 'link', 'posted', 'guid'] as $field) {
+		foreach (['author', 'profile', 'avatar', 'link', 'posted', 'guid', 'message_id'] as $field) {
 			preg_match("/$field=(['\"])(.+?)\\1/ism", $shareString, $matches);
 			$attributes[$field] = html_entity_decode($matches[2] ?? '', ENT_QUOTES, 'UTF-8');
 		}
@@ -2458,10 +2458,11 @@ class BBCode
 	 * @param string      $link    Post source URL
 	 * @param string      $posted  Post created date
 	 * @param string|null $guid    Post guid (if any)
+	 * @param string|null $uri     Post uri (if any)
 	 * @return string
 	 * @TODO Rewrite to handle over whole record array
 	 */
-	public static function getShareOpeningTag(string $author, string $profile, string $avatar, string $link, string $posted, string $guid = null): string
+	public static function getShareOpeningTag(string $author, string $profile, string $avatar, string $link, string $posted, string $guid = null, string $uri = null): string
 	{
 		DI::profiler()->startRecording('rendering');
 		$header = "[share author='" . str_replace(["'", "[", "]"], ["&#x27;", "&#x5B;", "&#x5D;"], $author) .
@@ -2472,6 +2473,10 @@ class BBCode
 
 		if ($guid) {
 			$header .= "' guid='" . str_replace(["'", "[", "]"], ["&#x27;", "&#x5B;", "&#x5D;"], $guid);
+		}
+
+		if ($uri) {
+			$header .= "' message_id='" . str_replace(["'", "[", "]"], ["&#x27;", "&#x5B;", "&#x5D;"], $uri);
 		}
 
 		$header  .= "']";

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3667,22 +3667,22 @@ class Item
 	public static function improveSharedDataInBody(array $item): string
 	{
 		$shared = BBCode::fetchShareAttributes($item['body']);
-		if (empty($shared['link'])) {
+		if (empty($shared['link']) && empty($shared['message_id'])) {
 			return $item['body'];
 		}
 
-		$id = self::fetchByLink($shared['link']);
-		Logger::info('Fetched shared post', ['uri-id' => $item['uri-id'], 'id' => $id, 'author' => $shared['profile'], 'url' => $shared['link'], 'guid' => $shared['guid'], 'callstack' => System::callstack()]);
+		$id = self::fetchByLink($shared['link'] ?: $shared['message_id']);
+		Logger::debug('Fetched shared post', ['uri-id' => $item['uri-id'], 'id' => $id, 'author' => $shared['profile'], 'url' => $shared['link'], 'guid' => $shared['guid'], 'uri' => $shared['message_id'], 'callstack' => System::callstack()]);
 		if (!$id) {
 			return $item['body'];
 		}
 
-		$shared_item = Post::selectFirst(['author-name', 'author-link', 'author-avatar', 'plink', 'created', 'guid', 'title', 'body'], ['id' => $id]);
+		$shared_item = Post::selectFirst(['author-name', 'author-link', 'author-avatar', 'plink', 'created', 'guid', 'uri', 'title', 'body'], ['id' => $id]);
 		if (!DBA::isResult($shared_item)) {
 			return $item['body'];
 		}
 
-		$shared_content = BBCode::getShareOpeningTag($shared_item['author-name'], $shared_item['author-link'], $shared_item['author-avatar'], $shared_item['plink'], $shared_item['created'], $shared_item['guid']);
+		$shared_content = BBCode::getShareOpeningTag($shared_item['author-name'], $shared_item['author-link'], $shared_item['author-avatar'], $shared_item['plink'], $shared_item['created'], $shared_item['guid'], $shared_item['uri']);
 
 		if (!empty($shared_item['title'])) {
 			$shared_content .= '[h3]'.$shared_item['title'].'[/h3]'."\n";
@@ -3691,7 +3691,7 @@ class Item
 		$shared_content .= $shared_item['body'];
 
 		$item['body'] = preg_replace("/\[share.*?\](.*)\[\/share\]/ism", $shared_content . '[/share]', $item['body']);
-		Logger::info('New shared data', ['uri-id' => $item['uri-id'], 'id' => $id, 'shared_item' => $shared_item]);
+		Logger::debug('New shared data', ['uri-id' => $item['uri-id'], 'id' => $id, 'shared_item' => $shared_item]);
 		return $item['body'];
 	}
 }

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3666,9 +3666,18 @@ class Item
 	 */
 	public static function improveSharedDataInBody(array $item): string
 	{
-		$shared = BBCode::fetchShareAttributes($item['body']);
-		if (empty($shared['link']) && empty($shared['message_id'])) {
-			return $item['body'];
+		if (preg_match('#\[share](.*)\[/share]#', $item['body'], $matches)) {
+			$shared = [
+				'message_id' => $matches[1],
+				'link'       => '',
+				'guid'       => '',
+				'profile'    => '',
+			];
+		} else {
+			$shared = BBCode::fetchShareAttributes($item['body']);
+			if (empty($shared['link']) && empty($shared['message_id'])) {
+				return $item['body'];
+			}	
 		}
 
 		$id = self::fetchByLink($shared['link'] ?: $shared['message_id']);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3666,19 +3666,10 @@ class Item
 	 */
 	public static function improveSharedDataInBody(array $item): string
 	{
-		if (preg_match('#\[share](.*)\[/share]#', $item['body'], $matches)) {
-			$shared = [
-				'message_id' => $matches[1],
-				'link'       => '',
-				'guid'       => '',
-				'profile'    => '',
-			];
-		} else {
-			$shared = BBCode::fetchShareAttributes($item['body']);
-			if (empty($shared['link']) && empty($shared['message_id'])) {
-				return $item['body'];
-			}	
-		}
+		$shared = BBCode::fetchShareAttributes($item['body']);
+		if (empty($shared['link']) && empty($shared['message_id'])) {
+			return $item['body'];
+		}	
 
 		$id = self::fetchByLink($shared['link'] ?: $shared['message_id']);
 		Logger::debug('Fetched shared post', ['uri-id' => $item['uri-id'], 'id' => $id, 'author' => $shared['profile'], 'url' => $shared['link'], 'guid' => $shared['guid'], 'uri' => $shared['message_id'], 'callstack' => System::callstack()]);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1930,7 +1930,7 @@ class Item
 	{
 		$latin = '';
 		$non_latin = '';
-		for ($i = 0; $i < mb_strlen($body); $i++) { 
+		for ($i = 0; $i < mb_strlen($body); $i++) {
 			$character = mb_substr($body, $i, 1);
 			$ord = mb_ord($character);
 
@@ -3669,7 +3669,7 @@ class Item
 		$shared = BBCode::fetchShareAttributes($item['body']);
 		if (empty($shared['link']) && empty($shared['message_id'])) {
 			return $item['body'];
-		}	
+		}
 
 		$id = self::fetchByLink($shared['link'] ?: $shared['message_id']);
 		Logger::debug('Fetched shared post', ['uri-id' => $item['uri-id'], 'id' => $id, 'author' => $shared['profile'], 'url' => $shared['link'], 'guid' => $shared['guid'], 'uri' => $shared['message_id'], 'callstack' => System::callstack()]);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -883,7 +883,7 @@ class Processor
 			return '';
 		}
 
-		$shared_item = Post::selectFirst(['author-name', 'author-link', 'author-avatar', 'plink', 'created', 'guid', 'title', 'body'], ['id' => $id]);
+		$shared_item = Post::selectFirst(['author-name', 'author-link', 'author-avatar', 'plink', 'created', 'guid', 'uri', 'title', 'body'], ['id' => $id]);
 		if (!DBA::isResult($shared_item)) {
 			return '';
 		}
@@ -894,7 +894,8 @@ class Processor
 			$shared_item['author-avatar'],
 			$shared_item['plink'],
 			$shared_item['created'],
-			$shared_item['guid']
+			$shared_item['guid'],
+			$shared_item['uri'],
 		);
 
 		if (!empty($shared_item['title'])) {

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2483,7 +2483,8 @@ class Diaspora
 			$original_item['author-avatar'],
 			$original_item['plink'],
 			$original_item['created'],
-			$original_item['guid']
+			$original_item['guid'],
+			$original_item['uri'],
 		);
 
 		if (!empty($original_item['title'])) {
@@ -4181,7 +4182,7 @@ class Diaspora
 
 	public static function performReshare(int $UriId, int $uid): int
 	{
-		$fields = ['uri-id', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink'];
+		$fields = ['uri-id', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'uri'];
 		$item = Post::selectFirst($fields, ['uri-id' => $UriId, 'uid' => [$uid, 0], 'private' => [Item::PUBLIC, Item::UNLISTED]]);
 		if (!DBA::isResult($item)) {
 			return 0;
@@ -4191,7 +4192,7 @@ class Diaspora
 			$pos = strpos($item['body'], '[share');
 			$post = substr($item['body'], $pos);
 		} else {
-			$post = BBCode::getShareOpeningTag($item['author-name'], $item['author-link'], $item['author-avatar'], $item['plink'], $item['created'], $item['guid']);
+			$post = BBCode::getShareOpeningTag($item['author-name'], $item['author-link'], $item['author-avatar'], $item['plink'], $item['created'], $item['guid'], $item['uri']);
 
 			if (!empty($item['title'])) {
 				$post .= '[h3]' . $item['title'] . "[/h3]\n";

--- a/src/Protocol/Email.php
+++ b/src/Protocol/Email.php
@@ -51,12 +51,12 @@ class Email
 
 		$errors = imap_errors();
 		if (!empty($errors)) {
-			Logger::warning('IMAP Errors occured', ['errors' => $errors]);
+			Logger::notice('IMAP Errors occured', ['errors' => $errors]);
 		}
 
 		$alerts = imap_alerts();
 		if (!empty($alerts)) {
-			Logger::warning('IMAP Alerts occured: ', ['alerts' => $alerts]);
+			Logger::notice('IMAP Alerts occured: ', ['alerts' => $alerts]);
 		}
 
 		return $mbox;

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -501,14 +501,12 @@ Karl Marx - Die ursprüngliche Akkumulation
 					'link' => '',
 					'posted' => '',
 					'guid' => '',
-					'message_id' => '',
+					'message_id' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'comment' => 'comment',
-					'shared' => 'shared',
+					'shared' => '',
 				],
 				'text' => ' comment
-				[share]
-				shared
-				[/share]',
+				[share]https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243[/share]',
 			],
 			'all-attributes' => [
 				'expected' => [

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -487,6 +487,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 				    'link' => '',
 				    'posted' => '',
 				    'guid' => '',
+				    'message_id' => '',
 				    'comment' => '',
 				    'shared' => '',
 				],
@@ -500,6 +501,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 					'link' => '',
 					'posted' => '',
 					'guid' => '',
+				    'message_id' => '',
 					'comment' => 'comment',
 					'shared' => 'shared',
 				],
@@ -516,6 +518,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 					'link' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'posted' => '2022-06-16 12:34:10',
 					'guid' => '735a2029-1062-ab23-42e4-f9c631220243',
+				    'message_id' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'comment' => '',
 					'shared' => 'George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?
@@ -528,6 +531,7 @@ Lucas: For the right price, yes.',
 				    link='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
 				    posted='2022-06-16 12:34:10'
 				    guid='735a2029-1062-ab23-42e4-f9c631220243'
+				    message_id='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
 			    ]George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?
 Lucas: For the right price, yes.[/share]",
@@ -540,6 +544,7 @@ Lucas: For the right price, yes.[/share]",
 					'link' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'posted' => '2022-06-16 12:34:10',
 					'guid' => '',
+				    'message_id' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'comment' => '',
 					'shared' => 'George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?
@@ -551,6 +556,7 @@ Lucas: For the right price, yes.',
 				    avatar='https://friendica.mrpetovan.com/photo/20682437145daa4e85f019a278584494-5.png'
 				    link='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
 				    posted='2022-06-16 12:34:10'
+				    message_id='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
 			    ]George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?
 Lucas: For the right price, yes.[/share]",
@@ -563,6 +569,7 @@ Lucas: For the right price, yes.[/share]",
 					'link' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'posted' => '2022-06-16 12:34:10',
 					'guid' => '',
+				    'message_id' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'comment' => '',
 					'shared' => 'George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?
@@ -573,6 +580,7 @@ Lucas: For the right price, yes.',
 				    profile="https://friendica.mrpetovan.com/profile/hypolite"
 				    avatar="https://friendica.mrpetovan.com/photo/20682437145daa4e85f019a278584494-5.png"
 				    link="https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243"
+				    message_id="https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243"
 				    posted="2022-06-16 12:34:10"
 			    ]George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -482,14 +482,14 @@ Karl Marx - Die ursprüngliche Akkumulation
 			'empty-tag' => [
 				'expected' => [
 					'author' => '',
-				    'profile' => '',
-				    'avatar' => '',
-				    'link' => '',
-				    'posted' => '',
-				    'guid' => '',
-				    'message_id' => '',
-				    'comment' => '',
-				    'shared' => '',
+					'profile' => '',
+					'avatar' => '',
+					'link' => '',
+					'posted' => '',
+					'guid' => '',
+					'message_id' => '',
+					'comment' => '',
+					'shared' => '',
 				],
 				'text' => '[share][/share]',
 			],
@@ -501,7 +501,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 					'link' => '',
 					'posted' => '',
 					'guid' => '',
-				    'message_id' => '',
+					'message_id' => '',
 					'comment' => 'comment',
 					'shared' => 'shared',
 				],
@@ -518,21 +518,21 @@ Karl Marx - Die ursprüngliche Akkumulation
 					'link' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'posted' => '2022-06-16 12:34:10',
 					'guid' => '735a2029-1062-ab23-42e4-f9c631220243',
-				    'message_id' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
+					'message_id' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'comment' => '',
 					'shared' => 'George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?
 Lucas: For the right price, yes.',
 				],
 				'text' => "[share
-				    author='Hypolite Petovan'
-				    profile='https://friendica.mrpetovan.com/profile/hypolite'
-				    avatar='https://friendica.mrpetovan.com/photo/20682437145daa4e85f019a278584494-5.png'
-				    link='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
-				    posted='2022-06-16 12:34:10'
-				    guid='735a2029-1062-ab23-42e4-f9c631220243'
-				    message_id='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
-			    ]George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
+					author='Hypolite Petovan'
+					profile='https://friendica.mrpetovan.com/profile/hypolite'
+					avatar='https://friendica.mrpetovan.com/photo/20682437145daa4e85f019a278584494-5.png'
+					link='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
+					posted='2022-06-16 12:34:10'
+					guid='735a2029-1062-ab23-42e4-f9c631220243'
+					message_id='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
+				]George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?
 Lucas: For the right price, yes.[/share]",
 			],
@@ -544,20 +544,20 @@ Lucas: For the right price, yes.[/share]",
 					'link' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'posted' => '2022-06-16 12:34:10',
 					'guid' => '',
-				    'message_id' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
+					'message_id' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'comment' => '',
 					'shared' => 'George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?
 Lucas: For the right price, yes.',
 				],
 				'text' => "[share
-				    author='Hypolite Petovan'
-				    profile='https://friendica.mrpetovan.com/profile/hypolite'
-				    avatar='https://friendica.mrpetovan.com/photo/20682437145daa4e85f019a278584494-5.png'
-				    link='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
-				    posted='2022-06-16 12:34:10'
-				    message_id='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
-			    ]George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
+					author='Hypolite Petovan'
+					profile='https://friendica.mrpetovan.com/profile/hypolite'
+					avatar='https://friendica.mrpetovan.com/photo/20682437145daa4e85f019a278584494-5.png'
+					link='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
+					posted='2022-06-16 12:34:10'
+					message_id='https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243'
+				]George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?
 Lucas: For the right price, yes.[/share]",
 			],
@@ -569,20 +569,20 @@ Lucas: For the right price, yes.[/share]",
 					'link' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'posted' => '2022-06-16 12:34:10',
 					'guid' => '',
-				    'message_id' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
+					'message_id' => 'https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243',
 					'comment' => '',
 					'shared' => 'George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?
 Lucas: For the right price, yes.',
 				],
 				'text' => '[share
-				    author="Hypolite Petovan"
-				    profile="https://friendica.mrpetovan.com/profile/hypolite"
-				    avatar="https://friendica.mrpetovan.com/photo/20682437145daa4e85f019a278584494-5.png"
-				    link="https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243"
-				    message_id="https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243"
-				    posted="2022-06-16 12:34:10"
-			    ]George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
+					author="Hypolite Petovan"
+					profile="https://friendica.mrpetovan.com/profile/hypolite"
+					avatar="https://friendica.mrpetovan.com/photo/20682437145daa4e85f019a278584494-5.png"
+					link="https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243"
+					message_id="https://friendica.mrpetovan.com/display/735a2029-1062-ab23-42e4-f9c631220243"
+					posted="2022-06-16 12:34:10"
+				]George Lucas: I made a science-fiction universe with a straightforward anti-authoritarianism plot where even the libertarian joins the rebellion.
 Disney: So a morally grey “choose your side” story, right?
 Lucas: For the right price, yes.[/share]',
 			],

--- a/view/js/autocomplete.js
+++ b/view/js/autocomplete.js
@@ -366,7 +366,7 @@ function string2bb(element) {
 
 	$.fn.bbco_autocomplete = function(type) {
 		if (type === 'bbcode') {
-			var open_close_elements = ['bold', 'italic', 'underline', 'overline', 'strike', 'quote', 'code', 'spoiler', 'map', 'img', 'url', 'audio', 'video', 'embed', 'youtube', 'vimeo', 'list', 'ul', 'ol', 'li', 'table', 'tr', 'th', 'td', 'center', 'color', 'font', 'size', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'nobb', 'noparse', 'pre', 'abstract'];
+			var open_close_elements = ['bold', 'italic', 'underline', 'overline', 'strike', 'quote', 'code', 'spoiler', 'map', 'img', 'url', 'audio', 'video', 'embed', 'youtube', 'vimeo', 'list', 'ul', 'ol', 'li', 'table', 'tr', 'th', 'td', 'center', 'color', 'font', 'size', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'nobb', 'noparse', 'pre', 'abstract', 'share'];
 			var open_elements = ['*', 'hr'];
 
 			var elements = open_close_elements.concat(open_elements);


### PR DESCRIPTION
The attribute "message_id" has been added for the "share" element. That attribute is also used by Hubzilla, so we will use it now as well.

Also the sharing experience has been improved. Instad of showing a confusingly chunk of BBCode with the "share" element we now display a very reduced form:
![image](https://user-images.githubusercontent.com/844208/194425568-6285b842-3656-484d-815b-34d6789e8ff1.png)

Previously it looked that way:
![image](https://user-images.githubusercontent.com/844208/194425632-dd881fc9-ced5-47f5-aae6-0cbe2b8ee98c.png)
