### PR TITLE
Issue 11969: Simplified share

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1009,14 +1009,15 @@ class BBCode
 	/**
 	 * @param string $text A BBCode string
 	 * @return array Empty array if no share tag is present or the following array, missing attributes end up empty strings:
-	 *               - comment: Text before the opening share tag
-	 *               - shared : Text inside the share tags
-	 *               - author : (Optional) Display name of the shared author
-	 *               - profile: (Optional) Profile page URL of the shared author
-	 *               - avatar : (Optional) Profile picture URL of the shared author
-	 *               - link   : (Optional) Canonical URL of the shared post
-	 *               - posted : (Optional) Date the shared post was initially posted ("Y-m-d H:i:s" in GMT)
-	 *               - guid   : (Optional) Shared post GUID if any
+	 *               - comment   : Text before the opening share tag
+	 *               - shared    : Text inside the share tags
+	 *               - author    : (Optional) Display name of the shared author
+	 *               - profile   : (Optional) Profile page URL of the shared author
+	 *               - avatar    : (Optional) Profile picture URL of the shared author
+	 *               - link      : (Optional) Canonical URL of the shared post
+	 *               - posted    : (Optional) Date the shared post was initially posted ("Y-m-d H:i:s" in GMT)
+	 *               - message_id: (Optional) Shared post URI if any
+	 *               - guid      : (Optional) Shared post GUID if any
 	 */
 	public static function fetchShareAttributes(string $text): array
 	{

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3671,7 +3671,15 @@ class Item
 			return $item['body'];
 		}
 
-		$id = self::fetchByLink($shared['link'] ?: $shared['message_id']);
+		$link = $shared['link'] ?: $shared['message_id'];
+
+		if (!empty($item['uid'])) {
+			$id = self::searchByLink($link, $item['uid']);
+		}
+
+		if (empty($id)) {
+			$id = self::fetchByLink($link);
+		}
 		Logger::debug('Fetched shared post', ['uri-id' => $item['uri-id'], 'id' => $id, 'author' => $shared['profile'], 'url' => $shared['link'], 'guid' => $shared['guid'], 'uri' => $shared['message_id'], 'callstack' => System::callstack()]);
 		if (!$id) {
 			return $item['body'];


### PR DESCRIPTION
This PR improves the quick fix for #11969. The problem occurred since on connector posts we only have got posts that are assigned to users.

Also resharing a reshared Diaspora hadn't improved. This is now done as well.

Important: When testing, I saw that when we reshare a reshared message with a quote, then we only reshare the reshared part, not the quote. This behavior hasn't changed with this PR. But we should at how to improve this behavior in the following version.