### PR TITLE
Issue 11975: Don't call the postupdate if the table is missing

### DIFF
--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -1040,6 +1040,11 @@ class PostUpdate
 			return true;
 		}
 
+		if (!DBStructure::existsTable('conversation')) {
+			DI::config()->set('system', 'post_update_version', 1452);
+			return true;
+		}
+
 		$id = DI::config()->get('system', 'post_update_version_1452_id', 0);
 
 		Logger::info('Start', ['uri-id' => $id]);


### PR DESCRIPTION
Fixes #11975