### PR TITLE
Return the pageinfo when feed is shared

### DIFF
--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -656,7 +656,9 @@ class Item
 	 */
 	public function createSharedBlockByArray(array $item): string
 	{
-		if (!in_array($item['network'] ?? '', Protocol::FEDERATED)) {
+		if ($item['network'] == Protocol::FEED) {
+			return PageInfo::getFooterFromUrl($item['plink']);
+		} elseif (!in_array($item['network'] ?? '', Protocol::FEDERATED)) {
 			$item['guid'] = '';
 			$item['uri']  = '';
 			$item['body'] = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
@@ -675,7 +677,7 @@ class Item
 			if (!empty($shared['guid']) && ($encaspulated_share = self::createSharedPostByGuid($shared['guid']))) {
 				$item['body'] = preg_replace("/\[share.*?\](.*)\[\/share\]/ism", $encaspulated_share, $item['body']);
 			}
-	
+
 			$item['body'] = HTML::toBBCode(BBCode::convertForUriId($item['uri-id'], $item['body'], BBCode::ACTIVITYPUB));
 		}
 


### PR DESCRIPTION
See here: https://libranet.de/display/0b6b25a8-6763-4836-6733-ca1825561470

A shared feed item doesn't look great, especially on non-friendica systems. Since the main purpose of a feed is to share links, we now treat a shared feed item like a shared link.