### PR TITLE
Fixed: "Argument 1 passed to Friendica\Util\Temporal::getRelativeDate() must be of the type string, null given"

### DIFF
--- a/src/Security/TwoFactor/Model/AppSpecificPassword.php
+++ b/src/Security/TwoFactor/Model/AppSpecificPassword.php
@@ -86,7 +86,7 @@ class AppSpecificPassword
 		$appSpecificPasswords = DBA::toArray($appSpecificPasswordsStmt);
 
 		array_walk($appSpecificPasswords, function (&$value) {
-			$value['ago']   = Temporal::getRelativeDate($value['last_used'] ?? '');
+			$value['ago']   = Temporal::getRelativeDate($value['last_used']);
 			$value['utc']   = $value['last_used'] ? DateTimeFormat::utc($value['last_used'], 'c') : '';
 			$value['local'] = $value['last_used'] ? DateTimeFormat::local($value['last_used'], 'r') : '';
 		});

--- a/src/Security/TwoFactor/Model/AppSpecificPassword.php
+++ b/src/Security/TwoFactor/Model/AppSpecificPassword.php
@@ -86,7 +86,7 @@ class AppSpecificPassword
 		$appSpecificPasswords = DBA::toArray($appSpecificPasswordsStmt);
 
 		array_walk($appSpecificPasswords, function (&$value) {
-			$value['ago']   = Temporal::getRelativeDate($value['last_used']);
+			$value['ago']   = Temporal::getRelativeDate($value['last_used'] ?? '');
 			$value['utc']   = $value['last_used'] ? DateTimeFormat::utc($value['last_used'], 'c') : '';
 			$value['local'] = $value['last_used'] ? DateTimeFormat::local($value['last_used'], 'r') : '';
 		});

--- a/src/Util/Temporal.php
+++ b/src/Util/Temporal.php
@@ -311,7 +311,7 @@ class Temporal
 	 *
 	 * @return string with relative date
 	 */
-	public static function getRelativeDate(string $posted_date, string $format = null): string
+	public static function getRelativeDate(string $posted_date = null, string $format = null): string
 	{
 		$localtime = $posted_date . ' UTC';
 

--- a/src/Util/Temporal.php
+++ b/src/Util/Temporal.php
@@ -311,13 +311,13 @@ class Temporal
 	 *
 	 * @return string with relative date
 	 */
-	public static function getRelativeDate(string $posted_date = null, string $format = null): string
+	public static function getRelativeDate(string $posted_date, string $format = null): string
 	{
 		$localtime = $posted_date . ' UTC';
 
 		$abs = strtotime($localtime);
 
-		if (is_null($posted_date) || $posted_date <= DBA::NULL_DATETIME || $abs === false) {
+		if (empty($posted_date) || $posted_date <= DBA::NULL_DATETIME || $abs === false) {
 			return DI::l10n()->t('never');
 		}
 

--- a/src/Util/Temporal.php
+++ b/src/Util/Temporal.php
@@ -311,13 +311,16 @@ class Temporal
 	 *
 	 * @return string with relative date
 	 */
-	public static function getRelativeDate(string $posted_date, string $format = null): string
+	public static function getRelativeDate(string $posted_date = null, string $format = null): string
 	{
-		$localtime = $posted_date . ' UTC';
+		if (empty($posted_date) || $posted_date <= DBA::NULL_DATETIME) {
+			return DI::l10n()->t('never');
+		}
 
+		$localtime = $posted_date . ' UTC';
 		$abs = strtotime($localtime);
 
-		if (empty($posted_date) || $posted_date <= DBA::NULL_DATETIME || $abs === false) {
+		if ($abs === false) {
 			return DI::l10n()->t('never');
 		}
 


### PR DESCRIPTION
This is a rebased change on current `develop` code. The original ticket was #11900 .