### PR TITLE
Improve quote generation

### DIFF
--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -574,9 +574,10 @@ class Item
 	 *
 	 * @param string $url
 	 * @param integer $uid
+	 * @param bool $add_media
 	 * @return string
 	 */
-	public function createSharedPostByUrl(string $url, int $uid = 0): string
+	public function createSharedPostByUrl(string $url, int $uid = 0, bool $add_media = false): string
 	{
 		if (!empty($uid)) {
 			$id = ModelItem::searchByLink($url, $uid);
@@ -599,7 +600,7 @@ class Item
 			return '';
 		}
 
-		return $this->createSharedBlockByArray($shared_item);
+		return $this->createSharedBlockByArray($shared_item, $add_media);
 	}
 
 	/**
@@ -652,15 +653,18 @@ class Item
 	 * Add a share block for the given item array
 	 *
 	 * @param array $item
+	 * @param bool $add_media
 	 * @return string
 	 */
-	public function createSharedBlockByArray(array $item): string
+	public function createSharedBlockByArray(array $item, bool $add_media = false): string
 	{
 		if ($item['network'] == Protocol::FEED) {
 			return PageInfo::getFooterFromUrl($item['plink']);
 		} elseif (!in_array($item['network'] ?? '', Protocol::FEDERATED)) {
 			$item['guid'] = '';
 			$item['uri']  = '';
+			$item['body'] = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
+		} elseif ($add_media) {
 			$item['body'] = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
 		}
 

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1086,6 +1086,22 @@ class BBCode
 	}
 
 	/**
+	 * Remove the share block
+	 *
+	 * @param string $body
+	 * @return string
+	 */
+	public static function removeSharedData(string $body): string
+	{
+		return BBCode::convertShare(
+			$body,
+			function (array $attributes) {
+				return '';
+			}
+		);
+	}
+
+	/**
 	 * This function converts a [share] block to text according to a provided callback function whose signature is:
 	 *
 	 * function(array $attributes, array $author_contact, string $content, boolean $is_quote_share): string
@@ -1134,7 +1150,7 @@ class BBCode
 		);
 
 		DI::profiler()->stopRecording();
-		return $return;
+		return trim($return);
 	}
 
 	/**

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1123,7 +1123,7 @@ class Item
 
 		if (!empty($quote_id) && Post::exists(['uri-id' => $quote_id, 'network' => Protocol::FEDERATED])) {
 			$item['quote-uri-id'] = $quote_id;
-			$item['raw-body'] = BBCode::replaceSharedData($item['raw-body']);
+			$item['raw-body'] = BBCode::removeSharedData($item['raw-body']);
 		}
 
 		if (!DBA::exists('contact', ['id' => $item['author-id'], 'network' => Protocol::DFRN])) {
@@ -3612,9 +3612,10 @@ class Item
 	 * Improve the data in shared posts
 	 *
 	 * @param array $item
+	 * @param bool  $add_media
 	 * @return string body
 	 */
-	public static function improveSharedDataInBody(array $item): string
+	public static function improveSharedDataInBody(array $item, bool $add_media = false): string
 	{
 		$shared = BBCode::fetchShareAttributes($item['body']);
 		if (empty($shared['guid']) && empty($shared['message_id'])) {
@@ -3624,7 +3625,7 @@ class Item
 		$link = $shared['link'] ?: $shared['message_id'];
 
 		if (empty($shared_content)) {
-			$shared_content = DI::contentItem()->createSharedPostByUrl($link, $item['uid'] ?? 0);
+			$shared_content = DI::contentItem()->createSharedPostByUrl($link, $item['uid'] ?? 0, $add_media);
 		}
 
 		if (empty($shared_content)) {


### PR DESCRIPTION
This improves my previous PR. We now completely remove the share information from the `raw-body` field and when transmitting the data we only transmit the quote-id when it is an AP post.