### PR TITLE
updates to the vagrant VM provision and config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 
-server_ip = "192.168.22.10"
+server_ip = "192.168.56.10"
 server_memory = "2048" # MB
 server_timezone = "UTC"
 

--- a/bin/dev/vagrant_provision.sh
+++ b/bin/dev/vagrant_provision.sh
@@ -51,7 +51,7 @@ service apache2 restart
 
 #Install php
 echo ">>> Installing PHP7"
-apt-get install -qq php libapache2-mod-php php-cli php-mysql php-curl php-gd php-mbstring php-xml imagemagick php-imagick php-zip
+apt-get install -qq php libapache2-mod-php php-cli php-mysql php-curl php-gd php-mbstring php-xml imagemagick php-imagick php-zip php-gmp
 systemctl restart apache2
 
 echo ">>> Installing PHP8"
@@ -59,7 +59,7 @@ apt-get install -qq -y lsb-release ca-certificates apt-transport-https software-
 echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/sury-php.list
 wget -qO - https://packages.sury.org/php/apt.gpg | sudo apt-key add -
 apt update
-apt-get install -qq php8.0 php8.0-cli php8.0-mysql php8.0-curl php8.0-gd php8.0-mbstring php8.0-xml php8.0-imagick php8.0-zip
+apt-get install -qq php8.0 php8.0-cli php8.0-mysql php8.0-curl php8.0-gd php8.0-mbstring php8.0-xml php8.0-imagick php8.0-zip php8.0-gmp
 systemctl restart apache2
 
 #Install mysql

--- a/bin/dev/vagrant_provision.sh
+++ b/bin/dev/vagrant_provision.sh
@@ -45,7 +45,7 @@ apt-get install -qq apache2
 a2enmod rewrite actions ssl
 cp /vagrant/bin/dev/vagrant_vhost.sh /usr/local/bin/vhost
 chmod guo+x /usr/local/bin/vhost
-vhost -s 192.168.22.10.xip.io -d /var/www -p /etc/ssl/xip.io -c xip.io -a friendica.local
+vhost -s 192.168.56.10.xip.io -d /var/www -p /etc/ssl/xip.io -c xip.io -a friendica.local
 a2dissite 000-default
 service apache2 restart
 

--- a/doc/Vagrant.md
+++ b/doc/Vagrant.md
@@ -10,7 +10,7 @@ Getting started
 No need to setup up a webserver, database etc. before actually starting.
 Vagrant creates a virtual machine for you that you can just run inside VirtualBox and start to work directly on Friendica.
 
-It brings an Debian Bullseye with PHP 7.4 and MariaDB 10.5.11.
+It brings an Debian Bullseye with PHP 8.0 and MariaDB 10.5.11.
 
 What you need to do:
 
@@ -24,7 +24,7 @@ This will start the virtual machine.
 Be patient: When it runs for the first time, it downloads a Debian Server image and installs Friendica.
 4. Run `vagrant ssh` to log into the virtual machine to log in to the VM in case you need to debug something on the server.
 5. Open you test installation in a browser.
-Go to friendica.local (or 192.168.22.10).
+Go to friendica.local (or 192.168.56.10).
 friendica.local is using a self-signed TLS certificate, so you will need to add an exception to trust the certificate the first time you are visiting the page.
 The mysql database is called "friendica", the mysql user and password both are "friendica".
 6. Work on Friendica's code in your git clone on your machine (not in the VM).

--- a/mods/local.config.vagrant.php
+++ b/mods/local.config.vagrant.php
@@ -29,7 +29,7 @@ return [
 	// ****************************************************************
 
 	'config' => [
-		'hostname' => 'friendica.local',
+		'hostname' => '192.168.56.10',
 		'admin_email' => 'admin@friendica.local',
 		'sitename' => 'Friendica Social Network',
 		'register_policy' => \Friendica\Module\Register::OPEN,


### PR DESCRIPTION
The virtualbox has now limitation on the IP address that can be used for the guest systems. So the VMs IP address was put into a valid range, so that it starts out of the box. Also to `friendica.local` name was not resolved for me any longer on a Debian host, so I've switched the config back to using the IP address.

And finally the PHP GMP was added to the requirements, it is now reflected in the VMs provision script.