### PR TITLE
Detect linked posts and add them as quote

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2022.12-dev (Giant Rhubarb)
--- DB_UPDATE_VERSION 1485
+-- DB_UPDATE_VERSION 1486
 -- ------------------------------------------
 
 
@@ -1292,6 +1292,7 @@ CREATE TABLE IF NOT EXISTS `post-media` (
 	`id` int unsigned NOT NULL auto_increment COMMENT 'sequential ID',
 	`uri-id` int unsigned NOT NULL COMMENT 'Id of the item-uri table entry that contains the item uri',
 	`url` varbinary(1024) NOT NULL COMMENT 'Media URL',
+	`media-uri-id` int unsigned COMMENT 'Id of the item-uri table entry that contains the activities uri-id',
 	`type` tinyint unsigned NOT NULL DEFAULT 0 COMMENT 'Media type',
 	`mimetype` varchar(60) COMMENT '',
 	`height` smallint unsigned COMMENT 'Height of the media',
@@ -1311,7 +1312,9 @@ CREATE TABLE IF NOT EXISTS `post-media` (
 	 PRIMARY KEY(`id`),
 	 UNIQUE INDEX `uri-id-url` (`uri-id`,`url`(512)),
 	 INDEX `uri-id-id` (`uri-id`,`id`),
-	FOREIGN KEY (`uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
+	 INDEX `media-uri-id` (`media-uri-id`),
+	FOREIGN KEY (`uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,
+	FOREIGN KEY (`media-uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Attached media';
 
 --

--- a/doc/database/db_post-media.md
+++ b/doc/database/db_post-media.md
@@ -6,36 +6,38 @@ Attached media
 Fields
 ------
 
-| Field           | Description                                               | Type              | Null | Key | Default | Extra          |
-| --------------- | --------------------------------------------------------- | ----------------- | ---- | --- | ------- | -------------- |
-| id              | sequential ID                                             | int unsigned      | NO   | PRI | NULL    | auto_increment |
-| uri-id          | Id of the item-uri table entry that contains the item uri | int unsigned      | NO   |     | NULL    |                |
-| url             | Media URL                                                 | varbinary(1024)   | NO   |     | NULL    |                |
-| type            | Media type                                                | tinyint unsigned  | NO   |     | 0       |                |
-| mimetype        |                                                           | varchar(60)       | YES  |     | NULL    |                |
-| height          | Height of the media                                       | smallint unsigned | YES  |     | NULL    |                |
-| width           | Width of the media                                        | smallint unsigned | YES  |     | NULL    |                |
-| size            | Media size                                                | bigint unsigned   | YES  |     | NULL    |                |
-| preview         | Preview URL                                               | varbinary(512)    | YES  |     | NULL    |                |
-| preview-height  | Height of the preview picture                             | smallint unsigned | YES  |     | NULL    |                |
-| preview-width   | Width of the preview picture                              | smallint unsigned | YES  |     | NULL    |                |
-| description     |                                                           | text              | YES  |     | NULL    |                |
-| name            | Name of the media                                         | varchar(255)      | YES  |     | NULL    |                |
-| author-url      | URL of the author of the media                            | varbinary(383)    | YES  |     | NULL    |                |
-| author-name     | Name of the author of the media                           | varchar(255)      | YES  |     | NULL    |                |
-| author-image    | Image of the author of the media                          | varbinary(383)    | YES  |     | NULL    |                |
-| publisher-url   | URL of the publisher of the media                         | varbinary(383)    | YES  |     | NULL    |                |
-| publisher-name  | Name of the publisher of the media                        | varchar(255)      | YES  |     | NULL    |                |
-| publisher-image | Image of the publisher of the media                       | varbinary(383)    | YES  |     | NULL    |                |
+| Field           | Description                                                        | Type              | Null | Key | Default | Extra          |
+| --------------- | ------------------------------------------------------------------ | ----------------- | ---- | --- | ------- | -------------- |
+| id              | sequential ID                                                      | int unsigned      | NO   | PRI | NULL    | auto_increment |
+| uri-id          | Id of the item-uri table entry that contains the item uri          | int unsigned      | NO   |     | NULL    |                |
+| url             | Media URL                                                          | varbinary(1024)   | NO   |     | NULL    |                |
+| media-uri-id    | Id of the item-uri table entry that contains the activities uri-id | int unsigned      | YES  |     | NULL    |                |
+| type            | Media type                                                         | tinyint unsigned  | NO   |     | 0       |                |
+| mimetype        |                                                                    | varchar(60)       | YES  |     | NULL    |                |
+| height          | Height of the media                                                | smallint unsigned | YES  |     | NULL    |                |
+| width           | Width of the media                                                 | smallint unsigned | YES  |     | NULL    |                |
+| size            | Media size                                                         | bigint unsigned   | YES  |     | NULL    |                |
+| preview         | Preview URL                                                        | varbinary(512)    | YES  |     | NULL    |                |
+| preview-height  | Height of the preview picture                                      | smallint unsigned | YES  |     | NULL    |                |
+| preview-width   | Width of the preview picture                                       | smallint unsigned | YES  |     | NULL    |                |
+| description     |                                                                    | text              | YES  |     | NULL    |                |
+| name            | Name of the media                                                  | varchar(255)      | YES  |     | NULL    |                |
+| author-url      | URL of the author of the media                                     | varbinary(383)    | YES  |     | NULL    |                |
+| author-name     | Name of the author of the media                                    | varchar(255)      | YES  |     | NULL    |                |
+| author-image    | Image of the author of the media                                   | varbinary(383)    | YES  |     | NULL    |                |
+| publisher-url   | URL of the publisher of the media                                  | varbinary(383)    | YES  |     | NULL    |                |
+| publisher-name  | Name of the publisher of the media                                 | varchar(255)      | YES  |     | NULL    |                |
+| publisher-image | Image of the publisher of the media                                | varbinary(383)    | YES  |     | NULL    |                |
 
 Indexes
 ------------
 
-| Name       | Fields                   |
-| ---------- | ------------------------ |
-| PRIMARY    | id                       |
-| uri-id-url | UNIQUE, uri-id, url(512) |
-| uri-id-id  | uri-id, id               |
+| Name         | Fields                   |
+| ------------ | ------------------------ |
+| PRIMARY      | id                       |
+| uri-id-url   | UNIQUE, uri-id, url(512) |
+| uri-id-id    | uri-id, id               |
+| media-uri-id | media-uri-id             |
 
 Foreign Keys
 ------------
@@ -43,5 +45,6 @@ Foreign Keys
 | Field | Target Table | Target Field |
 |-------|--------------|--------------|
 | uri-id | [item-uri](help/database/db_item-uri) | id |
+| media-uri-id | [item-uri](help/database/db_item-uri) | id |
 
 Return to [database documentation](help/database)

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -608,9 +608,10 @@ class Item
 	 *
 	 * @param integer $UriId
 	 * @param integer $uid
+	 * @param bool $add_media
 	 * @return string
 	 */
-	public function createSharedPostByUriId(int $UriId, int $uid = 0): string
+	public function createSharedPostByUriId(int $UriId, int $uid = 0, bool $add_media = false): string
 	{
 		$fields = ['uri-id', 'uri', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'network'];
 		$shared_item = Post::selectFirst($fields, ['uri-id' => $UriId, 'uid' => [$uid, 0], 'private' => [ModelItem::PUBLIC, ModelItem::UNLISTED]]);
@@ -619,7 +620,7 @@ class Item
 			return '';
 		}
 
-		return $this->createSharedBlockByArray($shared_item);
+		return $this->createSharedBlockByArray($shared_item, $add_media);
 	}
 
 	/**
@@ -627,9 +628,10 @@ class Item
 	 *
 	 * @param string $guid
 	 * @param integer $uid
+	 * @param bool $add_media
 	 * @return string
 	 */
-	public function createSharedPostByGuid(string $guid, int $uid = 0, string $host = ''): string
+	public function createSharedPostByGuid(string $guid, int $uid = 0, string $host = '', bool $add_media = false): string
 	{
 		$fields = ['uri-id', 'uri', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'network'];
 		$shared_item = Post::selectFirst($fields, ['guid' => $guid, 'uid' => [$uid, 0], 'private' => [ModelItem::PUBLIC, ModelItem::UNLISTED]]);
@@ -646,7 +648,7 @@ class Item
 			return '';
 		}
 
-		return $this->createSharedBlockByArray($shared_item);
+		return $this->createSharedBlockByArray($shared_item, $add_media);
 	}
 
 	/**
@@ -678,7 +680,7 @@ class Item
 
 		// If it is a reshared post then reformat it to avoid display problems with two share elements
 		if (Diaspora::isReshare($item['body'], false)) {
-			if (!empty($shared['guid']) && ($encaspulated_share = self::createSharedPostByGuid($shared['guid']))) {
+			if (!empty($shared['guid']) && ($encaspulated_share = self::createSharedPostByGuid($shared['guid'], 0, '', $add_media))) {
 				$item['body'] = preg_replace("/\[share.*?\](.*)\[\/share\]/ism", $encaspulated_share, $item['body']);
 			}
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -170,7 +170,7 @@ class Processor
 	}
 
 	/**
-	 * Stire attachment data
+	 * Store attachment data
 	 *
 	 * @param array   $activity
 	 * @param array   $item
@@ -187,7 +187,7 @@ class Processor
 	}
 
 	/**
-	 * Store attachment data
+	 * Store question data
 	 *
 	 * @param array   $activity
 	 * @param array   $item

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1674,13 +1674,8 @@ class Transmitter
 				}
 				$data['quoteUrl'] = $item['quote-uri'];
 			} elseif (!empty($item['quote-uri']) && !Diaspora::isReshare($body, false)) {
-				$fields = ['uri-id', 'uri', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'network'];
-				$shared_item = Post::selectFirst($fields, ['uri-id' => $item['quote-uri-id']]);
-				if (!empty($shared_item['uri-id'])) {
-					$shared_item['body'] = Post\Media::addAttachmentsToBody($shared_item['uri-id'], $shared_item['body']);
-					$body .= "\n" . DI::contentItem()->createSharedBlockByArray($shared_item);
-					$item['body'] = Item::improveSharedDataInBody($item, true);
-				}
+				$body .= "\n" . DI::contentItem()->createSharedPostByUriId($item['quote-uri-id'], $item['uid'], true);
+				$item['body'] = Item::improveSharedDataInBody($item, true);
 			}
 
 			$data['content'] = BBCode::convertForUriId($item['uri-id'], $body, BBCode::ACTIVITYPUB);

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1485);
+	define('DB_UPDATE_VERSION', 1486);
 }
 
 return [
@@ -1321,6 +1321,7 @@ return [
 			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => "sequential ID"],
 			"uri-id" => ["type" => "int unsigned", "not null" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
 			"url" => ["type" => "varbinary(1024)", "not null" => "1", "comment" => "Media URL"],
+			"media-uri-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the activities uri-id"],
 			"type" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "comment" => "Media type"],
 			"mimetype" => ["type" => "varchar(60)", "comment" => ""],
 			"height" => ["type" => "smallint unsigned", "comment" => "Height of the media"],
@@ -1342,6 +1343,7 @@ return [
 			"PRIMARY" => ["id"],
 			"uri-id-url" => ["UNIQUE", "uri-id", "url(512)"],
 			"uri-id-id" => ["uri-id", "id"],
+			"media-uri-id" => ["media-uri-id"],
 		]
 	],
 	"post-question" => [


### PR DESCRIPTION
People add links to other posts in their posts. These are now detected and displayed as quoted posts.

Before:
![Bildschirmfoto vom 2022-10-16 19-08-50](https://user-images.githubusercontent.com/844208/196059585-761400f9-8165-479c-86fe-6f329a2e5d59.png)

Now:
![Bildschirmfoto vom 2022-10-16 19-21-39](https://user-images.githubusercontent.com/844208/196059591-99794d6e-cfac-41e3-abe0-b83381092068.png)
