### PR TITLE
Suppress warning on load check

### DIFF
--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -442,7 +442,7 @@ class System
 	 */
 	public static function getLoadAvg(): array
 	{
-		if (is_readable('/proc/loadavg')) {
+		if (@is_readable('/proc/loadavg')) {
 			$content = @file_get_contents('/proc/loadavg');
 			if (empty($content)) {
 				$content = shell_exec('cat /proc/loadavg');


### PR DESCRIPTION
This PR suppresses the warning `is_readable(): open_basedir restriction in effect. File(/proc/loadavg) is not within the allowed path(s):`