### PR TITLE
added a breaking note for custom addons to the CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@ Version 2022.12 (unreleased)
   Friendica Core
 
   Friendica Addons
+    BREAKING: The functions from the boot.php file have been moved into better fitting classes
+              this may break your custom addons. See the pull requests #1293 and #1294 in the
+              addon repository about the needed changes to your addons.
 
   Closed Issues
 


### PR DESCRIPTION
With the movement of all the function from the boot.php into fitting classes custom addons will break (e.g. local_user() calls). The note in the CHANGELOG should be a warning and a reminder for the release notes of 2022.12.