### PR TITLE
Fix using wrong variable in DomainPatterBlocklist::extractFromCSVFile

### DIFF
--- a/src/Moderation/DomainPatternBlocklist.php
+++ b/src/Moderation/DomainPatternBlocklist.php
@@ -192,7 +192,7 @@ class DomainPatternBlocklist
 				'reason' => $data[1] ?? '',
 			];
 			if (!in_array($item, $blocklist)) {
-				$blocklist[] = $data;
+				$blocklist[] = $item;
 			}
 		}
 


### PR DESCRIPTION
- This was clobbering the internal block list structure from an associative array to a simple list

See https://librenet.co.za/display/f917d7dd-6763-5134-a5d5-3ff219866243

Fix https://github.com/friendica/friendica/issues/12342