### PR TITLE
Fix CI pipeline

### DIFF
--- a/.woodpecker/.continuous-deployment.yml
+++ b/.woodpecker/.continuous-deployment.yml
@@ -4,11 +4,6 @@ depends_on:
   - database_checks
   - messages.po_check
 
-# This prevents executing this pipeline at other servers than ci.friendi.ca
-labels:
-  location: friendica
-  type: releaser
-
 skip_clone: true
 
 pipeline:
@@ -23,6 +18,7 @@ pipeline:
       repo: friendica/friendica
       branch: [ develop, '*-rc' ]
       event: push
+      instance: releaser.ci.friendi.ca
   restore_cache:
     image: meltwater/drone-cache:dev
     settings:
@@ -38,6 +34,7 @@ pipeline:
       repo: friendica/friendica
       branch: [ develop, '*-rc' ]
       event: push
+      instance: releaser.ci.friendi.ca
   composer_install:
     image: friendicaci/php7.4:php7.4.18
     commands:
@@ -50,6 +47,7 @@ pipeline:
       repo: friendica/friendica
       branch: [ develop, '*-rc' ]
       event: push
+      instance: releaser.ci.friendi.ca
   create_artifacts:
     image: debian
     commands:
@@ -74,6 +72,7 @@ pipeline:
       repo: friendica/friendica
       branch: [ develop, '*-rc' ]
       event: push
+      instance: releaser.ci.friendi.ca
   sign_artifacts:
     image: plugins/gpgsign
     settings:
@@ -90,6 +89,7 @@ pipeline:
       repo: friendica/friendica
       branch: [ develop, '*-rc' ]
       event: push
+      instance: releaser.ci.friendi.ca
   publish_artifacts:
     image: alpine
     commands:
@@ -100,3 +100,4 @@ pipeline:
       repo: friendica/friendica
       branch: [ develop, '*-rc' ]
       event: push
+      instance: releaser.ci.friendi.ca

--- a/.woodpecker/.releaser.yml
+++ b/.woodpecker/.releaser.yml
@@ -2,11 +2,6 @@ depends_on:
   - phpunit
   - code_standards_check
 
-# This prevents executing this pipeline at other servers than ci.friendi.ca
-labels:
-  location: friendica
-  type: releaser
-
 skip_clone: true
 
 pipeline:
@@ -21,6 +16,7 @@ pipeline:
       repo: friendica/friendica
       branch: stable
       event: tag
+      instance: releaser.ci.friendi.ca
   restore_cache:
     image: meltwater/drone-cache:dev
     settings:
@@ -36,6 +32,7 @@ pipeline:
       repo: friendica/friendica
       branch: stable
       event: tag
+      instance: releaser.ci.friendi.ca
   composer_install:
     image: friendicaci/php7.4:php7.4.18
     commands:
@@ -46,6 +43,7 @@ pipeline:
       repo: friendica/friendica
       branch: stable
       event: tag
+      instance: releaser.ci.friendi.ca
     volumes:
       - /etc/hosts:/etc/hosts
   create_artifacts:
@@ -72,6 +70,7 @@ pipeline:
       repo: friendica/friendica
       branch: stable
       event: tag
+      instance: releaser.ci.friendi.ca
   sign_artifacts:
     image: plugins/gpgsign
     settings:
@@ -88,6 +87,7 @@ pipeline:
       repo: friendica/friendica
       branch: stable
       event: tag
+      instance: releaser.ci.friendi.ca
   publish_artifacts:
     image: alpine
     commands:
@@ -98,3 +98,4 @@ pipeline:
       repo: friendica/friendica
       branch: stable
       event: tag
+      instance: releaser.ci.friendi.ca


### PR DESCRIPTION
Currently, the pipeline randomly pushes the archive either on my server or on the Friendica server.
I believe that the `label` condition doesn't work as expected.

My new approach is using the `instance` (https://woodpecker-ci.org/docs/usage/conditional-execution#instance). The corresponding env variable https://woodpecker-ci.org/docs/administration/agent-config#woodpecker_hostname is already set.

I hope the best ...
btw. this was the issue why the archive wasn't built during the release ..