### PR TITLE
add a nofollow to the blocklist export link

### DIFF
--- a/view/templates/friendica.tpl
+++ b/view/templates/friendica.tpl
@@ -33,7 +33,7 @@
 			{{/foreach}}
 			</tbody>
 		</table>
-		<p><a href="/blocklist/domain/download"><i class="fa fa-download"></i> {{$block_list.download}}</a></p>
+		<p><a rel="nofollow" href="/blocklist/domain/download"><i class="fa fa-download"></i> {{$block_list.download}}</a></p>
 	</div>
 {{/if}}
 


### PR DESCRIPTION
So search engines might not follow it to index the block list.