### PR TITLE
[Composer] Remove bower-asset/vue dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,6 @@
 		"bower-asset/chart-js": "^2.8",
 		"bower-asset/dompurify": "^1.0",
 		"bower-asset/fork-awesome": "^1.1",
-		"bower-asset/vue": "^2.6",
 		"npm-asset/cropperjs": "1.2.2",
 		"npm-asset/es-jquery-sortable": "^0.9.13",
 		"npm-asset/fullcalendar": "^3.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c851fbba46ed090d0fbaf68e9b3b94df",
+    "content-hash": "e8626dc6957dff9cc783daad10cfc26f",
     "packages": [
         {
             "name": "asika/simple-console",
@@ -240,22 +240,6 @@
                 "icon"
             ],
             "time": "2021-08-26T18:46:39+00:00"
-        },
-        {
-            "name": "bower-asset/vue",
-            "version": "v2.7.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/vuejs/vue.git",
-                "reference": "ee57d9fd1d51abe245c6c37e6f8f2d45977b929e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/vuejs/vue/zipball/ee57d9fd1d51abe245c6c37e6f8f2d45977b929e",
-                "reference": "ee57d9fd1d51abe245c6c37e6f8f2d45977b929e",
-                "shasum": ""
-            },
-            "type": "bower-asset-library"
         },
         {
             "name": "brick/math",


### PR DESCRIPTION
Part of #12054 

- The Bower package doesn't have the dist/vue.min.js anymore (?) which is required for the advancedcontentfilter addon

On the other hand, we just saved 4 MB on the install size!