### PR TITLE
Accepting contact request does finally work per Mastodon API

### DIFF
--- a/src/Factory/Api/Mastodon/Notification.php
+++ b/src/Factory/Api/Mastodon/Notification.php
@@ -85,7 +85,7 @@ class Notification extends BaseFactory
 		if (($Notification->verb == Activity::FOLLOW) && ($Notification->type === Post\UserNotification::TYPE_NONE)) {
 			$contact = Contact::getById($Notification->actorId, ['pending', 'uri-id', 'uid']);
 			if (($contact['uid'] == 0) && !empty($contact['uri-id'])) {
-				$contact = Contact::selectFirst(['pending', 'uri-id', 'uid'], ['uri-id' => $contact['uri-id'], 'uid' => $Notification->uid]);
+				$contact = Contact::selectFirst(['pending'], ['uri-id' => $contact['uri-id'], 'uid' => $Notification->uid]);
 			}
 			$type = $contact['pending'] ? MstdnNotification::TYPE_INTRODUCTION : MstdnNotification::TYPE_FOLLOW;
 		} elseif (($Notification->verb == Activity::ANNOUNCE) &&

--- a/src/Factory/Api/Mastodon/Notification.php
+++ b/src/Factory/Api/Mastodon/Notification.php
@@ -83,7 +83,10 @@ class Notification extends BaseFactory
 	public static function getType(Entity\Notification $Notification): string
 	{
 		if (($Notification->verb == Activity::FOLLOW) && ($Notification->type === Post\UserNotification::TYPE_NONE)) {
-			$contact = Contact::getById($Notification->actorId, ['pending']);
+			$contact = Contact::getById($Notification->actorId, ['pending', 'uri-id', 'uid']);
+			if (($contact['uid'] == 0) && !empty($contact['uri-id'])) {
+				$contact = Contact::selectFirst(['pending', 'uri-id', 'uid'], ['uri-id' => $contact['uri-id'], 'uid' => $Notification->uid]);
+			}
 			$type = $contact['pending'] ? MstdnNotification::TYPE_INTRODUCTION : MstdnNotification::TYPE_FOLLOW;
 		} elseif (($Notification->verb == Activity::ANNOUNCE) &&
 			in_array($Notification->type, [Post\UserNotification::TYPE_DIRECT_COMMENT, Post\UserNotification::TYPE_DIRECT_THREAD_COMMENT])) {

--- a/src/Module/Api/Mastodon/FollowRequests.php
+++ b/src/Module/Api/Mastodon/FollowRequests.php
@@ -47,7 +47,12 @@ class FollowRequests extends BaseApi
 		self::checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCurrentUserID();
 
-		$introduction = DI::intro()->selectOneById($this->parameters['id'], $uid);
+		$cdata = Contact::getPublicAndUserContactID($this->parameters['id'], $uid);
+		if (empty($cdata['user'])) {
+			throw new HTTPException\NotFoundException('Contact not found');
+		}
+
+		$introduction = DI::intro()->selectForContact($cdata['user']);
 
 		$contactId = $introduction->cid;
 


### PR DESCRIPTION
Contact request hadn't appeared as contact requests in the API. And additionally it was not possible to accept them.

This is fixed.