### PR TITLE
Improved handling of native quotes

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -611,7 +611,8 @@ function item_post(App $a) {
 		$datarray['author-uri-id'] = ItemURI::getIdByURI($datarray['author-link']);
 		$datarray['owner-updated'] = '';
 		$datarray['has-media'] = false;
-		$datarray['body'] = DI::contentItem()->improveSharedDataInBody($datarray);
+		$datarray['quote-uri-id'] = Item::getQuoteUriId($datarray['body'], $datarray['uid']);
+		$datarray['body'] = BBCode::removeSharedData($datarray['body']);
 
 		$o = DI::conversation()->create([array_merge($contact_record, $datarray)], 'search', false, true);
 
@@ -652,7 +653,12 @@ function item_post(App $a) {
 	}
 
 	$datarray['uri-id'] = ItemURI::getIdByURI($datarray['uri']);
-	$datarray['body']   = DI::contentItem()->improveSharedDataInBody($datarray);
+
+	$quote_uri_id = Item::getQuoteUriId($datarray['body'], $datarray['uid']);
+	if (!empty($quote_uri_id)) {
+		$datarray['quote-uri-id'] = $quote_uri_id;
+		$datarray['body']         = BBCode::removeSharedData($datarray['body']);
+	}
 
 	if ($orig_post) {
 		$fields = [

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -748,8 +748,7 @@ class Item
 			return $body;
 		}
 
-		$link = $post['plink'] ?: $post['uri'];
-		$body .= "\n♲ " . $link;
+		$body .= "\n♲ " . ($post['plink'] ?: $post['uri']);
 
 		return $body;
 	}

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -574,57 +574,30 @@ class Item
 	}
 
 	/**
-	 * Add a share block for the given url
-	 *
-	 * @param string $url
-	 * @param integer $uid
-	 * @param bool $add_media
-	 * @return string
-	 */
-	public function createSharedPostByUrl(string $url, int $uid = 0, bool $add_media = false): string
-	{
-		if (!empty($uid)) {
-			$id = ItemModel::searchByLink($url, $uid);
-		}
-
-		if (empty($id)) {
-			$id = ItemModel::fetchByLink($url);
-		}
-
-		if (!$id) {
-			Logger::notice('Post could not be fetched.', ['url' => $url, 'uid' => $uid, 'callstack' => System::callstack()]);
-			return '';
-		}
-
-		Logger::debug('Fetched shared post', ['id' => $id, 'url' => $url, 'uid' => $uid, 'callstack' => System::callstack()]);
-
-		$shared_item = Post::selectFirst(['uri-id', 'uri', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'network'], ['id' => $id]);
-		if (!DBA::isResult($shared_item)) {
-			Logger::warning('Post does not exist.', ['id' => $id, 'url' => $url, 'uid' => $uid]);
-			return '';
-		}
-
-		return $this->createSharedBlockByArray($shared_item, $add_media);
-	}
-
-	/**
 	 * Add a share block for the given uri-id
 	 *
-	 * @param integer $UriId
-	 * @param integer $uid
-	 * @param bool $add_media
+	 * @param array  $item
+	 * @param string $body
 	 * @return string
 	 */
-	public function createSharedPostByUriId(int $UriId, int $uid = 0, bool $add_media = false): string
+	public function addSharedPost(array $item, string $body = ''): string
 	{
-		$fields = ['uri-id', 'uri', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'network'];
-		$shared_item = Post::selectFirst($fields, ['uri-id' => $UriId, 'uid' => [$uid, 0], 'private' => [ItemModel::PUBLIC, ItemModel::UNLISTED]]);
-		if (!DBA::isResult($shared_item)) {
-			Logger::notice('Post does not exist.', ['uri-id' => $UriId, 'uid' => $uid]);
-			return '';
+		if (empty($body)) {
+			$body = $item['body'];
 		}
 
-		return $this->createSharedBlockByArray($shared_item, $add_media);
+		if (empty($item['quote-uri-id'])) {
+			return $body;
+		}
+
+		$fields = ['uri-id', 'uri', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'network'];
+		$shared_item = Post::selectFirst($fields, ['uri-id' => $item['quote-uri-id'], 'uid' => [$item['uid'], 0], 'private' => [ItemModel::PUBLIC, ItemModel::UNLISTED]]);
+		if (!DBA::isResult($shared_item)) {
+			Logger::notice('Post does not exist.', ['uri-id' => $item['quote-uri-id'], 'uid' => $item['uid']]);
+			return $body;
+		}
+
+		return $body . "\n" . $this->createSharedBlockByArray($shared_item, true);
 	}
 
 	/**
@@ -635,20 +608,13 @@ class Item
 	 * @param bool $add_media
 	 * @return string
 	 */
-	public function createSharedPostByGuid(string $guid, int $uid = 0, string $host = '', bool $add_media = false): string
+	private function createSharedPostByGuid(string $guid, bool $add_media): string
 	{
 		$fields = ['uri-id', 'uri', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'network'];
-		$shared_item = Post::selectFirst($fields, ['guid' => $guid, 'uid' => [$uid, 0], 'private' => [ItemModel::PUBLIC, ItemModel::UNLISTED]]);
-
-		if (!DBA::isResult($shared_item) && !empty($host) && Diaspora::storeByGuid($guid, $host, true)) {
-			Logger::debug('Fetched post', ['guid' => $guid, 'host' => $host, 'uid' => $uid]);
-			$shared_item = Post::selectFirst($fields, ['guid' => $guid, 'uid' => [$uid, 0], 'private' => [ItemModel::PUBLIC, ItemModel::UNLISTED]]);
-		} elseif (DBA::isResult($shared_item)) {
-			Logger::debug('Found existing post', ['guid' => $guid, 'host' => $host, 'uid' => $uid]);
-		}
+		$shared_item = Post::selectFirst($fields, ['guid' => $guid, 'uid' => 0, 'private' => [ItemModel::PUBLIC, ItemModel::UNLISTED]]);
 
 		if (!DBA::isResult($shared_item)) {
-			Logger::notice('Post does not exist.', ['guid' => $guid, 'host' => $host, 'uid' => $uid]);
+			Logger::notice('Post does not exist.', ['guid' => $guid]);
 			return '';
 		}
 
@@ -669,8 +635,9 @@ class Item
 		} elseif (!in_array($item['network'] ?? '', Protocol::FEDERATED)) {
 			$item['guid'] = '';
 			$item['uri']  = '';
-			$item['body'] = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
-		} elseif ($add_media) {
+		}
+
+		if ($add_media) {
 			$item['body'] = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
 		}
 
@@ -684,7 +651,7 @@ class Item
 
 		// If it is a reshared post then reformat it to avoid display problems with two share elements
 		if (!empty($shared)) {
-			if (!empty($shared['guid']) && ($encaspulated_share = $this->createSharedPostByGuid($shared['guid'], 0, '', $add_media))) {
+			if (!empty($shared['guid']) && ($encaspulated_share = $this->createSharedPostByGuid($shared['guid'], $add_media))) {
 				$item['body'] = preg_replace("/\[share.*?\](.*)\[\/share\]/ism", $encaspulated_share, $item['body']);
 			}
 
@@ -731,36 +698,6 @@ class Item
 	}
 
 	/**
-	 * Improve the data in shared posts
-	 *
-	 * @param array $item
-	 * @param bool  $add_media
-	 * @return string body
-	 */
-	public function improveSharedDataInBody(array $item, bool $add_media = false): string
-	{
-		$shared = BBCode::fetchShareAttributes($item['body']);
-		if (empty($shared['guid']) && empty($shared['message_id'])) {
-			return $item['body'];
-		}
-
-		$link = $shared['link'] ?: $shared['message_id'];
-
-		if (empty($shared_content)) {
-			$shared_content = $this->createSharedPostByUrl($link, $item['uid'] ?? 0, $add_media);
-		}
-
-		if (empty($shared_content)) {
-			return $item['body'];
-		}
-
-		$item['body'] = preg_replace("/\[share.*?\](.*)\[\/share\]/ism", $shared_content, $item['body']);
-
-		Logger::debug('New shared data', ['uri-id' => $item['uri-id'], 'link' => $link, 'guid' => $item['guid']]);
-		return $item['body'];
-	}
-
-	/**
 	 * Return share data from an item array (if the item is shared item)
 	 * We are providing the complete Item array, because at some time in the future
 	 * we hopefully will define these values not in the body anymore but in some item fields.
@@ -795,5 +732,25 @@ class Item
 		}
 
 		return [];
+	}
+
+	/**
+	 * Add a link to a shared post at the end of the post 
+	 *
+	 * @param string  $body
+	 * @param integer $quote_uri_id
+	 * @return string
+	 */
+	public function addShareLink(string $body, int $quote_uri_id): string
+	{
+		$post = Post::selectFirstPost(['uri', 'plink'], ['uri-id' => $quote_uri_id]);
+		if (empty($post)) {
+			return $body;
+		}
+
+		$link = $post['plink'] ?: $post['uri'];
+		$body .= "\n♲ " . $link;
+
+		return $body;
 	}
 }

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1071,46 +1071,6 @@ class BBCode
 	}
 
 	/**
-	 * Checks, if the provided body contains a native reshare
-	 *
-	 * @param string $body
-	 * @return boolean
-	 */
-	public static function isNativeReshare(string $body): bool
-	{
-		$shared = BBCode::fetchShareAttributes($body);
-		return !empty($shared['guid'] ?? '');
-	}
-
-	/**
-	 * Checks if the provided body contains a "share" element
-	 *
-	 * @param string $body
-	 * @return boolean
-	 */
-	public static function existsShare(string $body): bool
-	{
-		$shared = BBCode::fetchShareAttributes($body);
-		return !empty($shared['link'] ?? '');
-	}
-
-	/**
-	 * Replace the share block with a link
-	 *
-	 * @param string $body
-	 * @return string
-	 */
-	public static function replaceSharedData(string $body): string
-	{
-		return BBCode::convertShare(
-			$body,
-			function (array $attributes) {
-				return '♲ ' . $attributes['link'];
-			}
-		);
-	}
-
-	/**
 	 * Remove the share block
 	 *
 	 * @param string $body
@@ -1118,7 +1078,7 @@ class BBCode
 	 */
 	public static function removeSharedData(string $body): string
 	{
-		return trim(preg_replace("/\s*\[share .*?\].*?\[\/share\]\s*/ism", '', $body));
+		return trim(preg_replace("/\s*\[share.*?\].*?\[\/share\]\s*/ism", '', $body));
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -86,7 +86,7 @@ class Status extends BaseFactory
 	public function createFromUriId(int $uriId, int $uid = 0): \Friendica\Object\Api\Mastodon\Status
 	{
 		$fields = ['uri-id', 'uid', 'author-id', 'author-uri-id', 'author-link', 'starred', 'app', 'title', 'body', 'raw-body', 'content-warning', 'question-id',
-			'created', 'network', 'thr-parent-id', 'parent-author-id', 'language', 'uri', 'plink', 'private', 'vid', 'gravity', 'featured', 'has-media'];
+			'created', 'network', 'thr-parent-id', 'parent-author-id', 'language', 'uri', 'plink', 'private', 'vid', 'gravity', 'featured', 'has-media', 'quote-uri-id'];
 		$item = Post::selectFirst($fields, ['uri-id' => $uriId, 'uid' => [0, $uid]], ['order' => ['uid' => true]]);
 		if (!$item) {
 			$mail = DBA::selectFirst('mail', ['id'], ['uri-id' => $uriId, 'uid' => $uid]);
@@ -178,6 +178,8 @@ class Status extends BaseFactory
 			$item['title'] = $reshared_item['title'] ?? $item['title'];
 			$item['body']  = $reshared_item['body'] ?? $item['body'];
 		} else {
+			$item['body']     = $this->contentItem->addSharedPost($item);
+			$item['raw-body'] = $this->contentItem->addSharedPost($item, $item['raw-body']);
 			$reshare = [];
 		}
 

--- a/src/Factory/Api/Twitter/Status.php
+++ b/src/Factory/Api/Twitter/Status.php
@@ -84,7 +84,7 @@ class Status extends BaseFactory
 	{
 		$fields = ['parent-uri-id', 'uri-id', 'uid', 'author-id', 'author-link', 'author-network', 'owner-id', 'causer-id',
 			'starred', 'app', 'title', 'body', 'raw-body', 'created', 'network','post-reason', 'language', 'gravity',
-			'thr-parent-id', 'parent-author-id', 'parent-author-nick', 'uri', 'plink', 'private', 'vid', 'coord'];
+			'thr-parent-id', 'parent-author-id', 'parent-author-nick', 'uri', 'plink', 'private', 'vid', 'coord', 'quote-uri-id'];
 		$item = Post::selectFirst($fields, ['id' => $id], ['order' => ['uid' => true]]);
 		if (!$item) {
 			throw new HTTPException\NotFoundException('Item with ID ' . $id . ' not found.');
@@ -146,7 +146,7 @@ class Status extends BaseFactory
 		$statusnetHtml = BBCode::convertForUriId($item['uri-id'], BBCode::setMentionsToNicknames($title . ($item['raw-body'] ?? $item['body'])), BBCode::API);
 		$friendicaHtml = BBCode::convertForUriId($item['uri-id'], $title . $item['body'], BBCode::EXTERNAL);
 
-		$text .= Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
+		$text .= Post\Media::addAttachmentsToBody($item['uri-id'], $this->contentItem->addSharedPost($item));
 
 		$text = trim(HTML::toPlaintext(BBCode::convertForUriId($item['uri-id'], $text, BBCode::API), 0));
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3690,13 +3690,12 @@ class Item
 		}
 
 		$shared_item = Post::selectFirst(['uri-id'], ['id' => $id]);
-		if (!DBA::isResult($shared_item)) {
-			Logger::warning('Post does not exist.', ['id' => $id, 'url' => $url, 'uid' => $uid]);
-			return 0;
-		} else {
+		if (!empty($shared_item['uri-id'])) {
 			Logger::debug('Fetched shared post', ['id' => $id, 'url' => $url, 'uid' => $uid]);
+			return $shared_item['uri-id'];
 		}
 
-		return $shared_item['uri-id'];
+		Logger::warning('Post does not exist although it was supposed to had been fetched.', ['id' => $id, 'url' => $url, 'uid' => $uid]);
+		return 0;
 	}
 }

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -403,11 +403,6 @@ class Media
 		// Simplify image codes
 		$unshared_body = $body = preg_replace("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/ism", '[img]$3[/img]', $body);
 
-		// Only remove the shared data from "real" reshares
-		if (BBCode::isNativeReshare($body)) {
-			$unshared_body = BBCode::removeSharedData($body);
-		}
-
 		$attachments = [];
 		if (preg_match_all("#\[url=([^\]]+?)\]\s*\[img=([^\[\]]*)\]([^\[\]]*)\[\/img\]\s*\[/url\]#ism", $body, $pictures, PREG_SET_ORDER)) {
 			foreach ($pictures as $picture) {
@@ -484,12 +479,6 @@ class Media
 	 */
 	public static function insertFromRelevantUrl(int $uriid, string $body)
 	{
-		// Only remove the shared data from "real" reshares
-		if (BBCode::isNativeReshare($body)) {
-			// Don't look at the shared content
-			$body = BBCode::removeSharedData($body);
-		}
-
 		// Remove all hashtags and mentions
 		$body = preg_replace("/([#@!])\[url\=(.*?)\](.*?)\[\/url\]/ism", '', $body);
 
@@ -519,9 +508,6 @@ class Media
 	 */
 	public static function insertFromAttachmentData(int $uriid, string $body)
 	{
-		// Don't look at the shared content
-		$body = BBCode::removeSharedData($body);
-
 		$data = BBCode::getAttachmentData($body);
 		if (empty($data))  {
 			return;

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -59,6 +59,7 @@ class Media
 	const XML         = 18;
 	const PLAIN       = 19;
 	const ACTIVITY    = 20;
+	const ACCOUNT     = 21;
 	const DOCUMENT    = 128;
 
 	/**
@@ -222,6 +223,10 @@ class Media
 			$media = self::addActivity($media);
 		}
 
+		if (in_array($media['type'], [self::TEXT, self::APPLICATION, self::HTML, self::XML, self::PLAIN])) {
+			$media = self::addAccount($media);
+		}
+
 		if ($media['type'] == self::HTML) {
 			$data = ParseUrl::getSiteinfoCached($media['url'], false);
 			$media['preview'] = $data['images'][0]['src'] ?? null;
@@ -268,8 +273,6 @@ class Media
 			$media['mimetype'] = 'application/activity+json';
 		} elseif ($item['network'] == Protocol::DIASPORA) {
 			$media['mimetype'] = 'application/xml';
-		} else {
-			$media['mimetype'] = '';
 		}
 
 		$contact = Contact::getById($item['author-id'], ['avatar', 'gsid']);
@@ -281,7 +284,6 @@ class Media
 		$media['media-uri-id'] = $item['uri-id'];
 		$media['height'] = null;
 		$media['width'] = null;
-		$media['size'] = null;
 		$media['preview'] = null;
 		$media['preview-height'] = null;
 		$media['preview-width'] = null;
@@ -295,6 +297,47 @@ class Media
 		$media['publisher-image'] = null;
 
 		Logger::debug('Activity detected', ['uri-id' => $media['uri-id'], 'url' => $media['url'], 'plink' => $item['plink'], 'uri' => $item['uri']]);
+		return $media;
+	}
+
+	/**
+	 * Adds the account type if the media entry is linked to an account
+	 *
+	 * @param array $media
+	 * @return array
+	 */
+	private static function addAccount(array $media): array
+	{
+		$contact = Contact::getByURL($media['url'], false);
+		if (empty($contact) || ($contact['network'] == Protocol::PHANTOM)) {
+			return $media;
+		}
+
+		if (in_array($contact['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN])) {
+			$media['mimetype'] = 'application/activity+json';
+		}
+
+		if (!empty($contact['gsid'])) {
+			$gserver = DBA::selectFirst('gserver', ['url', 'site_name'], ['id' => $contact['gsid']]);
+		}
+
+		$media['type'] = self::ACCOUNT;
+		$media['media-uri-id'] = $contact['uri-id'];
+		$media['height'] = null;
+		$media['width'] = null;
+		$media['preview'] = null;
+		$media['preview-height'] = null;
+		$media['preview-width'] = null;
+		$media['description'] = $contact['about'];
+		$media['name'] = $contact['name'];
+		$media['author-url'] = $contact['url'];
+		$media['author-name'] = $contact['name'];
+		$media['author-image'] = $contact['avatar'];
+		$media['publisher-url'] = $gserver['url'] ?? null;
+		$media['publisher-name'] = $gserver['site_name'] ?? null;
+		$media['publisher-image'] = null;
+
+		Logger::debug('Account detected', ['uri-id' => $media['uri-id'], 'url' => $media['url'], 'uri' => $contact['url']]);
 		return $media;
 	}
 
@@ -633,6 +676,12 @@ class Media
 				if (Strings::compareLink($preview, $medium['url'])) {
 					continue 2;
 				}
+			}
+
+			// Currently these two types are ignored here.
+			// Posts are added differently and contacts are not displayed as attachments.
+			if (in_array($medium['type'], [self::ACCOUNT, self::ACTIVITY])) {
+				continue;
 			}
 
 			if (!empty($medium['preview'])) {

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -319,15 +319,11 @@ class Tag
 			$tags = self::TAG_CHARACTER[self::HASHTAG] . self::TAG_CHARACTER[self::MENTION] . self::TAG_CHARACTER[self::EXCLUSIVE_MENTION];
 		}
 
-		// Only remove the shared data from "real" reshares
-		$shared = DI::contentItem()->getSharedPost($item, ['uri-id']);
-		if (!empty($shared)) {
-			$item['body'] = BBCode::removeSharedData($item['body']);
-		}
-
 		foreach (self::getFromBody($item['body'], $tags) as $tag) {
 			self::storeByHash($item['uri-id'], $tag[1], $tag[3], $tag[2]);
 		}
+
+		$shared = DI::contentItem()->getSharedPost($item, ['uri-id']);
 
 		// Search for hashtags in the shared body (but only if hashtags are wanted)
 		if (!empty($shared) && (strpos($tags, self::TAG_CHARACTER[self::HASHTAG]) !== false)) {

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -774,7 +774,7 @@ class DFRN
 			$entry->setAttribute("xmlns:statusnet", ActivityNamespace::STATUSNET);
 		}
 
-		$body = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body'] ?? '');
+		$body = Post\Media::addAttachmentsToBody($item['uri-id'], DI::contentItem()->addSharedPost($item));
 
 		if ($item['private'] == Item::PRIVATE) {
 			$body = Item::fixPrivatePhotos($body, $owner['uid'], $item, $cid);
@@ -1838,7 +1838,11 @@ class DFRN
 
 		$item['uri-id'] = ItemURI::insert(['uri' => $item['uri'], 'guid' => $item['guid']]);
 
-		$item['body'] = DI::contentItem()->improveSharedDataInBody($item);
+		$quote_uri_id = Item::getQuoteUriId($item['body'], $item['uid']);
+		if (!empty($quote_uri_id)) {
+			$item['quote-uri-id'] = $quote_uri_id;
+			$item['body']         = BBCode::removeSharedData($item['body']);
+		}
 
 		Tag::storeFromBody($item['uri-id'], $item['body']);
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1598,7 +1598,7 @@ class OStatus
 		XML::addElement($doc, $entry, 'id', $item['uri']);
 		XML::addElement($doc, $entry, 'title', html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 
-		$body = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
+		$body = Post\Media::addAttachmentsToBody($item['uri-id'], DI::contentItem()->addSharedPost($item));
 		$body = self::formatPicturePost($body, $item['uri-id']);
 
 		if (!empty($item['title'])) {


### PR DESCRIPTION
We are now only storing non native quotes in the body. All native quotes are done via the quote-uri-id field in the post. The whole code is cleaned up around this.

This PR has to be merged at the same time as the addon PR.