### PR TITLE
Fix wrong class name in logs view template

### DIFF
--- a/view/theme/frio/templates/admin/logs/view.tpl
+++ b/view/theme/frio/templates/admin/logs/view.tpl
@@ -121,7 +121,7 @@
 					</tbody>
 				</table>
 
-				<h3 class="header-event-data">{{$l10n.Data}}</h3>
+				<h3 class="event-data-header">{{$l10n.Data}}</h3>
 				<div class="event-source">
 				</div>
 				<div class="event-data">


### PR DESCRIPTION
Fixes #12085 

- This was stunting the Javascript responsible for showing log entry details