### PR TITLE
Replace remaining "follow" route instances to "contact/follow"

### DIFF
--- a/src/Module/Notifications/Introductions.php
+++ b/src/Module/Notifications/Introductions.php
@@ -128,7 +128,7 @@ class Introductions extends BaseNotifications
 						'$zrl'                   => $Introduction->getZrl(),
 						'$lbl_url'               => $this->t('Profile URL'),
 						'$addr'                  => $Introduction->getAddr(),
-						'$action'                => 'follow',
+						'$action'                => 'contact/follow',
 						'$approve'               => $this->t('Approve'),
 						'$note'                  => $Introduction->getNote(),
 						'$ignore'                => $this->t('Ignore'),

--- a/view/templates/widget/follow.tpl
+++ b/view/templates/widget/follow.tpl
@@ -2,7 +2,7 @@
 <div id="follow-sidebar" class="widget">
 	<h3>{{$connect}}</h3>
 	<div id="connect-desc">{{$desc nofilter}}</div>
-	<form action="follow" method="get">
+	<form action="contact/follow" method="get">
 		<input id="side-follow-url" type="text" name="url" value="{{$value}}" size="24" placeholder="{{$hint}}" title="{{$hint}}" /><input id="side-follow-submit" type="submit" name="submit" value="{{$follow}}" />
 	</form>
 </div>

--- a/view/theme/frio/templates/widget/follow.tpl
+++ b/view/theme/frio/templates/widget/follow.tpl
@@ -2,7 +2,7 @@
 <div id="follow-sidebar" class="widget">
 	<h3>{{$connect}}</h3>
 
-	<form action="follow" method="get">
+	<form action="contact/follow" method="get">
 		{{* The input field - For visual consistence we are using a search input field*}}
 		<div class="form-group form-group-search">
 			<input id="side-follow-url" class="search-input form-control form-search" type="text" name="url" value="{{$value}}" placeholder="{{$hint}}" data-toggle="tooltip" title="{{$hint}}" />

--- a/view/theme/smoothly/templates/widget/follow.tpl
+++ b/view/theme/smoothly/templates/widget/follow.tpl
@@ -2,7 +2,7 @@
 <div id="follow-sidebar" class="widget">
 	<h3>{{$connect}}</h3>
 	<div id="connect-desc">{{$desc nofilter}}</div>
-	<form action="follow" method="post">
+	<form action="contact/follow" method="post">
 		<input id="side-follow-url" type="text-sidebar" name="url" size="24" title="{{$hint}}" /><input id="side-follow-submit" type="submit" name="submit" value="{{$follow}}" />
 	</form>
 </div>


### PR DESCRIPTION
Follow up to https://github.com/friendica/friendica/pull/12077
Fixes #12090

Note: The friend suggestion doesn't seem to be able to work in non-Frio themes since the move to domain-driven design last year. Given we haven't received any complaints about it, I'd be in favor of removing this feature since it doesn't serve any purpose that a private message containing a link to a profile wouldn't do.