### PR TITLE
Remove non-top-level posts from notification labels when network sort order is "received"

### DIFF
--- a/src/Core/Config/Capability/IManageConfigValues.php
+++ b/src/Core/Config/Capability/IManageConfigValues.php
@@ -51,7 +51,7 @@ interface IManageConfigValues
 	 *
 	 * @param string  $cat        The category of the configuration value
 	 * @param string  $key           The configuration key to query
-	 * @param mixed   $default_value optional, The value to return if key is not set (default: null)
+	 * @param mixed   $default_value Deprecated, use `Config->get($cat, $key, null, $refresh) ?? $default_value` instead
 	 * @param boolean $refresh       optional, If true the config is loaded from the db and not from the cache (default: false)
 	 *
 	 * @return mixed Stored value or null if it does not exist

--- a/src/Core/PConfig/Capability/IManagePersonalConfigValues.php
+++ b/src/Core/PConfig/Capability/IManagePersonalConfigValues.php
@@ -51,7 +51,7 @@ interface IManagePersonalConfigValues
 	 * @param int     $uid           The user_id
 	 * @param string  $cat           The category of the configuration value
 	 * @param string  $key           The configuration key to query
-	 * @param mixed   $default_value optional, The value to return if key is not set (default: null)
+	 * @param mixed   $default_value Deprecated, use `PConfig->get($uid, $cat, $key, null, $refresh) ?? $default_value` instead
 	 * @param boolean $refresh       optional, If true the config is loaded from the db and not from the cache (default: false)
 	 *
 	 * @return mixed Stored value or null if it does not exist

--- a/src/Core/Session/Capability/IHandleSessions.php
+++ b/src/Core/Session/Capability/IHandleSessions.php
@@ -48,7 +48,7 @@ interface IHandleSessions
 	 * Handle the case where session_start() hasn't been called and the super global isn't available.
 	 *
 	 * @param string $name
-	 * @param mixed  $defaults
+	 * @param mixed  $defaults Deprecated, use `Session->get($name) ?? $defaults` instead
 	 *
 	 * @return mixed
 	 */
@@ -58,7 +58,7 @@ interface IHandleSessions
 	 * Retrieves a value from the provided key if it exists and removes it from session
 	 *
 	 * @param string $name
-	 * @param mixed  $defaults
+	 * @param mixed  $defaults Deprecated, use `Session->pop($name) ?? $defaults` instead
 	 *
 	 * @return mixed
 	 */

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -141,7 +141,7 @@ class Subscription
 	{
 		$type = NotificationFactory::getType($notification);
 
-		if (DI::notify()->NotifyOnDesktop($notification, $type)) {
+		if (DI::notify()->shouldShowOnDesktop($notification, $type)) {
 			DI::notify()->createFromNotification($notification);
 		}
 

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -29,7 +29,9 @@ use Friendica\Content\Widget;
 use Friendica\Content\Text\HTML;
 use Friendica\Core\ACL;
 use Friendica\Core\Hook;
+use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
 use Friendica\Core\Renderer;
+use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
@@ -306,7 +308,7 @@ class Network extends BaseModule
 
 		self::$forumContactId = $this->parameters['contact_id'] ?? 0;
 
-		self::$selectedTab = DI::session()->get('network-tab', DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'network.view', 'selected_tab', ''));
+		self::$selectedTab = self::getTimelineOrderBySession(DI::userSession(), DI::pConfig());
 
 		if (!empty($get['star'])) {
 			self::$selectedTab = 'star';
@@ -485,5 +487,19 @@ class Network extends BaseModule
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Returns the selected network tab of the currently logged-in user
+	 *
+	 * @param IHandleUserSessions         $session
+	 * @param IManagePersonalConfigValues $pconfig
+	 * @return string
+	 */
+	public static function getTimelineOrderBySession(IHandleUserSessions $session, IManagePersonalConfigValues $pconfig): string
+	{
+		return $session->get('network-tab')
+			?? $pconfig->get($session->getLocalUserId(), 'network.view', 'selected_tab')
+			?? '';
 	}
 }

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -128,6 +128,11 @@ class Ping extends BaseModule
 				$this->session->getLocalUserId(), Verb::getID(Activity::FOLLOW)
 			];
 
+			// No point showing counts for non-top-level posts when the network page is ordered by received field
+			if (Network::getTimelineOrderBySession($this->session, $this->pconfig) == 'received') {
+				$condition = DBA::mergeConditions($condition, ["`parent` = `id`"]);
+			}
+
 			$items_unseen = $this->database->toArray(Post::selectForUser(
 				$this->session->getLocalUserId(),
 				['wall', 'uid', 'uri-id'],

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -190,7 +190,7 @@ class Ping extends BaseModule
 			$owner = User::getOwnerDataById(DI::userSession()->getLocalUserId());
 
 			$navNotifications = array_map(function (Entity\Notification $notification) use ($owner) {
-				if (!DI::notify()->NotifyOnDesktop($notification)) {
+				if (!DI::notify()->shouldShowOnDesktop($notification)) {
 					return null;
 				}
 				if (($notification->type == Post\UserNotification::TYPE_NONE) && in_array($owner['page-flags'], [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_PRVGROUP])) {

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -664,7 +664,7 @@ class Notify extends BaseRepository
 		return false;
 	}
 
-	public function NotifyOnDesktop(Entity\Notification $Notification, string $type = null): bool
+	public function shouldShowOnDesktop(Entity\Notification $Notification, string $type = null): bool
 	{
 		if (is_null($type)) {
 			$type = NotificationFactory::getType($Notification);


### PR DESCRIPTION
- These posts don't alter the network view in this sort order and so are distracting with no actionable benefits

This has been a pet peeve of mine for a while, but it came to a head today when I published a post that received 100+ interactions. My notifications labels have been increasing non-stop which was very distracting but there was nothing I could do once I checked the number this post was doing.

Also, I finally realized that having the default value as a method parameter for session and config is obsolete since we have access to the null coalescing operator, so I added some documentation to show this.

Successfully tested on my production node because I needed a breather.