### PR TITLE
Improved bulk delivery / don't redistribute activities

### DIFF
--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -783,7 +783,7 @@ class Notifier
 			}
 
 			Logger::info('Remote item will be distributed', ['id' => $target_item['id'], 'url' => $target_item['uri'], 'verb' => $target_item['verb']]);
-		} elseif ($parent['origin']) {
+		} else {
 			Logger::info('Remote activity will not be distributed', ['id' => $target_item['id'], 'url' => $target_item['uri'], 'verb' => $target_item['verb']]);
 			return ['count' => 0, 'contacts' => []];
 		}

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -771,9 +771,9 @@ class Notifier
 				$relay_inboxes = ActivityPub\Transmitter::addRelayServerInboxes();
 			}
 
-			Logger::info('Origin item ' . $target_item['id'] . ' with URL ' . $target_item['uri'] . ' will be distributed.');
+			Logger::info('Origin item will be distributed', ['id' => $target_item['id'], 'url' => $target_item['uri'], 'verb' => $target_item['verb']]);
 		} elseif (!Post\Activity::exists($target_item['uri-id'])) {
-			Logger::info('Remote item ' . $target_item['id'] . ' with URL ' . $target_item['uri'] . ' is no AP post. It will not be distributed.');
+			Logger::info('Remote item is no AP post. It will not be distributed.', ['id' => $target_item['id'], 'url' => $target_item['uri'], 'verb' => $target_item['verb']]);
 			return ['count' => 0, 'contacts' => []];
 		} elseif ($parent['origin'] && (($target_item['gravity'] != Item::GRAVITY_ACTIVITY) || DI::config()->get('system', 'redistribute_activities'))) {
 			$inboxes = ActivityPub\Transmitter::fetchTargetInboxes($parent, $uid, false, $target_item['id']);
@@ -782,7 +782,10 @@ class Notifier
 				$inboxes = ActivityPub\Transmitter::addRelayServerInboxesForItem($parent['id'], $inboxes);
 			}
 
-			Logger::info('Remote item ' . $target_item['id'] . ' with URL ' . $target_item['uri'] . ' will be distributed.');
+			Logger::info('Remote item will be distributed', ['id' => $target_item['id'], 'url' => $target_item['uri'], 'verb' => $target_item['verb']]);
+		} elseif ($parent['origin']) {
+			Logger::info('Remote activity will not be distributed', ['id' => $target_item['id'], 'url' => $target_item['uri'], 'verb' => $target_item['verb']]);
+			return ['count' => 0, 'contacts' => []];
 		}
 
 		if (empty($inboxes) && empty($relay_inboxes)) {

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -775,7 +775,7 @@ class Notifier
 		} elseif (!Post\Activity::exists($target_item['uri-id'])) {
 			Logger::info('Remote item ' . $target_item['id'] . ' with URL ' . $target_item['uri'] . ' is no AP post. It will not be distributed.');
 			return ['count' => 0, 'contacts' => []];
-		} elseif ($parent['origin']) {
+		} elseif ($parent['origin'] && (($target_item['gravity'] != Item::GRAVITY_ACTIVITY) || DI::config()->get('system', 'redistribute_activities'))) {
 			$inboxes = ActivityPub\Transmitter::fetchTargetInboxes($parent, $uid, false, $target_item['id']);
 
 			if (in_array($target_item['private'], [Item::PUBLIC])) {

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -525,6 +525,10 @@ return [
 		// The authentication password for the redis database
 		'redis_password' => null,
 
+		// redistribute_activities (Boolean)
+		// Redistribute incoming activities via ActivityPub
+		'redistribute_activities' => true,
+
 		// relay_deny_languages (Array)
 		// Array of languages (two digit format) that are rejected.
 		'relay_deny_languages' => [],


### PR DESCRIPTION
Under certain circumstances bulk deliveries hadn't been deleted. This is fixed.

Additionally this PR handles the redistribution of activities (like, dislike, ...). On AP this doesn't really work, since these activities mostly arrive without an LD signature. This means that when we redistribute them (for example when someone liked our post), the receivers will most likely throw them away.