### PR TITLE
Transmit the quoted part in the source

### DIFF
--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -597,7 +597,7 @@ class Item
 			return $body;
 		}
 
-		return $body . "\n" . $this->createSharedBlockByArray($shared_item, true);
+		return BBCode::removeSharedData($body) . "\n" . $this->createSharedBlockByArray($shared_item, true);
 	}
 
 	/**
@@ -747,6 +747,8 @@ class Item
 		if (empty($post)) {
 			return $body;
 		}
+
+		$body = BBCode::removeSharedData($body);
 
 		$body .= "\n♲ " . ($post['plink'] ?: $post['uri']);
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -220,10 +220,7 @@ class Item
 				$content_fields['raw-body'] = Post\Media::insertFromBody($item['uri-id'], $content_fields['raw-body']);
 				$content_fields['raw-body'] = self::setHashtags($content_fields['raw-body']);
 
-				if ($item['author-network'] != Protocol::DFRN) {
-					Post\Media::insertFromRelevantUrl($item['uri-id'], $content_fields['raw-body']);
-				}
-
+				Post\Media::insertFromRelevantUrl($item['uri-id'], $content_fields['raw-body']);
 				Post\Content::update($item['uri-id'], $content_fields);
 			}
 
@@ -1148,9 +1145,7 @@ class Item
 		$item['raw-body'] = Post\Media::insertFromBody($item['uri-id'], $item['raw-body']);
 		$item['raw-body'] = self::setHashtags($item['raw-body']);
 
-		if (!DBA::exists('contact', ['id' => $item['author-id'], 'network' => Protocol::DFRN])) {
-			Post\Media::insertFromRelevantUrl($item['uri-id'], $item['raw-body']);
-		}
+		Post\Media::insertFromRelevantUrl($item['uri-id'], $item['raw-body']);
 
 		// Check for hashtags in the body and repair or add hashtag links
 		$item['body'] = self::setHashtags($item['body']);

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1667,7 +1667,6 @@ class Transmitter
 			$body = BBCode::setMentionsToNicknames($body);
 
 			if (!empty($item['quote-uri-id'])) {
-				$body = BBCode::removeSharedData($body);
 				if (Post::exists(['uri-id' => $item['quote-uri-id'], 'network' => [Protocol::ACTIVITYPUB, Protocol::DFRN]])) {
 					$real_quote = true;
 					$data['quoteUrl'] = $item['quote-uri'];
@@ -1687,7 +1686,6 @@ class Transmitter
 		if (!empty($language)) {
 			$richbody = BBCode::setMentionsToNicknames($item['body'] ?? '');
 			if (!empty($item['quote-uri-id'])) {
-				$richbody = BBCode::removeSharedData($richbody);
 				if ($real_quote) {
 					$richbody = DI::contentItem()->addShareLink($richbody, $item['quote-uri-id']);
 				} else {
@@ -1699,7 +1697,13 @@ class Transmitter
 			$data['contentMap'][$language] = BBCode::convertForUriId($item['uri-id'], $richbody, BBCode::EXTERNAL);
 		}
 
-		$data['source'] = ['content' => $item['body'], 'mediaType' => "text/bbcode"];
+		if (!empty($item['quote-uri-id'])) {
+			$source = DI::contentItem()->addSharedPost($item, $item['body']);
+		} else {
+			$source = $item['body'];
+		}
+
+		$data['source'] = ['content' => $source, 'mediaType' => "text/bbcode"];
 
 		if (!empty($item['signed_text']) && ($item['uri'] != $item['thr-parent'])) {
 			$data['diaspora:comment'] = $item['signed_text'];


### PR DESCRIPTION
When we transmit quoted posts to older Friendica systems, we have to transmit the quoted text in the source as well.

Also this PR contains some small change so that we now always look for more information on links, no matter which network. Doing so we now always can display the quoted text if someone just links to another post.