### PR TITLE
Don't show following/followed_by on pending

### DIFF
--- a/src/Object/Api/Mastodon/Relationship.php
+++ b/src/Object/Api/Mastodon/Relationship.php
@@ -94,9 +94,9 @@ class Relationship extends BaseDataTransferObject
 		$this->note                 = '';
 
 		if ($contactRecord['uid'] != 0) {
-			$this->following   = in_array($contactRecord['rel'] ?? 0, [Contact::SHARING, Contact::FRIEND]);
+			$this->following   = !$contactRecord['pending'] && in_array($contactRecord['rel'] ?? 0, [Contact::SHARING, Contact::FRIEND]);
 			$this->requested   = (bool)($contactRecord['pending'] ?? false);
-			$this->followed_by = in_array($contactRecord['rel'] ?? 0, [Contact::FOLLOWER, Contact::FRIEND]);
+			$this->followed_by = !$contactRecord['pending'] && in_array($contactRecord['rel'] ?? 0, [Contact::FOLLOWER, Contact::FRIEND]);
 			$this->muting      = (bool)($contactRecord['readonly'] ?? false) || $muted;
 			$this->notifying   = (bool)$contactRecord['notify_new_posts'] ?? false;
 			$this->blocking    = (bool)($contactRecord['blocked'] ?? false) || $blocked;


### PR DESCRIPTION
A pending contact isn't a follower.