### PR TITLE
Use different parser modes for Mastodon and Twitter-API

### DIFF
--- a/src/Content/Text/Plaintext.php
+++ b/src/Content/Text/Plaintext.php
@@ -116,7 +116,7 @@ class Plaintext
 	 * @see   \Friendica\Content\Text\BBCode::getAttachedData
 	 *
 	 */
-	public static function getPost($item, $limit = 0, $includedlinks = false, $htmlmode = BBCode::API, $target_network = '')
+	public static function getPost($item, $limit = 0, $includedlinks = false, $htmlmode = BBCode::MASTODON_API, $target_network = '')
 	{
 		// Remove hashtags
 		$URLSearchString = '^\[\]';

--- a/src/Factory/Api/Twitter/DirectMessage.php
+++ b/src/Factory/Api/Twitter/DirectMessage.php
@@ -65,13 +65,13 @@ class DirectMessage extends BaseFactory
 		if (!empty($text_mode)) {
 			$title = $mail['title'];
 			if ($text_mode == 'html') {
-				$text = BBCode::convertForUriId($mail['uri-id'], $mail['body'], BBCode::API);
+				$text = BBCode::convertForUriId($mail['uri-id'], $mail['body'], BBCode::TWITTER_API);
 			} elseif ($text_mode == 'plain') {
-				$text = HTML::toPlaintext(BBCode::convertForUriId($mail['uri-id'], $mail['body'], BBCode::API), 0);
+				$text = HTML::toPlaintext(BBCode::convertForUriId($mail['uri-id'], $mail['body'], BBCode::TWITTER_API), 0);
 			}
 		} else {
 			$title = '';
-			$text  = $mail['title'] . "\n" . HTML::toPlaintext(BBCode::convertForUriId($mail['uri-id'], $mail['body'], BBCode::API), 0);
+			$text  = $mail['title'] . "\n" . HTML::toPlaintext(BBCode::convertForUriId($mail['uri-id'], $mail['body'], BBCode::TWITTER_API), 0);
 		}
 
 		$pcid = Contact::getPublicIdByUserId($uid);

--- a/src/Factory/Api/Twitter/Status.php
+++ b/src/Factory/Api/Twitter/Status.php
@@ -143,12 +143,12 @@ class Status extends BaseFactory
 			$title = sprintf("[h4]%s[/h4]\n", $item['title']);
 		}
 
-		$statusnetHtml = BBCode::convertForUriId($item['uri-id'], BBCode::setMentionsToNicknames($title . ($item['raw-body'] ?? $item['body'])), BBCode::API);
+		$statusnetHtml = BBCode::convertForUriId($item['uri-id'], BBCode::setMentionsToNicknames($title . ($item['raw-body'] ?? $item['body'])), BBCode::TWITTER_API);
 		$friendicaHtml = BBCode::convertForUriId($item['uri-id'], $title . $item['body'], BBCode::EXTERNAL);
 
 		$text .= Post\Media::addAttachmentsToBody($item['uri-id'], $this->contentItem->addSharedPost($item));
 
-		$text = trim(HTML::toPlaintext(BBCode::convertForUriId($item['uri-id'], $text, BBCode::API), 0));
+		$text = trim(HTML::toPlaintext(BBCode::convertForUriId($item['uri-id'], $text, BBCode::TWITTER_API), 0));
 
 		$geo = [];
 

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -616,7 +616,7 @@ class Event
 
 			$title = BBCode::convertForUriId($event['uri-id'], Strings::escapeHtml($event['summary']));
 			if (!$title) {
-				list($title, $_trash) = explode("<br", BBCode::convertForUriId($event['uri-id'], Strings::escapeHtml($event['desc'])), BBCode::API);
+				list($title, $_trash) = explode("<br", BBCode::convertForUriId($event['uri-id'], Strings::escapeHtml($event['desc'])), BBCode::TWITTER_API);
 			}
 
 			$author_link = $event['author-link'];

--- a/src/Module/Api/Friendica/Profile/Show.php
+++ b/src/Module/Api/Friendica/Profile/Show.php
@@ -78,7 +78,7 @@ class Show extends BaseApi
 		foreach ($profileFields as $profileField) {
 			$custom_fields[] = [
 				'label' => $profileField->label,
-				'value' => BBCode::convert($profileField->value, false, BBCode::API),
+				'value' => BBCode::convert($profileField->value, false, BBCode::TWITTER_API),
 			];
 		}
 

--- a/src/Object/Api/Mastodon/ScheduledStatus.php
+++ b/src/Object/Api/Mastodon/ScheduledStatus.php
@@ -67,7 +67,7 @@ class ScheduledStatus extends BaseDataTransferObject
 		$this->scheduled_at = DateTimeFormat::utc($delayed_post['delayed'], DateTimeFormat::JSON);
 
 		$this->params = [
-			'text'           => BBCode::convert(BBCode::setMentionsToNicknames($parameters['item']['body'] ?? ''), false, BBCode::API),
+			'text'           => BBCode::convert(BBCode::setMentionsToNicknames($parameters['item']['body'] ?? ''), false, BBCode::MASTODON_API),
 			'media_ids'      => $media_ids,
 			'sensitive'      => null,
 			'spoiler_text'   => $parameters['item']['title'] ?? '',

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -132,7 +132,7 @@ class Status extends BaseDataTransferObject
 		$this->muted = $userAttributes->muted;
 		$this->bookmarked = $userAttributes->bookmarked;
 		$this->pinned = $userAttributes->pinned;
-		$this->content = BBCode::convertForUriId($item['uri-id'], BBCode::setMentionsToNicknames($item['raw-body'] ?? $item['body']), BBCode::API);
+		$this->content = BBCode::convertForUriId($item['uri-id'], BBCode::setMentionsToNicknames($item['raw-body'] ?? $item['body']), BBCode::MASTODON_API);
 		$this->reblog = $reblog;
 		$this->application = $application->toArray();
 		$this->account = $account->toArray();


### PR DESCRIPTION
We now use different BBCode constants to better fulfil the client expectations.