### PR TITLE
Quoted reshares containing quoted reshares should now look fine

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2962,7 +2962,7 @@ class Item
 
 		$body = $item['body'] ?? '';
 
-		$fields = ['uri-id', 'uri', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'network', 'has-media'];
+		$fields = ['uri-id', 'uri', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'network', 'has-media', 'quote-uri-id'];
 
 		$shared_uri_id = 0;
 		$shared_links  = [];


### PR DESCRIPTION
When a Diaspora reshare contained a Friendica quoted reshare with some media, there had been some display problems. This is now fixed.