### PR TITLE
We can now store reports done via API

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2022.12-dev (Giant Rhubarb)
--- DB_UPDATE_VERSION 1488
+-- DB_UPDATE_VERSION 1489
 -- ------------------------------------------
 
 
@@ -1645,6 +1645,35 @@ CREATE TABLE IF NOT EXISTS `register` (
 	 INDEX `uid` (`uid`),
 	FOREIGN KEY (`uid`) REFERENCES `user` (`uid`) ON UPDATE RESTRICT ON DELETE CASCADE
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='registrations requiring admin approval';
+
+--
+-- TABLE report
+--
+CREATE TABLE IF NOT EXISTS `report` (
+	`id` int unsigned NOT NULL auto_increment COMMENT 'sequential ID',
+	`uid` mediumint unsigned NOT NULL COMMENT 'Reporting user',
+	`cid` int unsigned NOT NULL COMMENT 'Reported contact',
+	`comment` text COMMENT 'Report',
+	`forward` boolean COMMENT 'Forward the report to the remote server',
+	`created` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
+	 PRIMARY KEY(`id`),
+	 INDEX `uid` (`uid`),
+	 INDEX `cid` (`cid`),
+	FOREIGN KEY (`uid`) REFERENCES `user` (`uid`) ON UPDATE RESTRICT ON DELETE CASCADE,
+	FOREIGN KEY (`cid`) REFERENCES `contact` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
+) DEFAULT COLLATE utf8mb4_general_ci COMMENT='';
+
+--
+-- TABLE report-post
+--
+CREATE TABLE IF NOT EXISTS `report-post` (
+	`rid` int unsigned NOT NULL COMMENT 'Report id',
+	`uri-id` int unsigned NOT NULL COMMENT 'Uri-id of the reported post',
+	 PRIMARY KEY(`rid`,`uri-id`),
+	 INDEX `uri-id` (`uri-id`),
+	FOREIGN KEY (`rid`) REFERENCES `report` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,
+	FOREIGN KEY (`uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
+) DEFAULT COLLATE utf8mb4_general_ci COMMENT='';
 
 --
 -- TABLE search

--- a/doc/database.md
+++ b/doc/database.md
@@ -74,6 +74,8 @@ Database Tables
 | [profile_field](help/database/db_profile_field) | Custom profile fields |
 | [push_subscriber](help/database/db_push_subscriber) | Used for OStatus: Contains feed subscribers |
 | [register](help/database/db_register) | registrations requiring admin approval |
+| [report](help/database/db_report) |  |
+| [report-post](help/database/db_report-post) |  |
 | [search](help/database/db_search) |  |
 | [session](help/database/db_session) | web session storage |
 | [storage](help/database/db_storage) | Data stored by Database storage backend |

--- a/doc/database/db_report-post.md
+++ b/doc/database/db_report-post.md
@@ -1,0 +1,30 @@
+Table report-post
+===========
+
+
+
+Fields
+------
+
+| Field  | Description                 | Type         | Null | Key | Default | Extra |
+| ------ | --------------------------- | ------------ | ---- | --- | ------- | ----- |
+| rid    | Report id                   | int unsigned | NO   | PRI | NULL    |       |
+| uri-id | Uri-id of the reported post | int unsigned | NO   | PRI | NULL    |       |
+
+Indexes
+------------
+
+| Name    | Fields      |
+| ------- | ----------- |
+| PRIMARY | rid, uri-id |
+| uri-id  | uri-id      |
+
+Foreign Keys
+------------
+
+| Field | Target Table | Target Field |
+|-------|--------------|--------------|
+| rid | [report](help/database/db_report) | id |
+| uri-id | [item-uri](help/database/db_item-uri) | id |
+
+Return to [database documentation](help/database)

--- a/doc/database/db_report.md
+++ b/doc/database/db_report.md
@@ -1,0 +1,35 @@
+Table report
+===========
+
+
+
+Fields
+------
+
+| Field   | Description                             | Type               | Null | Key | Default             | Extra          |
+| ------- | --------------------------------------- | ------------------ | ---- | --- | ------------------- | -------------- |
+| id      | sequential ID                           | int unsigned       | NO   | PRI | NULL                | auto_increment |
+| uid     | Reporting user                          | mediumint unsigned | NO   |     | NULL                |                |
+| cid     | Reported contact                        | int unsigned       | NO   |     | NULL                |                |
+| comment | Report                                  | text               | YES  |     | NULL                |                |
+| forward | Forward the report to the remote server | boolean            | YES  |     | NULL                |                |
+| created |                                         | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
+
+Indexes
+------------
+
+| Name    | Fields |
+| ------- | ------ |
+| PRIMARY | id     |
+| uid     | uid    |
+| cid     | cid    |
+
+Foreign Keys
+------------
+
+| Field | Target Table | Target Field |
+|-------|--------------|--------------|
+| uid | [user](help/database/db_user) | uid |
+| cid | [contact](help/database/db_contact) | id |
+
+Return to [database documentation](help/database)

--- a/src/Moderation/Entity/Report.php
+++ b/src/Moderation/Entity/Report.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Moderation\Entity;
+
+/**
+ * @property-read int            $id
+ * @property-read int            $uid
+ * @property-read int            $cid
+ * @property-read string         $comment
+ * @property-read bool           $forward
+ * @property-read array          $postUriIds
+ * @property-read \DateTime|null $created
+ */
+class Report extends \Friendica\BaseEntity
+{
+	/** @var int|null */
+	protected $id;
+	/** @var int ID of the user making a moderation report*/
+	protected $uid;
+	/** @var int ID of the contact being reported*/
+	protected $cid;
+	/** @var string Optional comment */
+	protected $comment;
+	/** @var bool Whether this report should be forwarded to the remote server */
+	protected $forward;
+	/** @var \DateTime|null When the report was created */
+	protected $created;
+	/** @var array Optional list of URI IDs of posts supporting the report*/
+	protected $postUriIds;
+
+	public function __construct(int $uid, int $cid, \DateTime $created, string $comment = '', bool $forward = false, array $postUriIds = [], int $id = null)
+	{
+		$this->uid        = $uid;
+		$this->cid        = $cid;
+		$this->created    = $created;
+		$this->comment    = $comment;
+		$this->forward    = $forward;
+		$this->postUriIds = $postUriIds;
+		$this->id         = $id;
+	}
+}

--- a/src/Moderation/Factory/Report.php
+++ b/src/Moderation/Factory/Report.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Moderation\Factory;
+
+use Friendica\Capabilities\ICanCreateFromTableRow;
+use Friendica\Moderation\Entity;
+
+class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
+{
+	/**
+	 * @param array $row        `report` table row
+	 * @param array $postUriIds List of post URI ids from the `report-post` table
+	 * @return Entity\Report
+	 * @throws \Exception
+	 */
+	public function createFromTableRow(array $row, array $postUriIds = []): Entity\Report
+	{
+		return new Entity\Report(
+			$row['uid'],
+			$row['cid'],
+			new \DateTime($row['created'] ?? 'now', new \DateTimeZone('UTC')),
+			$row['comment'],
+			$row['forward'],
+			$postUriIds,
+			$row['id'],
+		);
+	}
+
+	/**
+	 * Creates a Report entity from a Mastodon API /reports request
+	 *
+	 * @see \Friendica\Module\Api\Mastodon\Reports::post()
+	 *
+	 * @param int    $uid
+	 * @param int    $cid
+	 * @param string $comment
+	 * @param bool   $forward
+	 * @param array  $postUriIds
+	 * @return Entity\Report
+	 * @throws \Exception
+	 */
+	public function createFromReportsRequest(int $uid, int $cid, string $comment = '', bool $forward = false, array $postUriIds = []): Entity\Report
+	{
+		return new Entity\Report(
+			$uid,
+			$cid,
+			new \DateTime('now', new \DateTimeZone('UTC')),
+			$comment,
+			$forward,
+			$postUriIds,
+		);
+	}
+}

--- a/src/Moderation/Repository/Report.php
+++ b/src/Moderation/Repository/Report.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Moderation\Repository;
+
+use Friendica\BaseEntity;
+use Friendica\Core\Logger;
+use Friendica\Database\Database;
+use Friendica\Model\Post;
+use Friendica\Network\HTTPException\NotFoundException;
+use Friendica\Util\DateTimeFormat;
+use Psr\Log\LoggerInterface;
+
+class Report extends \Friendica\BaseRepository
+{
+	protected static $table_name = 'report';
+
+	/**
+	 * @var \Friendica\Moderation\Factory\Report
+	 */
+	protected $factory;
+
+	public function __construct(Database $database, LoggerInterface $logger, \Friendica\Moderation\Factory\Report $factory)
+	{
+		parent::__construct($database, $logger, $factory);
+
+		$this->factory = $factory;
+	}
+
+	public function selectOneById(int $lastInsertId): \Friendica\Moderation\Factory\Report
+	{
+		return $this->_selectOne(['id' => $lastInsertId]);
+	}
+
+	public function save(\Friendica\Moderation\Entity\Report $Report)
+	{
+		$fields = [
+			'uid'     => $Report->uid,
+			'cid'     => $Report->cid,
+			'comment' => $Report->comment,
+			'forward' => $Report->forward,
+		];
+
+		if ($Report->id) {
+			$this->db->update(self::$table_name, $fields, ['id' => $Report->id]);
+		} else {
+			$fields['created'] = DateTimeFormat::utcNow();
+			$this->db->insert(self::$table_name, $fields, Database::INSERT_IGNORE);
+
+			$Report = $this->selectOneById($this->db->lastInsertId());
+		}
+
+		$this->db->delete('report-post', ['rid' => $Report->id]);
+
+		foreach ($Report->postUriIds as $uriId) {
+			if (Post::exists(['uri-id' => $uriId])) {
+				$this->db->insert('report-post', ['rid' => $Report->id, 'uri-id' => $uriId]);
+			} else {
+				Logger::notice('Post does not exist', ['uri-id' => $uriId, 'report' => $Report]);
+			}
+		}
+
+		return $Report;
+	}
+
+	protected function _selectOne(array $condition, array $params = []): BaseEntity
+	{
+		$fields = $this->db->selectFirst(static::$table_name, [], $condition, $params);
+		if (!$this->db->isResult($fields)) {
+			throw new NotFoundException();
+		}
+
+		$postUriIds = array_column($this->db->selectToArray('report-post', ['uri-id'], ['rid' => $condition['id'] ?? 0]), 'uri-id');
+
+		return $this->factory->createFromTableRow($fields, $postUriIds);
+	}
+}

--- a/src/Module/Api/Mastodon/Reports.php
+++ b/src/Module/Api/Mastodon/Reports.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Module\Api\Mastodon;
+
+use Friendica\App;
+use Friendica\Core\L10n;
+use Friendica\Core\System;
+use Friendica\Model\Contact;
+use Friendica\Module\Api\ApiResponse;
+use Friendica\Module\BaseApi;
+use Friendica\Network\HTTPException;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @see https://docs.joinmastodon.org/methods/accounts/reports/
+ */
+class Reports extends BaseApi
+{
+	/** @var \Friendica\Moderation\Factory\Report */
+	private $reportFactory;
+	/** @var \Friendica\Moderation\Repository\Report */
+	private $reportRepo;
+
+	public function __construct(\Friendica\Moderation\Repository\Report $reportRepo, \Friendica\Moderation\Factory\Report $reportFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	{
+		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+
+		$this->reportFactory = $reportFactory;
+		$this->reportRepo    = $reportRepo;
+	}
+
+	public function post(array $request = [])
+	{
+		self::checkAllowedScope(self::SCOPE_WRITE);
+
+		$request = $this->getRequest([
+			'account_id' => '',    // ID of the account to report
+			'status_ids' => [],    // Array of Statuses to attach to the report, for context
+			'comment'    => '',    // Reason for the report (default max 1000 characters)
+			'forward'    => false, // If the account is remote, should the report be forwarded to the remote admin?
+		], $request);
+
+		$contact = Contact::getById($request['account_id'], ['id']);
+		if (empty($contact)) {
+			throw new HTTPException\NotFoundException('Account ' . $request['account_id'] . ' not found');
+		}
+
+		$report = $this->reportFactory->createFromReportsRequest(self::getCurrentUserID(), $request['account_id'], $request['comment'], $request['forward'], $request['status_ids']);
+
+		$this->reportRepo->save($report);
+
+		System::jsonExit([]);
+	}
+}

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1488);
+	define('DB_UPDATE_VERSION', 1489);
 }
 
 return [
@@ -1647,6 +1647,33 @@ return [
 		"indexes" => [
 			"PRIMARY" => ["id"],
 			"uid" => ["uid"],
+		]
+	],
+	"report" => [
+		"comment" => "",
+		"fields" => [
+			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => "sequential ID"],
+			"uid" => ["type" => "mediumint unsigned", "not null" => "1", "foreign" => ["user" => "uid"], "comment" => "Reporting user"],
+			"cid" => ["type" => "int unsigned", "not null" => "1", "foreign" => ["contact" => "id"], "comment" => "Reported contact"],
+			"comment" => ["type" => "text", "comment" => "Report"],
+			"forward" => ["type" => "boolean", "comment" => "Forward the report to the remote server"],
+			"created" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => ""],
+		],
+		"indexes" => [
+			"PRIMARY" => ["id"],
+			"uid" => ["uid"],
+			"cid" => ["cid"],
+		]
+	],
+	"report-post" => [
+		"comment" => "",
+		"fields" => [
+			"rid" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["report" => "id"], "comment" => "Report id"],
+			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Uri-id of the reported post"],
+		],
+		"indexes" => [
+			"PRIMARY" => ["rid", "uri-id"],
+			"uri-id" => ["uri-id"],
 		]
 	],
 	"search" => [

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -256,7 +256,7 @@ return [
 			'/polls/{id:\d+}/votes'              => [Module\Api\Mastodon\Unimplemented::class,            [        R::POST]], // not supported
 			'/preferences'                       => [Module\Api\Mastodon\Preferences::class,              [R::GET         ]],
 			'/push/subscription'                 => [Module\Api\Mastodon\PushSubscription::class,         [R::GET, R::POST, R::PUT, R::DELETE]],
-			'/reports'                           => [Module\Api\Mastodon\Unimplemented::class,            [        R::POST]], // not supported
+			'/reports'                           => [Module\Api\Mastodon\Reports::class,                  [        R::POST]],
 			'/scheduled_statuses'                => [Module\Api\Mastodon\ScheduledStatuses::class,        [R::GET         ]],
 			'/scheduled_statuses/{id:\d+}'       => [Module\Api\Mastodon\ScheduledStatuses::class,        [R::GET, R::PUT, R::DELETE]],
 			'/statuses'                          => [Module\Api\Mastodon\Statuses::class,                 [        R::POST]],

--- a/tests/src/Moderation/Factory/ReportTest.php
+++ b/tests/src/Moderation/Factory/ReportTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Test\src\Moderation\Factory;
+
+use Friendica\Moderation\Factory;
+use Friendica\Moderation\Entity;
+use Friendica\Test\MockedTest;
+use Psr\Log\NullLogger;
+
+class ReportTest extends MockedTest
+{
+	public function dataCreateFromTableRow(): array
+	{
+		return [
+			'default' => [
+				'row' => [
+					'id'      => 11,
+					'uid'     => 12,
+					'cid'     => 13,
+					'comment' => '',
+					'forward' => false,
+					'created' => null
+				],
+				'postUriIds' => [],
+				'assertion'  => new Entity\Report(
+					12,
+					13,
+					new \DateTime('now', new \DateTimeZone('UTC')),
+					'',
+					false,
+					[],
+					11,
+				),
+			],
+			'full' => [
+				'row' => [
+					'id'      => 11,
+					'uid'     => 12,
+					'cid'     => 13,
+					'comment' => 'Report',
+					'forward' => true,
+					'created' => '2021-10-12 12:23:00'
+				],
+				'postUriIds' => [89, 90],
+				'assertion'  => new Entity\Report(
+					12,
+					13,
+					new \DateTime('2021-10-12 12:23:00', new \DateTimeZone('UTC')),
+					'Report',
+					true,
+					[89, 90],
+					11
+				),
+			],
+		];
+	}
+
+	public function assertReport(Entity\Report $assertion, Entity\Report $report)
+	{
+		self::assertEquals(
+			$assertion->id,
+			$report->id
+		);
+		self::assertEquals($assertion->uid, $report->uid);
+		self::assertEquals($assertion->cid, $report->cid);
+		self::assertEquals($assertion->comment, $report->comment);
+		self::assertEquals($assertion->forward, $report->forward);
+		// No way to test "now" at the moment
+		//self::assertEquals($assertion->created, $report->created);
+		self::assertEquals($assertion->postUriIds, $report->postUriIds);
+	}
+
+	/**
+	 * @dataProvider dataCreateFromTableRow
+	 */
+	public function testCreateFromTableRow(array $row, array $postUriIds, Entity\Report $assertion)
+	{
+		$factory = new Factory\Report(new NullLogger());
+
+		$this->assertReport($factory->createFromTableRow($row, $postUriIds), $assertion);
+	}
+
+	public function dataCreateFromReportsRequest(): array
+	{
+		return [
+			'default' => [
+				'uid'        => 12,
+				'cid'        => 13,
+				'comment'    => '',
+				'forward'    => false,
+				'postUriIds' => [],
+				'assertion'  => new Entity\Report(
+					12,
+					13,
+					new \DateTime('now', new \DateTimeZone('UTC')),
+					'',
+					false,
+					[],
+					null
+				),
+			],
+			'full' => [
+				'uid'        => 12,
+				'cid'        => 13,
+				'comment'    => 'Report',
+				'forward'    => true,
+				'postUriIds' => [89, 90],
+				'assertion'  => new Entity\Report(
+					12,
+					13,
+					new \DateTime('now', new \DateTimeZone('UTC')),
+					'Report',
+					true,
+					[89, 90],
+					null
+				),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataCreateFromReportsRequest
+	 */
+	public function testCreateFromReportsRequest(int $uid, int $cid, string $comment, bool $forward, array $postUriIds, Entity\Report $assertion)
+	{
+		$factory = new Factory\Report(new NullLogger());
+
+		$this->assertReport($factory->createFromReportsRequest($uid, $cid, $comment, $forward, $postUriIds), $assertion);
+	}
+}


### PR DESCRIPTION
This is the first step for a better way to report posts. We now store reports that have been done via the API. We don't do anything with them by now.

This PR is done in such an early state since I wanted to layout the general structure of reports so that it can be picked up by someone who is better in UI than me :-)