### PR TITLE
Avoid duplicate media elements

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2995,14 +2995,14 @@ class Item
 		if (!empty($shared_item['uri-id'])) {
 			$shared_uri_id = $shared_item['uri-id'];
 			$shared_links[] = strtolower($shared_item['plink']);
-			$shared_attachments = Post\Media::splitAttachments($shared_uri_id, $shared_item['guid'], [], $shared_item['has-media']);
+			$shared_attachments = Post\Media::splitAttachments($shared_uri_id, [], $shared_item['has-media']);
 			$shared_links = array_merge($shared_links, array_column($shared_attachments['visual'], 'url'));
 			$shared_links = array_merge($shared_links, array_column($shared_attachments['link'], 'url'));
 			$shared_links = array_merge($shared_links, array_column($shared_attachments['additional'], 'url'));
 			$item['body'] = self::replaceVisualAttachments($shared_attachments, $item['body']);
 		}
 
-		$attachments = Post\Media::splitAttachments($item['uri-id'], $item['guid'] ?? '', $shared_links, $item['has-media'] ?? false);
+		$attachments = Post\Media::splitAttachments($item['uri-id'], $shared_links, $item['has-media'] ?? false);
 		$item['body'] = self::replaceVisualAttachments($attachments, $item['body'] ?? '');
 
 		$item['body'] = preg_replace("/\s*\[attachment .*?\].*?\[\/attachment\]\s*/ism", "\n", $item['body']);
@@ -3184,6 +3184,9 @@ class Item
 
 			if (!empty($attachment['preview'])) {
 				$preview_url = Post\Media::getPreviewUrlForId($attachment['id'], Proxy::SIZE_LARGE);
+				if (self::containsLink($item['body'], $preview_url)) {
+					continue;
+				}
 			} else {
 				$preview_url = '';
 			}

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -642,12 +642,11 @@ class Media
 	 * Split the attachment media in the three segments "visual", "link" and "additional"
 	 *
 	 * @param int    $uri_id URI id
-	 * @param string $guid GUID
 	 * @param array  $links list of links that shouldn't be added
 	 * @param bool   $has_media
 	 * @return array attachments
 	 */
-	public static function splitAttachments(int $uri_id, string $guid = '', array $links = [], bool $has_media = true): array
+	public static function splitAttachments(int $uri_id, array $links = [], bool $has_media = true): array
 	{
 		$attachments = ['visual' => [], 'link' => [], 'additional' => []];
 


### PR DESCRIPTION
This fixes the problem that sometimes images in shared posts have been duplicated.