### PR TITLE
Allow anonymous reports

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2022.12-dev (Giant Rhubarb)
--- DB_UPDATE_VERSION 1489
+-- DB_UPDATE_VERSION 1490
 -- ------------------------------------------
 
 
@@ -1651,7 +1651,7 @@ CREATE TABLE IF NOT EXISTS `register` (
 --
 CREATE TABLE IF NOT EXISTS `report` (
 	`id` int unsigned NOT NULL auto_increment COMMENT 'sequential ID',
-	`uid` mediumint unsigned NOT NULL COMMENT 'Reporting user',
+	`uid` mediumint unsigned COMMENT 'Reporting user',
 	`cid` int unsigned NOT NULL COMMENT 'Reported contact',
 	`comment` text COMMENT 'Report',
 	`forward` boolean COMMENT 'Forward the report to the remote server',

--- a/doc/database/db_report.md
+++ b/doc/database/db_report.md
@@ -9,7 +9,7 @@ Fields
 | Field   | Description                             | Type               | Null | Key | Default             | Extra          |
 | ------- | --------------------------------------- | ------------------ | ---- | --- | ------------------- | -------------- |
 | id      | sequential ID                           | int unsigned       | NO   | PRI | NULL                | auto_increment |
-| uid     | Reporting user                          | mediumint unsigned | NO   |     | NULL                |                |
+| uid     | Reporting user                          | mediumint unsigned | YES  |     | NULL                |                |
 | cid     | Reported contact                        | int unsigned       | NO   |     | NULL                |                |
 | comment | Report                                  | text               | YES  |     | NULL                |                |
 | forward | Forward the report to the remote server | boolean            | YES  |     | NULL                |                |

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1489);
+	define('DB_UPDATE_VERSION', 1490);
 }
 
 return [
@@ -1653,7 +1653,7 @@ return [
 		"comment" => "",
 		"fields" => [
 			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => "sequential ID"],
-			"uid" => ["type" => "mediumint unsigned", "not null" => "1", "foreign" => ["user" => "uid"], "comment" => "Reporting user"],
+			"uid" => ["type" => "mediumint unsigned", "foreign" => ["user" => "uid"], "comment" => "Reporting user"],
 			"cid" => ["type" => "int unsigned", "not null" => "1", "foreign" => ["contact" => "id"], "comment" => "Reported contact"],
 			"comment" => ["type" => "text", "comment" => "Report"],
 			"forward" => ["type" => "boolean", "comment" => "Forward the report to the remote server"],


### PR DESCRIPTION
Reports from external systems are anonymous, they aren't connected to a user. So the `uid` value can be `null` here.