### PR TITLE
Fix memory issue on displaying conversations

### DIFF
--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -970,7 +970,7 @@ class Conversation
 		}
 
 		$condition = DBA::mergeConditions($condition,
-			["`uid` IN (0, ?) AND (`vid` != ? OR `vid` IS NULL)", $uid, Verb::getID(Activity::FOLLOW)]);
+			["`uid` IN (0, ?) AND (NOT `vid` IN (?, ?) OR `vid` IS NULL)", $uid, Verb::getID(Activity::FOLLOW), Verb::getID(Activity::VIEW)]);
 
 		$thread_parents = Post::select(['uri-id', 'causer-id'], $condition, ['order' => ['uri-id' => false, 'uid']]);
 

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -200,6 +200,8 @@ class Summary extends BaseAdmin
 		$server_settings = [
 			'label' => DI::l10n()->t('Server Settings'),
 			'php'   => [
+				'version'             => phpversion(),
+				'php.ini'             => php_ini_loaded_file(),
 				'upload_max_filesize' => ini_get('upload_max_filesize'),
 				'post_max_size'       => ini_get('post_max_size'),
 				'memory_limit'        => ini_get('memory_limit')


### PR DESCRIPTION
A video with more than 83,000 views broke the memory limit on my machine. For now we simply don't fetch thjs activity. But for the future we will need a better way to fetch posts and activities, since there will be posts with some thousand likes.