### PR TITLE
Improve error message when conversation isn't available in Module\Item\Display

### DIFF
--- a/src/Module/Item/Display.php
+++ b/src/Module/Item/Display.php
@@ -136,7 +136,7 @@ class Display extends BaseModule
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {
-			$parent = Post::selectFirstForUser($itemUid, $fields, [
+			$parent = Post::selectFirst($fields, [
 				'uid'    => [0, $itemUid],
 				'uri-id' => $item['parent-uri-id']
 			], ['order' => ['uid' => true]]);
@@ -249,7 +249,15 @@ class Display extends BaseModule
 		$item = Post::selectFirstForUser($pageUid, $fields, $condition);
 
 		if (empty($item)) {
-			throw new HTTPException\NotFoundException($this->t('The requested item doesn\'t exist or has been deleted.'));
+			$this->page['aside'] = '';
+			throw new HTTPException\NotFoundException($this->t('Unfortunately, the requested conversation isn\'t available to you.</p>
+<p>Possible reasons include:</p>
+<ul>
+	<li>The top-level post isn\'t visible.</li>
+	<li>The top-level post was deleted.</li>
+	<li>The node has blocked the top-level author or the author of the shared post.</li>
+	<li>You have ignored or blocked the top-level author or the author of the shared post.</li>
+</ul><p>'));
 		}
 
 		$item['uri-id'] = $item['parent-uri-id'];

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.12-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-19 07:52-0500\n"
+"POT-Creation-Date: 2022-11-19 12:01-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -7089,9 +7089,22 @@ msgid ""
 "<a href=\"/settings/display\">Theme Customization settings</a>."
 msgstr ""
 
-#: src/Module/Item/Display.php:135 src/Module/Item/Display.php:252
-#: src/Module/Update/Display.php:55
+#: src/Module/Item/Display.php:135 src/Module/Update/Display.php:55
 msgid "The requested item doesn't exist or has been deleted."
+msgstr ""
+
+#: src/Module/Item/Display.php:253
+msgid ""
+"Unfortunately, the requested conversation isn't available to you.</p>\n"
+"<p>Possible reasons include:</p>\n"
+"<ul>\n"
+"\t<li>The top-level post isn't visible.</li>\n"
+"\t<li>The top-level post was deleted.</li>\n"
+"\t<li>The node has blocked the top-level author or the author of the shared "
+"post.</li>\n"
+"\t<li>You have ignored or blocked the top-level author or the author of the "
+"shared post.</li>\n"
+"</ul><p>"
 msgstr ""
 
 #: src/Module/Item/Feed.php:86

--- a/view/templates/exception.tpl
+++ b/view/templates/exception.tpl
@@ -1,7 +1,7 @@
 <div id="exception" class="generic-page-wrapper">
     <img class="hare" src="images/friendica-404_svg_flexy-o-hare.png"/>
     <h1>{{$title}}</h1>
-    <p>{{$message}}</p>
+    <p>{{$message nofilter}}</p>
 {{if $thrown}}
 	<pre>{{$thrown}}
 {{$stack_trace}}


### PR DESCRIPTION
- Retrieve the parent post no matter what. Previously it was depending on the user's settings, which gave unpredictable behavior if the parent post wasn't retrieved for whatever reason.
- List possible reasons the conversation isn't showing up based on the condition in `Model\Post::selectViewForUser`
- Allow HTML in exception messages

Fixes #12059, or rather is a workaround. Ideally the conversation would show no matter what in `/display`, but it uses the same code to select posts as in the `/network` page where it should honor user/node moderation choices.