### PR TITLE
When finding a duplicate contact, delete the duplicate instead of the contact that was just created

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -187,9 +187,8 @@ class Contact
 		} elseif ($account_user['id'] != $contact['id']) {
 			$duplicate = DBA::selectFirst('contact', [], ['id' => $account_user['id'], 'deleted' => false]);
 			if (!empty($duplicate['id'])) {
-				$ret = Contact::deleteById($contact['id']);
+				$ret = Contact::deleteById($duplicate['id']);
 				Logger::notice('Deleted duplicated contact', ['ret' => $ret, 'account-user' => $account_user, 'cid' => $duplicate['id'], 'uid' => $duplicate['uid'], 'uri-id' => $duplicate['uri-id'], 'url' => $duplicate['url']]);
-				$contact = $duplicate;
 			} else {
 				$ret = DBA::update('account-user', ['id' => $contact['id']], ['uid' => $contact['uid'], 'uri-id' => $contact['uri-id']]);
 				Logger::notice('Updated account-user', ['ret' => $ret, 'account-user' => $account_user, 'cid' => $contact['id'], 'uid' => $contact['uid'], 'uri-id' => $contact['uri-id'], 'url' => $contact['url']]);


### PR DESCRIPTION
- This was preventing a system contact to be created over and over again

Related to #12185 

Expanded reasoning: If a new contact was created, it means that the existing one couldn't be retrieved for some reason. Creating a new one and deleting the old one ensures that the new contact will be retrieved from now on.

I'm not sure how often this happens and it may break existing relationships but it will prevent this kind of infinite loop.