### PR TITLE
Prevent division by zero in Mastodon Attachment.

### DIFF
--- a/src/Object/Api/Mastodon/Attachment.php
+++ b/src/Object/Api/Mastodon/Attachment.php
@@ -63,15 +63,19 @@ class Attachment extends BaseDataTransferObject
 		$this->text_url = $this->remote_url ?? $this->url;
 		$this->description = $attachment['description'];
 		if ($type === 'image') {
-			$this->meta['original']['width'] = (int) $attachment['width'];
-			$this->meta['original']['height'] = (int) $attachment['height'];
-			$this->meta['original']['size'] = (int) $attachment['width'] . 'x' . (int) $attachment['height'];
-			$this->meta['original']['aspect'] = (float) ((int)  $attachment['width'] / (int) $attachment['height']);
+			if ((int) $attachment['width'] > 0 && (int) $attachment['height'] > 0) {
+				$this->meta['original']['width'] = (int) $attachment['width'];
+				$this->meta['original']['height'] = (int) $attachment['height'];
+				$this->meta['original']['size'] = (int) $attachment['width'] . 'x' . (int) $attachment['height'];
+				$this->meta['original']['aspect'] = (float) ((int)  $attachment['width'] / (int) $attachment['height']);
+			}
 
-			$this->meta['small']['width'] = (int) $attachment['preview-width'];
-			$this->meta['small']['height'] = (int) $attachment['preview-height'];
-			$this->meta['small']['size'] = (int) $attachment['preview-width'] . 'x' . (int) $attachment['preview-height'];
-			$this->meta['small']['aspect'] = (float) ((int)  $attachment['preview-width'] / (int) $attachment['preview-height']);
+			if ((int) $attachment['preview-width'] > 0 && (int) $attachment['preview-height'] > 0) {
+				$this->meta['small']['width'] = (int) $attachment['preview-width'];
+				$this->meta['small']['height'] = (int) $attachment['preview-height'];
+				$this->meta['small']['size'] = (int) $attachment['preview-width'] . 'x' . (int) $attachment['preview-height'];
+				$this->meta['small']['aspect'] = (float) ((int)  $attachment['preview-width'] / (int) $attachment['preview-height']);
+			}
 		}
 	}
 


### PR DESCRIPTION
This will prevent the division by zero. But this will only fight the symtom. How can an image have a height or a width matching 0? Maybe there is an issue while creating the database entry.