### PR TITLE
Add support for Mastodon /authorize_interaction route

### DIFF
--- a/src/Module/Contact/Follow.php
+++ b/src/Module/Contact/Follow.php
@@ -88,7 +88,9 @@ class Follow extends BaseModule
 		}
 
 		$uid = $this->session->getLocalUserId();
-		$url = Probe::cleanURI(trim($request['url'] ?? ''));
+
+		// uri is used by the /authorize_interaction Mastodon route
+		$url = Probe::cleanURI(trim($request['uri'] ?? $request['url'] ?? ''));
 
 		// Issue 6874: Allow remote following from Peertube
 		if (strpos($url, 'acct:') === 0) {

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -342,6 +342,10 @@ return [
 	'/acctlink'            => [Module\Acctlink::class,     [R::GET]],
 	'/apps'                => [Module\Apps::class,         [R::GET]],
 	'/attach/{item:\d+}'   => [Module\Attach::class,       [R::GET]],
+
+	// Mastodon route used by Fedifind to follow people who set their Webfinger address in their Twitter bio
+	'/authorize_interaction' => [Module\Contact\Follow::class, [R::GET, R::POST]],
+
 	'/babel'               => [Module\Debug\Babel::class,  [R::GET, R::POST]],
 	'/debug/ap'            => [Module\Debug\ActivityPubConversion::class,  [R::GET, R::POST]],
 


### PR DESCRIPTION
- It is used by Fedifind to follow people who set their Webfinger address in their Twitter bio

Close #12220 