### PR TITLE
Create /profile/{nickname}/photos route

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -50,7 +50,7 @@ We recommend to talk to the admin(s) of the affected friendica server. (Admins, 
 ### How can I upload images, files, links, videos and sound files to posts?
 
 You can upload images from your computer using the [editor](help/Text_editor).
-An overview of all uploaded images is listed at *yourpage.com/photos/profilename*.
+An overview of all uploaded images is listed at *yourpage.com/profile/profilename/photos*.
 On that page, you can also upload images directly and choose if your contacts will receive a message about this upload.
 
 Generally, you can attach any kind of file to a post.

--- a/doc/de/FAQ.md
+++ b/doc/de/FAQ.md
@@ -69,7 +69,7 @@ Andere erlauben nur kostenpflichtige Zertifikate als eigenes Angebot bzw. von an
 ### Wie kann ich Bilder, Dateien, Links, Video und Audio in Beiträge einfügen?
 
 Bilder können direkt im [Beitragseditor](help/Text_editor) vom Computer hochgeladen werden.
-Eine Übersicht aller Bilder, die auf Deinem Server liegen, findest Du unter <i>deineSeite.de/photos/profilname</i>.
+Eine Übersicht aller Bilder, die auf Deinem Server liegen, findest Du unter <i>deineSeite.de/profile/profilname/photos</i>.
 Dort kannst Du auch direkt Bilder hochladen und festlegen, ob Deine Kontakte eine Nachricht über das neue Bild bekommen.
 
 Alle Arten von Dateien können grundsätzlich als Anhang in Friendica hochgeladen werden.

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -361,7 +361,7 @@ class Item
 
 		if ($sparkle) {
 			$status_link = $profile_link . '/status';
-			$photos_link = str_replace('/profile/', '/photos/', $profile_link);
+			$photos_link = $profile_link . '/photos';
 			$profile_link = $profile_link . '/profile';
 		}
 
@@ -729,7 +729,7 @@ class Item
 					'message_id' => $shared['uri'],
 					'comment'    => $item['body'],
 					'shared'     => $shared['body'],
-				];				
+				];
 			}
 		}
 
@@ -737,7 +737,7 @@ class Item
 	}
 
 	/**
-	 * Add a link to a shared post at the end of the post 
+	 * Add a link to a shared post at the end of the post
 	 *
 	 * @param string  $body
 	 * @param integer $quote_uri_id

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -192,7 +192,7 @@ class Nav
 			// user menu
 			$nav['usermenu'][] = ['profile/' . $a->getLoggedInUserNickname(), DI::l10n()->t('Status'), '', DI::l10n()->t('Your posts and conversations')];
 			$nav['usermenu'][] = ['profile/' . $a->getLoggedInUserNickname() . '/profile', DI::l10n()->t('Profile'), '', DI::l10n()->t('Your profile page')];
-			$nav['usermenu'][] = ['photos/' . $a->getLoggedInUserNickname(), DI::l10n()->t('Photos'), '', DI::l10n()->t('Your photos')];
+			$nav['usermenu'][] = ['profile/' . $a->getLoggedInUserNickname() . '/photos', DI::l10n()->t('Photos'), '', DI::l10n()->t('Your photos')];
 			$nav['usermenu'][] = ['profile/' . $a->getLoggedInUserNickname() . '/media', DI::l10n()->t('Media'), '', DI::l10n()->t('Your postings with media')];
 			$nav['usermenu'][] = ['calendar/', DI::l10n()->t('Calendar'), '', DI::l10n()->t('Your calendar')];
 			$nav['usermenu'][] = ['notes/', DI::l10n()->t('Personal notes'), '', DI::l10n()->t('Your personal notes')];

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1158,7 +1158,7 @@ class Contact
 
 		if ($sparkle) {
 			$status_link = $profile_link . '/status';
-			$photos_link = str_replace('/profile/', '/photos/', $profile_link);
+			$photos_link = $profile_link . '/photos';
 			$profile_link = $profile_link . '/profile';
 		}
 

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -1130,8 +1130,8 @@ class Photo
 		$picture['height']      = $photo['height'];
 		$picture['type']        = $photo['type'];
 		$picture['albumpage']   = DI::baseUrl() . '/photos/' . $user['nickname'] . '/image/' . $resource_id;
-		$picture['picture']     = DI::baseUrl() . '/photo/{$resource_id}-0.' . $image->getExt();
-		$picture['preview']     = DI::baseUrl() . '/photo/{$resource_id}-{$smallest}.' . $image->getExt();
+		$picture['picture']     = DI::baseUrl() . '/photo/' . $resource_id . '-0.' . $image->getExt();
+		$picture['preview']     = DI::baseUrl() . '/photo/' . $resource_id . '-' . $smallest . '.' . $image->getExt();
 
 		Logger::info('upload done', ['picture' => $picture]);
 		return $picture;
@@ -1272,4 +1272,3 @@ class Photo
 		return $resource_id;
 	}
 }
-

--- a/src/Module/BaseProfile.php
+++ b/src/Module/BaseProfile.php
@@ -62,7 +62,7 @@ class BaseProfile extends BaseModule
 			],
 			[
 				'label' => DI::l10n()->t('Photos'),
-				'url'   => DI::baseUrl() . '/photos/' . $nickname,
+				'url'   => $baseProfileUrl . '/photos',
 				'sel'   => $current == 'photos' ? 'active' : '',
 				'title' => DI::l10n()->t('Photo Albums'),
 				'id'    => 'photo-tab',
@@ -78,7 +78,7 @@ class BaseProfile extends BaseModule
 			],
 		];
 
-		// the calendar link for the full featured events calendar
+		// the calendar link for the full-featured events calendar
 		if ($is_owner && $a->getThemeInfoValue('events_in_profile')) {
 			$tabs[] = [
 				'label' => DI::l10n()->t('Calendar'),

--- a/src/Module/Profile/Photos/Index.php
+++ b/src/Module/Profile/Photos/Index.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Module\Profile\Photos;
+
+use Friendica\App;
+use Friendica\Content\Pager;
+use Friendica\Content\Widget;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\L10n;
+use Friendica\Core\Renderer;
+use Friendica\Core\Session\Capability\IHandleUserSessions;
+use Friendica\Database\Database;
+use Friendica\Model\Contact;
+use Friendica\Model\Photo;
+use Friendica\Model\Profile;
+use Friendica\Model\User;
+use Friendica\Module\Response;
+use Friendica\Network\HTTPException;
+use Friendica\Security\Security;
+use Friendica\Util\Images;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
+class Index extends \Friendica\Module\BaseProfile
+{
+	/** @var IHandleUserSessions */
+	private $session;
+	/** @var App\Page */
+	private $page;
+	/** @var IManageConfigValues */
+	private $config;
+	/** @var App */
+	private $app;
+	/** @var Database */
+	private $database;
+
+	public function __construct(Database $database, App $app, IManageConfigValues $config, App\Page $page, IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	{
+		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+
+		$this->session  = $session;
+		$this->page     = $page;
+		$this->config   = $config;
+		$this->app      = $app;
+		$this->database = $database;
+	}
+
+	protected function content(array $request = []): string
+	{
+		parent::content($request);
+
+		if ($this->config->get('system', 'block_public') && !$this->session->isAuthenticated()) {
+			throw new HttpException\ForbiddenException($this->t('Public access denied.'));
+		}
+
+		$owner = User::getOwnerDataByNick($this->parameters['nickname']);
+		if (!isset($owner['account_removed']) || $owner['account_removed']) {
+			throw new HTTPException\NotFoundException($this->t('User not found.'));
+		}
+
+		$owner_uid = $owner['uid'];
+		$is_owner  = $this->session->getLocalUserId() && ($this->session->getLocalUserId() == $owner_uid);
+
+		$remote_contact = false;
+		if ($this->session->getRemoteContactID($owner_uid)) {
+			$contact_id = $this->session->getRemoteContactID($owner_uid);
+
+			$contact        = Contact::getContactForUser($contact_id, $owner_uid, ['blocked', 'pending']);
+			$remote_contact = $contact && !$contact['blocked'] && !$contact['pending'];
+		}
+
+		if ($owner['hidewall'] && !$is_owner && !$remote_contact) {
+			throw new HttpException\ForbiddenException($this->t('Access to this item is restricted.'));
+		}
+
+		$this->session->set('photo_return', $this->args->getCommand());
+
+		$sql_extra = Security::getPermissionsSQLByUserId($owner_uid);
+
+		$photo = $this->database->toArray($this->database->p(
+			"SELECT COUNT(DISTINCT `resource-id`) AS `count`
+			FROM `photo`
+			WHERE `uid` = ?
+			  AND `photo-type` = ?
+			  $sql_extra",
+			$owner['uid'],
+			Photo::DEFAULT,
+		));
+		$total = $photo[0]['count'];
+
+		$pager = new Pager($this->l10n, $this->args->getQueryString(), 20);
+
+		$photos = $this->database->toArray($this->database->p(
+			"SELECT
+				`resource-id`,
+				ANY_VALUE(`id`) AS `id`,
+				ANY_VALUE(`filename`) AS `filename`,
+				ANY_VALUE(`type`) AS `type`,
+				ANY_VALUE(`album`) AS `album`,
+				max(`scale`) AS `scale`,
+				ANY_VALUE(`created`) AS `created`
+			FROM `photo`
+			WHERE `uid` = ?
+			  AND `photo-type` = ?
+			  $sql_extra
+			GROUP BY `resource-id`
+			ORDER BY `created` DESC
+		    LIMIT ? , ?",
+			$owner['uid'],
+			Photo::DEFAULT,
+			$pager->getStart(),
+			$pager->getItemsPerPage()
+		));
+
+		$phototypes = Images::supportedTypes();
+
+		$photos = array_map(function ($photo) use ($owner, $phototypes) {
+			return [
+				'id'    => $photo['id'],
+				'link'  => 'photos/' . $owner['nickname'] . '/image/' . $photo['resource-id'],
+				'title' => $this->t('View Photo'),
+				'src'   => 'photo/' . $photo['resource-id'] . '-' . ((($photo['scale']) == 6) ? 4 : $photo['scale']) . '.' . $phototypes[$photo['type']],
+				'alt'   => $photo['filename'],
+				'album' => [
+					'link' => 'photos/' . $owner['nickname'] . '/album/' . bin2hex($photo['album']),
+					'name' => $photo['album'],
+					'alt'  => $this->t('View Album'),
+				],
+			];
+		}, $photos);
+
+		$tpl = Renderer::getMarkupTemplate('photos_head.tpl');
+		$this->page['htmlhead'] .= Renderer::replaceMacros($tpl, [
+			'$ispublic' => $this->t('everybody')
+		]);
+
+		if ($albums = Photo::getAlbums($owner['uid'])) {
+			$albums = array_map(function ($album) use ($owner) {
+				return [
+					'text'      => $album['album'],
+					'total'     => $album['total'],
+					'url'       => 'photos/' . $owner['nickname'] . '/album/' . bin2hex($album['album']),
+					'urlencode' => urlencode($album['album']),
+					'bin2hex'   => bin2hex($album['album'])
+				];
+			}, $albums);
+
+			$photo_albums_widget = Renderer::replaceMacros(Renderer::getMarkupTemplate('photo_albums.tpl'), [
+				'$nick'     => $owner['nickname'],
+				'$title'    => $this->t('Photo Albums'),
+				'$recent'   => $this->t('Recent Photos'),
+				'$albums'   => $albums,
+				'$upload'   => [$this->t('Upload New Photos'), 'photos/' . $owner['nickname'] . '/upload'],
+				'$can_post' => $this->session->getLocalUserId() && $owner['uid'] == $this->session->getLocalUserId(),
+			]);
+		}
+
+		$this->page['aside'] .= Widget\VCard::getHTML($owner);
+
+		if (!empty($photo_albums_widget)) {
+			$this->page['aside'] .= $photo_albums_widget;
+		}
+
+		$o = self::getTabsHTML($this->app, 'photos', $is_owner, $owner['nickname'], Profile::getByUID($owner['uid'])['hide-friends'] ?? false);
+
+		$tpl = Renderer::getMarkupTemplate('photos_recent.tpl');
+		$o .= Renderer::replaceMacros($tpl, [
+			'$title'    => $this->t('Recent Photos'),
+			'$can_post' => $is_owner || $remote_contact && $owner['page-flags'] == User::PAGE_FLAGS_COMMUNITY,
+			'$upload'   => [$this->t('Upload New Photos'), 'photos/' . $owner['nickname'] . '/upload'],
+			'$photos'   => $photos,
+			'$paginate' => $pager->renderFull($total),
+		]);
+
+		return $o;
+	}
+}

--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -230,7 +230,7 @@ class Index extends BaseSettings
 			'$banner' => DI::l10n()->t('Edit Profile Details'),
 			'$submit' => DI::l10n()->t('Submit'),
 			'$profpic' => DI::l10n()->t('Change Profile Photo'),
-			'$profpiclink' => '/photos/' . $profile['nickname'],
+			'$profpiclink' => '/profile/' . $profile['nickname'] . '/photos',
 			'$viewprof' => DI::l10n()->t('View Profile'),
 
 			'$lbl_personal_section' => DI::l10n()->t('Personal'),

--- a/src/Module/Settings/Profile/Photo/Index.php
+++ b/src/Module/Settings/Profile/Photo/Index.php
@@ -132,7 +132,7 @@ class Index extends BaseSettings
 				DI::l10n()->t('or'),
 				($newuser) ?
 					'<a href="' . DI::baseUrl() . '">' . DI::l10n()->t('skip this step') . '</a>'
-					: '<a href="' . DI::baseUrl() . '/photos/' . DI::app()->getLoggedInUserNickname() . '">'
+					: '<a href="' . DI::baseUrl() . '/profile/' . DI::app()->getLoggedInUserNickname() . '/photos">'
 						. DI::l10n()->t('select a photo from your photo albums') . '</a>'
 			),
 		]);

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -36,6 +36,7 @@ $profileRoutes = [
 	'/contacts/common'                         => [Module\Profile\Common::class,            [R::GET]],
 	'/contacts[/{type}]'                       => [Module\Profile\Contacts::class,          [R::GET]],
 	'/media'                                   => [Module\Profile\Media::class,             [R::GET]],
+	'/photos'                                  => [Module\Profile\Photos\Index::class,      [R::GET         ]],
 	'/photos/upload'                           => [Module\Profile\Photos\Upload::class,     [        R::POST]],
 	'/profile'                                 => [Module\Profile\Profile::class,           [R::GET]],
 	'/remote_follow'                           => [Module\Profile\RemoteFollow::class,      [R::GET, R::POST]],
@@ -552,6 +553,10 @@ return [
 		'/{type}/{customsize:\d+}/{uid_ext:\d+\..*}'               => [Module\Photo::class, [R::GET]],
 		'/{type}/{customsize:\d+}/{nickname_ext}'                  => [Module\Photo::class, [R::GET]],
 	],
+
+	// Kept for backwards-compatibility
+	// @TODO remove by version 2023.12
+	'/photos/{nickname}' => [Module\Profile\Photos\Index::class, [R::GET]],
 
 	'/ping'              => [Module\Notifications\Ping::class, [R::GET]],
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.12-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-19 12:01-0500\n"
+"POT-Creation-Date: 2022-11-20 17:22-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,13 +19,13 @@ msgstr ""
 
 
 #: mod/fbrowser.php:61 src/Content/Nav.php:195 src/Module/BaseProfile.php:64
-#: view/theme/frio/theme.php:239
+#: view/theme/frio/theme.php:242
 msgid "Photos"
 msgstr ""
 
-#: mod/fbrowser.php:119 mod/fbrowser.php:146 mod/photos.php:999
-#: mod/photos.php:1100 src/Content/Conversation.php:389
-#: src/Module/Contact/Follow.php:171 src/Module/Contact/Revoke.php:109
+#: mod/fbrowser.php:119 mod/fbrowser.php:146 mod/photos.php:997
+#: mod/photos.php:1098 src/Content/Conversation.php:389
+#: src/Module/Contact/Follow.php:173 src/Module/Contact/Revoke.php:109
 #: src/Module/Contact/Unfollow.php:126 src/Module/Post/Edit.php:164
 #: src/Module/Post/Tag/Remove.php:109 src/Module/Profile/RemoteFollow.php:134
 #: src/Module/Security/TwoFactor/SignOut.php:125
@@ -46,13 +46,13 @@ msgid "Unable to locate original post."
 msgstr ""
 
 #: mod/item.php:181 mod/item.php:186 mod/item.php:870 mod/message.php:69
-#: mod/message.php:114 mod/notes.php:44 mod/photos.php:159 mod/photos.php:886
+#: mod/message.php:114 mod/notes.php:44 mod/photos.php:159 mod/photos.php:884
 #: src/Module/Attach.php:56 src/Module/BaseApi.php:94
 #: src/Module/BaseNotifications.php:98 src/Module/BaseSettings.php:52
 #: src/Module/Calendar/Event/API.php:88 src/Module/Calendar/Event/Form.php:84
 #: src/Module/Calendar/Event/Show.php:54 src/Module/Calendar/Export.php:62
 #: src/Module/Calendar/Show.php:64 src/Module/Contact/Advanced.php:60
-#: src/Module/Contact/Follow.php:86 src/Module/Contact/Follow.php:158
+#: src/Module/Contact/Follow.php:86 src/Module/Contact/Follow.php:160
 #: src/Module/Contact/MatchInterests.php:86
 #: src/Module/Contact/Suggestions.php:54 src/Module/Contact/Unfollow.php:66
 #: src/Module/Contact/Unfollow.php:80 src/Module/Contact/Unfollow.php:112
@@ -244,7 +244,7 @@ msgstr ""
 msgid "Your password has been changed at %s"
 msgstr ""
 
-#: mod/message.php:46 mod/message.php:129 src/Content/Nav.php:289
+#: mod/message.php:46 mod/message.php:129 src/Content/Nav.php:285
 msgid "New Message"
 msgstr ""
 
@@ -270,7 +270,7 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: mod/message.php:136 src/Content/Nav.php:286 view/theme/frio/theme.php:246
+#: mod/message.php:136 src/Content/Nav.php:282 view/theme/frio/theme.php:249
 msgid "Messages"
 msgstr ""
 
@@ -316,16 +316,16 @@ msgstr ""
 msgid "Insert web link"
 msgstr ""
 
-#: mod/message.php:203 mod/message.php:360 mod/photos.php:1486
+#: mod/message.php:203 mod/message.php:360 mod/photos.php:1484
 #: src/Content/Conversation.php:371 src/Content/Conversation.php:717
 #: src/Module/Item/Compose.php:204 src/Module/Post/Edit.php:142
 #: src/Module/Profile/UnkMail.php:155 src/Object/Post.php:537
 msgid "Please wait"
 msgstr ""
 
-#: mod/message.php:204 mod/message.php:359 mod/photos.php:916
-#: mod/photos.php:1020 mod/photos.php:1292 mod/photos.php:1333
-#: mod/photos.php:1389 mod/photos.php:1463
+#: mod/message.php:204 mod/message.php:359 mod/photos.php:914
+#: mod/photos.php:1018 mod/photos.php:1290 mod/photos.php:1331
+#: mod/photos.php:1387 mod/photos.php:1461
 #: src/Module/Calendar/Event/Form.php:250 src/Module/Contact/Advanced.php:132
 #: src/Module/Contact/Profile.php:328
 #: src/Module/Debug/ActivityPubConversion.php:140
@@ -408,12 +408,13 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: mod/photos.php:68 mod/photos.php:139 mod/photos.php:793
+#: mod/photos.php:68 mod/photos.php:139 mod/photos.php:791
 #: src/Model/Event.php:514 src/Model/Profile.php:234
 #: src/Module/Calendar/Export.php:67 src/Module/Feed.php:72
 #: src/Module/HCard.php:51 src/Module/Profile/Common.php:40
 #: src/Module/Profile/Common.php:51 src/Module/Profile/Contacts.php:39
 #: src/Module/Profile/Contacts.php:49 src/Module/Profile/Media.php:38
+#: src/Module/Profile/Photos/Index.php:77
 #: src/Module/Profile/Photos/Upload.php:87
 #: src/Module/Profile/RemoteFollow.php:71 src/Module/Profile/Status.php:58
 #: src/Module/Register.php:267
@@ -421,18 +422,23 @@ msgid "User not found."
 msgstr ""
 
 #: mod/photos.php:107 src/Module/BaseProfile.php:67
+#: src/Module/Profile/Photos/Index.php:169
 msgid "Photo Albums"
 msgstr ""
 
-#: mod/photos.php:108 mod/photos.php:1581
+#: mod/photos.php:108 src/Module/Profile/Photos/Index.php:170
+#: src/Module/Profile/Photos/Index.php:187
 msgid "Recent Photos"
 msgstr ""
 
-#: mod/photos.php:110 mod/photos.php:1068 mod/photos.php:1583
+#: mod/photos.php:110 mod/photos.php:1066
+#: src/Module/Profile/Photos/Index.php:172
+#: src/Module/Profile/Photos/Index.php:189
 msgid "Upload New Photos"
 msgstr ""
 
 #: mod/photos.php:128 src/Module/BaseSettings.php:74
+#: src/Module/Profile/Photos/Index.php:153
 msgid "everybody"
 msgstr ""
 
@@ -456,217 +462,218 @@ msgstr ""
 msgid "Failed to delete the photo."
 msgstr ""
 
-#: mod/photos.php:552
+#: mod/photos.php:551
 msgid "a photo"
 msgstr ""
 
-#: mod/photos.php:552
+#: mod/photos.php:551
 #, php-format
 msgid "%1$s was tagged in %2$s by %3$s"
 msgstr ""
 
-#: mod/photos.php:631 mod/photos.php:634 mod/photos.php:661
+#: mod/photos.php:630 mod/photos.php:633 mod/photos.php:660
 #: src/Module/Profile/Photos/Upload.php:213
 #: src/Module/Settings/Profile/Photo/Index.php:59
 #, php-format
 msgid "Image exceeds size limit of %s"
 msgstr ""
 
-#: mod/photos.php:637
+#: mod/photos.php:636
 msgid "Image upload didn't complete, please try again"
 msgstr ""
 
-#: mod/photos.php:640
+#: mod/photos.php:639
 msgid "Image file is missing"
 msgstr ""
 
-#: mod/photos.php:645
+#: mod/photos.php:644
 msgid ""
 "Server can't accept new file upload at this time, please contact your "
 "administrator"
 msgstr ""
 
-#: mod/photos.php:669
+#: mod/photos.php:668
 msgid "Image file is empty."
 msgstr ""
 
-#: mod/photos.php:684 src/Module/Profile/Photos/Upload.php:179
+#: mod/photos.php:683 src/Module/Profile/Photos/Upload.php:179
 #: src/Module/Profile/Photos/Upload.php:180
 #: src/Module/Settings/Profile/Photo/Index.php:68
 msgid "Unable to process image."
 msgstr ""
 
-#: mod/photos.php:710 src/Module/Profile/Photos/Upload.php:231
+#: mod/photos.php:709 src/Module/Profile/Photos/Upload.php:231
 #: src/Module/Settings/Profile/Photo/Index.php:95
 msgid "Image upload failed."
 msgstr ""
 
-#: mod/photos.php:797 src/Module/Conversation/Community.php:187
-#: src/Module/Directory.php:48 src/Module/Search/Index.php:64
+#: mod/photos.php:795 src/Module/Conversation/Community.php:187
+#: src/Module/Directory.php:48 src/Module/Profile/Photos/Index.php:72
+#: src/Module/Search/Index.php:64
 msgid "Public access denied."
 msgstr ""
 
-#: mod/photos.php:802
+#: mod/photos.php:800
 msgid "No photos selected"
 msgstr ""
 
-#: mod/photos.php:871
+#: mod/photos.php:869 src/Module/Profile/Photos/Index.php:92
 msgid "Access to this item is restricted."
 msgstr ""
 
-#: mod/photos.php:926
+#: mod/photos.php:924
 msgid "Upload Photos"
 msgstr ""
 
-#: mod/photos.php:930 mod/photos.php:1016
+#: mod/photos.php:928 mod/photos.php:1014
 msgid "New album name: "
 msgstr ""
 
-#: mod/photos.php:931
+#: mod/photos.php:929
 msgid "or select existing album:"
 msgstr ""
 
-#: mod/photos.php:932
+#: mod/photos.php:930
 msgid "Do not show a status post for this upload"
 msgstr ""
 
-#: mod/photos.php:934 mod/photos.php:1288 src/Content/Conversation.php:373
+#: mod/photos.php:932 mod/photos.php:1286 src/Content/Conversation.php:373
 #: src/Module/Calendar/Event/Form.php:253 src/Module/Post/Edit.php:179
 msgid "Permissions"
 msgstr ""
 
-#: mod/photos.php:997
+#: mod/photos.php:995
 msgid "Do you really want to delete this photo album and all its photos?"
 msgstr ""
 
-#: mod/photos.php:998 mod/photos.php:1021
+#: mod/photos.php:996 mod/photos.php:1019
 msgid "Delete Album"
 msgstr ""
 
-#: mod/photos.php:1025
+#: mod/photos.php:1023
 msgid "Edit Album"
 msgstr ""
 
-#: mod/photos.php:1026
+#: mod/photos.php:1024
 msgid "Drop Album"
 msgstr ""
 
-#: mod/photos.php:1030
+#: mod/photos.php:1028
 msgid "Show Newest First"
 msgstr ""
 
-#: mod/photos.php:1032
+#: mod/photos.php:1030
 msgid "Show Oldest First"
 msgstr ""
 
-#: mod/photos.php:1053 mod/photos.php:1566
+#: mod/photos.php:1051 src/Module/Profile/Photos/Index.php:140
 msgid "View Photo"
 msgstr ""
 
-#: mod/photos.php:1086
+#: mod/photos.php:1084
 msgid "Permission denied. Access to this item may be restricted."
 msgstr ""
 
-#: mod/photos.php:1088
+#: mod/photos.php:1086
 msgid "Photo not available"
 msgstr ""
 
-#: mod/photos.php:1098
+#: mod/photos.php:1096
 msgid "Do you really want to delete this photo?"
 msgstr ""
 
-#: mod/photos.php:1099 mod/photos.php:1293
+#: mod/photos.php:1097 mod/photos.php:1291
 msgid "Delete Photo"
 msgstr ""
 
-#: mod/photos.php:1191
+#: mod/photos.php:1189
 msgid "View photo"
 msgstr ""
 
-#: mod/photos.php:1193
+#: mod/photos.php:1191
 msgid "Edit photo"
 msgstr ""
 
-#: mod/photos.php:1194
+#: mod/photos.php:1192
 msgid "Delete photo"
 msgstr ""
 
-#: mod/photos.php:1195
+#: mod/photos.php:1193
 msgid "Use as profile photo"
 msgstr ""
 
-#: mod/photos.php:1202
+#: mod/photos.php:1200
 msgid "Private Photo"
 msgstr ""
 
-#: mod/photos.php:1208
+#: mod/photos.php:1206
 msgid "View Full Size"
 msgstr ""
 
-#: mod/photos.php:1261
+#: mod/photos.php:1259
 msgid "Tags: "
 msgstr ""
 
-#: mod/photos.php:1264
+#: mod/photos.php:1262
 msgid "[Select tags to remove]"
 msgstr ""
 
-#: mod/photos.php:1279
+#: mod/photos.php:1277
 msgid "New album name"
 msgstr ""
 
-#: mod/photos.php:1280
+#: mod/photos.php:1278
 msgid "Caption"
 msgstr ""
 
-#: mod/photos.php:1281
+#: mod/photos.php:1279
 msgid "Add a Tag"
 msgstr ""
 
-#: mod/photos.php:1281
+#: mod/photos.php:1279
 msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
 msgstr ""
 
-#: mod/photos.php:1282
+#: mod/photos.php:1280
 msgid "Do not rotate"
 msgstr ""
 
-#: mod/photos.php:1283
+#: mod/photos.php:1281
 msgid "Rotate CW (right)"
 msgstr ""
 
-#: mod/photos.php:1284
+#: mod/photos.php:1282
 msgid "Rotate CCW (left)"
 msgstr ""
 
-#: mod/photos.php:1330 mod/photos.php:1386 mod/photos.php:1460
+#: mod/photos.php:1328 mod/photos.php:1384 mod/photos.php:1458
 #: src/Module/Contact.php:547 src/Module/Item/Compose.php:188
 #: src/Object/Post.php:983
 msgid "This is you"
 msgstr ""
 
-#: mod/photos.php:1332 mod/photos.php:1388 mod/photos.php:1462
+#: mod/photos.php:1330 mod/photos.php:1386 mod/photos.php:1460
 #: src/Object/Post.php:531 src/Object/Post.php:985
 msgid "Comment"
 msgstr ""
 
-#: mod/photos.php:1334 mod/photos.php:1390 mod/photos.php:1464
+#: mod/photos.php:1332 mod/photos.php:1388 mod/photos.php:1462
 #: src/Content/Conversation.php:386 src/Module/Calendar/Event/Form.php:248
 #: src/Module/Item/Compose.php:199 src/Module/Post/Edit.php:162
 #: src/Object/Post.php:997
 msgid "Preview"
 msgstr ""
 
-#: mod/photos.php:1335 src/Content/Conversation.php:341
+#: mod/photos.php:1333 src/Content/Conversation.php:341
 #: src/Module/Post/Edit.php:127 src/Object/Post.php:987
 msgid "Loading..."
 msgstr ""
 
-#: mod/photos.php:1421 src/Content/Conversation.php:633 src/Object/Post.php:255
+#: mod/photos.php:1419 src/Content/Conversation.php:633 src/Object/Post.php:255
 msgid "Select"
 msgstr ""
 
-#: mod/photos.php:1422 src/Content/Conversation.php:634
+#: mod/photos.php:1420 src/Content/Conversation.php:634
 #: src/Module/Moderation/Users/Active.php:136
 #: src/Module/Moderation/Users/Blocked.php:136
 #: src/Module/Moderation/Users/Index.php:151
@@ -674,28 +681,24 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: mod/photos.php:1483 src/Object/Post.php:378
+#: mod/photos.php:1481 src/Object/Post.php:378
 msgid "Like"
 msgstr ""
 
-#: mod/photos.php:1484 src/Object/Post.php:378
+#: mod/photos.php:1482 src/Object/Post.php:378
 msgid "I like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1485 src/Object/Post.php:379
+#: mod/photos.php:1483 src/Object/Post.php:379
 msgid "Dislike"
 msgstr ""
 
-#: mod/photos.php:1487 src/Object/Post.php:379
+#: mod/photos.php:1485 src/Object/Post.php:379
 msgid "I don't like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1509
+#: mod/photos.php:1507
 msgid "Map"
-msgstr ""
-
-#: mod/photos.php:1572
-msgid "View Album"
 msgstr ""
 
 #: src/App.php:493
@@ -706,17 +709,17 @@ msgstr ""
 msgid "Apologies but the website is unavailable at the moment."
 msgstr ""
 
-#: src/App/Page.php:282
+#: src/App/Page.php:246
 msgid "Delete this item?"
 msgstr ""
 
-#: src/App/Page.php:283
+#: src/App/Page.php:247
 msgid ""
 "Block this author? They won't be able to follow you nor see your public "
 "posts, and you won't be able to see their posts and their notifications."
 msgstr ""
 
-#: src/App/Page.php:353
+#: src/App/Page.php:317
 msgid "toggle mobile"
 msgstr ""
 
@@ -1317,7 +1320,7 @@ msgid "Message"
 msgstr ""
 
 #: src/Content/Conversation.php:397 src/Module/Post/Edit.php:178
-#: src/Module/Settings/TwoFactor/Trusted.php:139
+#: src/Module/Settings/TwoFactor/Trusted.php:140
 msgid "Browser"
 msgstr ""
 
@@ -1570,7 +1573,7 @@ msgstr ""
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: src/Content/Item.php:386 view/theme/frio/theme.php:267
+#: src/Content/Item.php:386 view/theme/frio/theme.php:270
 msgid "Follow Thread"
 msgstr ""
 
@@ -1624,7 +1627,7 @@ msgstr ""
 
 #: src/Content/Item.php:403 src/Content/Widget.php:80
 #: src/Model/Contact.php:1192 src/Model/Contact.php:1203
-#: src/Module/Contact/Follow.php:165 view/theme/vier/theme.php:198
+#: src/Module/Contact/Follow.php:167 view/theme/vier/theme.php:198
 msgid "Connect/Follow"
 msgstr ""
 
@@ -1667,7 +1670,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: src/Content/Nav.php:193 src/Content/Nav.php:276
+#: src/Content/Nav.php:193 src/Content/Nav.php:272
 #: view/theme/frio/theme.php:237
 msgid "Your posts and conversations"
 msgstr ""
@@ -1683,29 +1686,29 @@ msgstr ""
 msgid "Your profile page"
 msgstr ""
 
-#: src/Content/Nav.php:195 view/theme/frio/theme.php:239
+#: src/Content/Nav.php:195 view/theme/frio/theme.php:242
 msgid "Your photos"
 msgstr ""
 
 #: src/Content/Nav.php:196 src/Module/BaseProfile.php:72
 #: src/Module/BaseProfile.php:75 src/Module/Contact.php:452
-#: view/theme/frio/theme.php:240
+#: view/theme/frio/theme.php:243
 msgid "Media"
 msgstr ""
 
-#: src/Content/Nav.php:196 view/theme/frio/theme.php:240
+#: src/Content/Nav.php:196 view/theme/frio/theme.php:243
 msgid "Your postings with media"
 msgstr ""
 
-#: src/Content/Nav.php:197 src/Content/Nav.php:261
+#: src/Content/Nav.php:197 src/Content/Nav.php:257
 #: src/Module/BaseProfile.php:84 src/Module/BaseProfile.php:87
 #: src/Module/BaseProfile.php:95 src/Module/BaseProfile.php:98
-#: src/Module/Settings/Display.php:205 view/theme/frio/theme.php:241
-#: view/theme/frio/theme.php:245
+#: src/Module/Settings/Display.php:205 view/theme/frio/theme.php:244
+#: view/theme/frio/theme.php:248
 msgid "Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:197 view/theme/frio/theme.php:241
+#: src/Content/Nav.php:197 view/theme/frio/theme.php:244
 msgid "Your calendar"
 msgstr ""
 
@@ -1717,7 +1720,7 @@ msgstr ""
 msgid "Your personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:215 src/Content/Nav.php:276
+#: src/Content/Nav.php:215 src/Content/Nav.php:272
 msgid "Home"
 msgstr ""
 
@@ -1735,10 +1738,10 @@ msgid "Create an account"
 msgstr ""
 
 #: src/Content/Nav.php:225 src/Module/Help.php:67
-#: src/Module/Settings/TwoFactor/AppSpecific.php:128
+#: src/Module/Settings/TwoFactor/AppSpecific.php:129
 #: src/Module/Settings/TwoFactor/Index.php:118
-#: src/Module/Settings/TwoFactor/Recovery.php:106
-#: src/Module/Settings/TwoFactor/Verify.php:145 view/theme/vier/theme.php:243
+#: src/Module/Settings/TwoFactor/Recovery.php:107
+#: src/Module/Settings/TwoFactor/Verify.php:146 view/theme/vier/theme.php:243
 msgid "Help"
 msgstr ""
 
@@ -1772,124 +1775,124 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
-#: src/Content/Nav.php:238 src/Content/Nav.php:297
+#: src/Content/Nav.php:238 src/Content/Nav.php:293
 #: src/Content/Text/HTML.php:899 src/Module/BaseProfile.php:125
 #: src/Module/BaseProfile.php:128 src/Module/Contact.php:373
-#: src/Module/Contact.php:467 view/theme/frio/theme.php:248
+#: src/Module/Contact.php:467 view/theme/frio/theme.php:251
 msgid "Contacts"
 msgstr ""
 
-#: src/Content/Nav.php:257
+#: src/Content/Nav.php:253
 msgid "Community"
 msgstr ""
 
-#: src/Content/Nav.php:257
+#: src/Content/Nav.php:253
 msgid "Conversations on this and other servers"
 msgstr ""
 
-#: src/Content/Nav.php:264
+#: src/Content/Nav.php:260
 msgid "Directory"
 msgstr ""
 
-#: src/Content/Nav.php:264
+#: src/Content/Nav.php:260
 msgid "People directory"
 msgstr ""
 
-#: src/Content/Nav.php:266 src/Module/BaseAdmin.php:85
+#: src/Content/Nav.php:262 src/Module/BaseAdmin.php:85
 #: src/Module/BaseModeration.php:108
 msgid "Information"
 msgstr ""
 
-#: src/Content/Nav.php:266
+#: src/Content/Nav.php:262
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:269 src/Module/Admin/Tos.php:76
+#: src/Content/Nav.php:265 src/Module/Admin/Tos.php:76
 #: src/Module/BaseAdmin.php:95 src/Module/Register.php:176
 #: src/Module/Tos.php:87
 msgid "Terms of Service"
 msgstr ""
 
-#: src/Content/Nav.php:269
+#: src/Content/Nav.php:265
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:274 view/theme/frio/theme.php:244
+#: src/Content/Nav.php:270 view/theme/frio/theme.php:247
 msgid "Network"
 msgstr ""
 
-#: src/Content/Nav.php:274 view/theme/frio/theme.php:244
+#: src/Content/Nav.php:270 view/theme/frio/theme.php:247
 msgid "Conversations from your friends"
 msgstr ""
 
-#: src/Content/Nav.php:280
+#: src/Content/Nav.php:276
 msgid "Introductions"
 msgstr ""
 
-#: src/Content/Nav.php:280
+#: src/Content/Nav.php:276
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:281 src/Module/BaseNotifications.php:149
+#: src/Content/Nav.php:277 src/Module/BaseNotifications.php:149
 #: src/Module/Notifications/Introductions.php:75
 msgid "Notifications"
 msgstr ""
 
-#: src/Content/Nav.php:282
+#: src/Content/Nav.php:278
 msgid "See all notifications"
 msgstr ""
 
-#: src/Content/Nav.php:283 src/Module/Settings/Connectors.php:242
+#: src/Content/Nav.php:279 src/Module/Settings/Connectors.php:242
 msgid "Mark as seen"
 msgstr ""
 
-#: src/Content/Nav.php:283
+#: src/Content/Nav.php:279
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:286 view/theme/frio/theme.php:246
+#: src/Content/Nav.php:282 view/theme/frio/theme.php:249
 msgid "Private mail"
 msgstr ""
 
-#: src/Content/Nav.php:287
+#: src/Content/Nav.php:283
 msgid "Inbox"
 msgstr ""
 
-#: src/Content/Nav.php:288
+#: src/Content/Nav.php:284
 msgid "Outbox"
 msgstr ""
 
-#: src/Content/Nav.php:292
+#: src/Content/Nav.php:288
 msgid "Accounts"
 msgstr ""
 
-#: src/Content/Nav.php:292
+#: src/Content/Nav.php:288
 msgid "Manage other pages"
 msgstr ""
 
-#: src/Content/Nav.php:295 src/Module/Admin/Addons/Details.php:114
+#: src/Content/Nav.php:291 src/Module/Admin/Addons/Details.php:114
 #: src/Module/Admin/Themes/Details.php:93 src/Module/BaseSettings.php:170
-#: src/Module/Welcome.php:52 view/theme/frio/theme.php:247
+#: src/Module/Welcome.php:52 view/theme/frio/theme.php:250
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:295 view/theme/frio/theme.php:247
+#: src/Content/Nav.php:291 view/theme/frio/theme.php:250
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:297 view/theme/frio/theme.php:248
+#: src/Content/Nav.php:293 view/theme/frio/theme.php:251
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:302 src/Module/BaseAdmin.php:119
+#: src/Content/Nav.php:298 src/Module/BaseAdmin.php:119
 msgid "Admin"
 msgstr ""
 
-#: src/Content/Nav.php:302
+#: src/Content/Nav.php:298
 msgid "Site setup and configuration"
 msgstr ""
 
-#: src/Content/Nav.php:303 src/Module/BaseModeration.php:127
+#: src/Content/Nav.php:299 src/Module/BaseModeration.php:127
 #: src/Module/Moderation/Blocklist/Contact.php:110
 #: src/Module/Moderation/Blocklist/Server/Add.php:119
 #: src/Module/Moderation/Blocklist/Server/Import.php:115
@@ -1903,15 +1906,15 @@ msgstr ""
 msgid "Moderation"
 msgstr ""
 
-#: src/Content/Nav.php:303
+#: src/Content/Nav.php:299
 msgid "Content and user moderation"
 msgstr ""
 
-#: src/Content/Nav.php:306
+#: src/Content/Nav.php:302
 msgid "Navigation"
 msgstr ""
 
-#: src/Content/Nav.php:306
+#: src/Content/Nav.php:302
 msgid "Site map"
 msgstr ""
 
@@ -5398,7 +5401,7 @@ msgid "Profile Details"
 msgstr ""
 
 #: src/Module/BaseProfile.php:59 src/Module/Contact.php:447
-#: src/Module/Contact/Follow.php:190 src/Module/Contact/Unfollow.php:138
+#: src/Module/Contact/Follow.php:192 src/Module/Contact/Unfollow.php:138
 msgid "Status Messages and Posts"
 msgstr ""
 
@@ -5521,7 +5524,7 @@ msgstr ""
 #: src/Module/Moderation/Item/Delete.php:67 src/Module/Register.php:148
 #: src/Module/Security/TwoFactor/Verify.php:101
 #: src/Module/Settings/TwoFactor/Index.php:140
-#: src/Module/Settings/TwoFactor/Verify.php:154
+#: src/Module/Settings/TwoFactor/Verify.php:155
 msgid "Required"
 msgstr ""
 
@@ -5834,36 +5837,36 @@ msgstr[1] ""
 msgid "Access denied."
 msgstr ""
 
-#: src/Module/Contact/Follow.php:102 src/Module/Contact/Unfollow.php:125
+#: src/Module/Contact/Follow.php:104 src/Module/Contact/Unfollow.php:125
 #: src/Module/Profile/RemoteFollow.php:133
 msgid "Submit Request"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:113
+#: src/Module/Contact/Follow.php:115
 msgid "You already added this contact."
 msgstr ""
 
-#: src/Module/Contact/Follow.php:128
+#: src/Module/Contact/Follow.php:130
 msgid "The network type couldn't be detected. Contact can't be added."
 msgstr ""
 
-#: src/Module/Contact/Follow.php:136
+#: src/Module/Contact/Follow.php:138
 msgid "Diaspora support isn't enabled. Contact can't be added."
 msgstr ""
 
-#: src/Module/Contact/Follow.php:141
+#: src/Module/Contact/Follow.php:143
 msgid "OStatus support is disabled. Contact can't be added."
 msgstr ""
 
-#: src/Module/Contact/Follow.php:166 src/Module/Profile/RemoteFollow.php:132
+#: src/Module/Contact/Follow.php:168 src/Module/Profile/RemoteFollow.php:132
 msgid "Please answer the following:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:167 src/Module/Contact/Unfollow.php:123
+#: src/Module/Contact/Follow.php:169 src/Module/Contact/Unfollow.php:123
 msgid "Your Identity Address:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:168 src/Module/Contact/Profile.php:366
+#: src/Module/Contact/Follow.php:170 src/Module/Contact/Profile.php:366
 #: src/Module/Contact/Unfollow.php:129
 #: src/Module/Moderation/Blocklist/Contact.php:133
 #: src/Module/Notifications/Introductions.php:129
@@ -5871,22 +5874,22 @@ msgstr ""
 msgid "Profile URL"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:169 src/Module/Contact/Profile.php:378
+#: src/Module/Contact/Follow.php:171 src/Module/Contact/Profile.php:378
 #: src/Module/Notifications/Introductions.php:191
 #: src/Module/Profile/Profile.php:206
 msgid "Tags:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:180
+#: src/Module/Contact/Follow.php:182
 #, php-format
 msgid "%s knows you"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:181
+#: src/Module/Contact/Follow.php:183
 msgid "Add a personal note:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:219
+#: src/Module/Contact/Follow.php:221
 msgid "The contact could not be added."
 msgstr ""
 
@@ -6163,7 +6166,7 @@ msgstr ""
 #: src/Module/Contact/Revoke.php:108
 #: src/Module/Notifications/Introductions.php:144
 #: src/Module/OAuth/Acknowledge.php:53 src/Module/Register.php:130
-#: src/Module/Settings/TwoFactor/Trusted.php:125
+#: src/Module/Settings/TwoFactor/Trusted.php:126
 msgid "Yes"
 msgstr ""
 
@@ -7862,7 +7865,7 @@ msgstr ""
 
 #: src/Module/Notifications/Introductions.php:144
 #: src/Module/OAuth/Acknowledge.php:54 src/Module/Register.php:131
-#: src/Module/Settings/TwoFactor/Trusted.php:125
+#: src/Module/Settings/TwoFactor/Trusted.php:126
 msgid "No"
 msgstr ""
 
@@ -8131,7 +8134,7 @@ msgid "Select a tag to remove: "
 msgstr ""
 
 #: src/Module/Post/Tag/Remove.php:108 src/Module/Settings/Delegation.php:178
-#: src/Module/Settings/TwoFactor/Trusted.php:143
+#: src/Module/Settings/TwoFactor/Trusted.php:144
 msgid "Remove"
 msgstr ""
 
@@ -8154,6 +8157,10 @@ msgstr ""
 
 #: src/Module/Profile/Contacts.php:119
 msgid "No contacts."
+msgstr ""
+
+#: src/Module/Profile/Photos/Index.php:146
+msgid "View Album"
 msgstr ""
 
 #: src/Module/Profile/Profile.php:81
@@ -8636,7 +8643,7 @@ msgstr ""
 
 #: src/Module/Security/TwoFactor/Recovery.php:80
 #: src/Module/Security/TwoFactor/Verify.php:77
-#: src/Module/Settings/TwoFactor/Verify.php:94
+#: src/Module/Settings/TwoFactor/Verify.php:95
 msgid "Invalid code, please retry."
 msgstr ""
 
@@ -8722,7 +8729,7 @@ msgid ""
 msgstr ""
 
 #: src/Module/Security/TwoFactor/Verify.php:101
-#: src/Module/Settings/TwoFactor/Verify.php:154
+#: src/Module/Settings/TwoFactor/Verify.php:155
 msgid "Please enter a code from your authentication app"
 msgstr ""
 
@@ -9868,82 +9875,82 @@ msgstr ""
 msgid "Please enter your password for verification:"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:65
-#: src/Module/Settings/TwoFactor/Recovery.php:63
-#: src/Module/Settings/TwoFactor/Trusted.php:66
-#: src/Module/Settings/TwoFactor/Verify.php:68
+#: src/Module/Settings/TwoFactor/AppSpecific.php:66
+#: src/Module/Settings/TwoFactor/Recovery.php:64
+#: src/Module/Settings/TwoFactor/Trusted.php:67
+#: src/Module/Settings/TwoFactor/Verify.php:69
 msgid "Please enter your password to access this page."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:83
+#: src/Module/Settings/TwoFactor/AppSpecific.php:84
 msgid "App-specific password generation failed: The description is empty."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:86
+#: src/Module/Settings/TwoFactor/AppSpecific.php:87
 msgid ""
 "App-specific password generation failed: This description already exists."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:90
+#: src/Module/Settings/TwoFactor/AppSpecific.php:91
 msgid "New app-specific password generated."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:96
+#: src/Module/Settings/TwoFactor/AppSpecific.php:97
 msgid "App-specific passwords successfully revoked."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:106
+#: src/Module/Settings/TwoFactor/AppSpecific.php:107
 msgid "App-specific password successfully revoked."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:127
+#: src/Module/Settings/TwoFactor/AppSpecific.php:128
 msgid "Two-factor app-specific passwords"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:129
+#: src/Module/Settings/TwoFactor/AppSpecific.php:130
 msgid ""
 "<p>App-specific passwords are randomly generated passwords used instead your "
 "regular password to authenticate your account on third-party applications "
 "that don't support two-factor authentication.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:130
+#: src/Module/Settings/TwoFactor/AppSpecific.php:131
 msgid ""
 "Make sure to copy your new app-specific password now. You won’t be able to "
 "see it again!"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:133
+#: src/Module/Settings/TwoFactor/AppSpecific.php:134
 msgid "Description"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:134
+#: src/Module/Settings/TwoFactor/AppSpecific.php:135
 msgid "Last Used"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:135
+#: src/Module/Settings/TwoFactor/AppSpecific.php:136
 msgid "Revoke"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:136
+#: src/Module/Settings/TwoFactor/AppSpecific.php:137
 msgid "Revoke All"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:139
+#: src/Module/Settings/TwoFactor/AppSpecific.php:140
 msgid ""
 "When you generate a new app-specific password, you must use it right away, "
 "it will be shown to you once after you generate it."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:140
+#: src/Module/Settings/TwoFactor/AppSpecific.php:141
 msgid "Generate new app-specific password"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:141
+#: src/Module/Settings/TwoFactor/AppSpecific.php:142
 msgid "Friendiqa on my Fairphone 2..."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:142
+#: src/Module/Settings/TwoFactor/AppSpecific.php:143
 msgid "Generate"
 msgstr ""
 
@@ -10039,15 +10046,15 @@ msgstr ""
 msgid "Finish app configuration"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:79
+#: src/Module/Settings/TwoFactor/Recovery.php:80
 msgid "New recovery codes successfully generated."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:105
+#: src/Module/Settings/TwoFactor/Recovery.php:106
 msgid "Two-factor recovery codes"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:107
+#: src/Module/Settings/TwoFactor/Recovery.php:108
 msgid ""
 "<p>Recovery codes can be used to access your account in the event you lose "
 "access to your device and cannot receive two-factor authentication codes.</"
@@ -10055,68 +10062,68 @@ msgid ""
 "don’t have the recovery codes you will lose access to your account.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:109
+#: src/Module/Settings/TwoFactor/Recovery.php:110
 msgid ""
 "When you generate new recovery codes, you must copy the new codes. Your old "
 "codes won’t work anymore."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:110
+#: src/Module/Settings/TwoFactor/Recovery.php:111
 msgid "Generate new recovery codes"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Recovery.php:112
+#: src/Module/Settings/TwoFactor/Recovery.php:113
 msgid "Next: Verification"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:83
+#: src/Module/Settings/TwoFactor/Trusted.php:84
 msgid "Trusted browsers successfully removed."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:93
+#: src/Module/Settings/TwoFactor/Trusted.php:94
 msgid "Trusted browser successfully removed."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:135
+#: src/Module/Settings/TwoFactor/Trusted.php:136
 msgid "Two-factor Trusted Browsers"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:136
+#: src/Module/Settings/TwoFactor/Trusted.php:137
 msgid ""
 "Trusted browsers are individual browsers you chose to skip two-factor "
 "authentication to access Friendica. Please use this feature sparingly, as it "
 "can negate the benefit of two-factor authentication."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:137
+#: src/Module/Settings/TwoFactor/Trusted.php:138
 msgid "Device"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:138
+#: src/Module/Settings/TwoFactor/Trusted.php:139
 msgid "OS"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:140
+#: src/Module/Settings/TwoFactor/Trusted.php:141
 msgid "Trusted"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:141
+#: src/Module/Settings/TwoFactor/Trusted.php:142
 msgid "Created At"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:142
+#: src/Module/Settings/TwoFactor/Trusted.php:143
 msgid "Last Use"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Trusted.php:144
+#: src/Module/Settings/TwoFactor/Trusted.php:145
 msgid "Remove All"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:90
+#: src/Module/Settings/TwoFactor/Verify.php:91
 msgid "Two-factor authentication successfully activated."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:124
+#: src/Module/Settings/TwoFactor/Verify.php:125
 #, php-format
 msgid ""
 "<p>Or you can submit the authentication settings manually:</p>\n"
@@ -10136,24 +10143,24 @@ msgid ""
 "</dl>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:144
+#: src/Module/Settings/TwoFactor/Verify.php:145
 msgid "Two-factor code verification"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:146
+#: src/Module/Settings/TwoFactor/Verify.php:147
 msgid ""
 "<p>Please scan this QR Code with your authenticator app and submit the "
 "provided code.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:148
+#: src/Module/Settings/TwoFactor/Verify.php:149
 #, php-format
 msgid ""
 "<p>Or you can open the following URL in your mobile device:</p><p><a href="
 "\"%s\">%s</a></p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:155
+#: src/Module/Settings/TwoFactor/Verify.php:156
 msgid "Verify code and enable two-factor authentication"
 msgstr ""
 

--- a/view/templates/photo_albums.tpl
+++ b/view/templates/photo_albums.tpl
@@ -2,14 +2,14 @@
 	<h3>{{$title}}</h3>
 	<ul role="menubar" class="sidebar-photos-albums-ul">
 		<li role="menuitem" class="sidebar-photos-albums-li">
-			<a href="{{$baseurl}}/photos/{{$nick}}" class="sidebar-photos-albums-element" title="{{$title}}">{{$recent}}</a>
+			<a href="profile/{{$nick}}/photos" class="sidebar-photos-albums-element" title="{{$title}}">{{$recent}}</a>
 		</li>
 
 		{{if $albums}}
 		{{foreach $albums as $al}}
 		{{if $al.text}}
 		<li role="menuitem" class="sidebar-photos-albums-li">
-			<a href="{{$baseurl}}/photos/{{$nick}}/album/{{$al.bin2hex}}" class="sidebar-photos-albums-element">
+			<a href="photos/{{$nick}}/album/{{$al.bin2hex}}" class="sidebar-photos-albums-element">
 				<span class="badge pull-right">{{$al.total}}</span>{{$al.text}}
 			</a>
 		</li>

--- a/view/templates/photos_upload.tpl
+++ b/view/templates/photos_upload.tpl
@@ -3,7 +3,7 @@
 
 <div id="photos-usage-message">{{$usage}}</div>
 
-<form action="photos/{{$nickname}}" enctype="multipart/form-data" method="post" name="photos-upload-form" id="photos-upload-form">
+<form action="profile/{{$nickname}}/photos" enctype="multipart/form-data" method="post" name="photos-upload-form" id="photos-upload-form">
 	<div id="photos-upload-new-wrapper">
 		<div id="photos-upload-newalbum-div">
 			<label id="photos-upload-newalbum-text" for="photos-upload-newalbum">{{$newalbum}}</label>
@@ -47,4 +47,3 @@
 
 	<div class="photos-upload-end"></div>
 </form>
-

--- a/view/theme/frio/templates/photo_albums.tpl
+++ b/view/theme/frio/templates/photo_albums.tpl
@@ -2,7 +2,7 @@
 	<div class="pull-left">
 		<h3>{{$title}}</h3>
 	</div>
-	
+
 	<div class="pull-right">
 	{{if $can_post}}
 		<div class="photos-upload-link">
@@ -15,14 +15,14 @@
 
 	<ul role="menubar" class="sidebar-photos-albums-ul clear">
 		<li role="menuitem" class="sidebar-photos-albums-li">
-			<a href="{{$baseurl}}/photos/{{$nick}}" class="sidebar-photos-albums-element" title="{{$title}}">{{$recent}}</a>
+			<a href="profile/{{$nick}}/photos" class="sidebar-photos-albums-element" title="{{$title}}">{{$recent}}</a>
 		</li>
 
 		{{if $albums}}
 		{{foreach $albums as $al}}
 			{{if $al.text}}
 			<li role="menuitem" class="sidebar-photos-albums-li">
-				<a href="{{$baseurl}}/photos/{{$nick}}/album/{{$al.bin2hex}}" class="sidebar-photos-albums-element">
+				<a href="photos/{{$nick}}/album/{{$al.bin2hex}}" class="sidebar-photos-albums-element">
 					<span class="badge pull-right">{{$al.total}}</span>{{$al.text}}
 				</a>
 			</li>

--- a/view/theme/frio/templates/photos_upload.tpl
+++ b/view/theme/frio/templates/photos_upload.tpl
@@ -4,7 +4,7 @@
 
 	<div id="photos-usage-message">{{$usage}}</div>
 
-	<form action="photos/{{$nickname}}" enctype="multipart/form-data" method="post" name="photos-upload-form" id="photos-upload-form">
+	<form action="profile/{{$nickname}}/photos" enctype="multipart/form-data" method="post" name="photos-upload-form" id="photos-upload-form">
 		<div id="photos-upload-div" class="form-group">
 			<label id="photos-upload-text" for="photos-upload-newalbum">{{$newalbum}}</label>
 
@@ -40,7 +40,7 @@
 			<div class="photos-upload-wrapper">
 				<div id="photos-upload-perms" class="btn-group pull-right">
 					<button class="btn btn-default" data-toggle="modal" data-target="#aclModal" onclick="return false;">
-						<i id="jot-perms-icon" class="fa {{$lockstate}}"></i> 
+						<i id="jot-perms-icon" class="fa {{$lockstate}}"></i>
 					</button>
 
 					{{$default_upload_submit nofilter}}

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -236,6 +236,9 @@ function frio_remote_nav(App $a, array &$nav_info)
 			// user menu
 			$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'], DI::l10n()->t('Status'), '', DI::l10n()->t('Your posts and conversations')];
 			$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'] . '/profile', DI::l10n()->t('Profile'), '', DI::l10n()->t('Your profile page')];
+			// Kept for backwards-compatibility reasons, the remote server may not have updated to version 2022.12 yet
+			// @TODO Switch with the new routes by version 2023.12
+			//$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'] . '/photos', DI::l10n()->t('Photos'), '', DI::l10n()->t('Your photos')];
 			$nav_info['nav']['usermenu'][] = [$server_url . '/photos/' . $remoteUser['nick'], DI::l10n()->t('Photos'), '', DI::l10n()->t('Your photos')];
 			$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'] . '/media', DI::l10n()->t('Media'), '', DI::l10n()->t('Your postings with media')];
 			$nav_info['nav']['usermenu'][] = [$server_url . '/calendar/', DI::l10n()->t('Calendar'), '', DI::l10n()->t('Your calendar')];


### PR DESCRIPTION
Part of #4090

Taking this one step-by-step because of the wide ramifications of the module.

First: `/photos/{nickname}` to `/profile/{nickname}/photos`.

Unfortunately, I wasn't able to do a clean migration because the route is used in the Frio theme to show a link to the visiting user to their own server, and we don't know which Friendica version they are running. So the legacy route is still available, even if it's only used in one place.