### PR TITLE
Fix unfavourite (and related) endpoints

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2693,7 +2693,7 @@ class Item
 		}
 
 		$condition = ['vid' => $vids, 'deleted' => false, 'gravity' => self::GRAVITY_ACTIVITY,
-			'author-id' => $author_id, 'uid' => $item['uid'], 'thr-parent-id' => $uri_id];
+			'author-id' => $author_id, 'uid' => $uid, 'thr-parent-id' => $uri_id];
 		$like_item = Post::selectFirst(['id', 'guid', 'verb'], $condition);
 
 		if (DBA::isResult($like_item)) {


### PR DESCRIPTION
Working with @annando we discovered the reason why the unfavoriting endpoint was never unfavoriting anything. It was down in the guts of the Item performActivity static function. This change makes it so that the unfavouriting works now. I have not tried before/after on this with the reshare endpoint yet.