### PR TITLE
Update Notify->iid to itemId for notification endpoint

### DIFF
--- a/src/Module/Api/Friendica/Notification/Seen.php
+++ b/src/Module/Api/Friendica/Notification/Seen.php
@@ -65,7 +65,7 @@ class Seen extends BaseApi
 			DI::notify()->save($Notify);
 
 			if ($Notify->otype === Notification\ObjectType::ITEM) {
-				$item = Post::selectFirstForUser($uid, [], ['id' => $Notify->iid, 'uid' => $uid]);
+				$item = Post::selectFirstForUser($uid, [], ['id' => $Notify->itemId, 'uid' => $uid]);
 				if (DBA::isResult($item)) {
 					// we found the item, return it to the user
 					$ret  = [DI::twitterStatus()->createFromUriId($item['uri-id'], $item['uid'], $include_entities)->toArray()];


### PR DESCRIPTION
The friendica/notification/seen POST endpoint was throwing a 500 error because the Notify->iid field had been changed to itemId but that code hadn't been changed. I tried using the new mastodon endpoint but that doesn't seem to mark notifications read in the UI since it works with a different, but maybe related, table.