### PR TITLE
Update sample-nginx.config

### DIFF
--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -51,8 +51,6 @@ server {
   listen 443 ssl;
   server_name friendica.example.net;
 
-  ssl on;
-
   #Traditional SSL
   ssl_certificate /etc/nginx/ssl/friendica.example.net.chain.pem;
   ssl_certificate_key /etc/nginx/ssl/example.net.key;


### PR DESCRIPTION
Removed  `ssl on`  in line 54 directive since it is deprecated and already activated with the `listen 443 ssl;`  directive in line 51

With `ssl on`  nginx warns:

`nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /etc/nginx/sites-enabled/friendica-dev.conf:54`