### PR TITLE
Silently quit on unfollow of invalid contacts

### DIFF
--- a/src/Core/Protocol.php
+++ b/src/Core/Protocol.php
@@ -183,7 +183,7 @@ class Protocol
 	{
 		if (empty($contact['network'])) {
 			Logger::notice('Contact has got no network, we quit here', ['id' => $contact['id']]);
-			return true;
+			return null;
 		}
 
 		$protocol = $contact['network'];
@@ -207,7 +207,7 @@ class Protocol
 
 			if (empty($contact['notify'])) {
 				Logger::notice('OStatus/DFRN Contact is missing notify, we quit here', ['id' => $contact['id']]);
-				return true;
+				return null;
 			}
 
 			return Salmon::slapper($user, $contact['notify'], $slap) === 0;

--- a/src/Core/Protocol.php
+++ b/src/Core/Protocol.php
@@ -182,7 +182,8 @@ class Protocol
 	public static function unfollow(array $contact, array $user): ?bool
 	{
 		if (empty($contact['network'])) {
-			throw new \InvalidArgumentException('Missing network key in contact array');
+			Logger::notice('Contact has got no network, we quit here', ['id' => $contact['id']]);
+			return true;
 		}
 
 		$protocol = $contact['network'];
@@ -205,7 +206,8 @@ class Protocol
 			$slap = OStatus::salmon($item, $user);
 
 			if (empty($contact['notify'])) {
-				throw new \InvalidArgumentException('Missing expected "notify" key in OStatus/DFRN contact');
+				Logger::notice('OStatus/DFRN Contact is missing notify, we quit here', ['id' => $contact['id']]);
+				return true;
 			}
 
 			return Salmon::slapper($user, $contact['notify'], $slap) === 0;


### PR DESCRIPTION
This fixes the issue that an unfollow request for some invalid account lead to an endless loop consisting of:
- Execute the worker to unfollow
- Throw an error because of missing contact data
- Execute the worker again
- Throw again an error
- etc.

Since this data problem is not recoverable (in contrast to some connection issues), we silently quit and just pretent that we send some unfollow.