### PR TITLE
Issue 12189: Quote share a feed now shares the linked feed url

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -239,6 +239,8 @@ function item_post(App $a) {
 
 		$att_bbcode = "\n" . PageInfo::getFooterFromData($attachment);
 		$body .= $att_bbcode;
+	} elseif (preg_match("/\[attachment\](.*?)\[\/attachment\]/ism", $body, $matches)) {
+		$body = preg_replace("/\[attachment].*?\[\/attachment\]/ism", PageInfo::getFooterFromUrl($matches[1]), $body);
 	}
 
 	// Convert links with empty descriptions to links without an explicit description

--- a/src/Module/Post/Share.php
+++ b/src/Module/Post/Share.php
@@ -24,6 +24,7 @@ namespace Friendica\Module\Post;
 use Friendica\App;
 use Friendica\Content;
 use Friendica\Core\L10n;
+use Friendica\Core\Protocol;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Core\System;
 use Friendica\Model\Item;
@@ -59,7 +60,7 @@ class Share extends \Friendica\BaseModule
 			System::httpError(403);
 		}
 
-		$item = Post::selectFirst(['private', 'body', 'uri'], ['id' => $post_id]);
+		$item = Post::selectFirst(['private', 'body', 'uri', 'plink', 'network'], ['id' => $post_id]);
 		if (!$item || $item['private'] == Item::PRIVATE) {
 			System::httpError(404);
 		}
@@ -67,6 +68,8 @@ class Share extends \Friendica\BaseModule
 		$shared = $this->contentItem->getSharedPost($item, ['uri']);
 		if ($shared && empty($shared['comment'])) {
 			$content = '[share]' . $shared['post']['uri'] . '[/share]';
+		} elseif ($item['network'] == Protocol::FEED) {
+			$content = '[attachment]' . $item['plink'] . '[/attachment]';
 		} else {
 			$content = '[share]' . $item['uri'] . '[/share]';
 		}


### PR DESCRIPTION
Fixes #12189 by converting a quote share of a feed item in creating a post with an attached link.