### PR TITLE
Nginx template improvements

### DIFF
--- a/mods/sample-nginx-certbot.config
+++ b/mods/sample-nginx-certbot.config
@@ -45,7 +45,7 @@ server {
 
   # Logging
   access_log /var/log/nginx/friendica_access.log;
-  # uncomment the following line if you would like to log errors in a seperate file for friendica
+  # uncomment the following line if you would like to log errors in a separate file for friendica
   #error_log /var/log/nginx/friendica_error.log;
 
   index index.php;

--- a/mods/sample-nginx-certbot.config
+++ b/mods/sample-nginx-certbot.config
@@ -1,0 +1,128 @@
+##
+# Friendica Nginx configuration template to be autocnfgiured with cerbot
+# nased on sample-nginx.config by Olaf Conradi
+#
+# On Debian based distributions you can add this file to
+# /etc/nginx/sites-available
+#
+# Then customize it to your needs. At least replace the server_name in line 41.
+#
+# Enable the configuration by
+# symlink it to /etc/nginx/sites-enabled
+#
+# and run
+# certbot --nginx -d friendica.example.net
+#
+# Then reload Nginx using
+# systemctl nginx reload
+#
+##
+
+##
+# You should look at the following URL's in order to grasp a solid understanding
+# of Nginx configuration files in order to fully unleash the power of Nginx.
+#
+# http://wiki.nginx.org/Pitfalls
+# http://wiki.nginx.org/QuickStart
+# http://wiki.nginx.org/Configuration
+##
+
+##
+# This configuration assumes your domain is example.net
+# You have a separate subdomain friendica.example.net
+# You want all Friendica traffic to be https using letsencrypt with cerbot
+# You have an SSL certificate and key for your subdomain
+# You have PHP FastCGI Process Manager (php7.4-fpm) running on localhost
+# You have Friendica installed in /var/www/friendica
+##
+
+server {
+  listen 80;
+  server_name friendica.example.net;
+
+  # Point here to the path where your friendica files are located
+  root /var/www/friendica;
+
+  # Logging
+  access_log /var/log/nginx/friendica_access.log;
+  # uncomment the following line if you would like to log errors in a seperate file for friendica
+  #error_log /var/log/nginx/friendica_error.log;
+
+  index index.php;
+  charset utf-8;
+
+  # Uncomment the following line to include a standard configuration file Note
+  # that the most specific rule wins and your standard configuration will
+  # therefore *add* to this file, but not override it.
+  #include standard.conf
+
+  # allow uploads up to 20MB in size
+  client_max_body_size 20m;
+  client_body_buffer_size 128k;
+
+  # rewrite to front controller as default rule
+  location / {
+    try_files $uri /index.php?pagename=$uri&$args;
+  }
+
+  # make sure webfinger and other well known services aren't blocked
+  # by denying dot files and rewrite request to the front controller
+  location ^~ /.well-known/ {
+    allow all;
+    rewrite ^ /index.php?pagename=$uri;
+  }
+
+  include mime.types;
+
+  # statically serve these file types when possible otherwise fall back to
+  # front controller allow browser to cache them added .htm for advanced source
+  # code editor library
+  #location ~* \.(jpg|jpeg|gif|png|ico|css|js|htm|html|ttf|woff|svg)$ {
+  #  expires 30d;
+  #  try_files $uri /index.php?pagename=$uri&$args;
+  #}
+
+  # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+  # or a unix socket
+  location ~* \.php$ {
+    # Zero-day exploit defense.
+    # http://forum.nginx.org/read.php?2,88845,page=3
+    # Won't work properly (404 error) if the file is not stored on this
+    # server, which is entirely possible with php-fpm/php-fcgi.
+    # Comment the 'try_files' line out if you set up php-fpm/php-fcgi on
+    # another machine.  And then cross your fingers that you won't get hacked.
+    try_files $uri =404;
+
+    # NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
+
+    # With php5-cgi alone:
+    # fastcgi_pass 127.0.0.1:9000;
+
+    # With php7.4-fpm:
+    fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
+
+    include fastcgi_params;
+    fastcgi_index index.php;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+    fastcgi_buffers 16 16k;
+    fastcgi_buffer_size 32k;
+  }
+
+  # block these file types
+  location ~* \.(tpl|md|tgz|log|out)$ {
+    deny all;
+  }
+
+  # deny access to all dot files
+  location ~ /\. {
+    deny all;
+   }
+
+   # deny access to the CLI scripts
+  location ^~ /bin {
+    deny all;
+  }
+}
+

--- a/mods/sample-nginx-certbot.config
+++ b/mods/sample-nginx-certbot.config
@@ -1,6 +1,6 @@
 ##
-# Friendica Nginx configuration template to be autocnfgiured with cerbot
-# nased on sample-nginx.config by Olaf Conradi
+# Friendica Nginx configuration template to be autoconfigured with certbot
+# based on sample-nginx.config by Olaf Conradi
 #
 # On Debian based distributions you can add this file to
 # /etc/nginx/sites-available

--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -35,7 +35,7 @@ server {
 
   index index.php;
   root /var/www/friendica;
-  rewrite ^ https://friendica.example.net$request_uri? permanent;
+  rewrite ^ https://$server_name$request_uri? permanent;
 }
 
 ##
@@ -120,7 +120,7 @@ server {
     # fastcgi_pass 127.0.0.1:9000;
 
     # With php7.0-fpm:
-    fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+    fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
 
     include fastcgi_params;
     fastcgi_index index.php;


### PR DESCRIPTION
- Updated sample-nginx.conf to use php7.4-fpm (was 7.0)
- Removed double hard coded friendica.example.net declatation by replacing defining it with already defined `$server_name` variable
- Added `sample-nginx-cerbot.config` to be used directly with `cerbot --nginx`
