### PR TITLE
Added status to the report

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2022.12-dev (Giant Rhubarb)
--- DB_UPDATE_VERSION 1494
+-- DB_UPDATE_VERSION 1495
 -- ------------------------------------------
 
 
@@ -1656,6 +1656,7 @@ CREATE TABLE IF NOT EXISTS `report` (
 	`comment` text COMMENT 'Report',
 	`forward` boolean COMMENT 'Forward the report to the remote server',
 	`created` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
+	`status` tinyint unsigned COMMENT 'Status of the report',
 	 PRIMARY KEY(`id`),
 	 INDEX `uid` (`uid`),
 	 INDEX `cid` (`cid`),
@@ -1669,6 +1670,7 @@ CREATE TABLE IF NOT EXISTS `report` (
 CREATE TABLE IF NOT EXISTS `report-post` (
 	`rid` int unsigned NOT NULL COMMENT 'Report id',
 	`uri-id` int unsigned NOT NULL COMMENT 'Uri-id of the reported post',
+	`status` tinyint unsigned COMMENT 'Status of the reported post',
 	 PRIMARY KEY(`rid`,`uri-id`),
 	 INDEX `uri-id` (`uri-id`),
 	FOREIGN KEY (`rid`) REFERENCES `report` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,

--- a/doc/database/db_report-post.md
+++ b/doc/database/db_report-post.md
@@ -6,10 +6,11 @@ Table report-post
 Fields
 ------
 
-| Field  | Description                 | Type         | Null | Key | Default | Extra |
-| ------ | --------------------------- | ------------ | ---- | --- | ------- | ----- |
-| rid    | Report id                   | int unsigned | NO   | PRI | NULL    |       |
-| uri-id | Uri-id of the reported post | int unsigned | NO   | PRI | NULL    |       |
+| Field  | Description                 | Type             | Null | Key | Default | Extra |
+| ------ | --------------------------- | ---------------- | ---- | --- | ------- | ----- |
+| rid    | Report id                   | int unsigned     | NO   | PRI | NULL    |       |
+| uri-id | Uri-id of the reported post | int unsigned     | NO   | PRI | NULL    |       |
+| status | Status of the reported post | tinyint unsigned | YES  |     | NULL    |       |
 
 Indexes
 ------------

--- a/doc/database/db_report.md
+++ b/doc/database/db_report.md
@@ -14,6 +14,7 @@ Fields
 | comment | Report                                  | text               | YES  |     | NULL                |                |
 | forward | Forward the report to the remote server | boolean            | YES  |     | NULL                |                |
 | created |                                         | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
+| status  | Status of the report                    | tinyint unsigned   | YES  |     | NULL                |                |
 
 Indexes
 ------------

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1494);
+	define('DB_UPDATE_VERSION', 1495);
 }
 
 return [
@@ -1658,6 +1658,7 @@ return [
 			"comment" => ["type" => "text", "comment" => "Report"],
 			"forward" => ["type" => "boolean", "comment" => "Forward the report to the remote server"],
 			"created" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => ""],
+			"status" => ["type" => "tinyint unsigned", "comment" => "Status of the report"],
 		],
 		"indexes" => [
 			"PRIMARY" => ["id"],
@@ -1670,6 +1671,7 @@ return [
 		"fields" => [
 			"rid" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["report" => "id"], "comment" => "Report id"],
 			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Uri-id of the reported post"],
+			"status" => ["type" => "tinyint unsigned", "comment" => "Status of the reported post"],
 		],
 		"indexes" => [
 			"PRIMARY" => ["rid", "uri-id"],


### PR DESCRIPTION
This PR simply adds a "status" field to both the reported account as well as to the reported posts.

I was unsure where to place the status constants (factory, repository or entity), so I left that out.

At first we will simply need the status "open", "rejected" and "accepted", but later we could be in need of some interim status, so "open" should be "0", but "rejected" and "accepted" should something higher so that we later can add some more status there.

You can set the status of single posts so that you keep track of your work when someone for example reported 10 posts for a single user. 