### PR TITLE
Fix broken dismiss endpoint on Mastodon notifications API

### DIFF
--- a/src/Module/Api/Mastodon/Notifications/Dismiss.php
+++ b/src/Module/Api/Mastodon/Notifications/Dismiss.php
@@ -41,7 +41,8 @@ class Dismiss extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$Notification = DI::notification()->selectOneForUser($uid, $this->parameters['id']);
+		$condition = ['id' => $this->parameters['id']];
+		$Notification = DI::notification()->selectOneForUser($uid, $condition);
 		$Notification->setDismissed();
 		DI::notification()->save($Notification);
 


### PR DESCRIPTION
The notifications dismiss endpoint was broken since an argument into the condition parameter of selectOneForUser was not constructed correctly. 