### PR TITLE
Add dismissed field to mastodon notifications

### DIFF
--- a/src/Factory/Api/Mastodon/Notification.php
+++ b/src/Factory/Api/Mastodon/Notification.php
@@ -70,7 +70,9 @@ class Notification extends BaseFactory
 			$status = null;
 		}
 
-		return new MstdnNotification($Notification->id, $type, $Notification->created, $account, $status);
+		$dismissed = $Notification->dismissed;
+
+		return new MstdnNotification($Notification->id, $type, $Notification->created, $account, $status, $dismissed);
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Notification.php
+++ b/src/Factory/Api/Mastodon/Notification.php
@@ -70,9 +70,7 @@ class Notification extends BaseFactory
 			$status = null;
 		}
 
-		$dismissed = $Notification->dismissed;
-
-		return new MstdnNotification($Notification->id, $type, $Notification->created, $account, $status, $dismissed);
+		return new MstdnNotification($Notification->id, $type, $Notification->created, $account, $status, $Notification->dismissed);
 	}
 
 	/**

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -63,12 +63,16 @@ class Notifications extends BaseApi
 			'exclude_types' => [],    // Array of types to exclude (follow, favourite, reblog, mention, poll, follow_request)
 			'account_id'    => 0,     // Return only notifications received from this account
 			'with_muted'    => false, // Pleroma extension: return activities by muted (not by blocked!) users.
-			'count'         => 0,     // Unknown parameter
+			'count'         => 0,
+			'include_all'   => false  // Include dismissed and undismissed
 		], $request);
 
 		$params = ['order' => ['id' => true]];
 
 		$condition = ['uid' => $uid, 'dismissed' => false];
+		if($request['include_all']) {
+			$condition = ['uid' => $uid];
+		}
 
 		if (!empty($request['account_id'])) {
 			$contact = Contact::getById($request['account_id'], ['url']);

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -70,7 +70,7 @@ class Notifications extends BaseApi
 		$params = ['order' => ['id' => true]];
 
 		$condition = ['uid' => $uid, 'dismissed' => false];
-		if($request['include_all']) {
+		if ($request['include_all']) {
 			$condition = ['uid' => $uid];
 		}
 

--- a/src/Object/Api/Mastodon/Notification.php
+++ b/src/Object/Api/Mastodon/Notification.php
@@ -56,6 +56,8 @@ class Notification extends BaseDataTransferObject
 	protected $type;
 	/** @var string (Datetime) */
 	protected $created_at;
+	/** @var bool */
+	protected $dismissed;
 	/** @var Account */
 	protected $account;
 	/** @var Status|null */
@@ -66,12 +68,13 @@ class Notification extends BaseDataTransferObject
 	 *
 	 * @throws HttpException\InternalServerErrorException|Exception
 	 */
-	public function __construct(int $id, string $type, \DateTime $created_at, Account $account = null, Status $status = null)
+	public function __construct(int $id, string $type, \DateTime $created_at, Account $account = null, Status $status = null, bool $dismissed = false)
 	{
 		$this->id         = (string)$id;
 		$this->type       = $type;
 		$this->created_at = $created_at->format(DateTimeFormat::JSON);
 		$this->account    = $account->toArray();
+		$this->dismissed  = $dismissed;
 
 		if (!empty($status)) {
 			$this->status = $status->toArray();


### PR DESCRIPTION
I wanted to have the ability to have both dismissed and non-dismissed notifications. This required adding a new field to the return Notification objected named `dismissed` which reflects the nomenclature of the Mastodon endpoint but is a field that doesn't exist in the spec. It also adds an "include_all" query parameter so that by default the endpoint operates exactly like Mastodon's in only returning non-dismissed notifications. By including this parameter one can get dismissed endpoints as well as non-dismissed ones.