### PR TITLE
get the load average in a portable manner

### DIFF
--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -445,7 +445,7 @@ class System
 		if (@is_readable('/proc/loadavg')) {
 			$content = @file_get_contents('/proc/loadavg');
 			if (empty($content)) {
-				$content = shell_exec('cat /proc/loadavg');
+				$content = shell_exec('uptime | sed "s/.*e: //" | sed "s/,//"');
 			}
 		}
 

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -445,7 +445,7 @@ class System
 		if (@is_readable('/proc/loadavg')) {
 			$content = @file_get_contents('/proc/loadavg');
 			if (empty($content)) {
-				$content = shell_exec('uptime | sed "s/.*e: //" | sed "s/,//"');
+				$content = shell_exec('uptime | sed "s/.*averages*: //" | sed "s/,//"');
 			}
 		}
 

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -445,7 +445,7 @@ class System
 		if (@is_readable('/proc/loadavg')) {
 			$content = @file_get_contents('/proc/loadavg');
 			if (empty($content)) {
-				$content = shell_exec('uptime | sed "s/.*averages*: //" | sed "s/,//"');
+				$content = shell_exec('uptime | sed "s/.*averages*: //" | sed "s/,//g"');
 			}
 		}
 


### PR DESCRIPTION
Currently it is using `/proc/loadavg` to to get load average, which is a very none portable as it assume the base OS is Linux, even though it could easily be any other unix.

This replaces attempting to read `/proc/loadavg` a second time if the first time fails with actually getting the load average via a means can be used on anything vaguely unix like, `uptime | sed "s/.*averages*: //" | sed "s/,//g"`. Test on FreeBSD 12, FreeBSD 13, Debian 11, and Ubuntu 20.04.
