### PR TITLE
Only fetch the processes if needed

### DIFF
--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -438,11 +438,12 @@ class System
 	/**
 	 * Fetch the load and number of processes
 	 *
+	 * @param bool $get_processes
 	 * @return array
 	 */
-	public static function getLoadAvg(): array
+	public static function getLoadAvg(bool $get_processes = true): array
 	{
-		if (@is_readable('/proc/loadavg')) {
+		if ($get_processes && @is_readable('/proc/loadavg')) {
 			$content = @file_get_contents('/proc/loadavg');
 			if (empty($content)) {
 				$content = shell_exec('uptime | sed "s/.*averages*: //" | sed "s/,//g"');

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -462,7 +462,7 @@ class Worker
 			return false;
 		}
 
-		$load = System::getLoadAvg();
+		$load = System::getLoadAvg($processes_cooldown != 0);
 		if (empty($load)) {
 			return false;
 		}
@@ -508,7 +508,7 @@ class Worker
 
 		$sleeping = false;
 
-		while ($load = System::getLoadAvg()) {
+		while ($load = System::getLoadAvg($processes_cooldown != 0)) {
 			if (($load_cooldown > 0) && ($load['average1'] > $load_cooldown)) {
 				if (!$sleeping) {
 					Logger::notice('Load induced pre execution cooldown.', ['max' => $load_cooldown, 'load' => $load, 'called-by' => System::callstack(1)]);


### PR DESCRIPTION
There is no need to have to perform some shell magic to fetch the running processes when we don't need them.