### PR TITLE
Issue 10518: "last-activity" instead of "login_date"

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2022.12-dev (Giant Rhubarb)
--- DB_UPDATE_VERSION 1496
+-- DB_UPDATE_VERSION 1497
 -- ------------------------------------------
 
 
@@ -2693,6 +2693,7 @@ CREATE VIEW `owner-view` AS SELECT
 	`user`.`language` AS `language`,
 	`user`.`register_date` AS `register_date`,
 	`user`.`login_date` AS `login_date`,
+	IF (`user`.`last-activity` IS NULL, DATE(`user`.`login_date`), `user`.`last-activity`) AS `last-activity`,
 	`user`.`default-location` AS `default-location`,
 	`user`.`allow_location` AS `allow_location`,
 	`user`.`theme` AS `theme`,

--- a/database.sql
+++ b/database.sql
@@ -2693,7 +2693,7 @@ CREATE VIEW `owner-view` AS SELECT
 	`user`.`language` AS `language`,
 	`user`.`register_date` AS `register_date`,
 	`user`.`login_date` AS `login_date`,
-	IF (`user`.`last-activity` IS NULL, DATE(`user`.`login_date`), `user`.`last-activity`) AS `last-activity`,
+	`user`.`last-activity` AS `last-activity`,
 	`user`.`default-location` AS `default-location`,
 	`user`.`allow_location` AS `allow_location`,
 	`user`.`theme` AS `theme`,

--- a/src/Console/User.php
+++ b/src/Console/User.php
@@ -370,7 +370,7 @@ HELP;
 						$contact['url'],
 						$contact['email'],
 						Temporal::getRelativeDate($contact['created']),
-						Temporal::getRelativeDate($contact['login_date']),
+						Temporal::getRelativeDate($contact['last-activity']),
 						Temporal::getRelativeDate($contact['last-item']),
 					]);
 				}
@@ -396,7 +396,7 @@ HELP;
 			'nickname',
 			'email',
 			'register_date',
-			'login_date',
+			'last-activity',
 			'verified',
 			'blocked',
 		];

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -682,6 +682,8 @@ class User
 
 		if ($user['last-activity'] != $current_day) {
 			User::update(['last-activity' => $current_day], $uid);
+			// Set the last actitivy for all identities of the user
+			DBA::update('user', ['last-activity' => $current_day], ['parent-uid' => $uid, 'account_removed' => false]);
 		}
 	}
 
@@ -1729,8 +1731,8 @@ class User
 			'active_users_weekly'   => 0,
 		];
 
-		$userStmt = DBA::select('owner-view', ['uid', 'login_date', 'last-item'],
-			["`verified` AND `login_date` > ? AND NOT `blocked`
+		$userStmt = DBA::select('owner-view', ['uid', 'last-activity', 'last-item'],
+			["`verified` AND `last-activity` > ? AND NOT `blocked`
 			AND NOT `account_removed` AND NOT `account_expired`",
 			DBA::NULL_DATETIME]);
 		if (!DBA::isResult($userStmt)) {
@@ -1744,17 +1746,17 @@ class User
 		while ($user = DBA::fetch($userStmt)) {
 			$statistics['total_users']++;
 
-			if ((strtotime($user['login_date']) > $halfyear) || (strtotime($user['last-item']) > $halfyear)
+			if ((strtotime($user['last-activity']) > $halfyear) || (strtotime($user['last-item']) > $halfyear)
 			) {
 				$statistics['active_users_halfyear']++;
 			}
 
-			if ((strtotime($user['login_date']) > $month) || (strtotime($user['last-item']) > $month)
+			if ((strtotime($user['last-activity']) > $month) || (strtotime($user['last-item']) > $month)
 			) {
 				$statistics['active_users_monthly']++;
 			}
 
-			if ((strtotime($user['login_date']) > $week) || (strtotime($user['last-item']) > $week)
+			if ((strtotime($user['last-activity']) > $week) || (strtotime($user['last-item']) > $week)
 			) {
 				$statistics['active_users_weekly']++;
 			}

--- a/src/Module/Moderation/BaseUsers.php
+++ b/src/Module/Moderation/BaseUsers.php
@@ -137,7 +137,7 @@ abstract class BaseUsers extends BaseModeration
 			$user['account_type']     = ($user['page_flags_raw'] == 0) ? $account_types[$user['account-type']] : '';
 
 			$user['register_date'] = Temporal::getRelativeDate($user['register_date']);
-			$user['login_date']    = Temporal::getRelativeDate($user['login_date']);
+			$user['login_date']    = Temporal::getRelativeDate($user['last-activity']);
 			$user['lastitem_date'] = Temporal::getRelativeDate($user['last-item']);
 			$user['is_admin']      = in_array($user['email'], $adminlist);
 			$user['is_deletable']  = !$user['account_removed'] && intval($user['uid']) != $this->session->getLocalUserId();

--- a/src/Module/Moderation/Users/Active.php
+++ b/src/Module/Moderation/Users/Active.php
@@ -100,7 +100,7 @@ class Active extends BaseUsers
 			'name',
 			'email',
 			'register_date',
-			'login_date',
+			'last-activity',
 			'last-item',
 			'page-flags',
 		];

--- a/src/Module/Moderation/Users/Blocked.php
+++ b/src/Module/Moderation/Users/Blocked.php
@@ -100,7 +100,7 @@ class Blocked extends BaseUsers
 			'name',
 			'email',
 			'register_date',
-			'login_date',
+			'last-activity',
 			'last-item',
 			'page-flags',
 		];

--- a/src/Module/Moderation/Users/Deleted.php
+++ b/src/Module/Moderation/Users/Deleted.php
@@ -49,7 +49,7 @@ class Deleted extends BaseUsers
 			'name',
 			'email',
 			'register_date',
-			'login_date',
+			'last-activity',
 			'last-item',
 			'page-flags',
 		];

--- a/src/Module/Moderation/Users/Index.php
+++ b/src/Module/Moderation/Users/Index.php
@@ -114,7 +114,7 @@ class Index extends BaseUsers
 			'name',
 			'email',
 			'register_date',
-			'login_date',
+			'last-activity',
 			'last-item',
 			'page-flags',
 		];

--- a/src/Module/NoScrape.php
+++ b/src/Module/NoScrape.php
@@ -94,18 +94,9 @@ class NoScrape extends BaseModule
 		}
 
 		// We display the last activity (post or login), reduced to year and week number
-		$last_active = 0;
-		$condition   = ['uid' => $owner['uid'], 'self' => true];
-		$contact     = DBA::selectFirst('contact', ['last-item'], $condition);
-		if (DBA::isResult($contact)) {
-			$last_active = strtotime($contact['last-item']);
-		}
-
-		$user = User::getOwnerDataById($owner['uid']);
-		if (DBA::isResult($user)) {
-			if ($last_active < strtotime($user['last-activity'])) {
-				$last_active = strtotime($user['last-activity']);
-			}
+		$last_active = strtotime($owner['last-item']);
+		if ($last_active < strtotime($owner['last-activity'])) {
+			$last_active = strtotime($owner['last-activity']);
 		}
 		$json_info['last-activity'] = date('o-W', $last_active);
 

--- a/src/Module/NoScrape.php
+++ b/src/Module/NoScrape.php
@@ -101,11 +101,10 @@ class NoScrape extends BaseModule
 			$last_active = strtotime($contact['last-item']);
 		}
 
-		$condition = ['uid' => $owner['uid']];
-		$user      = DBA::selectFirst('user', ['login_date'], $condition);
+		$user = User::getOwnerDataById($owner['uid']);
 		if (DBA::isResult($user)) {
-			if ($last_active < strtotime($user['login_date'])) {
-				$last_active = strtotime($user['login_date']);
+			if ($last_active < strtotime($user['last-activity'])) {
+				$last_active = strtotime($user['last-activity']);
 			}
 		}
 		$json_info['last-activity'] = date('o-W', $last_active);

--- a/src/Security/Authentication.php
+++ b/src/Security/Authentication.php
@@ -356,7 +356,7 @@ class Authentication
 			$this->dba->update('user', ['last-activity' => DateTimeFormat::utcNow('Y-m-d'), 'login_date' => DateTimeFormat::utcNow()], ['uid' => $user_record['uid']]);
 
 			// Set the login date for all identities of the user
-			$this->dba->update('user', ['login_date' => DateTimeFormat::utcNow()],
+			$this->dba->update('user', ['last-activity' => DateTimeFormat::utcNow('Y-m-d'), 'login_date' => DateTimeFormat::utcNow()],
 				['parent-uid' => $user_record['uid'], 'account_removed' => false]);
 
 			// Regularly update suggestions

--- a/src/Worker/PollContacts.php
+++ b/src/Worker/PollContacts.php
@@ -45,7 +45,7 @@ class PollContacts
 
 		if (!empty($abandon_days)) {
 			$condition = DBA::mergeConditions($condition,
-				["`uid` != ? AND `uid` IN (SELECT `uid` FROM `user` WHERE NOT `account_expired` AND NOT `account_removed`  AND `login_date` > ?)", 0, DateTimeFormat::utc('now - ' . $abandon_days . ' days')]);
+				["`uid` != ? AND `uid` IN (SELECT `uid` FROM `owner-view` WHERE NOT `account_expired` AND NOT `account_removed` AND `last-activity` > ?)", 0, DateTimeFormat::utc('now - ' . $abandon_days . ' days')]);
 		} else 	{
 			$condition = DBA::mergeConditions($condition,
 				["`uid` != ? AND `uid` IN (SELECT `uid` FROM `user` WHERE NOT `account_expired` AND NOT `account_removed`)", 0]);

--- a/src/Worker/PollContacts.php
+++ b/src/Worker/PollContacts.php
@@ -45,7 +45,7 @@ class PollContacts
 
 		if (!empty($abandon_days)) {
 			$condition = DBA::mergeConditions($condition,
-				["`uid` != ? AND `uid` IN (SELECT `uid` FROM `owner-view` WHERE NOT `account_expired` AND NOT `account_removed` AND `last-activity` > ?)", 0, DateTimeFormat::utc('now - ' . $abandon_days . ' days')]);
+				["`uid` != ? AND `uid` IN (SELECT `uid` FROM `user` WHERE NOT `account_expired` AND NOT `account_removed` AND `last-activity` > ?)", 0, DateTimeFormat::utc('now - ' . $abandon_days . ' days')]);
 		} else 	{
 			$condition = DBA::mergeConditions($condition,
 				["`uid` != ? AND `uid` IN (SELECT `uid` FROM `user` WHERE NOT `account_expired` AND NOT `account_removed`)", 0]);

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1496);
+	define('DB_UPDATE_VERSION', 1497);
 }
 
 return [

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -889,7 +889,7 @@
 			"language" => ["user", "language"],
 			"register_date" => ["user", "register_date"],
 			"login_date" => ["user", "login_date"],
-			"last-activity" => "IF (`user`.`last-activity` IS NULL, DATE(`user`.`login_date`), `user`.`last-activity`)",
+			"last-activity" => ["user", "last-activity"],
 			"default-location" => ["user", "default-location"],
 			"allow_location" => ["user", "allow_location"],
 			"theme" => ["user", "theme"],

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -889,6 +889,7 @@
 			"language" => ["user", "language"],
 			"register_date" => ["user", "register_date"],
 			"login_date" => ["user", "login_date"],
+			"last-activity" => "IF (`user`.`last-activity` IS NULL, DATE(`user`.`login_date`), `user`.`last-activity`)",
 			"default-location" => ["user", "default-location"],
 			"allow_location" => ["user", "allow_location"],
 			"theme" => ["user", "theme"],

--- a/update.php
+++ b/update.php
@@ -1127,3 +1127,9 @@ function update_1491()
 	DBA::update('contact', ['remote_self' => Contact::MIRROR_OWN_POST], ['remote_self' => Contact::MIRROR_FORWARDED]);
 	return Update::SUCCESS;
 }
+
+function update_1497()
+{
+	DBA::e("UPDATE `user` SET `last-activity` = DATE(`login_date`) WHERE `last-activity` IS NULL");
+	return Update::SUCCESS;
+}


### PR DESCRIPTION
As a solution for #10518 we now use the "last-activity" date instead of "login_date"