### PR TITLE
Use the blurhash when the remote picture doesn't load

### DIFF
--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -353,7 +353,7 @@ class Photo
 	 * @return array
 	 * @throws \Exception
 	 */
-	public static function createPhotoForExternalResource(string $url, int $uid = 0, string $mimetype = '', string $blurhash = '', int $width = 0, int $height = 0): array
+	public static function createPhotoForExternalResource(string $url, int $uid = 0, string $mimetype = '', string $blurhash = null, int $width = null, int $height = null): array
 	{
 		if (empty($mimetype)) {
 			$mimetype = Images::guessTypeByExtension($url);

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -346,11 +346,14 @@ class Photo
 	 * @param string $url      Image URL
 	 * @param int    $uid      User ID of the requesting person
 	 * @param string $mimetype Image mime type. Is guessed by file name when empty.
+	 * @param string $blurhash The blurhash that will be used to generate a picture when the original picture can't be fetched
+	 * @param int    $width    Image width
+	 * @param int    $height   Image height
 	 *
 	 * @return array
 	 * @throws \Exception
 	 */
-	public static function createPhotoForExternalResource(string $url, int $uid = 0, string $mimetype = ''): array
+	public static function createPhotoForExternalResource(string $url, int $uid = 0, string $mimetype = '', string $blurhash = '', int $width = 0, int $height = 0): array
 	{
 		if (empty($mimetype)) {
 			$mimetype = Images::guessTypeByExtension($url);
@@ -364,6 +367,9 @@ class Photo
 		$photo['backend-ref']   = json_encode(['url' => $url, 'uid' => $uid]);
 		$photo['type']          = $mimetype;
 		$photo['cacheable']     = true;
+		$photo['blurhash']      = $blurhash;
+		$photo['width']         = $width;
+		$photo['height']        = $height;
 
 		return $photo;
 	}

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -780,13 +780,21 @@ class Image
 			return;
 		}
 
-		$pixels = Blurhash::decode($blurhash, $width, $height);
-		$this->image  = imagecreatetruecolor($width, $height);
-		for ($y = 0; $y < $height; ++$y) {
-			for ($x = 0; $x < $width; ++$x) {
+		$scaled = Images::getScalingDimensions($width, $height, 90);
+		$pixels = Blurhash::decode($blurhash, $scaled['width'], $scaled['height']);
+
+		$this->image = imagecreatetruecolor($scaled['width'], $scaled['height']);
+		for ($y = 0; $y < $scaled['height']; ++$y) {
+			for ($x = 0; $x < $scaled['width']; ++$x) {
 				[$r, $g, $b] = $pixels[$y][$x];
 				imagesetpixel($this->image, $x, $y, imagecolorallocate($this->image, $r, $g, $b));
 			}
 		}
+
+		$this->width  = imagesx($this->image);
+		$this->height = imagesy($this->image);
+		$this->valid  = true;
+
+		$this->scaleUp(min($width, $height));
 	}
 }


### PR DESCRIPTION
Follow up to #12325

When the remote picture can't be fetched, we now display the picture that had been created out of the blurhash.