### PR TITLE
API: Only search for direct hit without offset

### DIFF
--- a/src/Module/Api/Mastodon/Accounts/Search.php
+++ b/src/Module/Api/Mastodon/Accounts/Search.php
@@ -29,7 +29,7 @@ use Friendica\Module\BaseApi;
 use Friendica\Util\Network;
 
 /**
- * @see https://docs.joinmastodon.org/methods/accounts/
+ * @see https://docs.joinmastodon.org/methods/accounts/#search
  */
 class Search extends BaseApi
 {
@@ -44,13 +44,14 @@ class Search extends BaseApi
 		$request = $this->getRequest([
 			'q'         => '',    // What to search for
 			'limit'     => 40,    // Maximum number of results. Defaults to 40.
+			'offset'    => 0,     // Offset in search results. Used for pagination. Defaults to 0.
 			'resolve'   => false, // Attempt WebFinger lookup. Defaults to false. Use this when q is an exact address.
 			'following' => false, // Only who the user is following. Defaults to false.
 		], $request);
 
 		$accounts = [];
 
-		if ((strrpos($request['q'], '@') > 0) || Network::isValidHttpUrl($request['q'])) {
+		if (($request['offset'] == 0) && (Network::isValidHttpUrl($request['q']) || (strrpos($request['q'], '@') > 0))) {
 			$id = Contact::getIdForURL($request['q'], 0, $request['resolve'] ? null : false);
 
 			if (!empty($id)) {
@@ -59,7 +60,7 @@ class Search extends BaseApi
 		}
 
 		if (empty($accounts)) {
-			$contacts = Contact::searchByName($request['q'], '', $request['following'] ? $uid : 0, $request['limit']);
+			$contacts = Contact::searchByName($request['q'], '', $request['following'] ? $uid : 0, $request['limit'], $request['offset']);
 			foreach ($contacts as $contact) {
 				$accounts[] = DI::mstdnAccount()->createFromContactId($contact['id'], $uid);
 			}

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -108,7 +108,7 @@ class Search extends BaseApi
 	private static function searchAccounts(int $uid, string $q, bool $resolve, int $limit, int $offset, bool $following)
 	{
 		if (
-			(strrpos($q, '@') > 0 || Network::isValidHttpUrl($q))
+			($offset == 0) && (strrpos($q, '@') > 0 || Network::isValidHttpUrl($q))
 			&& $id = Contact::getIdForURL($q, 0, $resolve ? null : false)
 		) {
 			return DI::mstdnAccount()->createFromContactId($id, $uid);


### PR DESCRIPTION
This fixes the problem that searches for contacts via API ended in an endless list of the same contact since clients like Tusky are using the offset to search for the next hits.