### PR TITLE
The appearance of the link preview is now configurable

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -68,6 +68,12 @@ class BBCode
 
 	const TOP_ANCHOR = '<br class="top-anchor">';
 	const BOTTOM_ANCHOR = '<br class="button-anchor">';
+
+	const PREVIEW_NONE     = 0;
+	const PREVIEW_NO_IMAGE = 1;
+	const PREVIEW_LARGE    = 2;
+	const PREVIEW_SMALL    = 3;
+
 	/**
 	 * Fetches attachment data that were generated the old way
 	 *
@@ -654,7 +660,7 @@ class BBCode
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function convertAttachment(string $text, int $simplehtml = self::INTERNAL, bool $tryoembed = true, array $data = [], int $uriid = 0): string
+	public static function convertAttachment(string $text, int $simplehtml = self::INTERNAL, bool $tryoembed = true, array $data = [], int $uriid = 0, int $preview_mode = self::PREVIEW_LARGE): string
 	{
 		DI::profiler()->startRecording('rendering');
 		$data = $data ?: self::getAttachmentData($text);
@@ -689,12 +695,18 @@ class BBCode
 				$return = sprintf('<div class="type-%s">', $data['type']);
 			}
 
+			if ($preview_mode == self::PREVIEW_NO_IMAGE) {
+				unset($data['image']);
+				unset($data['preview']);
+			}
+
 			if (!empty($data['title']) && !empty($data['url'])) {
+				$preview_class = $preview_mode == self::PREVIEW_LARGE ? 'attachment-image' : 'attachment-preview';
 				if (!empty($data['image']) && empty($data['text']) && ($data['type'] == 'photo')) {
-					$return .= sprintf('<a href="%s" target="_blank" rel="noopener noreferrer"><img src="%s" alt="" title="%s" class="attachment-image" /></a>', $data['url'], self::proxyUrl($data['image'], $simplehtml, $uriid), $data['title']);
+					$return .= sprintf('<a href="%s" target="_blank" rel="noopener noreferrer"><img src="%s" alt="" title="%s" class="' . $preview_class . '" /></a>', $data['url'], self::proxyUrl($data['image'], $simplehtml, $uriid), $data['title']);
 				} else {
 					if (!empty($data['image'])) {
-						$return .= sprintf('<a href="%s" target="_blank" rel="noopener noreferrer"><img src="%s" alt="" title="%s" class="attachment-image" /></a><br>', $data['url'], self::proxyUrl($data['image'], $simplehtml, $uriid), $data['title']);
+						$return .= sprintf('<a href="%s" target="_blank" rel="noopener noreferrer"><img src="%s" alt="" title="%s" class="' . $preview_class . '" /></a><br>', $data['url'], self::proxyUrl($data['image'], $simplehtml, $uriid), $data['title']);
 					} elseif (!empty($data['preview'])) {
 						$return .= sprintf('<a href="%s" target="_blank" rel="noopener noreferrer"><img src="%s" alt="" title="%s" class="attachment-preview" /></a><br>', $data['url'], self::proxyUrl($data['preview'], $simplehtml, $uriid), $data['title']);
 					}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3004,7 +3004,7 @@ class Item
 		$item['hashtags'] = $tags['hashtags'];
 		$item['mentions'] = $tags['mentions'];
 
-		$body = $item['body'] ?? '';
+		$body = $item['body'] = Post\Media::removeFromEndOfBody($item['body'] ?? '');
 
 		$fields = ['uri-id', 'uri', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'network', 'has-media', 'quote-uri-id', 'post-type'];
 
@@ -3402,7 +3402,10 @@ class Item
 				}
 
 				// @todo Use a template
-				$rendered = BBCode::convertAttachment('', BBCode::INTERNAL, false, $data, $uriid);
+				$preview_mode =  DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'preview_mode', BBCode::PREVIEW_LARGE);
+				if ($preview_mode != BBCode::PREVIEW_NONE) {
+					$rendered = BBCode::convertAttachment('', BBCode::INTERNAL, false, $data, $uriid, $preview_mode);
+				}
 			} elseif (!self::containsLink($content, $data['url'], Post\Media::HTML)) {
 				$rendered = Renderer::replaceMacros(Renderer::getMarkupTemplate('content/link.tpl'), [
 					'$url'  => $data['url'],

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -21,7 +21,9 @@
 
 namespace Friendica\Module\Settings;
 
+use Friendica\Content\Text\BBCode;
 use Friendica\Core\Hook;
+use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
 use Friendica\Core\Theme;
 use Friendica\Database\DBA;
@@ -55,6 +57,7 @@ class Display extends BaseSettings
 		$enable_dislike         = !empty($_POST['enable_dislike'])         ? intval($_POST['enable_dislike'])       : 0;
 		$display_resharer       = !empty($_POST['display_resharer'])       ? intval($_POST['display_resharer'])   : 0;
 		$stay_local             = !empty($_POST['stay_local'])             ? intval($_POST['stay_local'])         : 0;
+		$preview_mode           = !empty($_POST['preview_mode'])           ? intval($_POST['preview_mode'])  : 0;
 		$browser_update         = !empty($_POST['browser_update'])         ? intval($_POST['browser_update'])     : 0;
 		if ($browser_update != -1) {
 			$browser_update = $browser_update * 1000;
@@ -91,6 +94,7 @@ class Display extends BaseSettings
 		DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'system', 'display_resharer'        , $display_resharer);
 		DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'system', 'stay_local'              , $stay_local);
 		DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'system', 'first_day_of_week'       , $first_day_of_week);
+		DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'system', 'preview_mode'            , $preview_mode);
 
 		if (in_array($theme, Theme::getAllowedList())) {
 			if ($theme == $user['theme']) {
@@ -175,7 +179,7 @@ class Display extends BaseSettings
 		$enable_dislike         = !DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'hide_dislike', 0);
 		$display_resharer       =  DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'display_resharer', 0);
 		$stay_local             =  DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'stay_local', 0);
-
+		$preview_mode           =  DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'preview_mode', BBCode::PREVIEW_LARGE);
 
 		$first_day_of_week = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'first_day_of_week', 0);
 		$weekdays = [
@@ -186,6 +190,13 @@ class Display extends BaseSettings
 			4 => DI::l10n()->t("Thursday"),
 			5 => DI::l10n()->t("Friday"),
 			6 => DI::l10n()->t("Saturday")
+		];
+
+		$preview_modes = [
+			BBCode::PREVIEW_NONE     => DI::l10n()->t('No preview'),
+			BBCode::PREVIEW_NO_IMAGE => DI::l10n()->t('No image'),
+			BBCode::PREVIEW_SMALL    => DI::l10n()->t('Small Image'),
+			BBCode::PREVIEW_LARGE    => DI::l10n()->t('Large Image'),
 		];
 
 		$theme_config = '';
@@ -222,6 +233,7 @@ class Display extends BaseSettings
 			'$enable_dislike'           => ['enable_dislike'          , DI::l10n()->t('Display the Dislike feature'), $enable_dislike, DI::l10n()->t('Display the Dislike button and dislike reactions on posts and comments.')],
 			'$display_resharer'         => ['display_resharer'        , DI::l10n()->t('Display the resharer'), $display_resharer, DI::l10n()->t('Display the first resharer as icon and text on a reshared item.')],
 			'$stay_local'               => ['stay_local'              , DI::l10n()->t('Stay local'), $stay_local, DI::l10n()->t("Don't go to a remote system when following a contact link.")],
+			'$preview_mode'             => ['preview_mode'            , DI::l10n()->t('Link preview mode'), $preview_mode, 'Appearance of the link preview that is added to each post with a link.', $preview_modes, false],
 
 			'$first_day_of_week' => ['first_day_of_week', DI::l10n()->t('Beginning of week:'), $first_day_of_week, '', $weekdays, false],
 		]);

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2022.12-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-04 06:41-0500\n"
+"POT-Creation-Date: 2022-12-07 07:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,7 +47,7 @@ msgstr ""
 #: src/Module/Register.php:245 src/Module/Search/Directory.php:37
 #: src/Module/Settings/Account.php:50 src/Module/Settings/Account.php:407
 #: src/Module/Settings/Delegation.php:41 src/Module/Settings/Delegation.php:69
-#: src/Module/Settings/Display.php:41 src/Module/Settings/Display.php:119
+#: src/Module/Settings/Display.php:43 src/Module/Settings/Display.php:123
 #: src/Module/Settings/Profile/Photo/Crop.php:165
 #: src/Module/Settings/Profile/Photo/Index.php:111
 #: src/Module/Settings/RemoveMe.php:117 src/Module/Settings/UserExport.php:80
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Enter user nickname: "
 msgstr ""
 
-#: src/Console/User.php:182 src/Model/User.php:661
+#: src/Console/User.php:182 src/Model/User.php:662
 #: src/Module/Api/Twitter/ContactEndpoint.php:74
 #: src/Module/Moderation/Users/Active.php:71
 #: src/Module/Moderation/Users/Blocked.php:71
@@ -1670,7 +1670,7 @@ msgstr ""
 #: src/Content/Nav.php:197 src/Content/Nav.php:257
 #: src/Module/BaseProfile.php:85 src/Module/BaseProfile.php:88
 #: src/Module/BaseProfile.php:96 src/Module/BaseProfile.php:99
-#: src/Module/Settings/Display.php:205 view/theme/frio/theme.php:242
+#: src/Module/Settings/Display.php:216 view/theme/frio/theme.php:242
 #: view/theme/frio/theme.php:246
 msgid "Calendar"
 msgstr ""
@@ -1909,39 +1909,39 @@ msgstr ""
 msgid "last"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1003 src/Content/Text/BBCode.php:1865
-#: src/Content/Text/BBCode.php:1866
+#: src/Content/Text/BBCode.php:1015 src/Content/Text/BBCode.php:1877
+#: src/Content/Text/BBCode.php:1878
 msgid "Image/photo"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1220
+#: src/Content/Text/BBCode.php:1232
 #, php-format
 msgid ""
 "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1245 src/Model/Item.php:3536
-#: src/Model/Item.php:3542 src/Model/Item.php:3543
+#: src/Content/Text/BBCode.php:1257 src/Model/Item.php:3539
+#: src/Model/Item.php:3545 src/Model/Item.php:3546
 msgid "Link to source"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1783 src/Content/Text/HTML.php:940
+#: src/Content/Text/BBCode.php:1795 src/Content/Text/HTML.php:940
 msgid "Click to open/close"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1814
+#: src/Content/Text/BBCode.php:1826
 msgid "$1 wrote:"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1870 src/Content/Text/BBCode.php:1871
+#: src/Content/Text/BBCode.php:1882 src/Content/Text/BBCode.php:1883
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2098
+#: src/Content/Text/BBCode.php:2110
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2113
+#: src/Content/Text/BBCode.php:2125
 msgid "Invalid link protocol"
 msgstr ""
 
@@ -2542,37 +2542,37 @@ msgid "Could not connect to database."
 msgstr ""
 
 #: src/Core/L10n.php:403 src/Model/Event.php:430
-#: src/Module/Settings/Display.php:183
+#: src/Module/Settings/Display.php:187
 msgid "Monday"
 msgstr ""
 
 #: src/Core/L10n.php:403 src/Model/Event.php:431
-#: src/Module/Settings/Display.php:184
+#: src/Module/Settings/Display.php:188
 msgid "Tuesday"
 msgstr ""
 
 #: src/Core/L10n.php:403 src/Model/Event.php:432
-#: src/Module/Settings/Display.php:185
+#: src/Module/Settings/Display.php:189
 msgid "Wednesday"
 msgstr ""
 
 #: src/Core/L10n.php:403 src/Model/Event.php:433
-#: src/Module/Settings/Display.php:186
+#: src/Module/Settings/Display.php:190
 msgid "Thursday"
 msgstr ""
 
 #: src/Core/L10n.php:403 src/Model/Event.php:434
-#: src/Module/Settings/Display.php:187
+#: src/Module/Settings/Display.php:191
 msgid "Friday"
 msgstr ""
 
 #: src/Core/L10n.php:403 src/Model/Event.php:435
-#: src/Module/Settings/Display.php:188
+#: src/Module/Settings/Display.php:192
 msgid "Saturday"
 msgstr ""
 
 #: src/Core/L10n.php:403 src/Model/Event.php:429
-#: src/Module/Settings/Display.php:182
+#: src/Module/Settings/Display.php:186
 msgid "Sunday"
 msgstr ""
 
@@ -2874,63 +2874,63 @@ msgstr ""
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:2831
+#: src/Model/Contact.php:2849
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:2836 src/Module/Friendica.php:82
+#: src/Model/Contact.php:2854 src/Module/Friendica.php:82
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:2841
+#: src/Model/Contact.php:2859
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:2850
+#: src/Model/Contact.php:2868
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:2892
+#: src/Model/Contact.php:2910
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:2894
+#: src/Model/Contact.php:2912
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:2897
+#: src/Model/Contact.php:2915
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:2900
+#: src/Model/Contact.php:2918
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:2903
+#: src/Model/Contact.php:2921
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:2904
+#: src/Model/Contact.php:2922
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:2910
+#: src/Model/Contact.php:2928
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:2915
+#: src/Model/Contact.php:2933
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:2974
+#: src/Model/Contact.php:2992
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -3100,44 +3100,44 @@ msgstr ""
 msgid "Content warning: %s"
 msgstr ""
 
-#: src/Model/Item.php:3448
+#: src/Model/Item.php:3451
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3479
+#: src/Model/Item.php:3482
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3481
+#: src/Model/Item.php:3484
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3486
+#: src/Model/Item.php:3489
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3488
+#: src/Model/Item.php:3491
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3490
+#: src/Model/Item.php:3493
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3524 src/Model/Item.php:3525
+#: src/Model/Item.php:3527 src/Model/Item.php:3528
 msgid "View on separate page"
 msgstr ""
 
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "[no subject]"
 msgstr ""
 
-#: src/Model/Photo.php:1145 src/Module/Media/Photo/Upload.php:198
+#: src/Model/Photo.php:1152 src/Module/Media/Photo/Upload.php:198
 msgid "Wall Photos"
 msgstr ""
 
@@ -3294,146 +3294,146 @@ msgstr ""
 msgid "Contact information and Social Networks"
 msgstr ""
 
-#: src/Model/User.php:212 src/Model/User.php:1102
+#: src/Model/User.php:213 src/Model/User.php:1103
 msgid "SERIOUS ERROR: Generation of security keys failed."
 msgstr ""
 
-#: src/Model/User.php:570 src/Model/User.php:603
+#: src/Model/User.php:571 src/Model/User.php:604
 msgid "Login failed"
 msgstr ""
 
-#: src/Model/User.php:635
+#: src/Model/User.php:636
 msgid "Not enough information to authenticate"
 msgstr ""
 
-#: src/Model/User.php:752
+#: src/Model/User.php:753
 msgid "Password can't be empty"
 msgstr ""
 
-#: src/Model/User.php:794
+#: src/Model/User.php:795
 msgid "Empty passwords are not allowed."
 msgstr ""
 
-#: src/Model/User.php:798
+#: src/Model/User.php:799
 msgid ""
 "The new password has been exposed in a public data dump, please choose "
 "another."
 msgstr ""
 
-#: src/Model/User.php:802
+#: src/Model/User.php:803
 msgid "The password length is limited to 72 characters."
 msgstr ""
 
-#: src/Model/User.php:806
+#: src/Model/User.php:807
 msgid ""
 "The password can't contain accentuated letters, white spaces or colons (:)"
 msgstr ""
 
-#: src/Model/User.php:985
+#: src/Model/User.php:986
 msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
-#: src/Model/User.php:992
+#: src/Model/User.php:993
 msgid "An invitation is required."
 msgstr ""
 
-#: src/Model/User.php:996
+#: src/Model/User.php:997
 msgid "Invitation could not be verified."
 msgstr ""
 
-#: src/Model/User.php:1004
+#: src/Model/User.php:1005
 msgid "Invalid OpenID url"
 msgstr ""
 
-#: src/Model/User.php:1017 src/Security/Authentication.php:241
+#: src/Model/User.php:1018 src/Security/Authentication.php:241
 msgid ""
 "We encountered a problem while logging in with the OpenID you provided. "
 "Please check the correct spelling of the ID."
 msgstr ""
 
-#: src/Model/User.php:1017 src/Security/Authentication.php:241
+#: src/Model/User.php:1018 src/Security/Authentication.php:241
 msgid "The error message was:"
 msgstr ""
 
-#: src/Model/User.php:1023
+#: src/Model/User.php:1024
 msgid "Please enter the required information."
 msgstr ""
 
-#: src/Model/User.php:1037
+#: src/Model/User.php:1038
 #, php-format
 msgid ""
 "system.username_min_length (%s) and system.username_max_length (%s) are "
 "excluding each other, swapping values."
 msgstr ""
 
-#: src/Model/User.php:1044
+#: src/Model/User.php:1045
 #, php-format
 msgid "Username should be at least %s character."
 msgid_plural "Username should be at least %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1048
+#: src/Model/User.php:1049
 #, php-format
 msgid "Username should be at most %s character."
 msgid_plural "Username should be at most %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1056
+#: src/Model/User.php:1057
 msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Model/User.php:1061
+#: src/Model/User.php:1062
 msgid "Your email domain is not among those allowed on this site."
 msgstr ""
 
-#: src/Model/User.php:1065
+#: src/Model/User.php:1066
 msgid "Not a valid email address."
 msgstr ""
 
-#: src/Model/User.php:1068
+#: src/Model/User.php:1069
 msgid "The nickname was blocked from registration by the nodes admin."
 msgstr ""
 
-#: src/Model/User.php:1072 src/Model/User.php:1078
+#: src/Model/User.php:1073 src/Model/User.php:1079
 msgid "Cannot use that email."
 msgstr ""
 
-#: src/Model/User.php:1084
+#: src/Model/User.php:1085
 msgid "Your nickname can only contain a-z, 0-9 and _."
 msgstr ""
 
-#: src/Model/User.php:1092 src/Model/User.php:1149
+#: src/Model/User.php:1093 src/Model/User.php:1150
 msgid "Nickname is already registered. Please choose another."
 msgstr ""
 
-#: src/Model/User.php:1136 src/Model/User.php:1140
+#: src/Model/User.php:1137 src/Model/User.php:1141
 msgid "An error occurred during registration. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1163
+#: src/Model/User.php:1164
 msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1170
+#: src/Model/User.php:1171
 msgid "An error occurred creating your self contact. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1175
+#: src/Model/User.php:1176
 msgid "Friends"
 msgstr ""
 
-#: src/Model/User.php:1179
+#: src/Model/User.php:1180
 msgid ""
 "An error occurred creating your default contact group. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1218
+#: src/Model/User.php:1219
 msgid "Profile Photos"
 msgstr ""
 
-#: src/Model/User.php:1411
+#: src/Model/User.php:1412
 #, php-format
 msgid ""
 "\n"
@@ -3441,7 +3441,7 @@ msgid ""
 "\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: src/Model/User.php:1414
+#: src/Model/User.php:1415
 #, php-format
 msgid ""
 "\n"
@@ -3479,12 +3479,12 @@ msgid ""
 "\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: src/Model/User.php:1447 src/Model/User.php:1554
+#: src/Model/User.php:1448 src/Model/User.php:1555
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
-#: src/Model/User.php:1467
+#: src/Model/User.php:1468
 #, php-format
 msgid ""
 "\n"
@@ -3500,12 +3500,12 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:1486
+#: src/Model/User.php:1487
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: src/Model/User.php:1510
+#: src/Model/User.php:1511
 #, php-format
 msgid ""
 "\n"
@@ -3514,7 +3514,7 @@ msgid ""
 "\t\t\t"
 msgstr ""
 
-#: src/Model/User.php:1518
+#: src/Model/User.php:1519
 #, php-format
 msgid ""
 "\n"
@@ -3623,7 +3623,7 @@ msgstr ""
 #: src/Module/Settings/Account.php:560 src/Module/Settings/Addons.php:81
 #: src/Module/Settings/Connectors.php:159
 #: src/Module/Settings/Connectors.php:244
-#: src/Module/Settings/Delegation.php:169 src/Module/Settings/Display.php:200
+#: src/Module/Settings/Delegation.php:169 src/Module/Settings/Display.php:211
 #: src/Module/Settings/Features.php:76
 msgid "Save Settings"
 msgstr ""
@@ -3975,11 +3975,11 @@ msgstr ""
 msgid "%s is no valid input for maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:342 src/Module/Settings/Display.php:137
+#: src/Module/Admin/Site.php:342 src/Module/Settings/Display.php:141
 msgid "No special theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:359 src/Module/Settings/Display.php:147
+#: src/Module/Admin/Site.php:359 src/Module/Settings/Display.php:151
 #, php-format
 msgid "%s - (Experimental)"
 msgstr ""
@@ -8120,12 +8120,12 @@ msgstr ""
 msgid "The Photo with id %s is not available."
 msgstr ""
 
-#: src/Module/Photo.php:174
+#: src/Module/Photo.php:178
 #, php-format
 msgid "Invalid external resource with url %s."
 msgstr ""
 
-#: src/Module/Photo.php:176
+#: src/Module/Photo.php:180
 #, php-format
 msgid "Invalid photo with id %s."
 msgstr ""
@@ -9529,125 +9529,145 @@ msgstr ""
 msgid "No entries."
 msgstr ""
 
-#: src/Module/Settings/Display.php:106
+#: src/Module/Settings/Display.php:110
 msgid "The theme you chose isn't available."
 msgstr ""
 
-#: src/Module/Settings/Display.php:145
+#: src/Module/Settings/Display.php:149
 #, php-format
 msgid "%s - (Unsupported)"
 msgstr ""
 
+#: src/Module/Settings/Display.php:196
+msgid "No preview"
+msgstr ""
+
+#: src/Module/Settings/Display.php:197
+msgid "No image"
+msgstr ""
+
+#: src/Module/Settings/Display.php:198
+msgid "Small Image"
+msgstr ""
+
 #: src/Module/Settings/Display.php:199
+msgid "Large Image"
+msgstr ""
+
+#: src/Module/Settings/Display.php:210
 msgid "Display Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:201
+#: src/Module/Settings/Display.php:212
 msgid "General Theme Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:202
+#: src/Module/Settings/Display.php:213
 msgid "Custom Theme Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:203
+#: src/Module/Settings/Display.php:214
 msgid "Content Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:204 view/theme/duepuntozero/config.php:86
+#: src/Module/Settings/Display.php:215 view/theme/duepuntozero/config.php:86
 #: view/theme/frio/config.php:172 view/theme/quattro/config.php:88
 #: view/theme/vier/config.php:136
 msgid "Theme settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:211
+#: src/Module/Settings/Display.php:222
 msgid "Display Theme:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:212
+#: src/Module/Settings/Display.php:223
 msgid "Mobile Theme:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:215
+#: src/Module/Settings/Display.php:226
 msgid "Number of items to display per page:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:215 src/Module/Settings/Display.php:216
+#: src/Module/Settings/Display.php:226 src/Module/Settings/Display.php:227
 msgid "Maximum of 100 items"
 msgstr ""
 
-#: src/Module/Settings/Display.php:216
+#: src/Module/Settings/Display.php:227
 msgid "Number of items to display per page when viewed from mobile device:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:217
+#: src/Module/Settings/Display.php:228
 msgid "Update browser every xx seconds"
 msgstr ""
 
-#: src/Module/Settings/Display.php:217
+#: src/Module/Settings/Display.php:228
 msgid "Minimum of 10 seconds. Enter -1 to disable it."
 msgstr ""
 
-#: src/Module/Settings/Display.php:218
+#: src/Module/Settings/Display.php:229
 msgid "Automatic updates only at the top of the post stream pages"
 msgstr ""
 
-#: src/Module/Settings/Display.php:218
+#: src/Module/Settings/Display.php:229
 msgid ""
 "Auto update may add new posts at the top of the post stream pages, which can "
 "affect the scroll position and perturb normal reading if it happens anywhere "
 "else the top of the page."
 msgstr ""
 
-#: src/Module/Settings/Display.php:219
+#: src/Module/Settings/Display.php:230
 msgid "Display emoticons"
 msgstr ""
 
-#: src/Module/Settings/Display.php:219
+#: src/Module/Settings/Display.php:230
 msgid "When enabled, emoticons are replaced with matching symbols."
 msgstr ""
 
-#: src/Module/Settings/Display.php:220
+#: src/Module/Settings/Display.php:231
 msgid "Infinite scroll"
 msgstr ""
 
-#: src/Module/Settings/Display.php:220
+#: src/Module/Settings/Display.php:231
 msgid "Automatic fetch new items when reaching the page end."
 msgstr ""
 
-#: src/Module/Settings/Display.php:221
+#: src/Module/Settings/Display.php:232
 msgid "Enable Smart Threading"
 msgstr ""
 
-#: src/Module/Settings/Display.php:221
+#: src/Module/Settings/Display.php:232
 msgid "Enable the automatic suppression of extraneous thread indentation."
 msgstr ""
 
-#: src/Module/Settings/Display.php:222
+#: src/Module/Settings/Display.php:233
 msgid "Display the Dislike feature"
 msgstr ""
 
-#: src/Module/Settings/Display.php:222
+#: src/Module/Settings/Display.php:233
 msgid "Display the Dislike button and dislike reactions on posts and comments."
 msgstr ""
 
-#: src/Module/Settings/Display.php:223
+#: src/Module/Settings/Display.php:234
 msgid "Display the resharer"
 msgstr ""
 
-#: src/Module/Settings/Display.php:223
+#: src/Module/Settings/Display.php:234
 msgid "Display the first resharer as icon and text on a reshared item."
 msgstr ""
 
-#: src/Module/Settings/Display.php:224
+#: src/Module/Settings/Display.php:235
 msgid "Stay local"
 msgstr ""
 
-#: src/Module/Settings/Display.php:224
+#: src/Module/Settings/Display.php:235
 msgid "Don't go to a remote system when following a contact link."
 msgstr ""
 
-#: src/Module/Settings/Display.php:226
+#: src/Module/Settings/Display.php:236
+msgid "Link preview mode"
+msgstr ""
+
+#: src/Module/Settings/Display.php:238
 msgid "Beginning of week:"
 msgstr ""
 
@@ -11330,7 +11350,7 @@ msgstr ""
 msgid "%1$d %2$s ago"
 msgstr ""
 
-#: src/Worker/Delivery.php:534
+#: src/Worker/Delivery.php:533
 msgid "(no subject)"
 msgstr ""
 

--- a/view/templates/settings/display.tpl
+++ b/view/templates/settings/display.tpl
@@ -20,6 +20,7 @@
 	{{include file="field_checkbox.tpl" field=$enable_dislike}}
 	{{include file="field_checkbox.tpl" field=$display_resharer}}
 	{{include file="field_checkbox.tpl" field=$stay_local}}
+	{{include file="field_select.tpl" field=$preview_mode}}
 
 	<h2>{{$calendar_title}}</h2>
 	{{include file="field_select.tpl" field=$first_day_of_week}}

--- a/view/theme/frio/templates/settings/display.tpl
+++ b/view/theme/frio/templates/settings/display.tpl
@@ -67,6 +67,7 @@
 						{{include file="field_checkbox.tpl" field=$enable_dislike}}
 						{{include file="field_checkbox.tpl" field=$display_resharer}}
 						{{include file="field_checkbox.tpl" field=$stay_local}}
+						{{include file="field_select.tpl" field=$preview_mode}}
 					</div>
 					<div class="panel-footer">
 						<button type="submit" name="submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>


### PR DESCRIPTION
To unify the behaviour between the different systems and because of adding automated quoted posts, we now always add a preview for links. This also reflects the behaviour of what users on other systems will experience on their own systems.

This can be unexpected and especially large images can be disturbing, see #12345. So now the user can control how previews appear for them.