### PR TITLE
css specification for oversized button in composer

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -40,6 +40,11 @@ a.btn, a.btn:hover {
 	height: 48px;
 }
 
+.template-icon {
+	width: 24px;
+	height: 24px;
+}
+
 /* List of social Networks */
 img.connector, img.connector-disabled {
   height: 40px;


### PR DESCRIPTION
In order to specify the buttons in the composer in the correct size again, an additional specification has been added. This can also be used for other oversized buttons.