### PR TITLE
Diaspora added to localprobe

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -2211,8 +2211,6 @@ class Probe
 			$approfile = ActivityPub\Transmitter::getProfile($uid);
 
 			$split_name = Diaspora::splitName($owner['name']);
-			$firstname = $split_name['first'];
-			$lastname = $split_name['last'];
 	
 			if (empty($owner['gsid'])) {
 				$owner['gsid'] = GServer::getID($approfile['generator']['url']);
@@ -2237,8 +2235,8 @@ class Probe
 				'networks' => [
 					Protocol::DIASPORA => [
 						'name'         => $owner['name'],
-						'given_name'   => $firstname,
-						'family_name'  => $lastname,
+						'given_name'   => $split_name['first'],
+						'family_name'  => $split_name['last'],
 						'nick'         => $owner['nick'],
 						'guid'         => $approfile['diaspora:guid'],
 						'url'          => $owner['url'],

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -38,6 +38,7 @@ use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Protocol\ActivityNamespace;
 use Friendica\Protocol\ActivityPub;
+use Friendica\Protocol\Diaspora;
 use Friendica\Protocol\Email;
 use Friendica\Protocol\Feed;
 use Friendica\Protocol\Salmon;
@@ -358,7 +359,9 @@ class Probe
 			if (empty($data) || (!empty($ap_profile) && empty($network) && (($data['network'] ?? '') != Protocol::DFRN))) {
 				$networks = $data['networks'] ?? [];
 				unset($data['networks']);
-				$networks[$data['network']] = $data;
+				if (!empty($data['network'])) {
+					$networks[$data['network']] = $data;
+				}
 				$data = $ap_profile;
 				$data['networks'] = $networks;
 			} elseif (!empty($ap_profile)) {
@@ -2207,6 +2210,10 @@ class Probe
 			$owner     = User::getOwnerDataById($uid);
 			$approfile = ActivityPub\Transmitter::getProfile($uid);
 
+			$split_name = Diaspora::splitName($owner['name']);
+			$firstname = $split_name['first'];
+			$lastname = $split_name['last'];
+	
 			if (empty($owner['gsid'])) {
 				$owner['gsid'] = GServer::getID($approfile['generator']['url']);
 			}
@@ -2226,7 +2233,28 @@ class Probe
 				'inbox'            => $approfile['inbox'], 'outbox' => $approfile['outbox'],
 				'sharedinbox'      => $approfile['endpoints']['sharedInbox'], 'network' => Protocol::DFRN,
 				'pubkey'           => $owner['upubkey'], 'baseurl' => $approfile['generator']['url'], 'gsid' => $owner['gsid'],
-				'manually-approve' => in_array($owner['page-flags'], [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_PRVGROUP])
+				'manually-approve' => in_array($owner['page-flags'], [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_PRVGROUP]),
+				'networks' => [
+					Protocol::DIASPORA => [
+						'name'         => $owner['name'],
+						'given_name'   => $firstname,
+						'family_name'  => $lastname,
+						'nick'         => $owner['nick'],
+						'guid'         => $approfile['diaspora:guid'],
+						'url'          => $owner['url'],
+						'addr'         => $owner['addr'],
+						'alias'        => $owner['alias'],
+						'photo'        => $owner['photo'],
+						'photo_medium' => $owner['thumb'],
+						'photo_small'  => $owner['micro'],
+						'batch'        => $approfile['generator']['url'] . '/receive/public',
+						'notify'       => $owner['notify'],
+						'poll'         => $owner['poll'],
+						'poco'         => $owner['poco'],						
+						'network'      => Protocol::DIASPORA,
+						'pubkey'       => $owner['upubkey'],
+					]
+				]
 			];
 		} catch (Exception $e) {
 			// Default values for non existing targets


### PR DESCRIPTION
When probing a contact from our own system we use an own function to avoid network requests. This functionality needs the changes from PR #12375 as well.