### PR TITLE
Add Clock classes to deal with "now" times in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
 		"npm-asset/perfect-scrollbar": "0.6.16",
 		"npm-asset/textcomplete": "^0.18.2",
 		"npm-asset/typeahead.js": "^0.11.1",
-		"kornrunner/blurhash": "^1.2"
+		"kornrunner/blurhash": "^1.2",
+		"psr/clock": "^1.0"
 	},
 	"repositories": [
 		{

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8e7baec685d20e6aee56978c275d64c",
+    "content-hash": "5af9ac9003f4653f3aa1860dd5a4d821",
     "packages": [
         {
             "name": "asika/simple-console",
@@ -3328,6 +3328,50 @@
                 "psr-6"
             ],
             "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/container",

--- a/src/Util/Clock/FrozenClock.php
+++ b/src/Util/Clock/FrozenClock.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Util\Clock;
+
+use DateTimeImmutable;
+
+/**
+ * Inspired by lcobucci/clock
+ * @see https://github.com/lcobucci/clock
+ */
+final class FrozenClock implements \Psr\Clock\ClockInterface
+{
+	/** @var DateTimeImmutable */
+	private $now;
+
+	public function __construct(DateTimeImmutable $now = null)
+	{
+		$this->now = $now ?? new DateTimeImmutable('now', new \DateTimeZone('UTC'));
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function now(): DateTimeImmutable
+	{
+		return $this->now;
+	}
+}

--- a/src/Util/Clock/SystemClock.php
+++ b/src/Util/Clock/SystemClock.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Util\Clock;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+/**
+ * Inspired by lcobucci/clock
+ * @see https://github.com/lcobucci/clock
+ */
+final class SystemClock implements \Psr\Clock\ClockInterface
+{
+	/** @var DateTimeZone */
+	private $timezone;
+
+	public function __construct(DateTimeZone $timezone = null)
+	{
+		$this->timezone = $timezone ?? new DateTimeZone('UTC');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function now(): DateTimeImmutable
+	{
+		return new DateTimeImmutable('now', $this->timezone);
+	}
+}

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -264,5 +264,8 @@ return [
 		'constructParams' => [
 			$_SERVER
 		],
+	],
+	\Psr\Clock\ClockInterface::class => [
+		'instanceOf' => Util\Clock\SystemClock::class
 	]
 ];


### PR DESCRIPTION
- [Composer] Add psr/clock dependency

cc @nupplaphil 

This was made as part of my larger work on moderation reports but it is a standalone improvement.