### PR TITLE
Handle some fatal errors

### DIFF
--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -199,8 +199,11 @@ class Status extends BaseFactory
 			}
 		}
 
-		$item['body']     = $this->contentItem->addSharedPost($item);
-		$item['raw-body'] = $this->contentItem->addSharedPost($item, $item['raw-body']);
+		$item['body'] = $this->contentItem->addSharedPost($item);
+
+		if (!is_null($item['raw-body'])) {
+			$item['raw-body'] = $this->contentItem->addSharedPost($item, $item['raw-body']);
+		}
 
 		if ($is_reshare) {
 			$reshare = $this->createFromUriId($uriId, $uid, false)->toArray();

--- a/src/Util/Images.php
+++ b/src/Util/Images.php
@@ -247,8 +247,11 @@ class Images
 		if ($data) {
 			$image = new Image($img_str);
 
-			$data['blurhash'] = $image->getBlurHash();
-			$data['size']     = $filesize;
+			if ($image->isValid()) {
+				$data['blurhash'] = $image->getBlurHash();
+			}
+
+			$data['size'] = $filesize;
 		}
 
 		return is_array($data) ? $data : [];


### PR DESCRIPTION
This handles `Call to a member function getImageWidth() on null` and `Argument 2 passed to Friendica\Content\Item::addSharedPost() must be of the type string, null given`