### PR TITLE
Issue 12338: Use redirect for "about" and "about/more"

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -717,10 +717,6 @@ class App
 				$this->baseURL->redirect('search');
 			}
 
-			if (in_array($moduleName, ['about', 'about/more'])) {
-				$this->baseURL->redirect('friendica');
-			}
-
 			// Initialize module that can set the current theme in the init() method, either directly or via App->setProfileOwner
 			$page['page_title'] = $moduleName;
 

--- a/src/App.php
+++ b/src/App.php
@@ -717,6 +717,10 @@ class App
 				$this->baseURL->redirect('search');
 			}
 
+			if (in_array($moduleName, ['about', 'about/more'])) {
+				$this->baseURL->redirect('friendica');
+			}
+
 			// Initialize module that can set the current theme in the init() method, either directly or via App->setProfileOwner
 			$page['page_title'] = $moduleName;
 

--- a/src/Module/About.php
+++ b/src/Module/About.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Module;
+
+use Friendica\BaseModule;
+
+/**
+ * Redirect to the friendica page
+ */
+class About extends BaseModule
+{
+	protected function rawContent(array $request = [])
+	{
+		$this->baseUrl->redirect('friendica');
+	}
+}

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -318,6 +318,8 @@ return [
 		'/proofs'                                => [Module\Api\Mastodon\Proofs::class,        [R::GET         ]], // Dummy, not supported
 	],
 
+	'/about[/more]'                              => [Module\About::class, [R::GET]],
+
 	'/admin'               => [
 		'[/]' => [Module\Admin\Summary::class, [R::GET]],
 

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -318,8 +318,6 @@ return [
 		'/proofs'                                => [Module\Api\Mastodon\Proofs::class,        [R::GET         ]], // Dummy, not supported
 	],
 
-	'/about[/more]'                              => [Module\Friendica::class, [R::GET]],
-
 	'/admin'               => [
 		'[/]' => [Module\Admin\Summary::class, [R::GET]],
 


### PR DESCRIPTION
Fixes #12338 by introducing a redirect instead of offering the same content under multiple endpoints.