### PR TITLE
API: Use "contact" for own relations

### DIFF
--- a/src/Module/Api/Twitter/Followers/Ids.php
+++ b/src/Module/Api/Twitter/Followers/Ids.php
@@ -23,6 +23,7 @@ namespace Friendica\Module\Api\Twitter\Followers;
 
 use Friendica\Core\System;
 use Friendica\Database\DBA;
+use Friendica\Model\Contact;
 use Friendica\Module\Api\Twitter\ContactEndpoint;
 use Friendica\Module\BaseApi;
 
@@ -47,34 +48,61 @@ class Ids extends ContactEndpoint
 		$max_id   = $this->getRequestValue($request, 'max_id', 0, 0);
 		$min_id   = $this->getRequestValue($request, 'min_id', 0, 0);
 
-		$params = ['order' => ['relation-cid' => true], 'limit' => $count];
+		if ($cid == Contact::getPublicIdByUserId($uid)) {
+			$params = ['order' => ['pid' => true], 'limit' => $count];
 
-		$condition = ['cid' => $cid, 'follows' => true];
+			$condition = ['uid' => $uid, 'self' => false, 'rel' => [Contact::FOLLOWER, Contact::FRIEND]];
+	
+			if (!empty($max_id)) {
+				$condition = DBA::mergeConditions($condition, ["`pid` < ?", $max_id]);
+			}
+	
+			if (!empty($since_id)) {
+				$condition = DBA::mergeConditions($condition, ["`pid` > ?", $since_id]);
+			}
+	
+			if (!empty($min_id)) {
+				$condition = DBA::mergeConditions($condition, ["`pid` > ?", $min_id]);
+	
+				$params['order'] = ['pid'];
+			}
+	
+			$ids = [];
+	
+			foreach (Contact::selectAccountToArray(['pid'], $condition, $params) as $follower) {
+				self::setBoundaries($follower['pid']);
+				$ids[] = $follower['pid'];
+			}
+		} else {
+			$params = ['order' => ['relation-cid' => true], 'limit' => $count];
 
-		$total_count = (int)DBA::count('contact-relation', $condition);
+			$condition = ['cid' => $cid, 'follows' => true];
 
-		if (!empty($max_id)) {
-			$condition = DBA::mergeConditions($condition, ["`relation-cid` < ?", $max_id]);
+			$total_count = (int)DBA::count('contact-relation', $condition);
+
+			if (!empty($max_id)) {
+				$condition = DBA::mergeConditions($condition, ["`relation-cid` < ?", $max_id]);
+			}
+
+			if (!empty($since_id)) {
+				$condition = DBA::mergeConditions($condition, ["`relation-cid` > ?", $since_id]);
+			}
+
+			if (!empty($min_id)) {
+				$condition = DBA::mergeConditions($condition, ["`relation-cid` > ?", $min_id]);
+
+				$params['order'] = ['relation-cid'];
+			}
+
+			$ids = [];
+
+			$followers = DBA::select('contact-relation', ['relation-cid'], $condition, $params);
+			while ($follower = DBA::fetch($followers)) {
+				self::setBoundaries($follower['relation-cid']);
+				$ids[] = $follower['relation-cid'];
+			}
+			DBA::close($followers);
 		}
-
-		if (!empty($since_id)) {
-			$condition = DBA::mergeConditions($condition, ["`relation-cid` > ?", $since_id]);
-		}
-
-		if (!empty($min_id)) {
-			$condition = DBA::mergeConditions($condition, ["`relation-cid` > ?", $min_id]);
-
-			$params['order'] = ['relation-cid'];
-		}
-
-		$ids = [];
-
-		$followers = DBA::select('contact-relation', ['relation-cid'], $condition, $params);
-		while ($follower = DBA::fetch($followers)) {
-			self::setBoundaries($follower['relation-cid']);
-			$ids[] = $follower['relation-cid'];
-		}
-		DBA::close($followers);
 
 		if (!empty($min_id)) {
 			$ids = array_reverse($ids);

--- a/src/Module/Api/Twitter/Followers/Ids.php
+++ b/src/Module/Api/Twitter/Followers/Ids.php
@@ -53,6 +53,8 @@ class Ids extends ContactEndpoint
 
 			$condition = ['uid' => $uid, 'self' => false, 'rel' => [Contact::FOLLOWER, Contact::FRIEND]];
 	
+			$total_count = (int)DBA::count('contact', $condition);
+
 			if (!empty($max_id)) {
 				$condition = DBA::mergeConditions($condition, ["`pid` < ?", $max_id]);
 			}

--- a/src/Module/Api/Twitter/Followers/Ids.php
+++ b/src/Module/Api/Twitter/Followers/Ids.php
@@ -51,7 +51,7 @@ class Ids extends ContactEndpoint
 		if ($cid == Contact::getPublicIdByUserId($uid)) {
 			$params = ['order' => ['pid' => true], 'limit' => $count];
 
-			$condition = ['uid' => $uid, 'self' => false, 'rel' => [Contact::FOLLOWER, Contact::FRIEND]];
+			$condition = ['uid' => $uid, 'self' => false, 'pending' => false, 'rel' => [Contact::FOLLOWER, Contact::FRIEND]];
 	
 			$total_count = (int)DBA::count('contact', $condition);
 

--- a/src/Module/Api/Twitter/Followers/Lists.php
+++ b/src/Module/Api/Twitter/Followers/Lists.php
@@ -110,9 +110,9 @@ class Lists extends ContactEndpoint
 			$ids = array_reverse($ids);
 		}
 
-		self::setLinkHeader();
-
 		$return = self::list($ids, $total_count, $uid, $cursor, $count, $skip_status, $include_user_entities);
+
+		$this->response->setHeader(self::getLinkHeader());	
 
 		$this->response->exit('lists', ['lists' => $return]);
 	}

--- a/src/Module/Api/Twitter/Followers/Lists.php
+++ b/src/Module/Api/Twitter/Followers/Lists.php
@@ -110,9 +110,9 @@ class Lists extends ContactEndpoint
 			$ids = array_reverse($ids);
 		}
 
-		$return = self::list($ids, $total_count, $uid, $cursor, $count, $skip_status, $include_user_entities);
-
 		self::setLinkHeader();
+
+		$return = self::list($ids, $total_count, $uid, $cursor, $count, $skip_status, $include_user_entities);
 
 		$this->response->exit('lists', ['lists' => $return]);
 	}

--- a/src/Module/Api/Twitter/Followers/Lists.php
+++ b/src/Module/Api/Twitter/Followers/Lists.php
@@ -53,6 +53,8 @@ class Lists extends ContactEndpoint
 
 			$condition = ['uid' => $uid, 'self' => false, 'rel' => [Contact::FOLLOWER, Contact::FRIEND]];
 	
+			$total_count = (int)DBA::count('contact', $condition);
+
 			if (!empty($max_id)) {
 				$condition = DBA::mergeConditions($condition, ["`pid` < ?", $max_id]);
 			}

--- a/src/Module/Api/Twitter/Followers/Lists.php
+++ b/src/Module/Api/Twitter/Followers/Lists.php
@@ -51,7 +51,7 @@ class Lists extends ContactEndpoint
 		if ($cid == Contact::getPublicIdByUserId($uid)) {
 			$params = ['order' => ['pid' => true], 'limit' => $count];
 
-			$condition = ['uid' => $uid, 'self' => false, 'rel' => [Contact::FOLLOWER, Contact::FRIEND]];
+			$condition = ['uid' => $uid, 'self' => false, 'pending' => false, 'rel' => [Contact::FOLLOWER, Contact::FRIEND]];
 	
 			$total_count = (int)DBA::count('contact', $condition);
 

--- a/src/Module/Api/Twitter/Friends/Ids.php
+++ b/src/Module/Api/Twitter/Friends/Ids.php
@@ -23,6 +23,7 @@ namespace Friendica\Module\Api\Twitter\Friends;
 
 use Friendica\Core\System;
 use Friendica\Database\DBA;
+use Friendica\Model\Contact;
 use Friendica\Module\Api\Twitter\ContactEndpoint;
 use Friendica\Module\BaseApi;
 
@@ -47,34 +48,61 @@ class Ids extends ContactEndpoint
 		$max_id   = $this->getRequestValue($request, 'max_id', 0, 0);
 		$min_id   = $this->getRequestValue($request, 'min_id', 0, 0);
 
-		$params = ['order' => ['cid' => true], 'limit' => $count];
+		if ($cid == Contact::getPublicIdByUserId($uid)) {
+			$params = ['order' => ['pid' => true], 'limit' => $count];
 
-		$condition = ['relation-cid' => $cid, 'follows' => true];
+			$condition = ['uid' => $uid, 'self' => false, 'rel' => [Contact::SHARING, Contact::FRIEND]];
+	
+			if (!empty($max_id)) {
+				$condition = DBA::mergeConditions($condition, ["`pid` < ?", $max_id]);
+			}
+	
+			if (!empty($since_id)) {
+				$condition = DBA::mergeConditions($condition, ["`pid` > ?", $since_id]);
+			}
+	
+			if (!empty($min_id)) {
+				$condition = DBA::mergeConditions($condition, ["`pid` > ?", $min_id]);
+	
+				$params['order'] = ['pid'];
+			}
+	
+			$ids = [];
+	
+			foreach (Contact::selectAccountToArray(['pid'], $condition, $params) as $follower) {
+				self::setBoundaries($follower['pid']);
+				$ids[] = $follower['pid'];
+			}
+		} else {
+			$params = ['order' => ['cid' => true], 'limit' => $count];
 
-		$total_count = (int)DBA::count('contact-relation', $condition);
+			$condition = ['relation-cid' => $cid, 'follows' => true];
 
-		if (!empty($max_id)) {
-			$condition = DBA::mergeConditions($condition, ["`cid` < ?", $max_id]);
+			$total_count = (int)DBA::count('contact-relation', $condition);
+
+			if (!empty($max_id)) {
+				$condition = DBA::mergeConditions($condition, ["`cid` < ?", $max_id]);
+			}
+
+			if (!empty($since_id)) {
+				$condition = DBA::mergeConditions($condition, ["`cid` > ?", $since_id]);
+			}
+
+			if (!empty($min_id)) {
+				$condition = DBA::mergeConditions($condition, ["`cid` > ?", $min_id]);
+
+				$params['order'] = ['cid'];
+			}
+
+			$ids = [];
+
+			$followers = DBA::select('contact-relation', ['cid'], $condition, $params);
+			while ($follower = DBA::fetch($followers)) {
+				self::setBoundaries($follower['cid']);
+				$ids[] = $follower['cid'];
+			}
+			DBA::close($followers);
 		}
-
-		if (!empty($since_id)) {
-			$condition = DBA::mergeConditions($condition, ["`cid` > ?", $since_id]);
-		}
-
-		if (!empty($min_id)) {
-			$condition = DBA::mergeConditions($condition, ["`cid` > ?", $min_id]);
-
-			$params['order'] = ['cid'];
-		}
-
-		$ids = [];
-
-		$followers = DBA::select('contact-relation', ['cid'], $condition, $params);
-		while ($follower = DBA::fetch($followers)) {
-			self::setBoundaries($follower['cid']);
-			$ids[] = $follower['cid'];
-		}
-		DBA::close($followers);
 
 		if (!empty($min_id)) {
 			$ids = array_reverse($ids);

--- a/src/Module/Api/Twitter/Friends/Ids.php
+++ b/src/Module/Api/Twitter/Friends/Ids.php
@@ -53,6 +53,8 @@ class Ids extends ContactEndpoint
 
 			$condition = ['uid' => $uid, 'self' => false, 'rel' => [Contact::SHARING, Contact::FRIEND]];
 	
+			$total_count = (int)DBA::count('contact', $condition);
+
 			if (!empty($max_id)) {
 				$condition = DBA::mergeConditions($condition, ["`pid` < ?", $max_id]);
 			}

--- a/src/Module/Api/Twitter/Friends/Ids.php
+++ b/src/Module/Api/Twitter/Friends/Ids.php
@@ -51,7 +51,7 @@ class Ids extends ContactEndpoint
 		if ($cid == Contact::getPublicIdByUserId($uid)) {
 			$params = ['order' => ['pid' => true], 'limit' => $count];
 
-			$condition = ['uid' => $uid, 'self' => false, 'rel' => [Contact::SHARING, Contact::FRIEND]];
+			$condition = ['uid' => $uid, 'self' => false, 'pending' => false, 'rel' => [Contact::SHARING, Contact::FRIEND]];
 	
 			$total_count = (int)DBA::count('contact', $condition);
 

--- a/src/Module/Api/Twitter/Friends/Lists.php
+++ b/src/Module/Api/Twitter/Friends/Lists.php
@@ -51,7 +51,7 @@ class Lists extends ContactEndpoint
 		if ($cid == Contact::getPublicIdByUserId($uid)) {
 			$params = ['order' => ['pid' => true], 'limit' => $count];
 
-			$condition = ['uid' => $uid, 'self' => false, 'rel' => [Contact::SHARING, Contact::FRIEND]];
+			$condition = ['uid' => $uid, 'self' => false, 'pending' => false, 'rel' => [Contact::SHARING, Contact::FRIEND]];
 	
 			$total_count = (int)DBA::count('contact', $condition);
 

--- a/src/Module/Api/Twitter/Friends/Lists.php
+++ b/src/Module/Api/Twitter/Friends/Lists.php
@@ -110,9 +110,9 @@ class Lists extends ContactEndpoint
 			$ids = array_reverse($ids);
 		}
 
-		$return = self::list($ids, $total_count, $uid, $cursor, $count, $skip_status, $include_user_entities);
-
 		self::setLinkHeader();
+
+		$return = self::list($ids, $total_count, $uid, $cursor, $count, $skip_status, $include_user_entities);
 
 		$this->response->exit('lists', ['lists' => $return]);
 	}

--- a/src/Module/Api/Twitter/Friends/Lists.php
+++ b/src/Module/Api/Twitter/Friends/Lists.php
@@ -77,7 +77,7 @@ class Lists extends ContactEndpoint
 			}
 		} else {
 			$params = ['order' => ['cid' => true], 'limit' => $count];
-	
+
 			$condition = ['relation-cid' => $cid, 'follows' => true];
 
 			$total_count = (int)DBA::count('contact-relation', $condition);
@@ -110,9 +110,9 @@ class Lists extends ContactEndpoint
 			$ids = array_reverse($ids);
 		}
 
-		self::setLinkHeader();
-
 		$return = self::list($ids, $total_count, $uid, $cursor, $count, $skip_status, $include_user_entities);
+
+		$this->response->setHeader(self::getLinkHeader());	
 
 		$this->response->exit('lists', ['lists' => $return]);
 	}

--- a/src/Module/Api/Twitter/Friends/Lists.php
+++ b/src/Module/Api/Twitter/Friends/Lists.php
@@ -21,8 +21,8 @@
 
 namespace Friendica\Module\Api\Twitter\Friends;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
+use Friendica\Model\Contact;
 use Friendica\Module\Api\Twitter\ContactEndpoint;
 use Friendica\Module\BaseApi;
 
@@ -48,34 +48,61 @@ class Lists extends ContactEndpoint
 		$max_id   = $this->getRequestValue($request, 'max_id', 0, 0);
 		$min_id   = $this->getRequestValue($request, 'min_id', 0, 0);
 
-		$params = ['order' => ['cid' => true], 'limit' => $count];
+		if ($cid == Contact::getPublicIdByUserId($uid)) {
+			$params = ['order' => ['pid' => true], 'limit' => $count];
 
-		$condition = ['relation-cid' => $cid, 'follows' => true];
+			$condition = ['uid' => $uid, 'self' => false, 'rel' => [Contact::SHARING, Contact::FRIEND]];
+	
+			if (!empty($max_id)) {
+				$condition = DBA::mergeConditions($condition, ["`pid` < ?", $max_id]);
+			}
+	
+			if (!empty($since_id)) {
+				$condition = DBA::mergeConditions($condition, ["`pid` > ?", $since_id]);
+			}
+	
+			if (!empty($min_id)) {
+				$condition = DBA::mergeConditions($condition, ["`pid` > ?", $min_id]);
+	
+				$params['order'] = ['pid'];
+			}
+	
+			$ids = [];
+	
+			foreach (Contact::selectAccountToArray(['pid'], $condition, $params) as $follower) {
+				self::setBoundaries($follower['pid']);
+				$ids[] = $follower['pid'];
+			}
+		} else {
+			$params = ['order' => ['cid' => true], 'limit' => $count];
+	
+			$condition = ['relation-cid' => $cid, 'follows' => true];
 
-		$total_count = (int)DBA::count('contact-relation', $condition);
+			$total_count = (int)DBA::count('contact-relation', $condition);
 
-		if (!empty($max_id)) {
-			$condition = DBA::mergeConditions($condition, ["`cid` < ?", $max_id]);
+			if (!empty($max_id)) {
+				$condition = DBA::mergeConditions($condition, ["`cid` < ?", $max_id]);
+			}
+
+			if (!empty($since_id)) {
+				$condition = DBA::mergeConditions($condition, ["`cid` > ?", $since_id]);
+			}
+
+			if (!empty($min_id)) {
+				$condition = DBA::mergeConditions($condition, ["`cid` > ?", $min_id]);
+
+				$params['order'] = ['cid'];
+			}
+
+			$ids = [];
+
+			$followers = DBA::select('contact-relation', ['cid'], $condition, $params);
+			while ($follower = DBA::fetch($followers)) {
+				self::setBoundaries($follower['cid']);
+				$ids[] = $follower['cid'];
+			}
+			DBA::close($followers);
 		}
-
-		if (!empty($since_id)) {
-			$condition = DBA::mergeConditions($condition, ["`cid` > ?", $since_id]);
-		}
-
-		if (!empty($min_id)) {
-			$condition = DBA::mergeConditions($condition, ["`cid` > ?", $min_id]);
-
-			$params['order'] = ['cid'];
-		}
-
-		$ids = [];
-
-		$followers = DBA::select('contact-relation', ['cid'], $condition, $params);
-		while ($follower = DBA::fetch($followers)) {
-			self::setBoundaries($follower['cid']);
-			$ids[] = $follower['cid'];
-		}
-		DBA::close($followers);
 
 		if (!empty($min_id)) {
 			$ids = array_reverse($ids);

--- a/src/Module/Api/Twitter/Friends/Lists.php
+++ b/src/Module/Api/Twitter/Friends/Lists.php
@@ -53,6 +53,8 @@ class Lists extends ContactEndpoint
 
 			$condition = ['uid' => $uid, 'self' => false, 'rel' => [Contact::SHARING, Contact::FRIEND]];
 	
+			$total_count = (int)DBA::count('contact', $condition);
+
 			if (!empty($max_id)) {
 				$condition = DBA::mergeConditions($condition, ["`pid` < ?", $max_id]);
 			}

--- a/src/Module/Api/Twitter/Friendships/Incoming.php
+++ b/src/Module/Api/Twitter/Friendships/Incoming.php
@@ -21,7 +21,6 @@
 
 namespace Friendica\Module\Api\Twitter\Friendships;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Module\Api\Twitter\ContactEndpoint;
 use Friendica\Module\BaseApi;
@@ -81,7 +80,7 @@ class Incoming extends ContactEndpoint
 
 		$return = self::ids($ids, $total_count, $cursor, $count, $stringify_ids);
 
-		self::setLinkHeader();
+		$this->response->setHeader(self::getLinkHeader());	
 
 		$this->response->exit('incoming', ['incoming' => $return]);
 	}

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -139,13 +139,13 @@ class BaseApi extends BaseModule
 	}
 
 	/**
-	 * Set the "link" header with "next" and "prev" links
-	 * @return void
+	 * Get the "link" header with "next" and "prev" links
+	 * @return string
 	 */
-	protected static function setLinkHeader()
+	protected static function getLinkHeader(): string
 	{
 		if (empty(self::$boundaries)) {
-			return;
+			return '';
 		}
 
 		$request = self::$request;
@@ -164,7 +164,19 @@ class BaseApi extends BaseModule
 		$prev = $command . '?' . http_build_query($prev_request);
 		$next = $command . '?' . http_build_query($next_request);
 
-		header('Link: <' . $next . '>; rel="next", <' . $prev . '>; rel="prev"');
+		return 'Link: <' . $next . '>; rel="next", <' . $prev . '>; rel="prev"';
+	}
+
+	/**
+	 * Set the "link" header with "next" and "prev" links
+	 * @return void
+	 */
+	protected static function setLinkHeader()
+	{
+		$header = self::getLinkHeader();
+		if (!empty($header)) {
+			header($header);
+		}
 	}
 
 	/**


### PR DESCRIPTION
The "contact-relation" table is not filled all the time. So we have to use the contact table when searching for our own contacts.

Fix https://github.com/friendica/friendica/issues/11284