### PR TITLE
Fix Friendica Photo GET API endpoint to work without explicit scale term

### DIFF
--- a/src/Factory/Api/Friendica/Photo.php
+++ b/src/Factory/Api/Friendica/Photo.php
@@ -57,14 +57,14 @@ class Photo extends BaseFactory
 	 * @param string $type
 	 * @return Array
 	 */
-	public function createFromId(string $photo_id, int $scale = null, int $uid, string $type = 'json', bool $with_posts = true): array
+	public function createFromId(string $photo_id, int $scale, int $uid, string $type = 'json', bool $with_posts = true): array
 	{
 		$fields = ['resource-id', 'created', 'edited', 'title', 'desc', 'album', 'filename','type',
 			'height', 'width', 'datasize', 'profile', 'allow_cid', 'deny_cid', 'allow_gid', 'deny_gid',
 			'backend-class', 'backend-ref', 'id', 'scale'];
 
 		$condition = ['uid' => $uid, 'resource-id' => $photo_id];
-		if (is_int($scale)) {
+		if ($scale >= 0) {
 			$fields = array_merge(['data'], $fields);
 
 			$condition['scale'] = $scale;

--- a/src/Factory/Api/Friendica/Photo.php
+++ b/src/Factory/Api/Friendica/Photo.php
@@ -57,14 +57,14 @@ class Photo extends BaseFactory
 	 * @param string $type
 	 * @return Array
 	 */
-	public function createFromId(string $photo_id, int $scale, int $uid, string $type = 'json', bool $with_posts = true): array
+	public function createFromId(string $photo_id, int $scale = null, int $uid, string $type = 'json', bool $with_posts = true): array
 	{
 		$fields = ['resource-id', 'created', 'edited', 'title', 'desc', 'album', 'filename','type',
 			'height', 'width', 'datasize', 'profile', 'allow_cid', 'deny_cid', 'allow_gid', 'deny_gid',
 			'backend-class', 'backend-ref', 'id', 'scale'];
 
 		$condition = ['uid' => $uid, 'resource-id' => $photo_id];
-		if ($scale >= 0) {
+		if (intval($scale)) {
 			$fields = array_merge(['data'], $fields);
 
 			$condition['scale'] = $scale;

--- a/src/Factory/Api/Friendica/Photo.php
+++ b/src/Factory/Api/Friendica/Photo.php
@@ -64,7 +64,7 @@ class Photo extends BaseFactory
 			'backend-class', 'backend-ref', 'id', 'scale'];
 
 		$condition = ['uid' => $uid, 'resource-id' => $photo_id];
-		if (intval($scale)) {
+		if (is_int($scale)) {
 			$fields = array_merge(['data'], $fields);
 
 			$condition['scale'] = $scale;

--- a/src/Module/Api/Friendica/Photo.php
+++ b/src/Module/Api/Friendica/Photo.php
@@ -54,7 +54,7 @@ class Photo extends BaseApi
 			throw new HTTPException\BadRequestException('No photo id.');
 		}
 
-		$scale    = (!empty($request['scale']) ? intval($request['scale']) : false);
+		$scale    = (!empty($request['scale']) ? intval($request['scale']) : -1);
 		$photo_id = $request['photo_id'];
 
 		// prepare json/xml output with data from database for the requested photo

--- a/src/Module/Api/Friendica/Photo.php
+++ b/src/Module/Api/Friendica/Photo.php
@@ -54,7 +54,7 @@ class Photo extends BaseApi
 			throw new HTTPException\BadRequestException('No photo id.');
 		}
 
-		$scale    = (!empty($request['scale']) ? intval($request['scale']) : -1);
+		$scale    = (!empty($request['scale']) ? intval($request['scale']) : null);
 		$photo_id = $request['photo_id'];
 
 		// prepare json/xml output with data from database for the requested photo


### PR DESCRIPTION
The problem is that in a previous version of PHP when we passed 'false' in for $scale it tripped the intval check on scale. This isn't working any longer. Instead I'm passing in -1 when scale isn't provided and checking for that. I only found this one place where the method was being used to remove the optional check and make sure the call was compliant. If it is known to be used elsewhere I can fix that elsewhere or just add back the optional default value.