### PR TITLE
Friendica api photo endpoint updates

### DIFF
--- a/src/Module/Api/Friendica/Photo/Create.php
+++ b/src/Module/Api/Friendica/Photo/Create.php
@@ -64,8 +64,8 @@ class Create extends BaseApi
 
 		// do several checks on input parameters
 		// we do not allow calls without album string
-		if ($album == null) {
-			throw new HTTPException\BadRequestException('no albumname specified');
+		if ($album === null) {
+			throw new HTTPException\BadRequestException('no album name specified');
 		}
 
 		// error if no media posted in create-mode

--- a/src/Module/Api/Friendica/Photo/Create.php
+++ b/src/Module/Api/Friendica/Photo/Create.php
@@ -88,6 +88,7 @@ class Create extends BaseApi
 
 		// return success of updating or error message
 		if (!empty($photo)) {
+			Photo::clearAlbumCache($uid);
 			$data = ['photo' => $this->friendicaPhoto->createFromId($photo['resource_id'], null, $uid, $type)];
 			$this->response->exit('photo_create', $data, $this->parameters['extension'] ?? null);
 		} else {

--- a/src/Module/Api/Friendica/Photo/Delete.php
+++ b/src/Module/Api/Friendica/Photo/Delete.php
@@ -60,7 +60,7 @@ class Delete extends BaseApi
 			// to the user and the contacts of the users (drop_items() do all the necessary magic to avoid orphans in database and federate deletion)
 			$condition = ['uid' => $uid, 'resource-id' => $request['photo_id'], 'post-type' => Item::PT_IMAGE, 'origin' => true];
 			Item::deleteForUser($condition, $uid);
-
+			Photo::clearAlbumCache($uid);
 			$result = ['result' => 'deleted', 'message' => 'photo with id `' . $request['photo_id'] . '` has been deleted from server.'];
 			$this->response->exit('photo_delete', ['$result' => $result], $this->parameters['extension'] ?? null);
 		} else {

--- a/src/Module/Api/Friendica/Photo/Update.php
+++ b/src/Module/Api/Friendica/Photo/Update.php
@@ -135,6 +135,7 @@ class Update extends BaseApi
 
 		// return success of updating or error message
 		if ($result) {
+			Photo::clearAlbumCache($uid);
 			$answer = ['result' => 'updated', 'message' => 'Image id `' . $photo_id . '` has been updated.'];
 			$this->response->exit('photo_update', ['$result' => $answer], $this->parameters['extension'] ?? null);
 			return;

--- a/src/Module/Api/Friendica/Photoalbum/Delete.php
+++ b/src/Module/Api/Friendica/Photoalbum/Delete.php
@@ -66,6 +66,7 @@ class Delete extends BaseApi
 
 		// return success of deletion or error message
 		if ($result) {
+			Photo::clearAlbumCache($uid);
 			$answer = ['result' => 'deleted', 'message' => 'album `' . $request['album'] . '` with all containing photos has been deleted.'];
 			$this->response->exit('photoalbum_delete', ['$result' => $answer], $this->parameters['extension'] ?? null);
 		} else {

--- a/src/Module/Api/Friendica/Photoalbum/Index.php
+++ b/src/Module/Api/Friendica/Photoalbum/Index.php
@@ -26,7 +26,7 @@ use Friendica\Model\Photo;
 use Friendica\Module\BaseApi;
 
 /**
- * api/friendica/photoalbums
+ * api/friendica/photoalbum
  *
  * @package  Friendica\Module\Api\Friendica\Photoalbum
  */

--- a/src/Module/Api/Friendica/Photoalbum/Index.php
+++ b/src/Module/Api/Friendica/Photoalbum/Index.php
@@ -42,9 +42,9 @@ class Index extends BaseApi
 		$items = [];
 		foreach ($albums as $album) {
 			$items[] = [
-				'name'         => $album['album'],
-				'created'      => $album['created'],
-				'count'        => $album['total'],
+				'name'    => $album['album'],
+				'created' => $album['created'],
+				'count'   => $album['total'],
 			];
 		}
 

--- a/src/Module/Api/Friendica/Photoalbum/Index.php
+++ b/src/Module/Api/Friendica/Photoalbum/Index.php
@@ -21,7 +21,6 @@
 
 namespace Friendica\Module\Api\Friendica\Photoalbum;
 
-use Friendica\Database\DBA;
 use Friendica\Model\Photo;
 use Friendica\Module\BaseApi;
 

--- a/src/Module/Api/Friendica/Photoalbum/Index.php
+++ b/src/Module/Api/Friendica/Photoalbum/Index.php
@@ -1,0 +1,53 @@
+<?php
+/**
+* @copyright Copyright (C) 2022, the Friendica project
+*
+* @license GNU AGPL version 3 or any later version
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*
+*/
+
+namespace Friendica\Module\Api\Friendica\Photoalbum;
+
+use Friendica\Database\DBA;
+use Friendica\Model\Photo;
+use Friendica\Module\BaseApi;
+
+/**
+ * api/friendica/photoalbum
+ *
+ * @package  Friendica\Module\Api\Friendica\Photoalbum
+ */
+class Index extends BaseApi
+{
+	protected function rawContent(array $request = [])
+	{
+		self::checkAllowedScope(self::SCOPE_READ);
+		$uid = self::getCurrentUserID();
+
+		$albums = Photo::getAlbums($uid);
+
+		$items = [];
+		foreach ($albums as $album) {
+			$items[] = [
+				'name'         => $album['album'],
+				'created'      => $album['created'],
+				'count'        => $album['total'],
+			];
+		}
+
+		$this->response->exit('albums', ['albums' => $items], $this->parameters['extension'] ?? null);
+	}
+}

--- a/src/Module/Api/Friendica/Photoalbum/Index.php
+++ b/src/Module/Api/Friendica/Photoalbum/Index.php
@@ -26,7 +26,7 @@ use Friendica\Model\Photo;
 use Friendica\Module\BaseApi;
 
 /**
- * api/friendica/photoalbum
+ * api/friendica/photoalbums
  *
  * @package  Friendica\Module\Api\Friendica\Photoalbum
  */

--- a/src/Module/Api/Friendica/Photoalbum/Index.php
+++ b/src/Module/Api/Friendica/Photoalbum/Index.php
@@ -1,23 +1,23 @@
 <?php
 /**
-* @copyright Copyright (C) 2022, the Friendica project
-*
-* @license GNU AGPL version 3 or any later version
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Affero General Public License as
-* published by the Free Software Foundation, either version 3 of the
-* License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Affero General Public License for more details.
-*
-* You should have received a copy of the GNU Affero General Public License
-* along with this program.  If not, see <https://www.gnu.org/licenses/>.
-*
-*/
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 
 namespace Friendica\Module\Api\Friendica\Photoalbum;
 

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -54,13 +54,13 @@ class Show extends BaseApi
 	protected function rawContent(array $request = [])
 	{
 		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
-		$uid = BaseApi::getCurrentUserID();
-		$type = $this->getRequestValue($this->parameters, 'extension', 'json');
+		$uid     = BaseApi::getCurrentUserID();
+		$type    = $this->getRequestValue($this->parameters, 'extension', 'json');
 		$request = $this->getRequest([
-			'album'           => '',    // Get pictures in this album
-			'offset'          => 0,     // Return results offset by this value
-			'limit'           => 50,    // Maximum number of results to return. Defaults to 50. Max 500
-			'latest_first'    => false, // Whether to reverse the order so newest are first
+			'album'        => '',    // Get pictures in this album
+			'offset'       => 0,     // Return results offset by this value
+			'limit'        => 50,    // Maximum number of results to return. Defaults to 50. Max 500
+			'latest_first' => false, // Whether to reverse the order so newest are first
 		], $request);
 
 		if (empty($request['album'])) {

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @copyright Copyright (C) 2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Module\Api\Friendica\Photoalbum;
+
+use Friendica\App;
+use Friendica\Core\L10n;
+use Friendica\Database\DBA;
+use Friendica\Factory\Api\Friendica\Photo as FriendicaPhoto;
+use Friendica\Model\Contact;
+use Friendica\Model\Photo;
+use Friendica\Module\Api\ApiResponse;
+use Friendica\Module\BaseApi;
+use Friendica\Network\HTTPException;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
+/**
+ * api/friendica/photoalbum/:name
+ *
+ * @package  Friendica\Module\Api\Friendica\Photoalbum
+ */
+class Show extends BaseApi
+{
+	/** @var FriendicaPhoto */
+	private $friendicaPhoto;
+
+
+	public function __construct(FriendicaPhoto $friendicaPhoto, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	{
+		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+
+		$this->friendicaPhoto = $friendicaPhoto;
+	}
+
+	protected function rawContent(array $request = [])
+	{
+		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$uid = BaseApi::getCurrentUserID();
+		$type = $this->getRequestValue($this->parameters, 'extension', 'json');
+		$request = $this->getRequest([
+			'album'           => '',    // Get pictures in this album
+			'offset'          => 0,     // Return results offset by this value
+			'limit'           => 50,    // Maximum number of results to return. Defaults to 50. Max 500
+		], $request);
+		if (empty($request['album'])) {
+			throw new HTTPException\BadRequestException('No album name specified.');
+		}
+
+
+		$album = $request['album'];
+		$condition = ["`uid` = ? AND `album` = ?", $uid, $album];
+		$params = ['order' => ['id'], 'group_by' => ['resource-id']];
+
+		//'limit' => [$request['offset'], $request['limit']]
+		$limit = $request['limit'];
+		if ($limit > 500) {
+			$limit = 500;
+		}
+
+		if ($limit <= 0) {
+			$limit = 1;
+		}
+
+		if(!empty($request['offset'])) {
+			$params['limit'] = [$request['offset'], $limit];
+		} else {
+			$params['limit'] = $limit;
+		}
+
+		$photos = Photo::selectToArray(['resource-id'], $condition, $params);
+
+		$data = ['photo' => []];
+		if (DBA::isResult($photos)) {
+			foreach ($photos as $photo) {
+				$element = $this->friendicaPhoto->createFromId($photo['resource-id'], null, $uid, 'json', false);
+
+				$element['thumb'] = end($element['link']);
+				unset($element['link']);
+
+				if ($type == 'xml') {
+					$thumb = $element['thumb'];
+					unset($element['thumb']);
+					$data['photo'][] = ['@attributes' => $element, '1' => $thumb];
+				} else {
+					$data['photo'][] = $element;
+				}
+			}
+		}
+
+		$this->response->exit('statuses', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+	}
+}

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -62,17 +62,16 @@ class Show extends BaseApi
 			'limit'           => 50,    // Maximum number of results to return. Defaults to 50. Max 500
 			'latest_first'    => false, // Whether to reverse the order so newest are first
 		], $request);
+
 		if (empty($request['album'])) {
 			throw new HTTPException\BadRequestException('No album name specified.');
 		}
-
 
 		$orderDescending = $request['latest_first'];
 		$album = $request['album'];
 		$condition = ["`uid` = ? AND `album` = ?", $uid, $album];
 		$params = ['order' => ['id' => $orderDescending], 'group_by' => ['resource-id']];
 
-		//'limit' => [$request['offset'], $request['limit']]
 		$limit = $request['limit'];
 		if ($limit > 500) {
 			$limit = 500;

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -90,20 +90,18 @@ class Show extends BaseApi
 		$photos = Photo::selectToArray(['resource-id'], $condition, $params);
 
 		$data = ['photo' => []];
-		if (DBA::isResult($photos)) {
-			foreach ($photos as $photo) {
-				$element = $this->friendicaPhoto->createFromId($photo['resource-id'], null, $uid, 'json', false);
+		foreach ($photos as $photo) {
+			$element = $this->friendicaPhoto->createFromId($photo['resource-id'], null, $uid, 'json', false);
 
-				$element['thumb'] = end($element['link']);
-				unset($element['link']);
+			$element['thumb'] = end($element['link']);
+			unset($element['link']);
 
-				if ($type == 'xml') {
-					$thumb = $element['thumb'];
-					unset($element['thumb']);
-					$data['photo'][] = ['@attributes' => $element, '1' => $thumb];
-				} else {
-					$data['photo'][] = $element;
-				}
+			if ($type == 'xml') {
+				$thumb = $element['thumb'];
+				unset($element['thumb']);
+				$data['photo'][] = ['@attributes' => $element, '1' => $thumb];
+			} else {
+				$data['photo'][] = $element;
 			}
 		}
 

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -82,7 +82,7 @@ class Show extends BaseApi
 			$limit = 1;
 		}
 
-		if(!empty($request['offset'])) {
+		if (!empty($request['offset'])) {
 			$params['limit'] = [$request['offset'], $limit];
 		} else {
 			$params['limit'] = $limit;

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (C) 2022, the Friendica project
+ * @copyright Copyright (C) 2010-2022, the Friendica project
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -68,9 +68,9 @@ class Show extends BaseApi
 		}
 
 		$orderDescending = $request['latest_first'];
-		$album = $request['album'];
-		$condition = ["`uid` = ? AND `album` = ?", $uid, $album];
-		$params = ['order' => ['id' => $orderDescending], 'group_by' => ['resource-id']];
+		$album           = $request['album'];
+		$condition       = ["`uid` = ? AND `album` = ?", $uid, $album];
+		$params          = ['order' => ['id' => $orderDescending], 'group_by' => ['resource-id']];
 
 		$limit = $request['limit'];
 		if ($limit > 500) {

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -23,7 +23,6 @@ namespace Friendica\Module\Api\Friendica\Photoalbum;
 
 use Friendica\App;
 use Friendica\Core\L10n;
-use Friendica\Database\DBA;
 use Friendica\Factory\Api\Friendica\Photo as FriendicaPhoto;
 use Friendica\Model\Contact;
 use Friendica\Model\Photo;

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -60,15 +60,17 @@ class Show extends BaseApi
 			'album'           => '',    // Get pictures in this album
 			'offset'          => 0,     // Return results offset by this value
 			'limit'           => 50,    // Maximum number of results to return. Defaults to 50. Max 500
+			'latest_first'    => false, // Whether to reverse the order so newest are first
 		], $request);
 		if (empty($request['album'])) {
 			throw new HTTPException\BadRequestException('No album name specified.');
 		}
 
 
+		$orderDescending = $request['latest_first'];
 		$album = $request['album'];
 		$condition = ["`uid` = ? AND `album` = ?", $uid, $album];
-		$params = ['order' => ['id'], 'group_by' => ['resource-id']];
+		$params = ['order' => ['id' => $orderDescending], 'group_by' => ['resource-id']];
 
 		//'limit' => [$request['offset'], $request['limit']]
 		$limit = $request['limit'];

--- a/src/Module/Api/Friendica/Photoalbum/Update.php
+++ b/src/Module/Api/Friendica/Photoalbum/Update.php
@@ -58,6 +58,7 @@ class Update extends BaseApi
 
 		// return success of updating or error message
 		if ($result) {
+			Photo::clearAlbumCache($uid);
 			$answer = ['result' => 'updated', 'message' => 'album `' . $request['album'] . '` with all containing photos has been renamed to `' . $request['album_new'] . '`.'];
 			$this->response->exit('photoalbum_update', ['$result' => $answer], $this->parameters['extension'] ?? null);
 		} else {

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -93,6 +93,7 @@ $apiRoutes = [
 		'/group_delete[.{extension:json|xml|rss|atom}]'            => [Module\Api\Friendica\Group\Delete::class,           [        R::POST]],
 		'/group_update[.{extension:json|xml|rss|atom}]'            => [Module\Api\Friendica\Group\Update::class,           [        R::POST]],
 		'/profile/show[.{extension:json|xml|rss|atom}]'            => [Module\Api\Friendica\Profile\Show::class,           [R::GET         ]],
+		'/photoalbums[.{extension:json|xml|rss|atom}]'             => [Module\Api\Friendica\Photoalbum\Index::class,       [R::GET         ]],
 		'/photoalbum/delete[.{extension:json|xml|rss|atom}]'       => [Module\Api\Friendica\Photoalbum\Delete::class,      [        R::POST]],
 		'/photoalbum/update[.{extension:json|xml|rss|atom}]'       => [Module\Api\Friendica\Photoalbum\Update::class,      [        R::POST]],
 		'/photos/list[.{extension:json|xml|rss|atom}]'             => [Module\Api\Friendica\Photo\Lists::class,            [R::GET         ]],

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -94,6 +94,7 @@ $apiRoutes = [
 		'/group_update[.{extension:json|xml|rss|atom}]'            => [Module\Api\Friendica\Group\Update::class,           [        R::POST]],
 		'/profile/show[.{extension:json|xml|rss|atom}]'            => [Module\Api\Friendica\Profile\Show::class,           [R::GET         ]],
 		'/photoalbums[.{extension:json|xml|rss|atom}]'             => [Module\Api\Friendica\Photoalbum\Index::class,       [R::GET         ]],
+		'/photoalbum[.{extension:json|xml|rss|atom}]'              => [Module\Api\Friendica\Photoalbum\Show::class,        [R::GET         ]],
 		'/photoalbum/delete[.{extension:json|xml|rss|atom}]'       => [Module\Api\Friendica\Photoalbum\Delete::class,      [        R::POST]],
 		'/photoalbum/update[.{extension:json|xml|rss|atom}]'       => [Module\Api\Friendica\Photoalbum\Update::class,      [        R::POST]],
 		'/photos/list[.{extension:json|xml|rss|atom}]'             => [Module\Api\Friendica\Photo\Lists::class,            [R::GET         ]],


### PR DESCRIPTION
- Allow album name to be empty string when posting so it automatically goes to the i18n "Wall Photos" gallery like in the Web UI
- Adds a GET Photo Albums endpoint to list photo albums:  `/api/friendica/photoalbums`
- Adds a GET Photo Album photo list end point to photo albums: `/api/friendica/photoalbum?album=:name`
  - With optional paging parameters: offset, limit, and latest_first
- Adds photo album cache flushes to all endpoints that successfully change the photo collections so it operates the same way as the Web UI. 