### PR TITLE
Add "int_id" field to Photo JSON 

### DIFF
--- a/src/Factory/Api/Friendica/Photo.php
+++ b/src/Factory/Api/Friendica/Photo.php
@@ -74,8 +74,9 @@ class Photo extends BaseFactory
 		if (empty($photos)) {
 			throw new HTTPException\NotFoundException();
 		}
-		$data       = $photos[0];
-		$data['id'] = $data['resource-id'];
+		$data           = $photos[0];
+		$data['int_id'] = $data['id'];
+		$data['id']     = $data['resource-id'];
 		if (is_int($scale)) {
 			$data['data'] = base64_encode(ModelPhoto::getImageDataForPhoto($data));
 		} else {


### PR DESCRIPTION
The Friendica API uses the `resource-id` column for referencing photo items. The Mastodon API uses the `id` column. I believe that's because `resource-id` is a string and all IDs in Mastodon while stored as strings are expected to be ints. This adds an explicit `int_id` field that maps the integer ID used in the `photo` table so as not to break backward compatibility with any of the existing endpoints rather than add a `resource_id` field and repurposing the `id` field back to the internal `id` column.