### PR TITLE
Use account-user-view entry to instantiate Api\Mastodon\FollowRequestobjects

### DIFF
--- a/src/Contact/Introduction/Entity/Introduction.php
+++ b/src/Contact/Introduction/Entity/Introduction.php
@@ -25,7 +25,7 @@ use Friendica\BaseEntity;
 
 /**
  * @property-read int $uid
- * @property-read int $cid
+ * @property-read int $cid Either a public contact id (DFRN suggestion) or user-specific id (Contact::addRelationship)
  * @property-read int|null $sid
  * @property-read bool $knowyou
  * @property-read string $note

--- a/src/Object/Api/Mastodon/FollowRequest.php
+++ b/src/Object/Api/Mastodon/FollowRequest.php
@@ -37,14 +37,12 @@ class FollowRequest extends Account
 	 *
 	 * @param BaseURL $baseUrl
 	 * @param int     $introduction_id Introduction record id
-	 * @param array   $publicContact   Full contact table record with uid = 0
-	 * @param array   $apcontact       Optional full apcontact table record
-	 * @param array   $userContact     Optional full contact table record with uid != 0
+	 * @param array   $account         entry of "account-user-view"
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function __construct(BaseURL $baseUrl, int $introduction_id, array $publicContact, array $apcontact = [], array $userContact = [])
+	public function __construct(BaseURL $baseUrl, int $introduction_id, array $account)
 	{
-		parent::__construct($baseUrl, $publicContact, new Fields(), $apcontact, $userContact);
+		parent::__construct($baseUrl, $account, new Fields());
 
 		$this->id = $introduction_id;
 	}


### PR DESCRIPTION
- Address https://github.com/friendica/friendica/issues/11993#issuecomment-1354395861

@annando I wasn't sure if I should have tested `id` or `pid` in the `DBA::selectFirst('account-user-view')` call. I assumed that the introduction `cid` is relative to the user, let me know if it's inaccurate.