### PR TITLE
Include DBA/View definitions from Hooks again

### DIFF
--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -249,7 +249,8 @@ class DBStructure
 
 		// Get the definition
 		if (is_null($definition)) {
-			$definition = DI::dbaDefinition()->getAll();
+			// just for Update purpose, reload the DBA definition with addons to explicit get the whole definition
+			$definition = DI::dbaDefinition()->load(true)->getAll();
 		}
 
 		// MySQL >= 5.7.4 doesn't support the IGNORE keyword in ALTER TABLE statements

--- a/src/Database/View.php
+++ b/src/Database/View.php
@@ -49,7 +49,8 @@ class View
 			}
 		}
 
-		$definition = DI::viewDefinition()->getAll();
+		// just for Create purpose, reload the view definition with addons to explicit get the whole definition
+		$definition = DI::viewDefinition()->load(true)->getAll();
 
 		foreach ($definition as $name => $structure) {
 			if (self::isView($name)) {


### PR DESCRIPTION
Introduced by #11728
Fixes #12437 

I tested it with the Advanced content Filter, which now creates the table again :-)

At first, I had the problem that the DBA/View Definition called the `Hook::` too early, but I introduced the regression that it now never called it anywhere again :D