### PR TITLE
Fix: Images must not be removed on preview

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3016,7 +3016,11 @@ class Item
 		$item['hashtags'] = $tags['hashtags'];
 		$item['mentions'] = $tags['mentions'];
 
-		$body = $item['body'] = Post\Media::removeFromEndOfBody($item['body'] ?? '');
+		if (!$is_preview) {
+			$item['body'] = Post\Media::removeFromEndOfBody($item['body'] ?? '');
+		}
+
+		$body = $item['body'];
 
 		$fields = ['uri-id', 'uri', 'body', 'title', 'author-name', 'author-link', 'author-avatar', 'guid', 'created', 'plink', 'network', 'has-media', 'quote-uri-id', 'post-type'];
 


### PR DESCRIPTION
When using the preview, we mustn't remove the picture from the body. There is no `uri-id` at this moment, so we cannot add the images there at this time.

Fix #12401