### PR TITLE
Don't perform a delivery to failing servers

### DIFF
--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -177,9 +177,13 @@ class GServer
 	public static function reachable(string $profile, string $server = '', string $network = '', bool $force = false): bool
 	{
 		if ($server == '') {
-			$contact = Contact::getByURL($profile, null, ['baseurl']);
+			$contact = Contact::getByURL($profile, null, ['baseurl', 'network']);
 			if (!empty($contact['baseurl'])) {
 				$server = $contact['baseurl'];
+			} elseif ($contact['network'] == Protocol::DIASPORA) {
+				$parts = parse_url($profile);
+				unset($parts['path']);
+				$server =  (string)Uri::fromParts($parts);
 			}
 		}
 

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -183,7 +183,7 @@ class GServer
 			} elseif ($contact['network'] == Protocol::DIASPORA) {
 				$parts = parse_url($profile);
 				unset($parts['path']);
-				$server =  (string)Uri::fromParts($parts);
+				$server = (string)Uri::fromParts($parts);
 			}
 		}
 


### PR DESCRIPTION
This fixes the issue that deliveries to non working Diaspora servers really can block the worker queue. On squeet.me for example there had been more than 100k of jobs that were awaiting delivery. Thsi check here shouldn't have an impact on systems that just had got some hiccup, but only aren't working for some time now.