### PR TITLE
Don't calculate the blurhash on images without a size

### DIFF
--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -734,13 +734,17 @@ class Image
 			return '';
 		}
 
-		$width = $image->getWidth();
+		$width  = $image->getWidth();
 		$height = $image->getHeight();
 
 		if (max($width, $height) > 90) {
 			$image->scaleDown(90);
-			$width = $image->getWidth();
+			$width  = $image->getWidth();
 			$height = $image->getHeight();
+		}
+
+		if (empty($width) || empty($height)) {
+			return '';
 		}
 
 		$pixels = [];


### PR DESCRIPTION
This fixes a randomly occuring issue that the blurhash can't be calculated since the image has got no width or heigth.