### PR TITLE
Changed registration text input to text area since BBcode is allowed …

### DIFF
--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -31,7 +31,7 @@
 		<div class="submit"><input type="submit" name="page_site" value="{{$submit}}"/></div>
 
 		<h2>{{$registration}}</h2>
-		{{include file="field_input.tpl" field=$register_text}}
+		{{include file="field_textarea.tpl" field=$register_text}}
 		{{include file="field_select.tpl" field=$register_policy}}
 		{{include file="field_input.tpl" field=$daily_registrations}}
 		{{include file="field_checkbox.tpl" field=$enable_multi_reg}}

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -70,7 +70,7 @@
 				</div>
 				<div id="admin-settings-registration-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-registration">
 					<div class="panel-body">
-						{{include file="field_input.tpl" field=$register_text}}
+						{{include file="field_textarea.tpl" field=$register_text}}
 						{{include file="field_select.tpl" field=$register_policy}}
 						{{include file="field_input.tpl" field=$daily_registrations}}
 						{{include file="field_checkbox.tpl" field=$enable_multi_reg}}


### PR DESCRIPTION
…there (was single line input)

As I set up a new instance, I noticed that the input field for registration text in only a formal one line input filed. I thought this is incontinent since bbcode is allowed for longer texts. So I changed the input to textarea core view and frio theme. Vier has not won `size.tpl`