### PR TITLE
Change email subject to "(...)like in conversation(...)" for likes in…

### DIFF
--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -784,13 +784,18 @@ class Notify extends BaseRepository
 		} else {
 			$params['type'] = Model\Notification\Type::COMMENT;
 			if ($params['verb'] = Activity::LIKE) {
-				$subject    = $l10n->t('%1$s Like in conversation #%2$d by %3$s', $subjectPrefix, $item['parent'], $contact['name']);
+				switch ($Notification->type) {
+					case Model\Post\UserNotification::TYPE_DIRECT_COMMENT:
+						$subject    = $l10n->t('%1$s %2$s liked your post #%3$d', $subjectPrefix, $contact['name'], $item['parent']);
+						break;
+					case Model\Post\UserNotification::TYPE_DIRECT_THREAD_COMMENT:
+						$subject    = $l10n->t('%1$s %2$s liked your comment on #%3$d', $subjectPrefix, $contact['name'], $item['parent']);
+						break;
+				}
 			} else {
 				$subject    = $l10n->t('%1$s Comment to conversation #%2$d by %3$s', $subjectPrefix, $item['parent'], $contact['name']);
 			}
 		}
-
-
 
 		$msg = $this->notification->getMessageFromNotification($Notification);
 		if (empty($msg)) {

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -771,7 +771,7 @@ class Notify extends BaseRepository
 			$title = '"' . trim(str_replace("\n", " ", $title)) . '"';
 		}
 
-		// Some mail software relies on subject field for threading.
+		// Some mail software rely on subject field for threading.
 		// So, we cannot have different subjects for notifications of the same thread.
 		// Before this we have the name of the replier on the subject rendering
 		// different subjects for messages on the same thread.

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -783,8 +783,14 @@ class Notify extends BaseRepository
 			$subject        = $l10n->t('%s %s shared a new post', $subjectPrefix, $contact['name']);
 		} else {
 			$params['type'] = Model\Notification\Type::COMMENT;
-			$subject        = $l10n->t('%1$s Comment to conversation #%2$d by %3$s', $subjectPrefix, $item['parent'], $contact['name']);
+			if ($params['verb'] = Activity::LIKE) {
+				$subject    = $l10n->t('%1$s Like in conversation #%2$d by %3$s', $subjectPrefix, $item['parent'], $contact['name']);
+			} else {
+				$subject    = $l10n->t('%1$s Comment to conversation #%2$d by %3$s', $subjectPrefix, $item['parent'], $contact['name']);
+			}
 		}
+
+
 
 		$msg = $this->notification->getMessageFromNotification($Notification);
 		if (empty($msg)) {

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -771,7 +771,7 @@ class Notify extends BaseRepository
 			$title = '"' . trim(str_replace("\n", " ", $title)) . '"';
 		}
 
-		// Some mail software rely on subject field for threading.
+		// Some mail software relies on the subject field for threading.
 		// So, we cannot have different subjects for notifications of the same thread.
 		// Before this we have the name of the replier on the subject rendering
 		// different subjects for messages on the same thread.

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -786,14 +786,14 @@ class Notify extends BaseRepository
 			if ($params['verb'] = Activity::LIKE) {
 				switch ($Notification->type) {
 					case Model\Post\UserNotification::TYPE_DIRECT_COMMENT:
-						$subject    = $l10n->t('%1$s %2$s liked your post #%3$d', $subjectPrefix, $contact['name'], $item['parent']);
+						$subject = $l10n->t('%1$s %2$s liked your post #%3$d', $subjectPrefix, $contact['name'], $item['parent']);
 						break;
 					case Model\Post\UserNotification::TYPE_DIRECT_THREAD_COMMENT:
-						$subject    = $l10n->t('%1$s %2$s liked your comment on #%3$d', $subjectPrefix, $contact['name'], $item['parent']);
+						$subject = $l10n->t('%1$s %2$s liked your comment on #%3$d', $subjectPrefix, $contact['name'], $item['parent']);
 						break;
 				}
 			} else {
-				$subject    = $l10n->t('%1$s Comment to conversation #%2$d by %3$s', $subjectPrefix, $item['parent'], $contact['name']);
+				$subject = $l10n->t('%1$s Comment to conversation #%2$d by %3$s', $subjectPrefix, $item['parent'], $contact['name']);
 			}
 		}
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2023.03-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-23 01:05+0100\n"
+"POT-Creation-Date: 2022-12-23 02:32+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10793,7 +10793,7 @@ msgid "%1$s commented on their %2$s %3$s"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:341
-#: src/Navigation/Notifications/Repository/Notify.php:789
+#: src/Navigation/Notifications/Repository/Notify.php:796
 #, php-format
 msgid "%1$s Comment to conversation #%2$d by %3$s"
 msgstr ""
@@ -10805,7 +10805,7 @@ msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:347
 #: src/Navigation/Notifications/Repository/Notify.php:362
-#: src/Navigation/Notifications/Repository/Notify.php:807
+#: src/Navigation/Notifications/Repository/Notify.php:812
 #, php-format
 msgid "Please visit %s to view and/or reply to the conversation."
 msgstr ""
@@ -11008,9 +11008,14 @@ msgstr ""
 msgid "%s %s shared a new post"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:787
+#: src/Navigation/Notifications/Repository/Notify.php:789
 #, php-format
-msgid "%1$s Like in conversation #%2$d by %3$s"
+msgid "%1$s %2$s liked your post #%3$d"
+msgstr ""
+
+#: src/Navigation/Notifications/Repository/Notify.php:792
+#, php-format
+msgid "%1$s %2$s liked your comment on #%3$d"
 msgstr ""
 
 #: src/Object/EMail/ItemCCEMail.php:42

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2023.03-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-17 23:06-0500\n"
+"POT-Creation-Date: 2022-12-23 01:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,7 +29,7 @@ msgstr ""
 #: src/Module/Calendar/Event/API.php:88 src/Module/Calendar/Event/Form.php:84
 #: src/Module/Calendar/Export.php:62 src/Module/Calendar/Show.php:82
 #: src/Module/Contact/Advanced.php:60 src/Module/Contact/Follow.php:86
-#: src/Module/Contact/Follow.php:160 src/Module/Contact/MatchInterests.php:86
+#: src/Module/Contact/Follow.php:159 src/Module/Contact/MatchInterests.php:86
 #: src/Module/Contact/Suggestions.php:54 src/Module/Contact/Unfollow.php:66
 #: src/Module/Contact/Unfollow.php:80 src/Module/Contact/Unfollow.php:112
 #: src/Module/Delegation.php:118 src/Module/FollowConfirm.php:38
@@ -38,8 +38,8 @@ msgstr ""
 #: src/Module/Notifications/Notification.php:76
 #: src/Module/Notifications/Notification.php:107
 #: src/Module/OStatus/Repair.php:60 src/Module/OStatus/Subscribe.php:66
-#: src/Module/Post/Edit.php:76 src/Module/Profile/Common.php:55
-#: src/Module/Profile/Contacts.php:55 src/Module/Profile/Photos.php:92
+#: src/Module/Post/Edit.php:76 src/Module/Profile/Common.php:75
+#: src/Module/Profile/Contacts.php:78 src/Module/Profile/Photos.php:92
 #: src/Module/Profile/Schedule.php:39 src/Module/Profile/Schedule.php:56
 #: src/Module/Profile/UnkMail.php:69 src/Module/Profile/UnkMail.php:121
 #: src/Module/Profile/UnkMail.php:132 src/Module/Register.php:77
@@ -310,7 +310,7 @@ msgstr ""
 #: src/Module/Install.php:252 src/Module/Install.php:294
 #: src/Module/Install.php:331 src/Module/Invite.php:178
 #: src/Module/Item/Compose.php:189 src/Module/Moderation/Item/Source.php:79
-#: src/Module/Profile/Profile.php:239 src/Module/Profile/UnkMail.php:156
+#: src/Module/Profile/Profile.php:274 src/Module/Profile/UnkMail.php:156
 #: src/Module/Settings/Profile/Index.php:231 src/Object/Post.php:986
 #: view/theme/duepuntozero/config.php:85 view/theme/frio/config.php:171
 #: view/theme/quattro/config.php:87 view/theme/vier/config.php:135
@@ -387,31 +387,31 @@ msgstr ""
 #: src/Model/Event.php:514 src/Model/Profile.php:234
 #: src/Module/Calendar/Export.php:67 src/Module/Calendar/Show.php:74
 #: src/Module/DFRN/Poll.php:43 src/Module/Feed.php:65 src/Module/HCard.php:51
-#: src/Module/Profile/Common.php:40 src/Module/Profile/Common.php:51
-#: src/Module/Profile/Contacts.php:39 src/Module/Profile/Contacts.php:49
+#: src/Module/Profile/Common.php:62 src/Module/Profile/Common.php:71
+#: src/Module/Profile/Contacts.php:64 src/Module/Profile/Contacts.php:72
 #: src/Module/Profile/Media.php:38 src/Module/Profile/Photos.php:83
-#: src/Module/Profile/RemoteFollow.php:71 src/Module/Profile/Status.php:58
+#: src/Module/Profile/RemoteFollow.php:71 src/Module/Profile/Status.php:91
 #: src/Module/Register.php:267
 msgid "User not found."
 msgstr ""
 
 #: mod/photos.php:105 src/Module/BaseProfile.php:68
-#: src/Module/Profile/Photos.php:407
+#: src/Module/Profile/Photos.php:399
 msgid "Photo Albums"
 msgstr ""
 
-#: mod/photos.php:106 src/Module/Profile/Photos.php:408
-#: src/Module/Profile/Photos.php:423
+#: mod/photos.php:106 src/Module/Profile/Photos.php:400
+#: src/Module/Profile/Photos.php:420
 msgid "Recent Photos"
 msgstr ""
 
-#: mod/photos.php:108 mod/photos.php:872 src/Module/Profile/Photos.php:410
-#: src/Module/Profile/Photos.php:425
+#: mod/photos.php:108 mod/photos.php:872 src/Module/Profile/Photos.php:402
+#: src/Module/Profile/Photos.php:422
 msgid "Upload New Photos"
 msgstr ""
 
 #: mod/photos.php:126 src/Module/BaseSettings.php:74
-#: src/Module/Profile/Photos.php:391
+#: src/Module/Profile/Photos.php:383
 msgid "everybody"
 msgstr ""
 
@@ -489,7 +489,7 @@ msgid "Delete Album"
 msgstr ""
 
 #: mod/photos.php:803 mod/photos.php:904 src/Content/Conversation.php:389
-#: src/Module/Contact/Follow.php:173 src/Module/Contact/Revoke.php:109
+#: src/Module/Contact/Follow.php:172 src/Module/Contact/Revoke.php:109
 #: src/Module/Contact/Unfollow.php:126
 #: src/Module/Media/Attachment/Browser.php:77
 #: src/Module/Media/Photo/Browser.php:88 src/Module/Post/Edit.php:164
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Show Oldest First"
 msgstr ""
 
-#: mod/photos.php:857 src/Module/Profile/Photos.php:378
+#: mod/photos.php:857 src/Module/Profile/Photos.php:370
 msgid "View Photo"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgid "Rotate CCW (left)"
 msgstr ""
 
 #: mod/photos.php:1134 mod/photos.php:1190 mod/photos.php:1264
-#: src/Module/Contact.php:547 src/Module/Item/Compose.php:188
+#: src/Module/Contact.php:550 src/Module/Item/Compose.php:188
 #: src/Object/Post.php:983
 msgid "This is you"
 msgstr ""
@@ -695,16 +695,16 @@ msgid "All contacts"
 msgstr ""
 
 #: src/BaseModule.php:424 src/Content/Widget.php:235 src/Core/ACL.php:194
-#: src/Module/Contact.php:370 src/Module/PermissionTooltip.php:122
+#: src/Module/Contact.php:371 src/Module/PermissionTooltip.php:122
 #: src/Module/PermissionTooltip.php:144
 msgid "Followers"
 msgstr ""
 
-#: src/BaseModule.php:429 src/Content/Widget.php:236 src/Module/Contact.php:371
+#: src/BaseModule.php:429 src/Content/Widget.php:236 src/Module/Contact.php:372
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:434 src/Content/Widget.php:237 src/Module/Contact.php:372
+#: src/BaseModule.php:434 src/Content/Widget.php:237 src/Module/Contact.php:373
 msgid "Mutual friends"
 msgstr ""
 
@@ -1539,35 +1539,35 @@ msgstr ""
 msgid "Follow Thread"
 msgstr ""
 
-#: src/Content/Item.php:387 src/Model/Contact.php:1213
+#: src/Content/Item.php:387 src/Model/Contact.php:1198
 msgid "View Status"
 msgstr ""
 
-#: src/Content/Item.php:388 src/Content/Item.php:406 src/Model/Contact.php:1151
-#: src/Model/Contact.php:1205 src/Model/Contact.php:1214
+#: src/Content/Item.php:388 src/Content/Item.php:406 src/Model/Contact.php:1142
+#: src/Model/Contact.php:1190 src/Model/Contact.php:1199
 #: src/Module/Directory.php:157 src/Module/Settings/Profile/Index.php:234
 msgid "View Profile"
 msgstr ""
 
-#: src/Content/Item.php:389 src/Model/Contact.php:1215
+#: src/Content/Item.php:389 src/Model/Contact.php:1200
 msgid "View Photos"
 msgstr ""
 
-#: src/Content/Item.php:390 src/Model/Contact.php:1206
-#: src/Model/Contact.php:1216
+#: src/Content/Item.php:390 src/Model/Contact.php:1191
+#: src/Model/Contact.php:1201
 msgid "Network Posts"
 msgstr ""
 
-#: src/Content/Item.php:391 src/Model/Contact.php:1207
-#: src/Model/Contact.php:1217
+#: src/Content/Item.php:391 src/Model/Contact.php:1192
+#: src/Model/Contact.php:1202
 msgid "View Contact"
 msgstr ""
 
-#: src/Content/Item.php:392 src/Model/Contact.php:1218
+#: src/Content/Item.php:392 src/Model/Contact.php:1203
 msgid "Send PM"
 msgstr ""
 
-#: src/Content/Item.php:393 src/Module/Contact.php:401
+#: src/Content/Item.php:393 src/Module/Contact.php:402
 #: src/Module/Contact/Profile.php:348 src/Module/Contact/Profile.php:467
 #: src/Module/Moderation/Blocklist/Contact.php:116
 #: src/Module/Moderation/Users/Active.php:137
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "Block"
 msgstr ""
 
-#: src/Content/Item.php:394 src/Module/Contact.php:402
+#: src/Content/Item.php:394 src/Module/Contact.php:403
 #: src/Module/Contact/Profile.php:349 src/Module/Contact/Profile.php:475
 #: src/Module/Notifications/Introductions.php:134
 #: src/Module/Notifications/Introductions.php:206
@@ -1588,8 +1588,8 @@ msgid "Languages"
 msgstr ""
 
 #: src/Content/Item.php:403 src/Content/Widget.php:80
-#: src/Model/Contact.php:1208 src/Model/Contact.php:1219
-#: src/Module/Contact/Follow.php:167 view/theme/vier/theme.php:196
+#: src/Model/Contact.php:1193 src/Model/Contact.php:1204
+#: src/Module/Contact/Follow.php:166 view/theme/vier/theme.php:196
 msgid "Connect/Follow"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgid "Sign in"
 msgstr ""
 
 #: src/Content/Nav.php:193 src/Module/BaseProfile.php:57
-#: src/Module/Contact.php:436 src/Module/Contact/Profile.php:380
+#: src/Module/Contact.php:437 src/Module/Contact/Profile.php:380
 #: src/Module/Settings/TwoFactor/Index.php:119 view/theme/frio/theme.php:236
 msgid "Status"
 msgstr ""
@@ -1638,8 +1638,8 @@ msgid "Your posts and conversations"
 msgstr ""
 
 #: src/Content/Nav.php:194 src/Module/BaseProfile.php:49
-#: src/Module/BaseSettings.php:100 src/Module/Contact.php:460
-#: src/Module/Contact/Profile.php:382 src/Module/Profile/Profile.php:233
+#: src/Module/BaseSettings.php:100 src/Module/Contact.php:461
+#: src/Module/Contact/Profile.php:382 src/Module/Profile/Profile.php:268
 #: src/Module/Welcome.php:57 view/theme/frio/theme.php:237
 msgid "Profile"
 msgstr ""
@@ -1658,7 +1658,7 @@ msgid "Your photos"
 msgstr ""
 
 #: src/Content/Nav.php:196 src/Module/BaseProfile.php:73
-#: src/Module/BaseProfile.php:76 src/Module/Contact.php:452
+#: src/Module/BaseProfile.php:76 src/Module/Contact.php:453
 #: view/theme/frio/theme.php:242
 msgid "Media"
 msgstr ""
@@ -1744,8 +1744,8 @@ msgstr ""
 
 #: src/Content/Nav.php:238 src/Content/Nav.php:293
 #: src/Content/Text/HTML.php:899 src/Module/BaseProfile.php:127
-#: src/Module/BaseProfile.php:130 src/Module/Contact.php:373
-#: src/Module/Contact.php:467 view/theme/frio/theme.php:250
+#: src/Module/BaseProfile.php:130 src/Module/Contact.php:374
+#: src/Module/Contact.php:468 view/theme/frio/theme.php:250
 msgid "Contacts"
 msgstr ""
 
@@ -1776,7 +1776,7 @@ msgstr ""
 
 #: src/Content/Nav.php:265 src/Module/Admin/Tos.php:78
 #: src/Module/BaseAdmin.php:95 src/Module/Register.php:176
-#: src/Module/Tos.php:98
+#: src/Module/Tos.php:100
 msgid "Terms of Service"
 msgstr ""
 
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "Link to source"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1795 src/Content/Text/HTML.php:940
+#: src/Content/Text/BBCode.php:1795 src/Content/Text/HTML.php:927
 msgid "Click to open/close"
 msgstr ""
 
@@ -1993,7 +1993,7 @@ msgstr ""
 msgid "Examples: Robert Morgenstein, Fishing"
 msgstr ""
 
-#: src/Content/Widget.php:82 src/Module/Contact.php:394
+#: src/Content/Widget.php:82 src/Module/Contact.php:395
 #: src/Module/Directory.php:96 view/theme/vier/theme.php:198
 msgid "Find"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgid "Local Directory"
 msgstr ""
 
 #: src/Content/Widget.php:211 src/Model/Group.php:587
-#: src/Module/Contact.php:357 src/Module/Welcome.php:76
+#: src/Module/Contact.php:358 src/Module/Welcome.php:76
 msgid "Groups"
 msgstr ""
 
@@ -2037,7 +2037,7 @@ msgstr ""
 msgid "Relationships"
 msgstr ""
 
-#: src/Content/Widget.php:244 src/Module/Contact.php:309
+#: src/Content/Widget.php:244 src/Module/Contact.php:310
 #: src/Module/Group.php:291
 msgid "All Contacts"
 msgstr ""
@@ -2081,7 +2081,7 @@ msgstr ""
 msgid "Organisations"
 msgstr ""
 
-#: src/Content/Widget.php:523 src/Model/Contact.php:1655
+#: src/Content/Widget.php:523 src/Model/Contact.php:1644
 msgid "News"
 msgstr ""
 
@@ -2140,12 +2140,12 @@ msgid "More Trending Tags"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:102 src/Model/Profile.php:378
-#: src/Module/Contact/Profile.php:371 src/Module/Profile/Profile.php:168
+#: src/Module/Contact/Profile.php:371 src/Module/Profile/Profile.php:199
 msgid "XMPP:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:103 src/Model/Profile.php:379
-#: src/Module/Contact/Profile.php:373 src/Module/Profile/Profile.php:172
+#: src/Module/Contact/Profile.php:373 src/Module/Profile/Profile.php:203
 msgid "Matrix:"
 msgstr ""
 
@@ -2153,7 +2153,7 @@ msgstr ""
 #: src/Model/Event.php:109 src/Model/Event.php:473 src/Model/Event.php:958
 #: src/Model/Profile.php:373 src/Module/Contact/Profile.php:369
 #: src/Module/Directory.php:147 src/Module/Notifications/Introductions.php:187
-#: src/Module/Profile/Profile.php:186
+#: src/Module/Profile/Profile.php:221
 msgid "Location:"
 msgstr ""
 
@@ -2162,13 +2162,13 @@ msgstr ""
 msgid "Network:"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:111 src/Model/Contact.php:1209
-#: src/Model/Contact.php:1220 src/Model/Profile.php:465
+#: src/Content/Widget/VCard.php:111 src/Model/Contact.php:1194
+#: src/Model/Contact.php:1205 src/Model/Profile.php:465
 #: src/Module/Contact/Profile.php:419
 msgid "Unfollow"
 msgstr ""
 
-#: src/Core/ACL.php:165 src/Module/Profile/Profile.php:234
+#: src/Core/ACL.php:165 src/Module/Profile/Profile.php:269
 msgid "Yourself"
 msgstr ""
 
@@ -2866,77 +2866,77 @@ msgstr ""
 msgid "Legacy module file not found: %s"
 msgstr ""
 
-#: src/Model/Contact.php:1226 src/Module/Moderation/Users/Pending.php:102
+#: src/Model/Contact.php:1211 src/Module/Moderation/Users/Pending.php:102
 #: src/Module/Notifications/Introductions.php:132
 #: src/Module/Notifications/Introductions.php:204
 msgid "Approve"
 msgstr ""
 
-#: src/Model/Contact.php:1651
+#: src/Model/Contact.php:1640
 msgid "Organisation"
 msgstr ""
 
-#: src/Model/Contact.php:1659
+#: src/Model/Contact.php:1648
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:2884
+#: src/Model/Contact.php:2877
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:2889 src/Module/Friendica.php:82
+#: src/Model/Contact.php:2882 src/Module/Friendica.php:82
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:2894
+#: src/Model/Contact.php:2887
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:2903
+#: src/Model/Contact.php:2896
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:2945
+#: src/Model/Contact.php:2931
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:2947
+#: src/Model/Contact.php:2933
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:2950
+#: src/Model/Contact.php:2936
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:2953
+#: src/Model/Contact.php:2939
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:2956
+#: src/Model/Contact.php:2942
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:2957
+#: src/Model/Contact.php:2943
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:2963
+#: src/Model/Contact.php:2949
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:2968
+#: src/Model/Contact.php:2954
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:3027
+#: src/Model/Contact.php:3019
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -3156,8 +3156,8 @@ msgstr ""
 msgid "Wall Photos"
 msgstr ""
 
-#: src/Model/Profile.php:361 src/Module/Profile/Profile.php:248
-#: src/Module/Profile/Profile.php:250
+#: src/Model/Profile.php:361 src/Module/Profile/Profile.php:283
+#: src/Module/Profile/Profile.php:285
 msgid "Edit profile"
 msgstr ""
 
@@ -3166,7 +3166,7 @@ msgid "Change profile photo"
 msgstr ""
 
 #: src/Model/Profile.php:376 src/Module/Directory.php:152
-#: src/Module/Profile/Profile.php:176
+#: src/Module/Profile/Profile.php:209
 msgid "Homepage:"
 msgstr ""
 
@@ -3585,9 +3585,9 @@ msgid "Enable"
 msgstr ""
 
 #: src/Module/Admin/Addons/Details.php:111 src/Module/Admin/Addons/Index.php:67
-#: src/Module/Admin/Federation.php:202 src/Module/Admin/Logs/Settings.php:79
+#: src/Module/Admin/Federation.php:207 src/Module/Admin/Logs/Settings.php:79
 #: src/Module/Admin/Logs/View.php:84 src/Module/Admin/Queue.php:72
-#: src/Module/Admin/Site.php:437 src/Module/Admin/Storage.php:138
+#: src/Module/Admin/Site.php:433 src/Module/Admin/Storage.php:138
 #: src/Module/Admin/Summary.php:216 src/Module/Admin/Themes/Details.php:90
 #: src/Module/Admin/Themes/Index.php:111 src/Module/Admin/Tos.php:77
 #: src/Module/Moderation/Users/Create.php:61
@@ -3625,7 +3625,7 @@ msgid "Addon %s failed to install."
 msgstr ""
 
 #: src/Module/Admin/Addons/Index.php:69 src/Module/Admin/Features.php:87
-#: src/Module/Admin/Logs/Settings.php:81 src/Module/Admin/Site.php:440
+#: src/Module/Admin/Logs/Settings.php:81 src/Module/Admin/Site.php:436
 #: src/Module/Admin/Themes/Index.php:113 src/Module/Admin/Tos.php:86
 #: src/Module/Settings/Account.php:560 src/Module/Settings/Addons.php:81
 #: src/Module/Settings/Connectors.php:159
@@ -3715,75 +3715,75 @@ msgstr ""
 msgid "Manage Additional Features"
 msgstr ""
 
-#: src/Module/Admin/Federation.php:70
+#: src/Module/Admin/Federation.php:73
 msgid "Other"
 msgstr ""
 
-#: src/Module/Admin/Federation.php:142 src/Module/Admin/Federation.php:391
+#: src/Module/Admin/Federation.php:147 src/Module/Admin/Federation.php:396
 msgid "unknown"
 msgstr ""
 
-#: src/Module/Admin/Federation.php:175
+#: src/Module/Admin/Federation.php:180
 #, php-format
 msgid "%2$s total system"
 msgid_plural "%2$s total systems"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Federation.php:176
+#: src/Module/Admin/Federation.php:181
 #, php-format
 msgid "%2$s active user last month"
 msgid_plural "%2$s active users last month"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Federation.php:177
+#: src/Module/Admin/Federation.php:182
 #, php-format
 msgid "%2$s active user last six months"
 msgid_plural "%2$s active users last six months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Federation.php:178
+#: src/Module/Admin/Federation.php:183
 #, php-format
 msgid "%2$s registered user"
 msgid_plural "%2$s registered users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Federation.php:179
+#: src/Module/Admin/Federation.php:184
 #, php-format
 msgid "%2$s locally created post or comment"
 msgid_plural "%2$s locally created posts and comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Federation.php:182
+#: src/Module/Admin/Federation.php:187
 #, php-format
 msgid "%2$s post per user"
 msgid_plural "%2$s posts per user"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Federation.php:187
+#: src/Module/Admin/Federation.php:192
 #, php-format
 msgid "%2$s user per system"
 msgid_plural "%2$s users per system"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Admin/Federation.php:197
+#: src/Module/Admin/Federation.php:202
 msgid ""
 "This page offers you some numbers to the known part of the federated social "
 "network your Friendica node is part of. These numbers are not complete but "
 "only reflect the part of the network your node is aware of."
 msgstr ""
 
-#: src/Module/Admin/Federation.php:203 src/Module/BaseAdmin.php:87
+#: src/Module/Admin/Federation.php:208 src/Module/BaseAdmin.php:87
 msgid "Federation Statistics"
 msgstr ""
 
-#: src/Module/Admin/Federation.php:207
+#: src/Module/Admin/Federation.php:212
 #, php-format
 msgid ""
 "Currently this node is aware of %2$s node (%3$s active users last month, "
@@ -4015,251 +4015,251 @@ msgstr ""
 msgid "Multi user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:408
+#: src/Module/Admin/Site.php:404
 msgid "Closed"
 msgstr ""
 
-#: src/Module/Admin/Site.php:409
+#: src/Module/Admin/Site.php:405
 msgid "Requires approval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:410
+#: src/Module/Admin/Site.php:406
 msgid "Open"
 msgstr ""
 
-#: src/Module/Admin/Site.php:414 src/Module/Install.php:222
+#: src/Module/Admin/Site.php:410 src/Module/Install.php:222
 msgid "No SSL policy, links will track page SSL state"
 msgstr ""
 
-#: src/Module/Admin/Site.php:415 src/Module/Install.php:223
+#: src/Module/Admin/Site.php:411 src/Module/Install.php:223
 msgid "Force all links to use SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:416 src/Module/Install.php:224
+#: src/Module/Admin/Site.php:412 src/Module/Install.php:224
 msgid "Self-signed certificate, use SSL for local links only (discouraged)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:420
+#: src/Module/Admin/Site.php:416
 msgid "Don't check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:421
+#: src/Module/Admin/Site.php:417
 msgid "check the stable version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:422
+#: src/Module/Admin/Site.php:418
 msgid "check the development version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:426
+#: src/Module/Admin/Site.php:422
 msgid "none"
 msgstr ""
 
-#: src/Module/Admin/Site.php:427
+#: src/Module/Admin/Site.php:423
 msgid "Local contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:428
+#: src/Module/Admin/Site.php:424
 msgid "Interactors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:438 src/Module/BaseAdmin.php:90
+#: src/Module/Admin/Site.php:434 src/Module/BaseAdmin.php:90
 msgid "Site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:439
+#: src/Module/Admin/Site.php:435
 msgid "General Information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:441
+#: src/Module/Admin/Site.php:437
 msgid "Republish users to directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:442 src/Module/Register.php:152
+#: src/Module/Admin/Site.php:438 src/Module/Register.php:152
 msgid "Registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:443
+#: src/Module/Admin/Site.php:439
 msgid "File upload"
 msgstr ""
 
-#: src/Module/Admin/Site.php:444
+#: src/Module/Admin/Site.php:440
 msgid "Policies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:445 src/Module/Calendar/Event/Form.php:252
-#: src/Module/Contact.php:477 src/Module/Profile/Profile.php:241
+#: src/Module/Admin/Site.php:441 src/Module/Calendar/Event/Form.php:252
+#: src/Module/Contact.php:478 src/Module/Profile/Profile.php:276
 msgid "Advanced"
 msgstr ""
 
-#: src/Module/Admin/Site.php:446
+#: src/Module/Admin/Site.php:442
 msgid "Auto Discovered Contact Directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:447
+#: src/Module/Admin/Site.php:443
 msgid "Performance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:448
+#: src/Module/Admin/Site.php:444
 msgid "Worker"
 msgstr ""
 
-#: src/Module/Admin/Site.php:449
+#: src/Module/Admin/Site.php:445
 msgid "Message Relay"
 msgstr ""
 
-#: src/Module/Admin/Site.php:450
+#: src/Module/Admin/Site.php:446
 msgid ""
 "Use the command \"console relay\" in the command line to add or remove "
 "relays."
 msgstr ""
 
-#: src/Module/Admin/Site.php:451
+#: src/Module/Admin/Site.php:447
 msgid "The system is not subscribed to any relays at the moment."
 msgstr ""
 
-#: src/Module/Admin/Site.php:452
+#: src/Module/Admin/Site.php:448
 msgid "The system is currently subscribed to the following relays:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:454
+#: src/Module/Admin/Site.php:450
 msgid "Relocate Node"
 msgstr ""
 
-#: src/Module/Admin/Site.php:455
+#: src/Module/Admin/Site.php:451
 msgid ""
 "Relocating your node enables you to change the DNS domain of this node and "
 "keep all the existing users and posts. This process takes a while and can "
 "only be started from the relocate console command like this:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:456
+#: src/Module/Admin/Site.php:452
 msgid "(Friendica directory)# bin/console relocate https://newdomain.com"
 msgstr ""
 
-#: src/Module/Admin/Site.php:460
+#: src/Module/Admin/Site.php:456
 msgid "Site name"
 msgstr ""
 
-#: src/Module/Admin/Site.php:461
+#: src/Module/Admin/Site.php:457
 msgid "Sender Email"
 msgstr ""
 
-#: src/Module/Admin/Site.php:461
+#: src/Module/Admin/Site.php:457
 msgid ""
 "The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: src/Module/Admin/Site.php:462
+#: src/Module/Admin/Site.php:458
 msgid "Name of the system actor"
 msgstr ""
 
-#: src/Module/Admin/Site.php:462
+#: src/Module/Admin/Site.php:458
 msgid ""
 "Name of the internal system account that is used to perform ActivityPub "
 "requests. This must be an unused username. If set, this can't be changed "
 "again."
 msgstr ""
 
-#: src/Module/Admin/Site.php:463
+#: src/Module/Admin/Site.php:459
 msgid "Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:464
+#: src/Module/Admin/Site.php:460
 msgid "Email Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:465
+#: src/Module/Admin/Site.php:461
 msgid "Shortcut icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:465
+#: src/Module/Admin/Site.php:461
 msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:462
 msgid "Touch icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:462
 msgid "Link to an icon that will be used for tablets and mobiles."
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:463
 msgid "Additional Info"
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:463
 #, php-format
 msgid ""
 "For public servers: you can add additional information here that will be "
 "listed at %s/servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:468
+#: src/Module/Admin/Site.php:464
 msgid "System language"
 msgstr ""
 
-#: src/Module/Admin/Site.php:469
+#: src/Module/Admin/Site.php:465
 msgid "System theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:469
+#: src/Module/Admin/Site.php:465
 #, php-format
 msgid ""
 "Default system theme - may be over-ridden by user profiles - <a href=\"%s\" "
 "id=\"cnftheme\">Change default theme settings</a>"
 msgstr ""
 
-#: src/Module/Admin/Site.php:470
+#: src/Module/Admin/Site.php:466
 msgid "Mobile system theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:470
+#: src/Module/Admin/Site.php:466
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:471 src/Module/Install.php:232
+#: src/Module/Admin/Site.php:467 src/Module/Install.php:232
 msgid "SSL link policy"
 msgstr ""
 
-#: src/Module/Admin/Site.php:471 src/Module/Install.php:234
+#: src/Module/Admin/Site.php:467 src/Module/Install.php:234
 msgid "Determines whether generated links should be forced to use SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:472
+#: src/Module/Admin/Site.php:468
 msgid "Force SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:472
+#: src/Module/Admin/Site.php:468
 msgid ""
 "Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
 "to endless loops."
 msgstr ""
 
-#: src/Module/Admin/Site.php:473
+#: src/Module/Admin/Site.php:469
 msgid "Show help entry from navigation menu"
 msgstr ""
 
-#: src/Module/Admin/Site.php:473
+#: src/Module/Admin/Site.php:469
 msgid ""
 "Displays the menu entry for the Help pages from the navigation menu. It is "
 "always accessible by calling /help directly."
 msgstr ""
 
-#: src/Module/Admin/Site.php:474
+#: src/Module/Admin/Site.php:470
 msgid "Single user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:474
+#: src/Module/Admin/Site.php:470
 msgid "Make this instance multi-user or single-user for the named user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:476
+#: src/Module/Admin/Site.php:472
 msgid "Maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:476
+#: src/Module/Admin/Site.php:472
 #, php-format
 msgid ""
 "Maximum size in bytes of uploaded images. Default is 0, which means no "
@@ -4271,192 +4271,192 @@ msgid ""
 "to %s (%s byte)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:476
 msgid "Maximum image length"
 msgstr ""
 
-#: src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:476
 msgid ""
 "Maximum length in pixels of the longest side of uploaded images. Default is "
 "-1, which means no limits."
 msgstr ""
 
-#: src/Module/Admin/Site.php:481
+#: src/Module/Admin/Site.php:477
 msgid "JPEG image quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:481
+#: src/Module/Admin/Site.php:477
 msgid ""
 "Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
 "100, which is full quality."
 msgstr ""
 
-#: src/Module/Admin/Site.php:483
+#: src/Module/Admin/Site.php:479
 msgid "Register policy"
 msgstr ""
 
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Site.php:480
 msgid "Maximum Daily Registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Site.php:480
 msgid ""
 "If registration is permitted above, this sets the maximum number of new user "
 "registrations to accept per day.  If register is set to closed, this setting "
 "has no effect."
 msgstr ""
 
-#: src/Module/Admin/Site.php:485
+#: src/Module/Admin/Site.php:481
 msgid "Register text"
 msgstr ""
 
-#: src/Module/Admin/Site.php:485
+#: src/Module/Admin/Site.php:481
 msgid ""
 "Will be displayed prominently on the registration page. You can use BBCode "
 "here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:482
 msgid "Forbidden Nicknames"
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:482
 msgid ""
 "Comma separated list of nicknames that are forbidden from registration. "
 "Preset is a list of role names according RFC 2142."
 msgstr ""
 
-#: src/Module/Admin/Site.php:487
+#: src/Module/Admin/Site.php:483
 msgid "Accounts abandoned after x days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:487
+#: src/Module/Admin/Site.php:483
 msgid ""
 "Will not waste system resources polling external sites for abandonded "
 "accounts. Enter 0 for no time limit."
 msgstr ""
 
-#: src/Module/Admin/Site.php:488
+#: src/Module/Admin/Site.php:484
 msgid "Allowed friend domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:488
+#: src/Module/Admin/Site.php:484
 msgid ""
 "Comma separated list of domains which are allowed to establish friendships "
 "with this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:485
 msgid "Allowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:485
 msgid ""
 "Comma separated list of domains which are allowed in email addresses for "
 "registrations to this site. Wildcards are accepted. Empty to allow any "
 "domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:490
+#: src/Module/Admin/Site.php:486
 msgid "No OEmbed rich content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:490
+#: src/Module/Admin/Site.php:486
 msgid ""
 "Don't show the rich content (e.g. embedded PDF), except from the domains "
 "listed below."
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
+#: src/Module/Admin/Site.php:487
 msgid "Trusted third-party domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
+#: src/Module/Admin/Site.php:487
 msgid ""
 "Comma separated list of domains from which content is allowed to be embedded "
 "in posts like with OEmbed. All sub-domains of the listed domains are allowed "
 "as well."
 msgstr ""
 
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:488
 msgid "Block public"
 msgstr ""
 
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:488
 msgid ""
 "Check to block public access to all otherwise public personal pages on this "
 "site unless you are currently logged in."
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:489
 msgid "Force publish"
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:489
 msgid ""
 "Check to force all profiles on this site to be listed in the site directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:489
 msgid "Enabling this may violate privacy laws like the GDPR"
 msgstr ""
 
-#: src/Module/Admin/Site.php:494
+#: src/Module/Admin/Site.php:490
 msgid "Global directory URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:494
+#: src/Module/Admin/Site.php:490
 msgid ""
 "URL to the global directory. If this is not set, the global directory is "
 "completely unavailable to the application."
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:491
 msgid "Private posts by default for new users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:491
 msgid ""
 "Set default post permissions for all new members to the default privacy "
 "group rather than public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:496
+#: src/Module/Admin/Site.php:492
 msgid "Don't include post content in email notifications"
 msgstr ""
 
-#: src/Module/Admin/Site.php:496
+#: src/Module/Admin/Site.php:492
 msgid ""
 "Don't include the content of a post/comment/private message/etc. in the "
 "email notifications that are sent out from this site, as a privacy measure."
 msgstr ""
 
-#: src/Module/Admin/Site.php:497
+#: src/Module/Admin/Site.php:493
 msgid "Disallow public access to addons listed in the apps menu."
 msgstr ""
 
-#: src/Module/Admin/Site.php:497
+#: src/Module/Admin/Site.php:493
 msgid ""
 "Checking this box will restrict addons listed in the apps menu to members "
 "only."
 msgstr ""
 
-#: src/Module/Admin/Site.php:498
+#: src/Module/Admin/Site.php:494
 msgid "Don't embed private images in posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:498
+#: src/Module/Admin/Site.php:494
 msgid ""
 "Don't replace locally-hosted private photos in posts with an embedded copy "
 "of the image. This means that contacts who receive posts containing private "
 "photos will have to authenticate and load each image, which may take a while."
 msgstr ""
 
-#: src/Module/Admin/Site.php:499
+#: src/Module/Admin/Site.php:495
 msgid "Explicit Content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:499
+#: src/Module/Admin/Site.php:495
 msgid ""
 "Set this to announce that your node is used mostly for explicit content that "
 "might not be suited for minors. This information will be published in the "
@@ -4465,267 +4465,267 @@ msgid ""
 "will be shown at the user registration page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:496
 msgid "Proxify external content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:496
 msgid ""
 "Route external content via the proxy functionality. This is used for example "
 "for some OEmbed accesses and in some other rare cases."
 msgstr ""
 
-#: src/Module/Admin/Site.php:501
+#: src/Module/Admin/Site.php:497
 msgid "Cache contact avatars"
 msgstr ""
 
-#: src/Module/Admin/Site.php:501
+#: src/Module/Admin/Site.php:497
 msgid ""
 "Locally store the avatar pictures of the contacts. This uses a lot of "
 "storage space but it increases the performance."
 msgstr ""
 
-#: src/Module/Admin/Site.php:502
+#: src/Module/Admin/Site.php:498
 msgid "Allow Users to set remote_self"
 msgstr ""
 
-#: src/Module/Admin/Site.php:502
+#: src/Module/Admin/Site.php:498
 msgid ""
 "With checking this, every user is allowed to mark every contact as a "
 "remote_self in the repair contact dialog. Setting this flag on a contact "
 "causes mirroring every posting of that contact in the users stream."
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:499
 msgid "Enable multiple registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:499
 msgid "Enable users to register additional accounts for use as pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:500
 msgid "Enable OpenID"
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:500
 msgid "Enable OpenID support for registration and logins."
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:501
 msgid "Enable Fullname check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:501
 msgid ""
 "Enable check to only allow users to register with a space between the first "
 "name and the last name in their full name."
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:502
 msgid "Email administrators on new registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:502
 msgid ""
 "If enabled and the system is set to an open registration, an email for each "
 "new registration is sent to the administrators."
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:503
 msgid "Community pages for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:503
 msgid ""
 "Which community pages should be available for visitors. Local users always "
 "see both pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:508
+#: src/Module/Admin/Site.php:504
 msgid "Posts per user on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:508
+#: src/Module/Admin/Site.php:504
 msgid ""
 "The maximum number of posts per user on the community page. (Not valid for "
 "\"Global Community\")"
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:506
 msgid "Enable Mail support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:506
 msgid ""
 "Enable built-in mail support to poll IMAP folders and to reply via mail."
 msgstr ""
 
-#: src/Module/Admin/Site.php:511
+#: src/Module/Admin/Site.php:507
 msgid ""
 "Mail support can't be enabled because the PHP IMAP module is not installed."
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:508
 msgid "Enable OStatus support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:508
 msgid ""
 "Enable built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
 "communications in OStatus are public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:510
 msgid ""
 "Diaspora support can't be enabled because Friendica was installed into a sub "
 "directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:511
 msgid "Enable Diaspora support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:511
 msgid ""
 "Enable built-in Diaspora network compatibility for communicating with "
 "diaspora servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:512
 msgid "Verify SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:512
 msgid ""
 "If you wish, you can turn on strict certificate checking. This will mean you "
 "cannot connect (at all) to self-signed SSL sites."
 msgstr ""
 
-#: src/Module/Admin/Site.php:517
+#: src/Module/Admin/Site.php:513
 msgid "Proxy user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:517
+#: src/Module/Admin/Site.php:513
 msgid "User name for the proxy server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:518
+#: src/Module/Admin/Site.php:514
 msgid "Proxy URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:518
+#: src/Module/Admin/Site.php:514
 msgid ""
 "If you want to use a proxy server that Friendica should use to connect to "
 "the network, put the URL of the proxy here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:519
+#: src/Module/Admin/Site.php:515
 msgid "Network timeout"
 msgstr ""
 
-#: src/Module/Admin/Site.php:519
+#: src/Module/Admin/Site.php:515
 msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:520
+#: src/Module/Admin/Site.php:516
 msgid "Maximum Load Average"
 msgstr ""
 
-#: src/Module/Admin/Site.php:520
+#: src/Module/Admin/Site.php:516
 #, php-format
 msgid ""
 "Maximum system load before delivery and poll processes are deferred - "
 "default %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:521
+#: src/Module/Admin/Site.php:517
 msgid "Minimal Memory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:521
+#: src/Module/Admin/Site.php:517
 msgid ""
 "Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
 "default 0 (deactivated)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:522
+#: src/Module/Admin/Site.php:518
 msgid "Periodically optimize tables"
 msgstr ""
 
-#: src/Module/Admin/Site.php:522
+#: src/Module/Admin/Site.php:518
 msgid "Periodically optimize tables like the cache and the workerqueue"
 msgstr ""
 
-#: src/Module/Admin/Site.php:524
+#: src/Module/Admin/Site.php:520
 msgid "Discover followers/followings from contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:524
+#: src/Module/Admin/Site.php:520
 msgid ""
 "If enabled, contacts are checked for their followers and following contacts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:525
+#: src/Module/Admin/Site.php:521
 msgid "None - deactivated"
 msgstr ""
 
-#: src/Module/Admin/Site.php:526
+#: src/Module/Admin/Site.php:522
 msgid ""
 "Local contacts - contacts of our local contacts are discovered for their "
 "followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:527
+#: src/Module/Admin/Site.php:523
 msgid ""
 "Interactors - contacts of our local contacts and contacts who interacted on "
 "locally visible postings are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:529
+#: src/Module/Admin/Site.php:525
 msgid "Synchronize the contacts with the directory server"
 msgstr ""
 
-#: src/Module/Admin/Site.php:529
+#: src/Module/Admin/Site.php:525
 msgid ""
 "if enabled, the system will check periodically for new contacts on the "
 "defined directory server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:531
+#: src/Module/Admin/Site.php:527
 msgid "Days between requery"
 msgstr ""
 
-#: src/Module/Admin/Site.php:531
+#: src/Module/Admin/Site.php:527
 msgid "Number of days after which a server is requeried for his contacts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:532
+#: src/Module/Admin/Site.php:528
 msgid "Discover contacts from other servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:532
+#: src/Module/Admin/Site.php:528
 msgid ""
 "Periodically query other servers for contacts. The system queries Friendica, "
 "Mastodon and Hubzilla servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:533
+#: src/Module/Admin/Site.php:529
 msgid "Search the local directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:533
+#: src/Module/Admin/Site.php:529
 msgid ""
 "Search the local directory instead of the global directory. When searching "
 "locally, every search will be executed on the global directory in the "
 "background. This improves the search results when the search is repeated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:535
+#: src/Module/Admin/Site.php:531
 msgid "Publish server information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:535
+#: src/Module/Admin/Site.php:531
 msgid ""
 "If enabled, general server and usage data will be published. The data "
 "contains the name and version of the server, number of users with public "
@@ -4733,50 +4733,50 @@ msgid ""
 "href=\"http://the-federation.info/\">the-federation.info</a> for details."
 msgstr ""
 
-#: src/Module/Admin/Site.php:537
+#: src/Module/Admin/Site.php:533
 msgid "Check upstream version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:537
+#: src/Module/Admin/Site.php:533
 msgid ""
 "Enables checking for new Friendica versions at github. If there is a new "
 "version, you will be informed in the admin panel overview."
 msgstr ""
 
-#: src/Module/Admin/Site.php:538
+#: src/Module/Admin/Site.php:534
 msgid "Suppress Tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:538
+#: src/Module/Admin/Site.php:534
 msgid "Suppress showing a list of hashtags at the end of the posting."
 msgstr ""
 
-#: src/Module/Admin/Site.php:539
+#: src/Module/Admin/Site.php:535
 msgid "Clean database"
 msgstr ""
 
-#: src/Module/Admin/Site.php:539
+#: src/Module/Admin/Site.php:535
 msgid ""
 "Remove old remote items, orphaned database records and old content from some "
 "other helper tables."
 msgstr ""
 
-#: src/Module/Admin/Site.php:540
+#: src/Module/Admin/Site.php:536
 msgid "Lifespan of remote items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:540
+#: src/Module/Admin/Site.php:536
 msgid ""
 "When the database cleanup is enabled, this defines the days after which "
 "remote items will be deleted. Own items, and marked or filed items are "
 "always kept. 0 disables this behaviour."
 msgstr ""
 
-#: src/Module/Admin/Site.php:541
+#: src/Module/Admin/Site.php:537
 msgid "Lifespan of unclaimed items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:541
+#: src/Module/Admin/Site.php:537
 msgid ""
 "When the database cleanup is enabled, this defines the days after which "
 "unclaimed remote items (mostly content from the relay) will be deleted. "
@@ -4784,144 +4784,144 @@ msgid ""
 "items if set to 0."
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:538
 msgid "Lifespan of raw conversation data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:538
 msgid ""
 "The conversation data is used for ActivityPub and OStatus, as well as for "
 "debug purposes. It should be safe to remove it after 14 days, default is 90 "
 "days."
 msgstr ""
 
-#: src/Module/Admin/Site.php:543
+#: src/Module/Admin/Site.php:539
 msgid "Maximum numbers of comments per post"
 msgstr ""
 
-#: src/Module/Admin/Site.php:543
+#: src/Module/Admin/Site.php:539
 msgid "How much comments should be shown for each post? Default value is 100."
 msgstr ""
 
-#: src/Module/Admin/Site.php:544
+#: src/Module/Admin/Site.php:540
 msgid "Maximum numbers of comments per post on the display page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:544
+#: src/Module/Admin/Site.php:540
 msgid ""
 "How many comments should be shown on the single view for each post? Default "
 "value is 1000."
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:541
 msgid "Temp path"
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:541
 msgid ""
 "If you have a restricted system where the webserver can't access the system "
 "temp path, enter another path here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:546
+#: src/Module/Admin/Site.php:542
 msgid "Only search in tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:546
+#: src/Module/Admin/Site.php:542
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: src/Module/Admin/Site.php:547
+#: src/Module/Admin/Site.php:543
 msgid "Generate counts per contact group when calculating network count"
 msgstr ""
 
-#: src/Module/Admin/Site.php:547
+#: src/Module/Admin/Site.php:543
 msgid ""
 "On systems with users that heavily use contact groups the query can be very "
 "expensive."
 msgstr ""
 
-#: src/Module/Admin/Site.php:549
+#: src/Module/Admin/Site.php:545
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:549
+#: src/Module/Admin/Site.php:545
 #, php-format
 msgid ""
 "On shared hosters set this to %d. On larger systems, values of %d are great. "
 "Default value is %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:550
+#: src/Module/Admin/Site.php:546
 msgid "Enable fastlane"
 msgstr ""
 
-#: src/Module/Admin/Site.php:550
+#: src/Module/Admin/Site.php:546
 msgid ""
 "When enabed, the fastlane mechanism starts an additional worker if processes "
 "with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: src/Module/Admin/Site.php:552
+#: src/Module/Admin/Site.php:548
 msgid "Direct relay transfer"
 msgstr ""
 
-#: src/Module/Admin/Site.php:552
+#: src/Module/Admin/Site.php:548
 msgid ""
 "Enables the direct transfer to other servers without using the relay servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:553
+#: src/Module/Admin/Site.php:549
 msgid "Relay scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:553
+#: src/Module/Admin/Site.php:549
 msgid ""
 "Can be \"all\" or \"tags\". \"all\" means that every public post should be "
 "received. \"tags\" means that only posts with selected tags should be "
 "received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:553 src/Module/Contact/Profile.php:274
+#: src/Module/Admin/Site.php:549 src/Module/Contact/Profile.php:274
 #: src/Module/Settings/TwoFactor/Index.php:125
 msgid "Disabled"
 msgstr ""
 
-#: src/Module/Admin/Site.php:553
+#: src/Module/Admin/Site.php:549
 msgid "all"
 msgstr ""
 
-#: src/Module/Admin/Site.php:553
+#: src/Module/Admin/Site.php:549
 msgid "tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:554
+#: src/Module/Admin/Site.php:550
 msgid "Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:554
+#: src/Module/Admin/Site.php:550
 msgid "Comma separated list of tags for the \"tags\" subscription."
 msgstr ""
 
-#: src/Module/Admin/Site.php:555
+#: src/Module/Admin/Site.php:551
 msgid "Deny Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:555
+#: src/Module/Admin/Site.php:551
 msgid "Comma separated list of tags that are rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:556
+#: src/Module/Admin/Site.php:552
 msgid "Allow user tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:556
+#: src/Module/Admin/Site.php:552
 msgid ""
 "If enabled, the tags from the saved searches will used for the \"tags\" "
 "subscription in addition to the \"relay_server_tags\"."
 msgstr ""
 
-#: src/Module/Admin/Site.php:559
+#: src/Module/Admin/Site.php:555
 msgid "Start Relocation"
 msgstr ""
 
@@ -5226,7 +5226,7 @@ msgstr ""
 msgid "Only starting posts can be muted"
 msgstr ""
 
-#: src/Module/Api/Mastodon/Statuses/Reblog.php:53
+#: src/Module/Api/Mastodon/Statuses/Reblog.php:56
 #, php-format
 msgid "Posts from %s can't be shared"
 msgstr ""
@@ -5239,7 +5239,7 @@ msgstr ""
 msgid "Only starting posts can be unmuted"
 msgstr ""
 
-#: src/Module/Api/Mastodon/Statuses/Unreblog.php:53
+#: src/Module/Api/Mastodon/Statuses/Unreblog.php:62
 #, php-format
 msgid "Posts from %s can't be unshared"
 msgstr ""
@@ -5387,12 +5387,12 @@ msgstr ""
 msgid "Item Source"
 msgstr ""
 
-#: src/Module/BaseProfile.php:52 src/Module/Contact.php:463
+#: src/Module/BaseProfile.php:52 src/Module/Contact.php:464
 msgid "Profile Details"
 msgstr ""
 
-#: src/Module/BaseProfile.php:60 src/Module/Contact.php:447
-#: src/Module/Contact/Follow.php:192 src/Module/Contact/Unfollow.php:138
+#: src/Module/BaseProfile.php:60 src/Module/Contact.php:448
+#: src/Module/Contact/Follow.php:191 src/Module/Contact/Unfollow.php:138
 msgid "Status Messages and Posts"
 msgstr ""
 
@@ -5547,7 +5547,7 @@ msgstr ""
 msgid "Share this event"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:251 src/Module/Profile/Profile.php:240
+#: src/Module/Calendar/Event/Form.php:251 src/Module/Profile/Profile.php:275
 msgid "Basic"
 msgstr ""
 
@@ -5579,78 +5579,78 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: src/Module/Contact.php:88
+#: src/Module/Contact.php:89
 #, php-format
 msgid "%d contact edited."
 msgid_plural "%d contacts edited."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact.php:312
+#: src/Module/Contact.php:313
 msgid "Show all contacts"
 msgstr ""
 
-#: src/Module/Contact.php:317 src/Module/Contact.php:377
+#: src/Module/Contact.php:318 src/Module/Contact.php:378
 #: src/Module/Moderation/BaseUsers.php:85
 msgid "Pending"
 msgstr ""
 
-#: src/Module/Contact.php:320
+#: src/Module/Contact.php:321
 msgid "Only show pending contacts"
 msgstr ""
 
-#: src/Module/Contact.php:325 src/Module/Contact.php:378
+#: src/Module/Contact.php:326 src/Module/Contact.php:379
 #: src/Module/Moderation/BaseUsers.php:93
 msgid "Blocked"
 msgstr ""
 
-#: src/Module/Contact.php:328
+#: src/Module/Contact.php:329
 msgid "Only show blocked contacts"
 msgstr ""
 
-#: src/Module/Contact.php:333 src/Module/Contact.php:380
+#: src/Module/Contact.php:334 src/Module/Contact.php:381
 #: src/Object/Post.php:338
 msgid "Ignored"
 msgstr ""
 
-#: src/Module/Contact.php:336
+#: src/Module/Contact.php:337
 msgid "Only show ignored contacts"
 msgstr ""
 
-#: src/Module/Contact.php:341 src/Module/Contact.php:381
+#: src/Module/Contact.php:342 src/Module/Contact.php:382
 msgid "Archived"
 msgstr ""
 
-#: src/Module/Contact.php:344
+#: src/Module/Contact.php:345
 msgid "Only show archived contacts"
 msgstr ""
 
-#: src/Module/Contact.php:349 src/Module/Contact.php:379
+#: src/Module/Contact.php:350 src/Module/Contact.php:380
 msgid "Hidden"
 msgstr ""
 
-#: src/Module/Contact.php:352
+#: src/Module/Contact.php:353
 msgid "Only show hidden contacts"
 msgstr ""
 
-#: src/Module/Contact.php:360
+#: src/Module/Contact.php:361
 msgid "Organize your contact groups"
 msgstr ""
 
-#: src/Module/Contact.php:392
+#: src/Module/Contact.php:393
 msgid "Search your contacts"
 msgstr ""
 
-#: src/Module/Contact.php:393 src/Module/Search/Index.php:206
+#: src/Module/Contact.php:394 src/Module/Search/Index.php:206
 #, php-format
 msgid "Results for: %s"
 msgstr ""
 
-#: src/Module/Contact.php:400
+#: src/Module/Contact.php:401
 msgid "Update"
 msgstr ""
 
-#: src/Module/Contact.php:401 src/Module/Contact/Profile.php:348
+#: src/Module/Contact.php:402 src/Module/Contact/Profile.php:348
 #: src/Module/Contact/Profile.php:467
 #: src/Module/Moderation/Blocklist/Contact.php:117
 #: src/Module/Moderation/Users/Blocked.php:138
@@ -5658,62 +5658,62 @@ msgstr ""
 msgid "Unblock"
 msgstr ""
 
-#: src/Module/Contact.php:402 src/Module/Contact/Profile.php:349
+#: src/Module/Contact.php:403 src/Module/Contact/Profile.php:349
 #: src/Module/Contact/Profile.php:475
 msgid "Unignore"
 msgstr ""
 
-#: src/Module/Contact.php:404
+#: src/Module/Contact.php:405
 msgid "Batch Actions"
 msgstr ""
 
-#: src/Module/Contact.php:439
+#: src/Module/Contact.php:440
 msgid "Conversations started by this contact"
 msgstr ""
 
-#: src/Module/Contact.php:444
+#: src/Module/Contact.php:445
 msgid "Posts and Comments"
 msgstr ""
 
-#: src/Module/Contact.php:455
+#: src/Module/Contact.php:456
 msgid "Posts containing media objects"
 msgstr ""
 
-#: src/Module/Contact.php:470
+#: src/Module/Contact.php:471
 msgid "View all known contacts"
 msgstr ""
 
-#: src/Module/Contact.php:480
+#: src/Module/Contact.php:481
 msgid "Advanced Contact Settings"
 msgstr ""
 
-#: src/Module/Contact.php:514
+#: src/Module/Contact.php:517
 msgid "Mutual Friendship"
 msgstr ""
 
-#: src/Module/Contact.php:518
+#: src/Module/Contact.php:521
 msgid "is a fan of yours"
 msgstr ""
 
-#: src/Module/Contact.php:522
+#: src/Module/Contact.php:525
 msgid "you are a fan of"
 msgstr ""
 
-#: src/Module/Contact.php:540
+#: src/Module/Contact.php:543
 msgid "Pending outgoing contact request"
 msgstr ""
 
-#: src/Module/Contact.php:542
+#: src/Module/Contact.php:545
 msgid "Pending incoming contact request"
 msgstr ""
 
-#: src/Module/Contact.php:555 src/Module/Contact/Profile.php:334
+#: src/Module/Contact.php:558 src/Module/Contact/Profile.php:334
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr ""
 
 #: src/Module/Contact/Advanced.php:70 src/Module/Contact/Advanced.php:109
-#: src/Module/Contact/Contacts.php:53 src/Module/Contact/Conversations.php:84
+#: src/Module/Contact/Contacts.php:71 src/Module/Contact/Conversations.php:84
 #: src/Module/Contact/Conversations.php:89
 #: src/Module/Contact/Conversations.php:94 src/Module/Contact/Media.php:43
 #: src/Module/Contact/Posts.php:78 src/Module/Contact/Posts.php:83
@@ -5761,60 +5761,60 @@ msgstr ""
 msgid "New photo from this URL"
 msgstr ""
 
-#: src/Module/Contact/Contacts.php:48 src/Module/Conversation/Network.php:188
+#: src/Module/Contact/Contacts.php:66 src/Module/Conversation/Network.php:188
 #: src/Module/Group.php:101
 msgid "Invalid contact."
 msgstr ""
 
-#: src/Module/Contact/Contacts.php:71
+#: src/Module/Contact/Contacts.php:89
 msgid "No known contacts."
 msgstr ""
 
-#: src/Module/Contact/Contacts.php:85 src/Module/Profile/Common.php:97
+#: src/Module/Contact/Contacts.php:103 src/Module/Profile/Common.php:128
 msgid "No common contacts."
 msgstr ""
 
-#: src/Module/Contact/Contacts.php:97 src/Module/Profile/Contacts.php:95
+#: src/Module/Contact/Contacts.php:115 src/Module/Profile/Contacts.php:132
 #, php-format
 msgid "Follower (%s)"
 msgid_plural "Followers (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact/Contacts.php:101 src/Module/Profile/Contacts.php:98
+#: src/Module/Contact/Contacts.php:119 src/Module/Profile/Contacts.php:135
 #, php-format
 msgid "Following (%s)"
 msgid_plural "Following (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact/Contacts.php:105 src/Module/Profile/Contacts.php:101
+#: src/Module/Contact/Contacts.php:123 src/Module/Profile/Contacts.php:138
 #, php-format
 msgid "Mutual friend (%s)"
 msgid_plural "Mutual friends (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact/Contacts.php:107 src/Module/Profile/Contacts.php:103
+#: src/Module/Contact/Contacts.php:125 src/Module/Profile/Contacts.php:140
 #, php-format
 msgid "These contacts both follow and are followed by <strong>%s</strong>."
 msgstr ""
 
-#: src/Module/Contact/Contacts.php:113 src/Module/Profile/Common.php:85
+#: src/Module/Contact/Contacts.php:131 src/Module/Profile/Common.php:116
 #, php-format
 msgid "Common contact (%s)"
 msgid_plural "Common contacts (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact/Contacts.php:115 src/Module/Profile/Common.php:87
+#: src/Module/Contact/Contacts.php:133 src/Module/Profile/Common.php:118
 #, php-format
 msgid ""
 "Both <strong>%s</strong> and yourself have publicly interacted with these "
 "contacts (follow, comment or likes on public posts)."
 msgstr ""
 
-#: src/Module/Contact/Contacts.php:121 src/Module/Profile/Contacts.php:109
+#: src/Module/Contact/Contacts.php:139 src/Module/Profile/Contacts.php:146
 #, php-format
 msgid "Contact (%s)"
 msgid_plural "Contacts (%s)"
@@ -5836,31 +5836,31 @@ msgstr ""
 msgid "Submit Request"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:115
+#: src/Module/Contact/Follow.php:114
 msgid "You already added this contact."
 msgstr ""
 
-#: src/Module/Contact/Follow.php:130
+#: src/Module/Contact/Follow.php:129
 msgid "The network type couldn't be detected. Contact can't be added."
 msgstr ""
 
-#: src/Module/Contact/Follow.php:138
+#: src/Module/Contact/Follow.php:137
 msgid "Diaspora support isn't enabled. Contact can't be added."
 msgstr ""
 
-#: src/Module/Contact/Follow.php:143
+#: src/Module/Contact/Follow.php:142
 msgid "OStatus support is disabled. Contact can't be added."
 msgstr ""
 
-#: src/Module/Contact/Follow.php:168 src/Module/Profile/RemoteFollow.php:132
+#: src/Module/Contact/Follow.php:167 src/Module/Profile/RemoteFollow.php:132
 msgid "Please answer the following:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:169 src/Module/Contact/Unfollow.php:123
+#: src/Module/Contact/Follow.php:168 src/Module/Contact/Unfollow.php:123
 msgid "Your Identity Address:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:170 src/Module/Contact/Profile.php:365
+#: src/Module/Contact/Follow.php:169 src/Module/Contact/Profile.php:365
 #: src/Module/Contact/Unfollow.php:129
 #: src/Module/Moderation/Blocklist/Contact.php:133
 #: src/Module/Notifications/Introductions.php:129
@@ -5868,22 +5868,22 @@ msgstr ""
 msgid "Profile URL"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:171 src/Module/Contact/Profile.php:377
+#: src/Module/Contact/Follow.php:170 src/Module/Contact/Profile.php:377
 #: src/Module/Notifications/Introductions.php:191
-#: src/Module/Profile/Profile.php:199
+#: src/Module/Profile/Profile.php:234
 msgid "Tags:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:182
+#: src/Module/Contact/Follow.php:181
 #, php-format
 msgid "%s knows you"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:183
+#: src/Module/Contact/Follow.php:182
 msgid "Add a personal note:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:221
+#: src/Module/Contact/Follow.php:220
 msgid "The contact could not be added."
 msgstr ""
 
@@ -8178,7 +8178,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: src/Module/Profile/Contacts.php:119
+#: src/Module/Profile/Contacts.php:156
 msgid "No contacts."
 msgstr ""
 
@@ -8200,47 +8200,47 @@ msgstr ""
 msgid "Image file is empty."
 msgstr ""
 
-#: src/Module/Profile/Photos.php:384
+#: src/Module/Profile/Photos.php:376
 msgid "View Album"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:81 src/Module/Profile/Restricted.php:50
+#: src/Module/Profile/Profile.php:112 src/Module/Profile/Restricted.php:50
 msgid "Profile not found."
 msgstr ""
 
-#: src/Module/Profile/Profile.php:127
+#: src/Module/Profile/Profile.php:158
 #, php-format
 msgid ""
 "You're currently viewing your profile as <b>%s</b> <a href=\"%s\" class="
 "\"btn btn-sm pull-right\">Cancel</a>"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:136 src/Module/Settings/Account.php:576
+#: src/Module/Profile/Profile.php:167 src/Module/Settings/Account.php:576
 msgid "Full Name:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:141
+#: src/Module/Profile/Profile.php:172
 msgid "Member since:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:147
+#: src/Module/Profile/Profile.php:178
 msgid "j F, Y"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:148
+#: src/Module/Profile/Profile.php:179
 msgid "j F"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:156 src/Util/Temporal.php:166
+#: src/Module/Profile/Profile.php:187 src/Util/Temporal.php:166
 msgid "Birthday:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:159 src/Module/Settings/Profile/Index.php:254
+#: src/Module/Profile/Profile.php:190 src/Module/Settings/Profile/Index.php:254
 #: src/Util/Temporal.php:168
 msgid "Age: "
 msgstr ""
 
-#: src/Module/Profile/Profile.php:159 src/Module/Settings/Profile/Index.php:254
+#: src/Module/Profile/Profile.php:190 src/Module/Settings/Profile/Index.php:254
 #: src/Util/Temporal.php:168
 #, php-format
 msgid "%d year old"
@@ -8248,37 +8248,37 @@ msgid_plural "%d years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Profile/Profile.php:164 src/Module/Settings/Profile/Index.php:247
+#: src/Module/Profile/Profile.php:195 src/Module/Settings/Profile/Index.php:247
 msgid "Description:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:226
+#: src/Module/Profile/Profile.php:261
 msgid "Forums:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:238
+#: src/Module/Profile/Profile.php:273
 msgid "View profile as:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:255
+#: src/Module/Profile/Profile.php:290
 msgid "View as"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:318 src/Module/Profile/Profile.php:321
-#: src/Module/Profile/Status.php:65 src/Module/Profile/Status.php:68
-#: src/Protocol/Feed.php:1024 src/Protocol/OStatus.php:1047
+#: src/Module/Profile/Profile.php:351 src/Module/Profile/Profile.php:354
+#: src/Module/Profile/Status.php:106 src/Module/Profile/Status.php:109
+#: src/Protocol/Feed.php:1024 src/Protocol/OStatus.php:1045
 #, php-format
 msgid "%s's timeline"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:319 src/Module/Profile/Status.php:66
-#: src/Protocol/Feed.php:1028 src/Protocol/OStatus.php:1052
+#: src/Module/Profile/Profile.php:352 src/Module/Profile/Status.php:107
+#: src/Protocol/Feed.php:1028 src/Protocol/OStatus.php:1050
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:320 src/Module/Profile/Status.php:67
-#: src/Protocol/Feed.php:1031 src/Protocol/OStatus.php:1056
+#: src/Module/Profile/Profile.php:353 src/Module/Profile/Status.php:108
+#: src/Protocol/Feed.php:1031 src/Protocol/OStatus.php:1054
 #, php-format
 msgid "%s's comments"
 msgstr ""
@@ -10287,7 +10287,7 @@ msgstr ""
 msgid "Exception thrown in %s:%d"
 msgstr ""
 
-#: src/Module/Tos.php:57 src/Module/Tos.php:104
+#: src/Module/Tos.php:57 src/Module/Tos.php:106
 msgid ""
 "At the time of registration, and for providing communications between the "
 "user account and their contacts, the user has to provide a display name (pen "
@@ -10300,14 +10300,14 @@ msgid ""
 "settings, it is not necessary for communication."
 msgstr ""
 
-#: src/Module/Tos.php:58 src/Module/Tos.php:105
+#: src/Module/Tos.php:58 src/Module/Tos.php:107
 msgid ""
 "This data is required for communication and is passed on to the nodes of the "
 "communication partners and is stored there. Users can enter additional "
 "private data that may be transmitted to the communication partners accounts."
 msgstr ""
 
-#: src/Module/Tos.php:59 src/Module/Tos.php:106
+#: src/Module/Tos.php:59 src/Module/Tos.php:108
 #, php-format
 msgid ""
 "At any point in time a logged in user can export their account data from the "
@@ -10318,11 +10318,11 @@ msgid ""
 "communication partners."
 msgstr ""
 
-#: src/Module/Tos.php:62 src/Module/Tos.php:103
+#: src/Module/Tos.php:62 src/Module/Tos.php:105
 msgid "Privacy Statement"
 msgstr ""
 
-#: src/Module/Tos.php:100
+#: src/Module/Tos.php:102
 msgid "Rules"
 msgstr ""
 
@@ -10659,6 +10659,7 @@ msgid "%1$s shared your comment %2$s"
 msgstr ""
 
 #: src/Navigation/Notifications/Factory/Notification.php:231
+#: src/Navigation/Notifications/Factory/Notification.php:316
 #, php-format
 msgid "%1$s shared your post %2$s"
 msgstr ""
@@ -10792,7 +10793,7 @@ msgid "%1$s commented on their %2$s %3$s"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:341
-#: src/Navigation/Notifications/Repository/Notify.php:786
+#: src/Navigation/Notifications/Repository/Notify.php:789
 #, php-format
 msgid "%1$s Comment to conversation #%2$d by %3$s"
 msgstr ""
@@ -10804,7 +10805,7 @@ msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:347
 #: src/Navigation/Notifications/Repository/Notify.php:362
-#: src/Navigation/Notifications/Repository/Notify.php:801
+#: src/Navigation/Notifications/Repository/Notify.php:807
 #, php-format
 msgid "Please visit %s to view and/or reply to the conversation."
 msgstr ""
@@ -11005,6 +11006,11 @@ msgstr ""
 #: src/Navigation/Notifications/Repository/Notify.php:783
 #, php-format
 msgid "%s %s shared a new post"
+msgstr ""
+
+#: src/Navigation/Notifications/Repository/Notify.php:787
+#, php-format
+msgid "%1$s Like in conversation #%2$d by %3$s"
 msgstr ""
 
 #: src/Object/EMail/ItemCCEMail.php:42
@@ -11231,21 +11237,21 @@ msgstr ""
 msgid "Show fewer"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1472
+#: src/Protocol/OStatus.php:1470
 #, php-format
 msgid "%s is now following %s."
 msgstr ""
 
-#: src/Protocol/OStatus.php:1473
+#: src/Protocol/OStatus.php:1471
 msgid "following"
 msgstr ""
 
-#: src/Protocol/OStatus.php:1476
+#: src/Protocol/OStatus.php:1474
 #, php-format
 msgid "%s stopped following %s."
 msgstr ""
 
-#: src/Protocol/OStatus.php:1477
+#: src/Protocol/OStatus.php:1475
 msgid "stopped following"
 msgstr ""
 


### PR DESCRIPTION
…stead of "(...)new comment(...)"

Sorry, for not having created a related issue beforehand. I initially thought it was only a translations issue. See the context for this PR [here](https://friendica.mbbit.de/display/b25b9f4f-1363-a37b-e916-5d0690159748)

Finally, I identified the location where the email subject is set. I guess we will have some discussion in this PR, since the comment above the affected code block tells that we should not use different subjects for notifications about events in a thread to allow grouping in email clients.

Anyway, I added a check if the verb is `Activity::LIKE` like and adjust the subject only for this case at the moment. 