### PR TITLE
Only check the homepage for active users with a homepage

### DIFF
--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -27,9 +27,9 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Tag;
-use Friendica\Model\User;
 use Friendica\Protocol\ActivityPub\Queue;
 use Friendica\Protocol\Relay;
+use Friendica\Util\DateTimeFormat;
 
 class Cron
 {
@@ -136,10 +136,12 @@ class Cron
 				Worker::add(Worker::PRIORITY_LOW, 'OptimizeTables');
 			}
 
-			foreach (User::getList(1, PHP_INT_MAX, 'active') as $user) {
+			$users = DBA::select('owner-view', ['uid'], ["`last-activity` > ? AND (`homepage_verified` OR `homepage` != ?)", DateTimeFormat::utc('now - 30 days', 'Y-m-d'), '']);
+			while ($user = DBA::fetch($users)) {
 				Worker::add(Worker::PRIORITY_LOW, 'CheckRelMeProfileLink', $user['uid']);
 			}
-
+			DBA::close($users);
+	
 			// Resubscribe to relay servers
 			Relay::reSubscribe();
 

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -136,7 +136,7 @@ class Cron
 				Worker::add(Worker::PRIORITY_LOW, 'OptimizeTables');
 			}
 
-			$users = DBA::select('owner-view', ['uid'], ["`last-activity` > ? AND (`homepage_verified` OR `homepage` != ?)", DateTimeFormat::utc('now - 30 days', 'Y-m-d'), '']);
+			$users = DBA::select('owner-view', ['uid'], ["`homepage_verified` OR (`last-activity` > ? AND `homepage` != ?)", DateTimeFormat::utc('now - 7 days', 'Y-m-d'), '']);
 			while ($user = DBA::fetch($users)) {
 				Worker::add(Worker::PRIORITY_LOW, 'CheckRelMeProfileLink', $user['uid']);
 			}


### PR DESCRIPTION
Especially on larger servers, the daily homepage check generates a lot of workers. We now only check the homepage when the user was active in the last week and a homepage is set or the homepage was verified.