### PR TITLE
AP: We can now store received reports

### DIFF
--- a/src/DI.php
+++ b/src/DI.php
@@ -532,6 +532,16 @@ abstract class DI
 		return self::$dice->create(Contact\Introduction\Factory\Introduction::class);
 	}
 
+	public static function report(): Moderation\Repository\Report
+	{
+		return self::$dice->create(Moderation\Repository\Report::class);
+	}
+
+	public static function reportFactory(): Moderation\Factory\Report
+	{
+		return self::$dice->create(Moderation\Factory\Report::class);
+	}
+
 	public static function localRelationship(): Contact\LocalRelationship\Repository\LocalRelationship
 	{
 		return self::$dice->create(Contact\LocalRelationship\Repository\LocalRelationship::class);

--- a/src/Moderation/Repository/Report.php
+++ b/src/Moderation/Repository/Report.php
@@ -45,7 +45,7 @@ class Report extends \Friendica\BaseRepository
 		$this->factory = $factory;
 	}
 
-	public function selectOneById(int $lastInsertId): \Friendica\Moderation\Factory\Report
+	public function selectOneById(int $lastInsertId): \Friendica\Moderation\Entity\Report
 	{
 		return $this->_selectOne(['id' => $lastInsertId]);
 	}
@@ -59,6 +59,8 @@ class Report extends \Friendica\BaseRepository
 			'forward' => $Report->forward,
 		];
 
+		$postUriIds = $Report->postUriIds;
+
 		if ($Report->id) {
 			$this->db->update(self::$table_name, $fields, ['id' => $Report->id]);
 		} else {
@@ -70,7 +72,7 @@ class Report extends \Friendica\BaseRepository
 
 		$this->db->delete('report-post', ['rid' => $Report->id]);
 
-		foreach ($Report->postUriIds as $uriId) {
+		foreach ($postUriIds as $uriId) {
 			if (Post::exists(['uri-id' => $uriId])) {
 				$this->db->insert('report-post', ['rid' => $Report->id, 'uri-id' => $uriId]);
 			} else {

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1848,6 +1848,7 @@ class Processor
 			}
 		}
 
+		// @todo We should store the actor
 		$report = DI::reportFactory()->createFromReportsRequest(0, $account_id, $activity['content'], false, $uri_ids);
 		DI::report()->save($report);
 

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -406,7 +406,14 @@ class Receiver
 		}
 
 		// Any activities on account types must not be altered
-		if (in_array($object_type, self::ACCOUNT_TYPES)) {
+		if (in_array($type, ['as:Flag'])) {
+			$object_data = [];
+			$object_data['id'] = JsonLD::fetchElement($activity, '@id');
+			$object_data['object_id'] = JsonLD::fetchElement($activity, 'as:object', '@id');
+			$object_data['object_ids'] = JsonLD::fetchElementArray($activity, 'as:object', '@id');
+			$object_data['content'] = JsonLD::fetchElement($activity, 'as:content', '@type');
+			$object_data['push'] = $push;
+		} elseif (in_array($object_type, self::ACCOUNT_TYPES)) {
 			$object_data = [];
 			$object_data['id'] = JsonLD::fetchElement($activity, '@id');
 			$object_data['object_id'] = JsonLD::fetchElement($activity, 'as:object', '@id');
@@ -843,6 +850,14 @@ class Receiver
 				}
 				break;
 
+			case 'as:Flag':
+				if (in_array($object_data['object_type'], self::ACCOUNT_TYPES)) {
+					ActivityPub\Processor::ReportAccount($object_data);
+				} else {
+					return false;
+				}
+				break;
+	
 			case 'as:Remove':
 				if (in_array($object_data['object_type'], self::CONTENT_TYPES)) {
 					ActivityPub\Processor::removeFromFeaturedCollection($object_data);


### PR DESCRIPTION
Incoming reports concerning users and posts can now be stored.

It currently only works partially, this error is thrown:

```
2022-12-23T22:00:52Z index [ERROR]: Uncaught Exception TypeError: "Friendica\Moderation\Repository\Report::selectOneById(): Return value must be of type Friendica\Moderation\Factory\Report, Friendica\Moderation\Entity\Report returned" at /src/Moderation/Repository/Report.php line 50 {"exception":"TypeError: Friendica\\Moderation\\Repository\\Report::selectOneById(): Return value must be of type Friendica\\Moderation\\Factory\\Report, Friendica\\Moderation\\Entity\\Report returned in /src/Moderation/Repository/Report.php:50\nStack trace:\n#0 /src/Moderation/Repository/Report.php(68): Friendica\\Moderation\\Repository\\Report->selectOneById(4)\n#1 /src/Protocol/ActivityPub/Processor.php(1852): Friendica\\Moderation\\Repository\\Report->save(Object(Friendica\\Moderation\\Entity\\Report))\n#2 /src/Protocol/ActivityPub/Receiver.php(855): Friendica\\Protocol\\ActivityPub\\Processor::ReportAccount(Array)\n#3 /src/Protocol/ActivityPub/Receiver.php(679): Friendica\\Protocol\\ActivityPub\\Receiver::routeActivities(Array, 'as:Flag', true)\n#4 /src/Protocol/ActivityPub/Receiver.php(167): Friendica\\Protocol\\ActivityPub\\Receiver::processActivity(Array, '{\"@context\":[\"h...', 0, true, true, Array, 'https://squeet....')\n#5 /src/Module/ActivityPub/Inbox.php(67): Friendica\\Protocol\\ActivityPub\\Receiver::processInbox('{\"@context\":[\"h...', Array, 0)\n#6 /src/BaseModule.php(238): Friendica\\Module\\ActivityPub\\Inbox->rawContent(Array)\n#7 /src/App.php(746): Friendica\\BaseModule->run(Array)\n#8 /index.php(44): Friendica\\App->runFrontend(Object(Friendica\\App\\Router), Object(Friendica\\Core\\PConfig\\Type\\JitPConfig), Object(Friendica\\Security\\Authentication), Object(Friendica\\App\\Page), Object(Friendica\\Util\\HTTPInputData), 1671832852.496)\n#9 {main}"} - {"file":null,"line":null,"function":null,"uid":"52d3ff","process_id":732029}
```