### PR TITLE
Reports: The reporting contact id is added

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1678,6 +1678,7 @@ CREATE TABLE IF NOT EXISTS `report` (
 	`cid` int unsigned NOT NULL COMMENT 'Reported contact',
 	`comment` text COMMENT 'Report',
 	`category` varchar(20) COMMENT 'Category of the report (spam, violation, other)',
+	`rules` text COMMENT 'Violated rules',
 	`forward` boolean COMMENT 'Forward the report to the remote server',
 	`created` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
 	`status` tinyint unsigned COMMENT 'Status of the report',

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2023.03-dev (Giant Rhubarb)
--- DB_UPDATE_VERSION 1503
+-- DB_UPDATE_VERSION 1504
 -- ------------------------------------------
 
 
@@ -1674,6 +1674,7 @@ CREATE TABLE IF NOT EXISTS `register` (
 CREATE TABLE IF NOT EXISTS `report` (
 	`id` int unsigned NOT NULL auto_increment COMMENT 'sequential ID',
 	`uid` mediumint unsigned COMMENT 'Reporting user',
+	`reporter-id` int unsigned COMMENT 'Reporting contact',
 	`cid` int unsigned NOT NULL COMMENT 'Reported contact',
 	`comment` text COMMENT 'Report',
 	`forward` boolean COMMENT 'Forward the report to the remote server',
@@ -1682,7 +1683,9 @@ CREATE TABLE IF NOT EXISTS `report` (
 	 PRIMARY KEY(`id`),
 	 INDEX `uid` (`uid`),
 	 INDEX `cid` (`cid`),
+	 INDEX `reporter-id` (`reporter-id`),
 	FOREIGN KEY (`uid`) REFERENCES `user` (`uid`) ON UPDATE RESTRICT ON DELETE CASCADE,
+	FOREIGN KEY (`reporter-id`) REFERENCES `contact` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,
 	FOREIGN KEY (`cid`) REFERENCES `contact` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='';
 

--- a/database.sql
+++ b/database.sql
@@ -1677,6 +1677,7 @@ CREATE TABLE IF NOT EXISTS `report` (
 	`reporter-id` int unsigned COMMENT 'Reporting contact',
 	`cid` int unsigned NOT NULL COMMENT 'Reported contact',
 	`comment` text COMMENT 'Report',
+	`category` varchar(20) COMMENT 'Category of the report (spam, violation, other)',
 	`forward` boolean COMMENT 'Forward the report to the remote server',
 	`created` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT '',
 	`status` tinyint unsigned COMMENT 'Status of the report',

--- a/doc/database/db_report.md
+++ b/doc/database/db_report.md
@@ -14,6 +14,7 @@ Fields
 | cid         | Reported contact                                | int unsigned       | NO   |     | NULL                |                |
 | comment     | Report                                          | text               | YES  |     | NULL                |                |
 | category    | Category of the report (spam, violation, other) | varchar(20)        | YES  |     | NULL                |                |
+| rules       | Violated rules                                  | text               | YES  |     | NULL                |                |
 | forward     | Forward the report to the remote server         | boolean            | YES  |     | NULL                |                |
 | created     |                                                 | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
 | status      | Status of the report                            | tinyint unsigned   | YES  |     | NULL                |                |

--- a/doc/database/db_report.md
+++ b/doc/database/db_report.md
@@ -6,16 +6,17 @@ Table report
 Fields
 ------
 
-| Field       | Description                             | Type               | Null | Key | Default             | Extra          |
-| ----------- | --------------------------------------- | ------------------ | ---- | --- | ------------------- | -------------- |
-| id          | sequential ID                           | int unsigned       | NO   | PRI | NULL                | auto_increment |
-| uid         | Reporting user                          | mediumint unsigned | YES  |     | NULL                |                |
-| reporter-id | Reporting contact                       | int unsigned       | YES  |     | NULL                |                |
-| cid         | Reported contact                        | int unsigned       | NO   |     | NULL                |                |
-| comment     | Report                                  | text               | YES  |     | NULL                |                |
-| forward     | Forward the report to the remote server | boolean            | YES  |     | NULL                |                |
-| created     |                                         | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
-| status      | Status of the report                    | tinyint unsigned   | YES  |     | NULL                |                |
+| Field       | Description                                     | Type               | Null | Key | Default             | Extra          |
+| ----------- | ----------------------------------------------- | ------------------ | ---- | --- | ------------------- | -------------- |
+| id          | sequential ID                                   | int unsigned       | NO   | PRI | NULL                | auto_increment |
+| uid         | Reporting user                                  | mediumint unsigned | YES  |     | NULL                |                |
+| reporter-id | Reporting contact                               | int unsigned       | YES  |     | NULL                |                |
+| cid         | Reported contact                                | int unsigned       | NO   |     | NULL                |                |
+| comment     | Report                                          | text               | YES  |     | NULL                |                |
+| category    | Category of the report (spam, violation, other) | varchar(20)        | YES  |     | NULL                |                |
+| forward     | Forward the report to the remote server         | boolean            | YES  |     | NULL                |                |
+| created     |                                                 | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
+| status      | Status of the report                            | tinyint unsigned   | YES  |     | NULL                |                |
 
 Indexes
 ------------

--- a/doc/database/db_report.md
+++ b/doc/database/db_report.md
@@ -6,24 +6,26 @@ Table report
 Fields
 ------
 
-| Field   | Description                             | Type               | Null | Key | Default             | Extra          |
-| ------- | --------------------------------------- | ------------------ | ---- | --- | ------------------- | -------------- |
-| id      | sequential ID                           | int unsigned       | NO   | PRI | NULL                | auto_increment |
-| uid     | Reporting user                          | mediumint unsigned | YES  |     | NULL                |                |
-| cid     | Reported contact                        | int unsigned       | NO   |     | NULL                |                |
-| comment | Report                                  | text               | YES  |     | NULL                |                |
-| forward | Forward the report to the remote server | boolean            | YES  |     | NULL                |                |
-| created |                                         | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
-| status  | Status of the report                    | tinyint unsigned   | YES  |     | NULL                |                |
+| Field       | Description                             | Type               | Null | Key | Default             | Extra          |
+| ----------- | --------------------------------------- | ------------------ | ---- | --- | ------------------- | -------------- |
+| id          | sequential ID                           | int unsigned       | NO   | PRI | NULL                | auto_increment |
+| uid         | Reporting user                          | mediumint unsigned | YES  |     | NULL                |                |
+| reporter-id | Reporting contact                       | int unsigned       | YES  |     | NULL                |                |
+| cid         | Reported contact                        | int unsigned       | NO   |     | NULL                |                |
+| comment     | Report                                  | text               | YES  |     | NULL                |                |
+| forward     | Forward the report to the remote server | boolean            | YES  |     | NULL                |                |
+| created     |                                         | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
+| status      | Status of the report                    | tinyint unsigned   | YES  |     | NULL                |                |
 
 Indexes
 ------------
 
-| Name    | Fields |
-| ------- | ------ |
-| PRIMARY | id     |
-| uid     | uid    |
-| cid     | cid    |
+| Name        | Fields      |
+| ----------- | ----------- |
+| PRIMARY     | id          |
+| uid         | uid         |
+| cid         | cid         |
+| reporter-id | reporter-id |
 
 Foreign Keys
 ------------
@@ -31,6 +33,7 @@ Foreign Keys
 | Field | Target Table | Target Field |
 |-------|--------------|--------------|
 | uid | [user](help/database/db_user) | uid |
+| reporter-id | [contact](help/database/db_contact) | id |
 | cid | [contact](help/database/db_contact) | id |
 
 Return to [database documentation](help/database)

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -665,10 +665,11 @@ class System
 
 	/**
 	 * Fetch the system rules
+	 * @param bool $numeric_id If set to "true", the rules are returned with a numeric id as key.
 	 *
 	 * @return array
 	 */
-	public static function getRules(): array
+	public static function getRules(bool $numeric_id = false): array
 	{
 		$rules = [];
 		$id    = 0;
@@ -681,7 +682,11 @@ class System
 			foreach (explode("\n", trim($msg)) as $line) {
 				$line = trim($line);
 				if ($line) {
-					$rules[] = ['id' => (string)++$id, 'text' => $line];
+					if ($numeric_id) {
+						$rules[++$id] = $line;
+					} else {
+						$rules[] = ['id' => (string)++$id, 'text' => $line];
+					}
 				}
 			}
 		}

--- a/src/Moderation/Entity/Report.php
+++ b/src/Moderation/Entity/Report.php
@@ -42,6 +42,8 @@ class Report extends \Friendica\BaseEntity
 	protected $cid;
 	/** @var string Optional comment */
 	protected $comment;
+	/** @var string Optional category */
+	protected $category;
 	/** @var bool Whether this report should be forwarded to the remote server */
 	protected $forward;
 	/** @var \DateTime|null When the report was created */
@@ -49,13 +51,14 @@ class Report extends \Friendica\BaseEntity
 	/** @var array Optional list of URI IDs of posts supporting the report*/
 	protected $postUriIds;
 
-	public function __construct(int $uid = null, int $reporterId, int $cid, \DateTime $created, string $comment = '', bool $forward = false, array $postUriIds = [], int $id = null)
+	public function __construct(int $uid = null, int $reporterId, int $cid, \DateTime $created, string $comment = '', string $category = null, bool $forward = false, array $postUriIds = [], int $id = null)
 	{
 		$this->uid        = $uid;
 		$this->reporterId = $reporterId;
 		$this->cid        = $cid;
 		$this->created    = $created;
 		$this->comment    = $comment;
+		$this->category   = $category;
 		$this->forward    = $forward;
 		$this->postUriIds = $postUriIds;
 		$this->id         = $id;

--- a/src/Moderation/Entity/Report.php
+++ b/src/Moderation/Entity/Report.php
@@ -35,6 +35,8 @@ class Report extends \Friendica\BaseEntity
 	/** @var int|null */
 	protected $id;
 	/** @var int ID of the user making a moderation report*/
+	protected $reporterId;
+	/** @var int ID of the contact making a moderation report*/
 	protected $uid;
 	/** @var int ID of the contact being reported*/
 	protected $cid;
@@ -47,9 +49,10 @@ class Report extends \Friendica\BaseEntity
 	/** @var array Optional list of URI IDs of posts supporting the report*/
 	protected $postUriIds;
 
-	public function __construct(int $uid, int $cid, \DateTime $created, string $comment = '', bool $forward = false, array $postUriIds = [], int $id = null)
+	public function __construct(int $uid = null, int $reporterId, int $cid, \DateTime $created, string $comment = '', bool $forward = false, array $postUriIds = [], int $id = null)
 	{
 		$this->uid        = $uid;
+		$this->reporterId = $reporterId;
 		$this->cid        = $cid;
 		$this->created    = $created;
 		$this->comment    = $comment;

--- a/src/Moderation/Entity/Report.php
+++ b/src/Moderation/Entity/Report.php
@@ -23,21 +23,21 @@ namespace Friendica\Moderation\Entity;
 
 /**
  * @property-read int            $id
- * @property-read int            $uid
+ * @property-read int            $reporterId
  * @property-read int            $cid
  * @property-read string         $comment
+ * @property-read string|null    $category
  * @property-read bool           $forward
  * @property-read array          $postUriIds
+ * @property-read int            $uid
  * @property-read \DateTime|null $created
  */
 class Report extends \Friendica\BaseEntity
 {
 	/** @var int|null */
 	protected $id;
-	/** @var int ID of the user making a moderation report*/
-	protected $reporterId;
 	/** @var int ID of the contact making a moderation report*/
-	protected $uid;
+	protected $reporterId;
 	/** @var int ID of the contact being reported*/
 	protected $cid;
 	/** @var string Optional comment */
@@ -50,10 +50,11 @@ class Report extends \Friendica\BaseEntity
 	protected $created;
 	/** @var array Optional list of URI IDs of posts supporting the report*/
 	protected $postUriIds;
+	/** @var int ID of the user making a moderation report*/
+	protected $uid;
 
-	public function __construct(int $uid = null, int $reporterId, int $cid, \DateTime $created, string $comment = '', string $category = null, bool $forward = false, array $postUriIds = [], int $id = null)
+	public function __construct(int $reporterId, int $cid, \DateTime $created, string $comment = '', string $category = null, bool $forward = false, array $postUriIds = [], int $uid = null, int $id = null)
 	{
-		$this->uid        = $uid;
 		$this->reporterId = $reporterId;
 		$this->cid        = $cid;
 		$this->created    = $created;
@@ -61,6 +62,7 @@ class Report extends \Friendica\BaseEntity
 		$this->category   = $category;
 		$this->forward    = $forward;
 		$this->postUriIds = $postUriIds;
+		$this->uid        = $uid;
 		$this->id         = $id;
 	}
 }

--- a/src/Moderation/Entity/Report.php
+++ b/src/Moderation/Entity/Report.php
@@ -44,6 +44,8 @@ class Report extends \Friendica\BaseEntity
 	protected $comment;
 	/** @var string Optional category */
 	protected $category;
+	/** @var string Violated rules */
+	protected $rules;
 	/** @var bool Whether this report should be forwarded to the remote server */
 	protected $forward;
 	/** @var \DateTime|null When the report was created */
@@ -53,13 +55,14 @@ class Report extends \Friendica\BaseEntity
 	/** @var int ID of the user making a moderation report*/
 	protected $uid;
 
-	public function __construct(int $reporterId, int $cid, \DateTime $created, string $comment = '', string $category = null, bool $forward = false, array $postUriIds = [], int $uid = null, int $id = null)
+	public function __construct(int $reporterId, int $cid, \DateTime $created, string $comment = '', string $category = null, string $rules = '', bool $forward = false, array $postUriIds = [], int $uid = null, int $id = null)
 	{
 		$this->reporterId = $reporterId;
 		$this->cid        = $cid;
 		$this->created    = $created;
 		$this->comment    = $comment;
 		$this->category   = $category;
+		$this->rules      = $rules;
 		$this->forward    = $forward;
 		$this->postUriIds = $postUriIds;
 		$this->uid        = $uid;

--- a/src/Moderation/Factory/Report.php
+++ b/src/Moderation/Factory/Report.php
@@ -40,6 +40,7 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 			$row['cid'],
 			new \DateTime($row['created'] ?? 'now', new \DateTimeZone('UTC')),
 			$row['comment'],
+			$row['category'],
 			$row['forward'],
 			$postUriIds,
 			$row['id'],
@@ -60,7 +61,7 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 	 * @return Entity\Report
 	 * @throws \Exception
 	 */
-	public function createFromReportsRequest(int $uid = null, int $reporterId, int $cid, string $comment = '', bool $forward = false, array $postUriIds = []): Entity\Report
+	public function createFromReportsRequest(int $uid = null, int $reporterId, int $cid, string $comment = '', string $category = null, bool $forward = false, array $postUriIds = []): Entity\Report
 	{
 		return new Entity\Report(
 			$uid,
@@ -68,6 +69,7 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 			$cid,
 			new \DateTime('now', new \DateTimeZone('UTC')),
 			$comment,
+			$category,
 			$forward,
 			$postUriIds,
 		);

--- a/src/Moderation/Factory/Report.php
+++ b/src/Moderation/Factory/Report.php
@@ -40,6 +40,7 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 			new \DateTime($row['created'] ?? 'now', new \DateTimeZone('UTC')),
 			$row['comment'],
 			$row['category'],
+			$row['rules'],
 			$row['forward'],
 			$postUriIds,
 			$row['uid'],
@@ -61,7 +62,7 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 	 * @return Entity\Report
 	 * @throws \Exception
 	 */
-	public function createFromReportsRequest(int $reporterId, int $cid, string $comment = '', string $category = null, bool $forward = false, array $postUriIds = [], int $uid = null): Entity\Report
+	public function createFromReportsRequest(int $reporterId, int $cid, string $comment = '', string $category = null, string $rules = '', bool $forward = false, array $postUriIds = [], int $uid = null): Entity\Report
 	{
 		return new Entity\Report(
 			$reporterId,
@@ -69,6 +70,7 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 			new \DateTime('now', new \DateTimeZone('UTC')),
 			$comment,
 			$category,
+			$rules,
 			$forward,
 			$postUriIds,
 			$uid,

--- a/src/Moderation/Factory/Report.php
+++ b/src/Moderation/Factory/Report.php
@@ -35,7 +35,6 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 	public function createFromTableRow(array $row, array $postUriIds = []): Entity\Report
 	{
 		return new Entity\Report(
-			$row['uid'],
 			$row['reporter-id'],
 			$row['cid'],
 			new \DateTime($row['created'] ?? 'now', new \DateTimeZone('UTC')),
@@ -43,6 +42,7 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 			$row['category'],
 			$row['forward'],
 			$postUriIds,
+			$row['uid'],
 			$row['id'],
 		);
 	}
@@ -61,10 +61,9 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 	 * @return Entity\Report
 	 * @throws \Exception
 	 */
-	public function createFromReportsRequest(int $uid = null, int $reporterId, int $cid, string $comment = '', string $category = null, bool $forward = false, array $postUriIds = []): Entity\Report
+	public function createFromReportsRequest(int $reporterId, int $cid, string $comment = '', string $category = null, bool $forward = false, array $postUriIds = [], int $uid = null): Entity\Report
 	{
 		return new Entity\Report(
-			$uid,
 			$reporterId,
 			$cid,
 			new \DateTime('now', new \DateTimeZone('UTC')),
@@ -72,6 +71,7 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 			$category,
 			$forward,
 			$postUriIds,
+			$uid,
 		);
 	}
 }

--- a/src/Moderation/Factory/Report.php
+++ b/src/Moderation/Factory/Report.php
@@ -36,6 +36,7 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 	{
 		return new Entity\Report(
 			$row['uid'],
+			$row['reporter-id'],
 			$row['cid'],
 			new \DateTime($row['created'] ?? 'now', new \DateTimeZone('UTC')),
 			$row['comment'],
@@ -51,6 +52,7 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 	 * @see \Friendica\Module\Api\Mastodon\Reports::post()
 	 *
 	 * @param int    $uid
+	 * @param int    $reporterId
 	 * @param int    $cid
 	 * @param string $comment
 	 * @param bool   $forward
@@ -58,10 +60,11 @@ class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 	 * @return Entity\Report
 	 * @throws \Exception
 	 */
-	public function createFromReportsRequest(int $uid, int $cid, string $comment = '', bool $forward = false, array $postUriIds = []): Entity\Report
+	public function createFromReportsRequest(int $uid = null, int $reporterId, int $cid, string $comment = '', bool $forward = false, array $postUriIds = []): Entity\Report
 	{
 		return new Entity\Report(
 			$uid,
+			$reporterId,
 			$cid,
 			new \DateTime('now', new \DateTimeZone('UTC')),
 			$comment,

--- a/src/Moderation/Repository/Report.php
+++ b/src/Moderation/Repository/Report.php
@@ -58,6 +58,7 @@ class Report extends \Friendica\BaseRepository
 			'cid'         => $Report->cid,
 			'comment'     => $Report->comment,
 			'category'    => $Report->category,
+			'rules'       => $Report->rules,
 			'forward'     => $Report->forward,
 		];
 

--- a/src/Moderation/Repository/Report.php
+++ b/src/Moderation/Repository/Report.php
@@ -53,10 +53,11 @@ class Report extends \Friendica\BaseRepository
 	public function save(\Friendica\Moderation\Entity\Report $Report)
 	{
 		$fields = [
-			'uid'     => $Report->uid,
-			'cid'     => $Report->cid,
-			'comment' => $Report->comment,
-			'forward' => $Report->forward,
+			'uid'         => $Report->uid,
+			'reporter-id' => $Report->reporterId,
+			'cid'         => $Report->cid,
+			'comment'     => $Report->comment,
+			'forward'     => $Report->forward,
 		];
 
 		$postUriIds = $Report->postUriIds;

--- a/src/Moderation/Repository/Report.php
+++ b/src/Moderation/Repository/Report.php
@@ -57,6 +57,7 @@ class Report extends \Friendica\BaseRepository
 			'reporter-id' => $Report->reporterId,
 			'cid'         => $Report->cid,
 			'comment'     => $Report->comment,
+			'category'    => $Report->category,
 			'forward'     => $Report->forward,
 		];
 

--- a/src/Module/Api/Mastodon/Reports.php
+++ b/src/Module/Api/Mastodon/Reports.php
@@ -66,7 +66,7 @@ class Reports extends BaseApi
 			throw new HTTPException\NotFoundException('Account ' . $request['account_id'] . ' not found');
 		}
 
-		$report = $this->reportFactory->createFromReportsRequest(self::getCurrentUserID(), Contact::getPublicIdByUserId(self::getCurrentUserID()), $request['account_id'], $request['comment'], $request['category'], $request['forward'], $request['status_ids']);
+		$report = $this->reportFactory->createFromReportsRequest(Contact::getPublicIdByUserId(self::getCurrentUserID()), $request['account_id'], $request['comment'], $request['category'], $request['forward'], $request['status_ids'], self::getCurrentUserID());
 
 		$this->reportRepo->save($report);
 

--- a/src/Module/Api/Mastodon/Reports.php
+++ b/src/Module/Api/Mastodon/Reports.php
@@ -54,10 +54,11 @@ class Reports extends BaseApi
 		self::checkAllowedScope(self::SCOPE_WRITE);
 
 		$request = $this->getRequest([
-			'account_id' => '',    // ID of the account to report
-			'status_ids' => [],    // Array of Statuses to attach to the report, for context
-			'comment'    => '',    // Reason for the report (default max 1000 characters)
-			'forward'    => false, // If the account is remote, should the report be forwarded to the remote admin?
+			'account_id' => '',      // ID of the account to report
+			'status_ids' => [],      // Array of Statuses to attach to the report, for context
+			'comment'    => '',      // Reason for the report (default max 1000 characters)
+			'category'   => 'other', // Specify if the report is due to spam, violation of enumerated instance rules, or some other reason.
+			'forward'    => false,   // If the account is remote, should the report be forwarded to the remote admin?
 		], $request);
 
 		$contact = Contact::getById($request['account_id'], ['id']);
@@ -65,7 +66,7 @@ class Reports extends BaseApi
 			throw new HTTPException\NotFoundException('Account ' . $request['account_id'] . ' not found');
 		}
 
-		$report = $this->reportFactory->createFromReportsRequest(self::getCurrentUserID(), Contact::getPublicIdByUserId(self::getCurrentUserID()), $request['account_id'], $request['comment'], $request['forward'], $request['status_ids']);
+		$report = $this->reportFactory->createFromReportsRequest(self::getCurrentUserID(), Contact::getPublicIdByUserId(self::getCurrentUserID()), $request['account_id'], $request['comment'], $request['category'], $request['forward'], $request['status_ids']);
 
 		$this->reportRepo->save($report);
 

--- a/src/Module/Api/Mastodon/Reports.php
+++ b/src/Module/Api/Mastodon/Reports.php
@@ -65,7 +65,7 @@ class Reports extends BaseApi
 			throw new HTTPException\NotFoundException('Account ' . $request['account_id'] . ' not found');
 		}
 
-		$report = $this->reportFactory->createFromReportsRequest(self::getCurrentUserID(), $request['account_id'], $request['comment'], $request['forward'], $request['status_ids']);
+		$report = $this->reportFactory->createFromReportsRequest(self::getCurrentUserID(), Contact::getPublicIdByUserId(self::getCurrentUserID()), $request['account_id'], $request['comment'], $request['forward'], $request['status_ids']);
 
 		$this->reportRepo->save($report);
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1855,7 +1855,7 @@ class Processor
 			}
 		}
 
-		$report = DI::reportFactory()->createFromReportsRequest(null, $reporter_id, $account_id, $activity['content'], false, $uri_ids);
+		$report = DI::reportFactory()->createFromReportsRequest(null, $reporter_id, $account_id, $activity['content'], null, false, $uri_ids);
 		DI::report()->save($report);
 
 		Logger::info('Stored report', ['reporter' => $reporter_id, 'account_id' => $account_id, 'comment' => $activity['content'], 'status_ids' => $status_ids]);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1838,7 +1838,7 @@ class Processor
 		}
 
 		$reporter_id = Contact::getIdForURL($activity['actor']);
-		if (empty($account_id)) {
+		if (empty($reporter_id)) {
 			Logger::info('Unknown actor', ['activity' => $activity]);
 			Queue::remove($activity);
 			return;

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1844,11 +1844,8 @@ class Processor
 			return;
 		}
 
-		$status_ids = $activity['object_ids'];
-		array_shift($status_ids);
-
 		$uri_ids = [];
-		foreach ($status_ids as $status_id) {
+		foreach ($activity['object_ids'] as $status_id) {
 			$post = Post::selectFirst(['uri-id'], ['uri' => $status_id]);
 			if (!empty($post['uri-id'])) {
 				$uri_ids[] = $post['uri-id'];
@@ -1858,7 +1855,7 @@ class Processor
 		$report = DI::reportFactory()->createFromReportsRequest(null, $reporter_id, $account_id, $activity['content'], null, false, $uri_ids);
 		DI::report()->save($report);
 
-		Logger::info('Stored report', ['reporter' => $reporter_id, 'account_id' => $account_id, 'comment' => $activity['content'], 'status_ids' => $status_ids]);
+		Logger::info('Stored report', ['reporter' => $reporter_id, 'account_id' => $account_id, 'comment' => $activity['content'], 'object_ids' => $activity['object_ids']]);
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1852,7 +1852,7 @@ class Processor
 			}
 		}
 
-		$report = DI::reportFactory()->createFromReportsRequest(null, $reporter_id, $account_id, $activity['content'], null, false, $uri_ids);
+		$report = DI::reportFactory()->createFromReportsRequest($reporter_id, $account_id, $activity['content'], null, false, $uri_ids);
 		DI::report()->save($report);
 
 		Logger::info('Stored report', ['reporter' => $reporter_id, 'account_id' => $account_id, 'comment' => $activity['content'], 'object_ids' => $activity['object_ids']]);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1837,6 +1837,13 @@ class Processor
 			return;
 		}
 
+		$reporter_id = Contact::getIdForURL($activity['actor']);
+		if (empty($account_id)) {
+			Logger::info('Unknown actor', ['activity' => $activity]);
+			Queue::remove($activity);
+			return;
+		}
+
 		$status_ids = $activity['object_ids'];
 		array_shift($status_ids);
 
@@ -1848,11 +1855,10 @@ class Processor
 			}
 		}
 
-		// @todo We should store the actor
-		$report = DI::reportFactory()->createFromReportsRequest(0, $account_id, $activity['content'], false, $uri_ids);
+		$report = DI::reportFactory()->createFromReportsRequest(null, $reporter_id, $account_id, $activity['content'], false, $uri_ids);
 		DI::report()->save($report);
 
-		Logger::info('Stored report', ['account_id' => $account_id, 'comment' => $activity['content'], 'status_ids' => $status_ids]);
+		Logger::info('Stored report', ['reporter' => $reporter_id, 'account_id' => $account_id, 'comment' => $activity['content'], 'status_ids' => $status_ids]);
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1852,7 +1852,7 @@ class Processor
 			}
 		}
 
-		$report = DI::reportFactory()->createFromReportsRequest($reporter_id, $account_id, $activity['content'], null, false, $uri_ids);
+		$report = DI::reportFactory()->createFromReportsRequest($reporter_id, $account_id, $activity['content'], null, '', false, $uri_ids);
 		DI::report()->save($report);
 
 		Logger::info('Stored report', ['reporter' => $reporter_id, 'account_id' => $account_id, 'comment' => $activity['content'], 'object_ids' => $activity['object_ids']]);

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1676,6 +1676,7 @@ return [
 			"reporter-id" => ["type" => "int unsigned", "foreign" => ["contact" => "id"], "comment" => "Reporting contact"],
 			"cid" => ["type" => "int unsigned", "not null" => "1", "foreign" => ["contact" => "id"], "comment" => "Reported contact"],
 			"comment" => ["type" => "text", "comment" => "Report"],
+			"category" => ["type" => "varchar(20)", "comment" => "Category of the report (spam, violation, other)"],
 			"forward" => ["type" => "boolean", "comment" => "Forward the report to the remote server"],
 			"created" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => ""],
 			"status" => ["type" => "tinyint unsigned", "comment" => "Status of the report"],

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1677,6 +1677,7 @@ return [
 			"cid" => ["type" => "int unsigned", "not null" => "1", "foreign" => ["contact" => "id"], "comment" => "Reported contact"],
 			"comment" => ["type" => "text", "comment" => "Report"],
 			"category" => ["type" => "varchar(20)", "comment" => "Category of the report (spam, violation, other)"],
+			"rules" => ["type" => "text", "comment" => "Violated rules"],
 			"forward" => ["type" => "boolean", "comment" => "Forward the report to the remote server"],
 			"created" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => ""],
 			"status" => ["type" => "tinyint unsigned", "comment" => "Status of the report"],

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1503);
+	define('DB_UPDATE_VERSION', 1504);
 }
 
 return [
@@ -1673,6 +1673,7 @@ return [
 		"fields" => [
 			"id" => ["type" => "int unsigned", "not null" => "1", "extra" => "auto_increment", "primary" => "1", "comment" => "sequential ID"],
 			"uid" => ["type" => "mediumint unsigned", "foreign" => ["user" => "uid"], "comment" => "Reporting user"],
+			"reporter-id" => ["type" => "int unsigned", "foreign" => ["contact" => "id"], "comment" => "Reporting contact"],
 			"cid" => ["type" => "int unsigned", "not null" => "1", "foreign" => ["contact" => "id"], "comment" => "Reported contact"],
 			"comment" => ["type" => "text", "comment" => "Report"],
 			"forward" => ["type" => "boolean", "comment" => "Forward the report to the remote server"],
@@ -1683,6 +1684,7 @@ return [
 			"PRIMARY" => ["id"],
 			"uid" => ["uid"],
 			"cid" => ["cid"],
+			"reporter-id" => ["reporter-id"],
 		]
 	],
 	"report-post" => [

--- a/tests/src/Moderation/Factory/ReportTest.php
+++ b/tests/src/Moderation/Factory/ReportTest.php
@@ -122,7 +122,7 @@ class ReportTest extends MockedTest
 				'cid'         => 13,
 				'comment'     => '',
 				'category'    => null,
-				'rules'       => null,
+				'rules'       => '',
 				'forward'     => false,
 				'postUriIds'  => [],
 				'uid'         => 12,

--- a/tests/src/Moderation/Factory/ReportTest.php
+++ b/tests/src/Moderation/Factory/ReportTest.php
@@ -39,6 +39,7 @@ class ReportTest extends MockedTest
 					'cid'         => 13,
 					'comment'     => '',
 					'category'    => null,
+					'rules'       => '',
 					'forward'     => false,
 					'created'     => null
 				],
@@ -96,6 +97,7 @@ class ReportTest extends MockedTest
 		self::assertEquals($assertion->cid, $report->cid);
 		self::assertEquals($assertion->comment, $report->comment);
 		self::assertEquals($assertion->category, $report->category);
+		self::assertEquals($assertion->rules, $report->rules);
 		self::assertEquals($assertion->forward, $report->forward);
 		// No way to test "now" at the moment
 		//self::assertEquals($assertion->created, $report->created);
@@ -142,6 +144,7 @@ class ReportTest extends MockedTest
 				'cid'         => 13,
 				'comment'     => 'Report',
 				'category'    => 'violation',
+				'rules'       => 'Rules',
 				'forward'     => true,
 				'postUriIds'  => [89, 90],
 				'uid'         => 12,
@@ -164,7 +167,7 @@ class ReportTest extends MockedTest
 	/**
 	 * @dataProvider dataCreateFromReportsRequest
 	 */
-	public function testCreateFromReportsRequest(int $reporter, int $cid, string $comment, string $category = null, string $rules = null, bool $forward, array $postUriIds, int $uid, Entity\Report $assertion)
+	public function testCreateFromReportsRequest(int $reporter, int $cid, string $comment, string $category = null, string $rules = '', bool $forward, array $postUriIds, int $uid, Entity\Report $assertion)
 	{
 		$factory = new Factory\Report(new NullLogger());
 

--- a/tests/src/Moderation/Factory/ReportTest.php
+++ b/tests/src/Moderation/Factory/ReportTest.php
@@ -49,6 +49,7 @@ class ReportTest extends MockedTest
 					new \DateTime('now', new \DateTimeZone('UTC')),
 					'',
 					null,
+					'',
 					false,
 					[],
 					12,
@@ -63,6 +64,7 @@ class ReportTest extends MockedTest
 					'cid'         => 13,
 					'comment'     => 'Report',
 					'category'    => 'violation',
+					'rules'       => 'Rules',
 					'forward'     => true,
 					'created'     => '2021-10-12 12:23:00'
 				],
@@ -73,6 +75,7 @@ class ReportTest extends MockedTest
 					new \DateTime('2021-10-12 12:23:00', new \DateTimeZone('UTC')),
 					'Report',
 					'violation',
+					'Rules',
 					true,
 					[89, 90],
 					12,
@@ -117,6 +120,7 @@ class ReportTest extends MockedTest
 				'cid'         => 13,
 				'comment'     => '',
 				'category'    => null,
+				'rules'       => null,
 				'forward'     => false,
 				'postUriIds'  => [],
 				'uid'         => 12,
@@ -126,6 +130,7 @@ class ReportTest extends MockedTest
 					new \DateTime('now', new \DateTimeZone('UTC')),
 					'',
 					null,
+					'',
 					false,
 					[],
 					12,
@@ -146,6 +151,7 @@ class ReportTest extends MockedTest
 					new \DateTime('now', new \DateTimeZone('UTC')),
 					'Report',
 					'violation',
+					'Rules',
 					true,
 					[89, 90],
 					12,
@@ -158,10 +164,10 @@ class ReportTest extends MockedTest
 	/**
 	 * @dataProvider dataCreateFromReportsRequest
 	 */
-	public function testCreateFromReportsRequest(int $reporter, int $cid, string $comment, string $category = null, bool $forward, array $postUriIds, int $uid, Entity\Report $assertion)
+	public function testCreateFromReportsRequest(int $reporter, int $cid, string $comment, string $category = null, string $rules = null, bool $forward, array $postUriIds, int $uid, Entity\Report $assertion)
 	{
 		$factory = new Factory\Report(new NullLogger());
 
-		$this->assertReport($factory->createFromReportsRequest($reporter, $cid, $comment, $category, $forward, $postUriIds, $uid), $assertion);
+		$this->assertReport($factory->createFromReportsRequest($reporter, $cid, $comment, $category, $rules, $forward, $postUriIds, $uid), $assertion);
 	}
 }

--- a/tests/src/Moderation/Factory/ReportTest.php
+++ b/tests/src/Moderation/Factory/ReportTest.php
@@ -113,13 +113,13 @@ class ReportTest extends MockedTest
 	{
 		return [
 			'default' => [
-				'uid'         => 12,
 				'reporter-id' => 14,
 				'cid'         => 13,
 				'comment'     => '',
 				'category'    => null,
 				'forward'     => false,
 				'postUriIds'  => [],
+				'uid'         => 12,
 				'assertion'   => new Entity\Report(
 					14,
 					13,
@@ -133,13 +133,13 @@ class ReportTest extends MockedTest
 				),
 			],
 			'full' => [
-				'uid'         => 12,
 				'reporter-id' => 14,
 				'cid'         => 13,
 				'comment'     => 'Report',
 				'category'    => 'violation',
 				'forward'     => true,
 				'postUriIds'  => [89, 90],
+				'uid'         => 12,
 				'assertion'   => new Entity\Report(
 					14,
 					13,

--- a/tests/src/Moderation/Factory/ReportTest.php
+++ b/tests/src/Moderation/Factory/ReportTest.php
@@ -33,16 +33,18 @@ class ReportTest extends MockedTest
 		return [
 			'default' => [
 				'row' => [
-					'id'      => 11,
-					'uid'     => 12,
-					'cid'     => 13,
-					'comment' => '',
-					'forward' => false,
-					'created' => null
+					'id'          => 11,
+					'uid'         => 12,
+					'reporter-id' => 14,
+					'cid'         => 13,
+					'comment'     => '',
+					'forward'     => false,
+					'created'     => null
 				],
 				'postUriIds' => [],
 				'assertion'  => new Entity\Report(
 					12,
+					14,
 					13,
 					new \DateTime('now', new \DateTimeZone('UTC')),
 					'',
@@ -53,16 +55,18 @@ class ReportTest extends MockedTest
 			],
 			'full' => [
 				'row' => [
-					'id'      => 11,
-					'uid'     => 12,
-					'cid'     => 13,
-					'comment' => 'Report',
-					'forward' => true,
-					'created' => '2021-10-12 12:23:00'
+					'id'          => 11,
+					'uid'         => 12,
+					'reporter-id' => 14,
+					'cid'         => 13,
+					'comment'     => 'Report',
+					'forward'     => true,
+					'created'     => '2021-10-12 12:23:00'
 				],
 				'postUriIds' => [89, 90],
 				'assertion'  => new Entity\Report(
 					12,
+					14,
 					13,
 					new \DateTime('2021-10-12 12:23:00', new \DateTimeZone('UTC')),
 					'Report',
@@ -81,6 +85,7 @@ class ReportTest extends MockedTest
 			$report->id
 		);
 		self::assertEquals($assertion->uid, $report->uid);
+		self::assertEquals($assertion->reporterId, $report->reporterId);
 		self::assertEquals($assertion->cid, $report->cid);
 		self::assertEquals($assertion->comment, $report->comment);
 		self::assertEquals($assertion->forward, $report->forward);
@@ -103,13 +108,15 @@ class ReportTest extends MockedTest
 	{
 		return [
 			'default' => [
-				'uid'        => 12,
-				'cid'        => 13,
-				'comment'    => '',
-				'forward'    => false,
-				'postUriIds' => [],
-				'assertion'  => new Entity\Report(
+				'uid'         => 12,
+				'reporter-id' => 14,
+				'cid'         => 13,
+				'comment'     => '',
+				'forward'     => false,
+				'postUriIds'  => [],
+				'assertion'   => new Entity\Report(
 					12,
+					14,
 					13,
 					new \DateTime('now', new \DateTimeZone('UTC')),
 					'',
@@ -119,13 +126,15 @@ class ReportTest extends MockedTest
 				),
 			],
 			'full' => [
-				'uid'        => 12,
-				'cid'        => 13,
-				'comment'    => 'Report',
-				'forward'    => true,
-				'postUriIds' => [89, 90],
-				'assertion'  => new Entity\Report(
+				'uid'         => 12,
+				'reporter-id' => 14,
+				'cid'         => 13,
+				'comment'     => 'Report',
+				'forward'     => true,
+				'postUriIds'  => [89, 90],
+				'assertion'   => new Entity\Report(
 					12,
+					14,
 					13,
 					new \DateTime('now', new \DateTimeZone('UTC')),
 					'Report',
@@ -140,10 +149,10 @@ class ReportTest extends MockedTest
 	/**
 	 * @dataProvider dataCreateFromReportsRequest
 	 */
-	public function testCreateFromReportsRequest(int $uid, int $cid, string $comment, bool $forward, array $postUriIds, Entity\Report $assertion)
+	public function testCreateFromReportsRequest(int $uid, int $reporter, int $cid, string $comment, bool $forward, array $postUriIds, Entity\Report $assertion)
 	{
 		$factory = new Factory\Report(new NullLogger());
 
-		$this->assertReport($factory->createFromReportsRequest($uid, $cid, $comment, $forward, $postUriIds), $assertion);
+		$this->assertReport($factory->createFromReportsRequest($uid, $reporter, $cid, $comment, $forward, $postUriIds), $assertion);
 	}
 }

--- a/tests/src/Moderation/Factory/ReportTest.php
+++ b/tests/src/Moderation/Factory/ReportTest.php
@@ -48,6 +48,7 @@ class ReportTest extends MockedTest
 					13,
 					new \DateTime('now', new \DateTimeZone('UTC')),
 					'',
+					null,
 					false,
 					[],
 					11,
@@ -70,6 +71,7 @@ class ReportTest extends MockedTest
 					13,
 					new \DateTime('2021-10-12 12:23:00', new \DateTimeZone('UTC')),
 					'Report',
+					'violation',
 					true,
 					[89, 90],
 					11
@@ -88,6 +90,7 @@ class ReportTest extends MockedTest
 		self::assertEquals($assertion->reporterId, $report->reporterId);
 		self::assertEquals($assertion->cid, $report->cid);
 		self::assertEquals($assertion->comment, $report->comment);
+		self::assertEquals($assertion->category, $report->category);
 		self::assertEquals($assertion->forward, $report->forward);
 		// No way to test "now" at the moment
 		//self::assertEquals($assertion->created, $report->created);
@@ -120,6 +123,7 @@ class ReportTest extends MockedTest
 					13,
 					new \DateTime('now', new \DateTimeZone('UTC')),
 					'',
+					null,
 					false,
 					[],
 					null
@@ -138,6 +142,7 @@ class ReportTest extends MockedTest
 					13,
 					new \DateTime('now', new \DateTimeZone('UTC')),
 					'Report',
+					'violation',
 					true,
 					[89, 90],
 					null
@@ -149,10 +154,10 @@ class ReportTest extends MockedTest
 	/**
 	 * @dataProvider dataCreateFromReportsRequest
 	 */
-	public function testCreateFromReportsRequest(int $uid, int $reporter, int $cid, string $comment, bool $forward, array $postUriIds, Entity\Report $assertion)
+	public function testCreateFromReportsRequest(int $uid, int $reporter, int $cid, string $comment, string $category = null, bool $forward, array $postUriIds, Entity\Report $assertion)
 	{
 		$factory = new Factory\Report(new NullLogger());
 
-		$this->assertReport($factory->createFromReportsRequest($uid, $reporter, $cid, $comment, $forward, $postUriIds), $assertion);
+		$this->assertReport($factory->createFromReportsRequest($uid, $reporter, $cid, $comment, $category, $forward, $postUriIds), $assertion);
 	}
 }

--- a/tests/src/Moderation/Factory/ReportTest.php
+++ b/tests/src/Moderation/Factory/ReportTest.php
@@ -38,6 +38,7 @@ class ReportTest extends MockedTest
 					'reporter-id' => 14,
 					'cid'         => 13,
 					'comment'     => '',
+					'category'    => null,
 					'forward'     => false,
 					'created'     => null
 				],
@@ -61,6 +62,7 @@ class ReportTest extends MockedTest
 					'reporter-id' => 14,
 					'cid'         => 13,
 					'comment'     => 'Report',
+					'category'    => 'violation',
 					'forward'     => true,
 					'created'     => '2021-10-12 12:23:00'
 				],
@@ -115,6 +117,7 @@ class ReportTest extends MockedTest
 				'reporter-id' => 14,
 				'cid'         => 13,
 				'comment'     => '',
+				'category'    => null,
 				'forward'     => false,
 				'postUriIds'  => [],
 				'assertion'   => new Entity\Report(
@@ -134,6 +137,7 @@ class ReportTest extends MockedTest
 				'reporter-id' => 14,
 				'cid'         => 13,
 				'comment'     => 'Report',
+				'category'    => 'violation',
 				'forward'     => true,
 				'postUriIds'  => [89, 90],
 				'assertion'   => new Entity\Report(

--- a/tests/src/Moderation/Factory/ReportTest.php
+++ b/tests/src/Moderation/Factory/ReportTest.php
@@ -44,7 +44,6 @@ class ReportTest extends MockedTest
 				],
 				'postUriIds' => [],
 				'assertion'  => new Entity\Report(
-					12,
 					14,
 					13,
 					new \DateTime('now', new \DateTimeZone('UTC')),
@@ -52,6 +51,7 @@ class ReportTest extends MockedTest
 					null,
 					false,
 					[],
+					12,
 					11,
 				),
 			],
@@ -68,7 +68,6 @@ class ReportTest extends MockedTest
 				],
 				'postUriIds' => [89, 90],
 				'assertion'  => new Entity\Report(
-					12,
 					14,
 					13,
 					new \DateTime('2021-10-12 12:23:00', new \DateTimeZone('UTC')),
@@ -76,6 +75,7 @@ class ReportTest extends MockedTest
 					'violation',
 					true,
 					[89, 90],
+					12,
 					11
 				),
 			],
@@ -121,7 +121,6 @@ class ReportTest extends MockedTest
 				'forward'     => false,
 				'postUriIds'  => [],
 				'assertion'   => new Entity\Report(
-					12,
 					14,
 					13,
 					new \DateTime('now', new \DateTimeZone('UTC')),
@@ -129,6 +128,7 @@ class ReportTest extends MockedTest
 					null,
 					false,
 					[],
+					12,
 					null
 				),
 			],
@@ -141,7 +141,6 @@ class ReportTest extends MockedTest
 				'forward'     => true,
 				'postUriIds'  => [89, 90],
 				'assertion'   => new Entity\Report(
-					12,
 					14,
 					13,
 					new \DateTime('now', new \DateTimeZone('UTC')),
@@ -149,6 +148,7 @@ class ReportTest extends MockedTest
 					'violation',
 					true,
 					[89, 90],
+					12,
 					null
 				),
 			],
@@ -158,10 +158,10 @@ class ReportTest extends MockedTest
 	/**
 	 * @dataProvider dataCreateFromReportsRequest
 	 */
-	public function testCreateFromReportsRequest(int $uid, int $reporter, int $cid, string $comment, string $category = null, bool $forward, array $postUriIds, Entity\Report $assertion)
+	public function testCreateFromReportsRequest(int $reporter, int $cid, string $comment, string $category = null, bool $forward, array $postUriIds, int $uid, Entity\Report $assertion)
 	{
 		$factory = new Factory\Report(new NullLogger());
 
-		$this->assertReport($factory->createFromReportsRequest($uid, $reporter, $cid, $comment, $category, $forward, $postUriIds), $assertion);
+		$this->assertReport($factory->createFromReportsRequest($reporter, $cid, $comment, $category, $forward, $postUriIds, $uid), $assertion);
 	}
 }


### PR DESCRIPTION
Reports from remote systems obviously can't contain a user id. Because of that we now add the contact id of the reporter as well.