### PR TITLE
Replace duplicated code by Images::getScalingDimensions call in Object\Image->scaleDown

### DIFF
--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -289,7 +289,7 @@ class Image
 			return false;
 		}
 
-		$scale = Images::getScalingDimensions($width, $height,$max);
+		$scale = Images::getScalingDimensions($width, $height, $max);
 		return $this->scale($scale['width'], $scale['height']);
 	}
 

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -285,12 +285,13 @@ class Image
 		$width = $this->getWidth();
 		$height = $this->getHeight();
 
-		if ((! $width)|| (! $height)) {
+		$scale = Images::getScalingDimensions($width, $height,$max);
+		if ($scale) {
+			return $this->scale($scale['width'], $scale['height']);
+		} else {
 			return false;
 		}
 
-		$scale = Images::getScalingDimensions($width, $height,$max);
-		return $this->scale($scale['width'], $scale['height']);
 	}
 
 	/**

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -289,45 +289,8 @@ class Image
 			return false;
 		}
 
-		if ($width > $max && $height > $max) {
-			// very tall image (greater than 16:9)
-			// constrain the width - let the height float.
-
-			if ((($height * 9) / 16) > $width) {
-				$dest_width = $max;
-				$dest_height = intval(($height * $max) / $width);
-			} elseif ($width > $height) {
-				// else constrain both dimensions
-				$dest_width = $max;
-				$dest_height = intval(($height * $max) / $width);
-			} else {
-				$dest_width = intval(($width * $max) / $height);
-				$dest_height = $max;
-			}
-		} else {
-			if ($width > $max) {
-				$dest_width = $max;
-				$dest_height = intval(($height * $max) / $width);
-			} else {
-				if ($height > $max) {
-					// very tall image (greater than 16:9)
-					// but width is OK - don't do anything
-
-					if ((($height * 9) / 16) > $width) {
-						$dest_width = $width;
-						$dest_height = $height;
-					} else {
-						$dest_width = intval(($width * $max) / $height);
-						$dest_height = $max;
-					}
-				} else {
-					$dest_width = $width;
-					$dest_height = $height;
-				}
-			}
-		}
-
-		return $this->scale($dest_width, $dest_height);
+		$scale = Images::getScalingDimensions($width, $height,$max);
+		return $this->scale($scale['width'], $scale['height']);
 	}
 
 	/**


### PR DESCRIPTION
I found this double code block during my search for faulty scaled portraits. Did not find the cause yet, but this doubled code.

Please review carefully, even PHPStrom clearly indicated that is was 100% redundant. 