### PR TITLE
Reduce the amount of "UpdateContact" worker calls

### DIFF
--- a/src/Protocol/ActivityPub/Delivery.php
+++ b/src/Protocol/ActivityPub/Delivery.php
@@ -205,9 +205,15 @@ class Delivery
 	 */
 	private static function setSuccess(array $receivers, bool $success)
 	{
-		$gsid = null;
+		$gsid           = null;
+		$update_counter = 0;
 
 		foreach ($receivers as $receiver) {
+			// Only update the first 10 receivers to avoid flooding the remote system with requests
+			if ($success && ($update_counter < 10) && Contact::updateByIdIfNeeded($receiver)) {
+				$update_counter++;
+			}
+
 			$contact = Contact::getById($receiver);
 			if (empty($contact)) {
 				continue;

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1530,6 +1530,12 @@ class Processor
 
 		$ldactivity['recursion-depth'] = !empty($child['recursion-depth']) ? $child['recursion-depth'] + 1 : 0;
 
+		if ($object_actor != $actor) {
+			Contact::updateByUrlIfNeeded($object_actor);
+		}
+
+		Contact::updateByUrlIfNeeded($actor);
+
 		if (!empty($relay_actor)) {
 			$ldactivity['thread-completion'] = $ldactivity['from-relay'] = Contact::getIdForURL($relay_actor);
 			$ldactivity['completion-mode']   = Receiver::COMPLETION_RELAY;

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -534,7 +534,7 @@ class Diaspora
 		if (is_null($fields)) {
 			$private = true;
 			if (!($fields = self::validPosting($msg))) {
-				Logger::warning('Invalid posting', ['msg' => $msg]);
+				Logger::notice('Invalid posting', ['msg' => $msg]);
 				return false;
 			}
 		} else {
@@ -812,6 +812,7 @@ class Diaspora
 	 */
 	private static function contactByHandle(int $uid, WebFingerUri $uri): array
 	{
+		Contact::updateByUrlIfNeeded($uri->getAddr());
 		return Contact::getByURL($uri->getAddr(), null, [], $uid);
 	}
 

--- a/src/Worker/UpdateContacts.php
+++ b/src/Worker/UpdateContacts.php
@@ -72,7 +72,7 @@ class UpdateContacts
 				++$count;
 			}
 			Worker::coolDown();
-	}
+		}
 		DBA::close($contacts);
 
 		Logger::info('Initiated update for federated contacts', ['count' => $count]);

--- a/src/Worker/UpdateContacts.php
+++ b/src/Worker/UpdateContacts.php
@@ -66,9 +66,10 @@ class UpdateContacts
 			if ((!empty($contact['gsid']) || !empty($contact['baseurl'])) && GServer::reachable($contact)) {
 				$stamp = (float)microtime(true);
 				$success = Contact::updateFromProbe($contact['id']);
-				Logger::debug('Direct update', ['id' => $contact['id'], 'duration' => round((float)microtime(true) - $stamp, 3), 'success' => $success]);
+				Logger::debug('Direct update', ['id' => $contact['id'], 'count' => $count, 'duration' => round((float)microtime(true) - $stamp, 3), 'success' => $success]);
 				++$count;
 			} elseif (Worker::add(['priority' => Worker::PRIORITY_LOW, 'dont_fork' => true], 'UpdateContact', $contact['id'])) {
+				Logger::debug('Update by worker', ['id' => $contact['id'], 'count' => $count]);
 				++$count;
 			}
 			Worker::coolDown();

--- a/src/Worker/UpdateContacts.php
+++ b/src/Worker/UpdateContacts.php
@@ -22,10 +22,11 @@
 namespace Friendica\Worker;
 
 use Friendica\Core\Logger;
-use Friendica\Core\Protocol;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Model\Contact;
+use Friendica\Model\GServer;
 use Friendica\Util\DateTimeFormat;
 
 /**
@@ -56,14 +57,22 @@ class UpdateContacts
 		}
 
 		$condition = DBA::mergeConditions(["`next-update` < ?", DateTimeFormat::utcNow()], $condition);
-		$contacts = DBA::select('contact', ['id'], $condition, ['order' => ['next-update'], 'limit' => $limit]);
+		$contacts = DBA::select('contact', ['id', 'url', 'gsid', 'baseurl'], $condition, ['order' => ['next-update'], 'limit' => $limit]);
 		$count = 0;
 		while ($contact = DBA::fetch($contacts)) {
-			if (Worker::add(['priority' => Worker::PRIORITY_LOW, 'dont_fork' => true], "UpdateContact", $contact['id'])) {
+			if (Contact::isLocal($contact['url'])) {
+				continue;
+			}
+			if ((!empty($contact['gsid']) || !empty($contact['baseurl'])) && GServer::reachable($contact)) {
+				$stamp = (float)microtime(true);
+				$success = Contact::updateFromProbe($contact['id']);
+				Logger::debug('Direct update', ['id' => $contact['id'], 'duration' => round((float)microtime(true) - $stamp, 3), 'success' => $success]);
+				++$count;
+			} elseif (Worker::add(['priority' => Worker::PRIORITY_LOW, 'dont_fork' => true], 'UpdateContact', $contact['id'])) {
 				++$count;
 			}
 			Worker::coolDown();
-		}
+	}
 		DBA::close($contacts);
 
 		Logger::info('Initiated update for federated contacts', ['count' => $count]);


### PR DESCRIPTION
This PR should to reduce the number of "UpdateContact" worker calls.

Now update calls are done directly if this doesn't cause issues. Also the setting to update only contacts with local data is now checked at other locations as well.