### PR TITLE
Fixed width and height not updated when image rotation is done by EXIF based orient method

### DIFF
--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -381,7 +381,7 @@ class Image
 					$this->rotate( 180);
 					break;
 				case Imagick::ORIENTATION_RIGHTTOP:
-					$this->rotate( -90);
+					$this->rotate(-90);
 					break;
 				case Imagick::ORIENTATION_LEFTBOTTOM:
 					$this->rotate(90);

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -378,13 +378,13 @@ class Image
 			$orientation = $this->image->getImageOrientation();
 			switch ($orientation) {
 				case Imagick::ORIENTATION_BOTTOMRIGHT:
-					$this->image->rotateimage("#000", 180);
+					$this->rotate( 180);
 					break;
 				case Imagick::ORIENTATION_RIGHTTOP:
-					$this->image->rotateimage("#000", 90);
+					$this->rotate( -90);
 					break;
 				case Imagick::ORIENTATION_LEFTBOTTOM:
-					$this->image->rotateimage("#000", -90);
+					$this->rotate(90);
 					break;
 			}
 

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -378,7 +378,7 @@ class Image
 			$orientation = $this->image->getImageOrientation();
 			switch ($orientation) {
 				case Imagick::ORIENTATION_BOTTOMRIGHT:
-					$this->rotate( 180);
+					$this->rotate(180);
 					break;
 				case Imagick::ORIENTATION_RIGHTTOP:
 					$this->rotate(-90);


### PR DESCRIPTION
It's a bit confusing as there are multiple locations where images are rotated.
This PR solves the problem of portrait images being rendered distorted as landscapes by having the rotation performed by the built-in [rotate ](https://github.com/friendica/friendica/blob/689b6b015b84da4b8ce2bdb2389093e5d104b2c9/src/Object/Image.php#L303)method, which correctly sets the new height and width after rotation.