### PR TITLE
Make tag 'Names' Field have case-sensitive version

### DIFF
--- a/src/Object/Api/Mastodon/Tag.php
+++ b/src/Object/Api/Mastodon/Tag.php
@@ -51,8 +51,8 @@ class Tag extends BaseDataTransferObject
 	 */
 	public function __construct(BaseURL $baseUrl, array $tag, array $history = [], bool $following = false)
 	{
-		$this->name      = strtolower($tag['name']);
-		$this->url       = $baseUrl . '/search?tag=' . urlencode($this->name);
+		$this->name      = $tag['name'];
+		$this->url       = $baseUrl . '/search?tag=' . urlencode(strtolower($this->name));
 		$this->history   = $history;
 		$this->following = $following;
 	}


### PR DESCRIPTION
The current implementation returns all lower case versions of the tag names. Looking at the Mastodon examples the "Name" field has the case-sensitive version of the name while the URL has the all lowercase version. This makes it consistent with that. Without it there is no way to get the case-aware version of tags.