### PR TITLE
Allow adding local contacts via console

### DIFF
--- a/src/Console/Contact.php
+++ b/src/Console/Contact.php
@@ -157,7 +157,7 @@ HELP;
 
 		$url = Probe::cleanURI($url);
 
-		$contact = ContactModel::getByURLForUser($url, $user['uid']);
+		$contact = ContactModel::getByURL($url, null, [], $user['uid']);
 		if (!empty($contact)) {
 			throw new RuntimeException('Contact already exists');
 		}


### PR DESCRIPTION
I found that I was unable to add contacts using the console commands, it would always complain that the contact already existed.  The reason is that `getByURLForUser` first looks for a contact for the specified URL, and then falls back to looking for a public contact for the specified URL.  But for a local user, there is always a public contact.

So instead of using `getByURLForUser`, I change it to `getByURL`.  This one does not have the fallback behaviour.