### PR TITLE
Allow HTTP requests to hosts in local hosts file

### DIFF
--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -69,7 +69,7 @@ class HttpClient implements ICanSendHttpRequests
 		$this->logger->debug('Request start.', ['url' => $url, 'method' => $method]);
 
 		$host = parse_url($url, PHP_URL_HOST);
-		if(!filter_var($host, FILTER_VALIDATE_IP) && !@dns_get_record($host . '.', DNS_A + DNS_AAAA)) {
+		if(!filter_var($host, FILTER_VALIDATE_IP) && !@dns_get_record($host . '.', DNS_A + DNS_AAAA) && !gethostbyname($host)) {
 			$this->logger->debug('URL cannot be resolved.', ['url' => $url, 'callstack' => System::callstack(20)]);
 			$this->profiler->stopRecording();
 			return CurlResult::createErrorCurl($url);


### PR DESCRIPTION
Not sure if this is a good idea, this file seems to have some important stuff in that I don't fully understand...

I found that it was impossible to add contacts between two test instances on my local network because the hostnames are only defined in the local `/etc/hosts` file.  This is because this sanity check performs a real DNS lookup.  If you use `gethostbyname` it also looks up in `/etc/hosts`, and that allows me to add contacts again.