### PR TITLE
Bulk delivery added for all protocols

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2023.03-dev (Giant Rhubarb)
--- DB_UPDATE_VERSION 1505
+-- DB_UPDATE_VERSION 1506
 -- ------------------------------------------
 
 
@@ -578,6 +578,27 @@ CREATE TABLE IF NOT EXISTS `delayed-post` (
 	FOREIGN KEY (`uid`) REFERENCES `user` (`uid`) ON UPDATE RESTRICT ON DELETE CASCADE,
 	FOREIGN KEY (`wid`) REFERENCES `workerqueue` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Posts that are about to be distributed at a later time';
+
+--
+-- TABLE delivery-queue
+--
+CREATE TABLE IF NOT EXISTS `delivery-queue` (
+	`gsid` int unsigned NOT NULL COMMENT 'Global Server ID',
+	`uri-id` int unsigned NOT NULL COMMENT 'Id of the item-uri table entry that contains the item uri',
+	`created` datetime COMMENT '',
+	`command` varbinary(32) COMMENT '',
+	`cid` int unsigned COMMENT 'contact_id (ID of the contact in contact table)',
+	`uid` mediumint unsigned COMMENT 'Delivering user',
+	`failed` tinyint DEFAULT 0 COMMENT 'Number of times the delivery has failed',
+	 PRIMARY KEY(`uri-id`,`gsid`),
+	 INDEX `gsid_created` (`gsid`,`created`),
+	 INDEX `uid` (`uid`),
+	 INDEX `cid` (`cid`),
+	FOREIGN KEY (`gsid`) REFERENCES `gserver` (`id`) ON UPDATE RESTRICT ON DELETE RESTRICT,
+	FOREIGN KEY (`uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,
+	FOREIGN KEY (`cid`) REFERENCES `contact` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,
+	FOREIGN KEY (`uid`) REFERENCES `user` (`uid`) ON UPDATE RESTRICT ON DELETE CASCADE
+) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Delivery data for posts for the batch processing';
 
 --
 -- TABLE diaspora-contact

--- a/database.sql
+++ b/database.sql
@@ -583,11 +583,11 @@ CREATE TABLE IF NOT EXISTS `delayed-post` (
 -- TABLE delivery-queue
 --
 CREATE TABLE IF NOT EXISTS `delivery-queue` (
-	`gsid` int unsigned NOT NULL COMMENT 'Global Server ID',
-	`uri-id` int unsigned NOT NULL COMMENT 'Id of the item-uri table entry that contains the item uri',
+	`gsid` int unsigned NOT NULL COMMENT 'Target server',
+	`uri-id` int unsigned NOT NULL COMMENT 'Delivered post',
 	`created` datetime COMMENT '',
 	`command` varbinary(32) COMMENT '',
-	`cid` int unsigned COMMENT 'contact_id (ID of the contact in contact table)',
+	`cid` int unsigned COMMENT 'Target contact',
 	`uid` mediumint unsigned COMMENT 'Delivering user',
 	`failed` tinyint DEFAULT 0 COMMENT 'Number of times the delivery has failed',
 	 PRIMARY KEY(`uri-id`,`gsid`),

--- a/doc/database.md
+++ b/doc/database.md
@@ -23,6 +23,7 @@ Database Tables
 | [contact-relation](help/database/db_contact-relation) | Contact relations |
 | [conv](help/database/db_conv) | private messages |
 | [delayed-post](help/database/db_delayed-post) | Posts that are about to be distributed at a later time |
+| [delivery-queue](help/database/db_delivery-queue) | Delivery data for posts for the batch processing |
 | [diaspora-contact](help/database/db_diaspora-contact) | Diaspora compatible contacts - used in the Diaspora implementation |
 | [diaspora-interaction](help/database/db_diaspora-interaction) | Signed Diaspora Interaction |
 | [endpoint](help/database/db_endpoint) | ActivityPub endpoints - used in the ActivityPub implementation |

--- a/doc/database/db_delivery-queue.md
+++ b/doc/database/db_delivery-queue.md
@@ -1,0 +1,39 @@
+Table delivery-queue
+===========
+
+Delivery data for posts for the batch processing
+
+Fields
+------
+
+| Field   | Description                                               | Type               | Null | Key | Default | Extra |
+| ------- | --------------------------------------------------------- | ------------------ | ---- | --- | ------- | ----- |
+| gsid    | Global Server ID                                          | int unsigned       | NO   | PRI | NULL    |       |
+| uri-id  | Id of the item-uri table entry that contains the item uri | int unsigned       | NO   | PRI | NULL    |       |
+| created |                                                           | datetime           | YES  |     | NULL    |       |
+| command |                                                           | varbinary(32)      | YES  |     | NULL    |       |
+| cid     | contact_id (ID of the contact in contact table)           | int unsigned       | YES  |     | NULL    |       |
+| uid     | Delivering user                                           | mediumint unsigned | YES  |     | NULL    |       |
+| failed  | Number of times the delivery has failed                   | tinyint            | YES  |     | 0       |       |
+
+Indexes
+------------
+
+| Name         | Fields        |
+| ------------ | ------------- |
+| PRIMARY      | uri-id, gsid  |
+| gsid_created | gsid, created |
+| uid          | uid           |
+| cid          | cid           |
+
+Foreign Keys
+------------
+
+| Field | Target Table | Target Field |
+|-------|--------------|--------------|
+| gsid | [gserver](help/database/db_gserver) | id |
+| uri-id | [item-uri](help/database/db_item-uri) | id |
+| cid | [contact](help/database/db_contact) | id |
+| uid | [user](help/database/db_user) | uid |
+
+Return to [database documentation](help/database)

--- a/doc/database/db_delivery-queue.md
+++ b/doc/database/db_delivery-queue.md
@@ -6,15 +6,15 @@ Delivery data for posts for the batch processing
 Fields
 ------
 
-| Field   | Description                                               | Type               | Null | Key | Default | Extra |
-| ------- | --------------------------------------------------------- | ------------------ | ---- | --- | ------- | ----- |
-| gsid    | Global Server ID                                          | int unsigned       | NO   | PRI | NULL    |       |
-| uri-id  | Id of the item-uri table entry that contains the item uri | int unsigned       | NO   | PRI | NULL    |       |
-| created |                                                           | datetime           | YES  |     | NULL    |       |
-| command |                                                           | varbinary(32)      | YES  |     | NULL    |       |
-| cid     | contact_id (ID of the contact in contact table)           | int unsigned       | YES  |     | NULL    |       |
-| uid     | Delivering user                                           | mediumint unsigned | YES  |     | NULL    |       |
-| failed  | Number of times the delivery has failed                   | tinyint            | YES  |     | 0       |       |
+| Field   | Description                             | Type               | Null | Key | Default | Extra |
+| ------- | --------------------------------------- | ------------------ | ---- | --- | ------- | ----- |
+| gsid    | Target server                           | int unsigned       | NO   | PRI | NULL    |       |
+| uri-id  | Delivered post                          | int unsigned       | NO   | PRI | NULL    |       |
+| created |                                         | datetime           | YES  |     | NULL    |       |
+| command |                                         | varbinary(32)      | YES  |     | NULL    |       |
+| cid     | Target contact                          | int unsigned       | YES  |     | NULL    |       |
+| uid     | Delivering user                         | mediumint unsigned | YES  |     | NULL    |       |
+| failed  | Number of times the delivery has failed | tinyint            | YES  |     | 0       |       |
 
 Indexes
 ------------

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1264,7 +1264,7 @@ class Worker
 
 		$command = array_shift($args);
 		$parameters = json_encode($args);
-		$queue = DBA::selectFirst('workerqueue', [], ['command' => $command, 'parameter' => $parameters, 'done' => false]);
+		$queue = DBA::selectFirst('workerqueue', ['id', 'priority'], ['command' => $command, 'parameter' => $parameters, 'done' => false]);
 		$added = 0;
 
 		if (!is_int($priority) || !in_array($priority, self::PRIORITIES)) {

--- a/src/Core/Worker/Cron.php
+++ b/src/Core/Worker/Cron.php
@@ -26,8 +26,10 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
+use Friendica\Model\GServer;
 use Friendica\Model\Post;
 use Friendica\Protocol\ActivityPub;
+use Friendica\Protocol\Delivery;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
 
@@ -58,7 +60,10 @@ class Cron
 		// Remove old entries from the workerqueue
 		self::cleanWorkerQueue();
 
-		// Directly deliver or requeue posts
+		// Directly deliver or requeue posts to ActivityPub systems
+		self::deliverAPPosts();
+
+		// Directly deliver or requeue posts to other systems
 		self::deliverPosts();
 	}
 
@@ -157,7 +162,7 @@ class Cron
 	 *
 	 * This function is placed here as a safeguard. Even when the worker queue is completely blocked, messages will be delivered.
 	 */
-	private static function deliverPosts()
+	private static function deliverAPPosts()
 	{
 		$deliveries = DBA::p("SELECT `item-uri`.`uri` AS `inbox`, MAX(`failed`) AS `failed` FROM `post-delivery` INNER JOIN `item-uri` ON `item-uri`.`id` = `post-delivery`.`inbox-id` GROUP BY `inbox` ORDER BY RAND()");
 		while ($delivery = DBA::fetch($deliveries)) {
@@ -181,7 +186,7 @@ class Cron
 			}
 
 			if (Worker::add(['priority' => $priority, 'force_priority' => true], 'APDelivery', '', 0, $delivery['inbox'], 0)) {
-				Logger::info('Missing APDelivery worker added for inbox', ['inbox' => $delivery['inbox'], 'failed' => $delivery['failed'], 'priority' => $priority]);
+				Logger::info('Priority for APDelivery worker adjusted', ['inbox' => $delivery['inbox'], 'failed' => $delivery['failed'], 'priority' => $priority]);
 			}
 		}
 
@@ -189,6 +194,41 @@ class Cron
 		if (DI::config()->get('system', 'optimize_tables')) {
 			Logger::info('Optimize start');
 			DBA::e("OPTIMIZE TABLE `post-delivery`");
+			Logger::info('Optimize end');
+		}
+	}
+
+	/**
+	 * Directly deliver messages or requeue them.
+	 */
+	private static function deliverPosts()
+	{
+		$deliveries = DBA::p("SELECT `gsid`, MAX(`failed`) AS `failed` FROM `delivery-queue` GROUP BY `gsid` ORDER BY RAND()");
+		while ($delivery = DBA::fetch($deliveries)) {
+			if ($delivery['failed'] > 0) {
+				Logger::info('Removing failed deliveries', ['gsid' => $delivery['gsid'], 'failed' => $delivery['failed']]);
+				Delivery::removeFailedQueue($delivery['gsid']);
+			}
+
+			if (($delivery['failed'] < 3) || GServer::reachableById($delivery['gsid'])) {
+				$priority = Worker::PRIORITY_HIGH;
+			} elseif ($delivery['failed'] < 6) {
+				$priority = Worker::PRIORITY_MEDIUM;
+			} elseif ($delivery['failed'] < 8) {
+				$priority = Worker::PRIORITY_LOW;
+			} else {
+				$priority = Worker::PRIORITY_NEGLIGIBLE;
+			}
+
+			if (Worker::add(['priority' => $priority, 'force_priority' => true], 'BulkDelivery', $delivery['gsid'])) {
+				Logger::info('Priority for BulkDelivery worker adjusted', ['gsid' => $delivery['gsid'], 'failed' => $delivery['failed'], 'priority' => $priority]);
+			}
+		}
+
+		// Optimizing this table only last seconds
+		if (DI::config()->get('system', 'optimize_tables')) {
+			Logger::info('Optimize start');
+			DBA::e("OPTIMIZE TABLE `delivery-queue`");
 			Logger::info('Optimize end');
 		}
 	}

--- a/src/Core/Worker/Cron.php
+++ b/src/Core/Worker/Cron.php
@@ -210,7 +210,7 @@ class Cron
 				Delivery::removeFailedQueue($delivery['gsid']);
 			}
 
-			if (($delivery['failed'] < 3) || GServer::reachableById($delivery['gsid'])) {
+			if (($delivery['failed'] < 3) || GServer::isReachableById($delivery['gsid'])) {
 				$priority = Worker::PRIORITY_HIGH;
 			} elseif ($delivery['failed'] < 6) {
 				$priority = Worker::PRIORITY_MEDIUM;

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1014,6 +1014,10 @@ class DFRN
 		$xml = $postResult->getBody();
 
 		$curl_stat = $postResult->getReturnCode();
+		if (!empty($contact['gsid']) && ($postResult->isTimeout() || empty($curl_stat))) {
+			GServer::setFailureById($contact['gsid']);
+		}
+
 		if (empty($curl_stat) || empty($xml)) {
 			Logger::notice('Empty answer from ' . $contact['id'] . ' - ' . $dest_url);
 			return -9; // timed out
@@ -1033,6 +1037,10 @@ class DFRN
 
 		if (empty($res->status)) {
 			return -23;
+		}
+
+		if (!empty($contact['gsid'])) {
+			GServer::setReachableById($contact['gsid']);
 		}
 
 		if (!empty($res->message)) {

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2955,6 +2955,12 @@ class Diaspora
 			return 200;
 		}
 
+		if (!empty($contact['gsid']) && (empty($return_code) || $postResult->isTimeout())) {
+			GServer::setFailureById($contact['gsid']);
+		} elseif (!empty($contact['gsid']) && ($return_code >= 200) && ($return_code <= 299)) {
+			GServer::setReachableById($contact['gsid']);
+		}
+
 		Logger::notice('transmit: ' . $logid . '-' . $guid . ' to ' . $dest_url . ' returns: ' . $return_code);
 
 		return $return_code ? $return_code : -1;

--- a/src/Worker/BulkDelivery.php
+++ b/src/Worker/BulkDelivery.php
@@ -41,7 +41,7 @@ class BulkDelivery
 			} else {
 				ProtocolDelivery::incrementFailedQueue($post['uri-id'], $post['gsid']);
 				$delivery_failure = true;
-		
+
 				if (!$server_failure) {
 					$server_failure = !GServer::reachableById($gsid);
 				}

--- a/src/Worker/BulkDelivery.php
+++ b/src/Worker/BulkDelivery.php
@@ -43,7 +43,7 @@ class BulkDelivery
 				$delivery_failure = true;
 
 				if (!$server_failure) {
-					$server_failure = !GServer::reachableById($gsid);
+					$server_failure = !GServer::isReachableById($gsid);
 				}
 				Logger::debug('Delivery failed', ['server_failure' => $server_failure, 'post' => $post]);
 			}

--- a/src/Worker/BulkDelivery.php
+++ b/src/Worker/BulkDelivery.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2022, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Worker;
+
+use Friendica\Core\Logger;
+use Friendica\Core\Worker;
+use Friendica\Model\GServer;
+use Friendica\Protocol\Delivery as ProtocolDelivery;
+
+class BulkDelivery
+{
+	public static function execute(int $gsid)
+	{
+		$server_failure   = false;
+		$delivery_failure = false;
+
+		$posts = ProtocolDelivery::selectQueueForServer($gsid);
+		foreach ($posts as $post) {
+			if (!$server_failure && ProtocolDelivery::deliver($post['command'], $post['uri-id'], $post['cid'], $post['uid'])) {
+				ProtocolDelivery::removeQueue($post['uri-id'], $post['gsid']);
+				Logger::debug('Delivery successful', $post);
+			} else {
+				ProtocolDelivery::incrementFailedQueue($post['uri-id'], $post['gsid']);
+				$delivery_failure = true;
+		
+				if (!$server_failure) {
+					$server_failure = !GServer::reachableById($gsid);
+				}
+				Logger::debug('Delivery failed', ['server_failure' => $server_failure, 'post' => $post]);
+			}
+		}
+
+		if ($server_failure) {
+			Worker::defer();
+		}
+
+		if ($delivery_failure) {
+			ProtocolDelivery::removeFailedQueue($gsid);
+		}
+	}
+}

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -570,8 +570,7 @@ class Notifier
 			} elseif (!DI::config()->get('system', 'bulk_delivery')) {
 				$reachable = !GServer::reachableById($contact['gsid']);
 			} else {
-				// On bulk delivery we don't check the server status at this point
-				$reachable = true;
+				$reachable = !GServer::defunct($contact['gsid']);
 			}
 
 			if (!$reachable) {

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -568,9 +568,9 @@ class Notifier
 			if (empty($contact['gsid'])) {
 				$reachable = !GServer::reachable($contact);
 			} elseif (!DI::config()->get('system', 'bulk_delivery')) {
-				$reachable = !GServer::reachableById($contact['gsid']);
+				$reachable = !GServer::isReachableById($contact['gsid']);
 			} else {
-				$reachable = !GServer::defunct($contact['gsid']);
+				$reachable = !GServer::isDefunctById($contact['gsid']);
 			}
 
 			if (!$reachable) {

--- a/src/Worker/UpdateGServer.php
+++ b/src/Worker/UpdateGServer.php
@@ -43,18 +43,18 @@ class UpdateGServer
 
 		$filtered = filter_var($server_url, FILTER_SANITIZE_URL);
 		if (substr(Strings::normaliseLink($filtered), 0, 7) != 'http://') {
-			GServer::setFailure($server_url);
+			GServer::setFailureByUrl($server_url);
 			return;
 		}
 
 		if (($filtered != $server_url) && DBA::exists('gserver', ['nurl' => Strings::normaliseLink($server_url)])) {
-			GServer::setFailure($server_url);
+			GServer::setFailureByUrl($server_url);
 			return;
 		}
 
 		$cleaned = GServer::cleanURL($server_url);
 		if (($cleaned != $server_url) && DBA::exists('gserver', ['nurl' => Strings::normaliseLink($server_url)])) {
-			GServer::setFailure($server_url);
+			GServer::setFailureByUrl($server_url);
 			return;
 		}
 

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1505);
+	define('DB_UPDATE_VERSION', 1506);
 }
 
 return [
@@ -636,6 +636,24 @@ return [
 			"PRIMARY" => ["id"],
 			"uid_uri" => ["UNIQUE", "uid", "uri(190)"],
 			"wid" => ["wid"],
+		]
+	],
+	"delivery-queue" => [
+		"comment" => "Delivery data for posts for the batch processing",
+		"fields" => [
+			"gsid" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["gserver" => "id", "on delete" => "restrict"], "comment" => "Global Server ID"],
+			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
+			"created" => ["type" => "datetime", "comment" => ""],
+			"command" => ["type" => "varbinary(32)", "comment" => ""],
+			"cid" => ["type" => "int unsigned", "foreign" => ["contact" => "id"], "comment" => "contact_id (ID of the contact in contact table)"],
+			"uid" => ["type" => "mediumint unsigned", "foreign" => ["user" => "uid"], "comment" => "Delivering user"],
+			"failed" => ["type" => "tinyint", "default" => 0, "comment" => "Number of times the delivery has failed"],
+		],
+		"indexes" => [
+			"PRIMARY" => ["uri-id", "gsid"],
+			"gsid_created" => ["gsid", "created"],
+			"uid" => ["uid"],
+			"cid" => ["cid"],
 		]
 	],
 	"diaspora-contact" => [

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -641,11 +641,11 @@ return [
 	"delivery-queue" => [
 		"comment" => "Delivery data for posts for the batch processing",
 		"fields" => [
-			"gsid" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["gserver" => "id", "on delete" => "restrict"], "comment" => "Global Server ID"],
-			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
+			"gsid" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["gserver" => "id", "on delete" => "restrict"], "comment" => "Target server"],
+			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Delivered post"],
 			"created" => ["type" => "datetime", "comment" => ""],
 			"command" => ["type" => "varbinary(32)", "comment" => ""],
-			"cid" => ["type" => "int unsigned", "foreign" => ["contact" => "id"], "comment" => "contact_id (ID of the contact in contact table)"],
+			"cid" => ["type" => "int unsigned", "foreign" => ["contact" => "id"], "comment" => "Target contact"],
 			"uid" => ["type" => "mediumint unsigned", "foreign" => ["user" => "uid"], "comment" => "Delivering user"],
 			"failed" => ["type" => "tinyint", "default" => 0, "comment" => "Number of times the delivery has failed"],
 		],


### PR DESCRIPTION
We now can deliver posts for all protocols per server in a single task.  This massively reduces the overhead when there are several posts for a single server.