### PR TITLE
The inbox-status can now be archived for a whole server

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2023.03-dev (Giant Rhubarb)
--- DB_UPDATE_VERSION 1506
+-- DB_UPDATE_VERSION 1507
 -- ------------------------------------------
 
 
@@ -824,6 +824,7 @@ CREATE TABLE IF NOT EXISTS `inbox-entry-receiver` (
 CREATE TABLE IF NOT EXISTS `inbox-status` (
 	`url` varbinary(383) NOT NULL COMMENT 'URL of the inbox',
 	`uri-id` int unsigned COMMENT 'Item-uri id of inbox url',
+	`gsid` int unsigned COMMENT 'ID of the related server',
 	`created` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'Creation date of this entry',
 	`success` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'Date of the last successful delivery',
 	`failure` datetime NOT NULL DEFAULT '0001-01-01 00:00:00' COMMENT 'Date of the last failed delivery',
@@ -832,7 +833,9 @@ CREATE TABLE IF NOT EXISTS `inbox-status` (
 	`shared` boolean NOT NULL DEFAULT '0' COMMENT 'Is it a shared inbox?',
 	 PRIMARY KEY(`url`),
 	 INDEX `uri-id` (`uri-id`),
-	FOREIGN KEY (`uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
+	 INDEX `gsid` (`gsid`),
+	FOREIGN KEY (`uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,
+	FOREIGN KEY (`gsid`) REFERENCES `gserver` (`id`) ON UPDATE RESTRICT ON DELETE RESTRICT
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Status of ActivityPub inboxes';
 
 --

--- a/doc/database/db_inbox-status.md
+++ b/doc/database/db_inbox-status.md
@@ -10,6 +10,7 @@ Fields
 | -------- | ------------------------------------ | -------------- | ---- | --- | ------------------- | ----- |
 | url      | URL of the inbox                     | varbinary(383) | NO   | PRI | NULL                |       |
 | uri-id   | Item-uri id of inbox url             | int unsigned   | YES  |     | NULL                |       |
+| gsid     | ID of the related server             | int unsigned   | YES  |     | NULL                |       |
 | created  | Creation date of this entry          | datetime       | NO   |     | 0001-01-01 00:00:00 |       |
 | success  | Date of the last successful delivery | datetime       | NO   |     | 0001-01-01 00:00:00 |       |
 | failure  | Date of the last failed delivery     | datetime       | NO   |     | 0001-01-01 00:00:00 |       |
@@ -24,6 +25,7 @@ Indexes
 | ------- | ------ |
 | PRIMARY | url    |
 | uri-id  | uri-id |
+| gsid    | gsid   |
 
 Foreign Keys
 ------------
@@ -31,5 +33,6 @@ Foreign Keys
 | Field | Target Table | Target Field |
 |-------|--------------|--------------|
 | uri-id | [item-uri](help/database/db_item-uri) | id |
+| gsid | [gserver](help/database/db_gserver) | id |
 
 Return to [database documentation](help/database)

--- a/src/Core/Worker/Cron.php
+++ b/src/Core/Worker/Cron.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (C) 2010-2022, the Friendica project
+ * @copyright Copyright (C) 2010-2023, the Friendica project
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/src/Core/Worker/Cron.php
+++ b/src/Core/Worker/Cron.php
@@ -192,6 +192,8 @@ class Cron
 			}
 		}
 
+		DBA::close($deliveries);
+
 		// Optimizing this table only last seconds
 		if (DI::config()->get('system', 'optimize_tables')) {
 			Logger::info('Optimize start');

--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (C) 2010-2022, the Friendica project
+ * @copyright Copyright (C) 2010-2023, the Friendica project
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -1224,7 +1224,8 @@ class PostUpdate
 			if (!empty($apcontact['sharedinbox'])) {
 				$inbox[] = $apcontact['sharedinbox'];
 			}
-			$condition = DBA::mergeConditions(['url' => $inbox], ["`gsid` IS NULL"]);
+//			$condition = DBA::mergeConditions(['url' => $inbox], ["`gsid` IS NULL"]);
+			$condition = ['url' => $inbox];
 			DBA::update('inbox-status', ['gsid' => $apcontact['gsid'], 'archive' => GServer::isDefunctById($apcontact['gsid'])], $condition);
 			++$rows;
 		}

--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -1225,7 +1225,7 @@ class PostUpdate
 				$inbox[] = $apcontact['sharedinbox'];
 			}
 			$condition = DBA::mergeConditions(['url' => $inbox], ["`gsid` IS NULL"]);
-			DBA::update('inbox-status', ['gsid' => $apcontact['gsid']], $condition);
+			DBA::update('inbox-status', ['gsid' => $apcontact['gsid'], 'archive' => GServer::isDefunctById($apcontact['gsid'])], $condition);
 			++$rows;
 		}
 		DBA::close($apcontacts);

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (C) 2010-2022, the Friendica project
+ * @copyright Copyright (C) 2010-2023, the Friendica project
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (C) 2010-2022, the Friendica project
+ * @copyright Copyright (C) 2010-2023, the Friendica project
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -408,7 +408,7 @@ class GServer
 			['nurl' => Strings::normaliseLink($url)]);
 			Logger::info('Set failed status for existing server', ['url' => $url]);
 			if (self::isDefunct($gserver)) {
-				Contact::update(['archive' => true], ['gsid' => $gserver['id']]);
+				self::archiveContacts($gserver['id']);
 			}
 			return;
 		}
@@ -416,6 +416,18 @@ class GServer
 			'network' => Protocol::PHANTOM, 'created' => DateTimeFormat::utcNow(),
 			'failed' => true, 'last_failure' => DateTimeFormat::utcNow()]);
 		Logger::info('Set failed status for new server', ['url' => $url]);
+	}
+
+	/**
+	 * Archive server related contacts and inboxes
+	 *
+	 * @param integer $gsid
+	 * @return void
+	 */
+	private static function archiveContacts(int $gsid)
+	{
+		Contact::update(['archive' => true], ['gsid' => $gsid]);
+		DBA::update('inbox-status', ['archive' => true], ['gsid' => $gsid]);
 	}
 
 	/**

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (C) 2010-2022, the Friendica project
+ * @copyright Copyright (C) 2010-2023, the Friendica project
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -332,15 +332,19 @@ class HTTPSignature
 	 * @param string  $url     The URL of the inbox
 	 * @param boolean $success Transmission status
 	 * @param boolean $shared  The inbox is a shared inbox
+	 * @param int     $gsid    Server ID
 	 * @throws \Exception
 	 */
-	static public function setInboxStatus(string $url, bool $success, bool $shared = false)
+	static public function setInboxStatus(string $url, bool $success, bool $shared = false, int $gsid = null)
 	{
 		$now = DateTimeFormat::utcNow();
 
 		$status = DBA::selectFirst('inbox-status', [], ['url' => $url]);
 		if (!DBA::isResult($status)) {
 			$insertFields = ['url' => $url, 'uri-id' => ItemURI::getIdByURI($url), 'created' => $now, 'shared' => $shared];
+			if (!empty($gsid)) {
+				$insertFields['gsid'] = $gsid;
+			}
 			if (!DBA::insert('inbox-status', $insertFields, Database::INSERT_IGNORE)) {
 				Logger::warning('Unable to insert inbox-status row', $insertFields);
 				return;
@@ -353,6 +357,10 @@ class HTTPSignature
 			$fields = ['success' => $now];
 		} else {
 			$fields = ['failure' => $now];
+		}
+
+		if (!empty($gsid)) {
+			$fields['gsid'] = $gsid;
 		}
 
 		if ($status['failure'] > DBA::NULL_DATETIME) {

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (C) 2010-2022, the Friendica project
+ * @copyright Copyright (C) 2010-2023, the Friendica project
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -816,7 +816,11 @@ class Notifier
 		}
 
 		// Fill the item cache
-		ActivityPub\Transmitter::createCachedActivityFromItem($target_item['id'], true);
+		$cache = ActivityPub\Transmitter::createCachedActivityFromItem($target_item['id'], true);
+		if (empty($cache)) {
+			Logger::info('Item cache was not created. The post will not be distributed.', ['id' => $target_item['id'], 'url' => $target_item['uri'], 'verb' => $target_item['verb']]);
+			return ['count' => 0, 'contacts' => []];
+		}
 
 		$delivery_queue_count = 0;
 		$contacts = [];

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (C) 2010-2022, the Friendica project
+ * @copyright Copyright (C) 2010-2023, the Friendica project
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1506);
+	define('DB_UPDATE_VERSION', 1507);
 }
 
 return [
@@ -872,6 +872,7 @@ return [
 		"fields" => [
 			"url" => ["type" => "varbinary(383)", "not null" => "1", "primary" => "1", "comment" => "URL of the inbox"],
 			"uri-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Item-uri id of inbox url"],
+			"gsid" => ["type" => "int unsigned", "foreign" => ["gserver" => "id", "on delete" => "restrict"], "comment" => "ID of the related server"],
 			"created" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "Creation date of this entry"],
 			"success" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "Date of the last successful delivery"],
 			"failure" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "Date of the last failed delivery"],
@@ -882,6 +883,7 @@ return [
 		"indexes" => [
 			"PRIMARY" => ["url"],
 			"uri-id" => ["uri-id"],
+			"gsid" => ["gsid"],
 		]
 	],
 	"intro" => [


### PR DESCRIPTION
The inbox status that had already been used to mark defunct inboxes is now improved by adding the server id. This enables us to mark inboxes of defunct servers as archived.