### PR TITLE
Set the server status directly after transmission

### DIFF
--- a/src/Core/Worker/Cron.php
+++ b/src/Core/Worker/Cron.php
@@ -164,18 +164,15 @@ class Cron
 	 */
 	private static function deliverAPPosts()
 	{
-		$deliveries = DBA::p("SELECT `item-uri`.`uri` AS `inbox`, MAX(`gsid`) AS `gsid`, MAX(`failed`) AS `failed` FROM `post-delivery` INNER JOIN `item-uri` ON `item-uri`.`id` = `post-delivery`.`inbox-id` LEFT JOIN `inbox-status` ON `inbox-status`.`url` = `item-uri`.`uri` GROUP BY `inbox` ORDER BY RAND()");
+		$deliveries = DBA::p("SELECT `item-uri`.`uri` AS `inbox`, MAX(`gsid`) AS `gsid`, MAX(`shared`) AS `shared`, MAX(`failed`) AS `failed` FROM `post-delivery` INNER JOIN `item-uri` ON `item-uri`.`id` = `post-delivery`.`inbox-id` LEFT JOIN `inbox-status` ON `inbox-status`.`url` = `item-uri`.`uri` GROUP BY `inbox` ORDER BY RAND()");
 		while ($delivery = DBA::fetch($deliveries)) {
 			if ($delivery['failed'] > 0) {
 				Logger::info('Removing failed deliveries', ['inbox' => $delivery['inbox'], 'failed' => $delivery['failed']]);
 				Post\Delivery::removeFailed($delivery['inbox']);
 			}
-			if (($delivery['failed'] == 0) && !empty($delivery['gsid']) && GServer::isReachableById($delivery['gsid'])) {
+			if (($delivery['failed'] == 0) && $delivery['shared'] && !empty($delivery['gsid']) && GServer::isReachableById($delivery['gsid'])) {
 				$result = ActivityPub\Delivery::deliver($delivery['inbox']);
 				Logger::info('Directly deliver inbox', ['inbox' => $delivery['inbox'], 'result' => $result['success']]);
-				if (!$result['success']) {
-					GServer::setFailureById($delivery['gsid']);
-				}
 				continue;
 			} elseif ($delivery['failed'] < 3) {
 				$priority = Worker::PRIORITY_HIGH;

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -360,13 +360,18 @@ class GServer
 	/**
 	 * Reset failed server status by gserver id
 	 *
-	 * @param int $gsid
+	 * @param int    $gsid
+	 * @param string $network
 	 */
-	public static function setReachableById(int $gsid)
+	public static function setReachableById(int $gsid, string $network)
 	{
-		$gserver = DBA::selectFirst('gserver', ['url', 'failed', 'next_contact'], ['id' => $gsid]);
+		$gserver = DBA::selectFirst('gserver', ['url', 'failed', 'next_contact', 'network'], ['id' => $gsid]);
 		if (DBA::isResult($gserver) && $gserver['failed']) {
-			self::update(['failed' => false, 'last_contact' => DateTimeFormat::utcNow()], ['id' => $gsid]);
+			$fields = ['failed' => false, 'last_contact' => DateTimeFormat::utcNow()];
+			if (!empty($network) && !in_array($gserver['network'], Protocol::FEDERATED)) {
+				$fields['network'] = $network;
+			}
+			self::update($fields, ['id' => $gsid]);
 			Logger::info('Reset failed status for server', ['url' => $gserver['url']]);
 
 			if (strtotime($gserver['next_contact']) < time()) {

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1040,7 +1040,7 @@ class DFRN
 		}
 
 		if (!empty($contact['gsid'])) {
-			GServer::setReachableById($contact['gsid']);
+			GServer::setReachableById($contact['gsid'], Protocol::DFRN);
 		}
 
 		if (!empty($res->message)) {

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2958,7 +2958,7 @@ class Diaspora
 		if (!empty($contact['gsid']) && (empty($return_code) || $postResult->isTimeout())) {
 			GServer::setFailureById($contact['gsid']);
 		} elseif (!empty($contact['gsid']) && ($return_code >= 200) && ($return_code <= 299)) {
-			GServer::setReachableById($contact['gsid']);
+			GServer::setReachableById($contact['gsid'], Protocol::DIASPORA);
 		}
 
 		Logger::notice('transmit: ' . $logid . '-' . $guid . ' to ' . $dest_url . ' returns: ' . $return_code);

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -22,11 +22,13 @@
 namespace Friendica\Util;
 
 use Friendica\Core\Logger;
+use Friendica\Core\Protocol;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\APContact;
 use Friendica\Model\Contact;
+use Friendica\Model\GServer;
 use Friendica\Model\ItemURI;
 use Friendica\Model\User;
 use Friendica\Network\HTTPClient\Capability\ICanHandleHttpResponses;
@@ -398,6 +400,14 @@ class HTTPSignature
 		}
 
 		DBA::update('inbox-status', $fields, ['url' => $url]);
+
+		if (!empty($status['gsid'])) {
+			if ($success) {
+				GServer::setReachableById($status['gsid'], Protocol::ACTIVITYPUB);
+			} elseif ($status['shared']) {
+				GServer::setFailureById($status['gsid']);
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Since we now have connected the inboxes with the servers, we can directly set a server to "reachable" when an AP transmission was successful (and vice versa). Also we now set the network when the current server entry is invalid.