### PR TITLE
`node.config.php` bugfixings

### DIFF
--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -82,6 +82,10 @@ $dice = $dice->addRule(LoggerInterface::class,['constructParams' => ['auth_ejabb
 
 \Friendica\DI::init($dice);
 \Friendica\Core\Logger\Handler\ErrorHandler::register($dice->create(\Psr\Log\LoggerInterface::class));
+
+// Check the database structure and possibly fixes it
+\Friendica\Core\Update::check(\Friendica\DI::basePath(), true, \Friendica\DI::mode());
+
 $appMode = $dice->create(Mode::class);
 
 if ($appMode->isNormal()) {

--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -84,7 +84,7 @@ $dice = $dice->addRule(LoggerInterface::class,['constructParams' => ['auth_ejabb
 \Friendica\Core\Logger\Handler\ErrorHandler::register($dice->create(\Psr\Log\LoggerInterface::class));
 
 // Check the database structure and possibly fixes it
-\Friendica\Core\Update::check(\Friendica\DI::basePath(), true, \Friendica\DI::mode());
+\Friendica\Core\Update::check(\Friendica\DI::basePath(), true);
 
 $appMode = $dice->create(Mode::class);
 

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -33,6 +33,7 @@ if (php_sapi_name() !== 'cli') {
 use Dice\Dice;
 use Friendica\App\Mode;
 use Friendica\Core\Logger;
+use Friendica\Core\Update;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
@@ -192,6 +193,9 @@ $last_cron = 0;
 
 // Now running as a daemon.
 while (true) {
+	// Check the database structure and possibly fixes it
+	Update::check(DI::basePath(), true);
+
 	if (!$do_cron && ($last_cron + $wait_interval) < time()) {
 		Logger::info('Forcing cron worker call.', ['pid' => $pid]);
 		$do_cron = true;

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -33,7 +33,6 @@ if (php_sapi_name() !== 'cli') {
 use Dice\Dice;
 use Friendica\App\Mode;
 use Friendica\Core\Logger;
-use Friendica\Core\Update;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
@@ -64,9 +63,6 @@ $dice = $dice->addRule(LoggerInterface::class,['constructParams' => ['daemon']])
 
 DI::init($dice);
 \Friendica\Core\Logger\Handler\ErrorHandler::register($dice->create(\Psr\Log\LoggerInterface::class));
-
-// Check the database structure and possibly fixes it
-Update::check(DI::basePath(), true, DI::mode());
 
 if (DI::mode()->isInstall()) {
 	die("Friendica isn't properly installed yet.\n");

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -33,6 +33,7 @@ if (php_sapi_name() !== 'cli') {
 use Dice\Dice;
 use Friendica\App\Mode;
 use Friendica\Core\Logger;
+use Friendica\Core\Update;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
@@ -63,7 +64,9 @@ $dice = $dice->addRule(LoggerInterface::class,['constructParams' => ['daemon']])
 
 DI::init($dice);
 \Friendica\Core\Logger\Handler\ErrorHandler::register($dice->create(\Psr\Log\LoggerInterface::class));
-$a = DI::app();
+
+// Check the database structure and possibly fixes it
+Update::check(DI::basePath(), true, DI::mode());
 
 if (DI::mode()->isInstall()) {
 	die("Friendica isn't properly installed yet.\n");

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -58,12 +58,11 @@ $dice = $dice->addRule(LoggerInterface::class,['constructParams' => ['worker']])
 
 DI::init($dice);
 \Friendica\Core\Logger\Handler\ErrorHandler::register($dice->create(\Psr\Log\LoggerInterface::class));
-$a = DI::app();
 
 DI::mode()->setExecutor(Mode::WORKER);
 
 // Check the database structure and possibly fixes it
-Update::check($a->getBasePath(), true, DI::mode());
+Update::check(DI::basePath(), true, DI::mode());
 
 // Quit when in maintenance
 if (!DI::mode()->has(App\Mode::MAINTENANCEDISABLED)) {

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -62,7 +62,7 @@ DI::init($dice);
 DI::mode()->setExecutor(Mode::WORKER);
 
 // Check the database structure and possibly fixes it
-Update::check(DI::basePath(), true, DI::mode());
+Update::check(DI::basePath(), true);
 
 // Quit when in maintenance
 if (!DI::mode()->has(App\Mode::MAINTENANCEDISABLED)) {

--- a/index.php
+++ b/index.php
@@ -37,7 +37,7 @@ $dice = $dice->addRule(Friendica\App\Mode::class, ['call' => [['determineRunMode
 \Friendica\Core\Logger\Handler\ErrorHandler::register($dice->create(\Psr\Log\LoggerInterface::class));
 
 // Check the database structure and possibly fixes it
-\Friendica\Core\Update::check(\Friendica\DI::basePath(), true, \Friendica\DI::mode());
+\Friendica\Core\Update::check(\Friendica\DI::basePath(), true);
 
 $a = \Friendica\DI::app();
 

--- a/index.php
+++ b/index.php
@@ -36,9 +36,6 @@ $dice = $dice->addRule(Friendica\App\Mode::class, ['call' => [['determineRunMode
 
 \Friendica\Core\Logger\Handler\ErrorHandler::register($dice->create(\Psr\Log\LoggerInterface::class));
 
-// Check the database structure and possibly fixes it
-\Friendica\Core\Update::check(\Friendica\DI::basePath(), true);
-
 $a = \Friendica\DI::app();
 
 \Friendica\DI::mode()->setExecutor(\Friendica\App\Mode::INDEX);

--- a/index.php
+++ b/index.php
@@ -36,6 +36,9 @@ $dice = $dice->addRule(Friendica\App\Mode::class, ['call' => [['determineRunMode
 
 \Friendica\Core\Logger\Handler\ErrorHandler::register($dice->create(\Psr\Log\LoggerInterface::class));
 
+// Check the database structure and possibly fixes it
+\Friendica\Core\Update::check(\Friendica\DI::basePath(), true, \Friendica\DI::mode());
+
 $a = \Friendica\DI::app();
 
 \Friendica\DI::mode()->setExecutor(\Friendica\App\Mode::INDEX);

--- a/src/App.php
+++ b/src/App.php
@@ -359,7 +359,7 @@ class App
 			$this->profiler->update($this->config);
 
 			Core\Hook::loadHooks();
-			$loader = (new Config())->createConfigFileLoader($this->getBasePath(), $_SERVER);
+			$loader = (new Config())->createConfigFileManager($this->getBasePath(), $_SERVER);
 			Core\Hook::callAll('load_config', $loader);
 
 			// Hooks are now working, reload the whole definitions with hook enabled

--- a/src/App.php
+++ b/src/App.php
@@ -659,7 +659,7 @@ class App
 				$this->baseURL->redirect('install');
 			} else {
 				$this->checkURL();
-				Core\Update::check($this->getBasePath(), false, $this->mode);
+				Core\Update::check($this->getBasePath(), false);
 				Core\Addon::loadAddons();
 				Core\Hook::loadHooks();
 			}

--- a/src/Core/Config/Factory/Config.php
+++ b/src/Core/Config/Factory/Config.php
@@ -56,7 +56,7 @@ class Config
 	 *
 	 * @return Util\ConfigFileManager
 	 */
-	public function createConfigFileLoader(string $basePath, array $server = []): Util\ConfigFileManager
+	public function createConfigFileManager(string $basePath, array $server = []): Util\ConfigFileManager
 	{
 		if (!empty($server[self::CONFIG_DIR_ENV]) && is_dir($server[self::CONFIG_DIR_ENV])) {
 			$configDir = $server[self::CONFIG_DIR_ENV];
@@ -65,19 +65,18 @@ class Config
 		}
 		$staticDir = $basePath . DIRECTORY_SEPARATOR . self::STATIC_DIR;
 
-		return new Util\ConfigFileManager($basePath, $configDir, $staticDir, new Util\ConfigFileTransformer());
+		return new Util\ConfigFileManager($basePath, $configDir, $staticDir, $server);
 	}
 
 	/**
 	 * @param Util\ConfigFileManager $configFileManager The Config Cache manager (INI/config/.htconfig)
-	 * @param array                  $server
 	 *
 	 * @return Cache
 	 */
-	public function createCache(Util\ConfigFileManager $configFileManager, array $server = []): Cache
+	public function createCache(Util\ConfigFileManager $configFileManager): Cache
 	{
 		$configCache = new Cache();
-		$configFileManager->setupCache($configCache, $server);
+		$configFileManager->setupCache($configCache);
 
 		return $configCache;
 	}

--- a/src/Core/Config/Model/Config.php
+++ b/src/Core/Config/Model/Config.php
@@ -39,19 +39,14 @@ class Config implements IManageConfigValues
 	/** @var ConfigFileManager */
 	protected $configFileManager;
 
-	/** @var array */
-	protected $server;
-
 	/**
 	 * @param ConfigFileManager $configFileManager The configuration file manager to save back configs
 	 * @param Cache             $configCache       The configuration cache (based on the config-files)
-	 * @param array             $server            The $_SERVER variable
 	 */
-	public function __construct(ConfigFileManager $configFileManager, Cache $configCache, array $server = [])
+	public function __construct(ConfigFileManager $configFileManager, Cache $configCache)
 	{
 		$this->configFileManager = $configFileManager;
 		$this->configCache       = $configCache;
-		$this->server            = $server;
 	}
 
 	/**
@@ -87,7 +82,7 @@ class Config implements IManageConfigValues
 		$configCache = new Cache();
 
 		try {
-			$this->configFileManager->setupCache($configCache, $this->server);
+			$this->configFileManager->setupCache($configCache);
 		} catch (ConfigFileException $e) {
 			throw new ConfigPersistenceException('Cannot reload config', $e);
 		}

--- a/src/Core/Config/Model/Config.php
+++ b/src/Core/Config/Model/Config.php
@@ -116,7 +116,7 @@ class Config implements IManageConfigValues
 	/** {@inheritDoc} */
 	public function delete(string $cat, string $key): bool
 	{
-		if ($this->configCache->delete($cat, $key)) {
+		if ($this->configCache->delete($cat, $key, Cache::SOURCE_DATA)) {
 			$this->save();
 			return true;
 		} else {

--- a/src/Core/Config/Util/ConfigFileManager.php
+++ b/src/Core/Config/Util/ConfigFileManager.php
@@ -203,7 +203,7 @@ class ConfigFileManager
 	}
 
 	/**
-	 * Saves overridden config entries back into the data.config.phpR
+	 * Saves overridden config entries back into the data.config.php
 	 *
 	 * @param Cache $configCache The config cache
 	 *

--- a/src/Core/Config/Util/ConfigFileManager.php
+++ b/src/Core/Config/Util/ConfigFileManager.php
@@ -257,12 +257,13 @@ class ConfigFileManager
 					// When reading the config file too fast, we get a wrong filesize, "clearstatcache" prevents that
 					clearstatcache(true, $filename);
 					$content = fread($configStream, filesize($filename));
-					// Event truncating the whole content wouldn't automatically rewind the stream,
-					// so we need to do it manually
-					rewind($configStream);
 					if (!$content) {
 						throw new ConfigFileException(sprintf('Cannot read file %s', $filename));
 					}
+
+					// Event truncating the whole content wouldn't automatically rewind the stream,
+					// so we need to do it manually
+					rewind($configStream);
 
 					$dataArray = eval('?>' . $content);
 
@@ -279,7 +280,6 @@ class ConfigFileManager
 				$data = $configCache->getDataBySource(Cache::SOURCE_DATA);
 
 				$encodedData = ConfigFileTransformer::encode($data);
-
 				if (!$encodedData) {
 					throw new ConfigFileException('config source cannot get encoded');
 				}

--- a/src/Core/Config/Util/ConfigFileManager.php
+++ b/src/Core/Config/Util/ConfigFileManager.php
@@ -203,11 +203,12 @@ class ConfigFileManager
 			}
 
 			/**
-			 * Evaluate the fetched content
+			 * Evaluate the content string as PHP code
+			 *
+			 * @see https://www.php.net/manual/en/function.eval.php
 			 *
 			 * @note
-			 * Because `eval()` directly evaluates PHP content, we need to "close" the expected PHP content again with
-			 * the prefixed "?>". Now we're in plain HTML again and can evaluate any PHP file :-)
+			 * To leave the PHP mode, we have to use the appropriate PHP tags '?>' as prefix.
 			 */
 			$dataArray = eval('?>' . $content);
 

--- a/src/Core/Config/Util/ConfigFileManager.php
+++ b/src/Core/Config/Util/ConfigFileManager.php
@@ -250,7 +250,7 @@ class ConfigFileManager
 			if (flock($configStream, LOCK_EX)) {
 
 				/**
-				 * If the file exists, read the whole file again
+				 * If the file exists, we read the whole file again to avoid a race condition with concurrent threads that could have modified the file between the first config read of this thread and now
 				 * Since we're currently exclusive locked, no other process can now change the config again
 				 */
 				if ($fileExists) {

--- a/src/Core/Config/Util/ConfigFileTransformer.php
+++ b/src/Core/Config/Util/ConfigFileTransformer.php
@@ -34,7 +34,6 @@ class ConfigFileTransformer
 		$categories = array_keys($data);
 
 		foreach ($categories as $category) {
-
 			if (is_null($data[$category])) {
 				$dataString .= "\t'$category' => null," . PHP_EOL;
 				continue;

--- a/src/Core/Config/Util/ConfigFileTransformer.php
+++ b/src/Core/Config/Util/ConfigFileTransformer.php
@@ -34,6 +34,12 @@ class ConfigFileTransformer
 		$categories = array_keys($data);
 
 		foreach ($categories as $category) {
+
+			if (is_null($data[$category])) {
+				$dataString .= "\t'$category' => null," . PHP_EOL;
+				continue;
+			}
+
 			$dataString .= "\t'$category' => [" . PHP_EOL;
 
 			if (is_array($data[$category])) {
@@ -66,7 +72,9 @@ class ConfigFileTransformer
 	{
 		$string = str_repeat("\t", $level + 2) . "'$key' => ";
 
-		if (is_array($value)) {
+		if (is_null($value)) {
+			$string .= "null,";
+		} elseif (is_array($value)) {
 			$string .= "[" . PHP_EOL;
 			$string .= static::extractArray($value, ++$level);
 			$string .= str_repeat("\t", $level + 1) . '],';

--- a/src/Core/Config/ValueObject/Cache.php
+++ b/src/Core/Config/ValueObject/Cache.php
@@ -182,7 +182,7 @@ class Cache
 		if ($this->hidePasswordOutput &&
 			$key == 'password' &&
 			is_string($value)) {
-			$this->setCatKeyValueSource($cat, $key, new HiddenString((string)$value), $source);
+			$this->setCatKeyValueSource($cat, $key, new HiddenString($value), $source);
 		} else if (is_string($value)) {
 			$this->setCatKeyValueSource($cat, $key, self::toConfigValue($value), $source);
 		} else {

--- a/src/Core/Config/ValueObject/Cache.php
+++ b/src/Core/Config/ValueObject/Cache.php
@@ -65,7 +65,7 @@ class Cache
 	 * @param bool  $hidePasswordOutput True, if cache variables should take extra care of password values
 	 * @param int   $source             Sets a source of the initial config values
 	 */
-	public function __construct(array $config = [], bool $hidePasswordOutput = true, $source = self::SOURCE_DEFAULT)
+	public function __construct(array $config = [], bool $hidePasswordOutput = true, int $source = self::SOURCE_DEFAULT)
 	{
 		$this->hidePasswordOutput = $hidePasswordOutput;
 		$this->load($config, $source);
@@ -87,11 +87,10 @@ class Cache
 				$keys = array_keys($config[$category]);
 
 				foreach ($keys as $key) {
-					$value = $config[$category][$key];
-					if (isset($value)) {
-						$this->set($category, $key, $value, $source);
-					}
+					$this->set($category, $key, $config[$category][$key] ?? null, $source);
 				}
+			} else {
+				$this->set($category, null, $config[$category], $source);
 			}
 		}
 	}
@@ -150,6 +149,8 @@ class Cache
 						$data[$category][$key] = $this->config[$category][$key];
 					}
 				}
+			} elseif (is_int($this->source[$category])) {
+				$data[$category] = null;
 			}
 		}
 
@@ -159,38 +160,47 @@ class Cache
 	/**
 	 * Sets a value in the config cache. Accepts raw output from the config table
 	 *
-	 * @param string $cat    Config category
-	 * @param string $key    Config key
-	 * @param mixed  $value  Value to set
-	 * @param int    $source The source of the current config key
+	 * @param string  $cat    Config category
+	 * @param ?string $key    Config key
+	 * @param ?mixed  $value  Value to set
+	 * @param int     $source The source of the current config key
 	 *
 	 * @return bool True, if the value is set
 	 */
-	public function set(string $cat, string $key, $value, int $source = self::SOURCE_DEFAULT): bool
+	public function set(string $cat, string $key = null, $value = null, int $source = self::SOURCE_DEFAULT): bool
 	{
-		if (!isset($this->config[$cat])) {
+		if (!isset($this->config[$cat]) && $key !== null) {
 			$this->config[$cat] = [];
 			$this->source[$cat] = [];
 		}
 
-		if (isset($this->source[$cat][$key]) &&
-			$source < $this->source[$cat][$key]) {
+		if ((isset($this->source[$cat][$key]) && $source < $this->source[$cat][$key]) ||
+			(is_int($this->source[$cat] ?? null) && $source < $this->source[$cat])) {
 			return false;
 		}
 
 		if ($this->hidePasswordOutput &&
 			$key == 'password' &&
 			is_string($value)) {
-			$this->config[$cat][$key] = new HiddenString((string)$value);
+			$this->setCatKeyValueSource($cat, $key, new HiddenString((string)$value), $source);
 		} else if (is_string($value)) {
-			$this->config[$cat][$key] = self::toConfigValue($value);
+			$this->setCatKeyValueSource($cat, $key, self::toConfigValue($value), $source);
 		} else {
-			$this->config[$cat][$key] = $value;
+			$this->setCatKeyValueSource($cat, $key, $value, $source);
 		}
 
-		$this->source[$cat][$key] = $source;
-
 		return true;
+	}
+
+	private function setCatKeyValueSource(string $cat, string $key = null, $value = null, int $source = self::SOURCE_DEFAULT)
+	{
+		if (isset($key)) {
+			$this->config[$cat][$key] = $value;
+			$this->source[$cat][$key] = $source;
+		} else {
+			$this->config[$cat] = $value;
+			$this->source[$cat] = $source;
+		}
 	}
 
 	/**
@@ -222,24 +232,27 @@ class Cache
 	/**
 	 * Deletes a value from the config cache.
 	 *
-	 * @param string $cat Config category
-	 * @param string $key Config key
+	 * @param string  $cat Config category
+	 * @param ?string $key Config key (if not set, the whole category will get deleted)
+	 * @param int     $source The source of the current config key
 	 *
 	 * @return bool true, if deleted
 	 */
-	public function delete(string $cat, string $key): bool
+	public function delete(string $cat, string $key = null, int $source = self::SOURCE_DEFAULT): bool
 	{
 		if (isset($this->config[$cat][$key])) {
-			unset($this->config[$cat][$key]);
-			unset($this->source[$cat][$key]);
-			if (count($this->config[$cat]) == 0) {
-				unset($this->config[$cat]);
-				unset($this->source[$cat]);
+			$this->config[$cat][$key] = null;
+			$this->source[$cat][$key] = $source;
+			if (empty(array_filter($this->config[$cat], function($value) { return !is_null($value); }))) {
+				$this->config[$cat] = null;
+				$this->source[$cat] = $source;
 			}
-			return true;
-		} else {
-			return false;
+		} elseif (isset($this->config[$cat])) {
+			$this->config[$cat] = null;
+			$this->source[$cat] = $source;
 		}
+
+		return true;
 	}
 
 	/**
@@ -302,39 +315,9 @@ class Cache
 					$newConfig[$category][$key] = $cache->config[$category][$key];
 					$newSource[$category][$key] = $cache->source[$category][$key];
 				}
-			}
-		}
-
-		$newCache = new Cache();
-		$newCache->config = $newConfig;
-		$newCache->source = $newSource;
-
-		return $newCache;
-	}
-
-
-	/**
-	 * Diffs a new Cache into the existing one and returns the diffed Cache
-	 *
-	 * @param Cache $cache The cache, which should get deleted for the current Cache
-	 *
-	 * @return Cache The diffed Cache
-	 */
-	public function diff(Cache $cache): Cache
-	{
-		$newConfig = $this->config;
-		$newSource = $this->source;
-
-		$categories = array_keys($cache->config);
-
-		foreach ($categories as $category) {
-			if (is_array($cache->config[$category])) {
-				$keys = array_keys($cache->config[$category]);
-
-				foreach ($keys as $key) {
-					unset($newConfig[$category][$key]);
-					unset($newSource[$category][$key]);
-				}
+			} else {
+				$newConfig[$category] = $cache->config[$category];
+				$newSource[$category] = $cache->source[$category];
 			}
 		}
 

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -61,8 +61,18 @@ class Update
 		$build = DI::config()->get('system', 'build');
 
 		if (empty($build)) {
-			DI::config()->set('system', 'build', DB_UPDATE_VERSION - 1);
-			$build = DB_UPDATE_VERSION - 1;
+			// legacy option - check if there's something in the Config table
+			if (DBStructure::existsTable('config')) {
+				$dbConfig = DBA::selectFirst('config', ['v'], ['cat' => 'system', 'k' => 'build']);
+				if (!empty($dbConfig)) {
+					$build = $dbConfig['v'];
+				}
+			}
+
+			if (empty($build)) {
+				DI::config()->set('system', 'build', DB_UPDATE_VERSION - 1);
+				$build = DB_UPDATE_VERSION - 1;
+			}
 		}
 
 		// We don't support upgrading from very old versions anymore
@@ -119,11 +129,21 @@ class Update
 			DI::lock()->release('dbupdate', true);
 		}
 
-		$build = DI::config()->get('system', 'build', null);
+		$build = DI::config()->get('system', 'build');
 
-		if (empty($build) || ($build > DB_UPDATE_VERSION)) {
-			$build = DB_UPDATE_VERSION - 1;
-			DI::config()->set('system', 'build', $build);
+		if (empty($build)) {
+			// legacy option - check if there's something in the Config table
+			if (DBStructure::existsTable('config')) {
+				$dbConfig = DBA::selectFirst('config', ['v'], ['cat' => 'system', 'k' => 'build']);
+				if (!empty($dbConfig)) {
+					$build = $dbConfig['v'];
+				}
+			}
+
+			if (empty($build) || ($build > DB_UPDATE_VERSION)) {
+				DI::config()->set('system', 'build', DB_UPDATE_VERSION - 1);
+				$build = DB_UPDATE_VERSION - 1;
+			}
 		}
 
 		if ($build != DB_UPDATE_VERSION || $force) {
@@ -141,7 +161,15 @@ class Update
 					Logger::notice('Update starting.', ['from' => $stored, 'to' => $current]);
 
 					// Checks if the build changed during Lock acquiring (so no double update occurs)
-					$retryBuild = DI::config()->get('system', 'build', null);
+					$retryBuild = DI::config()->get('system', 'build');
+					// legacy option - check if there's something in the Config table
+					if (DBStructure::existsTable('config')) {
+						$dbConfig = DBA::selectFirst('config', ['v'], ['cat' => 'system', 'k' => 'build']);
+						if (!empty($dbConfig)) {
+							$retryBuild = $dbConfig['v'];
+						}
+					}
+
 					if ($retryBuild !== $build) {
 						Logger::notice('Update already done.', ['from' => $stored, 'to' => $current]);
 						DI::lock()->release('dbupdate');

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -162,14 +162,6 @@ class Update
 
 					// Checks if the build changed during Lock acquiring (so no double update occurs)
 					$retryBuild = DI::config()->get('system', 'build');
-					// legacy option - check if there's something in the Config table
-					if (DBStructure::existsTable('config')) {
-						$dbConfig = DBA::selectFirst('config', ['v'], ['cat' => 'system', 'k' => 'build']);
-						if (!empty($dbConfig)) {
-							$retryBuild = $dbConfig['v'];
-						}
-					}
-
 					if ($retryBuild !== $build) {
 						Logger::notice('Update already done.', ['from' => $stored, 'to' => $current]);
 						DI::lock()->release('dbupdate');

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -47,7 +47,7 @@ class Update
 	 * @return void
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function check(string $basePath, bool $via_worker, App\Mode $mode)
+	public static function check(string $basePath, bool $via_worker)
 	{
 		if (!DBA::connected()) {
 			return;

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1315,8 +1315,8 @@ class Worker
 			return $added;
 		}
 
-		// Quit on daemon mode
-		if (Worker\Daemon::isMode()) {
+		// Quit on daemon mode, except the priority is critical (like for db updates)
+		if (Worker\Daemon::isMode() && $priority !== self::PRIORITY_CRITICAL) {
 			return $added;
 		}
 

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -154,7 +154,7 @@ class Summary extends BaseAdmin
 		}
 
 		// check legacy basepath settings
-		$configLoader = (new Config())->createConfigFileLoader($a->getBasePath(), $_SERVER);
+		$configLoader = (new Config())->createConfigFileManager($a->getBasePath(), $_SERVER);
 		$configCache = new Cache();
 		$configLoader->setupCache($configCache);
 		$confBasepath = $configCache->get('system', 'basepath');

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -79,7 +79,7 @@ return [
 	Config\Util\ConfigFileManager::class => [
 		'instanceOf' => Config\Factory\Config::class,
 		'call'       => [
-			['createConfigFileLoader', [
+			['createConfigFileManager', [
 				[Dice::INSTANCE => '$basepath'],
 				$_SERVER,
 			], Dice::CHAIN_CALL],
@@ -88,7 +88,7 @@ return [
 	Config\ValueObject\Cache::class => [
 		'instanceOf' => Config\Factory\Config::class,
 		'call'       => [
-			['createCache', [$_SERVER], Dice::CHAIN_CALL],
+			['createCache', [], Dice::CHAIN_CALL],
 		],
 	],
 	App\Mode::class              => [

--- a/tests/FixtureTest.php
+++ b/tests/FixtureTest.php
@@ -62,7 +62,7 @@ abstract class FixtureTest extends DatabaseTest
 			->addRules(include __DIR__ . '/../static/dependencies.config.php')
 			->addRule(ConfigFileManager::class, [
 				'instanceOf' => Config::class,
-				'call'       => [['createConfigFileLoader', [$this->root->url(), $server,],
+				'call'       => [['createConfigFileManager', [$this->root->url(), $server,],
 								  Dice::CHAIN_CALL]]])
 			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
 			->addRule(IHandleSessions::class, ['instanceOf' => Memory::class, 'shared' => true, 'call' => null])

--- a/tests/src/Core/Cache/DatabaseCacheTest.php
+++ b/tests/src/Core/Cache/DatabaseCacheTest.php
@@ -54,11 +54,11 @@ class DatabaseCacheTest extends CacheTest
 		$profiler->shouldReceive('saveTimestamp')->withAnyArgs()->andReturn(true);
 
 		// load real config to avoid mocking every config-entry which is related to the Database class
-		$configFactory = new Config();
-		$loader = (new Config())->createConfigFileLoader($this->root->url(), []);
-		$configCache = $configFactory->createCache($loader);
+		$configFactory     = new Config();
+		$configFileManager = (new Config())->createConfigFileManager($this->root->url(), []);
+		$configCache       = $configFactory->createCache($configFileManager);
 
-		$dbaDefinition = (new DbaDefinition($configCache->get('system', 'basepath')))->load();
+		$dbaDefinition  = (new DbaDefinition($configCache->get('system', 'basepath')))->load();
 		$viewDefinition = (new ViewDefinition($configCache->get('system', 'basepath')))->load();
 
 		$dba = new StaticDatabase($configCache, $profiler, $dbaDefinition, $viewDefinition);

--- a/tests/src/Core/Config/Cache/CacheTest.php
+++ b/tests/src/Core/Config/Cache/CacheTest.php
@@ -67,8 +67,6 @@ class CacheTest extends MockedTest
 		$configCache = new Cache();
 		$configCache->load($data);
 
-		print_r($configCache);
-
 		self::assertConfigValues($data, $configCache);
 	}
 

--- a/tests/src/Core/Config/Cache/ConfigFileManagerTest.php
+++ b/tests/src/Core/Config/Cache/ConfigFileManagerTest.php
@@ -51,6 +51,7 @@ class ConfigFileManagerTest extends MockedTest
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::CONFIG_DIR,
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::STATIC_DIR
 		);
+
 		$configCache = new Cache();
 
 		$configFileLoader->setupCache($configCache);
@@ -69,15 +70,15 @@ class ConfigFileManagerTest extends MockedTest
 		$this->delConfigFile('local.config.php');
 
 		vfsStream::newFile('local.config.php')
-			->at($this->root->getChild('config'))
-			->setContent('<?php return true;');
+				 ->at($this->root->getChild('config'))
+				 ->setContent('<?php return true;');
 
 		$configFileLoader = new ConfigFileManager(
 			$this->root->url(),
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::CONFIG_DIR,
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::STATIC_DIR
 		);
-		$configCache = new Cache();
+		$configCache      = new Cache();
 
 		$configFileLoader->setupCache($configCache);
 	}
@@ -90,23 +91,23 @@ class ConfigFileManagerTest extends MockedTest
 		$this->delConfigFile('local.config.php');
 
 		$file = dirname(__DIR__) . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'datasets' . DIRECTORY_SEPARATOR .
-			'config' . DIRECTORY_SEPARATOR .
-			'A.config.php';
+				'..' . DIRECTORY_SEPARATOR .
+				'..' . DIRECTORY_SEPARATOR .
+				'..' . DIRECTORY_SEPARATOR .
+				'datasets' . DIRECTORY_SEPARATOR .
+				'config' . DIRECTORY_SEPARATOR .
+				'A.config.php';
 
 		vfsStream::newFile('local.config.php')
-			->at($this->root->getChild('config'))
-			->setContent(file_get_contents($file));
+				 ->at($this->root->getChild('config'))
+				 ->setContent(file_get_contents($file));
 
 		$configFileLoader = new ConfigFileManager(
 			$this->root->url(),
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::CONFIG_DIR,
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::STATIC_DIR
 		);
-		$configCache = new Cache();
+		$configCache      = new Cache();
 
 		$configFileLoader->setupCache($configCache);
 
@@ -127,23 +128,23 @@ class ConfigFileManagerTest extends MockedTest
 		$this->delConfigFile('local.config.php');
 
 		$file = dirname(__DIR__) . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'datasets' . DIRECTORY_SEPARATOR .
-			'config' . DIRECTORY_SEPARATOR .
-			'A.ini.php';
+				'..' . DIRECTORY_SEPARATOR .
+				'..' . DIRECTORY_SEPARATOR .
+				'..' . DIRECTORY_SEPARATOR .
+				'datasets' . DIRECTORY_SEPARATOR .
+				'config' . DIRECTORY_SEPARATOR .
+				'A.ini.php';
 
 		vfsStream::newFile('local.ini.php')
-			->at($this->root->getChild('config'))
-			->setContent(file_get_contents($file));
+				 ->at($this->root->getChild('config'))
+				 ->setContent(file_get_contents($file));
 
 		$configFileLoader = new ConfigFileManager(
 			$this->root->url(),
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::CONFIG_DIR,
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::STATIC_DIR
 		);
-		$configCache = new Cache();
+		$configCache      = new Cache();
 
 		$configFileLoader->setupCache($configCache);
 
@@ -163,23 +164,23 @@ class ConfigFileManagerTest extends MockedTest
 		$this->delConfigFile('local.config.php');
 
 		$file = dirname(__DIR__) . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'datasets' . DIRECTORY_SEPARATOR .
-			'config' . DIRECTORY_SEPARATOR .
-			'.htconfig.php';
+				'..' . DIRECTORY_SEPARATOR .
+				'..' . DIRECTORY_SEPARATOR .
+				'..' . DIRECTORY_SEPARATOR .
+				'datasets' . DIRECTORY_SEPARATOR .
+				'config' . DIRECTORY_SEPARATOR .
+				'.htconfig.php';
 
 		vfsStream::newFile('.htconfig.php')
-			->at($this->root)
-			->setContent(file_get_contents($file));
+				 ->at($this->root)
+				 ->setContent(file_get_contents($file));
 
 		$configFileLoader = new ConfigFileManager(
 			$this->root->url(),
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::CONFIG_DIR,
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::STATIC_DIR
 		);
-		$configCache = new Cache();
+		$configCache      = new Cache();
 
 		$configFileLoader->setupCache($configCache);
 
@@ -217,16 +218,16 @@ class ConfigFileManagerTest extends MockedTest
 		vfsStream::create($structure, $this->root);
 
 		$file = dirname(__DIR__) . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'..' . DIRECTORY_SEPARATOR .
-			'datasets' . DIRECTORY_SEPARATOR .
-			'config' . DIRECTORY_SEPARATOR .
-			'A.config.php';
+				'..' . DIRECTORY_SEPARATOR .
+				'..' . DIRECTORY_SEPARATOR .
+				'..' . DIRECTORY_SEPARATOR .
+				'datasets' . DIRECTORY_SEPARATOR .
+				'config' . DIRECTORY_SEPARATOR .
+				'A.config.php';
 
 		vfsStream::newFile('test.config.php')
-			->at($this->root->getChild('addon')->getChild('test')->getChild('config'))
-			->setContent(file_get_contents($file));
+				 ->at($this->root->getChild('addon')->getChild('test')->getChild('config'))
+				 ->setContent(file_get_contents($file));
 
 		$configFileLoader = new ConfigFileManager(
 			$this->root->url(),
@@ -252,25 +253,25 @@ class ConfigFileManagerTest extends MockedTest
 		$this->delConfigFile('local.config.php');
 
 		$fileDir = dirname(__DIR__) . DIRECTORY_SEPARATOR .
-		        '..' . DIRECTORY_SEPARATOR .
-			   '..' . DIRECTORY_SEPARATOR .
-		        '..' . DIRECTORY_SEPARATOR .
-		        'datasets' . DIRECTORY_SEPARATOR .
-		        'config' . DIRECTORY_SEPARATOR;
+				   '..' . DIRECTORY_SEPARATOR .
+				   '..' . DIRECTORY_SEPARATOR .
+				   '..' . DIRECTORY_SEPARATOR .
+				   'datasets' . DIRECTORY_SEPARATOR .
+				   'config' . DIRECTORY_SEPARATOR;
 
 		vfsStream::newFile('A.config.php')
-		         ->at($this->root->getChild('config'))
-		         ->setContent(file_get_contents($fileDir . 'A.config.php'));
+				 ->at($this->root->getChild('config'))
+				 ->setContent(file_get_contents($fileDir . 'A.config.php'));
 		vfsStream::newFile('B.config.php')
-				->at($this->root->getChild('config'))
-		         ->setContent(file_get_contents($fileDir . 'B.config.php'));
+				 ->at($this->root->getChild('config'))
+				 ->setContent(file_get_contents($fileDir . 'B.config.php'));
 
 		$configFileLoader = new ConfigFileManager(
 			$this->root->url(),
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::CONFIG_DIR,
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::STATIC_DIR
 		);
-		$configCache = new Cache();
+		$configCache      = new Cache();
 
 		$configFileLoader->setupCache($configCache);
 
@@ -286,25 +287,25 @@ class ConfigFileManagerTest extends MockedTest
 		$this->delConfigFile('local.config.php');
 
 		$fileDir = dirname(__DIR__) . DIRECTORY_SEPARATOR .
-		           '..' . DIRECTORY_SEPARATOR .
-		           '..' . DIRECTORY_SEPARATOR .
 				   '..' . DIRECTORY_SEPARATOR .
-		           'datasets' . DIRECTORY_SEPARATOR .
-		           'config' . DIRECTORY_SEPARATOR;
+				   '..' . DIRECTORY_SEPARATOR .
+				   '..' . DIRECTORY_SEPARATOR .
+				   'datasets' . DIRECTORY_SEPARATOR .
+				   'config' . DIRECTORY_SEPARATOR;
 
 		vfsStream::newFile('A.ini.php')
-		         ->at($this->root->getChild('config'))
-		         ->setContent(file_get_contents($fileDir . 'A.ini.php'));
+				 ->at($this->root->getChild('config'))
+				 ->setContent(file_get_contents($fileDir . 'A.ini.php'));
 		vfsStream::newFile('B.ini.php')
-		         ->at($this->root->getChild('config'))
-		         ->setContent(file_get_contents($fileDir . 'B.ini.php'));
+				 ->at($this->root->getChild('config'))
+				 ->setContent(file_get_contents($fileDir . 'B.ini.php'));
 
 		$configFileLoader = new ConfigFileManager(
 			$this->root->url(),
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::CONFIG_DIR,
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::STATIC_DIR
 		);
-		$configCache = new Cache();
+		$configCache      = new Cache();
 
 		$configFileLoader->setupCache($configCache);
 
@@ -320,24 +321,25 @@ class ConfigFileManagerTest extends MockedTest
 		$this->delConfigFile('local.config.php');
 
 		$fileDir = dirname(__DIR__) . DIRECTORY_SEPARATOR .
-		           '..' . DIRECTORY_SEPARATOR .
 				   '..' . DIRECTORY_SEPARATOR .
-		           '..' . DIRECTORY_SEPARATOR .
-		           'datasets' . DIRECTORY_SEPARATOR .
-		           'config' . DIRECTORY_SEPARATOR;
+				   '..' . DIRECTORY_SEPARATOR .
+				   '..' . DIRECTORY_SEPARATOR .
+				   'datasets' . DIRECTORY_SEPARATOR .
+				   'config' . DIRECTORY_SEPARATOR;
 
 		vfsStream::newFile('A.ini.php')
-		         ->at($this->root->getChild('config'))
-		         ->setContent(file_get_contents($fileDir . 'A.ini.php'));
+				 ->at($this->root->getChild('config'))
+				 ->setContent(file_get_contents($fileDir . 'A.ini.php'));
 		vfsStream::newFile('B-sample.ini.php')
-		         ->at($this->root->getChild('config'))
-		         ->setContent(file_get_contents($fileDir . 'B.ini.php'));
+				 ->at($this->root->getChild('config'))
+				 ->setContent(file_get_contents($fileDir . 'B.ini.php'));
 
 		$configFileLoader = new ConfigFileManager(
 			$this->root->url(),
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::CONFIG_DIR,
 			$this->root->url() . DIRECTORY_SEPARATOR . Config::STATIC_DIR
 		);
+
 		$configCache = new Cache();
 
 		$configFileLoader->setupCache($configCache);
@@ -353,10 +355,10 @@ class ConfigFileManagerTest extends MockedTest
 	{
 		$this->delConfigFile('local.config.php');
 
-		$configFileLoader = (new Config())->createConfigFileLoader($this->root->url(), ['FRIENDICA_CONFIG_DIR' => '/a/wrong/dir/']);
-		$configCache = new Cache();
+		$configFileManager = (new Config())->createConfigFileManager($this->root->url(), ['FRIENDICA_CONFIG_DIR' => '/a/wrong/dir/']);
+		$configCache       = new Cache();
 
-		$configFileLoader->setupCache($configCache);
+		$configFileManager->setupCache($configCache);
 
 		self::assertEquals($this->root->url(), $configCache->get('system', 'basepath'));
 	}
@@ -379,10 +381,13 @@ class ConfigFileManagerTest extends MockedTest
 				 ->at($this->root->getChild('config2'))
 				 ->setContent(file_get_contents($fileDir . 'B.config.php'));
 
-		$configFileLoader = (new Config())->createConfigFileLoader($this->root->url(), ['FRIENDICA_CONFIG_DIR' => $this->root->getChild('config2')->url()]);
-		$configCache = new Cache();
+		$configFileManager = (new Config())->createConfigFileManager($this->root->url(),
+			[
+				'FRIENDICA_CONFIG_DIR' => $this->root->getChild('config2')->url(),
+			]);
+		$configCache       = new Cache();
 
-		$configFileLoader->setupCache($configCache);
+		$configFileManager->setupCache($configCache);
 
 		self::assertEquals('newValue', $configCache->get('system', 'newKey'));
 	}
@@ -402,10 +407,13 @@ class ConfigFileManagerTest extends MockedTest
 				 ->at($this->root->getChild('config2'))
 				 ->setContent(file_get_contents($fileDir . 'B.config.php'));
 
-		$configFileLoader = (new Config())->createConfigFileLoader($this->root->url(), ['FRIENDICA_CONFIG_DIR' => $this->root->getChild('config2')->url()]);
-		$configCache = new Cache();
+		$configFileManager = (new Config())->createConfigFileManager($this->root->url(),
+			[
+				'FRIENDICA_CONFIG_DIR' => $this->root->getChild('config2')->url(),
+			]);
+		$configCache       = new Cache();
 
-		$configFileLoader->setupCache($configCache);
+		$configFileManager->setupCache($configCache);
 
 		$specialChars = '!"§$%&/()(/&%$\'><?$a,;:[]}{}\\?¿¿ß';
 
@@ -414,19 +422,19 @@ class ConfigFileManagerTest extends MockedTest
 		$configCache->set('config', 'test', 'it', Cache::SOURCE_DATA);
 		$configCache->set('system', 'test_2', 2, Cache::SOURCE_DATA);
 		$configCache->set('special_chars', 'special', $specialChars, Cache::SOURCE_DATA);
-		$configFileLoader->saveData($configCache);
+		$configFileManager->saveData($configCache);
 
 		// Reload the configCache with the new values
 		$configCache2 = new Cache();
-		$configFileLoader->setupCache($configCache2);
+		$configFileManager->setupCache($configCache2);
 
 		self::assertEquals($configCache, $configCache2);
 		self::assertEquals([
-			'system' => [
-				'test' => 'it',
+			'system'        => [
+				'test'   => 'it',
 				'test_2' => 2
 			],
-			'config' => [
+			'config'        => [
 				'test' => 'it',
 			],
 			'special_chars' => [

--- a/tests/src/Core/Config/Cache/ConfigFileManagerTest.php
+++ b/tests/src/Core/Config/Cache/ConfigFileManagerTest.php
@@ -441,4 +441,74 @@ class ConfigFileManagerTest extends MockedTest
 				'special' => $specialChars,
 			]], $configCache2->getDataBySource(Cache::SOURCE_DATA));
 	}
+
+	/**
+	 * If we delete something with the Cache::delete() functionality, be sure to override the underlying source as well
+	 */
+	public function testDeleteKeyOverwrite()
+	{
+		$this->delConfigFile('node.config.php');
+
+		$fileDir = dirname(__DIR__) . DIRECTORY_SEPARATOR .
+				   '..' . DIRECTORY_SEPARATOR .
+				   '..' . DIRECTORY_SEPARATOR .
+				   '..' . DIRECTORY_SEPARATOR .
+				   'datasets' . DIRECTORY_SEPARATOR .
+				   'config' . DIRECTORY_SEPARATOR;
+
+		vfsStream::newFile('B.config.php')
+				 ->at($this->root->getChild('config'))
+				 ->setContent(file_get_contents($fileDir . 'B.config.php'));
+
+		$configFileManager = (new Config())->createConfigFileManager($this->root->url());
+		$configCache       = new Cache();
+
+		$configFileManager->setupCache($configCache);
+
+		$configCache->delete('system', 'default_timezone', Cache::SOURCE_DATA);
+
+		$configFileManager->saveData($configCache);
+
+		// assert that system.default_timezone is now null, even it's set with settings.conf.php
+		$configCache       = new Cache();
+
+		$configFileManager->setupCache($configCache);
+
+		self::assertNull($configCache->get('system', 'default_timezone'));
+	}
+
+	/**
+	 * If we delete something with the Cache::delete() functionality, be sure to override the underlying source as well
+	 */
+	public function testDeleteCategoryOverwrite()
+	{
+		$this->delConfigFile('node.config.php');
+
+		$fileDir = dirname(__DIR__) . DIRECTORY_SEPARATOR .
+				   '..' . DIRECTORY_SEPARATOR .
+				   '..' . DIRECTORY_SEPARATOR .
+				   '..' . DIRECTORY_SEPARATOR .
+				   'datasets' . DIRECTORY_SEPARATOR .
+				   'config' . DIRECTORY_SEPARATOR;
+
+		vfsStream::newFile('B.config.php')
+				 ->at($this->root->getChild('config'))
+				 ->setContent(file_get_contents($fileDir . 'B.config.php'));
+
+		$configFileManager = (new Config())->createConfigFileManager($this->root->url());
+		$configCache       = new Cache();
+
+		$configFileManager->setupCache($configCache);
+
+		$configCache->delete('system');
+
+		$configFileManager->saveData($configCache);
+
+		// assert that system.default_timezone is now null, even it's set with settings.conf.php
+		$configCache       = new Cache();
+
+		$configFileManager->setupCache($configCache);
+
+		self::assertNull($configCache->get('system', 'default_timezone'));
+	}
 }

--- a/tests/src/Core/Config/ConfigTest.php
+++ b/tests/src/Core/Config/ConfigTest.php
@@ -364,7 +364,7 @@ class ConfigTest extends MockedTest
 		self::assertNull($this->testedConfig->get('test', 'it'));
 		self::assertNull($this->testedConfig->getCache()->get('test', 'it'));
 
-		self::assertEmpty($this->testedConfig->getCache()->getAll());
+		self::assertEquals(['test' => null], $this->testedConfig->getCache()->getAll());
 	}
 
 	/**

--- a/tests/src/Core/Config/ConfigTest.php
+++ b/tests/src/Core/Config/ConfigTest.php
@@ -76,7 +76,7 @@ class ConfigTest extends MockedTest
 	 */
 	public function getInstance()
 	{
-		$this->configFileManager->setupCache($this->configCache, []);
+		$this->configFileManager->setupCache($this->configCache);
 		return new Config($this->configFileManager, $this->configCache);
 	}
 

--- a/tests/src/Core/Config/ConfigTransactionTest.php
+++ b/tests/src/Core/Config/ConfigTransactionTest.php
@@ -1,4 +1,23 @@
 <?php
+/**
+ * @copyright Copyright (C) 2010-2023, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
 
 namespace Friendica\Test\src\Core\Config;
 

--- a/tests/src/Core/Config/ConfigTransactionTest.php
+++ b/tests/src/Core/Config/ConfigTransactionTest.php
@@ -54,10 +54,6 @@ class ConfigTransactionTest extends MockedTest
 		$config->set('delete', 'keyDel', 'catDel');
 
 		$configTransaction = new ConfigTransaction($config);
-		self::assertEquals('value1', $configTransaction->get('config', 'key1'));
-		self::assertEquals('value2', $configTransaction->get('system', 'key2'));
-		self::assertEquals('valueDel', $configTransaction->get('system', 'keyDel'));
-		self::assertEquals('catDel', $configTransaction->get('delete', 'keyDel'));
 		// the config file knows it as well immediately
 		$tempData = include $this->root->url() . '/config/' . ConfigFileManager::CONFIG_DATA_FILE;
 		self::assertEquals('value1', $tempData['config']['key1'] ?? null);
@@ -77,11 +73,6 @@ class ConfigTransactionTest extends MockedTest
 		self::assertEquals('value1', $config->get('config', 'key1'));
 		self::assertEquals('valueDel', $config->get('system', 'keyDel'));
 		self::assertEquals('catDel', $config->get('delete', 'keyDel'));
-		// but the transaction config of course knows it
-		self::assertEquals('value3', $configTransaction->get('transaction', 'key3'));
-		self::assertEquals('changedValue1', $configTransaction->get('config', 'key1'));
-		self::assertNull($configTransaction->get('system', 'keyDel'));
-		self::assertNull($configTransaction->get('delete', 'keyDel'));
 		// The config file still doesn't know it either
 		$tempData = include $this->root->url() . '/config/' . ConfigFileManager::CONFIG_DATA_FILE;
 		self::assertEquals('value1', $tempData['config']['key1'] ?? null);
@@ -97,9 +88,6 @@ class ConfigTransactionTest extends MockedTest
 		self::assertEquals('value3', $config->get('transaction', 'key3'));
 		self::assertNull($config->get('system', 'keyDel'));
 		self::assertNull($config->get('delete', 'keyDel'));
-		self::assertEquals('value3', $configTransaction->get('transaction', 'key3'));
-		self::assertEquals('changedValue1', $configTransaction->get('config', 'key1'));
-		self::assertNull($configTransaction->get('system', 'keyDel'));
 		$tempData = include $this->root->url() . '/config/' . ConfigFileManager::CONFIG_DATA_FILE;
 		self::assertEquals('changedValue1', $tempData['config']['key1'] ?? null);
 		self::assertEquals('value2', $tempData['system']['key2'] ?? null);

--- a/tests/src/Core/Storage/DatabaseStorageTest.php
+++ b/tests/src/Core/Storage/DatabaseStorageTest.php
@@ -53,11 +53,11 @@ class DatabaseStorageTest extends StorageTest
 		$profiler->shouldReceive('saveTimestamp')->withAnyArgs()->andReturn(true);
 
 		// load real config to avoid mocking every config-entry which is related to the Database class
-		$configFactory = new Config();
-		$loader        = (new Config())->createConfigFileLoader($this->root->url(), []);
-		$configCache   = $configFactory->createCache($loader);
+		$configFactory     = new Config();
+		$configFileManager = (new Config())->createConfigFileManager($this->root->url());
+		$configCache       = $configFactory->createCache($configFileManager);
 
-		$dbaDefinition = (new DbaDefinition($configCache->get('system', 'basepath')))->load();
+		$dbaDefinition  = (new DbaDefinition($configCache->get('system', 'basepath')))->load();
 		$viewDefinition = (new ViewDefinition($configCache->get('system', 'basepath')))->load();
 
 		$dba = new StaticDatabase($configCache, $profiler, $dbaDefinition, $viewDefinition);


### PR DESCRIPTION
This is a general bugfixing of the `Config` behavior. Most of them introduced by #12593 , but not all :-)
f.e. currently, deleting "just" resets the config to the static default value and doesn't "really" deletes the value.

I tested the whole upgrade path from `stable` to `develop` a few times.
This should solve #12616 and https://github.com/friendica/friendica/pull/12593#issuecomment-1372598717

I added unit tests for edge-cases too..

Now it will run at my node over the next ~12hours and I will check my logs again.