### PR TITLE
Fix loading empty node.config.php

### DIFF
--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -84,7 +84,7 @@ class Addon
 	public static function getAdminList(): array
 	{
 		$addons_admin = [];
-		$addons = DI::config()->get('addons') ?? [];
+		$addons = array_filter(DI::config()->get('addons') ?? []);
 
 		ksort($addons);
 		foreach ($addons as $name => $data) {
@@ -117,7 +117,7 @@ class Addon
 	 */
 	public static function loadAddons()
 	{
-		self::$addons = array_keys(DI::config()->get('addons') ?? []);
+		self::$addons = array_keys(array_filter(DI::config()->get('addons') ?? []));
 	}
 
 	/**
@@ -192,7 +192,7 @@ class Addon
 	 */
 	public static function reload()
 	{
-		$addons = DI::config()->get('addons') ?? [];
+		$addons = array_filter(DI::config()->get('addons') ?? []);
 
 		foreach ($addons as $name => $data) {
 			$addonname = Strings::sanitizeFilePathItem(trim($name));
@@ -315,7 +315,7 @@ class Addon
 	public static function getVisibleList(): array
 	{
 		$visible_addons = [];
-		$addons = DI::config()->get('addons') ?? [];
+		$addons = array_filter(DI::config()->get('addons') ?? []);
 
 		foreach ($addons as $name => $data) {
 			$visible_addons[] = $name;

--- a/src/Core/Config/Util/ConfigFileManager.php
+++ b/src/Core/Config/Util/ConfigFileManager.php
@@ -194,11 +194,13 @@ class ConfigFileManager
 
 			try {
 				if (flock($configStream, LOCK_SH)) {
+					clearstatcache(true, $filename);
+
 					if (($filesize = filesize($filename)) === 0) {
 						return;
 					}
 
-					$content = fread($configStream, filesize($filename));
+					$content = fread($configStream, $filesize);
 					if (!$content) {
 						throw new ConfigFileException(sprintf('Couldn\'t read file %s', $filename));
 					}

--- a/src/Core/Config/Util/ConfigFileManager.php
+++ b/src/Core/Config/Util/ConfigFileManager.php
@@ -177,7 +177,7 @@ class ConfigFileManager
 	{
 		$filename = $this->configDir . '/' . self::CONFIG_DATA_FILE;
 
-		if (file_exists($filename)) {
+		if (file_exists($filename) && (filesize($filename) > 0)) {
 
 			// The fallback empty return content
 			$content = '<?php return [];';
@@ -188,9 +188,16 @@ class ConfigFileManager
 			 *
 			 * Any exclusive locking (LOCK_EX) would need to wait until all LOCK_SHs are unlocked
 			 */
-			$configStream = fopen($filename, 'r');
+			if (($configStream = @fopen($filename, 'r')) === false) {
+				throw new ConfigFileException(sprintf('Cannot open file "%s" in mode r', $filename));
+			}
+
 			try {
 				if (flock($configStream, LOCK_SH)) {
+					if (($filesize = filesize($filename)) === 0) {
+						return;
+					}
+
 					$content = fread($configStream, filesize($filename));
 					if (!$content) {
 						throw new ConfigFileException(sprintf('Couldn\'t read file %s', $filename));

--- a/src/Core/Config/ValueObject/Cache.php
+++ b/src/Core/Config/ValueObject/Cache.php
@@ -283,7 +283,7 @@ class Cache
 				$keys = array_keys($config[$category]);
 
 				foreach ($keys as $key) {
-					if (!isset($this->config[$category][$key])) {
+					if (!key_exists($key, $this->config[$category] ?? [])) {
 						$return[$category][$key] = $config[$category][$key];
 					}
 				}

--- a/src/Core/Config/ValueObject/Cache.php
+++ b/src/Core/Config/ValueObject/Cache.php
@@ -311,6 +311,11 @@ class Cache
 			if (is_array($cache->config[$category])) {
 				$keys = array_keys($cache->config[$category]);
 
+				if (is_null($newConfig[$category] ?? null)) {
+					$newConfig[$category] = [];
+					$newSource[$category] = [];
+				}
+
 				foreach ($keys as $key) {
 					$newConfig[$category][$key] = $cache->config[$category][$key];
 					$newSource[$category][$key] = $cache->source[$category][$key];

--- a/tests/src/Core/Config/Cache/ConfigFileManagerTest.php
+++ b/tests/src/Core/Config/Cache/ConfigFileManagerTest.php
@@ -511,4 +511,23 @@ class ConfigFileManagerTest extends MockedTest
 
 		self::assertNull($configCache->get('system', 'default_timezone'));
 	}
+
+	/**
+	 * Test for empty node.config.php
+	 */
+	public function testEmptyFile()
+	{
+		$this->delConfigFile('node.config.php');
+
+		vfsStream::newFile('node.config.php')
+				 ->at($this->root->getChild('config'))
+				 ->setContent('');
+
+		$configFileManager = (new Config())->createConfigFileManager($this->root->url());
+		$configCache       = new Cache();
+
+		$configFileManager->setupCache($configCache);
+
+		self::assertEquals(1,1);
+	}
 }


### PR DESCRIPTION
Addresses https://github.com/friendica/friendica/issues/12486#issuecomment-1374637788

But tbh this isn't the root-cause
--> why is there a empty `node.config.php` file?
--> But at least during the update, the config file should be fully created 

[EDIT] -> yes I thought this whole config-file change would be much more smother than it currently is, sry @annando , @copiis for the inconvenience :-/