### PR TITLE
Replace remaining mentions of "Status" by "Conversations" or "Posts"

### DIFF
--- a/index.php
+++ b/index.php
@@ -45,6 +45,7 @@ $a->runFrontend(
 	$dice->create(\Friendica\Core\PConfig\Capability\IManagePersonalConfigValues::class),
 	$dice->create(\Friendica\Security\Authentication::class),
 	$dice->create(\Friendica\App\Page::class),
+	$dice->create(\Friendica\Content\Nav::class),
 	$dice->create(Friendica\Module\Special\HTTPException::class),
 	new \Friendica\Util\HTTPInputData($_SERVER),
 	$start_time

--- a/src/App.php
+++ b/src/App.php
@@ -25,6 +25,7 @@ use Exception;
 use Friendica\App\Arguments;
 use Friendica\App\BaseURL;
 use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Content\Nav;
 use Friendica\Core\Config\Factory\Config;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Database\Definition\DbaDefinition;
@@ -579,7 +580,7 @@ class App
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public function runFrontend(App\Router $router, IManagePersonalConfigValues $pconfig, Authentication $auth, App\Page $page, ModuleHTTPException $httpException, HTTPInputData $httpInput, float $start_time)
+	public function runFrontend(App\Router $router, IManagePersonalConfigValues $pconfig, Authentication $auth, App\Page $page, Nav $nav, ModuleHTTPException $httpException, HTTPInputData $httpInput, float $start_time)
 	{
 		$this->profiler->set($start_time, 'start');
 		$this->profiler->set(microtime(true), 'classinit');
@@ -718,7 +719,7 @@ class App
 			$response = $module->run($httpException, $input);
 			$this->profiler->set(microtime(true) - $timestamp, 'content');
 			if ($response->getHeaderLine(ICanCreateResponses::X_HEADER) === ICanCreateResponses::TYPE_HTML) {
-				$page->run($this, $this->baseURL, $this->args, $this->mode, $response, $this->l10n, $this->profiler, $this->config, $pconfig, $this->session->getLocalUserId());
+				$page->run($this, $this->baseURL, $this->args, $this->mode, $response, $this->l10n, $this->profiler, $this->config, $pconfig, $nav, $this->session->getLocalUserId());
 			} else {
 				$page->exit($response);
 			}

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -27,18 +27,18 @@ use DOMXPath;
 use Friendica\App;
 use Friendica\Content\Nav;
 use Friendica\Core\Config\Capability\IManageConfigValues;
-use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
+use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
 use Friendica\Core\Renderer;
 use Friendica\Core\System;
 use Friendica\Core\Theme;
 use Friendica\Module\Response;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Network;
-use Friendica\Util\Strings;
 use Friendica\Util\Profiler;
+use Friendica\Util\Strings;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -407,13 +407,16 @@ class Page implements ArrayAccess
 	 * @param Mode                        $mode     The current node mode
 	 * @param ResponseInterface           $response The Response of the module class, including type, content & headers
 	 * @param L10n                        $l10n     The l10n language class
+	 * @param Profiler                    $profiler
 	 * @param IManageConfigValues         $config   The Configuration of this node
 	 * @param IManagePersonalConfigValues $pconfig  The personal/user configuration
-	 * @param int                         $localUID The UID of the local user
-	 *
-	 * @throws HTTPException\InternalServerErrorException|HTTPException\ServiceUnavailableException
+	 * @param Nav                         $nav
+	 * @param int                         $localUID
+	 * @throws HTTPException\MethodNotAllowedException
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws HTTPException\ServiceUnavailableException
 	 */
-	public function run(App $app, BaseURL $baseURL, Arguments $args, Mode $mode, ResponseInterface $response, L10n $l10n, Profiler $profiler, IManageConfigValues $config, IManagePersonalConfigValues $pconfig, int $localUID)
+	public function run(App $app, BaseURL $baseURL, Arguments $args, Mode $mode, ResponseInterface $response, L10n $l10n, Profiler $profiler, IManageConfigValues $config, IManagePersonalConfigValues $pconfig, Nav $nav, int $localUID)
 	{
 		$moduleName = $args->getModuleName();
 
@@ -463,7 +466,7 @@ class Page implements ArrayAccess
 		// Add the navigation (menu) template
 		if ($moduleName != 'install' && $moduleName != 'maintenance') {
 			$this->page['htmlhead'] .= Renderer::replaceMacros(Renderer::getMarkupTemplate('nav_head.tpl'), []);
-			$this->page['nav']      = Nav::build($app);
+			$this->page['nav']      = $nav->getHtml();
 		}
 
 		foreach ($response->getHeaders() as $key => $header) {

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -21,15 +21,21 @@
 
 namespace Friendica\Content;
 
-use Friendica\App;
+use Friendica\App\BaseURL;
+use Friendica\App\Router;
+use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Hook;
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Core\Session\Capability\IHandleUserSessions;
+use Friendica\Database\Database;
 use Friendica\Model\Contact;
 use Friendica\Model\Profile;
 use Friendica\Model\User;
 use Friendica\Module\Conversation\Community;
+use Friendica\Module\Home;
+use Friendica\Module\Security\Login;
+use Friendica\Network\HTTPException;
 
 class Nav
 {
@@ -53,9 +59,32 @@ class Nav
 	/**
 	 * An array of HTML links provided by addons providing a module via the app_menu hook
 	 *
-	 * @var array
+	 * @var array|null
 	 */
-	private static $app_menu = null;
+	private $appMenu = null;
+
+	/** @var BaseURL */
+	private $baseUrl;
+	/** @var L10n */
+	private $l10n;
+	/** @var IHandleUserSessions */
+	private $session;
+	/** @var Database */
+	private $database;
+	/** @var IManageConfigValues */
+	private $config;
+	/** @var Router */
+	private $router;
+
+	public function __construct(BaseURL $baseUrl, L10n $l10n, IHandleUserSessions $session, Database $database, IManageConfigValues $config, Router $router)
+	{
+		$this->baseUrl  = $baseUrl;
+		$this->l10n     = $l10n;
+		$this->session  = $session;
+		$this->database = $database;
+		$this->config   = $config;
+		$this->router   = $router;
+	}
 
 	/**
 	 * Set a menu item in navbar as selected
@@ -70,16 +99,17 @@ class Nav
 	/**
 	 * Build page header and site navigation bars
 	 *
-	 * @param  App    $a
 	 * @return string
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws HTTPException\MethodNotAllowedException
+	 * @throws HTTPException\ServiceUnavailableException
 	 */
-	public static function build(App $a): string
+	public function getHtml(): string
 	{
 		// Placeholder div for popup panel
 		$nav = '<div id="panel" style="display: none;"></div>';
 
-		$nav_info = self::getInfo($a);
+		$nav_info = $this->getInfo();
 
 		$tpl = Renderer::getMarkupTemplate('nav.tpl');
 
@@ -87,13 +117,13 @@ class Nav
 			'$sitelocation' => $nav_info['sitelocation'],
 			'$nav'          => $nav_info['nav'],
 			'$banner'       => $nav_info['banner'],
-			'$emptynotifications' => DI::l10n()->t('Nothing new here'),
+			'$emptynotifications' => $this->l10n->t('Nothing new here'),
 			'$userinfo'     => $nav_info['userinfo'],
 			'$sel'          => self::$selected,
-			'$apps'         => self::getAppMenu(),
-			'$home'         => DI::l10n()->t('Go back'),
-			'$clear_notifs' => DI::l10n()->t('Clear notifications'),
-			'$search_hint'  => DI::l10n()->t('@name, !forum, #tags, content')
+			'$apps'         => $this->getAppMenu(),
+			'$home'         => $this->l10n->t('Go back'),
+			'$clear_notifs' => $this->l10n->t('Clear notifications'),
+			'$search_hint'  => $this->l10n->t('@name, !forum, #tags, content')
 		]);
 
 		Hook::callAll('page_header', $nav);
@@ -105,60 +135,66 @@ class Nav
 	 * Returns the addon app menu
 	 *
 	 * @return array
+	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public static function getAppMenu(): array
+	public function getAppMenu(): array
 	{
-		if (is_null(self::$app_menu)) {
-			self::populateAppMenu();
+		if (is_null($this->appMenu)) {
+			$this->appMenu = $this->populateAppMenu();
 		}
 
-		return self::$app_menu;
+		return $this->appMenu;
 	}
 
 	/**
-	 * Fills the apps static variable with apps that require a menu
+	 * Returns menus for apps that require one
 	 *
-	 * @return void
+	 * @return array
+	 * @throws HTTPException\InternalServerErrorException
 	 */
-	private static function populateAppMenu()
+	private function populateAppMenu(): array
 	{
-		self::$app_menu = [];
+		$appMenu = [];
 
 		//Don't populate apps_menu if apps are private
-		$privateapps = DI::config()->get('config', 'private_addons', false);
-		if (DI::userSession()->getLocalUserId() || !$privateapps) {
-			$arr = ['app_menu' => self::$app_menu];
+		if (
+			$this->session->getLocalUserId()
+			|| !$this->config->get('config', 'private_addons', false)
+		) {
+			$arr = ['app_menu' => $appMenu];
 
 			Hook::callAll('app_menu', $arr);
 
-			self::$app_menu = $arr['app_menu'];
+			$appMenu = $arr['app_menu'];
 		}
+
+		return $appMenu;
 	}
 
 	/**
 	 * Prepares a list of navigation links
 	 *
-	 * @param  App   $a
 	 * @return array Navigation links
 	 *    string 'sitelocation' => The webbie (username@site.com)
 	 *    array 'nav' => Array of links used in the nav menu
 	 *    string 'banner' => Formatted html link with banner image
 	 *    array 'userinfo' => Array of user information (name, icon)
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws HTTPException\MethodNotAllowedException
 	 */
-	private static function getInfo(App $a): array
+	private function getInfo(): array
 	{
-		$ssl_state = (bool) DI::userSession()->getLocalUserId();
+		$ssl_state = (bool) $this->session->getLocalUserId();
 
 		/*
-		 * Our network is distributed, and as you visit friends some of the
+		 * Our network is distributed, and as you visit friends some
 		 * sites look exactly the same - it isn't always easy to know where you are.
 		 * Display the current site location as a navigation aid.
 		 */
 
-		$myident = !empty($a->getLoggedInUserNickname()) ? $a->getLoggedInUserNickname() . '@' : '';
+		$myident = !empty($this->session->getLocalUserNickname()) ? $this->session->getLocalUserNickname() . '@' : '';
 
-		$sitelocation = $myident . substr(DI::baseUrl()->get($ssl_state), strpos(DI::baseUrl()->get($ssl_state), '//') + 2);
+		$sitelocation = $myident . substr($this->baseUrl->get($ssl_state), strpos($this->baseUrl->get($ssl_state), '//') + 2);
 
 		$nav = [
 			'admin'         => null,
@@ -182,23 +218,23 @@ class Nav
 		$userinfo = null;
 
 		// nav links: array of array('href', 'text', 'extra css classes', 'title')
-		if (DI::userSession()->isAuthenticated()) {
-			$nav['logout'] = ['logout', DI::l10n()->t('Logout'), '', DI::l10n()->t('End this session')];
+		if ($this->session->isAuthenticated()) {
+			$nav['logout'] = ['logout', $this->l10n->t('Logout'), '', $this->l10n->t('End this session')];
 		} else {
-			$nav['login'] = ['login', DI::l10n()->t('Login'), (DI::args()->getModuleName() == 'login' ? 'selected' : ''), DI::l10n()->t('Sign in')];
+			$nav['login'] = ['login', $this->l10n->t('Login'), ($this->router->getModuleClass() == Login::class ? 'selected' : ''), $this->l10n->t('Sign in')];
 		}
 
-		if ($a->isLoggedIn()) {
+		if ($this->session->isAuthenticated()) {
 			// user menu
-			$nav['usermenu'][] = ['profile/' . $a->getLoggedInUserNickname(), DI::l10n()->t('Status'), '', DI::l10n()->t('Your posts and conversations')];
-			$nav['usermenu'][] = ['profile/' . $a->getLoggedInUserNickname() . '/profile', DI::l10n()->t('Profile'), '', DI::l10n()->t('Your profile page')];
-			$nav['usermenu'][] = ['profile/' . $a->getLoggedInUserNickname() . '/photos', DI::l10n()->t('Photos'), '', DI::l10n()->t('Your photos')];
-			$nav['usermenu'][] = ['profile/' . $a->getLoggedInUserNickname() . '/media', DI::l10n()->t('Media'), '', DI::l10n()->t('Your postings with media')];
-			$nav['usermenu'][] = ['calendar/', DI::l10n()->t('Calendar'), '', DI::l10n()->t('Your calendar')];
-			$nav['usermenu'][] = ['notes/', DI::l10n()->t('Personal notes'), '', DI::l10n()->t('Your personal notes')];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Status'), '', $this->l10n->t('Your posts and conversations')];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('Your profile page')];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos')];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/media', $this->l10n->t('Media'), '', $this->l10n->t('Your postings with media')];
+			$nav['usermenu'][] = ['calendar/', $this->l10n->t('Calendar'), '', $this->l10n->t('Your calendar')];
+			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Your personal notes')];
 
 			// user info
-			$contact = DBA::selectFirst('contact', ['id', 'url', 'avatar', 'micro', 'name', 'nick', 'baseurl', 'updated'], ['uid' => $a->getLoggedInUserId(), 'self' => true]);
+			$contact = $this->database->selectFirst('contact', ['id', 'url', 'avatar', 'micro', 'name', 'nick', 'baseurl', 'updated'], ['uid' => $this->session->getLocalUserId(), 'self' => true]);
 			$userinfo = [
 				'icon' => Contact::getMicro($contact),
 				'name' => $contact['name'],
@@ -206,103 +242,103 @@ class Nav
 		}
 
 		// "Home" should also take you home from an authenticated remote profile connection
-		$homelink = Profile::getMyURL();
-		if (! $homelink) {
-			$homelink = DI::session()->get('visitor_home', '');
+		$homelink = $this->session->getMyUrl();
+		if (!$homelink) {
+			$homelink = $this->session->get('visitor_home', '');
 		}
 
-		if (DI::args()->getModuleName() != 'home' && ! DI::userSession()->getLocalUserId()) {
-			$nav['home'] = [$homelink, DI::l10n()->t('Home'), '', DI::l10n()->t('Home Page')];
+		if ($this->router->getModuleClass() != Home::class && !$this->session->getLocalUserId()) {
+			$nav['home'] = [$homelink, $this->l10n->t('Home'), '', $this->l10n->t('Home Page')];
 		}
 
-		if (intval(DI::config()->get('config', 'register_policy')) === \Friendica\Module\Register::OPEN && !DI::userSession()->isAuthenticated()) {
-			$nav['register'] = ['register', DI::l10n()->t('Register'), '', DI::l10n()->t('Create an account')];
+		if (intval($this->config->get('config', 'register_policy')) === \Friendica\Module\Register::OPEN && !$this->session->isAuthenticated()) {
+			$nav['register'] = ['register', $this->l10n->t('Register'), '', $this->l10n->t('Create an account')];
 		}
 
 		$help_url = 'help';
 
-		if (!DI::config()->get('system', 'hide_help')) {
-			$nav['help'] = [$help_url, DI::l10n()->t('Help'), '', DI::l10n()->t('Help and documentation')];
+		if (!$this->config->get('system', 'hide_help')) {
+			$nav['help'] = [$help_url, $this->l10n->t('Help'), '', $this->l10n->t('Help and documentation')];
 		}
 
-		if (count(self::getAppMenu()) > 0) {
-			$nav['apps'] = ['apps', DI::l10n()->t('Apps'), '', DI::l10n()->t('Addon applications, utilities, games')];
+		if (count($this->getAppMenu()) > 0) {
+			$nav['apps'] = ['apps', $this->l10n->t('Apps'), '', $this->l10n->t('Addon applications, utilities, games')];
 		}
 
-		if (DI::userSession()->getLocalUserId() || !DI::config()->get('system', 'local_search')) {
-			$nav['search'] = ['search', DI::l10n()->t('Search'), '', DI::l10n()->t('Search site content')];
+		if ($this->session->getLocalUserId() || !$this->config->get('system', 'local_search')) {
+			$nav['search'] = ['search', $this->l10n->t('Search'), '', $this->l10n->t('Search site content')];
 
 			$nav['searchoption'] = [
-				DI::l10n()->t('Full Text'),
-				DI::l10n()->t('Tags'),
-				DI::l10n()->t('Contacts')
+				$this->l10n->t('Full Text'),
+				$this->l10n->t('Tags'),
+				$this->l10n->t('Contacts')
 			];
 
-			if (DI::config()->get('system', 'poco_local_search')) {
-				$nav['searchoption'][] = DI::l10n()->t('Forums');
+			if ($this->config->get('system', 'poco_local_search')) {
+				$nav['searchoption'][] = $this->l10n->t('Forums');
 			}
 		}
 
 		$gdirpath = 'directory';
-		if (DI::config()->get('system', 'singleuser') && DI::config()->get('system', 'directory')) {
-			$gdirpath = Profile::zrl(DI::config()->get('system', 'directory'), true);
+		if ($this->config->get('system', 'singleuser') && $this->config->get('system', 'directory')) {
+			$gdirpath = Profile::zrl($this->config->get('system', 'directory'), true);
 		}
 
-		if ((DI::userSession()->getLocalUserId() || DI::config()->get('system', 'community_page_style') != Community::DISABLED_VISITOR) &&
-			!(DI::config()->get('system', 'community_page_style') == Community::DISABLED)) {
-			$nav['community'] = ['community', DI::l10n()->t('Community'), '', DI::l10n()->t('Conversations on this and other servers')];
+		if (($this->session->getLocalUserId() || $this->config->get('system', 'community_page_style') != Community::DISABLED_VISITOR) &&
+			!($this->config->get('system', 'community_page_style') == Community::DISABLED)) {
+			$nav['community'] = ['community', $this->l10n->t('Community'), '', $this->l10n->t('Conversations on this and other servers')];
 		}
 
-		if (DI::userSession()->getLocalUserId()) {
-			$nav['calendar'] = ['calendar', DI::l10n()->t('Calendar'), '', DI::l10n()->t('Calendar')];
+		if ($this->session->getLocalUserId()) {
+			$nav['calendar'] = ['calendar', $this->l10n->t('Calendar'), '', $this->l10n->t('Calendar')];
 		}
 
-		$nav['directory'] = [$gdirpath, DI::l10n()->t('Directory'), '', DI::l10n()->t('People directory')];
+		$nav['directory'] = [$gdirpath, $this->l10n->t('Directory'), '', $this->l10n->t('People directory')];
 
-		$nav['about'] = ['friendica', DI::l10n()->t('Information'), '', DI::l10n()->t('Information about this friendica instance')];
+		$nav['about'] = ['friendica', $this->l10n->t('Information'), '', $this->l10n->t('Information about this friendica instance')];
 
-		if (DI::config()->get('system', 'tosdisplay')) {
-			$nav['tos'] = ['tos', DI::l10n()->t('Terms of Service'), '', DI::l10n()->t('Terms of Service of this Friendica instance')];
+		if ($this->config->get('system', 'tosdisplay')) {
+			$nav['tos'] = ['tos', $this->l10n->t('Terms of Service'), '', $this->l10n->t('Terms of Service of this Friendica instance')];
 		}
 
-		// The following nav links are only show to logged in users
-		if (DI::userSession()->getLocalUserId() && !empty($a->getLoggedInUserNickname())) {
-			$nav['network'] = ['network', DI::l10n()->t('Network'), '', DI::l10n()->t('Conversations from your friends')];
+		// The following nav links are only show to logged-in users
+		if ($this->session->getLocalUserNickname()) {
+			$nav['network'] = ['network', $this->l10n->t('Network'), '', $this->l10n->t('Conversations from your friends')];
 
-			$nav['home'] = ['profile/' . $a->getLoggedInUserNickname(), DI::l10n()->t('Home'), '', DI::l10n()->t('Your posts and conversations')];
+			$nav['home'] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Home'), '', $this->l10n->t('Your posts and conversations')];
 
 			// Don't show notifications for public communities
-			if (DI::session()->get('page_flags', '') != User::PAGE_FLAGS_COMMUNITY) {
-				$nav['introductions'] = ['notifications/intros', DI::l10n()->t('Introductions'), '', DI::l10n()->t('Friend Requests')];
-				$nav['notifications'] = ['notifications',	DI::l10n()->t('Notifications'), '', DI::l10n()->t('Notifications')];
-				$nav['notifications']['all'] = ['notifications/system', DI::l10n()->t('See all notifications'), '', ''];
-				$nav['notifications']['mark'] = ['', DI::l10n()->t('Mark as seen'), '', DI::l10n()->t('Mark all system notifications as seen')];
+			if ($this->session->get('page_flags', '') != User::PAGE_FLAGS_COMMUNITY) {
+				$nav['introductions'] = ['notifications/intros', $this->l10n->t('Introductions'), '', $this->l10n->t('Friend Requests')];
+				$nav['notifications'] = ['notifications',	$this->l10n->t('Notifications'), '', $this->l10n->t('Notifications')];
+				$nav['notifications']['all'] = ['notifications/system', $this->l10n->t('See all notifications'), '', ''];
+				$nav['notifications']['mark'] = ['', $this->l10n->t('Mark as seen'), '', $this->l10n->t('Mark all system notifications as seen')];
 			}
 
-			$nav['messages'] = ['message', DI::l10n()->t('Messages'), '', DI::l10n()->t('Private mail')];
-			$nav['messages']['inbox'] = ['message', DI::l10n()->t('Inbox'), '', DI::l10n()->t('Inbox')];
-			$nav['messages']['outbox'] = ['message/sent', DI::l10n()->t('Outbox'), '', DI::l10n()->t('Outbox')];
-			$nav['messages']['new'] = ['message/new', DI::l10n()->t('New Message'), '', DI::l10n()->t('New Message')];
+			$nav['messages'] = ['message', $this->l10n->t('Messages'), '', $this->l10n->t('Private mail')];
+			$nav['messages']['inbox'] = ['message', $this->l10n->t('Inbox'), '', $this->l10n->t('Inbox')];
+			$nav['messages']['outbox'] = ['message/sent', $this->l10n->t('Outbox'), '', $this->l10n->t('Outbox')];
+			$nav['messages']['new'] = ['message/new', $this->l10n->t('New Message'), '', $this->l10n->t('New Message')];
 
-			if (User::hasIdentities(DI::userSession()->getSubManagedUserId() ?: DI::userSession()->getLocalUserId())) {
-				$nav['delegation'] = ['delegation', DI::l10n()->t('Accounts'), '', DI::l10n()->t('Manage other pages')];
+			if (User::hasIdentities($this->session->getSubManagedUserId() ?: $this->session->getLocalUserId())) {
+				$nav['delegation'] = ['delegation', $this->l10n->t('Accounts'), '', $this->l10n->t('Manage other pages')];
 			}
 
-			$nav['settings'] = ['settings', DI::l10n()->t('Settings'), '', DI::l10n()->t('Account settings')];
+			$nav['settings'] = ['settings', $this->l10n->t('Settings'), '', $this->l10n->t('Account settings')];
 
-			$nav['contacts'] = ['contact', DI::l10n()->t('Contacts'), '', DI::l10n()->t('Manage/edit friends and contacts')];
+			$nav['contacts'] = ['contact', $this->l10n->t('Contacts'), '', $this->l10n->t('Manage/edit friends and contacts')];
 		}
 
 		// Show the link to the admin configuration page if user is admin
-		if ($a->isSiteAdmin()) {
-			$nav['admin']      = ['admin/', DI::l10n()->t('Admin'), '', DI::l10n()->t('Site setup and configuration')];
-			$nav['moderation'] = ['moderation/', DI::l10n()->t('Moderation'), '', DI::l10n()->t('Content and user moderation')];
+		if ($this->session->isSiteAdmin()) {
+			$nav['admin']      = ['admin/', $this->l10n->t('Admin'), '', $this->l10n->t('Site setup and configuration')];
+			$nav['moderation'] = ['moderation/', $this->l10n->t('Moderation'), '', $this->l10n->t('Content and user moderation')];
 		}
 
-		$nav['navigation'] = ['navigation/', DI::l10n()->t('Navigation'), '', DI::l10n()->t('Site map')];
+		$nav['navigation'] = ['navigation/', $this->l10n->t('Navigation'), '', $this->l10n->t('Site map')];
 
 		// Provide a banner/logo/whatever
-		$banner = DI::config()->get('system', 'banner');
+		$banner = $this->config->get('system', 'banner');
 		if (is_null($banner)) {
 			$banner = '<a href="https://friendi.ca"><img id="logo-img" width="32" height="32" src="images/friendica.svg" alt="logo" /></a><span id="logo-text"><a href="https://friendi.ca">Friendica</a></span>';
 		}

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -226,7 +226,7 @@ class Nav
 
 		if ($this->session->isAuthenticated()) {
 			// user menu
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Status'), '', $this->l10n->t('Your posts and conversations')];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Conversations'), '', $this->l10n->t('Conversations you started')];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('Your profile page')];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos')];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/media', $this->l10n->t('Media'), '', $this->l10n->t('Your postings with media')];

--- a/src/Module/Apps.php
+++ b/src/Module/Apps.php
@@ -22,13 +22,13 @@
 namespace Friendica\Module;
 
 use Friendica\App;
-use Friendica\App\BaseURL;
 use Friendica\BaseModule;
 use Friendica\Content\Nav;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Core\Session\Capability\IHandleUserSessions;
+use Friendica\Navigation\SystemMessages;
 use Friendica\Util\Profiler;
 use Psr\Log\LoggerInterface;
 
@@ -37,22 +37,29 @@ use Psr\Log\LoggerInterface;
  */
 class Apps extends BaseModule
 {
-	public function __construct(L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IManageConfigValues $config, array $server, array $parameters = [])
+	/** @var Nav */
+	protected $nav;
+	/** @var SystemMessages */
+	protected $systemMessages;
+
+	public function __construct(SystemMessages $systemMessages, Nav $nav, IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IManageConfigValues $config, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
+		$this->nav = $nav;
+		$this->systemMessages = $systemMessages;
+
 		$privateaddons = $config->get('config', 'private_addons');
-		if ($privateaddons === "1" && !DI::userSession()->getLocalUserId()) {
+		if ($privateaddons === "1" && !$session->getLocalUserId()) {
 			$baseUrl->redirect();
 		}
 	}
 
 	protected function content(array $request = []): string
 	{
-		$apps = Nav::getAppMenu();
-
+		$apps = $this->nav->getAppMenu();
 		if (count($apps) == 0) {
-			DI::sysmsg()->addNotice($this->t('No installed applications.'));
+			$this->systemMessages->addNotice($this->t('No installed applications.'));
 		}
 
 		$tpl = Renderer::getMarkupTemplate('apps.tpl');

--- a/src/Module/BaseProfile.php
+++ b/src/Module/BaseProfile.php
@@ -54,10 +54,10 @@ class BaseProfile extends BaseModule
 				'accesskey' => 'r',
 			],
 			[
-				'label' => DI::l10n()->t('Status'),
-				'url'   => $baseProfileUrl . '/status',
+				'label' => DI::l10n()->t('Conversations'),
+				'url'   => $baseProfileUrl . '/conversations',
 				'sel'   => $current == 'status' ? 'active' : '',
-				'title' => DI::l10n()->t('Status Messages and Posts'),
+				'title' => DI::l10n()->t('Conversations started'),
 				'id'    => 'status-tab',
 				'accesskey' => 'm',
 			],

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -451,7 +451,7 @@ class Contact extends BaseModule
 	/**
 	 * List of pages for the Contact TabBar
 	 *
-	 * Available Pages are 'Status', 'Profile', 'Contacts' and 'Common Friends'
+	 * Available Pages are 'Conversations', 'Profile', 'Contacts' and 'Common Friends'
 	 *
 	 * @param array $contact    The contact array
 	 * @param int   $active_tab 1 if tab should be marked as active
@@ -473,7 +473,15 @@ class Contact extends BaseModule
 		// tabs
 		$tabs = [
 			[
-				'label' => DI::l10n()->t('Status'),
+				'label' => DI::l10n()->t('Profile'),
+				'url'   => 'contact/' . $cid,
+				'sel'   => (($active_tab == self::TAB_PROFILE) ? 'active' : ''),
+				'title' => DI::l10n()->t('Profile Details'),
+				'id'    => 'profile-tab',
+				'accesskey' => 'o',
+			],
+			[
+				'label' => DI::l10n()->t('Conversations'),
 				'url'   => 'contact/' . $pcid . '/conversations',
 				'sel'   => (($active_tab == self::TAB_CONVERSATIONS) ? 'active' : ''),
 				'title' => DI::l10n()->t('Conversations started by this contact'),
@@ -484,7 +492,7 @@ class Contact extends BaseModule
 				'label' => DI::l10n()->t('Posts and Comments'),
 				'url'   => 'contact/' . $pcid . '/posts',
 				'sel'   => (($active_tab == self::TAB_POSTS) ? 'active' : ''),
-				'title' => DI::l10n()->t('Status Messages and Posts'),
+				'title' => DI::l10n()->t('Individual Posts and Replies'),
 				'id'    => 'posts-tab',
 				'accesskey' => 'p',
 			],
@@ -495,14 +503,6 @@ class Contact extends BaseModule
 				'title' => DI::l10n()->t('Posts containing media objects'),
 				'id'    => 'media-tab',
 				'accesskey' => 'd',
-			],
-			[
-				'label' => DI::l10n()->t('Profile'),
-				'url'   => 'contact/' . $cid,
-				'sel'   => (($active_tab == self::TAB_PROFILE) ? 'active' : ''),
-				'title' => DI::l10n()->t('Profile Details'),
-				'id'    => 'profile-tab',
-				'accesskey' => 'o',
 			],
 			['label' => DI::l10n()->t('Contacts'),
 				'url'   => 'contact/' . $pcid . '/contacts',

--- a/src/Module/Contact/Follow.php
+++ b/src/Module/Contact/Follow.php
@@ -188,7 +188,7 @@ class Follow extends BaseModule
 			$this->page['aside'] = VCard::getHTML($contact);
 
 			$output .= Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'),
-				['$title' => $this->t('Status Messages and Posts')]
+				['$title' => $this->t('Posts and Replies')]
 			);
 
 			// Show last public posts

--- a/src/Module/Contact/Unfollow.php
+++ b/src/Module/Contact/Unfollow.php
@@ -135,7 +135,7 @@ class Unfollow extends \Friendica\BaseModule
 
 		$this->page['aside'] = Widget\VCard::getHTML(Contact::getByURL($contact['url'], false));
 
-		$o .= Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), ['$title' => $this->t('Status Messages and Posts')]);
+		$o .= Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), ['$title' => $this->t('Posts and Replies')]);
 
 		// Show last public posts
 		$o .= Contact::getPostsFromUrl($contact['url']);

--- a/src/Module/Post/Tag/Add.php
+++ b/src/Module/Post/Tag/Add.php
@@ -120,7 +120,7 @@ EOT;
 
 		$tagger_link  = '[url=' . $contact['url'] . ']' . $contact['name'] . '[/url]';
 		$aauthor_link = '[url=' . $item['author-link'] . ']' . $item['author-name'] . '[/url]';
-		$post_link    = '[url=' . $item['plink'] . ']' . ($item['resource-id'] ? $this->t('photo') : $this->t('status')) . '[/url]';
+		$post_link    = '[url=' . $item['plink'] . ']' . ($item['resource-id'] ? $this->t('photo') : $this->t('post')) . '[/url]';
 		$term_link    = '#[url=' . $tagid . ']' . $term . '[/url]';
 
 		$post = [

--- a/src/Module/Profile/Conversations.php
+++ b/src/Module/Profile/Conversations.php
@@ -51,7 +51,7 @@ use Friendica\Util\Profiler;
 use Friendica\Util\Strings;
 use Psr\Log\LoggerInterface;
 
-class Status extends BaseProfile
+class Conversations extends BaseProfile
 {
 	/** @var App */
 	private $app;
@@ -147,8 +147,8 @@ class Status extends BaseProfile
 		$commpage    = $profile['page-flags'] == User::PAGE_FLAGS_COMMUNITY;
 		$commvisitor = $commpage && $remote_contact;
 
-		$this->page['aside'] .= Widget::postedByYear($this->baseUrl . '/profile/' . $profile['nickname'] . '/status', $profile['profile_uid'] ?? 0, true);
-		$this->page['aside'] .= Widget::categories($profile['uid'], $this->baseUrl . '/profile/' . $profile['nickname'] . '/status', $category);
+		$this->page['aside'] .= Widget::postedByYear($this->baseUrl . '/profile/' . $profile['nickname'] . '/conversations', $profile['profile_uid'] ?? 0, true);
+		$this->page['aside'] .= Widget::categories($profile['uid'], $this->baseUrl . '/profile/' . $profile['nickname'] . '/conversations', $category);
 		$this->page['aside'] .= Widget::tagCloud($profile['uid']);
 
 		if (Security::canWriteToUserWall($profile['uid'])) {

--- a/src/Module/Profile/Index.php
+++ b/src/Module/Profile/Index.php
@@ -42,7 +42,7 @@ use Psr\Log\LoggerInterface;
  * ActivityPub endpoint, but it should show statuses to web users.
  *
  * Both these view have dedicated sub-paths,
- * respectively https://domain.tld/profile/nickname/profile and https://domain.tld/profile/nickname/status
+ * respectively https://domain.tld/profile/nickname/profile and https://domain.tld/profile/nickname/conversations
  */
 class Index extends BaseModule
 {
@@ -90,6 +90,6 @@ class Index extends BaseModule
 
 	protected function content(array $request = []): string
 	{
-		return (new Status($this->mode, $this->pConfig, $this->conversation, $this->session, $this->config, $this->dateTimeFormat, $this->page, $this->app, $this->l10n, $this->baseUrl, $this->args, $this->logger, $this->profiler, $this->response, $this->server, $this->parameters))->content();
+		return (new Conversations($this->mode, $this->pConfig, $this->conversation, $this->session, $this->config, $this->dateTimeFormat, $this->page, $this->app, $this->l10n, $this->baseUrl, $this->args, $this->logger, $this->profiler, $this->response, $this->server, $this->parameters))->content();
 	}
 }

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -31,17 +31,17 @@ use Friendica\App\Router as R;
 use Friendica\Module;
 
 $profileRoutes = [
-	''                                         => [Module\Profile\Index::class,        [R::GET]],
-	'/contacts/common'                         => [Module\Profile\Common::class,       [R::GET]],
-	'/contacts[/{type}]'                       => [Module\Profile\Contacts::class,     [R::GET]],
-	'/media'                                   => [Module\Profile\Media::class,        [R::GET]],
-	'/photos'                                  => [Module\Profile\Photos::class,       [R::GET, R::POST]],
-	'/profile'                                 => [Module\Profile\Profile::class,      [R::GET]],
-	'/remote_follow'                           => [Module\Profile\RemoteFollow::class, [R::GET, R::POST]],
-	'/restricted'                              => [Module\Profile\Restricted::class,   [R::GET         ]],
-	'/schedule'                                => [Module\Profile\Schedule::class,     [R::GET, R::POST]],
-	'/status[/{category}[/{date1}[/{date2}]]]' => [Module\Profile\Status::class,       [R::GET]],
-	'/unkmail'                                 => [Module\Profile\UnkMail::class,      [R::GET, R::POST]],
+	''                                                => [Module\Profile\Index::class,         [R::GET]],
+	'/contacts/common'                                => [Module\Profile\Common::class,        [R::GET]],
+	'/contacts[/{type}]'                              => [Module\Profile\Contacts::class,      [R::GET]],
+	'/media'                                          => [Module\Profile\Media::class,         [R::GET]],
+	'/photos'                                         => [Module\Profile\Photos::class,        [R::GET, R::POST]],
+	'/profile'                                        => [Module\Profile\Profile::class,       [R::GET]],
+	'/remote_follow'                                  => [Module\Profile\RemoteFollow::class,  [R::GET, R::POST]],
+	'/restricted'                                     => [Module\Profile\Restricted::class,    [R::GET         ]],
+	'/schedule'                                       => [Module\Profile\Schedule::class,      [R::GET, R::POST]],
+	'/conversations[/{category}[/{date1}[/{date2}]]]' => [Module\Profile\Conversations::class, [R::GET]],
+	'/unkmail'                                        => [Module\Profile\UnkMail::class,       [R::GET, R::POST]],
 ];
 
 $apiRoutes = [

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2023.03-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-09 17:29+0000\n"
+"POT-Creation-Date: 2023-01-10 19:06-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,25 +26,25 @@ msgstr ""
 msgid "Post updated."
 msgstr ""
 
-#: mod/item.php:201 mod/item.php:205
+#: mod/item.php:203 mod/item.php:207
 msgid "Item wasn't stored."
 msgstr ""
 
-#: mod/item.php:215
+#: mod/item.php:217
 msgid "Item couldn't be fetched."
 msgstr ""
 
-#: mod/item.php:261 mod/item.php:265
+#: mod/item.php:255 mod/item.php:259
 msgid "Empty post discarded."
 msgstr ""
 
-#: mod/item.php:417 src/Module/Admin/Themes/Details.php:39
+#: mod/item.php:411 src/Module/Admin/Themes/Details.php:39
 #: src/Module/Admin/Themes/Index.php:59 src/Module/Debug/ItemBody.php:42
 #: src/Module/Debug/ItemBody.php:57 src/Module/Item/Feed.php:80
 msgid "Item not found."
 msgstr ""
 
-#: mod/item.php:441 mod/message.php:69 mod/message.php:114 mod/notes.php:44
+#: mod/item.php:435 mod/message.php:69 mod/message.php:114 mod/notes.php:44
 #: mod/photos.php:158 mod/photos.php:675 src/Model/Event.php:522
 #: src/Module/Attach.php:55 src/Module/BaseApi.php:95
 #: src/Module/BaseNotifications.php:98 src/Module/BaseSettings.php:52
@@ -219,7 +219,7 @@ msgstr ""
 msgid "Your password has been changed at %s"
 msgstr ""
 
-#: mod/message.php:46 mod/message.php:129 src/Content/Nav.php:285
+#: mod/message.php:46 mod/message.php:129 src/Content/Nav.php:322
 msgid "New Message"
 msgstr ""
 
@@ -245,7 +245,7 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: mod/message.php:136 src/Content/Nav.php:282 view/theme/frio/theme.php:248
+#: mod/message.php:136 src/Content/Nav.php:319 view/theme/frio/theme.php:248
 msgid "Messages"
 msgstr ""
 
@@ -377,7 +377,7 @@ msgstr ""
 msgid "Personal notes are visible only by yourself."
 msgstr ""
 
-#: mod/notes.php:56 src/Content/Text/HTML.php:883
+#: mod/notes.php:56 src/Content/Text/HTML.php:884
 #: src/Module/Admin/Storage.php:142 src/Module/Filer/SaveTag.php:74
 #: src/Module/Post/Edit.php:126
 msgid "Save"
@@ -389,8 +389,8 @@ msgstr ""
 #: src/Module/DFRN/Poll.php:43 src/Module/Feed.php:65 src/Module/HCard.php:51
 #: src/Module/Profile/Common.php:62 src/Module/Profile/Common.php:71
 #: src/Module/Profile/Contacts.php:64 src/Module/Profile/Contacts.php:72
-#: src/Module/Profile/Media.php:38 src/Module/Profile/Photos.php:83
-#: src/Module/Profile/RemoteFollow.php:71 src/Module/Profile/Status.php:91
+#: src/Module/Profile/Conversations.php:91 src/Module/Profile/Media.php:38
+#: src/Module/Profile/Photos.php:83 src/Module/Profile/RemoteFollow.php:71
 #: src/Module/Register.php:267
 msgid "User not found."
 msgstr ""
@@ -649,31 +649,31 @@ msgstr ""
 msgid "Map"
 msgstr ""
 
-#: src/App.php:471
+#: src/App.php:472
 msgid "No system theme config value set."
 msgstr ""
 
-#: src/App.php:593
+#: src/App.php:594
 msgid "Apologies but the website is unavailable at the moment."
 msgstr ""
 
-#: src/App/Page.php:246
+#: src/App/Page.php:247
 msgid "Delete this item?"
 msgstr ""
 
-#: src/App/Page.php:247
+#: src/App/Page.php:248
 msgid ""
 "Block this author? They won't be able to follow you nor see your public "
 "posts, and you won't be able to see their posts and their notifications."
 msgstr ""
 
-#: src/App/Page.php:248
+#: src/App/Page.php:249
 msgid ""
 "Ignore this author? You won't be able to see their posts and their "
 "notifications."
 msgstr ""
 
-#: src/App/Page.php:318
+#: src/App/Page.php:319
 msgid "toggle mobile"
 msgstr ""
 
@@ -1504,8 +1504,8 @@ msgid ""
 "Contact birthday events are private to you."
 msgstr ""
 
-#: src/Content/ForumManager.php:151 src/Content/Nav.php:242
-#: src/Content/Text/HTML.php:904 src/Content/Widget.php:524
+#: src/Content/ForumManager.php:151 src/Content/Nav.php:279
+#: src/Content/Text/HTML.php:905 src/Content/Widget.php:524
 msgid "Forums"
 msgstr ""
 
@@ -1522,16 +1522,15 @@ msgstr ""
 msgid "show more"
 msgstr ""
 
-#: src/Content/Item.php:326 src/Model/Item.php:2908
+#: src/Content/Item.php:326 src/Model/Item.php:2910
 msgid "event"
 msgstr ""
 
 #: src/Content/Item.php:329 src/Content/Item.php:339
-#: src/Module/Post/Tag/Add.php:123
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:335 src/Model/Item.php:2910
+#: src/Content/Item.php:335 src/Model/Item.php:2912
 #: src/Module/Post/Tag/Add.php:123
 msgid "photo"
 msgstr ""
@@ -1608,81 +1607,79 @@ msgstr ""
 msgid "Unable to fetch user."
 msgstr ""
 
-#: src/Content/Nav.php:90
+#: src/Content/Nav.php:121
 msgid "Nothing new here"
 msgstr ""
 
-#: src/Content/Nav.php:94 src/Module/Special/HTTPException.php:77
+#: src/Content/Nav.php:125 src/Module/Special/HTTPException.php:77
 msgid "Go back"
 msgstr ""
 
-#: src/Content/Nav.php:95
+#: src/Content/Nav.php:126
 msgid "Clear notifications"
 msgstr ""
 
-#: src/Content/Nav.php:96 src/Content/Text/HTML.php:891
+#: src/Content/Nav.php:127 src/Content/Text/HTML.php:892
 msgid "@name, !forum, #tags, content"
 msgstr ""
 
-#: src/Content/Nav.php:186 src/Module/Security/Login.php:158
+#: src/Content/Nav.php:223 src/Module/Security/Login.php:158
 msgid "Logout"
 msgstr ""
 
-#: src/Content/Nav.php:186
+#: src/Content/Nav.php:223
 msgid "End this session"
 msgstr ""
 
-#: src/Content/Nav.php:188 src/Module/Bookmarklet.php:44
+#: src/Content/Nav.php:225 src/Module/Bookmarklet.php:44
 #: src/Module/Security/Login.php:159
 msgid "Login"
 msgstr ""
 
-#: src/Content/Nav.php:188
+#: src/Content/Nav.php:225
 msgid "Sign in"
 msgstr ""
 
-#: src/Content/Nav.php:193 src/Module/BaseProfile.php:57
-#: src/Module/Contact.php:476 src/Module/Contact/Profile.php:397
-#: src/Module/Settings/TwoFactor/Index.php:119 view/theme/frio/theme.php:236
-msgid "Status"
+#: src/Content/Nav.php:230 src/Module/BaseProfile.php:57
+#: src/Module/Contact.php:484
+msgid "Conversations"
 msgstr ""
 
-#: src/Content/Nav.php:193 src/Content/Nav.php:272
-#: view/theme/frio/theme.php:236
-msgid "Your posts and conversations"
+#: src/Content/Nav.php:230
+msgid "Conversations you started"
 msgstr ""
 
-#: src/Content/Nav.php:194 src/Module/BaseProfile.php:49
-#: src/Module/BaseSettings.php:100 src/Module/Contact.php:500
+#: src/Content/Nav.php:231 src/Module/BaseProfile.php:49
+#: src/Module/BaseSettings.php:100 src/Module/Contact.php:476
 #: src/Module/Contact/Profile.php:399 src/Module/Profile/Profile.php:268
 #: src/Module/Welcome.php:57 view/theme/frio/theme.php:237
 msgid "Profile"
 msgstr ""
 
-#: src/Content/Nav.php:194 view/theme/frio/theme.php:237
+#: src/Content/Nav.php:231 view/theme/frio/theme.php:237
 msgid "Your profile page"
 msgstr ""
 
-#: src/Content/Nav.php:195 src/Module/BaseProfile.php:65
+#: src/Content/Nav.php:232 src/Module/BaseProfile.php:65
 #: src/Module/Media/Photo/Browser.php:74 view/theme/frio/theme.php:241
 msgid "Photos"
 msgstr ""
 
-#: src/Content/Nav.php:195 view/theme/frio/theme.php:241
+#: src/Content/Nav.php:232 view/theme/frio/theme.php:241
 msgid "Your photos"
 msgstr ""
 
-#: src/Content/Nav.php:196 src/Module/BaseProfile.php:73
-#: src/Module/BaseProfile.php:76 src/Module/Contact.php:492
+#: src/Content/Nav.php:233 src/Module/BaseProfile.php:73
+#: src/Module/BaseProfile.php:76 src/Module/Contact.php:500
 #: view/theme/frio/theme.php:242
 msgid "Media"
 msgstr ""
 
-#: src/Content/Nav.php:196 view/theme/frio/theme.php:242
+#: src/Content/Nav.php:233 view/theme/frio/theme.php:242
 msgid "Your postings with media"
 msgstr ""
 
-#: src/Content/Nav.php:197 src/Content/Nav.php:257
+#: src/Content/Nav.php:234 src/Content/Nav.php:294
 #: src/Module/BaseProfile.php:85 src/Module/BaseProfile.php:88
 #: src/Module/BaseProfile.php:96 src/Module/BaseProfile.php:99
 #: src/Module/Settings/Display.php:252 view/theme/frio/theme.php:243
@@ -1690,36 +1687,36 @@ msgstr ""
 msgid "Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:197 view/theme/frio/theme.php:243
+#: src/Content/Nav.php:234 view/theme/frio/theme.php:243
 msgid "Your calendar"
 msgstr ""
 
-#: src/Content/Nav.php:198
+#: src/Content/Nav.php:235
 msgid "Personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:198
+#: src/Content/Nav.php:235
 msgid "Your personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:215 src/Content/Nav.php:272
+#: src/Content/Nav.php:252 src/Content/Nav.php:309
 msgid "Home"
 msgstr ""
 
-#: src/Content/Nav.php:215 src/Module/Settings/OAuth.php:74
+#: src/Content/Nav.php:252 src/Module/Settings/OAuth.php:74
 msgid "Home Page"
 msgstr ""
 
-#: src/Content/Nav.php:219 src/Module/Register.php:168
+#: src/Content/Nav.php:256 src/Module/Register.php:168
 #: src/Module/Security/Login.php:124
 msgid "Register"
 msgstr ""
 
-#: src/Content/Nav.php:219
+#: src/Content/Nav.php:256
 msgid "Create an account"
 msgstr ""
 
-#: src/Content/Nav.php:225 src/Module/Help.php:67
+#: src/Content/Nav.php:262 src/Module/Help.php:67
 #: src/Module/Settings/TwoFactor/AppSpecific.php:129
 #: src/Module/Settings/TwoFactor/Index.php:118
 #: src/Module/Settings/TwoFactor/Recovery.php:107
@@ -1727,154 +1724,158 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: src/Content/Nav.php:225
+#: src/Content/Nav.php:262
 msgid "Help and documentation"
 msgstr ""
 
-#: src/Content/Nav.php:229
+#: src/Content/Nav.php:266
 msgid "Apps"
 msgstr ""
 
-#: src/Content/Nav.php:229
+#: src/Content/Nav.php:266
 msgid "Addon applications, utilities, games"
 msgstr ""
 
-#: src/Content/Nav.php:233 src/Content/Text/HTML.php:889
+#: src/Content/Nav.php:270 src/Content/Text/HTML.php:890
 #: src/Module/Admin/Logs/View.php:87 src/Module/Search/Index.php:111
 msgid "Search"
 msgstr ""
 
-#: src/Content/Nav.php:233
+#: src/Content/Nav.php:270
 msgid "Search site content"
 msgstr ""
 
-#: src/Content/Nav.php:236 src/Content/Text/HTML.php:898
+#: src/Content/Nav.php:273 src/Content/Text/HTML.php:899
 msgid "Full Text"
 msgstr ""
 
-#: src/Content/Nav.php:237 src/Content/Text/HTML.php:899
+#: src/Content/Nav.php:274 src/Content/Text/HTML.php:900
 #: src/Content/Widget/TagCloud.php:68
 msgid "Tags"
 msgstr ""
 
-#: src/Content/Nav.php:238 src/Content/Nav.php:293
-#: src/Content/Text/HTML.php:900 src/Module/BaseProfile.php:127
+#: src/Content/Nav.php:275 src/Content/Nav.php:330
+#: src/Content/Text/HTML.php:901 src/Module/BaseProfile.php:127
 #: src/Module/BaseProfile.php:130 src/Module/Contact.php:411
 #: src/Module/Contact.php:507 view/theme/frio/theme.php:250
 msgid "Contacts"
 msgstr ""
 
-#: src/Content/Nav.php:253
+#: src/Content/Nav.php:290
 msgid "Community"
 msgstr ""
 
-#: src/Content/Nav.php:253
+#: src/Content/Nav.php:290
 msgid "Conversations on this and other servers"
 msgstr ""
 
-#: src/Content/Nav.php:260
+#: src/Content/Nav.php:297
 msgid "Directory"
 msgstr ""
 
-#: src/Content/Nav.php:260
+#: src/Content/Nav.php:297
 msgid "People directory"
 msgstr ""
 
-#: src/Content/Nav.php:262 src/Module/BaseAdmin.php:85
+#: src/Content/Nav.php:299 src/Module/BaseAdmin.php:85
 #: src/Module/BaseModeration.php:108
 msgid "Information"
 msgstr ""
 
-#: src/Content/Nav.php:262
+#: src/Content/Nav.php:299
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:265 src/Module/Admin/Tos.php:78
+#: src/Content/Nav.php:302 src/Module/Admin/Tos.php:78
 #: src/Module/BaseAdmin.php:95 src/Module/Register.php:176
 #: src/Module/Tos.php:100
 msgid "Terms of Service"
 msgstr ""
 
-#: src/Content/Nav.php:265
+#: src/Content/Nav.php:302
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:270 view/theme/frio/theme.php:246
+#: src/Content/Nav.php:307 view/theme/frio/theme.php:246
 msgid "Network"
 msgstr ""
 
-#: src/Content/Nav.php:270 view/theme/frio/theme.php:246
+#: src/Content/Nav.php:307 view/theme/frio/theme.php:246
 msgid "Conversations from your friends"
 msgstr ""
 
-#: src/Content/Nav.php:276
+#: src/Content/Nav.php:309 view/theme/frio/theme.php:236
+msgid "Your posts and conversations"
+msgstr ""
+
+#: src/Content/Nav.php:313
 msgid "Introductions"
 msgstr ""
 
-#: src/Content/Nav.php:276
+#: src/Content/Nav.php:313
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:277 src/Module/BaseNotifications.php:149
+#: src/Content/Nav.php:314 src/Module/BaseNotifications.php:149
 #: src/Module/Notifications/Introductions.php:75
 msgid "Notifications"
 msgstr ""
 
-#: src/Content/Nav.php:278
+#: src/Content/Nav.php:315
 msgid "See all notifications"
 msgstr ""
 
-#: src/Content/Nav.php:279 src/Module/Settings/Connectors.php:242
+#: src/Content/Nav.php:316 src/Module/Settings/Connectors.php:242
 msgid "Mark as seen"
 msgstr ""
 
-#: src/Content/Nav.php:279
+#: src/Content/Nav.php:316
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:282 view/theme/frio/theme.php:248
+#: src/Content/Nav.php:319 view/theme/frio/theme.php:248
 msgid "Private mail"
 msgstr ""
 
-#: src/Content/Nav.php:283
+#: src/Content/Nav.php:320
 msgid "Inbox"
 msgstr ""
 
-#: src/Content/Nav.php:284
+#: src/Content/Nav.php:321
 msgid "Outbox"
 msgstr ""
 
-#: src/Content/Nav.php:288
+#: src/Content/Nav.php:325
 msgid "Accounts"
 msgstr ""
 
-#: src/Content/Nav.php:288
+#: src/Content/Nav.php:325
 msgid "Manage other pages"
 msgstr ""
 
-#: src/Content/Nav.php:291 src/Module/Admin/Addons/Details.php:114
+#: src/Content/Nav.php:328 src/Module/Admin/Addons/Details.php:114
 #: src/Module/Admin/Themes/Details.php:93 src/Module/BaseSettings.php:170
 #: src/Module/Welcome.php:52 view/theme/frio/theme.php:249
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:291 view/theme/frio/theme.php:249
+#: src/Content/Nav.php:328 view/theme/frio/theme.php:249
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:293 view/theme/frio/theme.php:250
+#: src/Content/Nav.php:330 view/theme/frio/theme.php:250
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:298 src/Module/BaseAdmin.php:119
+#: src/Content/Nav.php:335 src/Module/BaseAdmin.php:119
 msgid "Admin"
 msgstr ""
 
-#: src/Content/Nav.php:298
+#: src/Content/Nav.php:335
 msgid "Site setup and configuration"
 msgstr ""
 
-#: src/Content/Nav.php:299 src/Module/BaseModeration.php:127
+#: src/Content/Nav.php:336 src/Module/BaseModeration.php:127
 #: src/Module/Moderation/Blocklist/Contact.php:110
 #: src/Module/Moderation/Blocklist/Server/Add.php:119
 #: src/Module/Moderation/Blocklist/Server/Import.php:115
@@ -1888,15 +1889,15 @@ msgstr ""
 msgid "Moderation"
 msgstr ""
 
-#: src/Content/Nav.php:299
+#: src/Content/Nav.php:336
 msgid "Content and user moderation"
 msgstr ""
 
-#: src/Content/Nav.php:302
+#: src/Content/Nav.php:339
 msgid "Navigation"
 msgstr ""
 
-#: src/Content/Nav.php:302
+#: src/Content/Nav.php:339
 msgid "Site map"
 msgstr ""
 
@@ -1935,12 +1936,12 @@ msgid ""
 "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1257 src/Model/Item.php:3577
-#: src/Model/Item.php:3583 src/Model/Item.php:3584
+#: src/Content/Text/BBCode.php:1257 src/Model/Item.php:3579
+#: src/Model/Item.php:3585 src/Model/Item.php:3586
 msgid "Link to source"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1795 src/Content/Text/HTML.php:928
+#: src/Content/Text/BBCode.php:1795 src/Content/Text/HTML.php:929
 msgid "Click to open/close"
 msgstr ""
 
@@ -1960,15 +1961,15 @@ msgstr ""
 msgid "Invalid link protocol"
 msgstr ""
 
-#: src/Content/Text/HTML.php:806
+#: src/Content/Text/HTML.php:807
 msgid "Loading more entries..."
 msgstr ""
 
-#: src/Content/Text/HTML.php:807
+#: src/Content/Text/HTML.php:808
 msgid "The end"
 msgstr ""
 
-#: src/Content/Text/HTML.php:883 src/Content/Widget/VCard.php:109
+#: src/Content/Text/HTML.php:884 src/Content/Widget/VCard.php:109
 #: src/Model/Profile.php:463 src/Module/Contact/Profile.php:444
 msgid "Follow"
 msgstr ""
@@ -3105,71 +3106,71 @@ msgstr ""
 msgid "Edit groups"
 msgstr ""
 
-#: src/Model/Item.php:2009
+#: src/Model/Item.php:2011
 #, php-format
 msgid "Detected languages in this post:\\n%s"
 msgstr ""
 
-#: src/Model/Item.php:2912
+#: src/Model/Item.php:2914
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2914
+#: src/Model/Item.php:2916
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2917
+#: src/Model/Item.php:2919 src/Module/Post/Tag/Add.php:123
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3067
+#: src/Model/Item.php:3069
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:3071
+#: src/Model/Item.php:3073
 #, php-format
 msgid "Content warning: %s"
 msgstr ""
 
-#: src/Model/Item.php:3489
+#: src/Model/Item.php:3491
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3520
+#: src/Model/Item.php:3522
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3522
+#: src/Model/Item.php:3524
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3527
+#: src/Model/Item.php:3529
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3529
+#: src/Model/Item.php:3531
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3531
+#: src/Model/Item.php:3533
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3565 src/Model/Item.php:3566
+#: src/Model/Item.php:3567 src/Model/Item.php:3568
 msgid "View on separate page"
 msgstr ""
 
@@ -5276,11 +5277,11 @@ msgstr ""
 msgid "Contact not found"
 msgstr ""
 
-#: src/Module/Apps.php:55
+#: src/Module/Apps.php:62
 msgid "No installed applications."
 msgstr ""
 
-#: src/Module/Apps.php:60
+#: src/Module/Apps.php:67
 msgid "Applications"
 msgstr ""
 
@@ -5415,13 +5416,12 @@ msgstr ""
 msgid "Item Source"
 msgstr ""
 
-#: src/Module/BaseProfile.php:52 src/Module/Contact.php:503
+#: src/Module/BaseProfile.php:52 src/Module/Contact.php:479
 msgid "Profile Details"
 msgstr ""
 
-#: src/Module/BaseProfile.php:60 src/Module/Contact.php:487
-#: src/Module/Contact/Follow.php:191 src/Module/Contact/Unfollow.php:138
-msgid "Status Messages and Posts"
+#: src/Module/BaseProfile.php:60
+msgid "Conversations started"
 msgstr ""
 
 #: src/Module/BaseProfile.php:111
@@ -5707,15 +5707,19 @@ msgstr ""
 msgid "Batch Actions"
 msgstr ""
 
-#: src/Module/Contact.php:479
+#: src/Module/Contact.php:487
 msgid "Conversations started by this contact"
 msgstr ""
 
-#: src/Module/Contact.php:484
+#: src/Module/Contact.php:492
 msgid "Posts and Comments"
 msgstr ""
 
 #: src/Module/Contact.php:495
+msgid "Individual Posts and Replies"
+msgstr ""
+
+#: src/Module/Contact.php:503
 msgid "Posts containing media objects"
 msgstr ""
 
@@ -5921,6 +5925,10 @@ msgstr ""
 
 #: src/Module/Contact/Follow.php:182
 msgid "Add a personal note:"
+msgstr ""
+
+#: src/Module/Contact/Follow.php:191 src/Module/Contact/Unfollow.php:138
+msgid "Posts and Replies"
 msgstr ""
 
 #: src/Module/Contact/Follow.php:220
@@ -6147,6 +6155,11 @@ msgstr ""
 #: src/Module/Contact/Profile.php:395
 #: src/Module/Settings/TwoFactor/Index.php:139
 msgid "Actions"
+msgstr ""
+
+#: src/Module/Contact/Profile.php:397
+#: src/Module/Settings/TwoFactor/Index.php:119 view/theme/frio/theme.php:236
+msgid "Status"
 msgstr ""
 
 #: src/Module/Contact/Profile.php:403
@@ -8238,6 +8251,26 @@ msgstr ""
 msgid "No contacts."
 msgstr ""
 
+#: src/Module/Profile/Conversations.php:106
+#: src/Module/Profile/Conversations.php:109 src/Module/Profile/Profile.php:351
+#: src/Module/Profile/Profile.php:354 src/Protocol/Feed.php:1025
+#: src/Protocol/OStatus.php:1045
+#, php-format
+msgid "%s's timeline"
+msgstr ""
+
+#: src/Module/Profile/Conversations.php:107 src/Module/Profile/Profile.php:352
+#: src/Protocol/Feed.php:1029 src/Protocol/OStatus.php:1050
+#, php-format
+msgid "%s's posts"
+msgstr ""
+
+#: src/Module/Profile/Conversations.php:108 src/Module/Profile/Profile.php:353
+#: src/Protocol/Feed.php:1032 src/Protocol/OStatus.php:1054
+#, php-format
+msgid "%s's comments"
+msgstr ""
+
 #: src/Module/Profile/Photos.php:170
 msgid "Image upload didn't complete, please try again"
 msgstr ""
@@ -8318,25 +8351,6 @@ msgstr ""
 
 #: src/Module/Profile/Profile.php:290
 msgid "View as"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:351 src/Module/Profile/Profile.php:354
-#: src/Module/Profile/Status.php:106 src/Module/Profile/Status.php:109
-#: src/Protocol/Feed.php:1025 src/Protocol/OStatus.php:1045
-#, php-format
-msgid "%s's timeline"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:352 src/Module/Profile/Status.php:107
-#: src/Protocol/Feed.php:1029 src/Protocol/OStatus.php:1050
-#, php-format
-msgid "%s's posts"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:353 src/Module/Profile/Status.php:108
-#: src/Protocol/Feed.php:1032 src/Protocol/OStatus.php:1054
-#, php-format
-msgid "%s's comments"
 msgstr ""
 
 #: src/Module/Profile/RemoteFollow.php:82


### PR DESCRIPTION
Close #12629 

Now "Status" only means status on Friendica. I didn't pick "Thread" because we don't use the term anywhere, whereas we were already using the term "Conversation".