### PR TITLE
Fix: Forum posts from some contacts weren't distributed

### DIFF
--- a/src/Module/ActivityPub/Objects.php
+++ b/src/Module/ActivityPub/Objects.php
@@ -75,9 +75,7 @@ class Objects extends BaseModule
 			throw new HTTPException\NotFoundException();
 		}
 
-		$owner = User::getById($item['uid'], ['hidewall']);
-
-		$validated = empty($owner['hidewall']) && in_array($item['private'], [Item::PUBLIC, Item::UNLISTED]);
+		$validated = in_array($item['private'], [Item::PUBLIC, Item::UNLISTED]);
 
 		if (!$validated) {
 			$requester = HTTPSignature::getSigner('', $_SERVER);

--- a/src/Module/DFRN/Poll.php
+++ b/src/Module/DFRN/Poll.php
@@ -37,13 +37,13 @@ class Poll extends BaseModule
 	{
 		$owner = User::getByNickname(
 			$this->parameters['nickname'] ?? '',
-			['nickname', 'blocked', 'account_expired', 'account_removed', 'hidewall']
+			['nickname', 'blocked', 'account_expired', 'account_removed']
 		);
 		if (!$owner || $owner['account_expired'] || $owner['account_removed']) {
 			throw new HTTPException\NotFoundException($this->t('User not found.'));
 		}
 
-		if ($owner['blocked'] || $owner['hidewall']) {
+		if ($owner['blocked']) {
 			throw new HTTPException\UnauthorizedException($this->t('Access to this profile has been restricted.'));
 		}
 

--- a/src/Module/Feed.php
+++ b/src/Module/Feed.php
@@ -65,7 +65,7 @@ class Feed extends BaseModule
 			throw new HTTPException\NotFoundException($this->t('User not found.'));
 		}
 
-		if ($owner['blocked'] || $owner['hidewall']) {
+		if ($owner['blocked']) {
 			throw new HTTPException\UnauthorizedException($this->t('Access to this profile has been restricted.'));
 		}
 


### PR DESCRIPTION
Forum posts are distributed via resharing them. But reshared content needs to be checked via the remote system by fetching it from the source. So tis "hidewall" check prevented the posts from being distributed via the forum server.

Same goes with the feed endpoints. The "Poll" endpoint is needed for the OStatus communication.