### PR TITLE
Properly handle feed item urls with surrounding whitespace

### DIFF
--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -376,6 +376,7 @@ class Network
 	 */
 	public static function addBasePath(string $url, string $basepath): string
 	{
+		$url = trim($url);
 		if (!empty(parse_url($url, PHP_URL_SCHEME)) || empty(parse_url($basepath, PHP_URL_SCHEME)) || empty($url) || empty(parse_url($url))) {
 			return $url;
 		}


### PR DESCRIPTION
Some feeds might have whitespace around the URLs of each item. This can't be handled by parse_url.
Therefore the incoming url is trimmed to not contain any surrounding whitespace for proper handling.

Fix #12658