### PR TITLE
Ensure to reset the avatar paths when deleting avatar cache

### DIFF
--- a/src/Contact/Avatar.php
+++ b/src/Contact/Avatar.php
@@ -246,13 +246,16 @@ class Avatar
 	 * Delete locally cached avatar pictures of a contact
 	 *
 	 * @param string $avatar
-	 * @return void
+	 * @return bool
 	 */
-	public static function deleteCache(array $contact)
+	public static function deleteCache(array $contact): bool
 	{
+		$existed = (self::isCacheFile($contact['photo']) || self::isCacheFile($contact['thumb']) || self::isCacheFile($contact['micro']));
 		self::deleteCacheFile($contact['photo']);
 		self::deleteCacheFile($contact['thumb']);
 		self::deleteCacheFile($contact['micro']);
+
+		return $existed;
 	}
 
 	/**

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2252,7 +2252,9 @@ class Contact
 		}
 
 		if (in_array($contact['network'], [Protocol::FEED, Protocol::MAIL]) || $cache_avatar) {
-			Avatar::deleteCache($contact);
+			if (Avatar::deleteCache($contact)) {
+				$force = true;
+			}
 
 			if ($default_avatar && Proxy::isLocalImage($avatar)) {
 				$fields = ['avatar' => $avatar, 'avatar-date' => DateTimeFormat::utcNow(),


### PR DESCRIPTION
When using the file based avatar cache (can only be activated via the local.config.php) and then reactivating the database based cache again, the old avatar cache file was deleted, but the paths to it still stayed. We now enforce the creating of the photo entries when there had been avatar cache filed before.