### PR TITLE
Properly handle feed item creation date with surrounding whitespace

### DIFF
--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -376,11 +376,11 @@ class Feed
 			}
 
 			if ($published != '') {
-				$item['created'] = $published;
+				$item['created'] = trim($published);
 			}
 
 			if ($updated != '') {
-				$item['edited'] = $updated;
+				$item['edited'] = trim($updated);
 			}
 
 			if (!$dryRun) {


### PR DESCRIPTION
Some feeds might have whitespace around the creation date. This can't be parsed by DateTimeFormat methods.
Therefore the incoming creation date is trimmed to not contain any surrounding whitespace for proper handling.

Fix #12686