### PR TITLE
Allow colon in password

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -757,7 +757,7 @@ class User
 	}
 
 	/**
-	 * Allowed characters are a-z, A-Z, 0-9 and special characters except white spaces, accentuated letters and colon (:).
+	 * Allowed characters are a-z, A-Z, 0-9 and special characters except white spaces and accentuated letters.
 	 *
 	 * Password length is limited to 72 characters if the current default password hashing algorithm is Blowfish.
 	 * From the manual: "Using the PASSWORD_BCRYPT as the algorithm, will result in the password parameter being
@@ -770,7 +770,7 @@ class User
 	 */
 	public static function getPasswordRegExp(string $delimiter = null): string
 	{
-		$allowed_characters = '!"#$%&\'()*+,-./;<=>?@[\]^_`{|}~';
+		$allowed_characters = ':!"#$%&\'()*+,-./;<=>?@[\]^_`{|}~';
 
 		if ($delimiter) {
 			$allowed_characters = preg_quote($allowed_characters, $delimiter);
@@ -804,7 +804,7 @@ class User
 		}
 
 		if (!preg_match('/' . self::getPasswordRegExp('/') . '/', $password)) {
-			throw new Exception(DI::l10n()->t('The password can\'t contain accentuated letters, white spaces or colons (:)'));
+			throw new Exception(DI::l10n()->t("The password can't contain white spaces nor accentuated letters"));
 		}
 
 		return self::updatePasswordHashed($uid, self::hashPassword($password));

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -776,7 +776,7 @@ class User
 			$allowed_characters = preg_quote($allowed_characters, $delimiter);
 		}
 
-		return '^[a-zA-Z0-9' . $allowed_characters . ']' . (PASSWORD_DEFAULT !== PASSWORD_BCRYPT ? '{1,72}' : '+') . '$';
+		return '^[a-zA-Z0-9' . $allowed_characters . ']' . (PASSWORD_DEFAULT === PASSWORD_BCRYPT ? '{1,72}' : '+') . '$';
 	}
 
 	/**

--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -61,7 +61,10 @@ class Token extends BaseApi
 		}
 
 		if (empty($request['client_id']) && substr($authorization, 0, 6) == 'Basic ') {
-			$datapair = explode(':', base64_decode(trim(substr($authorization, 6))));
+			// Per RFC2617, usernames can't contain a colon but password can,
+			// so we cut on the first colon to obtain the username and the password
+			// @see https://www.rfc-editor.org/rfc/rfc2617#section-2
+			$datapair = explode(':', base64_decode(trim(substr($authorization, 6))), 2);
 			if (count($datapair) == 2) {
 				$request['client_id']     = $datapair[0];
 				$request['client_secret'] = $datapair[1];

--- a/src/Module/Security/PasswordTooLong.php
+++ b/src/Module/Security/PasswordTooLong.php
@@ -98,7 +98,7 @@ class PasswordTooLong extends \Friendica\BaseModule
 			'$return_url'          => $request['return_url'] ?? '',
 
 			'$password_current' => ['password_current', $this->l10n->t('Current Password:'), '', $this->l10n->t('Your current password to confirm the changes'), 'required', 'autocomplete="off"'],
-			'$password'         => ['password', $this->l10n->t('New Password:'), '', $this->l10n->t('Allowed characters are a-z, A-Z, 0-9 and special characters except white spaces, accentuated letters and colon (:).') . ' ' . $this->l10n->t('Password length is limited to 72 characters.'), 'required', 'autocomplete="off"', User::getPasswordRegExp()],
+			'$password'         => ['password', $this->l10n->t('New Password:'), '', $this->l10n->t('Allowed characters are a-z, A-Z, 0-9 and special characters except white spaces and accentuated letters.') . ' ' . $this->l10n->t('Password length is limited to 72 characters.'), 'required', 'autocomplete="off"', User::getPasswordRegExp()],
 			'$password_confirm' => ['password_confirm', $this->l10n->t('Confirm:'), '', '', 'required', 'autocomplete="off"'],
 		]);
 

--- a/src/Module/Settings/Account.php
+++ b/src/Module/Settings/Account.php
@@ -549,7 +549,7 @@ class Account extends BaseSettings
 
 		$notify_type = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'notify_type');
 
-		$passwordRules = DI::l10n()->t('Allowed characters are a-z, A-Z, 0-9 and special characters except white spaces, accentuated letters and colon (:).')
+		$passwordRules = DI::l10n()->t('Allowed characters are a-z, A-Z, 0-9 and special characters except white spaces and accentuated letters.')
 			. (PASSWORD_DEFAULT === PASSWORD_BCRYPT ? ' ' . DI::l10n()->t('Password length is limited to 72 characters.') : '');
 
 		$tpl = Renderer::getMarkupTemplate('settings/account.tpl');

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2023.03-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-14 21:19+0000\n"
+"POT-Creation-Date: 2023-01-18 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,7 +49,7 @@ msgstr ""
 #: src/Module/Attach.php:55 src/Module/BaseApi.php:95
 #: src/Module/BaseNotifications.php:98 src/Module/BaseSettings.php:52
 #: src/Module/Calendar/Event/API.php:88 src/Module/Calendar/Event/Form.php:84
-#: src/Module/Calendar/Export.php:62 src/Module/Calendar/Show.php:82
+#: src/Module/Calendar/Export.php:82 src/Module/Calendar/Show.php:82
 #: src/Module/Contact/Advanced.php:60 src/Module/Contact/Follow.php:86
 #: src/Module/Contact/Follow.php:159 src/Module/Contact/MatchInterests.php:86
 #: src/Module/Contact/Suggestions.php:54 src/Module/Contact/Unfollow.php:66
@@ -385,7 +385,7 @@ msgstr ""
 
 #: mod/photos.php:67 mod/photos.php:132 mod/photos.php:577
 #: src/Model/Event.php:514 src/Model/Profile.php:234
-#: src/Module/Calendar/Export.php:67 src/Module/Calendar/Show.php:74
+#: src/Module/Calendar/Export.php:74 src/Module/Calendar/Show.php:74
 #: src/Module/DFRN/Poll.php:43 src/Module/Feed.php:65 src/Module/HCard.php:51
 #: src/Module/Profile/Common.php:62 src/Module/Profile/Common.php:71
 #: src/Module/Profile/Contacts.php:64 src/Module/Profile/Contacts.php:72
@@ -649,11 +649,11 @@ msgstr ""
 msgid "Map"
 msgstr ""
 
-#: src/App.php:472
+#: src/App.php:470
 msgid "No system theme config value set."
 msgstr ""
 
-#: src/App.php:594
+#: src/App.php:592
 msgid "Apologies but the website is unavailable at the moment."
 msgstr ""
 
@@ -1877,9 +1877,9 @@ msgstr ""
 
 #: src/Content/Nav.php:335 src/Module/BaseModeration.php:127
 #: src/Module/Moderation/Blocklist/Contact.php:110
-#: src/Module/Moderation/Blocklist/Server/Add.php:119
-#: src/Module/Moderation/Blocklist/Server/Import.php:115
-#: src/Module/Moderation/Blocklist/Server/Index.php:92
+#: src/Module/Moderation/Blocklist/Server/Add.php:121
+#: src/Module/Moderation/Blocklist/Server/Import.php:118
+#: src/Module/Moderation/Blocklist/Server/Index.php:95
 #: src/Module/Moderation/Item/Delete.php:61
 #: src/Module/Moderation/Summary.php:76
 #: src/Module/Moderation/Users/Active.php:133
@@ -3296,7 +3296,7 @@ msgstr ""
 msgid "Title/Description:"
 msgstr ""
 
-#: src/Model/Profile.php:1023 src/Module/Admin/Summary.php:222
+#: src/Model/Profile.php:1023 src/Module/Admin/Summary.php:220
 #: src/Module/Moderation/Summary.php:77
 msgid "Summary"
 msgstr ""
@@ -3368,8 +3368,7 @@ msgid "The password length is limited to 72 characters."
 msgstr ""
 
 #: src/Model/User.php:807
-msgid ""
-"The password can't contain accentuated letters, white spaces or colons (:)"
+msgid "The password can't contain white spaces nor accentuated letters"
 msgstr ""
 
 #: src/Model/User.php:1002
@@ -3624,7 +3623,7 @@ msgstr ""
 #: src/Module/Admin/Federation.php:207 src/Module/Admin/Logs/Settings.php:79
 #: src/Module/Admin/Logs/View.php:84 src/Module/Admin/Queue.php:72
 #: src/Module/Admin/Site.php:435 src/Module/Admin/Storage.php:138
-#: src/Module/Admin/Summary.php:221 src/Module/Admin/Themes/Details.php:90
+#: src/Module/Admin/Summary.php:219 src/Module/Admin/Themes/Details.php:90
 #: src/Module/Admin/Themes/Index.php:111 src/Module/Admin/Tos.php:77
 #: src/Module/Moderation/Users/Create.php:61
 #: src/Module/Moderation/Users/Pending.php:96
@@ -5007,12 +5006,12 @@ msgstr ""
 msgid "Database (legacy)"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:57
+#: src/Module/Admin/Summary.php:55
 #, php-format
 msgid "Template engine (%s) error: %s"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:61
+#: src/Module/Admin/Summary.php:59
 #, php-format
 msgid ""
 "Your DB still runs with MyISAM tables. You should change the engine type to "
@@ -5023,7 +5022,7 @@ msgid ""
 "automatic conversion.<br />"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:66
+#: src/Module/Admin/Summary.php:64
 #, php-format
 msgid ""
 "Your DB still runs with InnoDB tables in the Antelope file format. You "
@@ -5034,7 +5033,7 @@ msgid ""
 "installation for an automatic conversion.<br />"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:76
+#: src/Module/Admin/Summary.php:74
 #, php-format
 msgid ""
 "Your table_definition_cache is too low (%d). This can lead to the database "
@@ -5042,39 +5041,39 @@ msgid ""
 "to %d. See <a href=\"%s\">here</a> for more information.<br />"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:86
+#: src/Module/Admin/Summary.php:84
 #, php-format
 msgid ""
 "There is a new version of Friendica available for download. Your current "
 "version is %1$s, upstream version is %2$s"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:95
+#: src/Module/Admin/Summary.php:93
 msgid ""
 "The database update failed. Please run \"php bin/console.php dbstructure "
 "update\" from the command line and have a look at the errors that might "
 "appear."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:99
+#: src/Module/Admin/Summary.php:97
 msgid ""
 "The last update failed. Please run \"php bin/console.php dbstructure update"
 "\" from the command line and have a look at the errors that might appear. "
 "(Some of the errors are possibly inside the logfile.)"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:104
+#: src/Module/Admin/Summary.php:102
 msgid "The worker was never executed. Please check your database structure!"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:106
+#: src/Module/Admin/Summary.php:104
 #, php-format
 msgid ""
 "The last worker execution was on %s UTC. This is older than one hour. Please "
 "check your crontab settings."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:111
+#: src/Module/Admin/Summary.php:109
 #, php-format
 msgid ""
 "Friendica's configuration now is stored in config/local.config.php, please "
@@ -5083,7 +5082,7 @@ msgid ""
 "with the transition."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:115
+#: src/Module/Admin/Summary.php:113
 #, php-format
 msgid ""
 "Friendica's configuration now is stored in config/local.config.php, please "
@@ -5092,7 +5091,7 @@ msgid ""
 "with the transition."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:119
+#: src/Module/Admin/Summary.php:117
 #, php-format
 msgid ""
 "Friendica's configuration store \"%s\" isn't writable. Until then database "
@@ -5100,7 +5099,7 @@ msgid ""
 "configuration changes won't be saved."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:125
+#: src/Module/Admin/Summary.php:123
 #, php-format
 msgid ""
 "<a href=\"%s\">%s</a> is not reachable on your system. This is a severe "
@@ -5108,50 +5107,50 @@ msgid ""
 "href=\"%s\">the installation page</a> for help."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:143
+#: src/Module/Admin/Summary.php:141
 #, php-format
 msgid "The logfile '%s' is not usable. No logging possible (error: '%s')"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:157
+#: src/Module/Admin/Summary.php:155
 #, php-format
 msgid "The debug logfile '%s' is not usable. No logging possible (error: '%s')"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:173
+#: src/Module/Admin/Summary.php:171
 #, php-format
 msgid ""
 "Friendica's system.basepath was updated from '%s' to '%s'. Please remove the "
 "system.basepath from your db to avoid differences."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:181
+#: src/Module/Admin/Summary.php:179
 #, php-format
 msgid ""
 "Friendica's current system.basepath '%s' is wrong and the config file '%s' "
 "isn't used."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:189
+#: src/Module/Admin/Summary.php:187
 #, php-format
 msgid ""
 "Friendica's current system.basepath '%s' is not equal to the config file "
 "'%s'. Please fix your configuration."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:200
+#: src/Module/Admin/Summary.php:198
 msgid "Message queues"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:206
+#: src/Module/Admin/Summary.php:204
 msgid "Server Settings"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:224
+#: src/Module/Admin/Summary.php:222
 msgid "Version"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:228
+#: src/Module/Admin/Summary.php:226
 msgid "Active addons"
 msgstr ""
 
@@ -5543,13 +5542,13 @@ msgstr ""
 #: src/Module/Install.php:286 src/Module/Install.php:291
 #: src/Module/Install.php:305 src/Module/Install.php:320
 #: src/Module/Install.php:347
-#: src/Module/Moderation/Blocklist/Server/Add.php:134
 #: src/Module/Moderation/Blocklist/Server/Add.php:136
-#: src/Module/Moderation/Blocklist/Server/Import.php:126
-#: src/Module/Moderation/Blocklist/Server/Index.php:83
-#: src/Module/Moderation/Blocklist/Server/Index.php:84
-#: src/Module/Moderation/Blocklist/Server/Index.php:112
-#: src/Module/Moderation/Blocklist/Server/Index.php:113
+#: src/Module/Moderation/Blocklist/Server/Add.php:138
+#: src/Module/Moderation/Blocklist/Server/Import.php:129
+#: src/Module/Moderation/Blocklist/Server/Index.php:86
+#: src/Module/Moderation/Blocklist/Server/Index.php:87
+#: src/Module/Moderation/Blocklist/Server/Index.php:115
+#: src/Module/Moderation/Blocklist/Server/Index.php:116
 #: src/Module/Moderation/Item/Delete.php:67 src/Module/Register.php:148
 #: src/Module/Security/TwoFactor/Verify.php:101
 #: src/Module/Settings/TwoFactor/Index.php:140
@@ -5589,15 +5588,15 @@ msgstr ""
 msgid "Basic"
 msgstr ""
 
-#: src/Module/Calendar/Export.php:77
+#: src/Module/Calendar/Export.php:94
 msgid "This calendar format is not supported"
 msgstr ""
 
-#: src/Module/Calendar/Export.php:79
+#: src/Module/Calendar/Export.php:96
 msgid "No exportable data found"
 msgstr ""
 
-#: src/Module/Calendar/Export.php:96
+#: src/Module/Calendar/Export.php:113
 msgid "calendar"
 msgstr ""
 
@@ -6725,8 +6724,8 @@ msgid "On this server the following remote servers are blocked."
 msgstr ""
 
 #: src/Module/Friendica.php:84
-#: src/Module/Moderation/Blocklist/Server/Index.php:84
-#: src/Module/Moderation/Blocklist/Server/Index.php:108
+#: src/Module/Moderation/Blocklist/Server/Index.php:87
+#: src/Module/Moderation/Blocklist/Server/Index.php:111
 msgid "Reason for the block"
 msgstr ""
 
@@ -7399,32 +7398,32 @@ msgid ""
 msgstr ""
 
 #: src/Module/Moderation/Blocklist/Contact.php:135
-#: src/Module/Moderation/Blocklist/Server/Import.php:121
+#: src/Module/Moderation/Blocklist/Server/Import.php:124
 msgid "Block Reason"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:78
+#: src/Module/Moderation/Blocklist/Server/Add.php:80
 msgid "Server domain pattern added to the blocklist."
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:86
+#: src/Module/Moderation/Blocklist/Server/Add.php:88
 #, php-format
 msgid "%s server scheduled to be purged."
 msgid_plural "%s servers scheduled to be purged."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:118
-#: src/Module/Moderation/Blocklist/Server/Import.php:114
+#: src/Module/Moderation/Blocklist/Server/Add.php:120
+#: src/Module/Moderation/Blocklist/Server/Import.php:117
 msgid "← Return to the list"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:120
+#: src/Module/Moderation/Blocklist/Server/Add.php:122
 msgid "Block A New Server Domain Pattern"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:121
-#: src/Module/Moderation/Blocklist/Server/Index.php:96
+#: src/Module/Moderation/Blocklist/Server/Add.php:123
+#: src/Module/Moderation/Blocklist/Server/Index.php:99
 msgid ""
 "<p>The server domain pattern syntax is case-insensitive shell wildcard, "
 "comprising the following special characters:</p>\n"
@@ -7434,55 +7433,55 @@ msgid ""
 "</ul>"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:126
-#: src/Module/Moderation/Blocklist/Server/Index.php:104
+#: src/Module/Moderation/Blocklist/Server/Add.php:128
+#: src/Module/Moderation/Blocklist/Server/Index.php:107
 msgid "Check pattern"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:127
+#: src/Module/Moderation/Blocklist/Server/Add.php:129
 msgid "Matching known servers"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:128
+#: src/Module/Moderation/Blocklist/Server/Add.php:130
 msgid "Server Name"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:129
+#: src/Module/Moderation/Blocklist/Server/Add.php:131
 msgid "Server Domain"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:130
+#: src/Module/Moderation/Blocklist/Server/Add.php:132
 msgid "Known Contacts"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:131
+#: src/Module/Moderation/Blocklist/Server/Add.php:133
 #, php-format
 msgid "%d known server"
 msgid_plural "%d known servers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:132
+#: src/Module/Moderation/Blocklist/Server/Add.php:134
 msgid "Add pattern to the blocklist"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:134
-#: src/Module/Moderation/Blocklist/Server/Index.php:113
+#: src/Module/Moderation/Blocklist/Server/Add.php:136
+#: src/Module/Moderation/Blocklist/Server/Index.php:116
 msgid "Server Domain Pattern"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:134
-#: src/Module/Moderation/Blocklist/Server/Index.php:113
+#: src/Module/Moderation/Blocklist/Server/Add.php:136
+#: src/Module/Moderation/Blocklist/Server/Index.php:116
 msgid ""
 "The domain pattern of the new server to add to the blocklist. Do not include "
 "the protocol."
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:135
+#: src/Module/Moderation/Blocklist/Server/Add.php:137
 msgid "Purge server"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:135
+#: src/Module/Moderation/Blocklist/Server/Add.php:137
 msgid ""
 "Also purges all the locally stored content authored by the known contacts "
 "registered on that server. Keeps the contacts and the server records. This "
@@ -7494,149 +7493,149 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:136
+#: src/Module/Moderation/Blocklist/Server/Add.php:138
 msgid "Block reason"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Add.php:136
+#: src/Module/Moderation/Blocklist/Server/Add.php:138
 msgid ""
 "The reason why you blocked this server domain pattern. This reason will be "
 "shown publicly in the server information page."
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:73
-#: src/Module/Moderation/Blocklist/Server/Import.php:82
+#: src/Module/Moderation/Blocklist/Server/Import.php:74
+#: src/Module/Moderation/Blocklist/Server/Import.php:83
 msgid "Error importing pattern file"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:88
+#: src/Module/Moderation/Blocklist/Server/Import.php:89
 msgid "Local blocklist replaced with the provided file."
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:92
+#: src/Module/Moderation/Blocklist/Server/Import.php:93
 #, php-format
 msgid "%d pattern was added to the local blocklist."
 msgid_plural "%d patterns were added to the local blocklist."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:94
+#: src/Module/Moderation/Blocklist/Server/Import.php:95
 msgid "No pattern was added to the local blocklist."
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:116
+#: src/Module/Moderation/Blocklist/Server/Import.php:119
 msgid "Import a Server Domain Pattern Blocklist"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:117
+#: src/Module/Moderation/Blocklist/Server/Import.php:120
 msgid ""
 "<p>This file can be downloaded from the <code>/friendica</code> path of any "
 "Friendica server.</p>"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:118
-#: src/Module/Moderation/Blocklist/Server/Index.php:103
+#: src/Module/Moderation/Blocklist/Server/Import.php:121
+#: src/Module/Moderation/Blocklist/Server/Index.php:106
 msgid "Upload file"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:119
+#: src/Module/Moderation/Blocklist/Server/Import.php:122
 msgid "Patterns to import"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:120
+#: src/Module/Moderation/Blocklist/Server/Import.php:123
 msgid "Domain Pattern"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:122
+#: src/Module/Moderation/Blocklist/Server/Import.php:125
 msgid "Import Mode"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:123
+#: src/Module/Moderation/Blocklist/Server/Import.php:126
 msgid "Import Patterns"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:124
+#: src/Module/Moderation/Blocklist/Server/Import.php:127
 #, php-format
 msgid "%d total pattern"
 msgid_plural "%d total patterns"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:126
-#: src/Module/Moderation/Blocklist/Server/Index.php:112
+#: src/Module/Moderation/Blocklist/Server/Import.php:129
+#: src/Module/Moderation/Blocklist/Server/Index.php:115
 msgid "Server domain pattern blocklist CSV file"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:127
+#: src/Module/Moderation/Blocklist/Server/Import.php:130
 msgid "Append"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:127
+#: src/Module/Moderation/Blocklist/Server/Import.php:130
 msgid ""
 "Imports patterns from the file that weren't already existing in the current "
 "blocklist."
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:128
+#: src/Module/Moderation/Blocklist/Server/Import.php:131
 msgid "Replace"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Import.php:128
+#: src/Module/Moderation/Blocklist/Server/Import.php:131
 msgid "Replaces the current blocklist by the imported patterns."
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:83
-#: src/Module/Moderation/Blocklist/Server/Index.php:107
+#: src/Module/Moderation/Blocklist/Server/Index.php:86
+#: src/Module/Moderation/Blocklist/Server/Index.php:110
 msgid "Blocked server domain pattern"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:85
+#: src/Module/Moderation/Blocklist/Server/Index.php:88
 msgid "Delete server domain pattern"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:85
+#: src/Module/Moderation/Blocklist/Server/Index.php:88
 msgid "Check to delete this entry from the blocklist"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:93
+#: src/Module/Moderation/Blocklist/Server/Index.php:96
 msgid "Server Domain Pattern Blocklist"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:94
+#: src/Module/Moderation/Blocklist/Server/Index.php:97
 msgid ""
 "This page can be used to define a blocklist of server domain patterns from "
 "the federated network that are not allowed to interact with your node. For "
 "each domain pattern you should also provide the reason why you block it."
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:95
+#: src/Module/Moderation/Blocklist/Server/Index.php:98
 msgid ""
 "The list of blocked server domain patterns will be made publically available "
 "on the <a href=\"/friendica\">/friendica</a> page so that your users and "
 "people investigating communication problems can find the reason easily."
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:101
+#: src/Module/Moderation/Blocklist/Server/Index.php:104
 msgid "Import server domain pattern blocklist"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:102
+#: src/Module/Moderation/Blocklist/Server/Index.php:105
 msgid "Add new entry to the blocklist"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:105
+#: src/Module/Moderation/Blocklist/Server/Index.php:108
 msgid "Save changes to the blocklist"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:106
+#: src/Module/Moderation/Blocklist/Server/Index.php:109
 msgid "Current Entries in the Blocklist"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:109
+#: src/Module/Moderation/Blocklist/Server/Index.php:112
 msgid "Delete entry from the blocklist"
 msgstr ""
 
-#: src/Module/Moderation/Blocklist/Server/Index.php:110
+#: src/Module/Moderation/Blocklist/Server/Index.php:113
 msgid "Delete entry from the blocklist?"
 msgstr ""
 
@@ -8071,7 +8070,7 @@ msgstr ""
 msgid "Unsupported or missing response type"
 msgstr ""
 
-#: src/Module/OAuth/Authorize.php:59 src/Module/OAuth/Token.php:73
+#: src/Module/OAuth/Authorize.php:59 src/Module/OAuth/Token.php:76
 msgid "Incomplete request data"
 msgstr ""
 
@@ -8082,11 +8081,11 @@ msgid ""
 "close this window: %s"
 msgstr ""
 
-#: src/Module/OAuth/Token.php:78
+#: src/Module/OAuth/Token.php:81
 msgid "Invalid data or unknown client"
 msgstr ""
 
-#: src/Module/OAuth/Token.php:97
+#: src/Module/OAuth/Token.php:100
 msgid "Unsupported or missing grant type"
 msgstr ""
 
@@ -8767,7 +8766,7 @@ msgstr ""
 #: src/Module/Settings/Account.php:552
 msgid ""
 "Allowed characters are a-z, A-Z, 0-9 and special characters except white "
-"spaces, accentuated letters and colon (:)."
+"spaces and accentuated letters."
 msgstr ""
 
 #: src/Module/Security/PasswordTooLong.php:101


### PR DESCRIPTION
- It was disallowed because of a too strict interpretation of RFC2617