### PR TITLE
Blocked domains flood gserver entries

### DIFF
--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -455,18 +455,11 @@ class GServer
 	 * Set failed server status
 	 *
 	 * @param string $url
+	 * @return void
 	 */
 	public static function setFailureByUrl(string $url)
 	{
 		$nurl = Strings::normaliseLink($url);
-
-		if (Network::isUrlBlocked($url)) {
-			Logger::info('Server domain is blocked', ['url' => $url]);
-			return;
-		} elseif (Network::isUrlBlocked($nurl)) {
-			Logger::info('Server domain is blocked', ['nurl' => $nurl]);
-			return;
-		}
 
 		$gserver = DBA::selectFirst('gserver', [], ['nurl' => $nurl]);
 		if (DBA::isResult($gserver)) {
@@ -478,6 +471,14 @@ class GServer
 			if (self::isDefunct($gserver)) {
 				self::archiveContacts($gserver['id']);
 			}
+			return;
+		}
+
+		if (Network::isUrlBlocked($url)) {
+			Logger::info('Server domain is blocked', ['url' => $url]);
+			return;
+		} elseif (Network::isUrlBlocked($nurl)) {
+			Logger::info('Server domain is blocked', ['nurl' => $nurl]);
 			return;
 		}
 

--- a/src/Worker/UpdateServerPeers.php
+++ b/src/Worker/UpdateServerPeers.php
@@ -63,7 +63,7 @@ class UpdateServerPeers
 			}
 
 			++$total;
-			if (DBA::exists('gserver', ['nurl' => Strings::normaliseLink('https://' . $peer)])) {
+			if (DBA::exists('gserver', ['nurl' => 'http://' . $peer])) {
 				// We already know this server
 				continue;
 			}

--- a/src/Worker/UpdateServerPeers.php
+++ b/src/Worker/UpdateServerPeers.php
@@ -57,13 +57,13 @@ class UpdateServerPeers
 		$total = 0;
 		$added = 0;
 		foreach ($peers as $peer) {
-			if (Network::isUrlBlocked('http://' . $peer)) {
+			if (Network::isUrlBlocked('https://' . $peer)) {
 				// Ignore blocked systems as soon as possible in the loop to avoid being slowed down by tar pits
 				continue;
 			}
 
 			++$total;
-			if (DBA::exists('gserver', ['nurl' => Strings::normaliseLink('http://' . $peer)])) {
+			if (DBA::exists('gserver', ['nurl' => Strings::normaliseLink('https://' . $peer)])) {
 				// We already know this server
 				continue;
 			}


### PR DESCRIPTION
It has shown in the past that trolls from the infamous `gab.best` and also more recently `activitypub-troll.cf` domains have used a flaw in Friendica to flood the `gserver` table with millions (see [this link](https://friendica.myportal.social/display/e65e1095-1763-c947-a194-ab1699044817)) of useless records (tons of invalid and not findable sub domains) of records that just pile up and seem to never end.

With this change, I was finally able to block them from entering my and other's database tables. This PR also contains a change to to avoid redundant invocations of `Strings::normaliseLink()` which can safe some CPU cycles and speedup the code.