### PR TITLE
Remove BaseURL Auto-Check

### DIFF
--- a/bin/worker.php
+++ b/bin/worker.php
@@ -69,8 +69,6 @@ if (!DI::mode()->has(App\Mode::MAINTENANCEDISABLED)) {
 	return;
 }
 
-DI::baseUrl()->saveByURL(DI::config()->get('system', 'url'));
-
 $spawn = array_key_exists('s', $options) || array_key_exists('spawn', $options);
 
 if ($spawn) {

--- a/config/local-sample.config.php
+++ b/config/local-sample.config.php
@@ -36,9 +36,11 @@ return [
 		'sitename' => 'Friendica Social Network',
 		'register_policy' => \Friendica\Module\Register::OPEN,
 		'register_text' => '',
+		'hostname' => 'friendica.local',
 	],
 	'system' => [
 		'default_timezone' => 'UTC',
 		'language' => 'en',
+		'url' => 'https://friendica.local',
 	],
 ];

--- a/mods/local.config.vagrant.php
+++ b/mods/local.config.vagrant.php
@@ -40,5 +40,7 @@ return [
 		'language' => 'en',
 		'basepath' => '/vagrant',
 		'ssl_policy' => \Friendica\App\BaseURL::SSL_POLICY_SELFSIGN,
+		'url' => 'https://192.168.56.10',
+		'urlpath' => '',
 	],
 ];

--- a/src/App.php
+++ b/src/App.php
@@ -541,25 +541,6 @@ class App
 	}
 
 	/**
-	 * Sets the base url for use in cmdline programs which don't have
-	 * $_SERVER variables
-	 */
-	public function checkURL()
-	{
-		$url = $this->config->get('system', 'url');
-
-		// if the url isn't set or the stored url is radically different
-		// than the currently visited url, store the current value accordingly.
-		// "Radically different" ignores common variations such as http vs https
-		// and www.example.com vs example.com.
-		// We will only change the url to an ip address if there is no existing setting
-
-		if (empty($url) || (!Util\Strings::compareLink($url, $this->baseURL->get())) && (!preg_match("/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/", $this->baseURL->getHostname()))) {
-			$this->config->set('system', 'url', $this->baseURL->get());
-		}
-	}
-
-	/**
 	 * Frontend App script
 	 *
 	 * The App object behaves like a container and a dispatcher at the same time, including a representation of the
@@ -657,7 +638,6 @@ class App
 			if ($this->mode->isInstall() && $moduleName !== 'install') {
 				$this->baseURL->redirect('install');
 			} else {
-				$this->checkURL();
 				Core\Update::check($this->getBasePath(), false);
 				Core\Addon::loadAddons();
 				Core\Hook::loadHooks();

--- a/src/App/BaseURL.php
+++ b/src/App/BaseURL.php
@@ -264,6 +264,10 @@ class BaseURL
 		$this->sslPolicy = $this->config->get('system', 'ssl_policy') ?? static::DEFAULT_SSL_SCHEME;
 		$this->url       = $this->config->get('system', 'url');
 
+		if (empty($this->hostname) || empty($this->url)) {
+			throw new \Exception('Invalid config - Missing system.url or config.hostname');
+		}
+
 		$this->determineSchema();
 	}
 

--- a/src/App/BaseURL.php
+++ b/src/App/BaseURL.php
@@ -257,109 +257,14 @@ class BaseURL
 	 */
 	public function __construct(IManageConfigValues $config, array $server)
 	{
-		$this->config = $config;
-		$this->server = $server;
-
-		$this->determineSchema();
-		$this->checkConfig();
-	}
-
-	/**
-	 * Check the current config during loading
-	 */
-	public function checkConfig()
-	{
+		$this->config    = $config;
+		$this->server    = $server;
 		$this->hostname  = $this->config->get('config', 'hostname');
-		$this->urlPath   = $this->config->get('system', 'urlpath');
-		$this->sslPolicy = $this->config->get('system', 'ssl_policy');
+		$this->urlPath   = $this->config->get('system', 'urlpath') ?? '';
+		$this->sslPolicy = $this->config->get('system', 'ssl_policy') ?? static::DEFAULT_SSL_SCHEME;
 		$this->url       = $this->config->get('system', 'url');
 
-		if (empty($this->hostname)) {
-			$this->determineHostname();
-
-			if (!empty($this->hostname)) {
-				$this->config->set('config', 'hostname', $this->hostname);
-			}
-		}
-
-		if (!isset($this->urlPath)) {
-			$this->determineURLPath();
-			$this->config->set('system', 'urlpath', $this->urlPath);
-		}
-
-		if (!isset($this->sslPolicy)) {
-			if ($this->scheme == 'https') {
-				$this->sslPolicy = self::SSL_POLICY_FULL;
-			} else {
-				$this->sslPolicy = self::DEFAULT_SSL_SCHEME;
-			}
-			$this->config->set('system', 'ssl_policy', $this->sslPolicy);
-		}
-
-		if (empty($this->url)) {
-			$this->determineBaseUrl();
-
-			if (!empty($this->url)) {
-				$this->config->set('system', 'url', $this->url);
-			}
-		}
-	}
-
-	/**
-	 * Determines the hostname of this node if not set already
-	 */
-	private function determineHostname()
-	{
-		$this->hostname = '';
-
-		if (!empty($this->server['SERVER_NAME'])) {
-			$this->hostname = $this->server['SERVER_NAME'];
-
-			if (!empty($this->server['SERVER_PORT']) && $this->server['SERVER_PORT'] != 80 && $this->server['SERVER_PORT'] != 443) {
-				$this->hostname .= ':' . $this->server['SERVER_PORT'];
-			}
-		}
-	}
-
-	/**
-	 * Figure out if we are running at the top of a domain or in a sub-directory
-	 */
-	private function determineURLPath()
-	{
-		$this->urlPath = '';
-
-		/*
-		 * The automatic path detection in this function is currently deactivated,
-		 * see issue https://github.com/friendica/friendica/issues/6679
-		 *
-		 * The problem is that the function seems to be confused with some url.
-		 * These then confuses the detection which changes the url path.
-		 */
-
-		/* Relative script path to the web server root
-		 * Not all of those $_SERVER properties can be present, so we do by inverse priority order
-		 */
-		$relative_script_path =
-			($this->server['REDIRECT_URL']        ?? '') ?:
-			($this->server['REDIRECT_URI']        ?? '') ?:
-			($this->server['REDIRECT_SCRIPT_URL'] ?? '') ?:
-			($this->server['SCRIPT_URL']          ?? '') ?:
-			 $this->server['REQUEST_URI']         ?? '';
-
-		/* $relative_script_path gives /relative/path/to/friendica/module/parameter
-		 * QUERY_STRING gives pagename=module/parameter
-		 *
-		 * To get /relative/path/to/friendica we perform dirname() for as many levels as there are slashes in the QUERY_STRING
-		 */
-		if (!empty($relative_script_path)) {
-			// Module
-			if (!empty($this->server['QUERY_STRING'])) {
-				$this->urlPath = trim(dirname($relative_script_path, substr_count(trim($this->server['QUERY_STRING'], '/'), '/') + 1), '/');
-			} else {
-				// Root page
-				$this->urlPath = trim($relative_script_path, '/');
-			}
-		}
+		$this->determineSchema();
 	}
 
 	/**

--- a/src/App/Request.php
+++ b/src/App/Request.php
@@ -74,7 +74,7 @@ class Request
 	public function __construct(IManageConfigValues $config, array $server = [])
 	{
 		$this->remoteAddress = $this->determineRemoteAddress($config, $server);
-		$this->requestId = $server[static::DEFAULT_REQUEST_ID_HEADER] ?? System::createGUID(8);
+		$this->requestId = $server[static::DEFAULT_REQUEST_ID_HEADER] ?? System::createGUID(8, false);
 	}
 
 	/**

--- a/tests/src/Util/BaseURLTest.php
+++ b/tests/src/Util/BaseURLTest.php
@@ -200,47 +200,6 @@ class BaseURLTest extends MockedTest
 		];
 	}
 
-	/**
-	 * Test the default config determination
-	 * @dataProvider dataDefault
-	 */
-	public function testCheck($server, $input, $assert)
-	{
-		$configMock = \Mockery::mock(IManageConfigValues::class);
-		$configMock->shouldReceive('get')->with('config', 'hostname')->andReturn($input['hostname']);
-		$configMock->shouldReceive('get')->with('system', 'urlpath')->andReturn($input['urlPath']);
-		$configMock->shouldReceive('get')->with('system', 'ssl_policy')->andReturn($input['sslPolicy']);
-		$configMock->shouldReceive('get')->with('system', 'url')->andReturn($input['url']);
-
-		// If we don't have an urlPath as an input, we assert it, we will save it to the DB for the next time
-		if (!isset($input['urlPath']) && isset($assert['urlPath'])) {
-			$configMock->shouldReceive('set')->with('system', 'urlpath', $assert['urlPath'])->once();
-		}
-
-		// If we don't have the ssl_policy as an input, we assert it, we will save it to the DB for the next time
-		if (!isset($input['sslPolicy']) && isset($assert['sslPolicy'])) {
-			$configMock->shouldReceive('set')->with('system', 'ssl_policy', $assert['sslPolicy'])->once();
-		}
-
-		// If we don't have the hostname as an input, we assert it, we will save it to the DB for the next time
-		if (empty($input['hostname']) && !empty($assert['hostname'])) {
-			$configMock->shouldReceive('set')->with('config', 'hostname', $assert['hostname'])->once();
-		}
-
-		// If we don't have an URL at first, but we assert it, we will save it to the DB for the next time
-		if (empty($input['url']) && !empty($assert['url'])) {
-			$configMock->shouldReceive('set')->with('system', 'url', $assert['url'])->once();
-		}
-
-		$baseUrl = new BaseURL($configMock, $server);
-
-		self::assertEquals($assert['hostname'], $baseUrl->getHostname());
-		self::assertEquals($assert['urlPath'], $baseUrl->getUrlPath());
-		self::assertEquals($assert['sslPolicy'], $baseUrl->getSSLPolicy());
-		self::assertEquals($assert['scheme'], $baseUrl->getScheme());
-		self::assertEquals($assert['url'], $baseUrl->get());
-	}
-
 	public function dataSave()
 	{
 		return [


### PR DESCRIPTION
There's no need for these auto-check routines.

Either there is a `system.url` or `system.hostname` - or it isn't.
It will be set during the install or autoinstall.

If these values aren't set, the whole node needs to be fixed and not "determining" what could possible be set for the URL based on the current call.

I guess this is a relict from old times, but plz prove me wrong :)

Should also fix the first issue from https://friendica.mrpetovan.com/display/735a2029-1063-c964-bd90-415612573486