### PR TITLE
Fix labels in contact request modal

### DIFF
--- a/view/theme/frio/templates/notifications/intros.tpl
+++ b/view/theme/frio/templates/notifications/intros.tpl
@@ -59,8 +59,7 @@
 
 		{{* This sections contains special settings for contact approval. We hide it by default and load this section in
 		a bootstrap modal in the case of approval *}}
-		<div id="intro-approve-wrapper-{{$intro_id}}" style="display: none;">
-
+		<template id="intro-approve-wrapper-{{$intro_id}}" style="display: none;">
 			<h3 class="heading">{{$fullname}}{{if $addr}}&nbsp;({{$addr}}){{/if}}</h3>
 			<form class="intro-approve-form" {{if $request}}action="{{$request}}" method="get"{{else}}action="{{$action}}" method="post"{{/if}}>
 				{{if $type != "friend_suggestion"}}
@@ -83,7 +82,7 @@
 				</div>
 				<div class="clear"></div>
 			</form>
-		</div>
+		</template>
 	</div>
 </div>
 <div class="intro-end"></div>


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/12709 (the same ID was present in the actual HTML, then copied and rendered in the modal).

A label doesn't point to the correct input if there are many inputs with the same ID. Template HTML tag solves this issue, so only the modal input is considered the target for its label. 