### PR TITLE
Replace custom WebFinger implementation by Probe::getWebfingerArray in APContact::fetchWebfingerData

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -71,21 +71,14 @@ class APContact
 			return $data;
 		}
 
-		$data = ['addr' => $addr];
-		$template = 'https://' . $addr_parts[1] . '/.well-known/webfinger?resource=acct:' . urlencode($addr);
-		$webfinger = Probe::webfinger(str_replace('{uri}', urlencode($addr), $template), HttpClientAccept::JRD_JSON);
-		if (empty($webfinger['links'])) {
-			$template = 'http://' . $addr_parts[1] . '/.well-known/webfinger?resource=acct:' . urlencode($addr);
-			$webfinger = Probe::webfinger(str_replace('{uri}', urlencode($addr), $template), HttpClientAccept::JRD_JSON);
-			if (empty($webfinger['links'])) {
-				return [];
-			}
-			$data['baseurl'] = 'http://' . $addr_parts[1];
-		} else {
-			$data['baseurl'] = 'https://' . $addr_parts[1];
+		$webfinger = Probe::getWebfingerArray($addr);
+		if (empty($webfinger['webfinger']['links'])) {
+			return [];
 		}
 
-		foreach ($webfinger['links'] as $link) {
+		$data['baseurl'] = $webfinger['baseurl'];
+
+		foreach ($webfinger['webfinger']['links'] as $link) {
 			if (empty($link['rel'])) {
 				continue;
 			}

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -519,7 +519,7 @@ class Probe
 	 * @return array Webfinger data
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	private static function getWebfingerArray(string $uri): array
+	public static function getWebfingerArray(string $uri): array
 	{
 		$parts = parse_url($uri);
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -761,7 +761,7 @@ class Probe
 			$result = self::feed($uri);
 		} else {
 			// We overwrite the detected nick with our try if the previois routines hadn't detected it.
-			// Additionally it is overwritten when the nickname doesn't make sense (contains spaces).
+			// Additionally, it is overwritten when the nickname doesn't make sense (contains spaces).
 			if ((empty($result['nick']) || (strstr($result['nick'], ' '))) && ($nick != '')) {
 				$result['nick'] = $nick;
 			}
@@ -1853,11 +1853,18 @@ class Probe
 	 */
 	private static function feed(string $url, bool $probe = true): array
 	{
-		$curlResult = DI::httpClient()->get($url, HttpClientAccept::FEED_XML);
+		try {
+			$curlResult = DI::httpClient()->get($url, HttpClientAccept::FEED_XML);
+		} catch(\Throwable $e) {
+			DI::logger()->info('Error requesting feed URL', ['url' => $url, 'exception' => $e]);
+			return [];
+		}
+
 		if ($curlResult->isTimeout()) {
 			self::$isTimeout = true;
 			return [];
 		}
+
 		$feed = $curlResult->getBody();
 		$feed_data = Feed::import($feed);
 


### PR DESCRIPTION
Part of #12733 

- This implementation didn't support separate domains for the address and the final account