### PR TITLE
Avoid local network communication / invalid url requests

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -305,7 +305,7 @@ class BBCode
 		// if nothing is found, it maybe having an image.
 		if (!isset($post['type'])) {
 			if (preg_match_all("#\[url=([^\]]+?)\]\s*\[img\]([^\[]+?)\[/img\]\s*\[/url\]#ism", $post['text'], $pictures, PREG_SET_ORDER)) {
-				if ((count($pictures) == 1) && !$has_title) {
+				if ((count($pictures) == 1) && !$has_title && !Photo::isLocal($pictures[0][2])) {
 					if (!empty($item['object-type']) && ($item['object-type'] == Activity\ObjectType::IMAGE)) {
 						// Replace the preview picture with the real picture
 						$url = str_replace('-1.', '-0.', $pictures[0][2]);

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -376,6 +376,11 @@ class APContact
 		// Unhandled from Kroeg
 		// kroeg:blocks, updated
 
+		if (!empty($apcontact['photo']) && !Network::isValidHttpUrl($apcontact['photo'])) {
+			Logger::info('Invalid URL for photo', ['url' => $apcontact['url'], 'photo' => $apcontact['photo']]);
+			$apcontact['photo'] = null;
+		}
+
 		// When the photo is too large, try to shorten it by removing parts
 		if (strlen($apcontact['photo'] ?? '') > 255) {
 			$parts = parse_url($apcontact['photo']);

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -180,7 +180,7 @@ class Media
 		}
 
 		// Fetch the mimetype or size if missing.
-		if (empty($media['mimetype']) || empty($media['size'])) {
+		if (Network::isValidHttpUrl($media['url']) && (empty($media['mimetype']) || empty($media['size']))) {
 			$timeout = DI::config()->get('system', 'xrd_timeout');
 			$curlResult = DI::httpClient()->head($media['url'], [HttpClientOptions::TIMEOUT => $timeout]);
 

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -31,6 +31,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Network;
 use Friendica\Util\Strings;
 
 /**
@@ -193,7 +194,7 @@ class Tag
 			} elseif (Contact::getIdForURL($url, 0, $fetch ? null : false)) {
 				$target = self::ACCOUNT;
 				Logger::debug('URL is an account', ['url' => $url]);
-			} elseif ($fetch && ($target != self::GENERAL_COLLECTION)) {
+			} elseif ($fetch && ($target != self::GENERAL_COLLECTION) && Network::isValidHttpUrl($url)) {
 				$content = ActivityPub::fetchContent($url);
 				if (!empty($content['type']) && ($content['type'] == 'OrderedCollection')) {
 					$target = self::GENERAL_COLLECTION;

--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -353,7 +353,6 @@ class Photo extends BaseModule
 				// If it is a local link, we save resources by just redirecting to it.
 				if (Network::isLocalLink($url)) {
 					System::externalRedirect($url);
-					System::exit();
 				}
 
 				$mimetext = '';
@@ -402,7 +401,6 @@ class Photo extends BaseModule
 					}
 					if (Network::isLocalLink($url)) {
 						System::externalRedirect($url);
-						System::exit();
 					}
 				}
 				return MPhoto::createPhotoForExternalResource($url, 0, $mimetext, $contact['blurhash'] ?? null, $customsize, $customsize);
@@ -430,7 +428,6 @@ class Photo extends BaseModule
 					$url = Contact::getDefaultHeader($contact);
 					if (Network::isLocalLink($url)) {
 						System::externalRedirect($url);
-						System::exit();
 					}
 				}
 				return MPhoto::createPhotoForExternalResource($url);
@@ -467,7 +464,6 @@ class Photo extends BaseModule
 
 			if (Network::isLocalLink($default)) {
 				System::externalRedirect($default);
-				System::exit();
 			}
 
 			$parts = parse_url($default);

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1065,6 +1065,10 @@ class Receiver
 			}
 
 			foreach ($receiver_list as $receiver) {
+				if ($receiver == 'Public') {
+					Logger::notice('Not compacted public collection found', ['activity' => $activity, 'callstack' => System::callstack(20)]);
+					$receiver = ActivityPub::PUBLIC_COLLECTION;
+				}
 				if ($receiver == self::PUBLIC_COLLECTION) {
 					$receiver = ActivityPub::PUBLIC_COLLECTION;
 				}

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -1122,7 +1122,7 @@ class Feed
 		XML::addElement($doc, $entry, 'id', $item['uri']);
 		XML::addElement($doc, $entry, 'title', html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 
-		$body = OStatus::formatPicturePost($item['body'], $item['uri-id']);
+		$body = Post\Media::addAttachmentsToBody($item['uri-id'], DI::contentItem()->addSharedPost($item));
 
 		$body = BBCode::convertForUriId($item['uri-id'], $body, BBCode::ACTIVITYPUB);
 

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -517,7 +517,11 @@ class Notifier
 
 		foreach ($contacts as $contact) {
 			// Direct delivery of local contacts
-			if (!in_array($cmd, [Delivery::RELOCATION, Delivery::SUGGESTION, Delivery::DELETION, Delivery::MAIL]) && $target_uid = User::getIdForURL($contact['url'])) {
+			if (!in_array($cmd, [Delivery::RELOCATION, Delivery::SUGGESTION, Delivery::MAIL]) && $target_uid = User::getIdForURL($contact['url'])) {
+				if ($cmd == Delivery::DELETION) {
+					Logger::info('No need to deliver deletions internally', ['uid' => $target_uid, 'guid' => $target_item['guid'], 'uri-id' => $target_item['uri-id'], 'uri' => $target_item['uri']]);
+					continue;
+				}
 				if ($target_item['origin'] || ($target_item['network'] != Protocol::ACTIVITYPUB)) {
 					if ($target_uid != $target_item['uid']) {
 						$fields = ['protocol' => Conversation::PARCEL_LOCAL_DFRN, 'direction' => Conversation::PUSH, 'post-reason' => Item::PR_DIRECT];
@@ -839,7 +843,11 @@ class Notifier
 
 			if ((count($receivers) == 1) && Network::isLocalLink($inbox)) {
 				$contact = Contact::getById($receivers[0], ['url']);
-				if (!in_array($cmd, [Delivery::RELOCATION, Delivery::SUGGESTION, Delivery::DELETION, Delivery::MAIL]) && ($target_uid = User::getIdForURL($contact['url']))) {
+				if (!in_array($cmd, [Delivery::RELOCATION, Delivery::SUGGESTION, Delivery::MAIL]) && ($target_uid = User::getIdForURL($contact['url']))) {
+					if ($cmd == Delivery::DELETION) {
+						Logger::info('No need to deliver deletions internally', ['uid' => $target_uid, 'guid' => $target_item['guid'], 'uri-id' => $target_item['uri-id'], 'uri' => $target_item['uri']]);
+						continue;
+					}
 					if ($target_item['origin'] || ($target_item['network'] != Protocol::ACTIVITYPUB)) {
 						if ($target_uid != $target_item['uid']) {
 							$fields = ['protocol' => Conversation::PARCEL_LOCAL_DFRN, 'direction' => Conversation::PUSH, 'post-reason' => Item::PR_BCC];

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -38,6 +38,7 @@ use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\Email;
 use Friendica\Protocol\Feed;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Network;
 use Friendica\Util\Strings;
 
 class OnePoll
@@ -154,6 +155,11 @@ class OnePoll
 		// Are we allowed to import from this person?
 		if ($contact['rel'] == Contact::FOLLOWER || $contact['blocked']) {
 			Logger::notice('Contact is blocked or only a follower');
+			return false;
+		}
+
+		if (!Network::isValidHttpUrl($contact['poll'])) {
+			Logger::notice('Poll address is not valid', ['id' => $contact['id'], 'uid' => $contact['uid'], 'url' => $contact['url'], 'poll' => $contact['poll']]);
 			return false;
 		}
 


### PR DESCRIPTION
This PR covers two related issues:
- It should handle all conditions in which we performed HTTP requests with invalid addresses
- local network communication (when a Friendica server speaks with itself via HTTP requests) is massively reduced