### PR TITLE
Avoid more local links and bad http requests

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -29,7 +29,6 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
-use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException;
 use Friendica\Network\Probe;
 use Friendica\Protocol\ActivityNamespace;
@@ -358,16 +357,6 @@ class APContact
 
 		$apcontact['discoverable'] = JsonLD::fetchElement($compacted, 'toot:discoverable', '@value');
 
-		// To-Do
-
-		// Unhandled
-		// tag, attachment, image, nomadicLocations, signature, movedTo, liked
-
-		// Unhandled from Misskey
-		// sharedInbox, isCat
-
-		// Unhandled from Kroeg
-		// kroeg:blocks, updated
 		if (!empty($apcontact['photo'])) {
 			$apcontact['photo'] = trim($apcontact['photo']);
 		}

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -368,10 +368,13 @@ class APContact
 
 		// Unhandled from Kroeg
 		// kroeg:blocks, updated
+		if (!empty($apcontact['photo'])) {
+			$apcontact['photo'] = trim($apcontact['photo']);
+		}
 
 		if (!empty($apcontact['photo']) && !Network::isValidHttpUrl($apcontact['photo'])) {
-			Logger::info('Invalid URL for photo', ['url' => $apcontact['url'], 'photo' => $apcontact['photo']]);
-			$apcontact['photo'] = null;
+			Logger::warning('Invalid URL for photo', ['url' => $apcontact['url'], 'photo' => $apcontact['photo']]);
+			$apcontact['photo'] = '';
 		}
 
 		// When the photo is too large, try to shorten it by removing parts

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2204,13 +2204,18 @@ class Contact
 			return;
 		}
 
+		if (!Network::isValidHttpUrl($avatar)) {
+			Logger::warning('Invalid avatar', ['cid' => $cid, 'avatar' => $avatar]);
+			$avatar = '';
+		}
+
 		$uid = $contact['uid'];
 
 		// Only update the cached photo links of public contacts when they already are cached
 		if (($uid == 0) && !$force && empty($contact['thumb']) && empty($contact['micro']) && !$create_cache) {
 			if (($contact['avatar'] != $avatar) || empty($contact['blurhash'])) {
 				$update_fields = ['avatar' => $avatar];
-				if (!Network::isLocalLink($avatar) && Network::isValidHttpUrl($avatar)) {
+				if (!Network::isLocalLink($avatar)) {
 					$fetchResult = HTTPSignature::fetchRaw($avatar, 0, [HttpClientOptions::ACCEPT_CONTENT => [HttpClientAccept::IMAGE]]);
 
 					$img_str = $fetchResult->getBody();

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3682,7 +3682,7 @@ class Item
 			return is_numeric($hookData['item_id']) ? $hookData['item_id'] : 0;
 		}
 
-		$fetched_uri = ActivityPub\Processor::fetchMissingActivity($uri);
+		$fetched_uri = ActivityPub\Processor::fetchMissingActivity($uri, [], '', ActivityPub\Receiver::COMPLETION_MANUAL, $uid);
 
 		if ($fetched_uri) {
 			$item_id = self::searchByLink($fetched_uri, $uid);

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -36,6 +36,7 @@ use Friendica\Object\Image;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
 use Friendica\Security\Security;
+use Friendica\Util\Network;
 use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 
@@ -582,8 +583,13 @@ class Photo
 
 		$photo_failure = false;
 
+		if (!Network::isValidHttpUrl($image_url)) {
+			Logger::warning('Invalid image url', ['image_url' => $image_url, 'uid' => $uid, 'cid' => $cid, 'callstack' => System::callstack(20)]);
+			return false;
+		}
+
 		$filename = basename($image_url);
-		if (!empty($image_url) && @parse_url($image_url, PHP_URL_HOST)) {
+		if (!empty($image_url)) {
 			$ret = DI::httpClient()->get($image_url, HttpClientAccept::IMAGE);
 			Logger::debug('Got picture', ['Content-Type' => $ret->getHeader('Content-Type'), 'url' => $image_url]);
 			$img_str = $ret->getBody();

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -194,7 +194,7 @@ class Tag
 			} elseif (Contact::getIdForURL($url, 0, $fetch ? null : false)) {
 				$target = self::ACCOUNT;
 				Logger::debug('URL is an account', ['url' => $url]);
-			} elseif ($fetch && ($target != self::GENERAL_COLLECTION) && Network::isValidHttpUrl($url)) {
+			} elseif ($fetch && ($target != self::GENERAL_COLLECTION)) {
 				$content = ActivityPub::fetchContent($url);
 				if (!empty($content['type']) && ($content['type'] == 'OrderedCollection')) {
 					$target = self::GENERAL_COLLECTION;

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -121,7 +121,7 @@ class Probe
 		$numeric_fields = ['gsid', 'hide', 'account-type', 'manually-approve'];
 
 		if (!empty($data['photo']) && !Network::isValidHttpUrl($data['photo'])) {
-			Logger::info('Invalid URL for photo', ['url' => $data['url'], 'photo' => $data['photo']]);
+			Logger::warning('Invalid URL for photo', ['url' => $data['url'], 'photo' => $data['photo']]);
 			unset($data['photo']);
 		}
 

--- a/src/Protocol/ActivityPub/Queue.php
+++ b/src/Protocol/ActivityPub/Queue.php
@@ -236,7 +236,7 @@ class Queue
 		}
 		DBA::close($receivers);
 
-		if (!Receiver::routeActivities($activity, $type, $push, $fetch_parents)) {
+		if (!Receiver::routeActivities($activity, $type, $push, $fetch_parents, $activity['receiver'][0] ?? 0)) {
 			self::remove($activity);
 		}
 

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -159,7 +159,7 @@ class OnePoll
 		}
 
 		if (!Network::isValidHttpUrl($contact['poll'])) {
-			Logger::notice('Poll address is not valid', ['id' => $contact['id'], 'uid' => $contact['uid'], 'url' => $contact['url'], 'poll' => $contact['poll']]);
+			Logger::warning('Poll address is not valid', ['id' => $contact['id'], 'uid' => $contact['uid'], 'url' => $contact['url'], 'poll' => $contact['poll']]);
 			return false;
 		}
 

--- a/src/Worker/PollContacts.php
+++ b/src/Worker/PollContacts.php
@@ -41,7 +41,7 @@ class PollContacts
 			$abandon_days = 0;
 		}
 
-		$condition = ['network' => [Protocol::FEED, Protocol::MAIL, Protocol::OSTATUS], 'self' => false, 'blocked' => false];
+		$condition = ['network' => [Protocol::FEED, Protocol::MAIL, Protocol::OSTATUS], 'self' => false, 'blocked' => false, 'archive' => false];
 
 		if (!empty($abandon_days)) {
 			$condition = DBA::mergeConditions($condition,

--- a/tests/FixtureTest.php
+++ b/tests/FixtureTest.php
@@ -82,7 +82,10 @@ abstract class FixtureTest extends DatabaseTest
 
 		$dba->setTestmode(true);
 
-		DBStructure::checkInitialValues();
+		if (DI::lock()->acquire('Test-checkInitialValues', 0)) {
+			DBStructure::checkInitialValues();
+			DI::lock()->release('Test-checkInitialValues');
+		}
 
 		// Load the API dataset for the whole API
 		$this->loadFixture(__DIR__ . '/datasets/api.fixture.php', $dba);


### PR DESCRIPTION
The main feature of this PR is a complete overwhaul of the "Announce" processing. Initially it had to be done in a quite weird way, since we hadn't supported real reshares at that point in time. But now we support it, so we can simplify the feature.

Also this PR contains some more improvements for handling with bad URL.