### PR TITLE
Fixes "Invalid URL for photo" for photos without host

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -29,6 +29,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException;
 use Friendica\Network\Probe;
 use Friendica\Protocol\ActivityNamespace;
@@ -358,12 +359,12 @@ class APContact
 		$apcontact['discoverable'] = JsonLD::fetchElement($compacted, 'toot:discoverable', '@value');
 
 		if (!empty($apcontact['photo'])) {
-			$apcontact['photo'] = trim($apcontact['photo']);
-		}
+			$apcontact['photo'] = Network::addBasePath($apcontact['photo'], $apcontact['url']);
 
-		if (!empty($apcontact['photo']) && !Network::isValidHttpUrl($apcontact['photo'])) {
-			Logger::warning('Invalid URL for photo', ['url' => $apcontact['url'], 'photo' => $apcontact['photo']]);
-			$apcontact['photo'] = '';
+			if (!Network::isValidHttpUrl($apcontact['photo'])) {
+				Logger::warning('Invalid URL for photo', ['url' => $apcontact['url'], 'photo' => $apcontact['photo']]);
+				$apcontact['photo'] = '';
+			}
 		}
 
 		// When the photo is too large, try to shorten it by removing parts

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -120,9 +120,13 @@ class Probe
 
 		$numeric_fields = ['gsid', 'hide', 'account-type', 'manually-approve'];
 
-		if (!empty($data['photo']) && !Network::isValidHttpUrl($data['photo'])) {
-			Logger::warning('Invalid URL for photo', ['url' => $data['url'], 'photo' => $data['photo']]);
-			unset($data['photo']);
+		if (!empty($data['photo'])) {
+			$data['photo'] = Network::addBasePath($data['photo'], $data['url']);
+
+			if (!Network::isValidHttpUrl($data['photo'])) {
+				Logger::warning('Invalid URL for photo', ['url' => $data['url'], 'photo' => $data['photo']]);
+				unset($data['photo']);
+			}
 		}
 
 		$newdata = [];
@@ -1684,11 +1688,8 @@ class Probe
 		}
 		if ($avatar) {
 			foreach ($avatar->attributes as $attribute) {
-				if ($attribute->name == 'src') {
-					$data['photo'] = trim($attribute->value);
-					if (!empty($data['photo']) && !parse_url($data['photo'], PHP_URL_SCHEME) && !parse_url($data['photo'], PHP_URL_HOST)) {
-						$data['photo'] = $baseurl . $data['photo'];
-					}
+				if (($attribute->name == 'src') && !empty($attribute->value)) {
+					$data['photo'] = Network::addBasePath($attribute->value, $baseurl);
 				}
 			}
 		}


### PR DESCRIPTION
Should fix the warning "Invalid URL for photo" when a remote system uses relative URL to point to the avatar picture.