### PR TITLE
Mastodon notifications api fixes

### DIFF
--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -63,7 +63,6 @@ class Notifications extends BaseApi
 			'exclude_types' => [],    // Array of types to exclude (follow, favourite, reblog, mention, poll, follow_request)
 			'account_id'    => 0,     // Return only notifications received from this account
 			'with_muted'    => false, // Pleroma extension: return activities by muted (not by blocked!) users.
-			'count'         => 0,
 			'include_all'   => false  // Include dismissed and undismissed
 		], $request);
 

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -68,9 +68,12 @@ class Notifications extends BaseApi
 
 		$params = ['order' => ['id' => true]];
 
-		$condition = ['uid' => $uid, 'dismissed' => false];
-		if ($request['include_all']) {
-			$condition = ['uid' => $uid];
+		$condition = ["`uid` = ? AND (NOT `type` IN (?, ?))", $uid,
+			Post\UserNotification::TYPE_ACTIVITY_PARTICIPATION,
+			POST\UserNotification::TYPE_COMMENT_PARTICIPATION];
+
+		if (!$request['include_all']) {
+			$condition = DBA::mergeConditions($condition, ['dismissed' => false]);
 		}
 
 		if (!empty($request['account_id'])) {

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -84,15 +84,21 @@ class Notifications extends BaseApi
 		}
 
 		if (in_array(Notification::TYPE_INTRODUCTION, $request['exclude_types'])) {
-			$condition = DBA::mergeConditions($condition,
+			$condition = DBA::mergeConditions(
+				$condition,
 				["(`vid` != ? OR `type` != ? OR NOT `actor-id` IN (SELECT `id` FROM `contact` WHERE `pending`))",
-				Verb::getID(Activity::FOLLOW), Post\UserNotification::TYPE_NONE]);
+				Verb::getID(Activity::FOLLOW),
+				Post\UserNotification::TYPE_NONE]
+			);
 		}
 
 		if (in_array(Notification::TYPE_FOLLOW, $request['exclude_types'])) {
-			$condition = DBA::mergeConditions($condition,
+			$condition = DBA::mergeConditions(
+				$condition,
 				["(`vid` != ? OR `type` != ? OR NOT `actor-id` IN (SELECT `id` FROM `contact` WHERE NOT `pending`))",
-				Verb::getID(Activity::FOLLOW), Post\UserNotification::TYPE_NONE]);
+				Verb::getID(Activity::FOLLOW),
+				Post\UserNotification::TYPE_NONE]
+			);
 		}
 
 		if (in_array(Notification::TYPE_LIKE, $request['exclude_types'])) {
@@ -134,7 +140,7 @@ class Notifications extends BaseApi
 			$request['limit']
 		);
 
-		foreach($Notifications as $Notification) {
+		foreach ($Notifications as $Notification) {
 			try {
 				$mstdnNotifications[] = DI::mstdnNotification()->createFromNotification($Notification, self::appSupportsQuotes());
 				self::setBoundaries($Notification->id);


### PR DESCRIPTION
The Mastodon Notifications API was producing irregular return result counts. This was caused by Friendica Notifications types that don't have any mapping to Mastodon API types thus causing conversion exceptions. In extreme cases all results returned from the database would fail conversion and thus the return set was empty and the paging data was non-existent to step over it. This change adds the TYPE_ACTIVITY_PARTICIPATION and TYPE_COMMENT_PARTICIPATION which were causing the problem without mapping.

This also removes an unused query parameter that I accidentally added when adding the "include_all" query parameter and an automatic style clean up on the rest of the file.