### PR TITLE
Fix mastodon api search

### DIFF
--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -108,8 +108,7 @@ class Search extends BaseApi
 	 */
 	private static function searchAccounts(int $uid, string $q, bool $resolve, int $limit, int $offset, bool $following)
 	{
-		if (
-			($offset == 0) && (strrpos($q, '@') > 0 || Network::isValidHttpUrl($q))
+		if (($offset == 0) && (strrpos($q, '@') > 0 || Network::isValidHttpUrl($q))
 			&& $id = Contact::getIdForURL($q, 0, $resolve ? null : false)
 		) {
 			return DI::mstdnAccount()->createFromContactId($id, $uid);

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -77,7 +77,7 @@ class Search extends BaseApi
 			}
 		}
 
-		if ((empty($request['type']) || ($request['type'] == 'statuses')) && (!strpos($request['q'], '@') || $request['resolve'])) {
+		if (empty($request['type']) || ($request['type'] == 'statuses')) {
 			$result['statuses'] = self::searchStatuses($uid, $request['q'], $request['account_id'], $request['max_id'], $request['min_id'], $limit, $request['offset']);
 
 			if (!is_array($result['statuses'])) {

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -77,7 +77,7 @@ class Search extends BaseApi
 			}
 		}
 
-		if ((empty($request['type']) || ($request['type'] == 'statuses')) && (strpos($request['q'], '@') == false)) {
+		if ((empty($request['type']) || ($request['type'] == 'statuses')) && (!strpos($request['q'], '@') || $request['resolve'])) {
 			$result['statuses'] = self::searchStatuses($uid, $request['q'], $request['account_id'], $request['max_id'], $request['min_id'], $limit, $request['offset']);
 
 			if (!is_array($result['statuses'])) {


### PR DESCRIPTION
When trying to do a "resolve" search query on Mastodon links the results would always come up with nothing because it was using an @-symbol filter for the general case. I believe it was doing that so it wouldn't run a hash or status query when the user was only looking for account queries. However Mastodon links often have @-symbols in their full URL. This change keeps the behavior if a general query is executed but if the API request is specifically asking to resolve links then it will execute the status query regardless of if there is an @-symbol there or not. 

This also fixes a style error that came up during phpcs scan. 