### PR TITLE
Activities are now displayed as Emojis

### DIFF
--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -979,6 +979,11 @@ class Conversation
 			$condition['author-hidden'] = false;
 		}
 
+		if ($this->config->get('system', 'emoji_activities')) {
+			$emojis = $this->getEmojis($uriids);
+			$condition = DBA::mergeConditions($condition, ["(`gravity` != ? OR `origin`)", ItemModel::GRAVITY_ACTIVITY]);
+		}
+
 		$condition = DBA::mergeConditions($condition,
 			["`uid` IN (0, ?) AND (NOT `vid` IN (?, ?, ?) OR `vid` IS NULL)", $uid, Verb::getID(Activity::FOLLOW), Verb::getID(Activity::VIEW), Verb::getID(Activity::READ)]);
 
@@ -1081,6 +1086,8 @@ class Conversation
 		}
 
 		foreach ($items as $key => $row) {
+			$items[$key]['emojis'] = $emojis[$key] ?? [];
+
 			$always_display = in_array($mode, [self::MODE_CONTACTS, self::MODE_CONTACT_POSTS]);
 
 			$items[$key]['user-blocked-author']   = !$always_display && in_array($row['author-id'], $blocks);
@@ -1100,6 +1107,53 @@ class Conversation
 
 		$this->profiler->stopRecording();
 		return $items;
+	}
+
+	/**
+	 * Fetch emoji reaction from the conversation
+	 *
+	 * @param array $uriids
+	 * @return array
+	 */
+	private function getEmojis(array $uriids): array
+	{
+		$activity_emoji = [
+			Activity::LIKE        => '👍',
+			Activity::DISLIKE     => '👎',
+			Activity::ATTEND      => '✔️',
+			Activity::ATTENDMAYBE => '❓',
+			Activity::ATTENDNO    => '❌',
+			Activity::ANNOUNCE    => '♻',
+			Activity::VIEW        => '📺',
+		];
+
+		$index_list = array_values($activity_emoji);
+		$verbs      = array_merge(array_keys($activity_emoji), [Activity::EMOJIREACT]);
+
+		$condition = DBA::mergeConditions(['parent-uri-id' => $uriids, 'gravity' => ItemModel::GRAVITY_ACTIVITY, 'verb' => $verbs], ["NOT `deleted`"]);
+		$separator = chr(255) . chr(255) . chr(255);
+
+		$sql = "SELECT `thr-parent-id`, `body`, `verb`, COUNT(*) AS `total`, GROUP_CONCAT(REPLACE(`author-name`, '" . $separator . "', ' ') SEPARATOR '". $separator ."' LIMIT 50) AS `title` FROM `post-view` WHERE " . array_shift($condition) . " GROUP BY `thr-parent-id`, `verb`, `body`";
+
+		$emojis = [];
+
+		$rows = DBA::p($sql, $condition);
+		while ($row = DBA::fetch($rows)) {
+			$row['verb'] = $row['body'] ? Activity::EMOJIREACT : $row['verb'];
+			$emoji       = $row['body'] ?: $activity_emoji[$row['verb']];
+			if (!isset($index_list[$emoji])) {
+				$index_list[] = $emoji;
+			}
+			$index = array_search($emoji, $index_list);
+
+			$emojis[$row['thr-parent-id']][$index]['emoji'] = $emoji;
+			$emojis[$row['thr-parent-id']][$index]['verb']  = $row['verb'];
+			$emojis[$row['thr-parent-id']][$index]['total'] = $emojis[$row['thr-parent-id']][$emoji]['total'] ?? 0 + $row['total'];
+			$emojis[$row['thr-parent-id']][$index]['title'] = array_unique(array_merge($emojis[$row['thr-parent-id']][$emoji]['title'] ?? [], explode($separator, $row['title'])));
+		}
+		DBA::close($rows);
+
+		return $emojis;
 	}
 
 	/**

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -534,6 +534,7 @@ class Post
 			'vote'            => $buttons,
 			'like_html'       => $responses['like']['output'],
 			'dislike_html'    => $responses['dislike']['output'],
+			'emojis'          => $this->getEmojis($item),
 			'responses'       => $responses,
 			'switchcomment'   => DI::l10n()->t('Comment'),
 			'reply_label'     => DI::l10n()->t('Reply to %s', $profile_name),
@@ -600,6 +601,70 @@ class Post
 		$result['threaded']           = $this->isThreaded();
 
 		return $result;
+	}
+
+	/**
+	 * Fetch emojis
+	 *
+	 * @param array $item
+	 * @return array
+	 */
+	private function getEmojis(array $item): array
+	{
+		if (empty($item['emojis'])) {
+			return [];
+		}
+
+		$emojis = [];
+		foreach ($item['emojis'] as $index => $element) {
+			$actors = implode(', ', $element['title']);
+			switch ($element['verb']) {
+				case Activity::ANNOUNCE:
+					$title = DI::l10n()->t('Reshared by: %s', $actors);
+					$icon  = ['fa' => 'fa-retweet', 'icon' => 'icon-retweet'];
+					break;
+
+				case Activity::VIEW:
+					$title = DI::l10n()->t('Viewed by: %s', $actors);
+					$icon  = ['fa' => 'fa-eye', 'icon' => 'icon-eye-open'];
+					break;
+
+				case Activity::LIKE:
+					$title = DI::l10n()->t('Liked by: %s', $actors);
+					$icon  = ['fa' => 'fa-thumbs-up', 'icon' => 'icon-thumbs-up'];
+					break;
+
+				case Activity::DISLIKE:
+					$title = DI::l10n()->t('Disliked by: %s', $actors);
+					$icon  = ['fa' => 'fa-thumbs-down', 'icon' => 'icon-thumbs-down'];
+					break;
+
+				case Activity::ATTEND:
+					$title = DI::l10n()->t('Attended by: %s', $actors);
+					$icon  = ['fa' => 'fa-check', 'icon' => 'icon-ok'];
+					break;
+
+				case Activity::ATTENDMAYBE:
+					$title = DI::l10n()->t('Maybe attended by: %s', $actors);
+					$icon  = ['fa' => 'fa-question', 'icon' => 'icon-question'];
+					break;
+
+				case Activity::ATTENDNO:
+					$title = DI::l10n()->t('Not attended by: %s', $actors);
+					$icon  = ['fa' => 'fa-times', 'icon' => 'icon-remove'];
+					break;
+
+				default:
+					$title = DI::l10n()->t('Reacted with %s by: %s', $element['emoji'], $actors);
+					$icon  = [];
+					break;
+				break;
+			}
+			$emojis[$index] = ['emoji' => $element['emoji'], 'total' => $element['total'], 'title' => $title, 'icon' => $icon];
+		}
+		ksort($emojis);
+
+		return $emojis;
 	}
 
 	/**

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -282,6 +282,10 @@ return [
 		// restricts develop log writes to requests originating from this IP address.
 		'dlogip' => '',
 
+		// emoji_activities (Boolean)
+		// Display received activities (like, dislike, reshare) as emojis
+		'emoji_activities' => false,
+
 		// expire-notify-priority (integer)
 		// Priority for the expirary notification
 		'expire-notify-priority' => Friendica\Core\Worker::PRIORITY_LOW,

--- a/view/global.css
+++ b/view/global.css
@@ -98,6 +98,9 @@ span.connector {
   margin-right: 0px;
 }
 
+.wall-item-emoji {
+  margin-right: 5px;
+}
 
 .wall-item-like-expanded,
 .wall-item-dislike-expanded,

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2023.03-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 12:37+0000\n"
+"POT-Creation-Date: 2023-02-18 06:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -294,7 +294,7 @@ msgstr ""
 #: mod/message.php:203 mod/message.php:360 mod/photos.php:1291
 #: src/Content/Conversation.php:381 src/Content/Conversation.php:727
 #: src/Module/Item/Compose.php:204 src/Module/Post/Edit.php:142
-#: src/Module/Profile/UnkMail.php:155 src/Object/Post.php:544
+#: src/Module/Profile/UnkMail.php:155 src/Object/Post.php:545
 msgid "Please wait"
 msgstr ""
 
@@ -311,7 +311,7 @@ msgstr ""
 #: src/Module/Install.php:331 src/Module/Invite.php:178
 #: src/Module/Item/Compose.php:189 src/Module/Moderation/Item/Source.php:79
 #: src/Module/Profile/Profile.php:274 src/Module/Profile/UnkMail.php:156
-#: src/Module/Settings/Profile/Index.php:231 src/Object/Post.php:993
+#: src/Module/Settings/Profile/Index.php:231 src/Object/Post.php:1058
 #: view/theme/duepuntozero/config.php:85 view/theme/frio/config.php:171
 #: view/theme/quattro/config.php:87 view/theme/vier/config.php:135
 msgid "Submit"
@@ -596,24 +596,24 @@ msgstr ""
 
 #: mod/photos.php:1135 mod/photos.php:1191 mod/photos.php:1265
 #: src/Module/Contact.php:589 src/Module/Item/Compose.php:188
-#: src/Object/Post.php:990
+#: src/Object/Post.php:1055
 msgid "This is you"
 msgstr ""
 
 #: mod/photos.php:1137 mod/photos.php:1193 mod/photos.php:1267
-#: src/Object/Post.php:538 src/Object/Post.php:992
+#: src/Object/Post.php:539 src/Object/Post.php:1057
 msgid "Comment"
 msgstr ""
 
 #: mod/photos.php:1139 mod/photos.php:1195 mod/photos.php:1269
 #: src/Content/Conversation.php:396 src/Module/Calendar/Event/Form.php:248
 #: src/Module/Item/Compose.php:199 src/Module/Post/Edit.php:162
-#: src/Object/Post.php:1004
+#: src/Object/Post.php:1069
 msgid "Preview"
 msgstr ""
 
 #: mod/photos.php:1140 src/Content/Conversation.php:351
-#: src/Module/Post/Edit.php:127 src/Object/Post.php:994
+#: src/Module/Post/Edit.php:127 src/Object/Post.php:1059
 msgid "Loading..."
 msgstr ""
 
@@ -1140,7 +1140,7 @@ msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
 #: src/Content/Conversation.php:321 src/Module/Item/Compose.php:198
-#: src/Object/Post.php:1003
+#: src/Object/Post.php:1068
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
@@ -1185,42 +1185,42 @@ msgid "attach file"
 msgstr ""
 
 #: src/Content/Conversation.php:356 src/Module/Item/Compose.php:190
-#: src/Module/Post/Edit.php:168 src/Object/Post.php:995
+#: src/Module/Post/Edit.php:168 src/Object/Post.php:1060
 msgid "Bold"
 msgstr ""
 
 #: src/Content/Conversation.php:357 src/Module/Item/Compose.php:191
-#: src/Module/Post/Edit.php:169 src/Object/Post.php:996
+#: src/Module/Post/Edit.php:169 src/Object/Post.php:1061
 msgid "Italic"
 msgstr ""
 
 #: src/Content/Conversation.php:358 src/Module/Item/Compose.php:192
-#: src/Module/Post/Edit.php:170 src/Object/Post.php:997
+#: src/Module/Post/Edit.php:170 src/Object/Post.php:1062
 msgid "Underline"
 msgstr ""
 
 #: src/Content/Conversation.php:359 src/Module/Item/Compose.php:193
-#: src/Module/Post/Edit.php:171 src/Object/Post.php:998
+#: src/Module/Post/Edit.php:171 src/Object/Post.php:1063
 msgid "Quote"
 msgstr ""
 
 #: src/Content/Conversation.php:360 src/Module/Item/Compose.php:194
-#: src/Module/Post/Edit.php:172 src/Object/Post.php:999
+#: src/Module/Post/Edit.php:172 src/Object/Post.php:1064
 msgid "Code"
 msgstr ""
 
 #: src/Content/Conversation.php:361 src/Module/Item/Compose.php:195
-#: src/Object/Post.php:1000
+#: src/Object/Post.php:1065
 msgid "Image"
 msgstr ""
 
 #: src/Content/Conversation.php:362 src/Module/Item/Compose.php:196
-#: src/Module/Post/Edit.php:173 src/Object/Post.php:1001
+#: src/Module/Post/Edit.php:173 src/Object/Post.php:1066
 msgid "Link"
 msgstr ""
 
 #: src/Content/Conversation.php:363 src/Module/Item/Compose.php:197
-#: src/Module/Post/Edit.php:174 src/Object/Post.php:1002
+#: src/Module/Post/Edit.php:174 src/Object/Post.php:1067
 msgid "Link or Media"
 msgstr ""
 
@@ -1504,25 +1504,25 @@ msgid ""
 "Contact birthday events are private to you."
 msgstr ""
 
-#: src/Content/ForumManager.php:151 src/Content/Nav.php:278
+#: src/Content/ForumManager.php:157 src/Content/Nav.php:278
 #: src/Content/Text/HTML.php:905 src/Content/Widget.php:524
 msgid "Forums"
 msgstr ""
 
-#: src/Content/ForumManager.php:153
+#: src/Content/ForumManager.php:159
 msgid "External link to forum"
 msgstr ""
 
-#: src/Content/ForumManager.php:156 src/Content/Widget.php:503
+#: src/Content/ForumManager.php:162 src/Content/Widget.php:503
 msgid "show less"
 msgstr ""
 
-#: src/Content/ForumManager.php:157 src/Content/Widget.php:405
+#: src/Content/ForumManager.php:163 src/Content/Widget.php:405
 #: src/Content/Widget.php:504
 msgid "show more"
 msgstr ""
 
-#: src/Content/Item.php:326 src/Model/Item.php:2899
+#: src/Content/Item.php:326 src/Model/Item.php:2900
 msgid "event"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:335 src/Model/Item.php:2901
+#: src/Content/Item.php:335 src/Model/Item.php:2902
 #: src/Module/Post/Tag/Add.php:123
 msgid "photo"
 msgstr ""
@@ -1936,8 +1936,8 @@ msgid ""
 "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1191 src/Model/Item.php:3572
-#: src/Model/Item.php:3578 src/Model/Item.php:3579
+#: src/Content/Text/BBCode.php:1191 src/Model/Item.php:3573
+#: src/Model/Item.php:3579 src/Model/Item.php:3580
 msgid "Link to source"
 msgstr ""
 
@@ -2761,22 +2761,22 @@ msgid ""
 "to version 2021.01 and wait until the postupdate finished version 1383."
 msgstr ""
 
-#: src/Core/Update.php:186
+#: src/Core/Update.php:197
 #, php-format
 msgid "%s: executing pre update %d"
 msgstr ""
 
-#: src/Core/Update.php:228
+#: src/Core/Update.php:239
 #, php-format
 msgid "%s: executing post update %d"
 msgstr ""
 
-#: src/Core/Update.php:302
+#: src/Core/Update.php:313
 #, php-format
 msgid "Update %s failed. See error logs."
 msgstr ""
 
-#: src/Core/Update.php:342
+#: src/Core/Update.php:353
 #, php-format
 msgid ""
 "\n"
@@ -2788,16 +2788,16 @@ msgid ""
 "might be invalid."
 msgstr ""
 
-#: src/Core/Update.php:348
+#: src/Core/Update.php:359
 #, php-format
 msgid "The error message is\\n[pre]%s[/pre]"
 msgstr ""
 
-#: src/Core/Update.php:352 src/Core/Update.php:380
+#: src/Core/Update.php:363 src/Core/Update.php:391
 msgid "[Friendica Notify] Database update"
 msgstr ""
 
-#: src/Core/Update.php:374
+#: src/Core/Update.php:385
 #, php-format
 msgid ""
 "\n"
@@ -3106,81 +3106,81 @@ msgstr ""
 msgid "Edit groups"
 msgstr ""
 
-#: src/Model/Item.php:2000
+#: src/Model/Item.php:2001
 #, php-format
 msgid "Detected languages in this post:\\n%s"
 msgstr ""
 
-#: src/Model/Item.php:2903
+#: src/Model/Item.php:2904
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2905
+#: src/Model/Item.php:2906
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2908 src/Module/Post/Tag/Add.php:123
+#: src/Model/Item.php:2909 src/Module/Post/Tag/Add.php:123
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3058
+#: src/Model/Item.php:3059
 #, php-format
 msgid "%s is blocked"
 msgstr ""
 
-#: src/Model/Item.php:3060
+#: src/Model/Item.php:3061
 #, php-format
 msgid "%s is ignored"
 msgstr ""
 
-#: src/Model/Item.php:3062
+#: src/Model/Item.php:3063
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:3066
+#: src/Model/Item.php:3067
 #, php-format
 msgid "Content warning: %s"
 msgstr ""
 
-#: src/Model/Item.php:3484
+#: src/Model/Item.php:3485
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3515
+#: src/Model/Item.php:3516
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3517
+#: src/Model/Item.php:3518
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3522
+#: src/Model/Item.php:3523
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3524
+#: src/Model/Item.php:3525
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3526
+#: src/Model/Item.php:3527
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3560 src/Model/Item.php:3561
+#: src/Model/Item.php:3561 src/Model/Item.php:3562
 msgid "View on separate page"
 msgstr ""
 
@@ -6841,7 +6841,7 @@ msgstr ""
 msgid "Help:"
 msgstr ""
 
-#: src/Module/Home.php:54
+#: src/Module/Home.php:63
 #, php-format
 msgid "Welcome to %s"
 msgstr ""
@@ -11280,48 +11280,88 @@ msgstr ""
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: src/Object/Post.php:539
+#: src/Object/Post.php:540
 #, php-format
 msgid "Reply to %s"
 msgstr ""
 
-#: src/Object/Post.php:542
+#: src/Object/Post.php:543
 msgid "More"
 msgstr ""
 
-#: src/Object/Post.php:560
+#: src/Object/Post.php:561
 msgid "Notifier task is pending"
 msgstr ""
 
-#: src/Object/Post.php:561
+#: src/Object/Post.php:562
 msgid "Delivery to remote servers is pending"
 msgstr ""
 
-#: src/Object/Post.php:562
+#: src/Object/Post.php:563
 msgid "Delivery to remote servers is underway"
 msgstr ""
 
-#: src/Object/Post.php:563
+#: src/Object/Post.php:564
 msgid "Delivery to remote servers is mostly done"
 msgstr ""
 
-#: src/Object/Post.php:564
+#: src/Object/Post.php:565
 msgid "Delivery to remote servers is done"
 msgstr ""
 
-#: src/Object/Post.php:584
+#: src/Object/Post.php:585
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Object/Post.php:585
+#: src/Object/Post.php:586
 msgid "Show more"
 msgstr ""
 
-#: src/Object/Post.php:586
+#: src/Object/Post.php:587
 msgid "Show fewer"
+msgstr ""
+
+#: src/Object/Post.php:623
+#, php-format
+msgid "Reshared by: %s"
+msgstr ""
+
+#: src/Object/Post.php:628
+#, php-format
+msgid "Viewed by: %s"
+msgstr ""
+
+#: src/Object/Post.php:633
+#, php-format
+msgid "Liked by: %s"
+msgstr ""
+
+#: src/Object/Post.php:638
+#, php-format
+msgid "Disliked by: %s"
+msgstr ""
+
+#: src/Object/Post.php:643
+#, php-format
+msgid "Attended by: %s"
+msgstr ""
+
+#: src/Object/Post.php:648
+#, php-format
+msgid "Maybe attended by: %s"
+msgstr ""
+
+#: src/Object/Post.php:653
+#, php-format
+msgid "Not attended by: %s"
+msgstr ""
+
+#: src/Object/Post.php:658
+#, php-format
+msgid "Reacted with %s by: %s"
 msgstr ""
 
 #: src/Protocol/Delivery.php:547

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -178,7 +178,15 @@
 					<div class="wall-item-bottom">
 						<div class="wall-item-links">
 						</div>
-                        {{if $item.responses}}
+						{{if $item.emojis}}
+							{{foreach $item.emojis as $emoji}}
+								{{if $emoji.icon.icon}}
+									<span class="wall-item-emoji" title="{{$emoji.title}}"><i class="{{$emoji.icon.icon}} icon-large" aria-hidden="true"></i> {{$emoji.total}}</span>
+								{{else}}
+									<span class="wall-item-emoji" title="{{$emoji.title}}">{{$emoji.emoji}} {{$emoji.total}}</span>
+								{{/if}}
+							{{/foreach}}
+                        {{elseif $item.responses}}
                             {{foreach $item.responses as $verb=>$response}}
 								<div class="wall-item-{{$verb}}" id="wall-item-{{$verb}}-{{$item.id}}">{{$response.output nofilter}}</div>
                             {{/foreach}}

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -277,12 +277,20 @@
 			</p><!--./wall-item-actions-->
 
 			{{* Display likes, dislike and attendance stats *}}
-			{{if $item.responses}}
-			<div class="wall-item-responses">
-				{{foreach $item.responses as $verb=>$response}}
-				<div class="wall-item-{{$verb}}" id="wall-item-{{$verb}}-{{$item.id}}">{{$response.output nofilter}}</div>
+			{{if $item.emojis}}
+				{{foreach $item.emojis as $emoji}}
+					{{if $emoji.icon.fa}}
+						<span class="wall-item-emoji" title="{{$emoji.title}}"><i class="fa {{$emoji.icon.fa}}" aria-hidden="true"></i> {{$emoji.total}}</span>
+					{{else}}
+						<span class="wall-item-emoji" title="{{$emoji.title}}">{{$emoji.emoji}} {{$emoji.total}}</span>
+					{{/if}}
 				{{/foreach}}
-			</div>
+			{{elseif $item.responses}}
+				<div class="wall-item-responses">
+				{{foreach $item.responses as $verb=>$response}}
+					<div class="wall-item-{{$verb}}" id="wall-item-{{$verb}}-{{$item.id}}">{{$response.output nofilter}}</div>
+				{{/foreach}}
+				</div>
 			{{/if}}
 
 			<div class="wall-item-conv" id="wall-item-conv-{{$item.id}}" dir="auto">

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -582,13 +582,21 @@ as the value of $top_child_total (this is done at the end of this file)
 		<div class="wall-item-links"></div>
 
 		{{* Display likes, dislike and attendance stats *}}
-	{{if $item.responses}}
-		<div class="wall-item-responses">
-			{{foreach $item.responses as $verb=>$response}}
-			<div class="wall-item-{{$verb}}" id="wall-item-{{$verb}}-{{$item.id}}">{{$response.output nofilter}}</div>
+		{{if $item.emojis}}
+			{{foreach $item.emojis as $emoji}}
+				{{if $emoji.icon.fa}}
+					<span class="wall-item-emoji" title="{{$emoji.title}}"><i class="fa {{$emoji.icon.fa}}" aria-hidden="true"></i> {{$emoji.total}}</span>
+				{{else}}
+					<span class="wall-item-emoji" title="{{$emoji.title}}">{{$emoji.emoji}} {{$emoji.total}}</span>
+				{{/if}}
 			{{/foreach}}
-		</div>
-	{{/if}}
+		{{elseif $item.responses}}
+			<div class="wall-item-responses">
+			{{foreach $item.responses as $verb=>$response}}
+				<div class="wall-item-{{$verb}}" id="wall-item-{{$verb}}-{{$item.id}}">{{$response.output nofilter}}</div>
+			{{/foreach}}
+			</div>
+		{{/if}}
 
 		{{* Insert comment box of threaded children *}}
 		{{if $item.threaded && $item.comment_html && $item.indent==comment}}

--- a/view/theme/quattro/templates/wall_thread.tpl
+++ b/view/theme/quattro/templates/wall_thread.tpl
@@ -160,7 +160,11 @@
 	</div>
 	<div class="wall-item-bottom">
 		<div class="wall-item-links"></div>
-		{{if $item.responses}}
+		{{if $item.emojis}}
+			{{foreach $item.emojis as $emoji}}
+				<span class="wall-item-emoji" title="{{$emoji.title}}">{{$emoji.emoji}} {{$emoji.total}}</span>
+			{{/foreach}}
+		{{elseif $item.responses}}
 			{{foreach $item.responses as $verb=>$response}}
 				<div class="wall-item-{{$verb}}" id="wall-item-{{$verb}}-{{$item.id}}">{{$response.output nofilter}}</div>
 			{{/foreach}}


### PR DESCRIPTION
When enabled, activities (like, displike, reshares) are now displayed as emojis. also we now display emoji reactions from systems like Misskey or Pleroma.

![grafik](https://user-images.githubusercontent.com/844208/219846668-25d8d0f4-72dd-40d4-80e4-1fda15375d50.png)
![grafik](https://user-images.githubusercontent.com/844208/219846711-8da35c6e-f984-481a-bf4f-6270715f730a.png)
![grafik](https://user-images.githubusercontent.com/844208/219846772-7efcee02-b4ee-4906-a54f-09ee715b4717.png)
![grafik](https://user-images.githubusercontent.com/844208/219846874-16d5fb10-a5ee-4a47-88cb-7de71ce176fa.png)

Also there is no memory issue any more displaying higher numbers:
![grafik](https://user-images.githubusercontent.com/844208/219847243-c9ac6acd-5363-442a-873c-662773a975b7.png)

We can now also display the viewer counts of Peertube videos:
![grafik](https://user-images.githubusercontent.com/844208/219847421-61ef0a1f-956c-407a-a2ac-c0a7c8d19973.png)
