### PR TITLE
Add tables to Optimize Worker

### DIFF
--- a/src/Worker/OptimizeTables.php
+++ b/src/Worker/OptimizeTables.php
@@ -57,6 +57,7 @@ class OptimizeTables
 		DBA::e("OPTIMIZE TABLE `notify`");
 		DBA::e("OPTIMIZE TABLE `oembed`");
 		DBA::e("OPTIMIZE TABLE `parsed_url`");
+		DBA::e("OPTIMIZE TABLE `session`");
 		DBA::e("OPTIMIZE TABLE `photo`");
 		DBA::e("OPTIMIZE TABLE `post`");
 		DBA::e("OPTIMIZE TABLE `post-content`");

--- a/src/Worker/OptimizeTables.php
+++ b/src/Worker/OptimizeTables.php
@@ -40,11 +40,33 @@ class OptimizeTables
 
 		Logger::info('Optimize start');
 
+		DBA::e("OPTIMIZE TABLE `apcontact`");
 		DBA::e("OPTIMIZE TABLE `cache`");
+		DBA::e("OPTIMIZE TABLE `contact`");
+		DBA::e("OPTIMIZE TABLE `contact-relation`");
+		DBA::e("OPTIMIZE TABLE `conversation`");
+		DBA::e("OPTIMIZE TABLE `diaspora-contact`");
+		DBA::e("OPTIMIZE TABLE `diaspora-interaction`");
+		DBA::e("OPTIMIZE TABLE `fcontact`");
+		DBA::e("OPTIMIZE TABLE `gserver`");
+		DBA::e("OPTIMIZE TABLE `gserver-tag`");
 		DBA::e("OPTIMIZE TABLE `locks`");
+		DBA::e("OPTIMIZE TABLE `inbox-status`");
+		DBA::e("OPTIMIZE TABLE `item-uri`");
+		DBA::e("OPTIMIZE TABLE `notification`");
+		DBA::e("OPTIMIZE TABLE `notify`");
 		DBA::e("OPTIMIZE TABLE `oembed`");
 		DBA::e("OPTIMIZE TABLE `parsed_url`");
-		DBA::e("OPTIMIZE TABLE `session`");
+		DBA::e("OPTIMIZE TABLE `photo`");
+		DBA::e("OPTIMIZE TABLE `post`");
+		DBA::e("OPTIMIZE TABLE `post-content`");
+		DBA::e("OPTIMIZE TABLE `post-delivery-data`");
+		DBA::e("OPTIMIZE TABLE `post-link`");
+		DBA::e("OPTIMIZE TABLE `post-thread`");
+		DBA::e("OPTIMIZE TABLE `post-thread-user`");
+		DBA::e("OPTIMIZE TABLE `post-user`");
+		DBA::e("OPTIMIZE TABLE `storage`");
+		DBA::e("OPTIMIZE TABLE `tag`");
 
 		Logger::info('Optimize end');
 


### PR DESCRIPTION
Between discussions about table cleanup after changing windows in #12810 and my issues with cleaning up the gserver table on my machine from the troll attack I executed `SQL OPTIMIZE` manually on most of the tables in the database. I created a list of any table optimization that saved more than a few MB of space on the disk either in the actual data or in the freed data. That list was then used to add to the list of tables to optimize when this worker runs. 

I am not a DBA so if there is a reason why some of these larger tables should not be in the list then they should of course be removed. Excluding the incredibly over-bloated gserver table on my server saving almost 9 GB of free space I recovered about 3 GB of disk space with the below optimization list.