### PR TITLE
Dislike capabilities for Mastodon compatible endpoints

### DIFF
--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -59,12 +59,18 @@ class Status extends BaseFactory
 	/** @var ContentItem */
 	private $contentItem;
 
-	public function __construct(LoggerInterface $logger, Database $dba,
-		Account $mstdnAccountFactory, Mention $mstdnMentionFactory,
-		Tag $mstdnTagFactory, Card $mstdnCardFactory,
-		Attachment $mstdnAttachementFactory, Error $mstdnErrorFactory,
-		Poll $mstdnPollFactory, ContentItem $contentItem)
-	{
+	public function __construct(
+		LoggerInterface $logger,
+		Database $dba,
+		Account $mstdnAccountFactory,
+		Mention $mstdnMentionFactory,
+		Tag $mstdnTagFactory,
+		Card $mstdnCardFactory,
+		Attachment $mstdnAttachementFactory,
+		Error $mstdnErrorFactory,
+		Poll $mstdnPollFactory,
+		ContentItem $contentItem
+	) {
 		parent::__construct($logger);
 		$this->dba                     = $dba;
 		$this->mstdnAccountFactory     = $mstdnAccountFactory;

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -144,10 +144,18 @@ class Status extends BaseFactory
 			'deleted'       => false
 		]);
 
+		$count_dislike = Post::countPosts([
+			'thr-parent-id' => $uriId,
+			'gravity'       => Item::GRAVITY_ACTIVITY,
+			'vid'           => Verb::getID(Activity::DISLIKE),
+			'deleted'       => false
+		]);
+
 		$counts = new \Friendica\Object\Api\Mastodon\Status\Counts(
 			Post::countPosts(['thr-parent-id' => $uriId, 'gravity' => Item::GRAVITY_COMMENT, 'deleted' => false], []),
 			$count_announce,
-			$count_like
+			$count_like,
+			$count_dislike
 		);
 
 		$origin_like = ($count_like == 0) ? false : Post::exists([
@@ -323,7 +331,7 @@ class Status extends BaseFactory
 
 		$replies = $this->dba->count('mail', ['thr-parent-id' => $item['uri-id'], 'reply' => true]);
 
-		$counts = new \Friendica\Object\Api\Mastodon\Status\Counts($replies, 0, 0);
+		$counts = new \Friendica\Object\Api\Mastodon\Status\Counts($replies, 0, 0, 0);
 
 		$userAttributes = new \Friendica\Object\Api\Mastodon\Status\UserAttributes(false, false, false, false, false);
 

--- a/src/Module/Api/Friendica/Statuses/Dislike.php
+++ b/src/Module/Api/Friendica/Statuses/Dislike.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2023, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Module\Api\Friendica\Statuses;
+
+use Friendica\Core\System;
+use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Model\Item;
+use Friendica\Model\Post;
+use Friendica\Module\BaseApi;
+
+/**
+ * @see https://docs.joinmastodon.org/methods/statuses/
+ */
+class Dislike extends BaseApi
+{
+	protected function post(array $request = [])
+	{
+		self::checkAllowedScope(self::SCOPE_WRITE);
+		$uid = self::getCurrentUserID();
+
+		if (empty($this->parameters['id'])) {
+			DI::mstdnError()->UnprocessableEntity();
+		}
+
+		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
+		if (!DBA::isResult($item)) {
+			DI::mstdnError()->RecordNotFound();
+		}
+
+		Item::performActivity($item['id'], 'dislike', $uid);
+
+		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
+	}
+}

--- a/src/Module/Api/Friendica/Statuses/DislikedBy.php
+++ b/src/Module/Api/Friendica/Statuses/DislikedBy.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2023, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Module\Api\Friendica\Statuses;
+
+use Friendica\Core\System;
+use Friendica\DI;
+use Friendica\Model\Item;
+use Friendica\Model\Post;
+use Friendica\Module\BaseApi;
+use Friendica\Protocol\Activity;
+
+/**
+ * @see https://docs.joinmastodon.org/methods/statuses/
+ */
+class DislikedBy extends BaseApi
+{
+	/**
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	protected function rawContent(array $request = [])
+	{
+		$uid = self::getCurrentUserID();
+
+		if (empty($this->parameters['id'])) {
+			DI::mstdnError()->UnprocessableEntity();
+		}
+
+		$id = $this->parameters['id'];
+		if (!Post::exists(['uri-id' => $id, 'uid' => [0, $uid]])) {
+			DI::mstdnError()->RecordNotFound();
+		}
+
+		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $id, 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::DISLIKE, 'deleted' => false]);
+
+		$accounts = [];
+
+		while ($activity = Post::fetch($activities)) {
+			$accounts[] = DI::mstdnAccount()->createFromContactId($activity['author-id'], $uid);
+		}
+
+		System::jsonExit($accounts);
+	}
+}

--- a/src/Module/Api/Friendica/Statuses/Undislike.php
+++ b/src/Module/Api/Friendica/Statuses/Undislike.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2023, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Module\Api\Friendica\Statuses;
+
+use Friendica\Core\System;
+use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Model\Item;
+use Friendica\Model\Post;
+use Friendica\Module\BaseApi;
+
+/**
+ * @see https://docs.joinmastodon.org/methods/statuses/
+ */
+class Undislike extends BaseApi
+{
+	protected function post(array $request = [])
+	{
+		self::checkAllowedScope(self::SCOPE_WRITE);
+		$uid = self::getCurrentUserID();
+
+		if (empty($this->parameters['id'])) {
+			DI::mstdnError()->UnprocessableEntity();
+		}
+
+		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
+		if (!DBA::isResult($item)) {
+			DI::mstdnError()->RecordNotFound();
+		}
+
+		Item::performActivity($item['id'], 'undislike', $uid);
+
+		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
+	}
+}

--- a/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
@@ -49,7 +49,7 @@ class FavouritedBy extends BaseApi
 			DI::mstdnError()->RecordNotFound();
 		}
 
-		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $id, 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::LIKE]);
+		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $id, 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::LIKE, 'deleted' => false]);
 
 		$accounts = [];
 

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -151,7 +151,7 @@ class Status extends BaseDataTransferObject
 		$this->emojis = [];
 		$this->card = $card->toArray() ?: null;
 		$this->poll = $poll;
-		$this->friendica = new FriendicaExtension($item['title']);
+		$this->friendica = new FriendicaExtension($item['title'], $counts->dislikes);
 	}
 
 	/**

--- a/src/Object/Api/Mastodon/Status/Counts.php
+++ b/src/Object/Api/Mastodon/Status/Counts.php
@@ -35,6 +35,9 @@ class Counts
 	/** @var int */
 	protected $favourites;
 
+	/** @var int */
+	protected $dislikes;
+
 	/**
 	 * Creates a status count object
 	 *
@@ -43,14 +46,16 @@ class Counts
 	 * @param int $favourites
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function __construct(int $replies, int $reblogs, int $favourites)
+	public function __construct(int $replies, int $reblogs, int $favourites, int $dislikes)
 	{
-		$this->replies = $replies;
-		$this->reblogs = $reblogs;
+		$this->replies    = $replies;
+		$this->reblogs    = $reblogs;
 		$this->favourites = $favourites;
+		$this->dislikes   = $dislikes;
 	}
 
-	public function __get($name) {
+	public function __get($name)
+	{
 		return $this->$name;
 	}
 }

--- a/src/Object/Api/Mastodon/Status/FriendicaExtension.php
+++ b/src/Object/Api/Mastodon/Status/FriendicaExtension.php
@@ -35,14 +35,18 @@ class FriendicaExtension extends BaseDataTransferObject
 	/** @var string */
 	protected $title;
 
+	/** @var int */
+	protected $dislikes_count;
+
 	/**
 	 * Creates a status count object
 	 *
 	 * @param string $title
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function __construct(string $title)
+	public function __construct(string $title, int $dislikes_count)
 	{
-		$this->title = $title;
+		$this->title          = $title;
+		$this->dislikes_count = $dislikes_count;
 	}
 }

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -80,6 +80,8 @@ $apiRoutes = [
 	'/friendica' => [
 		'/activity/{verb:attendmaybe|attendno|attendyes|dislike|like|unattendmaybe|unattendno|unattendyes|undislike|unlike}[.{extension:json|xml|rss|atom}]'
 			=> [Module\Api\Friendica\Activity::class, [        R::POST]],
+		'/statuses/{id:\d+}/dislike'                               => [Module\Api\Friendica\Statuses\Dislike::class,       [        R::POST]],
+		'/statuses/{id:\d+}/undislike'                             => [Module\Api\Friendica\Statuses\Undislike::class,     [        R::POST]],
 		'/notification/seen[.{extension:json|xml|rss|atom}]'       => [Module\Api\Friendica\Notification\Seen::class,      [        R::POST]],
 		'/notification[.{extension:json|xml|rss|atom}]'            => [Module\Api\Friendica\Notification::class,           [R::GET         ]],
 		'/notifications[.{extension:json|xml|rss|atom}]'           => [Module\Api\Friendica\Notification::class,           [R::GET         ]],

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -81,6 +81,7 @@ $apiRoutes = [
 		'/activity/{verb:attendmaybe|attendno|attendyes|dislike|like|unattendmaybe|unattendno|unattendyes|undislike|unlike}[.{extension:json|xml|rss|atom}]'
 			=> [Module\Api\Friendica\Activity::class, [        R::POST]],
 		'/statuses/{id:\d+}/dislike'                               => [Module\Api\Friendica\Statuses\Dislike::class,       [        R::POST]],
+		'/statuses/{id:\d+}/disliked_by'                           => [Module\Api\Friendica\Statuses\DislikedBy::class,    [R::GET         ]],
 		'/statuses/{id:\d+}/undislike'                             => [Module\Api\Friendica\Statuses\Undislike::class,     [        R::POST]],
 		'/notification/seen[.{extension:json|xml|rss|atom}]'       => [Module\Api\Friendica\Notification\Seen::class,      [        R::POST]],
 		'/notification[.{extension:json|xml|rss|atom}]'            => [Module\Api\Friendica\Notification::class,           [R::GET         ]],


### PR DESCRIPTION
Adds endpoints to the API space that replicates the Dislike capability but with Mastodon compatible JSON
* Adds the `dislike_count` to the Status object's Friendica extensions
* Adds `/api/friendica/statuses/:id/dislike` endpoint for the current user to dislike a status, equivalent to `/api/v1/statuses/:id/favourite` from Mastodon API spec with the same Mastodon Status return type
* Adds `/api/friendica/statuses/:id/undislike` endpoint for the current user to undo disliking a status, equivalent to `/api/v1/statuses/:id/unfavourite` from Mastodon API spec with the same Mastodon Status return type
* Adds `/api/friendica/statuses/:id/disliked_by` endpoint for the current list of users that have disliked a status, equivalent to `/api/v1/statuses/:id/favourited_by` from Mastodon API spec with the same Mastodon Status array return type
* Fixes the FavouritedBy Mastodon endpoint to only return active likers of the post. The previous version didn't check for whether they were deleted or not so every like/favorite action by all users was always showing them in the list, repeatedly if they had toggled like multiple times.

Example Status format update fragment:
```json
{
  "id": "281",
  "created_at": "2023-02-18T14:20:34.000Z",
  "in_reply_to_id": null,
  "in_reply_to_status": null,
  "in_reply_to_account_id": null,
    ...
  "friendica": {
    "title": "",
    "dislikes_count": 1
  }
}
```

