### PR TITLE
Fixed: DomainPatternBlocklist::exportToFile() must be of the type string, null given

### DIFF
--- a/src/Console/ServerBlock.php
+++ b/src/Console/ServerBlock.php
@@ -107,6 +107,11 @@ HELP;
 	{
 		$filename = $this->getArgument(1);
 
+		if (empty($filename)) {
+			$this->out('A file name is required, e.g. ./bin/console serverblock export backup.csv');
+			return 1;
+		}
+
 		$this->blocklist->exportToFile($filename);
 
 		// Success


### PR DESCRIPTION
Fixed:
- added check for empty file name as the export doesn't work without one: `[Error] Argument 1 passed to Friendica\Moderation\DomainPatternBlocklist::exportToFile() must be of the type string, null given, called in /var/www/.../src/Console/ServerBlock.php on line 110`

You can reproduce this by running `./bin/console serverblock export` (omitting the required file name)