### PR TITLE
Update json-ld to 1.1.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -671,11 +671,11 @@
         },
         {
             "name": "friendica/json-ld",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://git.friendi.ca/friendica/php-json-ld",
-                "reference": "ca3916d10d2ad9073b3b1eae383978dbe828e1e1"
+                "reference": "5f6ea87b261d346e57f03457ae906e6835f0205f"
             },
             "require": {
                 "ext-json": "*",
@@ -711,7 +711,7 @@
                 "Semantic Web",
                 "jsonld"
             ],
-            "time": "2018-10-08T20:41:00+00:00"
+            "time": "2023-02-20T21:56:16+00:00"
         },
         {
             "name": "fxp/composer-asset-plugin",


### PR DESCRIPTION
- JSON-LD: Add support for local files for unsecured document loading

see https://git.friendi.ca/friendica/php-json-ld/releases/tag/1.1.2
Addresses https://github.com/friendica/friendica/issues/12728#issuecomment-1407623586
Addresses https://github.com/friendica/friendica/issues/12488#issuecomment-1431144326

@MrPetovan - the `composer.lock` - `content-hash` doesn't change - Even with `bin/composer.phar update --lock`