### PR TITLE
[frio] Use all available space for post interaction buttons (mobile)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1994,6 +1994,18 @@ code > .hl-main {
 .wall-item-actions-right {
 	display: flex;
 }
+.wall-item-actions-items {
+	flex-grow: 1;
+}
+.wall-item-actions-row {
+	display: flex;
+}
+.wall-item-actions-row .btn {
+	width: 100%;
+}
+.wall-item-actions-row > * {
+	flex: 1 1 0;
+}
 .wall-item-actions .checkbox {
 	margin: 0 0 0 15px;
 }
@@ -2001,14 +2013,17 @@ code > .hl-main {
 	.wall-item-actions .btn,
 	.wall-item-actions a,
 	.wall-item-actions button {
-		padding-right: 12px;
-		padding-left: 12px;
+		padding-right: 0;
+		padding-left: 0;
 	}
 	.wall-item-actions .checkbox {
 		margin-top: 8px;
+		flex: 0 1 auto;
 	}
 	.wall-item-actions .like-rotator {
-		padding-top: 8px;	
+		position: absolute;
+		top: 8px;
+		right: 0;
 	}
 }
 .wall-item-actions button:hover {

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -479,12 +479,15 @@ as the value of $top_child_total (this is done at the end of this file)
 									</a>
 								</li>
 								{{/if}}
+								{{if $item.browsershare}}
+								<li role="menuitem">
+									<button type="button" class="btn-link button-browser-share" onclick="navigator.share({url: '{{$item.plink.orig}}'})" title="{{$item.browsershare.1}}">
+										<i class="fa fa-share-alt" aria-hidden="true"></i> {{$item.browsershare.0}}
+									</button>
+								</li>
+								{{/if}}
 							</ul>
 						</div>
-					{{/if}}
-
-					{{if $item.browsershare}}
-						<button type="button" class="btn button-browser-share" onclick="navigator.share({url: '{{$item.plink.orig}}'})" title="{{$item.browsershare.1}}"><i class="fa fa-share-alt"></i></button>
 					{{/if}}
 
 					{{* Put additional actions in a dropdown menu *}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -436,146 +436,146 @@ as the value of $top_child_total (this is done at the end of this file)
 				</span>
 			</span>
 
-			<div class="btn-toolbar btn-group visible-xs" role="group">
-			{{* Buttons for like and dislike *}}
-			{{if $item.vote}}
-				{{if $item.vote.like}}
-					<button type="button" class="btn button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doActivityItemAction({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}});" data-toggle="button"><i class="fa fa-thumbs-up" aria-hidden="true"></i></button>
-				{{/if}}
-				{{if $item.vote.dislike}}
-					<button type="button" class="btn button-likes{{if $item.responses.dislike.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doActivityItemAction({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}});" data-toggle="button"><i class="fa fa-thumbs-down" aria-hidden="true"></i></button>
-				{{/if}}
-			{{/if}}
-
-			{{* Button to open the comment text field *}}
-			{{if $item.comment_html}}
-				<button type="button" class="btn button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="fa fa-commenting" aria-hidden="true"></i></button>
-			{{/if}}
-
-			{{if $item.vote.announce OR $item.vote.share}}
-				<div class="share-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}" role="group">
-					<button type="button" class="btn dropdown-toggle{{if $item.responses.announce.self}} active{{/if}}" data-toggle="dropdown" id="shareMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}">
-						<i class="fa fa-share" aria-hidden="true"></i>
-					</button>
-					<ul class="dropdown-menu dropdown-menu-left" role="menu" aria-labelledby="shareMenuOptions-{{$item.id}}">
-						{{if $item.vote.announce}} {{* edit the posting *}}
-						<li role="menuitem">
-							{{if $item.responses.announce.self}}
-							<a class="btn-link" id="announce-{{$item.id}}" href="javascript:doActivityItemAction({{$item.id}}, 'announce', true);" title="{{$item.vote.unannounce.0}}">
-								<i class="fa fa-ban" aria-hidden="true"></i> {{$item.vote.unannounce.1}}
-							</a>
-							{{else}}
-							<a class="btn-link" id="announce-{{$item.id}}" href="javascript:doActivityItemAction({{$item.id}}, 'announce');" title="{{$item.vote.announce.0}}">
-								<i class="fa fa-retweet" aria-hidden="true"></i> {{$item.vote.announce.1}}
-							</a>
-							{{/if}}
-						</li>
+			<div class="wall-item-actions-items btn-toolbar btn-group visible-xs" role="group">
+				<div class="wall-item-actions-row">
+					{{* Buttons for like and dislike *}}
+					{{if $item.vote}}
+						{{if $item.vote.like}}
+							<button type="button" class="btn button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doActivityItemAction({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}});" data-toggle="button"><i class="fa fa-thumbs-up" aria-hidden="true"></i></button>
 						{{/if}}
-						{{if $item.vote.share}}
-						<li role="menuitem">
-							<a class="btn-link" id="share-{{$item.id}}" href="javascript:jotShare({{$item.id}});" title="{{$item.vote.share.0}}">
-								<i class="fa fa-share" aria-hidden="true"></i> {{$item.vote.share.1}}
-							</a>
-						</li>
+						{{if $item.vote.dislike}}
+							<button type="button" class="btn button-likes{{if $item.responses.dislike.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doActivityItemAction({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}});" data-toggle="button"><i class="fa fa-thumbs-down" aria-hidden="true"></i></button>
 						{{/if}}
-					</ul>
-				</div>
-			{{/if}}
+					{{/if}}
 
-			{{if $item.browsershare}}
-				<button type="button" class="btn button-browser-share" onclick="navigator.share({url: '{{$item.plink.orig}}'})" title="{{$item.browsershare.1}}"><i class="fa fa-share-alt"></i></button>
-			{{/if}}
+					{{* Button to open the comment text field *}}
+					{{if $item.comment_html}}
+						<button type="button" class="btn button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="fa fa-commenting" aria-hidden="true"></i></button>
+					{{/if}}
 
-			{{* Put additional actions in a dropdown menu *}}
-				<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
-			</div>
+					{{if $item.vote.announce OR $item.vote.share}}
+						<div class="share-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}" role="group">
+							<button type="button" class="btn dropdown-toggle{{if $item.responses.announce.self}} active{{/if}}" data-toggle="dropdown" id="shareMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}">
+								<i class="fa fa-share" aria-hidden="true"></i>
+							</button>
+							<ul class="dropdown-menu dropdown-menu-left" role="menu" aria-labelledby="shareMenuOptions-{{$item.id}}">
+								{{if $item.vote.announce}} {{* edit the posting *}}
+								<li role="menuitem">
+									{{if $item.responses.announce.self}}
+									<a class="btn-link" id="announce-{{$item.id}}" href="javascript:doActivityItemAction({{$item.id}}, 'announce', true);" title="{{$item.vote.unannounce.0}}">
+										<i class="fa fa-ban" aria-hidden="true"></i> {{$item.vote.unannounce.1}}
+									</a>
+									{{else}}
+									<a class="btn-link" id="announce-{{$item.id}}" href="javascript:doActivityItemAction({{$item.id}}, 'announce');" title="{{$item.vote.announce.0}}">
+										<i class="fa fa-retweet" aria-hidden="true"></i> {{$item.vote.announce.1}}
+									</a>
+									{{/if}}
+								</li>
+								{{/if}}
+								{{if $item.vote.share}}
+								<li role="menuitem">
+									<a class="btn-link" id="share-{{$item.id}}" href="javascript:jotShare({{$item.id}});" title="{{$item.vote.share.0}}">
+										<i class="fa fa-share" aria-hidden="true"></i> {{$item.vote.share.1}}
+									</a>
+								</li>
+								{{/if}}
+							</ul>
+						</div>
+					{{/if}}
 
-			<div class="wall-item-actions-right visible-xs">
+					{{if $item.browsershare}}
+						<button type="button" class="btn button-browser-share" onclick="navigator.share({url: '{{$item.plink.orig}}'})" title="{{$item.browsershare.1}}"><i class="fa fa-share-alt"></i></button>
+					{{/if}}
+
+					{{* Put additional actions in a dropdown menu *}}
+					<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
+
 				{{* Event attendance buttons *}}
-			{{if $item.isevent}}
+				{{if $item.isevent}}
 				<div class="btn-group" role="group">
 					<button type="button" class="btn btn-default button-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});"><i class="fa fa-check" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i></button>
 					<button type="button" class="btn btn-default button-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});"><i class="fa fa-times" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i></button>
 					<button type="button" class="btn btn-default button-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});"><i class="fa fa-question" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i></button>
 				</div>
-			{{/if}}
+				{{/if}}
 
-			{{if $item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.ignore || ($item.drop && $item.drop.dropping)}}
-				<div class="more-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}">
-					<button type="button" class="btn dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="fa fa-ellipsis-h" aria-hidden="true"></i></button>
-					<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenuOptions-{{$item.id}}">
-					{{if $item.edpost}} {{* edit the posting *}}
-						<li role="menuitem">
-							<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" title="{{$item.edpost.1}}" class="btn-link navicon pencil"><i class="fa fa-pencil" aria-hidden="true"></i> {{$item.edpost.1}}</a>
-						</li>
-					{{/if}}
-
-						{{if $item.tagger}} {{* tag the post *}}
+				{{if $item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.ignore || ($item.drop && $item.drop.dropping)}}
+					<div class="more-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}">
+						<button type="button" class="btn dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="fa fa-ellipsis-h" aria-hidden="true"></i></button>
+						<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenuOptions-{{$item.id}}">
+						{{if $item.edpost}} {{* edit the posting *}}
 							<li role="menuitem">
-							<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i> {{$item.tagger.add}}</a>
-						</li>
+								<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" title="{{$item.edpost.1}}" class="btn-link navicon pencil"><i class="fa fa-pencil" aria-hidden="true"></i> {{$item.edpost.1}}</a>
+							</li>
 						{{/if}}
 
-						{{if $item.filer}}
+							{{if $item.tagger}} {{* tag the post *}}
+								<li role="menuitem">
+								<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i> {{$item.tagger.add}}</a>
+							</li>
+							{{/if}}
+
+							{{if $item.filer}}
+								<li role="menuitem">
+								<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="fa fa-folder" aria-hidden="true"></i>&nbsp;{{$item.filer}}</a>
+							</li>
+							{{/if}}
+
+							{{if $item.pin}}
+								<li role="menuitem">
+								<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-circle-o" aria-hidden="true"></i>&nbsp;{{$item.pin.do}}</a>
+								<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="fa fa-dot-circle-o" aria-hidden="true"></i>&nbsp;{{$item.pin.undo}}</a>
+							</li>
+							{{/if}}
+
+							{{if $item.star}}
+								<li role="menuitem">
+								<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-star-o" aria-hidden="true"></i>&nbsp;{{$item.star.do}}</a>
+								<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-star" aria-hidden="true"></i>&nbsp;{{$item.star.undo}}</a>
+							</li>
+							{{/if}}
+
+							{{if $item.follow_thread}}
+								<li role="menuitem">
+								<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="fa fa-plus" aria-hidden="true"></i>&nbsp;{{$item.follow_thread.title}}</a>
+							</li>
+							{{/if}}
+
+							{{if $item.language}}
 							<li role="menuitem">
-							<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="fa fa-folder" aria-hidden="true"></i>&nbsp;{{$item.filer}}</a>
-						</li>
-						{{/if}}
+								<a id="language-{{$item.id}}" href="javascript:alert('{{$item.language.1}}');" class="btn-link filer-item language-icon" title="{{$item.language.0}}"><i class="fa fa-language" aria-hidden="true"></i>&nbsp;{{$item.language.0}}</a>
+							</li>
+							{{/if}}
 
-						{{if $item.pin}}
-							<li role="menuitem">
-							<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-circle-o" aria-hidden="true"></i>&nbsp;{{$item.pin.do}}</a>
-							<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="fa fa-dot-circle-o" aria-hidden="true"></i>&nbsp;{{$item.pin.undo}}</a>
-						</li>
-						{{/if}}
+							{{if $item.ignore || ($item.drop && $item.drop.dropping)}}
+								<li role="separator" class="divider"></li>
+							{{/if}}
 
-						{{if $item.star}}
-							<li role="menuitem">
-							<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-star-o" aria-hidden="true"></i>&nbsp;{{$item.star.do}}</a>
-							<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-star" aria-hidden="true"></i>&nbsp;{{$item.star.undo}}</a>
-						</li>
-						{{/if}}
+							{{if $item.ignore}}
+								<li role="menuitem">
+								<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-eye-slash" aria-hidden="true"></i> {{$item.ignore.do}}</a>
+							</li>
+								<li role="menuitem">
+								<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-eye" aria-hidden="true"></i> {{$item.ignore.undo}}</a>
+							</li>
+							{{/if}}
 
-						{{if $item.follow_thread}}
-							<li role="menuitem">
-							<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="fa fa-plus" aria-hidden="true"></i>&nbsp;{{$item.follow_thread.title}}</a>
-						</li>
-						{{/if}}
-
-						{{if $item.language}}
-						<li role="menuitem">
-							<a id="language-{{$item.id}}" href="javascript:alert('{{$item.language.1}}');" class="btn-link filer-item language-icon" title="{{$item.language.0}}"><i class="fa fa-language" aria-hidden="true"></i>&nbsp;{{$item.language.0}}</a>
-						</li>
-						{{/if}}
-
-						{{if $item.ignore || ($item.drop && $item.drop.dropping)}}
-							<li role="separator" class="divider"></li>
-						{{/if}}
-
-						{{if $item.ignore}}
-							<li role="menuitem">
-							<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-eye-slash" aria-hidden="true"></i> {{$item.ignore.do}}</a>
-						</li>
-							<li role="menuitem">
-							<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-eye" aria-hidden="true"></i> {{$item.ignore.undo}}</a>
-						</li>
-						{{/if}}
-
-						{{if $item.drop && $item.drop.dropping}}
-							<li role="menuitem">
-							<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}/{{$item.return}}', 'item-{{$item.guid}}');" title="{{$item.drop.delete}}"><i class="fa fa-trash" aria-hidden="true"></i> {{$item.drop.delete}}</a>
-						</li>
-						{{/if}}
-					</ul>
-					<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
-				</div>
-			{{/if}}
+							{{if $item.drop && $item.drop.dropping}}
+								<li role="menuitem">
+								<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}/{{$item.return}}', 'item-{{$item.guid}}');" title="{{$item.drop.delete}}"><i class="fa fa-trash" aria-hidden="true"></i> {{$item.drop.delete}}</a>
+							</li>
+							{{/if}}
+						</ul>
+						<img id="like-rotator-{{$item.id}}" class="like-rotator" src="images/rotator.gif" alt="{{$item.wait}}" title="{{$item.wait}}" style="display: none;" />
+					</div>
+				{{/if}}
 				<span class="pull-right checkbox">
-			{{if $item.drop && $item.drop.pagedrop}}
-					<input type="checkbox" title="{{$item.drop.select}}" name="itemselected[]" id="checkbox-{{$item.id}}" class="item-select" value="{{$item.id}}" />
-					<label for="checkbox-{{$item.id}}"></label>
-			{{/if}}
+					{{if $item.drop && $item.drop.pagedrop}}
+						<input type="checkbox" title="{{$item.drop.select}}" name="itemselected[]" id="checkbox-{{$item.id}}" class="item-select" value="{{$item.id}}" />
+						<label for="checkbox-{{$item.id}}"></label>
+					{{/if}}
 				</span>
+				</div>
 			</div>
 		</div><!--./wall-item-actions-->
 


### PR DESCRIPTION
| Before         | After     | After (with dislike button) |
|--------------|-----------|------------|
| ![before-01](https://user-images.githubusercontent.com/8630866/220703350-f1df4871-1191-4bdf-ac4d-79c567586580.png) | ![after-01](https://user-images.githubusercontent.com/8630866/220703396-92e5079a-1757-4323-b698-935e2ef2b23a.png)      | ![after-02](https://user-images.githubusercontent.com/8630866/220703454-672e9489-43e9-441e-bf71-c17a5eace0c8.png)        |

![loader](https://user-images.githubusercontent.com/8630866/220707307-bedf43dd-8b44-4498-b36c-6b5ff991fc38.png)

## Changes
- Full-width post interaction row with evenly distributed buttons
- Absolutely positioned loader to prevent buttons movement

Related: https://github.com/friendica/friendica/issues/12835