### PR TITLE
API documentation updates

### DIFF
--- a/doc/API-Entities.md
+++ b/doc/API-Entities.md
@@ -909,6 +909,13 @@ Identical to [the Twitter Media Object](https://developer.twitter.com/en/docs/tw
 </tr>
 
 <tr>
+<td><code>media-id</code></td>
+<td>String (Integer) </td>
+<td>ID used for attaching to a Mastodon Post Status</td>
+</tr>
+
+
+<tr>
 <td><code>created</code></td>
 <td>String (Date)</td>
 <td>Format <code>YYYY-MM-DD HH:MM:SS</code></td>
@@ -1002,6 +1009,14 @@ Mutually exclusive with <code>data</code> <code>datasize</code>.
 </tr>
 
 <tr>
+<td><code>scales</code></td>
+<td>Array of Photo Scales</td>
+<td>
+List of Scale objects listing the id, scale, link, etc. of each scale
+</td>
+</tr>
+
+<tr>
 <td><code>datasize</code></td>
 <td>Integer</td>
 <td>
@@ -1039,6 +1054,58 @@ Mutually exclusive with <code>link</code>.
 
 </tbody>
 </table>
+
+## Photo Scale
+
+<table class="table table-condensed table-striped table-bordered">
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Type</th>
+<th align="center">Nullable</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td><code>id</code></td>
+<td>String (Integer)</td>
+<td>Row ID of this photo scale</td>
+</tr>
+
+<tr>
+<td><code>scale</code></td>
+<td>Integer</td>
+<td>Scale number</td>
+</tr>
+
+<tr>
+<td><code>link</code></td>
+<td>String (URL)</td>
+<td>URL to this scale's image</td>
+</tr>
+
+<tr>
+<td><code>height</code></td>
+<td>Integer</td>
+<td>Image height in pixels</td>
+</tr>
+
+<tr>
+<td><code>width</code></td>
+<td>Integer</td>
+<td>Image width in pixels</td>
+</tr>
+
+<tr>
+<td><code>size</code></td>
+<td>Integer</td>
+<td>Image size in bytes</td>
+</tr>
+
+</tbody>
+</table>
+
 
 ## Photo List Item
 

--- a/doc/API-Entities.md
+++ b/doc/API-Entities.md
@@ -1170,6 +1170,40 @@ Mutually exclusive with <code>link</code>.
 </tbody>
 </table>
 
+
+## Photo Album
+
+<table class="table table-condensed table-striped table-bordered">
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td><code>name</code></td>
+<td>String</td>
+<td>The name of the photo album</td>
+</tr>
+
+<tr>
+<td><code>created</code></td>
+<td>String (Date)</td>
+<td>The creation date of the album. Format <code>YYYY-MM-DD HH:MM:SS</code></td>
+</tr>
+
+<tr>
+<td><code>count</code></td>
+<td>Integer</td>
+<td>The number of images in the album</td>
+</tr>
+
+</tbody>
+</table>
+
 ## Private message
 
 <table class="table table-condensed table-striped table-bordered">

--- a/doc/API-Entities.md
+++ b/doc/API-Entities.md
@@ -911,7 +911,7 @@ Identical to [the Twitter Media Object](https://developer.twitter.com/en/docs/tw
 <tr>
 <td><code>media-id</code></td>
 <td>String (Integer) </td>
-<td>ID used for attaching to a Mastodon Post Status</td>
+<td>ID used for attaching images to a Mastodon Post Status</td>
 </tr>
 
 

--- a/doc/API-Entities.md
+++ b/doc/API-Entities.md
@@ -1012,7 +1012,7 @@ Mutually exclusive with <code>data</code> <code>datasize</code>.
 <td><code>scales</code></td>
 <td>Array of Photo Scales</td>
 <td>
-List of Scale objects listing the id, scale, link, etc. of each scale
+List of the various resized versions of the Photo
 </td>
 </tr>
 

--- a/doc/API-Friendica.md
+++ b/doc/API-Friendica.md
@@ -724,36 +724,36 @@ On success:
 ```json
 [
   {
-	"created": "2023-02-14 14:31:06",
-	"edited": "2023-02-14 14:31:14",
-	"title": "",
-	"desc": "",
-	"album": "Wall Photos",
-	"filename": "image.png",
-	"type": "image/png",
-	"height": 835,
-	"width": 693,
-	"datasize": 119523,
-	"profile": 0,
-	"allow_cid": "",
-	"deny_cid": "",
-	"allow_gid": "",
-	"deny_gid": "",
-	"id": "899184972463eb9b2ae3dc2580502826",
-	"scale": 0,
-	"media-id": 52,
-	"scales": [
-	  {
-		"id": 52,
-		"scale": 0,
-		"link": "https://<server>/photo/899184972463eb9b2ae3dc2580502826-0.png",
-		"width": 693,
-		"height": 835,
-		"size": 119523
-	  },
-	  ...
-	],
-	"thumb": "https://<server>/photo/899184972463eb9b2ae3dc2580502826-2.png"
+    "created": "2023-02-14 14:31:06",
+    "edited": "2023-02-14 14:31:14",
+    "title": "",
+    "desc": "",
+    "album": "Wall Photos",
+    "filename": "image.png",
+    "type": "image/png",
+    "height": 835,
+    "width": 693,
+    "datasize": 119523,
+    "profile": 0,
+    "allow_cid": "",
+    "deny_cid": "",
+    "allow_gid": "",
+    "deny_gid": "",
+    "id": "899184972463eb9b2ae3dc2580502826",
+    "scale": 0,
+    "media-id": 52,
+    "scales": [
+      {
+        "id": 52,
+        "scale": 0,
+        "link": "https://<server>/photo/899184972463eb9b2ae3dc2580502826-0.png",
+        "width": 693,
+        "height": 835,
+        "size": 119523
+      },
+      ...
+    ],
+    "thumb": "https://<server>/photo/899184972463eb9b2ae3dc2580502826-2.png"
   },
   ...
 ]
@@ -825,11 +825,11 @@ A Mastodon [Status Entity](https://docs.joinmastodon.org/entities/Status/)
   "spoiler_text": "",
   "visibility": "public",
   "language": "en",
-   ...
+  ...
   "account": {
     "id": "8",
     "username": "testuser2",
-	  ...
+    ...
   },
   "media_attachments": [],
   "mentions": [],
@@ -863,11 +863,11 @@ in the body and next/previous link headers in the header
 
 ```json
 [
-	{
-		"id": "6",
-		"username": "testuser1",
-		...
-	}
+  {
+    "id": "6",
+    "username": "testuser1",
+    ...
+  }
 ]
 ```
 
@@ -899,11 +899,11 @@ A Mastodon [Status Entity](https://docs.joinmastodon.org/entities/Status/)
   "spoiler_text": "",
   "visibility": "public",
   "language": "en",
-   ...
+  ...
   "account": {
     "id": "8",
     "username": "testuser2",
-	  ...
+    ...
   },
   "media_attachments": [],
   "mentions": [],

--- a/doc/API-Friendica.md
+++ b/doc/API-Friendica.md
@@ -690,14 +690,14 @@ On success a list of photo album objects:
 ```json
 [
   {
-	"name": "Wall Photos",
-	"created": "2023-01-22 02:03:19",
-	"count": 4
+    "name": "Wall Photos",
+    "created": "2023-01-22 02:03:19",
+    "count": 4
   },
   {
-	"name": "Profile photos",
-	"created": "2022-11-20 14:40:06",
-	"count": 1
+    "name": "Profile photos",
+    "created": "2022-11-20 14:40:06",
+    "count": 1
   }
 ]
 ```

--- a/doc/API-Friendica.md
+++ b/doc/API-Friendica.md
@@ -665,8 +665,8 @@ On success:
 
 ```json
 {
-    "result": "updated",
-    "message":"album 'abc' with all containing photos has been renamed to 'xyz'."
+  "result": "updated",
+  "message":"album 'abc' with all containing photos has been renamed to 'xyz'."
 }
 ```
 
@@ -676,7 +676,91 @@ On error:
 * 400 BADREQUEST: "no albumname specified", "no new albumname specified", "album not available"
 * 500 INTERNALSERVERERROR: "unknown error - updating in database failed"
 
+### GET api/friendica/photoalbums
+
+Get a list of photo albums for the user
+
+#### Parameters
+
+None 
+#### Return values
+
+On success a list of photo album objects:
+
+```json
+[
+  {
+	"name": "Wall Photos",
+	"created": "2023-01-22 02:03:19",
+	"count": 4
+  },
+  {
+	"name": "Profile photos",
+	"created": "2022-11-20 14:40:06",
+	"count": 1
+  }
+]
+```
+
+### GET api/friendica/photoalbum
+
+Get a list of images in a photo album
+#### Parameters
+
+* `album` (Required): name of the album to be deleted
+* `limit` (Optional): Maximum number of items to get, defaults to 50, max 500
+* `offset`(Optional): Offset in results to page through total items, defaults to 0
+* `latest_first` (Optional): Reverse the order so the most recent images are first, defaults to false
+
+#### Return values
+
+On success:
+
+* JSON return with the list of Photo items
+
+**Example:**
+`https://<server>/api/friendica/photoalbum?album=Wall Photos&limit=10&offset=2`
+
+```json
+[
+  {
+	"created": "2023-02-14 14:31:06",
+	"edited": "2023-02-14 14:31:14",
+	"title": "",
+	"desc": "",
+	"album": "Wall Photos",
+	"filename": "image.png",
+	"type": "image/png",
+	"height": 835,
+	"width": 693,
+	"datasize": 119523,
+	"profile": 0,
+	"allow_cid": "",
+	"deny_cid": "",
+	"allow_gid": "",
+	"deny_gid": "",
+	"id": "899184972463eb9b2ae3dc2580502826",
+	"scale": 0,
+	"media-id": 52,
+	"scales": [
+	  {
+		"id": 52,
+		"scale": 0,
+		"link": "https://<server>/photo/899184972463eb9b2ae3dc2580502826-0.png",
+		"width": 693,
+		"height": 835,
+		"size": 119523
+	  },
+	  ...
+	],
+	"thumb": "https://<server>/photo/899184972463eb9b2ae3dc2580502826-2.png"
+  },
+  ...
+]
+```
+
 ---
+
 
 ### GET api/friendica/profile/show
 

--- a/doc/API-Friendica.md
+++ b/doc/API-Friendica.md
@@ -715,6 +715,127 @@ General description of profile data in API returns:
 
 ---
 
+### POST api/friendica/statuses/:id/dislike
+
+Marks the given status as disliked by this user
+
+#### Path Parameter
+
+* `id`: the status ID that is being marked
+
+#### Return values
+
+A Mastodon [Status Entity](https://docs.joinmastodon.org/entities/Status/)
+
+#### Example:
+`https://<server_name>/api/friendica/statuses/341/dislike`
+
+```json
+{
+  "id": "341",
+  "created_at": "2023-02-23T01:50:00.000Z",
+  "in_reply_to_id": null,
+  "in_reply_to_status": null,
+  "in_reply_to_account_id": null,
+  "sensitive": false,
+  "spoiler_text": "",
+  "visibility": "public",
+  "language": "en",
+   ...
+  "account": {
+    "id": "8",
+    "username": "testuser2",
+	  ...
+  },
+  "media_attachments": [],
+  "mentions": [],
+  "tags": [],
+  "emojis": [],
+  "card": null,
+  "poll": null,
+  "friendica": {
+    "title": "",
+    "dislikes_count": 1
+  }
+}
+```
+
+
+### GET api/friendica/statuses/:id/disliked_by
+
+Returns the list of accounts that have disliked the status as known by the current server
+
+#### Path Parameter
+
+* `id`: the status ID that is being marked
+
+#### Return values
+
+A list of [Mastodon Account](https://docs.joinmastodon.org/entities/Account/) objects
+in the body and next/previous link headers in the header
+
+#### Example:
+`https://<server_name>/api/friendica/statuses/341/disliked_by`
+
+```json
+[
+	{
+		"id": "6",
+		"username": "testuser1",
+		...
+	}
+]
+```
+
+
+
+### POST api/friendica/statuses/:id/undislike
+
+Removes the dislike mark (if it exists) on this status for this user
+
+#### Path Parameter
+
+* `id`: the status ID that is being marked
+
+#### Return values
+
+A Mastodon [Status Entity](https://docs.joinmastodon.org/entities/Status/)
+
+#### Example:
+`https://<server_name>/api/friendica/statuses/341/dislike`
+
+```json
+{
+  "id": "341",
+  "created_at": "2023-02-23T01:50:00.000Z",
+  "in_reply_to_id": null,
+  "in_reply_to_status": null,
+  "in_reply_to_account_id": null,
+  "sensitive": false,
+  "spoiler_text": "",
+  "visibility": "public",
+  "language": "en",
+   ...
+  "account": {
+    "id": "8",
+    "username": "testuser2",
+	  ...
+  },
+  "media_attachments": [],
+  "mentions": [],
+  "tags": [],
+  "emojis": [],
+  "card": null,
+  "poll": null,
+  "friendica": {
+    "title": "",
+    "dislikes_count": 0
+  }
+}
+```
+
+---
+
 ## Deprecated endpoints
 
 - POST api/statuses/mediap

--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -150,6 +150,10 @@ Example:
 - [`PUT /api/v1/media/:id`](https://docs.joinmastodon.org/methods/statuses/media/)
 - [`GET /api/v1/mutes`](https://docs.joinmastodon.org/methods/accounts/mutes/)
 - [`GET /api/v1/notifications`](https://docs.joinmastodon.org/methods/notifications/)
+	- Additional field `include_all` to return read and unread statuses, defaults to `false`
+    - Additional field `summary` returns a count of all of the statuses that match the type filter
+    - Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
+    - Does not support the `type` field, which is the mirror image of the supported `exclude_types` field
 - [`GET /api/v1/notifications/:id`](https://docs.joinmastodon.org/methods/notifications/)
 - [`POST /api/v1/notifications/clear`](https://docs.joinmastodon.org/methods/notifications/)
 - [`POST /api/v1/notifications/:id/dismiss`](https://docs.joinmastodon.org/methods/notifications/)
@@ -166,9 +170,15 @@ Example:
 - [`GET /api/v1/search`](https://docs.joinmastodon.org/methods/search/)
 - [`POST /api/v1/statuses`](https://docs.joinmastodon.org/methods/statuses/#create)
     - Additionally to the static values `public`, `unlisted` and `private`, the `visibility` parameter can contain a numeric value with a group id.
+    - Additional field `quote_id` for the post that is being quote reshared
+    - Additional fields `friendica` for Friendica specific parameters:
+       - `title`: Explicitly sets the title for a post status, ignored if used on a comment status. For post statuses the legacy behavior is to use any "spoiler text" as the title if it is provided. If both the title and spoiler text are provided for a post status then they will each be used for their respective roles. If no title is provided then the legacy behavior will persist. If you want to create a post with no title but spoiler text then explicitly set the title but set it to an empty string `""`. 
 - [`GET /api/v1/statuses/:id`](https://docs.joinmastodon.org/methods/statuses/#get)
 - [`DELETE /api/v1/statuses/:id`](https://docs.joinmastodon.org/methods/statuses/#delete)
 - [`GET /api/v1/statuses/:id/context`](https://docs.joinmastodon.org/methods/statuses/#context)
+    - Additional support for paging using `min_id`, `max_id`, `since_id` parameters
+    - Additional support for previous/next Link Headers to support paging
+    - Additional flag `show_all` to allow including posts from blocked and ignored/muted users, defaults to `false`
 - [`GET /api/v1/statuses/:id/reblogged_by`](https://docs.joinmastodon.org/methods/statuses/#reblogged_by)
 - [`GET /api/v1/statuses/:id/favourited_by`](https://docs.joinmastodon.org/methods/statuses/#favourited_by)
 - [`POST /api/v1/statuses/:id/favourite`](https://docs.joinmastodon.org/methods/statuses/#favourite)
@@ -197,6 +207,7 @@ Example:
 - [`GET /api/v1/trends/links`](https://github.com/mastodon/mastodon/pull/16917)
 - [`GET /api/v1/trends/statuses`](https://docs.joinmastodon.org/methods/trends/#statuses)
 - [`GET /api/v1/trends/tags`](https://docs.joinmastodon.org/methods/trends/#tags)
+	- Additional field `friendica_local` to return local trending tags instead of global tags, defaults to `false`
 - [`GET /api/v2/instance`](https://docs.joinmastodon.org/methods/instance/#v2)
 - [`GET /api/v2/search`](https://docs.joinmastodon.org/methods/search/)
 

--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -29,12 +29,13 @@ For supported apps please have a look at the [FAQ](help/FAQ#clients)
 
 ## Entities
 
-These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/entities/). With some additional extensions listed below.
+These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/entities/).
+With some additional extensions listed below.
 
 ### Instance (Version 2) Entities
 Extensions to the [Mastodon Instance::V2 Entities](https://docs.joinmastodon.org/entities/Instance/)
 * `friendica`: Friendica specific properties of the V2 Instance including:
-	* `version`: The Friendica version string
+    * `version`: The Friendica version string
     * `codename`: The Friendica version code name
     * `db_version`: The database schema version number
 
@@ -176,7 +177,7 @@ Example:
 - [`PUT /api/v1/media/:id`](https://docs.joinmastodon.org/methods/statuses/media/)
 - [`GET /api/v1/mutes`](https://docs.joinmastodon.org/methods/accounts/mutes/)
 - [`GET /api/v1/notifications`](https://docs.joinmastodon.org/methods/notifications/)
-	- Additional field `include_all` to return read and unread statuses, defaults to `false`
+    - Additional field `include_all` to return read and unread statuses, defaults to `false`
     - Additional field `summary` returns a count of all of the statuses that match the type filter
     - Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
     - Does not support the `type` field, which is the mirror image of the supported `exclude_types` field
@@ -196,10 +197,10 @@ Example:
 - [`GET /api/v1/search`](https://docs.joinmastodon.org/methods/search/)
 - [`PUT /api/v1/statuses`](https://docs.joinmastodon.org/methods/statuses/#edit)
     - Does not support `polls` argument as Friendica does not have polls
-	- Additional fields `friendica` for Friendica specific parameters:
-		- `title`: Explicitly sets the title for a post status, ignored if used on a comment status. For post statuses the legacy behavior is to use any "spoiler text" as the title if it is provided. If both the title and spoiler text are provided for a post status then they will each be used for their respective roles. If no title is provided then the legacy behavior will persist. If you want to create a post with no title but spoiler text then explicitly set the title but set it to an empty string `""`.
+    - Additional fields `friendica` for Friendica specific parameters:
+        - `title`: Explicitly sets the title for a post status, ignored if used on a comment status. For post statuses the legacy behavior is to use any "spoiler text" as the title if it is provided. If both the title and spoiler text are provided for a post status then they will each be used for their respective roles. If no title is provided then the legacy behavior will persist. If you want to create a post with no title but spoiler text then explicitly set the title but set it to an empty string `""`.
 - [`POST /api/v1/statuses`](https://docs.joinmastodon.org/methods/statuses/#create)
-	- Does not support `polls` argument as Friendica does not have polls
+    - Does not support `polls` argument as Friendica does not have polls
     - Additionally to the static values `public`, `unlisted` and `private`, the `visibility` parameter can contain a numeric value with a group id.
     - Additional field `quote_id` for the post that is being quote reshared
     - Additional fields `friendica` for Friendica specific parameters:
@@ -231,7 +232,7 @@ Example:
 - [`GET /api/v1/tags/:id/unfollow`](https://docs.joinmastodon.org/methods/tags/#unfollow)
 - [`GET /api/v1/timelines/direct`](https://docs.joinmastodon.org/methods/timelines/)
 - [`GET /api/v1/timelines/home`](https://docs.joinmastodon.org/methods/timelines/)
-	- Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
+    - Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
     - Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
 - [`GET /api/v1/timelines/list/:id`](https://docs.joinmastodon.org/methods/timelines/)
 	- Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
@@ -240,14 +241,14 @@ Example:
 	- Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
 	- Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
 - [`GET /api/v1/timelines/tag/:hashtag`](https://docs.joinmastodon.org/methods/timelines/)
-	- Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
-	- Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
+    - Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
+    - Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
     - Does not support the `any[]`, `all[]`, or `none[]` query parameters
 - [`GET /api/v1/trends`](https://docs.joinmastodon.org/methods/instance/trends/)
 - [`GET /api/v1/trends/links`](https://github.com/mastodon/mastodon/pull/16917)
 - [`GET /api/v1/trends/statuses`](https://docs.joinmastodon.org/methods/trends/#statuses)
 - [`GET /api/v1/trends/tags`](https://docs.joinmastodon.org/methods/trends/#tags)
-	- Additional field `friendica_local` to return local trending tags instead of global tags, defaults to `false`
+    - Additional field `friendica_local` to return local trending tags instead of global tags, defaults to `false`
 - [`GET /api/v2/instance`](https://docs.joinmastodon.org/methods/instance/#v2)
 - [`GET /api/v2/search`](https://docs.joinmastodon.org/methods/search/)
 

--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -31,6 +31,28 @@ For supported apps please have a look at the [FAQ](help/FAQ#clients)
 
 These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/entities/). With some additional extensions listed below.
 
+### Instance (Version 2) Entities
+Extensions to the [Mastodon Instance::V2 Entities](https://docs.joinmastodon.org/entities/Instance/)
+* `friendica`: Friendica specific properties of the V2 Instance including:
+	* `version`: The Friendica version string
+    * `codename`: The Friendica version code name
+    * `db_version`: The database schema version number
+
+Example: 
+```json
+{
+  "domain": "friendicadevtest1.myportal.social",
+  "title": "Friendica Social Network",
+  "version": "2.8.0 (compatible; Friendica 2023.03-dev)",
+  ...
+  "friendica": {
+    "version": "2023.03-dev",
+    "codename": "Giant Rhubarb",
+    "db_version": 1516
+  }
+}
+```
+
 ### Notification Entities
 Extensions to the [Mastodon Notification Entities](https://docs.joinmastodon.org/entities/Notification/)
 * `dismissed`: whether the object has been dismissed or not

--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -204,9 +204,18 @@ Example:
 - [`GET /api/v1/tags/:id/unfollow`](https://docs.joinmastodon.org/methods/tags/#unfollow)
 - [`GET /api/v1/timelines/direct`](https://docs.joinmastodon.org/methods/timelines/)
 - [`GET /api/v1/timelines/home`](https://docs.joinmastodon.org/methods/timelines/)
+	- Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
+    - Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
 - [`GET /api/v1/timelines/list/:id`](https://docs.joinmastodon.org/methods/timelines/)
+	- Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
+	- Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
 - [`GET /api/v1/timelines/public`](https://docs.joinmastodon.org/methods/timelines/)
+	- Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
+	- Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
 - [`GET /api/v1/timelines/tag/:hashtag`](https://docs.joinmastodon.org/methods/timelines/)
+	- Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
+	- Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
+    - Does not support the `any[]`, `all[]`, or `none[]` query parameters
 - [`GET /api/v1/trends`](https://docs.joinmastodon.org/methods/instance/trends/)
 - [`GET /api/v1/trends/links`](https://github.com/mastodon/mastodon/pull/16917)
 - [`GET /api/v1/trends/statuses`](https://docs.joinmastodon.org/methods/trends/#statuses)

--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -73,8 +73,8 @@ These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/en
     - `:id` is a follow request ID, not a regular account id
     - Returns a [Relationship](https://docs.joinmastodon.org/entities/relationship) object.
 
-- [`GET /api/v1/followed_tags'](https://docs.joinmastodon.org/methods/followed_tags/)
-- [`GET /api/v1/instance`](https://docs.joinmastodon.org/methods/instance#fetch-instance)
+- [`GET /api/v1/followed_tags`](https://docs.joinmastodon.org/methods/followed_tags/)
+- [`GET /api/v1/instance`](https://docs.joinmastodon.org/methods/instance/#v1)
 - `GET /api/v1/instance/rules` Undocumented, returns Terms of Service
 - [`GET /api/v1/instance/peers`](https://docs.joinmastodon.org/methods/instance#list-of-connected-domains)
 - [`GET /api/v1/lists`](https://docs.joinmastodon.org/methods/timelines/lists/)
@@ -139,6 +139,7 @@ These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/en
 - [`GET /api/v1/trends/links`](https://github.com/mastodon/mastodon/pull/16917)
 - [`GET /api/v1/trends/statuses`](https://docs.joinmastodon.org/methods/trends/#statuses)
 - [`GET /api/v1/trends/tags`](https://docs.joinmastodon.org/methods/trends/#tags)
+- [`GET /api/v2/instance`](https://docs.joinmastodon.org/methods/instance/#v2)
 - [`GET /api/v2/search`](https://docs.joinmastodon.org/methods/search/)
 
 

--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -31,6 +31,10 @@ For supported apps please have a look at the [FAQ](help/FAQ#clients)
 
 These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/entities/). With some additional extensions listed below.
 
+### Notification Entities
+Extensions to the [Mastodon Notification Entities](https://docs.joinmastodon.org/entities/Notification/)
+* `dismissed`: whether the object has been dismissed or not
+
 ### Status Entities
 Extensions to the [Mastodon Status Entities](https://docs.joinmastodon.org/entities/Status/)
 * `in_reply_to_status`: A fully populated Mastodon Status entity for the replied to status or null it is a post rather than a response

--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -235,11 +235,11 @@ Example:
     - Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
     - Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
 - [`GET /api/v1/timelines/list/:id`](https://docs.joinmastodon.org/methods/timelines/)
-	- Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
-	- Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
+    - Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
+    - Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
 - [`GET /api/v1/timelines/public`](https://docs.joinmastodon.org/methods/timelines/)
-	- Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
-	- Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
+    - Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
+    - Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`
 - [`GET /api/v1/timelines/tag/:hashtag`](https://docs.joinmastodon.org/methods/timelines/)
     - Additional field `with_muted` Pleroma extension to return notifications from muted users, defaults to `false`
     - Additional field `exclude_replies` to only return post statuses not replies/comments, defaults to `false`

--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -72,26 +72,26 @@ Example:
   "created_at": "2023-02-23T02:45:46.000Z",
   "in_reply_to_id": "356",
   "in_reply_to_status": {
-	"id": "356",
-	"created_at": "2023-02-23T02:45:35.000Z",
-	"in_reply_to_id": null,
-	"in_reply_to_status": null,
-	"in_reply_to_account_id": null,
-	...
-	"content": "A post from testuser1",
-	...
-	"account": {
-	  "id": "6",
-	  "username": "testuser1",
-	  "acct": "testuser1",
-	  "display_name": "testuser1",
-	  ...
-	},
-	...
-	"friendica": {
-	  "title": "",
-	  "dislikes_count": 0
-	}
+    "id": "356",
+    "created_at": "2023-02-23T02:45:35.000Z",
+    "in_reply_to_id": null,
+    "in_reply_to_status": null,
+    "in_reply_to_account_id": null,
+    ...
+    "content": "A post from testuser1",
+    ...
+    "account": {
+      "id": "6",
+      "username": "testuser1",
+      "acct": "testuser1",
+      "display_name": "testuser1",
+      ...
+    },
+    ...
+    "friendica": {
+      "title": "",
+      "dislikes_count": 0
+    }
   },
   "in_reply_to_account_id": "6",
   ...
@@ -102,16 +102,16 @@ Example:
   "content": "A reply from testuser2",
   ...
   "account": {
-	"id": "8",
-	"username": "testuser2",
-	"acct": "testuser2",
-	"display_name": "testuser2",
-	...
+    "id": "8",
+    "username": "testuser2",
+    "acct": "testuser2",
+    "display_name": "testuser2",
+    ...
   },
   ...
   "friendica": {
-	"title": "",
-	"dislikes_count": 0
+    "title": "",
+    "dislikes_count": 0
   }
 }
 ```

--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -172,7 +172,12 @@ Example:
 - [`DELETE /api/v1/scheduled_statuses/:id`](https://docs.joinmastodon.org/methods/statuses/scheduled_statuses/)
 - [`GET /api/v1/scheduled_statuses/:id`](https://docs.joinmastodon.org/methods/statuses/scheduled_statuses/)
 - [`GET /api/v1/search`](https://docs.joinmastodon.org/methods/search/)
+- [`PUT /api/v1/statuses`](https://docs.joinmastodon.org/methods/statuses/#edit)
+    - Does not support `polls` argument as Friendica does not have polls
+	- Additional fields `friendica` for Friendica specific parameters:
+		- `title`: Explicitly sets the title for a post status, ignored if used on a comment status. For post statuses the legacy behavior is to use any "spoiler text" as the title if it is provided. If both the title and spoiler text are provided for a post status then they will each be used for their respective roles. If no title is provided then the legacy behavior will persist. If you want to create a post with no title but spoiler text then explicitly set the title but set it to an empty string `""`.
 - [`POST /api/v1/statuses`](https://docs.joinmastodon.org/methods/statuses/#create)
+	- Does not support `polls` argument as Friendica does not have polls
     - Additionally to the static values `public`, `unlisted` and `private`, the `visibility` parameter can contain a numeric value with a group id.
     - Additional field `quote_id` for the post that is being quote reshared
     - Additional fields `friendica` for Friendica specific parameters:

--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -29,7 +29,65 @@ For supported apps please have a look at the [FAQ](help/FAQ#clients)
 
 ## Entities
 
-These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/entities/).
+These endpoints use the [Mastodon API entities](https://docs.joinmastodon.org/entities/). With some additional extensions listed below.
+
+### Status Entities
+Extensions to the [Mastodon Status Entities](https://docs.joinmastodon.org/entities/Status/)
+* `in_reply_to_status`: A fully populated Mastodon Status entity for the replied to status or null it is a post rather than a response
+* `friendica`: Friendica specific properties of a status including:
+  * `title`: The Friendica title for a post, or empty if the status is a comment
+  * `dislikes_count`: The number of dislikes that a status has accumulated according to the server.
+
+Example:
+```json
+{
+  "id": "358",
+  "created_at": "2023-02-23T02:45:46.000Z",
+  "in_reply_to_id": "356",
+  "in_reply_to_status": {
+	"id": "356",
+	"created_at": "2023-02-23T02:45:35.000Z",
+	"in_reply_to_id": null,
+	"in_reply_to_status": null,
+	"in_reply_to_account_id": null,
+	...
+	"content": "A post from testuser1",
+	...
+	"account": {
+	  "id": "6",
+	  "username": "testuser1",
+	  "acct": "testuser1",
+	  "display_name": "testuser1",
+	  ...
+	},
+	...
+	"friendica": {
+	  "title": "",
+	  "dislikes_count": 0
+	}
+  },
+  "in_reply_to_account_id": "6",
+  ...
+  "replies_count": 0,
+  "reblogs_count": 0,
+  "favourites_count": 0,
+  ...
+  "content": "A reply from testuser2",
+  ...
+  "account": {
+	"id": "8",
+	"username": "testuser2",
+	"acct": "testuser2",
+	"display_name": "testuser2",
+	...
+  },
+  ...
+  "friendica": {
+	"title": "",
+	"dislikes_count": 0
+  }
+}
+```
 
 ## Implemented endpoints
 


### PR DESCRIPTION
This PR attempts to bring the documentation up to the present state of the API. 

At the time of the initial PR invocation this is missing the `quote` status entity extension because I couldn't figure out how to get it to populate with something other than null in my testing, including using the `quote_id` additional parameter on the POST status endpoint. I'd like to get that added before this is merged. @annando do you have an example for me to use for this additional field?