### PR TITLE
Add Delivery Information to Mastodon Status API Entity

### DIFF
--- a/doc/API-Mastodon.md
+++ b/doc/API-Mastodon.md
@@ -63,6 +63,10 @@ Extensions to the [Mastodon Status Entities](https://docs.joinmastodon.org/entit
 * `in_reply_to_status`: A fully populated Mastodon Status entity for the replied to status or null it is a post rather than a response
 * `friendica`: Friendica specific properties of a status including:
   * `title`: The Friendica title for a post, or empty if the status is a comment
+  * `delivery_data`: Information about the state of federating a message from the server
+    * `delivery_queue_count`: Total number of remote servers that the status needs to be federated to.
+    * `delivery_queue_done`: Total number of remote servers that have successfully been federated to so far.
+    * `delivery_queue_failed`: Total number of remote servers that have we failed to federate to so far.
   * `dislikes_count`: The number of dislikes that a status has accumulated according to the server.
 
 Example:
@@ -111,6 +115,11 @@ Example:
   ...
   "friendica": {
     "title": "",
+    "delivery_data": {
+      "delivery_queue_count": 10,
+      "delivery_queue_done": 3, 
+      "delivery_queue_failed": 0
+    },
     "dislikes_count": 0
   }
 }

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -288,7 +288,7 @@ class Status extends BaseFactory
 			$in_reply = [];
 		}
 
-		$delivery_data = new FriendicaDeliveryData($item['delivery_queue_count'] ?? 0, $item['delivery_queue_done'] ?? 0, $item['delivery_queue_failed'] ?? 0);
+		$delivery_data = new FriendicaDeliveryData($item['delivery_queue_count'], $item['delivery_queue_done'], $item['delivery_queue_failed']);
 		$friendica     = new FriendicaExtension($item['title'], $counts->dislikes, $delivery_data);
 
 		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica, $quote, $poll);

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -288,10 +288,7 @@ class Status extends BaseFactory
 			$in_reply = [];
 		}
 
-		$queue_count   = $item['delivery_queue_count'];
-		$queue_done    = $item['delivery_queue_done'];
-		$queue_failed  = $item['delivery_queue_failed'];
-		$delivery_data = new FriendicaDeliveryData($queue_count, $queue_done, $queue_failed);
+		$delivery_data = new FriendicaDeliveryData($item['delivery_queue_count'] ?? 0, $item['delivery_queue_done'] ?? 0, $item['delivery_queue_failed'] ?? 0);
 		$friendica     = new FriendicaExtension($item['title'], $counts->dislikes, $delivery_data);
 
 		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica, $quote, $poll);

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -33,6 +33,8 @@ use Friendica\Model\Post;
 use Friendica\Model\Tag as TagModel;
 use Friendica\Model\Verb;
 use Friendica\Network\HTTPException;
+use Friendica\Object\Api\Mastodon\Status\FriendicaDeliveryData;
+use Friendica\Object\Api\Mastodon\Status\FriendicaExtension;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\ActivityPub;
 use ImagickException;
@@ -97,7 +99,8 @@ class Status extends BaseFactory
 	public function createFromUriId(int $uriId, int $uid = 0, bool $display_quote = false, bool $reblog = true, bool $in_reply_status = true): \Friendica\Object\Api\Mastodon\Status
 	{
 		$fields = ['uri-id', 'uid', 'author-id', 'causer-id', 'author-uri-id', 'author-link', 'causer-uri-id', 'post-reason', 'starred', 'app', 'title', 'body', 'raw-body', 'content-warning', 'question-id',
-			'created', 'network', 'thr-parent-id', 'parent-author-id', 'language', 'uri', 'plink', 'private', 'vid', 'gravity', 'featured', 'has-media', 'quote-uri-id'];
+			'created', 'network', 'thr-parent-id', 'parent-author-id', 'language', 'uri', 'plink', 'private', 'vid', 'gravity', 'featured', 'has-media', 'quote-uri-id',
+			'delivery_queue_count', 'delivery_queue_done','delivery_queue_failed'];
 		$item = Post::selectFirst($fields, ['uri-id' => $uriId, 'uid' => [0, $uid]], ['order' => ['uid' => true]]);
 		if (!$item) {
 			$mail = DBA::selectFirst('mail', ['id'], ['uri-id' => $uriId, 'uid' => $uid]);
@@ -285,7 +288,13 @@ class Status extends BaseFactory
 			$in_reply = [];
 		}
 
-		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $quote, $poll);
+		$queue_count   = $item['delivery_queue_count'];
+		$queue_done    = $item['delivery_queue_done'];
+		$queue_failed  = $item['delivery_queue_failed'];
+		$delivery_data = new FriendicaDeliveryData($queue_count, $queue_done, $queue_failed);
+		$friendica     = new FriendicaExtension($item['title'], $counts->dislikes, $delivery_data);
+
+		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica, $quote, $poll);
 	}
 
 	/**
@@ -349,7 +358,8 @@ class Status extends BaseFactory
 		$attachments = [];
 		$in_reply    = [];
 		$reshare     = [];
+		$friendica   = new FriendicaExtension('', 0, new FriendicaDeliveryData(0, 0, 0));
 
-		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare);
+		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica);
 	}
 }

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -105,7 +105,7 @@ class Status extends BaseDataTransferObject
 	 * @param array   $item
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function __construct(array $item, Account $account, Counts $counts, UserAttributes $userAttributes, bool $sensitive, Application $application, array $mentions, array $tags, Card $card, array $attachments, array $in_reply, array $reblog, array $quote = null, array $poll = null)
+	public function __construct(array $item, Account $account, Counts $counts, UserAttributes $userAttributes, bool $sensitive, Application $application, array $mentions, array $tags, Card $card, array $attachments, array $in_reply, array $reblog, FriendicaExtension $friendica, array $quote = null, array $poll = null)
 	{
 		$this->id         = (string)$item['uri-id'];
 		$this->created_at = DateTimeFormat::utc($item['created'], DateTimeFormat::JSON);
@@ -151,7 +151,7 @@ class Status extends BaseDataTransferObject
 		$this->emojis = [];
 		$this->card = $card->toArray() ?: null;
 		$this->poll = $poll;
-		$this->friendica = new FriendicaExtension($item['title'], $counts->dislikes);
+		$this->friendica = $friendica;
 	}
 
 	/**

--- a/src/Object/Api/Mastodon/Status/FriendicaDeliveryData.php
+++ b/src/Object/Api/Mastodon/Status/FriendicaDeliveryData.php
@@ -24,33 +24,32 @@ namespace Friendica\Object\Api\Mastodon\Status;
 use Friendica\BaseDataTransferObject;
 
 /**
- * Class FriendicaExtension
+ * Class FriendicaDeliveryData
  *
- * Additional fields on Mastodon Statuses for storing Friendica specific data
+ * Additional fields on Mastodon Statuses for storing Friendica delivery data
  *
  * @see https://docs.joinmastodon.org/entities/status
  */
-class FriendicaExtension extends BaseDataTransferObject
+class FriendicaDeliveryData extends BaseDataTransferObject
 {
-	/** @var string */
-	protected $title;
-
-	/** @var FriendicaDeliveryData */
-	protected $delivery_data;
 	/** @var int */
-	protected $dislikes_count;
+	protected $delivery_queue_count;
+
+	/** @var int */
+	protected $delivery_queue_done;
+
+	/** @var int */
+	protected $delivery_queue_failed;
 
 	/**
-	 * Creates a status count object
+	 * Creates a FriendicaDeliveryData object
 	 *
-	 * @param string $title
-	 * @param int $dislikes_count
-	 * @param FriendicaDeliveryData $delivery_data
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function __construct(string $title, int $dislikes_count, FriendicaDeliveryData $delivery_data)
+	public function __construct(int $delivery_queue_count, int $delivery_queue_done, int $delivery_queue_failed)
 	{
-		$this->title          = $title;
-		$this->delivery_data  = $delivery_data;
-		$this->dislikes_count = $dislikes_count;
+		$this->delivery_queue_count  = $delivery_queue_count;
+		$this->delivery_queue_done   = $delivery_queue_done;
+		$this->delivery_queue_failed = $delivery_queue_failed;
 	}
 }

--- a/src/Object/Api/Mastodon/Status/FriendicaDeliveryData.php
+++ b/src/Object/Api/Mastodon/Status/FriendicaDeliveryData.php
@@ -32,13 +32,13 @@ use Friendica\BaseDataTransferObject;
  */
 class FriendicaDeliveryData extends BaseDataTransferObject
 {
-	/** @var int */
+	/** @var int|null */
 	protected $delivery_queue_count;
 
-	/** @var int */
+	/** @var int|null */
 	protected $delivery_queue_done;
 
-	/** @var int */
+	/** @var int|null */
 	protected $delivery_queue_failed;
 
 	/**
@@ -46,7 +46,7 @@ class FriendicaDeliveryData extends BaseDataTransferObject
 	 *
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function __construct(int $delivery_queue_count, int $delivery_queue_done, int $delivery_queue_failed)
+	public function __construct(?int $delivery_queue_count, ?int $delivery_queue_done, ?int $delivery_queue_failed)
 	{
 		$this->delivery_queue_count  = $delivery_queue_count;
 		$this->delivery_queue_done   = $delivery_queue_done;


### PR DESCRIPTION
These changes adds delivery status information to the Mastodon Status API entity. This provides same numerical data as the "in flight" status icon and hover text in the web UI. It provides: 
  * Total number of servers that need to be federated to
  * Number of servers that have successfully been federated to at the time of the call
  * Number of servers that have been unsuccessfully federated to at the time of the call.

I have tried to not reproduce the white space inconsistency bugs with the documentation that I'm fighting my editors with on the previous API documentation update PR. If it persists I'd really like to walk through the settings in PHPStorm or get someone's settings file to fix this. 