### PR TITLE
Fix mastodon v2 active month naming error

### DIFF
--- a/src/Object/Api/Mastodon/InstanceV2/UserStats.php
+++ b/src/Object/Api/Mastodon/InstanceV2/UserStats.php
@@ -33,10 +33,10 @@ class UserStats extends BaseDataTransferObject
 	/** @var int */
 	protected $active_month = 0;
 
-	/**
-	 * @param $active_month
-	 */
-	public function __construct($active_month)
+    /**
+     * @param int $active_month
+     */
+    public function __construct(int $active_month)
 	{
 		$this->active_month = $active_month;
 	}

--- a/src/Object/Api/Mastodon/InstanceV2/UserStats.php
+++ b/src/Object/Api/Mastodon/InstanceV2/UserStats.php
@@ -31,13 +31,13 @@ use Friendica\BaseDataTransferObject;
 class UserStats extends BaseDataTransferObject
 {
 	/** @var int */
-	protected $active_monthly = 0;
+	protected $active_month = 0;
 
 	/**
 	 * @param $active_monthly
 	 */
-	public function __construct($active_monthly)
+	public function __construct($active_month)
 	{
-		$this->active_monthly = $active_monthly;
+		$this->active_month = $active_month;
 	}
 }

--- a/src/Object/Api/Mastodon/InstanceV2/UserStats.php
+++ b/src/Object/Api/Mastodon/InstanceV2/UserStats.php
@@ -34,7 +34,7 @@ class UserStats extends BaseDataTransferObject
 	protected $active_month = 0;
 
 	/**
-	 * @param $active_monthly
+	 * @param $active_month
 	 */
 	public function __construct($active_month)
 	{

--- a/src/Object/Api/Mastodon/InstanceV2/UserStats.php
+++ b/src/Object/Api/Mastodon/InstanceV2/UserStats.php
@@ -33,10 +33,10 @@ class UserStats extends BaseDataTransferObject
 	/** @var int */
 	protected $active_month = 0;
 
-    /**
-     * @param int $active_month
-     */
-    public function __construct(int $active_month)
+	/**
+	 * @param int $active_month
+	 */
+	public function __construct(int $active_month)
 	{
 		$this->active_month = $active_month;
 	}


### PR DESCRIPTION
Corrects naming error of the active monthly users stat from `active_monthly` to correct `active_month`. 

Fixes #12847