### PR TITLE
Use Mastodon standard edited_at field for tracking edit time

### DIFF
--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -289,7 +289,7 @@ class Status extends BaseFactory
 		}
 
 		$delivery_data = new FriendicaDeliveryData($item['delivery_queue_count'], $item['delivery_queue_done'], $item['delivery_queue_failed']);
-		$friendica     = new FriendicaExtension($item['title'], $item['commented'], $item['edited'], $item['received'], $counts->dislikes, $delivery_data);
+		$friendica     = new FriendicaExtension($item['title'], $item['changed'], $item['commented'], $item['received'], $counts->dislikes, $delivery_data);
 
 		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica, $quote, $poll);
 	}

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -289,7 +289,7 @@ class Status extends BaseFactory
 		}
 
 		$delivery_data = new FriendicaDeliveryData($item['delivery_queue_count'], $item['delivery_queue_done'], $item['delivery_queue_failed']);
-		$friendica     = new FriendicaExtension($item['title'], $item['changed'], $item['commented'], $item['edited'], $item['received'], $counts->dislikes, $delivery_data);
+		$friendica     = new FriendicaExtension($item['title'], $item['commented'], $item['edited'], $item['received'], $counts->dislikes, $delivery_data);
 
 		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica, $quote, $poll);
 	}
@@ -355,7 +355,7 @@ class Status extends BaseFactory
 		$attachments = [];
 		$in_reply    = [];
 		$reshare     = [];
-		$friendica   = new FriendicaExtension('', null, null, null, null, 0, new FriendicaDeliveryData(0, 0, 0));
+		$friendica   = new FriendicaExtension('', null, null, null, 0, new FriendicaDeliveryData(0, 0, 0));
 
 		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica);
 	}

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -221,8 +221,8 @@ class BaseApi extends BaseModule
 					}
 					break;
 				case TimelineOrderByTypes::EDITED:
-					if (!empty($status->friendicaExtension()->editedAt())) {
-						self::setBoundaries(new DateTime(DateTimeFormat::utc($status->friendicaExtension()->editedAt(), DateTimeFormat::JSON)));
+					if (!empty($status->editedAt())) {
+						self::setBoundaries(new DateTime(DateTimeFormat::utc($status->editedAt(), DateTimeFormat::JSON)));
 					}
 					break;
 				case TimelineOrderByTypes::RECEIVED:

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -40,6 +40,8 @@ class Status extends BaseDataTransferObject
 	protected $id;
 	/** @var string|null (Datetime) */
 	protected $created_at;
+	/** @var string|null (Datetime) */
+	protected $edited_at;
 	/** @var string|null */
 	protected $in_reply_to_id = null;
 	/** @var Status|null - Fedilab extension, see issue https://github.com/friendica/friendica/issues/12672 */
@@ -109,6 +111,7 @@ class Status extends BaseDataTransferObject
 	{
 		$this->id           = (string)$item['uri-id'];
 		$this->created_at   = $item['created'];
+		$this->edited_at    = $item['edited'];
 
 		if ($item['gravity'] == Item::GRAVITY_COMMENT) {
 			$this->in_reply_to_id         = (string)$item['thr-parent-id'];
@@ -161,6 +164,15 @@ class Status extends BaseDataTransferObject
 	public function createdAt(): ?string
 	{
 		return $this->created_at;
+	}
+
+	/**
+	 * Returns the current edited_at string or null if not set
+	 * @return ?string
+	 */
+	public function editedAt(): ?string
+	{
+		return $this->edited_at;
 	}
 
 	/**

--- a/src/Object/Api/Mastodon/Status/FriendicaExtension.php
+++ b/src/Object/Api/Mastodon/Status/FriendicaExtension.php
@@ -42,9 +42,6 @@ class FriendicaExtension extends BaseDataTransferObject
 	protected $commented_at;
 
 	/** @var string|null (Datetime) */
-	protected $edited_at;
-
-	/** @var string|null (Datetime) */
 	protected $received_at;
 
 	/** @var FriendicaDeliveryData */
@@ -68,7 +65,6 @@ class FriendicaExtension extends BaseDataTransferObject
 		string $title,
 		?string $changed_at,
 		?string $commented_at,
-		?string $edited_at,
 		?string $received_at,
 		int $dislikes_count,
 		FriendicaDeliveryData $delivery_data
@@ -76,7 +72,6 @@ class FriendicaExtension extends BaseDataTransferObject
 		$this->title          = $title;
 		$this->changed_at     = $changed_at;
 		$this->commented_at   = $commented_at;
-		$this->edited_at      = $edited_at;
 		$this->received_at    = $received_at;
 		$this->delivery_data  = $delivery_data;
 		$this->dislikes_count = $dislikes_count;
@@ -98,15 +93,6 @@ class FriendicaExtension extends BaseDataTransferObject
 	public function commentedAt(): ?string
 	{
 		return $this->commented_at;
-	}
-
-	/**
-	 * Returns the current edited_at string or null if not set
-	 * @return ?string
-	 */
-	public function editedAt(): ?string
-	{
-		return $this->edited_at;
 	}
 
 	/**


### PR DESCRIPTION
Mastodon added an edit field with version 3.5.0. This PR changes our Mastodon Status API to write to that rather than a Friendica extension field. 