### PR TITLE
API: Fix dateformat on status

### DIFF
--- a/src/Object/Api/Mastodon/Account.php
+++ b/src/Object/Api/Mastodon/Account.php
@@ -116,8 +116,8 @@ class Account extends BaseDataTransferObject
 		$this->following_count = $account['ap-following_count'] ?? $account['diaspora-interacting_count'] ?? 0;
 		$this->statuses_count  = $account['ap-statuses_count'] ?? $account['diaspora-post_count'] ?? 0;
 
-		$lastItem = $account['last-item'] ?: DBA::NULL_DATETIME;
-		$this->last_status_at  = $lastItem != DBA::NULL_DATETIME ? DateTimeFormat::utc($lastItem, 'Y-m-d') : null;
+		$lastItem = $account['last-item'] ? DateTimeFormat::utc($account['last-item'], 'Y-m-d') : DBA::NULL_DATETIME;
+		$this->last_status_at  = $lastItem != DBA::NULL_DATETIME ? DateTimeFormat::utc($lastItem, DateTimeFormat::JSON) : null;
 
 		// No custom emojis per account in Friendica
 		$this->emojis          = [];

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -110,8 +110,8 @@ class Status extends BaseDataTransferObject
 	public function __construct(array $item, Account $account, Counts $counts, UserAttributes $userAttributes, bool $sensitive, Application $application, array $mentions, array $tags, Card $card, array $attachments, array $in_reply, array $reblog, FriendicaExtension $friendica, array $quote = null, array $poll = null)
 	{
 		$this->id           = (string)$item['uri-id'];
-		$this->created_at   = $item['created'];
-		$this->edited_at    = $item['edited'];
+		$this->created_at   = DateTimeFormat::utc($item['created'], DateTimeFormat::JSON);
+		$this->edited_at    = DateTimeFormat::utc($item['edited'], DateTimeFormat::JSON);
 
 		if ($item['gravity'] == Item::GRAVITY_COMMENT) {
 			$this->in_reply_to_id         = (string)$item['thr-parent-id'];

--- a/src/Object/Api/Mastodon/Status/FriendicaExtension.php
+++ b/src/Object/Api/Mastodon/Status/FriendicaExtension.php
@@ -22,6 +22,7 @@
 namespace Friendica\Object\Api\Mastodon\Status;
 
 use Friendica\BaseDataTransferObject;
+use Friendica\Util\DateTimeFormat;
 
 /**
  * Class FriendicaExtension
@@ -70,9 +71,9 @@ class FriendicaExtension extends BaseDataTransferObject
 		FriendicaDeliveryData $delivery_data
 	) {
 		$this->title          = $title;
-		$this->changed_at     = $changed_at;
-		$this->commented_at   = $commented_at;
-		$this->received_at    = $received_at;
+		$this->changed_at     = $changed_at ? DateTimeFormat::utc($changed_at, DateTimeFormat::JSON) : null;
+		$this->commented_at   = $commented_at ? DateTimeFormat::utc($commented_at, DateTimeFormat::JSON) : null;
+		$this->received_at    = $received_at ? DateTimeFormat::utc($received_at, DateTimeFormat::JSON) : null;
 		$this->delivery_data  = $delivery_data;
 		$this->dislikes_count = $dislikes_count;
 	}


### PR DESCRIPTION
The date format has to be in a very specific format so that the clients don't complain. This is fixed now.