### PR TITLE
Fix missing attached links in posts

### DIFF
--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -260,9 +260,11 @@ class Status extends BaseFactory
 			}
 
 			$item['body'] = $this->contentItem->addSharedPost($item);
+			$item['body'] = Post\Media::addHTMLAttachmentToBody($uriId, $item['body']);
 
 			if (!is_null($item['raw-body'])) {
 				$item['raw-body'] = $this->contentItem->addSharedPost($item, $item['raw-body']);
+				$item['raw-body'] = Post\Media::addHTMLLinkToBody($uriId, $item['raw-body']);
 			}
 		}
 

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -259,12 +259,12 @@ class Status extends BaseFactory
 				}
 			}
 
-			$item['body'] = $this->contentItem->addSharedPost($item);
-			$item['body'] = Post\Media::addHTMLAttachmentToBody($uriId, $item['body']);
-
 			if (!is_null($item['raw-body'])) {
 				$item['raw-body'] = $this->contentItem->addSharedPost($item, $item['raw-body']);
 				$item['raw-body'] = Post\Media::addHTMLLinkToBody($uriId, $item['raw-body']);
+			} else {
+				$item['body'] = $this->contentItem->addSharedPost($item);
+				$item['body'] = Post\Media::addHTMLLinkToBody($uriId, $item['body']);
 			}
 		}
 

--- a/src/Factory/Api/Twitter/Status.php
+++ b/src/Factory/Api/Twitter/Status.php
@@ -124,6 +124,7 @@ class Status extends BaseFactory
 	 */
 	private function createFromArray(array $item, int $uid, bool $include_entities): \Friendica\Object\Api\Twitter\Status
 	{
+		$item = Post\Media::addHTMLAttachmentToItem($item);
 		$author = $this->twitterUser->createFromContactId($item['author-id'], $uid, true);
 
 		if (!empty($item['causer-id']) && ($item['post-reason'] == Item::PR_ANNOUNCEMENT)) {

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -912,12 +912,11 @@ class Media
 			'url'  => $links[0]['url'],
 			'title' => $links[0]['name'],
 			'text' => $links[0]['description'],
-			'alternative_title' => '', 
-			'publisher_name' => $links[0]['publisher-name'], 
-			'publisher_url' => $links[0]['publisher-url'], 
-			'publisher_img' => $links[0]['publisher-image'], 
-			'author_name' => $links[0]['author-name'], 
-			'author_url' => $links[0]['author-url'], 
+			'publisher_name' => $links[0]['publisher-name'],
+			'publisher_url' => $links[0]['publisher-url'],
+			'publisher_img' => $links[0]['publisher-image'],
+			'author_name' => $links[0]['author-name'],
+			'author_url' => $links[0]['author-url'],
 			'author_img' => $links[0]['author-image'],
 			'images' => [[
 				'src' => $links[0]['preview'],
@@ -926,7 +925,7 @@ class Media
 			]]
 		];
 		$body .= "\n" . PageInfo::getFooterFromData($data);
-		
+
 		return $body;
 	}
 

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Model\Post;
 
+use Friendica\Content\PageInfo;
 use Friendica\Content\Text\BBCode;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
@@ -893,6 +894,73 @@ class Media
 		}
 
 		return $body;
+	}
+
+	public static function addHTMLAttachmentToBody(int $uriid, string $body): string
+	{
+		if (preg_match("/.*(\[attachment.*?\].*?\[\/attachment\]).*/ism", $body, $match)) {
+			return $body;
+		}
+
+		$links = self::getByURIId($uriid, [self::HTML]);
+		if (empty($links)) {
+			return $body;
+		}
+
+		$data = [
+			'type' => 'link',
+			'url'  => $links[0]['url'],
+			'title' => $links[0]['name'],
+			'text' => $links[0]['description'],
+			'alternative_title' => '', 
+			'publisher_name' => $links[0]['publisher-name'], 
+			'publisher_url' => $links[0]['publisher-url'], 
+			'publisher_img' => $links[0]['publisher-image'], 
+			'author_name' => $links[0]['author-name'], 
+			'author_url' => $links[0]['author-url'], 
+			'author_img' => $links[0]['author-image'],
+			'images' => [[
+				'src' => $links[0]['preview'],
+				'height' => $links[0]['preview-height'],
+				'width' => $links[0]['preview-width'],
+			]]
+		];
+		$body .= "\n" . PageInfo::getFooterFromData($data);
+		
+		return $body;
+	}
+
+	public static function addHTMLLinkToBody(int $uriid, string $body): string
+	{
+		$links = self::getByURIId($uriid, [self::HTML]);
+		if (empty($links)) {
+			return $body;
+		}
+
+		if (strpos($body, $links[0]['url'])) {
+			return $body;
+		}
+
+		if (!empty($links[0]['name']) && ($links[0]['name'] != $links[0]['url'])) {
+			return $body . "\n[url=" . $links[0]['url'] . ']' . $links[0]['name'] . "[/url]";
+		} else {
+			return $body . "\n[url]" . $links[0]['url'] . "[/url]";
+		}
+	}
+
+	public static function addHTMLAttachmentToItem(array $item): array
+	{
+		if (($item['gravity'] == Item::GRAVITY_ACTIVITY) || empty($item['uri-id'])) {
+			return $item;
+		}
+
+		$item['body'] = self::addHTMLAttachmentToBody($item['uri-id'], $item['body']);
+
+		if (!empty($item['raw-body'])) {
+			$item['raw-body'] = self::addHTMLLinkToBody($item['uri-id'], $item['raw-body']);
+		}
+
+		return $item;
 	}
 
 	/**

--- a/src/Module/Post/Edit.php
+++ b/src/Module/Post/Edit.php
@@ -116,6 +116,7 @@ class Edit extends BaseModule
 		}
 
 		$item['body'] = Post\Media::addAttachmentsToBody($item['uri-id'], $item['body']);
+		$item = Post\Media::addHTMLAttachmentToItem($item);
 
 		$jotplugins = '';
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1639,6 +1639,8 @@ class Transmitter
 
 		$real_quote = false;
 
+		$item = Post\Media::addHTMLAttachmentToItem($item);
+
 		$body = $item['body'];
 
 		if ($type == 'Note') {

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -774,6 +774,7 @@ class DFRN
 		}
 
 		$body = Post\Media::addAttachmentsToBody($item['uri-id'], DI::contentItem()->addSharedPost($item));
+		$body = Post\Media::addHTMLAttachmentToBody($item['uri-id'], $body);
 
 		if ($item['private'] == Item::PRIVATE) {
 			$body = Item::fixPrivatePhotos($body, $owner['uid'], $item, $cid);

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3326,6 +3326,7 @@ class Diaspora
 
 			$title = $item['title'];
 			$body  = Post\Media::addAttachmentsToBody($item['uri-id'], DI::contentItem()->addSharedPost($item), $attach_media);
+			$body  = Post\Media::addHTMLLinkToBody($item['uri-id'], $body);
 
 			// Fetch the title from an attached link - if there is one
 			if (empty($item['title']) && DI::pConfig()->get($owner['uid'], 'system', 'attach_link_title')) {
@@ -3585,6 +3586,7 @@ class Diaspora
 		}
 
 		$body = Post\Media::addAttachmentsToBody($item['uri-id'], DI::contentItem()->addSharedPost($item));
+		$body = Post\Media::addHTMLLinkToBody($item['uri-id'], $body);
 
 		// The replied to autor mention is prepended for clarity if:
 		// - Item replied isn't yours

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -1124,7 +1124,7 @@ class Feed
 		XML::addElement($doc, $entry, 'title', html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 
 		$body = Post\Media::addAttachmentsToBody($item['uri-id'], DI::contentItem()->addSharedPost($item));
-		$body = Post\Media::addHTMLAttachmentToBody($item['uri-id'], $body);
+		$body = Post\Media::addHTMLLinkToBody($item['uri-id'], $body);
 
 		$body = BBCode::convertForUriId($item['uri-id'], $body, BBCode::ACTIVITYPUB);
 

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -1124,6 +1124,7 @@ class Feed
 		XML::addElement($doc, $entry, 'title', html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 
 		$body = Post\Media::addAttachmentsToBody($item['uri-id'], DI::contentItem()->addSharedPost($item));
+		$body = Post\Media::addHTMLAttachmentToBody($item['uri-id'], $body);
 
 		$body = BBCode::convertForUriId($item['uri-id'], $body, BBCode::ACTIVITYPUB);
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1515,7 +1515,7 @@ class OStatus
 		XML::addElement($doc, $entry, 'title', html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 
 		$body = Post\Media::addAttachmentsToBody($item['uri-id'], DI::contentItem()->addSharedPost($item));
-		$body = Post\Media::addHTMLAttachmentToBody($item['uri-id'], $body);
+		$body = Post\Media::addHTMLLinkToBody($item['uri-id'], $body);
 
 		if (!empty($item['title'])) {
 			$body = '[b]' . $item['title'] . "[/b]\n\n" . $body;

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1515,6 +1515,7 @@ class OStatus
 		XML::addElement($doc, $entry, 'title', html_entity_decode($title, ENT_QUOTES, 'UTF-8'));
 
 		$body = Post\Media::addAttachmentsToBody($item['uri-id'], DI::contentItem()->addSharedPost($item));
+		$body = Post\Media::addHTMLAttachmentToBody($item['uri-id'], $body);
 
 		if (!empty($item['title'])) {
 			$body = '[b]' . $item['title'] . "[/b]\n\n" . $body;

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -114,6 +114,7 @@ class Notifier
 			// find ancestors
 			$condition = ['id' => $target_id, 'visible' => true];
 			$target_item = Post::selectFirst(Item::DELIVER_FIELDLIST, $condition);
+			$target_item = Post\Media::addHTMLAttachmentToItem($target_item);
 
 			if (!DBA::isResult($target_item) || !intval($target_item['parent'])) {
 				Logger::info('No target item', ['cmd' => $cmd, 'target' => $target_id]);


### PR DESCRIPTION
One of the last PRs introduced a problem that links hadn't been transmitted to other systems. This PR fixes it by adding the link back at the relevant places. In the future we should get rid of the "attachment" BBCode and the other "special" BBCodes at all and should store and transmit additional data at a more appropriate place.

Fixes https://github.com/friendica/friendica/issues/12864