### PR TITLE
Fix plaintext function by partly reverting function removal

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -209,6 +209,183 @@ class BBCode
 		);
 	}
 
+	public static function getAttachedData(string $body, array $item = []): array
+	{
+		/*
+		- text:
+		- type: link, video, photo
+		- title:
+		- url:
+		- image:
+		- description:
+		- (thumbnail)
+		*/
+
+		DI::profiler()->startRecording('rendering');
+		$has_title = !empty($item['title']);
+		$plink = $item['plink'] ?? '';
+		$post = self::getAttachmentData($body);
+
+		// Get all linked images with alternative image description
+		if (preg_match_all("/\[img=(http[^\[\]]*)\]([^\[\]]*)\[\/img\]/Usi", $body, $pictures, PREG_SET_ORDER)) {
+			foreach ($pictures as $picture) {
+				if ($id = Photo::getIdForName($picture[1])) {
+					$post['images'][] = ['url' => str_replace('-1.', '-0.', $picture[1]), 'description' => $picture[2], 'id' => $id];
+				} else {
+					$post['remote_images'][] = ['url' => $picture[1], 'description' => $picture[2]];
+				}
+			}
+			if (!empty($post['images']) && !empty($post['images'][0]['description'])) {
+				$post['image_description'] = $post['images'][0]['description'];
+			}
+		}
+
+		if (preg_match_all("/\[img\]([^\[\]]*)\[\/img\]/Usi", $body, $pictures, PREG_SET_ORDER)) {
+			foreach ($pictures as $picture) {
+				if ($id = Photo::getIdForName($picture[1])) {
+					$post['images'][] = ['url' => str_replace('-1.', '-0.', $picture[1]), 'description' => '', 'id' => $id];
+				} else {
+					$post['remote_images'][] = ['url' => $picture[1], 'description' => ''];
+				}
+			}
+		}
+
+		if (!isset($post['type'])) {
+			$post['text'] = $body;
+		}
+
+		// Simplify image codes
+		$post['text'] = preg_replace("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/ism", '[img]$3[/img]', $post['text']);
+		$post['text'] = preg_replace("/\[img\=(.*?)\](.*?)\[\/img\]/ism", '[img]$1[/img]', $post['text']);
+
+		// if nothing is found, it maybe having an image.
+		if (!isset($post['type'])) {
+			if (preg_match_all("#\[url=([^\]]+?)\]\s*\[img\]([^\[]+?)\[/img\]\s*\[/url\]#ism", $post['text'], $pictures, PREG_SET_ORDER)) {
+				if ((count($pictures) == 1) && !$has_title) {
+					if (!empty($item['object-type']) && ($item['object-type'] == Activity\ObjectType::IMAGE)) {
+						// Replace the preview picture with the real picture
+						$url = str_replace('-1.', '-0.', $pictures[0][2]);
+						$data = ['url' => $url, 'type' => 'photo'];
+					} else {
+						// Checking, if the link goes to a picture
+						$data = ParseUrl::getSiteinfoCached($pictures[0][1]);
+					}
+
+					// Workaround:
+					// Sometimes photo posts to the own album are not detected at the start.
+					// So we seem to cannot use the cache for these cases. That's strange.
+					if (($data['type'] != 'photo') && strstr($pictures[0][1], '/photos/')) {
+						$data = ParseUrl::getSiteinfo($pictures[0][1]);
+					}
+
+					if ($data['type'] == 'photo') {
+						$post['type'] = 'photo';
+						if (isset($data['images'][0])) {
+							$post['image'] = $data['images'][0]['src'];
+							$post['url'] = $data['url'];
+						} else {
+							$post['image'] = $data['url'];
+						}
+
+						$post['preview'] = $pictures[0][2];
+						$post['text'] = trim(str_replace($pictures[0][0], '', $post['text']));
+					} else {
+						$imgdata = Images::getInfoFromURLCached($pictures[0][1]);
+						if (($imgdata) && substr($imgdata['mime'], 0, 6) == 'image/') {
+							$post['type'] = 'photo';
+							$post['image'] = $pictures[0][1];
+							$post['preview'] = $pictures[0][2];
+							$post['text'] = trim(str_replace($pictures[0][0], '', $post['text']));
+						}
+					}
+				} elseif (count($pictures) > 0) {
+					if (count($pictures) > 4) {
+						$post['type'] = 'link';
+						$post['url'] = $plink;
+					} else {
+						$post['type'] = 'photo';
+					}
+
+					$post['image'] = $pictures[0][2];
+
+					foreach ($pictures as $picture) {
+						$post['text'] = trim(str_replace($picture[0], '', $post['text']));
+					}
+				}
+			} elseif (preg_match_all("(\[img\](.*?)\[\/img\])ism", $post['text'], $pictures, PREG_SET_ORDER)) {
+				if ($has_title) {
+					$post['type'] = 'link';
+					$post['url'] = $plink;
+				} else {
+					$post['type'] = 'photo';
+				}
+
+				$post['image'] = $pictures[0][1];
+				foreach ($pictures as $picture) {
+					$post['text'] = trim(str_replace($picture[0], '', $post['text']));
+				}
+			}
+
+			// Test for the external links
+			preg_match_all("(\[url\](.*?)\[\/url\])ism", $post['text'], $links1, PREG_SET_ORDER);
+			preg_match_all("(\[url\=(.*?)\].*?\[\/url\])ism", $post['text'], $links2, PREG_SET_ORDER);
+
+			$links = array_merge($links1, $links2);
+
+			// If there is only a single one, then use it.
+			// This should cover link posts via API.
+			if ((count($links) == 1) && !isset($post['preview']) && !$has_title) {
+				$post['type'] = 'link';
+				$post['url'] = $links[0][1];
+			}
+
+			// Simplify "video" element
+			$post['text'] = preg_replace('(\[video.*?\ssrc\s?=\s?([^\s\]]+).*?\].*?\[/video\])ism', '[video]$1[/video]', $post['text']);
+
+			// Now count the number of external media links
+			preg_match_all("(\[vimeo\](.*?)\[\/vimeo\])ism", $post['text'], $links1, PREG_SET_ORDER);
+			preg_match_all("(\[youtube\\](.*?)\[\/youtube\\])ism", $post['text'], $links2, PREG_SET_ORDER);
+			preg_match_all("(\[video\\](.*?)\[\/video\\])ism", $post['text'], $links3, PREG_SET_ORDER);
+			preg_match_all("(\[audio\\](.*?)\[\/audio\\])ism", $post['text'], $links4, PREG_SET_ORDER);
+
+			// Add them to the other external links
+			$links = array_merge($links, $links1, $links2, $links3, $links4);
+
+			// Are there more than one?
+			if (count($links) > 1) {
+				// The post will be the type "text", which means a blog post
+				unset($post['type']);
+				$post['url'] = $plink;
+			}
+
+			if (!isset($post['type'])) {
+				$post['type'] = 'text';
+			}
+
+			if (($post['type'] == 'photo') && empty($post['images']) && !empty($post['remote_images'])) {
+				$post['images'] = $post['remote_images'];
+				$post['image'] = $post['images'][0]['url'];
+				if (!empty($post['images']) && !empty($post['images'][0]['description'])) {
+					$post['image_description'] = $post['images'][0]['description'];
+				}
+			}
+			unset($post['remote_images']);
+		} elseif (isset($post['url']) && ($post['type'] == 'video')) {
+			$data = ParseUrl::getSiteinfoCached($post['url']);
+
+			if (isset($data['images'][0])) {
+				$post['image'] = $data['images'][0]['src'];
+			}
+		} elseif (preg_match_all("#\[url=([^\]]+?)\]\s*\[img\]([^\[]+?)\[/img\]\s*\[/url\]#ism", $post['text'], $pictures, PREG_SET_ORDER)) {
+			foreach ($pictures as $picture) {
+				$post['text'] = trim(str_replace($picture[0], '', $post['text']));
+			}
+		}
+
+		DI::profiler()->stopRecording();
+		return $post;
+	}
+
 	/**
 	 * Remove [attachment] BBCode
 	 *

--- a/src/Content/Text/Plaintext.php
+++ b/src/Content/Text/Plaintext.php
@@ -132,7 +132,7 @@ class Plaintext
 		$body = BBCode::stripAbstract($body);
 
 		// At first look at data that is attached via "type-..." stuff
-		$post = BBCode::getAttachmentData($body, $item);
+		$post = BBCode::getAttachedData($body, $item);
 
 		if (($item['title'] != '') && ($post['text'] != '')) {
 			$post['text'] = trim($item['title'] . "\n\n" . $post['text']);


### PR DESCRIPTION
The function `getAttachmentData` is not a direct replacement for `getAttachedData`.

The plaintext function has to be reworked completely. Until then the old function is revived.