### PR TITLE
Mastodon edit title spoiler update

### DIFF
--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -78,14 +78,14 @@ class Statuses extends BaseApi
 			$item['language'] = json_encode([$request['language'] => 1]);
 		}
 
-		if ($post['gravity'] == 0) {
+		if ($post['gravity'] == Item::GRAVITY_PARENT) {
 			$item['title'] = $request['friendica']['title'] ?? '';
 		}
 
 		$spoiler_text = $request['spoiler_text'];
 
 		if (!empty($spoiler_text)) {
-			if (!isset($request['friendica']['title']) && $post['gravity'] == 0 && DI::pConfig()->get($uid, 'system', 'api_spoiler_title', true)) {
+			if (!isset($request['friendica']['title']) && $post['gravity'] == Item::GRAVITY_PARENT && DI::pConfig()->get($uid, 'system', 'api_spoiler_title', true)) {
 				$item['title'] = $spoiler_text;
 			} else {
 				$item['body'] = '[abstract=' . Protocol::ACTIVITYPUB . ']' . $spoiler_text . "[/abstract]\n" . $item['body'];


### PR DESCRIPTION
The handling of the spoiler text/title editing in Mastodon API was inconsistent with the creation endpoint. This change aligns the two.

I tried to wait until the larger image attachment editing change was put through so I could graft these changes into it but since that looks stalled I didn't want this to miss the 2023.03 release as well.