### PR TITLE
Cast the base URL as string in /friendica/json

### DIFF
--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -172,7 +172,7 @@ class Friendica extends BaseModule
 
 		$data = [
 			'version'          => App::VERSION,
-			'url'              => DI::baseUrl(),
+			'url'              => (string)DI::baseUrl(),
 			'addons'           => $visible_addons,
 			'locked_features'  => $locked_features,
 			'explicit_content' => intval($config->get('system', 'explicit_content', 0)),


### PR DESCRIPTION
- This was causing the data.url key to have no value, which broke the directory integration