### PR TITLE
[frio] Move upload-button in filebrowser above previews

### DIFF
--- a/view/theme/frio/templates/media/browser.tpl
+++ b/view/theme/frio/templates/media/browser.tpl
@@ -22,6 +22,10 @@
 			</div>
 		</ol>
 
+		<div class="upload">
+			<button id="upload-{{$type}}" type="button" class="btn btn-primary">{{$upload}}</button>
+		</div>
+
 		<div class="media">
 
 			{{* List of photo albums *}}
@@ -52,9 +56,6 @@
 			</div>
 		</div>
 
-		<div class="upload">
-			<button id="upload-{{$type}}" type="button" class="btn btn-primary">{{$upload}}</button>
-		</div>
 	</div>
 
 	{{* This part contains the conent loader icon which is visible when new conent is loaded *}}


### PR DESCRIPTION
its annoying, when you open filebrowser to upload an image or file, and the button moves away under your finger/cursor, in case of loading preview images slower than the form itself.

just change position of button (class="upload") and browser itself (class="media") disannoys the behaviour.

![grafik](https://user-images.githubusercontent.com/5894829/224666926-3cd7b58d-94a5-4bd9-9e96-406505cce28a.png)
