### PR TITLE
Option to automatically add links as attachment via API

### DIFF
--- a/src/Module/Settings/Connectors.php
+++ b/src/Module/Settings/Connectors.php
@@ -73,6 +73,7 @@ class Connectors extends BaseSettings
 			$this->pconfig->set($this->session->getLocalUserId(), 'system', 'simple_shortening', intval($request['simple_shortening']));
 			$this->pconfig->set($this->session->getLocalUserId(), 'system', 'attach_link_title', intval($request['attach_link_title']));
 			$this->pconfig->set($this->session->getLocalUserId(), 'system', 'api_spoiler_title', intval($request['api_spoiler_title']));
+			$this->pconfig->set($this->session->getLocalUserId(), 'system', 'api_auto_attach', intval($request['api_auto_attach']));
 			$this->pconfig->set($this->session->getLocalUserId(), 'ostatus', 'legacy_contact', $request['legacy_contact']);
 		} elseif (!empty($request['mail-submit']) && function_exists('imap_open') && !$this->config->get('system', 'imap_disabled')) {
 			$mail_server       =                 $request['mail_server'] ?? '';
@@ -136,6 +137,7 @@ class Connectors extends BaseSettings
 		$simple_shortening       =  intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'simple_shortening'));
 		$attach_link_title       =  intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'attach_link_title'));
 		$api_spoiler_title       =  intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'api_spoiler_title', true));
+		$api_auto_attach         =  intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'api_auto_attach', false));
 		$legacy_contact          =         $this->pconfig->get($this->session->getLocalUserId(), 'ostatus', 'legacy_contact');
 
 		if (!empty($legacy_contact)) {
@@ -221,6 +223,7 @@ class Connectors extends BaseSettings
 			'$simple_shortening'       => ['simple_shortening', $this->t('Enable simple text shortening'), $simple_shortening, $this->t('Normally the system shortens posts at the next line feed. If this option is enabled then the system will shorten the text at the maximum character limit.')],
 			'$attach_link_title'       => ['attach_link_title', $this->t('Attach the link title'), $attach_link_title, $this->t('When activated, the title of the attached link will be added as a title on posts to Diaspora. This is mostly helpful with "remote-self" contacts that share feed content.')],
 			'$api_spoiler_title'       => ['api_spoiler_title', $this->t('API: Use spoiler field as title'), $api_spoiler_title, $this->t('When activated, the "spoiler_text" field in the API will be used for the title on standalone posts. When deactivated it will be used for spoiler text. For comments it will always be used for spoiler text.')],
+			'$api_auto_attach'         => ['api_auto_attach', $this->t('API: Automatically links at the end of the post as attached posts'), $api_auto_attach, $this->t('When activated, added links at the end of the post react the same way as added links in the web interface.')],
 			'$legacy_contact'          => ['legacy_contact', $this->t('Your legacy ActivityPub/GNU Social account'), $legacy_contact, $this->t('If you enter your old account name from an ActivityPub based system or your GNU Social/Statusnet account name here (in the format user@domain.tld), your contacts will be added automatically. The field will be emptied when done.')],
 			'$repair_ostatus_url'  => 'ostatus/repair',
 			'$repair_ostatus_text' => $this->t('Repair OStatus subscriptions'),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2023.03-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-18 20:49+0000\n"
+"POT-Creation-Date: 2023-03-13 21:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,35 +18,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 
-#: mod/item.php:102 mod/item.php:105 mod/item.php:171 mod/item.php:174
+#: mod/item.php:100 mod/item.php:103 mod/item.php:170 mod/item.php:173
 msgid "Unable to locate original post."
 msgstr ""
 
-#: mod/item.php:139
+#: mod/item.php:138
 msgid "Post updated."
 msgstr ""
 
-#: mod/item.php:204 mod/item.php:208
+#: mod/item.php:203 mod/item.php:207
 msgid "Item wasn't stored."
 msgstr ""
 
-#: mod/item.php:218
+#: mod/item.php:217
 msgid "Item couldn't be fetched."
 msgstr ""
 
-#: mod/item.php:256 mod/item.php:260
+#: mod/item.php:255 mod/item.php:259
 msgid "Empty post discarded."
 msgstr ""
 
-#: mod/item.php:412 src/Module/Admin/Themes/Details.php:39
+#: mod/item.php:411 src/Module/Admin/Themes/Details.php:39
 #: src/Module/Admin/Themes/Index.php:59 src/Module/Debug/ItemBody.php:42
 #: src/Module/Debug/ItemBody.php:57 src/Module/Item/Feed.php:80
 msgid "Item not found."
 msgstr ""
 
-#: mod/item.php:436 mod/message.php:69 mod/message.php:114 mod/notes.php:45
+#: mod/item.php:435 mod/message.php:68 mod/message.php:113 mod/notes.php:45
 #: mod/photos.php:152 mod/photos.php:669 src/Model/Event.php:522
-#: src/Module/Attach.php:55 src/Module/BaseApi.php:95
+#: src/Module/Attach.php:55 src/Module/BaseApi.php:99
 #: src/Module/BaseNotifications.php:98 src/Module/BaseSettings.php:52
 #: src/Module/Calendar/Event/API.php:88 src/Module/Calendar/Event/Form.php:84
 #: src/Module/Calendar/Export.php:82 src/Module/Calendar/Show.php:82
@@ -150,7 +150,7 @@ msgid ""
 "your email for further instructions."
 msgstr ""
 
-#: mod/lostpass.php:130 src/Module/Security/Login.php:161
+#: mod/lostpass.php:130 src/Module/Security/Login.php:160
 msgid "Nickname or Email: "
 msgstr ""
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: mod/lostpass.php:146 src/Module/Security/Login.php:173
+#: mod/lostpass.php:146 src/Module/Security/Login.php:172
 msgid "Password Reset"
 msgstr ""
 
@@ -219,90 +219,90 @@ msgstr ""
 msgid "Your password has been changed at %s"
 msgstr ""
 
-#: mod/message.php:46 mod/message.php:129 src/Content/Nav.php:321
+#: mod/message.php:46 mod/message.php:128 src/Content/Nav.php:319
 msgid "New Message"
 msgstr ""
 
-#: mod/message.php:83 src/Module/Profile/UnkMail.php:100
+#: mod/message.php:82 src/Module/Profile/UnkMail.php:100
 msgid "No recipient selected."
 msgstr ""
 
-#: mod/message.php:88
+#: mod/message.php:87
 msgid "Unable to locate contact information."
 msgstr ""
 
-#: mod/message.php:92 src/Module/Profile/UnkMail.php:106
+#: mod/message.php:91 src/Module/Profile/UnkMail.php:106
 msgid "Message could not be sent."
 msgstr ""
 
-#: mod/message.php:96 src/Module/Profile/UnkMail.php:109
+#: mod/message.php:95 src/Module/Profile/UnkMail.php:109
 msgid "Message collection failure."
 msgstr ""
 
-#: mod/message.php:123 src/Module/Notifications/Introductions.php:135
+#: mod/message.php:122 src/Module/Notifications/Introductions.php:135
 #: src/Module/Notifications/Introductions.php:170
 #: src/Module/Notifications/Notification.php:85
 msgid "Discard"
 msgstr ""
 
-#: mod/message.php:136 src/Content/Nav.php:318 view/theme/frio/theme.php:241
+#: mod/message.php:135 src/Content/Nav.php:316 view/theme/frio/theme.php:241
 msgid "Messages"
 msgstr ""
 
-#: mod/message.php:149
+#: mod/message.php:148
 msgid "Conversation not found."
 msgstr ""
 
-#: mod/message.php:154
+#: mod/message.php:153
 msgid "Message was not deleted."
 msgstr ""
 
-#: mod/message.php:169
+#: mod/message.php:168
 msgid "Conversation was not removed."
 msgstr ""
 
-#: mod/message.php:183 mod/message.php:289 src/Module/Profile/UnkMail.php:146
+#: mod/message.php:181 mod/message.php:286 src/Module/Profile/UnkMail.php:145
 msgid "Please enter a link URL:"
 msgstr ""
 
-#: mod/message.php:192 src/Module/Profile/UnkMail.php:152
+#: mod/message.php:190 src/Module/Profile/UnkMail.php:151
 msgid "Send Private Message"
 msgstr ""
 
-#: mod/message.php:193 mod/message.php:349
+#: mod/message.php:191 mod/message.php:346
 msgid "To:"
 msgstr ""
 
-#: mod/message.php:194 mod/message.php:350
+#: mod/message.php:192 mod/message.php:347
 msgid "Subject:"
 msgstr ""
 
-#: mod/message.php:198 mod/message.php:353 src/Module/Invite.php:171
+#: mod/message.php:196 mod/message.php:350 src/Module/Invite.php:171
 msgid "Your message:"
 msgstr ""
 
-#: mod/message.php:201 mod/message.php:357 src/Content/Conversation.php:352
-#: src/Module/Post/Edit.php:128
+#: mod/message.php:199 mod/message.php:354 src/Content/Conversation.php:352
+#: src/Module/Post/Edit.php:131
 msgid "Upload photo"
 msgstr ""
 
-#: mod/message.php:202 mod/message.php:358 src/Module/Post/Edit.php:132
-#: src/Module/Profile/UnkMail.php:154
+#: mod/message.php:200 mod/message.php:355 src/Module/Post/Edit.php:135
+#: src/Module/Profile/UnkMail.php:153
 msgid "Insert web link"
 msgstr ""
 
-#: mod/message.php:203 mod/message.php:360 mod/photos.php:1291
-#: src/Content/Conversation.php:381 src/Content/Conversation.php:727
-#: src/Module/Item/Compose.php:204 src/Module/Post/Edit.php:142
-#: src/Module/Profile/UnkMail.php:155 src/Object/Post.php:545
+#: mod/message.php:201 mod/message.php:357 mod/photos.php:1291
+#: src/Content/Conversation.php:381 src/Content/Conversation.php:725
+#: src/Module/Item/Compose.php:204 src/Module/Post/Edit.php:145
+#: src/Module/Profile/UnkMail.php:154 src/Object/Post.php:545
 msgid "Please wait"
 msgstr ""
 
-#: mod/message.php:204 mod/message.php:359 mod/photos.php:702
+#: mod/message.php:202 mod/message.php:356 mod/photos.php:702
 #: mod/photos.php:819 mod/photos.php:1097 mod/photos.php:1138
 #: mod/photos.php:1194 mod/photos.php:1268
 #: src/Module/Calendar/Event/Form.php:250 src/Module/Contact/Advanced.php:132
-#: src/Module/Contact/Profile.php:340
+#: src/Module/Contact/Profile.php:339
 #: src/Module/Debug/ActivityPubConversion.php:140
 #: src/Module/Debug/Babel.php:313 src/Module/Debug/Localtime.php:64
 #: src/Module/Debug/Probe.php:54 src/Module/Debug/WebFinger.php:51
@@ -310,59 +310,59 @@ msgstr ""
 #: src/Module/Install.php:234 src/Module/Install.php:274
 #: src/Module/Install.php:309 src/Module/Invite.php:178
 #: src/Module/Item/Compose.php:189 src/Module/Moderation/Item/Source.php:79
-#: src/Module/Profile/Profile.php:274 src/Module/Profile/UnkMail.php:156
-#: src/Module/Settings/Profile/Index.php:231 src/Object/Post.php:1058
+#: src/Module/Profile/Profile.php:274 src/Module/Profile/UnkMail.php:155
+#: src/Module/Settings/Profile/Index.php:230 src/Object/Post.php:1058
 #: view/theme/duepuntozero/config.php:85 view/theme/frio/config.php:171
 #: view/theme/quattro/config.php:87 view/theme/vier/config.php:135
 msgid "Submit"
 msgstr ""
 
-#: mod/message.php:225
+#: mod/message.php:223
 msgid "No messages."
 msgstr ""
 
-#: mod/message.php:281
+#: mod/message.php:279
 msgid "Message not available."
 msgstr ""
 
-#: mod/message.php:326
+#: mod/message.php:323
 msgid "Delete message"
 msgstr ""
 
-#: mod/message.php:328 mod/message.php:459
+#: mod/message.php:325 mod/message.php:456
 msgid "D, d M Y - g:i A"
 msgstr ""
 
-#: mod/message.php:343 mod/message.php:456
+#: mod/message.php:340 mod/message.php:453
 msgid "Delete conversation"
 msgstr ""
 
-#: mod/message.php:345
+#: mod/message.php:342
 msgid ""
 "No secure communications available. You <strong>may</strong> be able to "
 "respond from the sender's profile page."
 msgstr ""
 
-#: mod/message.php:348
+#: mod/message.php:345
 msgid "Send Reply"
 msgstr ""
 
-#: mod/message.php:430
+#: mod/message.php:427
 #, php-format
 msgid "Unknown sender - %s"
 msgstr ""
 
-#: mod/message.php:432
+#: mod/message.php:429
 #, php-format
 msgid "You and %s"
 msgstr ""
 
-#: mod/message.php:434
+#: mod/message.php:431
 #, php-format
 msgid "%s and You"
 msgstr ""
 
-#: mod/message.php:462
+#: mod/message.php:459
 #, php-format
 msgid "%d message"
 msgid_plural "%d messages"
@@ -379,7 +379,7 @@ msgstr ""
 
 #: mod/notes.php:57 src/Content/Text/HTML.php:884
 #: src/Module/Admin/Storage.php:142 src/Module/Filer/SaveTag.php:74
-#: src/Module/Post/Edit.php:126
+#: src/Module/Post/Edit.php:129
 msgid "Save"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgid "Do not show a status post for this upload"
 msgstr ""
 
 #: mod/photos.php:733 mod/photos.php:1093 src/Content/Conversation.php:383
-#: src/Module/Calendar/Event/Form.php:253 src/Module/Post/Edit.php:179
+#: src/Module/Calendar/Event/Form.php:253 src/Module/Post/Edit.php:182
 msgid "Permissions"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 #: src/Module/Contact/Follow.php:172 src/Module/Contact/Revoke.php:109
 #: src/Module/Contact/Unfollow.php:126
 #: src/Module/Media/Attachment/Browser.php:77
-#: src/Module/Media/Photo/Browser.php:88 src/Module/Post/Edit.php:164
+#: src/Module/Media/Photo/Browser.php:88 src/Module/Post/Edit.php:167
 #: src/Module/Post/Tag/Remove.php:109 src/Module/Profile/RemoteFollow.php:134
 #: src/Module/Security/TwoFactor/SignOut.php:125
 msgid "Cancel"
@@ -595,7 +595,7 @@ msgid "Rotate CCW (left)"
 msgstr ""
 
 #: mod/photos.php:1135 mod/photos.php:1191 mod/photos.php:1265
-#: src/Module/Contact.php:589 src/Module/Item/Compose.php:188
+#: src/Module/Contact.php:588 src/Module/Item/Compose.php:188
 #: src/Object/Post.php:1055
 msgid "This is you"
 msgstr ""
@@ -607,25 +607,25 @@ msgstr ""
 
 #: mod/photos.php:1139 mod/photos.php:1195 mod/photos.php:1269
 #: src/Content/Conversation.php:396 src/Module/Calendar/Event/Form.php:248
-#: src/Module/Item/Compose.php:199 src/Module/Post/Edit.php:162
+#: src/Module/Item/Compose.php:199 src/Module/Post/Edit.php:165
 #: src/Object/Post.php:1069
 msgid "Preview"
 msgstr ""
 
 #: mod/photos.php:1140 src/Content/Conversation.php:351
-#: src/Module/Post/Edit.php:127 src/Object/Post.php:1059
+#: src/Module/Post/Edit.php:130 src/Object/Post.php:1059
 msgid "Loading..."
 msgstr ""
 
-#: mod/photos.php:1226 src/Content/Conversation.php:643 src/Object/Post.php:256
+#: mod/photos.php:1226 src/Content/Conversation.php:641 src/Object/Post.php:256
 msgid "Select"
 msgstr ""
 
-#: mod/photos.php:1227 src/Content/Conversation.php:644
+#: mod/photos.php:1227 src/Content/Conversation.php:642
 #: src/Module/Moderation/Users/Active.php:136
 #: src/Module/Moderation/Users/Blocked.php:136
 #: src/Module/Moderation/Users/Index.php:151
-#: src/Module/Settings/Connectors.php:241
+#: src/Module/Settings/Connectors.php:244
 msgid "Delete"
 msgstr ""
 
@@ -701,16 +701,16 @@ msgid "All contacts"
 msgstr ""
 
 #: src/BaseModule.php:432 src/Content/Widget.php:235 src/Core/ACL.php:194
-#: src/Module/Contact.php:408 src/Module/PermissionTooltip.php:122
+#: src/Module/Contact.php:407 src/Module/PermissionTooltip.php:122
 #: src/Module/PermissionTooltip.php:144
 msgid "Followers"
 msgstr ""
 
-#: src/BaseModule.php:437 src/Content/Widget.php:236 src/Module/Contact.php:409
+#: src/BaseModule.php:437 src/Content/Widget.php:236 src/Module/Contact.php:408
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:442 src/Content/Widget.php:237 src/Module/Contact.php:410
+#: src/BaseModule.php:442 src/Content/Widget.php:237 src/Module/Contact.php:409
 msgid "Mutual friends"
 msgstr ""
 
@@ -975,7 +975,7 @@ msgstr ""
 #: src/Content/ContactSelector.php:129
 #: src/Module/Moderation/Users/Active.php:126
 #: src/Module/Moderation/Users/Blocked.php:126
-#: src/Module/Moderation/Users/Create.php:73
+#: src/Module/Moderation/Users/Create.php:72
 #: src/Module/Moderation/Users/Deleted.php:83
 #: src/Module/Moderation/Users/Index.php:140
 #: src/Module/Moderation/Users/Index.php:160
@@ -1066,7 +1066,7 @@ msgid "%s attends maybe."
 msgstr ""
 
 #: src/Content/Conversation.php:235 src/Content/Conversation.php:273
-#: src/Content/Conversation.php:887
+#: src/Content/Conversation.php:885
 #, php-format
 msgid "%s reshared this."
 msgstr ""
@@ -1172,40 +1172,40 @@ msgstr ""
 msgid "Share"
 msgstr ""
 
-#: src/Content/Conversation.php:353 src/Module/Post/Edit.php:129
+#: src/Content/Conversation.php:353 src/Module/Post/Edit.php:132
 msgid "upload photo"
 msgstr ""
 
-#: src/Content/Conversation.php:354 src/Module/Post/Edit.php:130
+#: src/Content/Conversation.php:354 src/Module/Post/Edit.php:133
 msgid "Attach file"
 msgstr ""
 
-#: src/Content/Conversation.php:355 src/Module/Post/Edit.php:131
+#: src/Content/Conversation.php:355 src/Module/Post/Edit.php:134
 msgid "attach file"
 msgstr ""
 
 #: src/Content/Conversation.php:356 src/Module/Item/Compose.php:190
-#: src/Module/Post/Edit.php:168 src/Object/Post.php:1060
+#: src/Module/Post/Edit.php:171 src/Object/Post.php:1060
 msgid "Bold"
 msgstr ""
 
 #: src/Content/Conversation.php:357 src/Module/Item/Compose.php:191
-#: src/Module/Post/Edit.php:169 src/Object/Post.php:1061
+#: src/Module/Post/Edit.php:172 src/Object/Post.php:1061
 msgid "Italic"
 msgstr ""
 
 #: src/Content/Conversation.php:358 src/Module/Item/Compose.php:192
-#: src/Module/Post/Edit.php:170 src/Object/Post.php:1062
+#: src/Module/Post/Edit.php:173 src/Object/Post.php:1062
 msgid "Underline"
 msgstr ""
 
 #: src/Content/Conversation.php:359 src/Module/Item/Compose.php:193
-#: src/Module/Post/Edit.php:171 src/Object/Post.php:1063
+#: src/Module/Post/Edit.php:174 src/Object/Post.php:1063
 msgid "Quote"
 msgstr ""
 
 #: src/Content/Conversation.php:360 src/Module/Item/Compose.php:194
-#: src/Module/Post/Edit.php:172 src/Object/Post.php:1064
+#: src/Module/Post/Edit.php:175 src/Object/Post.php:1064
 msgid "Code"
 msgstr ""
 
@@ -1215,12 +1215,12 @@ msgid "Image"
 msgstr ""
 
 #: src/Content/Conversation.php:362 src/Module/Item/Compose.php:196
-#: src/Module/Post/Edit.php:173 src/Object/Post.php:1066
+#: src/Module/Post/Edit.php:176 src/Object/Post.php:1066
 msgid "Link"
 msgstr ""
 
 #: src/Content/Conversation.php:363 src/Module/Item/Compose.php:197
-#: src/Module/Post/Edit.php:174 src/Object/Post.php:1067
+#: src/Module/Post/Edit.php:177 src/Object/Post.php:1067
 msgid "Link or Media"
 msgstr ""
 
@@ -1229,29 +1229,29 @@ msgid "Video"
 msgstr ""
 
 #: src/Content/Conversation.php:365 src/Module/Item/Compose.php:200
-#: src/Module/Post/Edit.php:138
+#: src/Module/Post/Edit.php:141
 msgid "Set your location"
 msgstr ""
 
-#: src/Content/Conversation.php:366 src/Module/Post/Edit.php:139
+#: src/Content/Conversation.php:366 src/Module/Post/Edit.php:142
 msgid "set location"
 msgstr ""
 
-#: src/Content/Conversation.php:367 src/Module/Post/Edit.php:140
+#: src/Content/Conversation.php:367 src/Module/Post/Edit.php:143
 msgid "Clear browser location"
 msgstr ""
 
-#: src/Content/Conversation.php:368 src/Module/Post/Edit.php:141
+#: src/Content/Conversation.php:368 src/Module/Post/Edit.php:144
 msgid "clear location"
 msgstr ""
 
 #: src/Content/Conversation.php:370 src/Module/Item/Compose.php:205
-#: src/Module/Post/Edit.php:154
+#: src/Module/Post/Edit.php:157
 msgid "Set title"
 msgstr ""
 
 #: src/Content/Conversation.php:372 src/Module/Item/Compose.php:206
-#: src/Module/Post/Edit.php:156
+#: src/Module/Post/Edit.php:159
 msgid "Categories (comma-separated list)"
 msgstr ""
 
@@ -1259,136 +1259,136 @@ msgstr ""
 msgid "Scheduled at"
 msgstr ""
 
-#: src/Content/Conversation.php:382 src/Module/Post/Edit.php:143
+#: src/Content/Conversation.php:382 src/Module/Post/Edit.php:146
 msgid "Permission settings"
 msgstr ""
 
-#: src/Content/Conversation.php:392 src/Module/Post/Edit.php:152
+#: src/Content/Conversation.php:392 src/Module/Post/Edit.php:155
 msgid "Public post"
 msgstr ""
 
 #: src/Content/Conversation.php:406 src/Content/Widget/VCard.php:113
-#: src/Model/Profile.php:469 src/Module/Admin/Logs/View.php:93
-#: src/Module/Post/Edit.php:177
+#: src/Model/Profile.php:469 src/Module/Admin/Logs/View.php:92
+#: src/Module/Post/Edit.php:180
 msgid "Message"
 msgstr ""
 
-#: src/Content/Conversation.php:407 src/Module/Post/Edit.php:178
+#: src/Content/Conversation.php:407 src/Module/Post/Edit.php:181
 #: src/Module/Settings/TwoFactor/Trusted.php:140
 msgid "Browser"
 msgstr ""
 
-#: src/Content/Conversation.php:409 src/Module/Post/Edit.php:181
+#: src/Content/Conversation.php:409 src/Module/Post/Edit.php:184
 msgid "Open Compose page"
 msgstr ""
 
-#: src/Content/Conversation.php:671 src/Object/Post.php:243
+#: src/Content/Conversation.php:669 src/Object/Post.php:243
 msgid "Pinned item"
 msgstr ""
 
-#: src/Content/Conversation.php:687 src/Object/Post.php:491
+#: src/Content/Conversation.php:685 src/Object/Post.php:491
 #: src/Object/Post.php:492
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: src/Content/Conversation.php:700 src/Object/Post.php:479
+#: src/Content/Conversation.php:698 src/Object/Post.php:479
 msgid "Categories:"
 msgstr ""
 
-#: src/Content/Conversation.php:701 src/Object/Post.php:480
+#: src/Content/Conversation.php:699 src/Object/Post.php:480
 msgid "Filed under:"
 msgstr ""
 
-#: src/Content/Conversation.php:709 src/Object/Post.php:505
+#: src/Content/Conversation.php:707 src/Object/Post.php:505
 #, php-format
 msgid "%s from %s"
 msgstr ""
 
-#: src/Content/Conversation.php:725
+#: src/Content/Conversation.php:723
 msgid "View in context"
 msgstr ""
 
-#: src/Content/Conversation.php:790
+#: src/Content/Conversation.php:788
 msgid "remove"
 msgstr ""
 
-#: src/Content/Conversation.php:794
+#: src/Content/Conversation.php:792
 msgid "Delete Selected Items"
 msgstr ""
 
-#: src/Content/Conversation.php:859 src/Content/Conversation.php:862
-#: src/Content/Conversation.php:865 src/Content/Conversation.php:868
+#: src/Content/Conversation.php:857 src/Content/Conversation.php:860
+#: src/Content/Conversation.php:863 src/Content/Conversation.php:866
 #, php-format
 msgid "You had been addressed (%s)."
 msgstr ""
 
-#: src/Content/Conversation.php:871
+#: src/Content/Conversation.php:869
 #, php-format
 msgid "You are following %s."
 msgstr ""
 
-#: src/Content/Conversation.php:874
+#: src/Content/Conversation.php:872
 msgid "You subscribed to one or more tags in this post."
 msgstr ""
 
-#: src/Content/Conversation.php:889
+#: src/Content/Conversation.php:887
 msgid "Reshared"
 msgstr ""
 
-#: src/Content/Conversation.php:889
+#: src/Content/Conversation.php:887
 #, php-format
 msgid "Reshared by %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation.php:892
+#: src/Content/Conversation.php:890
 #, php-format
 msgid "%s is participating in this thread."
 msgstr ""
 
-#: src/Content/Conversation.php:895
+#: src/Content/Conversation.php:893
 msgid "Stored for general reasons"
 msgstr ""
 
-#: src/Content/Conversation.php:898
+#: src/Content/Conversation.php:896
 msgid "Global post"
 msgstr ""
 
-#: src/Content/Conversation.php:901
+#: src/Content/Conversation.php:899
 msgid "Sent via an relay server"
 msgstr ""
 
-#: src/Content/Conversation.php:901
+#: src/Content/Conversation.php:899
 #, php-format
 msgid "Sent via the relay server %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation.php:904
+#: src/Content/Conversation.php:902
 msgid "Fetched"
 msgstr ""
 
-#: src/Content/Conversation.php:904
+#: src/Content/Conversation.php:902
 #, php-format
 msgid "Fetched because of %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation.php:907
+#: src/Content/Conversation.php:905
 msgid "Stored because of a child post to complete this thread."
 msgstr ""
 
-#: src/Content/Conversation.php:910
+#: src/Content/Conversation.php:908
 msgid "Local delivery"
 msgstr ""
 
-#: src/Content/Conversation.php:913
+#: src/Content/Conversation.php:911
 msgid "Stored because of your activity (like, comment, star, ...)"
 msgstr ""
 
-#: src/Content/Conversation.php:916
+#: src/Content/Conversation.php:914
 msgid "Distributed"
 msgstr ""
 
-#: src/Content/Conversation.php:919
+#: src/Content/Conversation.php:917
 msgid "Pushed to us"
 msgstr ""
 
@@ -1504,25 +1504,25 @@ msgid ""
 "Contact birthday events are private to you."
 msgstr ""
 
-#: src/Content/ForumManager.php:151 src/Content/Nav.php:278
+#: src/Content/ForumManager.php:157 src/Content/Nav.php:276
 #: src/Content/Text/HTML.php:905 src/Content/Widget.php:524
 msgid "Forums"
 msgstr ""
 
-#: src/Content/ForumManager.php:153
+#: src/Content/ForumManager.php:159
 msgid "External link to forum"
 msgstr ""
 
-#: src/Content/ForumManager.php:156 src/Content/Widget.php:503
+#: src/Content/ForumManager.php:162 src/Content/Widget.php:503
 msgid "show less"
 msgstr ""
 
-#: src/Content/ForumManager.php:157 src/Content/Widget.php:405
+#: src/Content/ForumManager.php:163 src/Content/Widget.php:405
 #: src/Content/Widget.php:504
 msgid "show more"
 msgstr ""
 
-#: src/Content/Item.php:326 src/Model/Item.php:2900
+#: src/Content/Item.php:326 src/Model/Item.php:2904
 msgid "event"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:335 src/Model/Item.php:2902
+#: src/Content/Item.php:335 src/Model/Item.php:2906
 #: src/Module/Post/Tag/Add.php:123
 msgid "photo"
 msgstr ""
@@ -1548,9 +1548,9 @@ msgstr ""
 msgid "View Status"
 msgstr ""
 
-#: src/Content/Item.php:421 src/Content/Item.php:440 src/Model/Contact.php:1148
+#: src/Content/Item.php:421 src/Content/Item.php:441 src/Model/Contact.php:1148
 #: src/Model/Contact.php:1196 src/Model/Contact.php:1205
-#: src/Module/Directory.php:157 src/Module/Settings/Profile/Index.php:234
+#: src/Module/Directory.php:157 src/Module/Settings/Profile/Index.php:233
 msgid "View Profile"
 msgstr ""
 
@@ -1572,24 +1572,24 @@ msgstr ""
 msgid "Send PM"
 msgstr ""
 
-#: src/Content/Item.php:426 src/Module/Contact.php:440
-#: src/Module/Contact/Profile.php:478
+#: src/Content/Item.php:426 src/Module/Contact.php:439
+#: src/Module/Contact/Profile.php:477
 #: src/Module/Moderation/Blocklist/Contact.php:116
 #: src/Module/Moderation/Users/Active.php:137
 #: src/Module/Moderation/Users/Index.php:152
 msgid "Block"
 msgstr ""
 
-#: src/Content/Item.php:427 src/Module/Contact.php:441
-#: src/Module/Contact/Profile.php:486
+#: src/Content/Item.php:427 src/Module/Contact.php:440
+#: src/Module/Contact/Profile.php:485
 #: src/Module/Notifications/Introductions.php:134
 #: src/Module/Notifications/Introductions.php:206
 #: src/Module/Notifications/Notification.php:89
 msgid "Ignore"
 msgstr ""
 
-#: src/Content/Item.php:428 src/Module/Contact.php:442
-#: src/Module/Contact/Profile.php:494
+#: src/Content/Item.php:428 src/Module/Contact.php:441
+#: src/Module/Contact/Profile.php:493
 msgid "Collapse"
 msgstr ""
 
@@ -1597,13 +1597,13 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
-#: src/Content/Item.php:437 src/Content/Widget.php:80
+#: src/Content/Item.php:438 src/Content/Widget.php:80
 #: src/Model/Contact.php:1199 src/Model/Contact.php:1210
 #: src/Module/Contact/Follow.php:166 view/theme/vier/theme.php:196
 msgid "Connect/Follow"
 msgstr ""
 
-#: src/Content/Item.php:862
+#: src/Content/Item.php:863
 msgid "Unable to fetch user."
 msgstr ""
 
@@ -1623,63 +1623,63 @@ msgstr ""
 msgid "@name, !forum, #tags, content"
 msgstr ""
 
-#: src/Content/Nav.php:222 src/Module/Security/Login.php:158
+#: src/Content/Nav.php:220 src/Module/Security/Login.php:157
 msgid "Logout"
 msgstr ""
 
-#: src/Content/Nav.php:222
+#: src/Content/Nav.php:220
 msgid "End this session"
 msgstr ""
 
-#: src/Content/Nav.php:224 src/Module/Bookmarklet.php:44
-#: src/Module/Security/Login.php:159
+#: src/Content/Nav.php:222 src/Module/Bookmarklet.php:44
+#: src/Module/Security/Login.php:158
 msgid "Login"
 msgstr ""
 
-#: src/Content/Nav.php:224
+#: src/Content/Nav.php:222
 msgid "Sign in"
 msgstr ""
 
-#: src/Content/Nav.php:229 src/Module/BaseProfile.php:57
-#: src/Module/Contact.php:484
+#: src/Content/Nav.php:227 src/Module/BaseProfile.php:57
+#: src/Module/Contact.php:483
 msgid "Conversations"
 msgstr ""
 
-#: src/Content/Nav.php:229
+#: src/Content/Nav.php:227
 msgid "Conversations you started"
 msgstr ""
 
-#: src/Content/Nav.php:230 src/Module/BaseProfile.php:49
-#: src/Module/BaseSettings.php:100 src/Module/Contact.php:476
-#: src/Module/Contact/Profile.php:393 src/Module/Profile/Profile.php:268
+#: src/Content/Nav.php:228 src/Module/BaseProfile.php:49
+#: src/Module/BaseSettings.php:100 src/Module/Contact.php:475
+#: src/Module/Contact/Profile.php:392 src/Module/Profile/Profile.php:268
 #: src/Module/Welcome.php:57 view/theme/frio/theme.php:230
 msgid "Profile"
 msgstr ""
 
-#: src/Content/Nav.php:230 view/theme/frio/theme.php:230
+#: src/Content/Nav.php:228 view/theme/frio/theme.php:230
 msgid "Your profile page"
 msgstr ""
 
-#: src/Content/Nav.php:231 src/Module/BaseProfile.php:65
+#: src/Content/Nav.php:229 src/Module/BaseProfile.php:65
 #: src/Module/Media/Photo/Browser.php:74 view/theme/frio/theme.php:234
 msgid "Photos"
 msgstr ""
 
-#: src/Content/Nav.php:231 view/theme/frio/theme.php:234
+#: src/Content/Nav.php:229 view/theme/frio/theme.php:234
 msgid "Your photos"
 msgstr ""
 
-#: src/Content/Nav.php:232 src/Module/BaseProfile.php:73
-#: src/Module/BaseProfile.php:76 src/Module/Contact.php:500
+#: src/Content/Nav.php:230 src/Module/BaseProfile.php:73
+#: src/Module/BaseProfile.php:76 src/Module/Contact.php:499
 #: view/theme/frio/theme.php:235
 msgid "Media"
 msgstr ""
 
-#: src/Content/Nav.php:232 view/theme/frio/theme.php:235
+#: src/Content/Nav.php:230 view/theme/frio/theme.php:235
 msgid "Your postings with media"
 msgstr ""
 
-#: src/Content/Nav.php:233 src/Content/Nav.php:293
+#: src/Content/Nav.php:231 src/Content/Nav.php:291
 #: src/Module/BaseProfile.php:85 src/Module/BaseProfile.php:88
 #: src/Module/BaseProfile.php:96 src/Module/BaseProfile.php:99
 #: src/Module/Settings/Display.php:252 view/theme/frio/theme.php:236
@@ -1687,36 +1687,36 @@ msgstr ""
 msgid "Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:233 view/theme/frio/theme.php:236
+#: src/Content/Nav.php:231 view/theme/frio/theme.php:236
 msgid "Your calendar"
 msgstr ""
 
-#: src/Content/Nav.php:234
+#: src/Content/Nav.php:232
 msgid "Personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:234
+#: src/Content/Nav.php:232
 msgid "Your personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:251 src/Content/Nav.php:308
+#: src/Content/Nav.php:249 src/Content/Nav.php:306
 msgid "Home"
 msgstr ""
 
-#: src/Content/Nav.php:251 src/Module/Settings/OAuth.php:74
+#: src/Content/Nav.php:249 src/Module/Settings/OAuth.php:73
 msgid "Home Page"
 msgstr ""
 
-#: src/Content/Nav.php:255 src/Module/Register.php:168
+#: src/Content/Nav.php:253 src/Module/Register.php:168
 #: src/Module/Security/Login.php:124
 msgid "Register"
 msgstr ""
 
-#: src/Content/Nav.php:255
+#: src/Content/Nav.php:253
 msgid "Create an account"
 msgstr ""
 
-#: src/Content/Nav.php:261 src/Module/Help.php:67
+#: src/Content/Nav.php:259 src/Module/Help.php:67
 #: src/Module/Settings/TwoFactor/AppSpecific.php:129
 #: src/Module/Settings/TwoFactor/Index.php:118
 #: src/Module/Settings/TwoFactor/Recovery.php:107
@@ -1724,158 +1724,158 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: src/Content/Nav.php:261
+#: src/Content/Nav.php:259
 msgid "Help and documentation"
 msgstr ""
 
-#: src/Content/Nav.php:265
+#: src/Content/Nav.php:263
 msgid "Apps"
 msgstr ""
 
-#: src/Content/Nav.php:265
+#: src/Content/Nav.php:263
 msgid "Addon applications, utilities, games"
 msgstr ""
 
-#: src/Content/Nav.php:269 src/Content/Text/HTML.php:890
-#: src/Module/Admin/Logs/View.php:87 src/Module/Search/Index.php:112
+#: src/Content/Nav.php:267 src/Content/Text/HTML.php:890
+#: src/Module/Admin/Logs/View.php:86 src/Module/Search/Index.php:112
 msgid "Search"
 msgstr ""
 
-#: src/Content/Nav.php:269
+#: src/Content/Nav.php:267
 msgid "Search site content"
 msgstr ""
 
-#: src/Content/Nav.php:272 src/Content/Text/HTML.php:899
+#: src/Content/Nav.php:270 src/Content/Text/HTML.php:899
 msgid "Full Text"
 msgstr ""
 
-#: src/Content/Nav.php:273 src/Content/Text/HTML.php:900
+#: src/Content/Nav.php:271 src/Content/Text/HTML.php:900
 #: src/Content/Widget/TagCloud.php:68
 msgid "Tags"
 msgstr ""
 
-#: src/Content/Nav.php:274 src/Content/Nav.php:329
+#: src/Content/Nav.php:272 src/Content/Nav.php:327
 #: src/Content/Text/HTML.php:901 src/Module/BaseProfile.php:127
-#: src/Module/BaseProfile.php:130 src/Module/Contact.php:411
-#: src/Module/Contact.php:507 view/theme/frio/theme.php:243
+#: src/Module/BaseProfile.php:130 src/Module/Contact.php:410
+#: src/Module/Contact.php:506 view/theme/frio/theme.php:243
 msgid "Contacts"
 msgstr ""
 
-#: src/Content/Nav.php:289
+#: src/Content/Nav.php:287
 msgid "Community"
 msgstr ""
 
-#: src/Content/Nav.php:289
+#: src/Content/Nav.php:287
 msgid "Conversations on this and other servers"
 msgstr ""
 
-#: src/Content/Nav.php:296
+#: src/Content/Nav.php:294
 msgid "Directory"
 msgstr ""
 
-#: src/Content/Nav.php:296
+#: src/Content/Nav.php:294
 msgid "People directory"
 msgstr ""
 
-#: src/Content/Nav.php:298 src/Module/BaseAdmin.php:85
+#: src/Content/Nav.php:296 src/Module/BaseAdmin.php:85
 #: src/Module/BaseModeration.php:108
 msgid "Information"
 msgstr ""
 
-#: src/Content/Nav.php:298
+#: src/Content/Nav.php:296
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:301 src/Module/Admin/Tos.php:78
+#: src/Content/Nav.php:299 src/Module/Admin/Tos.php:78
 #: src/Module/BaseAdmin.php:95 src/Module/Register.php:176
 #: src/Module/Tos.php:100
 msgid "Terms of Service"
 msgstr ""
 
-#: src/Content/Nav.php:301
+#: src/Content/Nav.php:299
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:306 view/theme/frio/theme.php:239
+#: src/Content/Nav.php:304 view/theme/frio/theme.php:239
 msgid "Network"
 msgstr ""
 
-#: src/Content/Nav.php:306 view/theme/frio/theme.php:239
+#: src/Content/Nav.php:304 view/theme/frio/theme.php:239
 msgid "Conversations from your friends"
 msgstr ""
 
-#: src/Content/Nav.php:308 view/theme/frio/theme.php:229
+#: src/Content/Nav.php:306 view/theme/frio/theme.php:229
 msgid "Your posts and conversations"
 msgstr ""
 
-#: src/Content/Nav.php:312
+#: src/Content/Nav.php:310
 msgid "Introductions"
 msgstr ""
 
-#: src/Content/Nav.php:312
+#: src/Content/Nav.php:310
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:313 src/Module/BaseNotifications.php:149
+#: src/Content/Nav.php:311 src/Module/BaseNotifications.php:149
 #: src/Module/Notifications/Introductions.php:75
 msgid "Notifications"
 msgstr ""
 
-#: src/Content/Nav.php:314
+#: src/Content/Nav.php:312
 msgid "See all notifications"
 msgstr ""
 
-#: src/Content/Nav.php:315 src/Module/Settings/Connectors.php:241
+#: src/Content/Nav.php:313 src/Module/Settings/Connectors.php:244
 msgid "Mark as seen"
 msgstr ""
 
-#: src/Content/Nav.php:315
+#: src/Content/Nav.php:313
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:318 view/theme/frio/theme.php:241
+#: src/Content/Nav.php:316 view/theme/frio/theme.php:241
 msgid "Private mail"
 msgstr ""
 
-#: src/Content/Nav.php:319
+#: src/Content/Nav.php:317
 msgid "Inbox"
 msgstr ""
 
-#: src/Content/Nav.php:320
+#: src/Content/Nav.php:318
 msgid "Outbox"
 msgstr ""
 
-#: src/Content/Nav.php:324
+#: src/Content/Nav.php:322
 msgid "Accounts"
 msgstr ""
 
-#: src/Content/Nav.php:324
+#: src/Content/Nav.php:322
 msgid "Manage other pages"
 msgstr ""
 
-#: src/Content/Nav.php:327 src/Module/Admin/Addons/Details.php:114
+#: src/Content/Nav.php:325 src/Module/Admin/Addons/Details.php:114
 #: src/Module/Admin/Themes/Details.php:93 src/Module/BaseSettings.php:170
 #: src/Module/Welcome.php:52 view/theme/frio/theme.php:242
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:327 view/theme/frio/theme.php:242
+#: src/Content/Nav.php:325 view/theme/frio/theme.php:242
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:329 view/theme/frio/theme.php:243
+#: src/Content/Nav.php:327 view/theme/frio/theme.php:243
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:334 src/Module/BaseAdmin.php:119
+#: src/Content/Nav.php:332 src/Module/BaseAdmin.php:119
 msgid "Admin"
 msgstr ""
 
-#: src/Content/Nav.php:334
+#: src/Content/Nav.php:332
 msgid "Site setup and configuration"
 msgstr ""
 
-#: src/Content/Nav.php:335 src/Module/BaseModeration.php:127
+#: src/Content/Nav.php:333 src/Module/BaseModeration.php:127
 #: src/Module/Moderation/Blocklist/Contact.php:110
 #: src/Module/Moderation/Blocklist/Server/Add.php:121
 #: src/Module/Moderation/Blocklist/Server/Import.php:118
@@ -1889,15 +1889,15 @@ msgstr ""
 msgid "Moderation"
 msgstr ""
 
-#: src/Content/Nav.php:335
+#: src/Content/Nav.php:333
 msgid "Content and user moderation"
 msgstr ""
 
-#: src/Content/Nav.php:338
+#: src/Content/Nav.php:336
 msgid "Navigation"
 msgstr ""
 
-#: src/Content/Nav.php:338
+#: src/Content/Nav.php:336
 msgid "Site map"
 msgstr ""
 
@@ -1925,39 +1925,39 @@ msgstr ""
 msgid "last"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:949 src/Content/Text/BBCode.php:1811
-#: src/Content/Text/BBCode.php:1812
+#: src/Content/Text/BBCode.php:716 src/Content/Text/BBCode.php:1592
+#: src/Content/Text/BBCode.php:1593
 msgid "Image/photo"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1166
+#: src/Content/Text/BBCode.php:934
 #, php-format
 msgid ""
 "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1191 src/Model/Item.php:3573
-#: src/Model/Item.php:3579 src/Model/Item.php:3580
+#: src/Content/Text/BBCode.php:959 src/Model/Item.php:3585
+#: src/Model/Item.php:3591 src/Model/Item.php:3592
 msgid "Link to source"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1729 src/Content/Text/HTML.php:929
+#: src/Content/Text/BBCode.php:1504 src/Content/Text/HTML.php:929
 msgid "Click to open/close"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1760
+#: src/Content/Text/BBCode.php:1537
 msgid "$1 wrote:"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1816 src/Content/Text/BBCode.php:1817
+#: src/Content/Text/BBCode.php:1597 src/Content/Text/BBCode.php:1598
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2044
+#: src/Content/Text/BBCode.php:1863
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2059
+#: src/Content/Text/BBCode.php:1882
 msgid "Invalid link protocol"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgid "The end"
 msgstr ""
 
 #: src/Content/Text/HTML.php:884 src/Content/Widget/VCard.php:109
-#: src/Model/Profile.php:463 src/Module/Contact/Profile.php:438
+#: src/Model/Profile.php:463 src/Module/Contact/Profile.php:437
 msgid "Follow"
 msgstr ""
 
@@ -2009,7 +2009,7 @@ msgstr ""
 msgid "Examples: Robert Morgenstein, Fishing"
 msgstr ""
 
-#: src/Content/Widget.php:82 src/Module/Contact.php:433
+#: src/Content/Widget.php:82 src/Module/Contact.php:432
 #: src/Module/Directory.php:96 view/theme/vier/theme.php:198
 msgid "Find"
 msgstr ""
@@ -2041,7 +2041,7 @@ msgid "Local Directory"
 msgstr ""
 
 #: src/Content/Widget.php:211 src/Model/Group.php:587
-#: src/Module/Contact.php:395 src/Module/Welcome.php:76
+#: src/Module/Contact.php:394 src/Module/Welcome.php:76
 msgid "Groups"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Relationships"
 msgstr ""
 
-#: src/Content/Widget.php:244 src/Module/Contact.php:339
+#: src/Content/Widget.php:244 src/Module/Contact.php:338
 #: src/Module/Group.php:291
 msgid "All Contacts"
 msgstr ""
@@ -2156,18 +2156,18 @@ msgid "More Trending Tags"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:102 src/Model/Profile.php:378
-#: src/Module/Contact/Profile.php:382 src/Module/Profile/Profile.php:199
+#: src/Module/Contact/Profile.php:381 src/Module/Profile/Profile.php:199
 msgid "XMPP:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:103 src/Model/Profile.php:379
-#: src/Module/Contact/Profile.php:384 src/Module/Profile/Profile.php:203
+#: src/Module/Contact/Profile.php:383 src/Module/Profile/Profile.php:203
 msgid "Matrix:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:104 src/Model/Event.php:82
 #: src/Model/Event.php:109 src/Model/Event.php:473 src/Model/Event.php:958
-#: src/Model/Profile.php:373 src/Module/Contact/Profile.php:380
+#: src/Model/Profile.php:373 src/Module/Contact/Profile.php:379
 #: src/Module/Directory.php:147 src/Module/Notifications/Introductions.php:187
 #: src/Module/Profile/Profile.php:221
 msgid "Location:"
@@ -2180,7 +2180,7 @@ msgstr ""
 
 #: src/Content/Widget/VCard.php:111 src/Model/Contact.php:1200
 #: src/Model/Contact.php:1211 src/Model/Profile.php:465
-#: src/Module/Contact/Profile.php:430
+#: src/Module/Contact/Profile.php:429
 msgid "Unfollow"
 msgstr ""
 
@@ -2233,11 +2233,11 @@ msgstr ""
 msgid "Except to:"
 msgstr ""
 
-#: src/Core/ACL.php:326 src/Module/Post/Edit.php:151
+#: src/Core/ACL.php:326 src/Module/Post/Edit.php:154
 msgid "CC: email addresses"
 msgstr ""
 
-#: src/Core/ACL.php:327 src/Module/Post/Edit.php:157
+#: src/Core/ACL.php:327 src/Module/Post/Edit.php:160
 msgid "Example: bob@example.com, mary@example.com"
 msgstr ""
 
@@ -2896,68 +2896,68 @@ msgstr ""
 msgid "Forum"
 msgstr ""
 
-#: src/Model/Contact.php:2942
+#: src/Model/Contact.php:2947
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:2947 src/Module/Friendica.php:83
+#: src/Model/Contact.php:2952 src/Module/Friendica.php:83
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:2952
+#: src/Model/Contact.php:2957
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:2961
+#: src/Model/Contact.php:2966
 msgid ""
 "The contact could not be added. Please check the relevant network "
 "credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:2979
+#: src/Model/Contact.php:2984
 #, php-format
 msgid "Expected network %s does not match actual network %s"
 msgstr ""
 
-#: src/Model/Contact.php:2996
+#: src/Model/Contact.php:3001
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:2998
+#: src/Model/Contact.php:3003
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:3001
+#: src/Model/Contact.php:3006
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:3004
+#: src/Model/Contact.php:3009
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:3007
+#: src/Model/Contact.php:3012
 msgid ""
 "Unable to match @-style Identity Address with a known protocol or email "
 "contact."
 msgstr ""
 
-#: src/Model/Contact.php:3008
+#: src/Model/Contact.php:3013
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:3014
+#: src/Model/Contact.php:3019
 msgid ""
 "The profile address specified belongs to a network which has been disabled "
 "on this site."
 msgstr ""
 
-#: src/Model/Contact.php:3019
+#: src/Model/Contact.php:3024
 msgid ""
 "Limited profile. This person will be unable to receive direct/personal "
 "notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:3084
+#: src/Model/Contact.php:3089
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -3106,81 +3106,81 @@ msgstr ""
 msgid "Edit groups"
 msgstr ""
 
-#: src/Model/Item.php:2001
+#: src/Model/Item.php:2005
 #, php-format
 msgid "Detected languages in this post:\\n%s"
 msgstr ""
 
-#: src/Model/Item.php:2904
+#: src/Model/Item.php:2908
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2906
+#: src/Model/Item.php:2910
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2909 src/Module/Post/Tag/Add.php:123
+#: src/Model/Item.php:2913 src/Module/Post/Tag/Add.php:123
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3059
+#: src/Model/Item.php:3071
 #, php-format
 msgid "%s is blocked"
 msgstr ""
 
-#: src/Model/Item.php:3061
+#: src/Model/Item.php:3073
 #, php-format
 msgid "%s is ignored"
 msgstr ""
 
-#: src/Model/Item.php:3063
+#: src/Model/Item.php:3075
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:3067
+#: src/Model/Item.php:3079
 #, php-format
 msgid "Content warning: %s"
 msgstr ""
 
-#: src/Model/Item.php:3485
+#: src/Model/Item.php:3497
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3516
+#: src/Model/Item.php:3528
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3518
+#: src/Model/Item.php:3530
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3523
+#: src/Model/Item.php:3535
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3525
+#: src/Model/Item.php:3537
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3527
+#: src/Model/Item.php:3539
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3561 src/Model/Item.php:3562
+#: src/Model/Item.php:3573 src/Model/Item.php:3574
 msgid "View on separate page"
 msgstr ""
 
@@ -3206,7 +3206,7 @@ msgstr ""
 msgid "Homepage:"
 msgstr ""
 
-#: src/Model/Profile.php:377 src/Module/Contact/Profile.php:386
+#: src/Model/Profile.php:377 src/Module/Contact/Profile.php:385
 #: src/Module/Notifications/Introductions.php:189
 msgid "About:"
 msgstr ""
@@ -3621,7 +3621,7 @@ msgstr ""
 
 #: src/Module/Admin/Addons/Details.php:111 src/Module/Admin/Addons/Index.php:67
 #: src/Module/Admin/Federation.php:207 src/Module/Admin/Logs/Settings.php:79
-#: src/Module/Admin/Logs/View.php:84 src/Module/Admin/Queue.php:72
+#: src/Module/Admin/Logs/View.php:83 src/Module/Admin/Queue.php:72
 #: src/Module/Admin/Site.php:389 src/Module/Admin/Storage.php:138
 #: src/Module/Admin/Summary.php:220 src/Module/Admin/Themes/Details.php:90
 #: src/Module/Admin/Themes/Index.php:111 src/Module/Admin/Tos.php:77
@@ -3640,13 +3640,13 @@ msgstr ""
 msgid "Toggle"
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:121
-#: src/Module/Admin/Themes/Details.php:101
+#: src/Module/Admin/Addons/Details.php:120
+#: src/Module/Admin/Themes/Details.php:100
 msgid "Author: "
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:122
-#: src/Module/Admin/Themes/Details.php:102
+#: src/Module/Admin/Addons/Details.php:121
+#: src/Module/Admin/Themes/Details.php:101
 msgid "Maintainer: "
 msgstr ""
 
@@ -3659,12 +3659,12 @@ msgstr ""
 msgid "Addon %s failed to install."
 msgstr ""
 
-#: src/Module/Admin/Addons/Index.php:69 src/Module/Admin/Features.php:87
+#: src/Module/Admin/Addons/Index.php:69 src/Module/Admin/Features.php:86
 #: src/Module/Admin/Logs/Settings.php:81 src/Module/Admin/Site.php:392
 #: src/Module/Admin/Themes/Index.php:113 src/Module/Admin/Tos.php:86
 #: src/Module/Settings/Account.php:560 src/Module/Settings/Addons.php:78
-#: src/Module/Settings/Connectors.php:158
-#: src/Module/Settings/Connectors.php:243
+#: src/Module/Settings/Connectors.php:160
+#: src/Module/Settings/Connectors.php:246
 #: src/Module/Settings/Delegation.php:169 src/Module/Settings/Display.php:247
 #: src/Module/Settings/Features.php:76
 msgid "Save Settings"
@@ -3674,7 +3674,7 @@ msgstr ""
 msgid "Reload active addons"
 msgstr ""
 
-#: src/Module/Admin/Addons/Index.php:75
+#: src/Module/Admin/Addons/Index.php:74
 #, php-format
 msgid ""
 "There are currently no addons available on your node. You can find the "
@@ -3716,28 +3716,28 @@ msgstr ""
 msgid "There was no additional update function %s that needed to be called."
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:106
+#: src/Module/Admin/DBSync.php:105
 msgid "No failed updates."
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:107
+#: src/Module/Admin/DBSync.php:106
 msgid "Check database structure"
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:112
+#: src/Module/Admin/DBSync.php:110
 msgid "Failed Updates"
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:113
+#: src/Module/Admin/DBSync.php:111
 msgid ""
 "This does not include updates prior to 1139, which did not return a status."
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:114
+#: src/Module/Admin/DBSync.php:112
 msgid "Mark success (if update was manually applied)"
 msgstr ""
 
-#: src/Module/Admin/DBSync.php:115
+#: src/Module/Admin/DBSync.php:113
 msgid "Attempt to execute this update step automatically"
 msgstr ""
 
@@ -3746,7 +3746,7 @@ msgstr ""
 msgid "Lock feature %s"
 msgstr ""
 
-#: src/Module/Admin/Features.php:85
+#: src/Module/Admin/Features.php:84
 msgid "Manage Additional Features"
 msgstr ""
 
@@ -3853,29 +3853,29 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:86
+#: src/Module/Admin/Logs/Settings.php:85
 msgid "Enable Debugging"
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:87
+#: src/Module/Admin/Logs/Settings.php:86
 msgid "Log file"
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:87
+#: src/Module/Admin/Logs/Settings.php:86
 msgid ""
 "Must be writable by web server. Relative to your Friendica top-level "
 "directory."
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:88
+#: src/Module/Admin/Logs/Settings.php:87
 msgid "Log level"
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:90
+#: src/Module/Admin/Logs/Settings.php:89
 msgid "PHP logging"
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:91
+#: src/Module/Admin/Logs/Settings.php:90
 msgid ""
 "To temporarily enable logging of PHP errors and warnings you can prepend the "
 "following to the index.php file of your installation. The filename set in "
@@ -3898,77 +3898,77 @@ msgid ""
 "is readable."
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:85 src/Module/BaseAdmin.php:104
+#: src/Module/Admin/Logs/View.php:84 src/Module/BaseAdmin.php:104
 msgid "View Logs"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:88
+#: src/Module/Admin/Logs/View.php:87
 msgid "Search in logs"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:89
+#: src/Module/Admin/Logs/View.php:88
 #: src/Module/Notifications/Notifications.php:140
 msgid "Show all"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:90
+#: src/Module/Admin/Logs/View.php:89
 msgid "Date"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:91
+#: src/Module/Admin/Logs/View.php:90
 msgid "Level"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:92
+#: src/Module/Admin/Logs/View.php:91
 msgid "Context"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:94
+#: src/Module/Admin/Logs/View.php:93
 msgid "ALL"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:95
+#: src/Module/Admin/Logs/View.php:94
 msgid "View details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:96
+#: src/Module/Admin/Logs/View.php:95
 msgid "Click to view details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:97 src/Module/Calendar/Event/Form.php:207
+#: src/Module/Admin/Logs/View.php:96 src/Module/Calendar/Event/Form.php:207
 msgid "Event details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:98
+#: src/Module/Admin/Logs/View.php:97
 msgid "Data"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:99
+#: src/Module/Admin/Logs/View.php:98
 #: src/Module/Debug/ActivityPubConversion.php:57
 msgid "Source"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:100
+#: src/Module/Admin/Logs/View.php:99
 msgid "File"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:101
+#: src/Module/Admin/Logs/View.php:100
 msgid "Line"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:102
+#: src/Module/Admin/Logs/View.php:101
 msgid "Function"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:103
+#: src/Module/Admin/Logs/View.php:102
 msgid "UID"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:104
+#: src/Module/Admin/Logs/View.php:103
 msgid "Process ID"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:105
+#: src/Module/Admin/Logs/View.php:104
 msgid "Close"
 msgstr ""
 
@@ -4004,7 +4004,7 @@ msgstr ""
 msgid "Job Parameters"
 msgstr ""
 
-#: src/Module/Admin/Queue.php:78 src/Module/Settings/OAuth.php:75
+#: src/Module/Admin/Queue.php:78 src/Module/Settings/OAuth.php:74
 msgid "Created"
 msgstr ""
 
@@ -4111,7 +4111,7 @@ msgid "Policies"
 msgstr ""
 
 #: src/Module/Admin/Site.php:397 src/Module/Calendar/Event/Form.php:252
-#: src/Module/Contact.php:517 src/Module/Profile/Profile.php:276
+#: src/Module/Contact.php:516 src/Module/Profile/Profile.php:276
 msgid "Advanced"
 msgstr ""
 
@@ -4160,121 +4160,121 @@ msgstr ""
 msgid "(Friendica directory)# bin/console relocate https://newdomain.com"
 msgstr ""
 
-#: src/Module/Admin/Site.php:412
+#: src/Module/Admin/Site.php:411
 msgid "Site name"
 msgstr ""
 
-#: src/Module/Admin/Site.php:413
+#: src/Module/Admin/Site.php:412
 msgid "Sender Email"
 msgstr ""
 
-#: src/Module/Admin/Site.php:413
+#: src/Module/Admin/Site.php:412
 msgid ""
 "The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: src/Module/Admin/Site.php:414
+#: src/Module/Admin/Site.php:413
 msgid "Name of the system actor"
 msgstr ""
 
-#: src/Module/Admin/Site.php:414
+#: src/Module/Admin/Site.php:413
 msgid ""
 "Name of the internal system account that is used to perform ActivityPub "
 "requests. This must be an unused username. If set, this can't be changed "
 "again."
 msgstr ""
 
-#: src/Module/Admin/Site.php:415
+#: src/Module/Admin/Site.php:414
 msgid "Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:416
+#: src/Module/Admin/Site.php:415
 msgid "Email Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:417
+#: src/Module/Admin/Site.php:416
 msgid "Shortcut icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:417
+#: src/Module/Admin/Site.php:416
 msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:418
+#: src/Module/Admin/Site.php:417
 msgid "Touch icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:418
+#: src/Module/Admin/Site.php:417
 msgid "Link to an icon that will be used for tablets and mobiles."
 msgstr ""
 
-#: src/Module/Admin/Site.php:419
+#: src/Module/Admin/Site.php:418
 msgid "Additional Info"
 msgstr ""
 
-#: src/Module/Admin/Site.php:419
+#: src/Module/Admin/Site.php:418
 #, php-format
 msgid ""
 "For public servers: you can add additional information here that will be "
 "listed at %s/servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:420
+#: src/Module/Admin/Site.php:419
 msgid "System language"
 msgstr ""
 
-#: src/Module/Admin/Site.php:421
+#: src/Module/Admin/Site.php:420
 msgid "System theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:421
+#: src/Module/Admin/Site.php:420
 #, php-format
 msgid ""
 "Default system theme - may be over-ridden by user profiles - <a href=\"%s\" "
 "id=\"cnftheme\">Change default theme settings</a>"
 msgstr ""
 
-#: src/Module/Admin/Site.php:422
+#: src/Module/Admin/Site.php:421
 msgid "Mobile system theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:422
+#: src/Module/Admin/Site.php:421
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:423
+#: src/Module/Admin/Site.php:422
 msgid "Force SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:423
+#: src/Module/Admin/Site.php:422
 msgid ""
 "Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
 "to endless loops."
 msgstr ""
 
-#: src/Module/Admin/Site.php:424
+#: src/Module/Admin/Site.php:423
 msgid "Show help entry from navigation menu"
 msgstr ""
 
-#: src/Module/Admin/Site.php:424
+#: src/Module/Admin/Site.php:423
 msgid ""
 "Displays the menu entry for the Help pages from the navigation menu. It is "
 "always accessible by calling /help directly."
 msgstr ""
 
-#: src/Module/Admin/Site.php:425
+#: src/Module/Admin/Site.php:424
 msgid "Single user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:425
+#: src/Module/Admin/Site.php:424
 msgid "Make this instance multi-user or single-user for the named user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:427
+#: src/Module/Admin/Site.php:426
 msgid "Maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:427
+#: src/Module/Admin/Site.php:426
 #, php-format
 msgid ""
 "Maximum size in bytes of uploaded images. Default is 0, which means no "
@@ -4286,192 +4286,192 @@ msgid ""
 "to %s (%s byte)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:431
+#: src/Module/Admin/Site.php:430
 msgid "Maximum image length"
 msgstr ""
 
-#: src/Module/Admin/Site.php:431
+#: src/Module/Admin/Site.php:430
 msgid ""
 "Maximum length in pixels of the longest side of uploaded images. Default is "
 "-1, which means no limits."
 msgstr ""
 
-#: src/Module/Admin/Site.php:432
+#: src/Module/Admin/Site.php:431
 msgid "JPEG image quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:432
+#: src/Module/Admin/Site.php:431
 msgid ""
 "Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
 "100, which is full quality."
 msgstr ""
 
-#: src/Module/Admin/Site.php:434
+#: src/Module/Admin/Site.php:433
 msgid "Register policy"
 msgstr ""
 
-#: src/Module/Admin/Site.php:435
+#: src/Module/Admin/Site.php:434
 msgid "Maximum Daily Registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:435
+#: src/Module/Admin/Site.php:434
 msgid ""
 "If registration is permitted above, this sets the maximum number of new user "
 "registrations to accept per day.  If register is set to closed, this setting "
 "has no effect."
 msgstr ""
 
-#: src/Module/Admin/Site.php:436
+#: src/Module/Admin/Site.php:435
 msgid "Register text"
 msgstr ""
 
-#: src/Module/Admin/Site.php:436
+#: src/Module/Admin/Site.php:435
 msgid ""
 "Will be displayed prominently on the registration page. You can use BBCode "
 "here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:437
+#: src/Module/Admin/Site.php:436
 msgid "Forbidden Nicknames"
 msgstr ""
 
-#: src/Module/Admin/Site.php:437
+#: src/Module/Admin/Site.php:436
 msgid ""
 "Comma separated list of nicknames that are forbidden from registration. "
 "Preset is a list of role names according RFC 2142."
 msgstr ""
 
-#: src/Module/Admin/Site.php:438
+#: src/Module/Admin/Site.php:437
 msgid "Accounts abandoned after x days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:438
+#: src/Module/Admin/Site.php:437
 msgid ""
 "Will not waste system resources polling external sites for abandonded "
 "accounts. Enter 0 for no time limit."
 msgstr ""
 
-#: src/Module/Admin/Site.php:439
+#: src/Module/Admin/Site.php:438
 msgid "Allowed friend domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:439
+#: src/Module/Admin/Site.php:438
 msgid ""
 "Comma separated list of domains which are allowed to establish friendships "
 "with this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:440
+#: src/Module/Admin/Site.php:439
 msgid "Allowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:440
+#: src/Module/Admin/Site.php:439
 msgid ""
 "Comma separated list of domains which are allowed in email addresses for "
 "registrations to this site. Wildcards are accepted. Empty to allow any "
 "domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:441
+#: src/Module/Admin/Site.php:440
 msgid "No OEmbed rich content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:441
+#: src/Module/Admin/Site.php:440
 msgid ""
 "Don't show the rich content (e.g. embedded PDF), except from the domains "
 "listed below."
 msgstr ""
 
-#: src/Module/Admin/Site.php:442
+#: src/Module/Admin/Site.php:441
 msgid "Trusted third-party domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:442
+#: src/Module/Admin/Site.php:441
 msgid ""
 "Comma separated list of domains from which content is allowed to be embedded "
 "in posts like with OEmbed. All sub-domains of the listed domains are allowed "
 "as well."
 msgstr ""
 
-#: src/Module/Admin/Site.php:443
+#: src/Module/Admin/Site.php:442
 msgid "Block public"
 msgstr ""
 
-#: src/Module/Admin/Site.php:443
+#: src/Module/Admin/Site.php:442
 msgid ""
 "Check to block public access to all otherwise public personal pages on this "
 "site unless you are currently logged in."
 msgstr ""
 
-#: src/Module/Admin/Site.php:444
+#: src/Module/Admin/Site.php:443
 msgid "Force publish"
 msgstr ""
 
-#: src/Module/Admin/Site.php:444
+#: src/Module/Admin/Site.php:443
 msgid ""
 "Check to force all profiles on this site to be listed in the site directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:444
+#: src/Module/Admin/Site.php:443
 msgid "Enabling this may violate privacy laws like the GDPR"
 msgstr ""
 
-#: src/Module/Admin/Site.php:445
+#: src/Module/Admin/Site.php:444
 msgid "Global directory URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:445
+#: src/Module/Admin/Site.php:444
 msgid ""
 "URL to the global directory. If this is not set, the global directory is "
 "completely unavailable to the application."
 msgstr ""
 
-#: src/Module/Admin/Site.php:446
+#: src/Module/Admin/Site.php:445
 msgid "Private posts by default for new users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:446
+#: src/Module/Admin/Site.php:445
 msgid ""
 "Set default post permissions for all new members to the default privacy "
 "group rather than public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:447
+#: src/Module/Admin/Site.php:446
 msgid "Don't include post content in email notifications"
 msgstr ""
 
-#: src/Module/Admin/Site.php:447
+#: src/Module/Admin/Site.php:446
 msgid ""
 "Don't include the content of a post/comment/private message/etc. in the "
 "email notifications that are sent out from this site, as a privacy measure."
 msgstr ""
 
-#: src/Module/Admin/Site.php:448
+#: src/Module/Admin/Site.php:447
 msgid "Disallow public access to addons listed in the apps menu."
 msgstr ""
 
-#: src/Module/Admin/Site.php:448
+#: src/Module/Admin/Site.php:447
 msgid ""
 "Checking this box will restrict addons listed in the apps menu to members "
 "only."
 msgstr ""
 
-#: src/Module/Admin/Site.php:449
+#: src/Module/Admin/Site.php:448
 msgid "Don't embed private images in posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:449
+#: src/Module/Admin/Site.php:448
 msgid ""
 "Don't replace locally-hosted private photos in posts with an embedded copy "
 "of the image. This means that contacts who receive posts containing private "
 "photos will have to authenticate and load each image, which may take a while."
 msgstr ""
 
-#: src/Module/Admin/Site.php:450
+#: src/Module/Admin/Site.php:449
 msgid "Explicit Content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:450
+#: src/Module/Admin/Site.php:449
 msgid ""
 "Set this to announce that your node is used mostly for explicit content that "
 "might not be suited for minors. This information will be published in the "
@@ -4480,267 +4480,267 @@ msgid ""
 "will be shown at the user registration page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:451
+#: src/Module/Admin/Site.php:450
 msgid "Proxify external content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:451
+#: src/Module/Admin/Site.php:450
 msgid ""
 "Route external content via the proxy functionality. This is used for example "
 "for some OEmbed accesses and in some other rare cases."
 msgstr ""
 
-#: src/Module/Admin/Site.php:452
+#: src/Module/Admin/Site.php:451
 msgid "Cache contact avatars"
 msgstr ""
 
-#: src/Module/Admin/Site.php:452
+#: src/Module/Admin/Site.php:451
 msgid ""
 "Locally store the avatar pictures of the contacts. This uses a lot of "
 "storage space but it increases the performance."
 msgstr ""
 
-#: src/Module/Admin/Site.php:453
+#: src/Module/Admin/Site.php:452
 msgid "Allow Users to set remote_self"
 msgstr ""
 
-#: src/Module/Admin/Site.php:453
+#: src/Module/Admin/Site.php:452
 msgid ""
 "With checking this, every user is allowed to mark every contact as a "
 "remote_self in the repair contact dialog. Setting this flag on a contact "
 "causes mirroring every posting of that contact in the users stream."
 msgstr ""
 
-#: src/Module/Admin/Site.php:454
+#: src/Module/Admin/Site.php:453
 msgid "Enable multiple registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:454
+#: src/Module/Admin/Site.php:453
 msgid "Enable users to register additional accounts for use as pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:455
+#: src/Module/Admin/Site.php:454
 msgid "Enable OpenID"
 msgstr ""
 
-#: src/Module/Admin/Site.php:455
+#: src/Module/Admin/Site.php:454
 msgid "Enable OpenID support for registration and logins."
 msgstr ""
 
-#: src/Module/Admin/Site.php:456
+#: src/Module/Admin/Site.php:455
 msgid "Enable Fullname check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:456
+#: src/Module/Admin/Site.php:455
 msgid ""
 "Enable check to only allow users to register with a space between the first "
 "name and the last name in their full name."
 msgstr ""
 
-#: src/Module/Admin/Site.php:457
+#: src/Module/Admin/Site.php:456
 msgid "Email administrators on new registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:457
+#: src/Module/Admin/Site.php:456
 msgid ""
 "If enabled and the system is set to an open registration, an email for each "
 "new registration is sent to the administrators."
 msgstr ""
 
-#: src/Module/Admin/Site.php:458
+#: src/Module/Admin/Site.php:457
 msgid "Community pages for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:458
+#: src/Module/Admin/Site.php:457
 msgid ""
 "Which community pages should be available for visitors. Local users always "
 "see both pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:459
+#: src/Module/Admin/Site.php:458
 msgid "Posts per user on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:459
+#: src/Module/Admin/Site.php:458
 msgid ""
 "The maximum number of posts per user on the community page. (Not valid for "
 "\"Global Community\")"
 msgstr ""
 
-#: src/Module/Admin/Site.php:461
+#: src/Module/Admin/Site.php:460
 msgid "Enable Mail support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:461
+#: src/Module/Admin/Site.php:460
 msgid ""
 "Enable built-in mail support to poll IMAP folders and to reply via mail."
 msgstr ""
 
-#: src/Module/Admin/Site.php:462
+#: src/Module/Admin/Site.php:461
 msgid ""
 "Mail support can't be enabled because the PHP IMAP module is not installed."
 msgstr ""
 
-#: src/Module/Admin/Site.php:463
+#: src/Module/Admin/Site.php:462
 msgid "Enable OStatus support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:463
+#: src/Module/Admin/Site.php:462
 msgid ""
 "Enable built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
 "communications in OStatus are public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:465
+#: src/Module/Admin/Site.php:464
 msgid ""
 "Diaspora support can't be enabled because Friendica was installed into a sub "
 "directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:465
 msgid "Enable Diaspora support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:465
 msgid ""
 "Enable built-in Diaspora network compatibility for communicating with "
 "diaspora servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:466
 msgid "Verify SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:466
 msgid ""
 "If you wish, you can turn on strict certificate checking. This will mean you "
 "cannot connect (at all) to self-signed SSL sites."
 msgstr ""
 
-#: src/Module/Admin/Site.php:468
+#: src/Module/Admin/Site.php:467
 msgid "Proxy user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:468
+#: src/Module/Admin/Site.php:467
 msgid "User name for the proxy server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:469
+#: src/Module/Admin/Site.php:468
 msgid "Proxy URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:469
+#: src/Module/Admin/Site.php:468
 msgid ""
 "If you want to use a proxy server that Friendica should use to connect to "
 "the network, put the URL of the proxy here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:470
+#: src/Module/Admin/Site.php:469
 msgid "Network timeout"
 msgstr ""
 
-#: src/Module/Admin/Site.php:470
+#: src/Module/Admin/Site.php:469
 msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:471
+#: src/Module/Admin/Site.php:470
 msgid "Maximum Load Average"
 msgstr ""
 
-#: src/Module/Admin/Site.php:471
+#: src/Module/Admin/Site.php:470
 #, php-format
 msgid ""
 "Maximum system load before delivery and poll processes are deferred - "
 "default %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:472
+#: src/Module/Admin/Site.php:471
 msgid "Minimal Memory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:472
+#: src/Module/Admin/Site.php:471
 msgid ""
 "Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
 "default 0 (deactivated)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:473
+#: src/Module/Admin/Site.php:472
 msgid "Periodically optimize tables"
 msgstr ""
 
-#: src/Module/Admin/Site.php:473
+#: src/Module/Admin/Site.php:472
 msgid "Periodically optimize tables like the cache and the workerqueue"
 msgstr ""
 
-#: src/Module/Admin/Site.php:475
+#: src/Module/Admin/Site.php:474
 msgid "Discover followers/followings from contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:475
+#: src/Module/Admin/Site.php:474
 msgid ""
 "If enabled, contacts are checked for their followers and following contacts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:476
+#: src/Module/Admin/Site.php:475
 msgid "None - deactivated"
 msgstr ""
 
-#: src/Module/Admin/Site.php:477
+#: src/Module/Admin/Site.php:476
 msgid ""
 "Local contacts - contacts of our local contacts are discovered for their "
 "followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:478
+#: src/Module/Admin/Site.php:477
 msgid ""
 "Interactors - contacts of our local contacts and contacts who interacted on "
 "locally visible postings are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:479
 msgid "Synchronize the contacts with the directory server"
 msgstr ""
 
-#: src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:479
 msgid ""
 "if enabled, the system will check periodically for new contacts on the "
 "defined directory server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:482
+#: src/Module/Admin/Site.php:481
 msgid "Days between requery"
 msgstr ""
 
-#: src/Module/Admin/Site.php:482
+#: src/Module/Admin/Site.php:481
 msgid "Number of days after which a server is requeried for his contacts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:483
+#: src/Module/Admin/Site.php:482
 msgid "Discover contacts from other servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:483
+#: src/Module/Admin/Site.php:482
 msgid ""
 "Periodically query other servers for contacts. The system queries Friendica, "
 "Mastodon and Hubzilla servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Site.php:483
 msgid "Search the local directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Site.php:483
 msgid ""
 "Search the local directory instead of the global directory. When searching "
 "locally, every search will be executed on the global directory in the "
 "background. This improves the search results when the search is repeated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:485
 msgid "Publish server information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:485
 msgid ""
 "If enabled, general server and usage data will be published. The data "
 "contains the name and version of the server, number of users with public "
@@ -4748,50 +4748,50 @@ msgid ""
 "href=\"http://the-federation.info/\">the-federation.info</a> for details."
 msgstr ""
 
-#: src/Module/Admin/Site.php:488
+#: src/Module/Admin/Site.php:487
 msgid "Check upstream version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:488
+#: src/Module/Admin/Site.php:487
 msgid ""
 "Enables checking for new Friendica versions at github. If there is a new "
 "version, you will be informed in the admin panel overview."
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:488
 msgid "Suppress Tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:488
 msgid "Suppress showing a list of hashtags at the end of the posting."
 msgstr ""
 
-#: src/Module/Admin/Site.php:490
+#: src/Module/Admin/Site.php:489
 msgid "Clean database"
 msgstr ""
 
-#: src/Module/Admin/Site.php:490
+#: src/Module/Admin/Site.php:489
 msgid ""
 "Remove old remote items, orphaned database records and old content from some "
 "other helper tables."
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
+#: src/Module/Admin/Site.php:490
 msgid "Lifespan of remote items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
+#: src/Module/Admin/Site.php:490
 msgid ""
 "When the database cleanup is enabled, this defines the days after which "
 "remote items will be deleted. Own items, and marked or filed items are "
 "always kept. 0 disables this behaviour."
 msgstr ""
 
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:491
 msgid "Lifespan of unclaimed items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:491
 msgid ""
 "When the database cleanup is enabled, this defines the days after which "
 "unclaimed remote items (mostly content from the relay) will be deleted. "
@@ -4799,144 +4799,144 @@ msgid ""
 "items if set to 0."
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:492
 msgid "Lifespan of raw conversation data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:492
 msgid ""
 "The conversation data is used for ActivityPub and OStatus, as well as for "
 "debug purposes. It should be safe to remove it after 14 days, default is 90 "
 "days."
 msgstr ""
 
-#: src/Module/Admin/Site.php:494
+#: src/Module/Admin/Site.php:493
 msgid "Maximum numbers of comments per post"
 msgstr ""
 
-#: src/Module/Admin/Site.php:494
+#: src/Module/Admin/Site.php:493
 msgid "How much comments should be shown for each post? Default value is 100."
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:494
 msgid "Maximum numbers of comments per post on the display page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:494
 msgid ""
 "How many comments should be shown on the single view for each post? Default "
 "value is 1000."
 msgstr ""
 
-#: src/Module/Admin/Site.php:496
+#: src/Module/Admin/Site.php:495
 msgid "Temp path"
 msgstr ""
 
-#: src/Module/Admin/Site.php:496
+#: src/Module/Admin/Site.php:495
 msgid ""
 "If you have a restricted system where the webserver can't access the system "
 "temp path, enter another path here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:497
+#: src/Module/Admin/Site.php:496
 msgid "Only search in tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:497
+#: src/Module/Admin/Site.php:496
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: src/Module/Admin/Site.php:498
+#: src/Module/Admin/Site.php:497
 msgid "Generate counts per contact group when calculating network count"
 msgstr ""
 
-#: src/Module/Admin/Site.php:498
+#: src/Module/Admin/Site.php:497
 msgid ""
 "On systems with users that heavily use contact groups the query can be very "
 "expensive."
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:499
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:499
 #, php-format
 msgid ""
 "On shared hosters set this to %d. On larger systems, values of %d are great. "
 "Default value is %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:501
+#: src/Module/Admin/Site.php:500
 msgid "Enable fastlane"
 msgstr ""
 
-#: src/Module/Admin/Site.php:501
+#: src/Module/Admin/Site.php:500
 msgid ""
 "When enabed, the fastlane mechanism starts an additional worker if processes "
 "with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:502
 msgid "Direct relay transfer"
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:502
 msgid ""
 "Enables the direct transfer to other servers without using the relay servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:503
 msgid "Relay scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:503
 msgid ""
 "Can be \"all\" or \"tags\". \"all\" means that every public post should be "
 "received. \"tags\" means that only posts with selected tags should be "
 "received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:504 src/Module/Contact/Profile.php:287
+#: src/Module/Admin/Site.php:503 src/Module/Contact/Profile.php:286
 #: src/Module/Settings/TwoFactor/Index.php:125
 msgid "Disabled"
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:503
 msgid "all"
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:503
 msgid "tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:504
 msgid "Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:504
 msgid "Comma separated list of tags for the \"tags\" subscription."
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:505
 msgid "Deny Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:505
 msgid "Comma separated list of tags that are rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:506
 msgid "Allow user tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:506
 msgid ""
 "If enabled, the tags from the saved searches will used for the \"tags\" "
 "subscription in addition to the \"relay_server_tags\"."
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:509
 msgid "Start Relocation"
 msgstr ""
 
@@ -4982,7 +4982,7 @@ msgstr ""
 msgid "This backend doesn't have custom settings"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:149
+#: src/Module/Admin/Storage.php:148
 msgid "Database (legacy)"
 msgstr ""
 
@@ -5169,16 +5169,16 @@ msgstr ""
 msgid "Reload active themes"
 msgstr ""
 
-#: src/Module/Admin/Themes/Index.php:119
+#: src/Module/Admin/Themes/Index.php:118
 #, php-format
 msgid "No themes found on the system. They should be placed in %1$s"
 msgstr ""
 
-#: src/Module/Admin/Themes/Index.php:120
+#: src/Module/Admin/Themes/Index.php:119
 msgid "[Experimental]"
 msgstr ""
 
-#: src/Module/Admin/Themes/Index.php:121
+#: src/Module/Admin/Themes/Index.php:120
 msgid "[Unsupported]"
 msgstr ""
 
@@ -5352,26 +5352,26 @@ msgstr ""
 msgid "User registrations waiting for confirmation"
 msgstr ""
 
-#: src/Module/BaseApi.php:266 src/Module/BaseApi.php:282
-#: src/Module/BaseApi.php:298
+#: src/Module/BaseApi.php:451 src/Module/BaseApi.php:467
+#: src/Module/BaseApi.php:483
 msgid "Too Many Requests"
 msgstr ""
 
-#: src/Module/BaseApi.php:267
+#: src/Module/BaseApi.php:452
 #, php-format
 msgid "Daily posting limit of %d post reached. The post was rejected."
 msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/BaseApi.php:283
+#: src/Module/BaseApi.php:468
 #, php-format
 msgid "Weekly posting limit of %d post reached. The post was rejected."
 msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/BaseApi.php:299
+#: src/Module/BaseApi.php:484
 #, php-format
 msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgid_plural ""
@@ -5404,7 +5404,7 @@ msgstr ""
 msgid "Item Source"
 msgstr ""
 
-#: src/Module/BaseProfile.php:52 src/Module/Contact.php:479
+#: src/Module/BaseProfile.php:52 src/Module/Contact.php:478
 msgid "Profile Details"
 msgstr ""
 
@@ -5416,7 +5416,7 @@ msgstr ""
 msgid "Only You Can See This"
 msgstr ""
 
-#: src/Module/BaseProfile.php:116 src/Module/Profile/Schedule.php:82
+#: src/Module/BaseProfile.php:116 src/Module/Profile/Schedule.php:81
 msgid "Scheduled Posts"
 msgstr ""
 
@@ -5455,7 +5455,7 @@ msgstr ""
 msgid "Display"
 msgstr ""
 
-#: src/Module/BaseSettings.php:127 src/Module/Settings/Connectors.php:202
+#: src/Module/BaseSettings.php:127 src/Module/Settings/Connectors.php:204
 msgid "Social Networks"
 msgstr ""
 
@@ -5602,142 +5602,142 @@ msgid_plural "%d contacts edited."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact.php:342
+#: src/Module/Contact.php:341
 msgid "Show all contacts"
 msgstr ""
 
-#: src/Module/Contact.php:347 src/Module/Contact.php:415
+#: src/Module/Contact.php:346 src/Module/Contact.php:414
 #: src/Module/Moderation/BaseUsers.php:85
 msgid "Pending"
 msgstr ""
 
-#: src/Module/Contact.php:350
+#: src/Module/Contact.php:349
 msgid "Only show pending contacts"
 msgstr ""
 
-#: src/Module/Contact.php:355 src/Module/Contact.php:416
+#: src/Module/Contact.php:354 src/Module/Contact.php:415
 #: src/Module/Moderation/BaseUsers.php:93
 msgid "Blocked"
 msgstr ""
 
-#: src/Module/Contact.php:358
+#: src/Module/Contact.php:357
 msgid "Only show blocked contacts"
 msgstr ""
 
-#: src/Module/Contact.php:363 src/Module/Contact.php:418
+#: src/Module/Contact.php:362 src/Module/Contact.php:417
 #: src/Object/Post.php:344
 msgid "Ignored"
 msgstr ""
 
-#: src/Module/Contact.php:366
+#: src/Module/Contact.php:365
 msgid "Only show ignored contacts"
 msgstr ""
 
-#: src/Module/Contact.php:371 src/Module/Contact.php:419
+#: src/Module/Contact.php:370 src/Module/Contact.php:418
 msgid "Collapsed"
 msgstr ""
 
-#: src/Module/Contact.php:374
+#: src/Module/Contact.php:373
 msgid "Only show collapsed contacts"
 msgstr ""
 
-#: src/Module/Contact.php:379 src/Module/Contact.php:420
+#: src/Module/Contact.php:378 src/Module/Contact.php:419
 msgid "Archived"
 msgstr ""
 
-#: src/Module/Contact.php:382
+#: src/Module/Contact.php:381
 msgid "Only show archived contacts"
 msgstr ""
 
-#: src/Module/Contact.php:387 src/Module/Contact.php:417
+#: src/Module/Contact.php:386 src/Module/Contact.php:416
 msgid "Hidden"
 msgstr ""
 
-#: src/Module/Contact.php:390
+#: src/Module/Contact.php:389
 msgid "Only show hidden contacts"
 msgstr ""
 
-#: src/Module/Contact.php:398
+#: src/Module/Contact.php:397
 msgid "Organize your contact groups"
 msgstr ""
 
-#: src/Module/Contact.php:431
+#: src/Module/Contact.php:430
 msgid "Search your contacts"
 msgstr ""
 
-#: src/Module/Contact.php:432 src/Module/Search/Index.php:207
+#: src/Module/Contact.php:431 src/Module/Search/Index.php:207
 #, php-format
 msgid "Results for: %s"
 msgstr ""
 
-#: src/Module/Contact.php:439
+#: src/Module/Contact.php:438
 msgid "Update"
 msgstr ""
 
-#: src/Module/Contact.php:440 src/Module/Contact/Profile.php:478
+#: src/Module/Contact.php:439 src/Module/Contact/Profile.php:477
 #: src/Module/Moderation/Blocklist/Contact.php:117
 #: src/Module/Moderation/Users/Blocked.php:138
 #: src/Module/Moderation/Users/Index.php:154
 msgid "Unblock"
 msgstr ""
 
-#: src/Module/Contact.php:441 src/Module/Contact/Profile.php:486
+#: src/Module/Contact.php:440 src/Module/Contact/Profile.php:485
 msgid "Unignore"
 msgstr ""
 
-#: src/Module/Contact.php:442 src/Module/Contact/Profile.php:494
+#: src/Module/Contact.php:441 src/Module/Contact/Profile.php:493
 msgid "Uncollapse"
 msgstr ""
 
-#: src/Module/Contact.php:444
+#: src/Module/Contact.php:443
 msgid "Batch Actions"
 msgstr ""
 
-#: src/Module/Contact.php:487
+#: src/Module/Contact.php:486
 msgid "Conversations started by this contact"
 msgstr ""
 
-#: src/Module/Contact.php:492
+#: src/Module/Contact.php:491
 msgid "Posts and Comments"
 msgstr ""
 
-#: src/Module/Contact.php:495
+#: src/Module/Contact.php:494
 msgid "Individual Posts and Replies"
 msgstr ""
 
-#: src/Module/Contact.php:503
+#: src/Module/Contact.php:502
 msgid "Posts containing media objects"
 msgstr ""
 
-#: src/Module/Contact.php:510
+#: src/Module/Contact.php:509
 msgid "View all known contacts"
 msgstr ""
 
-#: src/Module/Contact.php:520
+#: src/Module/Contact.php:519
 msgid "Advanced Contact Settings"
 msgstr ""
 
-#: src/Module/Contact.php:556
+#: src/Module/Contact.php:555
 msgid "Mutual Friendship"
 msgstr ""
 
-#: src/Module/Contact.php:560
+#: src/Module/Contact.php:559
 msgid "is a fan of yours"
 msgstr ""
 
-#: src/Module/Contact.php:564
+#: src/Module/Contact.php:563
 msgid "you are a fan of"
 msgstr ""
 
-#: src/Module/Contact.php:582
+#: src/Module/Contact.php:581
 msgid "Pending outgoing contact request"
 msgstr ""
 
-#: src/Module/Contact.php:584
+#: src/Module/Contact.php:583
 msgid "Pending incoming contact request"
 msgstr ""
 
-#: src/Module/Contact.php:597 src/Module/Contact/Profile.php:347
+#: src/Module/Contact.php:596 src/Module/Contact/Profile.php:346
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr ""
@@ -5767,11 +5767,11 @@ msgstr ""
 #: src/Module/Moderation/Blocklist/Contact.php:122
 #: src/Module/Moderation/Users/Active.php:126
 #: src/Module/Moderation/Users/Blocked.php:126
-#: src/Module/Moderation/Users/Create.php:71
+#: src/Module/Moderation/Users/Create.php:70
 #: src/Module/Moderation/Users/Deleted.php:83
 #: src/Module/Moderation/Users/Index.php:140
 #: src/Module/Moderation/Users/Index.php:160
-#: src/Module/Moderation/Users/Pending.php:99 src/Module/Settings/OAuth.php:73
+#: src/Module/Moderation/Users/Pending.php:99 src/Module/Settings/OAuth.php:72
 msgid "Name"
 msgstr ""
 
@@ -5890,7 +5890,7 @@ msgstr ""
 msgid "Your Identity Address:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:169 src/Module/Contact/Profile.php:376
+#: src/Module/Contact/Follow.php:169 src/Module/Contact/Profile.php:375
 #: src/Module/Contact/Unfollow.php:129
 #: src/Module/Moderation/Blocklist/Contact.php:133
 #: src/Module/Notifications/Introductions.php:129
@@ -5898,7 +5898,7 @@ msgstr ""
 msgid "Profile URL"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:170 src/Module/Contact/Profile.php:388
+#: src/Module/Contact/Follow.php:170 src/Module/Contact/Profile.php:387
 #: src/Module/Notifications/Introductions.php:191
 #: src/Module/Profile/Profile.php:234
 msgid "Tags:"
@@ -5965,220 +5965,220 @@ msgstr ""
 msgid "Contact has been collapsed"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:243
+#: src/Module/Contact/Profile.php:242
 #, php-format
 msgid "You are mutual friends with %s"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:244
+#: src/Module/Contact/Profile.php:243
 #, php-format
 msgid "You are sharing with %s"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:245
+#: src/Module/Contact/Profile.php:244
 #, php-format
 msgid "%s is sharing with you"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:261
+#: src/Module/Contact/Profile.php:260
 msgid "Private communications are not available for this contact."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:263
+#: src/Module/Contact/Profile.php:262
 msgid "Never"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:266
+#: src/Module/Contact/Profile.php:265
 msgid "(Update was not successful)"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:266
+#: src/Module/Contact/Profile.php:265
 msgid "(Update was successful)"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:268 src/Module/Contact/Profile.php:449
+#: src/Module/Contact/Profile.php:267 src/Module/Contact/Profile.php:448
 msgid "Suggest friends"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:272
+#: src/Module/Contact/Profile.php:271
 #, php-format
 msgid "Network type: %s"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:277
+#: src/Module/Contact/Profile.php:276
 msgid "Communications lost with this contact!"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:283
+#: src/Module/Contact/Profile.php:282
 msgid "Fetch further information for feeds"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:285
+#: src/Module/Contact/Profile.php:284
 msgid ""
 "Fetch information like preview pictures, title and teaser from the feed "
 "item. You can activate this if the feed doesn't contain much text. Keywords "
 "are taken from the meta header in the feed item and are posted as hash tags."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:288
+#: src/Module/Contact/Profile.php:287
 msgid "Fetch information"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:289
+#: src/Module/Contact/Profile.php:288
 msgid "Fetch keywords"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:290
+#: src/Module/Contact/Profile.php:289
 msgid "Fetch information and keywords"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:300 src/Module/Contact/Profile.php:305
-#: src/Module/Contact/Profile.php:310 src/Module/Contact/Profile.php:316
+#: src/Module/Contact/Profile.php:299 src/Module/Contact/Profile.php:304
+#: src/Module/Contact/Profile.php:309 src/Module/Contact/Profile.php:315
 msgid "No mirroring"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:301 src/Module/Contact/Profile.php:311
-#: src/Module/Contact/Profile.php:317
+#: src/Module/Contact/Profile.php:300 src/Module/Contact/Profile.php:310
+#: src/Module/Contact/Profile.php:316
 msgid "Mirror as my own posting"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:306 src/Module/Contact/Profile.php:312
+#: src/Module/Contact/Profile.php:305 src/Module/Contact/Profile.php:311
 msgid "Native reshare"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:329
+#: src/Module/Contact/Profile.php:328
 msgid "Contact Information / Notes"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:330
+#: src/Module/Contact/Profile.php:329
 msgid "Contact Settings"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:338
+#: src/Module/Contact/Profile.php:337
 msgid "Contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:342
+#: src/Module/Contact/Profile.php:341
 msgid "Their personal note"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:344
+#: src/Module/Contact/Profile.php:343
 msgid "Edit contact notes"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:348
+#: src/Module/Contact/Profile.php:347
 msgid "Block/Unblock contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:349
+#: src/Module/Contact/Profile.php:348
 msgid "Ignore contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:350
+#: src/Module/Contact/Profile.php:349
 msgid "View conversations"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:355
+#: src/Module/Contact/Profile.php:354
 msgid "Last update:"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:357
+#: src/Module/Contact/Profile.php:356
 msgid "Update public posts"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:359 src/Module/Contact/Profile.php:459
+#: src/Module/Contact/Profile.php:358 src/Module/Contact/Profile.php:458
 msgid "Update now"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:361
+#: src/Module/Contact/Profile.php:360
 msgid "Awaiting connection acknowledge"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:362
+#: src/Module/Contact/Profile.php:361
 msgid "Currently blocked"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:363
+#: src/Module/Contact/Profile.php:362
 msgid "Currently ignored"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:364
+#: src/Module/Contact/Profile.php:363
 msgid "Currently collapsed"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:365
+#: src/Module/Contact/Profile.php:364
 msgid "Currently archived"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:368
+#: src/Module/Contact/Profile.php:367
 #: src/Module/Notifications/Introductions.php:192
 msgid "Hide this contact from others"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:368
+#: src/Module/Contact/Profile.php:367
 msgid ""
 "Replies/likes to your public posts <strong>may</strong> still be visible"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:369
+#: src/Module/Contact/Profile.php:368
 msgid "Notification for new posts"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:369
+#: src/Module/Contact/Profile.php:368
 msgid "Send a notification of every new post of this contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:371
+#: src/Module/Contact/Profile.php:370
 msgid "Keyword Deny List"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:371
+#: src/Module/Contact/Profile.php:370
 msgid ""
 "Comma separated list of keywords that should not be converted to hashtags, "
 "when \"Fetch information and keywords\" is selected"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:389
+#: src/Module/Contact/Profile.php:388
 #: src/Module/Settings/TwoFactor/Index.php:139
 msgid "Actions"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:391
+#: src/Module/Contact/Profile.php:390
 #: src/Module/Settings/TwoFactor/Index.php:119 view/theme/frio/theme.php:229
 msgid "Status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:397
+#: src/Module/Contact/Profile.php:396
 msgid "Mirror postings from this contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:399
+#: src/Module/Contact/Profile.php:398
 msgid ""
 "Mark this contact as remote_self, this will cause friendica to repost new "
 "entries from this contact."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:469
+#: src/Module/Contact/Profile.php:468
 msgid "Refetch contact data"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:480
+#: src/Module/Contact/Profile.php:479
 msgid "Toggle Blocked status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:488
+#: src/Module/Contact/Profile.php:487
 msgid "Toggle Ignored status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:496
+#: src/Module/Contact/Profile.php:495
 msgid "Toggle Collapsed status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:503 src/Module/Contact/Revoke.php:106
+#: src/Module/Contact/Profile.php:502 src/Module/Contact/Revoke.php:106
 msgid "Revoke Follow"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:505
+#: src/Module/Contact/Profile.php:504
 msgid "Revoke the follow from this contact"
 msgstr ""
 
@@ -6322,7 +6322,7 @@ msgid "Sort by post creation date"
 msgstr ""
 
 #: src/Module/Conversation/Network.php:281
-#: src/Module/Settings/Profile/Index.php:236
+#: src/Module/Settings/Profile/Index.php:235
 msgid "Personal"
 msgstr ""
 
@@ -7841,19 +7841,19 @@ msgstr ""
 msgid "Add User"
 msgstr ""
 
-#: src/Module/Moderation/Users/Create.php:71
+#: src/Module/Moderation/Users/Create.php:70
 msgid "Name of the new user."
 msgstr ""
 
-#: src/Module/Moderation/Users/Create.php:72
+#: src/Module/Moderation/Users/Create.php:71
 msgid "Nickname"
 msgstr ""
 
-#: src/Module/Moderation/Users/Create.php:72
+#: src/Module/Moderation/Users/Create.php:71
 msgid "Nickname of the new user."
 msgstr ""
 
-#: src/Module/Moderation/Users/Create.php:73
+#: src/Module/Moderation/Users/Create.php:72
 msgid "Email address of the new user."
 msgstr ""
 
@@ -8179,23 +8179,23 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: src/Module/Post/Edit.php:133
+#: src/Module/Post/Edit.php:136
 msgid "web link"
 msgstr ""
 
-#: src/Module/Post/Edit.php:134
+#: src/Module/Post/Edit.php:137
 msgid "Insert video link"
 msgstr ""
 
-#: src/Module/Post/Edit.php:135
+#: src/Module/Post/Edit.php:138
 msgid "video link"
 msgstr ""
 
-#: src/Module/Post/Edit.php:136
+#: src/Module/Post/Edit.php:139
 msgid "Insert audio link"
 msgstr ""
 
-#: src/Module/Post/Edit.php:137
+#: src/Module/Post/Edit.php:140
 msgid "audio link"
 msgstr ""
 
@@ -8218,20 +8218,20 @@ msgstr ""
 
 #: src/Module/Profile/Conversations.php:106
 #: src/Module/Profile/Conversations.php:109 src/Module/Profile/Profile.php:351
-#: src/Module/Profile/Profile.php:354 src/Protocol/Feed.php:1026
+#: src/Module/Profile/Profile.php:354 src/Protocol/Feed.php:1032
 #: src/Protocol/OStatus.php:1007
 #, php-format
 msgid "%s's timeline"
 msgstr ""
 
 #: src/Module/Profile/Conversations.php:107 src/Module/Profile/Profile.php:352
-#: src/Protocol/Feed.php:1030 src/Protocol/OStatus.php:1012
+#: src/Protocol/Feed.php:1036 src/Protocol/OStatus.php:1012
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
 #: src/Module/Profile/Conversations.php:108 src/Module/Profile/Profile.php:353
-#: src/Protocol/Feed.php:1033 src/Protocol/OStatus.php:1016
+#: src/Protocol/Feed.php:1039 src/Protocol/OStatus.php:1016
 #, php-format
 msgid "%s's comments"
 msgstr ""
@@ -8269,7 +8269,7 @@ msgid ""
 "\"btn btn-sm pull-right\">Cancel</a>"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:167 src/Module/Settings/Account.php:576
+#: src/Module/Profile/Profile.php:167 src/Module/Settings/Account.php:575
 msgid "Full Name:"
 msgstr ""
 
@@ -8289,12 +8289,12 @@ msgstr ""
 msgid "Birthday:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:190 src/Module/Settings/Profile/Index.php:254
+#: src/Module/Profile/Profile.php:190 src/Module/Settings/Profile/Index.php:253
 #: src/Util/Temporal.php:170
 msgid "Age: "
 msgstr ""
 
-#: src/Module/Profile/Profile.php:190 src/Module/Settings/Profile/Index.php:254
+#: src/Module/Profile/Profile.php:190 src/Module/Settings/Profile/Index.php:253
 #: src/Util/Temporal.php:170
 #, php-format
 msgid "%d year old"
@@ -8302,7 +8302,7 @@ msgid_plural "%d years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Profile/Profile.php:195 src/Module/Settings/Profile/Index.php:247
+#: src/Module/Profile/Profile.php:195 src/Module/Settings/Profile/Index.php:246
 msgid "Description:"
 msgstr ""
 
@@ -8369,15 +8369,15 @@ msgid ""
 "content from anonymous visitors."
 msgstr ""
 
-#: src/Module/Profile/Schedule.php:84
+#: src/Module/Profile/Schedule.php:83
 msgid "Scheduled"
 msgstr ""
 
-#: src/Module/Profile/Schedule.php:85
+#: src/Module/Profile/Schedule.php:84
 msgid "Content"
 msgstr ""
 
-#: src/Module/Profile/Schedule.php:86
+#: src/Module/Profile/Schedule.php:85
 msgid "Remove post"
 msgstr ""
 
@@ -8398,22 +8398,22 @@ msgstr ""
 msgid "Number of daily wall messages for %s exceeded. Message failed."
 msgstr ""
 
-#: src/Module/Profile/UnkMail.php:153
+#: src/Module/Profile/UnkMail.php:152
 #, php-format
 msgid ""
 "If you wish for %s to respond, please check that the privacy settings on "
 "your site allow private mail from unknown senders."
 msgstr ""
 
-#: src/Module/Profile/UnkMail.php:161
+#: src/Module/Profile/UnkMail.php:160
 msgid "To"
 msgstr ""
 
-#: src/Module/Profile/UnkMail.php:162
+#: src/Module/Profile/UnkMail.php:161
 msgid "Subject"
 msgstr ""
 
-#: src/Module/Profile/UnkMail.php:163
+#: src/Module/Profile/UnkMail.php:162
 msgid "Your message"
 msgstr ""
 
@@ -8477,8 +8477,8 @@ msgstr ""
 msgid "Please repeat your e-mail address:"
 msgstr ""
 
-#: src/Module/Register.php:162 src/Module/Security/PasswordTooLong.php:101
-#: src/Module/Settings/Account.php:567
+#: src/Module/Register.php:162 src/Module/Security/PasswordTooLong.php:100
+#: src/Module/Settings/Account.php:566
 msgid "New Password:"
 msgstr ""
 
@@ -8486,8 +8486,8 @@ msgstr ""
 msgid "Leave empty for an auto generated password."
 msgstr ""
 
-#: src/Module/Register.php:163 src/Module/Security/PasswordTooLong.php:102
-#: src/Module/Settings/Account.php:568
+#: src/Module/Register.php:163 src/Module/Security/PasswordTooLong.php:101
+#: src/Module/Settings/Account.php:567
 msgid "Confirm:"
 msgstr ""
 
@@ -8609,45 +8609,45 @@ msgstr ""
 msgid "Create a New Account"
 msgstr ""
 
-#: src/Module/Security/Login.php:143
+#: src/Module/Security/Login.php:142
 msgid "Your OpenID: "
 msgstr ""
 
-#: src/Module/Security/Login.php:146
+#: src/Module/Security/Login.php:145
 msgid ""
 "Please enter your username and password to add the OpenID to your existing "
 "account."
 msgstr ""
 
-#: src/Module/Security/Login.php:148
+#: src/Module/Security/Login.php:147
 msgid "Or login using OpenID: "
 msgstr ""
 
-#: src/Module/Security/Login.php:162
+#: src/Module/Security/Login.php:161
 msgid "Password: "
 msgstr ""
 
-#: src/Module/Security/Login.php:163
+#: src/Module/Security/Login.php:162
 msgid "Remember me"
 msgstr ""
 
-#: src/Module/Security/Login.php:172
+#: src/Module/Security/Login.php:171
 msgid "Forgot your password?"
 msgstr ""
 
-#: src/Module/Security/Login.php:175
+#: src/Module/Security/Login.php:174
 msgid "Website Terms of Service"
 msgstr ""
 
-#: src/Module/Security/Login.php:176
+#: src/Module/Security/Login.php:175
 msgid "terms of service"
 msgstr ""
 
-#: src/Module/Security/Login.php:178
+#: src/Module/Security/Login.php:177
 msgid "Website Privacy Policy"
 msgstr ""
 
-#: src/Module/Security/Login.php:179
+#: src/Module/Security/Login.php:178
 msgid "privacy policy"
 msgstr ""
 
@@ -8704,24 +8704,24 @@ msgstr ""
 msgid "Update Password"
 msgstr ""
 
-#: src/Module/Security/PasswordTooLong.php:100
-#: src/Module/Settings/Account.php:569
+#: src/Module/Security/PasswordTooLong.php:99
+#: src/Module/Settings/Account.php:568
 msgid "Current Password:"
 msgstr ""
 
-#: src/Module/Security/PasswordTooLong.php:100
-#: src/Module/Settings/Account.php:569
+#: src/Module/Security/PasswordTooLong.php:99
+#: src/Module/Settings/Account.php:568
 msgid "Your current password to confirm the changes"
 msgstr ""
 
-#: src/Module/Security/PasswordTooLong.php:101
+#: src/Module/Security/PasswordTooLong.php:100
 #: src/Module/Settings/Account.php:552
 msgid ""
 "Allowed characters are a-z, A-Z, 0-9 and special characters except white "
 "spaces and accentuated letters."
 msgstr ""
 
-#: src/Module/Security/PasswordTooLong.php:101
+#: src/Module/Security/PasswordTooLong.php:100
 #: src/Module/Settings/Account.php:553
 msgid "Password length is limited to 72 characters."
 msgstr ""
@@ -8963,73 +8963,73 @@ msgstr ""
 msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
 msgstr ""
 
-#: src/Module/Settings/Account.php:566
+#: src/Module/Settings/Account.php:565
 msgid "Password Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:568
+#: src/Module/Settings/Account.php:567
 msgid "Leave password fields blank unless changing"
 msgstr ""
 
-#: src/Module/Settings/Account.php:570
+#: src/Module/Settings/Account.php:569
 msgid "Password:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:570
+#: src/Module/Settings/Account.php:569
 msgid "Your current password to confirm the changes of the email address"
 msgstr ""
 
-#: src/Module/Settings/Account.php:573
+#: src/Module/Settings/Account.php:572
 msgid "Delete OpenID URL"
 msgstr ""
 
-#: src/Module/Settings/Account.php:575
+#: src/Module/Settings/Account.php:574
 msgid "Basic Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:577
+#: src/Module/Settings/Account.php:576
 msgid "Email Address:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:578
+#: src/Module/Settings/Account.php:577
 msgid "Your Timezone:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:579
+#: src/Module/Settings/Account.php:578
 msgid "Your Language:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:579
+#: src/Module/Settings/Account.php:578
 msgid ""
 "Set the language we use to show you friendica interface and to send you "
 "emails"
 msgstr ""
 
-#: src/Module/Settings/Account.php:580
+#: src/Module/Settings/Account.php:579
 msgid "Default Post Location:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:581
+#: src/Module/Settings/Account.php:580
 msgid "Use Browser Location:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:583
+#: src/Module/Settings/Account.php:582
 msgid "Security and Privacy Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:585
+#: src/Module/Settings/Account.php:584
 msgid "Maximum Friend Requests/Day:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:585 src/Module/Settings/Account.php:595
+#: src/Module/Settings/Account.php:584 src/Module/Settings/Account.php:594
 msgid "(to prevent spam abuse)"
 msgstr ""
 
-#: src/Module/Settings/Account.php:587
+#: src/Module/Settings/Account.php:586
 msgid "Allow your profile to be searchable globally?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:587
+#: src/Module/Settings/Account.php:586
 msgid ""
 "Activate this setting if you want others to easily find and follow you. Your "
 "profile will be searchable on remote systems. This setting also determines "
@@ -9037,43 +9037,43 @@ msgid ""
 "indexed or not."
 msgstr ""
 
-#: src/Module/Settings/Account.php:588
+#: src/Module/Settings/Account.php:587
 msgid "Hide your contact/friend list from viewers of your profile?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:588
+#: src/Module/Settings/Account.php:587
 msgid ""
 "A list of your contacts is displayed on your profile page. Activate this "
 "option to disable the display of your contact list."
 msgstr ""
 
-#: src/Module/Settings/Account.php:589
+#: src/Module/Settings/Account.php:588
 msgid "Hide your public content from anonymous viewers"
 msgstr ""
 
-#: src/Module/Settings/Account.php:589
+#: src/Module/Settings/Account.php:588
 msgid ""
 "Anonymous visitors will only see your basic profile details. Your public "
 "posts and replies will still be freely accessible on the remote servers of "
 "your followers and through relays."
 msgstr ""
 
-#: src/Module/Settings/Account.php:590
+#: src/Module/Settings/Account.php:589
 msgid "Make public posts unlisted"
 msgstr ""
 
-#: src/Module/Settings/Account.php:590
+#: src/Module/Settings/Account.php:589
 msgid ""
 "Your public posts will not appear on the community pages or in search "
 "results, nor be sent to relay servers. However they can still appear on "
 "public feeds on remote servers."
 msgstr ""
 
-#: src/Module/Settings/Account.php:591
+#: src/Module/Settings/Account.php:590
 msgid "Make all posted pictures accessible"
 msgstr ""
 
-#: src/Module/Settings/Account.php:591
+#: src/Module/Settings/Account.php:590
 msgid ""
 "This option makes every posted picture accessible via the direct link. This "
 "is a workaround for the problem that most other networks can't handle "
@@ -9081,233 +9081,233 @@ msgid ""
 "public on your photo albums though."
 msgstr ""
 
-#: src/Module/Settings/Account.php:592
+#: src/Module/Settings/Account.php:591
 msgid "Allow friends to post to your profile page?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:592
+#: src/Module/Settings/Account.php:591
 msgid ""
 "Your contacts may write posts on your profile wall. These posts will be "
 "distributed to your contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:593
+#: src/Module/Settings/Account.php:592
 msgid "Allow friends to tag your posts?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:593
+#: src/Module/Settings/Account.php:592
 msgid "Your contacts can add additional tags to your posts."
 msgstr ""
 
-#: src/Module/Settings/Account.php:594
+#: src/Module/Settings/Account.php:593
 msgid "Permit unknown people to send you private mail?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:594
+#: src/Module/Settings/Account.php:593
 msgid ""
 "Friendica network users may send you private messages even if they are not "
 "in your contact list."
 msgstr ""
 
-#: src/Module/Settings/Account.php:595
+#: src/Module/Settings/Account.php:594
 msgid "Maximum private messages per day from unknown people:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:597
+#: src/Module/Settings/Account.php:596
 msgid "Default Post Permissions"
 msgstr ""
 
-#: src/Module/Settings/Account.php:601
+#: src/Module/Settings/Account.php:600
 msgid "Expiration settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:602
+#: src/Module/Settings/Account.php:601
 msgid "Automatically expire posts after this many days:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:602
+#: src/Module/Settings/Account.php:601
 msgid "If empty, posts will not expire. Expired posts will be deleted"
 msgstr ""
 
-#: src/Module/Settings/Account.php:603
+#: src/Module/Settings/Account.php:602
 msgid "Expire posts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:603
+#: src/Module/Settings/Account.php:602
 msgid "When activated, posts and comments will be expired."
 msgstr ""
 
-#: src/Module/Settings/Account.php:604
+#: src/Module/Settings/Account.php:603
 msgid "Expire personal notes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:604
+#: src/Module/Settings/Account.php:603
 msgid ""
 "When activated, the personal notes on your profile page will be expired."
 msgstr ""
 
-#: src/Module/Settings/Account.php:605
+#: src/Module/Settings/Account.php:604
 msgid "Expire starred posts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:605
+#: src/Module/Settings/Account.php:604
 msgid ""
 "Starring posts keeps them from being expired. That behaviour is overwritten "
 "by this setting."
 msgstr ""
 
-#: src/Module/Settings/Account.php:606
+#: src/Module/Settings/Account.php:605
 msgid "Only expire posts by others"
 msgstr ""
 
-#: src/Module/Settings/Account.php:606
+#: src/Module/Settings/Account.php:605
 msgid ""
 "When activated, your own posts never expire. Then the settings above are "
 "only valid for posts you received."
 msgstr ""
 
-#: src/Module/Settings/Account.php:609
+#: src/Module/Settings/Account.php:608
 msgid "Notification Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:610
+#: src/Module/Settings/Account.php:609
 msgid "Send a notification email when:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:611
+#: src/Module/Settings/Account.php:610
 msgid "You receive an introduction"
 msgstr ""
 
-#: src/Module/Settings/Account.php:612
+#: src/Module/Settings/Account.php:611
 msgid "Your introductions are confirmed"
 msgstr ""
 
-#: src/Module/Settings/Account.php:613
+#: src/Module/Settings/Account.php:612
 msgid "Someone writes on your profile wall"
 msgstr ""
 
-#: src/Module/Settings/Account.php:614
+#: src/Module/Settings/Account.php:613
 msgid "Someone writes a followup comment"
 msgstr ""
 
-#: src/Module/Settings/Account.php:615
+#: src/Module/Settings/Account.php:614
 msgid "You receive a private message"
 msgstr ""
 
-#: src/Module/Settings/Account.php:616
+#: src/Module/Settings/Account.php:615
 msgid "You receive a friend suggestion"
 msgstr ""
 
-#: src/Module/Settings/Account.php:617
+#: src/Module/Settings/Account.php:616
 msgid "You are tagged in a post"
 msgstr ""
 
-#: src/Module/Settings/Account.php:619
+#: src/Module/Settings/Account.php:618
 msgid "Create a desktop notification when:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:620
+#: src/Module/Settings/Account.php:619
 msgid "Someone tagged you"
 msgstr ""
 
-#: src/Module/Settings/Account.php:621
+#: src/Module/Settings/Account.php:620
 msgid "Someone directly commented on your post"
 msgstr ""
 
-#: src/Module/Settings/Account.php:622
+#: src/Module/Settings/Account.php:621
 msgid "Someone liked your content"
 msgstr ""
 
-#: src/Module/Settings/Account.php:622 src/Module/Settings/Account.php:623
+#: src/Module/Settings/Account.php:621 src/Module/Settings/Account.php:622
 msgid "Can only be enabled, when the direct comment notification is enabled."
 msgstr ""
 
-#: src/Module/Settings/Account.php:623
+#: src/Module/Settings/Account.php:622
 msgid "Someone shared your content"
 msgstr ""
 
-#: src/Module/Settings/Account.php:624
+#: src/Module/Settings/Account.php:623
 msgid "Someone commented in your thread"
 msgstr ""
 
-#: src/Module/Settings/Account.php:625
+#: src/Module/Settings/Account.php:624
 msgid "Someone commented in a thread where you commented"
 msgstr ""
 
-#: src/Module/Settings/Account.php:626
+#: src/Module/Settings/Account.php:625
 msgid "Someone commented in a thread where you interacted"
 msgstr ""
 
-#: src/Module/Settings/Account.php:628
+#: src/Module/Settings/Account.php:627
 msgid "Activate desktop notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:628
+#: src/Module/Settings/Account.php:627
 msgid "Show desktop popup on new notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:632
+#: src/Module/Settings/Account.php:631
 msgid "Text-only notification emails"
 msgstr ""
 
-#: src/Module/Settings/Account.php:634
+#: src/Module/Settings/Account.php:633
 msgid "Send text only notification emails, without the html part"
 msgstr ""
 
-#: src/Module/Settings/Account.php:638
+#: src/Module/Settings/Account.php:637
 msgid "Show detailled notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:640
+#: src/Module/Settings/Account.php:639
 msgid ""
 "Per default, notifications are condensed to a single notification per item. "
 "When enabled every notification is displayed."
 msgstr ""
 
-#: src/Module/Settings/Account.php:644
+#: src/Module/Settings/Account.php:643
 msgid "Show notifications of ignored contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:646
+#: src/Module/Settings/Account.php:645
 msgid ""
 "You don't see posts from ignored contacts. But you still see their comments. "
 "This setting controls if you want to still receive regular notifications "
 "that are caused by ignored contacts or not."
 msgstr ""
 
-#: src/Module/Settings/Account.php:649
+#: src/Module/Settings/Account.php:648
 msgid "Advanced Account/Page Type Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:650
+#: src/Module/Settings/Account.php:649
 msgid "Change the behaviour of this account for special situations"
 msgstr ""
 
-#: src/Module/Settings/Account.php:653
+#: src/Module/Settings/Account.php:652
 msgid "Import Contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:654
+#: src/Module/Settings/Account.php:653
 msgid ""
 "Upload a CSV file that contains the handle of your followed accounts in the "
 "first column you exported from the old account."
 msgstr ""
 
-#: src/Module/Settings/Account.php:655
+#: src/Module/Settings/Account.php:654
 msgid "Upload File"
 msgstr ""
 
-#: src/Module/Settings/Account.php:658
+#: src/Module/Settings/Account.php:657
 msgid "Relocate"
 msgstr ""
 
-#: src/Module/Settings/Account.php:659
+#: src/Module/Settings/Account.php:658
 msgid ""
 "If you have moved this profile from another server, and some of your "
 "contacts don't receive your updates, try pushing this button."
 msgstr ""
 
-#: src/Module/Settings/Account.php:660
+#: src/Module/Settings/Account.php:659
 msgid "Resend relocate message to contacts"
 msgstr ""
 
@@ -9319,73 +9319,73 @@ msgstr ""
 msgid "No Addon settings configured"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:119
+#: src/Module/Settings/Connectors.php:120
 msgid "Failed to connect with email account using the settings provided."
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:164
-#: src/Module/Settings/Connectors.php:165
+#: src/Module/Settings/Connectors.php:166
+#: src/Module/Settings/Connectors.php:167
 msgid "Diaspora (Socialhome, Hubzilla)"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:164
-#: src/Module/Settings/Connectors.php:168
+#: src/Module/Settings/Connectors.php:166
+#: src/Module/Settings/Connectors.php:170
 #, php-format
 msgid "Built-in support for %s connectivity is enabled"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:165
 #: src/Module/Settings/Connectors.php:167
+#: src/Module/Settings/Connectors.php:169
 #, php-format
 msgid "Built-in support for %s connectivity is disabled"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:167
-#: src/Module/Settings/Connectors.php:168
+#: src/Module/Settings/Connectors.php:169
+#: src/Module/Settings/Connectors.php:170
 msgid "OStatus (GNU Social)"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:180
+#: src/Module/Settings/Connectors.php:182
 msgid "Email access is disabled on this site."
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:195
-#: src/Module/Settings/Connectors.php:241
+#: src/Module/Settings/Connectors.php:197
+#: src/Module/Settings/Connectors.php:244
 msgid "None"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:207
+#: src/Module/Settings/Connectors.php:209
 msgid "General Social Media Settings"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:210
+#: src/Module/Settings/Connectors.php:212
 msgid "Followed content scope"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:212
+#: src/Module/Settings/Connectors.php:214
 msgid ""
 "By default, conversations in which your follows participated but didn't "
 "start will be shown in your timeline. You can turn this behavior off, or "
 "expand it to the conversations in which your follows liked a post."
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:214
+#: src/Module/Settings/Connectors.php:216
 msgid "Only conversations my follows started"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:215
+#: src/Module/Settings/Connectors.php:217
 msgid "Conversations my follows started or commented on (default)"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:216
+#: src/Module/Settings/Connectors.php:218
 msgid "Any conversation my follows interacted with, including likes"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:219
+#: src/Module/Settings/Connectors.php:221
 msgid "Enable Content Warning"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:219
+#: src/Module/Settings/Connectors.php:221
 msgid ""
 "Users on networks like Mastodon or Pleroma are able to set a content warning "
 "field which collapse their post by default. This enables the automatic "
@@ -9393,115 +9393,125 @@ msgid ""
 "affect any other content filtering you eventually set up."
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:220
+#: src/Module/Settings/Connectors.php:222
 msgid "Enable intelligent shortening"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:220
+#: src/Module/Settings/Connectors.php:222
 msgid ""
 "Normally the system tries to find the best link to add to shortened posts. "
 "If disabled, every shortened post will always point to the original "
 "friendica post."
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:221
+#: src/Module/Settings/Connectors.php:223
 msgid "Enable simple text shortening"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:221
+#: src/Module/Settings/Connectors.php:223
 msgid ""
 "Normally the system shortens posts at the next line feed. If this option is "
 "enabled then the system will shorten the text at the maximum character limit."
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:222
+#: src/Module/Settings/Connectors.php:224
 msgid "Attach the link title"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:222
+#: src/Module/Settings/Connectors.php:224
 msgid ""
 "When activated, the title of the attached link will be added as a title on "
 "posts to Diaspora. This is mostly helpful with \"remote-self\" contacts that "
 "share feed content."
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:223
+#: src/Module/Settings/Connectors.php:225
 msgid "API: Use spoiler field as title"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:223
+#: src/Module/Settings/Connectors.php:225
 msgid ""
 "When activated, the \"spoiler_text\" field in the API will be used for the "
 "title on standalone posts. When deactivated it will be used for spoiler "
 "text. For comments it will always be used for spoiler text."
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:224
+#: src/Module/Settings/Connectors.php:226
+msgid "API: Automatically links at the end of the post as attached posts"
+msgstr ""
+
+#: src/Module/Settings/Connectors.php:226
+msgid ""
+"When activated, added links at the end of the post react the same way as "
+"added links in the web interface."
+msgstr ""
+
+#: src/Module/Settings/Connectors.php:227
 msgid "Your legacy ActivityPub/GNU Social account"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:224
+#: src/Module/Settings/Connectors.php:227
 msgid ""
 "If you enter your old account name from an ActivityPub based system or your "
 "GNU Social/Statusnet account name here (in the format user@domain.tld), your "
 "contacts will be added automatically. The field will be emptied when done."
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:226
+#: src/Module/Settings/Connectors.php:229
 msgid "Repair OStatus subscriptions"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:230
+#: src/Module/Settings/Connectors.php:233
 msgid "Email/Mailbox Setup"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:231
+#: src/Module/Settings/Connectors.php:234
 msgid ""
 "If you wish to communicate with email contacts using this service "
 "(optional), please specify how to connect to your mailbox."
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:232
+#: src/Module/Settings/Connectors.php:235
 msgid "Last successful email check:"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:234
+#: src/Module/Settings/Connectors.php:237
 msgid "IMAP server name:"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:235
+#: src/Module/Settings/Connectors.php:238
 msgid "IMAP port:"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:236
+#: src/Module/Settings/Connectors.php:239
 msgid "Security:"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:237
+#: src/Module/Settings/Connectors.php:240
 msgid "Email login name:"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:238
+#: src/Module/Settings/Connectors.php:241
 msgid "Email password:"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:239
+#: src/Module/Settings/Connectors.php:242
 msgid "Reply-to address:"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:240
+#: src/Module/Settings/Connectors.php:243
 msgid "Send public posts to all email contacts:"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:241
+#: src/Module/Settings/Connectors.php:244
 msgid "Action after import:"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:241
+#: src/Module/Settings/Connectors.php:244
 msgid "Move to folder"
 msgstr ""
 
-#: src/Module/Settings/Connectors.php:242
+#: src/Module/Settings/Connectors.php:245
 msgid "Move to folder:"
 msgstr ""
 
@@ -9629,95 +9639,95 @@ msgstr ""
 msgid "Theme settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:258
+#: src/Module/Settings/Display.php:257
 msgid "Display Theme:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:259
+#: src/Module/Settings/Display.php:258
 msgid "Mobile Theme:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:262
+#: src/Module/Settings/Display.php:261
 msgid "Number of items to display per page:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:262 src/Module/Settings/Display.php:263
+#: src/Module/Settings/Display.php:261 src/Module/Settings/Display.php:262
 msgid "Maximum of 100 items"
 msgstr ""
 
-#: src/Module/Settings/Display.php:263
+#: src/Module/Settings/Display.php:262
 msgid "Number of items to display per page when viewed from mobile device:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:264
+#: src/Module/Settings/Display.php:263
 msgid "Update browser every xx seconds"
 msgstr ""
 
-#: src/Module/Settings/Display.php:264
+#: src/Module/Settings/Display.php:263
 msgid "Minimum of 10 seconds. Enter -1 to disable it."
 msgstr ""
 
-#: src/Module/Settings/Display.php:265
+#: src/Module/Settings/Display.php:264
 msgid "Display emoticons"
 msgstr ""
 
-#: src/Module/Settings/Display.php:265
+#: src/Module/Settings/Display.php:264
 msgid "When enabled, emoticons are replaced with matching symbols."
 msgstr ""
 
-#: src/Module/Settings/Display.php:266
+#: src/Module/Settings/Display.php:265
 msgid "Infinite scroll"
 msgstr ""
 
-#: src/Module/Settings/Display.php:266
+#: src/Module/Settings/Display.php:265
 msgid "Automatic fetch new items when reaching the page end."
 msgstr ""
 
-#: src/Module/Settings/Display.php:267
+#: src/Module/Settings/Display.php:266
 msgid "Enable Smart Threading"
 msgstr ""
 
-#: src/Module/Settings/Display.php:267
+#: src/Module/Settings/Display.php:266
 msgid "Enable the automatic suppression of extraneous thread indentation."
 msgstr ""
 
-#: src/Module/Settings/Display.php:268
+#: src/Module/Settings/Display.php:267
 msgid "Display the Dislike feature"
 msgstr ""
 
-#: src/Module/Settings/Display.php:268
+#: src/Module/Settings/Display.php:267
 msgid "Display the Dislike button and dislike reactions on posts and comments."
 msgstr ""
 
-#: src/Module/Settings/Display.php:269
+#: src/Module/Settings/Display.php:268
 msgid "Display the resharer"
 msgstr ""
 
-#: src/Module/Settings/Display.php:269
+#: src/Module/Settings/Display.php:268
 msgid "Display the first resharer as icon and text on a reshared item."
 msgstr ""
 
-#: src/Module/Settings/Display.php:270
+#: src/Module/Settings/Display.php:269
 msgid "Stay local"
 msgstr ""
 
-#: src/Module/Settings/Display.php:270
+#: src/Module/Settings/Display.php:269
 msgid "Don't go to a remote system when following a contact link."
 msgstr ""
 
-#: src/Module/Settings/Display.php:271
+#: src/Module/Settings/Display.php:270
 msgid "Link preview mode"
 msgstr ""
 
-#: src/Module/Settings/Display.php:271
+#: src/Module/Settings/Display.php:270
 msgid "Appearance of the link preview that is added to each post with a link."
 msgstr ""
 
-#: src/Module/Settings/Display.php:273
+#: src/Module/Settings/Display.php:272
 msgid "Beginning of week:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:274
+#: src/Module/Settings/Display.php:273
 msgid "Default calendar view:"
 msgstr ""
 
@@ -9725,11 +9735,11 @@ msgstr ""
 msgid "Additional Features"
 msgstr ""
 
-#: src/Module/Settings/OAuth.php:72
+#: src/Module/Settings/OAuth.php:71
 msgid "Connected Apps"
 msgstr ""
 
-#: src/Module/Settings/OAuth.php:76
+#: src/Module/Settings/OAuth.php:75
 msgid "Remove authorization"
 msgstr ""
 
@@ -9765,114 +9775,114 @@ msgstr ""
 msgid "Add a new profile field"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:217
+#: src/Module/Settings/Profile/Index.php:216
 msgid ""
 "The homepage is verified. A rel=\"me\" link back to your Friendica profile "
 "page was found on the homepage."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:219
+#: src/Module/Settings/Profile/Index.php:218
 #, php-format
 msgid ""
 "To verify your homepage, add a rel=\"me\" link to it, pointing to your "
 "profile URL (%s)."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:229
+#: src/Module/Settings/Profile/Index.php:228
 msgid "Profile Actions"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:230
+#: src/Module/Settings/Profile/Index.php:229
 msgid "Edit Profile Details"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:232
+#: src/Module/Settings/Profile/Index.php:231
 msgid "Change Profile Photo"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:237
+#: src/Module/Settings/Profile/Index.php:236
 msgid "Profile picture"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:238
+#: src/Module/Settings/Profile/Index.php:237
 msgid "Location"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:239 src/Util/Temporal.php:97
+#: src/Module/Settings/Profile/Index.php:238 src/Util/Temporal.php:97
 #: src/Util/Temporal.php:99
 msgid "Miscellaneous"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:240
+#: src/Module/Settings/Profile/Index.php:239
 msgid "Custom Profile Fields"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:242 src/Module/Welcome.php:58
+#: src/Module/Settings/Profile/Index.php:241 src/Module/Welcome.php:58
 msgid "Upload Profile Photo"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:246
+#: src/Module/Settings/Profile/Index.php:245
 msgid "Display name:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:249
+#: src/Module/Settings/Profile/Index.php:248
 msgid "Street Address:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:250
+#: src/Module/Settings/Profile/Index.php:249
 msgid "Locality/City:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:251
+#: src/Module/Settings/Profile/Index.php:250
 msgid "Region/State:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:252
+#: src/Module/Settings/Profile/Index.php:251
 msgid "Postal/Zip Code:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:253
+#: src/Module/Settings/Profile/Index.php:252
 msgid "Country:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:255
+#: src/Module/Settings/Profile/Index.php:254
 msgid "XMPP (Jabber) address:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:255
+#: src/Module/Settings/Profile/Index.php:254
 msgid "The XMPP address will be published so that people can follow you there."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:256
+#: src/Module/Settings/Profile/Index.php:255
 msgid "Matrix (Element) address:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:256
+#: src/Module/Settings/Profile/Index.php:255
 msgid ""
 "The Matrix address will be published so that people can follow you there."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:257
+#: src/Module/Settings/Profile/Index.php:256
 msgid "Homepage URL:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:258
+#: src/Module/Settings/Profile/Index.php:257
 msgid "Public Keywords:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:258
+#: src/Module/Settings/Profile/Index.php:257
 msgid "(Used for suggesting potential friends, can be seen by others)"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:259
+#: src/Module/Settings/Profile/Index.php:258
 msgid "Private Keywords:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:259
+#: src/Module/Settings/Profile/Index.php:258
 msgid "(Used for searching profiles, never shown to others)"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:260
+#: src/Module/Settings/Profile/Index.php:259
 #, php-format
 msgid ""
 "<p>Custom fields appear on <a href=\"%s\">your profile page</a>.</p>\n"

--- a/view/templates/settings/connectors.tpl
+++ b/view/templates/settings/connectors.tpl
@@ -17,6 +17,7 @@
 		{{include file="field_checkbox.tpl" field=$simple_shortening}}
 		{{include file="field_checkbox.tpl" field=$attach_link_title}}
 		{{include file="field_checkbox.tpl" field=$api_spoiler_title}}
+		{{include file="field_checkbox.tpl" field=$api_auto_attach}}
 		{{include file="field_input.tpl" field=$legacy_contact}}
 
 		<p><a href="{{$repair_ostatus_url}}">{{$repair_ostatus_text}}</a></p>

--- a/view/theme/frio/templates/settings/connectors.tpl
+++ b/view/theme/frio/templates/settings/connectors.tpl
@@ -30,6 +30,8 @@
 
 					{{include file="field_checkbox.tpl" field=$api_spoiler_title}}
 
+					{{include file="field_checkbox.tpl" field=$api_auto_attach}}
+
 					{{include file="field_input.tpl" field=$legacy_contact}}
 
 					<p><a href="{{$repair_ostatus_url}}">{{$repair_ostatus_text}}</a></p>


### PR DESCRIPTION
You can now enable an option to automatically add links at the end of a post via API as attached links.

Also this fixes a problem with delayed posts that hadn't worked via API since the date format hadn't been converted for the database.