### PR TITLE
"edited_at" must only be displayed when the entry had been updated

### DIFF
--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -213,6 +213,10 @@ class Status extends BaseDataTransferObject
 			$status['in_reply_to_status'] = null;
 		}
 
+		if ($status['created_at'] == $status['edited_at']) {
+			unset($status['edited_at']);
+		}
+
 		return $status;
 	}
 }

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -214,7 +214,7 @@ class Status extends BaseDataTransferObject
 		}
 
 		if ($status['created_at'] == $status['edited_at']) {
-			unset($status['edited_at']);
+			$status['edited_at'] = null;
 		}
 
 		return $status;


### PR DESCRIPTION
When the field is filled then apps assume that there had been some change.