### PR TITLE
Fix being able to change/remove attached links.

### DIFF
--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -151,6 +151,9 @@ class Statuses extends BaseApi
 			throw new \Exception('Missing parameters in definition');
 		}
 
+		// Link Preview Attachment Processing
+		Post\Media::deleteByURIId($post['uri-id'], [Post\Media::HTML]);
+
 		Item::update($item, ['id' => $post['id']]);
 
 		foreach (Tag::getByURIId($post['uri-id']) as $tagToRemove) {


### PR DESCRIPTION
This change removes links/link previews from the previous version of the status being edited. Previously if a link preview was ever setup on the post it was impossible to remove. Adding link previews through the API works the same way the field is generated through the Web UI, by adding `[attachment]` blocks which are then stripped out of the body during processing. The Mastodon API provides the preview data in the "card" parameter. So an application calling this wanting to preserve the attachment will have to reconstruct the `attachment` block as part of the body for it to be included again.
