### PR TITLE
Ensure FactorySession->create returns an object no matter what

### DIFF
--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -237,7 +237,7 @@ return [
 	IHandleSessions::class => [
 		'instanceOf' => \Friendica\Core\Session\Factory\Session::class,
 		'call' => [
-			['createSession', [$_SERVER], Dice::CHAIN_CALL],
+			['create', [$_SERVER], Dice::CHAIN_CALL],
 			['start', [], Dice::CHAIN_CALL],
 		],
 	],

--- a/tests/src/Core/KeyValueStorage/DBKeyValueStorageTest.php
+++ b/tests/src/Core/KeyValueStorage/DBKeyValueStorageTest.php
@@ -80,6 +80,6 @@ class DBKeyValueStorageTest extends KeyValueStorageTest
 
 		$updateAtAfter = $entry['updated_at'];
 
-		self::assertLessThanOrEqual($updateAt, $updateAtAfter);
+		self::assertGreaterThanOrEqual($updateAt, $updateAtAfter);
 	}
 }


### PR DESCRIPTION
- Rename redundant method name createSession
- Add exception logging

Fixes #12792 

I'm curious about the kind of exception we are getting at this point, but we might have to suppress the most common ones.