### PR TITLE
Fix Mastodon InstanceV2 structure needs image max size under mediaAttachment

### DIFF
--- a/src/Module/Api/Mastodon/InstanceV2.php
+++ b/src/Module/Api/Mastodon/InstanceV2.php
@@ -112,10 +112,11 @@ class InstanceV2 extends BaseApi
 			$this->config->get('config', 'max_import_size')
 		));
 
+		$image_size_limit = $this->config->get('system', 'maximagesize');
+
 		return new InstanceEntity\Configuration(
 			$statuses_config,
-			new InstanceEntity\MediaAttachmentsConfig(Images::supportedTypes()),
-			$this->config->get('system', 'maximagesize')
+			new InstanceEntity\MediaAttachmentsConfig(Images::supportedTypes(), $image_size_limit),
 		);
 	}
 

--- a/src/Object/Api/Mastodon/InstanceV2/Configuration.php
+++ b/src/Object/Api/Mastodon/InstanceV2/Configuration.php
@@ -34,21 +34,16 @@ class Configuration extends BaseDataTransferObject
 	protected $statuses;
 	/** @var MediaAttachmentsConfig */
 	protected $media_attachments;
-	/** @var int */
-	protected $image_size_limit;
 
 	/**
 	 * @param StatusesConfig $statuses
 	 * @param MediaAttachmentsConfig $media_attachments
-	 * @param int $image_size_limit
 	 */
 	public function __construct(
 		StatusesConfig $statuses,
-		MediaAttachmentsConfig $media_attachments,
-		int $image_size_limit
+		MediaAttachmentsConfig $media_attachments
 	) {
 		$this->statuses          = $statuses;
 		$this->media_attachments = $media_attachments;
-		$this->image_size_limit  = $image_size_limit;
 	}
 }

--- a/src/Object/Api/Mastodon/InstanceV2/MediaAttachmentsConfig.php
+++ b/src/Object/Api/Mastodon/InstanceV2/MediaAttachmentsConfig.php
@@ -32,12 +32,15 @@ class MediaAttachmentsConfig extends BaseDataTransferObject
 {
 	/** @var string[] */
 	protected $supported_mime_types;
+	/** @var int */
+	protected $image_size_limit;
 
 	/**
 	 * @param array $supported_mime_types
 	 */
-	public function __construct(array $supported_mime_types)
+	public function __construct(array $supported_mime_types, int $image_size_limit)
 	{
 		$this->supported_mime_types = $supported_mime_types;
+		$this->image_size_limit     = $image_size_limit;
 	}
 }


### PR DESCRIPTION
The hierarchy of the Instance V2 configuration data incorrectly had the image_size_limit setting under configuration rather than under configuration->media_attachments.