### PR TITLE
Fix paging on mastodon timeline and status endpoints

### DIFF
--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -104,7 +104,7 @@ class ListTimeline extends BaseApi
 			$statuses = array_reverse($statuses);
 		}
 
-		self::setLinkHeader();
+		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
 		System::jsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
@@ -101,7 +101,7 @@ class PublicTimeline extends BaseApi
 			$statuses = array_reverse($statuses);
 		}
 
-		self::setLinkHeader();
+		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
 		System::jsonExit($statuses);
 	}
 }


### PR DESCRIPTION
When we added the more detailed paging types to the endpoints we left off the code to make the Link Header builder aware of whether it needs to use IDs versus temporal types. We also missed adding it to the account/statuses endpoint which acts as a timeline for a particular user. This endpoint is used to create the equivalent of the "home" timeline an the "statuses" for the logged-in user or "statuses and comments" timelines for any user in the Web UI.