### PR TITLE
Blocked servers can now be deleted

### DIFF
--- a/src/Worker/UpdateBlockedServers.php
+++ b/src/Worker/UpdateBlockedServers.php
@@ -57,8 +57,8 @@ class UpdateBlockedServers
 
 		if (DI::config()->get('system', 'delete-blocked-servers')) {
 			Logger::info('Delete blocked servers - start');
-			DBA::p("DELETE FROM `gserver` WHERE `blocked` AND NOT EXISTS(SELECT `gsid` FROM `inbox-status` WHERE `gsid` = `gserver`.`id`) AND NOT EXISTS(SELECT `gsid` FROM `contact` WHERE gsid= `gserver`.`id`) AND NOT EXISTS(SELECT `gsid` FROM `apcontact` WHERE `gsid` = `gserver`.`id`) AND NOT EXISTS(SELECT `gsid` FROM `delivery-queue` WHERE `gsid` = `gserver`.`id`) AND NOT EXISTS(SELECT `gsid` FROM `diaspora-contact` WHERE `gsid` = `gserver`.`id`) AND NOT EXISTS(SELECT `gserver-id` FROM `gserver-tag` WHERE `gserver-id` = `gserver`.`id`)");
-			Logger::info('Delete blocked servers - done', ['rows' => DBA::affectedRows()]);
+			$ret = DBA::delete('gserver', ["`blocked` AND NOT EXISTS(SELECT `gsid` FROM `inbox-status` WHERE `gsid` = `gserver`.`id`) AND NOT EXISTS(SELECT `gsid` FROM `contact` WHERE gsid= `gserver`.`id`) AND NOT EXISTS(SELECT `gsid` FROM `apcontact` WHERE `gsid` = `gserver`.`id`) AND NOT EXISTS(SELECT `gsid` FROM `delivery-queue` WHERE `gsid` = `gserver`.`id`) AND NOT EXISTS(SELECT `gsid` FROM `diaspora-contact` WHERE `gsid` = `gserver`.`id`) AND NOT EXISTS(SELECT `gserver-id` FROM `gserver-tag` WHERE `gserver-id` = `gserver`.`id`)"]);
+			Logger::info('Delete blocked servers - done', ['ret' => $ret, 'rows' => DBA::affectedRows()]);
 		}
 	}
 }

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -238,7 +238,7 @@ return [
 		'delete_sleeping_processes' => false,
 
 		// delete-blocked-servers (Boolean)
-		// Delete blocked servers if possible.
+		// Delete blocked servers if there are no foreign key violations.
 		'delete-blocked-servers' => false,
 
 		// dice_profiler_threshold (Float)

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -237,6 +237,10 @@ return [
 		// Periodically delete waiting database processes.
 		'delete_sleeping_processes' => false,
 
+		// delete-blocked-servers (Boolean)
+		// Delete blocked servers if possible.
+		'delete-blocked-servers' => false,
+
 		// dice_profiler_threshold (Float)
 		// For profiling Dice class creation (0 = disabled, >0 = seconds threshold for profiling)
 		'dice_profiler_threshold' => 0.5,
@@ -508,7 +512,7 @@ return [
 		'png_quality' => 8,
 
 		// process_view (Boolean)
-		// Process the "View" activity that is used by Peertube. View activities are displayed, when "emoji_activities" are enabled. 
+		// Process the "View" activity that is used by Peertube. View activities are displayed, when "emoji_activities" are enabled.
 		'process_view' => false,
 
 		// profiler (Boolean)


### PR DESCRIPTION
To get rid of blocked servers, there is now an option to delete them. Server entries can only be deleted if they don't have got any foreign keys violations.