### PR TITLE
Fix cant remove attachment

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -201,6 +201,8 @@ class Item
 		$notify_items = [];
 
 		while ($item = DBA::fetch($items)) {
+			Post\Media::deleteByURIId($item['uri-id'], [Post\Media::HTML]);
+
 			if (!empty($fields['body'])) {
 				if (!empty($item['quote-uri-id'])) {
 					$fields['body'] = BBCode::removeSharedData($fields['body']);

--- a/view/js/linkPreview.js
+++ b/view/js/linkPreview.js
@@ -548,12 +548,12 @@
 
 			matches = attributes.match(/url='([\s\S]*?)'/im);
 			if (matches !== null && typeof matches[1] !== 'undefined') {
-				url = matches[1].toLowerCase();
+				url = matches[1];
 			}
 
 			matches = attributes.match(/url="([\s\S]*?)"/im);
 			if (matches !== null && typeof matches[1] !== 'undefined') {
-				url = matches[1].toLowerCase();
+				url = matches[1];
 			}
 
 			if(url !== '') {
@@ -564,12 +564,12 @@
 
 			matches = attributes.match(/title='([\s\S]*?)'/im);
 			if (matches !== null && typeof matches[1] !== 'undefined') {
-				title = matches[1].toLowerCase();
+				title = trim(matches[1]);
 			}
 
 			matches = attributes.match(/title="([\s\S]*?)"/im);
 			if (matches !== null && typeof matches[1] !== 'undefined') {
-				title = matches[1].toLowerCase();
+				title = trim(matches[1]);
 			}
 
 			if (title !== '') {
@@ -580,12 +580,12 @@
 
 			matches = attributes.match(/image='([\s\S]*?)'/im);
 			if (matches !== null && typeof matches[1] !== 'undefined') {
-				image = matches[1].toLowerCase();
+				image = trim(matches[1]);
 			}
 
 			matches = attributes.match(/image="([\s\S]*?)"/im);
 			if (matches !== null && typeof matches[1] !== 'undefined') {
-				image = matches[1].toLowerCase();
+				image = trim(matches[1]);
 			}
 
 			if (image !== '') {
@@ -596,12 +596,12 @@
 
 			matches = attributes.match(/preview='([\s\S]*?)'/im);
 			if (matches !== null && typeof matches[1] !== 'undefined') {
-				preview = matches[1].toLowerCase();
+				preview = trim(matches[1]);
 			}
 
 			matches = attributes.match(/preview="([\s\S]*?)"/im);
 			if (matches !== null && typeof matches[1] !== 'undefined') {
-				preview = matches[1].toLowerCase();
+				preview = trim(matches[1]);
 			}
 
 			if (preview !== '') {


### PR DESCRIPTION
Should fix #12911 . Like with the API edit endpoints it removes any previous link attachments before processing the edited post's link attachments. This way if there are none in the edited post then it no longer will have one.

This also fixes the image preview links being broken and the title text being all lower-cased in the link preview being shown in the editor. 

Both the PHP file and the JS file seemed to have lots of style errors but I didn't want to do an auto-fix and obscure the changes I made. 