### PR TITLE
Fix posting/editing empty text image posts through Mastodon API

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -589,7 +589,7 @@ class Item
 	public static function isValid(array $item): bool
 	{
 		// When there is no content then we don't post it
-		if (($item['body'] . $item['title'] == '') && empty($item['quote-uri-id']) && (empty($item['uri-id']) || !Post\Media::existsByURIId($item['uri-id']))) {
+		if (($item['body'] . $item['title'] == '') && empty($item['quote-uri-id']) && empty($item['attachments']) && (empty($item['uri-id']) || !Post\Media::existsByURIId($item['uri-id']))) {
 			Logger::notice('No body, no title.');
 			return false;
 		}


### PR DESCRIPTION
The Item::isValid method assumed that any Post\Media entries for a post would already be inserted into the post-media table for a post by validation time. These insertions happen after the Item::insert method calls the isValid method. Therefore the short-circuit for the if statement with an empty body and title doesn't properly trigger. At this point we do however have whether we have an attachments for processing into the post-image table later. This change checks adds a check if this is empty. If it is not empty then it will accept a body/title being empty as valid. 