### PR TITLE
Rework new lines around list BBCode

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1473,8 +1473,8 @@ class BBCode
 					$text = preg_replace("/\[list=((?-i)I)\](.*?)\[\/list\]/ism", '</p><ul class="listupperroman" style="list-style-type: upper-roman;">$2</ul><p>', $text);
 					$text = preg_replace("/\[list=((?-i)a)\](.*?)\[\/list\]/ism", '</p><ul class="listloweralpha" style="list-style-type: lower-alpha;">$2</ul><p>', $text);
 					$text = preg_replace("/\[list=((?-i)A)\](.*?)\[\/list\]/ism", '</p><ul class="listupperalpha" style="list-style-type: upper-alpha;">$2</ul><p>', $text);
-					$text = preg_replace("/\[ul\](.*?)\[\/ul\]/ism", '</p><ul class="listbullet" style="list-style-type: circle;">$1</ul><p>', $text);
-					$text = preg_replace("/\[ol\](.*?)\[\/ol\]/ism", '</p><ul class="listdecimal" style="list-style-type: decimal;">$1</ul><p>', $text);
+					$text = preg_replace("/\[ul\](.*?)\[\/ul\]/ism", '</p><ul>$1</ul><p>', $text);
+					$text = preg_replace("/\[ol\](.*?)\[\/ol\]/ism", '</p><ol>$1</ol><p>', $text);
 					$text = preg_replace("/\[li\](.*?)\[\/li\]/ism", '<li>$1</li>', $text);
 				}
 

--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -281,9 +281,9 @@ class HTML
 			self::tagToBBCode($doc, 'div', [], "\r", "\r");
 			self::tagToBBCode($doc, 'p', [], "\n", "\n");
 
-			self::tagToBBCode($doc, 'ul', [], "[ul]", "[/ul]");
-			self::tagToBBCode($doc, 'ol', [], "[ol]", "[/ol]");
-			self::tagToBBCode($doc, 'li', [], "[*]", "");
+			self::tagToBBCode($doc, 'ul', [], "[ul]", "\n[/ul]");
+			self::tagToBBCode($doc, 'ol', [], "[ol]", "\n[/ol]");
+			self::tagToBBCode($doc, 'li', [], "\n[*]", "");
 
 			self::tagToBBCode($doc, 'hr', [], "[hr]", "");
 
@@ -348,33 +348,6 @@ class HTML
 				$oldmessage = $message;
 				$message = str_replace("\n\n\n", "\n\n", $message);
 			} while ($oldmessage != $message);
-
-			do {
-				$oldmessage = $message;
-				$message = str_replace(
-					[
-						"[/size]\n\n",
-						"\n[hr]",
-						"[hr]\n",
-						"\n[list",
-						"[/list]\n",
-						"\n[/",
-						"[list]\n",
-						"[list=1]\n",
-						"\n[*]"],
-					[
-						"[/size]\n",
-						"[hr]",
-						"[hr]",
-						"[list",
-						"[/list]",
-						"[/",
-						"[list]",
-						"[list=1]",
-						"[*]"],
-					$message
-				);
-			} while ($message != $oldmessage);
 
 			$message = str_replace(
 				['[b][b]', '[/b][/b]', '[i][i]', '[/i][/i]'],

--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -281,8 +281,8 @@ class HTML
 			self::tagToBBCode($doc, 'div', [], "\r", "\r");
 			self::tagToBBCode($doc, 'p', [], "\n", "\n");
 
-			self::tagToBBCode($doc, 'ul', [], "[list]", "[/list]");
-			self::tagToBBCode($doc, 'ol', [], "[list=1]", "[/list]");
+			self::tagToBBCode($doc, 'ul', [], "[ul]", "[/ul]");
+			self::tagToBBCode($doc, 'ol', [], "[ol]", "[/ol]");
 			self::tagToBBCode($doc, 'li', [], "[*]", "");
 
 			self::tagToBBCode($doc, 'hr', [], "[hr]", "");

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -265,7 +265,15 @@ Karl Marx - Die ursprüngliche Akkumulation
 			'task-12900-header-with-paragraphs' => [
 				'expectedHTML' => '<h1>Header</h1><p>Some Chapter</p>',
 				'text' => '[h1]Header[/h1]Some Chapter',
-			]
+			],
+			'bug-12842-ul-newlines' => [
+				'expectedHTML' => '<p>This is:</p><ul><li>some<br></li><li>amazing<br></li><li>list</li></ul>',
+				'text' => "This is:\r\n[ul]\r\n[*]some\r\n[*]amazing\r\n[*]list\r\n[/ul]",
+			],
+			'bug-12842-ol-newlines' => [
+				'expectedHTML' => '<p>This is:</p><ol><li>some<br></li><li>amazing<br></li><li>list</li></ol>',
+				'text' => "This is:\r\n[ol]\r\n[*]some\r\n[*]amazing\r\n[*]list\r\n[/ol]",
+			],
 		];
 	}
 

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -158,21 +158,21 @@ class BBCodeTest extends FixtureTest
 	{
 		return [
 			'bug-7271-condensed-space' => [
-				'expectedHtml' => '<ul class="listdecimal" style="list-style-type:decimal;"><li> <a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ul>',
+				'expectedHtml' => '<ol><li> <a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ol>',
 				'text' => '[ol][*] http://example.com/[/ol]',
 			],
 			'bug-7271-condensed-nospace' => [
-				'expectedHtml' => '<ul class="listdecimal" style="list-style-type:decimal;"><li><a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ul>',
+				'expectedHtml' => '<ol><li><a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ol>',
 				'text' => '[ol][*]http://example.com/[/ol]',
 			],
 			'bug-7271-indented-space' => [
-				'expectedHtml' => '<ul class="listbullet" style="list-style-type:circle;"><li> <a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ul>',
+				'expectedHtml' => '<ul><li> <a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ul>',
 				'text' => '[ul]
 [*] http://example.com/
 [/ul]',
 			],
 			'bug-7271-indented-nospace' => [
-				'expectedHtml' => '<ul class="listbullet" style="list-style-type:circle;"><li><a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ul>',
+				'expectedHtml' => '<ul><li><a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ul>',
 				'text' => '[ul]
 [*]http://example.com/
 [/ul]',
@@ -259,7 +259,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 				'text' => '[emoji=https://fedi.underscore.world/emoji/custom/custom/heart_nb.png]:heart_nb:[/emoji]',
 			],
 			'task-12900-multiple-paragraphs' => [
-				'expectedHTML' => '<h1>Header</h1><ul class="listbullet" style="list-style-type:circle;"><li>One</li><li>Two</li></ul><p>This is a paragraph<br>with a line feed.</p><p>Second Chapter</p>',
+				'expectedHTML' => '<h1>Header</h1><ul><li>One</li><li>Two</li></ul><p>This is a paragraph<br>with a line feed.</p><p>Second Chapter</p>',
 				'text' => "[h1]Header[/h1][ul][*]One[*]Two[/ul]\n\nThis is a paragraph\nwith a line feed.\n\nSecond Chapter",
 			],
 			'task-12900-header-with-paragraphs' => [

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -282,8 +282,9 @@ Karl Marx - Die ursprüngliche Akkumulation
 	 *
 	 * @throws InternalServerErrorException
 	 */
-	public function testConvert(string $expectedHtml, string $text, $try_oembed = false, int $simpleHtml = 0, bool $forPlaintext = false)
+	public function testConvert(string $expectedHtml, string $text, bool $try_oembed = true, int $simpleHtml = BBCode::INTERNAL, bool $forPlaintext = false)
 	{
+		// This assumes system.remove_multiplicated_lines = false
 		$actual = BBCode::convert($text, $try_oembed, $simpleHtml, $forPlaintext);
 
 		self::assertEquals($expectedHtml, $actual);

--- a/tests/src/Content/Text/HTMLTest.php
+++ b/tests/src/Content/Text/HTMLTest.php
@@ -88,6 +88,24 @@ its surprisingly good",
 				'expectedBBCode' => '[url=https://dev-friendica.mrpetovan.com/profile/hypolite]@hypolite[/url] 0',
 				'html' => '<p><span class="h-card"><a href="https://dev-friendica.mrpetovan.com/profile/hypolite" class="u-url mention">@<span>hypolite</span></a></span> 0</p>',
 			],
+			'bug-12842-ul-new-lines' => [
+				'expectedBBCode' => 'This is:
+[ul]
+[*]some
+[*]amazing
+[*]list
+[/ul]',
+				'html'=> '<p>This is:</p><ul><li>some</li><li>amazing</li><li>list</li></ul>',
+			],
+			'bug-12842-ol-new-lines' => [
+				'expectedBBCode' => 'This is:
+[ol]
+[*]some
+[*]amazing
+[*]list
+[/ol]',
+				'html'=> '<p>This is:</p><ol><li>some</li><li>amazing</li><li>list</li></ol>',
+			],
 		];
 	}
 

--- a/tests/src/Content/Text/HTMLTest.php
+++ b/tests/src/Content/Text/HTMLTest.php
@@ -627,13 +627,13 @@ its surprisingly good",
             e.preventDefault();
 //            console.log('[id=\"' + this.getAttribute('href') + '\"]');
 //            console.log(document.getElementById('[id=\"' + this.getAttribute('href') + '\"]'));
-            
+
             document.querySelector('[ez-toc-data-id=\"' + decodeURI(this.getAttribute('href')) + '\"]').scrollIntoView({
                 behavior: 'smooth'
             });
         });
     });
-};           
+};
 document.addEventListener('DOMContentLoaded', ezTocScrollScriptJS, false);</script> <script   type='text/javascript' src='https://blog.austria-insiderinfo.com/wp-includes/js/jquery/jquery.min.js?ver=3.6.1' id='jquery-core-js'></script> <link rel=\"https://api.w.org/\" href=\"https://blog.austria-insiderinfo.com/wp-json/\" /><link rel=\"alternate\" type=\"application/json\" href=\"https://blog.austria-insiderinfo.com/wp-json/wp/v2/posts/17543\" /><link rel=\"EditURI\" type=\"application/rsd+xml\" title=\"RSD\" href=\"https://blog.austria-insiderinfo.com/xmlrpc.php?rsd\" /><link rel='shortlink' href='https://blog.austria-insiderinfo.com/?p=17543' /><link rel=\"icon\" href=\"https://blog.austria-insiderinfo.com/wp-content/uploads/2016/11/cropped-fav_icon-2-32x32.png\" sizes=\"32x32\" /><link rel=\"icon\" href=\"https://blog.austria-insiderinfo.com/wp-content/uploads/2016/11/cropped-fav_icon-2-192x192.png\" sizes=\"192x192\" /><link rel=\"apple-touch-icon\" href=\"https://blog.austria-insiderinfo.com/wp-content/uploads/2016/11/cropped-fav_icon-2-180x180.png\" /><meta name=\"msapplication-TileImage\" content=\"https://blog.austria-insiderinfo.com/wp-content/uploads/2016/11/cropped-fav_icon-2-270x270.png\" /> <script type=\"text/javascript\">var doc = document.documentElement;
 \t\t\tdoc.setAttribute( 'data-useragent', navigator.userAgent );</script> <script type=\"text/javascript\">(function(c,l,a,r,i,t,y){
         c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
@@ -658,7 +658,7 @@ Du kannst Kommentare auch <a href=\"https://blog.austria-insiderinfo.com/comment
                         <div class=\"row\">
                             <div class=\"col-12\">
                                 <div class=\"_brlbs-flex-center\">
-                                    
+
                                     <span role=\"heading\" aria-level=\"3\" class=\"_brlbs-h3\" id=\"CookieBoxTextHeadline\">Cookie Einstellungen</span>
                                 </div>
 
@@ -685,7 +685,7 @@ Externe Medien<br />
                                                 >
                                                     Externe Medien                                                </li>
                                                                                 </ul>
-                                
+
                                 <p class=\"_brlbs-accept\">
                                     <a
                                         href=\"#\"
@@ -708,7 +708,7 @@ Externe Medien<br />
                                         >
                                             Nur essenzielle Cookies akzeptieren                                        </a>
                                     </p>
-                                
+
                                 <p class=\"_brlbs-manage\">
                                     <a
                                         href=\"#\"
@@ -736,7 +736,7 @@ Externe Medien<br />
                                             href=\"https://blog.austria-insiderinfo.com/rechtshinweis/\"
                                         >
                                             Datenschutzerklärung                                        </a>
-                                    
+
                                                                             <span class=\"_brlbs-separator\"></span>
                                         <a
                                             tabindex=\"0\"
@@ -760,7 +760,7 @@ Externe Medien<br />
         <div class=\"row no-gutters\">
             <div class=\"col-12\">
                 <div class=\"row no-gutters align-items-top\">
-                    
+
                     <div class=\"col-12\">
                         <span role=\"heading\" aria-level=\"3\" class=\"_brlbs-h3\">Datenschutzeinstellungen</span>
 
@@ -778,7 +778,7 @@ Externe Medien<br />
                                             data-cookie-accept-all
                                         >
                                             Alle Cookies akzeptieren                                        </a>
-                                        
+
                                     <a
                                         href=\"#\"
                                         id=\"CookiePrefSave\"
@@ -853,7 +853,7 @@ Externe Medien<br />
                                         data-cookie-accordion-parent=\"essential\"
                                     >
                                                                                     <table>
-                                                
+
                                                 <tr>
                                                     <th>Name</th>
                                                     <td>
@@ -871,21 +871,21 @@ Externe Medien<br />
                                                         <th>Zweck</th>
                                                         <td>Speichert die Einstellungen der Besucher, die in der Cookie Box von Borlabs Cookie ausgewählt wurden.</td>
                                                     </tr>
-                                                    
-                                                
-                                                
+
+
+
                                                                                                     <tr>
                                                         <th>Cookie Name</th>
                                                         <td>borlabs-cookie</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Laufzeit</th>
                                                         <td>1 Jahr</td>
                                                     </tr>
                                                                                                 </table>
                                                                                         <table>
-                                                
+
                                                 <tr>
                                                     <th>Name</th>
                                                     <td>
@@ -905,7 +905,7 @@ Externe Medien<br />
 
 Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezogenen Daten erfasst.</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Datenschutzerklärung</th>
                                                         <td class=\"_brlbs-pp-url\">
@@ -917,24 +917,24 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                                 https://www.vgwort.de/hilfsseiten/datenschutz.html                                                            </a>
                                                         </td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Host(s)</th>
                                                         <td>*.vgwort.de</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Name</th>
                                                         <td>srp</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Laufzeit</th>
                                                         <td>Sitzung</td>
                                                     </tr>
                                                                                                 </table>
                                                                                         <table>
-                                                
+
                                                 <tr>
                                                     <th>Name</th>
                                                     <td>
@@ -952,7 +952,7 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                         <th>Zweck</th>
                                                         <td>Content Delivery Netzwerk und DNS Verwaltung</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Datenschutzerklärung</th>
                                                         <td class=\"_brlbs-pp-url\">
@@ -964,24 +964,24 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                                 https://www.cloudflare.com/privacypolicy/                                                            </a>
                                                         </td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Host(s)</th>
                                                         <td>www.cloudflare.com</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Name</th>
                                                         <td>__cfduid</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Laufzeit</th>
                                                         <td>1 Jahr</td>
                                                     </tr>
                                                                                                 </table>
                                                                                         <table>
-                                                
+
                                                 <tr>
                                                     <th>Name</th>
                                                     <td>
@@ -999,7 +999,7 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                         <th>Zweck</th>
                                                         <td>Wird für den Austria Insiderinfo WebShop verwendet, um zum Beispiel den Inhalt des Warenkorbes zu sichern oder um die Versandkosten abhängig von deinem Standort berechnen zu können.</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Datenschutzerklärung</th>
                                                         <td class=\"_brlbs-pp-url\">
@@ -1011,17 +1011,17 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                                 https://blog.austria-insiderinfo.com/rechtshinweis/#Shop_der_Austria_Insiderinfo                                                            </a>
                                                         </td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Host(s)</th>
                                                         <td>blog.austria-insiderinfo.com</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Name</th>
                                                         <td>tk_ai</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Laufzeit</th>
                                                         <td>Sitzung</td>
@@ -1104,7 +1104,7 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                             </label>
                                                         </td>
                                                     </tr>
-                                                    
+
                                                 <tr>
                                                     <th>Name</th>
                                                     <td>
@@ -1122,7 +1122,7 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                         <th>Zweck</th>
                                                         <td>Cookie von Matomo für Website-Analysen. Erzeugt statistische Daten darüber, wie der Besucher die Website nutzt.</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Datenschutzerklärung</th>
                                                         <td class=\"_brlbs-pp-url\">
@@ -1134,17 +1134,17 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                                 https://blog.austria-insiderinfo.com/rechtshinweis/                                                            </a>
                                                         </td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Host(s)</th>
                                                         <td>analytics.austria-insiderinfo.com</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Name</th>
                                                         <td>_pk_*.*</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Laufzeit</th>
                                                         <td>13 Monate</td>
@@ -1227,7 +1227,7 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                             </label>
                                                         </td>
                                                     </tr>
-                                                    
+
                                                 <tr>
                                                     <th>Name</th>
                                                     <td>
@@ -1245,7 +1245,7 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                         <th>Zweck</th>
                                                         <td>Wird verwendet, um OpenStreetMap-Inhalte zu entsperren.</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Datenschutzerklärung</th>
                                                         <td class=\"_brlbs-pp-url\">
@@ -1257,17 +1257,17 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                                 https://wiki.osmfoundation.org/wiki/Privacy_Policy                                                            </a>
                                                         </td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Host(s)</th>
                                                         <td>.openstreetmap.org</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Name</th>
                                                         <td>_osm_location, _osm_session, _osm_totp_token, _osm_welcome, _pk_id., _pk_ref., _pk_ses., qos_token</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Laufzeit</th>
                                                         <td>1-10 Jahre</td>
@@ -1298,7 +1298,7 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                             </label>
                                                         </td>
                                                     </tr>
-                                                    
+
                                                 <tr>
                                                     <th>Name</th>
                                                     <td>
@@ -1316,7 +1316,7 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                         <th>Zweck</th>
                                                         <td>Wird verwendet, um Twitter-Inhalte zu entsperren.</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Datenschutzerklärung</th>
                                                         <td class=\"_brlbs-pp-url\">
@@ -1328,17 +1328,17 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                                 https://twitter.com/privacy                                                            </a>
                                                         </td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Host(s)</th>
                                                         <td>.twimg.com, .twitter.com</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Name</th>
                                                         <td>__widgetsettings, local_storage_support_test</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Laufzeit</th>
                                                         <td>Unbegrenzt</td>
@@ -1369,7 +1369,7 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                             </label>
                                                         </td>
                                                     </tr>
-                                                    
+
                                                 <tr>
                                                     <th>Name</th>
                                                     <td>
@@ -1387,7 +1387,7 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                         <th>Zweck</th>
                                                         <td>Wird verwendet, um YouTube-Inhalte zu entsperren.</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Datenschutzerklärung</th>
                                                         <td class=\"_brlbs-pp-url\">
@@ -1399,17 +1399,17 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                                                                 https://policies.google.com/privacy                                                            </a>
                                                         </td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Host(s)</th>
                                                         <td>google.com</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Name</th>
                                                         <td>NID</td>
                                                     </tr>
-                                                    
+
                                                                                                     <tr>
                                                         <th>Cookie Laufzeit</th>
                                                         <td>6 Monate</td>
@@ -1426,9 +1426,9 @@ Deine IP-Adresse wird nur anonymisiert verarbeitet, es werden keine personenbezo
                     <p class=\"_brlbs-legal flex-fill\">
                                                     <a href=\"https://blog.austria-insiderinfo.com/rechtshinweis/\">
                                 Datenschutzerklärung                            </a>
-                            
+
                                                     <span class=\"_brlbs-separator\"></span>
-                            
+
                                                     <a href=\"https://blog.austria-insiderinfo.com/impressum/\">
                                 Impressum                            </a>
                                                 </p>
@@ -1461,7 +1461,7 @@ BorlabsCookieInitCheck();});</script> <script type=\"application/ld+json\">{\"@c
 <!--
 Performance optimized by W3 Total Cache. Learn more: https://www.boldgrid.com/w3-total-cache/
 
-Seiten-Caching mit disk: enhanced 
+Seiten-Caching mit disk: enhanced
 
 Served from: blog.austria-insiderinfo.com @ 2023-01-07 10:50:10 by W3 Total Cache
 -->",


### PR DESCRIPTION
Fix #12842 

The Markdown parser shouldn't be detecting italic text in the BBCode text converted from HTML lists anymore.