### PR TITLE
Force correct string casting for BaseUrl

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -334,7 +334,7 @@ class Profile
 		if (!$local_user_is_self) {
 			if (!$visitor_is_authenticated) {
 				// Remote follow is only available for local profiles
-				if (!empty($profile['nickname']) && strpos($profile_url, DI::baseUrl()) === 0) {
+				if (!empty($profile['nickname']) && strpos($profile_url, (string)DI::baseUrl()) === 0) {
 					$follow_link = 'profile/' . $profile['nickname'] . '/remote_follow';
 				}
 			} else {


### PR DESCRIPTION
Addresses https://github.com/friendica/friendica/issues/12487#issuecomment-1438623263

But I don't know why `strpos()` tries to cast the second parameter to an int value .. normally the type-hint `string` should have cast `DI::baseUrl()` automatically to a `string` value.