### PR TITLE
Issue 12701: Fix Markdown problems with Quotes

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1567,8 +1567,13 @@ class BBCode
 					"/\[[iz]mg\=(.*?)\](.*?)\[\/[iz]mg\]/ism",
 					function ($matches) use ($simple_html, $uriid) {
 						$matches[1] = self::proxyUrl($matches[1], $simple_html, $uriid);
-						$matches[2] = htmlspecialchars($matches[2], ENT_COMPAT);
-						return '<img src="' . $matches[1] . '" alt="' . $matches[2] . '" title="' . $matches[2] . '">';
+						$alt = htmlspecialchars($matches[2], ENT_COMPAT);
+						// Fix for Markdown problems wirh Diaspora, see issue #12701
+						if (($simple_html != self::DIASPORA) || strpos($matches[2], '"') === false) {
+							return '<img src="' . $matches[1] . '" alt="' . $alt . '" title="' . $alt . '">';
+						} else {
+							return '<img src="' . $matches[1] . '" alt="' . $alt . '">';
+						}
 					},
 					$text
 				);

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1568,7 +1568,7 @@ class BBCode
 					function ($matches) use ($simple_html, $uriid) {
 						$matches[1] = self::proxyUrl($matches[1], $simple_html, $uriid);
 						$alt = htmlspecialchars($matches[2], ENT_COMPAT);
-						// Fix for Markdown problems wirh Diaspora, see issue #12701
+						// Fix for Markdown problems with Diaspora, see issue #12701
 						if (($simple_html != self::DIASPORA) || strpos($matches[2], '"') === false) {
 							return '<img src="' . $matches[1] . '" alt="' . $alt . '" title="' . $alt . '">';
 						} else {

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -317,6 +317,14 @@ Karl Marx - Die ursprüngliche Akkumulation
 				'expected' => '&amp;`&`',
 				'text' => '&[code]&[/code]',
 			],
+			'bug-12701-quotes' => [
+				'expected' => '[![abc"fgh](https://domain.tld/photo/86912721086415cdc8e0a03226831581-1.png)](https://domain.tld/photos/user/image/86912721086415cdc8e0a03226831581)',
+				'text' => '[url=https://domain.tld/photos/user/image/86912721086415cdc8e0a03226831581][img=https://domain.tld/photo/86912721086415cdc8e0a03226831581-1.png]abc"fgh[/img][/url]'
+			],
+			'bug-12701-no-quotes' => [
+				'expected' => '[![abcfgh](https://domain.tld/photo/86912721086415cdc8e0a03226831581-1.png "abcfgh")](https://domain.tld/photos/user/image/86912721086415cdc8e0a03226831581)',
+				'text' => '[url=https://domain.tld/photos/user/image/86912721086415cdc8e0a03226831581][img=https://domain.tld/photo/86912721086415cdc8e0a03226831581-1.png]abcfgh[/img][/url]'
+			],
 		];
 	}
 
@@ -331,7 +339,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 	 *
 	 * @throws InternalServerErrorException
 	 */
-	public function testToMarkdown(string $expected, string $text, $for_diaspora = false)
+	public function testToMarkdown(string $expected, string $text, $for_diaspora = true)
 	{
 		$actual = BBCode::toMarkdown($text, $for_diaspora);
 


### PR DESCRIPTION
Fixes #12701
The Diaspora Markdown parser has got a problem with quotes in the "title" field. So we don't transmit them in case they contain a quote sign. This is no accessibility problem, since we always transmit the "alt" description and it is parsed by Diaspora.