### PR TITLE
Add visibility to user's statuses in Mastodon API

### DIFF
--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -28,6 +28,7 @@ use Friendica\Content\Text\BBCode;
 use Friendica\Core\Logger;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
+use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Model\Tag as TagModel;
@@ -291,8 +292,9 @@ class Status extends BaseFactory
 			$in_reply = [];
 		}
 
+		$aclFormatter = DI::aclFormatter();
 		$delivery_data   = $uid != $item['uid'] ? null : new FriendicaDeliveryData($item['delivery_queue_count'], $item['delivery_queue_done'], $item['delivery_queue_failed']);
-		$visibility_data = $uid != $item['uid'] ? null : new FriendicaVisibility($item['allow_cid'], $item['deny_cid'], $item['allow_gid'], $item['deny_gid']);
+		$visibility_data = $uid != $item['uid'] ? null : new FriendicaVisibility($aclFormatter->expand($item['allow_cid']), $aclFormatter->expand($item['deny_cid']), $aclFormatter->expand($item['allow_gid']), $aclFormatter->expand($item['deny_gid']));
 		$friendica       = new FriendicaExtension($item['title'], $item['changed'], $item['commented'], $item['received'], $counts->dislikes, $delivery_data, $visibility_data);
 
 		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica, $quote, $poll);

--- a/src/Object/Api/Mastodon/Status/FriendicaExtension.php
+++ b/src/Object/Api/Mastodon/Status/FriendicaExtension.php
@@ -45,14 +45,18 @@ class FriendicaExtension extends BaseDataTransferObject
 	/** @var string|null (Datetime) */
 	protected $received_at;
 
-	/** @var FriendicaDeliveryData */
+	/** @var FriendicaDeliveryData|null */
 	protected $delivery_data;
 	/** @var int */
 	protected $dislikes_count;
+	/**
+	 * @var FriendicaVisibility|null
+	 */
+	protected $visibility;
 
 
 	/**
-	 * Creates a status count object
+	 * Creates a FriendicaExtension object
 	 *
 	 * @param string $title
 	 * @param string|null $changed_at
@@ -60,7 +64,8 @@ class FriendicaExtension extends BaseDataTransferObject
 	 * @param string|null $edited_at
 	 * @param string|null $received_at
 	 * @param int $dislikes_count
-	 * @param FriendicaDeliveryData $delivery_data
+	 * @param FriendicaDeliveryData|null $delivery_data
+	 * @param FriendicaVisibility|null $visibility
 	 */
 	public function __construct(
 		string $title,
@@ -68,7 +73,8 @@ class FriendicaExtension extends BaseDataTransferObject
 		?string $commented_at,
 		?string $received_at,
 		int $dislikes_count,
-		FriendicaDeliveryData $delivery_data
+		?FriendicaDeliveryData $delivery_data,
+		?FriendicaVisibility $visibility
 	) {
 		$this->title          = $title;
 		$this->changed_at     = $changed_at ? DateTimeFormat::utc($changed_at, DateTimeFormat::JSON) : null;
@@ -76,6 +82,7 @@ class FriendicaExtension extends BaseDataTransferObject
 		$this->received_at    = $received_at ? DateTimeFormat::utc($received_at, DateTimeFormat::JSON) : null;
 		$this->delivery_data  = $delivery_data;
 		$this->dislikes_count = $dislikes_count;
+		$this->visibility     = $visibility;
 	}
 
 	/**

--- a/src/Object/Api/Mastodon/Status/FriendicaVisibility.php
+++ b/src/Object/Api/Mastodon/Status/FriendicaVisibility.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2023, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Object\Api\Mastodon\Status;
+
+use Friendica\BaseDataTransferObject;
+
+/**
+ * Class FriendicaVisibility
+ *
+ * Fields for the user's visibility settings on a post if they own that post
+ *
+ * @see https://docs.joinmastodon.org/entities/status
+ */
+class FriendicaVisibility extends BaseDataTransferObject
+{
+	/** @var string|null */
+	protected $allow_cid;
+	/** @var string|null */
+	protected $deny_cid;
+	/** @var string|null */
+	protected $allow_gid;
+	/** @var string|null */
+	protected $deny_gid;
+
+	public function __construct(?string $allow_cid, ?string $deny_cid, ?string $allow_gid, ?string $deny_gid)
+	{
+		$this->allow_cid = $allow_cid;
+		$this->deny_cid  = $deny_cid;
+		$this->allow_gid = $allow_gid;
+		$this->deny_gid  = $deny_gid;
+	}
+}

--- a/src/Object/Api/Mastodon/Status/FriendicaVisibility.php
+++ b/src/Object/Api/Mastodon/Status/FriendicaVisibility.php
@@ -32,16 +32,16 @@ use Friendica\BaseDataTransferObject;
  */
 class FriendicaVisibility extends BaseDataTransferObject
 {
-	/** @var string|null */
+	/** @var array */
 	protected $allow_cid;
-	/** @var string|null */
+	/** @var array */
 	protected $deny_cid;
-	/** @var string|null */
+	/** @var array */
 	protected $allow_gid;
-	/** @var string|null */
+	/** @var array */
 	protected $deny_gid;
 
-	public function __construct(?string $allow_cid, ?string $deny_cid, ?string $allow_gid, ?string $deny_gid)
+	public function __construct(array $allow_cid, array $deny_cid, array $allow_gid, array $deny_gid)
 	{
 		$this->allow_cid = $allow_cid;
 		$this->deny_cid  = $deny_cid;


### PR DESCRIPTION
This commit adds a new FriendicaExtension item for the visibility data for a user's post. This has the allowed/denied CIDs/GIDs for a post. It is null if this isn't a user's post. The underlying data is null as well if it isn't a user's post but this just returns null for the whole field. This change also makes it so that delivery data is also now null if this isn't a user's post. Previously the structure was returned but with all null values for each of the counts.