### PR TITLE
Issue 12842: Use BBCode elements that are Markdown agnostic

### DIFF
--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -283,7 +283,7 @@ class HTML
 
 			self::tagToBBCode($doc, 'ul', [], "[ul]", "\n[/ul]");
 			self::tagToBBCode($doc, 'ol', [], "[ol]", "\n[/ol]");
-			self::tagToBBCode($doc, 'li', [], "\n[*]", "");
+			self::tagToBBCode($doc, 'li', [], "\n[li]", "[/li]");
 
 			self::tagToBBCode($doc, 'hr', [], "[hr]", "");
 

--- a/tests/src/Content/Text/HTMLTest.php
+++ b/tests/src/Content/Text/HTMLTest.php
@@ -91,18 +91,18 @@ its surprisingly good",
 			'bug-12842-ul-new-lines' => [
 				'expectedBBCode' => 'This is:
 [ul]
-[*]some
-[*]amazing
-[*]list
+[li]some[/li]
+[li]amazing[/li]
+[li]list[/li]
 [/ul]',
 				'html'=> '<p>This is:</p><ul><li>some</li><li>amazing</li><li>list</li></ul>',
 			],
 			'bug-12842-ol-new-lines' => [
 				'expectedBBCode' => 'This is:
 [ol]
-[*]some
-[*]amazing
-[*]list
+[li]some[/li]
+[li]amazing[/li]
+[li]list[/li]
 [/ol]',
 				'html'=> '<p>This is:</p><ol><li>some</li><li>amazing</li><li>list</li></ol>',
 			],


### PR DESCRIPTION
Fixes #12842
The BBCode element `[*] ...` is misinterpreted by the Markdown converter. To avoid this, we simply use the alternative element `[li]...[/li]` that doesn't have got this problem.