### PR TITLE
Handles warning: Undefined array key "gravity"

### DIFF
--- a/src/Module/Post/Edit.php
+++ b/src/Module/Post/Edit.php
@@ -83,7 +83,7 @@ class Edit extends BaseModule
 		}
 
 		$fields = [
-			'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid',
+			'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid', 'gravity',
 			'body', 'title', 'uri-id', 'wall', 'post-type', 'guid'
 		];
 


### PR DESCRIPTION
Handles `[WARNING]: E_WARNING: Undefined array key "gravity" {"code":2,"message":"Undefined array key \"gravity\"","file":"/src/Model/Post/Media.php","line":1069}`