### PR TITLE
Modify dropzones css: Correct spacing Text input Comments

### DIFF
--- a/view/theme/frio/css/dropzone.frio.css
+++ b/view/theme/frio/css/dropzone.frio.css
@@ -207,7 +207,7 @@
   min-height: 150px;
   border: 1px solid rgba(0, 0, 0, 0.3);
   background: white;
-  padding: 2px 2px;
+  padding: 10px 10px;
 }
 .dropzone.dz-clickable {
   cursor: pointer;


### PR DESCRIPTION
The spacing on the left is always specified with padding: 10px 10px; in the other editors. The text input does not look so nice at the moment.