### PR TITLE
Don't show permissions from permissiongroups on comments

### DIFF
--- a/src/Module/PermissionTooltip.php
+++ b/src/Module/PermissionTooltip.php
@@ -22,6 +22,7 @@
 namespace Friendica\Module;
 
 use Friendica\Core\Hook;
+use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
@@ -32,7 +33,6 @@ use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
 use Friendica\Network\HTTPException;
-use Friendica\Protocol\ActivityPub;
 
 /**
  * Outputs the permission tooltip HTML content for the provided item, photo or event id.
@@ -51,8 +51,21 @@ class PermissionTooltip extends \Friendica\BaseModule
 
 		$condition = ['id' => $referenceId, 'uid' => [0, DI::userSession()->getLocalUserId()]];
 		if ($type == 'item') {
-			$fields = ['uid', 'psid', 'private', 'uri-id'];
-			$model = Post::selectFirst($fields, $condition);
+			$fields = ['uid', 'psid', 'private', 'uri-id', 'origin', 'network'];
+			$model = Post::selectFirst($fields, $condition, ['order' => ['uid' => true]]);
+
+			if ($model['origin'] || ($model['network'] != Protocol::ACTIVITYPUB)) {
+				$permissionSet = DI::permissionSet()->selectOneById($model['psid'], $model['uid']);
+				$model['allow_cid'] = $permissionSet->allow_cid;
+				$model['allow_gid'] = $permissionSet->allow_gid;
+				$model['deny_cid']  = $permissionSet->deny_cid;
+				$model['deny_gid']  = $permissionSet->deny_gid;
+			} else {
+				$model['allow_cid'] = [];
+				$model['allow_gid'] = [];
+				$model['deny_cid']  = [];
+				$model['deny_gid']  = [];
+			}
 		} else {
 			$fields = ['uid', 'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid'];
 			$model = DBA::selectFirst($type, $fields, $condition);
@@ -64,14 +77,6 @@ class PermissionTooltip extends \Friendica\BaseModule
 
 		if (!DBA::isResult($model)) {
 			throw new HttpException\NotFoundException(DI::l10n()->t('Model not found'));
-		}
-
-		if (isset($model['psid'])) {
-			$permissionSet = DI::permissionSet()->selectOneById($model['psid'], $model['uid']);
-			$model['allow_cid'] = $permissionSet->allow_cid;
-			$model['allow_gid'] = $permissionSet->allow_gid;
-			$model['deny_cid']  = $permissionSet->deny_cid;
-			$model['deny_gid']  = $permissionSet->deny_gid;
 		}
 
 		// Kept for backwards compatiblity
@@ -161,11 +166,10 @@ class PermissionTooltip extends \Friendica\BaseModule
 		}
 
 		if (!empty($l)) {
-			echo $o . implode(', ', $l);
+			System::httpExit($o . implode(', ', $l));
 		} else {
-			echo $o . $receivers;
+			System::httpExit($o . $receivers);;
 		}
-		System::exit();
 	}
 
 	/**


### PR DESCRIPTION
On comments to our own posts we shouldn't display our permissionset but the real receivers of that comment.