### PR TITLE
Fix sending dms with oauth user

### DIFF
--- a/mod/message.php
+++ b/mod/message.php
@@ -69,12 +69,13 @@ function message_post(App $a)
 		return;
 	}
 
+	$sender_id = DI::userSession()->getLocalUserId();
 	$replyto   = !empty($_REQUEST['replyto'])   ? trim($_REQUEST['replyto'])                   : '';
 	$subject   = !empty($_REQUEST['subject'])   ? trim($_REQUEST['subject'])                   : '';
 	$body      = !empty($_REQUEST['body'])      ? Strings::escapeHtml(trim($_REQUEST['body'])) : '';
 	$recipient = !empty($_REQUEST['recipient']) ? intval($_REQUEST['recipient'])               : 0;
 
-	$ret = Mail::send($recipient, $body, $subject, $replyto);
+	$ret = Mail::send($sender_id, $recipient, $body, $subject, $replyto);
 	$norecip = false;
 
 	switch ($ret) {

--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -124,7 +124,7 @@ class Mail
 	 * @return int
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function send(int $recipient = 0, string $body = '', string $subject = '', string $replyto = ''): int
+	public static function send(string $uid, int $recipient = 0, string $body = '', string $subject = '', string $replyto = ''): int
 	{
 		$a = DI::app();
 
@@ -136,12 +136,12 @@ class Mail
 			$subject = DI::l10n()->t('[no subject]');
 		}
 
-		$me = DBA::selectFirst('contact', [], ['uid' => DI::userSession()->getLocalUserId(), 'self' => true]);
+		$me = DBA::selectFirst('contact', [], ['uid' => $uid, 'self' => true]);
 		if (!DBA::isResult($me)) {
 			return -2;
 		}
 
-		$contacts = ACL::getValidMessageRecipientsForUser(DI::userSession()->getLocalUserId());
+		$contacts = ACL::getValidMessageRecipientsForUser($uid);
 
 		$contactIndex = array_search($recipient, array_column($contacts, 'id'));
 		if ($contactIndex === false) {
@@ -150,7 +150,7 @@ class Mail
 
 		$contact = $contacts[$contactIndex];
 
-		Photo::setPermissionFromBody($body, DI::userSession()->getLocalUserId(), $me['id'],  '<' . $contact['id'] . '>', '', '', '');
+		Photo::setPermissionFromBody($body, $uid, $me['id'], '<' . $contact['id'] . '>', '', '', '');
 
 		$guid = System::createUUID();
 		$uri = Item::newURI($guid);
@@ -163,7 +163,7 @@ class Mail
 		if (strlen($replyto)) {
 			$reply = true;
 			$condition = ["`uid` = ? AND (`uri` = ? OR `parent-uri` = ?)",
-				DI::userSession()->getLocalUserId(), $replyto, $replyto];
+				$uid, $replyto, $replyto];
 			$mail = DBA::selectFirst('mail', ['convid'], $condition);
 			if (DBA::isResult($mail)) {
 				$convid = $mail['convid'];
@@ -176,7 +176,7 @@ class Mail
 			$conv_guid = System::createUUID();
 			$convuri = $contact['addr'] . ':' . $conv_guid;
 
-			$fields = ['uid' => DI::userSession()->getLocalUserId(), 'guid' => $conv_guid, 'creator' => $me['addr'],
+			$fields = ['uid' => $uid, 'guid' => $conv_guid, 'creator' => $me['addr'],
 				'created' => DateTimeFormat::utcNow(), 'updated' => DateTimeFormat::utcNow(),
 				'subject' => $subject, 'recips' => $contact['addr'] . ';' . $me['addr']];
 			if (DBA::insert('conv', $fields)) {
@@ -195,7 +195,7 @@ class Mail
 
 		$post_id = self::insert(
 			[
-				'uid' => DI::userSession()->getLocalUserId(),
+				'uid' => $uid,
 				'guid' => $guid,
 				'convid' => $convid,
 				'from-name' => $me['name'],
@@ -210,7 +210,8 @@ class Mail
 				'uri' => $uri,
 				'parent-uri' => $replyto,
 				'created' => DateTimeFormat::utcNow()
-			], false
+			],
+			false
 		);
 
 		/**
@@ -231,7 +232,7 @@ class Mail
 				foreach ($images as $image) {
 					$image_rid = Photo::ridFromURI($image);
 					if (!empty($image_rid)) {
-						Photo::update(['allow-cid' => '<' . $recipient . '>'], ['resource-id' => $image_rid, 'album' => 'Wall Photos', 'uid' => DI::userSession()->getLocalUserId()]);
+						Photo::update(['allow-cid' => '<' . $recipient . '>'], ['resource-id' => $image_rid, 'album' => 'Wall Photos', 'uid' => $uid]);
 					}
 				}
 			}
@@ -311,7 +312,8 @@ class Mail
 				'parent-uri' => $me['url'],
 				'created' => DateTimeFormat::utcNow(),
 				'unknown' => 1
-			], false
+			],
+			false
 		);
 
 		return 0;

--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -117,6 +117,7 @@ class Mail
 	/**
 	 * Send private message
 	 *
+	 * @param integer $sender_uid the user id of the sender, default 0
 	 * @param integer $recipient recipient id, default 0
 	 * @param string  $body      message body, default empty
 	 * @param string  $subject   message subject, default empty
@@ -124,7 +125,7 @@ class Mail
 	 * @return int
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function send(string $uid, int $recipient = 0, string $body = '', string $subject = '', string $replyto = ''): int
+	public static function send(int $sender_uid = 0, int $recipient = 0, string $body = '', string $subject = '', string $replyto = ''): int
 	{
 		$a = DI::app();
 
@@ -136,12 +137,12 @@ class Mail
 			$subject = DI::l10n()->t('[no subject]');
 		}
 
-		$me = DBA::selectFirst('contact', [], ['uid' => $uid, 'self' => true]);
+		$me = DBA::selectFirst('contact', [], ['uid' => $sender_uid, 'self' => true]);
 		if (!DBA::isResult($me)) {
 			return -2;
 		}
 
-		$contacts = ACL::getValidMessageRecipientsForUser($uid);
+		$contacts = ACL::getValidMessageRecipientsForUser($sender_uid);
 
 		$contactIndex = array_search($recipient, array_column($contacts, 'id'));
 		if ($contactIndex === false) {
@@ -150,7 +151,7 @@ class Mail
 
 		$contact = $contacts[$contactIndex];
 
-		Photo::setPermissionFromBody($body, $uid, $me['id'], '<' . $contact['id'] . '>', '', '', '');
+		Photo::setPermissionFromBody($body, $sender_uid, $me['id'], '<' . $contact['id'] . '>', '', '', '');
 
 		$guid = System::createUUID();
 		$uri = Item::newURI($guid);
@@ -163,7 +164,7 @@ class Mail
 		if (strlen($replyto)) {
 			$reply = true;
 			$condition = ["`uid` = ? AND (`uri` = ? OR `parent-uri` = ?)",
-				$uid, $replyto, $replyto];
+				$sender_uid, $replyto, $replyto];
 			$mail = DBA::selectFirst('mail', ['convid'], $condition);
 			if (DBA::isResult($mail)) {
 				$convid = $mail['convid'];
@@ -176,7 +177,7 @@ class Mail
 			$conv_guid = System::createUUID();
 			$convuri = $contact['addr'] . ':' . $conv_guid;
 
-			$fields = ['uid' => $uid, 'guid' => $conv_guid, 'creator' => $me['addr'],
+			$fields = ['uid' => $sender_uid, 'guid' => $conv_guid, 'creator' => $me['addr'],
 				'created' => DateTimeFormat::utcNow(), 'updated' => DateTimeFormat::utcNow(),
 				'subject' => $subject, 'recips' => $contact['addr'] . ';' . $me['addr']];
 			if (DBA::insert('conv', $fields)) {
@@ -195,7 +196,7 @@ class Mail
 
 		$post_id = self::insert(
 			[
-				'uid' => $uid,
+				'uid' => $sender_uid,
 				'guid' => $guid,
 				'convid' => $convid,
 				'from-name' => $me['name'],
@@ -232,7 +233,7 @@ class Mail
 				foreach ($images as $image) {
 					$image_rid = Photo::ridFromURI($image);
 					if (!empty($image_rid)) {
-						Photo::update(['allow-cid' => '<' . $recipient . '>'], ['resource-id' => $image_rid, 'album' => 'Wall Photos', 'uid' => $uid]);
+						Photo::update(['allow-cid' => '<' . $recipient . '>'], ['resource-id' => $image_rid, 'album' => 'Wall Photos', 'uid' => $sender_uid]);
 					}
 				}
 			}

--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -117,7 +117,7 @@ class Mail
 	/**
 	 * Send private message
 	 *
-	 * @param integer $sender_uid the user id of the sender, default 0
+	 * @param integer $sender_uid the user id of the sender
 	 * @param integer $recipient recipient id, default 0
 	 * @param string  $body      message body, default empty
 	 * @param string  $subject   message subject, default empty
@@ -125,7 +125,7 @@ class Mail
 	 * @return int
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function send(int $sender_uid = 0, int $recipient = 0, string $body = '', string $subject = '', string $replyto = ''): int
+	public static function send(int $sender_uid, int $recipient = 0, string $body = '', string $subject = '', string $replyto = ''): int
 	{
 		$a = DI::app();
 

--- a/src/Module/Api/Twitter/DirectMessages/NewDM.php
+++ b/src/Module/Api/Twitter/DirectMessages/NewDM.php
@@ -83,7 +83,7 @@ class NewDM extends BaseApi
 
 		$cdata = Contact::getPublicAndUserContactID($cid, $uid);
 
-		$id = Mail::send($cdata['user'], $request['text'], $sub, $replyto);
+		$id = Mail::send($uid, $cdata['user'], $request['text'], $sub, $replyto);
 
 		if ($id > -1) {
 			$ret = $this->directMessage->createFromMailId($id, $uid, $this->getRequestValue($request, 'getText', ''));


### PR DESCRIPTION
The Direct Message creation endpoint calls into the Mail model objects. These were using direct queries of the Session UID. Unfortunately in the case of OAuth this isn't set. This PR changes the Mail::send function to require the UID of the sender be provided. It changes the other location in the code where Mail::send was used as well.

The phpcs threw several "errors" on the message.php file that were not related to the one line added. I did not run phpcbf to change those in order to make my changes more clear.