### PR TITLE
Set different permissions for comments via API

### DIFF
--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -548,7 +548,7 @@ class Item
 				$item['allow_cid'] = '';
 				$item['allow_gid'] = '';
 			}
-		} elseif ($setPermissions && ($item['gravity'] == ItemModel::GRAVITY_PARENT)) {
+		} elseif ($setPermissions) {
 			if (empty($receivers)) {
 				// For security reasons direct posts without any receiver will be posts to yourself
 				$self = Contact::selectFirst(['id'], ['uid' => $item['uid'], 'self' => true]);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -892,6 +892,8 @@ class Item
 			$item['post-type'] = empty($item['title']) ? self::PT_NOTE : self::PT_ARTICLE;
 		}
 
+		$defined_permissions = isset($item['allow_cid']) && isset($item['allow_gid']) && isset($item['deny_cid']) && isset($item['deny_gid']) && isset($item['private']);
+
 		$item['wall']          = intval($item['wall'] ?? 0);
 		$item['extid']         = trim($item['extid'] ?? '');
 		$item['author-name']   = trim($item['author-name'] ?? '');
@@ -993,7 +995,7 @@ class Item
 			$item['wall']          = $toplevel_parent['wall'];
 
 			// Reshares have to keep their permissions to allow forums to work
-			if (!$item['origin'] || ($item['verb'] != Activity::ANNOUNCE)) {
+			if (!$defined_permissions && (!$item['origin'] || ($item['verb'] != Activity::ANNOUNCE))) {
 				$item['allow_cid']     = $toplevel_parent['allow_cid'];
 				$item['allow_gid']     = $toplevel_parent['allow_gid'];
 				$item['deny_cid']      = $toplevel_parent['deny_cid'];
@@ -1016,7 +1018,7 @@ class Item
 			 * This differs from the above settings as it subtly allows comments from
 			 * email correspondents to be private even if the overall thread is not.
 			 */
-			if ($toplevel_parent['private']) {
+			if (!$defined_permissions && $toplevel_parent['private']) {
 				$item['private'] = $toplevel_parent['private'];
 			}
 
@@ -1063,7 +1065,7 @@ class Item
 		}
 
 		// ACL settings
-		if (!empty($item['allow_cid'] . $item['allow_gid'] . $item['deny_cid'] . $item['deny_gid'])) {
+		if (!$defined_permissions && !empty($item['allow_cid'] . $item['allow_gid'] . $item['deny_cid'] . $item['deny_gid'])) {
 			$item['private'] = self::PRIVATE;
 		}
 

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -266,15 +266,14 @@ class Statuses extends BaseApi
 		}
 
 		if ($request['in_reply_to_id']) {
-			$parent = Post::selectFirst(['uri', 'private'], ['uri-id' => $request['in_reply_to_id'], 'uid' => [0, $uid]]);
+			$parent = Post::selectFirst(['uri'], ['uri-id' => $request['in_reply_to_id'], 'uid' => [0, $uid]]);
+			if (empty($parent)) {
+				throw new HTTPException\NotFoundException('Item with URI ID ' . $request['in_reply_to_id'] . ' not found for user ' . $uid . '.');
+			}
 
 			$item['thr-parent']  = $parent['uri'];
 			$item['gravity']     = Item::GRAVITY_COMMENT;
 			$item['object-type'] = Activity\ObjectType::COMMENT;
-
-			if (in_array($parent['private'], [Item::UNLISTED, Item::PUBLIC]) && ($item['private'] == Item::PRIVATE)) {
-				throw new HTTPException\NotImplementedException('Private replies for public posts are not implemented.');
-			}
 		} else {
 			self::checkThrottleLimit();
 


### PR DESCRIPTION
We are now able to answer via API and to set a different permission for the answer.