### PR TITLE
Don't search for contacts on blocked or failed systems

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2023.03-rc (Giant Rhubarb)
--- DB_UPDATE_VERSION 1517
+-- DB_UPDATE_VERSION 1518
 -- ------------------------------------------
 
 
@@ -2849,7 +2849,9 @@ CREATE VIEW `account-view` AS SELECT
 	`apcontact`.`statuses_count` AS `ap-statuses_count`,
 	`gserver`.`site_name` AS `site_name`,
 	`gserver`.`platform` AS `platform`,
-	`gserver`.`version` AS `version`
+	`gserver`.`version` AS `version`,
+	`gserver`.`blocked` AS `server-blocked`,
+	`gserver`.`failed` AS `server-failed`
 	FROM `contact`
 			LEFT JOIN `item-uri` ON `item-uri`.`id` = `contact`.`uri-id`
 			LEFT JOIN `apcontact` ON `apcontact`.`uri-id` = `contact`.`uri-id`
@@ -2953,7 +2955,9 @@ CREATE VIEW `account-user-view` AS SELECT
 	`apcontact`.`statuses_count` AS `ap-statuses_count`,
 	`gserver`.`site_name` AS `site_name`,
 	`gserver`.`platform` AS `platform`,
-	`gserver`.`version` AS `version`
+	`gserver`.`version` AS `version`,
+	`gserver`.`blocked` AS `server-blocked`,
+	`gserver`.`failed` AS `server-failed`
 	FROM `contact` AS `ucontact`
 			INNER JOIN `contact` ON `contact`.`uri-id` = `ucontact`.`uri-id` AND `contact`.`uid` = 0
 			LEFT JOIN `item-uri` ON `item-uri`.`id` = `ucontact`.`uri-id`

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -79,7 +79,7 @@ class Search
 				$user_data['url'] ?? '',
 				$user_data['photo'] ?? '',
 				$user_data['network'] ?? '',
-				$contactDetails['id'] ?? 0,
+				$contactDetails['cid'] ?? 0,
 				$user_data['id'] ?? 0,
 				$user_data['tags'] ?? ''
 			);
@@ -146,7 +146,7 @@ class Search
 				$profile['photo'] ?? '',
 				Protocol::DFRN,
 				$contactDetails['cid'] ?? 0,
-				0,
+				$contactDetails['zid'] ?? 0,
 				$profile['tags'] ?? ''
 			);
 
@@ -179,12 +179,12 @@ class Search
 			$result = new ContactResult(
 				$contact['name'],
 				$contact['addr'],
-				$contact['addr'],
+				$contact['addr'] ?: $contact['url'],
 				$contact['url'],
 				$contact['photo'],
 				$contact['network'],
-				$contact['cid'] ?? 0,
-				$contact['zid'] ?? 0,
+				0,
+				$contact['pid'],
 				$contact['keywords']
 			);
 

--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -171,7 +171,7 @@ class Search
 	{
 		Logger::info('Searching', ['search' => $search, 'type' => $type, 'start' => $start, 'itempage' => $itemPage]);
 
-		$contacts = Contact::searchByName($search, $type == self::TYPE_FORUM ? 'community' : '');
+		$contacts = Contact::searchByName($search, $type == self::TYPE_FORUM ? 'community' : '', true);
 
 		$resultList = new ResultList($start, $itemPage, count($contacts));
 
@@ -226,7 +226,7 @@ class Search
 
 		// check if searching in the local global contact table is enabled
 		if (DI::config()->get('system', 'poco_local_search')) {
-			$return = Contact::searchByName($search, $mode);
+			$return = Contact::searchByName($search, $mode, true);
 		} else {
 			$p = $page > 1 ? 'p=' . $page : '';
 			$curlResult = DI::httpClient()->get(self::getGlobalDirectory() . '/search/people?' . $p . '&q=' . urlencode($search), HttpClientAccept::JSON);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -3529,7 +3529,14 @@ class Contact
 			$networks[] = Protocol::OSTATUS;
 		}
 
-		$condition = ['network' => $networks, 'failed' => false, 'deleted' => false, 'uid' => $uid];
+		$condition = [
+			'network'        => $networks,
+			'server-failed'  => false,
+			'server-blocked' => false,
+			'failed'         => false,
+			'deleted'        => false,
+			'uid'            => $uid
+		];
 
 		if ($uid == 0) {
 			$condition['blocked'] = false;
@@ -3556,7 +3563,7 @@ class Contact
 			["(NOT `unsearchable` OR `nurl` IN (SELECT `nurl` FROM `owner-view` WHERE `publish` OR `net-publish`))
 			AND (`addr` LIKE ? OR `name` LIKE ? OR `nick` LIKE ?)", $search, $search, $search]);
 
-		return self::selectToArray([], $condition, $params);
+		return DBA::selectToArray('account-user-view', [], $condition, $params);
 	}
 
 	/**

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -3504,16 +3504,17 @@ class Contact
 	/**
 	 * Search contact table by nick or name
 	 *
-	 * @param string $search Name or nick
-	 * @param string $mode   Search mode (e.g. "community")
-	 * @param int    $uid    User ID
-	 * @param int    $limit  Maximum amount of returned values
-	 * @param int    $offset Limit offset
+	 * @param string $search       Name or nick
+	 * @param string $mode         Search mode (e.g. "community")
+	 * @param bool   $show_blocked Show users from blocked servers. Default is false
+	 * @param int    $uid          User ID
+	 * @param int    $limit        Maximum amount of returned values
+	 * @param int    $offset       Limit offset
 	 *
 	 * @return array with search results
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function searchByName(string $search, string $mode = '', int $uid = 0, int $limit = 0, int $offset = 0): array
+	public static function searchByName(string $search, string $mode = '', bool $show_blocked = false, int $uid = 0, int $limit = 0, int $offset = 0): array
 	{
 		if (empty($search)) {
 			return [];
@@ -3532,12 +3533,15 @@ class Contact
 		$condition = [
 			'network'        => $networks,
 			'server-failed'  => false,
-			'server-blocked' => false,
 			'failed'         => false,
 			'deleted'        => false,
 			'unsearchable'   => false,
 			'uid'            => $uid
 		];
+
+		if (!$show_blocked) {
+			$condition['server-blocked'] = true;
+		}
 
 		if ($uid == 0) {
 			$condition['blocked'] = false;

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -3535,6 +3535,7 @@ class Contact
 			'server-blocked' => false,
 			'failed'         => false,
 			'deleted'        => false,
+			'unsearchable'   => false,
 			'uid'            => $uid
 		];
 
@@ -3560,8 +3561,7 @@ class Contact
 		}
 
 		$condition = DBA::mergeConditions($condition,
-			["(NOT `unsearchable` OR `nurl` IN (SELECT `nurl` FROM `owner-view` WHERE `publish` OR `net-publish`))
-			AND (`addr` LIKE ? OR `name` LIKE ? OR `nick` LIKE ?)", $search, $search, $search]);
+			["(`addr` LIKE ? OR `name` LIKE ? OR `nick` LIKE ?)", $search, $search, $search]);
 
 		return DBA::selectToArray('account-user-view', [], $condition, $params);
 	}

--- a/src/Module/Api/Mastodon/Accounts/Search.php
+++ b/src/Module/Api/Mastodon/Accounts/Search.php
@@ -60,7 +60,7 @@ class Search extends BaseApi
 		}
 
 		if (empty($accounts)) {
-			$contacts = Contact::searchByName($request['q'], '', $request['following'] ? $uid : 0, $request['limit'], $request['offset']);
+			$contacts = Contact::searchByName($request['q'], '', false, $request['following'] ? $uid : 0, $request['limit'], $request['offset']);
 			foreach ($contacts as $contact) {
 				$accounts[] = DI::mstdnAccount()->createFromContactId($contact['id'], $uid);
 			}

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -115,7 +115,7 @@ class Search extends BaseApi
 		}
 
 		$accounts = [];
-		foreach (Contact::searchByName($q, '', $following ? $uid : 0, $limit, $offset) as $contact) {
+		foreach (Contact::searchByName($q, '', $following ? $uid : 0, false, $limit, $offset) as $contact) {
 			$accounts[] = DI::mstdnAccount()->createFromContactId($contact['id'], $uid);
 		}
 

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -55,7 +55,7 @@
 use Friendica\Database\DBA;
 
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1517);
+	define('DB_UPDATE_VERSION', 1518);
 }
 
 return [

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -1009,6 +1009,8 @@
 			"site_name" => ["gserver", "site_name"],
 			"platform" => ["gserver", "platform"],
 			"version" => ["gserver", "version"],
+			"server-blocked" => ["gserver", "blocked"],
+			"server-failed" => ["gserver", "failed"],
 		],
 		"query" => "FROM `contact`
 			LEFT JOIN `item-uri` ON `item-uri`.`id` = `contact`.`uri-id`
@@ -1111,6 +1113,8 @@
 			"site_name" => ["gserver", "site_name"],
 			"platform" => ["gserver", "platform"],
 			"version" => ["gserver", "version"],
+			"server-blocked" => ["gserver", "blocked"],
+			"server-failed" => ["gserver", "failed"],
 		],
 		"query" => "FROM `contact` AS `ucontact`
 			INNER JOIN `contact` ON `contact`.`uri-id` = `ucontact`.`uri-id` AND `contact`.`uid` = 0

--- a/update.php
+++ b/update.php
@@ -1315,3 +1315,14 @@ function update_1516()
 
 	return Update::SUCCESS;
 }
+
+function update_1518()
+{
+	$users = DBA::select('user', ['uid']);
+	while ($user = DBA::fetch($users)) {
+		Contact::updateSelfFromUserID($user['uid']);
+	}
+	DBA::close($users);
+
+	return Update::SUCCESS;
+}


### PR DESCRIPTION
Helps with #12555 by preventing the search for accounts on blocked or failed servers.