### PR TITLE
Add posix_kill() SIGTERM for Friendica

### DIFF
--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -76,8 +76,8 @@ DI::config()->reload();
 if (empty(DI::config()->get('system', 'pidfile'))) {
 	die(<<<TXT
 Please set system.pidfile in config/local.config.php. For example:
-    
-    'system' => [ 
+
+    'system' => [
         'pidfile' => '/path/to/daemon.pid',
     ],
 TXT
@@ -247,5 +247,6 @@ while (true) {
 }
 
 function shutdown() {
+	posix_kill(posix_getpid(), SIGTERM);
 	posix_kill(posix_getpid(), SIGHUP);
 }


### PR DESCRIPTION
Adding `SIGTERM` as shutdown event.

see https://docs.docker.com/engine/reference/commandline/stop/ for example why :-)