### PR TITLE
Adapt logging & temppath creation

### DIFF
--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -523,19 +523,18 @@ class System
 	 * Checks if a given directory is usable for the system
 	 *
 	 * @param      $directory
-	 * @param bool $check_writable
 	 *
 	 * @return boolean the directory is usable
 	 */
-	private static function isDirectoryUsable($directory, $check_writable = true)
+	private static function isDirectoryUsable($directory): bool
 	{
-		if ($directory == '') {
+		if (empty($directory)) {
 			Logger::warning('Directory is empty. This shouldn\'t happen.');
 			return false;
 		}
 
 		if (!file_exists($directory)) {
-			Logger::warning('Path does not exist', ['directory' => $directory, 'user' => static::getUser()]);
+			Logger::info('Path does not exist', ['directory' => $directory, 'user' => static::getUser()]);
 			return false;
 		}
 
@@ -549,7 +548,7 @@ class System
 			return false;
 		}
 
-		if ($check_writable && !is_writable($directory)) {
+		if (!is_writable($directory)) {
 			Logger::warning('Path is not writable', ['directory' => $directory, 'user' => static::getUser()]);
 			return false;
 		}
@@ -601,7 +600,7 @@ class System
 			$new_temppath = $temppath . "/" . DI::baseUrl()->getHost();
 			if (!is_dir($new_temppath)) {
 				/// @TODO There is a mkdir()+chmod() upwards, maybe generalize this (+ configurable) into a function/method?
-				mkdir($new_temppath);
+				@mkdir($new_temppath);
 			}
 
 			if (self::isDirectoryUsable($new_temppath)) {

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -526,7 +526,7 @@ class System
 	 *
 	 * @return boolean the directory is usable
 	 */
-	private static function isDirectoryUsable($directory): bool
+	private static function isDirectoryUsable(string $directory): bool
 	{
 		if (empty($directory)) {
 			Logger::warning('Directory is empty. This shouldn\'t happen.');


### PR DESCRIPTION
In the Docker environment, I set `/tmp` as a "tmpfs", which means that everytime, I update the container, the `/tmp` will be recreated.

So everytime, the following warnings occur:
```
index [WARNING]: Path does not exist {"directory":"/tmp/friendica.me","user":"www-data"} - {"file":"System.php","line":538,"function":"isDirectoryUsable","request-id":"a3a4349539e413aeb34c77cbef4efc8c","uid":"f0d6d0"}
```

This isn't necessary, so I reduced the loglevel to `INFO`

And there's a race condition when starting the daemon parallel with the php-fpm container, which leads sometimes to this error:
```
index [WARNING]: E_WARNING: mkdir(): File exists {"code":2,"message":"mkdir(): File exists","file":"/var/www/html/src/Core/System.php","line":604} - {"file":null,"line":null,"function":"mkdir","request-id":"ce2950524639b6e63dd34bb161f36bec","uid":"8c80ce"}
```