### PR TITLE
Fix  DateTimeFormat issue

### DIFF
--- a/src/Util/DateTimeFormat.php
+++ b/src/Util/DateTimeFormat.php
@@ -182,8 +182,8 @@ class DateTimeFormat
 	 */
 	public static function fix(string $dateString): string
 	{
-		$search  = ['Mär', 'März', 'Mai', 'Juni', 'Juli', 'Okt', 'Dez', 'ET' , 'ZZ', ' - ', '&#x2B;', '&amp;#43;', ' (Coordinated Universal Time)'];
-		$replace = ['Mar', 'Mar' , 'May', 'Jun' , 'Jul' , 'Oct', 'Dec', 'EST', 'Z' , ', ' , '+'     , '+'        , ''];
+		$search  = ['Mär', 'März', 'Mai', 'Juni', 'Juli', 'Okt', 'Dez', 'ET' , 'ZZ', ' - ', '&#x2B;', '&amp;#43;', ' (Coordinated Universal Time)', '\\'];
+		$replace = ['Mar', 'Mar' , 'May', 'Jun' , 'Jul' , 'Oct', 'Dec', 'EST', 'Z' , ', ' , '+'     , '+'        , ''                             , ''];
 
 		$dateString = str_replace($search, $replace, $dateString);
 

--- a/tests/src/Util/DateTimeFormatTest.php
+++ b/tests/src/Util/DateTimeFormatTest.php
@@ -134,7 +134,11 @@ class DateTimeFormatTest extends MockedTest
 			'Double HTML encode' => [
 				'expectedDate' => '2015-05-22T08:48:00+12:00',
 				'dateString' => '2015-05-22T08:48:00&amp;#43;12:00'
-			]
+			],
+			'2023-04-02\T17:22:42+05:30' => [
+				'expectedDate' => '2023-04-02T17:22:42+05:30',
+				'dateString' => '2023-04-02\T17:22:42+05:30'
+			],
 		];
 	}
 


### PR DESCRIPTION
Fixes
```
index [WARNING]: DateTimeFormat::convert: exception: DateTime::__construct(): Failed to parse time string (2023-04-02\T17:22:42+05:30) at position 10 (\): Unexpected character [] - {"file":"DateTimeFormat.php","line":157,"function":"convert","request-id":"41818c2c71bb267aae8108d81d423f94","uid":"d1449a"}
```