### PR TITLE
Transifex config for the new client

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,9 +1,9 @@
 [main]
-host = https://www.transifex.com
+host = https://api.transifex.com
 
-[friendica.messagespo]
+[o:Friendica:p:friendica:r:messagespo]
 file_filter = view/lang/<lang>/messages.po
 source_file = view/lang/C/messages.po
 source_lang = en
-type = PO
+type        = PO
 


### PR DESCRIPTION
The old CLI client for transifex had been deprecated. The new client needs a bit different config file (see also [the addon PR](https://git.friendi.ca/friendica/friendica-addons/pulls/1363/files)).