### PR TITLE
Issue 12977: Ensure to fetch quoted posts

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -840,6 +840,9 @@ class Processor
 			if ($id) {
 				$shared_item = Post::selectFirst(['uri-id'], ['id' => $id]);
 				$item['quote-uri-id'] = $shared_item['uri-id'];
+			} elseif ($uri_id = ItemURI::getIdByURI($activity['quote-url'], false)) {
+				Logger::info('Quote was not fetched but the uri-id existed', ['guid' => $item['guid'], 'uri-id' => $item['uri-id'], 'quote' => $activity['quote-url'], 'uri-id' => $uri_id]);
+				$item['quote-uri-id'] = $uri_id;
 			} else {
 				Logger::info('Quote was not fetched', ['guid' => $item['guid'], 'uri-id' => $item['uri-id'], 'quote' => $activity['quote-url']]);
 			}

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -630,7 +630,7 @@ class Receiver
 			$object_data['object_activity']	= $activity;
 		}
 
-		if (($type == 'as:Create') && $trust_source) {
+		if (($type == 'as:Create') && $trust_source && !in_array($completion, [self::COMPLETION_MANUAL, self::COMPLETION_ANNOUNCE])) {
 			if (self::hasArrived($object_data['object_id'])) {
 				Logger::info('The activity already arrived.', ['id' => $object_data['object_id']]);
 				return true;
@@ -641,6 +641,8 @@ class Receiver
 				Logger::info('The activity is already added.', ['id' => $object_data['object_id']]);
 				return true;
 			}
+		} elseif (($type == 'as:Create') && $trust_source && !self::hasArrived($object_data['object_id'])) {
+			self::addArrivedId($object_data['object_id']);
 		}
 
 		$decouple = DI::config()->get('system', 'decoupled_receiver') && !in_array($completion, [self::COMPLETION_MANUAL, self::COMPLETION_ANNOUNCE]);


### PR DESCRIPTION
Fixes #12977 
The problem in that issue is caused by some bad timing. The quoted post arrived some seconds earlier and had been added to the queue. Then some seconds later the post with the quote arrived. The system tried to fetch the post but realized that it had been already received and returned success. But since the item wasn't processed at that time, the quoted item wasn't found and thus the quote was ignored.

We now directly process items when they are fetched for reshares or quoted posts.