### PR TITLE
Don't perform BasicAuth on public endpoints

### DIFF
--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -372,7 +372,7 @@ class BaseApi extends BaseModule
 	 */
 	public static function appSupportsQuotes(): bool
 	{
-		$token = self::getCurrentApplication();
+		$token = OAuth::getCurrentApplicationToken();
 		return (!empty($token['name']) && in_array($token['name'], ['Fedilab']));
 	}
 


### PR DESCRIPTION
Prevent a BasicAuth request for endpoints that don't require a login.