### PR TITLE
Fixed check for likes in notification mail

### DIFF
--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -785,7 +785,7 @@ class Notify extends BaseRepository
 			$params['type'] = Model\Notification\Type::COMMENT;
 			$subject        = $l10n->t('%1$s Comment to conversation #%2$d by %3$s', $subjectPrefix, $item['parent'], $contact['name']);
 
-			if ($params['verb'] = Activity::LIKE) {
+			if ($params['verb'] == Activity::LIKE) {
 				switch ($Notification->type) {
 					case Model\Post\UserNotification::TYPE_DIRECT_COMMENT:
 						$subject = $l10n->t('%1$s %2$s liked your post #%3$d', $subjectPrefix, $contact['name'], $item['parent']);


### PR DESCRIPTION
Possibly this fix could help with #12504, since the notification mails should adhere the notification settings.

But possibly someone commented on a post and due to this bug the mail subject was changed.