### PR TITLE
[vier] Remove duplicate variable declaration

### DIFF
--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -85,9 +85,6 @@
         });
     };
 
-    var updateInterval = {{$update_interval}};
-	var localUser = {{if $local_user}}{{$local_user}}{{else}}false{{/if}};
-
 	function confirmDelete() { return confirm("{{$delitem}}"); }
 	function commentExpand(id) {
 		$("#comment-edit-text-" + id).putCursorAtEnd();


### PR DESCRIPTION
- They were meant to be removed when the const declarations were introduced

Follow-up to https://github.com/friendica/friendica/pull/12984
Fix #12993 

