### PR TITLE
Fix: Force baseUrl being a string

### DIFF
--- a/src/Console/Relocate.php
+++ b/src/Console/Relocate.php
@@ -94,7 +94,7 @@ HELP;
 
 		$this->out(sprintf('Relocation started from %s to %s. Could take a while to complete.', $this->baseUrl, $this->getArgument(0)));
 
-		$old_url = $this->baseUrl;
+		$old_url = (string)$this->baseUrl;
 
 		// Generate host names for relocation the addresses in the format user@address.tld
 		$new_host = str_replace('http://', '@', Strings::normaliseLink($new_url));

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -343,7 +343,7 @@ class Install extends BaseModule
 	 */
 	private function whatNext(): string
 	{
-		$baseurl = $this->baseUrl;
+		$baseurl = (string)$this->baseUrl;
 		return
 			$this->t('<h1>What next</h1>')
 			. "<p>" . $this->t('IMPORTANT: You will need to [manually] setup a scheduled task for the worker.')

--- a/src/Module/User/Import.php
+++ b/src/Module/User/Import.php
@@ -232,7 +232,7 @@ class Import extends \Friendica\BaseModule
 		}
 
 		$oldBaseUrl = $account['baseurl'];
-		$newBaseUrl = $this->baseUrl;
+		$newBaseUrl = (string)$this->baseUrl;
 
 		$oldAddr = str_replace('http://', '@', Strings::normaliseLink($oldBaseUrl));
 		$newAddr = str_replace('http://', '@', Strings::normaliseLink($newBaseUrl));

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -105,7 +105,7 @@ class Xrd extends BaseModule
 
 	private function printSystemJSON(array $owner)
 	{
-		$baseURL = $this->baseUrl;
+		$baseURL = (string)$this->baseUrl;
 		$json = [
 			'subject' => 'acct:' . $owner['addr'],
 			'aliases' => [$owner['url']],
@@ -151,7 +151,7 @@ class Xrd extends BaseModule
 
 	private function printJSON(string $alias, array $owner, array $avatar)
 	{
-		$baseURL = $this->baseUrl;
+		$baseURL = (string)$this->baseUrl;
 
 		$json = [
 			'subject' => 'acct:' . $owner['addr'],
@@ -228,7 +228,7 @@ class Xrd extends BaseModule
 
 	private function printXML(string $alias, array $owner, array $avatar)
 	{
-		$baseURL = $this->baseUrl;
+		$baseURL = (string)$this->baseUrl;
 
 		$xmlString = XML::fromArray([
 			'XRD' => [

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -264,7 +264,7 @@ class Notify extends BaseRepository
 			}
 		}
 
-		$siteurl = $this->baseUrl;
+		$siteurl = (string)$this->baseUrl;
 		$sitename = $this->config->get('config', 'sitename');
 
 		// with $params['show_in_notification_page'] == false, the notification isn't inserted into
@@ -807,7 +807,7 @@ class Notify extends BaseRepository
 		$epreamble = $msg['rich'];
 
 		$sitename = $this->config->get('config', 'sitename');
-		$siteurl  = $this->baseUrl;
+		$siteurl  = (string)$this->baseUrl;
 
 		$sitelink  = $l10n->t('Please visit %s to view and/or reply to the conversation.');
 		$tsitelink = sprintf($sitelink, $siteurl);


### PR DESCRIPTION
This fixes the issue that is described here: https://forum.friendi.ca/display/0b6b25a8-1964-3aa6-36a9-a5f859529066

Also this fix covers some other places where the class variable might cause similar issues.