### PR TITLE
Fix: Only add link preview for selected networks

### DIFF
--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -635,7 +635,7 @@ class Media
 			foreach ($matches[1] as $url) {
 				Logger::info('Got page url (link without description)', ['uri-id' => $uriid, 'url' => $url]);
 				$result = self::insert(['uri-id' => $uriid, 'type' => self::UNKNOWN, 'url' => $url], false, $network);
-				if ($result && ($network == Protocol::DFRN)) {
+				if ($result && !in_array($network, [Protocol::ACTIVITYPUB, Protocol::OSTATUS, Protocol::DIASPORA])) {
 					self::revertHTMLType($uriid, $url, $fullbody);
 					Logger::debug('Revert HTML type', ['uri-id' => $uriid, 'url' => $url]);
 				} elseif ($result) {
@@ -651,7 +651,7 @@ class Media
 			foreach ($matches[1] as $url) {
 				Logger::info('Got page url (link with description)', ['uri-id' => $uriid, 'url' => $url]);
 				$result = self::insert(['uri-id' => $uriid, 'type' => self::UNKNOWN, 'url' => $url], false, $network);
-				if ($result && ($network == Protocol::DFRN)) {
+				if ($result && !in_array($network, [Protocol::ACTIVITYPUB, Protocol::OSTATUS, Protocol::DIASPORA])) {
 					self::revertHTMLType($uriid, $url, $fullbody);
 					Logger::debug('Revert HTML type', ['uri-id' => $uriid, 'url' => $url]);
 				} elseif ($result) {


### PR DESCRIPTION
Until now we always looked for HTML links in all posts that were about to be stored and added them as a block in the bottom of the post. This is a nice feature - but not for networks where we can do this deliberately. For example on feed posts this can look weird.