### PR TITLE
Only share from federated posts

### DIFF
--- a/src/Module/Post/Share.php
+++ b/src/Module/Post/Share.php
@@ -68,7 +68,7 @@ class Share extends \Friendica\BaseModule
 		$shared = $this->contentItem->getSharedPost($item, ['uri']);
 		if ($shared && empty($shared['comment'])) {
 			$content = '[share]' . $shared['post']['uri'] . '[/share]';
-		} elseif ($item['network'] == Protocol::FEED) {
+		} elseif (!empty($item['plink']) && !in_array($item['network'], Protocol::FEDERATED)) {
 			$content = '[attachment]' . $item['plink'] . '[/attachment]';
 		} else {
 			$content = '[share]' . $item['uri'] . '[/share]';

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -205,8 +205,9 @@ class Post
 		$lock      = ($item['private'] == Item::PRIVATE) ? $privacy : false;
 		$connector = !in_array($item['network'], Protocol::NATIVE_SUPPORT) ? DI::l10n()->t('Connector Message') : false;
 
-		$shareable = in_array($conv->getProfileOwner(), [0, DI::userSession()->getLocalUserId()]) && $item['private'] != Item::PRIVATE;
-		$announceable = $shareable && in_array($item['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::TWITTER]);
+		$shareable    = in_array($conv->getProfileOwner(), [0, DI::userSession()->getLocalUserId()]) && $item['private'] != Item::PRIVATE;
+		$announceable = $shareable && in_array($item['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA, Protocol::TWITTER, Protocol::TUMBLR]);
+		$commentable  = ($item['network'] != Protocol::TUMBLR);
 
 		// On Diaspora only toplevel posts can be reshared
 		if ($announceable && ($item['network'] == Protocol::DIASPORA) && ($item['gravity'] != Item::GRAVITY_PARENT)) {
@@ -392,7 +393,11 @@ class Post
 			}
 		}
 
-		$comment_html = $this->getCommentBox($indent);
+		if ($commentable) {
+			$comment_html = $this->getCommentBox($indent);
+		} else {
+			$comment_html = '';
+		}
 
 		if (strcmp(DateTimeFormat::utc($item['created']), DateTimeFormat::utc('now - 12 hours')) > 0) {
 			$shiny = 'shiny';


### PR DESCRIPTION
This fixes the issue that a quote share from posts from (for example) Twitter doesn't look like expected when shared.

We are now converting these shares to posts with an added link, like we already did with quote shares from feeds.

Also some small change for the Tumblr connector is added, that has got not effect on the existing system. It just covers the problem that you cannot comment on Tumblr posts via known API endpoints.