### PR TITLE
Contacts from probeable networks are now updated correctly

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2409,6 +2409,11 @@ class Contact
 		$condition = ['self' => false, 'nurl' => Strings::normaliseLink($url)];
 
 		$condition['network'] = [Protocol::DFRN, Protocol::DIASPORA, Protocol::ACTIVITYPUB];
+
+		if (!in_array($contact['network'], Protocol::NATIVE_SUPPORT) && Protocol::supportsProbe($contact['network'])) {
+			$condition['network'][] = $contact['network'];
+		}
+
 		self::update($fields, $condition);
 
 		// We mustn't set the update fields for OStatus contacts since they are updated in OnePoll


### PR DESCRIPTION
When you update a contact via probe, then the update should be done for the contact entries.