### PR TITLE
Issue 13041: API activities for reshared posts are now performed on the original posts

### DIFF
--- a/src/Factory/Api/Mastodon/StatusSource.php
+++ b/src/Factory/Api/Mastodon/StatusSource.php
@@ -38,7 +38,7 @@ class StatusSource extends BaseFactory
 	 */
 	public function createFromUriId(int $uriId, int $uid): \Friendica\Object\Api\Mastodon\StatusSource
 	{
-		$post = Post::selectFirst(['uri-id', 'raw-body', 'body', 'title'], ['uri-id' => $uriId, 'uid' => [0, $uid]]);
+		$post = Post::selectOriginal(['uri-id', 'raw-body', 'body', 'title'], ['uri-id' => $uriId, 'uid' => [0, $uid]]);
 
 		$spoiler_text = $post['title'] ?: BBCode::toPlaintext(BBCode::getAbstract($post['body'], Protocol::ACTIVITYPUB));
 		$body         = BBCode::toMarkdown(Post\Media::removeFromEndOfBody($post['body']));

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -268,7 +268,7 @@ class Statuses extends BaseApi
 		}
 
 		if ($request['in_reply_to_id']) {
-			$parent = Post::selectFirst(['uri'], ['uri-id' => $request['in_reply_to_id'], 'uid' => [0, $uid]]);
+			$parent = Post::selectOriginal(['uri'], ['uri-id' => $request['in_reply_to_id'], 'uid' => [0, $uid]]);
 			if (empty($parent)) {
 				throw new HTTPException\NotFoundException('Item with URI ID ' . $request['in_reply_to_id'] . ' not found for user ' . $uid . '.');
 			}

--- a/src/Module/Api/Mastodon/Statuses/Bookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Bookmark.php
@@ -42,7 +42,7 @@ class Bookmark extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$item = Post::selectFirst(['uid', 'id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]], ['order' => ['uid' => true]]);
+		$item = Post::selectOriginal(['uid', 'id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]], ['order' => ['uid' => true]]);
 		if (!DBA::isResult($item)) {
 			DI::mstdnError()->RecordNotFound();
 		}
@@ -52,7 +52,7 @@ class Bookmark extends BaseApi
 		}
 
 		if ($item['uid'] == 0) {
-			$stored = Item::storeForUserByUriId($this->parameters['id'], $uid, ['post-reason' => Item::PR_ACTIVITY]);
+			$stored = Item::storeForUserByUriId($item['id'], $uid, ['post-reason' => Item::PR_ACTIVITY]);
 			if (!empty($stored)) {
 				$item = Post::selectFirst(['id', 'gravity'], ['id' => $stored]);
 				if (!DBA::isResult($item)) {

--- a/src/Module/Api/Mastodon/Statuses/Card.php
+++ b/src/Module/Api/Mastodon/Statuses/Card.php
@@ -43,13 +43,11 @@ class Card extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$id = $this->parameters['id'];
-
-		if (!Post::exists(['uri-id' => $id, 'uid' => [0, $uid]])) {
-			throw new HTTPException\NotFoundException('Item with URI ID ' . $id . ' not found' . ($uid ? ' for user ' . $uid : '.'));
+		if (!$post = Post::selectOriginal(['id'], ['uri-id' => $this->parameters['id'], 'uid' => [0, $uid]])) {
+			throw new HTTPException\NotFoundException('Item with URI ID ' . $this->parameters['id'] . ' not found' . ($uid ? ' for user ' . $uid : '.'));
 		}
 
-		$card = DI::mstdnCard()->createFromUriId($id);
+		$card = DI::mstdnCard()->createFromUriId($post['id']);
 
 		System::jsonExit($card->toArray());
 	}

--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -57,8 +57,9 @@ class Context extends BaseApi
 		$parents  = [];
 		$children = [];
 
-		$parent = Post::selectFirst(['parent-uri-id'], ['uri-id' => $id]);
+		$parent = Post::selectOriginal(['uri-id', 'parent-uri-id'], ['uri-id' => $id]);
 		if (DBA::isResult($parent)) {
+			$id = $parent['uri-id'];
 			$params    = ['order' => ['uri-id' => true]];
 			$condition = ['parent-uri-id' => $parent['parent-uri-id'], 'gravity' => [Item::GRAVITY_PARENT, Item::GRAVITY_COMMENT]];
 

--- a/src/Module/Api/Mastodon/Statuses/Favourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Favourite.php
@@ -42,7 +42,7 @@ class Favourite extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
+		$item = Post::selectOriginalForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
 			DI::mstdnError()->RecordNotFound();
 		}

--- a/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
@@ -44,12 +44,11 @@ class FavouritedBy extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$id = $this->parameters['id'];
-		if (!Post::exists(['uri-id' => $id, 'uid' => [0, $uid]])) {
+		if (!$post = Post::selectOriginal(['id'], ['uri-id' => $this->parameters['id'], 'uid' => [0, $uid]])) {
 			DI::mstdnError()->RecordNotFound();
 		}
 
-		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $id, 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::LIKE, 'deleted' => false]);
+		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $post['id'], 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::LIKE, 'deleted' => false]);
 
 		$accounts = [];
 

--- a/src/Module/Api/Mastodon/Statuses/Mute.php
+++ b/src/Module/Api/Mastodon/Statuses/Mute.php
@@ -42,7 +42,7 @@ class Mute extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$item = Post::selectFirstForUser($uid, ['id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
+		$item = Post::selectOriginalForUser($uid, ['id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
 			DI::mstdnError()->RecordNotFound();
 		}
@@ -51,7 +51,7 @@ class Mute extends BaseApi
 			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t('Only starting posts can be muted'));
 		}
 
-		Post\ThreadUser::setIgnored($this->parameters['id'], $uid, true);
+		Post\ThreadUser::setIgnored($item['id'], $uid, true);
 
 		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
 	}

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -41,12 +41,12 @@ class Pin extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$item = Post::selectFirstForUser($uid, ['id', 'gravity', 'author-id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
+		$item = Post::selectOriginalForUser($uid, ['id', 'gravity', 'author-id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
 			DI::mstdnError()->RecordNotFound();
 		}
 
-		Post\Collection::add($this->parameters['id'], Post\Collection::FEATURED, $item['author-id'], $uid);
+		Post\Collection::add($item['id'], Post\Collection::FEATURED, $item['author-id'], $uid);
 
 		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
 	}

--- a/src/Module/Api/Mastodon/Statuses/Reblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Reblog.php
@@ -45,7 +45,7 @@ class Reblog extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$item = Post::selectFirstForUser($uid, ['id', 'network'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
+		$item = Post::selectOriginalForUser($uid, ['id', 'network'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
 			DI::mstdnError()->RecordNotFound();
 		}

--- a/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
@@ -44,12 +44,11 @@ class RebloggedBy extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$id = $this->parameters['id'];
-		if (!Post::exists(['uri-id' => $id, 'uid' => [0, $uid]])) {
+		if (!$post = Post::selectOriginal(['id'], ['uri-id' => $this->parameters['id'], 'uid' => [0, $uid]])) {
 			DI::mstdnError()->RecordNotFound();
 		}
 
-		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $id, 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::ANNOUNCE]);
+		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $post['id'], 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::ANNOUNCE]);
 
 		$accounts = [];
 

--- a/src/Module/Api/Mastodon/Statuses/Unbookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Unbookmark.php
@@ -42,7 +42,7 @@ class Unbookmark extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$item = Post::selectFirst(['uid', 'id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]], ['order' => ['uid' => true]]);
+		$item = Post::selectOriginal(['uid', 'id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]], ['order' => ['uid' => true]]);
 		if (!DBA::isResult($item)) {
 			DI::mstdnError()->RecordNotFound();
 		}
@@ -52,7 +52,7 @@ class Unbookmark extends BaseApi
 		}
 
 		if ($item['uid'] == 0) {
-			$stored = Item::storeForUserByUriId($this->parameters['id'], $uid, ['post-reason' => Item::PR_ACTIVITY]);
+			$stored = Item::storeForUserByUriId($item['id'], $uid, ['post-reason' => Item::PR_ACTIVITY]);
 			if (!empty($stored)) {
 				$item = Post::selectFirst(['id', 'gravity'], ['id' => $stored]);
 				if (!DBA::isResult($item)) {

--- a/src/Module/Api/Mastodon/Statuses/Unfavourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Unfavourite.php
@@ -42,7 +42,7 @@ class Unfavourite extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
+		$item = Post::selectOriginalForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
 			DI::mstdnError()->RecordNotFound();
 		}

--- a/src/Module/Api/Mastodon/Statuses/Unmute.php
+++ b/src/Module/Api/Mastodon/Statuses/Unmute.php
@@ -42,7 +42,7 @@ class Unmute extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$item = Post::selectFirstForUser($uid, ['id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
+		$item = Post::selectOriginalForUser($uid, ['id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
 			DI::mstdnError()->RecordNotFound();
 		}
@@ -51,7 +51,7 @@ class Unmute extends BaseApi
 			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t('Only starting posts can be unmuted'));
 		}
 
-		Post\ThreadUser::setIgnored($this->parameters['id'], $uid, false);
+		Post\ThreadUser::setIgnored($item['id'], $uid, false);
 
 		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
 	}

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -41,12 +41,12 @@ class Unpin extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$item = Post::selectFirstForUser($uid, ['id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
+		$item = Post::selectOriginalForUser($uid, ['id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
 			DI::mstdnError()->RecordNotFound();
 		}
 
-		Post\Collection::remove($this->parameters['id'], Post\Collection::FEATURED, $uid);
+		Post\Collection::remove($item['id'], Post\Collection::FEATURED, $uid);
 
 		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
 	}

--- a/src/Module/Api/Mastodon/Statuses/Unreblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Unreblog.php
@@ -44,7 +44,7 @@ class Unreblog extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		$item = Post::selectFirstForUser($uid, ['id', 'network'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
+		$item = Post::selectOriginalForUser($uid, ['id', 'network'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
 			DI::mstdnError()->RecordNotFound();
 		}


### PR DESCRIPTION
Fixes #13041 by introducing two new functions that either are fetching the requested post or in case of a reshare are fetching the reshared post.