### PR TITLE
change test for navigator.share - fixes #13054

### DIFF
--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -445,7 +445,9 @@ $(document).ready(function () {
 			});
 	});
 
-	if (!navigator.canShare || !navigator.canShare()) {
+	try {
+		navigator.canShare({ url: "#", });
+	} catch(err) {
 		$('.button-browser-share').hide();
 	}
 });


### PR DESCRIPTION
this testing for navigator.share is recommended from mozilla. tested with firefox linux, android and vivaldi on linux.