### PR TITLE
Introduce settings for overriding php.ini values

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -335,7 +335,14 @@ class App
 	 */
 	protected function load(DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition)
 	{
-		set_time_limit(0);
+		if ($this->config->get('system', 'ini_max_execution_time') !== false) {
+			set_time_limit((int)$this->config->get('system', 'ini_max_execution_time'));
+		}
+
+		// This has to be quite large to deal with embedded private photos
+		if ($this->config->get('system', 'ini_pcre_backtrack_limit') !== false) {
+			ini_set('pcre.backtrack_limit', (int)$this->config->get('system', 'ini_pcre_backtrack_limit'));
+		}
 
 		// Normally this constant is defined - but not if "pcntl" isn't installed
 		if (!defined('SIGTERM')) {
@@ -344,9 +351,6 @@ class App
 
 		// Ensure that all "strtotime" operations do run timezone independent
 		date_default_timezone_set('UTC');
-
-		// This has to be quite large to deal with embedded private photos
-		ini_set('pcre.backtrack_limit', 500000);
 
 		set_include_path(
 			get_include_path() . PATH_SEPARATOR

--- a/src/App.php
+++ b/src/App.php
@@ -339,7 +339,6 @@ class App
 			set_time_limit((int)$this->config->get('system', 'ini_max_execution_time'));
 		}
 
-		// This has to be quite large to deal with embedded private photos
 		if ($this->config->get('system', 'ini_pcre_backtrack_limit') !== false) {
 			ini_set('pcre.backtrack_limit', (int)$this->config->get('system', 'ini_pcre_backtrack_limit'));
 		}

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -341,6 +341,14 @@ return [
 		// Resolve IPV4 addresses only. Don't resolve to IPV6.
 		'ipv4_resolve' => false,
 
+		// ini_max_execution_time (False|Integer)
+		// Set the number of seconds a script is allowed to run. Default unlimited for Friendica, False means disabled
+		'ini_max_execution_time' => 0,
+
+		// ini_pcre_backtrack_limit (False|Integer)
+		// This has to be quite large to deal with embedded private photos. False means disabled
+		'ini_pcre_backtrack_limit' => 500000,
+
 		// invitation_only (Boolean)
 		// If set true registration is only possible after a current member of the node has sent an invitation.
 		'invitation_only' => false,

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -342,11 +342,11 @@ return [
 		'ipv4_resolve' => false,
 
 		// ini_max_execution_time (False|Integer)
-		// Set the number of seconds a script is allowed to run. Default unlimited for Friendica, False means disabled
+		// Set the number of seconds a script is allowed to run. Default unlimited for Friendica, false to use the system value.
 		'ini_max_execution_time' => 0,
 
 		// ini_pcre_backtrack_limit (False|Integer)
-		// This has to be quite large to deal with embedded private photos. False means disabled
+		// This has to be quite large to deal with embedded private photos. False to use the system value.
 		'ini_pcre_backtrack_limit' => 500000,
 
 		// invitation_only (Boolean)


### PR DESCRIPTION
I still struggle with long running processes. I tried to override the `max_execution_time` INI value and found that we statically set it in PHP itself.

The two new settings now enable/disable/set these INI overrides. 