### PR TITLE
The emoji selector is now available for comments

### DIFF
--- a/view/templates/item/compose.tpl
+++ b/view/templates/item/compose.tpl
@@ -101,16 +101,3 @@
 <script>
 	dzFactory.setupDropzone('#dropzone-{{$id}}', 'comment-edit-text-{{$id}}'); 
 </script>
-<script>
-window.onload = function(){
-	new EmojiPicker({
-		trigger: [
-			{
-				selector: '.emojis',
-				insertInto: '.comment-edit-text'
-			}
-		],
-		closeButton: true,
-	});
-};
-</script>

--- a/view/theme/frio/templates/comment_item.tpl
+++ b/view/theme/frio/templates/comment_item.tpl
@@ -36,6 +36,9 @@
 				<button type="button" class="btn btn-sm template-icon quote" style="cursor: pointer;" aria-label="{{$edquote}}" title="{{$edquote}}" onclick="insertFormatting('quote',{{$id}});">
 					<i class="fa fa-quote-left"></i>
 				</button>
+				<button type="button" class="btn btn-sm template-icon emojis" style="cursor: pointer;" aria-label="{{$edemojis}}" title="{{$edemojis}}">
+					<i class="fa fa-smile-o"></i>
+				</button>
 			</span>
 			</p>
 			<div id="dropzone-{{$id}}" class="dropzone">

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -151,7 +151,20 @@
 	<script type="text/javascript" src="view/js/fancybox/jquery.fancybox.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 	<script type="text/javascript" src="view/js/fancybox/fancybox.config.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
 	<script type="text/javascript" src="view/js/vanillaEmojiPicker/vanillaEmojiPicker.min.js?v={{$smarty.const.FRIENDICA_VERSION}}"></script>
-
+	<script>
+	window.onload = function(){
+		new EmojiPicker({
+			trigger: [
+				{
+					selector: '.emojis',
+					insertInto: ['#comment-edit-text-0', '.profile-jot-text-full', '.comment-edit-text-full']
+				}
+			],
+			closeButton: true
+		});
+	};
+	</script>
+	
 	{{* Include the strings which are needed for some js functions (e.g. translation)
 They are loaded into the html <head> so that js functions can use them *}}
 	{{include file="js_strings.tpl"}}

--- a/view/theme/frio/templates/jot.tpl
+++ b/view/theme/frio/templates/jot.tpl
@@ -183,16 +183,3 @@ can load different content into the jot modal (e.g. the item edit jot)
 <script>
 	dzFactory.setupDropzone('#jot-text-wrap', 'profile-jot-text'); 
 </script>
-<script>
-window.onload = function(){
-	new EmojiPicker({
-		trigger: [
-			{
-				selector: '.emojis',
-				insertInto: '.profile-jot-text'
-			}
-		],
-		closeButton: true,
-	});
-};
-</script>


### PR DESCRIPTION
We can now select emojis in comments as well. But there are a couple of known issues:

1. You have to enter some text. When no text is entered, the comment area closes and no emoji is added
2. When you opened several comment areas and closed them and you then add an emoji, then it will be added to all comment areas you had opened before.