### PR TITLE
Support for feeds that follow the ATOM 0.3 specification

### DIFF
--- a/src/Protocol/ActivityNamespace.php
+++ b/src/Protocol/ActivityNamespace.php
@@ -146,6 +146,12 @@ final class ActivityNamespace
 	const ATOM1           = 'http://www.w3.org/2005/Atom';
 
 	/**
+	 * This namespace is used for the (deprecated) Atom 0.3 specification
+	 * @var string
+	 */
+	const ATOM03           = 'http://purl.org/atom/ns#';
+	
+	/**
 	 * @var string
 	 */
 	const MASTODON        = 'http://mastodon.social/schema/1.0';

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -92,7 +92,12 @@ class Feed
 		$doc = new DOMDocument();
 		@$doc->loadXML($xml);
 		$xpath = new DOMXPath($doc);
-		$xpath->registerNamespace('atom', ActivityNamespace::ATOM1);
+
+		if (strpos($xml, ActivityNamespace::ATOM03) && !strpos($xml, ActivityNamespace::ATOM1)) {
+			$xpath->registerNamespace('atom', ActivityNamespace::ATOM03);
+		} else {
+			$xpath->registerNamespace('atom', ActivityNamespace::ATOM1);
+		}
 		$xpath->registerNamespace('dc', 'http://purl.org/dc/elements/1.1/');
 		$xpath->registerNamespace('content', 'http://purl.org/rss/1.0/modules/content/');
 		$xpath->registerNamespace('rdf', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#');


### PR DESCRIPTION
There are feeds out there that still are using the long time deprecated ATOM 0.3 specification. We now support that.