### PR TITLE
Improved ATOM distinction, added OPML

### DIFF
--- a/src/Model/Conversation.php
+++ b/src/Model/Conversation.php
@@ -41,6 +41,8 @@ class Conversation
 	const PARCEL_RDF                = 12;
 	const PARCEL_RSS                = 13;
 	const PARCEL_ATOM               = 14;
+	const PARCEL_ATOM03             = 15;
+	const PARCEL_OPML               = 16;
 	const PARCEL_TWITTER            = 67;
 	const PARCEL_UNKNOWN            = 255;
 


### PR DESCRIPTION
During the tests with ATOM 0.3 I discovered that OPML is used for feed items as well and not only for lists of feeds. So it is now added as well. Also the distinction between ATOM 1.0 and ATOM 0.3 is improved.