### PR TITLE
Fix: Feeds had been imported with the wrong body

### DIFF
--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -309,6 +309,7 @@ class Feed
 			$entry = $entries->item($i);
 
 			$item = array_merge($header, $author);
+			$body = '';
 
 			$alternate = XML::getFirstAttributes($xpath, $atomns . ":link[@rel='alternate']", $entry);
 			if (!is_object($alternate)) {


### PR DESCRIPTION
When multiple feed entries had been imported, the system always took the body from the previous entry.