### PR TITLE
Improved preview size

### DIFF
--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -1194,7 +1194,7 @@ class Photo
 
 		$smallest = self::storeWithPreview($image, $user['uid'], $resource_id, $filename, $filesize, $album, $desc, $allow_cid, $allow_gid, $deny_cid, $deny_gid);
 		if ($smallest < 0) {
-			Logger::notice('Photo not stored', ['resource-id' => $resource_id]);
+			Logger::warning('Photo could not be stored', ['uid' => $user['uid'], 'resource_id' => $resource_id, 'filename' => $filename, 'album' => $album]);			Logger::notice('Photo not stored', ['resource-id' => $resource_id]);
 			return [];
 		}
 

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -1194,7 +1194,7 @@ class Photo
 
 		$smallest = self::storeWithPreview($image, $user['uid'], $resource_id, $filename, $filesize, $album, $desc, $allow_cid, $allow_gid, $deny_cid, $deny_gid);
 		if ($smallest < 0) {
-			Logger::warning('Photo could not be stored', ['uid' => $user['uid'], 'resource_id' => $resource_id, 'filename' => $filename, 'album' => $album]);			Logger::notice('Photo not stored', ['resource-id' => $resource_id]);
+			Logger::warning('Photo could not be stored', ['uid' => $user['uid'], 'resource_id' => $resource_id, 'filename' => $filename, 'album' => $album]);
 			return [];
 		}
 

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -1195,21 +1195,21 @@ class Photo
 
 		$smallest = 0;
 
-		$r = self::store($image, $user['uid'], 0, $resource_id, $filename, $album, 0, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $desc);
-		if (!$r) {
+		$result = self::store($image, $user['uid'], 0, $resource_id, $filename, $album, 0, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $desc);
+		if (!$result) {
 			Logger::warning('Photo could not be stored', ['uid' => $user['uid'], 'resource_id' => $resource_id, 'filename' => $filename, 'album' => $album]);
 			return [];
 		}
 
 		if ($width > 640 || $height > 640) {
 			$image->scaleDown(640);
+		}
+
+		if ($width > 320 || $height > 320) {
 			$r = self::store($image, $user['uid'], 0, $resource_id, $filename, $album, 1, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $desc);
 			if ($r) {
 				$smallest = 1;
 			}
-		}
-
-		if ($width > 320 || $height > 320) {
 			$image->scaleDown(320);
 			$r = self::store($image, $user['uid'], 0, $resource_id, $filename, $album, 2, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $desc);
 			if ($r && ($smallest == 0)) {

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -1192,8 +1192,8 @@ class Photo
 			$allow_gid = '';
 		}
 
-		$smallest = self::storeWithPreview($image, $user['uid'], $resource_id, $filename, $filesize, $album, $desc, $allow_cid, $allow_gid, $deny_cid, $deny_gid);
-		if ($smallest < 0) {
+		$preview = self::storeWithPreview($image, $user['uid'], $resource_id, $filename, $filesize, $album, $desc, $allow_cid, $allow_gid, $deny_cid, $deny_gid);
+		if ($preview < 0) {
 			Logger::warning('Photo could not be stored', ['uid' => $user['uid'], 'resource_id' => $resource_id, 'filename' => $filename, 'album' => $album]);
 			return [];
 		}
@@ -1215,7 +1215,7 @@ class Photo
 		$picture['type']        = $photo['type'];
 		$picture['albumpage']   = DI::baseUrl() . '/photos/' . $user['nickname'] . '/image/' . $resource_id;
 		$picture['picture']     = DI::baseUrl() . '/photo/' . $resource_id . '-0.' . $image->getExt();
-		$picture['preview']     = DI::baseUrl() . '/photo/' . $resource_id . '-' . $smallest . '.' . $image->getExt();
+		$picture['preview']     = DI::baseUrl() . '/photo/' . $resource_id . '-' . $preview . '.' . $image->getExt();
 
 		Logger::info('upload done', ['picture' => $picture]);
 		return $picture;
@@ -1236,7 +1236,7 @@ class Photo
 	 * @param string  $deny_cid    Permissions, denied contacts
 	 * @param string  $deny_gid    Permissions, denied group
 	 *
-	 * @return boolean True on success
+	 * @return integer preview photo size
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public static function storeWithPreview(Image $image, int $uid, string $resource_id, string $filename, int $filesize, string $album, string $description, string $allow_cid, string $allow_gid, string $deny_cid, string $deny_gid): int
@@ -1268,9 +1268,9 @@ class Photo
 			}
 		}
 
-		$width    = $image->getWidth();
-		$height   = $image->getHeight();
-		$smallest = 0;
+		$width   = $image->getWidth();
+		$height  = $image->getHeight();
+		$preview = 0;
 
 		$result = self::store($image, $uid, 0, $resource_id, $filename, $album, 0, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $description);
 		if (!$result) {
@@ -1285,15 +1285,15 @@ class Photo
 		if ($width > 320 || $height > 320) {
 			$result = self::store($image, $uid, 0, $resource_id, $filename, $album, 1, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $description);
 			if ($result) {
-				$smallest = 1;
+				$preview = 1;
 			}
 			$image->scaleDown(320);
 			$result = self::store($image, $uid, 0, $resource_id, $filename, $album, 2, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $description);
-			if ($result && ($smallest == 0)) {
-				$smallest = 2;
+			if ($result && ($preview == 0)) {
+				$preview = 2;
 			}
 		}
-		return $smallest;
+		return $preview;
 	}
 
 	/**

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -1241,6 +1241,10 @@ class Photo
 	 */
 	public static function storeWithPreview(Image $image, int $uid, string $resource_id, string $filename, int $filesize, string $album, string $description, string $allow_cid, string $allow_gid, string $deny_cid, string $deny_gid): int
 	{
+		if ($filesize == 0) {
+			$filesize = strlen($image->asString());
+		}
+
 		$width  = $image->getWidth();
 		$height = $image->getHeight();
 

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -1148,7 +1148,7 @@ class Photo
 			return [];
 		}
 
-		return ['image' => $image, 'filename' => $filename];
+		return ['image' => $image, 'filename' => $filename, 'size' => $filesize];
 	}
 
 	/**
@@ -1182,8 +1182,7 @@ class Photo
 
 		$image    = $data['image'];
 		$filename = $data['filename'];
-		$width    = $image->getWidth();
-		$height   = $image->getHeight();
+		$filesize = $data['size'];
 
 		$resource_id = $resource_id ?: self::newResource();
 		$album       = $album ?: DI::l10n()->t('Wall Photos');
@@ -1193,28 +1192,10 @@ class Photo
 			$allow_gid = '';
 		}
 
-		$smallest = 0;
-
-		$result = self::store($image, $user['uid'], 0, $resource_id, $filename, $album, 0, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $desc);
-		if (!$result) {
-			Logger::warning('Photo could not be stored', ['uid' => $user['uid'], 'resource_id' => $resource_id, 'filename' => $filename, 'album' => $album]);
+		$smallest = self::storeWithPreview($image, $user['uid'], $resource_id, $filename, $filesize, $album, $desc, $allow_cid, $allow_gid, $deny_cid, $deny_gid);
+		if ($smallest < 0) {
+			Logger::notice('Photo not stored', ['resource-id' => $resource_id]);
 			return [];
-		}
-
-		if ($width > 640 || $height > 640) {
-			$image->scaleDown(640);
-		}
-
-		if ($width > 320 || $height > 320) {
-			$r = self::store($image, $user['uid'], 0, $resource_id, $filename, $album, 1, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $desc);
-			if ($r) {
-				$smallest = 1;
-			}
-			$image->scaleDown(320);
-			$r = self::store($image, $user['uid'], 0, $resource_id, $filename, $album, 2, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $desc);
-			if ($r && ($smallest == 0)) {
-				$smallest = 2;
-			}
 		}
 
 		$condition = ['resource-id' => $resource_id];
@@ -1238,6 +1219,77 @@ class Photo
 
 		Logger::info('upload done', ['picture' => $picture]);
 		return $picture;
+	}
+
+	/**
+	 * store photo metadata in db and binary with preview photos in default backend
+	 *
+	 * @param Image   $image       Image object with data
+	 * @param integer $uid         User ID
+	 * @param string  $resource_id Resource ID
+	 * @param string  $filename    Filename
+	 * @param integer $filesize    Filesize
+	 * @param string  $album       Album name
+	 * @param string  $description Photo caption
+	 * @param string  $allow_cid   Permissions, allowed contacts
+	 * @param string  $allow_gid   Permissions, allowed groups
+	 * @param string  $deny_cid    Permissions, denied contacts
+	 * @param string  $deny_gid    Permissions, denied group
+	 *
+	 * @return boolean True on success
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public static function storeWithPreview(Image $image, int $uid, string $resource_id, string $filename, int $filesize, string $album, string $description, string $allow_cid, string $allow_gid, string $deny_cid, string $deny_gid): int
+	{
+		$width  = $image->getWidth();
+		$height = $image->getHeight();
+
+		$maximagesize = Strings::getBytesFromShorthand(DI::config()->get('system', 'maximagesize'));
+
+		if ($maximagesize && $filesize > $maximagesize) {
+			// Scale down to multiples of 640 until the maximum size isn't exceeded anymore
+			foreach ([5120, 2560, 1280, 640, 320] as $pixels) {
+				if ($filesize > $maximagesize && max($width, $height) > $pixels) {
+					DI::logger()->info('Resize', ['size' => $filesize, 'width' => $width, 'height' => $height, 'max' => $maximagesize, 'pixels' => $pixels]);
+					$image->scaleDown($pixels);
+					$filesize = strlen($image->asString());
+					$width    = $image->getWidth();
+					$height   = $image->getHeight();
+				}
+			}
+
+			if ($filesize > $maximagesize) {
+				DI::logger()->notice('Image size is too big', ['size' => $filesize, 'max' => $maximagesize]);
+				return -1;
+			}
+		}
+
+		$width    = $image->getWidth();
+		$height   = $image->getHeight();
+		$smallest = 0;
+
+		$result = self::store($image, $uid, 0, $resource_id, $filename, $album, 0, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $description);
+		if (!$result) {
+			Logger::warning('Photo could not be stored', ['uid' => $uid, 'resource_id' => $resource_id, 'filename' => $filename, 'album' => $album]);
+			return -1;
+		}
+
+		if ($width > 640 || $height > 640) {
+			$image->scaleDown(640);
+		}
+
+		if ($width > 320 || $height > 320) {
+			$result = self::store($image, $uid, 0, $resource_id, $filename, $album, 1, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $description);
+			if ($result) {
+				$smallest = 1;
+			}
+			$image->scaleDown(320);
+			$result = self::store($image, $uid, 0, $resource_id, $filename, $album, 2, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $description);
+			if ($result && ($smallest == 0)) {
+				$smallest = 2;
+			}
+		}
+		return $smallest;
 	}
 
 	/**

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -463,7 +463,7 @@ class Media
 	 */
 	private static function isLinkToPhoto(string $page, string $preview): bool
 	{
-		return preg_match('#/photo/.*-0\.#ism', $page) && preg_match('#/photo/.*-[01]\.#ism', $preview);
+		return preg_match('#/photo/.*-0\.#ism', $page) && preg_match('#/photo/.*-[012]\.#ism', $preview);
 	}
 
 	/**
@@ -475,7 +475,7 @@ class Media
 	 */
 	private static function isLinkToImagePage(string $page, string $preview): bool
 	{
-		return preg_match('#/photos/.*/image/#ism', $page) && preg_match('#/photo/.*-[01]\.#ism', $preview);
+		return preg_match('#/photos/.*/image/#ism', $page) && preg_match('#/photo/.*-[012]\.#ism', $preview);
 	}
 
 	/**
@@ -489,7 +489,7 @@ class Media
 		if (preg_match_all("#\[url=([^\]]+?)\]\s*\[img=([^\[\]]*)\]([^\[\]]*)\[\/img\]\s*\[/url\]#ism", $body, $pictures, PREG_SET_ORDER)) {
 			foreach ($pictures as $picture) {
 				if (self::isLinkToImagePage($picture[1], $picture[2])) {
-					$body = str_replace($picture[0], '[url=' . str_replace('-1.', '-0.', $picture[2]) . '][img=' . $picture[2] . ']' . $picture[3] . '[/img][/url]', $body);
+					$body = str_replace($picture[0], '[url=' . str_replace(['-1.', '-2.'], '-0.', $picture[2]) . '][img=' . $picture[2] . ']' . $picture[3] . '[/img][/url]', $body);
 				}
 			}
 		}
@@ -497,7 +497,7 @@ class Media
 		if (preg_match_all("#\[url=([^\]]+?)\]\s*\[img\]([^\[]+?)\[/img\]\s*\[/url\]#ism", $body, $pictures, PREG_SET_ORDER)) {
 			foreach ($pictures as $picture) {
 				if (self::isLinkToImagePage($picture[1], $picture[2])) {
-					$body = str_replace($picture[0], '[url=' . str_replace('-1.', '-0.', $picture[2]) . '][img]' . $picture[2] . '[/img][/url]', $body);
+					$body = str_replace($picture[0], '[url=' . str_replace(['-1.', '-2.'], '-0.', $picture[2]) . '][img]' . $picture[2] . '[/img][/url]', $body);
 				}
 			}
 		}
@@ -525,7 +525,7 @@ class Media
 			foreach ($pictures as $picture) {
 				if (self::isLinkToImagePage($picture[1], $picture[2])) {
 					$body = str_replace($picture[0], '', $body);
-					$image = str_replace('-1.', '-0.', $picture[2]);
+					$image = str_replace(['-1.', '-2.'], '-0.', $picture[2]);
 					$attachments[$image] = [
 						'uri-id' => $uriid, 'type' => self::IMAGE, 'url' => $image,
 						'preview' => $picture[2], 'description' => $picture[3]
@@ -557,7 +557,7 @@ class Media
 			foreach ($pictures as $picture) {
 				if (self::isLinkToImagePage($picture[1], $picture[2])) {
 					$body = str_replace($picture[0], '', $body);
-					$image = str_replace('-1.', '-0.', $picture[2]);
+					$image = str_replace(['-1.', '-2.'], '-0.', $picture[2]);
 					$attachments[$image] = [
 						'uri-id' => $uriid, 'type' => self::IMAGE, 'url' => $image,
 						'preview' => $picture[2], 'description' => null

--- a/src/Module/Item/Compose.php
+++ b/src/Module/Item/Compose.php
@@ -191,6 +191,7 @@ class Compose extends BaseModule
 				'editalic'             => $this->l10n->t('Italic'),
 				'eduline'              => $this->l10n->t('Underline'),
 				'edquote'              => $this->l10n->t('Quote'),
+				'$edemojis'            => $this->l10n->t('Add emojis'),
 				'edcode'               => $this->l10n->t('Code'),
 				'edimg'                => $this->l10n->t('Image'),
 				'edurl'                => $this->l10n->t('Link'),

--- a/src/Module/Media/Photo/Upload.php
+++ b/src/Module/Media/Photo/Upload.php
@@ -175,8 +175,8 @@ class Upload extends \Friendica\BaseModule
 
 		$smallest = Photo::storeWithPreview($image, $owner['uid'], $resource_id, $filename, $filesize, $album, '', $allow_cid, '', '', '');
 		if ($smallest < 0) {
-			$this->return(401, $this->t('Image could not be uploaded'));
-			@unlink($src);
+			$this->logger->warning('Photo::store() failed');
+			$this->return(401, $this->t('Image upload failed.'));
 		}
 
 		$this->logger->info('upload done');

--- a/src/Module/Media/Photo/Upload.php
+++ b/src/Module/Media/Photo/Upload.php
@@ -207,13 +207,13 @@ class Upload extends \Friendica\BaseModule
 
 		if ($width > 640 || $height > 640) {
 			$image->scaleDown(640);
+		}
+
+		if ($width > 320 || $height > 320) {
 			$result = Photo::store($image, $owner['uid'], 0, $resource_id, $filename, $album, 1, Photo::DEFAULT, $allow_cid);
 			if ($result) {
 				$smallest = 1;
 			}
-		}
-
-		if ($width > 320 || $height > 320) {
 			$image->scaleDown(320);
 			$result = Photo::store($image, $owner['uid'], 0, $resource_id, $filename, $album, 2, Photo::DEFAULT, $allow_cid);
 			if ($result && ($smallest == 0)) {

--- a/src/Module/Media/Photo/Upload.php
+++ b/src/Module/Media/Photo/Upload.php
@@ -173,14 +173,14 @@ class Upload extends \Friendica\BaseModule
 
 		$allow_cid = '<' . $owner['id'] . '>';
 
-		$smallest = Photo::storeWithPreview($image, $owner['uid'], $resource_id, $filename, $filesize, $album, '', $allow_cid, '', '', '');
-		if ($smallest < 0) {
+		$preview = Photo::storeWithPreview($image, $owner['uid'], $resource_id, $filename, $filesize, $album, '', $allow_cid, '', '', '');
+		if ($preview < 0) {
 			$this->logger->warning('Photo::store() failed');
 			$this->return(401, $this->t('Image upload failed.'));
 		}
 
 		$this->logger->info('upload done');
-		$this->return(200, "\n\n" . '[url=' . $this->baseUrl . '/photos/' . $owner['nickname'] . '/image/' . $resource_id . '][img=' . $this->baseUrl . "/photo/$resource_id-$smallest." . $image->getExt() . "][/img][/url]\n\n");
+		$this->return(200, "\n\n" . '[url=' . $this->baseUrl . '/photos/' . $owner['nickname'] . '/image/' . $resource_id . '][img=' . $this->baseUrl . "/photo/$resource_id-$preview." . $image->getExt() . "][/img][/url]\n\n");
 	}
 
 	/**

--- a/src/Module/Profile/Photos.php
+++ b/src/Module/Profile/Photos.php
@@ -229,36 +229,13 @@ class Photos extends \Friendica\Module\BaseProfile
 			$image->scaleDown($max_length);
 		}
 
-		$width  = $image->getWidth();
-		$height = $image->getHeight();
-
-		$smallest = 0;
-
 		$resource_id = Photo::newResource();
 
-		$r = Photo::store($image, $this->owner['uid'], 0, $resource_id, $filename, $album, 0 , Photo::DEFAULT, $str_contact_allow, $str_group_allow, $str_contact_deny, $str_group_deny);
-
-		if (!$r) {
+		$smallest = Photo::storeWithPreview($image, $this->owner['uid'], $resource_id, $filename, $filesize, $album, '', $str_contact_allow, $str_group_allow, $str_contact_deny, $str_group_deny);
+		if ($smallest < 0) {
 			$this->logger->warning('image store failed');
 			$this->systemMessages->addNotice($this->t('Image upload failed.'));
 			return;
-		}
-
-		if ($width > 640 || $height > 640) {
-			$image->scaleDown(640);
-		}
-
-		if ($width > 320 || $height > 320) {
-			$result = Photo::store($image, $this->owner['uid'], 0, $resource_id, $filename, $album, 1, Photo::DEFAULT, $str_contact_allow, $str_group_allow, $str_contact_deny, $str_group_deny);
-			if ($result) {
-				$smallest = 1;
-			}
-
-			$image->scaleDown(320);
-			$result = Photo::store($image, $this->owner['uid'], 0, $resource_id, $filename, $album, 2, Photo::DEFAULT, $str_contact_allow, $str_group_allow, $str_contact_deny, $str_group_deny);
-			if ($result && ($smallest == 0)) {
-				$smallest = 2;
-			}
 		}
 
 		$uri = Item::newURI();

--- a/src/Module/Profile/Photos.php
+++ b/src/Module/Profile/Photos.php
@@ -231,8 +231,8 @@ class Photos extends \Friendica\Module\BaseProfile
 
 		$resource_id = Photo::newResource();
 
-		$smallest = Photo::storeWithPreview($image, $this->owner['uid'], $resource_id, $filename, $filesize, $album, '', $str_contact_allow, $str_group_allow, $str_contact_deny, $str_group_deny);
-		if ($smallest < 0) {
+		$preview = Photo::storeWithPreview($image, $this->owner['uid'], $resource_id, $filename, $filesize, $album, '', $str_contact_allow, $str_group_allow, $str_contact_deny, $str_group_deny);
+		if ($preview < 0) {
 			$this->logger->warning('image store failed');
 			$this->systemMessages->addNotice($this->t('Image upload failed.'));
 			return;
@@ -274,7 +274,7 @@ class Photos extends \Friendica\Module\BaseProfile
 		$arr['origin']        = 1;
 
 		$arr['body']          = '[url=' . $this->baseUrl . '/photos/' . $this->owner['nickname'] . '/image/' . $resource_id . ']'
-			. '[img]' . $this->baseUrl . "/photo/{$resource_id}-{$smallest}.".$image->getExt() . '[/img]'
+			. '[img]' . $this->baseUrl . "/photo/{$resource_id}-{$preview}.".$image->getExt() . '[/img]'
 			. '[/url]';
 
 		$item_id = Item::insert($arr);

--- a/src/Module/Profile/Photos.php
+++ b/src/Module/Profile/Photos.php
@@ -246,14 +246,19 @@ class Photos extends \Friendica\Module\BaseProfile
 
 		if ($width > 640 || $height > 640) {
 			$image->scaleDown(640);
-			Photo::store($image, $this->owner['uid'], 0, $resource_id, $filename, $album, 1, Photo::DEFAULT, $str_contact_allow, $str_group_allow, $str_contact_deny, $str_group_deny);
-			$smallest = 1;
 		}
 
 		if ($width > 320 || $height > 320) {
+			$result = Photo::store($image, $this->owner['uid'], 0, $resource_id, $filename, $album, 1, Photo::DEFAULT, $str_contact_allow, $str_group_allow, $str_contact_deny, $str_group_deny);
+			if ($result) {
+				$smallest = 1;
+			}
+
 			$image->scaleDown(320);
-			Photo::store($image, $this->owner['uid'], 0, $resource_id, $filename, $album, 2, Photo::DEFAULT, $str_contact_allow, $str_group_allow, $str_contact_deny, $str_group_deny);
-			$smallest = 2;
+			$result = Photo::store($image, $this->owner['uid'], 0, $resource_id, $filename, $album, 2, Photo::DEFAULT, $str_contact_allow, $str_group_allow, $str_contact_deny, $str_group_deny);
+			if ($result && ($smallest == 0)) {
+				$smallest = 2;
+			}
 		}
 
 		$uri = Item::newURI();

--- a/src/Module/Profile/Photos.php
+++ b/src/Module/Profile/Photos.php
@@ -336,7 +336,7 @@ class Photos extends \Friendica\Module\BaseProfile
 			  $sql_extra
 			GROUP BY `resource-id`
 			ORDER BY `created` DESC
-		    LIMIT ? , ?",
+			LIMIT ? , ?",
 			$this->owner['uid'],
 			Photo::DEFAULT,
 			$pager->getStart(),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2023.06-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-04 10:54+0000\n"
+"POT-Creation-Date: 2023-05-09 06:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -293,7 +293,7 @@ msgstr ""
 
 #: mod/message.php:202 mod/message.php:358 mod/photos.php:1291
 #: src/Content/Conversation.php:390 src/Content/Conversation.php:734
-#: src/Module/Item/Compose.php:204 src/Module/Post/Edit.php:145
+#: src/Module/Item/Compose.php:205 src/Module/Post/Edit.php:145
 #: src/Module/Profile/UnkMail.php:154 src/Object/Post.php:550
 msgid "Please wait"
 msgstr ""
@@ -396,22 +396,22 @@ msgid "User not found."
 msgstr ""
 
 #: mod/photos.php:106 src/Module/BaseProfile.php:68
-#: src/Module/Profile/Photos.php:399
+#: src/Module/Profile/Photos.php:381
 msgid "Photo Albums"
 msgstr ""
 
-#: mod/photos.php:107 src/Module/Profile/Photos.php:400
-#: src/Module/Profile/Photos.php:420
+#: mod/photos.php:107 src/Module/Profile/Photos.php:382
+#: src/Module/Profile/Photos.php:402
 msgid "Recent Photos"
 msgstr ""
 
-#: mod/photos.php:109 mod/photos.php:867 src/Module/Profile/Photos.php:402
-#: src/Module/Profile/Photos.php:422
+#: mod/photos.php:109 mod/photos.php:867 src/Module/Profile/Photos.php:384
+#: src/Module/Profile/Photos.php:404
 msgid "Upload New Photos"
 msgstr ""
 
 #: mod/photos.php:121 src/Module/BaseSettings.php:74
-#: src/Module/Profile/Photos.php:383
+#: src/Module/Profile/Photos.php:365
 msgid "everybody"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgid "%1$s was tagged in %2$s by %3$s"
 msgstr ""
 
 #: mod/photos.php:581 src/Module/Conversation/Community.php:188
-#: src/Module/Directory.php:48 src/Module/Profile/Photos.php:315
+#: src/Module/Directory.php:48 src/Module/Profile/Photos.php:297
 #: src/Module/Search/Index.php:65
 msgid "Public access denied."
 msgstr ""
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Show Oldest First"
 msgstr ""
 
-#: mod/photos.php:852 src/Module/Profile/Photos.php:370
+#: mod/photos.php:852 src/Module/Profile/Photos.php:352
 msgid "View Photo"
 msgstr ""
 
@@ -607,7 +607,7 @@ msgstr ""
 
 #: mod/photos.php:1139 mod/photos.php:1195 mod/photos.php:1269
 #: src/Content/Conversation.php:405 src/Module/Calendar/Event/Form.php:248
-#: src/Module/Item/Compose.php:199 src/Module/Post/Edit.php:165
+#: src/Module/Item/Compose.php:200 src/Module/Post/Edit.php:165
 #: src/Object/Post.php:1075
 msgid "Preview"
 msgstr ""
@@ -649,11 +649,11 @@ msgstr ""
 msgid "Map"
 msgstr ""
 
-#: src/App.php:470
+#: src/App.php:473
 msgid "No system theme config value set."
 msgstr ""
 
-#: src/App.php:574
+#: src/App.php:577
 msgid "Apologies but the website is unavailable at the moment."
 msgstr ""
 
@@ -1212,7 +1212,7 @@ msgstr[1] ""
 msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
-#: src/Content/Conversation.php:329 src/Module/Item/Compose.php:198
+#: src/Content/Conversation.php:329 src/Module/Item/Compose.php:199
 #: src/Object/Post.php:1074
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
@@ -1277,27 +1277,27 @@ msgstr ""
 msgid "Quote"
 msgstr ""
 
-#: src/Content/Conversation.php:368 src/Module/Post/Edit.php:175
-#: src/Object/Post.php:1069
+#: src/Content/Conversation.php:368 src/Module/Item/Compose.php:194
+#: src/Module/Post/Edit.php:175 src/Object/Post.php:1069
 msgid "Add emojis"
 msgstr ""
 
-#: src/Content/Conversation.php:369 src/Module/Item/Compose.php:194
+#: src/Content/Conversation.php:369 src/Module/Item/Compose.php:195
 #: src/Module/Post/Edit.php:176 src/Object/Post.php:1070
 msgid "Code"
 msgstr ""
 
-#: src/Content/Conversation.php:370 src/Module/Item/Compose.php:195
+#: src/Content/Conversation.php:370 src/Module/Item/Compose.php:196
 #: src/Object/Post.php:1071
 msgid "Image"
 msgstr ""
 
-#: src/Content/Conversation.php:371 src/Module/Item/Compose.php:196
+#: src/Content/Conversation.php:371 src/Module/Item/Compose.php:197
 #: src/Module/Post/Edit.php:177 src/Object/Post.php:1072
 msgid "Link"
 msgstr ""
 
-#: src/Content/Conversation.php:372 src/Module/Item/Compose.php:197
+#: src/Content/Conversation.php:372 src/Module/Item/Compose.php:198
 #: src/Module/Post/Edit.php:178 src/Object/Post.php:1073
 msgid "Link or Media"
 msgstr ""
@@ -1306,7 +1306,7 @@ msgstr ""
 msgid "Video"
 msgstr ""
 
-#: src/Content/Conversation.php:374 src/Module/Item/Compose.php:200
+#: src/Content/Conversation.php:374 src/Module/Item/Compose.php:201
 #: src/Module/Post/Edit.php:141
 msgid "Set your location"
 msgstr ""
@@ -1323,17 +1323,17 @@ msgstr ""
 msgid "clear location"
 msgstr ""
 
-#: src/Content/Conversation.php:379 src/Module/Item/Compose.php:205
+#: src/Content/Conversation.php:379 src/Module/Item/Compose.php:206
 #: src/Module/Post/Edit.php:157
 msgid "Set title"
 msgstr ""
 
-#: src/Content/Conversation.php:381 src/Module/Item/Compose.php:206
+#: src/Content/Conversation.php:381 src/Module/Item/Compose.php:207
 #: src/Module/Post/Edit.php:159
 msgid "Categories (comma-separated list)"
 msgstr ""
 
-#: src/Content/Conversation.php:386 src/Module/Item/Compose.php:222
+#: src/Content/Conversation.php:386 src/Module/Item/Compose.php:223
 msgid "Scheduled at"
 msgstr ""
 
@@ -3272,7 +3272,7 @@ msgstr ""
 msgid "[no subject]"
 msgstr ""
 
-#: src/Model/Photo.php:1189 src/Module/Media/Photo/Upload.php:197
+#: src/Model/Photo.php:1188 src/Module/Media/Photo/Upload.php:171
 msgid "Wall Photos"
 msgstr ""
 
@@ -7227,21 +7227,21 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: src/Module/Item/Compose.php:201
+#: src/Module/Item/Compose.php:202
 msgid "Clear the location"
 msgstr ""
 
-#: src/Module/Item/Compose.php:202
+#: src/Module/Item/Compose.php:203
 msgid "Location services are unavailable on your device"
 msgstr ""
 
-#: src/Module/Item/Compose.php:203
+#: src/Module/Item/Compose.php:204
 msgid ""
 "Location services are disabled. Please check the website's permissions on "
 "your device"
 msgstr ""
 
-#: src/Module/Item/Compose.php:209
+#: src/Module/Item/Compose.php:210
 msgid ""
 "You can make this page always open when you use the New Post button in the "
 "<a href=\"/settings/display\">Theme Customization settings</a>."
@@ -7312,14 +7312,7 @@ msgstr ""
 msgid "Unable to process image."
 msgstr ""
 
-#: src/Module/Media/Photo/Upload.php:187 src/Module/Profile/Photos.php:164
-#: src/Module/Profile/Photos.php:167 src/Module/Profile/Photos.php:194
-#: src/Module/Settings/Profile/Photo/Index.php:59
-#, php-format
-msgid "Image exceeds size limit of %s"
-msgstr ""
-
-#: src/Module/Media/Photo/Upload.php:205 src/Module/Profile/Photos.php:243
+#: src/Module/Media/Photo/Upload.php:179 src/Module/Profile/Photos.php:237
 #: src/Module/Settings/Profile/Photo/Index.php:95
 msgid "Image upload failed."
 msgstr ""
@@ -8349,22 +8342,29 @@ msgstr ""
 
 #: src/Module/Profile/Conversations.php:106
 #: src/Module/Profile/Conversations.php:109 src/Module/Profile/Profile.php:351
-#: src/Module/Profile/Profile.php:354 src/Protocol/Feed.php:1032
+#: src/Module/Profile/Profile.php:354 src/Protocol/Feed.php:1090
 #: src/Protocol/OStatus.php:1007
 #, php-format
 msgid "%s's timeline"
 msgstr ""
 
 #: src/Module/Profile/Conversations.php:107 src/Module/Profile/Profile.php:352
-#: src/Protocol/Feed.php:1036 src/Protocol/OStatus.php:1012
+#: src/Protocol/Feed.php:1094 src/Protocol/OStatus.php:1012
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
 #: src/Module/Profile/Conversations.php:108 src/Module/Profile/Profile.php:353
-#: src/Protocol/Feed.php:1039 src/Protocol/OStatus.php:1016
+#: src/Protocol/Feed.php:1097 src/Protocol/OStatus.php:1016
 #, php-format
 msgid "%s's comments"
+msgstr ""
+
+#: src/Module/Profile/Photos.php:164 src/Module/Profile/Photos.php:167
+#: src/Module/Profile/Photos.php:194
+#: src/Module/Settings/Profile/Photo/Index.php:59
+#, php-format
+msgid "Image exceeds size limit of %s"
 msgstr ""
 
 #: src/Module/Profile/Photos.php:170
@@ -8385,7 +8385,7 @@ msgstr ""
 msgid "Image file is empty."
 msgstr ""
 
-#: src/Module/Profile/Photos.php:376
+#: src/Module/Profile/Photos.php:358
 msgid "View Album"
 msgstr ""
 


### PR DESCRIPTION
Until now the preview picture calculation had been:
- If the picture is larger than 640 pixel, then reduce it to 640 pixels and store it with the scale 1.
- If the picture is larger than 320 pixel, then reduce it to 320 pixels and store it with the scale 2.

This lead to the problem that picture smaller than 640 but larger than 320 lead to some small preview picture.

The rule is now changed to:
- If the picture is larger than 640 pixel, then reduce it to 640 pixels. If it is larger than 320 pixels then store  it with the scale 1.
- If the picture is larger than 320 pixel, then reduce it to 320 pixels and store it with the scale 2.

The image size detection (and automatic resize if the image exceeds the size limit) is now centralized as well and will now work at all situations where photos are uploaded.

Also it improves the detection of preview pictures by also accepting the size "2".

And finally it contains some unrelated small fix: A missing template variable for the new emojis feature.