### PR TITLE
Ensure that the baseurl return value is a string

### DIFF
--- a/mod/message.php
+++ b/mod/message.php
@@ -54,11 +54,10 @@ function message_init(App $a)
 		'$tabs' => $tabs,
 		'$new'  => $new,
 	]);
-	$base = DI::baseUrl();
 
 	$head_tpl = Renderer::getMarkupTemplate('message-head.tpl');
 	DI::page()['htmlhead'] .= Renderer::replaceMacros($head_tpl, [
-		'$base'    => $base
+		'$base' => (string)DI::baseUrl()
 	]);
 }
 

--- a/src/Content/Smilies.php
+++ b/src/Content/Smilies.php
@@ -106,7 +106,7 @@ class Smilies
 
 		];
 
-		$baseUrl = DI::baseUrl();
+		$baseUrl = (string)DI::baseUrl();
 
 		$icons = [
 		'<img class="smiley" src="' . $baseUrl . '/images/smiley-heart.gif" alt="&lt;3" title="&lt;3" />',

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -918,9 +918,7 @@ class Photo
 	 */
 	public static function getResourceData(string $name): array
 	{
-		$base = DI::baseUrl();
-
-		$guid = str_replace([Strings::normaliseLink($base), '/photo/'], '', Strings::normaliseLink($name));
+		$guid = str_replace([Strings::normaliseLink((string)DI::baseUrl()), '/photo/'], '', Strings::normaliseLink($name));
 
 		if (parse_url($guid, PHP_URL_SCHEME)) {
 			return [];
@@ -982,9 +980,7 @@ class Photo
 	 */
 	public static function isLocalPage(string $name): bool
 	{
-		$base = DI::baseUrl();
-
-		$guid = str_replace(Strings::normaliseLink($base), '', Strings::normaliseLink($name));
+		$guid = str_replace(Strings::normaliseLink((string)DI::baseUrl()), '', Strings::normaliseLink($name));
 		$guid = preg_replace("=/photos/.*/image/(.*)=ism", '$1', $guid);
 		if (empty($guid)) {
 			return false;

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -167,7 +167,7 @@ class User
 		$system['region'] = '';
 		$system['postal-code'] = '';
 		$system['country-name'] = '';
-		$system['homepage'] = DI::baseUrl();
+		$system['homepage'] = (string)DI::baseUrl();
 		$system['dob'] = '0000-00-00';
 
 		// Ensure that the user contains data

--- a/src/Module/HCard.php
+++ b/src/Module/HCard.php
@@ -64,9 +64,9 @@ class HCard extends BaseModule
 			$page['htmlhead'] .= '<link rel="openid.delegate" href="' . $delegate . '" />' . "\r\n";
 		}
 
-		$baseUrl = DI::baseUrl();
+		$baseUrl = (string)DI::baseUrl();
 
-		$uri = urlencode('acct:' . $profile['nickname'] . '@' . $baseUrl->getHost() . ($baseUrl->getPath() ? '/' . $baseUrl->getPath() : ''));
+		$uri = urlencode('acct:' . $profile['nickname'] . '@' . DI::baseUrl()->getHost() . (DI::baseUrl()->getPath() ? '/' . DI::baseUrl()->getPath() : ''));
 
 		$page['htmlhead'] .= '<meta name="dfrn-global-visibility" content="' . ($profile['net-publish'] ? 'true' : 'false') . '" />' . "\r\n";
 		$page['htmlhead'] .= '<link rel="alternate" type="application/atom+xml" href="' . $baseUrl . '/dfrn_poll/' . $nickname . '" />' . "\r\n";

--- a/src/Module/OpenSearch.php
+++ b/src/Module/OpenSearch.php
@@ -40,7 +40,7 @@ class OpenSearch extends BaseModule
 	protected function rawContent(array $request = [])
 	{
 		$hostname = DI::baseUrl()->getHost();
-		$baseUrl  = DI::baseUrl();
+		$baseUrl  = (string)DI::baseUrl();
 
 		/** @var DOMDocument $xml */
 		XML::fromArray([

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -298,7 +298,7 @@ class Register extends BaseModule
 
 		$user = $result['user'];
 
-		$base_url = DI::baseUrl();
+		$base_url = (string)DI::baseUrl();
 
 		if ($netpublish && intval(DI::config()->get('config', 'register_policy')) !== self::APPROVE) {
 			$url = $base_url . '/profile/' . $user['nickname'];

--- a/src/Module/WellKnown/HostMeta.php
+++ b/src/Module/WellKnown/HostMeta.php
@@ -46,7 +46,7 @@ class HostMeta extends BaseModule
 			$config->set('system', 'site_pubkey', $res['pubkey']);
 		}
 
-		$domain = DI::baseUrl();
+		$domain = (string)DI::baseUrl();
 
 		XML::fromArray([
 			'XRD' => [

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -330,7 +330,7 @@ class Transmitter
 		return [
 			'type' => 'Service',
 			'name' =>  App::PLATFORM . " '" . App::CODENAME . "' " . App::VERSION . '-' . DB_UPDATE_VERSION,
-			'url' => DI::baseUrl()
+			'url' => (string)DI::baseUrl()
 		];
 	}
 

--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -45,7 +45,7 @@ $is_singleuser_class = $is_singleuser ? "is-singleuser" : "is-not-singleuser";
 	<head>
 		<title><?php if (!empty($page['title'])) echo $page['title'] ?></title>
 		<meta request="<?php echo htmlspecialchars($_REQUEST['pagename'] ?? '') ?>">
-		<script  type="text/javascript">var baseurl = "<?php echo DI::baseUrl(); ?>";</script>
+		<script  type="text/javascript">var baseurl = "<?php echo (string)DI::baseUrl(); ?>";</script>
 		<script type="text/javascript">var frio = "<?php echo 'view/theme/frio'; ?>";</script>
 <?php
 		// Because we use minimal for modals the header and the included js stuff should be only loaded

--- a/view/theme/smoothly/theme.php
+++ b/view/theme/smoothly/theme.php
@@ -45,7 +45,7 @@ function smoothly_init(App $a) {
 
 	$cssFile = null;
 	$ssl_state = false;
-	$baseurl = DI::baseUrl();
+	$baseurl = (string)DI::baseUrl();
 	DI::page()['htmlhead'] .= <<< EOT
 
 <script>
@@ -112,7 +112,7 @@ if (! function_exists('_js_in_foot')) {
 		/** @purpose insert stuff in bottom of page
 		*/
 		$ssl_state = false;
-		$baseurl = DI::baseUrl();
+		$baseurl = (string)DI::baseUrl();
 		$bottom['$baseurl'] = $baseurl;
 		$tpl = Renderer::getMarkupTemplate('bottom.tpl');
 

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -137,8 +137,7 @@ function vier_community_info()
 	$show_lastusers  = get_vier_config("show_lastusers", 1);
 
 	// get_baseurl
-	$url = DI::baseUrl();
-	$aside['$url'] = $url;
+	$aside['$url'] = $url = (string)DI::baseUrl();
 
 	// community_profiles
 	if ($show_profiles) {


### PR DESCRIPTION
This PR fixes the problem that the `service` entry in the transmitted data contains some class content instead of the base url. To avoid any other problem, the return value is now casted at places that might cause a problem.