### PR TITLE
Escape notification text in /notifications module

### DIFF
--- a/view/templates/notifications/notification.tpl
+++ b/view/templates/notifications/notification.tpl
@@ -1,4 +1,4 @@
 
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}" {{if $item_seen}}aria-hidden="true"{{/if}}>
-	<a href="{{$notification.link}}"><img src="{{$notification.image}}" aria-hidden="true" class="notif-image">{{$notification.text nofilter}} <span class="notif-when">{{$notification.ago}}</span></a>
+	<a href="{{$notification.link}}"><img src="{{$notification.image}}" aria-hidden="true" class="notif-image">{{$notification.text}} <span class="notif-when">{{$notification.ago}}</span></a>
 </div>


### PR DESCRIPTION
Thanks to @kstrauser for the tip!

- This was causing literal HTML display names to be interpreted in the page

This could motivate an early release once https://github.com/friendica/friendica/pull/13115 is merged as well.