### PR TITLE
fix for probe loop in case that network of contact has changed

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2682,6 +2682,8 @@ class Contact
 			return true;
 		}
 
+                $has_local_data = self::hasLocalData($id, $contact);
+
 		$uid = $contact['uid'];
 		unset($contact['uid']);
 
@@ -2702,9 +2704,7 @@ class Contact
 
 		$updated = DateTimeFormat::utcNow();
 
-		$has_local_data = self::hasLocalData($id, $contact);
-
-		if (!Probe::isProbable($ret['network'])) {
+		if (!Probe::isProbable($ret['network']) && !Probe::isProbable($contact['network'])) {
 			// Periodical checks are only done on federated contacts
 			$failed_next_update  = null;
 			$success_next_update = null;


### PR DESCRIPTION
This fixes a loop of probes / contact updates where the network has been apup and for whatever reason is now feed. In this case the contact hasn't been updated and rescheduled with next_update as null resulting in a huge number of queries.

The call to hasLocalData has been moved a bit up as it checks for values that otherwise would be emptied before the call.

Fixes #13037

@annando: I think there are a few more lines to check in this file which looks suspicious to me, like
```
line 2719: if (Strings::normaliseLink($contact['url']) != Strings::normaliseLink($ret['url'])) {
line 2740: if (Strings::normaliseLink($ret['url']) != Strings::normaliseLink($contact['url'])) {
```
where 2740 seems to be never reached.
