### PR TITLE
Restore searching on WebFinger handles prefixed with @

### DIFF
--- a/src/Core/Search.php
+++ b/src/Core/Search.php
@@ -57,38 +57,36 @@ class Search
 	 */
 	public static function getContactsFromProbe(string $user): ResultList
 	{
-		$emptyResultList = new ResultList(1, 0, 1);
+		$emptyResultList = new ResultList();
 
-		if ((filter_var($user, FILTER_VALIDATE_EMAIL) && Network::isEmailDomainValid($user)) ||
-		    (substr(Strings::normaliseLink($user), 0, 7) == 'http://')) {
-
-			$user_data = Contact::getByURL($user);
-			if (empty($user_data)) {
-				return $emptyResultList;
-			}
-
-			if (!in_array($user_data['network'], Protocol::FEDERATED)) {
-				return $emptyResultList;
-			}
-
-			$contactDetails = Contact::getByURLForUser($user_data['url'] ?? '', DI::userSession()->getLocalUserId());
-
-			$result = new ContactResult(
-				$user_data['name'] ?? '',
-				$user_data['addr'] ?? '',
-				($contactDetails['addr'] ?? '') ?: ($user_data['url'] ?? ''),
-				new Uri($user_data['url'] ?? ''),
-				$user_data['photo'] ?? '',
-				$user_data['network'] ?? '',
-				$contactDetails['cid'] ?? 0,
-				$user_data['id'] ?? 0,
-				$user_data['tags'] ?? ''
-			);
-
-			return new ResultList(1, 1, 1, [$result]);
-		} else {
+		if (empty(parse_url($user, PHP_URL_SCHEME)) && !(filter_var($user, FILTER_VALIDATE_EMAIL) || Network::isEmailDomainValid($user))) {
 			return $emptyResultList;
 		}
+
+		$user_data = Contact::getByURL($user);
+		if (empty($user_data)) {
+			return $emptyResultList;
+		}
+
+		if (!Protocol::supportsProbe($user_data['network'])) {
+			return $emptyResultList;
+		}
+
+		$contactDetails = Contact::getByURLForUser($user_data['url'], DI::userSession()->getLocalUserId());
+
+		$result = new ContactResult(
+			$user_data['name'],
+			$user_data['addr'],
+			$user_data['addr'] ?: $user_data['url'],
+			new Uri($user_data['url']),
+			$user_data['photo'],
+			$user_data['network'],
+			$contactDetails['cid'] ?? 0,
+			$user_data['id'],
+			$user_data['tags']
+		);
+
+		return new ResultList(1, 1, 1, [$result]);
 	}
 
 	/**

--- a/src/Module/BaseSearch.php
+++ b/src/Module/BaseSearch.php
@@ -62,6 +62,7 @@ class BaseSearch extends BaseModule
 		}
 
 		$header = '';
+		$results = new ResultList();
 
 		if (strpos($search, '@') === 0) {
 			$search  = trim(substr($search, 1));
@@ -91,14 +92,14 @@ class BaseSearch extends BaseModule
 
 		$pager = new Pager(DI::l10n(), DI::args()->getQueryString(), $itemsPerPage);
 
-		if ($localSearch && empty($results)) {
-			$pager->setItemsPerPage(80);
-			$results = Search::getContactsFromLocalDirectory($search, $type, $pager->getStart(), $pager->getItemsPerPage());
-		} elseif (Search::getGlobalDirectory() && empty($results)) {
-			$results = Search::getContactsFromGlobalDirectory($search, $type, $pager->getPage());
-			$pager->setItemsPerPage($results->getItemsPage());
-		} else {
-			$results = new ResultList();
+		if (!$results->getTotal()) {
+			if ($localSearch) {
+				$pager->setItemsPerPage(80);
+				$results = Search::getContactsFromLocalDirectory($search, $type, $pager->getStart(), $pager->getItemsPerPage());
+			} elseif (Search::getGlobalDirectory()) {
+				$results = Search::getContactsFromGlobalDirectory($search, $type, $pager->getPage());
+				$pager->setItemsPerPage($results->getItemsPage());
+			}
 		}
 
 		return self::printResult($results, $pager, $header);


### PR DESCRIPTION
Replace https://github.com/friendica/friendica/pull/13115 without weakening the return type of `-`Core\Search::getContactsFromProbe`

Most of the credit goes to @annando, it was easier to submit my change request this way.