### PR TITLE
Unify the heading levels

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1403,12 +1403,32 @@ class BBCode
 				}
 
 				// Check for headers
-				$text = preg_replace("(\[h1\](.*?)\[\/h1\])ism", '</p><h1>$1</h1><p>', $text);
-				$text = preg_replace("(\[h2\](.*?)\[\/h2\])ism", '</p><h2>$1</h2><p>', $text);
-				$text = preg_replace("(\[h3\](.*?)\[\/h3\])ism", '</p><h3>$1</h3><p>', $text);
-				$text = preg_replace("(\[h4\](.*?)\[\/h4\])ism", '</p><h4>$1</h4><p>', $text);
-				$text = preg_replace("(\[h5\](.*?)\[\/h5\])ism", '</p><h5>$1</h5><p>', $text);
-				$text = preg_replace("(\[h6\](.*?)\[\/h6\])ism", '</p><h6>$1</h6><p>', $text);
+
+				if ($simple_html == self::INTERNAL) {
+					//Ensure to always start with <h4> if possible
+					$heading_count = 0;
+					for ($level = 6; $level > 0; $level--) { 
+						if (preg_match("(\[h$level\].*?\[\/h$level\])ism", $text)) {
+							$heading_count++;
+						}
+					}
+					if ($heading_count > 0) {
+						$heading = min($heading_count + 3, 6);
+						for ($level = 6; $level > 0; $level--) { 
+							if (preg_match("(\[h$level\].*?\[\/h$level\])ism", $text)) {
+								$text = preg_replace("(\[h$level\](.*?)\[\/h$level\])ism", "</p><h$heading>$1</h$heading><p>", $text);
+								$heading--;
+							}
+						}
+					}
+				} else {
+					$text = preg_replace("(\[h1\](.*?)\[\/h1\])ism", '</p><h1>$1</h1><p>', $text);
+					$text = preg_replace("(\[h2\](.*?)\[\/h2\])ism", '</p><h2>$1</h2><p>', $text);
+					$text = preg_replace("(\[h3\](.*?)\[\/h3\])ism", '</p><h3>$1</h3><p>', $text);
+					$text = preg_replace("(\[h4\](.*?)\[\/h4\])ism", '</p><h4>$1</h4><p>', $text);
+					$text = preg_replace("(\[h5\](.*?)\[\/h5\])ism", '</p><h5>$1</h5><p>', $text);
+					$text = preg_replace("(\[h6\](.*?)\[\/h6\])ism", '</p><h6>$1</h6><p>', $text);
+				}
 
 				// Check for paragraph
 				$text = preg_replace("(\[p\](.*?)\[\/p\])ism", '<p>$1</p>', $text);

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -259,12 +259,12 @@ Karl Marx - Die ursprüngliche Akkumulation
 				'text' => '[emoji=https://fedi.underscore.world/emoji/custom/custom/heart_nb.png]:heart_nb:[/emoji]',
 			],
 			'task-12900-multiple-paragraphs' => [
-				'expectedHTML' => '<h1>Header</h1><ul><li>One</li><li>Two</li></ul><p>This is a paragraph<br>with a line feed.</p><p>Second Chapter</p>',
-				'text' => "[h1]Header[/h1][ul][*]One[*]Two[/ul]\n\nThis is a paragraph\nwith a line feed.\n\nSecond Chapter",
+				'expectedHTML' => '<h4>Header</h4><ul><li>One</li><li>Two</li></ul><p>This is a paragraph<br>with a line feed.</p><p>Second Chapter</p>',
+				'text' => "[h4]Header[/h4][ul][*]One[*]Two[/ul]\n\nThis is a paragraph\nwith a line feed.\n\nSecond Chapter",
 			],
 			'task-12900-header-with-paragraphs' => [
-				'expectedHTML' => '<h1>Header</h1><p>Some Chapter</p>',
-				'text' => '[h1]Header[/h1]Some Chapter',
+				'expectedHTML' => '<h4>Header</h4><p>Some Chapter</p>',
+				'text' => '[h4]Header[/h4]Some Chapter',
 			],
 			'bug-12842-ul-newlines' => [
 				'expectedHTML' => '<p>This is:</p><ul><li>some</li><li>amazing</li><li>list</li></ul>',


### PR DESCRIPTION
On the different networks people use different heading levels. This coding here unifies the behaviour. Headings will now mostly start as `<h4>` (like the title). The start level will only increase if there are more than 3 levels in a single post.