### PR TITLE
Vagrant/libvirt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,8 @@ Ignore config files from VSCode
 /proxy/
 nbproject
 
-#ignore vagrant dir
+#ignore vagrant file and  dir
+Vagrantfile
 .vagrant/
 
 #ignore local folder

--- a/Vagrantfile.libvirt
+++ b/Vagrantfile.libvirt
@@ -1,0 +1,46 @@
+
+server_memory = "2048" # MB
+server_timezone = "UTC"
+public_folder = "/vagrant"
+
+Vagrant.configure(2) do |config|
+	# Set server to Debian 11 / Bullseye 64bit
+	config.vm.box = "debian/bullseye64"
+
+	# Disable automatic box update checking. If you disable this, then
+	# boxes will only be checked for updates when the user runs
+	# `vagrant box outdated`. This is not recommended.
+	config.vm.box_check_update = true
+
+	# Create a hostname, don't forget to put it to the `hosts` file
+	# This will point to the server's default virtual host
+	# TO DO: Make this work with virtualhost along-side xip.io URL
+	config.vm.hostname = "friendica.local"
+
+	config.vm.define "libvirt" do |virt|
+		virt.vm.synced_folder './', public_folder, id: "vagrant-root", type: '9p', disabled: false, accessmode: "squash"
+
+
+	virt.vm.provider :libvirt do |libvirt|
+		libvirt.uri = "qemu:///session"
+			libvirt.driver = "kvm"
+			#libvirt.cpu_model = "qemu64"
+			#libvirt.cpus = 1
+			libvirt.cpu_mode = 'host-passthrough'
+			libvirt.nested = true
+			libvirt.disk_bus = "virtio"
+			libvirt.disk_driver :cache => "writeback"
+			libvirt.memory = server_memory
+			libvirt.memorybacking :access, :mode => "shared"
+			libvirt.nic_model_type = "virtio"
+			libvirt.numa_nodes = [{ :cpus => "0-0", :memory => server_memory, :memAccess => "shared" }]
+			libvirt.video_type = "virtio"
+	  end
+	end
+
+  	# Enable provisioning with a shell script.
+	config.vm.provision "shell", path: "./bin/dev/vagrant_provision.sh", privileged: true
+	config.vm.provision "shell", path: "./bin/dev/vagrant_libvirt_provision.sh", privileged: true
+		# run: "always"
+		# run: "once"
+end

--- a/Vagrantfile.vbox
+++ b/Vagrantfile.vbox
@@ -41,10 +41,6 @@ Vagrant.configure(2) do |config|
     end
   end
 
-  config.vm.provider :libvirt do |libvirt|
-  	libvirt.memory = server_memory
-  end
-
   # Enable provisioning with a shell script.
   config.vm.provision "shell", path: "./bin/dev/vagrant_provision.sh", privileged: true
     # run: "always"

--- a/bin/dev/vagrant_libvirt_provision.sh
+++ b/bin/dev/vagrant_libvirt_provision.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# 9p write files as 'vagrant:vagrant' always.
+# let's run apache as 'vagrant' user to get around write permissions issues
+sed -i 's/www-data/vagrant/g' /etc/apache2/envvars
+systemctl restart apache2
+
+# I can't find a way to set static ip with libvirt, so configure friendica
+# with current ip
+MYIP=$(hostname -I | tr -d ' ')
+sed -i "s|'url' =>.*|'url' => 'http://$MYIP',|" /var/www/config/local.config.php
+echo "########################"
+echo
+echo "  http://$MYIP/"
+echo
+echo "########################"

--- a/bin/dev/vagrant_provision.sh
+++ b/bin/dev/vagrant_provision.sh
@@ -111,6 +111,9 @@ cp /vagrant/.htaccess-dist /vagrant/.htaccess
 # create the friendica database
 echo "create database friendica DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" | $MYSQL -u root -proot
 
+# install vendor
+bin/composer.phar install
+
 # install friendica
 bin/console autoinstall -f /vagrant/mods/local.config.vagrant.php
 


### PR DESCRIPTION
As seems impossible (or at least not easy) to have a single Vagrantfile
with suitable configuration for different backends, this commit add two
backend-specific Vagrantfile.
It's up to the user to choose which to symlink (or copy) to `Vagranfile`
before running vagrant.

- Rename Vagrantfile to Vagrantfile.vbox
- Add Vagrantfile.libvirt
- Add libvirt specific provision script
- Add 'Vagrantfile' to gitignore