### PR TITLE
Fix wrong CSS class name after renaming "forum" to "group"

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -453,7 +453,7 @@ td.federation-data {
 }
 
 /* group list widget */
-.grouplist-img {
+.group-list-img {
   height: 20px;
   width: 20px;
   vertical-align: middle;


### PR DESCRIPTION
Follow-up to #13183
Related to https://github.com/friendica/friendica/issues/13114