### PR TITLE
Notification link for direct comment fixed

### DIFF
--- a/src/Navigation/Notifications/Factory/Notification.php
+++ b/src/Navigation/Notifications/Factory/Notification.php
@@ -171,7 +171,7 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 					}
 				}
 
-				if (($Notification->verb != Activity::POST) || !in_array($Notification->type, [Post\UserNotification::TYPE_DIRECT_THREAD_COMMENT, Post\UserNotification::TYPE_IMPLICIT_TAGGED])) {
+				if (($Notification->verb != Activity::POST) || !in_array($Notification->type, [Post\UserNotification::TYPE_DIRECT_THREAD_COMMENT, Post\UserNotification::TYPE_IMPLICIT_TAGGED, Post\UserNotification::TYPE_DIRECT_COMMENT])) {
 					$link_item = $item;
 				}
 			}


### PR DESCRIPTION
This fixes the notication link for comments on comments that falsely linked to the comment that the commenter commented on and not the comment of the commenter that commented on the comment.