### PR TITLE
Language check moved to a separate function

### DIFF
--- a/src/Contact/Avatar.php
+++ b/src/Contact/Avatar.php
@@ -92,7 +92,7 @@ class Avatar
 			return $fields;
 		}
 
-		$filename  = self::getFilename($contact['url']);
+		$filename  = self::getFilename($contact['url'], $avatar);
 		$timestamp = time();
 
 		$fields['blurhash'] = $image->getBlurHash();
@@ -120,7 +120,7 @@ class Avatar
 			return $fields;
 		}
 
-		$filename  = self::getFilename($contact['url']);
+		$filename  = self::getFilename($contact['url'], $contact['avatar']);
 		$timestamp = time();
 
 		$fields['photo'] = self::storeAvatarCache($image, $filename, Proxy::PIXEL_SMALL, $timestamp);
@@ -130,9 +130,9 @@ class Avatar
 		return $fields;
 	}
 
-	private static function getFilename(string $url): string
+	private static function getFilename(string $url, string $host): string
 	{
-		$guid = Item::guidFromUri($url);
+		$guid = Item::guidFromUri($url, $host);
 
 		return substr($guid, 0, 2) . '/' . substr($guid, 3, 2) . '/' . substr($guid, 5, 3) . '/' .
 			substr($guid, 9, 2) .'/' . substr($guid, 11, 2) . '/' . substr($guid, 13, 4). '/' . substr($guid, 18) . '-';

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -62,6 +62,7 @@ class BBCode
 	const TWITTER      = 8;
 	const BACKLINK     = 8;
 	const ACTIVITYPUB  = 9;
+	const BLUESKY      = 10;
 
 	const TOP_ANCHOR = '<br class="top-anchor">';
 	const BOTTOM_ANCHOR = '<br class="button-anchor">';
@@ -1771,7 +1772,7 @@ class BBCode
 					$text
 				);
 
-				if (in_array($simple_html, [self::OSTATUS, self::TWITTER])) {
+				if (in_array($simple_html, [self::OSTATUS, self::TWITTER, self::BLUESKY])) {
 					$text = preg_replace_callback("/([^#@!])\[url\=([^\]]*)\](.*?)\[\/url\]/ism", [self::class, 'expandLinksCallback'], $text);
 					//$text = preg_replace("/[^#@!]\[url\=([^\]]*)\](.*?)\[\/url\]/ism", ' $2 [url]$1[/url]', $text);
 					$text = preg_replace("/\[bookmark\=([^\]]*)\](.*?)\[\/bookmark\]/ism", ' $2 [url]$1[/url]', $text);

--- a/src/Content/Text/Plaintext.php
+++ b/src/Content/Text/Plaintext.php
@@ -137,6 +137,10 @@ class Plaintext
 				$abstract = BBCode::getAbstract($item['body'], Protocol::STATUSNET);
 				break;
 
+			case BBCode::BLUESKY:
+				$abstract = BBCode::getAbstract($item['body'], Protocol::BLUESKY);
+				break;
+	
 			default: // We don't know the exact target.
 				// We fetch an abstract since there is a posting limit.
 				if ($limit > 0) {

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2773,7 +2773,7 @@ class Contact
 		}
 
 		$update = false;
-		$guid = ($ret['guid'] ?? '') ?: Item::guidFromUri($ret['url']);
+		$guid = ($ret['guid'] ?? '') ?: Item::guidFromUri($ret['url'], $ret['baseurl'] ?: $ret['alias']);
 
 		// make sure to not overwrite existing values with blank entries except some technical fields
 		$keep = ['batch', 'notify', 'poll', 'request', 'confirm', 'poco', 'baseurl'];

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2044,7 +2044,7 @@ class Item
 		// Remove the scheme to make sure that "https" and "http" doesn't make a difference
 		unset($parsed['scheme']);
 
-		$hostPart = $host ?? $parsed['host'] ?? '';
+		$hostPart = $host ?: $parsed['host'] ?? '';
 		if (!$hostPart) {
 			Logger::warning('Empty host GUID part', ['uri' => $uri, 'host' => $host, 'parsed' => $parsed, 'callstack' => System::callstack(10)]);
 		}


### PR DESCRIPTION
There is a language check when receiving relay postings. This ensures that you don't receive posts in languages that none of your users do understand. This language check has now been moved to a separate function so that it can be used from outside the relay functionality as well.

This PR also contains some changes that are needed for PR https://git.friendi.ca/friendica/friendica-addons/pulls/1396