### PR TITLE
Remove the "www." from the styled URL

### DIFF
--- a/src/Util/Strings.php
+++ b/src/Util/Strings.php
@@ -570,7 +570,7 @@ class Strings
 	public static function getStyledURL(string $url): string
 	{
 		$parts = parse_url($url);
-		$scheme = $parts['scheme'] . '://';
+		$scheme = [$parts['scheme'] . '://www.', $parts['scheme'] . '://'];
 		$styled_url = str_replace($scheme, '', $url);
 
 		if (strlen($styled_url) > 30) {


### PR DESCRIPTION
The removal of "www." improves the visual appearance of links.