### PR TITLE
[frio] Remove reference to nonexistent CSS file

### DIFF
--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -51,8 +51,6 @@
 	type="text/css" media="screen" />
 <link rel="stylesheet" href="view/js/fancybox/jquery.fancybox.min.css?v={{$smarty.const.FRIENDICA_VERSION}}"
 	type="text/css" media="screen" />
-<link rel="stylesheet" href="view/js/button/frio.css?v={{$smarty.const.FRIENDICA_VERSION}}"
-	type="text/css" media="screen" />
 
 {{* own css files *}}
 <link rel="stylesheet" href="view/theme/frio/css/hovercard.css?v={{$smarty.const.FRIENDICA_VERSION}}" type="text/css"


### PR DESCRIPTION
This removes the only occasion I found for the nonexistent file `/view/js/button/frio.css`.

Fixes #13201 