### PR TITLE
Added type-hints, reformatted arrays

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -752,8 +752,8 @@ class Database
 				@file_put_contents(
 					$this->config->get('system', 'db_log'),
 					DateTimeFormat::utcNow() . "\t" . $duration . "\t" .
-					basename($backtrace[1]["file"]) . "\t" .
-					$backtrace[1]["line"] . "\t" . $backtrace[2]["function"] . "\t" .
+					basename($backtrace[1]['file']) . "\t" .
+					$backtrace[1]['line'] . "\t" . $backtrace[2]['function'] . "\t" .
 					substr($this->replaceParameters($sql, $args), 0, 4000) . "\n",
 					FILE_APPEND
 				);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2560,7 +2560,7 @@ class Contact
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function updateFromProbe(int $id, string $network = '')
+	public static function updateFromProbe(int $id, string $network = ''): bool
 	{
 		$contact = DBA::selectFirst('contact', ['uid', 'url'], ['id' => $id]);
 		if (!DBA::isResult($contact)) {

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -346,6 +346,7 @@ class Probe
 	 * @return array uri data
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
+	 * @todo Choice: implement $cache parameter or remove documentation
 	 */
 	public static function uri(string $uri, string $network = '', int $uid = -1): array
 	{
@@ -1181,7 +1182,6 @@ class Probe
 			$data = self::pollHcard($profile_link, $data, true);
 		}
 
-		$prof_data = [];
 
 		if (empty($data['addr']) || empty($data['nick'])) {
 			$probe_data = self::uri($profile_link);
@@ -1189,15 +1189,17 @@ class Probe
 			$data['nick'] = ($data['nick'] ?? '') ?: $probe_data['nick'];
 		}
 
-		$prof_data['addr']         = $data['addr'];
-		$prof_data['nick']         = $data['nick'];
-		$prof_data['dfrn-request'] = $data['request'] ?? null;
-		$prof_data['dfrn-confirm'] = $data['confirm'] ?? null;
-		$prof_data['dfrn-notify']  = $data['notify']  ?? null;
-		$prof_data['dfrn-poll']    = $data['poll']    ?? null;
-		$prof_data['photo']        = $data['photo']   ?? null;
-		$prof_data['fn']           = $data['name']    ?? null;
-		$prof_data['key']          = $data['pubkey']  ?? null;
+		$prof_data = [
+			'addr'         => $data['addr'],
+			'nick'         => $data['nick'],
+			'dfrn-request' => $data['request'] ?? null,
+			'dfrn-confirm' => $data['confirm'] ?? null,
+			'dfrn-notify'  => $data['notify']  ?? null,
+			'dfrn-poll'    => $data['poll']    ?? null,
+			'photo'        => $data['photo']   ?? null,
+			'fn'           => $data['name']    ?? null,
+			'key'          => $data['pubkey']  ?? null,
+		];
 
 		Logger::debug('Result', ['link' => $profile_link, 'data' => $prof_data]);
 

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -341,12 +341,10 @@ class Probe
 	 * @param string  $uri     Address that should be probed
 	 * @param string  $network Test for this specific network
 	 * @param integer $uid     User ID for the probe (only used for mails)
-	 * @param boolean $cache   Use cached values?
 	 *
 	 * @return array uri data
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
-	 * @todo Choice: implement $cache parameter or remove documentation
 	 */
 	public static function uri(string $uri, string $network = '', int $uid = -1): array
 	{

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2839,7 +2839,7 @@ class Diaspora
 	public static function buildMagicEnvelope(string $msg, array $user): string
 	{
 		$b64url_data = Strings::base64UrlEncode($msg);
-		$data = str_replace(["\n", "\r", " ", "\t"], ['', '', '', ''], $b64url_data);
+		$data = str_replace(["\n", "\r", ' ', "\t"], ['', '', '', ''], $b64url_data);
 
 		$key_id = Strings::base64UrlEncode(self::myHandle($user));
 		$type = 'application/xml';
@@ -2857,11 +2857,11 @@ class Diaspora
 
 		$xmldata = [
 			'me:env' => [
-				'me:data' => $data,
-				'@attributes' => ['type' => $type],
-				'me:encoding' => $encoding,
-				'me:alg' => $alg,
-				'me:sig' => $sig,
+				'me:data'      => $data,
+				'@attributes'  => ['type' => $type],
+				'me:encoding'  => $encoding,
+				'me:alg'       => $alg,
+				'me:sig'       => $sig,
 				'@attributes2' => ['key_id' => $key_id]
 			]
 		];

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -42,6 +42,7 @@ use Friendica\Model\Tag;
 use Friendica\Model\User;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException;
+use Friendica\Network\HTTPException\BadRequestException;
 use Friendica\Network\Probe;
 use Friendica\Protocol\Delivery;
 use Friendica\Util\Crypto;
@@ -267,7 +268,7 @@ class Diaspora
 				if ($no_exit) {
 					return false;
 				} else {
-					throw new \Friendica\Network\HTTPException\BadRequestException();
+					throw new BadRequestException();
 				}
 			}
 		} else {
@@ -281,7 +282,7 @@ class Diaspora
 			if ($no_exit) {
 				return false;
 			} else {
-				throw new \Friendica\Network\HTTPException\BadRequestException();
+				throw new BadRequestException();
 			}
 		}
 
@@ -307,7 +308,7 @@ class Diaspora
 			if ($no_exit) {
 				return false;
 			} else {
-				throw new \Friendica\Network\HTTPException\BadRequestException();
+				throw new BadRequestException();
 			}
 		}
 
@@ -322,7 +323,7 @@ class Diaspora
 			if ($no_exit) {
 				return false;
 			} else {
-				throw new \Friendica\Network\HTTPException\BadRequestException();
+				throw new BadRequestException();
 			}
 		}
 
@@ -332,7 +333,7 @@ class Diaspora
 			if ($no_exit) {
 				return false;
 			} else {
-				throw new \Friendica\Network\HTTPException\BadRequestException();
+				throw new BadRequestException();
 			}
 		}
 
@@ -424,7 +425,7 @@ class Diaspora
 
 		if (!$base) {
 			Logger::notice('unable to locate salmon data in xml');
-			throw new \Friendica\Network\HTTPException\BadRequestException();
+			throw new BadRequestException();
 		}
 
 
@@ -444,13 +445,10 @@ class Diaspora
 		$encoding = $base->encoding;
 		$alg = $base->alg;
 
-
 		$signed_data = $data . '.' . Strings::base64UrlEncode($type) . '.' . Strings::base64UrlEncode($encoding) . '.' . Strings::base64UrlEncode($alg);
-
 
 		// decode the data
 		$data = Strings::base64UrlDecode($data);
-
 
 		if ($public) {
 			$inner_decrypted = $data;
@@ -467,14 +465,14 @@ class Diaspora
 		$key = self::key($author);
 		if (!$key) {
 			Logger::notice('Could not retrieve author key.');
-			throw new \Friendica\Network\HTTPException\BadRequestException();
+			throw new BadRequestException();
 		}
 
 		$verify = Crypto::rsaVerify($signed_data, $signature, $key);
 
 		if (!$verify) {
 			Logger::notice('Message did not verify. Discarding.');
-			throw new \Friendica\Network\HTTPException\BadRequestException();
+			throw new BadRequestException();
 		}
 
 		Logger::info('Message verified.');
@@ -499,8 +497,7 @@ class Diaspora
 	 */
 	public static function dispatchPublic(array $msg, int $direction)
 	{
-		$enabled = intval(DI::config()->get('system', 'diaspora_enabled'));
-		if (!$enabled) {
+		if (!DI::config()->get('system', 'diaspora_enabled')) {
 			Logger::notice('Diaspora is disabled');
 			return false;
 		}
@@ -940,7 +937,7 @@ class Diaspora
 	{
 		$item = Post::selectFirst(['id'], ['uid' => $uid, 'guid' => $guid]);
 		if (DBA::isResult($item)) {
-			Logger::notice('Message ' . $guid . ' already exists for user ' . $uid);
+			Logger::notice('Message already exists.', ['uid' => $uid, 'guid' => $guid, 'id' => $item['id']]);
 			return $item['id'];
 		}
 
@@ -951,6 +948,7 @@ class Diaspora
 	 * Checks for links to posts in a message
 	 *
 	 * @param array $item The item array
+	 *
 	 * @return void
 	 */
 	private static function fetchGuid(array $item)
@@ -2569,19 +2567,21 @@ class Diaspora
 	 *
 	 * @param int $uriid
 	 * @param object $photo
+	 *
 	 * @return void
 	 */
 	private static function storePhotoAsMedia(int $uriid, $photo)
 	{
 		// @TODO Need to find object type, roland@f.haeder.net
 		Logger::debug('photo=' . get_class($photo));
-		$data = [];
-		$data['uri-id'] = $uriid;
-		$data['type'] = Post\Media::IMAGE;
-		$data['url'] = XML::unescape($photo->remote_photo_path) . XML::unescape($photo->remote_photo_name);
-		$data['height'] = (int)XML::unescape($photo->height ?? 0);
-		$data['width'] = (int)XML::unescape($photo->width ?? 0);
-		$data['description'] = XML::unescape($photo->text ?? '');
+		$data = [
+			'uri-id'      => $uriid,
+			'type'        => Post\Media::IMAGE,
+			'url'         => XML::unescape($photo->remote_photo_path) . XML::unescape($photo->remote_photo_name),
+			'height'      => (int)XML::unescape($photo->height ?? 0),
+			'width'       => (int)XML::unescape($photo->width ?? 0),
+			'description' => XML::unescape($photo->text ?? ''),
+		];
 
 		Post\Media::insert($data);
 	}
@@ -2653,7 +2653,25 @@ class Diaspora
 
 		$raw_body = $body = Markdown::toBBCode($text);
 
-		$datarray = [];
+		$datarray = [
+			'guid'        => $guid,
+			'uri-id'      => ItemURI::insert(['uri' => $guid, 'guid' => $guid]),
+			'uid'         => $importer['uid'],
+			'contact-id'  => $contact['id'],
+			'network'     => Protocol::DIASPORA,
+			'author-link' => $contact['url'],
+			'author-id'   => Contact::getIdForURL($contact['url'], 0),
+			'verb'        => Activity::POST,
+			'gravity'     => Item::GRAVITY_PARENT,
+			'protocol'    => Conversation::PARCEL_DIASPORA,
+			'source'      => $xml,
+			'body'        => self::replacePeopleGuid($body, $contact['url']),
+			'raw-body'    => self::replacePeopleGuid($raw_body, $contact['url']),
+			'private'     => (($public == 'false') ? Item::PRIVATE : Item::PUBLIC),
+			// Default is note (aka. comment), later below is being checked the real type
+			'object-type' => Activity\ObjectType::NOTE,
+			'post-type'   => Item::PT_NOTE,
+		];
 
 		$datarray['guid'] = $guid;
 		$datarray['uri'] = $datarray['thr-parent'] = self::getUriFromGuid($guid, $author);
@@ -2670,9 +2688,6 @@ class Diaspora
 		} elseif ($data->poll) {
 			$datarray['object-type'] = Activity\ObjectType::NOTE;
 			$datarray['post-type'] = Item::PT_POLL;
-		} else {
-			$datarray['object-type'] = Activity\ObjectType::NOTE;
-			$datarray['post-type'] = Item::PT_NOTE;
 		}
 
 		/// @todo enable support for polls
@@ -2683,27 +2698,6 @@ class Diaspora
 		//}
 
 		/// @todo enable support for events
-
-		$datarray['uid'] = $importer['uid'];
-		$datarray['contact-id'] = $contact['id'];
-		$datarray['network'] = Protocol::DIASPORA;
-
-		$datarray['author-link'] = $contact['url'];
-		$datarray['author-id'] = Contact::getIdForURL($contact['url'], 0);
-
-		$datarray['owner-link'] = $datarray['author-link'];
-		$datarray['owner-id'] = $datarray['author-id'];
-
-		$datarray['verb'] = Activity::POST;
-		$datarray['gravity'] = Item::GRAVITY_PARENT;
-
-		$datarray['protocol'] = Conversation::PARCEL_DIASPORA;
-		$datarray['source'] = $xml;
-
-		$datarray = self::setDirection($datarray, $direction);
-
-		$datarray['body'] = self::replacePeopleGuid($body, $contact['url']);
-		$datarray['raw-body'] = self::replacePeopleGuid($raw_body, $contact['url']);
 
 		self::storeMentions($datarray['uri-id'], $text);
 		Tag::storeRawTagsFromBody($datarray['uri-id'], $datarray['body']);
@@ -2718,7 +2712,6 @@ class Diaspora
 		}
 
 		$datarray['plink'] = self::plink($author, $guid);
-		$datarray['private'] = (($public == 'false') ? Item::PRIVATE : Item::PUBLIC);
 		$datarray['changed'] = $datarray['created'] = $datarray['edited'] = $created_at;
 
 		if (isset($address['address'])) {

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -42,7 +42,6 @@ use Friendica\Model\Tag;
 use Friendica\Model\User;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException;
-use Friendica\Network\HTTPException\BadRequestException;
 use Friendica\Network\Probe;
 use Friendica\Protocol\Delivery;
 use Friendica\Util\Crypto;
@@ -268,7 +267,7 @@ class Diaspora
 				if ($no_exit) {
 					return false;
 				} else {
-					throw new BadRequestException();
+					throw new HTTPException\BadRequestException();
 				}
 			}
 		} else {
@@ -282,7 +281,7 @@ class Diaspora
 			if ($no_exit) {
 				return false;
 			} else {
-				throw new BadRequestException();
+				throw new HTTPException\BadRequestException();
 			}
 		}
 
@@ -308,7 +307,7 @@ class Diaspora
 			if ($no_exit) {
 				return false;
 			} else {
-				throw new BadRequestException();
+				throw new HTTPException\BadRequestException();
 			}
 		}
 
@@ -323,7 +322,7 @@ class Diaspora
 			if ($no_exit) {
 				return false;
 			} else {
-				throw new BadRequestException();
+				throw new HTTPException\BadRequestException();
 			}
 		}
 
@@ -333,7 +332,7 @@ class Diaspora
 			if ($no_exit) {
 				return false;
 			} else {
-				throw new BadRequestException();
+				throw new HTTPException\BadRequestException();
 			}
 		}
 
@@ -425,7 +424,7 @@ class Diaspora
 
 		if (!$base) {
 			Logger::notice('unable to locate salmon data in xml');
-			throw new BadRequestException();
+			throw new HTTPException\BadRequestException();
 		}
 
 
@@ -465,14 +464,14 @@ class Diaspora
 		$key = self::key($author);
 		if (!$key) {
 			Logger::notice('Could not retrieve author key.');
-			throw new BadRequestException();
+			throw new HTTPException\BadRequestException();
 		}
 
 		$verify = Crypto::rsaVerify($signed_data, $signature, $key);
 
 		if (!$verify) {
 			Logger::notice('Message did not verify. Discarding.');
-			throw new BadRequestException();
+			throw new HTTPException\BadRequestException();
 		}
 
 		Logger::info('Message verified.');
@@ -2686,7 +2685,6 @@ class Diaspora
 			$datarray['object-type'] = Activity\ObjectType::IMAGE;
 			$datarray['post-type'] = Item::PT_IMAGE;
 		} elseif ($data->poll) {
-			$datarray['object-type'] = Activity\ObjectType::NOTE;
 			$datarray['post-type'] = Item::PT_POLL;
 		}
 

--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -385,12 +385,14 @@ class OStatus
 			}
 		}
 
-		$header = [];
-		$header['uid'] = $importer['uid'];
-		$header['network'] = Protocol::OSTATUS;
-		$header['wall'] = 0;
-		$header['origin'] = 0;
-		$header['gravity'] = Item::GRAVITY_COMMENT;
+		// Initial header elements
+		$header = [
+			'uid'     => $importer['uid'],
+			'network' => Protocol::OSTATUS,
+			'wall'    => 0,
+			'origin'  => 0,
+			'gravity' => Item::GRAVITY_COMMENT,
+		];
 
 		if (!is_object($doc->firstChild) || empty($doc->firstChild->tagName)) {
 			return false;

--- a/src/Security/TwoFactor/Model/AppSpecificPassword.php
+++ b/src/Security/TwoFactor/Model/AppSpecificPassword.php
@@ -32,12 +32,12 @@ use PragmaRX\Random\Random;
  */
 class AppSpecificPassword
 {
-	public static function countForUser($uid)
+	public static function countForUser(int $uid)
 	{
 		return DBA::count('2fa_app_specific_password', ['uid' => $uid]);
 	}
 
-	public static function checkDuplicateForUser($uid, $description)
+	public static function checkDuplicateForUser(int $uid, string $description): bool
 	{
 		return DBA::exists('2fa_app_specific_password', ['uid' => $uid, 'description' => $description]);
 	}
@@ -50,7 +50,7 @@ class AppSpecificPassword
 	 * @return bool
 	 * @throws \Exception
 	 */
-	public static function authenticateUser($uid, $plaintextPassword)
+	public static function authenticateUser(int $uid, string $plaintextPassword): bool
 	{
 		$appSpecificPasswords = self::getListForUser($uid);
 
@@ -79,7 +79,7 @@ class AppSpecificPassword
      * @return array
      * @throws \Exception
      */
-	public static function getListForUser($uid)
+	public static function getListForUser(int $uid): array
 	{
 		$appSpecificPasswordsStmt = DBA::select('2fa_app_specific_password', ['id', 'description', 'hashed_password', 'last_used'], ['uid' => $uid]);
 
@@ -102,7 +102,7 @@ class AppSpecificPassword
      * @return array The new app-specific password data structure with the plaintext password added
      * @throws \Exception
      */
-	public static function generateForUser(int $uid, $description)
+	public static function generateForUser(int $uid, string $description): array
 	{
 		$Random = (new Random())->size(40);
 
@@ -111,10 +111,10 @@ class AppSpecificPassword
 		$generated = DateTimeFormat::utcNow();
 
 		$fields = [
-			'uid' => $uid,
-			'description' => $description,
+			'uid'             => $uid,
+			'description'     => $description,
 			'hashed_password' => User::hashPassword($plaintextPassword),
-			'generated' => $generated,
+			'generated'       => $generated,
 		];
 
 		DBA::insert('2fa_app_specific_password', $fields);
@@ -125,7 +125,7 @@ class AppSpecificPassword
 		return $fields;
 	}
 
-	private static function update($appSpecificPasswordId, $fields)
+	private static function update(int $appSpecificPasswordId, array $fields)
 	{
 		return DBA::update('2fa_app_specific_password', $fields, ['id' => $appSpecificPasswordId]);
 	}

--- a/src/Security/TwoFactor/Model/RecoveryCode.php
+++ b/src/Security/TwoFactor/Model/RecoveryCode.php
@@ -35,10 +35,11 @@ class RecoveryCode
      * Returns the number of code the provided users can still use to replace a TOTP code
      *
      * @param int $uid User ID
+     *
      * @return int
      * @throws \Exception
      */
-    public static function countValidForUser($uid)
+    public static function countValidForUser(int $uid): int
 	{
 		return DBA::count('2fa_recovery_codes', ['uid' => $uid, 'used' => null]);
 	}
@@ -46,12 +47,13 @@ class RecoveryCode
     /**
      * Checks the provided code is available to use for login by the provided user
      *
-     * @param  int $uid User ID
+     * @param int $uid User ID
      * @param string $code
+     *
      * @return bool
      * @throws \Exception
      */
-	public static function existsForUser($uid, $code)
+	public static function existsForUser(int $uid, string $code): bool
 	{
 		return DBA::exists('2fa_recovery_codes', ['uid' => $uid, 'code' => $code, 'used' => null]);
 	}
@@ -60,10 +62,11 @@ class RecoveryCode
      * Returns a complete list of all recovery codes for the provided user, including the used status
      *
      * @param  int $uid User ID
+     *
      * @return array
      * @throws \Exception
      */
-	public static function getListForUser($uid)
+	public static function getListForUser(int $uid): array
 	{
 		$codesStmt = DBA::select('2fa_recovery_codes', ['code', 'used'], ['uid' => $uid]);
 
@@ -76,10 +79,11 @@ class RecoveryCode
      *
      * @param  int $uid User ID
      * @param string $code
+     *
      * @return bool
      * @throws \Exception
      */
-	public static function markUsedForUser($uid, $code)
+	public static function markUsedForUser(int $uid, string $code): bool
 	{
 		DBA::update('2fa_recovery_codes', ['used' => DateTimeFormat::utcNow()], ['uid' => $uid, 'code' => $code, 'used' => null]);
 
@@ -91,9 +95,11 @@ class RecoveryCode
      * Generates 12 codes constituted of 2 blocks of 6 characters separated by a dash.
      *
      * @param  int $uid User ID
+     * @return void
+     *
      * @throws \Exception
      */
-	public static function generateForUser($uid)
+	public static function generateForUser(int $uid)
 	{
 		$Random = (new Random())->pattern('[a-z0-9]');
 
@@ -120,9 +126,11 @@ class RecoveryCode
      * Deletes all the recovery codes for the provided user.
      *
      * @param  int $uid User ID
+     * @return void
+     *
      * @throws \Exception
      */
-	public static function deleteForUser($uid)
+	public static function deleteForUser(int $uid)
 	{
 		DBA::delete('2fa_recovery_codes', ['uid' => $uid]);
 	}
@@ -131,9 +139,11 @@ class RecoveryCode
      * Replaces the existing recovery codes for the provided user by a freshly generated set.
      *
      * @param  int $uid User ID
+     * @return void
+     *
      * @throws \Exception
      */
-	public static function regenerateForUser($uid)
+	public static function regenerateForUser(int $uid)
 	{
 		self::deleteForUser($uid);
 		self::generateForUser($uid);

--- a/src/Security/TwoFactor/Repository/TrustedBrowser.php
+++ b/src/Security/TwoFactor/Repository/TrustedBrowser.php
@@ -143,6 +143,7 @@ class TrustedBrowser
 
 	/**
 	 * @param int $local_user
+	 *
 	 * @return bool
 	 */
 	public function removeAllForUser(int $local_user): bool


### PR DESCRIPTION
Changes:
- add type-hints
- replaced double-quotes with single
- changed a lot $array['foo'] into a single `$foo = ['foo' => $somethingFoo, 'bar' => $somethingBar];`