### PR TITLE
Fix Mastodon API Status->Context endpoint so doesn't return deleted statuses

### DIFF
--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -56,6 +56,7 @@ class Context extends BaseApi
 
 		$parents  = [];
 		$children = [];
+		$deleted  = [];
 
 		$parent = Post::selectOriginal(['uri-id', 'parent-uri-id'], ['uri-id' => $id]);
 		if (DBA::isResult($parent)) {
@@ -66,11 +67,11 @@ class Context extends BaseApi
 			if (!empty($request['max_id'])) {
 				$condition = DBA::mergeConditions($condition, ["`uri-id` < ?", $request['max_id']]);
 			}
-	
+
 			if (!empty($request['since_id'])) {
 				$condition = DBA::mergeConditions($condition, ["`uri-id` > ?", $request['since_id']]);
 			}
-	
+
 			if (!empty($request['min_id'])) {
 				$condition = DBA::mergeConditions($condition, ["`uri-id` > ?", $request['min_id']]);
 				$params['order'] = ['uri-id'];
@@ -82,8 +83,8 @@ class Context extends BaseApi
 					["NOT `author-id` IN (SELECT `cid` FROM `user-contact` WHERE `uid` = ? AND (`blocked` OR `ignored`))", $uid]
 				);
 			}
-	
-			$posts = Post::selectPosts(['uri-id', 'thr-parent-id'], $condition, $params);
+
+			$posts = Post::selectPosts(['uri-id', 'thr-parent-id', 'deleted'], $condition, $params);
 			while ($post = Post::fetch($posts)) {
 				if ($post['uri-id'] == $post['thr-parent-id']) {
 					continue;
@@ -93,6 +94,10 @@ class Context extends BaseApi
 				$parents[$post['uri-id']] = $post['thr-parent-id'];
 
 				$children[$post['thr-parent-id']][] = $post['uri-id'];
+
+				if ($post['deleted']) {
+					$deleted[] = $post['uri-id'];
+				}
 			}
 			DBA::close($posts);
 
@@ -117,7 +122,7 @@ class Context extends BaseApi
 
 		$statuses = ['ancestors' => [], 'descendants' => []];
 
-		$ancestors = self::getParents($id, $parents);
+		$ancestors = array_diff(self::getParents($id, $parents), $deleted);
 
 		asort($ancestors);
 
@@ -127,7 +132,7 @@ class Context extends BaseApi
 			$statuses['ancestors'][] = DI::mstdnStatus()->createFromUriId($ancestor, $uid, $display_quotes);
 		}
 
-		$descendants = self::getChildren($id, $children);
+		$descendants = array_diff(self::getChildren($id, $children), $deleted);
 
 		asort($descendants);
 


### PR DESCRIPTION
The current status context endpoint returns any and all comments created on a post. For example this post:
![image](https://github.com/friendica/friendica/assets/1683691/271f7869-70f5-49be-876f-6baed3e1ef45)

There are actually several deleted posts there, for a total ten over the lifetime of that post. I believe we were aware of this problem before but hadn't thought of a good way of addressing it. We thought we'd need the deleted posts to create the hierarchy so that if a comment was deleted with child comments then the child comments would still show up just like they do in the UI. 

This fix addresses this by keeping track of the deleted statuses during the traversal. During the final ancestor and descendants list building it subtracts out any uri-ids that were marked as deleted. 