### PR TITLE
Fix: Unseen marker wasn't set / Don't mark activities as unseen

### DIFF
--- a/src/Model/Post/User.php
+++ b/src/Model/Post/User.php
@@ -25,6 +25,8 @@ use Friendica\Database\DBA;
 use \BadMethodCallException;
 use Friendica\Database\Database;
 use Friendica\DI;
+use Friendica\Model\Item;
+use Friendica\Protocol\Activity;
 
 class User
 {
@@ -49,8 +51,8 @@ class User
 		$fields['uri-id'] = $uri_id;
 		$fields['uid'] = $uid;
 
-		// Public posts are always seen
-		if ($uid == 0) {
+		// Public posts and activities (like, dislike, ...) are always seen
+		if ($uid == 0 || (($data['gravity'] == Item::GRAVITY_ACTIVITY) && ($data['verb'] != Activity::ANNOUNCE))) {
 			$fields['unseen'] = false;
 		}
 

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -471,7 +471,7 @@ class Network extends BaseModule
 		}
 
 		if (DBA::isResult($items)) {
-			$parents = array_column($items, 'parent-uri-id');
+			$parents = array_column($items, 'uri-id');
 		} else {
 			$parents = [];
 		}


### PR DESCRIPTION
This fixes the problem that the "unseen" marker wasn't set, when the network stream was filtered (group, circle, ...).

Also this PR introduces a small change. The "unseen" marker now isn't set anymore on "likes", "dislikes" and similar activities since it doesn't really add new content to the network stream when someone presses the "like" button.