### PR TITLE
Configuration key api_mastodon_banner added

### DIFF
--- a/src/Object/Api/Mastodon/Instance.php
+++ b/src/Object/Api/Mastodon/Instance.php
@@ -91,7 +91,7 @@ class Instance extends BaseDataTransferObject
 		$this->version           = '2.8.0 (compatible; Friendica ' . App::VERSION . ')';
 		$this->urls              = null; // Not supported
 		$this->stats             = new Stats($config, $database);
-		$this->thumbnail         = $baseUrl . $config->get('config', 'api_mastodon_banner');
+		$this->thumbnail         = $baseUrl . $config->get('api', 'mastodon_banner');
 		$this->languages         = [$config->get('system', 'language')];
 		$this->max_toot_chars    = (int)$config->get('config', 'api_import_size', $config->get('config', 'max_import_size'));
 		$this->registrations     = ($register_policy != Register::CLOSED);

--- a/src/Object/Api/Mastodon/Instance.php
+++ b/src/Object/Api/Mastodon/Instance.php
@@ -91,7 +91,7 @@ class Instance extends BaseDataTransferObject
 		$this->version           = '2.8.0 (compatible; Friendica ' . App::VERSION . ')';
 		$this->urls              = null; // Not supported
 		$this->stats             = new Stats($config, $database);
-		$this->thumbnail         = $baseUrl . '/images/friendica-banner.jpg';
+		$this->thumbnail         = $baseUrl . $config->get('config', 'api_mastodon_banner');
 		$this->languages         = [$config->get('system', 'language')];
 		$this->max_toot_chars    = (int)$config->get('config', 'api_import_size', $config->get('config', 'max_import_size'));
 		$this->registrations     = ($register_policy != Register::CLOSED);

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -91,6 +91,10 @@ return [
 		// php_path (String)
 		// Location of PHP command line processor.
 		'php_path' => 'php',
+
+		// api_mastodon_banner (String)
+		// Banner for Mastodon API
+		'api_mastodon_banner' => '/images/friendica-banner.jpg',
 	],
 	'system' => [
 		// adjust_poll_frequency (Boolean)

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -91,10 +91,6 @@ return [
 		// php_path (String)
 		// Location of PHP command line processor.
 		'php_path' => 'php',
-
-		// api_mastodon_banner (String)
-		// Banner for Mastodon API
-		'api_mastodon_banner' => '/images/friendica-banner.jpg',
 	],
 	'system' => [
 		// adjust_poll_frequency (Boolean)
@@ -784,5 +780,10 @@ return [
 		// use_sub_dirs (Boolean)
 		// By default the template cache is stored in several subdirectories.
 		'use_sub_dirs' => true,
+	],
+	'api' => [
+		// mastodon_banner (String)
+		// Banner for Mastodon API
+		'mastodon_banner' => '/images/friendica-banner.jpg',
 	],
 ];


### PR DESCRIPTION
Added:
- config key 'config', 'api_mastodon_banner', see discussion at https://b65.me.in/display/67fef576-1564-a27a-405e-c17705255720
- the administrator can now customize it for Mastodon contacts
- credits goes to `@betamax65@b65.me.in`