### PR TITLE
Update PHP versions and add PHP 8.2 for testing

### DIFF
--- a/.woodpecker/.phpunit.yml
+++ b/.woodpecker/.phpunit.yml
@@ -5,9 +5,11 @@ matrix:
     - PHP_MAJOR_VERSION: 7.4
       PHP_VERSION: 7.4.33
     - PHP_MAJOR_VERSION: 8.0
-      PHP_VERSION: 8.0.25
+      PHP_VERSION: 8.0.29
     - PHP_MAJOR_VERSION: 8.1
-      PHP_VERSION: 8.1.12
+      PHP_VERSION: 8.1.20
+    - PHP_MAJOR_VERSION: 8.2
+      PHP_VERSION: 8.2.7
 
 # This forces PHP Unit executions at the "opensocial" labeled location (because of much more power...)
 labels:


### PR DESCRIPTION
This is a suggestion for your CI pipelines to include PHP 8.2 for testing.