### PR TITLE
Decouple conversation creation from rendering

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -104,7 +104,7 @@ function item_edit(int $uid, array $request, bool $preview, string $return_path)
 	}
 
 	$post['edit'] = $post;
-	$post['file'] = Post\Category::getTextByURIId($post['uri-id'], $post['uid']);	
+	$post['file'] = Post\Category::getTextByURIId($post['uri-id'], $post['uid']);
 
 	Post\Media::deleteByURIId($post['uri-id'], [Post\Media::AUDIO, Post\Media::VIDEO, Post\Media::IMAGE, Post\Media::HTML]);
 	$post = item_process($post, $request, $preview, $return_path);
@@ -274,7 +274,7 @@ function item_process(array $post, array $request, bool $preview, string $return
 		$post['body']           = BBCode::removeSharedData(Item::setHashtags($post['body']));
 		$post['writable']       = true;
 
-		$o = DI::conversation()->create([$post], Conversation::MODE_SEARCH, false, true);
+		$o = DI::conversation()->render([$post], Conversation::MODE_SEARCH, false, true);
 
 		System::jsonExit(['preview' => $o]);
 	}

--- a/mod/notes.php
+++ b/mod/notes.php
@@ -85,7 +85,7 @@ function notes_content(App $a, bool $update = false)
 
 		$count = count($notes);
 
-		$o .= DI::conversation()->create($notes, Conversation::MODE_NOTES, $update);
+		$o .= DI::conversation()->render($notes, Conversation::MODE_NOTES, $update);
 	}
 
 	$o .= $pager->renderMinimal($count);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1626,7 +1626,7 @@ class Contact
 				}
 			}
 
-			$o .= DI::conversation()->create($items, ConversationContent::MODE_CONTACTS, $update, false, 'pinned_commented', DI::userSession()->getLocalUserId());
+			$o .= DI::conversation()->render($items, ConversationContent::MODE_CONTACTS, $update, false, 'pinned_commented', DI::userSession()->getLocalUserId());
 		} else {
 			$fields = array_merge(Item::DISPLAY_FIELDLIST, ['featured']);
 			$items = Post::toArray(Post::selectForUser(DI::userSession()->getLocalUserId(), $fields, $condition, $params));
@@ -1643,7 +1643,7 @@ class Contact
 				}
 			}
 
-			$o .= DI::conversation()->create($items, ConversationContent::MODE_CONTACT_POSTS, $update);
+			$o .= DI::conversation()->render($items, ConversationContent::MODE_CONTACT_POSTS, $update);
 		}
 
 		if (!$update) {

--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -92,7 +92,7 @@ class Community extends BaseModule
 					'accesskey' => 'l'
 				];
 			}
-	
+
 			if (DI::userSession()->isAuthenticated() || in_array(self::$page_style, [self::LOCAL_AND_GLOBAL, self::GLOBAL])) {
 				$tabs[] = [
 					'label' => DI::l10n()->t('Global Community'),
@@ -110,14 +110,14 @@ class Community extends BaseModule
 			Nav::setSelected('community');
 
 			DI::page()['aside'] .= Widget::accountTypes('community/' . self::$content, self::$accountTypeString);
-	
+
 			if (DI::userSession()->getLocalUserId() && DI::config()->get('system', 'community_no_sharer')) {
 				$path = self::$content;
 				if (!empty($this->parameters['accounttype'])) {
 					$path .= '/' . $this->parameters['accounttype'];
 				}
 				$query_parameters = [];
-		
+
 				if (!empty($_GET['min_id'])) {
 					$query_parameters['min_id'] = $_GET['min_id'];
 				}
@@ -127,7 +127,7 @@ class Community extends BaseModule
 				if (!empty($_GET['last_commented'])) {
 					$query_parameters['max_id'] = $_GET['last_commented'];
 				}
-		
+
 				$path_all = $path . (!empty($query_parameters) ? '?' . http_build_query($query_parameters) : '');
 				$path_no_sharer = $path . '?' . http_build_query(array_merge($query_parameters, ['no_sharer' => true]));
 				DI::page()['aside'] .= Renderer::replaceMacros(Renderer::getMarkupTemplate('widget/community_sharer.tpl'), [
@@ -139,7 +139,7 @@ class Community extends BaseModule
 					'$no_sharer_label' => DI::l10n()->t('Hide'),
 				]);
 			}
-	
+
 			if (Feature::isEnabled(DI::userSession()->getLocalUserId(), 'trending_tags')) {
 				DI::page()['aside'] .= TrendingTags::getHTML(self::$content);
 			}
@@ -157,7 +157,7 @@ class Community extends BaseModule
 			return $o;
 		}
 
-		$o .= DI::conversation()->create($items, Conversation::MODE_COMMUNITY, false, false, 'commented', DI::userSession()->getLocalUserId());
+		$o .= DI::conversation()->render($items, Conversation::MODE_COMMUNITY, false, false, 'commented', DI::userSession()->getLocalUserId());
 
 		$pager = new BoundariesPager(
 			DI::l10n(),
@@ -339,7 +339,7 @@ class Community extends BaseModule
 				$condition[0] .= " AND NOT `uri-id` IN (SELECT `uri-id` FROM `post-user` WHERE `post-user`.`uid` = ? AND `post-user`.`uri-id` = `post-thread-user-view`.`uri-id`)";
 				$condition[] = DI::userSession()->getLocalUserId();
 			}
-	
+
 			if (isset($max_id)) {
 				$condition[0] .= " AND `commented` < ?";
 				$condition[] = $max_id;

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -201,7 +201,7 @@ class Network extends BaseModule
 			$ordering = '`commented`';
 		}
 
-		$o .= DI::conversation()->create($items, Conversation::MODE_NETWORK, false, false, $ordering, DI::userSession()->getLocalUserId());
+		$o .= DI::conversation()->render($items, Conversation::MODE_NETWORK, false, false, $ordering, DI::userSession()->getLocalUserId());
 
 		if (DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'infinite_scroll')) {
 			$o .= HTML::scrollLoader();

--- a/src/Module/Item/Display.php
+++ b/src/Module/Item/Display.php
@@ -275,7 +275,7 @@ class Display extends BaseModule
 			$output .= $this->conversation->statusEditor([], 0, true);
 		}
 
-		$output .= $this->conversation->create([$item], Conversation::MODE_DISPLAY, $updateUid, false, 'commented', $itemUid);
+		$output .= $this->conversation->render([$item], Conversation::MODE_DISPLAY, $updateUid, false, 'commented', $itemUid);
 
 		return $output;
 	}

--- a/src/Module/Profile/Conversations.php
+++ b/src/Module/Profile/Conversations.php
@@ -240,7 +240,7 @@ class Conversations extends BaseProfile
 			$items  = array_merge($items, $pinned);
 		}
 
-		$o .= $this->conversation->create($items, Conversation::MODE_PROFILE, false, false, 'pinned_received', $profile['uid']);
+		$o .= $this->conversation->render($items, Conversation::MODE_PROFILE, false, false, 'pinned_received', $profile['uid']);
 
 		$o .= $pager->renderMinimal(count($items));
 

--- a/src/Module/Search/Filed.php
+++ b/src/Module/Search/Filed.php
@@ -99,7 +99,7 @@ class Filed extends BaseSearch
 
 		$items = Post::toArray(Post::selectForUser(DI::userSession()->getLocalUserId(), Item::DISPLAY_FIELDLIST, $item_condition, $item_params));
 
-		$o .= DI::conversation()->create($items, Conversation::MODE_FILED, false, false, '', DI::userSession()->getLocalUserId());
+		$o .= DI::conversation()->render($items, Conversation::MODE_FILED, false, false, '', DI::userSession()->getLocalUserId());
 
 		if (DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'infinite_scroll')) {
 			$o .= HTML::scrollLoader();

--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -213,7 +213,7 @@ class Index extends BaseSearch
 
 		Logger::info('Start Conversation.', ['q' => $search]);
 
-		$o .= DI::conversation()->create($items, Conversation::MODE_SEARCH, false, false, 'commented', DI::userSession()->getLocalUserId());
+		$o .= DI::conversation()->render($items, Conversation::MODE_SEARCH, false, false, 'commented', DI::userSession()->getLocalUserId());
 
 		if (DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'infinite_scroll')) {
 			$o .= HTML::scrollLoader();

--- a/src/Module/Update/Community.php
+++ b/src/Module/Update/Community.php
@@ -40,7 +40,7 @@ class Community extends CommunityModule
 
 		$o = '';
 		if (!empty($request['force'])) {
-			$o = DI::conversation()->create(self::getItems(), Conversation::MODE_COMMUNITY, true, false, 'commented', DI::userSession()->getLocalUserId());
+			$o = DI::conversation()->render(self::getItems(), Conversation::MODE_COMMUNITY, true, false, 'commented', DI::userSession()->getLocalUserId());
 		}
 
 		System::htmlUpdateExit($o);

--- a/src/Module/Update/Network.php
+++ b/src/Module/Update/Network.php
@@ -79,7 +79,7 @@ class Network extends NetworkModule
 			$ordering = '`commented`';
 		}
 
-		$o = DI::conversation()->create($items, Conversation::MODE_NETWORK, $profile_uid, false, $ordering, DI::userSession()->getLocalUserId());
+		$o = DI::conversation()->render($items, Conversation::MODE_NETWORK, $profile_uid, false, $ordering, DI::userSession()->getLocalUserId());
 
 		System::htmlUpdateExit($o);
 	}

--- a/src/Module/Update/Profile.php
+++ b/src/Module/Update/Profile.php
@@ -116,7 +116,7 @@ class Profile extends BaseModule
 			}
 		}
 
-		$o .= DI::conversation()->create($items, Conversation::MODE_PROFILE, $a->getProfileOwner(), false, 'received', $a->getProfileOwner());
+		$o .= DI::conversation()->render($items, Conversation::MODE_PROFILE, $a->getProfileOwner(), false, 'received', $a->getProfileOwner());
 
 		System::htmlUpdateExit($o);
 	}

--- a/src/Object/Thread.php
+++ b/src/Object/Thread.php
@@ -190,13 +190,13 @@ class Thread
 	 * We should find a way to avoid using those arguments (at least most of them)
 	 *
 	 * @param array $conv_responses data
-	 * @param string $formSecurityToken A security Token to avoid CSF attacks
+	 * @param string $formSecurityToken A 'contact_action' form security token
 	 *
 	 * @return mixed The data requested on success
 	 *               false on failure
 	 * @throws \Exception
 	 */
-	public function getTemplateData($conv_responses, string $formSecurityToken)
+	public function getTemplateData(array $conv_responses, string $formSecurityToken)
 	{
 		$result = [];
 


### PR DESCRIPTION
Blocks #13245

- This allows to separately obtain a list of threads for rendering without having to deal with an already-formed HTML output
