### PR TITLE
Fix "Cannot add or update a child row: a foreign key constraint fails"

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1695,7 +1695,7 @@ CREATE TABLE IF NOT EXISTS `report` (
 	`uid` mediumint unsigned COMMENT 'Reporting user',
 	`reporter-id` int unsigned COMMENT 'Reporting contact',
 	`cid` int unsigned NOT NULL COMMENT 'Reported contact',
-	`gsid` int unsigned NOT NULL COMMENT 'Reported contact server',
+	`gsid` int unsigned COMMENT 'Reported contact server',
 	`comment` text COMMENT 'Report',
 	`category-id` int unsigned NOT NULL DEFAULT 1 COMMENT 'Report category, one of Entity\Report::CATEGORY_*',
 	`forward` boolean COMMENT 'Forward the report to the remote server',

--- a/doc/database/db_report.md
+++ b/doc/database/db_report.md
@@ -12,7 +12,7 @@ Fields
 | uid             | Reporting user                                               | mediumint unsigned | YES  |     | NULL                |                |
 | reporter-id     | Reporting contact                                            | int unsigned       | YES  |     | NULL                |                |
 | cid             | Reported contact                                             | int unsigned       | NO   |     | NULL                |                |
-| gsid            | Reported contact server                                      | int unsigned       | NO   |     | NULL                |                |
+| gsid            | Reported contact server                                      | int unsigned       | YES  |     | NULL                |                |
 | comment         | Report                                                       | text               | YES  |     | NULL                |                |
 | category-id     | Report category, one of Entity\Report::CATEGORY_*            | int unsigned       | NO   |     | 1                   |                |
 | forward         | Forward the report to the remote server                      | boolean            | YES  |     | NULL                |                |

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1691,7 +1691,7 @@ return [
 			"uid" => ["type" => "mediumint unsigned", "foreign" => ["user" => "uid"], "comment" => "Reporting user"],
 			"reporter-id" => ["type" => "int unsigned", "foreign" => ["contact" => "id"], "comment" => "Reporting contact"],
 			"cid" => ["type" => "int unsigned", "not null" => "1", "foreign" => ["contact" => "id"], "comment" => "Reported contact"],
-			"gsid" => ["type" => "int unsigned", "not null" => "1", "foreign" => ["gserver" => "id"], "comment" => "Reported contact server"],
+			"gsid" => ["type" => "int unsigned", "foreign" => ["gserver" => "id"], "comment" => "Reported contact server"],
 			"comment" => ["type" => "text", "comment" => "Report"],
 			"category-id" => ["type" => "int unsigned", "not null" => 1, "default" => \Friendica\Moderation\Entity\Report::CATEGORY_OTHER, "comment" => "Report category, one of Entity\Report::CATEGORY_*"],
 			"forward" => ["type" => "boolean", "comment" => "Forward the report to the remote server"],


### PR DESCRIPTION
Fixes ``"Cannot add or update a child row: a foreign key constraint fails (`piratica`.`#sql-alter-461-20ad59`, CONSTRAINT `#sql-alter-461-20ad59_ibfk_4` FOREIGN KEY (`gsid`) REFERENCES `gserver` (`id`) ON DELETE CASCADE)"``