### PR TITLE
Configuration key added to publish/hide blocklist

### DIFF
--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -94,7 +94,7 @@ class Friendica extends BaseModule
 
 		$blockList = $this->config->get('system', 'blocklist') ?? [];
 
-		if (!empty($blockList) && ($this->config->get('blocklist', 'published') || $this->session->isAuthenticated())) {
+		if (!empty($blockList) && ($this->config->get('blocklist', 'public') || $this->session->isAuthenticated())) {
 			$blocked = [
 				'title'    => $this->t('On this server the following remote servers are blocked.'),
 				'header'   => [

--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -94,8 +94,7 @@ class Friendica extends BaseModule
 
 		$blockList = $this->config->get('system', 'blocklist') ?? [];
 
-		$register_policy_int = $this->config->get('config', 'register_policy');
-		if (!empty($blockList) && ($register_policy_int !== Register::CLOSED || $this->session->isAuthenticated())) {
+		if (!empty($blockList) && ($this->config->get('blocklist', 'published') || $this->session->isAuthenticated())) {
 			$blocked = [
 				'title'    => $this->t('On this server the following remote servers are blocked.'),
 				'header'   => [

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -787,8 +787,8 @@ return [
 		'mastodon_banner' => '/images/friendica-banner.jpg',
 	],
 	'blocklist' => [
-		// published (Boolean)
-		// Wether the blocklist is published under /about (or any later API)
-		'published' => true,
+		// public (Boolean)
+		// Wether the blocklist is publicly listed under /about (or in any later API)
+		'public' => true,
 	],
 ];

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -786,4 +786,9 @@ return [
 		// Banner for Mastodon API
 		'mastodon_banner' => '/images/friendica-banner.jpg',
 	],
+	'blocklist' => [
+		// published (Boolean)
+		// Wether the blocklist is published under /about (or any later API)
+		'published' => true,
+	],
 ];


### PR DESCRIPTION
Feature added:
- Followup of #13264
- allow administrator to choose whether the blocklist is published under `/about` or later any other API (e.g. common is `/api/v1/instance/domain_blocks`).

See comments from me at https://rytter.me/display/4c906314-1464-a714-9a4f-89b078967607