### PR TITLE
Remove useless call to gethostbyname()

### DIFF
--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -73,7 +73,7 @@ class HttpClient implements ICanSendHttpRequests
 			throw new \InvalidArgumentException('Unable to retrieve the host in URL: ' . $url);
 		}
 
-		if(!filter_var($host, FILTER_VALIDATE_IP) && !@dns_get_record($host . '.', DNS_A + DNS_AAAA) && !gethostbyname($host)) {
+		if(!filter_var($host, FILTER_VALIDATE_IP) && !@dns_get_record($host . '.', DNS_A + DNS_AAAA)) {
 			$this->logger->debug('URL cannot be resolved.', ['url' => $url, 'callstack' => System::callstack(20)]);
 			$this->profiler->stopRecording();
 			return CurlResult::createErrorCurl($this->logger, $url);


### PR DESCRIPTION
- This function doesn't return a falsy value even when no IP address was able to be retrieved for the given host name
- Address https://github.com/friendica/friendica/issues/13157#issuecomment-1638505285