### PR TITLE
Make InstanceManager strategy naming convention case insensitive.

### DIFF
--- a/src/Core/Hooks/Model/DiceInstanceManager.php
+++ b/src/Core/Hooks/Model/DiceInstanceManager.php
@@ -49,11 +49,11 @@ class DiceInstanceManager implements ICanCreateInstances, ICanRegisterStrategies
 	/** {@inheritDoc} */
 	public function registerStrategy(string $interface, string $class, ?string $name = null): ICanRegisterStrategies
 	{
-		if (!empty($this->instance[$interface][$name])) {
+		if (!empty($this->instance[$interface][strtolower($name)])) {
 			throw new HookRegisterArgumentException(sprintf('A class with the name %s is already set for the interface %s', $name, $interface));
 		}
 
-		$this->instance[$interface][$name] = $class;
+		$this->instance[$interface][strtolower($name)] = $class;
 
 		return $this;
 	}
@@ -61,10 +61,10 @@ class DiceInstanceManager implements ICanCreateInstances, ICanRegisterStrategies
 	/** {@inheritDoc} */
 	public function create(string $class, string $strategy, array $arguments = []): object
 	{
-		if (empty($this->instance[$class][$strategy])) {
+		if (empty($this->instance[$class][strtolower($strategy)])) {
 			throw new HookInstanceException(sprintf('The class with the name %s isn\'t registered for the class or interface %s', $strategy, $class));
 		}
 
-		return $this->dice->create($this->instance[$class][$strategy], $arguments);
+		return $this->dice->create($this->instance[$class][strtolower($strategy)], $arguments);
 	}
 }

--- a/tests/src/Core/Hooks/Model/InstanceManagerTest.php
+++ b/tests/src/Core/Hooks/Model/InstanceManagerTest.php
@@ -235,4 +235,23 @@ class InstanceManagerTest extends MockedTest
 		self::assertEquals($cBool, $getInstanceA->getCBool());
 		self::assertEquals($cBool, $getInstanceB->getCBool());
 	}
+
+	/**
+	 * @see https://github.com/friendica/friendica/issues/13318
+	 */
+	public function testCaseInsensitiveNames()
+	{
+		$instance = new DiceInstanceManager(new Dice(), $this->hookFileManager);
+
+		$instance->registerStrategy(IAmADecoratedInterface::class, FakeInstance::class, 'fake');
+
+		// CamelCase
+		self::assertInstanceOf(FakeInstance::class, $instance->create(IAmADecoratedInterface::class, 'Fake'));
+		// UPPER CASE
+		self::assertInstanceOf(FakeInstance::class, $instance->create(IAmADecoratedInterface::class, 'FAKE'));
+		// lower case
+		self::assertInstanceOf(FakeInstance::class, $instance->create(IAmADecoratedInterface::class, 'fake'));
+		// UnKnOwN
+		self::assertInstanceOf(FakeInstance::class, $instance->create(IAmADecoratedInterface::class, 'fAkE'));
+	}
 }

--- a/tests/src/Core/Hooks/Model/InstanceManagerTest.php
+++ b/tests/src/Core/Hooks/Model/InstanceManagerTest.php
@@ -254,4 +254,5 @@ class InstanceManagerTest extends MockedTest
 		// UnKnOwN
 		self::assertInstanceOf(FakeInstance::class, $instance->create(IAmADecoratedInterface::class, 'fAkE'));
 	}
+
 }


### PR DESCRIPTION
Fixes #13318 