### PR TITLE
Fix: Pagination in search result works again

### DIFF
--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -173,7 +173,7 @@ class Index extends BaseSearch
 		$pager = new Pager(DI::l10n(), DI::args()->getQueryString(), $itemsPerPage);
 
 		if ($tag) {
-			Logger::info('Start tag search.', ['q' => $search]);
+			Logger::info('Start tag search.', ['q' => $search, 'start' => $pager->getStart(), 'items' => $pager->getItemsPerPage(), 'last' => $last_uriid]);
 			$uriids = Tag::getURIIdListByTag($search, DI::userSession()->getLocalUserId(), $pager->getStart(), $pager->getItemsPerPage(), $last_uriid);
 			$count = Tag::countByTag($search, DI::userSession()->getLocalUserId());
 		} else {
@@ -185,7 +185,7 @@ class Index extends BaseSearch
 		if (!empty($uriids)) {
 			$condition = ["(`uid` = ? OR (`uid` = ? AND NOT `global`))", 0, DI::userSession()->getLocalUserId()];
 			$condition = DBA::mergeConditions($condition, ['uri-id' => $uriids]);
-			$params = ['order' => ['id' => true]];
+			$params = ['order' => ['uri-id' => true]];
 			$items = Post::toArray(Post::selectForUser(DI::userSession()->getLocalUserId(), Item::DISPLAY_FIELDLIST, $condition, $params));
 		}
 

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -1,4 +1,8 @@
 <div id="item-{{$item.guid}}" class="item-{{$item.id}}">
+	<span class="commented" style="display: none;">{{$item.commented}}</span>
+	<span class="received" style="display: none;">{{$item.received}}</span>
+	<span class="created" style="display: none;">{{$item.created_date}}</span>
+	<span class="uriid" style="display: none;">{{$item.uriid}}</span>
 	<div class="wall-item-container panel-body{{$item.indent}} {{$item.shiny}} {{$item.previewing}}">
 		<div class="media">
 			{{* Put additional actions in a top-right dropdown menu *}}


### PR DESCRIPTION
In Frio the search results had been repeated over and over again, due to missing data in the template.