### PR TITLE
The twitter addon is no import connector anymore

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -266,6 +266,7 @@ function item_process(array $post, array $request, bool $preview, string $return
 		$post['uri-id']         = -1;
 		$post['author-network'] = Protocol::DFRN;
 		$post['author-updated'] = '';
+		$post['author-alias']   = '';
 		$post['author-gsid']    = 0;
 		$post['author-uri-id']  = ItemURI::getIdByURI($post['author-link']);
 		$post['owner-updated']  = '';

--- a/src/Content/ContactSelector.php
+++ b/src/Content/ContactSelector.php
@@ -220,7 +220,8 @@ class ContactSelector
 			'GNU Social' => 'gnu-social', 'gnusocial' => 'gnu-social', 'hubzilla' => 'hubzilla',
 			'mastodon' => 'mastodon', 'peertube' => 'peertube', 'pixelfed' => 'pixelfed',
 			'pleroma' => 'pleroma', 'red' => 'hubzilla', 'redmatrix' => 'hubzilla',
-			'socialhome' => 'social-home', 'wordpress' => 'wordpress', 'lemmy' => 'users'];
+			'socialhome' => 'social-home', 'wordpress' => 'wordpress', 'lemmy' => 'users',
+			'firefish' => 'fire', 'calckey' => 'calculator', 'kbin' => 'check'];
 
 		$search  = array_keys($nets);
 		$replace = array_values($nets);

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -102,7 +102,7 @@ class Widget
 	public static function unavailableNetworks(): array
 	{
 		// Always hide content from these networks
-		$networks = [Protocol::PHANTOM, Protocol::FACEBOOK, Protocol::APPNET, Protocol::ZOT];
+		$networks = [Protocol::PHANTOM, Protocol::FACEBOOK, Protocol::APPNET, Protocol::TWITTER, Protocol::ZOT];
 
 		if (!Addon::isEnabled("discourse")) {
 			$networks[] = Protocol::DISCOURSE;
@@ -114,10 +114,6 @@ class Widget
 
 		if (!Addon::isEnabled("pumpio")) {
 			$networks[] = Protocol::PUMPIO;
-		}
-
-		if (!Addon::isEnabled("twitter")) {
-			$networks[] = Protocol::TWITTER;
 		}
 
 		if (!Addon::isEnabled("tumblr")) {

--- a/src/Model/Nodeinfo.php
+++ b/src/Model/Nodeinfo.php
@@ -109,8 +109,9 @@ class Nodeinfo
 			'outbound' => [],
 		];
 
-		if (Addon::isEnabled('blogger')) {
-			$services['outbound'][] = 'blogger';
+		if (Addon::isEnabled('bluesky')) {
+			$services['inbound'][] = 'bluesky';
+			$services['outbound'][] = 'bluesky';
 		}
 		if (Addon::isEnabled('dwpost')) {
 			$services['outbound'][] = 'dreamwidth';
@@ -125,17 +126,8 @@ class Nodeinfo
 		if (Addon::isEnabled('libertree')) {
 			$services['outbound'][] = 'libertree';
 		}
-		if (Addon::isEnabled('buffer')) {
-			$services['outbound'][] = 'linkedin';
-		}
 		if (Addon::isEnabled('ljpost')) {
 			$services['outbound'][] = 'livejournal';
-		}
-		if (Addon::isEnabled('buffer')) {
-			$services['outbound'][] = 'pinterest';
-		}
-		if (Addon::isEnabled('posterous')) {
-			$services['outbound'][] = 'posterous';
 		}
 		if (Addon::isEnabled('pumpio')) {
 			$services['inbound'][] = 'pumpio';
@@ -147,7 +139,7 @@ class Nodeinfo
 		if (Addon::isEnabled('tumblr')) {
 			$services['outbound'][] = 'tumblr';
 		}
-		if (Addon::isEnabled('twitter') || Addon::isEnabled('buffer')) {
+		if (Addon::isEnabled('twitter')) {
 			$services['outbound'][] = 'twitter';
 		}
 		if (Addon::isEnabled('wppost')) {

--- a/src/Module/NodeInfo110.php
+++ b/src/Module/NodeInfo110.php
@@ -88,10 +88,6 @@ class NodeInfo110 extends BaseModule
 
 		$nodeinfo['metadata']['services'] = $nodeinfo['services'];
 
-		if (Addon::isEnabled('twitter')) {
-			$nodeinfo['metadata']['services']['inbound'][] = 'twitter';
-		}
-
 		$nodeinfo['metadata']['explicitContent'] = $this->config->get('system', 'explicit_content', false) == true;
 
 		$this->response->setType(ICanCreateResponses::TYPE_JSON);

--- a/src/Module/NodeInfo120.php
+++ b/src/Module/NodeInfo120.php
@@ -72,10 +72,6 @@ class NodeInfo120 extends BaseModule
 			$nodeinfo['protocols'][] = 'ostatus';
 		}
 
-		if (Addon::isEnabled('twitter')) {
-			$nodeinfo['services']['inbound'][] = 'twitter';
-		}
-
 		$nodeinfo['services']['inbound'][]  = 'atom1.0';
 		$nodeinfo['services']['inbound'][]  = 'rss2.0';
 		$nodeinfo['services']['outbound'][] = 'atom1.0';

--- a/src/Module/NodeInfo210.php
+++ b/src/Module/NodeInfo210.php
@@ -71,10 +71,6 @@ class NodeInfo210 extends BaseModule
 			$nodeinfo['protocols'][] = 'ostatus';
 		}
 
-		if (Addon::isEnabled('twitter')) {
-			$nodeinfo['services']['inbound'][] = 'twitter';
-		}
-
 		$nodeinfo['services']['inbound'][]  = 'atom1.0';
 		$nodeinfo['services']['inbound'][]  = 'rss2.0';
 		$nodeinfo['services']['outbound'][] = 'atom1.0';

--- a/src/Module/Statistics.php
+++ b/src/Module/Statistics.php
@@ -59,7 +59,7 @@ class Statistics extends BaseModule
 		/// @todo mark the "service" addons and load them dynamically here
 		$services = [
 			'appnet'      => Addon::isEnabled('appnet'),
-			'buffer'      => Addon::isEnabled('buffer'),
+			'bluesky'     => Addon::isEnabled('bluesky'),
 			'dreamwidth'  => Addon::isEnabled('dreamwidth'),
 			'gnusocial'   => Addon::isEnabled('gnusocial'),
 			'libertree'   => Addon::isEnabled('libertree'),


### PR DESCRIPTION
The Twitter addon is no import connector any more. These changes prevent that we display Twitter contacts or announce via nodeinfo that the Twitter addon is "outbound".

Also this includes a small fix for a warning that occurs when previewing a post.