### PR TITLE
Add a ChatGPT role for the built in robots.txt

### DIFF
--- a/src/Module/RobotsTxt.php
+++ b/src/Module/RobotsTxt.php
@@ -45,6 +45,11 @@ class RobotsTxt extends BaseModule
 		foreach ($allDisallowed as $disallowed) {
 			echo 'Disallow: ' . $disallowed . PHP_EOL;
 		}
+
+		echo PHP_EOL;
+		echo 'User-agent: ChatGPT-User' . PHP_EOL;
+		echo 'Disallow: /' . PHP_EOL;
+
 		System::exit();
 	}
 }


### PR DESCRIPTION
The default robots.txt now contains a rule to prevent crawling via ChatGPT.