### PR TITLE
Replace remaining references to default banner image by `api.mastodon_banner` configuration value

### DIFF
--- a/src/Contact/Header.php
+++ b/src/Contact/Header.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2023, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Contact;
+
+use Friendica\Core\Config\Capability\IManageConfigValues;
+
+class Header
+{
+	/** @var IManageConfigValues */
+	private $config;
+
+	public function __construct(IManageConfigValues $config)
+	{
+		$this->config = $config;
+	}
+
+	/**
+	 * Returns the Mastodon banner path relative to the Friendica folder.
+	 *
+	 * Ensures the existence of a leading slash.
+	 *
+	 * @return string
+	 */
+	public function getMastodonBannerPath(): string
+	{
+		return '/' . ltrim($this->config->get('api', 'mastodon_banner'), '/');
+	}
+}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1899,12 +1899,6 @@ class Contact
 		switch ($platform) {
 			case 'friendica':
 			case 'friendika':
-				/**
-				 * Picture credits
-				 * @author  Lostinlight <https://mastodon.xyz/@lightone>
-				 * @license CC0 https://creativecommons.org/share-your-work/public-domain/cc0/
-				 * @link    https://gitlab.com/lostinlight/per_aspera_ad_astra/-/blob/master/friendica-404/friendica-promo-bubbles.jpg
-				 */
 				$header = DI::baseUrl() . '/images/friendica-banner.jpg';
 				break;
 			case 'diaspora':

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -22,6 +22,7 @@
 namespace Friendica\Model;
 
 use Friendica\Contact\Avatar;
+use Friendica\Contact\Header;
 use Friendica\Contact\Introduction\Exception\IntroductionNotFoundException;
 use Friendica\Contact\LocalRelationship\Entity\LocalRelationship;
 use Friendica\Content\Conversation as ConversationContent;
@@ -1899,7 +1900,7 @@ class Contact
 		switch ($platform) {
 			case 'friendica':
 			case 'friendika':
-				$header = DI::baseUrl() . '/images/friendica-banner.jpg';
+				$header = DI::baseUrl() . (new Header(DI::config()))->getMastodonBannerPath();
 				break;
 			case 'diaspora':
 				/**

--- a/src/Module/Api/Mastodon/InstanceV2.php
+++ b/src/Module/Api/Mastodon/InstanceV2.php
@@ -23,6 +23,7 @@ namespace Friendica\Module\Api\Mastodon;
 
 use Exception;
 use Friendica\App;
+use Friendica\Contact\Header;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Core\System;
@@ -49,6 +50,9 @@ class InstanceV2 extends BaseApi
 	/** @var IManageConfigValues */
 	private $config;
 
+	/** @var Header */
+	private $contactHeader;
+
 	public function __construct(
 		App $app,
 		L10n $l10n,
@@ -64,8 +68,9 @@ class InstanceV2 extends BaseApi
 	) {
 		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
-		$this->database = $database;
-		$this->config   = $config;
+		$this->database      = $database;
+		$this->config        = $config;
+		$this->contactHeader = new Header($config);
 	}
 
 	/**
@@ -82,7 +87,7 @@ class InstanceV2 extends BaseApi
 		$version              = '2.8.0 (compatible; Friendica ' . App::VERSION . ')';
 		$description          = $this->config->get('config', 'info');
 		$usage                = $this->buildUsageInfo();
-		$thumbnail            = new InstanceEntity\Thumbnail($this->baseUrl->withPath('images/friendica-banner.jpg'));
+		$thumbnail            = new InstanceEntity\Thumbnail($this->baseUrl . $this->contactHeader->getMastodonBannerPath());
 		$languages            = [$this->config->get('system', 'language')];
 		$configuration        = $this->buildConfigurationInfo();
 		$registration         = $this->buildRegistrationsInfo();

--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -22,6 +22,7 @@
 namespace Friendica\Module;
 
 use Friendica\BaseModule;
+use Friendica\Contact\Header;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
@@ -482,6 +483,6 @@ class Photo extends BaseApi
 		if (!empty($photo)) {
 			return $photo;
 		}
-		return MPhoto::createPhotoForImageData(file_get_contents(DI::basePath() . '/images/friendica-banner.jpg'));
+		return MPhoto::createPhotoForImageData(file_get_contents(DI::basePath() . (new Header(DI::config()))->getMastodonBannerPath()));
 	}
 }

--- a/src/Object/Api/Mastodon/Instance.php
+++ b/src/Object/Api/Mastodon/Instance.php
@@ -24,6 +24,7 @@ namespace Friendica\Object\Api\Mastodon;
 use Friendica\App;
 use Friendica\App\BaseURL;
 use Friendica\BaseDataTransferObject;
+use Friendica\Contact\Header;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Database\Database;
 use Friendica\DI;
@@ -91,7 +92,7 @@ class Instance extends BaseDataTransferObject
 		$this->version           = '2.8.0 (compatible; Friendica ' . App::VERSION . ')';
 		$this->urls              = ['streaming_api' => '']; // Not supported
 		$this->stats             = new Stats($config, $database);
-		$this->thumbnail         = $baseUrl . $config->get('api', 'mastodon_banner');
+		$this->thumbnail         = $baseUrl . (new Header($config))->getMastodonBannerPath();
 		$this->languages         = [$config->get('system', 'language')];
 		$this->max_toot_chars    = (int)$config->get('config', 'api_import_size', $config->get('config', 'max_import_size'));
 		$this->registrations     = ($register_policy != Register::CLOSED);

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -783,7 +783,12 @@ return [
 	],
 	'api' => [
 		// mastodon_banner (String)
-		// Banner for Mastodon API
+		// Default banner image for Mastodon API, must be a relative path from the base Friendica folder
+		//
+		// Default picture credits:
+		// Author: Lostinlight <https://mastodon.xyz/@lightone>
+		// License: CC0 https://creativecommons.org/share-your-work/public-domain/cc0/
+		// Link to original work: https://gitlab.com/lostinlight/per_aspera_ad_astra/-/blob/master/friendica-404/friendica-promo-bubbles.jpg
 		'mastodon_banner' => '/images/friendica-banner.jpg',
 	],
 	'blocklist' => [


### PR DESCRIPTION
- Ensure leading slash is present at every place the configuration value is used

Fix #13355