### PR TITLE
GPTBot added to the default robots.txt

### DIFF
--- a/src/Module/RobotsTxt.php
+++ b/src/Module/RobotsTxt.php
@@ -38,6 +38,8 @@ class RobotsTxt extends BaseModule
 			'/search',
 			'/help',
 			'/proxy',
+			'/photo',
+			'/avatar',
 		];
 
 		header('Content-Type: text/plain');
@@ -48,6 +50,10 @@ class RobotsTxt extends BaseModule
 
 		echo PHP_EOL;
 		echo 'User-agent: ChatGPT-User' . PHP_EOL;
+		echo 'Disallow: /' . PHP_EOL;
+
+		echo PHP_EOL;
+		echo 'User-agent: GPTBot' . PHP_EOL;
 		echo 'Disallow: /' . PHP_EOL;
 
 		System::exit();


### PR DESCRIPTION
Now the other GPT user agent is added as well. Also somer mote path are excluded by default to avoid copyrhight claims because of proxied external images.