### PR TITLE
New functions for the language library

### DIFF
--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -398,7 +398,14 @@ class L10n
 				// Persian is manually added to language detection until a persian translation is provided for the interface, at
 				// which point it will be automatically available through `getAvailableLanguages()` and this should be removed.
 				// Additionally Portuguese, Ukrainian, traditional Chinese and Welsh are added to that list.
-				$langs = array_merge(['cy' => 'Cymraeg', 'uk' => 'Українська', 'pt-PT' => 'Português', 'zh-hant' => '繁體', 'fa' => 'فارسی'], $langs);
+				$additional_langs = [
+					'cy'      => 'Cymraeg',
+					'uk'      => 'Українська',
+					'pt-PT'   => 'Português',
+					'zh-hant' => '繁體',
+					'fa'      => 'فارسی'
+				];
+				$langs = array_merge($additional_langs, $langs);
 				ksort($langs);
 			}
 		}

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -397,8 +397,8 @@ class L10n
 				// See https://github.com/friendica/friendica/issues/10511
 				// Persian is manually added to language detection until a persian translation is provided for the interface, at
 				// which point it will be automatically available through `getAvailableLanguages()` and this should be removed.
-				// Additionally Portuguese, Ukrainian and Welsh are added to that list.
-				$langs = array_merge(['cy' => 'Cymraeg', 'uk' => 'Українська', 'pt-PT' => 'Português', 'fa' => 'فارسی'], $langs);
+				// Additionally Portuguese, Ukrainian, traditional Chinese and Welsh are added to that list.
+				$langs = array_merge(['cy' => 'Cymraeg', 'uk' => 'Українська', 'pt-PT' => 'Português', 'zh-hant' => '繁體', 'fa' => 'فارسی'], $langs);
 				ksort($langs);
 			}
 		}
@@ -407,7 +407,7 @@ class L10n
 
 	/**
 	 * The language detection routine uses some slightly different language codes.
-	 * This function changes the language language codes accordingly.
+	 * This function changes the language array accordingly.
 	 *
 	 * @param array $languages
 	 * @return array
@@ -423,12 +423,39 @@ class L10n
 		$languages['pt-BR'] = $languages['pt-br'];
 		unset($languages['pt-br']);
 		$languages['zh-Hans'] = $languages['zh-cn'];
-		$languages['zh-Hant'] = $languages['zh-cn'];
 		unset($languages['zh-cn']);
 
 		ksort($languages);
 
 		return $languages;
+	}
+
+	/**
+	 * The language detection routine uses some slightly different language codes.
+	 * This function changes the language codes accordingly.
+	 *
+	 * @param string $language
+	 * @return string
+	 */
+	public function convertCodeForLanguageDetection(string $language): string
+	{
+		switch ($language) {
+			case 'da-dk':
+				return 'da';
+			case 'en-us':
+			case 'en-gb':
+				return 'en';
+			case 'fi-fi':
+				return 'fi';
+			case 'nb-no':
+				return 'nb';
+			case 'pt-br':
+				return 'pt-BR';
+			case 'zh-cn':
+				return 'zh-Hans';
+			default:
+				return $language;
+		}
 	}
 
 	/**

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -414,16 +414,15 @@ class L10n
 	 */
 	public function convertForLanguageDetection(array $languages): array
 	{
-		$languages['fi'] = $languages['fi-fi'];
-		unset($languages['fi-fi']);
-		$languages['da'] = $languages['da-dk'];
-		unset($languages['da-dk']);
-		$languages['nb'] = $languages['nb-no'];
-		unset($languages['nb-no']);
-		$languages['pt-BR'] = $languages['pt-br'];
-		unset($languages['pt-br']);
-		$languages['zh-Hans'] = $languages['zh-cn'];
-		unset($languages['zh-cn']);
+		foreach ($languages as $key => $language) {
+			$newkey = $this->convertCodeForLanguageDetection($key);
+			if ($newkey != $key) {
+				if (!isset($languages[$newkey])) {
+					$languages[$newkey] = $language;
+				}
+				unset($languages[$key]);
+			}
+		}
 
 		ksort($languages);
 

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -378,7 +378,7 @@ class L10n
 	 *
 	 * @return array
 	 */
-	public static function getAvailableLanguages(): array
+	public function getAvailableLanguages(bool $additional = false): array
 	{
 		$langs              = [];
 		$strings_file_paths = glob('view/lang/*/strings.php');
@@ -392,8 +392,43 @@ class L10n
 				$path_array            = explode('/', $strings_file_path);
 				$langs[$path_array[2]] = self::LANG_NAMES[$path_array[2]] ?? $path_array[2];
 			}
+
+			if ($additional) {
+				// See https://github.com/friendica/friendica/issues/10511
+				// Persian is manually added to language detection until a persian translation is provided for the interface, at
+				// which point it will be automatically available through `getAvailableLanguages()` and this should be removed.
+				// Additionally Portuguese, Ukrainian and Welsh are added to that list.
+				$langs = array_merge(['cy' => 'Cymraeg', 'uk' => 'Українська', 'pt-PT' => 'Português', 'fa' => 'فارسی'], $langs);
+				ksort($langs);
+			}
 		}
 		return $langs;
+	}
+
+	/**
+	 * The language detection routine uses some slightly different language codes.
+	 * This function changes the language language codes accordingly.
+	 *
+	 * @param array $languages
+	 * @return array
+	 */
+	public function convertForLanguageDetection(array $languages): array
+	{
+		$languages['fi'] = $languages['fi-fi'];
+		unset($languages['fi-fi']);
+		$languages['da'] = $languages['da-dk'];
+		unset($languages['da-dk']);
+		$languages['nb'] = $languages['nb-no'];
+		unset($languages['nb-no']);
+		$languages['pt-BR'] = $languages['pt-br'];
+		unset($languages['pt-br']);
+		$languages['zh-Hans'] = $languages['zh-cn'];
+		$languages['zh-Hant'] = $languages['zh-cn'];
+		unset($languages['zh-cn']);
+
+		ksort($languages);
+
+		return $languages;
 	}
 
 	/**

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2015,11 +2015,8 @@ class Item
 
 		$naked_body = self::getDominantLanguage($naked_body);
 
-		$availableLanguages = DI::l10n()->getAvailableLanguages();
-		// See https://github.com/friendica/friendica/issues/10511
-		// Persian is manually added to language detection until a persian translation is provided for the interface, at
-		// which point it will be automatically available through `getAvailableLanguages()` and this should be removed.
-		$availableLanguages['fa'] = 'fa';
+		$availableLanguages = DI::l10n()->getAvailableLanguages(true);
+		$availableLanguages = DI::l10n()->convertForLanguageDetection($availableLanguages);
 
 		$ld = new Language(array_keys($availableLanguages));
 		return $ld->detect($naked_body)->limit(0, $count)->close() ?: [];

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -536,14 +536,13 @@ class User
 /**
  * Fetch the language code from the given user. If the code is invalid, return the system language
  *
- * @param integer $uid   User-Id
- * @param boolean $short If true, return the short form g.g. "en", otherwise the long form e.g. "en-gb"
+ * @param integer $uid User-Id
  * @return string
  */
-	public static function getLanguageCode(int $uid, bool $short): string
+	public static function getLanguageCode(int $uid): string
 	{
 		$owner = self::getOwnerDataById($uid);
-		$languages = DI::l10n()->getAvailableLanguages($short);
+		$languages = DI::l10n()->getAvailableLanguages(true);
 		if (in_array($owner['language'], array_keys($languages))) {
 			$language = $owner['language'];
 		} else {

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -543,14 +543,11 @@ class User
 	public static function getLanguageCode(int $uid, bool $short): string
 	{
 		$owner = self::getOwnerDataById($uid);
-		$languages = DI::l10n()->getAvailableLanguages();
+		$languages = DI::l10n()->getAvailableLanguages($short);
 		if (in_array($owner['language'], array_keys($languages))) {
 			$language = $owner['language'];
 		} else {
 			$language = DI::config()->get('system', 'language');
-		}
-		if ($short) {
-			return substr($language, 0, 2);
 		}
 		return $language;
 	}

--- a/src/Module/Conversation/Channel.php
+++ b/src/Module/Conversation/Channel.php
@@ -144,8 +144,8 @@ class Channel extends BaseModule
 				'accesskey' => 'h'
 			];
 
-			$language  = User::getLanguageCode($this->session->getLocalUserId(), false);
-			$languages = $this->l10n->getAvailableLanguages();
+			$language  = User::getLanguageCode($this->session->getLocalUserId());
+			$languages = $this->l10n->getAvailableLanguages(true);
 
 			$tabs[] = [
 				'label'     => $languages[$language],
@@ -344,7 +344,7 @@ class Channel extends BaseModule
 		} elseif (self::$content == self::AUDIO) {
 			$condition = ["`media-type` & ?", 4];
 		} elseif (self::$content == self::LANGUAGE) {
-			$condition = ["JSON_EXTRACT(JSON_KEYS(language), '$[0]') = ?", User::getLanguageCode($this->session->getLocalUserId(), true)];
+			$condition = ["JSON_EXTRACT(JSON_KEYS(language), '$[0]') = ?", $this->l10n->convertCodeForLanguageDetection(User::getLanguageCode($this->session->getLocalUserId()))];
 		}
 
 		if (self::$content != self::LANGUAGE) {
@@ -404,10 +404,11 @@ class Channel extends BaseModule
 	private function addLanguageCondition(array $condition): array
 	{
 		$conditions = [];
-		$languages  = $this->pConfig->get($this->session->getLocalUserId(), 'channel', 'languages', [User::getLanguageCode($this->session->getLocalUserId(), false)]);
+		$languages  = $this->pConfig->get($this->session->getLocalUserId(), 'channel', 'languages', [User::getLanguageCode($this->session->getLocalUserId())]);
+		$languages  = $this->l10n->convertForLanguageDetection($languages);
 		foreach ($languages as $language) {
 			$conditions[] = "JSON_EXTRACT(JSON_KEYS(language), '$[0]') = ?";
-			$condition[]  = substr($language, 0, 2);
+			$condition[]  = $language;
 		}
 		if (!empty($conditions)) {
 			$condition[0] .= " AND (`language` IS NULL OR " . implode(' OR ', $conditions) . ")";

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -218,7 +218,7 @@ class Display extends BaseSettings
 			BBCode::PREVIEW_LARGE    => $this->t('Large Image'),
 		];
 
-		$channel_languages = $this->pConfig->get($uid, 'channel', 'languages', [User::getLanguageCode($uid, false)]);
+		$channel_languages = $this->pConfig->get($uid, 'channel', 'languages', [User::getLanguageCode($uid)]);
 		$languages         = $this->l10n->getAvailableLanguages(true);
 
 		$first_day_of_week = $this->pConfig->get($uid, 'calendar', 'first_day_of_week', 0);

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -219,7 +219,7 @@ class Display extends BaseSettings
 		];
 
 		$channel_languages = $this->pConfig->get($uid, 'channel', 'languages', [User::getLanguageCode($uid, false)]);
-		$languages         = $this->l10n->getAvailableLanguages();
+		$languages         = $this->l10n->getAvailableLanguages(true);
 
 		$first_day_of_week = $this->pConfig->get($uid, 'calendar', 'first_day_of_week', 0);
 		$weekdays          = [


### PR DESCRIPTION
While coding PR #13390, I realized that we are using some language codes that aren't used by the language detection library. This means that languages like for example Danish or Finnish were never detected. Also some more languages are added, that we don't have got in our translations, but that might be used by our users and are detected by the library.