### PR TITLE
Simplified context definitions

### DIFF
--- a/static/security-data-integrity-v1.jsonld
+++ b/static/security-data-integrity-v1.jsonld
@@ -7,66 +7,56 @@
       "@type": "@id"
     },
     "DataIntegrityProof": {
-      "@id": "https://w3id.org/security#DataIntegrityProof",
-      "@context": {
-        "@protected": true,
-        "id": "@id",
-        "type": "@type",
-        "challenge": "https://w3id.org/security#challenge",
-        "created": {
-          "@id": "http://purl.org/dc/terms/created",
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-        },
-        "domain": "https://w3id.org/security#domain",
-        "expires": {
-          "@id": "https://w3id.org/security#expiration",
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-        },
-        "nonce": "https://w3id.org/security#nonce",
-        "proofPurpose": {
-          "@id": "https://w3id.org/security#proofPurpose",
-          "@type": "@vocab",
-          "@context": {
-            "@protected": true,
-            "id": "@id",
-            "type": "@type",
-            "assertionMethod": {
-              "@id": "https://w3id.org/security#assertionMethod",
-              "@type": "@id",
-              "@container": "@set"
-            },
-            "authentication": {
-              "@id": "https://w3id.org/security#authenticationMethod",
-              "@type": "@id",
-              "@container": "@set"
-            },
-            "capabilityInvocation": {
-              "@id": "https://w3id.org/security#capabilityInvocationMethod",
-              "@type": "@id",
-              "@container": "@set"
-            },
-            "capabilityDelegation": {
-              "@id": "https://w3id.org/security#capabilityDelegationMethod",
-              "@type": "@id",
-              "@container": "@set"
-            },
-            "keyAgreement": {
-              "@id": "https://w3id.org/security#keyAgreementMethod",
-              "@type": "@id",
-              "@container": "@set"
-            }
-          }
-        },
-        "cryptosuite": "https://w3id.org/security#cryptosuite",
-        "proofValue": {
-          "@id": "https://w3id.org/security#proofValue",
-          "@type": "https://w3id.org/security#multibase"
-        },
-        "verificationMethod": {
-          "@id": "https://w3id.org/security#verificationMethod",
-          "@type": "@id"
-        }
-      }
+      "@id": "https://w3id.org/security#DataIntegrityProof"
+    },
+    "challenge": "https://w3id.org/security#challenge",
+    "created": {
+      "@id": "http://purl.org/dc/terms/created",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "domain": "https://w3id.org/security#domain",
+    "expires": {
+      "@id": "https://w3id.org/security#expiration",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "nonce": "https://w3id.org/security#nonce",
+    "cryptosuite": "https://w3id.org/security#cryptosuite",
+    "proofValue": {
+      "@id": "https://w3id.org/security#proofValue",
+      "@type": "https://w3id.org/security#multibase"
+    },
+    "verificationMethod": {
+      "@id": "https://w3id.org/security#verificationMethod",
+      "@type": "@id"
+    },
+    "proofPurpose": {
+      "@id": "https://w3id.org/security#proofPurpose",
+      "@type": "@vocab"
+    },
+    "assertionMethod": {
+      "@id": "https://w3id.org/security#assertionMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "authentication": {
+      "@id": "https://w3id.org/security#authenticationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capabilityInvocation": {
+      "@id": "https://w3id.org/security#capabilityInvocationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capabilityDelegation": {
+      "@id": "https://w3id.org/security#capabilityDelegationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "keyAgreement": {
+      "@id": "https://w3id.org/security#keyAgreementMethod",
+      "@type": "@id",
+      "@container": "@set"
     }
   }
 }

--- a/static/security-multikey-v1.jsonld
+++ b/static/security-multikey-v1.jsonld
@@ -3,28 +3,23 @@
     "id": "@id",
     "type": "@type",
     "Multikey": {
-      "@id": "https://w3id.org/security#Multikey",
-      "@context": {
-        "@protected": true,
-        "id": "@id",
-        "type": "@type",
-        "controller": {
-          "@id": "https://w3id.org/security#controller",
-          "@type": "@id"
-        },
-        "revoked": {
-          "@id": "https://w3id.org/security#revoked",
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-        },
-        "publicKeyMultibase": {
-          "@id": "https://w3id.org/security#publicKeyMultibase",
-          "@type": "https://w3id.org/security#multibase"
-        },
-        "secretKeyMultibase": {
-          "@id": "https://w3id.org/security#secretKeyMultibase",
-          "@type": "https://w3id.org/security#multibase"
-        }
-      }
+      "@id": "https://w3id.org/security#Multikey"
+    },
+    "controller": {
+      "@id": "https://w3id.org/security#controller",
+      "@type": "@id"
+    },
+    "revoked": {
+      "@id": "https://w3id.org/security#revoked",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "publicKeyMultibase": {
+      "@id": "https://w3id.org/security#publicKeyMultibase",
+      "@type": "https://w3id.org/security#multibase"
+    },
+    "secretKeyMultibase": {
+      "@id": "https://w3id.org/security#secretKeyMultibase",
+      "@type": "https://w3id.org/security#multibase"
     }
   }
 }


### PR DESCRIPTION
There are some AP context definitions that can't be parsed by our validator. The easy solution is to change the context definitions so that the be parsed.