### PR TITLE
Avoid jumps in the timeline after "received" has been selected

### DIFF
--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -348,13 +348,15 @@ class Network extends Timeline
 			$this->order = 'commented';
 		}
 
+		$this->selectedTab = $this->selectedTab ?? $this->order;
+
 		// Upon updates in the background and order by last comment we order by received date,
 		// since otherwise the feed will optically jump, when some already visible thread has been updated.
 		if ($this->update && ($this->selectedTab == TimelineEntity::COMMENTED)) {
 			$this->order = 'received';
+			$request['last_received']  = $request['last_commented'] ?? null;
+			$request['first_received'] = $request['first_commented'] ?? null;
 		}
-
-		$this->selectedTab = $this->selectedTab ?? $this->order;
 
 		// Prohibit combined usage of "star" and "mention"
 		if ($this->selectedTab == TimelineEntity::STAR) {


### PR DESCRIPTION
When you switched from some other channel to the "received" channel, it can happen that a lot of content is added via the "update" functionality. Now only really new content is fetched.