### PR TITLE
Remove DI dependency for httpExit, httpError, jsonExit, jsonError and xmlExit

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -716,7 +716,7 @@ class App
 			}
 
 			$this->logger->debug('Request processed sucessfully', ['response' => $response->getStatusCode(), 'address' => $_SERVER['REMOTE_ADDR'] ?? '', 'request' => $requeststring, 'referer' => $_SERVER['HTTP_REFERER'] ?? '', 'user-agent' => $_SERVER['HTTP_USER_AGENT'] ?? '']);
-			$page->exit($response);
+			System::echoResponse($response);
 		} catch (HTTPException $e) {
 			$this->logger->debug('Request processed with exception', ['response' => $e->getCode(), 'address' => $_SERVER['REMOTE_ADDR'] ?? '', 'request' => $requeststring, 'referer' => $_SERVER['HTTP_REFERER'] ?? '', 'user-agent' => $_SERVER['HTTP_USER_AGENT'] ?? '']);
 			$httpException->rawContent($e);

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -402,36 +402,6 @@ class Page implements ArrayAccess
 	}
 
 	/**
-	 * Directly exit with the current response (include setting all headers)
-	 *
-	 * @param ResponseInterface $response
-	 */
-	public function exit(ResponseInterface $response)
-	{
-		header(sprintf("HTTP/%s %s %s",
-			$response->getProtocolVersion(),
-			$response->getStatusCode(),
-			$response->getReasonPhrase())
-		);
-
-		foreach ($response->getHeaders() as $key => $header) {
-			if (is_array($header)) {
-				$header_str = implode(',', $header);
-			} else {
-				$header_str = $header;
-			}
-
-			if (empty($key)) {
-				header($header_str);
-			} else {
-				header("$key: $header_str");
-			}
-		}
-
-		echo $response->getBody();
-	}
-
-	/**
 	 * Executes the creation of the current page and prints it to the screen
 	 *
 	 * @param App                         $app      The Friendica App

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -496,7 +496,9 @@ class Page implements ArrayAccess
 			}
 
 			if ($_GET["mode"] == "raw") {
-				System::httpExit(substr($target->saveHTML(), 6, -8), Response::TYPE_HTML);
+				$response->withBody(Utils::streamFor($target->saveHTML()));
+				System::echoResponse($response);
+				System::exit();
 			}
 		}
 

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -476,4 +476,23 @@ abstract class BaseModule implements ICanHandleRequests
 
 		System::exit();
 	}
+
+	/**
+	 * Send HTTP status header and exit.
+	 *
+	 * @param integer $httpCode HTTP status result value
+	 * @param string  $message  Error message. Optional.
+	 * @param mixed  $content   Response body. Optional.
+	 * @throws \Exception
+	 */
+	public function httpError(int $httpCode, string $message = '', $content = '')
+	{
+		if ($httpCode >= 400) {
+			$this->logger->debug('Exit with error', ['code' => $httpCode, 'message' => $message, 'callstack' => System::callstack(20), 'method' => $this->args->getMethod(), 'agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
+		}
+
+		$this->response->setStatus($httpCode, $message);
+
+		$this->httpExit($content);
+	}
 }

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -510,4 +510,23 @@ abstract class BaseModule implements ICanHandleRequests
 	{
 		$this->httpExit(json_encode($content, $options), ICanCreateResponses::TYPE_JSON, $content_type);
 	}
+
+	/**
+	 * Display a non-200 HTTP code response using JSON to encode the content and exit
+	 *
+	 * @param int    $httpCode
+	 * @param mixed  $content
+	 * @param string $content_type
+	 * @return void
+	 * @throws HTTPException\InternalServerErrorException
+	 */
+	public function jsonError(int $httpCode, $content, string $content_type = 'application/json')
+	{
+		if ($httpCode >= 400) {
+			$this->logger->debug('Exit with error', ['code' => $httpCode, 'content_type' => $content_type, 'callstack' => System::callstack(20), 'method' => $this->args->getMethod(), 'agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
+		}
+
+		$this->response->setStatus($httpCode);
+		$this->jsonExit($content, $content_type);
+	}
 }

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -495,4 +495,19 @@ abstract class BaseModule implements ICanHandleRequests
 
 		$this->httpExit($content);
 	}
+
+	/**
+	 * Display the response using JSON to encode the content
+	 *
+	 * @param mixed  $content
+	 * @param string $content_type
+	 * @param int    $options A combination of json_encode() binary flags
+	 * @return void
+	 * @throws HTTPException\InternalServerErrorException
+	 * @see json_encode()
+	 */
+	public function jsonExit($content, string $content_type = 'application/json', int $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)
+	{
+		$this->httpExit(json_encode($content, $options), ICanCreateResponses::TYPE_JSON, $content_type);
+	}
 }

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -27,6 +27,7 @@ use Friendica\Capabilities\ICanCreateResponses;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
+use Friendica\Core\System;
 use Friendica\Model\User;
 use Friendica\Module\Response;
 use Friendica\Module\Special\HTTPException as ModuleHTTPException;
@@ -106,8 +107,7 @@ abstract class BaseModule implements ICanHandleRequests
 	 */
 	protected function rawContent(array $request = [])
 	{
-		// echo '';
-		// exit;
+		// $this->httpExit(...);
 	}
 
 	/**
@@ -234,7 +234,8 @@ abstract class BaseModule implements ICanHandleRequests
 
 		$timestamp = microtime(true);
 		// "rawContent" is especially meant for technical endpoints.
-		// This endpoint doesn't need any theme initialization or other comparable stuff.
+		// This endpoint doesn't need any theme initialization or
+		// templating and is expected to exit on its own if it is set.
 		$this->rawContent($request);
 
 		try {
@@ -455,5 +456,24 @@ abstract class BaseModule implements ICanHandleRequests
 		}
 
 		return $tabs;
+	}
+
+	/**
+	 * This function adds the content and a content-type HTTP header to the output.
+	 * After finishing the process is getting killed.
+	 *
+	 * @param string      $content
+	 * @param string      $type
+	 * @param string|null $content_type
+	 * @return void
+	 * @throws HTTPException\InternalServerErrorException
+	 */
+	public function httpExit(string $content, string $type = Response::TYPE_HTML, ?string $content_type = null)
+	{
+		$this->response->setType($type, $content_type);
+		$this->response->addContent($content);
+		System::echoResponse($this->response->generate());
+
+		System::exit();
 	}
 }

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -33,6 +33,7 @@ use Friendica\Module\Response;
 use Friendica\Module\Special\HTTPException as ModuleHTTPException;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Profiler;
+use Friendica\Util\XML;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 

--- a/src/Capabilities/ICanCreateResponses.php
+++ b/src/Capabilities/ICanCreateResponses.php
@@ -70,7 +70,7 @@ interface ICanCreateResponses
 	 *
 	 * @throws InternalServerErrorException
 	 */
-	public function setType(string $type, ?string $content_type = null): void;
+	public function setType(string $type = ICanCreateResponses::TYPE_HTML, ?string $content_type = null): void;
 
 	/**
 	 * Sets the status and the reason for the response

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -311,27 +311,24 @@ class System
 	 * Outputs a basic dfrn XML status structure to STDOUT, with a <status> variable
 	 * of $st and an optional text <message> of $message and terminates the current process.
 	 *
-	 * @param        $st
+	 * @param mixed  $status
 	 * @param string $message
 	 * @throws \Exception
+	 * @deprecated since 2023.09 Use BaseModule->httpExit() instead
 	 */
-	public static function xmlExit($st, $message = '')
+	public static function xmlExit($status, string $message = '')
 	{
-		$result = ['status' => $st];
+		$result = ['status' => $status];
 
 		if ($message != '') {
 			$result['message'] = $message;
 		}
 
-		if ($st) {
-			Logger::notice('xml_status returning non_zero: ' . $st . " message=" . $message);
+		if ($status) {
+			Logger::notice('xml_status returning non_zero: ' . $status . " message=" . $message);
 		}
 
-		DI::apiResponse()->setType(Response::TYPE_XML);
-		DI::apiResponse()->addContent(XML::fromArray(['result' => $result]));
-		self::echoResponse(DI::apiResponse()->generate());
-
-		self::exit();
+		self::httpExit(XML::fromArray(['result' => $result]), Response::TYPE_XML);
 	}
 
 	/**

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -392,14 +392,12 @@ class System
 	 * @param mixed   $content      The input content
 	 * @param string  $content_type Type of the input (Default: 'application/json')
 	 * @param integer $options      JSON options
-	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws InternalServerErrorException
+	 * @deprecated since 2023.09 Use BaseModule->jsonExit instead
 	 */
-	public static function jsonExit($content, $content_type = 'application/json', int $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) {
-		DI::apiResponse()->setType(Response::TYPE_JSON, $content_type);
-		DI::apiResponse()->addContent(json_encode($content, $options));
-		self::echoResponse(DI::apiResponse()->generate());
-
-		self::exit();
+	public static function jsonExit($content, string $content_type = 'application/json', int $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)
+	{
+		self::httpExit(json_encode($content, $options), Response::TYPE_JSON, $content_type);
 	}
 
 	/**

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -28,6 +28,7 @@ use Friendica\DI;
 use Friendica\Model\User;
 use Friendica\Module\Response;
 use Friendica\Network\HTTPException\FoundException;
+use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Network\HTTPException\MovedPermanentlyException;
 use Friendica\Network\HTTPException\TemporaryRedirectException;
 use Friendica\Util\BasePath;
@@ -357,12 +358,15 @@ class System
 	 * This function adds the content and a content-type HTTP header to the output.
 	 * After finishing the process is getting killed.
 	 *
-	 * @param string $content
-	 * @param string $type
+	 * @param string      $content
+	 * @param string      $type
 	 * @param string|null $content_type
 	 * @return void
+	 * @throws InternalServerErrorException
+	 * @deprecated since 2023.09 Use BaseModule->httpExit() instead
 	 */
-	public static function httpExit(string $content, string $type = Response::TYPE_HTML, ?string $content_type = null) {
+	public static function httpExit(string $content, string $type = Response::TYPE_HTML, ?string $content_type = null)
+	{
 		DI::apiResponse()->setType($type, $content_type);
 		DI::apiResponse()->addContent($content);
 		self::echoResponse(DI::apiResponse()->generate());

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -373,6 +373,9 @@ class System
 		self::exit();
 	}
 
+	/**
+	 * @deprecated since 2023.09 Use BaseModule->jsonError instead
+	 */
 	public static function jsonError($httpCode, $content, $content_type = 'application/json')
 	{
 		if ($httpCode >= 400) {

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -341,6 +341,7 @@ class System
 	 * @param string  $message Error message. Optional.
 	 * @param string  $content Response body. Optional.
 	 * @throws \Exception
+	 * @deprecated since 2023.09 Use BaseModule->httpError instead
 	 */
 	public static function httpError($httpCode, $message = '', $content = '')
 	{
@@ -348,10 +349,8 @@ class System
 			Logger::debug('Exit with error', ['code' => $httpCode, 'message' => $message, 'callstack' => System::callstack(20), 'method' => DI::args()->getMethod(), 'agent' => $_SERVER['HTTP_USER_AGENT'] ?? '']);
 		}
 		DI::apiResponse()->setStatus($httpCode, $message);
-		DI::apiResponse()->addContent($content);
-		self::echoResponse(DI::apiResponse()->generate());
 
-		self::exit();
+		self::httpExit($content);
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Error.php
+++ b/src/Factory/Api/Mastodon/Error.php
@@ -57,7 +57,7 @@ class Error extends BaseFactory
 		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
 		$this->logError(404, $error);
-		System::jsonError(404, $errorObj->toArray());
+		$this->jsonError(404, $errorObj->toArray());
 	}
 
 	public function UnprocessableEntity(string $error = '')
@@ -67,7 +67,7 @@ class Error extends BaseFactory
 		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
 		$this->logError(422, $error);
-		System::jsonError(422, $errorObj->toArray());
+		$this->jsonError(422, $errorObj->toArray());
 	}
 
 	public function Unauthorized(string $error = '', string $error_description = '')
@@ -76,7 +76,7 @@ class Error extends BaseFactory
 		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
 		$this->logError(401, $error);
-		System::jsonError(401, $errorObj->toArray());
+		$this->jsonError(401, $errorObj->toArray());
 	}
 
 	public function Forbidden(string $error = '')
@@ -86,7 +86,7 @@ class Error extends BaseFactory
 		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
 		$this->logError(403, $error);
-		System::jsonError(403, $errorObj->toArray());
+		$this->jsonError(403, $errorObj->toArray());
 	}
 
 	public function InternalError(string $error = '')
@@ -96,6 +96,6 @@ class Error extends BaseFactory
 		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 
 		$this->logError(500, $error);
-		System::jsonError(500, $errorObj->toArray());
+		$this->jsonError(500, $errorObj->toArray());
 	}
 }

--- a/src/Module/AccountManagementControlDocument.php
+++ b/src/Module/AccountManagementControlDocument.php
@@ -79,6 +79,6 @@ class AccountManagementControlDocument extends BaseModule
 			],
 		];
 
-		System::jsonExit($output);
+		$this->jsonExit($output);
 	}
 }

--- a/src/Module/ActivityPub/Featured.php
+++ b/src/Module/ActivityPub/Featured.php
@@ -46,6 +46,6 @@ class Featured extends BaseModule
 
 		$featured = ActivityPub\Transmitter::getFeatured($owner, $page);
 
-		System::jsonExit($featured, 'application/activity+json');
+		$this->jsonExit($featured, 'application/activity+json');
 	}
 }

--- a/src/Module/ActivityPub/Followers.php
+++ b/src/Module/ActivityPub/Followers.php
@@ -49,6 +49,6 @@ class Followers extends BaseModule
 
 		$followers = ActivityPub\Transmitter::getContacts($owner, [Contact::FOLLOWER, Contact::FRIEND], 'followers', $page, (string)HTTPSignature::getSigner('', $_SERVER));
 
-		System::jsonExit($followers, 'application/activity+json');
+		$this->jsonExit($followers, 'application/activity+json');
 	}
 }

--- a/src/Module/ActivityPub/Following.php
+++ b/src/Module/ActivityPub/Following.php
@@ -47,6 +47,6 @@ class Following extends BaseModule
 
 		$following = ActivityPub\Transmitter::getContacts($owner, [Contact::SHARING, Contact::FRIEND], 'following', $page);
 
-		System::jsonExit($following, 'application/activity+json');
+		$this->jsonExit($following, 'application/activity+json');
 	}
 }

--- a/src/Module/ActivityPub/Inbox.php
+++ b/src/Module/ActivityPub/Inbox.php
@@ -66,7 +66,7 @@ class Inbox extends BaseApi
 			$inbox = ActivityPub\ClientToServer::getPublicInbox($uid, $page, $request['max_id'] ?? null);
 		}
 
-		System::jsonExit($inbox, 'application/activity+json');
+		$this->jsonExit($inbox, 'application/activity+json');
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/ActivityPub/Objects.php
+++ b/src/Module/ActivityPub/Objects.php
@@ -130,6 +130,6 @@ class Objects extends BaseModule
 		// Relaxed CORS header for public items
 		header('Access-Control-Allow-Origin: *');
 
-		System::jsonExit($data, 'application/activity+json');
+		$this->jsonExit($data, 'application/activity+json');
 	}
 }

--- a/src/Module/ActivityPub/Outbox.php
+++ b/src/Module/ActivityPub/Outbox.php
@@ -53,7 +53,7 @@ class Outbox extends BaseApi
 
 		$outbox = ActivityPub\ClientToServer::getOutbox($owner, $uid, $page, $request['max_id'] ?? null, HTTPSignature::getSigner('', $_SERVER));
 
-		System::jsonExit($outbox, 'application/activity+json');
+		$this->jsonExit($outbox, 'application/activity+json');
 	}
 
 	protected function post(array $request = [])
@@ -79,6 +79,6 @@ class Outbox extends BaseApi
 			throw new \Friendica\Network\HTTPException\BadRequestException();
 		}
 
-		System::jsonExit(ActivityPub\ClientToServer::processActivity($activity, $uid, self::getCurrentApplication() ?? []));
+		$this->jsonExit(ActivityPub\ClientToServer::processActivity($activity, $uid, self::getCurrentApplication() ?? []));
 	}
 }

--- a/src/Module/ActivityPub/Whoami.php
+++ b/src/Module/ActivityPub/Whoami.php
@@ -100,6 +100,6 @@ class Whoami extends BaseApi
 		];
 
 		$data['generator'] = ActivityPub\Transmitter::getService();
-		System::jsonExit($data, 'application/activity+json');
+		$this->jsonExit($data, 'application/activity+json');
 	}
 }

--- a/src/Module/Api/ApiResponse.php
+++ b/src/Module/Api/ApiResponse.php
@@ -25,6 +25,7 @@ use Friendica\App\Arguments;
 use Friendica\App\BaseURL;
 use Friendica\Core\L10n;
 use Friendica\Module\Response;
+use Friendica\Network\HTTPException;
 use Friendica\Util\Arrays;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\XML;
@@ -46,14 +47,20 @@ class ApiResponse extends Response
 	protected $baseUrl;
 	/** @var TwitterUser */
 	protected $twitterUser;
+	/** @var array */
+	protected $server;
+	/** @var string */
+	protected $jsonpCallback;
 
-	public function __construct(L10n $l10n, Arguments $args, LoggerInterface $logger, BaseURL $baseUrl, TwitterUser $twitterUser)
+	public function __construct(L10n $l10n, Arguments $args, LoggerInterface $logger, BaseURL $baseUrl, TwitterUser $twitterUser, array $server = [], string $jsonpCallback = '')
 	{
 		$this->l10n        = $l10n;
 		$this->args        = $args;
 		$this->logger      = $logger;
 		$this->baseUrl     = $baseUrl;
 		$this->twitterUser = $twitterUser;
+		$this->server      = $server;
+		$this->jsonpCallback = $jsonpCallback;
 	}
 
 	/**
@@ -63,6 +70,7 @@ class ApiResponse extends Response
 	 * @param string $root_element Name of the root element
 	 *
 	 * @return string The XML data
+	 * @throws \Exception
 	 */
 	public function createXML(array $data, string $root_element): string
 	{
@@ -109,6 +117,7 @@ class ApiResponse extends Response
 	 * @param int   $cid Contact ID of template
 	 *
 	 * @return array
+	 * @throws HTTPException\InternalServerErrorException
 	 */
 	private function addRSSValues(array $arr, int $cid): array
 	{
@@ -141,6 +150,7 @@ class ApiResponse extends Response
 	 * @param int    $cid          ID of the contact for RSS
 	 *
 	 * @return array|string (string|array) XML data or JSON data
+	 * @throws HTTPException\InternalServerErrorException
 	 */
 	public function formatData(string $root_element, string $type, array $data, int $cid = 0)
 	{
@@ -180,7 +190,7 @@ class ApiResponse extends Response
 	}
 
 	/**
-	 * Exit with error code
+	 * Add formatted error message to response
 	 *
 	 * @param int         $code
 	 * @param string      $description
@@ -188,6 +198,7 @@ class ApiResponse extends Response
 	 * @param string|null $format
 	 *
 	 * @return void
+	 * @throws HTTPException\InternalServerErrorException
 	 */
 	public function error(int $code, string $description, string $message, string $format = null)
 	{
@@ -197,19 +208,21 @@ class ApiResponse extends Response
 			'request' => $this->args->getQueryString()
 		];
 
-		$this->setHeader(($_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1') . ' ' . $code . ' ' . $description);
+		$this->setHeader(($this->server['SERVER_PROTOCOL'] ?? 'HTTP/1.1') . ' ' . $code . ' ' . $description);
 
 		$this->exit('status', ['status' => $error], $format);
 	}
 
 	/**
-	 * Outputs formatted data according to the data type and then exits the execution.
+	 * Add formatted data according to the data type to the response.
 	 *
 	 * @param string      $root_element
 	 * @param array       $data   An array with a single element containing the returned result
 	 * @param string|null $format Output format (xml, json, rss, atom)
+	 * @param int         $cid
 	 *
 	 * @return void
+	 * @throws HTTPException\InternalServerErrorException
 	 */
 	public function exit(string $root_element, array $data, string $format = null, int $cid = 0)
 	{
@@ -226,8 +239,8 @@ class ApiResponse extends Response
 				$this->setType(static::TYPE_JSON);
 				if (!empty($return)) {
 					$json = json_encode(end($return));
-					if (!empty($_GET['callback'])) {
-						$json = $_GET['callback'] . '(' . $json . ')';
+					if ($this->jsonpCallback) {
+						$json = $this->jsonpCallback . '(' . $json . ')';
 					}
 					$return = $json;
 				}
@@ -251,6 +264,7 @@ class ApiResponse extends Response
 	 * @param array $data
 	 *
 	 * @return void
+	 * @throws HTTPException\InternalServerErrorException
 	 */
 	public function exitWithJson(array $data)
 	{
@@ -273,7 +287,7 @@ class ApiResponse extends Response
 			[
 				'method'  => $method,
 				'path'    => $path,
-				'agent'   => $_SERVER['HTTP_USER_AGENT'] ?? '',
+				'agent'   => $this->server['HTTP_USER_AGENT'] ?? '',
 				'request' => $request,
 			]);
 		$error = $this->l10n->t('API endpoint %s %s is not implemented but might be in the future.', strtoupper($method), $path);

--- a/src/Module/Api/ApiResponse.php
+++ b/src/Module/Api/ApiResponse.php
@@ -210,7 +210,7 @@ class ApiResponse extends Response
 
 		$this->setHeader(($this->server['SERVER_PROTOCOL'] ?? 'HTTP/1.1') . ' ' . $code . ' ' . $description);
 
-		$this->exit('status', ['status' => $error], $format);
+		$this->addFormattedContent('status', ['status' => $error], $format);
 	}
 
 	/**
@@ -224,7 +224,7 @@ class ApiResponse extends Response
 	 * @return void
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public function exit(string $root_element, array $data, string $format = null, int $cid = 0)
+	public function addFormattedContent(string $root_element, array $data, string $format = null, int $cid = 0)
 	{
 		$format = $format ?? 'json';
 
@@ -259,16 +259,16 @@ class ApiResponse extends Response
 	}
 
 	/**
-	 * Wrapper around exit() for JSON only responses
+	 * Wrapper around addFormattedContent() for JSON only responses
 	 *
 	 * @param array $data
 	 *
 	 * @return void
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	public function exitWithJson(array $data)
+	public function addJsonContent(array $data)
 	{
-		$this->exit('content', ['content' => $data], static::TYPE_JSON);
+		$this->addFormattedContent('content', ['content' => $data], static::TYPE_JSON);
 	}
 
 	/**

--- a/src/Module/Api/Friendica/Activity.php
+++ b/src/Module/Api/Friendica/Activity.php
@@ -60,7 +60,7 @@ class Activity extends BaseApi
 
 		if ($res) {
 			$status_info = DI::twitterStatus()->createFromUriId($request['id'], $uid)->toArray();
-			$this->response->exit('status', ['status' => $status_info], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('status', ['status' => $status_info], $this->parameters['extension'] ?? null);
 		} else {
 			$this->response->error(500, 'Error adding activity', '', $this->parameters['extension'] ?? null);
 		}

--- a/src/Module/Api/Friendica/Circle/Create.php
+++ b/src/Module/Api/Friendica/Circle/Create.php
@@ -82,6 +82,6 @@ class Create extends BaseApi
 
 		$result = ['success' => true, 'gid' => $gid, 'name' => $name, 'status' => $status, 'wrong users' => $errorusers];
 
-		$this->response->exit('group_create', ['$result' => $result], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('group_create', ['$result' => $result], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Friendica/Circle/Delete.php
+++ b/src/Module/Api/Friendica/Circle/Delete.php
@@ -70,7 +70,7 @@ class Delete extends BaseApi
 		if ($ret) {
 			// return success
 			$success = ['success' => $ret, 'gid' => $request['gid'], 'name' => $request['name'], 'status' => 'deleted', 'wrong users' => []];
-			$this->response->exit('group_delete', ['$result' => $success], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('group_delete', ['$result' => $success], $this->parameters['extension'] ?? null);
 		} else {
 			throw new BadRequestException('other API error');
 		}

--- a/src/Module/Api/Friendica/Circle/Show.php
+++ b/src/Module/Api/Friendica/Circle/Show.php
@@ -75,6 +75,6 @@ class Show extends BaseApi
 			$grps[] = ['name' => $circle['name'], 'gid' => $circle['id'], $user_element => $users];
 		}
 
-		$this->response->exit('group_update', ['group' => $grps], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('group_update', ['group' => $grps], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Friendica/Circle/Update.php
+++ b/src/Module/Api/Friendica/Circle/Update.php
@@ -84,6 +84,6 @@ class Update extends BaseApi
 		// return success message incl. missing users in array
 		$status  = ($erroraddinguser ? 'missing user' : 'ok');
 		$success = ['success' => true, 'gid' => $gid, 'name' => $name, 'status' => $status, 'wrong users' => $errorusers];
-		$this->response->exit('group_update', ['$result' => $success], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('group_update', ['$result' => $success], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Friendica/DirectMessages/Search.php
+++ b/src/Module/Api/Friendica/DirectMessages/Search.php
@@ -64,7 +64,7 @@ class Search extends BaseApi
 		// error if no searchstring specified
 		if ($request['searchstring'] == '') {
 			$answer = ['result' => 'error', 'message' => 'searchstring not specified'];
-			$this->response->exit('direct_message_search', ['$result' => $answer], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('direct_message_search', ['$result' => $answer], $this->parameters['extension'] ?? null);
 			return;
 		}
 
@@ -82,6 +82,6 @@ class Search extends BaseApi
 			$success = ['success' => true, 'search_results' => $ret];
 		}
 
-		$this->response->exit('direct_message_search', ['$result' => $success], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('direct_message_search', ['$result' => $success], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Friendica/DirectMessages/Setseen.php
+++ b/src/Module/Api/Friendica/DirectMessages/Setseen.php
@@ -42,14 +42,14 @@ class Setseen extends BaseApi
 		// return error if id is zero
 		if (empty($request['id'])) {
 			$answer = ['result' => 'error', 'message' => 'message id not specified'];
-			$this->response->exit('direct_messages_setseen', ['$result' => $answer], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('direct_messages_setseen', ['$result' => $answer], $this->parameters['extension'] ?? null);
 			return;
 		}
 
 		// error message if specified id is not in database
 		if (!DBA::exists('mail', ['id' => $request['id'], 'uid' => $uid])) {
 			$answer = ['result' => 'error', 'message' => 'message id not in database'];
-			$this->response->exit('direct_messages_setseen', ['$result' => $answer], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('direct_messages_setseen', ['$result' => $answer], $this->parameters['extension'] ?? null);
 			return;
 		}
 
@@ -60,6 +60,6 @@ class Setseen extends BaseApi
 			$answer = ['result' => 'error', 'message' => 'unknown error'];
 		}
 
-		$this->response->exit('direct_messages_setseen', ['$result' => $answer], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('direct_messages_setseen', ['$result' => $answer], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Friendica/Events/Create.php
+++ b/src/Module/Api/Friendica/Events/Create.php
@@ -110,6 +110,6 @@ class Create extends BaseApi
 
 		$result = ['success' => true, 'event_id' => $event_id, 'event' => $event];
 
-		$this->response->exit('event_create', ['$result' => $result], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('event_create', ['$result' => $result], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Friendica/Events/Delete.php
+++ b/src/Module/Api/Friendica/Events/Delete.php
@@ -59,6 +59,6 @@ class Delete extends BaseApi
 		Event::delete($eventid);
 
 		$success = ['id' => $eventid, 'status' => 'deleted'];
-		$this->response->exit('event_delete', ['$result' => $success], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('event_delete', ['$result' => $success], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Friendica/Events/Index.php
+++ b/src/Module/Api/Friendica/Events/Index.php
@@ -69,6 +69,6 @@ class Index extends BaseApi
 			];
 		}
 
-		$this->response->exit('events', ['events' => $items], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('events', ['events' => $items], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Friendica/Notification.php
+++ b/src/Module/Api/Friendica/Notification.php
@@ -56,6 +56,6 @@ class Notification extends BaseApi
 			$result = false;
 		}
 
-		$this->response->exit('notes', ['note' => $result], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('notes', ['note' => $result], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Friendica/Notification/Seen.php
+++ b/src/Module/Api/Friendica/Notification/Seen.php
@@ -70,13 +70,13 @@ class Seen extends BaseApi
 					// we found the item, return it to the user
 					$ret  = [DI::twitterStatus()->createFromUriId($item['uri-id'], $item['uid'], $include_entities)->toArray()];
 					$data = ['status' => $ret];
-					$this->response->exit('statuses', $data, $this->parameters['extension'] ?? null);
+					$this->response->addFormattedContent('statuses', $data, $this->parameters['extension'] ?? null);
 					return;
 				}
 				// the item can't be found, but we set the notification as seen, so we count this as a success
 			}
 
-			$this->response->exit('statuses', ['result' => 'success'], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('statuses', ['result' => 'success'], $this->parameters['extension'] ?? null);
 		} catch (NotFoundException $e) {
 			throw new BadRequestException('Invalid argument', $e);
 		} catch (Exception $e) {

--- a/src/Module/Api/Friendica/Photo.php
+++ b/src/Module/Api/Friendica/Photo.php
@@ -60,6 +60,6 @@ class Photo extends BaseApi
 		// prepare json/xml output with data from database for the requested photo
 		$data = ['photo' => $this->friendicaPhoto->createFromId($photo_id, $scale, $uid, $type)];
 
-		$this->response->exit('statuses', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Friendica/Photo/Create.php
+++ b/src/Module/Api/Friendica/Photo/Create.php
@@ -90,7 +90,7 @@ class Create extends BaseApi
 		if (!empty($photo)) {
 			Photo::clearAlbumCache($uid);
 			$data = ['photo' => $this->friendicaPhoto->createFromId($photo['resource_id'], null, $uid, $type)];
-			$this->response->exit('photo_create', $data, $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('photo_create', $data, $this->parameters['extension'] ?? null);
 		} else {
 			throw new HTTPException\InternalServerErrorException('unknown error - uploading photo failed, see Friendica log for more information');
 		}

--- a/src/Module/Api/Friendica/Photo/Delete.php
+++ b/src/Module/Api/Friendica/Photo/Delete.php
@@ -62,7 +62,7 @@ class Delete extends BaseApi
 			Item::deleteForUser($condition, $uid);
 			Photo::clearAlbumCache($uid);
 			$result = ['result' => 'deleted', 'message' => 'photo with id `' . $request['photo_id'] . '` has been deleted from server.'];
-			$this->response->exit('photo_delete', ['$result' => $result], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('photo_delete', ['$result' => $result], $this->parameters['extension'] ?? null);
 		} else {
 			throw new InternalServerErrorException("unknown error on deleting photo from database table");
 		}

--- a/src/Module/Api/Friendica/Photo/Lists.php
+++ b/src/Module/Api/Friendica/Photo/Lists.php
@@ -77,6 +77,6 @@ class Lists extends BaseApi
 			}
 		}
 
-		$this->response->exit('statuses', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Friendica/Photo/Update.php
+++ b/src/Module/Api/Friendica/Photo/Update.php
@@ -128,7 +128,7 @@ class Update extends BaseApi
 			$photo       = Photo::upload($uid, $_FILES['media'], $album, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $desc, $photo_id);
 			if (!empty($photo)) {
 				$data = ['photo' => $this->friendicaPhoto->createFromId($photo['resource_id'], null, $uid, $type)];
-				$this->response->exit('photo_update', $data, $this->parameters['extension'] ?? null);
+				$this->response->addFormattedContent('photo_update', $data, $this->parameters['extension'] ?? null);
 				return;
 			}
 		}
@@ -137,12 +137,12 @@ class Update extends BaseApi
 		if ($result) {
 			Photo::clearAlbumCache($uid);
 			$answer = ['result' => 'updated', 'message' => 'Image id `' . $photo_id . '` has been updated.'];
-			$this->response->exit('photo_update', ['$result' => $answer], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('photo_update', ['$result' => $answer], $this->parameters['extension'] ?? null);
 			return;
 		} else {
 			if ($nothingtodo) {
 				$answer = ['result' => 'cancelled', 'message' => 'Nothing to update for image id `' . $photo_id . '`.'];
-				$this->response->exit('photo_update', ['$result' => $answer], $this->parameters['extension'] ?? null);
+				$this->response->addFormattedContent('photo_update', ['$result' => $answer], $this->parameters['extension'] ?? null);
 				return;
 			}
 			throw new HTTPException\InternalServerErrorException('unknown error - update photo entry in database failed');

--- a/src/Module/Api/Friendica/Photoalbum/Delete.php
+++ b/src/Module/Api/Friendica/Photoalbum/Delete.php
@@ -68,7 +68,7 @@ class Delete extends BaseApi
 		if ($result) {
 			Photo::clearAlbumCache($uid);
 			$answer = ['result' => 'deleted', 'message' => 'album `' . $request['album'] . '` with all containing photos has been deleted.'];
-			$this->response->exit('photoalbum_delete', ['$result' => $answer], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('photoalbum_delete', ['$result' => $answer], $this->parameters['extension'] ?? null);
 		} else {
 			throw new InternalServerErrorException("unknown error - deleting from database failed");
 		}

--- a/src/Module/Api/Friendica/Photoalbum/Index.php
+++ b/src/Module/Api/Friendica/Photoalbum/Index.php
@@ -47,6 +47,6 @@ class Index extends BaseApi
 			];
 		}
 
-		$this->response->exit('albums', ['albums' => $items], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('albums', ['albums' => $items], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -104,6 +104,6 @@ class Show extends BaseApi
 			}
 		}
 
-		$this->response->exit('statuses', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Friendica/Photoalbum/Update.php
+++ b/src/Module/Api/Friendica/Photoalbum/Update.php
@@ -60,7 +60,7 @@ class Update extends BaseApi
 		if ($result) {
 			Photo::clearAlbumCache($uid);
 			$answer = ['result' => 'updated', 'message' => 'album `' . $request['album'] . '` with all containing photos has been renamed to `' . $request['album_new'] . '`.'];
-			$this->response->exit('photoalbum_update', ['$result' => $answer], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('photoalbum_update', ['$result' => $answer], $this->parameters['extension'] ?? null);
 		} else {
 			throw new InternalServerErrorException("unknown error - updating in database failed");
 		}

--- a/src/Module/Api/Friendica/Profile/Show.php
+++ b/src/Module/Api/Friendica/Profile/Show.php
@@ -62,7 +62,7 @@ class Show extends BaseApi
 			'profiles' => $profiles
 		];
 
-		$this->response->exit('friendica_profiles', ['$result' => $result], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('friendica_profiles', ['$result' => $result], $this->parameters['extension'] ?? null);
 	}
 
 	/**

--- a/src/Module/Api/Friendica/Statuses/Dislike.php
+++ b/src/Module/Api/Friendica/Statuses/Dislike.php
@@ -49,6 +49,6 @@ class Dislike extends BaseApi
 
 		Item::performActivity($item['id'], 'dislike', $uid);
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
 	}
 }

--- a/src/Module/Api/Friendica/Statuses/DislikedBy.php
+++ b/src/Module/Api/Friendica/Statuses/DislikedBy.php
@@ -57,6 +57,6 @@ class DislikedBy extends BaseApi
 			$accounts[] = DI::mstdnAccount()->createFromContactId($activity['author-id'], $uid);
 		}
 
-		System::jsonExit($accounts);
+		$this->jsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Friendica/Statuses/Undislike.php
+++ b/src/Module/Api/Friendica/Statuses/Undislike.php
@@ -49,6 +49,6 @@ class Undislike extends BaseApi
 
 		Item::performActivity($item['id'], 'undislike', $uid);
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
 	}
 }

--- a/src/Module/Api/GNUSocial/GNUSocial/Config.php
+++ b/src/Module/Api/GNUSocial/GNUSocial/Config.php
@@ -61,6 +61,6 @@ class Config extends BaseApi
 			],
 		];
 
-		$this->response->exit('config', ['config' => $config], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('config', ['config' => $config], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/GNUSocial/GNUSocial/Version.php
+++ b/src/Module/Api/GNUSocial/GNUSocial/Version.php
@@ -31,6 +31,6 @@ class Version extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		$this->response->exit('version', ['version' => '0.9.7'], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('version', ['version' => '0.9.7'], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/GNUSocial/Help/Test.php
+++ b/src/Module/Api/GNUSocial/Help/Test.php
@@ -37,6 +37,6 @@ class Test extends BaseApi
 			$ok = 'ok';
 		}
 
-		$this->response->exit('ok', ['ok' => $ok], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('ok', ['ok' => $ok], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/GNUSocial/Statusnet/Conversation.php
+++ b/src/Module/Api/GNUSocial/Statusnet/Conversation.php
@@ -90,6 +90,6 @@ class Conversation extends BaseApi
 		}
 		DBA::close($statuses);
 
-		$this->response->exit('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts.php
+++ b/src/Module/Api/Mastodon/Accounts.php
@@ -58,6 +58,6 @@ class Accounts extends BaseApi
 		}
 
 		$account = DI::mstdnAccount()->createFromContactId($id, $uid);
-		System::jsonExit($account);
+		$this->jsonExit($account);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Block.php
+++ b/src/Module/Api/Mastodon/Accounts/Block.php
@@ -52,6 +52,6 @@ class Block extends BaseApi
 			}
 		}
 
-		System::jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/FeaturedTags.php
+++ b/src/Module/Api/Mastodon/Accounts/FeaturedTags.php
@@ -36,6 +36,6 @@ class FeaturedTags extends BaseApi
 	{
 		self::checkAllowedScope(self::SCOPE_READ);
 
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Follow.php
+++ b/src/Module/Api/Mastodon/Accounts/Follow.php
@@ -54,6 +54,6 @@ class Follow extends BaseApi
 
 		Contact::update(['notify_new_posts' => $request['notify']], ['id' => $result['cid']]);
 
-		System::jsonExit(DI::mstdnRelationship()->createFromContactId($result['cid'], $uid)->toArray());
+		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($result['cid'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Followers.php
+++ b/src/Module/Api/Mastodon/Accounts/Followers.php
@@ -115,6 +115,6 @@ class Followers extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($accounts);
+		$this->jsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Following.php
+++ b/src/Module/Api/Mastodon/Accounts/Following.php
@@ -115,6 +115,6 @@ class Following extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($accounts);
+		$this->jsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
+++ b/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
@@ -36,6 +36,6 @@ class IdentityProofs extends BaseApi
 	{
 		self::checkAllowedScope(self::SCOPE_READ);
 
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Lists.php
+++ b/src/Module/Api/Mastodon/Accounts/Lists.php
@@ -60,6 +60,6 @@ class Lists extends BaseApi
 			DBA::close($circles);
 		}
 
-		System::jsonExit($lists);
+		$this->jsonExit($lists);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Mute.php
+++ b/src/Module/Api/Mastodon/Accounts/Mute.php
@@ -42,6 +42,6 @@ class Mute extends BaseApi
 
 		Contact\User::setIgnored($this->parameters['id'], $uid, true);
 
-		System::jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Note.php
+++ b/src/Module/Api/Mastodon/Accounts/Note.php
@@ -52,6 +52,6 @@ class Note extends BaseApi
 
 		Contact::update(['info' => $request['comment']], ['id' => $cdata['user']]);
 
-		System::jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Relationships.php
+++ b/src/Module/Api/Mastodon/Accounts/Relationships.php
@@ -57,6 +57,6 @@ class Relationships extends BaseApi
 			$relationships[] = DI::mstdnRelationship()->createFromContactId($id, $uid);
 		}
 
-		System::jsonExit($relationships);
+		$this->jsonExit($relationships);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Search.php
+++ b/src/Module/Api/Mastodon/Accounts/Search.php
@@ -67,6 +67,6 @@ class Search extends BaseApi
 			DBA::close($contacts);
 		}
 
-		System::jsonExit($accounts);
+		$this->jsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Statuses.php
+++ b/src/Module/Api/Mastodon/Accounts/Statuses.php
@@ -122,6 +122,6 @@ class Statuses extends BaseApi
 		}
 
 		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
-		System::jsonExit($statuses);
+		$this->jsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Unblock.php
+++ b/src/Module/Api/Mastodon/Accounts/Unblock.php
@@ -42,6 +42,6 @@ class Unblock extends BaseApi
 
 		Contact\User::setBlocked($this->parameters['id'], $uid, false);
 
-		System::jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Unfollow.php
+++ b/src/Module/Api/Mastodon/Accounts/Unfollow.php
@@ -49,6 +49,6 @@ class Unfollow extends BaseApi
 
 		Contact::unfollow($contact);
 
-		System::jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Unmute.php
+++ b/src/Module/Api/Mastodon/Accounts/Unmute.php
@@ -42,6 +42,6 @@ class Unmute extends BaseApi
 
 		Contact\User::setIgnored($this->parameters['id'], $uid, false);
 
-		System::jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
@@ -105,6 +105,6 @@ class UpdateCredentials extends BaseApi
 		}
 
 		$account = DI::mstdnAccount()->createFromContactId($cdata['user'], $uid);
-		$this->response->exitWithJson($account->toArray());
+		$this->response->addJsonContent($account->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/VerifyCredentials.php
@@ -52,6 +52,6 @@ class VerifyCredentials extends BaseApi
 
 		// @todo Support the source property,
 		$account = DI::mstdnAccount()->createFromContactId($cdata['user'], $uid);
-		$this->response->exitWithJson($account->toArray());
+		$this->response->addJsonContent($account->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Announcements.php
+++ b/src/Module/Api/Mastodon/Announcements.php
@@ -37,6 +37,6 @@ class Announcements extends BaseApi
 		self::checkAllowedScope(self::SCOPE_READ);
 
 		// @todo Possibly use the message from the pageheader addon for this
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -66,7 +66,7 @@ class Apps extends BaseApi
 
 			if (!empty($request['redirect_uris']) && is_array($request['redirect_uris'])) {
 				$request['redirect_uris'] = $request['redirect_uris'][0];
-			}	
+			}
 		}
 
 		if (empty($request['client_name']) || empty($request['redirect_uris'])) {
@@ -95,6 +95,6 @@ class Apps extends BaseApi
 			DI::mstdnError()->InternalError();
 		}
 
-		System::jsonExit(DI::mstdnApplication()->createFromApplicationId(DBA::lastInsertId())->toArray());
+		$this->jsonExit(DI::mstdnApplication()->createFromApplicationId(DBA::lastInsertId())->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
@@ -39,6 +39,6 @@ class VerifyCredentials extends BaseApi
 			DI::mstdnError()->Unauthorized();
 		}
 
-		System::jsonExit(DI::mstdnApplication()->createFromApplicationId($application['id']));
+		$this->jsonExit(DI::mstdnApplication()->createFromApplicationId($application['id']));
 	}
 }

--- a/src/Module/Api/Mastodon/Blocks.php
+++ b/src/Module/Api/Mastodon/Blocks.php
@@ -77,6 +77,6 @@ class Blocks extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($accounts);
+		$this->jsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Bookmarks.php
+++ b/src/Module/Api/Mastodon/Bookmarks.php
@@ -88,6 +88,6 @@ class Bookmarks extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($statuses);
+		$this->jsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Conversations.php
+++ b/src/Module/Api/Mastodon/Conversations.php
@@ -43,7 +43,7 @@ class Conversations extends BaseApi
 		DBA::delete('conv', ['id' => $this->parameters['id'], 'uid' => $uid]);
 		DBA::delete('mail', ['convid' => $this->parameters['id'], 'uid' => $uid]);
 
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 
 	/**
@@ -95,6 +95,6 @@ class Conversations extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($conversations);
+		$this->jsonExit($conversations);
 	}
 }

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -42,6 +42,6 @@ class Read extends BaseApi
 
 		DBA::update('mail', ['seen' => true], ['convid' => $this->parameters['id'], 'uid' => $uid]);
 
-		System::jsonExit(DI::mstdnConversation()->createFromConvId($this->parameters['id'])->toArray());
+		$this->jsonExit(DI::mstdnConversation()->createFromConvId($this->parameters['id'])->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/CustomEmojis.php
+++ b/src/Module/Api/Mastodon/CustomEmojis.php
@@ -41,6 +41,6 @@ class CustomEmojis extends BaseApi
 	{
 		$emojis = DI::mstdnEmoji()->createCollectionFromSmilies(Smilies::getList());
 
-		System::jsonExit($emojis->getArrayCopy());
+		$this->jsonExit($emojis->getArrayCopy());
 	}
 }

--- a/src/Module/Api/Mastodon/Directory.php
+++ b/src/Module/Api/Mastodon/Directory.php
@@ -68,6 +68,6 @@ class Directory extends BaseApi
 		}
 		DBA::close($contacts);
 
-		System::jsonExit($accounts);
+		$this->jsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Endorsements.php
+++ b/src/Module/Api/Mastodon/Endorsements.php
@@ -34,6 +34,6 @@ class Endorsements extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Favourited.php
+++ b/src/Module/Api/Mastodon/Favourited.php
@@ -90,6 +90,6 @@ class Favourited extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($statuses);
+		$this->jsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Filters.php
+++ b/src/Module/Api/Mastodon/Filters.php
@@ -45,6 +45,6 @@ class Filters extends BaseApi
 	{
 		self::checkAllowedScope(self::SCOPE_READ);
 
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/FollowRequests.php
+++ b/src/Module/Api/Mastodon/FollowRequests.php
@@ -79,7 +79,7 @@ class FollowRequests extends BaseApi
 				throw new HTTPException\BadRequestException('Unexpected action parameter, expecting "authorize", "ignore" or "reject"');
 		}
 
-		System::jsonExit($relationship);
+		$this->jsonExit($relationship);
 	}
 
 	/**
@@ -115,6 +115,6 @@ class FollowRequests extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/Api/Mastodon/FollowedTags.php
+++ b/src/Module/Api/Mastodon/FollowedTags.php
@@ -77,6 +77,6 @@ class FollowedTags extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/Api/Mastodon/Instance.php
+++ b/src/Module/Api/Mastodon/Instance.php
@@ -59,6 +59,6 @@ class Instance extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		System::jsonExit(new InstanceEntity($this->config, $this->baseUrl, $this->database, System::getRules()));
+		$this->jsonExit(new InstanceEntity($this->config, $this->baseUrl, $this->database, System::getRules()));
 	}
 }

--- a/src/Module/Api/Mastodon/Instance/Peers.php
+++ b/src/Module/Api/Mastodon/Instance/Peers.php
@@ -52,6 +52,6 @@ class Peers extends BaseApi
 		}
 		DBA::close($instances);
 
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/Api/Mastodon/Instance/Rules.php
+++ b/src/Module/Api/Mastodon/Instance/Rules.php
@@ -38,6 +38,6 @@ class Rules extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		System::jsonExit(System::getRules());
+		$this->jsonExit(System::getRules());
 	}
 }

--- a/src/Module/Api/Mastodon/InstanceV2.php
+++ b/src/Module/Api/Mastodon/InstanceV2.php
@@ -94,7 +94,7 @@ class InstanceV2 extends BaseApi
 		$contact              = $this->buildContactInfo();
 		$friendica_extensions = $this->buildFriendicaExtensionInfo();
 		$rules                = System::getRules();
-		System::jsonExit(new InstanceEntity(
+		$this->jsonExit(new InstanceEntity(
 			$domain,
 			$title,
 			$version,

--- a/src/Module/Api/Mastodon/Lists.php
+++ b/src/Module/Api/Mastodon/Lists.php
@@ -48,7 +48,7 @@ class Lists extends BaseApi
 			DI::mstdnError()->InternalError();
 		}
 
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 
 	protected function post(array $request = [])
@@ -71,7 +71,7 @@ class Lists extends BaseApi
 			DI::mstdnError()->InternalError();
 		}
 
-		System::jsonExit(DI::mstdnList()->createFromCircleId($id));
+		$this->jsonExit(DI::mstdnList()->createFromCircleId($id));
 	}
 
 	public function put(array $request = [])
@@ -111,6 +111,6 @@ class Lists extends BaseApi
 			$lists = DI::mstdnList()->createFromCircleId($id);
 		}
 
-		System::jsonExit($lists);
+		$this->jsonExit($lists);
 	}
 }

--- a/src/Module/Api/Mastodon/Lists/Accounts.php
+++ b/src/Module/Api/Mastodon/Lists/Accounts.php
@@ -127,6 +127,6 @@ class Accounts extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($accounts);
+		$this->jsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Markers.php
+++ b/src/Module/Api/Mastodon/Markers.php
@@ -61,7 +61,7 @@ class Markers extends BaseApi
 
 		$fields = ['last_read_id' => $last_read_id, 'version' => $version, 'updated_at' => DateTimeFormat::utcNow()];
 		DBA::update('application-marker', $fields, $condition, true);
-		System::jsonExit($this->fetchTimelines($application['id'], $uid));
+		$this->jsonExit($this->fetchTimelines($application['id'], $uid));
 	}
 
 	/**
@@ -73,7 +73,7 @@ class Markers extends BaseApi
 		$uid         = self::getCurrentUserID();
 		$application = self::getCurrentApplication();
 
-		System::jsonExit($this->fetchTimelines($application['id'], $uid));
+		$this->jsonExit($this->fetchTimelines($application['id'], $uid));
 	}
 
 	private function fetchTimelines(int $application_id, int $uid)

--- a/src/Module/Api/Mastodon/Media.php
+++ b/src/Module/Api/Mastodon/Media.php
@@ -58,7 +58,7 @@ class Media extends BaseApi
 
 		Logger::info('Uploaded photo', ['media' => $media]);
 
-		System::jsonExit(DI::mstdnAttachment()->createFromPhoto($media['id']));
+		$this->jsonExit(DI::mstdnAttachment()->createFromPhoto($media['id']));
 	}
 
 	public function put(array $request = [])
@@ -87,12 +87,12 @@ class Media extends BaseApi
 				DI::mstdnError()->RecordNotFound();
 			}
 			Post\Media::updateById(['description' => $request['description']], $this->parameters['id']);
-			System::jsonExit(DI::mstdnAttachment()->createFromId($this->parameters['id']));
+			$this->jsonExit(DI::mstdnAttachment()->createFromId($this->parameters['id']));
 		}
 
 		Photo::update(['desc' => $request['description']], ['resource-id' => $photo['resource-id']]);
 
-		System::jsonExit(DI::mstdnAttachment()->createFromPhoto($this->parameters['id']));
+		$this->jsonExit(DI::mstdnAttachment()->createFromPhoto($this->parameters['id']));
 	}
 
 	/**
@@ -112,6 +112,6 @@ class Media extends BaseApi
 			DI::mstdnError()->RecordNotFound();
 		}
 
-		System::jsonExit(DI::mstdnAttachment()->createFromPhoto($id));
+		$this->jsonExit(DI::mstdnAttachment()->createFromPhoto($id));
 	}
 }

--- a/src/Module/Api/Mastodon/Mutes.php
+++ b/src/Module/Api/Mastodon/Mutes.php
@@ -85,6 +85,6 @@ class Mutes extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($accounts);
+		$this->jsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -48,7 +48,7 @@ class Notifications extends BaseApi
 			$id = $this->parameters['id'];
 			try {
 				$notification = DI::notification()->selectOneForUser($uid, ['id' => $id]);
-				System::jsonExit(DI::mstdnNotification()->createFromNotification($notification, self::appSupportsQuotes()));
+				$this->jsonExit(DI::mstdnNotification()->createFromNotification($notification, self::appSupportsQuotes()));
 			} catch (\Exception $e) {
 				DI::mstdnError()->RecordNotFound();
 			}
@@ -132,7 +132,7 @@ class Notifications extends BaseApi
 
 		if ($request['summary']) {
 			$count = DI::notification()->countForUser($uid, $condition);
-			System::jsonExit(['count' => $count]);
+			$this->jsonExit(['count' => $count]);
 		} else {
 			$mstdnNotifications = [];
 
@@ -154,7 +154,7 @@ class Notifications extends BaseApi
 			}
 
 			self::setLinkHeader();
-			System::jsonExit($mstdnNotifications);
+			$this->jsonExit($mstdnNotifications);
 		}
 	}
 }

--- a/src/Module/Api/Mastodon/Notifications/Clear.php
+++ b/src/Module/Api/Mastodon/Notifications/Clear.php
@@ -37,6 +37,6 @@ class Clear extends BaseApi
 
 		DI::notification()->setAllDismissedForUser($uid);
 
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Notifications/Dismiss.php
+++ b/src/Module/Api/Mastodon/Notifications/Dismiss.php
@@ -46,6 +46,6 @@ class Dismiss extends BaseApi
 		$Notification->setDismissed();
 		DI::notification()->save($Notification);
 
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Polls.php
+++ b/src/Module/Api/Mastodon/Polls.php
@@ -42,6 +42,6 @@ class Polls extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		System::jsonExit(DI::mstdnPoll()->createFromId($this->parameters['id'], $uid));
+		$this->jsonExit(DI::mstdnPoll()->createFromId($this->parameters['id'], $uid));
 	}
 }

--- a/src/Module/Api/Mastodon/Preferences.php
+++ b/src/Module/Api/Mastodon/Preferences.php
@@ -55,6 +55,6 @@ class Preferences extends BaseApi
 
 		$preferences = new \Friendica\Object\Api\Mastodon\Preferences($visibility, $sensitive, $language, $media, $spoilers);
 
-		System::jsonExit($preferences);
+		$this->jsonExit($preferences);
 	}
 }

--- a/src/Module/Api/Mastodon/Proofs.php
+++ b/src/Module/Api/Mastodon/Proofs.php
@@ -34,6 +34,6 @@ class Proofs extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		System::jsonError(404, ['error' => 'Record not found']);
+		$this->jsonError(404, ['error' => 'Record not found']);
 	}
 }

--- a/src/Module/Api/Mastodon/PushSubscription.php
+++ b/src/Module/Api/Mastodon/PushSubscription.php
@@ -81,7 +81,7 @@ class PushSubscription extends BaseApi
 		$this->logger->info('Subscription stored', ['ret' => $ret, 'subscription' => $subscription]);
 
 		$subscriptionObj = $this->subscriptionFac->createForApplicationIdAndUserId($application['id'], $uid);
-		$this->response->exitWithJson($subscriptionObj->toArray());
+		$this->response->addJsonContent($subscriptionObj->toArray());
 	}
 
 	public function put(array $request = []): void
@@ -120,7 +120,7 @@ class PushSubscription extends BaseApi
 		]);
 
 		$subscriptionObj = $this->subscriptionFac->createForApplicationIdAndUserId($application['id'], $uid);
-		$this->response->exitWithJson($subscriptionObj->toArray());
+		$this->response->addJsonContent($subscriptionObj->toArray());
 	}
 
 	protected function delete(array $request = []): void
@@ -137,7 +137,7 @@ class PushSubscription extends BaseApi
 			'uid'            => $uid,
 		]);
 
-		$this->response->exitWithJson([]);
+		$this->response->addJsonContent([]);
 	}
 
 	protected function rawContent(array $request = []): void
@@ -154,6 +154,6 @@ class PushSubscription extends BaseApi
 		$this->logger->info('Fetch subscription', ['application-id' => $application['id'], 'uid' => $uid]);
 
 		$subscriptionObj = $this->subscriptionFac->createForApplicationIdAndUserId($application['id'], $uid);
-		$this->response->exitWithJson($subscriptionObj->toArray());
+		$this->response->addJsonContent($subscriptionObj->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Reports.php
+++ b/src/Module/Api/Mastodon/Reports.php
@@ -82,6 +82,6 @@ class Reports extends BaseApi
 
 		$this->reportRepo->save($report);
 
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/ScheduledStatuses.php
+++ b/src/Module/Api/Mastodon/ScheduledStatuses.php
@@ -56,7 +56,7 @@ class ScheduledStatuses extends BaseApi
 
 		Post\Delayed::deleteById($this->parameters['id']);
 
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 
 	/**
@@ -68,7 +68,7 @@ class ScheduledStatuses extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (isset($this->parameters['id'])) {
-			System::jsonExit(DI::mstdnScheduledStatus()->createFromDelayedPostId($this->parameters['id'], $uid)->toArray());
+			$this->jsonExit(DI::mstdnScheduledStatus()->createFromDelayedPostId($this->parameters['id'], $uid)->toArray());
 		}
 
 		$request = $this->getRequest([
@@ -109,6 +109,6 @@ class ScheduledStatuses extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($statuses);
+		$this->jsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -91,7 +91,7 @@ class Search extends BaseApi
 			$result['hashtags'] = self::searchHashtags($request['q'], $request['exclude_unreviewed'], $limit, $request['offset'], $this->parameters['version']);
 		}
 
-		System::jsonExit($result);
+		$this->jsonExit($result);
 	}
 
 	/**

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -159,7 +159,7 @@ class Statuses extends BaseApi
 
 		Item::updateDisplayCache($post['uri-id']);
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($post['uri-id'], $uid, self::appSupportsQuotes()));
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($post['uri-id'], $uid, self::appSupportsQuotes()));
 	}
 
 	protected function post(array $request = [])
@@ -299,14 +299,14 @@ class Statuses extends BaseApi
 			if (empty($id)) {
 				DI::mstdnError()->InternalError();
 			}
-			System::jsonExit(DI::mstdnScheduledStatus()->createFromDelayedPostId($id, $uid)->toArray());
+			$this->jsonExit(DI::mstdnScheduledStatus()->createFromDelayedPostId($id, $uid)->toArray());
 		}
 
 		$id = Item::insert($item, true);
 		if (!empty($id)) {
 			$item = Post::selectFirst(['uri-id'], ['id' => $id]);
 			if (!empty($item['uri-id'])) {
-				System::jsonExit(DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, self::appSupportsQuotes()));
+				$this->jsonExit(DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, self::appSupportsQuotes()));
 			}
 		}
 
@@ -331,7 +331,7 @@ class Statuses extends BaseApi
 			DI::mstdnError()->RecordNotFound();
 		}
 
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 
 	/**
@@ -345,7 +345,7 @@ class Statuses extends BaseApi
 			DI::mstdnError()->UnprocessableEntity();
 		}
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), false));
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), false));
 	}
 
 	private function getApp(): string
@@ -422,7 +422,7 @@ class Statuses extends BaseApi
 		if (preg_match("/\[url=[^\[\]]*\](.*)\[\/url\]\z/ism", $status, $matches)) {
 			$status = preg_replace("/\[url=[^\[\]]*\].*\[\/url\]\z/ism", PageInfo::getFooterFromUrl($matches[1]), $status);
 		}
-		
+
 		return $status;
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -263,7 +263,7 @@ class Statuses extends BaseApi
 			$item['gravity']     = Item::GRAVITY_COMMENT;
 			$item['object-type'] = Activity\ObjectType::COMMENT;
 		} else {
-			self::checkThrottleLimit();
+			$this->checkThrottleLimit();
 
 			$item['gravity']     = Item::GRAVITY_PARENT;
 			$item['object-type'] = Activity\ObjectType::NOTE;

--- a/src/Module/Api/Mastodon/Statuses/Bookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Bookmark.php
@@ -70,6 +70,6 @@ class Bookmark extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Card.php
+++ b/src/Module/Api/Mastodon/Statuses/Card.php
@@ -49,6 +49,6 @@ class Card extends BaseApi
 
 		$card = DI::mstdnCard()->createFromUriId($post['uri-id']);
 
-		System::jsonExit($card->toArray());
+		$this->jsonExit($card->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -140,7 +140,7 @@ class Context extends BaseApi
 			$statuses['descendants'][] = DI::mstdnStatus()->createFromUriId($descendant, $uid, $display_quotes);
 		}
 
-		System::jsonExit($statuses);
+		$this->jsonExit($statuses);
 	}
 
 	private static function getParents(int $id, array $parents, array $list = [])

--- a/src/Module/Api/Mastodon/Statuses/Favourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Favourite.php
@@ -54,6 +54,6 @@ class Favourite extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
@@ -56,6 +56,6 @@ class FavouritedBy extends BaseApi
 			$accounts[] = DI::mstdnAccount()->createFromContactId($activity['author-id'], $uid);
 		}
 
-		System::jsonExit($accounts);
+		$this->jsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Mute.php
+++ b/src/Module/Api/Mastodon/Statuses/Mute.php
@@ -58,6 +58,6 @@ class Mute extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -53,6 +53,6 @@ class Pin extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(),$isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(),$isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Reblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Reblog.php
@@ -63,6 +63,6 @@ class Reblog extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
@@ -56,6 +56,6 @@ class RebloggedBy extends BaseApi
 			$accounts[] = DI::mstdnAccount()->createFromContactId($activity['author-id'], $uid);
 		}
 
-		System::jsonExit($accounts);
+		$this->jsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Source.php
+++ b/src/Module/Api/Mastodon/Statuses/Source.php
@@ -52,6 +52,6 @@ class Source extends BaseApi
 
 		$source = DI::mstdnStatusSource()->createFromUriId($id, $uid);
 
-		System::jsonExit($source->toArray());
+		$this->jsonExit($source->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unbookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Unbookmark.php
@@ -70,6 +70,6 @@ class Unbookmark extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unfavourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Unfavourite.php
@@ -54,6 +54,6 @@ class Unfavourite extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unmute.php
+++ b/src/Module/Api/Mastodon/Statuses/Unmute.php
@@ -58,6 +58,6 @@ class Unmute extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -53,6 +53,6 @@ class Unpin extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unreblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Unreblog.php
@@ -69,6 +69,6 @@ class Unreblog extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		System::jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Suggestions.php
+++ b/src/Module/Api/Mastodon/Suggestions.php
@@ -54,6 +54,6 @@ class Suggestions extends BaseApi
 			];
 		}
 
-		System::jsonExit($accounts);
+		$this->jsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Tags.php
+++ b/src/Module/Api/Mastodon/Tags.php
@@ -47,6 +47,6 @@ class Tags extends BaseApi
 		$following = DBA::exists('search', ['uid' => $uid, 'term' => '#' . $tag]);
 
 		$hashtag = new \Friendica\Object\Api\Mastodon\Tag($this->baseUrl, ['name' => $tag], [], $following);
-		System::jsonExit($hashtag->toArray());
+		$this->jsonExit($hashtag->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Tags/Follow.php
+++ b/src/Module/Api/Mastodon/Tags/Follow.php
@@ -46,6 +46,6 @@ class Follow extends BaseApi
 		}
 
 		$hashtag = new \Friendica\Object\Api\Mastodon\Tag($this->baseUrl, ['name' => ltrim($this->parameters['hashtag'])], [], true);
-		System::jsonExit($hashtag->toArray());
+		$this->jsonExit($hashtag->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Tags/Unfollow.php
+++ b/src/Module/Api/Mastodon/Tags/Unfollow.php
@@ -45,6 +45,6 @@ class Unfollow extends BaseApi
 		DBA::delete('search', $term);
 
 		$hashtag = new \Friendica\Object\Api\Mastodon\Tag($this->baseUrl, ['name' => ltrim($this->parameters['hashtag'])], [], false);
-		System::jsonExit($hashtag->toArray());
+		$this->jsonExit($hashtag->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -86,6 +86,6 @@ class Direct extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($statuses);
+		$this->jsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/Home.php
+++ b/src/Module/Api/Mastodon/Timelines/Home.php
@@ -101,6 +101,6 @@ class Home extends BaseApi
 
 
 		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
-		System::jsonExit($statuses);
+		$this->jsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -105,6 +105,6 @@ class ListTimeline extends BaseApi
 		}
 
 		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
-		System::jsonExit($statuses);
+		$this->jsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
@@ -102,6 +102,6 @@ class PublicTimeline extends BaseApi
 		}
 
 		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
-		System::jsonExit($statuses);
+		$this->jsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -131,6 +131,6 @@ class Tag extends BaseApi
 		}
 
 		self::setLinkHeader();
-		System::jsonExit($statuses);
+		$this->jsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Trends/Links.php
+++ b/src/Module/Api/Mastodon/Trends/Links.php
@@ -60,6 +60,6 @@ class Links extends BaseApi
 			self::setLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
 		}
 
-		System::jsonExit($trending);
+		$this->jsonExit($trending);
 	}
 }

--- a/src/Module/Api/Mastodon/Trends/Statuses.php
+++ b/src/Module/Api/Mastodon/Trends/Statuses.php
@@ -67,6 +67,6 @@ class Statuses extends BaseApi
 			self::setLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
 		}
 
-		System::jsonExit($trending);
+		$this->jsonExit($trending);
 	}
 }

--- a/src/Module/Api/Mastodon/Trends/Tags.php
+++ b/src/Module/Api/Mastodon/Trends/Tags.php
@@ -60,6 +60,6 @@ class Tags extends BaseApi
 			self::setLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
 		}
 
-		System::jsonExit($trending);
+		$this->jsonExit($trending);
 	}
 }

--- a/src/Module/Api/Twitter/Account/RateLimitStatus.php
+++ b/src/Module/Api/Twitter/Account/RateLimitStatus.php
@@ -51,6 +51,6 @@ class RateLimitStatus extends BaseApi
 			];
 		}
 
-		$this->response->exit('hash', ['hash' => $hash], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('hash', ['hash' => $hash], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Account/UpdateProfile.php
+++ b/src/Module/Api/Twitter/Account/UpdateProfile.php
@@ -66,6 +66,6 @@ class UpdateProfile extends BaseApi
 		// "uid" is only needed for some internal stuff, so remove it from here
 		unset($user_info['uid']);
 
-		$this->response->exit('user', ['user' => $user_info], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('user', ['user' => $user_info], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Account/UpdateProfileImage.php
+++ b/src/Module/Api/Twitter/Account/UpdateProfileImage.php
@@ -67,6 +67,6 @@ class UpdateProfileImage extends BaseApi
 		// "uid" is only needed for some internal stuff, so remove it from here
 		unset($user_info['uid']);
 
-		$this->response->exit('user', ['user' => $user_info], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('user', ['user' => $user_info], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Account/VerifyCredentials.php
+++ b/src/Module/Api/Twitter/Account/VerifyCredentials.php
@@ -47,6 +47,6 @@ class VerifyCredentials extends BaseApi
 		// "uid" is only needed for some internal stuff, so remove it from here
 		unset($user_info['uid']);
 
-		$this->response->exit('user', ['user' => $user_info], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('user', ['user' => $user_info], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Blocks/Ids.php
+++ b/src/Module/Api/Twitter/Blocks/Ids.php
@@ -83,6 +83,6 @@ class Ids extends ContactEndpoint
 
 		self::setLinkHeader();
 
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/Api/Twitter/Blocks/Lists.php
+++ b/src/Module/Api/Twitter/Blocks/Lists.php
@@ -84,6 +84,6 @@ class Lists extends ContactEndpoint
 
 		self::setLinkHeader();
 
-		$this->response->exit('lists', ['lists' => $return]);
+		$this->response->addFormattedContent('lists', ['lists' => $return]);
 	}
 }

--- a/src/Module/Api/Twitter/DirectMessages/Destroy.php
+++ b/src/Module/Api/Twitter/DirectMessages/Destroy.php
@@ -61,7 +61,7 @@ class Destroy extends BaseApi
 		// error if no id or parenturi specified (for clients posting parent-uri as well)
 		if ($verbose && $id == 0 && $parenturi == "") {
 			$answer = ['result' => 'error', 'message' => 'message id or parenturi not specified'];
-			$this->response->exit('direct_messages_delete', ['direct_messages_delete' => $answer], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('direct_messages_delete', ['direct_messages_delete' => $answer], $this->parameters['extension'] ?? null);
 			return;
 		}
 
@@ -72,7 +72,7 @@ class Destroy extends BaseApi
 		if (!$this->dba->exists('mail', ["`uid` = ? AND `id` = ? " . $sql_extra, $uid, $id])) {
 			if ($verbose) {
 				$answer = ['result' => 'error', 'message' => 'message id not in database'];
-				$this->response->exit('direct_messages_delete', ['direct_messages_delete' => $answer], $this->parameters['extension'] ?? null);
+				$this->response->addFormattedContent('direct_messages_delete', ['direct_messages_delete' => $answer], $this->parameters['extension'] ?? null);
 				return;
 			}
 			throw new BadRequestException('message id not in database');
@@ -85,10 +85,10 @@ class Destroy extends BaseApi
 			if ($result) {
 				// return success
 				$answer = ['result' => 'ok', 'message' => 'message deleted'];
-				$this->response->exit('direct_messages_delete', ['direct_messages_delete' => $answer], $this->parameters['extension'] ?? null);
+				$this->response->addFormattedContent('direct_messages_delete', ['direct_messages_delete' => $answer], $this->parameters['extension'] ?? null);
 			} else {
 				$answer = ['result' => 'error', 'message' => 'unknown error'];
-				$this->response->exit('direct_messages_delete', ['direct_messages_delete' => $answer], $this->parameters['extension'] ?? null);
+				$this->response->addFormattedContent('direct_messages_delete', ['direct_messages_delete' => $answer], $this->parameters['extension'] ?? null);
 			}
 		}
 	}

--- a/src/Module/Api/Twitter/DirectMessages/NewDM.php
+++ b/src/Module/Api/Twitter/DirectMessages/NewDM.php
@@ -91,6 +91,6 @@ class NewDM extends BaseApi
 			$ret = ['error' => $id];
 		}
 
-		$this->response->exit('direct-messages', ['direct_message' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('direct-messages', ['direct_message' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/DirectMessagesEndpoint.php
+++ b/src/Module/Api/Twitter/DirectMessagesEndpoint.php
@@ -99,7 +99,7 @@ abstract class DirectMessagesEndpoint extends BaseApi
 		$mails = $this->dba->selectToArray('mail', ['id'], $condition, $params);
 		if ($verbose && !DBA::isResult($mails)) {
 			$answer = ['result' => 'error', 'message' => 'no mails available'];
-			$this->response->exit('direct-messages', ['direct_message' => $answer], $this->parameters['extension'] ?? null);
+			$this->response->addFormattedContent('direct-messages', ['direct_message' => $answer], $this->parameters['extension'] ?? null);
 			return;
 		}
 
@@ -116,6 +116,6 @@ abstract class DirectMessagesEndpoint extends BaseApi
 
 		self::setLinkHeader();
 
-		$this->response->exit('direct-messages', ['direct_message' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('direct-messages', ['direct_message' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Favorites.php
+++ b/src/Module/Api/Twitter/Favorites.php
@@ -72,6 +72,6 @@ class Favorites extends BaseApi
 		}
 		DBA::close($statuses);
 
-		$this->response->exit('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Favorites/Create.php
+++ b/src/Module/Api/Twitter/Favorites/Create.php
@@ -52,6 +52,6 @@ class Create extends BaseApi
 
 		$status_info = DI::twitterStatus()->createFromUriId($id, $uid)->toArray();
 
-		$this->response->exit('status', ['status' => $status_info], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('status', ['status' => $status_info], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Favorites/Destroy.php
+++ b/src/Module/Api/Twitter/Favorites/Destroy.php
@@ -52,6 +52,6 @@ class Destroy extends BaseApi
 
 		$status_info = DI::twitterStatus()->createFromUriId($id, $uid)->toArray();
 
-		$this->response->exit('status', ['status' => $status_info], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('status', ['status' => $status_info], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Followers/Ids.php
+++ b/src/Module/Api/Twitter/Followers/Ids.php
@@ -114,6 +114,6 @@ class Ids extends ContactEndpoint
 
 		self::setLinkHeader();
 
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/Api/Twitter/Followers/Lists.php
+++ b/src/Module/Api/Twitter/Followers/Lists.php
@@ -114,6 +114,6 @@ class Lists extends ContactEndpoint
 
 		$this->response->setHeader(self::getLinkHeader());
 
-		$this->response->exit('lists', ['lists' => $return]);
+		$this->response->addFormattedContent('lists', ['lists' => $return]);
 	}
 }

--- a/src/Module/Api/Twitter/Friends/Ids.php
+++ b/src/Module/Api/Twitter/Friends/Ids.php
@@ -114,6 +114,6 @@ class Ids extends ContactEndpoint
 
 		self::setLinkHeader();
 
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/Api/Twitter/Friends/Lists.php
+++ b/src/Module/Api/Twitter/Friends/Lists.php
@@ -114,6 +114,6 @@ class Lists extends ContactEndpoint
 
 		$this->response->setHeader(self::getLinkHeader());
 
-		$this->response->exit('lists', ['lists' => $return]);
+		$this->response->addFormattedContent('lists', ['lists' => $return]);
 	}
 }

--- a/src/Module/Api/Twitter/Friendships/Destroy.php
+++ b/src/Module/Api/Twitter/Friendships/Destroy.php
@@ -87,6 +87,6 @@ class Destroy extends ContactEndpoint
 			throw new HTTPException\InternalServerErrorException('Unable to unfollow this contact, please contact your administrator');
 		}
 
-		$this->response->exit('friendships', ['user' => $user], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('friendships', ['user' => $user], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Friendships/Incoming.php
+++ b/src/Module/Api/Twitter/Friendships/Incoming.php
@@ -82,6 +82,6 @@ class Incoming extends ContactEndpoint
 
 		$this->response->setHeader(self::getLinkHeader());
 
-		$this->response->exit('incoming', ['incoming' => $return]);
+		$this->response->addFormattedContent('incoming', ['incoming' => $return]);
 	}
 }

--- a/src/Module/Api/Twitter/Friendships/Show.php
+++ b/src/Module/Api/Twitter/Friendships/Show.php
@@ -112,6 +112,6 @@ class Show extends ContactEndpoint
 			]
 		];
 
-		DI::apiResponse()->exit('relationship', ['relationship' => $relationship], $this->parameters['extension'] ?? null);
+		DI::apiResponse()->addFormattedContent('relationship', ['relationship' => $relationship], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Lists/Create.php
+++ b/src/Module/Api/Twitter/Lists/Create.php
@@ -80,6 +80,6 @@ class Create extends BaseApi
 
 		$grp = $this->friendicaCircle->createFromId($gid);
 
-		$this->response->exit('statuses', ['lists' => ['lists' => $grp]], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ['lists' => ['lists' => $grp]], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Lists/Destroy.php
+++ b/src/Module/Api/Twitter/Lists/Destroy.php
@@ -77,7 +77,7 @@ class Destroy extends BaseApi
 		$list = $this->friendicaCircle->createFromId($gid);
 
 		if (Circle::remove($gid)) {
-			$this->response->exit('statuses', ['lists' => ['lists' => $list]], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+			$this->response->addFormattedContent('statuses', ['lists' => ['lists' => $list]], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 		}
 	}
 }

--- a/src/Module/Api/Twitter/Lists/Lists.php
+++ b/src/Module/Api/Twitter/Lists/Lists.php
@@ -38,6 +38,6 @@ class Lists extends BaseApi
 
 		// This is a dummy endpoint
 		$ret = [];
-		$this->response->exit('statuses', ["lists_list" => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ["lists_list" => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Lists/Ownership.php
+++ b/src/Module/Api/Twitter/Lists/Ownership.php
@@ -64,6 +64,6 @@ class Ownership extends BaseApi
 			$lists[] = $this->friendicaCircle->createFromId($circle['id']);
 		}
 
-		$this->response->exit('statuses', ['lists' => ['lists' => $lists]], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ['lists' => ['lists' => $lists]], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Lists/Statuses.php
+++ b/src/Module/Api/Twitter/Lists/Statuses.php
@@ -103,6 +103,6 @@ class Statuses extends BaseApi
 		}
 		$this->dba->close($statuses);
 
-		$this->response->exit('statuses', ['status' => $items], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ['status' => $items], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Lists/Update.php
+++ b/src/Module/Api/Twitter/Lists/Update.php
@@ -78,7 +78,7 @@ class Update extends BaseApi
 		if (Circle::update($gid, $name)) {
 			$list = $this->friendicaCircle->createFromId($gid);
 
-			$this->response->exit('statuses', ['lists' => ['lists' => $list]], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+			$this->response->addFormattedContent('statuses', ['lists' => ['lists' => $list]], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 		}
 	}
 }

--- a/src/Module/Api/Twitter/Media/Upload.php
+++ b/src/Module/Api/Twitter/Media/Upload.php
@@ -65,6 +65,6 @@ class Upload extends BaseApi
 
 		Logger::info('Media uploaded', ['return' => $returndata]);
 
-		$this->response->exit('media', ['media' => $returndata], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('media', ['media' => $returndata], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/SavedSearches.php
+++ b/src/Module/Api/Twitter/SavedSearches.php
@@ -44,6 +44,6 @@ class SavedSearches extends BaseApi
 
 		DBA::close($terms);
 
-		$this->response->exit('terms', ['terms' => $result], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('terms', ['terms' => $result], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Search/Tweets.php
+++ b/src/Module/Api/Twitter/Search/Tweets.php
@@ -72,7 +72,7 @@ class Tweets extends BaseApi
 			DBA::close($tags);
 
 			if (empty($uriids)) {
-				$this->response->exit('statuses', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+				$this->response->addFormattedContent('statuses', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 				return;
 			}
 
@@ -116,6 +116,6 @@ class Tweets extends BaseApi
 		}
 		DBA::close($statuses);
 
-		$this->response->exit('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Statuses/Destroy.php
+++ b/src/Module/Api/Twitter/Statuses/Destroy.php
@@ -59,6 +59,6 @@ class Destroy extends BaseApi
 
 		Item::deleteForUser(['id' => $post['id']], $uid);
 
-		$this->response->exit('status', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('status', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Statuses/HomeTimeline.php
+++ b/src/Module/Api/Twitter/Statuses/HomeTimeline.php
@@ -87,6 +87,6 @@ class HomeTimeline extends BaseApi
 			}
 		}
 
-		$this->response->exit('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Statuses/Mentions.php
+++ b/src/Module/Api/Twitter/Statuses/Mentions.php
@@ -80,6 +80,6 @@ class Mentions extends BaseApi
 		}
 		DBA::close($statuses);
 
-		$this->response->exit('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Statuses/NetworkPublicTimeline.php
+++ b/src/Module/Api/Twitter/Statuses/NetworkPublicTimeline.php
@@ -63,6 +63,6 @@ class NetworkPublicTimeline extends BaseApi
 		}
 		DBA::close($statuses);
 
-		$this->response->exit('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Statuses/PublicTimeline.php
+++ b/src/Module/Api/Twitter/Statuses/PublicTimeline.php
@@ -85,6 +85,6 @@ class PublicTimeline extends BaseApi
 		}
 		DBA::close($statuses);
 
-		$this->response->exit('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Statuses/Retweet.php
+++ b/src/Module/Api/Twitter/Statuses/Retweet.php
@@ -69,6 +69,6 @@ class Retweet extends BaseApi
 
 		$status_info = DI::twitterStatus()->createFromItemId($item_id, $uid)->toArray();
 
-		DI::apiResponse()->exit('statuses', ['status' => $status_info], $this->parameters['extension'] ?? null);
+		DI::apiResponse()->addFormattedContent('statuses', ['status' => $status_info], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Statuses/Show.php
+++ b/src/Module/Api/Twitter/Statuses/Show.php
@@ -85,10 +85,10 @@ class Show extends BaseApi
 
 		if ($conversation) {
 			$data = ['status' => $ret];
-			$this->response->exit('statuses', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+			$this->response->addFormattedContent('statuses', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 		} else {
 			$data = ['status' => $ret[0]];
-			$this->response->exit('status', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+			$this->response->addFormattedContent('status', $data, $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 		}
 	}
 }

--- a/src/Module/Api/Twitter/Statuses/Update.php
+++ b/src/Module/Api/Twitter/Statuses/Update.php
@@ -121,7 +121,7 @@ class Update extends BaseApi
 			$item['gravity']     = Item::GRAVITY_COMMENT;
 			$item['object-type'] = Activity\ObjectType::COMMENT;
 		} else {
-			self::checkThrottleLimit();
+			$this->checkThrottleLimit();
 
 			$item['gravity']     = Item::GRAVITY_PARENT;
 			$item['object-type'] = Activity\ObjectType::NOTE;

--- a/src/Module/Api/Twitter/Statuses/Update.php
+++ b/src/Module/Api/Twitter/Statuses/Update.php
@@ -184,7 +184,7 @@ class Update extends BaseApi
 			if (!empty($item['uri-id'])) {
 				// output the post that we just posted.
 				$status_info = DI::twitterStatus()->createFromUriId($item['uri-id'], $uid, $request['include_entities'])->toArray();
-				DI::apiResponse()->exit('status', ['status' => $status_info], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+				DI::apiResponse()->addFormattedContent('status', ['status' => $status_info], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 				return;
 			}
 		}

--- a/src/Module/Api/Twitter/Statuses/UserTimeline.php
+++ b/src/Module/Api/Twitter/Statuses/UserTimeline.php
@@ -80,6 +80,6 @@ class UserTimeline extends BaseApi
 		}
 		DBA::close($statuses);
 
-		$this->response->exit('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
+		$this->response->addFormattedContent('statuses', ['status' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}
 }

--- a/src/Module/Api/Twitter/Users/Lookup.php
+++ b/src/Module/Api/Twitter/Users/Lookup.php
@@ -51,6 +51,6 @@ class Lookup extends BaseApi
 			throw new NotFoundException();
 		}
 
-		$this->response->exit('users', ['user' => $users], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('users', ['user' => $users], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Users/Search.php
+++ b/src/Module/Api/Twitter/Users/Search.php
@@ -69,6 +69,6 @@ class Search extends BaseApi
 			throw new BadRequestException('No search term specified.');
 		}
 
-		$this->response->exit('users', $userlist, $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('users', $userlist, $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/Api/Twitter/Users/Show.php
+++ b/src/Module/Api/Twitter/Users/Show.php
@@ -48,6 +48,6 @@ class Show extends BaseApi
 		// "uid" is only needed for some internal stuff, so remove it from here
 		unset($user_info['uid']);
 
-		$this->response->exit('user', ['user' => $user_info], $this->parameters['extension'] ?? null);
+		$this->response->addFormattedContent('user', ['user' => $user_info], $this->parameters['extension'] ?? null);
 	}
 }

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -434,7 +434,7 @@ class BaseApi extends BaseModule
 		}
 	}
 
-	public static function checkThrottleLimit()
+	public function checkThrottleLimit()
 	{
 		$uid = self::getCurrentUserID();
 
@@ -447,11 +447,11 @@ class BaseApi extends BaseModule
 			$posts_day = Post::countThread($condition);
 
 			if ($posts_day > $throttle_day) {
-				Logger::notice('Daily posting limit reached', ['uid' => $uid, 'posts' => $posts_day, 'limit' => $throttle_day]);
-				$error = DI::l10n()->t('Too Many Requests');
-				$error_description = DI::l10n()->tt("Daily posting limit of %d post reached. The post was rejected.", "Daily posting limit of %d posts reached. The post was rejected.", $throttle_day);
+				$this->logger->notice('Daily posting limit reached', ['uid' => $uid, 'posts' => $posts_day, 'limit' => $throttle_day]);
+				$error = $this->t('Too Many Requests');
+				$error_description = $this->tt("Daily posting limit of %d post reached. The post was rejected.", "Daily posting limit of %d posts reached. The post was rejected.", $throttle_day);
 				$errorobj = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
-				System::jsonError(429, $errorobj->toArray());
+				$this->jsonError(429, $errorobj->toArray());
 			}
 		}
 
@@ -464,10 +464,10 @@ class BaseApi extends BaseModule
 
 			if ($posts_week > $throttle_week) {
 				Logger::notice('Weekly posting limit reached', ['uid' => $uid, 'posts' => $posts_week, 'limit' => $throttle_week]);
-				$error = DI::l10n()->t('Too Many Requests');
-				$error_description = DI::l10n()->tt("Weekly posting limit of %d post reached. The post was rejected.", "Weekly posting limit of %d posts reached. The post was rejected.", $throttle_week);
+				$error = $this->t('Too Many Requests');
+				$error_description = $this->tt("Weekly posting limit of %d post reached. The post was rejected.", "Weekly posting limit of %d posts reached. The post was rejected.", $throttle_week);
 				$errorobj = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
-				System::jsonError(429, $errorobj->toArray());
+				$this->jsonError(429, $errorobj->toArray());
 			}
 		}
 
@@ -480,10 +480,10 @@ class BaseApi extends BaseModule
 
 			if ($posts_month > $throttle_month) {
 				Logger::notice('Monthly posting limit reached', ['uid' => $uid, 'posts' => $posts_month, 'limit' => $throttle_month]);
-				$error = DI::l10n()->t('Too Many Requests');
-				$error_description = DI::l10n()->tt('Monthly posting limit of %d post reached. The post was rejected.', 'Monthly posting limit of %d posts reached. The post was rejected.', $throttle_month);
+				$error = $this->t('Too Many Requests');
+				$error_description = $this->tt('Monthly posting limit of %d post reached. The post was rejected.', 'Monthly posting limit of %d posts reached. The post was rejected.', $throttle_month);
 				$errorobj = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
-				System::jsonError(429, $errorobj->toArray());
+				$this->jsonError(429, $errorobj->toArray());
 			}
 		}
 	}

--- a/src/Module/BaseNotifications.php
+++ b/src/Module/BaseNotifications.php
@@ -121,7 +121,7 @@ abstract class BaseNotifications extends BaseModule
 			'page'          => $pager->getPage(),
 		];
 
-		System::jsonExit($notifications);
+		$this->jsonExit($notifications);
 	}
 
 	/**

--- a/src/Module/Calendar/Event/API.php
+++ b/src/Module/Calendar/Event/API.php
@@ -183,7 +183,7 @@ class API extends BaseModule
 
 		if (strcmp($finish, $start) < 0 && !$noFinish) {
 			if ($isPreview) {
-				System::httpExit($this->t('Event can not end before it has started.'));
+				$this->httpExit($this->t('Event can not end before it has started.'));
 			} else {
 				$this->sysMessages->addNotice($this->t('Event can not end before it has started.'));
 				$this->baseUrl->redirect($redirectOnError);
@@ -192,7 +192,7 @@ class API extends BaseModule
 
 		if (empty($summary) || ($start === DBA::NULL_DATETIME)) {
 			if ($isPreview) {
-				System::httpExit($this->t('Event title and start time are required.'));
+				$this->httpExit($this->t('Event title and start time are required.'));
 			} else {
 				$this->sysMessages->addNotice($this->t('Event title and start time are required.'));
 				$this->baseUrl->redirect($redirectOnError);
@@ -251,7 +251,7 @@ class API extends BaseModule
 		];
 
 		if (intval($request['preview'])) {
-			System::httpExit(Event::getHTML($datarray));
+			$this->httpExit(Event::getHTML($datarray));
 		}
 
 		$eventId = Event::store($datarray);

--- a/src/Module/Calendar/Event/Get.php
+++ b/src/Module/Calendar/Event/Get.php
@@ -69,7 +69,7 @@ class Get extends \Friendica\BaseModule
 			$events = Event::getListByDate($owner['uid'], $request['start'] ?? '', $request['end'] ?? '');
 		}
 
-		System::jsonExit($events ? self::map($events) : []);
+		$this->jsonExit($events ? self::map($events) : []);
 	}
 
 	private static function map(array $events): array

--- a/src/Module/Calendar/Event/Show.php
+++ b/src/Module/Calendar/Event/Show.php
@@ -81,6 +81,6 @@ class Show extends BaseModule
 			'$event' => $tplEvent,
 		]);
 
-		System::httpExit($o);
+		$this->httpExit($o);
 	}
 }

--- a/src/Module/Circle.php
+++ b/src/Module/Circle.php
@@ -135,7 +135,7 @@ class Circle extends BaseModule
 			$this->jsonExit(['status' => 'OK', 'message' => $message]);
 		} catch (\Exception $e) {
 			DI::sysmsg()->addNotice($e->getMessage());
-			System::jsonError($e->getCode(), ['status' => 'error', 'message' => $e->getMessage()]);
+			$this->jsonError($e->getCode(), ['status' => 'error', 'message' => $e->getMessage()]);
 		}
 	}
 

--- a/src/Module/Circle.php
+++ b/src/Module/Circle.php
@@ -132,7 +132,7 @@ class Circle extends BaseModule
 			}
 
 			DI::sysmsg()->addInfo($message);
-			System::jsonExit(['status' => 'OK', 'message' => $message]);
+			$this->jsonExit(['status' => 'OK', 'message' => $message]);
 		} catch (\Exception $e) {
 			DI::sysmsg()->addNotice($e->getMessage());
 			System::jsonError($e->getCode(), ['status' => 'error', 'message' => $e->getMessage()]);

--- a/src/Module/Contact/Hovercard.php
+++ b/src/Module/Contact/Hovercard.php
@@ -115,6 +115,6 @@ class Hovercard extends BaseModule
 			],
 		]);
 
-		System::httpExit($o);
+		$this->httpExit($o);
 	}
 }

--- a/src/Module/DFRN/Poll.php
+++ b/src/Module/DFRN/Poll.php
@@ -48,6 +48,6 @@ class Poll extends BaseModule
 		}
 
 		$last_update = $request['last_update'] ?? '';
-		System::httpExit(OStatus::feed($owner['nickname'], $last_update, 10) ?? '', Response::TYPE_ATOM);
+		$this->httpExit(OStatus::feed($owner['nickname'], $last_update, 10) ?? '', Response::TYPE_ATOM);
 	}
 }

--- a/src/Module/Diaspora/Fetch.php
+++ b/src/Module/Diaspora/Fetch.php
@@ -85,6 +85,6 @@ class Fetch extends BaseModule
 		$xml = Diaspora::buildPostXml($status["type"], $status["message"]);
 
 		// Send the envelope
-		System::httpExit(Diaspora::buildMagicEnvelope($xml, $user), Response::TYPE_XML, 'application/magic-envelope+xml');
+		$this->httpExit(Diaspora::buildMagicEnvelope($xml, $user), Response::TYPE_XML, 'application/magic-envelope+xml');
 	}
 }

--- a/src/Module/Feed.php
+++ b/src/Module/Feed.php
@@ -71,6 +71,6 @@ class Feed extends BaseModule
 
 		$feed = ProtocolFeed::atom($owner, $last_update, 10, $type);
 
-		System::httpExit($feed, Response::TYPE_ATOM);
+		$this->httpExit($feed, Response::TYPE_ATOM);
 	}
 }

--- a/src/Module/Filer/RemoveTag.php
+++ b/src/Module/Filer/RemoveTag.php
@@ -54,7 +54,7 @@ class RemoveTag extends BaseModule
 
 	protected function post(array $request = [])
 	{
-		System::httpError($this->removeTag($request));
+		$this->httpError($this->removeTag($request));
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -144,7 +144,7 @@ class Friendica extends BaseModule
 				header('Cache-Control: max-age=23200, stale-while-revalidate=23200');
 				$this->jsonExit($data, 'application/activity+json');
 			} catch (HTTPException\NotFoundException $e) {
-				System::jsonError(404, ['error' => 'Record not found']);
+				$this->jsonError(404, ['error' => 'Record not found']);
 			}
 		}
 

--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -142,7 +142,7 @@ class Friendica extends BaseModule
 				$data = ActivityPub\Transmitter::getProfile(0);
 				header('Access-Control-Allow-Origin: *');
 				header('Cache-Control: max-age=23200, stale-while-revalidate=23200');
-				System::jsonExit($data, 'application/activity+json');
+				$this->jsonExit($data, 'application/activity+json');
 			} catch (HTTPException\NotFoundException $e) {
 				System::jsonError(404, ['error' => 'Record not found']);
 			}
@@ -200,6 +200,6 @@ class Friendica extends BaseModule
 			'no_scrape_url'    => $this->baseUrl . '/noscrape',
 		];
 
-		System::jsonExit($data);
+		$this->jsonExit($data);
 	}
 }

--- a/src/Module/Hashtag.php
+++ b/src/Module/Hashtag.php
@@ -36,7 +36,7 @@ class Hashtag extends BaseModule
 		$result = [];
 
 		if (empty($request['t'])) {
-			System::jsonExit($result);
+			$this->jsonExit($result);
 		}
 
 		$taglist = DBA::select(
@@ -50,6 +50,6 @@ class Hashtag extends BaseModule
 		}
 		DBA::close($taglist);
 
-		System::jsonExit($result);
+		$this->jsonExit($result);
 	}
 }

--- a/src/Module/Item/Activity.php
+++ b/src/Module/Item/Activity.php
@@ -89,6 +89,6 @@ class Activity extends BaseModule
 			'state' => 1,
 		];
 
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/Item/Feed.php
+++ b/src/Module/Item/Feed.php
@@ -86,6 +86,6 @@ class Feed extends BaseModule
 			throw new HTTPException\InternalServerErrorException($this->t('The feed for this item is unavailable.', ['uri-id' => $uriId]));
 		}
 
-		System::httpExit($xml, Response::TYPE_ATOM);
+		$this->httpExit($xml, Response::TYPE_ATOM);
 	}
 }

--- a/src/Module/Item/Follow.php
+++ b/src/Module/Item/Follow.php
@@ -71,6 +71,6 @@ class Follow extends BaseModule
 			'state' => 1
 		];
 
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/Item/Ignore.php
+++ b/src/Module/Item/Ignore.php
@@ -82,6 +82,6 @@ class Ignore extends BaseModule
 			'state'   => $ignored,
 		];
 
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/Item/Pin.php
+++ b/src/Module/Item/Pin.php
@@ -84,6 +84,6 @@ class Pin extends BaseModule
 			'state'   => (int)$pinned,
 		];
 
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/Item/Star.php
+++ b/src/Module/Item/Star.php
@@ -91,6 +91,6 @@ class Star extends BaseModule
 			'state'   => (int)$starred,
 		];
 
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/Manifest.php
+++ b/src/Module/Manifest.php
@@ -133,6 +133,6 @@ class Manifest extends BaseModule
 			$manifest['theme_color'] = $theme_color;
 		}
 
-		Core\System::jsonExit($manifest, 'application/manifest+json');
+		$this->jsonExit($manifest, 'application/manifest+json');
 	}
 }

--- a/src/Module/Media/Attachment/Browser.php
+++ b/src/Module/Media/Attachment/Browser.php
@@ -80,7 +80,7 @@ class Browser extends BaseModule
 		]);
 
 		if (empty($request['mode'])) {
-			System::httpExit($output);
+			$this->httpExit($output);
 		}
 
 		return $output;

--- a/src/Module/Media/Attachment/Upload.php
+++ b/src/Module/Media/Attachment/Upload.php
@@ -150,7 +150,7 @@ class Upload extends \Friendica\BaseModule
 			$this->response->addContent($message);
 		}
 
-		$this->page->exit($this->response->generate());
+		System::echoResponse($this->response->generate());
 		System::exit();
 	}
 }

--- a/src/Module/Media/Photo/Browser.php
+++ b/src/Module/Media/Photo/Browser.php
@@ -91,7 +91,7 @@ class Browser extends BaseModule
 		]);
 
 		if (empty($request['mode'])) {
-			System::httpExit($output);
+			$this->httpExit($output);
 		}
 
 		return $output;

--- a/src/Module/Media/Photo/Upload.php
+++ b/src/Module/Media/Photo/Upload.php
@@ -207,7 +207,7 @@ class Upload extends \Friendica\BaseModule
 			$this->response->addContent($message);
 		}
 
-		$this->page->exit($this->response->generate());
+		System::echoResponse($this->response->generate());
 		System::exit();
 	}
 }

--- a/src/Module/NoScrape.php
+++ b/src/Module/NoScrape.php
@@ -71,7 +71,7 @@ class NoScrape extends BaseModule
 
 		if (!$owner['net-publish']) {
 			$json_info['hide'] = true;
-			System::jsonExit($json_info);
+			$this->jsonExit($json_info);
 		}
 
 		$keywords = $owner['pub_keywords'] ?? '';
@@ -107,6 +107,6 @@ class NoScrape extends BaseModule
 			}
 		}
 
-		System::jsonExit($json_info);
+		$this->jsonExit($json_info);
 	}
 }

--- a/src/Module/NoScrape.php
+++ b/src/Module/NoScrape.php
@@ -45,13 +45,13 @@ class NoScrape extends BaseModule
 			// view infos about a known profile (needs a login)
 			$which = $a->getLoggedInUserNickname();
 		} else {
-			System::jsonError(403, 'Authentication required');
+			$this->jsonError(403, 'Authentication required');
 		}
 
 		$owner = User::getOwnerDataByNick($which);
 
 		if (empty($owner['uid'])) {
-			System::jsonError(404, 'Profile not found');
+			$this->jsonError(404, 'Profile not found');
 		}
 
 		$json_info = [

--- a/src/Module/Notifications/Notification.php
+++ b/src/Module/Notifications/Notification.php
@@ -116,7 +116,7 @@ class Notification extends BaseModule
 				$success = false;
 			}
 
-			System::jsonExit(['result' => (($success) ? 'success' : 'fail')]);
+			$this->jsonExit(['result' => (($success) ? 'success' : 'fail')]);
 		}
 	}
 

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -303,7 +303,7 @@ class Ping extends BaseModule
 
 		if (isset($_GET['callback'])) {
 			// JSONP support
-			System::httpExit($_GET['callback'] . '(' . json_encode(['result' => $data]) . ')', Response::TYPE_BLANK, 'application/javascript');
+			$this->httpExit($_GET['callback'] . '(' . json_encode(['result' => $data]) . ')', Response::TYPE_BLANK, 'application/javascript');
 		} else {
 			System::jsonExit(['result' => $data]);
 		}

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -305,7 +305,7 @@ class Ping extends BaseModule
 			// JSONP support
 			$this->httpExit($_GET['callback'] . '(' . json_encode(['result' => $data]) . ')', Response::TYPE_BLANK, 'application/javascript');
 		} else {
-			System::jsonExit(['result' => $data]);
+			$this->jsonExit(['result' => $data]);
 		}
 	}
 }

--- a/src/Module/OAuth/Revoke.php
+++ b/src/Module/OAuth/Revoke.php
@@ -55,6 +55,6 @@ class Revoke extends BaseApi
 		}
 
 		DBA::delete('application-token', ['application-id' => $token['id']]);
-		System::jsonExit([]);
+		$this->jsonExit([]);
 	}
 }

--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -110,6 +110,6 @@ class Token extends BaseApi
 
 		$object = new \Friendica\Object\Api\Mastodon\Token($token['access_token'], 'Bearer', $application['scopes'], $token['created_at'], $me);
 
-		System::jsonExit($object->toArray());
+		$this->jsonExit($object->toArray());
 	}
 }

--- a/src/Module/OStatus/PubSub.php
+++ b/src/Module/OStatus/PubSub.php
@@ -155,6 +155,6 @@ class PubSub extends \Friendica\BaseModule
 			$this->logger->notice('Success for contact.', ['mode' => $hub_mode, 'contact' => $contact_id]);
 		}
 
-		System::httpExit($hub_challenge);
+		$this->httpExit($hub_challenge);
 	}
 }

--- a/src/Module/OpenSearch.php
+++ b/src/Module/OpenSearch.php
@@ -85,6 +85,6 @@ class OpenSearch extends BaseModule
 			'template' => "$baseUrl/opensearch",
 		]);
 
-		System::httpExit($xml->saveXML(), Response::TYPE_XML, 'application/opensearchdescription+xml');
+		$this->httpExit($xml->saveXML(), Response::TYPE_XML, 'application/opensearchdescription+xml');
 	}
 }

--- a/src/Module/Owa.php
+++ b/src/Module/Owa.php
@@ -101,6 +101,6 @@ class Owa extends BaseModule
 				}
 			}
 		}
-		System::jsonExit($ret, 'application/x-zot+json');
+		$this->jsonExit($ret, 'application/x-zot+json');
 	}
 }

--- a/src/Module/ParseUrl.php
+++ b/src/Module/ParseUrl.php
@@ -102,7 +102,7 @@ class ParseUrl extends BaseModule
 			if ($format == 'json') {
 				System::jsonExit($arr['text']);
 			} else {
-				System::httpExit($arr['text']);
+				$this->httpExit($arr['text']);
 			}
 		}
 
@@ -135,7 +135,7 @@ class ParseUrl extends BaseModule
 
 			System::jsonExit($ret);
 		} else {
-			System::httpExit(BBCode::embedURL($url, empty($_GET['noAttachment']), $title, $description, $_GET['tags'] ?? ''));
+			$this->httpExit(BBCode::embedURL($url, empty($_GET['noAttachment']), $title, $description, $_GET['tags'] ?? ''));
 		}
 	}
 }

--- a/src/Module/ParseUrl.php
+++ b/src/Module/ParseUrl.php
@@ -100,7 +100,7 @@ class ParseUrl extends BaseModule
 
 		if ($arr['text']) {
 			if ($format == 'json') {
-				System::jsonExit($arr['text']);
+				$this->jsonExit($arr['text']);
 			} else {
 				$this->httpExit($arr['text']);
 			}
@@ -133,7 +133,7 @@ class ParseUrl extends BaseModule
 				$ret['success'] = true;
 			}
 
-			System::jsonExit($ret);
+			$this->jsonExit($ret);
 		} else {
 			$this->httpExit(BBCode::embedURL($url, empty($_GET['noAttachment']), $title, $description, $_GET['tags'] ?? ''));
 		}

--- a/src/Module/PermissionTooltip.php
+++ b/src/Module/PermissionTooltip.php
@@ -166,9 +166,9 @@ class PermissionTooltip extends \Friendica\BaseModule
 		}
 
 		if (!empty($l)) {
-			System::httpExit($o . implode(', ', $l));
+			$this->httpExit($o . implode(', ', $l));
 		} else {
-			System::httpExit($o . $receivers);;
+			$this->httpExit($o . $receivers);;
 		}
 	}
 

--- a/src/Module/Post/Share.php
+++ b/src/Module/Post/Share.php
@@ -57,12 +57,12 @@ class Share extends \Friendica\BaseModule
 	{
 		$post_id = $this->parameters['post_id'];
 		if (!$post_id || !$this->session->getLocalUserId()) {
-			System::httpError(403);
+			$this->httpError(403);
 		}
 
 		$item = Post::selectFirst(['private', 'body', 'uri', 'plink', 'network'], ['id' => $post_id]);
 		if (!$item || $item['private'] == Item::PRIVATE) {
-			System::httpError(404);
+			$this->httpError(404);
 		}
 
 		$shared = $this->contentItem->getSharedPost($item, ['uri']);

--- a/src/Module/Post/Share.php
+++ b/src/Module/Post/Share.php
@@ -74,6 +74,6 @@ class Share extends \Friendica\BaseModule
 			$content = '[share]' . $item['uri'] . '[/share]';
 		}
 
-		System::httpExit($content);
+		$this->httpExit($content);
 	}
 }

--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -89,7 +89,7 @@ class Profile extends BaseProfile
 					header('Cache-Control: max-age=23200, stale-while-revalidate=23200');
 					$this->jsonExit($data, 'application/activity+json');
 				} catch (HTTPException\NotFoundException $e) {
-					System::jsonError(404, ['error' => 'Record not found']);
+					$this->jsonError(404, ['error' => 'Record not found']);
 				}
 			}
 
@@ -97,10 +97,10 @@ class Profile extends BaseProfile
 				// Known deleted user
 				$data = ActivityPub\Transmitter::getDeletedUser($this->parameters['nickname']);
 
-				System::jsonError(410, $data);
+				$this->jsonError(410, $data);
 			} else {
 				// Any other case (unknown, blocked, nverified, expired, no profile, no self contact)
-				System::jsonError(404, []);
+				$this->jsonError(404, []);
 			}
 		}
 	}

--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -87,7 +87,7 @@ class Profile extends BaseProfile
 					$data = ActivityPub\Transmitter::getProfile($user['uid'], ActivityPub::isAcceptedRequester($user['uid']));
 					header('Access-Control-Allow-Origin: *');
 					header('Cache-Control: max-age=23200, stale-while-revalidate=23200');
-					System::jsonExit($data, 'application/activity+json');
+					$this->jsonExit($data, 'application/activity+json');
 				} catch (HTTPException\NotFoundException $e) {
 					System::jsonError(404, ['error' => 'Record not found']);
 				}

--- a/src/Module/PublicRSAKey.php
+++ b/src/Module/PublicRSAKey.php
@@ -45,7 +45,7 @@ class PublicRSAKey extends BaseModule
 			throw new BadRequestException();
 		}
 
-		System::httpExit(
+		$this->httpExit(
 			Salmon::salmonKey($user['spubkey']),
 			Response::TYPE_BLANK,
 			'application/magic-public-key'

--- a/src/Module/ReallySimpleDiscovery.php
+++ b/src/Module/ReallySimpleDiscovery.php
@@ -67,6 +67,6 @@ class ReallySimpleDiscovery extends BaseModule
 				],
 			],
 		]);
-		System::httpExit($content, Response::TYPE_XML);
+		$this->httpExit($content, Response::TYPE_XML);
 	}
 }

--- a/src/Module/Response.php
+++ b/src/Module/Response.php
@@ -89,7 +89,7 @@ class Response implements ICanCreateResponses
 	/**
 	 * {@inheritDoc}
 	 */
-	public function setType(string $type, ?string $content_type = null): void
+	public function setType(string $type = Response::TYPE_HTML, ?string $content_type = null): void
 	{
 		if (!in_array($type, static::ALLOWED_TYPES)) {
 			throw new InternalServerErrorException('wrong type');

--- a/src/Module/Search/Acl.php
+++ b/src/Module/Search/Acl.php
@@ -80,7 +80,7 @@ class Acl extends BaseModule
 			$o = $this->regularContactSearch($request, $type);
 		}
 
-		System::jsonExit($o);
+		$this->jsonExit($o);
 	}
 
 	private function globalContactSearch(array $request): array

--- a/src/Module/Search/Tags.php
+++ b/src/Module/Search/Tags.php
@@ -59,7 +59,7 @@ class Tags extends BaseModule
 		$results = [];
 
 		if (empty($tags)) {
-			System::jsonExit([
+			$this->jsonExit([
 				'total'      => 0,
 				'items_page' => $perPage,
 				'page'       => $page,
@@ -74,7 +74,7 @@ class Tags extends BaseModule
 
 		$totalCount = $this->database->count('owner-view', $condition);
 		if ($totalCount === 0) {
-			System::jsonExit([
+			$this->jsonExit([
 				'total'      => 0,
 				'items_page' => $perPage,
 				'page'       => $page,
@@ -97,7 +97,7 @@ class Tags extends BaseModule
 
 		$this->database->close($searchStmt);
 
-		System::jsonExit([
+		$this->jsonExit([
 			'total'      => $totalCount,
 			'items_page' => $perPage,
 			'page'       => $page,

--- a/src/Module/Smilies.php
+++ b/src/Module/Smilies.php
@@ -41,7 +41,7 @@ class Smilies extends BaseModule
 			for ($i = 0; $i < count($smilies['texts']); $i++) {
 				$results[] = ['text' => $smilies['texts'][$i], 'icon' => $smilies['icons'][$i]];
 			}
-			System::jsonExit($results);
+			$this->jsonExit($results);
 		}
 	}
 

--- a/src/Module/Special/HTTPException.php
+++ b/src/Module/Special/HTTPException.php
@@ -21,12 +21,12 @@
 
 namespace Friendica\Module\Special;
 
-use Friendica\App\Arguments;
-use Friendica\App\Request;
+use Friendica\App;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session\Model\UserSession;
 use Friendica\Core\System;
+use Friendica\Module\Response;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -40,7 +40,7 @@ class HTTPException
 	protected $l10n;
 	/** @var LoggerInterface */
 	protected $logger;
-	/** @var Arguments */
+	/** @var App\Arguments */
 	protected $args;
 	/** @var bool */
 	protected $isSiteAdmin;
@@ -49,7 +49,7 @@ class HTTPException
 	/** @var string */
 	protected $requestId;
 
-	public function __construct(L10n $l10n, LoggerInterface $logger, Arguments $args, UserSession $session, Request $request, array $server = [])
+	public function __construct(L10n $l10n, LoggerInterface $logger, App\Arguments $args, UserSession $session, App\Request $request, array $server = [])
 	{
 		$this->logger      = $logger;
 		$this->l10n        = $l10n;
@@ -113,7 +113,13 @@ class HTTPException
 			}
 		}
 
-		System::httpError($e->getCode(), $e->getDescription(), $content);
+		// We can't use a constructor parameter for this response object because we
+		// are in an Exception context where we don't want an existing Response.
+		$response = new Response();
+		$response->setStatus($e->getCode(), $e->getDescription());
+		$response->addContent($content);
+		System::echoResponse($response->generate());
+		System::exit();
 	}
 
 	/**

--- a/src/Module/Statistics.php
+++ b/src/Module/Statistics.php
@@ -83,6 +83,6 @@ class Statistics extends BaseModule
 		], $services);
 
 		$this->logger->debug("statistics.", ['statistics' => $statistics]);
-		System::jsonExit($statistics);
+		$this->jsonExit($statistics);
 	}
 }

--- a/src/Module/ThemeDetails.php
+++ b/src/Module/ThemeDetails.php
@@ -41,7 +41,7 @@ class ThemeDetails extends BaseModule
 			$version     = $info['version']     ?? '';
 			$credits     = $info['credits']     ?? '';
 
-			System::jsonExit([
+			$this->jsonExit([
 				'img'     => Theme::getScreenshot($theme),
 				'desc'    => $description,
 				'version' => $version,

--- a/src/Module/User/PortableContacts.php
+++ b/src/Module/User/PortableContacts.php
@@ -268,6 +268,6 @@ class PortableContacts extends BaseModule
 
 		$this->logger->info('End of poco');
 
-		System::jsonExit($return);
+		$this->jsonExit($return);
 	}
 }

--- a/src/Module/WellKnown/HostMeta.php
+++ b/src/Module/WellKnown/HostMeta.php
@@ -90,6 +90,6 @@ class HostMeta extends BaseModule
 			],
 		], $xml, false, ['hm' => 'http://host-meta.net/xrd/1.0', 'mk' => 'http://salmon-protocol.org/ns/magic-key']);
 
-		System::httpExit($xml->saveXML(), Response::TYPE_XML, 'application/xrd+xml');
+		$this->httpExit($xml->saveXML(), Response::TYPE_XML, 'application/xrd+xml');
 	}
 }

--- a/src/Module/WellKnown/NodeInfo.php
+++ b/src/Module/WellKnown/NodeInfo.php
@@ -33,25 +33,15 @@ class NodeInfo extends BaseModule
 {
 	protected function rawContent(array $request = [])
 	{
-		self::printWellKnown();
-	}
-
-	/**
-	 * Prints the well-known nodeinfo redirect
-	 *
-	 * @throws \Friendica\Network\HTTPException\NotFoundException
-	 */
-	private static function printWellKnown()
-	{
 		$nodeinfo = [
 			'links' => [
 				['rel'  => 'http://nodeinfo.diaspora.software/ns/schema/1.0',
-				'href' => DI::baseUrl() . '/nodeinfo/1.0'],
+				 'href' => DI::baseUrl() . '/nodeinfo/1.0'],
 				['rel'  => 'http://nodeinfo.diaspora.software/ns/schema/2.0',
-				'href' => DI::baseUrl() . '/nodeinfo/2.0'],
+				 'href' => DI::baseUrl() . '/nodeinfo/2.0'],
 			]
 		];
 
-		System::jsonExit($nodeinfo);
+		$this->jsonExit($nodeinfo);
 	}
 }

--- a/src/Module/WellKnown/XSocialRelay.php
+++ b/src/Module/WellKnown/XSocialRelay.php
@@ -77,6 +77,6 @@ class XSocialRelay extends BaseModule
 			$relay['protocols']['diaspora'] = ['receive' => DI::baseUrl() . '/receive/public'];
 		}
 
-		System::jsonExit($relay);
+		$this->jsonExit($relay);
 	}
 }

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -330,6 +330,6 @@ class Xrd extends BaseModule
 		]);
 
 		header('Access-Control-Allow-Origin: *');
-		System::httpExit($xmlString, Response::TYPE_XML, 'application/xrd+xml');
+		$this->httpExit($xmlString, Response::TYPE_XML, 'application/xrd+xml');
 	}
 }

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -156,7 +156,7 @@ class Xrd extends BaseModule
 			]
 		];
 		header('Access-Control-Allow-Origin: *');
-		System::jsonExit($json, 'application/jrd+json; charset=utf-8');
+		$this->jsonExit($json, 'application/jrd+json; charset=utf-8');
 	}
 
 	private function printJSON(string $alias, array $owner, array $avatar)
@@ -233,7 +233,7 @@ class Xrd extends BaseModule
 		];
 
 		header('Access-Control-Allow-Origin: *');
-		System::jsonExit($json, 'application/jrd+json; charset=utf-8');
+		$this->jsonExit($json, 'application/jrd+json; charset=utf-8');
 	}
 
 	private function printXML(string $alias, array $owner, array $avatar)

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -330,4 +330,10 @@ return [
 			$_SERVER
 		],
 	],
+	\Friendica\Module\Api\ApiResponse::class => [
+		'constructParams' => [
+			$_SERVER,
+			$_GET['callback'] ?? '',
+		],
+	],
 ];

--- a/tests/src/Module/Api/ApiResponseTest.php
+++ b/tests/src/Module/Api/ApiResponseTest.php
@@ -285,7 +285,7 @@ class ApiResponseTest extends MockedTest
 		$twitterUser = \Mockery::mock(User::class);
 
 		$response = new ApiResponse($l10n, $args, new NullLogger(), $baseUrl, $twitterUser);
-		$response->exitWithJson(['some_data']);
+		$response->addJsonContent(['some_data']);
 
 		self::assertEquals('["some_data"]', $response->getContent());
 	}
@@ -302,7 +302,7 @@ class ApiResponseTest extends MockedTest
 		$twitterUser = \Mockery::mock(User::class);
 
 		$response = new ApiResponse($l10n, $args, new NullLogger(), $baseUrl, $twitterUser, [], 'JsonPCallback');
-		$response->exitWithJson(['some_data']);
+		$response->addJsonContent(['some_data']);
 
 		self::assertEquals('JsonPCallback(["some_data"])', $response->getContent());
 	}

--- a/tests/src/Module/Api/ApiResponseTest.php
+++ b/tests/src/Module/Api/ApiResponseTest.php
@@ -127,7 +127,30 @@ class ApiResponseTest extends MockedTest
 		$baseUrl     = \Mockery::mock(BaseURL::class);
 		$twitterUser = \Mockery::mock(User::class);
 
-		$response = new ApiResponse($l10n, $args, new NullLogger(), $baseUrl, $twitterUser);
+		$logger = \Mockery::mock(NullLogger::class);
+		$logger->shouldReceive('info')->withArgs(['Unimplemented API call', ['method' => 'all', 'path' => '', 'agent' => '', 'request' => []]]);
+
+		$response = new ApiResponse($l10n, $args, $logger, $baseUrl, $twitterUser);
+		$response->unsupported();
+
+		self::assertEquals('{"error":"API endpoint %s %s is not implemented but might be in the future.","code":"501 Not Implemented","request":""}', $response->getContent());
+	}
+
+	public function testUnsupportedUserAgent()
+	{
+		$l10n = \Mockery::mock(L10n::class);
+		$l10n->shouldReceive('t')->andReturnUsing(function ($args) {
+			return $args;
+		});
+		$args = \Mockery::mock(Arguments::class);
+		$args->shouldReceive('getQueryString')->andReturn('');
+		$baseUrl     = \Mockery::mock(BaseURL::class);
+		$twitterUser = \Mockery::mock(User::class);
+
+		$logger = \Mockery::mock(NullLogger::class);
+		$logger->shouldReceive('info')->withArgs(['Unimplemented API call', ['method' => 'all', 'path' => '', 'agent' => 'PHPUnit', 'request' => []]]);
+
+		$response = new ApiResponse($l10n, $args, $logger, $baseUrl, $twitterUser, ['HTTP_USER_AGENT' => 'PHPUnit']);
 		$response->unsupported();
 
 		self::assertEquals('{"error":"API endpoint %s %s is not implemented but might be in the future.","code":"501 Not Implemented","request":""}', $response->getContent());
@@ -248,6 +271,40 @@ class ApiResponseTest extends MockedTest
 
 		$data = ['some_data'];
 		self::assertEquals($data, $response->formatData('root_element', 'json', $data));
+	}
+
+	public function testApiExitWithJson()
+	{
+		$l10n = \Mockery::mock(L10n::class);
+		$l10n->shouldReceive('t')->andReturnUsing(function ($args) {
+			return $args;
+		});
+		$args = \Mockery::mock(Arguments::class);
+		$args->shouldReceive('getQueryString')->andReturn('');
+		$baseUrl     = \Mockery::mock(BaseURL::class);
+		$twitterUser = \Mockery::mock(User::class);
+
+		$response = new ApiResponse($l10n, $args, new NullLogger(), $baseUrl, $twitterUser);
+		$response->exitWithJson(['some_data']);
+
+		self::assertEquals('["some_data"]', $response->getContent());
+	}
+
+	public function testApiExitWithJsonP()
+	{
+		$l10n = \Mockery::mock(L10n::class);
+		$l10n->shouldReceive('t')->andReturnUsing(function ($args) {
+			return $args;
+		});
+		$args = \Mockery::mock(Arguments::class);
+		$args->shouldReceive('getQueryString')->andReturn('');
+		$baseUrl     = \Mockery::mock(BaseURL::class);
+		$twitterUser = \Mockery::mock(User::class);
+
+		$response = new ApiResponse($l10n, $args, new NullLogger(), $baseUrl, $twitterUser, [], 'JsonPCallback');
+		$response->exitWithJson(['some_data']);
+
+		self::assertEquals('JsonPCallback(["some_data"])', $response->getContent());
 	}
 
 	/**


### PR DESCRIPTION
In `BaseModule->run` we set some HTTP headers depending on the incoming request. However, these headers are set on the module's `Module\Response` object, which isn't the same object as is used when using the exit-like family of methods from the static `Core\System` class. As a result the custom headers were ignored, including the CORS headers for `.well-known/host-meta` requests.

It turns out these headers are needed to implement platform identification from software like Keyoxide where @YarmoM looked into compatibility with Friendica: https://codeberg.org/keyoxide/doipjs/issues/59

This PR moves these methods to the BaseModule context where the same `Module\Response` object is used, and the expected headers magically appear in the response.

I've kept the `Core\System` methods, albeit with a deprecation notice, as they are still needed for legacy modules that don't inherit from `BaseModule` just yet.