### PR TITLE
Rework image grid to horizontal masonry, allocate space for images to load

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3356,6 +3356,7 @@ class Item
 						'attachment' => $attachment,
 					],
 					'$allocated_height' => Media::getAllocatedHeightByMedia($attachment),
+					'$allocated_max_width' => ($attachment['preview-width'] ?? $attachment['width']) . 'px',
 				]);
 			}, $s);
 		}
@@ -3472,8 +3473,10 @@ class Item
 
 			if ($attachment['filetype'] == 'image') {
 				$preview_url = Post\Media::getPreviewUrlForId($attachment['id'], ($attachment['width'] > $attachment['height']) ? Proxy::SIZE_MEDIUM : Proxy::SIZE_LARGE);
+				$attachment['preview-width'] = ($attachment['width'] > $attachment['height']) ? Proxy::PIXEL_MEDIUM : Proxy::PIXEL_LARGE;
 			} elseif (!empty($attachment['preview'])) {
 				$preview_url = Post\Media::getPreviewUrlForId($attachment['id'], Proxy::SIZE_LARGE);
+				$attachment['preview-width'] = Proxy::PIXEL_LARGE;
 			} else {
 				$preview_url = '';
 			}
@@ -3529,6 +3532,7 @@ class Item
 			$media = Renderer::replaceMacros(Renderer::getMarkupTemplate('content/image.tpl'), [
 				'$image' => $images[0],
 				'$allocated_height' => Media::getAllocatedHeightByMedia($images[0]['attachment']),
+				'$allocated_max_width' => ($images[0]['attachment']['preview-width'] ?? $images[0]['attachment']['width']) . 'px',
 			]);
 		}
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3325,7 +3325,8 @@ class Item
 		);
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('content/image_grid.tpl'), [
-			'rows' => $rows,
+			'$rows' => $rows,
+			'$column_size' => $column_size,
 		]);
 	}
 
@@ -3512,8 +3513,15 @@ class Item
 		if (count($images) > 1) {
 			$media = self::makeImageGrid($images);
 		} elseif (count($images) == 1) {
+			if (!empty($images[0]['attachment']['preview-height'])) {
+				$allocated_height = (100 * $images[0]['attachment']['preview-height'] / $images[0]['attachment']['preview-width']) . '%';
+			} else {
+				$allocated_height = (100 * $images[0]['attachment']['height'] / $images[0]['attachment']['width']) . '%';
+			}
+
 			$media = Renderer::replaceMacros(Renderer::getMarkupTemplate('content/image.tpl'), [
 				'$image' => $images[0],
+				'$allocated_height' => $allocated_height,
 			]);
 		}
 

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -1173,12 +1173,6 @@ class Media
 	 */
 	public static function getAllocatedHeightByMedia(array $media): string
 	{
-		if (!empty($media['preview-height'])) {
-			$allocated_height = (100 * $media['preview-height'] / $media['preview-width']) . '%';
-		} else {
-			$allocated_height = (100 * $media['height'] / $media['width']) . '%';
-		}
-
-		return $allocated_height;
+		return (100 * $media['height'] / $media['width']) . '%';
 	}
 }

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -1164,4 +1164,21 @@ class Media
 		}
 		return $url . $id;
 	}
+
+	/**
+	 * Computes the allocated height value used in the content/image.tpl template based on a post-media record
+	 *
+	 * @param array $media A post-media record array
+	 * @return string
+	 */
+	public static function getAllocatedHeightByMedia(array $media): string
+	{
+		if (!empty($media['preview-height'])) {
+			$allocated_height = (100 * $media['preview-height'] / $media['preview-width']) . '%';
+		} else {
+			$allocated_height = (100 * $media['height'] / $media['width']) . '%';
+		}
+
+		return $allocated_height;
+	}
 }

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -813,12 +813,14 @@ class Profile
 
 	/**
 	 * Set the visitor cookies (see remote_user()) for signed HTTP requests
-	 (
+	 *
+	 * @param array $server The content of the $_SERVER superglobal
 	 * @return array Visitor contact array
+	 * @throws InternalServerErrorException
 	 */
-	public static function addVisitorCookieForHTTPSigner(): array
+	public static function addVisitorCookieForHTTPSigner(array $server): array
 	{
-		$requester = HTTPSignature::getSigner('', $_SERVER);
+		$requester = HTTPSignature::getSigner('', $server);
 		if (empty($requester)) {
 			return [];
 		}

--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -77,7 +77,7 @@ class Photo extends BaseApi
 			throw new NotModifiedException();
 		}
 
-		Profile::addVisitorCookieForHTTPSigner();
+		Profile::addVisitorCookieForHTTPSigner($this->server);
 
 		$customsize = 0;
 		$square_resize = true;

--- a/view/global.css
+++ b/view/global.css
@@ -698,6 +698,7 @@ audio {
 figure.img-allocated-height {
 	position: relative;
 	background: center / auto rgba(0, 0, 0, 0.05) url(/images/icons/image.png) no-repeat;
+	margin: 0;
 }
 figure.img-allocated-height img{
 	position: absolute;

--- a/view/global.css
+++ b/view/global.css
@@ -685,22 +685,25 @@ audio {
 .imagegrid-row {
 	display: -ms-flexbox; /* IE10 */
 	display: flex;
-	margin-top: 1em;
+	/* Both the following values should be the same to ensure consistent margins between images in the grid */
 	column-gap: 5px;
+	margin-top: 5px;
 }
 
-.imagegrid-column {
-	-ms-flex: 50%; /* IE10 */
-	flex: 50%;
-	display: -ms-flexbox; /* IE10 */
-	display: flex;
-	flex-direction: column;
-	row-gap: 5px;
+/* This helps allocating space for image before they loaded, preventing content shifting once they are
+ * Inspired by https://www.smashingmagazine.com/2016/08/ways-to-reduce-content-shifting-on-page-load/
+ * Please note: The space is effectively allocated using padding-bottom using the image ratio as a value.
+ * In the image grid, this ratio isn't known in advance so no value is set in the stylesheet.
+ */
+.imagegrid-row figure {
+	position: relative;
 }
-
-.imagegrid-column img {
-	-ms-flex: 50%; /* IE10 */
-	flex: 50%;
+.imagegrid-row figure img{
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
 }
 /**
  * Image grid settings END

--- a/view/global.css
+++ b/view/global.css
@@ -695,16 +695,17 @@ audio {
  * Please note: The space is effectively allocated using padding-bottom using the image ratio as a value.
  * In the image grid, this ratio isn't known in advance so no value is set in the stylesheet.
  */
-.imagegrid-row figure {
+figure.img-allocated-height {
 	position: relative;
 	background: center / auto rgba(0, 0, 0, 0.05) url(/images/icons/image.png) no-repeat;
 }
-.imagegrid-row figure img{
+figure.img-allocated-height img{
 	position: absolute;
 	top: 0;
 	right: 0;
 	bottom: 0;
 	left: 0;
+	width: 100%;
 }
 /**
  * Image grid settings END

--- a/view/global.css
+++ b/view/global.css
@@ -697,6 +697,7 @@ audio {
  */
 .imagegrid-row figure {
 	position: relative;
+	background: center / auto rgba(0, 0, 0, 0.05) url(/images/icons/image.png) no-repeat;
 }
 .imagegrid-row figure img{
 	position: absolute;

--- a/view/templates/content/image.tpl
+++ b/view/templates/content/image.tpl
@@ -1,5 +1,7 @@
 {{if $image.preview}}
-<a data-fancybox="{{$image.uri_id}}" href="{{$image.attachment.url}}"><img src="{{$image.preview}}" alt="{{$image.attachment.description}}" title="{{$image.attachment.description}}"></a>
+<a data-fancybox="{{$image.uri_id}}" href="{{$image.attachment.url}}">
+	<img src="{{$image.preview}}" alt="{{$image.attachment.description}}" title="{{$image.attachment.description}}">
+</a>
 {{else}}
 <img src="{{$image.src}}" alt="{{$image.attachment.description}}" title="{{$image.attachment.description}}">
 {{/if}}

--- a/view/templates/content/image.tpl
+++ b/view/templates/content/image.tpl
@@ -1,7 +1,10 @@
+{{* $image.widthRatio is only set in the context of Model\Item->makeImageGrid *}}
+<figure class="img-allocated-height" style="width: {{if $image.widthRatio}}{{$image.widthRatio}}%{{else}}auto{{/if}}; padding-bottom: {{$allocated_height}}">
 {{if $image.preview}}
-<a data-fancybox="{{$image.uri_id}}" href="{{$image.attachment.url}}">
-	<img src="{{$image.preview}}" alt="{{$image.attachment.description}}" title="{{$image.attachment.description}}">
-</a>
+	<a data-fancybox="{{$image.uri_id}}" href="{{$image.attachment.url}}">
+		<img src="{{$image.preview}}" alt="{{$image.attachment.description}}" title="{{$image.attachment.description}}">
+	</a>
 {{else}}
-<img src="{{$image.src}}" alt="{{$image.attachment.description}}" title="{{$image.attachment.description}}">
+	<img src="{{$image.src}}" alt="{{$image.attachment.description}}" title="{{$image.attachment.description}}">
 {{/if}}
+</figure>

--- a/view/templates/content/image.tpl
+++ b/view/templates/content/image.tpl
@@ -1,5 +1,11 @@
-{{* $image.widthRatio is only set in the context of Model\Item->makeImageGrid *}}
-<figure class="img-allocated-height" style="width: {{if $image.widthRatio}}{{$image.widthRatio}}%{{else}}auto{{/if}}; padding-bottom: {{$allocated_height}}">
+{{* The padding-top height allocation trick only works if the <figure> fills its parent's width completely or with flex. 🤷‍♂️
+	As a result, we need to add a wrapping element for non-flex (non-image grid) environments, mostly single-image cases.
+ *}}
+{{if $allocated_max_width}}
+<div style="max-width: {{$allocated_max_width|default:"auto"}};">
+{{/if}}
+
+<figure class="img-allocated-height" style="width: {{$allocated_width|default:"auto"}}; padding-bottom: {{$allocated_height}}">
 {{if $image.preview}}
 	<a data-fancybox="{{$image.uri_id}}" href="{{$image.attachment.url}}">
 		<img src="{{$image.preview}}" alt="{{$image.attachment.description}}" title="{{$image.attachment.description}}">
@@ -8,3 +14,7 @@
 	<img src="{{$image.src}}" alt="{{$image.attachment.description}}" title="{{$image.attachment.description}}">
 {{/if}}
 </figure>
+
+{{if $allocated_max_width}}
+</div>
+{{/if}}

--- a/view/templates/content/image_grid.tpl
+++ b/view/templates/content/image_grid.tpl
@@ -1,12 +1,10 @@
-<div class="imagegrid-row">
-	<div class="imagegrid-column">
-		{{foreach $columns.fc as $img}}
-				{{include file="content/image.tpl" image=$img}}
-		{{/foreach}}
+{{foreach $rows as $images}}
+	<div class="imagegrid-row" style="height: {{$images[0].commonHeightRatio}}%">
+	{{foreach $images as $image}}
+		{{* The absolute pixel value in the calc() should be mirrored from the .imagegrid-row column-gap value *}}
+		<figure style="width: {{$image.widthRatio}}%; padding-bottom: calc({{$image.heightRatio * $image.widthRatio / 100}}% - 5px / 2)">
+            {{include file="content/image.tpl" image=$image}}
+		</figure>
+    {{/foreach}}
 	</div>
-	<div class="imagegrid-column">
-		{{foreach $columns.sc as $img}}
-				{{include file="content/image.tpl" image=$img}}
-		{{/foreach}}
-	</div>
-</div>
+{{/foreach}}

--- a/view/templates/content/image_grid.tpl
+++ b/view/templates/content/image_grid.tpl
@@ -2,9 +2,7 @@
 	<div class="imagegrid-row" style="height: {{$images[0].commonHeightRatio}}%">
 	{{foreach $images as $image}}
 		{{* The absolute pixel value in the calc() should be mirrored from the .imagegrid-row column-gap value *}}
-		<figure style="width: {{$image.widthRatio}}%; padding-bottom: calc({{$image.heightRatio * $image.widthRatio / 100}}% - 5px / 2)">
-            {{include file="content/image.tpl" image=$image}}
-		</figure>
+        {{include file="content/image.tpl" image=$image allocated_height="calc(`$image.heightRatio * $image.widthRatio / 100`% - 5px / `$column_size`)"}}
     {{/foreach}}
 	</div>
 {{/foreach}}

--- a/view/templates/content/image_grid.tpl
+++ b/view/templates/content/image_grid.tpl
@@ -2,7 +2,11 @@
 	<div class="imagegrid-row" style="height: {{$images[0].commonHeightRatio}}%">
 	{{foreach $images as $image}}
 		{{* The absolute pixel value in the calc() should be mirrored from the .imagegrid-row column-gap value *}}
-        {{include file="content/image.tpl" image=$image allocated_height="calc(`$image.heightRatio * $image.widthRatio / 100`% - 5px / `$column_size`)"}}
+        {{include file="content/image.tpl"
+            image=$image
+            allocated_height="calc(`$image.heightRatio * $image.widthRatio / 100`% - 5px / `$column_size`)"
+            allocated_width="`$image.widthRatio`%"
+        }}
     {{/foreach}}
 	</div>
 {{/foreach}}

--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -394,3 +394,7 @@ input[type="text"].tt-input {
 textarea#profile-jot-text:focus + #preview_profile-jot-text, textarea.comment-edit-text:focus + .comment-edit-form .preview {
 	border-color: $link_color;
 }
+
+.imagegrid-row figure {
+	background-color: rgba(255, 255, 255, 0.15);
+}

--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -395,6 +395,6 @@ textarea#profile-jot-text:focus + #preview_profile-jot-text, textarea.comment-ed
 	border-color: $link_color;
 }
 
-.imagegrid-row figure {
+figure.img-allocated-height {
 	background-color: rgba(255, 255, 255, 0.15);
 }

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -355,6 +355,6 @@ textarea#profile-jot-text:focus + #preview_profile-jot-text, textarea.comment-ed
 	border-color: $link_color;
 }
 
-.imagegrid-row figure {
+figure.img-allocated-height {
 	background-color: rgba(255, 255, 255, 0.05);
 }

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -354,3 +354,7 @@ input[type="text"].tt-input {
 textarea#profile-jot-text:focus + #preview_profile-jot-text, textarea.comment-edit-text:focus + .comment-edit-form .preview {
 	border-color: $link_color;
 }
+
+.imagegrid-row figure {
+	background-color: rgba(255, 255, 255, 0.05);
+}

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -240,10 +240,10 @@
 
 						{{if $item.ignore}}
 							<li role="menuitem">
-								<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-eye-slash" aria-hidden="true"></i> {{$item.ignore.do}}</a>
+								<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-bell-slash" aria-hidden="true"></i> {{$item.ignore.do}}</a>
 							</li>
 							<li role="menuitem">
-								<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-eye" aria-hidden="true"></i> {{$item.ignore.undo}}</a>
+								<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-bell" aria-hidden="true"></i> {{$item.ignore.undo}}</a>
 							</li>
 						{{/if}}
 

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -381,10 +381,10 @@ as the value of $top_child_total (this is done at the end of this file)
 
                                         {{if $item.ignore}}
                                         <li role="menuitem">
-                                                <a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-eye-slash" aria-hidden="true"></i> {{$item.ignore.do}}</a>
+                                                <a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-bell-slash" aria-hidden="true"></i> {{$item.ignore.do}}</a>
                                         </li>
                                         <li role="menuitem">
-                                                <a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-eye" aria-hidden="true"></i> {{$item.ignore.undo}}</a>
+                                                <a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-bell" aria-hidden="true"></i> {{$item.ignore.undo}}</a>
                                         </li>
                                         {{/if}}
 
@@ -560,10 +560,10 @@ as the value of $top_child_total (this is done at the end of this file)
 
 							{{if $item.ignore}}
 								<li role="menuitem">
-								<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-eye-slash" aria-hidden="true"></i> {{$item.ignore.do}}</a>
+								<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-bell-slash" aria-hidden="true"></i> {{$item.ignore.do}}</a>
 							</li>
 								<li role="menuitem">
-								<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-eye" aria-hidden="true"></i> {{$item.ignore.undo}}</a>
+								<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-bell" aria-hidden="true"></i> {{$item.ignore.undo}}</a>
 							</li>
 							{{/if}}
 


### PR DESCRIPTION
This is something I have been meaning to do for a while: rework the column-first image grid into a server-based horizontal masonry. No Javascript involved, mostly ~~magic~~ math and CSS. Now the original order of posted images is respected, while having as little blank space as possible (odd number of pictures 😰)

This also closes #13455

![image](https://github.com/friendica/friendica/assets/925415/cb581318-9a4e-4cab-b68a-c7cc5009a0d6)

![image](https://github.com/friendica/friendica/assets/925415/d14036bd-c205-4637-bfea-468019797a87)
