### PR TITLE
Restore attendance icons in event posts

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1078,7 +1078,10 @@ class Item
 		}
 
 		if ($item['origin']) {
-			if (Photo::setPermissionFromBody($item['body'], $item['uid'], $item['contact-id'], $item['allow_cid'], $item['allow_gid'], $item['deny_cid'], $item['deny_gid'])) {
+			if (
+				Photo::setPermissionFromBody($item['body'], $item['uid'], $item['contact-id'], $item['allow_cid'], $item['allow_gid'], $item['deny_cid'], $item['deny_gid'])
+				&& ($item['object-type'] != Activity\ObjectType::EVENT)
+			) {
 				$item['object-type'] = Activity\ObjectType::IMAGE;
 			}
 


### PR DESCRIPTION
Fix #13462 

- Co-authored by @mexon based on https://git.friendi.ca/mexon/friendica/commit/03f5e7a9526294edd2cb7e57ccfee56307d78299

I flipped the condition because we do need to execute `Photo::setPermissionFromBody` even in the case of an event.
