### PR TITLE
There is now a time limit when fetching AP endpoints

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -601,7 +601,7 @@ class Worker
 		$rest    = round(max(0, $up_duration - (self::$db_duration + self::$lock_duration)), 2);
 		$exec    = round($duration, 2);
 
-		Logger::info('Performance:', ['state' => self::$state, 'count' => $dbcount, 'stat' => $dbstat, 'write' => $dbwrite, 'lock' => $dblock, 'total' => $dbtotal, 'rest' => $rest, 'exec' => $exec]);
+		Logger::info('Performance:', ['function' => $funcname, 'state' => self::$state, 'count' => $dbcount, 'stat' => $dbstat, 'write' => $dbwrite, 'lock' => $dblock, 'total' => $dbtotal, 'rest' => $rest, 'exec' => $exec]);
 
 		self::coolDown();
 
@@ -622,7 +622,7 @@ class Worker
 			Logger::info('Longer than 2 minutes.', ['priority' => $queue['priority'], 'id' => $queue['id'], 'duration' => round($duration/60, 3)]);
 		}
 
-		Logger::info('Process done.', ['priority' => $queue['priority'], 'id' => $queue['id'], 'duration' => round($duration, 3)]);
+		Logger::info('Process done.', ['function' => $funcname, 'priority' => $queue['priority'], 'retrial' => $queue['retrial'], 'id' => $queue['id'], 'duration' => round($duration, 3)]);
 
 		DI::profiler()->saveLog(DI::logger(), 'ID ' . $queue['id'] . ': ' . $funcname);
 	}

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -241,16 +241,16 @@ class ActivityPub
 	/**
 	 * Fetch items from AP endpoints
 	 *
-	 * @param string $url        Address of the endpoint
-	 * @param integer $uid       Optional user id
-	 * @param integer $timestamp Internally used parameter to stop fetching after some time
+	 * @param string $url              Address of the endpoint
+	 * @param integer $uid             Optional user id
+	 * @param integer $start_timestamp Internally used parameter to stop fetching after some time
 	 * @return array Endpoint items
 	 */
-	public static function fetchItems(string $url, int $uid = 0, int $timestamp = 0): array
+	public static function fetchItems(string $url, int $uid = 0, int $start_timestamp = 0): array
 	{
-		$timestamp = $timestamp ?: time();
+		$start_timestamp = $start_timestamp ?: time();
 
-		if ((time() - $timestamp) > 60) {
+		if ((time() - $start_timestamp) > 60) {
 			Logger::info('Fetch time limit reached', ['url' => $url, 'uid' => $uid]);
 			return [];
 		}
@@ -265,13 +265,13 @@ class ActivityPub
 		} elseif (!empty($data['first']['orderedItems'])) {
 			$items = $data['first']['orderedItems'];
 		} elseif (!empty($data['first']) && is_string($data['first']) && ($data['first'] != $url)) {
-			return self::fetchItems($data['first'], $uid, $timestamp);
+			return self::fetchItems($data['first'], $uid, $start_timestamp);
 		} else {
 			return [];
 		}
 
 		if (!empty($data['next']) && is_string($data['next'])) {
-			$items = array_merge($items, self::fetchItems($data['next'], $uid, $timestamp));
+			$items = array_merge($items, self::fetchItems($data['next'], $uid, $start_timestamp));
 		}
 
 		return $items;

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -241,12 +241,20 @@ class ActivityPub
 	/**
 	 * Fetch items from AP endpoints
 	 *
-	 * @param string $url  Address of the endpoint
-	 * @param integer $uid Optional user id
+	 * @param string $url        Address of the endpoint
+	 * @param integer $uid       Optional user id
+	 * @param integer $timestamp Internally used parameter to stop fetching after some time
 	 * @return array Endpoint items
 	 */
-	public static function fetchItems(string $url, int $uid = 0): array
+	public static function fetchItems(string $url, int $uid = 0, int $timestamp = 0): array
 	{
+		$timestamp = $timestamp ?: time();
+
+		if ((time() - $timestamp) > 60) {
+			Logger::info('Fetch time limit reached', ['url' => $url, 'uid' => $uid]);
+			return [];
+		}
+
 		$data = self::fetchContent($url, $uid);
 		if (empty($data)) {
 			return [];
@@ -257,13 +265,13 @@ class ActivityPub
 		} elseif (!empty($data['first']['orderedItems'])) {
 			$items = $data['first']['orderedItems'];
 		} elseif (!empty($data['first']) && is_string($data['first']) && ($data['first'] != $url)) {
-			return self::fetchItems($data['first'], $uid);
+			return self::fetchItems($data['first'], $uid, $timestamp);
 		} else {
 			return [];
 		}
 
 		if (!empty($data['next']) && is_string($data['next'])) {
-			$items = array_merge($items, self::fetchItems($data['next'], $uid));
+			$items = array_merge($items, self::fetchItems($data['next'], $uid, $timestamp));
 		}
 
 		return $items;


### PR DESCRIPTION
Some accounts have got huge lists of followers. This can result in fetching the contacts for a long time. We now automatically stop after one minute of fetchting to not stress the remote system more than we have to.