### PR TITLE
[frio] add styling to event reminder

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1303,7 +1303,7 @@ aside #follow-sidebar .form-group-search .form-button-search {
 	padding: 2px 8px;
 }
 
-div#sidebar-circle-header h3, 
+div#sidebar-circle-header h3,
 div#sidebar-group-header h3 {
 	float: left;
 }
@@ -2214,9 +2214,11 @@ img.acpopup-img {
 	margin-left: 15px;
 }
 
-/* Birthday */
+/* Birthday and Event Reminders  */
 #birthday-notice,
-#birthday-wrapper {
+#birthday-wrapper,
+#event-notice,
+#event-wrapper {
 	margin-bottom: 5px;
 	padding: 10px;
 	border: none;
@@ -3069,7 +3071,7 @@ details.profile-jot-net[open] summary:before {
 	content: "\f0da"; /* Right Plain Pointer */
 }
 .widget > .fakelink > h3:before,
-#sidebar-circle-header > .fakelink > h3:before, 
+#sidebar-circle-header > .fakelink > h3:before,
 #sidebar-group-header > .fakelink > h3:before {
 	font-family: ForkAwesome;
 	content: "\f0d7"; /* Bottom Plain Pointer */


### PR DESCRIPTION
It seems as if only the birthday reminder was styled in frio, and the event reminder below not.
I have added the `#event-` ids to the `#birthday-` ids to use the same CSS. Why the two other whitespace are removed, I don't know. Hope it is okay. 