### PR TITLE
Allow macOS users to use Ctrl + Cmd + Space to bring up the emoji picker in Friendica text fields

### DIFF
--- a/view/js/main.js
+++ b/view/js/main.js
@@ -378,16 +378,10 @@ $(function() {
 
 	// Allow folks to stop the ajax page updates with the pause/break key
 	$(document).keydown(function(event) {
-		if (event.keyCode == '8') {
-			var target = event.target || event.srcElement;
-			if (!/input|textarea/i.test(target.nodeName)) {
-				return false;
-			}
-		}
-
-		if (event.keyCode == '19' || (event.ctrlKey && event.which == '32')) {
+		// Pause/Break or Ctrl + Space
+		if (event.which === 19 || (!event.shiftKey && !event.altKey && event.ctrlKey && event.which === 32)) {
 			event.preventDefault();
-			if (stopped == false) {
+			if (stopped === false) {
 				stopped = true;
 				if (event.ctrlKey) {
 					totStopped = true;


### PR DESCRIPTION
Fix https://github.com/friendica/friendica/issues/11142

- Remove Backspace guard against changing page
- Clarify keyboard shortcut to pause automatic updates

In the process of investigating this, I found a secret feature to pause the automatic updates using the Pause/Break key or Ctrl+Space. However, it was preventing macOS users from bringing up the emoji picker with Ctrl + Cmd +Space because its definition wasn't precise enough.