### PR TITLE
[frio] Remove superfluous padding from search results in mobile view

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3776,10 +3776,6 @@ section .profile-match-wrapper {
 		margin-bottom: 5px;
 	}
 
-	.panel .panel-body {
-		padding: 10px;
-	}
-
 	.toplevel_item > .wall-item-container {
 		padding: 0;
 	}


### PR DESCRIPTION
Before:
![image](https://github.com/friendica/friendica/assets/925415/8d7b426b-8bd8-4b9c-90bc-68df9d674678)

After:
![image](https://github.com/friendica/friendica/assets/925415/8b783547-fdc9-4562-a79c-7fa8c5deecc9)
