### PR TITLE
Add caption display for described images in Fancybox gallery

### DIFF
--- a/view/js/fancybox/fancybox.config.js
+++ b/view/js/fancybox/fancybox.config.js
@@ -1,13 +1,10 @@
 $(document).ready(function() {
     $.fancybox.defaults.loop = "true";
-    // this disables the colorbox hook found in frio/js/modal.js:34
-    $("body").off("click", ".wall-item-body a img");
-
-    // Adds ALT/TITLE text to fancybox
-    $('a[data-fancybox').fancybox({
-        afterLoad : function(instance, current) {
-            current.$image.attr('alt', current.opts.$orig.find('img').attr('alt') );
-            current.$image.attr('title', current.opts.$orig.find('img').attr('title') );
-        }
-    });
+	$.fancybox.defaults.afterLoad = function(instance, current) {
+		current.$image.attr('alt', current.opts.$orig.find('img').attr('alt') );
+		current.$image.attr('title', current.opts.$orig.find('img').attr('title') );
+	};
+    $.fancybox.defaults.caption = function (instance, slide, caption) {
+		return slide.$thumb.attr('alt');
+	};
 });

--- a/view/templates/content/image/single.tpl
+++ b/view/templates/content/image/single.tpl
@@ -1,5 +1,10 @@
 {{if $image->preview}}
 <a data-fancybox="{{$image->uriId}}" href="{{$image->url}}"><img src="{{$image->preview}}" alt="{{$image->description}}" title="{{$image->description}}" loading="lazy"></a>
 {{else}}
-<img src="{{$image->url}}" alt="{{$image->description}}" title="{{$image->description}}" loading="lazy">
+<figure>
+	<img src="{{$image->url}}" alt="{{$image->description}}" title="{{$image->description}}" loading="lazy">
+	{{if $image->description}}
+	<figcaption>{{$image->description}}</figcaption>
+    {{/if}}
+</figure>
 {{/if}}

--- a/view/templates/content/image/single_with_height_allocation.tpl
+++ b/view/templates/content/image/single_with_height_allocation.tpl
@@ -12,6 +12,9 @@
 		</a>
     {{else}}
 		<img src="{{$image->url}}" alt="{{$image->description}}" title="{{$image->description}}" loading="lazy">
+        {{if $image->description}}
+		    <figcaption>{{$image->description}}</figcaption>
+        {{/if}}
     {{/if}}
 </figure>
 


### PR DESCRIPTION
Fix #13440

I found a solution within the Fancybox plugin, which I thought would be easier to implement than replacing with a completely different library. Turns out I was slightly wrong, because of a quirk of the Fancybox library itself combined with a wrong use on our part, but it worked out in the end. Running this branch on my production node for a few days just to be sure.

Known caveat: Just with the Photoswipe library, it isn't possible to select the caption text (for translation purposes, for example)  by click and drag since the swipe motion is captured to flip through the images of a gallery.