### PR TITLE
Move jsonError out of Factory\Api\Mastodon\Error

### DIFF
--- a/src/Factory/Api/Mastodon/Error.php
+++ b/src/Factory/Api/Mastodon/Error.php
@@ -70,14 +70,11 @@ class Error extends BaseFactory
 		return new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 	}
 
-	public function Forbidden(string $error = '')
+	public function Forbidden(string $error = ''): \Friendica\Object\Api\Mastodon\Error
 	{
 		$error             = $error ?: $this->l10n->t('Token is not authorized with a valid user or is missing a required scope');
 		$error_description = '';
-		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
-
-		$this->logError(403, $error);
-		$this->jsonError(403, $errorObj->toArray());
+		return new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 	}
 
 	public function InternalError(string $error = '')

--- a/src/Factory/Api/Mastodon/Error.php
+++ b/src/Factory/Api/Mastodon/Error.php
@@ -57,14 +57,11 @@ class Error extends BaseFactory
 		return new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 	}
 
-	public function UnprocessableEntity(string $error = '')
+	public function UnprocessableEntity(string $error = ''): \Friendica\Object\Api\Mastodon\Error
 	{
 		$error             = $error ?: $this->l10n->t('Unprocessable Entity');
 		$error_description = '';
-		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
-
-		$this->logError(422, $error);
-		$this->jsonError(422, $errorObj->toArray());
+		return new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 	}
 
 	public function Unauthorized(string $error = '', string $error_description = '')

--- a/src/Factory/Api/Mastodon/Error.php
+++ b/src/Factory/Api/Mastodon/Error.php
@@ -50,14 +50,11 @@ class Error extends BaseFactory
 		$this->logger->info('API Error', ['no' => $errorno, 'error' => $error, 'method' => $this->args->getMethod(), 'command' => $this->args->getQueryString(), 'user-agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
 	}
 
-	public function RecordNotFound()
+	public function RecordNotFound(): \Friendica\Object\Api\Mastodon\Error
 	{
 		$error             = $this->l10n->t('Record not found');
 		$error_description = '';
-		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
-
-		$this->logError(404, $error);
-		$this->jsonError(404, $errorObj->toArray());
+		return new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 	}
 
 	public function UnprocessableEntity(string $error = '')

--- a/src/Factory/Api/Mastodon/Error.php
+++ b/src/Factory/Api/Mastodon/Error.php
@@ -77,13 +77,10 @@ class Error extends BaseFactory
 		return new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 	}
 
-	public function InternalError(string $error = '')
+	public function InternalError(string $error = ''): \Friendica\Object\Api\Mastodon\Error
 	{
 		$error             = $error ?: $this->l10n->t('Internal Server Error');
 		$error_description = '';
-		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
-
-		$this->logError(500, $error);
-		$this->jsonError(500, $errorObj->toArray());
+		return new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 	}
 }

--- a/src/Factory/Api/Mastodon/Error.php
+++ b/src/Factory/Api/Mastodon/Error.php
@@ -21,33 +21,20 @@
 
 namespace Friendica\Factory\Api\Mastodon;
 
-use Friendica\App\Arguments;
 use Friendica\BaseFactory;
 use Friendica\Core\L10n;
-use Friendica\Core\System;
 use Psr\Log\LoggerInterface;
 
 /** @todo A Factory shouldn't return something to the frontpage, it's for creating content, not showing it */
 class Error extends BaseFactory
 {
-	/** @var Arguments */
-	private $args;
-	/** @var string[] The $_SERVER array */
-	private $server;
 	/** @var L10n */
 	private $l10n;
 
-	public function __construct(LoggerInterface $logger, Arguments $args, L10n $l10n, array $server)
+	public function __construct(LoggerInterface $logger, L10n $l10n)
 	{
 		parent::__construct($logger);
-		$this->args   = $args;
-		$this->server = $server;
 		$this->l10n   = $l10n;
-	}
-
-	private function logError(int $errorno, string $error)
-	{
-		$this->logger->info('API Error', ['no' => $errorno, 'error' => $error, 'method' => $this->args->getMethod(), 'command' => $this->args->getQueryString(), 'user-agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
 	}
 
 	public function RecordNotFound(): \Friendica\Object\Api\Mastodon\Error

--- a/src/Factory/Api/Mastodon/Error.php
+++ b/src/Factory/Api/Mastodon/Error.php
@@ -64,13 +64,10 @@ class Error extends BaseFactory
 		return new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 	}
 
-	public function Unauthorized(string $error = '', string $error_description = '')
+	public function Unauthorized(string $error = '', string $error_description = ''): \Friendica\Object\Api\Mastodon\Error
 	{
 		$error             = $error ?: $this->l10n->t('Unauthorized');
-		$errorObj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
-
-		$this->logError(401, $error);
-		$this->jsonError(401, $errorObj->toArray());
+		return new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 	}
 
 	public function Forbidden(string $error = '')

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -359,7 +359,7 @@ class Status extends BaseFactory
 	{
 		$item = ActivityPub\Transmitter::getItemArrayFromMail($id, true);
 		if (empty($item)) {
-			$this->mstdnErrorFactory->RecordNotFound();
+			throw new HTTPException\NotFoundException('Mail record not found with id: ' . $id);
 		}
 
 		$account = $this->mstdnAccountFactory->createFromContactId($item['author-id']);

--- a/src/Module/ActivityPub/Inbox.php
+++ b/src/Module/ActivityPub/Inbox.php
@@ -45,7 +45,7 @@ class Inbox extends BaseApi
 
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid  = self::getCurrentUserID();
 		$page = $request['page'] ?? null;
 

--- a/src/Module/ActivityPub/Outbox.php
+++ b/src/Module/ActivityPub/Outbox.php
@@ -58,7 +58,7 @@ class Outbox extends BaseApi
 
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid      = self::getCurrentUserID();
 		$postdata = Network::postdata();
 

--- a/src/Module/ActivityPub/Whoami.php
+++ b/src/Module/ActivityPub/Whoami.php
@@ -38,7 +38,7 @@ class Whoami extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$owner = User::getOwnerDataById($uid);

--- a/src/Module/Api/Friendica/Activity.php
+++ b/src/Module/Api/Friendica/Activity.php
@@ -44,7 +44,7 @@ class Activity extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Friendica/Circle/Create.php
+++ b/src/Module/Api/Friendica/Circle/Create.php
@@ -34,7 +34,7 @@ class Create extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		// params

--- a/src/Module/Api/Friendica/Circle/Delete.php
+++ b/src/Module/Api/Friendica/Circle/Delete.php
@@ -34,7 +34,7 @@ class Delete extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Friendica/Circle/Show.php
+++ b/src/Module/Api/Friendica/Circle/Show.php
@@ -35,7 +35,7 @@ class Show extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid  = BaseApi::getCurrentUserID();
 		$type = $this->getRequestValue($this->parameters, 'extension', 'json');
 

--- a/src/Module/Api/Friendica/Circle/Update.php
+++ b/src/Module/Api/Friendica/Circle/Update.php
@@ -35,7 +35,7 @@ class Update extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		// params

--- a/src/Module/Api/Friendica/DirectMessages/Search.php
+++ b/src/Module/Api/Friendica/DirectMessages/Search.php
@@ -44,9 +44,9 @@ class Search extends BaseApi
 	/** @var DirectMessage */
 	private $directMessage;
 
-	public function __construct(DirectMessage $directMessage, Database $dba, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(DirectMessage $directMessage, Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->dba           = $dba;
 		$this->directMessage = $directMessage;

--- a/src/Module/Api/Friendica/DirectMessages/Search.php
+++ b/src/Module/Api/Friendica/DirectMessages/Search.php
@@ -54,7 +54,7 @@ class Search extends BaseApi
 
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Friendica/DirectMessages/Setseen.php
+++ b/src/Module/Api/Friendica/DirectMessages/Setseen.php
@@ -32,7 +32,7 @@ class Setseen extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Friendica/Events/Create.php
+++ b/src/Module/Api/Friendica/Events/Create.php
@@ -40,7 +40,7 @@ class Create extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		// params

--- a/src/Module/Api/Friendica/Events/Delete.php
+++ b/src/Module/Api/Friendica/Events/Delete.php
@@ -35,7 +35,7 @@ class Delete extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Friendica/Events/Index.php
+++ b/src/Module/Api/Friendica/Events/Index.php
@@ -34,7 +34,7 @@ class Index extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Friendica/Notification.php
+++ b/src/Module/Api/Friendica/Notification.php
@@ -33,7 +33,7 @@ class Notification extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$Notifies = DI::notify()->selectAllForUser($uid, 50);

--- a/src/Module/Api/Friendica/Notification/Seen.php
+++ b/src/Module/Api/Friendica/Notification/Seen.php
@@ -40,7 +40,7 @@ class Seen extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		if (DI::args()->getArgc() !== 4) {

--- a/src/Module/Api/Friendica/Photo.php
+++ b/src/Module/Api/Friendica/Photo.php
@@ -46,7 +46,7 @@ class Photo extends BaseApi
 
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid  = BaseApi::getCurrentUserID();
 		$type = $this->getRequestValue($this->parameters, 'extension', 'json');
 

--- a/src/Module/Api/Friendica/Photo.php
+++ b/src/Module/Api/Friendica/Photo.php
@@ -37,9 +37,9 @@ class Photo extends BaseApi
 	private $friendicaPhoto;
 
 
-	public function __construct(FriendicaPhoto $friendicaPhoto, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->friendicaPhoto = $friendicaPhoto;
 	}

--- a/src/Module/Api/Friendica/Photo/Create.php
+++ b/src/Module/Api/Friendica/Photo/Create.php
@@ -41,9 +41,9 @@ class Create extends BaseApi
 	private $friendicaPhoto;
 
 
-	public function __construct(FriendicaPhoto $friendicaPhoto, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->friendicaPhoto = $friendicaPhoto;
 	}

--- a/src/Module/Api/Friendica/Photo/Create.php
+++ b/src/Module/Api/Friendica/Photo/Create.php
@@ -50,7 +50,7 @@ class Create extends BaseApi
 
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid  = BaseApi::getCurrentUserID();
 		$type = $this->getRequestValue($this->parameters, 'extension', 'json');
 

--- a/src/Module/Api/Friendica/Photo/Lists.php
+++ b/src/Module/Api/Friendica/Photo/Lists.php
@@ -43,9 +43,9 @@ class Lists extends BaseApi
 	private $friendicaPhoto;
 
 
-	public function __construct(FriendicaPhoto $friendicaPhoto, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->friendicaPhoto = $friendicaPhoto;
 	}

--- a/src/Module/Api/Friendica/Photo/Lists.php
+++ b/src/Module/Api/Friendica/Photo/Lists.php
@@ -52,7 +52,7 @@ class Lists extends BaseApi
 
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid  = BaseApi::getCurrentUserID();
 		$type = $this->getRequestValue($this->parameters, 'extension', 'json');
 

--- a/src/Module/Api/Friendica/Photo/Update.php
+++ b/src/Module/Api/Friendica/Photo/Update.php
@@ -50,7 +50,7 @@ class Update extends BaseApi
 
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid  = BaseApi::getCurrentUserID();
 		$type = $this->getRequestValue($this->parameters, 'extension', 'json');
 

--- a/src/Module/Api/Friendica/Photo/Update.php
+++ b/src/Module/Api/Friendica/Photo/Update.php
@@ -41,9 +41,9 @@ class Update extends BaseApi
 	private $friendicaPhoto;
 
 
-	public function __construct(FriendicaPhoto $friendicaPhoto, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->friendicaPhoto = $friendicaPhoto;
 	}

--- a/src/Module/Api/Friendica/Photoalbum/Delete.php
+++ b/src/Module/Api/Friendica/Photoalbum/Delete.php
@@ -36,7 +36,7 @@ class Delete extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Friendica/Photoalbum/Index.php
+++ b/src/Module/Api/Friendica/Photoalbum/Index.php
@@ -33,7 +33,7 @@ class Index extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$albums = Photo::getAlbums($uid);

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -52,7 +52,7 @@ class Show extends BaseApi
 
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid     = BaseApi::getCurrentUserID();
 		$type    = $this->getRequestValue($this->parameters, 'extension', 'json');
 		$request = $this->getRequest([

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -43,9 +43,9 @@ class Show extends BaseApi
 	private $friendicaPhoto;
 
 
-	public function __construct(FriendicaPhoto $friendicaPhoto, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->friendicaPhoto = $friendicaPhoto;
 	}

--- a/src/Module/Api/Friendica/Photoalbum/Update.php
+++ b/src/Module/Api/Friendica/Photoalbum/Update.php
@@ -34,7 +34,7 @@ class Update extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Friendica/Profile/Show.php
+++ b/src/Module/Api/Friendica/Profile/Show.php
@@ -36,7 +36,7 @@ class Show extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		// retrieve general information about profiles for user

--- a/src/Module/Api/Friendica/Statuses/Dislike.php
+++ b/src/Module/Api/Friendica/Statuses/Dislike.php
@@ -44,7 +44,7 @@ class Dislike extends BaseApi
 
 		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Item::performActivity($item['id'], 'dislike', $uid);

--- a/src/Module/Api/Friendica/Statuses/Dislike.php
+++ b/src/Module/Api/Friendica/Statuses/Dislike.php
@@ -39,7 +39,7 @@ class Dislike extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);

--- a/src/Module/Api/Friendica/Statuses/Dislike.php
+++ b/src/Module/Api/Friendica/Statuses/Dislike.php
@@ -35,7 +35,7 @@ class Dislike extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Friendica/Statuses/Dislike.php
+++ b/src/Module/Api/Friendica/Statuses/Dislike.php
@@ -39,12 +39,12 @@ class Dislike extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Item::performActivity($item['id'], 'dislike', $uid);

--- a/src/Module/Api/Friendica/Statuses/DislikedBy.php
+++ b/src/Module/Api/Friendica/Statuses/DislikedBy.php
@@ -41,12 +41,12 @@ class DislikedBy extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];
 		if (!Post::exists(['uri-id' => $id, 'uid' => [0, $uid]])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $id, 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::DISLIKE, 'deleted' => false]);

--- a/src/Module/Api/Friendica/Statuses/DislikedBy.php
+++ b/src/Module/Api/Friendica/Statuses/DislikedBy.php
@@ -41,7 +41,7 @@ class DislikedBy extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];

--- a/src/Module/Api/Friendica/Statuses/DislikedBy.php
+++ b/src/Module/Api/Friendica/Statuses/DislikedBy.php
@@ -46,7 +46,7 @@ class DislikedBy extends BaseApi
 
 		$id = $this->parameters['id'];
 		if (!Post::exists(['uri-id' => $id, 'uid' => [0, $uid]])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $id, 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::DISLIKE, 'deleted' => false]);

--- a/src/Module/Api/Friendica/Statuses/Undislike.php
+++ b/src/Module/Api/Friendica/Statuses/Undislike.php
@@ -44,7 +44,7 @@ class Undislike extends BaseApi
 
 		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Item::performActivity($item['id'], 'undislike', $uid);

--- a/src/Module/Api/Friendica/Statuses/Undislike.php
+++ b/src/Module/Api/Friendica/Statuses/Undislike.php
@@ -39,7 +39,7 @@ class Undislike extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);

--- a/src/Module/Api/Friendica/Statuses/Undislike.php
+++ b/src/Module/Api/Friendica/Statuses/Undislike.php
@@ -39,12 +39,12 @@ class Undislike extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Item::performActivity($item['id'], 'undislike', $uid);

--- a/src/Module/Api/Friendica/Statuses/Undislike.php
+++ b/src/Module/Api/Friendica/Statuses/Undislike.php
@@ -35,7 +35,7 @@ class Undislike extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/GNUSocial/Statusnet/Conversation.php
+++ b/src/Module/Api/GNUSocial/Statusnet/Conversation.php
@@ -37,7 +37,7 @@ class Conversation extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// params

--- a/src/Module/Api/Mastodon/Accounts.php
+++ b/src/Module/Api/Mastodon/Accounts.php
@@ -40,20 +40,20 @@ class Accounts extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id']) && empty($this->parameters['name'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!empty($this->parameters['id'])) {
 			$id = $this->parameters['id'];
 			if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 		} else {
 			$contact = Contact::selectFirst(['id'], ['nick' => $this->parameters['name'], 'uid' => 0]);
 			if (!empty($contact['id'])) {
 				$id = $contact['id'];
 			} elseif (!($id = Contact::getIdForURL($this->parameters['name'], 0, false))) {
-				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 		}
 

--- a/src/Module/Api/Mastodon/Accounts.php
+++ b/src/Module/Api/Mastodon/Accounts.php
@@ -46,14 +46,14 @@ class Accounts extends BaseApi
 		if (!empty($this->parameters['id'])) {
 			$id = $this->parameters['id'];
 			if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-				DI::mstdnError()->RecordNotFound();
+				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 		} else {
 			$contact = Contact::selectFirst(['id'], ['nick' => $this->parameters['name'], 'uid' => 0]);
 			if (!empty($contact['id'])) {
 				$id = $contact['id'];
 			} elseif (!($id = Contact::getIdForURL($this->parameters['name'], 0, false))) {
-				DI::mstdnError()->RecordNotFound();
+				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 		}
 

--- a/src/Module/Api/Mastodon/Accounts.php
+++ b/src/Module/Api/Mastodon/Accounts.php
@@ -40,7 +40,7 @@ class Accounts extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id']) && empty($this->parameters['name'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Block.php
+++ b/src/Module/Api/Mastodon/Accounts/Block.php
@@ -34,7 +34,7 @@ class Block extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_FOLLOW);
+		$this->checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Block.php
+++ b/src/Module/Api/Mastodon/Accounts/Block.php
@@ -38,7 +38,7 @@ class Block extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Contact\User::setBlocked($this->parameters['id'], $uid, true);

--- a/src/Module/Api/Mastodon/Accounts/Block.php
+++ b/src/Module/Api/Mastodon/Accounts/Block.php
@@ -38,7 +38,7 @@ class Block extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Contact\User::setBlocked($this->parameters['id'], $uid, true);

--- a/src/Module/Api/Mastodon/Accounts/FeaturedTags.php
+++ b/src/Module/Api/Mastodon/Accounts/FeaturedTags.php
@@ -34,7 +34,7 @@ class FeaturedTags extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 
 		$this->jsonExit([]);
 	}

--- a/src/Module/Api/Mastodon/Accounts/Follow.php
+++ b/src/Module/Api/Mastodon/Accounts/Follow.php
@@ -37,7 +37,7 @@ class Follow extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Follow.php
+++ b/src/Module/Api/Mastodon/Accounts/Follow.php
@@ -33,7 +33,7 @@ class Follow extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_FOLLOW);
+		$this->checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Follow.php
+++ b/src/Module/Api/Mastodon/Accounts/Follow.php
@@ -37,7 +37,7 @@ class Follow extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Followers.php
+++ b/src/Module/Api/Mastodon/Accounts/Followers.php
@@ -37,7 +37,7 @@ class Followers extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Followers.php
+++ b/src/Module/Api/Mastodon/Accounts/Followers.php
@@ -41,12 +41,12 @@ class Followers extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Followers.php
+++ b/src/Module/Api/Mastodon/Accounts/Followers.php
@@ -46,7 +46,7 @@ class Followers extends BaseApi
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Followers.php
+++ b/src/Module/Api/Mastodon/Accounts/Followers.php
@@ -41,7 +41,7 @@ class Followers extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];

--- a/src/Module/Api/Mastodon/Accounts/Following.php
+++ b/src/Module/Api/Mastodon/Accounts/Following.php
@@ -46,7 +46,7 @@ class Following extends BaseApi
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Following.php
+++ b/src/Module/Api/Mastodon/Accounts/Following.php
@@ -41,7 +41,7 @@ class Following extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];

--- a/src/Module/Api/Mastodon/Accounts/Following.php
+++ b/src/Module/Api/Mastodon/Accounts/Following.php
@@ -37,7 +37,7 @@ class Following extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Following.php
+++ b/src/Module/Api/Mastodon/Accounts/Following.php
@@ -41,12 +41,12 @@ class Following extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
+++ b/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
@@ -34,7 +34,7 @@ class IdentityProofs extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 
 		$this->jsonExit([]);
 	}

--- a/src/Module/Api/Mastodon/Accounts/Lists.php
+++ b/src/Module/Api/Mastodon/Accounts/Lists.php
@@ -37,7 +37,7 @@ class Lists extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Lists.php
+++ b/src/Module/Api/Mastodon/Accounts/Lists.php
@@ -41,12 +41,12 @@ class Lists extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$lists = [];

--- a/src/Module/Api/Mastodon/Accounts/Lists.php
+++ b/src/Module/Api/Mastodon/Accounts/Lists.php
@@ -46,7 +46,7 @@ class Lists extends BaseApi
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$lists = [];

--- a/src/Module/Api/Mastodon/Accounts/Lists.php
+++ b/src/Module/Api/Mastodon/Accounts/Lists.php
@@ -41,7 +41,7 @@ class Lists extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];

--- a/src/Module/Api/Mastodon/Accounts/Mute.php
+++ b/src/Module/Api/Mastodon/Accounts/Mute.php
@@ -33,7 +33,7 @@ class Mute extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_FOLLOW);
+		$this->checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Mute.php
+++ b/src/Module/Api/Mastodon/Accounts/Mute.php
@@ -37,7 +37,7 @@ class Mute extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Contact\User::setIgnored($this->parameters['id'], $uid, true);

--- a/src/Module/Api/Mastodon/Accounts/Mute.php
+++ b/src/Module/Api/Mastodon/Accounts/Mute.php
@@ -37,7 +37,7 @@ class Mute extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Contact\User::setIgnored($this->parameters['id'], $uid, true);

--- a/src/Module/Api/Mastodon/Accounts/Note.php
+++ b/src/Module/Api/Mastodon/Accounts/Note.php
@@ -38,7 +38,7 @@ class Note extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Note.php
+++ b/src/Module/Api/Mastodon/Accounts/Note.php
@@ -38,7 +38,7 @@ class Note extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$request = $this->getRequest([
@@ -47,7 +47,7 @@ class Note extends BaseApi
 
 		$cdata = Contact::getPublicAndUserContactID($this->parameters['id'], $uid);
 		if (empty($cdata['user'])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Contact::update(['info' => $request['comment']], ['id' => $cdata['user']]);

--- a/src/Module/Api/Mastodon/Accounts/Note.php
+++ b/src/Module/Api/Mastodon/Accounts/Note.php
@@ -47,7 +47,7 @@ class Note extends BaseApi
 
 		$cdata = Contact::getPublicAndUserContactID($this->parameters['id'], $uid);
 		if (empty($cdata['user'])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Contact::update(['info' => $request['comment']], ['id' => $cdata['user']]);

--- a/src/Module/Api/Mastodon/Accounts/Note.php
+++ b/src/Module/Api/Mastodon/Accounts/Note.php
@@ -34,7 +34,7 @@ class Note extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Relationships.php
+++ b/src/Module/Api/Mastodon/Accounts/Relationships.php
@@ -44,7 +44,7 @@ class Relationships extends BaseApi
 		], $request);
 
 		if (empty($request['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!is_array($request['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Relationships.php
+++ b/src/Module/Api/Mastodon/Accounts/Relationships.php
@@ -44,7 +44,7 @@ class Relationships extends BaseApi
 		], $request);
 
 		if (empty($request['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!is_array($request['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Relationships.php
+++ b/src/Module/Api/Mastodon/Accounts/Relationships.php
@@ -36,7 +36,7 @@ class Relationships extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Search.php
+++ b/src/Module/Api/Mastodon/Accounts/Search.php
@@ -38,7 +38,7 @@ class Search extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Statuses.php
+++ b/src/Module/Api/Mastodon/Accounts/Statuses.php
@@ -47,7 +47,7 @@ class Statuses extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];

--- a/src/Module/Api/Mastodon/Accounts/Statuses.php
+++ b/src/Module/Api/Mastodon/Accounts/Statuses.php
@@ -47,12 +47,12 @@ class Statuses extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Statuses.php
+++ b/src/Module/Api/Mastodon/Accounts/Statuses.php
@@ -52,7 +52,7 @@ class Statuses extends BaseApi
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Accounts/Unblock.php
+++ b/src/Module/Api/Mastodon/Accounts/Unblock.php
@@ -37,7 +37,7 @@ class Unblock extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Contact\User::setBlocked($this->parameters['id'], $uid, false);

--- a/src/Module/Api/Mastodon/Accounts/Unblock.php
+++ b/src/Module/Api/Mastodon/Accounts/Unblock.php
@@ -37,7 +37,7 @@ class Unblock extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Contact\User::setBlocked($this->parameters['id'], $uid, false);

--- a/src/Module/Api/Mastodon/Accounts/Unblock.php
+++ b/src/Module/Api/Mastodon/Accounts/Unblock.php
@@ -33,7 +33,7 @@ class Unblock extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_FOLLOW);
+		$this->checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Unfollow.php
+++ b/src/Module/Api/Mastodon/Accounts/Unfollow.php
@@ -33,7 +33,7 @@ class Unfollow extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_FOLLOW);
+		$this->checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Unfollow.php
+++ b/src/Module/Api/Mastodon/Accounts/Unfollow.php
@@ -42,7 +42,7 @@ class Unfollow extends BaseApi
 
 		$cdata = Contact::getPublicAndUserContactID($this->parameters['id'], $uid);
 		if (empty($cdata['user'])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$contact = Contact::getById($cdata['user']);

--- a/src/Module/Api/Mastodon/Accounts/Unfollow.php
+++ b/src/Module/Api/Mastodon/Accounts/Unfollow.php
@@ -37,7 +37,7 @@ class Unfollow extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$cdata = Contact::getPublicAndUserContactID($this->parameters['id'], $uid);

--- a/src/Module/Api/Mastodon/Accounts/Unfollow.php
+++ b/src/Module/Api/Mastodon/Accounts/Unfollow.php
@@ -37,12 +37,12 @@ class Unfollow extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$cdata = Contact::getPublicAndUserContactID($this->parameters['id'], $uid);
 		if (empty($cdata['user'])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$contact = Contact::getById($cdata['user']);

--- a/src/Module/Api/Mastodon/Accounts/Unmute.php
+++ b/src/Module/Api/Mastodon/Accounts/Unmute.php
@@ -37,7 +37,7 @@ class Unmute extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Contact\User::setIgnored($this->parameters['id'], $uid, false);

--- a/src/Module/Api/Mastodon/Accounts/Unmute.php
+++ b/src/Module/Api/Mastodon/Accounts/Unmute.php
@@ -33,7 +33,7 @@ class Unmute extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_FOLLOW);
+		$this->checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Accounts/Unmute.php
+++ b/src/Module/Api/Mastodon/Accounts/Unmute.php
@@ -37,7 +37,7 @@ class Unmute extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Contact\User::setIgnored($this->parameters['id'], $uid, false);

--- a/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
@@ -36,7 +36,7 @@ class UpdateCredentials extends BaseApi
 {
 	protected function patch(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$owner = User::getOwnerDataById($uid);

--- a/src/Module/Api/Mastodon/Accounts/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/VerifyCredentials.php
@@ -37,7 +37,7 @@ class VerifyCredentials extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$self = User::getOwnerDataById($uid);

--- a/src/Module/Api/Mastodon/Announcements.php
+++ b/src/Module/Api/Mastodon/Announcements.php
@@ -34,7 +34,7 @@ class Announcements extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 
 		// @todo Possibly use the message from the pageheader addon for this
 		$this->jsonExit([]);

--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -70,7 +70,7 @@ class Apps extends BaseApi
 		}
 
 		if (empty($request['client_name']) || empty($request['redirect_uris'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Missing parameters')));
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity($this->t('Missing parameters')));
 		}
 
 		$client_id     = bin2hex(random_bytes(32));
@@ -92,7 +92,7 @@ class Apps extends BaseApi
 		}
 
 		if (!DBA::insert('application', $fields)) {
-			$this->logErrorAndJsonExit(500, $this->errorFactory->InternalError());
+			$this->logAndJsonError(500, $this->errorFactory->InternalError());
 		}
 
 		$this->jsonExit(DI::mstdnApplication()->createFromApplicationId(DBA::lastInsertId())->toArray());

--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -70,7 +70,7 @@ class Apps extends BaseApi
 		}
 
 		if (empty($request['client_name']) || empty($request['redirect_uris'])) {
-			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t('Missing parameters'));
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Missing parameters')));
 		}
 
 		$client_id     = bin2hex(random_bytes(32));

--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -92,7 +92,7 @@ class Apps extends BaseApi
 		}
 
 		if (!DBA::insert('application', $fields)) {
-			DI::mstdnError()->InternalError();
+			$this->logErrorAndJsonExit(500, $this->errorFactory->InternalError());
 		}
 
 		$this->jsonExit(DI::mstdnApplication()->createFromApplicationId(DBA::lastInsertId())->toArray());

--- a/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
@@ -36,7 +36,7 @@ class VerifyCredentials extends BaseApi
 		$application = self::getCurrentApplication();
 
 		if (empty($application['id'])) {
-			$this->logErrorAndJsonExit(401, $this->errorFactory->Unauthorized());
+			$this->logAndJsonError(401, $this->errorFactory->Unauthorized());
 		}
 
 		$this->jsonExit(DI::mstdnApplication()->createFromApplicationId($application['id']));

--- a/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
@@ -32,7 +32,7 @@ class VerifyCredentials extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$application = self::getCurrentApplication();
 
 		if (empty($application['id'])) {

--- a/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
@@ -36,7 +36,7 @@ class VerifyCredentials extends BaseApi
 		$application = self::getCurrentApplication();
 
 		if (empty($application['id'])) {
-			DI::mstdnError()->Unauthorized();
+			$this->logErrorAndJsonExit(401, $this->errorFactory->Unauthorized());
 		}
 
 		$this->jsonExit(DI::mstdnApplication()->createFromApplicationId($application['id']));

--- a/src/Module/Api/Mastodon/Blocks.php
+++ b/src/Module/Api/Mastodon/Blocks.php
@@ -36,7 +36,7 @@ class Blocks extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Bookmarks.php
+++ b/src/Module/Api/Mastodon/Bookmarks.php
@@ -39,7 +39,7 @@ class Bookmarks extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Conversations.php
+++ b/src/Module/Api/Mastodon/Conversations.php
@@ -33,7 +33,7 @@ class Conversations extends BaseApi
 {
 	protected function delete(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (!empty($this->parameters['id'])) {
@@ -51,7 +51,7 @@ class Conversations extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Conversations.php
+++ b/src/Module/Api/Mastodon/Conversations.php
@@ -38,7 +38,7 @@ class Conversations extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (!empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		DBA::delete('conv', ['id' => $this->parameters['id'], 'uid' => $uid]);

--- a/src/Module/Api/Mastodon/Conversations.php
+++ b/src/Module/Api/Mastodon/Conversations.php
@@ -38,7 +38,7 @@ class Conversations extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (!empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		DBA::delete('conv', ['id' => $this->parameters['id'], 'uid' => $uid]);
@@ -90,7 +90,7 @@ class Conversations extends BaseApi
 				$conversations[] = DI::mstdnConversation()->createFromConvId($conv['id']);
 			}
 		} catch (NotFoundException $e) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		DBA::close($convs);

--- a/src/Module/Api/Mastodon/Conversations.php
+++ b/src/Module/Api/Mastodon/Conversations.php
@@ -25,6 +25,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Module\BaseApi;
+use Friendica\Network\HTTPException\NotFoundException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/conversations/
@@ -83,9 +84,13 @@ class Conversations extends BaseApi
 
 		$conversations = [];
 
-		while ($conv = DBA::fetch($convs)) {
-			self::setBoundaries($conv['id']);
-			$conversations[] = DI::mstdnConversation()->createFromConvId($conv['id']);
+		try {
+			while ($conv = DBA::fetch($convs)) {
+				self::setBoundaries($conv['id']);
+				$conversations[] = DI::mstdnConversation()->createFromConvId($conv['id']);
+			}
+		} catch (NotFoundException $e) {
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		DBA::close($convs);

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -25,6 +25,7 @@ use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Module\BaseApi;
+use Friendica\Network\HTTPException\NotFoundException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/conversations/
@@ -42,6 +43,10 @@ class Read extends BaseApi
 
 		DBA::update('mail', ['seen' => true], ['convid' => $this->parameters['id'], 'uid' => $uid]);
 
-		$this->jsonExit(DI::mstdnConversation()->createFromConvId($this->parameters['id'])->toArray());
+		try {
+			$this->jsonExit(DI::mstdnConversation()->createFromConvId($this->parameters['id'])->toArray());
+		} catch (NotFoundException $e) {
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+		}
 	}
 }

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -38,7 +38,7 @@ class Read extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (!empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		DBA::update('mail', ['seen' => true], ['convid' => $this->parameters['id'], 'uid' => $uid]);

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -38,7 +38,7 @@ class Read extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (!empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		DBA::update('mail', ['seen' => true], ['convid' => $this->parameters['id'], 'uid' => $uid]);
@@ -46,7 +46,7 @@ class Read extends BaseApi
 		try {
 			$this->jsonExit(DI::mstdnConversation()->createFromConvId($this->parameters['id'])->toArray());
 		} catch (NotFoundException $e) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 	}
 }

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -33,7 +33,7 @@ class Read extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (!empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Favourited.php
+++ b/src/Module/Api/Mastodon/Favourited.php
@@ -41,7 +41,7 @@ class Favourited extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Filters.php
+++ b/src/Module/Api/Mastodon/Filters.php
@@ -33,7 +33,7 @@ class Filters extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 
 		$this->response->unsupported(Router::POST, $request);
 	}
@@ -43,7 +43,7 @@ class Filters extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 
 		$this->jsonExit([]);
 	}

--- a/src/Module/Api/Mastodon/FollowRequests.php
+++ b/src/Module/Api/Mastodon/FollowRequests.php
@@ -44,7 +44,7 @@ class FollowRequests extends BaseApi
 	 */
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_FOLLOW);
+		$this->checkAllowedScope(self::SCOPE_FOLLOW);
 		$uid = self::getCurrentUserID();
 
 		$cdata = Contact::getPublicAndUserContactID($this->parameters['id'], $uid);
@@ -89,7 +89,7 @@ class FollowRequests extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/FollowedTags.php
+++ b/src/Module/Api/Mastodon/FollowedTags.php
@@ -32,7 +32,7 @@ class FollowedTags extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Instance.php
+++ b/src/Module/Api/Mastodon/Instance.php
@@ -43,9 +43,9 @@ class Instance extends BaseApi
 	/** @var IManageConfigValues */
 	private $config;
 
-	public function __construct(App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, Database $database, IManageConfigValues $config, array $server, array $parameters = [])
+	public function __construct(\Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, Database $database, IManageConfigValues $config, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->database = $database;
 		$this->config = $config;

--- a/src/Module/Api/Mastodon/InstanceV2.php
+++ b/src/Module/Api/Mastodon/InstanceV2.php
@@ -54,6 +54,7 @@ class InstanceV2 extends BaseApi
 	private $contactHeader;
 
 	public function __construct(
+		\Friendica\Factory\Api\Mastodon\Error $errorFactory,
 		App $app,
 		L10n $l10n,
 		App\BaseURL $baseUrl,
@@ -66,7 +67,7 @@ class InstanceV2 extends BaseApi
 		array $server,
 		array $parameters = []
 	) {
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->database      = $database;
 		$this->config        = $config;

--- a/src/Module/Api/Mastodon/Lists.php
+++ b/src/Module/Api/Mastodon/Lists.php
@@ -37,15 +37,15 @@ class Lists extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!Circle::exists($this->parameters['id'], $uid)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if (!Circle::remove($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(500, $this->errorFactory->InternalError());
+			$this->logAndJsonError(500, $this->errorFactory->InternalError());
 		}
 
 		$this->jsonExit([]);
@@ -61,14 +61,14 @@ class Lists extends BaseApi
 		], $request);
 
 		if (empty($request['title'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Circle::create($uid, $request['title']);
 
 		$id = Circle::getIdByName($uid, $request['title']);
 		if (!$id) {
-			$this->logErrorAndJsonExit(500, $this->errorFactory->InternalError());
+			$this->logAndJsonError(500, $this->errorFactory->InternalError());
 		}
 
 		$this->jsonExit(DI::mstdnList()->createFromCircleId($id));
@@ -82,7 +82,7 @@ class Lists extends BaseApi
 		], $request);
 
 		if (empty($request['title']) || empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Circle::update($this->parameters['id'], $request['title']);
@@ -106,7 +106,7 @@ class Lists extends BaseApi
 			$id = $this->parameters['id'];
 
 			if (!Circle::exists($id, $uid)) {
-				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 			$lists = DI::mstdnList()->createFromCircleId($id);
 		}

--- a/src/Module/Api/Mastodon/Lists.php
+++ b/src/Module/Api/Mastodon/Lists.php
@@ -33,7 +33,7 @@ class Lists extends BaseApi
 {
 	protected function delete(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
@@ -53,7 +53,7 @@ class Lists extends BaseApi
 
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([
@@ -93,7 +93,7 @@ class Lists extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Lists.php
+++ b/src/Module/Api/Mastodon/Lists.php
@@ -37,7 +37,7 @@ class Lists extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!Circle::exists($this->parameters['id'], $uid)) {
@@ -61,7 +61,7 @@ class Lists extends BaseApi
 		], $request);
 
 		if (empty($request['title'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Circle::create($uid, $request['title']);
@@ -82,7 +82,7 @@ class Lists extends BaseApi
 		], $request);
 
 		if (empty($request['title']) || empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Circle::update($this->parameters['id'], $request['title']);

--- a/src/Module/Api/Mastodon/Lists.php
+++ b/src/Module/Api/Mastodon/Lists.php
@@ -45,7 +45,7 @@ class Lists extends BaseApi
 		}
 
 		if (!Circle::remove($this->parameters['id'])) {
-			DI::mstdnError()->InternalError();
+			$this->logErrorAndJsonExit(500, $this->errorFactory->InternalError());
 		}
 
 		$this->jsonExit([]);
@@ -68,7 +68,7 @@ class Lists extends BaseApi
 
 		$id = Circle::getIdByName($uid, $request['title']);
 		if (!$id) {
-			DI::mstdnError()->InternalError();
+			$this->logErrorAndJsonExit(500, $this->errorFactory->InternalError());
 		}
 
 		$this->jsonExit(DI::mstdnList()->createFromCircleId($id));

--- a/src/Module/Api/Mastodon/Lists.php
+++ b/src/Module/Api/Mastodon/Lists.php
@@ -41,7 +41,7 @@ class Lists extends BaseApi
 		}
 
 		if (!Circle::exists($this->parameters['id'], $uid)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if (!Circle::remove($this->parameters['id'])) {
@@ -106,7 +106,7 @@ class Lists extends BaseApi
 			$id = $this->parameters['id'];
 
 			if (!Circle::exists($id, $uid)) {
-				DI::mstdnError()->RecordNotFound();
+				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 			$lists = DI::mstdnList()->createFromCircleId($id);
 		}

--- a/src/Module/Api/Mastodon/Lists/Accounts.php
+++ b/src/Module/Api/Mastodon/Lists/Accounts.php
@@ -43,7 +43,7 @@ class Accounts extends BaseApi
 		], $request);
 
 		if (empty($request['account_ids']) || empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		return Circle::removeMembers($this->parameters['id'], $request['account_ids']);
@@ -58,7 +58,7 @@ class Accounts extends BaseApi
 		], $request);
 
 		if (empty($request['account_ids']) || empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Circle::addMembers($this->parameters['id'], $request['account_ids']);
@@ -73,7 +73,7 @@ class Accounts extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];

--- a/src/Module/Api/Mastodon/Lists/Accounts.php
+++ b/src/Module/Api/Mastodon/Lists/Accounts.php
@@ -78,7 +78,7 @@ class Accounts extends BaseApi
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('group', ['id' => $id, 'uid' => $uid])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Lists/Accounts.php
+++ b/src/Module/Api/Mastodon/Lists/Accounts.php
@@ -43,7 +43,7 @@ class Accounts extends BaseApi
 		], $request);
 
 		if (empty($request['account_ids']) || empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		return Circle::removeMembers($this->parameters['id'], $request['account_ids']);
@@ -58,7 +58,7 @@ class Accounts extends BaseApi
 		], $request);
 
 		if (empty($request['account_ids']) || empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Circle::addMembers($this->parameters['id'], $request['account_ids']);
@@ -73,12 +73,12 @@ class Accounts extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('group', ['id' => $id, 'uid' => $uid])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Lists/Accounts.php
+++ b/src/Module/Api/Mastodon/Lists/Accounts.php
@@ -36,7 +36,7 @@ class Accounts extends BaseApi
 {
 	protected function delete(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 
 		$request = $this->getRequest([
 			'account_ids' => [], // Array of account IDs to remove from the list
@@ -51,7 +51,7 @@ class Accounts extends BaseApi
 
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 
 		$request = $this->getRequest([
 			'account_ids' =>  [], // Array of account IDs to add to the list
@@ -69,7 +69,7 @@ class Accounts extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Markers.php
+++ b/src/Module/Api/Mastodon/Markers.php
@@ -34,7 +34,7 @@ class Markers extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid         = self::getCurrentUserID();
 		$application = self::getCurrentApplication();
 
@@ -69,7 +69,7 @@ class Markers extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid         = self::getCurrentUserID();
 		$application = self::getCurrentApplication();
 

--- a/src/Module/Api/Mastodon/Markers.php
+++ b/src/Module/Api/Mastodon/Markers.php
@@ -48,7 +48,7 @@ class Markers extends BaseApi
 		}
 
 		if (empty($timeline) || empty($last_read_id) || empty($application['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$condition = ['application-id' => $application['id'], 'uid' => $uid, 'timeline' => $timeline];

--- a/src/Module/Api/Mastodon/Markers.php
+++ b/src/Module/Api/Mastodon/Markers.php
@@ -48,7 +48,7 @@ class Markers extends BaseApi
 		}
 
 		if (empty($timeline) || empty($last_read_id) || empty($application['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$condition = ['application-id' => $application['id'], 'uid' => $uid, 'timeline' => $timeline];

--- a/src/Module/Api/Mastodon/Media.php
+++ b/src/Module/Api/Mastodon/Media.php
@@ -48,12 +48,12 @@ class Media extends BaseApi
 		Logger::info('Photo post', ['request' => $request, 'files' => $_FILES]);
 
 		if (empty($_FILES['file'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$media = Photo::upload($uid, $_FILES['file'], '', null, null, '', '', $request['description']);
 		if (empty($media)) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Logger::info('Uploaded photo', ['media' => $media]);
@@ -74,7 +74,7 @@ class Media extends BaseApi
 		], $request);
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$photo = Photo::selectFirst(['resource-id'], ['id' => $this->parameters['id'], 'uid' => $uid]);
@@ -104,7 +104,7 @@ class Media extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];

--- a/src/Module/Api/Mastodon/Media.php
+++ b/src/Module/Api/Mastodon/Media.php
@@ -48,12 +48,12 @@ class Media extends BaseApi
 		Logger::info('Photo post', ['request' => $request, 'files' => $_FILES]);
 
 		if (empty($_FILES['file'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$media = Photo::upload($uid, $_FILES['file'], '', null, null, '', '', $request['description']);
 		if (empty($media)) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		Logger::info('Uploaded photo', ['media' => $media]);
@@ -74,17 +74,17 @@ class Media extends BaseApi
 		], $request);
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$photo = Photo::selectFirst(['resource-id'], ['id' => $this->parameters['id'], 'uid' => $uid]);
 		if (empty($photo['resource-id'])) {
 			$media = Post\Media::getById($this->parameters['id']);
 			if (empty($media['uri-id'])) {
-				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 			if (!Post::exists(['uri-id' => $media['uri-id'], 'uid' => $uid, 'origin' => true])) {
-				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 			Post\Media::updateById(['description' => $request['description']], $this->parameters['id']);
 			$this->jsonExit(DI::mstdnAttachment()->createFromId($this->parameters['id']));
@@ -104,12 +104,12 @@ class Media extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];
 		if (!Photo::exists(['id' => $id, 'uid' => $uid])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$this->jsonExit(DI::mstdnAttachment()->createFromPhoto($id));

--- a/src/Module/Api/Mastodon/Media.php
+++ b/src/Module/Api/Mastodon/Media.php
@@ -81,10 +81,10 @@ class Media extends BaseApi
 		if (empty($photo['resource-id'])) {
 			$media = Post\Media::getById($this->parameters['id']);
 			if (empty($media['uri-id'])) {
-				DI::mstdnError()->RecordNotFound();
+				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 			if (!Post::exists(['uri-id' => $media['uri-id'], 'uid' => $uid, 'origin' => true])) {
-				DI::mstdnError()->RecordNotFound();
+				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 			Post\Media::updateById(['description' => $request['description']], $this->parameters['id']);
 			$this->jsonExit(DI::mstdnAttachment()->createFromId($this->parameters['id']));
@@ -109,7 +109,7 @@ class Media extends BaseApi
 
 		$id = $this->parameters['id'];
 		if (!Photo::exists(['id' => $id, 'uid' => $uid])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$this->jsonExit(DI::mstdnAttachment()->createFromPhoto($id));

--- a/src/Module/Api/Mastodon/Media.php
+++ b/src/Module/Api/Mastodon/Media.php
@@ -35,7 +35,7 @@ class Media extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([
@@ -63,7 +63,7 @@ class Media extends BaseApi
 
 	public function put(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([
@@ -100,7 +100,7 @@ class Media extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Mutes.php
+++ b/src/Module/Api/Mastodon/Mutes.php
@@ -36,7 +36,7 @@ class Mutes extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Mutes.php
+++ b/src/Module/Api/Mastodon/Mutes.php
@@ -40,12 +40,12 @@ class Mutes extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Mutes.php
+++ b/src/Module/Api/Mastodon/Mutes.php
@@ -40,7 +40,7 @@ class Mutes extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];

--- a/src/Module/Api/Mastodon/Mutes.php
+++ b/src/Module/Api/Mastodon/Mutes.php
@@ -45,7 +45,7 @@ class Mutes extends BaseApi
 
 		$id = $this->parameters['id'];
 		if (!DBA::exists('contact', ['id' => $id, 'uid' => 0])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -41,7 +41,7 @@ class Notifications extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (!empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -50,7 +50,7 @@ class Notifications extends BaseApi
 				$notification = DI::notification()->selectOneForUser($uid, ['id' => $id]);
 				$this->jsonExit(DI::mstdnNotification()->createFromNotification($notification, self::appSupportsQuotes()));
 			} catch (\Exception $e) {
-				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 		}
 

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -50,7 +50,7 @@ class Notifications extends BaseApi
 				$notification = DI::notification()->selectOneForUser($uid, ['id' => $id]);
 				$this->jsonExit(DI::mstdnNotification()->createFromNotification($notification, self::appSupportsQuotes()));
 			} catch (\Exception $e) {
-				DI::mstdnError()->RecordNotFound();
+				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 		}
 

--- a/src/Module/Api/Mastodon/Notifications/Clear.php
+++ b/src/Module/Api/Mastodon/Notifications/Clear.php
@@ -32,7 +32,7 @@ class Clear extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		DI::notification()->setAllDismissedForUser($uid);

--- a/src/Module/Api/Mastodon/Notifications/Dismiss.php
+++ b/src/Module/Api/Mastodon/Notifications/Dismiss.php
@@ -34,7 +34,7 @@ class Dismiss extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Notifications/Dismiss.php
+++ b/src/Module/Api/Mastodon/Notifications/Dismiss.php
@@ -38,7 +38,7 @@ class Dismiss extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$condition = ['id' => $this->parameters['id']];

--- a/src/Module/Api/Mastodon/Notifications/Dismiss.php
+++ b/src/Module/Api/Mastodon/Notifications/Dismiss.php
@@ -38,7 +38,7 @@ class Dismiss extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$condition = ['id' => $this->parameters['id']];

--- a/src/Module/Api/Mastodon/Polls.php
+++ b/src/Module/Api/Mastodon/Polls.php
@@ -39,7 +39,7 @@ class Polls extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$this->jsonExit(DI::mstdnPoll()->createFromId($this->parameters['id'], $uid));

--- a/src/Module/Api/Mastodon/Polls.php
+++ b/src/Module/Api/Mastodon/Polls.php
@@ -39,7 +39,7 @@ class Polls extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$this->jsonExit(DI::mstdnPoll()->createFromId($this->parameters['id'], $uid));

--- a/src/Module/Api/Mastodon/Preferences.php
+++ b/src/Module/Api/Mastodon/Preferences.php
@@ -36,7 +36,7 @@ class Preferences extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$user = User::getById($uid, ['language', 'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']);

--- a/src/Module/Api/Mastodon/PushSubscription.php
+++ b/src/Module/Api/Mastodon/PushSubscription.php
@@ -94,7 +94,7 @@ class PushSubscription extends BaseApi
 		$subscription = Subscription::select($application['id'], $uid, ['id']);
 		if (empty($subscription)) {
 			$this->logger->info('Subscription not found', ['application-id' => $application['id'], 'uid' => $uid]);
-			$this->errorFactory->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$fields = [
@@ -145,7 +145,7 @@ class PushSubscription extends BaseApi
 
 		if (!Subscription::exists($application['id'], $uid)) {
 			$this->logger->info('Subscription not found', ['application-id' => $application['id'], 'uid' => $uid]);
-			$this->errorFactory->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$this->logger->info('Fetch subscription', ['application-id' => $application['id'], 'uid' => $uid]);

--- a/src/Module/Api/Mastodon/PushSubscription.php
+++ b/src/Module/Api/Mastodon/PushSubscription.php
@@ -49,7 +49,7 @@ class PushSubscription extends BaseApi
 
 	protected function post(array $request = []): void
 	{
-		self::checkAllowedScope(self::SCOPE_PUSH);
+		$this->checkAllowedScope(self::SCOPE_PUSH);
 		$uid         = self::getCurrentUserID();
 		$application = self::getCurrentApplication();
 
@@ -83,7 +83,7 @@ class PushSubscription extends BaseApi
 
 	public function put(array $request = []): void
 	{
-		self::checkAllowedScope(self::SCOPE_PUSH);
+		$this->checkAllowedScope(self::SCOPE_PUSH);
 		$uid         = self::getCurrentUserID();
 		$application = self::getCurrentApplication();
 
@@ -122,7 +122,7 @@ class PushSubscription extends BaseApi
 
 	protected function delete(array $request = []): void
 	{
-		self::checkAllowedScope(self::SCOPE_PUSH);
+		$this->checkAllowedScope(self::SCOPE_PUSH);
 		$uid         = self::getCurrentUserID();
 		$application = self::getCurrentApplication();
 
@@ -139,7 +139,7 @@ class PushSubscription extends BaseApi
 
 	protected function rawContent(array $request = []): void
 	{
-		self::checkAllowedScope(self::SCOPE_PUSH);
+		$this->checkAllowedScope(self::SCOPE_PUSH);
 		$uid         = self::getCurrentUserID();
 		$application = self::getCurrentApplication();
 

--- a/src/Module/Api/Mastodon/PushSubscription.php
+++ b/src/Module/Api/Mastodon/PushSubscription.php
@@ -39,15 +39,12 @@ class PushSubscription extends BaseApi
 {
 	/** @var SubscriptionFactory */
 	protected $subscriptionFac;
-	/** @var Error */
-	protected $errorFac;
 
-	public function __construct(App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, SubscriptionFactory $subscriptionFac, Error $errorFac, array $server, array $parameters = [])
+	public function __construct(\Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, SubscriptionFactory $subscriptionFac, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->subscriptionFac = $subscriptionFac;
-		$this->errorFac        = $errorFac;
 	}
 
 	protected function post(array $request = []): void
@@ -97,7 +94,7 @@ class PushSubscription extends BaseApi
 		$subscription = Subscription::select($application['id'], $uid, ['id']);
 		if (empty($subscription)) {
 			$this->logger->info('Subscription not found', ['application-id' => $application['id'], 'uid' => $uid]);
-			$this->errorFac->RecordNotFound();
+			$this->errorFactory->RecordNotFound();
 		}
 
 		$fields = [
@@ -148,7 +145,7 @@ class PushSubscription extends BaseApi
 
 		if (!Subscription::exists($application['id'], $uid)) {
 			$this->logger->info('Subscription not found', ['application-id' => $application['id'], 'uid' => $uid]);
-			$this->errorFac->RecordNotFound();
+			$this->errorFactory->RecordNotFound();
 		}
 
 		$this->logger->info('Fetch subscription', ['application-id' => $application['id'], 'uid' => $uid]);

--- a/src/Module/Api/Mastodon/PushSubscription.php
+++ b/src/Module/Api/Mastodon/PushSubscription.php
@@ -94,7 +94,7 @@ class PushSubscription extends BaseApi
 		$subscription = Subscription::select($application['id'], $uid, ['id']);
 		if (empty($subscription)) {
 			$this->logger->info('Subscription not found', ['application-id' => $application['id'], 'uid' => $uid]);
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$fields = [
@@ -145,7 +145,7 @@ class PushSubscription extends BaseApi
 
 		if (!Subscription::exists($application['id'], $uid)) {
 			$this->logger->info('Subscription not found', ['application-id' => $application['id'], 'uid' => $uid]);
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$this->logger->info('Fetch subscription', ['application-id' => $application['id'], 'uid' => $uid]);

--- a/src/Module/Api/Mastodon/Reports.php
+++ b/src/Module/Api/Mastodon/Reports.php
@@ -51,7 +51,7 @@ class Reports extends BaseApi
 
 	public function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 
 		$request = $this->getRequest([
 			'account_id' => '',      // ID of the account to report

--- a/src/Module/Api/Mastodon/Reports.php
+++ b/src/Module/Api/Mastodon/Reports.php
@@ -41,9 +41,9 @@ class Reports extends BaseApi
 	/** @var \Friendica\Moderation\Repository\Report */
 	private $reportRepo;
 
-	public function __construct(\Friendica\Moderation\Repository\Report $reportRepo, \Friendica\Moderation\Factory\Report $reportFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(\Friendica\Moderation\Repository\Report $reportRepo, \Friendica\Moderation\Factory\Report $reportFactory, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->reportFactory = $reportFactory;
 		$this->reportRepo    = $reportRepo;

--- a/src/Module/Api/Mastodon/ScheduledStatuses.php
+++ b/src/Module/Api/Mastodon/ScheduledStatuses.php
@@ -35,7 +35,7 @@ class ScheduledStatuses extends BaseApi
 {
 	public function put(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$this->response->unsupported(Router::PUT, $request);
@@ -43,7 +43,7 @@ class ScheduledStatuses extends BaseApi
 
 	protected function delete(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
@@ -64,7 +64,7 @@ class ScheduledStatuses extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (isset($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/ScheduledStatuses.php
+++ b/src/Module/Api/Mastodon/ScheduledStatuses.php
@@ -47,7 +47,7 @@ class ScheduledStatuses extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!DBA::exists('delayed-post', ['id' => $this->parameters['id'], 'uid' => $uid])) {

--- a/src/Module/Api/Mastodon/ScheduledStatuses.php
+++ b/src/Module/Api/Mastodon/ScheduledStatuses.php
@@ -47,11 +47,11 @@ class ScheduledStatuses extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!DBA::exists('delayed-post', ['id' => $this->parameters['id'], 'uid' => $uid])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Post\Delayed::deleteById($this->parameters['id']);

--- a/src/Module/Api/Mastodon/ScheduledStatuses.php
+++ b/src/Module/Api/Mastodon/ScheduledStatuses.php
@@ -51,7 +51,7 @@ class ScheduledStatuses extends BaseApi
 		}
 
 		if (!DBA::exists('delayed-post', ['id' => $this->parameters['id'], 'uid' => $uid])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Post\Delayed::deleteById($this->parameters['id']);

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -60,7 +60,7 @@ class Search extends BaseApi
 		], $request);
 
 		if (empty($request['q'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$limit = min($request['limit'], 40);

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -43,7 +43,7 @@ class Search extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -60,7 +60,7 @@ class Search extends BaseApi
 		], $request);
 
 		if (empty($request['q'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$limit = min($request['limit'], 40);

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -297,7 +297,7 @@ class Statuses extends BaseApi
 			$item['uri'] = Item::newURI($item['guid']);
 			$id = Post\Delayed::add($item['uri'], $item, Worker::PRIORITY_HIGH, Post\Delayed::PREPARED, DateTimeFormat::utc($request['scheduled_at']));
 			if (empty($id)) {
-				DI::mstdnError()->InternalError();
+				$this->logErrorAndJsonExit(500, $this->errorFactory->InternalError());
 			}
 			$this->jsonExit(DI::mstdnScheduledStatus()->createFromDelayedPostId($id, $uid)->toArray());
 		}
@@ -310,7 +310,7 @@ class Statuses extends BaseApi
 			}
 		}
 
-		DI::mstdnError()->InternalError();
+		$this->logErrorAndJsonExit(500, $this->errorFactory->InternalError());
 	}
 
 	protected function delete(array $request = [])

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -49,7 +49,7 @@ class Statuses extends BaseApi
 {
 	public function put(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([
@@ -164,7 +164,7 @@ class Statuses extends BaseApi
 
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([
@@ -315,7 +315,7 @@ class Statuses extends BaseApi
 
 	protected function delete(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -319,7 +319,7 @@ class Statuses extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => $uid]);
@@ -342,7 +342,7 @@ class Statuses extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), false));

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -297,7 +297,7 @@ class Statuses extends BaseApi
 			$item['uri'] = Item::newURI($item['guid']);
 			$id = Post\Delayed::add($item['uri'], $item, Worker::PRIORITY_HIGH, Post\Delayed::PREPARED, DateTimeFormat::utc($request['scheduled_at']));
 			if (empty($id)) {
-				$this->logErrorAndJsonExit(500, $this->errorFactory->InternalError());
+				$this->logAndJsonError(500, $this->errorFactory->InternalError());
 			}
 			$this->jsonExit(DI::mstdnScheduledStatus()->createFromDelayedPostId($id, $uid)->toArray());
 		}
@@ -310,7 +310,7 @@ class Statuses extends BaseApi
 			}
 		}
 
-		$this->logErrorAndJsonExit(500, $this->errorFactory->InternalError());
+		$this->logAndJsonError(500, $this->errorFactory->InternalError());
 	}
 
 	protected function delete(array $request = [])
@@ -319,16 +319,16 @@ class Statuses extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => $uid]);
 		if (empty($item['id'])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if (!Item::markForDeletionById($item['id'])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$this->jsonExit([]);
@@ -342,7 +342,7 @@ class Statuses extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), false));

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -324,11 +324,11 @@ class Statuses extends BaseApi
 
 		$item = Post::selectFirstForUser($uid, ['id'], ['uri-id' => $this->parameters['id'], 'uid' => $uid]);
 		if (empty($item['id'])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if (!Item::markForDeletionById($item['id'])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$this->jsonExit([]);

--- a/src/Module/Api/Mastodon/Statuses/Bookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Bookmark.php
@@ -39,7 +39,7 @@ class Bookmark extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginal(['uid', 'id', 'uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]], ['order' => ['uid' => true]]);
@@ -48,7 +48,7 @@ class Bookmark extends BaseApi
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {
-			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t('Only starting posts can be bookmarked'));
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be bookmarked')));
 		}
 
 		if ($item['uid'] == 0) {

--- a/src/Module/Api/Mastodon/Statuses/Bookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Bookmark.php
@@ -39,16 +39,16 @@ class Bookmark extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginal(['uid', 'id', 'uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]], ['order' => ['uid' => true]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be bookmarked')));
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be bookmarked')));
 		}
 
 		if ($item['uid'] == 0) {
@@ -56,10 +56,10 @@ class Bookmark extends BaseApi
 			if (!empty($stored)) {
 				$item = Post::selectFirst(['id', 'gravity'], ['id' => $stored]);
 				if (!DBA::isResult($item)) {
-					$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+					$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 				}
 			} else {
-				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 		}
 

--- a/src/Module/Api/Mastodon/Statuses/Bookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Bookmark.php
@@ -44,7 +44,7 @@ class Bookmark extends BaseApi
 
 		$item = Post::selectOriginal(['uid', 'id', 'uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]], ['order' => ['uid' => true]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {
@@ -56,10 +56,10 @@ class Bookmark extends BaseApi
 			if (!empty($stored)) {
 				$item = Post::selectFirst(['id', 'gravity'], ['id' => $stored]);
 				if (!DBA::isResult($item)) {
-					DI::mstdnError()->RecordNotFound();
+					$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 				}
 			} else {
-				DI::mstdnError()->RecordNotFound();
+				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 		}
 

--- a/src/Module/Api/Mastodon/Statuses/Bookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Bookmark.php
@@ -35,7 +35,7 @@ class Bookmark extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Card.php
+++ b/src/Module/Api/Mastodon/Statuses/Card.php
@@ -40,7 +40,7 @@ class Card extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!$post = Post::selectOriginal(['uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [0, $uid]])) {

--- a/src/Module/Api/Mastodon/Statuses/Card.php
+++ b/src/Module/Api/Mastodon/Statuses/Card.php
@@ -40,7 +40,7 @@ class Card extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!$post = Post::selectOriginal(['uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [0, $uid]])) {

--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -41,7 +41,7 @@ class Context extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -116,7 +116,7 @@ class Context extends BaseApi
 				}
 				DBA::close($posts);
 			} else {
-				DI::mstdnError()->RecordNotFound();
+				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 		}
 

--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -41,7 +41,7 @@ class Context extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$request = $this->getRequest([
@@ -116,7 +116,7 @@ class Context extends BaseApi
 				}
 				DBA::close($posts);
 			} else {
-				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 		}
 

--- a/src/Module/Api/Mastodon/Statuses/Favourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Favourite.php
@@ -35,7 +35,7 @@ class Favourite extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Favourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Favourite.php
@@ -39,12 +39,12 @@ class Favourite extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['id', 'uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Item::performActivity($item['id'], 'like', $uid);

--- a/src/Module/Api/Mastodon/Statuses/Favourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Favourite.php
@@ -39,7 +39,7 @@ class Favourite extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['id', 'uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);

--- a/src/Module/Api/Mastodon/Statuses/Favourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Favourite.php
@@ -44,7 +44,7 @@ class Favourite extends BaseApi
 
 		$item = Post::selectOriginalForUser($uid, ['id', 'uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Item::performActivity($item['id'], 'like', $uid);

--- a/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
@@ -45,7 +45,7 @@ class FavouritedBy extends BaseApi
 		}
 
 		if (!$post = Post::selectOriginal(['uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [0, $uid]])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $post['uri-id'], 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::LIKE, 'deleted' => false]);

--- a/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
@@ -41,7 +41,7 @@ class FavouritedBy extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!$post = Post::selectOriginal(['uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [0, $uid]])) {

--- a/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
@@ -41,11 +41,11 @@ class FavouritedBy extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!$post = Post::selectOriginal(['uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [0, $uid]])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $post['uri-id'], 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::LIKE, 'deleted' => false]);

--- a/src/Module/Api/Mastodon/Statuses/Mute.php
+++ b/src/Module/Api/Mastodon/Statuses/Mute.php
@@ -44,7 +44,7 @@ class Mute extends BaseApi
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {

--- a/src/Module/Api/Mastodon/Statuses/Mute.php
+++ b/src/Module/Api/Mastodon/Statuses/Mute.php
@@ -35,7 +35,7 @@ class Mute extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Mute.php
+++ b/src/Module/Api/Mastodon/Statuses/Mute.php
@@ -39,7 +39,7 @@ class Mute extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
@@ -48,7 +48,7 @@ class Mute extends BaseApi
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {
-			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t('Only starting posts can be muted'));
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be muted')));
 		}
 
 		Post\ThreadUser::setIgnored($item['uri-id'], $uid, true);

--- a/src/Module/Api/Mastodon/Statuses/Mute.php
+++ b/src/Module/Api/Mastodon/Statuses/Mute.php
@@ -39,16 +39,16 @@ class Mute extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be muted')));
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be muted')));
 		}
 
 		Post\ThreadUser::setIgnored($item['uri-id'], $uid, true);

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -43,7 +43,7 @@ class Pin extends BaseApi
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity', 'author-id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Post\Collection::add($item['uri-id'], Post\Collection::FEATURED, $item['author-id'], $uid);

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -34,7 +34,7 @@ class Pin extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -38,12 +38,12 @@ class Pin extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity', 'author-id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Post\Collection::add($item['uri-id'], Post\Collection::FEATURED, $item['author-id'], $uid);

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -38,7 +38,7 @@ class Pin extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity', 'author-id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);

--- a/src/Module/Api/Mastodon/Statuses/Reblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Reblog.php
@@ -42,18 +42,18 @@ class Reblog extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['id', 'uri-id', 'network'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['network'] == Protocol::DIASPORA) {
 			Diaspora::performReshare($this->parameters['id'], $uid);
 		} elseif (!in_array($item['network'], [Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::TWITTER])) {
-			$this->logErrorAndJsonExit(
+			$this->logAndJsonError(
 				422,
 				$this->errorFactory->UnprocessableEntity($this->t("Posts from %s can't be shared", ContactSelector::networkToName($item['network'])))
 			);

--- a/src/Module/Api/Mastodon/Statuses/Reblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Reblog.php
@@ -38,7 +38,7 @@ class Reblog extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Reblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Reblog.php
@@ -47,7 +47,7 @@ class Reblog extends BaseApi
 
 		$item = Post::selectOriginalForUser($uid, ['id', 'uri-id', 'network'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['network'] == Protocol::DIASPORA) {

--- a/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
@@ -41,7 +41,7 @@ class RebloggedBy extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!$post = Post::selectOriginal(['uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [0, $uid]])) {

--- a/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
@@ -45,7 +45,7 @@ class RebloggedBy extends BaseApi
 		}
 
 		if (!$post = Post::selectOriginal(['uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [0, $uid]])) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $post['uri-id'], 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::ANNOUNCE]);

--- a/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
@@ -41,11 +41,11 @@ class RebloggedBy extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if (!$post = Post::selectOriginal(['uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [0, $uid]])) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		$activities = Post::selectPosts(['author-id'], ['thr-parent-id' => $post['uri-id'], 'gravity' => Item::GRAVITY_ACTIVITY, 'verb' => Activity::ANNOUNCE]);

--- a/src/Module/Api/Mastodon/Statuses/Source.php
+++ b/src/Module/Api/Mastodon/Statuses/Source.php
@@ -41,7 +41,7 @@ class Source extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];

--- a/src/Module/Api/Mastodon/Statuses/Source.php
+++ b/src/Module/Api/Mastodon/Statuses/Source.php
@@ -41,7 +41,7 @@ class Source extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$id = $this->parameters['id'];

--- a/src/Module/Api/Mastodon/Statuses/Source.php
+++ b/src/Module/Api/Mastodon/Statuses/Source.php
@@ -37,7 +37,7 @@ class Source extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Unbookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Unbookmark.php
@@ -35,7 +35,7 @@ class Unbookmark extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Unbookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Unbookmark.php
@@ -44,7 +44,7 @@ class Unbookmark extends BaseApi
 
 		$item = Post::selectOriginal(['uid', 'id', 'uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]], ['order' => ['uid' => true]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {
@@ -56,10 +56,10 @@ class Unbookmark extends BaseApi
 			if (!empty($stored)) {
 				$item = Post::selectFirst(['id', 'gravity'], ['id' => $stored]);
 				if (!DBA::isResult($item)) {
-					DI::mstdnError()->RecordNotFound();
+					$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 				}
 			} else {
-				DI::mstdnError()->RecordNotFound();
+				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 		}
 

--- a/src/Module/Api/Mastodon/Statuses/Unbookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Unbookmark.php
@@ -39,7 +39,7 @@ class Unbookmark extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginal(['uid', 'id', 'uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]], ['order' => ['uid' => true]]);
@@ -48,7 +48,7 @@ class Unbookmark extends BaseApi
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {
-			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t('Only starting posts can be unbookmarked'));
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be unbookmarked')));
 		}
 
 		if ($item['uid'] == 0) {

--- a/src/Module/Api/Mastodon/Statuses/Unbookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Unbookmark.php
@@ -39,16 +39,16 @@ class Unbookmark extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginal(['uid', 'id', 'uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]], ['order' => ['uid' => true]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be unbookmarked')));
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be unbookmarked')));
 		}
 
 		if ($item['uid'] == 0) {
@@ -56,10 +56,10 @@ class Unbookmark extends BaseApi
 			if (!empty($stored)) {
 				$item = Post::selectFirst(['id', 'gravity'], ['id' => $stored]);
 				if (!DBA::isResult($item)) {
-					$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+					$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 				}
 			} else {
-				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 		}
 

--- a/src/Module/Api/Mastodon/Statuses/Unfavourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Unfavourite.php
@@ -39,12 +39,12 @@ class Unfavourite extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['id', 'uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Item::performActivity($item['id'], 'unlike', $uid);

--- a/src/Module/Api/Mastodon/Statuses/Unfavourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Unfavourite.php
@@ -44,7 +44,7 @@ class Unfavourite extends BaseApi
 
 		$item = Post::selectOriginalForUser($uid, ['id', 'uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Item::performActivity($item['id'], 'unlike', $uid);

--- a/src/Module/Api/Mastodon/Statuses/Unfavourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Unfavourite.php
@@ -39,7 +39,7 @@ class Unfavourite extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['id', 'uri-id'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);

--- a/src/Module/Api/Mastodon/Statuses/Unfavourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Unfavourite.php
@@ -35,7 +35,7 @@ class Unfavourite extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Unmute.php
+++ b/src/Module/Api/Mastodon/Statuses/Unmute.php
@@ -35,7 +35,7 @@ class Unmute extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Unmute.php
+++ b/src/Module/Api/Mastodon/Statuses/Unmute.php
@@ -39,7 +39,7 @@ class Unmute extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
@@ -48,7 +48,7 @@ class Unmute extends BaseApi
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {
-			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t('Only starting posts can be unmuted'));
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be unmuted')));
 		}
 
 		Post\ThreadUser::setIgnored($item['uri-id'], $uid, false);

--- a/src/Module/Api/Mastodon/Statuses/Unmute.php
+++ b/src/Module/Api/Mastodon/Statuses/Unmute.php
@@ -39,16 +39,16 @@ class Unmute extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be unmuted')));
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity($this->t('Only starting posts can be unmuted')));
 		}
 
 		Post\ThreadUser::setIgnored($item['uri-id'], $uid, false);

--- a/src/Module/Api/Mastodon/Statuses/Unmute.php
+++ b/src/Module/Api/Mastodon/Statuses/Unmute.php
@@ -44,7 +44,7 @@ class Unmute extends BaseApi
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -34,7 +34,7 @@ class Unpin extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -38,7 +38,7 @@ class Unpin extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -43,7 +43,7 @@ class Unpin extends BaseApi
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Post\Collection::remove($item['uri-id'], Post\Collection::FEATURED, $uid);

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -38,12 +38,12 @@ class Unpin extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['uri-id', 'gravity'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		Post\Collection::remove($item['uri-id'], Post\Collection::FEATURED, $uid);

--- a/src/Module/Api/Mastodon/Statuses/Unreblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Unreblog.php
@@ -37,7 +37,7 @@ class Unreblog extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Statuses/Unreblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Unreblog.php
@@ -41,25 +41,25 @@ class Unreblog extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['id', 'uri-id', 'network'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['network'] == Protocol::DIASPORA) {
 			$item = Post::selectFirstForUser($uid, ['id'], ['quote-uri-id' => $this->parameters['id'], 'body' => '', 'origin' => true, 'uid' => $uid]);
 			if (empty($item['id'])) {
-				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 
 			if (!Item::markForDeletionById($item['id'])) {
-				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 		} elseif (!in_array($item['network'], [Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::TWITTER])) {
-			$this->logErrorAndJsonExit(
+			$this->logAndJsonError(
 				422,
 				$this->errorFactory->UnprocessableEntity($this->t("Posts from %s can't be unshared", ContactSelector::networkToName($item['network'])))
 			);

--- a/src/Module/Api/Mastodon/Statuses/Unreblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Unreblog.php
@@ -46,17 +46,17 @@ class Unreblog extends BaseApi
 
 		$item = Post::selectOriginalForUser($uid, ['id', 'uri-id', 'network'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
 		if (!DBA::isResult($item)) {
-			DI::mstdnError()->RecordNotFound();
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if ($item['network'] == Protocol::DIASPORA) {
 			$item = Post::selectFirstForUser($uid, ['id'], ['quote-uri-id' => $this->parameters['id'], 'body' => '', 'origin' => true, 'uid' => $uid]);
 			if (empty($item['id'])) {
-				DI::mstdnError()->RecordNotFound();
+				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 
 			if (!Item::markForDeletionById($item['id'])) {
-				DI::mstdnError()->RecordNotFound();
+				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 		} elseif (!in_array($item['network'], [Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::TWITTER])) {
 			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t("Posts from %s can't be unshared", ContactSelector::networkToName($item['network'])));

--- a/src/Module/Api/Mastodon/Statuses/Unreblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Unreblog.php
@@ -41,7 +41,7 @@ class Unreblog extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$item = Post::selectOriginalForUser($uid, ['id', 'uri-id', 'network'], ['uri-id' => $this->parameters['id'], 'uid' => [$uid, 0]]);
@@ -59,7 +59,10 @@ class Unreblog extends BaseApi
 				$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 			}
 		} elseif (!in_array($item['network'], [Protocol::DFRN, Protocol::ACTIVITYPUB, Protocol::TWITTER])) {
-			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t("Posts from %s can't be unshared", ContactSelector::networkToName($item['network'])));
+			$this->logErrorAndJsonExit(
+				422,
+				$this->errorFactory->UnprocessableEntity($this->t("Posts from %s can't be unshared", ContactSelector::networkToName($item['network'])))
+			);
 		} else {
 			Item::performActivity($item['id'], 'unannounce', $uid);
 		}

--- a/src/Module/Api/Mastodon/Suggestions.php
+++ b/src/Module/Api/Mastodon/Suggestions.php
@@ -36,7 +36,7 @@ class Suggestions extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Tags.php
+++ b/src/Module/Api/Mastodon/Tags.php
@@ -40,7 +40,7 @@ class Tags extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$tag       = ltrim($this->parameters['hashtag'], '#');

--- a/src/Module/Api/Mastodon/Tags.php
+++ b/src/Module/Api/Mastodon/Tags.php
@@ -36,7 +36,7 @@ class Tags extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {

--- a/src/Module/Api/Mastodon/Tags.php
+++ b/src/Module/Api/Mastodon/Tags.php
@@ -40,7 +40,7 @@ class Tags extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$tag       = ltrim($this->parameters['hashtag'], '#');

--- a/src/Module/Api/Mastodon/Tags/Follow.php
+++ b/src/Module/Api/Mastodon/Tags/Follow.php
@@ -37,7 +37,7 @@ class Follow extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$fields = ['uid' => $uid, 'term' => '#' . ltrim($this->parameters['hashtag'], '#')];

--- a/src/Module/Api/Mastodon/Tags/Follow.php
+++ b/src/Module/Api/Mastodon/Tags/Follow.php
@@ -33,7 +33,7 @@ class Follow extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {

--- a/src/Module/Api/Mastodon/Tags/Follow.php
+++ b/src/Module/Api/Mastodon/Tags/Follow.php
@@ -37,7 +37,7 @@ class Follow extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$fields = ['uid' => $uid, 'term' => '#' . ltrim($this->parameters['hashtag'], '#')];

--- a/src/Module/Api/Mastodon/Tags/Unfollow.php
+++ b/src/Module/Api/Mastodon/Tags/Unfollow.php
@@ -37,7 +37,7 @@ class Unfollow extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$term = ['uid' => $uid, 'term' => '#' . ltrim($this->parameters['hashtag'], '#')];

--- a/src/Module/Api/Mastodon/Tags/Unfollow.php
+++ b/src/Module/Api/Mastodon/Tags/Unfollow.php
@@ -33,7 +33,7 @@ class Unfollow extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {

--- a/src/Module/Api/Mastodon/Tags/Unfollow.php
+++ b/src/Module/Api/Mastodon/Tags/Unfollow.php
@@ -37,7 +37,7 @@ class Unfollow extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$term = ['uid' => $uid, 'term' => '#' . ltrim($this->parameters['hashtag'], '#')];

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -26,6 +26,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Module\BaseApi;
 use Friendica\Network\HTTPException;
+use Friendica\Network\HTTPException\NotFoundException;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/
@@ -76,9 +77,13 @@ class Direct extends BaseApi
 
 		$statuses = [];
 
-		while ($mail = DBA::fetch($mails)) {
-			self::setBoundaries($mail['uri-id']);
-			$statuses[] = DI::mstdnStatus()->createFromMailId($mail['id']);
+		try {
+			while ($mail = DBA::fetch($mails)) {
+				self::setBoundaries($mail['uri-id']);
+				$statuses[] = DI::mstdnStatus()->createFromMailId($mail['id']);
+			}
+		} catch (NotFoundException $e) {
+			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if (!empty($request['min_id'])) {

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -37,7 +37,7 @@ class Direct extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -83,7 +83,7 @@ class Direct extends BaseApi
 				$statuses[] = DI::mstdnStatus()->createFromMailId($mail['id']);
 			}
 		} catch (NotFoundException $e) {
-			$this->logErrorAndJsonExit(404, $this->errorFactory->RecordNotFound());
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
 		if (!empty($request['min_id'])) {

--- a/src/Module/Api/Mastodon/Timelines/Home.php
+++ b/src/Module/Api/Mastodon/Timelines/Home.php
@@ -41,7 +41,7 @@ class Home extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -45,7 +45,7 @@ class ListTimeline extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -41,7 +41,7 @@ class ListTimeline extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -45,7 +45,7 @@ class ListTimeline extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		$request = $this->getRequest([

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -41,7 +41,7 @@ class Tag extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -45,7 +45,7 @@ class Tag extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		/**

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -45,7 +45,7 @@ class Tag extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (empty($this->parameters['hashtag'])) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		/**

--- a/src/Module/Api/Twitter/Account/UpdateProfile.php
+++ b/src/Module/Api/Twitter/Account/UpdateProfile.php
@@ -34,7 +34,7 @@ class UpdateProfile extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		$api_user = DI::twitterUser()->createFromUserId($uid, true)->toArray();

--- a/src/Module/Api/Twitter/Account/UpdateProfileImage.php
+++ b/src/Module/Api/Twitter/Account/UpdateProfileImage.php
@@ -35,7 +35,7 @@ class UpdateProfileImage extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		// get mediadata from image or media (Twitter call api/account/update_profile_image provides image)

--- a/src/Module/Api/Twitter/Account/VerifyCredentials.php
+++ b/src/Module/Api/Twitter/Account/VerifyCredentials.php
@@ -34,7 +34,7 @@ class VerifyCredentials extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		$skip_status = $this->getRequestValue($request, 'skip_status', false);

--- a/src/Module/Api/Twitter/Blocks/Ids.php
+++ b/src/Module/Api/Twitter/Blocks/Ids.php
@@ -33,7 +33,7 @@ class Ids extends ContactEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// Expected value for user_id parameter: public/user contact id

--- a/src/Module/Api/Twitter/Blocks/Lists.php
+++ b/src/Module/Api/Twitter/Blocks/Lists.php
@@ -33,7 +33,7 @@ class Lists extends ContactEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// Expected value for user_id parameter: public/user contact id

--- a/src/Module/Api/Twitter/ContactEndpoint.php
+++ b/src/Module/Api/Twitter/ContactEndpoint.php
@@ -42,7 +42,7 @@ abstract class ContactEndpoint extends BaseApi
 	{
 		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 	}
 
 	/**

--- a/src/Module/Api/Twitter/ContactEndpoint.php
+++ b/src/Module/Api/Twitter/ContactEndpoint.php
@@ -38,9 +38,9 @@ abstract class ContactEndpoint extends BaseApi
 	const DEFAULT_COUNT = 20;
 	const MAX_COUNT = 200;
 
-	public function __construct(App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(\Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		self::checkAllowedScope(self::SCOPE_READ);
 	}

--- a/src/Module/Api/Twitter/DirectMessages/All.php
+++ b/src/Module/Api/Twitter/DirectMessages/All.php
@@ -31,7 +31,7 @@ class All extends DirectMessagesEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		$this->getMessages($request, $uid, []);

--- a/src/Module/Api/Twitter/DirectMessages/Conversation.php
+++ b/src/Module/Api/Twitter/DirectMessages/Conversation.php
@@ -31,7 +31,7 @@ class Conversation extends DirectMessagesEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		$this->getMessages($request, $uid, ["`parent-uri` = ?", $this->getRequestValue($request, 'uri', '')]);

--- a/src/Module/Api/Twitter/DirectMessages/Destroy.php
+++ b/src/Module/Api/Twitter/DirectMessages/Destroy.php
@@ -49,7 +49,7 @@ class Destroy extends BaseApi
 	}
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		$id = $this->getRequestValue($request, 'id', 0);

--- a/src/Module/Api/Twitter/DirectMessages/Destroy.php
+++ b/src/Module/Api/Twitter/DirectMessages/Destroy.php
@@ -41,9 +41,9 @@ class Destroy extends BaseApi
 	/** @var Database */
 	private $dba;
 
-	public function __construct(Database $dba, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->dba = $dba;
 	}

--- a/src/Module/Api/Twitter/DirectMessages/Inbox.php
+++ b/src/Module/Api/Twitter/DirectMessages/Inbox.php
@@ -34,7 +34,7 @@ class Inbox extends DirectMessagesEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid  = BaseApi::getCurrentUserID();
 		$pcid = Contact::getPublicIdByUserId($uid);
 

--- a/src/Module/Api/Twitter/DirectMessages/NewDM.php
+++ b/src/Module/Api/Twitter/DirectMessages/NewDM.php
@@ -46,9 +46,9 @@ class NewDM extends BaseApi
 	/** @var DirectMessage */
 	private $directMessage;
 
-	public function __construct(DirectMessage $directMessage, Database $dba, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(DirectMessage $directMessage, Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->dba           = $dba;
 		$this->directMessage = $directMessage;

--- a/src/Module/Api/Twitter/DirectMessages/NewDM.php
+++ b/src/Module/Api/Twitter/DirectMessages/NewDM.php
@@ -56,7 +56,7 @@ class NewDM extends BaseApi
 
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		if (empty($request['text']) || empty($request['screen_name']) && empty($request['user_id'])) {

--- a/src/Module/Api/Twitter/DirectMessages/Sent.php
+++ b/src/Module/Api/Twitter/DirectMessages/Sent.php
@@ -34,7 +34,7 @@ class Sent extends DirectMessagesEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid  = BaseApi::getCurrentUserID();
 		$pcid = Contact::getPublicIdByUserId($uid);
 

--- a/src/Module/Api/Twitter/DirectMessagesEndpoint.php
+++ b/src/Module/Api/Twitter/DirectMessagesEndpoint.php
@@ -40,9 +40,9 @@ abstract class DirectMessagesEndpoint extends BaseApi
 	/** @var DirectMessage */
 	private $directMessage;
 
-	public function __construct(DirectMessage $directMessage, Database $dba, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(DirectMessage $directMessage, Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->dba           = $dba;
 		$this->directMessage = $directMessage;

--- a/src/Module/Api/Twitter/Favorites.php
+++ b/src/Module/Api/Twitter/Favorites.php
@@ -38,7 +38,7 @@ class Favorites extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// in friendica starred item are private

--- a/src/Module/Api/Twitter/Favorites/Create.php
+++ b/src/Module/Api/Twitter/Favorites/Create.php
@@ -34,7 +34,7 @@ class Create extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$id = $this->getRequestValue($request, 'id', 0);

--- a/src/Module/Api/Twitter/Favorites/Destroy.php
+++ b/src/Module/Api/Twitter/Favorites/Destroy.php
@@ -34,7 +34,7 @@ class Destroy extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$id = $this->getRequestValue($request, 'id', 0);

--- a/src/Module/Api/Twitter/Followers/Ids.php
+++ b/src/Module/Api/Twitter/Followers/Ids.php
@@ -34,7 +34,7 @@ class Ids extends ContactEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// Expected value for user_id parameter: public/user contact id

--- a/src/Module/Api/Twitter/Followers/Lists.php
+++ b/src/Module/Api/Twitter/Followers/Lists.php
@@ -33,7 +33,7 @@ class Lists extends ContactEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// Expected value for user_id parameter: public/user contact id

--- a/src/Module/Api/Twitter/Friends/Ids.php
+++ b/src/Module/Api/Twitter/Friends/Ids.php
@@ -34,7 +34,7 @@ class Ids extends ContactEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// Expected value for user_id parameter: public/user contact id

--- a/src/Module/Api/Twitter/Friends/Lists.php
+++ b/src/Module/Api/Twitter/Friends/Lists.php
@@ -33,7 +33,7 @@ class Lists extends ContactEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// Expected value for user_id parameter: public/user contact id

--- a/src/Module/Api/Twitter/Friendships/Destroy.php
+++ b/src/Module/Api/Twitter/Friendships/Destroy.php
@@ -45,9 +45,9 @@ class Destroy extends ContactEndpoint
 	/** @var TwitterUser */
 	private $twitterUser;
 
-	public function __construct(App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, TwitterUser $twitterUser, array $server, array $parameters = [])
+	public function __construct(\Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, TwitterUser $twitterUser, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->twitterUser = $twitterUser;
 	}

--- a/src/Module/Api/Twitter/Friendships/Destroy.php
+++ b/src/Module/Api/Twitter/Friendships/Destroy.php
@@ -54,7 +54,7 @@ class Destroy extends ContactEndpoint
 
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		$owner = User::getOwnerDataById($uid);

--- a/src/Module/Api/Twitter/Friendships/Incoming.php
+++ b/src/Module/Api/Twitter/Friendships/Incoming.php
@@ -32,7 +32,7 @@ class Incoming extends ContactEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// Expected value for user_id parameter: public/user contact id

--- a/src/Module/Api/Twitter/Friendships/Show.php
+++ b/src/Module/Api/Twitter/Friendships/Show.php
@@ -35,7 +35,7 @@ class Show extends ContactEndpoint
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		$source_cid = BaseApi::getContactIDForSearchterm($this->getRequestValue($request, 'source_screen_name', ''), '', $this->getRequestValue($request, 'source_id', 0), $uid);

--- a/src/Module/Api/Twitter/Lists/Create.php
+++ b/src/Module/Api/Twitter/Lists/Create.php
@@ -46,9 +46,9 @@ class Create extends BaseApi
 	/** @var Database */
 	private $dba;
 
-	public function __construct(Database $dba, FriendicaCircle $friendicaCircle, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(Database $dba, FriendicaCircle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->dba             = $dba;
 		$this->friendicaCircle = $friendicaCircle;

--- a/src/Module/Api/Twitter/Lists/Create.php
+++ b/src/Module/Api/Twitter/Lists/Create.php
@@ -56,7 +56,7 @@ class Create extends BaseApi
 
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		// params

--- a/src/Module/Api/Twitter/Lists/Destroy.php
+++ b/src/Module/Api/Twitter/Lists/Destroy.php
@@ -46,9 +46,9 @@ class Destroy extends BaseApi
 	/** @var Database */
 	private $dba;
 
-	public function __construct(Database $dba, FriendicaCirle $friendicaCircle, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(Database $dba, FriendicaCirle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->dba             = $dba;
 		$this->friendicaCircle = $friendicaCircle;

--- a/src/Module/Api/Twitter/Lists/Destroy.php
+++ b/src/Module/Api/Twitter/Lists/Destroy.php
@@ -56,7 +56,7 @@ class Destroy extends BaseApi
 
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		// params

--- a/src/Module/Api/Twitter/Lists/Lists.php
+++ b/src/Module/Api/Twitter/Lists/Lists.php
@@ -33,7 +33,7 @@ class Lists extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// This is a dummy endpoint

--- a/src/Module/Api/Twitter/Lists/Ownership.php
+++ b/src/Module/Api/Twitter/Lists/Ownership.php
@@ -53,7 +53,7 @@ class Ownership extends BaseApi
 	}
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		$circles = $this->dba->select('group', [], ['deleted' => false, 'uid' => $uid, 'cid' => null]);

--- a/src/Module/Api/Twitter/Lists/Ownership.php
+++ b/src/Module/Api/Twitter/Lists/Ownership.php
@@ -44,9 +44,9 @@ class Ownership extends BaseApi
 	/** @var Database */
 	private $dba;
 
-	public function __construct(Database $dba, FriendicaCircle $friendicaCircle, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(Database $dba, FriendicaCircle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->dba             = $dba;
 		$this->friendicaCircle = $friendicaCircle;

--- a/src/Module/Api/Twitter/Lists/Statuses.php
+++ b/src/Module/Api/Twitter/Lists/Statuses.php
@@ -48,9 +48,9 @@ class Statuses extends BaseApi
 	/** @var Database */
 	private $dba;
 
-	public function __construct(Database $dba, TwitterStatus $twitterStatus, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(Database $dba, TwitterStatus $twitterStatus, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->dba           = $dba;
 		$this->twitterStatus = $twitterStatus;

--- a/src/Module/Api/Twitter/Lists/Statuses.php
+++ b/src/Module/Api/Twitter/Lists/Statuses.php
@@ -58,7 +58,7 @@ class Statuses extends BaseApi
 
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		if (empty($request['list_id'])) {

--- a/src/Module/Api/Twitter/Lists/Update.php
+++ b/src/Module/Api/Twitter/Lists/Update.php
@@ -56,7 +56,7 @@ class Update extends BaseApi
 
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		// params

--- a/src/Module/Api/Twitter/Lists/Update.php
+++ b/src/Module/Api/Twitter/Lists/Update.php
@@ -46,9 +46,9 @@ class Update extends BaseApi
 	/** @var Database */
 	private $dba;
 
-	public function __construct(Database $dba, FriendicaCircle $friendicaCircle, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(Database $dba, FriendicaCircle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
-		parent::__construct($app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->dba             = $dba;
 		$this->friendicaCircle = $friendicaCircle;

--- a/src/Module/Api/Twitter/Media/Metadata/Create.php
+++ b/src/Module/Api/Twitter/Media/Metadata/Create.php
@@ -36,7 +36,7 @@ class Create extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		$postdata = Network::postdata();

--- a/src/Module/Api/Twitter/Media/Upload.php
+++ b/src/Module/Api/Twitter/Media/Upload.php
@@ -37,7 +37,7 @@ class Upload extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_WRITE);
+		$this->checkAllowedScope(BaseApi::SCOPE_WRITE);
 		$uid = BaseApi::getCurrentUserID();
 
 		if (empty($_FILES['media'])) {

--- a/src/Module/Api/Twitter/SavedSearches.php
+++ b/src/Module/Api/Twitter/SavedSearches.php
@@ -32,7 +32,7 @@ class SavedSearches extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid = self::getCurrentUserID();
 
 		$terms = DBA::select('search', ['id', 'term'], ['uid' => $uid]);

--- a/src/Module/Api/Twitter/Search/Tweets.php
+++ b/src/Module/Api/Twitter/Search/Tweets.php
@@ -38,7 +38,7 @@ class Tweets extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		if (empty($request['q'])) {

--- a/src/Module/Api/Twitter/Statuses/Destroy.php
+++ b/src/Module/Api/Twitter/Statuses/Destroy.php
@@ -37,7 +37,7 @@ class Destroy extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		$id = $this->getRequestValue($request, 'id', 0);

--- a/src/Module/Api/Twitter/Statuses/HomeTimeline.php
+++ b/src/Module/Api/Twitter/Statuses/HomeTimeline.php
@@ -37,7 +37,7 @@ class HomeTimeline extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// get last network messages

--- a/src/Module/Api/Twitter/Statuses/Mentions.php
+++ b/src/Module/Api/Twitter/Statuses/Mentions.php
@@ -37,7 +37,7 @@ class Mentions extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// get last network messages

--- a/src/Module/Api/Twitter/Statuses/NetworkPublicTimeline.php
+++ b/src/Module/Api/Twitter/Statuses/NetworkPublicTimeline.php
@@ -35,7 +35,7 @@ class NetworkPublicTimeline extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		$count            = $this->getRequestValue($request, 'count', 20, 1, 100);

--- a/src/Module/Api/Twitter/Statuses/PublicTimeline.php
+++ b/src/Module/Api/Twitter/Statuses/PublicTimeline.php
@@ -35,7 +35,7 @@ class PublicTimeline extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		// get last network messages

--- a/src/Module/Api/Twitter/Statuses/Retweet.php
+++ b/src/Module/Api/Twitter/Statuses/Retweet.php
@@ -41,7 +41,7 @@ class Retweet extends BaseApi
 {
 	protected function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$id = $this->getRequestValue($request, 'id', 0);

--- a/src/Module/Api/Twitter/Statuses/Show.php
+++ b/src/Module/Api/Twitter/Statuses/Show.php
@@ -39,7 +39,7 @@ class Show extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		$id = $this->getRequestValue($request, 'id', 0);

--- a/src/Module/Api/Twitter/Statuses/Update.php
+++ b/src/Module/Api/Twitter/Statuses/Update.php
@@ -46,7 +46,7 @@ class Update extends BaseApi
 {
 	public function post(array $request = [])
 	{
-		self::checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();
 
 		$owner = User::getOwnerDataById($uid);

--- a/src/Module/Api/Twitter/Statuses/UserTimeline.php
+++ b/src/Module/Api/Twitter/Statuses/UserTimeline.php
@@ -38,7 +38,7 @@ class UserTimeline extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		Logger::info('api_statuses_user_timeline', ['api_user' => $uid, '_REQUEST' => $request]);

--- a/src/Module/Api/Twitter/Users/Lookup.php
+++ b/src/Module/Api/Twitter/Users/Lookup.php
@@ -34,7 +34,7 @@ class Lookup extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		$users = [];

--- a/src/Module/Api/Twitter/Users/Search.php
+++ b/src/Module/Api/Twitter/Users/Search.php
@@ -37,7 +37,7 @@ class Search extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		$userlist = [];

--- a/src/Module/Api/Twitter/Users/Show.php
+++ b/src/Module/Api/Twitter/Users/Show.php
@@ -34,7 +34,7 @@ class Show extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		BaseApi::checkAllowedScope(BaseApi::SCOPE_READ);
+		$this->checkAllowedScope(BaseApi::SCOPE_READ);
 		$uid = BaseApi::getCurrentUserID();
 
 		if (empty($this->parameters['id'])) {

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -424,17 +424,17 @@ class BaseApi extends BaseModule
 
 		if (empty($token)) {
 			$this->logger->notice('Empty application token');
-			DI::mstdnError()->Forbidden();
+			$this->logErrorAndJsonExit(403, $this->errorFactory->Forbidden());
 		}
 
 		if (!isset($token[$scope])) {
 			$this->logger->warning('The requested scope does not exist', ['scope' => $scope, 'application' => $token]);
-			DI::mstdnError()->Forbidden();
+			$this->logErrorAndJsonExit(403, $this->errorFactory->Forbidden());
 		}
 
 		if (empty($token[$scope])) {
 			$this->logger->warning('The requested scope is not allowed', ['scope' => $scope, 'application' => $token]);
-			DI::mstdnError()->Forbidden();
+			$this->logErrorAndJsonExit(403, $this->errorFactory->Forbidden());
 		}
 	}
 

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -97,7 +97,7 @@ class BaseApi extends BaseModule
 				case Router::PATCH:
 				case Router::POST:
 				case Router::PUT:
-					self::checkAllowedScope(self::SCOPE_WRITE);
+					$this->checkAllowedScope(self::SCOPE_WRITE);
 
 					if (!self::getCurrentUserID()) {
 						throw new HTTPException\ForbiddenException($this->t('Permission denied.'));
@@ -418,22 +418,22 @@ class BaseApi extends BaseModule
 	 *
 	 * @param string $scope the requested scope (read, write, follow, push)
 	 */
-	public static function checkAllowedScope(string $scope)
+	public function checkAllowedScope(string $scope)
 	{
 		$token = self::getCurrentApplication();
 
 		if (empty($token)) {
-			Logger::notice('Empty application token');
+			$this->logger->notice('Empty application token');
 			DI::mstdnError()->Forbidden();
 		}
 
 		if (!isset($token[$scope])) {
-			Logger::warning('The requested scope does not exist', ['scope' => $scope, 'application' => $token]);
+			$this->logger->warning('The requested scope does not exist', ['scope' => $scope, 'application' => $token]);
 			DI::mstdnError()->Forbidden();
 		}
 
 		if (empty($token[$scope])) {
-			Logger::warning('The requested scope is not allowed', ['scope' => $scope, 'application' => $token]);
+			$this->logger->warning('The requested scope is not allowed', ['scope' => $scope, 'application' => $token]);
 			DI::mstdnError()->Forbidden();
 		}
 	}

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -424,17 +424,17 @@ class BaseApi extends BaseModule
 
 		if (empty($token)) {
 			$this->logger->notice('Empty application token');
-			$this->logErrorAndJsonExit(403, $this->errorFactory->Forbidden());
+			$this->logAndJsonError(403, $this->errorFactory->Forbidden());
 		}
 
 		if (!isset($token[$scope])) {
 			$this->logger->warning('The requested scope does not exist', ['scope' => $scope, 'application' => $token]);
-			$this->logErrorAndJsonExit(403, $this->errorFactory->Forbidden());
+			$this->logAndJsonError(403, $this->errorFactory->Forbidden());
 		}
 
 		if (empty($token[$scope])) {
 			$this->logger->warning('The requested scope is not allowed', ['scope' => $scope, 'application' => $token]);
-			$this->logErrorAndJsonExit(403, $this->errorFactory->Forbidden());
+			$this->logAndJsonError(403, $this->errorFactory->Forbidden());
 		}
 	}
 
@@ -526,7 +526,7 @@ class BaseApi extends BaseModule
 	 * @return void
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	protected function logErrorAndJsonExit(int $errorno, Error $error)
+	protected function logAndJsonError(int $errorno, Error $error)
 	{
 		$this->logger->info('API Error', ['no' => $errorno, 'error' => $error->toArray(), 'method' => $this->args->getMethod(), 'command' => $this->args->getQueryString(), 'user-agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
 		$this->jsonError(403, $error->toArray());

--- a/src/Module/OAuth/Authorize.php
+++ b/src/Module/OAuth/Authorize.php
@@ -51,17 +51,17 @@ class Authorize extends BaseApi
 
 		if ($request['response_type'] != 'code') {
 			Logger::warning('Unsupported or missing response type', ['request' => $_REQUEST]);
-			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t('Unsupported or missing response type'));
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Unsupported or missing response type')));
 		}
 
 		if (empty($request['client_id']) || empty($request['redirect_uri'])) {
 			Logger::warning('Incomplete request data', ['request' => $_REQUEST]);
-			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t('Incomplete request data'));
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Incomplete request data')));
 		}
 
 		$application = OAuth::getApplication($request['client_id'], $request['client_secret'], $request['redirect_uri']);
 		if (empty($application)) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		// @todo Compare the application scope and requested scope
@@ -87,7 +87,7 @@ class Authorize extends BaseApi
 
 		$token = OAuth::createTokenForUser($application, $uid, $request['scope']);
 		if (!$token) {
-			DI::mstdnError()->UnprocessableEntity();
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if ($application['redirect_uri'] != 'urn:ietf:wg:oauth:2.0:oob') {

--- a/src/Module/OAuth/Authorize.php
+++ b/src/Module/OAuth/Authorize.php
@@ -51,17 +51,17 @@ class Authorize extends BaseApi
 
 		if ($request['response_type'] != 'code') {
 			Logger::warning('Unsupported or missing response type', ['request' => $_REQUEST]);
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Unsupported or missing response type')));
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity($this->t('Unsupported or missing response type')));
 		}
 
 		if (empty($request['client_id']) || empty($request['redirect_uri'])) {
 			Logger::warning('Incomplete request data', ['request' => $_REQUEST]);
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Incomplete request data')));
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity($this->t('Incomplete request data')));
 		}
 
 		$application = OAuth::getApplication($request['client_id'], $request['client_secret'], $request['redirect_uri']);
 		if (empty($application)) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		// @todo Compare the application scope and requested scope
@@ -87,7 +87,7 @@ class Authorize extends BaseApi
 
 		$token = OAuth::createTokenForUser($application, $uid, $request['scope']);
 		if (!$token) {
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity());
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
 		if ($application['redirect_uri'] != 'urn:ietf:wg:oauth:2.0:oob') {

--- a/src/Module/OAuth/Revoke.php
+++ b/src/Module/OAuth/Revoke.php
@@ -51,7 +51,7 @@ class Revoke extends BaseApi
 		$token = DBA::selectFirst('application-view', ['id'], $condition);
 		if (empty($token['id'])) {
 			$this->logger->notice('Token not found', $condition);
-			$this->logErrorAndJsonExit(401, $this->errorFactory->Unauthorized());
+			$this->logAndJsonError(401, $this->errorFactory->Unauthorized());
 		}
 
 		DBA::delete('application-token', ['application-id' => $token['id']]);

--- a/src/Module/OAuth/Revoke.php
+++ b/src/Module/OAuth/Revoke.php
@@ -50,8 +50,8 @@ class Revoke extends BaseApi
 		$condition = ['client_id' => $request['client_id'], 'client_secret' => $request['client_secret'], 'access_token' => $request['token']];
 		$token = DBA::selectFirst('application-view', ['id'], $condition);
 		if (empty($token['id'])) {
-			Logger::notice('Token not found', $condition);
-			DI::mstdnError()->Unauthorized();
+			$this->logger->notice('Token not found', $condition);
+			$this->logErrorAndJsonExit(401, $this->errorFactory->Unauthorized());
 		}
 
 		DBA::delete('application-token', ['application-id' => $token['id']]);

--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -74,13 +74,13 @@ class Token extends BaseApi
 		}
 
 		if (empty($request['client_id']) || empty($request['client_secret'])) {
-			Logger::warning('Incomplete request data', ['request' => $request]);
-			DI::mstdnError()->Unauthorized('invalid_client', DI::l10n()->t('Incomplete request data'));
+			$this->logger->warning('Incomplete request data', ['request' => $request]);
+			$this->logErrorAndJsonExit(401, $this->errorFactory->Unauthorized('invalid_client', $this->t('Incomplete request data')));;
 		}
 
 		$application = OAuth::getApplication($request['client_id'], $request['client_secret'], $request['redirect_uri']);
 		if (empty($application)) {
-			DI::mstdnError()->Unauthorized('invalid_client', DI::l10n()->t('Invalid data or unknown client'));
+			$this->logErrorAndJsonExit(401, $this->errorFactory->Unauthorized('invalid_client', $this->t('Invalid data or unknown client')));
 		}
 
 		if ($request['grant_type'] == 'client_credentials') {
@@ -98,8 +98,8 @@ class Token extends BaseApi
 
 			$token = DBA::selectFirst('application-view', ['access_token', 'created_at', 'uid'], $condition);
 			if (!DBA::isResult($token)) {
-				Logger::notice('Token not found or outdated', $condition);
-				DI::mstdnError()->Unauthorized();
+				$this->logger->notice('Token not found or outdated', $condition);
+				$this->logErrorAndJsonExit(401, $this->errorFactory->Unauthorized());
 			}
 			$owner = User::getOwnerDataById($token['uid']);
 			$me = $owner['url'];

--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -75,12 +75,12 @@ class Token extends BaseApi
 
 		if (empty($request['client_id']) || empty($request['client_secret'])) {
 			$this->logger->warning('Incomplete request data', ['request' => $request]);
-			$this->logErrorAndJsonExit(401, $this->errorFactory->Unauthorized('invalid_client', $this->t('Incomplete request data')));;
+			$this->logAndJsonError(401, $this->errorFactory->Unauthorized('invalid_client', $this->t('Incomplete request data')));;
 		}
 
 		$application = OAuth::getApplication($request['client_id'], $request['client_secret'], $request['redirect_uri']);
 		if (empty($application)) {
-			$this->logErrorAndJsonExit(401, $this->errorFactory->Unauthorized('invalid_client', $this->t('Invalid data or unknown client')));
+			$this->logAndJsonError(401, $this->errorFactory->Unauthorized('invalid_client', $this->t('Invalid data or unknown client')));
 		}
 
 		if ($request['grant_type'] == 'client_credentials') {
@@ -99,13 +99,13 @@ class Token extends BaseApi
 			$token = DBA::selectFirst('application-view', ['access_token', 'created_at', 'uid'], $condition);
 			if (!DBA::isResult($token)) {
 				$this->logger->notice('Token not found or outdated', $condition);
-				$this->logErrorAndJsonExit(401, $this->errorFactory->Unauthorized());
+				$this->logAndJsonError(401, $this->errorFactory->Unauthorized());
 			}
 			$owner = User::getOwnerDataById($token['uid']);
 			$me = $owner['url'];
 		} else {
 			Logger::warning('Unsupported or missing grant type', ['request' => $_REQUEST]);
-			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Unsupported or missing grant type')));
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity($this->t('Unsupported or missing grant type')));
 		}
 
 		$object = new \Friendica\Object\Api\Mastodon\Token($token['access_token'], 'Bearer', $application['scopes'], $token['created_at'], $me);

--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -105,7 +105,7 @@ class Token extends BaseApi
 			$me = $owner['url'];
 		} else {
 			Logger::warning('Unsupported or missing grant type', ['request' => $_REQUEST]);
-			DI::mstdnError()->UnprocessableEntity(DI::l10n()->t('Unsupported or missing grant type'));
+			$this->logErrorAndJsonExit(422, $this->errorFactory->UnprocessableEntity($this->t('Unsupported or missing grant type')));
 		}
 
 		$object = new \Friendica\Object\Api\Mastodon\Token($token['access_token'], 'Bearer', $application['scopes'], $token['created_at'], $me);

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -302,11 +302,6 @@ return [
 			['createClient', [], Dice::CHAIN_CALL],
 		],
 	],
-	Factory\Api\Mastodon\Error::class => [
-		'constructParams' => [
-			$_SERVER
-		],
-	],
 	ParsedLogIterator::class => [
 		'constructParams' => [
 			[Dice::INSTANCE => Util\ReversedFileReader::class],

--- a/tests/src/Module/Api/Friendica/DirectMessages/SearchTest.php
+++ b/tests/src/Module/Api/Friendica/DirectMessages/SearchTest.php
@@ -34,7 +34,7 @@ class SearchTest extends ApiTest
 	{
 		$directMessage = new DirectMessage(new NullLogger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Search($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Search($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
@@ -52,7 +52,7 @@ class SearchTest extends ApiTest
 
 		$directMessage = new DirectMessage(new NullLogger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Search($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Search($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'searchstring' => 'item_body'
 			]);
@@ -73,7 +73,7 @@ class SearchTest extends ApiTest
 	{
 		$directMessage = new DirectMessage(new NullLogger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Search($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Search($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'searchstring' => 'test'
 			]);

--- a/tests/src/Module/Api/Friendica/NotificationTest.php
+++ b/tests/src/Module/Api/Friendica/NotificationTest.php
@@ -66,7 +66,7 @@ class NotificationTest extends ApiTest
 </notes>
 XML;
 
-		$response = (new Notification(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
+		$response = (new Notification(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
 			->run($this->httpExceptionMock);
 
 		self::assertXmlStringEqualsXmlString($assertXml, (string)$response->getBody());
@@ -78,7 +78,7 @@ XML;
 
 	public function testWithJsonResult()
 	{
-		$response = (new Notification(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Notification(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Friendica/Photo/DeleteTest.php
+++ b/tests/src/Module/Api/Friendica/Photo/DeleteTest.php
@@ -39,7 +39,7 @@ class DeleteTest extends ApiTest
 	public function testEmpty()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock);
+		(new Delete(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock);
 	}
 
 	public function testWithoutAuthenticatedUser()
@@ -50,14 +50,14 @@ class DeleteTest extends ApiTest
 	public function testWrong()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock, ['photo_id' => 1]);
+		(new Delete(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock, ['photo_id' => 1]);
 	}
 
 	public function testValidWithPost()
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../datasets/photo/photo.fixture.php', DI::dba());
 
-		$response = (new Delete(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Delete(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'photo_id' => '709057080661a283a6aa598501504178'
 			]);
@@ -72,7 +72,7 @@ class DeleteTest extends ApiTest
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../datasets/photo/photo.fixture.php', DI::dba());
 
-		$response = (new Delete(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Delete(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'photo_id' => '709057080661a283a6aa598501504178'
 			]);

--- a/tests/src/Module/Api/Friendica/Photoalbum/DeleteTest.php
+++ b/tests/src/Module/Api/Friendica/Photoalbum/DeleteTest.php
@@ -39,7 +39,7 @@ class DeleteTest extends ApiTest
 	public function testEmpty()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Delete(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 	}
@@ -47,7 +47,7 @@ class DeleteTest extends ApiTest
 	public function testWrong()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Delete(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'album' => 'album_name'
 			]);
@@ -57,7 +57,7 @@ class DeleteTest extends ApiTest
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../datasets/photo/photo.fixture.php', DI::dba());
 
-		$response = (new Delete(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Delete(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'album' => 'test_album']
 			);

--- a/tests/src/Module/Api/Friendica/Photoalbum/UpdateTest.php
+++ b/tests/src/Module/Api/Friendica/Photoalbum/UpdateTest.php
@@ -39,14 +39,14 @@ class UpdateTest extends ApiTest
 	public function testEmpty()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Update(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Update(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
 	public function testTooFewArgs()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Update(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Update(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'album' => 'album_name'
 			]);
@@ -55,7 +55,7 @@ class UpdateTest extends ApiTest
 	public function testWrongUpdate()
 	{
 		$this->expectException(BadRequestException::class);
-		(new Update(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Update(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'album'     => 'album_name',
 				'album_new' => 'album_name'
@@ -71,7 +71,7 @@ class UpdateTest extends ApiTest
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../datasets/photo/photo.fixture.php', DI::dba());
 
-		$response = (new Update(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Update(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'album'     => 'test_album',
 				'album_new' => 'test_album_2'

--- a/tests/src/Module/Api/GnuSocial/GnuSocial/ConfigTest.php
+++ b/tests/src/Module/Api/GnuSocial/GnuSocial/ConfigTest.php
@@ -32,7 +32,7 @@ class ConfigTest extends ApiTest
 	 */
 	public function testApiStatusnetConfig()
 	{
-		$response = (new Config(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Config(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 		$json = $this->toJson($response);
 

--- a/tests/src/Module/Api/GnuSocial/GnuSocial/VersionTest.php
+++ b/tests/src/Module/Api/GnuSocial/GnuSocial/VersionTest.php
@@ -30,7 +30,7 @@ class VersionTest extends ApiTest
 {
 	public function test()
 	{
-		$response = (new Version(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Version(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 
 		self::assertEquals([

--- a/tests/src/Module/Api/GnuSocial/Help/TestTest.php
+++ b/tests/src/Module/Api/GnuSocial/Help/TestTest.php
@@ -30,7 +30,7 @@ class TestTest extends ApiTest
 {
 	public function testJson()
 	{
-		$response = (new Test(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Test(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
@@ -44,13 +44,13 @@ class TestTest extends ApiTest
 
 	public function testXml()
 	{
-		$response = (new Test(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
+		$response = (new Test(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
 			->run($this->httpExceptionMock);
 
 		self::assertEquals([
 			'Content-type'                => ['text/xml'],
 			ICanCreateResponses::X_HEADER => ['xml']
 		], $response->getHeaders());
-		self::assertxml($response->getBody(), 'ok');
+		self::assertXml($response->getBody(), 'ok');
 	}
 }

--- a/tests/src/Module/Api/Mastodon/Accounts/VerifyCredentialsTest.php
+++ b/tests/src/Module/Api/Mastodon/Accounts/VerifyCredentialsTest.php
@@ -35,7 +35,7 @@ class VerifyCredentialsTest extends ApiTest
 	 */
 	public function testApiAccountVerifyCredentials()
 	{
-		$response = (new VerifyCredentials(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new VerifyCredentials(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/Account/RateLimitStatusTest.php
+++ b/tests/src/Module/Api/Twitter/Account/RateLimitStatusTest.php
@@ -31,7 +31,7 @@ class RateLimitStatusTest extends ApiTest
 {
 	public function testWithJson()
 	{
-		$response = (new RateLimitStatus(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new RateLimitStatus(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 
 		$result = $this->toJson($response);
@@ -47,7 +47,7 @@ class RateLimitStatusTest extends ApiTest
 
 	public function testWithXml()
 	{
-		$response = (new RateLimitStatus(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
+		$response = (new RateLimitStatus(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
 			->run($this->httpExceptionMock);
 
 		self::assertEquals([

--- a/tests/src/Module/Api/Twitter/Account/UpdateProfileTest.php
+++ b/tests/src/Module/Api/Twitter/Account/UpdateProfileTest.php
@@ -35,7 +35,7 @@ class UpdateProfileTest extends ApiTest
 	{
 		$this->useHttpMethod(Router::POST);
 
-		$response = (new UpdateProfile(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new UpdateProfile(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'name'        => 'new_name',
 				'description' => 'new_description'

--- a/tests/src/Module/Api/Twitter/Blocks/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Blocks/ListsTest.php
@@ -33,7 +33,7 @@ class ListsTest extends ApiTest
 	 */
 	public function testApiStatusesFWithBlocks()
 	{
-		$response = (new Lists(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Lists(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/DirectMessages/AllTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/AllTest.php
@@ -39,7 +39,7 @@ class AllTest extends ApiTest
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new All($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new All($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/DirectMessages/ConversationTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/ConversationTest.php
@@ -38,7 +38,7 @@ class ConversationTest extends ApiTest
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Conversation($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Conversation($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'friendica_verbose' => true,
 			]);

--- a/tests/src/Module/Api/Twitter/DirectMessages/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/DestroyTest.php
@@ -37,7 +37,7 @@ class DestroyTest extends ApiTest
 	public function testApiDirectMessagesDestroy()
 	{
 		$this->expectException(\Friendica\Network\HTTPException\BadRequestException::class);
-		(new Destroy(DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		(new Destroy(DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 	}
 
@@ -48,7 +48,7 @@ class DestroyTest extends ApiTest
 	 */
 	public function testApiDirectMessagesDestroyWithVerbose()
 	{
-		$response = (new Destroy(DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'friendica_verbose' => true,
 			]);
@@ -84,7 +84,7 @@ class DestroyTest extends ApiTest
 	public function testApiDirectMessagesDestroyWithId()
 	{
 		$this->expectException(\Friendica\Network\HTTPException\BadRequestException::class);
-		(new Destroy(DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		(new Destroy(DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'id' => 1
 			]);
@@ -97,7 +97,7 @@ class DestroyTest extends ApiTest
 	 */
 	public function testApiDirectMessagesDestroyWithIdAndVerbose()
 	{
-		$response = (new Destroy(DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'id'                  => 1,
 				'friendica_parenturi' => 'parent_uri',
@@ -121,7 +121,7 @@ class DestroyTest extends ApiTest
 		$ids = DBA::selectToArray('mail', ['id']);
 		$id  = $ids[0]['id'];
 
-		$response = (new Destroy(DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'id'                => $id,
 				'friendica_verbose' => true,

--- a/tests/src/Module/Api/Twitter/DirectMessages/InboxTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/InboxTest.php
@@ -40,7 +40,7 @@ class InboxTest extends ApiTest
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Inbox($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Inbox($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/DirectMessages/NewDMTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/NewDMTest.php
@@ -38,7 +38,7 @@ class NewDMTest extends ApiTest
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new NewDM($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 
 		self::assertEmpty((string)$response->getBody());
@@ -70,7 +70,7 @@ class NewDMTest extends ApiTest
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new NewDM($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',
 				'user_id' => 43
@@ -92,7 +92,7 @@ class NewDMTest extends ApiTest
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new NewDM($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',
 				'user_id' => 44
@@ -116,7 +116,7 @@ class NewDMTest extends ApiTest
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new NewDM($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',
 				'user_id' => 44,
@@ -142,7 +142,7 @@ class NewDMTest extends ApiTest
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new NewDM($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
+		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',
 				'user_id' => 44,

--- a/tests/src/Module/Api/Twitter/DirectMessages/SentTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/SentTest.php
@@ -38,7 +38,7 @@ class SentTest extends ApiTest
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Sent($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Sent($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'friendica_verbose' => true,
 			]);
@@ -58,7 +58,7 @@ class SentTest extends ApiTest
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Sent($directMessage, DI::dba(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
+		$response = (new Sent($directMessage, DI::dba(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
 			->run($this->httpExceptionMock);
 
 		self::assertXml((string)$response->getBody(), 'direct-messages');

--- a/tests/src/Module/Api/Twitter/Favorites/CreateTest.php
+++ b/tests/src/Module/Api/Twitter/Favorites/CreateTest.php
@@ -46,7 +46,7 @@ class CreateTest extends ApiTest
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Create(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Create(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
@@ -57,7 +57,7 @@ class CreateTest extends ApiTest
 	 */
 	public function testApiFavoritesCreateDestroyWithCreateAction()
 	{
-		$response = (new Create(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Create(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 3
 			]);
@@ -74,7 +74,7 @@ class CreateTest extends ApiTest
 	 */
 	public function testApiFavoritesCreateDestroyWithCreateActionAndRss()
 	{
-		$response = (new Create(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]))
+		$response = (new Create(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]))
 			->run($this->httpExceptionMock, [
 				'id' => 3
 			]);

--- a/tests/src/Module/Api/Twitter/Favorites/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/Favorites/DestroyTest.php
@@ -45,7 +45,7 @@ class DestroyTest extends ApiTest
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Destroy(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Destroy(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
@@ -56,7 +56,7 @@ class DestroyTest extends ApiTest
 	 */
 	public function testApiFavoritesCreateDestroyWithDestroyAction()
 	{
-		$response = (new Destroy(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Destroy(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 3
 			]);

--- a/tests/src/Module/Api/Twitter/FavoritesTest.php
+++ b/tests/src/Module/Api/Twitter/FavoritesTest.php
@@ -36,7 +36,7 @@ class FavoritesTest extends ApiTest
 	 */
 	public function testApiFavorites()
 	{
-		$response = (new Favorites(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Favorites(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'page'   => -1,
 				'max_id' => 10,
@@ -56,7 +56,7 @@ class FavoritesTest extends ApiTest
 	 */
 	public function testApiFavoritesWithRss()
 	{
-		$response = (new Favorites(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+		$response = (new Favorites(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_RSS
 		]))->run($this->httpExceptionMock);
 

--- a/tests/src/Module/Api/Twitter/Followers/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Followers/ListsTest.php
@@ -33,7 +33,7 @@ class ListsTest extends ApiTest
 	 */
 	public function testApiStatusesFWithFollowers()
 	{
-		$response = (new Lists(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Lists(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/Friends/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Friends/ListsTest.php
@@ -35,7 +35,7 @@ class ListsTest extends ApiTest
 	 */
 	public function testApiStatusesFWithFriends()
 	{
-		$response = (new Lists(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Lists(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/Friendships/IncomingTest.php
+++ b/tests/src/Module/Api/Twitter/Friendships/IncomingTest.php
@@ -35,7 +35,7 @@ class IncomingTest extends ApiTest
 	 */
 	public function testApiFriendshipsIncoming()
 	{
-		$response = (new Incoming(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Incoming(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
+++ b/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
@@ -38,7 +38,7 @@ class StatusesTest extends ApiTest
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Statuses(DI::dba(), DI::twitterStatus(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
@@ -47,7 +47,7 @@ class StatusesTest extends ApiTest
 	 */
 	public function testApiListsStatusesWithListId()
 	{
-		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'list_id' => 1,
 				'page'    => -1,
@@ -67,7 +67,7 @@ class StatusesTest extends ApiTest
 	 */
 	public function testApiListsStatusesWithListIdAndRss()
 	{
-		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
+		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
 			->run($this->httpExceptionMock, [
 				'list_id' => 1
 			]);

--- a/tests/src/Module/Api/Twitter/Media/UploadTest.php
+++ b/tests/src/Module/Api/Twitter/Media/UploadTest.php
@@ -46,7 +46,7 @@ class UploadTest extends ApiTest
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Upload(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Upload(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
@@ -60,7 +60,7 @@ class UploadTest extends ApiTest
 		$this->expectException(UnauthorizedException::class);
 		AuthTestConfig::$authenticated = false;
 
-		(new Upload(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Upload(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
@@ -79,7 +79,7 @@ class UploadTest extends ApiTest
 			]
 		];
 
-		(new Upload(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Upload(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
@@ -102,7 +102,7 @@ class UploadTest extends ApiTest
 			]
 		];
 
-		$response = (new Upload(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Upload(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$media = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/SavedSearchesTest.php
+++ b/tests/src/Module/Api/Twitter/SavedSearchesTest.php
@@ -30,7 +30,7 @@ class SavedSearchesTest extends ApiTest
 {
 	public function test()
 	{
-		$response = (new SavedSearches(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new SavedSearches(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 
 		$result = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/Statuses/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/DestroyTest.php
@@ -45,7 +45,7 @@ class DestroyTest extends ApiTest
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Destroy(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Destroy(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
@@ -71,7 +71,7 @@ class DestroyTest extends ApiTest
 	 */
 	public function testApiStatusesDestroyWithId()
 	{
-		$response = (new Destroy(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Destroy(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 1
 			]);

--- a/tests/src/Module/Api/Twitter/Statuses/MentionsTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/MentionsTest.php
@@ -36,7 +36,7 @@ class MentionsTest extends ApiTest
 	 */
 	public function testApiStatusesMentions()
 	{
-		$response = (new Mentions(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Mentions(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'max_id' => 10
 			]);
@@ -54,7 +54,7 @@ class MentionsTest extends ApiTest
 	 */
 	public function testApiStatusesMentionsWithNegativePage()
 	{
-		$response = (new Mentions(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Mentions(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'page' => -2
 			]);
@@ -86,7 +86,7 @@ class MentionsTest extends ApiTest
 	 */
 	public function testApiStatusesMentionsWithRss()
 	{
-		$response = (new Mentions(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]))
+		$response = (new Mentions(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]))
 			->run($this->httpExceptionMock, [
 				'page' => -2
 			]);

--- a/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
@@ -36,7 +36,7 @@ class NetworkPublicTimelineTest extends ApiTest
 	 */
 	public function testApiStatusesNetworkpublicTimeline()
 	{
-		$response = (new NetworkPublicTimeline(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'max_id' => 10
 			]);
@@ -58,7 +58,7 @@ class NetworkPublicTimelineTest extends ApiTest
 	 */
 	public function testApiStatusesNetworkpublicTimelineWithNegativePage()
 	{
-		$response = (new NetworkPublicTimeline(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'page' => -2
 			]);
@@ -94,7 +94,7 @@ class NetworkPublicTimelineTest extends ApiTest
 	 */
 	public function testApiStatusesNetworkpublicTimelineWithRss()
 	{
-		$response = (new NetworkPublicTimeline(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_RSS
 		]))->run($this->httpExceptionMock, [
 			'page' => -2

--- a/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
@@ -45,7 +45,7 @@ class RetweetTest extends ApiTest
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Retweet(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Retweet(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
@@ -71,7 +71,7 @@ class RetweetTest extends ApiTest
 	 */
 	public function testApiStatusesRepeatWithId()
 	{
-		$response = (new Retweet(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Retweet(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 1
 			]);
@@ -88,7 +88,7 @@ class RetweetTest extends ApiTest
 	 */
 	public function testApiStatusesRepeatWithSharedId()
 	{
-		$response = (new Retweet(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Retweet(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 5
 			]);

--- a/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
@@ -39,7 +39,7 @@ class ShowTest extends ApiTest
 		$this->expectException(BadRequestException::class);
 
 
-		(new Show(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Show(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
@@ -50,7 +50,7 @@ class ShowTest extends ApiTest
 	 */
 	public function testApiStatusesShowWithId()
 	{
-		$response = (new Show(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Show(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 1
 			]);
@@ -68,7 +68,7 @@ class ShowTest extends ApiTest
 	 */
 	public function testApiStatusesShowWithConversation()
 	{
-		$response = (new Show(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Show(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id'           => 1,
 				'conversation' => 1

--- a/tests/src/Module/Api/Twitter/Statuses/UpdateTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/UpdateTest.php
@@ -54,7 +54,7 @@ class UpdateTest extends ApiTest
 			]
 		];
 
-		$response = (new Update(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Update(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'status'                => 'Status content #friendica',
 				'in_reply_to_status_id' => 0,
@@ -76,7 +76,7 @@ class UpdateTest extends ApiTest
 	 */
 	public function testApiStatusesUpdateWithHtml()
 	{
-		$response = (new Update(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Update(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'htmlstatus' => '<b>Status content</b>',
 			]);

--- a/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
@@ -36,7 +36,7 @@ class UserTimelineTest extends ApiTest
 	 */
 	public function testApiStatusesUserTimeline()
 	{
-		$response = (new UserTimeline(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new UserTimeline(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'user_id'         => 42,
 				'max_id'          => 10,
@@ -61,7 +61,7 @@ class UserTimelineTest extends ApiTest
 	 */
 	public function testApiStatusesUserTimelineWithNegativePage()
 	{
-		$response = (new UserTimeline(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new UserTimeline(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'user_id' => 42,
 				'page'    => -2,
@@ -84,7 +84,7 @@ class UserTimelineTest extends ApiTest
 	 */
 	public function testApiStatusesUserTimelineWithRss()
 	{
-		$response = (new UserTimeline(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+		$response = (new UserTimeline(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_RSS
 		]))->run($this->httpExceptionMock);
 

--- a/tests/src/Module/Api/Twitter/Users/LookupTest.php
+++ b/tests/src/Module/Api/Twitter/Users/LookupTest.php
@@ -38,7 +38,7 @@ class LookupTest extends ApiTest
 	{
 		$this->expectException(NotFoundException::class);
 
-		(new Lookup(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Lookup(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
@@ -49,7 +49,7 @@ class LookupTest extends ApiTest
 	 */
 	public function testApiUsersLookupWithUserId()
 	{
-		$response = (new Lookup(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Lookup(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'user_id' => static::OTHER_USER['id']
 			]);

--- a/tests/src/Module/Api/Twitter/Users/SearchTest.php
+++ b/tests/src/Module/Api/Twitter/Users/SearchTest.php
@@ -37,7 +37,7 @@ class SearchTest extends ApiTest
 	 */
 	public function testApiUsersSearch()
 	{
-		$response = (new Search(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Search(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'q' => static::OTHER_USER['name']
 			]);
@@ -54,7 +54,7 @@ class SearchTest extends ApiTest
 	 */
 	public function testApiUsersSearchWithXml()
 	{
-		$response = (new Search(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+		$response = (new Search(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_XML
 		]))->run($this->httpExceptionMock, [
 			'q' => static::OTHER_USER['name']
@@ -72,7 +72,7 @@ class SearchTest extends ApiTest
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Search(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Search(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 }

--- a/tests/src/Module/Api/Twitter/Users/ShowTest.php
+++ b/tests/src/Module/Api/Twitter/Users/ShowTest.php
@@ -36,7 +36,7 @@ class ShowTest extends ApiTest
 	 */
 	public function testApiUsersShow()
 	{
-		$response = (new Show(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Show(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
@@ -56,7 +56,7 @@ class ShowTest extends ApiTest
 	 */
 	public function testApiUsersShowWithXml()
 	{
-		$response = (new Show(DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+		$response = (new Show(DI::mstdnError(), DI::app(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_XML
 		]))->run($this->httpExceptionMock);
 


### PR DESCRIPTION
Address https://github.com/friendica/friendica/issues/13156#issuecomment-1753309559

In retrospect, it was obvious we were doing something funky in `Factory\Api\Mastodon\Error` because we had `Arguments` and `server` dependencies which should only be available in the Module context. Moving the `Factory\Api\Mastodon\Error->logError` method to `BaseApi` was (almost) straightforward because these dependencies were already met.

Now the Factory expectedly only return object instances it's supposed to create, and the HTTP return codes are only handled in the modules, where they should.