### PR TITLE
CI upgrade & Installer Check enabling

### DIFF
--- a/.woodpecker/.phpunit.yml
+++ b/.woodpecker/.phpunit.yml
@@ -5,11 +5,11 @@ matrix:
     - PHP_MAJOR_VERSION: 7.4
       PHP_VERSION: 7.4.33
     - PHP_MAJOR_VERSION: 8.0
-      PHP_VERSION: 8.0.29
+      PHP_VERSION: 8.0.30
     - PHP_MAJOR_VERSION: 8.1
-      PHP_VERSION: 8.1.21
+      PHP_VERSION: 8.1.23
     - PHP_MAJOR_VERSION: 8.2
-      PHP_VERSION: 8.2.8
+      PHP_VERSION: 8.2.11
 
 # This forces PHP Unit executions at the "opensocial" labeled location (because of much more power...)
 labels:

--- a/src/Core/Installer.php
+++ b/src/Core/Installer.php
@@ -404,8 +404,6 @@ class Installer
 		}
 		$this->addCheck(DI::l10n()->t('PDO or MySQLi PHP module'), $status, true, $help);
 
-		// Uncomment when IntlChar is installed in the check pipeline.
-		/*
 		$help   = '';
 		$status = true;
 		if (!class_exists('IntlChar')) {
@@ -414,7 +412,6 @@ class Installer
 			$returnVal = false;
 		}
 		$this->addCheck(DI::l10n()->t('IntlChar PHP module'), $status, true, $help);
-		*/
 
 		// check for XML DOM Documents being able to be generated
 		$help = '';

--- a/tests/src/Core/Addon/Model/AddonLoaderTest.php
+++ b/tests/src/Core/Addon/Model/AddonLoaderTest.php
@@ -160,7 +160,7 @@ EOF;
 	public function testWrongContent()
 	{
 		$filename     = 'addon/testaddon1/static/hooks.config.php';
-		$wrongContent = "<php return 'wrong';";
+		$wrongContent = "<?php return 'wrong';";
 
 		vfsStream::create($this->structure)->at($this->root);
 
@@ -190,7 +190,7 @@ EOF;
 	public function testNoHooksConfig()
 	{
 		$filename     = 'addon/testaddon1/static/hooks.config.php';
-		$wrongContent = "<php return 'wrong';";
+		$wrongContent = "<?php return 'wrong';";
 
 		vfsStream::create($this->structure)->at($this->root);
 

--- a/tests/src/Core/Hooks/Util/StrategiesFileManagerTest.php
+++ b/tests/src/Core/Hooks/Util/StrategiesFileManagerTest.php
@@ -190,7 +190,7 @@ EOF,
 		$hookFileManager = new StrategiesFileManager($this->root->url(), $addonLoader);
 
 		vfsStream::newFile(StrategiesFileManager::STATIC_DIR . '/' . StrategiesFileManager::CONFIG_NAME . '.config.php')
-				 ->withContent("<php return 'WRONG_CONTENT';")
+				 ->withContent("<?php return 'WRONG_CONTENT';")
 				 ->at($this->root);
 
 		self::expectException(HookConfigException::class);

--- a/tests/src/Core/InstallerTest.php
+++ b/tests/src/Core/InstallerTest.php
@@ -82,11 +82,15 @@ class InstallerTest extends MockedTest
 
 	/**
 	 * Mocking the DI::l10n()->t() calls for the function checks
+	 *
+	 * @param bool $disableTimes if true, the L10, which are just created in case of an error, will be set to false (because the check will succeed)
 	 */
-	private function mockFunctionL10TCalls()
+	private function mockFunctionL10TCalls(bool $disableTimes = false)
 	{
 		$this->mockL10nT('Apache mod_rewrite module', 1);
 		$this->mockL10nT('PDO or MySQLi PHP module', 1);
+		$this->mockL10nT('IntlChar PHP module', 1);
+		$this->mockL10nT('Error: The IntlChar module is not installed.', $disableTimes ? 0 : 1);
 		$this->mockL10nT('libCurl PHP module', 1);
 		$this->mockL10nT('Error: libCURL PHP module required but not installed.', 1);
 		$this->mockL10nT('XML PHP module', 1);
@@ -181,10 +185,21 @@ class InstallerTest extends MockedTest
 	public function testCheckFunctions()
 	{
 		$this->mockFunctionL10TCalls();
+		$this->setClasses(['IntlChar' => false]);
+		$install = new Installer();
+		self::assertFalse($install->checkFunctions());
+		self::assertCheckExist(2,
+			'IntlChar PHP module',
+			'Error: The IntlChar module is not installed.',
+			false,
+			true,
+			$install->getChecks());
+
+		$this->mockFunctionL10TCalls();
 		$this->setFunctions(['curl_init' => false, 'imagecreatefromjpeg' => true]);
 		$install = new Installer();
 		self::assertFalse($install->checkFunctions());
-		self::assertCheckExist(3,
+		self::assertCheckExist(4,
 			'libCurl PHP module',
 			'Error: libCURL PHP module required but not installed.',
 			false,
@@ -195,7 +210,7 @@ class InstallerTest extends MockedTest
 		$this->setFunctions(['imagecreatefromjpeg' => false]);
 		$install = new Installer();
 		self::assertFalse($install->checkFunctions());
-		self::assertCheckExist(4,
+		self::assertCheckExist(5,
 			'GD graphics PHP module',
 			'Error: GD graphics PHP module with JPEG support required but not installed.',
 			false,
@@ -206,7 +221,7 @@ class InstallerTest extends MockedTest
 		$this->setFunctions(['openssl_public_encrypt' => false]);
 		$install = new Installer();
 		self::assertFalse($install->checkFunctions());
-		self::assertCheckExist(5,
+		self::assertCheckExist(6,
 			'OpenSSL PHP module',
 			'Error: openssl PHP module required but not installed.',
 			false,
@@ -217,7 +232,7 @@ class InstallerTest extends MockedTest
 		$this->setFunctions(['mb_strlen' => false]);
 		$install = new Installer();
 		self::assertFalse($install->checkFunctions());
-		self::assertCheckExist(6,
+		self::assertCheckExist(7,
 			'mb_string PHP module',
 			'Error: mb_string PHP module required but not installed.',
 			false,
@@ -228,7 +243,7 @@ class InstallerTest extends MockedTest
 		$this->setFunctions(['iconv_strlen' => false]);
 		$install = new Installer();
 		self::assertFalse($install->checkFunctions());
-		self::assertCheckExist(7,
+		self::assertCheckExist(8,
 			'iconv PHP module',
 			'Error: iconv PHP module required but not installed.',
 			false,
@@ -239,7 +254,7 @@ class InstallerTest extends MockedTest
 		$this->setFunctions(['posix_kill' => false]);
 		$install = new Installer();
 		self::assertFalse($install->checkFunctions());
-		self::assertCheckExist(8,
+		self::assertCheckExist(9,
 			'POSIX PHP module',
 			'Error: POSIX PHP module required but not installed.',
 			false,
@@ -250,7 +265,7 @@ class InstallerTest extends MockedTest
 		$this->setFunctions(['proc_open' => false]);
 		$install = new Installer();
 		self::assertFalse($install->checkFunctions());
-		self::assertCheckExist(9,
+		self::assertCheckExist(10,
 			'Program execution functions',
 			'Error: Program execution functions (proc_open) required but not enabled.',
 			false,
@@ -260,7 +275,7 @@ class InstallerTest extends MockedTest
 		$this->setFunctions(['json_encode' => false]);
 		$install = new Installer();
 		self::assertFalse($install->checkFunctions());
-		self::assertCheckExist(10,
+		self::assertCheckExist(11,
 			'JSON PHP module',
 			'Error: JSON PHP module required but not installed.',
 			false,
@@ -271,7 +286,7 @@ class InstallerTest extends MockedTest
 		$this->setFunctions(['finfo_open' => false]);
 		$install = new Installer();
 		self::assertFalse($install->checkFunctions());
-		self::assertCheckExist(11,
+		self::assertCheckExist(12,
 			'File Information PHP module',
 			'Error: File Information PHP module required but not installed.',
 			false,
@@ -282,14 +297,14 @@ class InstallerTest extends MockedTest
 		$this->setFunctions(['gmp_strval' => false]);
 		$install = new Installer();
 		self::assertFalse($install->checkFunctions());
-		self::assertCheckExist(12,
+		self::assertCheckExist(13,
 			'GNU Multiple Precision PHP module',
 			'Error: GNU Multiple Precision PHP module required but not installed.',
 		false,
 			true,
 			$install->getChecks());
 
-		$this->mockFunctionL10TCalls();
+		$this->mockFunctionL10TCalls(true);
 		$this->setFunctions([
 			'curl_init' => true,
 			'imagecreatefromjpeg' => true,
@@ -301,6 +316,7 @@ class InstallerTest extends MockedTest
 			'finfo_open' => true,
 			'gmp_strval' => true,
 		]);
+		$this->setClasses(['IntlChar' => true]);
 		$install = new Installer();
 		self::assertTrue($install->checkFunctions());
 	}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2023.09-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-15 08:16+0000\n"
+"POT-Creation-Date: 2023-10-15 13:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2633,214 +2633,222 @@ msgstr ""
 msgid "PDO or MySQLi PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:425
+#: src/Core/Installer.php:411
+msgid "Error: The IntlChar module is not installed."
+msgstr ""
+
+#: src/Core/Installer.php:414
+msgid "IntlChar PHP module"
+msgstr ""
+
+#: src/Core/Installer.php:422
 msgid "Error, XML PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:429
+#: src/Core/Installer.php:426
 msgid "XML PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:432
+#: src/Core/Installer.php:429
 msgid "libCurl PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:433
+#: src/Core/Installer.php:430
 msgid "Error: libCURL PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:439
+#: src/Core/Installer.php:436
 msgid "GD graphics PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:440
+#: src/Core/Installer.php:437
 msgid ""
 "Error: GD graphics PHP module with JPEG support required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:446
+#: src/Core/Installer.php:443
 msgid "OpenSSL PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:447
+#: src/Core/Installer.php:444
 msgid "Error: openssl PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:453
+#: src/Core/Installer.php:450
 msgid "mb_string PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:454
+#: src/Core/Installer.php:451
 msgid "Error: mb_string PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:460
+#: src/Core/Installer.php:457
 msgid "iconv PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:461
+#: src/Core/Installer.php:458
 msgid "Error: iconv PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:467
+#: src/Core/Installer.php:464
 msgid "POSIX PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:468
+#: src/Core/Installer.php:465
 msgid "Error: POSIX PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:474
+#: src/Core/Installer.php:471
 msgid "Program execution functions"
 msgstr ""
 
-#: src/Core/Installer.php:475
+#: src/Core/Installer.php:472
 msgid ""
 "Error: Program execution functions (proc_open) required but not enabled."
 msgstr ""
 
-#: src/Core/Installer.php:481
+#: src/Core/Installer.php:478
 msgid "JSON PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:482
+#: src/Core/Installer.php:479
 msgid "Error: JSON PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:488
+#: src/Core/Installer.php:485
 msgid "File Information PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:489
+#: src/Core/Installer.php:486
 msgid "Error: File Information PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:495
+#: src/Core/Installer.php:492
 msgid "GNU Multiple Precision PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:496
+#: src/Core/Installer.php:493
 msgid "Error: GNU Multiple Precision PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:519
+#: src/Core/Installer.php:516
 msgid ""
 "The web installer needs to be able to create a file called \"local.config.php"
 "\" in the \"config\" folder of your web server and it is unable to do so."
 msgstr ""
 
-#: src/Core/Installer.php:520
+#: src/Core/Installer.php:517
 msgid ""
 "This is most often a permission setting, as the web server may not be able "
 "to write files in your folder - even if you can."
 msgstr ""
 
-#: src/Core/Installer.php:521
+#: src/Core/Installer.php:518
 msgid ""
 "At the end of this procedure, we will give you a text to save in a file "
 "named local.config.php in your Friendica \"config\" folder."
 msgstr ""
 
-#: src/Core/Installer.php:522
+#: src/Core/Installer.php:519
 msgid ""
 "You can alternatively skip this procedure and perform a manual installation. "
 "Please see the file \"doc/INSTALL.md\" for instructions."
 msgstr ""
 
-#: src/Core/Installer.php:525
+#: src/Core/Installer.php:522
 msgid "config/local.config.php is writable"
 msgstr ""
 
-#: src/Core/Installer.php:545
+#: src/Core/Installer.php:542
 msgid ""
 "Friendica uses the Smarty3 template engine to render its web views. Smarty3 "
 "compiles templates to PHP to speed up rendering."
 msgstr ""
 
-#: src/Core/Installer.php:546
+#: src/Core/Installer.php:543
 msgid ""
 "In order to store these compiled templates, the web server needs to have "
 "write access to the directory view/smarty3/ under the Friendica top level "
 "folder."
 msgstr ""
 
-#: src/Core/Installer.php:547
+#: src/Core/Installer.php:544
 msgid ""
 "Please ensure that the user that your web server runs as (e.g. www-data) has "
 "write access to this folder."
 msgstr ""
 
-#: src/Core/Installer.php:548
+#: src/Core/Installer.php:545
 msgid ""
 "Note: as a security measure, you should give the web server write access to "
 "view/smarty3/ only--not the template files (.tpl) that it contains."
 msgstr ""
 
-#: src/Core/Installer.php:551
+#: src/Core/Installer.php:548
 msgid "view/smarty3 is writable"
 msgstr ""
 
-#: src/Core/Installer.php:579
+#: src/Core/Installer.php:576
 msgid ""
 "Url rewrite in .htaccess seems not working. Make sure you copied .htaccess-"
 "dist to .htaccess."
 msgstr ""
 
-#: src/Core/Installer.php:580
+#: src/Core/Installer.php:577
 msgid ""
 "In some circumstances (like running inside containers), you can skip this "
 "error."
 msgstr ""
 
-#: src/Core/Installer.php:582
+#: src/Core/Installer.php:579
 msgid "Error message from Curl when fetching"
 msgstr ""
 
-#: src/Core/Installer.php:588
+#: src/Core/Installer.php:585
 msgid "Url rewrite is working"
 msgstr ""
 
-#: src/Core/Installer.php:617
+#: src/Core/Installer.php:614
 msgid ""
 "The detection of TLS to secure the communication between the browser and the "
 "new Friendica server failed."
 msgstr ""
 
-#: src/Core/Installer.php:618
+#: src/Core/Installer.php:615
 msgid ""
 "It is highly encouraged to use Friendica only over a secure connection as "
 "sensitive information like passwords will be transmitted."
 msgstr ""
 
-#: src/Core/Installer.php:619
+#: src/Core/Installer.php:616
 msgid "Please ensure that the connection to the server is secure."
 msgstr ""
 
-#: src/Core/Installer.php:620
+#: src/Core/Installer.php:617
 msgid "No TLS detected"
 msgstr ""
 
-#: src/Core/Installer.php:622
+#: src/Core/Installer.php:619
 msgid "TLS detected"
 msgstr ""
 
-#: src/Core/Installer.php:649
+#: src/Core/Installer.php:646
 msgid "ImageMagick PHP extension is not installed"
 msgstr ""
 
-#: src/Core/Installer.php:651
+#: src/Core/Installer.php:648
 msgid "ImageMagick PHP extension is installed"
 msgstr ""
 
-#: src/Core/Installer.php:653
+#: src/Core/Installer.php:650
 msgid "ImageMagick supports GIF"
 msgstr ""
 
-#: src/Core/Installer.php:675
+#: src/Core/Installer.php:672
 msgid "Database already in use."
 msgstr ""
 
-#: src/Core/Installer.php:680
+#: src/Core/Installer.php:677
 msgid "Could not connect to database."
 msgstr ""
 


### PR DESCRIPTION
- Use new CI container with intlChar support
- Bump PHP version
- Re-Add Installer-Check (FollowUp #13531)