### PR TITLE
Drop using the proxy large size for image preview 

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -312,16 +312,16 @@ function photos_post(App $a)
 
 					Photo::update(['height' => $height, 'width' => $width], ['resource-id' => $resource_id, 'uid' => $page_owner_uid, 'scale' => 0], $image);
 
-					if ($width > 640 || $height > 640) {
-						$image->scaleDown(640);
+					if ($width > \Friendica\Util\Proxy::PIXEL_MEDIUM || $height > \Friendica\Util\Proxy::PIXEL_MEDIUM) {
+						$image->scaleDown(\Friendica\Util\Proxy::PIXEL_MEDIUM);
 						$width  = $image->getWidth();
 						$height = $image->getHeight();
 
 						Photo::update(['height' => $height, 'width' => $width], ['resource-id' => $resource_id, 'uid' => $page_owner_uid, 'scale' => 1], $image);
 					}
 
-					if ($width > 320 || $height > 320) {
-						$image->scaleDown(320);
+					if ($width > \Friendica\Util\Proxy::PIXEL_SMALL || $height > \Friendica\Util\Proxy::PIXEL_SMALL) {
+						$image->scaleDown(\Friendica\Util\Proxy::PIXEL_SMALL);
 						$width  = $image->getWidth();
 						$height = $image->getHeight();
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3483,11 +3483,8 @@ class Item
 				continue;
 			}
 
-			if ($PostMedia->mimetype->type == 'image') {
-				$preview_size = $PostMedia->width > $PostMedia->height ? Proxy::SIZE_MEDIUM : Proxy::SIZE_LARGE;
-				$preview_url = DI::baseUrl() . $PostMedia->getPreviewPath($preview_size);
-			} elseif ($PostMedia->preview) {
-				$preview_size = Proxy::SIZE_LARGE;
+			if ($PostMedia->mimetype->type == 'image' || $PostMedia->preview) {
+				$preview_size = Proxy::SIZE_MEDIUM;
 				$preview_url = DI::baseUrl() . $PostMedia->getPreviewPath($preview_size);
 			} else {
 				$preview_size = 0;

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -1001,7 +1001,7 @@ class Photo
 		$filesize = strlen($image->asString());
 		$width    = $image->getWidth();
 		$height   = $image->getHeight();
-	
+
 		if ($maximagesize && ($filesize > $maximagesize)) {
 			// Scale down to multiples of 640 until the maximum size isn't exceeded anymore
 			foreach ([5120, 2560, 1280, 640, 320] as $pixels) {
@@ -1014,8 +1014,8 @@ class Photo
 				}
 			}
 		}
-	
-		return $image;	
+
+		return $image;
 	}
 
 	/**
@@ -1031,7 +1031,7 @@ class Photo
 			$image->scaleDown($max_length);
 			Logger::info('File upload: Scaling picture to new size', ['max-length' => $max_length]);
 		}
-		
+
 		return self::resizeToFileSize($image, Strings::getBytesFromShorthand(DI::config()->get('system', 'maximagesize')));
 	}
 
@@ -1255,16 +1255,16 @@ class Photo
 			return -1;
 		}
 
-		if ($width > 640 || $height > 640) {
-			$image->scaleDown(640);
+		if ($width > Proxy::PIXEL_MEDIUM || $height > Proxy::PIXEL_MEDIUM) {
+			$image->scaleDown(Proxy::PIXEL_MEDIUM);
 		}
 
-		if ($width > 320 || $height > 320) {
+		if ($width > Proxy::PIXEL_SMALL || $height > Proxy::PIXEL_SMALL) {
 			$result = self::store($image, $uid, 0, $resource_id, $filename, $album, 1, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $description);
 			if ($result) {
 				$preview = 1;
 			}
-			$image->scaleDown(320);
+			$image->scaleDown(Proxy::PIXEL_SMALL);
 			$result = self::store($image, $uid, 0, $resource_id, $filename, $album, 2, self::DEFAULT, $allow_cid, $allow_gid, $deny_cid, $deny_gid, $description);
 			if ($result && ($preview == 0)) {
 				$preview = 2;

--- a/src/Module/Media/Photo/Browser.php
+++ b/src/Module/Media/Photo/Browser.php
@@ -26,12 +26,12 @@ use Friendica\BaseModule;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
-use Friendica\Core\System;
 use Friendica\Model\Photo;
 use Friendica\Module\Response;
 use Friendica\Network\HTTPException\UnauthorizedException;
 use Friendica\Util\Images;
 use Friendica\Util\Profiler;
+use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 use Psr\Log\LoggerInterface;
 
@@ -109,8 +109,8 @@ class Browser extends BaseModule
 			[
 				"`resource-id` = ? AND `height` <= ? AND `width` <= ?",
 				$record['resource-id'],
-				640,
-				640
+				Proxy::PIXEL_MEDIUM,
+				Proxy::PIXEL_MEDIUM
 			],
 			['order' => ['scale']]);
 		$scale = $photo['scale'] ?? $record['loq'];

--- a/src/Module/Settings/Profile/Photo/Index.php
+++ b/src/Module/Settings/Profile/Photo/Index.php
@@ -30,6 +30,7 @@ use Friendica\Network\HTTPException;
 use Friendica\Object\Image;
 use Friendica\Util\Images;
 use Friendica\Util\Strings;
+use Friendica\Util\Proxy;
 
 class Index extends BaseSettings
 {
@@ -82,7 +83,7 @@ class Index extends BaseSettings
 		$height = $Image->getHeight();
 
 		if ($width < 175 || $height < 175) {
-			$Image->scaleUp(300);
+			$Image->scaleUp(Proxy::PIXEL_SMALL);
 			$width = $Image->getWidth();
 			$height = $Image->getHeight();
 		}
@@ -95,10 +96,10 @@ class Index extends BaseSettings
 			DI::sysmsg()->addNotice(DI::l10n()->t('Image upload failed.'));
 		}
 
-		if ($width > 640 || $height > 640) {
-			$Image->scaleDown(640);
+		if ($width > Proxy::PIXEL_MEDIUM || $height > Proxy::PIXEL_MEDIUM) {
+			$Image->scaleDown(Proxy::PIXEL_MEDIUM);
 			if (!Photo::store($Image, DI::userSession()->getLocalUserId(), 0, $resource_id, $filename, DI::l10n()->t(Photo::PROFILE_PHOTOS), 1, Photo::USER_AVATAR)) {
-				DI::sysmsg()->addNotice(DI::l10n()->t('Image size reduction [%s] failed.', '640'));
+				DI::sysmsg()->addNotice(DI::l10n()->t('Image size reduction [%s] failed.', Proxy::PIXEL_MEDIUM));
 			}
 		}
 

--- a/src/Util/Proxy.php
+++ b/src/Util/Proxy.php
@@ -36,8 +36,8 @@ class Proxy
 	 */
 	const SIZE_MICRO  = 'micro'; // 48
 	const SIZE_THUMB  = 'thumb'; // 80
-	const SIZE_SMALL  = 'small'; // 300
-	const SIZE_MEDIUM = 'medium'; // 600
+	const SIZE_SMALL  = 'small'; // 320
+	const SIZE_MEDIUM = 'medium'; // 640
 	const SIZE_LARGE  = 'large'; // 1024
 
 	/**
@@ -45,8 +45,8 @@ class Proxy
 	 */
 	const PIXEL_MICRO  = 48;
 	const PIXEL_THUMB  = 80;
-	const PIXEL_SMALL  = 300;
-	const PIXEL_MEDIUM = 600;
+	const PIXEL_SMALL  = 320;
+	const PIXEL_MEDIUM = 640;
 	const PIXEL_LARGE  = 1024;
 
 	/**


### PR DESCRIPTION
Fix #13534 

- It was causing blurry upscaling with portrait images that have a 640px size preview.

Also, I aligned proxy sizes to photo preview sizes :
- PIXEL_SMALL goes from 300 to 320
- PIXEL_MEDIUM goes from 600 to 640
- Use Proxy pixel constants where we used hard-coded pixel values


