### PR TITLE
Allow CORS requests to nodeinfo endpoints

### DIFF
--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -190,6 +190,11 @@ abstract class BaseModule implements ICanHandleRequests
 			$this->response->setHeader('*', 'Access-Control-Allow-Headers');
 			$this->response->setHeader(Router::GET, 'Access-Control-Allow-Methods');
 			$this->response->setHeader('false', 'Access-Control-Allow-Credentials');
+		} elseif (substr($this->args->getQueryString(), 0, 9) == 'nodeinfo/') {
+			$this->response->setHeader('*', 'Access-Control-Allow-Origin');
+			$this->response->setHeader('*', 'Access-Control-Allow-Headers');
+			$this->response->setHeader(Router::GET, 'Access-Control-Allow-Methods');
+			$this->response->setHeader('false', 'Access-Control-Allow-Credentials');
 		} elseif (substr($this->args->getQueryString(), 0, 8) == 'profile/') {
 			$this->response->setHeader('*', 'Access-Control-Allow-Origin');
 			$this->response->setHeader('*', 'Access-Control-Allow-Headers');


### PR DESCRIPTION
Web applications meant to work with different Fediverse applications need to download `/.well-known/nodeinfo` and `/nodeinfo/2.0` in order to determine what software they are dealing with. Friendica currently allows the former to happen on the client side, the latter is missing CORS headers however so that third-party web pages aren’t allowed to do it. I’ve hit this issue myself when implementing “Share to Fediverse” functionality for my website.

Adding CORS headers is trivial and solves this issue. With the node info being public information, there is no reason why third-party websites shouldn’t have access to it.