### PR TITLE
Post permissions are now copied from the thread parent

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -221,6 +221,10 @@ function item_insert(int $uid, array $request, bool $preview, string $return_pat
 
 	DI::contentItem()->postProcessPost($post, $recipients);
 
+	if (($post['private'] == Item::PRIVATE) && ($post['thr-parent-id'] != $post['uri-id'])) {
+		DI::contentItem()->copyPermissions($post['thr-parent-id'], $post['uri-id']);
+	}
+
 	Logger::debug('post_complete');
 
 	item_post_return(DI::baseUrl(), $return_path);

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -48,6 +48,7 @@ use Friendica\Model\User;
 use Friendica\Network\HTTPException;
 use Friendica\Object\EMail\ItemCCEMail;
 use Friendica\Protocol\Activity;
+use Friendica\Protocol\ActivityPub;
 use Friendica\Util\ACLFormatter;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Emailer;
@@ -991,12 +992,14 @@ class Item
 			$post['deny_gid']  = $owner['deny_gid'];
 		}
 
-		if ($post['allow_gid'] || $post['allow_cid'] || $post['deny_gid'] || $post['deny_cid']) {
-			$post['private'] = ItemModel::PRIVATE;
-		} elseif ($this->pConfig->get($post['uid'], 'system', 'unlisted')) {
-			$post['private'] = ItemModel::UNLISTED;
-		} else {
-			$post['private'] = ItemModel::PUBLIC;
+		if (!isset($post['private'])) {
+			if ($post['allow_gid'] || $post['allow_cid'] || $post['deny_gid'] || $post['deny_cid']) {
+				$post['private'] = ItemModel::PRIVATE;
+			} elseif ($this->pConfig->get($post['uid'], 'system', 'unlisted')) {
+				$post['private'] = ItemModel::UNLISTED;
+			} else {
+				$post['private'] = ItemModel::PUBLIC;
+			}
 		}
 
 		if (empty($post['contact-id'])) {
@@ -1046,6 +1049,8 @@ class Item
 			Tag::createImplicitMentions($post['uri-id'], $post['thr-parent-id']);
 		}
 
+		ActivityPub\Transmitter::storeReceiversForItem($post);
+
 		Hook::callAll('post_local_end', $post);
 
 		$author = DBA::selectFirst('contact', ['thumb'], ['uid' => $post['uid'], 'self' => true]);
@@ -1064,6 +1069,17 @@ class Item
 				$address,
 				$author['thumb'] ?? ''
 			));
+		}
+	}
+
+	public function copyPermissions(int $fromUriId, int $toUriId)
+	{
+		$existing = array_column(Tag::getByURIId($toUriId, [Tag::TO, Tag::CC, Tag::BCC]), 'url');
+		foreach (Tag::getByURIId($fromUriId, [Tag::TO, Tag::CC, Tag::BCC]) as $receiver) {
+			if (in_array($receiver['url'], $existing)) {
+				continue;
+			}
+			Tag::store($toUriId, $receiver['type'], $receiver['name'], $receiver['url']);
 		}
 	}
 }

--- a/src/Model/Circle.php
+++ b/src/Model/Circle.php
@@ -428,7 +428,7 @@ class Circle
 					'uid' => $uid,
 					'rel' => [Contact::FOLLOWER, Contact::FRIEND],
 					'network' => $networks,
-					'contact-type' => [Contact::TYPE_UNKNOWN, Contact::TYPE_PERSON],
+					'contact-type' => [Contact::TYPE_UNKNOWN, Contact::TYPE_PERSON, Contact::TYPE_NEWS, Contact::TYPE_ORGANISATION],
 					'archive' => false,
 					'pending' => false,
 					'blocked' => false,

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -880,6 +880,10 @@ class Item
 			if (is_int($notify) && in_array($notify, Worker::PRIORITIES)) {
 				$priority = $notify;
 			}
+
+			// Mastodon style API visibility
+			$copy_permissions = ($item['visibility'] ?? 'private') == 'private';
+			unset($item['visibility']);
 		} else {
 			$item['network'] = trim(($item['network'] ?? '') ?: Protocol::PHANTOM);
 		}
@@ -1359,6 +1363,9 @@ class Item
 
 		if ($notify) {
 			DI::contentItem()->postProcessPost($posted_item);
+			if ($copy_permissions && ($posted_item['thr-parent-id'] != $posted_item['uri-id']) && ($posted_item['private'] == self::PRIVATE)) {
+				DI::contentItem()->copyPermissions($posted_item['thr-parent-id'], $posted_item['uri-id']);
+			}
 		} else {
 			Hook::callAll('post_remote_end', $posted_item);
 		}

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -25,13 +25,11 @@ use Friendica\Content\Text\BBCode;
 use Friendica\Core\Cache\Enum\Duration;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
-use Friendica\Core\System;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Util\DateTimeFormat;
-use Friendica\Util\Network;
 use Friendica\Util\Strings;
 
 /**

--- a/src/Module/PermissionTooltip.php
+++ b/src/Module/PermissionTooltip.php
@@ -113,12 +113,26 @@ class PermissionTooltip extends \Friendica\BaseModule
 			exit;
 		}
 
+		if (!empty($model['allow_cid']) || !empty($model['allow_gid']) || !empty($model['deny_cid']) || !empty($model['deny_gid'])) {
+			$receivers = $this->fetchReceiversFromACL($model);
+		}
+
+		$this->httpExit(DI::l10n()->t('Visible to:') . '<br />' . $receivers);
+	}
+
+	/**
+	 * Fetch a list of receivers based on the ACL data
+	 *
+	 * @param array $model
+	 * @return string
+	 */
+	private function fetchReceiversFromACL(array $model)
+	{
 		$allowed_users   = $model['allow_cid'];
 		$allowed_circles = $model['allow_gid'];
 		$deny_users      = $model['deny_cid'];
 		$deny_circles    = $model['deny_gid'];
 
-		$o = DI::l10n()->t('Visible to:') . '<br />';
 		$l = [];
 
 		if (count($allowed_circles)) {
@@ -165,11 +179,7 @@ class PermissionTooltip extends \Friendica\BaseModule
 			$l[] = '<strike>' . $contact['name'] . '</strike>';
 		}
 
-		if (!empty($l)) {
-			$this->httpExit($o . implode(', ', $l));
-		} else {
-			$this->httpExit($o . $receivers);;
-		}
+		return implode(', ', $l);
 	}
 
 	/**

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -434,6 +434,7 @@ class HTTPSignature
 		}
 
 		if (!$curlResult->isSuccess() || empty($curlResult->getBody())) {
+			Logger::debug('Fetching was unsuccessful', ['url' => $request, 'return-code' => $curlResult->getReturnCode(), 'error-number' => $curlResult->getErrorNumber(), 'error' => $curlResult->getError()]);
 			return [];
 		}
 

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -815,7 +815,7 @@ class Notifier
 			Logger::info('Remote item is no AP post. It will not be distributed.', ['id' => $target_item['id'], 'url' => $target_item['uri'], 'verb' => $target_item['verb']]);
 			return ['count' => 0, 'contacts' => []];
 		} elseif ($parent['origin'] && (($target_item['gravity'] != Item::GRAVITY_ACTIVITY) || DI::config()->get('system', 'redistribute_activities'))) {
-			$inboxes = ActivityPub\Transmitter::fetchTargetInboxes($parent, $uid, false, $target_item['id']);
+			$inboxes = ActivityPub\Transmitter::fetchTargetInboxes($parent, $uid);
 
 			if (in_array($target_item['private'], [Item::PUBLIC])) {
 				$inboxes = ActivityPub\Transmitter::addRelayServerInboxesForItem($parent['id'], $inboxes);


### PR DESCRIPTION
This fixes the issue that comments on non public posts weren't distributed anymore. This was caused by the fact that comments in AP have their own permissions that can be different to the post they are referring to.

When creating comments, we now copy the permissions from the thread parent. 