### PR TITLE
Accept relay posts based on the selected user languages

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1001,7 +1001,7 @@ class Processor
 		}
 
 		$tags = array_column(Tag::getByURIId($item['uri-id'], [Tag::HASHTAG]), 'name');
-		if (Relay::isSolicitedPost($tags, $item['body'], $item['author-id'], $item['uri'], Protocol::ACTIVITYPUB, $activity['thread-completion'] ?? 0)) {
+		if (Relay::isSolicitedPost($tags, $item['title'] . ' ' . ($item['content-warning'] ?? '') . ' ' . $item['body'], $item['author-id'], $item['uri'], Protocol::ACTIVITYPUB, $activity['thread-completion'] ?? 0)) {
 			Logger::debug('Post is accepted because of the relay settings', ['uri-id' => $item['uri-id'], 'guid' => $item['guid'], 'url' => $item['uri']]);
 			return true;
 		} else {

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -558,10 +558,6 @@ return [
 		// Redistribute incoming activities via ActivityPub
 		'redistribute_activities' => true,
 
-		// relay_deny_languages (Array)
-		// Array of languages (two digit format) that are rejected.
-		'relay_deny_languages' => [],
-
 		// relay_deny_undetected_language (Boolean)
 		// Deny undetected languages
 		'relay_deny_undetected_language' => false,


### PR DESCRIPTION
Posts that are received via a relay server are now only accepted, when the language matches one of the languages at least one of the user have selected as user language or channel language.