### PR TITLE
Use the post language for the language detection / config for quality

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -117,7 +117,7 @@ class Item
 	const DELIVER_FIELDLIST = [
 		'uid', 'id', 'parent', 'uri-id', 'uri', 'thr-parent', 'parent-uri', 'guid',
 		'parent-guid', 'conversation', 'received', 'created', 'edited', 'verb', 'object-type', 'object', 'target',
-		'private', 'title', 'body', 'raw-body', 'location', 'coord', 'app',
+		'private', 'title', 'body', 'raw-body', 'language', 'location', 'coord', 'app',
 		'inform', 'deleted', 'extid', 'post-type', 'post-reason', 'gravity',
 		'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid',
 		'author-id', 'author-addr', 'author-link', 'author-name', 'author-avatar', 'owner-id', 'owner-link', 'contact-uid',
@@ -1484,6 +1484,10 @@ class Item
 	 */
 	private static function setOwnerforResharedItem(array $item)
 	{
+		if ($item['uid'] == 0) {
+			return;
+		}
+
 		$parent = Post::selectFirst(
 			['id', 'causer-id', 'owner-id', 'author-id', 'author-link', 'origin', 'post-reason'],
 			['uri-id' => $item['thr-parent-id'], 'uid' => $item['uid']]

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -612,6 +612,7 @@ class User
 		}
 		DBA::close($channels);
 
+		ksort($languages);
 		return array_keys($languages);
 	}
 

--- a/src/Protocol/Relay.php
+++ b/src/Protocol/Relay.php
@@ -179,17 +179,17 @@ class Relay
 	 */
 	public static function isWantedLanguage(string $body, int $uri_id = 0, int $author_id = 0, array $languages = [])
 	{
-		if (empty($languages) && (empty($body) || Smilies::isEmojiPost($body))) {
-			Logger::debug('Empty body or only emojis', ['body' => $body]);
-			return true;
-		}
-
 		$detected = [];
 		$quality  = DI::config()->get('system', 'relay_language_quality');
 		foreach (Item::getLanguageArray($body, DI::config()->get('system', 'relay_languages'), $uri_id, $author_id) as $language => $reliability) {
 			if (($reliability >= $quality) && ($quality > 0)) {
 				$detected[] = $language;
 			}
+		}
+
+		if (empty($languages) && empty($detected) && (empty($body) || Smilies::isEmojiPost($body))) {
+			Logger::debug('Empty body or only emojis', ['body' => $body]);
+			return true;
 		}
 
 		if (!empty($languages) || !empty($detected)) {

--- a/src/Protocol/Relay.php
+++ b/src/Protocol/Relay.php
@@ -186,7 +186,7 @@ class Relay
 
 		$detected = [];
 		$quality  = DI::config()->get('system', 'relay_language_quality');
-		foreach (Item::getLanguageArray($body, 10, $uri_id, $author_id) as $language => $reliability) {
+		foreach (Item::getLanguageArray($body, DI::config()->get('system', 'relay_languages'), $uri_id, $author_id) as $language => $reliability) {
 			if (($reliability >= $quality) && ($quality > 0)) {
 				$detected[] = $language;
 			}

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -566,6 +566,10 @@ return [
 		// Minimum value for the language detection quality for relay posts. The value must be betweeen 0 and 1.
 		'relay_language_quality' => 0,
 
+		// relay_languages (Integer)
+		// Number of languages that are used per post to check for acceptable posts.
+		'relay_languages' => 10,
+
 		// session_handler (database|cache|native)
 		// Whether to use Cache to store session data or to use PHP native session storage.
 		'session_handler' => 'database',

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -562,8 +562,8 @@ return [
 		// Deny undetected languages
 		'relay_deny_undetected_language' => false,
 
-		// relay_language_quality (Integer)
-		// Minimum value for the language detection quality for relay posts. The value must be betweeen 0 and 1.
+		// relay_language_quality (Float)
+		// Minimum value for the language detection quality for relay posts. The value must be between 0 and 1.
 		'relay_language_quality' => 0,
 
 		// relay_languages (Integer)

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -562,6 +562,10 @@ return [
 		// Deny undetected languages
 		'relay_deny_undetected_language' => false,
 
+		// relay_language_quality (Integer)
+		// Minimum value for the language detection quality for relay posts. The value must be betweeen 0 and 1.
+		'relay_language_quality' => 0,
+
 		// session_handler (database|cache|native)
 		// Whether to use Cache to store session data or to use PHP native session storage.
 		'session_handler' => 'database',


### PR DESCRIPTION
This PR contains several fixes and improvements for the language handling.
- a small bug was fixed that prevented us from transmitting the detected language with ActivityPub posts
- There is now a configuration value for the minimal quantity for accepting relay posts
- Since AP transmits the language, we now use if for the relay language detection as well