### PR TITLE
Ensure to always have stored the receivers

### DIFF
--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -1049,8 +1049,6 @@ class Item
 			Tag::createImplicitMentions($post['uri-id'], $post['thr-parent-id']);
 		}
 
-		ActivityPub\Transmitter::storeReceiversForItem($post);
-
 		Hook::callAll('post_local_end', $post);
 
 		$author = DBA::selectFirst('contact', ['thumb'], ['uid' => $post['uid'], 'self' => true]);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1414,10 +1414,12 @@ class Item
 		}
 
 		if (!empty($source) && ($transmit || DI::config()->get('debug', 'store_source'))) {
-			Post\Activity::insert($item['uri-id'], $source);
+			Post\Activity::insert($posted_item['uri-id'], $source);
 		}
 
 		if ($transmit) {
+			ActivityPub\Transmitter::storeReceiversForItem($posted_item);
+
 			Worker::add(['priority' => $priority, 'dont_fork' => true], 'Notifier', $notify_type, (int)$posted_item['uri-id'], (int)$posted_item['uid']);
 		}
 


### PR DESCRIPTION
There sometimes seems to be the problem that the receivers of a message aren't stored before the delivery. The creation is no stored prior to the call that will distribute the item. This should be more safe.