### PR TITLE
Fix OAuth Redirect Url Scrubbing

### DIFF
--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -90,10 +90,10 @@ class Token extends BaseApi
 			$me = null;
 		} elseif ($request['grant_type'] == 'authorization_code') {
 			// For security reasons only allow freshly created tokens
-			$uri = new Uri($request['redirect_uri']);
+			$redirect_uri = strtok($request['redirect_uri'],'?');
 			$condition = [
 				"`redirect_uri` LIKE ? AND `id` = ? AND `code` = ? AND `created_at` > ?",
-				'%' . $uri->getScheme() . '://' . $uri->getHost() . $uri->getPath() . '%', $application['id'], $request['code'], DateTimeFormat::utc('now - 5 minutes')
+				$redirect_uri, $application['id'], $request['code'], DateTimeFormat::utc('now - 5 minutes')
 			];
 
 			$token = DBA::selectFirst('application-view', ['access_token', 'created_at', 'uid'], $condition);

--- a/src/Security/OAuth.php
+++ b/src/Security/OAuth.php
@@ -142,7 +142,6 @@ class OAuth
 		}
 
 		// The redirect_uri could contain several URI that are separated by spaces.
-		$exploded = explode(' ', $application['redirect_uri']);
 		if (($application['redirect_uri'] != $redirect_uri) && !in_array($redirect_uri, explode(' ', $application['redirect_uri']))) {
 			return [];
 		}

--- a/src/Security/OAuth.php
+++ b/src/Security/OAuth.php
@@ -131,8 +131,7 @@ class OAuth
 		}
 
 		if (!empty($redirect_uri)) {
-			$uri = new Uri($redirect_uri);
-			$redirect_uri = $uri->getScheme() . '://' . $uri->getHost() . $uri->getPath();
+			$redirect_uri = strtok($redirect_uri, '?');
 			$condition = DBA::mergeConditions($condition, ["`redirect_uri` LIKE ?", '%' . $redirect_uri . '%']);
 		}
 
@@ -143,6 +142,7 @@ class OAuth
 		}
 
 		// The redirect_uri could contain several URI that are separated by spaces.
+		$exploded = explode(' ', $application['redirect_uri']);
 		if (($application['redirect_uri'] != $redirect_uri) && !in_array($redirect_uri, explode(' ', $application['redirect_uri']))) {
 			return [];
 		}


### PR DESCRIPTION
Fixes #13556  by changing how the redirect URIs are scrubbed. The original fixes for these problems to account for query parameters on buffer URIs broke it into constituents and then reassembled the scheme, host, and path. This method produces several problems that caused failures in the OAuth initial authorization process. First, it strips off port numbers in reconstruction. Therefore an app that uses port numbers will never have a matching URI. Second, it converted hosts to all lower case. Therefore an app that used mixed case in their "host" path would never have a matching URI. For custom app paths that only specified a scheme and not a path it would create a triple forward slash string which never matched the URI. Lastly on apps that used a single slash separator rather than double it would fail to properly parse. Converting this to using `strtok` to find the beginning of the query parameters string and then stripping all that off preserves the original scheme, hostname/port, and path as passed from the app.  I don't have buffers to test this against to confirm that there was not something else that needed to be captured. 

This was tested against all the clients listed as well as desktop Relatica 