### PR TITLE
Replace + rather than %20 for spaces in photo gallery folder name

### DIFF
--- a/view/theme/frio/js/module/media/browser.js
+++ b/view/theme/frio/js/module/media/browser.js
@@ -243,7 +243,7 @@ var Browser = {
 
 	_getUrl: function (mode, folder) {
 		let folderValue = folder !== undefined ? folder : Browser.folder;
-		let folderUrl = folderValue !== undefined ? '/' + encodeURIComponent(folderValue) : '';
+		let folderUrl = folderValue !== undefined ? '/' + encodeURIComponent(folderValue).replace('%20','+') : '';
 		return 'media/' + Browser.type + '/browser' + folderUrl + '?mode=' + mode + "&theme=frio";
 	}
 };


### PR DESCRIPTION
Fixes #13621 

The browser.js code was doing the right thing by trying to replace the spaces with `%20` however somewhere in the PHP routing it very much does not like that as a character in the path. Using the `+` instead seems to fix the issue. The error is way up the Apache or PHP stack since the request doesn't even make it to the Router.getModule() method with the `%20` replacement but does with the `+`. 

If this is an Apache or PHP configuration change issue I'm fine fixing it that way instead of by changing which character we replace it with. 