### PR TITLE
The transmitted language is now stored

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1996,7 +1996,7 @@ class Item
 	 * @return string detected language
 	 * @throws \Text_LanguageDetect_Exception
 	 */
-	private static function getLanguage(array $item): string
+	private static function getLanguage(array $item): ?string
 	{
 		if (!empty($item['language'])) {
 			return $item['language'];
@@ -2007,13 +2007,15 @@ class Item
 			$transmitted[$language] = 0;
 		}
 
-		if (!in_array($item['gravity'], [self::GRAVITY_PARENT, self::GRAVITY_COMMENT]) || empty($item['body'])) {
-			return empty($transmitted) ? '' : json_encode($transmitted);
+		$content = trim(($item['title'] ?? '') . ' ' . ($item['content-warning'] ?? '') . ' ' . ($item['body'] ?? ''));
+
+		if (!in_array($item['gravity'], [self::GRAVITY_PARENT, self::GRAVITY_COMMENT]) || empty($content)) {
+			return !empty($transmitted) ? json_encode($transmitted) : null;
 		}
 
-		$languages = self::getLanguageArray($item['title'] . ' ' . ($item['content-warning'] ?? '') . ' ' . $item['body'], 3, $item['uri-id'], $item['author-id']);
+		$languages = self::getLanguageArray($content, 3, $item['uri-id'], $item['author-id']);
 		if (empty($languages)) {
-			return empty($transmitted) ? '' : json_encode($transmitted);
+			return !empty($transmitted) ? json_encode($transmitted) : null;
 		}
 
 		if (!empty($transmitted)) {

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -854,6 +854,8 @@ class Processor
 			$item['language'] = self::processLanguages($activity['languages']);
 		}
 
+		$item['transmitted-languages'] = $activity['transmitted-languages'];
+
 		if (!empty($activity['emojis'])) {
 			$content = self::replaceEmojis($item['uri-id'], $content, $activity['emojis']);
 		}
@@ -1727,7 +1729,7 @@ class Processor
 			}
 		}
 
-		$languages = self::getPostLanguages($activity);
+		$languages = self::getPostLanguages($activity['as:object'] ?? '');
 
 		return Relay::isSolicitedPost($messageTags, $content, $authorid, $id, Protocol::ACTIVITYPUB, $activity['thread-completion'] ?? 0, $languages);
 	}
@@ -1738,10 +1740,10 @@ class Processor
 	 * @param array $activity
 	 * @return array
 	 */
-	private static function getPostLanguages(array $activity): array
+	public static function getPostLanguages(array $activity): array
 	{
-		$content   = JsonLD::fetchElement($activity['as:object'], 'as:content') ?? '';
-		$languages = JsonLD::fetchElementArray($activity['as:object'], 'as:content', '@language') ?? [];
+		$content   = JsonLD::fetchElement($activity, 'as:content') ?? '';
+		$languages = JsonLD::fetchElementArray($activity, 'as:content', '@language') ?? [];
 		if (empty($languages)) {
 			return [];
 		}

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -2005,6 +2005,7 @@ class Receiver
 		$object_data['tags'] = self::processTags(JsonLD::fetchElementArray($object, 'as:tag') ?? []);
 		$object_data['emojis'] = self::processEmojis(JsonLD::fetchElementArray($object, 'as:tag', null, '@type', 'toot:Emoji') ?? []);
 		$object_data['languages'] = self::processLanguages(JsonLD::fetchElementArray($object, 'sc:inLanguage') ?? []);
+		$object_data['transmitted-languages'] = Processor::getPostLanguages($object);
 		$object_data['generator'] = JsonLD::fetchElement($object, 'as:generator', 'as:name', '@type', 'as:Application');
 		$object_data['generator'] = JsonLD::fetchElement($object_data, 'generator', '@value');
 		$object_data['alternate-url'] = JsonLD::fetchElement($object, 'as:url', '@id');


### PR DESCRIPTION
Some ActivityPub system transmit a language indicator. We now store it. This can be different from the detected languages, but could be some indicator anyway. Since we don't have any quality value for that, we set the quality `0` for it. It will only appear in the language list, if not contained in the already detected languages.

![grafik](https://github.com/friendica/friendica/assets/844208/36e5dbbd-3907-4ca1-b971-96253ce4f65f)
