### PR TITLE
Improve emoji federation (ActivityPub) and Mastodon API compliance

### DIFF
--- a/src/Content/Smilies.php
+++ b/src/Content/Smilies.php
@@ -152,6 +152,34 @@ class Smilies
 		return $params;
 	}
 
+	/**
+	 * Finds all used smilies (like :heart: or :p) in the provided text.
+	 *
+	 * @param string $text that might contain smilie usages (denoted by a starting colon)
+	 * @param bool   $extract_url whether to further extract image urls
+	 * @return array with smilie codes (colon included) as the keys, the smilie images as values
+	 */
+	public static function extractUsedSmilies(string $text, bool $extract_url = false): array
+	{
+		$emojis = [];
+
+		$smilies = self::getList();
+		$icons = $smilies['icons'];
+		foreach ($smilies['texts'] as $i => $name) {
+			if (strstr($text, $name)) {
+				$image = $icons[$i];
+				if ($extract_url) {
+					if (preg_match('/src="(.+?)"/', $image, $match)) {
+						$image = $match[1];
+					} else {
+						continue;
+					}
+				}
+				$emojis[$name] = $image;
+			}
+		}
+		return $emojis;
+	}
 
 	/**
 	 * Copied from http://php.net/manual/en/function.str-replace.php#88569

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1234,7 +1234,7 @@ class BBCode
 	}
 
 	/**
-	 * Expand Youtube and Vimeo links to 
+	 * Expand Youtube and Vimeo links to
 	 *
 	 * @param string $text
 	 * @return string
@@ -1387,7 +1387,7 @@ class BBCode
 					"\n[hr]", "[hr]\n", " [hr]", "[hr] ",
 					"\n[attachment ", " [attachment ", "\n[/attachment]", "[/attachment]\n", " [/attachment]", "[/attachment] ",
 					"[table]\n", "[table] ", " [table]", "\n[/table]", " [/table]", "[/table] ",
-					" \n", "\t\n", "[/li]\n", "\n[li]", "\n[*]", 
+					" \n", "\t\n", "[/li]\n", "\n[li]", "\n[*]",
 				];
 				$replace = [
 					"[th]", "[th]", "[th]", "[/th]", "[/th]", "[/th]",
@@ -1480,14 +1480,14 @@ class BBCode
 				if ($simple_html == self::INTERNAL) {
 					//Ensure to always start with <h4> if possible
 					$heading_count = 0;
-					for ($level = 6; $level > 0; $level--) { 
+					for ($level = 6; $level > 0; $level--) {
 						if (preg_match("(\[h$level\].*?\[\/h$level\])ism", $text)) {
 							$heading_count++;
 						}
 					}
 					if ($heading_count > 0) {
 						$heading = min($heading_count + 3, 6);
-						for ($level = 6; $level > 0; $level--) { 
+						for ($level = 6; $level > 0; $level--) {
 							if (preg_match("(\[h$level\].*?\[\/h$level\])ism", $text)) {
 								$text = preg_replace("(\[h$level\](.*?)\[\/h$level\])ism", "</p><h$heading>$1</h$heading><p>", $text);
 								$heading--;
@@ -1548,7 +1548,11 @@ class BBCode
 				$text = preg_replace("(\[style=(.*?)\](.*?)\[\/style\])ism", '<span style="$1">$2</span>', $text);
 
 				// Mastodon Emoji (internal tag, do not document for users)
-				$text = preg_replace("(\[emoji=(.*?)](.*?)\[/emoji])ism", '<span class="mastodon emoji"><img src="$1" alt="$2" title="$2"/></span>', $text);
+				if ($simple_html == self::MASTODON_API) {
+					$text = preg_replace("(\[emoji=(.*?)](.*?)\[/emoji])ism", '$2', $text);
+				} else {
+					$text = preg_replace("(\[emoji=(.*?)](.*?)\[/emoji])ism", '<span class="mastodon emoji"><img src="$1" alt="$2" title="$2"/></span>', $text);
+				}
 
 				// Check for CSS classes
 				// @deprecated since 2021.12, left for backward-compatibility reasons

--- a/src/Factory/Api/Mastodon/Emoji.php
+++ b/src/Factory/Api/Mastodon/Emoji.php
@@ -34,28 +34,18 @@ class Emoji extends BaseFactory
 	/**
 	 * Creates an emoji collection from shortcode => image mappings.
 	 *
-	 * Only emojis with shortcodes of the form of ':shortcode:' are passed in the collection.
-	 *
 	 * @param array $smilies
-	 * @param bool  $extract_url
 	 *
 	 * @return Emojis
 	 */
-	public function createCollectionFromArray(array $smilies, bool $extract_url = true): Emojis
+	public function createCollectionFromArray(array $smilies): Emojis
 	{
 		$prototype = null;
 
 		$emojis = [];
 
 		foreach ($smilies as $shortcode => $url) {
-			if (substr($shortcode, 0, 1) == ':' && substr($shortcode, -1) == ':') {
-				if ($extract_url) {
-					if (preg_match('/src="(.+?)"/', $url, $matches)) {
-						$url = $matches[1];
-					} else {
-						continue;
-					}
-				}
+			if ($shortcode !== '' && $url !== '') {
 				$shortcode = trim($shortcode, ':');
 
 				if ($prototype === null) {
@@ -71,12 +61,20 @@ class Emoji extends BaseFactory
 	}
 
 	/**
-	 * @param array $smilies
+	 * @param array $smilies as is returned by Smilies::getList()
 	 *
 	 * @return Emojis
 	 */
 	public function createCollectionFromSmilies(array $smilies): Emojis
 	{
-		return self::createCollectionFromArray(array_combine($smilies['texts'], $smilies['icons']));
+		$emojis = [];
+		$icons = $smilies['icons'];
+		foreach ($smilies['texts'] as $i => $name) {
+			$url = $icons[$i];
+			if (preg_match('/src="(.+?)"/', $url, $matches)) {
+				$emojis[$name] = $matches[1];
+			}
+		}
+		return self::createCollectionFromArray($emojis);
 	}
 }

--- a/src/Factory/Api/Mastodon/Emoji.php
+++ b/src/Factory/Api/Mastodon/Emoji.php
@@ -32,19 +32,22 @@ class Emoji extends BaseFactory
 	}
 
 	/**
+	 * Creates an emoji collection from shortcode => image mappings.
+	 *
 	 * @param array $smilies
 	 *
 	 * @return Emojis
 	 */
-	public function createCollectionFromSmilies(array $smilies): Emojis
+	public function createCollectionFromArray(array $smilies): Emojis
 	{
 		$prototype = null;
 
 		$emojis = [];
 
-		foreach ($smilies['texts'] as $key => $shortcode) {
-			if (preg_match('/src="(.+?)"/', $smilies['icons'][$key], $matches)) {
+		foreach ($smilies as $shortcode => $icon) {
+			if (preg_match('/src="(.+?)"/', $icon, $matches)) {
 				$url = $matches[1];
+				$shortcode = trim($shortcode, ':');
 
 				if ($prototype === null) {
 					$prototype = $this->create($shortcode, $url);
@@ -52,9 +55,19 @@ class Emoji extends BaseFactory
 				} else {
 					$emojis[] = \Friendica\Object\Api\Mastodon\Emoji::createFromPrototype($prototype, $shortcode, $url);
 				}
-			};
+			}
 		}
 
 		return new Emojis($emojis);
+	}
+
+	/**
+	 * @param array $smilies
+	 *
+	 * @return Emojis
+	 */
+	public function createCollectionFromSmilies(array $smilies): Emojis
+	{
+		return self::createCollectionFromArray(array_combine($smilies['texts'], $smilies['icons']));
 	}
 }

--- a/src/Factory/Api/Mastodon/Emoji.php
+++ b/src/Factory/Api/Mastodon/Emoji.php
@@ -34,19 +34,28 @@ class Emoji extends BaseFactory
 	/**
 	 * Creates an emoji collection from shortcode => image mappings.
 	 *
+	 * Only emojis with shortcodes of the form of ':shortcode:' are passed in the collection.
+	 *
 	 * @param array $smilies
+	 * @param bool  $extract_url
 	 *
 	 * @return Emojis
 	 */
-	public function createCollectionFromArray(array $smilies): Emojis
+	public function createCollectionFromArray(array $smilies, bool $extract_url = true): Emojis
 	{
 		$prototype = null;
 
 		$emojis = [];
 
-		foreach ($smilies as $shortcode => $icon) {
-			if (preg_match('/src="(.+?)"/', $icon, $matches)) {
-				$url = $matches[1];
+		foreach ($smilies as $shortcode => $url) {
+			if (substr($shortcode, 0, 1) == ':' && substr($shortcode, -1) == ':') {
+				if ($extract_url) {
+					if (preg_match('/src="(.+?)"/', $url, $matches)) {
+						$url = $matches[1];
+					} else {
+						continue;
+					}
+				}
 				$shortcode = trim($shortcode, ':');
 
 				if ($prototype === null) {

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -292,6 +292,10 @@ class Status extends BaseFactory
 		if (DI::baseUrl()->isLocalUrl($item['uri'])) {
 			$used_smilies = Smilies::extractUsedSmilies($item['body'] ?: $item['raw-body']);
 			$emojis = $this->mstdnEmojiFactory->createCollectionFromArray($used_smilies)->getArrayCopy(true);
+		} else {
+			if (preg_match_all("(\[emoji=(.*?)](.*?)\[/emoji])ism", $item['body'] ?: $item['raw-body'], $matches)) {
+				$emojis = $this->mstdnEmojiFactory->createCollectionFromArray(array_combine($matches[2], $matches[1]), false)->getArrayCopy(true);
+			}
 		}
 
 		if ($is_reshare) {

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -290,14 +290,12 @@ class Status extends BaseFactory
 
 		$emojis = null;
 		if (DI::baseUrl()->isLocalUrl($item['uri'])) {
-			$used_smilies = Smilies::extractUsedSmilies($item['raw-body'] ?: $item['body']);
-			// $used_smilies contains normalized texts
+			$used_smilies = Smilies::extractUsedSmilies($item['raw-body'] ?: $item['body'], $normalized);
 			if ($item['raw-body']) {
-				$item['raw-body'] = $used_smilies[''];
+				$item['raw-body'] = $normalized;
 			} elseif ($item['body']) {
-				$item['body'] = $used_smilies[''];
+				$item['body'] = $normalized;
 			}
-			unset($used_smilies['']);
 			$emojis = $this->mstdnEmojiFactory->createCollectionFromArray($used_smilies)->getArrayCopy(true);
 		} else {
 			if (preg_match_all("(\[emoji=(.*?)](.*?)\[/emoji])ism", $item['body'] ?: $item['raw-body'], $matches)) {

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -290,11 +290,18 @@ class Status extends BaseFactory
 
 		$emojis = null;
 		if (DI::baseUrl()->isLocalUrl($item['uri'])) {
-			$used_smilies = Smilies::extractUsedSmilies($item['body'] ?: $item['raw-body']);
+			$used_smilies = Smilies::extractUsedSmilies($item['raw-body'] ?: $item['body']);
+			// $used_smilies contains normalized texts
+			if ($item['raw-body']) {
+				$item['raw-body'] = $used_smilies[''];
+			} elseif ($item['body']) {
+				$item['body'] = $used_smilies[''];
+			}
+			unset($used_smilies['']);
 			$emojis = $this->mstdnEmojiFactory->createCollectionFromArray($used_smilies)->getArrayCopy(true);
 		} else {
 			if (preg_match_all("(\[emoji=(.*?)](.*?)\[/emoji])ism", $item['body'] ?: $item['raw-body'], $matches)) {
-				$emojis = $this->mstdnEmojiFactory->createCollectionFromArray(array_combine($matches[2], $matches[1]), false)->getArrayCopy(true);
+				$emojis = $this->mstdnEmojiFactory->createCollectionFromArray(array_combine($matches[2], $matches[1]))->getArrayCopy(true);
 			}
 		}
 

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -24,6 +24,7 @@ namespace Friendica\Factory\Api\Mastodon;
 use Friendica\BaseFactory;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Item as ContentItem;
+use Friendica\Content\Smilies;
 use Friendica\Content\Text\BBCode;
 use Friendica\Core\Logger;
 use Friendica\Database\Database;
@@ -57,6 +58,8 @@ class Status extends BaseFactory
 	private $mstdnCardFactory;
 	/** @var Attachment */
 	private $mstdnAttachmentFactory;
+	/** @var Emoji */
+	private $mstdnEmojiFactory;
 	/** @var Error */
 	private $mstdnErrorFactory;
 	/** @var Poll */
@@ -74,6 +77,7 @@ class Status extends BaseFactory
 		Tag $mstdnTagFactory,
 		Card $mstdnCardFactory,
 		Attachment $mstdnAttachmentFactory,
+		Emoji $mstdnEmojiFactory,
 		Error $mstdnErrorFactory,
 		Poll $mstdnPollFactory,
 		ContentItem $contentItem,
@@ -86,6 +90,7 @@ class Status extends BaseFactory
 		$this->mstdnTagFactory        = $mstdnTagFactory;
 		$this->mstdnCardFactory       = $mstdnCardFactory;
 		$this->mstdnAttachmentFactory = $mstdnAttachmentFactory;
+		$this->mstdnEmojiFactory      = $mstdnEmojiFactory;
 		$this->mstdnErrorFactory      = $mstdnErrorFactory;
 		$this->mstdnPollFactory       = $mstdnPollFactory;
 		$this->contentItem            = $contentItem;
@@ -283,6 +288,9 @@ class Status extends BaseFactory
 			}
 		}
 
+		$used_smilies = Smilies::extractUsedSmilies($item['body'] ?: $item['raw-body']);
+		$emojis = $this->mstdnEmojiFactory->createCollectionFromArray($used_smilies)->getArrayCopy(true);
+
 		if ($is_reshare) {
 			try {
 				$reshare = $this->createFromUriId($uriId, $uid, $display_quote, false, false)->toArray();
@@ -309,7 +317,7 @@ class Status extends BaseFactory
 		$visibility_data = $uid != $item['uid'] ? null : new FriendicaVisibility($this->aclFormatter->expand($item['allow_cid']), $this->aclFormatter->expand($item['deny_cid']), $this->aclFormatter->expand($item['allow_gid']), $this->aclFormatter->expand($item['deny_gid']));
 		$friendica       = new FriendicaExtension($item['title'] ?? '', $item['changed'], $item['commented'], $item['received'], $counts->dislikes, $origin_dislike, $delivery_data, $visibility_data);
 
-		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica, $quote, $poll);
+		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica, $quote, $poll, $emojis);
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -288,8 +288,11 @@ class Status extends BaseFactory
 			}
 		}
 
-		$used_smilies = Smilies::extractUsedSmilies($item['body'] ?: $item['raw-body']);
-		$emojis = $this->mstdnEmojiFactory->createCollectionFromArray($used_smilies)->getArrayCopy(true);
+		$emojis = null;
+		if (DI::baseUrl()->isLocalUrl($item['uri'])) {
+			$used_smilies = Smilies::extractUsedSmilies($item['body'] ?: $item['raw-body']);
+			$emojis = $this->mstdnEmojiFactory->createCollectionFromArray($used_smilies)->getArrayCopy(true);
+		}
 
 		if ($is_reshare) {
 			try {

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -107,7 +107,7 @@ class Status extends BaseDataTransferObject
 	 * @param array   $item
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function __construct(array $item, Account $account, Counts $counts, UserAttributes $userAttributes, bool $sensitive, Application $application, array $mentions, array $tags, Card $card, array $attachments, array $in_reply, array $reblog, FriendicaExtension $friendica, array $quote = null, array $poll = null)
+	public function __construct(array $item, Account $account, Counts $counts, UserAttributes $userAttributes, bool $sensitive, Application $application, array $mentions, array $tags, Card $card, array $attachments, array $in_reply, array $reblog, FriendicaExtension $friendica, array $quote = null, array $poll = null, array $emojis = null)
 	{
 		$reblogged          = !empty($reblog);
 		$this->id           = (string)$item['uri-id'];
@@ -152,7 +152,7 @@ class Status extends BaseDataTransferObject
 		$this->media_attachments = $reblogged ? [] : $attachments;
 		$this->mentions = $reblogged ? [] : $mentions;
 		$this->tags = $reblogged ? [] : $tags;
-		$this->emojis = $reblogged ? [] : [];
+		$this->emojis = $reblogged ? [] : ($emojis ?: []);
 		$this->card = $reblogged ? null : ($card->toArray() ?: null);
 		$this->poll = $reblogged ? null : $poll;
 		$this->friendica = $reblogged ? null : $friendica;

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -23,6 +23,7 @@ namespace Friendica\Protocol\ActivityPub;
 
 use Friendica\App;
 use Friendica\Content\Feature;
+use Friendica\Content\Smilies;
 use Friendica\Content\Text\BBCode;
 use Friendica\Core\Cache\Enum\Duration;
 use Friendica\Core\Logger;
@@ -1507,6 +1508,26 @@ class Transmitter
 	}
 
 	/**
+	 * Appends emoji tags to a tag array according to the tags used.
+	 *
+	 * @param array $tags Tag array
+	 * @param string $text Text containing tags like :tag:
+	 */
+	private static function addEmojiTags(array &$tags, string $text)
+	{
+		foreach (Smilies::extractUsedSmilies($text, true) as $name => $url) {
+			$tags[] = [
+				'type' => 'Emoji',
+				'name' => $name,
+				'icon' => [
+					'type' => 'Image',
+					'url' => $url,
+				],
+			];
+		}
+	}
+
+	/**
 	 * Returns a tag array for a given item array
 	 *
 	 * @param array  $item      Item array
@@ -1537,6 +1558,8 @@ class Transmitter
 				$tags[] = ['type' => 'Mention', 'href' => $term['url'], 'name' => $mention];
 			}
 		}
+
+		self::addEmojiTags($tags, $item['body']);
 
 		$announce = self::getAnnounceArray($item);
 		// Mention the original author upon commented reshares

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1514,11 +1514,9 @@ class Transmitter
 	 * @param string $text Text containing tags like :tag:
 	 * @return string normalized text
 	 */
-	private static function addEmojiTags(array &$tags, string $text)
+	private static function addEmojiTags(array &$tags, string $text): string
 	{
-		$emojis = Smilies::extractUsedSmilies($text);
-		$normalized = $emojis[''];
-		unset($emojis['']);
+		$emojis = Smilies::extractUsedSmilies($text, $normalized);
 		foreach ($emojis as $name => $url) {
 			$tags[] = [
 				'type' => 'Emoji',

--- a/tests/datasets/api.fixture.php
+++ b/tests/datasets/api.fixture.php
@@ -112,6 +112,11 @@ return [
 			'uri'  => 'http://localhost/profile/mutualcontact',
 			'guid' => '46',
 		],
+		[
+			'id'   => 100,
+			'uri'  => 'https://friendica.local/posts/100',
+			'guid' => '100',
+		],
 	],
 	'contact' => [
 		[
@@ -362,6 +367,12 @@ return [
 						'consequatur maxime aut illum soluta quaerat natus unde aspernatur ' .
 						'et sed beatae nihil ullam temporibus corporis ratione blanditiis',
 			'plink'  => 'http://localhost/display/6',
+		],
+		[
+			'uri-id' => 100,
+			'title'  => 'item_title',
+			'body'   => ':like ~friendica no [code]:dislike[/code] :-p :-[',
+			'plink'  => 'https://friendica.local/post/100',
 		],
 	],
 	'post' => [
@@ -726,6 +737,28 @@ return [
 		[
 			'id'            => 13,
 			'uri-id'        => 7,
+			'visible'       => 1,
+			'contact-id'    => 44,
+			'author-id'     => 44,
+			'owner-id'      => 42,
+			'causer-id'     => 44,
+			'uid'           => 0,
+			'vid'           => 8,
+			'unseen'        => 0,
+			'parent-uri-id' => 7,
+			'thr-parent-id' => 7,
+			'private'       => Item::PUBLIC,
+			'global'        => true,
+			'gravity'       => Item::GRAVITY_PARENT,
+			'network'       => Protocol::DFRN,
+			'origin'        => 0,
+			'deleted'       => 0,
+			'wall'          => 0,
+		],
+		// An emoji post
+		[
+			'id'            => 14,
+			'uri-id'        => 100,
 			'visible'       => 1,
 			'contact-id'    => 44,
 			'author-id'     => 44,

--- a/tests/datasets/api.fixture.php
+++ b/tests/datasets/api.fixture.php
@@ -371,7 +371,7 @@ return [
 		[
 			'uri-id' => 100,
 			'title'  => 'item_title',
-			'body'   => ':like ~friendica no [code]:dislike[/code] :-p :-[',
+			'body'   => ':like ~friendica no [code]:dislike[/code] :-p :-[ <3',
 			'plink'  => 'https://friendica.local/post/100',
 		],
 	],

--- a/tests/src/Content/SmiliesTest.php
+++ b/tests/src/Content/SmiliesTest.php
@@ -143,4 +143,107 @@ class SmiliesTest extends FixtureTest
 	{
 		$this->assertEquals($expected, Smilies::isEmojiPost($body));
 	}
+
+
+	public function dataReplace(): array
+	{
+		return [
+			'simple-1' => [
+				'expected' => 'alt=":-p"',
+				'body' => ':-p',
+			],
+			'simple-1' => [
+				'expected' => 'alt=":-p"',
+				'body' => ' :-p ',
+			],
+			'word-boundary-1' => [
+				'expected' => ':-pppp',
+				'body' => ':-pppp',
+			],
+			'word-boundary-2' => [
+				'expected' => '~friendicaca',
+				'body' => '~friendicaca',
+			],
+			'symbol-boundary-1' => [
+				'expected' => '(:-p)',
+				'body' => '(:-p)',
+			],
+			'hearts-1' => [
+				'expected' => '❤ (❤) ❤',
+				'body' => '&lt;3 (&lt;3) &lt;3',
+			],
+			'hearts-8' => [
+				'expected' => '(❤❤❤❤❤❤❤❤)',
+				'body' => '(&lt;33333333)',
+			],
+			'no-hearts-1' => [
+				'expected' => '(&lt;30)',
+				'body' => '(&lt;30)',
+			],
+			'no-hearts-2' => [
+				'expected' => '(3&lt;33)',
+				'body' => '(3&lt;33)',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataReplace
+	 *
+	 * @param string $expected
+	 * @param string $body
+	 */
+	public function testReplace(string $expected, string $body)
+	{
+		$result = Smilies::replace($body);
+		$this->assertStringContainsString($expected, $result);
+	}
+
+	public function dataExtractUsedSmilies(): array
+	{
+		return [
+			'single-smiley' => [
+				'expected' => ['like'],
+				'body' => ':like',
+				'normalized' => ':like:',
+			],
+			'multiple-smilies' => [
+				'expected' => ['like', 'dislike'],
+				'body' => ':like :dislike',
+				'normalized' => ':like: :dislike:',
+			],
+			'nosmile' => [
+				'expected' => [],
+				'body' => '[nosmile] :like :like',
+				'normalized' => '[nosmile] :like :like'
+			],
+			'in-code' => [
+				'expected' => [],
+				'body' => '[code]:like :like :like[/code]',
+				'normalized' => '[code]:like :like :like[/code]'
+			],
+			'~friendica' => [
+				'expected' => ['friendica'],
+				'body' => '~friendica',
+				'normalized' => ':friendica:'
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataExtractUsedSmilies
+	 *
+	 * @param array  $expected
+	 * @param string $body
+	 * @param stirng $normalized
+	 */
+	public function testExtractUsedSmilies(array $expected, string $body, string $normalized)
+	{
+		$extracted = Smilies::extractUsedSmilies($body);
+		$this->assertEquals($normalized, $extracted['']);
+		foreach ($expected as $shortcode) {
+			$this->assertArrayHasKey($shortcode, $extracted);
+		}
+		$this->assertEquals(count($expected), count($extracted) - 1);
+	}
 }

--- a/tests/src/Factory/Api/Mastodon/EmojiTest.php
+++ b/tests/src/Factory/Api/Mastodon/EmojiTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2023, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Test\src\Factory\Api\Mastodon;
+
+use Friendica\Content\Smilies;
+use Friendica\DI;
+use Friendica\Test\FixtureTest;
+
+class EmojiTest extends FixtureTest
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		DI::config()->set('system', 'no_smilies', false);
+	}
+
+	public function testBuiltInCollection()
+	{
+		$emoji      = DI::mstdnEmoji();
+		$collection = $emoji->createCollectionFromSmilies(Smilies::getList())->getArrayCopy(true);
+		foreach ($collection as $item) {
+			$this->assertTrue(preg_match('(/images/.*)', $item['url']) === 1, $item['url']);
+		}
+	}
+}

--- a/tests/src/Factory/Api/Mastodon/StatusTest.php
+++ b/tests/src/Factory/Api/Mastodon/StatusTest.php
@@ -50,7 +50,7 @@ class StatusTest extends FixtureTest
 		$post = Post::selectFirst([], ['id' => 14]);
 		$this->assertNotNull($post);
 		$result = $this->status->createFromUriId($post['uri-id'])->toArray();
-		$this->assertEquals(':like: :friendica: no <code>:dislike</code> :p: :embarrassed:', $result['content']);
+		$this->assertEquals(':like: :friendica: no <code>:dislike</code> :p: :embarrassed: ❤', $result['content']);
 		$emojis = array_fill_keys(['like', 'friendica', 'p', 'embarrassed'], true);
 		$this->assertEquals(count($emojis), count($result['emojis']));
 		foreach ($result['emojis'] as $emoji) {

--- a/tests/src/Factory/Api/Mastodon/StatusTest.php
+++ b/tests/src/Factory/Api/Mastodon/StatusTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2023, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Test\src\Factory\Api\Mastodon;
+
+use Friendica\Model\Post;
+use Friendica\DI;
+use Friendica\Test\FixtureTest;
+
+class StatusTest extends FixtureTest
+{
+	protected $status;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		DI::config()->set('system', 'no_smilies', false);
+		$this->status = DI::mstdnStatus();
+	}
+
+	public function testSimpleStatus()
+	{
+		$post = Post::selectFirst([], ['id' => 13]);
+		$this->assertNotNull($post);
+		$result = $this->status->createFromUriId($post['uri-id']);
+		$this->assertNotNull($result);
+	}
+
+	public function testSimpleEmojiStatus()
+	{
+		$post = Post::selectFirst([], ['id' => 14]);
+		$this->assertNotNull($post);
+		$result = $this->status->createFromUriId($post['uri-id'])->toArray();
+		$this->assertEquals(':like: :friendica: no <code>:dislike</code> :p: :embarrassed:', $result['content']);
+		$emojis = array_fill_keys(['like', 'friendica', 'p', 'embarrassed'], true);
+		$this->assertEquals(count($emojis), count($result['emojis']));
+		foreach ($result['emojis'] as $emoji) {
+			$this->assertTrue(array_key_exists($emoji['shortcode'], $emojis));
+			$this->assertEquals(0, strpos($emoji['url'], 'http'));
+		}
+	}
+}

--- a/tests/src/Protocol/ActivityPub/TransmitterTest.php
+++ b/tests/src/Protocol/ActivityPub/TransmitterTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2023, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Test\src\Protocol\ActivityPub;
+
+use Friendica\DI;
+use Friendica\Model\Post;
+use Friendica\Protocol\ActivityPub\Transmitter;
+use Friendica\Test\FixtureTest;
+
+class TransmitterTest extends FixtureTest
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		DI::config()->set('system', 'no_smilies', false);
+	}
+
+	public function testEmojiPost()
+	{
+		$post = Post::selectFirst([], ['id' => 14]);
+		$this->assertNotNull($post);
+		$note = Transmitter::createNote($post);
+		$this->assertNotNull($note);
+
+		$this->assertEquals(':like: :friendica: no <code>:dislike</code> :p: :embarrassed:', $note['content']);
+		$emojis = array_fill_keys(['like', 'friendica', 'p', 'embarrassed'], true);
+		$this->assertEquals(count($emojis), count($note['tag']));
+		foreach ($note['tag'] as $emoji) {
+			$this->assertTrue(array_key_exists($emoji['name'], $emojis));
+			$this->assertEquals('Emoji', $emoji['type']);
+		}
+	}
+}

--- a/tests/src/Protocol/ActivityPub/TransmitterTest.php
+++ b/tests/src/Protocol/ActivityPub/TransmitterTest.php
@@ -42,7 +42,7 @@ class TransmitterTest extends FixtureTest
 		$note = Transmitter::createNote($post);
 		$this->assertNotNull($note);
 
-		$this->assertEquals(':like: :friendica: no <code>:dislike</code> :p: :embarrassed:', $note['content']);
+		$this->assertEquals(':like: :friendica: no <code>:dislike</code> :p: :embarrassed: ❤', $note['content']);
 		$emojis = array_fill_keys(['like', 'friendica', 'p', 'embarrassed'], true);
 		$this->assertEquals(count($emojis), count($note['tag']));
 		foreach ($note['tag'] as $emoji) {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1413,6 +1413,9 @@ section #jotOpen {
 		max-height: calc(100vh - 62px);
 	}
 }
+#jot-modal #jot-modal-body {
+	overflow: auto;
+}
 #jot-modal #jot-sections,
 #jot-modal #jot-modal-body,
 #jot-modal #profile-jot-form,
@@ -1423,7 +1426,6 @@ section #jotOpen {
 #jot-modal #item-Q0,
 #jot-modal #profile-jot-acl-wrapper,
 #jot-modal #acl-wrapper {
-	overflow: hidden;
 	display: flex;
 	flex: auto;
 	flex-direction: column;


### PR DESCRIPTION
This PR adds emoji federation (via ActivityPub protocol) and improves emoji experience on Mastodon-API clients.

- Fix the `shortcode` field in `/api/v1/custom_emojis` API endpoint

  Originally the `shortcode` field does not trim the colons (i.e. returning `:blobmeltsoblove:` instead of `blobmeltsoblove`), so inputting emojis from a Mastodon-API client will result in `::blobmeltsoblove::`.

- Pass used local emojis / smilies in the `emojis` field of a `Status` object returned by Mastodon API.

  Tested with a Fedilab client, the smilies (in local statuses) should now display correctly on Mastodon-API clients.

  **Note**: I am not familiar enough with Friendica codebase to implement it for remote statuses, which can come from not only ActivityPub servers but also all the other protocol.

- Pass used local emojis / smilies in the `tag` field of an ActivityPub post.

  This should make emojis federate with ActivityPub servers (tested with Mastodon and Pleroma).

- Modify the frio theme so that too many smilies do not cause trouble.

  (Textarea minimized due to the vast amount of smilies taking too much space.)

  ![image](https://github.com/friendica/friendica/assets/14026120/f72383be-d316-4ade-95bd-2986fdd025f4)

  This can probably be partially fixed in the `smileybutton` addon by allow scrolling the table and/or simply use flex box layout, but to handle narrower mobile views, this need to be address in the frio theme by allowing the whole modal to scroll.
