### PR TITLE
Check for user defined channel matches before storing them

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1868,14 +1868,14 @@ CREATE TABLE IF NOT EXISTS `subscription` (
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Push Subscription for the API';
 
 --
--- TABLE test-full-text-search
+-- TABLE check-full-text-search
 --
-CREATE TABLE IF NOT EXISTS `test-full-text-search` (
-	`pid` int unsigned NOT NULL DEFAULT 0 COMMENT 'Process id of the worker',
+CREATE TABLE IF NOT EXISTS `check-full-text-search` (
+	`pid` int unsigned NOT NULL COMMENT 'The ID of the process',
 	`searchtext` mediumtext COMMENT 'Simplified text for the full text search',
 	 PRIMARY KEY(`pid`),
 	 FULLTEXT INDEX `searchtext` (`searchtext`)
-) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Test for a full text search match in user defined channels before storing the message in the system';
+) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Check for a full text search match in user defined channels before storing the message in the system';
 
 --
 -- TABLE userd

--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2023.09-rc (Giant Rhubarb)
--- DB_UPDATE_VERSION 1539
+-- DB_UPDATE_VERSION 1540
 -- ------------------------------------------
 
 
@@ -1866,6 +1866,16 @@ CREATE TABLE IF NOT EXISTS `subscription` (
 	FOREIGN KEY (`application-id`) REFERENCES `application` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,
 	FOREIGN KEY (`uid`) REFERENCES `user` (`uid`) ON UPDATE RESTRICT ON DELETE CASCADE
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Push Subscription for the API';
+
+--
+-- TABLE test-full-text-search
+--
+CREATE TABLE IF NOT EXISTS `test-full-text-search` (
+	`pid` int unsigned NOT NULL DEFAULT 0 COMMENT 'Process id of the worker',
+	`searchtext` mediumtext COMMENT 'Simplified text for the full text search',
+	 PRIMARY KEY(`pid`),
+	 FULLTEXT INDEX `searchtext` (`searchtext`)
+) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Test for a full text search match in user defined channels before storing the message in the system';
 
 --
 -- TABLE userd

--- a/doc/Channels.md
+++ b/doc/Channels.md
@@ -68,6 +68,7 @@ Additionally to the search for content, there are additional keywords that can b
     * network:dscs - Posts that are received by the Discourse connector.
     * network:tmbl - Posts that are received by the Tumblr connector.
     * network:bsky - Posts that are received by the Bluesky connector.
+* platform - Use this to include or exclude some platforms from your channel, e.g. "+platform:friendica".
 * visibility - You have the choice between different visibilities. You can only see unlisted or private posts that you have the access for.
     * visibility:public
     * visibility:unlisted

--- a/doc/database.md
+++ b/doc/database.md
@@ -86,6 +86,7 @@ Database Tables
 | [storage](help/database/db_storage) | Data stored by Database storage backend |
 | [subscription](help/database/db_subscription) | Push Subscription for the API |
 | [tag](help/database/db_tag) | tags and mentions |
+| [test-full-text-search](help/database/db_test-full-text-search) | Test for a full text search match in user defined channels before storing the message in the system |
 | [user](help/database/db_user) | The local users |
 | [user-contact](help/database/db_user-contact) | User specific public contact data |
 | [user-gserver](help/database/db_user-gserver) | User settings about remote servers |

--- a/doc/database.md
+++ b/doc/database.md
@@ -18,6 +18,7 @@ Database Tables
 | [attach](help/database/db_attach) | file attachments |
 | [cache](help/database/db_cache) | Stores temporary data |
 | [channel](help/database/db_channel) | User defined Channels |
+| [check-full-text-search](help/database/db_check-full-text-search) | Check for a full text search match in user defined channels before storing the message in the system |
 | [config](help/database/db_config) | main configuration storage |
 | [contact](help/database/db_contact) | contact table |
 | [contact-relation](help/database/db_contact-relation) | Contact relations |
@@ -86,7 +87,6 @@ Database Tables
 | [storage](help/database/db_storage) | Data stored by Database storage backend |
 | [subscription](help/database/db_subscription) | Push Subscription for the API |
 | [tag](help/database/db_tag) | tags and mentions |
-| [test-full-text-search](help/database/db_test-full-text-search) | Test for a full text search match in user defined channels before storing the message in the system |
 | [user](help/database/db_user) | The local users |
 | [user-contact](help/database/db_user-contact) | User specific public contact data |
 | [user-gserver](help/database/db_user-gserver) | User settings about remote servers |

--- a/doc/database/db_test-full-text-search.md
+++ b/doc/database/db_test-full-text-search.md
@@ -1,0 +1,23 @@
+Table test-full-text-search
+===========
+
+Test for a full text search match in user defined channels before storing the message in the system
+
+Fields
+------
+
+| Field      | Description                              | Type         | Null | Key | Default | Extra |
+| ---------- | ---------------------------------------- | ------------ | ---- | --- | ------- | ----- |
+| pid        | Process id of the worker                 | int unsigned | NO   |     | 0       |       |
+| searchtext | Simplified text for the full text search | mediumtext   | YES  |     | NULL    |       |
+
+Indexes
+------------
+
+| Name       | Fields               |
+| ---------- | -------------------- |
+| PRIMARY    | pid                  |
+| searchtext | FULLTEXT, searchtext |
+
+
+Return to [database documentation](help/database)

--- a/doc/database/db_test-full-text-search.md
+++ b/doc/database/db_test-full-text-search.md
@@ -1,7 +1,7 @@
-Table test-full-text-search
+Table check-full-text-search
 ===========
 
-Test for a full text search match in user defined channels before storing the message in the system
+Check for a full text search match in user defined channels before storing the message in the system
 
 Fields
 ------

--- a/src/Content/Conversation/Repository/UserDefinedChannel.php
+++ b/src/Content/Conversation/Repository/UserDefinedChannel.php
@@ -154,14 +154,14 @@ class UserDefinedChannel extends \Friendica\BaseRepository
 		}
 
 		$store = false;
-		$this->db->insert('test-full-text-search', ['pid' => getmypid(), 'searchtext' => $searchtext], Database::INSERT_UPDATE);
+		$this->db->insert('check-full-text-search', ['pid' => getmypid(), 'searchtext' => $searchtext], Database::INSERT_UPDATE);
 		$channels = $this->db->select(self::$table_name, ['full-text-search', 'uid', 'label'], ["`full-text-search` != ?", '']);
 		while ($channel = $this->db->fetch($channels)) {
 			$channelsearchtext = $channel['full-text-search'];
 			foreach (['from', 'to', 'group', 'tag', 'network', 'platform', 'visibility'] as $keyword) {
 				$channelsearchtext = preg_replace('~(' . $keyword . ':.[\w@\.-]+)~', '"$1"', $channelsearchtext);
 			}
-			if ($this->db->exists('test-full-text-search', ["`pid` = ? AND MATCH (`searchtext`) AGAINST (? IN BOOLEAN MODE)", getmypid(), $channelsearchtext])) {
+			if ($this->db->exists('check-full-text-search', ["`pid` = ? AND MATCH (`searchtext`) AGAINST (? IN BOOLEAN MODE)", getmypid(), $channelsearchtext])) {
 				if (in_array($language, $this->pConfig->get($channel['uid'], 'channel', 'languages', [User::getLanguageCode($channel['uid'])]))) {
 					$store = true;
 					$this->logger->debug('Matching channel found.', ['uid' => $channel['uid'], 'label' => $channel['label'], 'language' => $language, 'channelsearchtext' => $channelsearchtext, 'searchtext' => $searchtext]);
@@ -171,7 +171,7 @@ class UserDefinedChannel extends \Friendica\BaseRepository
 		}
 		$this->db->close($channels);
 
-		$this->db->delete('test-full-text-search', ['pid' => getmypid()]);
+		$this->db->delete('check-full-text-search', ['pid' => getmypid()]);
 		return $store;
 	}
 }

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -240,7 +240,7 @@ class GServer
 		} elseif (!empty($contact['baseurl'])) {
 			$server = $contact['baseurl'];
 		} elseif ($contact['network'] == Protocol::DIASPORA) {
-			$parts = parse_url($contact['url']);
+			$parts = (array)parse_url($contact['url']);
 			unset($parts['path']);
 			$server = (string)Uri::fromParts($parts);
 		} else {
@@ -589,7 +589,7 @@ class GServer
 			if ((parse_url($url, PHP_URL_HOST) != parse_url($valid_url, PHP_URL_HOST)) && (parse_url($url, PHP_URL_PATH) != parse_url($valid_url, PHP_URL_PATH)) &&
 				(parse_url($url, PHP_URL_PATH) == '')) {
 				Logger::debug('Found redirect. Mark old entry as failure and redirect to the basepath.', ['old' => $url, 'new' => $valid_url]);
-				$parts = parse_url($valid_url);
+				$parts = (array)parse_url($valid_url);
 				unset($parts['path']);
 				$valid_url = (string)Uri::fromParts($parts);
 

--- a/src/Model/Search.php
+++ b/src/Model/Search.php
@@ -22,6 +22,8 @@
 namespace Friendica\Model;
 
 use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Util\DateTimeFormat;
 
 /**
  * Model for DB specific logic for the search entity
@@ -36,14 +38,43 @@ class Search
 	 */
 	public static function getUserTags(): array
 	{
-		$termsStmt = DBA::p("SELECT DISTINCT(`term`) FROM `search`");
+		$user_condition = ["`verified` AND NOT `blocked` AND NOT `account_removed` AND NOT `account_expired` AND `user`.`uid` > ?", 0];
+
+		$abandon_days = intval(DI::config()->get('system', 'account_abandon_days'));
+		if (!empty($abandon_days)) {
+			$user_condition = DBA::mergeConditions($user_condition, ["`last-activity` > ?", DateTimeFormat::utc('now - ' . $abandon_days . ' days')]);
+		}
+
+		$condition = $user_condition;
+		$condition[0] = "SELECT DISTINCT(`term`) FROM `search` INNER JOIN `user` ON `search`.`uid` = `user`.`uid` WHERE " . $user_condition[0];
+		$sql = array_shift($condition);
+		$termsStmt = DBA::p($sql, $condition);
 
 		$tags = [];
-
 		while ($term = DBA::fetch($termsStmt)) {
 			$tags[] = trim(mb_strtolower($term['term']), '#');
 		}
 		DBA::close($termsStmt);
+
+		$condition = $user_condition;
+		$condition[0] = "SELECT `include-tags` FROM `channel` INNER JOIN `user` ON `channel`.`uid` = `user`.`uid` WHERE " . $user_condition[0];
+		$sql = array_shift($condition);
+		$channels = DBA::p($sql, $condition);
+		while ($channel = DBA::fetch($channels)) {
+			foreach (explode(',', $channel['include-tags']) as $tag) {
+				$tag = trim(mb_strtolower($tag));
+				if (empty($tag)) {
+					continue;
+				}
+				if (!in_array($tag, $tags)) {
+					$tags[]	= $tag;
+				}
+			}
+		}
+		DBA::close($channels);
+
+		sort($tags);
+
 		return $tags;
 	}
 }

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -582,6 +582,12 @@ class User
 	 */
 	public static function getLanguages(): array
 	{
+		$cachekey  = 'user:getLanguages';
+		$languages = DI::cache()->get($cachekey);
+		if (!is_null($languages)) {
+			return $languages;
+		}
+
 		$supported = array_keys(DI::l10n()->getLanguageCodes());
 		$languages = [];
 		$uids      = [];
@@ -620,7 +626,10 @@ class User
 		DBA::close($channels);
 
 		ksort($languages);
-		return array_keys($languages);
+		$languages = array_keys($languages);
+		DI::cache()->set($cachekey, $languages);
+
+		return $languages;
 	}
 
 	/**

--- a/src/Module/Conversation/Timeline.php
+++ b/src/Module/Conversation/Timeline.php
@@ -391,7 +391,7 @@ class Timeline extends BaseModule
 
 		if (!empty($channel->fullTextSearch)) {
 			$search = $channel->fullTextSearch;
-			foreach (['from', 'to', 'group', 'tag', 'network', 'visibility'] as $keyword) {
+			foreach (['from', 'to', 'group', 'tag', 'network', 'platform', 'visibility'] as $keyword) {
 				$search = preg_replace('~(' . $keyword . ':.[\w@\.-]+)~', '"$1"', $search);
 			}
 			$condition = DBA::mergeConditions($condition, ["MATCH (`searchtext`) AGAINST (? IN BOOLEAN MODE)", $search]);

--- a/src/Protocol/Relay.php
+++ b/src/Protocol/Relay.php
@@ -193,12 +193,7 @@ class Relay
 		}
 
 		if (!empty($languages) || !empty($detected)) {
-			$cachekey = 'relay:isWantedLanguage';
-			$user_languages = DI::cache()->get($cachekey);
-			if (is_null($user_languages)) {
-				$user_languages = User::getLanguages();
-				DI::cache()->set($cachekey, $user_languages);
-			}
+			$user_languages = User::getLanguages();
 
 			foreach ($detected as $language) {
 				if (in_array($language, $user_languages)) {

--- a/src/Worker/OptimizeTables.php
+++ b/src/Worker/OptimizeTables.php
@@ -46,6 +46,7 @@ class OptimizeTables
 		DBA::optimizeTable('parsed_url');
 		DBA::optimizeTable('session');
 		DBA::optimizeTable('post-engagement');
+		DBA::optimizeTable('test-full-text-search');
 
 		if (DI::config()->get('system', 'optimize_all_tables')) {
 			DBA::optimizeTable('apcontact');

--- a/src/Worker/OptimizeTables.php
+++ b/src/Worker/OptimizeTables.php
@@ -46,7 +46,7 @@ class OptimizeTables
 		DBA::optimizeTable('parsed_url');
 		DBA::optimizeTable('session');
 		DBA::optimizeTable('post-engagement');
-		DBA::optimizeTable('test-full-text-search');
+		DBA::optimizeTable('check-full-text-search');
 
 		if (DI::config()->get('system', 'optimize_all_tables')) {
 			DBA::optimizeTable('apcontact');

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1858,10 +1858,10 @@ return [
 			"uid_application-id" => ["uid", "application-id"],
 		]
 	],
-	"test-full-text-search" => [
-		"comment" => "Test for a full text search match in user defined channels before storing the message in the system",
+	"check-full-text-search" => [
+		"comment" => "Check for a full text search match in user defined channels before storing the message in the system",
 		"fields" => [
-			"pid" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "comment" => "Process id of the worker"],
+			"pid" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "comment" => "The ID of the process"],
 			"searchtext" => ["type" => "mediumtext", "comment" => "Simplified text for the full text search"],
 		],
 		"indexes" => [

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -56,7 +56,7 @@ use Friendica\Database\DBA;
 
 // This file is required several times during the test in DbaDefinition which justifies this condition
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1539);
+	define('DB_UPDATE_VERSION', 1540);
 }
 
 return [
@@ -1857,6 +1857,17 @@ return [
 			"application-id_uid" => ["UNIQUE", "application-id", "uid"],
 			"uid_application-id" => ["uid", "application-id"],
 		]
+	],
+	"test-full-text-search" => [
+		"comment" => "Test for a full text search match in user defined channels before storing the message in the system",
+		"fields" => [
+			"pid" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "comment" => "Process id of the worker"],
+			"searchtext" => ["type" => "mediumtext", "comment" => "Simplified text for the full text search"],
+		],
+		"indexes" => [
+			"PRIMARY" => ["pid"],
+			"searchtext" => ["FULLTEXT", "searchtext"],
+		],
 	],
 	"userd" => [
 		"comment" => "Deleted usernames",


### PR DESCRIPTION
When receiving relay posts, we already have some checks, so we don't accept every post. Now we also check for the channel languages and we check if there are any user defined channels that match to this message.