### PR TITLE
Add expected xmlns attribute to group feed entries

### DIFF
--- a/src/Protocol/OStatus.php
+++ b/src/Protocol/OStatus.php
@@ -1470,6 +1470,8 @@ class OStatus
 			$entry = $doc->createElement('entry');
 
 			if ($owner['contact-type'] == Contact::TYPE_COMMUNITY) {
+				$entry->setAttribute('xmlns:activity', ActivityNamespace::ACTIVITY);
+
 				$contact = Contact::getByURL($item['author-link']) ?: $owner;
 				$contact['nickname'] = $contact['nickname'] ?? $contact['nick'];
 				$author = self::addAuthor($doc, $contact, false);


### PR DESCRIPTION
Should fix #10369 

This is a tentative fix, I wasn't able to test it because I don't have a group account available in my test environment. If an admin who does has such a setup, I would be grateful to them for testing this one-liner fix.