### PR TITLE
Allow to upload pictures up to the allowed system upload size

### DIFF
--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -36,6 +36,7 @@ use Friendica\Core\System;
 use Friendica\Core\Theme;
 use Friendica\Module\Response;
 use Friendica\Network\HTTPException;
+use Friendica\Util\Images;
 use Friendica\Util\Network;
 use Friendica\Util\Profiler;
 use Friendica\Util\Strings;
@@ -282,7 +283,7 @@ class Page implements ArrayAccess
 			'$stylesheets'     => $this->stylesheets,
 
 			// Dropzone
-			'$max_imagesize' => round(\Friendica\Util\Strings::getBytesFromShorthand($config->get('system', 'maximagesize')) / 1000000, 1),
+			'$max_imagesize' => round(Images::getMaxUploadBytes() / 1000000, 0),
 
 		]) . $this->page['htmlhead'];
 	}

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -95,7 +95,7 @@ class Display extends BaseSettings
 		$user = User::getById($uid);
 
 		$theme                  = trim($request['theme']);
-		$mobile_theme           = trim($request['mobile_theme']);
+		$mobile_theme           = trim($request['mobile_theme'] ?? '');
 		$enable_smile           = (bool)$request['enable_smile'];
 		$enable                 = (array)$request['enable'];
 		$bookmark               = (array)$request['bookmark'];

--- a/src/Util/Images.php
+++ b/src/Util/Images.php
@@ -244,22 +244,24 @@ class Images
 		$filesize = strlen($img_str);
 
 		try {
-			$data = @getimagesizefromstring($img_str);
+			$data = (array)@getimagesizefromstring($img_str);
 		} catch (\Exception $e) {
 			return [];
 		}
 
-		if ($data) {
-			$image = new Image($img_str);
-
-			if ($image->isValid()) {
-				$data['blurhash'] = $image->getBlurHash();
-			}
-
-			$data['size'] = $filesize;
+		if (empty($data)) {
+			return [];
 		}
 
-		return is_array($data) ? $data : [];
+		$image = new Image($img_str);
+
+		if ($image->isValid()) {
+			$data['blurhash'] = $image->getBlurHash();
+		}
+
+		$data['size'] = $filesize;
+
+		return $data;
 	}
 
 	/**
@@ -351,5 +353,16 @@ class Images
 		}
 
 		return '[img=' . $photo . ']' . $description . '[/img]';
+	}
+
+	/**
+	 * Get the maximum possible upload size in bytes
+	 *
+	 * @return integer
+	 */
+	public static function getMaxUploadBytes(): int
+	{
+		$upload_size = ini_get('upload_max_filesize') ?: DI::config()->get('system', 'maximagesize');
+		return Strings::getBytesFromShorthand($upload_size);
 	}
 }


### PR DESCRIPTION
We don't have to check for our allowed picture size before uploading the image, since we have got automated size checks in the system that will decrease the picture until the picture size is reached.