### PR TITLE
(Security) HTML-escape notification contact names

### DIFF
--- a/src/Navigation/Notifications/Entity/Notify.php
+++ b/src/Navigation/Notifications/Entity/Notify.php
@@ -134,6 +134,6 @@ class Notify extends BaseEntity
 	 */
 	public static function formatMessage(string $name, string $message): string
 	{
-		return str_replace('{0}', '<span class="contactname">' . BBCode::toPlaintext($name, false) . '</span>', htmlspecialchars($message));
+		return str_replace('{0}', '<span class="contactname">' . htmlspecialchars(BBCode::toPlaintext($name, false)) . '</span>', htmlspecialchars($message));
 	}
 }


### PR DESCRIPTION
This patch fixes a potential security issue I encountered in a recent development version of Friendica: **display names containing HTML markup are not HTML-escaped in Friendica's notification list panel.** A user with any HTML markup(!!) in their display name, which is displayed as plain text elsewhere, can inject that markup into another user's Friendica UI simply by interacting with a post. (This actually happened to me by accident, which is how I noticed the problem.)

You should be able to replicate this bug just by creating a user with HTML in their display name, either on your local instance or a remote one, then liking/replying to/etc. one of your own posts as that user.

(Sorry for being a faceless, anonymous user with no previous history, by the way; I just prefer to use other repository-hosting platforms over GitHub.)