### PR TITLE
Fix warning: Undefined array key "mime"

### DIFF
--- a/src/Util/Images.php
+++ b/src/Util/Images.php
@@ -244,12 +244,12 @@ class Images
 		$filesize = strlen($img_str);
 
 		try {
-			$data = (array)@getimagesizefromstring($img_str);
+			$data = @getimagesizefromstring($img_str);
 		} catch (\Exception $e) {
 			return [];
 		}
 
-		if (empty($data)) {
+		if (!$data) {
 			return [];
 		}
 


### PR DESCRIPTION
This fixes the warning `E_WARNING: Undefined array key "mime"`