### PR TITLE
Fix substituting smilies and smilies containing whitespaces

### DIFF
--- a/tests/Util/SmileyWhitespaceAddon.php
+++ b/tests/Util/SmileyWhitespaceAddon.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2023, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+use Friendica\Content\Smilies;
+
+function add_test_unicode_smilies(array &$b)
+{
+	// String-substitution smilies
+	// - no whitespaces
+	Smilies::add($b, '⽕', '&#x1F525;');
+	// - with whitespaces
+	Smilies::add($b, ':hugging face:', '&#x1F917;');
+	// - with multiple whitespaces
+	Smilies::add($b, ':face with hand over mouth:', '&#x1F92D;');
+	// Image-based smilies
+	// - with whitespaces
+	Smilies::add($b, ':smiley heart 333:', '<img class="smiley" src="/images/smiley-heart.gif" alt="smiley-heart" title="smiley-heart" />');
+}

--- a/tests/datasets/api.fixture.php
+++ b/tests/datasets/api.fixture.php
@@ -371,7 +371,7 @@ return [
 		[
 			'uri-id' => 100,
 			'title'  => 'item_title',
-			'body'   => ':like ~friendica no [code]:dislike[/code] :-p :-[ <3',
+			'body'   => ':like ~friendica no [code]:dislike[/code] :-p :-[ :hugging face: <3 :smiley heart 333: ⽕',
 			'plink'  => 'https://friendica.local/post/100',
 		],
 	],

--- a/tests/src/Content/SmiliesTest.php
+++ b/tests/src/Content/SmiliesTest.php
@@ -26,6 +26,7 @@
 namespace Friendica\Test\src\Content;
 
 use Friendica\Content\Smilies;
+use Friendica\Core\Hook;
 use Friendica\DI;
 use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Test\FixtureTest;
@@ -37,6 +38,9 @@ class SmiliesTest extends FixtureTest
 		parent::setUp();
 
 		DI::config()->set('system', 'no_smilies', false);
+
+		Hook::register('smilie', 'tests/Util/SmileyWhitespaceAddon.php', 'add_test_unicode_smilies');
+		Hook::loadHooks();
 	}
 
 	public function dataLinks()
@@ -184,6 +188,26 @@ class SmiliesTest extends FixtureTest
 				'expected' => '(3&lt;33)',
 				'body' => '(3&lt;33)',
 			],
+			'space' => [
+				'expected' => 'alt="smiley-heart"',
+				'body' => ':smiley heart 333:',
+			],
+			'substitution-1' => [
+				'expected' => '&#x1F525;',
+				'body' => '⽕',
+			],
+			'substitution-2' => [
+				'expected' => '&#x1F917;',
+				'body' => ':hugging face:',
+			],
+			'substitution-3' => [
+				'expected' => '&#x1F92D;',
+				'body' => ':face with hand over mouth:',
+			],
+			'mixed' => [
+				'expected' => '&#x1F525; &#x1F92D; invalid:hugging face: &#x1F917;',
+				'body' => '⽕ :face with hand over mouth: invalid:hugging face: :hugging face:',
+			],
 		];
 		foreach ([':-[', ':-D', 'o.O'] as $emoji) {
 			foreach (['A', '_', ':', '-'] as $prefix) {
@@ -244,6 +268,31 @@ class SmiliesTest extends FixtureTest
 				'expected' => ['friendica'],
 				'body' => '~friendica',
 				'normalized' => ':friendica:'
+			],
+			'space' => [
+				'expected' => ['smileyheart333'],
+				'body' => ':smiley heart 333:',
+				'normalized' => ':smileyheart333:'
+			],
+			'substitution-1' => [
+				'expected' => [],
+				'body' => '⽕',
+				'normalized' => '&#x1F525;',
+			],
+			'substitution-2' => [
+				'expected' => [],
+				'body' => ':hugging face:',
+				'normalized' => '&#x1F917;',
+			],
+			'substitution-3' => [
+				'expected' => [],
+				'body' => ':face with hand over mouth:',
+				'normalized' => '&#x1F92D;',
+			],
+			'mixed' => [
+				'expected' => [],
+				'body' => '⽕ :face with hand over mouth: invalid:hugging face: :hugging face:',
+				'normalized' => '&#x1F525; &#x1F92D; invalid:hugging face: &#x1F917;',
 			],
 		];
 	}

--- a/tests/src/Factory/Api/Mastodon/StatusTest.php
+++ b/tests/src/Factory/Api/Mastodon/StatusTest.php
@@ -21,8 +21,9 @@
 
 namespace Friendica\Test\src\Factory\Api\Mastodon;
 
-use Friendica\Model\Post;
+use Friendica\Core\Hook;
 use Friendica\DI;
+use Friendica\Model\Post;
 use Friendica\Test\FixtureTest;
 
 class StatusTest extends FixtureTest
@@ -35,6 +36,9 @@ class StatusTest extends FixtureTest
 
 		DI::config()->set('system', 'no_smilies', false);
 		$this->status = DI::mstdnStatus();
+
+		Hook::register('smilie', 'tests/Util/SmileyWhitespaceAddon.php', 'add_test_unicode_smilies');
+		Hook::loadHooks();
 	}
 
 	public function testSimpleStatus()
@@ -50,8 +54,8 @@ class StatusTest extends FixtureTest
 		$post = Post::selectFirst([], ['id' => 14]);
 		$this->assertNotNull($post);
 		$result = $this->status->createFromUriId($post['uri-id'])->toArray();
-		$this->assertEquals(':like: :friendica: no <code>:dislike</code> :p: :embarrassed: ❤', $result['content']);
-		$emojis = array_fill_keys(['like', 'friendica', 'p', 'embarrassed'], true);
+		$this->assertEquals(':like: :friendica: no <code>:dislike</code> :p: :embarrassed: 🤗 ❤ :smileyheart333: 🔥', $result['content']);
+		$emojis = array_fill_keys(['like', 'friendica', 'p', 'embarrassed', 'smileyheart333'], true);
 		$this->assertEquals(count($emojis), count($result['emojis']));
 		foreach ($result['emojis'] as $emoji) {
 			$this->assertTrue(array_key_exists($emoji['shortcode'], $emojis));

--- a/tests/src/Protocol/ActivityPub/TransmitterTest.php
+++ b/tests/src/Protocol/ActivityPub/TransmitterTest.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Test\src\Protocol\ActivityPub;
 
+use Friendica\Core\Hook;
 use Friendica\DI;
 use Friendica\Model\Post;
 use Friendica\Protocol\ActivityPub\Transmitter;
@@ -33,6 +34,9 @@ class TransmitterTest extends FixtureTest
 		parent::setUp();
 
 		DI::config()->set('system', 'no_smilies', false);
+
+		Hook::register('smilie', 'tests/Util/SmileyWhitespaceAddon.php', 'add_test_unicode_smilies');
+		Hook::loadHooks();
 	}
 
 	public function testEmojiPost()
@@ -42,8 +46,8 @@ class TransmitterTest extends FixtureTest
 		$note = Transmitter::createNote($post);
 		$this->assertNotNull($note);
 
-		$this->assertEquals(':like: :friendica: no <code>:dislike</code> :p: :embarrassed: ❤', $note['content']);
-		$emojis = array_fill_keys(['like', 'friendica', 'p', 'embarrassed'], true);
+		$this->assertEquals(':like: :friendica: no <code>:dislike</code> :p: :embarrassed: 🤗 ❤ :smileyheart333: 🔥', $note['content']);
+		$emojis = array_fill_keys(['like', 'friendica', 'p', 'embarrassed', 'smileyheart333'], true);
 		$this->assertEquals(count($emojis), count($note['tag']));
 		foreach ($note['tag'] as $emoji) {
 			$this->assertTrue(array_key_exists($emoji['name'], $emojis));


### PR DESCRIPTION
This PR fixes the smiley regression introduced by the previous PR #13635. This comes in two parts:

1. Fix for substitution-type smilies:

   Originally, smilies in Friendica seemed to be simple string substitutions (and they are rendered that way in Friendica). But to bridge between protocols, we categorize them into image-based ones and text-based ones. The previous PR handled image ones but failed to do so for text-based ones (e.g., those implemented in the `unicode_smilies` addon replacing smilies with Unicode escape sequences).
   
   This fix simply defaults to text substitution when it finds no image in a smiley.
   
   (Also, it occurs to me that the smiley processing does not handle smilies with multiple images (like `<img ... /><img ... />`). I don't think an addon should ever do that, but, we don't have a spec.)

2. Fix for smiley containing whitespaces:

   The inner loop in the previous PR should already be able to handle whitespaces, but I was too lazy to remove the outer loop (and ignorant of `unicode_smilies`). This fix just removes the outer loop that splits the string by whitespaces (as well as adjusting some conditions).

fixes #13662 