### PR TITLE
Improved control about the contact/server updates

### DIFF
--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -2373,16 +2373,16 @@ class GServer
 	 */
 	public static function discover()
 	{
+		if (!DI::config('system', 'discover_servers')) {
+			return;
+		}
+
 		// Update the server list
 		self::discoverFederation();
 
 		$no_of_queries = 5;
 
 		$requery_days = intval(DI::config()->get('system', 'poco_requery_days'));
-
-		if ($requery_days == 0) {
-			$requery_days = 7;
-		}
 
 		$last_update = date('c', time() - (60 * 60 * 24 * $requery_days));
 

--- a/src/Module/Admin/Site.php
+++ b/src/Module/Admin/Site.php
@@ -111,6 +111,7 @@ class Site extends BaseAdmin
 		$min_memory             = (!empty($_POST['min_memory'])             ? intval(trim($_POST['min_memory']))             : 0);
 		$optimize_tables        = (!empty($_POST['optimize_tables'])        ? intval(trim($_POST['optimize_tables']))        : false);
 		$contact_discovery      = (!empty($_POST['contact_discovery'])      ? intval(trim($_POST['contact_discovery']))      : Contact\Relation::DISCOVERY_NONE);
+		$update_active_contacts = (!empty($_POST['update_active_contacts']) ? intval(trim($_POST['update_active_contacts'])) : false);
 		$synchronize_directory  = (!empty($_POST['synchronize_directory'])  ? intval(trim($_POST['synchronize_directory']))  : false);
 		$poco_requery_days      = (!empty($_POST['poco_requery_days'])      ? intval(trim($_POST['poco_requery_days']))      : 7);
 		$poco_discovery         = (!empty($_POST['poco_discovery'])         ? intval(trim($_POST['poco_discovery']))         : false);
@@ -156,15 +157,16 @@ class Site extends BaseAdmin
 			$diaspora_enabled = false;
 		}
 
-		$transactionConfig->set('system', 'maxloadavg'            , $maxloadavg);
-		$transactionConfig->set('system', 'min_memory'            , $min_memory);
-		$transactionConfig->set('system', 'optimize_tables'       , $optimize_tables);
-		$transactionConfig->set('system', 'contact_discovery'     , $contact_discovery);
-		$transactionConfig->set('system', 'synchronize_directory' , $synchronize_directory);
-		$transactionConfig->set('system', 'poco_requery_days'     , $poco_requery_days);
-		$transactionConfig->set('system', 'poco_discovery'        , $poco_discovery);
-		$transactionConfig->set('system', 'poco_local_search'     , $poco_local_search);
-		$transactionConfig->set('system', 'nodeinfo'              , $nodeinfo);
+		$transactionConfig->set('system', 'maxloadavg'             , $maxloadavg);
+		$transactionConfig->set('system', 'min_memory'             , $min_memory);
+		$transactionConfig->set('system', 'optimize_tables'        , $optimize_tables);
+		$transactionConfig->set('system', 'contact_discovery'      , $contact_discovery);
+		$transactionConfig->set('system', 'update_active_contacts' , $update_active_contacts);
+		$transactionConfig->set('system', 'synchronize_directory'  , $synchronize_directory);
+		$transactionConfig->set('system', 'poco_requery_days'      , $poco_requery_days);
+		$transactionConfig->set('system', 'poco_discovery'         , $poco_discovery);
+		$transactionConfig->set('system', 'poco_local_search'      , $poco_local_search);
+		$transactionConfig->set('system', 'nodeinfo'               , $nodeinfo);
 		if (DI::config()->isWritable('config', 'sitename')) {
 			$transactionConfig->set('config', 'sitename', $sitename);
 		}
@@ -486,10 +488,11 @@ class Site extends BaseAdmin
 				'<li>' . DI::l10n()->t('Local contacts - contacts of our local contacts are discovered for their followers/followings.') . '</li>' .
 				'<li>' . DI::l10n()->t('Interactors - contacts of our local contacts and contacts who interacted on locally visible postings are discovered for their followers/followings.') . '</li></ul>',
 				$discovery_choices],
+			'$update_active_contacts' => ['update_active_contacts', DI::l10n()->t('Only update contacts/servers with local data'), DI::config()->get('system', 'update_active_contacts'), DI::l10n()->t('If enabled, the system will only look for changes in contacts and servers that engaged on this system by either being in a contact list of a user or when posts or comments exists from the contact on this system.')],	
 			'$synchronize_directory'  => ['synchronize_directory', DI::l10n()->t('Synchronize the contacts with the directory server'), DI::config()->get('system', 'synchronize_directory'), DI::l10n()->t('if enabled, the system will check periodically for new contacts on the defined directory server.')],
 
-			'$poco_requery_days'      => ['poco_requery_days', DI::l10n()->t('Days between requery'), DI::config()->get('system', 'poco_requery_days'), DI::l10n()->t('Number of days after which a server is requeried for his contacts.')],
-			'$poco_discovery'         => ['poco_discovery', DI::l10n()->t('Discover contacts from other servers'), DI::config()->get('system', 'poco_discovery'), DI::l10n()->t('Periodically query other servers for contacts. The system queries Friendica, Mastodon and Hubzilla servers.')],
+			'$poco_discovery'         => ['poco_discovery', DI::l10n()->t('Discover contacts from other servers'), DI::config()->get('system', 'poco_discovery'), DI::l10n()->t('Periodically query other servers for contacts and servers that they know of. The system queries Friendica, Mastodon and Hubzilla servers. Keep it deactivated on small machines to decrease the database size and load.')],
+			'$poco_requery_days'      => ['poco_requery_days', DI::l10n()->t('Days between requery'), DI::config()->get('system', 'poco_requery_days'), DI::l10n()->t('Number of days after which a server is requeried for their contacts and servers it knows of. This is only used when the discovery is activated.')],
 			'$poco_local_search'      => ['poco_local_search', DI::l10n()->t('Search the local directory'), DI::config()->get('system', 'poco_local_search'), DI::l10n()->t('Search the local directory instead of the global directory. When searching locally, every search will be executed on the global directory in the background. This improves the search results when the search is repeated.')],
 
 			'$nodeinfo'               => ['nodeinfo', DI::l10n()->t('Publish server information'), DI::config()->get('system', 'nodeinfo'), DI::l10n()->t('If enabled, general server and usage data will be published. The data contains the name and version of the server, number of users with public profiles, number of posts and the activated protocols and connectors. See <a href="http://the-federation.info/">the-federation.info</a> for details.')],

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -76,7 +76,9 @@ class Cron
 		Worker::add(Worker::PRIORITY_LOW, 'UpdateGServers');
 
 		// run the process to update server directories in the background
-		Worker::add(Worker::PRIORITY_LOW, 'UpdateServerDirectories');
+		if (DI::config()->get('system', 'poco_discovery')) {
+			Worker::add(Worker::PRIORITY_LOW, 'UpdateServerDirectories');
+		}
 
 		// Expire and remove user entries
 		Worker::add(Worker::PRIORITY_MEDIUM, 'ExpireAndRemoveUsers');

--- a/src/Worker/UpdateServerDirectory.php
+++ b/src/Worker/UpdateServerDirectory.php
@@ -36,6 +36,10 @@ class UpdateServerDirectory
 	 */
 	public static function execute(array $gserver)
 	{
+		if (!DI::config()->get('system', 'poco_discovery')) {
+			return;
+		}
+
 		if ($gserver['directory-type'] == GServer::DT_MASTODON) {
 			self::discoverMastodonDirectory($gserver);
 		} elseif (!empty($gserver['poco'])) {

--- a/src/Worker/UpdateServerPeers.php
+++ b/src/Worker/UpdateServerPeers.php
@@ -40,6 +40,10 @@ class UpdateServerPeers
 	 */
 	public static function execute(string $url)
 	{
+		if (!DI::config()->get('system', 'poco_discovery')) {
+			return;
+		}
+
 		$ret = DI::httpClient()->get($url . '/api/v1/instance/peers', HttpClientAccept::JSON);
 		if (!$ret->isSuccess() || empty($ret->getBody())) {
 			Logger::info('Server is not reachable or does not offer the "peers" endpoint', ['url' => $url]);

--- a/static/settings.config.php
+++ b/static/settings.config.php
@@ -212,6 +212,14 @@ return [
 		// The fully-qualified URL of this Friendica node.
 		// Used by the worker in a non-HTTP execution environment.
 		'url' => '',
+
+		// poco_discovery (Boolean)
+		// If enabled, the system will check for the existance of other contacts and servers
+		'poco_discovery' => false,
+
+		// poco_requery_days (Integer)
+		// Number of days after which a server is requeried for their contacts and servers it knows of.
+		'poco_requery_days' => 30,
 	],
 
 	// Used in the admin settings to lock certain features

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2023.09-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-25 14:54+0000\n"
+"POT-Creation-Date: 2023-11-27 19:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -602,7 +602,7 @@ msgid "Rotate CCW (left)"
 msgstr ""
 
 #: mod/photos.php:1139 mod/photos.php:1195 mod/photos.php:1275
-#: src/Module/Contact.php:618 src/Module/Item/Compose.php:188
+#: src/Module/Contact.php:611 src/Module/Item/Compose.php:188
 #: src/Object/Post.php:1146
 msgid "This is you"
 msgstr ""
@@ -796,22 +796,18 @@ msgid "All contacts"
 msgstr ""
 
 #: src/BaseModule.php:439 src/Content/Conversation/Factory/Channel.php:45
-#: src/Content/Widget.php:239 src/Core/ACL.php:195 src/Module/Contact.php:414
+#: src/Content/Widget.php:239 src/Core/ACL.php:195 src/Module/Contact.php:410
 #: src/Module/PermissionTooltip.php:141 src/Module/PermissionTooltip.php:163
 #: src/Module/Settings/Channels.php:121
 msgid "Followers"
 msgstr ""
 
-#: src/BaseModule.php:444 src/Content/Widget.php:240 src/Module/Contact.php:417
+#: src/BaseModule.php:444 src/Content/Widget.php:240 src/Module/Contact.php:413
 #: src/Module/Settings/Channels.php:120
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:449 src/Content/Widget.php:241 src/Module/Contact.php:420
-msgid "Mutual friends"
-msgstr ""
-
-#: src/BaseModule.php:457
+#: src/BaseModule.php:452
 msgid "Common"
 msgstr ""
 
@@ -1748,7 +1744,7 @@ msgid ""
 msgstr ""
 
 #: src/Content/GroupManager.php:152 src/Content/Nav.php:278
-#: src/Content/Text/HTML.php:880 src/Content/Widget.php:537
+#: src/Content/Text/HTML.php:880 src/Content/Widget.php:536
 #: src/Model/User.php:1355
 msgid "Groups"
 msgstr ""
@@ -1757,12 +1753,12 @@ msgstr ""
 msgid "External link to group"
 msgstr ""
 
-#: src/Content/GroupManager.php:158 src/Content/Widget.php:512
+#: src/Content/GroupManager.php:158 src/Content/Widget.php:511
 msgid "show less"
 msgstr ""
 
-#: src/Content/GroupManager.php:159 src/Content/Widget.php:410
-#: src/Content/Widget.php:513
+#: src/Content/GroupManager.php:159 src/Content/Widget.php:409
+#: src/Content/Widget.php:512
 msgid "show more"
 msgstr ""
 
@@ -1820,7 +1816,7 @@ msgstr ""
 msgid "Send PM"
 msgstr ""
 
-#: src/Content/Item.php:436 src/Module/Contact.php:467
+#: src/Content/Item.php:436 src/Module/Contact.php:460
 #: src/Module/Contact/Profile.php:511
 #: src/Module/Moderation/Blocklist/Contact.php:116
 #: src/Module/Moderation/Users/Active.php:137
@@ -1828,7 +1824,7 @@ msgstr ""
 msgid "Block"
 msgstr ""
 
-#: src/Content/Item.php:437 src/Module/Contact.php:468
+#: src/Content/Item.php:437 src/Module/Contact.php:461
 #: src/Module/Contact/Profile.php:519
 #: src/Module/Notifications/Introductions.php:134
 #: src/Module/Notifications/Introductions.php:206
@@ -1836,7 +1832,7 @@ msgstr ""
 msgid "Ignore"
 msgstr ""
 
-#: src/Content/Item.php:438 src/Module/Contact.php:469
+#: src/Content/Item.php:438 src/Module/Contact.php:462
 #: src/Module/Contact/Profile.php:527
 msgid "Collapse"
 msgstr ""
@@ -1894,7 +1890,7 @@ msgid "Sign in"
 msgstr ""
 
 #: src/Content/Nav.php:229 src/Module/BaseProfile.php:57
-#: src/Module/Contact.php:511
+#: src/Module/Contact.php:504
 msgid "Conversations"
 msgstr ""
 
@@ -1903,7 +1899,7 @@ msgid "Conversations you started"
 msgstr ""
 
 #: src/Content/Nav.php:230 src/Module/BaseProfile.php:49
-#: src/Module/BaseSettings.php:98 src/Module/Contact.php:503
+#: src/Module/BaseSettings.php:98 src/Module/Contact.php:496
 #: src/Module/Contact/Profile.php:419 src/Module/Profile/Profile.php:268
 #: src/Module/Welcome.php:57 view/theme/frio/theme.php:230
 msgid "Profile"
@@ -1923,7 +1919,7 @@ msgid "Your photos"
 msgstr ""
 
 #: src/Content/Nav.php:232 src/Module/BaseProfile.php:73
-#: src/Module/BaseProfile.php:76 src/Module/Contact.php:527
+#: src/Module/BaseProfile.php:76 src/Module/Contact.php:520
 #: view/theme/frio/theme.php:235
 msgid "Media"
 msgstr ""
@@ -2009,8 +2005,8 @@ msgstr ""
 
 #: src/Content/Nav.php:274 src/Content/Nav.php:329
 #: src/Content/Text/HTML.php:876 src/Module/BaseProfile.php:127
-#: src/Module/BaseProfile.php:130 src/Module/Contact.php:426
-#: src/Module/Contact.php:535 view/theme/frio/theme.php:243
+#: src/Module/BaseProfile.php:130 src/Module/Contact.php:419
+#: src/Module/Contact.php:528 view/theme/frio/theme.php:243
 msgid "Contacts"
 msgstr ""
 
@@ -2263,7 +2259,7 @@ msgstr ""
 msgid "Examples: Robert Morgenstein, Fishing"
 msgstr ""
 
-#: src/Content/Widget.php:82 src/Module/Contact.php:460
+#: src/Content/Widget.php:82 src/Module/Contact.php:453
 #: src/Module/Directory.php:96 view/theme/vier/theme.php:197
 msgid "Find"
 msgstr ""
@@ -2295,7 +2291,7 @@ msgid "Local Directory"
 msgstr ""
 
 #: src/Content/Widget.php:215 src/Model/Circle.php:601
-#: src/Module/Contact.php:400 src/Module/Welcome.php:76
+#: src/Module/Contact.php:396 src/Module/Welcome.php:76
 msgid "Circles"
 msgstr ""
 
@@ -2303,75 +2299,75 @@ msgstr ""
 msgid "Everyone"
 msgstr ""
 
-#: src/Content/Widget.php:242 src/Module/Contact.php:423
+#: src/Content/Widget.php:241 src/Module/Contact.php:416
 msgid "No relationship"
 msgstr ""
 
-#: src/Content/Widget.php:247
+#: src/Content/Widget.php:246
 msgid "Relationships"
 msgstr ""
 
-#: src/Content/Widget.php:249 src/Module/Circle.php:292
-#: src/Module/Contact.php:344
+#: src/Content/Widget.php:248 src/Module/Circle.php:292
+#: src/Module/Contact.php:340
 msgid "All Contacts"
 msgstr ""
 
-#: src/Content/Widget.php:288
+#: src/Content/Widget.php:287
 msgid "Protocols"
 msgstr ""
 
-#: src/Content/Widget.php:290
+#: src/Content/Widget.php:289
 msgid "All Protocols"
 msgstr ""
 
-#: src/Content/Widget.php:318
+#: src/Content/Widget.php:317
 msgid "Saved Folders"
 msgstr ""
 
-#: src/Content/Widget.php:320 src/Content/Widget.php:351
+#: src/Content/Widget.php:319 src/Content/Widget.php:350
 msgid "Everything"
 msgstr ""
 
-#: src/Content/Widget.php:349
+#: src/Content/Widget.php:348
 msgid "Categories"
 msgstr ""
 
-#: src/Content/Widget.php:406
+#: src/Content/Widget.php:405
 #, php-format
 msgid "%d contact in common"
 msgid_plural "%d contacts in common"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/Widget.php:506
+#: src/Content/Widget.php:505
 msgid "Archives"
 msgstr ""
 
-#: src/Content/Widget.php:514
+#: src/Content/Widget.php:513
 msgid "On this date"
 msgstr ""
 
-#: src/Content/Widget.php:534
+#: src/Content/Widget.php:533
 msgid "Persons"
 msgstr ""
 
-#: src/Content/Widget.php:535
+#: src/Content/Widget.php:534
 msgid "Organisations"
 msgstr ""
 
-#: src/Content/Widget.php:536 src/Model/Contact.php:1714
+#: src/Content/Widget.php:535 src/Model/Contact.php:1714
 msgid "News"
 msgstr ""
 
-#: src/Content/Widget.php:542 src/Module/Settings/Account.php:434
+#: src/Content/Widget.php:541 src/Module/Settings/Account.php:434
 msgid "Account Types"
 msgstr ""
 
-#: src/Content/Widget.php:544 src/Module/Moderation/BaseUsers.php:69
+#: src/Content/Widget.php:543 src/Module/Moderation/BaseUsers.php:69
 msgid "All"
 msgstr ""
 
-#: src/Content/Widget.php:591 src/Module/BaseSettings.php:125
+#: src/Content/Widget.php:590 src/Module/BaseSettings.php:125
 #: src/Module/Settings/Channels.php:158 src/Module/Settings/Display.php:315
 msgid "Channels"
 msgstr ""
@@ -3936,7 +3932,7 @@ msgstr ""
 #: src/Module/Admin/Addons/Details.php:111 src/Module/Admin/Addons/Index.php:67
 #: src/Module/Admin/Federation.php:214 src/Module/Admin/Logs/Settings.php:85
 #: src/Module/Admin/Logs/View.php:83 src/Module/Admin/Queue.php:72
-#: src/Module/Admin/Site.php:398 src/Module/Admin/Storage.php:138
+#: src/Module/Admin/Site.php:400 src/Module/Admin/Storage.php:138
 #: src/Module/Admin/Summary.php:196 src/Module/Admin/Themes/Details.php:90
 #: src/Module/Admin/Themes/Index.php:111 src/Module/Admin/Tos.php:77
 #: src/Module/Moderation/Users/Create.php:61
@@ -3974,7 +3970,7 @@ msgid "Addon %s failed to install."
 msgstr ""
 
 #: src/Module/Admin/Addons/Index.php:69 src/Module/Admin/Features.php:86
-#: src/Module/Admin/Logs/Settings.php:87 src/Module/Admin/Site.php:401
+#: src/Module/Admin/Logs/Settings.php:87 src/Module/Admin/Site.php:403
 #: src/Module/Admin/Themes/Index.php:113 src/Module/Admin/Tos.php:86
 #: src/Module/Settings/Account.php:541 src/Module/Settings/Addons.php:78
 #: src/Module/Settings/Connectors.php:160
@@ -4174,8 +4170,8 @@ msgid "Enable Debugging"
 msgstr ""
 
 #: src/Module/Admin/Logs/Settings.php:91 src/Module/Admin/Logs/Settings.php:92
-#: src/Module/Admin/Logs/Settings.php:93 src/Module/Admin/Site.php:420
-#: src/Module/Admin/Site.php:428
+#: src/Module/Admin/Logs/Settings.php:93 src/Module/Admin/Site.php:422
+#: src/Module/Admin/Site.php:430
 msgid "<strong>Read-only</strong> because it is set by an environment variable"
 msgstr ""
 
@@ -4335,269 +4331,269 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/Module/Admin/Site.php:212
+#: src/Module/Admin/Site.php:214
 #, php-format
 msgid "%s is no valid input for maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:313 src/Module/Settings/Display.php:215
+#: src/Module/Admin/Site.php:315 src/Module/Settings/Display.php:215
 msgid "No special theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:330 src/Module/Settings/Display.php:225
+#: src/Module/Admin/Site.php:332 src/Module/Settings/Display.php:225
 #, php-format
 msgid "%s - (Experimental)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:342
+#: src/Module/Admin/Site.php:344
 msgid "No community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:343
+#: src/Module/Admin/Site.php:345
 msgid "No community page for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:344
+#: src/Module/Admin/Site.php:346
 msgid "Public postings from users of this site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:345
+#: src/Module/Admin/Site.php:347
 msgid "Public postings from the federated network"
 msgstr ""
 
-#: src/Module/Admin/Site.php:346
+#: src/Module/Admin/Site.php:348
 msgid "Public postings from local users and the federated network"
 msgstr ""
 
-#: src/Module/Admin/Site.php:352
+#: src/Module/Admin/Site.php:354
 msgid "Multi user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:375
+#: src/Module/Admin/Site.php:377
 msgid "Closed"
 msgstr ""
 
-#: src/Module/Admin/Site.php:376
+#: src/Module/Admin/Site.php:378
 msgid "Requires approval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:377
+#: src/Module/Admin/Site.php:379
 msgid "Open"
 msgstr ""
 
-#: src/Module/Admin/Site.php:381
+#: src/Module/Admin/Site.php:383
 msgid "Don't check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:382
+#: src/Module/Admin/Site.php:384
 msgid "check the stable version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:383
+#: src/Module/Admin/Site.php:385
 msgid "check the development version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:387
+#: src/Module/Admin/Site.php:389
 msgid "none"
 msgstr ""
 
-#: src/Module/Admin/Site.php:388
+#: src/Module/Admin/Site.php:390
 msgid "Local contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:389
+#: src/Module/Admin/Site.php:391
 msgid "Interactors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:399 src/Module/BaseAdmin.php:90
+#: src/Module/Admin/Site.php:401 src/Module/BaseAdmin.php:90
 msgid "Site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:400
+#: src/Module/Admin/Site.php:402
 msgid "General Information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:402
+#: src/Module/Admin/Site.php:404
 msgid "Republish users to directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:403 src/Module/Register.php:152
+#: src/Module/Admin/Site.php:405 src/Module/Register.php:152
 msgid "Registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:404
+#: src/Module/Admin/Site.php:406
 msgid "File upload"
 msgstr ""
 
-#: src/Module/Admin/Site.php:405
+#: src/Module/Admin/Site.php:407
 msgid "Policies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:406 src/Module/Calendar/Event/Form.php:252
-#: src/Module/Contact.php:546 src/Module/Profile/Profile.php:276
+#: src/Module/Admin/Site.php:408 src/Module/Calendar/Event/Form.php:252
+#: src/Module/Contact.php:539 src/Module/Profile/Profile.php:276
 msgid "Advanced"
 msgstr ""
 
-#: src/Module/Admin/Site.php:407
+#: src/Module/Admin/Site.php:409
 msgid "Auto Discovered Contact Directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:408
+#: src/Module/Admin/Site.php:410
 msgid "Performance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:409
+#: src/Module/Admin/Site.php:411
 msgid "Worker"
 msgstr ""
 
-#: src/Module/Admin/Site.php:410
+#: src/Module/Admin/Site.php:412
 msgid "Message Relay"
 msgstr ""
 
-#: src/Module/Admin/Site.php:411
+#: src/Module/Admin/Site.php:413
 msgid ""
 "Use the command \"console relay\" in the command line to add or remove "
 "relays."
 msgstr ""
 
-#: src/Module/Admin/Site.php:412
+#: src/Module/Admin/Site.php:414
 msgid "The system is not subscribed to any relays at the moment."
 msgstr ""
 
-#: src/Module/Admin/Site.php:413
+#: src/Module/Admin/Site.php:415
 msgid "The system is currently subscribed to the following relays:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:415
+#: src/Module/Admin/Site.php:417
 msgid "Relocate Node"
 msgstr ""
 
-#: src/Module/Admin/Site.php:416
+#: src/Module/Admin/Site.php:418
 msgid ""
 "Relocating your node enables you to change the DNS domain of this node and "
 "keep all the existing users and posts. This process takes a while and can "
 "only be started from the relocate console command like this:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:417
+#: src/Module/Admin/Site.php:419
 msgid "(Friendica directory)# bin/console relocate https://newdomain.com"
 msgstr ""
 
-#: src/Module/Admin/Site.php:420
+#: src/Module/Admin/Site.php:422
 msgid "Site name"
 msgstr ""
 
-#: src/Module/Admin/Site.php:421
+#: src/Module/Admin/Site.php:423
 msgid "Sender Email"
 msgstr ""
 
-#: src/Module/Admin/Site.php:421
+#: src/Module/Admin/Site.php:423
 msgid ""
 "The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: src/Module/Admin/Site.php:422
+#: src/Module/Admin/Site.php:424
 msgid "Name of the system actor"
 msgstr ""
 
-#: src/Module/Admin/Site.php:422
+#: src/Module/Admin/Site.php:424
 msgid ""
 "Name of the internal system account that is used to perform ActivityPub "
 "requests. This must be an unused username. If set, this can't be changed "
 "again."
 msgstr ""
 
-#: src/Module/Admin/Site.php:423
+#: src/Module/Admin/Site.php:425
 msgid "Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:424
+#: src/Module/Admin/Site.php:426
 msgid "Email Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:425
+#: src/Module/Admin/Site.php:427
 msgid "Shortcut icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:425
+#: src/Module/Admin/Site.php:427
 msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:426
+#: src/Module/Admin/Site.php:428
 msgid "Touch icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:426
+#: src/Module/Admin/Site.php:428
 msgid "Link to an icon that will be used for tablets and mobiles."
 msgstr ""
 
-#: src/Module/Admin/Site.php:427
+#: src/Module/Admin/Site.php:429
 msgid "Additional Info"
 msgstr ""
 
-#: src/Module/Admin/Site.php:427
+#: src/Module/Admin/Site.php:429
 #, php-format
 msgid ""
 "For public servers: you can add additional information here that will be "
 "listed at %s/servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:428
+#: src/Module/Admin/Site.php:430
 msgid "System language"
 msgstr ""
 
-#: src/Module/Admin/Site.php:429
+#: src/Module/Admin/Site.php:431
 msgid "System theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:429
+#: src/Module/Admin/Site.php:431
 #, php-format
 msgid ""
 "Default system theme - may be over-ridden by user profiles - <a href=\"%s\" "
 "id=\"cnftheme\">Change default theme settings</a>"
 msgstr ""
 
-#: src/Module/Admin/Site.php:430
+#: src/Module/Admin/Site.php:432
 msgid "Mobile system theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:430
+#: src/Module/Admin/Site.php:432
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:431
+#: src/Module/Admin/Site.php:433
 msgid "Force SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:431
+#: src/Module/Admin/Site.php:433
 msgid ""
 "Force all Non-SSL requests to SSL - Attention: on some systems it could lead "
 "to endless loops."
 msgstr ""
 
-#: src/Module/Admin/Site.php:432
+#: src/Module/Admin/Site.php:434
 msgid "Show help entry from navigation menu"
 msgstr ""
 
-#: src/Module/Admin/Site.php:432
+#: src/Module/Admin/Site.php:434
 msgid ""
 "Displays the menu entry for the Help pages from the navigation menu. It is "
 "always accessible by calling /help directly."
 msgstr ""
 
-#: src/Module/Admin/Site.php:433
+#: src/Module/Admin/Site.php:435
 msgid "Single user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:433
+#: src/Module/Admin/Site.php:435
 msgid "Make this instance multi-user or single-user for the named user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:435
+#: src/Module/Admin/Site.php:437
 msgid "Maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:435
+#: src/Module/Admin/Site.php:437
 #, php-format
 msgid ""
 "Maximum size in bytes of uploaded images. Default is 0, which means no "
@@ -4609,35 +4605,35 @@ msgid ""
 "to %s (%s byte)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:439
+#: src/Module/Admin/Site.php:441
 msgid "Maximum image length"
 msgstr ""
 
-#: src/Module/Admin/Site.php:439
+#: src/Module/Admin/Site.php:441
 msgid ""
 "Maximum length in pixels of the longest side of uploaded images. Default is "
 "-1, which means no limits."
 msgstr ""
 
-#: src/Module/Admin/Site.php:440
+#: src/Module/Admin/Site.php:442
 msgid "JPEG image quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:440
+#: src/Module/Admin/Site.php:442
 msgid ""
 "Uploaded JPEGS will be saved at this quality setting [0-100]. Default is "
 "100, which is full quality."
 msgstr ""
 
-#: src/Module/Admin/Site.php:442
+#: src/Module/Admin/Site.php:444
 msgid "Register policy"
 msgstr ""
 
-#: src/Module/Admin/Site.php:443
+#: src/Module/Admin/Site.php:445
 msgid "Maximum Users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:443
+#: src/Module/Admin/Site.php:445
 msgid ""
 "If defined, the register policy is automatically closed when the given "
 "number of users is reached and reopens the registry when the number drops "
@@ -4645,168 +4641,168 @@ msgid ""
 "not when the policy is set to approval."
 msgstr ""
 
-#: src/Module/Admin/Site.php:444
+#: src/Module/Admin/Site.php:446
 msgid "Maximum Daily Registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:444
+#: src/Module/Admin/Site.php:446
 msgid ""
 "If registration is permitted above, this sets the maximum number of new user "
 "registrations to accept per day.  If register is set to closed, this setting "
 "has no effect."
 msgstr ""
 
-#: src/Module/Admin/Site.php:445
+#: src/Module/Admin/Site.php:447
 msgid "Register text"
 msgstr ""
 
-#: src/Module/Admin/Site.php:445
+#: src/Module/Admin/Site.php:447
 msgid ""
 "Will be displayed prominently on the registration page. You can use BBCode "
 "here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:446
+#: src/Module/Admin/Site.php:448
 msgid "Forbidden Nicknames"
 msgstr ""
 
-#: src/Module/Admin/Site.php:446
+#: src/Module/Admin/Site.php:448
 msgid ""
 "Comma separated list of nicknames that are forbidden from registration. "
 "Preset is a list of role names according RFC 2142."
 msgstr ""
 
-#: src/Module/Admin/Site.php:447
+#: src/Module/Admin/Site.php:449
 msgid "Accounts abandoned after x days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:447
+#: src/Module/Admin/Site.php:449
 msgid ""
 "Will not waste system resources polling external sites for abandonded "
 "accounts. Enter 0 for no time limit."
 msgstr ""
 
-#: src/Module/Admin/Site.php:448
+#: src/Module/Admin/Site.php:450
 msgid "Allowed friend domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:448
+#: src/Module/Admin/Site.php:450
 msgid ""
 "Comma separated list of domains which are allowed to establish friendships "
 "with this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:449
+#: src/Module/Admin/Site.php:451
 msgid "Allowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:449
+#: src/Module/Admin/Site.php:451
 msgid ""
 "Comma separated list of domains which are allowed in email addresses for "
 "registrations to this site. Wildcards are accepted. Empty to allow any "
 "domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:450
+#: src/Module/Admin/Site.php:452
 msgid "No OEmbed rich content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:450
+#: src/Module/Admin/Site.php:452
 msgid ""
 "Don't show the rich content (e.g. embedded PDF), except from the domains "
 "listed below."
 msgstr ""
 
-#: src/Module/Admin/Site.php:451
+#: src/Module/Admin/Site.php:453
 msgid "Trusted third-party domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:451
+#: src/Module/Admin/Site.php:453
 msgid ""
 "Comma separated list of domains from which content is allowed to be embedded "
 "in posts like with OEmbed. All sub-domains of the listed domains are allowed "
 "as well."
 msgstr ""
 
-#: src/Module/Admin/Site.php:452
+#: src/Module/Admin/Site.php:454
 msgid "Block public"
 msgstr ""
 
-#: src/Module/Admin/Site.php:452
+#: src/Module/Admin/Site.php:454
 msgid ""
 "Check to block public access to all otherwise public personal pages on this "
 "site unless you are currently logged in."
 msgstr ""
 
-#: src/Module/Admin/Site.php:453
+#: src/Module/Admin/Site.php:455
 msgid "Force publish"
 msgstr ""
 
-#: src/Module/Admin/Site.php:453
+#: src/Module/Admin/Site.php:455
 msgid ""
 "Check to force all profiles on this site to be listed in the site directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:453
+#: src/Module/Admin/Site.php:455
 msgid "Enabling this may violate privacy laws like the GDPR"
 msgstr ""
 
-#: src/Module/Admin/Site.php:454
+#: src/Module/Admin/Site.php:456
 msgid "Global directory URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:454
+#: src/Module/Admin/Site.php:456
 msgid ""
 "URL to the global directory. If this is not set, the global directory is "
 "completely unavailable to the application."
 msgstr ""
 
-#: src/Module/Admin/Site.php:455
+#: src/Module/Admin/Site.php:457
 msgid "Private posts by default for new users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:455
+#: src/Module/Admin/Site.php:457
 msgid ""
 "Set default post permissions for all new members to the default privacy "
 "circle rather than public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:456
+#: src/Module/Admin/Site.php:458
 msgid "Don't include post content in email notifications"
 msgstr ""
 
-#: src/Module/Admin/Site.php:456
+#: src/Module/Admin/Site.php:458
 msgid ""
 "Don't include the content of a post/comment/private message/etc. in the "
 "email notifications that are sent out from this site, as a privacy measure."
 msgstr ""
 
-#: src/Module/Admin/Site.php:457
+#: src/Module/Admin/Site.php:459
 msgid "Disallow public access to addons listed in the apps menu."
 msgstr ""
 
-#: src/Module/Admin/Site.php:457
+#: src/Module/Admin/Site.php:459
 msgid ""
 "Checking this box will restrict addons listed in the apps menu to members "
 "only."
 msgstr ""
 
-#: src/Module/Admin/Site.php:458
+#: src/Module/Admin/Site.php:460
 msgid "Don't embed private images in posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:458
+#: src/Module/Admin/Site.php:460
 msgid ""
 "Don't replace locally-hosted private photos in posts with an embedded copy "
 "of the image. This means that contacts who receive posts containing private "
 "photos will have to authenticate and load each image, which may take a while."
 msgstr ""
 
-#: src/Module/Admin/Site.php:459
+#: src/Module/Admin/Site.php:461
 msgid "Explicit Content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:459
+#: src/Module/Admin/Site.php:461
 msgid ""
 "Set this to announce that your node is used mostly for explicit content that "
 "might not be suited for minors. This information will be published in the "
@@ -4815,267 +4811,281 @@ msgid ""
 "will be shown at the user registration page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:460
+#: src/Module/Admin/Site.php:462
 msgid "Proxify external content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:460
+#: src/Module/Admin/Site.php:462
 msgid ""
 "Route external content via the proxy functionality. This is used for example "
 "for some OEmbed accesses and in some other rare cases."
 msgstr ""
 
-#: src/Module/Admin/Site.php:461
+#: src/Module/Admin/Site.php:463
 msgid "Cache contact avatars"
 msgstr ""
 
-#: src/Module/Admin/Site.php:461
+#: src/Module/Admin/Site.php:463
 msgid ""
 "Locally store the avatar pictures of the contacts. This uses a lot of "
 "storage space but it increases the performance."
 msgstr ""
 
-#: src/Module/Admin/Site.php:462
+#: src/Module/Admin/Site.php:464
 msgid "Allow Users to set remote_self"
 msgstr ""
 
-#: src/Module/Admin/Site.php:462
+#: src/Module/Admin/Site.php:464
 msgid ""
 "With checking this, every user is allowed to mark every contact as a "
 "remote_self in the repair contact dialog. Setting this flag on a contact "
 "causes mirroring every posting of that contact in the users stream."
 msgstr ""
 
-#: src/Module/Admin/Site.php:463
+#: src/Module/Admin/Site.php:465
 msgid "Enable multiple registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:463
+#: src/Module/Admin/Site.php:465
 msgid "Enable users to register additional accounts for use as pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:464
+#: src/Module/Admin/Site.php:466
 msgid "Enable OpenID"
 msgstr ""
 
-#: src/Module/Admin/Site.php:464
+#: src/Module/Admin/Site.php:466
 msgid "Enable OpenID support for registration and logins."
 msgstr ""
 
-#: src/Module/Admin/Site.php:465
+#: src/Module/Admin/Site.php:467
 msgid "Enable full name check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:465
+#: src/Module/Admin/Site.php:467
 msgid ""
 "Prevents users from registering with a display name with fewer than two "
 "parts separated by spaces."
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:468
 msgid "Email administrators on new registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:468
 msgid ""
 "If enabled and the system is set to an open registration, an email for each "
 "new registration is sent to the administrators."
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:469
 msgid "Community pages for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:469
 msgid ""
 "Which community pages should be available for visitors. Local users always "
 "see both pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:468
+#: src/Module/Admin/Site.php:470
 msgid "Posts per user on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:468
+#: src/Module/Admin/Site.php:470
 msgid ""
 "The maximum number of posts per user on the community page. (Not valid for "
 "\"Global Community\")"
 msgstr ""
 
-#: src/Module/Admin/Site.php:470
+#: src/Module/Admin/Site.php:472
 msgid "Enable Mail support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:470
+#: src/Module/Admin/Site.php:472
 msgid ""
 "Enable built-in mail support to poll IMAP folders and to reply via mail."
 msgstr ""
 
-#: src/Module/Admin/Site.php:471
+#: src/Module/Admin/Site.php:473
 msgid ""
 "Mail support can't be enabled because the PHP IMAP module is not installed."
 msgstr ""
 
-#: src/Module/Admin/Site.php:472
+#: src/Module/Admin/Site.php:474
 msgid "Enable OStatus support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:472
+#: src/Module/Admin/Site.php:474
 msgid ""
 "Enable built-in OStatus (StatusNet, GNU Social etc.) compatibility. All "
 "communications in OStatus are public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:474
+#: src/Module/Admin/Site.php:476
 msgid ""
 "Diaspora support can't be enabled because Friendica was installed into a sub "
 "directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:475
+#: src/Module/Admin/Site.php:477
 msgid "Enable Diaspora support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:475
+#: src/Module/Admin/Site.php:477
 msgid ""
 "Enable built-in Diaspora network compatibility for communicating with "
 "diaspora servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:476
+#: src/Module/Admin/Site.php:478
 msgid "Verify SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:476
+#: src/Module/Admin/Site.php:478
 msgid ""
 "If you wish, you can turn on strict certificate checking. This will mean you "
 "cannot connect (at all) to self-signed SSL sites."
 msgstr ""
 
-#: src/Module/Admin/Site.php:477
+#: src/Module/Admin/Site.php:479
 msgid "Proxy user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:477
+#: src/Module/Admin/Site.php:479
 msgid "User name for the proxy server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:478
+#: src/Module/Admin/Site.php:480
 msgid "Proxy URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:478
+#: src/Module/Admin/Site.php:480
 msgid ""
 "If you want to use a proxy server that Friendica should use to connect to "
 "the network, put the URL of the proxy here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:479
+#: src/Module/Admin/Site.php:481
 msgid "Network timeout"
 msgstr ""
 
-#: src/Module/Admin/Site.php:479
+#: src/Module/Admin/Site.php:481
 msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:482
 msgid "Maximum Load Average"
 msgstr ""
 
-#: src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:482
 #, php-format
 msgid ""
 "Maximum system load before delivery and poll processes are deferred - "
 "default %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:481
+#: src/Module/Admin/Site.php:483
 msgid "Minimal Memory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:481
+#: src/Module/Admin/Site.php:483
 msgid ""
 "Minimal free memory in MB for the worker. Needs access to /proc/meminfo - "
 "default 0 (deactivated)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:482
+#: src/Module/Admin/Site.php:484
 msgid "Periodically optimize tables"
 msgstr ""
 
-#: src/Module/Admin/Site.php:482
+#: src/Module/Admin/Site.php:484
 msgid "Periodically optimize tables like the cache and the workerqueue"
 msgstr ""
 
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Site.php:486
 msgid "Discover followers/followings from contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Site.php:486
 msgid ""
 "If enabled, contacts are checked for their followers and following contacts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:485
+#: src/Module/Admin/Site.php:487
 msgid "None - deactivated"
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:488
 msgid ""
 "Local contacts - contacts of our local contacts are discovered for their "
 "followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:487
+#: src/Module/Admin/Site.php:489
 msgid ""
 "Interactors - contacts of our local contacts and contacts who interacted on "
 "locally visible postings are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:491
+msgid "Only update contacts/servers with local data"
+msgstr ""
+
+#: src/Module/Admin/Site.php:491
+msgid ""
+"If enabled, the system will only look for changes in contacts and servers "
+"that engaged on this system by either being in a contact list of a user or "
+"when posts or comments exists from the contact on this system."
+msgstr ""
+
+#: src/Module/Admin/Site.php:492
 msgid "Synchronize the contacts with the directory server"
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:492
 msgid ""
 "if enabled, the system will check periodically for new contacts on the "
 "defined directory server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
-msgid "Days between requery"
-msgstr ""
-
-#: src/Module/Admin/Site.php:491
-msgid "Number of days after which a server is requeried for his contacts."
-msgstr ""
-
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:494
 msgid "Discover contacts from other servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:494
 msgid ""
-"Periodically query other servers for contacts. The system queries Friendica, "
-"Mastodon and Hubzilla servers."
+"Periodically query other servers for contacts and servers that they know of. "
+"The system queries Friendica, Mastodon and Hubzilla servers. Keep it "
+"deactivated on small machines to decrease the database size and load."
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:495
+msgid "Days between requery"
+msgstr ""
+
+#: src/Module/Admin/Site.php:495
+msgid ""
+"Number of days after which a server is requeried for their contacts and "
+"servers it knows of. This is only used when the discovery is activated."
+msgstr ""
+
+#: src/Module/Admin/Site.php:496
 msgid "Search the local directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:496
 msgid ""
 "Search the local directory instead of the global directory. When searching "
 "locally, every search will be executed on the global directory in the "
 "background. This improves the search results when the search is repeated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:498
 msgid "Publish server information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:498
 msgid ""
 "If enabled, general server and usage data will be published. The data "
 "contains the name and version of the server, number of users with public "
@@ -5083,50 +5093,50 @@ msgid ""
 "href=\"http://the-federation.info/\">the-federation.info</a> for details."
 msgstr ""
 
-#: src/Module/Admin/Site.php:497
+#: src/Module/Admin/Site.php:500
 msgid "Check upstream version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:497
+#: src/Module/Admin/Site.php:500
 msgid ""
 "Enables checking for new Friendica versions at github. If there is a new "
 "version, you will be informed in the admin panel overview."
 msgstr ""
 
-#: src/Module/Admin/Site.php:498
+#: src/Module/Admin/Site.php:501
 msgid "Suppress Tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:498
+#: src/Module/Admin/Site.php:501
 msgid "Suppress showing a list of hashtags at the end of the posting."
 msgstr ""
 
-#: src/Module/Admin/Site.php:499
+#: src/Module/Admin/Site.php:502
 msgid "Clean database"
 msgstr ""
 
-#: src/Module/Admin/Site.php:499
+#: src/Module/Admin/Site.php:502
 msgid ""
 "Remove old remote items, orphaned database records and old content from some "
 "other helper tables."
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:503
 msgid "Lifespan of remote items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:503
 msgid ""
 "When the database cleanup is enabled, this defines the days after which "
 "remote items will be deleted. Own items, and marked or filed items are "
 "always kept. 0 disables this behaviour."
 msgstr ""
 
-#: src/Module/Admin/Site.php:501
+#: src/Module/Admin/Site.php:504
 msgid "Lifespan of unclaimed items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:501
+#: src/Module/Admin/Site.php:504
 msgid ""
 "When the database cleanup is enabled, this defines the days after which "
 "unclaimed remote items (mostly content from the relay) will be deleted. "
@@ -5134,144 +5144,144 @@ msgid ""
 "items if set to 0."
 msgstr ""
 
-#: src/Module/Admin/Site.php:502
+#: src/Module/Admin/Site.php:505
 msgid "Lifespan of raw conversation data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:502
+#: src/Module/Admin/Site.php:505
 msgid ""
 "The conversation data is used for ActivityPub and OStatus, as well as for "
 "debug purposes. It should be safe to remove it after 14 days, default is 90 "
 "days."
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:506
 msgid "Maximum numbers of comments per post"
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:506
 msgid "How much comments should be shown for each post? Default value is 100."
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:507
 msgid "Maximum numbers of comments per post on the display page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:507
 msgid ""
 "How many comments should be shown on the single view for each post? Default "
 "value is 1000."
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:508
 msgid "Temp path"
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:508
 msgid ""
 "If you have a restricted system where the webserver can't access the system "
 "temp path, enter another path here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:509
 msgid "Only search in tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:509
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:510
 msgid "Generate counts per contact circle when calculating network count"
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:510
 msgid ""
 "On systems with users that heavily use contact circles the query can be very "
 "expensive."
 msgstr ""
 
-#: src/Module/Admin/Site.php:509
+#: src/Module/Admin/Site.php:512
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:509
+#: src/Module/Admin/Site.php:512
 #, php-format
 msgid ""
 "On shared hosters set this to %d. On larger systems, values of %d are great. "
 "Default value is %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:513
 msgid "Enable fastlane"
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:513
 msgid ""
 "When enabed, the fastlane mechanism starts an additional worker if processes "
 "with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:515
 msgid "Direct relay transfer"
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:515
 msgid ""
 "Enables the direct transfer to other servers without using the relay servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:516
 msgid "Relay scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:516
 msgid ""
 "Can be \"all\" or \"tags\". \"all\" means that every public post should be "
 "received. \"tags\" means that only posts with selected tags should be "
 "received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:513 src/Module/Contact/Profile.php:309
+#: src/Module/Admin/Site.php:516 src/Module/Contact/Profile.php:309
 #: src/Module/Settings/TwoFactor/Index.php:146
 msgid "Disabled"
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:516
 msgid "all"
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:516
 msgid "tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:517
 msgid "Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:517
 msgid "Comma separated list of tags for the \"tags\" subscription."
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:518
 msgid "Deny Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:518
 msgid "Comma separated list of tags that are rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:519
 msgid "Allow user tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:519
 msgid ""
 "If enabled, the tags from the saved searches will used for the \"tags\" "
 "subscription in addition to the \"relay_server_tags\"."
 msgstr ""
 
-#: src/Module/Admin/Site.php:519
+#: src/Module/Admin/Site.php:522
 msgid "Start Relocation"
 msgstr ""
 
@@ -5749,7 +5759,7 @@ msgstr ""
 msgid "Item Source"
 msgstr ""
 
-#: src/Module/BaseProfile.php:52 src/Module/Contact.php:506
+#: src/Module/BaseProfile.php:52 src/Module/Contact.php:499
 msgid "Profile Details"
 msgstr ""
 
@@ -6067,142 +6077,142 @@ msgid_plural "%d contacts edited."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact.php:347
+#: src/Module/Contact.php:343
 msgid "Show all contacts"
 msgstr ""
 
-#: src/Module/Contact.php:352 src/Module/Contact.php:431
+#: src/Module/Contact.php:348 src/Module/Contact.php:424
 #: src/Module/Moderation/BaseUsers.php:85
 msgid "Pending"
 msgstr ""
 
-#: src/Module/Contact.php:355
+#: src/Module/Contact.php:351
 msgid "Only show pending contacts"
 msgstr ""
 
-#: src/Module/Contact.php:360 src/Module/Contact.php:434
+#: src/Module/Contact.php:356 src/Module/Contact.php:427
 #: src/Module/Moderation/BaseUsers.php:93
 msgid "Blocked"
 msgstr ""
 
-#: src/Module/Contact.php:363
+#: src/Module/Contact.php:359
 msgid "Only show blocked contacts"
 msgstr ""
 
-#: src/Module/Contact.php:368 src/Module/Contact.php:440
+#: src/Module/Contact.php:364 src/Module/Contact.php:433
 #: src/Module/Settings/Server/Index.php:107 src/Object/Post.php:386
 msgid "Ignored"
 msgstr ""
 
-#: src/Module/Contact.php:371
+#: src/Module/Contact.php:367
 msgid "Only show ignored contacts"
 msgstr ""
 
-#: src/Module/Contact.php:376 src/Module/Contact.php:443
+#: src/Module/Contact.php:372 src/Module/Contact.php:436
 msgid "Collapsed"
 msgstr ""
 
-#: src/Module/Contact.php:379
+#: src/Module/Contact.php:375
 msgid "Only show collapsed contacts"
 msgstr ""
 
-#: src/Module/Contact.php:384 src/Module/Contact.php:446
+#: src/Module/Contact.php:380 src/Module/Contact.php:439
 msgid "Archived"
 msgstr ""
 
-#: src/Module/Contact.php:387
+#: src/Module/Contact.php:383
 msgid "Only show archived contacts"
 msgstr ""
 
-#: src/Module/Contact.php:392 src/Module/Contact.php:437
+#: src/Module/Contact.php:388 src/Module/Contact.php:430
 msgid "Hidden"
 msgstr ""
 
-#: src/Module/Contact.php:395
+#: src/Module/Contact.php:391
 msgid "Only show hidden contacts"
 msgstr ""
 
-#: src/Module/Contact.php:403
+#: src/Module/Contact.php:399
 msgid "Organize your contact circles"
 msgstr ""
 
-#: src/Module/Contact.php:458
+#: src/Module/Contact.php:451
 msgid "Search your contacts"
 msgstr ""
 
-#: src/Module/Contact.php:459 src/Module/Search/Index.php:207
+#: src/Module/Contact.php:452 src/Module/Search/Index.php:207
 #, php-format
 msgid "Results for: %s"
 msgstr ""
 
-#: src/Module/Contact.php:466
+#: src/Module/Contact.php:459
 msgid "Update"
 msgstr ""
 
-#: src/Module/Contact.php:467 src/Module/Contact/Profile.php:511
+#: src/Module/Contact.php:460 src/Module/Contact/Profile.php:511
 #: src/Module/Moderation/Blocklist/Contact.php:117
 #: src/Module/Moderation/Users/Blocked.php:138
 #: src/Module/Moderation/Users/Index.php:154
 msgid "Unblock"
 msgstr ""
 
-#: src/Module/Contact.php:468 src/Module/Contact/Profile.php:519
+#: src/Module/Contact.php:461 src/Module/Contact/Profile.php:519
 msgid "Unignore"
 msgstr ""
 
-#: src/Module/Contact.php:469 src/Module/Contact/Profile.php:527
+#: src/Module/Contact.php:462 src/Module/Contact/Profile.php:527
 msgid "Uncollapse"
 msgstr ""
 
-#: src/Module/Contact.php:471
+#: src/Module/Contact.php:464
 msgid "Batch Actions"
 msgstr ""
 
-#: src/Module/Contact.php:514
+#: src/Module/Contact.php:507
 msgid "Conversations started by this contact"
 msgstr ""
 
-#: src/Module/Contact.php:519
+#: src/Module/Contact.php:512
 msgid "Posts and Comments"
 msgstr ""
 
-#: src/Module/Contact.php:522
+#: src/Module/Contact.php:515
 msgid "Individual Posts and Replies"
 msgstr ""
 
-#: src/Module/Contact.php:530
+#: src/Module/Contact.php:523
 msgid "Posts containing media objects"
 msgstr ""
 
-#: src/Module/Contact.php:538
+#: src/Module/Contact.php:531
 msgid "View all known contacts"
 msgstr ""
 
-#: src/Module/Contact.php:549
+#: src/Module/Contact.php:542
 msgid "Advanced Contact Settings"
 msgstr ""
 
-#: src/Module/Contact.php:585
+#: src/Module/Contact.php:578
 msgid "Mutual Friendship"
 msgstr ""
 
-#: src/Module/Contact.php:589
+#: src/Module/Contact.php:582
 msgid "is a fan of yours"
 msgstr ""
 
-#: src/Module/Contact.php:593
+#: src/Module/Contact.php:586
 msgid "you are a fan of"
 msgstr ""
 
-#: src/Module/Contact.php:611
+#: src/Module/Contact.php:604
 msgid "Pending outgoing contact request"
 msgstr ""
 
-#: src/Module/Contact.php:613
+#: src/Module/Contact.php:606
 msgid "Pending incoming contact request"
 msgstr ""
 
-#: src/Module/Contact.php:626 src/Module/Contact/Profile.php:371
+#: src/Module/Contact.php:619 src/Module/Contact/Profile.php:371
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr ""
@@ -6248,51 +6258,39 @@ msgstr ""
 msgid "No known contacts."
 msgstr ""
 
-#: src/Module/Contact/Contacts.php:103 src/Module/Profile/Common.php:128
+#: src/Module/Contact/Contacts.php:100 src/Module/Profile/Common.php:128
 msgid "No common contacts."
 msgstr ""
 
-#: src/Module/Contact/Contacts.php:115 src/Module/Profile/Contacts.php:135
+#: src/Module/Contact/Contacts.php:112 src/Module/Profile/Contacts.php:135
 #, php-format
 msgid "Follower (%s)"
 msgid_plural "Followers (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact/Contacts.php:119 src/Module/Profile/Contacts.php:138
+#: src/Module/Contact/Contacts.php:116 src/Module/Profile/Contacts.php:138
 #, php-format
 msgid "Following (%s)"
 msgid_plural "Following (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact/Contacts.php:123 src/Module/Profile/Contacts.php:141
-#, php-format
-msgid "Mutual friend (%s)"
-msgid_plural "Mutual friends (%s)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/Module/Contact/Contacts.php:125 src/Module/Profile/Contacts.php:143
-#, php-format
-msgid "These contacts both follow and are followed by <strong>%s</strong>."
-msgstr ""
-
-#: src/Module/Contact/Contacts.php:131 src/Module/Profile/Common.php:116
+#: src/Module/Contact/Contacts.php:120 src/Module/Profile/Common.php:116
 #, php-format
 msgid "Common contact (%s)"
 msgid_plural "Common contacts (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact/Contacts.php:133 src/Module/Profile/Common.php:118
+#: src/Module/Contact/Contacts.php:122 src/Module/Profile/Common.php:118
 #, php-format
 msgid ""
 "Both <strong>%s</strong> and yourself have publicly interacted with these "
 "contacts (follow, comment or likes on public posts)."
 msgstr ""
 
-#: src/Module/Contact/Contacts.php:139 src/Module/Profile/Contacts.php:149
+#: src/Module/Contact/Contacts.php:128 src/Module/Profile/Contacts.php:149
 #, php-format
 msgid "Contact (%s)"
 msgid_plural "Contacts (%s)"
@@ -8803,6 +8801,18 @@ msgstr ""
 #: src/Module/Post/Tag/Remove.php:108
 #: src/Module/Settings/TwoFactor/Trusted.php:147
 msgid "Remove"
+msgstr ""
+
+#: src/Module/Profile/Contacts.php:141
+#, php-format
+msgid "Mutual friend (%s)"
+msgid_plural "Mutual friends (%s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Profile/Contacts.php:143
+#, php-format
+msgid "These contacts both follow and are followed by <strong>%s</strong>."
 msgstr ""
 
 #: src/Module/Profile/Contacts.php:159
@@ -11656,7 +11666,7 @@ msgid "%1$s commented on your thread %2$s"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:225
-#: src/Navigation/Notifications/Repository/Notify.php:752
+#: src/Navigation/Notifications/Repository/Notify.php:754
 msgid "[Friendica:Notify]"
 msgstr ""
 
@@ -11700,7 +11710,7 @@ msgid "%1$s commented on their %2$s %3$s"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:341
-#: src/Navigation/Notifications/Repository/Notify.php:786
+#: src/Navigation/Notifications/Repository/Notify.php:788
 #, php-format
 msgid "%1$s Comment to conversation #%2$d by %3$s"
 msgstr ""
@@ -11712,7 +11722,7 @@ msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:347
 #: src/Navigation/Notifications/Repository/Notify.php:362
-#: src/Navigation/Notifications/Repository/Notify.php:812
+#: src/Navigation/Notifications/Repository/Notify.php:814
 #, php-format
 msgid "Please visit %s to view and/or reply to the conversation."
 msgstr ""
@@ -11905,22 +11915,22 @@ msgstr ""
 msgid "Please visit %s to have a look at the new registration."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:780
+#: src/Navigation/Notifications/Repository/Notify.php:782
 #, php-format
 msgid "%s %s tagged you"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:783
+#: src/Navigation/Notifications/Repository/Notify.php:785
 #, php-format
 msgid "%s %s shared a new post"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:791
+#: src/Navigation/Notifications/Repository/Notify.php:793
 #, php-format
 msgid "%1$s %2$s liked your post #%3$d"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:794
+#: src/Navigation/Notifications/Repository/Notify.php:796
 #, php-format
 msgid "%1$s %2$s liked your comment on #%3$d"
 msgstr ""

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -101,9 +101,10 @@
 
 		<h2>{{$portable_contacts}}</h2>
 		{{include file="field_select.tpl" field=$contact_discovery}}
+		{{include file="field_checkbox.tpl" field=$update_active_contacts}}
 		{{include file="field_checkbox.tpl" field=$synchronize_directory}}
-		{{include file="field_input.tpl" field=$poco_requery_days}}
 		{{include file="field_checkbox.tpl" field=$poco_discovery}}
+		{{include file="field_input.tpl" field=$poco_requery_days}}
 		{{include file="field_checkbox.tpl" field=$poco_local_search}}
 		<div class="submit"><input type="submit" name="page_site" value="{{$submit}}"/></div>
 

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -217,6 +217,7 @@
 				<div id="admin-settings-contacts-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="admin-settings-cocontactsrporate">
 					<div class="panel-body">
 						{{include file="field_select.tpl" field=$contact_discovery}}
+						{{include file="field_checkbox.tpl" field=$update_active_contacts}}
 						{{include file="field_checkbox.tpl" field=$synchronize_directory}}
 						{{include file="field_checkbox.tpl" field=$poco_discovery}}
 						{{include file="field_input.tpl" field=$poco_requery_days}}


### PR DESCRIPTION
This PR is inspired by the discussion in the issue #10021. Admins now have got a better control about the server and contact update mechanism. The already existing configuration to only update contacts with local data now moved to the the site configuration. Also this option is extended to only update servers with users that have got local data.