### PR TITLE
Don't display additional content when the output mode is "raw"

### DIFF
--- a/src/Module/Conversation/Channel.php
+++ b/src/Module/Conversation/Channel.php
@@ -103,7 +103,7 @@ class Channel extends Timeline
 			$o .= Renderer::replaceMacros($tpl, ['$reload_uri' => $this->args->getQueryString()]);
 		}
 
-		if (empty($request['mode']) || ($request['mode'] != 'raw')) {
+		if (!$this->raw) {
 			$tabs = $this->getTabArray($this->channel->getTimelines($this->session->getLocalUserId()), 'channel');
 			$tabs = array_merge($tabs, $this->getTabArray($this->channelRepository->selectByUid($this->session->getLocalUserId()), 'channel'));
 			$tabs = array_merge($tabs, $this->getTabArray($this->community->getTimelines(true), 'channel'));

--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -97,7 +97,7 @@ class Community extends Timeline
 			$o .= Renderer::replaceMacros($tpl, ['$reload_uri' => $this->args->getQueryString()]);
 		}
 
-		if (empty($request['mode']) || ($request['mode'] != 'raw')) {
+		if (!$this->raw) {
 			$tabs    = $this->getTabArray($this->community->getTimelines($this->session->isAuthenticated()), 'community');
 			$tab_tpl = Renderer::getMarkupTemplate('common_tabs.tpl');
 			$o .= Renderer::replaceMacros($tab_tpl, ['$tabs' => $tabs]);

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -157,7 +157,7 @@ class Network extends Timeline
 			$o .= Renderer::replaceMacros($tpl, ['$reload_uri' => $this->args->getQueryString()]);
 		}
 
-		if (!(isset($_GET['mode']) and ($_GET['mode'] == 'raw'))) {
+		if (!$this->raw) {
 			$o .= $this->getTabsHTML();
 
 			Nav::setSelected($this->args->get(0));
@@ -210,30 +210,30 @@ class Network extends Timeline
 			];
 
 			$o .= $this->conversation->statusEditor($x);
-		}
 
-		if ($this->circleId) {
-			$circle = $this->database->selectFirst('group', ['name'], ['id' => $this->circleId, 'uid' => $this->session->getLocalUserId()]);
-			if (!$this->database->isResult($circle)) {
-				$this->systemMessages->addNotice($this->l10n->t('No such circle'));
-			}
+			if ($this->circleId) {
+				$circle = $this->database->selectFirst('group', ['name'], ['id' => $this->circleId, 'uid' => $this->session->getLocalUserId()]);
+				if (!$this->database->isResult($circle)) {
+					$this->systemMessages->addNotice($this->l10n->t('No such circle'));
+				}
 
-			$o = Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), [
-				'$title' => $this->l10n->t('Circle: %s', $circle['name'])
-			]) . $o;
-		} elseif ($this->groupContactId) {
-			$contact = Contact::getById($this->groupContactId);
-			if ($this->database->isResult($contact)) {
-				$o = Renderer::replaceMacros(Renderer::getMarkupTemplate('contact/list.tpl'), [
-					'contacts' => [ModuleContact::getContactTemplateVars($contact)],
-					'id' => $this->args->get(0),
+				$o = Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), [
+					'$title' => $this->l10n->t('Circle: %s', $circle['name'])
 				]) . $o;
-			} else {
-				$this->systemMessages->addNotice($this->l10n->t('Invalid contact.'));
+			} elseif ($this->groupContactId) {
+				$contact = Contact::getById($this->groupContactId);
+				if ($this->database->isResult($contact)) {
+					$o = Renderer::replaceMacros(Renderer::getMarkupTemplate('contact/list.tpl'), [
+						'contacts' => [ModuleContact::getContactTemplateVars($contact)],
+						'id' => $this->args->get(0),
+					]) . $o;
+				} else {
+					$this->systemMessages->addNotice($this->l10n->t('Invalid contact.'));
+				}
+			} elseif (Profile::shouldDisplayEventList($this->session->getLocalUserId(), $this->mode)) {
+				$o .= Profile::getBirthdays($this->session->getLocalUserId());
+				$o .= Profile::getEventsReminderHTML($this->session->getLocalUserId(), $this->session->getPublicContactId());
 			}
-		} elseif (Profile::shouldDisplayEventList($this->session->getLocalUserId(), $this->mode)) {
-			$o .= Profile::getBirthdays($this->session->getLocalUserId());
-			$o .= Profile::getEventsReminderHTML($this->session->getLocalUserId(), $this->session->getPublicContactId());
 		}
 
 		try {

--- a/src/Module/Conversation/Timeline.php
+++ b/src/Module/Conversation/Timeline.php
@@ -68,6 +68,8 @@ class Timeline extends BaseModule
 	protected $force;
 	/** @var bool */
 	protected $update;
+	/** @var bool */
+	protected $raw;
 
 	/** @var App\Mode $mode */
 	protected $mode;
@@ -140,6 +142,7 @@ class Timeline extends BaseModule
 		$this->noSharer = !empty($request['no_sharer']);
 		$this->force    = !empty($request['force']) && !empty($request['item']);
 		$this->update   = !empty($request['force']) && !empty($request['first_received']) && !empty($request['first_created']) && !empty($request['first_uriid']) && !empty($request['first_commented']);
+		$this->raw      = !empty($request['mode']) && ($request['mode'] == 'raw');
 	}
 
 	protected function getNoSharerWidget(string $base): string


### PR DESCRIPTION
This fixes the issue that the when scrolling down the network feed, the birthday reminder had been added to each updated feed. We mustn't add this data in the "raw" mode that is used with the automatic updates.