### PR TITLE
Distribute incoming posts according to the parent followers collection

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1235,7 +1235,7 @@ class Processor
 
 		$has_parents = false;
 
-		if (!empty($item['parent-uri-id'])) {
+		if (($item['private'] != Item::PRIVATE) && !empty($item['parent-uri-id'])) {
 			if (Post::exists(['uri-id' => $item['parent-uri-id'], 'uid' => $receiver])) {
 				$has_parents = true;
 			} elseif ($add_parent && Post::exists(['uri-id' => $item['parent-uri-id'], 'uid' => 0])) {
@@ -1254,7 +1254,7 @@ class Processor
 			}
 		}
 
-		if (empty($item['parent-uri-id']) || ($item['thr-parent-id'] != $item['parent-uri-id'])) {
+		if (($item['private'] == Item::PRIVATE) || empty($item['parent-uri-id']) || ($item['thr-parent-id'] != $item['parent-uri-id'])) {
 			if (Post::exists(['uri-id' => $item['thr-parent-id'], 'uid' => $receiver])) {
 				$has_parents = true;
 			} elseif (($has_parents || $add_parent) && Post::exists(['uri-id' => $item['thr-parent-id'], 'uid' => 0])) {

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -498,19 +498,6 @@ class Receiver
 		$object_data['receiver'] = array_replace($object_data['receiver'] ?? [], $receivers);
 		$object_data['reception_type'] = array_replace($object_data['reception_type'] ?? [], $reception_types);
 
-		//		This check here interferes with Hubzilla posts where the author host differs from the host the post was created
-		//		$author = $object_data['author'] ?? $actor;
-		//		if (!empty($author) && !empty($object_data['id'])) {
-		//			$author_host = parse_url($author, PHP_URL_HOST);
-		//			$id_host = parse_url($object_data['id'], PHP_URL_HOST);
-		//			if ($author_host == $id_host) {
-		//				Logger::info('Valid hosts', ['type' => $type, 'host' => $id_host]);
-		//			} else {
-		//				Logger::notice('Differing hosts on author and id', ['type' => $type, 'author' => $author_host, 'id' => $id_host]);
-		//				$trust_source = false;
-		//			}
-		//		}
-
 		$account = Contact::selectFirstAccount(['platform'], ['nurl' => Strings::normaliseLink($actor)]);
 		$platform = $account['platform'] ?? '';
 


### PR DESCRIPTION
This improves PR #13684. That one had got issues under several conditions. It is now reworked, so that we don't need to rely upon the HTTP signer anymore (which was problematic).