### PR TITLE
The option "community_no_sharer" is now always enabled

### DIFF
--- a/src/Module/Conversation/Channel.php
+++ b/src/Module/Conversation/Channel.php
@@ -115,7 +115,7 @@ class Channel extends Timeline
 
 			$this->page['aside'] .= Widget::accountTypes('channel/' . $this->selectedTab, $this->accountTypeString);
 
-			if (!in_array($this->selectedTab, [ChannelEntity::FOLLOWERS, ChannelEntity::FORYOU]) && $this->config->get('system', 'community_no_sharer')) {
+			if (!in_array($this->selectedTab, [ChannelEntity::FOLLOWERS, ChannelEntity::FORYOU])) {
 				$this->page['aside'] .= $this->getNoSharerWidget('channel');
 			}
 

--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -106,7 +106,7 @@ class Community extends Timeline
 
 			$this->page['aside'] .= Widget::accountTypes('community/' . $this->selectedTab, $this->accountTypeString);
 
-			if ($this->session->getLocalUserId() && $this->config->get('system', 'community_no_sharer')) {
+			if ($this->session->getLocalUserId()) {
 				$this->page['aside'] .= $this->getNoSharerWidget('community');
 			}
 

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -148,10 +148,6 @@ return [
 		// Comma separated list of hashtags that shouldn't be displayed in the trending tags
 		'blocked_tags' => '',
 
-		// community_no_sharer (Boolean)
-		// Don't display sharing accounts on the global community
-		'community_no_sharer' => false,
-
 		// contact_update_limit (Integer)
 		// How many contacts should be checked at a time?
 		'contact_update_limit' => 100,


### PR DESCRIPTION
This option does no harm, so we can enable it all the time.