### PR TITLE
Check if the daemon pid file can be written

### DIFF
--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -163,9 +163,15 @@ if (!$foreground) {
 		exit(1);
 	} elseif ($pid) {
 		// The parent process continues here
+		file_put_contents($pidfile, $pid);
+		if (!is_readable($pidfile)) {
+			echo "Pid file wasn't written.\n";
+			Logger::warning('Could not store pid file');
+			posix_kill($pid, SIGTERM);
+			exit(1);
+		}
 		echo 'Child process started with pid ' . $pid . ".\n";
 		Logger::notice('Child process started', ['pid' => $pid]);
-		file_put_contents($pidfile, $pid);
 		exit(0);
 	}
 

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -163,8 +163,7 @@ if (!$foreground) {
 		exit(1);
 	} elseif ($pid) {
 		// The parent process continues here
-		file_put_contents($pidfile, $pid);
-		if (!is_readable($pidfile)) {
+		if (!file_put_contents($pidfile, $pid)) {
 			echo "Pid file wasn't written.\n";
 			Logger::warning('Could not store pid file');
 			posix_kill($pid, SIGTERM);


### PR DESCRIPTION
When the directory for the pid file isn't writable, we will now stop the daemon to avoid being started multiple times.