### PR TITLE
Fix transmission of events to Diaspora

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2171,6 +2171,9 @@ class BBCode
 		// Maybe we should make this newline at every time before a quote.
 		$text = str_replace(['</a><blockquote>'], ['</a><br><blockquote>'], $text);
 
+		// The converter doesn't convert these elements
+		$text = str_replace(['<div>', '</div>'], ['<p>', '</p>'], $text);
+
 		// Now convert HTML to Markdown
 		$text = HTML::toMarkdown($text);
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3310,7 +3310,7 @@ class Diaspora
 
 		$result = DI::cache()->get($cachekey);
 		if (!is_null($result)) {
-//			return $result;
+			return $result;
 		}
 
 		$myaddr = self::myHandle($owner);

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -3310,7 +3310,7 @@ class Diaspora
 
 		$result = DI::cache()->get($cachekey);
 		if (!is_null($result)) {
-			return $result;
+//			return $result;
 		}
 
 		$myaddr = self::myHandle($owner);
@@ -3403,7 +3403,8 @@ class Diaspora
 			if ($item['event-id'] > 0) {
 				$event = self::buildEvent($item['event-id']);
 				if (count($event)) {
-					$message['event'] = $event;
+					// Deactivated, since Diaspora seems to have problems with the processing.
+					// $message['event'] = $event;
 
 					if (
 						!empty($event['location']['address']) &&


### PR DESCRIPTION
Events hadn't been processed by Diaspora anymore. We now only process the event text and not the specific XML elements that are meant for events.