### PR TITLE
Frio: perform item update after activity

### DIFF
--- a/view/js/main.js
+++ b/view/js/main.js
@@ -641,6 +641,11 @@ function liveUpdate(src) {
 	});
 }
 
+function updateItem(itemNo) {
+	force_update = true;
+	update_item = itemNo;	
+}
+
 function imgbright(node) {
 	$(node).removeClass("drophide").addClass("drop");
 }

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -865,6 +865,7 @@ function doActivityItemAction(ident, verb, un) {
 					$('button[id^=shareMenuOptions-' + ident.toString() + ']').addClass('active');
 				}
 			}
+			updateItem(ident.toString());
 		} else {
 			/* server-response was not ok. Database-problems or some changes in
 			 * data?


### PR DESCRIPTION
We now perform an update of the thread, after an activity was processed. This will for example update the activity counter.