### PR TITLE
Only use posts with wanted languages for subscribed tags

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -138,7 +138,7 @@ class Item
 		'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid', 'post-type', 'post-reason',
 		'private', 'pubmail', 'visible', 'starred',
 		'unseen', 'deleted', 'origin', 'mention', 'global', 'network',
-		'title', 'content-warning', 'body', 'location', 'coord', 'app',
+		'title', 'content-warning', 'body', 'language', 'location', 'coord', 'app',
 		'rendered-hash', 'rendered-html', 'object-type', 'object', 'target-type', 'target',
 		'author-id', 'author-link', 'author-name', 'author-avatar', 'author-network',
 		'owner-id', 'owner-link', 'owner-name', 'owner-avatar', 'causer-id'
@@ -1541,7 +1541,25 @@ class Item
 			return;
 		}
 
+		$languages = $item['language'] ? array_keys(json_decode($item['language'], true)) : [];
+		
 		foreach (Tag::getUIDListByURIId($item['uri-id']) as $uid => $tags) {
+			if (!empty($languages)) {
+				$keep = false;
+				$user_languages = User::getWantedLanguages($uid);
+				foreach ($user_languages as $language) {
+					if (in_array($language, $languages)) {
+						$keep = true;
+					}
+				}
+				if ($keep) {
+					Logger::debug('Wanted languages found', ['uid' => $uid, 'user-languages' => $user_languages, 'item-languages' => $languages]);
+				} else {
+					Logger::debug('No wanted languages found', ['uid' => $uid, 'user-languages' => $user_languages, 'item-languages' => $languages]);
+					continue;
+				}
+			}
+
 			$stored = self::storeForUserByUriId($item['uri-id'], $uid, ['post-reason' => self::PR_TAG]);
 			Logger::info('Stored item for users', ['uri-id' => $item['uri-id'], 'uid' => $uid, 'stored' => $stored]);
 			foreach ($tags as $tag) {

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -576,6 +576,17 @@ class User
 	}
 
 	/**
+	 * Fetch the wanted languages for a given user
+	 *
+	 * @param integer $uid
+	 * @return array
+	 */
+	public static function getWantedLanguages(int $uid): array
+	{
+		return DI::pConfig()->get($uid, 'channel', 'languages', [User::getLanguageCode($uid)]) ?? [];
+	}
+
+	/**
 	 * Get a list of all languages that are used by the users
 	 *
 	 * @return array

--- a/src/Module/Conversation/Timeline.php
+++ b/src/Module/Conversation/Timeline.php
@@ -426,7 +426,7 @@ class Timeline extends BaseModule
 	private function addLanguageCondition(int $uid, array $condition): array
 	{
 		$conditions = [];
-		$languages  = $this->pConfig->get($uid, 'channel', 'languages', [User::getLanguageCode($uid)]);
+		$languages  = User::getWantedLanguages($uid);
 		foreach ($languages as $language) {
 			$conditions[] = "JSON_EXTRACT(JSON_KEYS(language), '$[0]') = ?";
 			$condition[]  = $language;
@@ -439,7 +439,7 @@ class Timeline extends BaseModule
 
 	private function getMedianComments(int $uid, int $divider): int
 	{
-		$languages = $this->pConfig->get($uid, 'channel', 'languages', [User::getLanguageCode($uid)]);
+		$languages = User::getWantedLanguages($uid);
 		$cache_key = 'Channel:getMedianComments:' . $divider . ':' . implode(':', $languages);
 		$comments  = $this->cache->get($cache_key);
 		if (!empty($comments)) {
@@ -463,7 +463,7 @@ class Timeline extends BaseModule
 
 	private function getMedianActivities(int $uid, int $divider): int
 	{
-		$languages  = $this->pConfig->get($uid, 'channel', 'languages', [User::getLanguageCode($uid)]);
+		$languages  = User::getWantedLanguages($uid);
 		$cache_key  = 'Channel:getMedianActivities:' . $divider . ':' . implode(':', $languages);
 		$activities = $this->cache->get($cache_key);
 		if (!empty($activities)) {

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -265,7 +265,7 @@ class Display extends BaseSettings
 
 		$bookmarked_timelines = $this->pConfig->get($uid, 'system', 'network_timelines', $this->getAvailableTimelines($uid, true)->column('code'));
 		$enabled_timelines    = $this->pConfig->get($uid, 'system', 'enabled_timelines', $this->getAvailableTimelines($uid, false)->column('code'));
-		$channel_languages = $this->pConfig->get($uid, 'channel', 'languages', [User::getLanguageCode($uid)]);
+		$channel_languages = User::getWantedLanguages($uid);
 		$languages         = $this->l10n->getLanguageCodes(true);
 
 		$timelines = [];


### PR DESCRIPTION
Since we now have got the language selection for the channels, we can use this value to ensure that for posts with subscribed tags we now only use posts with the wanted languages.