### PR TITLE
Allow longer avatar URLs / the system outbox is now handled

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -385,18 +385,18 @@ class APContact
 		}
 
 		// When the photo is too large, try to shorten it by removing parts
-		if (strlen($apcontact['photo'] ?? '') > 255) {
+		if (strlen($apcontact['photo'] ?? '') > 383) {
 			$parts = parse_url($apcontact['photo']);
 			unset($parts['fragment']);
 			$apcontact['photo'] = (string)Uri::fromParts((array)$parts);
 
-			if (strlen($apcontact['photo']) > 255) {
+			if (strlen($apcontact['photo']) > 383) {
 				unset($parts['query']);
 				$apcontact['photo'] = (string)Uri::fromParts((array)$parts);
 			}
 
-			if (strlen($apcontact['photo']) > 255) {
-				$apcontact['photo'] = substr($apcontact['photo'], 0, 255);
+			if (strlen($apcontact['photo']) > 383) {
+				$apcontact['photo'] = substr($apcontact['photo'], 0, 383);
 			}
 		}
 

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -82,6 +82,7 @@ class GServer
 	const DETECT_STATUS_PHP = 17; // Nextcloud
 	const DETECT_V1_CONFIG = 18;
 	const DETECT_SYSTEM_ACTOR = 20; // Mistpark, Osada, Roadhouse, Zap
+	const DETECT_THREADS = 21;
 
 	// Standardized endpoints
 	const DETECT_STATISTICS_JSON = 100;
@@ -671,6 +672,12 @@ class GServer
 					return false;
 				}
 
+				if (in_array($url, ['https://www.threads.net', 'https://threads.net'])) {
+					$serverdata['detection-method'] = self::DETECT_THREADS;
+					$serverdata['network']          = Protocol::ACTIVITYPUB;
+					$serverdata['platform']         = 'threads';
+				}
+		
 				if (($serverdata['network'] == Protocol::PHANTOM) || in_array($serverdata['detection-method'], self::DETECT_UNSPECIFIC)) {
 					$serverdata = self::detectMastodonAlikes($url, $serverdata);
 				}

--- a/src/Module/ActivityPub/Outbox.php
+++ b/src/Module/ActivityPub/Outbox.php
@@ -21,7 +21,6 @@
 
 namespace Friendica\Module\ActivityPub;
 
-use Friendica\Core\System;
 use Friendica\Model\User;
 use Friendica\Module\BaseApi;
 use Friendica\Protocol\ActivityPub;
@@ -36,7 +35,7 @@ class Outbox extends BaseApi
 	protected function rawContent(array $request = [])
 	{
 		if (empty($this->parameters['nickname'])) {
-			throw new \Friendica\Network\HTTPException\NotFoundException();
+			$this->jsonExit([], 'application/activity+json');
 		}
 
 		$owner = User::getOwnerDataByNick($this->parameters['nickname']);

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -452,6 +452,7 @@ return [
 	'/following/{nickname}' => [Module\ActivityPub\Following::class, [R::GET]],
 	'/friendica[/{format:json}]' => [Module\Friendica::class,        [R::GET]],
 	'/friendica/inbox'      => [Module\ActivityPub\Inbox::class,     [R::GET, R::POST]],
+	'/friendica/outbox'     => [Module\ActivityPub\Outbox::class,    [R::GET]],
 
 	'/fsuggest/{contact:\d+}' => [Module\FriendSuggest::class,  [R::GET, R::POST]],
 


### PR DESCRIPTION
This is a continuation of PR #13721. Threads is using longer avatar URLs, that we now can handle. Also the newly introduced "outbox" endpoint for the system actor does now exist and returns an empty array.