### PR TITLE
Fix for issue #13403 [Frio] Optical assignment of a contact to a circle not/hardly distinguishable

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2655,7 +2655,7 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 }
 #circle-update-wrapper .viewcontact_wrapper .contact-circle-link {
 	opacity: 0.8;
-	font-size: 20px;
+	font-size: 15px;
 }
 #circle-update-wrapper .viewcontact_wrapper .contact-action-link:hover {
 	opacity: 1;

--- a/view/theme/frio/templates/contact/entry.tpl
+++ b/view/theme/frio/templates/contact/entry.tpl
@@ -76,7 +76,7 @@
 			{{* The button to add or remove contacts from a contact group - group edit page *}}
 			{{if $contact.change_member}}
 			<div class="contact-group-actions pull-right nav-pills preferences">
-				<button type="button" class="contact-action-link btn contact-group-link btn-default" onclick="circleChangeMember({{$contact.change_member.gid}},{{$contact.change_member.cid}},'{{$contact.change_member.sec_token}}'); return true;" data-toggle="tooltip" title="{{$contact.change_member.title}}">
+				<button type="button" class="contact-action-link btn contact-group-link btn-default contact-circle-actions" onclick="circleChangeMember({{$contact.change_member.gid}},{{$contact.change_member.cid}},'{{$contact.change_member.sec_token}}'); return true;" data-toggle="tooltip" title="{{$contact.change_member.title}}">
 					{{if $contact.label == "members"}}
 					<i class="fa fa-times-circle" aria-hidden="true"></i>
 					{{elseif $contact.label == "contacts"}}

--- a/view/theme/frio/templates/contact/entry.tpl
+++ b/view/theme/frio/templates/contact/entry.tpl
@@ -76,7 +76,7 @@
 			{{* The button to add or remove contacts from a contact group - group edit page *}}
 			{{if $contact.change_member}}
 			<div class="contact-group-actions pull-right nav-pills preferences">
-				<button type="button" class="contact-action-link btn contact-group-link btn-default contact-circle-actions" onclick="circleChangeMember({{$contact.change_member.gid}},{{$contact.change_member.cid}},'{{$contact.change_member.sec_token}}'); return true;" data-toggle="tooltip" title="{{$contact.change_member.title}}">
+				<button type="button" class="contact-action-link btn contact-group-link btn-default contact-circle-actions contact-circle-link" onclick="circleChangeMember({{$contact.change_member.gid}},{{$contact.change_member.cid}},'{{$contact.change_member.sec_token}}'); return true;" data-toggle="tooltip" title="{{$contact.change_member.title}}">
 					{{if $contact.label == "members"}}
 					<i class="fa fa-times-circle" aria-hidden="true"></i>
 					{{elseif $contact.label == "contacts"}}


### PR DESCRIPTION
this fixes Issue #13403 -[Frio] Optical assignment of a contact to a circle not/hardly distinguishable by adding two missing css-classes to thee circle-action button.