### PR TITLE
Fix lost local tags upon update

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -196,6 +196,10 @@ class Item
 			$previous = Post::selectFirst(['edited'], $condition);
 		}
 
+		if (!empty($fields['body'])) {
+			$fields['body'] = self::setHashtags($fields['body']);
+		}
+
 		$rows = Post::update($fields, $condition);
 		if (is_bool($rows)) {
 			return $rows;


### PR DESCRIPTION
This fixes the issue that local tags accidentally had been replaced by links tzo external tags, when the system received an updated post.