### PR TITLE
Also catch TypeError exceptions in Repository\PostMedia

### DIFF
--- a/src/Content/Post/Repository/PostMedia.php
+++ b/src/Content/Post/Repository/PostMedia.php
@@ -47,7 +47,7 @@ class PostMedia extends BaseRepository
 		foreach ($rows as $fields) {
 			try {
 				$Entities[] = $this->factory->createFromTableRow($fields);
-			} catch (\Exception $e) {
+			} catch (\Throwable $e) {
 				$this->logger->warning('Invalid media row', ['code' => $e->getCode(), 'message' => $e->getMessage(), 'fields' => $fields]);
 			}
 		}


### PR DESCRIPTION
- Address `Uncaught Exception TypeError: "Friendica\Content\Post\Entity\PostMedia::__construct(): Argument #2 ($url) must be of type Psr\Http\Message\UriInterface, null given`