### PR TITLE
Avoid exception for invalid media urls

### DIFF
--- a/src/Content/Post/Repository/PostMedia.php
+++ b/src/Content/Post/Repository/PostMedia.php
@@ -27,6 +27,7 @@ use Friendica\Content\Post\Collection;
 use Friendica\Content\Post\Entity;
 use Friendica\Content\Post\Factory;
 use Friendica\Database\Database;
+use Friendica\Util\Network;
 use Friendica\Util\Strings;
 use Psr\Log\LoggerInterface;
 
@@ -45,6 +46,9 @@ class PostMedia extends BaseRepository
 
 		$Entities = new Collection\PostMedias();
 		foreach ($rows as $fields) {
+			if (!Network::createUriFromString($fields['url'])) {
+				continue;
+			}
 			try {
 				$Entities[] = $this->factory->createFromTableRow($fields);
 			} catch (\Exception $e) {


### PR DESCRIPTION
This fixes `Uncaught Exception TypeError: "Friendica\Content\Post\Entity\PostMedia::__construct(): Argument #2 ($url) must be of type Psr\Http\Message\UriInterface, null given`

It seems as if the `try` doesn't catch that kind of errors, so we have to check in advance.