### PR TITLE
 Store Pixelfed's capabilities

### DIFF
--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -60,6 +60,10 @@ class Tag
 	const AUDIENCE   = 14;
 	const ATTRIBUTED = 15;
 
+	const CAN_ANNOUNCE = 20;
+	const CAN_LIKE     = 21;
+	const CAN_REPLY    = 22;
+
 	const ACCOUNT             = 1;
 	const GENERAL_COLLECTION  = 2;
 	const FOLLOWER_COLLECTION = 3;

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1324,23 +1324,21 @@ class Processor
 	public static function storeReceivers(int $uriid, array $receivers)
 	{
 		foreach (['as:to' => Tag::TO, 'as:cc' => Tag::CC, 'as:bto' => Tag::BTO, 'as:bcc' => Tag::BCC, 'as:audience' => Tag::AUDIENCE, 'as:attributedTo' => Tag::ATTRIBUTED] as $element => $type) {
-			if (!empty($receivers[$element])) {
-				foreach ($receivers[$element] as $receiver) {
-					if ($receiver == ActivityPub::PUBLIC_COLLECTION) {
-						$name = Receiver::PUBLIC_COLLECTION;
-					} elseif ($path = parse_url($receiver, PHP_URL_PATH)) {
-						$name = trim($path, '/');
-					} elseif ($host = parse_url($receiver, PHP_URL_HOST)) {
-						$name = $host;
-					} else {
-						Logger::warning('Unable to coerce name from receiver', ['element' => $element, 'type' => $type, 'receiver' => $receiver]);
-						$name = '';
-					}
-
-					$target = Tag::getTargetType($receiver);
-					Logger::debug('Got target type', ['type' => $target, 'url' => $receiver]);
-					Tag::store($uriid, $type, $name, $receiver, $target);
+			foreach ($receivers[$element] ?? [] as $receiver) {
+				if ($receiver == ActivityPub::PUBLIC_COLLECTION) {
+					$name = Receiver::PUBLIC_COLLECTION;
+				} elseif ($path = parse_url($receiver, PHP_URL_PATH)) {
+					$name = trim($path, '/');
+				} elseif ($host = parse_url($receiver, PHP_URL_HOST)) {
+					$name = $host;
+				} else {
+					Logger::warning('Unable to coerce name from receiver', ['element' => $element, 'type' => $type, 'receiver' => $receiver]);
+					$name = '';
 				}
+
+				$target = Tag::getTargetType($receiver);
+				Logger::debug('Got target type', ['type' => $target, 'url' => $receiver]);
+				Tag::store($uriid, $type, $name, $receiver, $target);
 			}
 		}
 	}
@@ -1348,22 +1346,20 @@ class Processor
 	private static function storeCapabilities(int $uriid, array $capabilities)
 	{
 		foreach (['pixelfed:canAnnounce' => Tag::CAN_ANNOUNCE, 'pixelfed:canLike' => Tag::CAN_LIKE, 'pixelfed:canReply' => Tag::CAN_REPLY] as $element => $type) {
-			if (!empty($capabilities[$element])) {
-				foreach ($capabilities[$element] as $capability) {
-					if ($capability == ActivityPub::PUBLIC_COLLECTION) {
-						$name = Receiver::PUBLIC_COLLECTION;
-					} elseif (empty($capability) || ($capability == '[]')) {
-						continue;
-					} elseif ($path = parse_url($capability, PHP_URL_PATH)) {
-						$name = trim($path, '/');
-					} elseif ($host = parse_url($capability, PHP_URL_HOST)) {
-						$name = $host;
-					} else {
-						Logger::warning('Unable to coerce name from capability', ['element' => $element, 'type' => $type, 'capability' => $capability]);
-						$name = '';
-					}
-					Tag::store($uriid, $type, $name, $capability);
+			foreach ($capabilities[$element] ?? [] as $capability) {
+				if ($capability == ActivityPub::PUBLIC_COLLECTION) {
+					$name = Receiver::PUBLIC_COLLECTION;
+				} elseif (empty($capability) || ($capability == '[]')) {
+					continue;
+				} elseif ($path = parse_url($capability, PHP_URL_PATH)) {
+					$name = trim($path, '/');
+				} elseif ($host = parse_url($capability, PHP_URL_HOST)) {
+					$name = $host;
+				} else {
+					Logger::warning('Unable to coerce name from capability', ['element' => $element, 'type' => $type, 'capability' => $capability]);
+ 					$name = '';
 				}
+				Tag::store($uriid, $type, $name, $capability);
 			}
 		}
 	}

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1943,11 +1943,27 @@ class Receiver
 		$object_data['receiver']       = $receivers;
 		$object_data['reception_type'] = $reception_types;
 
+		if (!empty($object['pixelfed:capabilities'])) {
+			$object_data['capabilities'] = self::getCapabilities($object);
+		}
+
 		$object_data['unlisted'] = in_array(-1, $object_data['receiver']);
 		unset($object_data['receiver'][-1]);
 		unset($object_data['reception_type'][-1]);
 
 		return $object_data;
+	}
+
+	private static function getCapabilities($object) {
+		$capabilities = [];
+		foreach (['pixelfed:canAnnounce', 'pixelfed:canLike', 'pixelfed:canReply'] as $element) {
+			$capabilities_list = JsonLD::fetchElementArray($object['pixelfed:capabilities'], $element, '@id');
+			if (empty($capabilities_list)) {
+				continue;
+			}
+			$capabilities[$element] = $capabilities_list;
+		}
+		return $capabilities;
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -2074,6 +2074,11 @@ class Receiver
 			$object_data['attachments'] = array_merge($object_data['attachments'], self::processAttachmentUrls($object['as:url'] ?? []));
 		}
 
+		$object_data['can-comment'] = JsonLD::fetchElement($object, 'pt:commentsEnabled', '@value');
+		if (is_null($object_data['can-comment'])) {
+			$object_data['can-comment'] = JsonLD::fetchElement($object, 'pixelfed:commentsEnabled', '@value');
+		}
+
 		// Support for quoted posts (Pleroma, Fedibird and Misskey)
 		$object_data['quote-url'] = JsonLD::fetchElement($object, 'as:quoteUrl', '@value');
 		if (empty($object_data['quote-url'])) {

--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -171,6 +171,7 @@ class JsonLD
 			'mobilizon' => (object)['@id' => 'https://joinmobilizon.org/ns#', '@type' => '@id'],
 			'fedibird' => (object)['@id' => 'http://fedibird.com/ns#', '@type' => '@id'],
 			'misskey' => (object)['@id' => 'https://misskey-hub.net/ns#', '@type' => '@id'],
+			'pixelfed' => (object)['@id' => 'http://pixelfed.org/ns#', '@type' => '@id'],
 		];
 
 		$orig_json = $json;


### PR DESCRIPTION
Pixelfed supports "capabilities" which defines, if you can reply, reshare or like a post. We now store this data, although we don't process it in the moment.

Additionally we now fetch the `commentsEnabled` field that is used by Peertube, Lemmy and Pixelfed.