### PR TITLE
[frio] Change reshare to quote icon for quote-button

### DIFF
--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -329,10 +329,10 @@ as the value of $top_child_total (this is done at the end of this file)
 				</span>
 				<span class="wall-item-response">
 				{{if $item.vote.share}}
-					<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="fa fa-share" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="fa fa-quote-right" aria-hidden="true"></i></button>
 					<span title="{{$item.quoteshares.title}}">{{$item.quoteshares.total}}</span>
 				{{else}}
-					<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" disabled><i class="fa fa-share" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" disabled><i class="fa fa-quote-right" aria-hidden="true"></i></button>
 				{{/if}}
 				</span>
 			{{/if}}
@@ -529,7 +529,7 @@ as the value of $top_child_total (this is done at the end of this file)
 							{{if $item.vote.share}}
 							<li role="menuitem">
 								<a class="btn-link" id="share-{{$item.id}}" href="javascript:jotShare({{$item.id}});" title="{{$item.vote.share.0}}">
-									<i class="fa fa-share" aria-hidden="true"></i> {{$item.vote.share.1}}
+									<i class="fa fa-quote-right" aria-hidden="true"></i> {{$item.vote.share.1}}
 								</a>
 							</li>
 							{{/if}}


### PR DESCRIPTION
It is confusing that in desktop-view the quote-button has a forward-icon and in smartphone-view the forward-icon opens a menu with reshare and quote-option.

I always clicked wrong in desktop in case of this confusing solution.

So i changed the icon for the quote-share option to quotation-marks in desktop- and smartphone-view.
The forward-icon for the menu is unchanged.