### PR TITLE
Fix for profile limitation / configurable list of limited servers

### DIFF
--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -24,6 +24,7 @@ namespace Friendica\Protocol;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
+use Friendica\DI;
 use Friendica\Model\APContact;
 use Friendica\Model\Contact;
 use Friendica\Model\User;
@@ -303,6 +304,15 @@ class ActivityPub
 		if (!empty($contact) && Contact\User::isBlocked($contact['id'], $uid)) {
 			Logger::info('Requesting contact is blocked', ['uid' => $uid, 'id' => $contact['id'], 'signer' => $signer, 'baseurl' => $contact['baseurl'], 'called_by' => $called_by]);
 			return false;
+		}
+
+		$limited = DI::config()->get('system', 'limited_servers');
+		if (!empty($limited)) {
+			$servers = explode(',', str_replace(' ', '', $limited));
+			$host = parse_url($contact['baseurl'], PHP_URL_HOST);
+			if (!empty($host) && in_array($host, $servers)) {
+				return false;
+			}
 		}
 
 		// @todo Look for user blocked domains

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -373,9 +373,9 @@ class Transmitter
 		}
 
 		$data['preferredUsername'] = $owner['nick'];
-		$data['name'] = $owner['name'];
+		$data['name'] = $full ? $owner['name'] : $owner['nick'];
 
-		if (!$full && !empty($owner['country-name'] . $owner['region'] . $owner['locality'])) {
+		if ($full && !empty($owner['country-name'] . $owner['region'] . $owner['locality'])) {
 			$data['vcard:hasAddress'] = ['@type' => 'vcard:Home', 'vcard:country-name' => $owner['country-name'],
 				'vcard:region' => $owner['region'], 'vcard:locality' => $owner['locality']];
 		}

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -325,6 +325,10 @@ return [
 		// Don't update the "commented" value of an item when it is liked.
 		'like_no_comment' => false,
 
+		// limited_servers (String)
+		// A comma separated list of server hostnames that should get limited profile data
+		'limited_servers' => '',
+
 		// local_tags (Boolean)
 		// If activated, all hashtags will point to the local server.
 		'local_tags' => true,


### PR DESCRIPTION
This is a fix for the limited profiles. By accident we had send the location data only when limited.

Also it is now possible to define a comma separated list of servers that always should receive only limited profile data.