### PR TITLE
[frio] More space between photo permissions and send button

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2769,6 +2769,11 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 .photo-album-actions .photos-order-link {
 	float: right;
 }
+
+#photo-edit-submit-button {
+	margin-top: 15px;
+}
+
 /* Events page */
 
 .fc .fc-month-view .fc-content .fc-title .item-desc:hover {


### PR DESCRIPTION
When editing photo details, the chance of hitting the send button instead of the permissions link on a mobile device was very high, as these two interactions were very close to each other.
This pull request adds 15 pixels of space between them.

before:
![image](https://github.com/friendica/friendica/assets/10846157/55fe1477-6bae-44de-8e11-8292e22b82ab)
-------------------
after:
![image](https://github.com/friendica/friendica/assets/10846157/fc4af71f-6c29-447d-b7dd-eba40f1c0bee)
-------------------