### PR TITLE
Restrict the access for servers that the user ignored

### DIFF
--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -315,7 +315,9 @@ class ActivityPub
 			}
 		}
 
-		// @todo Look for user blocked domains
+		if (DI::userGServer()->isIgnoredByUser($uid, $apcontact['gsid'])) {
+			return false;
+		}
 
 		Logger::debug('Server is an accepted requester', ['uid' => $uid, 'id' => $apcontact['gsid'], 'url' => $apcontact['baseurl'], 'signer' => $signer, 'called_by' => $called_by]);
 


### PR DESCRIPTION
When a user ignored posts from a whole server, we now limit the amount of data that this server can fetch about this specific user.

This can be used for example for people who want to completely ignore posts from Threads. Then they most likely also don't want Threads to be able to fetch too much data about them as well.