### PR TITLE
Fix for issue #13710 - [frio] long handles prevent a clean display of common contacts

### DIFF
--- a/view/templates/widget/remote_friends_common.tpl
+++ b/view/templates/widget/remote_friends_common.tpl
@@ -1,18 +1,18 @@
-<div id="remote-friends-in-common" class="bigwidget">
-	<div id="rfic-desc">{{$desc nofilter}} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{if $linkmore}}<a href="profile/{{$nickname}}/contacts/common">{{$more}}</a>{{/if}}</div>
-	{{foreach $contacts as $contact}}
-	<div class="profile-match-wrapper">
-		<div class="profile-match-photo">
-			<a href="{{$contact.url}}">
-				<img src="{{$contact.photo}}" width="80" height="80" alt="{{$contact.name}}" title="{{$contact.name}}" />
-			</a>
+<div id="rfic-desc">{{$desc nofilter}} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{if $linkmore}}<a href="profile/{{$nickname}}/contacts/common">{{$more}}</a>{{/if}}</div>
+	<div id="remote-friends-in-common" class="bigwidget">
+		{{foreach $contacts as $contact}}
+		<div class="profile-match-wrapper">
+			<div class="profile-match-photo">
+				<a href="{{$contact.url}}">
+					<img src="{{$contact.photo}}" width="80" height="80" alt="{{$contact.name}}" title="{{$contact.name}}" />
+				</a>
+			</div>
+			<div class="profile-match-break"></div>
+			<div class="profile-match-name">
+				<a href="{{$contact.url}}" title="{{$contact.name}}">{{$contact.name}}</a>
+			</div>
+			<div class="profile-match-end"></div>
 		</div>
-		<div class="profile-match-break"></div>
-		<div class="profile-match-name">
-			<a href="{{$contact.url}}" title="{{$contact.name}}">{{$contact.name}}</a>
-		</div>
-		<div class="profile-match-end"></div>
+		{{/foreach}}
+		<div id="rfic-end" class="clear"></div>
 	</div>
-	{{/foreach}}
-	<div id="rfic-end" class="clear"></div>
-</div>

--- a/view/templates/widget/remote_friends_common.tpl
+++ b/view/templates/widget/remote_friends_common.tpl
@@ -1,18 +1,20 @@
-<div id="rfic-desc">{{$desc nofilter}} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{{if $linkmore}}<a href="profile/{{$nickname}}/contacts/common">{{$more}}</a>{{/if}}</div>
-	<div id="remote-friends-in-common" class="bigwidget">
-		{{foreach $contacts as $contact}}
-		<div class="profile-match-wrapper">
-			<div class="profile-match-photo">
-				<a href="{{$contact.url}}">
-					<img src="{{$contact.photo}}" width="80" height="80" alt="{{$contact.name}}" title="{{$contact.name}}" />
-				</a>
+<div id="rfic-desc" onclick="openClose('remote-friends-in-common-wrapper');">{{$desc nofilter}}&emsp;&emsp;{{if $linkmore}}<a href="profile/{{$nickname}}/contacts/common">{{$more}}</a>{{/if}}</div>
+	<div id="remote-friends-in-common-wrapper">
+		<div id="remote-friends-in-common" class="bigwidget" >
+			{{foreach $contacts as $contact}}
+			<div class="profile-match-wrapper">
+				<div class="profile-match-photo">
+					<a href="{{$contact.url}}">
+						<img src="{{$contact.photo}}" width="80" height="80" alt="{{$contact.name}}" title="{{$contact.name}}" />
+					</a>
+				</div>
+				<div class="profile-match-break"></div>
+				<div class="profile-match-name">
+					<a href="{{$contact.url}}" title="{{$contact.name}}">{{$contact.name}}</a>
+				</div>
+				<div class="profile-match-end"></div>
 			</div>
-			<div class="profile-match-break"></div>
-			<div class="profile-match-name">
-				<a href="{{$contact.url}}" title="{{$contact.name}}">{{$contact.name}}</a>
-			</div>
-			<div class="profile-match-end"></div>
+			{{/foreach}}
+			<div id="rfic-end" class="clear"></div>
 		</div>
-		{{/foreach}}
-		<div id="rfic-end" class="clear"></div>
 	</div>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3489,8 +3489,39 @@ body .tread-wrapper .hovercard:hover .hover-card-content a {
  * some temporary workarounds until this will solved
  * elsewhere (e.g. new templates)
  */
+#remote-friends-in-common {
+	background-color: #fff;
+	border-radius: 4px;
+	color: #444;
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	grid-gap: 10px;
+	margin-bottom: 15px;
+	padding: 10px;
+}
+
 section .profile-match-wrapper {
 	float: left;
+}
+
+.profile-match-photo {
+	align-items: center;
+	display: flex;
+	justify-content: center;
+
+}
+.profile-match-name {
+	align-items: center;
+	display: flex;
+	justify-content: center;
+	text-align:center;
+}
+.profile-match-break {
+	display:none;
+}
+
+.profile-match-end {
+	display:none;
 }
 
 /**

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3510,12 +3510,14 @@ section .profile-match-wrapper {
 	justify-content: center;
 
 }
+
 .profile-match-name {
 	align-items: center;
 	display: flex;
 	justify-content: center;
 	text-align:center;
 }
+
 .profile-match-break {
 	display:none;
 }

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3520,15 +3520,15 @@ section .profile-match-wrapper {
 	align-items: center;
 	display: flex;
 	justify-content: center;
-	text-align:center;
+	text-align: center;
 }
 
 .profile-match-break {
-	display:none;
+	display: none;
 }
 
 .profile-match-end {
-	display:none;
+	display: none;
 }
 
 /**

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3508,7 +3508,6 @@ section .profile-match-wrapper {
 	align-items: center;
 	display: flex;
 	justify-content: center;
-
 }
 
 .profile-match-name {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2231,6 +2231,8 @@ img.acpopup-img {
 /* Birthday and Event Reminders  */
 #birthday-notice,
 #birthday-wrapper,
+#rfic-desc,
+#remote-friends-in-common,
 #event-notice,
 #event-wrapper {
 	margin-bottom: 5px;
@@ -2241,6 +2243,20 @@ img.acpopup-img {
 	-webkit-box-shadow: 0 0 3px #dadada;
 	-moz-box-shadow: 0 0 3px #dadada;
 	border-radius: 4px;
+	cursor: pointer;
+}
+#remote-friends-in-common {
+	background-color: rgba(247, 247, 247, $contentbg_transp)
+	border-radius: 4px;
+	color: #444;
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	grid-gap: 10px;
+	margin-bottom: 15px;
+	padding: 10px;
+}
+#remote-friends-in-common-wrapper{
+	display: none;
 }
 
 /* Menubar Tabs */
@@ -3489,16 +3505,6 @@ body .tread-wrapper .hovercard:hover .hover-card-content a {
  * some temporary workarounds until this will solved
  * elsewhere (e.g. new templates)
  */
-#remote-friends-in-common {
-	background-color: rgba(247, 247, 247, $contentbg_transp)
-	border-radius: 4px;
-	color: #444;
-	display: grid;
-	grid-template-columns: repeat(4, 1fr);
-	grid-gap: 10px;
-	margin-bottom: 15px;
-	padding: 10px;
-}
 
 section .profile-match-wrapper {
 	float: left;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3490,7 +3490,7 @@ body .tread-wrapper .hovercard:hover .hover-card-content a {
  * elsewhere (e.g. new templates)
  */
 #remote-friends-in-common {
-	background-color: #fff;
+	background-color: rgba(247, 247, 247, $contentbg_transp)
 	border-radius: 4px;
 	color: #444;
 	display: grid;

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -235,7 +235,6 @@ div.pager {
 	cursor:pointer;
 }
 
-
 #live-network {
 	/* border-bottom: 1px solid #BDCDD4; */
 	border-bottom: 1px solid #D2D2D2;

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -232,7 +232,7 @@ div.pager {
 }
 
 #rfic-desc {
-	cursor:pointer;
+	cursor: pointer;
 }
 
 #live-network {

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -221,11 +221,20 @@ div.pager {
 	margin-bottom: 5px; */
 }
 
-.birthday-notice, .event-notice {
+.birthday-notice, .event-notice, #rfic-desc {
 	margin-top: 5px;
 	margin-bottom: 5px;
 	background-color: #F5F5F5;
 }
+
+#remote-friends-in-common-wrapper {
+	display: none;
+}
+
+#rfic-desc {
+	cursor:pointer;
+}
+
 
 #live-network {
 	/* border-bottom: 1px solid #BDCDD4; */


### PR DESCRIPTION
This fixes Issue #13710.

I first tried to display the username beside the user-picture, but that looked strange.
So i used the command display-methid with the username under the user-picture realized with a css grid.
Tested on vier and frio, Desktop and mobile.

before:
![image](https://github.com/friendica/friendica/assets/10846157/319494d0-f384-49fb-ba21-b9dfe4395f14)

after:
![image](https://github.com/friendica/friendica/assets/10846157/7a5eeedb-a46d-47e7-8881-9cfced96d9ff)
