### PR TITLE
Fixed detection for empty server data in apcontact

### DIFF
--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -295,7 +295,7 @@ class ActivityPub
 			return false;
 		}
 
-		if (empty($apcontact['gsid'] || empty($apcontact['baseurl']))) {
+		if (empty($apcontact['gsid']) || empty($apcontact['baseurl'])) {
 			Logger::debug('No server found', ['uid' => $uid, 'signer' => $signer, 'called_by' => $called_by]);
 			return false;
 		}


### PR DESCRIPTION
This fixes a fatal error that ocurred on incoming requests from actors where we couldn't detect their server.