### PR TITLE
There is now a single way to display group postings

### DIFF
--- a/src/Content/GroupManager.php
+++ b/src/Content/GroupManager.php
@@ -106,14 +106,12 @@ class GroupManager
 	 * Sidebar widget to show subscribed Friendica groups. If activated
 	 * in the settings, it appears in the network page sidebar
 	 *
-	 * @param string $baseurl Base module path
-	 * @param int    $uid     The ID of the User
-	 * @param int    $cid     The contact id which is used to mark a group as "selected"
+	 * @param int $uid The ID of the User
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function widget(string $baseurl, int $uid, int $cid = 0)
+	public static function widget(int $uid)
 	{
 		$o = '';
 
@@ -130,14 +128,11 @@ class GroupManager
 			$entries = [];
 
 			foreach ($contacts as $contact) {
-				$selected = (($cid == $contact['id']) ? ' group-selected' : '');
-
 				$entry = [
-					'url' => $baseurl . '/' . $contact['id'],
+					'url' => 'contact/' . $contact['id'] . '/conversations',
 					'external_url' => Contact::magicLinkByContact($contact),
 					'name' => $contact['name'],
 					'cid' => $contact['id'],
-					'selected' 	=> $selected,
 					'micro' => DI::baseUrl()->remove(Contact::getMicro($contact)),
 					'id' => ++$id,
 				];

--- a/view/templates/widget/group_list.tpl
+++ b/view/templates/widget/group_list.tpl
@@ -34,7 +34,7 @@ function showHideGroupList() {
 			<a href="{{$group.external_url}}" title="{{$group.link_desc}}" class="label sparkle" target="_blank" rel="noopener noreferrer">
 				<img class="group-list-img" src="{{$group.micro}}" alt="{{$group.link_desc}}" />
 			</a>
-			<a class="group-widget-link {{if $group.selected}}group-selected{{/if}}" id="group-widget-link-{{$group.id}}" href="{{$group.url}}">{{$group.name}}</a>
+			<a class="group-widget-link" id="group-widget-link-{{$group.id}}" href="{{$group.url}}">{{$group.name}}</a>
 		</li>
 		{{/if}}
 
@@ -44,7 +44,7 @@ function showHideGroupList() {
 			<a href="{{$group.external_url}}" title="{{$group.link_desc}}" class="label sparkle" target="_blank" rel="noopener noreferrer">
 				<img class="group-list-img" src="{{$group.micro}}" alt="{{$group.link_desc}}" />
 			</a>
-			<a class="group-widget-link {{if $group.selected}}group-selected{{/if}}" id="group-widget-link-{{$group.id}}" href="{{$group.url}}">{{$group.name}}</a>
+			<a class="group-widget-link" id="group-widget-link-{{$group.id}}" href="{{$group.url}}">{{$group.name}}</a>
 		</li>
 		{{/if}}
 		{{/foreach}}

--- a/view/theme/quattro/templates/widget/group_list.tpl
+++ b/view/theme/quattro/templates/widget/group_list.tpl
@@ -19,7 +19,7 @@ function showHideGroupList() {
 	<ul id="group-list-sidebar-ul" role="menu">
 		{{foreach $groups as $group}}
 		{{if $group.id <= $visible_groups}}
-		<li class="group-widget-entry group-{{$group.cid}} tool {{if $group.selected}}selected{{/if}}" id="group-widget-entry-{{$group.id}}" role="menuitem">
+		<li class="group-widget-entry group-{{$group.cid}} tool" id="group-widget-entry-{{$group.id}}" role="menuitem">
 			<span class="notify badge pull-right"></span>
 			<a href="{{$group.external_url}}" title="{{$group.link_desc}}" class="label sparkle" target="_blank" rel="noopener noreferrer">
 				<img class="group-list-img" src="{{$group.micro}}" alt="{{$group.link_desc}}" />
@@ -29,7 +29,7 @@ function showHideGroupList() {
 		{{/if}}
 
 		{{if $group.id > $visible_groups}}
-		<li class="group-widget-entry group-{{$group.cid}} tool {{if $group.selected}}selected{{/if}}" id="group-widget-entry-extended-{{$group.id}}" role="menuitem" style="display: none;">
+		<li class="group-widget-entry group-{{$group.cid}} tool" id="group-widget-entry-extended-{{$group.id}}" role="menuitem" style="display: none;">
 			<span class="notify badge pull-right"></span>
 			<a href="{{$group.external_url}}" title="{{$group.link_desc}}" class="label sparkle" target="_blank" rel="noopener noreferrer">
 				<img class="group-list-img" src="{{$group.micro}}" alt="{{$group.link_desc}}" />

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -208,7 +208,7 @@ function vier_community_info()
 
 	//Community_Pages at right_aside
 	if ($show_pages && DI::userSession()->getLocalUserId()) {
-		$aside['$page'] = GroupManager::widget('network/group', DI::userSession()->getLocalUserId());;
+		$aside['$page'] = GroupManager::widget(DI::userSession()->getLocalUserId());
 	}
 	// END Community Page
 


### PR DESCRIPTION
There had been two different paths to display group postings. One via the network feed, one via the contact posts. The network feed has got the disadvantage that it is slower than the contacts posts page. Also it has got the disadvantage that it only shows posts from the time on, the user has subscribed to the group. The contact posts page displays all posts.

Also it is confusing, having two different ways to display the same content.