### PR TITLE
Don't set a profile to "discoverable" for restricted hosts

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -397,7 +397,7 @@ class Transmitter
 
 		$data['url'] = $owner['url'];
 		$data['manuallyApprovesFollowers'] = in_array($owner['page-flags'], [User::PAGE_FLAGS_NORMAL, User::PAGE_FLAGS_PRVGROUP]);
-		$data['discoverable'] = (bool)$owner['net-publish'];
+		$data['discoverable'] = (bool)$owner['net-publish'] && $full;
 		$data['publicKey'] = ['id' => $owner['url'] . '#main-key',
 			'owner' => $owner['url'],
 			'publicKeyPem' => $owner['pubkey']];


### PR DESCRIPTION
When the profile access is limited for given hosts, the profile is now set to be not discoverable.