### PR TITLE
Clean up smarty templates.

### DIFF
--- a/view/templates/field_checkbox.tpl
+++ b/view/templates/field_checkbox.tpl
@@ -1,7 +1,7 @@
 	<div class="field checkbox" id="div_id_{{$field.0}}">
 		<label id="id_{{$field.0}}_label" for="id_{{$field.0}}">{{$field.1}}</label>
 		<input type="hidden" name="{{$field.0}}" value="0">
-		<input type="checkbox" name="{{$field.0}}" id="id_{{$field.0}}" aria-describedby="{{$field.0}}_tip" value="1" {{if $field.2}}checked="checked"{{/if}} {{if $field.4}}{{$field.4 nofilter}}{{/if}}>
+		<input type="checkbox" name="{{$field.0}}" id="id_{{$field.0}}" aria-describedby="{{$field.0}}_tip" value="1" {{if $field.2}}checked{{/if}} {{$field.4 nofilter}}>
 		{{if $field.3}}
 		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>
 		{{/if}}

--- a/view/templates/field_combobox.tpl
+++ b/view/templates/field_combobox.tpl
@@ -1,12 +1,12 @@
-	<div class='field combobox'>
-		<label for='id_{{$field.0}}' id='id_{{$field.0}}_label'>{{$field.1}}</label>
+	<div class="field combobox">
+		<label for="id_{{$field.0}}" id="id_{{$field.0}}_label">{{$field.1}}</label>
 		{{* html5 don't work on Chrome, Safari and IE9
 		<input id="id_{{$field.0}}" type="text" list="data_{{$field.0}}">
 		<datalist id="data_{{$field.0}}">
 		   {{foreach $field.4 as $opt=>$val}}<option value="{{$val}}">{{/foreach}}
 		</datalist> *}}
 
-		<input id="id_{{$field.0}}" type="text" value="{{$field.2}}" aria-describedby='{{$field.0}}_tip'>
+		<input id="id_{{$field.0}}" type="text" value="{{$field.2}}" aria-describedby="{{$field.0}}_tip">
 		<select id="select_{{$field.0}}" onChange="$('#id_{{$field.0}}').val($(this).val())">
 			<option value="">{{$field.5}}</option>
 			{{foreach $field.4 as $opt=>$val}}<option value="{{$val}}">{{$val}}</option>{{/foreach}}

--- a/view/templates/field_custom.tpl
+++ b/view/templates/field_custom.tpl
@@ -1,7 +1,7 @@
 
-	
-	<div class='field custom'>
-		<label for='{{$field.0}}'>{{$field.1}}</label>
+
+	<div class="field custom">
+		<label for="{{$field.0}}">{{$field.1}}</label>
 		{{$field.2 nofilter}}
 		{{if $field.3}}
 		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>

--- a/view/templates/field_datetime.tpl
+++ b/view/templates/field_datetime.tpl
@@ -1,4 +1,4 @@
-{{include file='field_input.tpl' field=$field}}
+{{include file="field_input.tpl" field=$field}}
 
 <script type="text/javascript">
 	$(function () {

--- a/view/templates/field_input.tpl
+++ b/view/templates/field_input.tpl
@@ -1,7 +1,7 @@
-	
+
 	<div class="field input" id="wrapper_{{$field.0}}">
 		<label for="id_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
-		<input type="{{$field.6|default:'text'}}" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2}}"{{if $field.4}} required{{/if}}{{if $field.5 eq "autofocus"}} autofocus{{elseif $field.5}} {{$field.5 nofilter}}{{/if}} aria-describedby="{{$field.0}}_tip" dir="auto">
+		<input type="{{$field.6|default:'text'}}" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2}}"{{if $field.4}} required{{/if}} {{$field.5 nofilter}} aria-describedby="{{$field.0}}_tip" dir="auto">
 	{{if $field.3}}
 		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>
 	{{/if}}

--- a/view/templates/field_intcheckbox.tpl
+++ b/view/templates/field_intcheckbox.tpl
@@ -1,9 +1,9 @@
 
 
-	<div class='field checkbox'>
-		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input type="checkbox" name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.3}}" {{if $field.2}}checked{{/if}} aria-describedby='{{$field.0}}_tip'>
+	<div class="field checkbox">
+		<label for="id_{{$field.0}}">{{$field.1}}</label>
+		<input type="checkbox" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.3}}" {{if $field.2}}checked{{/if}} aria-describedby="{{$field.0}}_tip">
 		{{if $field.4}}
-		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.4 nofilter}}</span>
+		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.4 nofilter}}</span>
 		{{/if}}
 	</div>

--- a/view/templates/field_intcheckbox.tpl
+++ b/view/templates/field_intcheckbox.tpl
@@ -1,8 +1,8 @@
 
-	
+
 	<div class='field checkbox'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input type="checkbox" name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.3}}" {{if $field.2}}checked="true"{{/if}} aria-describedby='{{$field.0}}_tip'>
+		<input type="checkbox" name='{{$field.0}}' id='id_{{$field.0}}' value="{{$field.3}}" {{if $field.2}}checked{{/if}} aria-describedby='{{$field.0}}_tip'>
 		{{if $field.4}}
 		<span class='field_help' role='tooltip' id='{{$field.0}}_tip'>{{$field.4 nofilter}}</span>
 		{{/if}}

--- a/view/templates/field_openid.tpl
+++ b/view/templates/field_openid.tpl
@@ -1,6 +1,6 @@
 	<div class='field input openid' id='wrapper_{{$field.0}}'>
 		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input name='{{$field.0}}' id='id_{{$field.0}}' type="text" value="{{$field.2}}" {{if $field.4}} readonly="readonly" {{/if}} aria-describedby='{{$field.0}}_tip'>
+		<input name='{{$field.0}}' id='id_{{$field.0}}' type="text" value="{{$field.2}}" {{if $field.4}}readonly{{/if}} aria-describedby='{{$field.0}}_tip'>
 		{{if $field.3}}
 		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>
 		{{/if}}

--- a/view/templates/field_openid.tpl
+++ b/view/templates/field_openid.tpl
@@ -1,6 +1,6 @@
-	<div class='field input openid' id='wrapper_{{$field.0}}'>
-		<label for='id_{{$field.0}}'>{{$field.1}}</label>
-		<input name='{{$field.0}}' id='id_{{$field.0}}' type="text" value="{{$field.2}}" {{if $field.4}}readonly{{/if}} aria-describedby='{{$field.0}}_tip'>
+	<div class="field input openid" id="wrapper_{{$field.0}}">
+		<label for="id_{{$field.0}}">{{$field.1}}</label>
+		<input name="{{$field.0}}" id="id_{{$field.0}}" type="text" value="{{$field.2}}" {{if $field.4}}readonly{{/if}} aria-describedby="{{$field.0}}_tip">
 		{{if $field.3}}
 		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>
 		{{/if}}

--- a/view/templates/field_password.tpl
+++ b/view/templates/field_password.tpl
@@ -1,6 +1,6 @@
 	<div class="field password" id="wrapper_{{$field.0}}">
 		<label for="id_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
-		<input type="password" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2}}"{{if $field.4}} required{{/if}}{{if $field.5 eq "autofocus"}} autofocus{{elseif $field.5}} {{$field.5 nofilter}}{{/if}}{{if $field.6}} pattern="(($field.6}}"{{/if}} aria-describedby="{{$field.0}}_tip">
+		<input type="password" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} {{if $field.6}}pattern="(($field.6}}"{{/if}} aria-describedby="{{$field.0}}_tip">
 		{{if $field.3}}
 		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>
 		{{/if}}

--- a/view/templates/field_radio.tpl
+++ b/view/templates/field_radio.tpl
@@ -1,7 +1,7 @@
-	<div class='field radio'>
-		<label for='id_{{$field.0}}_{{$field.2}}'>{{$field.1}}</label>
-		<input type="radio" name='{{$field.0}}' id='id_{{$field.0}}_{{$field.2}}' value="{{$field.2}}" {{if $field.4}}checked{{/if}} aria-describedby={{$field.0}}_{{$field.2}}_tip'>
+	<div class="field radio">
+		<label for="id_{{$field.0}}_{{$field.2}}">{{$field.1}}</label>
+		<input type="radio" name="{{$field.0}}" id="id_{{$field.0}}_{{$field.2}}" value="{{$field.2}}" {{if $field.4}}checked{{/if}} aria-describedby="{{$field.0}}_{{$field.2}}_tip">
 		{{if $field.3}}
-		<span class='field_help' role='tooltip' id='{{$field.0}}_{{$field.2}}_tip'>{{$field.3 nofilter}}</span>
+		<span class="field_help" role="tooltip" id="{{$field.0}}_{{$field.2}}_tip">{{$field.3 nofilter}}</span>
 		{{/if}}
 	</div>

--- a/view/templates/field_select.tpl
+++ b/view/templates/field_select.tpl
@@ -3,7 +3,7 @@
 		<label for="id_{{$field.0}}">{{$field.1}}</label>
 		<select name="{{$field.0}}" id="id_{{$field.0}}" aria-describedby="{{$field.0}}_tip" {{$field.5 nofilter}}>
 	{{foreach $field.4 as $opt => $val}}
-		{{if $field.5 == 'multiple'}}
+		{{if $field.5 == "multiple"}}
 			<option value="{{$opt}}" dir="auto" {{if in_array($opt, $field.2)}}selected{{/if}}>{{$val}}</option>
 		{{else}}
 			<option value="{{$opt}}" dir="auto" {{if $opt == $field.2}}selected{{/if}}>{{$val}}</option>

--- a/view/templates/field_select.tpl
+++ b/view/templates/field_select.tpl
@@ -4,9 +4,9 @@
 		<select name="{{$field.0}}" id="id_{{$field.0}}" aria-describedby="{{$field.0}}_tip" {{$field.5 nofilter}}>
 	{{foreach $field.4 as $opt => $val}}
 		{{if $field.5 == 'multiple'}}
-			<option value="{{$opt}}" dir="auto"{{if in_array($opt, $field.2)}} selected="selected"{{/if}}>{{$val}}</option>
+			<option value="{{$opt}}" dir="auto" {{if in_array($opt, $field.2)}}selected{{/if}}>{{$val}}</option>
 		{{else}}
-			<option value="{{$opt}}" dir="auto"{{if $opt == $field.2}} selected="selected"{{/if}}>{{$val}}</option>
+			<option value="{{$opt}}" dir="auto" {{if $opt == $field.2}}selected{{/if}}>{{$val}}</option>
 		{{/if}}
 	{{/foreach}}
 		</select>

--- a/view/templates/field_textarea.tpl
+++ b/view/templates/field_textarea.tpl
@@ -1,7 +1,7 @@
 
 	<div class="field textarea">
 		<label for="id_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
-		<textarea class="form-control text-autosize" name="{{$field.0}}" id="id_{{$field.0}}" {{if $field.4}} required{{/if}}{{if $field.5}} {{$field.5 nofilter}}{{/if}} aria-describedby="{{$field.0}}_tip" dir="auto">{{$field.2}}</textarea>
+		<textarea class="form-control text-autosize" name="{{$field.0}}" id="id_{{$field.0}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} aria-describedby="{{$field.0}}_tip" dir="auto">{{$field.2}}</textarea>
 	{{if $field.3}}
 		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>
 	{{/if}}

--- a/view/templates/field_themeselect.tpl
+++ b/view/templates/field_themeselect.tpl
@@ -6,7 +6,7 @@
 		<label for="id_{{$field.0}}">{{$field.1}}</label>
 		<select name="{{$field.0}}" id="id_{{$field.0}}" {{if $field.5}}onchange="previewTheme(this);"{{/if}} aria-describedby="{{$field.0}}_tip">
 	{{foreach $field.4 as $opt=>$val}}
-			<option value="{{$opt}}" dir="auto"{{if $opt==$field.2}} selected="selected"{{/if}}>{{$val}}</option>
+			<option value="{{$opt}}" dir="auto" {{if $opt==$field.2}}selected{{/if}}>{{$val}}</option>
 	{{/foreach}}
 		</select>
 	{{if $field.3}}

--- a/view/theme/frio/templates/field_checkbox.tpl
+++ b/view/theme/frio/templates/field_checkbox.tpl
@@ -1,8 +1,8 @@
 
 	<div class="field checkbox" id="div_id_{{$field.0}}">
 			<input type="hidden" name="{{$field.0}}" value="0">
-			<input type="checkbox" name="{{$field.0}}" id="id_{{$field.0}}" value="1" {{if $field.2}}checked="checked"{{/if}} {{if $field.3}}aria-describedby="{{$field.0}}_tip"{{/if}} {{if $field.4}}{{$field.4 nofilter}}{{/if}}>
-			<label for="id_{{$field.0}}">
+			<input type="checkbox" name="{{$field.0}}" id="id_{{$field.0}}" value="1" {{if $field.2}}checked{{/if}} {{if $field.3}}aria-describedby="{{$field.0}}_tip"{{/if}} {{$field.4 nofilter}}>
+			<label for="id_{{$field.0}}">01
 				{{$field.1}}
 				{{if $field.3}}
 				<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.3 nofilter}}</span>

--- a/view/theme/frio/templates/field_fileinput.tpl
+++ b/view/theme/frio/templates/field_fileinput.tpl
@@ -1,7 +1,7 @@
 <div class="form-group field input file">
 	<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
 	<div class="input-group" id="{{$field.0}}">
-		<input class="form-control file" name="{{$field.0}}" id="id_{{$field.0}}" type="text" value="{{$field.2}}"{{if $field.4}} required{{/if}} aria-describedby="{{$field.0}}_tip">
+		<input class="form-control file" name="{{$field.0}}" id="id_{{$field.0}}" type="text" value="{{$field.2}}" {{if $field.4}}required{{/if}} aria-describedby="{{$field.0}}_tip">
 		<span class="input-group-addon image-select"><i class="fa fa-picture-o"></i></span>
 	</div>
 	{{if $field.3}}

--- a/view/theme/frio/templates/field_input.tpl
+++ b/view/theme/frio/templates/field_input.tpl
@@ -3,7 +3,7 @@
 	{{if !isset($label) || $label != false }}
 		<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1 nofilter}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
 	{{/if}}
-		<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="{{$field.6|default:'text'}}" value="{{$field.2}}"{{if $field.4}} required{{/if}}{{if $field.5 eq "autofocus"}} autofocus{{elseif $field.5}} {{$field.5 nofilter}}{{/if}} aria-describedby="{{$field.0}}_tip">
+		<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="{{$field.6|default:'text'}}" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} aria-describedby="{{$field.0}}_tip">
 	{{if $field.3}}
 		<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.3 nofilter}}</span>
 	{{/if}}

--- a/view/theme/frio/templates/field_intcheckbox.tpl
+++ b/view/theme/frio/templates/field_intcheckbox.tpl
@@ -1,6 +1,6 @@
 
 	<div class="form-group field checkbox">
-		<input type="checkbox" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.3}}" {{if $field.2}}checked="checked"{{/if}} aria-checked="{{if $field.2}}true{{else}}false{{/if}}" aria-describedby="{{$field.0}}_tip">
+		<input type="checkbox" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.3}}" {{if $field.2}}checked{{/if}} aria-checked="{{if $field.2}}true{{else}}false{{/if}}" aria-describedby="{{$field.0}}_tip">
 		<label for="id_{{$field.0}}">{{$field.1}}</label>
 		{{if $field.4}}
 		<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.4 nofilter}}</span>

--- a/view/theme/frio/templates/field_openid.tpl
+++ b/view/theme/frio/templates/field_openid.tpl
@@ -1,6 +1,6 @@
 <div id="id_{{$field.0}}_wrapper" class="form-group field input openid">
 	<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1}}</label>
-	<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="text" value="{{$field.2}}" {{if $field.4}} readonly="readonly" {{/if}} aria-describedby="{{$field.0}}_tip">
+	<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="text" value="{{$field.2}}" {{if $field.4}}readonly{{/if}} aria-describedby="{{$field.0}}_tip">
 	{{if $field.3}}
 	<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.3 nofilter}}</span>
 	{{/if}}

--- a/view/theme/frio/templates/field_password.tpl
+++ b/view/theme/frio/templates/field_password.tpl
@@ -1,6 +1,6 @@
 <div id="id_{{$field.0}}_wrapper" class="form-group field input password">
 	<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
-	<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="password" value="{{$field.2}}" {{if $field.4}} required{{/if}}{{if $field.5 eq "autofocus"}} autofocus{{elseif $field.5}} {{$field.5 nofilter}}{{/if}}{{if $field.6}} pattern="{{$field.6}}"{{/if}} aria-describedby="{{$field.0}}_tip">
+	<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="password" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} {{if $field.6}}pattern="{{$field.6}}"{{/if}} aria-describedby="{{$field.0}}_tip">
 	{{if $field.3}}
 	<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.3 nofilter}}</span>
 	{{/if}}

--- a/view/theme/frio/templates/field_select.tpl
+++ b/view/theme/frio/templates/field_select.tpl
@@ -3,7 +3,7 @@
 		<label for="id_{{$field.0}}">{{$field.1}}</label>
 		<select name="{{$field.0}}" id="id_{{$field.0}}" class="form-control" aria-describedby="{{$field.0}}_tip" {{$field.5 nofilter}}>
 	{{foreach $field.4 as $opt => $val}}
-		{{if $field.5 == 'multiple'}}
+		{{if $field.5 == "multiple"}}
 			<option value="{{$opt}}" {{if in_array($opt, $field.2)}}selected{{/if}}>{{$val}}</option>
 		{{else}}
 			<option value="{{$opt}}" {{if $opt == $field.2}}selected{{/if}}>{{$val}}</option>

--- a/view/theme/frio/templates/field_select.tpl
+++ b/view/theme/frio/templates/field_select.tpl
@@ -4,9 +4,9 @@
 		<select name="{{$field.0}}" id="id_{{$field.0}}" class="form-control" aria-describedby="{{$field.0}}_tip" {{$field.5 nofilter}}>
 	{{foreach $field.4 as $opt => $val}}
 		{{if $field.5 == 'multiple'}}
-			<option value="{{$opt}}" {{if in_array($opt, $field.2)}}selected="selected"{{/if}}>{{$val}}</option>
+			<option value="{{$opt}}" {{if in_array($opt, $field.2)}}selected{{/if}}>{{$val}}</option>
 		{{else}}
-			<option value="{{$opt}}" {{if $opt == $field.2}}selected="selected"{{/if}}>{{$val}}</option>
+			<option value="{{$opt}}" {{if $opt == $field.2}}selected{{/if}}>{{$val}}</option>
 		{{/if}}
 	{{/foreach}}
 		</select>

--- a/view/theme/frio/templates/field_textarea.tpl
+++ b/view/theme/frio/templates/field_textarea.tpl
@@ -2,7 +2,7 @@
 	{{if $field.1}}
 		<label for="id_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
 	{{/if}}
-		<textarea class="form-control text-autosize" name="{{$field.0}}" id="id_{{$field.0}}"{{if $field.4}} required{{/if}}{{if $field.5}} {{$field.5 nofilter}}{{/if}} aria-describedby="{{$field.0}}_tip">{{$field.2}}</textarea>
+		<textarea class="form-control text-autosize" name="{{$field.0}}" id="id_{{$field.0}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} aria-describedby="{{$field.0}}_tip">{{$field.2}}</textarea>
 	{{if $field.3}}
 		<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.3 nofilter}}</span>
 	{{/if}}

--- a/view/theme/frio/templates/field_themeselect.tpl
+++ b/view/theme/frio/templates/field_themeselect.tpl
@@ -6,7 +6,7 @@
 		<label for="id_{{$field.0}}">{{$field.1}}</label>
 		<select class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" {{if $field.5=="preview"}}onchange="previewTheme(this);"{{/if}} aria-describedby="{{$field.0}}_tip">
 	{{foreach $field.4 as $opt=>$val}}
-			<option value="{{$opt}}" {{if $opt==$field.2}}selected="selected"{{/if}}>{{$val}}</option>
+			<option value="{{$opt}}" {{if $opt==$field.2}}selected{{/if}}>{{$val}}</option>
 	{{/foreach}}
 		</select>
 	{{if $field.3}}


### PR DESCRIPTION
This simplifies some logic in if-conditions, because smarty just returns an empty string for undefined variables.

Also, this commit removes unnecessary values from HTML input attributes.

See https://github.com/friendica/friendica/pull/13805#issuecomment-1879745102 for motivation.