### PR TITLE
allow hosts to be validated even if ipv6 fails

### DIFF
--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -73,7 +73,7 @@ class HttpClient implements ICanSendHttpRequests
 			throw new \InvalidArgumentException('Unable to retrieve the host in URL: ' . $url);
 		}
 
-		if(!filter_var($host, FILTER_VALIDATE_IP) && !@dns_get_record($host . '.', DNS_A + DNS_AAAA)) {
+		if(!filter_var($host, FILTER_VALIDATE_IP) && !@dns_get_record($host . '.', DNS_A) && !@dns_get_record($host . '.', DNS_AAAA)) {
 			$this->logger->debug('URL cannot be resolved.', ['url' => $url]);
 			$this->profiler->stopRecording();
 			return CurlResult::createErrorCurl($this->logger, $url);


### PR DESCRIPTION
The problem here is that we check the domain as both an A (IPv4) and AAAA (IPv6) record using `dns_get_record`.  But if either of those fails, the entire function returns `false`.

It's pretty rare that an IPv6 address lookup will actually fail like this.  However, it so happens that my brand new test setup uses vagrant-dns, which has no support for IPv6, and to avoid long timeouts simply [returns NOTIMPL](https://github.com/BerlinVagrant/vagrant-dns/issues/76) instead.  As a result all requests fail in this check.

This is a regression unintentionally introduced by [this change](https://github.com/MrPetovan/friendica/commit/bb980468467d740691a081a9fe3334070fa9a7eb).  It used to be that when `dns_get_record` failed, `gethostbyname` would still succeed, covering up the problem.

By the way, I'd prefer to create this pull request on gitea, but I don't seem to be able to.  Am I doing the right thing by submitting it on github instead?