### PR TITLE
Update use of PasswordExposed API

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -864,7 +864,7 @@ class User
 		try {
 			$passwordExposedChecker = new PasswordExposed\PasswordExposedChecker(null, $cache);
 
-			return $passwordExposedChecker->passwordExposed($password) === PasswordExposed\PasswordStatus::EXPOSED;
+			return $passwordExposedChecker->passwordExposed($password) === PasswordExposed\Enums\PasswordStatus::EXPOSED;
 		} catch (Exception $e) {
 			Logger::error('Password Exposed Exception: ' . $e->getMessage(), [
 				'code' => $e->getCode(),


### PR DESCRIPTION
It seems this library has changed its API, and the previous console command for changing passwords doesn't work.  This brings it up to date so that the command works again.