### PR TITLE
Allow setting user avatar in the console at creation

### DIFF
--- a/src/Console/User.php
+++ b/src/Console/User.php
@@ -58,7 +58,7 @@ class User extends \Asika\SimpleConsole\Console
 console user - Modify user settings per console commands.
 Usage
 	bin/console user password <nickname> [<password>] [-h|--help|-?] [-v]
-	bin/console user add [<name> [<nickname> [<email> [<language>]]]] [-h|--help|-?] [-v]
+	bin/console user add [<name> [<nickname> [<email> [<language> [<avatar_url>]]]]] [-h|--help|-?] [-v]
 	bin/console user delete [<nickname>] [-y] [-h|--help|-?] [-v]
 	bin/console user allow [<nickname>] [-h|--help|-?] [-v]
 	bin/console user deny [<nickname>] [-h|--help|-?] [-v]
@@ -228,10 +228,11 @@ HELP;
 	 */
 	private function addUser()
 	{
-		$name  = $this->getArgument(1);
-		$nick  = $this->getArgument(2);
-		$email = $this->getArgument(3);
-		$lang  = $this->getArgument(4);
+		$name   = $this->getArgument(1);
+		$nick   = $this->getArgument(2);
+		$email  = $this->getArgument(3);
+		$lang   = $this->getArgument(4);
+		$avatar = $this->getArgument(5);
 
 		if (empty($name)) {
 			$this->out($this->l10n->t('Enter user name: '));
@@ -262,10 +263,15 @@ HELP;
 			$lang = CliPrompt::prompt();
 		}
 
+		if (empty($avatar)) {
+			$this->out($this->l10n->t('Enter URL of an image to use as avatar (optional): '));
+			$avatar = CliPrompt::prompt();
+		}
+
 		if (empty($lang)) {
 			return UserModel::createMinimal($name, $email, $nick);
 		} else {
-			return UserModel::createMinimal($name, $email, $nick, $lang);
+			return UserModel::createMinimal($name, $email, $nick, $lang, $avatar);
 		}
 	}
 

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1553,16 +1553,17 @@ class User
 	/**
 	 * Creates a new user based on a minimal set and sends an email to this user
 	 *
-	 * @param string $name  The user's name
-	 * @param string $email The user's email address
-	 * @param string $nick  The user's nick name
-	 * @param string $lang  The user's language (default is english)
+	 * @param string $name   The user's name
+	 * @param string $email  The user's email address
+	 * @param string $nick   The user's nick name
+	 * @param string $lang   The user's language (default is english)
+	 * @param string $avatar URL to an image to use as avatar (default is to prompt user at first login)
 	 * @return bool True, if the user was created successfully
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws ErrorException
 	 * @throws ImagickException
 	 */
-	public static function createMinimal(string $name, string $email, string $nick, string $lang = L10n::DEFAULT): bool
+	public static function createMinimal(string $name, string $email, string $nick, string $lang = L10n::DEFAULT, string $avatar = ''): bool
 	{
 		if (empty($name) ||
 		    empty($email) ||
@@ -1575,7 +1576,8 @@ class User
 			'email' => $email,
 			'nickname' => $nick,
 			'verified' => 1,
-			'language' => $lang
+			'language' => $lang,
+			'photo' => $avatar
 		]);
 
 		$user = $result['user'];


### PR DESCRIPTION
This might be considered of marginal value, but I'm throwing it out there anyway...

I create a lot of test accounts, and I get sick of having to upload profile photos by hand at each first login.  I don't think there's any other way to set a profile photo from the console utility.  So I've added an extra optional parameter to the add user command.

Note that this is in some sense a breaking change: my scripts actually hung at first because the command now prompts for an optional photo.

It would be nicer if setting a profile photo also automatically skipped the photo prompt at first login.  I looked into that, but it's not trivial to tell whether the current photo is the default photo or a custom one.  So never mind, it's only one click.