### PR TITLE
"ANY_VALUE" is removed

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -215,14 +215,14 @@ function photos_post(App $a)
 			// get the list of photos we are about to delete
 			if ($visitor) {
 				$r = DBA::toArray(DBA::p(
-					"SELECT distinct(`resource-id`) as `rid` FROM `photo` WHERE `contact-id` = ? AND `uid` = ? AND `album` = ?",
+					"SELECT distinct(`resource-id`) AS `rid` FROM `photo` WHERE `contact-id` = ? AND `uid` = ? AND `album` = ?",
 					$visitor,
 					$page_owner_uid,
 					$album
 				));
 			} else {
 				$r = DBA::toArray(DBA::p(
-					"SELECT distinct(`resource-id`) as `rid` FROM `photo` WHERE `uid` = ? AND `album` = ?",
+					"SELECT distinct(`resource-id`) AS `rid` FROM `photo` WHERE `uid` = ? AND `album` = ?",
 					DI::userSession()->getLocalUserId(),
 					$album
 				));
@@ -762,7 +762,7 @@ function photos_content(App $a)
 
 		$total = 0;
 		$r = DBA::toArray(DBA::p(
-			"SELECT `resource-id`, max(`scale`) AS `scale` FROM `photo` WHERE `uid` = ? AND `album` = ?
+			"SELECT `resource-id`, MAX(`scale`) AS `scale` FROM `photo` WHERE `uid` = ? AND `album` = ?
 			AND `scale` <= 4 $sql_extra GROUP BY `resource-id`",
 			$owner_uid,
 			$album
@@ -782,9 +782,9 @@ function photos_content(App $a)
 		}
 
 		$r = DBA::toArray(DBA::p(
-			"SELECT `resource-id`, ANY_VALUE(`id`) AS `id`, ANY_VALUE(`filename`) AS `filename`,
-			ANY_VALUE(`type`) AS `type`, max(`scale`) AS `scale`, ANY_VALUE(`desc`) as `desc`,
-			ANY_VALUE(`created`) as `created`
+			"SELECT `resource-id`, MIN(`id`) AS `id`, MIN(`filename`) AS `filename`,
+			MIN(`type`) AS `type`, MAX(`scale`) AS `scale`, MIN(`desc`) AS `desc`,
+			MIN(`created`) AS `created`
 			FROM `photo` WHERE `uid` = ? AND `album` = ?
 			AND `scale` <= 4 $sql_extra GROUP BY `resource-id` ORDER BY `created` $order LIMIT ? , ?",
 			intval($owner_uid),
@@ -1167,11 +1167,11 @@ function photos_content(App $a)
 				}
 
 				if (!empty($conv_responses['like'][$link_item['uri']])) {
-					$like = DI::conversation()->formatActivity($conv_responses['like'][$link_item['uri']]['links'], 'like', $link_item['id']);
+					$like = DI::conversation()->formatActivity($conv_responses['like'][$link_item['uri']]['links'], 'like', $link_item['id'], '', []);
 				}
 
 				if (!empty($conv_responses['dislike'][$link_item['uri']])) {
-					$dislike = DI::conversation()->formatActivity($conv_responses['dislike'][$link_item['uri']]['links'], 'dislike', $link_item['id']);
+					$dislike = DI::conversation()->formatActivity($conv_responses['dislike'][$link_item['uri']]['links'], 'dislike', $link_item['id'], '', []);
 				}
 
 				if (($can_post || Security::canWriteToUserWall($owner_uid))) {

--- a/src/Database/DBA.php
+++ b/src/Database/DBA.php
@@ -133,22 +133,6 @@ class DBA
 	}
 
 	/**
-	 * Replaces ANY_VALUE() function by MIN() function,
-	 * if the database server does not support ANY_VALUE().
-	 *
-	 * Considerations for Standard SQL, or MySQL with ONLY_FULL_GROUP_BY (default since 5.7.5).
-	 * ANY_VALUE() is available from MySQL 5.7.5 https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html
-	 * A standard fall-back is to use MIN().
-	 *
-	 * @param string $sql An SQL string without the values
-	 * @return string The input SQL string modified if necessary.
-	 */
-	public static function anyValueFallback(string $sql): string
-	{
-		return DI::dba()->anyValueFallback($sql);
-	}
-
-	/**
 	 * beautifies the query - useful for "SHOW PROCESSLIST"
 	 *
 	 * This is safe when we bind the parameters later.

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -229,8 +229,8 @@ class Photo
 
 		return DBA::toArray(
 			DBA::p(
-				"SELECT `resource-id`, ANY_VALUE(`id`) AS `id`, ANY_VALUE(`filename`) AS `filename`, ANY_VALUE(`type`) AS `type`,
-					min(`scale`) AS `hiq`, max(`scale`) AS `loq`, ANY_VALUE(`desc`) AS `desc`, ANY_VALUE(`created`) AS `created`
+				"SELECT `resource-id`, MIN(`id`) AS `id`, MIN(`filename`) AS `filename`, MIN(`type`) AS `type`,
+					min(`scale`) AS `hiq`, max(`scale`) AS `loq`, MIN(`desc`) AS `desc`, MIN(`created`) AS `created`
 					FROM `photo` WHERE `uid` = ? AND NOT `photo-type` IN (?, ?) $sqlExtra
 					GROUP BY `resource-id` $sqlExtra2",
 				$values
@@ -751,7 +751,7 @@ class Photo
 			if (!DI::config()->get('system', 'no_count', false)) {
 				/// @todo This query needs to be renewed. It is really slow
 				// At this time we just store the data in the cache
-				$albums = DBA::toArray(DBA::p("SELECT COUNT(DISTINCT `resource-id`) AS `total`, `album`, ANY_VALUE(`created`) AS `created`
+				$albums = DBA::toArray(DBA::p("SELECT COUNT(DISTINCT `resource-id`) AS `total`, `album`, MIN(`created`) AS `created`
 					FROM `photo`
 					WHERE `uid` = ? AND `photo-type` IN (?, ?, ?) $sql_extra
 					GROUP BY `album` ORDER BY `created` DESC",

--- a/src/Module/Admin/Federation.php
+++ b/src/Module/Admin/Federation.php
@@ -97,7 +97,7 @@ class Federation extends BaseAdmin
 			SUM(IFNULL(`local-posts`, 0) + IFNULL(`local-comments`, 0)) AS `posts`,
 			SUM(IFNULL(`active-month-users`, `active-week-users`)) AS `month`,
 			SUM(IFNULL(`active-halfyear-users`, `active-week-users`)) AS `halfyear`, `platform`,
-			ANY_VALUE(`network`) AS `network`, MAX(`version`) AS `version`
+			MIN(`network`) AS `network`, MAX(`version`) AS `version`
 			FROM `gserver` WHERE NOT `failed` AND `platform` != ? AND `detection-method` != ? AND NOT `network` IN (?, ?) GROUP BY `platform`",
 				'', GServer::DETECT_MANUAL, Protocol::PHANTOM, Protocol::FEED);
 		while ($gserver = DBA::fetch($gservers)) {

--- a/src/Module/Profile/Photos.php
+++ b/src/Module/Profile/Photos.php
@@ -322,12 +322,12 @@ class Photos extends \Friendica\Module\BaseProfile
 		$photos = $this->database->toArray($this->database->p(
 			"SELECT
 				`resource-id`,
-				ANY_VALUE(`id`) AS `id`,
-				ANY_VALUE(`filename`) AS `filename`,
-				ANY_VALUE(`type`) AS `type`,
-				ANY_VALUE(`album`) AS `album`,
-				max(`scale`) AS `scale`,
-				ANY_VALUE(`created`) AS `created`
+				MIN(`id`) AS `id`,
+				MIN(`filename`) AS `filename`,
+				MIN(`type`) AS `type`,
+				MIN(`album`) AS `album`,
+				MAX(`scale`) AS `scale`,
+				MIN(`created`) AS `created`
 			FROM `photo`
 			WHERE `uid` = ?
 			  AND `photo-type` = ?

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2024.03-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-14 07:50+0000\n"
+"POT-Creation-Date: 2024-01-15 16:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -953,7 +953,7 @@ msgstr ""
 msgid "All pending post updates are done."
 msgstr ""
 
-#: src/Console/User.php:158 src/Console/User.php:245
+#: src/Console/User.php:158 src/Console/User.php:246
 msgid "Enter user nickname: "
 msgstr ""
 
@@ -980,44 +980,48 @@ msgstr ""
 msgid "Password changed."
 msgstr ""
 
-#: src/Console/User.php:237
+#: src/Console/User.php:238
 msgid "Enter user name: "
 msgstr ""
 
-#: src/Console/User.php:253
+#: src/Console/User.php:254
 msgid "Enter user email address: "
 msgstr ""
 
-#: src/Console/User.php:261
+#: src/Console/User.php:262
 msgid "Enter a language (optional): "
 msgstr ""
 
-#: src/Console/User.php:286
+#: src/Console/User.php:267
+msgid "Enter URL of an image to use as avatar (optional): "
+msgstr ""
+
+#: src/Console/User.php:292
 msgid "User is not pending."
 msgstr ""
 
-#: src/Console/User.php:318
+#: src/Console/User.php:324
 msgid "User has already been marked for deletion."
 msgstr ""
 
-#: src/Console/User.php:323
+#: src/Console/User.php:329
 #, php-format
 msgid "Type \"yes\" to delete %s"
 msgstr ""
 
-#: src/Console/User.php:325
+#: src/Console/User.php:331
 msgid "Deletion aborted."
 msgstr ""
 
-#: src/Console/User.php:450
+#: src/Console/User.php:456
 msgid "Enter category: "
 msgstr ""
 
-#: src/Console/User.php:460
+#: src/Console/User.php:466
 msgid "Enter key: "
 msgstr ""
 
-#: src/Console/User.php:494
+#: src/Console/User.php:500
 msgid "Enter value: "
 msgstr ""
 
@@ -3785,7 +3789,7 @@ msgstr ""
 msgid "Profile Photos"
 msgstr ""
 
-#: src/Model/User.php:1582
+#: src/Model/User.php:1584
 #, php-format
 msgid ""
 "\n"
@@ -3793,7 +3797,7 @@ msgid ""
 "\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: src/Model/User.php:1585
+#: src/Model/User.php:1587
 #, php-format
 msgid ""
 "\n"
@@ -3829,12 +3833,12 @@ msgid ""
 "\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: src/Model/User.php:1617 src/Model/User.php:1723
+#: src/Model/User.php:1619 src/Model/User.php:1725
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
-#: src/Model/User.php:1637
+#: src/Model/User.php:1639
 #, php-format
 msgid ""
 "\n"
@@ -3850,12 +3854,12 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:1656
+#: src/Model/User.php:1658
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: src/Model/User.php:1680
+#: src/Model/User.php:1682
 #, php-format
 msgid ""
 "\n"
@@ -3864,7 +3868,7 @@ msgid ""
 "\t\t\t"
 msgstr ""
 
-#: src/Model/User.php:1688
+#: src/Model/User.php:1690
 #, php-format
 msgid ""
 "\n"
@@ -3902,7 +3906,7 @@ msgid ""
 "\t\t\tThank you and welcome to %2$s."
 msgstr ""
 
-#: src/Model/User.php:1750
+#: src/Model/User.php:1752
 msgid ""
 "User with delegates can't be removed, please remove delegate users first"
 msgstr ""


### PR DESCRIPTION
The function "ANY_VALUE" does only exist for MySQL but not for MariaDB. Since we primarily support MariaDB it doesn't make sense to support some compatibility layer like we did before. We now simply use "MIN" which always had been done for each query anyway.