### PR TITLE
Make hard-coded max response configurable

### DIFF
--- a/src/Network/HTTPClient/Factory/HttpClient.php
+++ b/src/Network/HTTPClient/Factory/HttpClient.php
@@ -123,7 +123,7 @@ class HttpClient extends BaseFactory
 		$resolver->setMaxRedirects(10);
 		$resolver->setRequestTimeout(10);
 		// if the file is too large then exit
-		$resolver->setMaxResponseDataSize($this->config->get('system', 'max_response_data_size', 1000000));
+		$resolver->setMaxResponseDataSize($this->config->get('http_client', 'max_response_data_size', 1000000));
 		// Designate a temporary file that will store cookies during the session.
 		// Some websites test the browser for cookie support, so this enhances results.
 		$resolver->setCookieJar(System::getTempPath() .'/resolver-cookie-' . Strings::getRandomName(10));

--- a/src/Network/HTTPClient/Factory/HttpClient.php
+++ b/src/Network/HTTPClient/Factory/HttpClient.php
@@ -123,7 +123,7 @@ class HttpClient extends BaseFactory
 		$resolver->setMaxRedirects(10);
 		$resolver->setRequestTimeout(10);
 		// if the file is too large then exit
-		$resolver->setMaxResponseDataSize($this->config->get('http_client', 'max_response_data_size', 1000000));
+		$resolver->setMaxResponseDataSize($this->config->get('performance', 'max_response_data_size', 1000000));
 		// Designate a temporary file that will store cookies during the session.
 		// Some websites test the browser for cookie support, so this enhances results.
 		$resolver->setCookieJar(System::getTempPath() .'/resolver-cookie-' . Strings::getRandomName(10));

--- a/src/Network/HTTPClient/Factory/HttpClient.php
+++ b/src/Network/HTTPClient/Factory/HttpClient.php
@@ -123,7 +123,7 @@ class HttpClient extends BaseFactory
 		$resolver->setMaxRedirects(10);
 		$resolver->setRequestTimeout(10);
 		// if the file is too large then exit
-		$resolver->setMaxResponseDataSize(1000000);
+		$resolver->setMaxResponseDataSize($this->config->get('system', 'max_response_data_size', 1000000));
 		// Designate a temporary file that will store cookies during the session.
 		// Some websites test the browser for cookie support, so this enhances results.
 		$resolver->setCookieJar(System::getTempPath() .'/resolver-cookie-' . Strings::getRandomName(10));

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -613,7 +613,8 @@ return [
 		// xrd_timeout (Integer)
 		// Timeout in seconds for fetching the XRD links and other requests with an expected shorter timeout
 		'xrd_timeout' => 20,
-
+	],
+	'http_client' => [
 		// max_response_data_size (Integer)
 		// Maximum allowed response data size in Bytes, default is hard-coded value from code
 		'max_response_data_size' => 1000000,

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -614,7 +614,7 @@ return [
 		// Timeout in seconds for fetching the XRD links and other requests with an expected shorter timeout
 		'xrd_timeout' => 20,
 	],
-	'http_client' => [
+	'performance' => [
 		// max_response_data_size (Integer)
 		// Maximum allowed response data size in Bytes, default is hard-coded value from code
 		'max_response_data_size' => 1000000,

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -616,7 +616,7 @@ return [
 	],
 	'performance' => [
 		// max_response_data_size (Integer)
-		// Maximum allowed response data size in Bytes, default is hard-coded value from code
+		// Maximum allowed outgoing HTTP request response data size in Bytes. Does not affect incoming requests to this node.
 		'max_response_data_size' => 1000000,
 	],
 	'proxy' => [

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -617,6 +617,7 @@ return [
 	'performance' => [
 		// max_response_data_size (Integer)
 		// Maximum allowed outgoing HTTP request response data size in Bytes. Does not affect incoming requests to this node.
+		// Warning: Lowering this value can help with some PHP memory exhaustion issues, but can also partially break some federation features e.g. large posts may not be fetched or received from remote servers.
 		'max_response_data_size' => 1000000,
 	],
 	'proxy' => [

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -613,6 +613,10 @@ return [
 		// xrd_timeout (Integer)
 		// Timeout in seconds for fetching the XRD links and other requests with an expected shorter timeout
 		'xrd_timeout' => 20,
+
+		// max_response_data_size (Integer)
+		// Maximum allowed response data size in Bytes, default is hard-coded value from code
+		'max_response_data_size' => 1000000,
 	],
 	'proxy' => [
 		// forwarded_for_headers (String)


### PR DESCRIPTION
Make hard-coded max response configurable:
- see discussion started by @schmaker@schmaker.eu at https://schmaker.eu/display/c83e3896-1265-a3d6-0ab5-a78119129626
- this allows servers with lower RAM amount to still run without OOMs (or much lesser)