### PR TITLE
Refactor user-defined channel match

### DIFF
--- a/src/Content/Conversation/Collection/UserDefinedChannels.php
+++ b/src/Content/Conversation/Collection/UserDefinedChannels.php
@@ -21,6 +21,12 @@
 
 namespace Friendica\Content\Conversation\Collection;
 
+use Friendica\Content\Conversation\Entity;
+
 class UserDefinedChannels extends Timelines
 {
+	public function current(): Entity\UserDefinedChannel
+	{
+		return parent::current();
+	}
 }

--- a/src/Database/DisposableFullTextSearch.php
+++ b/src/Database/DisposableFullTextSearch.php
@@ -42,7 +42,7 @@ class DisposableFullTextSearch
 		do {
 			// Maximum value is indicated by the INT UNSIGNED type of the check-full-text-search.pid field
 			$this->identifier = random_int(0, pow(2, 32) - 1);
-		} while($this->db->exists('check-full-text-search', ['pid' => $this->identifier, 'searchtext' => $haystack]));
+		} while ($this->db->exists('check-full-text-search', ['pid' => $this->identifier]));
 
 		// If the `exists()` call fails and return false because the database is unavailable, the `insert()` call will likely fail as well, which means
 		// all subsequent calls to `match()` will return false because the haystack won't have been inserted.

--- a/src/Database/DisposableFullTextSearch.php
+++ b/src/Database/DisposableFullTextSearch.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2024, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Database;
+
+/**
+ * Full-text search on a haystack string that isn't present in the database.
+ * The haystack is inserted in a temporary table with a FULLTEXT index, then any number of
+ * matches can be performed on it before the row is deleted when the class instance is destroyed,
+ * either manually or at the end of the script at the latest.
+ */
+class DisposableFullTextSearch
+{
+	private Database $db;
+	private int $identifier;
+
+	public function __construct(Database $database, string $haystack)
+	{
+		$this->db = $database;
+
+		// Maximum value is indicated by the INT UNSIGNED type of the check-full-text-search.pid field
+		$this->identifier = random_int(0, pow(2, 32) - 1);
+
+		$this->db->insert('check-full-text-search', ['pid' => $this->identifier, 'searchtext' => $haystack], Database::INSERT_UPDATE);
+	}
+
+	public function __destruct()
+	{
+		$this->db->delete('check-full-text-search', ['pid' => $this->identifier]);
+	}
+
+	/**
+	 * @param string $needle Boolean mode search string
+	 * @return bool
+	 * @throws \Exception
+	 */
+	public function match(string $needle): bool
+	{
+		return $this->db->exists('check-full-text-search', ["`pid` = ? AND MATCH (`searchtext`) AGAINST (? IN BOOLEAN MODE)", $this->identifier, $needle]);
+	}
+}

--- a/src/Database/DisposableFullTextSearch.php
+++ b/src/Database/DisposableFullTextSearch.php
@@ -37,12 +37,12 @@ class DisposableFullTextSearch
 	{
 		$this->db = $database;
 
-		// Unique identifier generation. Two DisposableFullTextSearch object should never have the same as the first object destruction
-		// would delete both check-full-text-search rows, before the second object destruction is called, leading to unexpected behavior.
-		// Maximum value is indicated by the INT UNSIGNED type of the check-full-text-search.pid field
-		$this->identifier = random_int(0, pow(2, 32) - 1);
-
-		$this->db->insert('check-full-text-search', ['pid' => $this->identifier, 'searchtext' => $haystack], Database::INSERT_UPDATE);
+		do {
+			// Unique identifier generation. Two DisposableFullTextSearch object should never have the same as the first object destruction
+			// would delete both check-full-text-search rows before the second object destruction is called, leading to unexpected behavior.
+			// Maximum value is indicated by the INT UNSIGNED type of the check-full-text-search.pid field
+			$this->identifier = random_int(0, pow(2, 32) - 1);
+		} while($this->db->insert('check-full-text-search', ['pid' => $this->identifier, 'searchtext' => $haystack]));
 	}
 
 	public function __destruct()

--- a/src/Database/DisposableFullTextSearch.php
+++ b/src/Database/DisposableFullTextSearch.php
@@ -30,12 +30,15 @@ namespace Friendica\Database;
 class DisposableFullTextSearch
 {
 	private Database $db;
+	/** @var int Unique identifier of the haystack in the database. */
 	private int $identifier;
 
 	public function __construct(Database $database, string $haystack)
 	{
 		$this->db = $database;
 
+		// Unique identifier generation. Two DisposableFullTextSearch object should never have the same as the first object destruction
+		// would delete both check-full-text-search rows, before the second object destruction is called, leading to unexpected behavior.
 		// Maximum value is indicated by the INT UNSIGNED type of the check-full-text-search.pid field
 		$this->identifier = random_int(0, pow(2, 32) - 1);
 


### PR DESCRIPTION
Follow-up to https://github.com/friendica/friendica/pull/13806

- ~~Move throwaway full-text search feature to the Database class~~
- Move disposable full-text search feature to a Database-namespaced class
- ~~Invert the boolean logic in favor of a positive match in `Repository\UserDefinedChannel->getMatchingChannelUsers`~~
- Convert generic `foreach` into an `array_filter` call in `Repository\UserDefinedChannel->getMatchingChannelUsers`
- Fix return value of `Repository\UserDefinedChannel->match`