### PR TITLE
Fix "Data too long for column 'reaction' at row 1"

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2024.03-dev (Yellow Archangel)
--- DB_UPDATE_VERSION 1547
+-- DB_UPDATE_VERSION 1548
 -- ------------------------------------------
 
 
@@ -1243,7 +1243,7 @@ CREATE TABLE IF NOT EXISTS `post-category` (
 CREATE TABLE IF NOT EXISTS `post-counts` (
 	`uri-id` int unsigned NOT NULL COMMENT 'Id of the item-uri table entry that contains the item uri',
 	`vid` smallint unsigned NOT NULL COMMENT 'Id of the verb table entry that contains the activity verbs',
-	`reaction` varchar(1) NOT NULL COMMENT 'Emoji Reaction',
+	`reaction` varchar(4) NOT NULL COMMENT 'Emoji Reaction',
 	`parent-uri-id` int unsigned COMMENT 'Id of the item-uri table that contains the parent uri',
 	`count` int unsigned DEFAULT 0 COMMENT 'Number of activities',
 	 PRIMARY KEY(`uri-id`,`vid`,`reaction`),

--- a/doc/database/db_post-counts.md
+++ b/doc/database/db_post-counts.md
@@ -10,7 +10,7 @@ Fields
 | ------------- | ----------------------------------------------------------- | ----------------- | ---- | --- | ------- | ----- |
 | uri-id        | Id of the item-uri table entry that contains the item uri   | int unsigned      | NO   | PRI | NULL    |       |
 | vid           | Id of the verb table entry that contains the activity verbs | smallint unsigned | NO   | PRI | NULL    |       |
-| reaction      | Emoji Reaction                                              | varchar(1)        | NO   | PRI | NULL    |       |
+| reaction      | Emoji Reaction                                              | varchar(4)        | NO   | PRI | NULL    |       |
 | parent-uri-id | Id of the item-uri table that contains the parent uri       | int unsigned      | YES  |     | NULL    |       |
 | count         | Number of activities                                        | int unsigned      | YES  |     | 0       |       |
 

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -56,7 +56,7 @@ use Friendica\Database\DBA;
 
 // This file is required several times during the test in DbaDefinition which justifies this condition
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1547);
+	define('DB_UPDATE_VERSION', 1548);
 }
 
 return [
@@ -1270,7 +1270,7 @@ return [
 		"fields" => [
 			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
 			"vid" => ["type" => "smallint unsigned", "not null" => "1", "primary" => "1", "foreign" => ["verb" => "id", "on delete" => "restrict"], "comment" => "Id of the verb table entry that contains the activity verbs"],
-			"reaction" => ["type" => "varchar(1)", "not null" => "1", "primary" => "1", "comment" => "Emoji Reaction"],
+			"reaction" => ["type" => "varchar(4)", "not null" => "1", "primary" => "1", "comment" => "Emoji Reaction"],
 			"parent-uri-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table that contains the parent uri"],
 			"count" => ["type" => "int unsigned", "default" => 0, "comment" => "Number of activities"],
 		],


### PR DESCRIPTION
This fixes a length problem that can occur, when your database isn't set to the utf8mb4 collation.