### PR TITLE
Compare lengths of hashtags with the content length for improved spam detection

### DIFF
--- a/src/Protocol/Relay.php
+++ b/src/Protocol/Relay.php
@@ -120,7 +120,7 @@ class Relay
 				$cleaned = preg_replace('/[@!#]\[url\=.*?\].*?\[\/url\]/ism', '', $body);
 				$content_cleaned = mb_strtolower(BBCode::toPlaintext($cleaned, false));
 
-				if (strlen($content_cleaned) < (strlen($content) - strlen($content_cleaned))) {
+				if (strlen($content_cleaned) < strlen($content) / 2) {
 					Logger::info('Possible hashtag spam detected - rejected', ['hashtags' => $tags, 'network' => $network, 'url' => $url, 'causer' => $causer, 'body' => $body]);
 					return false;
 				}

--- a/src/Protocol/Relay.php
+++ b/src/Protocol/Relay.php
@@ -113,13 +113,18 @@ class Relay
 		}
 
 		if (!empty($tagList) || !empty($denyTags)) {
+			$content = mb_strtolower(BBCode::toPlaintext($body, false));
+
 			$max_tags = $config->get('system', 'relay_max_tags');
 			if ($max_tags && (count($tags) > $max_tags) && preg_match('/[^@!#]\[url\=.*?\].*?\[\/url\]/ism', $body)) {
-				Logger::info('Possible hashtag spam detected - rejected', ['hashtags' => $tags, 'network' => $network, 'url' => $url, 'causer' => $causer, 'body' => $body]);
-				return false;
-			}
+				$cleaned = preg_replace('/[@!#]\[url\=.*?\].*?\[\/url\]/ism', '', $body);
+				$content_cleaned = mb_strtolower(BBCode::toPlaintext($cleaned, false));
 
-			$content = mb_strtolower(BBCode::toPlaintext($body, false));
+				if (strlen($content_cleaned) < (strlen($content) - strlen($content_cleaned))) {
+					Logger::info('Possible hashtag spam detected - rejected', ['hashtags' => $tags, 'network' => $network, 'url' => $url, 'causer' => $causer, 'body' => $body]);
+					return false;
+				}
+			}
 
 			foreach ($tags as $tag) {
 				$tag = mb_strtolower($tag);

--- a/static/settings.config.php
+++ b/static/settings.config.php
@@ -239,7 +239,7 @@ return [
 
 		// relay_max_tags (Integer)
 		// Maximum amount of tags in a post before it is rejected as spam.
-		'relay_max_tags' => 10,
+		'relay_max_tags' => 20,
 
 		// proxify_content (Boolean)
 		// Use the proxy functionality for fetching external content


### PR DESCRIPTION
We now compare the length of the post without hashtags with the length of all hashtags and will only reject posts with more hashtags than content.