### PR TITLE
New channel option "discover"

### DIFF
--- a/doc/Channels.md
+++ b/doc/Channels.md
@@ -25,6 +25,10 @@ Predefined Channels
     * Posts from people you interact with on a more than average level.
     * Posts from the accounts that you follow with a more than average number of interactions-
     * Posts from accounts where you activated "notify on new posts" or where you have set the channel frequency accordingly.
+* Discover: Posts from contacts you don't follow, but that might be of interest for you to follow. In detail, it consists of:
+    * Posts from people you don't follow but you interact with on a more than average level.
+    * Posts from people you don't follow but that interact with you on a more than average level.
+    * Popular posts from people you don't follow but you interacted with or who interacted with you on any level.
 * What's Hot: Posts with a more than average number of interactions.
 * Language: Posts in your language.
 * Followers: Posts from your followers that you don't follow.

--- a/src/Content/Conversation/Entity/Channel.php
+++ b/src/Content/Conversation/Entity/Channel.php
@@ -25,6 +25,7 @@ class Channel extends Timeline
 {
 	const WHATSHOT         = 'whatshot';
 	const FORYOU           = 'foryou';
+	const DISCOVER         = 'discover';
 	const FOLLOWERS        = 'followers';
 	const SHARERSOFSHARERS = 'sharersofsharers';
 	const IMAGE            = 'image';

--- a/src/Content/Conversation/Factory/Channel.php
+++ b/src/Content/Conversation/Factory/Channel.php
@@ -40,6 +40,7 @@ final class Channel extends Timeline
 
 		$tabs = [
 			new ChannelEntity(ChannelEntity::FORYOU, $this->l10n->t('For you'), $this->l10n->t('Posts from contacts you interact with and who interact with you'), 'y'),
+			new ChannelEntity(ChannelEntity::DISCOVER, $this->l10n->t('Discover'), $this->l10n->t('Posts from accounts that you don\'t follow, but that you might like.'), 'o'),
 			new ChannelEntity(ChannelEntity::WHATSHOT, $this->l10n->t('What\'s Hot'), $this->l10n->t('Posts with a lot of interactions'), 'h'),
 			new ChannelEntity(ChannelEntity::LANGUAGE, $native, $this->l10n->t('Posts in %s', $native), 'g'),
 			new ChannelEntity(ChannelEntity::FOLLOWERS, $this->l10n->t('Followers'), $this->l10n->t('Posts from your followers that you don\'t follow'), 'f'),
@@ -54,6 +55,6 @@ final class Channel extends Timeline
 
 	public function isTimeline(string $selectedTab): bool
 	{
-		return in_array($selectedTab, [ChannelEntity::WHATSHOT, ChannelEntity::FORYOU, ChannelEntity::FOLLOWERS, ChannelEntity::SHARERSOFSHARERS, ChannelEntity::IMAGE, ChannelEntity::VIDEO, ChannelEntity::AUDIO, ChannelEntity::LANGUAGE]);
+		return in_array($selectedTab, [ChannelEntity::WHATSHOT, ChannelEntity::FORYOU, ChannelEntity::DISCOVER, ChannelEntity::FOLLOWERS, ChannelEntity::SHARERSOFSHARERS, ChannelEntity::IMAGE, ChannelEntity::VIDEO, ChannelEntity::AUDIO, ChannelEntity::LANGUAGE]);
 	}
 }

--- a/src/Module/Conversation/Channel.php
+++ b/src/Module/Conversation/Channel.php
@@ -115,7 +115,7 @@ class Channel extends Timeline
 
 			$this->page['aside'] .= Widget::accountTypes('channel/' . $this->selectedTab, $this->accountTypeString);
 
-			if (!in_array($this->selectedTab, [ChannelEntity::FOLLOWERS, ChannelEntity::FORYOU])) {
+			if (!in_array($this->selectedTab, [ChannelEntity::FOLLOWERS, ChannelEntity::FORYOU, ChannelEntity::DISCOVER])) {
 				$this->page['aside'] .= $this->getNoSharerWidget('channel');
 			}
 

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -25,6 +25,7 @@ use Friendica\App;
 use Friendica\App\Mode;
 use Friendica\Content\BoundariesPager;
 use Friendica\Content\Conversation;
+use Friendica\Content\Conversation\Entity\Channel;
 use Friendica\Content\Conversation\Entity\Network as NetworkEntity;
 use Friendica\Content\Conversation\Factory\Timeline as TimelineFactory;
 use Friendica\Content\Conversation\Repository\UserDefinedChannel;
@@ -141,6 +142,11 @@ class Network extends Timeline
 		$this->page['aside'] .= Widget::channels($module, $this->selectedTab, $this->session->getLocalUserId());
 		$this->page['aside'] .= Widget\SavedSearches::getHTML($this->args->getQueryString());
 		$this->page['aside'] .= Widget::fileAs('filed', '');
+
+		if (($this->channel->isTimeline($this->selectedTab) || $this->userDefinedChannel->isTimeline($this->selectedTab, $this->session->getLocalUserId())) &&
+			!in_array($this->selectedTab, [Channel::FOLLOWERS, Channel::FORYOU, Channel::DISCOVER])) {
+			$this->page['aside'] .= $this->getNoSharerWidget('network');
+		}
 
 		if (Feature::isEnabled($this->session->getLocalUserId(), 'trending_tags')) {
 			$this->page['aside'] .= TrendingTags::getHTML($this->selectedTab);

--- a/src/Module/Conversation/Timeline.php
+++ b/src/Module/Conversation/Timeline.php
@@ -291,6 +291,20 @@ class Timeline extends BaseModule
 				$cid, $this->getMedianRelationThreadScore($cid, 4), $this->getMedianComments($uid, 4), $this->getMedianActivities($uid, 4), $cid,
 				$uid, Contact\User::FREQUENCY_ALWAYS
 			];
+		} elseif ($this->selectedTab == ChannelEntity::DISCOVER) {
+			$cid = Contact::getPublicIdByUserId($uid);
+
+			$condition = [
+				"`owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` = ? AND NOT `follows`) AND
+				(`owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` = ? AND NOT `follows` AND `relation-thread-score` > ?) OR
+				`owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `cid` = ? AND `relation-thread-score` > ?) OR
+				((`comments` >= ? OR `activities` >= ?) AND 
+				(`owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `cid` = ? AND `relation-thread-score` > ?)) OR 
+				(`owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` = ? AND `relation-thread-score` > ?))))",
+				$cid, $cid, $this->getMedianRelationThreadScore($cid, 4), $cid, $this->getMedianRelationThreadScore($cid, 4),
+				$this->getMedianComments($uid, 4), $this->getMedianActivities($uid, 4), $cid, 0, $cid, 0 
+			];
+
 		} elseif ($this->selectedTab == ChannelEntity::FOLLOWERS) {
 			$condition = ["`owner-id` IN (SELECT `pid` FROM `account-user-view` WHERE `uid` = ? AND `rel` = ?)", $uid, Contact::FOLLOWER];
 		} elseif ($this->selectedTab == ChannelEntity::SHARERSOFSHARERS) {

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2024.03-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-23 22:10+0000\n"
+"POT-Creation-Date: 2024-01-25 10:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -791,7 +791,7 @@ msgstr ""
 msgid "All contacts"
 msgstr ""
 
-#: src/BaseModule.php:439 src/Content/Conversation/Factory/Channel.php:45
+#: src/BaseModule.php:439 src/Content/Conversation/Factory/Channel.php:46
 #: src/Content/Widget.php:239 src/Core/ACL.php:195 src/Module/Contact.php:414
 #: src/Module/PermissionTooltip.php:141 src/Module/PermissionTooltip.php:163
 #: src/Module/Settings/Channels.php:147
@@ -1526,54 +1526,62 @@ msgid "Posts from contacts you interact with and who interact with you"
 msgstr ""
 
 #: src/Content/Conversation/Factory/Channel.php:43
-msgid "What's Hot"
+msgid "Discover"
 msgstr ""
 
 #: src/Content/Conversation/Factory/Channel.php:43
-msgid "Posts with a lot of interactions"
+msgid "Posts from accounts that you don't follow, but that you might like."
 msgstr ""
 
 #: src/Content/Conversation/Factory/Channel.php:44
+msgid "What's Hot"
+msgstr ""
+
+#: src/Content/Conversation/Factory/Channel.php:44
+msgid "Posts with a lot of interactions"
+msgstr ""
+
+#: src/Content/Conversation/Factory/Channel.php:45
 #, php-format
 msgid "Posts in %s"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Channel.php:45
+#: src/Content/Conversation/Factory/Channel.php:46
 msgid "Posts from your followers that you don't follow"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Channel.php:46
+#: src/Content/Conversation/Factory/Channel.php:47
 msgid "Sharers of sharers"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Channel.php:46
+#: src/Content/Conversation/Factory/Channel.php:47
 msgid "Posts from accounts that are followed by accounts that you follow"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Channel.php:47
+#: src/Content/Conversation/Factory/Channel.php:48
 #: src/Module/Settings/Channels.php:184 src/Module/Settings/Channels.php:203
 msgid "Images"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Channel.php:47
+#: src/Content/Conversation/Factory/Channel.php:48
 msgid "Posts with images"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Channel.php:48
+#: src/Content/Conversation/Factory/Channel.php:49
 #: src/Module/Settings/Channels.php:186 src/Module/Settings/Channels.php:205
 msgid "Audio"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Channel.php:48
+#: src/Content/Conversation/Factory/Channel.php:49
 msgid "Posts with audio"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Channel.php:49
+#: src/Content/Conversation/Factory/Channel.php:50
 #: src/Module/Settings/Channels.php:185 src/Module/Settings/Channels.php:204
 msgid "Videos"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Channel.php:49
+#: src/Content/Conversation/Factory/Channel.php:50
 msgid "Posts with videos"
 msgstr ""
 


### PR DESCRIPTION
There is now a new channel `discover` to find new contacts to subscribe to. Also the widget to exclude sharers is now added to the network page. This fixes #13839, I think.