### PR TITLE
Issue 13859: Posts to a group in "Vier" is now possible

### DIFF
--- a/src/Module/Contact/Conversations.php
+++ b/src/Module/Contact/Conversations.php
@@ -27,11 +27,13 @@ use Friendica\Contact\LocalRelationship\Repository\LocalRelationship;
 use Friendica\Content\Conversation;
 use Friendica\Content\Nav;
 use Friendica\Content\Widget;
+use Friendica\Core\ACL;
 use Friendica\Core\L10n;
 use Friendica\Core\Protocol;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Core\Theme;
 use Friendica\Model;
+use Friendica\Model\Contact as ModelContact;
 use Friendica\Module\Contact;
 use Friendica\Module\Response;
 use Friendica\Module\Security\Login;
@@ -109,8 +111,13 @@ class Conversations extends BaseModule
 
 		Nav::setSelected('contact');
 
-		// We need the editor here to be able to reshare an item.
-		$o = $this->conversation->statusEditor([], 0, true);
+		$options = [
+			'lockstate' => ACL::getLockstateForUserId($this->userSession->getLocalUserId()) ? 'lock' : 'unlock',
+			'acl' => ACL::getFullSelectorHTML($this->page, $this->userSession->getLocalUserId(), true, []),
+			'bang' => '',
+			'content' => ($contact['contact-type'] == ModelContact::TYPE_COMMUNITY ? '!' : '@') . ($contact['addr'] ?: $contact['url']),
+		];
+		$o = $this->conversation->statusEditor($options);
 
 		$o .= Contact::getTabsHTML($contact, Contact::TAB_CONVERSATIONS);
 		$o .= Model\Contact::getThreadsFromId($contact['id'], $this->userSession->getLocalUserId(), 0, 0, $request['last_created'] ?? '');

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -162,8 +162,6 @@ class Network extends Timeline
 
 			Nav::setSelected($this->args->get(0));
 
-			$content = '';
-
 			$default_permissions = [];
 			if ($this->circleId) {
 				$default_permissions['allow_gid'] = [$this->circleId];
@@ -195,7 +193,7 @@ class Network extends Timeline
 				'lockstate' => $this->circleId || $this->network || ACL::getLockstateForUserId($this->session->getLocalUserId()) ? 'lock' : 'unlock',
 				'acl' => ACL::getFullSelectorHTML($this->page, $this->session->getLocalUserId(), true, $default_permissions),
 				'bang' => (($this->circleId || $this->network) ? '!' : ''),
-				'content' => $content,
+				'content' => '',
 			];
 
 			$o .= $this->conversation->statusEditor($x);

--- a/view/templates/widget/vcard.tpl
+++ b/view/templates/widget/vcard.tpl
@@ -41,9 +41,6 @@
 			{{if $wallmessage_link}}
 				<li><a id="wallmessage-link" href="{{$wallmessage_link}}">{{$wallmessage}}</a></li>
 			{{/if}}
-			{{if $mention_link}}
-				<li><a id="mention-link" href="{{$mention_link}}">{{$mention}}</a></li>
-			{{/if}}
 			{{if $showgroup_link}}
 				<li><a id="showgroup-link" href="{{$showgroup_link}}">{{$showgroup}}</a></li>
 			{{/if}}


### PR DESCRIPTION
This fixes #13859. In "vier" there is now the status editor on top of the contact posts, just like on the network page.