### PR TITLE
Deprecate use of [*] BBCode tag for list items in favor of [li]

### DIFF
--- a/doc/BBCode.md
+++ b/doc/BBCode.md
@@ -376,8 +376,8 @@ code</code></td>
 &nbsp;&nbsp;[li] Second list element<br>
 [/ul]<br>
 [list]<br>
-&nbsp;&nbsp;[*] First list element<br>
-&nbsp;&nbsp;[*] Second list element<br>
+&nbsp;&nbsp;[li] First list element<br>
+&nbsp;&nbsp;[li] Second list element<br>
 [/list]</td>
   <td>
 	<ul class="listbullet" style="list-style-type: circle;">
@@ -388,12 +388,12 @@ code</code></td>
 </tr>
 <tr>
   <td>[ol]<br>
-&nbsp;&nbsp;[*] First list element<br>
-&nbsp;&nbsp;[*] Second list element<br>
+&nbsp;&nbsp;[li] First list element<br>
+&nbsp;&nbsp;[li] Second list element<br>
 [/ol]<br>
 [list=1]<br>
-&nbsp;&nbsp;[*] First list element<br>
-&nbsp;&nbsp;[*] Second list element<br>
+&nbsp;&nbsp;[li] First list element<br>
+&nbsp;&nbsp;[li] Second list element<br>
 [/list]</td>
   <td>
     <ul class="listdecimal" style="list-style-type: decimal;">
@@ -404,8 +404,8 @@ code</code></td>
 </tr>
 <tr>
   <td>[list=]<br>
-&nbsp;&nbsp;[*] First list element<br>
-&nbsp;&nbsp;[*] Second list element<br>
+&nbsp;&nbsp;[li] First list element<br>
+&nbsp;&nbsp;[li] Second list element<br>
 [/list]</td>
   <td>
     <ul class="listnone" style="list-style-type: none;">
@@ -416,8 +416,8 @@ code</code></td>
 </tr>
 <tr>
   <td>[list=i]<br>
-&nbsp;&nbsp;[*] First list element<br>
-&nbsp;&nbsp;[*] Second list element<br>
+&nbsp;&nbsp;[li] First list element<br>
+&nbsp;&nbsp;[li] Second list element<br>
 [/list]</td>
   <td>
     <ul class="listlowerroman" style="list-style-type: lower-roman;">
@@ -428,8 +428,8 @@ code</code></td>
 </tr>
 <tr>
   <td>[list=I]<br>
-&nbsp;&nbsp;[*] First list element<br>
-&nbsp;&nbsp;[*] Second list element<br>
+&nbsp;&nbsp;[li] First list element<br>
+&nbsp;&nbsp;[li] Second list element<br>
 [/list]</td>
   <td>
     <ul class="listupperroman" style="list-style-type: upper-roman;">
@@ -440,8 +440,8 @@ code</code></td>
 </tr>
 <tr>
   <td>[list=a]<br>
-&nbsp;&nbsp;[*] First list element<br>
-&nbsp;&nbsp;[*] Second list element<br>
+&nbsp;&nbsp;[li] First list element<br>
+&nbsp;&nbsp;[li] Second list element<br>
 [/list]</td>
   <td>
     <ul class="listloweralpha" style="list-style-type: lower-alpha;">
@@ -452,8 +452,8 @@ code</code></td>
 </tr>
 <tr>
   <td>[list=A]<br>
-&nbsp;&nbsp;[*] First list element<br>
-&nbsp;&nbsp;[*] Second list element<br>
+&nbsp;&nbsp;[li] First list element<br>
+&nbsp;&nbsp;[li] Second list element<br>
 [/list]</td>
   <td>
     <ul class="listupperalpha" style="list-style-type: upper-alpha;">

--- a/doc/de/BBCode.md
+++ b/doc/de/BBCode.md
@@ -356,8 +356,8 @@ Zeilen</code></td>
 &nbsp;&nbsp;[li] Zweites Listenelement<br>
 [/ul]<br>
 [list]<br>
-&nbsp;&nbsp;[*] Erstes Listenelement<br>
-&nbsp;&nbsp;[*] Zweites Listenelement<br>
+&nbsp;&nbsp;[li] Erstes Listenelement<br>
+&nbsp;&nbsp;[li] Zweites Listenelement<br>
 [/list]</td>
   <td>
 	<ul class="listbullet" style="list-style-type: circle;">
@@ -368,12 +368,12 @@ Zeilen</code></td>
 </tr>
 <tr>
   <td>[ol]<br>
-&nbsp;&nbsp;[*] Erstes Listenelement<br>
-&nbsp;&nbsp;[*] Zweites Listenelement<br>
+&nbsp;&nbsp;[li] Erstes Listenelement<br>
+&nbsp;&nbsp;[li] Zweites Listenelement<br>
 [/ol]<br>
 [list=1]<br>
-&nbsp;&nbsp;[*] Erstes Listenelement<br>
-&nbsp;&nbsp;[*] Zweites Listenelement<br>
+&nbsp;&nbsp;[li] Erstes Listenelement<br>
+&nbsp;&nbsp;[li] Zweites Listenelement<br>
 [/list]</td>
   <td>
     <ul class="listdecimal" style="list-style-type: decimal;">
@@ -384,8 +384,8 @@ Zeilen</code></td>
 </tr>
 <tr>
   <td>[list=]<br>
-&nbsp;&nbsp;[*] Erstes Listenelement<br>
-&nbsp;&nbsp;[*] Zweites Listenelement<br>
+&nbsp;&nbsp;[li] Erstes Listenelement<br>
+&nbsp;&nbsp;[li] Zweites Listenelement<br>
 [/list]</td>
   <td>
     <ul class="listnone" style="list-style-type: none;">
@@ -396,8 +396,8 @@ Zeilen</code></td>
 </tr>
 <tr>
   <td>[list=i]<br>
-&nbsp;&nbsp;[*] Erstes Listenelement<br>
-&nbsp;&nbsp;[*] Zweites Listenelement<br>
+&nbsp;&nbsp;[li] Erstes Listenelement<br>
+&nbsp;&nbsp;[li] Zweites Listenelement<br>
 [/list]</td>
   <td>
     <ul class="listlowerroman" style="list-style-type: lower-roman;">
@@ -408,8 +408,8 @@ Zeilen</code></td>
 </tr>
 <tr>
   <td>[list=I]<br>
-&nbsp;&nbsp;[*] Erstes Listenelement<br>
-&nbsp;&nbsp;[*] Zweites Listenelement<br>
+&nbsp;&nbsp;[li] Erstes Listenelement<br>
+&nbsp;&nbsp;[li] Zweites Listenelement<br>
 [/list]</td>
   <td>
     <ul class="listupperroman" style="list-style-type: upper-roman;">
@@ -420,8 +420,8 @@ Zeilen</code></td>
 </tr>
 <tr>
   <td>[list=a]<br>
-&nbsp;&nbsp;[*] Erstes Listenelement<br>
-&nbsp;&nbsp;[*] Zweites Listenelement<br>
+&nbsp;&nbsp;[li] Erstes Listenelement<br>
+&nbsp;&nbsp;[li] Zweites Listenelement<br>
 [/list]</td>
   <td>
     <ul class="listloweralpha" style="list-style-type: lower-alpha;">
@@ -432,8 +432,8 @@ Zeilen</code></td>
 </tr>
 <tr>
   <td>[list=A]<br>
-&nbsp;&nbsp;[*] Erstes Listenelement<br>
-&nbsp;&nbsp;[*] Zweites Listenelement<br>
+&nbsp;&nbsp;[li] Erstes Listenelement<br>
+&nbsp;&nbsp;[li] Zweites Listenelement<br>
 [/list]</td>
   <td>
     <ul class="listupperalpha" style="list-style-type: upper-alpha;">

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1549,9 +1549,6 @@ class BBCode
 				// Check for centered text
 				$text = preg_replace("(\[center\](.*?)\[\/center\])ism", '<div style="text-align:center;">$1</div>', $text);
 
-				// Check for list text
-				$text = str_replace("[*]", "<li>", $text);
-
 				// Check for block-level custom CSS
 				$text = preg_replace('#(?<=^|\n)\[style=(.*?)](.*?)\[/style](?:\n|$)#ism', '<div style="$1">$2</div>', $text);
 
@@ -1590,6 +1587,10 @@ class BBCode
 					$text = preg_replace("/\[ol\](.*?)\[\/ol\]/ism", '</p><ol>$1</ol><p>', $text);
 					$text = preg_replace("/\[li\](.*?)\[\/li\]/ism", '<li>$1</li>', $text);
 				}
+
+				// Check for list text
+				$text = str_replace("[*]", "<li>", $text);
+				$text = str_replace("[li]", "<li>", $text);
 
 				$text = preg_replace("/\[th\](.*?)\[\/th\]/sm", '<th>$1</th>', $text);
 				$text = preg_replace("/\[td\](.*?)\[\/td\]/sm", '<td>$1</td>', $text);

--- a/src/Module/Tos.php
+++ b/src/Module/Tos.php
@@ -89,7 +89,7 @@ class Tos extends BaseModule
 				$rules = "[ol]";
 				foreach (explode("\n", $lines) as $line) {
 					if (trim($line)) {
-						$rules .= "\n[*]" . trim($line);
+						$rules .= "\n[li]" . trim($line);
 					}
 				}
 				$rules .= "\n[/ol]\n";

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -162,22 +162,22 @@ class BBCodeTest extends FixtureTest
 		return [
 			'bug-7271-condensed-space' => [
 				'expectedHtml' => '<ol><li> <a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ol>',
-				'text' => '[ol][*] http://example.com/[/ol]',
+				'text' => '[ol][li] http://example.com/[/ol]',
 			],
 			'bug-7271-condensed-nospace' => [
 				'expectedHtml' => '<ol><li><a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ol>',
-				'text' => '[ol][*]http://example.com/[/ol]',
+				'text' => '[ol][li]http://example.com/[/ol]',
 			],
 			'bug-7271-indented-space' => [
 				'expectedHtml' => '<ul><li> <a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ul>',
 				'text' => '[ul]
-[*] http://example.com/
+[li] http://example.com/
 [/ul]',
 			],
 			'bug-7271-indented-nospace' => [
 				'expectedHtml' => '<ul><li><a href="http://example.com/" target="_blank" rel="noopener noreferrer">http://example.com/</a></li></ul>',
 				'text' => '[ul]
-[*]http://example.com/
+[li]http://example.com/
 [/ul]',
 			],
 			'bug-2199-named-size' => [
@@ -263,7 +263,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 			],
 			'task-12900-multiple-paragraphs' => [
 				'expectedHTML' => '<h4>Header</h4><ul><li>One</li><li>Two</li></ul><p>This is a paragraph<br>with a line feed.</p><p>Second Chapter</p>',
-				'text' => "[h4]Header[/h4][ul][*]One[*]Two[/ul]\n\nThis is a paragraph\nwith a line feed.\n\nSecond Chapter",
+				'text' => "[h4]Header[/h4][ul][li]One[li]Two[/ul]\n\nThis is a paragraph\nwith a line feed.\n\nSecond Chapter",
 			],
 			'task-12900-header-with-paragraphs' => [
 				'expectedHTML' => '<h4>Header</h4><p>Some Chapter</p>',
@@ -271,11 +271,11 @@ Karl Marx - Die ursprüngliche Akkumulation
 			],
 			'bug-12842-ul-newlines' => [
 				'expectedHTML' => '<p>This is:</p><ul><li>some</li><li>amazing</li><li>list</li></ul>',
-				'text' => "This is:\r\n[ul]\r\n[*]some\r\n[*]amazing\r\n[*]list\r\n[/ul]",
+				'text' => "This is:\r\n[ul]\r\n[li]some\r\n[li]amazing\r\n[li]list\r\n[/ul]",
 			],
 			'bug-12842-ol-newlines' => [
 				'expectedHTML' => '<p>This is:</p><ol><li>some</li><li>amazing</li><li>list</li></ol>',
-				'text' => "This is:\r\n[ol]\r\n[*]some\r\n[*]amazing\r\n[*]list\r\n[/ol]",
+				'text' => "This is:\r\n[ol]\r\n[li]some\r\n[li]amazing\r\n[li]list\r\n[/ol]",
 			],
 			'task-12917-tabs-between-linebreaks' => [
 				'expectedHTML' => '<p>Paragraph</p><p>New Paragraph</p>',

--- a/view/js/autocomplete.js
+++ b/view/js/autocomplete.js
@@ -175,7 +175,7 @@ function listNewLineAutocomplete(id) {
 	if (word != null) {
 		var textBefore = text.value.substring(0, caretPos);
 		var textAfter  = text.value.substring(caretPos, text.length);
-		$('#' + id).val(textBefore + '\r\n[*] ' + textAfter).trigger('change');
+		$('#' + id).val(textBefore + '\r\n[li] ' + textAfter).trigger('change');
 		setCaretPosition(text, caretPos + 5);
 		return true;
 	}
@@ -384,7 +384,7 @@ function string2bb(element) {
 				element = string2bb(element);
 				if(open_elements.indexOf(element) < 0) {
 					if(element === 'list' || element === 'ol' || element === 'ul') {
-						return ['\[' + element + '\]' + '\n\[*\] ', '\n\[/' + element + '\]'];
+						return ['\[' + element + '\]' + '\n\[li\] ', '\n\[/' + element + '\]'];
 					}
 					else if(element === 'table') {
 						return ['\[' + element + '\]' + '\n\[tr\]', '\[/tr\]\n\[/' + element + '\]'];


### PR DESCRIPTION
Fix #13878 

- It is conflicting with Markdown syntax