### PR TITLE
User setting to disable blurring of sensitive pictures

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -278,6 +278,7 @@ function item_process(array $post, array $request, bool $preview, string $return
 		$post['quote-uri-id']   = Item::getQuoteUriId($post['body'], $post['uid']);
 		$post['body']           = BBCode::removeSharedData(Item::setHashtags($post['body']));
 		$post['writable']       = true;
+		$post['sensitive']      = true;
 
 		$o = DI::conversation()->render([$post], Conversation::MODE_SEARCH, false, true);
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3330,8 +3330,8 @@ class Item
 	public static function prepareBody(array &$item, bool $attach = false, bool $is_preview = false, bool $only_cache = false): string
 	{
 		$a = DI::app();
+		$uid = DI::userSession()->getLocalUserId();
 		Hook::callAll('prepare_body_init', $item);
-
 
 		// In order to provide theme developers more possibilities, event items
 		// are treated differently.
@@ -3345,7 +3345,7 @@ class Item
 		$item['tags'] = $tags['tags'];
 		$item['hashtags'] = $tags['hashtags'];
 		$item['mentions'] = $tags['mentions'];
-		$sensitive = (bool)$item['sensitive'];
+		$sensitive = $item['sensitive'] && !DI::pConfig()->get($uid, 'system', 'display_sensitive', false);
 
 		if (!$is_preview) {
 			$item['body'] = preg_replace("#\s*\[attachment .*?].*?\[/attachment]\s*#ism", "\n", $item['body']);
@@ -3438,7 +3438,7 @@ class Item
 				$filter_reasons[] = DI::l10n()->t('Content from %s is collapsed', $item['author-name']);
 			}
 
-			if (!empty($item['content-warning']) && (!DI::userSession()->getLocalUserId() || !DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'disable_cw', false))) {
+			if (!empty($item['content-warning']) && (!$uid || !DI::pConfig()->get($uid, 'system', 'disable_cw', false))) {
 				$filter_reasons[] = DI::l10n()->t('Content warning: %s', $item['content-warning']);
 			}
 

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -106,6 +106,7 @@ class Display extends BaseSettings
 		$enable_smart_threading = (bool)$request['enable_smart_threading'];
 		$enable_dislike         = (bool)$request['enable_dislike'];
 		$display_resharer       = (bool)$request['display_resharer'];
+		$display_sensitive      = (bool)$request['display_sensitive'];
 		$stay_local             = (bool)$request['stay_local'];
 		$show_page_drop         = (bool)$request['show_page_drop'];
 		$display_eventlist      = (bool)$request['display_eventlist'];
@@ -157,6 +158,7 @@ class Display extends BaseSettings
 		$this->pConfig->set($uid, 'system', 'no_smart_threading'      , !$enable_smart_threading);
 		$this->pConfig->set($uid, 'system', 'hide_dislike'            , !$enable_dislike);
 		$this->pConfig->set($uid, 'system', 'display_resharer'        , $display_resharer);
+		$this->pConfig->set($uid, 'system', 'display_sensitive'       , $display_sensitive);
 		$this->pConfig->set($uid, 'system', 'stay_local'              , $stay_local);
 		$this->pConfig->set($uid, 'system', 'show_page_drop'          , $show_page_drop);
 		$this->pConfig->set($uid, 'system', 'display_eventlist'       , $display_eventlist);
@@ -251,6 +253,7 @@ class Display extends BaseSettings
 		$enable_smart_threading = !$this->pConfig->get($uid, 'system', 'no_smart_threading', false);
 		$enable_dislike         = !$this->pConfig->get($uid, 'system', 'hide_dislike', false);
 		$display_resharer       =  $this->pConfig->get($uid, 'system', 'display_resharer', false);
+		$display_sensitive      =  $this->pConfig->get($uid, 'system', 'display_sensitive', false);
 		$stay_local             =  $this->pConfig->get($uid, 'system', 'stay_local', false);
 		$show_page_drop         =  $this->pConfig->get($uid, 'system', 'show_page_drop', true);
 		$display_eventlist      =  $this->pConfig->get($uid, 'system', 'display_eventlist', true);
@@ -330,6 +333,7 @@ class Display extends BaseSettings
 			'$enable_smart_threading'   => ['enable_smart_threading'  , $this->t('Enable Smart Threading'), $enable_smart_threading, $this->t('Enable the automatic suppression of extraneous thread indentation.')],
 			'$enable_dislike'           => ['enable_dislike'          , $this->t('Display the Dislike feature'), $enable_dislike, $this->t('Display the Dislike button and dislike reactions on posts and comments.')],
 			'$display_resharer'         => ['display_resharer'        , $this->t('Display the resharer'), $display_resharer, $this->t('Display the first resharer as icon and text on a reshared item.')],
+			'$display_sensitive'        => ['display_sensitive'       , $this->t('Display sensitive content'), $display_sensitive, $this->t('If enabled, pictures in posts marked as "sensitive" will not be blurred.')],
 			'$stay_local'               => ['stay_local'              , $this->t('Stay local'), $stay_local, $this->t("Don't go to a remote system when following a contact link.")],
 			'$show_page_drop'           => ['show_page_drop'          , $this->t('Show the post deletion checkbox'), $show_page_drop, $this->t("Display the checkbox for the post deletion on the network page.")],
 			'$display_eventlist'        => ['display_eventlist'       , $this->t('DIsplay the event list'), $display_eventlist, $this->t("Display the birthday reminder and event list on the network page.")],

--- a/view/templates/settings/display.tpl
+++ b/view/templates/settings/display.tpl
@@ -18,6 +18,7 @@
 	{{include file="field_checkbox.tpl" field=$enable_smart_threading}}
 	{{include file="field_checkbox.tpl" field=$enable_dislike}}
 	{{include file="field_checkbox.tpl" field=$display_resharer}}
+	{{include file="field_checkbox.tpl" field=$display_sensitive}}
 	{{include file="field_checkbox.tpl" field=$stay_local}}
 	{{include file="field_checkbox.tpl" field=$show_page_drop}}
 	{{include file="field_checkbox.tpl" field=$display_eventlist}}

--- a/view/theme/frio/templates/settings/display.tpl
+++ b/view/theme/frio/templates/settings/display.tpl
@@ -65,6 +65,7 @@
 						{{include file="field_checkbox.tpl" field=$enable_smart_threading}}
 						{{include file="field_checkbox.tpl" field=$enable_dislike}}
 						{{include file="field_checkbox.tpl" field=$display_resharer}}
+						{{include file="field_checkbox.tpl" field=$display_sensitive}}
 						{{include file="field_checkbox.tpl" field=$stay_local}}
 						{{include file="field_checkbox.tpl" field=$show_page_drop}}
 						{{include file="field_checkbox.tpl" field=$display_eventlist}}


### PR DESCRIPTION
We now blur preview pictures if they are part of a post that is marked as "sensitive". There is now a user setting that disables this behaviour.