### PR TITLE
Don't display preview images for links, when the post is marked as sensitive

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3823,6 +3823,12 @@ class Item
 		} elseif (preg_match("/.*(\[attachment.*?\].*?\[\/attachment\]).*/ism", $body, $match)) {
 			$data = BBCode::getAttachmentData($match[1]);
 		}
+
+		if ($sensitive) {
+			$data['image']   = '';
+			$data['preview'] = '';
+		}
+
 		DI::profiler()->stopRecording();
 
 		if (isset($data['url']) && !in_array(strtolower($data['url']), $ignore_links)) {


### PR DESCRIPTION
This fixes #13891 in a way that it doesn't displays a blurred image that you can't unblur.

The link preview images are just a decoration, but no essential part of the post. So we now don't display them anymore for content that is marked as sensitive.