### PR TITLE
Fix contact-relation follower calculation

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2024.03-rc (Yellow Archangel)
--- DB_UPDATE_VERSION 1552
+-- DB_UPDATE_VERSION 1553
 -- ------------------------------------------
 
 
@@ -539,6 +539,7 @@ CREATE TABLE IF NOT EXISTS `contact-relation` (
 	`relation-score` smallint unsigned COMMENT 'score for interactions of relation-cid on cid',
 	`thread-score` smallint unsigned COMMENT 'score for interactions of cid on threads of relation-cid',
 	`relation-thread-score` smallint unsigned COMMENT 'score for interactions of relation-cid on threads of cid',
+	`post-score` smallint unsigned COMMENT 'score for the amount of posts from cid that can be seen by relation-cid',
 	 PRIMARY KEY(`cid`,`relation-cid`),
 	 INDEX `relation-cid` (`relation-cid`),
 	FOREIGN KEY (`cid`) REFERENCES `contact` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,

--- a/doc/database/db_contact-relation.md
+++ b/doc/database/db_contact-relation.md
@@ -6,17 +6,18 @@ Contact relations
 Fields
 ------
 
-| Field                 | Description                                              | Type              | Null | Key | Default             | Extra |
-| --------------------- | -------------------------------------------------------- | ----------------- | ---- | --- | ------------------- | ----- |
-| cid                   | contact the related contact had interacted with          | int unsigned      | NO   | PRI | 0                   |       |
-| relation-cid          | related contact who had interacted with the contact      | int unsigned      | NO   | PRI | 0                   |       |
-| last-interaction      | Date of the last interaction by relation-cid on cid      | datetime          | NO   |     | 0001-01-01 00:00:00 |       |
-| follow-updated        | Date of the last update of the contact relationship      | datetime          | NO   |     | 0001-01-01 00:00:00 |       |
-| follows               | if true, relation-cid follows cid                        | boolean           | NO   |     | 0                   |       |
-| score                 | score for interactions of cid on relation-cid            | smallint unsigned | YES  |     | NULL                |       |
-| relation-score        | score for interactions of relation-cid on cid            | smallint unsigned | YES  |     | NULL                |       |
-| thread-score          | score for interactions of cid on threads of relation-cid | smallint unsigned | YES  |     | NULL                |       |
-| relation-thread-score | score for interactions of relation-cid on threads of cid | smallint unsigned | YES  |     | NULL                |       |
+| Field                 | Description                                                             | Type              | Null | Key | Default             | Extra |
+| --------------------- | ----------------------------------------------------------------------- | ----------------- | ---- | --- | ------------------- | ----- |
+| cid                   | contact the related contact had interacted with                         | int unsigned      | NO   | PRI | 0                   |       |
+| relation-cid          | related contact who had interacted with the contact                     | int unsigned      | NO   | PRI | 0                   |       |
+| last-interaction      | Date of the last interaction by relation-cid on cid                     | datetime          | NO   |     | 0001-01-01 00:00:00 |       |
+| follow-updated        | Date of the last update of the contact relationship                     | datetime          | NO   |     | 0001-01-01 00:00:00 |       |
+| follows               | if true, relation-cid follows cid                                       | boolean           | NO   |     | 0                   |       |
+| score                 | score for interactions of cid on relation-cid                           | smallint unsigned | YES  |     | NULL                |       |
+| relation-score        | score for interactions of relation-cid on cid                           | smallint unsigned | YES  |     | NULL                |       |
+| thread-score          | score for interactions of cid on threads of relation-cid                | smallint unsigned | YES  |     | NULL                |       |
+| relation-thread-score | score for interactions of relation-cid on threads of cid                | smallint unsigned | YES  |     | NULL                |       |
+| post-score            | score for the amount of posts from cid that can be seen by relation-cid | smallint unsigned | YES  |     | NULL                |       |
 
 Indexes
 ------------

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -103,6 +103,7 @@ class Widget
 	{
 		// Always hide content from these networks
 		$networks = [Protocol::PHANTOM, Protocol::FACEBOOK, Protocol::APPNET, Protocol::TWITTER, Protocol::ZOT];
+		Addon::loadAddons();
 
 		if (!Addon::isEnabled("discourse")) {
 			$networks[] = Protocol::DISCOURSE;

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -56,7 +56,7 @@ use Friendica\Database\DBA;
 
 // This file is required several times during the test in DbaDefinition which justifies this condition
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1552);
+	define('DB_UPDATE_VERSION', 1553);
 }
 
 return [
@@ -598,6 +598,7 @@ return [
 			"relation-score" => ["type" => "smallint unsigned", "comment" => "score for interactions of relation-cid on cid"],
 			"thread-score" => ["type" => "smallint unsigned", "comment" => "score for interactions of cid on threads of relation-cid"],
 			"relation-thread-score" => ["type" => "smallint unsigned", "comment" => "score for interactions of relation-cid on threads of cid"],
+			"post-score" => ["type" => "smallint unsigned", "comment" => "score for the amount of posts from cid that can be seen by relation-cid"],
 		],
 		"indexes" => [
 			"PRIMARY" => ["cid", "relation-cid"],


### PR DESCRIPTION
While doing some score calculation tests I detected problems with the contact relation calculation. We used a wrong contact id and not used all networks. This - for example - had caused the problem that we displayed a too low amount of users via the API.

This is now fixed. This PR contains some score calculation that is currently unused, but prepares data that will be used in the future.