### PR TITLE
Avoid passing null bytes in regular expression in Object\Image

### DIFF
--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -53,7 +53,7 @@ class Image
 	 *
 	 * @param string $data     Image data
 	 * @param string $type     optional, default ''
-	 * @param string $filename optional, default '' 
+	 * @param string $filename optional, default ''
 	 * @param string $imagick  optional, default 'true'
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
@@ -100,7 +100,7 @@ class Image
 		}
 
 		if ($this->imageType == IMAGETYPE_GIF) {
-			$count = @preg_match_all("#\x00\x21\xF9\x04.{4}\x00(\x2C|\x21)#s", $data);
+			$count = preg_match_all("#\\x00\\x21\\xF9\\x04.{4}\\x00[\\x2C\\x21]#s", $data);
 			return ($count > 0);
 		}
 
@@ -748,7 +748,7 @@ class Image
 			case IMAGETYPE_GIF:
 				imagegif($this->image, $stream);
 				break;
-				
+
 			case IMAGETYPE_WEBP:
 				imagewebp($this->image, $stream, DI::config()->get('system', 'jpeg_quality'));
 				break;


### PR DESCRIPTION
- Regular expressions have their own character escape notation including backslashes that need to be escaped in a PHP string.
- Remove capturing expression `(A|B)` in favor of bracket syntax `[AB]` in regular expression since matches aren't used.
- Actually address https://github.com/friendica/friendica/issues/13761#issuecomment-1949930922


- Fix-up to https://github.com/friendica/friendica/pull/13904