### PR TITLE
Check for activity pub mime types

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -208,6 +208,9 @@ class APContact
 
 				if (!$failed && ($curlResult->getReturnCode() == 410)) {
 					$data = ['@context' => ActivityPub::CONTEXT, 'id' => $url, 'type' => 'Tombstone'];
+				} elseif (!$failed && !HTTPSignature::isValidContentType($curlResult->getContentType())) {
+					Logger::debug('Unexpected content type', ['content-type' => $curlResult->getContentType(), 'url' => $url]);
+					$failed = true;
 				}
 			} catch (\Exception $exception) {
 				Logger::notice('Error fetching url', ['url' => $url, 'exception' => $exception]);

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1610,16 +1610,16 @@ class Processor
 		}
 
 		if (empty($object) || !is_array($object)) {
-			$element = explode(';', $curlResult->getContentType());
-			if (!in_array($element[0], ['application/activity+json', 'application/ld+json', 'application/json'])) {
-				Logger::debug('Unexpected content-type', ['url' => $url, 'content-type' => $curlResult->getContentType()]);
-				return null;
-			}
 			Logger::notice('Invalid JSON data', ['url' => $url, 'content-type' => $curlResult->getContentType(), 'body' => $body]);
 			return '';
 		}
 
 		if (!self::isValidObject($object, $url)) {
+			return '';
+		}
+
+		if (!HTTPSignature::isValidContentType($curlResult->getContentType())) {
+			Logger::notice('Unexpected content type', ['content-type' => $curlResult->getContentType(), 'url' => $url]);
 			return '';
 		}
 

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -443,7 +443,23 @@ class HTTPSignature
 			return [];
 		}
 
+		if (!self::isValidContentType($curlResult->getContentType())) {
+			Logger::notice('Unexpected content type', ['content-type' => $curlResult->getContentType(), 'url' => $request]);
+			return [];
+		}
+
 		return $content;
+	}
+
+	/**
+	 * Check if the provided content type is a valid LD JSON mime type
+	 *
+	 * @param string $contentType
+	 * @return boolean
+	 */
+	public static function isValidContentType(string $contentType): bool
+	{
+		return in_array(current(explode(';', $contentType)), ['application/activity+json', 'application/ld+json']);
 	}
 
 	/**


### PR DESCRIPTION
When we request ActivityPub related content, we now check for the correct content type and reject content in case it doesn't match.