### PR TITLE
Round the load to two digits

### DIFF
--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -473,7 +473,7 @@ class System
 			return false;
 		}
 
-		return max($load_arr[0], $load_arr[1]);
+		return round(max($load_arr[0], $load_arr[1]), 2);
 	}
 
 	/**


### PR DESCRIPTION
On ine of my servers, thr system returns a floating point value for the current load. Especially in the logging this is just irritating. So we now round the value.