### PR TITLE
Oembed: Some more cleanup

### DIFF
--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -225,7 +225,7 @@ class OEmbed
 						'$turl' => BBCode::proxyUrl($oembed->thumbnail_url, BBCode::INTERNAL, $uriid, Proxy::SIZE_SMALL),
 					]);
 				} else {
-					$ret = $oembed->html;
+					$ret .= Proxy::proxifyHtml($oembed->html, $uriid);
 				}
 				break;
 

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -365,7 +365,7 @@ class Media
 	 */
 	private static function addPage(array $media): array
 	{
-		$data = ParseUrl::getSiteinfoCached($media['url'], false);
+		$data = ParseUrl::getSiteinfoCached($media['url']);
 		$media['preview'] = $data['images'][0]['src'] ?? null;
 		$media['preview-height'] = $data['images'][0]['height'] ?? null;
 		$media['preview-width'] = $data['images'][0]['width'] ?? null;

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -23,7 +23,6 @@ namespace Friendica\Util;
 
 use DOMDocument;
 use DOMXPath;
-use Friendica\Content\OEmbed;
 use Friendica\Content\Text\HTML;
 use Friendica\Protocol\HTTP\MediaType;
 use Friendica\Core\Hook;
@@ -165,8 +164,6 @@ class ParseUrl
 	 * \<meta name="description" content="An awesome description"\>
 	 *
 	 * @param string $url         The url of the page which should be scraped
-	 * @param bool   $do_oembed   The false option is used by the function fetch_oembed()
-	 *                            to avoid endless loops
 	 * @param int    $count       Internal counter to avoid endless loops
 	 *
 	 * @return array which contains needed data for embedding


### PR DESCRIPTION
This is just some cleanup. We don't have got the second parameter for `getSiteinfoCached` anymore. 