### PR TITLE
Improved assigning of "last-activity" and "login_date"

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -833,7 +833,7 @@ class User
 	public static function updateLastActivity(array $user, bool $refresh_login)
 	{
 		$current_day = DateTimeFormat::utcNow('Y-m-d');
-		if (($user['last-activity'] == $current_day) && (!$refresh_login || DateTimeFormat::utc($user['login_date'], 'z-H') == date('z-H'))) {
+		if (($user['last-activity'] == $current_day) && (!$refresh_login || DateTimeFormat::utc($user['login_date'], 'z-H') == DateTimeFormat::utcNow('z-H'))) {
 			return;
 		}
 

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -826,27 +826,26 @@ class User
 	/**
 	 * Update the day of the last activity of the given user
 	 *
-	 * @param integer $uid
+	 * @param array $user
+	 * @param bool  $refresh_login
 	 * @return void
 	 */
-	public static function updateLastActivity(int $uid)
+	public static function updateLastActivity(array $user, bool $refresh_login)
 	{
-		if (!$uid) {
-			return;
-		}
-
-		$user = self::getById($uid, ['last-activity']);
-		if (empty($user)) {
-			return;
-		}
-
 		$current_day = DateTimeFormat::utcNow('Y-m-d');
-
-		if ($user['last-activity'] != $current_day) {
-			self::update(['last-activity' => $current_day], $uid);
-			// Set the last activity for all identities of the user
-			DBA::update('user', ['last-activity' => $current_day], ['parent-uid' => $uid, 'verified' => true, 'blocked' => false, 'account_removed' => false, 'account_expired' => false]);
+		if (($user['last-activity'] == $current_day) && (!$refresh_login || DateTimeFormat::utc($user['login_date'], 'z-H') == date('z-H'))) {
+			return;
 		}
+
+		$fields = ['last-activity' => $current_day];
+		if ($refresh_login) {
+			$fields['login_date'] = DateTimeFormat::utcNow();
+		}
+
+		Logger::debug('Set last activity for user', ['uid' => $user['uid'], 'fields' => $fields]);
+		self::update($fields, $user['uid']);
+		// Set the last activity for all identities of the user
+		DBA::update('user', $fields, ['parent-uid' => $user['uid'], 'verified' => true, 'blocked' => false, 'account_removed' => false, 'account_expired' => false]);
 	}
 
 	/**

--- a/src/Security/BasicAuth.php
+++ b/src/Security/BasicAuth.php
@@ -183,10 +183,7 @@ class BasicAuth
 			throw new UnauthorizedException("This API requires login");
 		}
 
-		// Don't refresh the login date more often than twice a day to spare database writes
-		$login_refresh = strcmp(DateTimeFormat::utc('now - 12 hours'), $record['login_date']) > 0;
-
-		DI::auth()->setForUser($a, $record, false, false, $login_refresh);
+		DI::auth()->setForUser($a, $record, false, false, false);
 
 		Hook::callAll('logged_in', $record);
 

--- a/src/Security/OAuth.php
+++ b/src/Security/OAuth.php
@@ -104,7 +104,10 @@ class OAuth
 		}
 		Logger::debug('Token found', $token);
 
-		User::updateLastActivity($token['uid']);
+		$user = User::getById($token['uid'], ['uid', 'last-activity', 'login_date']);
+		if (!empty($user)) {
+			User::updateLastActivity($user, false);
+		}
 
 		// Regularly update suggestions
 		if (Contact\Relation::areSuggestionsOutdated($token['uid'])) {

--- a/tests/datasets/api.fixture.php
+++ b/tests/datasets/api.fixture.php
@@ -215,7 +215,7 @@ return [
 			'id'       => 48,
 			'uid'      => 0,
 			'uri-id'   => 42,
-			'name'     => 'Self contact',
+			'name'     => 'Test user',
 			'nick'     => 'selfcontact',
 			'self'     => 0,
 			'nurl'     => 'http://friendica.local/profile/selfcontact',
@@ -928,6 +928,7 @@ return [
 		[
 			'id'  => 1,
 			'uid' => 42,
+			'locality' => 'DFRN',
 		],
 	],
 	'group' => [

--- a/tests/src/Module/Api/ApiTest.php
+++ b/tests/src/Module/Api/ApiTest.php
@@ -43,7 +43,7 @@ abstract class ApiTest extends FixtureTest
 	// User data that the test database is populated with
 	const SELF_USER = [
 		'id'   => 42,
-		'name' => 'Self contact',
+		'name' => 'Test user',
 		'nick' => 'selfcontact',
 		'nurl' => 'http://localhost/profile/selfcontact'
 	];


### PR DESCRIPTION
The user fields "last-activity" and "login_date" are assigned during login and the API access. Historically there had been two separate functions for that. This is now unified. Also we now always assign "login_date" only when a user is active directly on the web interface, while any API activities will solely update the "last-activity" field. Also "login_date" is updated once per hour.

These changes make these values more accurate and reliable.