### PR TITLE
Reduce the height of portrait videos

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3643,6 +3643,13 @@ class Item
 			}
 
 			if ($PostMedia->mimetype->type == 'video') {
+				if (($PostMedia->height ?? 0) > ($PostMedia->width ?? 0)) {
+					$height = min(DI::config()->get('system', 'max_video_height'), $PostMedia->height);
+					$width  = 'auto';
+				} else {
+					$height = 'auto';
+					$width  = '100%';
+				}
 				/// @todo Move the template to /content as well
 				$media = Renderer::replaceMacros(Renderer::getMarkupTemplate('video_top.tpl'), [
 					'$video' => [
@@ -3651,6 +3658,8 @@ class Item
 						'name'    => $PostMedia->name ?: $PostMedia->url,
 						'preview' => $preview_url,
 						'mime'    => (string)$PostMedia->mimetype,
+						'height'  => $height,
+						'width'   => $width,
 					],
 				]);
 				if (($item['post-type'] ?? null) == Item::PT_VIDEO) {

--- a/view/templates/video_top.tpl
+++ b/view/templates/video_top.tpl
@@ -1,6 +1,6 @@
 <div class="video-top-wrapper lframe" id="video-top-wrapper-{{$video.id}}">
 	{{* set preloading to none to lessen the load on the server *}}
-	<video src="{{$video.src}}" controls {{if $video.preview}}preload="none" poster="{{$video.preview}}" {else}preload="metadata" {{/if}}width="100%" height="auto">
+	<video src="{{$video.src}}" controls {{if $video.preview}}preload="none" poster="{{$video.preview}}" {else}preload="metadata" {{/if}}width="{{$video.width}}" height="{{$video.height}}">
 		<a href="{{$video.src}}">{{$video.name}}</a>
 	</video>
 


### PR DESCRIPTION
Videos in portrait mode often are higher than the screen height. We now reduce the height to a maximum height.