### PR TITLE
Check for the content type before fetching the content

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1610,7 +1610,7 @@ class Processor
 		}
 
 		if (empty($object) || !is_array($object)) {
-			Logger::notice('Invalid JSON data', ['url' => $url, 'content-type' => $curlResult->getContentType(), 'body' => $body]);
+			Logger::notice('Invalid JSON data', ['url' => $url, 'content-type' => $curlResult->getContentType()]);
 			return '';
 		}
 


### PR DESCRIPTION
Fixes #13969

We now check the content type before we fetch the content. Ths check is done in the function where we don't know, if the result really is an AP post.
