### PR TITLE
Centralized logging for a wrong JSON content-type

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -208,8 +208,7 @@ class APContact
 
 				if (!$failed && ($curlResult->getReturnCode() == 410)) {
 					$data = ['@context' => ActivityPub::CONTEXT, 'id' => $url, 'type' => 'Tombstone'];
-				} elseif (!$failed && !HTTPSignature::isValidContentType($curlResult->getContentType())) {
-					Logger::debug('Unexpected content type', ['content-type' => $curlResult->getContentType(), 'url' => $url]);
+				} elseif (!$failed && !HTTPSignature::isValidContentType($curlResult->getContentType(), $url)) {
 					$failed = true;
 				}
 			} catch (\Exception $exception) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -4097,7 +4097,7 @@ class Item
 		}
 
 		$curlResult = DI::httpClient()->head($uri, [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::JSON_AS]);
-		if (HTTPSignature::isValidContentType($curlResult->getContentType())) {
+		if (HTTPSignature::isValidContentType($curlResult->getContentType(), $uri)) {
 			$fetched_uri = ActivityPub\Processor::fetchMissingActivity($uri, [], '', $completion, $uid);
 		}
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1618,8 +1618,7 @@ class Processor
 			return '';
 		}
 
-		if (!HTTPSignature::isValidContentType($curlResult->getContentType())) {
-			Logger::notice('Unexpected content type', ['content-type' => $curlResult->getContentType(), 'url' => $url]);
+		if (!HTTPSignature::isValidContentType($curlResult->getContentType(), $url)) {
 			return '';
 		}
 

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -443,8 +443,7 @@ class HTTPSignature
 			return [];
 		}
 
-		if (!self::isValidContentType($curlResult->getContentType())) {
-			Logger::notice('Unexpected content type', ['content-type' => $curlResult->getContentType(), 'url' => $request]);
+		if (!self::isValidContentType($curlResult->getContentType(), $request)) {
 			return [];
 		}
 
@@ -457,9 +456,16 @@ class HTTPSignature
 	 * @param string $contentType
 	 * @return boolean
 	 */
-	public static function isValidContentType(string $contentType): bool
+	public static function isValidContentType(string $contentType, string $url = ''): bool
 	{
-		return in_array(current(explode(';', $contentType)), ['application/activity+json', 'application/ld+json']);
+		if (in_array(current(explode(';', $contentType)), ['application/activity+json', 'application/ld+json'])) {
+			return true;
+		}
+
+		if (current(explode(';', $contentType)) == 'application/json') {
+			Logger::notice('Unexpected content type, possibly from a remote system that is not standard compliant.', ['content-type' => $contentType, 'url' => $url]);
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
We now had got multiple places where we created a log entry, when an expected content type hadnÄt been one that is used with ActivityPub content. This is now centralized and thus better to observe.