### PR TITLE
Automatically close the registration when the admin is inactive

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -251,7 +251,7 @@ class Nav
 			$nav['home'] = [$homelink, $this->l10n->t('Home'), '', $this->l10n->t('Home Page')];
 		}
 
-		if (intval($this->config->get('config', 'register_policy')) === \Friendica\Module\Register::OPEN && !$this->session->isAuthenticated()) {
+		if (\Friendica\Module\Register::getPolicy() === \Friendica\Module\Register::OPEN && !$this->session->isAuthenticated()) {
 			$nav['register'] = ['register', $this->l10n->t('Register'), '', $this->l10n->t('Create an account')];
 		}
 

--- a/src/Module/Api/GNUSocial/GNUSocial/Config.php
+++ b/src/Module/Api/GNUSocial/GNUSocial/Config.php
@@ -47,7 +47,7 @@ class Config extends BaseApi
 				'broughtby'    => '',
 				'broughtbyurl' => '',
 				'timezone'     => DI::config()->get('system', 'default_timezone'),
-				'closed'       => (DI::config()->get('config', 'register_policy') == Register::CLOSED),
+				'closed'       => Register::getPolicy() === Register::CLOSED,
 				'inviteonly'   => (bool)DI::config()->get('system', 'invitation_only'),
 				'private'      => (bool)DI::config()->get('system', 'block_public'),
 				'textlimit'    => (string) DI::config()->get('config', 'api_import_size', DI::config()->get('config', 'max_import_size')),

--- a/src/Module/Api/Mastodon/InstanceV2.php
+++ b/src/Module/Api/Mastodon/InstanceV2.php
@@ -166,9 +166,9 @@ class InstanceV2 extends BaseApi
 
 	private function buildRegistrationsInfo(): InstanceEntity\Registrations
 	{
-		$register_policy   = intval($this->config->get('config', 'register_policy'));
-		$enabled           = ($register_policy != Register::CLOSED);
-		$approval_required = ($register_policy == Register::APPROVE);
+		$register_policy   = Register::getPolicy();
+		$enabled           = $register_policy !== Register::CLOSED;
+		$approval_required = $register_policy === Register::APPROVE;
 
 		return new InstanceEntity\Registrations($enabled, $approval_required);
 	}

--- a/src/Module/Bookmarklet.php
+++ b/src/Module/Bookmarklet.php
@@ -42,7 +42,7 @@ class Bookmarklet extends BaseModule
 
 		if (!DI::userSession()->getLocalUserId()) {
 			$output = '<h2>' . DI::l10n()->t('Login') . '</h2>';
-			$output .= Login::form(DI::args()->getQueryString(), intval($config->get('config', 'register_policy')) === Register::CLOSED ? false : true);
+			$output .= Login::form(DI::args()->getQueryString(), Register::getPolicy() !== Register::CLOSED);
 			return $output;
 		}
 

--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -30,7 +30,6 @@ use Friendica\Core\KeyValueStorage\Capability\IManageKeyValuePairs;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
-use Friendica\Core\System;
 use Friendica\Database\PostUpdate;
 use Friendica\Model\User;
 use Friendica\Network\HTTPException;
@@ -154,7 +153,7 @@ class Friendica extends BaseModule
 			Register::OPEN    => 'REGISTER_OPEN'
 		];
 
-		$register_policy_int = $this->config->get('config', 'register_policy');
+		$register_policy_int = Register::getPolicy();
 		if ($register_policy_int !== Register::CLOSED && $this->config->get('config', 'invitation_only')) {
 			$register_policy = 'REGISTER_INVITATION';
 		} else {

--- a/src/Module/Home.php
+++ b/src/Module/Home.php
@@ -73,7 +73,7 @@ class Home extends BaseModule
 			}
 		}
 
-		$login = Login::form(DI::args()->getQueryString(), $config->get('config', 'register_policy') === Register::CLOSED ? 0 : 1);
+		$login = Login::form(DI::args()->getQueryString(), Register::getPolicy() !== Register::CLOSED);
 
 		$content = '';
 		Hook::callAll('home_content', $content);

--- a/src/Module/Invite.php
+++ b/src/Module/Invite.php
@@ -146,14 +146,14 @@ class Invite extends BaseModule
 
 		$dirLocation = Search::getGlobalDirectory();
 		if (strlen($dirLocation)) {
-			if ($config->get('config', 'register_policy') === Register::CLOSED) {
+			if (Register::getPolicy() === Register::CLOSED) {
 				$linkTxt = DI::l10n()->t('Visit %s for a list of public sites that you can join. Friendica members on other sites can all connect with each other, as well as with members of many other social networks.', $dirLocation . '/servers');
 			} else {
 				$linkTxt = DI::l10n()->t('To accept this invitation, please visit and register at %s or any other public Friendica website.', DI::baseUrl() . '/register')
 					. "\r\n" . "\r\n" . DI::l10n()->t('Friendica sites all inter-connect to create a huge privacy-enhanced social web that is owned and controlled by its members. They can also connect with many traditional social networks. See %s for a list of alternate Friendica sites you can join.', $dirLocation . '/servers');
 			}
 		} else { // there is no global directory URL defined
-			if ($config->get('config', 'register_policy') === Register::CLOSED) {
+			if (Register::getPolicy() === Register::CLOSED) {
 				return DI::l10n()->t('Our apologies. This system is not currently configured to connect with other public sites or invite members.');
 			} else {
 				$linkTxt = DI::l10n()->t('To accept this invitation, please visit and register at %s.', DI::baseUrl() . '/register' 

--- a/src/Module/NodeInfo110.php
+++ b/src/Module/NodeInfo110.php
@@ -24,7 +24,6 @@ namespace Friendica\Module;
 use Friendica\App;
 use Friendica\BaseModule;
 use Friendica\Capabilities\ICanCreateResponses;
-use Friendica\Core\Addon;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Model\Nodeinfo;
@@ -65,7 +64,7 @@ class NodeInfo110 extends BaseModule
 			],
 			'services'          => Nodeinfo::getServices(),
 			'usage'             => Nodeinfo::getUsage(),
-			'openRegistrations' => intval($this->config->get('config', 'register_policy')) !== Register::CLOSED,
+			'openRegistrations' => Register::getPolicy() !== Register::CLOSED,
 			'metadata'          => [
 				'nodeName' => $this->config->get('config', 'sitename'),
 			],

--- a/src/Module/NodeInfo120.php
+++ b/src/Module/NodeInfo120.php
@@ -24,7 +24,6 @@ namespace Friendica\Module;
 use Friendica\App;
 use Friendica\BaseModule;
 use Friendica\Capabilities\ICanCreateResponses;
-use Friendica\Core\Addon;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Model\Nodeinfo;
@@ -58,7 +57,7 @@ class NodeInfo120 extends BaseModule
 			'protocols'         => ['dfrn', 'activitypub'],
 			'services'          => Nodeinfo::getServices(),
 			'usage'             => Nodeinfo::getUsage(),
-			'openRegistrations' => intval($this->config->get('config', 'register_policy')) !== Register::CLOSED,
+			'openRegistrations' => Register::getPolicy() !== Register::CLOSED,
 			'metadata'          => [
 				'nodeName' => $this->config->get('config', 'sitename'),
 			],

--- a/src/Module/NodeInfo210.php
+++ b/src/Module/NodeInfo210.php
@@ -24,7 +24,6 @@ namespace Friendica\Module;
 use Friendica\App;
 use Friendica\BaseModule;
 use Friendica\Capabilities\ICanCreateResponses;
-use Friendica\Core\Addon;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Model\Nodeinfo;
@@ -59,7 +58,7 @@ class NodeInfo210 extends BaseModule
 			'organization'      => Nodeinfo::getOrganization($this->config),
 			'protocols'         => ['dfrn', 'activitypub'],
 			'services'          => Nodeinfo::getServices(),
-			'openRegistrations' => intval($this->config->get('config', 'register_policy')) !== Register::CLOSED,
+			'openRegistrations' => Register::getPolicy() !== Register::CLOSED,
 			'usage'             => Nodeinfo::getUsage(true),
 		];
 

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -32,7 +32,6 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
-use Friendica\Core\System;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\Model\Circle;
@@ -175,7 +174,7 @@ class Ping extends BaseModule
 			$myurl      = $this->session->getMyUrl();
 			$mail_count = $this->database->count('mail', ["`uid` = ? AND NOT `seen` AND `from-url` != ?", $this->session->getLocalUserId(), $myurl]);
 
-			if (intval($this->config->get('config', 'register_policy')) === Register::APPROVE && $this->session->isSiteAdmin()) {
+			if (Register::getPolicy() === Register::APPROVE && $this->session->isSiteAdmin()) {
 				$registrations = \Friendica\Model\Register::getPending();
 				$register_count = count($registrations);
 			}

--- a/src/Module/Security/Login.php
+++ b/src/Module/Security/Login.php
@@ -66,7 +66,7 @@ class Login extends BaseModule
 			$this->baseUrl->redirect($return_path);
 		}
 
-		return self::form($return_path, intval($this->config->get('config', 'register_policy')) !== \Friendica\Module\Register::CLOSED);
+		return self::form($return_path, \Friendica\Module\Register::getPolicy() !== \Friendica\Module\Register::CLOSED);
 	}
 
 	protected function post(array $request = [])
@@ -118,7 +118,7 @@ class Login extends BaseModule
 		}
 
 		$reg = false;
-		if ($register && intval(DI::config()->get('config', 'register_policy')) !== Register::CLOSED) {
+		if ($register && Register::getPolicy() !== Register::CLOSED) {
 			$reg = [
 				'title' => DI::l10n()->t('Create a New Account'),
 				'desc' => DI::l10n()->t('Register'),

--- a/src/Module/Security/OpenID.php
+++ b/src/Module/Security/OpenID.php
@@ -86,7 +86,7 @@ class OpenID extends BaseModule
 				$open_id_obj->identity = $authId;
 				$session->set('openid_server', $open_id_obj->discover($open_id_obj->identity));
 
-				if (intval(DI::config()->get('config', 'register_policy')) === \Friendica\Module\Register::CLOSED) {
+				if (\Friendica\Module\Register::getPolicy() === \Friendica\Module\Register::CLOSED) {
 					DI::sysmsg()->addNotice($l10n->t('Account not found. Please login to your existing account to add the OpenID to it.'));
 				} else {
 					DI::sysmsg()->addNotice($l10n->t('Account not found. Please register a new account or login to your existing account to add the OpenID to it.'));

--- a/src/Module/Statistics.php
+++ b/src/Module/Statistics.php
@@ -27,7 +27,6 @@ use Friendica\Core\Addon;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\KeyValueStorage\Capability\IManageKeyValuePairs;
 use Friendica\Core\L10n;
-use Friendica\Core\System;
 use Friendica\Network\HTTPException\NotFoundException;
 use Friendica\Util\Profiler;
 use Psr\Log\LoggerInterface;
@@ -53,7 +52,7 @@ class Statistics extends BaseModule
 	protected function rawContent(array $request = [])
 	{
 		$registration_open =
-			intval($this->config->get('config', 'register_policy')) !== Register::CLOSED
+			Register::getPolicy() !== Register::CLOSED
 			&& !$this->config->get('config', 'invitation_only');
 
 		/// @todo mark the "service" addons and load them dynamically here

--- a/src/Module/User/Import.php
+++ b/src/Module/User/Import.php
@@ -80,7 +80,7 @@ class Import extends \Friendica\BaseModule
 
 	protected function post(array $request = [])
 	{
-		if ($this->config->get('config', 'register_policy') != \Friendica\Module\Register::OPEN && !$this->app->isSiteAdmin()) {
+		if (\Friendica\Module\Register::getPolicy() !== \Friendica\Module\Register::OPEN && !$this->app->isSiteAdmin()) {
 			throw new HttpException\ForbiddenException($this->t('Permission denied.'));
 		}
 
@@ -99,7 +99,7 @@ class Import extends \Friendica\BaseModule
 
 	protected function content(array $request = []): string
 	{
-		if (($this->config->get('config', 'register_policy') != \Friendica\Module\Register::OPEN) && !$this->app->isSiteAdmin()) {
+		if ((\Friendica\Module\Register::getPolicy() !== \Friendica\Module\Register::OPEN) && !$this->app->isSiteAdmin()) {
 			$this->systemMessages->addNotice($this->t('User imports on closed servers can only be done by an administrator.'));
 		}
 

--- a/src/Object/Api/Mastodon/Instance.php
+++ b/src/Object/Api/Mastodon/Instance.php
@@ -75,7 +75,7 @@ class Instance extends BaseDataTransferObject
 
 	public function __construct(IManageConfigValues $config, BaseURL $baseUrl, Database $database, Configuration $configuration, ?Account $contact_account, array $rules)
 	{
-		$register_policy = intval($config->get('config', 'register_policy'));
+		$register_policy = Register::getPolicy();
 
 		$this->uri               = $baseUrl->getHost();
 		$this->title             = $config->get('config', 'sitename');
@@ -87,8 +87,8 @@ class Instance extends BaseDataTransferObject
 		$this->thumbnail         = $baseUrl . (new Header($config))->getMastodonBannerPath();
 		$this->languages         = [$config->get('system', 'language')];
 		$this->max_toot_chars    = (int)$config->get('config', 'api_import_size', $config->get('config', 'max_import_size'));
-		$this->registrations     = ($register_policy != Register::CLOSED);
-		$this->approval_required = ($register_policy == Register::APPROVE);
+		$this->registrations     = ($register_policy !== Register::CLOSED);
+		$this->approval_required = ($register_policy === Register::APPROVE);
 		$this->invites_enabled   = false;
 		$this->configuration     = $configuration;
 		$this->contact_account   = $contact_account ?? [];

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -97,6 +97,10 @@ return [
 		// Checks for missing entries in "post", "post-thread" or "post-thread-user" and creates them
 		'add_missing_posts' => false,
 
+		// admin_inactivity_limit (Integer)
+		// Days of inactivity after which an admin is considered inactive. "0" means that there will be no check for inactivity.
+		'admin_inactivity_limit' => 30,
+
 		// allowed_link_protocols (Array)
 		// Allowed protocols in links URLs, add at your own risk. http(s) is always allowed.
 		'allowed_link_protocols' => ['ftp://', 'ftps://', 'mailto:', 'cid:', 'gopher://'],


### PR DESCRIPTION
This PR introduces a mechanism to automatically close the registrations when an admin isn't active any more on the system.