### PR TITLE
The "summary" has now a dedicated field when creating and editing posts

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (C) 2010-2024, the Friendica project
  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
@@ -46,7 +47,7 @@ function item_post()
 	$eventDispatcher = DI::eventDispatcher();
 
 	$_REQUEST = $eventDispatcher->dispatch(
-		new ArrayFilterEvent(ArrayFilterEvent::INSERT_POST_LOCAL_START, $_REQUEST)
+		new ArrayFilterEvent(ArrayFilterEvent::INSERT_POST_LOCAL_START, $_REQUEST),
 	)->getArray();
 
 	$return_path = $_REQUEST['return'] ?? '';
@@ -101,14 +102,16 @@ function item_edit(int $uid, array $request, bool $preview, string $return_path)
 	$post = item_process($post, $request, $preview, $return_path);
 
 	$fields = [
-		'title'    => $post['title'],
-		'body'     => $post['body'],
-		'attach'   => $post['attach'],
-		'file'     => $post['file'],
-		'location' => $post['location'],
-		'coord'    => $post['coord'],
-		'edited'   => DateTimeFormat::utcNow(),
-		'changed'  => DateTimeFormat::utcNow()
+		'title'           => $post['title'],
+		'content-warning' => $post['content-warning'],
+		'sensitive'       => $post['sensitive'],
+		'body'            => $post['body'],
+		'attach'          => $post['attach'],
+		'file'            => $post['file'],
+		'location'        => $post['location'],
+		'coord'           => $post['coord'],
+		'edited'          => DateTimeFormat::utcNow(),
+		'changed'         => DateTimeFormat::utcNow(),
 	];
 
 	$fields['body'] = Item::setHashtags($fields['body']);
@@ -288,7 +291,7 @@ function item_process(array $post, array $request, bool $preview, string $return
 	];
 
 	$hook_data = $eventDispatcher->dispatch(
-		new ArrayFilterEvent(ArrayFilterEvent::INSERT_POST_LOCAL, $hook_data)
+		new ArrayFilterEvent(ArrayFilterEvent::INSERT_POST_LOCAL, $hook_data),
 	)->getArray();
 
 	$post = $hook_data['item'] ?? $post;

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -389,8 +389,11 @@ class Conversation
 			'$shortnoloc'          => $this->l10n->t('clear location'),
 			'$title'               => $x['title'] ?? '',
 			'$placeholdertitle'    => $this->l10n->t('Set title'),
+			'$summary'             => $x['summary'] ?? '',
+			'$placeholdersummary'  => Feature::isEnabled($this->session->getLocalUserId(), Feature::SUMMARY) ? $this->l10n->t('Set summary, abstract or spoiler text') : '',
 			'$category'            => $x['category'] ?? '',
 			'$placeholdercategory' => Feature::isEnabled($this->session->getLocalUserId(), Feature::CATEGORIES) ? $this->l10n->t("Categories \x28comma-separated list\x29") : '',
+			'$sensitive'           => ['sensitive', $this->l10n->t('Sensitive post'), $x['sensitive'] ?? false],
 			'$scheduled_at'        => Temporal::getDateTimeField(
 				new \DateTime(),
 				new \DateTime('now + 6 months'),

--- a/src/Content/Feature.php
+++ b/src/Content/Feature.php
@@ -12,25 +12,26 @@ use Friendica\Event\ArrayFilterEvent;
 
 class Feature
 {
-	const ADD_ABSTRACT      = 'add_abstract';
-	const CATEGORIES        = 'categories';
-	const COMMUNITY         = 'community';
-	const EXPLICIT_MENTIONS = 'explicit_mentions';
-	const MEMBER_SINCE      = 'profile_membersince';
-	const PHOTO_LOCATION    = 'photo_location';
-	const PUBLIC_CALENDAR   = 'public_calendar';
-	const TAGCLOUD          = 'tagadelic';
+	public const ADD_ABSTRACT      = 'add_abstract';
+	public const CATEGORIES        = 'categories';
+	public const COMMUNITY         = 'community';
+	public const EXPLICIT_MENTIONS = 'explicit_mentions';
+	public const MEMBER_SINCE      = 'profile_membersince';
+	public const PHOTO_LOCATION    = 'photo_location';
+	public const PUBLIC_CALENDAR   = 'public_calendar';
+	public const SUMMARY           = 'summary';
+	public const TAGCLOUD          = 'tagadelic';
 	// The different widgets:
-	const ACCOUNTS      = 'accounts';
-	const ARCHIVE       = 'archive';
-	const CIRCLES       = 'circles';
-	const CHANNELS      = 'channels';
-	const FOLDERS       = 'folders';
-	const GROUPS        = 'forumlist_profile';
-	const NETWORKS      = 'networks';
-	const NOSHARER      = 'nosharer';
-	const SEARCHES      = 'searches';
-	const TRENDING_TAGS = 'trending_tags';
+	public const ACCOUNTS      = 'accounts';
+	public const ARCHIVE       = 'archive';
+	public const CIRCLES       = 'circles';
+	public const CHANNELS      = 'channels';
+	public const FOLDERS       = 'folders';
+	public const GROUPS        = 'forumlist_profile';
+	public const NETWORKS      = 'networks';
+	public const NOSHARER      = 'nosharer';
+	public const SEARCHES      = 'searches';
+	public const TRENDING_TAGS = 'trending_tags';
 
 	/**
 	 * check if feature is enabled
@@ -56,10 +57,10 @@ class Feature
 		$arr = ['uid' => $uid, 'feature' => $feature, 'enabled' => $enabled];
 
 		$arr = $eventDispatcher->dispatch(
-			new ArrayFilterEvent(ArrayFilterEvent::FEATURE_ENABLED, $arr)
+			new ArrayFilterEvent(ArrayFilterEvent::FEATURE_ENABLED, $arr),
 		)->getArray();
 
-		return (bool)$arr['enabled'];
+		return (bool) $arr['enabled'];
 	}
 
 	/**
@@ -119,6 +120,7 @@ class Feature
 			'tools' => [
 				$l10n->t('Post/Comment Tools'),
 				[self::CATEGORIES, $l10n->t('Post Categories'),         $l10n->t('Add categories to your posts'), false, $config->get('feature_lock', self::CATEGORIES, false)],
+				[self::SUMMARY,    $l10n->t('Summary'),                 $l10n->t('Add a summary, abstract or spoiler text to your posts'), false, $config->get('feature_lock', self::SUMMARY, false)],
 			],
 
 			// Widget visibility on the network stream
@@ -147,7 +149,7 @@ class Feature
 			'advanced_calendar' => [
 				$l10n->t('Advanced Calendar Settings'),
 				[self::PUBLIC_CALENDAR, $l10n->t('Allow anonymous access to your calendar'), $l10n->t('Allows anonymous visitors to consult your calendar and your public events. Contact birthday events are private to you.'), false, $config->get('feature_lock', self::PUBLIC_CALENDAR, false)],
-			]
+			],
 		];
 
 		// removed any locked features and remove the entire category if this makes it empty
@@ -172,7 +174,7 @@ class Feature
 		}
 
 		$arr = $eventDispatcher->dispatch(
-			new ArrayFilterEvent(ArrayFilterEvent::FEATURE_GET, $arr)
+			new ArrayFilterEvent(ArrayFilterEvent::FEATURE_GET, $arr),
 		)->getArray();
 
 		return $arr;

--- a/src/Module/Item/Compose.php
+++ b/src/Module/Item/Compose.php
@@ -78,7 +78,7 @@ class Compose extends BaseModule
 
 	protected function post(array $request = [])
 	{
-		if (!empty($_REQUEST['body'])) {
+		if (!empty($request['body'])) {
 			$_REQUEST['return'] = 'network';
 			require_once 'mod/item.php';
 			item_post();
@@ -131,10 +131,10 @@ class Compose extends BaseModule
 				$type          = 'post';
 				$doesFederate  = true;
 
-				$contact_allow = $_REQUEST['contact_allow'] ?? '';
-				$circle_allow  = $_REQUEST['circle_allow']  ?? '';
-				$contact_deny  = $_REQUEST['contact_deny']  ?? '';
-				$circle_deny   = $_REQUEST['circle_deny']   ?? '';
+				$contact_allow = $request['contact_allow'] ?? '';
+				$circle_allow  = $request['circle_allow']  ?? '';
+				$contact_deny  = $request['contact_deny']  ?? '';
+				$circle_deny   = $request['circle_deny']   ?? '';
 
 				if ($contact_allow
 					. $circle_allow
@@ -149,11 +149,13 @@ class Compose extends BaseModule
 				break;
 		}
 
-		$title    = $_REQUEST['title']    ?? '';
-		$category = $_REQUEST['category'] ?? '';
-		$body     = $_REQUEST['body']     ?? '';
-		$location = $_REQUEST['location'] ?? $user['default-location'];
-		$wall     = $_REQUEST['wall']     ?? $type == 'post';
+		$title     = $request['title']     ?? '';
+		$summary   = $request['summary']   ?? '';
+		$sensitive = $request['sensitive'] ?? false;
+		$category  = $request['category']  ?? '';
+		$body      = $request['body']      ?? '';
+		$location  = $request['location']  ?? $user['default-location'];
+		$wall      = $request['wall']      ?? $type == 'post';
 
 		$jotplugins = $this->eventDispatcher->dispatch(
 			new HtmlFilterEvent(HtmlFilterEvent::JOT_TOOL, ''),
@@ -172,7 +174,7 @@ class Compose extends BaseModule
 				new DateTime('now'),
 				null,
 				$this->l10n->t('Created at'),
-				'created_at'
+				'created_at',
 			);
 		} else {
 			$created_at = '';
@@ -183,6 +185,7 @@ class Compose extends BaseModule
 			'$l10n' => [
 				'compose_title'        => $compose_title,
 				'default'              => '',
+				'summary'              => $this->l10n->t('Summary'),
 				'visibility_title'     => $this->l10n->t('Visibility'),
 				'mytitle'              => $this->l10n->t('This is you'),
 				'submit'               => $this->l10n->t('Submit'),
@@ -204,14 +207,15 @@ class Compose extends BaseModule
 				'location_disabled'    => $this->l10n->t('Location services are disabled. Please check the website\'s permissions on your device'),
 				'wait'                 => $this->l10n->t('Please wait'),
 				'placeholdertitle'     => $this->l10n->t('Set title'),
+				'placeholdersummary'   => Feature::isEnabled($this->session->getLocalUserId(), Feature::SUMMARY) ? $this->l10n->t('Set summary, abstract or spoiler text') : '',
 				'placeholdercategory'  => Feature::isEnabled($this->session->getLocalUserId(), Feature::CATEGORIES) ? $this->l10n->t('Categories (comma-separated list)') : '',
 				'always_open_compose'  => $this->pConfig->get(
 					$this->session->getLocalUserId(),
 					'frio',
 					'always_open_compose',
-					$this->config->get('frio', 'always_open_compose', false)
-				) ? '' :
-						$this->l10n->t('If you want to always use this editor for posting, you can configure the New Post button to always open it in your <a href="/settings/display">Theme settings</a>.'),
+					$this->config->get('frio', 'always_open_compose', false),
+				) ? ''
+						: $this->l10n->t('If you want to always use this editor for posting, you can configure the New Post button to always open it in your <a href="/settings/display">Theme settings</a>.'),
 			],
 
 			'$id'           => 0,
@@ -220,15 +224,18 @@ class Compose extends BaseModule
 			'$wall'         => $wall,
 			'$mylink'       => $this->baseUrl->remove($contact['url']),
 			'$myphoto'      => $this->baseUrl->remove($contact['thumb']),
+			'$sensitive'    => ['sensitive', $this->l10n->t('Sensitive post'), $request['sensitive'] ?? false],
 			'$scheduled_at' => Temporal::getDateTimeField(
 				new DateTime(),
 				new DateTime('now + 6 months'),
 				null,
 				$this->l10n->t('Scheduled at'),
-				'scheduled_at'
+				'scheduled_at',
 			),
 			'$created_at' => $created_at,
 			'$title'      => $title,
+			'$summary'    => $summary,
+			'sensitive'   => $sensitive,
 			'$category'   => $category,
 			'$body'       => $body,
 			'$location'   => $location,

--- a/src/Module/Post/Edit.php
+++ b/src/Module/Post/Edit.php
@@ -79,8 +79,8 @@ class Edit extends BaseModule
 		}
 
 		$fields = [
-			'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid', 'gravity',
-			'body', 'title', 'uri-id', 'wall', 'post-type', 'guid'
+			'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid', 'gravity', 'sensitive',
+			'body', 'title', 'content-warning', 'uri-id', 'wall', 'post-type', 'guid',
 		];
 
 		$item = Post::selectFirstForUser($this->session->getLocalUserId(), $fields, [
@@ -153,6 +153,8 @@ class Edit extends BaseModule
 			'$public'              => $this->t('Public post'),
 			'$title'               => $item['title'],
 			'$placeholdertitle'    => $this->t('Set title'),
+			'$summary'             => $item['content-warning'],
+			'$placeholdersummary'  => (Feature::isEnabled($this->session->getLocalUserId(), Feature::SUMMARY) ? $this->t('Set summary, abstract or spoiler text') : ''),
 			'$category'            => Post\Category::getCSVByURIId($item['uri-id'], $this->session->getLocalUserId(), Post\Category::CATEGORY),
 			'$placeholdercategory' => (Feature::isEnabled($this->session->getLocalUserId(), Feature::CATEGORIES) ? $this->t("Categories \x28comma-separated list\x29") : ''),
 			'$emtitle'             => $this->t('Example: bob@example.com, mary@example.com'),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -1279,7 +1279,16 @@ msgstr ""
 
 #: src/Content/Conversation.php:393 src/Module/Item/Compose.php:207
 #: src/Module/Post/Edit.php:157
+msgid "Set summary, abstract or spoiler text"
+msgstr ""
+
+#: src/Content/Conversation.php:395 src/Module/Item/Compose.php:211
+#: src/Module/Post/Edit.php:159
 msgid "Categories (comma-separated list)"
+msgstr ""
+
+#: src/Content/Conversation.php:396 src/Module/Item/Compose.php:227
+msgid "Sensitive post"
 msgstr ""
 
 #: src/Content/Conversation.php:398 src/Module/Item/Compose.php:227
@@ -1637,6 +1646,17 @@ msgstr ""
 
 #: src/Content/Feature.php:121
 msgid "Add categories to your posts"
+msgstr ""
+
+#: src/Content/Feature.php:123 src/Model/Profile.php:807
+#: src/Module/Admin/Summary.php:207 src/Module/Item/Compose.php:188
+#: src/Module/Moderation/Report/Create.php:282
+#: src/Module/Moderation/Summary.php:65
+msgid "Summary"
+msgstr ""
+
+#: src/Content/Feature.php:123
+msgid "Add a summary, abstract or spoiler text to your posts"
 msgstr ""
 
 #: src/Content/Feature.php:126
@@ -3502,12 +3522,6 @@ msgstr ""
 
 #: src/Model/Profile.php:806
 msgid "Title/Description:"
-msgstr ""
-
-#: src/Model/Profile.php:807 src/Module/Admin/Summary.php:207
-#: src/Module/Moderation/Report/Create.php:282
-#: src/Module/Moderation/Summary.php:65
-msgid "Summary"
 msgstr ""
 
 #: src/Model/Profile.php:808

--- a/view/templates/item/compose.tpl
+++ b/view/templates/item/compose.tpl
@@ -18,6 +18,11 @@
             <div id="jot-title-wrap">
                 <input type="text" name="title" id="jot-title" class="jothidden jotforms form-control" placeholder="{{$l10n.placeholdertitle}}" title="{{$l10n.placeholdertitle}}" value="{{$title}}" tabindex="1" dir="auto" />
             </div>
+			{{if $l10n.placeholdersummary}}
+			<div id="jot-summary-wrap">
+				<input type="text" name="summary" id="jot-summary" class="jothidden jotforms form-control" placeholder="{{$l10n.placeholdersummary}}" title="{{$l10n.placeholdersummary}}" value="{{$summary}}" tabindex="1" dir="auto" />
+			</div>
+			{{/if}}
             {{if $l10n.placeholdercategory}}
                 <div id="jot-category-wrap">
                     <input name="category" id="jot-category" class="jothidden jotforms form-control" type="text" placeholder="{{$l10n.placeholdercategory}}" title="{{$l10n.placeholdercategory}}" value="{{$category}}" tabindex="2" dir="auto" />
@@ -112,6 +117,7 @@
                         {{$jotplugins nofilter}}
                     </div>
 
+        			{{include file="field_checkbox.tpl" field=$sensitive}}
                     {{if $scheduled_at}}{{$scheduled_at nofilter}}{{/if}}
                     {{if $created_at}}{{$created_at nofilter}}{{/if}}
                 {{else}}

--- a/view/templates/jot.tpl
+++ b/view/templates/jot.tpl
@@ -24,6 +24,9 @@
 		<input type="hidden" name="contact_allow[]" value="<{{$notes_cid}}>" />
 		{{/if}}
 		<div id="jot-title-wrap"><input name="title" id="jot-title" type="text" placeholder="{{$placeholdertitle}}" value="{{$title}}" class="jothidden" style="display:none" dir="auto"></div>
+		{{if $placeholdersummary}}
+		<div id="jot-summary-wrap"><input name="summary" id="jot-summary" type="text" placeholder="{{$placeholdersummary}}" value="{{$summary}}" class="jothidden" style="display:none" dir="auto"></div>
+	{{/if}}
 		{{if $placeholdercategory}}
 		<div id="jot-category-wrap"><input name="category" id="jot-category" type="text" placeholder="{{$placeholdercategory}}" value="{{$category}}" class="jothidden" style="display:none" dir="auto"></div>
 		{{/if}}
@@ -87,6 +90,7 @@
 	<div style="display: none;">
 		<div id="profile-jot-acl-wrapper" style="width:auto;height:auto;overflow:auto;">
 			{{$acl nofilter}}
+			{{include file="field_checkbox.tpl" field=$sensitive}}
 			{{if $scheduled_at}}{{$scheduled_at nofilter}}{{/if}}
 			{{if $created_at}}{{$created_at nofilter}}{{/if}}
 		</div>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1534,6 +1534,7 @@ section #jotOpen {
 	margin-right: 20px;
 }
 #jot-title-wrap,
+#jot-summary-wrap,
 #jot-category-wrap {
 	margin-bottom: 10px;
 }

--- a/view/theme/frio/templates/jot.tpl
+++ b/view/theme/frio/templates/jot.tpl
@@ -105,6 +105,9 @@
 					<input type="hidden" name="contact_allow[]" value="<{{$notes_cid}}>" />
 					{{/if}}
 					<div id="jot-title-wrap"><input name="title" id="jot-title" class="jothidden jotforms form-control" type="text" placeholder="{{$placeholdertitle}}" title="{{$placeholdertitle}}" value="{{$title}}" style="display:block;" dir="auto" /></div>
+					{{if $placeholdersummary}}
+					<div id="jot-summary-wrap"><input name="summary" id="jot-summary" class="jothidden jotforms form-control" type="text" placeholder="{{$placeholdersummary}}" title="{{$placeholdersummary}}" value="{{$summary}}" style="display:block;" dir="auto" /></div>
+					{{/if}}
 					{{if $placeholdercategory}}
 					<div id="jot-category-wrap"><input name="category" id="jot-category" class="jothidden jotforms form-control" type="text" placeholder="{{$placeholdercategory}}" title="{{$placeholdercategory}}" value="{{$category}}" dir="auto" /></div>
 					{{/if}}
@@ -147,6 +150,7 @@
 
 				<div id="profile-jot-acl-wrapper" class="minimize" aria-labelledby="jot-perms-lnk" role="tabpanel" aria-hidden="true">
 					{{$acl nofilter}}
+					{{include file="field_checkbox.tpl" field=$sensitive}}
 					{{if $scheduled_at}}{{$scheduled_at nofilter}}{{/if}}
 					{{if $created_at}}{{$created_at nofilter}}{{/if}}
 				</div>

--- a/view/theme/quattro/templates/jot.tpl
+++ b/view/theme/quattro/templates/jot.tpl
@@ -8,6 +8,9 @@
 	<div id="jot">
 		<div id="profile-jot-desc" class="jothidden">&nbsp;</div>
 		<input name="title" id="jot-title" type="text" placeholder="{{$placeholdertitle}}" title="{{$placeholdertitle}}" value="{{$title}}" class="jothidden" style="display:none" dir="auto" />
+		{{if $placeholdersummary}}
+		<input name="summary" id="jot-summary" type="text" placeholder="{{$placeholdersummary}}" title="{{$placeholdersummary}}" value="{{$summary}}" class="jothidden" style="display:none" dir="auto" />
+		{{/if}}
 		{{if $placeholdercategory}}
 		<input name="category" id="jot-category" type="text" placeholder="{{$placeholdercategory}}" title="{{$placeholdercategory}}" value="{{$category}}" class="jothidden" style="display:none" dir="auto" />
 		{{/if}}
@@ -53,6 +56,7 @@
 	<div style="display: none;">
 		<div id="profile-jot-acl-wrapper" style="width:auto;height:auto;overflow:auto;">
 			{{$acl nofilter}}
+			{{include file="field_checkbox.tpl" field=$sensitive}}
 			{{if $scheduled_at}}{{$scheduled_at nofilter}}{{/if}}
 			{{if $created_at}}{{$created_at nofilter}}{{/if}}
 		</div>

--- a/view/theme/smoothly/style.css
+++ b/view/theme/smoothly/style.css
@@ -1420,6 +1420,7 @@ ul .sidebar-circle-li .icon {
 #jot-coord,
 #jot-preview,
 #jot-title-wrap,
+#jot-summary-wrap,
 #jot-category-wrap,
 #jot-text-wrap,
 #profile-jot-text-loading,

--- a/view/theme/smoothly/templates/jot.tpl
+++ b/view/theme/smoothly/templates/jot.tpl
@@ -24,6 +24,11 @@
 		<div id="jot-title-wrap">
 			<input name="title" id="jot-title" type="text" placeholder="{{$placeholdertitle}}" value="{{$title}}" class="jothidden" style="display:none" dir="auto">
 		</div>
+		{{if $placeholdersummary}}
+		<div id="jot-summary-wrap">
+			<input name="summary" id="jot-summary" type="text" placeholder="{{$placeholdersummary}}" value="{{$summary}}" class="jothidden" style="display:none" dir="auto">
+		</div>
+		{{/if}}
 		{{if $placeholdercategory}}
 		<div id="jot-category-wrap">
 			<input name="category" id="jot-category" type="text" placeholder="{{$placeholdercategory}}" value="{{$category}}" class="jothidden" style="display:none" dir="auto" />
@@ -76,6 +81,7 @@
         <div style="display: none;">
             <div id="profile-jot-acl-wrapper" style="width:auto;height:auto;overflow:auto;">
                 {{$acl nofilter}}
+				{{include file="field_checkbox.tpl" field=$sensitive}}
                 {{if $scheduled_at}}{{$scheduled_at nofilter}}{{/if}}
                 {{if $created_at}}{{$created_at nofilter}}{{/if}}
             </div>


### PR DESCRIPTION
The "summary" field that is used in Mastodon as "content warning" can now be edited more easily. This is a feature that has to be enabled by the user.

When Mastodon users enter a "content warning", then the "summary" field is set and the "sensitive" flag is set to `true`. We can do this separately. This means we can set a summary without flagging the post as "sensitive" and we can set a post as "sensitive" without having to set a summary.
<img width="670" height="527" alt="image" src="https://github.com/user-attachments/assets/3e547161-fe17-4e2d-9544-306c6c9ff6ab" />
<img width="659" height="667" alt="image" src="https://github.com/user-attachments/assets/21d49ec9-9dc3-4f65-99d4-c7200b3a6c86" />

This means that at least in Friendica we only hide the post content when the "sensitive" flag is set. (We do this for a long time now).
