### PR TITLE
Implementation of FEP-e232 for quoted posts

### DIFF
--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -800,14 +800,14 @@ class Item
 	 */
 	public function addShareLink(string $body, int $quote_uri_id): string
 	{
-		$post = Post::selectFirstPost(['uri', 'plink'], ['uri-id' => $quote_uri_id]);
+		$post = Post::selectFirstPost(['uri'], ['uri-id' => $quote_uri_id]);
 		if (empty($post)) {
 			return $body;
 		}
 
 		$body = BBCode::removeSharedData($body);
 
-		$body .= "\n♲ " . ($post['plink'] ?: $post['uri']);
+		$body .= "\nRE: " . $post['uri'];
 
 		return $body;
 	}

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1577,7 +1577,8 @@ class Receiver
 			$element = [
 				'type' => str_replace('as:', '', JsonLD::fetchElement($tag, '@type') ?? ''),
 				'href' => JsonLD::fetchElement($tag, 'as:href', '@id'),
-				'name' => JsonLD::fetchElement($tag, 'as:name', '@value')
+				'name' => JsonLD::fetchElement($tag, 'as:name', '@value'),
+				'mediaType' => JsonLD::fetchElement($tag, 'as:mediaType', '@value')
 			];
 
 			if (empty($element['type'])) {
@@ -2094,12 +2095,18 @@ class Receiver
 		}
 
 		// Support for quoted posts (Pleroma, Fedibird and Misskey)
-		$object_data['quote-url'] = JsonLD::fetchElement($object, 'as:quoteUrl', '@value');
+		$object_data['quote-url'] = JsonLD::fetchElement($object, 'as:quoteUrl', '@id');
 		if (empty($object_data['quote-url'])) {
-			$object_data['quote-url'] = JsonLD::fetchElement($object, 'fedibird:quoteUri', '@value');
+			$object_data['quote-url'] = JsonLD::fetchElement($object, 'fedibird:quoteUri', '@id');
 		}
 		if (empty($object_data['quote-url'])) {
-			$object_data['quote-url'] = JsonLD::fetchElement($object, 'misskey:_misskey_quote', '@value');
+			$object_data['quote-url'] = JsonLD::fetchElement($object, 'misskey:_misskey_quote', '@id');
+		}
+
+		foreach ($object_data['tags'] as $tag) {
+			if (HTTPSignature::isValidContentType($tag['mediaType'] ?? '', $tag['href'])) {
+				$object_data['quote-url'] = $tag['href'];
+			}
 		}
 
 		// Misskey adds some data to the standard "content" value for quoted posts for backwards compatibility.

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1589,15 +1589,14 @@ class Transmitter
 			$tags[] = ['type' => 'Mention', 'href' => $announce['actor']['url'], 'name' => '@' . $announce['actor']['addr']];
 		}
 
-		// @see https://codeberg.org/fediverse/fep/src/branch/main/feps/fep-e232.md
+		// @see https://codeberg.org/fediverse/fep/src/branch/main/fep/e232/fep-e232.md
 		if (!empty($quote_url)) {
-			// Currently deactivated because of compatibility issues with Pleroma
-			//$tags[] = [
-			//	'type'      => 'Link',
-			//	'mediaType' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
-			//	'href'      => $quote_url,
-			//	'name'      => '♲ ' . BBCode::convertForUriId($item['uri-id'], $quote_url, BBCode::ACTIVITYPUB)
-			//];
+			$tags[] = [
+				'type'      => 'Link',
+				'mediaType' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+				'href'      => $quote_url,
+				'name'      => 'RE: ' . $quote_url,
+			];
 		}
 
 		return $tags;
@@ -1862,6 +1861,7 @@ class Transmitter
 			if (!empty($item['quote-uri-id']) && ($item['quote-uri-id'] != $item['uri-id'])) {
 				if (Post::exists(['uri-id' => $item['quote-uri-id'], 'network' => [Protocol::ACTIVITYPUB, Protocol::DFRN]])) {
 					$real_quote = true;
+					$data['_misskey_content'] = BBCode::removeSharedData($body);
 					$data['quoteUrl'] = $item['quote-uri'];
 					$body = DI::contentItem()->addShareLink($body, $item['quote-uri-id']);
 				} else {


### PR DESCRIPTION
We now fully support [FEP-e232](https://codeberg.org/fediverse/fep/src/branch/main/fep/e232/fep-e232.md) for outgoing and incoming quoted posts. We also added a Misskey specific field to make quoted posts look better on their system.
Fixes https://github.com/friendica/friendica/issues/14030