### PR TITLE
Add `'$VERSION'` template variable to make Friendica version available in templates

### DIFF
--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -332,7 +332,6 @@ class Conversation
 		$tpl = Renderer::getMarkupTemplate('jot-header.tpl');
 		$this->page['htmlhead'] .= Renderer::replaceMacros($tpl, [
 			'$newpost'   => 'true',
-			'$baseurl'   => $this->baseURL,
 			'$geotag'    => $geotag,
 			'$nickname'  => $x['nickname'],
 			'$ispublic'  => $this->l10n->t('Visible to <strong>everybody</strong>'),
@@ -405,7 +404,6 @@ class Conversation
 			'$posttype'     => $notes_cid ? ItemModel::PT_PERSONAL_NOTE : ItemModel::PT_ARTICLE,
 			'$content'      => $x['content'] ?? '',
 			'$post_id'      => $x['post_id'] ?? '',
-			'$baseurl'      => $this->baseURL,
 			'$defloc'       => $x['default_location'],
 			'$visitor'      => $x['visitor'],
 			'$pvisit'       => $notes_cid ? 'none' : $x['visitor'],
@@ -591,7 +589,6 @@ class Conversation
 		}
 
 		$o = Renderer::replaceMacros($page_template, [
-			'$baseurl'     => $this->baseURL,
 			'$return_path' => $this->args->getQueryString(),
 			'$live_update' => $live_update_div,
 			'$remove'      => $this->l10n->t('remove'),

--- a/src/Core/Renderer.php
+++ b/src/Core/Renderer.php
@@ -75,8 +75,11 @@ class Renderer
 	{
 		DI::profiler()->startRecording('rendering');
 
-		// pass $baseurl to all templates if it isn't set
-		$vars = array_merge(['$baseurl' => DI::baseUrl(), '$APP' => DI::app()], $vars);
+		// Default template variables
+		$vars = array_merge([
+			'$baseurl' => DI::baseUrl(),
+			'$VERSION' => \Friendica\App::VERSION,
+		], $vars);
 
 		$t = self::getTemplateEngine();
 

--- a/src/Module/Admin/Federation.php
+++ b/src/Module/Admin/Federation.php
@@ -221,7 +221,6 @@ class Federation extends BaseAdmin
 			'$page' => DI::l10n()->t('Federation Statistics'),
 			'$intro' => $intro,
 			'$counts' => $counts,
-			'$version' => App::VERSION,
 			'$legendtext' => DI::l10n()->tt('Currently this node is aware of %2$s node (%3$s active users last month, %4$s active users last six months, %5$s registered users in total) from the following platforms:', 'Currently this node is aware of %2$s nodes (%3$s active users last month, %4$s active users last six months, %5$s registered users in total) from the following platforms:', $total, number_format($total), number_format($month), number_format($halfyear), number_format($users)),
 		]);
 	}

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -196,7 +196,7 @@ class Summary extends BaseAdmin
 			'$title'          => DI::l10n()->t('Administration'),
 			'$page'           => DI::l10n()->t('Summary'),
 			'$queues'         => $queues,
-			'$version'        => [DI::l10n()->t('Version'), App::VERSION],
+			'$version_label'  => DI::l10n()->t('Version'),
 			'$platform'       => App::PLATFORM,
 			'$codename'       => App::CODENAME,
 			'$build'          => DI::config()->get('system', 'build'),

--- a/src/Module/Moderation/Blocklist/Contact.php
+++ b/src/Module/Moderation/Blocklist/Contact.php
@@ -124,8 +124,6 @@ class Contact extends BaseModeration
 			'$form_security_token' => self::getFormSecurityToken('moderation_contactblock'),
 
 			// values //
-			'$baseurl' => $this->baseUrl,
-
 			'$contacts'       => $contacts,
 			'$total_contacts' => $this->tt('%s total blocked contact', '%s total blocked contacts', $total),
 			'$paginate'       => $pager->renderFull($total),

--- a/src/Module/Moderation/Blocklist/Server/Add.php
+++ b/src/Module/Moderation/Blocklist/Server/Add.php
@@ -138,7 +138,6 @@ class Add extends BaseModeration
 			'$newreason'           => ['reason', $this->t('Block reason'), $request['reason'] ?? '', $this->t('The reason why you blocked this server domain pattern. This reason will be shown publicly in the server information page.'), $this->t('Required'), '', ''],
 			'$pattern'             => $pattern,
 			'$gservers'            => $gservers,
-			'$baseurl'             => $this->baseUrl,
 			'$form_security_token' => self::getFormSecurityToken('moderation_blocklist_add')
 		]);
 	}

--- a/src/Module/Moderation/Blocklist/Server/Import.php
+++ b/src/Module/Moderation/Blocklist/Server/Import.php
@@ -130,7 +130,6 @@ class Import extends \Friendica\Module\BaseModeration
 			'$mode_append'         => ['mode', $this->t('Append'), 'append', $this->t('Imports patterns from the file that weren\'t already existing in the current blocklist.'), 'checked="checked"'],
 			'$mode_replace'        => ['mode', $this->t('Replace'), 'replace', $this->t('Replaces the current blocklist by the imported patterns.')],
 			'$blocklist'           => $this->blocklist,
-			'$baseurl'             => $this->baseUrl,
 			'$form_security_token' => self::getFormSecurityToken('moderation_blocklist_import')
 		]);
 	}

--- a/src/Module/Moderation/Blocklist/Server/Index.php
+++ b/src/Module/Moderation/Blocklist/Server/Index.php
@@ -115,7 +115,6 @@ class Index extends BaseModeration
 			'$listfile'  => ['listfile', $this->t('Server domain pattern blocklist CSV file'), '', '', $this->t('Required'), '', 'file'],
 			'$newdomain' => ['pattern', $this->t('Server Domain Pattern'), '', $this->t('The domain pattern of the new server to add to the blocklist. Do not include the protocol.'), $this->t('Required'), '', ''],
 			'$entries'   => $blocklistform,
-			'$baseurl'   => $this->baseUrl,
 
 			'$form_security_token'        => self::getFormSecurityToken('moderation_blocklist'),
 			'$form_security_token_import' => self::getFormSecurityToken('moderation_blocklist_import'),

--- a/src/Module/Moderation/Reports.php
+++ b/src/Module/Moderation/Reports.php
@@ -95,8 +95,6 @@ class Reports extends BaseModeration
 			'$th_reports' => [$this->t('Created'), $this->t('Photo'), $this->t('Name'), $this->t('Comment'), $this->t('Category')],
 
 			// values //
-			'$baseurl' => $this->baseUrl,
-
 			'$reports'       => $reports,
 			'$total_reports' => $this->tt('%s total report', '%s total reports', $total),
 			'$paginate'      => $pager->renderFull($total),

--- a/src/Module/Moderation/Users/Active.php
+++ b/src/Module/Moderation/Users/Active.php
@@ -150,7 +150,6 @@ class Active extends BaseUsers
 			'$form_security_token' => self::getFormSecurityToken('moderation_users_active'),
 
 			// values //
-			'$baseurl'      => $this->baseUrl,
 			'$query_string' => $this->args->getQueryString(),
 
 			'$users' => $users,

--- a/src/Module/Settings/Channels.php
+++ b/src/Module/Settings/Channels.php
@@ -228,7 +228,6 @@ class Channels extends BaseSettings
 				'confirm_delete' => $this->t('Delete entry from the channel list?'),
 			],
 			'$entries' => $channels,
-			'$baseurl' => $this->baseUrl,
 
 			'$form_security_token' => self::getFormSecurityToken('settings_channels'),
 		]);

--- a/view/templates/admin/federation.tpl
+++ b/view/templates/admin/federation.tpl
@@ -1,4 +1,4 @@
-<script src="{{$baseurl}}/view/asset/Chart-js/dist/Chart.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script src="{{$baseurl}}/view/asset/Chart-js/dist/Chart.min.js?v={{$VERSION}}"></script>
 <div id="adminpage">
 	<h1>{{$title}} - {{$page}}</h1>
 
@@ -115,7 +115,7 @@
 				<ul class="federation-stats">
 				{{foreach $c[1] as $v}}
 					<li>
-						{{if ($c[0]['platform']==='Friendica' and  $version===$v['version']) }}
+						{{if $c[0]['platform'] === 'Friendica' && $VERSION === $v['version']}}
 						<span class="version-match">{{$v['version']}}</span>
 						{{else}}
 						{{$v['version']}}

--- a/view/templates/admin/summary.tpl
+++ b/view/templates/admin/summary.tpl
@@ -16,16 +16,16 @@
 
 	<dl>
 		<dt>{{$addons.0}}</dt>
-		
+
 		{{foreach $addons.1 as $p}}
 			<dd><a href="{{$baseurl}}/admin/addons/{{$p}}/">{{$p}}</a></dd>
 		{{/foreach}}
-		
+
 	</dl>
 
 	<dl>
-		<dt>{{$version.0}}</dt>
-		<dd> {{$platform}} '{{$codename}}' {{$version.1}} - {{$build}}</dt>
+		<dt>{{$version_label}}</dt>
+		<dd> {{$platform}} '{{$codename}}' {{$VERSION}} - {{$build}}</dt>
 	</dl>
 
 	<dl>

--- a/view/templates/calendar/calendar_head.tpl
+++ b/view/templates/calendar/calendar_head.tpl
@@ -1,7 +1,7 @@
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css?v={{constant('\Friendica\App::VERSION')}}" />
-<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css?v={{constant('\Friendica\App::VERSION')}}" media="print" />
-<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.css?v={{$VERSION}}" />
+<link rel="stylesheet" type="text/css" href="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.print.min.css?v={{$VERSION}}" media="print" />
+<script type="text/javascript" src="{{$baseurl}}/view/asset/moment/min/moment-with-locales.min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/asset/fullcalendar/dist/fullcalendar.min.js?v={{$VERSION}}"></script>
 
 <script>
 	function showEvent(eventid) {

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -1,12 +1,12 @@
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <base href="{{$baseurl}}/" />
 <meta name="generator" content="{{$generator}}" />
-<link rel="stylesheet" href="view/global.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="all" />
-<link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/perfect-scrollbar/dist/css/perfect-scrollbar.min.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen" />
-<link rel="stylesheet" href="view/js/fancybox/jquery.fancybox.min.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/global.css?v={{$VERSION}}" type="text/css" media="all" />
+<link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css?v={{$VERSION}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css?v={{$VERSION}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css?v={{$VERSION}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/perfect-scrollbar/dist/css/perfect-scrollbar.min.css?v={{$VERSION}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/js/fancybox/jquery.fancybox.min.css?v={{$VERSION}}" type="text/css" media="screen" />
 
 {{foreach $stylesheets as $stylesheetUrl => $media}}
 	<link rel="stylesheet" href="{{$stylesheetUrl}}" type="text/css" media="{{$media}}" />
@@ -30,23 +30,23 @@
          title="Search in Friendica" />
 
 <!--[if IE]>
-<script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js?v={{$VERSION}}"></script>
 <![endif]-->
-<script type="text/javascript" src="view/js/modernizr.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/asset/jquery/dist/jquery.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/js/jquery.textinputs.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/asset/textcomplete/dist/textcomplete.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/js/autocomplete.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/asset/jquery-colorbox/jquery.colorbox-min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/asset/jgrowl/jquery.jgrowl.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/asset/perfect-scrollbar/dist/js/perfect-scrollbar.jquery.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/asset/imagesloaded/imagesloaded.pkgd.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/asset/base64/base64.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/asset/dompurify/dist/purify.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/js/fancybox/jquery.fancybox.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/js/fancybox/fancybox.config.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/js/vanillaEmojiPicker/vanillaEmojiPicker.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="view/js/modernizr.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/asset/jquery/dist/jquery.min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/js/jquery.textinputs.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/asset/textcomplete/dist/textcomplete.min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/js/autocomplete.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/asset/jquery-colorbox/jquery.colorbox-min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/asset/jgrowl/jquery.jgrowl.min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/asset/perfect-scrollbar/dist/js/perfect-scrollbar.jquery.min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/asset/imagesloaded/imagesloaded.pkgd.min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/asset/base64/base64.min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/asset/dompurify/dist/purify.min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/js/fancybox/jquery.fancybox.min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/js/fancybox/fancybox.config.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/js/vanillaEmojiPicker/vanillaEmojiPicker.min.js?v={{$VERSION}}"></script>
 <script>
 window.onload = function(){
 	new EmojiPicker({
@@ -68,7 +68,7 @@ window.onload = function(){
 	const updateInterval = {{$update_interval}};
 	const localUser = {{if $local_user}}{{$local_user}}{{else}}false{{/if}};
 </script>
-<script type="text/javascript" src="view/js/main.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="view/js/main.js?v={{$VERSION}}"></script>
 <script>
 	// Lifted from https://css-tricks.com/snippets/jquery/move-cursor-to-end-of-textarea-or-input/
     jQuery.fn.putCursorAtEnd = function() {

--- a/view/templates/jot-header.tpl
+++ b/view/templates/jot-header.tpl
@@ -45,7 +45,7 @@ function enableOnUser(){
 }
 
 </script>
-<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{$VERSION}}"></script>
 <script>
 	var ispublic = '{{$ispublic nofilter}}';
 

--- a/view/templates/media/browser.tpl
+++ b/view/templates/media/browser.tpl
@@ -1,8 +1,8 @@
 <!--
 	This is the template used by mod/fbrowser.php
 -->
-<script type="text/javascript" src="view/js/ajaxupload.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="view/js/module/media/browser.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="view/js/ajaxupload.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="view/js/module/media/browser.js?v={{$VERSION}}"></script>
 <script>
 	$(function() {
 		Browser.init("{{$nickname}}", "{{$type}}");

--- a/view/templates/msg-header.tpl
+++ b/view/templates/msg-header.tpl
@@ -1,7 +1,7 @@
 <script language="javascript" type="text/javascript">
 	$("#prvmail-text").editor_autocomplete(baseurl + '/search/acl');
 </script>
-<script type="text/javascript" src="view/js/ajaxupload.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="view/js/ajaxupload.js?v={{$VERSION}}"></script>
 <script>
 	$(document).ready(function() {
 		var uploader = new window.AjaxUpload(

--- a/view/templates/settings/profile/index_head.tpl
+++ b/view/templates/settings/profile/index_head.tpl
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="view/js/country.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="view/js/country.js?v={{$VERSION}}"></script>

--- a/view/templates/settings/profile/photo/crop_head.tpl
+++ b/view/templates/settings/profile/photo/crop_head.tpl
@@ -1,2 +1,2 @@
-<script type="text/javascript" src="view/asset/cropperjs/dist/cropper.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<link rel="stylesheet" href="view/asset/cropperjs/dist/cropper.min.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" />
+<script type="text/javascript" src="view/asset/cropperjs/dist/cropper.min.js?v={{$VERSION}}"></script>
+<link rel="stylesheet" href="view/asset/cropperjs/dist/cropper.min.css?v={{$VERSION}}" type="text/css" />

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -17,7 +17,7 @@
 		});
 	});
 </script>
-<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$VERSION}}" type="text/css" media="screen"/>
 
 <div id="adminpage" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}}</h1>

--- a/view/theme/frio/templates/admin/storage.tpl
+++ b/view/theme/frio/templates/admin/storage.tpl
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen"/>
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$VERSION}}" type="text/css" media="screen"/>
 
 <div id="adminpage" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}}</h1>

--- a/view/theme/frio/templates/admin/summary.tpl
+++ b/view/theme/frio/templates/admin/summary.tpl
@@ -31,8 +31,8 @@
 		{{* The Friendica version. *}}
 		<div id="admin-summary-version" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 admin-summary">
 			<hr class="admin-summary-separator">
-			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$version.0}}</div>
-			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">{{$platform}} '{{$codename}}' {{$version.1}} - {{$build}}</div>
+			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$version_label}}</div>
+			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">{{$platform}} '{{$codename}}' {{$VERSION}} - {{$build}}</div>
 		</div>
 
 		{{* Server Settings. *}}

--- a/view/theme/frio/templates/calendar/calendar_head.tpl
+++ b/view/theme/frio/templates/calendar/calendar_head.tpl
@@ -1,5 +1,5 @@
 
-<script type="text/javascript" src="view/theme/frio/js/mod_events.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="view/theme/frio/js/mod_events.js?v={{$VERSION}}"></script>
 
 <script type="text/javascript">
 	// pass php translation strings to js variables/arrays so we can make use of it in js files

--- a/view/theme/frio/templates/circle_edit.tpl
+++ b/view/theme/frio/templates/circle_edit.tpl
@@ -3,7 +3,7 @@
     add or remove contacts to the contact circle.
 *}}
 
-<script type="text/javascript" src="view/theme/frio/js/mod_circle.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="view/theme/frio/js/mod_circle.js?v={{$VERSION}}"></script>
 
 <div class="generic-page-wrapper">
 	{{if $editable == 1}}

--- a/view/theme/frio/templates/contacts-head.tpl
+++ b/view/theme/frio/templates/contacts-head.tpl
@@ -1,2 +1,2 @@
 
-<script type="text/javascript" src="view/theme/frio/js/mod_contacts.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="view/theme/frio/js/mod_contacts.js?v={{$VERSION}}"></script>

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -6,56 +6,56 @@
 <meta name="viewport" content="initial-scale=1.0">
 
 {{* All needed css files - Note: css must be inserted before js files *}}
-<link rel="stylesheet" href="view/global.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="all" />
-<link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css?v={{constant('\Friendica\App::VERSION')}}"
+<link rel="stylesheet" href="view/global.css?v={{$VERSION}}" type="text/css" media="all" />
+<link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css?v={{constant('\Friendica\App::VERSION')}}"
-	type="text/css" media="screen" />
-<link rel="stylesheet"
-	href="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css?v={{constant('\Friendica\App::VERSION')}}"
+<link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 <link rel="stylesheet"
-	href="view/asset/perfect-scrollbar/dist/css/perfect-scrollbar.min.css?v={{constant('\Friendica\App::VERSION')}}"
+	href="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.min.css?v={{$VERSION}}"
+	type="text/css" media="screen" />
+<link rel="stylesheet"
+	href="view/asset/perfect-scrollbar/dist/css/perfect-scrollbar.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 
 <link rel="stylesheet"
-	href="view/theme/frio/frameworks/bootstrap/css/bootstrap.min.css?v={{constant('\Friendica\App::VERSION')}}"
+	href="view/theme/frio/frameworks/bootstrap/css/bootstrap.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 <link rel="stylesheet"
-	href="view/theme/frio/frameworks/bootstrap/css/bootstrap-theme.min.css?v={{constant('\Friendica\App::VERSION')}}"
+	href="view/theme/frio/frameworks/bootstrap/css/bootstrap-theme.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/fork-awesome/css/fork-awesome.min.css?v={{constant('\Friendica\App::VERSION')}}"
-	type="text/css" media="screen" />
-<link rel="stylesheet"
-	href="view/theme/frio/frameworks/jasny/css/jasny-bootstrap.min.css?v={{constant('\Friendica\App::VERSION')}}"
+<link rel="stylesheet" href="view/asset/fork-awesome/css/fork-awesome.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 <link rel="stylesheet"
-	href="view/theme/frio/frameworks/bootstrap-select/css/bootstrap-select.min.css?v={{constant('\Friendica\App::VERSION')}}"
+	href="view/theme/frio/frameworks/jasny/css/jasny-bootstrap.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 <link rel="stylesheet"
-	href="view/theme/frio/frameworks/ekko-lightbox/ekko-lightbox.min.css?v={{constant('\Friendica\App::VERSION')}}"
+	href="view/theme/frio/frameworks/bootstrap-select/css/bootstrap-select.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 <link rel="stylesheet"
-	href="view/theme/frio/frameworks/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.css?v={{constant('\Friendica\App::VERSION')}}"
+	href="view/theme/frio/frameworks/ekko-lightbox/ekko-lightbox.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 <link rel="stylesheet"
-	href="view/theme/frio/frameworks/justifiedGallery/justifiedGallery.min.css?v={{constant('\Friendica\App::VERSION')}}"
+	href="view/theme/frio/frameworks/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 <link rel="stylesheet"
-	href="view/theme/frio/frameworks/bootstrap-colorpicker/css/bootstrap-colorpicker.min.css?v={{constant('\Friendica\App::VERSION')}}"
+	href="view/theme/frio/frameworks/justifiedGallery/justifiedGallery.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 <link rel="stylesheet"
-	href="view/theme/frio/frameworks/bootstrap-toggle/css/bootstrap-toggle.min.css?v={{constant('\Friendica\App::VERSION')}}"
+	href="view/theme/frio/frameworks/bootstrap-colorpicker/css/bootstrap-colorpicker.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
-<link rel="stylesheet" href="view/theme/frio/font/open_sans/open-sans.css?v={{constant('\Friendica\App::VERSION')}}"
+<link rel="stylesheet"
+	href="view/theme/frio/frameworks/bootstrap-toggle/css/bootstrap-toggle.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
-<link rel="stylesheet" href="view/js/fancybox/jquery.fancybox.min.css?v={{constant('\Friendica\App::VERSION')}}"
+<link rel="stylesheet" href="view/theme/frio/font/open_sans/open-sans.css?v={{$VERSION}}"
+	type="text/css" media="screen" />
+<link rel="stylesheet" href="view/js/fancybox/jquery.fancybox.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 
 {{* own css files *}}
-<link rel="stylesheet" href="view/theme/frio/css/hovercard.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css"
+<link rel="stylesheet" href="view/theme/frio/css/hovercard.css?v={{$VERSION}}" type="text/css"
 	media="screen" />
-<link rel="stylesheet" href="view/theme/frio/css/font-awesome.custom.css?v={{constant('\Friendica\App::VERSION')}}"
+<link rel="stylesheet" href="view/theme/frio/css/font-awesome.custom.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 
 {{foreach $stylesheets as $stylesheetUrl => $media}}
@@ -81,74 +81,74 @@
 
 	{{* The js files we use *}}
 	<!--[if IE]>
-<script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="https://html5shiv.googlecode.com/svn/trunk/html5.js?v={{$VERSION}}"></script>
 <![endif]-->
-	<script type="text/javascript" src="view/js/modernizr.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-	<script type="text/javascript" src="view/asset/jquery/dist/jquery.min.js?v={{constant('\Friendica\App::VERSION')}}">
+	<script type="text/javascript" src="view/js/modernizr.js?v={{$VERSION}}"></script>
+	<script type="text/javascript" src="view/asset/jquery/dist/jquery.min.js?v={{$VERSION}}">
 	</script>
-	<script type="text/javascript" src="view/js/jquery.textinputs.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+	<script type="text/javascript" src="view/js/jquery.textinputs.js?v={{$VERSION}}"></script>
 	<script type="text/javascript"
-		src="view/asset/textcomplete/dist/textcomplete.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-	<script type="text/javascript" src="view/js/autocomplete.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+		src="view/asset/textcomplete/dist/textcomplete.min.js?v={{$VERSION}}"></script>
+	<script type="text/javascript" src="view/js/autocomplete.js?v={{$VERSION}}"></script>
 	<script type="text/javascript"
-		src="view/asset/jquery-colorbox/jquery.colorbox-min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-	<script type="text/javascript" src="view/asset/jgrowl/jquery.jgrowl.min.js?v={{constant('\Friendica\App::VERSION')}}">
-	</script>
-	<script type="text/javascript"
-		src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js?v={{constant('\Friendica\App::VERSION')}}">
+		src="view/asset/jquery-colorbox/jquery.colorbox-min.js?v={{$VERSION}}"></script>
+	<script type="text/javascript" src="view/asset/jgrowl/jquery.jgrowl.min.js?v={{$VERSION}}">
 	</script>
 	<script type="text/javascript"
-		src="view/asset/perfect-scrollbar/dist/js/perfect-scrollbar.jquery.min.js?v={{constant('\Friendica\App::VERSION')}}">
+		src="view/asset/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js?v={{$VERSION}}">
 	</script>
 	<script type="text/javascript"
-		src="view/asset/imagesloaded/imagesloaded.pkgd.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-	<script type="text/javascript" src="view/asset/base64/base64.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-	<script type="text/javascript" src="view/asset/dompurify/dist/purify.min.js?v={{constant('\Friendica\App::VERSION')}}">
+		src="view/asset/perfect-scrollbar/dist/js/perfect-scrollbar.jquery.min.js?v={{$VERSION}}">
+	</script>
+	<script type="text/javascript"
+		src="view/asset/imagesloaded/imagesloaded.pkgd.min.js?v={{$VERSION}}"></script>
+	<script type="text/javascript" src="view/asset/base64/base64.min.js?v={{$VERSION}}"></script>
+	<script type="text/javascript" src="view/asset/dompurify/dist/purify.min.js?v={{$VERSION}}">
 	</script>
 	<script type="text/javascript">
 		const updateInterval = {{$update_interval}};
 		const localUser = {{if $local_user}}{{$local_user}}{{else}}false{{/if}};
 	</script>
-	<script type="text/javascript" src="view/js/main.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+	<script type="text/javascript" src="view/js/main.js?v={{$VERSION}}"></script>
 
 	<script type="text/javascript"
-		src="view/theme/frio/frameworks/bootstrap/js/bootstrap.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+		src="view/theme/frio/frameworks/bootstrap/js/bootstrap.min.js?v={{$VERSION}}"></script>
 	<script type="text/javascript"
-		src="view/theme/frio/frameworks/jasny/js/jasny-bootstrap.custom.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+		src="view/theme/frio/frameworks/jasny/js/jasny-bootstrap.custom.js?v={{$VERSION}}"></script>
 	<script type="text/javascript"
-		src="view/theme/frio/frameworks/bootstrap-select/js/bootstrap-select.min.js?v={{constant('\Friendica\App::VERSION')}}">
+		src="view/theme/frio/frameworks/bootstrap-select/js/bootstrap-select.min.js?v={{$VERSION}}">
 	</script>
 	<script type="text/javascript"
-		src="view/theme/frio/frameworks/ekko-lightbox/ekko-lightbox.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+		src="view/theme/frio/frameworks/ekko-lightbox/ekko-lightbox.min.js?v={{$VERSION}}"></script>
 	<script type="text/javascript"
-		src="view/theme/frio/frameworks/justifiedGallery/jquery.justifiedGallery.min.js?v={{constant('\Friendica\App::VERSION')}}">
+		src="view/theme/frio/frameworks/justifiedGallery/jquery.justifiedGallery.min.js?v={{$VERSION}}">
 	</script>
 	<script type="text/javascript"
-		src="view/theme/frio/frameworks/bootstrap-colorpicker/js/bootstrap-colorpicker.min.js?v={{constant('\Friendica\App::VERSION')}}">
+		src="view/theme/frio/frameworks/bootstrap-colorpicker/js/bootstrap-colorpicker.min.js?v={{$VERSION}}">
 	</script>
 	<script type="text/javascript"
-		src="view/theme/frio/frameworks/flexMenu/flexmenu.custom.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+		src="view/theme/frio/frameworks/flexMenu/flexmenu.custom.js?v={{$VERSION}}"></script>
 	<script type="text/javascript"
-		src="view/theme/frio/frameworks/jquery-scrollspy/jquery-scrollspy.js?v={{constant('\Friendica\App::VERSION')}}">
+		src="view/theme/frio/frameworks/jquery-scrollspy/jquery-scrollspy.js?v={{$VERSION}}">
 	</script>
 	<script type="text/javascript"
-		src="view/theme/frio/frameworks/autosize/autosize.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+		src="view/theme/frio/frameworks/autosize/autosize.min.js?v={{$VERSION}}"></script>
 	<script type="text/javascript"
-		src="view/theme/frio/frameworks/sticky-kit/jquery.sticky-kit.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+		src="view/theme/frio/frameworks/sticky-kit/jquery.sticky-kit.min.js?v={{$VERSION}}"></script>
 
 	{{* own js files *}}
-	<script type="text/javascript" src="view/theme/frio/js/theme.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-	<script type="text/javascript" src="view/theme/frio/js/modal.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+	<script type="text/javascript" src="view/theme/frio/js/theme.js?v={{$VERSION}}"></script>
+	<script type="text/javascript" src="view/theme/frio/js/modal.js?v={{$VERSION}}"></script>
 	{{if ! $block_public}}
-		<script type="text/javascript" src="view/theme/frio/js/hovercard.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+		<script type="text/javascript" src="view/theme/frio/js/hovercard.js?v={{$VERSION}}"></script>
 	{{/if}}
-	<script type="text/javascript" src="view/theme/frio/js/textedit.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-	<script type="text/javascript" src="vendor/enyo/dropzone/dist/min/dropzone.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-	<script type="text/javascript" src="view/js/dropzone-factory.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+	<script type="text/javascript" src="view/theme/frio/js/textedit.js?v={{$VERSION}}"></script>
+	<script type="text/javascript" src="vendor/enyo/dropzone/dist/min/dropzone.min.js?v={{$VERSION}}"></script>
+	<script type="text/javascript" src="view/js/dropzone-factory.js?v={{$VERSION}}"></script>
 	<script type="text/javascript"> const dzFactory = new DzFactory({{$max_imagesize}});</script>
-	<script type="text/javascript" src="view/js/fancybox/jquery.fancybox.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-	<script type="text/javascript" src="view/js/fancybox/fancybox.config.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-	<script type="text/javascript" src="view/js/vanillaEmojiPicker/vanillaEmojiPicker.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+	<script type="text/javascript" src="view/js/fancybox/jquery.fancybox.min.js?v={{$VERSION}}"></script>
+	<script type="text/javascript" src="view/js/fancybox/fancybox.config.js?v={{$VERSION}}"></script>
+	<script type="text/javascript" src="view/js/vanillaEmojiPicker/vanillaEmojiPicker.min.js?v={{$VERSION}}"></script>
 	<script>
 	window.onload = function(){
 		new EmojiPicker({

--- a/view/theme/frio/templates/jot-header.tpl
+++ b/view/theme/frio/templates/jot-header.tpl
@@ -1,7 +1,7 @@
 
-<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/js/linkPreview.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/theme/frio/js/jot.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/js/linkPreview.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/theme/frio/js/jot.js?v={{$VERSION}}"></script>
 
 <script type="text/javascript">
 	var editor = false;

--- a/view/theme/frio/templates/moderation/blocklist/contact.tpl
+++ b/view/theme/frio/templates/moderation/blocklist/contact.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen"/>
+<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{$VERSION}}"></script>
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$VERSION}}" type="text/css" media="screen"/>
 
 <div id="admin-contactblock" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}}</h1>

--- a/view/theme/frio/templates/moderation/users/active.tpl
+++ b/view/theme/frio/templates/moderation/users/active.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen"/>
+<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{$VERSION}}"></script>
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$VERSION}}" type="text/css" media="screen"/>
 
 <div id="admin-users" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}} ({{$count}})</h1>

--- a/view/theme/frio/templates/moderation/users/blocked.tpl
+++ b/view/theme/frio/templates/moderation/users/blocked.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen"/>
+<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{$VERSION}}"></script>
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$VERSION}}" type="text/css" media="screen"/>
 
 <div id="admin-users-blocked" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}} ({{$count}})</h1>

--- a/view/theme/frio/templates/moderation/users/deleted.tpl
+++ b/view/theme/frio/templates/moderation/users/deleted.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen"/>
+<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{$VERSION}}"></script>
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$VERSION}}" type="text/css" media="screen"/>
 
 <div id="admin-users" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}} ({{$count}})</h1>

--- a/view/theme/frio/templates/moderation/users/index.tpl
+++ b/view/theme/frio/templates/moderation/users/index.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen"/>
+<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{$VERSION}}"></script>
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$VERSION}}" type="text/css" media="screen"/>
 
 <div id="admin-users" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}} ({{$count}})</h1>

--- a/view/theme/frio/templates/moderation/users/pending.tpl
+++ b/view/theme/frio/templates/moderation/users/pending.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{constant('\Friendica\App::VERSION')}}" type="text/css" media="screen"/>
+<script type="text/javascript" src="view/theme/frio/js/mod_admin.js?v={{$VERSION}}"></script>
+<link rel="stylesheet" href="view/theme/frio/css/mod_admin.css?v={{$VERSION}}" type="text/css" media="screen"/>
 
 <div id="admin-users" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}} ({{$count}})</h1>

--- a/view/theme/frio/templates/notifications/notifications.tpl
+++ b/view/theme/frio/templates/notifications/notifications.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="../../frameworks/jquery-color/jquery.color.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="../../js/mod_notifications.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="../../frameworks/jquery-color/jquery.color.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="../../js/mod_notifications.js?v={{$VERSION}}"></script>
 
 <div class="generic-page-wrapper">
 	{{include file="section_title.tpl" title=$header}}

--- a/view/theme/frio/templates/photos_head.tpl
+++ b/view/theme/frio/templates/photos_head.tpl
@@ -1,5 +1,5 @@
 
-<script type="text/javascript" src="view/theme/frio/js/mod_photos.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script type="text/javascript" src="view/theme/frio/js/mod_photos.js?v={{$VERSION}}"></script>
 <script type="text/javascript">
 	var ispublic = "{{$ispublic nofilter}}";
 </script>

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -1,5 +1,5 @@
-<script src="{{$baseurl}}/view/theme/frio/js/jquery.tools.min.js?v={{constant('\Friendica\App::VERSION')}}"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{constant('\Friendica\App::VERSION')}}"></script>
+<script src="{{$baseurl}}/view/theme/frio/js/jquery.tools.min.js?v={{$VERSION}}"></script>
+<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{$VERSION}}"></script>
 
 <div class="form-group field select">
 	<label for="id_{{$scheme.0}}">{{$scheme.1}}</label>

--- a/view/theme/frio/templates/threaded_conversation.tpl
+++ b/view/theme/frio/templates/threaded_conversation.tpl
@@ -1,5 +1,5 @@
-{{if !$update}}<script type="text/javascript" src="view/theme/frio/frameworks/jquery-color/jquery.color.js?v={{constant('\Friendica\App::VERSION')}}"></script>{{/if}}
-{{if $mode == display}}<script type="text/javascript" src="view/theme/frio/js/mod_display.js?v={{constant('\Friendica\App::VERSION')}}"></script>{{/if}}
+{{if !$update}}<script type="text/javascript" src="view/theme/frio/frameworks/jquery-color/jquery.color.js?v={{$VERSION}}"></script>{{/if}}
+{{if $mode == display}}<script type="text/javascript" src="view/theme/frio/js/mod_display.js?v={{$VERSION}}"></script>{{/if}}
 {{$live_update nofilter}}
 {{foreach $threads as $thread}}
 <hr class="sr-only" />


### PR DESCRIPTION
Add `'$VERSION'` template variable to make Friendica version available in templates

- `constant()` Smarty function is deprecated
- Remove unused site-wide template variable `'$APP'`
- Address [#14027 (comment)](https://github.com/friendica/friendica/issues/14027#issuecomment-2016469408)

Remove duplicated '$baseurl' template variable declarations 

- This variable is declared for all templates in Renderer