### PR TITLE
The visibility of network widgets can now be locked

### DIFF
--- a/src/Content/Feature.php
+++ b/src/Content/Feature.php
@@ -126,16 +126,16 @@ class Feature
 			// Widget visibility on the network stream
 			'network' => [
 				DI::l10n()->t('Network Widgets'),
-				[self::CIRCLES, DI::l10n()->t('Circles'), DI::l10n()->t('Display posts that have been created by accounts of the selected circle.'), true, false, true],
-				[self::GROUPS, DI::l10n()->t('Groups'), DI::l10n()->t('Display posts that have been distributed by the selected group.'), true, false, true],
-				[self::ARCHIVE, DI::l10n()->t('Archives'), DI::l10n()->t('Display an archive where posts can be selected by month and year.'), true, false, true],
-				[self::NETWORKS, DI::l10n()->t('Protocols'), DI::l10n()->t('Display posts with the selected protocols.'), true, false, true],
-				[self::ACCOUNTS, DI::l10n()->t('Account Types'), DI::l10n()->t('Display posts done by accounts with the selected account type.'), true, false, true],
-				[self::CHANNELS, DI::l10n()->t('Channels'), DI::l10n()->t('Display posts in the system channels and user defined channels.'), true, false, true],
-				[self::SEARCHES, DI::l10n()->t('Saved Searches'), DI::l10n()->t('Display posts that contain subscribed hashtags.'), true, false, true],
-				[self::FOLDERS, DI::l10n()->t('Saved Folders'), DI::l10n()->t('Display a list of folders in which posts are stored.'), true, false, true],
-				[self::NOSHARER, DI::l10n()->t('Own Contacts'), DI::l10n()->t('Include or exclude posts from subscribed accounts. This widget is not visible on all channels.'), true, false, true],
-				[self::TRENDING_TAGS,  DI::l10n()->t('Trending Tags'), DI::l10n()->t('Display a list of the most popular tags in recent public posts.'), false, false, true],
+				[self::CIRCLES, DI::l10n()->t('Circles'), DI::l10n()->t('Display posts that have been created by accounts of the selected circle.'), true, DI::config()->get('feature_lock', self::CIRCLES, false)],
+				[self::GROUPS, DI::l10n()->t('Groups'), DI::l10n()->t('Display posts that have been distributed by the selected group.'), true, DI::config()->get('feature_lock', self::GROUPS, false)],
+				[self::ARCHIVE, DI::l10n()->t('Archives'), DI::l10n()->t('Display an archive where posts can be selected by month and year.'), true, DI::config()->get('feature_lock', self::ARCHIVE, false)],
+				[self::NETWORKS, DI::l10n()->t('Protocols'), DI::l10n()->t('Display posts with the selected protocols.'), true, DI::config()->get('feature_lock', self::NETWORKS, false)],
+				[self::ACCOUNTS, DI::l10n()->t('Account Types'), DI::l10n()->t('Display posts done by accounts with the selected account type.'), true, DI::config()->get('feature_lock', self::ACCOUNTS, false)],
+				[self::CHANNELS, DI::l10n()->t('Channels'), DI::l10n()->t('Display posts in the system channels and user defined channels.'), true, DI::config()->get('feature_lock', self::CHANNELS, false)],
+				[self::SEARCHES, DI::l10n()->t('Saved Searches'), DI::l10n()->t('Display posts that contain subscribed hashtags.'), true, DI::config()->get('feature_lock', self::SEARCHES, false)],
+				[self::FOLDERS, DI::l10n()->t('Saved Folders'), DI::l10n()->t('Display a list of folders in which posts are stored.'), true, DI::config()->get('feature_lock', self::FOLDERS, false)],
+				[self::NOSHARER, DI::l10n()->t('Own Contacts'), DI::l10n()->t('Include or exclude posts from subscribed accounts. This widget is not visible on all channels.'), true, DI::config()->get('feature_lock', self::NOSHARER, false)],
+				[self::TRENDING_TAGS,  DI::l10n()->t('Trending Tags'), DI::l10n()->t('Display a list of the most popular tags in recent public posts.'), false, DI::config()->get('feature_lock', self::TRENDING_TAGS, false)],
 			],
 
 			// Advanced Profile Settings

--- a/src/Module/Admin/Features.php
+++ b/src/Module/Admin/Features.php
@@ -64,11 +64,10 @@ class Features extends BaseAdmin
 			$features[$fname][0] = $fdata[0];
 			foreach (array_slice($fdata, 1) as $f) {
 				$set = DI::config()->get('feature', $f[0], $f[3]);
-				$feature = [['feature_' . $f[0], $f[1], $set, $f[2]]];
-				if (empty($f[5])) {
-					$feature[] = ['featurelock_' . $f[0], DI::l10n()->t('Lock feature %s', $f[1]), $f[4], ''];
-				}
-				$features[$fname][1][] = $feature;
+				$features[$fname][1][] = [
+					['feature_' . $f[0], $f[1], $set, $f[2]],
+					['featurelock_' . $f[0], DI::l10n()->t('Lock feature %s', $f[1]), $f[4], '']
+				];
 			}
 		}
 

--- a/view/theme/frio/templates/admin/features.tpl
+++ b/view/theme/frio/templates/admin/features.tpl
@@ -18,9 +18,7 @@
 							{{foreach $f.1 as $fcat}}
 								<div class="settings-block">
 									{{include file="field_checkbox.tpl" field=$fcat.0}}
-									{{if $fcat.1}}
-										{{include file="field_checkbox.tpl" field=$fcat.1}}
-									{{/if}}
+									{{include file="field_checkbox.tpl" field=$fcat.1}}
 								</div>
 							{{/foreach}}
 						</div>


### PR DESCRIPTION
Addition to PR https://github.com/friendica/friendica/pull/14039

The possibility to disable the feature lock is disabled. This coding had been added due to some misunderstanding of the functionality.