### PR TITLE
Simplified admin frontend for features

### DIFF
--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2024.06-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-25 07:19+0000\n"
+"POT-Creation-Date: 2024-03-25 21:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1654,191 +1654,191 @@ msgstr ""
 msgid "Favourite Posts"
 msgstr ""
 
-#: src/Content/Feature.php:106
+#: src/Content/Feature.php:107
 msgid "General Features"
 msgstr ""
 
-#: src/Content/Feature.php:108
+#: src/Content/Feature.php:109
 msgid "Photo Location"
 msgstr ""
 
-#: src/Content/Feature.php:108
+#: src/Content/Feature.php:109
 msgid ""
 "Photo metadata is normally stripped. This extracts the location (if present) "
 "prior to stripping metadata and links it to a map."
 msgstr ""
 
-#: src/Content/Feature.php:109
+#: src/Content/Feature.php:110
 msgid "Display the community in the navigation"
 msgstr ""
 
-#: src/Content/Feature.php:109
+#: src/Content/Feature.php:110
 msgid ""
 "If enabled, the community can be accessed via the navigation menu. "
 "Independant from this setting, the community timelines can always be "
 "accessed via the channels."
 msgstr ""
 
-#: src/Content/Feature.php:114
+#: src/Content/Feature.php:115
 msgid "Post Composition Features"
 msgstr ""
 
-#: src/Content/Feature.php:115
+#: src/Content/Feature.php:116
 msgid "Explicit Mentions"
 msgstr ""
 
-#: src/Content/Feature.php:115
+#: src/Content/Feature.php:116
 msgid ""
 "Add explicit mentions to comment box for manual control over who gets "
 "mentioned in replies."
 msgstr ""
 
-#: src/Content/Feature.php:116
+#: src/Content/Feature.php:117
 msgid "Add an abstract from ActivityPub content warnings"
 msgstr ""
 
-#: src/Content/Feature.php:116
+#: src/Content/Feature.php:117
 msgid ""
 "Add an abstract when commenting on ActivityPub posts with a content warning. "
 "Abstracts are displayed as content warning on systems like Mastodon or "
 "Pleroma."
 msgstr ""
 
-#: src/Content/Feature.php:121
+#: src/Content/Feature.php:122
 msgid "Post/Comment Tools"
 msgstr ""
 
-#: src/Content/Feature.php:122
+#: src/Content/Feature.php:123
 msgid "Post Categories"
 msgstr ""
 
-#: src/Content/Feature.php:122
+#: src/Content/Feature.php:123
 msgid "Add categories to your posts"
 msgstr ""
 
-#: src/Content/Feature.php:127
+#: src/Content/Feature.php:128
 msgid "Network Widgets"
 msgstr ""
 
-#: src/Content/Feature.php:128 src/Content/Widget.php:216
+#: src/Content/Feature.php:129 src/Content/Widget.php:216
 #: src/Model/Circle.php:601 src/Module/Contact.php:400
 #: src/Module/Welcome.php:76
 msgid "Circles"
 msgstr ""
 
-#: src/Content/Feature.php:128
+#: src/Content/Feature.php:129
 msgid ""
 "Display posts that have been created by accounts of the selected circle."
 msgstr ""
 
-#: src/Content/Feature.php:129 src/Content/GroupManager.php:147
+#: src/Content/Feature.php:130 src/Content/GroupManager.php:147
 #: src/Content/Nav.php:278 src/Content/Text/HTML.php:881
 #: src/Content/Widget.php:538 src/Model/User.php:1385
 msgid "Groups"
 msgstr ""
 
-#: src/Content/Feature.php:129
+#: src/Content/Feature.php:130
 msgid "Display posts that have been distributed by the selected group."
 msgstr ""
 
-#: src/Content/Feature.php:130 src/Content/Widget.php:507
+#: src/Content/Feature.php:131 src/Content/Widget.php:507
 msgid "Archives"
 msgstr ""
 
-#: src/Content/Feature.php:130
+#: src/Content/Feature.php:131
 msgid "Display an archive where posts can be selected by month and year."
 msgstr ""
 
-#: src/Content/Feature.php:131 src/Content/Widget.php:289
+#: src/Content/Feature.php:132 src/Content/Widget.php:289
 msgid "Protocols"
 msgstr ""
 
-#: src/Content/Feature.php:131
+#: src/Content/Feature.php:132
 msgid "Display posts with the selected protocols."
 msgstr ""
 
-#: src/Content/Feature.php:132 src/Content/Widget.php:544
+#: src/Content/Feature.php:133 src/Content/Widget.php:544
 #: src/Module/Settings/Account.php:442
 msgid "Account Types"
 msgstr ""
 
-#: src/Content/Feature.php:132
+#: src/Content/Feature.php:133
 msgid "Display posts done by accounts with the selected account type."
 msgstr ""
 
-#: src/Content/Feature.php:133 src/Content/Widget.php:593
+#: src/Content/Feature.php:134 src/Content/Widget.php:593
 #: src/Module/Admin/Site.php:474 src/Module/BaseSettings.php:125
 #: src/Module/Settings/Channels.php:219 src/Module/Settings/Display.php:318
 msgid "Channels"
 msgstr ""
 
-#: src/Content/Feature.php:133
+#: src/Content/Feature.php:134
 msgid "Display posts in the system channels and user defined channels."
 msgstr ""
 
-#: src/Content/Feature.php:134 src/Content/Widget/SavedSearches.php:60
+#: src/Content/Feature.php:135 src/Content/Widget/SavedSearches.php:60
 msgid "Saved Searches"
 msgstr ""
 
-#: src/Content/Feature.php:134
+#: src/Content/Feature.php:135
 msgid "Display posts that contain subscribed hashtags."
 msgstr ""
 
-#: src/Content/Feature.php:135 src/Content/Widget.php:319
+#: src/Content/Feature.php:136 src/Content/Widget.php:319
 msgid "Saved Folders"
 msgstr ""
 
-#: src/Content/Feature.php:135
+#: src/Content/Feature.php:136
 msgid "Display a list of folders in which posts are stored."
 msgstr ""
 
-#: src/Content/Feature.php:136 src/Module/Conversation/Timeline.php:196
+#: src/Content/Feature.php:137 src/Module/Conversation/Timeline.php:196
 msgid "Own Contacts"
 msgstr ""
 
-#: src/Content/Feature.php:136
+#: src/Content/Feature.php:137
 msgid ""
 "Include or exclude posts from subscribed accounts. This widget is not "
 "visible on all channels."
 msgstr ""
 
-#: src/Content/Feature.php:137
+#: src/Content/Feature.php:138
 msgid "Trending Tags"
 msgstr ""
 
-#: src/Content/Feature.php:137
+#: src/Content/Feature.php:138
 msgid "Display a list of the most popular tags in recent public posts."
 msgstr ""
 
-#: src/Content/Feature.php:142
+#: src/Content/Feature.php:143
 msgid "Advanced Profile Settings"
 msgstr ""
 
-#: src/Content/Feature.php:143
+#: src/Content/Feature.php:144
 msgid "Tag Cloud"
 msgstr ""
 
-#: src/Content/Feature.php:143
+#: src/Content/Feature.php:144
 msgid "Provide a personal tag cloud on your profile page"
 msgstr ""
 
-#: src/Content/Feature.php:144
+#: src/Content/Feature.php:145
 msgid "Display Membership Date"
 msgstr ""
 
-#: src/Content/Feature.php:144
+#: src/Content/Feature.php:145
 msgid "Display membership date in profile"
 msgstr ""
 
-#: src/Content/Feature.php:149
+#: src/Content/Feature.php:150
 msgid "Advanced Calendar Settings"
 msgstr ""
 
-#: src/Content/Feature.php:150
+#: src/Content/Feature.php:151
 msgid "Allow anonymous access to your calendar"
 msgstr ""
 
-#: src/Content/Feature.php:150
+#: src/Content/Feature.php:151
 msgid ""
 "Allows anonymous visitors to consult your calendar and your public events. "
 "Contact birthday events are private to you."
@@ -4038,7 +4038,7 @@ msgstr ""
 msgid "Addon %s failed to install."
 msgstr ""
 
-#: src/Module/Admin/Addons/Index.php:69 src/Module/Admin/Features.php:80
+#: src/Module/Admin/Addons/Index.php:69 src/Module/Admin/Features.php:83
 #: src/Module/Admin/Logs/Settings.php:87 src/Module/Admin/Site.php:460
 #: src/Module/Admin/Themes/Index.php:113 src/Module/Admin/Tos.php:86
 #: src/Module/Settings/Account.php:551 src/Module/Settings/Addons.php:78
@@ -4120,12 +4120,25 @@ msgstr ""
 msgid "Attempt to execute this update step automatically"
 msgstr ""
 
-#: src/Module/Admin/Features.php:69
-#, php-format
-msgid "Lock feature %s"
+#: src/Module/Admin/Features.php:67
+#: src/Module/Notifications/Introductions.php:144
+#: src/Module/OAuth/Acknowledge.php:55 src/Module/Register.php:132
+#: src/Module/Settings/TwoFactor/Trusted.php:129
+msgid "No"
 msgstr ""
 
-#: src/Module/Admin/Features.php:78
+#: src/Module/Admin/Features.php:67 src/Module/Contact/Revoke.php:108
+#: src/Module/Notifications/Introductions.php:144
+#: src/Module/OAuth/Acknowledge.php:54 src/Module/Register.php:131
+#: src/Module/Settings/TwoFactor/Trusted.php:129
+msgid "Yes"
+msgstr ""
+
+#: src/Module/Admin/Features.php:67
+msgid "Locked"
+msgstr ""
+
+#: src/Module/Admin/Features.php:81
 msgid "Manage Additional Features"
 msgstr ""
 
@@ -7058,13 +7071,6 @@ msgid ""
 "and they will have to manually follow you back again."
 msgstr ""
 
-#: src/Module/Contact/Revoke.php:108
-#: src/Module/Notifications/Introductions.php:144
-#: src/Module/OAuth/Acknowledge.php:54 src/Module/Register.php:131
-#: src/Module/Settings/TwoFactor/Trusted.php:129
-msgid "Yes"
-msgstr ""
-
 #: src/Module/Contact/Suggestions.php:62
 msgid ""
 "No suggestions available. If this is a new site, please try again in 24 "
@@ -8831,12 +8837,6 @@ msgstr ""
 
 #: src/Module/Notifications/Introductions.php:143
 msgid "Claims to be known to you: "
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:144
-#: src/Module/OAuth/Acknowledge.php:55 src/Module/Register.php:132
-#: src/Module/Settings/TwoFactor/Trusted.php:129
-msgid "No"
 msgstr ""
 
 #: src/Module/Notifications/Introductions.php:152

--- a/view/templates/admin/features.tpl
+++ b/view/templates/admin/features.tpl
@@ -10,8 +10,7 @@
 	<div class="settings-content-block">
 		{{foreach $f.1 as $fcat}}
 			<div class="settings-block">
-			{{include file="field_checkbox.tpl" field=$fcat.0}}
-			{{include file="field_checkbox.tpl" field=$fcat.1}}
+			{{include file="field_select.tpl" field=$fcat}}
 			</div>
 		{{/foreach}}
 

--- a/view/theme/frio/templates/admin/features.tpl
+++ b/view/theme/frio/templates/admin/features.tpl
@@ -17,8 +17,7 @@
 						<div class="panel-body">
 							{{foreach $f.1 as $fcat}}
 								<div class="settings-block">
-									{{include file="field_checkbox.tpl" field=$fcat.0}}
-									{{include file="field_checkbox.tpl" field=$fcat.1}}
+									{{include file="field_select.tpl" field=$fcat}}
 								</div>
 							{{/foreach}}
 						</div>


### PR DESCRIPTION
The admin frontend for the features had been slightly confusing, since it had been unclear in which state the "lock" setting locked the feature. It is now a single select box instead of two checkboxes.