### PR TITLE
frio theme: a little padding for the mobile view

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3824,8 +3824,8 @@ section .profile-match-wrapper {
 	}
 
 	.container {
-		padding-right: 0;
-		padding-left: 0;
+		padding-right: 5px;
+		padding-left: 5px;
 	}
 
 	.panel {


### PR DESCRIPTION
I thought it is not optimal to have no padding on the mobile view on the left and right sides. With the 5px it looks maybe a little better (at least on my smartphone). 
