### PR TITLE
Add some padding for the login page at mobile width (frio)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3849,6 +3849,12 @@ section .profile-match-wrapper {
 		margin-top: 0;
 	}
 
+	.mod-home.is-not-singleuser,
+	.mod-login {
+		padding-left: 10px;
+		padding-right: 10px;
+	}
+
 	.generic-page-wrapper,
 	.videos-content-wrapper,
 	.suggest-content-wrapper,


### PR DESCRIPTION
Again, an attempt to add some padding for the login page of the `frio` theme for mobile width.

I tried different things and ended up creating 2 new `div`s for the 2 classes `login-content` and `login-form` (because otherwise the new padding conflicted with the padding of another class), and  then I have added the padding in the mobile section of `style.css`.

should fix https://github.com/friendica/friendica/issues/14053