### PR TITLE
Don't set posts to seen on channel ping

### DIFF
--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -378,6 +378,11 @@ class Network extends Timeline
 		}
 	}
 
+	protected function setPing(bool $ping)
+	{
+		$this->ping = $ping;
+	}
+
 	protected function getItems()
 	{
 		$conditionFields  = ['uid' => $this->session->getLocalUserId()];

--- a/src/Module/Conversation/Timeline.php
+++ b/src/Module/Conversation/Timeline.php
@@ -71,6 +71,8 @@ class Timeline extends BaseModule
 	/** @var bool */
 	protected $update;
 	/** @var bool */
+	protected $ping;
+	/** @var bool */
 	protected $raw;
 	/** @var string */
 	protected $order;
@@ -823,7 +825,7 @@ class Timeline extends BaseModule
 	 */
 	protected function setItemsSeenByCondition(array $condition)
 	{
-		if (empty($condition)) {
+		if (empty($condition) || $this->ping) {
 			return;
 		}
 

--- a/src/Module/Ping/Network.php
+++ b/src/Module/Ping/Network.php
@@ -46,6 +46,7 @@ class Network extends NetworkModule
 			System::httpExit('');
 		}
 
+		$this->setPing(true);
 		$this->itemsPerPage = 100;
 
 		if ($this->channel->isTimeline($this->selectedTab) || $this->userDefinedChannel->isTimeline($this->selectedTab, $this->session->getLocalUserId())) {


### PR DESCRIPTION
The `ping` functonality set the `unseen` field - which caused the profile counter always set to zero.