### PR TITLE
round scaled dimensions up to avoid zero size

### DIFF
--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -591,6 +591,9 @@ class Image
 		if (!$this->isValid()) {
 			return false;
 		}
+		if ($dest_width <= 0 || $dest_height <= 0) {
+			return false;
+		}
 
 		if ($this->isImagick()) {
 			/*

--- a/src/Util/Images.php
+++ b/src/Util/Images.php
@@ -418,19 +418,19 @@ class Images
 
 			if ((($height * 9) / 16) > $width) {
 				$dest_width = $max;
-				$dest_height = intval(($height * $max) / $width);
+				$dest_height = intval(ceil(($height * $max) / $width));
 			} elseif ($width > $height) {
 				// else constrain both dimensions
 				$dest_width = $max;
-				$dest_height = intval(($height * $max) / $width);
+				$dest_height = intval(ceil(($height * $max) / $width));
 			} else {
-				$dest_width = intval(($width * $max) / $height);
+				$dest_width = intval(ceil(($width * $max) / $height));
 				$dest_height = $max;
 			}
 		} else {
 			if ($width > $max) {
 				$dest_width = $max;
-				$dest_height = intval(($height * $max) / $width);
+				$dest_height = intval(ceil(($height * $max) / $width));
 			} else {
 				if ($height > $max) {
 					// very tall image (greater than 16:9)
@@ -440,7 +440,7 @@ class Images
 						$dest_width = $width;
 						$dest_height = $height;
 					} else {
-						$dest_width = intval(($width * $max) / $height);
+						$dest_width = intval(ceil(($width * $max) / $height));
 						$dest_height = $max;
 					}
 				} else {

--- a/tests/src/Util/ImagesTest.php
+++ b/tests/src/Util/ImagesTest.php
@@ -96,4 +96,104 @@ class ImagesTest extends MockedTest
 
 		self::assertArraySubset($assertion, Images::getInfoFromURL($url));
 	}
+
+	public function dataScalingDimensions()
+	{
+		return [
+			'landscape' => [
+				'width' => 640,
+				'height' => 480,
+				'max' => 320,
+				'assertion' => [
+					'width' => 320,
+					'height' => 240,
+				]
+			],
+			'wide_landscape' => [
+				'width' => 640,
+				'height' => 120,
+				'max' => 320,
+				'assertion' => [
+					'width' => 320,
+					'height' => 60,
+				]
+			],
+			'landscape_round_up' => [
+				'width' => 640,
+				'height' => 479,
+				'max' => 320,
+				'assertion' => [
+					'width' => 320,
+					'height' => 240,
+				]
+			],
+			'landscape_zero_height' => [
+				'width' => 640,
+				'height' => 1,
+				'max' => 160,
+				'assertion' => [
+					'width' => 160,
+					'height' => 1,
+				]
+			],
+			'portrait' => [
+				'width' => 480,
+				'height' => 640,
+				'max' => 320,
+				'assertion' => [
+					'width' => 240,
+					'height' => 320,
+				]
+			],
+			// For portrait with aspect ratio <= 16:9, constrain height
+			'portrait_16_9' => [
+				'width' => 1080,
+				'height' => 1920,
+				'max' => 320,
+				'assertion' => [
+					'width' => 180,
+					'height' => 320,
+				]
+			],
+			// For portrait with aspect ratio > 16:9, constrain width
+			'portrait_over_16_9_too_wide' => [
+				'width' => 1080,
+				'height' => 1921,
+				'max' => 320,
+				'assertion' => [
+					'width' => 320,
+					'height' => 570,
+				]
+			],
+			// For portrait with aspect ratio > 16:9, constrain width
+			'portrait_over_16_9_not_too_wide' => [
+				'width' => 1080,
+				'height' => 1921,
+				'max' => 1080,
+				'assertion' => [
+					'width' => 1080,
+					'height' => 1921,
+				]
+			],
+			'portrait_round_up' => [
+				'width' => 479,
+				'height' => 640,
+				'max' => 320,
+				'assertion' => [
+					'width' => 240,
+					'height' => 320,
+				]
+			],
+		];
+	}
+
+	/**
+	 * Test the Images::getScalingDimensions() method
+	 *
+	 * @dataProvider dataScalingDimensions
+	 */
+	public function testGetScalingDimensions(int $width, int $height, int $max, array $assertion)
+	{
+		self::assertArraySubset($assertion, Images::getScalingDimensions($width, $height, $max));
+	}
 }


### PR DESCRIPTION
This bug surfaced in my own plugin that scrapes content from websites, when it tries to insert an extremely non-square image such as https://ichef.bbci.co.uk/news/624/cpsprodpb/179B9/production/_106279669_fb1c6c40-2f65-4fc3-9432-c4967c0d59c7.jpg which is 624x2 pixels big.  It attempts to scale the image to a maximum of 90 pixels (hard-coded).  Using `intval`, this produces a height of 0 pixels.  Imagemagick then throws an exception trying to resize it.

This change rounds upwards.  It also includes an early return in the `scale()` function when asked to scale an image to zero size, treating this the same as an invalid image.