### PR TITLE
Don't display the "follow/unfollow" vcard-link on pages meant for follow/unfollow

### DIFF
--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -43,9 +43,10 @@ class VCard
 	 * @template widget/vcard.tpl
 	 * @param array $contact
 	 * @param bool  $hide_mention
+	 * @param bool  $hide_follow
 	 * @return string
 	 */
-	public static function getHTML(array $contact, bool $hide_mention = false): string
+	public static function getHTML(array $contact, bool $hide_mention = false, bool $hide_follow = false): string
 	{
 		if (!isset($contact['network']) || !isset($contact['id'])) {
 			Logger::warning('Incomplete contact', ['contact' => $contact ?? []]);
@@ -87,7 +88,7 @@ class VCard
 				}
 			}
 
-			if (empty($contact['self']) && Protocol::supportsFollow($contact['network'])) {
+			if (!$hide_follow && empty($contact['self']) && Protocol::supportsFollow($contact['network'])) {
 				if (in_array($rel, [Contact::SHARING, Contact::FRIEND])) {
 					$unfollow_link = 'contact/unfollow?url=' . urlencode($contact_url) . '&auto=1';
 				} elseif (!$pending) {

--- a/src/Module/Contact/Follow.php
+++ b/src/Module/Contact/Follow.php
@@ -186,7 +186,7 @@ class Follow extends BaseModule
 		$this->page['aside'] = '';
 
 		if (!in_array($protocol, [Protocol::PHANTOM, Protocol::MAIL])) {
-			$this->page['aside'] = VCard::getHTML($contact);
+			$this->page['aside'] = VCard::getHTML($contact, false, true);
 
 			$output .= Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'),
 				['$title' => $this->t('Posts and Replies')]

--- a/src/Module/Contact/Unfollow.php
+++ b/src/Module/Contact/Unfollow.php
@@ -133,7 +133,7 @@ class Unfollow extends \Friendica\BaseModule
 			'$keywords_label' => ''
 		]);
 
-		$this->page['aside'] = Widget\VCard::getHTML(Contact::getByURL($contact['url'], false));
+		$this->page['aside'] = Widget\VCard::getHTML(Contact::getByURL($contact['url'], false), false, true);
 
 		$o .= Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), ['$title' => $this->t('Posts and Replies')]);
 

--- a/src/Module/Profile/RemoteFollow.php
+++ b/src/Module/Profile/RemoteFollow.php
@@ -118,7 +118,7 @@ class RemoteFollow extends BaseModule
 
 	protected function content(array $request = []): string
 	{
-		$this->page['aside'] = Widget\VCard::getHTML($this->owner);
+		$this->page['aside'] = Widget\VCard::getHTML($this->owner, false, true);
 
 		$target_addr = $this->owner['addr'];
 		$target_url  = $this->owner['url'];


### PR DESCRIPTION
It is confusing for users to have a "follow" link in the vcard section on the follow/unfollow page. 