### PR TITLE
allow overriding password during local testing

### DIFF
--- a/bin/dev/autotest.sh
+++ b/bin/dev/autotest.sh
@@ -152,8 +152,8 @@ function execute_tests() {
             echo "To use the docker container set the USEDOCKER environment variable"
             exit 3
           fi
-          mysql -u "${DATABASE_USER}" -pfriendica -e "DROP DATABASE IF EXISTS ${DATABASE_NAME}" -h ${DATABASE_HOST} || true
-          mysql -u "${DATABASE_USER}" -pfriendica -e "CREATE DATABASE ${DATABASE_NAME} DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" -h ${DATABASE_HOST}
+          mysql -u "${DATABASE_USER}" -p"${DATABASE_PASSWORD}" -e "DROP DATABASE IF EXISTS ${DATABASE_NAME}" -h ${DATABASE_HOST} || true
+          mysql -u "${DATABASE_USER}" -p"${DATABASE_PASSWORD}" -e "CREATE DATABASE ${DATABASE_NAME} DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" -h ${DATABASE_HOST}
         else
           DATABASE_HOST=mysql
         fi
@@ -185,8 +185,8 @@ function execute_tests() {
             echo "To use the docker container set the USEDOCKER environment variable"
             exit 3
           fi
-          mysql -u "${DATABASE_USER}" -pfriendica -e "DROP DATABASE IF EXISTS ${DATABASE_NAME}" -h ${DATABASE_HOST} || true
-          mysql -u "${DATABASE_USER}" -pfriendica -e "CREATE DATABASE ${DATABASE_NAME} DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" -h ${DATABASE_HOST}
+          mysql -u "${DATABASE_USER}" -p"${DATABASE_PASSWORD}" -e "DROP DATABASE IF EXISTS ${DATABASE_NAME}" -h ${DATABASE_HOST} || true
+          mysql -u "${DATABASE_USER}" -p"${DATABASE_PASSWORD}" -e "CREATE DATABASE ${DATABASE_NAME} DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" -h ${DATABASE_HOST}
         else
           DATABASE_HOST=mariadb
         fi
@@ -203,7 +203,7 @@ function execute_tests() {
 
     if [ -n "${USEDOCKER}" ]; then
       echo "Initialize database..."
-      docker exec ${DOCKER_CONTAINER_ID} mysql -u root -pfriendica -e "CREATE DATABASE IF NOT EXISTS ${DATABASE_NAME};"
+      docker exec ${DOCKER_CONTAINER_ID} mysql -u root -p"${DATABASE_PASSWORD}" -e "CREATE DATABASE IF NOT EXISTS ${DATABASE_NAME};"
     fi
 
     export MYSQL_HOST="${DATABASE_HOST}"

--- a/bin/dev/autotest.sh
+++ b/bin/dev/autotest.sh
@@ -138,9 +138,9 @@ function execute_tests() {
       if [ -n "${USEDOCKER}" ]; then
         echo "Fire up the mysql docker"
         DOCKER_CONTAINER_ID=$(docker run \
-          -e MYSQL_ROOT_PASSWORD=friendica \
+          -e MYSQL_ROOT_PASSWORD="${DATABASE_PASSWORD}" \
           -e MYSQL_USER="${DATABASE_USER}" \
-          -e MYSQL_PASSWORD=friendica \
+          -e MYSQL_PASSWORD="${DATABASE_PASSWORD}" \
           -e MYSQL_DATABASE="${DATABASE_NAME}" \
           -d mysql)
         DATABASE_HOST=$(docker inspect --format="{{.NetworkSettings.IPAddress}}" "${DOCKER_CONTAINER_ID}")
@@ -171,9 +171,9 @@ function execute_tests() {
       if [ -n "${USEDOCKER}" ]; then
         echo "Fire up the mariadb docker"
         DOCKER_CONTAINER_ID=$(docker run \
-          -e MYSQL_ROOT_PASSWORD=friendica \
+          -e MYSQL_ROOT_PASSWORD="${DATABASE_PASSWORD}" \
           -e MYSQL_USER="${DATABASE_USER}" \
-          -e MYSQL_PASSWORD=friendica \
+          -e MYSQL_PASSWORD="${DATABASE_PASSWORD}" \
           -e MYSQL_DATABASE="${DATABASE_NAME}" \
           -d mariadb)
         DATABASE_HOST=$(docker inspect --format="{{.NetworkSettings.IPAddress}}" "${DOCKER_CONTAINER_ID}")
@@ -210,7 +210,7 @@ function execute_tests() {
 
     #call installer
     echo "Installing Friendica..."
-    "${PHP}" ./bin/console.php autoinstall --dbuser="${DATABASE_USER}" --dbpass=friendica --dbdata="${DATABASE_NAME}" --dbhost="${DATABASE_HOST}" --url=https://friendica.local --admin=admin@friendica.local
+    "${PHP}" ./bin/console.php autoinstall --dbuser="${DATABASE_USER}" --dbpass="${DATABASE_PASSWORD}" --dbdata="${DATABASE_NAME}" --dbhost="${DATABASE_HOST}" --url=https://friendica.local --admin=admin@friendica.local
   fi
 
   #test execution


### PR DESCRIPTION
I had difficulty testing with the new `autotest.sh` script because it hard-codes the password.  This change allows overriding the password with environment variables, as documented, and have that actually work.