### PR TITLE
"self::" should be "$this->" on non static functions

### DIFF
--- a/src/Module/Conversation/Timeline.php
+++ b/src/Module/Conversation/Timeline.php
@@ -461,7 +461,7 @@ class Timeline extends BaseModule
 
 		if (!empty($channel->fullTextSearch)) {
 			if (!empty($channel->includeTags)) {
-				$additional = self:: addIncludeTags($channel->includeTags);
+				$additional = $this->addIncludeTags($channel->includeTags);
 			} else {
 				$additional = '';
 			}
@@ -473,10 +473,10 @@ class Timeline extends BaseModule
 			}
 
 			if (!empty($channel->mediaType)) {
-				$additional .= self::addMediaTerms($channel->mediaType);
+				$additional .= $this->addMediaTerms($channel->mediaType);
 			}
 
-			$additional .= self::addLanguageSearchTerms($uid, $channel->languages);
+			$additional .= $this->addLanguageSearchTerms($uid, $channel->languages);
 
 			if ($additional) {
 				$searchterms = '+(' . trim($channel->fullTextSearch) . ')' . $additional;


### PR DESCRIPTION
This is just a small fix that hasn't any influence on the functionality.

I found it, while I had a look on how to move some of these functions to a central place. A question for @MrPetovan or @nupplaphil: I want to move the functionality of the function `getChannelItems` that is currently in the timeline module to a place where I can call it from the API as well. Where would that be?