### PR TITLE
API: Access channels and groups via lists

### DIFF
--- a/src/Factory/Api/Mastodon/ListEntity.php
+++ b/src/Factory/Api/Mastodon/ListEntity.php
@@ -22,6 +22,7 @@
 namespace Friendica\Factory\Api\Mastodon;
 
 use Friendica\BaseFactory;
+use Friendica\Content\Conversation\Entity\Timeline;
 use Friendica\Database\Database;
 use Friendica\Network\HTTPException\InternalServerErrorException;
 use Psr\Log\LoggerInterface;
@@ -44,5 +45,15 @@ class ListEntity extends BaseFactory
 	{
 		$circle = $this->dba->selectFirst('group', ['name'], ['id' => $id, 'deleted' => false]);
 		return new \Friendica\Object\Api\Mastodon\ListEntity($id, $circle['name'] ?? '', 'list');
+	}
+
+	public function createFromChannel(Timeline $channel): \Friendica\Object\Api\Mastodon\ListEntity
+	{
+		return new \Friendica\Object\Api\Mastodon\ListEntity('channel:' . $channel->code, $channel->label, 'followed');
+	}
+
+	public function createFromGroup(array $group): \Friendica\Object\Api\Mastodon\ListEntity
+	{
+		return new \Friendica\Object\Api\Mastodon\ListEntity('group:' . $group['id'], $group['name'], 'followed');
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -21,21 +21,39 @@
 
 namespace Friendica\Module\Api\Mastodon\Timelines;
 
+use Friendica\App;
+use Friendica\Core\L10n;
 use Friendica\Core\Logger;
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Model\Contact;
+use Friendica\Model\Conversation;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
+use Friendica\Model\Verb;
+use Friendica\Module\Api\ApiResponse;
 use Friendica\Module\BaseApi;
+use Friendica\Module\Conversation\Timeline;
 use Friendica\Network\HTTPException;
 use Friendica\Object\Api\Mastodon\TimelineOrderByTypes;
+use Friendica\Protocol\Activity;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/
  */
 class ListTimeline extends BaseApi
 {
+	/** @var Timeline */
+	protected $timeline;
+
+	public function __construct(Timeline $timeline, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	{
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		$this->timeline = $timeline;
+	}
+
 	/**
 	 * @throws HTTPException\InternalServerErrorException
 	 */
@@ -61,6 +79,70 @@ class ListTimeline extends BaseApi
 			'friendica_order' => TimelineOrderByTypes::ID, // Sort order options (defaults to ID)
 		], $request);
 
+		$display_quotes = self::appSupportsQuotes();
+
+		if (substr($this->parameters['id'], 0, 6) == 'group:') {
+			$items = $this->getStatusesForGroup($uid, $request);
+		} elseif (substr($this->parameters['id'], 0, 8) == 'channel:') {
+			$items = $this->getStatusesForChannel($uid, $request);
+		} else{
+			$items = $this->getStatusesForCircle($uid, $request);
+		}
+
+		$statuses = [];
+		foreach ($items as $item) {
+			try {
+				$status =  DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, $display_quotes);
+				$this->updateBoundaries($status, $item, $request['friendica_order']);
+				$statuses[] = $status;
+			} catch (\Throwable $th) {
+				Logger::info('Post not fetchable', ['uri-id' => $item['uri-id'], 'uid' => $uid, 'error' => $th]);
+			}
+		}
+
+		if (!empty($request['min_id'])) {
+			$statuses = array_reverse($statuses);
+		}
+
+		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
+		$this->jsonExit($statuses);
+	}
+
+	private function getStatusesForGroup(int $uid, array $request): array
+	{
+		$cdata = Contact::getPublicAndUserContactID((int)substr($this->parameters['id'], 6), $uid);
+		$cid = $cdata['public'];
+
+		$condition = ["(`uid` = ? OR (`uid` = ? AND NOT `global`))", 0, $uid];
+
+		$condition1 = DBA::mergeConditions($condition, ["`owner-id` = ? AND `gravity` = ?", $cid, Item::GRAVITY_PARENT]);
+
+		$condition2 = DBA::mergeConditions($condition, [
+			"`author-id` = ? AND `gravity` = ? AND `vid` = ? AND `protocol` != ? AND `thr-parent-id` = `parent-uri-id`",
+			$cid, Item::GRAVITY_ACTIVITY, Verb::getID(Activity::ANNOUNCE), Conversation::PARCEL_DIASPORA
+		]);
+
+		$condition1 = $this->addPagingConditions($request, $condition1);
+		$condition2 = $this->addPagingConditions($request, $condition2);
+
+		$sql1 = "SELECT `uri-id` FROM `post-thread-user-view` WHERE " . array_shift($condition1);
+		$sql2 = "SELECT `thr-parent-id` AS `uri-id` FROM `post-user-view` WHERE " . array_shift($condition2);
+
+		$condition = array_merge($condition1, $condition2);
+		$sql       = $sql1 . " UNION " . $sql2 . " GROUP BY `uri-id` " . DBA::buildParameter($this->buildOrderAndLimitParams($request));
+
+		return Post::toArray(DBA::p($sql, $condition));
+	}
+
+	private function getStatusesForChannel(int $uid, array $request): array
+	{
+		$request['friendica_order'] = TimelineOrderByTypes::ID;
+
+		return $this->timeline->getChannelItemsForAPI(substr($this->parameters['id'], 8), $uid, $request['limit'], $request['min_id'], $request['max_id']);
+	}
+
+	private function getStatusesForCircle(int $uid, array $request): array
+	{
 		$condition = [
 			"`uid` = ? AND `gravity` IN (?, ?) AND `contact-id` IN (SELECT `contact-id` FROM `group_member` WHERE `gid` = ?)",
 			$uid, Item::GRAVITY_PARENT, Item::GRAVITY_COMMENT, $this->parameters['id']
@@ -89,26 +171,6 @@ class ListTimeline extends BaseApi
 		}
 
 		$items = Post::selectTimelineForUser($uid, ['uri-id'], $condition, $params);
-
-		$display_quotes = self::appSupportsQuotes();
-
-		$statuses = [];
-		while ($item = Post::fetch($items)) {
-			try {
-				$status =  DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, $display_quotes);
-				$this->updateBoundaries($status, $item, $request['friendica_order']);
-				$statuses[] = $status;
-			} catch (\Throwable $th) {
-				Logger::info('Post not fetchable', ['uri-id' => $item['uri-id'], 'uid' => $uid, 'error' => $th]);
-			}
-		}
-		DBA::close($items);
-
-		if (!empty($request['min_id'])) {
-			$statuses = array_reverse($statuses);
-		}
-
-		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
-		$this->jsonExit($statuses);
+		return Post::toArray($items);
 	}
 }

--- a/src/Module/Conversation/Channel.php
+++ b/src/Module/Conversation/Channel.php
@@ -128,7 +128,7 @@ class Channel extends Timeline
 		}
 
 		if ($this->channel->isTimeline($this->selectedTab) || $this->userDefinedChannel->isTimeline($this->selectedTab, $this->session->getLocalUserId())) {
-			$items = $this->getChannelItems($request);
+			$items = $this->getChannelItems($request, $this->session->getLocalUserId());
 			$order = 'created';
 		} else {
 			$items = $this->getCommunityItems();

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -225,7 +225,7 @@ class Network extends Timeline
 
 		try {
 			if ($this->channel->isTimeline($this->selectedTab) || $this->userDefinedChannel->isTimeline($this->selectedTab, $this->session->getLocalUserId())) {
-				$items = $this->getChannelItems($request);
+				$items = $this->getChannelItems($request, $this->session->getLocalUserId());
 			} elseif ($this->community->isTimeline($this->selectedTab)) {
 				$items = $this->getCommunityItems();
 			} else {

--- a/src/Module/Ping/Network.php
+++ b/src/Module/Ping/Network.php
@@ -88,7 +88,7 @@ class Network extends NetworkModule
 		$this->itemsPerPage = 100;
 
 		if ($this->channel->isTimeline($this->selectedTab) || $this->userDefinedChannel->isTimeline($this->selectedTab, $this->session->getLocalUserId())) {
-			$items = $this->getChannelItems($request);
+			$items = $this->getChannelItems($request, $this->session->getLocalUserId());
 		} elseif ($this->community->isTimeline($this->selectedTab)) {
 			$items = $this->getCommunityItems();
 		} else {

--- a/src/Module/Update/Channel.php
+++ b/src/Module/Update/Channel.php
@@ -39,7 +39,7 @@ class Channel extends ChannelModule
 		$o = '';
 		if ($this->update || $this->force) {
 			if ($this->channel->isTimeline($this->selectedTab) || $this->userDefinedChannel->isTimeline($this->selectedTab, $this->session->getLocalUserId())) {
-				$items = $this->getChannelItems($request);
+				$items = $this->getChannelItems($request, $this->session->getLocalUserId());
 			} else {
 				$items = $this->getCommunityItems();
 			}

--- a/src/Module/Update/Network.php
+++ b/src/Module/Update/Network.php
@@ -42,7 +42,7 @@ class Network extends NetworkModule
 		}
 
 		if ($this->channel->isTimeline($this->selectedTab) || $this->userDefinedChannel->isTimeline($this->selectedTab, $this->session->getLocalUserId())) {
-			$items = $this->getChannelItems($request);
+			$items = $this->getChannelItems($request, $this->session->getLocalUserId());
 		} elseif ($this->community->isTimeline($this->selectedTab)) {
 			$items = $this->getCommunityItems();
 		} else {

--- a/src/Object/Api/Mastodon/ListEntity.php
+++ b/src/Object/Api/Mastodon/ListEntity.php
@@ -34,6 +34,8 @@ class ListEntity extends BaseDataTransferObject
 	protected $id;
 	/** @var string */
 	protected $title;
+	/** @var string */
+	protected $replies_policy;
 
 	/**
 	 * Creates an list record
@@ -42,9 +44,9 @@ class ListEntity extends BaseDataTransferObject
 	 * @param string $title
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function __construct(int $id, string $title, string $policy)
+	public function __construct(string $id, string $title, string $policy)
 	{
-		$this->id             = (string)$id;
+		$this->id             = $id;
 		$this->title          = $title;
 		$this->replies_policy = $policy;
 	}

--- a/src/Object/Api/Mastodon/Status.php
+++ b/src/Object/Api/Mastodon/Status.php
@@ -160,7 +160,7 @@ class Status extends BaseDataTransferObject
 
 	/**
 	 * Returns the current created_at string or null if not set
-	 * @return \DateTime|null
+	 * @return ?string
 	 */
 	public function createdAt(): ?string
 	{

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -308,7 +308,7 @@ return [
 			'/tags/{hashtag}/unfollow'           => [Module\Api\Mastodon\Tags\Unfollow::class,            [        R::POST]],
 			'/timelines/direct'                  => [Module\Api\Mastodon\Timelines\Direct::class,         [R::GET         ]],
 			'/timelines/home'                    => [Module\Api\Mastodon\Timelines\Home::class,           [R::GET         ]],
-			'/timelines/list/{id:\d+}'           => [Module\Api\Mastodon\Timelines\ListTimeline::class,   [R::GET         ]],
+			'/timelines/list/{id}'               => [Module\Api\Mastodon\Timelines\ListTimeline::class,   [R::GET         ]],
 			'/timelines/public'                  => [Module\Api\Mastodon\Timelines\PublicTimeline::class, [R::GET         ]],
 			'/timelines/tag/{hashtag}'           => [Module\Api\Mastodon\Timelines\Tag::class,            [R::GET         ]],
 			'/trends'                            => [Module\Api\Mastodon\Trends\Tags::class,              [R::GET         ]],


### PR DESCRIPTION
The API endpoint for lists now displays channels and groups as well. Also you can access them. In the channels and groups only the top level posts are displayed and they are always sort via `uri-id`.

Fixes #13821