### PR TITLE
Colorize loglevels

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -764,6 +764,7 @@ figure.img-allocated-height img{
 }
 .loglevel-warning {
 	color: #ff8c00; /* dark orange */
+	font-weight: bold;
 }
 .loglevel-error {
 	color: #ff0000; /* red */

--- a/view/global.css
+++ b/view/global.css
@@ -767,9 +767,9 @@ figure.img-allocated-height img{
 }
 .loglevel-error {
 	color: #ff0000; /* red */
-	font-weight: bold; 
+	font-weight: bold;
 }
 .loglevel-critical {
 	color: #8b0000; /* dark red */
-	font-weight: bold; 
+	font-weight: bold;
 }

--- a/view/global.css
+++ b/view/global.css
@@ -754,16 +754,15 @@ figure.img-allocated-height img{
  * Log levels colorized in the admin panel
  **/
 .loglevel-debug {
-	color: #00ff00; /* green */
 }
 .loglevel-info {
-	color: #013220; /* dark green */
+	color: #0f009f; /* blue */
 }
 .loglevel-notice {
-	color: #ffa500; /* orange */
+	color: #007e01; /* green */
 }
 .loglevel-warning {
-	color: #ff8c00; /* dark orange */
+	color: #de9600; /* dark orange */
 	font-weight: bold;
 }
 .loglevel-error {
@@ -771,6 +770,6 @@ figure.img-allocated-height img{
 	font-weight: bold;
 }
 .loglevel-critical {
-	color: #8b0000; /* dark red */
+	color: #731289; /* purple */
 	font-weight: bold;
 }

--- a/view/global.css
+++ b/view/global.css
@@ -749,3 +749,27 @@ figure.img-allocated-height img{
 	width: 48px;
 	height: 48px;
 }
+
+/**
+ * Log levels colorized in the admin panel
+ **/
+.loglevel-debug {
+	color: #00ff00; /* green */
+}
+.loglevel-info {
+	color: #013220; /* dark green */
+}
+.loglevel-notice {
+	color: #ffa500; /* orange */
+}
+.loglevel-warning {
+	color: #ff8c00; /* dark orange */
+}
+.loglevel-error {
+	color: #ff0000; /* red */
+	font-weight: bold; 
+}
+.loglevel-critical {
+	color: #8b0000; /* dark red */
+	font-weight: bold; 
+}

--- a/view/templates/admin/logs/view.tpl
+++ b/view/templates/admin/logs/view.tpl
@@ -50,7 +50,7 @@
 						 style="cursor:pointer;"
 						 title="{{$l10n.Click_to_view_details}}">
 							<td>{{$row->date}}</td>
-							<td>{{$row->level}}</td>
+							<td class="loglevel-{{$row->level|lower}}">{{$row->level}}</td>
 							<td>{{$row->context}}</td>
 							<td>{{$row->message}}</td>
 						</tr>


### PR DESCRIPTION
In the Admin Panel -> View logs the error levels are colorized according to their severity from green over orange to (bold) red. Thus the important errors might be spotted more easily.

![grafik](https://github.com/friendica/friendica/assets/433490/98980aa6-a921-4bab-9701-2c7b1c614c35)
