### PR TITLE
Improved user agent string

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -37,6 +37,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
+use Friendica\Network\HTTPClient\Client\HttpClientRequest;
 use Friendica\Network\HTTPException;
 use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Protocol\Activity;
@@ -781,7 +782,7 @@ class Profile
 			$magic_path = $basepath . '/magic' . '?owa=1&dest=' . $dest . '&' . $addr_request;
 
 			// We have to check if the remote server does understand /magic without invoking something
-			$serverret = DI::httpClient()->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
+			$serverret = DI::httpClient()->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML, HttpClientOptions::REQUEST => HttpClientRequest::MAGICAUTH]);
 			if ($serverret->isSuccess()) {
 				Logger::info('Doing magic auth for visitor ' . $my_url . ' to ' . $magic_path);
 				System::externalRedirect($magic_path);

--- a/src/Module/Contact/Redir.php
+++ b/src/Module/Contact/Redir.php
@@ -30,6 +30,7 @@ use Friendica\Module\Response;
 use Friendica\Network\HTTPClient\Capability\ICanSendHttpRequests;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
+use Friendica\Network\HTTPClient\Client\HttpClientRequest;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Profiler;
 use Friendica\Util\Strings;
@@ -107,7 +108,7 @@ class Redir extends \Friendica\BaseModule
 		}
 
 		// Test for magic auth on the target system
-		$response = $this->httpClient->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML]);
+		$response = $this->httpClient->head($basepath . '/magic', [HttpClientOptions::ACCEPT_CONTENT => HttpClientAccept::HTML, HttpClientOptions::REQUEST => HttpClientRequest::MAGICAUTH]);
 		if ($response->isSuccess()) {
 			$separator = strpos($target_url, '?') ? '&' : '?';
 			$target_url .= $separator . 'zrl=' . urlencode($visitor) . '&addr=' . urlencode($contact_url);

--- a/src/Network/HTTPClient/Capability/ICanSendHttpRequests.php
+++ b/src/Network/HTTPClient/Capability/ICanSendHttpRequests.php
@@ -95,10 +95,11 @@ interface ICanSendHttpRequests
 	 * @param mixed  $params         POST variables (if an array is passed, it will automatically set as formular parameters)
 	 * @param array  $headers        HTTP headers
 	 * @param int    $timeout        The timeout in seconds, default system config value or 60 seconds
+	 * @param string $request        The type of the request. This is set in the user agent string
 	 *
 	 * @return ICanHandleHttpResponses The content
 	 */
-	public function post(string $url, $params, array $headers = [], int $timeout = 0): ICanHandleHttpResponses;
+	public function post(string $url, $params, array $headers = [], int $timeout = 0, string $request = ''): ICanHandleHttpResponses;
 
 	/**
 	 * Sends an HTTP request to a given url

--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -21,6 +21,7 @@
 
 namespace Friendica\Network\HTTPClient\Client;
 
+use Friendica\App;
 use Friendica\Core\System;
 use Friendica\Network\HTTPClient\Response\CurlResult;
 use Friendica\Network\HTTPClient\Response\GuzzleResponse;
@@ -51,13 +52,16 @@ class HttpClient implements ICanSendHttpRequests
 	private $client;
 	/** @var URLResolver */
 	private $resolver;
+	/** @var App\BaseURL */
+	private $baseUrl;
 
-	public function __construct(LoggerInterface $logger, Profiler $profiler, Client $client, URLResolver $resolver)
+	public function __construct(LoggerInterface $logger, Profiler $profiler, Client $client, URLResolver $resolver, App\BaseURL $baseUrl)
 	{
 		$this->logger   = $logger;
 		$this->profiler = $profiler;
 		$this->client   = $client;
 		$this->resolver = $resolver;
+		$this->baseUrl  = $baseUrl;
 	}
 
 	/**
@@ -73,7 +77,7 @@ class HttpClient implements ICanSendHttpRequests
 			throw new \InvalidArgumentException('Unable to retrieve the host in URL: ' . $url);
 		}
 
-		if(!filter_var($host, FILTER_VALIDATE_IP) && !@dns_get_record($host . '.', DNS_A) && !@dns_get_record($host . '.', DNS_AAAA)) {
+		if (!filter_var($host, FILTER_VALIDATE_IP) && !@dns_get_record($host . '.', DNS_A) && !@dns_get_record($host . '.', DNS_AAAA)) {
 			$this->logger->debug('URL cannot be resolved.', ['url' => $url]);
 			$this->profiler->stopRecording();
 			return CurlResult::createErrorCurl($this->logger, $url);
@@ -115,7 +119,7 @@ class HttpClient implements ICanSendHttpRequests
 			$conf[RequestOptions::COOKIES] = $jar;
 		}
 
-		$headers = [];
+		$headers = ['User-Agent' => $this->getUserAgent($opts[HttpClientOptions::REQUEST] ?? '')];
 
 		if (!empty($opts[HttpClientOptions::ACCEPT_CONTENT])) {
 			$headers['Accept'] = $opts[HttpClientOptions::ACCEPT_CONTENT];
@@ -153,8 +157,10 @@ class HttpClient implements ICanSendHttpRequests
 		}
 
 		$conf[RequestOptions::ON_HEADERS] = function (ResponseInterface $response) use ($opts) {
-			if (!empty($opts[HttpClientOptions::CONTENT_LENGTH]) &&
-				(int)$response->getHeaderLine('Content-Length') > $opts[HttpClientOptions::CONTENT_LENGTH]) {
+			if (
+				!empty($opts[HttpClientOptions::CONTENT_LENGTH]) &&
+				(int)$response->getHeaderLine('Content-Length') > $opts[HttpClientOptions::CONTENT_LENGTH]
+			) {
 				throw new TransferException('The file is too big!');
 			}
 		};
@@ -172,8 +178,10 @@ class HttpClient implements ICanSendHttpRequests
 			$response = $this->client->request($method, $url, $conf);
 			return new GuzzleResponse($response, $url);
 		} catch (TransferException $exception) {
-			if ($exception instanceof RequestException &&
-				$exception->hasResponse()) {
+			if (
+				$exception instanceof RequestException &&
+				$exception->hasResponse()
+			) {
 				return new GuzzleResponse($exception->getResponse(), $url, $exception->getCode(), '');
 			} else {
 				return new CurlResult($this->logger, $url, '', ['http_code' => 500], $exception->getCode(), '');
@@ -209,7 +217,7 @@ class HttpClient implements ICanSendHttpRequests
 	/**
 	 * {@inheritDoc}
 	 */
-	public function post(string $url, $params, array $headers = [], int $timeout = 0): ICanHandleHttpResponses
+	public function post(string $url, $params, array $headers = [], int $timeout = 0, string $request = ''): ICanHandleHttpResponses
 	{
 		$opts = [];
 
@@ -225,6 +233,10 @@ class HttpClient implements ICanSendHttpRequests
 
 		if (!empty($timeout)) {
 			$opts[HttpClientOptions::TIMEOUT] = $timeout;
+		}
+
+		if (!empty($request)) {
+			$opts[HttpClientOptions::REQUEST] = $request;
 		}
 
 		return $this->request('post', $url, $opts);
@@ -255,6 +267,7 @@ class HttpClient implements ICanSendHttpRequests
 
 		$url = trim($url, "'");
 
+		$this->resolver->setUserAgent($this->getUserAgent(HttpClientRequest::RESOLVER));
 		$urlResult = $this->resolver->resolveURL($url);
 
 		if ($urlResult->didErrorOccur()) {
@@ -287,5 +300,16 @@ class HttpClient implements ICanSendHttpRequests
 				HttpClientOptions::COOKIEJAR => $cookiejar
 			]
 		);
+	}
+
+	private function getUserAgent(string $type = ''): string
+	{
+		// @see https://developers.whatismybrowser.com/learn/browser-detection/user-agents/user-agent-best-practices
+		$userAgent = App::PLATFORM . '/' . App::VERSION  . ' DatabaseVersion/' . DB_UPDATE_VERSION;
+		if ($type != '') {
+			$userAgent .= ' Request/' . $type;
+		}
+		$userAgent .= ' +' . $this->baseUrl;
+		return $userAgent;
 	}
 }

--- a/src/Network/HTTPClient/Client/HttpClientOptions.php
+++ b/src/Network/HTTPClient/Client/HttpClientOptions.php
@@ -52,7 +52,10 @@ class HttpClientOptions
 	 * content_length: (int) maximum File content length
 	 */
 	const CONTENT_LENGTH = 'content_length';
-
+	/**
+	 * Request: (string) Type of request (ActivityPub, Diaspora, server discovery, ...)
+	 */
+	const REQUEST = 'request';
 	/**
 	 * verify: (bool|string, default=true) Describes the SSL certificate
 	 */

--- a/src/Network/HTTPClient/Client/HttpClientRequest.php
+++ b/src/Network/HTTPClient/Client/HttpClientRequest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2024, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Network\HTTPClient\Client;
+
+/**
+ * This class contains a list of request types that are set in the user agent string
+ */
+class HttpClientRequest
+{
+	public const ACTIVITYPUB = 'ActivityPub/1';
+	public const CONTENTTYPE = 'ContentTypeChecker/1';
+	public const DFRN        = 'DFRN/1';
+	public const DIASPORA    = 'Diaspora/1';
+	public const MAGICAUTH   = 'MagicAuth/1';
+	public const MEDIAPROXY  = 'MediaProxy/1';
+	public const SALMON      = 'Salmon/1';
+	public const PUBSUB      = 'PubSub/1';
+	public const RESOLVER    = 'URLResolver/1';
+	public const VERIFIER    = 'URLVerifier/1';
+}

--- a/src/Network/HTTPClient/Factory/HttpClient.php
+++ b/src/Network/HTTPClient/Factory/HttpClient.php
@@ -86,12 +86,6 @@ class HttpClient extends BaseFactory
 			$logger->info('Curl redirect.', ['url' => $request->getUri(), 'to' => $uri, 'method' => $request->getMethod()]);
 		};
 
-		$userAgent = App::PLATFORM . " '" .
-					 App::CODENAME . "' " .
-					 App::VERSION . '-' .
-					 DB_UPDATE_VERSION . '; ' .
-					 $this->baseUrl;
-
 		$guzzle = new GuzzleHttp\Client([
 			RequestOptions::ALLOW_REDIRECTS => [
 				'max'             => 8,
@@ -112,22 +106,19 @@ class HttpClient extends BaseFactory
 			// but it can be overridden
 			RequestOptions::VERIFY  => (bool)$this->config->get('system', 'verifyssl'),
 			RequestOptions::PROXY   => $proxy,
-			RequestOptions::HEADERS => [
-				'User-Agent' => $userAgent,
-			],
+			RequestOptions::HEADERS => [],
 			'handler' => $handlerStack ?? HandlerStack::create(),
 		]);
 
 		$resolver = new URLResolver();
-		$resolver->setUserAgent($userAgent);
 		$resolver->setMaxRedirects(10);
 		$resolver->setRequestTimeout(10);
 		// if the file is too large then exit
 		$resolver->setMaxResponseDataSize($this->config->get('performance', 'max_response_data_size', 1000000));
 		// Designate a temporary file that will store cookies during the session.
 		// Some websites test the browser for cookie support, so this enhances results.
-		$resolver->setCookieJar(System::getTempPath() .'/resolver-cookie-' . Strings::getRandomName(10));
+		$resolver->setCookieJar(System::getTempPath() . '/resolver-cookie-' . Strings::getRandomName(10));
 
-		return new Client\HttpClient($logger, $this->profiler, $guzzle, $resolver);
+		return new Client\HttpClient($logger, $this->profiler, $guzzle, $resolver, $this->baseUrl);
 	}
 }

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -44,6 +44,7 @@ use Friendica\Model\Post;
 use Friendica\Model\Profile;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
+use Friendica\Network\HTTPClient\Client\HttpClientRequest;
 use Friendica\Network\HTTPException;
 use Friendica\Network\Probe;
 use Friendica\Util\Crypto;
@@ -1009,7 +1010,7 @@ class DFRN
 
 		$content_type = ($public_batch ? 'application/magic-envelope+xml' : 'application/json');
 
-		$postResult = DI::httpClient()->post($dest_url, $envelope, ['Content-Type' => $content_type]);
+		$postResult = DI::httpClient()->post($dest_url, $envelope, ['Content-Type' => $content_type], 0, HttpClientRequest::DFRN);
 		$xml = $postResult->getBodyString();
 
 		$curl_stat = $postResult->getReturnCode();

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -41,6 +41,7 @@ use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Model\User;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
+use Friendica\Network\HTTPClient\Client\HttpClientRequest;
 use Friendica\Network\HTTPException;
 use Friendica\Network\Probe;
 use Friendica\Protocol\Delivery;
@@ -2937,7 +2938,7 @@ class Diaspora
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	private static function transmit(array $owner, array $contact, string $envelope, bool $public_batch, string $guid = ''): int
+	private static function transmit(array $contact, string $envelope, bool $public_batch, string $guid = ''): int
 	{
 		$enabled = intval(DI::config()->get('system', 'diaspora_enabled'));
 		if (!$enabled) {
@@ -2968,7 +2969,7 @@ class Diaspora
 		if (!intval(DI::config()->get('system', 'diaspora_test'))) {
 			$content_type = (($public_batch) ? 'application/magic-envelope+xml' : 'application/json');
 
-			$postResult = DI::httpClient()->post($dest_url . '/', $envelope, ['Content-Type' => $content_type]);
+			$postResult = DI::httpClient()->post($dest_url . '/', $envelope, ['Content-Type' => $content_type], 0, HttpClientRequest::DIASPORA);
 			$return_code = $postResult->getReturnCode();
 		} else {
 			Logger::notice('test_mode');
@@ -3042,7 +3043,7 @@ class Diaspora
 
 		$envelope = self::buildMessage($msg, $owner, $contact, $owner['uprvkey'], $pubkey ?? '', $public_batch);
 
-		$return_code = self::transmit($owner, $contact, $envelope, $public_batch, $guid);
+		$return_code = self::transmit($contact, $envelope, $public_batch, $guid);
 
 		Logger::info('Transmitted message', ['owner' => $owner['uid'], 'target' => $contact['addr'], 'type' => $type, 'guid' => $guid, 'result' => $return_code]);
 

--- a/src/Protocol/Salmon.php
+++ b/src/Protocol/Salmon.php
@@ -24,6 +24,7 @@ namespace Friendica\Protocol;
 use Friendica\Core\Logger;
 use Friendica\DI;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
+use Friendica\Network\HTTPClient\Client\HttpClientRequest;
 use Friendica\Network\Probe;
 use Friendica\Protocol\Salmon\Format\Magic;
 use Friendica\Util\Crypto;
@@ -49,7 +50,7 @@ class Salmon
 	{
 		$ret = [];
 
-		Logger::info('Fetching salmon key for '.$uri);
+		Logger::info('Fetching salmon key for ' . $uri);
 
 		$arr = Probe::lrdd($uri);
 
@@ -67,7 +68,7 @@ class Salmon
 		// If it's inline, parse it - otherwise get the key
 
 		if (count($ret) > 0) {
-			for ($x = 0; $x < count($ret); $x ++) {
+			for ($x = 0; $x < count($ret); $x++) {
 				if (substr($ret[$x], 0, 5) === 'data:') {
 					if (strstr($ret[$x], ',')) {
 						$ret[$x] = substr($ret[$x], strpos($ret[$x], ',') + 1);
@@ -120,12 +121,15 @@ class Salmon
 		}
 
 		if (!$owner['sprvkey']) {
-			Logger::notice(sprintf("user '%s' (%d) does not have a salmon private key. Send failed.",
-			$owner['name'], $owner['uid']));
+			Logger::notice(sprintf(
+				"user '%s' (%d) does not have a salmon private key. Send failed.",
+				$owner['name'],
+				$owner['uid']
+			));
 			return -1;
 		}
 
-		Logger::info('slapper called for '.$url.'. Data: ' . $slap);
+		Logger::info('slapper called for ' . $url . '. Data: ' . $slap);
 
 		// create a magic envelope
 
@@ -166,7 +170,7 @@ class Salmon
 		$postResult = DI::httpClient()->post($url, $salmon, [
 			'Content-type' => 'application/magic-envelope+xml',
 			'Content-length' => strlen($salmon),
-		]);
+		], 0, HttpClientRequest::SALMON);
 
 		$return_code = $postResult->getReturnCode();
 
@@ -193,7 +197,7 @@ class Salmon
 			$postResult = DI::httpClient()->post($url, $salmon, [
 				'Content-type' => 'application/magic-envelope+xml',
 				'Content-length' => strlen($salmon),
-			]);
+			], 0, HttpClientRequest::SALMON);
 			$return_code = $postResult->getReturnCode();
 		}
 
@@ -217,13 +221,14 @@ class Salmon
 			// slap them
 			$postResult = DI::httpClient()->post($url, $salmon, [
 				'Content-type' => 'application/magic-envelope+xml',
-				'Content-length' => strlen($salmon)]);
+				'Content-length' => strlen($salmon)
+			], 0, HttpClientRequest::SALMON);
 			$return_code = $postResult->getReturnCode();
 		}
 
-		Logger::info('slapper for '.$url.' returned ' . $return_code);
+		Logger::info('slapper for ' . $url . ' returned ' . $return_code);
 
-		if (! $return_code) {
+		if (!$return_code) {
 			return -1;
 		}
 

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -27,6 +27,7 @@ use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
+use Friendica\Network\HTTPClient\Client\HttpClientRequest;
 use Friendica\Network\HTTPException\NotModifiedException;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;
@@ -78,7 +79,8 @@ class Network
 		}
 
 		if (in_array(parse_url($url, PHP_URL_SCHEME), ['https', 'http'])) {
-			$options = [HttpClientOptions::VERIFY => true, HttpClientOptions::TIMEOUT => $xrd_timeout];
+			$options = [HttpClientOptions::VERIFY => true, HttpClientOptions::TIMEOUT => $xrd_timeout,
+				HttpClientOptions::REQUEST => HttpClientRequest::VERIFIER];
 			try {
 				$curlResult = DI::httpClient()->head($url, $options);
 			} catch (\Exception $e) {

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -33,6 +33,7 @@ use Friendica\DI;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
+use Friendica\Network\HTTPClient\Client\HttpClientRequest;
 
 /**
  * Get information about a given URL
@@ -64,9 +65,9 @@ class ParseUrl
 	public static function getContentType(string $url, string $accept = HttpClientAccept::DEFAULT, int $timeout = 0): array
 	{
 		if (!empty($timeout)) {
-			$options = [HttpClientOptions::TIMEOUT => $timeout];
+			$options = [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::REQUEST => HttpClientRequest::CONTENTTYPE];
 		} else {
-			$options = [];
+			$options = [HttpClientOptions::REQUEST => HttpClientRequest::CONTENTTYPE];
 		}
 
 		try {

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -33,6 +33,7 @@ use Friendica\Model\Post;
 use Friendica\Model\User;
 use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPClient\Client\HttpClientOptions;
+use Friendica\Network\HTTPClient\Client\HttpClientRequest;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Protocol\Email;
@@ -487,7 +488,7 @@ class OnePoll
 			Contact::update(['hub-verify' => $verify_token], ['id' => $contact['id']]);
 		}
 
-		$postResult = DI::httpClient()->post($url, $params);
+		$postResult = DI::httpClient()->post($url, $params, [], 0, HttpClientRequest::PUBSUB);
 
 		Logger::info('Hub subscription done', ['result' => $postResult->getReturnCode()]);
 

--- a/src/Worker/PubSubPublish.php
+++ b/src/Worker/PubSubPublish.php
@@ -25,6 +25,7 @@ use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\PushSubscriber;
+use Friendica\Network\HTTPClient\Client\HttpClientRequest;
 use Friendica\Protocol\OStatus;
 
 class PubSubPublish
@@ -73,14 +74,17 @@ class PubSubPublish
 
 		$headers = [
 			'Content-type' => 'application/atom+xml',
-			'Link' => sprintf('<%s>;rel=hub,<%s>;rel=self',
-					DI::baseUrl() . '/pubsubhubbub/' . $subscriber['nickname'],
-					$subscriber['topic']),
-			'X-Hub-Signature' => 'sha1=' . $hmac_sig];
+			'Link' => sprintf(
+				'<%s>;rel=hub,<%s>;rel=self',
+				DI::baseUrl() . '/pubsubhubbub/' . $subscriber['nickname'],
+				$subscriber['topic']
+			),
+			'X-Hub-Signature' => 'sha1=' . $hmac_sig
+		];
 
 		Logger::debug('POST', ['headers' => $headers, 'params' => $params]);
 
-		$postResult = DI::httpClient()->post($subscriber['callback_url'], $params, $headers);
+		$postResult = DI::httpClient()->post($subscriber['callback_url'], $params, $headers, 0, HttpClientRequest::PUBSUB);
 		$ret = $postResult->getReturnCode();
 
 		if ($ret >= 200 && $ret <= 299) {


### PR DESCRIPTION
In coordination with an expert from a company that provides services concerning user agent strings, our user agent is no reformatted. Additionally we also now transmit the request type. This helps a lot, if for example some external admin complains about HTTP requests done by Friendica. With the request type it should then be better to find the origin of these requests.

The request type is added at some places, a lot more places will be covered in some future PR.