### PR TITLE
Add support for absolute file paths when removing addon

### DIFF
--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -140,7 +140,8 @@ class Addon
 			$func();
 		}
 
-		Hook::delete(['file' => 'addon/' . $addon . '/' . $addon . '.php']);
+		// Handles both relative and absolute file paths
+		Hook::delete(['`file` LIKE ?', "%addon/$addon/$addon.php"]);
 
 		unset(self::$addons[array_search($addon, self::$addons)]);
 	}


### PR DESCRIPTION
Fix #14045

- This handles a rare case where absolute addon file paths were saved to the hook table