### PR TITLE
Support for non HTML content for feed imports

### DIFF
--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -253,8 +253,10 @@ class HTML
 			self::tagToBBCode($doc, 'span', ['class' => 'type-link'], '[class=type-link]', '[/class]');
 			self::tagToBBCode($doc, 'span', ['class' => 'type-video'], '[class=type-video]', '[/class]');
 
-			$elements = ['b', 'del', 'em', 'i', 'ins', 'kbd', 'mark',
-				's', 'samp', 'strong', 'sub', 'sup', 'u', 'var'];
+			$elements = [
+				'b', 'del', 'em', 'i', 'ins', 'kbd', 'mark',
+				's', 'samp', 'strong', 'sub', 'sup', 'u', 'var'
+			];
 			foreach ($elements as $element) {
 				self::tagToBBCode($doc, $element, [], '[' . $element . ']', '[/' . $element . ']');
 			}
@@ -1058,5 +1060,16 @@ class HTML
 		}
 
 		return null;
+	}
+
+	/**
+	 * Check if a document contains HTML or entities
+	 *
+	 * @param string $text
+	 * @return boolean
+	 */
+	public static function isHTML(string $text): bool
+	{
+		return ($text != html_entity_decode($text)) || ($text != strip_tags($text));
 	}
 }

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -29,7 +29,6 @@ use Friendica\Contact\LocalRelationship\Entity\LocalRelationship;
 use Friendica\Content\PageInfo;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
-use Friendica\Core\Cache\Enum\Duration;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Core\Worker;
@@ -546,6 +545,13 @@ class Feed
 			if (self::titleIsBody($item['title'], $body)) {
 				$item['title'] = '';
 			}
+
+			if (!HTML::isHTML($body)) {
+				$original = $body;
+				$body = BBCode::convert($body, false, BBCode::EXTERNAL);
+				Logger::debug('Body contained no HTML', ['original' => $original, 'converted' => $body]);
+			}
+
 			$item['body'] = HTML::toBBCode($body, $basepath);
 
 			// Remove tracking pixels


### PR DESCRIPTION
During some tests I discovered feeds that don't provide HTML, but text with line breaks with CR and LF. There is now a check for that.