### PR TITLE
Probing for Zot improved and Pumpio removed

### DIFF
--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -184,6 +184,12 @@ class Media
 	{
 		if (Network::isLocalLink($media['url'])) {
 			$media = self::fetchLocalData($media);
+			if (preg_match('|.*?/search\?(.+)|', $media['url'], $matches)) {
+				return $media;
+			}
+			if (empty($media['mimetype']) || empty($media['size'])) {
+				Logger::debug('Unknown local link', ['url' => $media['url']]);
+			}
 		}
 
 		// Fetch the mimetype or size if missing.
@@ -391,7 +397,7 @@ class Media
 	 */
 	private static function fetchLocalData(array $media): array
 	{
-		if (preg_match('|.*?/attach/(\d+)|', $media['url'] ?? '', $matches)) {
+		if (preg_match('|.*?/attach/(\d+)|', $media['url'], $matches)) {
 			$attachment = Attach::selectFirst(['filename', 'filetype', 'filesize'], ['id' => $matches[1]]);
 			if (!empty($attachment)) {
 				$media['name']     = $attachment['filename'];
@@ -401,7 +407,7 @@ class Media
 			return $media;
 		}
 
-		if (!preg_match('|.*?/photo/(.*[a-fA-F0-9])\-(.*[0-9])\..*[\w]|', $media['url'] ?? '', $matches)) {
+		if (!preg_match('|.*?/photo/(.*[a-fA-F0-9])\-(.*[0-9])\..*[\w]|', $media['url'], $matches)) {
 			return $media;
 		}
 		$photo = Photo::selectFirst([], ['resource-id' => $matches[1], 'scale' => $matches[2]]);

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -386,10 +386,12 @@ class Feed
 
 			$orig_plink = $item['plink'];
 
-			try {
-				$item['plink'] = DI::httpClient()->finalUrl($item['plink']);
-			} catch (TransferException $exception) {
-				Logger::notice('Item URL couldn\'t get expanded', ['url' => $item['plink'], 'exception' => $exception]);
+			if (!$dryRun) {
+				try {
+					$item['plink'] = DI::httpClient()->finalUrl($item['plink']);
+				} catch (TransferException $exception) {
+					Logger::notice('Item URL couldn\'t get expanded', ['url' => $item['plink'], 'exception' => $exception]);
+				}
 			}
 
 			if (empty($item['title'])) {


### PR DESCRIPTION
This PR touches several parts:

1. The poll for Zot account data has been improved
2. Pumpio probing is removed, since pumpio really isn't in use anymore and we never used that data
3. We probed for OStatus data for the additional "networks" part, but never used it. (we only use that part for diaspora)
4. We avoid an unneeded HTTP request when we simply check a feed
5. We avoid several HTTP requests when a post is scanned for links