### PR TITLE
[frio] Colour for fading in a comment adjusted

### DIFF
--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -741,8 +741,8 @@ function scrollToItem(elementId) {
 	}
 
 	// Define the colors which are used for highlighting
-	var colWhite = { backgroundColor: "#F5F5F5" };
-	var colShiny = { backgroundColor: "#FFF176" };
+	var colWhite = { backgroundColor: "#7f7f7f" };
+	var colShiny = { backgroundColor: "#7e763a" };
 
 	// Get the Item Position (we need to substract 100 to match correct position
 	var itemPos = $el.offset().top - 100;


### PR DESCRIPTION
When a comment is called up via the notification, the comment is highlighted brightly. With a dark theme, this is disproportionately bright. 

The changed colour values represent a compromise between light and dark themes. 

https://github.com/friendica/friendica/issues/14052