### PR TITLE
Issue 14153: Don't transmit activities to all participants

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -765,7 +765,7 @@ class Transmitter
 		}
 
 		if (!empty($item['parent']) && (!$exclusive || ($item['private'] == Item::PRIVATE))) {
-			if ($item['private'] == Item::PRIVATE) {
+			if ($item['private'] == Item::PRIVATE || $item['gravity'] == Item::GRAVITY_ACTIVITY) {
 				$condition = ['parent' => $item['parent'], 'uri-id' => $item['thr-parent-id']];
 			} else {
 				$condition = ['parent' => $item['parent']];
@@ -812,6 +812,14 @@ class Transmitter
 				}
 			}
 			DBA::close($parents);
+		}
+
+		if (!empty($item['quote-uri-id']) && in_array($item['private'], [Item::PUBLIC, Item::UNLISTED])) {
+			$quoted = Post::selectFirst(['author-link'], ['uri-id' => $item['quote-uri-id']]);
+			$profile = APContact::getByURL($quoted['author-link'], false);
+			if (!empty($profile)) {
+				$data['cc'][] = $profile['url'];
+			}
 		}
 
 		$data['to']       = array_unique($data['to']);


### PR DESCRIPTION
Fixes #14153

With this change a reshare is now only transmitted to the followers of the resharer and the person who posted the original post. Prior it had been transmitted to all participants of the thread.

Also we now ensure that we send a quoted post to the original author of that post as well. This ensures to get notified about the quote.