### PR TITLE
OpenWebAuth path is now fetched during probing

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2024.06-dev (Yellow Archangel)
--- DB_UPDATE_VERSION 1560
+-- DB_UPDATE_VERSION 1561
 -- ------------------------------------------
 
 
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS `gserver` (
 	`local-comments` int unsigned COMMENT 'Number of local comments',
 	`directory-type` tinyint DEFAULT 0 COMMENT 'Type of directory service (Poco, Mastodon)',
 	`poco` varbinary(383) NOT NULL DEFAULT '' COMMENT '',
+	`openwebauth` varbinary(383) COMMENT 'Path to the OpenWebAuth endpoint',
 	`noscrape` varbinary(383) NOT NULL DEFAULT '' COMMENT '',
 	`network` char(4) NOT NULL DEFAULT '' COMMENT '',
 	`protocol` tinyint unsigned COMMENT 'The protocol of the server',

--- a/doc/database/db_gserver.md
+++ b/doc/database/db_gserver.md
@@ -23,6 +23,7 @@ Fields
 | local-comments        | Number of local comments                           | int unsigned     | YES  |     | NULL                |                |
 | directory-type        | Type of directory service (Poco, Mastodon)         | tinyint          | YES  |     | 0                   |                |
 | poco                  |                                                    | varbinary(383)   | NO   |     |                     |                |
+| openwebauth           | Path to the OpenWebAuth endpoint                   | varbinary(383)   | YES  |     | NULL                |                |
 | noscrape              |                                                    | varbinary(383)   | NO   |     |                     |                |
 | network               |                                                    | char(4)          | NO   |     |                     |                |
 | protocol              | The protocol of the server                         | tinyint unsigned | YES  |     | NULL                |                |

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -42,6 +42,7 @@ use Friendica\Module\BaseProfile;
 use Friendica\Network\HTTPException;
 use Friendica\Network\Probe;
 use Friendica\Protocol\Activity;
+use Friendica\Protocol\ActivityNamespace;
 use Friendica\Security\Security;
 use Friendica\Util\Crypto;
 use Friendica\Util\DateTimeFormat;
@@ -408,7 +409,7 @@ function photos_post()
 
 							if (count($links)) {
 								foreach ($links as $link) {
-									if ($link['@attributes']['rel'] === 'http://webfinger.net/rel/profile-page') {
+									if ($link['@attributes']['rel'] === ActivityNamespace::WEBFINGERPROFILE) {
 										$profile = $link['@attributes']['href'];
 									}
 

--- a/src/App.php
+++ b/src/App.php
@@ -583,7 +583,7 @@ class App
 						}
 					}
 
-					Model\Profile::zrlInit($this);
+					Model\Profile::zrlInit();
 				} else {
 					// Someone came with an invalid parameter, maybe as a DDoS attempt
 					// We simply stop processing here

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -90,7 +90,7 @@ class APContact
 				$data['url'] = $link['href'];
 			}
 
-			if (!empty($link['href']) && !empty($link['type']) && ($link['rel'] == 'http://webfinger.net/rel/profile-page') && ($link['type'] == 'text/html')) {
+			if (!empty($link['href']) && !empty($link['type']) && ($link['rel'] == ActivityNamespace::WEBFINGERPROFILE) && ($link['type'] == 'text/html')) {
 				$data['alias'] = $link['href'];
 			}
 		}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1446,6 +1446,7 @@ class Contact
 			}
 		}
 
+		GServer::updateFromProbeArray($data);
 		self::updateFromProbeArray($contact_id, $data);
 
 		// Don't return a number for a deleted account
@@ -2673,6 +2674,7 @@ class Contact
 			}
 		}
 
+		GServer::updateFromProbeArray($data);
 		return self::updateFromProbeArray($id, $data);
 	}
 
@@ -3215,6 +3217,7 @@ class Contact
 		}
 
 		if ($probed) {
+			GServer::updateFromProbeArray($ret);
 			self::updateFromProbeArray($contact_id, $ret);
 		} else {
 			try {

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -2484,6 +2484,25 @@ class GServer
 		DI::keyValue()->set('poco_last_federation_discovery', time());
 	}
 
+	public static function updateFromProbeArray(array $data)
+	{
+		if (empty($data['gsid']) || empty($data['openwebauth'])) {
+			return;
+		}
+
+		$gserver = DBA::selectFirst('gserver', ['openwebauth'], ['id' => $data['gsid']]);
+		if (!DBA::isResult($gserver)) {
+			return;
+		}
+
+		if ($data['openwebauth'] == $gserver['openwebauth']) {
+			return;
+		}
+
+		Logger::debug('Set Open Web Auth path', ['baseurl' => $data['baseurl'], 'openwebauth' => $data['openwebauth']]);
+		self::update(['openwebauth' => $data['openwebauth']], ['id' => $data['gsid']]);
+	}
+
 	/**
 	 * Set the protocol for the given server
 	 *

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -711,13 +711,11 @@ class Profile
 	 *
 	 * It would be favourable to harmonize the two implementations.
 	 *
-	 * @param App $a Application instance.
-	 *
 	 * @return void
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function zrlInit(App $a)
+	public static function zrlInit()
 	{
 		$my_url = DI::userSession()->getMyUrl();
 		$my_url = Network::isUrlValid($my_url);

--- a/src/Module/Magic.php
+++ b/src/Module/Magic.php
@@ -25,8 +25,10 @@ use Exception;
 use Friendica\App;
 use Friendica\BaseModule;
 use Friendica\Core\L10n;
+use Friendica\Core\Protocol;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Core\System;
+use Friendica\Core\Worker;
 use Friendica\Database\Database;
 use Friendica\Model\Contact;
 use Friendica\Model\GServer;
@@ -36,7 +38,7 @@ use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Util\HTTPSignature;
 use Friendica\Util\Profiler;
 use Friendica\Util\Strings;
-use GuzzleHttp\Psr7\Uri;
+use Friendica\Worker\UpdateContact;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -115,22 +117,39 @@ class Magic extends BaseModule
 		$owner = User::getOwnerDataById($this->userSession->getLocalUserId());
 
 		if (!empty($contact['gsid'])) {
-			$gserver = $this->dba->selectFirst('gserver', ['url'], ['id' => $contact['gsid']]);
-			if (empty($gserver)) {
-				$this->logger->notice('Server not found, redirecting to destination.', ['gsid' => $contact['gsid'], 'dest' => $dest]);
-				System::externalRedirect($dest);
-			}
-
-			$basepath = $gserver['url'];
+			$gsid = $contact['gsid'];
 		} elseif (GServer::check($target)) {
-			$basepath = (string)GServer::cleanUri(new Uri($target));
-		} else {
+			$gsid = GServer::getID($target);
+		}
+
+		if (empty($gsid)) {
 			$this->logger->notice('The target is not a server path, redirecting to destination.', ['target' => $target]);
 			System::externalRedirect($dest);
 		}
 
+		$gserver = $this->dba->selectFirst('gserver', ['url', 'network', 'openwebauth'], ['id' => $gsid]);
+		if (empty($gserver)) {
+			$this->logger->notice('Server not found, redirecting to destination.', ['gsid' => $gsid, 'dest' => $dest]);
+			System::externalRedirect($dest);
+		}
+
+		$openwebauth = $gserver['openwebauth'];
+
+		// This part can be removed, when all server entries had been updated. So removing it in 2025 should be safe.
+		if (empty($openwebauth) && ($gserver['network'] == Protocol::DFRN)) {
+			$this->logger->notice('Open Web Auth path not provided. Assume default path', ['gsid' => $gsid, 'dest' => $dest]);
+			$openwebauth = $gserver['url'] . '/owa';
+			// Update contact to assign the path to the server
+			UpdateContact::add(Worker::PRIORITY_MEDIUM, $contact['id']);
+		}
+
+		if (empty($openwebauth)) {
+			$this->logger->debug('Server does not support open web auth, redirecting to destination.', ['gsid' => $gsid, 'dest' => $dest]);
+			System::externalRedirect($dest);
+		}
+
 		$header = [
-			'Accept'          => 'application/x-dfrn+json, application/x-zot+json',
+			'Accept'          => 'application/x-zot+json',
 			'X-Open-Web-Auth' => Strings::getRandomHex()
 		];
 
@@ -141,13 +160,13 @@ class Magic extends BaseModule
 			'acct:' . $owner['addr']
 		);
 
-		$this->logger->info('Fetch from remote system', ['basepath' => $basepath, 'headers' => $header]);
+		$this->logger->info('Fetch from remote system', ['openwebauth' => $openwebauth, 'headers' => $header]);
 
 		// Try to get an authentication token from the other instance.
 		try {
-			$curlResult = $this->httpClient->request('get', $basepath . '/owa', [HttpClientOptions::HEADERS => $header]);
+			$curlResult = $this->httpClient->request('get', $openwebauth, [HttpClientOptions::HEADERS => $header]);
 		} catch (Exception $exception) {
-			$this->logger->notice('URL is invalid, redirecting to destination.', ['url' => $basepath, 'error' => $exception, 'dest' => $dest]);
+			$this->logger->notice('URL is invalid, redirecting to destination.', ['url' => $openwebauth, 'error' => $exception, 'dest' => $dest]);
 			System::externalRedirect($dest);
 		}
 		if (!$curlResult->isSuccess()) {

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -121,7 +121,7 @@ class Xrd extends BaseModule
 			'aliases' => [$owner['url']],
 			'links'   => [
 				[
-					'rel'  => 'http://webfinger.net/rel/profile-page',
+					'rel'  => ActivityNamespace::WEBFINGERPROFILE,
 					'type' => 'text/html',
 					'href' => $owner['url'],
 				],
@@ -131,7 +131,7 @@ class Xrd extends BaseModule
 					'href' => $owner['url'],
 				],
 				[
-					'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
+					'rel'      => ActivityNamespace::OSTATUSSUB,
 					'template' => $baseURL . '/contact/follow?url={uri}',
 				],
 				[
@@ -144,12 +144,12 @@ class Xrd extends BaseModule
 					'href' => $baseURL . '/salmon/' . $owner['nickname'],
 				],
 				[
-					'rel'  => 'http://microformats.org/profile/hcard',
+					'rel'  => ActivityNamespace::HCARD,
 					'type' => 'text/html',
 					'href' => $baseURL . '/hcard/' . $owner['nickname'],
 				],
 				[
-					'rel'  => 'http://joindiaspora.com/seed_location',
+					'rel'  => ActivityNamespace::DIASPORA_SEED,
 					'type' => 'text/html',
 					'href' => $baseURL,
 				],
@@ -171,7 +171,7 @@ class Xrd extends BaseModule
 			],
 			'links'   => [
 				[
-					'rel'  => ActivityNamespace::DFRN ,
+					'rel'  => ActivityNamespace::DFRN,
 					'href' => $owner['url'],
 				],
 				[
@@ -180,7 +180,7 @@ class Xrd extends BaseModule
 					'href' => $owner['poll'],
 				],
 				[
-					'rel'  => 'http://webfinger.net/rel/profile-page',
+					'rel'  => ActivityNamespace::WEBFINGERPROFILE,
 					'type' => 'text/html',
 					'href' => $owner['url'],
 				],
@@ -190,17 +190,17 @@ class Xrd extends BaseModule
 					'href' => $owner['url'],
 				],
 				[
-					'rel'  => 'http://microformats.org/profile/hcard',
+					'rel'  => ActivityNamespace::HCARD,
 					'type' => 'text/html',
 					'href' => $baseURL . '/hcard/' . $owner['nickname'],
 				],
 				[
-					'rel'  => 'http://webfinger.net/rel/avatar',
+					'rel'  => ActivityNamespace::WEBFINGERAVATAR,
 					'type' => $avatar['type'],
 					'href' => User::getAvatarUrl($owner),
 				],
 				[
-					'rel'  => 'http://joindiaspora.com/seed_location',
+					'rel'  => ActivityNamespace::DIASPORA_SEED,
 					'type' => 'text/html',
 					'href' => $baseURL,
 				],
@@ -217,7 +217,7 @@ class Xrd extends BaseModule
 					'href' => $baseURL . '/salmon/' . $owner['nickname'] . '/mention',
 				],
 				[
-					'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
+					'rel'      => ActivityNamespace::OSTATUSSUB,
 					'template' => $baseURL . '/contact/follow?url={uri}',
 				],
 				[
@@ -225,7 +225,7 @@ class Xrd extends BaseModule
 					'href' => 'data:application/magic-public-key,' . Salmon::salmonKey($owner['spubkey']),
 				],
 				[
-					'rel'  => 'http://purl.org/openwebauth/v1',
+					'rel'  => ActivityNamespace::OPENWEBAUTH,
 					'type' => 'application/x-zot+json',
 					'href' => $baseURL . '/owa',
 				],
@@ -263,28 +263,28 @@ class Xrd extends BaseModule
 				],
 				'3:link' => [
 					'@attributes' => [
-						'rel'  => 'http://webfinger.net/rel/profile-page',
+						'rel'  => ActivityNamespace::WEBFINGERPROFILE,
 						'type' => 'text/html',
 						'href' => $owner['url']
 					]
 				],
 				'4:link' => [
 					'@attributes' => [
-						'rel'  => 'http://microformats.org/profile/hcard',
+						'rel'  => ActivityNamespace::HCARD,
 						'type' => 'text/html',
 						'href' => $baseURL . '/hcard/' . $owner['nickname']
 					]
 				],
 				'5:link' => [
 					'@attributes' => [
-						'rel'  => 'http://webfinger.net/rel/avatar',
+						'rel'  => ActivityNamespace::WEBFINGERAVATAR,
 						'type' => $avatar['type'],
 						'href' => User::getAvatarUrl($owner)
 					]
 				],
 				'6:link' => [
 					'@attributes' => [
-						'rel'  => 'http://joindiaspora.com/seed_location',
+						'rel'  => ActivityNamespace::DIASPORA_SEED,
 						'type' => 'text/html',
 						'href' => $baseURL
 					]
@@ -309,7 +309,7 @@ class Xrd extends BaseModule
 				],
 				'10:link' => [
 					'@attributes' => [
-						'rel'  => 'http://ostatus.org/schema/1.0/subscribe',
+						'rel'      => ActivityNamespace::OSTATUSSUB,
 						'template' => $baseURL . '/contact/follow?url={uri}'
 					]
 				],
@@ -321,7 +321,7 @@ class Xrd extends BaseModule
 				],
 				'12:link' => [
 					'@attributes' => [
-						'rel'  => 'http://purl.org/openwebauth/v1',
+						'rel'  => ActivityNamespace::OPENWEBAUTH,
 						'type' => 'application/x-zot+json',
 						'href' => $baseURL . '/owa'
 					]

--- a/src/Protocol/ActivityNamespace.php
+++ b/src/Protocol/ActivityNamespace.php
@@ -105,6 +105,39 @@ final class ActivityNamespace
 	 */
 	const OSTATUSSUB      = 'http://ostatus.org/schema/1.0/subscribe';
 	/**
+	 * Webfinger avatar
+	 *
+	 * @see https://webfinger.net/rel/#avatar
+	 * @var string
+	 */
+	const WEBFINGERAVATAR = 'http://webfinger.net/rel/avatar';
+	/**
+	 * Webfinger profile
+	 *
+	 * @see https://webfinger.net/rel/#profile-page
+	 * @var string
+	 */
+	const WEBFINGERPROFILE = 'http://webfinger.net/rel/profile-page';
+	/**
+	 * HCard
+	 *
+	 * @see http://microformats.org/wiki/hcard
+	 * @var string
+	 */
+	const HCARD           = 'http://microformats.org/profile/hcard';
+	/**
+	 * Base url of the Diaspora installation
+	 *
+	 * @var string
+	 */
+	const DIASPORA_SEED   = 'http://joindiaspora.com/seed_location';
+	/**
+	 * Diaspora Guid
+	 *
+	 * @var string
+	 */
+	const DIASPORA_GUID   = 'http://joindiaspora.com/guid';
+	/**
 	 * GeoRSS was designed as a lightweight, community driven way to extend existing feeds with geographic information.
 	 *
 	 * @see http://www.georss.org/
@@ -120,6 +153,12 @@ final class ActivityNamespace
 	 * @var string
 	 */
 	const POCO            = 'http://portablecontacts.net/spec/1.0';
+	/**
+	 * OpenWebAuth is used by Friendica and Hubzilla to authenticate at remote systems
+	 *
+	 * @var string
+	 */
+	const OPENWEBAUTH     = 'http://purl.org/openwebauth/v1';
 	/**
 	 * @var string
 	 */

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -56,7 +56,7 @@ use Friendica\Database\DBA;
 
 // This file is required several times during the test in DbaDefinition which justifies this condition
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1560);
+	define('DB_UPDATE_VERSION', 1561);
 }
 
 return [
@@ -79,6 +79,7 @@ return [
 			"local-comments" => ["type" => "int unsigned", "comment" => "Number of local comments"],
 			"directory-type" => ["type" => "tinyint", "default" => "0", "comment" => "Type of directory service (Poco, Mastodon)"],
 			"poco" => ["type" => "varbinary(383)", "not null" => "1", "default" => "", "comment" => ""],
+			"openwebauth" => ["type" => "varbinary(383)", "comment" => "Path to the OpenWebAuth endpoint"],
 			"noscrape" => ["type" => "varbinary(383)", "not null" => "1", "default" => "", "comment" => ""],
 			"network" => ["type" => "char(4)", "not null" => "1", "default" => "", "comment" => ""],
 			"protocol" => ["type" => "tinyint unsigned", "comment" => "The protocol of the server"],


### PR DESCRIPTION
The whole probing is improved by using much more constants. Also the path for OpenWebAuth is now stored at the server. This is a preparation for the remote login at Hubzilla systems. (This isn't possible by now and there will be much more to do, to enable this)