### PR TITLE
Provide OpenWebAuth related data

### DIFF
--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -737,7 +737,7 @@ class GServer
 			}
 		}
 
-		if (in_array($serverdata['platform'] ?? '', ['hubzilla', 'streams', 'osada', 'mistpark', 'roadhouse', 'zap'])) {
+		if (in_array($serverdata['platform'] ?? '', ['friendica', 'hubzilla', 'streams', 'osada', 'mistpark', 'roadhouse', 'zap'])) {
 			$serverdata = self::getZotData($url, $serverdata);
 		}
 
@@ -1673,7 +1673,7 @@ class GServer
 			$serverdata['info'] = $data['location'];
 		}
 
-		if (!empty($data['project']) && in_array($data['project'], ['hubzilla', 'streams', 'osada', 'mistpark', 'roadhouse', 'zap'])) {
+		if (!empty($data['project']) && in_array($data['project'], ['friendica', 'hubzilla', 'streams', 'osada', 'mistpark', 'roadhouse', 'zap'])) {
 			$serverdata['platform'] = $data['project'];
 		}
 
@@ -1691,9 +1691,6 @@ class GServer
 					break;
 				case 'approve':
 					$serverdata['register_policy'] = Register::APPROVE;
-					break;
-				default:
-					echo $data['register_policy'] . "\n";
 					break;
 			}
 		}
@@ -2568,17 +2565,17 @@ class GServer
 			return;
 		}
 
-		$gserver = DBA::selectFirst('gserver', ['openwebauth'], ['id' => $data['gsid']]);
+		$gserver = DBA::selectFirst('gserver', ['url', 'openwebauth'], ['id' => $data['gsid']]);
 		if (!DBA::isResult($gserver)) {
 			return;
 		}
 
-		if ($data['openwebauth'] == $gserver['openwebauth']) {
-			return;
+		$serverdata = self::getZotData($gserver['url'], []);
+		if (empty($serverdata)) {
+			$serverdata = ['openwebauth' => $data['openwebauth']];
 		}
 
-		Logger::debug('Set Open Web Auth path', ['baseurl' => $data['baseurl'], 'openwebauth' => $data['openwebauth']]);
-		self::update(['openwebauth' => $data['openwebauth']], ['id' => $data['gsid']]);
+		self::update($serverdata, ['id' => $data['gsid']]);
 	}
 
 	/**

--- a/src/Module/Home.php
+++ b/src/Module/Home.php
@@ -28,6 +28,7 @@ use Friendica\DI;
 use Friendica\Model\User;
 use Friendica\Module\Security\Login;
 use Friendica\Protocol\ActivityPub;
+use Friendica\Protocol\ZOT;
 
 /**
  * Home module - Landing page of the current node
@@ -38,6 +39,8 @@ class Home extends BaseModule
 	{
 		if (ActivityPub::isRequest()) {
 			DI::baseUrl()->redirect(User::getActorName());
+		} elseif (ZOT::isRequest()) {
+			$this->jsonExit(ZOT::getSiteInfo(), 'application/x-zot+json');
 		}
 	}
 

--- a/src/Protocol/ZOT.php
+++ b/src/Protocol/ZOT.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2024, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Protocol;
+
+use Friendica\App;
+use Friendica\Core\Addon;
+use Friendica\Core\Logger;
+use Friendica\DI;
+use Friendica\Module;
+use Friendica\Module\Register;
+
+/**
+ * ZOT Protocol class
+ *
+ * This class contains functionality that is needed for OpenWebAuth, which is part of ZOT.
+ * Friendica doesn't support the ZOT protocol itself.
+ */
+class ZOT
+{
+	/**
+	 * Checks if the web request is done for the AP protocol
+	 *
+	 * @return bool is it ZOT?
+	 */
+	public static function isRequest(): bool
+	{
+		if (stristr($_SERVER['HTTP_ACCEPT'] ?? '', 'application/x-zot+json')) {
+			Logger::debug('Is ZOT request', ['accept' => $_SERVER['HTTP_ACCEPT'], 'agent' => $_SERVER['HTTP_USER_AGENT'] ?? '']);
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get information about this site
+	 *
+	 * @return array
+	 */
+	public static function getSiteInfo(): array
+	{
+		$policies = [
+			Module\Register::OPEN    => 'open',
+			Module\Register::APPROVE => 'approve',
+			Module\Register::CLOSED  => 'closed',
+		];
+
+		return [
+			'url'             => (string)DI::baseUrl(),
+			'openWebAuth'     => (string)DI::baseUrl() . '/owa',
+			'authRedirect'    => (string)DI::baseUrl() . '/magic',
+			'register_policy' => $policies[Register::getPolicy()],
+			'accounts'        => DI::keyValue()->get('nodeinfo_total_users'),
+			'plugins'         => Addon::getVisibleList(),
+			'sitename'        => DI::config()->get('config', 'sitename'),
+			'about'           => DI::config()->get('config', 'info'),
+			'project'         => App::PLATFORM,
+			'version'         => App::VERSION,
+		];
+	}
+}


### PR DESCRIPTION
We now provide some ZOT related data to publish the endpoints that are used form OpenWebAuth. We don't support ZOT, so we only publish some ZOT related data like the two endpoints and some basic site information.