### PR TITLE
Add documentation about behaviour of blocks

### DIFF
--- a/doc/Making-Friends.md
+++ b/doc/Making-Friends.md
@@ -107,5 +107,7 @@ They think they are a friend.
 You can also "block" a person.
 This completely blocks communications with that person.
 They may still be able to see your public posts, as can anybody in the world, but they cannot communicate with you directly.
+Friendica will notify their server that you have blocked them, although normally that server should not notify them individually.
+However, there are various simple ways they can deduce that they have been blocked if they investigate.
 
 You can also delete a friend no matter what the friendship status - which completely removes everything relating to that person from your website.


### PR DESCRIPTION
This adds a little documentation about how blocking works, compared to muting.  I only just realised this myself!  Until now I assumed blocks only affected my own server, that they did not send any kind of moderation report to the blocked account's server.  This very much changes my mental model about what blocks can do.

I've seen people suggesting that the current behaviour is dangerous.  If you are being harrassed by someone, you block them, and they are notified of the block, that's likely to lead to an escalation of the harrassment.  In practice that's why most software does not notify the blocked account.  However, that depends on the administrator of the notified server co-operating - and they might be the person doing the harrassment.  So it seems worth documenting for users.