### PR TITLE
Fix remote login issues between Friendica instances

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -795,7 +795,7 @@ class Profile
 
 		// Authenticate the visitor.
 		DI::userSession()->setMultiple([
-			'authenticated'  => 1,
+			'authenticated'  => 0,
 			'visitor_id'     => $visitor['id'],
 			'visitor_handle' => $visitor['addr'],
 			'visitor_home'   => $visitor['url'],

--- a/src/Module/Magic.php
+++ b/src/Module/Magic.php
@@ -156,9 +156,7 @@ class Magic extends BaseModule
 
 		$header = [
 			'Accept'          => 'application/x-zot+json',
-			'Content-Type'    => 'application/x-zot+json',
 			'X-Open-Web-Auth' => Strings::getRandomHex(),
-			'Host'            => strtolower(parse_url($gserver['url'], PHP_URL_HOST)),
 		];
 
 		// Create a header that is signed with the local users private key.


### PR DESCRIPTION
This fixes two issues. The previous PR prevented authentication on a remote Friendica instance. This is fixed.

The second fix touches the issue, that with the remote authentication the system displayed the "system user" as logged in user. Remote accounts aren't considered as "logged in" anymore.