### PR TITLE
Reduce probing / handle exception for invalid url / always check for https

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2124,7 +2124,12 @@ class BBCode
 		}
 
 		$parts['host'] = idn_to_ascii(urldecode($parts['host']));
-		return (string)Uri::fromParts($parts);
+		try {
+			return (string)Uri::fromParts($parts);
+		} catch (\Throwable $th) {
+			Logger::notice('Exception on unparsing url', ['url' => $url, 'parts' => $parts, 'code' => $th->getCode(), 'message' => $th->getMessage()]);
+			return $url;
+		}
 	}
 
 	private static function unifyLinks(string $text): string


### PR DESCRIPTION
This PR handles three related topics.
Under certain circumstances we queried remote systems relly often during probing. This is reduced. Also an exception is now handles that occurs on invalid url. And finally we now try to switch to HTTPS during contact probing.