### PR TITLE
Don't display wordpress accounts in the forumlist

### DIFF
--- a/src/Content/GroupManager.php
+++ b/src/Content/GroupManager.php
@@ -66,7 +66,7 @@ class GroupManager
 			'archive' => false,
 		];
 
-		$condition = DBA::mergeConditions($condition, ["`platform` != ?", 'peertube']);
+		$condition = DBA::mergeConditions($condition, ["`platform` NOT IN (?, ?)", 'peertube', 'wordpress']);
 
 		if (!$showprivate) {
 			$condition = DBA::mergeConditions($condition, ['manually-approve' => false]);


### PR DESCRIPTION
This fixes the issue that the forumlist displays wordpress accounts. There we only should display group accounts that behave like our groups, Lemmy, Kbin, Mbin or gup.pe.