### PR TITLE
Improve adding of alt descriptions when linking images

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2646,7 +2646,7 @@ class BBCode
 					$bbcode = "\n" . '[audio]' . $url . '[/audio]' . "\n";
 					break;
 				default:
-					$bbcode = "\n" . '[img]' . $url . '[/img]' . "\n";
+					$bbcode = "\n" . '[img=' . $url . '][/img]' . "\n";
 					break;
 			}
 

--- a/view/js/linkPreview.js
+++ b/view/js/linkPreview.js
@@ -200,7 +200,7 @@
 			if (!isExtern) {
 				return;
 			}
-			var bbcode = '\n[img]' + data.url + '[/img]\n';
+			var bbcode = '\n[img=' + data.url + '][/img]\n';
 			addeditortext(bbcode);
 		};
 


### PR DESCRIPTION
We now use the BBCode formaz where alt descriptions can be added easier.

See also here: https://forum.friendi.ca/display/373ebf56-1666-2f42-55b7-cdf380384421