### PR TITLE
Support for "nodeDescription" in nodeinfo

### DIFF
--- a/src/Module/NodeInfo120.php
+++ b/src/Module/NodeInfo120.php
@@ -59,7 +59,8 @@ class NodeInfo120 extends BaseModule
 			'openRegistrations' => Register::getPolicy() !== Register::CLOSED,
 			'usage'             => Nodeinfo::getUsage(),
 			'metadata'          => [
-				'nodeName' => $this->config->get('config', 'sitename'),
+				'nodeName'        => $this->config->get('config', 'sitename'),
+				'nodeDescription' => $this->config->get('config', 'info'),
 			],
 		];
 

--- a/src/Module/NodeInfo121.php
+++ b/src/Module/NodeInfo121.php
@@ -60,7 +60,10 @@ class NodeInfo121 extends BaseModule
 			'services'          => Nodeinfo::getServices(),
 			'openRegistrations' => Register::getPolicy() !== Register::CLOSED,
 			'usage'             => Nodeinfo::getUsage(),
-			'metadata'          => [],
+			'metadata'          => [
+				'nodeName'        => $this->config->get('config', 'sitename'),
+				'nodeDescription' => $this->config->get('config', 'info'),
+			],
 		];
 
 		if (!empty($this->config->get('system', 'diaspora_enabled'))) {

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -491,7 +491,8 @@ return [
 	'/logout'             => [Module\Security\Logout::class, [R::GET, R::POST]],
 	'/magic'              => [Module\Magic::class,           [R::GET]],
 	'/manifest'           => [Module\Manifest::class,        [R::GET]],
-	'/friendica.webmanifest'  => [Module\Manifest::class,    [R::GET]],
+	'/manifest.json'      => [Module\Manifest::class,        [R::GET]],
+	'/friendica.webmanifest' => [Module\Manifest::class,     [R::GET]],
 
 	'/media' => [
 		'/attachment/browser'      => [Module\Media\Attachment\Browser::class, [R::GET]],


### PR DESCRIPTION
This enables support for the widely used field "nodeDescription" in Nodeinfo:
https://codeberg.org/thefederationinfo/nodeinfo_metadata_survey

Also it adds an alternative parr to the manifest, since systems seem use that endpoint.