### PR TITLE
Add addon hook for additional moderation tabs

### DIFF
--- a/src/Module/Moderation/BaseUsers.php
+++ b/src/Module/Moderation/BaseUsers.php
@@ -22,6 +22,7 @@
 namespace Friendica\Module\Moderation;
 
 use Friendica\App;
+use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
@@ -106,9 +107,11 @@ abstract class BaseUsers extends BaseModeration
 				'accesskey' => 'd',
 			],
 		];
+		$tabs_arr = ['tabs' => $tabs, 'selectedTab' => $selectedTab];
+		Hook::callAll('moderation_users_tabs', $tabs_arr);
 
 		$tpl = Renderer::getMarkupTemplate('common_tabs.tpl');
-		return Renderer::replaceMacros($tpl, ['$tabs' => $tabs]);
+		return Renderer::replaceMacros($tpl, ['$tabs' => $tabs_arr['tabs']]);
 	}
 
 	protected function setupUserCallback(): \Closure


### PR DESCRIPTION
I'd been thinking for a while that I'd like more metrics about my interactions with other people on the network.  Then I saw [a request for something similar](https://xoxo.zone/@fraying/112644787955619828) and thought I'd have a go.  The small problem is that there's no easy way to insert that info into the obvious place in the moderation panels.  So this adds that hook.

I think kind of thing is best done as an addon, rather than in core.  There are many statistics that people might find interesting, so it'd be good if they can experiment without disturbing the core system.  Also, my prototype is really not useful for larger instances, which would require a more complex implementation.

For an example of how to use the hook, see [this PR](https://git.friendi.ca/friendica/friendica-addons/pulls/1518) in the addons repo.