### PR TITLE
Fetch replies to fetched posts

### DIFF
--- a/doc/database/db_post-user.md
+++ b/doc/database/db_post-user.md
@@ -6,39 +6,40 @@ User specific post data
 Fields
 ------
 
-| Field             | Description                                                                       | Type               | Null | Key | Default             | Extra          |
-| ----------------- | --------------------------------------------------------------------------------- | ------------------ | ---- | --- | ------------------- | -------------- |
-| id                |                                                                                   | int unsigned       | NO   | PRI | NULL                | auto_increment |
-| uri-id            | Id of the item-uri table entry that contains the item uri                         | int unsigned       | NO   |     | NULL                |                |
-| parent-uri-id     | Id of the item-uri table that contains the parent uri                             | int unsigned       | YES  |     | NULL                |                |
-| thr-parent-id     | Id of the item-uri table that contains the thread parent uri                      | int unsigned       | YES  |     | NULL                |                |
-| external-id       | Id of the item-uri table entry that contains the external uri                     | int unsigned       | YES  |     | NULL                |                |
-| created           | Creation timestamp.                                                               | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
-| edited            | Date of last edit (default is created)                                            | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
-| received          | datetime                                                                          | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
-| gravity           |                                                                                   | tinyint unsigned   | NO   |     | 0                   |                |
-| network           | Network from where the item comes from                                            | char(4)            | NO   |     |                     |                |
-| owner-id          | Link to the contact table with uid=0 of the owner of this item                    | int unsigned       | NO   |     | 0                   |                |
-| author-id         | Link to the contact table with uid=0 of the author of this item                   | int unsigned       | NO   |     | 0                   |                |
-| causer-id         | Link to the contact table with uid=0 of the contact that caused the item creation | int unsigned       | YES  |     | NULL                |                |
-| post-type         | Post type (personal note, image, article, ...)                                    | tinyint unsigned   | NO   |     | 0                   |                |
-| post-reason       | Reason why the post arrived at the user                                           | tinyint unsigned   | NO   |     | 0                   |                |
-| vid               | Id of the verb table entry that contains the activity verbs                       | smallint unsigned  | YES  |     | NULL                |                |
-| private           | 0=public, 1=private, 2=unlisted                                                   | tinyint unsigned   | NO   |     | 0                   |                |
-| restrictions      | Bit array of post restrictions (1 = Reply, 2 = Like, 4 = Announce)                | tinyint unsigned   | YES  |     | NULL                |                |
-| global            |                                                                                   | boolean            | NO   |     | 0                   |                |
-| visible           |                                                                                   | boolean            | NO   |     | 0                   |                |
-| deleted           | item has been marked for deletion                                                 | boolean            | NO   |     | 0                   |                |
-| uid               | Owner id which owns this copy of the item                                         | mediumint unsigned | NO   |     | NULL                |                |
-| protocol          | Protocol used to deliver the item for this user                                   | tinyint unsigned   | YES  |     | NULL                |                |
-| contact-id        | contact.id                                                                        | int unsigned       | NO   |     | 0                   |                |
-| event-id          | Used to link to the event.id                                                      | int unsigned       | YES  |     | NULL                |                |
-| unseen            | post has not been seen                                                            | boolean            | NO   |     | 1                   |                |
-| hidden            | Marker to hide the post from the user                                             | boolean            | NO   |     | 0                   |                |
-| notification-type |                                                                                   | smallint unsigned  | NO   |     | 0                   |                |
-| wall              | This item was posted to the wall of uid                                           | boolean            | NO   |     | 0                   |                |
-| origin            | item originated at this site                                                      | boolean            | NO   |     | 0                   |                |
-| psid              | ID of the permission set of this post                                             | int unsigned       | YES  |     | NULL                |                |
+| Field             | Description                                                                          | Type               | Null | Key | Default             | Extra          |
+| ----------------- | ------------------------------------------------------------------------------------ | ------------------ | ---- | --- | ------------------- | -------------- |
+| id                |                                                                                      | int unsigned       | NO   | PRI | NULL                | auto_increment |
+| uri-id            | Id of the item-uri table entry that contains the item uri                            | int unsigned       | NO   |     | NULL                |                |
+| parent-uri-id     | Id of the item-uri table that contains the parent uri                                | int unsigned       | YES  |     | NULL                |                |
+| thr-parent-id     | Id of the item-uri table that contains the thread parent uri                         | int unsigned       | YES  |     | NULL                |                |
+| external-id       | Id of the item-uri table entry that contains the external uri                        | int unsigned       | YES  |     | NULL                |                |
+| replies-id        | Id of the item-uri table entry that contains the endpoint for the replies collection | int unsigned       | YES  |     | NULL                |                |
+| created           | Creation timestamp.                                                                  | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
+| edited            | Date of last edit (default is created)                                               | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
+| received          | datetime                                                                             | datetime           | NO   |     | 0001-01-01 00:00:00 |                |
+| gravity           |                                                                                      | tinyint unsigned   | NO   |     | 0                   |                |
+| network           | Network from where the item comes from                                               | char(4)            | NO   |     |                     |                |
+| owner-id          | Link to the contact table with uid=0 of the owner of this item                       | int unsigned       | NO   |     | 0                   |                |
+| author-id         | Link to the contact table with uid=0 of the author of this item                      | int unsigned       | NO   |     | 0                   |                |
+| causer-id         | Link to the contact table with uid=0 of the contact that caused the item creation    | int unsigned       | YES  |     | NULL                |                |
+| post-type         | Post type (personal note, image, article, ...)                                       | tinyint unsigned   | NO   |     | 0                   |                |
+| post-reason       | Reason why the post arrived at the user                                              | tinyint unsigned   | NO   |     | 0                   |                |
+| vid               | Id of the verb table entry that contains the activity verbs                          | smallint unsigned  | YES  |     | NULL                |                |
+| private           | 0=public, 1=private, 2=unlisted                                                      | tinyint unsigned   | NO   |     | 0                   |                |
+| restrictions      | Bit array of post restrictions (1 = Reply, 2 = Like, 4 = Announce)                   | tinyint unsigned   | YES  |     | NULL                |                |
+| global            |                                                                                      | boolean            | NO   |     | 0                   |                |
+| visible           |                                                                                      | boolean            | NO   |     | 0                   |                |
+| deleted           | item has been marked for deletion                                                    | boolean            | NO   |     | 0                   |                |
+| uid               | Owner id which owns this copy of the item                                            | mediumint unsigned | NO   |     | NULL                |                |
+| protocol          | Protocol used to deliver the item for this user                                      | tinyint unsigned   | YES  |     | NULL                |                |
+| contact-id        | contact.id                                                                           | int unsigned       | NO   |     | 0                   |                |
+| event-id          | Used to link to the event.id                                                         | int unsigned       | YES  |     | NULL                |                |
+| unseen            | post has not been seen                                                               | boolean            | NO   |     | 1                   |                |
+| hidden            | Marker to hide the post from the user                                                | boolean            | NO   |     | 0                   |                |
+| notification-type |                                                                                      | smallint unsigned  | NO   |     | 0                   |                |
+| wall              | This item was posted to the wall of uid                                              | boolean            | NO   |     | 0                   |                |
+| origin            | item originated at this site                                                         | boolean            | NO   |     | 0                   |                |
+| psid              | ID of the permission set of this post                                                | int unsigned       | YES  |     | NULL                |                |
 
 Indexes
 ------------
@@ -51,6 +52,7 @@ Indexes
 | parent-uri-id        | parent-uri-id           |
 | thr-parent-id        | thr-parent-id           |
 | external-id          | external-id             |
+| replies-id           | replies-id              |
 | owner-id             | owner-id                |
 | author-id            | author-id               |
 | causer-id            | causer-id               |
@@ -77,6 +79,7 @@ Foreign Keys
 | parent-uri-id | [item-uri](help/database/db_item-uri) | id |
 | thr-parent-id | [item-uri](help/database/db_item-uri) | id |
 | external-id | [item-uri](help/database/db_item-uri) | id |
+| replies-id | [item-uri](help/database/db_item-uri) | id |
 | owner-id | [contact](help/database/db_contact) | id |
 | author-id | [contact](help/database/db_contact) | id |
 | causer-id | [contact](help/database/db_contact) | id |

--- a/doc/database/db_post.md
+++ b/doc/database/db_post.md
@@ -6,26 +6,27 @@ Structure for all posts
 Fields
 ------
 
-| Field         | Description                                                                       | Type              | Null | Key | Default             | Extra |
-| ------------- | --------------------------------------------------------------------------------- | ----------------- | ---- | --- | ------------------- | ----- |
-| uri-id        | Id of the item-uri table entry that contains the item uri                         | int unsigned      | NO   | PRI | NULL                |       |
-| parent-uri-id | Id of the item-uri table that contains the parent uri                             | int unsigned      | YES  |     | NULL                |       |
-| thr-parent-id | Id of the item-uri table that contains the thread parent uri                      | int unsigned      | YES  |     | NULL                |       |
-| external-id   | Id of the item-uri table entry that contains the external uri                     | int unsigned      | YES  |     | NULL                |       |
-| created       | Creation timestamp.                                                               | datetime          | NO   |     | 0001-01-01 00:00:00 |       |
-| edited        | Date of last edit (default is created)                                            | datetime          | NO   |     | 0001-01-01 00:00:00 |       |
-| received      | datetime                                                                          | datetime          | NO   |     | 0001-01-01 00:00:00 |       |
-| gravity       |                                                                                   | tinyint unsigned  | NO   |     | 0                   |       |
-| network       | Network from where the item comes from                                            | char(4)           | NO   |     |                     |       |
-| owner-id      | Link to the contact table with uid=0 of the owner of this item                    | int unsigned      | NO   |     | 0                   |       |
-| author-id     | Link to the contact table with uid=0 of the author of this item                   | int unsigned      | NO   |     | 0                   |       |
-| causer-id     | Link to the contact table with uid=0 of the contact that caused the item creation | int unsigned      | YES  |     | NULL                |       |
-| post-type     | Post type (personal note, image, article, ...)                                    | tinyint unsigned  | NO   |     | 0                   |       |
-| vid           | Id of the verb table entry that contains the activity verbs                       | smallint unsigned | YES  |     | NULL                |       |
-| private       | 0=public, 1=private, 2=unlisted                                                   | tinyint unsigned  | NO   |     | 0                   |       |
-| global        |                                                                                   | boolean           | NO   |     | 0                   |       |
-| visible       |                                                                                   | boolean           | NO   |     | 0                   |       |
-| deleted       | item has been marked for deletion                                                 | boolean           | NO   |     | 0                   |       |
+| Field         | Description                                                                          | Type              | Null | Key | Default             | Extra |
+| ------------- | ------------------------------------------------------------------------------------ | ----------------- | ---- | --- | ------------------- | ----- |
+| uri-id        | Id of the item-uri table entry that contains the item uri                            | int unsigned      | NO   | PRI | NULL                |       |
+| parent-uri-id | Id of the item-uri table that contains the parent uri                                | int unsigned      | YES  |     | NULL                |       |
+| thr-parent-id | Id of the item-uri table that contains the thread parent uri                         | int unsigned      | YES  |     | NULL                |       |
+| external-id   | Id of the item-uri table entry that contains the external uri                        | int unsigned      | YES  |     | NULL                |       |
+| replies-id    | Id of the item-uri table entry that contains the endpoint for the replies collection | int unsigned      | YES  |     | NULL                |       |
+| created       | Creation timestamp.                                                                  | datetime          | NO   |     | 0001-01-01 00:00:00 |       |
+| edited        | Date of last edit (default is created)                                               | datetime          | NO   |     | 0001-01-01 00:00:00 |       |
+| received      | datetime                                                                             | datetime          | NO   |     | 0001-01-01 00:00:00 |       |
+| gravity       |                                                                                      | tinyint unsigned  | NO   |     | 0                   |       |
+| network       | Network from where the item comes from                                               | char(4)           | NO   |     |                     |       |
+| owner-id      | Link to the contact table with uid=0 of the owner of this item                       | int unsigned      | NO   |     | 0                   |       |
+| author-id     | Link to the contact table with uid=0 of the author of this item                      | int unsigned      | NO   |     | 0                   |       |
+| causer-id     | Link to the contact table with uid=0 of the contact that caused the item creation    | int unsigned      | YES  |     | NULL                |       |
+| post-type     | Post type (personal note, image, article, ...)                                       | tinyint unsigned  | NO   |     | 0                   |       |
+| vid           | Id of the verb table entry that contains the activity verbs                          | smallint unsigned | YES  |     | NULL                |       |
+| private       | 0=public, 1=private, 2=unlisted                                                      | tinyint unsigned  | NO   |     | 0                   |       |
+| global        |                                                                                      | boolean           | NO   |     | 0                   |       |
+| visible       |                                                                                      | boolean           | NO   |     | 0                   |       |
+| deleted       | item has been marked for deletion                                                    | boolean           | NO   |     | 0                   |       |
 
 Indexes
 ------------
@@ -36,6 +37,7 @@ Indexes
 | parent-uri-id | parent-uri-id |
 | thr-parent-id | thr-parent-id |
 | external-id   | external-id   |
+| replies-id    | replies-id    |
 | owner-id      | owner-id      |
 | author-id     | author-id     |
 | causer-id     | causer-id     |
@@ -50,6 +52,7 @@ Foreign Keys
 | parent-uri-id | [item-uri](help/database/db_item-uri) | id |
 | thr-parent-id | [item-uri](help/database/db_item-uri) | id |
 | external-id | [item-uri](help/database/db_item-uri) | id |
+| replies-id | [item-uri](help/database/db_item-uri) | id |
 | owner-id | [contact](help/database/db_contact) | id |
 | author-id | [contact](help/database/db_contact) | id |
 | causer-id | [contact](help/database/db_contact) | id |

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -198,6 +198,10 @@ class Item
 			$fields['external-id'] = ItemURI::getIdByURI($fields['extid']);
 		}
 
+		if (!empty($fields['replies'])) {
+			$fields['replies-id'] = ItemURI::getIdByURI($fields['replies']);
+		}
+
 		if (!empty($fields['verb'])) {
 			$fields['vid'] = Verb::getID($fields['verb']);
 		}
@@ -1163,6 +1167,10 @@ class Item
 
 		if (!empty($item['extid'])) {
 			$item['external-id'] = ItemURI::getIdByURI($item['extid']);
+		}
+
+		if (!empty($item['replies'])) {
+			$item['replies-id'] = ItemURI::getIdByURI($item['replies']);
 		}
 
 		if ($item['verb'] == Activity::ANNOUNCE) {

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -88,9 +88,9 @@ class ActivityPub
 	];
 	const ACCOUNT_TYPES = ['Person', 'Organization', 'Service', 'Group', 'Application', 'Tombstone'];
 
-	CONST ARTICLE_DEFAULT     = 0;
-	CONST ARTICLE_USE_SUMMARY = 1;
-	CONST ARTICLE_EMBED_TITLE = 2;
+	const ARTICLE_DEFAULT     = 0;
+	const ARTICLE_USE_SUMMARY = 1;
+	const ARTICLE_EMBED_TITLE = 2;
 
 	/**
 	 * Checks if the web request is done for the AP protocol
@@ -259,13 +259,19 @@ class ActivityPub
 			$items = $data['orderedItems'];
 		} elseif (!empty($data['first']['orderedItems'])) {
 			$items = $data['first']['orderedItems'];
+		} elseif (!empty($data['items'])) {
+			$items = $data['items'];
+		} elseif (!empty($data['first']['items'])) {
+			$items = $data['first']['items'];
 		} elseif (!empty($data['first']) && is_string($data['first']) && ($data['first'] != $url)) {
 			return self::fetchItems($data['first'], $uid, $start_timestamp);
 		} else {
 			return [];
 		}
 
-		if (!empty($data['next']) && is_string($data['next'])) {
+		if (!empty($data['first']['next']) && is_string($data['first']['next'])) {
+			$items = array_merge($items, self::fetchItems($data['first']['next'], $uid, $start_timestamp));
+		} elseif (!empty($data['next']) && is_string($data['next'])) {
 			$items = array_merge($items, self::fetchItems($data['next'], $uid, $start_timestamp));
 		}
 

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -2070,6 +2070,7 @@ class Receiver
 		$object_data['generator'] = JsonLD::fetchElement($object, 'as:generator', 'as:name', '@type', 'as:Application');
 		$object_data['generator'] = JsonLD::fetchElement($object_data, 'generator', '@value');
 		$object_data['alternate-url'] = JsonLD::fetchElement($object, 'as:url', '@id');
+		$object_data['replies'] = JsonLD::fetchElement($object, 'as:replies', '@id');
 
 		// Special treatment for Hubzilla links
 		if (is_array($object_data['alternate-url'])) {

--- a/src/Worker/ExpirePosts.php
+++ b/src/Worker/ExpirePosts.php
@@ -203,6 +203,7 @@ class ExpirePosts
 			AND NOT EXISTS(SELECT `parent-uri-id` FROM `post-user` WHERE `parent-uri-id` = `item-uri`.`id`)
 			AND NOT EXISTS(SELECT `thr-parent-id` FROM `post-user` WHERE `thr-parent-id` = `item-uri`.`id`)
 			AND NOT EXISTS(SELECT `external-id` FROM `post-user` WHERE `external-id` = `item-uri`.`id`)
+			AND NOT EXISTS(SELECT `replies-id` FROM `post-user` WHERE `replies-id` = `item-uri`.`id`)
 			AND NOT EXISTS(SELECT `conversation-id` FROM `post-thread` WHERE `conversation-id` = `item-uri`.`id`)
 			AND NOT EXISTS(SELECT `uri-id` FROM `mail` WHERE `uri-id` = `item-uri`.`id`)
 			AND NOT EXISTS(SELECT `uri-id` FROM `event` WHERE `uri-id` = `item-uri`.`id`)

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -56,7 +56,7 @@ use Friendica\Database\DBA;
 
 // This file is required several times during the test in DbaDefinition which justifies this condition
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1568);
+	define('DB_UPDATE_VERSION', 1569);
 }
 
 return [
@@ -1222,6 +1222,7 @@ return [
 			"parent-uri-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table that contains the parent uri"],
 			"thr-parent-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table that contains the thread parent uri"],
 			"external-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the external uri"],
+			"replies-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the endpoint for the replies collection"],
 			"created" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "Creation timestamp."],
 			"edited" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "Date of last edit (default is created)"],
 			"received" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "datetime"],
@@ -1242,6 +1243,7 @@ return [
 			"parent-uri-id" => ["parent-uri-id"],
 			"thr-parent-id" => ["thr-parent-id"],
 			"external-id" => ["external-id"],
+			"replies-id" => ["replies-id"],
 			"owner-id" => ["owner-id"],
 			"author-id" => ["author-id"],
 			"causer-id" => ["causer-id"],
@@ -1581,6 +1583,7 @@ return [
 			"parent-uri-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table that contains the parent uri"],
 			"thr-parent-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table that contains the thread parent uri"],
 			"external-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the external uri"],
+			"replies-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the endpoint for the replies collection"],
 			"created" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "Creation timestamp."],
 			"edited" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "Date of last edit (default is created)"],
 			"received" => ["type" => "datetime", "not null" => "1", "default" => DBA::NULL_DATETIME, "comment" => "datetime"],
@@ -1615,6 +1618,7 @@ return [
 			"parent-uri-id" => ["parent-uri-id"],
 			"thr-parent-id" => ["thr-parent-id"],
 			"external-id" => ["external-id"],
+			"replies-id" => ["replies-id"],
 			"owner-id" => ["owner-id"],
 			"author-id" => ["author-id"],
 			"causer-id" => ["causer-id"],

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -268,6 +268,8 @@
 			"gravity" => ["post-origin", "gravity"],
 			"extid" => ["external-item-uri", "uri"],
 			"external-id" => ["post-user", "external-id"],
+			"replies" => ["replies-item-uri", "uri"],
+			"replies-id" => ["post-user", "replies-id"],
 			"created" => ["post-origin", "created"],
 			"edited" => ["post-user", "edited"],
 			"commented" => ["post-thread-user", "commented"],
@@ -423,6 +425,7 @@
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post-origin`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread-user`.`conversation-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post-user`.`external-id`
+			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post-user`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post-origin`.`vid`
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-origin`.`uri-id`
@@ -454,6 +457,8 @@
 			"gravity" => ["post-origin", "gravity"],
 			"extid" => ["external-item-uri", "uri"],
 			"external-id" => ["post-user", "external-id"],
+			"replies" => ["replies-item-uri", "uri"],
+			"replies-id" => ["post-user", "replies-id"],
 			"created" => ["post-origin", "created"],
 			"edited" => ["post-user", "edited"],
 			"commented" => ["post-thread-user", "commented"],
@@ -608,6 +613,7 @@
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post-origin`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread-user`.`conversation-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post-user`.`external-id`
+			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post-user`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post-origin`.`vid`
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-origin`.`uri-id`
@@ -638,6 +644,8 @@
 			"gravity" => ["post-user", "gravity"],
 			"extid" => ["external-item-uri", "uri"],
 			"external-id" => ["post-user", "external-id"],
+			"replies" => ["replies-item-uri", "uri"],
+			"replies-id" => ["post-user", "replies-id"],
 			"created" => ["post-user", "created"],
 			"edited" => ["post-user", "edited"],
 			"commented" => ["post-thread-user", "commented"],
@@ -792,6 +800,7 @@
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post-user`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread-user`.`conversation-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post-user`.`external-id`
+			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post-user`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post-user`.`vid`
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-user`.`uri-id`
@@ -823,6 +832,8 @@
 			"gravity" => ["post-user", "gravity"],
 			"extid" => ["external-item-uri", "uri"],
 			"external-id" => ["post-user", "external-id"],
+			"replies" => ["replies-item-uri", "uri"],
+			"replies-id" => ["post-user", "replies-id"],
 			"created" => ["post-thread-user", "created"],
 			"edited" => ["post-user", "edited"],
 			"commented" => ["post-thread-user", "commented"],
@@ -976,6 +987,7 @@
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post-user`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread-user`.`conversation-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post-user`.`external-id`
+			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post-user`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post-user`.`vid`
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-thread-user`.`uri-id`
@@ -1001,6 +1013,8 @@
 			"gravity" => ["post", "gravity"],
 			"extid" => ["external-item-uri", "uri"],
 			"external-id" => ["post", "external-id"],
+			"replies" => ["replies-item-uri", "uri"],
+			"replies-id" => ["post", "replies-id"],
 			"created" => ["post", "created"],
 			"edited" => ["post", "edited"],
 			"commented" => ["post-thread", "commented"],
@@ -1123,6 +1137,7 @@
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread`.`conversation-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post`.`external-id`
+			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post`.`vid`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post`.`uri-id`
@@ -1146,6 +1161,8 @@
 			"gravity" => ["post", "gravity"],
 			"extid" => ["external-item-uri", "uri"],
 			"external-id" => ["post", "external-id"],
+			"replies" => ["replies-item-uri", "uri"],
+			"replies-id" => ["post", "replies-id"],
 			"created" => ["post-thread", "created"],
 			"edited" => ["post", "edited"],
 			"commented" => ["post-thread", "commented"],
@@ -1270,6 +1287,7 @@
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread`.`conversation-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post`.`external-id`
+			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post`.`vid`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-thread`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post-thread`.`uri-id`


### PR DESCRIPTION
This partially fixes the problem of incomplete threads. When a post is processed, we now fetch the replies to that post as well. This is only enabled if the decoupled receiver is active, as this takes some time, which could be problematic if it is done on receipt. Also to reduce the stress on the remote system, queries to the same thread are limited to once in 5 minutes.