### PR TITLE
Default to adjusting poll frequency automatically

### DIFF
--- a/static/settings.config.php
+++ b/static/settings.config.php
@@ -54,7 +54,7 @@ return [
 
 		// adjust_poll_frequency (Boolean)
 		// Automatically detect and set the best feed poll frequency.
-		'adjust_poll_frequency' => false,
+		'adjust_poll_frequency' => true,
 
 		// allow_relay_channels (Boolean)
 		// Allow Users to set remote_self


### PR DESCRIPTION
I've been participating in [this test of RSS feed reader "politeness"](https://rachelbythebay.com/w/2024/05/30/fs/).  Friendica scores badly for a whole bunch of reasons.  Some of those are difficult to fix, but this seems like a simple improvement: by default, adjust the poll frequency according to the frequency of articles found in the feed.

According to [the recommendations](https://rachelbythebay.com/fs/help.html), a reasonable default poll frequency in the absence of any other information is once per day.  By default, without user intervention, Friendica polls every 15 minutes.

I've been manually setting my poll frequency for years and never noticed that this setting existed.  It's likely other users never realised they can/should adjust the poll frequency.  IMO this is a significant improvement in user experience as well as good internet citizenship.