### PR TITLE
Add an explicit network field to the Mastodon API FriendicaExtension.php

### DIFF
--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -213,7 +213,8 @@ class Status extends BaseFactory
 		);
 
 		$sensitive   = (bool)$item['sensitive'];
-		$application = new \Friendica\Object\Api\Mastodon\Application($item['app'] ?: ContactSelector::networkToName($item['network'], $item['author-link']));
+		$network     = ContactSelector::networkToName($item['network'], $item['author-link']);
+		$application = new \Friendica\Object\Api\Mastodon\Application($item['app'] ?: $network);
 
 		$mentions    = $this->mstdnMentionFactory->createFromUriId($uriId)->getArrayCopy();
 		$tags        = $this->mstdnTagFactory->createFromUriId($uriId);
@@ -322,7 +323,7 @@ class Status extends BaseFactory
 
 		$delivery_data   = $uid != $item['uid'] ? null : new FriendicaDeliveryData($item['delivery_queue_count'], $item['delivery_queue_done'], $item['delivery_queue_failed']);
 		$visibility_data = $uid != $item['uid'] ? null : new FriendicaVisibility($this->aclFormatter->expand($item['allow_cid']), $this->aclFormatter->expand($item['deny_cid']), $this->aclFormatter->expand($item['allow_gid']), $this->aclFormatter->expand($item['deny_gid']));
-		$friendica       = new FriendicaExtension($item['title'] ?? '', $item['changed'], $item['commented'], $item['received'], $counts->dislikes, $origin_dislike, $delivery_data, $visibility_data);
+		$friendica       = new FriendicaExtension($item['title'] ?? '', $item['changed'], $item['commented'], $item['received'], $counts->dislikes, $origin_dislike, $network, $delivery_data, $visibility_data);
 
 		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica, $quote, $poll, $emojis);
 	}
@@ -393,7 +394,7 @@ class Status extends BaseFactory
 		$attachments = [];
 		$in_reply    = [];
 		$reshare     = [];
-		$friendica   = new FriendicaExtension('', null, null, null, 0, false, null, null);
+		$friendica   = new FriendicaExtension('', null, null, null, 0, false, null, null, null);
 
 		return new \Friendica\Object\Api\Mastodon\Status($item, $account, $counts, $userAttributes, $sensitive, $application, $mentions, $tags, $card, $attachments, $in_reply, $reshare, $friendica);
 	}

--- a/src/Object/Api/Mastodon/Status/FriendicaExtension.php
+++ b/src/Object/Api/Mastodon/Status/FriendicaExtension.php
@@ -54,6 +54,9 @@ class FriendicaExtension extends BaseDataTransferObject
 	/** @var bool */
 	protected $disliked = false;
 
+	/** @var string|null */
+	protected $network;
+
 	/**
 	 * @var FriendicaVisibility|null
 	 */
@@ -68,6 +71,7 @@ class FriendicaExtension extends BaseDataTransferObject
 	 * @param ?string                $received_at
 	 * @param int                    $dislikes_count
 	 * @param bool                   $disliked
+	 * @param ?string                $network
 	 * @param ?FriendicaDeliveryData $delivery_data
 	 * @param ?FriendicaVisibility   $visibility
 	 * @throws \Exception
@@ -79,6 +83,7 @@ class FriendicaExtension extends BaseDataTransferObject
 		?string $received_at,
 		int $dislikes_count,
 		bool $disliked,
+		?string $network,
 		?FriendicaDeliveryData $delivery_data,
 		?FriendicaVisibility $visibility
 	) {
@@ -89,6 +94,7 @@ class FriendicaExtension extends BaseDataTransferObject
 		$this->delivery_data  = $delivery_data;
 		$this->dislikes_count = $dislikes_count;
 		$this->disliked       = $disliked;
+		$this->network        = $network;
 		$this->visibility     = $visibility;
 	}
 


### PR DESCRIPTION
The Application field has the name of the network if no application data is present. If application data is present then the network data isn't available. This adds a 'network' field to the friendica_extensions area. If no application data is available it will be identical but if it isn't then it preserves the network information in this entry.