### PR TITLE
Use last URL from redirect chain

### DIFF
--- a/src/Network/HTTPClient/Response/GuzzleResponse.php
+++ b/src/Network/HTTPClient/Response/GuzzleResponse.php
@@ -89,7 +89,7 @@ class GuzzleResponse extends Response implements ICanHandleHttpResponses, Respon
 		$headersRedirect = $response->getHeader(RedirectMiddleware::HISTORY_HEADER) ?? [];
 
 		if (count($headersRedirect) > 0) {
-			$this->redirectUrl   = $headersRedirect[0];
+			$this->redirectUrl   = end($headersRedirect);
 			$this->isRedirectUrl = true;
 		}
 	}


### PR DESCRIPTION
According to [the Guzzle documentation](https://docs.guzzlephp.org/en/stable/request-options.html#allow-redirects):
> All URIs and status codes will be stored in the order which the redirects were encountered.

This means that where redirects are chained together, it's the last item that stores the final URL, not the first.

To test:

* Add this log line to OnePoll::pollFeed:

```
		Logger::debug('Polled feed', ['url' => $contact['poll'], 'http-code' => $curlResult->getReturnCode(), 'redirect-url' => $curlResult->getRedirectUrl()]);
```

* On a test wordpress instance, configure a redirect chain in Apache:

```
    RewriteEngine on
    RewriteCond %{SERVER_NAME} =blog.holograms.test
    RewriteRule ^/mattest$ /mattest1 [R=301,L]
    RewriteRule ^/mattest1$ /mattest2 [R=302,L]
    RewriteRule ^/mattest2$ /feed [R=301,L]
    RewriteRule ^/wp-content/(.*)$ /srv/wordpress/test_wordpress/wp-content/$1
```

* Add an RSS contact to the first element in the chain, in this case `https://blog.holograms.test/mattest` 
* Observe the logged `redirect-url` with and without the change