### PR TITLE
Store the context as a separate field

### DIFF
--- a/doc/database/db_inbox-entry.md
+++ b/doc/database/db_inbox-entry.md
@@ -12,6 +12,7 @@ Fields
 | activity-id        | id of the incoming activity            | varbinary(383)   | YES  |     | NULL    |                |
 | object-id          |                                        | varbinary(383)   | YES  |     | NULL    |                |
 | in-reply-to-id     |                                        | varbinary(383)   | YES  |     | NULL    |                |
+| context            |                                        | varbinary(383)   | YES  |     | NULL    |                |
 | conversation       |                                        | varbinary(383)   | YES  |     | NULL    |                |
 | type               | Type of the activity                   | varchar(64)      | YES  |     | NULL    |                |
 | object-type        | Type of the object activity            | varchar(64)      | YES  |     | NULL    |                |

--- a/doc/database/db_post-thread-user.md
+++ b/doc/database/db_post-thread-user.md
@@ -9,6 +9,7 @@ Fields
 | Field           | Description                                                                                             | Type               | Null | Key | Default             | Extra |
 | --------------- | ------------------------------------------------------------------------------------------------------- | ------------------ | ---- | --- | ------------------- | ----- |
 | uri-id          | Id of the item-uri table entry that contains the item uri                                               | int unsigned       | NO   | PRI | NULL                |       |
+| context-id      | Id of the item-uri table entry that contains the endpoint for the context collection                    | int unsigned       | YES  |     | NULL                |       |
 | conversation-id | Id of the item-uri table entry that contains the conversation uri                                       | int unsigned       | YES  |     | NULL                |       |
 | owner-id        | Item owner                                                                                              | int unsigned       | NO   |     | 0                   |       |
 | author-id       | Item author                                                                                             | int unsigned       | NO   |     | 0                   |       |
@@ -40,6 +41,7 @@ Indexes
 | -------------------- | --------------------- |
 | PRIMARY              | uid, uri-id           |
 | uri-id               | uri-id                |
+| context-id           | context-id            |
 | conversation-id      | conversation-id       |
 | owner-id             | owner-id              |
 | author-id            | author-id             |
@@ -68,6 +70,7 @@ Foreign Keys
 | Field | Target Table | Target Field |
 |-------|--------------|--------------|
 | uri-id | [item-uri](help/database/db_item-uri) | id |
+| context-id | [item-uri](help/database/db_item-uri) | id |
 | conversation-id | [item-uri](help/database/db_item-uri) | id |
 | owner-id | [contact](help/database/db_contact) | id |
 | author-id | [contact](help/database/db_contact) | id |

--- a/doc/database/db_post-thread.md
+++ b/doc/database/db_post-thread.md
@@ -9,6 +9,7 @@ Fields
 | Field           | Description                                                                                             | Type         | Null | Key | Default             | Extra |
 | --------------- | ------------------------------------------------------------------------------------------------------- | ------------ | ---- | --- | ------------------- | ----- |
 | uri-id          | Id of the item-uri table entry that contains the item uri                                               | int unsigned | NO   | PRI | NULL                |       |
+| context-id      | Id of the item-uri table entry that contains the endpoint for the context collection                    | int unsigned | YES  |     | NULL                |       |
 | conversation-id | Id of the item-uri table entry that contains the conversation uri                                       | int unsigned | YES  |     | NULL                |       |
 | owner-id        | Item owner                                                                                              | int unsigned | NO   |     | 0                   |       |
 | author-id       | Item author                                                                                             | int unsigned | NO   |     | 0                   |       |
@@ -25,6 +26,7 @@ Indexes
 | Name            | Fields          |
 | --------------- | --------------- |
 | PRIMARY         | uri-id          |
+| context-id      | context-id      |
 | conversation-id | conversation-id |
 | owner-id        | owner-id        |
 | author-id       | author-id       |
@@ -38,6 +40,7 @@ Foreign Keys
 | Field | Target Table | Target Field |
 |-------|--------------|--------------|
 | uri-id | [item-uri](help/database/db_item-uri) | id |
+| context-id | [item-uri](help/database/db_item-uri) | id |
 | conversation-id | [item-uri](help/database/db_item-uri) | id |
 | owner-id | [contact](help/database/db_contact) | id |
 | author-id | [contact](help/database/db_contact) | id |

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1081,6 +1081,10 @@ class Item
 			$parent_id = 0;
 			$parent_origin = $item['origin'];
 
+			if ($item['wall'] && empty($item['context'])) {
+				$item['context'] = $item['parent-uri'] . '#context';
+			}
+
 			if ($item['wall'] && empty($item['conversation'])) {
 				$item['conversation'] = $item['parent-uri'] . '#context';
 			}
@@ -1100,6 +1104,10 @@ class Item
 
 		if (!empty($item['conversation']) && empty($item['conversation-id'])) {
 			$item['conversation-id'] = ItemURI::getIdByURI($item['conversation']);
+		}
+
+		if (!empty($item['context']) && empty($item['context-id'])) {
+			$item['context-id'] = ItemURI::getIdByURI($item['context']);
 		}
 
 		// Is this item available in the global items (with uid=0)?

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -320,13 +320,22 @@ class Processor
 			$item['object-type'] = Activity\ObjectType::COMMENT;
 		}
 
-		if (!empty($activity['conversation'])) {
-			$item['conversation'] = $activity['conversation'];
-		} elseif (!empty($activity['context'])) {
-			$item['conversation'] = $activity['context'];
+		if (!empty($activity['context'])) {
+			$item['context'] = $activity['context'];
 		}
 
-		if (!empty($item['conversation'])) {
+		if (!empty($activity['conversation'])) {
+			$item['conversation'] = $activity['conversation'];
+		}
+
+		if (!empty($item['context'])) {
+			$conversation = Post::selectFirstThread(['uri'], ['context' => $item['context']]);
+			if (!empty($conversation)) {
+				Logger::debug('Got context', ['context' => $item['context'], 'parent' => $conversation]);
+				$item['parent-uri'] = $conversation['uri'];
+				$item['parent-uri-id'] = ItemURI::getIdByURI($item['parent-uri']);
+			}
+		} elseif (!empty($item['conversation'])) {
 			$conversation = Post::selectFirstThread(['uri'], ['conversation' => $item['conversation']]);
 			if (!empty($conversation)) {
 				Logger::debug('Got conversation', ['conversation' => $item['conversation'], 'parent' => $conversation]);

--- a/src/Protocol/ActivityPub/Queue.php
+++ b/src/Protocol/ActivityPub/Queue.php
@@ -64,8 +64,10 @@ class Queue
 		}
 
 		if (!empty($activity['context'])) {
-			$fields['conversation'] = $activity['context'];
-		} elseif (!empty($activity['conversation'])) {
+			$fields['context'] = $activity['context'];
+		}
+
+		if (!empty($activity['conversation'])) {
 			$fields['conversation'] = $activity['conversation'];
 		}
 
@@ -296,9 +298,15 @@ class Queue
 			return true;
 		}
 
+		if (!empty($entry['context'])) {
+			if (DBA::exists('post-thread', ['context-id' => ItemURI::getIdByURI($entry['context'], false)])) {
+				// We have got the context in the system, so the post can be processed
+				return true;
+			}
+		}
+
 		if (!empty($entry['conversation'])) {
-			$conv_id = ItemURI::getIdByURI($entry['conversation'], false);
-			if (DBA::exists('post-thread', ['conversation-id' => $conv_id])) {
+			if (DBA::exists('post-thread', ['conversation-id' => ItemURI::getIdByURI($entry['conversation'], false)])) {
 				// We have got the conversation in the system, so the post can be processed
 				return true;
 			}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1865,8 +1865,12 @@ class Transmitter
 		}
 		$data['sensitive'] = (bool)$item['sensitive'];
 
+		if (!empty($item['context']) && ($item['context'] != './')) {
+			$data['context'] = $item['context'];
+		}
+
 		if (!empty($item['conversation']) && ($item['conversation'] != './')) {
-			$data['conversation'] = $data['context'] = $item['conversation'];
+			$data['conversation'] = $item['conversation'];
 		}
 
 		if (!empty($title)) {

--- a/src/Worker/ExpirePosts.php
+++ b/src/Worker/ExpirePosts.php
@@ -204,6 +204,7 @@ class ExpirePosts
 			AND NOT EXISTS(SELECT `thr-parent-id` FROM `post-user` WHERE `thr-parent-id` = `item-uri`.`id`)
 			AND NOT EXISTS(SELECT `external-id` FROM `post-user` WHERE `external-id` = `item-uri`.`id`)
 			AND NOT EXISTS(SELECT `replies-id` FROM `post-user` WHERE `replies-id` = `item-uri`.`id`)
+			AND NOT EXISTS(SELECT `context-id` FROM `post-thread` WHERE `context-id` = `item-uri`.`id`)
 			AND NOT EXISTS(SELECT `conversation-id` FROM `post-thread` WHERE `conversation-id` = `item-uri`.`id`)
 			AND NOT EXISTS(SELECT `uri-id` FROM `mail` WHERE `uri-id` = `item-uri`.`id`)
 			AND NOT EXISTS(SELECT `uri-id` FROM `event` WHERE `uri-id` = `item-uri`.`id`)

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -56,7 +56,7 @@ use Friendica\Database\DBA;
 
 // This file is required several times during the test in DbaDefinition which justifies this condition
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1569);
+	define('DB_UPDATE_VERSION', 1570);
 }
 
 return [
@@ -867,6 +867,7 @@ return [
 			"activity-id" => ["type" => "varbinary(383)", "comment" => "id of the incoming activity"],
 			"object-id" => ["type" => "varbinary(383)", "comment" => ""],
 			"in-reply-to-id" => ["type" => "varbinary(383)", "comment" => ""],
+			"context" => ["type" => "varbinary(383)", "comment" => ""],
 			"conversation" => ["type" => "varbinary(383)", "comment" => ""],
 			"type" => ["type" => "varchar(64)", "comment" => "Type of the activity"],
 			"object-type" => ["type" => "varchar(64)", "comment" => "Type of the object activity"],
@@ -1555,6 +1556,7 @@ return [
 		"comment" => "Thread related data",
 		"fields" => [
 			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
+			"context-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the endpoint for the context collection"],
 			"conversation-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the conversation uri"],
 			"owner-id" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "foreign" => ["contact" => "id", "on delete" => "restrict"], "comment" => "Item owner"],
 			"author-id" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "foreign" => ["contact" => "id", "on delete" => "restrict"], "comment" => "Item author"],
@@ -1567,6 +1569,7 @@ return [
 		],
 		"indexes" => [
 			"PRIMARY" => ["uri-id"],
+			"context-id" => ["context-id"],
 			"conversation-id" => ["conversation-id"],
 			"owner-id" => ["owner-id"],
 			"author-id" => ["author-id"],
@@ -1641,6 +1644,7 @@ return [
 		"comment" => "Thread related data per user",
 		"fields" => [
 			"uri-id" => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
+			"context-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the endpoint for the context collection"],
 			"conversation-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the conversation uri"],
 			"owner-id" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "foreign" => ["contact" => "id", "on delete" => "restrict"], "comment" => "Item owner"],
 			"author-id" => ["type" => "int unsigned", "not null" => "1", "default" => "0", "foreign" => ["contact" => "id", "on delete" => "restrict"], "comment" => "Item author"],
@@ -1668,6 +1672,7 @@ return [
 		"indexes" => [
 			"PRIMARY" => ["uid", "uri-id"],
 			"uri-id" => ["uri-id"],
+			"context-id" => ["context-id"],
 			"conversation-id" => ["conversation-id"],
 			"owner-id" => ["owner-id"],
 			"author-id" => ["author-id"],

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -261,6 +261,8 @@
 			"thr-parent-id" => ["post-origin", "thr-parent-id"],
 			"conversation" => ["conversation-item-uri", "uri"],
 			"conversation-id" => ["post-thread-user", "conversation-id"],
+			"context" => ["context-item-uri", "uri"],
+			"context-id" => ["post-thread-user", "context-id"],
 			"quote-uri" => ["quote-item-uri", "uri"],
 			"quote-uri-id" => ["post-content", "quote-uri-id"],
 			"guid" => ["item-uri", "guid"],
@@ -424,6 +426,7 @@
 			LEFT JOIN `item-uri` AS `thr-parent-item-uri` ON `thr-parent-item-uri`.`id` = `post-origin`.`thr-parent-id`
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post-origin`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread-user`.`conversation-id`
+			LEFT JOIN `item-uri` AS `context-item-uri` ON `context-item-uri`.`id` = `post-thread-user`.`context-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post-user`.`external-id`
 			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post-user`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post-origin`.`vid`
@@ -450,6 +453,8 @@
 			"thr-parent-id" => ["post-origin", "thr-parent-id"],
 			"conversation" => ["conversation-item-uri", "uri"],
 			"conversation-id" => ["post-thread-user", "conversation-id"],
+			"context" => ["context-item-uri", "uri"],
+			"context-id" => ["post-thread-user", "context-id"],
 			"quote-uri" => ["quote-item-uri", "uri"],
 			"quote-uri-id" => ["post-content", "quote-uri-id"],
 			"guid" => ["item-uri", "guid"],
@@ -612,6 +617,7 @@
 			LEFT JOIN `item-uri` AS `thr-parent-item-uri` ON `thr-parent-item-uri`.`id` = `post-origin`.`thr-parent-id`
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post-origin`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread-user`.`conversation-id`
+			LEFT JOIN `item-uri` AS `context-item-uri` ON `context-item-uri`.`id` = `post-thread-user`.`context-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post-user`.`external-id`
 			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post-user`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post-origin`.`vid`
@@ -637,6 +643,8 @@
 			"thr-parent-id" => ["post-user", "thr-parent-id"],
 			"conversation" => ["conversation-item-uri", "uri"],
 			"conversation-id" => ["post-thread-user", "conversation-id"],
+			"context" => ["context-item-uri", "uri"],
+			"context-id" => ["post-thread-user", "context-id"],
 			"quote-uri" => ["quote-item-uri", "uri"],
 			"quote-uri-id" => ["post-content", "quote-uri-id"],
 			"guid" => ["item-uri", "guid"],
@@ -799,6 +807,7 @@
 			LEFT JOIN `item-uri` AS `thr-parent-item-uri` ON `thr-parent-item-uri`.`id` = `post-user`.`thr-parent-id`
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post-user`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread-user`.`conversation-id`
+			LEFT JOIN `item-uri` AS `context-item-uri` ON `context-item-uri`.`id` = `post-thread-user`.`context-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post-user`.`external-id`
 			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post-user`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post-user`.`vid`
@@ -825,6 +834,8 @@
 			"thr-parent-id" => ["post-user", "thr-parent-id"],
 			"conversation" => ["conversation-item-uri", "uri"],
 			"conversation-id" => ["post-thread-user", "conversation-id"],
+			"context" => ["context-item-uri", "uri"],
+			"context-id" => ["post-thread-user", "context-id"],
 			"quote-uri" => ["quote-item-uri", "uri"],
 			"quote-uri-id" => ["post-content", "quote-uri-id"],
 			"guid" => ["item-uri", "guid"],
@@ -986,6 +997,7 @@
 			LEFT JOIN `item-uri` AS `thr-parent-item-uri` ON `thr-parent-item-uri`.`id` = `post-user`.`thr-parent-id`
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post-user`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread-user`.`conversation-id`
+			LEFT JOIN `item-uri` AS `context-item-uri` ON `context-item-uri`.`id` = `post-thread-user`.`context-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post-user`.`external-id`
 			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post-user`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post-user`.`vid`
@@ -1007,6 +1019,8 @@
 			"thr-parent-id" => ["post", "thr-parent-id"],
 			"conversation" => ["conversation-item-uri", "uri"],
 			"conversation-id" => ["post-thread", "conversation-id"],
+			"context" => ["context-item-uri", "uri"],
+			"context-id" => ["post-thread", "context-id"],
 			"quote-uri" => ["quote-item-uri", "uri"],
 			"quote-uri-id" => ["post-content", "quote-uri-id"],
 			"guid" => ["item-uri", "guid"],
@@ -1136,6 +1150,7 @@
 			LEFT JOIN `item-uri` AS `thr-parent-item-uri` ON `thr-parent-item-uri`.`id` = `post`.`thr-parent-id`
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread`.`conversation-id`
+			LEFT JOIN `item-uri` AS `context-item-uri` ON `context-item-uri`.`id` = `post-thread`.`context-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post`.`external-id`
 			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post`.`vid`
@@ -1155,6 +1170,8 @@
 			"thr-parent-id" => ["post", "thr-parent-id"],
 			"conversation" => ["conversation-item-uri", "uri"],
 			"conversation-id" => ["post-thread", "conversation-id"],
+			"context" => ["context-item-uri", "uri"],
+			"context-id" => ["post-thread", "context-id"],
 			"quote-uri" => ["quote-item-uri", "uri"],
 			"quote-uri-id" => ["post-content", "quote-uri-id"],
 			"guid" => ["item-uri", "guid"],
@@ -1286,6 +1303,7 @@
 			LEFT JOIN `item-uri` AS `thr-parent-item-uri` ON `thr-parent-item-uri`.`id` = `post`.`thr-parent-id`
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post`.`parent-uri-id`
 			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread`.`conversation-id`
+			LEFT JOIN `item-uri` AS `context-item-uri` ON `context-item-uri`.`id` = `post-thread`.`context-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post`.`external-id`
 			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post`.`vid`


### PR DESCRIPTION
Until now we treated the two fields "context" and "conversation" the same. Both are used to identify a thread. But they serve slightly different purposes, since there are systems out there that use "conversation" for a collection of all posts in the thread.

So to support this, we will need to store these two fields in separate database fields.