### PR TITLE
Update feed URL after permanent redirect

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2446,7 +2446,7 @@ class Contact
 	}
 
 	/**
-	 * Updates the poll URL of a contact.  This is the right function to call if there is a redirect.
+	 * Updates the poll URL of a contact. This is the right function to call if there is a redirect.
 	 *
 	 * @param integer $id  contact id
 	 * @param string  $url The new URL to use for polling

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2446,6 +2446,19 @@ class Contact
 	}
 
 	/**
+	 * Updates the poll URL of a contact.  This is the right function to call if there is a redirect.
+	 *
+	 * @param integer $id  contact id
+	 * @param string  $url The new URL to use for polling
+	 *
+	 * @throws \Exception
+	 */
+	public static function updatePollUrl(int $id, string $url)
+	{
+		self::update(['poll', $url], ['id' => $id]);
+	}
+
+	/**
 	 * Helper function for "updateFromProbe". Updates personal and public contact
 	 *
 	 * @param integer $id     contact id

--- a/src/Network/HTTPClient/Capability/ICanHandleHttpResponses.php
+++ b/src/Network/HTTPClient/Capability/ICanHandleHttpResponses.php
@@ -90,9 +90,19 @@ interface ICanHandleHttpResponses
 	public function getUrl(): string;
 
 	/**
+	 * If the request was redirected to another URL, gets the final URL requested
 	 * @return string
 	 */
 	public function getRedirectUrl(): string;
+
+	/**
+	 * If the request was redirected to another URL, indicates if the redirect is permanent.
+	 * If the request was not redirected, returns false.
+	 * If the request was redirected multiple times, returns true only if all of the redirects were permanent.
+	 *
+	 * @return bool True if the redirect is permanent
+	 */
+	public function redirectIsPermanent(): bool;
 
 	/**
 	 * Getter for body

--- a/src/Network/HTTPClient/Response/CurlResult.php
+++ b/src/Network/HTTPClient/Response/CurlResult.php
@@ -230,7 +230,7 @@ class CurlResult implements ICanHandleHttpResponses
 
 			$this->redirectUrl = (string)Uri::fromParts((array)$redirect_parts);
 			$this->isRedirectUrl = true;
-			$this->redirectIsPermanent = $this->returnCode == 301 or $this->returnCode == 308;
+			$this->redirectIsPermanent = $this->returnCode == 301 || $this->returnCode == 308;
 		} else {
 			$this->isRedirectUrl = false;
 			$this->redirectIsPermanent = false;

--- a/src/Network/HTTPClient/Response/CurlResult.php
+++ b/src/Network/HTTPClient/Response/CurlResult.php
@@ -82,6 +82,11 @@ class CurlResult implements ICanHandleHttpResponses
 	private $isRedirectUrl;
 
 	/**
+	 * @var boolean true if the URL has a permanent redirect
+	 */
+	private $redirectIsPermanent;
+
+	/**
 	 * @var boolean true if the curl request timed out
 	 */
 	private $isTimeout;
@@ -197,7 +202,7 @@ class CurlResult implements ICanHandleHttpResponses
 			$this->redirectUrl = $this->info['url'];
 		}
 
-		if ($this->returnCode == 301 || $this->returnCode == 302 || $this->returnCode == 303 || $this->returnCode == 307) {
+		if ($this->returnCode == 301 || $this->returnCode == 302 || $this->returnCode == 303 || $this->returnCode == 307 || $this->returnCode == 308) {
 			$redirect_parts = parse_url($this->info['redirect_url'] ?? '');
 			if (empty($redirect_parts)) {
 				$redirect_parts = [];
@@ -224,10 +229,11 @@ class CurlResult implements ICanHandleHttpResponses
 			}
 
 			$this->redirectUrl = (string)Uri::fromParts((array)$redirect_parts);
-
 			$this->isRedirectUrl = true;
+			$this->redirectIsPermanent = $this->returnCode == 301 or $this->returnCode == 308;
 		} else {
 			$this->isRedirectUrl = false;
+			$this->redirectIsPermanent = false;
 		}
 	}
 
@@ -338,6 +344,12 @@ class CurlResult implements ICanHandleHttpResponses
 	public function isRedirectUrl(): bool
 	{
 		return $this->isRedirectUrl;
+	}
+
+	/** {@inheritDoc} */
+	public function redirectIsPermanent(): bool
+	{
+		return $this->redirectIsPermanent;
 	}
 
 	/** {@inheritDoc} */

--- a/src/Network/HTTPClient/Response/GuzzleResponse.php
+++ b/src/Network/HTTPClient/Response/GuzzleResponse.php
@@ -52,6 +52,8 @@ class GuzzleResponse extends Response implements ICanHandleHttpResponses, Respon
 	private $redirectUrl = '';
 	/** @var bool */
 	private $isRedirectUrl = false;
+	/** @var bool */
+	private $redirectIsPermanent = false;
 
 	public function __construct(ResponseInterface $response, string $url, $errorNumber = 0, $error = '')
 	{
@@ -91,6 +93,13 @@ class GuzzleResponse extends Response implements ICanHandleHttpResponses, Respon
 		if (count($headersRedirect) > 0) {
 			$this->redirectUrl   = $headersRedirect[0];
 			$this->isRedirectUrl = true;
+
+			$this->redirectIsPermanent = true;
+			foreach (($response->getHeader(RedirectMiddleware::STATUS_HISTORY_HEADER) ?? []) as $history) {
+				if (preg_match('/30(2|3|4|7)/', $history)) {
+					$this->redirectIsPermanent = false;
+				}
+			}
 		}
 	}
 
@@ -143,6 +152,12 @@ class GuzzleResponse extends Response implements ICanHandleHttpResponses, Respon
 	public function isRedirectUrl(): bool
 	{
 		return $this->isRedirectUrl;
+	}
+
+	/** {@inheritDoc} */
+	public function redirectIsPermanent(): bool
+	{
+		return $this->redirectIsPermanent;
 	}
 
 	/** {@inheritDoc} */


### PR DESCRIPTION
If the server indicates that a URL is being permanently redirected, it's likely the intent is that this is a grace period before the redirect is replaced by a 410.  To keep working, the feed URL should be automatically updated.