### PR TITLE
Overflowing of log messages in the admin log view

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3324,10 +3324,18 @@ li.addon {
 #adminpage .addon .desc {
 	padding-left: 10px;
 }
+#adminpage td.log-message,
+#logdetail td.log-message {
+	width: 80%;
+	word-break: break-all;
+}
+#logdetail td.log-message {
+	width: 80%;
+}
 #admin-users #users tr.blocked {
 	background-color: #f8efc0;
 }
-.adminpage .table-hover > tbody > tr:hover + tr.details {
+#adminpage .table-hover > tbody > tr:hover + tr.details {
 	background-color: #f5f5f5;
 }
 .offset-anchor::before {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3329,13 +3329,10 @@ li.addon {
 	width: 80%;
 	word-break: break-all;
 }
-#logdetail td.log-message {
-	width: 80%;
-}
 #admin-users #users tr.blocked {
 	background-color: #f8efc0;
 }
-#adminpage .table-hover > tbody > tr:hover + tr.details {
+.adminpage .table-hover > tbody > tr:hover + tr.details {
 	background-color: #f5f5f5;
 }
 .offset-anchor::before {

--- a/view/theme/frio/templates/admin/logs/view.tpl
+++ b/view/theme/frio/templates/admin/logs/view.tpl
@@ -59,7 +59,7 @@
 			</thead>
 			<tbody>
 				{{foreach $data as $row}}
-				<tr id="ev-{{$row->id}}" class="log-event" 
+				<tr id="ev-{{$row->id}}" class="log-event"
 					role="button" tabIndex="0"
 					aria-label="{{$l10n.View_details}}" aria-haspopup="true" aria-expanded="false"
 					data-data="{{$row->data}}" data-source="{{$row->source}}">
@@ -76,7 +76,7 @@
 						{{/if}}
 					">{{$row->level}}</td>
 					<td>{{$row->context}}</td>
-					<td style="width:80%">{{$row->message}}</td>
+					<td class="log-message">{{$row->message}}</td>
 				</tr>
 				{{/foreach}}
 			</tbody>


### PR DESCRIPTION
I have added a CSS rule to break the text inside the last log view table `<td>`, so that it stops overflowing the table and the container div.

The 80% width rule was there before and is mainly for the modal window, the `#logdetail` view . It looks more consistent then, when clicking "next" or "previous" log message.

The Javascript code, that is executed, when clicking a log message, takes the HTML elements from the `#adminpage` `<tbody>` and inserts them into the modal's `#logdetail`  `<tbody>`. I wrote both ids into the CSS, so that it is maybe easier to understand.  Only `#adminpage .log-message` would not be sufficient, to cover both `<td>`s. 