### PR TITLE
improve log view table for mobile width using display:grid

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3324,10 +3324,25 @@ li.addon {
 #adminpage .addon .desc {
 	padding-left: 10px;
 }
+#adminpage h2 {
+	word-break: break-all;
+}
+#adminpage .table-logs-grid thead tr {
+	display: grid;
+	grid-auto-flow: row;
+}
+@media (min-width: 600px) {
+	#adminpage .table-logs-grid thead tr {
+		grid-auto-flow: column;
+	}
+}
+#adminpage .table-logs-grid tbody {
+	display: grid;
+}
 #adminpage td.log-message,
 #logdetail td.log-message {
 	width: 80%;
-	word-break: break-all;
+	word-break: break-word;
 }
 #admin-users #users tr.blocked {
 	background-color: #f8efc0;

--- a/view/theme/frio/templates/admin/logs/view.tpl
+++ b/view/theme/frio/templates/admin/logs/view.tpl
@@ -22,7 +22,7 @@
 			</div>
 		</form>
 
-		<table class="table table-hover">
+		<table class="table table-hover table-logs-grid">
 			<thead>
 				<tr>
 					<th>{{$l10n.Date}}</th>


### PR DESCRIPTION
I have added a little more CSS to further improve the admin logs view table for narrow screens (mobile)... 
A new class in the log view table was added, so only this table should be affected.  hope it is okay so.

Screenshots:

before:
![log-table-grid-before](https://github.com/friendica/friendica/assets/5753419/566066d4-c4cb-4aaa-b449-22aa95e2974e)

after (mobile):
![log-table-grid-after-mobile](https://github.com/friendica/friendica/assets/5753419/bda9e0a2-4bca-4e51-8adc-68b2635a289b)

after (desktop):
![log-table-grid-after-desktop](https://github.com/friendica/friendica/assets/5753419/90e1f17a-bf7f-4c77-a0a5-c77037effbff)
