### PR TITLE
make logs table straight, don't use grid for table body

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3327,22 +3327,31 @@ li.addon {
 #adminpage h2 {
 	word-break: break-all;
 }
-#adminpage .table-logs-grid thead tr {
+#adminpage .table-logs thead tr {
 	display: grid;
 	grid-auto-flow: row;
 }
-@media (min-width: 600px) {
-	#adminpage .table-logs-grid thead tr {
-		grid-auto-flow: column;
-	}
+#adminpage .table-logs tbody {
+	display: table;
+	width: 100%;
+	table-layout: fixed;
 }
-#adminpage .table-logs-grid tbody {
-	display: grid;
+#adminpage .table-logs td {
+	word-break: break-word;
 }
-#adminpage td.log-message,
+#adminpage .table-logs td.log-message {
+	width: 40%;
+}
 #logdetail td.log-message {
 	width: 80%;
-	word-break: break-word;
+}
+@media (min-width: 600px) {
+	#adminpage .table-logs thead tr {
+		grid-auto-flow: column;
+	}
+	#adminpage .table-logs td.log-message {
+		width: 60%;
+	}
 }
 #admin-users #users tr.blocked {
 	background-color: #f8efc0;

--- a/view/theme/frio/templates/admin/logs/view.tpl
+++ b/view/theme/frio/templates/admin/logs/view.tpl
@@ -22,7 +22,7 @@
 			</div>
 		</form>
 
-		<table class="table table-hover table-logs-grid">
+		<table class="table table-hover table-logs">
 			<thead>
 				<tr>
 					<th>{{$l10n.Date}}</th>


### PR DESCRIPTION
The logs view table should now look straight again, using `display:table` for the `<tbody>` instead of `display:grid`.
And the class `table-logs-grid` has been renamed to `table-logs`. 

The `td.log-message` has now 3 different widths: 40% for mobile, 60% for desktop and 80% in the modal.
The media query has been moved to the end of the rules for the logs table.

#### Screenshots

before:
![logs-table-straight-before](https://github.com/friendica/friendica/assets/5753419/3a210b77-5e91-4ef1-a8d7-3b220c6461e8)

after:
![logs-table-straight-after](https://github.com/friendica/friendica/assets/5753419/f7494566-9886-4422-9e07-e01ca4898cf5)
