### PR TITLE
Hide inflated widgets when Javascript is off

### DIFF
--- a/view/templates/circle_side.tpl
+++ b/view/templates/circle_side.tpl
@@ -1,4 +1,4 @@
-<span id="circle-sidebar-inflated" class="widget fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');">
+<span id="circle-sidebar-inflated" class="widget inflated fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');">
 	<h3>{{$title}}</h3>
 </span>
 <div class="widget" id="circle-sidebar">

--- a/view/templates/widget/accounts.tpl
+++ b/view/templates/widget/accounts.tpl
@@ -1,4 +1,4 @@
-<span id="sidebar-accounts-inflated" class="widget fakelink" onclick="openCloseWidget('sidebar-accounts', 'sidebar-accounts-inflated');">
+<span id="sidebar-accounts-inflated" class="widget inflated fakelink" onclick="openCloseWidget('sidebar-accounts', 'sidebar-accounts-inflated');">
 	<h3>{{$title}}</h3>
 </span>
 <div id="sidebar-accounts" class="widget">

--- a/view/templates/widget/community_sharer.tpl
+++ b/view/templates/widget/community_sharer.tpl
@@ -1,4 +1,4 @@
-<span id="sidebar-community-no-sharer-inflated" class="widget fakelink" onclick="openCloseWidget('sidebar-community-no-sharer', 'sidebar-community-no-sharer-inflated');">
+<span id="sidebar-community-no-sharer-inflated" class="widget inflated fakelink" onclick="openCloseWidget('sidebar-community-no-sharer', 'sidebar-community-no-sharer-inflated');">
 	<h3>{{$title}}</h3>
 </span>
 <div id="sidebar-community-no-sharer" class="widget">

--- a/view/templates/widget/filter.tpl
+++ b/view/templates/widget/filter.tpl
@@ -1,4 +1,4 @@
-<span id="{{$type}}-sidebar-inflated" class="widget fakelink" onclick="openCloseWidget('{{$type}}-sidebar', '{{$type}}-sidebar-inflated');">
+<span id="{{$type}}-sidebar-inflated" class="widget inflated fakelink" onclick="openCloseWidget('{{$type}}-sidebar', '{{$type}}-sidebar-inflated');">
 	<h3>{{$title}}</h3>
 </span>
 <div id="{{$type}}-sidebar" class="widget">

--- a/view/templates/widget/group_list.tpl
+++ b/view/templates/widget/group_list.tpl
@@ -12,7 +12,7 @@ function showHideGroupList() {
 }
 </script>
 <span id="group-list-sidebar-frame">
-<span id="group-list-sidebar-inflated" class="widget fakelink" onclick="openCloseWidget('group-list-sidebar', 'group-list-sidebar-inflated');">
+<span id="group-list-sidebar-inflated" class="widget inflated fakelink" onclick="openCloseWidget('group-list-sidebar', 'group-list-sidebar-inflated');">
 	<h3>{{$title}}</h3>
 </span>
 <div id="group-list-sidebar" class="widget">
@@ -25,7 +25,7 @@ function showHideGroupList() {
 		</a>
 	</div>
 	<div id="sidebar-group-list" class="sidebar-widget-list">
-		{{* The list of available groups *}}	
+		{{* The list of available groups *}}
 	<ul id="group-list-sidebar-ul" role="menu">
 		{{foreach $groups as $group}}
 		{{if $group.id <= $visible_groups}}

--- a/view/templates/widget/posted_date.tpl
+++ b/view/templates/widget/posted_date.tpl
@@ -11,7 +11,7 @@ function showHideDates() {
 }
 </script>
 
-<span id="datebrowse-sidebar-inflated" class="widget fakelink" onclick="openCloseWidget('datebrowse-sidebar', 'datebrowse-sidebar-inflated');">
+<span id="datebrowse-sidebar-inflated" class="widget inflated fakelink" onclick="openCloseWidget('datebrowse-sidebar', 'datebrowse-sidebar-inflated');">
 	<h3>{{$title}}</h3>
 </span>
 <div id="datebrowse-sidebar" class="widget">
@@ -24,7 +24,7 @@ function showHideDates() {
 		{{if $y == $cutoff_year}}
 		</ul>
 		<ul id="posted-date-selector-drop" class="datebrowse-ul" style="display: none;">
-		{{/if}} 
+		{{/if}}
 
 		<li id="posted-date-selector-year-{{$y}}" class="tool">
 			<a class="datebrowse-link" href="#" onclick="openClose('posted-date-selector-{{$y}}'); return false;">{{$y}}</a>
@@ -40,7 +40,7 @@ function showHideDates() {
 				<li class="tool">
 					<a class="datebrowse-link" href="{{$url}}/{{$d.1}}/{{$d.2}}">{{$d.0}}</a>
 				</li>
-				
+
 				{{/foreach}}
 			</ul>
 		</li>

--- a/view/templates/widget/saved_searches.tpl
+++ b/view/templates/widget/saved_searches.tpl
@@ -1,4 +1,4 @@
-<span id="saved-search-list-inflated" class="widget fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');">
+<span id="saved-search-list-inflated" class="widget inflated fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');">
 	<h3>{{$title}}</h3>
 </span>
 <div class="widget" id="saved-search-list">
@@ -6,7 +6,7 @@
 		<h3 id="search">{{$title}}</h3>
 	</span>
 	{{$searchbox nofilter}}
-	
+
 	<ul role="menu" id="saved-search-ul">
 		{{foreach $saved as $search}}
 		<li role="menuitem" class="saved-search-li clear">

--- a/view/templates/widget/tagcloud.tpl
+++ b/view/templates/widget/tagcloud.tpl
@@ -1,4 +1,4 @@
-<span id="tagblock-inflated" class="widget fakelink" onclick="openCloseWidget('tagblock', 'tagblock-inflated');">
+<span id="tagblock-inflated" class="widget inflated fakelink" onclick="openCloseWidget('tagblock', 'tagblock-inflated');">
 	<h3>{{$title}}</h3>
 </span>
 <div id="tagblock" class="tagblock widget">

--- a/view/templates/widget/trending_tags.tpl
+++ b/view/templates/widget/trending_tags.tpl
@@ -1,4 +1,4 @@
-<span id="trending-tags-sidebar-inflated" class="widget fakelink" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');">
+<span id="trending-tags-sidebar-inflated" class="widget inflated fakelink" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');">
 	<h3>{{$title}}</h3>
 </span>
 <div id="trending-tags-sidebar" class="widget">

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -90,6 +90,9 @@ blockquote {
 	max-height: 0px !important;
 	overflow: hidden !important;
 }
+.inflated {
+	display: none;
+}
 
 /**
  * details tag

--- a/view/theme/frio/templates/circle_side.tpl
+++ b/view/theme/frio/templates/circle_side.tpl
@@ -1,4 +1,4 @@
-<span id="circle-sidebar-inflated" class="widget fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');">
+<span id="circle-sidebar-inflated" class="widget inflated fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');">
         <h3>{{$title}}</h3>
 </span>
 <div class="widget" id="circle-sidebar">

--- a/view/theme/frio/templates/widget/saved_searches.tpl
+++ b/view/theme/frio/templates/widget/saved_searches.tpl
@@ -1,5 +1,5 @@
 {{if $saved}}
-<span id="saved-search-list-inflated" class="widget fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');">
+<span id="saved-search-list-inflated" class="widget inflated fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');">
 	<h3>{{$title}}</h3>
 </span>
 <div class="widget" id="saved-search-list">

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -312,7 +312,7 @@ a:hover {
 .right {
 	float: right;
 }
-.hidden {
+.hidden, .inflated {
 	display: none;
 }
 .clear {


### PR DESCRIPTION
When Javascript is turned off, the unused widget parts were visible, because not hidden by the Javascript.
I have added a class `inflated` to those elements to make them `display:none` by default. Using the existing `hidden` class was not working, because the `Frio` theme has an `!important` there, that would stop the functioning of the Javascript.

Now the broken looking elements are no more visible, when JS is switched off.

#### Screenshot before

![hide-inflated-widgets-when-js-off](https://github.com/friendica/friendica/assets/5753419/f15485eb-2d7f-42b0-9ff8-5865e9a6098c)
