### PR TITLE
Remove contact immediately on 410 response code

### DIFF
--- a/src/Network/HTTPClient/Capability/ICanHandleHttpResponses.php
+++ b/src/Network/HTTPClient/Capability/ICanHandleHttpResponses.php
@@ -85,6 +85,13 @@ interface ICanHandleHttpResponses
 	public function isSuccess(): bool;
 
 	/**
+	 * Returns if the URL is permanently gone (return code 410)
+	 *
+	 * @return bool
+	 */
+	public function isGone(): bool;
+
+	/**
 	 * @return string
 	 */
 	public function getUrl(): string;

--- a/src/Network/HTTPClient/Response/CurlResult.php
+++ b/src/Network/HTTPClient/Response/CurlResult.php
@@ -57,6 +57,11 @@ class CurlResult implements ICanHandleHttpResponses
 	private $isSuccess;
 
 	/**
+	 * @var boolean true (if HTTP 410 result) or false
+	 */
+	private $isGone;
+
+	/**
 	 * @var string the URL which was called
 	 */
 	private $url;
@@ -148,6 +153,7 @@ class CurlResult implements ICanHandleHttpResponses
 
 		$this->parseBodyHeader($result);
 		$this->checkSuccess();
+		$this->checkGone();
 		$this->checkRedirect();
 		$this->checkInfo();
 	}
@@ -192,6 +198,11 @@ class CurlResult implements ICanHandleHttpResponses
 		} else {
 			$this->isTimeout = false;
 		}
+	}
+
+	private function checkGone()
+	{
+		$this->isGone = $this->returnCode == 410;
 	}
 
 	private function checkRedirect()
@@ -318,6 +329,12 @@ class CurlResult implements ICanHandleHttpResponses
 
 	/** {@inheritDoc} */
 	public function isSuccess(): bool
+	{
+		return $this->isSuccess;
+	}
+
+	/** {@inheritDoc} */
+	public function isGone(): bool
 	{
 		return $this->isSuccess;
 	}

--- a/src/Network/HTTPClient/Response/GuzzleResponse.php
+++ b/src/Network/HTTPClient/Response/GuzzleResponse.php
@@ -38,6 +38,8 @@ class GuzzleResponse extends Response implements ICanHandleHttpResponses, Respon
 	private $isTimeout;
 	/** @var boolean */
 	private $isSuccess;
+	/** @var boolean */
+	private $isGone;
 	/**
 	 * @var int the error number or 0 (zero) if no error
 	 */
@@ -63,6 +65,7 @@ class GuzzleResponse extends Response implements ICanHandleHttpResponses, Respon
 		$this->errorNumber = $errorNumber;
 
 		$this->checkSuccess();
+		$this->checkGone();
 		$this->checkRedirect($response);
 	}
 
@@ -84,6 +87,11 @@ class GuzzleResponse extends Response implements ICanHandleHttpResponses, Respon
 		} else {
 			$this->isTimeout = false;
 		}
+	}
+
+	private function checkGone()
+	{
+		$this->isGone = $this->getStatusCode() == 410;
 	}
 
 	private function checkRedirect(ResponseInterface $response)
@@ -133,6 +141,12 @@ class GuzzleResponse extends Response implements ICanHandleHttpResponses, Respon
 	public function isSuccess(): bool
 	{
 		return $this->isSuccess;
+	}
+
+	/** {@inheritDoc} */
+	public function isGone(): bool
+	{
+		return $this->isGone;
 	}
 
 	/** {@inheritDoc} */

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -174,6 +174,12 @@ class OnePoll
 			return false;
 		}
 
+		if ($curlResult->isGone()) {
+			Logger::notice('URL is permanently gone', ['id' => $contact['id'], 'url' => $contact['poll']]);
+			Contact::remove($contact['id']);
+			return false;
+		}
+
 		if ($curlResult->redirectIsPermanent()) {
 			Logger::notice('Poll address permanently changed', [
 				'id' => $contact['id'],


### PR DESCRIPTION
There are many accidental problems on a web server that can cause it to issue 404, but 410 must be specifically set up by a site administrator to indicate that a specific URL is never coming back.  As such, we can take this as a cue to remove a contact immedately, rather than continuing to ping the URL for a month.