### PR TITLE
Process unprocessed queue entries in a separate worker process

### DIFF
--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -28,7 +28,6 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Tag;
-use Friendica\Protocol\ActivityPub\Queue;
 use Friendica\Protocol\Relay;
 use Friendica\Util\DateTimeFormat;
 
@@ -93,7 +92,7 @@ class Cron
 			Tag::setGlobalTrendingHashtags(24, 20);
 
 			// Process all unprocessed entries
-			Queue::processAll();
+			Worker::add(Worker::PRIORITY_LOW, 'ProcessUnprocessedEntries');
 
 			// Search for new contacts in the directory
 			if (DI::config()->get('system', 'synchronize_directory')) {

--- a/src/Worker/ProcessUnprocessedEntries.php
+++ b/src/Worker/ProcessUnprocessedEntries.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @copyright Copyright (C) 2010-2024, the Friendica project
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Friendica\Worker;
+
+use Friendica\Core\Logger;
+use Friendica\Protocol\ActivityPub\Queue;
+
+class ProcessUnprocessedEntries
+{
+	/**
+	 * Process all unprocessed entries
+	 *
+	 * @return void
+	 */
+	public static function execute()
+	{
+		Logger::info('Start processing unprocessed entries');
+		Queue::processAll();
+		Logger::info('Successfully processed unprocessed entries');
+	}
+}


### PR DESCRIPTION
The processing of unprocessed queue entries can take some time. So it now has got its own worker process.