### PR TITLE
Initial version of devcontainer for friendica

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,43 @@
+ARG VARIANT="8.0-apache-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/php:${VARIANT}
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y;
+
+# Install MariaDB client
+RUN apt-get install -y mariadb-client
+COPY include/my.cnf /home/vscode/.my.cnf
+
+# Base packages
+RUN apt install -y vim software-properties-common sudo nano gnupg2
+
+RUN apt-get install -y \
+        libpng-dev \
+        libjpeg62-turbo-dev \
+        libtool \
+        libmagick++-dev \
+        libmemcached-dev \
+        libgraphicsmagick1-dev \
+        libfreetype6-dev \
+        libwebp-dev \
+        librsvg2-2 \
+        libzip-dev \
+        libldap2-dev \
+        libgmp-dev \
+        libmagickcore-6.q16-6-extra \
+	&& docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+	&& docker-php-ext-install -j$(nproc) \
+        pdo_mysql \
+        gd \
+        exif \
+        zip \
+        opcache \
+        ctype \
+        pcntl \
+        ldap \
+        gmp \
+        intl
+
+RUN apt-get clean -y && rm -rf /var/lib/apt/lists/*
+

--- a/.devcontainer/README.MD
+++ b/.devcontainer/README.MD
@@ -1,0 +1,53 @@
+
+This folder holds a devcontainer definition for Friendica.
+
+The main features are:
+
+- The development container is based on the PHP dev container image in variant that includes an Apache2 
+  webserver. The variant defines the PHP version and the OS it is based on. The currently used variant 
+  is defined in the Dockerfile.
+
+- Creating a dev container from the Git repository should give you a running development environment 
+  with no or optionally only a very little things to do after creation.
+
+- A MariaDB container is used for the database. It can be accessed in the dev container's terminal with simple 
+  calling mysql. The needed parameters for the client are created and copied during setup. The runtime configuration 
+  needs to use 127.0.0.1 instead of localhost as the latter causes PHP to try to use a socket connection which is not 
+  available in this setup.
+
+
+The development setup is:
+
+- After creation of the dev container the Apache2 web server shall be availaible through port forwarding on 
+  port 8080 from your local development machine (http://localhost:8080/). This is also the url as configured 
+  in local.config.php. You should be able to log in with user 'admin@friendica.local' and password 'admin'.
+
+- Important values are defined in the devcontainer.env file and applied during creation wherever possible. The
+  environment is also available during run/debug time to the application.
+
+- XDebug can be started by the launch configuration 'Listen for Xdebug'. The launch configuration is in .vscode/launch.json
+  (this file is added to git).
+
+
+Open points:
+
+- Cron jobs / worker are not available. For a dev environment those are disabled by default (but can be optionally 
+  enabled).
+
+- The creation of the container runs the postCreate.sh script. This includes a few setup steps that do not need to 
+  be runned on a container rebuild (but on creation of the container). I plan to seperate steps from creation and rebuild 
+  but it is not really a problem at the moment (it just gives some output stating Error where no error is).
+
+- Passing values from the local development machine (with $localEnv) does not seem to work. This would be handy to apply
+  a few settings differently based on user choice. 
+
+- The dev container does not have an email MTA. 
+
+- The devcontainer does currently not support TLS.
+
+- There are still a bit too much warnings logged at startup but that doesn't seem to be a problem.
+
+- Only the first launch configuration ('Listen for Xdebug') is working.
+
+- There is no port exposed on the container (only forwarded ports used). It would be handy to have the dev instance being able
+  to work as a normal instance in the fediverse. 

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -1,0 +1,17 @@
+#Database setup
+MYSQL_HOST=127.0.0.1
+MYSQL_DATABASE=friendica
+MYSQL_USER=friendica
+MYSQL_PASSWORD=friendica
+
+#Webserver setup
+ServerName=192.168.56.10.xip.io
+ServerAlias=friendica.local
+DocumentRoot=/var/www/html
+APACHE_LOG_DIR=/var/log/apache2
+
+#Test users
+ADMIN_NICK=admin
+ADMIN_PASSW=admin
+USER_NICK=user
+USER_PASSW=user

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/php-mariadb
+{
+	"name": "Friendica",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	"remoteEnv": {
+		"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+		"developmentUser": "vscode"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// For use with PHP or Apache (e.g.php -S localhost:8080 or apache2ctl start)
+	"forwardPorts": [3306, 8080],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bash -c '.devcontainer/postCreate.sh && .devcontainer/postCreateApacheSetup.sh && .devcontainer/postCreateFriendicaSetup.sh'",
+	"postStartCommand": "service apache2 start",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"xdebug.php-debug",
+				"ms-azuretools.vscode-docker",
+				"donjayamanne.githistory",
+				"bmewburn.vscode-intelephense-client"
+			],
+			"settings": {
+				"php.suggest.basic": false
+			}
+		}
+	},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services: 
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+    env_file: "devcontainer.env"
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: mariadb:10.4
+    restart: unless-stopped
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    env_file: "devcontainer.env"
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+    command: ['mysqld', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
+
+    # Add "forwardPorts": ["3306"] to **devcontainer.json** to forward MariaDB locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+  
+volumes:
+  mariadb-data:
+
+networks:
+  default:
+  

--- a/.devcontainer/include/001-friendica.conf
+++ b/.devcontainer/include/001-friendica.conf
@@ -1,0 +1,28 @@
+<VirtualHost *:8080>
+    ServerAdmin webmaster@localhost
+    ServerName ${ServerName}
+    ServerAlias ${ServerAlias}
+
+    DocumentRoot ${DocumentRoot}
+
+    <Directory ${DocumentRoot}>
+       Options Indexes FollowSymLinks MultiViews
+       AllowOverride All 
+       Order allow,deny
+       allow from all
+    </Directory>
+
+    <Location /server-status>
+       SetHandler server-status
+       Order deny,allow
+       Allow from all
+    </Location>
+    
+    # Possible values include: debug, info, notice, warn, error, crit,
+    # alert, emerg.
+    LogLevel warn
+
+    ErrorLog ${APACHE_LOG_DIR}/${ServerName}-error.log
+    CustomLog ${APACHE_LOG_DIR}/${ServerName}-access.log combined
+
+</VirtualHost>

--- a/.devcontainer/include/autoinstall.config.php
+++ b/.devcontainer/include/autoinstall.config.php
@@ -1,0 +1,46 @@
+<?php
+
+// Local configuration
+
+/* If automatic system installation fails:
+ *
+ * Copy this file to local.config.php
+ *
+ * Why local.config.php? Because it contains sensitive information which could
+ * give somebody complete control of your database. Apache's default
+ * configuration will interpret any .php file as a script and won't show the values
+ *
+ * Then set the following for your MySQL installation
+ *
+ * If you're unsure about what any of the config keys below do, please check the static/defaults.config.php file for
+ * detailed documentation of their data type and behavior.
+ */
+
+return [
+	'database' => [
+		'hostname' => '${MYSQL_HOST}',
+		'username' => '${MYSQL_USER}',
+		'password' => '${MYSQL_PASSWORD}',
+		'database' => '${MYSQL_DATABASE}',
+		'charset' => 'utf8mb4',
+	],
+
+	// ****************************************************************
+	// The configuration below will be overruled by the admin panel.
+	// Changes made below will only have an effect if the database does
+	// not contain any configuration for the friendica system.
+	// ****************************************************************
+
+	'config' => [
+		'admin_email' => 'admin@friendica.local',
+		'sitename' => 'Friendica Social Network',
+		'register_policy' => \Friendica\Module\Register::OPEN,
+		'register_text' => '',
+	],
+	'system' => [
+		'default_timezone' => 'UTC',
+		'language' => 'en',
+		'basepath' => '${workspaceFolder}',
+		'url' => 'http://localhost:8080',
+	],
+];

--- a/.devcontainer/include/my.cnf
+++ b/.devcontainer/include/my.cnf
@@ -1,0 +1,4 @@
+[client]
+protocol = tcp
+user = friendica
+password = friendica

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+
+# Prepare the workspace files with the values from the devcontainer.env file
+set -a
+source $workspaceFolder/.devcontainer/devcontainer.env
+
+echo ">>> Development Setup"
+sudo apt-get update
+
+#Make the workspace directory the docroot
+echo ">>> Symlink $DocumentRoot to $workspaceFolder"
+sudo rm -rf $DocumentRoot
+sudo ln -fs $workspaceFolder $DocumentRoot
+
+echo 'error_reporting=0' | sudo tee /usr/local/etc/php/conf.d/no-warn.ini
+
+exit 0

--- a/.devcontainer/postCreateApacheSetup.sh
+++ b/.devcontainer/postCreateApacheSetup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+source $workspaceFolder/.devcontainer/devcontainer.env
+
+echo ">>> Apache2 Configuration"
+envsubst < $workspaceFolder/.devcontainer/include/001-friendica.conf > /tmp/001-friendica.conf
+
+sudo cp /tmp/001-friendica.conf /etc/apache2/sites-available/001-friendica.conf
+sudo a2enmod rewrite actions
+sudo a2ensite 001-friendica
+sudo a2dissite 000-default
+
+exit 0

--- a/.devcontainer/postCreateFriendicaSetup.sh
+++ b/.devcontainer/postCreateFriendicaSetup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+source $workspaceFolder/.devcontainer/devcontainer.env
+
+# Setup Friendica
+echo ">>> Friendica Setup"
+envsubst < $workspaceFolder/.devcontainer/include/autoinstall.config.php > /tmp/autoinstall.config.php
+
+cd $DocumentRoot
+
+# copy the .htaccess-dist file to .htaccess so that rewrite rules work
+cp $DocumentRoot/.htaccess-dist $DocumentRoot/.htaccess
+
+bin/composer.phar --no-dev install
+
+# install friendica
+bin/console autoinstall -f /tmp/autoinstall.config.php
+
+# add users
+# (disable a bunch of validation because this is a dev install, deh, it needs invalid emails and stupid passwords)
+bin/console config system disable_email_validation 1
+bin/console config system disable_password_exposed 1
+bin/console user add "$ADMIN_NICK" "$ADMIN_NICK" "$ADMIN_NICK@friendica.local" en http://friendica.local/profile/$ADMIN_NICK
+bin/console user password "$ADMIN_NICK" "$ADMIN_PASSW"
+bin/console user add "$USER_NICK" "$USER_NICK" "$USER_NICK@friendica.local" en http://friendica.local/profile/$USER_NICK
+bin/console user password "$USER_NICK" "$USER_PASSW"
+
+exit 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ robots.txt
 
 #Ignore config files from VSCode
 /.vscode/
+!/.vscode/launch.json
 
 #ignore smarty cache
 /view/smarty3/compiled/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9000,
+            "runtimeArgs": [
+                "-dzend_extension=xdebug.so",
+                "-dxdebug.mode=debug",
+                "-dxdebug.start_with_request=yes",
+                "-dxdebug.client_host=127.0.0.1",
+                "-dxdebug.client_port=9000",
+                "-dxdebug.log=/tmp/xdebug.log"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This is an initial version of a devcontainer for Friendica.

- created and tested with vscode running the devcontainer on a remote host
- working: git, automatic setup and start with Apache 2 web server, creating database, Debugger
- details can be found in README.MD in .devcontainer folder
- based on what I found in the Vagrant setup though a few features are still missing:
  - no TLS
  - no mail MTA
  - works with port forwarding (switch to published ports is on the list)

Feedback is welcome. I plan to extend the setup to a fully working Friendica instance in a devcontainer for development.

