### PR TITLE
devcontainer: network connectivity

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -5,7 +5,8 @@ MYSQL_USER=friendica
 MYSQL_PASSWORD=friendica
 
 #Webserver setup
-ServerName=192.168.56.10.xip.io
+ServerName=localhost
+ServerPort=8080
 ServerAlias=friendica.local
 DocumentRoot=/var/www/html
 APACHE_LOG_DIR=/var/log/apache2

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update -y;
 
 # Install MariaDB client
 RUN apt-get install -y mariadb-client
-COPY include/my.cnf /home/vscode/.my.cnf
 
 # Base packages
 RUN apt install -y vim software-properties-common sudo nano gnupg2

--- a/.devcontainer/README.MD
+++ b/.devcontainer/README.MD
@@ -3,7 +3,7 @@ This folder holds a devcontainer definition for Friendica.
 
 The main features are:
 
-- The development container is based on the PHP dev container image in variant that includes an Apache2 
+- The development container is based on the PHP dev container image in a variant that includes an Apache2 
   webserver. The variant defines the PHP version and the OS it is based on. The currently used variant 
   is defined in the Dockerfile.
 
@@ -22,11 +22,20 @@ The development setup is:
   port 8080 from your local development machine (http://localhost:8080/). This is also the url as configured 
   in local.config.php. You should be able to log in with user 'admin@friendica.local' and password 'admin'.
 
-- Important values are defined in the devcontainer.env file and applied during creation wherever possible. The
+- Important values are defined in the .env file within the .devcontainer folder and applied during creation wherever possible. The
   environment is also available during run/debug time to the application.
 
 - XDebug can be started by the launch configuration 'Listen for Xdebug'. The launch configuration is in .vscode/launch.json
   (this file is added to git).
+
+- The Apache server in the dev container is reachable with http on the ports 80 and 8080 and with https on port 443. The
+  url used for Friendica is defined in local.config.php (currently localhost:8080) and any subsequent request will be redirected 
+  to this url. To change the url to one you like you need to modify the url in local.config.php which can be done by
+  setting the values in the .env file accordingly and rebuilding the container.
+
+- The hostname friendica.local is used for the ceritificate and added to the hosts file in the container. .local is a reserved TLD
+  for mDNS and if you can use this depends on your network configuration. For developing and debugging using forwarded ports 
+  (localhost:8080) works fine.
 
 
 Open points:
@@ -34,20 +43,12 @@ Open points:
 - Cron jobs / worker are not available. For a dev environment those are disabled by default (but can be optionally 
   enabled).
 
-- The creation of the container runs the postCreate.sh script. This includes a few setup steps that do not need to 
-  be runned on a container rebuild (but on creation of the container). I plan to seperate steps from creation and rebuild 
-  but it is not really a problem at the moment (it just gives some output stating Error where no error is).
-
 - Passing values from the local development machine (with $localEnv) does not seem to work. This would be handy to apply
   a few settings differently based on user choice. 
 
 - The dev container does not have an email MTA. 
 
-- The devcontainer does currently not support TLS.
-
 - There are still a bit too much warnings logged at startup but that doesn't seem to be a problem.
 
 - Only the first launch configuration ('Listen for Xdebug') is working.
 
-- There is no port exposed on the container (only forwarded ports used). It would be handy to have the dev instance being able
-  to work as a normal instance in the fediverse. 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,9 +14,6 @@
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
-	// For use with PHP or Apache (e.g.php -S localhost:8080 or apache2ctl start)
-	"forwardPorts": [3306, 8080],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "bash -c '.devcontainer/postCreate.sh && .devcontainer/postCreateApacheSetup.sh && .devcontainer/postCreateFriendicaSetup.sh'",
 	"postStartCommand": "service apache2 start",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,29 +8,35 @@ services:
 
     volumes:
       - ../..:/workspaces:cached
-    env_file: "devcontainer.env"
+    env_file: ".env"
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db
-
+    ports:
+      - 80:80
+      - 443:443
+      - 8080:8080
+      - 3306:3306
+       
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
     # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+    extra_hosts:
+      - "${ServerAlias}:127.0.0.1"  
 
   db:
     image: mariadb:10.4
     restart: unless-stopped
     volumes:
       - mariadb-data:/var/lib/mysql
-    env_file: "devcontainer.env"
+    env_file: ".env"
     environment:
       MYSQL_ROOT_PASSWORD: root
     command: ['mysqld', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
 
-    # Add "forwardPorts": ["3306"] to **devcontainer.json** to forward MariaDB locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    # Runs app on the same network as the app container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:app
   
 volumes:
   mariadb-data:

--- a/.devcontainer/include/001-friendica.conf
+++ b/.devcontainer/include/001-friendica.conf
@@ -1,9 +1,15 @@
-<VirtualHost *:8080>
+<VirtualHost *:80 *:8080>
     ServerAdmin webmaster@localhost
     ServerName ${ServerName}
     ServerAlias ${ServerAlias}
 
     DocumentRoot ${DocumentRoot}
+
+    <Location /server-status>
+       SetHandler server-status
+       Order deny,allow
+       Allow from all
+    </Location>
 
     <Directory ${DocumentRoot}>
        Options Indexes FollowSymLinks MultiViews
@@ -11,12 +17,6 @@
        Order allow,deny
        allow from all
     </Directory>
-
-    <Location /server-status>
-       SetHandler server-status
-       Order deny,allow
-       Allow from all
-    </Location>
     
     # Possible values include: debug, info, notice, warn, error, crit,
     # alert, emerg.
@@ -25,4 +25,47 @@
     ErrorLog ${APACHE_LOG_DIR}/${ServerName}-error.log
     CustomLog ${APACHE_LOG_DIR}/${ServerName}-access.log combined
 
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    ServerName ${ServerName}
+    ServerAlias ${ServerAlias}
+
+    DocumentRoot ${DocumentRoot}
+
+    <Location /server-status>
+       SetHandler server-status
+       Order deny,allow
+       Allow from all
+    </Location>
+
+    <Directory ${DocumentRoot}>
+       Options Indexes FollowSymLinks MultiViews
+       AllowOverride All 
+       Order allow,deny
+       allow from all
+    </Directory>
+    
+    # Possible values include: debug, info, notice, warn, error, crit,
+    # alert, emerg.
+    LogLevel warn
+
+    ErrorLog ${APACHE_LOG_DIR}/${ServerName}-error.log
+    CustomLog ${APACHE_LOG_DIR}/${ServerName}-access.log combined
+
+    SSLEngine on
+
+    SSLCertificateFile  /etc/ssl/certs/friendica.crt
+    SSLCertificateKeyFile /etc/ssl/private/friendica.key
+
+    <FilesMatch "\.(cgi|shtml|phtml|php)$">
+        SSLOptions +StdEnvVars
+    </FilesMatch>
+
+    BrowserMatch "MSIE [2-6]" \\
+        nokeepalive ssl-unclean-shutdown \\
+        downgrade-1.0 force-response-1.0
+    # MSIE 7 and newer should be able to use keepalive
+    BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
 </VirtualHost>

--- a/.devcontainer/include/autoinstall.config.php
+++ b/.devcontainer/include/autoinstall.config.php
@@ -1,19 +1,22 @@
 <?php
-
-// Local configuration
-
-/* If automatic system installation fails:
+/**
+ * @copyright Copyright (C) 2010-2024, the Friendica project
  *
- * Copy this file to local.config.php
+ * @license GNU AGPL version 3 or any later version
  *
- * Why local.config.php? Because it contains sensitive information which could
- * give somebody complete control of your database. Apache's default
- * configuration will interpret any .php file as a script and won't show the values
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- * Then set the following for your MySQL installation
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
  *
- * If you're unsure about what any of the config keys below do, please check the static/defaults.config.php file for
- * detailed documentation of their data type and behavior.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
  */
 
 return [
@@ -32,15 +35,16 @@ return [
 	// ****************************************************************
 
 	'config' => [
-		'admin_email' => 'admin@friendica.local',
+		'admin_email' => 'admin@${ServerAlias}',
 		'sitename' => 'Friendica Social Network',
 		'register_policy' => \Friendica\Module\Register::OPEN,
 		'register_text' => '',
+		'php' => '${FRIENDICA_PHP_PATH}',
 	],
 	'system' => [
 		'default_timezone' => 'UTC',
 		'language' => 'en',
 		'basepath' => '${workspaceFolder}',
-		'url' => 'http://localhost:8080',
+		'url' => 'http://${ServerName}:${ServerPort}',
 	],
 ];

--- a/.devcontainer/include/my.cnf
+++ b/.devcontainer/include/my.cnf
@@ -1,4 +1,4 @@
 [client]
 protocol = tcp
-user = friendica
-password = friendica
+user = ${MYSQL_USER}
+password = ${MYSQL_PASSWORD}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -3,10 +3,12 @@
 
 # Prepare the workspace files with the values from the devcontainer.env file
 set -a
-source $workspaceFolder/.devcontainer/devcontainer.env
+source $workspaceFolder/.devcontainer/.env
 
 echo ">>> Development Setup"
 sudo apt-get update
+
+envsubst < $workspaceFolder/.devcontainer/include/my.cnf > /home/vscode/.my.cnf
 
 #Make the workspace directory the docroot
 echo ">>> Symlink $DocumentRoot to $workspaceFolder"

--- a/.devcontainer/postCreateApacheSetup.sh
+++ b/.devcontainer/postCreateApacheSetup.sh
@@ -1,13 +1,26 @@
 #!/bin/bash
 #
-source $workspaceFolder/.devcontainer/devcontainer.env
+source $workspaceFolder/.devcontainer/.env
 
 echo ">>> Apache2 Configuration"
 envsubst < $workspaceFolder/.devcontainer/include/001-friendica.conf > /tmp/001-friendica.conf
 
+# Create a self-signed SSL certificate
+sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+   -keyout /etc/ssl/private/friendica.key \
+   -out /etc/ssl/certs/friendica.crt \
+   -subj "/C=US/ST=State/L=City/O=Organization/CN=$ServerAlias" \
+   -addext "subjectAltName = DNS:$ServerAlias, DNS:$ServerName"
+
+sudo chmod +rx /etc/ssl/private
+sudo chmod 644 /etc/ssl/private/friendica.key
+sudo chmod 644 /etc/ssl/certs/friendica.crt
+
 sudo cp /tmp/001-friendica.conf /etc/apache2/sites-available/001-friendica.conf
-sudo a2enmod rewrite actions
+sudo a2enmod rewrite actions ssl
 sudo a2ensite 001-friendica
 sudo a2dissite 000-default
+
+echo 'ServerName 127.0.0.1' | sudo tee -a /etc/apache2/apache2.conf
 
 exit 0

--- a/.devcontainer/postCreateFriendicaSetup.sh
+++ b/.devcontainer/postCreateFriendicaSetup.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 #
-source $workspaceFolder/.devcontainer/devcontainer.env
+source $workspaceFolder/.devcontainer/.env
 
 # Setup Friendica
 echo ">>> Friendica Setup"
+
+FRIENDICA_PHP_PATH=$(which php)
+export FRIENDICA_PHP_PATH
+  
 envsubst < $workspaceFolder/.devcontainer/include/autoinstall.config.php > /tmp/autoinstall.config.php
+
 
 cd $DocumentRoot
 
@@ -20,9 +25,9 @@ bin/console autoinstall -f /tmp/autoinstall.config.php
 # (disable a bunch of validation because this is a dev install, deh, it needs invalid emails and stupid passwords)
 bin/console config system disable_email_validation 1
 bin/console config system disable_password_exposed 1
-bin/console user add "$ADMIN_NICK" "$ADMIN_NICK" "$ADMIN_NICK@friendica.local" en http://friendica.local/profile/$ADMIN_NICK
+bin/console user add "$ADMIN_NICK" "$ADMIN_NICK" "$ADMIN_NICK@$ServerAlias" en http://friendica.local/profile/$ADMIN_NICK
 bin/console user password "$ADMIN_NICK" "$ADMIN_PASSW"
-bin/console user add "$USER_NICK" "$USER_NICK" "$USER_NICK@friendica.local" en http://friendica.local/profile/$USER_NICK
+bin/console user add "$USER_NICK" "$USER_NICK" "$USER_NICK@$ServerAlias" en http://friendica.local/profile/$USER_NICK
 bin/console user password "$USER_NICK" "$USER_PASSW"
 
 exit 0


### PR DESCRIPTION
Updated configuration mainly for network settings of the dev container.
- friendica instance in the container can now be reached on port 80, 8080 and 443
- create self-signed certificate upon creation of the dev container
- updated configuration to make use of values defined in .env file
