### PR TITLE
Avoid fetching posts in a loop

### DIFF
--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -757,6 +757,8 @@ class Receiver
 			$object_data['recursion-depth'] = $activity['recursion-depth'];
 		}
 
+		$object_data['children'] = $activity['children'] ?? [];
+
 		if (!self::routeActivities($object_data, $type, $push, true, $uid)) {
 			self::storeUnhandledActivity(true, $type, $object_data, $activity, $body, $uid, $trust_source, $push, $signer);
 			Queue::remove($object_data);


### PR DESCRIPTION
This should fix the problem that sometimes the item processing seems to be processed in a loop.