### PR TITLE
Issue 14325: Execute "rawContent" only for GET requests

### DIFF
--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -224,17 +224,17 @@ abstract class BaseModule implements ICanHandleRequests
 		switch ($this->args->getMethod()) {
 			case Router::DELETE:
 				$this->delete($request);
-				break;
+				return $this->response->generate();
 			case Router::PATCH:
 				$this->patch($request);
-				break;
+				return $this->response->generate();
 			case Router::POST:
 				Core\Hook::callAll($this->args->getModuleName() . '_mod_post', $request);
 				$this->post($request);
-				break;
+				return $this->response->generate();
 			case Router::PUT:
 				$this->put($request);
-				break;
+				return $this->response->generate();
 		}
 
 		$timestamp = microtime(true);


### PR DESCRIPTION
Fixes #14325

Problem: `rawContent` is processed independent from the HTTP type. With this PR we now ensure that the content functions are really only called for `GET` requests.