### PR TITLE
Don't query the OWA data if already set

### DIFF
--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -2611,6 +2611,10 @@ class GServer
 			return;
 		}
 
+		if ($data['openwebauth'] == $gserver['openwebauth']) {
+			return;
+		}
+
 		$serverdata = self::getZotData($gserver['url'], []);
 		if (empty($serverdata)) {
 			$serverdata = ['openwebauth' => $data['openwebauth']];


### PR DESCRIPTION
When the OWA path is already stored in the server data, we don't query it again.