### PR TITLE
Usability improvements trending_tags.tpl & CSS instructions for formatting in the notification.tpl 

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -793,17 +793,17 @@ summary.wall-item-summary {
 /* css instructions notification.tpl */
 /* Flexbox layout to align the icon and text in a single line */
 .notif-item a {
-    display: flex;
-    align-items: flex-start;
+    	display: flex;
+    	align-items: flex-start;
 }
 
 /* Margin to create space between the icon and the text */
 .notif-image {
-    margin-right: 10px;
+    	margin-right: 10px;
 
 /* Styles to ensure the text wraps properly after 70 characters */
 .notif-text {
-    display: inline-block;
-    max-width: 70ch;
-    overflow-wrap: break-word;
+    	display: inline-block;
+    	max-width: 70ch;
+    	overflow-wrap: break-word;
 }

--- a/view/global.css
+++ b/view/global.css
@@ -789,3 +789,21 @@ summary.wall-item-summary {
 	font-style: oblique;
   padding-bottom: 5px;
 }
+
+/* css instructions notification.tpl */
+/* Flexbox layout to align the icon and text in a single line */
+.notif-item a {
+    display: flex;
+    align-items: flex-start;
+}
+
+/* Margin to create space between the icon and the text */
+.notif-image {
+    margin-right: 10px;
+
+/* Styles to ensure the text wraps properly after 70 characters */
+.notif-text {
+    display: inline-block;
+    max-width: 70ch;
+    overflow-wrap: break-word;
+}

--- a/view/templates/notifications/notification.tpl
+++ b/view/templates/notifications/notification.tpl
@@ -1,28 +1,8 @@
 
-<style>
-	/* Flexbox layout to align the icon and text in a single line */
-	.notif-item a {
-		display: flex;
-		align-items: flex-start; /* Aligns items at the start of the flex container */
-	}
-
-	/* Margin to create space between the icon and the text */
-	.notif-image {
-		margin-right: 10px; /* Adjust the space between the icon and text as needed */
-
-		}
-
-	/* Styles to ensure the text wraps properly after 70 characters */
-	.notif-text {
-		display: inline-block; /* Allows the text to be constrained within a block-level element */
-		max-width: 70ch; /* Limits the maximum width of the text to 70 characters */
-		overflow-wrap: break-word; /* Ensures that words will break if necessary to fit the width */
-	}
-</style>
-
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}" {{if $item_seen}}aria-hidden="true"{{/if}}>
 	<a href="{{$notification.link}}">
 		<img src="{{$notification.image}}" aria-hidden="true" class="notif-image">
+		<link rel="stylesheet" href="view/global.css">
 		<span class="notif-text">{{$notification.text}}</span>
 		<span class="notif-when">{{$notification.ago}}</span>
 	</a>

--- a/view/templates/notifications/notification.tpl
+++ b/view/templates/notifications/notification.tpl
@@ -1,29 +1,4 @@
 
-<style>
-	/* Flexbox layout to align the icon and text in a single line */
-	.notif-item a {
-		display: flex;
-		align-items: flex-start; /* Aligns items at the start of the flex container */
-	}
-
-	/* Margin to create space between the icon and the text */
-	.notif-image {
-		margin-right: 10px; /* Adjust the space between the icon and text as needed */
-
-		}
-
-	/* Styles to ensure the text wraps properly after 70 characters */
-	.notif-text {
-		display: inline-block; /* Allows the text to be constrained within a block-level element */
-		max-width: 70ch; /* Limits the maximum width of the text to 70 characters */
-		overflow-wrap: break-word; /* Ensures that words will break if necessary to fit the width */
-	}
-</style>
-
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}" {{if $item_seen}}aria-hidden="true"{{/if}}>
-	<a href="{{$notification.link}}">
-		<img src="{{$notification.image}}" aria-hidden="true" class="notif-image">
-		<span class="notif-text">{{$notification.text}}</span>
-		<span class="notif-when">{{$notification.ago}}</span>
-	</a>
+	<a href="{{$notification.link}}"><img src="{{$notification.image}}" aria-hidden="true" class="notif-image">{{$notification.text}} <span class="notif-when">{{$notification.ago}}</span></a>
 </div>

--- a/view/templates/notifications/notification.tpl
+++ b/view/templates/notifications/notification.tpl
@@ -1,4 +1,29 @@
 
+<style>
+	/* Flexbox layout to align the icon and text in a single line */
+	.notif-item a {
+		display: flex;
+		align-items: flex-start; /* Aligns items at the start of the flex container */
+	}
+
+	/* Margin to create space between the icon and the text */
+	.notif-image {
+		margin-right: 10px; /* Adjust the space between the icon and text as needed */
+
+		}
+
+	/* Styles to ensure the text wraps properly after 70 characters */
+	.notif-text {
+		display: inline-block; /* Allows the text to be constrained within a block-level element */
+		max-width: 70ch; /* Limits the maximum width of the text to 70 characters */
+		overflow-wrap: break-word; /* Ensures that words will break if necessary to fit the width */
+	}
+</style>
+
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}" {{if $item_seen}}aria-hidden="true"{{/if}}>
-	<a href="{{$notification.link}}"><img src="{{$notification.image}}" aria-hidden="true" class="notif-image">{{$notification.text}} <span class="notif-when">{{$notification.ago}}</span></a>
+	<a href="{{$notification.link}}">
+		<img src="{{$notification.image}}" aria-hidden="true" class="notif-image">
+		<span class="notif-text">{{$notification.text}}</span>
+		<span class="notif-when">{{$notification.ago}}</span>
+	</a>
 </div>

--- a/view/templates/widget/trending_tags.tpl
+++ b/view/templates/widget/trending_tags.tpl
@@ -40,7 +40,7 @@
 
 <script>
 function toggleTags(event) {
-	event.preventDefault(); // Prevents the link from reloading the page
+	event.preventDefault();
 	var moreTags = document.getElementById('more-tags');
 	var link = event.target.closest('a');
 	var caretIcon = document.getElementById('caret-icon');
@@ -50,12 +50,12 @@ function toggleTags(event) {
 		moreTags.style.display = 'block';
 		linkText.textContent = 'Show Less';
 		link.setAttribute('aria-expanded', 'true');
-		caretIcon.className = 'fa fa-caret-down'; // Changes the icon to "Caret Down"
+		caretIcon.className = 'fa fa-caret-down';
 	} else {
 		moreTags.style.display = 'none';
 		linkText.textContent = 'Show More';
 		link.setAttribute('aria-expanded', 'false');
-		caretIcon.className = 'fa fa-caret-right'; // Changes the icon to "Caret Down"
+		caretIcon.className = 'fa fa-caret-right';
 	}
 }
 

--- a/view/templates/widget/trending_tags.tpl
+++ b/view/templates/widget/trending_tags.tpl
@@ -5,22 +5,59 @@
 	<span class="fakelink" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');">
 		<h3>{{$title}}</h3>
 	</span>
-	<ul>
-{{section name=ol loop=$tags max=10}}
-		<li><a href="search?tag={{$tags[ol].term}}">#{{$tags[ol].term}}</a></li>
-{{/section}}
-	</ul>
-{{if $tags|count > 10}}
-	<details>
-		<summary>{{$more}}</summary>
-		<ul>
-	{{section name=ul loop=$tags start=10}}
-			<li><a href="search?tag={{$tags[ul].term}}">#{{$tags[ul].term}}</a></li>
+	<ul id="tags-list" style="list-style-type: none; padding: 0; margin: 0;">
+	{{section name=ol loop=$tags max=10}}
+		<li style="margin-bottom: 5px;">
+			<a href="search?tag={{$tags[ol].term}}" style="text-decoration: none; color: inherit;">
+				<i class="fa fa-hashtag" aria-hidden="true"></i> {{$tags[ol].term}}
+			</a>
+		</li>
 	{{/section}}
-		</ul>
-	</details>
-{{/if}}
+	</ul>
+	{{if $tags|count > 10}}
+	<div style="text-align: left; margin-top: 10px;">
+		<a href="#"
+			onclick="toggleTags(event)"
+			role="button"
+			aria-expanded="false"
+			aria-controls="more-tags"
+			style="text-decoration: none; color: inherit; cursor: pointer; display: inline-flex; align-items: center; font-weight: bold;">
+			<i id="caret-icon" class="fa fa-caret-right" aria-hidden="true" style="margin-right: 5px;"></i>
+			<span id="link-text">Show More</span>
+		</a>
+	</div>
+	<ul id="more-tags" style="display:none; list-style-type: none; padding: 0; margin: 0;">
+		{{section name=ul loop=$tags start=10}}
+			<li style="margin-bottom: 5px;">
+				<a href="search?tag={{$tags[ul].term}}" style="text-decoration: none; color: inherit;">
+					<i class="fa fa-hashtag" aria-hidden="true"></i> {{$tags[ul].term}}
+				</a>
+			</li>
+		{{/section}}
+	</ul>
+	{{/if}}
 </div>
+
 <script>
+function toggleTags(event) {
+	event.preventDefault(); // Verhindert, dass der Link die Seite neu lädt
+	var moreTags = document.getElementById('more-tags');
+	var link = event.target.closest('a');
+	var caretIcon = document.getElementById('caret-icon');
+	var linkText = document.getElementById('link-text');
+
+	if (moreTags.style.display === 'none') {
+		moreTags.style.display = 'block';
+		linkText.textContent = 'Show Less';
+		link.setAttribute('aria-expanded', 'true');
+		caretIcon.className = 'fa fa-caret-down'; // Ändert das Icon auf "Caret Down"
+	} else {
+		moreTags.style.display = 'none';
+		linkText.textContent = 'Show More';
+		link.setAttribute('aria-expanded', 'false');
+		caretIcon.className = 'fa fa-caret-right'; // Ändert das Icon auf "Caret Right"
+	}
+}
+
 initWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');
 </script>

--- a/view/templates/widget/trending_tags.tpl
+++ b/view/templates/widget/trending_tags.tpl
@@ -40,7 +40,7 @@
 
 <script>
 function toggleTags(event) {
-	event.preventDefault(); // Verhindert, dass der Link die Seite neu lädt
+	event.preventDefault(); // Prevents the link from reloading the page
 	var moreTags = document.getElementById('more-tags');
 	var link = event.target.closest('a');
 	var caretIcon = document.getElementById('caret-icon');
@@ -50,12 +50,12 @@ function toggleTags(event) {
 		moreTags.style.display = 'block';
 		linkText.textContent = 'Show Less';
 		link.setAttribute('aria-expanded', 'true');
-		caretIcon.className = 'fa fa-caret-down'; // Ändert das Icon auf "Caret Down"
+		caretIcon.className = 'fa fa-caret-down'; // Changes the icon to "Caret Down"
 	} else {
 		moreTags.style.display = 'none';
 		linkText.textContent = 'Show More';
 		link.setAttribute('aria-expanded', 'false');
-		caretIcon.className = 'fa fa-caret-right'; // Ändert das Icon auf "Caret Right"
+		caretIcon.className = 'fa fa-caret-right'; // Changes the icon to "Caret Down"
 	}
 }
 


### PR DESCRIPTION
The tranding tags don't look very nice. The changes are intended to make them more attractive. 

 - For this purpose, each tag is preceded by a "fa fa-hashtag".
 - The # in front of the word has been removed
 - Clicking on a hashtag searches with a hashtag as usual.
 - Other tags were previously displayed indented
 - Now it is ensured that all hashtags are in one line

This is a suggestion that can be discarded at any time. I would still be happy if the changes could be adopted.

 **CSS instructions for formatting in the notification.tpl**

A space has been inserted between the user icon and the outlined text. Texts are wrapped after 70 characters.