### PR TITLE
Prevent fetching replies when fetching replies

### DIFF
--- a/src/Protocol/ActivityPub/Queue.php
+++ b/src/Protocol/ActivityPub/Queue.php
@@ -333,6 +333,7 @@ class Queue
 					return false;
 				}
 				$activity['recursion-depth'] = 0;
+				$activity['callstack'] = Processor::addToCallstack($activity['callstack'] ?? []);
 				$wid = Worker::add(Worker::PRIORITY_HIGH, 'FetchMissingActivity', $entry['in-reply-to-id'], $activity, '', Receiver::COMPLETION_ASYNC);
 				Fetch::setWorkerId($entry['in-reply-to-id'], $wid);
 				Logger::debug('Fetch missing activity', ['wid' => $wid, 'id' => $entry['activity-id'], 'reply-to-id' => $entry['in-reply-to-id']]);

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -250,7 +250,6 @@ class Receiver
 		} elseif (!Fetch::hasWorker($object_id)) {
 			Logger::notice('Fetching is done by worker.', ['id' => $object_id]);
 			Fetch::add($object_id);
-			$activity['recursion-depth'] = 0;
 			$wid = Worker::add(Worker::PRIORITY_HIGH, 'FetchMissingActivity', $object_id, [], $actor, self::COMPLETION_RELAY);
 			Fetch::setWorkerId($object_id, $wid);
 		} else {
@@ -757,7 +756,8 @@ class Receiver
 			$object_data['recursion-depth'] = $activity['recursion-depth'];
 		}
 
-		$object_data['children'] = $activity['children'] ?? [];
+		$object_data['children']  = $activity['children'] ?? [];
+		$object_data['callstack'] = $activity['callstack'] ?? [];
 
 		if (!self::routeActivities($object_data, $type, $push, true, $uid)) {
 			self::storeUnhandledActivity(true, $type, $object_data, $activity, $body, $uid, $trust_source, $push, $signer);


### PR DESCRIPTION
Don't fetch replies when we already fetch replies. This should prevent/reduce performance problems.