### PR TITLE
Fix for fetching the target inboxes

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1928,8 +1928,6 @@ class Processor
 	{
 		if (!empty($object['published'])) {
 			$published = $object['published'];
-		} elseif (!empty($child['published'])) {
-			$published = $child['published'];
 		} else {
 			$published = DateTimeFormat::utcNow();
 		}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -930,7 +930,7 @@ class Transmitter
 	 * @param boolean $blindcopy
 	 * @return void
 	 */
-	public static function getReceiversForUriId(int $uri_id, bool $blindcopy)
+	public static function getReceiversForUriId(int $uri_id, bool $blindcopy): array
 	{
 		$tags = Tag::getByURIId($uri_id, [Tag::TO, Tag::CC, Tag::BTO, Tag::BCC, Tag::AUDIENCE]);
 		if (empty($tags)) {
@@ -1029,8 +1029,8 @@ class Transmitter
 		$inboxes = [];
 
 		$isGroup = false;
-		if (!empty($item['uid'])) {
-			$profile = User::getOwnerDataById($item['uid']);
+		if (!empty($uid)) {
+			$profile = User::getOwnerDataById($uid);
 			if (!empty($profile)) {
 				$isGroup = $profile['account-type'] == User::ACCOUNT_TYPE_COMMUNITY;
 			}


### PR DESCRIPTION
We used a wrong variable. This caused for example that profile updates weren't send to the receivers. Also this possibly could have got other side effects.