### PR TITLE
Issue 14186: Respect public restrictions for ttimeline API endpoint

### DIFF
--- a/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
@@ -21,15 +21,22 @@
 
 namespace Friendica\Module\Api\Mastodon\Timelines;
 
+use Friendica\App;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
+use Friendica\Module\Api\ApiResponse;
 use Friendica\Module\BaseApi;
+use Friendica\Module\Conversation\Community;
 use Friendica\Network\HTTPException;
 use Friendica\Object\Api\Mastodon\TimelineOrderByTypes;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
 
 /**
  * @see https://docs.joinmastodon.org/methods/timelines/
@@ -37,10 +44,24 @@ use Friendica\Object\Api\Mastodon\TimelineOrderByTypes;
 class PublicTimeline extends BaseApi
 {
 	/**
+	 * @var IManageConfigValues
+	 */
+	private $config;
+
+	public function __construct(IManageConfigValues $config, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	{
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		$this->config = $config;
+	}
+	/**
 	 * @throws HTTPException\InternalServerErrorException
 	 */
 	protected function rawContent(array $request = [])
 	{
+		if ($this->config->get('system', 'block_public') || $this->config->get('system', 'community_page_style') == Community::DISABLED_VISITOR) {
+			$this->checkAllowedScope(BaseApi::SCOPE_READ);
+		}
+
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([
@@ -56,6 +77,10 @@ class PublicTimeline extends BaseApi
 			'friendica_order' => TimelineOrderByTypes::ID, // Sort order options (defaults to ID)
 		], $request);
 
+		if (!$this->localAllowed() && !$this->globalAllowed()) {
+			$this->jsonExit([]);
+		}
+
 		$condition = [
 			'gravity' => [Item::GRAVITY_PARENT, Item::GRAVITY_COMMENT], 'private' => Item::PUBLIC,
 			'network' => Protocol::FEDERATED, 'author-blocked' => false, 'author-hidden' => false
@@ -64,13 +89,13 @@ class PublicTimeline extends BaseApi
 		$condition = $this->addPagingConditions($request, $condition);
 		$params = $this->buildOrderAndLimitParams($request);
 
-		if ($request['local']) {
+		if ($request['local'] && $this->localAllowed()) {
 			$condition = DBA::mergeConditions($condition, ['origin' => true]);
 		} else {
 			$condition = DBA::mergeConditions($condition, ['uid' => 0]);
 		}
 
-		if ($request['remote']) {
+		if ($request['remote'] && $this->globalAllowed()) {
 			$condition = DBA::mergeConditions($condition, ["NOT `uri-id` IN (SELECT `uri-id` FROM `post-user` WHERE `origin` AND `post-user`.`uri-id` = `post-timeline-view`.`uri-id`)"]);
 		}
 
@@ -112,5 +137,15 @@ class PublicTimeline extends BaseApi
 
 		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
 		$this->jsonExit($statuses);
+	}
+
+	private function localAllowed(): bool
+	{
+		return in_array($this->config->get('system', 'community_page_style'), [Community::LOCAL, Community::LOCAL_AND_GLOBAL]);
+	}
+
+	private function globalAllowed(): bool
+	{
+		return in_array($this->config->get('system', 'community_page_style'), [Community::GLOBAL, Community::LOCAL_AND_GLOBAL]);
 	}
 }

--- a/src/Module/Api/Mastodon/Trends/Statuses.php
+++ b/src/Module/Api/Mastodon/Trends/Statuses.php
@@ -21,14 +21,20 @@
 
 namespace Friendica\Module\Api\Mastodon\Trends;
 
+use Friendica\App;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
+use Friendica\Module\Api\ApiResponse;
 use Friendica\Module\BaseApi;
+use Friendica\Module\Conversation\Community;
 use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
 
 /**
  * @see https://docs.joinmastodon.org/methods/trends/#statuses
@@ -36,10 +42,25 @@ use Friendica\Util\DateTimeFormat;
 class Statuses extends BaseApi
 {
 	/**
+	 * @var IManageConfigValues
+	 */
+	private $config;
+
+	public function __construct(IManageConfigValues $config, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	{
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+		$this->config = $config;
+	}
+
+	/**
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	protected function rawContent(array $request = [])
 	{
+		if ($this->config->get('system', 'block_public') || $this->config->get('system', 'community_page_style') == Community::DISABLED_VISITOR) {
+			$this->checkAllowedScope(BaseApi::SCOPE_READ);
+		}
+
 		$uid = self::getCurrentUserID();
 
 		$request = $this->getRequest([


### PR DESCRIPTION
Fixes #14186

When the public access is restricted or the community is restricted for visitors, we now enforce a login at the public timeline and the trends API endpoint.

Additionally we limit access to the local or global timeline depending upon the settings.