### PR TITLE
Remove apcontact and diaspora-contact entries that aren't connected to contacts

### DIFF
--- a/src/Worker/RemoveUnusedContacts.php
+++ b/src/Worker/RemoveUnusedContacts.php
@@ -89,5 +89,13 @@ class RemoveUnusedContacts
 		}
 		DBA::close($contacts);
 		Logger::notice('Removal done', ['count' => $count, 'total' => $total]);
+		
+		Logger::notice('Remove apcontact entries with no related contact');
+		DBA::delete('apcontact', ["`uri-id` NOT IN (SELECT `uri-id` FROM `contact`) AND `updated` < ?", DateTimeFormat::utc('now - 30 days')]);
+		Logger::notice('Removed apcontact entries with no related contact', ['count' => DBA::affectedRows()]);
+
+		Logger::notice('Remove diaspora-contact entries with no related contact');
+		DBA::delete('diaspora-contact', ["`uri-id` NOT IN (SELECT `uri-id` FROM `contact`) AND `updated` < ?", DateTimeFormat::utc('now - 30 days')]);
+		Logger::notice('Removed diaspora-contact entries with no related contact', ['count' => DBA::affectedRows()]);
 	}
 }


### PR DESCRIPTION
With this PR we now remove apcontact and diaspora-contact entries that aren't connected to a contact. These entries aren't needed and can easily be removed. On my test system it removed 1.8 million entries.