### PR TITLE
Delete unused media attachments

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2024.09-dev (Yellow Archangel)
--- DB_UPDATE_VERSION 1572
+-- DB_UPDATE_VERSION 1573
 -- ------------------------------------------
 
 
@@ -1424,6 +1424,7 @@ CREATE TABLE IF NOT EXISTS `post-media` (
 	`uri-id` int unsigned NOT NULL COMMENT 'Id of the item-uri table entry that contains the item uri',
 	`url` varbinary(1024) NOT NULL COMMENT 'Media URL',
 	`media-uri-id` int unsigned COMMENT 'Id of the item-uri table entry that contains the activities uri-id',
+	`attach-id` int unsigned COMMENT 'In case of a local attachment, this field is filled with the id in the attach table',
 	`type` tinyint unsigned NOT NULL DEFAULT 0 COMMENT 'Media type',
 	`mimetype` varchar(60) COMMENT '',
 	`height` smallint unsigned COMMENT 'Height of the media',
@@ -1445,8 +1446,10 @@ CREATE TABLE IF NOT EXISTS `post-media` (
 	 UNIQUE INDEX `uri-id-url` (`uri-id`,`url`(512)),
 	 INDEX `uri-id-id` (`uri-id`,`id`),
 	 INDEX `media-uri-id` (`media-uri-id`),
+	 INDEX `attach-id` (`attach-id`),
 	FOREIGN KEY (`uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,
-	FOREIGN KEY (`media-uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
+	FOREIGN KEY (`media-uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,
+	FOREIGN KEY (`attach-id`) REFERENCES `attach` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
 ) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Attached media';
 
 --

--- a/doc/database/db_post-media.md
+++ b/doc/database/db_post-media.md
@@ -6,29 +6,30 @@ Attached media
 Fields
 ------
 
-| Field           | Description                                                        | Type              | Null | Key | Default | Extra          |
-| --------------- | ------------------------------------------------------------------ | ----------------- | ---- | --- | ------- | -------------- |
-| id              | sequential ID                                                      | int unsigned      | NO   | PRI | NULL    | auto_increment |
-| uri-id          | Id of the item-uri table entry that contains the item uri          | int unsigned      | NO   |     | NULL    |                |
-| url             | Media URL                                                          | varbinary(1024)   | NO   |     | NULL    |                |
-| media-uri-id    | Id of the item-uri table entry that contains the activities uri-id | int unsigned      | YES  |     | NULL    |                |
-| type            | Media type                                                         | tinyint unsigned  | NO   |     | 0       |                |
-| mimetype        |                                                                    | varchar(60)       | YES  |     | NULL    |                |
-| height          | Height of the media                                                | smallint unsigned | YES  |     | NULL    |                |
-| width           | Width of the media                                                 | smallint unsigned | YES  |     | NULL    |                |
-| size            | Media size                                                         | bigint unsigned   | YES  |     | NULL    |                |
-| blurhash        | BlurHash representation of the image                               | varbinary(255)    | YES  |     | NULL    |                |
-| preview         | Preview URL                                                        | varbinary(512)    | YES  |     | NULL    |                |
-| preview-height  | Height of the preview picture                                      | smallint unsigned | YES  |     | NULL    |                |
-| preview-width   | Width of the preview picture                                       | smallint unsigned | YES  |     | NULL    |                |
-| description     |                                                                    | text              | YES  |     | NULL    |                |
-| name            | Name of the media                                                  | varchar(255)      | YES  |     | NULL    |                |
-| author-url      | URL of the author of the media                                     | varbinary(383)    | YES  |     | NULL    |                |
-| author-name     | Name of the author of the media                                    | varchar(255)      | YES  |     | NULL    |                |
-| author-image    | Image of the author of the media                                   | varbinary(383)    | YES  |     | NULL    |                |
-| publisher-url   | URL of the publisher of the media                                  | varbinary(383)    | YES  |     | NULL    |                |
-| publisher-name  | Name of the publisher of the media                                 | varchar(255)      | YES  |     | NULL    |                |
-| publisher-image | Image of the publisher of the media                                | varbinary(383)    | YES  |     | NULL    |                |
+| Field           | Description                                                                         | Type              | Null | Key | Default | Extra          |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------- | ---- | --- | ------- | -------------- |
+| id              | sequential ID                                                                       | int unsigned      | NO   | PRI | NULL    | auto_increment |
+| uri-id          | Id of the item-uri table entry that contains the item uri                           | int unsigned      | NO   |     | NULL    |                |
+| url             | Media URL                                                                           | varbinary(1024)   | NO   |     | NULL    |                |
+| media-uri-id    | Id of the item-uri table entry that contains the activities uri-id                  | int unsigned      | YES  |     | NULL    |                |
+| attach-id       | In case of a local attachment, this field is filled with the id in the attach table | int unsigned      | YES  |     | NULL    |                |
+| type            | Media type                                                                          | tinyint unsigned  | NO   |     | 0       |                |
+| mimetype        |                                                                                     | varchar(60)       | YES  |     | NULL    |                |
+| height          | Height of the media                                                                 | smallint unsigned | YES  |     | NULL    |                |
+| width           | Width of the media                                                                  | smallint unsigned | YES  |     | NULL    |                |
+| size            | Media size                                                                          | bigint unsigned   | YES  |     | NULL    |                |
+| blurhash        | BlurHash representation of the image                                                | varbinary(255)    | YES  |     | NULL    |                |
+| preview         | Preview URL                                                                         | varbinary(512)    | YES  |     | NULL    |                |
+| preview-height  | Height of the preview picture                                                       | smallint unsigned | YES  |     | NULL    |                |
+| preview-width   | Width of the preview picture                                                        | smallint unsigned | YES  |     | NULL    |                |
+| description     |                                                                                     | text              | YES  |     | NULL    |                |
+| name            | Name of the media                                                                   | varchar(255)      | YES  |     | NULL    |                |
+| author-url      | URL of the author of the media                                                      | varbinary(383)    | YES  |     | NULL    |                |
+| author-name     | Name of the author of the media                                                     | varchar(255)      | YES  |     | NULL    |                |
+| author-image    | Image of the author of the media                                                    | varbinary(383)    | YES  |     | NULL    |                |
+| publisher-url   | URL of the publisher of the media                                                   | varbinary(383)    | YES  |     | NULL    |                |
+| publisher-name  | Name of the publisher of the media                                                  | varchar(255)      | YES  |     | NULL    |                |
+| publisher-image | Image of the publisher of the media                                                 | varbinary(383)    | YES  |     | NULL    |                |
 
 Indexes
 ------------
@@ -39,6 +40,7 @@ Indexes
 | uri-id-url   | UNIQUE, uri-id, url(512) |
 | uri-id-id    | uri-id, id               |
 | media-uri-id | media-uri-id             |
+| attach-id    | attach-id                |
 
 Foreign Keys
 ------------
@@ -47,5 +49,6 @@ Foreign Keys
 |-------|--------------|--------------|
 | uri-id | [item-uri](help/database/db_item-uri) | id |
 | media-uri-id | [item-uri](help/database/db_item-uri) | id |
+| attach-id | [attach](help/database/db_attach) | id |
 
 Return to [database documentation](help/database)

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -380,14 +380,6 @@ class Item
 			Event::delete($item['event-id']);
 		}
 
-		// If item has attachments, drop them
-		$attachments = Post\Media::getByURIId($item['uri-id'], [Post\Media::DOCUMENT]);
-		foreach ($attachments as $attachment) {
-			if (preg_match('|attach/(\d+)|', $attachment['url'], $matches)) {
-				Attach::delete(['id' => $matches[1], 'uid' => $item['uid']]);
-			}
-		}
-
 		// Set the item to "deleted"
 		$item_fields = ['deleted' => true, 'edited' => DateTimeFormat::utcNow(), 'changed' => DateTimeFormat::utcNow()];
 		Post::update($item_fields, ['id' => $item['id']]);

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -384,11 +384,12 @@ class Media
 	private static function fetchLocalData(array $media): array
 	{
 		if (preg_match('|.*?/attach/(\d+)|', $media['url'], $matches)) {
-			$attachment = Attach::selectFirst(['filename', 'filetype', 'filesize'], ['id' => $matches[1]]);
+			$attachment = Attach::selectFirst(['id', 'filename', 'filetype', 'filesize'], ['id' => $matches[1]]);
 			if (!empty($attachment)) {
-				$media['name']     = $attachment['filename'];
-				$media['mimetype'] = $attachment['filetype'];
-				$media['size']     = $attachment['filesize'];
+				$media['attach-id'] = $attachment['id'];
+				$media['name']      = $attachment['filename'];
+				$media['mimetype']  = $attachment['filetype'];
+				$media['size']      = $attachment['filesize'];
 			}
 			return $media;
 		}
@@ -396,7 +397,7 @@ class Media
 		if (!preg_match('|.*?/photo/(.*[a-fA-F0-9])\-(.*[0-9])\..*[\w]|', $media['url'], $matches)) {
 			return $media;
 		}
-		$photo = Photo::selectFirst([], ['resource-id' => $matches[1], 'scale' => $matches[2]]);
+		$photo = Photo::selectFirst(['type', 'datasize', 'width', 'height', 'blurhash'], ['resource-id' => $matches[1], 'scale' => $matches[2]]);
 		if (!empty($photo)) {
 			$media['mimetype'] = $photo['type'];
 			$media['size'] = $photo['datasize'];
@@ -408,7 +409,7 @@ class Media
 		if (!preg_match('|.*?/photo/(.*[a-fA-F0-9])\-(.*[0-9])\..*[\w]|', $media['preview'] ?? '', $matches)) {
 			return $media;
 		}
-		$photo = Photo::selectFirst([], ['resource-id' => $matches[1], 'scale' => $matches[2]]);
+		$photo = Photo::selectFirst(['width', 'height'], ['resource-id' => $matches[1], 'scale' => $matches[2]]);
 		if (!empty($photo)) {
 			$media['preview-width'] = $photo['width'];
 			$media['preview-height'] = $photo['height'];

--- a/src/Module/Admin/Site.php
+++ b/src/Module/Admin/Site.php
@@ -53,7 +53,8 @@ class Site extends BaseAdmin
 		$language         = (!empty($_POST['language'])         ? trim($_POST['language'])      : '');
 		$theme            = (!empty($_POST['theme'])            ? trim($_POST['theme'])         : '');
 		$theme_mobile     = (!empty($_POST['theme_mobile'])     ? trim($_POST['theme_mobile'])  : '');
-		$maximagesize     = (!empty($_POST['maximagesize'])     ? trim($_POST['maximagesize'])              : 0);
+		$maxfilesize      = (!empty($_POST['maxfilesize'])      ? trim($_POST['maxfilesize'])                        : 0);
+		$maximagesize     = (!empty($_POST['maximagesize'])     ? trim($_POST['maximagesize'])                       : 0);
 		$maximagelength   = (!empty($_POST['maximagelength'])   ? intval(trim($_POST['maximagelength']))             : -1);
 		$jpegimagequality = (!empty($_POST['jpegimagequality']) ? intval(trim($_POST['jpegimagequality']))           : 100);
 
@@ -223,6 +224,11 @@ class Site extends BaseAdmin
 			$transactionConfig->delete('system', 'singleuser');
 		} else {
 			$transactionConfig->set('system', 'singleuser', $singleuser);
+		}
+		if (preg_match('/\d+(?:\s*[kmg])?/i', $maxfilesize)) {
+			$transactionConfig->set('system', 'maxfilesize', $maxfilesize);
+		} else {
+			DI::sysmsg()->addNotice(DI::l10n()->t('%s is no valid input for maximum media size', $maxfilesize));
 		}
 		if (preg_match('/\d+(?:\s*[kmg])?/i', $maximagesize)) {
 			$transactionConfig->set('system', 'maximagesize', $maximagesize);
@@ -484,6 +490,10 @@ class Site extends BaseAdmin
 													'', 'pattern="\d+(?:\s*[kmg])?"'],
 			'$maximagelength'   => ['maximagelength', DI::l10n()->t('Maximum image length'), DI::config()->get('system', 'max_image_length'), DI::l10n()->t('Maximum length in pixels of the longest side of uploaded images. Default is -1, which means no limits.')],
 			'$jpegimagequality' => ['jpegimagequality', DI::l10n()->t('JPEG image quality'), DI::config()->get('system', 'jpeg_quality'), DI::l10n()->t('Uploaded JPEGS will be saved at this quality setting [0-100]. Default is 100, which is full quality.')],
+			'$maxfilesize'      => ['maxfilesize', DI::l10n()->t('Maximum media file size'), DI::config()->get('system', 'maxfilesize'), DI::l10n()->t('Maximum size in bytes of uploaded media files. Default is 0, which means no limits. You can put k, m, or g behind the desired value for KiB, MiB, GiB, respectively.
+													The value of <code>upload_max_filesize</code> in your <code>PHP.ini</code> needs be set to at least the desired limit.
+													Currently <code>upload_max_filesize</code> is set to %s (%s byte)', Strings::formatBytes(Strings::getBytesFromShorthand(ini_get('upload_max_filesize'))), Strings::getBytesFromShorthand(ini_get('upload_max_filesize'))),
+													'', 'pattern="\d+(?:\s*[kmg])?"'],
 
 			'$register_policy'        => ['register_policy', DI::l10n()->t('Register policy'), DI::config()->get('config', 'register_policy'), '', $register_choices],
 			'$max_registered_users'   => ['max_registered_users', DI::l10n()->t('Maximum Users'), DI::config()->get('config', 'max_registered_users'), DI::l10n()->t('If defined, the register policy is automatically closed when the given number of users is reached and reopens the registry when the number drops below the limit. It only works when the policy is set to open or close, but not when the policy is set to approval.')],

--- a/src/Module/Api/Mastodon/Instance.php
+++ b/src/Module/Api/Mastodon/Instance.php
@@ -79,9 +79,14 @@ class Instance extends BaseApi
 			$image_matrix_limit = 33177600; // 5760^2
 		}
 
+		$media_size_limit = Strings::getBytesFromShorthand($this->config->get('system', 'maxfilesize'));
+		if (empty($media_size_limit)) {
+			$media_size_limit = Strings::getBytesFromShorthand(ini_get('upload_max_filesize'));
+		}
+
 		return new InstanceV2Entity\Configuration(
 			$statuses_config,
-			new InstanceV2Entity\MediaAttachmentsConfig(Images::supportedMimeTypes(), $image_size_limit, $image_matrix_limit),
+			new InstanceV2Entity\MediaAttachmentsConfig(Images::supportedMimeTypes(), $image_size_limit, $image_matrix_limit, $media_size_limit),
 			new InstanceV2Entity\Polls(),
 			new InstanceV2Entity\Accounts(),
 		);

--- a/src/Module/Api/Mastodon/InstanceV2.php
+++ b/src/Module/Api/Mastodon/InstanceV2.php
@@ -115,9 +115,14 @@ class InstanceV2 extends BaseApi
 			$image_matrix_limit = 33177600; // 5760^2
 		}
 
+		$media_size_limit = Strings::getBytesFromShorthand($this->config->get('system', 'maxfilesize'));
+		if (empty($media_size_limit)) {
+			$media_size_limit = Strings::getBytesFromShorthand(ini_get('upload_max_filesize'));
+		}
+
 		return new InstanceEntity\Configuration(
 			$statuses_config,
-			new InstanceEntity\MediaAttachmentsConfig($this->supportedMimeTypes(), $image_size_limit, $image_matrix_limit),
+			new InstanceEntity\MediaAttachmentsConfig($this->supportedMimeTypes(), $image_size_limit, $image_matrix_limit, $media_size_limit),
 			new InstanceEntity\Polls(),
 			new InstanceEntity\Accounts(),
 		);

--- a/src/Module/Media/Attachment/Upload.php
+++ b/src/Module/Media/Attachment/Upload.php
@@ -71,7 +71,7 @@ class Upload extends \Friendica\BaseModule
 		$tempFileName = $_FILES['userfile']['tmp_name'];
 		$fileName     = basename($_FILES['userfile']['name']);
 		$fileSize     = intval($_FILES['userfile']['size']);
-		$maxFileSize  = $this->config->get('system', 'maxfilesize');
+		$maxFileSize  = Strings::getBytesFromShorthand($this->config->get('system', 'maxfilesize'));
 
 		/*
 		 * Found html code written in text field of form, when trying to upload a

--- a/src/Object/Api/Mastodon/InstanceV2/MediaAttachmentsConfig.php
+++ b/src/Object/Api/Mastodon/InstanceV2/MediaAttachmentsConfig.php
@@ -32,12 +32,12 @@ class MediaAttachmentsConfig extends BaseDataTransferObject
 	/**
 	 * @param array $supported_mime_types
 	 */
-	public function __construct(array $supported_mime_types, int $image_size_limit, int $image_matrix_limit)
+	public function __construct(array $supported_mime_types, int $image_size_limit, int $image_matrix_limit, int $media_size_limit)
 	{
 		$this->supported_mime_types = $supported_mime_types;
 		$this->image_size_limit     = $image_size_limit;
 		$this->image_matrix_limit   = $image_matrix_limit;
-		$this->video_size_limit     = $image_size_limit;
+		$this->video_size_limit     = $media_size_limit;
 		$this->video_matrix_limit   = $image_matrix_limit;
 	}
 }

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -979,9 +979,11 @@ class Processor
 			}
 		}
 
-		$author = Contact::selectFirstAccount(['ap-posting-restricted'], ['id' => $item['author-id']]);
-		if (!empty($author['ap-posting-restricted'])) {
-			$item['restrictions'] = $item['restrictions'] | Item::CANT_REPLY;
+		if (!empty($item['author-id'])) {
+			$author = Contact::selectFirstAccount(['ap-posting-restricted'], ['id' => $item['author-id']]);
+			if (!empty($author['ap-posting-restricted'])) {
+				$item['restrictions'] = $item['restrictions'] | Item::CANT_REPLY;
+			}
 		}
 
 		$item['location'] = $activity['location'];

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -44,7 +44,7 @@ use Friendica\Database\DBA;
 
 // This file is required several times during the test in DbaDefinition which justifies this condition
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1572);
+	define('DB_UPDATE_VERSION', 1573);
 }
 
 return [
@@ -1431,6 +1431,7 @@ return [
 			"uri-id" => ["type" => "int unsigned", "not null" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
 			"url" => ["type" => "varbinary(1024)", "not null" => "1", "comment" => "Media URL"],
 			"media-uri-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the activities uri-id"],
+			"attach-id" => ["type" => "int unsigned", "foreign" => ["attach" => "id"], "comment" => "In case of a local attachment, this field is filled with the id in the attach table"],
 			"type" => ["type" => "tinyint unsigned", "not null" => "1", "default" => "0", "comment" => "Media type"],
 			"mimetype" => ["type" => "varchar(60)", "comment" => ""],
 			"height" => ["type" => "smallint unsigned", "comment" => "Height of the media"],
@@ -1454,6 +1455,7 @@ return [
 			"uri-id-url" => ["UNIQUE", "uri-id", "url(512)"],
 			"uri-id-id" => ["uri-id", "id"],
 			"media-uri-id" => ["media-uri-id"],
+			"attach-id" => ["attach-id"],
 		]
 	],
 	"post-origin" => [

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2024.09-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-11 06:43+0000\n"
+"POT-Creation-Date: 2024-08-24 10:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1741,7 +1741,7 @@ msgid "Display posts done by accounts with the selected account type."
 msgstr ""
 
 #: src/Content/Feature.php:134 src/Content/Widget.php:593
-#: src/Module/Admin/Site.php:474 src/Module/BaseSettings.php:125
+#: src/Module/Admin/Site.php:480 src/Module/BaseSettings.php:125
 #: src/Module/Settings/Channels.php:225 src/Module/Settings/Display.php:315
 msgid "Channels"
 msgstr ""
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Create new group"
 msgstr ""
 
-#: src/Content/Item.php:331 src/Model/Item.php:3304
+#: src/Content/Item.php:331 src/Model/Item.php:3296
 msgid "event"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:340 src/Model/Item.php:3306
+#: src/Content/Item.php:340 src/Model/Item.php:3298
 #: src/Module/Post/Tag/Add.php:123
 msgid "photo"
 msgstr ""
@@ -2246,8 +2246,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:947 src/Model/Item.php:4060
-#: src/Model/Item.php:4066 src/Model/Item.php:4067
+#: src/Content/Text/BBCode.php:947 src/Model/Item.php:4052
+#: src/Model/Item.php:4058 src/Model/Item.php:4059
 msgid "Link to source"
 msgstr ""
 
@@ -2406,7 +2406,7 @@ msgstr ""
 msgid "Relays"
 msgstr ""
 
-#: src/Content/Widget.php:546 src/Module/Moderation/BaseUsers.php:69
+#: src/Content/Widget.php:546 src/Module/Moderation/BaseUsers.php:70
 msgid "All"
 msgstr ""
 
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Could not connect to database."
 msgstr ""
 
-#: src/Core/L10n.php:444 src/Model/Item.php:2348
+#: src/Core/L10n.php:444 src/Model/Item.php:2340
 msgid "Undetermined"
 msgstr ""
 
@@ -3209,68 +3209,68 @@ msgstr ""
 msgid "Group"
 msgstr ""
 
-#: src/Model/Contact.php:1762 src/Module/Moderation/BaseUsers.php:131
+#: src/Model/Contact.php:1762 src/Module/Moderation/BaseUsers.php:134
 msgid "Relay"
 msgstr ""
 
-#: src/Model/Contact.php:3084
+#: src/Model/Contact.php:3097
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:3089 src/Module/Friendica.php:100
+#: src/Model/Contact.php:3102 src/Module/Friendica.php:100
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:3094
+#: src/Model/Contact.php:3107
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:3103
+#: src/Model/Contact.php:3116
 msgid "The contact could not be added. Please check the relevant network credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:3121
+#: src/Model/Contact.php:3134
 #, php-format
 msgid "Expected network %s does not match actual network %s"
 msgstr ""
 
-#: src/Model/Contact.php:3138
+#: src/Model/Contact.php:3151
 msgid "This seems to be a relay account. They can't be followed by users."
 msgstr ""
 
-#: src/Model/Contact.php:3145
+#: src/Model/Contact.php:3158
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:3147
+#: src/Model/Contact.php:3160
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:3150
+#: src/Model/Contact.php:3163
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:3153
+#: src/Model/Contact.php:3166
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:3156
+#: src/Model/Contact.php:3169
 msgid "Unable to match @-style Identity Address with a known protocol or email contact."
 msgstr ""
 
-#: src/Model/Contact.php:3157
+#: src/Model/Contact.php:3170
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:3163
+#: src/Model/Contact.php:3176
 msgid "The profile address specified belongs to a network which has been disabled on this site."
 msgstr ""
 
-#: src/Model/Contact.php:3168
+#: src/Model/Contact.php:3181
 msgid "Limited profile. This person will be unable to receive direct/personal notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:3234
+#: src/Model/Contact.php:3247
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -3375,90 +3375,90 @@ msgstr ""
 msgid "Happy Birthday %s"
 msgstr ""
 
-#: src/Model/Item.php:2355
+#: src/Model/Item.php:2347
 #, php-format
 msgid "%s (%s - %s): %s"
 msgstr ""
 
-#: src/Model/Item.php:2357
+#: src/Model/Item.php:2349
 #, php-format
 msgid "%s (%s): %s"
 msgstr ""
 
-#: src/Model/Item.php:2360
+#: src/Model/Item.php:2352
 #, php-format
 msgid "Detected languages in this post:\\n%s"
 msgstr ""
 
-#: src/Model/Item.php:3308
+#: src/Model/Item.php:3300
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:3310
+#: src/Model/Item.php:3302
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:3313 src/Module/Post/Tag/Add.php:123
+#: src/Model/Item.php:3305 src/Module/Post/Tag/Add.php:123
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3483
+#: src/Model/Item.php:3475
 #, php-format
 msgid "%s is blocked"
 msgstr ""
 
-#: src/Model/Item.php:3485
+#: src/Model/Item.php:3477
 #, php-format
 msgid "%s is ignored"
 msgstr ""
 
-#: src/Model/Item.php:3487
+#: src/Model/Item.php:3479
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:3491
+#: src/Model/Item.php:3483
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3960
+#: src/Model/Item.php:3952
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3991
+#: src/Model/Item.php:3983
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3993
+#: src/Model/Item.php:3985
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3998
+#: src/Model/Item.php:3990
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:4000
+#: src/Model/Item.php:3992
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:4002
+#: src/Model/Item.php:3994
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:4043 src/Model/Item.php:4044
+#: src/Model/Item.php:4035 src/Model/Item.php:4036
 msgid "View on separate page"
 msgstr ""
 
@@ -3882,7 +3882,7 @@ msgstr ""
 #: src/Module/Admin/Addons/Details.php:111 src/Module/Admin/Addons/Index.php:73
 #: src/Module/Admin/Federation.php:220 src/Module/Admin/Logs/Settings.php:88
 #: src/Module/Admin/Logs/View.php:85 src/Module/Admin/Queue.php:73
-#: src/Module/Admin/Site.php:457 src/Module/Admin/Storage.php:138
+#: src/Module/Admin/Site.php:463 src/Module/Admin/Storage.php:138
 #: src/Module/Admin/Summary.php:196 src/Module/Admin/Themes/Details.php:96
 #: src/Module/Admin/Themes/Index.php:117 src/Module/Admin/Tos.php:77
 #: src/Module/Moderation/Users/Create.php:61
@@ -3920,7 +3920,7 @@ msgid "Addon %s failed to install."
 msgstr ""
 
 #: src/Module/Admin/Addons/Index.php:75 src/Module/Admin/Features.php:83
-#: src/Module/Admin/Logs/Settings.php:90 src/Module/Admin/Site.php:460
+#: src/Module/Admin/Logs/Settings.php:90 src/Module/Admin/Site.php:466
 #: src/Module/Admin/Themes/Index.php:119 src/Module/Admin/Tos.php:86
 #: src/Module/Settings/Account.php:563 src/Module/Settings/Addons.php:78
 #: src/Module/Settings/Connectors.php:163
@@ -4120,8 +4120,8 @@ msgid "Enable Debugging"
 msgstr ""
 
 #: src/Module/Admin/Logs/Settings.php:94 src/Module/Admin/Logs/Settings.php:95
-#: src/Module/Admin/Logs/Settings.php:96 src/Module/Admin/Site.php:480
-#: src/Module/Admin/Site.php:488
+#: src/Module/Admin/Logs/Settings.php:96 src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:494
 msgid "<strong>Read-only</strong> because it is set by an environment variable"
 msgstr ""
 
@@ -4270,252 +4270,257 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/Module/Admin/Site.php:244
+#: src/Module/Admin/Site.php:245
+#, php-format
+msgid "%s is no valid input for maximum media size"
+msgstr ""
+
+#: src/Module/Admin/Site.php:250
 #, php-format
 msgid "%s is no valid input for maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:372 src/Module/Settings/Display.php:215
+#: src/Module/Admin/Site.php:378 src/Module/Settings/Display.php:215
 msgid "No special theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:389 src/Module/Settings/Display.php:225
+#: src/Module/Admin/Site.php:395 src/Module/Settings/Display.php:225
 #, php-format
 msgid "%s - (Experimental)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:401
+#: src/Module/Admin/Site.php:407
 msgid "No community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:402
+#: src/Module/Admin/Site.php:408
 msgid "No community page for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:403
+#: src/Module/Admin/Site.php:409
 msgid "Public postings from users of this site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:404
+#: src/Module/Admin/Site.php:410
 msgid "Public postings from the federated network"
 msgstr ""
 
-#: src/Module/Admin/Site.php:405
+#: src/Module/Admin/Site.php:411
 msgid "Public postings from local users and the federated network"
 msgstr ""
 
-#: src/Module/Admin/Site.php:411
+#: src/Module/Admin/Site.php:417
 msgid "Multi user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:434
+#: src/Module/Admin/Site.php:440
 msgid "Closed"
 msgstr ""
 
-#: src/Module/Admin/Site.php:435
+#: src/Module/Admin/Site.php:441
 msgid "Requires approval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:436
+#: src/Module/Admin/Site.php:442
 msgid "Open"
 msgstr ""
 
-#: src/Module/Admin/Site.php:440
+#: src/Module/Admin/Site.php:446
 msgid "Don't check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:441
+#: src/Module/Admin/Site.php:447
 msgid "check the stable version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:442
+#: src/Module/Admin/Site.php:448
 msgid "check the development version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:446
+#: src/Module/Admin/Site.php:452
 msgid "none"
 msgstr ""
 
-#: src/Module/Admin/Site.php:447
+#: src/Module/Admin/Site.php:453
 msgid "Local contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:448
+#: src/Module/Admin/Site.php:454
 msgid "Interactors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:458 src/Module/BaseAdmin.php:90
+#: src/Module/Admin/Site.php:464 src/Module/BaseAdmin.php:90
 msgid "Site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:459
+#: src/Module/Admin/Site.php:465
 msgid "General Information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:461
+#: src/Module/Admin/Site.php:467
 msgid "Republish users to directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:462 src/Module/Register.php:159
+#: src/Module/Admin/Site.php:468 src/Module/Register.php:159
 msgid "Registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:463
+#: src/Module/Admin/Site.php:469
 msgid "File upload"
 msgstr ""
 
-#: src/Module/Admin/Site.php:464
+#: src/Module/Admin/Site.php:470
 msgid "Policies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:465 src/Module/Calendar/Event/Form.php:252
+#: src/Module/Admin/Site.php:471 src/Module/Calendar/Event/Form.php:252
 #: src/Module/Contact.php:553 src/Module/Profile/Profile.php:278
 msgid "Advanced"
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:472
 msgid "Auto Discovered Contact Directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:473
 msgid "Performance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:468
+#: src/Module/Admin/Site.php:474
 msgid "Worker"
 msgstr ""
 
-#: src/Module/Admin/Site.php:469
+#: src/Module/Admin/Site.php:475
 msgid "Message Relay"
 msgstr ""
 
-#: src/Module/Admin/Site.php:470
+#: src/Module/Admin/Site.php:476
 msgid "Use the command \"console relay\" in the command line to add or remove relays."
 msgstr ""
 
-#: src/Module/Admin/Site.php:471
+#: src/Module/Admin/Site.php:477
 msgid "The system is not subscribed to any relays at the moment."
 msgstr ""
 
-#: src/Module/Admin/Site.php:472
+#: src/Module/Admin/Site.php:478
 msgid "The system is currently subscribed to the following relays:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:475
+#: src/Module/Admin/Site.php:481
 msgid "Relocate Node"
 msgstr ""
 
-#: src/Module/Admin/Site.php:476
+#: src/Module/Admin/Site.php:482
 msgid "Relocating your node enables you to change the DNS domain of this node and keep all the existing users and posts. This process takes a while and can only be started from the relocate console command like this:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:477
+#: src/Module/Admin/Site.php:483
 msgid "(Friendica directory)# bin/console relocate https://newdomain.com"
 msgstr ""
 
-#: src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:486
 msgid "Site name"
 msgstr ""
 
-#: src/Module/Admin/Site.php:481
+#: src/Module/Admin/Site.php:487
 msgid "Sender Email"
 msgstr ""
 
-#: src/Module/Admin/Site.php:481
+#: src/Module/Admin/Site.php:487
 msgid "The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: src/Module/Admin/Site.php:482
+#: src/Module/Admin/Site.php:488
 msgid "Name of the system actor"
 msgstr ""
 
-#: src/Module/Admin/Site.php:482
+#: src/Module/Admin/Site.php:488
 msgid "Name of the internal system account that is used to perform ActivityPub requests. This must be an unused username. If set, this can't be changed again."
 msgstr ""
 
-#: src/Module/Admin/Site.php:483
+#: src/Module/Admin/Site.php:489
 msgid "Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Site.php:490
 msgid "Email Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:485
+#: src/Module/Admin/Site.php:491
 msgid "Shortcut icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:485
+#: src/Module/Admin/Site.php:491
 msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:492
 msgid "Touch icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:492
 msgid "Link to an icon that will be used for tablets and mobiles."
 msgstr ""
 
-#: src/Module/Admin/Site.php:487
+#: src/Module/Admin/Site.php:493
 msgid "Additional Info"
 msgstr ""
 
-#: src/Module/Admin/Site.php:487
+#: src/Module/Admin/Site.php:493
 #, php-format
 msgid "For public servers: you can add additional information here that will be listed at %s/servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:488
+#: src/Module/Admin/Site.php:494
 msgid "System language"
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:495
 msgid "System theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:495
 #, php-format
 msgid "Default system theme - may be over-ridden by user profiles - <a href=\"%s\" id=\"cnftheme\">Change default theme settings</a>"
 msgstr ""
 
-#: src/Module/Admin/Site.php:490
+#: src/Module/Admin/Site.php:496
 msgid "Mobile system theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:490
+#: src/Module/Admin/Site.php:496
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
+#: src/Module/Admin/Site.php:497
 msgid "Force SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
+#: src/Module/Admin/Site.php:497
 msgid "Force all Non-SSL requests to SSL - Attention: on some systems it could lead to endless loops."
 msgstr ""
 
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:498
 msgid "Show help entry from navigation menu"
 msgstr ""
 
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:498
 msgid "Displays the menu entry for the Help pages from the navigation menu. It is always accessible by calling /help directly."
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:499
 msgid "Single user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:499
 msgid "Make this instance multi-user or single-user for the named user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:501
 msgid "Maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:501
 #, php-format
 msgid ""
 "Maximum size in bytes of uploaded images. Default is 0, which means no limits. You can put k, m, or g behind the desired value for KiB, MiB, GiB, respectively.\n"
@@ -4523,762 +4528,774 @@ msgid ""
 "\t\t\t\t\t\t\t\t\t\t\t\t\tCurrently <code>upload_max_filesize</code> is set to %s (%s byte)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:499
+#: src/Module/Admin/Site.php:505
 msgid "Maximum image length"
 msgstr ""
 
-#: src/Module/Admin/Site.php:499
+#: src/Module/Admin/Site.php:505
 msgid "Maximum length in pixels of the longest side of uploaded images. Default is -1, which means no limits."
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:506
 msgid "JPEG image quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:506
 msgid "Uploaded JPEGS will be saved at this quality setting [0-100]. Default is 100, which is full quality."
 msgstr ""
 
-#: src/Module/Admin/Site.php:502
+#: src/Module/Admin/Site.php:507
+msgid "Maximum media file size"
+msgstr ""
+
+#: src/Module/Admin/Site.php:507
+#, php-format
+msgid ""
+"Maximum size in bytes of uploaded media files. Default is 0, which means no limits. You can put k, m, or g behind the desired value for KiB, MiB, GiB, respectively.\n"
+"\t\t\t\t\t\t\t\t\t\t\t\t\tThe value of <code>upload_max_filesize</code> in your <code>PHP.ini</code> needs be set to at least the desired limit.\n"
+"\t\t\t\t\t\t\t\t\t\t\t\t\tCurrently <code>upload_max_filesize</code> is set to %s (%s byte)"
+msgstr ""
+
+#: src/Module/Admin/Site.php:512
 msgid "Register policy"
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:513
 msgid "Maximum Users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:513
 msgid "If defined, the register policy is automatically closed when the given number of users is reached and reopens the registry when the number drops below the limit. It only works when the policy is set to open or close, but not when the policy is set to approval."
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:514
 msgid "Maximum Daily Registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:514
 msgid "If registration is permitted above, this sets the maximum number of new user registrations to accept per day.  If register is set to closed, this setting has no effect."
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:515
 msgid "Register text"
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:515
 msgid "Will be displayed prominently on the registration page. You can use BBCode here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:516
 msgid "Forbidden Nicknames"
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:516
 msgid "Comma separated list of nicknames that are forbidden from registration. Preset is a list of role names according RFC 2142."
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:517
 msgid "Accounts abandoned after x days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:517
 msgid "Will not waste system resources polling external sites for abandonded accounts. Enter 0 for no time limit."
 msgstr ""
 
-#: src/Module/Admin/Site.php:508
+#: src/Module/Admin/Site.php:518
 msgid "Allowed friend domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:508
+#: src/Module/Admin/Site.php:518
 msgid "Comma separated list of domains which are allowed to establish friendships with this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:509
+#: src/Module/Admin/Site.php:519
 msgid "Allowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:509
+#: src/Module/Admin/Site.php:519
 msgid "Comma separated list of domains which are allowed in email addresses for registrations to this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:520
 msgid "Disallowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:520
 msgid "Comma separated list of domains which are rejected as email addresses for registrations to this site. Wildcards are accepted."
 msgstr ""
 
-#: src/Module/Admin/Site.php:511
+#: src/Module/Admin/Site.php:521
 msgid "No OEmbed rich content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:511
+#: src/Module/Admin/Site.php:521
 msgid "Don't show the rich content (e.g. embedded PDF), except from the domains listed below."
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:522
 msgid "Trusted third-party domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:522
 msgid "Comma separated list of domains from which content is allowed to be embedded in posts like with OEmbed. All sub-domains of the listed domains are allowed as well."
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:523
 msgid "Block public"
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:523
 msgid "Check to block public access to all otherwise public personal pages on this site unless you are currently logged in."
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:524
 msgid "Force publish"
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:524
 msgid "Check to force all profiles on this site to be listed in the site directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:524
 msgid "Enabling this may violate privacy laws like the GDPR"
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:525
 msgid "Global directory URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:525
 msgid "URL to the global directory. If this is not set, the global directory is completely unavailable to the application."
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:526
 msgid "Private posts by default for new users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:526
 msgid "Set default post permissions for all new members to the default privacy circle rather than public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:517
+#: src/Module/Admin/Site.php:527
 msgid "Don't include post content in email notifications"
 msgstr ""
 
-#: src/Module/Admin/Site.php:517
+#: src/Module/Admin/Site.php:527
 msgid "Don't include the content of a post/comment/private message/etc. in the email notifications that are sent out from this site, as a privacy measure."
 msgstr ""
 
-#: src/Module/Admin/Site.php:518
+#: src/Module/Admin/Site.php:528
 msgid "Disallow public access to addons listed in the apps menu."
 msgstr ""
 
-#: src/Module/Admin/Site.php:518
+#: src/Module/Admin/Site.php:528
 msgid "Checking this box will restrict addons listed in the apps menu to members only."
 msgstr ""
 
-#: src/Module/Admin/Site.php:519
+#: src/Module/Admin/Site.php:529
 msgid "Don't embed private images in posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:519
+#: src/Module/Admin/Site.php:529
 msgid "Don't replace locally-hosted private photos in posts with an embedded copy of the image. This means that contacts who receive posts containing private photos will have to authenticate and load each image, which may take a while."
 msgstr ""
 
-#: src/Module/Admin/Site.php:520
+#: src/Module/Admin/Site.php:530
 msgid "Explicit Content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:520
+#: src/Module/Admin/Site.php:530
 msgid "Set this to announce that your node is used mostly for explicit content that might not be suited for minors. This information will be published in the node information and might be used, e.g. by the global directory, to filter your node from listings of nodes to join. Additionally a note about this will be shown at the user registration page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:521
+#: src/Module/Admin/Site.php:531
 msgid "Only local search"
 msgstr ""
 
-#: src/Module/Admin/Site.php:521
+#: src/Module/Admin/Site.php:531
 msgid "Blocks search for users who are not logged in to prevent crawlers from blocking your system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:522
+#: src/Module/Admin/Site.php:532
 msgid "Blocked tags for trending tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:522
+#: src/Module/Admin/Site.php:532
 msgid "Comma separated list of hashtags that shouldn't be displayed in the trending tags."
 msgstr ""
 
-#: src/Module/Admin/Site.php:523
+#: src/Module/Admin/Site.php:533
 msgid "Cache contact avatars"
 msgstr ""
 
-#: src/Module/Admin/Site.php:523
+#: src/Module/Admin/Site.php:533
 msgid "Locally store the avatar pictures of the contacts. This uses a lot of storage space but it increases the performance."
 msgstr ""
 
-#: src/Module/Admin/Site.php:524
+#: src/Module/Admin/Site.php:534
 msgid "Allow Users to set remote_self"
 msgstr ""
 
-#: src/Module/Admin/Site.php:524
+#: src/Module/Admin/Site.php:534
 msgid "With checking this, every user is allowed to mark every contact as a remote_self in the repair contact dialog. Setting this flag on a contact causes mirroring every posting of that contact in the users stream."
 msgstr ""
 
-#: src/Module/Admin/Site.php:525
+#: src/Module/Admin/Site.php:535
 msgid "Allow Users to set up relay channels"
 msgstr ""
 
-#: src/Module/Admin/Site.php:525
+#: src/Module/Admin/Site.php:535
 msgid "If enabled, it is possible to create relay users that are used to reshare content based on user defined channels."
 msgstr ""
 
-#: src/Module/Admin/Site.php:526
+#: src/Module/Admin/Site.php:536
 msgid "Adjust the feed poll frequency"
 msgstr ""
 
-#: src/Module/Admin/Site.php:526
+#: src/Module/Admin/Site.php:536
 msgid "Automatically detect and set the best feed poll frequency."
 msgstr ""
 
-#: src/Module/Admin/Site.php:527
+#: src/Module/Admin/Site.php:537
 msgid "Minimum poll interval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:527
+#: src/Module/Admin/Site.php:537
 msgid "Minimal distance in minutes between two polls for mail and feed contacts. Reasonable values are between 1 and 59."
 msgstr ""
 
-#: src/Module/Admin/Site.php:528
+#: src/Module/Admin/Site.php:538
 msgid "Enable multiple registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:528
+#: src/Module/Admin/Site.php:538
 msgid "Enable users to register additional accounts for use as pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:529
+#: src/Module/Admin/Site.php:539
 msgid "Enable OpenID"
 msgstr ""
 
-#: src/Module/Admin/Site.php:529
+#: src/Module/Admin/Site.php:539
 msgid "Enable OpenID support for registration and logins."
 msgstr ""
 
-#: src/Module/Admin/Site.php:530
+#: src/Module/Admin/Site.php:540
 msgid "Enable full name check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:530
+#: src/Module/Admin/Site.php:540
 msgid "Prevents users from registering with a display name with fewer than two parts separated by spaces."
 msgstr ""
 
-#: src/Module/Admin/Site.php:531
+#: src/Module/Admin/Site.php:541
 msgid "Email administrators on new registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:531
+#: src/Module/Admin/Site.php:541
 msgid "If enabled and the system is set to an open registration, an email for each new registration is sent to the administrators."
 msgstr ""
 
-#: src/Module/Admin/Site.php:532
+#: src/Module/Admin/Site.php:542
 msgid "Community pages for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:532
+#: src/Module/Admin/Site.php:542
 msgid "Which community pages should be available for visitors. Local users always see both pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:533
+#: src/Module/Admin/Site.php:543
 msgid "Posts per user on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:533
+#: src/Module/Admin/Site.php:543
 msgid "The maximum number of posts per user on the local community page. This is useful, when a single user floods the local community page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:534
+#: src/Module/Admin/Site.php:544
 msgid "Posts per server on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:534
+#: src/Module/Admin/Site.php:544
 msgid "The maximum number of posts per server on the global community page. This is useful, when posts from a single server flood the global community page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:536
+#: src/Module/Admin/Site.php:546
 msgid "Enable Mail support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:536
+#: src/Module/Admin/Site.php:546
 msgid "Enable built-in mail support to poll IMAP folders and to reply via mail."
 msgstr ""
 
-#: src/Module/Admin/Site.php:537
+#: src/Module/Admin/Site.php:547
 msgid "Mail support can't be enabled because the PHP IMAP module is not installed."
 msgstr ""
 
-#: src/Module/Admin/Site.php:538
+#: src/Module/Admin/Site.php:548
 msgid "Enable OStatus support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:538
+#: src/Module/Admin/Site.php:548
 msgid "Enable built-in OStatus (StatusNet, GNU Social etc.) compatibility. All communications in OStatus are public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:540
+#: src/Module/Admin/Site.php:550
 msgid "Diaspora support can't be enabled because Friendica was installed into a sub directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:541
+#: src/Module/Admin/Site.php:551
 msgid "Enable Diaspora support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:541
+#: src/Module/Admin/Site.php:551
 msgid "Enable built-in Diaspora network compatibility for communicating with diaspora servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:552
 msgid "Verify SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:552
 msgid "If you wish, you can turn on strict certificate checking. This will mean you cannot connect (at all) to self-signed SSL sites."
 msgstr ""
 
-#: src/Module/Admin/Site.php:543
+#: src/Module/Admin/Site.php:553
 msgid "Proxy user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:543
+#: src/Module/Admin/Site.php:553
 msgid "User name for the proxy server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:544
+#: src/Module/Admin/Site.php:554
 msgid "Proxy URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:544
+#: src/Module/Admin/Site.php:554
 msgid "If you want to use a proxy server that Friendica should use to connect to the network, put the URL of the proxy here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:555
 msgid "Network timeout"
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:555
 msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:546
+#: src/Module/Admin/Site.php:556
 msgid "Maximum Load Average"
 msgstr ""
 
-#: src/Module/Admin/Site.php:546
+#: src/Module/Admin/Site.php:556
 #, php-format
 msgid "Maximum system load before delivery and poll processes are deferred - default %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:547
+#: src/Module/Admin/Site.php:557
 msgid "Minimal Memory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:547
+#: src/Module/Admin/Site.php:557
 msgid "Minimal free memory in MB for the worker. Needs access to /proc/meminfo - default 0 (deactivated)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:548
+#: src/Module/Admin/Site.php:558
 msgid "Periodically optimize tables"
 msgstr ""
 
-#: src/Module/Admin/Site.php:548
+#: src/Module/Admin/Site.php:558
 msgid "Periodically optimize tables like the cache and the workerqueue"
 msgstr ""
 
-#: src/Module/Admin/Site.php:550
+#: src/Module/Admin/Site.php:560
 msgid "Discover followers/followings from contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:550
+#: src/Module/Admin/Site.php:560
 msgid "If enabled, contacts are checked for their followers and following contacts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:551
+#: src/Module/Admin/Site.php:561
 msgid "None - deactivated"
 msgstr ""
 
-#: src/Module/Admin/Site.php:552
+#: src/Module/Admin/Site.php:562
 msgid "Local contacts - contacts of our local contacts are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:553
+#: src/Module/Admin/Site.php:563
 msgid "Interactors - contacts of our local contacts and contacts who interacted on locally visible postings are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:555
+#: src/Module/Admin/Site.php:565
 msgid "Only update contacts/servers with local data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:555
+#: src/Module/Admin/Site.php:565
 msgid "If enabled, the system will only look for changes in contacts and servers that engaged on this system by either being in a contact list of a user or when posts or comments exists from the contact on this system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:556
+#: src/Module/Admin/Site.php:566
 msgid "Synchronize the contacts with the directory server"
 msgstr ""
 
-#: src/Module/Admin/Site.php:556
+#: src/Module/Admin/Site.php:566
 msgid "if enabled, the system will check periodically for new contacts on the defined directory server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:558
+#: src/Module/Admin/Site.php:568
 msgid "Discover contacts from other servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:558
+#: src/Module/Admin/Site.php:568
 msgid "Periodically query other servers for contacts and servers that they know of. The system queries Friendica, Mastodon and Hubzilla servers. Keep it deactivated on small machines to decrease the database size and load."
 msgstr ""
 
-#: src/Module/Admin/Site.php:559
+#: src/Module/Admin/Site.php:569
 msgid "Days between requery"
 msgstr ""
 
-#: src/Module/Admin/Site.php:559
+#: src/Module/Admin/Site.php:569
 msgid "Number of days after which a server is requeried for their contacts and servers it knows of. This is only used when the discovery is activated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:560
+#: src/Module/Admin/Site.php:570
 msgid "Search the local directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:560
+#: src/Module/Admin/Site.php:570
 msgid "Search the local directory instead of the global directory. When searching locally, every search will be executed on the global directory in the background. This improves the search results when the search is repeated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:562
+#: src/Module/Admin/Site.php:572
 msgid "Publish server information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:562
+#: src/Module/Admin/Site.php:572
 msgid "If enabled, general server and usage data will be published. The data contains the name and version of the server, number of users with public profiles, number of posts and the activated protocols and connectors. See <a href=\"http://the-federation.info/\">the-federation.info</a> for details."
 msgstr ""
 
-#: src/Module/Admin/Site.php:564
+#: src/Module/Admin/Site.php:574
 msgid "Check upstream version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:564
+#: src/Module/Admin/Site.php:574
 msgid "Enables checking for new Friendica versions at github. If there is a new version, you will be informed in the admin panel overview."
 msgstr ""
 
-#: src/Module/Admin/Site.php:565
+#: src/Module/Admin/Site.php:575
 msgid "Suppress Tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:565
+#: src/Module/Admin/Site.php:575
 msgid "Suppress showing a list of hashtags at the end of the posting."
 msgstr ""
 
-#: src/Module/Admin/Site.php:566
+#: src/Module/Admin/Site.php:576
 msgid "Clean database"
 msgstr ""
 
-#: src/Module/Admin/Site.php:566
+#: src/Module/Admin/Site.php:576
 msgid "Remove old remote items, orphaned database records and old content from some other helper tables."
 msgstr ""
 
-#: src/Module/Admin/Site.php:567
+#: src/Module/Admin/Site.php:577
 msgid "Lifespan of remote items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:567
+#: src/Module/Admin/Site.php:577
 msgid "When the database cleanup is enabled, this defines the days after which remote items will be deleted. Own items, and marked or filed items are always kept. 0 disables this behaviour."
 msgstr ""
 
-#: src/Module/Admin/Site.php:568
+#: src/Module/Admin/Site.php:578
 msgid "Lifespan of unclaimed items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:568
+#: src/Module/Admin/Site.php:578
 msgid "When the database cleanup is enabled, this defines the days after which unclaimed remote items (mostly content from the relay) will be deleted. Default value is 90 days. Defaults to the general lifespan value of remote items if set to 0."
 msgstr ""
 
-#: src/Module/Admin/Site.php:569
+#: src/Module/Admin/Site.php:579
 msgid "Lifespan of raw conversation data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:569
+#: src/Module/Admin/Site.php:579
 msgid "The conversation data is used for ActivityPub and OStatus, as well as for debug purposes. It should be safe to remove it after 14 days, default is 90 days."
 msgstr ""
 
-#: src/Module/Admin/Site.php:570
+#: src/Module/Admin/Site.php:580
 msgid "Maximum numbers of comments per post"
 msgstr ""
 
-#: src/Module/Admin/Site.php:570
+#: src/Module/Admin/Site.php:580
 msgid "How much comments should be shown for each post? Default value is 100."
 msgstr ""
 
-#: src/Module/Admin/Site.php:571
+#: src/Module/Admin/Site.php:581
 msgid "Maximum numbers of comments per post on the display page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:571
+#: src/Module/Admin/Site.php:581
 msgid "How many comments should be shown on the single view for each post? Default value is 1000."
 msgstr ""
 
-#: src/Module/Admin/Site.php:572
+#: src/Module/Admin/Site.php:582
 msgid "Items per page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:572
+#: src/Module/Admin/Site.php:582
 msgid "Number of items per page in stream pages (network, community, profile/contact statuses, search)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:573
+#: src/Module/Admin/Site.php:583
 msgid "Items per page for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:573
+#: src/Module/Admin/Site.php:583
 msgid "Number of items per page in stream pages (network, community, profile/contact statuses, search) for mobile devices."
 msgstr ""
 
-#: src/Module/Admin/Site.php:574
+#: src/Module/Admin/Site.php:584
 msgid "Temp path"
 msgstr ""
 
-#: src/Module/Admin/Site.php:574
+#: src/Module/Admin/Site.php:584
 msgid "If you have a restricted system where the webserver can't access the system temp path, enter another path here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:575
+#: src/Module/Admin/Site.php:585
 msgid "Only search in tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:575
+#: src/Module/Admin/Site.php:585
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: src/Module/Admin/Site.php:576
+#: src/Module/Admin/Site.php:586
 msgid "Limited search scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:576
+#: src/Module/Admin/Site.php:586
 msgid "If enabled, searches will only be performed in the data used for the channels and not in all posts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:577
+#: src/Module/Admin/Site.php:587
 msgid "Maximum age of items in the search table"
 msgstr ""
 
-#: src/Module/Admin/Site.php:577
+#: src/Module/Admin/Site.php:587
 msgid "Maximum age of items in the search table in days. Lower values will increase the performance and reduce disk usage. 0 means no age restriction."
 msgstr ""
 
-#: src/Module/Admin/Site.php:578
+#: src/Module/Admin/Site.php:588
 msgid "Generate counts per contact circle when calculating network count"
 msgstr ""
 
-#: src/Module/Admin/Site.php:578
+#: src/Module/Admin/Site.php:588
 msgid "On systems with users that heavily use contact circles the query can be very expensive."
 msgstr ""
 
-#: src/Module/Admin/Site.php:579
+#: src/Module/Admin/Site.php:589
 msgid "Process \"view\" activities"
 msgstr ""
 
-#: src/Module/Admin/Site.php:579
+#: src/Module/Admin/Site.php:589
 msgid "\"view\" activities are mostly geberated by Peertube systems. Per default they are not processed for performance reasons. Only activate this option on performant system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:580
+#: src/Module/Admin/Site.php:590
 msgid "Days, after which a contact is archived"
 msgstr ""
 
-#: src/Module/Admin/Site.php:580
+#: src/Module/Admin/Site.php:590
 msgid "Number of days that we try to deliver content or to update the contact data before we archive a contact."
 msgstr ""
 
-#: src/Module/Admin/Site.php:582
+#: src/Module/Admin/Site.php:592
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:582
+#: src/Module/Admin/Site.php:592
 #, php-format
 msgid "On shared hosters set this to %d. On larger systems, values of %d are great. Default value is %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:583
+#: src/Module/Admin/Site.php:593
 msgid "Maximum load for workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:583
+#: src/Module/Admin/Site.php:593
 msgid "Maximum load that causes a cooldown before each worker function call."
 msgstr ""
 
-#: src/Module/Admin/Site.php:584
+#: src/Module/Admin/Site.php:594
 msgid "Enable fastlane"
 msgstr ""
 
-#: src/Module/Admin/Site.php:584
+#: src/Module/Admin/Site.php:594
 msgid "When enabed, the fastlane mechanism starts an additional worker if processes with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: src/Module/Admin/Site.php:585
+#: src/Module/Admin/Site.php:595
 msgid "Decoupled receiver"
 msgstr ""
 
-#: src/Module/Admin/Site.php:585
+#: src/Module/Admin/Site.php:595
 msgid "Decouple incoming ActivityPub posts by processing them in the background via a worker process. Only enable this on fast systems."
 msgstr ""
 
-#: src/Module/Admin/Site.php:586
+#: src/Module/Admin/Site.php:596
 msgid "Cron interval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:586
+#: src/Module/Admin/Site.php:596
 msgid "Minimal period in minutes between two calls of the \"Cron\" worker job."
 msgstr ""
 
-#: src/Module/Admin/Site.php:587
+#: src/Module/Admin/Site.php:597
 msgid "Worker defer limit"
 msgstr ""
 
-#: src/Module/Admin/Site.php:587
+#: src/Module/Admin/Site.php:597
 msgid "Per default the systems tries delivering for 15 times before dropping it."
 msgstr ""
 
-#: src/Module/Admin/Site.php:588
+#: src/Module/Admin/Site.php:598
 msgid "Worker fetch limit"
 msgstr ""
 
-#: src/Module/Admin/Site.php:588
+#: src/Module/Admin/Site.php:598
 msgid "Number of worker tasks that are fetched in a single query. Higher values should increase the performance, too high values will mostly likely decrease it. Only change it, when you know how to measure the performance of your system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:590
+#: src/Module/Admin/Site.php:600
 msgid "Direct relay transfer"
 msgstr ""
 
-#: src/Module/Admin/Site.php:590
+#: src/Module/Admin/Site.php:600
 msgid "Enables the direct transfer to other servers without using the relay servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:591
+#: src/Module/Admin/Site.php:601
 msgid "Relay scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:591
+#: src/Module/Admin/Site.php:601
 msgid "Can be \"all\" or \"tags\". \"all\" means that every public post should be received. \"tags\" means that only posts with selected tags should be received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:591 src/Module/Contact/Profile.php:328
+#: src/Module/Admin/Site.php:601 src/Module/Contact/Profile.php:328
 #: src/Module/Settings/TwoFactor/Index.php:146
 msgid "Disabled"
 msgstr ""
 
-#: src/Module/Admin/Site.php:591
+#: src/Module/Admin/Site.php:601
 msgid "all"
 msgstr ""
 
-#: src/Module/Admin/Site.php:591
+#: src/Module/Admin/Site.php:601
 msgid "tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:592
+#: src/Module/Admin/Site.php:602
 msgid "Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:592
+#: src/Module/Admin/Site.php:602
 msgid "Comma separated list of tags for the \"tags\" subscription."
 msgstr ""
 
-#: src/Module/Admin/Site.php:593
+#: src/Module/Admin/Site.php:603
 msgid "Deny Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:593
+#: src/Module/Admin/Site.php:603
 msgid "Comma separated list of tags that are rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:594
+#: src/Module/Admin/Site.php:604
 msgid "Maximum amount of tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:594
+#: src/Module/Admin/Site.php:604
 msgid "Maximum amount of tags in a post before it is rejected as spam. The post has to contain at least one link. Posts from subscribed accounts will not be rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:595
+#: src/Module/Admin/Site.php:605
 msgid "Allow user tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:595
+#: src/Module/Admin/Site.php:605
 msgid "If enabled, the tags from the saved searches will used for the \"tags\" subscription in addition to the \"relay_server_tags\"."
 msgstr ""
 
-#: src/Module/Admin/Site.php:596
+#: src/Module/Admin/Site.php:606
 msgid "Deny undetected languages"
 msgstr ""
 
-#: src/Module/Admin/Site.php:596
+#: src/Module/Admin/Site.php:606
 msgid "If enabled, posts with undetected languages will be rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:597
+#: src/Module/Admin/Site.php:607
 msgid "Language Quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:597
+#: src/Module/Admin/Site.php:607
 msgid "The minimum language quality that is required to accept the post."
 msgstr ""
 
-#: src/Module/Admin/Site.php:598
+#: src/Module/Admin/Site.php:608
 msgid "Number of languages for the language detection"
 msgstr ""
 
-#: src/Module/Admin/Site.php:598
+#: src/Module/Admin/Site.php:608
 msgid "The system detects a list of languages per post. Only if the desired languages are in the list, the message will be accepted. The higher the number, the more posts will be falsely detected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:600
+#: src/Module/Admin/Site.php:610
 msgid "Maximum age of channel"
 msgstr ""
 
-#: src/Module/Admin/Site.php:600
+#: src/Module/Admin/Site.php:610
 msgid "This defines the maximum age in hours of items that should be displayed in channels. This affects the channel performance."
 msgstr ""
 
-#: src/Module/Admin/Site.php:601
+#: src/Module/Admin/Site.php:611
 msgid "Maximum number of channel posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:601
+#: src/Module/Admin/Site.php:611
 msgid "For performance reasons, the channels use a dedicated table to store content. The higher the value the slower the channels."
 msgstr ""
 
-#: src/Module/Admin/Site.php:602
+#: src/Module/Admin/Site.php:612
 msgid "Interaction score days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:602
+#: src/Module/Admin/Site.php:612
 msgid "Number of days that are used to calculate the interaction score."
 msgstr ""
 
-#: src/Module/Admin/Site.php:603
+#: src/Module/Admin/Site.php:613
 msgid "Maximum number of posts per author"
 msgstr ""
 
-#: src/Module/Admin/Site.php:603
+#: src/Module/Admin/Site.php:613
 msgid "Maximum number of posts per page by author if the contact frequency is set to \"Display only few posts\". If there are more posts, then the post with the most interactions will be displayed."
 msgstr ""
 
-#: src/Module/Admin/Site.php:604
+#: src/Module/Admin/Site.php:614
 msgid "Sharer interaction days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:604
+#: src/Module/Admin/Site.php:614
 msgid "Number of days of the last interaction that are used to define which sharers are used for the \"sharers of sharers\" channel."
 msgstr ""
 
-#: src/Module/Admin/Site.php:607
+#: src/Module/Admin/Site.php:617
 msgid "Start Relocation"
 msgstr ""
 
@@ -6013,7 +6030,7 @@ msgid "Show all contacts"
 msgstr ""
 
 #: src/Module/Contact.php:358 src/Module/Contact.php:437
-#: src/Module/Moderation/BaseUsers.php:85
+#: src/Module/Moderation/BaseUsers.php:86
 msgid "Pending"
 msgstr ""
 
@@ -6022,7 +6039,7 @@ msgid "Only show pending contacts"
 msgstr ""
 
 #: src/Module/Contact.php:366 src/Module/Contact.php:440
-#: src/Module/Moderation/BaseUsers.php:93
+#: src/Module/Moderation/BaseUsers.php:94
 msgid "Blocked"
 msgstr ""
 
@@ -7409,74 +7426,74 @@ msgstr ""
 msgid "Image upload failed."
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:72
+#: src/Module/Moderation/BaseUsers.php:73
 msgid "List of all users"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:77
+#: src/Module/Moderation/BaseUsers.php:78
 msgid "Active"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:80
+#: src/Module/Moderation/BaseUsers.php:81
 msgid "List of active accounts"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:88
+#: src/Module/Moderation/BaseUsers.php:89
 msgid "List of pending registrations"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:96
+#: src/Module/Moderation/BaseUsers.php:97
 msgid "List of blocked users"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:101
+#: src/Module/Moderation/BaseUsers.php:102
 msgid "Deleted"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:104
+#: src/Module/Moderation/BaseUsers.php:105
 msgid "List of pending user deletions"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:119 src/Module/Settings/Account.php:487
+#: src/Module/Moderation/BaseUsers.php:122 src/Module/Settings/Account.php:487
 msgid "Normal Account Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:120 src/Module/Settings/Account.php:494
+#: src/Module/Moderation/BaseUsers.php:123 src/Module/Settings/Account.php:494
 msgid "Soapbox Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:121 src/Module/Settings/Account.php:501
+#: src/Module/Moderation/BaseUsers.php:124 src/Module/Settings/Account.php:501
 msgid "Public Group"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:122 src/Module/Settings/Account.php:508
+#: src/Module/Moderation/BaseUsers.php:125 src/Module/Settings/Account.php:508
 msgid "Public Group - Restricted"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:123 src/Module/Settings/Account.php:515
+#: src/Module/Moderation/BaseUsers.php:126 src/Module/Settings/Account.php:515
 msgid "Automatic Friend Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:124
+#: src/Module/Moderation/BaseUsers.php:127
 msgid "Private Group"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:127 src/Module/Moderation/Summary.php:53
+#: src/Module/Moderation/BaseUsers.php:130 src/Module/Moderation/Summary.php:53
 #: src/Module/Settings/Account.php:458
 msgid "Personal Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:128 src/Module/Moderation/Summary.php:54
+#: src/Module/Moderation/BaseUsers.php:131 src/Module/Moderation/Summary.php:54
 #: src/Module/Settings/Account.php:465
 msgid "Organisation Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:129 src/Module/Moderation/Summary.php:55
+#: src/Module/Moderation/BaseUsers.php:132 src/Module/Moderation/Summary.php:55
 #: src/Module/Settings/Account.php:472
 msgid "News Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:130 src/Module/Moderation/Summary.php:56
+#: src/Module/Moderation/BaseUsers.php:133 src/Module/Moderation/Summary.php:56
 #: src/Module/Settings/Account.php:479
 msgid "Community Group"
 msgstr ""

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -47,6 +47,7 @@
 		{{include file="field_input.tpl" field=$maximagesize}}
 		{{include file="field_input.tpl" field=$maximagelength}}
 		{{include file="field_input.tpl" field=$jpegimagequality}}
+		{{include file="field_input.tpl" field=$maxfilesize}}
 		<div class="submit"><input type="submit" name="page_site" value="{{$submit}}"/></div>
 
 		<h2>{{$corporate}}</h2>

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -106,6 +106,7 @@
 						{{include file="field_input.tpl" field=$maximagesize}}
 						{{include file="field_input.tpl" field=$maximagelength}}
 						{{include file="field_input.tpl" field=$jpegimagequality}}
+						{{include file="field_input.tpl" field=$maxfilesize}}
 					</div>
 					<div class="panel-footer">
 						<input type="submit" name="page_site" class="btn btn-primary" value="{{$submit}}"/>


### PR DESCRIPTION
It is not possible to delete attached media. This PR now introduces a new mechanism that deletes any attachment that isn't used in a post. Also there is now a dedicated value for the maximum media upload size.