### PR TITLE
Issue 14373: Avoid exception in BBCode parser

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -814,7 +814,7 @@ class BBCode
 
 				$content = preg_replace(Strings::autoLinkRegEx(), '<a href="$1">$1</a>', $match[3]);
 
-				return $match[1] . $callback($attributes, $author_contact, $content, trim($match[1]) != '');
+				return $match[1] . $callback($attributes, $author_contact, $content ?? '', trim($match[1]) != '');
 			},
 			$text
 		);


### PR DESCRIPTION
Fixes [#14373](https://github.com/friendica/friendica/issues/14373#issuecomment-2313198761)