### PR TITLE
AVoid throwing an error / store the size of pages

### DIFF
--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -193,7 +193,7 @@ class Media
 						$media['mimetype'] = $curlResult->getContentType() ?? '';
 					}
 					if (empty($media['size'])) {
-						$media['size'] = (int)($curlResult->getHeader('Content-Length')[0] ?? 0);
+						$media['size'] = (int)($curlResult->getHeader('Content-Length')[0] ?? strlen($curlResult->getBodyString() ?? ''));
 					}
 				} else {
 					Logger::notice('Could not fetch head', ['media' => $media]);
@@ -363,6 +363,7 @@ class Media
 	private static function addPage(array $media): array
 	{
 		$data = ParseUrl::getSiteinfoCached($media['url']);
+		$media['size'] = $data['size'] ?? null;
 		$media['preview'] = $data['images'][0]['src'] ?? null;
 		$media['preview-height'] = $data['images'][0]['height'] ?? null;
 		$media['preview-width'] = $data['images'][0]['width'] ?? null;

--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -61,11 +61,13 @@ class HttpClient implements ICanSendHttpRequests
 
 		$host = parse_url($url, PHP_URL_HOST);
 		if (empty($host)) {
-			throw new \InvalidArgumentException('Unable to retrieve the host in URL: ' . $url);
+			$this->logger->notice('Unable to retrieve the host in URL', ['url' => $url]);
+			$this->profiler->stopRecording();
+			return CurlResult::createErrorCurl($this->logger, $url);
 		}
 
 		if (!filter_var($host, FILTER_VALIDATE_IP) && !@dns_get_record($host . '.', DNS_A) && !@dns_get_record($host . '.', DNS_AAAA)) {
-			$this->logger->debug('URL cannot be resolved.', ['url' => $url]);
+			$this->logger->info('URL cannot be resolved.', ['url' => $url]);
 			$this->profiler->stopRecording();
 			return CurlResult::createErrorCurl($this->logger, $url);
 		}
@@ -75,7 +77,7 @@ class HttpClient implements ICanSendHttpRequests
 		}
 
 		if (strlen($url) > 1000) {
-			$this->logger->debug('URL is longer than 1000 characters.', ['url' => $url]);
+			$this->logger->info('URL is longer than 1000 characters.', ['url' => $url]);
 			$this->profiler->stopRecording();
 			return CurlResult::createErrorCurl($this->logger, substr($url, 0, 200));
 		}

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -245,6 +245,7 @@ class ParseUrl
 		}
 
 		$body = $curlResult->getBodyString();
+		$siteinfo['size'] = mb_strlen($body);
 
 		$charset = '';
 		try {


### PR DESCRIPTION
We now just exit with an error instead of throwing an error. Also we now store the size of HTML pages in the `post-media` table. Hopefully now really fixes https://github.com/friendica/friendica/issues/14307