### PR TITLE
Feeds: Check the content type before fetching feeds

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -1715,9 +1715,11 @@ class Probe
 		}
 
 		$feed = $curlResult->getBodyString();
-		$feed_data = Feed::import($feed);
+		if (strpos($curlResult->getContentType(), 'xml') !== false) {
+			$feed_data = Feed::import($feed);
+		}
 
-		if (!$feed_data) {
+		if (empty($feed_data)) {
 			if (!$probe) {
 				return [];
 			}

--- a/src/Worker/OnePoll.php
+++ b/src/Worker/OnePoll.php
@@ -188,6 +188,11 @@ class OnePoll
 			return false;
 		}
 
+		if (strpos($curlResult->getContentType(), 'xml') !== false) {
+			Logger::notice('Unexpected content type.', ['id' => $contact['id'], 'url' => $contact['poll'], 'content-type' => $curlResult->getContentType()]);
+			return false;
+		}
+
 		if (!strstr($xml, '<')) {
 			Logger::notice('response did not contain XML.', ['id' => $contact['id'], 'url' => $contact['poll']]);
 			return false;


### PR DESCRIPTION
We should only process feeds when the content type is correct.