### PR TITLE
Issue 14413: Ensure that the expiry is performed

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2881,10 +2881,10 @@ class Item
 		return $recipients;
 	}
 
-	public static function expire(int $uid, int $days, string $network = "", bool $force = false)
+	public static function expire(int $uid, int $days, string $network = "", bool $force = false): int
 	{
 		if (!$uid || ($days < 1)) {
-			return;
+			return 0;
 		}
 
 		$condition = [
@@ -2913,7 +2913,7 @@ class Item
 		$items = Post::select(['resource-id', 'starred', 'id', 'post-type', 'uid', 'uri-id'], $condition);
 
 		if (!DBA::isResult($items)) {
-			return;
+			return 0;
 		}
 
 		$expire_items = (bool)DI::pConfig()->get($uid, 'expire', 'items', true);
@@ -2955,6 +2955,7 @@ class Item
 		}
 		DBA::close($items);
 		Logger::notice('Expired', ['user' => $uid, 'days' => $days, 'network' => $network, 'force' => $force, 'expired' => $expired, 'expire items' => $expire_items, 'expire notes' => $expire_notes, 'expire starred' => $expire_starred, 'expire photos' => $expire_photos, 'condition' => $condition]);
+		return $expired;
 	}
 
 	public static function firstPostDate(int $uid, bool $wall = false)

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -107,11 +107,15 @@ class Cron
 
 			Worker::add(Worker::PRIORITY_LOW, 'ExpireSearchIndex');
 
+			Worker::add(Worker::PRIORITY_LOW, 'Expire');
+
 			Worker::add(Worker::PRIORITY_LOW, 'RemoveUnusedTags');
 
 			Worker::add(Worker::PRIORITY_LOW, 'RemoveUnusedContacts');
 
 			Worker::add(Worker::PRIORITY_LOW, 'RemoveUnusedAvatars');
+
+			Worker::add(Worker::PRIORITY_LOW, 'NodeInfo');
 
 			// check upstream version?
 			Worker::add(Worker::PRIORITY_LOW, 'CheckVersion');

--- a/src/Worker/Expire.php
+++ b/src/Worker/Expire.php
@@ -29,8 +29,8 @@ class Expire
 			$user = DBA::selectFirst('user', ['uid', 'username', 'expire'], ['uid' => $param]);
 			if (DBA::isResult($user)) {
 				Logger::info('Expire items', ['user' => $user['uid'], 'username' => $user['username'], 'interval' => $user['expire']]);
-				Item::expire($user['uid'], $user['expire']);
-				Logger::info('Expire items done', ['user' => $user['uid'], 'username' => $user['username'], 'interval' => $user['expire']]);
+				$expired = Item::expire($user['uid'], $user['expire']);
+				Logger::info('Expire items done', ['user' => $user['uid'], 'username' => $user['username'], 'interval' => $user['expire'], 'expired' => $expired]);
 			}
 			return;
 		} elseif ($param == 'hook' && !empty($hook_function)) {


### PR DESCRIPTION
Hopefully fixes #14413. It seems as if the "ExpirePosts" worker runs for a long time, so that it is killed at the end. Because of that the expiry of personal posts never happens.

The worker call has been moved to ensure this. The underlying problem with the performance of the "ExpirePosts" stays and has to be addressed in a future PR.