### PR TITLE
Remove custom emojis from contact names

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -245,6 +245,8 @@ class APContact
 			}
 		}
 
+		$apcontact['name'] = self::removeCustomEmojis($apcontact['name'], JsonLD::fetchElementArray($compacted, 'as:tag') ?? []);
+
 		$apcontact['photo'] = JsonLD::fetchElement($compacted, 'as:icon', '@id');
 		if (is_array($apcontact['photo']) || !empty($compacted['as:icon']['as:url']['@id'])) {
 			$apcontact['photo'] = JsonLD::fetchElement($compacted['as:icon'], 'as:url', '@id');
@@ -482,6 +484,19 @@ class APContact
 		Logger::info('Updated profile', ['url' => $url]);
 
 		return DBA::selectFirst('apcontact', [], ['url' => $apcontact['url']]) ?: [];
+	}
+
+	public static function removeCustomEmojis(string $name, array $tags): string
+	{
+		$original = $name;
+		foreach ($tags as $tag) {
+			if ($tag['@type'] != 'toot:Emoji') {
+				continue;
+			}
+			$name = trim(str_replace($tag['as:name'], '', $name));
+		}
+
+		return $name ?: $original;
 	}
 
 	/**


### PR DESCRIPTION
We don't parse custom emojis in contact names. Because of that and because of accessibility reasons - we now remove them. This is done during the contact refresh. So custom emoji texts will start to disappear over the next weeks.