### PR TITLE
Changed order of expiry commands

### DIFF
--- a/src/Core/Worker/Cron.php
+++ b/src/Core/Worker/Cron.php
@@ -67,7 +67,7 @@ class Cron
 		$entries = DBA::select(
 			'workerqueue',
 			['id', 'pid', 'executed', 'priority', 'command', 'parameter'],
-			['NOT `done` AND `pid` != 0'],
+			['NOT `done` AND `pid` != ? AND `executed` > ?', 0, DBA::NULL_DATETIME],
 			['order' => ['priority', 'retrial', 'created']]
 		);
 

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -16,6 +16,7 @@ use Friendica\Network\HTTPException\BadRequestException;
 use Friendica\Network\HTTPException\NotFoundException;
 use Friendica\Protocol\ActivityNamespace;
 use Friendica\Protocol\Salmon;
+use Friendica\Util\Network;
 use Friendica\Util\XML;
 
 /**
@@ -44,7 +45,7 @@ class Xrd extends BaseModule
 			$mode = self::getAcceptedContentType($_SERVER['HTTP_ACCEPT'] ?? '', Response::TYPE_XML);
 		}
 
-		if (substr($uri, 0, 4) === 'http') {
+		if (Network::isValidHttpUrl($uri)) {
 			$name = ltrim(basename($uri), '~');
 			$host = parse_url($uri, PHP_URL_HOST);
 		} else if (preg_match('/^[[:alpha:]][[:alnum:]+-.]+:/', $uri)) {

--- a/src/Worker/ExpirePosts.php
+++ b/src/Worker/ExpirePosts.php
@@ -41,9 +41,6 @@ class ExpirePosts
 		Logger::notice('Expire posts - Delete orphaned entries');
 		self::deleteOrphanedEntries();
 
-		Logger::notice('Expire posts - delete unused item-uri entries');
-		self::deleteUnusedItemUri();
-
 		Logger::notice('Expire posts - delete external posts');
 		self::deleteExpiredExternalPosts();
 
@@ -54,6 +51,9 @@ class ExpirePosts
 
 		Logger::notice('Expire posts - delete unused attachments');
 		self::deleteUnusedAttachments();
+
+		Logger::notice('Expire posts - delete unused item-uri entries');
+		self::deleteUnusedItemUri();
 
 		DBA::releaseOptimizeLock();
 		Logger::notice('Expire posts - done');


### PR DESCRIPTION
It seems as if the expiry is often killed before finishing its work. Because of that the order of deleting content is now changed. This doesn't solve the whole problem, but at least now post data should be deleted more reiiably. Also a bug is fixed where the system accidentally deleted worker tasks.