### PR TITLE
Fix counter for emoji reactions

### DIFF
--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -1018,18 +1018,18 @@ class Conversation
 		}
 
 		// @todo The following code should be removed, once that we display activity authors on demand 
-		$activity_emoji = [
-			Activity::LIKE        => '👍',
-			Activity::DISLIKE     => '👎',
-			Activity::ATTEND      => '✔️',
-			Activity::ATTENDMAYBE => '❓',
-			Activity::ATTENDNO    => '❌',
-			Activity::ANNOUNCE    => '♻',
-			Activity::VIEW        => '📺',
-			Activity::READ        => '📖',
+		$activity_verbs = [
+			Activity::LIKE,
+			Activity::DISLIKE,
+			Activity::ATTEND,
+			Activity::ATTENDMAYBE,
+			Activity::ATTENDNO,
+			Activity::ANNOUNCE,
+			Activity::VIEW,
+			Activity::READ,
 		];
 
-		$verbs     = array_merge(array_keys($activity_emoji), [Activity::EMOJIREACT, Activity::POST]);
+		$verbs     = array_merge($activity_verbs, [Activity::EMOJIREACT, Activity::POST]);
 		$condition = DBA::mergeConditions(['parent-uri-id' => $uriids, 'gravity' => [ItemModel::GRAVITY_ACTIVITY, ItemModel::GRAVITY_COMMENT], 'verb' => $verbs], ["NOT `deleted`"]);
 		$separator = chr(255) . chr(255) . chr(255);
 
@@ -1038,7 +1038,7 @@ class Conversation
 		$rows = DBA::p($sql, $condition);
 		while ($row = DBA::fetch($rows)) {
 			if ($row['gravity'] == ItemModel::GRAVITY_ACTIVITY) {
-				$emoji = $row['body'] ?: $activity_emoji[$row['verb']];
+				$emoji = $row['body'] ?: $row['verb'];
 			} else {
 				$emoji = '';
 			}

--- a/src/Model/Post/Counts.php
+++ b/src/Model/Post/Counts.php
@@ -82,18 +82,18 @@ class Counts
 	{
 		$counts = [];
 
-		$activity_emoji = [
-			Activity::LIKE        => '👍',
-			Activity::DISLIKE     => '👎',
-			Activity::ATTEND      => '✔️',
-			Activity::ATTENDMAYBE => '❓',
-			Activity::ATTENDNO    => '❌',
-			Activity::ANNOUNCE    => '♻',
-			Activity::VIEW        => '📺',
-			Activity::READ        => '📖',
+		$activity_verbs = [
+			Activity::LIKE,
+			Activity::DISLIKE,
+			Activity::ATTEND,
+			Activity::ATTENDMAYBE,
+			Activity::ATTENDNO,
+			Activity::ANNOUNCE,
+			Activity::VIEW,
+			Activity::READ,
 		];
 
-		$verbs = array_merge(array_keys($activity_emoji), [Activity::EMOJIREACT, Activity::POST]);
+		$verbs = array_merge($activity_verbs, [Activity::EMOJIREACT, Activity::POST]);
 
 		$condition  = DBA::mergeConditions($condition, ['verb' => $verbs]);
 		$countquery = DBA::select('post-counts-view', [], $condition);
@@ -101,8 +101,8 @@ class Counts
 			if (!empty($count['reaction'])) {
 				$count['verb'] = Activity::EMOJIREACT;
 				$count['vid']  = Verb::getID($count['verb']);
-			} elseif (!empty($activity_emoji[$count['verb']])) {
-				$count['reaction'] = $activity_emoji[$count['verb']];
+			} elseif (in_array($count['verb'], $activity_verbs)) {
+				$count['reaction'] = $count['verb'];
 			}
 			$counts[] = $count;
 		}


### PR DESCRIPTION
It happened from time to time that likes weren't counted correctly. This happened when someone used "👍" as an emoji reaction.