### PR TITLE
Fix linefeeds in "detected languages" popup

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2319,12 +2319,12 @@ class Item
 			}
 
 			if ($native != $language) {
-				$used_languages .= DI::l10n()->t('%s (%s - %s): %s', $native, $language, $code, number_format($reliability, 5)) . '\n';
+				$used_languages .= DI::l10n()->t('%s (%s - %s): %s', $native, $language, $code, number_format($reliability, 5)) . "\n";
 			} else {
-				$used_languages .= DI::l10n()->t('%s (%s): %s', $native, $code, number_format($reliability, 5)) . '\n';
+				$used_languages .= DI::l10n()->t('%s (%s): %s', $native, $code, number_format($reliability, 5)) . "\n";
 			}
 		}
-		$used_languages = DI::l10n()->t('Detected languages in this post:\n%s', $used_languages);
+		$used_languages = DI::l10n()->t("Detected languages in this post:\n%s", $used_languages);
 		return $used_languages;
 	}
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2024.09-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-03 12:14+0200\n"
+"POT-Creation-Date: 2024-10-07 20:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3382,7 +3382,9 @@ msgstr ""
 
 #: src/Model/Item.php:2327
 #, php-format
-msgid "Detected languages in this post:\\n%s"
+msgid ""
+"Detected languages in this post:\n"
+"%s"
 msgstr ""
 
 #: src/Model/Item.php:3276


### PR DESCRIPTION
The popup that displays the detected languages of a post had the problem, that it displayed `\n` instead of a line break. This is now fixed.