### PR TITLE
Fix for the string truncation for "latin1" charset

### DIFF
--- a/src/Database/Definition/DbaDefinition.php
+++ b/src/Database/Definition/DbaDefinition.php
@@ -8,7 +8,9 @@
 namespace Friendica\Database\Definition;
 
 use Exception;
+use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Hook;
+use Friendica\DI;
 
 /**
  * Stores the whole database definition
@@ -65,12 +67,18 @@ class DbaDefinition
 
 		$fields = [];
 
+		$charset = DI::config()->get('database', 'charset') ?? '';
+
 		// Assign all field that are present in the table
 		foreach ($fieldNames as $field) {
 			if (isset($data[$field])) {
 				// Limit the length of varchar, varbinary, char and binary fields
 				if (is_string($data[$field]) && preg_match("/char\((\d*)\)/", $definition[$table]['fields'][$field]['type'], $result)) {
-					$data[$field] = mb_substr($data[$field], 0, $result[1]);
+					if ($charset == 'latin1') {
+						$data[$field] = substr($data[$field], 0, $result[1]);
+					} else {
+						$data[$field] = mb_substr($data[$field], 0, $result[1]);
+					}
 				} elseif (is_string($data[$field]) && preg_match("/binary\((\d*)\)/", $definition[$table]['fields'][$field]['type'], $result)) {
 					$data[$field] = substr($data[$field], 0, $result[1]);
 				} elseif (is_numeric($data[$field]) && $definition[$table]['fields'][$field]['type'] === 'int') {


### PR DESCRIPTION
Nowadays most databases are set up with "utf8mb4". But especially older databases can be set up with "latin1" instead. There we have to truncate the fields in a different way to avoid database errors.