### PR TITLE
Fix Apache instructions and PHP extension list

### DIFF
--- a/doc/Install.md
+++ b/doc/Install.md
@@ -27,10 +27,10 @@ Due to the large variety of operating systems and PHP platforms in existence we 
 
 ### Requirements
 
-* Apache with mod-rewrite enabled and "Options All" so you can use a local `.htaccess` file
+* Apache with mod_rewrite enabled and "[AllowOverride All](https://httpd.apache.org/docs/2.4/mod/core.html#allowoverride)" so you can use a local `.htaccess` file
 * PHP 7.4+
   * PHP *command line* access with register_argc_argv set to true in the php.ini file
-  * Curl, GD, GMP, PDO, mbstrings, MySQLi, hash, xml, zip, IntlChar, IDN and OpenSSL extensions
+  * Curl, GD, GMP, PDO, mbstring, MySQLi, xml, zip, IntlChar, IDN and OpenSSL extensions
   * The POSIX module of PHP needs to be activated (e.g. [RHEL, CentOS](http://www.bigsoft.co.uk/blog/index.php/2014/12/08/posix-php-commands-not-working-under-centos-7) have disabled it)
   * Some form of email server or email gateway such that PHP mail() works.
     If you cannot set up your own email server, you can use the [phpmailer](https://github.com/friendica/friendica-addons/tree/develop/phpmailer) addon and use a remote SMTP server.


### PR DESCRIPTION
For the Apache instruction, the Options directive does exist, but it's not the one that controls .htaccess usage, that's AllowOverride.

For the PHP module, correct mbstrings to mbstring and remove hash, since the [hash extension][1] has been included in PHP since 5.1.2, and is core since PHP 7.4, both of which are above the minimum Friendica version.

[1]: https://www.php.net/manual/en/hash.installation.php