### PR TITLE
Add admin_info API endpoint

### DIFF
--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -49,7 +49,7 @@ class Update
 	 *
 	 * @return bool|null
 	 */
-	public static function hasUpdate(): ?bool
+	public static function needsUpdate(): ?bool
 	{
 		if (DI::config()->get('system', 'check_new_version_url', 'none') != 'none') {
 			if (version_compare(App::VERSION, static::getGitVersion()) < 0) {

--- a/src/Core/Update.php
+++ b/src/Core/Update.php
@@ -25,6 +25,44 @@ class Update
 	const NEW_TABLE_STRUCTURE_VERSION = 1288;
 
 	/**
+	 * Returns the status of the current update
+	 *
+	 * @return int
+	 */
+	public static function getStatus(): int
+	{
+		return (int)DI::config()->get('system', 'update') ?? static::SUCCESS;
+	}
+
+	/**
+	 * Returns the latest Version of the Friendica git repository and null, if this node doesn't check updates automatically
+	 *
+	 * @return string
+	 */
+	public static function getGitVersion(): ?string
+	{
+		return DI::keyValue()->get('git_friendica_version') ?? null;
+	}
+
+	/**
+	 * Returns true, if there's a new update and null if this node doesn't check updates automatically
+	 *
+	 * @return bool|null
+	 */
+	public static function hasUpdate(): ?bool
+	{
+		if (DI::config()->get('system', 'check_new_version_url', 'none') != 'none') {
+			if (version_compare(App::VERSION, static::getGitVersion()) < 0) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Function to check if the Database structure needs an update.
 	 *
 	 * @param string   $basePath   The base path of this application

--- a/src/Database/DBStructure.php
+++ b/src/Database/DBStructure.php
@@ -189,6 +189,16 @@ class DBStructure
 	}
 
 	/**
+	 * Returns the current status of the Update
+	 *
+	 * @return int
+	 */
+	public static function getUpdateStatus(): int
+	{
+		return (int)DI::config()->get('system', 'dbupdate') ?? static::UPDATE_NOT_CHECKED;
+	}
+
+	/**
 	 * Updates DB structure from the installation and returns eventual errors messages
 	 *
 	 * @return string Empty string if the update is successful, error messages otherwise

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -65,7 +65,7 @@ class Summary extends BaseAdmin
 
 		// Check if github.com/friendica/stable/VERSION is higher then
 		// the local version of Friendica. Check is opt-in, source may be stable or develop branch
-		if (Update::hasUpdate()) {
+		if (Update::needsUpdate()) {
 			$warningtext[] = DI::l10n()->t('There is a new version of Friendica available for download. Your current version is %1$s, upstream version is %2$s', App::VERSION, Update::getGitVersion());
 		}
 

--- a/src/Module/Api/Friendica/Admin/Info.php
+++ b/src/Module/Api/Friendica/Admin/Info.php
@@ -47,13 +47,13 @@ class Info extends BaseApi
 		}
 
 		$adminInfo = [
-			'php'    => [
+			'php' => [
 				'version'             => phpversion(),
 				'upload_max_filesize' => ini_get('upload_max_filesize'),
 				'post_max_size'       => ini_get('post_max_size'),
 				'memory_limit'        => ini_get('memory_limit')
 			],
-			'mysql'  => [
+			'mysql' => [
 				'max_allowed_packet' => DBA::getVariable('max_allowed_packet'),
 			],
 			'worker' => [
@@ -64,7 +64,7 @@ class Info extends BaseApi
 			'update' => [
 				'dbupdate_status' => DBStructure::getUpdateStatus(),
 				'update_status'   => Update::getStatus(),
-				'has_update'      => Update::hasUpdate(),
+				'has_update'      => Update::needsUpdate(),
 				'git_version'     => Update::getGitVersion(),
 			]
 		];

--- a/src/Module/Api/Friendica/Admin/Info.php
+++ b/src/Module/Api/Friendica/Admin/Info.php
@@ -1,0 +1,75 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Module\Api\Friendica\Admin;
+
+use Friendica\App;
+use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Core\L10n;
+use Friendica\Core\Session\Model\UserSession;
+use Friendica\Core\Update;
+use Friendica\Core\Worker;
+use Friendica\Database\DBA;
+use Friendica\Database\DBStructure;
+use Friendica\Module\Api\ApiResponse;
+use Friendica\Module\BaseApi;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Returns information about the current node for administration purposes
+ * Like for alerting systems
+ *
+ * API endpoint: api/friendica/admin/info
+ */
+class Info extends BaseApi
+{
+	/** @var UserSession */
+	private $userSession;
+
+	public function __construct(UserSession $userSession, \Friendica\Factory\Api\Mastodon\Error $errorFactory, App $app, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	{
+		parent::__construct($errorFactory, $app, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+
+		$this->userSession = $userSession;
+	}
+
+	protected function rawContent(array $request = [])
+	{
+		$this->checkAllowedScope(self::SCOPE_READ);
+
+		if (!$this->userSession->isSiteAdmin()) {
+			$this->logAndJsonError(401, $this->errorFactory->Unauthorized());
+		}
+
+		$adminInfo = [
+			'php'    => [
+				'version'             => phpversion(),
+				'upload_max_filesize' => ini_get('upload_max_filesize'),
+				'post_max_size'       => ini_get('post_max_size'),
+				'memory_limit'        => ini_get('memory_limit')
+			],
+			'mysql'  => [
+				'max_allowed_packet' => DBA::getVariable('max_allowed_packet'),
+			],
+			'worker' => [
+				'last_call'   => Worker::getLastCall(),
+				'deffered'    => Worker::getDeferredMessagesCount(),
+				'workerqueue' => Worker::getWorkerQueueCount(),
+			],
+			'update' => [
+				'dbupdate_status' => DBStructure::getUpdateStatus(),
+				'update_status'   => Update::getStatus(),
+				'has_update'      => Update::hasUpdate(),
+				'git_version'     => Update::getGitVersion(),
+			]
+		];
+
+		$this->response->setType(ICanCreateResponses::TYPE_JSON, 'application/json; charset=utf-8');
+		$this->response->addContent(json_encode($adminInfo, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+	}
+}

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -65,6 +65,8 @@ $apiRoutes = [
 	'/friendships/show[.{extension:json|xml|rss|atom}]'            => [Module\Api\Twitter\Friendships\Show::class,         [R::GET         ]],
 
 	'/friendica' => [
+		'/admin/info'                                              => [Module\Api\Friendica\Admin\Info::class,             [R::GET         ]],
+
 		'/activity/{verb:attendmaybe|attendno|attendyes|dislike|like|unattendmaybe|unattendno|unattendyes|undislike|unlike}[.{extension:json|xml|rss|atom}]'
 			=> [Module\Api\Friendica\Activity::class, [        R::POST]],
 		'/statuses/{id:\d+}/dislike'                               => [Module\Api\Friendica\Statuses\Dislike::class,       [        R::POST]],


### PR DESCRIPTION
Hi all,

Since opensocial.at recently got some hickups and I didn't notice it fast enough (my queue grew up to 240.000 entries...), I'm planning to create a Prometheus exporter.

But the exporter needs relevant data to be useful, so I created a small admin API endpoint.

I tested it on my local node:
-) not logged in -> unauthorized
-) logged in as a user -> unauthorized
-) logged in as admin -> JSON result

i tested the summary as well (no regression so far and the recent worker call warning appears as well.