### PR TITLE
Don't show "(AP)" at platform names anymore

### DIFF
--- a/src/Content/ContactSelector.php
+++ b/src/Content/ContactSelector.php
@@ -155,15 +155,15 @@ class ContactSelector
 
 			if (!empty($platform)) {
 				$networkname = $platform;
-
-				if ($network == Protocol::ACTIVITYPUB) {
-					$networkname .= ' (AP)';
-				}
 			}
 		}
 
-		if (!empty($protocol) && ($protocol != $network)) {
+		if (!empty($protocol) && ($protocol != $network) && $network != Protocol::DFRN) {
 			$networkname = DI::l10n()->t('%s (via %s)', $networkname, self::networkToName($protocol));
+		} elseif (in_array($network, ['', $protocol]) && ($network == Protocol::DFRN)) {
+			$networkname .= ' (DFRN)';
+		} elseif (in_array($network, ['', $protocol]) && ($network == Protocol::DIASPORA) && ($platform != 'diaspora')) {
+			$networkname .= ' (Diaspora)';
 		}
 
 		return $networkname;


### PR DESCRIPTION
This "(AP)" had been introduced at a time when ActivityPub was really new, so that we could see, over which protocol a message had been transmitted.

This is now reversed, so that we display "(DFRN)" or "(Diaspora)" instead.