### PR TITLE
Improved cached context file

### DIFF
--- a/static/security-data-integrity-v1.jsonld
+++ b/static/security-data-integrity-v1.jsonld
@@ -35,23 +35,19 @@
     },
     "assertionMethod": {
       "@id": "https://w3id.org/security#assertionMethod",
-      "@type": "@id",
-      "@container": "@set"
+      "@type": "@id"
     },
     "authentication": {
       "@id": "https://w3id.org/security#authenticationMethod",
-      "@type": "@id",
-      "@container": "@set"
+      "@type": "@id"
     },
     "capabilityInvocation": {
       "@id": "https://w3id.org/security#capabilityInvocationMethod",
-      "@type": "@id",
-      "@container": "@set"
+      "@type": "@id"
     },
     "capabilityDelegation": {
       "@id": "https://w3id.org/security#capabilityDelegationMethod",
-      "@type": "@id",
-      "@container": "@set"
+      "@type": "@id"
     },
     "keyAgreement": {
       "@id": "https://w3id.org/security#keyAgreementMethod",


### PR DESCRIPTION
We cache the context files, so that we don't have to fetch them at the time of compacting the incoming JSON-LD content.

The cached context files are now harmonized ion the content with the ones that the Hubzilla project is using.