### PR TITLE
Add Prometheus exporter link to docs

### DIFF
--- a/doc/tools.md
+++ b/doc/tools.md
@@ -84,3 +84,9 @@ The following will compress */var/log/friendica* (assuming this is the location 
 To monitor the health status of your Friendica installation, you can use for example a tool like Zabbix. Please define 'stats_key' in your local.config.php in the 'system' section to be able to access the statistics page at /stats?key=your-defined-stats_key
 
 The statistics contain data about the worker performance, the last cron call, number of reports, inbound and outbound packets, posts and comments.
+
+### Prometheus
+
+To use [prometheus](https://prometheus.io) for gathering metrics, use the [Friendica exporter](https://git.friendi.ca/friendica/friendica-exporter).
+
+You can find the installation instructions here: https://git.friendi.ca/friendica/friendica-exporter#installation


### PR DESCRIPTION
I created a prometheus exporter for Friendica with a Grafana Dashboard example:
![image](https://github.com/user-attachments/assets/88953246-30eb-4b13-91e6-2304c60198a3)

I pushed the whole repository to http://git.friendi.ca/friendica/friendica-exporter 

Some of the `/stats` metrics are still not included, but the `serverinfo` go-type-file already contains the baseline for them. So it's "just" mapping the json-output onto a propper prometheus description. Everything else is prepared :-)