### PR TITLE
Prevent dead contacts from being revived

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1367,7 +1367,7 @@ class Contact
 				$personal_contact = DBA::selectFirst('contact', $fields, ["`nurl` = ? AND `uid` != 0", Strings::normaliseLink($url)]);
 			}
 
-			if (DBA::isResult($personal_contact)) {
+			if (DBA::isResult($personal_contact) && !Probe::isProbable($personal_contact['network'])) {
 				Logger::info('Take contact data from personal contact', ['url' => $url, 'update' => $update, 'contact' => $personal_contact]);
 				$data = $personal_contact;
 				$data['photo'] = $personal_contact['avatar'];


### PR DESCRIPTION
This fixes the issue that a dead contact appeared as vital in the case that there had been a user contact entry for that contact. This is fixed now.