### PR TITLE
Process deletions via ActivityPub

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1082,7 +1082,7 @@ class Contact
 	 */
 	public static function markForArchival(array $contact)
 	{
-		if ((!isset($contact['url']) || !isset($contact['uri-id'])) && !empty($contact['id'])) {
+		if ((!isset($contact['uri-id']) || !isset($contact['url']) || !isset($contact['archive']) || !isset($contact['self']) || !isset($contact['term-date'])) && !empty($contact['id'])) {
 			$fields = ['id', 'uri-id', 'url', 'archive', 'self', 'term-date'];
 			$contact = DBA::selectFirst('contact', $fields, ['id' => $contact['id']]);
 			if (!DBA::isResult($contact)) {

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1391,7 +1391,7 @@ class Transmitter
 			}
 		}
 
-		if (!$api_mode && !$item['origin']) {
+		if (!$api_mode && !$item['deleted'] && !$item['origin']) {
 			Logger::debug('Post is not ours and is not stored', ['id' => $item['id'], 'uri-id' => $item['uri-id']]);
 			return false;
 		}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -986,7 +986,7 @@ class DFRN
 			Logger::notice('Got exception', ['code' => $th->getCode(), 'message' => $th->getMessage()]);
 			return -25;
 		}
-		Item::incrementOutbound(Protocol::DFRN);
+
 		$xml = $postResult->getBodyString();
 
 		$curl_stat = $postResult->getReturnCode();
@@ -1017,6 +1017,7 @@ class DFRN
 
 		if (!empty($contact['gsid'])) {
 			GServer::setReachableById($contact['gsid'], Protocol::DFRN);
+			Item::incrementOutbound(Protocol::DFRN);
 		}
 
 		if (!empty($res->message)) {

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -2962,7 +2962,6 @@ class Diaspora
 				return 0;
 			}
 			$return_code = $postResult->getReturnCode();
-			Item::incrementOutbound(Protocol::DIASPORA);
 		} else {
 			Logger::notice('test_mode');
 			return 200;
@@ -2971,6 +2970,7 @@ class Diaspora
 		if (!empty($contact['gsid']) && (empty($return_code) || $postResult->isTimeout())) {
 			GServer::setFailureById($contact['gsid']);
 		} elseif (!empty($contact['gsid']) && ($return_code >= 200) && ($return_code <= 299)) {
+			Item::incrementOutbound(Protocol::DIASPORA);
 			GServer::setReachableById($contact['gsid'], Protocol::DIASPORA);
 		}
 

--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -297,7 +297,9 @@ class HTTPSignature
 
 		self::setInboxStatus($target, ($return_code >= 200) && ($return_code <= 299));
 
-		Item::incrementOutbound(Protocol::ACTIVITYPUB);
+		if (($return_code >= 200) && ($return_code <= 299)) {
+			Item::incrementOutbound(Protocol::ACTIVITYPUB);
+		}
 
 		return $postResult;
 	}

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -527,7 +527,7 @@ class Notifier
 				continue;
 			}
 
-			Logger::info('Delivery', ['batch' => $in_batch, 'target' => $post_uriid, 'uid' => $sender_uid, 'guid' => $target_item['guid'] ?? '', 'to' => $contact]);
+			Logger::info('Delivery', ['cmd' => $cmd, 'batch' => $in_batch, 'target' => $post_uriid, 'uid' => $sender_uid, 'guid' => $target_item['guid'] ?? '', 'to' => $contact]);
 
 			// Ensure that posts with our own protocol arrives before Diaspora posts arrive.
 			// Situation is that sometimes Friendica servers receive Friendica posts over the Diaspora protocol first.


### PR DESCRIPTION
This PR contains two related changes. We now only increase the outbound counter if a transmission had been successful, since otherwise retries count multiple times.

Also we now transmit deletions always via ActivityPub and not via DFRN anymore.