### PR TITLE
Fixes "foreach() argument must be of type array|object, string given"

### DIFF
--- a/src/Worker/UpdateServerDirectory.php
+++ b/src/Worker/UpdateServerDirectory.php
@@ -76,7 +76,7 @@ class UpdateServerDirectory
 		}
 
 		$accounts = json_decode($result, true);
-		if (empty($accounts)) {
+		if (!is_array($accounts)) {
 			Logger::info('No contacts', ['url' => $gserver['url']]);
 			return;
 		}


### PR DESCRIPTION
Fixes `E_WARNING: foreach() argument must be of type array|object, string given`