### PR TITLE
"Connector" added as parcel

### DIFF
--- a/src/Model/Conversation.php
+++ b/src/Model/Conversation.php
@@ -30,6 +30,7 @@ class Conversation
 	const PARCEL_ATOM03             = 15;
 	const PARCEL_OPML               = 16;
 	const PARCEL_TWITTER            = 67;
+	const PARCEL_CONNECTOR          = 68;
 	const PARCEL_UNKNOWN            = 255;
 
 	/**


### PR DESCRIPTION
Too better distinguish if a post originated from a connector, we now have got a constant for this that will be added to each imported post from Tumblr or Bluesky.