### PR TITLE
New option to disable SVG icons / Functionality added to Vier

### DIFF
--- a/src/Content/ContactSelector.php
+++ b/src/Content/ContactSelector.php
@@ -18,6 +18,7 @@ use Friendica\Util\Strings;
  */
 class ContactSelector
 {
+	const SVG_DISABLED    = -1;
 	const SVG_COLOR_BLACK = 0;
 	const SVG_BLACK       = 1;
 	const SVG_COLOR_WHITE = 2;
@@ -182,6 +183,10 @@ class ContactSelector
 	public static function networkToSVG(string $network, int $gsid = null, string $platform = '', int $uid = 0): string
 	{
 		$platform_icon_style = $uid ? (DI::pConfig()->get($uid, 'accessibility', 'platform_icon_style') ?? self::SVG_COLOR_BLACK) : self::SVG_COLOR_BLACK;
+
+		if ($platform_icon_style == self::SVG_DISABLED) {
+			return '';
+		}
 
 		$nets = [
 			Protocol::ACTIVITYPUB => 'activitypub', // https://commons.wikimedia.org/wiki/File:ActivityPub-logo-symbol.svg

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -253,6 +253,7 @@ class Display extends BaseSettings
 		$hide_custom_emojis      =  $this->pConfig->get($uid, 'accessibility', 'hide_custom_emojis', false);
 		$platform_icon_style     =  $this->pConfig->get($uid, 'accessibility', 'platform_icon_style', ContactSelector::SVG_COLOR_BLACK);
 		$platform_icon_styles = [
+			ContactSelector::SVG_DISABLED    => $this->t('Disabled'),
 			ContactSelector::SVG_COLOR_BLACK => $this->t('Color/Black'),
 			ContactSelector::SVG_BLACK       => $this->t('Black'),
 			ContactSelector::SVG_COLOR_WHITE => $this->t('Color/White'),

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -71,9 +71,13 @@
                                 {{/if}}
 				<span class="pinned">{{$item.pinned}}</span>
 			</span>
-                            {{if $item.lock}}<span class="icon s10 lock fakelink" onclick="lockview(event, 'item', {{$item.id}});" title="{{$item.lock}}">{{$item.lock}}</span>{{/if}}
-							<span class="wall-item-network" title="{{$item.app}}">
+			{{if $item.lock}}<span class="icon s10 lock fakelink" onclick="lockview(event, 'item', {{$item.id}});" title="{{$item.lock}}">{{$item.lock}}</span>{{/if}}
+			<span class="wall-item-network" title="{{$item.app}}">
+			{{if $item.network_svg}}
+				<img class="network-svg" src="{{$item.network_svg}}" title="{{$item.network_name}}" alt="{{$item.network_name}}" loading="lazy"/>
+			{{else}}
 				{{$item.network_name}}
+			{{/if}}
 			</span>
 							<div class="wall-item-network-end"></div>
 						</div>

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -1779,6 +1779,13 @@ section.minimal {
 	padding-right: 12px; */
 }
 
+.network-svg {
+	width: 18px;
+	height: 18px;
+	border-radius: 4px;
+	padding: 2px;
+}
+
 #profile-jot-form {
 	box-shadow: 1px 2px 0px 0px #D8D8D8;
 	background-color: #fafafa;


### PR DESCRIPTION
This PR adds the option "Disabled" to the SVG icon selection. This means that no icon will be displayed, but simply a text, just like it is happeing now with "Vier". At the same time the SVG functionality is added to "Vier" as well, so that you now can see SVG icons there as well.