### PR TITLE
Improved message splitting when posting to Bluesky or Twitter

### DIFF
--- a/src/Content/Text/Plaintext.php
+++ b/src/Content/Text/Plaintext.php
@@ -12,6 +12,7 @@ use Friendica\DI;
 use Friendica\Model\Photo;
 use Friendica\Model\Post;
 use Friendica\Util\Network;
+use IntlChar;
 
 class Plaintext
 {
@@ -237,39 +238,55 @@ class Plaintext
 	 */
 	private static function getParts(string $message, int $baselimit): array
 	{
-		$parts = [];
-		$part = '';
+		$parts     = [];
+		$part      = '';
+		$break_pos = 0;
 
 		$limit = $baselimit;
 
 		while ($message) {
-			$pos1 = strpos($message, ' ');
-			$pos2 = strpos($message, "\n");
+			$pos_word = mb_strpos($message, ' ');
+			$pos_paragraph = mb_strpos($message, "\n");
 
-			if (($pos1 !== false) && ($pos2 !== false)) {
-				$pos = min($pos1, $pos2) + 1;
-			} elseif ($pos1 !== false) {
-				$pos = $pos1 + 1;
-			} elseif ($pos2 !== false) {
-				$pos = $pos2 + 1;
+			if (($pos_word !== false) && ($pos_paragraph !== false)) {
+				$pos = min($pos_word, $pos_paragraph) + 1;
+			} elseif ($pos_word !== false) {
+				$pos = $pos_word + 1;
+			} elseif ($pos_paragraph !== false) {
+				$pos = $pos_paragraph + 1;
 			} else {
 				$word = $message;
 				$message = '';
 			}
 
 			if (trim($message)) {
-				$word    = substr($message, 0, $pos);
-				$message = trim(substr($message, $pos));
+				$word    = mb_substr($message, 0, $pos);
+				$message = trim(mb_substr($message, $pos));
 			}
 
 			if (Network::isValidHttpUrl(trim($word))) {
 				$limit += mb_strlen(trim($word)) - self::URL_LENGTH;
 			}
 
+			$break = mb_strrpos($word, "\n") !== false;
+			if (!$break && mb_strrpos($word, '. ') !== false) {
+				$next = mb_substr($message, 0, 1);
+				$break = IntlChar::isupper($next);
+			} 
+			if ($break) {
+				$break_pos = $pos + mb_strlen($part);
+			}
+
 			if ((mb_strlen($part . $word) > $limit - 8) && ($parts || (mb_strlen($part . $word . $message) > $limit))) {
-				$parts[] = trim($part);
-				$part    = '';
-				$limit   = $baselimit;
+				if ($break_pos) {
+					$parts[] = trim(mb_substr($part, 0, $break_pos));
+					$part    = mb_substr($part, $break_pos);
+				} else {
+					$parts[] = trim($part);
+					$part    = '';
+				}
+				$limit     = $baselimit;
+				$break_pos = 0;
 			}
 			$part .= $word;
 		}


### PR DESCRIPTION
We have to split messages when we post them to length restricted systems like Bluesky or Twitter. By now we just had done the split after the last word that still fitted.

We now look for paragraphs and sentences as well and will prefer to split there.