### PR TITLE
Avoid useless "warning" logging

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -2301,7 +2301,7 @@ class Contact
 			return;
 		}
 
-		if (!Network::isValidHttpUrl($avatar)) {
+		if (!empty($avatar) && !Network::isValidHttpUrl($avatar)) {
 			Logger::warning('Invalid avatar', ['cid' => $cid, 'avatar' => $avatar]);
 			$avatar = '';
 		}

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -877,10 +877,10 @@ class Processor
 	{
 		if (!empty($activity['mediatype']) && ($activity['mediatype'] == 'text/markdown')) {
 			$item['title'] = strip_tags($activity['name'] ?? '');
-			$content = Markdown::toBBCode($activity['content']);
+			$content = Markdown::toBBCode($activity['content'] ?? '');
 		} elseif (!empty($activity['mediatype']) && ($activity['mediatype'] == 'text/bbcode')) {
-			$item['title'] = $activity['name'];
-			$content = $activity['content'];
+			$item['title'] = $activity['name'] ?? '';
+			$content = $activity['content'] ?? '';
 		} else {
 			// By default assume "text/html"
 			$item['title'] = HTML::toBBCode($activity['name'] ?? '');


### PR DESCRIPTION
This avoids the logging of "Invalid avatar" when the avatar is empty.