### PR TITLE
No restrictions check on connector networks

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1472,6 +1472,12 @@ class Item
 			return false;
 		}
 
+		// We only have to apply restrictions if the post originates from our server or is federated.
+		// Every other time we can trust the remote system.
+		if (!in_array($item['network'], Protocol::FEDERATED) && !$item['origin']) {
+			return false;
+		}
+
 		if (($restrictions & self::CANT_REPLY) && ($item['verb'] == Activity::POST)) {
 			return true;
 		}
@@ -1796,7 +1802,7 @@ class Item
 			}
 		}
 
-		if (($source_uid == 0) && (($item['private'] == self::PRIVATE) || !in_array($item['network'], Protocol::FEDERATED))) {
+		if (($source_uid == 0) && (($item['private'] == self::PRIVATE) || !in_array($item['network'], array_merge(Protocol::FEDERATED, [Protocol::BLUESKY])))) {
 			Logger::notice('Item is private or not from a federated network. It will not be stored for the user.', ['uri-id' => $uri_id, 'uid' => $uid, 'private' => $item['private'], 'network' => $item['network']]);
 			return 0;
 		}


### PR DESCRIPTION
Some networks have got posting restrictions. We don't have to follow these restrictions if the post orignates from a connector network where we can be sure that they already checked the restritions.