### PR TITLE
Fix PHPStan errors level 2 in addons

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -13,6 +13,7 @@ parameters:
         analyse:
             - addon/*/lang/*
             - addon/*/vendor/*
+            - addon/convert/UnitConvertor.php
             - addon/pumpio/oauth/*
 
     scanDirectories:

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -6,7 +6,7 @@ parameters:
     level: 2
 
     paths:
-        # - addon/
+        - addon/
         - src/
 
     excludePaths:

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -40,3 +40,27 @@ parameters:
             # Ignore missing IMAP\Connection class in PHP <= 8.0
             message: '(^Parameter .+ has invalid type IMAP\\Connection\.$)'
             path: src
+
+        -
+            # Ignore missing SMTP class in PHPMailer 5.2.21
+            # see https://github.com/PHPMailer/PHPMailer/blob/v5.2.21/class.smtp.php
+            message: '(^.+ an unknown class SMTP\.$)'
+            path: addon/mailstream/phpmailer
+
+        -
+            # Ignore missing SMTP class in PHPMailer 5.2.21
+            # see https://github.com/PHPMailer/PHPMailer/blob/v5.2.21/class.smtp.php
+            message: '(^Property .+ has unknown class SMTP as its type\.$)'
+            path: addon/mailstream/phpmailer
+
+        -
+            # Ignore missing SMTP class in PHPMailer 5.2.21
+            # see https://github.com/PHPMailer/PHPMailer/blob/v5.2.21/class.smtp.php
+            message: '(^Method .+ has invalid return type SMTP\.$)'
+            path: addon/mailstream/phpmailer
+
+        -
+            # Ignore missing SMTP class in PHPMailer 5.2.21
+            # see https://github.com/PHPMailer/PHPMailer/blob/v5.2.21/class.smtp.php
+            message: '(^Instantiated class SMTP not found\.$)'
+            path: addon/mailstream/phpmailer

--- a/src/Util/Strings.php
+++ b/src/Util/Strings.php
@@ -530,8 +530,12 @@ class Strings
 	{
 		$shorthand = trim($shorthand);
 
-		if (is_numeric($shorthand)) {
-			return $shorthand;
+		if (ctype_digit($shorthand)) {
+			return (int) $shorthand;
+		}
+
+		if ($shorthand === '') {
+			return 0;
 		}
 
 		$last      = strtolower($shorthand[strlen($shorthand) - 1]);


### PR DESCRIPTION
This PR will analyze the addon folder with PHPStan level 2. The reported errors will be fixed in the friendica-addon repository, see https://github.com/friendica/friendica-addons/pull/1372

Requires:

- [x] #14584
- [x] https://github.com/friendica/friendica-addons/pull/1372