### PR TITLE
Add `App::fromDice()` factory method

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -8,6 +8,7 @@ parameters:
     paths:
         - addon/
         - src/
+        - index.php
 
     excludePaths:
         analyse:

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@ $dice = $dice->addRule(Friendica\App\Mode::class, ['call' => [['determineRunMode
 
 \Friendica\Core\Logger\Handler\ErrorHandler::register($dice->create(\Psr\Log\LoggerInterface::class));
 
-$a = \Friendica\DI::app();
+$a = \Friendica\App::fromDice($dice);
 
 \Friendica\DI::mode()->setExecutor(\Friendica\App\Mode::INDEX);
 

--- a/index.php
+++ b/index.php
@@ -15,11 +15,13 @@ if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 
 require __DIR__ . '/vendor/autoload.php';
 
+$request = \GuzzleHttp\Psr7\ServerRequest::fromGlobals();
+
 $dice = (new Dice())->addRules(include __DIR__ . '/static/dependencies.config.php');
 /** @var \Friendica\Core\Addon\Capability\ICanLoadAddons $addonLoader */
 $addonLoader = $dice->create(\Friendica\Core\Addon\Capability\ICanLoadAddons::class);
 $dice = $dice->addRules($addonLoader->getActiveAddonConfig('dependencies'));
-$dice = $dice->addRule(Friendica\App\Mode::class, ['call' => [['determineRunMode', [false, $_SERVER], Dice::CHAIN_CALL]]]);
+$dice = $dice->addRule(Friendica\App\Mode::class, ['call' => [['determineRunMode', [false, $request->getServerParams()], Dice::CHAIN_CALL]]]);
 
 \Friendica\DI::init($dice);
 
@@ -36,7 +38,7 @@ $a->runFrontend(
 	$dice->create(\Friendica\App\Page::class),
 	$dice->create(\Friendica\Content\Nav::class),
 	$dice->create(Friendica\Module\Special\HTTPException::class),
-	new \Friendica\Util\HTTPInputData($_SERVER),
+	new \Friendica\Util\HTTPInputData($request->getServerParams()),
 	$start_time,
-	$_SERVER
+	$request->getServerParams()
 );

--- a/index.php
+++ b/index.php
@@ -31,8 +31,6 @@ $a = \Friendica\App::fromDice($dice);
 
 $a->processRequest();
 
-\Friendica\DI::mode()->setExecutor(\Friendica\App\Mode::INDEX);
-
 $a->runFrontend(
 	$dice->create(\Friendica\App\Router::class),
 	$dice->create(\Friendica\Core\PConfig\Capability\IManagePersonalConfigValues::class),

--- a/index.php
+++ b/index.php
@@ -29,6 +29,11 @@ $dice = $dice->addRule(Friendica\App\Mode::class, ['call' => [['determineRunMode
 
 $a = \Friendica\App::fromDice($dice);
 
+$a->load(
+	$dice->create(\Friendica\Database\Definition\DbaDefinition::class),
+	$dice->create(\Friendica\Database\Definition\ViewDefinition::class),
+);
+
 \Friendica\DI::mode()->setExecutor(\Friendica\App\Mode::INDEX);
 
 $a->runFrontend(

--- a/index.php
+++ b/index.php
@@ -29,10 +29,7 @@ $dice = $dice->addRule(Friendica\App\Mode::class, ['call' => [['determineRunMode
 
 $a = \Friendica\App::fromDice($dice);
 
-$a->load(
-	$dice->create(\Friendica\Database\Definition\DbaDefinition::class),
-	$dice->create(\Friendica\Database\Definition\ViewDefinition::class),
-);
+$a->processRequest();
 
 \Friendica\DI::mode()->setExecutor(\Friendica\App\Mode::INDEX);
 

--- a/index.php
+++ b/index.php
@@ -29,16 +29,4 @@ $dice = $dice->addRule(Friendica\App\Mode::class, ['call' => [['determineRunMode
 
 $a = \Friendica\App::fromDice($dice);
 
-$a->processRequest();
-
-$a->runFrontend(
-	$dice->create(\Friendica\App\Router::class),
-	$dice->create(\Friendica\Core\PConfig\Capability\IManagePersonalConfigValues::class),
-	$dice->create(\Friendica\Security\Authentication::class),
-	$dice->create(\Friendica\App\Page::class),
-	$dice->create(\Friendica\Content\Nav::class),
-	$dice->create(Friendica\Module\Special\HTTPException::class),
-	new \Friendica\Util\HTTPInputData($request->getServerParams()),
-	$start_time,
-	$request->getServerParams()
-);
+$a->processRequest($request, $start_time);

--- a/src/App.php
+++ b/src/App.php
@@ -122,7 +122,7 @@ class App
 	 */
 	private $appHelper;
 
-	public function __construct(
+	private function __construct(
 		Request $request,
 		Authentication $auth,
 		IManageConfigValues $config,

--- a/src/App.php
+++ b/src/App.php
@@ -142,7 +142,7 @@ class App
 		IHandleUserSessions $session,
 		DbaDefinition $dbaDefinition,
 		ViewDefinition $viewDefinition,
-		AppHelper $appHelper = null,
+		AppHelper $appHelper,
 	) {
 		$this->container = $container;
 		$this->requestId = $request->getRequestId();
@@ -155,7 +155,7 @@ class App
 		$this->l10n      = $l10n;
 		$this->args      = $args;
 		$this->session   = $session;
-		$this->appHelper = $appHelper ?? DI::appHelper();
+		$this->appHelper = $appHelper;
 
 		$this->load($dbaDefinition, $viewDefinition);
 	}

--- a/src/App.php
+++ b/src/App.php
@@ -55,6 +55,7 @@ class App
 	public static function fromDice(Dice $dice): self
 	{
 		return new self(
+			$dice,
 			$dice->create(Request::class),
 			$dice->create(Authentication::class),
 			$dice->create(IManageConfigValues::class),
@@ -70,6 +71,11 @@ class App
 			$dice->create(AppHelper::class)
 		);
 	}
+
+	/**
+	 * @var Dice
+	 */
+	private $container;
 
 	/**
 	 * @var Mode The Mode of the Application
@@ -123,6 +129,7 @@ class App
 	private $appHelper;
 
 	private function __construct(
+		Dice $container,
 		Request $request,
 		Authentication $auth,
 		IManageConfigValues $config,
@@ -137,6 +144,7 @@ class App
 		ViewDefinition $viewDefinition,
 		AppHelper $appHelper = null,
 	) {
+		$this->container = $container;
 		$this->requestId = $request->getRequestId();
 		$this->auth      = $auth;
 		$this->config    = $config;

--- a/src/App.php
+++ b/src/App.php
@@ -117,6 +117,10 @@ class App
 	private function __construct(Dice $container)
 	{
 		$this->container = $container;
+	}
+
+	public function processRequest(ServerRequestInterface $request, float $start_time): void
+	{
 		$this->requestId = $this->container->create(Request::class)->getRequestId();
 		$this->auth      = $this->container->create(Authentication::class);
 		$this->config    = $this->container->create(IManageConfigValues::class);
@@ -128,10 +132,7 @@ class App
 		$this->args      = $this->container->create(Arguments::class);
 		$this->session   = $this->container->create(IHandleUserSessions::class);
 		$this->appHelper = $this->container->create(AppHelper::class);
-	}
 
-	public function processRequest(ServerRequestInterface $request, float $start_time): void
-	{
 		$this->load(
 			$this->container->create(DbaDefinition::class),
 			$this->container->create(ViewDefinition::class),
@@ -155,7 +156,7 @@ class App
 	/**
 	 * Load the whole app instance
 	 */
-	public function load(DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition)
+	private function load(DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition)
 	{
 		if ($this->config->get('system', 'ini_max_execution_time') !== false) {
 			set_time_limit((int)$this->config->get('system', 'ini_max_execution_time'));
@@ -229,7 +230,7 @@ class App
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public function runFrontend(
+	private function runFrontend(
 		Router $router,
 		IManagePersonalConfigValues $pconfig,
 		Authentication $auth,

--- a/src/App.php
+++ b/src/App.php
@@ -66,8 +66,6 @@ class App
 			$dice->create(L10n::class),
 			$dice->create(Arguments::class),
 			$dice->create(IHandleUserSessions::class),
-			$dice->create(DbaDefinition::class),
-			$dice->create(ViewDefinition::class),
 			$dice->create(AppHelper::class)
 		);
 	}
@@ -140,8 +138,6 @@ class App
 		L10n $l10n,
 		Arguments $args,
 		IHandleUserSessions $session,
-		DbaDefinition $dbaDefinition,
-		ViewDefinition $viewDefinition,
 		AppHelper $appHelper,
 	) {
 		$this->container = $container;
@@ -156,14 +152,12 @@ class App
 		$this->args      = $args;
 		$this->session   = $session;
 		$this->appHelper = $appHelper;
-
-		$this->load($dbaDefinition, $viewDefinition);
 	}
 
 	/**
 	 * Load the whole app instance
 	 */
-	protected function load(DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition)
+	public function load(DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition)
 	{
 		if ($this->config->get('system', 'ini_max_execution_time') !== false) {
 			set_time_limit((int)$this->config->get('system', 'ini_max_execution_time'));

--- a/src/App.php
+++ b/src/App.php
@@ -7,6 +7,7 @@
 
 namespace Friendica;
 
+use Dice\Dice;
 use Friendica\App\Arguments;
 use Friendica\App\BaseURL;
 use Friendica\App\Mode;
@@ -50,6 +51,25 @@ class App
 	const PLATFORM = 'Friendica';
 	const CODENAME = 'Yellow Archangel';
 	const VERSION  = '2024.12-dev';
+
+	public static function fromDice(Dice $dice): self
+	{
+		return new self(
+			$dice->create(Request::class),
+			$dice->create(Authentication::class),
+			$dice->create(IManageConfigValues::class),
+			$dice->create(Mode::class),
+			$dice->create(BaseURL::class),
+			$dice->create(LoggerInterface::class),
+			$dice->create(Profiler::class),
+			$dice->create(L10n::class),
+			$dice->create(Arguments::class),
+			$dice->create(IHandleUserSessions::class),
+			$dice->create(DbaDefinition::class),
+			$dice->create(ViewDefinition::class),
+			$dice->create(AppHelper::class)
+		);
+	}
 
 	/**
 	 * @var Mode The Mode of the Application
@@ -114,7 +134,8 @@ class App
 		Arguments $args,
 		IHandleUserSessions $session,
 		DbaDefinition $dbaDefinition,
-		ViewDefinition $viewDefinition
+		ViewDefinition $viewDefinition,
+		AppHelper $appHelper = null,
 	) {
 		$this->requestId = $request->getRequestId();
 		$this->auth      = $auth;
@@ -126,7 +147,7 @@ class App
 		$this->l10n      = $l10n;
 		$this->args      = $args;
 		$this->session   = $session;
-		$this->appHelper = DI::appHelper();
+		$this->appHelper = $appHelper ?? DI::appHelper();
 
 		$this->load($dbaDefinition, $viewDefinition);
 	}

--- a/src/App.php
+++ b/src/App.php
@@ -154,6 +154,14 @@ class App
 		$this->appHelper = $appHelper;
 	}
 
+	public function processRequest(): void
+	{
+		$this->load(
+			$this->container->create(DbaDefinition::class),
+			$this->container->create(ViewDefinition::class),
+		);
+	}
+
 	/**
 	 * Load the whole app instance
 	 */

--- a/src/App.php
+++ b/src/App.php
@@ -160,6 +160,8 @@ class App
 			$this->container->create(DbaDefinition::class),
 			$this->container->create(ViewDefinition::class),
 		);
+
+		$this->mode->setExecutor(Mode::INDEX);
 	}
 
 	/**

--- a/src/App.php
+++ b/src/App.php
@@ -141,13 +141,12 @@ class App
 		$this->mode->setExecutor(Mode::INDEX);
 
 		$this->runFrontend(
-			$this->container->create(\Friendica\App\Router::class),
-			$this->container->create(\Friendica\Core\PConfig\Capability\IManagePersonalConfigValues::class),
-			$this->container->create(\Friendica\Security\Authentication::class),
-			$this->container->create(\Friendica\App\Page::class),
-			$this->container->create(\Friendica\Content\Nav::class),
-			$this->container->create(\Friendica\Module\Special\HTTPException::class),
-			new \Friendica\Util\HTTPInputData($request->getServerParams()),
+			$this->container->create(Router::class),
+			$this->container->create(IManagePersonalConfigValues::class),
+			$this->container->create(Page::class),
+			$this->container->create(Nav::class),
+			$this->container->create(ModuleHTTPException::class),
+			new HTTPInputData($request->getServerParams()),
 			$start_time,
 			$request->getServerParams()
 		);
@@ -220,7 +219,6 @@ class App
 	 *
 	 * @param Router                      $router
 	 * @param IManagePersonalConfigValues $pconfig
-	 * @param Authentication              $auth       The Authentication backend of the node
 	 * @param Page                        $page       The Friendica page printing container
 	 * @param ModuleHTTPException         $httpException The possible HTTP Exception container
 	 * @param HTTPInputData               $httpInput  A library for processing PHP input streams
@@ -233,7 +231,6 @@ class App
 	private function runFrontend(
 		Router $router,
 		IManagePersonalConfigValues $pconfig,
-		Authentication $auth,
 		Page $page,
 		Nav $nav,
 		ModuleHTTPException $httpException,
@@ -301,7 +298,7 @@ class App
 			}
 
 			if (!$this->mode->isBackend()) {
-				$auth->withSession();
+				$this->auth->withSession();
 			}
 
 			if ($this->session->isUnauthenticated()) {

--- a/src/App.php
+++ b/src/App.php
@@ -55,20 +55,7 @@ class App
 
 	public static function fromDice(Dice $dice): self
 	{
-		return new self(
-			$dice,
-			$dice->create(Request::class),
-			$dice->create(Authentication::class),
-			$dice->create(IManageConfigValues::class),
-			$dice->create(Mode::class),
-			$dice->create(BaseURL::class),
-			$dice->create(LoggerInterface::class),
-			$dice->create(Profiler::class),
-			$dice->create(L10n::class),
-			$dice->create(Arguments::class),
-			$dice->create(IHandleUserSessions::class),
-			$dice->create(AppHelper::class)
-		);
+		return new self($dice);
 	}
 
 	/**
@@ -127,32 +114,20 @@ class App
 	 */
 	private $appHelper;
 
-	private function __construct(
-		Dice $container,
-		Request $request,
-		Authentication $auth,
-		IManageConfigValues $config,
-		Mode $mode,
-		BaseURL $baseURL,
-		LoggerInterface $logger,
-		Profiler $profiler,
-		L10n $l10n,
-		Arguments $args,
-		IHandleUserSessions $session,
-		AppHelper $appHelper,
-	) {
+	private function __construct(Dice $container)
+	{
 		$this->container = $container;
-		$this->requestId = $request->getRequestId();
-		$this->auth      = $auth;
-		$this->config    = $config;
-		$this->mode      = $mode;
-		$this->baseURL   = $baseURL;
-		$this->profiler  = $profiler;
-		$this->logger    = $logger;
-		$this->l10n      = $l10n;
-		$this->args      = $args;
-		$this->session   = $session;
-		$this->appHelper = $appHelper;
+		$this->requestId = $this->container->create(Request::class)->getRequestId();
+		$this->auth      = $this->container->create(Authentication::class);
+		$this->config    = $this->container->create(IManageConfigValues::class);
+		$this->mode      = $this->container->create(Mode::class);
+		$this->baseURL   = $this->container->create(BaseURL::class);
+		$this->logger    = $this->container->create(LoggerInterface::class);
+		$this->profiler  = $this->container->create(Profiler::class);
+		$this->l10n      = $this->container->create(L10n::class);
+		$this->args      = $this->container->create(Arguments::class);
+		$this->session   = $this->container->create(IHandleUserSessions::class);
+		$this->appHelper = $this->container->create(AppHelper::class);
 	}
 
 	public function processRequest(ServerRequestInterface $request, float $start_time): void

--- a/src/App.php
+++ b/src/App.php
@@ -34,6 +34,7 @@ use Friendica\Util\DateTimeFormat;
 use Friendica\Util\HTTPInputData;
 use Friendica\Util\HTTPSignature;
 use Friendica\Util\Profiler;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -154,7 +155,7 @@ class App
 		$this->appHelper = $appHelper;
 	}
 
-	public function processRequest(): void
+	public function processRequest(ServerRequestInterface $request, float $start_time): void
 	{
 		$this->load(
 			$this->container->create(DbaDefinition::class),
@@ -162,6 +163,18 @@ class App
 		);
 
 		$this->mode->setExecutor(Mode::INDEX);
+
+		$this->runFrontend(
+			$this->container->create(\Friendica\App\Router::class),
+			$this->container->create(\Friendica\Core\PConfig\Capability\IManagePersonalConfigValues::class),
+			$this->container->create(\Friendica\Security\Authentication::class),
+			$this->container->create(\Friendica\App\Page::class),
+			$this->container->create(\Friendica\Content\Nav::class),
+			$this->container->create(\Friendica\Module\Special\HTTPException::class),
+			new \Friendica\Util\HTTPInputData($request->getServerParams()),
+			$start_time,
+			$request->getServerParams()
+		);
 	}
 
 	/**

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -18,9 +18,7 @@ class AppTest extends TestCase
 	public function testFromDiceReturnsApp(): void
 	{
 		$dice = $this->createMock(Dice::class);
-		$dice->expects($this->exactly(11))->method('create')->willReturnCallback(function($classname) {
-			return $this->createMock($classname);
-		});
+		$dice->expects($this->never())->method('create');
 
 		$app = App::fromDice($dice);
 

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -18,7 +18,7 @@ class AppTest extends TestCase
 	public function testFromDiceReturnsApp(): void
 	{
 		$dice = $this->createMock(Dice::class);
-		$dice->expects($this->exactly(13))->method('create')->willReturnCallback(function($classname) {
+		$dice->expects($this->exactly(11))->method('create')->willReturnCallback(function($classname) {
 			return $this->createMock($classname);
 		});
 

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -1,0 +1,29 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types = 1);
+
+namespace Friendica\Test\Unit;
+
+use Dice\Dice;
+use Friendica\App;
+use PHPUnit\Framework\TestCase;
+
+class AppTest extends TestCase
+{
+	public function testFromDiceReturnsApp(): void
+	{
+		$dice = $this->createMock(Dice::class);
+		$dice->expects($this->exactly(13))->method('create')->willReturnCallback(function($classname) {
+			return $this->createMock($classname);
+		});
+
+		$app = App::fromDice($dice);
+
+		$this->assertInstanceOf(App::class, $app);
+	}
+}


### PR DESCRIPTION
This PR adds a new static factory method `App::fromDice()` to create the app instance from Dice. This replaces the last call of `DI::app()`. The `DI::app()` method can be deleted and the Dice rules for the App class can be removed in followup PRs.

Refs: #14535

Requires:

- [x] #14602