### PR TITLE
Documentation to connectors updated

### DIFF
--- a/doc/Addons.md
+++ b/doc/Addons.md
@@ -604,7 +604,7 @@ Hook data:
 
 ### follow
 
-Called before adding a new contact for a user to handle non-native network remote contact (like Twitter).
+Called before adding a new contact for a user to handle non-native network remote contact (like Bluesky).
 
 Hook data:
 
@@ -613,7 +613,7 @@ Hook data:
 
 ### unfollow
 
-Called when unfollowing a remote contact on a non-native network (like Twitter)
+Called when unfollowing a remote contact on a non-native network (like Bluesky)
 
 Hook data:
 - **contact** (input): the target public contact (uid = 0) array.
@@ -622,7 +622,7 @@ Hook data:
 
 ### revoke_follow
 
-Called when making a remote contact on a non-native network (like Twitter) unfollow you.
+Called when making a remote contact on a non-native network (like Bluesky) unfollow you.
 
 Hook data:
 - **contact** (input): the target public contact (uid = 0) array.
@@ -631,7 +631,7 @@ Hook data:
 
 ### block
 
-Called when blocking a remote contact on a non-native network (like Twitter).
+Called when blocking a remote contact on a non-native network (like Bluesky).
 
 Hook data:
 - **contact** (input): the remote contact (uid = 0) array.
@@ -640,7 +640,7 @@ Hook data:
 
 ### unblock
 
-Called when unblocking a remote contact on a non-native network (like Twitter).
+Called when unblocking a remote contact on a non-native network (like Bluesky).
 
 Hook data:
 - **contact** (input): the remote contact (uid = 0) array.

--- a/doc/Circles-and-Privacy.md
+++ b/doc/Circles-and-Privacy.md
@@ -95,14 +95,6 @@ However we take privacy seriously and don't behave like some networks that __pre
 Your profile and "wall" may also be visited by your friends from other networks, and you can block access to these by web visitors that Friendica doesn't know.
 Be aware that this could include some of your friends on other networks.
 
-This may produce undesired results when posting a long status message to (for instance) Twitter.
-When Friendica sends a post to these networks which exceeds the service length limit, we truncate it and provide a link to the original.
-The original is a link back to your Friendica profile.
-As Friendica cannot prove who they are, it may not be possible for these people to view your post in full.
-
-For people in this situation we would recommend providing a "Twitter-length" summary, with more detail for friends that can see the post in full.
-You can do so by including the BBCode tag *abstract* in your posting.
-
 Blocking your profile or entire Friendica site from unknown web visitors also has serious implications for communicating with GNU Social members.
 These networks communicate with others via public protocols that are not authenticated.
 In order to view your posts, these networks have to access them as an "unknown web visitor".

--- a/doc/Connectors.md
+++ b/doc/Connectors.md
@@ -4,14 +4,9 @@ Connectors
 * [Home](help)
 
 Connectors allow you to connect with external social networks and services.
-They are only required for posting to existing accounts on Twitter or GNU Social.
+They are only required for posting to existing accounts on for example Bluesky, Tumblr or Twitter.
+For Bluesky and Tumblr you can also enable a bidirectional synchronisation, so that you can use Friendica to read your timeline from Tumblr or Bluesky.
 There is also a connector for accessing your email INBOX.
-
-If the following network connectors are installed on your system, select the following links to visit the appropriate settings page and configure them for your account:
-
-* [Twitter](/settings/addons)
-* [GNU Social](/settings/addons)
-* [Email](/settings)
 
 Instructions For Connecting To People On Specific Services
 ==========================================================
@@ -36,14 +31,6 @@ PLease note that you will not be able to reply to these contacts.
 
 This feed reader feature will allow you to _connect_ with millions of pages on the internet.
 All that the pages need to have is a discoverable feed using either the RSS or Atom syndication format, and which provides an author name and a site image in a form which we can extract. 
-
-Twitter
----
-
-To follow a Twitter member, the Twitter-Connector (Addon) needs to be configured on your node.
-If this is the case put the URL of the Twitter member's main page into the Connect box on your [Contacts](contacts) page.
-To reply, you must have the Twitter connector installed, and reply using your own status editor.
-Begin the message with @twitterperson replacing with the Twitter username.
 
 Email
 ---

--- a/doc/Export-Import-Contacts.md
+++ b/doc/Export-Import-Contacts.md
@@ -11,8 +11,7 @@ To export the list of accounts that you follow, go to the [Settings Export perso
 
 ## Import of followed Contacts
 
-To import contacts from a CSV file, go to the [Settings page](settings).
-At the bottom of the *account settings* page you'll find the *import contacts* section.
+To import contacts from a CSV file, go to the [import contacts](settings/importcontacts).
 Upload the CSV file there.
 
 ### Supported File Format

--- a/doc/Home.md
+++ b/doc/Home.md
@@ -31,7 +31,7 @@ Help
 * [Install](help/Install)
 * [Update](help/Update)
 * [Settings & Admin Panel](help/Settings)
-* [Installing Connectors (Twitter/GNU Social)](help/Installing-Connectors)
+* [Installing Connectors](help/Installing-Connectors)
 * [Install an ejabberd server (XMPP chat) with synchronized credentials](help/install-ejabberd)
 * [Using SSL with Friendica](help/SSL)
 * [Config values that can only be set in config/local.config.php](help/Config)

--- a/doc/Installing-Connectors.md
+++ b/doc/Installing-Connectors.md
@@ -1,89 +1,34 @@
-Installing Connectors (Twitter/GNU Social)
+Installing Connectors
 ==================================================
 
 * [Home](help)
 
+Friendica uses add-ons to connect to some networks, such as Tumblr or Bluesky.
 
-Friendica uses addons to provide connectivity to some networks, such as Twitter.
+All of these add-ons require an account on the target network.
+In addition, you (or usually the server administrator) will need to obtain an API key to allow authenticated access to your Friendica server.
 
-There is also a addon to post through to an existing account on a GNU Social service.
-You only need this to post to an already existing GNU Social account, but not to communicate with GNU Social members in general.
-
-All three addons require an account on the target network.
-In addition you (or typically the server administrator) will need to obtain an API key to provide authenticated access to your Friendica server.
-
-Site Configuration
+Site configuration
 ---
 
-Addons must be installed by the site administrator before they can be used.
-This is accomplished through the site administration panel.
+Addons need to be installed by the site administrator before they can be used.
+This is done through the site administration panel.
 
-Each of the connectors also requires an "API key" from the service you wish to connect with.
-Some addons allow you to enter this information in the site administration pages, while others may require you to edit your configuration file (config/local.config.php).
-The ways to obtain these keys vary between the services, but they all require an existing account on the target service.
-Once installed, these API keys can usually be shared by all site members.
+Some of the connectors also require an "API key" from the service you wish to connect to.
+For Tumblr, this information can be found in the site administration pages, while for Twitter (X) each user has to create their own API key.
+Other connectors, such as Bluesky, don't require an API key at all.
 
-The details of configuring each service follow (much of this information comes directly from the addon source files):
+You can find more information about specific requirements on each addon's settings page, either on the admin page or the user page.
 
-Twitter Addon for Friendica
+Bluesky Jetstream
 ---
 
-* Author: Tobias Diekershoff
-* tobias.diekershoff@gmx.net
-* License: 3-clause BSD license
+To further improve connectivity to Bluesky, Admins can choose to enable 'Jetstream' connectivity.
+Jetstream is a service that connects to the Bluesky firehose.
+With Jetstream, messages arrive in real time rather than having to be polled.
+It also enables real-time processing of blocks or tracking activities performed by the user via the Bluesky website or application.
 
-### Configuration
-To use this addon you need a OAuth Consumer key pair (key & secret).
-You can get it from [Twitter](https://twitter.com/apps).
+To enable Jetstream processing, run `bin/jetstream.php' from the command line.
+You will need to define the process id file in local.config.php in the 'jetstream' section using the key 'pidfile'.
 
-Register your Friendica site as "Client" application with "Read & Write" access.
-We do not need "Twitter as login".
-When you've registered the app you get a key pair with an OAuth Consumer key and a secret key for your application/site.
-Add this key pair to your config/local.config.php:
-
-	[twitter]
-	consumerkey = your consumer_key here
-	consumersecret = your consumer_secret here
-
-After this, your users can configure their Twitter account settings from "Settings -> Connector Settings".
-
-### More documentation
-
-Find the author's documentation here: [http://diekershoff.homeunix.net/redmine/wiki/friendikaplugin/Twitter_Plugin](http://diekershoff.homeunix.net/redmine/wiki/friendikaplugin/Twitter_Plugin)
-
-
-GNU Social Addon for Friendica
----
-
-* Author: Tobias Diekershoff
-* tobias.diekershoff@gmx.net
-* License: 3-clause BSD license
-
-### Configuration
-
-When the addon is activated the user has to acquire the following in order to connect to the GNU Social account of choice.
-
-* The base URL for the GNU Social API, for quitter.se this is https://quitter.se/api/
-* OAuth Consumer key & secret
-
-To get the OAuth Consumer key pair the user has to
-
-1 ask her Friendica admin if a pair already exists or
-2 has to register the Friendica server as a client application on the GNU Social server.
-
-This can be done from the account settings under "Settings -> Connections -> Register an OAuth client application -> Register a new application" on the GNU Social server.
-
-During the registration of the OAuth client remember the following:
-
-* Application names must be unique on the GNU Social site, so we recommend a Name of 'friendica-nnnn', replace 'nnnn' with a random number or your website name.
-* there is no callback url
-* register a desktop client
-* with read & write access
-* the Source URL should be the URL of your Friendica server
-
-After the required credentials for the application are stored in the configuration you have to actually connect your Friendica account with GNU Social.
-This is done from the Settings -> Connector Settings page.
-Follow the Sign in with GNU Social button, allow access and then copy the security code into the box provided.
-Friendica will then try to acquire the final OAuth credentials from the API.
-
-If successful, the addon settings will allow you to select to post your public messages to your GNU Social account (have a look behind the little lock symbol beneath the status "editor" on your Home or Network pages).
+To keep track of the messages processed and the drift (the time difference between the date of the message and the date the system processed that message), some fields are added to the statistics endpoint.

--- a/doc/de/Circles-and-Privacy.md
+++ b/doc/de/Circles-and-Privacy.md
@@ -97,13 +97,6 @@ Wir nehmen hingegen Privatsphäre ernst und agieren nicht wie andere Netzwerke, 
 Dein Profil und deine "Wall" sollen vielleicht auch von Freunden anderer Netzwerke besucht werden können.
 Wenn du diese Seiten allerdings für Webbesucher sperrst, die Friendica nicht kennt, kann das auch Freunde anderer Netzwerke blockieren.
 
-Das kann möglicherweise ungewollte Ergebnisse produzieren, wenn du lange Statusbeiträge z.B. für Twitter oder Facebook schreibst.
-Wenn Friendica einen Beitrag an diese Netzwerke schickt und nur eine bestimmte Nachrichtenlänge erlaubt ist, dann verkürzen wir diesen und erstellen einen Link, der zum Originalbeitrag führt.
-Der Originallink führt zurück zu deinem Friendica-Profil.
-Da Friendica nicht bestätigen kann, um wen es sich handelt, kann es passieren, dass diese Leute den Beitrag nicht komplett lesen können.
-
-Für Leute, die davon betroffen sind, schlagen wir vor, eine Zusammenfassung in Twitter-Länge zu erstellen mit mehr Details für Freunde, die den ganzen Beitrag sehen können.
-
 Dein Profil oder deine gesamte Friendica-Seite zu blockieren, hat außerdem ernsthafte Einflüsse auf deine Kommunikation mit GNU Social-Nutzern.
 Diese Netzwerke kommunizieren mit anderen über öffentliche Protokolle, die nicht authentifiziert werden.
 Um deine Beiträge zu sehen, müssen diese Netzwerke deine Beiträge als "unbekannte Webbesucher" ansehen.

--- a/doc/de/Connectors.md
+++ b/doc/de/Connectors.md
@@ -4,15 +4,10 @@ Konnektoren (Connectors)
 * [Zur Startseite der Hilfe](help)
 
 Konnektoren erlauben es Dir, Dich mit anderen sozialen Netzwerken zu verbinden. 
-Konnektoren werden nur bei bestehenden Twitter und GNU Social-Accounts benötigt. 
+Mit diesen Konnektoren kannst Du z.B. zu Bluesky, Tumblr oder Twitter posten.
+Für Bluesky und Tumblr gibt es eine bidirektionale Verbindung, d.h. du kannst Friendica nutzen, um deine Timeline von diesen Diensten zu lesen.  
 Außerdem gibt es einen Konnektor, um Deinen Email-Posteingang zu nutzen.
-Wenn Du keinen eigenen Knoten betreibst und wissen willst, ob der server Deiner Wahl diese Konnektoren installiert hat, kannst Du Dich darüber auf der Seite '&lt;domain_des_friendica-servers&gt;/friendica' informieren.
-
-Sind die Netzwerk-Konnektoren auf Deinem System installiert sind, kannst Du mit den folgenden Links die Einstellungsseiten besuchen und für Deinen Account konfigurieren:
-
-* [Twitter](/settings/connectors)
-* [GNU Social](/settings/connectors)
-* [Email](/settings/connectors)
+Wenn Du keinen eigenen Knoten betreibst und wissen willst, ob der Server Deiner Wahl diese Konnektoren installiert hat, kannst Du Dich darüber auf der Seite '&lt;domain_des_friendica-servers&gt;/friendica' informieren.
 
 Anleitung, um sich mit Personen in bestimmten Netzwerken zu verbinden
 ==========================================================
@@ -34,14 +29,6 @@ Du hast keine Möglichkeit, diesen Kontakten zu antworten.
 
 Das erlaubt Dir, Dich mit Millionen von Seiten im Internet zu _verbinden_. 
 Alles, was dafür nötig ist, ist dass die Seite einen Feed im RSS- oder Atom Syndication-Format nutzt und welches einen Autoren und ein Bild zur Seite liefert. 
-
-
-**Twitter**
-
-Um einem Twitter-Nutzer zu folgen, trage die URL der Hauptseite des Twitter-Accounts auf Deiner ["Kontakte"-Seite](contacts) in das Feld "Neuen Kontakt hinzufügen" ein. 
-Um zu antworten, musst Du den Twitter-Konnektor installieren und über Deinen eigenen Status-Editor antworten. 
-Beginne Deine Nachricht mit @twitternutzer, ersetze das aber durch den richtigen Twitter-Namen.
-
 
 **Email**
 

--- a/doc/de/Export-Import-Contacts.md
+++ b/doc/de/Export-Import-Contacts.md
@@ -11,8 +11,7 @@ Um die Liste der Kontakte *denen du folgst* zu exportieren, geht die [Einstellun
 
 ## Import der gefolgten Kontakte
 
-Um die Kontakt CSV Datei zu importieren, gehe in die [Einstellungen](settings).
-Am Ende der Einstellungen zum Nutzerkonto findest du den Abschnitt "Kontakte Importieren".
+Um die Kontakt CSV Datei zu importieren, gehe zu [Kontakte Importieren](settings/importcontacts).
 Hier kannst du die CSV Datei auswählen und hoch laden.
 
 ### Unterstütztes Datei Format

--- a/doc/de/Home.md
+++ b/doc/de/Home.md
@@ -32,7 +32,7 @@ Hilfe
 * [Update](help/Update) (EN)
 * [Konfigurationen & Admin-Panel](help/Settings)
 * [Addons](help/Addons)
-* [Konnektoren (Connectors) installieren (Twitter/GNU Social)](help/Installing-Connectors)
+* [Konnektoren (Connectors) installieren](help/Installing-Connectors)
 * [Installation eines ejabberd Servers (XMPP-Chat) mit synchronisierten Anmeldedaten](help/install-ejabberd) (EN)
 * [Betreibe deine Seite mit einem SSL-Zertifikat](help/SSL)
 * [Konfigurationswerte, die nur in der config/local.config.php gesetzt werden können](help/Config) (EN)

--- a/doc/de/Installing-Connectors.md
+++ b/doc/de/Installing-Connectors.md
@@ -1,85 +1,33 @@
-Konnektoren installieren (Twitter/GNU Social)
+Konnektoren installieren
 ==================================================
 
 * [Zur Startseite der Hilfe](help)
 
-Friendica nutzt Erweiterung, um die Verbindung zu anderen Netzwerken wie Twitter oder App.net zu gewährleisten.
+Friendica verwendet Konnektoren, um sich mit einigen Netzwerken zu verbinden, wie Tumblr oder Bluesky.
 
-Es gibt außerdem ein Erweiterung, um über einen bestehenden GNU Social-Account diesen Service zu nutzen.
-Du brauchst dieses Erweiterung aber nicht, um mit GNU Social-Mitgliedern von Friendica aus zu kommunizieren - es sei denn, du wünschst es, über einen existierenden Account einen Beitrag zu schreiben.
-
-Alle drei Erweiterung benötigen einen Account im gewünschten Netzwerk.
-Zusätzlich musst du (bzw. der Administrator der Seite) einen API-Schlüssel holen, um einen authentifizierten Zugriff zu deinem Friendica-Server herstellen zu lassen.
-
+Alle diese Konnektoren erfordern einen Account im Zielnetzwerk.
+Außerdem musst du (oder die Server-Administration) in der Regel einen API-Schlüssel erhalten, um die Verbindung zu ermöglichen.
 
 **Seitenkonfiguration**
 
-Erweiterung müssen vom Administrator installiert werden, bevor sie genutzt werden können.
-Dieses kann über das Administrationsmenü erstellt werden.
+Konnektoren müssen von der Server-Administration installiert werden, bevor sie verwendet werden können.
+Dies geschieht über die Server-Verwaltung.
 
-Jeder der Konnektoren benötigt zudem einen API-Schlüssel vom Service, der verbunden werden soll.
-Einige Erweiterung erlaube es, diese Informationen auf den Administrationsseiten einzustellen, wohingegen andere eine direkte Bearbeitung der Konfigurationsdatei "config/local.config.php" erfordern.
-Der Weg, um diese Schlüssel zu erhalten, variiert stark, jedoch brauchen fast alle einen bestehenden Account im gewünschten Service.
-Einmal installiert, können diese Schlüssel von allen Seitennutzern genutzt werden.
+Einige der Konnektoren erfordern auch einen „API-Schlüssel“ des Dienstes, mit dem du dich verbinden möchtest.
+Für Tumblr findet man diese Informationen auf den Seiten der Server-Verwaltung, während für Twitter (X) jede Person einen eigenen API-Schlüssel erstellen muss.
+Andere Konnektoren, wie Bluesky, benötigen überhaupt keinen API-Schlüssel.
 
-Im Folgenden findest du die Einstellungen für die verschiedenen Services (viele dieser Informationen kommen direkt aus den Quelldateien der Erweiterung):
+Weitere Informationen zu den spezifischen Anforderungen findest du auf der Einstellungsseite des jeweiligen Addons, entweder auf der Verwaltungsseite oder auf der Benutzerseite.
 
+Bluesky Jetstream
+---
 
-**Twitter Erweiterung für Friendica**
+Um die Konnektivität mit Bluesky weiter zu verbessern, kann die „Jetstream“-Konnektivität aktiviert werden.
+Jetstream ist ein Dienst, der sich mit dem Bluesky-Firehose verbindet.
+Mit Jetstream kommen die Nachrichten in Echtzeit an und müssen nicht erst abgefragt werden.
+Es ermöglicht auch die Echtzeitverarbeitung von Blöcken oder Tracking-Aktivitäten, die über die Bluesky-Website oder -Anwendung durchgeführt werden.
 
-* Author: Tobias Diekershoff
-* tobias.diekershoff@gmx.net
+Um die Jetstream-Verarbeitung zu aktivieren, führe `bin/jetstream.php' über die Befehlszeile aus.
+Du musst vorher die Prozess-ID-Datei in local.config.php im Abschnitt „jetstream“ mit dem Schlüssel „pidfile“ definieren.
 
-* License:3-clause BSD license
-
-Konfiguration:
-Um dieses Erweiterung zu nutzen, benötigst du einen OAuth Consumer-Schlüsselpaar (Schlüssel und Geheimnis), das du auf der Seite [https://twitter.com/apps](https://twitter.com/apps) erhalten kannst
-
-Registriere deine Friendica-Seite als "Client"-Anwendung mit "Read&Write"-Zugriff. Wir benötigen "Twitter als Login" nicht. Sobald du deine Anwendung installiert hast, erhältst du das Schlüsselpaar für deine Seite.
-
-Trage dieses Schlüsselpaar in deine globale "config/local.config.php"-Datei ein.
-
-```
-[twitter]
-consumerkey = your consumer_key here
-consumersecret = your consumer_secret here
-```
-
-Anschließend kann der Nutzer deiner Seite die Twitter-Einstellungen selbst eintragen: "Einstellungen -> Connector Einstellungen".
-
-
-**GNU Social Erweiterung für Friendica**
-
-* Author: Tobias Diekershoff
-* tobias.diekershoff@gmx.net
-
-* License:3-clause BSD license
-
-Konfiguration
-
-Wenn das Addon aktiv ist, muss der Nutzer die folgenden Einstellungen vornehmen, um sich mit dem GNU Social-Account seiner Wahl zu verbinden.
-
-* Die Basis-URL des GNU Social-API; für quitter.se ist es https://quitter.se/api/
-* OAuth Consumer key & Geheimnis
-
-Um das OAuth-Schlüsselpaar zu erhalten, muss der Nutzer
-
-(a) seinen Friendica-Admin fragen, ob bereits ein Schlüsselpaar existiert oder
-(b) einen Friendica-Server als Anwendung auf dem GNU Social-Server anmelden.
-
-Dies kann über Einstellungen --> Connections --> "Register an OAuth client application" -> "Register a new application" auf dem GNU Social-Server durchgeführt werden.
-
-Während der Registrierung des OAuth-Clients ist Folgendes zu beachten:
-
-* Der Anwendungsname muss auf der GNU Social-Seite einzigartig sein, daher empfehlen wir einen Namen wie "friendica-nnnn", ersetze dabei "nnnn" mit einer frei gewählten Nummer oder deinem Webseitennamen.
-* es gibt keine Callback-URL
-* Registriere einen Desktop-Client
-* stelle Lese- und Schreibrechte ein
-* die Quell-URL sollte die URL deines Friendica-Servers sein
-
-Sobald die benötigten Daten gespeichert sind, musst du deinen Friendica-Account mit GNU Social verbinden.
-Das kannst du über Einstellungen --> Connector-Einstellungen durchführen.
-Folge dem "Einloggen mit GNU Social"-Button, erlaube den Zugriff und kopiere den Sicherheitscode in die entsprechende Box.
-Friendica wird dann versuchen, die abschließende OAuth-Einstellungen über die API zu beziehen.
-
-Wenn es geklappt hat, kannst du in den Einstellungen festlegen, ob deine öffentlichen Nachrichten automatisch in deinem GNU Social-Account erscheinen soll (achte hierbei auf das kleine Schloss-Symbol im Status-Editor)
+Um die verarbeiteten Nachrichten und die Drift (die Zeitdifferenz zwischen dem Datum der Nachricht und dem Datum, an dem das System diese Nachricht verarbeitet hat) zu verfolgen, wurden dem Statistik-Endpunkt einige Felder hinzugefügt.


### PR DESCRIPTION
GNU Social is removed from the documentation. Also documentation for the Bluesky jetstream is added.