### PR TITLE
Remove `DI::app()`

### DIFF
--- a/src/DI.php
+++ b/src/DI.php
@@ -71,16 +71,6 @@ abstract class DI
 	// common instances
 	//
 
-	/**
-	 * @deprecated 2024.12 use DI::appHelper() instead
-	 *
-	 * @return App
-	 */
-	public static function app()
-	{
-		return self::$dice->create(App::class);
-	}
-
 	public static function appHelper(): AppHelper
 	{
 		return self::$dice->create(AppHelper::class);


### PR DESCRIPTION
The last call of `DI::app()` was removed with #14603. This PR removes the now unused `DI::app()` method.