### PR TITLE
Refactor entrypoint in `index.php`

### DIFF
--- a/index.php
+++ b/index.php
@@ -18,14 +18,6 @@ require __DIR__ . '/vendor/autoload.php';
 $request = \GuzzleHttp\Psr7\ServerRequest::fromGlobals();
 
 $dice = (new Dice())->addRules(include __DIR__ . '/static/dependencies.config.php');
-/** @var \Friendica\Core\Addon\Capability\ICanLoadAddons $addonLoader */
-$addonLoader = $dice->create(\Friendica\Core\Addon\Capability\ICanLoadAddons::class);
-$dice = $dice->addRules($addonLoader->getActiveAddonConfig('dependencies'));
-$dice = $dice->addRule(Friendica\App\Mode::class, ['call' => [['determineRunMode', [false, $request->getServerParams()], Dice::CHAIN_CALL]]]);
-
-\Friendica\DI::init($dice);
-
-\Friendica\Core\Logger\Handler\ErrorHandler::register($dice->create(\Psr\Log\LoggerInterface::class));
 
 $a = \Friendica\App::fromDice($dice);
 

--- a/index.php
+++ b/index.php
@@ -19,6 +19,6 @@ $request = \GuzzleHttp\Psr7\ServerRequest::fromGlobals();
 
 $dice = (new Dice())->addRules(include __DIR__ . '/static/dependencies.config.php');
 
-$a = \Friendica\App::fromDice($dice);
+$app = \Friendica\App::fromDice($dice);
 
-$a->processRequest($request, $start_time);
+$app->processRequest($request, $start_time);

--- a/src/App.php
+++ b/src/App.php
@@ -123,6 +123,8 @@ class App
 	{
 		$this->setupContainerForRunningFrontend($request);
 
+		$this->registerErrorHandler();
+
 		$this->requestId = $this->container->create(Request::class)->getRequestId();
 		$this->auth      = $this->container->create(Authentication::class);
 		$this->config    = $this->container->create(IManageConfigValues::class);
@@ -167,7 +169,10 @@ class App
 		]);
 
 		\Friendica\DI::init($this->container);
+	}
 
+	private function registerErrorHandler(): void
+	{
 		\Friendica\Core\Logger\Handler\ErrorHandler::register($this->container->create(LoggerInterface::class));
 	}
 

--- a/src/App.php
+++ b/src/App.php
@@ -158,12 +158,17 @@ class App
 	{
 		/** @var \Friendica\Core\Addon\Capability\ICanLoadAddons $addonLoader */
 		$addonLoader = $this->container->create(\Friendica\Core\Addon\Capability\ICanLoadAddons::class);
+
 		$this->container = $this->container->addRules($addonLoader->getActiveAddonConfig('dependencies'));
-		$this->container = $this->container->addRule(\Friendica\App\Mode::class, ['call' => [['determineRunMode', [false, $request->getServerParams()], Dice::CHAIN_CALL]]]);
+		$this->container = $this->container->addRule(Mode::class, [
+			'call' => [
+				['determineRunMode', [false, $request->getServerParams()], Dice::CHAIN_CALL],
+			],
+		]);
 
 		\Friendica\DI::init($this->container);
 
-		\Friendica\Core\Logger\Handler\ErrorHandler::register($this->container->create(\Psr\Log\LoggerInterface::class));
+		\Friendica\Core\Logger\Handler\ErrorHandler::register($this->container->create(LoggerInterface::class));
 	}
 
 	/**


### PR DESCRIPTION
This PR refactors the entrypoint in the `index.php`. It moves most of the logic inside the App class to keep the `index.php` as entrypoint very simple. 

Goal of this PR is that we can load the app (`$app = \Friendica\App::fromDice($dice);`) with nearly no side effects.

In the next PRs I will refactor the other entrypoints by moving their logic into the App class as well. Then we have the code for every entrypoint in one place an can refactor this code more efficiently.