### PR TITLE
Repair schema.org context.

### DIFF
--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -227,6 +227,11 @@ class JsonLD
 				Logger::debug('schema.org path fixed');
 				$value = 'http://schema.org#';
 			}
+			// Issue 14630: Wordpress Event Bridge uses a URL that cannot be retrieved
+			if ($value == 'https://schema.org/') {
+				Logger::debug('https schema.org path fixed');
+				$value = 'https://schema.org/docs/jsonldcontext.json#';
+			}
 		});
 
 		// Bookwyrm transmits "id" fields with "null", which isn't allowed.

--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -228,7 +228,7 @@ class JsonLD
 				$value = 'http://schema.org#';
 			}
 			// Issue 14630: Wordpress Event Bridge uses a URL that cannot be retrieved
-			if ($value == 'https://schema.org/') {
+			if (is_int($key) && $value == 'https://schema.org/') {
 				Logger::debug('https schema.org path fixed');
 				$value = 'https://schema.org/docs/jsonldcontext.json#';
 			}


### PR DESCRIPTION
I find that when using Wordpress with the Event Bridge plugin, events are not received by Friendica.  This is due to an unretrievable context URL.  See discussion [here](https://friendica.exon.name/display/ec054ce7-8967-6e7d-b1e4-417848405890).