### PR TITLE
Fix duplicate SCOPE_WRITE check

### DIFF
--- a/src/Security/OAuth.php
+++ b/src/Security/OAuth.php
@@ -189,7 +189,7 @@ class OAuth
 			'created_at'     => DateTimeFormat::utcNow()
 		];
 
-		foreach ([BaseApi::SCOPE_READ, BaseApi::SCOPE_WRITE, BaseApi::SCOPE_WRITE, BaseApi::SCOPE_PUSH] as $scope) {
+		foreach ([BaseApi::SCOPE_READ, BaseApi::SCOPE_WRITE, BaseApi::SCOPE_FOLLOW, BaseApi::SCOPE_PUSH] as $scope) {
 			if ($fields[$scope] && !$application[$scope]) {
 				Logger::warning('Requested token scope is not allowed for the application', ['token' => $fields, 'application' => $application]);
 			}


### PR DESCRIPTION
It's pretty clear from context this is intended to be SCOPE_FOLLOW. It's been like this ever since it was introduced in revision 49207a862451057c7f195a17e4600ffe4b99eddc