### PR TITLE
[Vagrant] Upgrade & Fixup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ public_folder = "/vagrant"
 
 Vagrant.configure(2) do |config|
   # Set server to Debian 11 / Bullseye 64bit
-  config.vm.box = "debian/bullseye64"
+  config.vm.box = "debian/bookworm64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/bin/dev/vagrant_provision.sh
+++ b/bin/dev/vagrant_provision.sh
@@ -46,7 +46,7 @@ openssl x509 -req -days 365 -in "$SSL_DIR/xip.io.csr" -signkey "$SSL_DIR/xip.io.
 echo ">>> Add PHP repository"
 apt-get install -qq -y lsb-release ca-certificates apt-transport-https software-properties-common gnupg
 echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/sury-php.list
-wget -qO - https://packages.sury.org/php/apt.gpg | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/spotify.gpg
+wget -qO - https://packages.sury.org/php/apt.gpg | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/php.gpg
 apt update
 
 echo ">>> Installing PHP8"

--- a/bin/dev/vagrant_provision.sh
+++ b/bin/dev/vagrant_provision.sh
@@ -42,6 +42,18 @@ openssl genrsa -out "$SSL_DIR/xip.io.key" 4096
 openssl req -new -subj "$(echo -n "$SUBJ" | tr "\n" "/")" -key "$SSL_DIR/xip.io.key" -out "$SSL_DIR/xip.io.csr" -passin pass:$PASSPHRASE
 openssl x509 -req -days 365 -in "$SSL_DIR/xip.io.csr" -signkey "$SSL_DIR/xip.io.key" -out "$SSL_DIR/xip.io.crt"
 
+#Install php
+echo ">>> Add PHP repository"
+apt-get install -qq -y lsb-release ca-certificates apt-transport-https software-properties-common gnupg
+echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/sury-php.list
+wget -qO - https://packages.sury.org/php/apt.gpg | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/spotify.gpg
+apt update
+
+echo ">>> Installing PHP8"
+apt-get install -qq php libapache2-mod-php php8.3-cli php8.3-mysql php8.3-curl php8.3-gd php8.3-mbstring php8.3-xml imagemagick php8.3-imagick php8.3-zip php8.3-gmp php8.3-intl
+
+echo ">>> Installing PHP7"
+apt-get install -qq php7.4 php7.4-cli php7.4-mysql php7.4-curl php7.4-gd php7.4-mbstring php7.4-xml php7.4-imagick php7.4-zip php7.4-gmp php7.4-intl
 
 #Install apache2
 echo ">>> Installing Apache2 webserver"
@@ -52,19 +64,6 @@ chmod guo+x /usr/local/bin/vhost
 vhost -s 192.168.56.10.xip.io -d /var/www -p /etc/ssl/xip.io -c xip.io -a friendica.local
 a2dissite 000-default
 service apache2 restart
-
-#Install php
-echo ">>> Installing PHP7"
-apt-get install -qq php libapache2-mod-php php-cli php-mysql php-curl php-gd php-mbstring php-xml imagemagick php-imagick php-zip php-gmp php-intl
-systemctl restart apache2
-
-echo ">>> Installing PHP8"
-apt-get install -qq -y lsb-release ca-certificates apt-transport-https software-properties-common gnupg
-echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/sury-php.list
-wget -qO - https://packages.sury.org/php/apt.gpg | sudo apt-key add -
-apt update
-apt-get install -qq php8.0 php8.0-cli php8.0-mysql php8.0-curl php8.0-gd php8.0-mbstring php8.0-xml php8.0-imagick php8.0-zip php8.0-gmp php8.0-intl
-systemctl restart apache2
 
 #Install mysql
 echo ">>> Installing Mysql"

--- a/bin/dev/vagrant_provision.sh
+++ b/bin/dev/vagrant_provision.sh
@@ -55,7 +55,7 @@ service apache2 restart
 
 #Install php
 echo ">>> Installing PHP7"
-apt-get install -qq php libapache2-mod-php php-cli php-mysql php-curl php-gd php-mbstring php-xml imagemagick php-imagick php-zip php-gmp
+apt-get install -qq php libapache2-mod-php php-cli php-mysql php-curl php-gd php-mbstring php-xml imagemagick php-imagick php-zip php-gmp php-intl
 systemctl restart apache2
 
 echo ">>> Installing PHP8"
@@ -63,7 +63,7 @@ apt-get install -qq -y lsb-release ca-certificates apt-transport-https software-
 echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/sury-php.list
 wget -qO - https://packages.sury.org/php/apt.gpg | sudo apt-key add -
 apt update
-apt-get install -qq php8.0 php8.0-cli php8.0-mysql php8.0-curl php8.0-gd php8.0-mbstring php8.0-xml php8.0-imagick php8.0-zip php8.0-gmp
+apt-get install -qq php8.0 php8.0-cli php8.0-mysql php8.0-curl php8.0-gd php8.0-mbstring php8.0-xml php8.0-imagick php8.0-zip php8.0-gmp php8.0-intl
 systemctl restart apache2
 
 #Install mysql


### PR DESCRIPTION
Some Vagrant improvements

1. Upgrade to bookworm64
2. Use state-of-the-art method for adding GPG-keys
3. Install php7.4 explicit (default php switched to php8.3)
4. Install missing php-intl extension (otherwise autoinstall won't work anymore)
