### PR TITLE
Force exits in PushSubscription PUT, POST and DELETE handlers

### DIFF
--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -223,17 +223,17 @@ abstract class BaseModule implements ICanHandleRequests
 		switch ($this->args->getMethod()) {
 			case Router::DELETE:
 				$this->delete($request);
-				return $this->response->generate();
+				break;
 			case Router::PATCH:
 				$this->patch($request);
-				return $this->response->generate();
+				break;
 			case Router::POST:
 				Core\Hook::callAll($this->args->getModuleName() . '_mod_post', $request);
 				$this->post($request);
-				return $this->response->generate();
+				break;
 			case Router::PUT:
 				$this->put($request);
-				return $this->response->generate();
+				break;
 			case Router::GET:
 				$this->get($request);
 				break;

--- a/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
@@ -92,6 +92,6 @@ class UpdateCredentials extends BaseApi
 		}
 
 		$account = DI::mstdnAccount()->createFromContactId($ucid, $uid);
-		$this->response->addJsonContent($account->toArray());
+		$this->jsonExit($account->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/PushSubscription.php
+++ b/src/Module/Api/Mastodon/PushSubscription.php
@@ -66,7 +66,7 @@ class PushSubscription extends BaseApi
 		$this->logger->info('Subscription stored', ['ret' => $ret, 'subscription' => $subscription]);
 
 		$subscriptionObj = $this->subscriptionFac->createForApplicationIdAndUserId($application['id'], $uid);
-		$this->response->addJsonContent($subscriptionObj->toArray());
+		$this->jsonExit($subscriptionObj->toArray());
 	}
 
 	public function put(array $request = []): void
@@ -105,7 +105,7 @@ class PushSubscription extends BaseApi
 		]);
 
 		$subscriptionObj = $this->subscriptionFac->createForApplicationIdAndUserId($application['id'], $uid);
-		$this->response->addJsonContent($subscriptionObj->toArray());
+		$this->jsonExit($subscriptionObj->toArray());
 	}
 
 	private function setBoolean($input): bool
@@ -130,7 +130,7 @@ class PushSubscription extends BaseApi
 			'uid'            => $uid,
 		]);
 
-		$this->response->addJsonContent([]);
+		$this->jsonExit([]);
 	}
 
 	protected function get(array $request = []): void

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -165,7 +165,6 @@ class Install extends BaseModule
 
 				break;
 		}
-		DI::baseUrl()->redirect('install?pass=' . $this->currentWizardStep);
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -179,20 +179,20 @@ class Install extends BaseModule
 
 				$status = $this->installer->checkEnvironment($this->baseUrl, $php_path);
 
-				$tpl    = Renderer::getMarkupTemplate('install/01_checks.tpl');
+				$tpl = Renderer::getMarkupTemplate('install/01_checks.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
-					'$title'       => $install_title,
-					'$pass'        => $this->t('System check'),
-					'$required'    => $this->t('Required'),
-					'$requirement_not_satisfied' => $this->t('Requirement not satisfied'),
+					'$title'                              => $install_title,
+					'$pass'                               => $this->t('System check'),
+					'$required'                           => $this->t('Required'),
+					'$requirement_not_satisfied'          => $this->t('Requirement not satisfied'),
 					'$optional_requirement_not_satisfied' => $this->t('Optional requirement not satisfied'),
-					'$ok'          => $this->t('OK'),
-					'$checks'      => $this->installer->getChecks(),
-					'$passed'      => $status,
-					'$see_install' => $this->t('Please see the file "doc/INSTALL.md".'),
-					'$next'        => $this->t('Next'),
-					'$reload'      => $this->t('Check again'),
-					'$php_path'    => $php_path,
+					'$ok'                                 => $this->t('OK'),
+					'$checks'                             => $this->installer->getChecks(),
+					'$passed'                             => $status,
+					'$see_install'                        => $this->t('Please see the file "doc/INSTALL.md".'),
+					'$next'                               => $this->t('Next'),
+					'$reload'                             => $this->t('Check again'),
+					'$php_path'                           => $php_path,
 				]);
 				break;
 
@@ -201,62 +201,62 @@ class Install extends BaseModule
 					new Uri($this->configCache->get('system', 'url')) :
 					$this->baseUrl;
 
-				$tpl    = Renderer::getMarkupTemplate('install/02_base_config.tpl');
+				$tpl = Renderer::getMarkupTemplate('install/02_base_config.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
-					'$title'      => $install_title,
-					'$pass'       => $this->t('Base settings'),
-					'$basepath'   => ['system-basepath',
+					'$title'    => $install_title,
+					'$pass'     => $this->t('Base settings'),
+					'$basepath' => ['system-basepath',
 						$this->t("Base path to installation"),
 						$this->configCache->get('system', 'basepath'),
 						$this->t("If the system cannot detect the correct path to your installation, enter the correct path here. This setting should only be set if you are using a restricted system and symbolic links to your webroot."),
 						$this->t('Required')],
-					'$system_url'    => ['system-url',
+					'$system_url' => ['system-url',
 						$this->t('The Friendica system URL'),
 						(string)$baseUrl,
 						$this->t("Overwrite this field in case the system URL determination isn't right, otherwise leave it as is."),
 						$this->t('Required')],
-					'$php_path'   => $this->configCache->get('config', 'php_path'),
-					'$submit'     => $this->t('Submit'),
+					'$php_path' => $this->configCache->get('config', 'php_path'),
+					'$submit'   => $this->t('Submit'),
 				]);
 				break;
 
 			case self::DATABASE_CONFIG:
-				$tpl    = Renderer::getMarkupTemplate('install/03_database_config.tpl');
+				$tpl = Renderer::getMarkupTemplate('install/03_database_config.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
-					'$title'      => $install_title,
-					'$pass'       => $this->t('Database connection'),
-					'$info_01'    => $this->t('In order to install Friendica we need to know how to connect to your database.'),
-					'$info_02'    => $this->t('Please contact your hosting provider or site administrator if you have questions about these settings.'),
-					'$info_03'    => $this->t('The database you specify below should already exist. If it does not, please create it before continuing.'),
-					'$required'   => $this->t('Required'),
+					'$title'                     => $install_title,
+					'$pass'                      => $this->t('Database connection'),
+					'$info_01'                   => $this->t('In order to install Friendica we need to know how to connect to your database.'),
+					'$info_02'                   => $this->t('Please contact your hosting provider or site administrator if you have questions about these settings.'),
+					'$info_03'                   => $this->t('The database you specify below should already exist. If it does not, please create it before continuing.'),
+					'$required'                  => $this->t('Required'),
 					'$requirement_not_satisfied' => $this->t('Requirement not satisfied'),
-					'$checks'     => $this->installer->getChecks(),
-					'$basepath'   => $this->configCache->get('system', 'basepath'),
-					'$system_url' => $this->configCache->get('system', 'url'),
-					'$dbhost'     => ['database-hostname',
+					'$checks'                    => $this->installer->getChecks(),
+					'$basepath'                  => $this->configCache->get('system', 'basepath'),
+					'$system_url'                => $this->configCache->get('system', 'url'),
+					'$dbhost'                    => ['database-hostname',
 						$this->t('Database Server Name'),
 						$this->configCache->get('database', 'hostname'),
 						'',
 						$this->t('Required')],
-					'$dbuser'     => ['database-username',
+					'$dbuser' => ['database-username',
 						$this->t('Database Login Name'),
 						$this->configCache->get('database', 'username'),
 						'',
 						$this->t('Required'),
 						'autofocus'],
-					'$dbpass'     => ['database-password',
+					'$dbpass' => ['database-password',
 						$this->t('Database Login Password'),
 						$this->configCache->get('database', 'password'),
 						$this->t("For security reasons the password must not be empty"),
 						$this->t('Required')],
-					'$dbdata'     => ['database-database',
+					'$dbdata' => ['database-database',
 						$this->t('Database Name'),
 						$this->configCache->get('database', 'database'),
 						'',
 						$this->t('Required')],
-					'$lbl_10'     => $this->t('Please select a default timezone for your website'),
-					'$php_path'   => $this->configCache->get('config', 'php_path'),
-					'$submit'     => $this->t('Submit')
+					'$lbl_10'   => $this->t('Please select a default timezone for your website'),
+					'$php_path' => $this->configCache->get('config', 'php_path'),
+					'$submit'   => $this->t('Submit')
 				]);
 				break;
 
@@ -264,7 +264,7 @@ class Install extends BaseModule
 				/* Installed langs */
 				$lang_choices = $this->l10n->getAvailableLanguages();
 
-				$tpl    = Renderer::getMarkupTemplate('install/04_site_settings.tpl');
+				$tpl = Renderer::getMarkupTemplate('install/04_site_settings.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
 					'$title'      => $install_title,
 					'$required'   => $this->t('Required'),
@@ -281,17 +281,19 @@ class Install extends BaseModule
 						$this->configCache->get('config', 'admin_email'),
 						$this->t('Your account email address must match this in order to use the web admin panel.'),
 						$this->t('Required'), 'autofocus', 'email'],
-					'$timezone'   => Temporal::getTimezoneField('system-default_timezone',
+					'$timezone' => Temporal::getTimezoneField(
+						'system-default_timezone',
 						$this->t('Please select a default timezone for your website'),
 						$this->configCache->get('system', 'default_timezone'),
-						''),
-					'$language'   => ['system-language',
+						''
+					),
+					'$language' => ['system-language',
 						$this->t('System Language:'),
 						$this->configCache->get('system', 'language'),
 						$this->t('Set the default language for your Friendica installation interface and to send emails.'),
 						$lang_choices],
-					'$php_path'   => $this->configCache->get('config', 'php_path'),
-					'$submit'     => $this->t('Submit')
+					'$php_path' => $this->configCache->get('config', 'php_path'),
+					'$submit'   => $this->t('Submit')
 				]);
 				break;
 
@@ -299,19 +301,19 @@ class Install extends BaseModule
 				$db_return_text = "";
 
 				if (count($this->installer->getChecks()) == 0) {
-					$txt            = '<p style="font-size: 130%;">';
-					$txt            .= $this->t('Your Friendica site database has been installed.') . '<br />';
+					$txt = '<p style="font-size: 130%;">';
+					$txt .= $this->t('Your Friendica site database has been installed.') . '<br />';
 					$db_return_text .= $txt;
 				}
 
-				$tpl    = Renderer::getMarkupTemplate('install/05_finished.tpl');
+				$tpl = Renderer::getMarkupTemplate('install/05_finished.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
-					'$title'    => $install_title,
-					'$required' => $this->t('Required'),
+					'$title'                     => $install_title,
+					'$required'                  => $this->t('Required'),
 					'$requirement_not_satisfied' => $this->t('Requirement not satisfied'),
-					'$checks'   => $this->installer->getChecks(),
-					'$pass'     => $this->t('Installation finished'),
-					'$text'     => $db_return_text . $this->whatNext(),
+					'$checks'                    => $this->installer->getChecks(),
+					'$pass'                      => $this->t('Installation finished'),
+					'$text'                      => $db_return_text . $this->whatNext(),
 				]);
 
 				break;

--- a/src/Module/Settings/TwoFactor/AppSpecific.php
+++ b/src/Module/Settings/TwoFactor/AppSpecific.php
@@ -77,8 +77,7 @@ class AppSpecific extends BaseSettings
 						$this->baseUrl->redirect('settings/2fa/app_specific?t=' . self::getFormSecurityToken('settings_2fa_password'));
 					} else {
 						$this->appSpecificPassword = AppSpecificPassword::generateForUser($this->session->getLocalUserId(), $request['description'] ?? '');
-						$this->systemMessages->addInfo($this->t('New app-specific password generated: %s', $this->appSpecificPassword['plaintext_password']));
-						$this->baseUrl->redirect('settings/2fa/app_specific?t=' . self::getFormSecurityToken('settings_2fa_password'));
+						$this->systemMessages->addInfo($this->t('New app-specific password generated.'));
 					}
 
 					break;

--- a/src/Module/Settings/TwoFactor/AppSpecific.php
+++ b/src/Module/Settings/TwoFactor/AppSpecific.php
@@ -38,7 +38,7 @@ class AppSpecific extends BaseSettings
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
-		$this->pConfig = $pConfig;
+		$this->pConfig        = $pConfig;
 		$this->systemMessages = $systemMessages;
 
 		if (!$this->session->getLocalUserId()) {
@@ -81,7 +81,7 @@ class AppSpecific extends BaseSettings
 					}
 
 					break;
-				case 'revoke_all' :
+				case 'revoke_all':
 					AppSpecificPassword::deleteAllForUser($this->session->getLocalUserId());
 					$this->systemMessages->addInfo($this->t('App-specific passwords successfully revoked.'));
 					$this->baseUrl->redirect('settings/2fa/app_specific?t=' . self::getFormSecurityToken('settings_2fa_password'));
@@ -114,22 +114,22 @@ class AppSpecific extends BaseSettings
 			'$form_security_token'     => self::getFormSecurityToken('settings_2fa_app_specific'),
 			'$password_security_token' => self::getFormSecurityToken('settings_2fa_password'),
 
-			'$title'                  => $this->t('Two-factor app-specific passwords'),
-			'$help_label'             => $this->t('Help'),
-			'$message'                => $this->t('<p>App-specific passwords are randomly generated passwords used instead your regular password to authenticate your account on third-party applications that don\'t support two-factor authentication.</p>'),
-			'$generated_message'      => $this->t('Make sure to copy your new app-specific password now. You won’t be able to see it again!'),
+			'$title'                           => $this->t('Two-factor app-specific passwords'),
+			'$help_label'                      => $this->t('Help'),
+			'$message'                         => $this->t('<p>App-specific passwords are randomly generated passwords used instead your regular password to authenticate your account on third-party applications that don\'t support two-factor authentication.</p>'),
+			'$generated_message'               => $this->t('Make sure to copy your new app-specific password now. You won’t be able to see it again!'),
 			'$generated_app_specific_password' => $this->appSpecificPassword,
 
-			'$description_label'      => $this->t('Description'),
-			'$last_used_label'        => $this->t('Last Used'),
-			'$revoke_label'           => $this->t('Revoke'),
-			'$revoke_all_label'       => $this->t('Revoke All'),
+			'$description_label' => $this->t('Description'),
+			'$last_used_label'   => $this->t('Last Used'),
+			'$revoke_label'      => $this->t('Revoke'),
+			'$revoke_all_label'  => $this->t('Revoke All'),
 
-			'$app_specific_passwords' => $appSpecificPasswords,
-			'$generate_message'       => $this->t('When you generate a new app-specific password, you must use it right away, it will be shown to you once after you generate it.'),
-			'$generate_title'         => $this->t('Generate new app-specific password'),
+			'$app_specific_passwords'        => $appSpecificPasswords,
+			'$generate_message'              => $this->t('When you generate a new app-specific password, you must use it right away, it will be shown to you once after you generate it.'),
+			'$generate_title'                => $this->t('Generate new app-specific password'),
 			'$description_placeholder_label' => $this->t('Friendiqa on my Fairphone 2...'),
-			'$generate_label' => $this->t('Generate'),
+			'$generate_label'                => $this->t('Generate'),
 		]);
 	}
 }

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.02-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-01 23:33+0000\n"
+"POT-Creation-Date: 2025-01-04 20:55-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Map"
 msgstr ""
 
-#: src/App.php:397
+#: src/App.php:394
 msgid "Apologies but the website is unavailable at the moment."
 msgstr ""
 
@@ -765,15 +765,15 @@ msgstr ""
 msgid "No system theme config value set."
 msgstr ""
 
-#: src/BaseModule.php:393
+#: src/BaseModule.php:395
 msgid "The form security token was not correct. This probably happened because the form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
-#: src/BaseModule.php:420
+#: src/BaseModule.php:422
 msgid "All contacts"
 msgstr ""
 
-#: src/BaseModule.php:425 src/Content/Conversation/Factory/Channel.php:32
+#: src/BaseModule.php:427 src/Content/Conversation/Factory/Channel.php:32
 #: src/Content/Widget.php:254 src/Core/ACL.php:182 src/Module/Contact.php:395
 #: src/Module/Privacy/PermissionTooltip.php:150
 #: src/Module/Privacy/PermissionTooltip.php:172
@@ -781,16 +781,16 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: src/BaseModule.php:430 src/Content/Widget.php:255 src/Module/Contact.php:398
+#: src/BaseModule.php:432 src/Content/Widget.php:255 src/Module/Contact.php:398
 #: src/Module/Settings/Channels.php:145
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:435 src/Content/Widget.php:256 src/Module/Contact.php:401
+#: src/BaseModule.php:437 src/Content/Widget.php:256 src/Module/Contact.php:401
 msgid "Mutual friends"
 msgstr ""
 
-#: src/BaseModule.php:443
+#: src/BaseModule.php:445
 msgid "Common"
 msgstr ""
 
@@ -1835,7 +1835,7 @@ msgstr ""
 msgid "Create new group"
 msgstr ""
 
-#: src/Content/Item.php:322 src/Model/Item.php:3281
+#: src/Content/Item.php:322 src/Model/Item.php:3297
 msgid "event"
 msgstr ""
 
@@ -1843,7 +1843,7 @@ msgstr ""
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:331 src/Model/Item.php:3283
+#: src/Content/Item.php:331 src/Model/Item.php:3299
 #: src/Module/Post/Tag/Add.php:109
 msgid "photo"
 msgstr ""
@@ -2040,7 +2040,7 @@ msgid "Create an account"
 msgstr ""
 
 #: src/Content/Nav.php:247 src/Module/Help.php:53
-#: src/Module/Settings/TwoFactor/AppSpecific.php:119
+#: src/Module/Settings/TwoFactor/AppSpecific.php:118
 #: src/Module/Settings/TwoFactor/Index.php:125
 #: src/Module/Settings/TwoFactor/Recovery.php:96
 #: src/Module/Settings/TwoFactor/Verify.php:135 view/theme/vier/theme.php:228
@@ -2245,8 +2245,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:926 src/Model/Item.php:4080
-#: src/Model/Item.php:4086 src/Model/Item.php:4087
+#: src/Content/Text/BBCode.php:926 src/Model/Item.php:4096
+#: src/Model/Item.php:4102 src/Model/Item.php:4103
 msgid "Link to source"
 msgstr ""
 
@@ -2834,7 +2834,7 @@ msgstr ""
 msgid "Could not connect to database."
 msgstr ""
 
-#: src/Core/L10n.php:426 src/Model/Item.php:2324
+#: src/Core/L10n.php:426 src/Model/Item.php:2340
 msgid "Undetermined"
 msgstr ""
 
@@ -3376,92 +3376,92 @@ msgstr ""
 msgid "Happy Birthday %s"
 msgstr ""
 
-#: src/Model/Item.php:2331
+#: src/Model/Item.php:2347
 #, php-format
 msgid "%s (%s - %s): %s"
 msgstr ""
 
-#: src/Model/Item.php:2333
+#: src/Model/Item.php:2349
 #, php-format
 msgid "%s (%s): %s"
 msgstr ""
 
-#: src/Model/Item.php:2336
+#: src/Model/Item.php:2352
 #, php-format
 msgid ""
 "Detected languages in this post:\n"
 "%s"
 msgstr ""
 
-#: src/Model/Item.php:3285
+#: src/Model/Item.php:3301
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:3287
+#: src/Model/Item.php:3303
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:3290 src/Module/Post/Tag/Add.php:109
+#: src/Model/Item.php:3306 src/Module/Post/Tag/Add.php:109
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3463
+#: src/Model/Item.php:3479
 #, php-format
 msgid "%s is blocked"
 msgstr ""
 
-#: src/Model/Item.php:3465
+#: src/Model/Item.php:3481
 #, php-format
 msgid "%s is ignored"
 msgstr ""
 
-#: src/Model/Item.php:3467
+#: src/Model/Item.php:3483
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:3471
+#: src/Model/Item.php:3487
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3980
+#: src/Model/Item.php:3996
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:4011
+#: src/Model/Item.php:4027
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:4013
+#: src/Model/Item.php:4029
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:4018
+#: src/Model/Item.php:4034
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:4020
+#: src/Model/Item.php:4036
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:4022
+#: src/Model/Item.php:4038
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:4063 src/Model/Item.php:4064
+#: src/Model/Item.php:4079 src/Model/Item.php:4080
 msgid "View on separate page"
 msgstr ""
 
@@ -9544,7 +9544,7 @@ msgstr ""
 
 #: src/Module/Settings/Channels.php:177 src/Module/Settings/Channels.php:198
 #: src/Module/Settings/Display.php:350
-#: src/Module/Settings/TwoFactor/AppSpecific.php:124
+#: src/Module/Settings/TwoFactor/AppSpecific.php:123
 msgid "Description"
 msgstr ""
 
@@ -10446,55 +10446,54 @@ msgid "App-specific password generation failed: This description already exists.
 msgstr ""
 
 #: src/Module/Settings/TwoFactor/AppSpecific.php:80
-#, php-format
-msgid "New app-specific password generated: %s"
+msgid "New app-specific password generated."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:87
+#: src/Module/Settings/TwoFactor/AppSpecific.php:86
 msgid "App-specific passwords successfully revoked."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:97
+#: src/Module/Settings/TwoFactor/AppSpecific.php:96
 msgid "App-specific password successfully revoked."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:118
+#: src/Module/Settings/TwoFactor/AppSpecific.php:117
 msgid "Two-factor app-specific passwords"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:120
+#: src/Module/Settings/TwoFactor/AppSpecific.php:119
 msgid "<p>App-specific passwords are randomly generated passwords used instead your regular password to authenticate your account on third-party applications that don't support two-factor authentication.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:121
+#: src/Module/Settings/TwoFactor/AppSpecific.php:120
 msgid "Make sure to copy your new app-specific password now. You won’t be able to see it again!"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:125
+#: src/Module/Settings/TwoFactor/AppSpecific.php:124
 msgid "Last Used"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:126
+#: src/Module/Settings/TwoFactor/AppSpecific.php:125
 msgid "Revoke"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:127
+#: src/Module/Settings/TwoFactor/AppSpecific.php:126
 msgid "Revoke All"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:130
+#: src/Module/Settings/TwoFactor/AppSpecific.php:129
 msgid "When you generate a new app-specific password, you must use it right away, it will be shown to you once after you generate it."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:131
+#: src/Module/Settings/TwoFactor/AppSpecific.php:130
 msgid "Generate new app-specific password"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:132
+#: src/Module/Settings/TwoFactor/AppSpecific.php:131
 msgid "Friendiqa on my Fairphone 2..."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/AppSpecific.php:133
+#: src/Module/Settings/TwoFactor/AppSpecific.php:132
 msgid "Generate"
 msgstr ""
 


### PR DESCRIPTION
Fix #14325
Fix #14450 
Fix #14469
Reverts #14326
Reverts #14484
Reverts #14530

I decided to revisit #14326 which seemed too extensive to me given the localized issue it was trying to fix. In particular, it was meant to address `rawContent()` but it affected `content()` as well which we expected to be able to be called after a successful call to `post()`, which prompted the subsequent #14484 and #14530 quick fixes.

Instead, I fixed the original issue reported in #14325 which concerns only a couple modules. If PUT, PATCH, POST and DELETE handlers set their own data, then they must exit themselves through `BaseModule->httpExit()` or `BaseModule->jsonExit()` in this case.

An earlier version of this PR tried to fiddle with the `BaseModule->run` order of operations, but it tripped the `Options` module that should execute `rawContent` in a non-GET context. Thanks to @nupplaphil for providing a crucial unit test to avoid a collateral issue with my naive fix.

Also thanks to @bmillwood for digging up the cause of the issue they reported, it proved crucial to provide a simple solution to the UX problem caused by #14326