### PR TITLE
Refactor Container and App class

### DIFF
--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -48,7 +48,7 @@ chdir(dirname(__DIR__));
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$container = \Friendica\Core\Container::fromBasePath(dirname(__DIR__));
+$container = \Friendica\Core\DiceContainer::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 

--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -44,15 +44,12 @@ if (php_sapi_name() !== 'cli') {
 	exit();
 }
 
-use Dice\Dice;
+chdir(dirname(__DIR__));
 
-chdir(dirname(__FILE__, 2));
+require dirname(__DIR__) . '/vendor/autoload.php';
 
-require dirname(__FILE__, 2) . '/vendor/autoload.php';
+$container = \Friendica\Core\Container::fromBasePath(dirname(__DIR__));
 
-$dice = (new Dice())->addRules(require(dirname(__FILE__, 2) . '/static/dependencies.config.php'));
-
-$container = \Friendica\Core\Container::fromDice($dice);
-$app       = \Friendica\App::fromContainer($container);
+$app = \Friendica\App::fromContainer($container);
 
 $app->processEjabberd();

--- a/bin/console.php
+++ b/bin/console.php
@@ -13,13 +13,9 @@ if (php_sapi_name() !== 'cli') {
 	exit();
 }
 
-use Dice\Dice;
-
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$dice = (new Dice())->addRules(require(dirname(__DIR__) . '/static/dependencies.config.php'));
-
-$container = \Friendica\Core\Container::fromDice($dice);
+$container = \Friendica\Core\Container::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 

--- a/bin/console.php
+++ b/bin/console.php
@@ -15,7 +15,7 @@ if (php_sapi_name() !== 'cli') {
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$container = \Friendica\Core\Container::fromBasePath(dirname(__DIR__));
+$container = \Friendica\Core\DiceContainer::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 

--- a/bin/console.php
+++ b/bin/console.php
@@ -20,4 +20,7 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 $dice = (new Dice())->addRules(require(dirname(__DIR__) . '/static/dependencies.config.php'));
 
 $container = \Friendica\Core\Container::fromDice($dice);
-\Friendica\Core\Console::create($container, $_SERVER['argv'] ?? [])->execute();
+
+$app = \Friendica\App::fromContainer($container);
+
+$app->processConsole($_SERVER['argv'] ?? []);

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -32,4 +32,7 @@ $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "daemon");
 
 $container = \Friendica\Core\Container::fromDice($dice);
-\Friendica\Core\Console::create($container, $argv)->execute();
+
+$app = \Friendica\App::fromContainer($container);
+
+$app->processConsole($argv);

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -19,19 +19,15 @@ if (php_sapi_name() !== 'cli') {
 	exit();
 }
 
-use Dice\Dice;
-
 // Ensure that daemon.php is executed from the base path of the installation
 chdir(dirname(__DIR__));
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$dice = (new Dice())->addRules(require(dirname(__DIR__) . '/static/dependencies.config.php'));
-
 $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "daemon");
 
-$container = \Friendica\Core\Container::fromDice($dice);
+$container = \Friendica\Core\Container::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -27,7 +27,7 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "daemon");
 
-$container = \Friendica\Core\Container::fromBasePath(dirname(__DIR__));
+$container = \Friendica\Core\DiceContainer::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 

--- a/bin/jetstream.php
+++ b/bin/jetstream.php
@@ -27,4 +27,7 @@ $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "jetstream");
 
 $container = \Friendica\Core\Container::fromDice($dice);
-\Friendica\Core\Console::create($container, $argv)->execute();
+
+$app = \Friendica\App::fromContainer($container);
+
+$app->processConsole($argv);

--- a/bin/jetstream.php
+++ b/bin/jetstream.php
@@ -9,8 +9,6 @@
  * @deprecated 2025.02 use bin/console.php jetstream instead
  */
 
-use Dice\Dice;
-
 if (php_sapi_name() !== 'cli') {
 	header($_SERVER["SERVER_PROTOCOL"] . ' 403 Forbidden');
 	exit();
@@ -21,12 +19,10 @@ chdir(dirname(__DIR__));
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$dice = (new Dice())->addRules(require(dirname(__DIR__) . '/static/dependencies.config.php'));
-
 $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "jetstream");
 
-$container = \Friendica\Core\Container::fromDice($dice);
+$container = \Friendica\Core\Container::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 

--- a/bin/jetstream.php
+++ b/bin/jetstream.php
@@ -22,7 +22,7 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "jetstream");
 
-$container = \Friendica\Core\Container::fromBasePath(dirname(__DIR__));
+$container = \Friendica\Core\DiceContainer::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -29,4 +29,7 @@ $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "worker");
 
 $container = \Friendica\Core\Container::fromDice($dice);
-\Friendica\Core\Console::create($container, $argv)->execute();
+
+$app = \Friendica\App::fromContainer($container);
+
+$app->processConsole($argv);

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -16,19 +16,15 @@ if (php_sapi_name() !== 'cli') {
 	exit();
 }
 
-use Dice\Dice;
-
 // Ensure that worker.php is executed from the base path of the installation
 chdir(dirname(__DIR__));
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$dice = (new Dice())->addRules(require(dirname(__DIR__) . '/static/dependencies.config.php'));
-
 $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "worker");
 
-$container = \Friendica\Core\Container::fromDice($dice);
+$container = \Friendica\Core\Container::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -24,7 +24,7 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "worker");
 
-$container = \Friendica\Core\Container::fromBasePath(dirname(__DIR__));
+$container = \Friendica\Core\DiceContainer::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 

--- a/index.php
+++ b/index.php
@@ -5,8 +5,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use Dice\Dice;
-
 $start_time = microtime(true);
 
 if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
@@ -17,9 +15,7 @@ require __DIR__ . '/vendor/autoload.php';
 
 $request = \GuzzleHttp\Psr7\ServerRequest::fromGlobals();
 
-$dice = (new Dice())->addRules(require(__DIR__ . '/static/dependencies.config.php'));
-
-$container = \Friendica\Core\Container::fromDice($dice);
+$container = \Friendica\Core\Container::fromBasePath(__DIR__);
 $app       = \Friendica\App::fromContainer($container);
 
 $app->processRequest($request, $start_time);

--- a/index.php
+++ b/index.php
@@ -15,7 +15,8 @@ require __DIR__ . '/vendor/autoload.php';
 
 $request = \GuzzleHttp\Psr7\ServerRequest::fromGlobals();
 
-$container = \Friendica\Core\Container::fromBasePath(__DIR__);
-$app       = \Friendica\App::fromContainer($container);
+$container = \Friendica\Core\DiceContainer::fromBasePath(__DIR__);
+
+$app = \Friendica\App::fromContainer($container);
 
 $app->processRequest($request, $start_time);

--- a/src/App.php
+++ b/src/App.php
@@ -138,7 +138,9 @@ class App
 
 		$this->setupContainerForAddons();
 
-		$this->container->setup(LogChannel::APP);
+		$this->setupContainerForLogger(LogChannel::APP);
+
+		$this->container->setup();
 
 		$this->registerErrorHandler();
 
@@ -178,6 +180,10 @@ class App
 	{
 		$this->setupContainerForAddons();
 
+		$this->setupContainerForLogger($this->determineLogChannel($argv));
+
+		$this->container->setup();
+
 		$this->registerErrorHandler();
 
 		$this->registerTemplateEngine();
@@ -189,7 +195,9 @@ class App
 	{
 		$this->setupContainerForAddons();
 
-		$this->container->setup(LogChannel::AUTH_JABBERED);
+		$this->setupContainerForLogger(LogChannel::AUTH_JABBERED);
+
+		$this->container->setup();
 
 		$this->registerErrorHandler();
 
@@ -216,6 +224,30 @@ class App
 		foreach ($addonLoader->getActiveAddonConfig('dependencies') as $name => $rule) {
 			$this->container->addRule($name, $rule);
 		}
+	}
+
+	private function determineLogChannel(array $argv): string
+	{
+		$command = strtolower($argv[1]) ?? '';
+
+		if ($command === 'daemon' || $command === 'jetstream') {
+			return LogChannel::DAEMON;
+		}
+
+		if ($command === 'worker') {
+			return LogChannel::WORKER;
+		}
+
+		// @TODO Add support for jetstream
+
+		return LogChannel::CONSOLE;
+	}
+
+	private function setupContainerForLogger(string $logChannel): void
+	{
+		$this->container->addRule(LoggerInterface::class, [
+			'constructParams' => [$logChannel],
+		]);
 	}
 
 	private function registerErrorHandler(): void

--- a/src/App.php
+++ b/src/App.php
@@ -29,6 +29,7 @@ use Friendica\Security\Authentication;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger\Capability\LogChannel;
+use Friendica\Core\Logger\Handler\ErrorHandler;
 use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
 use Friendica\Core\System;
 use Friendica\Core\Update;
@@ -137,7 +138,9 @@ class App
 
 		$this->setupContainerForAddons();
 
-		$this->container->setup(LogChannel::APP, false);
+		$this->container->setup(LogChannel::APP);
+
+		$this->registerErrorHandler();
 
 		$this->requestId = $this->container->create(Request::class)->getRequestId();
 		$this->auth      = $this->container->create(Authentication::class);
@@ -175,6 +178,8 @@ class App
 	{
 		$this->setupContainerForAddons();
 
+		$this->registerErrorHandler();
+
 		$this->registerTemplateEngine();
 
 		(\Friendica\Core\Console::create($this->container, $argv))->execute();
@@ -184,9 +189,9 @@ class App
 	{
 		$this->setupContainerForAddons();
 
-		$this->container->setup(LogChannel::AUTH_JABBERED, false);
+		$this->container->setup(LogChannel::AUTH_JABBERED);
 
-		$this->registerTemplateEngine();
+		$this->registerErrorHandler();
 
 		/** @var BasePath */
 		$basePath = $this->container->create(BasePath::class);
@@ -211,6 +216,11 @@ class App
 		foreach ($addonLoader->getActiveAddonConfig('dependencies') as $name => $rule) {
 			$this->container->addRule($name, $rule);
 		}
+	}
+
+	private function registerErrorHandler(): void
+	{
+		ErrorHandler::register($this->container->create(LoggerInterface::class));
 	}
 
 	private function registerTemplateEngine(): void

--- a/src/App.php
+++ b/src/App.php
@@ -168,6 +168,11 @@ class App
 		);
 	}
 
+	public function processConsole(array $argv): void
+	{
+		(\Friendica\Core\Console::create($this->container, $argv))->execute();
+	}
+
 	public function processEjabberd(): void
 	{
 		$this->container->setup(LogChannel::AUTH_JABBERED, false);

--- a/src/App.php
+++ b/src/App.php
@@ -27,6 +27,7 @@ use Friendica\Database\Definition\ViewDefinition;
 use Friendica\Module\Maintenance;
 use Friendica\Security\Authentication;
 use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\DiceContainer;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger\Capability\LogChannel;
 use Friendica\Core\Logger\Handler\ErrorHandler;
@@ -140,7 +141,7 @@ class App
 
 		$this->setupContainerForLogger(LogChannel::APP);
 
-		$this->container->setup();
+		$this->setupLegacyServiceLocator();
 
 		$this->registerErrorHandler();
 
@@ -182,7 +183,7 @@ class App
 
 		$this->setupContainerForLogger($this->determineLogChannel($argv));
 
-		$this->container->setup();
+		$this->setupLegacyServiceLocator();
 
 		$this->registerErrorHandler();
 
@@ -197,7 +198,7 @@ class App
 
 		$this->setupContainerForLogger(LogChannel::AUTH_JABBERED);
 
-		$this->container->setup();
+		$this->setupLegacyServiceLocator();
 
 		$this->registerErrorHandler();
 
@@ -248,6 +249,13 @@ class App
 		$this->container->addRule(LoggerInterface::class, [
 			'constructParams' => [$logChannel],
 		]);
+	}
+
+	private function setupLegacyServiceLocator(): void
+	{
+		if ($this->container instanceof DiceContainer) {
+			DI::init($this->container->getDice());
+		}
 	}
 
 	private function registerErrorHandler(): void

--- a/src/App.php
+++ b/src/App.php
@@ -175,6 +175,8 @@ class App
 	{
 		$this->setupContainerForAddons();
 
+		$this->registerTemplateEngine();
+
 		(\Friendica\Core\Console::create($this->container, $argv))->execute();
 	}
 
@@ -183,6 +185,8 @@ class App
 		$this->setupContainerForAddons();
 
 		$this->container->setup(LogChannel::AUTH_JABBERED, false);
+
+		$this->registerTemplateEngine();
 
 		/** @var BasePath */
 		$basePath = $this->container->create(BasePath::class);

--- a/src/Console/AbstractConsole.php
+++ b/src/Console/AbstractConsole.php
@@ -32,7 +32,7 @@ abstract class AbstractConsole extends Console
 	 */
 	protected function checkDeprecated(string $command): void
 	{
-		if (substr($this->executable, -strlen(CoreConsole::getDefaultExecutable())) === CoreConsole::getDefaultExecutable()) {
+		if (substr($this->executable, -strlen(CoreConsole::getDefaultExecutable())) !== CoreConsole::getDefaultExecutable()) {
 			$this->out(sprintf("'%s' is deprecated and will removed. Please use 'bin/console.php %s' instead", $this->executable, $command));
 		}
 	}

--- a/src/Core/Console.php
+++ b/src/Core/Console.php
@@ -9,7 +9,6 @@ namespace Friendica\Core;
 
 use Friendica;
 use Friendica\App;
-use Friendica\Core\Logger\Capability\LogChannel;
 
 /**
  * Description of Console

--- a/src/Core/Console.php
+++ b/src/Core/Console.php
@@ -187,12 +187,6 @@ HELP;
 
 		$className = $this->subConsoles[$command];
 
-		if (is_subclass_of($className, Friendica\Console\AbstractConsole::class)) {
-			$this->container->setup($className::LOG_CHANNEL);
-		} else {
-			$this->container->setup(LogChannel::CONSOLE);
-		}
-
 		/** @var Console $subconsole */
 		$subconsole = $this->container->create($className, [$subargs]);
 

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -19,11 +19,9 @@ interface Container
 	 *
 	 * @deprecated
 	 *
-	 * @param string $logChannel The Log Channel of this call
-	 *
 	 * @return void
 	 */
-	public function setup(string $logChannel): void;
+	public function setup(): void;
 
 	/**
 	 * Returns a fully constructed object based on $name using $args and $share as constructor arguments if supplied

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace Friendica\Core;
 
-use Friendica\Core\Logger\Capability\LogChannel;
-
 /**
  * Dependency Injection Container
  */
@@ -25,7 +23,7 @@ interface Container
 	 *
 	 * @return void
 	 */
-	public function setup(string $logChannel = LogChannel::DEFAULT): void;
+	public function setup(string $logChannel): void;
 
 	/**
 	 * Returns a fully constructed object based on $name using $args and $share as constructor arguments if supplied

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -19,6 +19,8 @@ interface Container
 	/**
 	 * Initialize the container with the given parameters
 	 *
+	 * @deprecated
+	 *
 	 * @param string $logChannel The Log Channel of this call
 	 * @param bool   $withTemplateEngine true, if the template engine should be set too
 	 *

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -15,15 +15,6 @@ namespace Friendica\Core;
 interface Container
 {
 	/**
-	 * Initialize the container with the given parameters
-	 *
-	 * @deprecated
-	 *
-	 * @return void
-	 */
-	public function setup(): void;
-
-	/**
 	 * Returns a fully constructed object based on $name using $args and $share as constructor arguments if supplied
 	 * @param string $name  name The name of the class to instantiate
 	 * @param array  $args  An array with any additional arguments to be passed into the constructor upon instantiation

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -22,11 +22,10 @@ interface Container
 	 * @deprecated
 	 *
 	 * @param string $logChannel The Log Channel of this call
-	 * @param bool   $withTemplateEngine true, if the template engine should be set too
 	 *
 	 * @return void
 	 */
-	public function setup(string $logChannel = LogChannel::DEFAULT, bool $withTemplateEngine = true): void;
+	public function setup(string $logChannel = LogChannel::DEFAULT): void;
 
 	/**
 	 * Returns a fully constructed object based on $name using $args and $share as constructor arguments if supplied

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -21,9 +21,18 @@ use Psr\Log\LoggerInterface;
  */
 class Container
 {
+	public static function fromBasePath(string $basePath): self
+	{
+		$path = $basePath . '/static/dependencies.config.php';
+
+		$dice = (new Dice())->addRules(require($path));
+
+		return static::fromDice($dice);
+	}
+
 	private Dice $container;
 
-	protected function __construct(Dice $container)
+	private function __construct(Dice $container)
 	{
 		$this->container = $container;
 	}

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Friendica\Core;
 
 use Dice\Dice;
-use Friendica\Core\Addon\Capability\ICanLoadAddons;
 use Friendica\Core\Logger\Capability\LogChannel;
 use Friendica\Core\Logger\Handler\ErrorHandler;
 use Friendica\DI;
@@ -43,19 +42,14 @@ final class DiceContainer implements Container
 	 * @deprecated
 	 *
 	 * @param string $logChannel The Log Channel of this call
-	 * @param bool   $withTemplateEngine true, if the template engine should be set too
 	 *
 	 * @return void
 	 */
-	public function setup(string $logChannel = LogChannel::DEFAULT, bool $withTemplateEngine = true): void
+	public function setup(string $logChannel = LogChannel::DEFAULT): void
 	{
 		$this->setupContainerForLogger($logChannel);
 		$this->setupLegacyServiceLocator();
 		$this->registerErrorHandler();
-
-		if ($withTemplateEngine) {
-			$this->registerTemplateEngine();
-		}
 	}
 
 	/**
@@ -99,10 +93,5 @@ final class DiceContainer implements Container
 	private function registerErrorHandler(): void
 	{
 		ErrorHandler::register($this->container->create(LoggerInterface::class));
-	}
-
-	private function registerTemplateEngine(): void
-	{
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
 	}
 }

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -49,7 +49,6 @@ final class DiceContainer implements Container
 	 */
 	public function setup(string $logChannel = LogChannel::DEFAULT, bool $withTemplateEngine = true): void
 	{
-		$this->setupContainerForAddons();
 		$this->setupContainerForLogger($logChannel);
 		$this->setupLegacyServiceLocator();
 		$this->registerErrorHandler();
@@ -83,14 +82,6 @@ final class DiceContainer implements Container
 	public function addRule(string $name, array $rule): void
 	{
 		$this->container = $this->container->addRule($name, $rule);
-	}
-
-	private function setupContainerForAddons(): void
-	{
-		/** @var ICanLoadAddons $addonLoader */
-		$addonLoader = $this->container->create(ICanLoadAddons::class);
-
-		$this->container = $this->container->addRules($addonLoader->getActiveAddonConfig('dependencies'));
 	}
 
 	private function setupContainerForLogger(string $logChannel): void

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -40,6 +40,8 @@ final class DiceContainer implements Container
 	/**
 	 * Initialize the container with the given parameters
 	 *
+	 * @deprecated
+	 *
 	 * @param string $logChannel The Log Channel of this call
 	 * @param bool   $withTemplateEngine true, if the template engine should be set too
 	 *

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -33,18 +33,6 @@ final class DiceContainer implements Container
 	}
 
 	/**
-	 * Initialize the container with the given parameters
-	 *
-	 * @deprecated
-	 *
-	 * @return void
-	 */
-	public function setup(): void
-	{
-		// this method can be removed
-	}
-
-	/**
 	 * Returns a fully constructed object based on $name using $args and $share as constructor arguments if supplied
 	 * @param string $name  name The name of the class to instantiate
 	 * @param array  $args  An array with any additional arguments to be passed into the constructor upon instantiation

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -11,7 +11,6 @@ namespace Friendica\Core;
 
 use Dice\Dice;
 use Friendica\DI;
-use Psr\Log\LoggerInterface;
 
 /**
  * Wrapper for the Dice class to make some basic setups
@@ -39,13 +38,10 @@ final class DiceContainer implements Container
 	 *
 	 * @deprecated
 	 *
-	 * @param string $logChannel The Log Channel of this call
-	 *
 	 * @return void
 	 */
-	public function setup(string $logChannel): void
+	public function setup(): void
 	{
-		$this->setupContainerForLogger($logChannel);
 		$this->setupLegacyServiceLocator();
 	}
 
@@ -73,13 +69,6 @@ final class DiceContainer implements Container
 	public function addRule(string $name, array $rule): void
 	{
 		$this->container = $this->container->addRule($name, $rule);
-	}
-
-	private function setupContainerForLogger(string $logChannel): void
-	{
-		$this->container = $this->container->addRule(LoggerInterface::class, [
-			'constructParams' => [$logChannel],
-		]);
 	}
 
 	private function setupLegacyServiceLocator(): void

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Friendica\Core;
 
 use Dice\Dice;
-use Friendica\Core\Logger\Capability\LogChannel;
 use Friendica\DI;
 use Psr\Log\LoggerInterface;
 
@@ -44,7 +43,7 @@ final class DiceContainer implements Container
 	 *
 	 * @return void
 	 */
-	public function setup(string $logChannel = LogChannel::DEFAULT): void
+	public function setup(string $logChannel): void
 	{
 		$this->setupContainerForLogger($logChannel);
 		$this->setupLegacyServiceLocator();

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -11,7 +11,6 @@ namespace Friendica\Core;
 
 use Dice\Dice;
 use Friendica\Core\Logger\Capability\LogChannel;
-use Friendica\Core\Logger\Handler\ErrorHandler;
 use Friendica\DI;
 use Psr\Log\LoggerInterface;
 
@@ -49,7 +48,6 @@ final class DiceContainer implements Container
 	{
 		$this->setupContainerForLogger($logChannel);
 		$this->setupLegacyServiceLocator();
-		$this->registerErrorHandler();
 	}
 
 	/**
@@ -88,10 +86,5 @@ final class DiceContainer implements Container
 	private function setupLegacyServiceLocator(): void
 	{
 		DI::init($this->container);
-	}
-
-	private function registerErrorHandler(): void
-	{
-		ErrorHandler::register($this->container->create(LoggerInterface::class));
 	}
 }

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Friendica\Core;
 
 use Dice\Dice;
-use Friendica\DI;
 
 /**
  * Wrapper for the Dice class to make some basic setups
@@ -42,7 +41,7 @@ final class DiceContainer implements Container
 	 */
 	public function setup(): void
 	{
-		$this->setupLegacyServiceLocator();
+		// this method can be removed
 	}
 
 	/**
@@ -71,8 +70,17 @@ final class DiceContainer implements Container
 		$this->container = $this->container->addRule($name, $rule);
 	}
 
-	private function setupLegacyServiceLocator(): void
+	/**
+	 * Only used to inject Dice into DI class
+	 *
+	 * @see \Friendica\DI
+	 *
+	 * @internal
+	 *
+	 * @deprecated
+	 */
+	public function getDice(): Dice
 	{
-		DI::init($this->container);
+		return $this->container;
 	}
 }

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -1,0 +1,127 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Core;
+
+use Dice\Dice;
+use Friendica\Core\Addon\Capability\ICanLoadAddons;
+use Friendica\Core\Logger\Capability\LogChannel;
+use Friendica\Core\Logger\Handler\ErrorHandler;
+use Friendica\DI;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Wrapper for the Dice class to make some basic setups
+ */
+final class DiceContainer implements Container
+{
+	public static function fromBasePath(string $basePath): self
+	{
+		$path = $basePath . '/static/dependencies.config.php';
+
+		$dice = (new Dice())->addRules(require($path));
+
+		return static::fromDice($dice);
+	}
+
+	private Dice $container;
+
+	private function __construct(Dice $container)
+	{
+		$this->container = $container;
+	}
+
+	/**
+	 * Creates an instance with Dice
+	 *
+	 * @param Dice $container
+	 *
+	 * @return self
+	 */
+	public static function fromDice(Dice $container): self
+	{
+		return new self($container);
+	}
+
+	/**
+	 * Initialize the container with the given parameters
+	 *
+	 * @param string $logChannel The Log Channel of this call
+	 * @param bool   $withTemplateEngine true, if the template engine should be set too
+	 *
+	 * @return void
+	 */
+	public function setup(string $logChannel = LogChannel::DEFAULT, bool $withTemplateEngine = true): void
+	{
+		$this->setupContainerForAddons();
+		$this->setupContainerForLogger($logChannel);
+		$this->setupLegacyServiceLocator();
+		$this->registerErrorHandler();
+
+		if ($withTemplateEngine) {
+			$this->registerTemplateEngine();
+		}
+	}
+
+	/**
+	 * Returns a fully constructed object based on $name using $args and $share as constructor arguments if supplied
+	 * @param string $name  name The name of the class to instantiate
+	 * @param array  $args  An array with any additional arguments to be passed into the constructor upon instantiation
+	 * @param array  $share a list of defined in shareInstances for objects higher up the object graph, should only be used internally
+	 * @return object A fully constructed object based on the specified input arguments
+	 *
+	 * @see Dice::create()
+	 */
+	public function create(string $name, array $args = [], array $share = []): object
+	{
+		return $this->container->create($name, $args, $share);
+	}
+
+	/**
+	 * Add a rule $rule to the class $name
+	 * @param string $name The name of the class to add the rule for
+	 * @param array  $rule The container can be fully configured using rules provided by associative arrays. See {@link https://r.je/dice.html#example3} for a description of the rules.
+	 *
+	 * @see Dice::addRule()
+	 */
+	public function addRule(string $name, array $rule): void
+	{
+		$this->container = $this->container->addRule($name, $rule);
+	}
+
+	private function setupContainerForAddons(): void
+	{
+		/** @var ICanLoadAddons $addonLoader */
+		$addonLoader = $this->container->create(ICanLoadAddons::class);
+
+		$this->container = $this->container->addRules($addonLoader->getActiveAddonConfig('dependencies'));
+	}
+
+	private function setupContainerForLogger(string $logChannel): void
+	{
+		$this->container = $this->container->addRule(LoggerInterface::class, [
+			'constructParams' => [$logChannel],
+		]);
+	}
+
+	private function setupLegacyServiceLocator(): void
+	{
+		DI::init($this->container);
+	}
+
+	private function registerErrorHandler(): void
+	{
+		ErrorHandler::register($this->container->create(LoggerInterface::class));
+	}
+
+	private function registerTemplateEngine(): void
+	{
+		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+	}
+}

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -27,7 +27,7 @@ final class DiceContainer implements Container
 
 		$dice = (new Dice())->addRules(require($path));
 
-		return static::fromDice($dice);
+		return new self($dice);
 	}
 
 	private Dice $container;
@@ -35,18 +35,6 @@ final class DiceContainer implements Container
 	private function __construct(Dice $container)
 	{
 		$this->container = $container;
-	}
-
-	/**
-	 * Creates an instance with Dice
-	 *
-	 * @param Dice $container
-	 *
-	 * @return self
-	 */
-	public static function fromDice(Dice $container): self
-	{
-		return new self($container);
 	}
 
 	/**

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -10,7 +10,6 @@ namespace Friendica\Core;
 use Friendica\DI;
 use Friendica\Core\Logger\Type\WorkerLogger;
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 
 /**
  * Logger functions

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -191,21 +191,4 @@ class Logger
 	{
 		self::getInstance()->debug($message, $context);
 	}
-
-	/**
-	 * An alternative logger for development.
-	 *
-	 * Works largely as log() but allows developers
-	 * to isolate particular elements they are targeting
-	 * personally without background noise
-	 *
-	 * @param string $message Message to log
-	 * @param string $level Logging level
-	 * @return void
-	 * @throws \Exception
-	 */
-	public static function devLog(string $message, string $level = LogLevel::DEBUG)
-	{
-		DI::devLogger()->log($level, $message);
-	}
 }

--- a/src/DI.php
+++ b/src/DI.php
@@ -305,8 +305,8 @@ abstract class DI
 	public static function flushLogger()
 	{
 		$flushDice = self::$dice
-			->addRule(LoggerInterface::class, self::$dice->getRule(LoggerInterface::class))
-			->addRule('$devLogger', self::$dice->getRule('$devLogger'));
+			->addRule(LoggerInterface::class, self::$dice->getRule(LoggerInterface::class));
+
 		static::init($flushDice);
 	}
 

--- a/src/DI.php
+++ b/src/DI.php
@@ -324,14 +324,6 @@ abstract class DI
 	}
 
 	/**
-	 * @return LoggerInterface
-	 */
-	public static function devLogger()
-	{
-		return self::$dice->create('$devLogger');
-	}
-
-	/**
 	 * @return \Friendica\Core\Logger\Type\WorkerLogger
 	 */
 	public static function workerLogger()

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -180,12 +180,6 @@ return (function(string $basepath, array $getVars, array $serverVars, array $coo
 				\Friendica\Core\Logger\Capability\IHaveCallIntrospections::IGNORE_CLASS_LIST,
 			],
 		],
-		'$devLogger' => [
-			'instanceOf' => \Friendica\Core\Logger\Factory\StreamLogger::class,
-			'call' => [
-				['createDev', [], Dice::CHAIN_CALL],
-			],
-		],
 		\Friendica\Core\Cache\Capability\ICanCache::class => [
 			'instanceOf' => \Friendica\Core\Cache\Factory\Cache::class,
 			'call' => [

--- a/tests/Unit/Core/ContainerTest.php
+++ b/tests/Unit/Core/ContainerTest.php
@@ -11,12 +11,45 @@ namespace Core;
 
 use Dice\Dice;
 use Friendica\Core\Container;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 class ContainerTest extends TestCase
 {
+	public function testFromBasePathReturnsContainer(): void
+	{
+		$root = vfsStream::setup('friendica', null, [
+			'static' => [
+				'dependencies.config.php' => '<?php return [];',
+			],
+		]);
+
+		$container = Container::fromBasePath($root->url());
+
+		$this->assertInstanceOf(Container::class, $container);
+	}
+
+	public function testCreateReturnsObject(): void
+	{
+		$root = vfsStream::setup('friendica', null, [
+			'static' => [
+				'dependencies.config.php' => <<< PHP
+					<?php return [
+						\Psr\Log\LoggerInterface::class => [
+							'instanceOf' => \Psr\Log\NullLogger::class,
+						],
+					];
+					PHP,
+			],
+		]);
+
+		$container = Container::fromBasePath($root->url());
+
+		$this->assertInstanceOf(NullLogger::class, $container->create(LoggerInterface::class));
+	}
+
 	public function testFromDiceReturnsContainer(): void
 	{
 		$dice = $this->createMock(Dice::class);

--- a/tests/Unit/Core/DiceContainerTest.php
+++ b/tests/Unit/Core/DiceContainerTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Core;
 
-use Dice\Dice;
 use Friendica\Core\Container;
 use Friendica\Core\DiceContainer;
 use org\bovigo\vfs\vfsStream;

--- a/tests/Unit/Core/DiceContainerTest.php
+++ b/tests/Unit/Core/DiceContainerTest.php
@@ -11,12 +11,13 @@ namespace Core;
 
 use Dice\Dice;
 use Friendica\Core\Container;
+use Friendica\Core\DiceContainer;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
-class ContainerTest extends TestCase
+class DiceContainerTest extends TestCase
 {
 	public function testFromBasePathReturnsContainer(): void
 	{
@@ -26,7 +27,7 @@ class ContainerTest extends TestCase
 			],
 		]);
 
-		$container = Container::fromBasePath($root->url());
+		$container = DiceContainer::fromBasePath($root->url());
 
 		$this->assertInstanceOf(Container::class, $container);
 	}
@@ -45,7 +46,7 @@ class ContainerTest extends TestCase
 			],
 		]);
 
-		$container = Container::fromBasePath($root->url());
+		$container = DiceContainer::fromBasePath($root->url());
 
 		$this->assertInstanceOf(NullLogger::class, $container->create(LoggerInterface::class));
 	}
@@ -55,7 +56,7 @@ class ContainerTest extends TestCase
 		$dice = $this->createMock(Dice::class);
 		$dice->expects($this->never())->method('create');
 
-		$container = Container::fromDice($dice);
+		$container = DiceContainer::fromDice($dice);
 
 		$this->assertInstanceOf(Container::class, $container);
 	}
@@ -65,7 +66,7 @@ class ContainerTest extends TestCase
 		$dice = $this->createMock(Dice::class);
 		$dice->expects($this->once())->method('create')->with(LoggerInterface::class)->willReturn(new NullLogger());
 
-		$container = Container::fromDice($dice);
+		$container = DiceContainer::fromDice($dice);
 
 		$this->assertInstanceOf(NullLogger::class, $container->create(LoggerInterface::class));
 	}
@@ -75,7 +76,7 @@ class ContainerTest extends TestCase
 		$dice = $this->createMock(Dice::class);
 		$dice->expects($this->once())->method('addRule')->with(LoggerInterface::class, ['constructParams' => ['console']])->willReturn($dice);
 
-		$container = Container::fromDice($dice);
+		$container = DiceContainer::fromDice($dice);
 		$container->addRule(LoggerInterface::class, ['constructParams' => ['console']]);
 	}
 }

--- a/tests/Unit/Core/DiceContainerTest.php
+++ b/tests/Unit/Core/DiceContainerTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace Core;
+namespace Friendica\Test\Unit\Core;
 
 use Friendica\Core\Container;
 use Friendica\Core\DiceContainer;

--- a/tests/Unit/Core/DiceContainerTest.php
+++ b/tests/Unit/Core/DiceContainerTest.php
@@ -50,33 +50,4 @@ class DiceContainerTest extends TestCase
 
 		$this->assertInstanceOf(NullLogger::class, $container->create(LoggerInterface::class));
 	}
-
-	public function testFromDiceReturnsContainer(): void
-	{
-		$dice = $this->createMock(Dice::class);
-		$dice->expects($this->never())->method('create');
-
-		$container = DiceContainer::fromDice($dice);
-
-		$this->assertInstanceOf(Container::class, $container);
-	}
-
-	public function testCreateFromContainer(): void
-	{
-		$dice = $this->createMock(Dice::class);
-		$dice->expects($this->once())->method('create')->with(LoggerInterface::class)->willReturn(new NullLogger());
-
-		$container = DiceContainer::fromDice($dice);
-
-		$this->assertInstanceOf(NullLogger::class, $container->create(LoggerInterface::class));
-	}
-
-	public function testAddRuleFromContainer(): void
-	{
-		$dice = $this->createMock(Dice::class);
-		$dice->expects($this->once())->method('addRule')->with(LoggerInterface::class, ['constructParams' => ['console']])->willReturn($dice);
-
-		$container = DiceContainer::fromDice($dice);
-		$container->addRule(LoggerInterface::class, ['constructParams' => ['console']]);
-	}
 }

--- a/tests/functional/DependencyCheckTest.php
+++ b/tests/functional/DependencyCheckTest.php
@@ -118,18 +118,6 @@ class DependencyCheckTest extends FixtureTestCase
 		self::assertInstanceOf(LoggerInterface::class, $logger);
 	}
 
-	public function testDevLogger()
-	{
-		/** @var IManageConfigValues $config */
-		$config = $this->dice->create(IManageConfigValues::class);
-		$config->set('system', 'dlogfile', $this->root->url() . '/friendica.log');
-
-		/** @var LoggerInterface $logger */
-		$logger = $this->dice->create('$devLogger', ['dev']);
-
-		self::assertInstanceOf(LoggerInterface::class, $logger);
-	}
-
 	public function testCache()
 	{
 		/** @var ICanCache $cache */

--- a/tests/functional/DependencyCheckTest.php
+++ b/tests/functional/DependencyCheckTest.php
@@ -21,7 +21,7 @@ use Psr\Log\LoggerInterface;
 
 class DependencyCheckTest extends FixtureTestCase
 {
-	protected function setUp() : void
+	protected function setUp(): void
 	{
 		parent::setUp();
 


### PR DESCRIPTION
This PR refactors the Container class to create the Dice instance inside the Container class. This PR also creates an interface for a Container and moves some logic back into the App class (see https://github.com/friendica/friendica/pull/14659#issuecomment-2578711071), so `Container::setup()` can be removed.

Refs #14535.

