### PR TITLE
Improved handling of archive posts

### DIFF
--- a/src/Protocol/ATProtocol/Processor.php
+++ b/src/Protocol/ATProtocol/Processor.php
@@ -170,7 +170,7 @@ class Processor
 					}
 				}
 				$item['source'] = json_encode($post);
-				$item = $this->addMedia($post->thread->post->embed, $item, 0);
+				$item           = $this->addMedia($post->thread->post->embed, $item, 0);
 			}
 
 			$id = Item::insert($item);
@@ -547,7 +547,7 @@ class Processor
 						'preview'     => $image->thumb,
 						'description' => $image->alt,
 						'height'      => $image->aspectRatio->height ?? null,
-						'width'       => $image->aspectRatio->width ?? null,
+						'width'       => $image->aspectRatio->width  ?? null,
 					];
 					Post\Media::insert($media);
 				}

--- a/src/Protocol/ATProtocol/Processor.php
+++ b/src/Protocol/ATProtocol/Processor.php
@@ -354,6 +354,10 @@ class Processor
 			'source'        => json_encode($data),
 		];
 
+		if ((time() - strtotime($item['created'])) > 600) {
+			$item['received'] = $item['created'];
+		}
+
 		if ($this->postExists($item['uri'], [$uid])) {
 			$this->logger->info('Post already exists for user', ['uri' => $item['uri'], 'uid' => $uid]);
 			return [];


### PR DESCRIPTION
On Bluesky it is possible to import your old Twitter posts. This creates a lot of posts in the timeline. With this change these posts won't appear as newly arrived posts.