### PR TITLE
Load hooks when initialising legacy AppHelper

### DIFF
--- a/src/AppLegacy.php
+++ b/src/AppLegacy.php
@@ -107,6 +107,7 @@ final class AppLegacy implements AppHelper
 		$this->baseURL  = $baseURL;
 		$this->pConfig  = $pConfig;
 		$this->session  = $session;
+		Core\Hook::loadHooks();
 	}
 
 	/**


### PR DESCRIPTION
It seems that the `AppLegacy`, which is now loaded by the worker instead of `App`, does not load the hooks.  As a result, addons that run in the worker no longer work.

This is a crude hack, but it at least demonstrates that there's a problem, and it can be fixed.  I don't recommend merging this PR.

Thread [here](https://friendica.exon.name/display/97d67096-3767-8e91-5da3-3bb090063997).