### PR TITLE
fix photo albums button appeareance for dark appereance in frio theme

### DIFF
--- a/view/theme/frio/templates/media/browser.tpl
+++ b/view/theme/frio/templates/media/browser.tpl
@@ -40,7 +40,7 @@
 				<ul role="menu">
 					{{foreach $folders as $folder}}
 					<li role="presentation">
-						<button type="button" data-folder="{{$folder}}" role="menuitem">{{$folder}}</button>
+						<button class="btn btn-default" type="button" data-folder="{{$folder}}" role="menuitem">{{$folder}}</button>
 					</li>
 					{{/foreach}}
 				</ul>


### PR DESCRIPTION
Hi, 

I noticed that using dark appearance in frio the buttons for the photo album selection in the album browser are unreadable

![grafik](https://github.com/user-attachments/assets/44854341-4fa9-43f0-aa50-91664dd5e091)


I found that the reason is that in the `view/theme/frio/templates/media/browser.tpl` the corresponding button tags had no class attribute. 
I added just the btn-default class to the tags, which fixes the appearance:

![grafik](https://github.com/user-attachments/assets/8698c2b3-ffbe-4062-bcf3-9ba6030ad102)


Please comment your opinion which button class should be used