### PR TITLE
Fix App not loading Hooks

### DIFF
--- a/bin/auth_ejabberd.php
+++ b/bin/auth_ejabberd.php
@@ -52,4 +52,4 @@ $container = \Friendica\Core\DiceContainer::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 
-$app->processEjabberd();
+$app->processEjabberd($_SERVER);

--- a/bin/console.php
+++ b/bin/console.php
@@ -19,4 +19,4 @@ $container = \Friendica\Core\DiceContainer::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 
-$app->processConsole($_SERVER['argv'] ?? []);
+$app->processConsole($_SERVER);

--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -24,11 +24,13 @@ chdir(dirname(__DIR__));
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
+// BC: Add console command as second argument
 $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "daemon");
+$_SERVER['argv'] = $argv;
 
 $container = \Friendica\Core\DiceContainer::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 
-$app->processConsole($argv);
+$app->processConsole($_SERVER);

--- a/bin/jetstream.php
+++ b/bin/jetstream.php
@@ -19,11 +19,13 @@ chdir(dirname(__DIR__));
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
+// BC: Add console command as second argument
 $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "jetstream");
+$_SERVER['argv'] = $argv;
 
 $container = \Friendica\Core\DiceContainer::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 
-$app->processConsole($argv);
+$app->processConsole($_SERVER);

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -21,11 +21,13 @@ chdir(dirname(__DIR__));
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
+// BC: Add console command as second argument
 $argv = $_SERVER['argv'] ?? [];
 array_splice($argv, 1, 0, "worker");
+$_SERVER['argv'] = $argv;
 
 $container = \Friendica\Core\DiceContainer::fromBasePath(dirname(__DIR__));
 
 $app = \Friendica\App::fromContainer($container);
 
-$app->processConsole($argv);
+$app->processConsole($_SERVER);

--- a/src/App.php
+++ b/src/App.php
@@ -168,6 +168,7 @@ class App
 		$this->registerTemplateEngine();
 
 		$this->runFrontend(
+			$this->mode,
 			$this->container->create(IManagePersonalConfigValues::class),
 			$this->container->create(Page::class),
 			$this->container->create(Nav::class),
@@ -340,6 +341,7 @@ class App
 	 * @throws \ImagickException
 	 */
 	private function runFrontend(
+		Mode $mode,
 		IManagePersonalConfigValues $pconfig,
 		Page $page,
 		Nav $nav,
@@ -347,7 +349,7 @@ class App
 		float $start_time,
 		ServerRequestInterface $request
 	) {
-		$this->mode->setExecutor(Mode::INDEX);
+		$mode->setExecutor(Mode::INDEX);
 
 		$httpInput  = new HTTPInputData($request->getServerParams());
 		$serverVars = $request->getServerParams();
@@ -366,11 +368,11 @@ class App
 
 		try {
 			// Missing DB connection: ERROR
-			if ($this->mode->has(Mode::LOCALCONFIGPRESENT) && !$this->mode->has(Mode::DBAVAILABLE)) {
+			if ($mode->has(Mode::LOCALCONFIGPRESENT) && !$mode->has(Mode::DBAVAILABLE)) {
 				throw new HTTPException\InternalServerErrorException($this->l10n->t('Apologies but the website is unavailable at the moment.'));
 			}
 
-			if (!$this->mode->isInstall()) {
+			if (!$mode->isInstall()) {
 				// Force SSL redirection
 				if ($this->config->get('system', 'force_ssl') &&
 					(empty($serverVars['HTTPS']) || $serverVars['HTTPS'] === 'off') &&
@@ -384,7 +386,7 @@ class App
 
 			DID::routeRequest($this->args->getCommand(), $serverVars);
 
-			if ($this->mode->isNormal() && !$this->mode->isBackend()) {
+			if ($mode->isNormal() && !$mode->isBackend()) {
 				$requester = HTTPSignature::getSigner('', $serverVars);
 				if (!empty($requester)) {
 					OpenWebAuth::addVisitorCookieForHandle($requester);
@@ -392,7 +394,7 @@ class App
 			}
 
 			// ZRL
-			if (!empty($queryVars['zrl']) && $this->mode->isNormal() && !$this->mode->isBackend() && !$this->session->getLocalUserId()) {
+			if (!empty($queryVars['zrl']) && $mode->isNormal() && !$mode->isBackend() && !$this->session->getLocalUserId()) {
 				// Only continue when the given profile link seems valid.
 				// Valid profile links contain a path with "/profile/" and no query parameters
 				if ((parse_url($queryVars['zrl'], PHP_URL_QUERY) == '') &&
@@ -407,12 +409,12 @@ class App
 				}
 			}
 
-			if (!empty($queryVars['owt']) && $this->mode->isNormal()) {
+			if (!empty($queryVars['owt']) && $mode->isNormal()) {
 				$token = $queryVars['owt'];
 				OpenWebAuth::init($token);
 			}
 
-			if (!$this->mode->isBackend()) {
+			if (!$mode->isBackend()) {
 				$this->auth->withSession();
 			}
 
@@ -428,7 +430,7 @@ class App
 
 			// in install mode, any url loads install module
 			// but we need "view" module for stylesheet
-			if ($this->mode->isInstall() && $moduleName !== 'install') {
+			if ($mode->isInstall() && $moduleName !== 'install') {
 				$this->baseURL->redirect('install');
 			} else {
 				Core\Update::check($this->appHelper->getBasePath(), false);
@@ -478,7 +480,7 @@ class App
 			$page['page_title'] = $moduleName;
 
 			// The "view" module is required to show the theme CSS
-			if (!$this->mode->isInstall() && !$this->mode->has(Mode::MAINTENANCEDISABLED) && $moduleName !== 'view') {
+			if (!$mode->isInstall() && !$mode->has(Mode::MAINTENANCEDISABLED) && $moduleName !== 'view') {
 				$module = $this->createModuleInstance(Maintenance::class);
 			} else {
 				// determine the module class and save it to the module instance
@@ -500,7 +502,7 @@ class App
 
 			// Wrapping HTML responses in the theme template
 			if ($response->getHeaderLine(ICanCreateResponses::X_HEADER) === ICanCreateResponses::TYPE_HTML) {
-				$response = $page->run($this->appHelper, $this->session, $this->baseURL, $this->args, $this->mode, $response, $this->l10n, $this->profiler, $this->config, $pconfig, $nav, $this->session->getLocalUserId());
+				$response = $page->run($this->appHelper, $this->session, $this->baseURL, $this->args, $mode, $response, $this->l10n, $this->profiler, $this->config, $pconfig, $nav, $this->session->getLocalUserId());
 			}
 
 			$this->logger->debug('Request processed sucessfully', ['response' => $response->getStatusCode(), 'address' => $serverVars['REMOTE_ADDR'] ?? '', 'request' => $requeststring, 'referer' => $serverVars['HTTP_REFERER'] ?? '', 'user-agent' => $serverVars['HTTP_USER_AGENT'] ?? '', 'duration' => number_format(microtime(true) - $request_start, 3)]);

--- a/src/App.php
+++ b/src/App.php
@@ -312,7 +312,7 @@ class App
 			$viewDefinition->load(true);
 		}
 
-		$this->loadDefaultTimezone($config);
+		$this->loadDefaultTimezone($config, $appHelper);
 	}
 
 	/**
@@ -322,7 +322,7 @@ class App
 	 *
 	 * @global string $default_timezone
 	 */
-	private function loadDefaultTimezone(IManageConfigValues $config)
+	private function loadDefaultTimezone(IManageConfigValues $config, AppHelper $appHelper)
 	{
 		if ($config->get('system', 'default_timezone')) {
 			$timezone = $config->get('system', 'default_timezone', 'UTC');
@@ -331,7 +331,7 @@ class App
 			$timezone = $default_timezone ?? '' ?: 'UTC';
 		}
 
-		$this->appHelper->setTimeZone($timezone);
+		$appHelper->setTimeZone($timezone);
 	}
 
 	/**

--- a/src/App.php
+++ b/src/App.php
@@ -181,8 +181,11 @@ class App
 		);
 	}
 
-	public function processConsole(array $argv): void
+
+	public function processConsole(array $serverParams): void
 	{
+		$argv = $serverParams['argv'] ?? [];
+
 		$this->setupContainerForAddons();
 
 		$this->setupLogChannel($this->determineLogChannel($argv));

--- a/src/App.php
+++ b/src/App.php
@@ -164,6 +164,7 @@ class App
 			$this->container->create(ViewDefinition::class),
 			$this->mode,
 			$this->config,
+			$this->profiler,
 		);
 
 		$this->registerTemplateEngine();
@@ -278,7 +279,8 @@ class App
 		DbaDefinition $dbaDefinition,
 		ViewDefinition $viewDefinition,
 		Mode $mode,
-		IManageConfigValues $config
+		IManageConfigValues $config,
+		Profiler $profiler
 	): void {
 		if ($config->get('system', 'ini_max_execution_time') !== false) {
 			set_time_limit((int) $config->get('system', 'ini_max_execution_time'));
@@ -296,7 +298,7 @@ class App
 		// Ensure that all "strtotime" operations do run timezone independent
 		date_default_timezone_set('UTC');
 
-		$this->profiler->reset();
+		$profiler->reset();
 
 		if ($mode->has(Mode::DBAVAILABLE)) {
 			Core\Hook::loadHooks();

--- a/src/App.php
+++ b/src/App.php
@@ -158,7 +158,7 @@ class App
 		$this->session   = $this->container->create(IHandleUserSessions::class);
 		$this->appHelper = $this->container->create(AppHelper::class);
 
-		$this->loadSetupForFrontend(
+		$this->load(
 			$request,
 			$this->container->create(DbaDefinition::class),
 			$this->container->create(ViewDefinition::class),
@@ -272,7 +272,7 @@ class App
 	/**
 	 * Load the whole app instance
 	 */
-	private function loadSetupForFrontend(ServerRequestInterface $request, DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition)
+	private function load(ServerRequestInterface $request, DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition)
 	{
 		if ($this->config->get('system', 'ini_max_execution_time') !== false) {
 			set_time_limit((int)$this->config->get('system', 'ini_max_execution_time'));

--- a/src/App.php
+++ b/src/App.php
@@ -194,12 +194,22 @@ class App
 
 		$this->registerErrorHandler();
 
+		$this->load(
+			$serverParams,
+			$this->container->create(DbaDefinition::class),
+			$this->container->create(ViewDefinition::class),
+			$this->container->create(Mode::class),
+			$this->container->create(IManageConfigValues::class),
+			$this->container->create(Profiler::class),
+			$this->container->create(AppHelper::class),
+		);
+
 		$this->registerTemplateEngine();
 
 		(\Friendica\Core\Console::create($this->container, $argv))->execute();
 	}
 
-	public function processEjabberd(): void
+	public function processEjabberd(array $serverParams): void
 	{
 		$this->setupContainerForAddons();
 
@@ -208,6 +218,16 @@ class App
 		$this->setupLegacyServiceLocator();
 
 		$this->registerErrorHandler();
+
+		$this->load(
+			$serverParams,
+			$this->container->create(DbaDefinition::class),
+			$this->container->create(ViewDefinition::class),
+			$this->container->create(Mode::class),
+			$this->container->create(IManageConfigValues::class),
+			$this->container->create(Profiler::class),
+			$this->container->create(AppHelper::class),
+		);
 
 		/** @var BasePath */
 		$basePath = $this->container->create(BasePath::class);

--- a/src/App.php
+++ b/src/App.php
@@ -166,8 +166,6 @@ class App
 
 		$this->registerTemplateEngine();
 
-		$this->mode->setExecutor(Mode::INDEX);
-
 		$this->runFrontend(
 			$this->container->create(IManagePersonalConfigValues::class),
 			$this->container->create(Page::class),
@@ -348,6 +346,8 @@ class App
 		float $start_time,
 		ServerRequestInterface $request
 	) {
+		$this->mode->setExecutor(Mode::INDEX);
+
 		$httpInput  = new HTTPInputData($request->getServerParams());
 		$serverVars = $request->getServerParams();
 		$queryVars  = $request->getQueryParams();

--- a/src/App.php
+++ b/src/App.php
@@ -159,7 +159,7 @@ class App
 		$this->appHelper = $this->container->create(AppHelper::class);
 
 		$this->load(
-			$request,
+			$request->getServerParams(),
 			$this->container->create(DbaDefinition::class),
 			$this->container->create(ViewDefinition::class),
 		);
@@ -272,7 +272,7 @@ class App
 	/**
 	 * Load the whole app instance
 	 */
-	private function load(ServerRequestInterface $request, DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition)
+	private function load(array $serverParams, DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition)
 	{
 		if ($this->config->get('system', 'ini_max_execution_time') !== false) {
 			set_time_limit((int)$this->config->get('system', 'ini_max_execution_time'));
@@ -294,7 +294,7 @@ class App
 
 		if ($this->mode->has(Mode::DBAVAILABLE)) {
 			Core\Hook::loadHooks();
-			$loader = (new Config())->createConfigFileManager($this->appHelper->getBasePath(), $request->getServerParams());
+			$loader = (new Config())->createConfigFileManager($this->appHelper->getBasePath(), $serverParams);
 			Core\Hook::callAll('load_config', $loader);
 
 			// Hooks are now working, reload the whole definitions with hook enabled

--- a/src/App.php
+++ b/src/App.php
@@ -163,6 +163,7 @@ class App
 			$this->container->create(DbaDefinition::class),
 			$this->container->create(ViewDefinition::class),
 			$this->mode,
+			$this->config,
 		);
 
 		$this->registerTemplateEngine();
@@ -272,14 +273,19 @@ class App
 	/**
 	 * Load the whole app instance
 	 */
-	private function load(array $serverParams, DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition, Mode $mode)
-	{
-		if ($this->config->get('system', 'ini_max_execution_time') !== false) {
-			set_time_limit((int)$this->config->get('system', 'ini_max_execution_time'));
+	private function load(
+		array $serverParams,
+		DbaDefinition $dbaDefinition,
+		ViewDefinition $viewDefinition,
+		Mode $mode,
+		IManageConfigValues $config
+	): void {
+		if ($config->get('system', 'ini_max_execution_time') !== false) {
+			set_time_limit((int) $config->get('system', 'ini_max_execution_time'));
 		}
 
-		if ($this->config->get('system', 'ini_pcre_backtrack_limit') !== false) {
-			ini_set('pcre.backtrack_limit', (int)$this->config->get('system', 'ini_pcre_backtrack_limit'));
+		if ($config->get('system', 'ini_pcre_backtrack_limit') !== false) {
+			ini_set('pcre.backtrack_limit', (int) $config->get('system', 'ini_pcre_backtrack_limit'));
 		}
 
 		// Normally this constant is defined - but not if "pcntl" isn't installed

--- a/src/App.php
+++ b/src/App.php
@@ -162,6 +162,7 @@ class App
 			$request->getServerParams(),
 			$this->container->create(DbaDefinition::class),
 			$this->container->create(ViewDefinition::class),
+			$this->mode,
 		);
 
 		$this->registerTemplateEngine();
@@ -270,7 +271,7 @@ class App
 	/**
 	 * Load the whole app instance
 	 */
-	private function load(array $serverParams, DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition)
+	private function load(array $serverParams, DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition, Mode $mode)
 	{
 		if ($this->config->get('system', 'ini_max_execution_time') !== false) {
 			set_time_limit((int)$this->config->get('system', 'ini_max_execution_time'));
@@ -290,7 +291,7 @@ class App
 
 		$this->profiler->reset();
 
-		if ($this->mode->has(Mode::DBAVAILABLE)) {
+		if ($mode->has(Mode::DBAVAILABLE)) {
 			Core\Hook::loadHooks();
 			$loader = (new Config())->createConfigFileManager($this->appHelper->getBasePath(), $serverParams);
 			Core\Hook::callAll('load_config', $loader);

--- a/src/App.php
+++ b/src/App.php
@@ -308,7 +308,7 @@ class App
 			$viewDefinition->load(true);
 		}
 
-		$this->loadDefaultTimezone();
+		$this->loadDefaultTimezone($config);
 	}
 
 	/**
@@ -318,10 +318,10 @@ class App
 	 *
 	 * @global string $default_timezone
 	 */
-	private function loadDefaultTimezone()
+	private function loadDefaultTimezone(IManageConfigValues $config)
 	{
-		if ($this->config->get('system', 'default_timezone')) {
-			$timezone = $this->config->get('system', 'default_timezone', 'UTC');
+		if ($config->get('system', 'default_timezone')) {
+			$timezone = $config->get('system', 'default_timezone', 'UTC');
 		} else {
 			global $default_timezone;
 			$timezone = $default_timezone ?? '' ?: 'UTC';

--- a/src/App.php
+++ b/src/App.php
@@ -165,6 +165,7 @@ class App
 			$this->mode,
 			$this->config,
 			$this->profiler,
+			$this->appHelper,
 		);
 
 		$this->registerTemplateEngine();
@@ -280,7 +281,8 @@ class App
 		ViewDefinition $viewDefinition,
 		Mode $mode,
 		IManageConfigValues $config,
-		Profiler $profiler
+		Profiler $profiler,
+		AppHelper $appHelper
 	): void {
 		if ($config->get('system', 'ini_max_execution_time') !== false) {
 			set_time_limit((int) $config->get('system', 'ini_max_execution_time'));
@@ -302,7 +304,7 @@ class App
 
 		if ($mode->has(Mode::DBAVAILABLE)) {
 			Core\Hook::loadHooks();
-			$loader = (new Config())->createConfigFileManager($this->appHelper->getBasePath(), $serverParams);
+			$loader = (new Config())->createConfigFileManager($appHelper->getBasePath(), $serverParams);
 			Core\Hook::callAll('load_config', $loader);
 
 			// Hooks are now working, reload the whole definitions with hook enabled


### PR DESCRIPTION
While refactoring the `Friendica\App` class in #14603 I moved the call of `App::load()` from the constructor into the new `App::processRequest()` method, see commit 7a4542cd50a0d261af2dc44db804d974460a472a. This move was misleading, because `App::load()` was always loaded, e.g. if `DI::app()` was called. This could also happen inside addons, console commands or worker.

This PR fixes this by calling `App::load()` also on `App::processConsole()`.

Fixes #14714