### PR TITLE
Partially revert "Improve search for user in Modration module"

### DIFF
--- a/src/Module/Moderation/Users/Active.php
+++ b/src/Module/Moderation/Users/Active.php
@@ -51,15 +51,12 @@ class Active extends BaseUsers
 		$action = (string) $this->parameters['action'] ?? '';
 		$uid    = (int) $this->parameters['uid'] ?? 0;
 
-		if ($uid === 0) {
-			$this->systemMessages->addNotice($this->t('User not found'));
-			$this->baseUrl->redirect('moderation/users');
-		}
-
-		$user = User::getById($uid, ['username', 'blocked']);
-		if (!is_array($user)) {
-			$this->systemMessages->addNotice($this->t('User not found'));
-			$this->baseUrl->redirect('moderation/users');
+		if ($uid !== 0) {
+			$user = User::getById($uid, ['username', 'blocked']);
+			if (!$user) {
+				$this->systemMessages->addNotice($this->t('User not found'));
+				$this->baseUrl->redirect('moderation/users');
+			}
 		}
 
 		switch ($action) {

--- a/src/Module/Moderation/Users/Active.php
+++ b/src/Module/Moderation/Users/Active.php
@@ -48,38 +48,8 @@ class Active extends BaseUsers
 	{
 		parent::content();
 
-		$action = (string) $this->parameters['action'] ?? '';
-		$uid    = (int) $this->parameters['uid'] ?? 0;
+		$this->processGetActions();
 
-		if ($uid !== 0) {
-			$user = User::getById($uid, ['username', 'blocked']);
-			if (!$user) {
-				$this->systemMessages->addNotice($this->t('User not found'));
-				$this->baseUrl->redirect('moderation/users');
-			}
-		}
-
-		switch ($action) {
-			case 'delete':
-				if ($this->session->getLocalUserId() != $uid) {
-					self::checkFormSecurityTokenRedirectOnError('moderation/users/active', 'moderation_users_active', 't');
-					// delete user
-					User::remove($uid);
-
-					$this->systemMessages->addNotice($this->t('User "%s" deleted', $user['username']));
-				} else {
-					$this->systemMessages->addNotice($this->t('You can\'t remove yourself'));
-				}
-
-				$this->baseUrl->redirect('moderation/users/active');
-				break;
-			case 'block':
-				self::checkFormSecurityTokenRedirectOnError('moderation/users/active', 'moderation_users_active', 't');
-				User::block($uid);
-				$this->systemMessages->addNotice($this->t('User "%s" blocked', $user['username']));
-				$this->baseUrl->redirect('moderation/users/active');
-				break;
-		}
 		$pager = new Pager($this->l10n, $this->args->getQueryString(), 100);
 
 		$valid_orders = [
@@ -142,5 +112,49 @@ class Active extends BaseUsers
 			'$count' => $count,
 			'$pager' => $pager->renderFull($count),
 		]);
+	}
+
+	/**
+	 * @return void
+	 * @throws \Friendica\Network\HTTPException\FoundException
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws \Friendica\Network\HTTPException\MovedPermanentlyException
+	 * @throws \Friendica\Network\HTTPException\NotFoundException
+	 * @throws \Friendica\Network\HTTPException\TemporaryRedirectException
+	 */
+	private function processGetActions(): void
+	{
+		$action = (string)$this->parameters['action'] ?? '';
+		$uid = (int)$this->parameters['uid'] ?? 0;
+
+		if ($uid === 0) {
+			return;
+		}
+
+		$user = User::getById($uid, ['username']);
+		if (!$user) {
+			$this->systemMessages->addNotice($this->t('User not found'));
+			$this->baseUrl->redirect('moderation/users');
+		}
+
+		switch ($action) {
+			case 'delete':
+				if ($this->session->getLocalUserId() != $uid) {
+					self::checkFormSecurityTokenRedirectOnError('moderation/users/active', 'moderation_users_active', 't');
+					// delete user
+					User::remove($uid);
+
+					$this->systemMessages->addNotice($this->t('User "%s" deleted', $user['username']));
+				} else {
+					$this->systemMessages->addNotice($this->t('You can\'t remove yourself'));
+				}
+
+				$this->baseUrl->redirect('moderation/users/active');
+			case 'block':
+				self::checkFormSecurityTokenRedirectOnError('moderation/users/active', 'moderation_users_active', 't');
+				User::block($uid);
+				$this->systemMessages->addNotice($this->t('User "%s" blocked', $user['username']));
+				$this->baseUrl->redirect('moderation/users/active');
+		}
 	}
 }

--- a/src/Module/Moderation/Users/Blocked.php
+++ b/src/Module/Moderation/Users/Blocked.php
@@ -51,15 +51,12 @@ class Blocked extends BaseUsers
 		$action = (string) $this->parameters['action'] ?? '';
 		$uid    = (int) $this->parameters['uid'] ?? 0;
 
-		if ($uid === 0) {
-			$this->systemMessages->addNotice($this->t('User not found'));
-			$this->baseUrl->redirect('moderation/users');
-		}
-
-		$user = User::getById($uid, ['username', 'blocked']);
-		if (!is_array($user)) {
-			$this->systemMessages->addNotice($this->t('User not found'));
-			$this->baseUrl->redirect('moderation/users');
+		if ($uid !== 0) {
+			$user = User::getById($uid, ['username', 'blocked']);
+			if (!$user) {
+				$this->systemMessages->addNotice($this->t('User not found'));
+				$this->baseUrl->redirect('moderation/users');
+			}
 		}
 
 		switch ($action) {

--- a/src/Module/Moderation/Users/Index.php
+++ b/src/Module/Moderation/Users/Index.php
@@ -58,15 +58,12 @@ class Index extends BaseUsers
 		$action = (string) $this->parameters['action'] ?? '';
 		$uid    = (int) $this->parameters['uid'] ?? 0;
 
-		if ($uid === 0) {
-			$this->systemMessages->addNotice($this->t('User not found'));
-			$this->baseUrl->redirect('moderation/users');
-		}
-
-		$user = User::getById($uid, ['username', 'blocked']);
-		if (!is_array($user)) {
-			$this->systemMessages->addNotice($this->t('User not found'));
-			$this->baseUrl->redirect('moderation/users');
+		if ($uid !== 0) {
+			$user = User::getById($uid, ['username', 'blocked']);
+			if (!$user) {
+				$this->systemMessages->addNotice($this->t('User not found'));
+				$this->baseUrl->redirect('moderation/users');
+			}
 		}
 
 		switch ($action) {


### PR DESCRIPTION
Fixes #14717 

This reverts commit 78444ff25cfb0e30d79b78e4744a8b84aa06c52a.
↪️ When the uid parameter isn't set, the regular list should be shown instead of throwing an error.

Additionally, `User::getById` returns an empty array when the user doesn't exist, so `is_array()` can't be used to check for user non-existence.