### PR TITLE
Bugfix/log table: Log level not readable in dark and black frio appeareance

### DIFF
--- a/view/theme/frio/templates/admin/logs/view.tpl
+++ b/view/theme/frio/templates/admin/logs/view.tpl
@@ -70,17 +70,17 @@
 					aria-label="{{$l10n.View_details}}" aria-haspopup="true" aria-expanded="false"
 					data-data="{{$row->data}}" data-source="{{$row->source}}">
 					<td>{{$row->date}}</td>
-					<td class="
-						{{if $row->level == "EMERGENCY"}}bg-danger
-						{{elseif $row->level == "ALERT"}}bg-danger
-						{{elseif $row->level == "CRITICAL"}}bg-danger
-						{{elseif $row->level == "ERROR"}}bg-danger
-						{{elseif $row->level == "WARNING"}}bg-warning
-						{{elseif $row->level == "NOTICE"}}bg-info
-						{{elseif $row->level == "INFO"}}bg-info
-						{{else}}text-muted
-						{{/if}}
-					">{{$row->level}}</td>
+					{{assign var="class" value="bg-info"}}
+					{{if $row->level == "EMERGENCY" || $row->level == "ALERT" || $row->level == "CRITICAL" || $row->level == "ERROR"}}
+						{{assign var="class" value="bg-danger"}}
+					{{elseif $row->level == "WARNING"}}
+						{{assign var="class" value="bg-warning"}}
+					{{elseif $row->level == "NOTICE" || $row->level == "INFO"}}
+						{{assign var="class" value="bg-info"}}
+					{{else}}
+						{{ assign var="class" value="text-muted"}}
+					{{/if}}
+					<td class="{{$class}}">{{$row->level}}</td>
 					<td>{{$row->context}}</td>
 					<td class="log-message">{{$row->message}}</td>
 				</tr>

--- a/view/theme/frio/templates/admin/logs/view.tpl
+++ b/view/theme/frio/templates/admin/logs/view.tpl
@@ -70,13 +70,13 @@
 					aria-label="{{$l10n.View_details}}" aria-haspopup="true" aria-expanded="false"
 					data-data="{{$row->data}}" data-source="{{$row->source}}">
 					<td>{{$row->date}}</td>
-					{{assign var="class" value="bg-info text-info"}}
+					{{assign var="class" value="text-info"}}
 					{{if $row->level == "EMERGENCY" || $row->level == "ALERT" || $row->level == "CRITICAL" || $row->level == "ERROR"}}
-						{{assign var="class" value="bg-danger text-danger"}}
+						{{assign var="class" value="text-danger"}}
 					{{elseif $row->level == "WARNING"}}
-						{{assign var="class" value="bg-warning text-warning"}}
+						{{assign var="class" value="text-warning"}}
 					{{elseif $row->level == "NOTICE" || $row->level == "INFO"}}
-						{{assign var="class" value="bg-info text-info"}}
+						{{assign var="class" value="text-info"}}
 					{{else}}
 						{{ assign var="class" value="text-muted"}}
 					{{/if}}

--- a/view/theme/frio/templates/admin/logs/view.tpl
+++ b/view/theme/frio/templates/admin/logs/view.tpl
@@ -70,13 +70,13 @@
 					aria-label="{{$l10n.View_details}}" aria-haspopup="true" aria-expanded="false"
 					data-data="{{$row->data}}" data-source="{{$row->source}}">
 					<td>{{$row->date}}</td>
-					{{assign var="class" value="bg-info"}}
+					{{assign var="class" value="bg-info text-info"}}
 					{{if $row->level == "EMERGENCY" || $row->level == "ALERT" || $row->level == "CRITICAL" || $row->level == "ERROR"}}
-						{{assign var="class" value="bg-danger"}}
+						{{assign var="class" value="bg-danger text-danger"}}
 					{{elseif $row->level == "WARNING"}}
-						{{assign var="class" value="bg-warning"}}
+						{{assign var="class" value="bg-warning text-warning"}}
 					{{elseif $row->level == "NOTICE" || $row->level == "INFO"}}
-						{{assign var="class" value="bg-info"}}
+						{{assign var="class" value="bg-info text-info"}}
 					{{else}}
 						{{ assign var="class" value="text-muted"}}
 					{{/if}}


### PR DESCRIPTION
The log level was difficult to read in the black and dark appearances of the Frio theme. 

![grafik](https://github.com/user-attachments/assets/ab0f93aa-0445-4575-9291-9ae1c0de852c)


This issue has been addressed in by dynamically assigning appropriate text classes from Bootstrap in `view.tpl` for the `td` tag representing log levels.

![grafik](https://github.com/user-attachments/assets/773369f0-097d-40c6-930e-15d0d82a62aa)


Additionally, the inline Smarty3 logic for assigning the class attribute of the `td` tag was replaced with a variable. This ensures that indentation whitespaces are not inadvertently injected into the class attribute, resulting in cleaner HTML output.

Let me know if further refinements are needed!