### PR TITLE
Exclude invitation register rows from pending-view

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -3809,7 +3809,8 @@ CREATE VIEW `pending-view` AS SELECT
 	`contact`.`nick` AS `nick`
 	FROM `register`
 			INNER JOIN `contact` ON `register`.`uid` = `contact`.`uid`
-			INNER JOIN `user` ON `register`.`uid` = `user`.`uid`;
+			INNER JOIN `user` ON `register`.`uid` = `user`.`uid`
+			WHERE `register`.`uid` != 0;
 
 --
 -- VIEW tag-search-view

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -1763,7 +1763,8 @@ return [
 		],
 		"query" => "FROM `register`
 			INNER JOIN `contact` ON `register`.`uid` = `contact`.`uid`
-			INNER JOIN `user` ON `register`.`uid` = `user`.`uid`"
+			INNER JOIN `user` ON `register`.`uid` = `user`.`uid`
+			WHERE `register`.`uid` != 0"
 	],
 	"tag-search-view" => [
 		"fields" => [


### PR DESCRIPTION
↪ They were wrongly appearing in the moderation screen and in the notifications

Fix #14424 