### PR TITLE
fix font-size for .media-heading

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1815,11 +1815,11 @@ blockquote.shared_content {
 .media .contact-info-comment {
 	display: table-cell;
 }
-.media .contact-info-xs h5,
 .media .contact-info-comment {
 	margin: 0 0 5px;
 }
 .media-heading {
+	font-size: 14px;
 	margin: 0px;
 }
 .wall-item-name,


### PR DESCRIPTION
This should fix the font-size (in the Frio theme) for the new headings (introduced for accessibility) with the `.media-heading` class, that means, the user names on the "wall", and in the contact list and in the search results. 

On the wall it was only visible with mobile page width.  

The one line was removed, because the elements are no longer `<h5>` now.

I have looked/tested with chromium and firefox. Here it is active: https://boerdica.de/profile/noidea