### PR TITLE
Frio: break too long words in topbar notifications

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -740,6 +740,7 @@ nav.navbar .nav > li > button:focus {
 #topbar-first #nav-notifications-menu a {
 	color: $font_color_darker;
 	padding: 0;
+	word-break: break-word;
 }
 #topbar-first #nav-notifications-menu li.notif-entry {
 	color: $font_color_darker;


### PR DESCRIPTION
This should break too long words (or links) in the topbar notifications, so that the situation on the first screenshot should no longer happen ( discussed [here](https://forum.friendi.ca/display/4edd2508-1567-98ee-7052-ebd074546994) ):

before:

![Bildschirmfoto_2025-01-28_21-31-02--word-break](https://github.com/user-attachments/assets/a76c462b-e386-4156-9ebb-ffe740d01bc4)

after:

![Bildschirmfoto_2025-01-28_21-39-39--notification-break-word-after](https://github.com/user-attachments/assets/3616bf5e-e82a-4503-8639-68e1dc549b27)

tested with Firefox and Chromium browsers.