### PR TITLE
Frio: change modal header border to reflect the current color scheme

### DIFF
--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -113,10 +113,9 @@ main .nav-tabs > li.active > a:hover {
 	background-color: rgba(238, 238, 238, $contentbg_transp);
 }
 
-#modal-header {
+.modal-header {
 	border-color: $link_color;
 }
-
 .modal-content {
 	background-color: $background_color;
 }

--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -113,6 +113,10 @@ main .nav-tabs > li.active > a:hover {
 	background-color: rgba(238, 238, 238, $contentbg_transp);
 }
 
+#modal-header {
+	border-color: $link_color;
+}
+
 .modal-content {
 	background-color: $background_color;
 }

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -112,6 +112,10 @@ main .nav-tabs > li.active > a:hover {
 	background-color: rgba(238, 238, 238, $contentbg_transp);
 }
 
+#modal-header {
+	border-color: $link_color;
+}
+
 .modal-content {
 	background-color: $background_color;
 }

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -112,10 +112,9 @@ main .nav-tabs > li.active > a:hover {
 	background-color: rgba(238, 238, 238, $contentbg_transp);
 }
 
-#modal-header {
+.modal-header {
 	border-color: $link_color;
 }
-
 .modal-content {
 	background-color: $background_color;
 }


### PR DESCRIPTION
This should let the border of the `#modal-header` use the color of the current color scheme.

dark:

![Bildschirmfoto_2025-01-29_14-44-38--modal-header](https://github.com/user-attachments/assets/41ad27cb-8527-4bbb-acab-dc3fc9c7c3d4)
![Bildschirmfoto_2025-01-29_14-54-38--modal-header-after](https://github.com/user-attachments/assets/e64f6713-8652-4c13-a5ea-5903b9d4312c)

black:

![Bildschirmfoto_2025-01-29_15-04-54--modal-header-black](https://github.com/user-attachments/assets/1629a616-73e5-4a37-b13b-8c236df3089d)
![Bildschirmfoto_2025-01-29_15-05-29--modal-header-black-after](https://github.com/user-attachments/assets/1132073d-1880-415e-864c-45397bd13c9b)
