### PR TITLE
[frio] Improve dropzone background color

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3670,9 +3670,8 @@ section .profile-match-wrapper {
 }
 
 .qq-upload-drop-area {
-	background: white !important;
+	background: inherit !important;
 	float: none;
-	border: none;
 	-webkit-box-shadow: none;
 	box-shadow: none;
 	-moz-box-shadow: none;
@@ -3687,7 +3686,7 @@ section .profile-match-wrapper {
 	width: 100% !important;
 	display: block !important;
 	position: relative !important;
-	border: black 1px dashed !important;
+	border: $font_color_darker 1px dashed !important;
 	margin-bottom: 5px !important;
 	margin-top: 15px !important;
 }


### PR DESCRIPTION
This is meant to make the background-color of the dropzone drop-area (in the photo upload.. I believe it is the js-upload) a little bit lighter on the eyes in the dark and black color schemes. 

I wanted to use a color with less contrast for the dashed line, but could not find the right variable that would work in all schemes, so I chose `$font_color_darker` for now.

before:

![Bildschirmfoto_2025-01-29_16-16-10--drop-area-dark](https://github.com/user-attachments/assets/778b1962-85bc-494e-8ba1-fb2d3b4e18ca)
![Bildschirmfoto_2025-01-29_16-19-02--drop-area-black](https://github.com/user-attachments/assets/3ce67148-343a-49e3-b696-c2462aaa73a8)

after:

![Bildschirmfoto_2025-01-29_16-55-17--drop-area-black-after](https://github.com/user-attachments/assets/61dd9a7a-5918-436a-a563-465a72970837)
![Bildschirmfoto_2025-01-29_16-56-08--drop-area-dark-after](https://github.com/user-attachments/assets/998e2d83-1e41-48f2-adb0-3fe4b8a8a280)
![Bildschirmfoto_2025-01-29_16-57-04--drop-area-light-after](https://github.com/user-attachments/assets/a8c5f947-d506-4244-be2d-d1697b99ca56)
 