### PR TITLE
[frio] Use modal instead of popupbox for permissions on photo edit page

### DIFF
--- a/view/theme/frio/templates/photo_edit.tpl
+++ b/view/theme/frio/templates/photo_edit.tpl
@@ -1,0 +1,45 @@
+{{*
+  * Copyright (C) 2010-2024, the Friendica project
+  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
+  *
+  * SPDX-License-Identifier: AGPL-3.0-or-later
+  *}}
+
+<form action="photos/{{$nickname}}/image/{{$resource_id}}/edit" method="post" id="photo_edit_form">
+
+	<input type="hidden" name="item_id" value="{{$item_id}}" />
+	<input type="hidden" name="origaname" value="{{$album.2}}" />
+
+	{{include file="field_input.tpl" field=$album}}
+	{{include file="field_input.tpl" field=$caption}}
+	{{include file="field_input.tpl" field=$tags}}
+
+	{{include file="field_radio.tpl" field=$rotate_none}}
+	{{include file="field_radio.tpl" field=$rotate_cw}}
+	{{include file="field_radio.tpl" field=$rotate_ccw}}
+
+	<div id="photo-edit-perms">
+		<button class="btn btn-default btn-sm" data-toggle="modal" data-target="#aclModal" onclick="return false;">
+			<i id="jot-perms-icon" class="fa {{$lockstate}}"></i> {{$permissions}}
+		</button>
+	</div>
+
+	<input id="photo-edit-submit-button" type="submit" name="submit" value="{{$submit}}" />
+
+	{{* The modal for advanced-expire (photo permissions) *}}
+	<div id="aclModal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header" class="modal-header">
+					<button id="modal-close" type="button" class="close" data-dismiss="modal" aria-hidden="true">
+						&times;
+					</button>
+					<h4 id="modal-title" class="modal-title">{{$permissions}}</h4>
+				</div>
+				<div id="photos-edit-permissions-wrapper" class="modal-body">
+					{{$aclselect nofilter}}
+				</div>
+			</div>
+		</div>
+	</div>
+</form>

--- a/view/theme/frio/templates/photo_edit.tpl
+++ b/view/theme/frio/templates/photo_edit.tpl
@@ -19,7 +19,7 @@
 	{{include file="field_radio.tpl" field=$rotate_ccw}}
 
 	<div id="photo-edit-perms">
-		<button class="btn btn-default btn-sm" data-toggle="modal" data-target="#aclModal" onclick="return false;">
+		<button class="btn btn-default btn-sm" data-toggle="modal" data-target="#photo-edit-permission-acl" onclick="return false;">
 			<i id="jot-perms-icon" class="fa {{$lockstate}}"></i> {{$permissions}}
 		</button>
 	</div>
@@ -27,14 +27,14 @@
 	<input id="photo-edit-submit-button" type="submit" name="submit" value="{{$submit}}" />
 
 	{{* The modal for advanced-expire (photo permissions) *}}
-	<div id="aclModal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+	<div id="photo-edit-permission-acl" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
 		<div class="modal-dialog">
 			<div class="modal-content">
-				<div class="modal-header" class="modal-header">
+				<div class="modal-header">
 					<button id="modal-close" type="button" class="close" data-dismiss="modal" aria-hidden="true">
 						&times;
 					</button>
-					<h4 id="modal-title" class="modal-title">{{$permissions}}</h4>
+					<h4 class="modal-title">{{$permissions}}</h4>
 				</div>
 				<div id="photos-edit-permissions-wrapper" class="modal-body">
 					{{$aclselect nofilter}}

--- a/view/theme/frio/templates/photos_upload.tpl
+++ b/view/theme/frio/templates/photos_upload.tpl
@@ -30,7 +30,7 @@
 
 		{{if $alt_uploader}}
 			<div id="photos-upload-perms" class="pull-right">
-				<button class="btn btn-default btn-sm" data-toggle="modal" data-target="#aclModal" onclick="return false;">
+				<button class="btn btn-default btn-sm" data-toggle="modal" data-target="#photo-upload-permission-acl" onclick="return false;">
 					<i id="jot-perms-icon" class="fa {{$lockstate}}"></i> {{$permissions}}
 				</button>
 			</div>
@@ -49,7 +49,7 @@
 
 			<div class="photos-upload-wrapper">
 				<div id="photos-upload-perms" class="btn-group pull-right">
-					<button class="btn btn-default" data-toggle="modal" data-target="#aclModal" onclick="return false;">
+					<button class="btn btn-default" data-toggle="modal" data-target="#photo-upload-permission-acl" onclick="return false;">
 						<i id="jot-perms-icon" class="fa {{$lockstate}}"></i>
 					</button>
 
@@ -63,14 +63,14 @@
 		<div class="photos-upload-end" class="clearfix"></div>
 
 		{{* The modal for advanced-expire *}}
-		<div id="aclModal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+		<div id="photo-upload-permission-acl" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
 			<div class="modal-dialog">
 				<div class="modal-content">
 					<div class="modal-header">
 						<button id="modal-close" type="button" class="close" data-dismiss="modal" aria-hidden="true">
 							&times;
 						</button>
-						<h4 id="modal-title" class="modal-title">{{$permissions}}</h4>
+						<h4 class="modal-title">{{$permissions}}</h4>
 					</div>
 					<div id="photos-upload-permissions-wrapper" class="modal-body">
 						{{$aclselect nofilter}}

--- a/view/theme/frio/templates/photos_upload.tpl
+++ b/view/theme/frio/templates/photos_upload.tpl
@@ -66,7 +66,7 @@
 		<div id="aclModal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
 			<div class="modal-dialog">
 				<div class="modal-content">
-					<div class="modal-header" class="modal-header">
+					<div class="modal-header">
 						<button id="modal-close" type="button" class="close" data-dismiss="modal" aria-hidden="true">
 							&times;
 						</button>

--- a/view/theme/frio/templates/settings/profile/field/edit.tpl
+++ b/view/theme/frio/templates/settings/profile/field/edit.tpl
@@ -19,7 +19,7 @@
 	</p>
 
 	{{* We include the aclModal directly into the template since we cant use frio's default modal *}}
-	<div class="modal" id="profile-field-acl-{{$profile_field.id}}">
+	<div id="profile-field-acl-{{$profile_field.id}}" class="modal fade">
 		<div class="modal-dialog">
 			<div class="modal-content">
 				<div class="modal-header">


### PR DESCRIPTION
On the photo edit page, the option to set the photo permissions was opening a popupbox and was always in light colors, also when using `dark` or `black` schemes.

I tried to use the same modal there, that is used for the permissions on the photo upload page. For that, the template `view/templates/photo_edit.tpl` was copied to `view/theme/frio/templates/` and adapted. It seems to work, except that the `$lockstate` variable seems not to be available. So there  is no locked or unlocked icon to see on the button. But I tried to change the permissions of a photo and it looked good. It was not found on Diaspora if locked and vice versa.

Hope everything is okay..

#### Screenshots before

dark scheme:
![Bildschirmfoto_2025-01-29_20-12-40--photo-permissions-before](https://github.com/user-attachments/assets/06d83782-51b8-4546-ac22-d0d38e10080e)

black scheme:
![Bildschirmfoto_2025-01-29_21-21-48--photo-permissions-black-before](https://github.com/user-attachments/assets/95e336e4-91e0-48d4-8c07-def00d42dc04)

#### Screenshots after

dark scheme:
![Bildschirmfoto_2025-01-29_20-54-39--photo-permissions-dark-after](https://github.com/user-attachments/assets/1423c9ed-ee1b-400b-b860-e2ce8f88a106)

light scheme:
![Bildschirmfoto_2025-01-29_21-33-41--photo-permissions-after](https://github.com/user-attachments/assets/7252a02d-ee0b-4574-b2d4-7a49b7140365)

Tested with Chromium and Firefox browsers.