### PR TITLE
Hard deprecate `Friendica\Core\Logger`

### DIFF
--- a/doc/Developers-Intro.md
+++ b/doc/Developers-Intro.md
@@ -210,9 +210,9 @@ If the deprecated code is no longer used inside Friendica or the official addons
 The code MUST NOT be deleted.
 Starting from the next release, it MUST be stay for at least 5 months.
 Hard deprecated code COULD remain longer than 5 months, depending on when a release appears.
-Addon developer MUST NOT consider that they have more than 5 months to adjust their code.
+Addon developer SHOULD NOT consider that they have more than 5 months to adjust their code.
 
-Hard deprecation code means that the code triggers an `E_USER_DEPRECATION` error if it is called.
+Hard deprecation code means that the code triggers a muted `E_USER_DEPRECATION` error if it is called.
 For instance with the deprecated class `Friendica\Core\Logger` the call of every method should trigger an error:
 
 ```php
@@ -224,7 +224,7 @@ For instance with the deprecated class `Friendica\Core\Logger` the call of every
 class Logger {
 	public static function info(string $message, array $context = [])
 	{
-		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.05 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.05 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->info($message, $context);
 	}
@@ -233,7 +233,7 @@ class Logger {
 }
 ```
 
-This way the maintainer or users of addons will be notified that the addon will stop working in one of the next releases.
+This way the maintainer or users of addons will be notified in the logs that the addon will stop working in one of the next releases.
 The addon maintainer now has at least 5 months or at least one release to fix the deprecations.
 
 Please note that the deprecation message contains the release that will be released next.

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -8,7 +8,6 @@
 namespace Friendica\Core;
 
 use Friendica\DI;
-use Friendica\Core\Logger\Type\WorkerLogger;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -18,10 +17,7 @@ use Psr\Log\LoggerInterface;
  */
 class Logger
 {
-	/**
-	 * @return LoggerInterface|WorkerLogger
-	 */
-	private static function getInstance()
+	private static function getInstance(): LoggerInterface
 	{
 		return DI::logger();
 	}
@@ -38,6 +34,8 @@ class Logger
 	 */
 	public static function emergency(string $message, array $context = [])
 	{
+		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+
 		self::getInstance()->emergency($message, $context);
 	}
 
@@ -55,6 +53,8 @@ class Logger
 	 */
 	public static function alert(string $message, array $context = [])
 	{
+		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+
 		self::getInstance()->alert($message, $context);
 	}
 
@@ -71,6 +71,8 @@ class Logger
 	 */
 	public static function critical(string $message, array $context = [])
 	{
+		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+
 		self::getInstance()->critical($message, $context);
 	}
 
@@ -86,6 +88,8 @@ class Logger
 	 */
 	public static function error(string $message, array $context = [])
 	{
+		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+
 		self::getInstance()->error($message, $context);
 	}
 
@@ -103,6 +107,8 @@ class Logger
 	 */
 	public static function warning(string $message, array $context = [])
 	{
+		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+
 		self::getInstance()->warning($message, $context);
 	}
 
@@ -117,6 +123,8 @@ class Logger
 	 */
 	public static function notice(string $message, array $context = [])
 	{
+		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+
 		self::getInstance()->notice($message, $context);
 	}
 
@@ -134,6 +142,8 @@ class Logger
 	 */
 	public static function info(string $message, array $context = [])
 	{
+		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+
 		self::getInstance()->info($message, $context);
 	}
 
@@ -148,6 +158,8 @@ class Logger
 	 */
 	public static function debug(string $message, array $context = [])
 	{
+		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+
 		self::getInstance()->debug($message, $context);
 	}
 }

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -34,7 +34,7 @@ class Logger
 	 */
 	public static function emergency(string $message, array $context = [])
 	{
-		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->emergency($message, $context);
 	}
@@ -53,7 +53,7 @@ class Logger
 	 */
 	public static function alert(string $message, array $context = [])
 	{
-		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->alert($message, $context);
 	}
@@ -71,7 +71,7 @@ class Logger
 	 */
 	public static function critical(string $message, array $context = [])
 	{
-		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->critical($message, $context);
 	}
@@ -88,7 +88,7 @@ class Logger
 	 */
 	public static function error(string $message, array $context = [])
 	{
-		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->error($message, $context);
 	}
@@ -107,7 +107,7 @@ class Logger
 	 */
 	public static function warning(string $message, array $context = [])
 	{
-		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->warning($message, $context);
 	}
@@ -123,7 +123,7 @@ class Logger
 	 */
 	public static function notice(string $message, array $context = [])
 	{
-		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->notice($message, $context);
 	}
@@ -142,7 +142,7 @@ class Logger
 	 */
 	public static function info(string $message, array $context = [])
 	{
-		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->info($message, $context);
 	}
@@ -158,7 +158,7 @@ class Logger
 	 */
 	public static function debug(string $message, array $context = [])
 	{
-		trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->debug($message, $context);
 	}

--- a/src/DI.php
+++ b/src/DI.php
@@ -332,7 +332,7 @@ abstract class DI
 	 */
 	public static function workerLogger()
 	{
-		trigger_error('`' . __METHOD__ . '()` is deprecated since 2025.02 and will be removed after 5 months, use `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('`' . __METHOD__ . '()` is deprecated since 2025.02 and will be removed after 5 months, use `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		return self::$dice->create(Core\Logger\Type\WorkerLogger::class);
 	}

--- a/src/DI.php
+++ b/src/DI.php
@@ -332,9 +332,16 @@ abstract class DI
 	 */
 	public static function workerLogger()
 	{
+		trigger_error('`' . __METHOD__ . '()` is deprecated since 2025.02 and will be removed after 5 months, use `DI::logger()` instead.', E_USER_DEPRECATED);
+
 		return self::$dice->create(Core\Logger\Type\WorkerLogger::class);
 	}
 
+	/**
+	 * @internal Only for use in Friendica\Core\Worker class
+	 *
+	 * @see Friendica\Core\Worker::execFunction()
+	 */
 	public static function loggerManager(): LoggerManager
 	{
 		return self::$dice->create(LoggerManager::class);


### PR DESCRIPTION
We have removed all calls of `Friendica\Core\Logger`, see #14688 and https://git.friendi.ca/friendica/friendica-addons/pulls/1594

This PR hard-deprecates `Friendica\Core\Logger` and the `DI::workerLogger()` method. I also changed the log level for `E_USER_DEPRECATIONS` from `notice` to `warning` because it is more likely that ignoring this errors will become a bigger problem soon.

I also improved the ErrorHanlder. If one is calling a hard-deprecated method (and logs are enabled), the logs will show exactly where the deprecated code where called. This way addon maintainer and users can find (and search for) deprecations in their addons, as I mentioned in #14694.

![grafik](https://github.com/user-attachments/assets/ed129543-0e4a-42bc-8170-61ab07260684)
