### PR TITLE
Prioritize coalescing parameters in Moderation\Users\*->processGetActions

### DIFF
--- a/src/Module/Moderation/Users/Active.php
+++ b/src/Module/Moderation/Users/Active.php
@@ -125,7 +125,7 @@ class Active extends BaseUsers
 	private function processGetActions(): void
 	{
 		$action = (string) ($this->parameters['action'] ?? '');
-		$uid = (int) ($this->parameters['uid'] ?? 0);
+		$uid    = (int) ($this->parameters['uid'] ?? 0);
 
 		if ($uid === 0) {
 			return;
@@ -150,6 +150,7 @@ class Active extends BaseUsers
 				}
 
 				$this->baseUrl->redirect('moderation/users/active');
+				// no break
 			case 'block':
 				self::checkFormSecurityTokenRedirectOnError('moderation/users/active', 'moderation_users_active', 't');
 				User::block($uid);

--- a/src/Module/Moderation/Users/Active.php
+++ b/src/Module/Moderation/Users/Active.php
@@ -124,8 +124,8 @@ class Active extends BaseUsers
 	 */
 	private function processGetActions(): void
 	{
-		$action = (string)$this->parameters['action'] ?? '';
-		$uid = (int)$this->parameters['uid'] ?? 0;
+		$action = (string) ($this->parameters['action'] ?? '');
+		$uid = (int) ($this->parameters['uid'] ?? 0);
 
 		if ($uid === 0) {
 			return;

--- a/src/Module/Moderation/Users/Blocked.php
+++ b/src/Module/Moderation/Users/Blocked.php
@@ -124,7 +124,7 @@ class Blocked extends BaseUsers
 	private function processGetActions(): void
 	{
 		$action = (string) ($this->parameters['action'] ?? '');
-		$uid = (int) ($this->parameters['uid'] ?? 0);
+		$uid    = (int) ($this->parameters['uid'] ?? 0);
 
 		if ($uid === 0) {
 			return;
@@ -148,6 +148,7 @@ class Blocked extends BaseUsers
 					$this->systemMessages->addNotice($this->t('You can\'t remove yourself'));
 				}
 				$this->baseUrl->redirect('moderation/users/blocked');
+				// no break
 			case 'unblock':
 				self::checkFormSecurityTokenRedirectOnError('/moderation/users/blocked', 'moderation_users_blocked', 't');
 				User::block($uid, false);

--- a/src/Module/Moderation/Users/Blocked.php
+++ b/src/Module/Moderation/Users/Blocked.php
@@ -123,8 +123,8 @@ class Blocked extends BaseUsers
 	 */
 	private function processGetActions(): void
 	{
-		$action = (string)$this->parameters['action'] ?? '';
-		$uid = (int)$this->parameters['uid'] ?? 0;
+		$action = (string) ($this->parameters['action'] ?? '');
+		$uid = (int) ($this->parameters['uid'] ?? 0);
 
 		if ($uid === 0) {
 			return;

--- a/src/Module/Moderation/Users/Index.php
+++ b/src/Module/Moderation/Users/Index.php
@@ -135,8 +135,8 @@ class Index extends BaseUsers
 	 */
 	private function processGetActions(): void
 	{
-		$action = (string) $this->parameters['action'] ?? '';
-		$uid = (int) $this->parameters['uid'] ?? 0;
+		$action = (string) ($this->parameters['action'] ?? '');
+		$uid = (int) ($this->parameters['uid'] ?? 0);
 
 		if ($uid === 0) {
 			return;

--- a/src/Module/Moderation/Users/Index.php
+++ b/src/Module/Moderation/Users/Index.php
@@ -136,7 +136,7 @@ class Index extends BaseUsers
 	private function processGetActions(): void
 	{
 		$action = (string) ($this->parameters['action'] ?? '');
-		$uid = (int) ($this->parameters['uid'] ?? 0);
+		$uid    = (int) ($this->parameters['uid'] ?? 0);
 
 		if ($uid === 0) {
 			return;
@@ -161,11 +161,13 @@ class Index extends BaseUsers
 				}
 
 				$this->baseUrl->redirect('moderation/users');
+				// no break
 			case 'block':
 				self::checkFormSecurityTokenRedirectOnError('moderation/users', 'moderation_users', 't');
 				User::block($uid);
 				$this->systemMessages->addNotice($this->t('User "%s" blocked', $user['username']));
 				$this->baseUrl->redirect('moderation/users');
+				// no break
 			case 'unblock':
 				self::checkFormSecurityTokenRedirectOnError('moderation/users', 'moderation_users', 't');
 				User::block($uid, false);


### PR DESCRIPTION
Fix #14759

↪ This was causing missing array index warnings when the casting took precedence