### PR TITLE
Create `addon/` folder in the proper order, since it's now mandatory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,11 +72,7 @@ venv/
 /.idea
 
 #ignore addons directory
-/addons
 /addon
-# except those:
-!/addons/.gitkeep
-!/addon/.gitkeep
 
 #ignore base .htaccess
 /.htaccess

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ venv/
 #ignore addons directory
 /addons
 /addon
+# except those:
+!/addons/.gitkeep
+!/addon/.gitkeep
 
 #ignore base .htaccess
 /.htaccess

--- a/doc/Install.md
+++ b/doc/Install.md
@@ -76,14 +76,6 @@ This makes the software much easier to update.
 The Linux commands to clone the repository into a directory "mywebsite" would be
 
     git clone https://github.com/friendica/friendica.git -b stable mywebsite
-    cd mywebsite
-    bin/composer.phar install --no-dev
-
-Make sure the folder *view/smarty3* exists and is writable by the webserver user, in this case *www-data*
-
-    mkdir -p view/smarty3
-    chown www-data:www-data view/smarty3
-    chmod 775 view/smarty3
 
 Get the addons by going into your website folder.
 
@@ -91,7 +83,17 @@ Get the addons by going into your website folder.
 
 Clone the addon repository (separately):
 
-    git clone https://github.com/friendica/friendica-addons.git -b stable addon
+	git clone https://github.com/friendica/friendica-addons.git -b stable addon
+
+Install the dependencies:
+
+    bin/composer.phar install --no-dev
+
+Make sure the folder *view/smarty3* exists and is writable by the webserver user, in this case *www-data*
+
+    mkdir -p view/smarty3
+    chown www-data:www-data view/smarty3
+    chmod 775 view/smarty3
 
 If you want to use the development version of Friendica you can switch to the develop branch in the repository by running
 


### PR DESCRIPTION
Fixes #14761 

By making sure we have this (`--force`-added) empty file, we ensure the `addon/` folder is being created on fresh installs.

Now the install works without a hitch:
![image](https://github.com/user-attachments/assets/b74ee225-3b74-40a7-ae4e-018c13600412)
