### PR TITLE
[frio] Small CSS fix for circle-update-wrapper shortmode headings

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2708,10 +2708,10 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 #circle-update-wrapper .shortmode .contact-entry-desc {
 	font-size: 12px !important;
 }
-#circle-update-wrapper .shortmode .contact-entry-desc h1.media-heading {
+#circle-update-wrapper .shortmode .contact-entry-desc h4.media-heading {
 	margin: 0;
 }
-#circle-update-wrapper .shortmode .contact-entry-desc h1.media-heading a {
+#circle-update-wrapper .shortmode .contact-entry-desc h4.media-heading a {
 	font-size: 13px !important;
 	white-space: nowrap;
 }


### PR DESCRIPTION
The headings on the circle edit page, (for example `/circle/4`) , are `<h4>`, not `<h1>`.

That seemed to be wrong in the CSS file. 

(The `.shortmode` class is added, when you click on the top right button, for the alternate list layout...)
