### PR TITLE
Faster count queries when updating the info about current node

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2025.02-dev (Interrupted Fern)
--- DB_UPDATE_VERSION 1576
+-- DB_UPDATE_VERSION 1577
 -- ------------------------------------------
 
 
@@ -1609,7 +1609,7 @@ CREATE TABLE IF NOT EXISTS `post-user` (
 	`psid` int unsigned COMMENT 'ID of the permission set of this post',
 	 PRIMARY KEY(`id`),
 	 UNIQUE INDEX `uid_uri-id` (`uid`,`uri-id`),
-	 INDEX `uri-id` (`uri-id`),
+	 INDEX `uri-id_origin_deleted` (`uri-id`,`origin`,`deleted`),
 	 INDEX `parent-uri-id` (`parent-uri-id`),
 	 INDEX `thr-parent-id` (`thr-parent-id`),
 	 INDEX `external-id` (`external-id`),

--- a/doc/database/db_post-user.md
+++ b/doc/database/db_post-user.md
@@ -44,31 +44,31 @@ Fields
 Indexes
 ------------
 
-| Name                 | Fields                  |
-| -------------------- | ----------------------- |
-| PRIMARY              | id                      |
-| uid_uri-id           | UNIQUE, uid, uri-id     |
-| uri-id               | uri-id                  |
-| parent-uri-id        | parent-uri-id           |
-| thr-parent-id        | thr-parent-id           |
-| external-id          | external-id             |
-| replies-id           | replies-id              |
-| owner-id             | owner-id                |
-| author-id            | author-id               |
-| causer-id            | causer-id               |
-| vid                  | vid                     |
-| contact-id           | contact-id              |
-| event-id             | event-id                |
-| psid                 | psid                    |
-| author-id_uid        | author-id, uid          |
-| author-id_created    | author-id, created      |
-| owner-id_created     | owner-id, created       |
-| parent-uri-id_uid    | parent-uri-id, uid      |
-| uid_wall_received    | uid, wall, received     |
-| uid_contactid        | uid, contact-id         |
-| uid_unseen_contactid | uid, unseen, contact-id |
-| uid_unseen           | uid, unseen             |
-| uid_hidden_uri-id    | uid, hidden, uri-id     |
+| Name                  | Fields                  |
+|-----------------------| ----------------------- |
+| PRIMARY               | id                      |
+| uid_uri-id            | UNIQUE, uid, uri-id     |
+| uri-id_origin_deleted | uri-id, origin, deleted |
+| parent-uri-id         | parent-uri-id           |
+| thr-parent-id         | thr-parent-id           |
+| external-id           | external-id             |
+| replies-id            | replies-id              |
+| owner-id              | owner-id                |
+| author-id             | author-id               |
+| causer-id             | causer-id               |
+| vid                   | vid                     |
+| contact-id            | contact-id              |
+| event-id              | event-id                |
+| psid                  | psid                    |
+| author-id_uid         | author-id, uid          |
+| author-id_created     | author-id, created      |
+| owner-id_created      | owner-id, created       |
+| parent-uri-id_uid     | parent-uri-id, uid      |
+| uid_wall_received     | uid, wall, received     |
+| uid_contactid         | uid, contact-id         |
+| uid_unseen_contactid  | uid, unseen, contact-id |
+| uid_unseen            | uid, unseen             |
+| uid_hidden_uri-id     | uid, hidden, uri-id     |
 
 Foreign Keys
 ------------

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -44,7 +44,7 @@ use Friendica\Database\DBA;
 
 // This file is required several times during the test in DbaDefinition which justifies this condition
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1576);
+	define('DB_UPDATE_VERSION', 1577);
 }
 
 return [
@@ -1604,7 +1604,7 @@ return [
 		"indexes" => [
 			"PRIMARY" => ["id"],
 			"uid_uri-id" => ["UNIQUE", "uid", "uri-id"],
-			"uri-id" => ["uri-id"],
+			"uri-id_origin_deleted" => ["uri-id", "origin", "deleted"],
 			"parent-uri-id" => ["parent-uri-id"],
 			"thr-parent-id" => ["thr-parent-id"],
 			"external-id" => ["external-id"],


### PR DESCRIPTION
MySQL optimiser seems to prefer a full table scan of `post-user` table in the count query mentioned in issue #14763. When the origin and deleted columns are added to the index, the IN-query part of the query can be done with index-only scan, which is much faster.

Adding the columns in the order

    uri-id, origin, deleted

allows some other queries to also use it when checking for uri-id and origin.

Fixes #14763