### PR TITLE
Add composer script for production installation

### DIFF
--- a/.devcontainer/postCreateFriendicaSetup.sh
+++ b/.devcontainer/postCreateFriendicaSetup.sh
@@ -7,7 +7,7 @@ echo ">>> Friendica Setup"
 
 FRIENDICA_PHP_PATH=$(which php)
 export FRIENDICA_PHP_PATH
-  
+
 envsubst < $workspaceFolder/.devcontainer/include/autoinstall.config.php > /tmp/autoinstall.config.php
 cp $workspaceFolder/.devcontainer/include/00apcu.config.php $workspaceFolder/config/00apcu.config.php
 cp $workspaceFolder/.devcontainer/include/01redis.config.php $workspaceFolder/config/01redis.config.php
@@ -19,7 +19,7 @@ cd $DocumentRoot
 # copy the .htaccess-dist file to .htaccess so that rewrite rules work
 cp $DocumentRoot/.htaccess-dist $DocumentRoot/.htaccess
 
-bin/composer.phar --no-dev install
+bin/composer.phar install
 
 # install friendica
 bin/console autoinstall -f /tmp/autoinstall.config.php

--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,6 @@
 		},
 		"sort-packages": true,
 		"autoloader-suffix": "Friendica",
-		"optimize-autoloader": true,
 		"preferred-install": "dist",
 		"allow-plugins": {
 			"composer/installers": true,
@@ -174,6 +173,7 @@
 			"@cs:install",
 			"bin/dev/php-cs-fixer/vendor/bin/php-cs-fixer fix"
 		],
-		"cs:fix-develop": "TARGET_BRANCH=develop COMMAND=fix bin/dev/fix-codestyle.sh"
+		"cs:fix-develop": "TARGET_BRANCH=develop COMMAND=fix bin/dev/fix-codestyle.sh",
+		"install:prod": "@composer install -o --no-dev"
 	}
 }

--- a/doc/Developers-Intro.md
+++ b/doc/Developers-Intro.md
@@ -62,7 +62,7 @@ If you want to have git automatically update the dependencies with composer, you
     }
     # `composer install` if the `composer.lock` file gets changed
     # to update all the php dependencies
-    check_run composer.lock "bin/composer.phar install --no-dev"
+    check_run composer.lock "bin/composer.phar install"
 
 just place it into `.git/hooks/post-merge` and make it executable.
 

--- a/doc/Install.md
+++ b/doc/Install.md
@@ -87,7 +87,7 @@ Clone the addon repository (separately):
 
 Install the dependencies:
 
-    bin/composer.phar install --no-dev
+    bin/composer.phar run install:prod
 
 Make sure the folder *view/smarty3* exists and is writable by the webserver user, in this case *www-data*
 
@@ -98,7 +98,7 @@ Make sure the folder *view/smarty3* exists and is writable by the webserver user
 If you want to use the development version of Friendica you can switch to the develop branch in the repository by running
 
     git checkout develop
-    bin/composer.phar install
+    bin/composer.phar run install:prod
     cd addon
     git checkout develop
 

--- a/doc/Update.md
+++ b/doc/Update.md
@@ -14,7 +14,7 @@ If you installed Friendica in the ``path/to/friendica`` folder:
    * ``.htaccess`` if using Apache web server
 
     The following items only need to be copied if they are located inside your friendica path:
-   * your storage folder as set in **Admin -> Site -> File Upload -> Storage base path** 
+   * your storage folder as set in **Admin -> Site -> File Upload -> Storage base path**
    * your item cache as set in **Admin -> Site -> Performance -> Path to item cache**
    * your temp folder as set in **Admin -> Site -> Advanced -> Temp path**
 3. Rename the ``path/to/friendica`` folder to ``path/to/friendica_old``.
@@ -30,7 +30,7 @@ You can get the latest changes at any time with
 
     cd path/to/friendica
     git pull
-    bin/composer.phar install --no-dev
+    bin/composer.phar run install:prod
 
 The addon tree has to be updated separately like so:
 
@@ -89,7 +89,7 @@ Some of the updates include the use of foreign keys now that will bump into issu
 ```
 Error 1452 occurred during database update:
 Cannot add or update a child row: a foreign key constraint fails (`friendica`.`#sql-10ea6_5a6d`, CONSTRAINT `#sql-10ea6_5a6d_ibfk_1` FOREIGN KEY (`contact-id`) REFERENCES `contact` (`id`))
-ALTER TABLE `thread` ADD FOREIGN KEY (`iid`) REFERENCES `item` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE; 
+ALTER TABLE `thread` ADD FOREIGN KEY (`iid`) REFERENCES `item` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE;
 ```
 
 All current known fixes for possible items that can go wrong are as below.

--- a/doc/Vagrant.md
+++ b/doc/Vagrant.md
@@ -18,7 +18,7 @@ What you need to do:
 Please use an up-to-date vagrant version from https://www.vagrantup.com/downloads.html.
 2. Git clone your Friendica repository.
 Inside, you'll find a `Vagrantfile` and some scripts in the `bin/dev` folder.
-Pull the PHP requirements with `bin/composer install`.
+Pull the PHP requirements with `bin/composer.phar install`.
 3. Run `vagrant up` from inside the friendica clone.
 This will start the virtual machine.
 Be patient: When it runs for the first time, it downloads a Debian Server image and installs Friendica.
@@ -60,7 +60,7 @@ Trouble Shooting
 If you see a version mis-match for the _VirtualBox Guest Additions_ between host and guest during the initial setup of the Vagrant VM, you will need to install an addon to Vagrant (ref. [Stack Overflow](https://stackoverflow.com/a/38010683)).
 Stop the Vagrant VM and run the following command:
 
-	$> vagrant plugin install vagrant-vbguest 
+	$> vagrant plugin install vagrant-vbguest
 
 On the next Vagrant up, the version problem should be fixed.
 

--- a/doc/de/Install.md
+++ b/doc/de/Install.md
@@ -59,7 +59,7 @@ Der Linux-Code, mit dem man die Dateien direkt in ein Verzeichnis wie "meinewebs
 
     git clone https://github.com/friendica/friendica.git -b stable mywebsite
     cd mywebsite
-    bin/composer.phar install
+    bin/composer.phar run install:prod
 
 Stelle sicher, dass der Ordner *view/smarty3* existiert and von dem Webserver-Benutzer beschreibbar ist
 
@@ -85,7 +85,7 @@ Wenn du die Entwickler Version von Friendica verwenden möchtest kannst du auf d
 Dies tust du mit den folgenden Befehlen
 
     git checkout develop
-    bin/composer.phar install
+    bin/composer.phar run install:prod
     cd addon
     git checkout develop
 

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@
 $start_time = microtime(true);
 
 if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
-	die('Vendor path not found. Please execute "bin/composer.phar --no-dev install" on the command line in the web root.');
+	die('Vendor path not found. Please execute "bin/composer.phar run install:prod" on the command line in the web root.');
 }
 
 require __DIR__ . '/vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,7 +8,7 @@
 use PHPUnit\Framework\TestCase;
 
 if (!file_exists(__DIR__ . '/../vendor/autoload.php')) {
-	die('Vendor path not found. Please execute "bin/composer.phar --no-dev install" on the command line in the web root.');
+	die('Vendor path not found. Please execute "bin/composer.phar install" on the command line in the web root.');
 }
 
 require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
[The composer docs](https://getcomposer.org/doc/articles/autoloader-optimization.md#autoloader-optimization) stated:

> **Note:** You **should not** enable any of these optimizations in **development** as they all will cause various problems when adding/removing classes. The performance gains are not worth the trouble in a development setting.

This PR removes the optimization for autoload files in composer and adds a new composer script for installation on production systems:

```
bin/composer.phar run install:prod
```

The script runs `composer install -o --no-dev`, so on production one only has to run this command withoud any options. On development we can use `composer.phar install` directly without getting troubles with the optimizations.

Refs https://github.com/friendica/friendica/pull/14640#issuecomment-2638006561