### PR TITLE
Fix Crypto::randomDigits()

### DIFF
--- a/src/Util/Crypto.php
+++ b/src/Util/Crypto.php
@@ -299,11 +299,11 @@ class Crypto
 	 * Creates cryptographic secure random digits
 	 *
 	 * @param string $digits The count of digits
-	 * @return int The random Digits
+	 * @return string The random Digits
 	 *
 	 * @throws \Exception In case 'random_int' isn't usable
 	 */
-	public static function randomDigits($digits)
+	public static function randomDigits($digits): string
 	{
 		$rn = '';
 
@@ -312,6 +312,6 @@ class Crypto
 			$rn .= random_int(0, 9);
 		}
 
-		return (int) $rn;
+		return $rn;
 	}
 }

--- a/src/Util/Crypto.php
+++ b/src/Util/Crypto.php
@@ -305,6 +305,13 @@ class Crypto
 	 */
 	public static function randomDigits($digits)
 	{
-		return random_int(0, 10 ** $digits - 1);
+		$rn = '';
+
+		// generating cryptographically secure pseudo-random integers
+		for ($i = 0; $i < $digits; $i++) {
+			$rn .= random_int(0, 9);
+		}
+
+		return (int) $rn;
 	}
 }

--- a/tests/Unit/Util/CryptoTest.php
+++ b/tests/Unit/Util/CryptoTest.php
@@ -21,10 +21,11 @@ class CryptoTest extends TestCase
 	{
 		$random_int = $this->getFunctionMock('Friendica\Util', 'random_int');
 		$random_int->expects($this->any())->willReturnCallback(function ($min, $max) {
-			return 12345678;
+			return 1;
 		});
 
-		self::assertSame(12345678, Crypto::randomDigits(8));
+		self::assertSame(1, Crypto::randomDigits(1));
+		self::assertSame(11111111, Crypto::randomDigits(8));
 	}
 
 	public function testDiasporaPubRsaToMe()

--- a/tests/Unit/Util/CryptoTest.php
+++ b/tests/Unit/Util/CryptoTest.php
@@ -24,8 +24,8 @@ class CryptoTest extends TestCase
 			return 1;
 		});
 
-		self::assertSame(1, Crypto::randomDigits(1));
-		self::assertSame(11111111, Crypto::randomDigits(8));
+		self::assertSame('1', Crypto::randomDigits(1));
+		self::assertSame('11111111', Crypto::randomDigits(8));
 	}
 
 	public function testDiasporaPubRsaToMe()


### PR DESCRIPTION
This PR reverts commit 940884e4bd0c1f68757e464f46b4e76c1f4da5b1 and lets `Crypto::randomDigits()` return a string again.

Fixes https://github.com/friendica/friendica/issues/14646#issuecomment-2636672857