### PR TITLE
Deprecate the strategy concept for addons

### DIFF
--- a/doc/StrategyHooks.md
+++ b/doc/StrategyHooks.md
@@ -83,6 +83,8 @@ return [
 
 ## Addons
 
+> ⚠️ Since Friendica 2025.02 the strategy hooks for addons are deprecated, please use PHP hooks instead.
+
 The hook logic is useful for decoupling the Friendica core logic, but its primary goal is to modularize Friendica in creating addons.
 
 Therefor you can either use the interfaces directly as shown above, or you can place your own `hooks.config.php` file inside a `static` directory directly under your addon core directory.

--- a/src/Core/Addon/Model/AddonLoader.php
+++ b/src/Core/Addon/Model/AddonLoader.php
@@ -10,7 +10,9 @@ namespace Friendica\Core\Addon\Model;
 use Friendica\Core\Addon\Capability\ICanLoadAddons;
 use Friendica\Core\Addon\Exception\AddonInvalidConfigFileException;
 use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\Logger\Factory\LoggerFactory;
 use Friendica\Util\Strings;
+use Psr\Log\LoggerInterface;
 
 class AddonLoader implements ICanLoadAddons
 {
@@ -46,6 +48,19 @@ class AddonLoader implements ICanLoadAddons
 
 			if (!is_array($config)) {
 				throw new AddonInvalidConfigFileException('Error loading config file ' . $configFile);
+			}
+
+			if ($configName === 'strategies') {
+				foreach ($config as $classname => $rule) {
+					if ($classname === LoggerInterface::class) {
+						@trigger_error(sprintf(
+							'Providing a strategy for `%s` is deprecated since 2025.02, please provide an implementation for `%s` via `dependency.config.php` instead in %s addon.',
+							LoggerInterface::class,
+							LoggerFactory::class,
+							$addonName,
+						), \E_USER_DEPRECATED);
+					}
+				}
 			}
 
 			$returnConfig = array_merge_recursive($returnConfig, $config);

--- a/src/Core/Addon/Model/AddonLoader.php
+++ b/src/Core/Addon/Model/AddonLoader.php
@@ -54,9 +54,15 @@ class AddonLoader implements ICanLoadAddons
 				foreach ($config as $classname => $rule) {
 					if ($classname === LoggerInterface::class) {
 						@trigger_error(sprintf(
-							'Providing a strategy for `%s` is deprecated since 2025.02, please provide an implementation for `%s` via `dependency.config.php` instead in %s addon.',
-							LoggerInterface::class,
+							'Providing a strategy for `%s` is deprecated since 2025.02 and will stop working in 5 months, please provide an implementation for `%s` via `dependency.config.php` and remove the `strategies.config.php` file in the `%s` addon.',
+							$classname,
 							LoggerFactory::class,
+							$addonName,
+						), \E_USER_DEPRECATED);
+					} else {
+						@trigger_error(sprintf(
+							'Providing strategies for `%s` via addons is deprecated since 2025.02 and will stop working in 5 months, please stop using this and remove the `strategies.config.php` file in the `%s` addon.',
+							$classname,
 							$addonName,
 						), \E_USER_DEPRECATED);
 					}

--- a/src/Core/Hooks/Util/StrategiesFileManager.php
+++ b/src/Core/Hooks/Util/StrategiesFileManager.php
@@ -81,6 +81,9 @@ class StrategiesFileManager
 			throw new HookConfigException(sprintf('Error loading config file %s.', $configFile));
 		}
 
+		/**
+		 * @deprecated 2025.02 Providing strategies via addons is deprecated and will be removed in 5 months.
+		 */
 		$this->config = array_merge_recursive($config, $this->addonLoader->getActiveAddonConfig(static::CONFIG_NAME));
 	}
 }


### PR DESCRIPTION
While refactoring the logger system, addon system, App class and Container I noticed a complicated coupling to the addons. Especially the possibilities for providing Dice dependencies via `static/dependencies.config.php` and `static/strategies.config.php` files is a bigger problem, because we cannot setup the Friendica App without loading the addons first.

In #14724 I've created an alterative how addons may provide their own dependencies via `DependencyProvider::provideDependencyRules()`, so this can be refactored in the future.

The next problem is the `strategy` concept. I cannot find an easy way how we can decouple this concept from the Friendica core. But I noticed that this feature is only used in the monolog addon atm.

I've already create a PR for the monolog addon to switch from the strategy concept to provide a `LoggerFactory` implementation using the `dependency` concept, see https://git.friendi.ca/friendica/friendica-addons/pulls/1598

So there is no more official addon that uses this concept. So I propose in this PR to deprecate the strategy concept for addons and remove it in the future. Without this dependencies refactoring will become much easier.

This PR adds `trigger_error()` calls, but due the fact that the addon strategies are loaded **before** the Error handler or LoggerManager is loaded, these errors won't be logged in the logs. But I don't think that this should be a problem.