### PR TITLE
Fix refresh after commenting

### DIFF
--- a/view/js/main.js
+++ b/view/js/main.js
@@ -632,11 +632,13 @@ function liveUpdate(src) {
 
 	var orgHeight = $("section").height();
 
+	var update_url = getUpdateUrl(src);
+
 	if (force_update) {
 		force_update = false;
 	}
 
-	$.get('update_' + getUpdateUrl(src), function(data) {
+	$.get('update_' + update_url, function(data) {
 		in_progress = false;
 		update_item = 0;
 


### PR DESCRIPTION
This is a small fix for PR #14803. On the network page the content wasn't updated anymore after a comment had been posted.