### PR TITLE
Fixes fatal error "Return value must be of type Friendica\Object\OEmbed, string returned"

### DIFF
--- a/src/Content/OEmbed.php
+++ b/src/Content/OEmbed.php
@@ -184,13 +184,16 @@ class OEmbed
 
 		$eventDispatcher = DI::eventDispatcher();
 
-		$oembed_data = ['url' => $embedurl];
+		$oembed_data = [
+			'url'  => $embedurl,
+			'data' => $oembed,
+		];
 
 		$oembed_data = $eventDispatcher->dispatch(
 			new ArrayFilterEvent(ArrayFilterEvent::OEMBED_FETCH_END, $oembed_data),
 		)->getArray();
 
-		return $oembed_data['url'] ?? $embedurl;
+		return $oembed_data['data'];
 	}
 
 	/**


### PR DESCRIPTION
See https://github.com/friendica/friendica/issues/14646#issuecomment-2692621100