### PR TITLE
[frio] Fix Safari bug where notification icon jumps to next line

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -629,6 +629,14 @@ nav.navbar .nav > li > button:focus {
 	text-align: center;
 	z-index: 1;
 }
+/* Workaround for Safari bug where the notification icon jumps on the next line */
+#topbar-first .topbar-nav .nav > li + li {
+	margin-left: 1px;
+}
+#topbar-first .topbar-nav .nav > li + li > a {
+	margin-left: -1px;
+}
+/* End workaround */
 #topbar-first .topbar-nav .nav-segment {
 	position: relative;
 	text-align: left;


### PR DESCRIPTION
Fix #14801 

It looks like we're stretching the Bootstrap framework past its limits. `nav`-class elements are expected to have an additional class for the type of navigation bar, like `nav-pills` or `nav-tabs`. Both of them interfere with the custom styles we wrote for the top menu, but they do fix the alignment issue on Safari.

I ended up adding the specific property that did the trick, and compensating for the added margin by removing some for the inside element.

If it sounds stupid, it's because it is, but it's working so we should close the door on this and never speak of it again.