### PR TITLE
Remove BC promise for extending any non-abstract class

### DIFF
--- a/doc/Developers-Intro.md
+++ b/doc/Developers-Intro.md
@@ -170,6 +170,7 @@ This is called the Backward Compatibility Promise.
 Inspired by the [Symonfy BC promise](https://symfony.com/doc/current/contributing/code/bc.html) we promise BC for every class, interface, trait, enum, function, constant, etc., but with the exception of:
 
 - Classes, interfaces, traits, enums, functions, methods, properties and constants marked as `@internal` or `@private`
+- Extending or modifying any non-abstract class or method in any way
 - Extending or modifying a `final` class or method in any way
 - Calling `private` methods (via Reflection)
 - Accessing `private` properties (via Reflection)


### PR DESCRIPTION
This PR removes the BC promise for extending any non-abstract class. This will make the refactoring easier.

refs https://github.com/friendica/friendica/pull/14830#discussion_r1984418489