### PR TITLE
Improved support for backfilled posts

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1090,9 +1090,9 @@ class Item
 		}
 
 		if ($update_commented) {
-			$fields = ['commented' => DateTimeFormat::utcNow(), 'changed' => DateTimeFormat::utcNow()];
+			$fields = ['commented' => $posted_item['received'], 'changed' => $posted_item['received']];
 		} else {
-			$fields = ['changed' => DateTimeFormat::utcNow()];
+			$fields = ['changed' => $posted_item['received']];
 		}
 
 		Post::update($fields, ['uri-id' => $posted_item['parent-uri-id'], 'uid' => $posted_item['uid']]);

--- a/src/Model/ItemHelper.php
+++ b/src/Model/ItemHelper.php
@@ -205,13 +205,25 @@ final class ItemHelper
 		$item['file']          = trim($item['file'] ?? '');
 
 		// Items cannot be stored before they happen ...
-		if ($item['created'] > DateTimeFormat::utcNow()) {
-			$item['created'] = DateTimeFormat::utcNow();
+		if ($item['received'] > DateTimeFormat::utcNow()) {
+			$item['received'] = DateTimeFormat::utcNow();
+		}
+
+		if ($item['created'] > $item['received']) {
+			$item['created'] = $item['received'];
 		}
 
 		// We haven't invented time travel by now.
-		if ($item['edited'] > DateTimeFormat::utcNow()) {
-			$item['edited'] = DateTimeFormat::utcNow();
+		if ($item['edited'] > $item['received'] ) {
+			$item['edited'] = $item['received'] ;
+		}
+
+		if ($item['changed'] > $item['received'] ) {
+			$item['changed'] = $item['received'] ;
+		}
+
+		if ($item['commented'] > $item['received'] ) {
+			$item['commented'] = $item['received'] ;
 		}
 
 		$item['plink'] = ($item['plink'] ?? '') ?: $this->baseUrl . '/display/' . urlencode($item['guid']);


### PR DESCRIPTION
Especially on Bluesky it happens regularly that people import their old Tweets. By now they clodged the current timeline. This is now mostly handled.

Only problem left is the API, since there we have to display the posts via their ID. So these old posts will still show up via API, but that is something that isn't easily to solve.