### PR TITLE
Viewing other's profiles in default theme over the profile owner's when not logged in.

### DIFF
--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -52,22 +52,26 @@ if (DI::mode()->has(\Friendica\App\Mode::MAINTENANCEDISABLED)) {
 	$login_bg_color   = DI::config()->get('frio', 'login_bg_color')   ?: $login_bg_color;
 	$modified         = DI::config()->get('frio', 'css_modified')     ?: $modified;
 
-	// Get the UID of the profile owner.
-	$uid = $_REQUEST['puid'] ?? 0;
-	if ($uid) {
-		DI::pConfig()->load($uid, 'frio');
+	if (DI::userSession()->getLocalUserId()) {
+		// Get the UID of the profile owner.
+		$uid = $_REQUEST['puid'] ?? 0;
+		if ($uid) {
+			DI::pConfig()->load($uid, 'frio');
 
-		// Only override display settings that have actually been set
-		$scheme           = frio_scheme_get_current_for_user($uid);
-		$scheme_accent    = DI::pConfig()->get($uid, 'frio', 'scheme_accent')    ?: $scheme_accent;
-		$nav_bg           = DI::pConfig()->get($uid, 'frio', 'nav_bg')           ?: $nav_bg;
-		$nav_icon_color   = DI::pConfig()->get($uid, 'frio', 'nav_icon_color')   ?: $nav_icon_color;
-		$link_color       = DI::pConfig()->get($uid, 'frio', 'link_color')       ?: $link_color;
-		$background_color = DI::pConfig()->get($uid, 'frio', 'background_color') ?: $background_color;
-		$contentbg_transp = DI::pConfig()->get($uid, 'frio', 'contentbg_transp') ?? $contentbg_transp;
-		$background_image = DI::pConfig()->get($uid, 'frio', 'background_image') ?: $background_image;
-		$bg_image_option  = DI::pConfig()->get($uid, 'frio', 'bg_image_option')  ?: $bg_image_option;
-		$modified         = DI::pConfig()->get($uid, 'frio', 'css_modified')     ?: $modified;
+			// Only override display settings that have actually been set
+			$scheme           = frio_scheme_get_current_for_user($uid);
+			$scheme_accent    = DI::pConfig()->get($uid, 'frio', 'scheme_accent')    ?: $scheme_accent;
+			$nav_bg           = DI::pConfig()->get($uid, 'frio', 'nav_bg')           ?: $nav_bg;
+			$nav_icon_color   = DI::pConfig()->get($uid, 'frio', 'nav_icon_color')   ?: $nav_icon_color;
+			$link_color       = DI::pConfig()->get($uid, 'frio', 'link_color')       ?: $link_color;
+			$background_color = DI::pConfig()->get($uid, 'frio', 'background_color') ?: $background_color;
+			$contentbg_transp = DI::pConfig()->get($uid, 'frio', 'contentbg_transp') ?? $contentbg_transp;
+			$background_image = DI::pConfig()->get($uid, 'frio', 'background_image') ?: $background_image;
+			$bg_image_option  = DI::pConfig()->get($uid, 'frio', 'bg_image_option')  ?: $bg_image_option;
+			$modified         = DI::pConfig()->get($uid, 'frio', 'css_modified')     ?: $modified;
+		}
+	} else {
+		$uid = 0;
 	}
 }
 


### PR DESCRIPTION
Fixes issue I stumbled across when you visit someone's profile while you are NOT logged into that server it *should* show the profile using the server's default Frio scheme setting, but it was pulling the $uid for the profile you are looking at along with their $scheme preference instead.

So if the default was set to Frio "Dark" and the person whose profile you're looking at has it set to "Light" you would see that instead of "Dark." But it would work properly on the login page or the info page. It was only messed up on profiles because it was pulling the wrong user ID number. The user ID *should* be 0 (zero) for anyone who is not logged in. So I wrapped the user settings in a check for whether or not the person currently viewing the profile is logged in or not.

At least I *think* this is how to check if a user is logged in. It seems to work on my dev server. This is something you'd never notice if the person whose profile you're looking at had the same Frio scheme as the site default, and you'd also never notice it if you were looking at profiles while logged in because then it uses your own scheme preference.