### PR TITLE
Log uncaught exceptions as critical

### DIFF
--- a/src/Core/Logger/Handler/ErrorHandler.php
+++ b/src/Core/Logger/Handler/ErrorHandler.php
@@ -208,7 +208,7 @@ class ErrorHandler
 	 */
 	private function handleException(Throwable $e): void
 	{
-		$level = LogLevel::ERROR;
+		$level = LogLevel::CRITICAL;
 		foreach ($this->uncaughtExceptionLevelMap as $class => $candidate) {
 			if ($e instanceof $class) {
 				$level = $candidate;


### PR DESCRIPTION
I noticed that uncaught exceptions where logged as error. I propose to log them as critical, because this will lead to an WSOD and should not be happen.