### PR TITLE
Bluesky: use did based profile links

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -1729,7 +1729,7 @@ class Probe
 		$data = [
 			'network' => Protocol::BLUESKY,
 			'url'     => $profile->did,
-			'alias'   => ATProtocol::WEB . '/profile/' . $nick,
+			'alias'   => ATProtocol::WEB . '/profile/' . $profile->did,
 			'name'    => $name ?: $nick,
 			'nick'    => $nick,
 			'addr'    => $nick,

--- a/src/Protocol/ATProtocol/Actor.php
+++ b/src/Protocol/ATProtocol/Actor.php
@@ -117,7 +117,7 @@ class Actor
 		$name = $profile->displayName ?? $nick;
 
 		$fields = [
-			'alias'   => ATProtocol::WEB . '/profile/' . $nick,
+			'alias'   => ATProtocol::WEB . '/profile/' . $profile->did,
 			'name'    => $name ?: $nick,
 			'nick'    => $nick,
 			'addr'    => $nick,

--- a/src/Protocol/ATProtocol/Processor.php
+++ b/src/Protocol/ATProtocol/Processor.php
@@ -72,7 +72,7 @@ class Processor
 	public function processIdentity(stdClass $data)
 	{
 		$fields = [
-			'alias'   => ATProtocol::WEB . '/profile/' . $data->identity->handle,
+			'alias'   => ATProtocol::WEB . '/profile/' . $data->identity->did,
 			'nick'    => $data->identity->handle,
 			'addr'    => $data->identity->handle,
 			'updated' => DateTimeFormat::utc($data->identity->time, DateTimeFormat::MYSQL),


### PR DESCRIPTION
Currently we use the handle of a bluesky user for the path to their profile and their posts. This is a problem when someone changes their handle.

The solution to this problem is to use the DID instead since this cannot change.