### PR TITLE
Strip HTML tags from content sent as Markdown

### DIFF
--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -689,7 +689,7 @@ class HTML
 	public static function toMarkdown(string $html): string
 	{
 		DI::profiler()->startRecording('rendering');
-		$converter = new HtmlConverter(['hard_break' => true]);
+		$converter = new HtmlConverter(['hard_break' => true, ‘strip_tags’ => true]]);
 		$markdown  = $converter->convert($html);
 
 		DI::profiler()->stopRecording();


### PR DESCRIPTION
The "toMarkdown" function prepares content to be sent, primarily, to Diaspora.

The HTML to Markdown converter by default "preserves HTML tags without Markdown equivalents like `<span>` and `<div>.`" At least according to the README in _/friendica/vendor/league/html-to-markdown/_ - which also says "To strip HTML tags that don’t have a Markdown equivalent while preserving the content inside them, set strip_tags..."

Diaspora, however, does not appear to know what to DO with the HTML sent to it. It actually appears to _encode_ the HTML and displays the *code* in the post body rather than rendering it as HTML. In which case it would make more sense to strip out all tags that have no Markdown equivalents.

**Example**
The  post as sent from Friendica mixed BBcode and Markdown:

`[class=postbox-ocean]Norddeutscher Bürger ![Noddeutscher Bürger - Bismark Brötchen (Roger Cziwerny - pixapay)](/rscamo/……)[/class]`

The BBcode gets converted into an HTML `<span>` tag. And this screenshot shows how it came through to Diaspora:

![39405527-1](https://github.com/user-attachments/assets/17f1dda7-cc42-453d-99c6-7aa8c643067c)

It _also_ looks like Diaspora encoded the Markdown for the image rather than parsing it, or at the very least didn't parse it as Markdown. Yet another reason to strip out HTML that has no Markdown equivalents. It looks like it may be encoding the tags _and_ the content inside the tags.

And, yes, I'm aware the `[class]` BBcode was marked as "deprecated" in the Friendica code, but it's the only way my _Bookface_ scheme for the "Frio" theme could implement both profile "Cover Photos" and "Postboxes." Which won't display to other platforms anyway, so I don't want to see this custom BBcode removed, I just think it needs to be stripped out before content is delivered to other platforms.

_(There is a related issue with Hubzilla where the raw BBcode is coming through unparsed because the `[class]` code apparently does not exist in Hubzilla's BBcodes. But I've no clue where or how to fix that in Friendica or if it can be as it may need to be handled on Hubzilla's end)._
