### PR TITLE
Make the calendar use the default view mode

### DIFF
--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -397,7 +397,7 @@ class Event
 	{
 		// First day of the week (0 = Sunday).
 		$firstDay    = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'calendar', 'first_day_of_week') ?? 0;
-		$defaultView = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'calendar', 'defaultView')       ?? 'month';
+		$defaultView = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'calendar', 'default_view')       ?? 'month';
 
 		return [
 			'firstDay'    => $firstDay,

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -397,7 +397,7 @@ class Event
 	{
 		// First day of the week (0 = Sunday).
 		$firstDay    = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'calendar', 'first_day_of_week') ?? 0;
-		$defaultView = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'calendar', 'default_view')       ?? 'month';
+		$defaultView = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'calendar', 'default_view')      ?? 'month';
 
 		return [
 			'firstDay'    => $firstDay,


### PR DESCRIPTION
This should make the calendar use the default view mode, that can be set in `/settings/display`  .

(The first bug in the Bugs list in this issue: https://github.com/friendica/friendica/issues/14824 )