### PR TITLE
Capitalize language names in /settings/channels, /settings/display and /network

### DIFF
--- a/src/Content/Conversation/Factory/Channel.php
+++ b/src/Content/Conversation/Factory/Channel.php
@@ -10,6 +10,7 @@ namespace Friendica\Content\Conversation\Factory;
 use Friendica\Content\Conversation\Collection\Timelines;
 use Friendica\Content\Conversation\Entity\Channel as ChannelEntity;
 use Friendica\Model\User;
+use Friendica\Util\Strings;
 
 final class Channel extends Timeline
 {
@@ -21,8 +22,8 @@ final class Channel extends Timeline
 	 */
 	public function getTimelines(int $uid): Timelines
 	{
-		$iso639 = new \Matriphe\ISO639\ISO639;
-		$native = $iso639->nativeByCode1(User::getLanguageCode($uid));
+		$iso639 = new \Matriphe\ISO639\ISO639();
+		$native = Strings::ucFirst($iso639->nativeByCode1(User::getLanguageCode($uid)));
 
 		$tabs = [
 			new ChannelEntity(ChannelEntity::FORYOU, $this->l10n->t('For you'), $this->l10n->t('Posts from contacts you interact with and who interact with you'), 'y'),

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -444,7 +444,7 @@ class L10n
 	 * @param bool $international If set to true, additionally the international language name is returned as well.
 	 * @return array
 	 */
-	public function getLanguageCodes(bool $international = false): array
+	public function getLanguageCodes(bool $international = false, bool $sentence_start_capitalization = false): array
 	{
 		$iso639 = new \Matriphe\ISO639\ISO639();
 
@@ -453,8 +453,11 @@ class L10n
 		$languages = [self::UNDETERMINED_LANGUAGE => $this->t('Undetermined')];
 
 		foreach ($this->getDetectableLanguages() as $code) {
-			$code     = $this->toISO6391($code);
-			$native   = $iso639->nativeByCode1($code);
+			$code   = $this->toISO6391($code);
+			$native = $iso639->nativeByCode1($code);
+			if ($sentence_start_capitalization) {
+				$native = Strings::ucFirst($native);
+			}
 			$language = $iso639->languageByCode1($code);
 			if ($native != $language && $international) {
 				$languages[$code] = $this->t('%s (%s)', $native, $language);

--- a/src/Module/Settings/Channels.php
+++ b/src/Module/Settings/Channels.php
@@ -151,7 +151,7 @@ class Channels extends BaseSettings
 			$circles[$circle['id']] = $circle['name'];
 		}
 
-		$languages         = $this->l10n->getLanguageCodes(true);
+		$languages         = $this->l10n->getLanguageCodes(true, true);
 		$channel_languages = User::getWantedLanguages($uid);
 
 		$channels = [];

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -264,7 +264,7 @@ class Display extends BaseSettings
 		$bookmarked_timelines = $this->pConfig->get($uid, 'system', 'network_timelines', $this->getAvailableTimelines($uid, true)->column('code'));
 		$enabled_timelines    = $this->pConfig->get($uid, 'system', 'enabled_timelines', $this->getAvailableTimelines($uid, false)->column('code'));
 		$channel_languages    = User::getWantedLanguages($uid);
-		$languages            = $this->l10n->getLanguageCodes(true);
+		$languages            = $this->l10n->getLanguageCodes(true, true);
 
 		$timelines = [];
 		foreach ($this->getAvailableTimelines($uid) as $timeline) {


### PR DESCRIPTION
Closes #14910

Before:
![image](https://github.com/user-attachments/assets/7ce465bc-f29c-4905-8e52-0a207de0650c)

After:
![image](https://github.com/user-attachments/assets/c05af86e-623f-4e05-bb4d-2fd5f3ed5707)

Edit: Updated the PR with a better, more targeted solution that also should work for multibyte characters if mb_ucfirst is available.