### PR TITLE
Fix empty HTML content loading (500)

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3282,7 +3282,7 @@ class Item
 		}
 
 		$dom = new \DOMDocument();
-		if (!@$dom->loadHTML($html)) {
+		if (empty ($html) || !@$dom->loadHTML($html)) {
 			return $html;
 		}
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3282,7 +3282,7 @@ class Item
 		}
 
 		$dom = new \DOMDocument();
-		if (empty ($html) || !@$dom->loadHTML($html)) {
+		if (empty($html) || !@$dom->loadHTML($html)) {
 			return $html;
 		}
 


### PR DESCRIPTION
Fixes 
```
ValueError: DOMDocument::loadHTML(): Argument #1 ($source) must not be empty in /var/www/html/src/Model/Item.php:3558
Stack trace:
#0 /var/www/html/src/Model/Item.php(3558): DOMDocument->loadHTML()
#1 /var/www/html/src/Model/Item.php(3481): Friendica\\Model\\Item::replacePlatformIcon()
#2 /var/www/html/src/Object/Post.php(451): Friendica\\Model\\Item::prepareBody()
#3 /var/www/html/src/Object/Thread.php(190): Friendica\\Object\\Post->getTemplateData()
#4 /var/www/html/src/Content/Conversation.php(666): Friendica\\Object\\Thread->getTemplateData()
#5 /var/www/html/src/Content/Conversation.php(569): Friendica\\Content\\Conversation->getThreadList()
#6 /var/www/html/src/Module/Profile/Conversations.php(228): Friendica\\Content\\Conversation->render()
#7 /var/www/html/src/Module/Profile/Index.php(79
```