### PR TITLE
Move contact fetching into module

### DIFF
--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -8,7 +8,6 @@
 namespace Friendica\Core;
 
 use Friendica\DI;
-use Friendica\Model\Contact;
 use Friendica\Util\Strings;
 
 /**
@@ -267,12 +266,6 @@ class Addon
 					if ($type == "author" || $type == "maintainer") {
 						$r = preg_match("|([^<]+)<([^>]+)>|", $v, $m);
 						if ($r) {
-							if (!empty($m[2]) && empty(parse_url($m[2], PHP_URL_SCHEME))) {
-								$contact = Contact::getByURL($m[2], false);
-								if (!empty($contact['url'])) {
-									$m[2] = $contact['url'];
-								}
-							}
 							$info[$type][] = ['name' => $m[1], 'link' => $m[2]];
 						} else {
 							$info[$type][] = ['name' => $v];

--- a/src/Module/Admin/Addons/Details.php
+++ b/src/Module/Admin/Addons/Details.php
@@ -10,6 +10,7 @@ namespace Friendica\Module\Admin\Addons;
 use Friendica\Content\Text\Markdown;
 use Friendica\Core\Renderer;
 use Friendica\DI;
+use Friendica\Model\Contact;
 use Friendica\Module\BaseAdmin;
 use Friendica\Util\Strings;
 
@@ -92,6 +93,35 @@ class Details extends BaseAdmin
 
 		$addonInfo = $addonHelper->getAddonInfo($addon);
 
+		$addonAuthors = [];
+
+		foreach ($addonInfo->getAuthors() as $addonAuthor) {
+			$addonAuthor['link'] = 'foo@bar.com';
+			if (array_key_exists('link', $addonAuthor) && empty(parse_url($addonAuthor['link'], PHP_URL_SCHEME))) {
+				$contact = Contact::getByURL($addonAuthor['link'], false);
+
+				if (!empty($contact['url'])) {
+					$addonAuthor['link'] = $contact['url'];
+				}
+			}
+
+			$addonAuthors[] = $addonAuthor;
+		}
+
+		$addonMaintainers = [];
+
+		foreach ($addonInfo->getMaintainers() as $addonMaintainer) {
+			if (array_key_exists('link', $addonMaintainer) && empty(parse_url($addonMaintainer['link'], PHP_URL_SCHEME))) {
+				$contact = Contact::getByURL($addonMaintainer['link'], false);
+
+				if (!empty($contact['url'])) {
+					$addonMaintainer['link'] = $contact['url'];
+				}
+			}
+
+			$addonMaintainers[] = $addonMaintainer;
+		}
+
 		$t = Renderer::getMarkupTemplate('admin/addons/details.tpl');
 
 		return Renderer::replaceMacros($t, [
@@ -107,8 +137,8 @@ class Details extends BaseAdmin
 				'name'        => $addonInfo->getName(),
 				'version'     => $addonInfo->getVersion(),
 				'description' => $addonInfo->getDescription(),
-				'author'      => $addonInfo->getAuthors(),
-				'maintainer'  => $addonInfo->getMaintainers(),
+				'author'      => $addonAuthors,
+				'maintainer'  => $addonMaintainers,
 			],
 			'$str_author'     => DI::l10n()->t('Author: '),
 			'$str_maintainer' => DI::l10n()->t('Maintainer: '),


### PR DESCRIPTION
While working on #14913 I noticed that loading the addon infos could potentially call the DB multiple times to fetch the url about a contact, even if the url is not needed. In this PR I moved the url fetching into the admin module for addon details. This will speed up things a little bit and we can remove the dependency from the Contact model in the Addon class.