### PR TITLE
Fix redirect for photo remove tag page and only show the link if tags…

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -1022,7 +1022,7 @@ function photos_content()
 				}
 			}
 			$tags = ['title' => DI::l10n()->t('Tags: '), 'tags' => $tag_arr];
-			if ($cmd === 'edit') {
+			if ($cmd === 'edit' && !empty($tag_arr)) {
 				$tags['removeanyurl'] = 'post/' . $link_item['id'] . '/tag/remove?return=' . urlencode(DI::args()->getCommand());
 				$tags['removetitle']  = DI::l10n()->t('[Select tags to remove]');
 			}

--- a/src/Module/Post/Tag/Remove.php
+++ b/src/Module/Post/Tag/Remove.php
@@ -54,7 +54,7 @@ class Remove extends \Friendica\BaseModule
 
 	protected function content(array $request = []): string
 	{
-		$returnUrl = hex2bin($request['return'] ?? '');
+		$returnUrl = $request['return'] ?? '';
 
 		if (!$this->session->getLocalUserId()) {
 			$this->baseUrl->redirect($returnUrl);
@@ -80,7 +80,7 @@ class Remove extends \Friendica\BaseModule
 		if ($tag_text === '') {
 			$this->baseUrl->redirect($returnUrl);
 		}
-		
+
 		$tags = explode(',', $tag_text);
 
 		$tag_checkboxes = array_map(function ($tag_text) {
@@ -97,7 +97,7 @@ class Remove extends \Friendica\BaseModule
 			],
 
 			'$item_id'        => $item_id,
-			'$return'         => $returnUrl,
+			'$return'         => urlencode($returnUrl),
 			'$tag_checkboxes' => $tag_checkboxes,
 		]);
 	}


### PR DESCRIPTION
..exist.

On the photo edit page, there is a link to remove tags from the photo. 

That link was always shown, even if there were no tags, and when clicked, redirected to the `/network` page.
If there are tags, then the link worked, but not the return URL. 

This should be okay now.. if I didn't miss something..



