### PR TITLE
Improve BBCode buttons for Event Location

### DIFF
--- a/src/Module/Calendar/Event/Form.php
+++ b/src/Module/Calendar/Event/Form.php
@@ -108,8 +108,10 @@ class Form extends BaseModule
 		$share_disabled = '';
 
 		if (empty($orig_event)) {
-			$orig_event = User::getById($this->session->getLocalUserId(),
-				['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']);
+			$orig_event = User::getById(
+				$this->session->getLocalUserId(),
+				['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']
+			);
 		} elseif ($orig_event['allow_cid'] !== '<' . $this->session->getLocalUserId() . '>'
 				   || $orig_event['allow_gid']
 				   || $orig_event['deny_cid']

--- a/src/Module/Calendar/Event/Form.php
+++ b/src/Module/Calendar/Event/Form.php
@@ -224,7 +224,7 @@ class Form extends BaseModule
 			'$t_orig'      => $t_orig,
 			'$d_text'      => $this->t('Description (BBCode allowed)'),
 			'$d_orig'      => $d_orig,
-			'$l_text'      => $this->t('Location (BBCode not allowed)'),
+			'$l_text'      => $this->t('Location:'),
 			'$l_orig'      => $l_orig,
 			'$summary'     => ['summary', $this->t('Title (BBCode not allowed)'), $t_orig, '', '*'],
 			'$sh_text'     => $this->t('Share this event'),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.02-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-28 19:34+0200\n"
+"POT-Creation-Date: 2025-05-14 23:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,14 +38,14 @@ msgstr ""
 msgid "Empty post discarded."
 msgstr ""
 
-#: mod/item.php:431 src/Module/Admin/Themes/Details.php:31
+#: mod/item.php:437 src/Module/Admin/Themes/Details.php:31
 #: src/Module/Admin/Themes/Index.php:51 src/Module/Debug/ItemBody.php:34
 #: src/Module/Debug/ItemBody.php:42 src/Module/Item/Feed.php:66
 msgid "Item not found."
 msgstr ""
 
-#: mod/item.php:455 mod/message.php:54 mod/message.php:100 mod/notes.php:34
-#: mod/photos.php:131 mod/photos.php:623 src/Model/Event.php:506
+#: mod/item.php:461 mod/message.php:54 mod/message.php:100 mod/notes.php:34
+#: mod/photos.php:131 mod/photos.php:623 src/Model/Event.php:511
 #: src/Module/Attach.php:40 src/Module/BaseApi.php:90
 #: src/Module/BaseNotifications.php:83 src/Module/BaseSettings.php:38
 #: src/Module/Calendar/Event/API.php:75 src/Module/Calendar/Event/Form.php:70
@@ -61,10 +61,10 @@ msgstr ""
 #: src/Module/Notifications/Notification.php:93
 #: src/Module/OStatus/Subscribe.php:54 src/Module/Post/Edit.php:72
 #: src/Module/Profile/Common.php:63 src/Module/Profile/Contacts.php:66
-#: src/Module/Profile/Photos.php:81 src/Module/Profile/Schedule.php:25
-#: src/Module/Profile/Schedule.php:42 src/Module/Register.php:70
-#: src/Module/Register.php:83 src/Module/Register.php:199
-#: src/Module/Register.php:238 src/Module/Search/Directory.php:23
+#: src/Module/Profile/Photos.php:100 src/Module/Profile/Schedule.php:25
+#: src/Module/Profile/Schedule.php:42 src/Module/Register.php:74
+#: src/Module/Register.php:87 src/Module/Register.php:212
+#: src/Module/Register.php:251 src/Module/Search/Directory.php:23
 #: src/Module/Settings/Account.php:34 src/Module/Settings/Account.php:337
 #: src/Module/Settings/Channels.php:52 src/Module/Settings/Channels.php:127
 #: src/Module/Settings/ContactImport.php:49
@@ -261,7 +261,7 @@ msgid "Send Private Message"
 msgstr ""
 
 #: mod/message.php:178 mod/message.php:333
-#: src/Module/Privacy/PermissionTooltip.php:118
+#: src/Module/Privacy/PermissionTooltip.php:149
 msgid "To:"
 msgstr ""
 
@@ -285,7 +285,7 @@ msgstr ""
 #: mod/message.php:188 mod/message.php:344 mod/photos.php:1256
 #: src/Content/Conversation.php:390 src/Content/Conversation.php:1569
 #: src/Module/Item/Compose.php:205 src/Module/Post/Edit.php:141
-#: src/Object/Post.php:614
+#: src/Object/Post.php:613
 msgid "Please wait"
 msgstr ""
 
@@ -293,7 +293,7 @@ msgstr ""
 #: mod/photos.php:778 mod/photos.php:1055 mod/photos.php:1097
 #: mod/photos.php:1153 mod/photos.php:1233
 #: src/Module/Calendar/Event/Form.php:236 src/Module/Contact/Advanced.php:118
-#: src/Module/Contact/Profile.php:376
+#: src/Module/Contact/Profile.php:407
 #: src/Module/Debug/ActivityPubConversion.php:128
 #: src/Module/Debug/Babel.php:279 src/Module/Debug/Localtime.php:50
 #: src/Module/Debug/Probe.php:40 src/Module/Debug/WebFinger.php:37
@@ -305,9 +305,9 @@ msgstr ""
 #: src/Module/Moderation/Report/Create.php:169
 #: src/Module/Moderation/Report/Create.php:197
 #: src/Module/Moderation/Report/Create.php:249
-#: src/Module/Profile/Profile.php:265 src/Module/Settings/Profile/Index.php:248
+#: src/Module/Profile/Profile.php:283 src/Module/Settings/Profile/Index.php:272
 #: src/Module/Settings/Server/Action.php:65 src/Module/User/Delegation.php:181
-#: src/Object/Post.php:1158 view/theme/duepuntozero/config.php:73
+#: src/Object/Post.php:1159 view/theme/duepuntozero/config.php:73
 #: view/theme/frio/config.php:155 view/theme/quattro/config.php:75
 #: view/theme/vier/config.php:123
 msgid "Submit"
@@ -378,34 +378,34 @@ msgid "Save"
 msgstr ""
 
 #: mod/photos.php:50 mod/photos.php:113 mod/photos.php:533
-#: src/Model/Event.php:498 src/Model/Profile.php:211
+#: src/Model/Event.php:503 src/Model/Profile.php:211
 #: src/Module/Calendar/Export.php:60 src/Module/Calendar/Show.php:62
 #: src/Module/Feed.php:52 src/Module/HCard.php:37
 #: src/Module/Profile/Common.php:50 src/Module/Profile/Common.php:59
 #: src/Module/Profile/Contacts.php:52 src/Module/Profile/Contacts.php:60
 #: src/Module/Profile/Conversations.php:81 src/Module/Profile/Media.php:58
-#: src/Module/Profile/Photos.php:72 src/Module/Profile/RemoteFollow.php:57
-#: src/Module/Register.php:260
+#: src/Module/Profile/Photos.php:91 src/Module/Profile/RemoteFollow.php:57
+#: src/Module/Register.php:273
 msgid "User not found."
 msgstr ""
 
 #: mod/photos.php:87 src/Module/BaseProfile.php:53
-#: src/Module/Profile/Photos.php:372
+#: src/Module/Profile/Photos.php:419
 msgid "Photo Albums"
 msgstr ""
 
-#: mod/photos.php:88 src/Module/Profile/Photos.php:373
-#: src/Module/Profile/Photos.php:393
+#: mod/photos.php:88 src/Module/Profile/Photos.php:420
+#: src/Module/Profile/Photos.php:440
 msgid "Recent Photos"
 msgstr ""
 
-#: mod/photos.php:90 mod/photos.php:826 src/Module/Profile/Photos.php:375
-#: src/Module/Profile/Photos.php:395
+#: mod/photos.php:90 mod/photos.php:826 src/Module/Profile/Photos.php:422
+#: src/Module/Profile/Photos.php:442
 msgid "Upload New Photos"
 msgstr ""
 
 #: mod/photos.php:102 src/Module/BaseSettings.php:60
-#: src/Module/Profile/Photos.php:356
+#: src/Module/Profile/Photos.php:403
 msgid "everybody"
 msgstr ""
 
@@ -439,7 +439,7 @@ msgid "%1$s was tagged in %2$s by %3$s"
 msgstr ""
 
 #: mod/photos.php:537 src/Module/Conversation/Community.php:148
-#: src/Module/Directory.php:34 src/Module/Profile/Photos.php:290
+#: src/Module/Directory.php:34 src/Module/Profile/Photos.php:337
 #: src/Module/Search/Index.php:50
 msgid "Public access denied."
 msgstr ""
@@ -508,7 +508,7 @@ msgstr ""
 msgid "Show Oldest First"
 msgstr ""
 
-#: mod/photos.php:811 src/Module/Profile/Photos.php:343
+#: mod/photos.php:811 src/Module/Profile/Photos.php:390
 msgid "View Photo"
 msgstr ""
 
@@ -590,30 +590,30 @@ msgstr ""
 
 #: mod/photos.php:1094 mod/photos.php:1150 mod/photos.php:1230
 #: src/Module/Contact.php:599 src/Module/Item/Compose.php:187
-#: src/Object/Post.php:1155
+#: src/Object/Post.php:1156
 msgid "This is you"
 msgstr ""
 
 #: mod/photos.php:1096 mod/photos.php:1152 mod/photos.php:1232
-#: src/Module/Moderation/Reports.php:105 src/Object/Post.php:608
-#: src/Object/Post.php:1157
+#: src/Module/Moderation/Reports.php:105 src/Object/Post.php:607
+#: src/Object/Post.php:1158
 msgid "Comment"
 msgstr ""
 
 #: mod/photos.php:1098 mod/photos.php:1154 mod/photos.php:1234
 #: src/Content/Conversation.php:404 src/Module/Calendar/Event/Form.php:234
 #: src/Module/Item/Compose.php:200 src/Module/Post/Edit.php:161
-#: src/Object/Post.php:1171
+#: src/Object/Post.php:1172
 msgid "Preview"
 msgstr ""
 
 #: mod/photos.php:1099 src/Content/Conversation.php:358
-#: src/Module/Post/Edit.php:126 src/Object/Post.php:1159
+#: src/Module/Post/Edit.php:126 src/Object/Post.php:1160
 msgid "Loading..."
 msgstr ""
 
 #: mod/photos.php:1191 src/Content/Conversation.php:1491
-#: src/Object/Post.php:260
+#: src/Object/Post.php:259
 msgid "Select"
 msgstr ""
 
@@ -626,19 +626,19 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: mod/photos.php:1253 src/Object/Post.php:432
+#: mod/photos.php:1253 src/Object/Post.php:431
 msgid "Like"
 msgstr ""
 
-#: mod/photos.php:1254 src/Object/Post.php:432
+#: mod/photos.php:1254 src/Object/Post.php:431
 msgid "I like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1255 src/Object/Post.php:433
+#: mod/photos.php:1255 src/Object/Post.php:432
 msgid "Dislike"
 msgstr ""
 
-#: mod/photos.php:1257 src/Object/Post.php:433
+#: mod/photos.php:1257 src/Object/Post.php:432
 msgid "I don't like this (toggle)"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgid "Method not allowed for this module. Allowed method(s): %s"
 msgstr ""
 
 #: src/App/Router.php:296 src/Module/HTTPException/PageNotFound.php:35
-#: src/Module/Stats.php:56
+#: src/Module/Stats.php:72 src/Module/StatsCaching.php:54
 msgid "Page not found."
 msgstr ""
 
@@ -780,8 +780,8 @@ msgstr ""
 
 #: src/BaseModule.php:440 src/Content/Conversation/Factory/Channel.php:32
 #: src/Content/Widget.php:257 src/Core/ACL.php:185 src/Module/Contact.php:394
-#: src/Module/Privacy/PermissionTooltip.php:150
-#: src/Module/Privacy/PermissionTooltip.php:172
+#: src/Module/Privacy/PermissionTooltip.php:181
+#: src/Module/Privacy/PermissionTooltip.php:203
 #: src/Module/Settings/Channels.php:146
 msgid "Followers"
 msgstr ""
@@ -949,7 +949,7 @@ msgstr ""
 msgid "Enter user nickname: "
 msgstr ""
 
-#: src/Console/User.php:168 src/Model/User.php:833
+#: src/Console/User.php:168 src/Model/User.php:837
 #: src/Module/Api/Twitter/ContactEndpoint.php:62
 #: src/Module/Moderation/Users/Active.php:136
 #: src/Module/Moderation/Users/Blocked.php:135
@@ -1235,7 +1235,7 @@ msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
 #: src/Content/Conversation.php:327 src/Module/Item/Compose.php:199
-#: src/Object/Post.php:1170
+#: src/Object/Post.php:1171
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
@@ -1280,52 +1280,52 @@ msgid "attach file"
 msgstr ""
 
 #: src/Content/Conversation.php:363 src/Module/Item/Compose.php:189
-#: src/Module/Post/Edit.php:167 src/Object/Post.php:1160
+#: src/Module/Post/Edit.php:167 src/Object/Post.php:1161
 msgid "Bold"
 msgstr ""
 
 #: src/Content/Conversation.php:364 src/Module/Item/Compose.php:190
-#: src/Module/Post/Edit.php:168 src/Object/Post.php:1161
+#: src/Module/Post/Edit.php:168 src/Object/Post.php:1162
 msgid "Italic"
 msgstr ""
 
 #: src/Content/Conversation.php:365 src/Module/Item/Compose.php:191
-#: src/Module/Post/Edit.php:169 src/Object/Post.php:1162
+#: src/Module/Post/Edit.php:169 src/Object/Post.php:1163
 msgid "Underline"
 msgstr ""
 
 #: src/Content/Conversation.php:366 src/Module/Item/Compose.php:192
-#: src/Module/Post/Edit.php:170 src/Object/Post.php:1164
+#: src/Module/Post/Edit.php:170 src/Object/Post.php:1165
 msgid "Quote"
 msgstr ""
 
 #: src/Content/Conversation.php:367 src/Module/Item/Compose.php:193
-#: src/Module/Post/Edit.php:171 src/Object/Post.php:1165
+#: src/Module/Post/Edit.php:171 src/Object/Post.php:1166
 msgid "Add emojis"
 msgstr ""
 
 #: src/Content/Conversation.php:368 src/Module/Item/Compose.php:194
-#: src/Object/Post.php:1163
+#: src/Object/Post.php:1164
 msgid "Content Warning"
 msgstr ""
 
 #: src/Content/Conversation.php:369 src/Module/Item/Compose.php:195
-#: src/Module/Post/Edit.php:172 src/Object/Post.php:1166
+#: src/Module/Post/Edit.php:172 src/Object/Post.php:1167
 msgid "Code"
 msgstr ""
 
 #: src/Content/Conversation.php:370 src/Module/Item/Compose.php:196
-#: src/Object/Post.php:1167
+#: src/Object/Post.php:1168
 msgid "Image"
 msgstr ""
 
 #: src/Content/Conversation.php:371 src/Module/Item/Compose.php:197
-#: src/Module/Post/Edit.php:173 src/Object/Post.php:1168
+#: src/Module/Post/Edit.php:173 src/Object/Post.php:1169
 msgid "Link"
 msgstr ""
 
 #: src/Content/Conversation.php:372 src/Module/Item/Compose.php:198
-#: src/Module/Post/Edit.php:174 src/Object/Post.php:1169
+#: src/Module/Post/Edit.php:174 src/Object/Post.php:1170
 msgid "Link or Media"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgid "Public post"
 msgstr ""
 
 #: src/Content/Conversation.php:414 src/Content/Widget/VCard.php:120
-#: src/Model/Profile.php:458 src/Module/Admin/Logs/View.php:80
+#: src/Model/Profile.php:463 src/Module/Admin/Logs/View.php:80
 #: src/Module/Post/Edit.php:177
 msgid "Message"
 msgstr ""
@@ -1481,25 +1481,25 @@ msgstr ""
 msgid "Pushed to us"
 msgstr ""
 
-#: src/Content/Conversation.php:1511 src/Object/Post.php:247
+#: src/Content/Conversation.php:1511 src/Object/Post.php:246
 msgid "Pinned item"
 msgstr ""
 
-#: src/Content/Conversation.php:1528 src/Object/Post.php:549
-#: src/Object/Post.php:550
+#: src/Content/Conversation.php:1528 src/Object/Post.php:548
+#: src/Object/Post.php:549
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: src/Content/Conversation.php:1542 src/Object/Post.php:537
+#: src/Content/Conversation.php:1542 src/Object/Post.php:536
 msgid "Categories:"
 msgstr ""
 
-#: src/Content/Conversation.php:1543 src/Object/Post.php:538
+#: src/Content/Conversation.php:1543 src/Object/Post.php:537
 msgid "Filed under:"
 msgstr ""
 
-#: src/Content/Conversation.php:1551 src/Object/Post.php:565
+#: src/Content/Conversation.php:1551 src/Object/Post.php:564
 #, php-format
 msgid "%s from %s"
 msgstr ""
@@ -1629,7 +1629,7 @@ msgid "Sort by post creation date"
 msgstr ""
 
 #: src/Content/Conversation/Factory/Network.php:27
-#: src/Module/Settings/Profile/Index.php:251
+#: src/Module/Settings/Profile/Index.php:275
 msgid "Personal"
 msgstr ""
 
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "Posts that mention or involve you"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Network.php:28 src/Object/Post.php:403
+#: src/Content/Conversation/Factory/Network.php:28 src/Object/Post.php:402
 msgid "Starred"
 msgstr ""
 
@@ -1713,7 +1713,7 @@ msgstr ""
 
 #: src/Content/Feature.php:127 src/Content/GroupManager.php:128
 #: src/Content/Nav.php:274 src/Content/Text/HTML.php:876
-#: src/Content/Widget.php:558 src/Model/User.php:1393
+#: src/Content/Widget.php:558 src/Model/User.php:1397
 msgid "Groups"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgstr ""
 msgid "Create new group"
 msgstr ""
 
-#: src/Content/Item.php:324 src/Model/Item.php:2984
+#: src/Content/Item.php:324 src/Model/Item.php:3012
 msgid "event"
 msgstr ""
 
@@ -1845,7 +1845,7 @@ msgstr ""
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:333 src/Model/Item.php:2986
+#: src/Content/Item.php:333 src/Model/Item.php:3014
 #: src/Module/Post/Tag/Add.php:112
 msgid "photo"
 msgstr ""
@@ -1865,7 +1865,7 @@ msgstr ""
 
 #: src/Content/Item.php:423 src/Content/Item.php:446 src/Model/Contact.php:1228
 #: src/Model/Contact.php:1284 src/Model/Contact.php:1294
-#: src/Module/Directory.php:143 src/Module/Settings/Profile/Index.php:250
+#: src/Module/Directory.php:143 src/Module/Settings/Profile/Index.php:274
 msgid "View Profile"
 msgstr ""
 
@@ -1874,7 +1874,7 @@ msgid "View Photos"
 msgstr ""
 
 #: src/Content/Item.php:425 src/Model/Contact.php:1262
-#: src/Model/Profile.php:443
+#: src/Model/Profile.php:448
 msgid "Network Posts"
 msgstr ""
 
@@ -1888,7 +1888,7 @@ msgid "Send PM"
 msgstr ""
 
 #: src/Content/Item.php:428 src/Module/Contact.php:448
-#: src/Module/Contact/Profile.php:524
+#: src/Module/Contact/Profile.php:560
 #: src/Module/Moderation/Blocklist/Contact.php:104
 #: src/Module/Moderation/Users/Active.php:93
 #: src/Module/Moderation/Users/Index.php:101
@@ -1896,7 +1896,7 @@ msgid "Block"
 msgstr ""
 
 #: src/Content/Item.php:429 src/Module/Contact.php:449
-#: src/Module/Contact/Profile.php:532
+#: src/Module/Contact/Profile.php:568
 #: src/Module/Notifications/Introductions.php:126
 #: src/Module/Notifications/Introductions.php:199
 #: src/Module/Notifications/Notification.php:75
@@ -1904,27 +1904,27 @@ msgid "Ignore"
 msgstr ""
 
 #: src/Content/Item.php:430 src/Module/Contact.php:450
-#: src/Module/Contact/Profile.php:540
+#: src/Module/Contact/Profile.php:576
 msgid "Collapse"
 msgstr ""
 
-#: src/Content/Item.php:431 src/Object/Post.php:288
+#: src/Content/Item.php:431 src/Object/Post.php:287
 #, php-format
 msgid "Ignore %s server"
 msgstr ""
 
 #: src/Content/Item.php:435 src/Module/Settings/Channels.php:188
-#: src/Module/Settings/Channels.php:209 src/Object/Post.php:509
+#: src/Module/Settings/Channels.php:209 src/Object/Post.php:508
 msgid "Languages"
 msgstr ""
 
-#: src/Content/Item.php:438 src/Object/Post.php:592
+#: src/Content/Item.php:438 src/Object/Post.php:591
 msgid "Search Text"
 msgstr ""
 
 #: src/Content/Item.php:443 src/Content/Widget.php:65
 #: src/Model/Contact.php:1287 src/Model/Contact.php:1299
-#: src/Module/Contact/Follow.php:152 view/theme/vier/theme.php:183
+#: src/Module/Contact/Follow.php:152 view/theme/vier/theme.php:182
 msgid "Connect/Follow"
 msgstr ""
 
@@ -1980,7 +1980,7 @@ msgstr ""
 
 #: src/Content/Nav.php:226 src/Module/BaseProfile.php:34
 #: src/Module/BaseSettings.php:86 src/Module/Contact.php:484
-#: src/Module/Contact/Profile.php:431 src/Module/Profile/Profile.php:259
+#: src/Module/Contact/Profile.php:462 src/Module/Profile/Profile.php:277
 #: src/Module/Welcome.php:43 view/theme/frio/theme.php:219
 msgid "Profile"
 msgstr ""
@@ -2032,7 +2032,7 @@ msgstr ""
 msgid "Home Page"
 msgstr ""
 
-#: src/Content/Nav.php:251 src/Module/Register.php:161
+#: src/Content/Nav.php:251 src/Module/Register.php:169
 #: src/Module/Security/Login.php:113
 msgid "Register"
 msgstr ""
@@ -2045,7 +2045,7 @@ msgstr ""
 #: src/Module/Settings/TwoFactor/AppSpecific.php:118
 #: src/Module/Settings/TwoFactor/Index.php:125
 #: src/Module/Settings/TwoFactor/Recovery.php:96
-#: src/Module/Settings/TwoFactor/Verify.php:135 view/theme/vier/theme.php:228
+#: src/Module/Settings/TwoFactor/Verify.php:135 view/theme/vier/theme.php:227
 msgid "Help"
 msgstr ""
 
@@ -2112,7 +2112,7 @@ msgid "Information about this friendica instance"
 msgstr ""
 
 #: src/Content/Nav.php:297 src/Module/Admin/Tos.php:64
-#: src/Module/BaseAdmin.php:80 src/Module/Register.php:169
+#: src/Module/BaseAdmin.php:80 src/Module/Register.php:177
 #: src/Module/Tos.php:87
 msgid "Terms of Service"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "Manage other pages"
 msgstr ""
 
-#: src/Content/Nav.php:323 src/Module/Admin/Addons/Details.php:101
+#: src/Content/Nav.php:323 src/Module/Admin/Addons/Details.php:131
 #: src/Module/Admin/Themes/Details.php:85 src/Module/BaseSettings.php:177
 #: src/Module/Welcome.php:38 view/theme/frio/theme.php:231
 msgid "Settings"
@@ -2247,8 +2247,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:926 src/Model/Item.php:3791
-#: src/Model/Item.php:3797 src/Model/Item.php:3798
+#: src/Content/Text/BBCode.php:926 src/Model/Item.php:3850
+#: src/Model/Item.php:3856 src/Model/Item.php:3857
 msgid "Link to source"
 msgstr ""
 
@@ -2281,7 +2281,7 @@ msgid "The end"
 msgstr ""
 
 #: src/Content/Text/HTML.php:855 src/Content/Widget/VCard.php:116
-#: src/Model/Profile.php:452 src/Module/Contact/Profile.php:484
+#: src/Model/Profile.php:457 src/Module/Contact/Profile.php:520
 msgid "Follow"
 msgstr ""
 
@@ -2308,46 +2308,46 @@ msgid_plural "%d invitations available"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/Widget.php:63 view/theme/vier/theme.php:181
+#: src/Content/Widget.php:63 view/theme/vier/theme.php:180
 msgid "Find People"
 msgstr ""
 
-#: src/Content/Widget.php:64 view/theme/vier/theme.php:182
+#: src/Content/Widget.php:64 view/theme/vier/theme.php:181
 msgid "Enter name or interest"
 msgstr ""
 
-#: src/Content/Widget.php:66 view/theme/vier/theme.php:184
+#: src/Content/Widget.php:66 view/theme/vier/theme.php:183
 msgid "Examples: Robert Morgenstein, Fishing"
 msgstr ""
 
 #: src/Content/Widget.php:67 src/Module/Contact.php:440
-#: src/Module/Directory.php:82 view/theme/vier/theme.php:185
+#: src/Module/Directory.php:82 view/theme/vier/theme.php:184
 msgid "Find"
 msgstr ""
 
 #: src/Content/Widget.php:68 src/Module/Contact/Suggestions.php:59
-#: view/theme/vier/theme.php:186
+#: view/theme/vier/theme.php:185
 msgid "Friend Suggestions"
 msgstr ""
 
-#: src/Content/Widget.php:69 view/theme/vier/theme.php:187
+#: src/Content/Widget.php:69 view/theme/vier/theme.php:186
 msgid "Similar Interests"
 msgstr ""
 
-#: src/Content/Widget.php:70 view/theme/vier/theme.php:188
+#: src/Content/Widget.php:70 view/theme/vier/theme.php:187
 msgid "Random Profile"
 msgstr ""
 
-#: src/Content/Widget.php:71 view/theme/vier/theme.php:189
+#: src/Content/Widget.php:71 view/theme/vier/theme.php:188
 msgid "Invite Friends"
 msgstr ""
 
 #: src/Content/Widget.php:72 src/Module/Directory.php:74
-#: view/theme/vier/theme.php:190
+#: view/theme/vier/theme.php:189
 msgid "Global Directory"
 msgstr ""
 
-#: src/Content/Widget.php:74 view/theme/vier/theme.php:192
+#: src/Content/Widget.php:74 view/theme/vier/theme.php:191
 msgid "Local Directory"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "Organisations"
 msgstr ""
 
-#: src/Content/Widget.php:557 src/Model/Contact.php:1797
+#: src/Content/Widget.php:557 src/Model/Contact.php:1805
 msgid "News"
 msgstr ""
 
@@ -2407,7 +2407,7 @@ msgstr ""
 msgid "Relays"
 msgstr ""
 
-#: src/Content/Widget.php:566 src/Module/Moderation/BaseUsers.php:58
+#: src/Content/Widget.php:566 src/Module/Moderation/BaseUsers.php:76
 msgid "All"
 msgstr ""
 
@@ -2462,55 +2462,56 @@ msgid "Show Less"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:94 src/Model/Contact.php:1256
-#: src/Model/Profile.php:437
+#: src/Model/Profile.php:442
 msgid "Post to group"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:99 src/Model/Contact.php:1260
-#: src/Model/Profile.php:441 src/Module/Moderation/Item/Source.php:80
+#: src/Model/Profile.php:446 src/Module/Moderation/Item/Source.php:80
 msgid "Mention"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:109 src/Model/Profile.php:356
-#: src/Module/Contact/Profile.php:420 src/Module/Profile/Profile.php:190
+#: src/Content/Widget/VCard.php:109 src/Model/Profile.php:361
+#: src/Module/Contact/Profile.php:451 src/Module/Profile/Profile.php:208
 msgid "XMPP:"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:110 src/Model/Profile.php:357
-#: src/Module/Contact/Profile.php:422 src/Module/Profile/Profile.php:194
+#: src/Content/Widget/VCard.php:110 src/Model/Profile.php:362
+#: src/Module/Contact/Profile.php:453 src/Module/Profile/Profile.php:212
 msgid "Matrix:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:111 src/Model/Event.php:68
-#: src/Model/Event.php:95 src/Model/Event.php:457 src/Model/Event.php:945
-#: src/Model/Profile.php:351 src/Module/Contact/Profile.php:418
-#: src/Module/Directory.php:133 src/Module/Notifications/Introductions.php:180
-#: src/Module/Profile/Profile.php:212
+#: src/Model/Event.php:95 src/Model/Event.php:462 src/Model/Event.php:950
+#: src/Model/Profile.php:356 src/Module/Calendar/Event/Form.php:227
+#: src/Module/Contact/Profile.php:449 src/Module/Directory.php:133
+#: src/Module/Notifications/Introductions.php:180
+#: src/Module/Profile/Profile.php:230
 msgid "Location:"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:114 src/Model/Profile.php:465
+#: src/Content/Widget/VCard.php:114 src/Model/Profile.php:470
 #: src/Module/Notifications/Introductions.php:194
 msgid "Network:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:118 src/Model/Contact.php:1288
-#: src/Model/Contact.php:1300 src/Model/Profile.php:454
-#: src/Module/Contact/Profile.php:476
+#: src/Model/Contact.php:1300 src/Model/Profile.php:459
+#: src/Module/Contact/Profile.php:512
 msgid "Unfollow"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:124 src/Model/Contact.php:1258
-#: src/Model/Profile.php:439
+#: src/Model/Profile.php:444
 msgid "View group"
 msgstr ""
 
-#: src/Core/ACL.php:154 src/Module/Profile/Profile.php:260
+#: src/Core/ACL.php:154 src/Module/Profile/Profile.php:278
 msgid "Yourself"
 msgstr ""
 
-#: src/Core/ACL.php:192 src/Module/Privacy/PermissionTooltip.php:156
-#: src/Module/Privacy/PermissionTooltip.php:178
+#: src/Core/ACL.php:192 src/Module/Privacy/PermissionTooltip.php:187
+#: src/Module/Privacy/PermissionTooltip.php:209
 msgid "Mutuals"
 msgstr ""
 
@@ -2518,8 +2519,8 @@ msgstr ""
 msgid "Post to Email"
 msgstr ""
 
-#: src/Core/ACL.php:316 src/Module/Privacy/PermissionTooltip.php:103
-#: src/Module/Privacy/PermissionTooltip.php:217
+#: src/Core/ACL.php:316 src/Module/Privacy/PermissionTooltip.php:130
+#: src/Module/Privacy/PermissionTooltip.php:248
 msgid "Public"
 msgstr ""
 
@@ -2527,7 +2528,7 @@ msgstr ""
 msgid "This content will be shown to all your followers and can be seen in the community pages and by anyone with its link."
 msgstr ""
 
-#: src/Core/ACL.php:318 src/Module/Privacy/PermissionTooltip.php:105
+#: src/Core/ACL.php:318 src/Module/Privacy/PermissionTooltip.php:136
 msgid "Limited/Private"
 msgstr ""
 
@@ -2844,7 +2845,7 @@ msgstr ""
 msgid "Could not connect to database."
 msgstr ""
 
-#: src/Core/L10n.php:453 src/Model/Item.php:2030
+#: src/Core/L10n.php:453 src/Model/Item.php:2051
 msgid "Undetermined"
 msgstr ""
 
@@ -2853,142 +2854,142 @@ msgstr ""
 msgid "%s (%s)"
 msgstr ""
 
-#: src/Core/L10n.php:509 src/Model/Event.php:416
+#: src/Core/L10n.php:509 src/Model/Event.php:421
 #: src/Module/Settings/Display.php:282
 msgid "Monday"
 msgstr ""
 
-#: src/Core/L10n.php:509 src/Model/Event.php:417
+#: src/Core/L10n.php:509 src/Model/Event.php:422
 #: src/Module/Settings/Display.php:283
 msgid "Tuesday"
 msgstr ""
 
-#: src/Core/L10n.php:509 src/Model/Event.php:418
+#: src/Core/L10n.php:509 src/Model/Event.php:423
 #: src/Module/Settings/Display.php:284
 msgid "Wednesday"
 msgstr ""
 
-#: src/Core/L10n.php:509 src/Model/Event.php:419
+#: src/Core/L10n.php:509 src/Model/Event.php:424
 #: src/Module/Settings/Display.php:285
 msgid "Thursday"
 msgstr ""
 
-#: src/Core/L10n.php:509 src/Model/Event.php:420
+#: src/Core/L10n.php:509 src/Model/Event.php:425
 #: src/Module/Settings/Display.php:286
 msgid "Friday"
 msgstr ""
 
-#: src/Core/L10n.php:509 src/Model/Event.php:421
+#: src/Core/L10n.php:509 src/Model/Event.php:426
 #: src/Module/Settings/Display.php:287
 msgid "Saturday"
 msgstr ""
 
-#: src/Core/L10n.php:509 src/Model/Event.php:415
+#: src/Core/L10n.php:509 src/Model/Event.php:420
 #: src/Module/Settings/Display.php:281
 msgid "Sunday"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Model/Event.php:436
+#: src/Core/L10n.php:515 src/Model/Event.php:441
 msgid "January"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Model/Event.php:437
+#: src/Core/L10n.php:515 src/Model/Event.php:442
 msgid "February"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Model/Event.php:438
+#: src/Core/L10n.php:515 src/Model/Event.php:443
 msgid "March"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Model/Event.php:439
+#: src/Core/L10n.php:515 src/Model/Event.php:444
 msgid "April"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Core/L10n.php:538 src/Model/Event.php:427
+#: src/Core/L10n.php:515 src/Core/L10n.php:538 src/Model/Event.php:432
 msgid "May"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Model/Event.php:440
+#: src/Core/L10n.php:515 src/Model/Event.php:445
 msgid "June"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Model/Event.php:441
+#: src/Core/L10n.php:515 src/Model/Event.php:446
 msgid "July"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Model/Event.php:442
+#: src/Core/L10n.php:515 src/Model/Event.php:447
 msgid "August"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Model/Event.php:443
+#: src/Core/L10n.php:515 src/Model/Event.php:448
 msgid "September"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Model/Event.php:444
+#: src/Core/L10n.php:515 src/Model/Event.php:449
 msgid "October"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Model/Event.php:445
+#: src/Core/L10n.php:515 src/Model/Event.php:450
 msgid "November"
 msgstr ""
 
-#: src/Core/L10n.php:515 src/Model/Event.php:446
+#: src/Core/L10n.php:515 src/Model/Event.php:451
 msgid "December"
 msgstr ""
 
-#: src/Core/L10n.php:532 src/Model/Event.php:408
+#: src/Core/L10n.php:532 src/Model/Event.php:413
 msgid "Mon"
 msgstr ""
 
-#: src/Core/L10n.php:532 src/Model/Event.php:409
+#: src/Core/L10n.php:532 src/Model/Event.php:414
 msgid "Tue"
 msgstr ""
 
-#: src/Core/L10n.php:532 src/Model/Event.php:410
+#: src/Core/L10n.php:532 src/Model/Event.php:415
 msgid "Wed"
 msgstr ""
 
-#: src/Core/L10n.php:532 src/Model/Event.php:411
+#: src/Core/L10n.php:532 src/Model/Event.php:416
 msgid "Thu"
 msgstr ""
 
-#: src/Core/L10n.php:532 src/Model/Event.php:412
+#: src/Core/L10n.php:532 src/Model/Event.php:417
 msgid "Fri"
 msgstr ""
 
-#: src/Core/L10n.php:532 src/Model/Event.php:413
+#: src/Core/L10n.php:532 src/Model/Event.php:418
 msgid "Sat"
 msgstr ""
 
-#: src/Core/L10n.php:532 src/Model/Event.php:407
+#: src/Core/L10n.php:532 src/Model/Event.php:412
 msgid "Sun"
 msgstr ""
 
-#: src/Core/L10n.php:538 src/Model/Event.php:423
+#: src/Core/L10n.php:538 src/Model/Event.php:428
 msgid "Jan"
 msgstr ""
 
-#: src/Core/L10n.php:538 src/Model/Event.php:424
+#: src/Core/L10n.php:538 src/Model/Event.php:429
 msgid "Feb"
 msgstr ""
 
-#: src/Core/L10n.php:538 src/Model/Event.php:425
+#: src/Core/L10n.php:538 src/Model/Event.php:430
 msgid "Mar"
 msgstr ""
 
-#: src/Core/L10n.php:538 src/Model/Event.php:426
+#: src/Core/L10n.php:538 src/Model/Event.php:431
 msgid "Apr"
 msgstr ""
 
-#: src/Core/L10n.php:538 src/Model/Event.php:428
+#: src/Core/L10n.php:538 src/Model/Event.php:433
 msgid "Jun"
 msgstr ""
 
-#: src/Core/L10n.php:538 src/Model/Event.php:429
+#: src/Core/L10n.php:538 src/Model/Event.php:434
 msgid "Jul"
 msgstr ""
 
-#: src/Core/L10n.php:538 src/Model/Event.php:430
+#: src/Core/L10n.php:538 src/Model/Event.php:435
 msgid "Aug"
 msgstr ""
 
@@ -2996,15 +2997,15 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: src/Core/L10n.php:538 src/Model/Event.php:432
+#: src/Core/L10n.php:538 src/Model/Event.php:437
 msgid "Oct"
 msgstr ""
 
-#: src/Core/L10n.php:538 src/Model/Event.php:433
+#: src/Core/L10n.php:538 src/Model/Event.php:438
 msgid "Nov"
 msgstr ""
 
-#: src/Core/L10n.php:538 src/Model/Event.php:434
+#: src/Core/L10n.php:538 src/Model/Event.php:439
 msgid "Dec"
 msgstr ""
 
@@ -3210,78 +3211,78 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: src/Model/Contact.php:1641 src/Model/Contact.php:1713
-#: src/Module/Contact/Profile.php:360
+#: src/Model/Contact.php:1649 src/Model/Contact.php:1721
+#: src/Module/Contact/Profile.php:391
 #, php-format
 msgid "%s has blocked you"
 msgstr ""
 
-#: src/Model/Contact.php:1793
+#: src/Model/Contact.php:1801
 msgid "Organisation"
 msgstr ""
 
-#: src/Model/Contact.php:1801
+#: src/Model/Contact.php:1809
 msgid "Group"
 msgstr ""
 
-#: src/Model/Contact.php:1805 src/Module/Moderation/BaseUsers.php:122
+#: src/Model/Contact.php:1813 src/Module/Moderation/BaseUsers.php:150
 msgid "Relay"
 msgstr ""
 
-#: src/Model/Contact.php:3131
+#: src/Model/Contact.php:3143
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:3136 src/Module/Friendica.php:90
+#: src/Model/Contact.php:3148 src/Module/Friendica.php:106
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:3141
+#: src/Model/Contact.php:3153
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:3150
+#: src/Model/Contact.php:3166
 msgid "The contact could not be added. Please check the relevant network credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:3168
+#: src/Model/Contact.php:3184
 #, php-format
 msgid "Expected network %s does not match actual network %s"
 msgstr ""
 
-#: src/Model/Contact.php:3185
+#: src/Model/Contact.php:3201
 msgid "This seems to be a relay account. They can't be followed by users."
 msgstr ""
 
-#: src/Model/Contact.php:3192
+#: src/Model/Contact.php:3208
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:3194
+#: src/Model/Contact.php:3210
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:3197
+#: src/Model/Contact.php:3213
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:3200
+#: src/Model/Contact.php:3216
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:3203
+#: src/Model/Contact.php:3219
 msgid "Unable to match @-style Identity Address with a known protocol or email contact."
 msgstr ""
 
-#: src/Model/Contact.php:3204
+#: src/Model/Contact.php:3220
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:3210
+#: src/Model/Contact.php:3226
 msgid "Limited profile. This person will be unable to receive direct/personal notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:3269
+#: src/Model/Contact.php:3285
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -3289,189 +3290,189 @@ msgstr ""
 msgid "l F d, Y \\@ g:i A \\G\\M\\TP (e)"
 msgstr ""
 
-#: src/Model/Event.php:61 src/Model/Event.php:78 src/Model/Event.php:455
-#: src/Model/Event.php:927
+#: src/Model/Event.php:61 src/Model/Event.php:78 src/Model/Event.php:460
+#: src/Model/Event.php:932
 msgid "Starts:"
 msgstr ""
 
-#: src/Model/Event.php:64 src/Model/Event.php:84 src/Model/Event.php:456
-#: src/Model/Event.php:931
+#: src/Model/Event.php:64 src/Model/Event.php:84 src/Model/Event.php:461
+#: src/Model/Event.php:936
 msgid "Finishes:"
 msgstr ""
 
-#: src/Model/Event.php:405
+#: src/Model/Event.php:410
 msgid "all-day"
 msgstr ""
 
-#: src/Model/Event.php:431
+#: src/Model/Event.php:436
 msgid "Sept"
 msgstr ""
 
-#: src/Model/Event.php:448 src/Module/Calendar/Show.php:116
+#: src/Model/Event.php:453 src/Module/Calendar/Show.php:116
 #: src/Util/Temporal.php:333
 msgid "today"
 msgstr ""
 
-#: src/Model/Event.php:449 src/Module/Calendar/Show.php:117
+#: src/Model/Event.php:454 src/Module/Calendar/Show.php:117
 #: src/Module/Settings/Display.php:292 src/Util/Temporal.php:343
 msgid "month"
 msgstr ""
 
-#: src/Model/Event.php:450 src/Module/Calendar/Show.php:118
+#: src/Model/Event.php:455 src/Module/Calendar/Show.php:118
 #: src/Module/Settings/Display.php:293 src/Util/Temporal.php:344
 msgid "week"
 msgstr ""
 
-#: src/Model/Event.php:451 src/Module/Calendar/Show.php:119
+#: src/Model/Event.php:456 src/Module/Calendar/Show.php:119
 #: src/Module/Settings/Display.php:294 src/Util/Temporal.php:345
 msgid "day"
 msgstr ""
 
-#: src/Model/Event.php:453
+#: src/Model/Event.php:458
 msgid "No events to display"
 msgstr ""
 
-#: src/Model/Event.php:502 src/Module/Feed.php:56
+#: src/Model/Event.php:507 src/Module/Feed.php:56
 #: src/Module/Update/Profile.php:42
 msgid "Access to this profile has been restricted."
 msgstr ""
 
-#: src/Model/Event.php:543 src/Module/Calendar/Event/Show.php:52
+#: src/Model/Event.php:548 src/Module/Calendar/Event/Show.php:52
 msgid "Event not found."
 msgstr ""
 
-#: src/Model/Event.php:622
+#: src/Model/Event.php:627
 msgid "l, F j"
 msgstr ""
 
-#: src/Model/Event.php:649
+#: src/Model/Event.php:654
 msgid "Edit event"
 msgstr ""
 
-#: src/Model/Event.php:650
+#: src/Model/Event.php:655
 msgid "Duplicate event"
 msgstr ""
 
-#: src/Model/Event.php:651
+#: src/Model/Event.php:656
 msgid "Delete event"
 msgstr ""
 
-#: src/Model/Event.php:881 src/Module/Debug/Localtime.php:24
+#: src/Model/Event.php:886 src/Module/Debug/Localtime.php:24
 msgid "l F d, Y \\@ g:i A"
 msgstr ""
 
-#: src/Model/Event.php:882
+#: src/Model/Event.php:887
 msgid "D g:i A"
 msgstr ""
 
-#: src/Model/Event.php:883
+#: src/Model/Event.php:888
 msgid "g:i A"
 msgstr ""
 
-#: src/Model/Event.php:946 src/Model/Event.php:948
+#: src/Model/Event.php:951 src/Model/Event.php:953
 msgid "Show map"
 msgstr ""
 
-#: src/Model/Event.php:947
+#: src/Model/Event.php:952
 msgid "Hide map"
 msgstr ""
 
-#: src/Model/Event.php:1040
+#: src/Model/Event.php:1045
 #, php-format
 msgid "%s's birthday"
 msgstr ""
 
-#: src/Model/Event.php:1041
+#: src/Model/Event.php:1046
 #, php-format
 msgid "Happy Birthday %s"
 msgstr ""
 
-#: src/Model/Item.php:2037
+#: src/Model/Item.php:2058
 #, php-format
 msgid "%s (%s - %s): %s"
 msgstr ""
 
-#: src/Model/Item.php:2039
+#: src/Model/Item.php:2060
 #, php-format
 msgid "%s (%s): %s"
 msgstr ""
 
-#: src/Model/Item.php:2042
+#: src/Model/Item.php:2063
 #, php-format
 msgid ""
 "Detected languages in this post:\n"
 "%s"
 msgstr ""
 
-#: src/Model/Item.php:2988
+#: src/Model/Item.php:3016
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2990
+#: src/Model/Item.php:3018
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2993 src/Module/Post/Tag/Add.php:112
+#: src/Model/Item.php:3021 src/Module/Post/Tag/Add.php:112
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3166
+#: src/Model/Item.php:3210
 #, php-format
 msgid "%s is blocked"
 msgstr ""
 
-#: src/Model/Item.php:3168
+#: src/Model/Item.php:3212
 #, php-format
 msgid "%s is ignored"
 msgstr ""
 
-#: src/Model/Item.php:3170
+#: src/Model/Item.php:3214
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:3174
+#: src/Model/Item.php:3218
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3691
+#: src/Model/Item.php:3750
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3722
+#: src/Model/Item.php:3781
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3724
+#: src/Model/Item.php:3783
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3729
+#: src/Model/Item.php:3788
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3731
+#: src/Model/Item.php:3790
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3733
+#: src/Model/Item.php:3792
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3774 src/Model/Item.php:3775
+#: src/Model/Item.php:3833 src/Model/Item.php:3834
 msgid "View on separate page"
 msgstr ""
 
@@ -3479,288 +3480,288 @@ msgstr ""
 msgid "[no subject]"
 msgstr ""
 
-#: src/Model/Photo.php:1194 src/Module/Media/Photo/Upload.php:154
+#: src/Model/Photo.php:1193 src/Module/Media/Photo/Upload.php:154
 msgid "Wall Photos"
 msgstr ""
 
-#: src/Model/Profile.php:339 src/Module/Profile/Profile.php:274
-#: src/Module/Profile/Profile.php:276
+#: src/Model/Profile.php:344 src/Module/Profile/Profile.php:292
+#: src/Module/Profile/Profile.php:294
 msgid "Edit profile"
 msgstr ""
 
-#: src/Model/Profile.php:341
+#: src/Model/Profile.php:346
 msgid "Change profile photo"
 msgstr ""
 
-#: src/Model/Profile.php:354 src/Module/Directory.php:138
-#: src/Module/Profile/Profile.php:200
+#: src/Model/Profile.php:359 src/Module/Directory.php:138
+#: src/Module/Profile/Profile.php:218
 msgid "Homepage:"
 msgstr ""
 
-#: src/Model/Profile.php:355 src/Module/Contact/Profile.php:424
+#: src/Model/Profile.php:360 src/Module/Contact/Profile.php:455
 #: src/Module/Notifications/Introductions.php:182
 msgid "About:"
 msgstr ""
 
-#: src/Model/Profile.php:456
+#: src/Model/Profile.php:461
 msgid "Atom feed"
 msgstr ""
 
-#: src/Model/Profile.php:463
+#: src/Model/Profile.php:468
 msgid "This website has been verified to belong to the same person."
 msgstr ""
 
-#: src/Model/Profile.php:514
+#: src/Model/Profile.php:527
 msgid "F d"
 msgstr ""
 
-#: src/Model/Profile.php:578 src/Model/Profile.php:659
+#: src/Model/Profile.php:591 src/Model/Profile.php:672
 msgid "[today]"
 msgstr ""
 
-#: src/Model/Profile.php:587
+#: src/Model/Profile.php:600
 msgid "Birthday Reminders"
 msgstr ""
 
-#: src/Model/Profile.php:588
+#: src/Model/Profile.php:601
 msgid "Birthdays this week:"
 msgstr ""
 
-#: src/Model/Profile.php:604
+#: src/Model/Profile.php:617
 msgid "g A l F d"
 msgstr ""
 
-#: src/Model/Profile.php:646
+#: src/Model/Profile.php:659
 msgid "[No description]"
 msgstr ""
 
-#: src/Model/Profile.php:672
+#: src/Model/Profile.php:685
 msgid "Event Reminders"
 msgstr ""
 
-#: src/Model/Profile.php:673
+#: src/Model/Profile.php:686
 msgid "Upcoming events the next 7 days:"
 msgstr ""
 
-#: src/Model/Profile.php:783
+#: src/Model/Profile.php:796
 msgid "Hometown:"
 msgstr ""
 
-#: src/Model/Profile.php:784
+#: src/Model/Profile.php:797
 msgid "Marital Status:"
 msgstr ""
 
-#: src/Model/Profile.php:785
+#: src/Model/Profile.php:798
 msgid "With:"
 msgstr ""
 
-#: src/Model/Profile.php:786
+#: src/Model/Profile.php:799
 msgid "Since:"
 msgstr ""
 
-#: src/Model/Profile.php:787
+#: src/Model/Profile.php:800
 msgid "Sexual Preference:"
 msgstr ""
 
-#: src/Model/Profile.php:788
+#: src/Model/Profile.php:801
 msgid "Political Views:"
 msgstr ""
 
-#: src/Model/Profile.php:789
+#: src/Model/Profile.php:802
 msgid "Religious Views:"
 msgstr ""
 
-#: src/Model/Profile.php:790
+#: src/Model/Profile.php:803
 msgid "Likes:"
 msgstr ""
 
-#: src/Model/Profile.php:791
+#: src/Model/Profile.php:804
 msgid "Dislikes:"
 msgstr ""
 
-#: src/Model/Profile.php:792
+#: src/Model/Profile.php:805
 msgid "Title/Description:"
 msgstr ""
 
-#: src/Model/Profile.php:793 src/Module/Admin/Summary.php:184
+#: src/Model/Profile.php:806 src/Module/Admin/Summary.php:184
 #: src/Module/Moderation/Report/Create.php:266
 #: src/Module/Moderation/Summary.php:65
 msgid "Summary"
 msgstr ""
 
-#: src/Model/Profile.php:794
+#: src/Model/Profile.php:807
 msgid "Musical interests"
 msgstr ""
 
-#: src/Model/Profile.php:795
+#: src/Model/Profile.php:808
 msgid "Books, literature"
 msgstr ""
 
-#: src/Model/Profile.php:796
+#: src/Model/Profile.php:809
 msgid "Television"
 msgstr ""
 
-#: src/Model/Profile.php:797
+#: src/Model/Profile.php:810
 msgid "Film/dance/culture/entertainment"
 msgstr ""
 
-#: src/Model/Profile.php:798
+#: src/Model/Profile.php:811
 msgid "Hobbies/Interests"
 msgstr ""
 
-#: src/Model/Profile.php:799
+#: src/Model/Profile.php:812
 msgid "Love/romance"
 msgstr ""
 
-#: src/Model/Profile.php:800
+#: src/Model/Profile.php:813
 msgid "Work/employment"
 msgstr ""
 
-#: src/Model/Profile.php:801
+#: src/Model/Profile.php:814
 msgid "School/education"
 msgstr ""
 
-#: src/Model/Profile.php:802
+#: src/Model/Profile.php:815
 msgid "Contact information and Social Networks"
 msgstr ""
 
-#: src/Model/Profile.php:850
+#: src/Model/Profile.php:863
 #, php-format
 msgid "Responsible account: %s"
 msgstr ""
 
-#: src/Model/User.php:216 src/Model/User.php:1313
+#: src/Model/User.php:216 src/Model/User.php:1317
 msgid "SERIOUS ERROR: Generation of security keys failed."
 msgstr ""
 
-#: src/Model/User.php:739 src/Model/User.php:772
+#: src/Model/User.php:739 src/Model/User.php:776
 msgid "Login failed"
 msgstr ""
 
-#: src/Model/User.php:805
+#: src/Model/User.php:809
 msgid "Not enough information to authenticate"
 msgstr ""
 
-#: src/Model/User.php:932
+#: src/Model/User.php:936
 msgid "Password can't be empty"
 msgstr ""
 
-#: src/Model/User.php:974
+#: src/Model/User.php:978
 msgid "Empty passwords are not allowed."
 msgstr ""
 
-#: src/Model/User.php:978
+#: src/Model/User.php:982
 msgid "The new password has been exposed in a public data dump, please choose another."
 msgstr ""
 
-#: src/Model/User.php:982
+#: src/Model/User.php:986
 msgid "The password length is limited to 72 characters."
 msgstr ""
 
-#: src/Model/User.php:986
+#: src/Model/User.php:990
 msgid "The password can't contain white spaces nor accentuated letters"
 msgstr ""
 
-#: src/Model/User.php:1195
+#: src/Model/User.php:1199
 msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
-#: src/Model/User.php:1202
+#: src/Model/User.php:1206
 msgid "An invitation is required."
 msgstr ""
 
-#: src/Model/User.php:1206
+#: src/Model/User.php:1210
 msgid "Invitation could not be verified."
 msgstr ""
 
-#: src/Model/User.php:1214
+#: src/Model/User.php:1218
 msgid "Invalid OpenID url"
 msgstr ""
 
-#: src/Model/User.php:1228 src/Security/Authentication.php:231
+#: src/Model/User.php:1232 src/Security/Authentication.php:231
 msgid "We encountered a problem while logging in with the OpenID you provided. Please check the correct spelling of the ID."
 msgstr ""
 
-#: src/Model/User.php:1228 src/Security/Authentication.php:231
+#: src/Model/User.php:1232 src/Security/Authentication.php:231
 msgid "The error message was:"
 msgstr ""
 
-#: src/Model/User.php:1234
+#: src/Model/User.php:1238
 msgid "Please enter the required information."
 msgstr ""
 
-#: src/Model/User.php:1248
+#: src/Model/User.php:1252
 #, php-format
 msgid "system.username_min_length (%s) and system.username_max_length (%s) are excluding each other, swapping values."
 msgstr ""
 
-#: src/Model/User.php:1255
+#: src/Model/User.php:1259
 #, php-format
 msgid "Username should be at least %s character."
 msgid_plural "Username should be at least %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1259
+#: src/Model/User.php:1263
 #, php-format
 msgid "Username should be at most %s character."
 msgid_plural "Username should be at most %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1267
+#: src/Model/User.php:1271
 msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Model/User.php:1272
+#: src/Model/User.php:1276
 msgid "Your email domain is not among those allowed on this site."
 msgstr ""
 
-#: src/Model/User.php:1276
+#: src/Model/User.php:1280
 msgid "Not a valid email address."
 msgstr ""
 
-#: src/Model/User.php:1279
+#: src/Model/User.php:1283
 msgid "The nickname was blocked from registration by the nodes admin."
 msgstr ""
 
-#: src/Model/User.php:1283 src/Model/User.php:1289
+#: src/Model/User.php:1287 src/Model/User.php:1293
 msgid "Cannot use that email."
 msgstr ""
 
-#: src/Model/User.php:1295
+#: src/Model/User.php:1299
 msgid "Your nickname can only contain a-z, 0-9 and _."
 msgstr ""
 
-#: src/Model/User.php:1303 src/Model/User.php:1353
+#: src/Model/User.php:1307 src/Model/User.php:1357
 msgid "Nickname is already registered. Please choose another."
 msgstr ""
 
-#: src/Model/User.php:1340 src/Model/User.php:1344
+#: src/Model/User.php:1344 src/Model/User.php:1348
 msgid "An error occurred during registration. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1367
+#: src/Model/User.php:1371
 msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1374
+#: src/Model/User.php:1378
 msgid "An error occurred creating your self contact. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1379
+#: src/Model/User.php:1383
 msgid "Friends"
 msgstr ""
 
-#: src/Model/User.php:1383
+#: src/Model/User.php:1387
 msgid "An error occurred creating your default contact circle. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1431
+#: src/Model/User.php:1435
 msgid "Profile Photos"
 msgstr ""
 
-#: src/Model/User.php:1619
+#: src/Model/User.php:1632
 #, php-format
 msgid ""
 "\n"
@@ -3768,7 +3769,7 @@ msgid ""
 "\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: src/Model/User.php:1622
+#: src/Model/User.php:1635
 #, php-format
 msgid ""
 "\n"
@@ -3799,12 +3800,12 @@ msgid ""
 "\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: src/Model/User.php:1654 src/Model/User.php:1760
+#: src/Model/User.php:1667 src/Model/User.php:1773
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
-#: src/Model/User.php:1674
+#: src/Model/User.php:1687
 #, php-format
 msgid ""
 "\n"
@@ -3819,12 +3820,12 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:1693
+#: src/Model/User.php:1706
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: src/Model/User.php:1717
+#: src/Model/User.php:1730
 #, php-format
 msgid ""
 "\n"
@@ -3833,7 +3834,7 @@ msgid ""
 "\t\t\t"
 msgstr ""
 
-#: src/Model/User.php:1725
+#: src/Model/User.php:1738
 #, php-format
 msgid ""
 "\n"
@@ -3864,35 +3865,35 @@ msgid ""
 "\t\t\tThank you and welcome to %2$s."
 msgstr ""
 
-#: src/Model/User.php:1787
+#: src/Model/User.php:1800
 msgid "User with delegates can't be removed, please remove delegate users first"
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:48
+#: src/Module/Admin/Addons/Details.php:49
 msgid "Addon not found."
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:59 src/Module/Admin/Addons/Index.php:43
+#: src/Module/Admin/Addons/Details.php:60 src/Module/Admin/Addons/Index.php:43
 #, php-format
 msgid "Addon %s disabled."
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:62 src/Module/Admin/Addons/Index.php:45
+#: src/Module/Admin/Addons/Details.php:63 src/Module/Admin/Addons/Index.php:45
 #, php-format
 msgid "Addon %s enabled."
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:71
+#: src/Module/Admin/Addons/Details.php:72
 #: src/Module/Admin/Themes/Details.php:38
 msgid "Disable"
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:74
+#: src/Module/Admin/Addons/Details.php:75
 #: src/Module/Admin/Themes/Details.php:41 src/Module/Settings/Display.php:341
 msgid "Enable"
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:98 src/Module/Admin/Addons/Index.php:77
+#: src/Module/Admin/Addons/Details.php:128 src/Module/Admin/Addons/Index.php:77
 #: src/Module/Admin/Federation.php:213 src/Module/Admin/Logs/Settings.php:74
 #: src/Module/Admin/Logs/View.php:71 src/Module/Admin/Queue.php:59
 #: src/Module/Admin/Site.php:446 src/Module/Admin/Storage.php:124
@@ -3903,22 +3904,22 @@ msgstr ""
 msgid "Administration"
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:99 src/Module/Admin/Addons/Index.php:78
+#: src/Module/Admin/Addons/Details.php:129 src/Module/Admin/Addons/Index.php:78
 #: src/Module/BaseAdmin.php:77 src/Module/BaseSettings.php:127
 msgid "Addons"
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:100
+#: src/Module/Admin/Addons/Details.php:130
 #: src/Module/Admin/Themes/Details.php:84
 msgid "Toggle"
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:113
+#: src/Module/Admin/Addons/Details.php:143
 #: src/Module/Admin/Themes/Details.php:92
 msgid "Author: "
 msgstr ""
 
-#: src/Module/Admin/Addons/Details.php:114
+#: src/Module/Admin/Addons/Details.php:144
 #: src/Module/Admin/Themes/Details.php:93
 msgid "Maintainer: "
 msgstr ""
@@ -4013,14 +4014,14 @@ msgstr ""
 
 #: src/Module/Admin/Features.php:53
 #: src/Module/Notifications/Introductions.php:136
-#: src/Module/OAuth/Acknowledge.php:41 src/Module/Register.php:124
+#: src/Module/OAuth/Acknowledge.php:41 src/Module/Register.php:128
 #: src/Module/Settings/TwoFactor/Trusted.php:115
 msgid "No"
 msgstr ""
 
 #: src/Module/Admin/Features.php:53 src/Module/Contact/Revoke.php:91
 #: src/Module/Notifications/Introductions.php:136
-#: src/Module/OAuth/Acknowledge.php:40 src/Module/Register.php:123
+#: src/Module/OAuth/Acknowledge.php:40 src/Module/Register.php:127
 #: src/Module/Settings/TwoFactor/Trusted.php:115
 msgid "Yes"
 msgstr ""
@@ -4371,7 +4372,7 @@ msgstr ""
 msgid "Republish users to directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:451 src/Module/Register.php:145
+#: src/Module/Admin/Site.php:451 src/Module/Register.php:153
 msgid "Registration"
 msgstr ""
 
@@ -4384,7 +4385,7 @@ msgid "Policies"
 msgstr ""
 
 #: src/Module/Admin/Site.php:454 src/Module/Calendar/Event/Form.php:238
-#: src/Module/Contact.php:527 src/Module/Profile/Profile.php:267
+#: src/Module/Contact.php:527 src/Module/Profile/Profile.php:285
 msgid "Advanced"
 msgstr ""
 
@@ -5196,7 +5197,7 @@ msgstr ""
 msgid "Can be \"all\" or \"tags\". \"all\" means that every public post should be received. \"tags\" means that only posts with selected tags should be received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:584 src/Module/Contact/Profile.php:315
+#: src/Module/Admin/Site.php:584 src/Module/Contact/Profile.php:346
 #: src/Module/Settings/Display.php:249
 #: src/Module/Settings/TwoFactor/Index.php:132
 msgid "Disabled"
@@ -5749,11 +5750,11 @@ msgstr ""
 msgid "Tips for New Members"
 msgstr ""
 
-#: src/Module/BaseProfile.php:137 src/Module/Contact.php:390
+#: src/Module/BaseProfile.php:141 src/Module/Contact.php:390
 #: src/Module/Contact.php:537 src/Module/Conversation/Channel.php:98
 #: src/Module/Conversation/Community.php:91
-#: src/Module/Conversation/Network.php:295
-#: src/Module/Moderation/BaseUsers.php:102 src/Object/Post.php:612
+#: src/Module/Conversation/Network.php:349
+#: src/Module/Moderation/BaseUsers.php:130 src/Object/Post.php:611
 msgid "More"
 msgstr ""
 
@@ -5872,7 +5873,7 @@ msgstr ""
 #: src/Module/Moderation/Blocklist/Server/Index.php:76
 #: src/Module/Moderation/Blocklist/Server/Index.php:104
 #: src/Module/Moderation/Blocklist/Server/Index.php:105
-#: src/Module/Moderation/Item/Delete.php:53 src/Module/Register.php:141
+#: src/Module/Moderation/Item/Delete.php:53 src/Module/Register.php:149
 #: src/Module/Security/TwoFactor/Verify.php:87
 #: src/Module/Settings/Channels.php:176 src/Module/Settings/Channels.php:197
 #: src/Module/Settings/TwoFactor/Index.php:147
@@ -5899,16 +5900,12 @@ msgstr ""
 msgid "Description (BBCode allowed)"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:227
-msgid "Location (BBCode not allowed)"
-msgstr ""
-
 #: src/Module/Calendar/Event/Form.php:230
 #: src/Module/Calendar/Event/Form.php:231
 msgid "Share this event"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:237 src/Module/Profile/Profile.php:266
+#: src/Module/Calendar/Event/Form.php:237 src/Module/Profile/Profile.php:284
 msgid "Basic"
 msgstr ""
 
@@ -5962,8 +5959,8 @@ msgstr ""
 #: src/Module/Contact/Conversations.php:78
 #: src/Module/Contact/Conversations.php:83 src/Module/Contact/Media.php:47
 #: src/Module/Contact/Posts.php:64 src/Module/Contact/Posts.php:69
-#: src/Module/Contact/Posts.php:74 src/Module/Contact/Profile.php:146
-#: src/Module/Contact/Profile.php:151 src/Module/Contact/Profile.php:170
+#: src/Module/Contact/Posts.php:74 src/Module/Contact/Profile.php:172
+#: src/Module/Contact/Profile.php:177 src/Module/Contact/Profile.php:196
 #: src/Module/Contact/Redir.php:79 src/Module/Contact/Redir.php:133
 #: src/Module/FriendSuggest.php:58 src/Module/FriendSuggest.php:96
 msgid "Contact not found."
@@ -6053,7 +6050,7 @@ msgid "Show all contacts"
 msgstr ""
 
 #: src/Module/Contact.php:332 src/Module/Contact.php:411
-#: src/Module/Moderation/BaseUsers.php:74
+#: src/Module/Moderation/BaseUsers.php:92
 msgid "Pending"
 msgstr ""
 
@@ -6062,7 +6059,7 @@ msgid "Only show pending contacts"
 msgstr ""
 
 #: src/Module/Contact.php:340 src/Module/Contact.php:414
-#: src/Module/Moderation/BaseUsers.php:82
+#: src/Module/Moderation/BaseUsers.php:100
 msgid "Blocked"
 msgstr ""
 
@@ -6071,7 +6068,7 @@ msgid "Only show blocked contacts"
 msgstr ""
 
 #: src/Module/Contact.php:348 src/Module/Contact.php:420
-#: src/Module/Settings/Server/Index.php:93 src/Object/Post.php:391
+#: src/Module/Settings/Server/Index.php:93 src/Object/Post.php:390
 msgid "Ignored"
 msgstr ""
 
@@ -6120,18 +6117,18 @@ msgstr ""
 msgid "Update"
 msgstr ""
 
-#: src/Module/Contact.php:448 src/Module/Contact/Profile.php:524
+#: src/Module/Contact.php:448 src/Module/Contact/Profile.php:560
 #: src/Module/Moderation/Blocklist/Contact.php:105
 #: src/Module/Moderation/Users/Blocked.php:94
 #: src/Module/Moderation/Users/Index.php:103
 msgid "Unblock"
 msgstr ""
 
-#: src/Module/Contact.php:449 src/Module/Contact/Profile.php:532
+#: src/Module/Contact.php:449 src/Module/Contact/Profile.php:568
 msgid "Unignore"
 msgstr ""
 
-#: src/Module/Contact.php:450 src/Module/Contact/Profile.php:540
+#: src/Module/Contact.php:450 src/Module/Contact/Profile.php:576
 msgid "Uncollapse"
 msgstr ""
 
@@ -6183,7 +6180,7 @@ msgstr ""
 msgid "Pending incoming contact request"
 msgstr ""
 
-#: src/Module/Contact.php:607 src/Module/Contact/Profile.php:383
+#: src/Module/Contact.php:607 src/Module/Contact/Profile.php:414
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr ""
@@ -6314,7 +6311,7 @@ msgstr ""
 msgid "Your Identity Address:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:155 src/Module/Contact/Profile.php:414
+#: src/Module/Contact/Follow.php:155 src/Module/Contact/Profile.php:445
 #: src/Module/Contact/Unfollow.php:115
 #: src/Module/Moderation/Blocklist/Contact.php:119
 #: src/Module/Moderation/Reports.php:112
@@ -6323,9 +6320,9 @@ msgstr ""
 msgid "Profile URL"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:156 src/Module/Contact/Profile.php:426
+#: src/Module/Contact/Follow.php:156 src/Module/Contact/Profile.php:457
 #: src/Module/Notifications/Introductions.php:184
-#: src/Module/Profile/Profile.php:225
+#: src/Module/Profile/Profile.php:243
 msgid "Tags:"
 msgstr ""
 
@@ -6362,301 +6359,301 @@ msgstr ""
 msgid "Profile Match"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:131
+#: src/Module/Contact/Profile.php:157
 msgid "Failed to update contact record."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:196
+#: src/Module/Contact/Profile.php:222
 msgid "Contact has been unblocked"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:200
+#: src/Module/Contact/Profile.php:226
 msgid "Contact has been blocked"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:212
+#: src/Module/Contact/Profile.php:238
 msgid "Contact has been unignored"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:216
+#: src/Module/Contact/Profile.php:242
 msgid "Contact has been ignored"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:228
+#: src/Module/Contact/Profile.php:254
 msgid "Contact has been uncollapsed"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:232
+#: src/Module/Contact/Profile.php:258
 msgid "Contact has been collapsed"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:260
+#: src/Module/Contact/Profile.php:287
 #, php-format
 msgid "You are mutual friends with %s"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:261
+#: src/Module/Contact/Profile.php:290
 #, php-format
 msgid "You are sharing with %s"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:262
+#: src/Module/Contact/Profile.php:293
 #, php-format
 msgid "%s is sharing with you"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:278
+#: src/Module/Contact/Profile.php:310
 msgid "Private communications are not available for this contact."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:288
+#: src/Module/Contact/Profile.php:319
 msgid "This contact is on a server you ignored."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:291
+#: src/Module/Contact/Profile.php:322
 msgid "Never"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:294
+#: src/Module/Contact/Profile.php:325
 msgid "(Update was not successful)"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:294
+#: src/Module/Contact/Profile.php:325
 msgid "(Update was successful)"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:296 src/Module/Contact/Profile.php:495
+#: src/Module/Contact/Profile.php:327 src/Module/Contact/Profile.php:531
 msgid "Suggest friends"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:300
+#: src/Module/Contact/Profile.php:331
 #, php-format
 msgid "Network type: %s"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:305
+#: src/Module/Contact/Profile.php:336
 msgid "Communications lost with this contact!"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:311
+#: src/Module/Contact/Profile.php:342
 msgid "Fetch further information for feeds"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:313
+#: src/Module/Contact/Profile.php:344
 msgid "Fetch information like preview pictures, title and teaser from the feed item. You can activate this if the feed doesn't contain much text. Keywords are taken from the meta header in the feed item and are posted as hash tags."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:316
+#: src/Module/Contact/Profile.php:347
 msgid "Fetch information"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:317
+#: src/Module/Contact/Profile.php:348
 msgid "Fetch keywords"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:318
+#: src/Module/Contact/Profile.php:349
 msgid "Fetch information and keywords"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:328 src/Module/Contact/Profile.php:333
-#: src/Module/Contact/Profile.php:338 src/Module/Contact/Profile.php:344
+#: src/Module/Contact/Profile.php:359 src/Module/Contact/Profile.php:364
+#: src/Module/Contact/Profile.php:369 src/Module/Contact/Profile.php:375
 msgid "No mirroring"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:329 src/Module/Contact/Profile.php:339
-#: src/Module/Contact/Profile.php:345
+#: src/Module/Contact/Profile.php:360 src/Module/Contact/Profile.php:370
+#: src/Module/Contact/Profile.php:376
 msgid "Mirror as my own posting"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:334 src/Module/Contact/Profile.php:340
+#: src/Module/Contact/Profile.php:365 src/Module/Contact/Profile.php:371
 msgid "Native reshare"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:365
+#: src/Module/Contact/Profile.php:396
 msgid "Contact Information / Notes"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:366
+#: src/Module/Contact/Profile.php:397
 msgid "Contact Settings"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:374
+#: src/Module/Contact/Profile.php:405
 msgid "Contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:378
+#: src/Module/Contact/Profile.php:409
 msgid "Their personal note"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:380
+#: src/Module/Contact/Profile.php:411
 msgid "Edit contact notes"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:384
+#: src/Module/Contact/Profile.php:415
 msgid "Block/Unblock contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:385
+#: src/Module/Contact/Profile.php:416
 #: src/Module/Moderation/Report/Create.php:279
 msgid "Ignore contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:386
+#: src/Module/Contact/Profile.php:417
 msgid "View conversations"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:391
+#: src/Module/Contact/Profile.php:422
 msgid "Last update:"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:393
+#: src/Module/Contact/Profile.php:424
 msgid "Update public posts"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:395 src/Module/Contact/Profile.php:505
+#: src/Module/Contact/Profile.php:426 src/Module/Contact/Profile.php:541
 msgid "Update now"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:397
+#: src/Module/Contact/Profile.php:428
 msgid "Awaiting connection acknowledge"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:398
+#: src/Module/Contact/Profile.php:429
 msgid "Currently blocked"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:399
+#: src/Module/Contact/Profile.php:430
 msgid "Currently ignored"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:400
+#: src/Module/Contact/Profile.php:431
 msgid "Currently collapsed"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:401
+#: src/Module/Contact/Profile.php:432
 msgid "Currently archived"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:404
+#: src/Module/Contact/Profile.php:435
 msgid "Manage remote servers"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:406
+#: src/Module/Contact/Profile.php:437
 #: src/Module/Notifications/Introductions.php:185
 msgid "Hide this contact from others"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:406
+#: src/Module/Contact/Profile.php:437
 msgid "Replies/likes to your public posts <strong>may</strong> still be visible"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:407
+#: src/Module/Contact/Profile.php:438
 msgid "Notification for new posts"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:407
+#: src/Module/Contact/Profile.php:438
 msgid "Send a notification of every new post of this contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:409
+#: src/Module/Contact/Profile.php:440
 msgid "Keyword Deny List"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:409
+#: src/Module/Contact/Profile.php:440
 msgid "Comma separated list of keywords that should not be converted to hashtags, when \"Fetch information and keywords\" is selected"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:427
+#: src/Module/Contact/Profile.php:458
 #: src/Module/Settings/TwoFactor/Index.php:146
 msgid "Actions"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:429
+#: src/Module/Contact/Profile.php:460
 #: src/Module/Settings/TwoFactor/Index.php:126 view/theme/frio/theme.php:218
 msgid "Status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:435
+#: src/Module/Contact/Profile.php:466
 msgid "Mirror postings from this contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:437
+#: src/Module/Contact/Profile.php:468
 msgid "Mark this contact as remote_self, this will cause friendica to repost new entries from this contact."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:440
+#: src/Module/Contact/Profile.php:471
 msgid "Channel Settings"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:441
+#: src/Module/Contact/Profile.php:472
 msgid "Frequency of this contact in relevant channels"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:442
+#: src/Module/Contact/Profile.php:473
 msgid "Depending on the type of the channel not all posts from this contact are displayed. By default, posts need to have a minimum amount of interactions (comments, likes) to show in your channels. On the other hand there can be contacts who flood the channel, so you might want to see only some of their posts. Or you don't want to see their content at all, but you don't want to block or hide the contact completely."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:443
+#: src/Module/Contact/Profile.php:474
 msgid "Default frequency"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:443
+#: src/Module/Contact/Profile.php:474
 msgid "Posts by this contact are displayed in the \"for you\" channel if you interact often with this contact or if a post reached some level of interaction."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:444
+#: src/Module/Contact/Profile.php:475
 msgid "Display all posts of this contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:444
+#: src/Module/Contact/Profile.php:475
 msgid "All posts from this contact will appear on the \"for you\" channel"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:445
+#: src/Module/Contact/Profile.php:476
 msgid "Display only few posts"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:445
+#: src/Module/Contact/Profile.php:476
 msgid "When a contact creates a lot of posts in a short period, this setting reduces the number of displayed posts in every channel."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:446
+#: src/Module/Contact/Profile.php:477
 msgid "Never display posts"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:446
+#: src/Module/Contact/Profile.php:477
 msgid "Posts from this contact will never be displayed in any channel"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:447
+#: src/Module/Contact/Profile.php:478
 msgid "Channel Only"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:447
+#: src/Module/Contact/Profile.php:478
 msgid "If enabled, posts from this contact will only appear in channels and network streams in circles, but not in the general network stream."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:515
+#: src/Module/Contact/Profile.php:551
 msgid "Refetch contact data"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:526
+#: src/Module/Contact/Profile.php:562
 msgid "Toggle Blocked status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:534
+#: src/Module/Contact/Profile.php:570
 msgid "Toggle Ignored status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:542
+#: src/Module/Contact/Profile.php:578
 msgid "Toggle Collapsed status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:549 src/Module/Contact/Revoke.php:89
+#: src/Module/Contact/Profile.php:585 src/Module/Contact/Revoke.php:89
 msgid "Revoke Follow"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:551
+#: src/Module/Contact/Profile.php:587
 msgid "Revoke the follow from this contact"
 msgstr ""
 
@@ -6722,21 +6719,21 @@ msgstr ""
 msgid "Not available."
 msgstr ""
 
-#: src/Module/Conversation/Network.php:205
+#: src/Module/Conversation/Network.php:254
 msgid "No such circle"
 msgstr ""
 
-#: src/Module/Conversation/Network.php:209
+#: src/Module/Conversation/Network.php:258
 #, php-format
 msgid "Circle: %s"
 msgstr ""
 
-#: src/Module/Conversation/Network.php:229
+#: src/Module/Conversation/Network.php:278
 #, php-format
 msgid "Error %d (%s) while fetching the timeline."
 msgstr ""
 
-#: src/Module/Conversation/Network.php:307
+#: src/Module/Conversation/Network.php:361
 msgid "Network feed not available."
 msgstr ""
 
@@ -6949,7 +6946,7 @@ msgid "Twitter Source / Tweet URL (requires API key)"
 msgstr ""
 
 #: src/Module/Debug/Feed.php:39 src/Module/Filer/SaveTag.php:33
-#: src/Module/Settings/Profile/Index.php:166
+#: src/Module/Settings/Profile/Index.php:190
 msgid "You must be logged in to use this module"
 msgstr ""
 
@@ -7024,11 +7021,11 @@ msgstr ""
 msgid "Site Directory"
 msgstr ""
 
-#: src/Module/Filer/RemoveTag.php:91
+#: src/Module/Filer/RemoveTag.php:90
 msgid "Item was not deleted"
 msgstr ""
 
-#: src/Module/Filer/RemoveTag.php:101
+#: src/Module/Filer/RemoveTag.php:100
 msgid "Item was not removed"
 msgstr ""
 
@@ -7057,52 +7054,52 @@ msgstr ""
 msgid "Suggest a friend for %s"
 msgstr ""
 
-#: src/Module/Friendica.php:71
+#: src/Module/Friendica.php:87
 msgid "Installed addons/apps:"
 msgstr ""
 
-#: src/Module/Friendica.php:76
+#: src/Module/Friendica.php:92
 msgid "No installed addons/apps"
 msgstr ""
 
-#: src/Module/Friendica.php:81
+#: src/Module/Friendica.php:97
 #, php-format
 msgid "Read about the <a href=\"%1$s/tos\">Terms of Service</a> of this node."
 msgstr ""
 
-#: src/Module/Friendica.php:88
+#: src/Module/Friendica.php:104
 msgid "On this server the following remote servers are blocked."
 msgstr ""
 
-#: src/Module/Friendica.php:91
+#: src/Module/Friendica.php:107
 #: src/Module/Moderation/Blocklist/Server/Index.php:76
 #: src/Module/Moderation/Blocklist/Server/Index.php:100
 #: src/Module/Settings/Channels.php:218
 msgid "Reason for the block"
 msgstr ""
 
-#: src/Module/Friendica.php:93
+#: src/Module/Friendica.php:109
 msgid "Download this list in CSV format"
 msgstr ""
 
-#: src/Module/Friendica.php:108
+#: src/Module/Friendica.php:126
 #, php-format
 msgid "This is Friendica, version %s that is running at the web location %s. The database version is %s, the post update version is %s."
 msgstr ""
 
-#: src/Module/Friendica.php:114
+#: src/Module/Friendica.php:132
 msgid "Please visit <a href=\"https://friendi.ca\">Friendi.ca</a> to learn more about the Friendica project."
 msgstr ""
 
-#: src/Module/Friendica.php:115
+#: src/Module/Friendica.php:133
 msgid "Bug reports and issues: please visit"
 msgstr ""
 
-#: src/Module/Friendica.php:115
+#: src/Module/Friendica.php:133
 msgid "the bugtracker at github"
 msgstr ""
 
-#: src/Module/Friendica.php:116
+#: src/Module/Friendica.php:134
 msgid "Suggestions, praise, etc. - please email \"info\" at \"friendi - dot - ca"
 msgstr ""
 
@@ -7427,84 +7424,84 @@ msgid "File upload failed."
 msgstr ""
 
 #: src/Module/Media/Photo/Upload.php:136 src/Module/Media/Photo/Upload.php:137
-#: src/Module/Profile/Photos.php:212
+#: src/Module/Profile/Photos.php:255
 #: src/Module/Settings/Profile/Photo/Index.php:53
 msgid "Unable to process image."
 msgstr ""
 
-#: src/Module/Media/Photo/Upload.php:162 src/Module/Profile/Photos.php:232
+#: src/Module/Media/Photo/Upload.php:162 src/Module/Profile/Photos.php:278
 #: src/Module/Settings/Profile/Photo/Index.php:80
 msgid "Image upload failed."
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:61
+#: src/Module/Moderation/BaseUsers.php:79
 msgid "List of all users"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:66
+#: src/Module/Moderation/BaseUsers.php:84
 msgid "Active"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:69
+#: src/Module/Moderation/BaseUsers.php:87
 msgid "List of active accounts"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:77
+#: src/Module/Moderation/BaseUsers.php:95
 msgid "List of pending registrations"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:85
+#: src/Module/Moderation/BaseUsers.php:103
 msgid "List of blocked users"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:90
+#: src/Module/Moderation/BaseUsers.php:108
 msgid "Deleted"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:93
+#: src/Module/Moderation/BaseUsers.php:111
 msgid "List of pending user deletions"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:110 src/Module/Settings/Account.php:431
+#: src/Module/Moderation/BaseUsers.php:138 src/Module/Settings/Account.php:431
 msgid "Normal Account Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:111 src/Module/Settings/Account.php:438
+#: src/Module/Moderation/BaseUsers.php:139 src/Module/Settings/Account.php:438
 msgid "Soapbox Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:112 src/Module/Settings/Account.php:445
+#: src/Module/Moderation/BaseUsers.php:140 src/Module/Settings/Account.php:445
 msgid "Public Group"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:113 src/Module/Settings/Account.php:452
+#: src/Module/Moderation/BaseUsers.php:141 src/Module/Settings/Account.php:452
 msgid "Public Group - Restricted"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:114 src/Module/Settings/Account.php:459
+#: src/Module/Moderation/BaseUsers.php:142 src/Module/Settings/Account.php:459
 msgid "Automatic Friend Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:115
+#: src/Module/Moderation/BaseUsers.php:143
 msgid "Private Group"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:118 src/Module/Moderation/Summary.php:42
+#: src/Module/Moderation/BaseUsers.php:146 src/Module/Moderation/Summary.php:42
 #: src/Module/Settings/Account.php:402
 msgid "Personal Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:119 src/Module/Moderation/Summary.php:43
+#: src/Module/Moderation/BaseUsers.php:147 src/Module/Moderation/Summary.php:43
 #: src/Module/Settings/Account.php:409
 msgid "Organisation Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:120 src/Module/Moderation/Summary.php:44
+#: src/Module/Moderation/BaseUsers.php:148 src/Module/Moderation/Summary.php:44
 #: src/Module/Settings/Account.php:416
 msgid "News Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:121 src/Module/Moderation/Summary.php:45
+#: src/Module/Moderation/BaseUsers.php:149 src/Module/Moderation/Summary.php:45
 #: src/Module/Settings/Account.php:423
 msgid "Community Group"
 msgstr ""
@@ -8522,54 +8519,54 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:57
+#: src/Module/Privacy/PermissionTooltip.php:76
 #, php-format
 msgid "Wrong type \"%s\", expected one of: %s"
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:87
+#: src/Module/Privacy/PermissionTooltip.php:106
 msgid "Model not found"
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:104
+#: src/Module/Privacy/PermissionTooltip.php:133
 msgid "Unlisted"
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:110
+#: src/Module/Privacy/PermissionTooltip.php:141
 msgid "Remote privacy information not available."
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:117
+#: src/Module/Privacy/PermissionTooltip.php:148
 msgid "Visible to:"
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:119
+#: src/Module/Privacy/PermissionTooltip.php:150
 msgid "CC:"
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:120
+#: src/Module/Privacy/PermissionTooltip.php:151
 msgid "BCC:"
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:121
+#: src/Module/Privacy/PermissionTooltip.php:152
 msgid "Audience:"
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:122
+#: src/Module/Privacy/PermissionTooltip.php:153
 msgid "Attributed To:"
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:220
+#: src/Module/Privacy/PermissionTooltip.php:251
 #, php-format
 msgid "Collection (%s)"
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:224
+#: src/Module/Privacy/PermissionTooltip.php:255
 #, php-format
 msgid "Followers (%s)"
 msgstr ""
 
-#: src/Module/Privacy/PermissionTooltip.php:241
+#: src/Module/Privacy/PermissionTooltip.php:272
 #, php-format
 msgid "%d more"
 msgstr ""
@@ -8578,86 +8575,86 @@ msgstr ""
 msgid "No contacts."
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:96 src/Module/Profile/Profile.php:342
+#: src/Module/Profile/Conversations.php:96 src/Module/Profile/Profile.php:362
 #: src/Protocol/Feed.php:1124
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:97 src/Module/Profile/Profile.php:343
+#: src/Module/Profile/Conversations.php:97 src/Module/Profile/Profile.php:363
 #: src/Protocol/Feed.php:1127
 #, php-format
 msgid "%s's comments"
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:98 src/Module/Profile/Profile.php:344
+#: src/Module/Profile/Conversations.php:98 src/Module/Profile/Profile.php:364
 #: src/Protocol/Feed.php:1120
 #, php-format
 msgid "%s's timeline"
 msgstr ""
 
-#: src/Module/Profile/Photos.php:157 src/Module/Profile/Photos.php:160
-#: src/Module/Profile/Photos.php:189
+#: src/Module/Profile/Photos.php:192 src/Module/Profile/Photos.php:195
+#: src/Module/Profile/Photos.php:226
 #: src/Module/Settings/Profile/Photo/Index.php:44
 #, php-format
 msgid "Image exceeds size limit of %s"
 msgstr ""
 
-#: src/Module/Profile/Photos.php:163
+#: src/Module/Profile/Photos.php:198
 msgid "Image upload didn't complete, please try again"
 msgstr ""
 
-#: src/Module/Profile/Photos.php:166
+#: src/Module/Profile/Photos.php:201
 msgid "Image file is missing"
 msgstr ""
 
-#: src/Module/Profile/Photos.php:171
+#: src/Module/Profile/Photos.php:206
 msgid "Server can't accept new file upload at this time, please contact your administrator"
 msgstr ""
 
-#: src/Module/Profile/Photos.php:197
+#: src/Module/Profile/Photos.php:237
 msgid "Image file is empty."
 msgstr ""
 
-#: src/Module/Profile/Photos.php:349
+#: src/Module/Profile/Photos.php:396
 msgid "View Album"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:103 src/Module/Profile/Restricted.php:38
+#: src/Module/Profile/Profile.php:121 src/Module/Profile/Restricted.php:38
 msgid "Profile not found."
 msgstr ""
 
-#: src/Module/Profile/Profile.php:149
+#: src/Module/Profile/Profile.php:167
 #, php-format
 msgid "You're currently viewing your profile as <b>%s</b> <a href=\"%s\" class=\"btn btn-sm pull-right\">Cancel</a>"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:158
+#: src/Module/Profile/Profile.php:176
 msgid "Full Name:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:163
+#: src/Module/Profile/Profile.php:181
 msgid "Member since:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:169
+#: src/Module/Profile/Profile.php:187
 msgid "j F, Y"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:170
+#: src/Module/Profile/Profile.php:188
 msgid "j F"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:178 src/Util/Temporal.php:155
+#: src/Module/Profile/Profile.php:196 src/Util/Temporal.php:155
 msgid "Birthday:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:181 src/Module/Settings/Profile/Index.php:282
+#: src/Module/Profile/Profile.php:199 src/Module/Settings/Profile/Index.php:307
 #: src/Util/Temporal.php:157
 msgid "Age: "
 msgstr ""
 
-#: src/Module/Profile/Profile.php:181 src/Module/Settings/Profile/Index.php:282
+#: src/Module/Profile/Profile.php:199 src/Module/Settings/Profile/Index.php:307
 #: src/Util/Temporal.php:157
 #, php-format
 msgid "%d year old"
@@ -8665,19 +8662,19 @@ msgid_plural "%d years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Profile/Profile.php:186 src/Module/Settings/Profile/Index.php:275
+#: src/Module/Profile/Profile.php:204 src/Module/Settings/Profile/Index.php:300
 msgid "Description:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:252
+#: src/Module/Profile/Profile.php:270
 msgid "Groups:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:264
+#: src/Module/Profile/Profile.php:282
 msgid "View profile as:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:281
+#: src/Module/Profile/Profile.php:299
 msgid "View as"
 msgstr ""
 
@@ -8735,160 +8732,160 @@ msgstr ""
 msgid "Remove post"
 msgstr ""
 
-#: src/Module/Register.php:77
+#: src/Module/Register.php:81
 msgid "Only parent users can create additional accounts."
 msgstr ""
 
-#: src/Module/Register.php:92 src/Module/User/Import.php:98
+#: src/Module/Register.php:96 src/Module/User/Import.php:98
 msgid "This site has exceeded the number of allowed daily account registrations. Please try again tomorrow."
 msgstr ""
 
-#: src/Module/Register.php:109
+#: src/Module/Register.php:113
 msgid "You may (optionally) fill in this form via OpenID by supplying your OpenID and clicking \"Register\"."
 msgstr ""
 
-#: src/Module/Register.php:110
+#: src/Module/Register.php:114
 msgid "If you are not familiar with OpenID, please leave that field blank and fill in the rest of the items."
 msgstr ""
 
-#: src/Module/Register.php:111
+#: src/Module/Register.php:115
 msgid "Your OpenID (optional): "
 msgstr ""
 
-#: src/Module/Register.php:120
+#: src/Module/Register.php:124
 msgid "Include your profile in member directory?"
 msgstr ""
 
-#: src/Module/Register.php:141
+#: src/Module/Register.php:149
 msgid "Note for the admin"
 msgstr ""
 
-#: src/Module/Register.php:141
+#: src/Module/Register.php:149
 msgid "Leave a message for the admin, why you want to join this node"
 msgstr ""
 
-#: src/Module/Register.php:142
+#: src/Module/Register.php:150
 msgid "Membership on this site is by invitation only."
 msgstr ""
 
-#: src/Module/Register.php:143
+#: src/Module/Register.php:151
 msgid "Your invitation code: "
 msgstr ""
 
-#: src/Module/Register.php:151
+#: src/Module/Register.php:159
 msgid "Your Display Name (as you would like it to be displayed on this system):"
 msgstr ""
 
-#: src/Module/Register.php:152
+#: src/Module/Register.php:160
 msgid "Your Email Address (initial information will be sent there, so this must be a valid address):"
 msgstr ""
 
-#: src/Module/Register.php:153
+#: src/Module/Register.php:161
 msgid "Please repeat your e-mail address:"
 msgstr ""
 
-#: src/Module/Register.php:155 src/Module/Security/PasswordTooLong.php:86
+#: src/Module/Register.php:163 src/Module/Security/PasswordTooLong.php:86
 #: src/Module/Settings/Account.php:513
 msgid "New Password:"
 msgstr ""
 
-#: src/Module/Register.php:155
+#: src/Module/Register.php:163
 msgid "Leave empty for an auto generated password."
 msgstr ""
 
-#: src/Module/Register.php:156 src/Module/Security/PasswordTooLong.php:87
+#: src/Module/Register.php:164 src/Module/Security/PasswordTooLong.php:87
 #: src/Module/Settings/Account.php:514
 msgid "Confirm:"
 msgstr ""
 
-#: src/Module/Register.php:157
+#: src/Module/Register.php:165
 #, php-format
 msgid "Choose a profile nickname. This must begin with a text character. Your profile address on this site will then be \"<strong>nickname@%s</strong>\"."
 msgstr ""
 
-#: src/Module/Register.php:158
+#: src/Module/Register.php:166
 msgid "Choose a nickname: "
 msgstr ""
 
-#: src/Module/Register.php:166 src/Module/User/Import.php:104
+#: src/Module/Register.php:174 src/Module/User/Import.php:104
 msgid "Import"
 msgstr ""
 
-#: src/Module/Register.php:167
+#: src/Module/Register.php:175
 msgid "Import your profile to this friendica instance"
 msgstr ""
 
-#: src/Module/Register.php:174
+#: src/Module/Register.php:182
 msgid "Note: This node explicitly contains adult content"
 msgstr ""
 
-#: src/Module/Register.php:176 src/Module/Settings/Delegation.php:167
+#: src/Module/Register.php:184 src/Module/Settings/Delegation.php:167
 msgid "Parent Password:"
 msgstr ""
 
-#: src/Module/Register.php:176 src/Module/Settings/Delegation.php:167
+#: src/Module/Register.php:184 src/Module/Settings/Delegation.php:167
 msgid "Please enter the password of the parent account to legitimize your request."
 msgstr ""
 
-#: src/Module/Register.php:205
+#: src/Module/Register.php:218
 msgid "Password doesn't match."
 msgstr ""
 
-#: src/Module/Register.php:211
+#: src/Module/Register.php:224
 msgid "Please enter your password."
 msgstr ""
 
-#: src/Module/Register.php:253
+#: src/Module/Register.php:266
 msgid "You have entered too much information."
 msgstr ""
 
-#: src/Module/Register.php:276
+#: src/Module/Register.php:289
 msgid "Please enter the identical mail address in the second field."
 msgstr ""
 
-#: src/Module/Register.php:284
+#: src/Module/Register.php:297
 msgid "Nickname cannot start with a digit."
 msgstr ""
 
-#: src/Module/Register.php:286
+#: src/Module/Register.php:299
 msgid "Nickname can only contain US-ASCII characters."
 msgstr ""
 
-#: src/Module/Register.php:315
+#: src/Module/Register.php:328
 msgid "The additional account was created."
 msgstr ""
 
-#: src/Module/Register.php:340
+#: src/Module/Register.php:353
 msgid "Registration successful. Please check your email for further instructions."
 msgstr ""
 
-#: src/Module/Register.php:348
+#: src/Module/Register.php:361
 #, php-format
 msgid "Failed to send email message. Here your accout details:<br> login: %s<br> password: %s<br><br>You can change your password after login."
 msgstr ""
 
-#: src/Module/Register.php:355
+#: src/Module/Register.php:368
 msgid "Registration successful."
 msgstr ""
 
-#: src/Module/Register.php:364 src/Module/Register.php:371
-#: src/Module/Register.php:381
+#: src/Module/Register.php:377 src/Module/Register.php:384
+#: src/Module/Register.php:394
 msgid "Your registration can not be processed."
 msgstr ""
 
-#: src/Module/Register.php:370
+#: src/Module/Register.php:383
 msgid "You have to leave a request note for the admin."
 msgstr ""
 
-#: src/Module/Register.php:380
+#: src/Module/Register.php:393
 msgid "An internal error occured."
 msgstr ""
 
-#: src/Module/Register.php:402
+#: src/Module/Register.php:415
 msgid "Your registration is pending approval by the site owner."
 msgstr ""
 
-#: src/Module/Search/Acl.php:64
+#: src/Module/Search/Acl.php:78
 msgid "You must be logged in to use this module."
 msgstr ""
 
@@ -9263,7 +9260,7 @@ msgid "Basic Settings"
 msgstr ""
 
 #: src/Module/Settings/Account.php:522
-#: src/Module/Settings/Profile/Index.php:274
+#: src/Module/Settings/Profile/Index.php:299
 msgid "Display name:"
 msgstr ""
 
@@ -10175,81 +10172,81 @@ msgstr ""
 msgid "Remove authorization"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:102
+#: src/Module/Settings/Profile/Index.php:126
 msgid "Display Name is required."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:156
+#: src/Module/Settings/Profile/Index.php:180
 msgid "Profile couldn't be updated."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:196
-#: src/Module/Settings/Profile/Index.php:217
+#: src/Module/Settings/Profile/Index.php:220
+#: src/Module/Settings/Profile/Index.php:241
 msgid "Label:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:197
-#: src/Module/Settings/Profile/Index.php:218
+#: src/Module/Settings/Profile/Index.php:221
+#: src/Module/Settings/Profile/Index.php:242
 msgid "Value:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:208
-#: src/Module/Settings/Profile/Index.php:229
+#: src/Module/Settings/Profile/Index.php:232
+#: src/Module/Settings/Profile/Index.php:253
 msgid "Field Permissions"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:209
-#: src/Module/Settings/Profile/Index.php:230
+#: src/Module/Settings/Profile/Index.php:233
+#: src/Module/Settings/Profile/Index.php:254
 msgid "(click to open/close)"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:215
+#: src/Module/Settings/Profile/Index.php:239
 msgid "Add a new profile field"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:238
+#: src/Module/Settings/Profile/Index.php:262
 msgid "The homepage is verified. A rel=\"me\" link back to your Friendica profile page was found on the homepage."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:240
+#: src/Module/Settings/Profile/Index.php:264
 #, php-format
 msgid "To verify your homepage, add a rel=\"me\" link to it, pointing to your profile URL (%s)."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:246
+#: src/Module/Settings/Profile/Index.php:270
 msgid "Profile Actions"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:247
+#: src/Module/Settings/Profile/Index.php:271
 msgid "Edit Profile Details"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:249
+#: src/Module/Settings/Profile/Index.php:273
 msgid "Change Profile Photo"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:252
+#: src/Module/Settings/Profile/Index.php:276
 msgid "Profile picture"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:253
+#: src/Module/Settings/Profile/Index.php:277
 msgid "Location"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:254 src/Util/Temporal.php:83
+#: src/Module/Settings/Profile/Index.php:278 src/Util/Temporal.php:83
 #: src/Util/Temporal.php:85
 msgid "Miscellaneous"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:255
+#: src/Module/Settings/Profile/Index.php:279
 msgid "Custom Profile Fields"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:256 src/Module/Welcome.php:44
+#: src/Module/Settings/Profile/Index.php:280 src/Module/Welcome.php:44
 msgid "Upload Profile Photo"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:257
+#: src/Module/Settings/Profile/Index.php:282
 #, php-format
 msgid ""
 "<p>Custom fields appear on <a href=\"%s\">your profile page</a>.</p>\n"
@@ -10259,59 +10256,59 @@ msgid ""
 "\t\t\t\t<p>Non-public fields can only be seen by the selected Friendica contacts or the Friendica contacts in the selected circles.</p>"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:277
+#: src/Module/Settings/Profile/Index.php:302
 msgid "Street Address:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:278
+#: src/Module/Settings/Profile/Index.php:303
 msgid "Locality/City:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:279
+#: src/Module/Settings/Profile/Index.php:304
 msgid "Region/State:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:280
+#: src/Module/Settings/Profile/Index.php:305
 msgid "Postal/Zip Code:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:281
+#: src/Module/Settings/Profile/Index.php:306
 msgid "Country:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:283
+#: src/Module/Settings/Profile/Index.php:308
 msgid "XMPP (Jabber) address:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:283
+#: src/Module/Settings/Profile/Index.php:308
 msgid "The XMPP address will be published so that people can follow you there."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:284
+#: src/Module/Settings/Profile/Index.php:309
 msgid "Matrix (Element) address:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:284
+#: src/Module/Settings/Profile/Index.php:309
 msgid "The Matrix address will be published so that people can follow you there."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:285
+#: src/Module/Settings/Profile/Index.php:310
 msgid "Homepage URL:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:286
+#: src/Module/Settings/Profile/Index.php:311
 msgid "Public Keywords:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:286
+#: src/Module/Settings/Profile/Index.php:311
 msgid "(Used for suggesting potential friends, can be seen by others)"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:287
+#: src/Module/Settings/Profile/Index.php:312
 msgid "Private Keywords:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:287
+#: src/Module/Settings/Profile/Index.php:312
 msgid "(Used for searching profiles, never shown to others)"
 msgstr ""
 
@@ -10393,8 +10390,8 @@ msgid "If this error persists, please contact your administrator."
 msgstr ""
 
 #: src/Module/Settings/RemoveMe.php:76
-#: src/Navigation/Notifications/Repository/Notify.php:463
-#: src/Navigation/Notifications/Repository/Notify.php:487
+#: src/Navigation/Notifications/Repository/Notify.php:475
+#: src/Navigation/Notifications/Repository/Notify.php:499
 msgid "[Friendica System Notify]"
 msgstr ""
 
@@ -11197,217 +11194,217 @@ msgstr ""
 msgid "%1$s commented on your thread %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:210
-#: src/Navigation/Notifications/Repository/Notify.php:754
+#: src/Navigation/Notifications/Repository/Notify.php:222
+#: src/Navigation/Notifications/Repository/Notify.php:770
 msgid "[Friendica:Notify]"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:278
+#: src/Navigation/Notifications/Repository/Notify.php:290
 #, php-format
 msgid "%s New mail received at %s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:280
+#: src/Navigation/Notifications/Repository/Notify.php:292
 #, php-format
 msgid "%1$s sent you a new private message at %2$s."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:281
+#: src/Navigation/Notifications/Repository/Notify.php:293
 msgid "a private message"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:281
+#: src/Navigation/Notifications/Repository/Notify.php:293
 #, php-format
 msgid "%1$s sent you %2$s."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:283
+#: src/Navigation/Notifications/Repository/Notify.php:295
 #, php-format
 msgid "Please visit %s to view and/or reply to your private messages."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:313
+#: src/Navigation/Notifications/Repository/Notify.php:325
 #, php-format
 msgid "%1$s commented on %2$s's %3$s %4$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:318
+#: src/Navigation/Notifications/Repository/Notify.php:330
 #, php-format
 msgid "%1$s commented on your %2$s %3$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:322
+#: src/Navigation/Notifications/Repository/Notify.php:334
 #, php-format
 msgid "%1$s commented on their %2$s %3$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:326
-#: src/Navigation/Notifications/Repository/Notify.php:788
+#: src/Navigation/Notifications/Repository/Notify.php:338
+#: src/Navigation/Notifications/Repository/Notify.php:804
 #, php-format
 msgid "%1$s Comment to conversation #%2$d by %3$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:328
+#: src/Navigation/Notifications/Repository/Notify.php:340
 #, php-format
 msgid "%s commented on an item/conversation you have been following."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:332
-#: src/Navigation/Notifications/Repository/Notify.php:348
-#: src/Navigation/Notifications/Repository/Notify.php:814
+#: src/Navigation/Notifications/Repository/Notify.php:344
+#: src/Navigation/Notifications/Repository/Notify.php:360
+#: src/Navigation/Notifications/Repository/Notify.php:830
 #, php-format
 msgid "Please visit %s to view and/or reply to the conversation."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:339
+#: src/Navigation/Notifications/Repository/Notify.php:351
 #, php-format
 msgid "%s %s posted to your profile wall"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:341
+#: src/Navigation/Notifications/Repository/Notify.php:353
 #, php-format
 msgid "%1$s posted to your profile wall at %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:343
+#: src/Navigation/Notifications/Repository/Notify.php:355
 #, php-format
 msgid "%1$s posted to [url=%2$s]your wall[/url]"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:356
+#: src/Navigation/Notifications/Repository/Notify.php:368
 #, php-format
 msgid "%s Introduction received"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:358
+#: src/Navigation/Notifications/Repository/Notify.php:370
 #, php-format
 msgid "You've received an introduction from '%1$s' at %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:360
+#: src/Navigation/Notifications/Repository/Notify.php:372
 #, php-format
 msgid "You've received [url=%1$s]an introduction[/url] from %2$s."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:365
-#: src/Navigation/Notifications/Repository/Notify.php:414
+#: src/Navigation/Notifications/Repository/Notify.php:377
+#: src/Navigation/Notifications/Repository/Notify.php:426
 #, php-format
 msgid "You may visit their profile at %s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:367
+#: src/Navigation/Notifications/Repository/Notify.php:379
 #, php-format
 msgid "Please visit %s to approve or reject the introduction."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:374
+#: src/Navigation/Notifications/Repository/Notify.php:386
 #, php-format
 msgid "%s A new person is sharing with you"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:376
-#: src/Navigation/Notifications/Repository/Notify.php:378
+#: src/Navigation/Notifications/Repository/Notify.php:388
+#: src/Navigation/Notifications/Repository/Notify.php:390
 #, php-format
 msgid "%1$s is sharing with you at %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:385
+#: src/Navigation/Notifications/Repository/Notify.php:397
 #, php-format
 msgid "%s You have a new follower"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:387
-#: src/Navigation/Notifications/Repository/Notify.php:389
+#: src/Navigation/Notifications/Repository/Notify.php:399
+#: src/Navigation/Notifications/Repository/Notify.php:401
 #, php-format
 msgid "You have a new follower at %2$s : %1$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:402
+#: src/Navigation/Notifications/Repository/Notify.php:414
 #, php-format
 msgid "%s Friend suggestion received"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:404
+#: src/Navigation/Notifications/Repository/Notify.php:416
 #, php-format
 msgid "You've received a friend suggestion from '%1$s' at %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:406
+#: src/Navigation/Notifications/Repository/Notify.php:418
 #, php-format
 msgid "You've received [url=%1$s]a friend suggestion[/url] for %2$s from %3$s."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:412
+#: src/Navigation/Notifications/Repository/Notify.php:424
 msgid "Name:"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:413
+#: src/Navigation/Notifications/Repository/Notify.php:425
 msgid "Photo:"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:416
+#: src/Navigation/Notifications/Repository/Notify.php:428
 #, php-format
 msgid "Please visit %s to approve or reject the suggestion."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:424
-#: src/Navigation/Notifications/Repository/Notify.php:440
+#: src/Navigation/Notifications/Repository/Notify.php:436
+#: src/Navigation/Notifications/Repository/Notify.php:452
 #, php-format
 msgid "%s Connection accepted"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:426
-#: src/Navigation/Notifications/Repository/Notify.php:442
+#: src/Navigation/Notifications/Repository/Notify.php:438
+#: src/Navigation/Notifications/Repository/Notify.php:454
 #, php-format
 msgid "'%1$s' has accepted your connection request at %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:428
-#: src/Navigation/Notifications/Repository/Notify.php:444
+#: src/Navigation/Notifications/Repository/Notify.php:440
+#: src/Navigation/Notifications/Repository/Notify.php:456
 #, php-format
 msgid "%2$s has accepted your [url=%1$s]connection request[/url]."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:433
+#: src/Navigation/Notifications/Repository/Notify.php:445
 msgid "You are now mutual friends and may exchange status updates, photos, and email without restriction."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:435
+#: src/Navigation/Notifications/Repository/Notify.php:447
 #, php-format
 msgid "Please visit %s if you wish to make any changes to this relationship."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:449
+#: src/Navigation/Notifications/Repository/Notify.php:461
 #, php-format
 msgid "'%1$s' has chosen to accept you a fan, which restricts some forms of communication - such as private messaging and some profile interactions. If this is a celebrity or community page, these settings were applied automatically."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:451
+#: src/Navigation/Notifications/Repository/Notify.php:463
 #, php-format
 msgid "'%1$s' may choose to extend this into a two-way or more permissive relationship in the future."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:453
+#: src/Navigation/Notifications/Repository/Notify.php:465
 #, php-format
 msgid "Please visit %s  if you wish to make any changes to this relationship."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:463
+#: src/Navigation/Notifications/Repository/Notify.php:475
 msgid "registration request"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:465
+#: src/Navigation/Notifications/Repository/Notify.php:477
 #, php-format
 msgid "You've received a registration request from '%1$s' at %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:467
+#: src/Navigation/Notifications/Repository/Notify.php:479
 #, php-format
 msgid "You've received a [url=%1$s]registration request[/url] from %2$s."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:473
-#: src/Navigation/Notifications/Repository/Notify.php:497
+#: src/Navigation/Notifications/Repository/Notify.php:485
+#: src/Navigation/Notifications/Repository/Notify.php:509
 #, php-format
 msgid ""
 "Display Name:\t%s\n"
@@ -11415,46 +11412,46 @@ msgid ""
 "Login Name:\t%s (%s)"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:480
+#: src/Navigation/Notifications/Repository/Notify.php:492
 #, php-format
 msgid "Please visit %s to approve or reject the request."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:487
+#: src/Navigation/Notifications/Repository/Notify.php:499
 msgid "new registration"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:489
+#: src/Navigation/Notifications/Repository/Notify.php:501
 #, php-format
 msgid "You've received a new registration from '%1$s' at %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:491
+#: src/Navigation/Notifications/Repository/Notify.php:503
 #, php-format
 msgid "You've received a [url=%1$s]new registration[/url] from %2$s."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:504
+#: src/Navigation/Notifications/Repository/Notify.php:516
 #, php-format
 msgid "Please visit %s to have a look at the new registration."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:782
+#: src/Navigation/Notifications/Repository/Notify.php:798
 #, php-format
 msgid "%s %s tagged you"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:785
+#: src/Navigation/Notifications/Repository/Notify.php:801
 #, php-format
 msgid "%s %s shared a new post"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:793
+#: src/Navigation/Notifications/Repository/Notify.php:809
 #, php-format
 msgid "%1$s %2$s liked your post #%3$d"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:796
+#: src/Navigation/Notifications/Repository/Notify.php:812
 #, php-format
 msgid "%1$s %2$s liked your comment on #%3$d"
 msgstr ""
@@ -11478,282 +11475,282 @@ msgstr ""
 msgid "%s posted an update."
 msgstr ""
 
-#: src/Object/Post.php:124
+#: src/Object/Post.php:123
 msgid "Private Message"
 msgstr ""
 
-#: src/Object/Post.php:128
+#: src/Object/Post.php:127
 msgid "Public Message"
 msgstr ""
 
-#: src/Object/Post.php:132
+#: src/Object/Post.php:131
 msgid "Unlisted Message"
 msgstr ""
 
-#: src/Object/Post.php:168
+#: src/Object/Post.php:167
 msgid "This entry was edited"
 msgstr ""
 
-#: src/Object/Post.php:196
+#: src/Object/Post.php:195
 msgid "Connector Message"
 msgstr ""
 
-#: src/Object/Post.php:225 src/Object/Post.php:227
+#: src/Object/Post.php:224 src/Object/Post.php:226
 msgid "Edit"
 msgstr ""
 
-#: src/Object/Post.php:261
+#: src/Object/Post.php:260
 msgid "Delete globally"
 msgstr ""
 
-#: src/Object/Post.php:261
+#: src/Object/Post.php:260
 msgid "Remove locally"
 msgstr ""
 
-#: src/Object/Post.php:268
+#: src/Object/Post.php:267
 #, php-format
 msgid "Block %s"
 msgstr ""
 
-#: src/Object/Post.php:273
+#: src/Object/Post.php:272
 #, php-format
 msgid "Ignore %s"
 msgstr ""
 
-#: src/Object/Post.php:278
+#: src/Object/Post.php:277
 #, php-format
 msgid "Collapse %s"
 msgstr ""
 
-#: src/Object/Post.php:282
+#: src/Object/Post.php:281
 msgid "Report post"
 msgstr ""
 
-#: src/Object/Post.php:293
+#: src/Object/Post.php:292
 msgid "Save to folder"
 msgstr ""
 
-#: src/Object/Post.php:339
+#: src/Object/Post.php:338
 msgid "I will attend"
 msgstr ""
 
-#: src/Object/Post.php:339
+#: src/Object/Post.php:338
 msgid "I will not attend"
 msgstr ""
 
-#: src/Object/Post.php:339
+#: src/Object/Post.php:338
 msgid "I might attend"
 msgstr ""
 
-#: src/Object/Post.php:386
+#: src/Object/Post.php:385
 msgid "Ignore thread"
 msgstr ""
 
-#: src/Object/Post.php:387
+#: src/Object/Post.php:386
 msgid "Unignore thread"
 msgstr ""
 
-#: src/Object/Post.php:388
+#: src/Object/Post.php:387
 msgid "Toggle ignore status"
 msgstr ""
 
-#: src/Object/Post.php:398
+#: src/Object/Post.php:397
 msgid "Add star"
 msgstr ""
 
-#: src/Object/Post.php:399
+#: src/Object/Post.php:398
 msgid "Remove star"
 msgstr ""
 
-#: src/Object/Post.php:400
+#: src/Object/Post.php:399
 msgid "Toggle star status"
 msgstr ""
 
-#: src/Object/Post.php:411
+#: src/Object/Post.php:410
 msgid "Pin"
 msgstr ""
 
-#: src/Object/Post.php:412
+#: src/Object/Post.php:411
 msgid "Unpin"
 msgstr ""
 
-#: src/Object/Post.php:413
+#: src/Object/Post.php:412
 msgid "Toggle pin status"
 msgstr ""
 
-#: src/Object/Post.php:416
+#: src/Object/Post.php:415
 msgid "Pinned"
 msgstr ""
 
-#: src/Object/Post.php:421
+#: src/Object/Post.php:420
 msgid "Add tag"
 msgstr ""
 
-#: src/Object/Post.php:436
+#: src/Object/Post.php:435
 msgid "Quote share this"
 msgstr ""
 
-#: src/Object/Post.php:436
+#: src/Object/Post.php:435
 msgid "Quote Share"
 msgstr ""
 
-#: src/Object/Post.php:439
+#: src/Object/Post.php:438
 msgid "Reshare this"
 msgstr ""
 
-#: src/Object/Post.php:439
+#: src/Object/Post.php:438
 msgid "Reshare"
 msgstr ""
 
-#: src/Object/Post.php:440
+#: src/Object/Post.php:439
 msgid "Cancel your Reshare"
 msgstr ""
 
-#: src/Object/Post.php:440
+#: src/Object/Post.php:439
 msgid "Unshare"
 msgstr ""
 
-#: src/Object/Post.php:484
+#: src/Object/Post.php:483
 #, php-format
 msgid "%s (Received %s)"
 msgstr ""
 
-#: src/Object/Post.php:490
+#: src/Object/Post.php:489
 msgid "Comment this item on your system"
 msgstr ""
 
-#: src/Object/Post.php:490
+#: src/Object/Post.php:489
 msgid "Remote comment"
 msgstr ""
 
-#: src/Object/Post.php:514
+#: src/Object/Post.php:513
 msgid "Share via ..."
 msgstr ""
 
-#: src/Object/Post.php:514
+#: src/Object/Post.php:513
 msgid "Share via external services"
 msgstr ""
 
-#: src/Object/Post.php:521
+#: src/Object/Post.php:520
 msgid "Unknown parent"
 msgstr ""
 
-#: src/Object/Post.php:525
+#: src/Object/Post.php:524
 #, php-format
 msgid "in reply to %s"
 msgstr ""
 
-#: src/Object/Post.php:527
+#: src/Object/Post.php:526
 msgid "Parent is probably private or not federated."
 msgstr ""
 
-#: src/Object/Post.php:551
+#: src/Object/Post.php:550
 msgid "to"
 msgstr ""
 
-#: src/Object/Post.php:552
+#: src/Object/Post.php:551
 msgid "via"
 msgstr ""
 
-#: src/Object/Post.php:553
+#: src/Object/Post.php:552
 msgid "Wall-to-Wall"
 msgstr ""
 
-#: src/Object/Post.php:554
+#: src/Object/Post.php:553
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: src/Object/Post.php:609
+#: src/Object/Post.php:608
 #, php-format
 msgid "Reply to %s"
 msgstr ""
 
-#: src/Object/Post.php:631
+#: src/Object/Post.php:630
 msgid "Notifier task is pending"
 msgstr ""
 
-#: src/Object/Post.php:632
+#: src/Object/Post.php:631
 msgid "Delivery to remote servers is pending"
 msgstr ""
 
-#: src/Object/Post.php:633
+#: src/Object/Post.php:632
 msgid "Delivery to remote servers is underway"
 msgstr ""
 
-#: src/Object/Post.php:634
+#: src/Object/Post.php:633
 msgid "Delivery to remote servers is mostly done"
 msgstr ""
 
-#: src/Object/Post.php:635
+#: src/Object/Post.php:634
 msgid "Delivery to remote servers is done"
 msgstr ""
 
-#: src/Object/Post.php:660
+#: src/Object/Post.php:659
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Object/Post.php:661
+#: src/Object/Post.php:660
 msgid "Show more"
 msgstr ""
 
-#: src/Object/Post.php:662
+#: src/Object/Post.php:661
 msgid "Show fewer"
 msgstr ""
 
-#: src/Object/Post.php:699
+#: src/Object/Post.php:698
 #, php-format
 msgid "Reshared by: %s"
 msgstr ""
 
-#: src/Object/Post.php:704
+#: src/Object/Post.php:703
 #, php-format
 msgid "Viewed by: %s"
 msgstr ""
 
-#: src/Object/Post.php:709
+#: src/Object/Post.php:708
 #, php-format
 msgid "Read by: %s"
 msgstr ""
 
-#: src/Object/Post.php:714
+#: src/Object/Post.php:713
 #, php-format
 msgid "Liked by: %s"
 msgstr ""
 
-#: src/Object/Post.php:719
+#: src/Object/Post.php:718
 #, php-format
 msgid "Disliked by: %s"
 msgstr ""
 
-#: src/Object/Post.php:724
+#: src/Object/Post.php:723
 #, php-format
 msgid "Attended by: %s"
 msgstr ""
 
-#: src/Object/Post.php:729
+#: src/Object/Post.php:728
 #, php-format
 msgid "Maybe attended by: %s"
 msgstr ""
 
-#: src/Object/Post.php:734
+#: src/Object/Post.php:733
 #, php-format
 msgid "Not attended by: %s"
 msgstr ""
 
-#: src/Object/Post.php:739
+#: src/Object/Post.php:738
 #, php-format
 msgid "Commented by: %s"
 msgstr ""
 
-#: src/Object/Post.php:744
+#: src/Object/Post.php:743
 #, php-format
 msgid "Reacted with %s by: %s"
 msgstr ""
 
-#: src/Object/Post.php:767
+#: src/Object/Post.php:766
 #, php-format
 msgid "Quote shared by: %s"
 msgstr ""
@@ -12123,7 +12120,7 @@ msgstr ""
 msgid "Community Pages"
 msgstr ""
 
-#: view/theme/vier/config.php:127 view/theme/vier/theme.php:136
+#: view/theme/vier/config.php:127 view/theme/vier/theme.php:135
 msgid "Community Profiles"
 msgstr ""
 
@@ -12131,7 +12128,7 @@ msgstr ""
 msgid "Help or @NewHere ?"
 msgstr ""
 
-#: view/theme/vier/config.php:129 view/theme/vier/theme.php:307
+#: view/theme/vier/config.php:129 view/theme/vier/theme.php:308
 msgid "Connect Services"
 msgstr ""
 
@@ -12139,10 +12136,10 @@ msgstr ""
 msgid "Find Friends"
 msgstr ""
 
-#: view/theme/vier/config.php:131 view/theme/vier/theme.php:163
+#: view/theme/vier/config.php:131 view/theme/vier/theme.php:162
 msgid "Last users"
 msgstr ""
 
-#: view/theme/vier/theme.php:222
+#: view/theme/vier/theme.php:221
 msgid "Quick Start"
 msgstr ""

--- a/view/theme/frio/templates/calendar/event_form.tpl
+++ b/view/theme/frio/templates/calendar/event_form.tpl
@@ -132,34 +132,8 @@
 					</li>
 					*}}
 					<li>
-						<button type="button" class="btn-link icon bb-url" style="cursor: pointer;" title="{{$edurl}}" data-role="insert-formatting" data-comment=" " data-bbcode="url" data-id="loc">
-							<i class="fa fa-link"></i>
-						</button>
-					</li>
-					<li>
-						<button type="button" class="btn-link icon bb-video" style="cursor: pointer;" title="{{$edvideo}}" data-role="insert-formatting" data-comment=" " data-bbcode="video" data-id="loc">
-							<i class="fa fa-video-camera"></i>
-						</button>
-					</li>
-
-					<li>
-						<button type="button" class="btn-link icon underline" style="cursor: pointer;" title="{{$eduline}}" data-role="insert-formatting" data-comment=" " data-bbcode="u" data-id="loc">
-							<i class="fa fa-underline"></i>
-						</button>
-					</li>
-					<li>
-						<button type="button" class="btn-link icon italic" style="cursor: pointer;" title="{{$editalic}}" data-role="insert-formatting" data-comment=" " data-bbcode="i" data-id="loc">
-							<i class="fa fa-italic"></i>
-						</button>
-					</li>
-					<li>
-						<button type="button" class="btn-link icon bold" style="cursor: pointer;"  title="{{$edbold}}" data-role="insert-formatting" data-comment=" " data-bbcode="b" data-id="loc">
-							<i class="fa fa-bold"></i>
-						</button>
-					</li>
-					<li>
-						<button type="button" class="btn-link icon quote" style="cursor: pointer;" title="{{$edquote}}" data-role="insert-formatting" data-comment=" " data-bbcode="quote" data-id="loc">
-							<i class="fa fa-quote-left"></i>
+						<button type="button" class="btn-link icon map" style="cursor: pointer;" title="{{$edmap}}" data-role="insert-formatting" data-comment=" " data-bbcode="map" data-id="loc">
+							<i class="fa fa-map-marker"></i>
 						</button>
 					</li>
 				</ul>


### PR DESCRIPTION
This is for the 5th point of the bug list in this issue: 

Events / Calendar improvements + bugs #14824

> In the create/edit dialog there is no BBCode allowed for the location field. But why are there then the buttons to insert BBCodes right after the location input?

The BBCode Buttons for the Location Field have been removed, and a single BBCode `map` button has been added, because it seems to be possible to add something like `[map]Berlin[/map]`, or also like `[map][52.5148,13.3625[/map]`.

![Bildschirmfoto_2025-05-15_00-18-45--map](https://github.com/user-attachments/assets/7bbaa8a7-b875-4a0d-8a11-ca8743b38dac)
![Bildschirmfoto_2025-05-15_00-19-55--map](https://github.com/user-attachments/assets/245548ab-b3e2-4092-ae65-487c8a7ca335)

It seems, the map will only be visible, when the Openstreetmap Addon is activated.. But I think the `Map` code is the [friendica ](https://github.com/friendica/friendica) repository: https://github.com/friendica/friendica/blob/0165e2206457585b948b92d568104314d8ebbb89/src/Util/Map.php  .