### PR TITLE
Support YouTube links without www

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1210,13 +1210,13 @@ class BBCode
 	 */
 	private static function normalizeVideoLinks(string $text): string
 	{
-		$text = preg_replace("/\[youtube\]https?:\/\/(www.)?youtube.com\/watch\?v\=(.*?)\[\/youtube\]/ism", '[youtube]$2[/youtube]', $text);
-		$text = preg_replace("/\[youtube\]https?:\/\/(www.)?youtube.com\/embed\/(.*?)\[\/youtube\]/ism", '[youtube]$2[/youtube]', $text);
-		$text = preg_replace("/\[youtube\]https?:\/\/(www.)?youtube.com\/shorts\/(.*?)\[\/youtube\]/ism", '[youtube]$2[/youtube]', $text);
-		$text = preg_replace("/\[youtube\]https?:\/\/youtu.be\/(.*?)\[\/youtube\]/ism", '[youtube]$1[/youtube]', $text);
+		$text = preg_replace("/\[youtube\]https?:\/\/(www\.)?youtube\.com\/watch\?v\=(.*?)\[\/youtube\]/ism", '[youtube]$2[/youtube]', $text);
+		$text = preg_replace("/\[youtube\]https?:\/\/(www\.)?youtube\.com\/embed\/(.*?)\[\/youtube\]/ism", '[youtube]$2[/youtube]', $text);
+		$text = preg_replace("/\[youtube\]https?:\/\/(www\.)?youtube\.com\/shorts\/(.*?)\[\/youtube\]/ism", '[youtube]$2[/youtube]', $text);
+		$text = preg_replace("/\[youtube\]https?:\/\/youtu\.be\/(.*?)\[\/youtube\]/ism", '[youtube]$1[/youtube]', $text);
 
-		$text = preg_replace("/\[vimeo\]https?:\/\/player.vimeo.com\/video\/([0-9]+)(.*?)\[\/vimeo\]/ism", '[vimeo]$1[/vimeo]', $text);
-		$text = preg_replace("/\[vimeo\]https?:\/\/vimeo.com\/([0-9]+)(.*?)\[\/vimeo\]/ism", '[vimeo]$1[/vimeo]', $text);
+		$text = preg_replace("/\[vimeo\]https?:\/\/player\.vimeo\.com\/video\/([0-9]+)(.*?)\[\/vimeo\]/ism", '[vimeo]$1[/vimeo]', $text);
+		$text = preg_replace("/\[vimeo\]https?:\/\/vimeo\.com\/([0-9]+)(.*?)\[\/vimeo\]/ism", '[vimeo]$1[/vimeo]', $text);
 
 		return $text;
 	}

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1210,9 +1210,9 @@ class BBCode
 	 */
 	private static function normalizeVideoLinks(string $text): string
 	{
-		$text = preg_replace("/\[youtube\]https?:\/\/www.youtube.com\/watch\?v\=(.*?)\[\/youtube\]/ism", '[youtube]$1[/youtube]', $text);
-		$text = preg_replace("/\[youtube\]https?:\/\/www.youtube.com\/embed\/(.*?)\[\/youtube\]/ism", '[youtube]$1[/youtube]', $text);
-		$text = preg_replace("/\[youtube\]https?:\/\/www.youtube.com\/shorts\/(.*?)\[\/youtube\]/ism", '[youtube]$1[/youtube]', $text);
+		$text = preg_replace("/\[youtube\]https?:\/\/(www.)?youtube.com\/watch\?v\=(.*?)\[\/youtube\]/ism", '[youtube]$2[/youtube]', $text);
+		$text = preg_replace("/\[youtube\]https?:\/\/(www.)?youtube.com\/embed\/(.*?)\[\/youtube\]/ism", '[youtube]$2[/youtube]', $text);
+		$text = preg_replace("/\[youtube\]https?:\/\/(www.)?youtube.com\/shorts\/(.*?)\[\/youtube\]/ism", '[youtube]$2[/youtube]', $text);
 		$text = preg_replace("/\[youtube\]https?:\/\/youtu.be\/(.*?)\[\/youtube\]/ism", '[youtube]$1[/youtube]', $text);
 
 		$text = preg_replace("/\[vimeo\]https?:\/\/player.vimeo.com\/video\/([0-9]+)(.*?)\[\/vimeo\]/ism", '[vimeo]$1[/vimeo]', $text);

--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -121,12 +121,13 @@ class Markdown
 		$s = str_replace('&#x2672;', html_entity_decode('&#x2672;', ENT_QUOTES, 'UTF-8'), $s);
 
 		//$s = preg_replace("/([^\]\=]|^)(https?\:\/\/)(vimeo|youtu|www\.youtube|soundcloud)([a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\%\$\!\+\,]+)/ism", '$1[url=$2$3$4]$2$3$4[/url]',$s);
-		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/www.youtube.com\/watch\?v\=(.*?)\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www.)?youtube.com\/watch\?v\=(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www.)?youtube.com\/embed\/(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www.)?youtube.com\/shorts\/(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/vimeo.com\/([0-9]+)(.*?)\[\/url\]/ism', '[vimeo]$2[/vimeo]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/vimeo.com\/([0-9]+)\](.*?)\[\/url\]/ism', '[vimeo]$1[/vimeo]', 'url', $s);
+		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/www\.youtube\.com\/watch\?v\=(.*?)\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
+		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www\.)?youtube\.com\/watch\?v\=(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
+		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www\.)?youtube\.com\/embed\/(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
+		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www\.)?youtube\.com\/shorts\/(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
+		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/vimeo\.com\/([0-9]+)(.*?)\[\/url\]/ism', '[vimeo]$2[/vimeo]', 'url', $s);
+		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/player\.vimeo\.com\/video\/([0-9]+)(.*?)\[\/url\]/ism', '[vimeo]$2[/vimeo]', 'url', $s);
+		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/vimeo\.com\/([0-9]+)\](.*?)\[\/url\]/ism', '[vimeo]$1[/vimeo]', 'url', $s);
 
 		// remove duplicate adjacent code tags
 		$s = preg_replace('/(\[code\])+(.*?)(\[\/code\])+/ism', '[code]$2[/code]', $s);

--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -122,8 +122,9 @@ class Markdown
 
 		//$s = preg_replace("/([^\]\=]|^)(https?\:\/\/)(vimeo|youtu|www\.youtube|soundcloud)([a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\%\$\!\+\,]+)/ism", '$1[url=$2$3$4]$2$3$4[/url]',$s);
 		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/www.youtube.com\/watch\?v\=(.*?)\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/www.youtube.com\/watch\?v\=(.*?)\].*?\[\/url\]/ism', '[youtube]$1[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/www.youtube.com\/shorts\/(.*?)\].*?\[\/url\]/ism', '[youtube]$1[/youtube]', 'url', $s);
+		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www.)?youtube.com\/watch\?v\=(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
+		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www.)?youtube.com\/shorts\/(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
+		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www.)?youtube.com\/embed\/(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
 		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/vimeo.com\/([0-9]+)(.*?)\[\/url\]/ism', '[vimeo]$2[/vimeo]', 'url', $s);
 		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/vimeo.com\/([0-9]+)\](.*?)\[\/url\]/ism', '[vimeo]$1[/vimeo]', 'url', $s);
 

--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -123,8 +123,8 @@ class Markdown
 		//$s = preg_replace("/([^\]\=]|^)(https?\:\/\/)(vimeo|youtu|www\.youtube|soundcloud)([a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\%\$\!\+\,]+)/ism", '$1[url=$2$3$4]$2$3$4[/url]',$s);
 		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/www.youtube.com\/watch\?v\=(.*?)\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
 		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www.)?youtube.com\/watch\?v\=(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www.)?youtube.com\/shorts\/(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
 		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www.)?youtube.com\/embed\/(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
+		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www.)?youtube.com\/shorts\/(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
 		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/vimeo.com\/([0-9]+)(.*?)\[\/url\]/ism', '[vimeo]$2[/vimeo]', 'url', $s);
 		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/vimeo.com\/([0-9]+)\](.*?)\[\/url\]/ism', '[vimeo]$1[/vimeo]', 'url', $s);
 

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -73,51 +73,51 @@ class BBCodeTest extends FixtureTestCase
 			],
 			'no-protocol' => [
 				'data'       => 'example.com/path',
-				'assertHTML' => false
+				'assertHTML' => false,
 			],
 			'wrong-protocol' => [
 				'data'       => 'ftp://example.com',
-				'assertHTML' => false
+				'assertHTML' => false,
 			],
 			'wrong-domain-without-path' => [
 				'data'       => 'http://example',
-				'assertHTML' => false
+				'assertHTML' => false,
 			],
 			'wrong-domain-with-path' => [
 				'data'       => 'http://example/path',
-				'assertHTML' => false
+				'assertHTML' => false,
 			],
 			'bug-6857-domain-start' => [
 				'data'       => "http://\nexample.com",
-				'assertHTML' => false
+				'assertHTML' => false,
 			],
 			'bug-6857-domain-end' => [
 				'data'       => "http://example\n.com",
-				'assertHTML' => false
+				'assertHTML' => false,
 			],
 			'bug-6857-tld' => [
 				'data'       => "http://example.\ncom",
-				'assertHTML' => false
+				'assertHTML' => false,
 			],
 			'bug-6857-end' => [
 				'data'       => "http://example.com\ntest",
-				'assertHTML' => false
+				'assertHTML' => false,
 			],
 			'bug-6901' => [
 				'data'       => "http://example.com<ul>",
-				'assertHTML' => false
+				'assertHTML' => false,
 			],
 			'bug-7150' => [
 				'data'       => html_entity_decode('http://example.com&nbsp;', ENT_QUOTES, 'UTF-8'),
-				'assertHTML' => false
+				'assertHTML' => false,
 			],
 			'bug-7271-query-string-brackets' => [
 				'data'       => 'https://example.com/search?q=square+brackets+[url]',
-				'assertHTML' => true
+				'assertHTML' => true,
 			],
 			'bug-7271-path-brackets' => [
 				'data'       => 'http://example.com/path/to/file[3].html',
-				'assertHTML' => true
+				'assertHTML' => true,
 			],
 		];
 	}
@@ -215,19 +215,19 @@ class BBCodeTest extends FixtureTestCase
 			],
 			'bug-9611-purify-xss-nobb' => [
 				'expectedHTML' => '<span>dare to move your mouse here</span>',
-				'text'         => '[nobb]<span onmouseover="alert(0)">dare to move your mouse here</span>[/nobb]'
+				'text'         => '[nobb]<span onmouseover="alert(0)">dare to move your mouse here</span>[/nobb]',
 			],
 			'bug-9611-purify-xss-noparse' => [
 				'expectedHTML' => '<span>dare to move your mouse here</span>',
-				'text'         => '[noparse]<span onmouseover="alert(0)">dare to move your mouse here</span>[/noparse]'
+				'text'         => '[noparse]<span onmouseover="alert(0)">dare to move your mouse here</span>[/noparse]',
 			],
 			'bug-9611-purify-xss-attributes' => [
 				'expectedHTML' => '<span>dare to move your mouse here</span>',
-				'text'         => '[color="onmouseover=alert(0) style="]dare to move your mouse here[/color]'
+				'text'         => '[color="onmouseover=alert(0) style="]dare to move your mouse here[/color]',
 			],
 			'bug-9611-purify-attributes-correct' => [
 				'expectedHTML' => '<span style="color:#FFFFFF;">dare to move your mouse here</span>',
-				'text'         => '[color=FFFFFF]dare to move your mouse here[/color]'
+				'text'         => '[color=FFFFFF]dare to move your mouse here[/color]',
 			],
 			'bug-9639-span-classes' => [
 				'expectedHTML' => '<span class="arbitrary classes">Test</span>',
@@ -308,11 +308,11 @@ Karl Marx - Die ursprüngliche Akkumulation
 			],
 			'bug-12701-quotes' => [
 				'expected' => '[![abc"fgh](https://domain.tld/photo/86912721086415cdc8e0a03226831581-1.png)](https://domain.tld/photos/user/image/86912721086415cdc8e0a03226831581)',
-				'text'     => '[url=https://domain.tld/photos/user/image/86912721086415cdc8e0a03226831581][img=https://domain.tld/photo/86912721086415cdc8e0a03226831581-1.png]abc"fgh[/img][/url]'
+				'text'     => '[url=https://domain.tld/photos/user/image/86912721086415cdc8e0a03226831581][img=https://domain.tld/photo/86912721086415cdc8e0a03226831581-1.png]abc"fgh[/img][/url]',
 			],
 			'bug-12701-no-quotes' => [
 				'expected' => '[![abcfgh](https://domain.tld/photo/86912721086415cdc8e0a03226831581-1.png "abcfgh")](https://domain.tld/photos/user/image/86912721086415cdc8e0a03226831581)',
-				'text'     => '[url=https://domain.tld/photos/user/image/86912721086415cdc8e0a03226831581][img=https://domain.tld/photo/86912721086415cdc8e0a03226831581-1.png]abcfgh[/img][/url]'
+				'text'     => '[url=https://domain.tld/photos/user/image/86912721086415cdc8e0a03226831581][img=https://domain.tld/photo/86912721086415cdc8e0a03226831581-1.png]abcfgh[/img][/url]',
 			],
 		];
 	}
@@ -345,7 +345,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 			'bug-10692-start-line' => [
 				'#[url=https://friendica.local/search?tag=L160]L160[/url]',
 				'#L160',
-			]
+			],
 		];
 	}
 
@@ -358,6 +358,58 @@ Karl Marx - Die ursprüngliche Akkumulation
 	public function testExpandTags(string $expected, string $text)
 	{
 		$actual = BBCode::expandTags($text);
+
+		self::assertEquals($expected, $actual);
+	}
+
+	public function dataExpandVideoLinks(): array
+	{
+		return [
+			/** @see https://github.com/friendica/friendica/pull/14940 */
+			'task-14940-youtube-watch-with-www' => [
+				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
+				'text'         => '[youtube]https://www.youtube.com/watch?v=hfwbmTzBFT0[/youtube]',
+			],
+			'task-14940-youtube-watch-without-www' => [
+				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
+				'text'         => '[youtube]https://youtube.com/watch?v=hfwbmTzBFT0[/youtube]',
+			],
+			'task-14940-youtube-shorts-with-www' => [
+				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
+				'text'         => '[youtube]https://www.youtube.com/shorts/hfwbmTzBFT0[/youtube]',
+			],
+			'task-14940-youtube-shorts-without-www' => [
+				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
+				'text'         => '[youtube]https://youtube.com/shorts/hfwbmTzBFT0[/youtube]',
+			],
+			'task-14940-youtube-embed-with-www' => [
+				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
+				'text'         => '[youtube]https://www.youtube.com/embed/hfwbmTzBFT0[/youtube]',
+			],
+			'task-14940-youtube-embed-without-www' => [
+				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
+				'text'         => '[youtube]https://youtube.com/embed/hfwbmTzBFT0[/youtube]',
+			],
+			'task-14940-vimeo' => [
+				'expectedBBCode' => '[url=https://vimeo.com/2345345]https://vimeo.com/2345345[/url]',
+				'text'         => '[vimeo]https://vimeo.com/2345345[/vimeo]',
+			],
+			'task-14940-player-vimeo' => [
+				'expectedBBCode' => '[url=https://vimeo.com/2345345]https://vimeo.com/2345345[/url]',
+				'text'         => '[vimeo]https://player.vimeo.com/video/2345345[/vimeo]',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataExpandVideoLinks
+	 *
+	 * @param string $expected Expected BBCode output
+	 * @param string $text     Input text
+	 */
+	public function testExpandVideoLinks(string $expected, string $text)
+	{
+		$actual = BBCode::expandVideoLinks($text);
 
 		self::assertEquals($expected, $actual);
 	}

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -368,35 +368,35 @@ Karl Marx - Die ursprüngliche Akkumulation
 			/** @see https://github.com/friendica/friendica/pull/14940 */
 			'task-14940-youtube-watch-with-www' => [
 				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
-				'text'         => '[youtube]https://www.youtube.com/watch?v=hfwbmTzBFT0[/youtube]',
+				'text'           => '[youtube]https://www.youtube.com/watch?v=hfwbmTzBFT0[/youtube]',
 			],
 			'task-14940-youtube-watch-without-www' => [
 				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
-				'text'         => '[youtube]https://youtube.com/watch?v=hfwbmTzBFT0[/youtube]',
+				'text'           => '[youtube]https://youtube.com/watch?v=hfwbmTzBFT0[/youtube]',
 			],
 			'task-14940-youtube-shorts-with-www' => [
 				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
-				'text'         => '[youtube]https://www.youtube.com/shorts/hfwbmTzBFT0[/youtube]',
+				'text'           => '[youtube]https://www.youtube.com/shorts/hfwbmTzBFT0[/youtube]',
 			],
 			'task-14940-youtube-shorts-without-www' => [
 				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
-				'text'         => '[youtube]https://youtube.com/shorts/hfwbmTzBFT0[/youtube]',
+				'text'           => '[youtube]https://youtube.com/shorts/hfwbmTzBFT0[/youtube]',
 			],
 			'task-14940-youtube-embed-with-www' => [
 				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
-				'text'         => '[youtube]https://www.youtube.com/embed/hfwbmTzBFT0[/youtube]',
+				'text'           => '[youtube]https://www.youtube.com/embed/hfwbmTzBFT0[/youtube]',
 			],
 			'task-14940-youtube-embed-without-www' => [
 				'expectedBBCode' => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
-				'text'         => '[youtube]https://youtube.com/embed/hfwbmTzBFT0[/youtube]',
+				'text'           => '[youtube]https://youtube.com/embed/hfwbmTzBFT0[/youtube]',
 			],
 			'task-14940-vimeo' => [
 				'expectedBBCode' => '[url=https://vimeo.com/2345345]https://vimeo.com/2345345[/url]',
-				'text'         => '[vimeo]https://vimeo.com/2345345[/vimeo]',
+				'text'           => '[vimeo]https://vimeo.com/2345345[/vimeo]',
 			],
 			'task-14940-player-vimeo' => [
 				'expectedBBCode' => '[url=https://vimeo.com/2345345]https://vimeo.com/2345345[/url]',
-				'text'         => '[vimeo]https://player.vimeo.com/video/2345345[/vimeo]',
+				'text'           => '[vimeo]https://player.vimeo.com/video/2345345[/vimeo]',
 			],
 		];
 	}

--- a/tests/src/Content/Text/MarkdownTest.php
+++ b/tests/src/Content/Text/MarkdownTest.php
@@ -53,6 +53,44 @@ class MarkdownTest extends FixtureTestCase
 				'expectedBBCode' => 'with the <sup> and </sup> tag',
 				'markdown' => 'with the &lt;sup&gt; and &lt;/sup&gt; tag',
 			],
+			/** @see https://github.com/friendica/friendica/pull/14940 */
+			'task-14940-youtube-watch-with-www' => [
+				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
+				'markdown'         => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
+			],
+			'task-14940-youtube-watch-without-www' => [
+				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
+				'markdown'         => '[url=https://youtube.com/watch?v=hfwbmTzBFT0]https://youtube.com/watch?v=hfwbmTzBFT0[/url]',
+			],
+			'task-14940-youtube-shorts-with-www' => [
+				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
+				'markdown'         => '[url=https://www.youtube.com/shorts/hfwbmTzBFT0]https://www.youtube.com/shorts/hfwbmTzBFT0[/url]',
+			],
+			'task-14940-youtube-shorts-without-www' => [
+				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
+				'markdown'         => '[url=https://youtube.com/shorts/hfwbmTzBFT0]https://youtube.com/shorts/hfwbmTzBFT0[/url]',
+			],
+			'task-14940-youtube-embed-with-www' => [
+				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
+				'markdown'         => '[url=https://www.youtube.com/embed/hfwbmTzBFT0]https://www.youtube.com/embed/hfwbmTzBFT0[/url]',
+			],
+			'task-14940-youtube-embed-without-www' => [
+				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
+				'markdown'         => '[url=https://youtube.com/embed/hfwbmTzBFT0]https://youtube.com/embed/hfwbmTzBFT0[/url]',
+			],
+			// @todo - should we really ignore the URL content in favor of parsing the link of the body?
+			'task-14940-vimeo-custom-url' => [
+				'expectedBBCode' => '[vimeo]2345345[/vimeo]',
+				'markdown'         => '[url=https://no.thing]https://vimeo.com/2345345[/url]',
+			],
+			'task-14940-vimeo-custom-text' => [
+				'expectedBBCode' => '[vimeo]2345345[/vimeo]',
+				'markdown'         => '[url=https://vimeo.com/2345345]CustomText[/url]',
+			],
+			'task-14940-player-vimeo' => [
+				'expectedBBCode' => '[vimeo]2345345[/vimeo]',
+				'markdown'         => '[url=https://player.vimeo.com/video/2345345]https://player.vimeo.com/video/2345345[/url]',
+			],
 		];
 	}
 

--- a/tests/src/Content/Text/MarkdownTest.php
+++ b/tests/src/Content/Text/MarkdownTest.php
@@ -51,45 +51,45 @@ class MarkdownTest extends FixtureTestCase
 		return [
 			'bug-8358-double-decode' => [
 				'expectedBBCode' => 'with the <sup> and </sup> tag',
-				'markdown' => 'with the &lt;sup&gt; and &lt;/sup&gt; tag',
+				'markdown'       => 'with the &lt;sup&gt; and &lt;/sup&gt; tag',
 			],
 			/** @see https://github.com/friendica/friendica/pull/14940 */
 			'task-14940-youtube-watch-with-www' => [
 				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'         => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
+				'markdown'       => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
 			],
 			'task-14940-youtube-watch-without-www' => [
 				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'         => '[url=https://youtube.com/watch?v=hfwbmTzBFT0]https://youtube.com/watch?v=hfwbmTzBFT0[/url]',
+				'markdown'       => '[url=https://youtube.com/watch?v=hfwbmTzBFT0]https://youtube.com/watch?v=hfwbmTzBFT0[/url]',
 			],
 			'task-14940-youtube-shorts-with-www' => [
 				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'         => '[url=https://www.youtube.com/shorts/hfwbmTzBFT0]https://www.youtube.com/shorts/hfwbmTzBFT0[/url]',
+				'markdown'       => '[url=https://www.youtube.com/shorts/hfwbmTzBFT0]https://www.youtube.com/shorts/hfwbmTzBFT0[/url]',
 			],
 			'task-14940-youtube-shorts-without-www' => [
 				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'         => '[url=https://youtube.com/shorts/hfwbmTzBFT0]https://youtube.com/shorts/hfwbmTzBFT0[/url]',
+				'markdown'       => '[url=https://youtube.com/shorts/hfwbmTzBFT0]https://youtube.com/shorts/hfwbmTzBFT0[/url]',
 			],
 			'task-14940-youtube-embed-with-www' => [
 				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'         => '[url=https://www.youtube.com/embed/hfwbmTzBFT0]https://www.youtube.com/embed/hfwbmTzBFT0[/url]',
+				'markdown'       => '[url=https://www.youtube.com/embed/hfwbmTzBFT0]https://www.youtube.com/embed/hfwbmTzBFT0[/url]',
 			],
 			'task-14940-youtube-embed-without-www' => [
 				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'         => '[url=https://youtube.com/embed/hfwbmTzBFT0]https://youtube.com/embed/hfwbmTzBFT0[/url]',
+				'markdown'       => '[url=https://youtube.com/embed/hfwbmTzBFT0]https://youtube.com/embed/hfwbmTzBFT0[/url]',
 			],
 			// @todo - should we really ignore the URL content in favor of parsing the link of the body?
 			'task-14940-vimeo-custom-url' => [
 				'expectedBBCode' => '[vimeo]2345345[/vimeo]',
-				'markdown'         => '[url=https://no.thing]https://vimeo.com/2345345[/url]',
+				'markdown'       => '[url=https://no.thing]https://vimeo.com/2345345[/url]',
 			],
 			'task-14940-vimeo-custom-text' => [
 				'expectedBBCode' => '[vimeo]2345345[/vimeo]',
-				'markdown'         => '[url=https://vimeo.com/2345345]CustomText[/url]',
+				'markdown'       => '[url=https://vimeo.com/2345345]CustomText[/url]',
 			],
 			'task-14940-player-vimeo' => [
 				'expectedBBCode' => '[vimeo]2345345[/vimeo]',
-				'markdown'         => '[url=https://player.vimeo.com/video/2345345]https://player.vimeo.com/video/2345345[/url]',
+				'markdown'       => '[url=https://player.vimeo.com/video/2345345]https://player.vimeo.com/video/2345345[/url]',
 			],
 		];
 	}


### PR DESCRIPTION
This seems to allow also YouTube links without `www.`
Before the change, only this worked:

`https://www.youtube.com/watch?v=zYpDJw7fThU`

Now, this worked, too:

`https://youtube.com/watch?v=zYpDJw7fThU`

Also these:

```
https://www.youtube.com/shorts/hfwbmTzBFT0
https://youtube.com/shorts/hfwbmTzBFT0

https://www.youtube.com/embed/hfwbmTzBFT0
https://youtube.com/embed/hfwbmTzBFT0
```


Only one thing, I didn't touch, because I didn't understand what it does -- this line:
https://github.com/friendica/friendica/blob/8e0a3d00bb3e794973d76463dfc5869d881b3da1/src/Content/Text/Markdown.php#L124

It has a URL inside the `[url]` tag? Maybe it can be fixed/added later..

I have also checked and switched Markdown Support off, to see if the BBCode variants work:

```
[youtube]https://www.youtube.com/watch?v=zYpDJw7fThU[/youtube]
[youtube]https://youtube.com/watch?v=zYpDJw7fThU[/youtube]

[youtube]https://www.youtube.com/shorts/hfwbmTzBFT0[/youtube]
[youtube]https://youtube.com/shorts/hfwbmTzBFT0[/youtube]

[youtube]https://www.youtube.com/embed/hfwbmTzBFT0[/youtube]
[youtube]https://youtube.com/embed/hfwbmTzBFT0[/youtube]
```

On my instance, it looked good..

