### PR TITLE
Added casts to binary for regexp comparison in mysql to solve issue #14914

### DIFF
--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -256,7 +256,7 @@ class Contact extends BaseModule
 			$search_txt = preg_quote(trim($search, ' @!'));
 			$sql_extra .= " AND (CAST(`name` AS BINARY) REGEXP BINARY ? OR CAST(`url` AS BINARY) REGEXP BINARY ?";
 			$sql_extra .= " OR  CAST(`nick` AS BINARY) REGEXP BINARY ? OR  CAST(`addr` AS BINARY) REGEXP BINARY ?";
-                        $sql_extra .= " OR  CAST(`alias` AS BINARY) REGEXP BINARY ?)";
+			$sql_extra .= " OR  CAST(`alias` AS BINARY) REGEXP BINARY ?)";
 			$sql_values[] = $search_txt;
 			$sql_values[] = $search_txt;
 			$sql_values[] = $search_txt;

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -254,7 +254,9 @@ class Contact extends BaseModule
 			$searching  = true;
 			$search_hdr = $search;
 			$search_txt = preg_quote(trim($search, ' @!'));
-			$sql_extra .= " AND (`name` REGEXP ? OR `url` REGEXP ? OR `nick` REGEXP ? OR `addr` REGEXP ? OR `alias` REGEXP ?)";
+			$sql_extra .= " AND (CAST(`name` AS BINARY) REGEXP BINARY ? OR CAST(`url` AS BINARY) REGEXP BINARY ?";
+			$sql_extra .= " OR  CAST(`nick` AS BINARY) REGEXP BINARY ? OR  CAST(`addr` AS BINARY) REGEXP BINARY ?";
+                        $sql_extra .= " OR  CAST(`alias` AS BINARY) REGEXP BINARY ?)";
 			$sql_values[] = $search_txt;
 			$sql_values[] = $search_txt;
 			$sql_values[] = $search_txt;

--- a/src/Security/PermissionSet/Repository/PermissionSet.php
+++ b/src/Security/PermissionSet/Repository/PermissionSet.php
@@ -132,13 +132,13 @@ class PermissionSet extends BaseRepository
 			}
 
 			if (!empty($user_contact_str)) {
-				$condition = ["`uid` = ? AND (NOT (LOCATE(?, `deny_cid`) OR LOCATE(?, `deny_cid`) OR deny_gid REGEXP ?)
-				AND (LOCATE(?, allow_cid) OR LOCATE(?, allow_cid) OR allow_gid REGEXP ? OR (allow_cid = '' AND allow_gid = '')))",
+				$condition = ["`uid` = ? AND (NOT (LOCATE(?, `deny_cid`) OR LOCATE(?, `deny_cid`) OR CAST(deny_gid AS BINARY) REGEXP BINARY ?)
+				AND (LOCATE(?, allow_cid) OR LOCATE(?, allow_cid) OR  CAST(allow_gid AS BINARY) REGEXP BINARY ? OR (allow_cid = '' AND allow_gid = '')))",
 					$uid, $user_contact_str, $public_contact_str, $circle_str,
 					$user_contact_str, $public_contact_str, $circle_str];
 			} else {
-				$condition = ["`uid` = ? AND (NOT (LOCATE(?, `deny_cid`) OR deny_gid REGEXP ?)
-				AND (LOCATE(?, allow_cid) OR allow_gid REGEXP ? OR (allow_cid = '' AND allow_gid = '')))",
+				$condition = ["`uid` = ? AND (NOT (LOCATE(?, `deny_cid`) OR CAST(deny_gid AS BINARY) REGEXP BINARY ?)
+				AND (LOCATE(?, allow_cid) OR CAST(allow_gid AS BINARY) REGEXP BINARY ? OR (allow_cid = '' AND allow_gid = '')))",
 					$uid, $public_contact_str, $circle_str, $public_contact_str, $circle_str];
 			}
 

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -105,8 +105,8 @@ class Security
 			}
 
 			$sql = sprintf(
-				" AND (NOT (deny_cid REGEXP '<%d>' OR deny_gid REGEXP '%s')
-				  AND (allow_cid REGEXP '<%d>' OR allow_gid REGEXP '%s'
+				" AND (NOT (CAST(deny_cid AS BINARY) REGEXP BINARY '<%d>' OR CAST(deny_gid AS BINARY) REGEXP BINARY '%s')
+				  AND (CAST(allow_cid AS BINARY) REGEXP BINARY '<%d>' OR CAST(allow_gid AS BINARY) REGEXP BINARY '%s'
 				  OR (allow_cid = '' AND allow_gid = ''))" . $acc_sql . ") ",
 				intval($remote_contact),
 				DBA::escape($circleIds),


### PR DESCRIPTION
Added casts to binary for regexp comparison in mysql to solve issue #14914. mysql rejects comparison of UTF with binary strings (see https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-22.html#mysqld-8-0-22-feature). The SQL statements also work for mariadb.