### PR TITLE
Frio (Bookface): Fix vertical alignment in the main menu (user menu)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -572,6 +572,11 @@ nav.navbar {
 	}
 }
 
+button#main-menu {
+	align-items: center;
+	display: flex;
+	gap: 5px;
+}
 #topbar-first .navbar-toggle {
 	margin-top: 5px;
 	margin-bottom: 0;
@@ -602,7 +607,6 @@ nav.navbar .nav > li > button:focus {
 	margin-left: 20px;
 }
 #topbar-first .nav > .account img {
-	margin-left: 10px;
 	height: 32px;
 	width: 32px;
 	border-radius: 3px;
@@ -784,7 +788,6 @@ nav.navbar .nav > li > button:focus {
 /* The Top Nav Bar user menu */
 #topbar-first .account .user-title {
 	text-align: right;
-	margin-top: 7px;
 }
 #topbar-first .account .user-title span {
 	color: $nav_icon_color;


### PR DESCRIPTION
The alignment of the name and profile picture are currently aligned in a way where it's hardcoded by pixels to the currently used image size.
This easily breaks with changes in profile image sizes, like bookface.

This small MR makes that hardcoded dynamic, using flexbox.

I'm also considering if the caret next to the image should be removed.
Facebook has such a caret put on top of the profile image, while GitHub doesn't, so it seems to vary whether designers deem it necessary.

Bookface before:
![image](https://github.com/user-attachments/assets/b0d8ec1c-5cdd-4985-9385-4103105054b6)

Bookface after:
![image](https://github.com/user-attachments/assets/a771e0f9-091a-49a8-8ff7-4a1491bca73f)

Frio before:
![image](https://github.com/user-attachments/assets/e5278e9f-3cb4-485e-a923-0d935e237453)

Frio after:
![image](https://github.com/user-attachments/assets/f7617c9c-69ce-4b7b-b3e0-459d4cd242b8)