### PR TITLE
Frio: Fix vertical alignment of overlayed submit buttons

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2460,7 +2460,7 @@ input[type="range"].form-control {
 
 .form-group-search .form-button-search {
 	position: absolute;
-	top: 4px;
+	top: 2px;
 	right: 4px;
 	border-radius: 30px;
 }


### PR DESCRIPTION
Before Firefox:
![image](https://github.com/user-attachments/assets/3b221b6d-36b6-492a-8909-0b5f7f5bb272)
(the submit button is not vertically centered within the input field)

After Firefox:
![image](https://github.com/user-attachments/assets/f296c27d-190c-4f6b-b02e-88baa31841ab)

Also cross checked with Chromium.
Both were on Linux, though.