### PR TITLE
New logger for Jetstream / new Worker-Id per task

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -202,7 +202,7 @@ class App
 	/**
 	 * @internal
 	 */
-	public function processConsole(array $serverParams): void
+	public function processConsole(array $serverParams, bool $testmode = false): void
 	{
 		$argv = $serverParams['argv'] ?? [];
 
@@ -229,6 +229,10 @@ class App
 		);
 
 		$this->registerTemplateEngine();
+
+		if ($testmode) {
+			return;
+		}
 
 		(\Friendica\Core\Console::create($this->container, $argv))->execute();
 	}
@@ -293,15 +297,17 @@ class App
 	{
 		$command = strtolower($argv[1] ?? '');
 
-		if ($command === 'daemon' || $command === 'jetstream') {
+		if ($command === 'daemon') {
 			return LogChannel::DAEMON;
+		}
+
+		if ($command === 'jetstream') {
+			return LogChannel::JETSTREAM;
 		}
 
 		if ($command === 'worker') {
 			return LogChannel::WORKER;
 		}
-
-		// @TODO Add support for jetstream
 
 		return LogChannel::CONSOLE;
 	}
@@ -456,11 +462,13 @@ class App
 
 			if (!$this->mode->isInstall()) {
 				// Force SSL redirection
-				if ($this->config->get('system', 'force_ssl') &&
+				if (
+					$this->config->get('system', 'force_ssl') &&
 					(empty($serverVars['HTTPS']) || $serverVars['HTTPS'] === 'off') &&
 					(empty($serverVars['HTTP_X_FORWARDED_PROTO']) || $serverVars['HTTP_X_FORWARDED_PROTO'] === 'http') &&
 					!empty($serverVars['REQUEST_METHOD']) &&
-					$serverVars['REQUEST_METHOD'] === 'GET') {
+					$serverVars['REQUEST_METHOD'] === 'GET'
+				) {
 					System::externalRedirect($this->baseURL . '/' . $this->args->getQueryString());
 				}
 
@@ -481,7 +489,8 @@ class App
 				// Only continue when the given profile link seems valid.
 				// Valid profile links contain a path with "/profile/" and no query parameters
 				if ((parse_url($queryVars['zrl'], PHP_URL_QUERY) == '') &&
-					strpos(parse_url($queryVars['zrl'], PHP_URL_PATH) ?? '', '/profile/') !== false) {
+					strpos(parse_url($queryVars['zrl'], PHP_URL_PATH) ?? '', '/profile/') !== false
+				) {
 					$this->auth->setUnauthenticatedVisitor($queryVars['zrl']);
 					OpenWebAuth::zrlInit();
 				} else {
@@ -652,8 +661,8 @@ class App
 		@file_put_contents(
 			$logfile,
 			DateTimeFormat::utcNow() . "\t" . round($duration, 3) . "\t" .
-			$this->requestId . "\t" . $code . "\t" .
-			$request . "\t" . $agent . "\n",
+				$this->requestId . "\t" . $code . "\t" .
+				$request . "\t" . $agent . "\n",
 			FILE_APPEND
 		);
 	}

--- a/src/Core/Logger/Capability/LogChannel.php
+++ b/src/Core/Logger/Capability/LogChannel.php
@@ -24,6 +24,8 @@ interface LogChannel
 	public const DAEMON = 'daemon';
 	/** @var string channel for worker execution */
 	public const WORKER = 'worker';
+	/** @var string channel for jetstream execution */
+	public const JETSTREAM = 'jetstream';
 	/** @var string channel for frontend app executions */
 	public const APP = 'app';
 }

--- a/src/Core/Logger/LoggerManager.php
+++ b/src/Core/Logger/LoggerManager.php
@@ -12,6 +12,7 @@ namespace Friendica\Core\Logger;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Logger\Capability\LogChannel;
 use Friendica\Core\Logger\Factory\LoggerFactory;
+use Friendica\Core\Logger\Type\JetstreamLogger;
 use Friendica\Core\Logger\Type\ProfilerLogger;
 use Friendica\Core\Logger\Type\WorkerLogger;
 use Friendica\Util\Profiler;
@@ -66,6 +67,11 @@ final class LoggerManager
 		self::$logger     = null;
 	}
 
+	public function getLogChannel(): string
+	{
+		return self::$logChannel;
+	}
+
 	/**
 	 * (Creates and) Returns the logger instance
 	 */
@@ -76,6 +82,11 @@ final class LoggerManager
 		}
 
 		return self::$logger;
+	}
+
+	public function setLogger(LoggerInterface $logger): void
+	{
+		self::$logger = $logger;
 	}
 
 	private function createLogger(): LoggerInterface
@@ -96,6 +107,10 @@ final class LoggerManager
 		// Decorate Logger as WorkerLogger for BC
 		if (self::$logChannel === LogChannel::WORKER) {
 			$logger = new WorkerLogger($logger);
+		}
+
+		if (self::$logChannel === LogChannel::JETSTREAM) {
+			$logger = new JetstreamLogger($logger);
 		}
 
 		return $logger;

--- a/src/Core/Logger/Type/JetstreamLogger.php
+++ b/src/Core/Logger/Type/JetstreamLogger.php
@@ -12,13 +12,13 @@ use Friendica\Util\Strings;
 use Psr\Log\LoggerInterface;
 
 /**
- * A Logger for specific worker tasks, which adds a worker id to it.
+ * A Logger for specific jetstream tasks, which adds a jetstream id to it.
  * Uses the decorator pattern (https://en.wikipedia.org/wiki/Decorator_pattern)
  */
-class WorkerLogger implements LoggerInterface
+class JetstreamLogger implements LoggerInterface
 {
-	/** @var int Length of the unique worker id */
-	const WORKER_ID_LENGTH = 7;
+	/** @var int Length of the unique jetstream id */
+	const JETSTREAM_ID_LENGTH = 7;
 
 	/**
 	 * @var LoggerInterface The original Logger instance
@@ -26,17 +26,12 @@ class WorkerLogger implements LoggerInterface
 	private $logger;
 
 	/**
-	 * @var string the current worker ID
+	 * @var string the current jetstream ID
 	 */
-	private $workerId;
+	private $jetstreamId;
 
 	/**
-	 * @var string The called function name
-	 */
-	private $functionName;
-
-	/**
-	 * @param LoggerInterface $logger       The logger for worker entries
+	 * @param LoggerInterface $logger       The logger for jetstream tasks
 	 *
 	 * @throws LoggerException
 	 */
@@ -44,58 +39,44 @@ class WorkerLogger implements LoggerInterface
 	{
 		$this->logger = $logger;
 		try {
-			$this->workerId = Strings::getRandomHex(self::WORKER_ID_LENGTH);
+			$this->jetstreamId = Strings::getRandomHex(self::JETSTREAM_ID_LENGTH);
 		} catch (\Exception $exception) {
 			throw new LoggerException('Cannot generate random Hex.', $exception);
 		}
 	}
 
 	/**
-	 * Sets the function name for additional logging
-	 *
-	 * @param string $functionName
-	 *
-	 * @throws LoggerException
-	 */
-	public function setFunctionName(?string $functionName)
-	{
-		$this->functionName = $functionName;
-		try {
-			$this->workerId = Strings::getRandomHex(self::WORKER_ID_LENGTH);
-		} catch (\Exception $exception) {
-			throw new LoggerException('Cannot generate random Hex.', $exception);
-		}
-	}
-
-	public function getFunctionName(): ?string
-	{
-		return $this->functionName;
-	}
-
-	/**
-	 * Adds the worker context for each log entry
+	 * Adds the jetstream context for each log entry
 	 *
 	 * @param array $context
 	 */
 	private function addContext(array &$context)
 	{
-		$context['worker_id']  = $this->workerId;
-		$context['worker_cmd'] = $this->functionName;
+		$context['jetstream_id'] = $this->jetstreamId;
 	}
 
 	/**
-	 * Returns the worker ID
+	 * Returns the jetstream ID
 	 *
 	 * @return string
 	 */
-	public function getWorkerId(): string
+	public function getJetstreamId(): string
 	{
-		return $this->workerId;
+		return $this->jetstreamId;
 	}
 
-	public function setWorkerId(string $workerId): void
+	public function setJetstreamId(string $jetstreamId): void
 	{
-		$this->workerId = $workerId;
+		$this->jetstreamId = $jetstreamId;
+	}
+
+	public function initJetstreamId(): void
+	{
+		try {
+			$this->jetstreamId = Strings::getRandomHex(self::JETSTREAM_ID_LENGTH);
+		} catch (\Exception $exception) {
+			throw new LoggerException('Cannot generate random Hex.', $exception);
+		}
 	}
 
 	/**

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -82,7 +82,7 @@ class Worker
 		// Kill stale processes every 5 minutes
 		$last_cleanup = DI::keyValue()->get('worker_last_cleaned') ?? 0;
 		if (time() > ($last_cleanup + 300)) {
-			DI::keyValue()->set( 'worker_last_cleaned', time());
+			DI::keyValue()->set('worker_last_cleaned', time());
 			Worker\Cron::killStaleWorkers();
 		}
 
@@ -399,7 +399,7 @@ class Worker
 
 		require_once $include;
 
-		$funcname = str_replace('.php', '', basename($argv[0])) .'_run';
+		$funcname = str_replace('.php', '', basename($argv[0])) . '_run';
 
 		if (function_exists($funcname)) {
 			// We constantly update the "executed" date every minute to avoid being killed too soon
@@ -541,7 +541,19 @@ class Worker
 
 		self::coolDown();
 
-		DI::loggerManager()->changeLogChannel(LogChannel::WORKER);
+		$loggerManager = DI::loggerManager();
+
+		$previousLogger  = $loggerManager->getLogger();
+		$previousChannel = $loggerManager->getLogChannel();
+		if ($previousLogger instanceof WorkerLogger) {
+			$previousId       = $previousLogger->getWorkerId();
+			$previousFunction = $previousLogger->getFunctionName();
+		} else {
+			$previousId       = null;
+			$previousFunction = null;
+		}
+
+		$loggerManager->changeLogChannel(LogChannel::WORKER);
 
 		$logger = DI::logger();
 
@@ -624,6 +636,14 @@ class Worker
 
 		DI::logger()->info('Process done.', ['function' => $funcname, 'priority' => $queue['priority'], 'retrial' => $queue['retrial'], 'id' => $queue['id'], 'duration' => round($duration, 3)]);
 
+		$loggerManager->changeLogChannel($previousChannel);
+		$loggerManager->setLogger($previousLogger);
+
+		if ($previousLogger instanceof WorkerLogger) {
+			$previousLogger->setWorkerId($previousId);
+			$previousLogger->setFunctionName($previousFunction);
+		}
+
 		DI::profiler()->saveLog(DI::logger(), 'ID ' . $queue['id'] . ': ' . $funcname);
 	}
 
@@ -684,7 +704,7 @@ class Worker
 			$level = ($used / $max) * 100;
 
 			if ($level >= $maxlevel) {
-				DI::logger()->warning('Maximum level (' . $maxlevel . '%) of user connections reached: ' . $used .'/' . $max);
+				DI::logger()->warning('Maximum level (' . $maxlevel . '%) of user connections reached: ' . $used . '/' . $max);
 				return true;
 			}
 		}
@@ -765,7 +785,7 @@ class Worker
 					self::$db_duration_stat += (microtime(true) - $stamp);
 					$jobs_per_minute[$interval] = number_format($jobs / $interval, 0);
 				}
-				$processlist = ' - jpm: '.implode('/', $jobs_per_minute);
+				$processlist = ' - jpm: ' . implode('/', $jobs_per_minute);
 			}
 
 			// Create a list of queue entries grouped by their priority
@@ -810,7 +830,7 @@ class Worker
 
 			$listitem[0] = '0:' . max(0, $idle_workers);
 
-			$processlist .= ' ('.implode(', ', $listitem).')';
+			$processlist .= ' (' . implode(', ', $listitem) . ')';
 
 			if (DI::config()->get('system', 'worker_fastlane', false) && ($queues > 0) && ($active >= $queues) && self::entriesExists()) {
 				$top_priority = self::highestPriority();
@@ -1305,8 +1325,13 @@ class Worker
 		}
 
 		if (empty($queue)) {
-			if (!DBA::insert('workerqueue', ['command' => $command, 'parameter' => $parameters, 'created' => $created,
-				'priority'                                => $priority, 'next_try' => $delayed])) {
+			if (!DBA::insert('workerqueue', [
+				'command'   => $command,
+				'parameter' => $parameters,
+				'created'   => $created,
+				'priority'  => $priority,
+				'next_try'  => $delayed
+			])) {
 				return 0;
 			}
 			$added = DBA::lastInsertId();

--- a/src/Protocol/ATProtocol/Jetstream.php
+++ b/src/Protocol/ATProtocol/Jetstream.php
@@ -12,6 +12,7 @@ namespace Friendica\Protocol\ATProtocol;
 
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\KeyValueStorage\Capability\IManageKeyValuePairs;
+use Friendica\Core\Logger\Type\JetstreamLogger;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Model\Contact;
@@ -38,7 +39,7 @@ use stdClass;
  */
 class Jetstream
 {
-	/** 
+	/**
 	 * Maximum drift values in seconds for the threads completion.
 	 * If the drift is higher than this value, only a few posts in a thread will be fetched.
 	 */
@@ -47,13 +48,13 @@ class Jetstream
 	 * Maximum drift values in seconds for the DID cap.
 	 * If the drift is higher than this value, the number of DIDs will be capped.
 	 */
-	const MAX_DRIFT_DID_CAP           = 60;
+	const MAX_DRIFT_DID_CAP = 60;
 	/**
 	 * Maximum drift values in seconds for creating posts.
 	 * If the drift is higher than this value, posts and reshares will not be created.
 	 * The other collections will still be processed.
 	 */
-	const MAX_DRIFT_CREATE_POSTS      = 1200;
+	const MAX_DRIFT_CREATE_POSTS = 1200;
 
 	private $uids   = [];
 	private $self   = [];
@@ -293,6 +294,13 @@ class Jetstream
 	 */
 	private function route(stdClass $data): void
 	{
+		if ($this->logger instanceof JetstreamLogger) {
+			$previousId = $this->logger->getJetstreamId();
+			$this->logger->initJetstreamId();
+		} else {
+			$previousId = null;
+		}
+
 		Item::incrementInbound(Protocol::BLUESKY);
 
 		switch ($data->kind) {
@@ -309,6 +317,10 @@ class Jetstream
 			case 'commit':
 				$this->routeCommits($data);
 				break;
+		}
+
+		if ($this->logger instanceof JetstreamLogger) {
+			$this->logger->setJetstreamId($previousId);
 		}
 	}
 


### PR DESCRIPTION
Jetstream now has got its own logger channel. Also each Jetstream process will have its own jetstream id.

For the worker processes now the system restores the previous logger channel and worker id. This means that it is much easier to trace single worker processes.

The change to `processConsole` is needed to support external scripts (that can be used for development purposes).