### PR TITLE
Remove extra calendar reference from personal menu (simplify ui/ux)

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -226,7 +226,6 @@ class Nav
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('Your profile page')];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos')];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/media', $this->l10n->t('Media'), '', $this->l10n->t('Your postings with media')];
-			$nav['usermenu'][] = ['calendar/', $this->l10n->t('Calendar'), '', $this->l10n->t('Your calendar')];
 			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Your personal notes')];
 
 			// user info


### PR DESCRIPTION
Based off #14905, this removes the link to the calendar from the personal menu.

Originally I also wanted to remove it from the profile menu, leaving only the most visible link to the calendar, in the always accessible global menu ( number 1 in this screenshot):

![friendica-calendar](https://github.com/user-attachments/assets/3260f0ec-37cb-4f90-8949-f29276d2d16a)

...but it turns out number 3 sometimes points to another user's calendar, if theirs is set to publically available, so I left that unchanged so one's own profile doesn't differ to the profiles of others in that way.

After this change:
![image](https://github.com/user-attachments/assets/84e3a8e9-cc22-4f4e-a867-f8bb245e0f4b)