### PR TITLE
Frio: Make profile contacts header link to contacts instead of the eye icon (Suggestion)

### DIFF
--- a/view/theme/frio/templates/widget/contacts.tpl
+++ b/view/theme/frio/templates/widget/contacts.tpl
@@ -6,14 +6,16 @@
   *}}
 
 <div id="contact-block">
-	<h3 class="contact-block-h4 pull-left">{{$contacts}}</h3>
-
 {{if $micropro}}
-	<a class="pull-right widget-action faded-icon" id="contact-block-view-contacts" href="profile/{{$nickname}}/contacts">
-		<i class="fa fa-eye" aria-hidden="true"></i>
+	<a id="contact-block-view-contacts" href="profile/{{$nickname}}/contacts">
+		<h3 class="contact-block-h4">{{$contacts}}</h3>
 		<span class="sr-only">{{$viewcontacts}}</span>
 	</a>
+{{else}}
+	<h3 class="contact-block-h4">{{$contacts}}</h3>
+{{/if}}
 
+{{if $micropro}}
 	<div class='contact-block-content'>
 	{{foreach $micropro as $m}}
 		{{$m nofilter}}


### PR DESCRIPTION
Currently there's an eye icon which links to Contacts on `/profile/<username>/profile`.
I personally find it nonintuitive that that's just a link to seeing the Contacts, as I assume it has something to do with showing or hiding the section, or that it's some sort of other side action related to the items.

In general on Friendica that eye icon is used for things like:
- Viewed by
- View as
- Preview
- Ignore user or server

Some other side panels have icons top right, for things like creating a group, but I think it makes more sense in that case. Ie. when it's an action related to what's listed.

This PR removes the eye icon and instead makes the text "Contacts" a link that goes to that page.
I don't think most of those headers are clickable so it's a little nonstandard for Friendica as well. Most of the similar looking sections are collapsible, and here clicking the header collapses it. But this section indicates its not collapsible by not having the icon for it + I'd say in a more general web design sense it's pretty standard that that text is clickable, and of course it will automatically be styled as a link.

Before:
![image](https://github.com/user-attachments/assets/b7a5e5eb-c766-46a3-a015-391981bf22fd)

After:
![image](https://github.com/user-attachments/assets/67b04d2d-f800-4f40-ace5-4c110a6422d0)

I'm just putting this up as a suggestion. I'm curious to hear what you think.

Also please review the code changes, if you think it's a good idea. I wasn't quite sure what to do with what I assume is a section for screen readers. I kept it inside the link.