### PR TITLE
Settings: Better handling of no content in addons and connected apps

### DIFF
--- a/src/Module/Settings/Addons.php
+++ b/src/Module/Settings/Addons.php
@@ -60,7 +60,7 @@ class Addons extends BaseSettings
 					'$addon'  => $data['addon'],
 					'$title'  => $data['title'],
 					'$open'   => ($this->parameters['addon'] ?? '') === $data['addon'],
-					'$html'   => $data['html'] ?? '',
+					'$html'   => $data['html']   ?? '',
 					'$submit' => $data['submit'] ?? $this->t('Save Settings'),
 				]);
 			}
@@ -68,10 +68,10 @@ class Addons extends BaseSettings
 
 		$tpl = Renderer::getMarkupTemplate('settings/addons.tpl');
 		return Renderer::replaceMacros($tpl, [
-			'$form_security_token'           => BaseSettings::getFormSecurityToken('settings_addon'),
-			'$title'                         => $this->t('Addon Settings'),
+			'$form_security_token'          => BaseSettings::getFormSecurityToken('settings_addon'),
+			'$title'                        => $this->t('Addon Settings'),
 			'$no_addon_settings_configured' => $this->t('None of the addons installed on this server have any settings.'),
-			'$addon_settings_forms'          => $addon_settings_forms,
+			'$addon_settings_forms'         => $addon_settings_forms,
 		]);
 	}
 }

--- a/src/Module/Settings/Addons.php
+++ b/src/Module/Settings/Addons.php
@@ -70,7 +70,7 @@ class Addons extends BaseSettings
 		return Renderer::replaceMacros($tpl, [
 			'$form_security_token'           => BaseSettings::getFormSecurityToken('settings_addon'),
 			'$title'                         => $this->t('Addon Settings'),
-			'$no_addons_settings_configured' => $this->t('No Addon settings configured'),
+			'$no_addon_settings_configured' => $this->t('None of the addons installed on this server have any settings.'),
 			'$addon_settings_forms'          => $addon_settings_forms,
 		]);
 	}

--- a/src/Module/Settings/OAuth.php
+++ b/src/Module/Settings/OAuth.php
@@ -59,6 +59,7 @@ class OAuth extends BaseSettings
 			'$website'             => $this->t('Home Page'),
 			'$created_at'          => $this->t('Created'),
 			'$delete'              => $this->t('Remove authorization'),
+			'$no_connected_apps'   => $this->t('You have no connected apps.'),
 			'$apps'                => $applications,
 		]);
 	}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.02-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-21 13:03+0200\n"
+"POT-Creation-Date: 2025-06-21 14:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -9545,7 +9545,7 @@ msgid "Addon Settings"
 msgstr ""
 
 #: src/Module/Settings/Addons.php:73
-msgid "No Addon settings configured"
+msgid "None of the addons installed on this server have any settings."
 msgstr ""
 
 #: src/Module/Settings/Channels.php:134
@@ -10178,6 +10178,10 @@ msgstr ""
 
 #: src/Module/Settings/OAuth.php:61
 msgid "Remove authorization"
+msgstr ""
+
+#: src/Module/Settings/OAuth.php:62
+msgid "You have no connected apps."
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:126

--- a/view/templates/settings/oauth.tpl
+++ b/view/templates/settings/oauth.tpl
@@ -6,31 +6,35 @@
   *}}
 <div class="generic-page-wrapper">
 	<h1>{{$title}}</h1>
-	<form action="settings/oauth" method="post" autocomplete="off">
-		<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
-		<table id='application-block' class='table table-condensed table-striped'>
-			<thead>
-				<tr>
-					<th>{{$name}}</th>
-					<th>{{$website}}</th>
-					<th>{{$created_at}}</th>
-					<th></th>
-				</tr>
-			</thead>
-			<tbody>
-				{{foreach $apps as $app}}
-				<tr>
-					<td>{{$app.name}}</td>
-					<td>{{$app.website}}</td>
-					<td>{{$app.created_at}}</td>
-					<td>
-						<button type="submit" class="btn" title="{{$delete}}" name="delete" value="{{$app.id}}">
-							<i class="icon s22 delete" aria-hidden="true"></i>
-						</button>
-					</td>
-				</tr>
-				{{/foreach}}
-			</tbody>
-		</table>
-	</form>
+	{{if !$apps}}
+		{{$no_connected_apps}}
+	{{else}}
+		<form action="settings/oauth" method="post" autocomplete="off">
+			<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+			<table id='application-block' class='table table-condensed table-striped'>
+				<thead>
+					<tr>
+						<th>{{$name}}</th>
+						<th>{{$website}}</th>
+						<th>{{$created_at}}</th>
+						<th></th>
+					</tr>
+				</thead>
+				<tbody>
+					{{foreach $apps as $app}}
+					<tr>
+						<td>{{$app.name}}</td>
+						<td>{{$app.website}}</td>
+						<td>{{$app.created_at}}</td>
+						<td>
+							<button type="submit" class="btn" title="{{$delete}}" name="delete" value="{{$app.id}}">
+								<i class="icon s22 delete" aria-hidden="true"></i>
+							</button>
+						</td>
+					</tr>
+					{{/foreach}}
+				</tbody>
+			</table>
+		</form>
+	{{/if}}
 </div>

--- a/view/theme/frio/templates/settings/addons.tpl
+++ b/view/theme/frio/templates/settings/addons.tpl
@@ -15,7 +15,7 @@
 			{{$addon_settings_form nofilter}}
 		</form>
 {{foreachelse}}
-		<div class="alert alert-info" role="alert">{{$no_addon_settings_configured}}</div>
+		{{$no_addon_settings_configured}}
 {{/foreach}}
 	</div>
 

--- a/view/theme/frio/templates/settings/oauth.tpl
+++ b/view/theme/frio/templates/settings/oauth.tpl
@@ -7,31 +7,36 @@
 <div class="generic-page-wrapper">
 	{{* include the title template for the settings title *}}
 	{{include file="section_title.tpl" title=$title}}
-	<form action="settings/oauth" method="post" autocomplete="off">
-		<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
-		<table id='application-block' class='table table-condensed table-striped'>
-			<thead>
-				<tr>
-					<th>{{$name}}</th>
-					<th>{{$website}}</th>
-					<th>{{$created_at}}</th>
-					<th></th>
-				</tr>
-			</thead>
-			<tbody>
-				{{foreach $apps as $app}}
-				<tr>
-					<td>{{$app.name}}</td>
-					<td>{{$app.website}}</td>
-					<td>{{$app.created_at}}</td>
-					<td>
-						<button type="submit" class="btn" title="{{$delete}}" name="delete" value="{{$app.id}}">
-							<i class="fa fa-trash" aria-hidden="true"></i>
-						</button>
-					</td>
-				</tr>
-				{{/foreach}}
-			</tbody>
-		</table>
-	</form>
+
+	{{if !$apps}}
+		{{$no_connected_apps}}
+	{{else}}
+		<form action="settings/oauth" method="post" autocomplete="off">
+			<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+			<table id='application-block' class='table table-condensed table-striped'>
+				<thead>
+					<tr>
+						<th>{{$name}}</th>
+						<th>{{$website}}</th>
+						<th>{{$created_at}}</th>
+						<th></th>
+					</tr>
+				</thead>
+				<tbody>
+					{{foreach $apps as $app}}
+					<tr>
+						<td>{{$app.name}}</td>
+						<td>{{$app.website}}</td>
+						<td>{{$app.created_at}}</td>
+						<td>
+							<button type="submit" class="btn" title="{{$delete}}" name="delete" value="{{$app.id}}">
+								<i class="fa fa-trash" aria-hidden="true"></i>
+							</button>
+						</td>
+					</tr>
+					{{/foreach}}
+				</tbody>
+			</table>
+		</form>
+	{{/if}}
 </div>


### PR DESCRIPTION
This PR makes two changes under settings, related to how how Addons and Connected Apps are shown when there are none

# Addons

There was a bug in the variable naming where in php it was call "no_addon**s**_settings_configured" but in the templates it was "no_addon_settings_configured", so the content of the variable was simply not displayed.

I also changed the wording of that message, based on my understanding of what it means for the user.
**Is it correct that it means that "None of the addons installed on this server have any settings"?**

Vier before:
![image](https://github.com/user-attachments/assets/9e796d07-f787-4e33-ab4d-b2ba78ad90f4)

Vier after:
![image](https://github.com/user-attachments/assets/cfa734e9-903b-4315-8c15-8a19e536f9bf)

Frio before:
![image](https://github.com/user-attachments/assets/a614811b-c3b6-41de-b36d-9703621b6c65)

Frio after:
![image](https://github.com/user-attachments/assets/5b599e75-f686-4c76-987c-73cd8cbfea83)

# Connected apps

When the Connected apps list was empty an empty table was shown.
This adds a conditional, and if there are no apps, instead a message is shown.

**I've written it as "You have no connected apps". Is that correctly interpreted that that is when that table will be empty?
It means the currently signed in user hasn't connected any apps, or that the server hasn't?**

Vier before:
![image](https://github.com/user-attachments/assets/9537388b-6098-49f1-a785-e77ec8b5e71e)


Vier after:
![image](https://github.com/user-attachments/assets/fe695a36-0c86-4c28-9e58-444bb465cb64)

Frio before:
![image](https://github.com/user-attachments/assets/118dc979-4610-4e06-ab3e-a40d9bb362a8)

Frio after:
![image](https://github.com/user-attachments/assets/3c29b1fa-55bb-4eed-865a-5f5dcb79c2e1)

# Thoughts on settings

I also considered that perhaps these should simply not show up in settings if they're empty anyway, especially since settings is already so confusing/comprehensive, but I'm not sure how to do that. I know it's handled in BaseSettings, but I'm not sure how to check if there are no connected apps or no addons with settings available there.

Speaking of cleaning up settings I also started considering that perhaps "Import contacts", "Export personal data" and "Delete account" should be moved somewhere else, or at least be visually separated from the rest. In my opinion they aren't really "settings". "Export personal data" and "Delete account" "could be under Account Management" or something like that. "Import contacts" should probably be an independent page just accessible from where you see your contacts and/or add friends?

Also it would help if settings were searchable.

But that's for another time.