### PR TITLE
Search: Replace "No results" notification with translated text

### DIFF
--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -136,7 +136,9 @@ class Index extends BaseSearch
 		// Tags don't look like an URL and the fulltext search does only work with natural words
 		if (parse_url($search, PHP_URL_SCHEME) && parse_url($search, PHP_URL_HOST)) {
 			$this->logger->info('Skipping tag and fulltext search since the search looks like a URL.', ['q' => $search]);
-			DI::sysmsg()->addNotice(DI::l10n()->t('No results.'));
+			$o .= Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), [
+				'$title' => DI::l10n()->t('No results.')
+			]);
 			return $o;
 		}
 
@@ -186,7 +188,9 @@ class Index extends BaseSearch
 
 		if (empty($items)) {
 			if (empty($last_uriid)) {
-				DI::sysmsg()->addNotice(DI::l10n()->t('No results.'));
+				$o .= Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), [
+					'$title' => DI::l10n()->t('No results.')
+				]);
 			}
 			return $o;
 		}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.02-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-14 15:06+0200\n"
+"POT-Creation-Date: 2025-06-21 13:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Map"
 msgstr ""
 
-#: src/App.php:451
+#: src/App.php:454
 msgid "Apologies but the website is unavailable at the moment."
 msgstr ""
 
@@ -2227,11 +2227,11 @@ msgstr ""
 msgid "prev"
 msgstr ""
 
-#: src/Content/Pager.php:262 src/Module/Calendar/Show.php:122
+#: src/Content/Pager.php:246 src/Module/Calendar/Show.php:122
 msgid "next"
 msgstr ""
 
-#: src/Content/Pager.php:267
+#: src/Content/Pager.php:251
 msgid "last"
 msgstr ""
 
@@ -6108,7 +6108,7 @@ msgstr ""
 msgid "Search your contacts"
 msgstr ""
 
-#: src/Module/Contact.php:441 src/Module/Search/Index.php:202
+#: src/Module/Contact.php:441 src/Module/Search/Index.php:206
 #, php-format
 msgid "Results for: %s"
 msgstr ""
@@ -6698,8 +6698,8 @@ msgid "Unable to unfollow this contact, please contact your administrator"
 msgstr ""
 
 #: src/Module/Conversation/Channel.php:125
-#: src/Module/Conversation/Community.php:114 src/Module/Search/Index.php:139
-#: src/Module/Search/Index.php:189
+#: src/Module/Conversation/Community.php:114 src/Module/Search/Index.php:140
+#: src/Module/Search/Index.php:192
 msgid "No results."
 msgstr ""
 
@@ -8901,7 +8901,7 @@ msgstr ""
 msgid "Only one search per minute is permitted for not logged in users."
 msgstr ""
 
-#: src/Module/Search/Index.php:200
+#: src/Module/Search/Index.php:204
 #, php-format
 msgid "Items tagged with: %s"
 msgstr ""

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -174,9 +174,8 @@ $(document).ready(function () {
 
 		// temporary workaround to avoid 'undefined' being displayed (issue #9789)
 		// https://github.com/friendica/friendica/issues/9789
-		// TODO: find a way to localize this string
 		if (typeof searchText === "undefined") {
-			searchText = "No results";
+			searchText = "";
 		}
 		// insert the plain text in a <h4> heading and give it a class
 		var newText = '<h4 class="search-heading">' + searchText + "</h4>";


### PR DESCRIPTION
When searching and there are no results two things happen in Frio:
1. There's a notification saying there are "no results". This is translated to the current language, as its defined in PHP.
2. There's some text in the interface saying "no results". This is NOT translated, and it's created by Javascript, and there is a comment about finding a way to translate it.

In Vier there's seemingly just no feedback on there being no results, because instead of making a general fix, frio was updated to handle it in a way that only works in frio.

I only think we need that feedback in one place, and that it should be translated, and it should work in Friendica generally, not just in Frio. I also think the notification is easy to miss particularly on desktop, because it's very far away from the search field, by the edge of the screen.

This PR hopes to change that, specifically by removing the JS generated version and the notification, and instead reusing the template used for results to display "no results" as well.

Vier before:
![image](https://github.com/user-attachments/assets/1abc453c-3e82-43f6-afc1-8a8acda641e9)
There's no feedback about there being no results. (except maybe the notification?)

Vier after:
![image](https://github.com/user-attachments/assets/75a06f5f-0227-45a4-ae62-5d9a00bc056d)

Frio before:
![image](https://github.com/user-attachments/assets/28d6a74e-a717-45bc-8671-92e250bed78c)
There's feedback text in the middle + a  notification. The former is not being translated.

Frio after:
![image](https://github.com/user-attachments/assets/3b2be030-38ce-4d1e-b196-ca90e0d31296)
The middle text is now translated, and there's no notification anymore.