### PR TITLE
Frio - Calendar: Replace ambiguous "today" icon with text + minor UI changes

### DIFF
--- a/src/Module/Calendar/Show.php
+++ b/src/Module/Calendar/Show.php
@@ -113,13 +113,13 @@ class Show extends BaseModule
 			'$view'      => $this->t('View'),
 			'$new_event' => ['calendar/event/new', $this->t('Create New Event'), '', ''],
 
-			'$today' => $this->t('today'),
-			'$month' => $this->t('month'),
-			'$week'  => $this->t('week'),
-			'$day'   => $this->t('day'),
-			'$list'  => $this->t('list'),
-			'$prev'  => $this->t('prev'),
-			'$next'  => $this->t('next'),
+			'$today' => mb_ucfirst($this->t('today')),
+			'$month' => mb_ucfirst($this->t('month')),
+			'$week'  => mb_ucfirst($this->t('week')),
+			'$day'   => mb_ucfirst($this->t('day')),
+			'$list'  => mb_ucfirst($this->t('list')),
+			'$prev'  => mb_ucfirst($this->t('prev')),
+			'$next'  => mb_ucfirst($this->t('next')),
 		]);
 
 		return $o;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3717,6 +3717,7 @@ section .profile-match-wrapper {
  * The different views of js fullcalendar
  */
 #fc-header {
+	display: flex;
 	margin-top: 20px;
 	margin-bottom: 10px;
 }
@@ -3736,6 +3737,8 @@ section .profile-match-wrapper {
 	color: inherit;
 }
 #event-calendar-title {
+	flex: 1;
+	text-align: center;
 	vertical-align: middle;
 }
 #event-calendar-views {

--- a/view/theme/frio/templates/calendar/calendar.tpl
+++ b/view/theme/frio/templates/calendar/calendar.tpl
@@ -19,7 +19,18 @@
 
 	{{* We create our own fullcalendar header (with title & calendar view *}}
 	<div id="fc-header" class="clear">
-		<div id="fc-header-right" class="pull-right">
+
+		{{* The buttons to change the month/weeks/days *}}
+		<div id="fc-fc-header-left" class="btn-group">
+			<button class="btn btn-eventnav" onclick="changeView('prev', false);" title="{{$prev}}"><i class="fa fa-angle-up" aria-hidden="true"></i></button>
+			<button class="btn btn-eventnav btn-separator" onclick="changeView('next', false);" title="{{$next}}"><i class="fa fa-angle-down" aria-hidden="true"></i></button>
+			<button class="btn btn-eventnav btn-separator" onclick="changeView('today', false);">{{$today}}</button>
+		</div>
+
+		{{* The title (e.g. name of the mont/week/day) *}}
+		<div id="event-calendar-title"><h4 id="fc-title"></h4></div>
+
+		<div id="fc-header-right">
 			{{* The dropdown to change the calendar view *}}
 			<ul class="nav nav-pills">
 				<li class="dropdown pull-right">
@@ -43,16 +54,6 @@
 				</li>
 			</ul>
 		</div>
-
-		{{* The buttons to change the month/weeks/days *}}
-		<div id="fc-fc-header-left" class="btn-group">
-			<button class="btn btn-eventnav" onclick="changeView('prev', false);" title="{{$prev}}"><i class="fa fa-angle-up" aria-hidden="true"></i></button>
-			<button class="btn btn-eventnav btn-separator" onclick="changeView('next', false);" title="{{$next}}"><i class="fa fa-angle-down" aria-hidden="true"></i></button>
-			<button class="btn btn-eventnav btn-separator" onclick="changeView('today', false);" title="{{$today}}"><i class="fa fa-bullseye" aria-hidden="true"></i></button>
-		</div>
-
-		{{* The title (e.g. name of the mont/week/day) *}}
-		<div id="event-calendar-title"><h4 id="fc-title"></h4></div>
 
 	</div>
 


### PR DESCRIPTION
In the calendar in Frio, Friendica currently uses this concentric circle icon for the button that switches the calendar view to the current day:
![image](https://github.com/user-attachments/assets/829d87d7-2fce-4c08-9b57-e8e90558f2c1)

I don't think it's obvious it means "today", and it's also confusing that the same icon is used for the /community section:
![image](https://github.com/user-attachments/assets/736490e0-a81e-4069-8c07-e70d1f036560)

I tried finding a different font awesome icon for it, but I can only find a good option for showing a calendar generally, and that would also be ambiguous. So instead I've replaced it with text simply saying "Today", which is also what Vier shows.
I also checked Google calendar, and it also writes the text, rather than use an icon.

I also changed it so the name of current month is centered, to separate it more from the buttons that change the current period shown.

Additionally I uppercased the words "week", "month" etc. since they're written alone (ie. starting sentences), using `mb_ucfirst` so their existing translations remain working.

Frio before:
![image](https://github.com/user-attachments/assets/8334241c-9565-418b-bbf4-b7b1dfd96656)

Frio after:
![image](https://github.com/user-attachments/assets/91e6a515-5bf1-4bfa-b59c-a9874f6b57cd)