### PR TITLE
Frio - User nav: Add icons to the rest of the menu

### DIFF
--- a/src/Render/FriendicaSmarty.php
+++ b/src/Render/FriendicaSmarty.php
@@ -42,6 +42,7 @@ class FriendicaSmarty extends Smarty
 		$this->registerPlugin('modifier', 'is_string', function ($value) {
 			return is_string($value);
 		});
+		$this->registerPlugin("modifier", "str_ends_with", "str_ends_with");
 
 		/*
 		 * Enable sub-directory splitting for reducing directory descriptor

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -201,6 +201,20 @@
 										<li>
 											<a role="menuitem" class="{{$usermenu.2}}" href="{{$usermenu.0}}"
 												title="{{$usermenu.3}}">
+
+												{{if $usermenu.0|str_ends_with:$userinfo.name}}
+													<i class="fa fa-commenting"></i>
+												{{elseif $usermenu.0|str_ends_with:"/profile"}}
+													<i class="fa fa-user"></i>
+												{{elseif $usermenu.0|str_ends_with:"/photos"}}
+													<i class="fa fa-picture-o"></i>
+												{{elseif $usermenu.0|str_ends_with:"/media"}}
+													<i class="fa fa-edit"></i>
+												{{elseif $usermenu.0|str_ends_with:"calendar/"}}
+													<i class="fa fa-calendar"></i>
+												{{elseif $usermenu.0|str_ends_with:"notes/"}}
+													<i class="fa fa-book"></i>
+												{{/if}}
 												{{$usermenu.1}}
 											</a>
 										</li>


### PR DESCRIPTION
The first six entries in the user nav are missing icons. This PR adds them.
If you have better/more consistent suggestions for the icons, please let me know:
https://fontawesome.com/v3/icons/

Ideally I think several of these entries should be removed to simplify the menu, since I think many are rarely visited, and they're accessible by one click once you're on your profile anyway, which many of the links take you to.
But that's for another PR.

Frio before:
![image](https://github.com/user-attachments/assets/06b61eb4-bcda-46af-bc69-49dd74b88cc9)

Frio after:
![image](https://github.com/user-attachments/assets/f1298943-6d62-44d3-9c3f-b10d5dea4b6c)1