### PR TITLE
Issue 14491 - Add alt tag indicators to images

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -813,3 +813,16 @@ summary.wall-item-summary {
     	max-width: 70ch;
     	overflow-wrap: break-word;
 }
+
+/* Add alt tag indicators to the relevant images */
+a:has(img.has-alt-description)::after {
+	background: lightgray;
+	border-radius: 4px;
+	color: black;
+	content: "ALT";
+	font-weight: bold;
+	padding: 3px 8px;
+	position: absolute;
+	bottom: 10px;
+	right: 10px;
+}


### PR DESCRIPTION
Related to #14491 and #14507 this is a stab at adding a visible "Alt"-tag indicator to images.

I've set it as a draft as it should be tested a more, and also because I'm unsure of where exactly it should be shown and where it shouldn't.

I currently haven't added any indication of "Alt" text missing, other than the fact that the label isn't there.
That seems to align with Mastodon and Bluesky, which @annando referenced in the issue.
I've also pretty much taken their styling of it. It's not gonna work well on images with light gray backgrounds, but I'm not sure how that could be handled.

Example image with "Alt" text:
![image](https://github.com/user-attachments/assets/bb87cd63-5a03-4ff1-8aed-b31065e7fdf9)

Example with two images with "Alt" texts and one without, zoomed out a lot to be able to show it:
![image](https://github.com/user-attachments/assets/68066d7e-f37d-4c50-9cec-23a0fa5fa575)

Edit: Come to think of it this currently hardcodes the text to be "ALT" and thus it doesn't handle translations.
So I guess it should ideally be some translated string passed from php.