### PR TITLE
Make 1 character domains clickable

### DIFF
--- a/src/Util/Strings.php
+++ b/src/Util/Strings.php
@@ -395,8 +395,7 @@ class Strings
 	{
 		return 'https?://                   # http or https protocol
   (?:
-	[^/\s\xA0`!()\[\]{};:\'",<>?«»“”‘’.]    # Domain can\'t start with a .
-	[^/\s\xA0`!()\[\]{};:\'",<>?«»“”‘’]*    # Domain can\'t end with a .
+	[^/\s\xA0`!()\[\]{};:\'",<>?«»“”‘’.]+
 	\.
 	[^/\s\xA0`!()\[\]{};:\'".,<>?«»“”‘’]+/? # Followed by a slash
   )

--- a/src/Util/Strings.php
+++ b/src/Util/Strings.php
@@ -396,7 +396,7 @@ class Strings
 		return 'https?://                   # http or https protocol
   (?:
 	[^/\s\xA0`!()\[\]{};:\'",<>?«»“”‘’.]    # Domain can\'t start with a .
-	[^/\s\xA0`!()\[\]{};:\'",<>?«»“”‘’]+    # Domain can\'t end with a .
+	[^/\s\xA0`!()\[\]{};:\'",<>?«»“”‘’]*    # Domain can\'t end with a .
 	\.
 	[^/\s\xA0`!()\[\]{};:\'".,<>?«»“”‘’]+/? # Followed by a slash
   )


### PR DESCRIPTION
closes #14991

Set as a draft for now as I'm unsure why the original regex didn't do this to begin with. Maybe there's a good reason.
This is referenced in a comment:
https://daringfireball.net/2010/07/improved_regex_for_matching_urls