### PR TITLE
Fix version in deprecation messages for 2025.07

### DIFF
--- a/bin/daemon.php
+++ b/bin/daemon.php
@@ -6,7 +6,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * @deprecated 2025.02 use `bin/console.php daemon` instead
+ * @deprecated 2025.07 use `bin/console.php daemon` instead
  */
 
 /**
@@ -24,7 +24,7 @@ chdir(dirname(__DIR__));
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-fwrite(STDOUT, '`bin/daemon.php` is deprecated since 2025.02 and will be removed in 5 months, please use `bin/console.php daemon` instead.' . \PHP_EOL);
+fwrite(STDOUT, '`bin/daemon.php` is deprecated since 2025.07 and will be removed in 5 months, please use `bin/console.php daemon` instead.' . \PHP_EOL);
 
 // BC: Add console command as second argument
 $argv = $_SERVER['argv'] ?? [];

--- a/bin/jetstream.php
+++ b/bin/jetstream.php
@@ -6,7 +6,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * @deprecated 2025.02 use `bin/console.php jetstream` instead
+ * @deprecated 2025.07 use `bin/console.php jetstream` instead
  */
 
 if (php_sapi_name() !== 'cli') {
@@ -19,7 +19,7 @@ chdir(dirname(__DIR__));
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-fwrite(STDOUT, '`bin/jetstream.php` is deprecated since 2025.02 and will be removed in 5 months, please use `bin/console.php jetstream` instead.' . \PHP_EOL);
+fwrite(STDOUT, '`bin/jetstream.php` is deprecated since 2025.07 and will be removed in 5 months, please use `bin/console.php jetstream` instead.' . \PHP_EOL);
 
 // BC: Add console command as second argument
 $argv = $_SERVER['argv'] ?? [];

--- a/bin/worker.php
+++ b/bin/worker.php
@@ -8,7 +8,7 @@
  *
  * Starts the background processing
  *
- * @deprecated 2025.02 use `bin/console.php worker` instead
+ * @deprecated 2025.07 use `bin/console.php worker` instead
  */
 
 if (php_sapi_name() !== 'cli') {
@@ -21,7 +21,7 @@ chdir(dirname(__DIR__));
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-fwrite(STDOUT, '`bin/worker.php` is deprecated since 2025.02 and will be removed in 5 months, please use `bin/console.php worker` instead.' . \PHP_EOL);
+fwrite(STDOUT, '`bin/worker.php` is deprecated since 2025.07 and will be removed in 5 months, please use `bin/console.php worker` instead.' . \PHP_EOL);
 
 // BC: Add console command as second argument
 $argv = $_SERVER['argv'] ?? [];

--- a/doc/StrategyHooks.md
+++ b/doc/StrategyHooks.md
@@ -83,7 +83,7 @@ return [
 
 ## Addons
 
-> ⚠️ Since Friendica 2025.02 the strategy hooks for addons are deprecated, please use PHP hooks instead.
+> ⚠️ Since Friendica 2025.07 the strategy hooks for addons are deprecated, please use PHP hooks instead.
 
 The hook logic is useful for decoupling the Friendica core logic, but its primary goal is to modularize Friendica in creating addons.
 

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -148,13 +148,13 @@ abstract class BaseRepository
 	}
 
 	/**
-	 * @deprecated 2025.05 Use `\Friendica\BaseRepository::_selectFirstRowAsArray()` instead
+	 * @deprecated 2025.07 Use `\Friendica\BaseRepository::_selectFirstRowAsArray()` instead
 	 *
 	 * @throws NotFoundException
 	 */
 	protected function _selectOne(array $condition, array $params = []): BaseEntity
 	{
-		@trigger_error('`' . __METHOD__ . '()` is deprecated since 2025.05 and will be removed after 5 months, use `\Friendica\BaseRepository::_selectFirstRowAsArray()` instead.', E_USER_DEPRECATED);
+		@trigger_error('`' . __METHOD__ . '()` is deprecated since 2025.07 and will be removed after 5 months, use `\Friendica\BaseRepository::_selectFirstRowAsArray()` instead.', E_USER_DEPRECATED);
 
 		$fields = $this->_selectFirstRowAsArray( $condition, $params);
 

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -266,7 +266,7 @@ class Conversation
 					break;
 				case 'dislike':
 					$dislike_translation_plural = '<button type="button" %2$s>%1$d people</button> don\'t like this';
-					// @deprecated 2025.04 this translation is scheduled for removal as a new translation has been added without the typo
+					// @deprecated 2025.07 this translation is scheduled for removal as a new translation has been added without the typo
 					$dislike_translation_plural = '<button type="button" %2$s>%1$d peiple</button> don\'t like this';
 					$phrase                     = $this->l10n->tt('<button type="button" %2$s>%1$d person</button> doesn\'t like this', $dislike_translation_plural, $total, $spanatts);
 					break;

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -13,14 +13,14 @@ use Friendica\Util\Strings;
 /**
  * Some functions to handle addons
  *
- * @deprecated 2025.02 Use implementation of `Friendica\Core\Addon\AddonHelper` instead
+ * @deprecated 2025.07 Use implementation of `Friendica\Core\Addon\AddonHelper` instead
  */
 class Addon
 {
 	/**
 	 * The addon sub-directory
 	 *
-	 * @deprecated 2025.02 Use `Friendica\Core\Addon\AddonHelper::getAddonPath()` instead
+	 * @deprecated 2025.07 Use `Friendica\Core\Addon\AddonHelper::getAddonPath()` instead
 	 *
 	 * @var string
 	 */
@@ -38,14 +38,14 @@ class Addon
 	 * This list is made from scanning the addon/ folder.
 	 * Unsupported addons are excluded unless they already are enabled or system.show_unsupported_addon is set.
 	 *
-	 * @deprecated 2025.02 Use `Friendica\Core\Addon\AddonHelper::getAvailableAddons()` instead
+	 * @deprecated 2025.07 Use `Friendica\Core\Addon\AddonHelper::getAvailableAddons()` instead
 	 *
 	 * @return array
 	 * @throws \Exception
 	 */
 	public static function getAvailableList(): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addons = [];
 		$files  = glob('addon/*/');
@@ -72,14 +72,14 @@ class Addon
 	 * Returns a list of addons that can be configured at the node level.
 	 * The list is formatted for display in the admin panel aside.
 	 *
-	 * @deprecated 2025.02 Use `Friendica\Core\Addon\AddonHelper::getEnabledAddonsWithAdminSettings()` instead
+	 * @deprecated 2025.07 Use `Friendica\Core\Addon\AddonHelper::getEnabledAddonsWithAdminSettings()` instead
 	 *
 	 * @return array
 	 * @throws \Exception
 	 */
 	public static function getAdminList(): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addons_admin = [];
 		$addons       = array_filter(DI::config()->get('addons') ?? []);
@@ -111,11 +111,11 @@ class Addon
 	 * Then go through the config list and if we have a addon that isn't installed,
 	 * call the install procedure and add it to the database.
 	 *
-	 * @deprecated 2025.02 Use `Friendica\Core\Addon\AddonHelper::loadAddons()` instead
+	 * @deprecated 2025.07 Use `Friendica\Core\Addon\AddonHelper::loadAddons()` instead
 	 */
 	public static function loadAddons()
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		self::$addons = array_keys(array_filter(DI::config()->get('addons') ?? []));
 	}
@@ -123,7 +123,7 @@ class Addon
 	/**
 	 * uninstalls an addon.
 	 *
-	 * @deprecated 2025.02 Use `Friendica\Core\Addon\AddonHelper::uninstallAddon()` instead
+	 * @deprecated 2025.07 Use `Friendica\Core\Addon\AddonHelper::uninstallAddon()` instead
 	 *
 	 * @param string $addon name of the addon
 	 * @return void
@@ -131,7 +131,7 @@ class Addon
 	 */
 	public static function uninstall(string $addon)
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addon = Strings::sanitizeFilePathItem($addon);
 
@@ -153,7 +153,7 @@ class Addon
 	/**
 	 * installs an addon.
 	 *
-	 * @deprecated 2025.02 Use `Friendica\Core\Addon\AddonHelper::installAddon()` instead
+	 * @deprecated 2025.07 Use `Friendica\Core\Addon\AddonHelper::installAddon()` instead
 	 *
 	 * @param string $addon name of the addon
 	 * @return bool
@@ -161,7 +161,7 @@ class Addon
 	 */
 	public static function install(string $addon): bool
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addon = Strings::sanitizeFilePathItem($addon);
 
@@ -195,7 +195,7 @@ class Addon
 	/**
 	 * reload all updated addons
 	 *
-	 * @deprecated 2025.02 Use `Friendica\Core\Addon\AddonHelper::reloadAddons()` instead
+	 * @deprecated 2025.07 Use `Friendica\Core\Addon\AddonHelper::reloadAddons()` instead
 	 *
 	 * @return void
 	 * @throws \Exception
@@ -203,7 +203,7 @@ class Addon
 	 */
 	public static function reload()
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addons = array_filter(DI::config()->get('addons') ?? []);
 
@@ -236,7 +236,7 @@ class Addon
 	 *   *
 	 *   *\endcode
 	 *
-	 * @deprecated 2025.02 Use `Friendica\Core\Addon\AddonHelper::getAddonInfo()` instead
+	 * @deprecated 2025.07 Use `Friendica\Core\Addon\AddonHelper::getAddonInfo()` instead
 	 *
 	 * @param string $addon the name of the addon
 	 * @return array with the addon information
@@ -244,7 +244,7 @@ class Addon
 	 */
 	public static function getInfo(string $addon): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addon = Strings::sanitizeFilePathItem($addon);
 
@@ -300,14 +300,14 @@ class Addon
 	/**
 	 * Checks if the provided addon is enabled
 	 *
-	 * @deprecated 2025.02 Use `Friendica\Core\Addon\AddonHelper::isAddonEnabled()` instead
+	 * @deprecated 2025.07 Use `Friendica\Core\Addon\AddonHelper::isAddonEnabled()` instead
 	 *
 	 * @param string $addon
 	 * @return boolean
 	 */
 	public static function isEnabled(string $addon): bool
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		return in_array($addon, self::$addons);
 	}
@@ -315,13 +315,13 @@ class Addon
 	/**
 	 * Returns a list of the enabled addon names
 	 *
-	 * @deprecated 2025.02 Use `Friendica\Core\Addon\AddonHelper::getEnabledAddons()` instead
+	 * @deprecated 2025.07 Use `Friendica\Core\Addon\AddonHelper::getEnabledAddons()` instead
 	 *
 	 * @return array
 	 */
 	public static function getEnabledList(): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		return self::$addons;
 	}
@@ -329,14 +329,14 @@ class Addon
 	/**
 	 * Returns the list of non-hidden enabled addon names
 	 *
-	 * @deprecated 2025.02 Use `Friendica\Core\Addon\AddonHelper::getVisibleEnabledAddons()` instead
+	 * @deprecated 2025.07 Use `Friendica\Core\Addon\AddonHelper::getVisibleEnabledAddons()` instead
 	 *
 	 * @return array
 	 * @throws \Exception
 	 */
 	public static function getVisibleList(): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$visible_addons = [];
 		$addons         = array_filter(DI::config()->get('addons') ?? []);

--- a/src/Core/Addon/Capability/ICanLoadAddons.php
+++ b/src/Core/Addon/Capability/ICanLoadAddons.php
@@ -10,14 +10,14 @@ namespace Friendica\Core\Addon\Capability;
 /**
  * Interface for loading Addons specific content
  *
- * @deprecated 2025.02 Use implementation of `\Friendica\Core\Addon\AddonHelper` instead.
+ * @deprecated 2025.07 Use implementation of `\Friendica\Core\Addon\AddonHelper` instead.
  */
 interface ICanLoadAddons
 {
 	/**
 	 * Returns a merged config array of all active addons for a given config-name
 	 *
-	 * @deprecated 2025.02 Use `\Friendica\Core\Addon\AddonHelper::getAddonDependencyConfig()` instead.
+	 * @deprecated 2025.07 Use `\Friendica\Core\Addon\AddonHelper::getAddonDependencyConfig()` instead.
 	 *
 	 * @param string $configName The config-name (config-file at the static directory, like 'hooks' => '{addon}/static/hooks.config.php)
 	 *

--- a/src/Core/Addon/Model/AddonLoader.php
+++ b/src/Core/Addon/Model/AddonLoader.php
@@ -15,7 +15,7 @@ use Friendica\Util\Strings;
 use Psr\Log\LoggerInterface;
 
 /**
- * @deprecated 2025.02 Use implementation of `\Friendica\Core\Addon\AddonHelper` instead.
+ * @deprecated 2025.07 Use implementation of `\Friendica\Core\Addon\AddonHelper` instead.
  */
 class AddonLoader implements ICanLoadAddons
 {
@@ -27,18 +27,18 @@ class AddonLoader implements ICanLoadAddons
 
 	public function __construct(string $basePath, IManageConfigValues $config)
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$this->basePath = $basePath;
 		$this->config   = $config;
 	}
 
 	/**
-	 * @deprecated 2025.02 Use `\Friendica\Core\Addon\AddonHelper::getAddonDependencyConfig()` instead.
+	 * @deprecated 2025.07 Use `\Friendica\Core\Addon\AddonHelper::getAddonDependencyConfig()` instead.
 	 */
 	public function getActiveAddonConfig(string $configName): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use `\Friendica\Core\Addon\AddonHelper::getAddonDependencyConfig()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use `\Friendica\Core\Addon\AddonHelper::getAddonDependencyConfig()` instead.', E_USER_DEPRECATED);
 
 		$addons       = array_keys(array_filter($this->config->get('addons') ?? []));
 		$returnConfig = [];
@@ -63,14 +63,14 @@ class AddonLoader implements ICanLoadAddons
 				foreach ($config as $classname => $rule) {
 					if ($classname === LoggerInterface::class) {
 						@trigger_error(sprintf(
-							'Providing a strategy for `%s` is deprecated since 2025.02 and will stop working in 5 months, please provide an implementation for `%s` via `dependency.config.php` and remove the `strategies.config.php` file in the `%s` addon.',
+							'Providing a strategy for `%s` is deprecated since 2025.07 and will stop working in 5 months, please provide an implementation for `%s` via `dependency.config.php` and remove the `strategies.config.php` file in the `%s` addon.',
 							$classname,
 							LoggerFactory::class,
 							$addonName,
 						), \E_USER_DEPRECATED);
 					} else {
 						@trigger_error(sprintf(
-							'Providing strategies for `%s` via addons is deprecated since 2025.02 and will stop working in 5 months, please stop using this and remove the `strategies.config.php` file in the `%s` addon.',
+							'Providing strategies for `%s` via addons is deprecated since 2025.07 and will stop working in 5 months, please stop using this and remove the `strategies.config.php` file in the `%s` addon.',
 							$classname,
 							$addonName,
 						), \E_USER_DEPRECATED);

--- a/src/Core/Hooks/Util/StrategiesFileManager.php
+++ b/src/Core/Hooks/Util/StrategiesFileManager.php
@@ -84,7 +84,7 @@ class StrategiesFileManager
 		}
 
 		/**
-		 * @deprecated 2025.02 Providing strategies via addons is deprecated and will be removed in 5 months.
+		 * @deprecated 2025.07 Providing strategies via addons is deprecated and will be removed in 5 months.
 		 */
 		$this->config = array_merge_recursive($config, $this->getActiveAddonConfig());
 	}
@@ -113,14 +113,14 @@ class StrategiesFileManager
 			foreach ($config as $classname => $rule) {
 				if ($classname === LoggerInterface::class) {
 					@trigger_error(sprintf(
-						'Providing a strategy for `%s` is deprecated since 2025.02 and will stop working in 5 months, please provide an implementation for `%s` via `dependency.config.php` and remove the `strategies.config.php` file in the `%s` addon.',
+						'Providing a strategy for `%s` is deprecated since 2025.07 and will stop working in 5 months, please provide an implementation for `%s` via `dependency.config.php` and remove the `strategies.config.php` file in the `%s` addon.',
 						$classname,
 						LoggerFactory::class,
 						$addonName,
 					), \E_USER_DEPRECATED);
 				} else {
 					@trigger_error(sprintf(
-						'Providing strategies for `%s` via addons is deprecated since 2025.02 and will stop working in 5 months, please stop using this and remove the `strategies.config.php` file in the `%s` addon.',
+						'Providing strategies for `%s` via addons is deprecated since 2025.07 and will stop working in 5 months, please stop using this and remove the `strategies.config.php` file in the `%s` addon.',
 						$classname,
 						$addonName,
 					), \E_USER_DEPRECATED);

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Logger functions
  *
- * @deprecated 2025.02 Use constructor injection or `DI::logger()` instead
+ * @deprecated 2025.07 Use constructor injection or `DI::logger()` instead
  */
 class Logger
 {
@@ -34,7 +34,7 @@ class Logger
 	 */
 	public static function emergency(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->emergency($message, $context);
 	}
@@ -53,7 +53,7 @@ class Logger
 	 */
 	public static function alert(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->alert($message, $context);
 	}
@@ -71,7 +71,7 @@ class Logger
 	 */
 	public static function critical(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->critical($message, $context);
 	}
@@ -88,7 +88,7 @@ class Logger
 	 */
 	public static function error(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->error($message, $context);
 	}
@@ -107,7 +107,7 @@ class Logger
 	 */
 	public static function warning(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->warning($message, $context);
 	}
@@ -123,7 +123,7 @@ class Logger
 	 */
 	public static function notice(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->notice($message, $context);
 	}
@@ -142,7 +142,7 @@ class Logger
 	 */
 	public static function info(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->info($message, $context);
 	}
@@ -158,7 +158,7 @@ class Logger
 	 */
 	public static function debug(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->debug($message, $context);
 	}

--- a/src/Core/Logger/Factory/AbstractLoggerTypeFactory.php
+++ b/src/Core/Logger/Factory/AbstractLoggerTypeFactory.php
@@ -13,7 +13,7 @@ use Psr\Log\LogLevel;
 /**
  * Abstract class for creating logger types, which includes common necessary logic/content
  *
- * @deprecated 2025.02 Implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead
+ * @deprecated 2025.07 Implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead
  */
 abstract class AbstractLoggerTypeFactory
 {
@@ -27,7 +27,7 @@ abstract class AbstractLoggerTypeFactory
 	 */
 	public function __construct(IHaveCallIntrospections $introspection, string $channel)
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
 
 		$this->channel       = $channel;
 		$this->introspection = $introspection;

--- a/src/Core/Logger/Factory/DelegatingLoggerFactory.php
+++ b/src/Core/Logger/Factory/DelegatingLoggerFactory.php
@@ -48,10 +48,10 @@ final class DelegatingLoggerFactory implements LoggerFactory
 		$factoryName = $this->config->get('system', 'logger_config') ?? '';
 
 		/**
-		 * @deprecated 2025.02 The value `monolog` for `system.logger_config` inside the `config/local.config.php` file is deprecated, please use `stream` or `syslog` instead.
+		 * @deprecated 2025.07 The value `monolog` for `system.logger_config` inside the `config/local.config.php` file is deprecated, please use `stream` or `syslog` instead.
 		 */
 		if ($factoryName === 'monolog') {
-			@trigger_error('The config `system.logger_config` with value `monolog` is deprecated since 2025.02 and will stop working in 5 months, please change the value to `stream` or `syslog` in the `config/local.config.php` file.', \E_USER_DEPRECATED);
+			@trigger_error('The config `system.logger_config` with value `monolog` is deprecated since 2025.07 and will stop working in 5 months, please change the value to `stream` or `syslog` in the `config/local.config.php` file.', \E_USER_DEPRECATED);
 
 			$factoryName = 'stream';
 		}

--- a/src/Core/Logger/Factory/Logger.php
+++ b/src/Core/Logger/Factory/Logger.php
@@ -19,7 +19,7 @@ use Throwable;
 /**
  * The logger factory for the core logging instances
  *
- * @deprecated 2025.02 Implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead
+ * @deprecated 2025.07 Implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead
  */
 class Logger
 {
@@ -28,7 +28,7 @@ class Logger
 
 	public function __construct(string $channel = LogChannel::DEFAULT)
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
 
 		$this->channel = $channel;
 	}

--- a/src/Core/Logger/Factory/StreamLogger.php
+++ b/src/Core/Logger/Factory/StreamLogger.php
@@ -20,7 +20,7 @@ use Psr\Log\NullLogger;
 /**
  * The logger factory for the StreamLogger instance
  *
- * @deprecated 2025.02 Implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead
+ * @deprecated 2025.07 Implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead
  * @see StreamLoggerFactory
  * @see StreamLoggerClass
  */
@@ -40,7 +40,7 @@ class StreamLogger extends AbstractLoggerTypeFactory
 	 */
 	public function create(IManageConfigValues $config, string $logfile = null, string $channel = null): LoggerInterface
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
 
 		$fileSystem = new FileSystem();
 

--- a/src/Core/Logger/Factory/SyslogLogger.php
+++ b/src/Core/Logger/Factory/SyslogLogger.php
@@ -16,7 +16,7 @@ use Psr\Log\LoggerInterface;
 /**
  * The logger factory for the SyslogLogger instance
  *
- * @deprecated 2025.02 Implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead
+ * @deprecated 2025.07 Implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead
  * @see SyslogLoggerFactory
  * @see SyslogLoggerClass
  */
@@ -33,7 +33,7 @@ class SyslogLogger extends AbstractLoggerTypeFactory
 	 */
 	public function create(IManageConfigValues $config): LoggerInterface
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.02 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
 
 		$logOpts     = $config->get('system', 'syslog_flags')    ?? SyslogLoggerClass::DEFAULT_FLAGS;
 		$logFacility = $config->get('system', 'syslog_facility') ?? SyslogLoggerClass::DEFAULT_FACILITY;

--- a/src/DI.php
+++ b/src/DI.php
@@ -332,13 +332,13 @@ abstract class DI
 	}
 
 	/**
-	 * @deprecated 2025.02 Use `DI::loggerManager()` and `DI::logger()` instead
+	 * @deprecated 2025.07 Use `DI::loggerManager()` and `DI::logger()` instead
 	 *
 	 * @return \Friendica\Core\Logger\Type\WorkerLogger
 	 */
 	public static function workerLogger()
 	{
-		@trigger_error('`' . __METHOD__ . '()` is deprecated since 2025.02 and will be removed after 5 months, use `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('`' . __METHOD__ . '()` is deprecated since 2025.07 and will be removed after 5 months, use `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		return self::$dice->create(Core\Logger\Type\WorkerLogger::class);
 	}
@@ -798,7 +798,7 @@ abstract class DI
 
 	/**
 	 * @internal The EventDispatcher should never called outside of the core, like in addons or themes
-	 * @deprecated 2025.02 Use constructor injection instead
+	 * @deprecated 2025.07 Use constructor injection instead
 	 */
 	public static function eventDispatcher(): \Psr\EventDispatcher\EventDispatcherInterface
 	{

--- a/src/Module/Moderation/Report/Create.php
+++ b/src/Module/Moderation/Report/Create.php
@@ -269,7 +269,7 @@ class Create extends BaseModule
 		$tpl = Renderer::getMarkupTemplate('moderation/report/create/summary.tpl');
 
 		$forward_translation = $this->t('Would you like to forward this report to the remote server?');
-		// @deprecated 2025.04 this translation is scheduled for removal as a new translation has been added without the typo
+		// @deprecated 2025.07 this translation is scheduled for removal as a new translation has been added without the typo
 		$forward_translation = $this->t('Would you ike to forward this report to the remote server?');
 
 		return Renderer::replaceMacros($tpl, [

--- a/src/Module/Settings/Channels.php
+++ b/src/Module/Settings/Channels.php
@@ -194,7 +194,7 @@ class Channels extends BaseSettings
 		$t = Renderer::getMarkupTemplate('settings/channels.tpl');
 
 		$exclude_tags_translation = $this->t('Comma separated list of tags. If a post contain any of these tags, then it will not be part of this channel.');
-		// @deprecated 2025.04 this translation is scheduled for removal as a new translation has been added without the typo
+		// @deprecated 2025.07 this translation is scheduled for removal as a new translation has been added without the typo
 		$exclude_tags_translation = $this->t('Comma separated list of tags. If a post contain any of these tags, then it will not be part of nthis channel.');
 
 		return Renderer::replaceMacros($t, [

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -340,7 +340,7 @@ return [
 
 		// logger_config (String)
 		// Sets the logging adapter of Friendica globally (syslog, stream)
-		// @deprecated 2025.02 The value `monolog` is deprecated, please use `stream` or `syslog` instead.
+		// @deprecated 2025.07 The value `monolog` is deprecated, please use `stream` or `syslog` instead.
 		'logger_config' => 'stream',
 
 		// syslog_flags (Integer)


### PR DESCRIPTION
Because of the new `2025.07-rc` branch I assume that `2025.07` will be the next release version. This PR adjusts all deprecation messages to this version.