### PR TITLE
Fix one nav icon sometimes missing, make link not block

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -111,6 +111,7 @@ class Nav
 			'$banner'             => $nav_info['banner'],
 			'$emptynotifications' => $this->l10n->t('Nothing new here'),
 			'$userinfo'           => $nav_info['userinfo'],
+			'$nickname'           => $this->session->getLocalUserNickname(),
 			'$sel'                => self::$selected,
 			'$apps'               => $this->getAppMenu(),
 			'$home'               => $this->l10n->t('Home'),

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1405,6 +1405,9 @@ aside #circle-sidebar li .circle-edit-tool:first-child {
 	width: 75px;
 	border-radius: 4px;
 }
+.contact-block-h4 {
+	display: inline-block;
+}
 
 /* Tag cloud widget */
 .tagblock.widget > .tag-cloud {

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -202,7 +202,7 @@
 											<a role="menuitem" class="{{$usermenu.2}}" href="{{$usermenu.0}}"
 												title="{{$usermenu.3}}">
 
-												{{if $usermenu.0|str_ends_with:$userinfo.name}}
+												{{if $usermenu.0|str_ends_with:$nickname}}
 													<i class="fa fa-commenting"></i>
 												{{elseif $usermenu.0|str_ends_with:"/profile"}}
 													<i class="fa fa-user"></i>


### PR DESCRIPTION
Fixes two small things I've noticed on develop/rc branch related to my own changes (#14964 and #14982) :
1. The contacts link had a block element inside it (h4) so the link extended to fill the entire width of the menu, so you could click to the right of the text and still follow the link. Not ideal.
2. The icon in the personal menu was set based on a check for the display name in the URL rather than the nickname, so the icon only appeared when they're the same. Now it checks for nickname instead, which is actually what's in the URL.