### PR TITLE
[INVALID] Fixed self::atProtocol() in Probe class

### DIFF
--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -734,7 +734,7 @@ class Probe
 		$parts = parse_url($uri);
 		if (empty($parts['scheme']) && empty($parts['host']) && (empty($parts['path']) || strpos($parts['path'], '@') === false)) {
 			DI::logger()->info('URI was not detectable, probe for AT Protocol now', ['uri' => $uri]);
-			return self::atProtocol($uri);
+			return DI::atProtocol($uri);
 		}
 
 		// If the URI starts with "mailto:" then jump directly to the mail detection
@@ -758,7 +758,7 @@ class Probe
 		}
 
 		if (empty($data)) {
-			$data = self::atProtocol($uri);
+			$data = DI::atProtocol($uri);
 			if (!empty($data)) {
 				return $data;
 			}


### PR DESCRIPTION
Fixed self::atProtocol() in Probe class, needs to be directly `DI::atProtocol()`

See error:

> 2025-06-25T01:59:03Z worker [ERROR]: Uncaught exception in worker execution {"class":"Error","message":"Call to undefined method Friendica\\DI::atProtocol()","code":0,"file":"/var/www/.../src/Network/Probe.php:1713","trace":"#0 /var/www/.../src/Network/Probe.php(761): Friendica\\Network\\Probe::atProtocol()\n#1 /var/www/.../src/Network/Probe.php(377): Friendica\\Network\\Probe::detect()\n#2 /var/www/.../src/Model/Contact.php(1349): Friendica\\Network\\Probe::uri()\n#3 /var/www/.../src/Model/Tag.php(199): Friendica\\Model\\Contact::getIdForURL()\n#4 /var/www/.../src/Protocol/ActivityPub/Processor.php(1347): Friendica\\Model\\Tag::getTargetType()\n#5 /var/www/.../src/Protocol/ActivityPub/Processor.php(919): Friendica\\Protocol\\ActivityPub\\Processor::storeReceivers()\n#6 /var/www/.../src/Protocol/ActivityPub/Processor.php(487): Friendica\\Protocol\\ActivityPub\\Processor::processContent()\n#7 /var/www/.../src/Protocol/ActivityPub/Processor.php(690): Friendica\\Protocol\\ActivityPub\\Processor::createItem()\n#8 /var/www/.../src/Protocol/ActivityPub/Receiver.php(843): Friendica\\Protocol\\ActivityPub\\Processor::createActivity()\n#9 /var/www/.../src/Protocol/ActivityPub/Queue.php(239): Friendica\\Protocol\\ActivityPub\\Receiver::routeActivities()\n#10 /var/www/.../src/Worker/ProcessQueue.php(39): Friendica\\Protocol\\ActivityPub\\Queue::process()\n#11 [internal function]: Friendica\\Worker\\ProcessQueue::execute()\n#12 /var/www/.../src/Core/Worker.php(572): call_user_func_array()\n#13 /var/www/.../src/Core/Worker.php(386): Friendica\\Core\\Worker::execFunction()\n#14 /var/www/.../src/Core/Worker.php(121): Friendica\\Core\\Worker::execute()\n#15 /var/www/.../bin/worker.php(87): Friendica\\Core\\Worker::processQueue()\n#16 {main}","previous":null,"worker_id":"cac3a88","worker_cmd":"ProcessQueue"} - {"file":"Worker.php","line":577,"function":"execFunction","request-id":"685b5777d3206","stack":"Worker::execFunction (386), Worker::execute (121), Worker::processQueue (87)","uid":"0f5d40","process_id":31780}

These changes are reverted now.