### PR TITLE
Trending tags UI adjustments, for consistency with the other widgets

### DIFF
--- a/src/Content/Widget/TrendingTags.php
+++ b/src/Content/Widget/TrendingTags.php
@@ -36,7 +36,8 @@ class TrendingTags
 
 		$tpl = Renderer::getMarkupTemplate('widget/trending_tags.tpl');
 		$o   = Renderer::replaceMacros($tpl, [
-			'$title'    => DI::l10n()->tt('Trending Tags (last %d hour)', 'Trending Tags (last %d hours)', $period),
+			'$title'    => DI::l10n()->t('Trending Tags'),
+			'$subtitle' => DI::l10n()->tt('(%d hour)', '(%d hours)', $period),
 			'$more'     => DI::l10n()->t('More Trending Tags'),
 			'$showmore' => DI::l10n()->t('Show More'),
 			'$showless' => DI::l10n()->t('Show Less'),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-07 12:09+0200\n"
+"POT-Creation-Date: 2025-07-09 20:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1773,7 +1773,7 @@ msgstr ""
 msgid "Include or exclude posts from subscribed accounts. This widget is not visible on all channels."
 msgstr ""
 
-#: src/Content/Feature.php:135
+#: src/Content/Feature.php:135 src/Content/Widget/TrendingTags.php:39
 msgid "Trending Tags"
 msgstr ""
 
@@ -2435,22 +2435,22 @@ msgstr ""
 msgid "Remove term"
 msgstr ""
 
-#: src/Content/Widget/TrendingTags.php:39
+#: src/Content/Widget/TrendingTags.php:40
 #, php-format
-msgid "Trending Tags (last %d hour)"
-msgid_plural "Trending Tags (last %d hours)"
+msgid "(%d hour)"
+msgid_plural "(%d hours)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/Widget/TrendingTags.php:40
+#: src/Content/Widget/TrendingTags.php:41
 msgid "More Trending Tags"
 msgstr ""
 
-#: src/Content/Widget/TrendingTags.php:41
+#: src/Content/Widget/TrendingTags.php:42
 msgid "Show More"
 msgstr ""
 
-#: src/Content/Widget/TrendingTags.php:42
+#: src/Content/Widget/TrendingTags.php:43
 msgid "Show Less"
 msgstr ""
 

--- a/view/templates/widget/trending_tags.tpl
+++ b/view/templates/widget/trending_tags.tpl
@@ -6,15 +6,17 @@
   *}}
 <nav>
 	<span id="trending-tags-sidebar-inflated" class="widget inflated fakelink">
-		<button class="fakelink" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');" aria-expanded="false">
-			<h3>{{$title}}</h3>
+		<button class="fakelink" style="display: flex; justify-content: space-between; width: 100%;" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');" aria-expanded="false">
+			<h3 style="text-align: left;">{{$title}}</h3>
+			<small>{{$subtitle}}</small>
 		</button>
 	</span>
 	<div id="trending-tags-sidebar" class="widget">
-		<button class="fakelink" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');">
-			<h3>{{$title}}</h3>
+		<button class="fakelink" style="display: flex; justify-content: space-between; width: 100%;" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');">
+			<h3 style="text-align: left;">{{$title}}</h3>
+			<small>{{$subtitle}}</small>
 		</button>
-		<ul id="tags-list" style="list-style-type: none; padding: 0; margin: 0;">
+		<ul id="tags-list">
 			{{section name=ol loop=$tags max=10}}
 				<li style="margin-bottom: 5px;">
 					<a href="search?tag={{$tags[ol].term}}" style="text-decoration: none; color: inherit;">
@@ -30,7 +32,7 @@
 					<span id="link-text">{{$showmore}}</span>
 				</a>
 			</div>
-			<ul id="more-tags" style="display:none; list-style-type: none; padding: 0; margin: 0;">
+			<ul id="more-tags" style="display:none;">
 				{{section name=ul loop=$tags start=10}}
 					<li style="margin-bottom: 5px;">
 						<a href="search?tag={{$tags[ul].term}}" style="text-decoration: none; color: inherit;">


### PR DESCRIPTION
Right now on the release branch ,trending tags appears to be indented differently than the other widget blocks. Both the title and the list of tags. Also, as a result, the hover line isn't along the edge like it is for the other widgets.

This PR tries to fix that.

Also changed the title of the widget so it fits easily on a single line in English, hopefully also fitting better into such limited space in other languages

Before:
![image](https://github.com/user-attachments/assets/17c4e02d-be20-4a81-be3c-650aae162175)

After:
![image](https://github.com/user-attachments/assets/c2dcba78-c084-49b2-b3dd-f67eb0671815)