### PR TITLE
Minor visual adjustments to the ALT tag

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -817,15 +817,16 @@ summary.wall-item-summary {
 
 /* Add alt tag indicators to the relevant images */
 a:has(img.has-alt-description)::after {
-	background: lightgray;
+	background: rgba(0, 0, 0, 0.69);
 	border-radius: 4px;
-	color: black;
+	color: #eee;
 	content: "ALT";
+	font-size: 12px;
 	font-weight: bold;
-	padding: 3px 8px;
+	padding: 4px 5px;
 	position: absolute;
-	bottom: 10px;
-	right: 10px;
+	bottom: 8px;
+	right: 8px;
 }
 
 #change-profile-picture {


### PR DESCRIPTION
Based on the discussions in #15011

...this arguably makes the ALT tag slightly less visually dominant on most images, by being a little bit smaller, with a slightly transparent background, less bright and closer to the edge.

Before:
<img width="560" height="648" alt="image" src="https://github.com/user-attachments/assets/9637ae21-a15d-4146-8749-58e7b4eb35d0" />

After:
<img width="550" height="639" alt="image" src="https://github.com/user-attachments/assets/10800a7c-66ce-4149-9557-dd6d75d144b1" />

Mastodon for comparison:
<img width="573" height="708" alt="image" src="https://github.com/user-attachments/assets/95869458-e96d-40b1-a4d5-c7473a66f934" />