### PR TITLE
Add verified checkmark to homepage url on main profile page

### DIFF
--- a/view/templates/profile/profile.tpl
+++ b/view/templates/profile/profile.tpl
@@ -71,7 +71,7 @@
 	<dl id="aprofile-homepage" class="row {{$basic_fields.homepage.class|default:'aprofile'}}">
 		<hr class="profile-separator">
 		<dt class="col-lg-4 col-md-4 col-sm-4 col-xs-12 profile-label-name text-muted">{{$basic_fields.homepage.label}}</dt>
-		<dd class="col-lg-8 col-md-8 col-sm-8 col-xs-12 profile-entry">{{$basic_fields.homepage.value nofilter}}</dd>
+		<dd class="col-lg-8 col-md-8 col-sm-8 col-xs-12 profile-entry">{{$basic_fields.homepage.value nofilter}}{{if $profile.homepage_verified}} <span title="{{$homepage_verified}}">✔</span>{{/if}}</dd>
 	</dl>
 {{/if}}
 


### PR DESCRIPTION
Currently if you've self-verified your homepage URL it only gets the verified checkmark in the sidebar vcard but not in the main profile page. This adds the checkmark there as well if your homepage is verified.

Note that $homepage_verified is empty so the span won't have a title. I have changes to another file to fix that. But I don't know how to merge commits into a single PR on GitHub.