### PR TITLE
Remove duplicate site name from profiles in HTML title

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -213,7 +213,7 @@ class Profile
 
 		$appHelper->setProfileOwner($profile['uid']);
 
-		DI::page()['title'] = $profile['name'] . ' @ ' . DI::config()->get('config', 'sitename');
+		DI::page()['title'] = $profile['name'];
 
 		if (!DI::userSession()->getLocalUserId()) {
 			$appHelper->setCurrentTheme($profile['theme']);


### PR DESCRIPTION
The site name is currently inserted into the title for all pages in Page.php, and profiles/contacts also inserts it, after the username. Thus currently it's written twice on those pages.

This small PR removes the one inserted by profiles/contacts, leaving just the global one.

Before:
<img width="658" height="44" alt="image" src="https://github.com/user-attachments/assets/e73ce512-1a41-4d53-a122-baa75c03457f" />

After:
<img width="459" height="28" alt="image" src="https://github.com/user-attachments/assets/f204ace5-6d87-4cd7-9194-2f130168c7b5" />

Note: I'm generally setting all my branches to target the RC branch just so it's possible to merge them easily - of course they shouldn't delay the release either, so when you want to go on with the release, I'll just switch any remaining back to `develop`.