### PR TITLE
Add the BBCode selection [attachment] to the editor

### DIFF
--- a/view/js/autocomplete.js
+++ b/view/js/autocomplete.js
@@ -370,7 +370,7 @@ function string2bb(element) {
 
 	$.fn.bbco_autocomplete = function(type) {
 		if (type === 'bbcode') {
-			var open_close_elements = ['bold', 'italic', 'underline', 'overline', 'strike', 'quote', 'code', 'spoiler', 'map', 'img', 'url', 'audio', 'video', 'embed', 'youtube', 'vimeo', 'list', 'ul', 'ol', 'li', 'table', 'tr', 'th', 'td', 'center', 'color', 'font', 'size', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'nobb', 'noparse', 'pre', 'abstract', 'share'];
+			var open_close_elements = ['bold', 'italic', 'underline', 'overline', 'strike', 'quote', 'code', 'spoiler', 'map', 'img', 'url', 'audio', 'video', 'embed', 'youtube', 'vimeo', 'list', 'ul', 'ol', 'li', 'table', 'tr', 'th', 'td', 'center', 'color', 'font', 'size', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'nobb', 'noparse', 'pre', 'abstract', 'share', 'attachment'];
 			var open_elements = ['*', 'hr'];
 
 			var elements = open_close_elements.concat(open_elements);

--- a/view/templates/item/compose.tpl
+++ b/view/templates/item/compose.tpl
@@ -63,38 +63,37 @@
 					<textarea id="comment-edit-text-{{$id}}" class="comment-edit-text form-control text-autosize expandable-textarea" name="body" placeholder="{{$l10n.default}}" rows="18" tabindex="3" dir="auto" onkeydown="sendOnCtrlEnter(event, 'comment-edit-submit-{{$id}}')">{{$body}}</textarea>
 				</p>
 			</div>
-			<p class="comment-edit-submit-wrapper">
-{{if $type == 'post'}}
-				<span class="form-inline">
-					<button type="button" name="permissions" class="btn btn-sm template-icon" id="toggle-permissions" title="{{$l10n.toggle_permissions_tooltip}}" onclick="togglePermissions()" style="margin-right: 10px;" tabindex="5">
-						<i class="fa fa-ellipsis-h"></i> {{$l10n.toggle_permissions}}
-					</button>
-					<input type="text" name="location" class="form-control" id="jot-location" value="{{$location}}" placeholder="{{$l10n.location_set}}" tabindex="6"/>
-                    			<button type="button" class="btn btn-sm template-icon" id="profile-location"
-						data-title-set="{{$l10n.location_set}}"
-						data-title-disabled="{{$l10n.location_disabled}}"
-						data-title-unavailable="{{$l10n.location_unavailable}}"
-						data-title-clear="{{$l10n.location_clear}}"
-						title="{{$l10n.location_set}}"
-						tabindex="7">
-						<i class="fa fa-map-marker" aria-hidden="true"></i>
-					</button>
-				</span>
-{{/if}}
-				<span id="profile-rotator-wrapper">
-					<img id="profile-rotator" src="images/rotator.gif" alt="{{$l10n.wait}}" title="{{$l10n.wait}}" style="display: none;" />
-				</span>
-				<span id="character-counter" class="grey text-info"></span>
-				<button type="button" class="btn btn-default" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}" tabindex="8"><i class="fa fa-eye"></i> {{$l10n.preview}}</button>
-				<button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="fa fa-envelope"></i> {{$l10n.submit}}</button>
-			</p>
+			<p class="comment-edit-submit-wrapper clearfix">
+				{{if $type == 'post'}}
+					<span class="pull-left">
+						<button type="button" name="permissions" class="btn btn-sm template-icon" id="toggle-permissions" title="{{$l10n.toggle_permissions_tooltip}}" onclick="togglePermissions()" style="margin-right: 10px;" tabindex="5">
+							<i class="fa fa-ellipsis-h"></i> {{$l10n.toggle_permissions}}
+						</button>
+						<input type="text" name="location" class="form-control d-inline-block" id="jot-location" value="{{$location}}" placeholder="{{$l10n.location_set}}" tabindex="6" style="width: auto; display: inline-block;" />
+						<button type="button" class="btn btn-sm template-icon" id="profile-location"
+							data-title-set="{{$l10n.location_set}}"
+							data-title-disabled="{{$l10n.location_disabled}}"
+							data-title-unavailable="{{$l10n.location_unavailable}}"
+							data-title-clear="{{$l10n.location_clear}}"
+							title="{{$l10n.location_set}}"
+							tabindex="7">
+							<i class="fa fa-map-marker" aria-hidden="true"></i>
+						</button>
+					</span>
+				{{/if}}
+		<span class="pull-right">
+			<span role="presentation" id="profile-rotator-wrapper">
+				<img role="presentation" id="profile-rotator" src="images/rotator.gif" alt="{{$l10n.wait}}" title="{{$l10n.wait}}" style="display: none;" />
+			</span>
+			<span role="presentation" id="character-counter" class="grey text-info"></span>
+			<button type="button" class="btn btn-default" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}" tabindex="8"><i class="fa fa-eye"></i> {{$l10n.preview}}</button>
+			<button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="fa fa-envelope"></i> {{$l10n.submit}}</button>
+		</span>
+		</p>
 
 			<div id="comment-edit-preview-{{$id}}" class="comment-edit-preview" style="display:none;"></div>
 
 			<div id="permissions-section" style="display: none;">
-			<script>
-				dzFactory.setupDropzone('#dropzone-{{$id}}', 'comment-edit-text-{{$id}}');
-			</script>
 {{if $type == 'post'}}
 			<h3>{{$l10n.visibility_title}}</h3>
 			{{$acl_selector nofilter}}
@@ -116,6 +115,8 @@
     </div>
 </div>
 <script>
+	dzFactory.setupDropzone('#dropzone-{{$id}}', 'comment-edit-text-{{$id}}');
+
 	document.addEventListener("DOMContentLoaded", function() {
 		var textareas = document.querySelectorAll(".expandable-textarea");
 


### PR DESCRIPTION
**Adds 'attachment' to the list of permitted BBCode commands for the editor.**

https://github.com/friendica/friendica/issues/15014

---

**Button positions in the Compose Editor**
The position of the buttons below the editor were previously placed on the right. The sandwitch and the position information were separated from the buttons for preview and send and placed on the left and right respectively.