### PR TITLE
Button positions in the Compose Editor

### DIFF
--- a/view/templates/item/compose.tpl
+++ b/view/templates/item/compose.tpl
@@ -63,15 +63,14 @@
 					<textarea id="comment-edit-text-{{$id}}" class="comment-edit-text form-control text-autosize expandable-textarea" name="body" placeholder="{{$l10n.default}}" rows="18" tabindex="3" dir="auto" onkeydown="sendOnCtrlEnter(event, 'comment-edit-submit-{{$id}}')">{{$body}}</textarea>
 				</p>
 			</div>
-			<p class="comment-edit-submit-wrapper">
-				<div class="left-section">
-					{{if $type == 'post'}}
-						<span role="presentation" class="form-inline">
-							<button type="button" name="permissions" class="btn btn-sm template-icon" id="toggle-permissions" title="{{$l10n.toggle_permissions_tooltip}}" onclick="togglePermissions()" style="margin-right: 10px;" tabindex="5">
-								<i class="fa fa-ellipsis-h"></i> {{$l10n.toggle_permissions}}
-							</button>
-							<input type="text" name="location" class="form-control" id="jot-location" value="{{$location}}" placeholder="{{$l10n.location_set}}" tabindex="6"/>
-                    			<button type="button" class="btn btn-sm template-icon" id="profile-location"
+			<p class="comment-edit-submit-wrapper clearfix">
+				{{if $type == 'post'}}
+					<span class="pull-left">
+						<button type="button" name="permissions" class="btn btn-sm template-icon" id="toggle-permissions" title="{{$l10n.toggle_permissions_tooltip}}" onclick="togglePermissions()" style="margin-right: 10px;" tabindex="5">
+							<i class="fa fa-ellipsis-h"></i> {{$l10n.toggle_permissions}}
+						</button>
+						<input type="text" name="location" class="form-control d-inline-block" id="jot-location" value="{{$location}}" placeholder="{{$l10n.location_set}}" tabindex="6" style="width: auto; display: inline-block;" />
+						<button type="button" class="btn btn-sm template-icon" id="profile-location"
 							data-title-set="{{$l10n.location_set}}"
 							data-title-disabled="{{$l10n.location_disabled}}"
 							data-title-unavailable="{{$l10n.location_unavailable}}"
@@ -80,23 +79,25 @@
 							tabindex="7">
 							<i class="fa fa-map-marker" aria-hidden="true"></i>
 						</button>
-						</span>
-					{{/if}}
-				</div>
-				<div class="right-section">
-					<span role="presentation" id="profile-rotator-wrapper">
-						<img role="presentation" id="profile-rotator" src="images/rotator.gif" alt="{{$l10n.wait}}" title="{{$l10n.wait}}" style="display: none;" />
 					</span>
-					<span role="presentation" id="character-counter" class="grey text-info"></span>
-					<button type="button" class="btn btn-default" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}" tabindex="8"><i class="fa fa-eye"></i> {{$l10n.preview}}</button>
-					<button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="fa fa-envelope"></i> {{$l10n.submit}}</button>
-				</div>
-			</p>
-			<div id="comment-edit-preview-{{$id}}" class="comment-edit-preview" style="display:none; margin-top: 50px;"></div>
+				{{/if}}
+		<span class="pull-right">
+			<span role="presentation" id="profile-rotator-wrapper">
+				<img role="presentation" id="profile-rotator" src="images/rotator.gif" alt="{{$l10n.wait}}" title="{{$l10n.wait}}" style="display: none;" />
+			</span>
+			<span role="presentation" id="character-counter" class="grey text-info"></span>
+			<button type="button" class="btn btn-default" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}" tabindex="8"><i class="fa fa-eye"></i> {{$l10n.preview}}</button>
+			<button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="fa fa-envelope"></i> {{$l10n.submit}}</button>
+		</span>
+		</p>
+
+			<div id="comment-edit-preview-{{$id}}" class="comment-edit-preview" style="display:none;"></div>
+
 			<div id="permissions-section" style="display: none;">
 {{if $type == 'post'}}
 			<h3>{{$l10n.visibility_title}}</h3>
 			{{$acl_selector nofilter}}
+
 			<div class="jotplugins">
 				{{$jotplugins nofilter}}
 			</div>
@@ -113,26 +114,6 @@
         </form>
     </div>
 </div>
-<style>
-.left-section {
-    float: left;
-    width: 50%;
-}
-
-.right-section {
-    float: right;
-    width: 50%;
-    text-align: right;
-}
-
-.comment-edit-submit-wrapper {
-    overflow: hidden; /* Clearfix to contain the floated elements */
-}
-
-.comment-edit-preview {
-    margin-top: 50px; /* Adjust the value as needed */
-}
-</style>
 <script>
 	dzFactory.setupDropzone('#dropzone-{{$id}}', 'comment-edit-text-{{$id}}');
 

--- a/view/templates/item/compose.tpl
+++ b/view/templates/item/compose.tpl
@@ -64,41 +64,39 @@
 				</p>
 			</div>
 			<p class="comment-edit-submit-wrapper">
-{{if $type == 'post'}}
-				<span class="form-inline">
-					<button type="button" name="permissions" class="btn btn-sm template-icon" id="toggle-permissions" title="{{$l10n.toggle_permissions_tooltip}}" onclick="togglePermissions()" style="margin-right: 10px;" tabindex="5">
-						<i class="fa fa-ellipsis-h"></i> {{$l10n.toggle_permissions}}
-					</button>
-					<input type="text" name="location" class="form-control" id="jot-location" value="{{$location}}" placeholder="{{$l10n.location_set}}" tabindex="6"/>
+				<div class="left-section">
+					{{if $type == 'post'}}
+						<span role="presentation" class="form-inline">
+							<button type="button" name="permissions" class="btn btn-sm template-icon" id="toggle-permissions" title="{{$l10n.toggle_permissions_tooltip}}" onclick="togglePermissions()" style="margin-right: 10px;" tabindex="5">
+								<i class="fa fa-ellipsis-h"></i> {{$l10n.toggle_permissions}}
+							</button>
+							<input type="text" name="location" class="form-control" id="jot-location" value="{{$location}}" placeholder="{{$l10n.location_set}}" tabindex="6"/>
                     			<button type="button" class="btn btn-sm template-icon" id="profile-location"
-						data-title-set="{{$l10n.location_set}}"
-						data-title-disabled="{{$l10n.location_disabled}}"
-						data-title-unavailable="{{$l10n.location_unavailable}}"
-						data-title-clear="{{$l10n.location_clear}}"
-						title="{{$l10n.location_set}}"
-						tabindex="7">
-						<i class="fa fa-map-marker" aria-hidden="true"></i>
-					</button>
-				</span>
-{{/if}}
-				<span id="profile-rotator-wrapper">
-					<img id="profile-rotator" src="images/rotator.gif" alt="{{$l10n.wait}}" title="{{$l10n.wait}}" style="display: none;" />
-				</span>
-				<span id="character-counter" class="grey text-info"></span>
-				<button type="button" class="btn btn-default" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}" tabindex="8"><i class="fa fa-eye"></i> {{$l10n.preview}}</button>
-				<button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="fa fa-envelope"></i> {{$l10n.submit}}</button>
+							data-title-set="{{$l10n.location_set}}"
+							data-title-disabled="{{$l10n.location_disabled}}"
+							data-title-unavailable="{{$l10n.location_unavailable}}"
+							data-title-clear="{{$l10n.location_clear}}"
+							title="{{$l10n.location_set}}"
+							tabindex="7">
+							<i class="fa fa-map-marker" aria-hidden="true"></i>
+						</button>
+						</span>
+					{{/if}}
+				</div>
+				<div class="right-section">
+					<span role="presentation" id="profile-rotator-wrapper">
+						<img role="presentation" id="profile-rotator" src="images/rotator.gif" alt="{{$l10n.wait}}" title="{{$l10n.wait}}" style="display: none;" />
+					</span>
+					<span role="presentation" id="character-counter" class="grey text-info"></span>
+					<button type="button" class="btn btn-default" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}" tabindex="8"><i class="fa fa-eye"></i> {{$l10n.preview}}</button>
+					<button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="fa fa-envelope"></i> {{$l10n.submit}}</button>
+				</div>
 			</p>
-
-			<div id="comment-edit-preview-{{$id}}" class="comment-edit-preview" style="display:none;"></div>
-
+			<div id="comment-edit-preview-{{$id}}" class="comment-edit-preview" style="display:none; margin-top: 50px;"></div>
 			<div id="permissions-section" style="display: none;">
-			<script>
-				dzFactory.setupDropzone('#dropzone-{{$id}}', 'comment-edit-text-{{$id}}');
-			</script>
 {{if $type == 'post'}}
 			<h3>{{$l10n.visibility_title}}</h3>
 			{{$acl_selector nofilter}}
-
 			<div class="jotplugins">
 				{{$jotplugins nofilter}}
 			</div>
@@ -115,7 +113,29 @@
         </form>
     </div>
 </div>
+<style>
+.left-section {
+    float: left;
+    width: 50%;
+}
+
+.right-section {
+    float: right;
+    width: 50%;
+    text-align: right;
+}
+
+.comment-edit-submit-wrapper {
+    overflow: hidden; /* Clearfix to contain the floated elements */
+}
+
+.comment-edit-preview {
+    margin-top: 50px; /* Adjust the value as needed */
+}
+</style>
 <script>
+	dzFactory.setupDropzone('#dropzone-{{$id}}', 'comment-edit-text-{{$id}}');
+
 	document.addEventListener("DOMContentLoaded", function() {
 		var textareas = document.querySelectorAll(".expandable-textarea");
 


### PR DESCRIPTION
The position of the buttons below the editor were previously placed on the right. The sandwitch and the position information were separated from the buttons for preview and send and placed on the left and right respectively.

old
![2025-07-14_11-57](https://github.com/user-attachments/assets/a5d4644c-dda4-440a-a0ec-9c3c26829591)

new
![2025-07-14_11-59](https://github.com/user-attachments/assets/7d5d8325-b89a-4831-8578-5f1b087cddf4)
