### PR TITLE
Turn alt tags into buttons showing the alt text

### DIFF
--- a/src/Content/Image.php
+++ b/src/Content/Image.php
@@ -12,6 +12,7 @@ use Friendica\Content\Image\Entity\MasonryImage;
 use Friendica\Content\Post\Collection\PostMedias;
 use Friendica\Core\Renderer;
 use Friendica\Network\HTTPException\ServiceUnavailableException;
+use Friendica\DI;
 
 class Image
 {
@@ -24,9 +25,10 @@ class Image
 				$media = self::getHorizontalMasonryHtml($PostMediaImages);
 			} elseif (count($PostMediaImages) == 1) {
 				$media = Renderer::replaceMacros(Renderer::getMarkupTemplate('content/image/single_with_height_allocation.tpl'), [
-					'$image' => $PostMediaImages[0],
-					'$allocated_height' => $PostMediaImages[0]->getAllocatedHeight(),
+					'$image'               => $PostMediaImages[0],
+					'$allocated_height'    => $PostMediaImages[0]->getAllocatedHeight(),
 					'$allocated_max_width' => ($PostMediaImages[0]->previewWidth ?? $PostMediaImages[0]->width) . 'px',
+					'$alt_text_title'      => DI::l10n()->t('Alt text'),
 				]);
 			}
 		} else {
@@ -81,14 +83,14 @@ class Image
 					$PostMediaImages[] = $PostMediaImages[0];
 				}
 
-				$widths = [];
+				$widths  = [];
 				$heights = [];
 				foreach ($PostMediaImages as $PostMediaImage) {
 					if ($PostMediaImage->width && $PostMediaImage->height) {
-						$widths[] = $PostMediaImage->width;
+						$widths[]  = $PostMediaImage->width;
 						$heights[] = $PostMediaImage->height;
 					} else {
-						$widths[] = $PostMediaImage->previewWidth;
+						$widths[]  = $PostMediaImage->previewWidth;
 						$heights[] = $PostMediaImage->previewHeight;
 					}
 				}
@@ -130,7 +132,7 @@ class Image
 		);
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('content/image/horizontal_masonry.tpl'), [
-			'$rows' => $rows,
+			'$rows'        => $rows,
 			'$column_size' => $column_size,
 		]);
 	}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3374,6 +3374,7 @@ class Item
 						'$image'               => $PostMedia,
 						'$allocated_height'    => $PostMedia->getAllocatedHeight(),
 						'$allocated_max_width' => ($PostMedia->previewWidth ?? $PostMedia->width) . 'px',
+						'$alt_text_title'      => DI::l10n()->t('Alt text'),
 					]);
 				}, $s);
 			} else {

--- a/view/global.css
+++ b/view/global.css
@@ -816,17 +816,21 @@ summary.wall-item-summary {
 }
 
 /* Add alt tag indicators to the relevant images */
-a:has(img.has-alt-description)::after {
+.alt-tag-button {
 	background: rgba(0, 0, 0, 0.69);
+	border: none;
 	border-radius: 4px;
 	color: #eee;
-	content: "ALT";
 	font-size: 12px;
 	font-weight: bold;
 	padding: 4px 5px;
 	position: absolute;
 	bottom: 8px;
 	right: 8px;
+}
+
+.alt-tag-button:hover {
+	background: rgba(120, 120, 120, 1.00);
 }
 
 #change-profile-picture {

--- a/view/templates/content/image/single.tpl
+++ b/view/templates/content/image/single.tpl
@@ -10,7 +10,7 @@
 <figure>
 	<img src="{{$image->url}}" alt="{{$image->description}}" title="{{$image->description}}" {{if $image->description}}class="has-alt-description"{{else}}class="empty-description"{{/if}} loading="lazy">
 	{{if $image->description}}
-	<figcaption>{{$image->description}}</figcaption>
-    {{/if}}
+		<figcaption>{{$image->description}}</figcaption>
+	{{/if}}
 </figure>
 {{/if}}

--- a/view/templates/content/image/single_with_height_allocation.tpl
+++ b/view/templates/content/image/single_with_height_allocation.tpl
@@ -8,22 +8,27 @@
 	As a result, we need to add a wrapping element for non-flex (non-image grid) environments, mostly single-image cases.
  *}}
 {{if $allocated_max_width}}
-<div class="img-allocated-max-width" style="max-width: {{$allocated_max_width|default:"auto"}};">
+	<div class="img-allocated-max-width" style="max-width: {{$allocated_max_width|default:"auto"}};">
 {{/if}}
 
-<figure class="img-allocated-height" style="width: {{$allocated_width|default:"auto"}}; padding-bottom: {{$allocated_height}}">
-    {{if $image->preview}}
-		<a data-fancybox="uri-id-{{$image->uriId}}" href="{{$image->url}}">
-			<img src="{{$image->preview}}" alt="{{$image->description}}" title="{{$image->description}}" {{if $image->description}}class="has-alt-description"{{else}}class="empty-description"{{/if}} loading="lazy">
-		</a>
-    {{else}}
-		<img src="{{$image->url}}" alt="{{$image->description}}" title="{{$image->description}}" {{if $image->description}}class="has-alt-description"{{else}}class="empty-description"{{/if}} loading="lazy">
-        {{if $image->description}}
-		    <figcaption>{{$image->description}}</figcaption>
-        {{/if}}
-    {{/if}}
+	<figure class="img-allocated-height" style="width: {{$allocated_width|default:"auto"}}; padding-bottom: {{$allocated_height}}">
+		{{if $image->preview}}
+			<a data-fancybox="uri-id-{{$image->uriId}}" href="{{$image->url}}">
+				<img src="{{$image->preview}}" alt="{{$image->description}}" title="{{$image->description}}" {{if $image->description}}class="has-alt-description"{{else}}class="empty-description"{{/if}} loading="lazy">
+			</a>
+		{{else}}
+			<img src="{{$image->url}}" alt="{{$image->description}}" title="{{$image->description}}" {{if $image->description}}class="has-alt-description"{{else}}class="empty-description"{{/if}} loading="lazy">
+			{{if $image->description}}
+				<figcaption>{{$image->description}}</figcaption>
+			{{/if}}
+		{{/if}}
+		{{if $image->description}}
+			<button class="alt-tag-button" aria-hidden="true" data-toggle="popover" data-title="{{$alt_text_title}}" data-content="{{$image->description}}">
+				ALT
+			</button>
+		{{/if}}
 </figure>
 
 {{if $allocated_max_width}}
-</div>
+	</div>
 {{/if}}

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2138,6 +2138,23 @@ button[disabled] {
 	}
 }
 
+/* Alt tag popover */
+.img-allocated-height .popover, .img-allocated-height .popover-title {
+	backdrop-filter: blur(10px) saturate(180%) contrast(75%) brightness(70%);
+	background: rgba(0, 0, 0, 0.65);
+	box-shadow: rgba(0, 0, 0, 0.25) 0px 20px 25px -5px, rgba(0, 0, 0, 0.25) 0px 8px 10px -6px;
+	color: #eee;
+	margin-right: 12px;
+	max-width: 100%;
+}
+.img-allocated-height .popover.top > .arrow::after {
+	border-top-color: rgba(10, 10, 10, 0.75);
+}
+.img-allocated-height .popover-title {
+	border-bottom: none;
+	font-weight: bold;
+}
+
 /*
 * Comments
 */

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -157,6 +157,17 @@ $(document).ready(function () {
 		},
 	});
 
+	// initialize the Bootstrap popovers
+	$body.popover({
+		selector: '[data-toggle="popover"]',
+		trigger: "hover click",
+		placement: "top",
+		delay: {
+			show: 100,
+			hide: 100,
+		},
+	});
+
 	// initialize the bootstrap-select
 	$(".selectpicker").selectpicker();
 


### PR DESCRIPTION
This is an attempt to make the alt tags more useful, by rewriting them to be elements - specifically buttons - instead, which can be clicked or hovered to show the alt text, similar to what Mastodon does.

This is essentially additional changes on top of #15016, based on the discussions in #15011 and on friendica itself.

This required more code changes than the previous approach, though, so I could use some feedback and help in verifying it works as intended.

Right now this option to click it and view the alt text only works in Frio. Vier just shows the alt label text like before. Vier will still show the alt text when clicking to view the image in full size, though, so the icon just indicates there's alt text to find there.

It's using popovers, and currently it seems only Frio uses tooltips, which are quite similar to popovers, so I wasn't sure if Vier should use them or not, or some other approach should be used there. In general it seems Vier doesn't use JS much, perhaps intentionally.
I did try briefly to add it to main.js (so it should affect all themes) instead of frio's theme.js and it didn't activate them successfully, but that could likely  be solved. 

I'm thinking that perhaps this only needs to be shown on posted images - and it doesn't need to be shown in the preview(?), so maybe adding it to e.g. BBCode.php isn't necessary??
With these changes, the alt text CSS classes won't have any effect anymore, as I made my own conditional to add the button, as CSS alone, which was used before, would not be able to create a button with a hover/click effect on, so I don't know whether those classes should remain or be removed? (`has-alt-description` and possibly `empty-description`).

This is what they look like in Frio:
<img width="670" height="430" alt="image" src="https://github.com/user-attachments/assets/d085c10d-9b3f-40a7-b7d9-e3d6cfe824ee" />

...and if hovered/clicked:
<img width="668" height="441" alt="image" src="https://github.com/user-attachments/assets/e1914099-9fd7-4f34-938b-3c3e2c4045af" />

Vier - where the buttons currently can't be interacted with:
<img width="786" height="385" alt="image" src="https://github.com/user-attachments/assets/4637cc7f-269d-4f9c-bfdd-14fe4e47cdcf" />

Mastodon, for comparison:
<img width="585" height="780" alt="image" src="https://github.com/user-attachments/assets/4361e07a-23a8-49a8-8445-354497781d9f" />
IMO admittedly Mastodon's looks better, and perhaps it would be possible to get something similar with more tweaking, even with Bootstrap 3.4 popovers.