### PR TITLE
Issue 15025: Make post title larger again

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1839,7 +1839,6 @@ blockquote.shared_content {
 	margin: 0 0 5px;
 }
 .media-heading {
-	font-size: 14px;
 	margin: 0px;
 }
 .wall-item-name,
@@ -2625,7 +2624,7 @@ ul.viewcontact_wrapper > li {
 .contact-entry-checkbox {
 	margin-top: -20px;
 }
-.contact-wrapper .media-body .contact-entry-name h1.media-heading a {
+.contact-wrapper .media-body .contact-entry-name h4.media-heading a {
 	font-weight: bold !important;
 	color: $link_color;
 	font-size: 15px !important;


### PR DESCRIPTION
This fixes #15025  .. I hope..

Maybe someone can check how it looks with the bookface theme, in Frio it looks okay.

![Bildschirmfoto_2025-07-20_13-37-49--post-title](https://github.com/user-attachments/assets/f2a589d8-2653-444b-b43b-cbefc6bdd654)

The post title should no longer be affected by the `14px` rule, that I had wrongly added here https://github.com/friendica/friendica/pull/14742 .. and the displayed usernames in the contacts page and in the search results should be bold again, too. 