### PR TITLE
Add event location without BBCode

### DIFF
--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -985,16 +985,10 @@ class Event
 		$found = preg_match("/([\d]+[\.]{1}[\d]+ *, *[\d]+[\.]{1}[\d]+)/ism", $s, $match);
 		if (intval($found) > 0 && array_key_exists(1, $match)) {
 			$location['coordinates'] = $match[1];
-			// Remove the map bbcode from the location name.
-			//$location['name'] = str_replace($match[0], "", $s);
 		} else {
 			// Map tag with location name - e.g. Paris
 			$location['address'] = $location['name'];
-			// Remove the map bbcode from the location name.
-			//$location['name'] = str_replace($match[0], "", $s);
 		}
-
-		//$location['name'] = BBCode::toPlaintext($location['name'], false);
 
 		// Construct the map HTML.
 		if (isset($location['address'])) {

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -96,12 +96,10 @@ class Event
 				. strip_tags(BBCode::convertForUriId($uriid, $event['location'], $simple))
 				. '</span></div>' . "\r\n";
 
-			// Include a map of the location if the [map] BBCode is used.
-			if (strpos($event['location'], "[map") !== false) {
-				$map = Map::byLocation($event['location'], $simple);
-				if ($map !== $event['location']) {
-					$o .= $map;
-				}
+			// Include a map of the location.
+			$map = Map::byLocation($event['location'], $simple);
+			if ($map !== $event['location']) {
+				$o .= $map;
 			}
 		}
 
@@ -661,6 +659,10 @@ class Event
 			list($title, $_trash) = explode("<br", BBCode::convertForUriId($event['uri-id'], Strings::escapeHtml($event['desc'])), BBCode::TWITTER_API);
 		}
 
+		if ($event['location']) {
+			$event['location'] = strip_tags(BBCode::toPlaintext($event['location'], false));
+		}
+
 		$event['author-link'] = Contact::magicLink($event['author-link']);
 
 		return [
@@ -977,27 +979,22 @@ class Event
 			return [];
 		}
 
-		$location = ['name' => $s];
+		$location = ['name' => BBCode::toPlaintext($s, false)];
 
-		// Map tag with location name - e.g. [map]Paris[/map].
-		if (strpos($s, '[/map]') !== false) {
-			$found = preg_match("/\[map\](.*?)\[\/map\]/ism", $s, $match);
-			if (intval($found) > 0 && array_key_exists(1, $match)) {
-				$location['address'] = $match[1];
-				// Remove the map bbcode from the location name.
-				$location['name'] = str_replace($match[0], "", $s);
-			}
-			// Map tag with coordinates - e.g. [map=48.864716,2.349014].
-		} elseif (strpos($s, '[map=') !== false) {
-			$found = preg_match("/\[map=(.*?)\]/ism", $s, $match);
-			if (intval($found) > 0 && array_key_exists(1, $match)) {
-				$location['coordinates'] = $match[1];
-				// Remove the map bbcode from the location name.
-				$location['name'] = str_replace($match[0], "", $s);
-			}
+		// Map tag with coordinates - e.g. 48.864716,2.349014
+		$found = preg_match("/([\d]+[\.]{1}[\d]+ *, *[\d]+[\.]{1}[\d]+)/ism", $s, $match);
+		if (intval($found) > 0 && array_key_exists(1, $match)) {
+			$location['coordinates'] = $match[1];
+			// Remove the map bbcode from the location name.
+			//$location['name'] = str_replace($match[0], "", $s);
+		} else {
+			// Map tag with location name - e.g. Paris
+			$location['address'] = $location['name'];
+			// Remove the map bbcode from the location name.
+			//$location['name'] = str_replace($match[0], "", $s);
 		}
 
-		$location['name'] = BBCode::toPlaintext($location['name'], false);
+		//$location['name'] = BBCode::toPlaintext($location['name'], false);
 
 		// Construct the map HTML.
 		if (isset($location['address'])) {

--- a/src/Module/Calendar/Event/Form.php
+++ b/src/Module/Calendar/Event/Form.php
@@ -108,8 +108,10 @@ class Form extends BaseModule
 		$share_disabled = '';
 
 		if (empty($orig_event)) {
-			$orig_event = User::getById($this->session->getLocalUserId(),
-				['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']);
+			$orig_event = User::getById(
+				$this->session->getLocalUserId(),
+				['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']
+			);
 		} elseif ($orig_event['allow_cid'] !== '<' . $this->session->getLocalUserId() . '>'
 				   || $orig_event['allow_gid']
 				   || $orig_event['deny_cid']

--- a/src/Module/Calendar/Event/Form.php
+++ b/src/Module/Calendar/Event/Form.php
@@ -224,7 +224,7 @@ class Form extends BaseModule
 			'$t_orig'      => $t_orig,
 			'$d_text'      => $this->t('Description (BBCode allowed)'),
 			'$d_orig'      => $d_orig,
-			'$l_text'      => $this->t('Location (BBCode not allowed)'),
+			'$l_text'      => $this->t('Location:'),
 			'$l_orig'      => $l_orig,
 			'$summary'     => ['summary', $this->t('Title (BBCode not allowed)'), $t_orig, '', '*'],
 			'$sh_text'     => $this->t('Share this event'),

--- a/src/Module/Calendar/Event/Form.php
+++ b/src/Module/Calendar/Event/Form.php
@@ -226,7 +226,7 @@ class Form extends BaseModule
 			'$t_orig'      => $t_orig,
 			'$d_text'      => $this->t('Description (BBCode allowed)'),
 			'$d_orig'      => $d_orig,
-			'$l_text'      => $this->t('Location:'),
+			'$l_text'      => $this->t('Location (BBCode not allowed)'),
 			'$l_orig'      => $l_orig,
 			'$summary'     => ['summary', $this->t('Title (BBCode not allowed)'), $t_orig, '', '*'],
 			'$sh_text'     => $this->t('Share this event'),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-20 16:09+0200\n"
+"POT-Creation-Date: 2025-07-20 16:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,7 +45,7 @@ msgid "Item not found."
 msgstr ""
 
 #: mod/item.php:461 mod/message.php:55 mod/message.php:101 mod/notes.php:34
-#: mod/photos.php:131 mod/photos.php:623 src/Model/Event.php:511
+#: mod/photos.php:131 mod/photos.php:623 src/Model/Event.php:509
 #: src/Module/Attach.php:40 src/Module/BaseApi.php:90
 #: src/Module/BaseNotifications.php:83 src/Module/BaseSettings.php:38
 #: src/Module/Calendar/Event/API.php:75 src/Module/Calendar/Event/Form.php:70
@@ -292,7 +292,7 @@ msgstr ""
 #: mod/message.php:190 mod/message.php:346 mod/photos.php:658
 #: mod/photos.php:778 mod/photos.php:1055 mod/photos.php:1097
 #: mod/photos.php:1153 mod/photos.php:1233
-#: src/Module/Calendar/Event/Form.php:236 src/Module/Contact/Advanced.php:118
+#: src/Module/Calendar/Event/Form.php:238 src/Module/Contact/Advanced.php:118
 #: src/Module/Contact/Profile.php:407
 #: src/Module/Debug/ActivityPubConversion.php:128
 #: src/Module/Debug/Babel.php:279 src/Module/Debug/Localtime.php:50
@@ -378,7 +378,7 @@ msgid "Save"
 msgstr ""
 
 #: mod/photos.php:50 mod/photos.php:113 mod/photos.php:533
-#: src/Model/Event.php:503 src/Model/Profile.php:211
+#: src/Model/Event.php:501 src/Model/Profile.php:211
 #: src/Module/Calendar/Export.php:60 src/Module/Calendar/Show.php:63
 #: src/Module/Feed.php:52 src/Module/HCard.php:37
 #: src/Module/Profile/Common.php:50 src/Module/Profile/Common.php:59
@@ -470,7 +470,7 @@ msgid "Do not show a status post for this upload"
 msgstr ""
 
 #: mod/photos.php:690 mod/photos.php:1051 src/Content/Conversation.php:395
-#: src/Module/Calendar/Event/Form.php:239 src/Module/Post/Edit.php:179
+#: src/Module/Calendar/Event/Form.php:241 src/Module/Post/Edit.php:179
 msgid "Permissions"
 msgstr ""
 
@@ -601,7 +601,7 @@ msgid "Comment"
 msgstr ""
 
 #: mod/photos.php:1098 mod/photos.php:1154 mod/photos.php:1234
-#: src/Content/Conversation.php:407 src/Module/Calendar/Event/Form.php:234
+#: src/Content/Conversation.php:407 src/Module/Calendar/Event/Form.php:236
 #: src/Module/Item/Compose.php:200 src/Module/Post/Edit.php:161
 #: src/Object/Post.php:1172
 msgid "Preview"
@@ -2475,8 +2475,8 @@ msgid "Matrix:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:111 src/Model/Event.php:68
-#: src/Model/Event.php:95 src/Model/Event.php:462 src/Model/Event.php:950
-#: src/Model/Profile.php:351 src/Module/Calendar/Event/Form.php:227
+#: src/Model/Event.php:95 src/Model/Event.php:460 src/Model/Event.php:952
+#: src/Model/Profile.php:351 src/Module/Calendar/Event/Form.php:229
 #: src/Module/Contact/Profile.php:449 src/Module/Directory.php:133
 #: src/Module/Notifications/Introductions.php:180
 #: src/Module/Profile/Profile.php:235
@@ -2847,142 +2847,142 @@ msgstr ""
 msgid "%s (%s)"
 msgstr ""
 
-#: src/Core/L10n.php:512 src/Model/Event.php:421
+#: src/Core/L10n.php:512 src/Model/Event.php:419
 #: src/Module/Settings/Display.php:282
 msgid "Monday"
 msgstr ""
 
-#: src/Core/L10n.php:512 src/Model/Event.php:422
+#: src/Core/L10n.php:512 src/Model/Event.php:420
 #: src/Module/Settings/Display.php:283
 msgid "Tuesday"
 msgstr ""
 
-#: src/Core/L10n.php:512 src/Model/Event.php:423
+#: src/Core/L10n.php:512 src/Model/Event.php:421
 #: src/Module/Settings/Display.php:284
 msgid "Wednesday"
 msgstr ""
 
-#: src/Core/L10n.php:512 src/Model/Event.php:424
+#: src/Core/L10n.php:512 src/Model/Event.php:422
 #: src/Module/Settings/Display.php:285
 msgid "Thursday"
 msgstr ""
 
-#: src/Core/L10n.php:512 src/Model/Event.php:425
+#: src/Core/L10n.php:512 src/Model/Event.php:423
 #: src/Module/Settings/Display.php:286
 msgid "Friday"
 msgstr ""
 
-#: src/Core/L10n.php:512 src/Model/Event.php:426
+#: src/Core/L10n.php:512 src/Model/Event.php:424
 #: src/Module/Settings/Display.php:287
 msgid "Saturday"
 msgstr ""
 
-#: src/Core/L10n.php:512 src/Model/Event.php:420
+#: src/Core/L10n.php:512 src/Model/Event.php:418
 #: src/Module/Settings/Display.php:281
 msgid "Sunday"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Model/Event.php:441
+#: src/Core/L10n.php:518 src/Model/Event.php:439
 msgid "January"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Model/Event.php:442
+#: src/Core/L10n.php:518 src/Model/Event.php:440
 msgid "February"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Model/Event.php:443
+#: src/Core/L10n.php:518 src/Model/Event.php:441
 msgid "March"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Model/Event.php:444
+#: src/Core/L10n.php:518 src/Model/Event.php:442
 msgid "April"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Core/L10n.php:541 src/Model/Event.php:432
+#: src/Core/L10n.php:518 src/Core/L10n.php:541 src/Model/Event.php:430
 msgid "May"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Model/Event.php:445
+#: src/Core/L10n.php:518 src/Model/Event.php:443
 msgid "June"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Model/Event.php:446
+#: src/Core/L10n.php:518 src/Model/Event.php:444
 msgid "July"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Model/Event.php:447
+#: src/Core/L10n.php:518 src/Model/Event.php:445
 msgid "August"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Model/Event.php:448
+#: src/Core/L10n.php:518 src/Model/Event.php:446
 msgid "September"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Model/Event.php:449
+#: src/Core/L10n.php:518 src/Model/Event.php:447
 msgid "October"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Model/Event.php:450
+#: src/Core/L10n.php:518 src/Model/Event.php:448
 msgid "November"
 msgstr ""
 
-#: src/Core/L10n.php:518 src/Model/Event.php:451
+#: src/Core/L10n.php:518 src/Model/Event.php:449
 msgid "December"
 msgstr ""
 
-#: src/Core/L10n.php:535 src/Model/Event.php:413
+#: src/Core/L10n.php:535 src/Model/Event.php:411
 msgid "Mon"
 msgstr ""
 
-#: src/Core/L10n.php:535 src/Model/Event.php:414
+#: src/Core/L10n.php:535 src/Model/Event.php:412
 msgid "Tue"
 msgstr ""
 
-#: src/Core/L10n.php:535 src/Model/Event.php:415
+#: src/Core/L10n.php:535 src/Model/Event.php:413
 msgid "Wed"
 msgstr ""
 
-#: src/Core/L10n.php:535 src/Model/Event.php:416
+#: src/Core/L10n.php:535 src/Model/Event.php:414
 msgid "Thu"
 msgstr ""
 
-#: src/Core/L10n.php:535 src/Model/Event.php:417
+#: src/Core/L10n.php:535 src/Model/Event.php:415
 msgid "Fri"
 msgstr ""
 
-#: src/Core/L10n.php:535 src/Model/Event.php:418
+#: src/Core/L10n.php:535 src/Model/Event.php:416
 msgid "Sat"
 msgstr ""
 
-#: src/Core/L10n.php:535 src/Model/Event.php:412
+#: src/Core/L10n.php:535 src/Model/Event.php:410
 msgid "Sun"
 msgstr ""
 
-#: src/Core/L10n.php:541 src/Model/Event.php:428
+#: src/Core/L10n.php:541 src/Model/Event.php:426
 msgid "Jan"
 msgstr ""
 
-#: src/Core/L10n.php:541 src/Model/Event.php:429
+#: src/Core/L10n.php:541 src/Model/Event.php:427
 msgid "Feb"
 msgstr ""
 
-#: src/Core/L10n.php:541 src/Model/Event.php:430
+#: src/Core/L10n.php:541 src/Model/Event.php:428
 msgid "Mar"
 msgstr ""
 
-#: src/Core/L10n.php:541 src/Model/Event.php:431
+#: src/Core/L10n.php:541 src/Model/Event.php:429
 msgid "Apr"
 msgstr ""
 
-#: src/Core/L10n.php:541 src/Model/Event.php:433
+#: src/Core/L10n.php:541 src/Model/Event.php:431
 msgid "Jun"
 msgstr ""
 
-#: src/Core/L10n.php:541 src/Model/Event.php:434
+#: src/Core/L10n.php:541 src/Model/Event.php:432
 msgid "Jul"
 msgstr ""
 
-#: src/Core/L10n.php:541 src/Model/Event.php:435
+#: src/Core/L10n.php:541 src/Model/Event.php:433
 msgid "Aug"
 msgstr ""
 
@@ -2990,15 +2990,15 @@ msgstr ""
 msgid "Sep"
 msgstr ""
 
-#: src/Core/L10n.php:541 src/Model/Event.php:437
+#: src/Core/L10n.php:541 src/Model/Event.php:435
 msgid "Oct"
 msgstr ""
 
-#: src/Core/L10n.php:541 src/Model/Event.php:438
+#: src/Core/L10n.php:541 src/Model/Event.php:436
 msgid "Nov"
 msgstr ""
 
-#: src/Core/L10n.php:541 src/Model/Event.php:439
+#: src/Core/L10n.php:541 src/Model/Event.php:437
 msgid "Dec"
 msgstr ""
 
@@ -3283,99 +3283,99 @@ msgstr ""
 msgid "l F d, Y \\@ g:i A \\G\\M\\TP (e)"
 msgstr ""
 
-#: src/Model/Event.php:61 src/Model/Event.php:78 src/Model/Event.php:460
-#: src/Model/Event.php:932
+#: src/Model/Event.php:61 src/Model/Event.php:78 src/Model/Event.php:458
+#: src/Model/Event.php:934
 msgid "Starts:"
 msgstr ""
 
-#: src/Model/Event.php:64 src/Model/Event.php:84 src/Model/Event.php:461
-#: src/Model/Event.php:936
+#: src/Model/Event.php:64 src/Model/Event.php:84 src/Model/Event.php:459
+#: src/Model/Event.php:938
 msgid "Finishes:"
 msgstr ""
 
-#: src/Model/Event.php:410
+#: src/Model/Event.php:408
 msgid "all-day"
 msgstr ""
 
-#: src/Model/Event.php:436
+#: src/Model/Event.php:434
 msgid "Sept"
 msgstr ""
 
-#: src/Model/Event.php:453 src/Module/Calendar/Show.php:117
+#: src/Model/Event.php:451 src/Module/Calendar/Show.php:117
 #: src/Util/Temporal.php:333
 msgid "today"
 msgstr ""
 
-#: src/Model/Event.php:454 src/Module/Calendar/Show.php:118
+#: src/Model/Event.php:452 src/Module/Calendar/Show.php:118
 #: src/Module/Settings/Display.php:292 src/Util/Temporal.php:343
 msgid "month"
 msgstr ""
 
-#: src/Model/Event.php:455 src/Module/Calendar/Show.php:119
+#: src/Model/Event.php:453 src/Module/Calendar/Show.php:119
 #: src/Module/Settings/Display.php:293 src/Util/Temporal.php:344
 msgid "week"
 msgstr ""
 
-#: src/Model/Event.php:456 src/Module/Calendar/Show.php:120
+#: src/Model/Event.php:454 src/Module/Calendar/Show.php:120
 #: src/Module/Settings/Display.php:294 src/Util/Temporal.php:345
 msgid "day"
 msgstr ""
 
-#: src/Model/Event.php:458
+#: src/Model/Event.php:456
 msgid "No events to display"
 msgstr ""
 
-#: src/Model/Event.php:507 src/Module/Feed.php:56
+#: src/Model/Event.php:505 src/Module/Feed.php:56
 #: src/Module/Update/Profile.php:42
 msgid "Access to this profile has been restricted."
 msgstr ""
 
-#: src/Model/Event.php:548 src/Module/Calendar/Event/Show.php:52
+#: src/Model/Event.php:546 src/Module/Calendar/Event/Show.php:52
 msgid "Event not found."
 msgstr ""
 
-#: src/Model/Event.php:627
+#: src/Model/Event.php:625
 msgid "l, F j"
 msgstr ""
 
-#: src/Model/Event.php:654
+#: src/Model/Event.php:652
 msgid "Edit event"
 msgstr ""
 
-#: src/Model/Event.php:655
+#: src/Model/Event.php:653
 msgid "Duplicate event"
 msgstr ""
 
-#: src/Model/Event.php:656
+#: src/Model/Event.php:654
 msgid "Delete event"
 msgstr ""
 
-#: src/Model/Event.php:886 src/Module/Debug/Localtime.php:24
+#: src/Model/Event.php:888 src/Module/Debug/Localtime.php:24
 msgid "l F d, Y \\@ g:i A"
 msgstr ""
 
-#: src/Model/Event.php:887
+#: src/Model/Event.php:889
 msgid "D g:i A"
 msgstr ""
 
-#: src/Model/Event.php:888
+#: src/Model/Event.php:890
 msgid "g:i A"
 msgstr ""
 
-#: src/Model/Event.php:951 src/Model/Event.php:953
+#: src/Model/Event.php:953 src/Model/Event.php:955
 msgid "Show map"
 msgstr ""
 
-#: src/Model/Event.php:952
+#: src/Model/Event.php:954
 msgid "Hide map"
 msgstr ""
 
-#: src/Model/Event.php:1045
+#: src/Model/Event.php:1042
 #, php-format
 msgid "%s's birthday"
 msgstr ""
 
-#: src/Model/Event.php:1046
+#: src/Model/Event.php:1043
 #, php-format
 msgid "Happy Birthday %s"
 msgstr ""
@@ -4199,7 +4199,7 @@ msgstr ""
 msgid "Click to view details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:84 src/Module/Calendar/Event/Form.php:193
+#: src/Module/Admin/Logs/View.php:84 src/Module/Calendar/Event/Form.php:195
 msgid "Event details"
 msgstr ""
 
@@ -4376,7 +4376,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:454 src/Module/Calendar/Event/Form.php:238
+#: src/Module/Admin/Site.php:454 src/Module/Calendar/Event/Form.php:240
 #: src/Module/Contact.php:529 src/Module/Profile/Profile.php:290
 msgid "Advanced"
 msgstr ""
@@ -5841,17 +5841,17 @@ msgstr ""
 msgid "Event title and start time are required."
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:194
+#: src/Module/Calendar/Event/Form.php:196
 msgid "Starting date and Title are required."
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:195
-#: src/Module/Calendar/Event/Form.php:200
+#: src/Module/Calendar/Event/Form.php:197
+#: src/Module/Calendar/Event/Form.php:202
 msgid "Event Starts:"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:195
-#: src/Module/Calendar/Event/Form.php:223 src/Module/Debug/Probe.php:45
+#: src/Module/Calendar/Event/Form.php:197
+#: src/Module/Calendar/Event/Form.php:225 src/Module/Debug/Probe.php:45
 #: src/Module/Install.php:186 src/Module/Install.php:212
 #: src/Module/Install.php:217 src/Module/Install.php:231
 #: src/Module/Install.php:240 src/Module/Install.php:245
@@ -5873,31 +5873,31 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:209
-#: src/Module/Calendar/Event/Form.php:233
+#: src/Module/Calendar/Event/Form.php:211
+#: src/Module/Calendar/Event/Form.php:235
 msgid "Finish date/time is not known or not relevant"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:211
-#: src/Module/Calendar/Event/Form.php:216
+#: src/Module/Calendar/Event/Form.php:213
+#: src/Module/Calendar/Event/Form.php:218
 msgid "Event Finishes:"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:223
-#: src/Module/Calendar/Event/Form.php:229
+#: src/Module/Calendar/Event/Form.php:225
+#: src/Module/Calendar/Event/Form.php:231
 msgid "Title (BBCode not allowed)"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:225
+#: src/Module/Calendar/Event/Form.php:227
 msgid "Description (BBCode allowed)"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:230
-#: src/Module/Calendar/Event/Form.php:231
+#: src/Module/Calendar/Event/Form.php:232
+#: src/Module/Calendar/Event/Form.php:233
 msgid "Share this event"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:237 src/Module/Profile/Profile.php:289
+#: src/Module/Calendar/Event/Form.php:239 src/Module/Profile/Profile.php:289
 msgid "Basic"
 msgstr ""
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-17 09:29+0200\n"
+"POT-Creation-Date: 2025-07-20 16:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2476,8 +2476,9 @@ msgstr ""
 
 #: src/Content/Widget/VCard.php:111 src/Model/Event.php:68
 #: src/Model/Event.php:95 src/Model/Event.php:462 src/Model/Event.php:950
-#: src/Model/Profile.php:351 src/Module/Contact/Profile.php:449
-#: src/Module/Directory.php:133 src/Module/Notifications/Introductions.php:180
+#: src/Model/Profile.php:351 src/Module/Calendar/Event/Form.php:227
+#: src/Module/Contact/Profile.php:449 src/Module/Directory.php:133
+#: src/Module/Notifications/Introductions.php:180
 #: src/Module/Profile/Profile.php:235
 msgid "Location:"
 msgstr ""
@@ -5889,10 +5890,6 @@ msgstr ""
 
 #: src/Module/Calendar/Event/Form.php:225
 msgid "Description (BBCode allowed)"
-msgstr ""
-
-#: src/Module/Calendar/Event/Form.php:227
-msgid "Location (BBCode not allowed)"
 msgstr ""
 
 #: src/Module/Calendar/Event/Form.php:230

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-20 16:34+0200\n"
+"POT-Creation-Date: 2025-07-20 17:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2476,9 +2476,8 @@ msgstr ""
 
 #: src/Content/Widget/VCard.php:111 src/Model/Event.php:68
 #: src/Model/Event.php:95 src/Model/Event.php:460 src/Model/Event.php:952
-#: src/Model/Profile.php:351 src/Module/Calendar/Event/Form.php:229
-#: src/Module/Contact/Profile.php:449 src/Module/Directory.php:133
-#: src/Module/Notifications/Introductions.php:180
+#: src/Model/Profile.php:351 src/Module/Contact/Profile.php:449
+#: src/Module/Directory.php:133 src/Module/Notifications/Introductions.php:180
 #: src/Module/Profile/Profile.php:235
 msgid "Location:"
 msgstr ""
@@ -3370,12 +3369,12 @@ msgstr ""
 msgid "Hide map"
 msgstr ""
 
-#: src/Model/Event.php:1042
+#: src/Model/Event.php:1036
 #, php-format
 msgid "%s's birthday"
 msgstr ""
 
-#: src/Model/Event.php:1043
+#: src/Model/Event.php:1037
 #, php-format
 msgid "Happy Birthday %s"
 msgstr ""
@@ -5890,6 +5889,10 @@ msgstr ""
 
 #: src/Module/Calendar/Event/Form.php:227
 msgid "Description (BBCode allowed)"
+msgstr ""
+
+#: src/Module/Calendar/Event/Form.php:229
+msgid "Location (BBCode not allowed)"
 msgstr ""
 
 #: src/Module/Calendar/Event/Form.php:232

--- a/view/theme/frio/templates/calendar/event_form.tpl
+++ b/view/theme/frio/templates/calendar/event_form.tpl
@@ -74,7 +74,7 @@
 
 			{{* The textarea for the event description *}}
 			<div class="form-group">
-				<div id="event-desc-text"><b>{{$d_text}}</b></div>
+				<div id="event-desc-text"><b>{{$d_text}}</b>:</div>
 				<textarea id="comment-edit-text-desc" class="form-control text-autosize" name="desc" rows="8" dir="auto">{{$d_orig}}</textarea>
 				<ul id="event-desc-text-edit-bb" class="comment-edit-bb comment-icon-list nav nav-pills hidden-xs pull-left">
 					{{* commented out because it isn't implemented yet
@@ -131,11 +131,6 @@
 						</button>
 					</li>
 					*}}
-					<li>
-						<button type="button" class="btn-link icon map" style="cursor: pointer;" title="{{$edmap}}" data-role="insert-formatting" data-comment=" " data-bbcode="map" data-id="loc">
-							<i class="fa fa-map-marker"></i>
-						</button>
-					</li>
 				</ul>
 				<div class="clear"></div>
 			</div>

--- a/view/theme/frio/templates/calendar/event_form.tpl
+++ b/view/theme/frio/templates/calendar/event_form.tpl
@@ -155,7 +155,7 @@
 		// disable finish date input if it isn't available
 		enableDisableFinishDate();
 		// load bbcode autocomplete for the description textarea
-		$('#comment-edit-text-desc, #comment-edit-text-loc').bbco_autocomplete('bbcode');
+		$('#comment-edit-text-desc').bbco_autocomplete('bbcode');
 
 		// initiale autosize for the textareas
 		autosize($("textarea.text-autosize"));

--- a/view/theme/frio/templates/calendar/event_form.tpl
+++ b/view/theme/frio/templates/calendar/event_form.tpl
@@ -74,7 +74,7 @@
 
 			{{* The textarea for the event description *}}
 			<div class="form-group">
-				<div id="event-desc-text"><b>{{$d_text}}</b>:</div>
+				<div id="event-desc-text"><b>{{$d_text}}</b></div>
 				<textarea id="comment-edit-text-desc" class="form-control text-autosize" name="desc" rows="8" dir="auto">{{$d_orig}}</textarea>
 				<ul id="event-desc-text-edit-bb" class="comment-edit-bb comment-icon-list nav nav-pills hidden-xs pull-left">
 					{{* commented out because it isn't implemented yet

--- a/view/theme/frio/templates/calendar/event_form.tpl
+++ b/view/theme/frio/templates/calendar/event_form.tpl
@@ -132,34 +132,8 @@
 					</li>
 					*}}
 					<li>
-						<button type="button" class="btn-link icon bb-url" style="cursor: pointer;" title="{{$edurl}}" data-role="insert-formatting" data-comment=" " data-bbcode="url" data-id="loc">
-							<i class="fa fa-link"></i>
-						</button>
-					</li>
-					<li>
-						<button type="button" class="btn-link icon bb-video" style="cursor: pointer;" title="{{$edvideo}}" data-role="insert-formatting" data-comment=" " data-bbcode="video" data-id="loc">
-							<i class="fa fa-video-camera"></i>
-						</button>
-					</li>
-
-					<li>
-						<button type="button" class="btn-link icon underline" style="cursor: pointer;" title="{{$eduline}}" data-role="insert-formatting" data-comment=" " data-bbcode="u" data-id="loc">
-							<i class="fa fa-underline"></i>
-						</button>
-					</li>
-					<li>
-						<button type="button" class="btn-link icon italic" style="cursor: pointer;" title="{{$editalic}}" data-role="insert-formatting" data-comment=" " data-bbcode="i" data-id="loc">
-							<i class="fa fa-italic"></i>
-						</button>
-					</li>
-					<li>
-						<button type="button" class="btn-link icon bold" style="cursor: pointer;"  title="{{$edbold}}" data-role="insert-formatting" data-comment=" " data-bbcode="b" data-id="loc">
-							<i class="fa fa-bold"></i>
-						</button>
-					</li>
-					<li>
-						<button type="button" class="btn-link icon quote" style="cursor: pointer;" title="{{$edquote}}" data-role="insert-formatting" data-comment=" " data-bbcode="quote" data-id="loc">
-							<i class="fa fa-quote-left"></i>
+						<button type="button" class="btn-link icon map" style="cursor: pointer;" title="{{$edmap}}" data-role="insert-formatting" data-comment=" " data-bbcode="map" data-id="loc">
+							<i class="fa fa-map-marker"></i>
 						</button>
 					</li>
 				</ul>

--- a/view/theme/vier/templates/calendar/event_form.tpl
+++ b/view/theme/vier/templates/calendar/event_form.tpl
@@ -43,16 +43,6 @@
 
 <div id="event-location-text">{{$l_text}}</div>
 <textarea id="comment-edit-text-location" rows="4" cols="64" name="location" dir="auto">{{$l_orig}}</textarea>
-<div id="event-location-text-edit-bb" class="comment-edit-bb">
-	<a title="{{$edimg}}" data-role="insert-formatting" data-bbcode="img" data-id="location"><i class="icon-picture"></i></a>
-	<a title="{{$edurl}}" data-role="insert-formatting" data-bbcode="url" data-id="location"><i class="icon-link"></i></a>
-	<a title="{{$edvideo}}" data-role="insert-formatting" data-bbcode="video" data-id="location"><i class="icon-film"></i></a>
-
-	<a title="{{$eduline}}" data-role="insert-formatting" data-bbcode="u" data-id="location"><i class="icon-underline"></i></a>
-	<a title="{{$editalic}}" data-role="insert-formatting" data-bbcode="i" data-id="location"><i class="icon-italic"></i></a>
-	<a title="{{$edbold}}" data-role="insert-formatting" data-bbcode="b" data-id="location"><i class="icon-bold"></i></a>
-	<a title="{{$edquote}}" data-role="insert-formatting" data-bbcode="quote" data-id="location"><i class="icon-quote-left"></i></a>
-</div>
 
 <div id="event-location-break"></div>
 


### PR DESCRIPTION
I tried to make it possible to add a location to an event, without using BBCode.

See the screenshots. The last one shows a problem. I don't know if and where the location name should be validated . Or will it be inserted into the database as it is? What will happen, if a user inserts something like "`[map]Some Crap[/map]`".. ?



 #### Frio

![Bildschirmfoto_2025-07-20_15-59-27--event-location-textarea](https://github.com/user-attachments/assets/656780c4-1b4b-4c0c-a6b1-9126d3f8a1f2)

![Bildschirmfoto_2025-07-20_16-00-51--event-location-resulting-post](https://github.com/user-attachments/assets/977fea77-cd28-4d67-9645-be4b7903ef4f)

#### Vier (before)

![Bildschirmfoto_2025-07-20_16-16-01--event-location-textarea-vier-before](https://github.com/user-attachments/assets/6c8239ce-e90a-4513-9f79-550a9c5bc24b)

#### Vier (after)

![Bildschirmfoto_2025-07-20_16-19-51--event-location-textarea-vier-after](https://github.com/user-attachments/assets/698c797e-3ba6-43b7-97fd-c967e654dba8)

![Bildschirmfoto_2025-07-20_16-21-13--event-location-resulting-post-vier](https://github.com/user-attachments/assets/38ad12f5-815b-4630-84c6-39821b17d589)

#### Problem

![Bildschirmfoto_2025-07-20_16-29-01--event-location-problem](https://github.com/user-attachments/assets/80641575-df6e-490a-8caa-4857a2ffb22e)


