### PR TITLE
Frio: Restore left alignment of profile description (but not display and nickname)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1214,11 +1214,11 @@ aside .vcard #profile-photo-wrapper.crop-preview {
 }
 aside .vcard .profile-header {
 	padding: 5px 0px 20px 0px;
-	text-align: center;
 }
 aside .vcard .fn {
 	font-weight: bold;
 	padding: 5px 0px 5px 0px;
+	text-align: center;
 }
 aside .vcard .p-addr {
 	font-style: italic;
@@ -1226,6 +1226,7 @@ aside .vcard .p-addr {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	padding-bottom: 2px;
+	text-align: center;
 }
 aside .vcard .title {
 	margin-top: 10px;


### PR DESCRIPTION
Related to #14988 , found out it didn't just apply to the the display name and nickname but also the description, and the latter part was unintentional.
This restores left alignment for the description. Also @haheute didn't like it.

I'm inclined to prefer centered for the display name and nickname, but it could also be considered whether the centering should be reverted entirely.
What do others think?

Before:
<img width="266" height="643" alt="image" src="https://github.com/user-attachments/assets/7bce308c-7274-4286-afe4-06e80b0e82e8" />

After:
<img width="266" height="643" alt="image" src="https://github.com/user-attachments/assets/ce595869-7242-470d-b34a-45920883b5ec" />

