### PR TITLE
Contacts: Show contact name in page title on /contact/ URLs

### DIFF
--- a/mod/message.php
+++ b/mod/message.php
@@ -24,7 +24,8 @@ use Friendica\Util\Temporal;
 
 function message_init()
 {
-	$tabs = '';
+	$tabs               = '';
+	DI::page()['title'] = DI::l10n()->t('Messages');
 
 	if (DI::args()->getArgc() > 1 && is_numeric(DI::args()->getArgv()[1])) {
 		$tabs = render_messages(get_messages(DI::userSession()->getLocalUserId(), 0, 15), 'mail_list.tpl');

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -177,6 +177,9 @@ class Contact extends BaseModule
 
 		$page = DI::page();
 
+		// Default page title when not viewing a specific contact
+		$page['title'] = DI::l10n()->t('Contacts');
+
 		$page->registerFooterScript(Theme::getPathForFile('asset/typeahead.js/dist/typeahead.bundle.js'));
 		$page->registerFooterScript(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput.js'));
 		$page->registerStylesheet(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput.css'));

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -541,6 +541,11 @@ class Contact extends BaseModule
 		return $tab_str;
 	}
 
+	public static function setPageTitle(array $contact)
+	{
+		DI::page()['title'] = $contact['name'];
+	}
+
 	/**
 	 * Return the fields for the contact template
 	 *

--- a/src/Module/Contact/Contacts.php
+++ b/src/Module/Contact/Contacts.php
@@ -34,7 +34,7 @@ class Contacts extends BaseModule
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->userSession = $userSession;
-		$this->page = $page;
+		$this->page        = $page;
 	}
 
 	protected function content(array $request = []): string
@@ -43,9 +43,9 @@ class Contacts extends BaseModule
 			throw new HTTPException\ForbiddenException();
 		}
 
-		$cid = $this->parameters['id'];
-		$type = $this->parameters['type'] ?? 'all';
-		$accounttype = $request['accounttype'] ?? '';
+		$cid           = $this->parameters['id'];
+		$type          = $this->parameters['type'] ?? 'all';
+		$accounttype   = $request['accounttype']   ?? '';
 		$accounttypeid = User::getAccountTypeByString($accounttype);
 
 		if (!$cid) {
@@ -85,7 +85,7 @@ class Contacts extends BaseModule
 				$total = Model\Contact\Relation::countMutuals($cid, $condition);
 				break;
 			case 'common':
-				$total = Model\Contact\Relation::countCommon($localContactId, $cid, $condition);
+				$total          = Model\Contact\Relation::countCommon($localContactId, $cid, $condition);
 				$noresult_label = $this->t('No common contacts.');
 				break;
 			default:
@@ -93,37 +93,39 @@ class Contacts extends BaseModule
 		}
 
 		$pager = new Pager($this->l10n, $this->args->getQueryString(), 30);
-		$desc = '';
+		$desc  = '';
 
 		switch ($type) {
 			case 'followers':
 				$friends = Model\Contact\Relation::listFollowers($cid, $condition, $pager->getItemsPerPage(), $pager->getStart());
-				$title = $this->tt('Follower (%s)', 'Followers (%s)', $total);
+				$title   = $this->tt('Follower (%s)', 'Followers (%s)', $total);
 				break;
 			case 'following':
 				$friends = Model\Contact\Relation::listFollows($cid, $condition, $pager->getItemsPerPage(), $pager->getStart());
-				$title = $this->tt('Following (%s)', 'Following (%s)', $total);
+				$title   = $this->tt('Following (%s)', 'Following (%s)', $total);
 				break;
 			case 'mutuals':
 				$friends = Model\Contact\Relation::listMutuals($cid, $condition, $pager->getItemsPerPage(), $pager->getStart());
-				$title = $this->tt('Mutual friend (%s)', 'Mutual friends (%s)', $total);
-				$desc = $this->t(
+				$title   = $this->tt('Mutual friend (%s)', 'Mutual friends (%s)', $total);
+				$desc    = $this->t(
 					'These contacts both follow and are followed by <strong>%s</strong>.',
 					htmlentities($contact['name'], ENT_COMPAT, 'UTF-8')
 				);
 				break;
 			case 'common':
 				$friends = Model\Contact\Relation::listCommon($localContactId, $cid, $condition, $pager->getItemsPerPage(), $pager->getStart());
-				$title = $this->tt('Common contact (%s)', 'Common contacts (%s)', $total);
-				$desc = $this->t(
+				$title   = $this->tt('Common contact (%s)', 'Common contacts (%s)', $total);
+				$desc    = $this->t(
 					'Both <strong>%s</strong> and yourself have publicly interacted with these contacts (follow, comment or likes on public posts).',
 					htmlentities($contact['name'], ENT_COMPAT, 'UTF-8')
 				);
 				break;
 			default:
 				$friends = Model\Contact\Relation::listAll($cid, $condition, $pager->getItemsPerPage(), $pager->getStart());
-				$title = $this->tt('Contact (%s)', 'Contacts (%s)', $total);
+				$title   = $this->tt('Contact (%s)', 'Contacts (%s)', $total);
 		}
+
+		Module\Contact::setPageTitle($contact);
 
 		$o = Module\Contact::getTabsHTML($contact, Module\Contact::TAB_CONTACTS);
 
@@ -135,7 +137,7 @@ class Contacts extends BaseModule
 				$contact = Model\Contact::selectFirst(
 					[],
 					['uri-id' => $contact['uri-id'], 'uid' => [0, $this->userSession->getLocalUserId()]],
-					['order' => ['uid' => 'DESC']]
+					['order'  => ['uid' => 'DESC']]
 				);
 				return Module\Contact::getContactTemplateVars($contact);
 			},
@@ -144,11 +146,11 @@ class Contacts extends BaseModule
 
 		$tpl = Renderer::getMarkupTemplate('profile/contacts.tpl');
 		$o .= Renderer::replaceMacros($tpl, [
-			'$title'    => $title,
-			'$desc'     => $desc,
-			'$tabs'     => $tabs,
+			'$title' => $title,
+			'$desc'  => $desc,
+			'$tabs'  => $tabs,
 
-			'$noresult_label'  => $noresult_label,
+			'$noresult_label' => $noresult_label,
 
 			'$contacts' => $contacts,
 			'$paginate' => $pager->renderFull($total),

--- a/src/Module/Contact/Conversations.php
+++ b/src/Module/Contact/Conversations.php
@@ -103,13 +103,14 @@ class Conversations extends BaseModule
 		if (!$contact['ap-posting-restricted']) {
 			$options = [
 				'lockstate' => ACL::getLockstateForUserId($this->userSession->getLocalUserId()) ? 'lock' : 'unlock',
-				'acl' => ACL::getFullSelectorHTML($this->page, $this->userSession->getLocalUserId(), true, []),
-				'bang' => '',
-				'content' => ($contact['contact-type'] == ModelContact::TYPE_COMMUNITY ? '!' : '@') . ($contact['addr'] ?: $contact['url']),
+				'acl'       => ACL::getFullSelectorHTML($this->page, $this->userSession->getLocalUserId(), true, []),
+				'bang'      => '',
+				'content'   => ($contact['contact-type'] == ModelContact::TYPE_COMMUNITY ? '!' : '@') . ($contact['addr'] ?: $contact['url']),
 			];
 			$output = $this->conversation->statusEditor($options);
 		}
 
+		Contact::setPageTitle($contact);
 		$output .= Contact::getTabsHTML($contact, Contact::TAB_CONVERSATIONS);
 		$output .= ModelContact::getThreadsFromId($contact['id'], $this->userSession->getLocalUserId(), 0, 0, $request['last_created'] ?? '');
 

--- a/src/Module/Contact/Media.php
+++ b/src/Module/Contact/Media.php
@@ -49,6 +49,8 @@ class Media extends BaseModule
 
 		DI::page()['aside'] = Widget\VCard::getHTML($contact);
 
+		Contact::setPageTitle($contact);
+
 		$o = Contact::getTabsHTML($contact, Contact::TAB_MEDIA);
 
 		$o .= ModelContact::getPostsFromUrl($contact['url'], $this->userSession->getLocalUserId(), true, $request['last_created'] ?? '');

--- a/src/Module/Contact/Posts.php
+++ b/src/Module/Contact/Posts.php
@@ -83,6 +83,8 @@ class Posts extends BaseModule
 
 		Nav::setSelected('contact');
 
+		Contact::setPageTitle($contact);
+
 		$o = Contact::getTabsHTML($contact, Contact::TAB_POSTS);
 
 		$o .= Model\Contact::getPostsFromId($contact['id'], $this->userSession->getLocalUserId(), false, $request['last_created'] ?? '');

--- a/src/Module/Contact/Profile.php
+++ b/src/Module/Contact/Profile.php
@@ -330,6 +330,8 @@ class Profile extends BaseModule
 
 		$nettype = $this->t('Network type: %s', ContactSelector::networkToName($contact['network'], $contact['protocol'], $contact['gsid']));
 
+		ContactModule::setPageTitle($contact);
+
 		// tabs
 		$tab_str = ContactModule::getTabsHTML($contact, ContactModule::TAB_PROFILE);
 

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -107,7 +107,7 @@ class Contacts extends Module\BaseProfile
 				$contact = Model\Contact::selectFirst(
 					[],
 					['uri-id' => $contact['uri-id'], 'uid' => [0, $this->userSession->getLocalUserId()]],
-					['order' => ['uid' => 'DESC']]
+					['order'  => ['uid' => 'DESC']]
 				);
 				return $contact ? Module\Contact::getContactTemplateVars($contact) : null;
 			},
@@ -139,7 +139,7 @@ class Contacts extends Module\BaseProfile
 		}
 
 		$tpl = Renderer::getMarkupTemplate('profile/contacts.tpl');
-		$o   .= Renderer::replaceMacros($tpl, [
+		$o .= Renderer::replaceMacros($tpl, [
 			'$title' => $title,
 			'$desc'  => $desc,
 			'$tabs'  => $tabs,

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-10 20:37+0200\n"
+"POT-Creation-Date: 2025-08-21 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Item not found."
 msgstr ""
 
-#: mod/item.php:461 mod/message.php:55 mod/message.php:101 mod/notes.php:34
+#: mod/item.php:461 mod/message.php:56 mod/message.php:102 mod/notes.php:34
 #: mod/photos.php:131 mod/photos.php:623 src/Model/Event.php:511
 #: src/Module/Attach.php:40 src/Module/BaseApi.php:90
 #: src/Module/BaseNotifications.php:83 src/Module/BaseSettings.php:38
@@ -210,133 +210,134 @@ msgstr ""
 msgid "Your password has been changed at %s"
 msgstr ""
 
-#: mod/message.php:34 mod/message.php:116 src/Content/Nav.php:318
+#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:315
+#: view/theme/frio/theme.php:230
+msgid "Messages"
+msgstr ""
+
+#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:318
 msgid "New Message"
 msgstr ""
 
-#: mod/message.php:70
+#: mod/message.php:71
 msgid "No recipient selected."
 msgstr ""
 
-#: mod/message.php:75
+#: mod/message.php:76
 msgid "Unable to locate contact information."
 msgstr ""
 
-#: mod/message.php:79
+#: mod/message.php:80
 msgid "Message could not be sent."
 msgstr ""
 
-#: mod/message.php:83
+#: mod/message.php:84
 msgid "Message collection failure."
 msgstr ""
 
-#: mod/message.php:110 src/Module/Notifications/Introductions.php:127
+#: mod/message.php:111 src/Module/Notifications/Introductions.php:127
 #: src/Module/Notifications/Introductions.php:163
 #: src/Module/Notifications/Notification.php:71
 msgid "Discard"
 msgstr ""
 
-#: mod/message.php:123 src/Content/Nav.php:315 view/theme/frio/theme.php:230
-msgid "Messages"
-msgstr ""
-
-#: mod/message.php:136
+#: mod/message.php:137
 msgid "Conversation not found."
 msgstr ""
 
-#: mod/message.php:141
+#: mod/message.php:142
 msgid "Message was not deleted."
 msgstr ""
 
-#: mod/message.php:156
+#: mod/message.php:157
 msgid "Conversation was not removed."
 msgstr ""
 
-#: mod/message.php:169 mod/message.php:276
+#: mod/message.php:170 mod/message.php:277
 msgid "Please enter a link URL:"
 msgstr ""
 
-#: mod/message.php:178
+#: mod/message.php:179
 msgid "Send Private Message"
 msgstr ""
 
-#: mod/message.php:179 mod/message.php:336
+#: mod/message.php:180 mod/message.php:337
 #: src/Module/Privacy/PermissionTooltip.php:149
 msgid "To:"
 msgstr ""
 
-#: mod/message.php:180 mod/message.php:337
+#: mod/message.php:181 mod/message.php:338
 msgid "Subject:"
 msgstr ""
 
-#: mod/message.php:184 mod/message.php:340 src/Module/Invite.php:155
+#: mod/message.php:185 mod/message.php:341 src/Module/Invite.php:155
 msgid "Your message:"
 msgstr ""
 
-#: mod/message.php:187 mod/message.php:344 src/Content/Conversation.php:362
+#: mod/message.php:188 mod/message.php:345 src/Content/Conversation.php:362
 #: src/Module/Post/Edit.php:127
 msgid "Upload photo"
 msgstr ""
 
-#: mod/message.php:188 mod/message.php:345 src/Module/Post/Edit.php:131
+#: mod/message.php:189 mod/message.php:346 src/Module/Post/Edit.php:131
 msgid "Insert web link"
 msgstr ""
 
-#: mod/message.php:189 mod/message.php:347 mod/photos.php:1256
+#: mod/message.php:190 mod/message.php:348 mod/photos.php:1256
 #: src/Content/Conversation.php:393 src/Content/Conversation.php:1572
 #: src/Module/Item/Compose.php:205 src/Module/Post/Edit.php:141
 #: src/Object/Post.php:613
 msgid "Please wait"
 msgstr ""
 
-#: mod/message.php:190 mod/message.php:346
+#: mod/message.php:191 mod/message.php:347
 msgid "Send Message"
 msgstr ""
 
-#: mod/message.php:211
+#: mod/message.php:212
 msgid "You have no messages."
 msgstr ""
 
-#: mod/message.php:269
+#: mod/message.php:270
 msgid "Message not available."
 msgstr ""
 
-#: mod/message.php:313
+#: mod/message.php:314
 msgid "Delete message"
 msgstr ""
 
-#: mod/message.php:315 mod/message.php:443
+#: mod/message.php:316 mod/message.php:444
 msgid "D, d M Y - g:i A"
 msgstr ""
 
-#: mod/message.php:330 mod/message.php:440
+#: mod/message.php:331 mod/message.php:441
 msgid "Delete conversation"
 msgstr ""
 
-#: mod/message.php:332
+#: mod/message.php:333
 msgid "No secure communications available. You <strong>may</strong> be able to respond from the sender's profile page."
 msgstr ""
 
-#: mod/message.php:335
+#: mod/message.php:336
 msgid "Send Reply"
 msgstr ""
 
-#: mod/message.php:414
+#: mod/message.php:415
 #, php-format
 msgid "Unknown sender - %s"
 msgstr ""
 
-#: mod/message.php:416
+#: mod/message.php:417
 #, php-format
 msgid "You and %s"
 msgstr ""
 
-#: mod/message.php:418
+#: mod/message.php:419
 #, php-format
 msgid "%s and You"
 msgstr ""
 
-#: mod/message.php:446
+#: mod/message.php:447
 #, php-format
 msgid "%d message"
 msgid_plural "%d messages"
@@ -431,7 +432,7 @@ msgstr ""
 #: mod/photos.php:658 mod/photos.php:778 mod/photos.php:1055
 #: mod/photos.php:1097 mod/photos.php:1153 mod/photos.php:1233
 #: src/Module/Calendar/Event/Form.php:236 src/Module/Contact/Advanced.php:118
-#: src/Module/Contact/Profile.php:407
+#: src/Module/Contact/Profile.php:409
 #: src/Module/Debug/ActivityPubConversion.php:128
 #: src/Module/Debug/Babel.php:279 src/Module/Debug/Localtime.php:50
 #: src/Module/Debug/Probe.php:40 src/Module/Debug/WebFinger.php:37
@@ -591,7 +592,7 @@ msgid "Rotate CCW (left)"
 msgstr ""
 
 #: mod/photos.php:1094 mod/photos.php:1150 mod/photos.php:1230
-#: src/Module/Contact.php:601 src/Module/Item/Compose.php:187
+#: src/Module/Contact.php:609 src/Module/Item/Compose.php:187
 #: src/Object/Post.php:1156
 msgid "This is you"
 msgstr ""
@@ -781,19 +782,19 @@ msgid "All contacts"
 msgstr ""
 
 #: src/BaseModule.php:440 src/Content/Conversation/Factory/Channel.php:33
-#: src/Content/Widget.php:257 src/Core/ACL.php:185 src/Module/Contact.php:396
+#: src/Content/Widget.php:257 src/Core/ACL.php:185 src/Module/Contact.php:399
 #: src/Module/Privacy/PermissionTooltip.php:181
 #: src/Module/Privacy/PermissionTooltip.php:203
 #: src/Module/Settings/Channels.php:146
 msgid "Followers"
 msgstr ""
 
-#: src/BaseModule.php:445 src/Content/Widget.php:258 src/Module/Contact.php:399
+#: src/BaseModule.php:445 src/Content/Widget.php:258 src/Module/Contact.php:402
 #: src/Module/Settings/Channels.php:145
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:450 src/Content/Widget.php:259 src/Module/Contact.php:402
+#: src/BaseModule.php:450 src/Content/Widget.php:259 src/Module/Contact.php:405
 msgid "Mutual friends"
 msgstr ""
 
@@ -1697,7 +1698,7 @@ msgid "Network Widgets"
 msgstr ""
 
 #: src/Content/Feature.php:126 src/Content/Widget.php:233
-#: src/Model/Circle.php:587 src/Module/Contact.php:382
+#: src/Model/Circle.php:587 src/Module/Contact.php:385
 #: src/Module/Welcome.php:63
 msgid "Circles"
 msgstr ""
@@ -1882,24 +1883,24 @@ msgstr ""
 msgid "Send PM"
 msgstr ""
 
-#: src/Content/Item.php:433 src/Module/Contact.php:450
-#: src/Module/Contact/Profile.php:560
+#: src/Content/Item.php:433 src/Module/Contact.php:453
+#: src/Module/Contact/Profile.php:562
 #: src/Module/Moderation/Blocklist/Contact.php:104
 #: src/Module/Moderation/Users/Active.php:93
 #: src/Module/Moderation/Users/Index.php:101
 msgid "Block"
 msgstr ""
 
-#: src/Content/Item.php:434 src/Module/Contact.php:451
-#: src/Module/Contact/Profile.php:568
+#: src/Content/Item.php:434 src/Module/Contact.php:454
+#: src/Module/Contact/Profile.php:570
 #: src/Module/Notifications/Introductions.php:126
 #: src/Module/Notifications/Introductions.php:199
 #: src/Module/Notifications/Notification.php:75
 msgid "Ignore"
 msgstr ""
 
-#: src/Content/Item.php:435 src/Module/Contact.php:452
-#: src/Module/Contact/Profile.php:576
+#: src/Content/Item.php:435 src/Module/Contact.php:455
+#: src/Module/Contact/Profile.php:578
 msgid "Collapse"
 msgstr ""
 
@@ -1986,7 +1987,7 @@ msgid "Sign in"
 msgstr ""
 
 #: src/Content/Nav.php:226 src/Module/BaseProfile.php:42
-#: src/Module/Contact.php:494
+#: src/Module/Contact.php:497
 msgid "Conversations"
 msgstr ""
 
@@ -1995,8 +1996,8 @@ msgid "Conversations you started"
 msgstr ""
 
 #: src/Content/Nav.php:227 src/Module/BaseProfile.php:34
-#: src/Module/BaseSettings.php:86 src/Module/Contact.php:486
-#: src/Module/Contact/Profile.php:462 src/Module/Profile/Profile.php:282
+#: src/Module/BaseSettings.php:86 src/Module/Contact.php:489
+#: src/Module/Contact/Profile.php:464 src/Module/Profile/Profile.php:282
 #: src/Module/Welcome.php:44 view/theme/frio/theme.php:219
 msgid "Profile"
 msgstr ""
@@ -2016,7 +2017,7 @@ msgid "Your photos"
 msgstr ""
 
 #: src/Content/Nav.php:229 src/Module/BaseProfile.php:58
-#: src/Module/BaseProfile.php:61 src/Module/Contact.php:510
+#: src/Module/BaseProfile.php:61 src/Module/Contact.php:513
 #: view/theme/frio/theme.php:224
 msgid "Media"
 msgstr ""
@@ -2098,8 +2099,9 @@ msgstr ""
 
 #: src/Content/Nav.php:271 src/Content/Nav.php:326
 #: src/Content/Text/HTML.php:872 src/Module/BaseProfile.php:112
-#: src/Module/BaseProfile.php:115 src/Module/Contact.php:408
-#: src/Module/Contact.php:518 view/theme/frio/theme.php:232
+#: src/Module/BaseProfile.php:115 src/Module/Contact.php:181
+#: src/Module/Contact.php:411 src/Module/Contact.php:521
+#: view/theme/frio/theme.php:232
 msgid "Contacts"
 msgstr ""
 
@@ -2298,7 +2300,7 @@ msgid "The end"
 msgstr ""
 
 #: src/Content/Text/HTML.php:855 src/Content/Widget/VCard.php:116
-#: src/Model/Profile.php:454 src/Module/Contact/Profile.php:520
+#: src/Model/Profile.php:454 src/Module/Contact/Profile.php:522
 msgid "Follow"
 msgstr ""
 
@@ -2341,7 +2343,7 @@ msgstr ""
 msgid "Examples: Robert Morgenstein, Fishing"
 msgstr ""
 
-#: src/Content/Widget.php:67 src/Module/Contact.php:442
+#: src/Content/Widget.php:67 src/Module/Contact.php:445
 #: src/Module/Directory.php:82 view/theme/vier/theme.php:184
 msgid "Find"
 msgstr ""
@@ -2376,7 +2378,7 @@ msgstr ""
 msgid "Everyone"
 msgstr ""
 
-#: src/Content/Widget.php:260 src/Module/Contact.php:405
+#: src/Content/Widget.php:260 src/Module/Contact.php:408
 msgid "No relationship"
 msgstr ""
 
@@ -2385,7 +2387,7 @@ msgid "Relationships"
 msgstr ""
 
 #: src/Content/Widget.php:267 src/Module/Circle.php:281
-#: src/Module/Contact.php:326
+#: src/Module/Contact.php:329
 msgid "All Contacts"
 msgstr ""
 
@@ -2493,18 +2495,18 @@ msgid "Mention"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:109 src/Model/Profile.php:356
-#: src/Module/Contact/Profile.php:451 src/Module/Profile/Profile.php:213
+#: src/Module/Contact/Profile.php:453 src/Module/Profile/Profile.php:213
 msgid "XMPP:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:110 src/Model/Profile.php:357
-#: src/Module/Contact/Profile.php:453 src/Module/Profile/Profile.php:217
+#: src/Module/Contact/Profile.php:455 src/Module/Profile/Profile.php:217
 msgid "Matrix:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:111 src/Model/Event.php:68
 #: src/Model/Event.php:95 src/Model/Event.php:462 src/Model/Event.php:950
-#: src/Model/Profile.php:351 src/Module/Contact/Profile.php:449
+#: src/Model/Profile.php:351 src/Module/Contact/Profile.php:451
 #: src/Module/Directory.php:133 src/Module/Notifications/Introductions.php:180
 #: src/Module/Profile/Profile.php:235
 msgid "Location:"
@@ -2517,7 +2519,7 @@ msgstr ""
 
 #: src/Content/Widget/VCard.php:118 src/Model/Contact.php:1288
 #: src/Model/Contact.php:1300 src/Model/Profile.php:456
-#: src/Module/Contact/Profile.php:512
+#: src/Module/Contact/Profile.php:514
 msgid "Unfollow"
 msgstr ""
 
@@ -3228,7 +3230,7 @@ msgid "Approve"
 msgstr ""
 
 #: src/Model/Contact.php:1649 src/Model/Contact.php:1721
-#: src/Module/Contact/Profile.php:391
+#: src/Module/Contact/Profile.php:393
 #, php-format
 msgid "%s has blocked you"
 msgstr ""
@@ -3492,7 +3494,7 @@ msgstr ""
 msgid "Homepage:"
 msgstr ""
 
-#: src/Model/Profile.php:355 src/Module/Contact/Profile.php:455
+#: src/Model/Profile.php:355 src/Module/Contact/Profile.php:457
 #: src/Module/Notifications/Introductions.php:182
 msgid "About:"
 msgstr ""
@@ -4384,7 +4386,7 @@ msgid "Policies"
 msgstr ""
 
 #: src/Module/Admin/Site.php:454 src/Module/Calendar/Event/Form.php:238
-#: src/Module/Contact.php:529 src/Module/Profile/Profile.php:290
+#: src/Module/Contact.php:532 src/Module/Profile/Profile.php:290
 msgid "Advanced"
 msgstr ""
 
@@ -5196,7 +5198,7 @@ msgstr ""
 msgid "Can be \"all\" or \"tags\". \"all\" means that every public post should be received. \"tags\" means that only posts with selected tags should be received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:584 src/Module/Contact/Profile.php:346
+#: src/Module/Admin/Site.php:584 src/Module/Contact/Profile.php:348
 #: src/Module/Settings/Display.php:249
 #: src/Module/Settings/TwoFactor/Index.php:132
 msgid "Disabled"
@@ -5725,7 +5727,7 @@ msgstr ""
 msgid "Item Source"
 msgstr ""
 
-#: src/Module/BaseProfile.php:37 src/Module/Contact.php:489
+#: src/Module/BaseProfile.php:37 src/Module/Contact.php:492
 msgid "Profile Details"
 msgstr ""
 
@@ -5749,8 +5751,8 @@ msgstr ""
 msgid "Tips for New Members"
 msgstr ""
 
-#: src/Module/BaseProfile.php:141 src/Module/Contact.php:392
-#: src/Module/Contact.php:539 src/Module/Conversation/Channel.php:98
+#: src/Module/BaseProfile.php:141 src/Module/Contact.php:395
+#: src/Module/Contact.php:542 src/Module/Conversation/Channel.php:98
 #: src/Module/Conversation/Community.php:91
 #: src/Module/Conversation/Network.php:347
 #: src/Module/Moderation/BaseUsers.php:130 src/Object/Post.php:611
@@ -6048,142 +6050,142 @@ msgid_plural "%d contacts edited."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Contact.php:329
+#: src/Module/Contact.php:332
 msgid "Show all contacts"
 msgstr ""
 
-#: src/Module/Contact.php:334 src/Module/Contact.php:413
+#: src/Module/Contact.php:337 src/Module/Contact.php:416
 #: src/Module/Moderation/BaseUsers.php:92
 msgid "Pending"
 msgstr ""
 
-#: src/Module/Contact.php:337
+#: src/Module/Contact.php:340
 msgid "Only show pending contacts"
 msgstr ""
 
-#: src/Module/Contact.php:342 src/Module/Contact.php:416
+#: src/Module/Contact.php:345 src/Module/Contact.php:419
 #: src/Module/Moderation/BaseUsers.php:100
 msgid "Blocked"
 msgstr ""
 
-#: src/Module/Contact.php:345
+#: src/Module/Contact.php:348
 msgid "Only show blocked contacts"
 msgstr ""
 
-#: src/Module/Contact.php:350 src/Module/Contact.php:422
+#: src/Module/Contact.php:353 src/Module/Contact.php:425
 #: src/Module/Settings/Server/Index.php:94 src/Object/Post.php:390
 msgid "Ignored"
 msgstr ""
 
-#: src/Module/Contact.php:353
+#: src/Module/Contact.php:356
 msgid "Only show ignored contacts"
 msgstr ""
 
-#: src/Module/Contact.php:358 src/Module/Contact.php:425
+#: src/Module/Contact.php:361 src/Module/Contact.php:428
 msgid "Collapsed"
 msgstr ""
 
-#: src/Module/Contact.php:361
+#: src/Module/Contact.php:364
 msgid "Only show collapsed contacts"
 msgstr ""
 
-#: src/Module/Contact.php:366 src/Module/Contact.php:428
+#: src/Module/Contact.php:369 src/Module/Contact.php:431
 msgid "Archived"
 msgstr ""
 
-#: src/Module/Contact.php:369
+#: src/Module/Contact.php:372
 msgid "Only show archived contacts"
 msgstr ""
 
-#: src/Module/Contact.php:374 src/Module/Contact.php:419
+#: src/Module/Contact.php:377 src/Module/Contact.php:422
 msgid "Hidden"
 msgstr ""
 
-#: src/Module/Contact.php:377
+#: src/Module/Contact.php:380
 msgid "Only show hidden contacts"
 msgstr ""
 
-#: src/Module/Contact.php:385
+#: src/Module/Contact.php:388
 msgid "Organize your contact circles"
 msgstr ""
 
-#: src/Module/Contact.php:440
+#: src/Module/Contact.php:443
 msgid "Search your contacts"
 msgstr ""
 
-#: src/Module/Contact.php:441 src/Module/Search/Index.php:206
+#: src/Module/Contact.php:444 src/Module/Search/Index.php:206
 #, php-format
 msgid "Results for: %s"
 msgstr ""
 
-#: src/Module/Contact.php:449
+#: src/Module/Contact.php:452
 msgid "Update"
 msgstr ""
 
-#: src/Module/Contact.php:450 src/Module/Contact/Profile.php:560
+#: src/Module/Contact.php:453 src/Module/Contact/Profile.php:562
 #: src/Module/Moderation/Blocklist/Contact.php:105
 #: src/Module/Moderation/Users/Blocked.php:94
 #: src/Module/Moderation/Users/Index.php:103
 msgid "Unblock"
 msgstr ""
 
-#: src/Module/Contact.php:451 src/Module/Contact/Profile.php:568
+#: src/Module/Contact.php:454 src/Module/Contact/Profile.php:570
 msgid "Unignore"
 msgstr ""
 
-#: src/Module/Contact.php:452 src/Module/Contact/Profile.php:576
+#: src/Module/Contact.php:455 src/Module/Contact/Profile.php:578
 msgid "Uncollapse"
 msgstr ""
 
-#: src/Module/Contact.php:454
+#: src/Module/Contact.php:457
 msgid "Batch Actions"
 msgstr ""
 
-#: src/Module/Contact.php:497
+#: src/Module/Contact.php:500
 msgid "Conversations started by this contact"
 msgstr ""
 
-#: src/Module/Contact.php:502
+#: src/Module/Contact.php:505
 msgid "Posts and Comments"
 msgstr ""
 
-#: src/Module/Contact.php:505
+#: src/Module/Contact.php:508
 msgid "Individual Posts and Replies"
 msgstr ""
 
-#: src/Module/Contact.php:513
+#: src/Module/Contact.php:516
 msgid "Posts containing media objects"
 msgstr ""
 
-#: src/Module/Contact.php:521
+#: src/Module/Contact.php:524
 msgid "View all known contacts"
 msgstr ""
 
-#: src/Module/Contact.php:532
+#: src/Module/Contact.php:535
 msgid "Advanced Contact Settings"
 msgstr ""
 
-#: src/Module/Contact.php:568
+#: src/Module/Contact.php:576
 msgid "Mutual Friendship"
 msgstr ""
 
-#: src/Module/Contact.php:572
+#: src/Module/Contact.php:580
 msgid "is a fan of yours"
 msgstr ""
 
-#: src/Module/Contact.php:576
+#: src/Module/Contact.php:584
 msgid "you are a fan of"
 msgstr ""
 
-#: src/Module/Contact.php:594
+#: src/Module/Contact.php:602
 msgid "Pending outgoing contact request"
 msgstr ""
 
-#: src/Module/Contact.php:596
+#: src/Module/Contact.php:604
 msgid "Pending incoming contact request"
 msgstr ""
 
-#: src/Module/Contact.php:609 src/Module/Contact/Profile.php:414
+#: src/Module/Contact.php:617 src/Module/Contact/Profile.php:416
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr ""
@@ -6314,7 +6316,7 @@ msgstr ""
 msgid "Your Identity Address:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:155 src/Module/Contact/Profile.php:445
+#: src/Module/Contact/Follow.php:155 src/Module/Contact/Profile.php:447
 #: src/Module/Contact/Unfollow.php:115
 #: src/Module/Moderation/Blocklist/Contact.php:119
 #: src/Module/Moderation/Reports.php:112
@@ -6323,7 +6325,7 @@ msgstr ""
 msgid "Profile URL"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:156 src/Module/Contact/Profile.php:457
+#: src/Module/Contact/Follow.php:156 src/Module/Contact/Profile.php:459
 #: src/Module/Notifications/Introductions.php:184
 #: src/Module/Profile/Profile.php:248
 msgid "Tags:"
@@ -6425,7 +6427,7 @@ msgstr ""
 msgid "(Update was successful)"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:327 src/Module/Contact/Profile.php:531
+#: src/Module/Contact/Profile.php:327 src/Module/Contact/Profile.php:533
 msgid "Suggest friends"
 msgstr ""
 
@@ -6434,229 +6436,229 @@ msgstr ""
 msgid "Network type: %s"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:336
+#: src/Module/Contact/Profile.php:338
 msgid "Communications lost with this contact!"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:342
+#: src/Module/Contact/Profile.php:344
 msgid "Fetch further information for feeds"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:344
+#: src/Module/Contact/Profile.php:346
 msgid "Fetch information like preview pictures, title and teaser from the feed item. You can activate this if the feed doesn't contain much text. Keywords are taken from the meta header in the feed item and are posted as hash tags."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:347
+#: src/Module/Contact/Profile.php:349
 msgid "Fetch information"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:348
+#: src/Module/Contact/Profile.php:350
 msgid "Fetch keywords"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:349
+#: src/Module/Contact/Profile.php:351
 msgid "Fetch information and keywords"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:359 src/Module/Contact/Profile.php:364
-#: src/Module/Contact/Profile.php:369 src/Module/Contact/Profile.php:375
+#: src/Module/Contact/Profile.php:361 src/Module/Contact/Profile.php:366
+#: src/Module/Contact/Profile.php:371 src/Module/Contact/Profile.php:377
 msgid "No mirroring"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:360 src/Module/Contact/Profile.php:370
-#: src/Module/Contact/Profile.php:376
+#: src/Module/Contact/Profile.php:362 src/Module/Contact/Profile.php:372
+#: src/Module/Contact/Profile.php:378
 msgid "Mirror as my own posting"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:365 src/Module/Contact/Profile.php:371
+#: src/Module/Contact/Profile.php:367 src/Module/Contact/Profile.php:373
 msgid "Native reshare"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:396
+#: src/Module/Contact/Profile.php:398
 msgid "Contact Information / Notes"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:397
+#: src/Module/Contact/Profile.php:399
 msgid "Contact Settings"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:405
+#: src/Module/Contact/Profile.php:407
 msgid "Contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:409
+#: src/Module/Contact/Profile.php:411
 msgid "Their personal note"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:411
+#: src/Module/Contact/Profile.php:413
 msgid "Edit contact notes"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:415
+#: src/Module/Contact/Profile.php:417
 msgid "Block/Unblock contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:416
+#: src/Module/Contact/Profile.php:418
 #: src/Module/Moderation/Report/Create.php:291
 msgid "Ignore contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:417
+#: src/Module/Contact/Profile.php:419
 msgid "View conversations"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:422
+#: src/Module/Contact/Profile.php:424
 msgid "Last update:"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:424
+#: src/Module/Contact/Profile.php:426
 msgid "Update public posts"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:426 src/Module/Contact/Profile.php:541
+#: src/Module/Contact/Profile.php:428 src/Module/Contact/Profile.php:543
 msgid "Update now"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:428
+#: src/Module/Contact/Profile.php:430
 msgid "Awaiting connection acknowledge"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:429
+#: src/Module/Contact/Profile.php:431
 msgid "Currently blocked"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:430
+#: src/Module/Contact/Profile.php:432
 msgid "Currently ignored"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:431
+#: src/Module/Contact/Profile.php:433
 msgid "Currently collapsed"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:432
+#: src/Module/Contact/Profile.php:434
 msgid "Currently archived"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:435
+#: src/Module/Contact/Profile.php:437
 msgid "Manage remote servers"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:437
+#: src/Module/Contact/Profile.php:439
 #: src/Module/Notifications/Introductions.php:185
 msgid "Hide this contact from others"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:437
+#: src/Module/Contact/Profile.php:439
 msgid "Replies/likes to your public posts <strong>may</strong> still be visible"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:438
+#: src/Module/Contact/Profile.php:440
 msgid "Notification for new posts"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:438
+#: src/Module/Contact/Profile.php:440
 msgid "Send a notification of every new post of this contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:440
+#: src/Module/Contact/Profile.php:442
 msgid "Keyword Deny List"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:440
+#: src/Module/Contact/Profile.php:442
 msgid "Comma separated list of keywords that should not be converted to hashtags, when \"Fetch information and keywords\" is selected"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:458
+#: src/Module/Contact/Profile.php:460
 #: src/Module/Settings/TwoFactor/Index.php:146
 msgid "Actions"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:460
+#: src/Module/Contact/Profile.php:462
 #: src/Module/Settings/TwoFactor/Index.php:126 view/theme/frio/theme.php:218
 msgid "Status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:466
+#: src/Module/Contact/Profile.php:468
 msgid "Mirror postings from this contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:468
+#: src/Module/Contact/Profile.php:470
 msgid "Mark this contact as remote_self, this will cause friendica to repost new entries from this contact."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:471
+#: src/Module/Contact/Profile.php:473
 msgid "Channel Settings"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:472
+#: src/Module/Contact/Profile.php:474
 msgid "Frequency of this contact in relevant channels"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:473
+#: src/Module/Contact/Profile.php:475
 msgid "Depending on the type of the channel not all posts from this contact are displayed. By default, posts need to have a minimum amount of interactions (comments, likes) to show in your channels. On the other hand there can be contacts who flood the channel, so you might want to see only some of their posts. Or you don't want to see their content at all, but you don't want to block or hide the contact completely."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:474
+#: src/Module/Contact/Profile.php:476
 msgid "Default frequency"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:474
+#: src/Module/Contact/Profile.php:476
 msgid "Posts by this contact are displayed in the \"for you\" channel if you interact often with this contact or if a post reached some level of interaction."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:475
+#: src/Module/Contact/Profile.php:477
 msgid "Display all posts of this contact"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:475
+#: src/Module/Contact/Profile.php:477
 msgid "All posts from this contact will appear on the \"for you\" channel"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:476
+#: src/Module/Contact/Profile.php:478
 msgid "Display only few posts"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:476
+#: src/Module/Contact/Profile.php:478
 msgid "When a contact creates a lot of posts in a short period, this setting reduces the number of displayed posts in every channel."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:477
+#: src/Module/Contact/Profile.php:479
 msgid "Never display posts"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:477
+#: src/Module/Contact/Profile.php:479
 msgid "Posts from this contact will never be displayed in any channel"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:478
+#: src/Module/Contact/Profile.php:480
 msgid "Channel Only"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:478
+#: src/Module/Contact/Profile.php:480
 msgid "If enabled, posts from this contact will only appear in channels and network streams in circles, but not in the general network stream."
 msgstr ""
 
-#: src/Module/Contact/Profile.php:551
+#: src/Module/Contact/Profile.php:553
 msgid "Refetch contact data"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:562
+#: src/Module/Contact/Profile.php:564
 msgid "Toggle Blocked status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:570
+#: src/Module/Contact/Profile.php:572
 msgid "Toggle Ignored status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:578
+#: src/Module/Contact/Profile.php:580
 msgid "Toggle Collapsed status"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:585 src/Module/Contact/Revoke.php:89
+#: src/Module/Contact/Profile.php:587 src/Module/Contact/Revoke.php:89
 msgid "Revoke Follow"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:587
+#: src/Module/Contact/Profile.php:589
 msgid "Revoke the follow from this contact"
 msgstr ""
 


### PR DESCRIPTION
One can view (some?) profiles through at least three URLs: 
-  `/display/<someuid?>` (not sure if this URL is shareable with others or not)
- `/profile/<nickname>` (this URL should be shareable with others)
- `/contact/<contactId>` (confusingly I think this URL can't be shared with other users?) 

I don't know why there are three, but it is confusing.
It's possible the last one is only/mostly used when Settings -> Display -> Content/Layout -> Stay local is enabled?
Maybe /contact/ is specifically used to show remote users on your own instance? But with that setting enabled, even local users are displayed with that URL instead of `/profile/`. Maybe ideally for local users it should just redirect to the `/profile/` URL in that case, so the URL is shareable?

When viewing another user through their `/display/` URL or `/profile/` URL, their name is currently shown in the HTML title:
<img width="330" height="38" alt="image" src="https://github.com/user-attachments/assets/6385b2e0-a53b-487e-a2f8-9cc759597396" />

...but when visiting their profile via `/contact/` the title is just literally `Contact` (it's translated if friendica is set to another  language):
<img width="328" height="39" alt="image" src="https://github.com/user-attachments/assets/49d7fd66-01fd-4eab-a9bb-1f12364b1011" />

This PR changes the five pages under `/contact/` so they also display the display name in the title:
<img width="328" height="39" alt="image" src="https://github.com/user-attachments/assets/edb87c3b-2842-477f-8813-fa74f1854fe5" />

# Thoughts

I'm wondering a little what the disadvantages would be, if "stay local" was default. I think it makes it simpler to use Friendica, and it makes it easier to interact with content from other instances, as long as it's been federated to one's instance. I guess perhaps a limitation is one may see less content because not all of it has been federated??