### PR TITLE
Settings -> Delegation: Turn register link into a button to improve visibility

### DIFF
--- a/view/templates/settings/delegation.tpl
+++ b/view/templates/settings/delegation.tpl
@@ -10,7 +10,7 @@
 {{if !$is_child_user}}
 	<h3>{{$l10n.account_header}}</h3>
 	<div id="add-account-desc" class="add-account-desc"><p>{{$l10n.account_desc}}</p></div>
-	<p><a href="register">{{$l10n.add_account}}</a></p>
+	<p><a class="btn btn-primary" href="register">{{$l10n.add_account}}</a></p>
 {{/if}}
 
 {{if $parent_user}}
@@ -22,7 +22,7 @@
             {{include file="field_select.tpl" field=$parent_user}}
             {{include file="field_password.tpl" field=$parent_password}}
 			<div class="submit">
-				<button type="submit" name="delegate" value="{{$l10n.submit}}">{{$l10n.submit}}</button>
+				<button class="btn btn-primary" type="submit" name="delegate" value="{{$l10n.submit}}">{{$l10n.submit}}</button>
 			</div>
 		</form>
 	</div>


### PR DESCRIPTION
The link to register a new account doesn't stand out enough on settings/delegation IMO.
This PR changes it from a regular ol' link to a much more visible button.
The "Save settings" button is also turned into a bootstrap button and btn-primary so they're the same size, and for consistency with the rest of the "Save settings" buttons under settings.

Additionally changed: 
- The settings/profile button to also say "Save settings" instead of "Submit" for consistency.
- The send message button to say "Send message", also so translators can select a specific translation for that particular button, instead of having to select one translation for the many different buttons that say "Submit".

Together with a change like #14960 and somewhat #15015 I hope to make it more visible and easier to create groups and pages.

A future thing I'd like to do is fx. add the selection of the account type directly to the account creation page when additional accounts are created, and probably, in general, separate the templates for initial registration and additional account registration, because they already differ a fair amount, and I think for a good experience they should differ even more.

Before (Frio):
<img width="648" height="519" alt="image" src="https://github.com/user-attachments/assets/797148b9-9493-4be2-b32b-3ab675779017" />

After (Frio):
<img width="663" height="813" alt="image" src="https://github.com/user-attachments/assets/72dc27dd-7902-459d-bb32-99360d5aea92" />

After (Vier):
<img width="783" height="710" alt="image" src="https://github.com/user-attachments/assets/22720e03-a5b6-4a6a-96ab-62790daa99b6" />