### PR TITLE
Improve UX for the search input field (mostly Frio)

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -117,7 +117,7 @@ class Nav
 			'$home'               => $this->l10n->t('Home'),
 			'$skip'               => $this->l10n->t('Skip to main content'),
 			'$clear_notifs'       => $this->l10n->t('Clear notifications'),
-			'$search_hint'        => $this->l10n->t('@name, !group, #tags, content')
+			'$search_placeholder' => $this->l10n->t('Search: @name, !group, #tags, content')
 		]);
 
 		$nav = $this->eventDispatcher->dispatch(

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-06 05:55+0000\n"
+"POT-Creation-Date: 2025-08-07 19:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1964,8 +1964,8 @@ msgstr ""
 msgid "Clear notifications"
 msgstr ""
 
-#: src/Content/Nav.php:120 src/Content/Text/HTML.php:863
-msgid "@name, !group, #tags, content"
+#: src/Content/Nav.php:120
+msgid "Search: @name, !group, #tags, content"
 msgstr ""
 
 #: src/Content/Nav.php:219 src/Module/Security/Login.php:146
@@ -2299,6 +2299,10 @@ msgstr ""
 #: src/Content/Text/HTML.php:855 src/Content/Widget/VCard.php:116
 #: src/Model/Profile.php:454 src/Module/Contact/Profile.php:520
 msgid "Follow"
+msgstr ""
+
+#: src/Content/Text/HTML.php:863
+msgid "@name, !group, #tags, content"
 msgstr ""
 
 #: src/Content/Widget.php:36

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -161,6 +161,11 @@ details summary {
 	body.aside-out {
 		overflow: hidden;
 	}
+	/* More space for the search field */
+	#topbar-first .container {
+		padding-left: 0;
+		padding-right: 0;
+	}
 }
 /*
 * standard page elements
@@ -884,7 +889,7 @@ nav.navbar .nav > li > button:focus {
 }
 
 #nav-search-input-field {
-	width: 250px;
+	width: 296px;
 }
 
 #nav-search-input-field::placeholder {
@@ -2479,6 +2484,10 @@ input[type="range"].form-control {
 }
 #search-box .form-button-search {
 	top: 1px;
+}
+
+#search-box .navbar-form {
+	margin-right: -15px;
 }
 
 .search-input.form-control.form-search {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -854,10 +854,6 @@ nav.navbar .nav > li > button:focus {
 	max-height: calc(100vh - 55px);
 	overflow-y: auto;
 }
-#topbar-first #search-box .navbar-form {
-	margin: 0px;
-	padding: 12px 12px;
-}
 #search-mobile {
 	position: fixed;
 	top: 90px;
@@ -873,17 +869,26 @@ nav.navbar .nav > li > button:focus {
 	min-height: 0;
 	border-radius: 0;
 }
+
 #search-mobile .navbar-form {
 	margin: 0;
 }
-#topbar-first #search-box .form-search {
-	height: 25px;
-	font-size: 13px;
-	background-position: 8px 4px;
+
+#search-mobile .form-button-search {
+	padding: 4px 15px;
+	top: 2px;
 }
-#topbar-first #search-box .btn {
-	font-size: 10px;
-	padding: 1px 8px;
+
+#search-mobile .form-button-search .fa {
+	font-size: 1.6em;
+}
+
+#nav-search-input-field {
+	width: 250px;
+}
+
+#nav-search-input-field::placeholder {
+	font-size: 13px;
 }
 
 /* second topbar */
@@ -2454,22 +2459,28 @@ input[type="range"].form-control {
 /* Search form */
 .form-control.form-search {
 	border-radius: 30px;
-	background-image: url(img/icon_search16x16.png);
-	background-repeat: no-repeat;
-	background-position: 10px 8px;
-	padding-left: 34px;
 }
 .form-group-search {
 	position: relative;
 	width: 100%;
 }
 
-.form-group-search .form-button-search {
-	position: absolute;
-	top: 2px;
-	right: 4px;
-	border-radius: 30px;
+#search-box .fa-search {
+	font-size: 1.4em;
 }
+
+/* Both desktop and mobile - multiple search fields */
+.form-group-search .form-button-search {
+	border-radius: 30px;
+	padding: 3px 10px;
+	position: absolute;
+	right: 4px;
+	top: 2px;
+}
+#search-box .form-button-search {
+	top: 1px;
+}
+
 .search-input.form-control.form-search {
 	width: 100%;
 }

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -164,10 +164,11 @@
 								<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
 									<div class="form-group form-group-search">
 										<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
-											type="text" name="q" data-toggle="tooltip" data-viewport="#topbar-first" title="{{$search_hint}}"
-											placeholder="{{$nav.search.1}}">
-										<button class="btn btn-default btn-sm form-button-search"
-											type="submit">{{$nav.search.1}}</button>
+											type="search" name="q" placeholder="{{$search_hint}}">
+										<button class="btn btn-primary btn-md form-button-search" type="submit">
+											<i class="fa fa-search" aria-hidden="true"></i>
+											<span class="sr-only">{{$nav.search.1}}</span>
+										</button>
 									</div>
 								</form>
 							</li>
@@ -516,9 +517,12 @@
 	<div class="col-xs-12">
 		<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
 			<div class="form-group form-group-search">
-				<input id="nav-search-input-field-mobile" class="form-control form-search" type="text" name="q"
-					data-toggle="tooltip"  data-viewport="#topbar-first" title="{{$search_hint}}" placeholder="{{$nav.search.1}}">
-				<button class="btn btn-default btn-sm form-button-search" type="submit">{{$nav.search.1}}</button>
+				<input id="nav-search-input-field-mobile" class="form-control form-search" type="search" name="q"
+					placeholder="{{$search_hint}}">
+				<button class="btn btn-primary btn-sm form-button-search" type="submit">
+					<i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
+					<span class="sr-only">{{$nav.search.1}}</span>
+				</button>
 			</div>
 		</form>
 	</div>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -164,7 +164,7 @@
 								<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
 									<div class="form-group form-group-search">
 										<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
-											type="search" name="q" placeholder="{{$nav.search.1}}: {{$search_hint}}">
+											type="search" name="q" placeholder="{{$search_placeholder}}">
 										<button class="btn btn-primary btn-md form-button-search" type="submit">
 											<i class="fa fa-search" aria-hidden="true"></i>
 											<span class="sr-only">{{$nav.search.1}}</span>
@@ -518,7 +518,7 @@
 		<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
 			<div class="form-group form-group-search">
 				<input id="nav-search-input-field-mobile" class="form-control form-search" type="search" name="q"
-					placeholder="{{$nav.search.1}}: {{$search_hint}}">
+					placeholder="{{$search_placeholder}}">
 				<button class="btn btn-primary btn-sm form-button-search" type="submit">
 					<i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
 					<span class="sr-only">{{$nav.search.1}}</span>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -164,7 +164,7 @@
 								<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
 									<div class="form-group form-group-search">
 										<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
-											type="search" name="q" placeholder="{{$search_hint}}">
+											type="search" name="q" placeholder="{{$nav.search.1}}: {{$search_hint}}">
 										<button class="btn btn-primary btn-md form-button-search" type="submit">
 											<i class="fa fa-search" aria-hidden="true"></i>
 											<span class="sr-only">{{$nav.search.1}}</span>
@@ -518,7 +518,7 @@
 		<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
 			<div class="form-group form-group-search">
 				<input id="nav-search-input-field-mobile" class="form-control form-search" type="search" name="q"
-					placeholder="{{$search_hint}}">
+					placeholder="{{$nav.search.1}}: {{$search_hint}}">
 				<button class="btn btn-primary btn-sm form-button-search" type="submit">
 					<i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
 					<span class="sr-only">{{$nav.search.1}}</span>

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -679,8 +679,7 @@ nav#topbar-first #nav-search-box #nav-search-text {
 	position: relative;
 	height: 17px;
 	margin: 4px 0px 4px 4px;
-	width: 150px;
-	max-width: 150px;
+	width: 257px;
 	background-color: #eee;
 }
 

--- a/view/theme/vier/templates/nav.tpl
+++ b/view/theme/vier/templates/nav.tpl
@@ -128,7 +128,7 @@
 		{{if $nav.search}}
 			<li role="search" id="nav-search-box">
 				<form method="get" action="{{$nav.search.0}}">
-					<input accesskey="s" id="nav-search-text" class="nav-menu-search" type="text" value="" name="q" placeholder=" {{$search_hint}}">
+					<input accesskey="s" id="nav-search-text" class="nav-menu-search" type="text" value="" name="q" placeholder=" {{$search_placeholder}}">
 					<select name="search-option">
 						<option value="fulltext">{{$nav.searchoption.0}}</option>
 						<option value="tags">{{$nav.searchoption.1}}</option>


### PR DESCRIPTION
Closes #3073

This PR makes changes to the search box mostly based off suggestions by @foss- on the linked issue.
Specifically it copies the hover title to the placeholder text, removes the now redundant hover title, and makes the search field larger both because I think it's too small and to better fit the longer placeholder text.

In some cases I think the hover texts are a symptom of a UI not being sufficiently self explanatory or too complex, and I don't know if something based on hover can be viewed at all on a touch screen? And if it's important information, like in this case, it shouldn't be hidden inside a hover text.

Currently the PR also removes the leading magnifying glass icon and instead uses that on the search button replacing the text...?

I've opened it as a draft for anyone who may have feedback/suggestions.

Before - desktop:
<img width="260" height="46" alt="image" src="https://github.com/user-attachments/assets/555e808c-5754-4f8f-8954-096c20d1b682" />

After - desktop:
<img width="613" height="155" alt="image" src="https://github.com/user-attachments/assets/0e0c9d58-b345-4e77-a595-63e48d14048b" />

After - at smaller resolutions like mobile:
<img width="590" height="210" alt="image" src="https://github.com/user-attachments/assets/a1ebaf48-da9a-4007-81ed-db9a011f363b" />

I've made the search button somewhat larger on mobile to hopefully make it easier to hit on a touch screen.
