### PR TITLE
Dedicated check for Peertube application account

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -618,9 +618,11 @@ class APContact
 			return true;
 		}
 
-		$contact = Contact::getByURL($apcontact['url'], false, ['contact-type']);
-		if ($contact['contact-type'] ?? 0 == Contact::TYPE_RELAY) {
-			return true;
+		if (($apcontact['type'] == 'Application') && !empty($apcontact['gsid'])) {
+			$gserver = DBA::selectFirst('gserver', ['platform'], ['id' => $apcontact['gsid']]);
+			if ($gserver['platform'] ?? '' == 'peertube') {
+				return true;
+			}
 		}
 
 		return false;


### PR DESCRIPTION
PR #15038 introduced a way to subscribe to the application account of Peertube servers as a relay. 

This had a side effect: Now every Peertube channel appeared as relay contact. Same happened with Friendica channels.

This is now fixed.