### PR TITLE
Add a translatable HTML title to newmember page

### DIFF
--- a/src/Module/Welcome.php
+++ b/src/Module/Welcome.php
@@ -18,10 +18,11 @@ class Welcome extends BaseModule
 {
 	protected function content(array $request = []): string
 	{
-		$config = DI::config();
+		$config             = DI::config();
+		DI::page()['title'] = DI::l10n()->t('Welcome to Friendica');
 
-		$mail_disabled   = ((function_exists('imap_open') &&
-		                     (!$config->get('system', 'imap_disabled'))));
+		$mail_disabled = ((function_exists('imap_open') &&
+							 (!$config->get('system', 'imap_disabled'))));
 		$newuser_private = $config->get('system', 'newuser_private');
 
 		$tpl = Renderer::getMarkupTemplate('welcome.tpl');
@@ -62,9 +63,9 @@ class Welcome extends BaseModule
 			'$circles'             => DI::l10n()->t('Circles'),
 			'$circle_contact_link' => DI::l10n()->t('Add Your Contacts To Circle'),
 			'$circle_contact_txt'  => DI::l10n()->t('Once you have made some friends, organize them into private conversation circles from the sidebar of your Contacts page and then you can interact with each circle privately on your Network page.'),
-			'$newuser_private'    => $newuser_private,
-			'$private_link'       => DI::l10n()->t('Why Aren\'t My Posts Public?'),
-			'$private_txt'        => DI::l10n()->t('Friendica respects your privacy. By default, your posts will only show up to people you\'ve added as friends. For more information, see the help section from the link above.'),
+			'$newuser_private'     => $newuser_private,
+			'$private_link'        => DI::l10n()->t('Why Aren\'t My Posts Public?'),
+			'$private_txt'         => DI::l10n()->t('Friendica respects your privacy. By default, your posts will only show up to people you\'ve added as friends. For more information, see the help section from the link above.'),
 
 			'$help'      => DI::l10n()->t('Getting Help'),
 			'$help_link' => DI::l10n()->t('Go to the Help Section'),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-17 09:29+0200\n"
+"POT-Creation-Date: 2025-08-03 18:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -302,9 +302,9 @@ msgstr ""
 #: src/Module/Invite.php:162 src/Module/Item/Compose.php:188
 #: src/Module/Moderation/Item/Source.php:74
 #: src/Module/Moderation/Report/Create.php:153
-#: src/Module/Moderation/Report/Create.php:168
-#: src/Module/Moderation/Report/Create.php:196
-#: src/Module/Moderation/Report/Create.php:256
+#: src/Module/Moderation/Report/Create.php:170
+#: src/Module/Moderation/Report/Create.php:198
+#: src/Module/Moderation/Report/Create.php:258
 #: src/Module/Profile/Profile.php:288 src/Module/Settings/Profile/Index.php:272
 #: src/Module/Settings/Server/Action.php:65 src/Module/User/Delegation.php:181
 #: src/Object/Post.php:1159 view/theme/duepuntozero/config.php:73
@@ -1696,7 +1696,7 @@ msgstr ""
 
 #: src/Content/Feature.php:126 src/Content/Widget.php:233
 #: src/Model/Circle.php:587 src/Module/Contact.php:382
-#: src/Module/Welcome.php:62
+#: src/Module/Welcome.php:63
 msgid "Circles"
 msgstr ""
 
@@ -1765,7 +1765,7 @@ msgstr ""
 msgid "Display a list of folders in which posts are stored."
 msgstr ""
 
-#: src/Content/Feature.php:134 src/Module/Conversation/Timeline.php:189
+#: src/Content/Feature.php:134 src/Module/Conversation/Timeline.php:190
 msgid "Own Contacts"
 msgstr ""
 
@@ -1974,7 +1974,7 @@ msgstr ""
 #: src/Content/Nav.php:227 src/Module/BaseProfile.php:34
 #: src/Module/BaseSettings.php:86 src/Module/Contact.php:486
 #: src/Module/Contact/Profile.php:462 src/Module/Profile/Profile.php:282
-#: src/Module/Welcome.php:43 view/theme/frio/theme.php:219
+#: src/Module/Welcome.php:44 view/theme/frio/theme.php:219
 msgid "Profile"
 msgstr ""
 
@@ -2173,7 +2173,7 @@ msgstr ""
 
 #: src/Content/Nav.php:324 src/Module/Admin/Addons/Details.php:140
 #: src/Module/Admin/Themes/Details.php:85 src/Module/BaseSettings.php:177
-#: src/Module/Welcome.php:38 view/theme/frio/theme.php:231
+#: src/Module/Welcome.php:39 view/theme/frio/theme.php:231
 msgid "Settings"
 msgstr ""
 
@@ -3494,7 +3494,7 @@ msgstr ""
 msgid "Atom feed"
 msgstr ""
 
-#: src/Model/Profile.php:465
+#: src/Model/Profile.php:465 src/Module/Profile/Profile.php:296
 msgid "This website has been verified to belong to the same person."
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgid "Title/Description:"
 msgstr ""
 
 #: src/Model/Profile.php:803 src/Module/Admin/Summary.php:184
-#: src/Module/Moderation/Report/Create.php:278
+#: src/Module/Moderation/Report/Create.php:280
 #: src/Module/Moderation/Summary.php:65
 msgid "Summary"
 msgstr ""
@@ -4026,8 +4026,8 @@ msgid "Manage Additional Features"
 msgstr ""
 
 #: src/Module/Admin/Federation.php:70
-#: src/Module/Moderation/Report/Create.php:176
-#: src/Module/Moderation/Report/Create.php:319
+#: src/Module/Moderation/Report/Create.php:178
+#: src/Module/Moderation/Report/Create.php:321
 msgid "Other"
 msgstr ""
 
@@ -5744,7 +5744,7 @@ msgstr ""
 #: src/Module/BaseProfile.php:141 src/Module/Contact.php:392
 #: src/Module/Contact.php:539 src/Module/Conversation/Channel.php:98
 #: src/Module/Conversation/Community.php:91
-#: src/Module/Conversation/Network.php:349
+#: src/Module/Conversation/Network.php:347
 #: src/Module/Moderation/BaseUsers.php:130 src/Object/Post.php:611
 msgid "More"
 msgstr ""
@@ -6489,7 +6489,7 @@ msgid "Block/Unblock contact"
 msgstr ""
 
 #: src/Module/Contact/Profile.php:416
-#: src/Module/Moderation/Report/Create.php:291
+#: src/Module/Moderation/Report/Create.php:293
 msgid "Ignore contact"
 msgstr ""
 
@@ -6714,29 +6714,29 @@ msgstr ""
 msgid "Not available."
 msgstr ""
 
-#: src/Module/Conversation/Network.php:254
+#: src/Module/Conversation/Network.php:252
 msgid "No such circle"
 msgstr ""
 
-#: src/Module/Conversation/Network.php:258
+#: src/Module/Conversation/Network.php:256
 #, php-format
 msgid "Circle: %s"
 msgstr ""
 
-#: src/Module/Conversation/Network.php:278
+#: src/Module/Conversation/Network.php:276
 #, php-format
 msgid "Error %d (%s) while fetching the timeline."
 msgstr ""
 
-#: src/Module/Conversation/Network.php:361
+#: src/Module/Conversation/Network.php:359
 msgid "Network feed not available."
 msgstr ""
 
-#: src/Module/Conversation/Timeline.php:193
+#: src/Module/Conversation/Timeline.php:194
 msgid "Include"
 msgstr ""
 
-#: src/Module/Conversation/Timeline.php:194
+#: src/Module/Conversation/Timeline.php:195
 msgid "Hide"
 msgstr ""
 
@@ -7884,10 +7884,10 @@ msgid "Please login to access this page."
 msgstr ""
 
 #: src/Module/Moderation/Report/Create.php:150
-#: src/Module/Moderation/Report/Create.php:165
-#: src/Module/Moderation/Report/Create.php:193
-#: src/Module/Moderation/Report/Create.php:253
-#: src/Module/Moderation/Report/Create.php:277
+#: src/Module/Moderation/Report/Create.php:167
+#: src/Module/Moderation/Report/Create.php:195
+#: src/Module/Moderation/Report/Create.php:255
+#: src/Module/Moderation/Report/Create.php:279
 msgid "Create Moderation Report"
 msgstr ""
 
@@ -7903,152 +7903,152 @@ msgstr ""
 msgid "Contact address/URL"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:166
+#: src/Module/Moderation/Report/Create.php:168
 msgid "Pick Category"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:167
+#: src/Module/Moderation/Report/Create.php:169
 msgid "Please pick below the category of your report."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:171
-#: src/Module/Moderation/Report/Create.php:309
+#: src/Module/Moderation/Report/Create.php:173
+#: src/Module/Moderation/Report/Create.php:311
 msgid "Spam"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:171
+#: src/Module/Moderation/Report/Create.php:173
 msgid "This contact is publishing many repeated/overly long posts/replies or advertising their product/websites in otherwise irrelevant conversations."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:172
-#: src/Module/Moderation/Report/Create.php:311
+#: src/Module/Moderation/Report/Create.php:174
+#: src/Module/Moderation/Report/Create.php:313
 msgid "Illegal Content"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:172
+#: src/Module/Moderation/Report/Create.php:174
 msgid "This contact is publishing content that is considered illegal in this node's hosting juridiction."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:173
-#: src/Module/Moderation/Report/Create.php:313
+#: src/Module/Moderation/Report/Create.php:175
+#: src/Module/Moderation/Report/Create.php:315
 msgid "Community Safety"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:173
+#: src/Module/Moderation/Report/Create.php:175
 msgid "This contact aggravated you or other people, by being provocative or insensitive, intentionally or not. This includes disclosing people's private information (doxxing), posting threats or offensive pictures in posts or replies."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:174
-#: src/Module/Moderation/Report/Create.php:315
+#: src/Module/Moderation/Report/Create.php:176
+#: src/Module/Moderation/Report/Create.php:317
 msgid "Unwanted Content/Behavior"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:174
+#: src/Module/Moderation/Report/Create.php:176
 msgid "This contact has repeatedly published content irrelevant to the node's theme or is openly criticizing the node's administration/moderation without directly engaging with the relevant people for example or repeatedly nitpicking on a sensitive topic."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:175
-#: src/Module/Moderation/Report/Create.php:317
+#: src/Module/Moderation/Report/Create.php:177
+#: src/Module/Moderation/Report/Create.php:319
 msgid "Rules Violation"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:175
+#: src/Module/Moderation/Report/Create.php:177
 msgid "This contact violated one or more rules of this node. You will be able to pick which one(s) in the next step."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:176
+#: src/Module/Moderation/Report/Create.php:178
 msgid "Please elaborate below why you submitted this report. The more details you provide, the better your report can be handled."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:178
+#: src/Module/Moderation/Report/Create.php:180
 msgid "Additional Information"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:178
+#: src/Module/Moderation/Report/Create.php:180
 msgid "Please provide any additional information relevant to this particular report. You will be able to attach posts by this contact in the next step, but any context is welcome."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:194
+#: src/Module/Moderation/Report/Create.php:196
 msgid "Pick Rules"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:195
+#: src/Module/Moderation/Report/Create.php:197
 msgid "Please pick below the node rules you believe this contact violated."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:254
+#: src/Module/Moderation/Report/Create.php:256
 msgid "Pick Posts"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:255
+#: src/Module/Moderation/Report/Create.php:257
 msgid "Please optionally pick posts to attach to your report."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:271
+#: src/Module/Moderation/Report/Create.php:273
 msgid "Would you like to forward this report to the remote server?"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:273
+#: src/Module/Moderation/Report/Create.php:275
 msgid "Would you ike to forward this report to the remote server?"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:279
+#: src/Module/Moderation/Report/Create.php:281
 msgid "Submit Report"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:280
+#: src/Module/Moderation/Report/Create.php:282
 msgid "Further Action"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:281
+#: src/Module/Moderation/Report/Create.php:283
 msgid "You can also perform one of the following action on the contact you reported:"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:289
+#: src/Module/Moderation/Report/Create.php:291
 msgid "Nothing"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:290
+#: src/Module/Moderation/Report/Create.php:292
 msgid "Collapse contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:290
+#: src/Module/Moderation/Report/Create.php:292
 msgid "Their posts and replies will keep appearing in your Network page but their content will be collapsed by default."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:291
+#: src/Module/Moderation/Report/Create.php:293
 msgid "Their posts won't appear in your Network page anymore, but their replies can appear in forum threads. They still can follow you."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:292
+#: src/Module/Moderation/Report/Create.php:294
 msgid "Block contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:292
+#: src/Module/Moderation/Report/Create.php:294
 msgid "Their posts won't appear in your Network page anymore, but their replies can appear in forum threads, with their content collapsed by default. They cannot follow you but still can have access to your public posts by other means."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:295
+#: src/Module/Moderation/Report/Create.php:297
 msgid "Forward report"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:334
+#: src/Module/Moderation/Report/Create.php:336
 msgid "1. Pick a contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:335
+#: src/Module/Moderation/Report/Create.php:337
 msgid "2. Pick a category"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:336
+#: src/Module/Moderation/Report/Create.php:338
 msgid "2a. Pick rules"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:337
+#: src/Module/Moderation/Report/Create.php:339
 msgid "2b. Add comment"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:338
+#: src/Module/Moderation/Report/Create.php:340
 msgid "3. Pick posts"
 msgstr ""
 
@@ -8574,19 +8574,19 @@ msgstr ""
 msgid "No contacts."
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:96 src/Module/Profile/Profile.php:367
+#: src/Module/Profile/Conversations.php:96 src/Module/Profile/Profile.php:368
 #: src/Protocol/Feed.php:1124
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:97 src/Module/Profile/Profile.php:368
+#: src/Module/Profile/Conversations.php:97 src/Module/Profile/Profile.php:369
 #: src/Protocol/Feed.php:1127
 #, php-format
 msgid "%s's comments"
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:98 src/Module/Profile/Profile.php:369
+#: src/Module/Profile/Conversations.php:98 src/Module/Profile/Profile.php:370
 #: src/Protocol/Feed.php:1120
 #, php-format
 msgid "%s's timeline"
@@ -8674,11 +8674,11 @@ msgstr ""
 msgid "View profile as:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:297 src/Module/Profile/Profile.php:299
+#: src/Module/Profile/Profile.php:298 src/Module/Profile/Profile.php:300
 msgid "Edit profile"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:304
+#: src/Module/Profile/Profile.php:305
 msgid "View as"
 msgstr ""
 
@@ -10254,7 +10254,7 @@ msgstr ""
 msgid "Custom Profile Fields"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:280 src/Module/Welcome.php:44
+#: src/Module/Settings/Profile/Index.php:280 src/Module/Welcome.php:45
 msgid "Upload Profile Photo"
 msgstr ""
 
@@ -10912,123 +10912,123 @@ msgstr ""
 msgid "Done. You can now login with your username and password"
 msgstr ""
 
-#: src/Module/Welcome.php:30
+#: src/Module/Welcome.php:22 src/Module/Welcome.php:31
 msgid "Welcome to Friendica"
 msgstr ""
 
-#: src/Module/Welcome.php:31
+#: src/Module/Welcome.php:32
 msgid "New Member Checklist"
 msgstr ""
 
-#: src/Module/Welcome.php:32
+#: src/Module/Welcome.php:33
 msgid "We would like to offer some tips and links to help make your experience enjoyable. Click any item to visit the relevant page. A link to this page will be visible from your home page for two weeks after your initial registration and then will quietly disappear."
 msgstr ""
 
-#: src/Module/Welcome.php:34
+#: src/Module/Welcome.php:35
 msgid "Getting Started"
 msgstr ""
 
-#: src/Module/Welcome.php:35
+#: src/Module/Welcome.php:36
 msgid "Friendica Walk-Through"
 msgstr ""
 
-#: src/Module/Welcome.php:36
+#: src/Module/Welcome.php:37
 msgid "On your <em>Quick Start</em> page - find a brief introduction to your profile and network tabs, make some new connections, and find some groups to join."
 msgstr ""
 
-#: src/Module/Welcome.php:39
+#: src/Module/Welcome.php:40
 msgid "Go to Your Settings"
 msgstr ""
 
-#: src/Module/Welcome.php:40
+#: src/Module/Welcome.php:41
 msgid "On your <em>Settings</em> page -  change your initial password. Also make a note of your Identity Address. This looks just like an email address - and will be useful in making friends on the free social web."
 msgstr ""
 
-#: src/Module/Welcome.php:41
+#: src/Module/Welcome.php:42
 msgid "Review the other settings, particularly the privacy settings. An unpublished directory listing is like having an unlisted phone number. In general, you should probably publish your listing - unless all of your friends and potential friends know exactly how to find you."
 msgstr ""
 
-#: src/Module/Welcome.php:45
+#: src/Module/Welcome.php:46
 msgid "Upload a profile photo if you have not done so already. Studies have shown that people with real photos of themselves are ten times more likely to make friends than people who do not."
 msgstr ""
 
-#: src/Module/Welcome.php:46
+#: src/Module/Welcome.php:47
 msgid "Edit Your Profile"
 msgstr ""
 
-#: src/Module/Welcome.php:47
+#: src/Module/Welcome.php:48
 msgid "Edit your <strong>default</strong> profile to your liking. Review the settings for hiding your list of friends and hiding the profile from unknown visitors."
 msgstr ""
 
-#: src/Module/Welcome.php:48
+#: src/Module/Welcome.php:49
 msgid "Profile Keywords"
 msgstr ""
 
-#: src/Module/Welcome.php:49
+#: src/Module/Welcome.php:50
 msgid "Set some public keywords for your profile which describe your interests. We may be able to find other people with similar interests and suggest friendships."
 msgstr ""
 
-#: src/Module/Welcome.php:51
+#: src/Module/Welcome.php:52
 msgid "Connecting"
 msgstr ""
 
-#: src/Module/Welcome.php:53
+#: src/Module/Welcome.php:54
 msgid "Importing Emails"
 msgstr ""
 
-#: src/Module/Welcome.php:54
+#: src/Module/Welcome.php:55
 msgid "Enter your email access information on your Connector Settings page if you wish to import and interact with friends or mailing lists from your email INBOX"
 msgstr ""
 
-#: src/Module/Welcome.php:55
+#: src/Module/Welcome.php:56
 msgid "Go to Your Contacts Page"
 msgstr ""
 
-#: src/Module/Welcome.php:56
+#: src/Module/Welcome.php:57
 msgid "Your Contacts page is your gateway to managing friendships and connecting with friends on other networks. Typically you enter their address or site URL in the <em>Add New Contact</em> dialog."
 msgstr ""
 
-#: src/Module/Welcome.php:57
+#: src/Module/Welcome.php:58
 msgid "Go to Your Site's Directory"
 msgstr ""
 
-#: src/Module/Welcome.php:58
+#: src/Module/Welcome.php:59
 msgid "The Directory page lets you find other people in this network or other federated sites. Look for a <em>Connect</em> or <em>Follow</em> link on their profile page. Provide your own Identity Address if requested."
 msgstr ""
 
-#: src/Module/Welcome.php:59
+#: src/Module/Welcome.php:60
 msgid "Finding New People"
 msgstr ""
 
-#: src/Module/Welcome.php:60
+#: src/Module/Welcome.php:61
 msgid "On the side panel of the Contacts page are several tools to find new friends. We can match people by interest, look up people by name or interest, and provide suggestions based on network relationships. On a brand new site, friend suggestions will usually begin to be populated within 24 hours."
 msgstr ""
 
-#: src/Module/Welcome.php:63
+#: src/Module/Welcome.php:64
 msgid "Add Your Contacts To Circle"
 msgstr ""
 
-#: src/Module/Welcome.php:64
+#: src/Module/Welcome.php:65
 msgid "Once you have made some friends, organize them into private conversation circles from the sidebar of your Contacts page and then you can interact with each circle privately on your Network page."
 msgstr ""
 
-#: src/Module/Welcome.php:66
+#: src/Module/Welcome.php:67
 msgid "Why Aren't My Posts Public?"
 msgstr ""
 
-#: src/Module/Welcome.php:67
+#: src/Module/Welcome.php:68
 msgid "Friendica respects your privacy. By default, your posts will only show up to people you've added as friends. For more information, see the help section from the link above."
 msgstr ""
 
-#: src/Module/Welcome.php:69
+#: src/Module/Welcome.php:70
 msgid "Getting Help"
 msgstr ""
 
-#: src/Module/Welcome.php:70
+#: src/Module/Welcome.php:71
 msgid "Go to the Help Section"
 msgstr ""
 
-#: src/Module/Welcome.php:71
+#: src/Module/Welcome.php:72
 msgid "Our <strong>help</strong> pages may be consulted for detail on other program features and resources."
 msgstr ""
 


### PR DESCRIPTION
Currently the title on /newmember is hardcoded to Newmember, and is not translatable.

This sets it to "Welcome to Friendica", like the title on the page, and it's now translatable and because it's an existing header it's likely already translated in many languages.