### PR TITLE
Welcome: Remove legacy name for the walkthrough

### DIFF
--- a/src/Module/Welcome.php
+++ b/src/Module/Welcome.php
@@ -32,9 +32,9 @@ class Welcome extends BaseModule
 			'$checklist'   => DI::l10n()->t('New Member Checklist'),
 			'$description' => DI::l10n()->t('We would like to offer some tips and links to help make your experience enjoyable. Click any item to visit the relevant page. A link to this page will be visible from your home page for two weeks after your initial registration and then will quietly disappear.'),
 
-			'$started'         => DI::l10n()->t('Getting Started'),
-			'$quickstart_link' => DI::l10n()->t('Friendica Walk-Through'),
-			'$quickstart_txt'  => DI::l10n()->t('On your <em>Quick Start</em> page - find a brief introduction to your profile and network tabs, make some new connections, and find some groups to join.'),
+			'$started'          => DI::l10n()->t('Getting Started'),
+			'$walkthrough_link' => DI::l10n()->t('Friendica Walk-Through'),
+			'$walkthrough_txt'  => DI::l10n()->t('Complete the walk-through to get a quick overview of your profile and network tabs, establish new connections and find groups to join.'),
 
 			'$settings'       => DI::l10n()->t('Settings'),
 			'$settings_link'  => DI::l10n()->t('Go to Your Settings'),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-03 18:01+0200\n"
+"POT-Creation-Date: 2025-08-03 20:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10933,7 +10933,7 @@ msgid "Friendica Walk-Through"
 msgstr ""
 
 #: src/Module/Welcome.php:37
-msgid "On your <em>Quick Start</em> page - find a brief introduction to your profile and network tabs, make some new connections, and find some groups to join."
+msgid "Complete the walk-through to get a quick overview of your profile and network tabs, establish new connections and find groups to join."
 msgstr ""
 
 #: src/Module/Welcome.php:40

--- a/view/templates/welcome.tpl
+++ b/view/templates/welcome.tpl
@@ -12,8 +12,8 @@
 		<h4>{{$started nofilter}}</h4>
 		<ul>
 			<li>
-				<a target="newmember" href="help/Quick-Start-guide">{{$quickstart_link}}</a><br />
-				{{$quickstart_txt nofilter}}
+				<a target="newmember" href="help/Quick-Start-guide">{{$walkthrough_link}}</a><br />
+				{{$walkthrough_txt nofilter}}
 			</li>
 		</ul>
 		<h4>{{$settings nofilter}}</h4>


### PR DESCRIPTION
/newmember has this passage of text:
<img width="611" height="77" alt="image" src="https://github.com/user-attachments/assets/dd34b05d-8f97-4c6e-8a54-644deeb77e4f" />

...which I was about to translate, but then it confused me on Transifex as I didn't find other translations indicating where this "Quick start" page could be found. It turns out it's now called the "Friendica walk-through", which I found out from looking at the page the translation belongs to and because "Quick-Start-Guide" is still the URL for it. But most people don't read URLs.

This small PR rewrites and simplifies that passage to the following, which also avoids naming it twice in a row which could get out of sync again:
<img width="611" height="77" alt="image" src="https://github.com/user-attachments/assets/982221d0-0783-446d-ab4e-4bfd2ff61054" />