### PR TITLE
Two minor submit button text changes

### DIFF
--- a/mod/message.php
+++ b/mod/message.php
@@ -187,7 +187,7 @@ function message_content()
 			'$upload'      => DI::l10n()->t('Upload photo'),
 			'$insert'      => DI::l10n()->t('Insert web link'),
 			'$wait'        => DI::l10n()->t('Please wait'),
-			'$submit'      => DI::l10n()->t('Submit')
+			'$submit'      => DI::l10n()->t('Send Message')
 		]);
 		return $o;
 	}

--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -269,7 +269,7 @@ class Index extends BaseSettings
 			'$l10n' => [
 				'profile_action'            => $this->t('Profile Actions'),
 				'banner'                    => $this->t('Edit Profile Details'),
-				'submit'                    => $this->t('Submit'),
+				'submit'                    => $this->t('Save Settings'),
 				'profpic'                   => $this->t('Change Profile Photo'),
 				'viewprof'                  => $this->t('View Profile'),
 				'personal_section'          => $this->t('Personal'),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-03 20:36+0200\n"
+"POT-Creation-Date: 2025-08-05 21:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -289,28 +289,8 @@ msgstr ""
 msgid "Please wait"
 msgstr ""
 
-#: mod/message.php:190 mod/message.php:346 mod/photos.php:658
-#: mod/photos.php:778 mod/photos.php:1055 mod/photos.php:1097
-#: mod/photos.php:1153 mod/photos.php:1233
-#: src/Module/Calendar/Event/Form.php:236 src/Module/Contact/Advanced.php:118
-#: src/Module/Contact/Profile.php:407
-#: src/Module/Debug/ActivityPubConversion.php:128
-#: src/Module/Debug/Babel.php:279 src/Module/Debug/Localtime.php:50
-#: src/Module/Debug/Probe.php:40 src/Module/Debug/WebFinger.php:37
-#: src/Module/FriendSuggest.php:132 src/Module/Install.php:219
-#: src/Module/Install.php:259 src/Module/Install.php:296
-#: src/Module/Invite.php:162 src/Module/Item/Compose.php:188
-#: src/Module/Moderation/Item/Source.php:74
-#: src/Module/Moderation/Report/Create.php:153
-#: src/Module/Moderation/Report/Create.php:170
-#: src/Module/Moderation/Report/Create.php:198
-#: src/Module/Moderation/Report/Create.php:258
-#: src/Module/Profile/Profile.php:288 src/Module/Settings/Profile/Index.php:272
-#: src/Module/Settings/Server/Action.php:65 src/Module/User/Delegation.php:181
-#: src/Object/Post.php:1159 view/theme/duepuntozero/config.php:73
-#: view/theme/frio/config.php:155 view/theme/quattro/config.php:75
-#: view/theme/vier/config.php:123
-msgid "Submit"
+#: mod/message.php:190
+msgid "Send Message"
 msgstr ""
 
 #: mod/message.php:211
@@ -339,6 +319,28 @@ msgstr ""
 
 #: mod/message.php:335
 msgid "Send Reply"
+msgstr ""
+
+#: mod/message.php:346 mod/photos.php:658 mod/photos.php:778
+#: mod/photos.php:1055 mod/photos.php:1097 mod/photos.php:1153
+#: mod/photos.php:1233 src/Module/Calendar/Event/Form.php:236
+#: src/Module/Contact/Advanced.php:118 src/Module/Contact/Profile.php:407
+#: src/Module/Debug/ActivityPubConversion.php:128
+#: src/Module/Debug/Babel.php:279 src/Module/Debug/Localtime.php:50
+#: src/Module/Debug/Probe.php:40 src/Module/Debug/WebFinger.php:37
+#: src/Module/FriendSuggest.php:132 src/Module/Install.php:219
+#: src/Module/Install.php:259 src/Module/Install.php:296
+#: src/Module/Invite.php:162 src/Module/Item/Compose.php:188
+#: src/Module/Moderation/Item/Source.php:74
+#: src/Module/Moderation/Report/Create.php:153
+#: src/Module/Moderation/Report/Create.php:168
+#: src/Module/Moderation/Report/Create.php:196
+#: src/Module/Moderation/Report/Create.php:256
+#: src/Module/Profile/Profile.php:288 src/Module/Settings/Server/Action.php:65
+#: src/Module/User/Delegation.php:181 src/Object/Post.php:1159
+#: view/theme/duepuntozero/config.php:73 view/theme/frio/config.php:155
+#: view/theme/quattro/config.php:75 view/theme/vier/config.php:123
+msgid "Submit"
 msgstr ""
 
 #: mod/message.php:414
@@ -646,7 +648,7 @@ msgstr ""
 msgid "Map"
 msgstr ""
 
-#: src/App.php:456
+#: src/App.php:465
 msgid "Apologies but the website is unavailable at the moment."
 msgstr ""
 
@@ -1830,7 +1832,7 @@ msgstr ""
 msgid "Create new group"
 msgstr ""
 
-#: src/Content/Item.php:324 src/Model/Item.php:3012
+#: src/Content/Item.php:324 src/Model/Item.php:3025
 msgid "event"
 msgstr ""
 
@@ -1838,7 +1840,7 @@ msgstr ""
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:333 src/Model/Item.php:3014
+#: src/Content/Item.php:333 src/Model/Item.php:3027
 #: src/Module/Post/Tag/Add.php:112
 msgid "photo"
 msgstr ""
@@ -2240,8 +2242,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:931 src/Model/Item.php:3850
-#: src/Model/Item.php:3856 src/Model/Item.php:3857
+#: src/Content/Text/BBCode.php:931 src/Model/Item.php:3863
+#: src/Model/Item.php:3869 src/Model/Item.php:3870
 msgid "Link to source"
 msgstr ""
 
@@ -3396,75 +3398,75 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/Model/Item.php:3016
+#: src/Model/Item.php:3029
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:3018
+#: src/Model/Item.php:3031
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:3021 src/Module/Post/Tag/Add.php:112
+#: src/Model/Item.php:3034 src/Module/Post/Tag/Add.php:112
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3210
+#: src/Model/Item.php:3223
 #, php-format
 msgid "%s is blocked"
 msgstr ""
 
-#: src/Model/Item.php:3212
+#: src/Model/Item.php:3225
 #, php-format
 msgid "%s is ignored"
 msgstr ""
 
-#: src/Model/Item.php:3214
+#: src/Model/Item.php:3227
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:3218
+#: src/Model/Item.php:3231
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3750
+#: src/Model/Item.php:3763
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3781
+#: src/Model/Item.php:3794
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3783
+#: src/Model/Item.php:3796
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3788
+#: src/Model/Item.php:3801
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3790
+#: src/Model/Item.php:3803
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3792
+#: src/Model/Item.php:3805
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3833 src/Model/Item.php:3834
+#: src/Model/Item.php:3846 src/Model/Item.php:3847
 msgid "View on separate page"
 msgstr ""
 
@@ -3571,7 +3573,7 @@ msgid "Title/Description:"
 msgstr ""
 
 #: src/Model/Profile.php:803 src/Module/Admin/Summary.php:184
-#: src/Module/Moderation/Report/Create.php:280
+#: src/Module/Moderation/Report/Create.php:278
 #: src/Module/Moderation/Summary.php:65
 msgid "Summary"
 msgstr ""
@@ -3933,6 +3935,7 @@ msgstr ""
 #: src/Module/Settings/ContactImport.php:110
 #: src/Module/Settings/Delegation.php:179 src/Module/Settings/Display.php:307
 #: src/Module/Settings/Features.php:61
+#: src/Module/Settings/Profile/Index.php:272
 msgid "Save Settings"
 msgstr ""
 
@@ -4026,8 +4029,8 @@ msgid "Manage Additional Features"
 msgstr ""
 
 #: src/Module/Admin/Federation.php:70
-#: src/Module/Moderation/Report/Create.php:178
-#: src/Module/Moderation/Report/Create.php:321
+#: src/Module/Moderation/Report/Create.php:176
+#: src/Module/Moderation/Report/Create.php:319
 msgid "Other"
 msgstr ""
 
@@ -6489,7 +6492,7 @@ msgid "Block/Unblock contact"
 msgstr ""
 
 #: src/Module/Contact/Profile.php:416
-#: src/Module/Moderation/Report/Create.php:293
+#: src/Module/Moderation/Report/Create.php:291
 msgid "Ignore contact"
 msgstr ""
 
@@ -7884,10 +7887,10 @@ msgid "Please login to access this page."
 msgstr ""
 
 #: src/Module/Moderation/Report/Create.php:150
-#: src/Module/Moderation/Report/Create.php:167
-#: src/Module/Moderation/Report/Create.php:195
-#: src/Module/Moderation/Report/Create.php:255
-#: src/Module/Moderation/Report/Create.php:279
+#: src/Module/Moderation/Report/Create.php:165
+#: src/Module/Moderation/Report/Create.php:193
+#: src/Module/Moderation/Report/Create.php:253
+#: src/Module/Moderation/Report/Create.php:277
 msgid "Create Moderation Report"
 msgstr ""
 
@@ -7903,152 +7906,152 @@ msgstr ""
 msgid "Contact address/URL"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:168
+#: src/Module/Moderation/Report/Create.php:166
 msgid "Pick Category"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:169
+#: src/Module/Moderation/Report/Create.php:167
 msgid "Please pick below the category of your report."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:173
-#: src/Module/Moderation/Report/Create.php:311
+#: src/Module/Moderation/Report/Create.php:171
+#: src/Module/Moderation/Report/Create.php:309
 msgid "Spam"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:173
+#: src/Module/Moderation/Report/Create.php:171
 msgid "This contact is publishing many repeated/overly long posts/replies or advertising their product/websites in otherwise irrelevant conversations."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:174
-#: src/Module/Moderation/Report/Create.php:313
+#: src/Module/Moderation/Report/Create.php:172
+#: src/Module/Moderation/Report/Create.php:311
 msgid "Illegal Content"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:174
+#: src/Module/Moderation/Report/Create.php:172
 msgid "This contact is publishing content that is considered illegal in this node's hosting juridiction."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:175
-#: src/Module/Moderation/Report/Create.php:315
+#: src/Module/Moderation/Report/Create.php:173
+#: src/Module/Moderation/Report/Create.php:313
 msgid "Community Safety"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:175
+#: src/Module/Moderation/Report/Create.php:173
 msgid "This contact aggravated you or other people, by being provocative or insensitive, intentionally or not. This includes disclosing people's private information (doxxing), posting threats or offensive pictures in posts or replies."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:176
-#: src/Module/Moderation/Report/Create.php:317
+#: src/Module/Moderation/Report/Create.php:174
+#: src/Module/Moderation/Report/Create.php:315
 msgid "Unwanted Content/Behavior"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:176
+#: src/Module/Moderation/Report/Create.php:174
 msgid "This contact has repeatedly published content irrelevant to the node's theme or is openly criticizing the node's administration/moderation without directly engaging with the relevant people for example or repeatedly nitpicking on a sensitive topic."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:177
-#: src/Module/Moderation/Report/Create.php:319
+#: src/Module/Moderation/Report/Create.php:175
+#: src/Module/Moderation/Report/Create.php:317
 msgid "Rules Violation"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:177
+#: src/Module/Moderation/Report/Create.php:175
 msgid "This contact violated one or more rules of this node. You will be able to pick which one(s) in the next step."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:178
+#: src/Module/Moderation/Report/Create.php:176
 msgid "Please elaborate below why you submitted this report. The more details you provide, the better your report can be handled."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:180
+#: src/Module/Moderation/Report/Create.php:178
 msgid "Additional Information"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:180
+#: src/Module/Moderation/Report/Create.php:178
 msgid "Please provide any additional information relevant to this particular report. You will be able to attach posts by this contact in the next step, but any context is welcome."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:196
+#: src/Module/Moderation/Report/Create.php:194
 msgid "Pick Rules"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:197
+#: src/Module/Moderation/Report/Create.php:195
 msgid "Please pick below the node rules you believe this contact violated."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:256
+#: src/Module/Moderation/Report/Create.php:254
 msgid "Pick Posts"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:257
+#: src/Module/Moderation/Report/Create.php:255
 msgid "Please optionally pick posts to attach to your report."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:273
+#: src/Module/Moderation/Report/Create.php:271
 msgid "Would you like to forward this report to the remote server?"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:275
+#: src/Module/Moderation/Report/Create.php:273
 msgid "Would you ike to forward this report to the remote server?"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:281
+#: src/Module/Moderation/Report/Create.php:279
 msgid "Submit Report"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:282
+#: src/Module/Moderation/Report/Create.php:280
 msgid "Further Action"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:283
+#: src/Module/Moderation/Report/Create.php:281
 msgid "You can also perform one of the following action on the contact you reported:"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:291
+#: src/Module/Moderation/Report/Create.php:289
 msgid "Nothing"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:292
+#: src/Module/Moderation/Report/Create.php:290
 msgid "Collapse contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:292
+#: src/Module/Moderation/Report/Create.php:290
 msgid "Their posts and replies will keep appearing in your Network page but their content will be collapsed by default."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:293
+#: src/Module/Moderation/Report/Create.php:291
 msgid "Their posts won't appear in your Network page anymore, but their replies can appear in forum threads. They still can follow you."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:294
+#: src/Module/Moderation/Report/Create.php:292
 msgid "Block contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:294
+#: src/Module/Moderation/Report/Create.php:292
 msgid "Their posts won't appear in your Network page anymore, but their replies can appear in forum threads, with their content collapsed by default. They cannot follow you but still can have access to your public posts by other means."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:297
+#: src/Module/Moderation/Report/Create.php:295
 msgid "Forward report"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:336
+#: src/Module/Moderation/Report/Create.php:334
 msgid "1. Pick a contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:337
+#: src/Module/Moderation/Report/Create.php:335
 msgid "2. Pick a category"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:338
+#: src/Module/Moderation/Report/Create.php:336
 msgid "2a. Pick rules"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:339
+#: src/Module/Moderation/Report/Create.php:337
 msgid "2b. Add comment"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:340
+#: src/Module/Moderation/Report/Create.php:338
 msgid "3. Pick posts"
 msgstr ""
 
@@ -11215,7 +11218,7 @@ msgid "%1$s commented on your thread %2$s"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:222
-#: src/Navigation/Notifications/Repository/Notify.php:770
+#: src/Navigation/Notifications/Repository/Notify.php:780
 msgid "[Friendica:Notify]"
 msgstr ""
 
@@ -11259,7 +11262,7 @@ msgid "%1$s commented on their %2$s %3$s"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:338
-#: src/Navigation/Notifications/Repository/Notify.php:804
+#: src/Navigation/Notifications/Repository/Notify.php:817
 #, php-format
 msgid "%1$s Comment to conversation #%2$d by %3$s"
 msgstr ""
@@ -11271,7 +11274,7 @@ msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:344
 #: src/Navigation/Notifications/Repository/Notify.php:360
-#: src/Navigation/Notifications/Repository/Notify.php:830
+#: src/Navigation/Notifications/Repository/Notify.php:843
 #, php-format
 msgid "Please visit %s to view and/or reply to the conversation."
 msgstr ""
@@ -11456,22 +11459,22 @@ msgstr ""
 msgid "Please visit %s to have a look at the new registration."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:798
+#: src/Navigation/Notifications/Repository/Notify.php:811
 #, php-format
 msgid "%s %s tagged you"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:801
+#: src/Navigation/Notifications/Repository/Notify.php:814
 #, php-format
 msgid "%s %s shared a new post"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:809
+#: src/Navigation/Notifications/Repository/Notify.php:822
 #, php-format
 msgid "%1$s %2$s liked your post #%3$d"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:812
+#: src/Navigation/Notifications/Repository/Notify.php:825
 #, php-format
 msgid "%1$s %2$s liked your comment on #%3$d"
 msgstr ""


### PR DESCRIPTION
Pulling these out of #15045 into their own PR as there were really unrelated.

It changes the translations for two submit buttons:
1. The "Send message" button on /message, so users can write unique, descriptive translations for that button
    "Submit" -> "Send Message"
2. A submit button in settings/profile which - unlike almost all other buttons in settings - said "Submit" instead of "Save Settings" 
   "Submit" -> "Save Settings"
   
"Save Settings" was already in translations while "Send Message" is new.