### PR TITLE
Improve exclusion of URI fragments when looking for hashtags in posts

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2464,7 +2464,7 @@ class BBCode
 			// Otherwise pull out single word tags. These can be @nickname, @first_last
 			// and #hash tags.
 
-			if (preg_match_all('/([!#@][^\^ \x0D\x0A,;:?\']*[^\^ \x0D\x0A,;:?!\'.])/', $string, $matches)) {
+			if (preg_match_all('/(?<=^|\s)([!#@][^\^ \x0D\x0A,;:?\']*[^\^ \x0D\x0A,;:?!\'.])/', $string, $matches)) {
 				foreach ($matches[1] as $match) {
 					if (strstr($match, ']')) {
 						// we might be inside a bbcode color tag - leave it alone

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -340,6 +340,29 @@ Karl Marx - Die ursprüngliche Akkumulation
 		self::assertEquals($expected, $actual);
 	}
 
+	public function dataGetTags()
+	{
+		return [
+			'bug-15076-uri-fragments-require-space-before-tags' => [
+				[],
+				'https://github.com/uBlockOrigin/uBOL-home/wiki/Frequently-asked-questions-(FAQ)#if-i-install-ubol-will-i-see-a-difference-with-ubo',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetTags
+	 *
+	 * @param array $expected Expected BBCode output
+	 * @param string $text     Input text
+	 */
+	public function testGetTags(array $expected, string $text)
+	{
+		$actual = BBCode::getTags($text);
+
+		self::assertEquals($expected, $actual);
+	}
+
 	public function dataExpandTags()
 	{
 		return [


### PR DESCRIPTION
Closes #15076  

An attempt at further preventing detection of URI fragments as hashtags, specifically by expecting a hashtag to either start a line or have some kind of space character in front (`\s), checking via positive lookbehind.

Test case, which is broken before this PR:
`https://github.com/uBlockOrigin/uBOL-home/wiki/Frequently-asked-questions-(FAQ)#if-i-install-ubol-will-i-see-a-difference-with-ubo`

After this PR it still seems to find hashtags starting sentences, in the middle of them and ending them:
<img width="379" height="54" alt="image" src="https://github.com/user-attachments/assets/8ab31ae9-89b4-47a5-bdff-e39fdbcaa535" />

Opening as a draft in case someone else has feedback or want to test, and because it's probably very common to overlook some relevant scenarios, just like previous PRs to this have done.  
Here some automated tests for various different scenarios would probably be quite helpful.