### PR TITLE
Messages: Raise the number of messages shown in the side bar

### DIFF
--- a/mod/message.php
+++ b/mod/message.php
@@ -27,7 +27,7 @@ function message_init()
 	$tabs = '';
 
 	if (DI::args()->getArgc() > 1 && is_numeric(DI::args()->getArgv()[1])) {
-		$tabs = render_messages(get_messages(DI::userSession()->getLocalUserId(), 0, 5), 'mail_list.tpl');
+		$tabs = render_messages(get_messages(DI::userSession()->getLocalUserId(), 0, 15), 'mail_list.tpl');
 	}
 
 	$new = [


### PR DESCRIPTION
Currently this list of messages on the left is hardcoded to only show up to 5 posts:

<img width="956" height="768" alt="image" src="https://github.com/user-attachments/assets/4a56475c-4ca3-47ce-b3db-a8a5f737950c" />

This tiny PR raises it to 15, making it more usable to navigate between different message threads, so one doesn't have to go back to the main messages screen to find other messages to read/reply to quite as often.

I have verified that the pane supports scrolling, in case there isn't space to show them all.

Longer term maybe a `pconfig` could be added for it, or maybe it could be dynamically set based off available space somehow. The main list of messages is set to "items per page", which appears to be 50, and possibly also hardcoded. But maybe that's a bit high for that side column...?
