### PR TITLE
Issue 15047: Set the notification to seen

### DIFF
--- a/src/Module/Notifications/Notification.php
+++ b/src/Module/Notifications/Notification.php
@@ -144,11 +144,11 @@ class Notification extends BaseModule
 			$Notify->setSeen();
 			$this->notifyRepo->save($Notify);
 		} else {
-			if ($Notify->uriId) {
-				$this->notificationRepo->setAllSeenForUser($Notify->uid, ['target-uri-id' => $Notify->uriId]);
-			}
-
 			$this->notifyRepo->setAllSeenForRelatedNotify($Notify);
+		}
+
+		if ($Notify->uriId) {
+			$this->notificationRepo->setAllSeenForUser($Notify->uid, ['target-uri-id' => $Notify->uriId]);
 		}
 
 		if ((string)$Notify->link) {


### PR DESCRIPTION
Fixes #15047. We have got two classes that are responsible for notifications. So when we set an item to seen on the one class, this has to be done on the other as well. 