### PR TITLE
Frio - Textarea adjustments

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1495,7 +1495,6 @@ section #jotOpen {
 #jot-text-wrap textarea {
 	min-height: 100px;
 	overflow-y: auto !important;
-	overflow-y: overlay !important;
 }
 #jot-text-wrap .preview textarea {
 	width: 100%;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -73,6 +73,13 @@ video {
 blockquote {
 	font-size: inherit;
 }
+textarea {
+	/* The JS autoresizing lib autosize appears to lock vertical resizing because I guess it may conflict with it.
+	 * This leaves horizontal resizing but that generally is less useful and it frequently breaks the layout.
+	 * So fully disable resizing for textareas until we replace this lib with CSS field-sizing
+	 * */
+	resize: none;
+}
 .clear {
 	clear: both;
 }

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2786,8 +2786,8 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 .mail-thread #prvmail-message-label > label {
 	display: none;
 }
-.mail-thread #prvmail-message-label textarea {
-	max-height: 120px;
+.mail-thread #prvmail-message-label textarea, #comment-edit-text-input {
+	min-height: 120px;
 }
 .mail-conv-wrapper {
 	padding: 15px 0;

--- a/view/theme/frio/js/mod_contacts.js
+++ b/view/theme/frio/js/mod_contacts.js
@@ -7,9 +7,6 @@
 var batchConfirmed = false;
 
 $(document).ready(function () {
-	// Initiale autosize for the textareas.
-	autosize($("textarea.text-autosize"));
-
 	// Replace the drop contact link of the photo menu
 	// with a confirmation modal.
 	$("body").on("click", ".contact-photo-menu a", function (e) {

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -468,6 +468,9 @@ $(document).ready(function () {
 	} catch(err) {
 		$('.button-browser-share').hide();
 	}
+
+	// initiale autosize for the textareas
+	autosize($("textarea.text-autosize"));
 });
 
 function openClose(theID) {

--- a/view/theme/frio/templates/calendar/event_form.tpl
+++ b/view/theme/frio/templates/calendar/event_form.tpl
@@ -187,8 +187,5 @@
 		enableDisableFinishDate();
 		// load bbcode autocomplete for the description textarea
 		$('#comment-edit-text-desc, #comment-edit-text-loc').bbco_autocomplete('bbcode');
-
-		// initiale autosize for the textareas
-		autosize($("textarea.text-autosize"));
 	});
 </script>

--- a/view/theme/frio/templates/photo_edit.tpl
+++ b/view/theme/frio/templates/photo_edit.tpl
@@ -43,10 +43,3 @@
 		</div>
 	</div>
 </form>
-
-<script type="text/javascript">
-	$(document).ready( function() {
-		// initiale autosize for the textareas
-		autosize($("textarea.text-autosize"));
-	});
-</script>

--- a/view/theme/frio/templates/prv_message.tpl
+++ b/view/theme/frio/templates/prv_message.tpl
@@ -81,10 +81,3 @@
 
 </form>
 </div>
-
-<script type="text/javascript">
-	$(document).ready( function() {
-		// initiale autosize for the textareas
-		autosize($("textarea.text-autosize"));
-	});
-</script>

--- a/view/theme/frio/templates/prv_message.tpl
+++ b/view/theme/frio/templates/prv_message.tpl
@@ -25,7 +25,7 @@
 	{{* The message input field which contains the message text *}}
 	<div id="prvmail-message-label" class="form-group">
 		<label for="comment-edit-text-input">{{$yourmessage}}</label>
-		<textarea rows="8" cols="72" class="prvmail-text form-control text-autosize" id="comment-edit-text-input" name="body" tabindex="12" dir="auto" onkeydown="sendOnCtrlEnter(event, 'prvmail-submit')">{{$text}}</textarea>
+		<textarea class="prvmail-text form-control text-autosize" id="comment-edit-text-input" name="body" tabindex="12" dir="auto" onkeydown="sendOnCtrlEnter(event, 'prvmail-submit')">{{$text}}</textarea>
 	</div>
 
 	<ul id="prvmail-text-edit-bb" class="comment-edit-bb comment-icon-list nav nav-pills hidden-xs pull-left">

--- a/view/theme/frio/templates/settings/profile/index.tpl
+++ b/view/theme/frio/templates/settings/profile/index.tpl
@@ -177,7 +177,4 @@
 <script type="text/javascript">
 	Fill_Country('{{$country_name.2}}');
 	Fill_States('{{$region.2}}');
-
-	// initiale autosize for the textareas
-	autosize($("textarea.text-autosize"));
 </script>


### PR DESCRIPTION
Does three things in frio:

# Apply textarea resizing to all elements with the relevant css class

Moves the resizing of textareas from individual JS files to theme.js so they apply everywhere where the `text-autosize` class has been set on an element.

Fx. the newmember addon had the class added for resizing but that page didn't run the necessary JS to activate it. And it's quite useful to not only be limited to seeing three lines at a time  when writing a decently sized welcome text:
<img width="639" height="272" alt="image" src="https://github.com/user-attachments/assets/a403e33b-545c-4a9d-b078-dd14abdf978a" />

In the future the new CSS attribute mentioned here #15088 should make this JS library superfluous in Friendica.

# Disable horizontal resize for textareas 

The `autosize` library textarea resizing disables vertical resizing, I assume because it does the resizing itself. That leaves horizontal resize but that's rarely useful and mostly just breaks the layout
<img width="1007" height="466" alt="image" src="https://github.com/user-attachments/assets/ca4bed4e-e42e-48da-8761-d81342713947" />

# Allow private message textarea to expand with contents

Right now it's limited to 120px and so autosizing doesn't really do much. I've set 120px to the miniimum height instead,
so now it can expand if you write long texts.

<img width="640" height="286" alt="image" src="https://github.com/user-attachments/assets/edbddf9d-5a56-41c2-9162-c972f2a15288" />

---

...and finally a deprecated CSS rule - `overflow-y: overlay` is removed.