### PR TITLE
Frio CSS: Only apply resize: none to .text-autosize, not all textareas

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -73,7 +73,7 @@ video {
 blockquote {
 	font-size: inherit;
 }
-textarea {
+textarea.text-autosize {
 	/* The JS autoresizing lib autosize appears to lock vertical resizing because I guess it may conflict with it.
 	 * This leaves horizontal resizing but that generally is less useful and it frequently breaks the layout.
 	 * So fully disable resizing for textareas until we replace this lib with CSS field-sizing


### PR DESCRIPTION
A tiny adjustment to #15090 changing the disabling of resizing to only affect elements with the `.text-autosize` class, instead of all textareas.
In the future perhaps textarea element itself should just be autosized by default, but until then I think it makes sense that those that don't autosize can still be manually resized.