### PR TITLE
Added support for HLS videos from Peertube

### DIFF
--- a/mod/item.php
+++ b/mod/item.php
@@ -97,7 +97,7 @@ function item_edit(int $uid, array $request, bool $preview, string $return_path)
 	$post['edit'] = $post;
 	$post['file'] = Post\Category::getTextByURIId($post['uri-id'], $post['uid']);
 
-	Post\Media::deleteByURIId($post['uri-id'], [Post\Media::AUDIO, Post\Media::VIDEO, Post\Media::IMAGE, Post\Media::HTML]);
+	Post\Media::deleteByURIId($post['uri-id'], [Post\Media::AUDIO, Post\Media::VIDEO, Post\Media::IMAGE, Post\Media::HTML, Post\Media::HLS]);
 	$post = item_process($post, $request, $preview, $return_path);
 
 	$fields = [

--- a/src/Content/Post/Repository/PostMedia.php
+++ b/src/Content/Post/Repository/PostMedia.php
@@ -124,6 +124,15 @@ class PostMedia extends BaseRepository
 		$selected = '';
 		$previews = [];
 		$video    = [];
+		$is_hls   = false;
+
+		// Check if there is any HLS media
+		// This is used to determine if we should suppress some of the media types
+		foreach ($PostMedias as $PostMedia) {
+			if ($PostMedia->type == PostMediaEntity::TYPE_HLS) {
+				$is_hls = true;
+			}
+		}
 
 		foreach ($PostMedias as $PostMedia) {
 			foreach ($links as $link) {
@@ -142,6 +151,12 @@ class PostMedia extends BaseRepository
 			// Currently these two types are ignored here.
 			// Posts are added differently and contacts are not displayed as attachments.
 			if (in_array($PostMedia->type, [PostMediaEntity::TYPE_ACCOUNT, PostMediaEntity::TYPE_ACTIVITY])) {
+				continue;
+			}
+
+			if ($is_hls && in_array($PostMedia->type, [PostMediaEntity::TYPE_VIDEO, PostMediaEntity::TYPE_TORRENT])) {
+				// If there is HLS media, we don't want to show any other video or torrents.
+				// This is mainly a workaround for Peertube.
 				continue;
 			}
 

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -250,7 +250,7 @@ class Media
 			$media = self::addAccount($media);
 		}
 
-		if (in_array($media['type'], [self::ACTIVITY, self::LD, self::JSON]) || self::isFederatedServer($media['url'])) {
+		if (in_array($media['type'], [self::ACTIVITY, self::LD, self::JSON]) || (self::isFederatedServer($media['url']) && !in_array($media['type'], [self::HLS, self::AUDIO, self::VIDEO]))) {
 			$media = self::addActivity($media);
 		}
 
@@ -552,7 +552,7 @@ class Media
 			$type = self::TEXT;
 		} elseif (($filetype == 'application') && ($subtype == 'x-bittorrent')) {
 			$type = self::TORRENT;
-		} elseif (($filetype == 'application') && ($subtype == 'vnd.apple.mpegurl')) {
+		} elseif (($filetype == 'application') && in_array($subtype, ['vnd.apple.mpegurl', 'x-mpegurl'])) {
 			$type = self::HLS;
 		} elseif (($filetype == 'application') && ($subtype == 'activity+json')) {
 			$type = self::ACTIVITY;

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -231,7 +231,7 @@ class Processor
 		$item['changed'] = DateTimeFormat::utcNow();
 		$item['edited']  = DateTimeFormat::utc($activity['updated']);
 
-		Post\Media::deleteByURIId($item['uri-id'], [Post\Media::AUDIO, Post\Media::VIDEO, Post\Media::IMAGE, Post\Media::HTML]);
+		Post\Media::deleteByURIId($item['uri-id'], [Post\Media::AUDIO, Post\Media::VIDEO, Post\Media::IMAGE, Post\Media::HTML, Post\Media::HLS, Post\Media::TORRENT]);
 		$item = self::processContent($activity, $item);
 		if (empty($item)) {
 			Queue::remove($activity);

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1676,6 +1676,11 @@ class Receiver
 					];
 					break;
 				default:
+					if (!empty($attachment['as:icon'])) {
+						$icon = JsonLD::fetchElement($attachment['as:icon'], 'as:url', '@id');
+					} else {
+						$icon = null;
+					}
 					$attachlist[] = [
 						'type'      => str_replace('as:', '', JsonLD::fetchElement($attachment, '@type')),
 						'mediaType' => JsonLD::fetchElement($attachment, 'as:mediaType', '@value'),
@@ -1683,7 +1688,7 @@ class Receiver
 						'url'       => JsonLD::fetchElement($attachment, 'as:url', '@id') ?? JsonLD::fetchElement($attachment, 'as:href', '@id'),
 						'height'    => JsonLD::fetchElement($attachment, 'as:height', '@value'),
 						'width'     => JsonLD::fetchElement($attachment, 'as:width', '@value'),
-						'image'     => JsonLD::fetchElement($attachment, 'as:image', '@id')
+						'image'     => JsonLD::fetchElement($attachment, 'as:image', '@id') ?? $icon,
 					];
 			}
 		}
@@ -1748,6 +1753,33 @@ class Receiver
 		}
 
 		return $question;
+	}
+
+	/**
+	 * Process the icon of an object
+	 *
+	 * @param array $object The object to process
+	 *
+	 * @return string|null The icon URL or null if not found
+	 */
+	private static function processIcon(array $object): ?string
+	{
+		if (empty($object['as:icon'])) {
+			return null;
+		}
+
+		$icon     = null;
+		$width    = 0;
+		$previous = 0;
+		foreach (JsonLD::fetchElementArray($object, 'as:icon') as $element) {
+			$width = (int)JsonLD::fetchElement($element, 'as:width', '@value');
+			if ($previous < $width) {
+				$icon     = JsonLD::fetchElement($element, 'as:url', '@id');
+				$previous = $width;
+			}
+		}
+
+		return $icon;
 	}
 
 	/**
@@ -1826,10 +1858,11 @@ class Receiver
 	 * This is the case with audio and video posts.
 	 * Then the links are added as attachments
 	 *
-	 * @param array $urls The object URL list
+	 * @param array       $urls The object URL list
+	 * @param string|null $icon The icon URL to use for the attachments
 	 * @return array an array of attachments
 	 */
-	private static function processAttachmentUrls(array $urls): array
+	private static function processAttachmentUrls(array $urls, ?string $icon): array
 	{
 		$attachments = [];
 		foreach ($urls as $key => $url) {
@@ -1855,7 +1888,7 @@ class Receiver
 			$filetype = strtolower(substr($mediatype, 0, strpos($mediatype, '/')));
 
 			if ($filetype == 'audio') {
-				$attachments[] = ['type' => $filetype, 'mediaType' => $mediatype, 'url' => $href, 'height' => null, 'size' => null, 'name' => ''];
+				$attachments[] = ['type' => $filetype, 'mediaType' => $mediatype, 'url' => $href, 'height' => null, 'size' => null, 'name' => '', 'image' => $icon];
 			} elseif ($filetype == 'video') {
 				$height = (int)JsonLD::fetchElement($url, 'as:height', '@value');
 				// PeerTube audio-only track
@@ -1865,7 +1898,7 @@ class Receiver
 
 				$size = (int)JsonLD::fetchElement($url, 'pt:size', '@value');
 
-				$attachments[] = ['type' => $filetype, 'mediaType' => $mediatype, 'url' => $href, 'height' => $height, 'size' => $size, 'name' => ''];
+				$attachments[] = ['type' => $filetype, 'mediaType' => $mediatype, 'url' => $href, 'height' => $height, 'size' => $size, 'name' => '', 'image' => $icon];
 			} elseif (in_array($mediatype, ['application/x-bittorrent', 'application/x-bittorrent;x-scheme-handler/magnet'])) {
 				$height = (int)JsonLD::fetchElement($url, 'as:height', '@value');
 
@@ -1876,8 +1909,10 @@ class Receiver
 
 				$attachments[$mediatype] = ['type' => $mediatype, 'mediaType' => $mediatype, 'url' => $href, 'height' => $height, 'size' => null, 'name' => ''];
 			} elseif ($mediatype == 'application/x-mpegURL') {
-				// PeerTube exception, actual video link is in the tags of this URL element
-				$attachments = array_merge($attachments, self::processAttachmentUrls($url['as:tag']));
+				// PeerTube uses HLS streams for video. We prefer HLS streams over the video file itself.
+				// But we still store the video file as an attachment to be used by the API which currently does not support HLS streams.
+				$attachments   = array_merge($attachments, self::processAttachmentUrls($url['as:tag'], $icon));
+				$attachments[] = ['type' => $filetype, 'mediaType' => $mediatype, 'url' => $href, 'height' => null, 'size' => null, 'name' => '', 'image' => $icon];
 			}
 		}
 
@@ -2047,7 +2082,7 @@ class Receiver
 
 		if (in_array($object_data['object_type'], ['as:Audio', 'as:Video'])) {
 			$object_data['alternate-url'] = self::extractAlternateUrl($object['as:url'] ?? []) ?: $object_data['alternate-url'];
-			$object_data['attachments']   = array_merge($object_data['attachments'], self::processAttachmentUrls($object['as:url'] ?? []));
+			$object_data['attachments']   = array_merge($object_data['attachments'], self::processAttachmentUrls($object['as:url'] ?? [], self::processIcon($object)));
 		}
 
 		$object_data['can-comment'] = JsonLD::fetchElement($object, 'pt:commentsEnabled', '@value');


### PR DESCRIPTION
Peertube posts contain HLS videos. Since we now support HLS, we will use it to display Peertube videos by default. This will enhance the viewing experience, as we will also be processing preview pictures.