### PR TITLE
Set different owner when attributedTo contains multiple entries

### DIFF
--- a/src/Module/Item/Display.php
+++ b/src/Module/Item/Display.php
@@ -28,7 +28,6 @@ use Friendica\Module\Special\DisplayNotFound;
 use Friendica\Navigation\Notifications\Repository\Notification;
 use Friendica\Navigation\Notifications\Repository\Notify;
 use Friendica\Protocol\ActivityPub;
-use Friendica\Util\Network;
 use Friendica\Util\Profiler;
 use Friendica\Network\HTTPException;
 use Friendica\Content\Widget;
@@ -88,7 +87,7 @@ class Display extends BaseModule
 		$item    = null;
 		$itemUid = $this->session->getLocalUserId();
 
-		$fields = ['uri-id', 'parent-uri-id', 'author-id', 'author-link', 'body', 'uid', 'guid', 'gravity'];
+		$fields = ['uri-id', 'parent-uri-id', 'author-id', 'author-link', 'contact-id', 'contact-contact-type', 'body', 'uid', 'guid', 'gravity'];
 
 		// Does the local user have this item?
 		if ($this->session->getLocalUserId()) {
@@ -121,7 +120,7 @@ class Display extends BaseModule
 
 		if (empty($item)) {
 			$this->page['aside'] = '';
-			$displayNotFound = new DisplayNotFound($this->l10n, $this->baseUrl, $this->args, $this->logger, $this->profiler, $this->response, $this->server, $this->parameters);
+			$displayNotFound     = new DisplayNotFound($this->l10n, $this->baseUrl, $this->args, $this->logger, $this->profiler, $this->response, $this->server, $this->parameters);
 			return $displayNotFound->content();
 		}
 
@@ -173,7 +172,11 @@ class Display extends BaseModule
 		}
 
 		if ($author === []) {
-			$author = Contact::getById($item['author-id']);
+			if ($item['contact-contact-type'] == Contact::TYPE_COMMUNITY) {
+				$author = Contact::getById($item['contact-id']);
+			} else {
+				$author = Contact::getById($item['author-id']);
+			}
 		}
 
 		if ($this->baseUrl->isLocalUrl($author['url'])) {
@@ -195,7 +198,7 @@ class Display extends BaseModule
 		}
 
 		if (!empty($parent)) {
-			$pageUid         = $parent['uid'];
+			$pageUid = $parent['uid'];
 			if ($this->session->getRemoteContactID($pageUid)) {
 				$itemUid = $parent['uid'];
 			}
@@ -237,7 +240,7 @@ class Display extends BaseModule
 
 		if (empty($item)) {
 			$this->page['aside'] = '';
-			$displayNotFound = new DisplayNotFound($this->l10n, $this->baseUrl, $this->args, $this->logger, $this->profiler, $this->response, $this->server, $this->parameters);
+			$displayNotFound     = new DisplayNotFound($this->l10n, $this->baseUrl, $this->args, $this->logger, $this->profiler, $this->response, $this->server, $this->parameters);
 			return $displayNotFound->content();
 		}
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -422,9 +422,6 @@ class Processor
 				$item['causer-id']   = $item['owner-id'];
 				DI::logger()->info('Use actor as causer.', ['id' => $item['owner-id'], 'actor' => $item['owner-link']]);
 			}
-
-			$item['owner-link'] = $item['author-link'];
-			$item['owner-id']   = $item['author-id'];
 		}
 
 		if (!$item['isGroup'] && !empty($activity['receiver_urls']['as:audience'])) {

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -489,10 +489,13 @@ class Receiver
 		}
 
 		$object_data['type']           = $type;
-		$object_data['actor']          = $actor;
 		$object_data['item_receiver']  = $receivers;
 		$object_data['receiver']       = array_replace($object_data['receiver'] ?? [], $receivers);
 		$object_data['reception_type'] = array_replace($object_data['reception_type'] ?? [], $reception_types);
+
+		if (empty($object_data['actor'])) {
+			$object_data['actor'] = $actor;
+		}
 
 		$account  = Contact::selectFirstAccount(['platform'], ['nurl' => Strings::normaliseLink($actor)]);
 		$platform = $account['platform'] ?? '';
@@ -2021,9 +2024,18 @@ class Receiver
 			$object_data['published'] = $object_data['updated'];
 		}
 
-		$actor = JsonLD::fetchElement($object, 'as:attributedTo', '@id');
-		if (empty($actor)) {
-			$actor = JsonLD::fetchElement($object, 'as:actor', '@id');
+		$actor  = JsonLD::fetchElement($object, 'as:attributedTo', '@id');
+		$author = JsonLD::fetchElement($object, 'as:actor', '@id') ?? $actor;
+
+		if (!empty($actor)) {
+			foreach (JsonLD::fetchElementArray($object, 'as:attributedTo', '@id') as $element) {
+				if ($element != $author) {
+					$actor = $element;
+					break;
+				}
+			}
+		} else {
+			$actor = $author;
 		}
 
 		$location = JsonLD::fetchElement($object, 'as:location', 'as:name', '@type', 'as:Place');
@@ -2039,7 +2051,8 @@ class Receiver
 		$object_data['diaspora:guid']         = JsonLD::fetchElement($object, 'diaspora:guid', '@value');
 		$object_data['diaspora:comment']      = JsonLD::fetchElement($object, 'diaspora:comment', '@value');
 		$object_data['diaspora:like']         = JsonLD::fetchElement($object, 'diaspora:like', '@value');
-		$object_data['actor']                 = $object_data['author'] = $actor;
+		$object_data['author']                = $author;
+		$object_data['actor']                 = $actor;
 		$element                              = JsonLD::fetchElement($object, 'as:context', '@id');
 		$object_data['context']               = $element != './' ? $element : null;
 		$element                              = JsonLD::fetchElement($object, 'ostatus:conversation', '@id');


### PR DESCRIPTION
This should help with #15006 but is mostly meant as a workaround and for special cases like Peertube videos that had been manually imported or had been shared by someone else.

In Peertube the "attributedTo" header contains two entries: One with the actor (the author) and one with the group. We now use this to store these different accounts in our "author" and "owner" fields. This also means that these posts should work with "remote self" and the posts should appear in the timeline.

Also the display had been changed. When you now open a thread from a group, the displayed avatar is the one from the group.