### PR TITLE
Prevent parallel update processes

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1342,8 +1342,8 @@ class Worker
 			return $added;
 		}
 
-		// Quit on daemon mode, except the priority is critical (like for db updates)
-		if (Worker\Daemon::isMode() && $priority !== self::PRIORITY_CRITICAL) {
+		// Quit on daemon mode
+		if (Worker\Daemon::isMode()) {
 			return $added;
 		}
 


### PR DESCRIPTION
This fix prevents the system from spawning an endless number of parallel workers to perform database updates.