### PR TITLE
Reduce the size of portrait videos to fit the screen

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -69,6 +69,7 @@ iframe,
 img,
 video {
 	max-width: 100%;
+	max-height: 85vh;
 }
 blockquote {
 	font-size: inherit;

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -3319,3 +3319,10 @@ fbrowser.photo .photo-album-image-wrapper { margin-left: 10px; }
 #settings-server td + td {
 	text-align: center;
 }
+
+iframe,
+img,
+video {
+	max-width: 100%;
+	max-height: 90vh;
+}


### PR DESCRIPTION
This helps with portrait videos without a provided height. They will no longer be displayed larger than the screen. Fixes #13222