### PR TITLE
Add additional media if the linked page offers it

### DIFF
--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -486,7 +486,7 @@ class Media
 			return;
 		}
 
-		if ($element['mimetype'] ?? '' == 'application/x-mpegURL') {
+		if (($element['mimetype'] ?? '') === 'application/x-mpegURL') {
 			// Until we can detect live streaming, we don't store HLS streams
 			return;
 		}

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -463,7 +463,48 @@ class Media
 		$media['published']       = $data['published']      ?? null;
 		$media['modified']        = $data['modified']       ?? null;
 
+		if (DI::config()->get('system', 'add_page_media')) {
+			if (!empty($data['audio'])) {
+				foreach ($data['audio'] as $entry) {
+					self::insertMedia($entry, $media['uri-id']);
+				}
+			}
+
+			if (!empty($data['video'])) {
+				foreach ($data['video'] as $entry) {
+					self::insertMedia($entry, $media['uri-id']);
+				}
+			}
+		}
+
 		return $media;
+	}
+
+	private static function insertMedia(array $element, int $uri_id)
+	{
+		if (empty($element['src']) || $uri_id <= 0) {
+			return;
+		}
+
+		if ($element['mimetype'] ?? '' == 'application/x-mpegURL') {
+			// Until we can detect live streaming, we don't store HLS streams
+			return;
+		}
+
+		$media                = ['uri-id' => $uri_id];
+		$media['type']        = Post\Media::UNKNOWN;
+		$media['url']         = $element['src'];
+		$media['mimetype']    = $element['contenttype'] ?? null;
+		$media['name']        = $element['name']        ?? null;
+		$media['description'] = $element['description'] ?? null;
+		$media['size']        = $element['size']        ?? null;
+		$media['height']      = $element['height']      ?? null;
+		$media['width']       = $element['width']       ?? null;
+		if (!empty($element['uploaded'])) {
+			$media['modified'] = DateTimeFormat::utc($element['uploaded']);
+		}
+		$result = self::insert($media);
+		DI::logger()->debug('Found media in page', ['result' => $result, 'uri-id' => $uri_id, 'media' => $media]);
 	}
 
 	/**

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -83,6 +83,10 @@ return [
 		// Checks for missing entries in "post", "post-thread" or "post-thread-user" and creates them
 		'add_missing_posts' => false,
 
+		// add_page_media (boolean)
+		// Add page related audio and video media when adding a HTML page entry
+		'add_page_media' => false,
+
 		// admin_inactivity_limit (Integer)
 		// Days of inactivity after which an admin is considered inactive. "0" means that there will be no check for inactivity.
 		'admin_inactivity_limit' => 30,


### PR DESCRIPTION
Especially news sites provide video or audio media in their page description when the linked page contains this media. Ths means that when someone links a news article, then we now directly embedd the video in the post and the user doesn't need to visit that page anymore to view that video.