### PR TITLE
Avoid error when target item couldn't be fetched

### DIFF
--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -103,12 +103,12 @@ class Notifier
 			// find ancestors
 			$condition   = ['id' => $target_id, 'visible' => true];
 			$target_item = Post::selectFirst(Item::DELIVER_FIELDLIST, $condition);
-			$target_item = Post\Media::addHTMLAttachmentToItem($target_item);
-
 			if (!DBA::isResult($target_item) || !intval($target_item['parent'])) {
 				DI::logger()->info('No target item', ['cmd' => $cmd, 'target' => $target_id]);
 				return;
 			}
+
+			$target_item = Post\Media::addHTMLAttachmentToItem($target_item);
 
 			if (!empty($target_item['contact-uid'])) {
 				$uid = $target_item['contact-uid'];


### PR DESCRIPTION
The function is now executed after we checked if the item was fetched.