### PR TITLE
Fix contact handling (improved error handling / only insert if new)

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -218,7 +218,13 @@ class Contact
 
 		$fields = DI::dbaDefinition()->truncateFieldsForTable('contact', $fields);
 		DBA::insert('contact', $fields, $duplicate_mode);
-		$contact = DBA::selectFirst('contact', [], ['id' => DBA::lastInsertId()]);
+		$id = DBA::lastInsertId();
+		if ($id == 0) {
+			DI::logger()->warning('Contact was not created', ['fields' => $fields]);
+			return 0;
+		}
+
+		$contact = DBA::selectFirst('contact', [], ['id' => $id]);
 		if (!DBA::isResult($contact)) {
 			// Shouldn't happen
 			DI::logger()->warning('Created contact could not be found', ['fields' => $fields]);
@@ -234,7 +240,7 @@ class Contact
 			$duplicate = DBA::selectFirst('contact', [], ['id' => $account_user['id'], 'deleted' => false]);
 			if (!empty($duplicate['id'])) {
 				$ret = Contact::deleteById($contact['id']);
-				DI::logger()->notice('Deleted duplicated contact', ['ret' => $ret, 'account-user' => $account_user, 'cid' => $duplicate['id'], 'uid' => $duplicate['uid'], 'uri-id' => $duplicate['uri-id'], 'url' => $duplicate['url']]);
+				DI::logger()->notice('Deleted duplicated contact', ['ret' => $ret, 'id' => $contact['id'], 'account-user' => $account_user, 'cid' => $duplicate['id'], 'uid' => $duplicate['uid'], 'uri-id' => $duplicate['uri-id'], 'url' => $duplicate['url']]);
 				$contact = $duplicate;
 			} else {
 				$ret = DBA::update('account-user', ['id' => $contact['id']], ['uid' => $contact['uid'], 'uri-id' => $contact['uri-id']]);

--- a/src/Protocol/ATProtocol/Actor.php
+++ b/src/Protocol/ATProtocol/Actor.php
@@ -197,24 +197,28 @@ class Actor
 			return $contact;
 		}
 
-		$fields = [
-			'uid'      => $contact_uid,
-			'network'  => Protocol::BLUESKY,
-			'priority' => 1,
-			'writable' => true,
-			'blocked'  => false,
-			'readonly' => false,
-			'pending'  => false,
-			'url'      => $did,
-			'nurl'     => $did,
-			'alias'    => ATProtocol::WEB . '/profile/' . $did,
-			'name'     => $did,
-			'nick'     => $did,
-			'addr'     => $did,
-			'rel'      => Contact::NOTHING,
-		];
+		if (empty($contact)) {
+			$fields = [
+				'uid'      => $contact_uid,
+				'network'  => Protocol::BLUESKY,
+				'priority' => 1,
+				'writable' => true,
+				'blocked'  => false,
+				'readonly' => false,
+				'pending'  => false,
+				'url'      => $did,
+				'nurl'     => $did,
+				'alias'    => ATProtocol::WEB . '/profile/' . $did,
+				'name'     => $did,
+				'nick'     => $did,
+				'addr'     => $did,
+				'rel'      => Contact::NOTHING,
+			];
 
-		$cid = Contact::insert($fields);
+			$cid = Contact::insert($fields);
+		} else {
+			$cid = $contact['id'];
+		}
 
 		$this->updateContactByDID($did, $contact_uid);
 


### PR DESCRIPTION
This PR fixes two problems:

1. In the AT protocol part we accidentally always tried to insert contacts even if the contact existed.
2. When the contact insert fails we now quit immediately.