### PR TITLE
/display: Distinguishable, more descriptive HTML title

### DIFF
--- a/src/Module/Item/Display.php
+++ b/src/Module/Item/Display.php
@@ -150,6 +150,9 @@ class Display extends BaseModule
 
 		$output .= $this->getDisplayData($item);
 
+		$author              = Contact::getByURLForUser($item['author-link'], $this->session->getLocalUserId());
+		$this->page['title'] = $this->l10n->t("Post by %s", $author['name']);
+
 		return $output;
 	}
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-21 21:26+0200\n"
+"POT-Creation-Date: 2025-09-03 15:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6283,7 +6283,7 @@ msgstr[1] ""
 #: src/Module/Contact/Follow.php:56 src/Module/Contact/Redir.php:47
 #: src/Module/Contact/Redir.php:208 src/Module/Conversation/Community.php:154
 #: src/Module/Debug/ItemBody.php:30 src/Module/Diaspora/Receive.php:45
-#: src/Module/Item/Display.php:83 src/Module/Item/Feed.php:45
+#: src/Module/Item/Display.php:82 src/Module/Item/Feed.php:45
 #: src/Module/Item/Follow.php:27 src/Module/Item/Ignore.php:27
 #: src/Module/Item/Language.php:43 src/Module/Item/Pin.php:27
 #: src/Module/Item/Pin.php:42 src/Module/Item/Searchtext.php:39
@@ -7374,6 +7374,11 @@ msgstr ""
 
 #: src/Module/Item/Compose.php:214
 msgid "You can make this page always open when you use the New Post button in the <a href=\"/settings/display\">Theme Customization settings</a>."
+msgstr ""
+
+#: src/Module/Item/Display.php:154
+#, php-format
+msgid "Post by %s"
 msgstr ""
 
 #: src/Module/Item/Feed.php:72
@@ -11785,7 +11790,7 @@ msgstr ""
 msgid "Quote shared by: %s"
 msgstr ""
 
-#: src/Protocol/ActivityPub/Receiver.php:565
+#: src/Protocol/ActivityPub/Receiver.php:568
 msgid "Chat"
 msgstr ""
 


### PR DESCRIPTION
This changes the HTML title on /display URLs from just the author name (display name) to "Post by `<author name>`"

Before:
<img width="327" height="27" alt="image" src="https://github.com/user-attachments/assets/b53755ea-9e69-488f-a30e-b1105a1281b3" />

After:
<img width="327" height="27" alt="image" src="https://github.com/user-attachments/assets/1dd317db-a57d-44ad-8f51-0ebe2cfcb145" /> (that's just my cursor at the bottom)

This makes /display URLs distinguishable from viewing a contact/profile.