### PR TITLE
Frio: Move Friendica logo to the top left

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -407,8 +407,6 @@ header #site-location {
 header #banner {
 	position: fixed;
 	top: 0px;
-	left: 49%;
-	right: 49%;
 	z-index: 1040;
 	margin-top: 12.5px;
 	text-align: center;
@@ -418,7 +416,7 @@ header #banner {
 	color: #fff;
 	font-weight: bold;
 	white-space: nowrap;
-	padding-left: 55px;
+	padding-left: 20px;
 }
 header #banner #logo-img,
 .navbar-brand #logo-img {
@@ -426,8 +424,6 @@ header #banner #logo-img,
 	background-color: $nav_icon_color;
 	height: 25px;
 	width: 25px;
-	margin-left: auto;
-	margin-right: auto;
 }
 
 #navbrand-container {

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -11,7 +11,7 @@
 
 		<div id="site-location" aria-hidden="true">{{$sitelocation}}</div>
 		<div id="banner" class="hidden-sm hidden-xs">
-			{{* show on remote/visitor connections another logo which symbols that fact*}}
+			{{* show on remote/visitor connections another logo which symbols that fact *}}
 			{{if $nav.remote}}
 				<a href="{{$baseurl}}" aria-hidden="true">
 					<div id="remote-logo-img" aria-label="{{$home}}"></div>


### PR DESCRIPTION
Closes #15087

Moving the logo more out of the way has the additional advantage that long display names currently means the search field starts covering the logo.

Before:
<img width="2131" height="91" alt="image" src="https://github.com/user-attachments/assets/ce0c0fac-b1d9-4c75-aa3f-8e9d8f005d44" />

After - at a slightly above average desktop resolution:
<img width="2131" height="91" alt="image" src="https://github.com/user-attachments/assets/1e33c2d7-53a4-4ed5-9b43-91e592885883" />

After - at a smaller resolution:
<img width="1339" height="85" alt="image" src="https://github.com/user-attachments/assets/dda53460-f280-4018-a995-a8a43ee05315" />

Right now it's fixed to the top left, so it get quite far away from the rest of the page.
This could be changed, but then we need a little bit more complex CSS to prevent it from not covering anything at lower resolutions. If people think it's better I can do that.