### PR TITLE
Frio Add text to main "compose" button and adjust "mention" button accordingly (UI)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1438,9 +1438,11 @@ section ul.tabs {
 section #jotOpen {
 	display: none;
 }
-#jotOpen {
-	margin-top: 3px;
-	float: right;
+#jotOpen, #mention-link {
+	align-items: center;
+	display: flex;
+	padding-bottom: 7px;
+	padding-top: 7px;
 }
 #jot-content {
 	display: none;

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -88,8 +88,7 @@ $(document).ready(function () {
 	let $mentionButton = $("#mention-link-button");
 	if ($mentionButton.length) {
 		$mentionButton.appendTo("#topbar-second > .container > #navbar-button").addClass("pull-right");
-		$("#mention-link").addClass("btn-sm ");
-		$("#mention-link > span i").addClass("fa-2x");
+		$("#mention-link > span i").addClass("fa-lg");
 		if ($mentionButton.hasClass("modal-open")) {
 			$mentionButton.on("click", function (e) {
 				e.preventDefault();

--- a/view/theme/frio/templates/jot.tpl
+++ b/view/theme/frio/templates/jot.tpl
@@ -5,7 +5,10 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 {{* The button to open the jot - in This theme we move the button with js to the second nav bar *}}
-<a class="btn btn-sm btn-primary pull-right{{if !$always_open_compose}} modal-open{{/if}}" id="jotOpen" href="compose/{{$posttype}}{{if $content}}?body={{$content}}{{/if}}" aria-label="{{$new_post}}" title="{{$new_post}}"><i class="fa fa-pencil-square-o fa-2x"></i></a>
+<a class="btn btn-primary pull-right{{if !$always_open_compose}} modal-open{{/if}}" id="jotOpen" href="compose/{{$posttype}}{{if $content}}?body={{$content}}{{/if}}" aria-label="{{$new_post}}" title="{{$new_post}}">
+	<i class="fa fa-lg fa-pencil-square-o"></i>&nbsp;
+	<span>{{$new_post}}</span>
+</a>
 
 <div id="jot-content">
 	<div id="jot-sections">
@@ -191,5 +194,5 @@ can load different content into the jot modal (e.g. the item edit jot)
 </script>
 
 <script>
-	dzFactory.setupDropzone('#jot-text-wrap', 'profile-jot-text'); 
+	dzFactory.setupDropzone('#jot-text-wrap', 'profile-jot-text');
 </script>

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -76,7 +76,7 @@
 				{{if $profile.addr}}
 					<div id="mention-link-button">
 						<button type="button" id="mention-link" class="btn btn-labeled btn-primary" onclick="openWallMessage('{{$mention_url}}')">
-							<span class=""><i class="fa fa-pencil-square-o"></i></span>
+							<span class=""><i class="fa fa-pencil-square-o"></i></span>&nbsp;
 							<span class="">{{$mention_label}}</span>
 						</button>
 					</div>

--- a/view/theme/frio/templates/widget/vcard.tpl
+++ b/view/theme/frio/templates/widget/vcard.tpl
@@ -67,7 +67,7 @@
 			{{if $mention_link}}
 				<div id="mention-link-button">
 					<button type="button" id="mention-link" class="btn btn-labeled btn-primary{{if !$always_open_compose}} modal-open{{/if}}" onclick="openWallMessage('{{$mention_link}}')" title="{{$mention}}" aria-label="{{$mention}}">
-						<span class=""><i class="fa fa-pencil-square-o"></i></span>
+						<span class=""><i class="fa fa-pencil-square-o"></i></span>&nbsp;
 						<span class="">{{$mention}}</span>
 					</button>
 				</div>


### PR DESCRIPTION
This PR adds the text "New post" to the main compose button, and it also fixes the alignment of the "Mention" button.

This is especially meant to make the button stand out more for newcomers, and to more clearly explain its purpose.

The now look similar to each other, and they also look more similar to other buttons on Friendica.

Before:
<img width="1176" height="91" alt="image" src="https://github.com/user-attachments/assets/ba3949a7-6090-44e2-9a44-4caeef1bfe7a" />

<img width="1176" height="91" alt="image" src="https://github.com/user-attachments/assets/cef52c32-430c-47e7-a2b1-c775b975ab8c" />

After:
<img width="1176" height="91" alt="image" src="https://github.com/user-attachments/assets/4fb30169-73d0-4f8f-a8ce-0843d27b9ac4" />

<img width="1176" height="91" alt="image" src="https://github.com/user-attachments/assets/1958acea-98da-485f-9971-2610ed50291b" />
