### PR TITLE
UI: Restyle main actions on calendar and message to improve visibility and increase touch area

### DIFF
--- a/src/Module/Calendar/Show.php
+++ b/src/Module/Calendar/Show.php
@@ -112,7 +112,7 @@ class Show extends BaseModule
 			'$tabs'      => $tabs,
 			'$title'     => $this->t('Events'),
 			'$view'      => $this->t('View'),
-			'$new_event' => ['calendar/event/new', $this->t('Create New Event'), '', ''],
+			'$new_event' => ['calendar/event/new', $this->t('New Event'), '', ''],
 
 			'$today' => Strings::ucFirst($this->t('today')),
 			'$month' => Strings::ucFirst($this->t('month')),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-03 17:36+0200\n"
+"POT-Creation-Date: 2025-09-03 21:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -5947,7 +5947,7 @@ msgid "View"
 msgstr ""
 
 #: src/Module/Calendar/Show.php:115
-msgid "Create New Event"
+msgid "New Event"
 msgstr ""
 
 #: src/Module/Calendar/Show.php:121 src/Module/Settings/Display.php:295

--- a/view/templates/calendar/calendar.tpl
+++ b/view/templates/calendar/calendar.tpl
@@ -8,6 +8,8 @@
 {{$tabs nofilter}}
 <h2>{{$title}}</h2>
 
-<div id="new-event-link"><a href="{{$new_event.0}}">{{$new_event.1}}</a></div>
+<div id="new-event-link">
+	<a class="btn btn-primary" href="{{$new_event.0}}">{{$new_event.1}}</a>
+</div>
 
 <div id="events-calendar"></div>

--- a/view/templates/mail_head.tpl
+++ b/view/templates/mail_head.tpl
@@ -5,4 +5,4 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 
-<h3>{{$messages}}</h3>
+<h2>{{$messages}}</h2>

--- a/view/templates/message_side.tpl
+++ b/view/templates/message_side.tpl
@@ -5,7 +5,9 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <nav id="message-sidebar" class="widget">
-  <div id="message-new"><a href="{{$new.url}}" accesskey="m" class="{{if $new.sel}}newmessage-selected{{/if}}">{{$new.label}}</a> </div>
+  <div id="message-new">
+    <a href="{{$new.url}}" accesskey="m" class="btn btn-primary {{if $new.sel}}newmessage-selected{{/if}}">{{$new.label}}</a>
+  </div>
 
   {{if $tabs}}
     <div id="message-preview">

--- a/view/templates/widget/follow.tpl
+++ b/view/templates/widget/follow.tpl
@@ -9,6 +9,6 @@
   <h3>{{$connect}}</h3>
   <div id="connect-desc">{{$desc nofilter}}</div>
   <form action="contact/follow" method="post">
-    <input id="side-follow-url" type="text" name="follow-url" value="{{$value}}" size="24" placeholder="{{$hint}}" title="{{$hint}}" /><input id="side-follow-submit" type="submit" name="submit" value="{{$follow}}" />
+    <input id="side-follow-url" type="text" name="follow-url" value="{{$value}}" size="24" placeholder="{{$hint}}"/><input id="side-follow-submit" type="submit" name="submit" value="{{$follow}}" />
   </form>
 </nav>

--- a/view/theme/frio/templates/calendar/calendar.tpl
+++ b/view/theme/frio/templates/calendar/calendar.tpl
@@ -11,8 +11,9 @@
 	{{* The link to create a new event *}}
 	{{if $new_event.0}}
 	<div class="pull-right" id="new-event-link">
-		<button type="button" class="btn-link page-action faded-icon" onclick="addToModal('{{$new_event.0}}')" title="{{$new_event.1}}" data-toggle="tooltip">
+		<button type="button" class="btn btn-primary page-action onclick="addToModal('{{$new_event.0}}')" data-toggle="tooltip">
 			<i class="fa fa-plus"></i>
+			<span>{{$new_event.1}}</span>
 		</button>
 	</div>
 	{{/if}}

--- a/view/theme/frio/templates/mail_head.tpl
+++ b/view/theme/frio/templates/mail_head.tpl
@@ -11,8 +11,9 @@
 
 <div id="message-new" class="pull-right">
 	{{if $button.sel == "new"}}
-	<a href="{{$button.url}}" accesskey="m" class="newmessage-selected faded-icon page-action" title="{{$button.label}}" data-toggle="tooltip">
+	<a href="{{$button.url}}" accesskey="m" class="btn btn-primary newmessage-selected page-action" data-toggle="tooltip">
 		<i class="fa fa-plus"></i>
+		<span>{{$button.label}}</span>
 	</a>
 	{{else}}
 	<a href="{{$button.url}}" title="{{$button.label}}" class="faded-icon page-action" data-toggle="tooltip">

--- a/view/theme/frio/templates/mail_head.tpl
+++ b/view/theme/frio/templates/mail_head.tpl
@@ -6,7 +6,7 @@
   *}}
 
 <div class="pull-left">
-	<h3 class="heading">{{$messages}}</h3>
+	<h2 class="heading">{{$messages}}</h2>
 </div>
 
 <div id="message-new" class="pull-right">

--- a/view/theme/frio/templates/widget/follow.tpl
+++ b/view/theme/frio/templates/widget/follow.tpl
@@ -11,7 +11,7 @@
 	<form action="contact/follow" method="post">
 		{{* The input field - For visual consistence we are using a search input field*}}
 		<div class="form-group form-group-search">
-			<input id="side-follow-url" class="search-input form-control form-search" type="text" name="follow-url" value="{{$value}}" placeholder="{{$hint}}" data-toggle="tooltip" title="{{$hint}}" />
+			<input id="side-follow-url" class="search-input form-control form-search" type="text" name="follow-url" value="{{$value}}" placeholder="{{$hint}}" data-toggle="tooltip" />
 			<button id="side-follow-submit" class="btn btn-default btn-sm form-button-search" type="submit">{{$follow}}</button>
 		</div>
 	</form>


### PR DESCRIPTION
Restyles the actions on message and calendar - specifically the buttons to send a "New message" and to "Create a new event", moving the text from being hover texts to being text on the buttons.

This is done to make them stand out more, easier to click on touchscreens, and since using hover for information doesn't work that well on touchscreens.

Vier's equivalents are also mildly updated, as right now it's not even clear they can be clicked.

I've also removed the fade-unless-hovered effect on them, because if that effect is useful it makes more sense for the timelinse, than for the main actions on pages that otherwise have little content.

Showing before/after for Frio since Vier is very minimal.

Edit: Also changed the main header from h3->h2, consistent with the similar headers on "Events" and "Contacts". (Under "Settings", somewhat confusingly in terms of consistency, those similar headers are h1.)

# Before

<img width="664" height="267" alt="image" src="https://github.com/user-attachments/assets/d86d7e15-3eb3-4e0a-bdaf-08f5190a9fde" />

<img width="664" height="267" alt="image" src="https://github.com/user-attachments/assets/1e1e06b6-f191-424f-ac36-f15094fd5fb9" />

# After

<img width="664" height="267" alt="image" src="https://github.com/user-attachments/assets/d47d0d5b-83cf-4246-a099-66627678272a" />

<img width="664" height="267" alt="image" src="https://github.com/user-attachments/assets/46fc9159-a52c-49e6-87c3-d788d7e3c9bf" />