### PR TITLE
Enchancement: Notifications indicator when loading is not finished

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -110,6 +110,7 @@ class Nav
 			'$nav'                => $nav_info['nav'],
 			'$banner'             => $nav_info['banner'],
 			'$emptynotifications' => $this->l10n->t('Nothing new here'),
+			'$loadingnotifications' => $this->l10n->t('Loading...'),
 			'$userinfo'           => $nav_info['userinfo'],
 			'$nickname'           => $this->session->getLocalUserNickname(),
 			'$sel'                => self::$selected,

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -248,6 +248,10 @@ $(function() {
 	var notifications_all = unescape($('<div>').append($("#nav-notifications-see-all").clone()).html()); //outerHtml hack
 	var notifications_mark = unescape($('<div>').append($("#nav-notifications-mark-all").clone()).html()); //outerHtml hack
 	var notifications_empty = unescape($("#nav-notifications-menu").html());
+	
+	/* Initially show loading state and hide empty state*/
+	$("#nav-notifications-loading").show();
+	$("#nav-notifications-empty").hide();
 
 	/* enable perfect-scrollbars for different elements */
 	$('#nav-notifications-menu, aside').perfectScrollbar();
@@ -303,9 +307,13 @@ $(function() {
 			$(".group-"+fid+" .notify").addClass("show").text(fcount);
 		});
 
+		// Hide loading state when we receive notification data
+		$("#nav-notifications-loading").hide();
+		
 		if (data.notifications.length == 0) {
-			$("#nav-notifications-menu").html(notifications_empty);
+			$("#nav-notifications-empty").show();
 		} else {
+			$("#nav-notifications-empty").hide();
 			var nnm = $("#nav-notifications-menu");
 			nnm.html(notifications_all + notifications_mark);
 

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -252,6 +252,14 @@ $(function() {
 	/* Initially show loading state and hide empty state*/
 	$("#nav-notifications-loading").show();
 	$("#nav-notifications-empty").hide();
+	
+	/* Also ensure loading is visible by default when notifications menu is opened*/
+	$(document).on('click', '#nav-notifications-linkmenu', function() {
+		if ($("#nav-notifications-loading").length && $("#nav-notifications-empty").length) {
+			$("#nav-notifications-loading").show();
+			$("#nav-notifications-empty").hide();
+		}
+	});
 
 	/* enable perfect-scrollbars for different elements */
 	$('#nav-notifications-menu, aside').perfectScrollbar();

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -250,8 +250,10 @@ $(function() {
 	var notifications_empty = unescape($("#nav-notifications-menu").html());
 	
 	/* Initially show loading state and hide empty state*/
-	$("#nav-notifications-loading").show();
-	$("#nav-notifications-empty").hide();
+	$(document).ready(function() {
+		$("#nav-notifications-loading").show();
+		$("#nav-notifications-empty").hide();
+	});
 	
 	/* Also ensure loading is visible by default when notifications menu is opened*/
 	$(document).on('click', '#nav-notifications-linkmenu', function() {
@@ -265,7 +267,7 @@ $(function() {
 	$('#nav-notifications-menu, aside').perfectScrollbar();
 
 	/* nav update event  */
-	$('#topbar-first').bind('nav-update', function(e, data) {
+	$(document).bind('nav-update', function(e, data) {
 		var invalid = data.invalid || 0;
 		if (invalid == 1) {
 			window.location.href=window.location.href
@@ -512,8 +514,8 @@ function NavUpdate() {
 		var pingCmd = 'ping';
 		$.get(pingCmd, function(data) {
 			if (data.result) {
-				// send nav-update event
-				$('#topbar-first').trigger('nav-update', data.result);
+		// send nav-update event
+		$(document).trigger('nav-update', data.result);
 
 				// start live update
 				['network', 'profile', 'channel', 'community', 'notes', 'display', 'contact'].forEach(function (src) {

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -325,7 +325,19 @@ $(function() {
 		} else {
 			$("#nav-notifications-empty").hide();
 			var nnm = $("#nav-notifications-menu");
+			// Preserve the loading and empty state elements when rebuilding the menu
+			var loadingElement = nnm.find("#nav-notifications-loading");
+			var emptyElement = nnm.find("#nav-notifications-empty");
+			
 			nnm.html(notifications_all + notifications_mark);
+			
+			// Re-add the loading and empty elements if they existed
+			if (loadingElement.length > 0) {
+				nnm.append(loadingElement);
+			}
+			if (emptyElement.length > 0) {
+				nnm.append(emptyElement);
+			}
 
 			var lastItemStorageKey = "notification-lastitem:" + localUser;
 			var notification_lastitem = parseInt(localStorage.getItem(lastItemStorageKey));

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -266,7 +266,7 @@ $(function() {
 	$('#nav-notifications-menu, aside').perfectScrollbar();
 
 	/* nav update event  */
-	$(document).bind('nav-update', function(e, data) {
+	$('#topbar-first').bind('nav-update', function(e, data) {
 		var invalid = data.invalid || 0;
 		if (invalid == 1) {
 			window.location.href=window.location.href

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -249,17 +249,16 @@ $(function() {
 	var notifications_mark = unescape($('<div>').append($("#nav-notifications-mark-all").clone()).html()); //outerHtml hack
 	var notifications_empty = unescape($("#nav-notifications-menu").html());
 	
-	/* Initially show loading state and hide empty state*/
-	$(document).ready(function() {
-		$("#nav-notifications-loading").show();
-		$("#nav-notifications-empty").hide();
-	});
-	
-	/* Also ensure loading is visible by default when notifications menu is opened*/
+	/* Ensure loading is visible when notifications menu is opened (if no notifications loaded yet)*/
 	$(document).on('click', '#nav-notifications-linkmenu, #nav-notifications-menu-btn', function() {
 		if ($("#nav-notifications-loading").length && $("#nav-notifications-empty").length) {
-			$("#nav-notifications-loading").show();
-			$("#nav-notifications-empty").hide();
+			// Only show loading if we haven't loaded notifications yet
+			var menu = $("#nav-notifications-menu");
+			var hasNotifications = menu.find('.notification-link, .contact-notification-link').length > 0;
+			if (!hasNotifications) {
+				$("#nav-notifications-loading").show();
+				$("#nav-notifications-empty").hide();
+			}
 		}
 	});
 

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -256,7 +256,7 @@ $(function() {
 	});
 	
 	/* Also ensure loading is visible by default when notifications menu is opened*/
-	$(document).on('click', '#nav-notifications-linkmenu', function() {
+	$(document).on('click', '#nav-notifications-linkmenu, #nav-notifications-menu-btn', function() {
 		if ($("#nav-notifications-loading").length && $("#nav-notifications-empty").length) {
 			$("#nav-notifications-loading").show();
 			$("#nav-notifications-empty").hide();

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -64,8 +64,8 @@
 				<ul id="nav-notifications-menu" class="menu-popup">
 					<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
 					<li id="nav-notifications-mark-all"><a href="#" onclick="notificationMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
-				<li id="nav-notifications-loading" class="loading" style="display: block; text-align: center;">{{$loadingnotifications}}</li>
-				<li id="nav-notifications-empty" class="empty" style="display: none; text-align: center;"><i>{{$emptynotifications}}</i></li>
+			<li id="nav-notifications-loading" class="loading" style="font-weight: bold; color: #555;">{{$loadingnotifications}}</li>
+			<li id="nav-notifications-empty" class="empty" style="display: none; text-align: center;"><i>{{$emptynotifications}}</i></li>
 				</ul>
 		{{/if}}		
 

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -64,8 +64,8 @@
 				<ul id="nav-notifications-menu" class="menu-popup">
 					<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
 					<li id="nav-notifications-mark-all"><a href="#" onclick="notificationMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
-					<li id="nav-notifications-loading" class="loading">{{$loadingnotifications}}</li>
-					<li id="nav-notifications-empty" class="empty" style="display: none;">{{$emptynotifications}}</li>
+				<li id="nav-notifications-loading" class="loading"><span style="display: block; text-align: center;"><i class="fa fa-spinner fa-pulse" aria-hidden="true"></i> {{$loadingnotifications}}</span></li>
+				<li id="nav-notifications-empty" class="empty" style="display: none; text-align: center;"><i>{{$emptynotifications}}</i></li>
 				</ul>
 		{{/if}}		
 

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -64,7 +64,7 @@
 				<ul id="nav-notifications-menu" class="menu-popup">
 					<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
 					<li id="nav-notifications-mark-all"><a href="#" onclick="notificationMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
-			<li id="nav-notifications-loading" class="loading" style="font-weight: bold; color: #555;">{{$loadingnotifications}}</li>
+			<li id="nav-notifications-loading" class="loading" style="font-weight: bold; color: #555; padding-left: 10px;">{{$loadingnotifications}}</li>
 			<li id="nav-notifications-empty" class="empty" style="display: none; text-align: center;"><i>{{$emptynotifications}}</i></li>
 				</ul>
 		{{/if}}		

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -64,7 +64,7 @@
 				<ul id="nav-notifications-menu" class="menu-popup">
 					<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
 					<li id="nav-notifications-mark-all"><a href="#" onclick="notificationMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
-				<li id="nav-notifications-loading" class="loading"><span style="display: block; text-align: center;"><i class="fa fa-spinner fa-pulse" aria-hidden="true"></i> {{$loadingnotifications}}</span></li>
+				<li id="nav-notifications-loading" class="loading" style="display: block; text-align: center;">{{$loadingnotifications}}</li>
 				<li id="nav-notifications-empty" class="empty" style="display: none; text-align: center;"><i>{{$emptynotifications}}</i></li>
 				</ul>
 		{{/if}}		

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -64,7 +64,8 @@
 				<ul id="nav-notifications-menu" class="menu-popup">
 					<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
 					<li id="nav-notifications-mark-all"><a href="#" onclick="notificationMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
-					<li class="empty">{{$emptynotifications}}</li>
+					<li id="nav-notifications-loading" class="loading">{{$loadingnotifications}}</li>
+					<li id="nav-notifications-empty" class="empty" style="display: none;">{{$emptynotifications}}</li>
 				</ul>
 		{{/if}}		
 

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -144,9 +144,9 @@
 
 									</li>
 
-					<li id="nav-notifications-loading" class="loading">
-						<p role="menuitem" class="text-center"><i class="fa fa-spinner fa-pulse" aria-hidden="true"></i> {{$loadingnotifications}}</p>
-					</li>
+			<li id="nav-notifications-loading" class="loading">
+				<p role="menuitem" class="text-center">{{$loadingnotifications}}</p>
+			</li>
 					<li id="nav-notifications-empty" class="empty" style="display: none;">
 						<p role="menuitem" class="text-muted text-center"><i>{{$emptynotifications}}</i></p>
 					</li>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -144,9 +144,12 @@
 
 									</li>
 
-									<li>
-										<p role="menuitem" class="text-muted"><i>{{$emptynotifications}}</i></p>
-									</li>
+						<li id="nav-notifications-loading" class="loading">
+							<p role="menuitem" class="text-muted"><i>{{$loadingnotifications}}</i></p>
+						</li>
+						<li id="nav-notifications-empty" class="empty" style="display: none;">
+							<p role="menuitem" class="text-muted"><i>{{$emptynotifications}}</i></p>
+						</li>
 								</ul>
 							</li>
 						{{/if}}

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -144,12 +144,12 @@
 
 									</li>
 
-						<li id="nav-notifications-loading" class="loading">
-							<p role="menuitem" class="text-muted"><i>{{$loadingnotifications}}</i></p>
-						</li>
-						<li id="nav-notifications-empty" class="empty" style="display: none;">
-							<p role="menuitem" class="text-muted"><i>{{$emptynotifications}}</i></p>
-						</li>
+					<li id="nav-notifications-loading" class="loading">
+						<p role="menuitem" class="text-center"><i class="fa fa-spinner fa-pulse" aria-hidden="true"></i> {{$loadingnotifications}}</p>
+					</li>
+					<li id="nav-notifications-empty" class="empty" style="display: none;">
+						<p role="menuitem" class="text-muted text-center"><i>{{$emptynotifications}}</i></p>
+					</li>
 								</ul>
 							</li>
 						{{/if}}

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -144,7 +144,7 @@
 
 									</li>
 
-			<li id="nav-notifications-loading" class="loading" style="font-weight: bold; color: #555;">
+			<li id="nav-notifications-loading" class="loading" style="font-weight: bold; color: #555; padding-left: 10px;">
 				{{$loadingnotifications}}
 			</li>
 			<li id="nav-notifications-empty" class="empty" style="display: none;">

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -144,12 +144,12 @@
 
 									</li>
 
-			<li id="nav-notifications-loading" class="loading">
-				<p role="menuitem" class="text-center">{{$loadingnotifications}}</p>
+			<li id="nav-notifications-loading" class="loading" style="font-weight: bold; color: #555;">
+				{{$loadingnotifications}}
 			</li>
-					<li id="nav-notifications-empty" class="empty" style="display: none;">
-						<p role="menuitem" class="text-muted text-center"><i>{{$emptynotifications}}</i></p>
-					</li>
+			<li id="nav-notifications-empty" class="empty" style="display: none;">
+				<p role="menuitem" class="text-muted text-center"><i>{{$emptynotifications}}</i></p>
+			</li>
 								</ul>
 							</li>
 						{{/if}}


### PR DESCRIPTION
I have been working on the loading indicator. 
At first, I wanted a spinning loading indicator, but that wasn't possible, at least not for me.

If notifications have not yet been loaded, “loading...” is now displayed.
Tested on friendica.opensocial.space in live operation with both the Frio and Vier themes.
Fixes #15097 
