### PR TITLE
Terminology: Full name -> Display name

### DIFF
--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -178,7 +178,7 @@ class Profile extends BaseProfile
 
 		$basic_fields = [];
 
-		$basic_fields += self::buildField('fullname', $this->t('Full Name:'), $this->cleanInput($profile['uri-id'], $profile['name']));
+		$basic_fields += self::buildField('fullname', $this->t('Display name:'), $this->cleanInput($profile['uri-id'], $profile['name']));
 
 		if (Feature::isEnabled($profile['uid'], Feature::MEMBER_SINCE)) {
 			$basic_fields += self::buildField(

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-07 12:22+0200\n"
+"POT-Creation-Date: 2025-09-07 23:20+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -8656,8 +8656,9 @@ msgstr ""
 msgid "You're currently viewing your profile as <b>%s</b> <a href=\"%s\" class=\"btn btn-sm pull-right\">Cancel</a>"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:181
-msgid "Full Name:"
+#: src/Module/Profile/Profile.php:181 src/Module/Settings/Account.php:522
+#: src/Module/Settings/Profile/Index.php:300
+msgid "Display name:"
 msgstr ""
 
 #: src/Module/Profile/Profile.php:186
@@ -9288,11 +9289,6 @@ msgstr ""
 
 #: src/Module/Settings/Account.php:521
 msgid "Basic Settings"
-msgstr ""
-
-#: src/Module/Settings/Account.php:522
-#: src/Module/Settings/Profile/Index.php:300
-msgid "Display name:"
 msgstr ""
 
 #: src/Module/Settings/Account.php:523


### PR DESCRIPTION
Split up from #14965, so a PR just covers one particular area/section.

h1. Full name -> Display name

On a profile page one's display name is shown with the header "Full name", but Friendica is designed so profiles are used more broadly than just being used for private, personal accounts. "Full name" applies well to individual users private accounts, but not so well to Pages/Groups. Also it's a bit confusing that what's called "Display name" almost everywhere is suddenly called something else here. It's better if it's consistent.

"Display name" is already in translations, so no new translation needed.