### PR TITLE
Terminology: Browser -> Add file

### DIFF
--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -415,7 +415,7 @@ class Conversation
 
 			//jot nav tab (used in some themes)
 			'$message' => $this->l10n->t('Message'),
-			'$browser' => $this->l10n->t('Browser'),
+			'$browser' => $this->l10n->t('Add file'),
 
 			'$compose_link_title'  => $this->l10n->t('Open Compose page'),
 			'$always_open_compose' => $this->pConfig->get($this->session->getLocalUserId(), 'frio', 'always_open_compose', false),

--- a/src/Module/Post/Edit.php
+++ b/src/Module/Post/Edit.php
@@ -175,7 +175,7 @@ class Edit extends BaseModule
 
 			//jot nav tab (used in some themes)
 			'$message'      => $this->t('Message'),
-			'$browser'      => $this->t('Browser'),
+			'$browser'      => $this->t('Add file'),
 			'$shortpermset' => $this->t('Permissions'),
 
 			'$compose_link_title' => $this->t('Open Compose page'),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 22:39+0200\n"
+"POT-Creation-Date: 2025-09-09 23:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1387,8 +1387,7 @@ msgid "Message"
 msgstr ""
 
 #: src/Content/Conversation.php:418 src/Module/Post/Edit.php:178
-#: src/Module/Settings/TwoFactor/Trusted.php:129
-msgid "Browser"
+msgid "Add file"
 msgstr ""
 
 #: src/Content/Conversation.php:420 src/Module/Post/Edit.php:181
@@ -10717,6 +10716,10 @@ msgstr ""
 
 #: src/Module/Settings/TwoFactor/Trusted.php:128
 msgid "OS"
+msgstr ""
+
+#: src/Module/Settings/TwoFactor/Trusted.php:129
+msgid "Browser"
 msgstr ""
 
 #: src/Module/Settings/TwoFactor/Trusted.php:130


### PR DESCRIPTION
Split up from https://github.com/friendica/friendica/pull/14965, so a PR just covers one particular area/section.

# Update to the below

As Alfred pointed out one of the tiny buttons switches it over to being able to upload/attach random files, seemingly. At least even non image and non-media files work, such as a TXT file.

So it's instead being changed to "Add file":
<img width="468" height="56" alt="image" src="https://github.com/user-attachments/assets/7783e0f9-2e48-467f-8035-ab716219425c" />

Have kept the image icon, though.

# Original description

## Browser -> Add image

On the pages to create/edit a post there's an option simply called "Browser", which is used to add an image to the post.
There's a good icon for it, but the text name does not properly convey its function.

This PR changes it to "Add image". Originally I thought it should be "Add media" but I believe it can only add images, and specifically only one at a time, so therefore I've not pluralized it.

The improved name should also help screen readers.

This is not in translations currently, so there'll a new translation will pop up on Transifex. That can't really be avoided if a given piece of software is to evolve and become more user friendly. Once on Transifex, it takes maybe 4 minutes to both do the translation and update it on a server, the latter part taking 75% of that time so you can do multiple new translations in one go which only takes marginally longer.

Before:
<img width="661" height="428" alt="image" src="https://github.com/user-attachments/assets/e313c0d2-6e51-4992-a722-f2bfb415dde7" />

After:
<img width="661" height="428" alt="image" src="https://github.com/user-attachments/assets/270a53e9-849e-4ad4-a6d9-5057fed48bb5" />