### PR TITLE
Settings: Remove incorrect colon after "Use browser location"

### DIFF
--- a/src/Module/Settings/Account.php
+++ b/src/Module/Settings/Account.php
@@ -156,15 +156,15 @@ class Account extends BaseSettings
 			DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'system', 'default-group-gid', intval($request['circle-selection-group'] ?? $def_gid));
 
 			$fields = [
-				'allow_cid'  => $str_contact_allow,
-				'allow_gid'  => $str_circle_allow,
-				'deny_cid'   => $str_contact_deny,
-				'deny_gid'   => $str_circle_deny,
-				'maxreq'     => $maxreq,
-				'def_gid'    => $def_gid,
-				'blockwall'  => $blockwall,
-				'hidewall'   => $hidewall,
-				'blocktags'  => $blocktags,
+				'allow_cid' => $str_contact_allow,
+				'allow_gid' => $str_circle_allow,
+				'deny_cid'  => $str_contact_deny,
+				'deny_gid'  => $str_circle_deny,
+				'maxreq'    => $maxreq,
+				'def_gid'   => $def_gid,
+				'blockwall' => $blockwall,
+				'hidewall'  => $hidewall,
+				'blocktags' => $blocktags,
 			];
 
 			$profile_fields = [
@@ -426,7 +426,7 @@ class Account extends BaseSettings
 				$user['account-type'] == User::ACCOUNT_TYPE_COMMUNITY
 			],
 			'$account_relay' => $account_relay,
-			'$page_normal' => [
+			'$page_normal'   => [
 				'page-flags',
 				DI::l10n()->t('Normal Account Page'),
 				User::PAGE_FLAGS_NORMAL,
@@ -524,23 +524,23 @@ class Account extends BaseSettings
 			'$timezone'         => ['timezone_select', DI::l10n()->t('Your Timezone:'), Temporal::getTimezoneSelect($timezone), ''],
 			'$language'         => ['language', DI::l10n()->t('Your Language:'), $language, DI::l10n()->t('Set the language we use to show you friendica interface and to send you emails'), $lang_choices],
 			'$default_location' => ['default_location', DI::l10n()->t('Default Post Location:'), $default_location, ''],
-			'$allow_location'   => ['allow_location', DI::l10n()->t('Use Browser Location:'), ($user['allow_location'] == 1), ''],
+			'$allow_location'   => ['allow_location', DI::l10n()->t('Use browser location'), ($user['allow_location'] == 1), ''],
 
-			'$h_prv'              => DI::l10n()->t('Security and Privacy Settings'),
-			'$is_community'       => ($user['account-type'] == User::ACCOUNT_TYPE_COMMUNITY),
-			'$maxreq'             => ['maxreq', DI::l10n()->t('Maximum Friend Requests/Day:'), $maxreq, DI::l10n()->t("(to prevent spam abuse)")],
-			'$profile_in_dir'     => $profile_in_dir,
-			'$profile_in_net_dir' => ['profile_in_netdirectory', DI::l10n()->t('Allow your profile to be searchable globally?'), $profile['net-publish'], DI::l10n()->t("Activate this setting if you want others to easily find and follow you. Your profile will be searchable on remote systems. This setting also determines whether Friendica will inform search engines that your profile should be indexed or not.") . $net_pub_desc],
-			'$hide_friends'       => ['hide-friends', DI::l10n()->t('Hide your contact/friend list from viewers of your profile?'), $profile['hide-friends'], DI::l10n()->t('A list of your contacts is displayed on your profile page. Activate this option to disable the display of your contact list.')],
-			'$hide_wall'          => ['hidewall', $this->t('Hide your public content from anonymous viewers'), $user['hidewall'], $this->t('Anonymous visitors will only see your basic profile details. Your public posts and replies will still be freely accessible on the remote servers of your followers and through relays.')],
-			'$unlisted'           => ['unlisted', DI::l10n()->t('Make public posts unlisted'), DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'unlisted'), DI::l10n()->t('Your public posts will not appear on the community pages or in search results, nor be sent to relay servers. However they can still appear on public feeds on remote servers.')],
-			'$accessiblephotos'   => ['accessible-photos', DI::l10n()->t('Make all posted pictures accessible'), DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'accessible-photos'), DI::l10n()->t("This option makes every posted picture accessible via the direct link. This is a workaround for the problem that most other networks can't handle permissions on pictures. Non public pictures still won't be visible for the public on your photo albums though.")],
-			'$blockwall'          => ['blockwall', DI::l10n()->t('Allow friends to post to your profile page?'), (intval($user['blockwall']) ? '0' : '1'), DI::l10n()->t('Your contacts may write posts on your profile wall. These posts will be distributed to your contacts')],
-			'$blocktags'          => ['blocktags', DI::l10n()->t('Allow friends to tag your posts?'), (intval($user['blocktags']) ? '0' : '1'), DI::l10n()->t('Your contacts can add additional tags to your posts.')],
-			'$circle_select'      => Circle::getSelectorHTML(DI::userSession()->getLocalUserId(), $user['def_gid'], 'circle-selection', DI::l10n()->t('Default privacy circle for new contacts')),
+			'$h_prv'               => DI::l10n()->t('Security and Privacy Settings'),
+			'$is_community'        => ($user['account-type'] == User::ACCOUNT_TYPE_COMMUNITY),
+			'$maxreq'              => ['maxreq', DI::l10n()->t('Maximum Friend Requests/Day:'), $maxreq, DI::l10n()->t("(to prevent spam abuse)")],
+			'$profile_in_dir'      => $profile_in_dir,
+			'$profile_in_net_dir'  => ['profile_in_netdirectory', DI::l10n()->t('Allow your profile to be searchable globally?'), $profile['net-publish'], DI::l10n()->t("Activate this setting if you want others to easily find and follow you. Your profile will be searchable on remote systems. This setting also determines whether Friendica will inform search engines that your profile should be indexed or not.") . $net_pub_desc],
+			'$hide_friends'        => ['hide-friends', DI::l10n()->t('Hide your contact/friend list from viewers of your profile?'), $profile['hide-friends'], DI::l10n()->t('A list of your contacts is displayed on your profile page. Activate this option to disable the display of your contact list.')],
+			'$hide_wall'           => ['hidewall', $this->t('Hide your public content from anonymous viewers'), $user['hidewall'], $this->t('Anonymous visitors will only see your basic profile details. Your public posts and replies will still be freely accessible on the remote servers of your followers and through relays.')],
+			'$unlisted'            => ['unlisted', DI::l10n()->t('Make public posts unlisted'), DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'unlisted'), DI::l10n()->t('Your public posts will not appear on the community pages or in search results, nor be sent to relay servers. However they can still appear on public feeds on remote servers.')],
+			'$accessiblephotos'    => ['accessible-photos', DI::l10n()->t('Make all posted pictures accessible'), DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'accessible-photos'), DI::l10n()->t("This option makes every posted picture accessible via the direct link. This is a workaround for the problem that most other networks can't handle permissions on pictures. Non public pictures still won't be visible for the public on your photo albums though.")],
+			'$blockwall'           => ['blockwall', DI::l10n()->t('Allow friends to post to your profile page?'), (intval($user['blockwall']) ? '0' : '1'), DI::l10n()->t('Your contacts may write posts on your profile wall. These posts will be distributed to your contacts')],
+			'$blocktags'           => ['blocktags', DI::l10n()->t('Allow friends to tag your posts?'), (intval($user['blocktags']) ? '0' : '1'), DI::l10n()->t('Your contacts can add additional tags to your posts.')],
+			'$circle_select'       => Circle::getSelectorHTML(DI::userSession()->getLocalUserId(), $user['def_gid'], 'circle-selection', DI::l10n()->t('Default privacy circle for new contacts')),
 			'$circle_select_group' => Circle::getSelectorHTML(DI::userSession()->getLocalUserId(), DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'default-group-gid', $user['def_gid']), 'circle-selection-group', DI::l10n()->t('Default privacy circle for new group contacts')),
-			'$permissions'        => DI::l10n()->t('Default Post Permissions'),
-			'$aclselect'          => ACL::getFullSelectorHTML(DI::page(), $this->session->getLocalUserId()),
+			'$permissions'         => DI::l10n()->t('Default Post Permissions'),
+			'$aclselect'           => ACL::getFullSelectorHTML(DI::page(), $this->session->getLocalUserId()),
 
 			'$expire' => [
 				'label'        => DI::l10n()->t('Expiration settings'),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-05 02:58+0000\n"
+"POT-Creation-Date: 2025-09-07 12:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -210,12 +210,12 @@ msgstr ""
 msgid "Your password has been changed at %s"
 msgstr ""
 
-#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:315
+#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:316
 #: view/theme/frio/theme.php:230
 msgid "Messages"
 msgstr ""
 
-#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:318
+#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:319
 msgid "New Message"
 msgstr ""
 
@@ -610,7 +610,7 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: mod/photos.php:1100 src/Content/Conversation.php:361
+#: mod/photos.php:1100 src/Content/Conversation.php:361 src/Content/Nav.php:113
 #: src/Module/Post/Edit.php:126 src/Object/Post.php:1160
 msgid "Loading..."
 msgstr ""
@@ -1720,7 +1720,7 @@ msgid "Display posts that have been created by accounts of the selected circle."
 msgstr ""
 
 #: src/Content/Feature.php:127 src/Content/GroupManager.php:128
-#: src/Content/Nav.php:275 src/Content/Text/HTML.php:876
+#: src/Content/Nav.php:276 src/Content/Text/HTML.php:876
 #: src/Content/Widget.php:558 src/Model/User.php:1397
 msgid "Groups"
 msgstr ""
@@ -1965,80 +1965,80 @@ msgstr ""
 msgid "Nothing new here"
 msgstr ""
 
-#: src/Content/Nav.php:117 src/Content/Nav.php:248 src/Content/Nav.php:305
+#: src/Content/Nav.php:118 src/Content/Nav.php:249 src/Content/Nav.php:306
 msgid "Home"
 msgstr ""
 
-#: src/Content/Nav.php:118
+#: src/Content/Nav.php:119
 msgid "Skip to main content"
 msgstr ""
 
-#: src/Content/Nav.php:119
+#: src/Content/Nav.php:120
 msgid "Clear notifications"
 msgstr ""
 
-#: src/Content/Nav.php:120
+#: src/Content/Nav.php:121
 msgid "Search: @name, !group, #tags, content"
 msgstr ""
 
-#: src/Content/Nav.php:219 src/Module/Security/Login.php:146
+#: src/Content/Nav.php:220 src/Module/Security/Login.php:146
 msgid "Logout"
 msgstr ""
 
-#: src/Content/Nav.php:219
+#: src/Content/Nav.php:220
 msgid "End this session"
 msgstr ""
 
-#: src/Content/Nav.php:221 src/Module/Bookmarklet.php:30
+#: src/Content/Nav.php:222 src/Module/Bookmarklet.php:30
 #: src/Module/Security/Login.php:147
 msgid "Login"
 msgstr ""
 
-#: src/Content/Nav.php:221
+#: src/Content/Nav.php:222
 msgid "Sign in"
 msgstr ""
 
-#: src/Content/Nav.php:226 src/Module/BaseProfile.php:42
+#: src/Content/Nav.php:227 src/Module/BaseProfile.php:42
 #: src/Module/Contact.php:497
 msgid "Conversations"
 msgstr ""
 
-#: src/Content/Nav.php:226
+#: src/Content/Nav.php:227
 msgid "Conversations you started"
 msgstr ""
 
-#: src/Content/Nav.php:227 src/Module/BaseProfile.php:34
+#: src/Content/Nav.php:228 src/Module/BaseProfile.php:34
 #: src/Module/BaseSettings.php:86 src/Module/Contact.php:489
 #: src/Module/Contact/Profile.php:464 src/Module/Profile/Profile.php:282
 #: src/Module/Welcome.php:44 view/theme/frio/theme.php:219
 msgid "Profile"
 msgstr ""
 
-#: src/Content/Nav.php:227 view/theme/frio/theme.php:219
+#: src/Content/Nav.php:228 view/theme/frio/theme.php:219
 msgid "Your profile page"
 msgstr ""
 
-#: src/Content/Nav.php:228 src/Module/BaseProfile.php:50
+#: src/Content/Nav.php:229 src/Module/BaseProfile.php:50
 #: src/Module/Media/Photo/Browser.php:62 view/theme/frio/theme.php:223
 msgid "Photos"
 msgstr ""
 
-#: src/Content/Nav.php:228 src/Module/Settings/Profile/Index.php:274
+#: src/Content/Nav.php:229 src/Module/Settings/Profile/Index.php:274
 #: view/theme/frio/theme.php:223
 msgid "Your photos"
 msgstr ""
 
-#: src/Content/Nav.php:229 src/Module/BaseProfile.php:58
+#: src/Content/Nav.php:230 src/Module/BaseProfile.php:58
 #: src/Module/BaseProfile.php:61 src/Module/Contact.php:513
 #: view/theme/frio/theme.php:224
 msgid "Media"
 msgstr ""
 
-#: src/Content/Nav.php:229 view/theme/frio/theme.php:224
+#: src/Content/Nav.php:230 view/theme/frio/theme.php:224
 msgid "Your postings with media"
 msgstr ""
 
-#: src/Content/Nav.php:230 src/Content/Nav.php:290
+#: src/Content/Nav.php:231 src/Content/Nav.php:291
 #: src/Module/BaseProfile.php:70 src/Module/BaseProfile.php:73
 #: src/Module/BaseProfile.php:81 src/Module/BaseProfile.php:84
 #: src/Module/Settings/Display.php:320 view/theme/frio/theme.php:225
@@ -2046,32 +2046,32 @@ msgstr ""
 msgid "Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:230 view/theme/frio/theme.php:225
+#: src/Content/Nav.php:231 view/theme/frio/theme.php:225
 msgid "Your calendar"
 msgstr ""
 
-#: src/Content/Nav.php:231
+#: src/Content/Nav.php:232
 msgid "Personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:231
+#: src/Content/Nav.php:232
 msgid "Your personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:248 src/Module/Settings/OAuth.php:59
+#: src/Content/Nav.php:249 src/Module/Settings/OAuth.php:59
 msgid "Home Page"
 msgstr ""
 
-#: src/Content/Nav.php:252 src/Module/Register.php:169
+#: src/Content/Nav.php:253 src/Module/Register.php:169
 #: src/Module/Security/Login.php:113
 msgid "Register"
 msgstr ""
 
-#: src/Content/Nav.php:252
+#: src/Content/Nav.php:253
 msgid "Create an account"
 msgstr ""
 
-#: src/Content/Nav.php:258 src/Module/Help.php:53
+#: src/Content/Nav.php:259 src/Module/Help.php:53
 #: src/Module/Settings/TwoFactor/AppSpecific.php:118
 #: src/Module/Settings/TwoFactor/Index.php:125
 #: src/Module/Settings/TwoFactor/Recovery.php:96
@@ -2079,37 +2079,37 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: src/Content/Nav.php:258
+#: src/Content/Nav.php:259
 msgid "Help and documentation"
 msgstr ""
 
-#: src/Content/Nav.php:262
+#: src/Content/Nav.php:263
 msgid "Apps"
 msgstr ""
 
-#: src/Content/Nav.php:262
+#: src/Content/Nav.php:263
 msgid "Addon applications, utilities, games"
 msgstr ""
 
-#: src/Content/Nav.php:266 src/Content/Text/HTML.php:861
+#: src/Content/Nav.php:267 src/Content/Text/HTML.php:861
 #: src/Module/Admin/Logs/View.php:74 src/Module/Search/Index.php:99
 msgid "Search"
 msgstr ""
 
-#: src/Content/Nav.php:266
+#: src/Content/Nav.php:267
 msgid "Search site content"
 msgstr ""
 
-#: src/Content/Nav.php:269 src/Content/Text/HTML.php:870
+#: src/Content/Nav.php:270 src/Content/Text/HTML.php:870
 msgid "Full Text"
 msgstr ""
 
-#: src/Content/Nav.php:270 src/Content/Text/HTML.php:871
+#: src/Content/Nav.php:271 src/Content/Text/HTML.php:871
 #: src/Content/Widget/TagCloud.php:54
 msgid "Tags"
 msgstr ""
 
-#: src/Content/Nav.php:271 src/Content/Nav.php:326
+#: src/Content/Nav.php:272 src/Content/Nav.php:327
 #: src/Content/Text/HTML.php:872 src/Module/BaseProfile.php:112
 #: src/Module/BaseProfile.php:115 src/Module/Contact.php:181
 #: src/Module/Contact.php:411 src/Module/Contact.php:521
@@ -2117,121 +2117,121 @@ msgstr ""
 msgid "Contacts"
 msgstr ""
 
-#: src/Content/Nav.php:286
+#: src/Content/Nav.php:287
 msgid "Community"
 msgstr ""
 
-#: src/Content/Nav.php:286
+#: src/Content/Nav.php:287
 msgid "Conversations on this and other servers"
 msgstr ""
 
-#: src/Content/Nav.php:293
+#: src/Content/Nav.php:294
 msgid "Directory"
 msgstr ""
 
-#: src/Content/Nav.php:293
+#: src/Content/Nav.php:294
 msgid "People directory"
 msgstr ""
 
-#: src/Content/Nav.php:295 src/Module/BaseAdmin.php:70
+#: src/Content/Nav.php:296 src/Module/BaseAdmin.php:70
 #: src/Module/BaseModeration.php:97
 msgid "Information"
 msgstr ""
 
-#: src/Content/Nav.php:295
+#: src/Content/Nav.php:296
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:298 src/Module/Admin/Tos.php:64
+#: src/Content/Nav.php:299 src/Module/Admin/Tos.php:64
 #: src/Module/BaseAdmin.php:80 src/Module/Register.php:177
 #: src/Module/Tos.php:87
 msgid "Terms of Service"
 msgstr ""
 
-#: src/Content/Nav.php:298
+#: src/Content/Nav.php:299
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:303 view/theme/frio/theme.php:228
+#: src/Content/Nav.php:304 view/theme/frio/theme.php:228
 msgid "Network"
 msgstr ""
 
-#: src/Content/Nav.php:303 view/theme/frio/theme.php:228
+#: src/Content/Nav.php:304 view/theme/frio/theme.php:228
 msgid "Conversations from your friends"
 msgstr ""
 
-#: src/Content/Nav.php:305 view/theme/frio/theme.php:218
+#: src/Content/Nav.php:306 view/theme/frio/theme.php:218
 msgid "Your posts and conversations"
 msgstr ""
 
-#: src/Content/Nav.php:309
+#: src/Content/Nav.php:310
 msgid "Introductions"
 msgstr ""
 
-#: src/Content/Nav.php:309
+#: src/Content/Nav.php:310
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:310 src/Module/BaseNotifications.php:134
+#: src/Content/Nav.php:311 src/Module/BaseNotifications.php:134
 #: src/Module/Notifications/Introductions.php:61
 msgid "Notifications"
 msgstr ""
 
-#: src/Content/Nav.php:311
+#: src/Content/Nav.php:312
 msgid "See all notifications"
 msgstr ""
 
-#: src/Content/Nav.php:312 src/Module/Settings/Connectors.php:226
+#: src/Content/Nav.php:313 src/Module/Settings/Connectors.php:226
 msgid "Mark as seen"
 msgstr ""
 
-#: src/Content/Nav.php:312
+#: src/Content/Nav.php:313
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:315 view/theme/frio/theme.php:230
+#: src/Content/Nav.php:316 view/theme/frio/theme.php:230
 msgid "Private mail"
 msgstr ""
 
-#: src/Content/Nav.php:316
+#: src/Content/Nav.php:317
 msgid "Inbox"
 msgstr ""
 
-#: src/Content/Nav.php:317
+#: src/Content/Nav.php:318
 msgid "Outbox"
 msgstr ""
 
-#: src/Content/Nav.php:321
+#: src/Content/Nav.php:322
 msgid "Accounts"
 msgstr ""
 
-#: src/Content/Nav.php:321
+#: src/Content/Nav.php:322
 msgid "Manage other pages"
 msgstr ""
 
-#: src/Content/Nav.php:324 src/Module/Admin/Addons/Details.php:140
+#: src/Content/Nav.php:325 src/Module/Admin/Addons/Details.php:140
 #: src/Module/Admin/Themes/Details.php:85 src/Module/BaseSettings.php:177
 #: src/Module/Welcome.php:39 view/theme/frio/theme.php:231
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:324 view/theme/frio/theme.php:231
+#: src/Content/Nav.php:325 view/theme/frio/theme.php:231
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:326 view/theme/frio/theme.php:232
+#: src/Content/Nav.php:327 view/theme/frio/theme.php:232
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:331 src/Module/BaseAdmin.php:114
+#: src/Content/Nav.php:332 src/Module/BaseAdmin.php:114
 msgid "Admin"
 msgstr ""
 
-#: src/Content/Nav.php:331
+#: src/Content/Nav.php:332
 msgid "Site setup and configuration"
 msgstr ""
 
-#: src/Content/Nav.php:332 src/Module/BaseModeration.php:117
+#: src/Content/Nav.php:333 src/Module/BaseModeration.php:117
 #: src/Module/Moderation/Blocklist/Contact.php:98
 #: src/Module/Moderation/Blocklist/Server/Add.php:110
 #: src/Module/Moderation/Blocklist/Server/Import.php:105
@@ -2245,15 +2245,15 @@ msgstr ""
 msgid "Moderation"
 msgstr ""
 
-#: src/Content/Nav.php:332
+#: src/Content/Nav.php:333
 msgid "Content and user moderation"
 msgstr ""
 
-#: src/Content/Nav.php:335
+#: src/Content/Nav.php:336
 msgid "Navigation"
 msgstr ""
 
-#: src/Content/Nav.php:335
+#: src/Content/Nav.php:336
 msgid "Site map"
 msgstr ""
 
@@ -9316,7 +9316,7 @@ msgid "Default Post Location:"
 msgstr ""
 
 #: src/Module/Settings/Account.php:527
-msgid "Use Browser Location:"
+msgid "Use browser location"
 msgstr ""
 
 #: src/Module/Settings/Account.php:529


### PR DESCRIPTION
Under Settings "Use browser location" is a checkbox, but confusingly it has a colon afterwards, which doesn't make sense.
Then, when translators see this, they obviously translate it with a colon as well, and so most languages will propagate that mistake.

This is what it looks like:
<img width="630" height="295" alt="image" src="https://github.com/user-attachments/assets/d73dfb2b-35e6-4606-8ef9-8f5f4bb7964d" />

This tiny PR removes that colon. It also lowercases the words after the first, so it matches the current English translation, since it has to be re-translated anyway.

Before:
<img width="199" height="49" alt="image" src="https://github.com/user-attachments/assets/f06dc77e-92d5-4110-aca0-57e555d860c8" />

After:
<img width="199" height="49" alt="image" src="https://github.com/user-attachments/assets/2f0af5c8-9822-4b5f-a09e-39f6e80febe1" />
