### PR TITLE
Accessibility adjuments and cleanup related to #15123 (Frio)

### DIFF
--- a/view/theme/frio/templates/jot.tpl
+++ b/view/theme/frio/templates/jot.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 {{* The button to open the jot - in This theme we move the button with js to the second nav bar *}}
-<a class="btn btn-primary pull-right{{if !$always_open_compose}} modal-open{{/if}}" id="jotOpen" href="compose/{{$posttype}}{{if $content}}?body={{$content}}{{/if}}" aria-label="{{$new_post}}" title="{{$new_post}}">
+<a class="btn btn-primary pull-right{{if !$always_open_compose}} modal-open{{/if}}" id="jotOpen" href="compose/{{$posttype}}{{if $content}}?body={{$content}}{{/if}}">
 	<i class="fa fa-lg fa-pencil-square-o"></i>&nbsp;
 	<span>{{$new_post}}</span>
 </a>

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -46,13 +46,13 @@
 					<div id="dfrn-request-link-button">
 						{{if $unfollow_link}}
 							<a id="dfrn-request-link" class="btn btn-labeled btn-primary" href="{{$unfollow_link}}">
-								<span class=""><i class="fa fa-user-times"></i></span>
-								<span class="">{{$unfollow}}</span>
+								<span><i class="fa fa-user-times"></i></span>
+								<span>{{$unfollow}}</span>
 							</a>
 						{{else}}
 							<a id="dfrn-request-link" class="btn btn-labeled btn-primary" href="{{$follow_link}}">
-								<span class=""><i class="fa fa-user-plus"></i></span>
-								<span class="">{{$follow}}</span>
+								<span><i class="fa fa-user-plus"></i></span>
+								<span>{{$follow}}</span>
 							</a>
 						{{/if}}
 					</div>
@@ -60,32 +60,32 @@
 				{{if $subscribe_feed_link}}
 					<div id="subscribe-feed-link-button">
 						<a id="subscribe-feed-link" class="btn btn-labeled btn-primary" href="{{$subscribe_feed_link}}">
-							<span class=""><i class="fa fa-rss"></i></span>
-							<span class="">{{$subscribe_feed}}</span>
+							<span><i class="fa fa-rss"></i></span>
+							<span>{{$subscribe_feed}}</span>
 						</a>
 					</div>
 				{{/if}}
 				{{if $wallmessage_link}}
 					<div id="wallmessage-link-button">
 						<button type="button" id="wallmessage-link" class="btn btn-labeled btn-primary" onclick="openWallMessage('{{$wallmessage_link}}')">
-							<span class=""><i class="fa fa-envelope"></i></span>
-							<span class="">{{$wallmessage}}</span>
+							<span><i class="fa fa-envelope"></i></span>
+							<span>{{$wallmessage}}</span>
 						</button>
 					</div>
 				{{/if}}
 				{{if $profile.addr}}
 					<div id="mention-link-button">
 						<button type="button" id="mention-link" class="btn btn-labeled btn-primary" onclick="openWallMessage('{{$mention_url}}')">
-							<span class=""><i class="fa fa-pencil-square-o"></i></span>&nbsp;
-							<span class="">{{$mention_label}}</span>
+							<span><i class="fa fa-pencil-square-o"></i></span>&nbsp;
+							<span>{{$mention_label}}</span>
 						</button>
 					</div>
 				{{/if}}
 				{{if $network_label}}
 					<div id="showgroup-button">
 						<a id="showgroup" class="btn btn-labeled btn-primary" href="{{$network_url}}">
-							<span class=""><i class="fa fa-group"></i></span>
-							<span class="">{{$network_label}}</span>
+							<span><i class="fa fa-group"></i></span>
+							<span>{{$network_label}}</span>
 						</a>
 					</div>
 				{{/if}}

--- a/view/theme/frio/templates/widget/vcard.tpl
+++ b/view/theme/frio/templates/widget/vcard.tpl
@@ -45,30 +45,30 @@
 			<div id="dfrn-request-link-button">
 				{{if $follow_link}}
 					<a id="dfrn-request-link" class="btn btn-labeled btn-primary" href="{{$follow_link}}"">
-						<span class=""><i class="fa fa-user-plus"></i></span>
-						<span class="">{{$follow}}</span>
+						<span><i class="fa fa-user-plus"></i></span>
+						<span>{{$follow}}</span>
 					</a>
 				{{/if}}
 				{{if $unfollow_link}}
 					<a id="dfrn-request-link" class="btn btn-labeled btn-primary" href="{{$unfollow_link}}">
-						<span class=""><i class="fa fa-user-times"></i></span>
-						<span class="">{{$unfollow}}</span>
+						<span><i class="fa fa-user-times"></i></span>
+						<span>{{$unfollow}}</span>
 					</a>
 				{{/if}}
 			</div>
 			{{if $wallmessage_link}}
 				<div id="wallmessage-link-button">
 					<button type="button" id="wallmessage-link" class="btn btn-labeled btn-primary" onclick="openWallMessage('{{$wallmessage_link}}')">
-						<span class=""><i class="fa fa-envelope"></i></span>
-						<span class="">{{$wallmessage}}</span>
+						<span><i class="fa fa-envelope"></i></span>
+						<span>{{$wallmessage}}</span>
 					</button>
 				</div>
 			{{/if}}
 			{{if $mention_link}}
 				<div id="mention-link-button">
-					<button type="button" id="mention-link" class="btn btn-labeled btn-primary{{if !$always_open_compose}} modal-open{{/if}}" onclick="openWallMessage('{{$mention_link}}')" title="{{$mention}}" aria-label="{{$mention}}">
-						<span class=""><i class="fa fa-pencil-square-o"></i></span>&nbsp;
-						<span class="">{{$mention}}</span>
+					<button type="button" id="mention-link" class="btn btn-labeled btn-primary{{if !$always_open_compose}} modal-open{{/if}}" onclick="openWallMessage('{{$mention_link}}')" aria-label="{{$mention}}">
+						<span><i class="fa fa-pencil-square-o"></i></span>&nbsp;
+						<span>{{$mention}}</span>
 					</button>
 				</div>
 			{{/if}}


### PR DESCRIPTION
This PR does some cleanup for screenreaders, and a bit of HTML cleanup, related to #15123 

1. The `aria-label` attribute is removed from the `New post` action because the action is now accompanied with text itself. This should stop screenreaders from reading it twice.
2. The `title` attribute is being removed from two buttons because the buttons themselves has the text, so the hover text just says the same thing as the button itself, making them superfluous.
3. A number of empty HTML `class` attributes are removed.