### PR TITLE
Replace Friendica\Addon autoloading from classmap to PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,9 +100,9 @@
 	],
 	"autoload": {
 		"psr-4": {
-			"Friendica\\": "src/"
+			"Friendica\\": "src/",
+			"Friendica\\Addon\\":  "addon/"
 		},
-		"classmap": ["addon/"],
 		"exclude-from-classmap": [
 			"addon/*/vendor/"
 		]


### PR DESCRIPTION
the command `./bin/composer.phar` creates a `vendor/composer` directory and glues all namespaces to given directories. Since the `addon/` directory isn't always present during execution (like when executing during a pipeline ...), all the `Friendica/Addon` namespaces can be completely missing.

This never happens, when the `addon/` directory is present, so it was a little bit hard to find.

The new approach is to add `Friendica\Addon` as explicit psr-4 namespace, so it's autoloading based dynamically on psr-4 and not per `classmap()` statically.

I tested it manually with the Docker-file and it seems to work fine.

maybe @ne20002 can have a look and maybe @art4 has some php insights about it, if this really DOES work and I'm not about to break something ;-)

Fixes #14834 and fixes #14998