### PR TITLE
Store incoming blurhash values / display blurhash as preview

### DIFF
--- a/src/Module/Photo.php
+++ b/src/Module/Photo.php
@@ -272,6 +272,12 @@ class Photo extends BaseApi
 					$height = $media['height'];
 				}
 
+				if (empty($url) && isset($media['blurhash']) && isset($media['width']) && isset($media['height'])) {
+					$image = new Image('', image_type_to_mime_type(IMAGETYPE_WEBP));
+					$image->getFromBlurHash($media['blurhash'], $media['width'], $media['height']);
+					return MPhoto::createPhotoForImageData($image->asString());
+				}
+
 				if (empty($url)) {
 					return false;
 				}

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -152,6 +152,7 @@ class Processor
 		$data['height']        = $attachment['height']        ?? null;
 		$data['width']         = $attachment['width']         ?? null;
 		$data['size']          = $attachment['size']          ?? null;
+		$data['blurhash']      = $attachment['blurhash']      ?? null;
 		$data['preview']       = $attachment['image']         ?? null;
 		$data['description']   = $attachment['name']          ?? null;
 		$data['player-url']    = $attachment['player-url']    ?? null;

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1677,6 +1677,7 @@ class Receiver
 						'name'      => JsonLD::fetchElement($attachment, 'as:name', '@value'),
 						'url'       => $imageFullUrl,
 						'image'     => $imagePreviewUrl !== $imageFullUrl ? $imagePreviewUrl : null,
+						'blurhash'  => JsonLD::fetchElement($attachment, 'toot:blurhash', '@value'),
 					];
 					break;
 				default:
@@ -1693,6 +1694,7 @@ class Receiver
 						'height'    => JsonLD::fetchElement($attachment, 'as:height', '@value'),
 						'width'     => JsonLD::fetchElement($attachment, 'as:width', '@value'),
 						'image'     => JsonLD::fetchElement($attachment, 'as:image', '@id') ?? $icon,
+						'blurhash'  => JsonLD::fetchElement($attachment, 'toot:blurhash', '@value'),
 					];
 			}
 		}


### PR DESCRIPTION
The blurhash is a blurry picture preview. We normally create it on our own, but we can't do so for videos. We will now store incoming blurhash values. Also we will be able to display the blurhash as preview when there is no preview picture.