### PR TITLE
Consistent action buttons, post icon change, related css+js cleanup

### DIFF
--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -852,14 +852,14 @@ class HTML
 		if (strpos($s, '#') === 0) {
 			$mode = 'tag';
 		}
-		$save_label = $mode === 'text' ? DI::l10n()->t('Save') : DI::l10n()->t('Follow');
+		$action_text = DI::l10n()->t('Save search');
 
 		$values = [
 			'$s'            => $s,
 			'$q'            => urlencode($s),
 			'$id'           => $id,
 			'$search_label' => DI::l10n()->t('Search'),
-			'$save_label'   => $save_label,
+			'$action_text'  => $action_text,
 			'$search_hint'  => DI::l10n()->t('@name, !group, #tags, content'),
 			'$mode'         => $mode,
 			'$return_url'   => bin2hex(Search::getSearchPath($s)),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-07 23:20+0200\n"
+"POT-Creation-Date: 2025-09-09 22:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -352,9 +352,9 @@ msgstr ""
 msgid "Personal notes are visible only by yourself."
 msgstr ""
 
-#: mod/notes.php:46 src/Content/Text/HTML.php:855
-#: src/Module/Admin/Storage.php:128 src/Module/Filer/SaveTag.php:60
-#: src/Module/Post/Edit.php:125 src/Module/Settings/Channels.php:220
+#: mod/notes.php:46 src/Module/Admin/Storage.php:128
+#: src/Module/Filer/SaveTag.php:60 src/Module/Post/Edit.php:125
+#: src/Module/Settings/Channels.php:220
 msgid "Save"
 msgstr ""
 
@@ -2311,9 +2311,8 @@ msgstr ""
 msgid "The end"
 msgstr ""
 
-#: src/Content/Text/HTML.php:855 src/Content/Widget/VCard.php:116
-#: src/Model/Profile.php:454 src/Module/Contact/Profile.php:522
-msgid "Follow"
+#: src/Content/Text/HTML.php:855
+msgid "Save search"
 msgstr ""
 
 #: src/Content/Text/HTML.php:863
@@ -2527,6 +2526,11 @@ msgstr ""
 #: src/Content/Widget/VCard.php:114 src/Model/Profile.php:467
 #: src/Module/Notifications/Introductions.php:194
 msgid "Network:"
+msgstr ""
+
+#: src/Content/Widget/VCard.php:116 src/Model/Profile.php:454
+#: src/Module/Contact/Profile.php:522
+msgid "Follow"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:118 src/Model/Contact.php:1294

--- a/view/templates/searchbox.tpl
+++ b/view/templates/searchbox.tpl
@@ -17,7 +17,7 @@
     {{/if}}
 		<input type="submit" name="submit" id="search-submit" value="{{$search_label}}"/>
     {{if $s}}
-	    <a href="search/saved/add?term={{$q}}&amp;return_url={{$return_url}}">{{$save_label}}</a>
+	    <a href="search/saved/add?term={{$q}}&amp;return_url={{$return_url}}">{{$action_label}}</a>
     {{/if}}
 {{/strip}}
 	</form>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1438,11 +1438,14 @@ section ul.tabs {
 section #jotOpen {
 	display: none;
 }
-#jotOpen, #mention-link {
+.action-button {
 	align-items: center;
 	display: flex;
 	padding-bottom: 7px;
 	padding-top: 7px;
+}
+.action-button span {
+	margin-left: 6px;
 }
 #jot-content {
 	display: none;
@@ -2509,9 +2512,6 @@ input[type="range"].form-control {
 }
 .search-content-wrapper > .section-title-wrapper {
 	display: none;
-}
-#navbar-button > #search-save {
-	margin-top: 3px;
 }
 /* Section-Content-Wrapper */
 #search-header-wrapper {

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -84,20 +84,6 @@ $(document).ready(function () {
 		target: ".flex-target",
 	});
 
-	// add mention-link button to the second navbar
-	let $mentionButton = $("#mention-link-button");
-	if ($mentionButton.length) {
-		$mentionButton.appendTo("#topbar-second > .container > #navbar-button").addClass("pull-right");
-		$("#mention-link > span i").addClass("fa-lg");
-		if ($mentionButton.hasClass("modal-open")) {
-			$mentionButton.on("click", function (e) {
-				e.preventDefault();
-				jotShow();
-			});
-		}
-	}
-
-
 	// add Jot button to the second navbar
 	let $jotButton = $("#jotOpen");
 	if ($jotButton.length) {

--- a/view/theme/frio/templates/jot.tpl
+++ b/view/theme/frio/templates/jot.tpl
@@ -5,8 +5,8 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 {{* The button to open the jot - in This theme we move the button with js to the second nav bar *}}
-<a class="btn btn-primary pull-right{{if !$always_open_compose}} modal-open{{/if}}" id="jotOpen" href="compose/{{$posttype}}{{if $content}}?body={{$content}}{{/if}}">
-	<i class="fa fa-lg fa-pencil-square-o"></i>&nbsp;
+<a class="action-button btn btn-primary pull-right{{if !$always_open_compose}} modal-open{{/if}}" id="jotOpen" href="compose/{{$posttype}}{{if $content}}?body={{$content}}{{/if}}">
+	<i class="fa fa-lg fa-pencil"></i>
 	<span>{{$new_post}}</span>
 </a>
 

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -74,9 +74,9 @@
 					</div>
 				{{/if}}
 				{{if $profile.addr}}
-					<div id="mention-link-button">
-						<button type="button" id="mention-link" class="btn btn-labeled btn-primary" onclick="openWallMessage('{{$mention_url}}')">
-							<span><i class="fa fa-pencil-square-o"></i></span>&nbsp;
+					<div id="jotOpen" class="pull-right">
+						<button type="button" id="mention-link" class="action-button btn btn-labeled btn-primary" onclick="openWallMessage('{{$mention_url}}')">
+							<i class="fa fa-lg fa-pencil"></i>
 							<span>{{$mention_label}}</span>
 						</button>
 					</div>

--- a/view/theme/frio/templates/searchbox.tpl
+++ b/view/theme/frio/templates/searchbox.tpl
@@ -24,7 +24,7 @@ Some parts of this template will be moved by js to other places (see theme.js) -
 					<div class="col-md-8">
 						{{* The button to save searches *}}
 						{{if $s}}
-						<a href="search/saved/add?term={{$q}}&amp;return_url={{$return_url}}" class="btn btn-primary btn-small pull-right">{{$save_label}}</a>
+						<a href="search/saved/add?term={{$q}}&amp;return_url={{$return_url}}" class="btn btn-primary btn-small pull-right">{{$action_text}}</a>
 						{{/if}}
 
 						{{* The select popup menu to select what kind of results the user would like to search for *}}
@@ -39,7 +39,7 @@ Some parts of this template will be moved by js to other places (see theme.js) -
 							</div>
 						</div>
 						{{/if}}
-						
+
 					</div>
 				</div>
 				<div class="col-md-2"></div>
@@ -47,18 +47,14 @@ Some parts of this template will be moved by js to other places (see theme.js) -
 				<div class="clearfix"></div>
 
 			</div>
-			
+
 		</form>
 	</div>
 
 {{if $s}}
-	<a href="search/saved/add?term={{$q}}&amp;return_url={{$return_url}}" class="btn btn-sm btn-primary pull-right" id="search-save" title="{{$save_label}}" aria-label="{{$save_label}}" value="{{$save_label}}" data-toggle="tooltip">
-	{{if $mode == "tag"}}
-		<i class="fa fa-plus fa-2x" aria-hidden="true"></i>
-	{{else}}
-		<i class="fa fa-floppy-o fa-2x" aria-hidden="true"></i>
-	{{/if}}
-		<span class="sr-only">{{$save_label}}</span>
+	<a href="search/saved/add?term={{$q}}&amp;return_url={{$return_url}}" class="action-button btn btn-primary pull-right" id="search-save">
+		<i class="fa fa-lg fa-floppy-o" aria-hidden="true"></i>
+		<span>{{$action_text}}</span>
 	</a>
 {{/if}}
 </div>

--- a/view/theme/frio/templates/widget/vcard.tpl
+++ b/view/theme/frio/templates/widget/vcard.tpl
@@ -65,9 +65,9 @@
 				</div>
 			{{/if}}
 			{{if $mention_link}}
-				<div id="mention-link-button">
-					<button type="button" id="mention-link" class="btn btn-labeled btn-primary{{if !$always_open_compose}} modal-open{{/if}}" onclick="openWallMessage('{{$mention_link}}')" aria-label="{{$mention}}">
-						<span><i class="fa fa-pencil-square-o"></i></span>&nbsp;
+				<div id="jotOpen" class="pull-right">
+					<button type="button" id="mention-link" class="action-button btn btn-labeled btn-primary{{if !$always_open_compose}} modal-open{{/if}}" onclick="openWallMessage('{{$mention_link}}')" aria-label="{{$mention}}">
+						<i class="fa fa-lg fa-pencil"></i>
 						<span>{{$mention}}</span>
 					</button>
 				</div>


### PR DESCRIPTION
Closes #15137, #15136 

- Updates the save search and follow tag actions which I'd missed updating earlier, to also have text, and look like Mention and New Post actions. Also they both effectively save a search, so I made them identical, using the same icon and text. Did consider calling the tag one "Save tag search" but at smaller resolutions it would start to cover the search string earlier.

- Fixes The duplicate "New post" and "Mention buttons" on /profile/`<user>`/conversations. Now it's only "Mention".

- Changes the Post/Mention icon to a pen instead of pen on square based on the suggestion in #15136. I also think it's a more consistent look with other icons used in Friendica

- Cleans up the CSS a bit, so all these action buttons are styled with the same rule, and switching the "Mention" button over to using the same JS as "New post", as it's copy pasted with only minor changes. 
In time I'd suggest moving away from moving them via JS at all and just adding them to the proper templates in the spot where they're needed (maybe via a PHP `include` to not duplicate the code), but that'll be for another time.

# Screenshots

## Before

Old icon for New post and Mention:
<img width="175" height="41" alt="image" src="https://github.com/user-attachments/assets/53d5586d-c177-4cea-9714-3a4a4b8f3a59" />

Old styling for save search:
<img width="481" height="36" alt="image" src="https://github.com/user-attachments/assets/fe03caf2-308d-4eef-95a2-3ed35f069f77" />

Old styling for save tag search:
<img width="294" height="44" alt="image" src="https://github.com/user-attachments/assets/c3eb27f5-6ea8-4d2f-9295-95c576a734e2" />

## After

New icon for New post and Mention:
<img width="175" height="41" alt="image" src="https://github.com/user-attachments/assets/e45729db-15eb-4ae0-a056-131a90dcc8ca" />

New styling for save search and save tag search.
<img width="341" height="42" alt="image" src="https://github.com/user-attachments/assets/189ecc9b-4665-42a9-bf7d-7783843c2740" />
