### PR TITLE
Login, forgotten password and (minor) registration adjustments

### DIFF
--- a/mod/lostpass.php
+++ b/mod/lostpass.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (C) 2010-2024, the Friendica project
  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
@@ -22,7 +23,7 @@ function lostpass_post()
 	}
 
 	$condition = ['(`email` = ? OR `nickname` = ?) AND `verified` AND NOT `blocked` AND NOT `account_removed` AND NOT `account_expired`', $loginame, $loginame];
-	$user = DBA::selectFirst('user', ['uid', 'username', 'nickname', 'email', 'language'], $condition);
+	$user      = DBA::selectFirst('user', ['uid', 'username', 'nickname', 'email', 'language'], $condition);
 	if (!DBA::isResult($user)) {
 		DI::sysmsg()->addNotice(DI::l10n()->t('No valid account found.'));
 		DI::baseUrl()->redirect();
@@ -31,7 +32,7 @@ function lostpass_post()
 	$pwdreset_token = Strings::getRandomHex(32);
 
 	$fields = [
-		'pwdreset' => hash('sha256', $pwdreset_token),
+		'pwdreset'      => hash('sha256', $pwdreset_token),
 		'pwdreset_time' => DateTimeFormat::utcNow()
 	];
 	$result = DBA::update('user', $fields, ['uid' => $user['uid']]);
@@ -39,7 +40,7 @@ function lostpass_post()
 		DI::sysmsg()->addInfo(DI::l10n()->t('Password reset request issued. Check your email.'));
 	}
 
-	$sitename = DI::config()->get('config', 'sitename');
+	$sitename  = DI::config()->get('config', 'sitename');
 	$resetlink = DI::baseUrl() . '/lostpass/' . $pwdreset_token;
 
 	$preamble = Strings::deindent(DI::l10n()->t('
@@ -92,7 +93,7 @@ function lostpass_content()
 		// Password reset requests expire in 60 minutes
 		if ($user['pwdreset_time'] < DateTimeFormat::utc('now - 1 hour')) {
 			$fields = [
-				'pwdreset' => null,
+				'pwdreset'      => null,
 				'pwdreset_time' => null
 			];
 			DBA::update('user', $fields, ['uid' => $user['uid']]);
@@ -111,11 +112,11 @@ function lostpass_content()
 function lostpass_form()
 {
 	$tpl = Renderer::getMarkupTemplate('lostpass.tpl');
-	$o = Renderer::replaceMacros($tpl, [
-		'$title' => DI::l10n()->t('Forgot your Password?'),
-		'$desc' => DI::l10n()->t('Enter your email address and submit to have your password reset. Then check your email for further instructions.'),
-		'$name' => DI::l10n()->t('Nickname or Email: '),
-		'$submit' => DI::l10n()->t('Reset')
+	$o   = Renderer::replaceMacros($tpl, [
+		'$title'  => DI::l10n()->t('Forgot your Password?'),
+		'$desc'   => DI::l10n()->t('Enter your email address and submit to have your password reset. Then check your email for further instructions.'),
+		'$name'   => DI::l10n()->t('Nickname or email'),
+		'$submit' => DI::l10n()->t('Reset my password')
 	]);
 
 	return $o;
@@ -126,7 +127,7 @@ function lostpass_generate_password($user)
 	$o = '';
 
 	$new_password = User::generateNewPassword();
-	$result = User::updatePassword($user['uid'], $new_password);
+	$result       = User::updatePassword($user['uid'], $new_password);
 	if (DBA::isResult($result)) {
 		$tpl = Renderer::getMarkupTemplate('pwdreset.tpl');
 		$o .= Renderer::replaceMacros($tpl, [

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -217,9 +217,9 @@ class Nav
 
 		// nav links: array of array('href', 'text', 'extra css classes', 'title')
 		if ($this->session->isAuthenticated()) {
-			$nav['logout'] = ['logout', $this->l10n->t('Logout'), '', $this->l10n->t('End this session')];
+			$nav['logout'] = ['logout', $this->l10n->t('Sign out'), '', $this->l10n->t('End this session')];
 		} else {
-			$nav['login'] = ['login', $this->l10n->t('Login'), ($this->router->getModuleClass() == Login::class ? 'selected' : ''), $this->l10n->t('Sign in')];
+			$nav['login'] = ['login', $this->l10n->t('Sign in'), ($this->router->getModuleClass() == Login::class ? 'selected' : ''), $this->l10n->t('Sign in')];
 		}
 
 		if ($this->session->isAuthenticated()) {

--- a/src/Module/Bookmarklet.php
+++ b/src/Module/Bookmarklet.php
@@ -27,13 +27,13 @@ class Bookmarklet extends BaseModule
 		$config = DI::config();
 
 		if (!DI::userSession()->getLocalUserId()) {
-			$output = '<h2>' . DI::l10n()->t('Login') . '</h2>';
+			$output = '<h2>' . DI::l10n()->t('Sign in') . '</h2>';
 			$output .= Login::form(DI::args()->getQueryString(), Register::getPolicy() !== Register::CLOSED);
 			return $output;
 		}
 
 		$referer = Strings::normaliseLink($_SERVER['HTTP_REFERER'] ?? '');
-		$page = Strings::normaliseLink(DI::baseUrl() . "/bookmarklet");
+		$page    = Strings::normaliseLink(DI::baseUrl() . "/bookmarklet");
 
 		if (!strstr($referer, $page)) {
 			if (empty($_REQUEST["url"])) {
@@ -43,8 +43,8 @@ class Bookmarklet extends BaseModule
 			$content = "\n" . PageInfo::getFooterFromUrl($_REQUEST['url']);
 
 			$x = [
-				'title'            => trim($_REQUEST['title'] ?? '', '*'),
-				'content'          => $content
+				'title'   => trim($_REQUEST['title'] ?? '', '*'),
+				'content' => $content
 			];
 			$output = DI::conversation()->statusEditor($x, 0, false);
 			$output .= "<script>window.resizeTo(800,550);</script>";

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -154,7 +154,7 @@ class Register extends BaseModule
 			'$invite_desc'           => DI::l10n()->t('Membership on this site is by invitation only.'),
 			'$invite_label'          => DI::l10n()->t('Your invitation code: '),
 			'$invite_id'             => $invite_id,
-			'$regtitle'              => DI::l10n()->t('Registration'),
+			'$regtitle'              => DI::l10n()->t('Create an account'),
 			'$registertext'          => BBCode::convertForUriId(User::getSystemUriId(), DI::config()->get('config', 'register_text', '')),
 			'$fillwith'              => $fillwith,
 			'$fillext'               => $fillext,

--- a/src/Module/Security/Login.php
+++ b/src/Module/Security/Login.php
@@ -148,11 +148,12 @@ class Login extends BaseModule
 			$identity        = DI::session()->get('openid_identity');
 			$username_desc   = DI::l10n()->t('Please enter your username and password to add the OpenID to your existing account.');
 		} else {
-			$openid_title    = DI::l10n()->t('Or login using OpenID: ');
+			$openid_title    = DI::l10n()->t('Or login using OpenID');
 			$openid_readonly = false;
 			$identity        = '';
 			$username_desc   = '';
 		}
+		$openid_placeholder = DI::l10n()->t('OpenID');
 
 		$o = Renderer::replaceMacros(
 			$tpl,
@@ -162,12 +163,12 @@ class Login extends BaseModule
 				'$logout'   => DI::l10n()->t('Logout'),
 				'$login'    => DI::l10n()->t('Login'),
 
-				'$lname'     => ['username', DI::l10n()->t('Nickname or Email: '), '', $username_desc],
-				'$lpassword' => ['password', DI::l10n()->t('Password: '), '', ''],
+				'$lname'     => ['username', DI::l10n()->t('Nickname or email'), '', $username_desc],
+				'$lpassword' => ['password', DI::l10n()->t('Password'), '', ''],
 				'$lremember' => ['remember', DI::l10n()->t('Remember me'), 0,  ''],
 
 				'$openid'  => !$noid,
-				'$lopenid' => ['openid_url', $openid_title, $identity, '', $openid_readonly],
+				'$lopenid' => ['openid_url', $openid_title, $identity, '', $openid_readonly, $openid_placeholder],
 
 				'$hiddens' => ['return_path' => $return_path ?? DI::args()->getQueryString()],
 

--- a/src/Module/Security/Login.php
+++ b/src/Module/Security/Login.php
@@ -124,7 +124,7 @@ class Login extends BaseModule
 		$reg = false;
 		if ($register && Register::getPolicy() !== Register::CLOSED) {
 			$reg = [
-				'title' => DI::l10n()->t('Create a New Account'),
+				'title' => DI::l10n()->t('Create an account'),
 				'desc'  => DI::l10n()->t('Register'),
 				'url'   => self::getRegisterURL()
 			];
@@ -148,7 +148,7 @@ class Login extends BaseModule
 			$identity        = DI::session()->get('openid_identity');
 			$username_desc   = DI::l10n()->t('Please enter your username and password to add the OpenID to your existing account.');
 		} else {
-			$openid_title    = DI::l10n()->t('Or login using OpenID');
+			$openid_title    = DI::l10n()->t('Or sign in using OpenID');
 			$openid_readonly = false;
 			$identity        = '';
 			$username_desc   = '';
@@ -160,8 +160,9 @@ class Login extends BaseModule
 			[
 				'$notices'  => $notices,
 				'$dest_url' => DI::baseUrl() . '/login',
-				'$logout'   => DI::l10n()->t('Logout'),
-				'$login'    => DI::l10n()->t('Login'),
+				'$logout'   => DI::l10n()->t('Sign out'),
+				'$login'    => DI::l10n()->t('Sign in'),
+				'$new'      => DI::l10n()->t('New here?'),
 
 				'$lname'     => ['username', DI::l10n()->t('Nickname or email'), '', $username_desc],
 				'$lpassword' => ['password', DI::l10n()->t('Password'), '', ''],

--- a/src/Module/Security/Login.php
+++ b/src/Module/Security/Login.php
@@ -164,8 +164,8 @@ class Login extends BaseModule
 				'$login'    => DI::l10n()->t('Sign in'),
 				'$new'      => DI::l10n()->t('New here?'),
 
-				'$lname'     => ['username', DI::l10n()->t('Nickname or email'), '', $username_desc],
-				'$lpassword' => ['password', DI::l10n()->t('Password'), '', ''],
+				'$lname'     => ['username', DI::l10n()->t('Nickname or email'), '', $username_desc, '', 'autofocus', '', DI::l10n()->t('Nickname or email')],
+				'$lpassword' => ['password', DI::l10n()->t('Password'), '', '', '', '', '', DI::l10n()->t('Password')],
 				'$lremember' => ['remember', DI::l10n()->t('Remember me'), 0,  ''],
 
 				'$openid'  => !$noid,

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-03 20:38+0200\n"
+"POT-Creation-Date: 2025-10-05 14:42+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,15 +82,15 @@ msgstr ""
 msgid "Permission denied."
 msgstr ""
 
-#: mod/lostpass.php:27
+#: mod/lostpass.php:28
 msgid "No valid account found."
 msgstr ""
 
-#: mod/lostpass.php:39
+#: mod/lostpass.php:40
 msgid "Password reset request issued. Check your email."
 msgstr ""
 
-#: mod/lostpass.php:45
+#: mod/lostpass.php:46
 #, php-format
 msgid ""
 "\n"
@@ -106,7 +106,7 @@ msgid ""
 "\t\tissued this request."
 msgstr ""
 
-#: mod/lostpass.php:56
+#: mod/lostpass.php:57
 #, php-format
 msgid ""
 "\n"
@@ -123,64 +123,64 @@ msgid ""
 "\t\tLogin Name:\t%3$s"
 msgstr ""
 
-#: mod/lostpass.php:71
+#: mod/lostpass.php:72
 #, php-format
 msgid "Password reset requested at %s"
 msgstr ""
 
-#: mod/lostpass.php:87
+#: mod/lostpass.php:88
 msgid "Request could not be verified. (You may have previously submitted it.) Password reset failed."
 msgstr ""
 
-#: mod/lostpass.php:100
+#: mod/lostpass.php:101
 msgid "Request has expired, please make a new one."
 msgstr ""
 
-#: mod/lostpass.php:115
+#: mod/lostpass.php:116
 msgid "Forgot your Password?"
 msgstr ""
 
-#: mod/lostpass.php:116
+#: mod/lostpass.php:117
 msgid "Enter your email address and submit to have your password reset. Then check your email for further instructions."
 msgstr ""
 
-#: mod/lostpass.php:117 src/Module/Security/Login.php:165
-msgid "Nickname or Email: "
+#: mod/lostpass.php:118 src/Module/Security/Login.php:167
+msgid "Nickname or email"
 msgstr ""
 
-#: mod/lostpass.php:118
-msgid "Reset"
+#: mod/lostpass.php:119
+msgid "Reset my password"
 msgstr ""
 
-#: mod/lostpass.php:133 src/Module/Security/Login.php:177
+#: mod/lostpass.php:134 src/Module/Security/Login.php:179
 msgid "Password Reset"
 msgstr ""
 
-#: mod/lostpass.php:134
+#: mod/lostpass.php:135
 msgid "Your password has been reset as requested."
 msgstr ""
 
-#: mod/lostpass.php:135
+#: mod/lostpass.php:136
 msgid "Your new password is"
 msgstr ""
 
-#: mod/lostpass.php:136
+#: mod/lostpass.php:137
 msgid "Save or copy your new password - and then"
 msgstr ""
 
-#: mod/lostpass.php:137
+#: mod/lostpass.php:138
 msgid "click here to login"
 msgstr ""
 
-#: mod/lostpass.php:138
+#: mod/lostpass.php:139
 msgid "Your password may be changed from the <em>Settings</em> page after successful login."
 msgstr ""
 
-#: mod/lostpass.php:142
+#: mod/lostpass.php:143
 msgid "Your password has been reset."
 msgstr ""
 
-#: mod/lostpass.php:145
+#: mod/lostpass.php:146
 #, php-format
 msgid ""
 "\n"
@@ -191,7 +191,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: mod/lostpass.php:151
+#: mod/lostpass.php:152
 #, php-format
 msgid ""
 "\n"
@@ -205,7 +205,7 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: mod/lostpass.php:163
+#: mod/lostpass.php:164
 #, php-format
 msgid "Your password has been changed at %s"
 msgstr ""
@@ -1970,8 +1970,9 @@ msgstr ""
 msgid "Search: @name, !group, #tags, content"
 msgstr ""
 
-#: src/Content/Nav.php:220 src/Module/Security/Login.php:162
-msgid "Logout"
+#: src/Content/Nav.php:220 src/Module/Security/Login.php:163
+#: src/Module/Security/TwoFactor/SignOut.php:105
+msgid "Sign out"
 msgstr ""
 
 #: src/Content/Nav.php:220
@@ -1979,11 +1980,7 @@ msgid "End this session"
 msgstr ""
 
 #: src/Content/Nav.php:222 src/Module/Bookmarklet.php:30
-#: src/Module/Security/Login.php:163
-msgid "Login"
-msgstr ""
-
-#: src/Content/Nav.php:222
+#: src/Module/Security/Login.php:164
 msgid "Sign in"
 msgstr ""
 
@@ -2055,7 +2052,8 @@ msgstr ""
 msgid "Register"
 msgstr ""
 
-#: src/Content/Nav.php:253
+#: src/Content/Nav.php:253 src/Module/Register.php:157
+#: src/Module/Security/Login.php:127
 msgid "Create an account"
 msgstr ""
 
@@ -4372,7 +4370,7 @@ msgstr ""
 msgid "Republish users to directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:447 src/Module/Register.php:157
+#: src/Module/Admin/Site.php:447
 msgid "Registration"
 msgstr ""
 
@@ -8753,10 +8751,6 @@ msgstr ""
 msgid "Search term was not removed."
 msgstr ""
 
-#: src/Module/Security/Login.php:127
-msgid "Create a New Account"
-msgstr ""
-
 #: src/Module/Security/Login.php:146
 msgid "Your OpenID: "
 msgstr ""
@@ -8766,34 +8760,42 @@ msgid "Please enter your username and password to add the OpenID to your existin
 msgstr ""
 
 #: src/Module/Security/Login.php:151
-msgid "Or login using OpenID: "
+msgid "Or sign in using OpenID"
 msgstr ""
 
-#: src/Module/Security/Login.php:166
-msgid "Password: "
+#: src/Module/Security/Login.php:156
+msgid "OpenID"
 msgstr ""
 
-#: src/Module/Security/Login.php:167
+#: src/Module/Security/Login.php:165
+msgid "New here?"
+msgstr ""
+
+#: src/Module/Security/Login.php:168
+msgid "Password"
+msgstr ""
+
+#: src/Module/Security/Login.php:169
 msgid "Remember me"
 msgstr ""
 
-#: src/Module/Security/Login.php:176
+#: src/Module/Security/Login.php:178
 msgid "Forgot your password?"
 msgstr ""
 
-#: src/Module/Security/Login.php:179
+#: src/Module/Security/Login.php:181
 msgid "Website Terms of Service"
 msgstr ""
 
-#: src/Module/Security/Login.php:180
+#: src/Module/Security/Login.php:182
 msgid "terms of service"
 msgstr ""
 
-#: src/Module/Security/Login.php:182
+#: src/Module/Security/Login.php:184
 msgid "Website Privacy Policy"
 msgstr ""
 
-#: src/Module/Security/Login.php:183
+#: src/Module/Security/Login.php:185
 msgid "privacy policy"
 msgstr ""
 
@@ -8893,10 +8895,6 @@ msgstr ""
 
 #: src/Module/Security/TwoFactor/SignOut.php:104
 msgid "<p>If you trust this browser, you will not be asked for verification code the next time you sign in.</p>"
-msgstr ""
-
-#: src/Module/Security/TwoFactor/SignOut.php:105
-msgid "Sign out"
 msgstr ""
 
 #: src/Module/Security/TwoFactor/SignOut.php:107

--- a/view/templates/field_input.tpl
+++ b/view/templates/field_input.tpl
@@ -6,8 +6,10 @@
   *}}
 
 	<div class="field input" id="wrapper_{{$field.0}}">
-		<label for="id_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
-		<input type="{{$field.6|default:'text'}}" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2}}"{{if $field.4}} required{{/if}} {{$field.5 nofilter}} aria-describedby="{{$field.0}}_tip" dir="auto">
+		{{if $label != false}}
+			<label for="id_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
+		{{/if}}
+		<input type="{{$field.6|default:'text'}}" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2}}"{{if $field.4}} required{{/if}} {{$field.5 nofilter}} aria-describedby="{{$field.0}}_tip" dir="auto" {{if $field.7}}placeholder="{{$field.7}}"{{/if}}>
 	{{if $field.3}}
 		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>
 	{{/if}}

--- a/view/templates/field_openid.tpl
+++ b/view/templates/field_openid.tpl
@@ -4,10 +4,10 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-	<div class="field input openid" id="wrapper_{{$field.0}}">
-		<label for="id_{{$field.0}}">{{$field.1}}</label>
-		<input name="{{$field.0}}" id="id_{{$field.0}}" type="text" value="{{$field.2}}" {{if $field.4}}readonly{{/if}} aria-describedby="{{$field.0}}_tip">
-		{{if $field.3}}
-		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>
-		{{/if}}
-	</div>
+<div id="wrapper_{{$field.0}}" class="field input openid">
+	<p id="openid-header">{{$field.1}}</p>
+	<input id="id_{{$field.0}}" name="{{$field.0}}" type="text" placeholder="{{$field.5}}" value="{{$field.2}}" {{if $field.4}}readonly{{/if}} aria-describedby="{{$field.0}}_tip">
+	{{if $field.3}}
+	<span id="{{$field.0}}_tip" class="field_help" role="tooltip">{{$field.3 nofilter}}</span>
+	{{/if}}
+</div>

--- a/view/templates/field_password.tpl
+++ b/view/templates/field_password.tpl
@@ -5,8 +5,10 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 	<div class="field password" id="wrapper_{{$field.0}}">
-		<label for="id_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
-		<input type="password" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} {{if $field.6}}pattern="(($field.6}}"{{/if}} aria-describedby="{{$field.0}}_tip">
+		{{if $label != false}}
+			<label for="id_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
+		{{/if}}
+		<input type="password" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} {{if $field.6}}pattern="(($field.6}}"{{/if}} aria-describedby="{{$field.0}}_tip" {{if $field.7}}placeholder="{{$field.7}}"{{/if}}>
 		{{if $field.3}}
 		<span class="field_help" role="tooltip" id="{{$field.0}}_tip">{{$field.3 nofilter}}</span>
 		{{/if}}

--- a/view/templates/login.tpl
+++ b/view/templates/login.tpl
@@ -25,7 +25,7 @@
 		<a href="lostpass" title="{{$lostpass}}" id="lost-password-link">{{$lostlink}}</a>
 	</div>
 	</div>
-	
+
 	{{if $openid}}
 		<div id="login_openid">
 		{{include file="field_openid.tpl" field=$lopenid}}
@@ -37,11 +37,11 @@
 	</div>
 
 	{{include file="field_checkbox.tpl" field=$lremember}}
-	
+
 	{{foreach $hiddens as $k=>$v}}
 		<input type="hidden" name="{{$k}}" value="{{$v}}" />
 	{{/foreach}}
-	
+
 </div>
 </form>
 

--- a/view/templates/lostpass.tpl
+++ b/view/templates/lostpass.tpl
@@ -13,12 +13,11 @@
 
 <form action="lostpass" method="post">
 <div id="login-name-wrapper">
-        <label for="login-name" id="label-login-name">{{$name}}</label>
-        <input type="text" maxlength="60" name="login-name" id="login-name" value="" />
+   <input type="text" name="login-name" id="login-name" placeholder="{{$name}}" value="" class="form-control" autofocus />
 </div>
 <div id="login-extra-end"></div>
 <div id="login-submit-wrapper">
-        <input type="submit" name="submit" id="lostpass-submit-button" value="{{$submit}}" />
+   <input type="submit" name="submit" id="lostpass-submit-button" class="btn btn-primary" value="{{$submit}}" />
 </div>
 <div id="login-submit-end"></div>
 </form>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2592,6 +2592,11 @@ section > .generic-page-wrapper,
 	overflow: hidden;
 }
 /* Home and Login Page */
+#login-head h1 {
+	margin-top: 0;
+	margin-bottom: 30px;
+}
+
 body.mod-home nav.navbar .nav > li > a:hover {
 	background-color: rgba(255, 255, 255, 0.2);
 }
@@ -2621,6 +2626,11 @@ body.mod-login .navbar #nav-login {
 #openid-header {
 	font-size: 16px;
 	margin: 15px 0;
+}
+
+#new-here {
+	font-size: 20px;
+	margin-top: -5px;
 }
 
 /* contacts page */
@@ -3699,13 +3709,10 @@ section .profile-match-wrapper {
 	text-align: right;
 }
 #div_id_remember {
-	float: left;
+	margin: 20px 0;
 }
 #id_password_wrapper {
 	margin-bottom: unset;
-}
-#login_openid {
-	clear: both;
 }
 .login-form hr, #modal-body hr {
 	margin: 25px 0;
@@ -3716,11 +3723,8 @@ section .profile-match-wrapper {
 #register-link {
 	color: white;
 	background: #5aa071;
-	margin-bottom: 15px;
+	margin-bottom: 10px;
 	width: 75%;
-}
-#login-end {
-	clear: both;
 }
 
 .mod-home.is-not-singleuser,
@@ -3927,7 +3931,7 @@ section .profile-match-wrapper {
 	.mod-home.is-not-singleuser .login-form,
 	.mod-login #content .login-form {
 		background-color: #fff;
-		padding: 1em;
+		padding: 1.5em;
 		position: relative;
 	}
 	.mod-home.is-not-singleuser .login-form > #login-extra-links {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -536,6 +536,7 @@ header #banner #logo-img,
 .topbar ul.nav > li {
 	float: left;
 }
+
 @media (min-width: 992px) {
 	.topbar ul.nav > li > a,
 	.topbar ul.nav > li > button {
@@ -2604,6 +2605,16 @@ body.mod-home .navbar #nav-login,
 body.mod-login .navbar #nav-login {
 	display: none;
 }
+
+.mod-lostpass #content {
+	margin-top: 0!important;
+	width: 650px;
+}
+
+.mod-lostpass #login-name-wrapper{
+	margin: 20px 0;
+}
+
 /* Profile-page */
 #profile-content-standard,
 #profile-content-advanced {
@@ -3700,8 +3711,22 @@ section .profile-match-wrapper {
 }
 
 /**
- * Login page
+ * Home / Login page
  */
+
+#openid-header, #new-here {
+	padding-top: 15px;
+}
+.mod-home .row {
+	margin: 0;
+}
+.mod-home #content {
+	padding: 0;
+}
+div.login-form, .login-content-wrapper {
+	margin: 20px 0;
+	padding: 10px 15px;
+}
 #lost-password-link {
 	flex-grow: 2;
 }
@@ -3721,15 +3746,19 @@ section .profile-match-wrapper {
 	text-align: center;
 }
 #register-link {
-	color: white;
 	background: #5aa071;
 	margin-bottom: 10px;
 	width: 75%;
 }
 
+div.login-form, .login-content-wrapper,
 .mod-home.is-not-singleuser,
 .mod-login {
 	background-color: $login_bg_color;
+}
+
+.mod-home.is-not-singleuser,
+.mod-login {
 	background-image: linear-gradient(to right, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.4)), url($login_bg_image);
 	background-size: cover;
 	background-attachment: fixed;
@@ -3749,13 +3778,13 @@ section .profile-match-wrapper {
 }
 .mod-home.is-not-singleuser .login-content,
 .mod-login .login-content {
-	color: #eee;
 	margin-top: 2.5%;
 }
 
-.mod-home.is-not-singleuser .login-form > #login-form label,
-.mod-login #content #login-form label {
-	color: #eee;
+.mod-home.is-not-singleuser .login-content,
+.mod-login .login-content,
+#register-link {
+	color: white;
 }
 
 .mod-home.is-not-singleuser .login-panel-content,

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2612,6 +2612,17 @@ body.mod-login .navbar #nav-login {
 	float: left;
 }
 
+#login-submit-button, #register-submit-button, #register-link {
+	font-size: 19px;
+	font-weight: normal;
+	width: 100%;
+}
+
+#openid-header {
+	font-size: 16px;
+	margin: 15px 0;
+}
+
 /* contacts page */
 ul.viewcontact_wrapper {
 	margin-left: -15px;
@@ -3681,15 +3692,11 @@ section .profile-match-wrapper {
 /**
  * Login page
  */
-#login-submit-wrapper {
-	float: right;
-}
 #lost-password-link {
 	flex-grow: 2;
 }
 #login-lost-password-link {
-	margin-bottom: 10px;
-	float: right;
+	text-align: right;
 }
 #div_id_remember {
 	float: left;
@@ -3700,10 +3707,17 @@ section .profile-match-wrapper {
 #login_openid {
 	clear: both;
 }
+.login-form hr, #modal-body hr {
+	margin: 25px 0;
+}
+#login-extra-links {
+	text-align: center;
+}
 #register-link {
 	color: white;
-	background: #8ad0a1;
-	width: 100%;
+	background: #5aa071;
+	margin-bottom: 15px;
+	width: 75%;
 }
 #login-end {
 	clear: both;
@@ -3733,10 +3747,6 @@ section .profile-match-wrapper {
 .mod-login .login-content {
 	color: #eee;
 	margin-top: 2.5%;
-}
-
-.mod-home.is-not-singleuser .login-form > #login-extra-links {
-	margin-top: 4em;
 }
 
 .mod-home.is-not-singleuser .login-form > #login-form label,
@@ -3914,16 +3924,15 @@ section .profile-match-wrapper {
 		margin-top: 100px !important;
 	}
 
-	.mod-home.is-not-singleuser .login-form > #login-form,
-	.mod-home.is-not-singleuser .login-form > #login-extra-links,
-	.mod-login #content #login-form {
+	.mod-home.is-not-singleuser .login-form,
+	.mod-login #content .login-form {
 		background-color: #fff;
 		padding: 1em;
 		position: relative;
 	}
 	.mod-home.is-not-singleuser .login-form > #login-extra-links {
-		margin-top: unset;
-		background-color: white;
+		padding-bottom: 0;
+		padding-top: 1em 0;
 	}
 
 	.mod-home.is-not-singleuser .login-form > #login-form label,

--- a/view/theme/frio/scheme/light.php
+++ b/view/theme/frio/scheme/light.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright (C) 2010-2024, the Friendica project
  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
@@ -16,11 +17,11 @@ require_once 'view/theme/frio/php/PHPColors/Color.php';
 
 $accentColor = new Color($scheme_accent);
 
-$nav_bg = '#' . $accentColor->darken(10);
+$nav_bg                      = '#' . $accentColor->darken(10);
 $menu_background_hover_color = '#' . $accentColor->darken(5);
-$nav_icon_color = "#fff";
-$link_color = '#' . $accentColor->getHex();
-$background_color = "#ededed";
-$login_bg_color = "#ededed";
-$contentbg_transp = 100;
-$background_image = '';
+$nav_icon_color              = "#fff";
+$link_color                  = '#' . $accentColor->getHex();
+$background_color            = "#ededed";
+$login_bg_color              = "#fff";
+$contentbg_transp            = 100;
+$background_image            = '';

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (C) 2010-2024, the Friendica project
  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
@@ -15,7 +16,7 @@ require_once 'view/theme/frio/theme.php';
 require_once 'view/theme/frio/php/scheme.php';
 require_once 'view/theme/frio/php/PHPColors/Color.php';
 
-$schemecssfile = false;
+$schemecssfile   = false;
 $scheme_modified = 0;
 
 /*
@@ -74,7 +75,7 @@ if (DI::mode()->has(\Friendica\App\Mode::MAINTENANCEDISABLED)) {
 if (!$login_bg_image && !$login_bg_color) {
 	$login_bg_image = 'img/login_bg.jpg';
 }
-$login_bg_color = $login_bg_color ?: '#ededed';
+$login_bg_color = $login_bg_color ?: '#fff';
 
 $scheme = Strings::sanitizeFilePathItem($scheme);
 
@@ -94,14 +95,14 @@ $contentbg_transp = $contentbg_transp != '' ? $contentbg_transp : 100;
 // Some colors are calculated to don't have too many selection
 // fields in the theme settings.
 if (!isset($menu_background_hover_color)) {
-	$mbhc = new Color($nav_bg);
+	$mbhc   = new Color($nav_bg);
 	$mcolor = $mbhc->getHex();
 
 	if ($mbhc->isLight($mcolor, 75)) {
-		$menu_is = 'light';
+		$menu_is                     = 'light';
 		$menu_background_hover_color = '#' . $mbhc->darken(5);
 	} else {
-		$menu_is = 'dark';
+		$menu_is                     = 'dark';
 		$menu_background_hover_color = '#' . $mbhc->lighten(5);
 	}
 }
@@ -115,7 +116,7 @@ if (!isset($nav_icon_hover_color)) {
 	}
 }
 if (!isset($link_hover_color)) {
-	$lhc = new Color($link_color);
+	$lhc    = new Color($link_color);
 	$lcolor = $lhc->getHex();
 
 	if ($lhc->isLight($lcolor, 75)) {
@@ -133,24 +134,24 @@ if (!isset($bg_image_option)) {
 switch ($bg_image_option) {
 	case 'stretch':
 		$background_size_img = '100%';
-		$background_repeat = 'no-repeat';
+		$background_repeat   = 'no-repeat';
 		break;
 	case 'cover':
 		$background_size_img = 'cover';
-		$background_repeat = 'no-repeat';
+		$background_repeat   = 'no-repeat';
 		break;
 	case 'repeat':
 		$background_size_img = 'auto';
-		$background_repeat = 'repeat';
+		$background_repeat   = 'repeat';
 		break;
 	case 'contain':
 		$background_size_img = 'contain';
-		$background_repeat = 'repeat';
+		$background_repeat   = 'repeat';
 		break;
 
 	default:
 		$background_size_img = 'auto';
-		$background_repeat = 'no-repeat';
+		$background_repeat   = 'no-repeat';
 		break;
 }
 
@@ -173,9 +174,9 @@ $options = [
 	'$background_repeat'           => $background_repeat,
 	'$login_bg_image'              => $login_bg_image,
 	'$login_bg_color'              => $login_bg_color,
-	'$font_color_darker'           => $font_color_darker ?? '#222',
+	'$font_color_darker'           => $font_color_darker  ?? '#222',
 	'$font_color_lighter'          => $font_color_lighter ?? '#aaa',
-	'$font_color'                  => $font_color ?? '#444',
+	'$font_color'                  => $font_color         ?? '#444',
 ];
 
 $css_tpl = file_get_contents('view/theme/frio/css/style.css');
@@ -208,8 +209,11 @@ header('Last-Modified: ' . $modified);
 /// @todo Check if this works at all (possibly clients are sending only the one or the other header) - compare with mod/photo.php
 if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
 	$cached_modified = gmdate('r', strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']));
-	$cached_etag = str_replace(['"', '-gzip'], ['', ''],
-				stripslashes($_SERVER['HTTP_IF_NONE_MATCH']));
+	$cached_etag     = str_replace(
+		['"', '-gzip'],
+		['', ''],
+		stripslashes($_SERVER['HTTP_IF_NONE_MATCH'])
+	);
 
 	if (($cached_modified == $modified) && ($cached_etag == $etag)) {
 		throw new NotModifiedException();

--- a/view/theme/frio/templates/field_input.tpl
+++ b/view/theme/frio/templates/field_input.tpl
@@ -9,7 +9,7 @@
 	{{if !isset($label) || $label != false }}
 		<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1 nofilter}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
 	{{/if}}
-		<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="{{$field.6|default:'text'}}" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} aria-describedby="{{$field.0}}_tip">
+	<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="{{$field.6|default:'text'}}" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} aria-describedby="{{$field.0}}_tip" {{if $field.7}}placeholder="{{$field.7}}"{{/if}}>
 	{{if $field.3}}
 		<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.3 nofilter}}</span>
 	{{/if}}

--- a/view/theme/frio/templates/field_openid.tpl
+++ b/view/theme/frio/templates/field_openid.tpl
@@ -5,10 +5,9 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div id="id_{{$field.0}}_wrapper" class="form-group field input openid">
-	<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1}}</label>
-	<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="text" value="{{$field.2}}" {{if $field.4}}readonly{{/if}} aria-describedby="{{$field.0}}_tip">
+	<p id="openid-header">{{$field.1}}</p>
+	<input id="id_{{$field.0}}" class="form-control" name="{{$field.0}}" type="text" placeholder="{{$field.5}}" value="{{$field.2}}" {{if $field.4}}readonly{{/if}} aria-describedby="{{$field.0}}_tip">
 	{{if $field.3}}
-	<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.3 nofilter}}</span>
+	<span id="{{$field.0}}_tip" class="help-block" role="tooltip">{{$field.3 nofilter}}</span>
 	{{/if}}
-	<div class="clear"></div>
 </div>

--- a/view/theme/frio/templates/field_password.tpl
+++ b/view/theme/frio/templates/field_password.tpl
@@ -5,8 +5,10 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div id="id_{{$field.0}}_wrapper" class="form-group field input password">
-	<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
-	<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="password" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} {{if $field.6}}pattern="{{$field.6}}"{{/if}} aria-describedby="{{$field.0}}_tip">
+	{{if $label != false }}
+		<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
+	{{/if}}
+	<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="password" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} {{if $field.6}}pattern="{{$field.6}}"{{/if}} aria-describedby="{{$field.0}}_tip" {{if $field.7}}placeholder="{{$field.7}}"{{/if}}>
 	{{if $field.3}}
 	<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.3 nofilter}}</span>
 	{{/if}}

--- a/view/theme/frio/templates/login.tpl
+++ b/view/theme/frio/templates/login.tpl
@@ -16,7 +16,7 @@
 	<div id="login-group" role="group" aria-labelledby="login-head">
 		<input type="hidden" name="auth-params" value="login" />
 
-		<div id="login-head" class="sr-only">{{$login}}</div>
+		<div id="login-head"><h1>{{$login}}</h1></div>
 
 		<div id="login_standard">
 			<div id="id_{{$lname.0}}_wrapper" class="form-group field input">
@@ -33,7 +33,7 @@
 			</div>
 			<div id="login-end"></div>
 			<div id="login-lost-password-link">
-				<a href="lostpass" title="{{$lostpass}}" id="lost-password-link">{{$lostlink}}</a>
+				<a href="lostpass" id="lost-password-link">{{$lostlink}}</a>
 			</div>
 		</div>
 
@@ -58,7 +58,8 @@
 {{if $register}}
 <hr>
 <div id="login-extra-links">
+	<p id="new-here">{{$new}}</p>
 	<h3 id="login-head" class="sr-only">{{$register.title}}</h3>
-	<a href="{{$register.url}}" title="{{$register.title}}" id="register-link" class="btn btn-default">{{$register.desc}}</a>
+	<a href="{{$register.url}}" id="register-link" class="btn btn-default">{{$register.title}}</a>
 </div>
 {{/if}}

--- a/view/theme/frio/templates/login.tpl
+++ b/view/theme/frio/templates/login.tpl
@@ -17,24 +17,11 @@
 		<input type="hidden" name="auth-params" value="login" />
 
 		<div id="login-head"><h1>{{$login}}</h1></div>
-
-		<div id="login_standard">
-			<div id="id_{{$lname.0}}_wrapper" class="form-group field input">
-				<input id="id_{{$lname.0}}" class="form-control" name="{{$lname.0}}" placeholder="{{$lname.1}}" autofocus></input>
-				{{if $lname.3}}
-					<span class="help-block" id="{{$lname.0}}_tip" role="tooltip">{{$lname.3 nofilter}}</span>
-				{{/if}}
-			</div>
-			<div id="id_{{$lpassword.0}}_wrapper" class="form-group field input">
-				<input id="id_{{$lpassword.0}}" class="form-control" name="{{$lpassword.0}}" placeholder="{{$lpassword.1}}" autofocus type="password"></input>
-				{{if $lpassword.3}}
-					<span class="help-block" id="{{$lpassword.0}}_tip" role="tooltip">{{$lpassword.3 nofilter}}</span>
-				{{/if}}
-			</div>
-			<div id="login-end"></div>
-			<div id="login-lost-password-link">
-				<a href="lostpass" id="lost-password-link">{{$lostlink}}</a>
-			</div>
+		{{include file="field_input.tpl" field=$lname label=false}}
+		{{include file="field_password.tpl" field=$lpassword label=false}}
+		<div id="login-end"></div>
+		<div id="login-lost-password-link">
+			<a href="lostpass" id="lost-password-link">{{$lostlink}}</a>
 		</div>
 
 		{{if $openid}}

--- a/view/theme/frio/templates/login.tpl
+++ b/view/theme/frio/templates/login.tpl
@@ -19,12 +19,22 @@
 		<div id="login-head" class="sr-only">{{$login}}</div>
 
 		<div id="login_standard">
-			{{include file="field_input.tpl" field=$lname}}
-			{{include file="field_password.tpl" field=$lpassword}}
+			<div id="id_{{$lname.0}}_wrapper" class="form-group field input">
+				<input id="id_{{$lname.0}}" class="form-control" name="{{$lname.0}}" placeholder="{{$lname.1}}" autofocus></input>
+				{{if $lname.3}}
+					<span class="help-block" id="{{$lname.0}}_tip" role="tooltip">{{$lname.3 nofilter}}</span>
+				{{/if}}
+			</div>
+			<div id="id_{{$lpassword.0}}_wrapper" class="form-group field input">
+				<input id="id_{{$lpassword.0}}" class="form-control" name="{{$lpassword.0}}" placeholder="{{$lpassword.1}}" autofocus type="password"></input>
+				{{if $lpassword.3}}
+					<span class="help-block" id="{{$lpassword.0}}_tip" role="tooltip">{{$lpassword.3 nofilter}}</span>
+				{{/if}}
+			</div>
+			<div id="login-end"></div>
 			<div id="login-lost-password-link">
 				<a href="lostpass" title="{{$lostpass}}" id="lost-password-link">{{$lostlink}}</a>
 			</div>
-			<div id="login-end"></div>
 		</div>
 
 		{{if $openid}}
@@ -35,12 +45,7 @@
 
 		{{include file="field_checkbox.tpl" field=$lremember}}
 
-		<div id="login-submit-wrapper">
-			<div class="pull-right">
-				<button type="submit" name="submit" id="login-submit-button" class="btn btn-primary" value="{{$login}}">{{$login}}</button>
-			</div>
-		</div>
-
+		<button type="submit" name="submit" id="login-submit-button" class="btn btn-primary" value="{{$login}}">{{$login}}</button>
 
 		{{foreach $hiddens as $k=>$v}}
 			<input type="hidden" name="{{$k}}" value="{{$v}}" />
@@ -51,10 +56,9 @@
 </form>
 
 {{if $register}}
+<hr>
 <div id="login-extra-links">
 	<h3 id="login-head" class="sr-only">{{$register.title}}</h3>
 	<a href="{{$register.url}}" title="{{$register.title}}" id="register-link" class="btn btn-default">{{$register.desc}}</a>
 </div>
 {{/if}}
-
-<script type="text/javascript"> $(document).ready(function() { $("#id_{{$lname.0}}").focus();} );</script>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -488,9 +488,9 @@
 			<div class="pull-right">
 				<ul class="nav navbar-nav navbar-right">
 					<li>
-						<a href="login?mode=none" id="nav-login" data-toggle="tooltip" aria-label="{{$nav.login.3}}"
-							title="{{$nav.login.3}}">
+						<a href="login?mode=none" id="nav-login">
 							<i class="fa fa-sign-in fa-fw" aria-hidden="true"></i>
+							{{$nav.login.3}}
 						</a>
 					</li>
 					<li>

--- a/view/theme/frio/templates/register.tpl
+++ b/view/theme/frio/templates/register.tpl
@@ -44,7 +44,7 @@
 
 		<div id="register-name-wrapper" class="form-group">
 			<label for="register-name" id="label-register-name">{{$namelabel}}</label>
-			<input type="text" maxlength="60" size="32" name="username" id="register-name" class="form-control" value="{{$username}}" required>
+			<input type="text" maxlength="60" size="32" name="username" id="register-name" class="form-control" value="{{$username}}" required autofocus>
 		</div>
 		<div id="register-name-end"></div>
 


### PR DESCRIPTION
Opening this up as a draft to begin with, both for feedback, and because I need to test it a bit further.

I'm also not sure if this should target `develop` or `rc`...?
At least I think someone else should help verify nothing is broken if it should target `rc`.

Another question, also relevant to the target branch, is how likely this is to break the login/home screen theme changes that some instances do.

# Significant code changes

- `field_input` and `field_password` are expanded with the possibility to set a placeholder text - for both Frio and the default templates.
- Frio's `field_input` already has a way to disable the label by setting label to false. That functionality is copied to `field_password` for Frio, as well as the general `field_input` and `field_password` templates.

# UX / Visual changes

Visually it doesn't make *that* many changes, but I did have to change the code quite a lot comparatively, so that's why there's some potential for breakage. Fx. the username and password field are no longer generated by the `field` templates but instead input elements are added directly to the template to get more control over them, while not affecting everything else on Friendica.

The main changes are:
- Login/Logout -> Sign in/Sign out
- Autofocus is added in a few places where it was missing, so it preselects the first input element on the login and registration forms, and preselects the nickname/email field in the forgotten password form.
- A larger login action button, more similar to the register action
- Separate the register action a bit from the rest of the form
- Placeholder texts rather than labels
- The OpenID label is now more of a header of sorts. But not an HTML header, because it's in the main login form is both above and below it. It's just for visual separation.
- Increase contrast between the background and text on the register button

It's quite inspired by Facebook's login prompt, which it already seemed to be to begin with.

# Screenshots

## Navigation

Text is added to the sign in action. The hover text is removed.

### Before

<img width="156" height="56" alt="image" src="https://github.com/user-attachments/assets/e66eb966-7c92-420d-b1a5-0de4636c6cd9" />

### After

<img width="173" height="52" alt="image" src="https://github.com/user-attachments/assets/f7429bb7-e971-46b3-958b-05a61629f1ad" />

## Home

### Before

<img width="759" height="601" alt="image" src="https://github.com/user-attachments/assets/4047331e-e7a5-460d-8f84-8c403637c6f5" />

### After

<img width="661" height="732" alt="image" src="https://github.com/user-attachments/assets/c30d397d-2a64-43c4-8f4c-d8bc9df0a7d5" />

Smaller resolution:
<img width="319" height="619" alt="image" src="https://github.com/user-attachments/assets/61b257d2-d96b-4289-bf8c-b6639da23393" />

## /login

### Before

<img width="694" height="407" alt="image" src="https://github.com/user-attachments/assets/48ace081-ae1d-4d40-9f6a-d1aedd1ed5aa" />

### After

<img width="697" height="565" alt="image" src="https://github.com/user-attachments/assets/e314c613-4c42-47ea-9903-1bf6fa14ca34" />

I think, as mentioned in #15215, that at some point we should remove /login and make it redirect to Home.

## Modal

### Before

<img width="666" height="432" alt="image" src="https://github.com/user-attachments/assets/fd412ed1-d354-40ed-acb2-f4b13ef0a8db" />

### After

<img width="671" height="644" alt="image" src="https://github.com/user-attachments/assets/36394cd9-575f-4557-aebc-6704ad54eb94" />

## Forgotten password

Only adjusted it a little

### Before

<img width="1181" height="313" alt="image" src="https://github.com/user-attachments/assets/0ff95419-3b57-4b44-a0d6-a8fda5d5a39f" />

### After

<img width="655" height="340" alt="image" src="https://github.com/user-attachments/assets/649e52c9-789e-4f7c-9697-7055a85f5fe4" />

# Vier

## Home - Before

<img width="564" height="490" alt="image" src="https://github.com/user-attachments/assets/91a76e89-d71c-49c0-9fc4-2f7c63eb6dae" />

## Home - After

<img width="564" height="490" alt="image" src="https://github.com/user-attachments/assets/401866a4-08b9-4331-95d2-266d4980dc42" />