### PR TITLE
Remove logout sysmsg (notification)

### DIFF
--- a/src/Module/Security/Logout.php
+++ b/src/Module/Security/Logout.php
@@ -14,8 +14,6 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Core\System;
-use Friendica\DI;
-use Friendica\Model\Profile;
 use Friendica\Model\User\Cookie;
 use Friendica\Module\Response;
 use Friendica\Util\Profiler;
@@ -72,7 +70,6 @@ class Logout extends BaseModule
 		if ($visitor_home) {
 			System::externalRedirect($visitor_home);
 		} else {
-			DI::sysmsg()->addInfo($this->t('Logged out.'));
 			$this->baseUrl->redirect();
 		}
 	}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 23:47+0200\n"
+"POT-Creation-Date: 2025-09-11 21:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -8993,14 +8993,6 @@ msgstr ""
 msgid "privacy policy"
 msgstr ""
 
-#: src/Module/Security/Logout.php:75
-#: src/Module/Security/TwoFactor/SignOut.php:64
-#: src/Module/Security/TwoFactor/SignOut.php:72
-#: src/Module/Security/TwoFactor/SignOut.php:94
-#: src/Module/Security/TwoFactor/SignOut.php:101
-msgid "Logged out."
-msgstr ""
-
 #: src/Module/Security/OpenID.php:40
 msgid "OpenID protocol error. No ID returned"
 msgstr ""
@@ -9089,6 +9081,13 @@ msgstr ""
 
 #: src/Module/Security/TwoFactor/Recovery.php:91
 msgid "Submit recovery code and complete login"
+msgstr ""
+
+#: src/Module/Security/TwoFactor/SignOut.php:64
+#: src/Module/Security/TwoFactor/SignOut.php:72
+#: src/Module/Security/TwoFactor/SignOut.php:94
+#: src/Module/Security/TwoFactor/SignOut.php:101
+msgid "Logged out."
 msgstr ""
 
 #: src/Module/Security/TwoFactor/SignOut.php:108


### PR DESCRIPTION
Closes #8925

Looking at this it seems there's actually currently no notification showing up on `develop` or `rc`, versions unlike `stable`.

...but the logic to create it is still there, and it seems unchanged. I even checked another place where `addInfo` was called, and there it produced a notification, so maybe it's just buggy for logout currently for some reason?

This ensures it stays gone.

Note: The removed imports is php-cs-fixer's work.