### PR TITLE
Restyle profile view and edit actions - mostly Frio

### DIFF
--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -296,12 +296,10 @@ class Profile extends BaseProfile
 			'$homepage_verified'     => $this->l10n->t('This website has been verified to belong to the same person.'),
 			'$edit_link'             => [
 				'url'   => 'settings/profile', $this->t('Edit profile'),
-				'title' => '',
 				'label' => $this->t('Edit profile')
 			],
 			'$viewas_link' => [
 				'url'   => $this->args->getQueryString() . '#viewas',
-				'title' => '',
 				'label' => $this->t('View as')
 			],
 		]);

--- a/view/templates/profile/profile.tpl
+++ b/view/templates/profile/profile.tpl
@@ -16,18 +16,17 @@
 {{if $is_owner}}
 	<div id="profile-edit-links">
 		<ul class="nav nav-pills preferences">
-			<li class="pull-right">
-				<a class="btn btn-link btn-sm" type="button" id="profile-edit-link" href="{{$edit_link.url}}" title="{{$edit_link.title}}">
-					<i class="fa fa-pencil-square-o" aria-hidden="true"></i>&nbsp;{{$edit_link.label}}
-				</a>
-			</li>
-			<li class="pull-right">
-				<a class="btn btn-link btn-sm" type="button" id="profile-viewas-link" href="{{$viewas_link.url}}" title="{{$viewas_link.title}}">
+			<li>
+				<a class="btn btn-primary" type="button" id="profile-viewas-link" href="{{$viewas_link.url}}">
 					<i class="fa fa-eye" aria-hidden="true"></i>&nbsp;{{$viewas_link.label}}
 				</a>
 			</li>
+			<li>
+				<a class="btn btn-primary" type="button" id="profile-edit-link" href="{{$edit_link.url}}">
+					<i class="fa fa-pencil" aria-hidden="true"></i>&nbsp;{{$edit_link.label}}
+				</a>
+			</li>
 		</ul>
-		<div class="clear"></div>
 	</div>
 {{/if}}
 	<dl id="{{$basic_fields.fullname.id}}" class="row {{$basic_fields.fullname.class|default:'aprofile'}}">

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1818,6 +1818,17 @@ aside .panel-body {
 	right: 0;
 	top: 0;
 }
+#profile-edit-links .preferences {
+	top: 15px;
+	right: 15px;
+}
+#profile-edit-links .preferences li:not(:first-child) {
+	padding-left: 3px;
+}
+#profile-edit-links .preferences a {
+	/* Standard btn padding */
+	padding: 8px 16px
+}
 .shared_header {
 	margin-left: 0px;
 	margin-top: 0px;

--- a/view/theme/frio/templates/settings/profile/index.tpl
+++ b/view/theme/frio/templates/settings/profile/index.tpl
@@ -10,8 +10,8 @@
 	{{* The actions dropdown which can performed to the current profile *}}
 	<div id="profile-edit-links">
 		<ul class="nav nav-pills preferences">
-			<li class="pull-right">
-				<a class="btn btn-link btn-sm" href="profile/{{$nickname}}/profile"><i class="fa fa-eye" aria-hidden="true"></i>&nbsp;{{$l10n.viewprof}}</a>
+			<li>
+				<a class="btn btn-primary" href="profile/{{$nickname}}/profile"><i class="fa fa-eye" aria-hidden="true"></i>&nbsp;{{$l10n.viewprof}}</a>
 			</li>
 		</ul>
 	</div>

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -2394,6 +2394,11 @@ aside #id_password {
 	margin-bottom: 15px;
 }
 
+#aprofile-fullname {
+	clear: both;
+	padding-top: 15px;
+}
+
 #profile-edit-links ul {margin: 0; padding:0 0 20px 0; list-style: none; }
 
 #profile-edit-links li {


### PR DESCRIPTION
Restyles the actions when viewing or editing a profile to be similar to the restyling of those in Photos. Also switched out the edit icon for a simpler and thus more readable one, which is already used for editing in various places (and now also for writing a post).

Also removed: 
- Two empty title attributes.
- Some float handling that seemed to no longer be necessary

Frio before:
<img width="667" height="338" alt="image" src="https://github.com/user-attachments/assets/404a5cfd-e0d6-4008-861c-d923f5e10ecd" />

<img width="667" height="338" alt="image" src="https://github.com/user-attachments/assets/bca86d64-2b16-46f1-bc26-5e40563dc02a" />

Frio after:
<img width="667" height="338" alt="image" src="https://github.com/user-attachments/assets/6f0cbc74-eb2b-4a7c-97f8-0c7d4fb347a5" />

<img width="667" height="338" alt="image" src="https://github.com/user-attachments/assets/a3b4fb91-2f4c-4b6b-b126-7312275e5495" />

The template is also used by Vier, so I just made a few changes to not break Vier's layout:

Vier Before:
<img width="800" height="328" alt="image" src="https://github.com/user-attachments/assets/f528905b-d956-4e20-b3ee-b09334ae8cc0" />

Vier after:
<img width="800" height="328" alt="image" src="https://github.com/user-attachments/assets/bd5aa0c1-d3a5-4e1f-bfe9-ab03b0f9e6b1" />