### PR TITLE
Cleaned behaviour of video related BBCode elements

### DIFF
--- a/src/Content/Text/BBCode/Video.php
+++ b/src/Content/Text/BBCode/Video.php
@@ -7,6 +7,8 @@
 
 namespace Friendica\Content\Text\BBCode;
 
+use Friendica\Util\Strings;
+
 /**
  * Video specific BBCode util class
  */
@@ -22,13 +24,15 @@ class Video
 	public function transform(string $bbCodeString)
 	{
 		$matches = null;
-		$found = preg_match_all("/\[video\](.*?)\[\/video\]/ism",$bbCodeString,$matches,PREG_SET_ORDER);
+		$found   = preg_match_all("/\[video\](.*?)\[\/video\]/ism", $bbCodeString, $matches, PREG_SET_ORDER);
 		if ($found) {
 			foreach ($matches as $match) {
-				if ((stristr($match[1], 'youtube')) || (stristr($match[1], 'youtu.be'))) {
-					$bbCodeString = str_replace($match[0], '[youtube]' . $match[1] . '[/youtube]', $bbCodeString);
-				} elseif (stristr($match[1], 'vimeo')) {
-					$bbCodeString = str_replace($match[0], '[vimeo]' . $match[1] . '[/vimeo]', $bbCodeString);
+				$hostname = parse_url($match[1], PHP_URL_HOST);
+				if (!$hostname) {
+					continue;
+				}
+				if (in_array(Strings::normaliseLink($hostname), ['youtube.com', 'youtu.be', 'vimeo.com', 'dailymotion.com', 'dai.ly'])) {
+					$bbCodeString = str_replace($match[0], '[embed]' . $match[1] . '[/embed]', $bbCodeString);
 				}
 			}
 		}

--- a/src/Content/Text/Markdown.php
+++ b/src/Content/Text/Markdown.php
@@ -120,16 +120,6 @@ class Markdown
 		// protect the recycle symbol from turning into a tag, but without unescaping angles and naked ampersands
 		$s = str_replace('&#x2672;', html_entity_decode('&#x2672;', ENT_QUOTES, 'UTF-8'), $s);
 
-		//$s = preg_replace("/([^\]\=]|^)(https?\:\/\/)(vimeo|youtu|www\.youtube|soundcloud)([a-zA-Z0-9\:\/\-\?\&\;\.\=\_\~\#\%\$\!\+\,]+)/ism", '$1[url=$2$3$4]$2$3$4[/url]',$s);
-		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/www\.youtube\.com\/watch\?v\=(.*?)\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www\.)?youtube\.com\/watch\?v\=(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www\.)?youtube\.com\/embed\/(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/(www\.)?youtube\.com\/shorts\/(.*?)\].*?\[\/url\]/ism', '[youtube]$2[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/m\.youtube\.com\/watch\?v\=(.*?)\].*?\[\/url\]/ism', '[youtube]$1[/youtube]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/vimeo\.com\/([0-9]+)(.*?)\[\/url\]/ism', '[vimeo]$2[/vimeo]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=?(.*?)\]https?:\/\/player\.vimeo\.com\/video\/([0-9]+)(.*?)\[\/url\]/ism', '[vimeo]$2[/vimeo]', 'url', $s);
-		$s = BBCode::pregReplaceInTag('/\[url\=https?:\/\/vimeo\.com\/([0-9]+)\](.*?)\[\/url\]/ism', '[vimeo]$1[/vimeo]', 'url', $s);
-
 		// remove duplicate adjacent code tags
 		$s = preg_replace('/(\[code\])+(.*?)(\[\/code\])+/ism', '[code]$2[/code]', $s);
 

--- a/tests/src/Content/Text/BBCode/VideoTest.php
+++ b/tests/src/Content/Text/BBCode/VideoTest.php
@@ -16,20 +16,36 @@ class VideoTest extends MockedTestCase
 	{
 		return [
 			'youtube' => [
-				'input' => '[video]https://youtube.link/4523[/video]',
-				'assert' => '[youtube]https://youtube.link/4523[/youtube]',
+				'input'  => '[video]https://youtube.com/4523[/video]',
+				'assert' => '[embed]https://youtube.com/4523[/embed]',
 			],
 			'youtu.be' => [
-				'input' => '[video]https://youtu.be.link/4523[/video]',
-				'assert' => '[youtube]https://youtu.be.link/4523[/youtube]',
+				'input'  => '[video]https://youtu.be/4523[/video]',
+				'assert' => '[embed]https://youtu.be/4523[/embed]',
 			],
 			'vimeo' => [
-				'input' => '[video]https://vimeo.link/2343[/video]',
-				'assert' => '[vimeo]https://vimeo.link/2343[/vimeo]',
+				'input'  => '[video]https://vimeo.com/2343[/video]',
+				'assert' => '[embed]https://vimeo.com/2343[/embed]',
+			],
+			'dailymotion.com' => [
+				'input'  => '[video]https://dailymotion.com/2343[/video]',
+				'assert' => '[embed]https://dailymotion.com/2343[/embed]',
+			],
+			'dai.ly' => [
+				'input'  => '[video]https://dai.ly/2343[/video]',
+				'assert' => '[embed]https://dai.ly/2343[/embed]',
 			],
 			'mixed' => [
-				'input' => '[video]https://vimeo.link/2343[/video] With other [b]string[/b] [video]https://youtu.be/blaa[/video]',
-				'assert' => '[vimeo]https://vimeo.link/2343[/vimeo] With other [b]string[/b] [youtube]https://youtu.be/blaa[/youtube]',
+				'input'  => '[video]https://vimeo.com/2343[/video] With other [b]string[/b] [video]https://youtu.be/blaa[/video]',
+				'assert' => '[embed]https://vimeo.com/2343[/embed] With other [b]string[/b] [embed]https://youtu.be/blaa[/embed]',
+			],
+			'negative' => [
+				'input'  => '[video]https://some.video.link/video.mp4[/video]',
+				'assert' => '[video]https://some.video.link/video.mp4[/video]',
+			],
+			'invalid' => [
+				'input'  => '[video]invalid.link/video.mp4[/video]',
+				'assert' => '[video]invalid.link/video.mp4[/video]',
 			]
 		];
 	}

--- a/tests/src/Content/Text/MarkdownTest.php
+++ b/tests/src/Content/Text/MarkdownTest.php
@@ -53,48 +53,6 @@ class MarkdownTest extends FixtureTestCase
 				'expectedBBCode' => 'with the <sup> and </sup> tag',
 				'markdown'       => 'with the &lt;sup&gt; and &lt;/sup&gt; tag',
 			],
-			/** @see https://github.com/friendica/friendica/pull/14940 */
-			'task-14940-youtube-watch-with-www' => [
-				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'       => '[url=https://www.youtube.com/watch?v=hfwbmTzBFT0]https://www.youtube.com/watch?v=hfwbmTzBFT0[/url]',
-			],
-			'task-14940-youtube-watch-without-www' => [
-				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'       => '[url=https://youtube.com/watch?v=hfwbmTzBFT0]https://youtube.com/watch?v=hfwbmTzBFT0[/url]',
-			],
-			'task-14940-youtube-shorts-with-www' => [
-				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'       => '[url=https://www.youtube.com/shorts/hfwbmTzBFT0]https://www.youtube.com/shorts/hfwbmTzBFT0[/url]',
-			],
-			'task-14940-youtube-shorts-without-www' => [
-				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'       => '[url=https://youtube.com/shorts/hfwbmTzBFT0]https://youtube.com/shorts/hfwbmTzBFT0[/url]',
-			],
-			'task-14940-youtube-embed-with-www' => [
-				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'       => '[url=https://www.youtube.com/embed/hfwbmTzBFT0]https://www.youtube.com/embed/hfwbmTzBFT0[/url]',
-			],
-			'task-14940-youtube-embed-without-www' => [
-				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'       => '[url=https://youtube.com/embed/hfwbmTzBFT0]https://youtube.com/embed/hfwbmTzBFT0[/url]',
-			],
-			'task-14940-youtube-mobile' => [
-				'expectedBBCode' => '[youtube]hfwbmTzBFT0[/youtube]',
-				'markdown'       => '[url=https://m.youtube.com/watch?v=hfwbmTzBFT0]https://m.youtube.com/watch?v=hfwbmTzBFT0[/url]',
-			],
-			// @todo - should we really ignore the URL content in favor of parsing the link of the body?
-			'task-14940-vimeo-custom-url' => [
-				'expectedBBCode' => '[vimeo]2345345[/vimeo]',
-				'markdown'       => '[url=https://no.thing]https://vimeo.com/2345345[/url]',
-			],
-			'task-14940-vimeo-custom-text' => [
-				'expectedBBCode' => '[vimeo]2345345[/vimeo]',
-				'markdown'       => '[url=https://vimeo.com/2345345]CustomText[/url]',
-			],
-			'task-14940-player-vimeo' => [
-				'expectedBBCode' => '[vimeo]2345345[/vimeo]',
-				'markdown'       => '[url=https://player.vimeo.com/video/2345345]https://player.vimeo.com/video/2345345[/url]',
-			],
 		];
 	}
 


### PR DESCRIPTION
The check for falsely added video links when the target link wasn't a video is now improved by checking for the real hostnames. The markdown check for youtube and vimeo is removed since this doesn't look nice when someone links to some Youtube video in a sentence and that gets transformed into an embed that tears of the sentence.