### PR TITLE
Join the two ways of changing profile picture into one collapse, describe the difference

### DIFF
--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -270,15 +270,18 @@ class Index extends BaseSettings
 				'profile_action'            => $this->t('Profile Actions'),
 				'banner'                    => $this->t('Edit Profile Details'),
 				'submit'                    => $this->t('Save Settings'),
-				'profpic'                   => $this->t('Change Profile Photo'),
-				'yourphotos'                => $this->t('Your photos'),
+				'profpic_header'            => $this->t('Change profile picture'),
+				'profpic_intro'             => $this->t('To change your profile picture, you can either upload a new picture here, or click to visit your photos to pick among your existing pictures.'),
+				'profpic_upload_new_header' => $this->t('Upload new picture'),
+				'profpic_upload_submit'     => $this->t('Upload selected picture'),
+				'profpic_existing_header'   => $this->t('Pick existing picture from photos'),
+				'yourphotos'                => $this->t('Go to my photos'),
 				'viewprof'                  => $this->t('View Profile'),
 				'personal_section'          => $this->t('Personal'),
 				'picture_section'           => $this->t('Profile picture'),
 				'location_section'          => $this->t('Location'),
 				'miscellaneous_section'     => $this->t('Miscellaneous'),
 				'custom_fields_section'     => $this->t('Custom Profile Fields'),
-				'profile_photo'             => $this->t('Upload Profile Photo'),
 				'custom_fields_description' => $this->t(
 					'<p>Custom fields appear on <a href="%s">your profile page</a>.</p>
 				<p>You can use BBCodes in the field values.</p>

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-12 23:54+0200\n"
+"POT-Creation-Date: 2025-09-13 19:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -491,7 +491,7 @@ msgstr ""
 #: src/Module/Media/Attachment/Browser.php:64
 #: src/Module/Media/Photo/Browser.php:76 src/Module/Post/Edit.php:163
 #: src/Module/Post/Tag/Remove.php:96 src/Module/Profile/RemoteFollow.php:120
-#: src/Module/Security/TwoFactor/SignOut.php:107
+#: src/Module/Security/TwoFactor/SignOut.php:106
 msgid "Cancel"
 msgstr ""
 
@@ -1636,7 +1636,7 @@ msgid "Sort by post creation date"
 msgstr ""
 
 #: src/Content/Conversation/Factory/Network.php:27
-#: src/Module/Settings/Profile/Index.php:276
+#: src/Module/Settings/Profile/Index.php:280
 msgid "Personal"
 msgstr ""
 
@@ -1872,7 +1872,7 @@ msgstr ""
 
 #: src/Content/Item.php:435 src/Content/Item.php:458 src/Model/Contact.php:1234
 #: src/Model/Contact.php:1290 src/Model/Contact.php:1300
-#: src/Module/Directory.php:143 src/Module/Settings/Profile/Index.php:275
+#: src/Module/Directory.php:143 src/Module/Settings/Profile/Index.php:279
 msgid "View Profile"
 msgstr ""
 
@@ -2022,8 +2022,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: src/Content/Nav.php:229 src/Module/Settings/Profile/Index.php:274
-#: view/theme/frio/theme.php:223
+#: src/Content/Nav.php:229 view/theme/frio/theme.php:223
 msgid "Your photos"
 msgstr ""
 
@@ -8660,7 +8659,7 @@ msgid "You're currently viewing your profile as <b>%s</b> <a href=\"%s\" class=\
 msgstr ""
 
 #: src/Module/Profile/Profile.php:181 src/Module/Settings/Account.php:522
-#: src/Module/Settings/Profile/Index.php:300
+#: src/Module/Settings/Profile/Index.php:303
 msgid "Display name:"
 msgstr ""
 
@@ -8680,12 +8679,12 @@ msgstr ""
 msgid "Birthday:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:204 src/Module/Settings/Profile/Index.php:308
+#: src/Module/Profile/Profile.php:204 src/Module/Settings/Profile/Index.php:311
 #: src/Util/Temporal.php:157
 msgid "Age: "
 msgstr ""
 
-#: src/Module/Profile/Profile.php:204 src/Module/Settings/Profile/Index.php:308
+#: src/Module/Profile/Profile.php:204 src/Module/Settings/Profile/Index.php:311
 #: src/Util/Temporal.php:157
 #, php-format
 msgid "%d year old"
@@ -8693,7 +8692,7 @@ msgid_plural "%d years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Profile/Profile.php:209 src/Module/Settings/Profile/Index.php:301
+#: src/Module/Profile/Profile.php:209 src/Module/Settings/Profile/Index.php:304
 msgid "Description:"
 msgstr ""
 
@@ -9083,19 +9082,19 @@ msgstr ""
 msgid "Submit recovery code and complete login"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/SignOut.php:104
+#: src/Module/Security/TwoFactor/SignOut.php:103
 msgid "Sign out of this browser?"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/SignOut.php:105
+#: src/Module/Security/TwoFactor/SignOut.php:104
 msgid "<p>If you trust this browser, you will not be asked for verification code the next time you sign in.</p>"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/SignOut.php:106
+#: src/Module/Security/TwoFactor/SignOut.php:105
 msgid "Sign out"
 msgstr ""
 
-#: src/Module/Security/TwoFactor/SignOut.php:108
+#: src/Module/Security/TwoFactor/SignOut.php:107
 msgid "Trust and sign out"
 msgstr ""
 
@@ -10268,31 +10267,47 @@ msgid "Edit Profile Details"
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:273
-msgid "Change Profile Photo"
+msgid "Change profile picture"
+msgstr ""
+
+#: src/Module/Settings/Profile/Index.php:274
+msgid "To change your profile picture, you can either upload a new picture here, or click to visit your photos to pick among your existing pictures."
+msgstr ""
+
+#: src/Module/Settings/Profile/Index.php:275
+msgid "Upload new picture"
+msgstr ""
+
+#: src/Module/Settings/Profile/Index.php:276
+msgid "Upload selected picture"
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:277
-msgid "Profile picture"
+msgid "Pick existing picture from photos"
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:278
+msgid "Go to my photos"
+msgstr ""
+
+#: src/Module/Settings/Profile/Index.php:281
+msgid "Profile picture"
+msgstr ""
+
+#: src/Module/Settings/Profile/Index.php:282
 msgid "Location"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:279 src/Util/Temporal.php:83
+#: src/Module/Settings/Profile/Index.php:283 src/Util/Temporal.php:83
 #: src/Util/Temporal.php:85
 msgid "Miscellaneous"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:280
+#: src/Module/Settings/Profile/Index.php:284
 msgid "Custom Profile Fields"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:281 src/Module/Welcome.php:45
-msgid "Upload Profile Photo"
-msgstr ""
-
-#: src/Module/Settings/Profile/Index.php:283
+#: src/Module/Settings/Profile/Index.php:286
 #, php-format
 msgid ""
 "<p>Custom fields appear on <a href=\"%s\">your profile page</a>.</p>\n"
@@ -10302,59 +10317,59 @@ msgid ""
 "\t\t\t\t<p>Non-public fields can only be seen by the selected Friendica contacts or the Friendica contacts in the selected circles.</p>"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:303
+#: src/Module/Settings/Profile/Index.php:306
 msgid "Street Address:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:304
+#: src/Module/Settings/Profile/Index.php:307
 msgid "Locality/City:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:305
+#: src/Module/Settings/Profile/Index.php:308
 msgid "Region/State:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:306
+#: src/Module/Settings/Profile/Index.php:309
 msgid "Postal/Zip Code:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:307
+#: src/Module/Settings/Profile/Index.php:310
 msgid "Country:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:309
+#: src/Module/Settings/Profile/Index.php:312
 msgid "XMPP (Jabber) address:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:309
+#: src/Module/Settings/Profile/Index.php:312
 msgid "The XMPP address will be published so that people can follow you there."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:310
+#: src/Module/Settings/Profile/Index.php:313
 msgid "Matrix (Element) address:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:310
+#: src/Module/Settings/Profile/Index.php:313
 msgid "The Matrix address will be published so that people can follow you there."
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:311
+#: src/Module/Settings/Profile/Index.php:314
 msgid "Homepage URL:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:312
+#: src/Module/Settings/Profile/Index.php:315
 msgid "Public Keywords:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:312
+#: src/Module/Settings/Profile/Index.php:315
 msgid "(Used for suggesting potential friends, can be seen by others)"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:313
+#: src/Module/Settings/Profile/Index.php:316
 msgid "Private Keywords:"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:313
+#: src/Module/Settings/Profile/Index.php:316
 msgid "(Used for searching profiles, never shown to others)"
 msgstr ""
 
@@ -10984,6 +10999,10 @@ msgstr ""
 
 #: src/Module/Welcome.php:42
 msgid "Review the other settings, particularly the privacy settings. An unpublished directory listing is like having an unlisted phone number. In general, you should probably publish your listing - unless all of your friends and potential friends know exactly how to find you."
+msgstr ""
+
+#: src/Module/Welcome.php:45
+msgid "Upload Profile Photo"
 msgstr ""
 
 #: src/Module/Welcome.php:46

--- a/view/templates/settings/profile/index.tpl
+++ b/view/templates/settings/profile/index.tpl
@@ -33,7 +33,7 @@
 			<div class="js-section toggle-section-content hidden">
 
 				<div id="profile-photo-upload-wrapper">
-					<label id="profile-photo-upload-label" for="profile-photo-upload">{{$l10n.profile_photo}}:</label>
+					<label id="profile-photo-upload-label" for="profile-photo-upload">{{$l10n.profpic_upload_new_header}}:</label>
 					<input name="userfile" type="file" id="profile-photo-upload" size="48"/>
 				</div>
 

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2864,7 +2864,37 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 }
 
 #photo-toprofile-link, .photo-back-link {
-  margin-right: 25px;
+	margin-right: 25px;
+}
+
+#photo-upload-collapse .row {
+	display: flex;
+}
+
+#photo-upload-collapse #profpic-intro-description {
+	margin-bottom: 20px;
+}
+
+#photo-upload-collapse #profpic-right {
+	border-left: 2px solid black;
+	display: flex;
+	flex-direction: column;
+}
+
+#photo-upload-collapse .spacer {
+	flex: 1;
+}
+
+#photo-upload-collapse h3 {
+	font-size: 17px;
+}
+
+#photo-upload-collapse h3:first-of-type {
+	margin-top: 0;
+}
+
+.profile-edit-submit-button {
+	margin-top: 15px;
 }
 
 /* Events page */
@@ -3927,6 +3957,7 @@ section .profile-match-wrapper {
 
 /* Mobile display */
 @media (max-width: 600px) {
+
 	body {
 		padding-top: 95px;
 	}
@@ -4074,5 +4105,13 @@ section .profile-match-wrapper {
 	.wall-item-container.thread_level_8,
 	.wall-item-container.thread_level_9 {
 		margin-left: 5px;
+	}
+	#photo-upload-collapse .row {
+		flex-direction: column;
+	}
+
+	#photo-upload-collapse #profpic-right {
+		margin-top: 10px;
+		border: none;
 	}
 }

--- a/view/theme/frio/templates/settings/profile/index.tpl
+++ b/view/theme/frio/templates/settings/profile/index.tpl
@@ -25,46 +25,40 @@
 		3 => The additional help text (if available)
 	*}}
 
-	<div class="panel-group panel-group-settings" id="profile-photo-edit-wrapper" role="tablist" aria-multiselectable="true">
-		{{* Upload profile photo *}}
+	<div class="panel-group panel-group-settings" id="profile-photo-edit-wrapper" role="tablist" aria-multiselectable="false">
+		{{* Change profile picture *}}
 		<div class="panel">
 			<div class="section-subtitle-wrapper panel-heading" role="tab" id="photo-upload">
 				<h2>
 					<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#profile-photo-edit-wrapper" href="#photo-upload-collapse" aria-expanded="true" aria-controls="photo-upload-collapse">
-						{{$l10n.profile_photo}}
+						{{$l10n.profpic_header}}
 					</button>
 				</h2>
 			</div>
 			<div id="photo-upload-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="photo-upload">
 				<div class="panel-body">
-					<form enctype="multipart/form-data" action="settings/profile/photo" method="post">
-						<input type="hidden" name="form_security_token" value="{{$form_security_token_photo}}">
-							<div id="profile-photo-upload-wrapper">
-								<label id="profile-photo-upload-label" for="profile-photo-upload">{{$l10n.profile_photo}}:</label>
-								<input name="userfile" type="file" id="profile-photo-upload" size="48" />
+					<p id="profpic-intro-description">{{$l10n.profpic_intro}}</p>
+					<div class="row">
+						<div id="profpic-left" class="col-md-6">
+							<h3>{{$l10n.profpic_upload_new_header}}</h3>
+							<form enctype="multipart/form-data" action="settings/profile/photo" method="post">
+								<input type="hidden" name="form_security_token" value="{{$form_security_token_photo}}">
+									<div id="profile-photo-upload-wrapper">
+										<input name="userfile" type="file" id="profile-photo-upload" size="48" />
+									</div>
+									<div class="profile-edit-submit-wrapper">
+										<button type="submit" name="submit" class="profile-edit-submit-button btn btn-primary">{{$l10n.profpic_upload_submit}}</button>
+									</div>
+								</form>
 							</div>
-
-							<div class="profile-edit-submit-wrapper pull-right">
-								<button type="submit" name="submit" class="profile-edit-submit-button btn btn-primary">{{$l10n.submit}}</button>
+							<div id="profpic-right" class="col-md-6">
+								<h3>{{$l10n.profpic_existing_header}}</h3>
+								<div class="spacer"></div>
+								<div>
+								<a class="btn btn-primary" href="{{$profpiclink}}">{{$l10n.yourphotos}}</a>
 							</div>
-							<div class="clear"></div>
-					</form>
-				</div>
-			</div>
-		</div>
-
-		{{* Change profile photo *}}
-		<div class="panel">
-			<div class="section-subtitle-wrapper panel-heading" role="tab" id="photo-change">
-				<h2>
-					<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#profile-photo-edit-wrapper" href="#photo-change-collapse" aria-expanded="true" aria-controls="photo-change-collapse">
-						{{$l10n.profpic}}
-					</button>
-				</h2>
-			</div>
-			<div id="photo-change-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="photo-change">
-				<div class="panel-body">
-					<a href="{{$profpiclink}}">{{$l10n.yourphotos}}</a>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -78,13 +72,13 @@
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="personal">
 					<h2>
-						<button class="btn-link accordion-toggle" data-toggle="collapse" data-parent="#profile-edit-wrapper" href="#personal-collapse" aria-expanded="true" aria-controls="personal-collapse">
+						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#profile-edit-wrapper" href="#personal-collapse" aria-expanded="false" aria-controls="personal-collapse">
 							{{$l10n.personal_section}}
 						</button>
 					</h2>
 				</div>
 				{{* for the $detailed_profile we use bootstraps collapsable panel-groups to have expandable groups *}}
-				<div id="personal-collapse" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="personal">
+				<div id="personal-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="personal">
 					<div class="panel-body">
 						{{include file="field_input.tpl" field=$username}}
 


### PR DESCRIPTION
Closes #15122

Really this just does a few additional adjustments on top of the previous improvement to move profile picture setting to where the rest of the profile is edited.

I updated the texts to hopefully indicate clearly that there are two ways of setting profile picture, and how they're different.

I've gone with the term "profile picture" as I think it's the most common term, and sometimes people set profile pictures, that aren't photos. I do say "photos" when referring to the section on one's profile, though, as that is currently its name.

Before:
<img width="632" height="418" alt="image" src="https://github.com/user-attachments/assets/ee98e521-6ff1-453b-bc00-b453e0f481ee" />

After:
<img width="632" height="418" alt="image" src="https://github.com/user-attachments/assets/215252ce-4d75-4299-bce4-dc3b169d9b71" />

I'm a bit unsure if it looks better if the button on the right comes immediately after the text so there isn't a big gap, or if it's better that the left and right buttons are aligned, as they are currently.