### PR TITLE
Profile picture term consistency, and centering

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -956,7 +956,7 @@ function photos_content()
 			} else {
 				$tools['edit']    = ['photos/' . $user['nickname'] . '/image/' . $datum . '/edit', DI::l10n()->t('Edit photo')];
 				$tools['delete']  = ['photos/' . $user['nickname'] . '/image/' . $datum . '/drop', DI::l10n()->t('Delete photo')];
-				$tools['profile'] = ['settings/profile/photo/crop/' . $ph[0]['resource-id'], DI::l10n()->t('Use as profile photo')];
+				$tools['profile'] = ['settings/profile/photo/crop/' . $ph[0]['resource-id'], DI::l10n()->t('Use as profile picture')];
 			}
 
 			if (

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -338,7 +338,7 @@ class Profile
 		}
 		if ($local_user_is_self && $view_as_contact_id == 0) {
 			$picture_dest_url            = DI::baseUrl() . '/profile/' . $profile['nickname'] . '/photos';
-			$change_profile_picture_text = DI::l10n()->t('Change profile photo');
+			$change_profile_picture_text = DI::l10n()->t('Change profile picture');
 		} else {
 			$picture_dest_url            = $profile['url'];
 			$change_profile_picture_text = "";

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-13 19:32+0200\n"
+"POT-Creation-Date: 2025-09-14 18:56+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -543,8 +543,8 @@ msgstr ""
 msgid "Delete photo"
 msgstr ""
 
-#: mod/photos.php:959
-msgid "Use as profile photo"
+#: mod/photos.php:959 mod/photos.php:1281
+msgid "Use as profile picture"
 msgstr ""
 
 #: mod/photos.php:966
@@ -647,10 +647,6 @@ msgstr ""
 
 #: mod/photos.php:1279 src/Object/Post.php:224 src/Object/Post.php:226
 msgid "Edit"
-msgstr ""
-
-#: mod/photos.php:1281
-msgid "Use as profile picture"
 msgstr ""
 
 #: mod/photos.php:1282
@@ -3499,8 +3495,8 @@ msgstr ""
 msgid "Wall Photos"
 msgstr ""
 
-#: src/Model/Profile.php:341
-msgid "Change profile photo"
+#: src/Model/Profile.php:341 src/Module/Settings/Profile/Index.php:273
+msgid "Change profile picture"
 msgstr ""
 
 #: src/Model/Profile.php:354 src/Module/Directory.php:138
@@ -10264,10 +10260,6 @@ msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:271
 msgid "Edit Profile Details"
-msgstr ""
-
-#: src/Module/Settings/Profile/Index.php:273
-msgid "Change profile picture"
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:274

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1193,7 +1193,7 @@ aside > .help-aside-wrapper h2 {
 
 /* vcard / h-card */
 aside .vcard #profile-photo-wrapper {
-	margin: 0;
+	text-align: center;
 }
 aside .vcard img.u-photo,
 aside img.vcard-photo {


### PR DESCRIPTION
Related to #15164, makes changes to use the term "profile picture" more consistently.

Additionally I found out that on rc in some cases tall pictures are not horizontally aligned properly. Maybe when they contain transparency? This fixes that.

Before:
<img width="262" height="463" alt="image" src="https://github.com/user-attachments/assets/eb152eaf-9b27-4363-9ca1-6eef6f00d358" />

After:
<img width="262" height="463" alt="image" src="https://github.com/user-attachments/assets/4d6c7e2f-7cd9-4467-b10c-e43b2c2ca6fe" />
