### PR TITLE
Improve embedding of Peertube videos

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2907,7 +2907,7 @@ class Item
 		$shared_item        = [];
 
 		$shared = DI::contentItem()->getSharedPost($item, $fields);
-		if (!empty($shared['post'])) {
+		if (!empty($shared['post']) && !self::containsEmbed($body, $shared['post']['uri']) && !self::containsEmbed($body, $shared['post']['plink'] ?? '')) {
 			$shared_item         = $shared['post'];
 			$shared_item['body'] = Post\Media::removeFromEndOfBody($shared_item['body']);
 			$shared_item['body'] = Post\Media::replaceImage($shared_item['body']);
@@ -3156,19 +3156,21 @@ class Item
 
 	private static function containsEmbed(string $body, string $url): bool
 	{
+		$contains = false;
+
 		if (preg_match_all("/\[audio\]([^\[\]]*)\[\/audio\]/Usi", $body, $embeds)) {
-			return in_array($url, $embeds[1]);
+			$contains = in_array($url, $embeds[1]);
 		}
 
-		if (preg_match_all("/\[video\]([^\[\]]*)\[\/video\]/Usi", $body, $embeds)) {
-			return in_array($url, $embeds[1]);
+		if (!$contains && preg_match_all("/\[video\]([^\[\]]*)\[\/video\]/Usi", $body, $embeds)) {
+			$contains = in_array($url, $embeds[1]);
 		}
 
-		if (preg_match_all("/\[embed\]([^\[\]]*)\[\/embed\]/Usi", $body, $embeds)) {
-			return in_array($url, $embeds[1]);
+		if (!$contains && preg_match_all("/\[embed\]([^\[\]]*)\[\/embed\]/Usi", $body, $embeds)) {
+			$contains = in_array($url, $embeds[1]);
 		}
 
-		return false;
+		return $contains;
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1828,7 +1828,7 @@ class Receiver
 	 * @param array $urls
 	 * @return string
 	 */
-	private static function extractAlternateUrl(array $urls): string
+	private static function extractAlternateUrl(array $urls, string $id): string
 	{
 		$alternateUrl = '';
 		foreach ($urls as $key => $url) {
@@ -1851,7 +1851,7 @@ class Receiver
 				continue;
 			}
 
-			if ($mediatype == 'text/html') {
+			if ($mediatype == 'text/html' && $href != $id) {
 				$alternateUrl = $href;
 			}
 		}
@@ -2119,7 +2119,7 @@ class Receiver
 		}
 
 		if (in_array($object_data['object_type'], ['as:Audio', 'as:Video'])) {
-			$object_data['alternate-url'] = self::extractAlternateUrl($object['as:url'] ?? []) ?: $object_data['alternate-url'];
+			$object_data['alternate-url'] = self::extractAlternateUrl($object['as:url'] ?? [], $object_data['id']) ?: $object_data['alternate-url'];
 
 			$siteinfo = ParseUrl::getSiteinfoCached($object_data['alternate-url']);
 			if (isset($siteinfo['player'])) {


### PR DESCRIPTION
It is possible to embed Peertube video via the "embed" tag. This PR suppresses the display of the quoted video.