### PR TITLE
Make profile picture hover go to settings/profile, open collapse

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -337,7 +337,7 @@ class Profile
 			}
 		}
 		if ($local_user_is_self && $view_as_contact_id == 0) {
-			$picture_dest_url            = DI::baseUrl() . '/profile/' . $profile['nickname'] . '/photos';
+			$picture_dest_url            = DI::baseUrl() . '/settings/profile?profilepicture';
 			$change_profile_picture_text = DI::l10n()->t('Change profile picture');
 		} else {
 			$picture_dest_url            = $profile['url'];

--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -292,7 +292,8 @@ class Index extends BaseSettings
 				),
 			],
 
-			'$personal_account' => $personal_account,
+			'$personal_account'       => $personal_account,
+			'$change_profile_picture' => isset($_GET['profilepicture']),
 
 			'$form_security_token'       => self::getFormSecurityToken('settings_profile'),
 			'$form_security_token_photo' => self::getFormSecurityToken('settings_profile_photo'),

--- a/view/theme/frio/templates/settings/profile/index.tpl
+++ b/view/theme/frio/templates/settings/profile/index.tpl
@@ -30,12 +30,12 @@
 		<div class="panel">
 			<div class="section-subtitle-wrapper panel-heading" role="tab" id="photo-upload">
 				<h2>
-					<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#profile-photo-edit-wrapper" href="#photo-upload-collapse" aria-expanded="true" aria-controls="photo-upload-collapse">
+					<button class="btn-link accordion-toggle {{if !$change_profile_picture}}collapsed{{/if}}" data-toggle="collapse" data-parent="#profile-photo-edit-wrapper" href="#photo-upload-collapse" aria-expanded="true" aria-controls="photo-upload-collapse">
 						{{$l10n.profpic_header}}
 					</button>
 				</h2>
 			</div>
-			<div id="photo-upload-collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="photo-upload">
+			<div id="photo-upload-collapse" class="panel-collapse collapse {{if $change_profile_picture}}in{{/if}}" role="tabpanel" aria-labelledby="photo-upload">
 				<div class="panel-body">
 					<p id="profpic-intro-description">{{$l10n.profpic_intro}}</p>
 					<div class="row">


### PR DESCRIPTION
Closes #15167

<img width="274" height="382" alt="image" src="https://github.com/user-attachments/assets/9b4ab32d-6c1f-4474-b706-46b1fc7f3368" />

---

Makes two adjustments:

# 1. Profile image hover goes to /settings/profile instead of /profile/USER/photos.

This is faster and simpler if you want to upload a new picture, and slower if you want to use an existing one from Photos. But the former is easier for new/less technical users, so overall maybe it's preferable? Also this way they're presented with both approaches to changing it.

In the future I think this hover profile image change functionality could be improved even further, by opening fx. a modal showing your existing photos, and a form to upload a new one right there, without needing to go to settings or leaving the page you're on at all.

# 2. Pre-open the section to change profile picture

I've added some logic to pre-open the section that lets you set a profile picture, specifically when you click your profile image to go there.

<img width="644" height="301" alt="image" src="https://github.com/user-attachments/assets/c0269efa-4116-49a1-bfc7-58c8322da8a2" />

...

It's done through a GET parameter, PHP checking for it and passing it on to the template, which conditionally opens the section.

Right now that's not done in a particularly reusable way. If we want this functionality for anything else it should be reusable, but I'm not sure we do, and it could always be rewritten at that point...? I am unsure though.

Also, instead of handling it through PHP, one could also only set the GET parameter and then do the rest of the handling in Javascript instead.