### PR TITLE
add contextmenu action to compose-button

### DIFF
--- a/view/theme/frio/templates/widget/vcard.tpl
+++ b/view/theme/frio/templates/widget/vcard.tpl
@@ -66,11 +66,12 @@
 			{{/if}}
 			{{if $mention_link}}
 				<div id="jotOpen" class="pull-right">
-					<button type="button" id="mention-link" class="action-button btn btn-labeled btn-primary{{if !$always_open_compose}} modal-open{{/if}}" onclick="openWallMessage('{{$mention_link}}')" aria-label="{{$mention}}">
+					<button type="button" id="mention-link" class="action-button btn btn-labeled btn-primary{{if !$always_open_compose}} modal-open{{/if}}" onclick="openWallMessage('{{$mention_link}}')" aria-label="{{$mention}}" oncontextmenu="openWallMessage('compose/0')">
 						<i class="fa fa-lg fa-pencil"></i>
 						<span>{{$mention}}</span>
 					</button>
 				</div>
+				<script>jotOpen.addEventListener("contextmenu", (e) => {e.preventDefault()});</script>
 			{{/if}}
 			{{if $showgroup_link}}
 				<div id="show-group-button">


### PR DESCRIPTION
when visiting a contact i can create a posting, mentioning this user. Many times i visited a user and wanted to create a "normal" posting. So i had to go back and push the create button.

This commit adds on desktop-view a right-click event and on smartphone-view a longtap event (contextMenu) which opens the jot with NO mention to create a "normal" posting from contact vcard.

This is just a small improvement. 