### PR TITLE
Frio: Small fix for overflowing photos

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1931,6 +1931,7 @@ blockquote.shared_content {
 }
 .wall-item-content img {
 	object-fit: contain;
+	max-width: 100%;
 }
 .wall-item-body > img,
 .wall-item-body > a > img {


### PR DESCRIPTION
I just saw, that a photo from Diaspora was too wide / overflowing..
This should normally fix it and cause no other problems, I think.. 

before:
![Bildschirmfoto_2025-09-17_07-00-31--wall-item-content-img-before](https://github.com/user-attachments/assets/39c2cae2-8a83-47c3-9954-7d3fe7af6621)

after:
![Bildschirmfoto_2025-09-17_07-04-15--wall-item-content-img-after](https://github.com/user-attachments/assets/971b6e1b-0295-41ca-9e80-18f73814b4d4)
 