### PR TITLE
Frio: Remove logo mask made for firefox as it is troublesome and seemingly superfluous

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -336,6 +336,7 @@ class Nav
 		$nav['navigation'] = ['navigation/', $this->l10n->t('Navigation'), '', $this->l10n->t('Site map')];
 
 		// Provide a banner/logo/whatever
+		// NOTE: Frio does not use this.
 		$banner = $this->config->get('system', 'banner');
 		if (is_null($banner)) {
 			$banner = '<a href="https://friendi.ca"><img id="logo-img" width="32" height="32" src="images/friendica.svg" alt="logo" /></a><span id="logo-text"><a href="https://friendi.ca">Friendica</a></span>';

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -750,10 +750,6 @@ nav.navbar .nav > li > button:focus {
 	display: flex;
 }
 
-#friendica-logo-mask {
-	display: block;
-}
-
 /* Notification Menu */
 #topbar-first #nav-notifications-menu {
 	max-height: 400px;
@@ -3963,10 +3959,6 @@ section .profile-match-wrapper {
 	}
 	body.minimal {
 		padding: 15px;
-	}
-
-	#friendica-logo-mask {
-		display: none;
 	}
 
 	.container {

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -63,17 +63,6 @@ $(document).ready(function () {
 	// move the tabbar to the second nav bar
 	$("section .tabbar-wrapper").first().appendTo("#topbar-second > .container > #tabmenu");
 
-	// add mask css url to the logo-img container
-	//
-	// This is for firefox - we use a mask which looks like the friendica logo to apply user colors
-	// to the friendica logo (the mask is in nav.tpl at the bottom). To make it work we need to apply the
-	// correct url. The only way which comes to my mind was to do this with js
-	// So we apply the correct url (with the link to the id of the mask) after the page is loaded.
-	if ($("#logo-img").length) {
-		var pageurl = "url('" + window.location.href + "#logo-mask')";
-		$("#logo-img").css({ mask: pageurl });
-	}
-
 	// make responsive tabmenu with flexmenu.js
 	// the menupoints which doesn't fit in the second nav bar will moved to a
 	// dropdown menu. Look at common_tabs.tpl

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -11,19 +11,9 @@
 
 		<div id="site-location" aria-hidden="true">{{$sitelocation}}</div>
 		<div id="banner" class="hidden-sm hidden-xs">
-			{{* show on remote/visitor connections another logo which symbols that fact *}}
-			{{if $nav.remote}}
-				<a href="{{$baseurl}}" aria-hidden="true">
-					<div id="remote-logo-img" aria-label="{{$home}}"></div>
-				</a>
-			{{else}}
-				{{* #logo-img is the placeholder to insert a mask (friendica logo) into this div
-				For Firefox we have to call the paths of the mask (look at the bottom of this file).
-				Because for FF we need relative paths we apply them with js after the page is loaded (look at theme.js *}}
-				<a href="{{$baseurl}}" aria-hidden="true">
-					<div id="logo-img" aria-label="{{$home}}"></div>
-				</a>
-			{{/if}}
+			<a href="{{$baseurl}}" aria-hidden="true">
+				<div id="logo-img" aria-label="{{$home}}"></div>
+			</a>
 		</div>
 	</header>
 	<nav id="topbar-first" class="topbar" role="menubar">

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -539,15 +539,3 @@
 		<div class="col-lg-2 col-md-2 col-sm-1 col-xs-2" id="navbar-button"></div>
 	</div>
 </div>
-
-{{* This is the mask of the firefox logo. We set the background of #logo-img to the user icon color and apply this mask to it
-The result is a friendica logo in the user icon color.*}}
-<svg id="friendica-logo-mask" x="0px" y="0px" width="0px" height="0px" viewBox="0 0 250 250">
-	<defs>
-		<mask id="logo-mask" maskUnits="objectBoundingBox" maskContentUnits="objectBoundingBox">
-			<path style="fill-rule:evenodd;clip-rule:evenodd;fill:#ffffff;"
-				d="M0.796,0L0.172,0.004C0.068,0.008,0.008,0.068,0,0.172V0.824c0,0.076,0.06,0.16,0.168,0.172h0.652c0.072,0,0.148-0.06,0.172-0.144V0.14C1,0.06,0.908,0,0.796,0zM0.812,0.968H0.36v-0.224h0.312v-0.24H0.36V0.3h0.316l0-0.264l0.116-0c0.088,0,0.164,0.044,0.164,0.096l0,0.696C0.96,0.912,0.876,0.968,0.812,0.968z">
-			</path>
-		</mask>
-	</defs>
-</svg>


### PR DESCRIPTION
Specifically because:
- The mask has started to cause issues for Webkit browsers (Epiphany/Safari), where the logo disappeared.
- The Friendica icon adapts to the nav background color without it (also in Firefox), so I don't see it having any effect?

I'm opening this as a draft to begin with, in case this icon mask provides another function I'm not currently aware of, and maybe others here can enlighten me.

Next I thought maybe it has to do with the "platform colors" for logos, so one could set it to be black and white even when using a theme with colours, but that does not seem to be the case. It's still coloured if choosing black/white platform logos.

Here's  how the code comments describe what it's supposed to do:
> This is for firefox - we use a mask which looks like the friendica logo to apply user colors to the friendica logo 

> This is the mask of the firefox logo. We set the background of #logo-img to the user icon color and apply this mask to it
The result is a friendica logo in the user icon color.

# Tests

I've tested in a Firefox-based browser and Epiphany, which is Webkit-based like Safari.

## Epiphany

The icon is not there before this change, because somehow the mask hides it.
It is there after the change.

The icon still changes colour with the theme.

## Firefox

The icon still changes colour with the theme. 

The icon looks *almost* identical before and after. I can't even tell the difference from the screenshots below, but if I hide/remove the mask there's a tiny difference in the line thickness at some points. But effectively it's nothing.

Before:
<img width="57" height="40" alt="image" src="https://github.com/user-attachments/assets/ecdbc459-e759-4d9d-87b0-7ea985730aaf" />

After:
<img width="57" height="40" alt="image" src="https://github.com/user-attachments/assets/635b3b84-3dda-4dfe-b7c4-b6ffaf8086b3" />