### PR TITLE
Fix for Issue #15181 - Sysmessages not showing at login and registration

### DIFF
--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -131,6 +131,9 @@ class Register extends BaseModule
 
 		$ask_password = !DBA::count('contact');
 
+		// Retrieve system messages to display on the registration page
+		$notices = DI::sysmsg()->flushNotices();
+
 		$tpl = Renderer::getMarkupTemplate('register.tpl');
 
 		$hook_data = [
@@ -144,6 +147,7 @@ class Register extends BaseModule
 		$tpl = $hook_data['template'] ?? $tpl;
 
 		$o = Renderer::replaceMacros($tpl, [
+			'$notices'               => $notices,
 			'$invitations'           => DI::config()->get('system', 'invitation_only'),
 			'$permonly'              => self::getPolicy() === self::APPROVE,
 			'$permonlybox'           => ['permonlybox', DI::l10n()->t('Note for the admin'), '', DI::l10n()->t('Leave a message for the admin, why you want to join this node'), DI::l10n()->t('Required')],

--- a/src/Module/Security/Login.php
+++ b/src/Module/Security/Login.php
@@ -63,10 +63,10 @@ class Login extends BaseModule
 	{
 		// Save sysmessages before clearing session
 		$notices = $this->session->get('sysmsg', []);
-		$infos = $this->session->get('sysmsg_info', []);
-		
+		$infos   = $this->session->get('sysmsg_info', []);
+
 		$this->session->clear();
-		
+
 		// Restore sysmessages after clearing
 		if (!empty($notices)) {
 			$this->session->set('sysmsg', $notices);
@@ -121,14 +121,14 @@ class Login extends BaseModule
 		// Retrieve system messages to display on the login page
 		$notices = DI::sysmsg()->flushNotices();
 
-		$reg = false;
-		if ($register && Register::getPolicy() !== Register::CLOSED) {
-			$reg = [
-				'title' => DI::l10n()->t('Create a New Account'),
-				'desc' => DI::l10n()->t('Register'),
-				'url' => self::getRegisterURL()
-			];
-		}
+	$reg = false;
+	if ($register && Register::getPolicy() !== Register::CLOSED) {
+		$reg = [
+			'title' => DI::l10n()->t('Create a New Account'),
+			'desc'  => DI::l10n()->t('Register'),
+			'url'   => self::getRegisterURL()
+		];
+	}
 
 		if (DI::userSession()->getLocalUserId()) {
 			$tpl = Renderer::getMarkupTemplate('logout.tpl');
@@ -142,42 +142,42 @@ class Login extends BaseModule
 			$tpl = Renderer::getMarkupTemplate('login.tpl');
 		}
 
-		if (!empty(DI::session()->get('openid_identity'))) {
-			$openid_title = DI::l10n()->t('Your OpenID: ');
-			$openid_readonly = true;
-			$identity = DI::session()->get('openid_identity');
-			$username_desc = DI::l10n()->t('Please enter your username and password to add the OpenID to your existing account.');
-		} else {
-			$openid_title = DI::l10n()->t('Or login using OpenID: ');
-			$openid_readonly = false;
-			$identity = '';
-			$username_desc = '';
-		}
+	if (!empty(DI::session()->get('openid_identity'))) {
+		$openid_title    = DI::l10n()->t('Your OpenID: ');
+		$openid_readonly = true;
+		$identity        = DI::session()->get('openid_identity');
+		$username_desc   = DI::l10n()->t('Please enter your username and password to add the OpenID to your existing account.');
+	} else {
+		$openid_title    = DI::l10n()->t('Or login using OpenID: ');
+		$openid_readonly = false;
+		$identity        = '';
+		$username_desc   = '';
+	}
 
 		$o = Renderer::replaceMacros(
 			$tpl,
 			[
-				'$notices'      => $notices,
-				'$dest_url'     => DI::baseUrl() . '/login',
-				'$logout'       => DI::l10n()->t('Logout'),
-				'$login'        => DI::l10n()->t('Login'),
+				'$notices'  => $notices,
+				'$dest_url' => DI::baseUrl() . '/login',
+				'$logout'   => DI::l10n()->t('Logout'),
+				'$login'    => DI::l10n()->t('Login'),
 
-				'$lname'        => ['username', DI::l10n()->t('Nickname or Email: '), '', $username_desc],
-				'$lpassword'    => ['password', DI::l10n()->t('Password: '), '', ''],
-				'$lremember'    => ['remember', DI::l10n()->t('Remember me'), 0,  ''],
+				'$lname'     => ['username', DI::l10n()->t('Nickname or Email: '), '', $username_desc],
+				'$lpassword' => ['password', DI::l10n()->t('Password: '), '', ''],
+				'$lremember' => ['remember', DI::l10n()->t('Remember me'), 0,  ''],
 
-				'$openid'       => !$noid,
-				'$lopenid'      => ['openid_url', $openid_title, $identity, '', $openid_readonly],
+				'$openid'  => !$noid,
+				'$lopenid' => ['openid_url', $openid_title, $identity, '', $openid_readonly],
 
-				'$hiddens'      => ['return_path' => $return_path ?? DI::args()->getQueryString()],
+				'$hiddens' => ['return_path' => $return_path ?? DI::args()->getQueryString()],
 
-				'$register'     => $reg,
+				'$register' => $reg,
 
-				'$lostpass'     => DI::l10n()->t('Forgot your password?'),
-				'$lostlink'     => DI::l10n()->t('Password Reset'),
+				'$lostpass' => DI::l10n()->t('Forgot your password?'),
+				'$lostlink' => DI::l10n()->t('Password Reset'),
 
-				'$tostitle'     => DI::l10n()->t('Website Terms of Service'),
-				'$toslink'      => DI::l10n()->t('terms of service'),
+				'$tostitle' => DI::l10n()->t('Website Terms of Service'),
+				'$toslink'  => DI::l10n()->t('terms of service'),
 
 				'$privacytitle' => DI::l10n()->t('Website Privacy Policy'),
 				'$privacylink'  => DI::l10n()->t('privacy policy'),

--- a/src/Module/Security/Login.php
+++ b/src/Module/Security/Login.php
@@ -61,7 +61,19 @@ class Login extends BaseModule
 
 	protected function post(array $request = [])
 	{
+		// Save sysmessages before clearing session
+		$notices = $this->session->get('sysmsg', []);
+		$infos = $this->session->get('sysmsg_info', []);
+		
 		$this->session->clear();
+		
+		// Restore sysmessages after clearing
+		if (!empty($notices)) {
+			$this->session->set('sysmsg', $notices);
+		}
+		if (!empty($infos)) {
+			$this->session->set('sysmsg_info', $infos);
+		}
 
 		// OpenId Login
 		if (
@@ -106,6 +118,9 @@ class Login extends BaseModule
 			DI::session()->remove('openid_attributes');
 		}
 
+		// Retrieve system messages to display on the login page
+		$notices = DI::sysmsg()->flushNotices();
+
 		$reg = false;
 		if ($register && Register::getPolicy() !== Register::CLOSED) {
 			$reg = [
@@ -142,6 +157,7 @@ class Login extends BaseModule
 		$o = Renderer::replaceMacros(
 			$tpl,
 			[
+				'$notices'      => $notices,
 				'$dest_url'     => DI::baseUrl() . '/login',
 				'$logout'       => DI::l10n()->t('Logout'),
 				'$login'        => DI::l10n()->t('Login'),

--- a/src/Module/Security/Login.php
+++ b/src/Module/Security/Login.php
@@ -121,14 +121,14 @@ class Login extends BaseModule
 		// Retrieve system messages to display on the login page
 		$notices = DI::sysmsg()->flushNotices();
 
-	$reg = false;
-	if ($register && Register::getPolicy() !== Register::CLOSED) {
-		$reg = [
-			'title' => DI::l10n()->t('Create a New Account'),
-			'desc'  => DI::l10n()->t('Register'),
-			'url'   => self::getRegisterURL()
-		];
-	}
+		$reg = false;
+		if ($register && Register::getPolicy() !== Register::CLOSED) {
+			$reg = [
+				'title' => DI::l10n()->t('Create a New Account'),
+				'desc'  => DI::l10n()->t('Register'),
+				'url'   => self::getRegisterURL()
+			];
+		}
 
 		if (DI::userSession()->getLocalUserId()) {
 			$tpl = Renderer::getMarkupTemplate('logout.tpl');
@@ -142,17 +142,17 @@ class Login extends BaseModule
 			$tpl = Renderer::getMarkupTemplate('login.tpl');
 		}
 
-	if (!empty(DI::session()->get('openid_identity'))) {
-		$openid_title    = DI::l10n()->t('Your OpenID: ');
-		$openid_readonly = true;
-		$identity        = DI::session()->get('openid_identity');
-		$username_desc   = DI::l10n()->t('Please enter your username and password to add the OpenID to your existing account.');
-	} else {
-		$openid_title    = DI::l10n()->t('Or login using OpenID: ');
-		$openid_readonly = false;
-		$identity        = '';
-		$username_desc   = '';
-	}
+		if (!empty(DI::session()->get('openid_identity'))) {
+			$openid_title    = DI::l10n()->t('Your OpenID: ');
+			$openid_readonly = true;
+			$identity        = DI::session()->get('openid_identity');
+			$username_desc   = DI::l10n()->t('Please enter your username and password to add the OpenID to your existing account.');
+		} else {
+			$openid_title    = DI::l10n()->t('Or login using OpenID: ');
+			$openid_readonly = false;
+			$identity        = '';
+			$username_desc   = '';
+		}
 
 		$o = Renderer::replaceMacros(
 			$tpl,

--- a/src/Navigation/SystemMessages.php
+++ b/src/Navigation/SystemMessages.php
@@ -54,7 +54,7 @@ class SystemMessages
 
 	public function addInfo(string $message)
 	{
-		$sysmsg = $this->getNotices();
+		$sysmsg = $this->getInfos();
 
 		$sysmsg[] = $message;
 

--- a/view/templates/login.tpl
+++ b/view/templates/login.tpl
@@ -5,6 +5,12 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 
+{{* Display system messages *}}
+{{if $notices}}
+	{{foreach $notices as $notice}}
+		<div class="alert alert-warning" role="alert">{{$notice}}</div>
+	{{/foreach}}
+{{/if}}
 
 <form id="login-form" action="{{$dest_url}}" role="form" method="post">
 <div id="login-group" role="group" aria-labelledby="login-head">

--- a/view/templates/register.tpl
+++ b/view/templates/register.tpl
@@ -4,6 +4,14 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
+
+{{* Display system messages *}}
+{{if $notices}}
+	{{foreach $notices as $notice}}
+		<div class="alert alert-warning" role="alert">{{$notice}}</div>
+	{{/foreach}}
+{{/if}}
+
 <h3>{{$regtitle}}</h3>
 
 <form action="register" method="post" id="register-form">

--- a/view/theme/frio/templates/login.tpl
+++ b/view/theme/frio/templates/login.tpl
@@ -5,6 +5,13 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 
+{{* Display system messages *}}
+{{if $notices}}
+	{{foreach $notices as $notice}}
+		<div class="alert alert-warning" role="alert">{{$notice}}</div>
+	{{/foreach}}
+{{/if}}
+
 <form id="login-form" action="{{$dest_url}}" role="form" method="post">
 	<div id="login-group" role="group" aria-labelledby="login-head">
 		<input type="hidden" name="auth-params" value="login" />

--- a/view/theme/frio/templates/register.tpl
+++ b/view/theme/frio/templates/register.tpl
@@ -6,6 +6,13 @@
   *}}
 <div class="generic-page-wrapper">
 
+	{{* Display system messages *}}
+	{{if $notices}}
+		{{foreach $notices as $notice}}
+			<div class="alert alert-warning" role="alert">{{$notice}}</div>
+		{{/foreach}}
+	{{/if}}
+
 	<form action="register" method="post" id="register-form">
 
 		<input type="hidden" name="photo" value="{{$photo}}" />


### PR DESCRIPTION
Behavior after the fix:

Wrong Credentials:
<img width="569" height="412" alt="image" src="https://github.com/user-attachments/assets/cc4239e5-e3de-4e4f-843f-02b237820fea" />

Username already taken:
<img width="647" height="312" alt="image" src="https://github.com/user-attachments/assets/efb9c7a9-65d1-4dff-973c-c43fb1d8939d" />

fixes #15181 