### PR TITLE
Remove translations of technical, code-specific terms and theme variation names

### DIFF
--- a/src/Module/Debug/Babel.php
+++ b/src/Module/Debug/Babel.php
@@ -39,195 +39,196 @@ class Babel extends BaseModule
 			self::checkFormSecurityTokenForbiddenOnError('babel');
 			switch (($request['type'] ?? '') ?: 'bbcode') {
 				case 'bbcode':
-					$bbcode = $request['text'];
+					$bbcode    = $request['text'];
 					$results[] = [
-						'title'   => DI::l10n()->t('Source input'),
+						'title'   => 'Source input',
 						'content' => $visible_whitespace($bbcode)
 					];
 
-					$plain = Text\BBCode::toPlaintext($bbcode, false);
+					$plain     = Text\BBCode::toPlaintext($bbcode, false);
 					$results[] = [
-						'title'   => DI::l10n()->t('BBCode::toPlaintext'),
+						'title'   => 'BBCode::toPlaintext',
 						'content' => $visible_whitespace($plain)
 					];
 
-					$html = Text\BBCode::convertForUriId(0, $bbcode);
+					$html      = Text\BBCode::convertForUriId(0, $bbcode);
 					$results[] = [
-						'title'   => DI::l10n()->t('BBCode::convert (raw HTML)'),
+						'title'   => 'BBCode::convert (raw HTML)',
 						'content' => $visible_whitespace($html)
 					];
 
 					$results[] = [
-						'title'   => DI::l10n()->t('BBCode::convert (hex)'),
+						'title'   => 'BBCode::convert (hex)',
 						'content' => $visible_whitespace(bin2hex($html)),
 					];
 
 					$results[] = [
-						'title'   => DI::l10n()->t('BBCode::convert'),
+						'title'   => 'BBCode::convert',
 						'content' => $html
 					];
 
-					$bbcode2 = Text\HTML::toBBCode($html);
+					$bbcode2   = Text\HTML::toBBCode($html);
 					$results[] = [
-						'title'   => DI::l10n()->t('BBCode::convert => HTML::toBBCode'),
+						'title'   => 'BBCode::convert => HTML::toBBCode',
 						'content' => $visible_whitespace($bbcode2)
 					];
 
-					$markdown = Text\BBCode::toMarkdown($bbcode);
+					$markdown  = Text\BBCode::toMarkdown($bbcode);
 					$results[] = [
-						'title'   => DI::l10n()->t('BBCode::toMarkdown'),
+						'title'   => 'BBCode::toMarkdown',
 						'content' => $visible_whitespace($markdown)
 					];
 
-					$html2 = Text\Markdown::convert($markdown);
+					$html2     = Text\Markdown::convert($markdown);
 					$results[] = [
-						'title'   => DI::l10n()->t('BBCode::toMarkdown => Markdown::convert (raw HTML)'),
+						'title'   => 'BBCode::toMarkdown => Markdown::convert (raw HTML)',
 						'content' => $visible_whitespace($html2)
 					];
 					$results[] = [
-						'title'   => DI::l10n()->t('BBCode::toMarkdown => Markdown::convert'),
+						'title'   => 'BBCode::toMarkdown => Markdown::convert',
 						'content' => $html2
 					];
 
-					$bbcode3 = Text\Markdown::toBBCode($markdown);
+					$bbcode3   = Text\Markdown::toBBCode($markdown);
 					$results[] = [
-						'title'   => DI::l10n()->t('BBCode::toMarkdown => Markdown::toBBCode'),
+						'title'   => 'BBCode::toMarkdown => Markdown::toBBCode',
 						'content' => $visible_whitespace($bbcode3)
 					];
 
-					$bbcode4 = Text\HTML::toBBCode($html2);
+					$bbcode4   = Text\HTML::toBBCode($html2);
 					$results[] = [
-						'title'   => DI::l10n()->t('BBCode::toMarkdown =>  Markdown::convert => HTML::toBBCode'),
+						'title'   => 'BBCode::toMarkdown =>  Markdown::convert => HTML::toBBCode',
 						'content' => $visible_whitespace($bbcode4)
 					];
 
 					$tags = Text\BBCode::getTags($bbcode);
 
-					$body = Item::setHashtags($bbcode);
+					$body      = Item::setHashtags($bbcode);
 					$results[] = [
-						'title'   => DI::l10n()->t('Item Body'),
+						'title'   => 'Item Body',
 						'content' => $visible_whitespace($body)
 					];
 					$results[] = [
-						'title'   => DI::l10n()->t('Item Tags'),
+						'title'   => 'Item Tags',
 						'content' => $visible_whitespace(var_export($tags, true)),
 					];
 
-					$body2 = PageInfo::searchAndAppendToBody($bbcode, true);
+					$body2     = PageInfo::searchAndAppendToBody($bbcode, true);
 					$results[] = [
-						'title'   => DI::l10n()->t('PageInfo::appendToBody'),
+						'title'   => 'PageInfo::appendToBody',
 						'content' => $visible_whitespace($body2)
 					];
-					$html3 = Text\BBCode::convertForUriId(0, $body2);
+					$html3     = Text\BBCode::convertForUriId(0, $body2);
 					$results[] = [
-						'title'   => DI::l10n()->t('PageInfo::appendToBody => BBCode::convert (raw HTML)'),
+						'title'   => 'PageInfo::appendToBody => BBCode::convert (raw HTML)',
 						'content' => $visible_whitespace($html3)
 					];
 					$results[] = [
-						'title'   => DI::l10n()->t('PageInfo::appendToBody => BBCode::convert'),
+						'title'   => 'PageInfo::appendToBody => BBCode::convert',
 						'content' => $html3
 					];
 					break;
 				case 'diaspora':
-					$diaspora = trim($request['text']);
+					$diaspora  = trim($request['text']);
 					$results[] = [
-						'title'   => DI::l10n()->t('Source input (Diaspora format)'),
+						'title'   => 'Source input (Diaspora format)',
 						'content' => $visible_whitespace($diaspora),
 					];
 
 					$markdown = XML::unescape($diaspora);
+					// no break
 				case 'markdown':
 					$markdown = $markdown ?? trim($request['text']);
 
 					$results[] = [
-						'title'   => DI::l10n()->t('Source input (Markdown)'),
+						'title'   => 'Source input (Markdown)',
 						'content' => $visible_whitespace($markdown),
 					];
 
-					$html = Text\Markdown::convert($markdown);
+					$html      = Text\Markdown::convert($markdown);
 					$results[] = [
-						'title'   => DI::l10n()->t('Markdown::convert (raw HTML)'),
+						'title'   => 'Markdown::convert (raw HTML)',
 						'content' => $visible_whitespace($html),
 					];
 
 					$results[] = [
-						'title'   => DI::l10n()->t('Markdown::convert'),
+						'title'   => 'Markdown::convert',
 						'content' => $html
 					];
 
-					$bbcode = Text\Markdown::toBBCode($markdown);
+					$bbcode    = Text\Markdown::toBBCode($markdown);
 					$results[] = [
-						'title'   => DI::l10n()->t('Markdown::toBBCode'),
+						'title'   => 'Markdown::toBBCode',
 						'content' => $visible_whitespace($bbcode),
 					];
 					break;
-				case 'html' :
-					$html = trim($request['text']);
+				case 'html':
+					$html      = trim($request['text']);
 					$results[] = [
-						'title'   => DI::l10n()->t('Raw HTML input'),
+						'title'   => 'Raw HTML input',
 						'content' => $visible_whitespace($html),
 					];
 
 					$results[] = [
-						'title'   => DI::l10n()->t('HTML Input'),
+						'title'   => 'HTML Input',
 						'content' => $html
 					];
 
 					$purified = Text\HTML::purify($html);
 
 					$results[] = [
-						'title'   => DI::l10n()->t('HTML Purified (raw)'),
+						'title'   => 'HTML Purified (raw)',
 						'content' => $visible_whitespace($purified),
 					];
 
 					$results[] = [
-						'title'   => DI::l10n()->t('HTML Purified (hex)'),
+						'title'   => 'HTML Purified (hex)',
 						'content' => $visible_whitespace(bin2hex($purified)),
 					];
 
 					$results[] = [
-						'title'   => DI::l10n()->t('HTML Purified'),
+						'title'   => 'HTML Purified',
 						'content' => $purified,
 					];
 
-					$bbcode = Text\HTML::toBBCode($html);
+					$bbcode    = Text\HTML::toBBCode($html);
 					$results[] = [
-						'title'   => DI::l10n()->t('HTML::toBBCode'),
+						'title'   => 'HTML::toBBCode',
 						'content' => $visible_whitespace($bbcode)
 					];
 
-					$html2 = Text\BBCode::convertForUriId(0, $bbcode);
+					$html2     = Text\BBCode::convertForUriId(0, $bbcode);
 					$results[] = [
-						'title'   => DI::l10n()->t('HTML::toBBCode => BBCode::convert'),
+						'title'   => 'HTML::toBBCode => BBCode::convert',
 						'content' => $html2
 					];
 
 					$results[] = [
-						'title'   => DI::l10n()->t('HTML::toBBCode => BBCode::convert (raw HTML)'),
+						'title'   => 'HTML::toBBCode => BBCode::convert (raw HTML)',
 						'content' => htmlspecialchars($html2)
 					];
 
 					$bbcode2plain = Text\BBCode::toPlaintext($bbcode);
-					$results[] = [
-						'title'   => DI::l10n()->t('HTML::toBBCode => BBCode::toPlaintext'),
+					$results[]    = [
+						'title'   => 'HTML::toBBCode => BBCode::toPlaintext',
 						'content' => $visible_whitespace($bbcode2plain),
 					];
 
-					$markdown = Text\HTML::toMarkdown($html);
+					$markdown  = Text\HTML::toMarkdown($html);
 					$results[] = [
-						'title'   => DI::l10n()->t('HTML::toMarkdown'),
+						'title'   => 'HTML::toMarkdown',
 						'content' => $visible_whitespace($markdown)
 					];
 
-					$text = Text\HTML::toPlaintext($html, 0);
+					$text      = Text\HTML::toPlaintext($html, 0);
 					$results[] = [
-						'title'   => DI::l10n()->t('HTML::toPlaintext'),
+						'title'   => 'HTML::toPlaintext',
 						'content' => $visible_whitespace($text),
 					];
 
-					$text = Text\HTML::toPlaintext($html, 0, true);
+					$text      = Text\HTML::toPlaintext($html, 0, true);
 					$results[] = [
-						'title'   => DI::l10n()->t('HTML::toPlaintext (compact)'),
+						'title'   => 'HTML::toPlaintext (compact)',
 						'content' => $visible_whitespace($text),
 					];
 					break;
@@ -237,11 +238,11 @@ class Babel extends BaseModule
 					$status = json_decode($json);
 
 					$results[] = [
-						'title'   => DI::l10n()->t('Decoded post'),
+						'title'   => 'Decoded post',
 						'content' => $visible_whitespace(var_export($status, true)),
 					];
 
-					$postarray = [];
+					$postarray                = [];
 					$postarray['object-type'] = Activity\ObjectType::NOTE;
 
 					if (!empty($status->full_text)) {
@@ -256,7 +257,7 @@ class Babel extends BaseModule
 					}
 
 					$results[] = [
-						'title'   => DI::l10n()->t('Post array before expand entities'),
+						'title'   => 'Post array before expand entities',
 						'content' => $visible_whitespace(var_export($postarray, true)),
 					];
 
@@ -265,18 +266,18 @@ class Babel extends BaseModule
 		}
 
 		$tpl = Renderer::getMarkupTemplate('babel.tpl');
-		$o = Renderer::replaceMacros($tpl, [
-			'$title'         => DI::l10n()->t('Babel Diagnostic'),
+		$o   = Renderer::replaceMacros($tpl, [
+			'$title'               => DI::l10n()->t('Babel Diagnostic'),
 			'$form_security_token' => self::getFormSecurityToken('babel'),
-			'$text'          => ['text', DI::l10n()->t('Source text'), $request['text'] ?? '', ''],
-			'$type_bbcode'   => ['type', DI::l10n()->t('BBCode'), 'bbcode', '', (($request['type'] ?? '') ?: 'bbcode') == 'bbcode'],
-			'$type_diaspora' => ['type', DI::l10n()->t('Diaspora'), 'diaspora', '', (($request['type'] ?? '') ?: 'bbcode') == 'diaspora'],
-			'$type_markdown' => ['type', DI::l10n()->t('Markdown'), 'markdown', '', (($request['type'] ?? '') ?: 'bbcode') == 'markdown'],
-			'$type_html'     => ['type', DI::l10n()->t('HTML'), 'html', '', (($request['type'] ?? '') ?: 'bbcode') == 'html'],
-			'$flag_twitter'  => file_exists('addon/twitter/twitter.php'),
-			'$type_twitter'  => ['type', DI::l10n()->t('Twitter Source / Tweet URL (requires API key)'), 'twitter', '', (($request['type'] ?? '') ?: 'bbcode') == 'twitter'],
-			'$results'       => $results,
-			'$submit'        => DI::l10n()->t('Submit'),
+			'$text'                => ['text', 'Source text', $request['text'] ?? '', ''],
+			'$type_bbcode'         => ['type', 'BBCode', 'bbcode', '', (($request['type'] ?? '') ?: 'bbcode') == 'bbcode'],
+			'$type_diaspora'       => ['type', 'Diaspora', 'diaspora', '', (($request['type'] ?? '') ?: 'bbcode') == 'diaspora'],
+			'$type_markdown'       => ['type', 'Markdown', 'markdown', '', (($request['type'] ?? '') ?: 'bbcode') == 'markdown'],
+			'$type_html'           => ['type', 'HTML', 'html', '', (($request['type'] ?? '') ?: 'bbcode') == 'html'],
+			'$flag_twitter'        => file_exists('addon/twitter/twitter.php'),
+			'$type_twitter'        => ['type', DI::l10n()->t('Twitter Source / Tweet URL (requires API key)'), 'twitter', '', (($request['type'] ?? '') ?: 'bbcode') == 'twitter'],
+			'$results'             => $results,
+			'$submit'              => DI::l10n()->t('Submit'),
 		]);
 
 		return $o;

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-25 21:00+0200\n"
+"POT-Creation-Date: 2025-10-03 20:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -435,7 +435,7 @@ msgstr ""
 #: src/Module/Calendar/Event/Form.php:236 src/Module/Contact/Advanced.php:118
 #: src/Module/Contact/Profile.php:410
 #: src/Module/Debug/ActivityPubConversion.php:128
-#: src/Module/Debug/Babel.php:279 src/Module/Debug/Localtime.php:50
+#: src/Module/Debug/Babel.php:280 src/Module/Debug/Localtime.php:50
 #: src/Module/Debug/Probe.php:40 src/Module/Debug/WebFinger.php:37
 #: src/Module/FriendSuggest.php:132 src/Module/Install.php:219
 #: src/Module/Install.php:259 src/Module/Install.php:296
@@ -1081,7 +1081,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: src/Content/ContactSelector.php:123 src/Module/Debug/Babel.php:273
+#: src/Content/ContactSelector.php:123
 msgid "Diaspora"
 msgstr ""
 
@@ -6758,167 +6758,11 @@ msgstr[1] ""
 msgid "Source activity"
 msgstr ""
 
-#: src/Module/Debug/Babel.php:44
-msgid "Source input"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:50
-msgid "BBCode::toPlaintext"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:56
-msgid "BBCode::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:61
-msgid "BBCode::convert (hex)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:66
-msgid "BBCode::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:72
-msgid "BBCode::convert => HTML::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:78
-msgid "BBCode::toMarkdown"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:84
-msgid "BBCode::toMarkdown => Markdown::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:88
-msgid "BBCode::toMarkdown => Markdown::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:94
-msgid "BBCode::toMarkdown => Markdown::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:100
-msgid "BBCode::toMarkdown =>  Markdown::convert => HTML::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:108
-msgid "Item Body"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:112
-msgid "Item Tags"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:118
-msgid "PageInfo::appendToBody"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:123
-msgid "PageInfo::appendToBody => BBCode::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:127
-msgid "PageInfo::appendToBody => BBCode::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:134
-msgid "Source input (Diaspora format)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:143
-msgid "Source input (Markdown)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:149
-msgid "Markdown::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:154
-msgid "Markdown::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:160
-msgid "Markdown::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:167
-msgid "Raw HTML input"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:172
-msgid "HTML Input"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:179
-msgid "HTML Purified (raw)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:184
-msgid "HTML Purified (hex)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:189
-msgid "HTML Purified"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:195
-msgid "HTML::toBBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:201
-msgid "HTML::toBBCode => BBCode::convert"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:206
-msgid "HTML::toBBCode => BBCode::convert (raw HTML)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:212
-msgid "HTML::toBBCode => BBCode::toPlaintext"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:218
-msgid "HTML::toMarkdown"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:224
-msgid "HTML::toPlaintext"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:230
-msgid "HTML::toPlaintext (compact)"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:240
-msgid "Decoded post"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:259
-msgid "Post array before expand entities"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:269
+#: src/Module/Debug/Babel.php:270
 msgid "Babel Diagnostic"
 msgstr ""
 
-#: src/Module/Debug/Babel.php:271
-msgid "Source text"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:272
-msgid "BBCode"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:274
-msgid "Markdown"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:275
-msgid "HTML"
-msgstr ""
-
-#: src/Module/Debug/Babel.php:277
+#: src/Module/Debug/Babel.php:278
 msgid "Twitter Source / Tweet URL (requires API key)"
 msgstr ""
 
@@ -11928,34 +11772,6 @@ msgstr ""
 
 #: src/Worker/PushSubscription.php:96
 msgid "Empty Post"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:56
-msgid "default"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:57
-msgid "greenzero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:58
-msgid "purplezero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:59
-msgid "easterbunny"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:60
-msgid "darkzero"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:61
-msgid "comix"
-msgstr ""
-
-#: view/theme/duepuntozero/config.php:62
-msgid "slackr"
 msgstr ""
 
 #: view/theme/duepuntozero/config.php:75

--- a/view/theme/duepuntozero/config.php
+++ b/view/theme/duepuntozero/config.php
@@ -53,13 +53,13 @@ function theme_admin_post()
 function clean_form(AppHelper $appHelper, &$colorset, $user)
 {
 	$colorset = [
-		'default'     => DI::l10n()->t('default'),
-		'greenzero'   => DI::l10n()->t('greenzero'),
-		'purplezero'  => DI::l10n()->t('purplezero'),
-		'easterbunny' => DI::l10n()->t('easterbunny'),
-		'darkzero'    => DI::l10n()->t('darkzero'),
-		'comix'       => DI::l10n()->t('comix'),
-		'slackr'      => DI::l10n()->t('slackr'),
+		'default'     => 'default',
+		'greenzero'   => 'greenzero',
+		'purplezero'  => 'purplezero',
+		'easterbunny' => 'easterbunny',
+		'darkzero'    => 'darkzero',
+		'comix'       => 'comix',
+		'slackr'      => 'slackr',
 	];
 
 	if ($user) {


### PR DESCRIPTION
Closes #15163 

How about this? Duepuntozero theme variation names are removed, and most translations are removed from the debugging tool Babel.php, focused on those that are or include things like file formats, function names and such.

I'm unsure whether a few should be kept, or for that matter if the remaining should be removed, if there's an assumption that this tool is really only helpful to programmers, and the code is in English anyway.
But in that case I don't know if a translation to  fx. "Source input" and "Decoded post" should remain?

Also the duepuntozero array, previously used for translations, could now be removed, but since it's deprecated I'm thinking that maybe doing that cleanup isn't worth it.