### PR TITLE
Settings: Set required on the image upload file field to prevent possible server error

### DIFF
--- a/view/templates/settings/profile/index.tpl
+++ b/view/templates/settings/profile/index.tpl
@@ -34,7 +34,7 @@
 
 				<div id="profile-photo-upload-wrapper">
 					<label id="profile-photo-upload-label" for="profile-photo-upload">{{$l10n.profpic_upload_new_header}}:</label>
-					<input name="userfile" type="file" id="profile-photo-upload" size="48"/>
+					<input name="userfile" type="file" id="profile-photo-upload" required/>
 				</div>
 
 				<div class="profile-edit-submit-wrapper">

--- a/view/theme/frio/templates/settings/profile/index.tpl
+++ b/view/theme/frio/templates/settings/profile/index.tpl
@@ -44,7 +44,7 @@
 							<form enctype="multipart/form-data" action="settings/profile/photo" method="post">
 								<input type="hidden" name="form_security_token" value="{{$form_security_token_photo}}">
 									<div id="profile-photo-upload-wrapper">
-										<input name="userfile" type="file" id="profile-photo-upload" size="48" />
+										<input name="userfile" type="file" id="profile-photo-upload" required/>
 									</div>
 									<div class="profile-edit-submit-wrapper">
 										<button type="submit" name="submit" class="profile-edit-submit-button btn btn-primary">{{$l10n.profpic_upload_submit}}</button>


### PR DESCRIPTION
...as discussed in #15178, reported by @foss-, with a client side solution suggested by @haheute

The purpose is to do client/user side prevention of a server error which occurs if you click the submit button without first selecting a file.

It's done in both Frio and Vier (the non-Frio specific template file).

Also the `size` attribute on the field is removed as it has no effect.

A task for a possible follow-up PR could be to add server side handling for it as well.