### PR TITLE
Terminology: Send PM -> Message

### DIFF
--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -436,7 +436,7 @@ class Item
 				$this->l10n->t('View Photos')                                 => $photos_link,
 				$this->l10n->t('Network Posts')                               => $posts_link,
 				$this->l10n->t('View Contact')                                => $contact_url,
-				$this->l10n->t('Send PM')                                     => $pm_url,
+				$this->l10n->t('Message')                                     => $pm_url,
 				$this->l10n->t('Block')                                       => $block_link,
 				$this->l10n->t('Ignore')                                      => $ignore_link,
 				$this->l10n->t('Collapse')                                    => $collapse_link,

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -319,7 +319,7 @@ class Nav
 			$nav['messages']['new']    = ['message/new', $this->l10n->t('New Message'), '', $this->l10n->t('New Message')];
 
 			if (User::hasIdentities($this->session->getSubManagedUserId() ?: $this->session->getLocalUserId())) {
-				$nav['delegation'] = ['delegation', $this->l10n->t('Accounts'), '', $this->l10n->t('Manage other pages')];
+				$nav['delegation'] = ['delegation', $this->l10n->t('Accounts'), '', $this->l10n->t('Manage other accounts, including groups and pages')];
 			}
 
 			$nav['settings'] = ['settings', $this->l10n->t('Settings'), '', $this->l10n->t('Account settings')];

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1301,7 +1301,7 @@ class Contact
 				'photos'   => [DI::l10n()->t('View Photos'), $photos_link, true],
 				'network'  => [$network_label, $network_url, false],
 				'edit'     => [DI::l10n()->t('View Contact'), $contact_url, false],
-				'pm'       => [DI::l10n()->t('Send PM'), $pm_url, false],
+				'pm'       => [DI::l10n()->t('Message'), $pm_url, false],
 				'follow'   => [DI::l10n()->t('Connect/Follow'), $follow_link, true],
 				'unfollow' => [DI::l10n()->t('Unfollow'), $unfollow_link, true],
 				'mention'  => [$mention_label, $mention_url, false],

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-20 02:09+0200\n"
+"POT-Creation-Date: 2025-09-20 20:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2198,7 +2198,7 @@ msgid "Accounts"
 msgstr ""
 
 #: src/Content/Nav.php:322
-msgid "Manage other pages"
+msgid "Manage other accounts, including groups and pages"
 msgstr ""
 
 #: src/Content/Nav.php:325 src/Module/Admin/Addons/Details.php:140

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-19 20:31+0200\n"
+"POT-Creation-Date: 2025-09-20 02:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1377,7 +1377,8 @@ msgstr ""
 msgid "Public post"
 msgstr ""
 
-#: src/Content/Conversation.php:417 src/Content/Widget/VCard.php:120
+#: src/Content/Conversation.php:417 src/Content/Item.php:439
+#: src/Content/Widget/VCard.php:120 src/Model/Contact.php:1304
 #: src/Model/Profile.php:460 src/Module/Admin/Logs/View.php:80
 #: src/Module/Post/Edit.php:177
 msgid "Message"
@@ -1885,10 +1886,6 @@ msgstr ""
 #: src/Content/Item.php:438 src/Model/Contact.php:1292
 #: src/Model/Contact.php:1303
 msgid "View Contact"
-msgstr ""
-
-#: src/Content/Item.php:439 src/Model/Contact.php:1304
-msgid "Send PM"
 msgstr ""
 
 #: src/Content/Item.php:440 src/Module/Contact.php:453


### PR DESCRIPTION
In most of Friendica it's called a "Message", but in two places it's called "PM" (specifically "Send PM").

This changes those two to "Message".

This is also because @randompenguin1 mentioned working on the hovercard for their theme, and wanting to move the text from a title shown on hover to the buttons themselves, so consistency becomes more important.

Edit: Also added this minor adjustment:
"Manage other pages" -> "Manage other accounts, including groups and pages" shown when hovering "Accounts" in the user menu.