### PR TITLE
Search text -> Raw content, Languages -> Detected languages (credit to randompenguin1)

### DIFF
--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -444,10 +444,10 @@ class Item
 			];
 
 			if (!empty($item['language'])) {
-				$menu[$this->l10n->t('Languages')] = 'javascript:displayLanguage(' . $item['uri-id'] . ');';
+				$menu[$this->l10n->t('Detected languages')] = 'javascript:displayLanguage(' . $item['uri-id'] . ');';
 			}
 
-			$menu[$this->l10n->t('Search Text')] = 'javascript:displaySearchText(' . $item['uri-id'] . ');';
+			$menu[$this->l10n->t('Raw content')] = 'javascript:displaySearchText(' . $item['uri-id'] . ');';
 
 			if ((($cid == 0) || ($rel == Contact::FOLLOWER)) &&
 				in_array($item['network'], Protocol::FEDERATED)

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -505,7 +505,7 @@ class Post
 		$languages = [];
 		$language  = '';
 		if (!empty($item['language'])) {
-			$languages = DI::l10n()->t('Languages');
+			$languages = DI::l10n()->t('Detected languages');
 			$language  = array_key_first(json_decode($item['language'], true));
 		}
 
@@ -588,7 +588,7 @@ class Post
 			'filer'                  => $filer,
 			'language'               => $languages,
 			'lang'                   => $language,
-			'searchtext'             => DI::l10n()->t('Search Text'),
+			'searchtext'             => DI::l10n()->t('Raw content'),
 			'drop'                   => $drop,
 			'block'                  => $block,
 			'ignore_author'          => $ignore,

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-20 20:37+0200\n"
+"POT-Creation-Date: 2025-09-21 16:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1914,13 +1914,12 @@ msgstr ""
 msgid "Ignore %s server"
 msgstr ""
 
-#: src/Content/Item.php:447 src/Module/Settings/Channels.php:188
-#: src/Module/Settings/Channels.php:214 src/Object/Post.php:508
-msgid "Languages"
+#: src/Content/Item.php:447 src/Object/Post.php:508
+msgid "Detected languages"
 msgstr ""
 
 #: src/Content/Item.php:450 src/Object/Post.php:591
-msgid "Search Text"
+msgid "Raw content"
 msgstr ""
 
 #: src/Content/Item.php:455 src/Content/Widget.php:65
@@ -2287,11 +2286,11 @@ msgstr ""
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2175
+#: src/Content/Text/BBCode.php:2164
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2194
+#: src/Content/Text/BBCode.php:2183
 msgid "Invalid link protocol"
 msgstr ""
 
@@ -9578,6 +9577,10 @@ msgstr ""
 
 #: src/Module/Settings/Channels.php:184 src/Module/Settings/Channels.php:210
 msgid "Full Text Search"
+msgstr ""
+
+#: src/Module/Settings/Channels.php:188 src/Module/Settings/Channels.php:214
+msgid "Languages"
 msgstr ""
 
 #: src/Module/Settings/Channels.php:188

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -227,12 +227,12 @@
 
 						{{if $item.language}}
 						<li role="menuitem">
-							<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item language-icon" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&nbsp;{{$item.language}}</a>
+							<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&nbsp;{{$item.language}}</a>
 						</li>
 						{{/if}}
 
 						<li role="menuitem">
-							<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item search-icon" title="{{$item.searchtext}}"><i class="fa fa-search" aria-hidden="true"></i>&nbsp;{{$item.searchtext}}</a>
+							<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&nbsp;{{$item.searchtext}}</a>
 						</li>
 
 						{{if $item.browsershare}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -443,12 +443,12 @@ as the value of $top_child_total (this is done at the end of this file)
 
 				{{if $item.language}}
 				<li role="menuitem">
-						<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item language-icon" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
+						<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
 				</li>
 				{{/if}}
 
 				<li role="menuitem">
-						<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item search-icon" title="{{$item.searchtext}}"><i class="fa fa-search" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
+						<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
 				</li>
 
 				{{if $item.browsershare}}
@@ -630,12 +630,12 @@ as the value of $top_child_total (this is done at the end of this file)
 
 							{{if $item.language}}
 								<li role="menuitem">
-									<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item language-icon" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
+									<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
 								</li>
 							{{/if}}
 
 							<li role="menuitem">
-								<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item search-icon" title="{{$item.searchtext}}"><i class="fa fa-search" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
+								<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
 							</li>
 
 							{{if ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread) && ($item.ignore || ($item.drop && $item.drop.dropping))}}


### PR DESCRIPTION
Based on the discussion in:
https://friendica.world/display/8aa28c03-2068-c879-554d-bac389216069
...with credit to @randompenguin1

Changes the terms for two things in the dropdown menu for a post:
Search text -> Raw content (which is what it is, and the name of the method)
Languages -> Detected languages

Also the icon is updated for "Raw content".

Longer term, I'm wondering whether these ought to be hidden by default, and then maybe only visible to admins, or only visible if you enable them under "Advanced settings" or something like that?

# Before

<img width="177" height="264" alt="image" src="https://github.com/user-attachments/assets/3c3e443f-27e0-468a-8788-384d9a0ae778" />

# After

<img width="194" height="257" alt="image" src="https://github.com/user-attachments/assets/37fa94d2-4cda-4af6-8850-1c8ab5bf7741" />