### PR TITLE
Photos updates (mostly Frio)

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -88,7 +88,7 @@ function photos_init()
 				'$title'    => DI::l10n()->t('Photo Albums'),
 				'$recent'   => DI::l10n()->t('Recent Photos'),
 				'$albums'   => $ret['albums'],
-				'$upload'   => [DI::l10n()->t('Upload New Photos'), 'photos/' . $owner['nickname'] . '/upload'],
+				'$upload'   => [DI::l10n()->t('Upload Photos'), 'photos/' . $owner['nickname'] . '/upload'],
 				'$can_post' => $can_post
 			]);
 		}
@@ -782,7 +782,7 @@ function photos_content()
 			}
 		} elseif ($can_post) {
 			$edit = [DI::l10n()->t('Edit Album'), 'photos/' . $user['nickname'] . '/album/' . bin2hex($album) . '/edit'];
-			$drop = [DI::l10n()->t('Drop Album'), 'photos/' . $user['nickname'] . '/album/' . bin2hex($album) . '/drop'];
+			$drop = [DI::l10n()->t('Delete album'), 'photos/' . $user['nickname'] . '/album/' . bin2hex($album) . '/drop'];
 		}
 
 		if ($order_field === 'created') {
@@ -824,7 +824,7 @@ function photos_content()
 			'$photos'   => $photos,
 			'$album'    => $album,
 			'$can_post' => $can_post,
-			'$upload'   => [DI::l10n()->t('Upload New Photos'), 'photos/' . $user['nickname'] . '/upload/' . bin2hex($album)],
+			'$upload'   => [DI::l10n()->t('Upload Photos'), 'photos/' . $user['nickname'] . '/upload/' . bin2hex($album)],
 			'$order'    => $order,
 			'$edit'     => $edit,
 			'$drop'     => $drop,

--- a/src/Module/Profile/Photos.php
+++ b/src/Module/Profile/Photos.php
@@ -419,7 +419,7 @@ class Photos extends \Friendica\Module\BaseProfile
 				'$title'    => $this->t('Photo Albums'),
 				'$recent'   => $this->t('Recent Photos'),
 				'$albums'   => $albums,
-				'$upload'   => [$this->t('Upload New Photos'), 'photos/' . $this->owner['nickname'] . '/upload'],
+				'$upload'   => [$this->t('Upload Photos'), 'photos/' . $this->owner['nickname'] . '/upload'],
 				'$can_post' => $this->session->getLocalUserId() && $this->owner['uid'] == $this->session->getLocalUserId(),
 			]);
 		}
@@ -439,7 +439,7 @@ class Photos extends \Friendica\Module\BaseProfile
 		$o .= Renderer::replaceMacros($tpl, [
 			'$title'      => $this->t('Recent Photos'),
 			'$can_post'   => $is_owner,
-			'$upload'     => [$this->t('Upload New Photos'), 'photos/' . $this->owner['nickname'] . '/upload'],
+			'$upload'     => [$this->t('Upload Photos'), 'photos/' . $this->owner['nickname'] . '/upload'],
 			'$photos'     => $photos,
 			'$paginate'   => $pager->renderFull($total),
 			'upload_text' => $this->t('Upload Photos'),

--- a/view/templates/photo_album.tpl
+++ b/view/templates/photo_album.tpl
@@ -21,7 +21,7 @@
 <div class="photo-album-image-wrapper" id="photo-album-image-wrapper-{{$photo.id}}">
 	<a href="{{$photo.link}}" class="photo-album-photo-link" id="photo-album-photo-link-{{$photo.id}}" title="{{$photo.title}}">
 		<img src="{{$photo.src}}" alt="{{if $photo.album.name}}{{$photo.album.name}}{{elseif $photo.desc}}{{$photo.desc}}{{elseif $photo.alt}}{{$photo.alt}}{{else}}{{$photo.unknown}}{{/if}}" title="{{$photo.title}}" class="photo-album-photo lframe resize{{$photo.twist}}" id="photo-album-photo-{{$photo.id}}" />
-		<p class="caption" dir="auto">{{$photo.desc}}</p>		
+		<p class="caption" dir="auto">{{$photo.desc}}</p>
 	</a>
 </div>
 <div class="photo-album-image-wrapper-end"></div>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -214,6 +214,14 @@ details summary {
 	display: none;
 }
 
+#confirm-message {
+	margin-bottom: 30px;
+}
+
+#confirm-form .settings-submit-wrapper {
+	margin-bottom: 0;
+}
+
 /*
 * Overwriting and Extend Bootstrap
 */
@@ -2809,6 +2817,9 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 }
 
 /* photos */
+.photo-album-edit-name, #photo-album-edit-submit {
+	display: inline-block;
+}
 #photo-album-edit-name-label {
 	width: 100%;
 }
@@ -2827,7 +2838,7 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 	margin-top: 15px;
 }
 
-#photo-toprofile-link, .photo-back-link {
+#photo-toprofile-link, .photo-back-link, #album-drop-link {
 	margin-right: 25px;
 }
 
@@ -3006,6 +3017,8 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 }
 /* Photos Pages */
 #photo-photo {
+	margin: 0 auto !important;
+	max-width: 100%;
 	position: relative;
 }
 .photo-next-link,

--- a/view/theme/frio/frameworks/justifiedGallery/justifiedGallery.min.css
+++ b/view/theme/frio/frameworks/justifiedGallery/justifiedGallery.min.css
@@ -7,19 +7,31 @@
 .justified-gallery {
   width: 100%;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: start;
+  height: auto!important;
+  max-height: 100%;
 }
 .justified-gallery > a,
 .justified-gallery > div,
 .justified-gallery > figure {
-  position: absolute;
+  height: 180px !important;
+  width: 180px !important;
+ /* These three can probably be removed? */
+  position: relative;
+  top: auto !important;
+  left: auto !important;
+  border: 1px solid #ccc;
   display: inline-block;
   overflow: hidden;
   /* background: #888888; To have gray placeholders while the gallery is loading with waitThumbnailsLoad = false */
   filter: "alpha(opacity=10)";
   opacity: 0.1;
   margin: 0;
-  padding: 0;
+  border-radius: 8px;
+  margin: 4px !important;
 }
 .justified-gallery > a > img,
 .justified-gallery > div > img,
@@ -84,6 +96,13 @@
   -moz-transition: opacity 500ms ease-in;
   -o-transition: opacity 500ms ease-in;
   transition: opacity 500ms ease-in;
+  width: 100% !important;
+  height:  100% !important;
+  margin: 0 !important;
+  top: 0 !important;
+  left: 0 !important;
+  object-fit: contain;
+  object-position: center;
 }
 .justified-gallery > .jg-filtered {
   display: none;

--- a/view/theme/frio/templates/album_edit.tpl
+++ b/view/theme/frio/templates/album_edit.tpl
@@ -7,14 +7,12 @@
 <div id="photo-album-edit-wrapper">
 	<form name="photo-album-edit-form" id="photo-album-edit-form" action="photos/{{$nickname}}/album/{{$hexalbum}}" method="post">
 		<label id="photo-album-edit-name-label" for="photo-album-edit-name">{{$nametext}}</label>
-		<div class="pull-left photo-album-edit-name">
+		<div class="photo-album-edit-name">
 			<input class="form-control" type="text" size="64" name="albumname" value="{{$album}}" id="photo-album-edit-name">
 		</div>
 
-		<div class="pull-right">
+		<div id="photo-album-edit-submit">
 			<input class="btn-primary btn btn-small" id="photo-album-edit-submit" type="submit" name="submit" value="{{$submit}}" />
 		</div>
 	</form>
-	<div class="clear"></div>
 </div>
-<div class="clear"></div>

--- a/view/theme/frio/templates/confirm.tpl
+++ b/view/theme/frio/templates/confirm.tpl
@@ -12,4 +12,5 @@
 		<button type="submit" name="{{$confirm_name}}" id="confirm-submit-button" class="btn btn-primary confirm-button" value="{{$confirm_value}}">{{$l10n.confirm}}</button>
 		<button type="submit" name="canceled" value="{{$l10n.cancel}}" id="confirm-cancel-button" class="btn confirm-button" data-dismiss="modal">{{$l10n.cancel}}</button>
 	</div>
+	<div class="clear"></div>
 </form>

--- a/view/theme/frio/templates/photo_album.tpl
+++ b/view/theme/frio/templates/photo_album.tpl
@@ -5,34 +5,33 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div class="generic-page-wrapper">
-	<div class="pull-left">
+	<div style="display: inline-block">
 		<h3 id="photo-album-title">{{$album}}</h3>
 	</div>
 
 	<div class="photo-album-actions pull-right">
 		{{if $can_post}}
-		<a class="btn btn-primary photos-upload-link page-action" href="{{$upload.1}}" title="{{$upload.0}}" data-toggle="tooltip">
+		<a class="btn btn-primary photos-upload-link page-action" href="{{$upload.1}}">
 			<i class="fa fa-plus"></i>
-			{{$upload_text}}
+			{{$upload.0}}
 		</a>
 		{{/if}}
 
 		{{if $edit}}
-		<span class="icon-padding"> </span>
-		<button id="album-edit-link" class="btn-link page-action faded-icon" type="button" data-modal-url="{{$edit.1}}" title="{{$edit.0}}" data-toggle="tooltip">
+		<button id="album-edit-link" class="btn btn-primary page-action" type="button" data-modal-url="{{$edit.1}}">
 			<i class="fa fa-pencil"></i>
+			{{$edit.0}}
 		</button>
 		{{/if}}
 		{{if $drop}}
-		<span class="icon-padding"> </span>
-		<button id="album-drop-link" class="btn-link page-action faded-icon" type="button" data-modal-url="{{$drop.1}}" title="{{$drop.0}}" data-toggle="tooltip">
+		<button id="album-drop-link" class="btn btn-primary page-action" type="button" data-modal-url="{{$drop.1}}">
 			<i class="fa fa-trash"></i>
+			{{$drop.0}}
 		</button>
 		{{/if}}
 
 		{{if ! $noorder}}
-		<span class="icon-padding"> </span>
-		<a class="photos-order-link page-action faded-icon" href="{{$order.1}}" title="{{$order.0}}" data-toggle="tooltip">
+		<a class="photos-order-link page-action" href="{{$order.1}}" title="{{$order.0}}" data-toggle="tooltip">
 			{{if $order.2 == "newest"}}
 			<i class="fa fa-sort-numeric-desc"></i>
 			{{else}}
@@ -41,7 +40,6 @@
 		</a>
 		{{/if}}
 	</div>
-	<div class="clear"></div>
 
 	<div class="photo-album-wrapper" id="photo-album-contents">
 		{{foreach $photos as $photo}}

--- a/view/theme/frio/templates/photo_view.tpl
+++ b/view/theme/frio/templates/photo_view.tpl
@@ -11,38 +11,39 @@
 
 <div id="photo-view-{{$id}}" class="generic-page-wrapper">
 	<div class="pull-left" id="photo-edit-link-wrap">
-		<a class="page-action faded-icon" id="photo-album-link" href="{{$album.0}}" title="{{$album.1}}" data-toggle="tooltip">
-			<i class="fa fa-folder-open"></i>&nbsp;{{$album.1}}
+		<a class="page-action faded-icon" id="photo-album-link" href="{{$album.0}}">
+			<i class="fa fa-folder-open"></i>
+			{{$album.1}}
 		</a>
 	</div>
 	<div class="pull-right" id="photo-edit-link-wrap">
 {{if $tools}}
 	{{if $tools.view}}
-		<a id="photo-edit-link" class="btn btn-primary photo-back-link" href="{{$tools.view.0}}" data-toggle="tooltip">
+		<a id="photo-edit-link" class="btn btn-primary photo-back-link" href="{{$tools.view.0}}">
 			<i class="page-action fa fa-mail-reply"></i>
 			 {{$back_to_viewing_text}}
 		</a>
 	{{/if}}
 	{{if $tools.edit}}
-		<a id="photo-edit-link" class="btn btn-primary" href="{{$tools.edit.0}}" data-toggle="tooltip">
+		<a id="photo-edit-link" class="btn btn-primary" href="{{$tools.edit.0}}">
 			 <i class="page-action fa fa-pencil"></i>
 			 {{$edit_text}}
 		</a>
 	{{/if}}
 	{{if $tools.delete}}
-		<a id="photo-edit-link" class="btn btn-primary" href="{{$tools.delete.0}}" data-toggle="tooltip">
+		<a id="photo-delete-link" class="btn btn-primary" href="{{$tools.delete.0}}">
 			<i class="page-action fa fa-trash"></i>
 			{{$delete_text}}
 		</a>
 	{{/if}}
 	{{if $tools.profile}}
-		<a id="photo-toprofile-link" class="btn btn-primary" href="{{$tools.profile.0}}" data-toggle="tooltip">
+		<a id="photo-toprofile-link" class="btn btn-primary" href="{{$tools.profile.0}}">
 			<i class="page-action fa fa-user"></i>
 			{{$use_as_profile_picture_text}}
 		</a>
 	{{/if}}
 	{{if $tools.lock}}
-		<a id="photo-lock-link" onclick="lockview(event, 'photo', {{$id}});" title="{{$tools.lock}}" data-toggle="tooltip">
+		<a id="photo-lock-link" onclick="lockview(event, 'photo', {{$id}});" title="{{$tools.lock}}">
 			<i class="page-action fa fa-lg fa-lock faded-icon"></i>
 		</a>
 	{{/if}}


### PR DESCRIPTION
This does a few things in the Photos section:

**The grid display used by Bookface is essentially upstreamed/copied to Frio.**

This was mostly done because #15188 revealed that the photo album a photo is in was no longer shown on hover, and I found out that in some cases there wouldn't be space to even show it, because images in there aren't fixed size.

All credits to @randompenguin1 for that improvement

**The album page is updated to fit the new styling of the rest of the gallery, with text on the buttons**

It was missed previously.

**The form to delete an album turned out to be visually broken - that's been fixed**

---

And a few small things:

- "Upload new photos", written in some places, is simplified to "Upload photos".
- "Drop album" is renamed to "Delete album".
- A bit of related HTML/CSS cleanup.

# Before

<img width="674" height="520" alt="image" src="https://github.com/user-attachments/assets/e45c53bb-a261-4aaa-99d3-1b86e3e3347c" />

<img width="683" height="226" alt="image" src="https://github.com/user-attachments/assets/ab1ad471-588e-4957-a6ef-945a8dd3a74c" />

<img width="675" height="144" alt="image" src="https://github.com/user-attachments/assets/b3329be0-827e-4cde-ad96-7ad68c8f9eb1" />

# After

New grid layout:
<img width="662" height="1224" alt="image" src="https://github.com/user-attachments/assets/bb0b0f61-54d4-4694-876c-fd1b064aaeb8" />

Restyled buttons when editing an album:
<img width="670" height="478" alt="image" src="https://github.com/user-attachments/assets/84f7cb3c-9b10-4b5e-b17e-2d5450e6f292" />

<img width="673" height="182" alt="image" src="https://github.com/user-attachments/assets/b6f1605f-a857-4389-9f36-07e8542e6391" />
