### PR TITLE
Fix exception when processing Peertube videos

### DIFF
--- a/src/Factory/Api/Mastodon/Account.php
+++ b/src/Factory/Api/Mastodon/Account.php
@@ -95,7 +95,7 @@ class Account extends BaseFactory
 				// Create a default source object if the request is done by the profile owner
 				// Friendica doesn't support roles, so we create a dummy role object
 				$role = new \Friendica\Object\Api\Mastodon\Role(1, 'User', '#000000', '0000000', false);
-				$note = BBCode::toPlaintext($account['about'], true);
+				$note = BBCode::toPlaintext($account['about'] ?? '', true);
 
 				$user = User::getById($profile_uid, ['allow_gid', 'allow_cid', 'deny_gid', 'deny_cid']);
 				if ($user['allow_gid'] || $user['allow_cid'] || $user['deny_gid'] || $user['deny_cid']) {

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1851,7 +1851,7 @@ class Receiver
 				continue;
 			}
 
-			if ($mediatype == 'text/html' && $href != $id) {
+			if ($mediatype === 'text/html' && ($href != $id || $alternateUrl === '')) {
 				$alternateUrl = $href;
 			}
 		}
@@ -2121,7 +2121,7 @@ class Receiver
 		if (in_array($object_data['object_type'], ['as:Audio', 'as:Video'])) {
 			$object_data['alternate-url'] = self::extractAlternateUrl($object['as:url'] ?? [], $object_data['id']) ?: $object_data['alternate-url'];
 
-			$siteinfo = ParseUrl::getSiteinfoCached($object_data['alternate-url']);
+			$siteinfo = ParseUrl::getSiteinfoCached($object_data['alternate-url'] ?? '');
 			if (isset($siteinfo['player'])) {
 				$player = $siteinfo['player'];
 			} else {


### PR DESCRIPTION
This fixes the exception `Friendica\Util\ParseUrl::getSiteinfoCached(): Argument #1 ($url) must be of type string, null given`