### PR TITLE
Fix photo album hover effect for Frio theme

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1650,6 +1650,38 @@ textarea.comment-edit-text:focus + .comment-edit-form .preview {
 .fbrowser.photo .photo-album-image-wrapper .jg-caption {
 	pointer-events: none;
 }
+
+/* Photo album hover effect using jg-caption */
+.photo-top-image-wrapper {
+	position: relative;
+	display: inline-block;
+}
+
+.photo-top-image-wrapper .jg-caption {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	background-color: rgba(0, 0, 0, 0.7);
+	color: #fff;
+	padding: 8px 12px;
+	font-size: 14px;
+	text-align: center;
+	opacity: 0;
+	visibility: hidden;
+	transition: opacity 0.3s ease, visibility 0.3s ease;
+	pointer-events: none;
+}
+
+.photo-top-image-wrapper:hover .jg-caption {
+	opacity: 1;
+	visibility: visible;
+}
+
+.photo-top-image-wrapper .jg-caption a {
+	color: #fff;
+	text-decoration: none;
+}
 .fbrowser .profile-rotator-wrapper {
 	min-height: 200px;
 }

--- a/view/theme/frio/templates/photo_top.tpl
+++ b/view/theme/frio/templates/photo_top.tpl
@@ -4,7 +4,9 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<a href="{{$photo.link}}" id="photo-top-photo-link-{{$photo.id}}" title="{{$photo.title}}">
-	<img src="{{$photo.src}}" alt="{{if $photo.album.name}}{{$photo.album.name}}{{elseif $photo.desc}}{{$photo.desc}}{{elseif $photo.alt}}{{$photo.alt}}{{else}}{{$photo.unknown}}{{/if}}" title="{{$photo.title}}" id="photo-top-photo-{{$photo.id}}" />
-</a>
-
+<div class="photo-top-image-wrapper" id="photo-top-image-wrapper-{{$photo.id}}">
+	<a href="{{$photo.link}}" id="photo-top-photo-link-{{$photo.id}}" title="{{$photo.title}}">
+		<img src="{{$photo.src}}" alt="{{if $photo.album.name}}{{$photo.album.name}}{{elseif $photo.desc}}{{$photo.desc}}{{elseif $photo.alt}}{{$photo.alt}}{{else}}{{$photo.unknown}}{{/if}}" title="{{$photo.title}}" id="photo-top-photo-{{$photo.id}}" />
+	</a>
+	<div class="jg-caption"><a href="{{$photo.album.link}}" class="photo-top-album-link" title="{{$photo.album.alt}}">{{$photo.album.name}}</a></div>
+</div>


### PR DESCRIPTION
This fixes the mussing jg.caption (Photo.album.name) in the frio theme.

Behavior after the fix:
<img width="164" height="109" alt="image" src="https://github.com/user-attachments/assets/20b64dfd-06e2-4e66-bceb-5bf753afd329" />

fixes #15188
