### PR TITLE
PHP-Warning: hex2bin validation in Search module

### DIFF
--- a/src/Module/Search/Saved.php
+++ b/src/Module/Search/Saved.php
@@ -15,6 +15,7 @@ use Friendica\Database\Database;
 use Friendica\DI;
 use Friendica\Module\Response;
 use Friendica\Util\Profiler;
+use Friendica\Util\Strings;
 use Psr\Log\LoggerInterface;
 
 class Saved extends BaseModule
@@ -34,7 +35,7 @@ class Saved extends BaseModule
 		$action = $this->args->get(2, 'none');
 		$search = trim(rawurldecode($_GET['term'] ?? ''));
 
-		if (!empty($_GET['return_url'])) {
+		if (!empty($_GET['return_url']) && Strings::isHex($_GET['return_url'])) {
 			$return_url = hex2bin($_GET['return_url']);
 		} else {
 			$return_url = Search::getSearchPath($search);


### PR DESCRIPTION
Add additional hexadecimal validation before calling hex2bin() in src/Module/Search/Saved.php to prevent PHP warnings when invalid input is provided via $_GET['return_url'] parameter with fallback to Search::getSearchPath() for invalid hex strings

Resolves: PHP Warning: hex2bin(): Input string must be hexadecimal string

<img width="1721" height="701" alt="image" src="https://github.com/user-attachments/assets/e504bd05-068d-4d04-8579-eb9c82d07305" />
