### PR TITLE
UI: Fix messages overflow as the textarea expands

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2746,9 +2746,6 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 */
 	list-style-type: none;
 }
-.mail-thread {
-	max-height: calc(100vh - 200px);
-}
 #mail-conversation {
 	overflow-y: auto;
 	max-height: calc(100vh - 400px);


### PR DESCRIPTION
When I made it possible for the textarea to expand in Messages (/message) with long messages it breaks the layout (the buttons below the text area break outside the background).

This small change makes the parent element expand with it, removing the height limit on it.

Before:
<img width="677" height="550" alt="image" src="https://github.com/user-attachments/assets/d73694c4-8b33-4337-8edf-5a677c6537b3" />

After:
<img width="687" height="584" alt="image" src="https://github.com/user-attachments/assets/5e86132d-1d1d-40c1-841a-3fa4c4823f37" />