### PR TITLE
Remove notification: "Contact successfully unfollowed"

### DIFF
--- a/src/Module/Contact/Unfollow.php
+++ b/src/Module/Contact/Unfollow.php
@@ -158,13 +158,12 @@ class Unfollow extends \Friendica\BaseModule
 
 		try {
 			Contact::unfollow($contact);
-			$notice_message = $this->t('Contact was successfully unfollowed');
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['contact' => $contact]);
 			$notice_message = $this->t('Unable to unfollow this contact, please contact your administrator');
+			$this->systemMessages->addNotice($notice_message);
 		}
 
-		$this->systemMessages->addNotice($notice_message);
 		$this->baseUrl->redirect($return_path);
 	}
 }

--- a/src/Module/Notifications/Introductions.php
+++ b/src/Module/Notifications/Introductions.php
@@ -80,7 +80,7 @@ class Introductions extends BaseNotifications
 
 		$notificationResult = $this->getNotifications();
 		$notifications      = $notificationResult['notifications'] ?? [];
-		$notificationHeader = $notificationResult['header'] ?? '';
+		$notificationHeader = $notificationResult['header']        ?? '';
 
 		$notificationSuggestions = Renderer::getMarkupTemplate('notifications/suggestions.tpl');
 		$notificationTemplate    = Renderer::getMarkupTemplate('notifications/intros.tpl');
@@ -129,14 +129,14 @@ class Introductions extends BaseNotifications
 					]);
 					break;
 
-				// Normal connection requests
+					// Normal connection requests
 				default:
 					if ($Introduction->getNetwork() === Protocol::DFRN) {
 						$lbl_knowyou = $this->t('Claims to be known to you: ');
 						$knowyou     = ($Introduction->getKnowYou() ? $this->t('Yes') : $this->t('No'));
 					} else {
 						$lbl_knowyou = '';
-						$knowyou = '';
+						$knowyou     = '';
 					}
 
 					$convertedName = BBCode::toPlaintext($Introduction->getName(), false);
@@ -145,7 +145,7 @@ class Introductions extends BaseNotifications
 					$helptext2 = $this->t('Accepting %s as a friend allows %s to subscribe to your posts, and you will also receive updates from them in your news feed.', $convertedName, $convertedName);
 					$helptext3 = $this->t('Accepting %s as a subscriber allows them to subscribe to your posts, but you will not receive updates from them in your news feed.', $convertedName);
 
-					$friend = ['duplex', $this->t('Friend'), '1', $helptext2, true];
+					$friend   = ['duplex', $this->t('Friend'), '1', $helptext2, true];
 					$follower = ['duplex', $this->t('Subscriber'), '0', $helptext3, false];
 
 					$action = 'follow_confirm';
@@ -206,7 +206,6 @@ class Introductions extends BaseNotifications
 		}
 
 		if (count($notifications['notifications']) == 0) {
-			DI::sysmsg()->addNotice($this->t('No introductions.'));
 			$notificationNoContent = $this->t('No more %s notifications.', $notifications['ident']);
 		}
 

--- a/src/Worker/Contact/Unfollow.php
+++ b/src/Worker/Contact/Unfollow.php
@@ -45,7 +45,7 @@ class Unfollow
 		$result = Protocol::unfollow($contact, $owner);
 		if ($result === false) {
 			if (!Worker::defer(self::WORKER_DEFER_LIMIT)) {
-				Contact::removeSharer($contact);	
+				Contact::removeSharer($contact);
 			}
 		} else {
 			Contact::removeSharer($contact);

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-24 22:11+0200\n"
+"POT-Creation-Date: 2025-09-25 10:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6668,11 +6668,7 @@ msgstr ""
 msgid "Disconnect/Unfollow"
 msgstr ""
 
-#: src/Module/Contact/Unfollow.php:161
-msgid "Contact was successfully unfollowed"
-msgstr ""
-
-#: src/Module/Contact/Unfollow.php:164
+#: src/Module/Contact/Unfollow.php:163
 msgid "Unable to unfollow this contact, please contact your administrator"
 msgstr ""
 
@@ -8319,10 +8315,6 @@ msgid "Subscriber"
 msgstr ""
 
 #: src/Module/Notifications/Introductions.php:209
-msgid "No introductions."
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:210
 #: src/Module/Notifications/Notifications.php:127
 #, php-format
 msgid "No more %s notifications."


### PR DESCRIPTION
Removes this notification:
<img width="277" height="61" alt="image" src="https://github.com/user-attachments/assets/f66234f9-c74f-4636-a482-dbea9b21bfbe" />

...because when things go as expected and intended, a notification that Friendica is working shouldn't be necessary.
The notification in case of an error is kept.