### PR TITLE
Position the textcomplete window (BBcode dropdown) above the composer/jot modal

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2254,6 +2254,10 @@ nav .acpopup {
 img.acpopup-img {
 	border-radius: 4px;
 }
+/* Position the BBCode selector above the post/composer/JOT modal */
+.textcomplete-dropdown {
+	z-index: 1055!important;
+}
 
 /* The wall-item thread levels */
 .wall-item-container.thread_level_3,


### PR DESCRIPTION
Related to:  #15216

Not sure if this is the good solution, but it does seem to solve the issue.

Specifically it seems the z-index for it the bbcode dropdown is 100, while the z-index for the jot-modal is 1050.

This generally sets textcomplete-dropdown to z-index 1055. Not sure if:

1. It should instead be set in a way so it only applies to when textcomplete is used above the compose window?
2. It should be set elsewhere, as the current one is in style.css and it has to have `!important` because the existing `z-index` value it has, is from a style attribute directly on the element.