### PR TITLE
Fix z-index values for textcomplete suggestion list

### DIFF
--- a/view/js/autocomplete.js
+++ b/view/js/autocomplete.js
@@ -280,7 +280,7 @@ function string2bb(element) {
 		};
 
 		this.attr('autocomplete','off');
-		this.textcomplete([contacts, groups, smilies, tags], {dropdown: {className:'acpopup'}, debounce: 250});
+		this.textcomplete([contacts, groups, smilies, tags], {dropdownClassName: 'acpopup', debounce: 250, zIndex: 1050});
 		this.fixTextcompleteEscape();
 
 		return this;
@@ -315,7 +315,7 @@ function string2bb(element) {
 		};
 
 		this.attr('autocomplete', 'off');
-		this.textcomplete([contacts, community, tags], {dropdown: {className:'acpopup', maxCount:100}, debounce: 250});
+		this.textcomplete([contacts, community, tags], {dropdownClassName: 'acpopup', maxCount: 100, debounce: 250, zIndex: 1050});
 		this.fixTextcompleteEscape();
 		this.on('textComplete:select', function(e, value, strategy) { submit_form(this); });
 
@@ -336,7 +336,7 @@ function string2bb(element) {
 		};
 
 		this.attr('autocomplete','off');
-		this.textcomplete([names], {dropdown: {className:'acpopup'}, debounce: 250});
+		this.textcomplete([names], {dropdownClassName: 'acpopup', debounce: 250, zIndex: 1050});
 		this.fixTextcompleteEscape();
 
 		if(autosubmit) {
@@ -386,7 +386,7 @@ function string2bb(element) {
 		};
 
 		this.attr('autocomplete','off');
-		this.textcomplete([bbco], {dropdown: {className:'acpopup'}, debounce: 250});
+		this.textcomplete([bbco], {dropdownClassName: 'acpopup', debounce: 250, zIndex: 1050});
 		this.fixTextcompleteEscape();
 
 		this.on('textComplete:select', function(e, value, strategy) { value; });

--- a/view/theme/duepuntozero/style.css
+++ b/view/theme/duepuntozero/style.css
@@ -3044,14 +3044,12 @@ aside input[type='text'] {
 .acpopup {
 	background-color:#ffffff;
 	overflow:auto;
-	z-index:100000;
 	border:1px solid #cccccc;
 }
 .acpopup-mce {
 	max-height:150px;
 	background-color:#ffffff;
 	overflow:auto;
-	z-index:100000;
 	border:1px solid #cccccc;
 }
 .acpopupitem {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2230,7 +2230,6 @@ wall-item-comment-wrapper.well hr {
 	background-color: #ffffff;
 	border-radius: 4px;
 	overflow: auto;
-	z-index: 100000;
 	box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
 }
 nav .acpopup {
@@ -2240,13 +2239,13 @@ nav .acpopup {
  at the beginning of this file to get rid of the !important */
 .textcomplete-item > a {
 	color: $font_color_darker !important;
-	padding: 5px 20px !important;
+	border-left: 3px solid transparent;
+	padding: 5px 20px 5px 17px !important;
 }
 .textcomplete-item.active > a {
 	background-color: rgb(247, 247, 247) !important;
 	background-image: none !important;
-	border-left: 3px solid $link_color;
-	padding-left: 17px !important;
+	border-left-color: $link_color;
 }
 .textcomplete-item a .group {
 	color: $link_color;

--- a/view/theme/quattro/dark/style.css
+++ b/view/theme/quattro/dark/style.css
@@ -761,7 +761,6 @@ ul.menu-popup .toolbar a:hover {
   color: #2d2d2d;
   border: 1px solid #364e59;
   overflow: auto;
-  z-index: 100000;
   -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.7);
   -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.7);
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.7);

--- a/view/theme/quattro/green/style.css
+++ b/view/theme/quattro/green/style.css
@@ -761,7 +761,6 @@ ul.menu-popup .toolbar a:hover {
   color: #2d2d2d;
   border: 1px solid #364e59;
   overflow: auto;
-  z-index: 100000;
   -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.7);
   -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.7);
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.7);

--- a/view/theme/quattro/lilac/style.css
+++ b/view/theme/quattro/lilac/style.css
@@ -761,7 +761,6 @@ ul.menu-popup .toolbar a:hover {
   color: #2d2d2d;
   border: 1px solid #364e59;
   overflow: auto;
-  z-index: 100000;
   -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.7);
   -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.7);
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.7);

--- a/view/theme/quattro/quattro.less
+++ b/view/theme/quattro/quattro.less
@@ -279,7 +279,6 @@ ul.menu-popup {
 	color: @Menu;
 	border:1px solid @MenuBorder;
 	overflow:auto;
-	z-index:100000;
 	.shadow();
 }
 .autocomplete > div,

--- a/view/theme/smoothly/style.css
+++ b/view/theme/smoothly/style.css
@@ -937,7 +937,7 @@ li.widget-list {
 }
 
 #sidebar-new-circle,
-#sidebar-edit-circles, 
+#sidebar-edit-circles,
 #sidebar-new-group {
 	padding: 7px;
 	width: 165px;
@@ -4226,7 +4226,6 @@ a.active {
 /* autocomplete popup */
 .acpopup, acpopup-mce {
 	overflow: auto;
-	z-index: 100000;
 	color: #2e3436;
 	border-top: 0px;
 	background: #eeeeee;

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -935,7 +935,6 @@ ul.menu-popup .empty {
 	background-color: #ffffff;
 	border: 1px solid #MenuBorder;
 	overflow: auto;
-	z-index: 100000;
 	box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.7);
 }
 .acpopup-mce {


### PR DESCRIPTION
Fix #15216 

- The newer textcomplete version has a flat option list now
- The textcomplete z-index value is now defined in the $.textcomplete() calls instead of of the CSS