### PR TITLE
View as: "Submit" -> "View as selected profile" + delegation submit button styling

### DIFF
--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -285,7 +285,7 @@ class Profile extends BaseProfile
 			'$view_as_contact_id'    => $view_as_contact_id,
 			'$view_as_contact_alert' => $view_as_contact_alert,
 			'$view_as'               => $this->t('View profile as:'),
-			'$submit'                => $this->t('Submit'),
+			'$submit'                => $this->t('View as selected profile'),
 			'$basic'                 => $this->t('Basic'),
 			'$advanced'              => $this->t('Advanced'),
 			'$is_owner'              => $profile['uid'] == $this->session->getLocalUserId(),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-05 14:42+0200\n"
+"POT-Creation-Date: 2025-10-06 18:57+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -445,10 +445,10 @@ msgstr ""
 #: src/Module/Moderation/Report/Create.php:168
 #: src/Module/Moderation/Report/Create.php:196
 #: src/Module/Moderation/Report/Create.php:256
-#: src/Module/Profile/Profile.php:288 src/Module/Settings/Server/Action.php:65
-#: src/Module/User/Delegation.php:181 src/Object/Post.php:1159
-#: view/theme/duepuntozero/config.php:73 view/theme/frio/config.php:155
-#: view/theme/quattro/config.php:75 view/theme/vier/config.php:123
+#: src/Module/Settings/Server/Action.php:65 src/Module/User/Delegation.php:181
+#: src/Object/Post.php:1159 view/theme/duepuntozero/config.php:73
+#: view/theme/frio/config.php:155 view/theme/quattro/config.php:75
+#: view/theme/vier/config.php:123
 msgid "Submit"
 msgstr ""
 
@@ -8505,6 +8505,10 @@ msgstr ""
 
 #: src/Module/Profile/Profile.php:287
 msgid "View profile as:"
+msgstr ""
+
+#: src/Module/Profile/Profile.php:288
+msgid "View as selected profile"
 msgstr ""
 
 #: src/Module/Profile/Profile.php:298 src/Module/Profile/Profile.php:299

--- a/view/templates/settings/delegation.tpl
+++ b/view/templates/settings/delegation.tpl
@@ -22,7 +22,7 @@
             {{include file="field_select.tpl" field=$parent_user}}
             {{include file="field_password.tpl" field=$parent_password}}
 			<div class="submit">
-				<button type="submit" name="delegate" value="{{$l10n.submit}}">{{$l10n.submit}}</button>
+				<button type="submit" class="btn btn-primary" name="delegate" value="{{$l10n.submit}}">{{$l10n.submit}}</button>
 			</div>
 		</form>
 	</div>


### PR DESCRIPTION
Just a tiny PR that changes the activation button for "View as" from the vague, technical "Submit" into a more descriptive "View as selected profile".

This also allows translators to set their own unique names for it.

<img width="682" height="80" alt="image" src="https://github.com/user-attachments/assets/f0f11bd8-3cb5-4634-b8c4-2fcb7fba2e0e" />

-

Also this submit button is restyled from a regular gray submit button to using the accent colour:
<img width="501" height="335" alt="image" src="https://github.com/user-attachments/assets/e790248e-7bfd-4cb7-bc7d-7fd64012db55" />