### PR TITLE
Frio: Fix login UI broken for some languages

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2628,22 +2628,6 @@ body.mod-login .navbar #nav-login {
 	float: left;
 }
 
-#login-submit-button, #register-submit-button, #register-link {
-	font-size: 19px;
-	font-weight: normal;
-	width: 100%;
-}
-
-#openid-header {
-	font-size: 16px;
-	margin: 15px 0;
-}
-
-#new-here {
-	font-size: 20px;
-	margin-top: -5px;
-}
-
 /* contacts page */
 ul.viewcontact_wrapper {
 	margin-left: -15px;
@@ -3748,7 +3732,26 @@ div.login-form, .login-content-wrapper {
 #register-link {
 	background: #5aa071;
 	margin-bottom: 10px;
-	width: 75%;
+	min-width: 75%;
+}
+
+#login-submit-button, #register-submit-button, #register-link {
+	font-size: 19px;
+	font-weight: normal;
+}
+
+#login-submit-button, #register-submit-button {
+	min-width: 100%;
+}
+
+#openid-header {
+	font-size: 16px;
+	margin: 15px 0;
+}
+
+#new-here {
+	font-size: 20px;
+	margin-top: -5px;
 }
 
 div.login-form, .login-content-wrapper,


### PR DESCRIPTION
The register button was hardcoded to 80% which works fine in English, but not in German because the text is longer than that.

This PR changes it so instead of setting `width`, `min-width` is set. Then it will break the layout above a certain length, but that still seems better  than cutting it off.

# Before

<img width="695" height="627" alt="image" src="https://github.com/user-attachments/assets/4b3d5c74-45a4-447e-b7b7-cfecbc1baf30" />

# After

<img width="700" height="656" alt="image" src="https://github.com/user-attachments/assets/dc5fd482-6fd1-4a07-9f50-905fb1176b96" />

...or if the text is longer still:
<img width="842" height="644" alt="image" src="https://github.com/user-attachments/assets/17a26db8-7ffb-4b8a-b8f8-de8b9d69c5d0" />

Ideally in this case the entire container resized with it, but it's size is determined by the base template used everywhere so changing anything there is not a quick fix.