### PR TITLE
Improved iframe handling

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2025.07-rc (Interrupted Fern)
--- DB_UPDATE_VERSION 1582
+-- DB_UPDATE_VERSION 1583
 -- ------------------------------------------
 
 
@@ -1436,6 +1436,8 @@ CREATE TABLE IF NOT EXISTS `post-media` (
 	`embed-html` text COMMENT 'HTML embed code for this media',
 	`embed-height` smallint unsigned COMMENT 'Height of the embed',
 	`embed-width` smallint unsigned COMMENT 'Width of the embed',
+	`page-type` varchar(30) COMMENT 'Type of the page (e.g. article, website)',
+	`schematypes` varchar(255) COMMENT 'Schema types of the page as JSON string',
 	`language` char(3) COMMENT 'Language information about this media in the ISO 639 format',
 	`published` datetime COMMENT 'Publification date of this media',
 	`modified` datetime COMMENT 'Modification date of this media',

--- a/doc/database/db_post-media.md
+++ b/doc/database/db_post-media.md
@@ -37,6 +37,8 @@ Fields
 | embed-html      | HTML embed code for this media                                                      | text              | YES  |     | NULL    |                |
 | embed-height    | Height of the embed                                                                 | smallint unsigned | YES  |     | NULL    |                |
 | embed-width     | Width of the embed                                                                  | smallint unsigned | YES  |     | NULL    |                |
+| page-type       | Type of the page (e.g. article, website)                                            | varchar(30)       | YES  |     | NULL    |                |
+| schematypes     | Schema types of the page as JSON string                                             | varchar(255)      | YES  |     | NULL    |                |
 | language        | Language information about this media in the ISO 639 format                         | char(3)           | YES  |     | NULL    |                |
 | published       | Publification date of this media                                                    | datetime          | YES  |     | NULL    |                |
 | modified        | Modification date of this media                                                     | datetime          | YES  |     | NULL    |                |

--- a/src/Content/Post/Entity/PostMedia.php
+++ b/src/Content/Post/Entity/PostMedia.php
@@ -42,6 +42,8 @@ use Psr\Http\Message\UriInterface;
  * @property-read ?string $embedHtml
  * @property-read ?int $embedWidth
  * @property-read ?int $embedHeight
+ * @property-read ?string $pageType
+ * @property-read ?array $schemaTypes
  * @property-read ?int $attachId
  * @property-read ?string $language
  * @property-read ?string $published
@@ -131,6 +133,10 @@ class PostMedia extends BaseEntity
 	protected $embedWidth;
 	/** @var ?int In pixels */
 	protected $embedHeight;
+	/** @var ?string */
+	protected $pageType;
+	/** @var ?array */
+	protected $schemaTypes;
 
 	public function __construct(
 		int $uriId,
@@ -164,7 +170,9 @@ class PostMedia extends BaseEntity
 		?string $embedType = null,
 		?string $embedHtml = null,
 		?int $embedWidth = null,
-		?int $embedHeight = null
+		?int $embedHeight = null,
+		?string $pageType = null,
+		?array $schemaTypes = null
 	) {
 		$this->uriId          = $uriId;
 		$this->url            = $url;
@@ -198,8 +206,102 @@ class PostMedia extends BaseEntity
 		$this->embedHtml      = $embedHtml;
 		$this->embedWidth     = $embedWidth;
 		$this->embedHeight    = $embedHeight;
+		$this->pageType       = $pageType;
+		$this->schemaTypes    = $schemaTypes;
 	}
 
+	/**
+	 * Checks if the media has a player url set
+	 *
+	 * @return boolean
+	 */
+	public function hasPlayerUrl(): bool
+	{
+		return !is_null($this->playerUrl) && $this->playerUrl !== '';
+	}
+
+	/**
+	 * Checks if the media has a player width set
+	 *
+	 * @return boolean
+	 */
+	public function hasPlayerWidth(): bool
+	{
+		return !is_null($this->playerWidth) && $this->playerWidth > 0;
+	}
+
+	/**
+	 * Checks if the media has a player height set
+	 *
+	 * @return boolean
+	 */
+	public function hasPlayerHeight(): bool
+	{
+		return !is_null($this->playerHeight) && $this->playerHeight > 0;
+	}
+
+	/**
+	 * Checks if the media has an embed html set
+	 *
+	 * @return boolean
+	 */
+	public function hasEmbedHtml(): bool
+	{
+		return !is_null($this->embedHtml) && $this->embedHtml !== '';
+	}
+
+	/**
+	 * Checks if the media has an embed width set
+	 *
+	 * @return boolean
+	 */
+	public function hasEmbedWidth(): bool
+	{
+		return !is_null($this->embedWidth) && $this->embedWidth > 0;
+	}
+
+	/**
+	 * Checks if the media has an embed height set
+	 *
+	 * @return boolean
+	 */
+	public function hasEmbedHeight(): bool
+	{
+		return !is_null($this->embedHeight) && $this->embedHeight > 0;
+	}
+
+	/**
+	 * Checks if the media is a photo
+	 *
+	 * @return boolean
+	 */
+	public function isPhoto(): bool
+	{
+		return $this->embedType === 'photo';
+	}
+
+	/**
+	 * Checks if the media is a video
+	 *
+	 * @return boolean
+	 */
+	public function isVideo(): bool
+	{
+		return $this->embedType === 'video' || $this->getPageType() === 'video';
+	}
+
+	/**
+	 * Get the page type. In case of a type with main und sub category (separated by `.`), only the main category is returned
+	 *
+	 * @return string|null
+	 */
+	public function getPageType(): ?string
+	{
+		if (is_null($this->pageType)) {
+			return null;
+		}
+		return explode('.', $this->pageType)[0];
+	}
 
 	/**
 	 * Get media link for given media id
@@ -313,7 +415,9 @@ class PostMedia extends BaseEntity
 			$this->embedType,
 			$this->embedHtml,
 			$this->embedWidth,
-			$this->embedHeight
+			$this->embedHeight,
+			$this->pageType,
+			$this->schemaTypes
 		);
 	}
 
@@ -351,7 +455,9 @@ class PostMedia extends BaseEntity
 			$this->embedType,
 			$this->embedHtml,
 			$this->embedWidth,
-			$this->embedHeight
+			$this->embedHeight,
+			$this->pageType,
+			$this->schemaTypes
 		);
 	}
 

--- a/src/Content/Post/Factory/PostMedia.php
+++ b/src/Content/Post/Factory/PostMedia.php
@@ -68,7 +68,9 @@ class PostMedia extends BaseFactory implements ICanCreateFromTableRow
 			$row['embed-type'],
 			$row['embed-html'],
 			$row['embed-width'],
-			$row['embed-height']
+			$row['embed-height'],
+			$row['page-type'],
+			$row['schematypes'] ? json_decode($row['schematypes'], true) : null
 		);
 	}
 
@@ -141,6 +143,8 @@ class PostMedia extends BaseFactory implements ICanCreateFromTableRow
 			'embed-html'      => $attachment['embed_html']    ?? null,
 			'embed-width'     => $attachment['embed_width']   ?? null,
 			'embed-height'    => $attachment['embed_height']  ?? null,
+			'page-type'       => $attachment['page_type']     ?? null,
+			'schematypes'     => null,
 			'attach-id'       => null,
 			'language'        => null,
 			'published'       => null,
@@ -190,10 +194,12 @@ class PostMedia extends BaseFactory implements ICanCreateFromTableRow
 			'embed-html'      => $data['embed']['html']         ?? null,
 			'embed-width'     => $data['embed']['width']        ?? null,
 			'embed-height'    => $data['embed']['height']       ?? null,
+			'page-type'       => $data['pagetype']              ?? null,
 			'attach-id'       => null,
 			'language'        => $data['language']  ?? null,
 			'published'       => $data['published'] ?? null,
 			'modified'        => $data['modified']  ?? null,
+			'schematypes'     => isset($data['schematypes']) ? json_encode($data['schematypes']) : null,
 		];
 
 		return $this->createFromTableRow($row);

--- a/src/Content/Post/Repository/PostMedia.php
+++ b/src/Content/Post/Repository/PostMedia.php
@@ -150,6 +150,8 @@ class PostMedia extends BaseRepository
 			'embed-html'      => $PostMedia->embedHtml,
 			'embed-height'    => $PostMedia->embedHeight,
 			'embed-width'     => $PostMedia->embedWidth,
+			'page-type'       => $PostMedia->pageType,
+			'schematypes'     => $PostMedia->schemaTypes ? json_encode($PostMedia->schemaTypes) : null,
 			'attach-id'       => $PostMedia->attachId,
 			'language'        => $PostMedia->language,
 			'published'       => $PostMedia->published,
@@ -367,10 +369,10 @@ class PostMedia extends BaseRepository
 				$player = $this->getAudioAttachment($media);
 			} elseif (in_array($media->type, [Post\Media::VIDEO, Post\Media::HLS])) {
 				$player = $this->getVideoAttachment($media, $uid);
-			} elseif ($allow_embed && !empty($media->playerUrl)) {
+			} elseif ($allow_embed && $media->hasPlayerUrl() && $media->hasPlayerHeight()) {
 				$player = $this->getPlayerIframe($media);
-			} elseif ($allow_embed && !empty($media->embedHtml)) {
-				$player = '<span class="embedded-media">' . $this->getEmbedIframe($media) . '</span>';
+			} elseif ($allow_embed && $media->hasEmbedHtml() && !$media->isPhoto()) {
+				$player = $this->getEmbedIframe($media);
 			} else {
 				$player = $this->getLinkAttachment($media);
 			}
@@ -408,9 +410,9 @@ class PostMedia extends BaseRepository
 			$width  = '100%';
 		}
 
-		if ($this->pConfig->get($uid, 'system', 'embed_media', false) && ($postMedia->playerUrl != '') && ($postMedia->playerHeight > 0)) {
+		if ($this->pConfig->get($uid, 'system', 'embed_media', false) && $postMedia->hasPlayerUrl() && $postMedia->hasPlayerHeight()) {
 			$media = $this->getPlayerIframe($postMedia);
-		} elseif ($this->pConfig->get($uid, 'system', 'embed_media', false) && ($postMedia->embedHtml != '')) {
+		} elseif ($this->pConfig->get($uid, 'system', 'embed_media', false) && $postMedia->hasEmbedHtml() && !$postMedia->isPhoto()) {
 			$media = $this->getEmbedIframe($postMedia);
 		} else {
 			/// @todo Move the template to /content as well
@@ -436,22 +438,33 @@ class PostMedia extends BaseRepository
 			return '';
 		}
 
-		$div_style    = '';
 		$iframe_style = '';
-		$height       = min($this->config->get('system', 'max_height'), $postMedia->playerHeight);
+		$height       = '100%';
+		$width        = '100%';
 
-		if ($postMedia->playerWidth != 0 && $postMedia->playerHeight != 0 && $postMedia->playerWidth > $this->config->get('system', 'max_width') && $postMedia->playerWidth > $postMedia->playerHeight) {
-			$factor = round($postMedia->playerHeight / $postMedia->playerWidth, 2) * 100;
-			$height = '100%';
-			$iframe_style .= 'position:absolute;left:0px;top:0px;';
-			$div_style .= 'position:relative;padding-bottom:' . $factor . '%;';
+		if ($postMedia->isVideo()) {
+			if ($postMedia->hasPlayerWidth() && $postMedia->hasPlayerHeight()) {
+				$iframe_style .= 'aspect-ratio:' . $postMedia->playerWidth . '/' . $postMedia->playerHeight . ';';
+				if ($postMedia->playerWidth < $postMedia->playerHeight) {
+					$height = $postMedia->playerHeight;
+					$width  = '';
+				} else {
+					$height = '';
+				}
+			}
+		} else {
+			if ($postMedia->hasPlayerHeight()) {
+				$height = $postMedia->playerHeight . 'px';
+			}
+			if ($postMedia->hasPlayerWidth()) {
+				$width = $postMedia->playerWidth . 'px';
+			}
 		}
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('content/iframe.tpl'), [
 			'src'          => $postMedia->playerUrl,
 			'height'       => $height,
-			'width'        => $postMedia->embedWidth && $postMedia->embedWidth <= $this->config->get('system', 'max_width') ? $postMedia->embedWidth : '100%',
-			'div_style'    => $div_style,
+			'width'        => $width,
 			'iframe_style' => $iframe_style,
 		]);
 	}
@@ -462,11 +475,35 @@ class PostMedia extends BaseRepository
 			return '';
 		}
 
+		$iframe_style = '';
+		$height       = '100%';
+		$width        = '100%';
+
+		if ($postMedia->isVideo()) {
+			if ($postMedia->hasEmbedWidth() && $postMedia->hasEmbedHeight()) {
+				$iframe_style .= 'aspect-ratio:' . $postMedia->embedWidth . '/' . $postMedia->embedHeight . ';';
+				if ($postMedia->embedWidth < $postMedia->embedHeight) {
+					$height = $postMedia->embedHeight;
+					$width  = '';
+				} else {
+					$height = '';
+				}
+			}
+		} else {
+			if ($postMedia->hasEmbedHeight()) {
+				$height = $postMedia->embedHeight . 'px';
+			}
+			if ($postMedia->hasEmbedWidth()) {
+				$width = $postMedia->embedWidth . 'px';
+			}
+		}
+
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate($postMedia->embedHeight ? 'content/embed-iframe.tpl' : 'content/embed-iframe-resize.tpl'), [
-			'id'     => 'iframe-' . hash('md5', $postMedia->embedHtml),
-			'src'    => $postMedia->embedHtml,
-			'height' => $postMedia->embedHeight + 20,
-			'width'  => $postMedia->embedWidth && $postMedia->embedWidth <= $this->config->get('system', 'max_width') ? $postMedia->embedWidth : '100%',
+			'id'           => 'iframe-' . hash('md5', $postMedia->embedHtml),
+			'src'          => $postMedia->embedHtml,
+			'height'       => $height,
+			'width'        => $width,
+			'iframe_style' => $iframe_style,
 		]);
 	}
 

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -443,19 +443,26 @@ class BBCode
 			$return = sprintf('<div class="type-%s">', $data['type']);
 		}
 
-		if ($embed && (($data['player_url'] != '' && $data['player_height'] != 0) || $data['embed_html'] != '')) {
+		if ($embed) {
 			$media = DI::postMediaFactory()->createFromAttachment($data, $uriid);
-			if ($data['player_url'] != '' && $data['player_height'] != 0) {
-				$return .= DI::postMediaRepository()->getPlayerIframe($media);
+			if ($media->hasPlayerUrl() && $media->hasPlayerHeight()) {
+				$embed_media = DI::postMediaRepository()->getPlayerIframe($media);
+			} elseif ($media->hasEmbedHtml() && !$media->isPhoto()) {
+				$embed_media = DI::postMediaRepository()->getEmbedIframe($media);
 			} else {
-				$return .= DI::postMediaRepository()->getEmbedIframe($media);
+				$embed_media = null;
 			}
-			$preview_mode = self::PREVIEW_NO_IMAGE;
-			unset($data['title']);
-			unset($data['url']);
-			unset($data['description']);
-			unset($data['provider_url']);
-			unset($data['provider_name']);
+
+			if ($embed_media) {
+				$return .= $embed_media;
+
+				$preview_mode = self::PREVIEW_NO_IMAGE;
+				unset($data['title']);
+				unset($data['url']);
+				unset($data['description']);
+				unset($data['provider_url']);
+				unset($data['provider_name']);
+			}
 		}
 
 		if ($preview_mode == self::PREVIEW_NO_IMAGE) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3034,7 +3034,7 @@ class Item
 		if (!empty($sharedSplitAttachments)) {
 			$s    = self::addGallery($s, $sharedSplitAttachments['visual']);
 			$s    = self::addVisualAttachments($sharedSplitAttachments['visual'], $shared_item, $s, true, $uid);
-			$s    = self::addLinkAttachment($shared_uri_id ?: $item['uri-id'], $sharedSplitAttachments, $body, $s, true, $quote_shared_links, $uid);
+			$s    = self::addLinkAttachment($shared_uri_id ?: $item['uri-id'], $sharedSplitAttachments, $body, $s, true, $quote_shared_links, $uid, $shared_item);
 			$s    = self::addNonVisualAttachments($sharedSplitAttachments['additional'], $item, $s);
 			$body = BBCode::removeSharedData($body);
 		}
@@ -3047,7 +3047,7 @@ class Item
 
 		$s = self::addGallery($s, $itemSplitAttachments['visual']);
 		$s = self::addVisualAttachments($itemSplitAttachments['visual'], $item, $s, false, $uid);
-		$s = self::addLinkAttachment($item['uri-id'], $itemSplitAttachments, $body, $s, false, $shared_links, $uid);
+		$s = self::addLinkAttachment($item['uri-id'], $itemSplitAttachments, $body, $s, false, $shared_links, $uid, $item);
 		$s = self::addNonVisualAttachments($itemSplitAttachments['additional'], $item, $s);
 		$s = self::addQuestions($item, $s);
 
@@ -3359,16 +3359,18 @@ class Item
 	 * @param bool         $shared
 	 * @param array        $ignore_links A list of URLs to ignore
 	 * @param int          $uid
+	 * @param array        $item
 	 * @return string modified content
 	 * @throws InternalServerErrorException
 	 * @throws ServiceUnavailableException
 	 */
-	private static function addLinkAttachment(int $uriid, array $attachments, string $body, string $content, bool $shared, array $ignore_links, int $uid): string
+	private static function addLinkAttachment(int $uriid, array $attachments, string $body, string $content, bool $shared, array $ignore_links, int $uid, array $item): string
 	{
 		DI::profiler()->startRecording('rendering');
 		// Don't show a preview when there is a visual attachment (audio or video)
-		$types   = $attachments['visual']->column('type');
-		$preview = !in_array(PostMedia::TYPE_IMAGE, $types) && !in_array(PostMedia::TYPE_VIDEO, $types);
+		$types     = $attachments['visual']->column('type');
+		$preview   = !in_array(PostMedia::TYPE_IMAGE, $types) && !in_array(PostMedia::TYPE_VIDEO, $types);
+		$has_media = in_array($item['post-type'] ?? null, [Item::PT_AUDIO, Item::PT_VIDEO]);
 
 		/** @var ?PostMedia $attachment */
 		$attachment = null;
@@ -3409,6 +3411,7 @@ class Item
 				'embed_html'    => $attachment->embedHtml,
 				'embed_width'   => $attachment->embedWidth,
 				'embed_height'  => $attachment->embedHeight,
+				'page_type'     => $attachment->pageType,
 			];
 
 			if ($preview && $attachment->preview) {
@@ -3460,7 +3463,7 @@ class Item
 
 				// @todo Use a template
 				$preview_mode = DI::pConfig()->get($uid, 'system', 'preview_mode', BBCode::PREVIEW_LARGE);
-				if ($preview_mode != BBCode::PREVIEW_NONE && !self::containsEmbed($body, $data['url'])) {
+				if (!$has_media && $preview_mode != BBCode::PREVIEW_NONE && !self::containsEmbed($body, $data['url'])) {
 					$rendered = BBCode::convertAttachment('', BBCode::INTERNAL, $data, $uriid, $preview_mode, DI::pConfig()->get($uid, 'system', 'embed_remote_media', false));
 				} elseif (!self::containsLink($content, $data['url'], Post\Media::HTML)) {
 					$rendered = Renderer::replaceMacros(Renderer::getMarkupTemplate('content/link.tpl'), [

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -479,18 +479,20 @@ class Media
 		$media['embed-html']      = $data['embed']['html']    ?? null;
 		$media['embed-height']    = $data['embed']['height']  ?? null;
 		$media['embed-width']     = $data['embed']['width']   ?? null;
+		$media['page-type']       = $data['pagetype']         ?? null;
 		$media['language']        = $data['language']         ?? null;
 		$media['published']       = $data['published']        ?? null;
 		$media['modified']        = $data['modified']         ?? null;
+		$media['schematypes']     = isset($data['schematypes']) ? json_encode($data['schematypes']) : null;
 
 		if (DI::config()->get('system', 'add_page_media')) {
-			if (!empty($data['audio'])) {
+			if (isset($data['audio']) && sizeof($data['audio']) == 1) {
 				foreach ($data['audio'] as $entry) {
 					self::insertMedia($entry, $media['uri-id']);
 				}
 			}
 
-			if (!empty($data['video'])) {
+			if (isset($data['video']) && sizeof($data['video']) == 1) {
 				foreach ($data['video'] as $entry) {
 					self::insertMedia($entry, $media['uri-id']);
 				}

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -158,6 +158,10 @@ class Processor
 		$data['player-url']    = $attachment['player-url']    ?? null;
 		$data['player-height'] = $attachment['player-height'] ?? null;
 		$data['player-width']  = $attachment['player-width']  ?? null;
+		$data['embed-type']    = $attachment['embed-type']    ?? null;
+		$data['embed-html']    = $attachment['embed-html']    ?? null;
+		$data['embed-width']   = $attachment['embed-width']   ?? null;
+		$data['embed-height']  = $attachment['embed-height']  ?? null;
 
 		Post\Media::insert($data);
 	}

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1867,9 +1867,10 @@ class Receiver
 	 * @param array       $urls   The object URL list
 	 * @param string|null $icon   The icon URL to use for the attachments
 	 * @param array       $player Embedded player data (url, width, height)
+	 * @param array       $embed  oEmbed data (html, width, height)
 	 * @return array an array of attachments
 	 */
-	private static function processAttachmentUrls(array $urls, ?string $icon, array $player): array
+	private static function processAttachmentUrls(array $urls, ?string $icon, array $player, array $embed): array
 	{
 		$attachments = [];
 		foreach ($urls as $key => $url) {
@@ -1918,30 +1919,27 @@ class Receiver
 			} elseif ($mediatype == 'application/x-mpegURL') {
 				// PeerTube uses HLS streams for video. We prefer HLS streams over the video file itself.
 				// But we still store the video file as an attachment to be used by the API which currently does not support HLS streams.
-				$attachments = array_merge($attachments, self::processAttachmentUrls($url['as:tag'], $icon, []));
+				$attachments = array_merge($attachments, self::processAttachmentUrls($url['as:tag'], $icon, [], []));
 
 				$attachment = ['type' => $filetype, 'mediaType' => $mediatype, 'url' => $href, 'height' => $height, 'width' => $width, 'size' => null, 'name' => '', 'image' => $icon];
-				if (!empty($player)) {
+				if (is_array($player)) {
 					$attachment['player-url']    = $player['embed']  ?? null;
 					$attachment['player-height'] = $player['height'] ?? null;
 					$attachment['player-width']  = $player['width']  ?? null;
-
-					if (is_null($attachment['player-height']) && is_null($attachment['player-width'])) {
-						foreach ($attachments as $media) {
-							if (isset($media['height']) && isset($media['width'])) {
-								if ($media['height'] > $attachment['player-height'] || $media['width'] > $attachment['player-width']) {
-									$attachment['player-height'] = $media['height'];
-									$attachment['player-width']  = $media['width'];
-								}
-							}
-						}
-					}
 
 					if (!$height && !$width) {
 						$attachment['height'] = $attachment['player-height'];
 						$attachment['width']  = $attachment['player-width'];
 					}
 				}
+
+				if (is_array($embed)) {
+					$attachment['embed-type']   = $embed['type']   ?? null;
+					$attachment['embed-html']   = $embed['html']   ?? null;
+					$attachment['embed-height'] = $embed['height'] ?? null;
+					$attachment['embed-width']  = $embed['width']  ?? null;
+				}
+
 				DI::logger()->info('Adding video attachment', ['attachment' => $attachment]);
 				$attachments[] = $attachment;
 			}
@@ -2130,8 +2128,13 @@ class Receiver
 			} else {
 				$player = [];
 			}
+			if (isset($siteinfo['embed'])) {
+				$embed = $siteinfo['embed'];
+			} else {
+				$embed = [];
+			}
 
-			$object_data['attachments'] = array_merge($object_data['attachments'], self::processAttachmentUrls($object['as:url'] ?? [], self::processIcon($object), $player));
+			$object_data['attachments'] = array_merge($object_data['attachments'], self::processAttachmentUrls($object['as:url'] ?? [], self::processIcon($object), $player, $embed));
 		}
 
 		$object_data['can-comment'] = JsonLD::fetchElement($object, 'pt:commentsEnabled', '@value');

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -22,6 +22,7 @@ use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\HTTPClient\Client\HttpClientRequest;
 use Embera\Embera;
 use Friendica\Content\Text\BBCode;
+use Friendica\Core\Cache\Enum\Duration;
 use Friendica\Model\Post;
 
 /**
@@ -459,6 +460,9 @@ class ParseUrl
 					case 'og:description':
 						$siteinfo['text'] = trim($meta_tag['content']);
 						break;
+					case 'og:updated_time':
+						$siteinfo['modified'] = DateTimeFormat::utc(trim($meta_tag['content']));
+						break;
 					case 'og:site_name':
 						$siteinfo['publisher_name'] = trim($meta_tag['content']);
 						break;
@@ -494,14 +498,22 @@ class ParseUrl
 			}
 		}
 
+		$siteinfo['schematypes'] = [];
+
 		$list = $xpath->query("//script[@type='application/ld+json']");
 		foreach ($list as $node) {
 			if (!empty($node->nodeValue)) {
 				$jsonld = json_decode($node->nodeValue, true);
 				if (is_array($jsonld)) {
-					$siteinfo = self::parseParts($siteinfo, $jsonld);
+					$siteinfo = self::parseParts($siteinfo, $jsonld, true);
 				}
 			}
+		}
+
+		$siteinfo['schematypes'] = array_values(array_unique($siteinfo['schematypes']));
+
+		if (sizeof($siteinfo['schematypes']) === 0) {
+			unset($siteinfo['schematypes']);
 		}
 
 		$siteinfo = self::getOembedInfo($xpath, $siteinfo);
@@ -595,7 +607,7 @@ class ParseUrl
 
 		foreach (['audio', 'video'] as $element) {
 			if (!empty($siteinfo[$element])) {
-				array_walk($siteinfo[$element], function (&$media) use ($page_url, &$siteinfo) {
+				array_walk($siteinfo[$element], function (&$media) use ($page_url) {
 					$url         = '';
 					$embed       = '';
 					$content     = '';
@@ -630,9 +642,6 @@ class ParseUrl
 					}
 					if (!empty($embed)) {
 						$media['embed'] = $embed;
-						if (empty($siteinfo['player']['embed'])) {
-							$siteinfo['player']['embed'] = $embed;
-						}
 					}
 					if (!empty($content)) {
 						$media['src'] = $content;
@@ -748,16 +757,16 @@ class ParseUrl
 	 *
 	 * @return array siteinfo
 	 */
-	private static function parseParts(array $siteinfo, array $jsonld): array
+	private static function parseParts(array $siteinfo, array $jsonld, bool $root): array
 	{
 		if (!empty($jsonld['@graph']) && is_array($jsonld['@graph'])) {
 			foreach ($jsonld['@graph'] as $part) {
 				if (!empty($part) && is_array($part)) {
-					$siteinfo = self::parseParts($siteinfo, $part);
+					$siteinfo = self::parseParts($siteinfo, $part, false);
 				}
 			}
 		} elseif (!empty($jsonld['@type'])) {
-			$siteinfo = self::parseJsonLd($siteinfo, $jsonld);
+			$siteinfo = self::parseJsonLd($siteinfo, $jsonld, $root);
 		} elseif (!empty($jsonld)) {
 			$keys         = array_keys($jsonld);
 			$numeric_keys = true;
@@ -769,7 +778,7 @@ class ParseUrl
 			if ($numeric_keys) {
 				foreach ($jsonld as $part) {
 					if (!empty($part) && is_array($part)) {
-						$siteinfo = self::parseParts($siteinfo, $part);
+						$siteinfo = self::parseParts($siteinfo, $part, false);
 					}
 				}
 			}
@@ -794,12 +803,16 @@ class ParseUrl
 	 *
 	 * @return array siteinfo
 	 */
-	private static function parseJsonLd(array $siteinfo, array $jsonld): array
+	private static function parseJsonLd(array $siteinfo, array $jsonld, bool $root): array
 	{
 		$type = JsonLD::fetchElement($jsonld, '@type');
 		if (empty($type)) {
 			DI::logger()->info('Empty type', ['url' => $siteinfo['url']]);
 			return $siteinfo;
+		}
+
+		if ($root) {
+			$siteinfo['schematypes'][] = $type;
 		}
 
 		// Silently ignore some types that aren't processed
@@ -1321,12 +1334,28 @@ class ParseUrl
 			DI::logger()->debug('Using Twitter oEmbed', ['url' => $url, 'oembed' => $oembed]);
 		}
 
+		if (in_array(parse_url(Strings::normaliseLink($url), PHP_URL_HOST), ['tidal.com'])) {
+			$oembed = 'https://oembed.tidal.com?url=' . urlencode($url);
+			DI::logger()->debug('Using Tidal oEmbed', ['url' => $url, 'oembed' => $oembed]);
+			// @todo Check how to support the parameters listed here: https://developer.tidal.com/documentation/embeds/embeds-code-generator
+		}
+
+		if (in_array(parse_url(Strings::normaliseLink($url), PHP_URL_HOST), ['link.deezer.com', 'deezer.com', 'www.deezer.com'])) {
+			$oembed = 'https://api.deezer.com/oembed?url=' . urlencode($url) . '&tracklist=true';
+			DI::logger()->debug('Using Deezer oEmbed', ['url' => $url, 'oembed' => $oembed]);
+			// @see https://developers.deezer.com/api/oembed
+		}
+
 		if (!$oembed) {
 			foreach ($xpath->query("//link[@type='application/json+oembed']") as $link) {
 				/** @var DOMElement $link */
 				$oembed = $link->getAttributeNode('href')->nodeValue;
 				DI::logger()->debug('Found oEmbed JSON from page', ['url' => $url, 'oembed' => $oembed]);
 			}
+		}
+
+		if (!$oembed) {
+			$oembed = self::fetchFromProviderList($url);
 		}
 
 		if ($oembed) {
@@ -1346,7 +1375,69 @@ class ParseUrl
 			$data = current($urldata);
 			DI::logger()->debug('Found oEmbed JSON from Embera', ['url' => $url]);
 		}
+
+		if  (!isset($data['type']) || !isset($data['provider_url'])) {
+			return [];
+		}
+
+		// Some provider return "rich", although they should return "photo"
+		if ($data['type'] === 'rich' && in_array($data['provider_url'], ['https://www.pixiv.net/', 'https://www.pinterest.com'])) {
+			$data['type'] = 'photo';
+		}
+
 		return $data;
+	}
+
+	/**
+	 * Fetch the oEmbed provider from the oembed.com provider list
+	 *
+	 * @param string $url The url to fetch the oEmbed provider for
+	 *
+	 * @return string|null The oEmbed url or null if no provider was found
+	 */
+	private static function fetchFromProviderList(string $url): ?string
+	{
+		$cachekey = 'ParseUrl:fetchFromProviderList';
+
+		$providers = DI::cache()->get($cachekey);
+		if (!$providers) {
+			$providers_content = DI::httpClient()->fetch('https://oembed.com/providers.json', HttpClientAccept::JSON, 0, '', HttpClientRequest::SITEINFO);
+			if (!$providers_content) {
+				DI::logger()->warning('Could not fetch oEmbed provider list');
+				return null;
+			}
+			$providers = json_decode($providers_content, true);
+			if (!is_array($providers)) {
+				DI::logger()->warning('Could not decode oEmbed provider list');
+				return null;
+			}
+			DI::cache()->set($cachekey, $providers, Duration::WEEK);
+		}
+		$schemes = [];
+		foreach ($providers as $provider) {
+			if (!isset($provider['endpoints']) || !is_array($provider['endpoints'])) {
+				continue;
+			}
+			foreach ($provider['endpoints'] as $endpoint) {
+				if (!isset($endpoint['schemes']) || !is_array($endpoint['schemes'])) {
+					$schemes[rtrim($provider['provider_url'], '/') . '/*'] = str_replace('{format}', 'json', $endpoint['url']);
+					continue;
+				}
+				foreach ($endpoint['schemes'] as $scheme) {
+					$schemes[$scheme] = str_replace('{format}', 'json', $endpoint['url']);
+				}
+			}
+		}
+
+		foreach ($schemes as $scheme => $provider_url) {
+			$regex = str_replace(['.', '?', '*'], ['\.', '\?', '.*'], $scheme);
+			if (preg_match('~' . $regex . '~i', $url)) {
+				$oembed = $provider_url . (strpos($provider_url, '?') === false ? '?' : '&') . 'url=' . urlencode($url);
+				DI::logger()->debug('Found oEmbed provider from oembed.com list', ['url' => $url, 'oembed' => $oembed]);
+				return $oembed;
+			}
+		}
+		return null;
 	}
 
 	private static function getSiteinfoFromoEmbed(array $siteinfo, array $data): array
@@ -1358,31 +1449,34 @@ class ParseUrl
 
 		$unknown_fields = $data;
 		foreach (['account_type', 'asset_type', 'author_unique_id', 'availability', 'brand',
-			'cache_age', 'category', 'currency_code', 'duration', 'embera_using_fake_response',
-			'embera_provider_name', 'embed_product_id', 'embed_type', 'flickr_type',
-			'height', 'html', 'images','iframe_url', 'is_plus', 'price', 'products',
-			'product_expiration', 'product_id', 'quantity', 'referrer', 'safety', 'success', 'type',
-			'thumbnail_credit', 'thumbnail_credit_url', 'thumbnail_credit_note',
+			'cache_age', 'category', 'collection', 'currency_code', 'duration', 'embera_using_fake_response',
+			'embera_provider_name', 'embed_product_id', 'embed_type', 'embed', 'entity', 'flickr_type',
+			'height', 'html', 'id', 'images','iframe_url', 'is_plus', 'photographer', 'price', 'products',
+			'product_expiration', 'product_id', 'quantity', 'ratio', 'referrer', 'safety', 'success',
+			'terms_of_use_url', 'type', 'thumbnail_credit', 'thumbnail_credit_url', 'thumbnail_credit_note',
 			'thumbnail_height', 'thumbnail_url_with_play_button', 'thumbnail_width',
-			'uri', 'url', 'version', 'video_id', 'web_page', 'web_page_short_url', 'width'] as $value) {
+			'uri', 'url', 'version', 'video_id', 'web_page', 'web_page_short_url', 'width', 'work_type'] as $value) {
 			unset($unknown_fields[$value]);
 		}
 
 		$fields = [
-			'title'            => 'title',
-			'description'      => 'text',
-			'summary'          => 'text',
-			'author_name'      => 'author_name',
-			'author_url'       => 'author_url',
-			'author'           => 'author_name',
-			'provider_name'    => 'publisher_name',
-			'provider_url'     => 'publisher_url',
-			'thumbnail_url'    => 'image',
-			'upload_date'      => 'published',
-			'publication_date' => 'published',
-			'license'          => 'license_name',
-			'license_url'      => 'license_url',
-			'license_id'       => 'license_id',
+			'title'             => 'title',
+			'caption'           => 'text',
+			'description'       => 'text',
+			'summary'           => 'text',
+			'video_description' => 'text',
+			'author_name'       => 'author_name',
+			'author_url'        => 'author_url',
+			'author'            => 'author_name',
+			'provider_name'     => 'publisher_name',
+			'provider_url'      => 'publisher_url',
+			'image'             => 'image',
+			'thumbnail_url'     => 'image',
+			'upload_date'       => 'published',
+			'publication_date'  => 'published',
+			'license'           => 'license_name',
+			'license_url'       => 'license_url',
+			'license_id'        => 'license_id',
 		];
 
 		foreach ($fields as $key => $value) {
@@ -1407,11 +1501,15 @@ class ParseUrl
 	private static function getOembedInfo(DOMXPath $xpath, array $siteinfo): array
 	{
 		$data = self::getOembedData($xpath, $siteinfo['url']);
-		if (empty($data) || !is_array($data)) {
+		if (!$data) {
 			return $siteinfo;
 		}
 
 		$siteinfo = self::getSiteinfoFromoEmbed($siteinfo, $data);
+
+		if (!self::isWantedEmbed($siteinfo, $data)) {
+			return $siteinfo;
+		}
 
 		if ($data['type'] == 'video' & empty($siteinfo['player']) && ($data['provider_url'] ?? '') == 'https://www.tiktok.com' && isset($data['embed_product_id']) && isset($data['thumbnail_width']) && isset($data['thumbnail_height'])) {
 			$siteinfo['embed']['type']    = $data['type'];
@@ -1424,8 +1522,16 @@ class ParseUrl
 			return $siteinfo;
 		}
 
+		if ($data['provider_url'] == 'https://www.pinterest.com' && isset($siteinfo['video'])) {
+			$data['type'] = 'video';
+		}
+
 		if (!isset($data['html'])) {
 			return $siteinfo;
+		}
+
+		if (strpos($data['html'], '&lt;') === 0) {
+			$data['html'] = html_entity_decode($data['html']);
 		}
 
 		unset($siteinfo['player']);
@@ -1455,7 +1561,7 @@ class ParseUrl
 					$curlResult = DI::httpClient()->head($link);
 					$redirect   = $curlResult->getRedirectUrl();
 					if (preg_match('#/(video|broadcasts)/#', $redirect)) {
-						$siteinfo['embed']['type']   = $data['type'];
+						$siteinfo['embed']['type']   = 'video';
 						$siteinfo['embed']['html']   = trim(str_replace('<blockquote class="twitter-tweet"', '<blockquote class="twitter-tweet" data-media-max-width="560"', $data['html']));
 						$siteinfo['embed']['width']  = is_numeric($data['width'] ?? '') ? $data['width']  : null;
 						$siteinfo['embed']['height'] = is_numeric($data['height'] ?? '') ? $data['height'] : null;
@@ -1468,7 +1574,13 @@ class ParseUrl
 			return $siteinfo;
 		}
 
-		if ($data['type'] != 'video' && ($siteinfo['pagetype'] ?? '') != 'video') {
+		if (isset($siteinfo['pagetype'])) {
+			$pagetype = explode('.', $siteinfo['pagetype'])[0];
+		} else {
+			$pagetype = '';
+		}
+
+		if (!in_array($data['type'], ['video', 'photo']) && $pagetype != 'video') {
 			return $siteinfo;
 		}
 
@@ -1479,6 +1591,42 @@ class ParseUrl
 		DI::logger()->debug('Fetched oEmbed HTML', ['provider' => $data['provider_url'], 'url' => $siteinfo['url']]);
 
 		return $siteinfo;
+	}
+
+	private static function isWantedEmbed(array $siteinfo, array $data): bool
+	{
+		if (isset($siteinfo['player'])) {
+			return true;
+		}
+
+		if ($data['type'] !== 'rich') {
+			return true;
+		}
+
+		$pagetype = isset($siteinfo['pagetype']) ? explode('.', $siteinfo['pagetype'])[0] : '';
+		if (in_array($pagetype, ['episode', 'song', 'music', 'video'])) {
+			return true;
+		}
+
+		if (isset($siteinfo['schematypes'])) {
+			foreach (['AudioObject', 'MusicRecording', 'PodcastEpisode', 'PresentationDigitalDocument'] as $type) {
+				if (in_array($type, $siteinfo['schematypes'])) {
+					return true;
+				}
+			}
+
+			foreach (['Article', 'BackgroundNewsArticle', 'NewsArticle'] as $type) {
+				if (in_array($type, $siteinfo['schematypes'])) {
+					return false;
+				}
+			}
+		}
+
+		if (in_array($pagetype, ['article'])) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -1507,13 +1655,25 @@ class ParseUrl
 		$xpath = new DOMXPath($dom);
 
 		$nodes = $xpath->query('/html/body/*');
-		if ($nodes->length !== 1) {
+		if ($nodes->length !== 1 && $data['type'] != 'video') {
 			return $siteinfo;
 		}
 
 		/** @var DOMElement $iframe */
 		$iframe = $nodes->item(0);
-		if ($iframe->nodeName !== 'iframe') {
+		$found  = $iframe->nodeName == 'iframe';
+
+		// When the oEmbed data belongs to a video, we can safely use any iframe that we can fetch
+		if (!$found && $data['type'] == 'video') {
+			$nodes = $xpath->query('//iframe');
+			if ($nodes->length > 0) {
+				/** @var DOMElement $iframe */
+				$iframe = $nodes->item(0);
+				$found  = true;
+			}
+		}
+
+		if (!$found) {
 			return $siteinfo;
 		}
 

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -44,7 +44,7 @@ use Friendica\Database\DBA;
 
 // This file is required several times during the test in DbaDefinition which justifies this condition
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1582);
+	define('DB_UPDATE_VERSION', 1583);
 }
 
 return [
@@ -1441,6 +1441,8 @@ return [
 			"embed-html" => ["type" => "text", "comment" => "HTML embed code for this media"],
 			"embed-height" => ["type" => "smallint unsigned", "comment" => "Height of the embed"],
 			"embed-width" => ["type" => "smallint unsigned", "comment" => "Width of the embed"],
+			"page-type" => ["type" => "varchar(30)", "comment" => "Type of the page (e.g. article, website)"],
+			"schematypes" => ["type" => "varchar(255)", "comment" => "Schema types of the page as JSON string"],
 			"language" => ["type" => "char(3)", "comment" => "Language information about this media in the ISO 639 format"],
 			"published" => ["type" => "datetime", "comment" => "Publification date of this media"],
 			"modified" => ["type" => "datetime", "comment" => "Modification date of this media"],

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -726,12 +726,9 @@ Lucas: For the right price, yes.[/share]',
 	public function dataConvertAttachment(): array
 	{
 		return [
-			'player' => [
-				'expected' => 'text <div class="type-link"><div style="">' . "\n" .
-'  <iframe src="http://domain.tld/player" style="" height="480" width="100%" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>' . "\n" .
-"</div>\n" .
-'</div>',
-				'data' => [
+			'player-rich' => [
+				'expected' => 'text <div class="type-link"><iframe class="embed" src="http://domain.tld/player" style="" height="480px" width="620px" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>' . "\n</div>",
+				'data'     => [
 					'author_name'   => 'author_name',
 					'author_url'    => 'http://domain.tld/author_url',
 					'description'   => 'description',
@@ -746,12 +743,12 @@ Lucas: For the right price, yes.[/share]',
 					'player_url'    => 'http://domain.tld/player',
 					'player_width'  => 620,
 					'player_height' => 480,
+					'embed_type'    => 'rich',
 				],
 			],
-			'embed' => [
-				'expected' => 'text <div class="type-link"><iframe srcdoc="&lt;iframe src=&quot;http://domain.tld/player&quot;&gt;&lt;/iframe&gt;" height="500" width="620" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>' . "\n" .
-'</div>',
-				'data' => [
+			'embed-rich' => [
+				'expected' => 'text <div class="type-link"><iframe class="embed" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;style&gt;html,body{margin:0;padding:0;height:100%;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;iframe src=&quot;http://domain.tld/player&quot;&gt;&lt;/iframe&gt;&lt;/body&gt;&lt;/html&gt;" style="" height="480px" width="620px" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>' . "\n</div>",
+				'data'     => [
 					'author_name'   => 'author_name',
 					'author_url'    => 'http://domain.tld/author_url',
 					'description'   => 'description',
@@ -764,6 +761,48 @@ Lucas: For the right price, yes.[/share]',
 					'type'          => 'link',
 					'url'           => 'http://domain.tld/page',
 					'player_url'    => '',
+					'embed_type'    => 'rich',
+					'embed_html'    => '<iframe src="http://domain.tld/player"></iframe>',
+					'embed_width'   => 620,
+					'embed_height'  => 480,
+				]
+			],
+			'player-video' => [
+				'expected' => 'text <div class="type-link"><iframe class="embed" src="http://domain.tld/player" style="aspect-ratio:620/480;" height="" width="100%" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>' . "\n</div>",
+				'data'     => [
+					'author_name'   => 'author_name',
+					'author_url'    => 'http://domain.tld/author_url',
+					'description'   => 'description',
+					'image'         => 'http://domain.tld/image',
+					'preview'       => 'http://domain.tld/preview',
+					'provider_name' => 'provider_name',
+					'provider_url'  => 'http://domain.tld/provider_url',
+					'text'          => 'text',
+					'title'         => 'title',
+					'type'          => 'link',
+					'url'           => 'http://domain.tld/page',
+					'player_url'    => 'http://domain.tld/player',
+					'player_width'  => 620,
+					'player_height' => 480,
+					'embed_type'    => 'video',
+				],
+			],
+			'embed-video' => [
+				'expected' => 'text <div class="type-link"><iframe class="embed" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;style&gt;html,body{margin:0;padding:0;height:100%;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;iframe src=&quot;http://domain.tld/player&quot;&gt;&lt;/iframe&gt;&lt;/body&gt;&lt;/html&gt;" style="aspect-ratio:620/480;" height="" width="100%" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>' . "\n</div>",
+				'data'     => [
+					'author_name'   => 'author_name',
+					'author_url'    => 'http://domain.tld/author_url',
+					'description'   => 'description',
+					'image'         => 'http://domain.tld/image',
+					'preview'       => 'http://domain.tld/preview',
+					'provider_name' => 'provider_name',
+					'provider_url'  => 'http://domain.tld/provider_url',
+					'text'          => 'text',
+					'title'         => 'title',
+					'type'          => 'link',
+					'url'           => 'http://domain.tld/page',
+					'player_url'    => '',
+					'embed_type'    => 'video',
 					'embed_html'    => '<iframe src="http://domain.tld/player"></iframe>',
 					'embed_width'   => 620,
 					'embed_height'  => 480,

--- a/view/templates/content/embed-iframe-resize.tpl
+++ b/view/templates/content/embed-iframe-resize.tpl
@@ -4,22 +4,24 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<iframe id="{{$id}}" srcdoc="{{$src}}&lt;script&gt;
-function sendResize() {
-    parent.postMessage({type:'resize',height:document.body.scrollHeight},'*');
-}
-window.onload = function() {
-    sendResize();
-    setTimeout(sendResize, 2000);
-};
-&lt;/script&gt;" width="{{$width}}" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>
-<script>
-  window.addEventListener('message', function(event) {
-    if (event.data && event.data.type === 'resize') {
-      var iframe = document.getElementById('{{$id}}');
-      if (iframe) {
-        iframe.style.height = (event.data.height + 20) + 'px';
+<span class="embedded-media">
+  <iframe class="embed" id="{{$id}}" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;style&gt;html,body{margin:0;padding:0;height:100%;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;{{$src}}&lt;script&gt;
+  function sendResize() {
+      parent.postMessage({type:'resize',height:document.body.scrollHeight},'*');
+  }
+  window.onload = function() {
+      sendResize();
+      setTimeout(sendResize, 2000);
+  };
+  &lt;/script&gt;&lt;/body&gt;&lt;/html&gt;" width="{{$width}}" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>
+  <script>
+    window.addEventListener('message', function(event) {
+      if (event.data && event.data.type === 'resize') {
+        var iframe = document.getElementById('{{$id}}');
+        if (iframe) {
+          iframe.style.height = event.data.height + 'px';
+        }
       }
-    }
-  });
-</script>
+    });
+  </script>
+</span>

--- a/view/templates/content/embed-iframe.tpl
+++ b/view/templates/content/embed-iframe.tpl
@@ -4,4 +4,4 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<iframe srcdoc="{{$src}}" height="{{$height}}" width="{{$width}}" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>
+<iframe class="embed" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;style&gt;html,body{margin:0;padding:0;height:100%;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;{{$src}}&lt;/body&gt;&lt;/html&gt;" style="{{$iframe_style}}" height="{{$height}}" width="{{$width}}" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>

--- a/view/templates/content/iframe.tpl
+++ b/view/templates/content/iframe.tpl
@@ -4,6 +4,4 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<div style="{{$div_style}}">
-  <iframe src="{{$src}}" style="{{$iframe_style}}" height="{{$height}}" width="{{$width}}" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>
-</div>
+<iframe class="embed" src="{{$src}}" style="{{$iframe_style}}" height="{{$height}}" width="{{$width}}" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -65,10 +65,10 @@ aside hr,
 section hr {
 	border-color: rgba(238, 238, 238, $contentbg_transp);
 }
-iframe,
+iframe.embed,
 video {
 	max-width: 100%;
-	max-height: 85vh;
+	max-height: calc(100vh - 260px);
 }
 blockquote {
 	font-size: inherit;

--- a/view/theme/frio/templates/jot.tpl
+++ b/view/theme/frio/templates/jot.tpl
@@ -187,12 +187,6 @@ can load different content into the jot modal (e.g. the item edit jot)
 	</div>
 </div>
 
-<script type="text/javascript">
-	$('iframe').load(function() {
-		this.style.height = this.contentWindow.document.body.offsetHeight + 'px';
-	});
-</script>
-
 <script>
 	dzFactory.setupDropzone('#jot-text-wrap', 'profile-jot-text');
 </script>

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -3299,8 +3299,8 @@ fbrowser.photo .photo-album-image-wrapper { margin-left: 10px; }
 	text-align: center;
 }
 
-iframe,
+iframe.embed,
 video {
 	max-width: 100%;
-	max-height: 90vh;
+	max-height: calc(100vh - 150px);
 }


### PR DESCRIPTION
This PR improves the iframe sizing for "rich" content. Also we can now extract player strings out of `<div><iframe src=...></iframe></div>` elements. Also we store now `embed` data for Peertube videos as well and not only the player data.

Also some more provider are added, including the ability to fetch a list a providers from the official oEmbed page. Also the HTML construct of the iframes is now much leaner.