### PR TITLE
Moderation: Create user UI/UX improvements and consistency, item source consistency

### DIFF
--- a/src/Module/Moderation/Item/Source.php
+++ b/src/Module/Moderation/Item/Source.php
@@ -47,16 +47,16 @@ class Source extends BaseModeration
 		$guid = basename($request['guid'] ?? $this->parameters['guid'] ?? '');
 
 		$item_uri = '';
-		$item_id = '';
-		$terms = [];
-		$source = '';
+		$item_id  = '';
+		$terms    = [];
+		$source   = '';
 		if (!empty($guid)) {
 			$item = Model\Post::selectFirst(['id', 'uri-id', 'guid', 'uri'], ['guid' => $guid]);
 
 			if ($item) {
-				$item_id = $item['id'];
+				$item_id  = $item['id'];
 				$item_uri = $item['uri'];
-				$terms = Model\Tag::getByURIId($item['uri-id'], [Model\Tag::HASHTAG, Model\Tag::MENTION, Model\Tag::IMPLICIT_MENTION]);
+				$terms    = Model\Tag::getByURIId($item['uri-id'], [Model\Tag::HASHTAG, Model\Tag::MENTION, Model\Tag::IMPLICIT_MENTION]);
 
 				$activity = Model\Post\Activity::getByURIId($item['uri-id']);
 				if (!empty($activity)) {
@@ -68,7 +68,8 @@ class Source extends BaseModeration
 		$tpl = Renderer::getMarkupTemplate('moderation/item/source.tpl');
 		return Renderer::replaceMacros($tpl, [
 			'$l10n' => [
-				'title'       => $this->t('Item Source'),
+				'title'       => $this->t('Moderation'),
+				'page'        => $this->t('Item Source'),
 				'itemidlbl'   => $this->t('Item Id'),
 				'itemurilbl'  => $this->t('Item URI'),
 				'submit'      => $this->t('Submit'),
@@ -79,12 +80,12 @@ class Source extends BaseModeration
 				'urllbl'      => $this->t('URL'),
 				'mentionlbl'  => $this->t('Mention'),
 				'implicitlbl' => $this->t('Implicit Mention'),
-				'error'       => $this->tt('Error','Errors', 1),
+				'error'       => $this->tt('Error', 'Errors', 1),
 				'notfound'    => $this->t('Item not found'),
 				'nosource'    => $this->t('No source recorded'),
 				'noconfig'    => !$this->config->get('debug', 'store_source') ? $this->t('Please make sure the <code>debug.store_source</code> config key is set in <code>config/local.config.php</code> for future items to have sources.') : '',
 			],
-			'$guid_field' => ['guid', $this->t('Item Guid'), $guid, ''],
+			'$guid_field' => ['guid', '', $guid, '', '', 'autofocus', '', $this->t('Item Guid')],
 			'$guid'       => $guid,
 			'$item_uri'   => $item_uri,
 			'$item_id'    => $item_id,

--- a/src/Module/Moderation/Users/Create.php
+++ b/src/Module/Moderation/Users/Create.php
@@ -20,9 +20,9 @@ class Create extends BaseUsers
 
 		self::checkFormSecurityTokenRedirectOnError('moderation/users/create', 'admin_users_create');
 
-		$nu_name     = $request['new_user_name'] ?? '';
+		$nu_name     = $request['new_user_name']     ?? '';
 		$nu_nickname = $request['new_user_nickname'] ?? '';
-		$nu_email    = $request['new_user_email'] ?? '';
+		$nu_email    = $request['new_user_email']    ?? '';
 		$nu_language = DI::config()->get('system', 'language');
 
 		if ($nu_name !== '' && $nu_email !== '' && $nu_nickname !== '') {
@@ -44,18 +44,19 @@ class Create extends BaseUsers
 		$t = Renderer::getMarkupTemplate('moderation/users/create.tpl');
 		return self::getTabsHTML('all') . Renderer::replaceMacros($t, [
 			// strings //
-			'$title'  => $this->t('Administration'),
-			'$page'   => $this->t('New User'),
-			'$submit' => $this->t('Add User'),
+			'$title'       => $this->t('Moderation'),
+			'$page'        => $this->t('Create user'),
+			'$description' => $this->t('Type in the details for the new user to be created.'),
+			'$submit'      => $this->t('Create user'),
 
 			'$form_security_token' => self::getFormSecurityToken('admin_users_create'),
 
 			// values //
 			'$query_string' => $this->args->getQueryString(),
 
-			'$newusername'     => ['new_user_name', $this->t('Name'), '', $this->t('Name of the new user.')],
-			'$newusernickname' => ['new_user_nickname', $this->t('Nickname'), '', $this->t('Nickname of the new user.')],
-			'$newuseremail'    => ['new_user_email', $this->t('Email'), '', $this->t('Email address of the new user.'), '', '', 'email'],
+			'$newusername'     => ['new_user_name', '', '', '', true, 'autofocus', '', $this->t('Display name')],
+			'$newusernickname' => ['new_user_nickname', '', '', '', true, '', '', $this->t('Nickname')],
+			'$newuseremail'    => ['new_user_email', '', '', '', true, 'email', '', $this->t('Email')],
 		]);
 	}
 }

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-06 18:57+0200\n"
+"POT-Creation-Date: 2025-10-10 20:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -440,7 +440,7 @@ msgstr ""
 #: src/Module/FriendSuggest.php:132 src/Module/Install.php:219
 #: src/Module/Install.php:259 src/Module/Install.php:296
 #: src/Module/Invite.php:162 src/Module/Item/Compose.php:188
-#: src/Module/Moderation/Item/Source.php:74
+#: src/Module/Moderation/Item/Source.php:75
 #: src/Module/Moderation/Report/Create.php:153
 #: src/Module/Moderation/Report/Create.php:168
 #: src/Module/Moderation/Report/Create.php:196
@@ -1073,7 +1073,7 @@ msgstr ""
 #: src/Content/ContactSelector.php:122
 #: src/Module/Moderation/Users/Active.php:82
 #: src/Module/Moderation/Users/Blocked.php:82
-#: src/Module/Moderation/Users/Create.php:58
+#: src/Module/Moderation/Users/Create.php:59
 #: src/Module/Moderation/Users/Deleted.php:69
 #: src/Module/Moderation/Users/Index.php:89
 #: src/Module/Moderation/Users/Index.php:109
@@ -2223,9 +2223,11 @@ msgstr ""
 #: src/Module/Moderation/Blocklist/Server/Import.php:105
 #: src/Module/Moderation/Blocklist/Server/Index.php:84
 #: src/Module/Moderation/Item/Delete.php:47
+#: src/Module/Moderation/Item/Source.php:71
 #: src/Module/Moderation/Reports.php:99 src/Module/Moderation/Summary.php:64
 #: src/Module/Moderation/Users/Active.php:89
 #: src/Module/Moderation/Users/Blocked.php:89
+#: src/Module/Moderation/Users/Create.php:47
 #: src/Module/Moderation/Users/Deleted.php:66
 #: src/Module/Moderation/Users/Index.php:96
 msgid "Moderation"
@@ -2259,33 +2261,33 @@ msgstr ""
 msgid "last"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:900
+#: src/Content/Text/BBCode.php:909
 #, php-format
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:928 src/Model/Item.php:3618
-#: src/Model/Item.php:3624 src/Model/Item.php:3625
+#: src/Content/Text/BBCode.php:937 src/Model/Item.php:3622
+#: src/Model/Item.php:3628 src/Model/Item.php:3629
 msgid "Link to source"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1718 src/Content/Text/HTML.php:901
+#: src/Content/Text/BBCode.php:1727 src/Content/Text/HTML.php:901
 msgid "Click to open/close"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1773
+#: src/Content/Text/BBCode.php:1782
 msgid "$1 wrote:"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1847 src/Content/Text/BBCode.php:1848
+#: src/Content/Text/BBCode.php:1856 src/Content/Text/BBCode.php:1857
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2164
+#: src/Content/Text/BBCode.php:2173
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2183
+#: src/Content/Text/BBCode.php:2192
 msgid "Invalid link protocol"
 msgstr ""
 
@@ -2487,7 +2489,7 @@ msgid "Post to group"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:99 src/Model/Contact.php:1266
-#: src/Model/Profile.php:441 src/Module/Moderation/Item/Source.php:80
+#: src/Model/Profile.php:441 src/Module/Moderation/Item/Source.php:81
 msgid "Mention"
 msgstr ""
 
@@ -3437,44 +3439,44 @@ msgstr ""
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3518
+#: src/Model/Item.php:3522
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3549
+#: src/Model/Item.php:3553
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3551
+#: src/Model/Item.php:3555
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3556
+#: src/Model/Item.php:3560
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3558
+#: src/Model/Item.php:3562
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3560
+#: src/Model/Item.php:3564
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3601 src/Model/Item.php:3602
+#: src/Model/Item.php:3605 src/Model/Item.php:3606
 msgid "View on separate page"
 msgstr ""
 
@@ -3896,7 +3898,6 @@ msgstr ""
 #: src/Module/Admin/Site.php:442 src/Module/Admin/Storage.php:124
 #: src/Module/Admin/Summary.php:183 src/Module/Admin/Themes/Details.php:82
 #: src/Module/Admin/Themes/Index.php:103 src/Module/Admin/Tos.php:63
-#: src/Module/Moderation/Users/Create.php:47
 #: src/Module/Moderation/Users/Pending.php:82
 msgid "Administration"
 msgstr ""
@@ -5704,7 +5705,7 @@ msgstr ""
 msgid "Delete Item"
 msgstr ""
 
-#: src/Module/BaseModeration.php:110 src/Module/Moderation/Item/Source.php:71
+#: src/Module/BaseModeration.php:110 src/Module/Moderation/Item/Source.php:72
 msgid "Item Source"
 msgstr ""
 
@@ -6184,7 +6185,6 @@ msgstr ""
 #: src/Module/Moderation/Reports.php:105
 #: src/Module/Moderation/Users/Active.php:82
 #: src/Module/Moderation/Users/Blocked.php:82
-#: src/Module/Moderation/Users/Create.php:56
 #: src/Module/Moderation/Users/Deleted.php:69
 #: src/Module/Moderation/Users/Index.php:89
 #: src/Module/Moderation/Users/Index.php:109
@@ -6745,7 +6745,7 @@ msgid "Result Item"
 msgstr ""
 
 #: src/Module/Debug/ActivityPubConversion.php:117
-#: src/Module/Moderation/Item/Source.php:82
+#: src/Module/Moderation/Item/Source.php:83
 #: src/Module/Security/TwoFactor/Verify.php:84
 msgid "Error"
 msgid_plural "Errors"
@@ -7653,54 +7653,54 @@ msgstr ""
 msgid "The GUID of the item you want to delete."
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:72
+#: src/Module/Moderation/Item/Source.php:73
 msgid "Item Id"
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:73
+#: src/Module/Moderation/Item/Source.php:74
 msgid "Item URI"
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:75
+#: src/Module/Moderation/Item/Source.php:76
 msgid "Terms"
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:76
+#: src/Module/Moderation/Item/Source.php:77
 msgid "Tag"
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:77
+#: src/Module/Moderation/Item/Source.php:78
 #: src/Module/Moderation/Users/Active.php:82
 #: src/Module/Moderation/Users/Blocked.php:82
 #: src/Module/Moderation/Users/Index.php:89
 msgid "Type"
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:78
+#: src/Module/Moderation/Item/Source.php:79
 msgid "Term"
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:79
+#: src/Module/Moderation/Item/Source.php:80
 msgid "URL"
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:81
+#: src/Module/Moderation/Item/Source.php:82
 msgid "Implicit Mention"
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:83
+#: src/Module/Moderation/Item/Source.php:84
 msgid "Item not found"
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:84
+#: src/Module/Moderation/Item/Source.php:85
 msgid "No source recorded"
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:85
+#: src/Module/Moderation/Item/Source.php:86
 msgid "Please make sure the <code>debug.store_source</code> config key is set in <code>config/local.config.php</code> for future items to have sources."
 msgstr ""
 
-#: src/Module/Moderation/Item/Source.php:87
+#: src/Module/Moderation/Item/Source.php:88
 msgid "Item Guid"
 msgstr ""
 
@@ -8041,27 +8041,20 @@ msgid "User \"%s\" unblocked"
 msgstr ""
 
 #: src/Module/Moderation/Users/Create.php:48
-msgid "New User"
+#: src/Module/Moderation/Users/Create.php:50
+msgid "Create user"
 msgstr ""
 
 #: src/Module/Moderation/Users/Create.php:49
-msgid "Add User"
-msgstr ""
-
-#: src/Module/Moderation/Users/Create.php:56
-msgid "Name of the new user."
+msgid "Type in the details for the new user to be created."
 msgstr ""
 
 #: src/Module/Moderation/Users/Create.php:57
-msgid "Nickname"
-msgstr ""
-
-#: src/Module/Moderation/Users/Create.php:57
-msgid "Nickname of the new user."
+msgid "Display name"
 msgstr ""
 
 #: src/Module/Moderation/Users/Create.php:58
-msgid "Email address of the new user."
+msgid "Nickname"
 msgstr ""
 
 #: src/Module/Moderation/Users/Deleted.php:67

--- a/view/templates/moderation/item/source.tpl
+++ b/view/templates/moderation/item/source.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div id="source" class="generic-page-wrapper">
-	<h2>{{$l10n.title}}</h2>
+	<h1>{{$l10n.title}} - {{$l10n.page}}</h1>
 	<form action="moderation/item/source" method="get" class="panel panel-default">
 		<div class="panel-body">
 			<div class="form-group">

--- a/view/templates/moderation/users/create.tpl
+++ b/view/templates/moderation/users/create.tpl
@@ -7,18 +7,20 @@
 <div id="adminpage">
 	<h1>{{$title}} - {{$page}}</h1>
 
+	<p>{{$description}}</p>
+
 	<form action="{{$baseurl}}/{{$query_string}}" method="post">
 		<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
 		<table id="users">
 			<tbody>
 			<tr>
-				<td>{{include file="field_input.tpl" field=$newusername}}</td>
+				<td>{{include file="field_input.tpl" field=$newusername label=false}}</td>
 			</tr>
 			<tr>
-				<td>{{include file="field_input.tpl" field=$newusernickname}}</td>
+				<td>{{include file="field_input.tpl" field=$newusernickname label=false}}</td>
 			</tr>
 			<tr>
-				<td>{{include file="field_input.tpl" field=$newuseremail}}</td>
+				<td>{{include file="field_input.tpl" field=$newuseremail label=false}}</td>
 			</tr>
 			</tbody>
 		</table>

--- a/view/theme/frio/templates/moderation/users/create.tpl
+++ b/view/theme/frio/templates/moderation/users/create.tpl
@@ -7,12 +7,14 @@
 <div id="admin-users" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}}</h1>
 
+	<p>{{$description}}</p>
+
 	<form action="{{$baseurl}}/{{$query_string}}" method="post">
 		<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
 
-		{{include file="field_input.tpl" field=$newusername}}
-		{{include file="field_input.tpl" field=$newusernickname}}
-		{{include file="field_input.tpl" field=$newuseremail}}
+		{{include file="field_input.tpl" field=$newusername label=false}}
+		{{include file="field_input.tpl" field=$newusernickname label=false}}
+		{{include file="field_input.tpl" field=$newuseremail label=false}}
 		<p>
 			<button type="submit" class="btn btn-primary">{{$submit}}</button>
 		</p>

--- a/view/theme/frio/templates/register.tpl
+++ b/view/theme/frio/templates/register.tpl
@@ -27,7 +27,7 @@
 		{{if $oidlabel}}
 		<div id="register-openid-wrapper" class="form-group">
 			<label for="register-openid" id="label-register-openid">{{$oidlabel}}</label>
-			<input type="text" maxlength="60" size="32" name="openid_url" class="openid form-control" id="register-openid" value="{{$openid}}">
+			<input type="text" maxlength="60" name="openid_url" class="openid form-control" id="register-openid" value="{{$openid}}">
 			<span class="help-block" id="openid_url_tip">{{$fillwith}}&nbsp;{{$fillext}}</span>
 		</div>
 		<div id="register-openid-end"></div>
@@ -36,7 +36,7 @@
 		{{if $invitations}}
 		<div id="register-invite-wrapper" class="form-group">
 			<label for="register-invite" id="label-register-invite">{{$invite_label}}</label>
-			<input type="text" maxlength="60" size="32" name="invite_id" id="register-invite" class="form-control" value="{{$invite_id}}">
+			<input type="text" maxlength="60" name="invite_id" id="register-invite" class="form-control" value="{{$invite_id}}">
 			<span class="help-block" id="invite_id_tip">{{$invite_desc nofilter}}</span>
 		</div>
 		<div id="register-name-end"></div>
@@ -44,7 +44,7 @@
 
 		<div id="register-name-wrapper" class="form-group">
 			<label for="register-name" id="label-register-name">{{$namelabel}}</label>
-			<input type="text" maxlength="60" size="32" name="username" id="register-name" class="form-control" value="{{$username}}" required autofocus>
+			<input type="text" maxlength="60" name="username" id="register-name" class="form-control" value="{{$username}}" required autofocus>
 		</div>
 		<div id="register-name-end"></div>
 
@@ -52,13 +52,13 @@
 		{{if !$additional}}
 			<div id="register-email-wrapper" class="form-group">
 				<label for="register-email" id="label-register-email">{{$addrlabel}}</label>
-				<input type="text" maxlength="60" size="32" name="field1" id="register-email" class="form-control" value="{{$email}}" required>
+				<input type="text" maxlength="60" name="field1" id="register-email" class="form-control" value="{{$email}}" required>
 			</div>
 			<div id="register-email-end"></div>
 
 			<div id="register-repeat-wrapper" class="form-group">
 				<label for="register-repeat" id="label-register-repeat">{{$addrlabel2}}</label>
-				<input type="text" maxlength="60" size="32" name="repeat" id="register-repeat" class="form-control" value="" required>
+				<input type="text" maxlength="60" name="repeat" id="register-repeat" class="form-control" value="" required>
 			</div>
 			<div id="register-repeat-end"></div>
 		{{/if}}


### PR DESCRIPTION
Mostly extracts a few things from #15083 

- Title on the moderation page to create a user is changed to "Moderation" instead of "Administration"
  The three fields for creating a user are all set to be required in HTML, as they are, and the first one is also autofocused.
  "Name" is changed to "Display name".
- The title on "Item source" is changed to be consistent with other moderation pages. The field is also autofocused.
- Some unused `size` attributes are removed in register.tpl (frio) - they're sized by the `form-control` class.

# Before

<img width="639" height="422" alt="image" src="https://github.com/user-attachments/assets/30b3e670-ef28-4ccc-a005-c46532e1a025" />

<img width="631" height="215" alt="image" src="https://github.com/user-attachments/assets/181f551c-bb3c-4975-8dbd-8ca04365ca8e" />

# After

<img width="637" height="302" alt="image" src="https://github.com/user-attachments/assets/e0744d60-5f7d-4e77-9fda-461e67b61bf9" />

<img width="624" height="203" alt="image" src="https://github.com/user-attachments/assets/ec771f96-6edb-4401-a554-000a47eec3eb" />