### PR TITLE
Add missing moderation report category

### DIFF
--- a/src/Module/Moderation/Report/Create.php
+++ b/src/Module/Moderation/Report/Create.php
@@ -298,28 +298,32 @@ class Create extends BaseModule
 		]);
 	}
 
+	// A copy of the one in Moderation/Reports.php - please consolidate!
+	public function getReportCategoryName(int $category): string
+	{
+		switch ($category) {
+			case Report::CATEGORY_SPAM:
+				return $this->t('Spam');
+			case Report::CATEGORY_ILLEGAL:
+				return $this->t('Illegal Content');
+			case Report::CATEGORY_SAFETY:
+				return $this->t('Community Safety');
+			case Report::CATEGORY_UNWANTED:
+				return $this->t('Unwanted Content/Behavior');
+			case Report::CATEGORY_VIOLATION:
+				return $this->t('Rules Violation');
+			case Report::CATEGORY_OTHER:
+				return $this->t('Other');
+			default:
+				return "";
+		};
+	}
+
 	private function getAside(array $request): string
 	{
 		$contact = null;
 		if (!empty($request['cid'])) {
 			$contact = Contact::getById($request['cid']);
-		}
-
-		switch ($request['category'] ?? 0) {
-			case Report::CATEGORY_SPAM:      $category = $this->t('Spam');
-				break;
-			case Report::CATEGORY_ILLEGAL:   $category = $this->t('Illegal Content');
-				break;
-			case Report::CATEGORY_SAFETY:    $category = $this->t('Community Safety');
-				break;
-			case Report::CATEGORY_UNWANTED:  $category = $this->t('Unwanted Content/Behavior');
-				break;
-			case Report::CATEGORY_VIOLATION: $category = $this->t('Rules Violation');
-				break;
-			case Report::CATEGORY_OTHER:     $category = $this->t('Other');
-				break;
-
-			default: $category = '';
 		}
 
 		if (!empty($request['rule-ids'])) {
@@ -339,7 +343,7 @@ class Create extends BaseModule
 			],
 
 			'$contact'  => $contact,
-			'$category' => $category,
+			'$category' => self::getReportCategoryName($request['category'] ?? 0),
 			'$rules'    => $rules ?? [],
 			'$comment'  => BBCode::convertForUriId($contact['uri-id'] ?? 0, $this->session->get('report_comment') ?? '', BBCode::EXTERNAL),
 			'$posts'    => count($request['uri-ids'] ?? []),

--- a/src/Module/Moderation/Report/Create.php
+++ b/src/Module/Moderation/Report/Create.php
@@ -23,6 +23,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Moderation\Entity\Report;
+use Friendica\Module\Moderation\Utils\ReportUtil;
 use Friendica\Module\Response;
 use Friendica\Navigation\SystemMessages;
 use Friendica\Network\HTTPException\ForbiddenException;
@@ -46,13 +47,16 @@ class Create extends BaseModule
 	private $factory;
 	/** @var \Friendica\Moderation\Repository\Report */
 	private $repository;
+	/** @var ReportUtil */
+	protected $reportUtil;
 
-	public function __construct(\Friendica\Moderation\Repository\Report $repository, \Friendica\Moderation\Factory\Report $factory, UserSession $session, App\Page $page, SystemMessages $systemMessages, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(\Friendica\Moderation\Repository\Report $repository, ReportUtil $reportUtil, \Friendica\Moderation\Factory\Report $factory, UserSession $session, App\Page $page, SystemMessages $systemMessages, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->systemMessages = $systemMessages;
 		$this->page           = $page;
+		$this->reportUtil     = $reportUtil;
 		$this->session        = $session;
 		$this->factory        = $factory;
 		$this->repository     = $repository;
@@ -298,27 +302,6 @@ class Create extends BaseModule
 		]);
 	}
 
-	// A copy of the one in Moderation/Reports.php - please consolidate!
-	public function getReportCategoryName(int $category): string
-	{
-		switch ($category) {
-			case Report::CATEGORY_SPAM:
-				return $this->t('Spam');
-			case Report::CATEGORY_ILLEGAL:
-				return $this->t('Illegal Content');
-			case Report::CATEGORY_SAFETY:
-				return $this->t('Community Safety');
-			case Report::CATEGORY_UNWANTED:
-				return $this->t('Unwanted Content/Behavior');
-			case Report::CATEGORY_VIOLATION:
-				return $this->t('Rules Violation');
-			case Report::CATEGORY_OTHER:
-				return $this->t('Other');
-			default:
-				return "";
-		};
-	}
-
 	private function getAside(array $request): string
 	{
 		$contact = null;
@@ -343,7 +326,7 @@ class Create extends BaseModule
 			],
 
 			'$contact'  => $contact,
-			'$category' => self::getReportCategoryName($request['category'] ?? 0),
+			'$category' => $this->reportUtil->getReportCategoryName($request['category'] ?? 0),
 			'$rules'    => $rules ?? [],
 			'$comment'  => BBCode::convertForUriId($contact['uri-id'] ?? 0, $this->session->get('report_comment') ?? '', BBCode::EXTERNAL),
 			'$posts'    => count($request['uri-ids'] ?? []),

--- a/src/Module/Moderation/Reports.php
+++ b/src/Module/Moderation/Reports.php
@@ -19,6 +19,7 @@ use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\Module\BaseModeration;
+use Friendica\Moderation\Entity\Report;
 use Friendica\Module\Response;
 use Friendica\Navigation\SystemMessages;
 use Friendica\Util\DateTimeFormat;
@@ -41,6 +42,27 @@ class Reports extends BaseModeration
 	{
 		// @todo check if POST is really used here
 		$this->content($request);
+	}
+
+	// A copy of the one in Report/Create.php - please consolidate!
+	public function getReportCategoryName(int $category): string
+	{
+		switch ($category) {
+			case Report::CATEGORY_SPAM:
+				return $this->t('Spam');
+			case Report::CATEGORY_ILLEGAL:
+				return $this->t('Illegal Content');
+			case Report::CATEGORY_SAFETY:
+				return $this->t('Community Safety');
+			case Report::CATEGORY_UNWANTED:
+				return $this->t('Unwanted Content/Behavior');
+			case Report::CATEGORY_VIOLATION:
+				return $this->t('Rules Violation');
+			case Report::CATEGORY_OTHER:
+				return $this->t('Other');
+			default:
+				return "";
+		};
 	}
 
 	protected function content(array $request = []): string
@@ -72,8 +94,9 @@ LIMIT ?, ?",
 
 		$reports = [];
 		while ($report = $this->database->fetch($query)) {
-			$report['posts']   = [];
-			$report['created'] = DateTimeFormat::local($report['created'], DateTimeFormat::MYSQL);
+			$report['posts']    = [];
+			$report['created']  = DateTimeFormat::local($report['created'], DateTimeFormat::MYSQL);
+			$report['category'] = self::getReportCategoryName($report['category-id']);
 
 			$reports[$report['id']] = $report;
 		}

--- a/src/Module/Moderation/Reports.php
+++ b/src/Module/Moderation/Reports.php
@@ -19,7 +19,7 @@ use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\Module\BaseModeration;
-use Friendica\Moderation\Entity\Report;
+use Friendica\Module\Moderation\Utils\ReportUtil;
 use Friendica\Module\Response;
 use Friendica\Navigation\SystemMessages;
 use Friendica\Util\DateTimeFormat;
@@ -30,39 +30,21 @@ class Reports extends BaseModeration
 {
 	/** @var Database */
 	private $database;
+	/** @var ReportUtil */
+	protected $reportUtil;
 
-	public function __construct(Database $database, Page $page, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(Database $database, Page $page, ReportUtil $reportUtil, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($page, $appHelper, $systemMessages, $session, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
-		$this->database = $database;
+		$this->database   = $database;
+		$this->reportUtil = $reportUtil;
 	}
 
 	protected function post(array $request = [])
 	{
 		// @todo check if POST is really used here
 		$this->content($request);
-	}
-
-	// A copy of the one in Report/Create.php - please consolidate!
-	public function getReportCategoryName(int $category): string
-	{
-		switch ($category) {
-			case Report::CATEGORY_SPAM:
-				return $this->t('Spam');
-			case Report::CATEGORY_ILLEGAL:
-				return $this->t('Illegal Content');
-			case Report::CATEGORY_SAFETY:
-				return $this->t('Community Safety');
-			case Report::CATEGORY_UNWANTED:
-				return $this->t('Unwanted Content/Behavior');
-			case Report::CATEGORY_VIOLATION:
-				return $this->t('Rules Violation');
-			case Report::CATEGORY_OTHER:
-				return $this->t('Other');
-			default:
-				return "";
-		};
 	}
 
 	protected function content(array $request = []): string
@@ -96,7 +78,7 @@ LIMIT ?, ?",
 		while ($report = $this->database->fetch($query)) {
 			$report['posts']    = [];
 			$report['created']  = DateTimeFormat::local($report['created'], DateTimeFormat::MYSQL);
-			$report['category'] = self::getReportCategoryName($report['category-id']);
+			$report['category'] = $this->reportUtil->getReportCategoryName($report['category-id']);
 
 			$reports[$report['id']] = $report;
 		}

--- a/src/Module/Moderation/Utils/ReportUtil.php
+++ b/src/Module/Moderation/Utils/ReportUtil.php
@@ -1,0 +1,41 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Module\Moderation\Utils;
+
+use Friendica\Core\L10n;
+use Friendica\Moderation\Entity\Report;
+
+final class ReportUtil
+{
+	private L10n $l10n;
+
+	public function __construct(L10n $l10n)
+	{
+		$this->l10n = $l10n;
+	}
+
+	public function getReportCategoryName(int $category): string
+	{
+		switch ($category) {
+			case Report::CATEGORY_SPAM:
+				return $this->l10n->t('Spam');
+			case Report::CATEGORY_ILLEGAL:
+				return $this->l10n->t('Illegal Content');
+			case Report::CATEGORY_SAFETY:
+				return $this->l10n->t('Community Safety');
+			case Report::CATEGORY_UNWANTED:
+				return $this->l10n->t('Unwanted Content/Behavior');
+			case Report::CATEGORY_VIOLATION:
+				return $this->l10n->t('Rules Violation');
+			case Report::CATEGORY_OTHER:
+				return $this->l10n->t('Other');
+			default:
+				return "";
+		};
+	}
+}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-24 11:58+0000\n"
+"POT-Creation-Date: 2025-10-29 19:23+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -441,10 +441,10 @@ msgstr ""
 #: src/Module/Install.php:259 src/Module/Install.php:296
 #: src/Module/Invite.php:162 src/Module/Item/Compose.php:188
 #: src/Module/Moderation/Item/Source.php:75
-#: src/Module/Moderation/Report/Create.php:153
-#: src/Module/Moderation/Report/Create.php:168
-#: src/Module/Moderation/Report/Create.php:196
-#: src/Module/Moderation/Report/Create.php:256
+#: src/Module/Moderation/Report/Create.php:157
+#: src/Module/Moderation/Report/Create.php:172
+#: src/Module/Moderation/Report/Create.php:200
+#: src/Module/Moderation/Report/Create.php:260
 #: src/Module/Settings/Server/Action.php:65 src/Module/User/Delegation.php:181
 #: src/Object/Post.php:1159 view/theme/duepuntozero/config.php:73
 #: view/theme/frio/config.php:155 view/theme/quattro/config.php:75
@@ -595,7 +595,7 @@ msgid "This is you"
 msgstr ""
 
 #: mod/photos.php:1097 mod/photos.php:1153 mod/photos.php:1233
-#: src/Module/Moderation/Reports.php:105 src/Object/Post.php:607
+#: src/Module/Moderation/Reports.php:111 src/Object/Post.php:607
 #: src/Object/Post.php:1158
 msgid "Comment"
 msgstr ""
@@ -2224,7 +2224,7 @@ msgstr ""
 #: src/Module/Moderation/Blocklist/Server/Index.php:84
 #: src/Module/Moderation/Item/Delete.php:47
 #: src/Module/Moderation/Item/Source.php:71
-#: src/Module/Moderation/Reports.php:99 src/Module/Moderation/Summary.php:64
+#: src/Module/Moderation/Reports.php:105 src/Module/Moderation/Summary.php:64
 #: src/Module/Moderation/Users/Active.php:89
 #: src/Module/Moderation/Users/Blocked.php:89
 #: src/Module/Moderation/Users/Create.php:47
@@ -2266,8 +2266,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3630
-#: src/Model/Item.php:3636 src/Model/Item.php:3637
+#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3644
+#: src/Model/Item.php:3650 src/Model/Item.php:3651
 msgid "Link to source"
 msgstr ""
 
@@ -3439,44 +3439,44 @@ msgstr ""
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3530
+#: src/Model/Item.php:3544
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3561
+#: src/Model/Item.php:3575
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3563
+#: src/Model/Item.php:3577
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3568
+#: src/Model/Item.php:3582
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3570
+#: src/Model/Item.php:3584
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3572
+#: src/Model/Item.php:3586
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3613 src/Model/Item.php:3614
+#: src/Model/Item.php:3627 src/Model/Item.php:3628
 msgid "View on separate page"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgid "Title/Description:"
 msgstr ""
 
 #: src/Model/Profile.php:803 src/Module/Admin/Summary.php:184
-#: src/Module/Moderation/Report/Create.php:278
+#: src/Module/Moderation/Report/Create.php:282
 #: src/Module/Moderation/Summary.php:65
 msgid "Summary"
 msgstr ""
@@ -4034,8 +4034,8 @@ msgid "Manage Additional Features"
 msgstr ""
 
 #: src/Module/Admin/Federation.php:70
-#: src/Module/Moderation/Report/Create.php:176
-#: src/Module/Moderation/Report/Create.php:319
+#: src/Module/Moderation/Report/Create.php:180
+#: src/Module/Moderation/Utils/ReportUtil.php:36
 msgid "Other"
 msgstr ""
 
@@ -4267,7 +4267,7 @@ msgstr ""
 msgid "Job Parameters"
 msgstr ""
 
-#: src/Module/Admin/Queue.php:65 src/Module/Moderation/Reports.php:105
+#: src/Module/Admin/Queue.php:65 src/Module/Moderation/Reports.php:111
 #: src/Module/Settings/OAuth.php:60
 msgid "Created"
 msgstr ""
@@ -5680,7 +5680,7 @@ msgstr ""
 msgid "Submanaged account can't access the moderation pages. Please log back in as the main account."
 msgstr ""
 
-#: src/Module/BaseModeration.php:99 src/Module/Moderation/Reports.php:104
+#: src/Module/BaseModeration.php:99 src/Module/Moderation/Reports.php:110
 msgid "Reports"
 msgstr ""
 
@@ -6182,7 +6182,7 @@ msgstr ""
 
 #: src/Module/Contact/Advanced.php:120
 #: src/Module/Moderation/Blocklist/Contact.php:110
-#: src/Module/Moderation/Reports.php:105
+#: src/Module/Moderation/Reports.php:111
 #: src/Module/Moderation/Users/Active.php:82
 #: src/Module/Moderation/Users/Blocked.php:82
 #: src/Module/Moderation/Users/Deleted.php:69
@@ -6300,7 +6300,7 @@ msgstr ""
 #: src/Module/Contact/Follow.php:155 src/Module/Contact/Profile.php:449
 #: src/Module/Contact/Unfollow.php:115
 #: src/Module/Moderation/Blocklist/Contact.php:119
-#: src/Module/Moderation/Reports.php:112
+#: src/Module/Moderation/Reports.php:118
 #: src/Module/Notifications/Introductions.php:121
 #: src/Module/Notifications/Introductions.php:192
 msgid "Profile URL"
@@ -6469,7 +6469,7 @@ msgid "Block/Unblock contact"
 msgstr ""
 
 #: src/Module/Contact/Profile.php:420
-#: src/Module/Moderation/Report/Create.php:291
+#: src/Module/Moderation/Report/Create.php:295
 msgid "Ignore contact"
 msgstr ""
 
@@ -7378,7 +7378,7 @@ msgid "Block New Remote Contact"
 msgstr ""
 
 #: src/Module/Moderation/Blocklist/Contact.php:110
-#: src/Module/Moderation/Reports.php:105
+#: src/Module/Moderation/Reports.php:111
 msgid "Photo"
 msgstr ""
 
@@ -7704,207 +7704,207 @@ msgstr ""
 msgid "Item Guid"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:80
+#: src/Module/Moderation/Report/Create.php:84
 msgid "Contact not found or their server is already blocked on this node."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:121
+#: src/Module/Moderation/Report/Create.php:125
 msgid "Please login to access this page."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:150
-#: src/Module/Moderation/Report/Create.php:165
-#: src/Module/Moderation/Report/Create.php:193
-#: src/Module/Moderation/Report/Create.php:253
-#: src/Module/Moderation/Report/Create.php:277
+#: src/Module/Moderation/Report/Create.php:154
+#: src/Module/Moderation/Report/Create.php:169
+#: src/Module/Moderation/Report/Create.php:197
+#: src/Module/Moderation/Report/Create.php:257
+#: src/Module/Moderation/Report/Create.php:281
 msgid "Create Moderation Report"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:151
+#: src/Module/Moderation/Report/Create.php:155
 msgid "Pick Contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:152
+#: src/Module/Moderation/Report/Create.php:156
 msgid "Please enter below the contact address or profile URL you would like to create a moderation report about."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:156
+#: src/Module/Moderation/Report/Create.php:160
 msgid "Contact address/URL"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:166
+#: src/Module/Moderation/Report/Create.php:170
 msgid "Pick Category"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:167
+#: src/Module/Moderation/Report/Create.php:171
 msgid "Please pick below the category of your report."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:171
-#: src/Module/Moderation/Report/Create.php:309
+#: src/Module/Moderation/Report/Create.php:175
+#: src/Module/Moderation/Utils/ReportUtil.php:26
 msgid "Spam"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:171
+#: src/Module/Moderation/Report/Create.php:175
 msgid "This contact is publishing many repeated/overly long posts/replies or advertising their product/websites in otherwise irrelevant conversations."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:172
-#: src/Module/Moderation/Report/Create.php:311
+#: src/Module/Moderation/Report/Create.php:176
+#: src/Module/Moderation/Utils/ReportUtil.php:28
 msgid "Illegal Content"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:172
+#: src/Module/Moderation/Report/Create.php:176
 msgid "This contact is publishing content that is considered illegal in this node's hosting juridiction."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:173
-#: src/Module/Moderation/Report/Create.php:313
+#: src/Module/Moderation/Report/Create.php:177
+#: src/Module/Moderation/Utils/ReportUtil.php:30
 msgid "Community Safety"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:173
+#: src/Module/Moderation/Report/Create.php:177
 msgid "This contact aggravated you or other people, by being provocative or insensitive, intentionally or not. This includes disclosing people's private information (doxxing), posting threats or offensive pictures in posts or replies."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:174
-#: src/Module/Moderation/Report/Create.php:315
+#: src/Module/Moderation/Report/Create.php:178
+#: src/Module/Moderation/Utils/ReportUtil.php:32
 msgid "Unwanted Content/Behavior"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:174
+#: src/Module/Moderation/Report/Create.php:178
 msgid "This contact has repeatedly published content irrelevant to the node's theme or is openly criticizing the node's administration/moderation without directly engaging with the relevant people for example or repeatedly nitpicking on a sensitive topic."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:175
-#: src/Module/Moderation/Report/Create.php:317
+#: src/Module/Moderation/Report/Create.php:179
+#: src/Module/Moderation/Utils/ReportUtil.php:34
 msgid "Rules Violation"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:175
+#: src/Module/Moderation/Report/Create.php:179
 msgid "This contact violated one or more rules of this node. You will be able to pick which one(s) in the next step."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:176
+#: src/Module/Moderation/Report/Create.php:180
 msgid "Please elaborate below why you submitted this report. The more details you provide, the better your report can be handled."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:178
+#: src/Module/Moderation/Report/Create.php:182
 msgid "Additional Information"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:178
+#: src/Module/Moderation/Report/Create.php:182
 msgid "Please provide any additional information relevant to this particular report. You will be able to attach posts by this contact in the next step, but any context is welcome."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:194
+#: src/Module/Moderation/Report/Create.php:198
 msgid "Pick Rules"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:195
+#: src/Module/Moderation/Report/Create.php:199
 msgid "Please pick below the node rules you believe this contact violated."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:254
+#: src/Module/Moderation/Report/Create.php:258
 msgid "Pick Posts"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:255
+#: src/Module/Moderation/Report/Create.php:259
 msgid "Please optionally pick posts to attach to your report."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:271
+#: src/Module/Moderation/Report/Create.php:275
 msgid "Would you like to forward this report to the remote server?"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:273
+#: src/Module/Moderation/Report/Create.php:277
 msgid "Would you ike to forward this report to the remote server?"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:279
+#: src/Module/Moderation/Report/Create.php:283
 msgid "Submit Report"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:280
+#: src/Module/Moderation/Report/Create.php:284
 msgid "Further Action"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:281
+#: src/Module/Moderation/Report/Create.php:285
 msgid "You can also perform one of the following action on the contact you reported:"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:289
+#: src/Module/Moderation/Report/Create.php:293
 msgid "Nothing"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:290
+#: src/Module/Moderation/Report/Create.php:294
 msgid "Collapse contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:290
+#: src/Module/Moderation/Report/Create.php:294
 msgid "Their posts and replies will keep appearing in your Network page but their content will be collapsed by default."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:291
+#: src/Module/Moderation/Report/Create.php:295
 msgid "Their posts won't appear in your Network page anymore, but their replies can appear in forum threads. They still can follow you."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:292
+#: src/Module/Moderation/Report/Create.php:296
 msgid "Block contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:292
+#: src/Module/Moderation/Report/Create.php:296
 msgid "Their posts won't appear in your Network page anymore, but their replies can appear in forum threads, with their content collapsed by default. They cannot follow you but still can have access to your public posts by other means."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:295
+#: src/Module/Moderation/Report/Create.php:299
 msgid "Forward report"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:334
+#: src/Module/Moderation/Report/Create.php:321
 msgid "1. Pick a contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:335
+#: src/Module/Moderation/Report/Create.php:322
 msgid "2. Pick a category"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:336
+#: src/Module/Moderation/Report/Create.php:323
 msgid "2a. Pick rules"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:337
+#: src/Module/Moderation/Report/Create.php:324
 msgid "2b. Add comment"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:338
+#: src/Module/Moderation/Report/Create.php:325
 msgid "3. Pick posts"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:100
+#: src/Module/Moderation/Reports.php:106
 msgid "List of reports"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:101
+#: src/Module/Moderation/Reports.php:107
 msgid "This page display reports created by our or remote users."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:102
+#: src/Module/Moderation/Reports.php:108
 msgid "No report exists at this node."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:105
+#: src/Module/Moderation/Reports.php:111
 msgid "Category"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:109
+#: src/Module/Moderation/Reports.php:115
 #, php-format
 msgid "%s total report"
 msgid_plural "%s total reports"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Moderation/Reports.php:112
+#: src/Module/Moderation/Reports.php:118
 msgid "URL of the reported contact."
 msgstr ""
 


### PR DESCRIPTION
Closes #14525

This appears to solve the issue, but I don't particularly like the solution so it's set as *draft* for now.
Particularly I'd like to centrally define the source string for each category, instead of repeating it in multiple places.
I tried putting it in Report/Create.php and calling the method from Moderation/Reports, but it didn't seem to work. Maybe Create wasn't properly instantiated? Then I tried making the method `static` but that seems to cause issues because the translation methods are not?

I think it would make more sense if something like Entity/Model contained this mapping, but maybe that's not the right place either, if that's generally tied to the database? Does it belong in a new Report model class?

<img width="628" height="435" alt="image" src="https://github.com/user-attachments/assets/eaa5e2f4-c0be-4bd8-a019-49566e412062" />

# Edit

The PR used to change this, but I've now changed it to instead default to an empty string. Still not sure if this idea is better or not:

> Also, right now, my rewrites changes things so if no category is passed, it defaults to the "OTHER" category.