### PR TITLE
Minor update to docs to say frio is the default theme

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -54,11 +54,10 @@ See [this help page](/help/translations) for more information about the translat
 
 Choose a theme to be the default system theme.
 This can be over-ridden by user profiles.
-Default theme is `vier` at the moment.
+Default theme is `frio` at the moment.
 
 You may also want to set a special theme for mobile interfaces.
-Which may or may not be necessary depending of the mobile friendliness of the desktop theme you have chosen.
-The `vier` theme for instance is mobile friendly.
+It may or may not be necessary depending of the mobile friendliness of the desktop theme you have chosen.
 
 ### Registration
 

--- a/doc/de/Settings.md
+++ b/doc/de/Settings.md
@@ -47,10 +47,9 @@ Mehr Informationen zum Übersetzungsprozess von Friendica findest du [auf dieser
 
 Hier kann das Theme bestimmt werden, welches standardmäßig zum Anzeigen der Seite verwendet werden soll.
 Nutzer können in ihren Einstellungen andere Themes wählen.
-Derzeit ist das "vier" Theme das vorausgewählte Theme.
+Derzeit ist das "frio" Theme das vorausgewählte Theme.
 
 Für mobile Geräte kannst du ein spezielles Theme wählen, wenn das Standardtheme ungeeignet für mobile Geräte sein sollte.
-Das `vier` Theme z.B. unterstützt kleine Anzeigen und benötigt kein zusätzliches mobiles Theme.
 
 ### Registrierung
 


### PR DESCRIPTION
Also I've removed a specific recommendation for vier as a mobile friendly theme, as my guess is that frio is no less mobile friendly (I could be wrong, though?), and if vier is highlighted I'd read it as frio not being that?