### PR TITLE
Don't store MP4 video when processing HLS video

### DIFF
--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1917,10 +1917,6 @@ class Receiver
 
 				$attachments[$mediatype] = ['type' => $mediatype, 'mediaType' => $mediatype, 'url' => $href, 'height' => $height, 'width' => $width, 'size' => null, 'name' => ''];
 			} elseif ($mediatype == 'application/x-mpegURL') {
-				// PeerTube uses HLS streams for video. We prefer HLS streams over the video file itself.
-				// But we still store the video file as an attachment to be used by the API which currently does not support HLS streams.
-				$attachments = array_merge($attachments, self::processAttachmentUrls($url['as:tag'], $icon, [], []));
-
 				$attachment = ['type' => $filetype, 'mediaType' => $mediatype, 'url' => $href, 'height' => $height, 'width' => $width, 'size' => null, 'name' => '', 'image' => $icon];
 				if (is_array($player)) {
 					$attachment['player-url']    = $player['embed']  ?? null;


### PR DESCRIPTION
In the past we stored the MP4 videos from Peertube videos, because we couldn't handle HLS videos. But for some time now we can handle HLS and treat it with priority. So we don't need Peertube's MP4 videos any more.