### PR TITLE
Attach single media to post

### DIFF
--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -485,7 +485,7 @@ class Media
 		$media['modified']        = $data['modified']         ?? null;
 		$media['schematypes']     = isset($data['schematypes']) ? json_encode($data['schematypes']) : null;
 
-		if (DI::config()->get('system', 'add_page_media')) {
+		if (!isset($media['player-url']) && !isset($media['embed-html']) && DI::config()->get('system', 'add_page_media')) {
 			if (isset($data['audio']) && sizeof($data['audio']) == 1) {
 				foreach ($data['audio'] as $entry) {
 					self::insertMedia($entry, $media['uri-id']);

--- a/src/Protocol/Feed.php
+++ b/src/Protocol/Feed.php
@@ -688,29 +688,6 @@ class Feed
 					$taglist             = $fetch_further_information == LocalRelationship::FFI_BOTH ? PageInfo::getTagsFromUrl($item['plink'], $preview, $contact['ffi_keyword_denylist'] ?? '') : [];
 					$item['object-type'] = Activity\ObjectType::BOOKMARK;
 					$attachments         = [];
-
-					foreach (['audio', 'video'] as $elementname) {
-						if (!empty($data[$elementname])) {
-							foreach ($data[$elementname] as $element) {
-								if (!empty($element['src'])) {
-									$src = $element['src'];
-								} elseif (!empty($element['content'])) {
-									$src = $element['content'];
-								} else {
-									continue;
-								}
-
-								$attachments[] = [
-									'type'        => ($elementname == 'audio') ? Post\Media::AUDIO : Post\Media::VIDEO,
-									'url'         => $src,
-									'preview'     => $element['image']       ?? null,
-									'mimetype'    => $element['contenttype'] ?? null,
-									'name'        => $element['name']        ?? null,
-									'description' => $element['description'] ?? null,
-								];
-							}
-						}
-					}
 				}
 			} else {
 				if ($fetch_further_information == LocalRelationship::FFI_KEYWORD) {


### PR DESCRIPTION
Information from a remote pages can contain links to audio and video media as well. We already had the option to fetch them. But some pages add tons of media, so we now only process them, when there is only a single one.

Also the similar function is removed from the feeds, since it is obsoleted by this functionality. 