### PR TITLE
Automatic preview size size detection

### DIFF
--- a/src/Content/Post/Entity/PostMedia.php
+++ b/src/Content/Post/Entity/PostMedia.php
@@ -291,6 +291,24 @@ class PostMedia extends BaseEntity
 	}
 
 	/**
+	 * Checks if the media is an article
+	 *
+	 * @return boolean
+	 */
+	public function isArticle(): bool
+	{
+		if (is_array($this->schemaTypes)) {
+			foreach (['Article', 'BackgroundNewsArticle', 'NewsArticle'] as $type) {
+				if (in_array($type, $this->schemaTypes)) {
+					return true;
+				}
+			}
+		}
+
+		return in_array($this->getPageType(), ['article']);
+	}
+
+	/**
 	 * Get the page type. In case of a type with main und sub category (separated by `.`), only the main category is returned
 	 *
 	 * @return string|null

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -58,6 +58,7 @@ class BBCode
 	const PREVIEW_NO_IMAGE = 1;
 	const PREVIEW_LARGE    = 2;
 	const PREVIEW_SMALL    = 3;
+	const PREVIEW_AUTO     = 4;
 
 	/**
 	 * Fetches attachment data that were generated with the "attachment" element
@@ -412,7 +413,7 @@ class BBCode
 	 * @return string
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function convertAttachment(string $text, int $simplehtml = self::INTERNAL, array $data = [], int $uriid = 0, int $preview_mode = self::PREVIEW_LARGE, bool $embed = false): string
+	public static function convertAttachment(string $text, int $simplehtml = self::INTERNAL, array $data = [], int $uriid = 0, int $preview_mode = self::PREVIEW_AUTO, bool $embed = false): string
 	{
 		DI::profiler()->startRecording('rendering');
 		$data = $data ?: self::getAttachmentData($text);
@@ -471,7 +472,7 @@ class BBCode
 		}
 
 		if (!empty($data['title']) && !empty($data['url'])) {
-			$preview_class = $preview_mode == self::PREVIEW_LARGE ? 'attachment-image' : 'attachment-preview';
+			$preview_class = in_array($preview_mode, [self::PREVIEW_AUTO, self::PREVIEW_LARGE]) ? 'attachment-image' : 'attachment-preview';
 			if (!empty($data['image']) && empty($data['text']) && ($data['type'] == 'photo')) {
 				$return .= sprintf('<a href="%s" target="_blank" rel="noopener noreferrer"><img src="%s" alt="" title="%s" class="' . $preview_class . '" /></a>', $data['url'], self::proxyUrl($data['image'], $simplehtml, $uriid), $data['title']);
 			} else {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3368,9 +3368,10 @@ class Item
 	{
 		DI::profiler()->startRecording('rendering');
 		// Don't show a preview when there is a visual attachment (audio or video)
-		$types     = $attachments['visual']->column('type');
-		$preview   = !in_array(PostMedia::TYPE_IMAGE, $types) && !in_array(PostMedia::TYPE_VIDEO, $types);
-		$has_media = in_array($item['post-type'] ?? null, [Item::PT_AUDIO, Item::PT_VIDEO]);
+		$types      = $attachments['visual']->column('type');
+		$preview    = !in_array(PostMedia::TYPE_IMAGE, $types) && !in_array(PostMedia::TYPE_VIDEO, $types);
+		$has_media  = in_array($item['post-type'] ?? null, [Item::PT_AUDIO, Item::PT_VIDEO]);
+		$is_article = false;
 
 		/** @var ?PostMedia $attachment */
 		$attachment = null;
@@ -3413,6 +3414,7 @@ class Item
 				'embed_height'  => $attachment->embedHeight,
 				'page_type'     => $attachment->pageType,
 			];
+			$is_article = $attachment->isArticle();
 
 			if ($preview && $attachment->preview) {
 				if ($attachment->previewWidth >= 500) {
@@ -3462,7 +3464,10 @@ class Item
 				}
 
 				// @todo Use a template
-				$preview_mode = DI::pConfig()->get($uid, 'system', 'preview_mode', BBCode::PREVIEW_LARGE);
+				$preview_mode = DI::pConfig()->get($uid, 'system', 'preview_mode', BBCode::PREVIEW_AUTO);
+				if ($preview_mode == BBCode::PREVIEW_AUTO) {
+					$preview_mode = $is_article ? BBCode::PREVIEW_SMALL : BBCode::PREVIEW_LARGE;
+				}
 				if (!$has_media && $preview_mode != BBCode::PREVIEW_NONE && !self::containsEmbed($body, $data['url'])) {
 					$rendered = BBCode::convertAttachment('', BBCode::INTERNAL, $data, $uriid, $preview_mode, DI::pConfig()->get($uid, 'system', 'embed_remote_media', false));
 				} elseif (!self::containsLink($content, $data['url'], Post\Media::HTML)) {

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -259,12 +259,13 @@ class Display extends BaseSettings
 			ContactSelector::SVG_WHITE       => $this->t('White'),
 		];
 
-		$preview_mode  = $this->pConfig->get($uid, 'system', 'preview_mode', BBCode::PREVIEW_LARGE);
+		$preview_mode  = $this->pConfig->get($uid, 'system', 'preview_mode', BBCode::PREVIEW_AUTO);
 		$preview_modes = [
 			BBCode::PREVIEW_NONE     => $this->t('No preview'),
 			BBCode::PREVIEW_NO_IMAGE => $this->t('No image'),
 			BBCode::PREVIEW_SMALL    => $this->t('Small Image'),
 			BBCode::PREVIEW_LARGE    => $this->t('Large Image'),
+			BBCode::PREVIEW_AUTO     => $this->t('Automatic image size'),
 		];
 
 		$bookmarked_timelines = $this->pConfig->get($uid, 'system', 'network_timelines', $this->getAvailableTimelines($uid, true)->column('code'));

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-10 20:47+0200\n"
+"POT-Creation-Date: 2025-10-22 15:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -799,7 +799,7 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:450 src/Content/Widget.php:259 src/Model/User.php:1383
+#: src/BaseModule.php:450 src/Content/Widget.php:259 src/Model/User.php:1386
 #: src/Module/Contact.php:405
 msgid "Friends"
 msgstr ""
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Public post"
 msgstr ""
 
-#: src/Content/Conversation.php:417 src/Content/Item.php:439
+#: src/Content/Conversation.php:417 src/Content/Item.php:437
 #: src/Content/Widget/VCard.php:120 src/Model/Contact.php:1304
 #: src/Model/Profile.php:460 src/Module/Admin/Logs/View.php:80
 #: src/Module/Post/Edit.php:177
@@ -1715,7 +1715,7 @@ msgstr ""
 
 #: src/Content/Feature.php:127 src/Content/GroupManager.php:128
 #: src/Content/Nav.php:276 src/Content/Text/HTML.php:877
-#: src/Content/Widget.php:558 src/Model/User.php:1397
+#: src/Content/Widget.php:558 src/Model/User.php:1400
 msgid "Groups"
 msgstr ""
 
@@ -1750,7 +1750,7 @@ msgstr ""
 
 #: src/Content/Feature.php:131 src/Content/Widget.php:613
 #: src/Module/Admin/Site.php:459 src/Module/BaseSettings.php:113
-#: src/Module/Settings/Channels.php:216 src/Module/Settings/Display.php:319
+#: src/Module/Settings/Channels.php:216 src/Module/Settings/Display.php:320
 msgid "Channels"
 msgstr ""
 
@@ -1857,35 +1857,35 @@ msgstr ""
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: src/Content/Item.php:433 view/theme/frio/theme.php:249
+#: src/Content/Item.php:431 view/theme/frio/theme.php:249
 msgid "Follow Thread"
 msgstr ""
 
-#: src/Content/Item.php:434 src/Model/Contact.php:1299
+#: src/Content/Item.php:432 src/Model/Contact.php:1299
 msgid "View Status"
 msgstr ""
 
-#: src/Content/Item.php:435 src/Content/Item.php:458 src/Model/Contact.php:1234
+#: src/Content/Item.php:433 src/Content/Item.php:456 src/Model/Contact.php:1234
 #: src/Model/Contact.php:1290 src/Model/Contact.php:1300
 #: src/Module/Directory.php:143 src/Module/Settings/Profile/Index.php:279
 msgid "View Profile"
 msgstr ""
 
-#: src/Content/Item.php:436 src/Model/Contact.php:1301
+#: src/Content/Item.php:434 src/Model/Contact.php:1301
 msgid "View Photos"
 msgstr ""
 
-#: src/Content/Item.php:437 src/Model/Contact.php:1268
+#: src/Content/Item.php:435 src/Model/Contact.php:1268
 #: src/Model/Profile.php:443
 msgid "Network Posts"
 msgstr ""
 
-#: src/Content/Item.php:438 src/Model/Contact.php:1292
+#: src/Content/Item.php:436 src/Model/Contact.php:1292
 #: src/Model/Contact.php:1303
 msgid "View Contact"
 msgstr ""
 
-#: src/Content/Item.php:440 src/Module/Contact.php:453
+#: src/Content/Item.php:438 src/Module/Contact.php:453
 #: src/Module/Contact/Profile.php:564
 #: src/Module/Moderation/Blocklist/Contact.php:104
 #: src/Module/Moderation/Users/Active.php:93
@@ -1893,7 +1893,7 @@ msgstr ""
 msgid "Block"
 msgstr ""
 
-#: src/Content/Item.php:441 src/Module/Contact.php:454
+#: src/Content/Item.php:439 src/Module/Contact.php:454
 #: src/Module/Contact/Profile.php:572
 #: src/Module/Notifications/Introductions.php:126
 #: src/Module/Notifications/Introductions.php:200
@@ -1901,49 +1901,49 @@ msgstr ""
 msgid "Ignore"
 msgstr ""
 
-#: src/Content/Item.php:442 src/Module/Contact.php:455
+#: src/Content/Item.php:440 src/Module/Contact.php:455
 #: src/Module/Contact/Profile.php:580
 msgid "Collapse"
 msgstr ""
 
-#: src/Content/Item.php:443 src/Object/Post.php:287
+#: src/Content/Item.php:441 src/Object/Post.php:287
 #, php-format
 msgid "Ignore %s server"
 msgstr ""
 
-#: src/Content/Item.php:447 src/Object/Post.php:508
+#: src/Content/Item.php:445 src/Object/Post.php:508
 msgid "Detected languages"
 msgstr ""
 
-#: src/Content/Item.php:450 src/Object/Post.php:591
+#: src/Content/Item.php:448 src/Object/Post.php:591
 msgid "Raw content"
 msgstr ""
 
-#: src/Content/Item.php:455 src/Content/Widget.php:65
+#: src/Content/Item.php:453 src/Content/Widget.php:65
 #: src/Model/Contact.php:1293 src/Model/Contact.php:1305
 #: src/Module/Contact/Follow.php:152 view/theme/vier/theme.php:182
 msgid "Connect/Follow"
 msgstr ""
 
-#: src/Content/Item.php:886
+#: src/Content/Item.php:884
 msgid "Unable to fetch user."
 msgstr ""
 
-#: src/Content/Item.php:1348 src/Core/L10n.php:453
+#: src/Content/Item.php:1346 src/Core/L10n.php:453
 msgid "Undetermined"
 msgstr ""
 
-#: src/Content/Item.php:1355
+#: src/Content/Item.php:1353
 #, php-format
 msgid "%s (%s - %s): %s"
 msgstr ""
 
-#: src/Content/Item.php:1357
+#: src/Content/Item.php:1355
 #, php-format
 msgid "%s (%s): %s"
 msgstr ""
 
-#: src/Content/Item.php:1360
+#: src/Content/Item.php:1358
 #, php-format
 msgid ""
 "Detected languages in this post:\n"
@@ -2026,7 +2026,7 @@ msgstr ""
 #: src/Content/Nav.php:231 src/Content/Nav.php:291
 #: src/Module/BaseProfile.php:70 src/Module/BaseProfile.php:73
 #: src/Module/BaseProfile.php:81 src/Module/BaseProfile.php:84
-#: src/Module/Settings/Display.php:320 view/theme/frio/theme.php:223
+#: src/Module/Settings/Display.php:321 view/theme/frio/theme.php:223
 #: view/theme/frio/theme.php:227
 msgid "Calendar"
 msgstr ""
@@ -2261,33 +2261,33 @@ msgstr ""
 msgid "last"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:909
+#: src/Content/Text/BBCode.php:917
 #, php-format
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:937 src/Model/Item.php:3622
-#: src/Model/Item.php:3628 src/Model/Item.php:3629
+#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3630
+#: src/Model/Item.php:3636 src/Model/Item.php:3637
 msgid "Link to source"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1727 src/Content/Text/HTML.php:901
+#: src/Content/Text/BBCode.php:1735 src/Content/Text/HTML.php:901
 msgid "Click to open/close"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1782
+#: src/Content/Text/BBCode.php:1790
 msgid "$1 wrote:"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1856 src/Content/Text/BBCode.php:1857
+#: src/Content/Text/BBCode.php:1864 src/Content/Text/BBCode.php:1865
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2173
+#: src/Content/Text/BBCode.php:2181
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2192
+#: src/Content/Text/BBCode.php:2200
 msgid "Invalid link protocol"
 msgstr ""
 
@@ -2877,37 +2877,37 @@ msgid "%s (%s)"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:421
-#: src/Module/Settings/Display.php:288
+#: src/Module/Settings/Display.php:289
 msgid "Monday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:422
-#: src/Module/Settings/Display.php:289
+#: src/Module/Settings/Display.php:290
 msgid "Tuesday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:423
-#: src/Module/Settings/Display.php:290
+#: src/Module/Settings/Display.php:291
 msgid "Wednesday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:424
-#: src/Module/Settings/Display.php:291
+#: src/Module/Settings/Display.php:292
 msgid "Thursday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:425
-#: src/Module/Settings/Display.php:292
+#: src/Module/Settings/Display.php:293
 msgid "Friday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:426
-#: src/Module/Settings/Display.php:293
+#: src/Module/Settings/Display.php:294
 msgid "Saturday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:420
-#: src/Module/Settings/Display.php:287
+#: src/Module/Settings/Display.php:288
 msgid "Sunday"
 msgstr ""
 
@@ -3335,17 +3335,17 @@ msgid "today"
 msgstr ""
 
 #: src/Model/Event.php:454 src/Module/Calendar/Show.php:118
-#: src/Module/Settings/Display.php:298 src/Util/Temporal.php:343
+#: src/Module/Settings/Display.php:299 src/Util/Temporal.php:343
 msgid "month"
 msgstr ""
 
 #: src/Model/Event.php:455 src/Module/Calendar/Show.php:119
-#: src/Module/Settings/Display.php:299 src/Util/Temporal.php:344
+#: src/Module/Settings/Display.php:300 src/Util/Temporal.php:344
 msgid "week"
 msgstr ""
 
 #: src/Model/Event.php:456 src/Module/Calendar/Show.php:120
-#: src/Module/Settings/Display.php:300 src/Util/Temporal.php:345
+#: src/Module/Settings/Display.php:301 src/Util/Temporal.php:345
 msgid "day"
 msgstr ""
 
@@ -3439,44 +3439,44 @@ msgstr ""
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3522
+#: src/Model/Item.php:3530
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3553
+#: src/Model/Item.php:3561
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3555
+#: src/Model/Item.php:3563
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3560
+#: src/Model/Item.php:3568
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3562
+#: src/Model/Item.php:3570
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3564
+#: src/Model/Item.php:3572
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3605 src/Model/Item.php:3606
+#: src/Model/Item.php:3613 src/Model/Item.php:3614
 msgid "View on separate page"
 msgstr ""
 
@@ -3629,7 +3629,7 @@ msgstr ""
 msgid "Responsible account: %s"
 msgstr ""
 
-#: src/Model/User.php:216 src/Model/User.php:1317
+#: src/Model/User.php:216 src/Model/User.php:1320
 msgid "SERIOUS ERROR: Generation of security keys failed."
 msgstr ""
 
@@ -3661,102 +3661,102 @@ msgstr ""
 msgid "The password can't contain white spaces nor accentuated letters"
 msgstr ""
 
-#: src/Model/User.php:1199
+#: src/Model/User.php:1200
 msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
-#: src/Model/User.php:1206
+#: src/Model/User.php:1209
 msgid "An invitation is required."
 msgstr ""
 
-#: src/Model/User.php:1210
+#: src/Model/User.php:1213
 msgid "Invitation could not be verified."
 msgstr ""
 
-#: src/Model/User.php:1218
+#: src/Model/User.php:1221
 msgid "Invalid OpenID url"
 msgstr ""
 
-#: src/Model/User.php:1232 src/Security/Authentication.php:231
+#: src/Model/User.php:1235 src/Security/Authentication.php:231
 msgid "We encountered a problem while logging in with the OpenID you provided. Please check the correct spelling of the ID."
 msgstr ""
 
-#: src/Model/User.php:1232 src/Security/Authentication.php:231
+#: src/Model/User.php:1235 src/Security/Authentication.php:231
 msgid "The error message was:"
 msgstr ""
 
-#: src/Model/User.php:1238
+#: src/Model/User.php:1241
 msgid "Please enter the required information."
 msgstr ""
 
-#: src/Model/User.php:1252
+#: src/Model/User.php:1255
 #, php-format
 msgid "system.username_min_length (%s) and system.username_max_length (%s) are excluding each other, swapping values."
 msgstr ""
 
-#: src/Model/User.php:1259
+#: src/Model/User.php:1262
 #, php-format
 msgid "Username should be at least %s character."
 msgid_plural "Username should be at least %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1263
+#: src/Model/User.php:1266
 #, php-format
 msgid "Username should be at most %s character."
 msgid_plural "Username should be at most %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1271
+#: src/Model/User.php:1274
 msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Model/User.php:1276
+#: src/Model/User.php:1279
 msgid "Your email domain is not among those allowed on this site."
 msgstr ""
 
-#: src/Model/User.php:1280
+#: src/Model/User.php:1283
 msgid "Not a valid email address."
 msgstr ""
 
-#: src/Model/User.php:1283
+#: src/Model/User.php:1286
 msgid "The nickname was blocked from registration by the nodes admin."
 msgstr ""
 
-#: src/Model/User.php:1287 src/Model/User.php:1293
+#: src/Model/User.php:1290 src/Model/User.php:1296
 msgid "Cannot use that email."
 msgstr ""
 
-#: src/Model/User.php:1299
+#: src/Model/User.php:1302
 msgid "Your nickname can only contain a-z, 0-9 and _."
 msgstr ""
 
-#: src/Model/User.php:1307 src/Model/User.php:1357
+#: src/Model/User.php:1310 src/Model/User.php:1360
 msgid "Nickname is already registered. Please choose another."
 msgstr ""
 
-#: src/Model/User.php:1344 src/Model/User.php:1348
+#: src/Model/User.php:1347 src/Model/User.php:1351
 msgid "An error occurred during registration. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1371
+#: src/Model/User.php:1374
 msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1378
+#: src/Model/User.php:1381
 msgid "An error occurred creating your self contact. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1387
+#: src/Model/User.php:1390
 msgid "An error occurred creating your default contact circle. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1435
+#: src/Model/User.php:1438
 msgid "Profile Photos"
 msgstr ""
 
-#: src/Model/User.php:1632
+#: src/Model/User.php:1636
 #, php-format
 msgid ""
 "\n"
@@ -3764,7 +3764,7 @@ msgid ""
 "\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: src/Model/User.php:1635
+#: src/Model/User.php:1639
 #, php-format
 msgid ""
 "\n"
@@ -3795,12 +3795,12 @@ msgid ""
 "\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: src/Model/User.php:1667 src/Model/User.php:1773
+#: src/Model/User.php:1671 src/Model/User.php:1777
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
-#: src/Model/User.php:1687
+#: src/Model/User.php:1691
 #, php-format
 msgid ""
 "\n"
@@ -3815,12 +3815,12 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:1706
+#: src/Model/User.php:1710
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: src/Model/User.php:1730
+#: src/Model/User.php:1734
 #, php-format
 msgid ""
 "\n"
@@ -3829,7 +3829,7 @@ msgid ""
 "\t\t\t"
 msgstr ""
 
-#: src/Model/User.php:1738
+#: src/Model/User.php:1742
 #, php-format
 msgid ""
 "\n"
@@ -3860,7 +3860,7 @@ msgid ""
 "\t\t\tThank you and welcome to %2$s."
 msgstr ""
 
-#: src/Model/User.php:1800
+#: src/Model/User.php:1804
 msgid "User with delegates can't be removed, please remove delegate users first"
 msgstr ""
 
@@ -3884,7 +3884,7 @@ msgid "Disable"
 msgstr ""
 
 #: src/Module/Admin/Addons/Details.php:78
-#: src/Module/Admin/Themes/Details.php:41 src/Module/Settings/Display.php:349
+#: src/Module/Admin/Themes/Details.php:41 src/Module/Settings/Display.php:350
 msgid "Enable"
 msgstr ""
 
@@ -3938,7 +3938,7 @@ msgstr ""
 #: src/Module/Settings/Connectors.php:143
 #: src/Module/Settings/Connectors.php:228
 #: src/Module/Settings/ContactImport.php:110
-#: src/Module/Settings/Delegation.php:179 src/Module/Settings/Display.php:313
+#: src/Module/Settings/Delegation.php:179 src/Module/Settings/Display.php:314
 #: src/Module/Settings/Features.php:61
 #: src/Module/Settings/Profile/Index.php:272
 msgid "Save Settings"
@@ -5920,7 +5920,7 @@ msgstr ""
 msgid "New Event"
 msgstr ""
 
-#: src/Module/Calendar/Show.php:121 src/Module/Settings/Display.php:301
+#: src/Module/Calendar/Show.php:121 src/Module/Settings/Display.php:302
 msgid "list"
 msgstr ""
 
@@ -8400,19 +8400,19 @@ msgid "No contacts."
 msgstr ""
 
 #: src/Module/Profile/Conversations.php:96 src/Module/Profile/Profile.php:366
-#: src/Protocol/Feed.php:1124
+#: src/Protocol/Feed.php:1127
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
 #: src/Module/Profile/Conversations.php:97 src/Module/Profile/Profile.php:367
-#: src/Protocol/Feed.php:1127
+#: src/Protocol/Feed.php:1130
 #, php-format
 msgid "%s's comments"
 msgstr ""
 
 #: src/Module/Profile/Conversations.php:98 src/Module/Profile/Profile.php:368
-#: src/Protocol/Feed.php:1120
+#: src/Protocol/Feed.php:1123
 #, php-format
 msgid "%s's timeline"
 msgstr ""
@@ -9382,12 +9382,12 @@ msgid "When selected, the channel results are reshared. This only works for publ
 msgstr ""
 
 #: src/Module/Settings/Channels.php:176 src/Module/Settings/Channels.php:202
-#: src/Module/Settings/Display.php:347
+#: src/Module/Settings/Display.php:348
 msgid "Label"
 msgstr ""
 
 #: src/Module/Settings/Channels.php:177 src/Module/Settings/Channels.php:203
-#: src/Module/Settings/Display.php:348
+#: src/Module/Settings/Display.php:349
 #: src/Module/Settings/TwoFactor/AppSpecific.php:123
 msgid "Description"
 msgstr ""
@@ -9815,193 +9815,197 @@ msgstr ""
 msgid "Large Image"
 msgstr ""
 
-#: src/Module/Settings/Display.php:312
+#: src/Module/Settings/Display.php:268
+msgid "Automatic image size"
+msgstr ""
+
+#: src/Module/Settings/Display.php:313
 msgid "Display Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:314
+#: src/Module/Settings/Display.php:315
 msgid "General Theme Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:315
+#: src/Module/Settings/Display.php:316
 msgid "Custom Theme Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:316
+#: src/Module/Settings/Display.php:317
 msgid "Content Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:317 view/theme/duepuntozero/config.php:74
+#: src/Module/Settings/Display.php:318 view/theme/duepuntozero/config.php:74
 #: view/theme/frio/config.php:156 view/theme/quattro/config.php:76
 #: view/theme/vier/config.php:124
 msgid "Theme settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:318
+#: src/Module/Settings/Display.php:319
 msgid "Timelines"
 msgstr ""
 
-#: src/Module/Settings/Display.php:325
+#: src/Module/Settings/Display.php:326
 msgid "Display Theme:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:326
+#: src/Module/Settings/Display.php:327
 msgid "Mobile Theme:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:329
+#: src/Module/Settings/Display.php:330
 msgid "Number of items to display per page:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:329 src/Module/Settings/Display.php:330
+#: src/Module/Settings/Display.php:330 src/Module/Settings/Display.php:331
 msgid "Maximum of 100 items"
 msgstr ""
 
-#: src/Module/Settings/Display.php:330
+#: src/Module/Settings/Display.php:331
 msgid "Number of items to display per page when viewed from mobile device:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:331
+#: src/Module/Settings/Display.php:332
 msgid "Regularly update the page content"
 msgstr ""
 
-#: src/Module/Settings/Display.php:331
+#: src/Module/Settings/Display.php:332
 msgid "When enabled, new content on network, community and channels are added on top."
 msgstr ""
 
-#: src/Module/Settings/Display.php:332
+#: src/Module/Settings/Display.php:333
 msgid "Display emoticons"
 msgstr ""
 
-#: src/Module/Settings/Display.php:332
+#: src/Module/Settings/Display.php:333
 msgid "When enabled, emoticons are replaced with matching symbols."
 msgstr ""
 
-#: src/Module/Settings/Display.php:333
+#: src/Module/Settings/Display.php:334
 msgid "Infinite scroll"
 msgstr ""
 
-#: src/Module/Settings/Display.php:333
+#: src/Module/Settings/Display.php:334
 msgid "Automatic fetch new items when reaching the page end."
 msgstr ""
 
-#: src/Module/Settings/Display.php:334
+#: src/Module/Settings/Display.php:335
 msgid "Enable Smart Threading"
 msgstr ""
 
-#: src/Module/Settings/Display.php:334
+#: src/Module/Settings/Display.php:335
 msgid "Enable the automatic suppression of extraneous thread indentation."
 msgstr ""
 
-#: src/Module/Settings/Display.php:335
+#: src/Module/Settings/Display.php:336
 msgid "Display the Dislike feature"
 msgstr ""
 
-#: src/Module/Settings/Display.php:335
+#: src/Module/Settings/Display.php:336
 msgid "Display the Dislike button and dislike reactions on posts and comments."
 msgstr ""
 
-#: src/Module/Settings/Display.php:336
+#: src/Module/Settings/Display.php:337
 msgid "Display the resharer"
 msgstr ""
 
-#: src/Module/Settings/Display.php:336
+#: src/Module/Settings/Display.php:337
 msgid "Display the first resharer as icon and text on a reshared item."
 msgstr ""
 
-#: src/Module/Settings/Display.php:337
+#: src/Module/Settings/Display.php:338
 msgid "Stay local"
 msgstr ""
 
-#: src/Module/Settings/Display.php:337
+#: src/Module/Settings/Display.php:338
 msgid "Don't go to a remote system when following a contact link."
 msgstr ""
 
-#: src/Module/Settings/Display.php:338
+#: src/Module/Settings/Display.php:339
 msgid "Show the post deletion checkbox"
 msgstr ""
 
-#: src/Module/Settings/Display.php:338
+#: src/Module/Settings/Display.php:339
 msgid "Display the checkbox for the post deletion on the network page."
 msgstr ""
 
-#: src/Module/Settings/Display.php:339
+#: src/Module/Settings/Display.php:340
 msgid "DIsplay the event list"
 msgstr ""
 
-#: src/Module/Settings/Display.php:339
+#: src/Module/Settings/Display.php:340
 msgid "Display the birthday reminder and event list on the network page."
 msgstr ""
 
-#: src/Module/Settings/Display.php:340
+#: src/Module/Settings/Display.php:341
 msgid "Link preview mode"
 msgstr ""
 
-#: src/Module/Settings/Display.php:340
+#: src/Module/Settings/Display.php:341
 msgid "Appearance of the link preview that is added to each post with a link."
 msgstr ""
 
-#: src/Module/Settings/Display.php:341
+#: src/Module/Settings/Display.php:342
 msgid "Hide pictures with empty alternative text"
 msgstr ""
 
-#: src/Module/Settings/Display.php:341
+#: src/Module/Settings/Display.php:342
 msgid "Don't display pictures that are missing the alternative text."
 msgstr ""
 
-#: src/Module/Settings/Display.php:342
+#: src/Module/Settings/Display.php:343
 msgid "Hide custom emojis"
 msgstr ""
 
-#: src/Module/Settings/Display.php:342
+#: src/Module/Settings/Display.php:343
 msgid "Don't display custom emojis."
 msgstr ""
 
-#: src/Module/Settings/Display.php:343
+#: src/Module/Settings/Display.php:344
 msgid "Platform icons style"
 msgstr ""
 
-#: src/Module/Settings/Display.php:343
+#: src/Module/Settings/Display.php:344
 msgid "Style of the platform icons"
 msgstr ""
 
-#: src/Module/Settings/Display.php:344
+#: src/Module/Settings/Display.php:345
 msgid "Embed remote media"
 msgstr ""
 
-#: src/Module/Settings/Display.php:344
+#: src/Module/Settings/Display.php:345
 msgid "When enabled, remote media will be embedded in the post, like for example YouTube videos."
 msgstr ""
 
-#: src/Module/Settings/Display.php:345
+#: src/Module/Settings/Display.php:346
 msgid "Embed supported media"
 msgstr ""
 
-#: src/Module/Settings/Display.php:345
+#: src/Module/Settings/Display.php:346
 msgid "When enabled, remote media will be embedded in the post instead of using the local player if this is supported by the remote system. This is useful for media where the remote player is better than the local one, like for example Peertube videos."
 msgstr ""
 
-#: src/Module/Settings/Display.php:350
+#: src/Module/Settings/Display.php:351
 msgid "Bookmark"
 msgstr ""
 
-#: src/Module/Settings/Display.php:352
+#: src/Module/Settings/Display.php:353
 msgid "Enable timelines that you want to see in the channels widget. Bookmark timelines that you want to see in the top menu."
 msgstr ""
 
-#: src/Module/Settings/Display.php:354
+#: src/Module/Settings/Display.php:355
 msgid "Channel languages:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:354
+#: src/Module/Settings/Display.php:355
 msgid "Select all the languages you want to see in your channels. \"Unspecified\" describes all posts for which no language information was detected (e.g. posts with just an image or too little text to be sure of the language). If you want to see all languages, you will need to select all items in the list."
 msgstr ""
 
-#: src/Module/Settings/Display.php:356
+#: src/Module/Settings/Display.php:357
 msgid "Beginning of week:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:357
+#: src/Module/Settings/Display.php:358
 msgid "Default calendar view:"
 msgstr ""
 


### PR DESCRIPTION
We have got a user setting where we can define the size of the preview picture of page previews. There is now a new setting: "Auto". This means that on news pages the preview picture will be small, while on other pages (for example photo pages) it will be large.