### PR TITLE
The callstack now is more readable

### DIFF
--- a/src/Core/Logger/Util/Introspection.php
+++ b/src/Core/Logger/Util/Introspection.php
@@ -73,7 +73,7 @@ class Introspection implements IHaveCallIntrospections
 			'line'       => $trace[$i - 1]['line'] ?? null,
 			'function'   => $trace[$i]['function'] ?? null,
 			'request-id' => $this->requestId,
-			'stack'      => System::callstack(15, 0, true, ['Friendica\Core\Logger\Type\StreamLogger', 'Friendica\Core\Logger\Type\AbstractLogger', 'Friendica\Core\Logger\Type\WorkerLogger', 'Friendica\Core\Logger']),
+			'stack'      => System::callstack(15, 1, ['Friendica\Core\Logger\Type\StreamLogger', 'Friendica\Core\Logger\Type\AbstractLogger', 'Friendica\Core\Logger\Type\WorkerLogger', 'Friendica\Core\Logger']),
 		];
 	}
 

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -213,24 +213,50 @@ class System
 	}
 
 	/**
+	 * Get the callstack without the database operations
+	 *
+	 * @return array the callstack
+	 */
+	public static function getCallstack(): array
+	{
+		$backtrace = [];
+		$file      = '';
+		$line      = 0;
+		foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $trace) {
+			if (in_array(basename($trace['file']), ['DBA.php', 'Database.php'])) {
+				continue;
+			}
+			if (in_array(basename($trace['function']), ['selectView', 'selectPosts', 'selectFirstPost', 'fetch', 'toArray', 'exists', 'count', 'selectFirst', 'selectToArray', 'select', 'selectFirstForUser', 'selectForUser'])) {
+				continue;
+			}
+			if ($line != 0) {
+				$new         = $trace;
+				$new['file'] = $file;
+				$new['line'] = $line;
+				$backtrace[] = $new;
+			}
+			$file = $trace['file'];
+			$line = $trace['line'];
+		}
+
+		return $backtrace;
+	}
+
+	/**
 	 * Returns a string with a callstack. Can be used for logging.
 	 *
 	 * @param integer $depth   How many calls to include in the stacks after filtering
 	 * @param int     $offset  How many calls to shave off the top of the stack, for example if
 	 *                         this is called from a centralized method that isn't relevant to the callstack
-	 * @param bool    $full    If enabled, the callstack is not compacted
 	 * @param array   $exclude
 	 * @return string
 	 */
-	public static function callstack(int $depth = 4, int $offset = 0, bool $full = false, array $exclude = []): string
+	public static function callstack(int $depth = 4, int $offset = 0, array $exclude = []): string
 	{
-		$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-
-		// We remove at least the first two items from the list since they contain data that we don't need.
-		$trace = array_slice($trace, 2 + $offset);
+		// We remove at least the first item from the list since they contain data that we don't need.
+		$trace = array_slice(self::getCallstack(), 1 + $offset);
 
 		$callstack = [];
-		$previous  = ['class' => '', 'function' => '', 'database' => false];
 
 		// The ignore list contains all functions that are only wrapper functions
 		$ignore = ['call_user_func_array'];
@@ -240,25 +266,12 @@ class System
 				if (in_array($func['class'], $exclude)) {
 					continue;
 				}
-
-				if (!$full && in_array($previous['function'], ['insert', 'fetch', 'toArray', 'exists', 'count', 'selectFirst', 'selectToArray',
-					'select', 'update', 'delete', 'selectFirstForUser', 'selectForUser'])
-					&& (substr($previous['class'], 0, 15) === 'Friendica\Model')) {
-					continue;
-				}
-
-				// Don't show multiple calls from the Database classes to show the essential parts of the callstack
-				$func['database'] = in_array($func['class'], ['Friendica\Database\DBA', 'Friendica\Database\Database']);
-				if ($full || !$previous['database'] || !$func['database']) {
-					$classparts  = explode("\\", $func['class']);
-					$callstack[] = array_pop($classparts).'::'.$func['function'] . (isset($func['line']) ? ' (' . $func['line'] . ')' : '');
-					$previous    = $func;
-				}
+				$classparts  = explode("\\", $func['class']);
+				$callstack[] = array_pop($classparts).'::'.$func['function'] . (isset($func['line']) ? ' (' . $func['line'] . ')' : '');
 			} elseif (!in_array($func['function'], $ignore)) {
 				$func['database'] = ($func['function'] == 'q');
 				$callstack[]      = $func['function'] . (isset($func['line']) ? ' (' . $func['line'] . ')' : '');
 				$func['class']    = '';
-				$previous         = $func;
 			}
 		}
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -723,13 +723,13 @@ class Database
 
 			if (($duration > $this->config->get('system', 'db_loglimit'))) {
 				$duration  = round($duration, 3);
-				$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+				$backtrace = System::getCallstack();
 
 				@file_put_contents(
 					$this->config->get('system', 'db_log'),
 					DateTimeFormat::utcNow() . "\t" . $duration . "\t" .
-					basename($backtrace[1]['file']) . "\t" .
-					$backtrace[1]['line'] . "\t" . $backtrace[2]['function'] . "\t" .
+					basename($backtrace[0]['file']) . "\t" .
+					$backtrace[0]['line'] . "\t" . $backtrace[0]['function'] . "\t" .
 					substr($this->replaceParameters($sql, $args), 0, 4000) . "\n",
 					FILE_APPEND
 				);

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -251,7 +251,7 @@ class Contact
 		Contact\User::insertForContactArray($contact);
 
 		if ((empty($contact['baseurl']) || empty($contact['gsid'])) && Probe::isProbable($contact['network'])) {
-			DI::logger()->debug('Update missing baseurl', ['id' => $contact['id'], 'url' => $contact['url'], 'callstack' => System::callstack(4, 0, true)]);
+			DI::logger()->debug('Update missing baseurl', ['id' => $contact['id'], 'url' => $contact['url'], 'callstack' => System::callstack(4, 0)]);
 			UpdateContact::add(['priority' => Worker::PRIORITY_MEDIUM, 'dont_fork' => true], $contact['id']);
 		}
 


### PR DESCRIPTION
The callstack had some problems. For example the line number had displayed where the named function has been executed and not the line inside the function. For debugging purposes this doesn't make sense.

Also we previously suppressed some callstack lines for clarity but this introduced some unclarity. This should be improved now.