### PR TITLE
Fix warning "E_WARNING: Undefined array key"

### DIFF
--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -223,6 +223,9 @@ class System
 		$file      = '';
 		$line      = 0;
 		foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $trace) {
+			if (!isset($trace['file']) || !isset($trace['function']) || !isset($trace['line'])) {
+				continue;
+			}
 			if (in_array(basename($trace['file']), ['DBA.php', 'Database.php'])) {
 				continue;
 			}


### PR DESCRIPTION
Fixes `[WARNING]: E_WARNING: Undefined array key "file"`