### PR TITLE
Partial support for Mastodon's way of quoting posts

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -158,6 +158,7 @@ class Item
 	const CANT_REPLY    = 1;
 	const CANT_LIKE     = 2;
 	const CANT_ANNOUNCE = 4;
+	const CANT_QUOTE    = 8;
 
 	/**
 	 * Update existing item entries

--- a/src/Model/ItemHelper.php
+++ b/src/Model/ItemHelper.php
@@ -389,6 +389,10 @@ final class ItemHelper
 			return true;
 		}
 
+		if (($restrictions & Item::CANT_QUOTE) && (!empty($item['quote-uri']) || !empty($item['quote-uri-id']))) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -48,6 +48,7 @@ class Tag
 	const CAN_ANNOUNCE = 20;
 	const CAN_LIKE     = 21;
 	const CAN_REPLY    = 22;
+	const CAN_QUOTE    = 23;
 
 	const ACCOUNT             = 1;
 	const GENERAL_COLLECTION  = 2;

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -216,6 +216,10 @@ class Post
 			$announceable = false;
 		}
 
+		if ($item['restrictions'] & Item::CANT_QUOTE) {
+			$shareable = false;
+		}
+
 		$edpost = false;
 
 		if (DI::userSession()->getLocalUserId()) {

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -50,15 +50,38 @@ class ActivityPub
 	const CONTEXT           = [
 		'https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1',
 		[
-			'ostatus'  => 'http://ostatus.org#',
-			'vcard'    => 'http://www.w3.org/2006/vcard/ns#',
-			'dfrn'     => 'http://purl.org/macgirvin/dfrn/1.0/',
-			'diaspora' => 'https://diasporafoundation.org/ns/',
-			'litepub'  => 'http://litepub.social/ns#',
-			'toot'     => 'http://joinmastodon.org/ns#',
+			'ostatus'            => 'http://ostatus.org#',
+			'vcard'              => 'http://www.w3.org/2006/vcard/ns#',
+			'dfrn'               => 'http://purl.org/macgirvin/dfrn/1.0/',
+			'diaspora'           => 'https://diasporafoundation.org/ns/',
+			'litepub'            => 'http://litepub.social/ns#',
+			'toot'               => 'http://joinmastodon.org/ns#',
+			'quote'              => 'https://w3id.org/fep/044f#quote',
+			'quoteUri'           => 'http://fedibird.com/ns#quoteUri',
+			'quoteAuthorization' => [
+				'@id'   => 'https://w3id.org/fep/044f#quoteAuthorization',
+				'@type' => '@id',
+			],
+			'gts'               => 'https://gotosocial.org/ns#',
+			'interactionPolicy' => [
+				'@id'   => 'gts:interactionPolicy',
+				'@type' => '@id',
+			],
+			'canQuote' => [
+				'@id'   => 'gts:canQuote',
+				'@type' => '@id',
+			],
+			'automaticApproval' => [
+				'@id'   => 'gts:automaticApproval',
+				'@type' => '@id',
+			],
+			'manualApproval' => [
+				'@id'   => 'gts:manualApproval',
+				'@type' => '@id',
+			],
 			'featured' => [
-				"@id"   => "toot:featured",
-				"@type" => "@id",
+				"@id"   => 'toot:featured',
+				"@type" => '@id',
 			],
 			'schema'                    => 'http://schema.org#',
 			'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers',

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -964,7 +964,9 @@ class Processor
 
 		self::storeReceivers($item['uri-id'], $activity['receiver_urls'] ?? []);
 
-		if (!empty($activity['capabilities'])) {
+		if (!empty($activity['interaction'])) {
+			$restrictions = self::storeInteractions($item['uri-id'], $activity['interaction']);
+		} elseif (!empty($activity['capabilities'])) {
 			$restrictions = self::storeCapabilities($item['uri-id'], $activity['capabilities']);
 		} elseif (!is_null($activity['can-comment']) && !$activity['can-comment']) {
 			$restrictions = [Tag::CAN_REPLY];
@@ -980,6 +982,8 @@ class Processor
 				$item['restrictions'] = $item['restrictions'] | Item::CANT_LIKE;
 			} elseif ($restriction == Tag::CAN_ANNOUNCE) {
 				$item['restrictions'] = $item['restrictions'] | Item::CANT_ANNOUNCE;
+			} elseif ($restriction == Tag::CAN_QUOTE) {
+				$item['restrictions'] = $item['restrictions'] | Item::CANT_QUOTE;
 			}
 		}
 
@@ -1418,6 +1422,32 @@ class Processor
 				Tag::store($uriid, $type, $name, $receiver, $target);
 			}
 		}
+	}
+
+	private static function storeInteractions(int $uriid, array $interactions): array
+	{
+		$restrictions = [];
+		foreach ($interactions as $key => $key_interaction) {
+			$restricted = true;
+			foreach ($key_interaction as $interaction) {
+				if ($interaction == ActivityPub::PUBLIC_COLLECTION) {
+					$name       = Receiver::PUBLIC_COLLECTION;
+					$restricted = false;
+				} elseif ($path = parse_url($interaction, PHP_URL_PATH)) {
+					$name = trim($path, '/');
+				} elseif ($host = parse_url($interaction, PHP_URL_HOST)) {
+					$name = $host;
+				} else {
+					DI::logger()->warning('Unable to coerce name from interaction', ['key' => $key, 'interaction' => $interaction]);
+					$name = '';
+				}
+				Tag::store($uriid, $key, $name, $interaction);
+			}
+			if ($restricted) {
+				$restrictions[] = $key;
+			}
+		}
+		return $restrictions;
 	}
 
 	private static function storeCapabilities(int $uriid, array $capabilities): array

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -20,6 +20,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\APContact;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
+use Friendica\Model\Tag;
 use Friendica\Model\User;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\ActivityPub;
@@ -1980,11 +1981,43 @@ class Receiver
 			}
 		}
 
+		if (!empty($object['gts:interactionPolicy'])) {
+			$object_data['interaction'] = self::getinteractionPolicy($object['gts:interactionPolicy']);
+		}
+
 		if (!empty($object['pixelfed:capabilities'])) {
 			$object_data['capabilities'] = self::getCapabilities($object);
 		}
 
 		return $object_data;
+	}
+
+	/**
+	 * Import GoToSocial's interaction policx
+	 * @see https://docs.gotosocial.org/en/latest/federation/interaction_policy/
+	 *
+	 * @param array $object
+	 * @return array
+	 */
+	private static function getinteractionPolicy(array $object): array
+	{
+		$interactions = [];
+		foreach ([Tag::CAN_ANNOUNCE => 'gts:canAnnounce', Tag::CAN_LIKE => 'gts:canLike', Tag::CAN_REPLY => 'gts:canReply', Tag::CAN_QUOTE => 'gts:canQuote'] as $key => $element) {
+			foreach (['gts:automaticApproval', 'gts:manualApproval'] as $approval) {
+				if (!isset($object[$element][$approval])) {
+					continue;
+				}
+				$interaction = JsonLD::fetchElement($object[$element][$approval], '@id');
+				if (empty($interaction)) {
+					continue;
+				}
+				if ($interaction == self::PUBLIC_COLLECTION) {
+					$interaction = ActivityPub::PUBLIC_COLLECTION;
+				}
+				$interactions[$key][] = $interaction;
+			}
+		}
+		return $interactions;
 	}
 
 	private static function getCapabilities($object)
@@ -2151,6 +2184,9 @@ class Receiver
 		}
 		if (empty($object_data['quote-url'])) {
 			$object_data['quote-url'] = JsonLD::fetchElement($object, 'misskey:_misskey_quote', '@id');
+		}
+		if (empty($object_data['quote-url'])) {
+			$object_data['quote-url'] = JsonLD::fetchElement($object, 'quote:quote');
 		}
 
 		foreach ($object_data['tags'] as $tag) {

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1899,6 +1899,7 @@ class Transmitter
 					$real_quote               = true;
 					$data['_misskey_content'] = BBCode::removeSharedData($body);
 					$data['quoteUrl']         = $item['quote-uri'];
+					$data['quoteUri']         = $item['quote-uri'];
 					$body                     = DI::contentItem()->addShareLink($body, $item['quote-uri-id']);
 				} else {
 					$body = DI::contentItem()->addSharedPost($item, $body);
@@ -1937,6 +1938,16 @@ class Transmitter
 
 		if (!empty($item['signed_text']) && ($item['uri'] != $item['thr-parent'])) {
 			$data['diaspora:comment'] = $item['signed_text'];
+		}
+
+		// @todo full support of GoToSocial's interaction policy
+		// @see https://docs.gotosocial.org/en/latest/federation/interaction_policy/
+		if ($item['private'] != Item::PRIVATE) {
+			$data['interactionPolicy'] = [
+				'canQuote' => [
+					'automaticApproval' => [ActivityPub::PUBLIC_COLLECTION]
+				]
+			];
 		}
 
 		$data['attachment'] = self::createAttachmentList($item);

--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -165,6 +165,8 @@ class JsonLD
 			'misskey'   => (object)['@id' => 'https://misskey-hub.net/ns#', '@type' => '@id'],
 			'pixelfed'  => (object)['@id' => 'http://pixelfed.org/ns#', '@type' => '@id'],
 			'lemmy'     => (object)['@id' => 'https://join-lemmy.org/ns#', '@type' => '@id'],
+			'quote'     => (object)['@id' => 'https://w3id.org/fep/044f#', '@type' => '@id'],
+			'gts'       => (object)['@id' => 'https://gotosocial.org/ns#', '@type' => '@id'],
 		];
 
 		$orig_json = $json;


### PR DESCRIPTION
See #15096
Mastodon now introduced their way of quoting posts. This PR adds a partial support for this. Means: With this PR we will be able to process incoming quoted posts.

We now also partially support [GoToSocial's interaction policy](https://docs.gotosocial.org/en/latest/federation/interaction_policy/) when processing posts. (We currently only allow interaction when set to public. When an interaction is allowed only for followers, we currently restrict interaction totally) This possibly could enable us to safely transmit quoted posts via Mastodon's fields as well. But for now we will transmit quoted posts like we did in the past.