### PR TITLE
Fix "implicitly nullable parameters are deprecated" warning

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1367,7 +1367,7 @@ class Contact
 	 * @throws InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function getIdForURL(string $url = null, int $uid = 0, $update = null, array $default = []): int
+	public static function getIdForURL(?string $url = null, int $uid = 0, $update = null, array $default = []): int
 	{
 		$contact_id = 0;
 
@@ -1629,7 +1629,7 @@ class Contact
 	 * @return string posts in HTML
 	 * @throws Exception
 	 */
-	public static function getPostsFromUrl(string $contact_url, int $uid, bool $only_media = false, string $last_created = null): string
+	public static function getPostsFromUrl(string $contact_url, int $uid, bool $only_media = false, ?string $last_created = null): string
 	{
 		return self::getPostsFromId(self::getIdForURL($contact_url), $uid, $only_media, $last_created);
 	}
@@ -1644,7 +1644,7 @@ class Contact
 	 * @return string posts in HTML
 	 * @throws Exception
 	 */
-	public static function getPostsFromId(int $cid, int $uid, bool $only_media = false, string $last_created = null): string
+	public static function getPostsFromId(int $cid, int $uid, bool $only_media = false, ?string $last_created = null): string
 	{
 		$contact = DBA::selectFirst('contact', ['contact-type', 'network', 'name', 'nick'], ['id' => $cid]);
 		if (!DBA::isResult($contact)) {
@@ -1834,7 +1834,7 @@ class Contact
 	 * @param string $reason Block reason
 	 * @return bool Whether it was successful
 	 */
-	public static function block(int $cid, string $reason = null): bool
+	public static function block(int $cid, ?string $reason = null): bool
 	{
 		$return = self::update(['blocked' => true, 'block_reason' => $reason], ['id' => $cid]);
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1831,7 +1831,7 @@ class Item
 	 * @return string Unique guid
 	 * @throws \Exception
 	 */
-	public static function guidFromUri(string $uri, string $host = null): string
+	public static function guidFromUri(string $uri, ?string $host = null): string
 	{
 		// Our regular guid routine is using this kind of prefix as well
 		// We have to avoid that different routines could accidentally create the same value
@@ -2233,7 +2233,7 @@ class Item
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function fixPrivatePhotos(string $s, int $uid, array $item = null, int $cid = 0): string
+	public static function fixPrivatePhotos(string $s, int $uid, ?array $item = null, int $cid = 0): string
 	{
 		if (DI::config()->get('system', 'disable_embedded')) {
 			return $s;
@@ -2499,7 +2499,7 @@ class Item
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function performActivity(int $item_id, string $verb, int $uid, string $allow_cid = null, string $allow_gid = null, string $deny_cid = null, string $deny_gid = null): bool
+	public static function performActivity(int $item_id, string $verb, int $uid, ?string $allow_cid = null, ?string $allow_gid = null, ?string $deny_cid = null, ?string $deny_gid = null): bool
 	{
 		if (empty($uid)) {
 			return false;

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -72,7 +72,7 @@ class Tag
 	 * @param integer $target Target (default: null)
 	 * @return void
 	 */
-	public static function store(int $uriId, int $type, string $name, string $url = '', int $target = null)
+	public static function store(int $uriId, int $type, string $name, string $url = '', ?int $target = null)
 	{
 		if ($type == self::HASHTAG) {
 			// Trim Unicode non-word characters
@@ -213,7 +213,7 @@ class Tag
 	 * @param int    $type Type of tag
 	 * @return int Tag id
 	 */
-	public static function getID(string $name, string $url = '', int $type = null): int
+	public static function getID(string $name, string $url = '', ?int $type = null): int
 	{
 		$fields = ['name' => substr($name, 0, 96), 'url' => $url];
 
@@ -269,7 +269,7 @@ class Tag
 	 *
 	 * @return array Tag list
 	 */
-	public static function getFromBody(string $body, string $tags = null): array
+	public static function getFromBody(string $body, ?string $tags = null): array
 	{
 		if (is_null($tags)) {
 			$tags = self::TAG_CHARACTER[self::HASHTAG] . self::TAG_CHARACTER[self::MENTION] . self::TAG_CHARACTER[self::EXCLUSIVE_MENTION];
@@ -290,7 +290,7 @@ class Tag
 	 * @param string  $tags    Accepted tags
 	 * @return void
 	 */
-	public static function storeFromBody(int $uriId, string $body, string $tags = null)
+	public static function storeFromBody(int $uriId, string $body, ?string $tags = null)
 	{
 		$item = ['uri-id' => $uriId, 'body' => $body, 'quote-uri-id' => null];
 		self::storeFromArray($item, $tags);
@@ -303,7 +303,7 @@ class Tag
 	 * @param string  $tags    Accepted tags
 	 * @return void
 	 */
-	public static function storeFromArray(array $item, string $tags = null)
+	public static function storeFromArray(array $item, ?string $tags = null)
 	{
 		DI::logger()->info('Check for tags', ['uri-id' => $item['uri-id'], 'hash' => $tags]);
 

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1363,7 +1363,7 @@ class Processor
 	 * @param integer $uriid
 	 * @param array $tags
 	 */
-	private static function storeTags(int $uriid, array $tags = null)
+	private static function storeTags(int $uriid, ?array $tags = null)
 	{
 		foreach ($tags as $tag) {
 			if (empty($tag['name']) || empty($tag['type']) || !in_array($tag['type'], ['Mention', 'Hashtag'])) {

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -612,7 +612,7 @@ class Receiver
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function processActivity(array $activity, string $body = '', int $uid = null, bool $trust_source = false, bool $push = false, array $signer = [], string $http_signer = '', int $completion = Receiver::COMPLETION_AUTO): bool
+	public static function processActivity(array $activity, string $body = '', ?int $uid = null, bool $trust_source = false, bool $push = false, array $signer = [], string $http_signer = '', int $completion = Receiver::COMPLETION_AUTO): bool
 	{
 		$type = JsonLD::fetchElement($activity, '@type');
 		if (!$type) {
@@ -1077,7 +1077,7 @@ class Receiver
 	 * @param array   $signer       The signer of the post
 	 * @return void
 	 */
-	private static function storeUnhandledActivity(bool $unknown, string $type, array $object_data, array $activity, string $body = '', int $uid = null, bool $trust_source = false, bool $push = false, array $signer = [])
+	private static function storeUnhandledActivity(bool $unknown, string $type, array $object_data, array $activity, string $body = '', ?int $uid = null, bool $trust_source = false, bool $push = false, array $signer = [])
 	{
 		if (!DI::config()->get('debug', 'ap_log_unknown')) {
 			return;


### PR DESCRIPTION
This just fixes several warnings in the editor.