### PR TITLE
Docs updates v4

### DIFF
--- a/doc/de/admin/faq.md
+++ b/doc/de/admin/faq.md
@@ -1,7 +1,5 @@
 # Häufig gestellte Fragen (Admin) - FAQ
 
-* [Zur Startseite der Hilfe](help)
-
 ## Kann ich mehrere Domains mit den selben Dateien aufsetzen?
 
 Ja, das ist möglich.

--- a/doc/de/admin/improve-performance.md
+++ b/doc/de/admin/improve-performance.md
@@ -1,7 +1,5 @@
 # How-to: Performance verbessern
 
-* [Zur Startseite der Hilfe](help)
-
 Eine kleine Anleitung, um die Performance einer Friendica-Seite zu verbessern.
 
 **Vorab:**

--- a/doc/de/admin/install.md
+++ b/doc/de/admin/install.md
@@ -1,7 +1,5 @@
 # Friendica Installation
 
-* [Zur Startseite der Hilfe](help)
-
 Wir haben hart daran gearbeitet, um Friendica auf vorgefertigten Hosting-Plattformen zum Laufen zu bringen - solche, auf denen auch WordPress Blogs und Drupal-Installationen laufen.
 Wir bieten eine manuelle und eine automatische Installation an.
 Aber bedenke, dass Friendica mehr als eine einfache Webanwendung ist.

--- a/doc/de/admin/installing-connectors.md
+++ b/doc/de/admin/installing-connectors.md
@@ -1,7 +1,5 @@
 # Konnektoren installieren
 
-* [Zur Startseite der Hilfe](help)
-
 Friendica verwendet Konnektoren, um sich mit einigen Netzwerken zu verbinden, wie Tumblr oder Bluesky.
 
 Alle diese Konnektoren erfordern einen Account im Zielnetzwerk.

--- a/doc/de/admin/settings.md
+++ b/doc/de/admin/settings.md
@@ -1,7 +1,5 @@
 # Settings
 
-* [Zur Startseite der Hilfe](help)
-
 Wenn du der Administrator einer Friendica-Instanz bist, hast du Zugriff auf das so genannte **Admin Panel** in dem du die Friendica-Instanz konfigurieren kannst,
 
 Auf der Startseite des Admin Panels werden die Informationen zu der Instanz zusammengefasst.

--- a/doc/de/admin/ssl.md
+++ b/doc/de/admin/ssl.md
@@ -1,7 +1,5 @@
 # Friendica mit SSL nutzen
 
-* [Zur Startseite der Hilfe](help)
-
 ## Disclaimer
 
 **Dieses Dokument wurde im November 2016 aktualisiert.

--- a/doc/de/developer/addon-development.md
+++ b/doc/de/developer/addon-development.md
@@ -1,7 +1,5 @@
 # Friendica Addon/Entwicklung
 
-* [Zur Startseite der Hilfe](help)
-
 Bitte schau dir das Beispiel-Addon "randplace" für ein funktionierendes Beispiel für manche der hier aufgeführten Funktionen an.
 Das Facebook-Addon bietet ein Beispiel dafür, die "addon"- und "module"-Funktion gemeinsam zu integrieren.
 Addons arbeiten, indem sie Event Hooks abfangen.

--- a/doc/de/developer/guide.md
+++ b/doc/de/developer/guide.md
@@ -1,7 +1,5 @@
 # Friendica - Entwickler-Guide
 
-* [Zur Startseite der Hilfe](help)
-
 Hier erfährst Du, wie Du bei uns mitmachen kannst:
 
 Zunächst erstelle Dir per 'git clone https://github.com/friendica/friendica.git' ein funktionierendes Git-Paket auf Deinem System, auf dem Du die Entwicklung durchführst, und einen eigenen Github-Account.

--- a/doc/de/spec/protocol/message-flow.md
+++ b/doc/de/spec/protocol/message-flow.md
@@ -1,7 +1,5 @@
 # Friendica Nachrichtenfluss
 
-* [Zur Startseite der Hilfe](help)
-
 Diese Seite soll einige Infos darüber dokumentieren, wie Nachrichten innerhalb von Friendica von einer Person zur anderen übertragen werden.
 Es gibt verschiedene Pfade, die verschiedene Protokolle und Nachrichtenformate nutzen.
 

--- a/doc/de/user/account-basics.md
+++ b/doc/de/user/account-basics.md
@@ -1,7 +1,5 @@
 # Account - Basics
 
-* [Zur Startseite der Hilfe](help)
-
 ## Registrierung
 
 Viele, aber nicht alle Friendica-Knoten (Server) bieten die Möglichkeit zur Registrierung an.

--- a/doc/de/user/accounts-groups-pages.md
+++ b/doc/de/user/accounts-groups-pages.md
@@ -1,8 +1,5 @@
 # Accounttypen: Gruppen und Seiten
 
-* [Zur Startseite der Hilfe](help)
-
-
 In Friendica kannst Du auch Gruppen und/oder Prominenten-Seiten erstellen.
 
 Jede Seite in Friendica hat einen einmaligen Spitznamen.

--- a/doc/de/user/bbcode.md
+++ b/doc/de/user/bbcode.md
@@ -1,7 +1,5 @@
 # Referenz der Friendica BBCode Tags
 
-* [Zur Startseite der Hilfe](help)
-
 ## Inline
 
 <style>

--- a/doc/de/user/bugs-and-issues.md
+++ b/doc/de/user/bugs-and-issues.md
@@ -1,7 +1,5 @@
 # Bugs und Probleme
 
-* [Zur Startseite der Hilfe](help)
-
 Du solltest jeden Bug und jedes Problem, den/das Du findest, zunächst dem Administrator (oder gegebenenfalls der Support-Seite) Deines Servers melden, statt auf der allgemeinen Bug-Seite.
 Das erleichtert den Entwicklern ihre Arbeit (z. B. neue Features zu entwickeln), da sie sich nicht mit Fehlern beschäftigen müssen, mit denen sie nichts zu tun haben.
 

--- a/doc/de/user/channels.md
+++ b/doc/de/user/channels.md
@@ -1,7 +1,5 @@
 # Kanäle (Channels)
 
-* [Home](help)
-
 Kanäle sind eine Möglichkeit neue Inhalte zu finden, oder Inhalte anzuzeigen, die du sonst möglicherweise verpasst hättest.
 Es gibt mehrere vordefinierte Kanäle und zusätzlich kannst du deine eigenen, basierend auf ein paar Regeln, erstellen.
 Kanäle zeigen nur Beiträge aus den letzten 24 Stunden an. (Dieser Wert kann vom Administrator geändert werden.)

--- a/doc/de/user/chats.md
+++ b/doc/de/user/chats.md
@@ -1,7 +1,5 @@
 # Chats
 
-* [Zur Startseite der Hilfe](help)
-
 Du hast derzeit zwei Möglichkeiten, einen Chat auf Deiner Friendica-Seite zu betreiben
 
 * IRC - Internet Relay Chat

--- a/doc/de/user/circles-and-privacy.md
+++ b/doc/de/user/circles-and-privacy.md
@@ -1,7 +1,5 @@
 # Circles und Privatsphäre
 
-* [Zur Startseite der Hilfe](help)
-
 Circles sind nur eine Ansammlung von Freunden.
 Aber Friendica nutzt diese, um sehr mächtige Features zur Verfügung zu stellen.
 

--- a/doc/de/user/connectors.md
+++ b/doc/de/user/connectors.md
@@ -1,7 +1,5 @@
 # Konnektoren (Connectors)
 
-* [Zur Startseite der Hilfe](help)
-
 Konnektoren erlauben es Dir, Dich mit anderen sozialen Netzwerken zu verbinden.
 Mit diesen Konnektoren kannst Du z.B. zu Bluesky, Tumblr oder Twitter posten.
 Für Bluesky und Tumblr gibt es eine bidirektionale Verbindung, d.h. du kannst Friendica nutzen, um deine Timeline von diesen Diensten zu lesen.

--- a/doc/de/user/events.md
+++ b/doc/de/user/events.md
@@ -1,7 +1,5 @@
 # Veranstaltungen
 
-* [Zur Startseite der Hilfe](help)
-
 Veranstaltungen sind spezielle Postings.
 Die Veranstaltungen, die Du und deine Kontakte teilen, können unter [/events](/events) auf deiner Instanz aufgefunden werden.
 Um da hinzukommen gehe über den Tab "Veranstalltungen", abhänig von dem Theme, das du benutzt, ist der eventuell ein zusätzlicher link im Navigationsmenü der Seite vorhanden.

--- a/doc/de/user/export-import-contacts.md
+++ b/doc/de/user/export-import-contacts.md
@@ -1,7 +1,5 @@
 # Export / Import von gefolgten Kontakte
 
-* [Home](help)
-
 Zusätzlich zum [Umziehen des Accounts](help/user/move-account) kannst du die Liste der von dir gefolgten Kontakte exportieren und importieren.
 Die exportierte Liste wird als CSV Datei in einem zu anderen Plattformen, z.B. Mastodon, Misskey oder Pleroma, kompatiblen Format gespeichert.
 

--- a/doc/de/user/faq.md
+++ b/doc/de/user/faq.md
@@ -1,7 +1,5 @@
 # Häufig gestellte Fragen - FAQ
 
-* [Zur Startseite der Hilfe](help)
-
 ## Wo finde ich Hilfe?
 
 Wenn Du Probleme mit Deiner Friendica-Seite hast, dann kannst Du die Community in der [Friendica-Support-Gruppe](https://forum.friendi.ca/profile/helpers) fragen.

--- a/doc/de/user/making-friends.md
+++ b/doc/de/user/making-friends.md
@@ -1,7 +1,5 @@
 # Freunde finden
 
-* [Zur Startseite der Hilfe](help)
-
 Freundschaft kann in Friendica viele verschiedene Bedeutungen annehmen.
 Aber lasst es uns einfach halten, du willst einfach mit jemandem befreundet sein.
 Wie machst du das?

--- a/doc/de/user/move-account.md
+++ b/doc/de/user/move-account.md
@@ -1,7 +1,5 @@
 # Accounts Umziehen
 
-* [Zur Startseite der Hilfe](help)
-
 ! **Dies ist ein experimentelles Feature**
 
 **Wie man einen Account von einem Server zu einem anderen umzieht.**

--- a/doc/de/user/quick-start/groups-and-pages.md
+++ b/doc/de/user/quick-start/groups-and-pages.md
@@ -1,7 +1,5 @@
 # Gruppen und Seiten
 
-* [Zur Startseite der Hilfe](help)
-
 Hier siehst Du das globale Verzeichnis.
 Wenn Du Dich mal verirrt hast, kannst Du diesen Link klicken und wieder hierher kommen.
 
@@ -20,4 +18,4 @@ Solltest Du beim Stöbern durch die vielen Gruppen nicht wieder hierher zurück 
 
 Wenn Du einige Gruppen hinzugefügt hast, gehe [weiter zum nächsten Schritt](help/user/quick-start/finally).
 
-<iframe src="https://dir.friendica.social/group" width="950" height="600"></iframe>
+<iframe src="https://dir.friendica.social/group" width="100%" height="600"></iframe>

--- a/doc/de/user/quick-start/guide.md
+++ b/doc/de/user/quick-start/guide.md
@@ -1,7 +1,5 @@
 # Erste Schritte...
 
-* [Zur Startseite der Hilfe](help)
-
 Als Erstes: Gehe sicher, dass Du eingeloggt bist.
 Wenn Du noch nicht eingeloggt bist, kannst Du das in dem Fenster unten machen.
 
@@ -30,4 +28,4 @@ Auch wenn Du Deinen Server so konfiguriert hast, dass der Zugriff von außerhalb
 
 Probiere es doch einfach mal aus. Wenn Du fertig bist, schauen wir uns den ["Netzwerk"-Tab](help/user/quick-start/network) an.
 
-<iframe src="login" width="950" height="600"></iframe>
+<iframe src="login" width="100%" height="600"></iframe>

--- a/doc/de/user/quick-start/making-new-friends.md
+++ b/doc/de/user/quick-start/making-new-friends.md
@@ -1,7 +1,5 @@
 # Neue Freunde finden
 
-* [Zur Startseite der Hilfe](help)
-
 Hier siehst Du die Kontaktvorschläge.
 Wenn Du Dich mal verirrt hast, kannst Du [diesen Link klicken](help/user/quick-start/making-new-friends) und wieder hierher kommen.
 
@@ -22,4 +20,4 @@ Klicke einfach auf den Link oben auf dieser Seite und Du gelangst zur Seite mit 
 Du willst nicht einfach Personen hinzufügen, die du nicht kennst?
 Kein Problem - an dieser Stelle kommen wir zu den [Gruppen und Seiten](help/user/quick-start/groups-and-pages).
 
-<iframe src="contact/suggestions" width="950" height="600"></iframe>
+<iframe src="contact/suggestions" width="100%" height="600"></iframe>

--- a/doc/de/user/quick-start/network.md
+++ b/doc/de/user/quick-start/network.md
@@ -1,7 +1,5 @@
 # Deine "Netzwerk"-Seite
 
-* [Zur Startseite der Hilfe](help)
-
 Dies ist Dein "Netzwerk"-Tab.
 Wenn Du Dich mal verirrt hast, kannst Du [diesen Link klicken](help/user/quick-start/network), um wieder hierher zu kommen.
 
@@ -14,4 +12,4 @@ Du kannst ihre Beiträge von hier aus kommentieren, mitteilen, dass Du den Beitr
 Nun wollen wir diese Seite mit Inhalt füllen.
 Der erste Schritt ist es, [Leute zu Deinem Account hinzuzufügen](help/user/quick-start/making-new-friends).
 
-<iframe src="network" width="950" height="600"></iframe>
+<iframe src="network" width="100%" height="600"></iframe>

--- a/doc/de/user/remove-account.md
+++ b/doc/de/user/remove-account.md
@@ -1,7 +1,5 @@
 # Accounts löschen
 
-* [Zur Startseite der Hilfe](help)
-
 Wir freuen uns nicht, wenn Leute Friendica verlassen, aber wenn du deinen Account löschen willst, dann besuche die folgende URL
 
 [Lösche mich (http://NamederSeite/settings/removeme)](../settings/removeme)

--- a/doc/de/user/tags-and-mentions.md
+++ b/doc/de/user/tags-and-mentions.md
@@ -1,7 +1,5 @@
 # Tags und Erwähnungen
 
-* [Zur Startseite der Hilfe](help)
-
 Wie viele andere soziale Netzwerke benutzt auch Friendica eine spezielle Schreibweise in seinen Nachrichten, um Tags oder kontextbezogene Links zu anderen Beiträgen hervorzuheben.
 
 **Erwähnungen**

--- a/doc/de/user/text-comment.md
+++ b/doc/de/user/text-comment.md
@@ -1,7 +1,5 @@
 # Beiträge kommentieren, einordnen und löschen
 
-* [Zur Startseite der Hilfe](help)
-
 Hier findest du eine Übersicht über die verschiedenen Möglichkeiten, bestehende Beiträge einzuordnen und zu kommentieren.
 <span style="color: red;">
 Achtung: für dieses Beispiel wurde das Thema <b>"Diabook"</b> genutzt.

--- a/doc/de/user/text-editor.md
+++ b/doc/de/user/text-editor.md
@@ -1,7 +1,5 @@
 # Beiträge erstellen
 
-* [Zur Startseite der Hilfe](help)
-
 Hier findest du eine Übersicht über die verschiedenen Möglichkeiten, deinen Beitrag zu bearbeiten.
 <span style="color: red;">
 Achtung: für dieses Beispiel wurde das Thema <b>"Diabook"</b> genutzt.

--- a/doc/en/admin/config.md
+++ b/doc/en/admin/config.md
@@ -1,7 +1,5 @@
 # Config values that can only be set in config/local.config.php
 
-* [Home](help)
-
 Friendica's configuration is done in two places: in PHP array configuration files and in the `config` database table.
 Database config values overwrite the same file config values.
 

--- a/doc/en/admin/faq.md
+++ b/doc/en/admin/faq.md
@@ -1,7 +1,5 @@
 # Frequently asked questions (Admin) - FAQ
 
-* [Home](help)
-
 ## Can I configure multiple domains with the same code instance?
 
 No, this function is no longer supported as of Friendica 3.3 onwards.

--- a/doc/en/admin/improve-performance.md
+++ b/doc/en/admin/improve-performance.md
@@ -1,7 +1,5 @@
 # How to improve the performance of a Friendica server
 
-* [Home](help)
-
 Feel free to ask in the [Friendica support group](https://forum.friendi.ca/profile/helpers) if you need some clarification about the following instructions or if you need help in any other way.
 
 ## System configuration

--- a/doc/en/admin/install-ejabberd.md
+++ b/doc/en/admin/install-ejabberd.md
@@ -1,7 +1,5 @@
 # Install an ejabberd with synchronized credentials
 
-* [Home](help)
-
 [Ejabberd](https://www.ejabberd.im/) is a chat server that uses XMPP as messaging protocol that you can use with a large amount of clients.
 In conjunction with the "xmpp" addon it can be used for a web based chat solution for your users.
 

--- a/doc/en/admin/installing-connectors.md
+++ b/doc/en/admin/installing-connectors.md
@@ -1,7 +1,5 @@
 # Installing Connectors
 
-* [Home](help)
-
 Friendica uses add-ons to connect to some networks, such as Tumblr or Bluesky.
 
 All of these add-ons require an account on the target network.

--- a/doc/en/admin/migrate.md
+++ b/doc/en/admin/migrate.md
@@ -1,7 +1,5 @@
 # Migrating to a new server installation
 
-* [Home](help)
-
 ## Preparation
 
 ### New server

--- a/doc/en/admin/monitoring.md
+++ b/doc/en/admin/monitoring.md
@@ -1,7 +1,5 @@
 # Monitoring
 
-* [Home](help)
-
 ## Endpoints
 
 Currently, there are two endpoints for statistics available

--- a/doc/en/admin/settings.md
+++ b/doc/en/admin/settings.md
@@ -1,7 +1,5 @@
 # Settings
 
-* [Home](help)
-
 If you are the admin of a Friendica node, you have access to the **Admin Panel** where you can configure your Friendica node.
 
 ## Overview

--- a/doc/en/admin/ssl.md
+++ b/doc/en/admin/ssl.md
@@ -1,7 +1,5 @@
 # Using SSL with Friendica
 
-* [Home](help)
-
 ## Disclaimer
 
 **This document has been updated in November 2016.

--- a/doc/en/admin/tools.md
+++ b/doc/en/admin/tools.md
@@ -1,7 +1,5 @@
 # Admin tools
 
-* [Home](help)
-
 ## Friendica tools
 
 Friendica has a build in command console you can find in the *bin* directory.

--- a/doc/en/admin/update.md
+++ b/doc/en/admin/update.md
@@ -1,7 +1,5 @@
 # Updating Friendica
 
-* [Home](help)
-
 ## Using a Friendica archive
 
 If you installed Friendica in the ``path/to/friendica`` folder:

--- a/doc/en/developer/addon-development.md
+++ b/doc/en/developer/addon-development.md
@@ -1,7 +1,5 @@
 # Friendica addon development
 
-* [Home](help)
-
 Please see the sample addon 'randplace' for a working example of using some of these features.
 Addons work by intercepting event hooks - which must be registered.
 Modules work by intercepting specific page requests (by URL path).

--- a/doc/en/developer/addon-storage-backend.md
+++ b/doc/en/developer/addon-storage-backend.md
@@ -1,7 +1,5 @@
 # Friendica storage backend addon development
 
-* [Home](help)
-
 Storage backends can be added via addons.
 A storage backend is implemented as a class, and the plugin register the class to make it available to the system.
 

--- a/doc/en/developer/autoloader.md
+++ b/doc/en/developer/autoloader.md
@@ -1,7 +1,6 @@
 # Autoloader with Composer
 
-* [Home](help)
-  * [Developer Intro](help/developer/index)
+* [Developer Intro](help/developer/index)
 
 Friendica uses [Composer](https://getcomposer.org) to manage dependencies libraries and the class autoloader both for libraries and namespaced Friendica classes.
 

--- a/doc/en/developer/composer.md
+++ b/doc/en/developer/composer.md
@@ -1,7 +1,6 @@
 # Using Composer
 
-* [Home](help)
-  * [Developer Intro](help/developer/index)
+* [Developer Intro](help/developer/index)
 
 Friendica uses [Composer](https://getcomposer.org) to manage dependencies libraries and the class autoloader both for libraries and namespaced Friendica classes.
 

--- a/doc/en/developer/domain-driven-design.md
+++ b/doc/en/developer/domain-driven-design.md
@@ -1,7 +1,6 @@
 # Domain-driven design
 
-* [Home](help)
-  * [Developer Intro](help/developer/index)
+* [Developer Intro](help/developer/index)
 
 Friendica uses class structures inspired by Domain-Driven-Design programming patterns.
 This page is meant to explain what it means in practical terms for Friendica development.

--- a/doc/en/developer/github.md
+++ b/doc/en/developer/github.md
@@ -1,7 +1,5 @@
 # Friendica on GitHub
 
-* [Home](help)
-
 Here is how you can work on the code with us. If you have any questions please write to the Friendica developers' group.
 
 ## Introduction to the workflow with our GitHub repository

--- a/doc/en/developer/how-to-move-classes-to-src.md
+++ b/doc/en/developer/how-to-move-classes-to-src.md
@@ -1,7 +1,6 @@
 # How to move classes to `src`
 
-* [Home](help)
-  * [Developer Intro](help/developer/index)
+* [Developer Intro](help/developer/index)
 
 Friendica uses [Composer](help/developer/composer) to manage autoloading.
 This means that all the PHP class files moved to the `src` folder will be [automatically included](help/developer/autoloader) when the class it defines is first used in the flow.

--- a/doc/en/developer/index.md
+++ b/doc/en/developer/index.md
@@ -2,8 +2,6 @@
 
 <!-- markdownlint-disable MD010 MD013 -->
 
-* [Home](help)
-
 Do you want to help us improve Friendica?
 Here we have compiled some hints on how to get started and some tasks to help you choose.
 A project like Friendica is the sum of many contributions.

--- a/doc/en/developer/smarty3-templates.md
+++ b/doc/en/developer/smarty3-templates.md
@@ -1,7 +1,5 @@
 # Friendica templating documentation
 
-* [Home](help)
-
 Friendica uses [Smarty 3](http://www.smarty.net/) as PHP templating engine.
 The main templates are found in
 

--- a/doc/en/developer/strategy-hooks.md
+++ b/doc/en/developer/strategy-hooks.md
@@ -1,7 +1,5 @@
 # Friendica strategy Hooks
 
-* [Home](help)
-
 ## Strategy hooks
 
 This type of hook is based on the [Strategy Design Pattern](https://refactoring.guru/design-patterns/strategy).

--- a/doc/en/developer/tests.md
+++ b/doc/en/developer/tests.md
@@ -1,7 +1,5 @@
 # Tests
 
-* [Home](help)
-
 You can run unit tests with [PHPUnit](https://phpunit.de/):
 
 ```bash

--- a/doc/en/developer/translations.md
+++ b/doc/en/developer/translations.md
@@ -1,7 +1,5 @@
 # Friendica translations
 
-* [Home](help)
-
 ## Overview
 
 The Friendica translation process is based on `gettext` PO files.

--- a/doc/en/developer/vagrant.md
+++ b/doc/en/developer/vagrant.md
@@ -1,7 +1,5 @@
 # Vagrant for Friendica developers
 
-* [Home](help)
-
 ## Getting started
 
 [Vagrant](https://www.vagrantup.com/) is a virtualization solution for developers.

--- a/doc/en/spec/api/friendica.md
+++ b/doc/en/spec/api/friendica.md
@@ -1,7 +1,6 @@
 # Friendica API
 
-* [Home](help)
-  * [Using the APIs](help/spec/api/index)
+* [Using the APIs](help/spec/api/index)
 
 ## Overview
 

--- a/doc/en/spec/api/gnu-social.md
+++ b/doc/en/spec/api/gnu-social.md
@@ -1,7 +1,6 @@
 # GNU Social API
 
-* [Home](help)
-  * [Using the APIs](help/spec/api/index)
+* [Using the APIs](help/spec/api/index)
 
 ## Overview
 

--- a/doc/en/spec/api/mastodon.md
+++ b/doc/en/spec/api/mastodon.md
@@ -1,7 +1,6 @@
 # Mastodon API
 
-* [Home](help)
-  * [Using the APIs](help/spec/api/index)
+* [Using the APIs](help/spec/api/index)
 
 ## Overview
 

--- a/doc/en/spec/api/twitter.md
+++ b/doc/en/spec/api/twitter.md
@@ -1,7 +1,6 @@
 # Twitter API
 
-* [Home](help)
-  * [Using the APIs](help/spec/api/index)
+* [Using the APIs](help/spec/api/index)
 
 ## Overview
 

--- a/doc/en/spec/protocol/protocol.md
+++ b/doc/en/spec/protocol/protocol.md
@@ -1,7 +1,5 @@
 # Used protocols
 
-* [Home](help)
-
 ## Friendicas DFRN Protocol
 
 * [Document with the DFRN specification](spec/dfrn2.pdf)

--- a/doc/en/user/access-keys.md
+++ b/doc/en/user/access-keys.md
@@ -1,7 +1,5 @@
 # Access keys reference
 
-* [Home](help)
-
 Access keys are keyboard shortcuts that allow you to easily navigate the user interface.
 Access keys are currently not available with the Frio theme.
 

--- a/doc/en/user/account-basics.md
+++ b/doc/en/user/account-basics.md
@@ -1,7 +1,5 @@
 # Account basics
 
-* [Home](help)
-
 ## Registration
 
 Not all Friendica sites allow open registration.

--- a/doc/en/user/accounts-groups-pages.md
+++ b/doc/en/user/accounts-groups-pages.md
@@ -1,7 +1,5 @@
 # Account types: Groups and pages
 
-* [Home](help)
-
 Friendica also lets you create accounts that can function as discussion groups, celebrity accounts, announcement channels, news reflectors, or organization pages, depending on how you want to interact with others.
 Management of these accounts can be delegated to other accounts, or a parent account can be designated to easily toggle multiple identities.
 

--- a/doc/en/user/bugs-and-issues.md
+++ b/doc/en/user/bugs-and-issues.md
@@ -1,7 +1,5 @@
 # Bugs and issues
 
-* [Home](help)
-
 If your server has a support page, you should report any bugs/issues you encounter there first.
 Reporting to your support page before reporting to the developers makes their job easier, as they don't have to deal with bug reports that might not have anything to do with them.
 Reducing the workload in this way helps us get new features faster.

--- a/doc/en/user/channels.md
+++ b/doc/en/user/channels.md
@@ -1,7 +1,5 @@
 # Channels
 
-* [Home](help)
-
 Channels are a way to discover new content or to display content that you might have missed otherwise.
 There are several predefined channels, additionally you can create your own channels, based on some rules.
 Channels only display posts from the last 24 hours (this value can be changed by the admin).

--- a/doc/en/user/chats.md
+++ b/doc/en/user/chats.md
@@ -1,7 +1,5 @@
 # Chats
 
-* [Home](help)
-
 There are two possibilities to use chat on your friendica site
 
 * IRC Chat

--- a/doc/en/user/circles-and-privacy.md
+++ b/doc/en/user/circles-and-privacy.md
@@ -1,7 +1,5 @@
 # Circles and privacy
 
-* [Home](help)
-
 Circles are merely collections of friends.
 But Friendica uses these to unlock some very powerful features.
 

--- a/doc/en/user/connectors.md
+++ b/doc/en/user/connectors.md
@@ -1,7 +1,5 @@
 # Connectors
 
-* [Home](help)
-
 Connectors allow you to connect with external social networks and services.
 They are only required for posting to existing accounts on for example Bluesky, Tumblr or Twitter.
 For Bluesky and Tumblr you can also enable a bidirectional synchronisation, so that you can use Friendica to read your timeline from Tumblr or Bluesky.

--- a/doc/en/user/delete-account.md
+++ b/doc/en/user/delete-account.md
@@ -1,7 +1,5 @@
 # Deleting an account
 
-* [Home](help)
-
 We don't like to see people leave Friendica, but if you need to remove your account, you should visit the URL
 
 http://sitename/settings/removeme

--- a/doc/en/user/events.md
+++ b/doc/en/user/events.md
@@ -1,7 +1,5 @@
 # Events
 
-* [Home](help)
-
 A special form of postings are events.
 The events you and your contacts share can be found at [/events](/events) on your node.
 To get there go to your wall and follow the tab "events"

--- a/doc/en/user/export-import-contacts.md
+++ b/doc/en/user/export-import-contacts.md
@@ -1,7 +1,5 @@
 # Export / Import of followed Contacts
 
-* [Home](help)
-
 In addition to [move your account](help/user/move-account) you can export and import the list of accounts you follow.
 The exported list is stored as CSV file that is compatible to the format used by other platforms as e.g. Mastodon, Misskey or Pleroma.
 

--- a/doc/en/user/faq.md
+++ b/doc/en/user/faq.md
@@ -1,7 +1,5 @@
 # Frequently asked questions - FAQ
 
-* [Home](help)
-
 ## Where I can find help?
 
 If this FAQ does not answer your question you can always reach out to the community via the following options:

--- a/doc/en/user/keyboard-shortcuts.md
+++ b/doc/en/user/keyboard-shortcuts.md
@@ -1,7 +1,5 @@
 # Keyboard shortcuts in Friendica
 
-* [Home](help)
-
 ## General
 
 * j: Scroll to next thread

--- a/doc/en/user/making-friends.md
+++ b/doc/en/user/making-friends.md
@@ -1,7 +1,5 @@
 # Making friends
 
-* [Home](help)
-
 Friendship in Friendica can sometimes take on different meaning.
 But let's keep it simple; you want to be friends with somebody.
 How do you do it?

--- a/doc/en/user/move-account.md
+++ b/doc/en/user/move-account.md
@@ -1,8 +1,5 @@
 # Moving an account between servers
 
-* [Home](help)
-
-
 ! **This is an experimental feature**
 
 * Go to "Settings" -> "[Export personal data](uexport)"

--- a/doc/en/user/quick-start/groups-and-pages.md
+++ b/doc/en/user/quick-start/groups-and-pages.md
@@ -15,4 +15,4 @@ Remember the link at the top of this page will bring you back here.
 
 Once you've added some groups, [move on to the next section](help/user/quick-start/finally).
 
-<iframe src="https://dir.friendica.social/group" width="950" height="600"></iframe>
+<iframe src="https://dir.friendica.social/group" width="100%" height="600"></iframe>

--- a/doc/en/user/quick-start/guide.md
+++ b/doc/en/user/quick-start/guide.md
@@ -20,4 +20,4 @@ This means it will appear to anybody who views your profile, and in the communit
 
 Play around with this a bit, then when you're ready to move on, we'll take a look at the [Network Tab](help/user/quick-start/network).
 
-<iframe src="login" width="950" height="600"></iframe>
+<iframe src="login" width="100%" height="600"></iframe>

--- a/doc/en/user/quick-start/making-new-friends.md
+++ b/doc/en/user/quick-start/making-new-friends.md
@@ -16,4 +16,4 @@ Click the link at the top of this page to go back to the suggested friends list 
 Feel uncomfortable adding people you don't know?
 Don't worry - that's where [Groups and Pages](help/user/quick-start/groups-and-pages) come in!
 
-<iframe src="contact/suggestions" width="950" height="600"></iframe>
+<iframe src="contact/suggestions" width="100%" height="600"></iframe>

--- a/doc/en/user/quick-start/network.md
+++ b/doc/en/user/quick-start/network.md
@@ -9,4 +9,4 @@ Here, you can comment, like, or dislike posts, or click on somebody's name to vi
 
 Now we need to fill it up, the first step, is to [make some new friends](help/user/quick-start/making-new-friends).
 
-<iframe src="network" width="950" height="600"></iframe>
+<iframe src="network" width="100%" height="600"></iframe>

--- a/doc/en/user/safety.md
+++ b/doc/en/user/safety.md
@@ -1,7 +1,5 @@
 # Safety
 
-* [Home](help)
-
 Each Friendica instance is linked together with a global network of other servers, some running Friendica and some running other software.
 These servers support a diverse global community of millions of users.
 Inevitably, some of these users are malicious.

--- a/doc/en/user/tags-and-mentions.md
+++ b/doc/en/user/tags-and-mentions.md
@@ -1,7 +1,5 @@
 # Tags and mentions
 
-* [Home](help)
-
 Like many other modern social networks, Friendica uses a special notation inside messages to indicate "tags" or contextual links to other entities.
 
 ## Mentions

--- a/doc/en/user/text-comment.md
+++ b/doc/en/user/text-comment.md
@@ -1,7 +1,5 @@
 # Comment, sort and delete posts
 
-* [Home](help)
-
 Here you can find an overview of the different ways to comment and sort existing posts. <span style="color: red;">Attention: we've used the <b>"diabook"</b> theme. If you're using another theme, some of the icons may be different.</span>
 
 <img src="doc/assets/img/diabook.png" width="308" height="42" alt="diabook" >

--- a/doc/en/user/text-editor.md
+++ b/doc/en/user/text-editor.md
@@ -6,8 +6,6 @@ figure figcaption { background: #eeeeee; color: #444444; padding: 2px; font-styl
 
 # Creating posts
 
-* [Home](help)
-
 Here you can find an overview of the different ways to create and edit your post.
 
 One click on the Pencil & Paper icon in the top right of your Home or Network page, or the "Share" text box, and the post editor shows up.

--- a/doc/en/user/themes.md
+++ b/doc/en/user/themes.md
@@ -1,7 +1,5 @@
 # Themes
 
-* [Home](help)
-
 The default Theme in Friendica is called [frio](https://github.com/friendica/friendica/tree/stable/view/theme/frio).
 
 Open `Settings > Display > Custom Theme Settings` adjust the Theme to your liking. Select your preferred Appearance - light, dark or black - and your favorite Accent color. Click `Submit` to save your changes.

--- a/doc/en/user/two-factor-authentication.md
+++ b/doc/en/user/two-factor-authentication.md
@@ -1,7 +1,5 @@
 # Configuring two-factor authentication
 
-* [Home](help)
-
 You can configure two-factor authentication using a mobile app.
 A time-based one-time password (TOTP) application automatically generates an authentication code that changes after a certain period of time.
 
@@ -17,7 +15,7 @@ Nonetheless, we recommend:
 
  - For iOS, [Matt Rubin's MIT-licensed Authenticator app](https://mattrubin.me/authenticator).
  - For Android, [andOTP](https://github.com/andOTP/andOTP).
- 
+
 ### 2. Record your one-use recovery codes
 
 From your [two-factor authentication user settings](/settings/2fa), enter your password and click on "Enable two-factor authentication".

--- a/src/Core/Console.php
+++ b/src/Core/Console.php
@@ -41,36 +41,42 @@ class Console extends \Asika\SimpleConsole\Console
 Usage: bin/console [--version] [-h|--help|-?] <command> [<args>] [-v]
 
 Commands:
-	addon                  Addon management
-	cache                  Manage node cache
-	clearavatarcache       Clear the file based avatar cache
-	config                 Edit site config
-	contact                Contact management
-	createdoxygen          Generate Doxygen headers
 	daemon                 Interact with the Friendica daemon
+	help                   Show help about a command, e.g (bin/console help config)
 	jetstream              Interact with the Jetstream daemon
 	worker                 Start worker process
-	dbstructure            Do database updates
-	docbloxerrorchecker    Check the file tree for DocBlox errors
-	extract                Generate translation string file for the Friendica project (deprecated)
-	globalcommunityblock   Block remote profile from interacting with this node
-	globalcommunitysilence Silence a profile from the global community page
-	archivecontact         Archive a contact when you know that it isn't existing anymore
-	help                   Show help about a command, e.g (bin/console help config)
-	autoinstall            Starts automatic installation of friendica based on values from htconfig.php
-	lock                   Edit site locks
-	maintenance            Set maintenance mode for this node
-	movetoavatarcache      Move cached avatars to the file based avatar cache
-	mergecontacts          Merge duplicated contact entries
-	user                   User management
-	php2po                 Generate a messages.po file from a strings.php file
-	po2php                 Generate a strings.php file from a messages.po file
-	typo                   Checks for parse errors in Friendica files
-	postupdate             Execute pending post update scripts (can last days)
-	relocate               Update node base URL
-	serverblock            Manage blocked servers
-	storage                Manage storage backend
-	relay                  Manage ActivityPub relay servers
+
+	node management
+		archivecontact         Archive a contact when you know that it isn't existing anymore
+		cache                  Manage node cache
+		contact                Contact management
+		globalcommunityblock   Block remote profile from interacting with this node
+		globalcommunitysilence Silence a profile from the global community page
+		lock                   Edit site locks
+		mergecontacts          Merge duplicated contact entries
+		serverblock            Manage blocked servers
+		relay                  Manage ActivityPub relay servers
+		user                   User management
+
+	node configuration
+		addon                  Addon management
+		autoinstall            Starts automatic installation of friendica based on values from htconfig.php
+		clearavatarcache       Clear the file based avatar cache
+		config                 Edit site config
+		dbstructure            Do database updates
+		maintenance            Set maintenance mode for this node
+		movetoavatarcache      Move cached avatars to the file based avatar cache
+		postupdate             Execute pending post update scripts (can last days)
+		relocate               Update node base URL
+		storage                Manage storage backend
+
+	developer
+		createdoxygen          Generate Doxygen headers
+		docbloxerrorchecker    Check the file tree for DocBlox errors
+		extract                Generate translation string file for the Friendica project (deprecated)
+		php2po                 Generate a messages.po file from a strings.php file
+		po2php                 Generate a strings.php file from a messages.po file
+		typo                   Checks for parse errors in Friendica files
 
 Options:
 	-h|--help|-? Show help information

--- a/src/Module/Help.php
+++ b/src/Module/Help.php
@@ -64,7 +64,8 @@ class Help extends BaseModule
 		if ($filename !== "home") {
 			// create TOC but not for home
 			$lines     = explode("\n", $html);
-			$toc       = "<h2>TOC</h2><ul id='toc'>";
+			$back_text = DI::l10n()->t('Home');
+			$toc       = "<p><i class='fa fa-arrow-left'></i> <a href='/help'>&nbsp;$back_text</a></p><h2>TOC</h2><ul id='toc'>";
 			$lastLevel = 1;
 			$idNum     = [0, 0, 0, 0, 0, 0, 0];
 			foreach ($lines as &$line) {

--- a/src/Module/Help.php
+++ b/src/Module/Help.php
@@ -40,7 +40,7 @@ class Help extends BaseModule
 
 				$path .= DI::args()->get($x);
 			}
-			$title              = basename($path);
+			$title              = mb_ucfirst(basename($path));
 			$filename           = $path;
 			$text               = self::loadDocFile($path . '.md', $lang);
 			DI::page()['title'] = DI::l10n()->t('Help:') . ' ' . str_replace('-', ' ', $title);

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-29 19:23+0100\n"
+"POT-Creation-Date: 2025-11-02 23:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -286,7 +286,7 @@ msgstr ""
 #: mod/message.php:190 mod/message.php:348 mod/photos.php:1257
 #: src/Content/Conversation.php:393 src/Content/Conversation.php:1572
 #: src/Module/Item/Compose.php:205 src/Module/Post/Edit.php:141
-#: src/Object/Post.php:613
+#: src/Object/Post.php:617
 msgid "Please wait"
 msgstr ""
 
@@ -446,7 +446,7 @@ msgstr ""
 #: src/Module/Moderation/Report/Create.php:200
 #: src/Module/Moderation/Report/Create.php:260
 #: src/Module/Settings/Server/Action.php:65 src/Module/User/Delegation.php:181
-#: src/Object/Post.php:1159 view/theme/duepuntozero/config.php:73
+#: src/Object/Post.php:1163 view/theme/duepuntozero/config.php:73
 #: view/theme/frio/config.php:155 view/theme/quattro/config.php:75
 #: view/theme/vier/config.php:123
 msgid "Submit"
@@ -590,30 +590,30 @@ msgstr ""
 
 #: mod/photos.php:1095 mod/photos.php:1151 mod/photos.php:1231
 #: src/Module/Contact.php:609 src/Module/Item/Compose.php:187
-#: src/Object/Post.php:1156
+#: src/Object/Post.php:1160
 msgid "This is you"
 msgstr ""
 
 #: mod/photos.php:1097 mod/photos.php:1153 mod/photos.php:1233
-#: src/Module/Moderation/Reports.php:111 src/Object/Post.php:607
-#: src/Object/Post.php:1158
+#: src/Module/Moderation/Reports.php:110 src/Object/Post.php:611
+#: src/Object/Post.php:1162
 msgid "Comment"
 msgstr ""
 
 #: mod/photos.php:1099 mod/photos.php:1155 mod/photos.php:1235
 #: src/Content/Conversation.php:407 src/Module/Calendar/Event/Form.php:234
 #: src/Module/Item/Compose.php:200 src/Module/Post/Edit.php:161
-#: src/Object/Post.php:1172
+#: src/Object/Post.php:1176
 msgid "Preview"
 msgstr ""
 
 #: mod/photos.php:1100 src/Content/Conversation.php:361 src/Content/Nav.php:113
-#: src/Module/Post/Edit.php:126 src/Object/Post.php:1160
+#: src/Module/Post/Edit.php:126 src/Object/Post.php:1164
 msgid "Loading..."
 msgstr ""
 
 #: mod/photos.php:1192 src/Content/Conversation.php:1494
-#: src/Object/Post.php:259
+#: src/Object/Post.php:263
 msgid "Select"
 msgstr ""
 
@@ -626,23 +626,23 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: mod/photos.php:1254 src/Object/Post.php:431
+#: mod/photos.php:1254 src/Object/Post.php:435
 msgid "Like"
 msgstr ""
 
-#: mod/photos.php:1255 src/Object/Post.php:431
+#: mod/photos.php:1255 src/Object/Post.php:435
 msgid "I like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1256 src/Object/Post.php:432
+#: mod/photos.php:1256 src/Object/Post.php:436
 msgid "Dislike"
 msgstr ""
 
-#: mod/photos.php:1258 src/Object/Post.php:432
+#: mod/photos.php:1258 src/Object/Post.php:436
 msgid "I don't like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1279 src/Object/Post.php:224 src/Object/Post.php:226
+#: mod/photos.php:1279 src/Object/Post.php:228 src/Object/Post.php:230
 msgid "Edit"
 msgstr ""
 
@@ -1237,7 +1237,7 @@ msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
 #: src/Content/Conversation.php:330 src/Module/Item/Compose.php:199
-#: src/Object/Post.php:1171
+#: src/Object/Post.php:1175
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
@@ -1282,52 +1282,52 @@ msgid "attach file"
 msgstr ""
 
 #: src/Content/Conversation.php:366 src/Module/Item/Compose.php:189
-#: src/Module/Post/Edit.php:167 src/Object/Post.php:1161
+#: src/Module/Post/Edit.php:167 src/Object/Post.php:1165
 msgid "Bold"
 msgstr ""
 
 #: src/Content/Conversation.php:367 src/Module/Item/Compose.php:190
-#: src/Module/Post/Edit.php:168 src/Object/Post.php:1162
+#: src/Module/Post/Edit.php:168 src/Object/Post.php:1166
 msgid "Italic"
 msgstr ""
 
 #: src/Content/Conversation.php:368 src/Module/Item/Compose.php:191
-#: src/Module/Post/Edit.php:169 src/Object/Post.php:1163
+#: src/Module/Post/Edit.php:169 src/Object/Post.php:1167
 msgid "Underline"
 msgstr ""
 
 #: src/Content/Conversation.php:369 src/Module/Item/Compose.php:192
-#: src/Module/Post/Edit.php:170 src/Object/Post.php:1165
+#: src/Module/Post/Edit.php:170 src/Object/Post.php:1169
 msgid "Quote"
 msgstr ""
 
 #: src/Content/Conversation.php:370 src/Module/Item/Compose.php:193
-#: src/Module/Post/Edit.php:171 src/Object/Post.php:1166
+#: src/Module/Post/Edit.php:171 src/Object/Post.php:1170
 msgid "Add emojis"
 msgstr ""
 
 #: src/Content/Conversation.php:371 src/Module/Item/Compose.php:194
-#: src/Object/Post.php:1164
+#: src/Object/Post.php:1168
 msgid "Content Warning"
 msgstr ""
 
 #: src/Content/Conversation.php:372 src/Module/Item/Compose.php:195
-#: src/Module/Post/Edit.php:172 src/Object/Post.php:1167
+#: src/Module/Post/Edit.php:172 src/Object/Post.php:1171
 msgid "Code"
 msgstr ""
 
 #: src/Content/Conversation.php:373 src/Module/Item/Compose.php:196
-#: src/Object/Post.php:1168
+#: src/Object/Post.php:1172
 msgid "Image"
 msgstr ""
 
 #: src/Content/Conversation.php:374 src/Module/Item/Compose.php:197
-#: src/Module/Post/Edit.php:173 src/Object/Post.php:1169
+#: src/Module/Post/Edit.php:173 src/Object/Post.php:1173
 msgid "Link"
 msgstr ""
 
 #: src/Content/Conversation.php:375 src/Module/Item/Compose.php:198
-#: src/Module/Post/Edit.php:174 src/Object/Post.php:1170
+#: src/Module/Post/Edit.php:174 src/Object/Post.php:1174
 msgid "Link or Media"
 msgstr ""
 
@@ -1483,25 +1483,25 @@ msgstr ""
 msgid "Pushed to us"
 msgstr ""
 
-#: src/Content/Conversation.php:1514 src/Object/Post.php:246
+#: src/Content/Conversation.php:1514 src/Object/Post.php:250
 msgid "Pinned item"
 msgstr ""
 
-#: src/Content/Conversation.php:1531 src/Object/Post.php:548
-#: src/Object/Post.php:549
+#: src/Content/Conversation.php:1531 src/Object/Post.php:552
+#: src/Object/Post.php:553
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: src/Content/Conversation.php:1545 src/Object/Post.php:536
+#: src/Content/Conversation.php:1545 src/Object/Post.php:540
 msgid "Categories:"
 msgstr ""
 
-#: src/Content/Conversation.php:1546 src/Object/Post.php:537
+#: src/Content/Conversation.php:1546 src/Object/Post.php:541
 msgid "Filed under:"
 msgstr ""
 
-#: src/Content/Conversation.php:1554 src/Object/Post.php:564
+#: src/Content/Conversation.php:1554 src/Object/Post.php:568
 #, php-format
 msgid "%s from %s"
 msgstr ""
@@ -1639,7 +1639,7 @@ msgstr ""
 msgid "Posts that mention or involve you"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Network.php:28 src/Object/Post.php:402
+#: src/Content/Conversation/Factory/Network.php:28 src/Object/Post.php:406
 msgid "Starred"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Create new group"
 msgstr ""
 
-#: src/Content/Item.php:336 src/Model/Item.php:2780
+#: src/Content/Item.php:336 src/Model/Item.php:2781
 msgid "event"
 msgstr ""
 
@@ -1847,7 +1847,7 @@ msgstr ""
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:345 src/Model/Item.php:2782
+#: src/Content/Item.php:345 src/Model/Item.php:2783
 #: src/Module/Post/Tag/Add.php:112
 msgid "photo"
 msgstr ""
@@ -1906,16 +1906,16 @@ msgstr ""
 msgid "Collapse"
 msgstr ""
 
-#: src/Content/Item.php:441 src/Object/Post.php:287
+#: src/Content/Item.php:441 src/Object/Post.php:291
 #, php-format
 msgid "Ignore %s server"
 msgstr ""
 
-#: src/Content/Item.php:445 src/Object/Post.php:508
+#: src/Content/Item.php:445 src/Object/Post.php:512
 msgid "Detected languages"
 msgstr ""
 
-#: src/Content/Item.php:448 src/Object/Post.php:591
+#: src/Content/Item.php:448 src/Object/Post.php:595
 msgid "Raw content"
 msgstr ""
 
@@ -1955,6 +1955,7 @@ msgid "Nothing new here"
 msgstr ""
 
 #: src/Content/Nav.php:118 src/Content/Nav.php:249 src/Content/Nav.php:306
+#: src/Module/Help.php:67
 msgid "Home"
 msgstr ""
 
@@ -2224,7 +2225,7 @@ msgstr ""
 #: src/Module/Moderation/Blocklist/Server/Index.php:84
 #: src/Module/Moderation/Item/Delete.php:47
 #: src/Module/Moderation/Item/Source.php:71
-#: src/Module/Moderation/Reports.php:105 src/Module/Moderation/Summary.php:64
+#: src/Module/Moderation/Reports.php:104 src/Module/Moderation/Summary.php:64
 #: src/Module/Moderation/Users/Active.php:89
 #: src/Module/Moderation/Users/Blocked.php:89
 #: src/Module/Moderation/Users/Create.php:47
@@ -2266,8 +2267,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3644
-#: src/Model/Item.php:3650 src/Model/Item.php:3651
+#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3645
+#: src/Model/Item.php:3651 src/Model/Item.php:3652
 msgid "Link to source"
 msgstr ""
 
@@ -3408,75 +3409,75 @@ msgstr ""
 msgid "Happy Birthday %s"
 msgstr ""
 
-#: src/Model/Item.php:2784
+#: src/Model/Item.php:2785
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2786
+#: src/Model/Item.php:2787
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2789 src/Module/Post/Tag/Add.php:112
+#: src/Model/Item.php:2790 src/Module/Post/Tag/Add.php:112
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:2978
+#: src/Model/Item.php:2979
 #, php-format
 msgid "%s is blocked"
 msgstr ""
 
-#: src/Model/Item.php:2980
+#: src/Model/Item.php:2981
 #, php-format
 msgid "%s is ignored"
 msgstr ""
 
-#: src/Model/Item.php:2982
+#: src/Model/Item.php:2983
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:2986
+#: src/Model/Item.php:2987
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3544
+#: src/Model/Item.php:3545
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3575
+#: src/Model/Item.php:3576
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3577
+#: src/Model/Item.php:3578
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3582
+#: src/Model/Item.php:3583
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3584
+#: src/Model/Item.php:3585
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3586
+#: src/Model/Item.php:3587
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3627 src/Model/Item.php:3628
+#: src/Model/Item.php:3628 src/Model/Item.php:3629
 msgid "View on separate page"
 msgstr ""
 
@@ -4267,7 +4268,7 @@ msgstr ""
 msgid "Job Parameters"
 msgstr ""
 
-#: src/Module/Admin/Queue.php:65 src/Module/Moderation/Reports.php:111
+#: src/Module/Admin/Queue.php:65 src/Module/Moderation/Reports.php:110
 #: src/Module/Settings/OAuth.php:60
 msgid "Created"
 msgstr ""
@@ -5680,7 +5681,7 @@ msgstr ""
 msgid "Submanaged account can't access the moderation pages. Please log back in as the main account."
 msgstr ""
 
-#: src/Module/BaseModeration.php:99 src/Module/Moderation/Reports.php:110
+#: src/Module/BaseModeration.php:99 src/Module/Moderation/Reports.php:109
 msgid "Reports"
 msgstr ""
 
@@ -5737,7 +5738,7 @@ msgstr ""
 #: src/Module/Contact.php:542 src/Module/Conversation/Channel.php:98
 #: src/Module/Conversation/Community.php:91
 #: src/Module/Conversation/Network.php:347
-#: src/Module/Moderation/BaseUsers.php:130 src/Object/Post.php:611
+#: src/Module/Moderation/BaseUsers.php:130 src/Object/Post.php:615
 msgid "More"
 msgstr ""
 
@@ -6055,7 +6056,7 @@ msgid "Only show blocked contacts"
 msgstr ""
 
 #: src/Module/Contact.php:353 src/Module/Contact.php:425
-#: src/Module/Settings/Server/Index.php:94 src/Object/Post.php:390
+#: src/Module/Settings/Server/Index.php:94 src/Object/Post.php:394
 msgid "Ignored"
 msgstr ""
 
@@ -6182,7 +6183,7 @@ msgstr ""
 
 #: src/Module/Contact/Advanced.php:120
 #: src/Module/Moderation/Blocklist/Contact.php:110
-#: src/Module/Moderation/Reports.php:111
+#: src/Module/Moderation/Reports.php:110
 #: src/Module/Moderation/Users/Active.php:82
 #: src/Module/Moderation/Users/Blocked.php:82
 #: src/Module/Moderation/Users/Deleted.php:69
@@ -6300,7 +6301,7 @@ msgstr ""
 #: src/Module/Contact/Follow.php:155 src/Module/Contact/Profile.php:449
 #: src/Module/Contact/Unfollow.php:115
 #: src/Module/Moderation/Blocklist/Contact.php:119
-#: src/Module/Moderation/Reports.php:118
+#: src/Module/Moderation/Reports.php:117
 #: src/Module/Notifications/Introductions.php:121
 #: src/Module/Notifications/Introductions.php:192
 msgid "Profile URL"
@@ -7378,7 +7379,7 @@ msgid "Block New Remote Contact"
 msgstr ""
 
 #: src/Module/Moderation/Blocklist/Contact.php:110
-#: src/Module/Moderation/Reports.php:111
+#: src/Module/Moderation/Reports.php:110
 msgid "Photo"
 msgstr ""
 
@@ -7881,30 +7882,30 @@ msgstr ""
 msgid "3. Pick posts"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:106
+#: src/Module/Moderation/Reports.php:105
 msgid "List of reports"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:107
+#: src/Module/Moderation/Reports.php:106
 msgid "This page display reports created by our or remote users."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:108
+#: src/Module/Moderation/Reports.php:107
 msgid "No report exists at this node."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:111
+#: src/Module/Moderation/Reports.php:110
 msgid "Category"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:115
+#: src/Module/Moderation/Reports.php:114
 #, php-format
 msgid "%s total report"
 msgid_plural "%s total reports"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Moderation/Reports.php:118
+#: src/Module/Moderation/Reports.php:117
 msgid "URL of the reported contact."
 msgstr ""
 
@@ -8558,7 +8559,7 @@ msgstr ""
 msgid "Private Message"
 msgstr ""
 
-#: src/Module/Profile/Schedule.php:101 src/Object/Post.php:551
+#: src/Module/Profile/Schedule.php:101 src/Object/Post.php:555
 msgid "via"
 msgstr ""
 
@@ -11380,259 +11381,259 @@ msgstr ""
 msgid "Connector Message"
 msgstr ""
 
-#: src/Object/Post.php:260
+#: src/Object/Post.php:264
 msgid "Delete globally"
 msgstr ""
 
-#: src/Object/Post.php:260
+#: src/Object/Post.php:264
 msgid "Remove locally"
 msgstr ""
 
-#: src/Object/Post.php:267
+#: src/Object/Post.php:271
 #, php-format
 msgid "Block %s"
 msgstr ""
 
-#: src/Object/Post.php:272
+#: src/Object/Post.php:276
 #, php-format
 msgid "Ignore %s"
 msgstr ""
 
-#: src/Object/Post.php:277
+#: src/Object/Post.php:281
 #, php-format
 msgid "Collapse %s"
 msgstr ""
 
-#: src/Object/Post.php:281
+#: src/Object/Post.php:285
 msgid "Report post"
 msgstr ""
 
-#: src/Object/Post.php:292
+#: src/Object/Post.php:296
 msgid "Save to folder"
 msgstr ""
 
-#: src/Object/Post.php:338
+#: src/Object/Post.php:342
 msgid "I will attend"
 msgstr ""
 
-#: src/Object/Post.php:338
+#: src/Object/Post.php:342
 msgid "I will not attend"
 msgstr ""
 
-#: src/Object/Post.php:338
+#: src/Object/Post.php:342
 msgid "I might attend"
 msgstr ""
 
-#: src/Object/Post.php:385
+#: src/Object/Post.php:389
 msgid "Ignore thread"
 msgstr ""
 
-#: src/Object/Post.php:386
+#: src/Object/Post.php:390
 msgid "Unignore thread"
 msgstr ""
 
-#: src/Object/Post.php:387
+#: src/Object/Post.php:391
 msgid "Toggle ignore status"
 msgstr ""
 
-#: src/Object/Post.php:397
+#: src/Object/Post.php:401
 msgid "Add star"
 msgstr ""
 
-#: src/Object/Post.php:398
+#: src/Object/Post.php:402
 msgid "Remove star"
 msgstr ""
 
-#: src/Object/Post.php:399
+#: src/Object/Post.php:403
 msgid "Toggle star status"
 msgstr ""
 
-#: src/Object/Post.php:410
+#: src/Object/Post.php:414
 msgid "Pin"
 msgstr ""
 
-#: src/Object/Post.php:411
+#: src/Object/Post.php:415
 msgid "Unpin"
 msgstr ""
 
-#: src/Object/Post.php:412
+#: src/Object/Post.php:416
 msgid "Toggle pin status"
 msgstr ""
 
-#: src/Object/Post.php:415
+#: src/Object/Post.php:419
 msgid "Pinned"
 msgstr ""
 
-#: src/Object/Post.php:420
+#: src/Object/Post.php:424
 msgid "Add tag"
 msgstr ""
 
-#: src/Object/Post.php:435
+#: src/Object/Post.php:439
 msgid "Quote share this"
 msgstr ""
 
-#: src/Object/Post.php:435
+#: src/Object/Post.php:439
 msgid "Quote Share"
 msgstr ""
 
-#: src/Object/Post.php:438
+#: src/Object/Post.php:442
 msgid "Reshare this"
 msgstr ""
 
-#: src/Object/Post.php:438
+#: src/Object/Post.php:442
 msgid "Reshare"
 msgstr ""
 
-#: src/Object/Post.php:439
+#: src/Object/Post.php:443
 msgid "Cancel your Reshare"
 msgstr ""
 
-#: src/Object/Post.php:439
+#: src/Object/Post.php:443
 msgid "Unshare"
 msgstr ""
 
-#: src/Object/Post.php:483
+#: src/Object/Post.php:487
 #, php-format
 msgid "%s (Received %s)"
 msgstr ""
 
-#: src/Object/Post.php:489
+#: src/Object/Post.php:493
 msgid "Comment this item on your system"
 msgstr ""
 
-#: src/Object/Post.php:489
+#: src/Object/Post.php:493
 msgid "Remote comment"
 msgstr ""
 
-#: src/Object/Post.php:513
+#: src/Object/Post.php:517
 msgid "Share via ..."
 msgstr ""
 
-#: src/Object/Post.php:513
+#: src/Object/Post.php:517
 msgid "Share via external services"
 msgstr ""
 
-#: src/Object/Post.php:520
+#: src/Object/Post.php:524
 msgid "Unknown parent"
 msgstr ""
 
-#: src/Object/Post.php:524
+#: src/Object/Post.php:528
 #, php-format
 msgid "in reply to %s"
 msgstr ""
 
-#: src/Object/Post.php:526
+#: src/Object/Post.php:530
 msgid "Parent is probably private or not federated."
 msgstr ""
 
-#: src/Object/Post.php:550
+#: src/Object/Post.php:554
 msgid "to"
 msgstr ""
 
-#: src/Object/Post.php:552
+#: src/Object/Post.php:556
 msgid "Wall-to-Wall"
 msgstr ""
 
-#: src/Object/Post.php:553
+#: src/Object/Post.php:557
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: src/Object/Post.php:608
+#: src/Object/Post.php:612
 #, php-format
 msgid "Reply to %s"
 msgstr ""
 
-#: src/Object/Post.php:630
+#: src/Object/Post.php:634
 msgid "Notifier task is pending"
 msgstr ""
 
-#: src/Object/Post.php:631
+#: src/Object/Post.php:635
 msgid "Delivery to remote servers is pending"
 msgstr ""
 
-#: src/Object/Post.php:632
+#: src/Object/Post.php:636
 msgid "Delivery to remote servers is underway"
 msgstr ""
 
-#: src/Object/Post.php:633
+#: src/Object/Post.php:637
 msgid "Delivery to remote servers is mostly done"
 msgstr ""
 
-#: src/Object/Post.php:634
+#: src/Object/Post.php:638
 msgid "Delivery to remote servers is done"
 msgstr ""
 
-#: src/Object/Post.php:659
+#: src/Object/Post.php:663
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Object/Post.php:660
+#: src/Object/Post.php:664
 msgid "Show more"
 msgstr ""
 
-#: src/Object/Post.php:661
+#: src/Object/Post.php:665
 msgid "Show fewer"
 msgstr ""
 
-#: src/Object/Post.php:698
+#: src/Object/Post.php:702
 #, php-format
 msgid "Reshared by: %s"
 msgstr ""
 
-#: src/Object/Post.php:703
+#: src/Object/Post.php:707
 #, php-format
 msgid "Viewed by: %s"
 msgstr ""
 
-#: src/Object/Post.php:708
+#: src/Object/Post.php:712
 #, php-format
 msgid "Read by: %s"
 msgstr ""
 
-#: src/Object/Post.php:713
+#: src/Object/Post.php:717
 #, php-format
 msgid "Liked by: %s"
 msgstr ""
 
-#: src/Object/Post.php:718
+#: src/Object/Post.php:722
 #, php-format
 msgid "Disliked by: %s"
 msgstr ""
 
-#: src/Object/Post.php:723
+#: src/Object/Post.php:727
 #, php-format
 msgid "Attended by: %s"
 msgstr ""
 
-#: src/Object/Post.php:728
+#: src/Object/Post.php:732
 #, php-format
 msgid "Maybe attended by: %s"
 msgstr ""
 
-#: src/Object/Post.php:733
+#: src/Object/Post.php:737
 #, php-format
 msgid "Not attended by: %s"
 msgstr ""
 
-#: src/Object/Post.php:738
+#: src/Object/Post.php:742
 #, php-format
 msgid "Commented by: %s"
 msgstr ""
 
-#: src/Object/Post.php:743
+#: src/Object/Post.php:747
 #, php-format
 msgid "Reacted with %s by: %s"
 msgstr ""
 
-#: src/Object/Post.php:766
+#: src/Object/Post.php:770
 #, php-format
 msgid "Quote shared by: %s"
 msgstr ""
 
-#: src/Protocol/ActivityPub/Receiver.php:569
+#: src/Protocol/ActivityPub/Receiver.php:570
 msgid "Chat"
 msgstr ""
 


### PR DESCRIPTION
Related to #11702 

# Changes with this PR

- Capitalizes the HTML titles with `mb_ucfirst`, which became lowercase when the filenames were lowercased.

- Console: Move the commands into different sections, almost exactly like the referenced PR (sorted the commands alphabetically as well - and I left three commands - daemon, jetstream and worker - outside of the categories as I wasn't sure whether they belong in "node management" or "node configuration"?)

- Adds a consistent reference back to the docs home (/help) at the top of the docs side bar, and removes all manual references there inside the docs themselves. It reuses the preexisting source string/translation "Home". (Also considered calling it "Go back")

<img width="290" height="211" alt="image" src="https://github.com/user-attachments/assets/6413155e-8d6b-431d-8da9-1985cac809b0" />

- Limit quick start guide iframes to the width of the parent container. I'm not sure how this broke, but the iframe width specified has been "950" for a while, but previously it was somehow still resized to match the parent container anyway, but on rc it breaks out of the container:

Stable:
<img width="886" height="737" alt="image" src="https://github.com/user-attachments/assets/5dd1e666-ec49-45c9-ac52-3d1e58011f67" />

RC:
<img width="886" height="737" alt="image" src="https://github.com/user-attachments/assets/18a3f6e5-9355-4534-a2e9-f8dbbc991480" />

This PR:
<img width="886" height="737" alt="image" src="https://github.com/user-attachments/assets/3faddc91-d4a6-4c1b-8102-7400bb2cd6d6" />