### PR TITLE
Sortable Widgets and Timelines

### DIFF
--- a/src/Content/Feature.php
+++ b/src/Content/Feature.php
@@ -21,16 +21,16 @@ class Feature
 	const PUBLIC_CALENDAR   = 'public_calendar';
 	const TAGCLOUD          = 'tagadelic';
 	// The different widgets:
-	const ACCOUNTS          = 'accounts';
-	const ARCHIVE           = 'archive';
-	const CIRCLES           = 'circles';
-	const CHANNELS          = 'channels';
-	const FOLDERS           = 'folders';
-	const GROUPS            = 'forumlist_profile';
-	const NETWORKS          = 'networks';
-	const NOSHARER          = 'nosharer';
-	const SEARCHES          = 'searches';
-	const TRENDING_TAGS     = 'trending_tags';
+	const ACCOUNTS      = 'accounts';
+	const ARCHIVE       = 'archive';
+	const CIRCLES       = 'circles';
+	const CHANNELS      = 'channels';
+	const FOLDERS       = 'folders';
+	const GROUPS        = 'forumlist_profile';
+	const NETWORKS      = 'networks';
+	const NOSHARER      = 'nosharer';
+	const SEARCHES      = 'searches';
+	const TRENDING_TAGS = 'trending_tags';
 
 	/**
 	 * check if feature is enabled

--- a/src/Content/Feature.php
+++ b/src/Content/Feature.php
@@ -12,23 +12,24 @@ use Friendica\Event\ArrayFilterEvent;
 
 class Feature
 {
-	const ACCOUNTS          = 'accounts';
 	const ADD_ABSTRACT      = 'add_abstract';
-	const ARCHIVE           = 'archive';
 	const CATEGORIES        = 'categories';
-	const CHANNELS          = 'channels';
-	const CIRCLES           = 'circles';
 	const COMMUNITY         = 'community';
 	const EXPLICIT_MENTIONS = 'explicit_mentions';
-	const FOLDERS           = 'folders';
-	const GROUPS            = 'forumlist_profile';
 	const MEMBER_SINCE      = 'profile_membersince';
-	const NETWORKS          = 'networks';
-	const NOSHARER          = 'nosharer';
 	const PHOTO_LOCATION    = 'photo_location';
 	const PUBLIC_CALENDAR   = 'public_calendar';
-	const SEARCHES          = 'searches';
 	const TAGCLOUD          = 'tagadelic';
+	// The different widgets:
+	const ACCOUNTS          = 'accounts';
+	const ARCHIVE           = 'archive';
+	const CIRCLES           = 'circles';
+	const CHANNELS          = 'channels';
+	const FOLDERS           = 'folders';
+	const GROUPS            = 'forumlist_profile';
+	const NETWORKS          = 'networks';
+	const NOSHARER          = 'nosharer';
+	const SEARCHES          = 'searches';
 	const TRENDING_TAGS     = 'trending_tags';
 
 	/**

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -608,6 +608,19 @@ class Widget
 			}
 		}
 
+		$widget_timelineorder = json_decode(DI::pConfig()->get($uid, 'system', 'widget_timeline_order'));
+		if (!empty($widget_timelineorder)){
+			$tmp = [];
+			foreach($widget_timelineorder as $order){
+				foreach($channels as $channel){
+					if($channel['ref'] == $order){
+						$tmp[] = $channel;
+					}
+				}
+			}
+			$channels = $tmp;
+		}
+		
 		return self::filter(
 			'channel',
 			DI::l10n()->t('Channels'),

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -609,18 +609,18 @@ class Widget
 		}
 
 		$widget_timelineorder = json_decode(DI::pConfig()->get($uid, 'system', 'widget_timeline_order'));
-		if (!empty($widget_timelineorder)){
+		if (!empty($widget_timelineorder)) {
 			$tmp = [];
-			foreach($widget_timelineorder as $order){
-				foreach($channels as $channel){
-					if($channel['ref'] == $order){
+			foreach($widget_timelineorder as $order) {
+				foreach($channels as $channel) {
+					if($channel['ref'] == $order) {
 						$tmp[] = $channel;
 					}
 				}
 			}
 			$channels = $tmp;
 		}
-		
+
 		return self::filter(
 			'channel',
 			DI::l10n()->t('Channels'),

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -148,9 +148,10 @@ class Network extends Timeline
 		$this->userDefinedChannel = $userDefinedChannel;
 	}
 
-	protected function widgets(string $widget) {
+	protected function widgets(string $widget)
+	{
 		$module = 'network';
-		switch($widget){
+		switch($widget) {
 			case "circles":
 				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::CIRCLES)) {
 					$this->page['aside'] .= Circle::sidebarWidget($module, $module . '/circle', 'standard', $this->circleId);
@@ -204,7 +205,7 @@ class Network extends Timeline
 				break;
 		}
 	}
-	
+
 	protected function content(array $request = []): string
 	{
 		if (!$this->session->getLocalUserId()) {
@@ -223,10 +224,10 @@ class Network extends Timeline
 			new ArrayFilterEvent(ArrayFilterEvent::NETWORK_CONTENT_START, $hook_data)
 		);
 
-		$o = '';
+		$o           = '';
 		$widgetorder = json_decode($this->pConfig->get($this->session->getLocalUserId(), 'feature', 'widgetorder'));
 
-		if (empty($widgetorder)){
+		if (empty($widgetorder)) {
 			$widgetorder = [
 				"circles",
 				"forumlist_profile",
@@ -240,8 +241,8 @@ class Network extends Timeline
 				"trending_tags"
 			];
 		}
-		
-		foreach($widgetorder as $widget){
+
+		foreach($widgetorder as $widget) {
 			$this->widgets($widget);
 		}
 
@@ -368,11 +369,11 @@ class Network extends Timeline
 		}
 
 		$menu_tab_order = json_decode($this->pConfig->get($this->session->getLocalUserId(), 'system', 'menu_timeline_order'));
-		if (!empty($menu_tab_order)){
+		if (!empty($menu_tab_order)) {
 			$tmp = [];
-			foreach($menu_tab_order as $order){
-				foreach($tabs as $key => $val){
-					if($key == $order){
+			foreach($menu_tab_order as $order) {
+				foreach($tabs as $key => $val) {
+					if($key == $order) {
 						$tmp[$key] = $val;
 					}
 				}

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -351,7 +351,7 @@ class Network extends Timeline
 			$tmp = [];
 			foreach ($menu_tab_order as $order) {
 				foreach ($tabs as $key => $val) {
-					if ($key == $order) {
+					if ($key == $order || $order == $val['code']) {
 						$tmp[$key] = $val;
 					}
 				}

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -148,6 +148,63 @@ class Network extends Timeline
 		$this->userDefinedChannel = $userDefinedChannel;
 	}
 
+	protected function widgets(string $widget) {
+		$module = 'network';
+		switch($widget){
+			case "circles":
+				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::CIRCLES)) {
+					$this->page['aside'] .= Circle::sidebarWidget($module, $module . '/circle', 'standard', $this->circleId);
+				};
+				break;
+			case "forumlist_profile":
+				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::GROUPS)) {
+					$this->page['aside'] .= GroupManager::widget($this->session->getLocalUserId());
+				}
+				break;
+			case "archive":
+				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::ARCHIVE)) {
+					$this->page['aside'] .= Widget::postedByYear($module . '/archive', $this->session->getLocalUserId(), false);
+				}
+				break;
+			case "networks":
+				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::NETWORKS)) {
+					$this->page['aside'] .= Widget::networks($module, $this->network);
+				}
+				break;
+			case "accounts":
+				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::ACCOUNTS)) {
+					$this->page['aside'] .= Widget::accountTypes($module, $this->accountTypeString);
+				}
+				break;
+			case "channels":
+				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::CHANNELS)) {
+					$this->page['aside'] .= Widget::channels($module, $this->selectedTab, $this->session->getLocalUserId());
+				}
+				break;
+			case "searches":
+				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::SEARCHES)) {
+					$this->page['aside'] .= Widget\SavedSearches::getHTML($this->args->getQueryString());
+				}
+				break;
+			case "folders":
+				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::FOLDERS)) {
+					$this->page['aside'] .= Widget::fileAs('filed', '');
+				}
+				break;
+			case "nosharer":
+				if (($this->channel->isTimeline($this->selectedTab) || $this->userDefinedChannel->isTimeline($this->selectedTab, $this->session->getLocalUserId())) &&
+					!in_array($this->selectedTab, [Channel::FOLLOWERS, Channel::FORYOU, Channel::DISCOVER]) && Feature::isEnabled($this->session->getLocalUserId(), Feature::NOSHARER)) {
+					$this->page['aside'] .= $this->getNoSharerWidget('network');
+				}
+				break;
+			case "trending_tags":
+				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::TRENDING_TAGS)) {
+					$this->page['aside'] .= TrendingTags::getHTML($this->selectedTab);
+				}
+				break;
+		}
+	}
+	
 	protected function content(array $request = []): string
 	{
 		if (!$this->session->getLocalUserId()) {
@@ -167,37 +224,25 @@ class Network extends Timeline
 		);
 
 		$o = '';
+		$widgetorder = json_decode($this->pConfig->get($this->session->getLocalUserId(), 'feature', 'widgetorder'));
 
-		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::CIRCLES)) {
-			$this->page['aside'] .= Circle::sidebarWidget($module, $module . '/circle', 'standard', $this->circleId);
+		if (empty($widgetorder)){
+			$widgetorder = [
+				"circles",
+				"forumlist_profile",
+				"archive",
+				"networks",
+				"accounts",
+				"channels",
+				"searches",
+				"folders",
+				"nosharer",
+				"trending_tags"
+			];
 		}
-		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::GROUPS)) {
-			$this->page['aside'] .= GroupManager::widget($this->session->getLocalUserId());
-		}
-		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::ARCHIVE)) {
-			$this->page['aside'] .= Widget::postedByYear($module . '/archive', $this->session->getLocalUserId(), false);
-		}
-		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::NETWORKS)) {
-			$this->page['aside'] .= Widget::networks($module, $this->network);
-		}
-		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::ACCOUNTS)) {
-			$this->page['aside'] .= Widget::accountTypes($module, $this->accountTypeString);
-		}
-		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::CHANNELS)) {
-			$this->page['aside'] .= Widget::channels($module, $this->selectedTab, $this->session->getLocalUserId());
-		}
-		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::SEARCHES)) {
-			$this->page['aside'] .= Widget\SavedSearches::getHTML($this->args->getQueryString());
-		}
-		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::FOLDERS)) {
-			$this->page['aside'] .= Widget::fileAs('filed', '');
-		}
-		if (($this->channel->isTimeline($this->selectedTab) || $this->userDefinedChannel->isTimeline($this->selectedTab, $this->session->getLocalUserId())) &&
-			!in_array($this->selectedTab, [Channel::FOLLOWERS, Channel::FORYOU, Channel::DISCOVER]) && Feature::isEnabled($this->session->getLocalUserId(), Feature::NOSHARER)) {
-			$this->page['aside'] .= $this->getNoSharerWidget('network');
-		}
-		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::TRENDING_TAGS)) {
-			$this->page['aside'] .= TrendingTags::getHTML($this->selectedTab);
+		
+		foreach($widgetorder as $widget){
+			$this->widgets($widget);
 		}
 
 		if ($this->pConfig->get($this->session->getLocalUserId(), 'system', 'infinite_scroll', true) && ($_GET['mode'] ?? '') != 'minimal') {
@@ -320,6 +365,19 @@ class Network extends Timeline
 			$tabs = array_merge($tabs, $this->getTabArray($this->channel->getTimelines($this->session->getLocalUserId()), 'network', 'channel'));
 			$tabs = array_merge($tabs, $this->getTabArray($this->channelRepository->selectByUid($this->session->getLocalUserId()), 'network', 'channel'));
 			$tabs = array_merge($tabs, $this->getTabArray($this->community->getTimelines(true), 'network', 'channel'));
+		}
+
+		$menu_tab_order = json_decode($this->pConfig->get($this->session->getLocalUserId(), 'system', 'menu_timeline_order'));
+		if (!empty($menu_tab_order)){
+			$tmp = [];
+			foreach($menu_tab_order as $order){
+				foreach($tabs as $key => $val){
+					if($key == $order){
+						$tmp[$key] = $val;
+					}
+				}
+			}
+			$tabs = $tmp;
 		}
 
 		$hook_data = [

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -148,64 +148,6 @@ class Network extends Timeline
 		$this->userDefinedChannel = $userDefinedChannel;
 	}
 
-	protected function widgets(string $widget)
-	{
-		$module = 'network';
-		switch($widget) {
-			case "circles":
-				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::CIRCLES)) {
-					$this->page['aside'] .= Circle::sidebarWidget($module, $module . '/circle', 'standard', $this->circleId);
-				};
-				break;
-			case "forumlist_profile":
-				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::GROUPS)) {
-					$this->page['aside'] .= GroupManager::widget($this->session->getLocalUserId());
-				}
-				break;
-			case "archive":
-				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::ARCHIVE)) {
-					$this->page['aside'] .= Widget::postedByYear($module . '/archive', $this->session->getLocalUserId(), false);
-				}
-				break;
-			case "networks":
-				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::NETWORKS)) {
-					$this->page['aside'] .= Widget::networks($module, $this->network);
-				}
-				break;
-			case "accounts":
-				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::ACCOUNTS)) {
-					$this->page['aside'] .= Widget::accountTypes($module, $this->accountTypeString);
-				}
-				break;
-			case "channels":
-				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::CHANNELS)) {
-					$this->page['aside'] .= Widget::channels($module, $this->selectedTab, $this->session->getLocalUserId());
-				}
-				break;
-			case "searches":
-				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::SEARCHES)) {
-					$this->page['aside'] .= Widget\SavedSearches::getHTML($this->args->getQueryString());
-				}
-				break;
-			case "folders":
-				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::FOLDERS)) {
-					$this->page['aside'] .= Widget::fileAs('filed', '');
-				}
-				break;
-			case "nosharer":
-				if (($this->channel->isTimeline($this->selectedTab) || $this->userDefinedChannel->isTimeline($this->selectedTab, $this->session->getLocalUserId())) &&
-					!in_array($this->selectedTab, [Channel::FOLLOWERS, Channel::FORYOU, Channel::DISCOVER]) && Feature::isEnabled($this->session->getLocalUserId(), Feature::NOSHARER)) {
-					$this->page['aside'] .= $this->getNoSharerWidget('network');
-				}
-				break;
-			case "trending_tags":
-				if (Feature::isEnabled($this->session->getLocalUserId(), Feature::TRENDING_TAGS)) {
-					$this->page['aside'] .= TrendingTags::getHTML($this->selectedTab);
-				}
-				break;
-		}
-	}
-
 	protected function content(array $request = []): string
 	{
 		if (!$this->session->getLocalUserId()) {
@@ -229,21 +171,57 @@ class Network extends Timeline
 
 		if (empty($widgetorder)) {
 			$widgetorder = [
-				"circles",
-				"forumlist_profile",
-				"archive",
-				"networks",
-				"accounts",
-				"channels",
-				"searches",
-				"folders",
-				"nosharer",
-				"trending_tags"
+				Feature::CIRCLES,
+				Feature::GROUPS,
+				Feature::ARCHIVE,
+				Feature::NETWORKS,
+				Feature::ACCOUNTS,
+				Feature::CHANNELS,
+				Feature::SEARCHES,
+				Feature::FOLDERS,
+				Feature::NOSHARER,
+				Feature::TRENDING_TAGS
 			];
 		}
 
-		foreach($widgetorder as $widget) {
-			$this->widgets($widget);
+		foreach ($widgetorder as $widget) {
+			if (Feature::isEnabled($this->session->getLocalUserId(), $widget)) {
+				switch ($widget) {
+					case Feature::CIRCLES:
+						$this->page['aside'] .= Circle::sidebarWidget($module, $module . '/circle', 'standard', $this->circleId);
+						break;
+					case Feature::GROUPS:
+						$this->page['aside'] .= GroupManager::widget($this->session->getLocalUserId());
+						break;
+					case Feature::ARCHIVE:
+						$this->page['aside'] .= Widget::postedByYear($module . '/archive', $this->session->getLocalUserId(), false);
+						break;
+					case Feature::NETWORKS:
+						$this->page['aside'] .= Widget::networks($module, $this->network);
+						break;
+					case Feature::ACCOUNTS:
+						$this->page['aside'] .= Widget::accountTypes($module, $this->accountTypeString);
+						break;
+					case Feature::CHANNELS:
+						$this->page['aside'] .= Widget::channels($module, $this->selectedTab, $this->session->getLocalUserId());
+						break;
+					case Feature::SEARCHES:
+						$this->page['aside'] .= Widget\SavedSearches::getHTML($this->args->getQueryString());
+						break;
+					case Feature::FOLDERS:
+						$this->page['aside'] .= Widget::fileAs('filed', '');
+						break;
+					case Feature::TRENDING_TAGS:
+						$this->page['aside'] .= TrendingTags::getHTML($this->selectedTab);
+						break;
+					case Feature::NOSHARER:
+						if (($this->channel->isTimeline($this->selectedTab) || $this->userDefinedChannel->isTimeline($this->selectedTab, $this->session->getLocalUserId())) &&
+							!in_array($this->selectedTab, [Channel::FOLLOWERS, Channel::FORYOU, Channel::DISCOVER])) {
+							$this->page['aside'] .= $this->getNoSharerWidget('network');
+						}
+						break;
+				}
+			}
 		}
 
 		if ($this->pConfig->get($this->session->getLocalUserId(), 'system', 'infinite_scroll', true) && ($_GET['mode'] ?? '') != 'minimal') {
@@ -371,9 +349,9 @@ class Network extends Timeline
 		$menu_tab_order = json_decode($this->pConfig->get($this->session->getLocalUserId(), 'system', 'menu_timeline_order'));
 		if (!empty($menu_tab_order)) {
 			$tmp = [];
-			foreach($menu_tab_order as $order) {
-				foreach($tabs as $key => $val) {
-					if($key == $order) {
+			foreach ($menu_tab_order as $order) {
+				foreach ($tabs as $key => $val) {
+					if ($key == $order) {
 						$tmp[$key] = $val;
 					}
 				}

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -107,6 +107,10 @@ class Display extends BaseSettings
 		$update_content          = (int)$request['update_content'];
 		$embed_remote_media      = (bool)$request['embed_remote_media'];
 		$embed_media             = (bool)$request['embed_media'];
+		$widget_timelineorder	 = trim($request['widget_timelineorder']);
+		$menu_timelineorder      = trim($request['menu_timelineorder']);
+		$widget_timeline_reset	 = (bool)$request['widget_timeline_reset'];
+		$menu_timeline_reset     = (bool)$request['menu_timeline_reset'];
 
 		$enabled_timelines = [];
 		foreach ($enable as $code => $enabled) {
@@ -153,7 +157,16 @@ class Display extends BaseSettings
 		$this->pConfig->set($uid, 'system', 'preview_mode', $preview_mode);
 		$this->pConfig->set($uid, 'system', 'embed_remote_media', $embed_remote_media);
 		$this->pConfig->set($uid, 'system', 'embed_media', $embed_media);
-
+		if ($widget_timeline_reset == 1){
+			$this->pConfig->delete($uid, 'system', 'widget_timeline_order');
+		} else {
+			$this->pConfig->set($uid, 'system', 'widget_timeline_order', $widget_timelineorder);
+		}
+		if ($menu_timeline_reset == 1){
+			$this->pConfig->delete($uid, 'system', 'menu_timeline_order');
+		} else {
+			$this->pConfig->set($uid, 'system', 'menu_timeline_order', $menu_timelineorder);
+		}
 		$this->pConfig->set($uid, 'system', 'network_timelines', $network_timelines);
 		$this->pConfig->set($uid, 'system', 'enabled_timelines', $enabled_timelines);
 		$this->pConfig->set($uid, 'channel', 'languages', $channel_languages);
@@ -277,10 +290,8 @@ class Display extends BaseSettings
 		$timelines = [];
 		foreach ($this->getAvailableTimelines($uid) as $timeline) {
 			$timelines[] = [
-				'label'       => $timeline->label,
-				'description' => $timeline->description,
-				'enable'      => ["enable[{$timeline->code}]", '', in_array($timeline->code, $enabled_timelines)],
-				'bookmark'    => ["bookmark[{$timeline->code}]", '', in_array($timeline->code, $bookmarked_timelines)],
+				'enable'      => ["enable[{$timeline->code}]", $timeline->label, in_array($timeline->code, $enabled_timelines), $timeline->description],
+				'bookmark'    => ["bookmark[{$timeline->code}]", $timeline->label, in_array($timeline->code, $bookmarked_timelines), $timeline->description],
 			];
 		}
 
@@ -321,6 +332,8 @@ class Display extends BaseSettings
 			'$timeline_title'      => $this->t('Timelines'),
 			'$channel_title'       => $this->t('Channels'),
 			'$calendar_title'      => $this->t('Calendar'),
+			'$sortable'            => $this->t('Drag to reorder or tab to item with keyboard and move up/down with arrow keys'),
+			'$reset_label'         => $this->t('Reset order'),
 
 			'$form_security_token' => self::getFormSecurityToken('settings_display'),
 			'$uid'                 => $uid,
@@ -349,6 +362,8 @@ class Display extends BaseSettings
 
 			'$timeline_label'       => $this->t('Label'),
 			'$timeline_descriptiom' => $this->t('Description'),
+			'$timeline_enable'      => $this->t('Channels Widget'),
+			'$timeline_bookmark'    => $this->t('Top Menu'),
 			'$timeline_enable'      => $this->t('Enable'),
 			'$timeline_bookmark'    => $this->t('Bookmark'),
 			'$timelines'            => $timelines,

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -157,12 +157,12 @@ class Display extends BaseSettings
 		$this->pConfig->set($uid, 'system', 'preview_mode', $preview_mode);
 		$this->pConfig->set($uid, 'system', 'embed_remote_media', $embed_remote_media);
 		$this->pConfig->set($uid, 'system', 'embed_media', $embed_media);
-		if ($widget_timeline_reset == 1) {
+		if ($widget_timeline_reset) {
 			$this->pConfig->delete($uid, 'system', 'widget_timeline_order');
 		} else {
 			$this->pConfig->set($uid, 'system', 'widget_timeline_order', $widget_timelineorder);
 		}
-		if ($menu_timeline_reset == 1) {
+		if ($menu_timeline_reset) {
 			$this->pConfig->delete($uid, 'system', 'menu_timeline_order');
 		} else {
 			$this->pConfig->set($uid, 'system', 'menu_timeline_order', $menu_timelineorder);

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -107,9 +107,9 @@ class Display extends BaseSettings
 		$update_content          = (int)$request['update_content'];
 		$embed_remote_media      = (bool)$request['embed_remote_media'];
 		$embed_media             = (bool)$request['embed_media'];
-		$widget_timelineorder	 = trim($request['widget_timelineorder']);
+		$widget_timelineorder    = trim($request['widget_timelineorder']);
 		$menu_timelineorder      = trim($request['menu_timelineorder']);
-		$widget_timeline_reset	 = (bool)$request['widget_timeline_reset'];
+		$widget_timeline_reset   = (bool)$request['widget_timeline_reset'];
 		$menu_timeline_reset     = (bool)$request['menu_timeline_reset'];
 
 		$enabled_timelines = [];
@@ -157,12 +157,12 @@ class Display extends BaseSettings
 		$this->pConfig->set($uid, 'system', 'preview_mode', $preview_mode);
 		$this->pConfig->set($uid, 'system', 'embed_remote_media', $embed_remote_media);
 		$this->pConfig->set($uid, 'system', 'embed_media', $embed_media);
-		if ($widget_timeline_reset == 1){
+		if ($widget_timeline_reset == 1) {
 			$this->pConfig->delete($uid, 'system', 'widget_timeline_order');
 		} else {
 			$this->pConfig->set($uid, 'system', 'widget_timeline_order', $widget_timelineorder);
 		}
-		if ($menu_timeline_reset == 1){
+		if ($menu_timeline_reset == 1) {
 			$this->pConfig->delete($uid, 'system', 'menu_timeline_order');
 		} else {
 			$this->pConfig->set($uid, 'system', 'menu_timeline_order', $menu_timelineorder);
@@ -290,8 +290,8 @@ class Display extends BaseSettings
 		$timelines = [];
 		foreach ($this->getAvailableTimelines($uid) as $timeline) {
 			$timelines[] = [
-				'enable'      => ["enable[{$timeline->code}]", $timeline->label, in_array($timeline->code, $enabled_timelines), $timeline->description],
-				'bookmark'    => ["bookmark[{$timeline->code}]", $timeline->label, in_array($timeline->code, $bookmarked_timelines), $timeline->description],
+				'enable'   => ["enable[{$timeline->code}]", $timeline->label, in_array($timeline->code, $enabled_timelines), $timeline->description],
+				'bookmark' => ["bookmark[{$timeline->code}]", $timeline->label, in_array($timeline->code, $bookmarked_timelines), $timeline->description],
 			];
 		}
 

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -294,7 +294,74 @@ class Display extends BaseSettings
 				'bookmark' => ["bookmark[{$timeline->code}]", $timeline->label, in_array($timeline->code, $bookmarked_timelines), $timeline->description],
 			];
 		}
-
+		/*  GET CUSTOM TIMELINE ORDERS IF ANY
+			=================================
+			First we see if there is a custom order saved in user prefs, if there is we set working array to that.
+			If we have an array create a temporary array with the items in the correct order.
+			Lastly we modify the $timelines array with our new order for "enable", "bookmark", or both.	
+		*/
+		$widget_timeline_order = json_decode($this->pConfig->get($uid, 'system', 'widget_timeline_order'));
+		$menu_timeline_order = json_decode($this->pConfig->get($uid, 'system', 'menu_timeline_order'));
+		$temp_widget_order = [];
+		$temp_menu_order = [];
+		// do the sidebar widget order first...
+		if (!empty($widget_timeline_order)){
+			$tmp = [];
+			$xtr = [];
+			foreach($widget_timeline_order as $order){
+				foreach($timelines as $timeline){
+					$name = str_replace(['enable[',']'],'',$timeline['enable'][0]);
+					if ($name == $order){
+						$tmp[]['enable'] = $timeline['enable'];
+					}
+				}
+			}
+			// there could be custom or add-on channels not in our array, append those
+			foreach($timelines as $timeline){
+				$name = str_replace(['enable[',']'],'',$timeline['enable'][0]);
+				if (!in_array($name,$widget_timeline_order)){
+					$xtr[]['enable'] = $timeline['enable'];
+				}
+			}
+			// combine our two temp arrays into one big temp array
+			$temp_widget_order = array_merge($tmp,$xtr);
+		}
+		// do the top menu order next...
+		if (!empty($menu_timeline_order)){
+			$tmp = [];
+			$xtr = [];
+			foreach($menu_timeline_order as $order){
+				foreach($timelines as $timeline){
+					$name = str_replace(['bookmark[',']'],'',$timeline['bookmark'][0]);
+					if ($name == $order){
+						$tmp[]['bookmark'] = $timeline['bookmark'];
+					}
+				}
+			}
+			// there could be custom or add-on channels unaccounted for in our array, append them
+			foreach($timelines as $timeline){
+				$name = str_replace(['bookmark[',']'],'',$timeline['bookmark'][0]);
+				if (!in_array($name,$menu_timeline_order)){
+					$xtr[]['bookmark'] = $timeline['bookmark'];
+				}
+			}
+			// combine our two temp arrays into one big temp array
+			$temp_menu_order = array_merge($tmp,$xtr);
+		}
+		/*  now we need to alter the original timelines array directly...
+			in theory populated temp arrays should be same length as timelines
+		*/
+		for($t=0; $t<count($timelines);$t++){
+			// only mod from populated widget array
+			if (count($temp_widget_order) > 0){
+				$timelines[$t]['enable'] = $temp_widget_order[$t]['enable'];
+			}
+			// only mod from populated menu array
+			if (count($temp_menu_order) > 0){
+				$timelines[$t]['bookmark'] = $temp_menu_order[$t]['bookmark'];
+			}
+		}
+		
 		$first_day_of_week = $this->pConfig->get($uid, 'calendar', 'first_day_of_week', 0);
 		$weekdays          = [
 			0 => $this->t('Sunday'),
@@ -333,7 +400,14 @@ class Display extends BaseSettings
 			'$channel_title'       => $this->t('Channels'),
 			'$calendar_title'      => $this->t('Calendar'),
 			'$sortable'            => $this->t('Drag to reorder or tab to item with keyboard and move up/down with arrow keys'),
-			'$reset_label'         => $this->t('Reset order'),
+			'$reset_widget'        => [
+				'0' => 'widget_timeline_reset',
+				'1'	=> $this->t('Reset order')
+			],
+			'$reset_menu'		   => [
+				'0' => 'menu_timeline_reset',
+				'1' => $this->t('Reset order')
+			],
 
 			'$form_security_token' => self::getFormSecurityToken('settings_display'),
 			'$uid'                 => $uid,

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -298,70 +298,70 @@ class Display extends BaseSettings
 			=================================
 			First we see if there is a custom order saved in user prefs, if there is we set working array to that.
 			If we have an array create a temporary array with the items in the correct order.
-			Lastly we modify the $timelines array with our new order for "enable", "bookmark", or both.	
+			Lastly we modify the $timelines array with our new order for "enable", "bookmark", or both.
 		*/
 		$widget_timeline_order = json_decode($this->pConfig->get($uid, 'system', 'widget_timeline_order'));
-		$menu_timeline_order = json_decode($this->pConfig->get($uid, 'system', 'menu_timeline_order'));
-		$temp_widget_order = [];
-		$temp_menu_order = [];
+		$menu_timeline_order   = json_decode($this->pConfig->get($uid, 'system', 'menu_timeline_order'));
+		$temp_widget_order     = [];
+		$temp_menu_order       = [];
 		// do the sidebar widget order first...
-		if (!empty($widget_timeline_order)){
+		if (!empty($widget_timeline_order)) {
 			$tmp = [];
 			$xtr = [];
-			foreach($widget_timeline_order as $order){
-				foreach($timelines as $timeline){
-					$name = str_replace(['enable[',']'],'',$timeline['enable'][0]);
-					if ($name == $order){
+			foreach ($widget_timeline_order as $order) {
+				foreach ($timelines as $timeline) {
+					$name = str_replace(['enable[',']'], '', $timeline['enable'][0]);
+					if ($name == $order) {
 						$tmp[]['enable'] = $timeline['enable'];
 					}
 				}
 			}
 			// there could be custom or add-on channels not in our array, append those
-			foreach($timelines as $timeline){
-				$name = str_replace(['enable[',']'],'',$timeline['enable'][0]);
-				if (!in_array($name,$widget_timeline_order)){
+			foreach ($timelines as $timeline) {
+				$name = str_replace(['enable[',']'], '', $timeline['enable'][0]);
+				if (!in_array($name, $widget_timeline_order)) {
 					$xtr[]['enable'] = $timeline['enable'];
 				}
 			}
 			// combine our two temp arrays into one big temp array
-			$temp_widget_order = array_merge($tmp,$xtr);
+			$temp_widget_order = array_merge($tmp, $xtr);
 		}
 		// do the top menu order next...
-		if (!empty($menu_timeline_order)){
+		if (!empty($menu_timeline_order)) {
 			$tmp = [];
 			$xtr = [];
-			foreach($menu_timeline_order as $order){
-				foreach($timelines as $timeline){
-					$name = str_replace(['bookmark[',']'],'',$timeline['bookmark'][0]);
-					if ($name == $order){
+			foreach ($menu_timeline_order as $order) {
+				foreach ($timelines as $timeline) {
+					$name = str_replace(['bookmark[',']'], '', $timeline['bookmark'][0]);
+					if ($name == $order) {
 						$tmp[]['bookmark'] = $timeline['bookmark'];
 					}
 				}
 			}
 			// there could be custom or add-on channels unaccounted for in our array, append them
-			foreach($timelines as $timeline){
-				$name = str_replace(['bookmark[',']'],'',$timeline['bookmark'][0]);
-				if (!in_array($name,$menu_timeline_order)){
+			foreach ($timelines as $timeline) {
+				$name = str_replace(['bookmark[',']'], '', $timeline['bookmark'][0]);
+				if (!in_array($name, $menu_timeline_order)) {
 					$xtr[]['bookmark'] = $timeline['bookmark'];
 				}
 			}
 			// combine our two temp arrays into one big temp array
-			$temp_menu_order = array_merge($tmp,$xtr);
+			$temp_menu_order = array_merge($tmp, $xtr);
 		}
 		/*  now we need to alter the original timelines array directly...
 			in theory populated temp arrays should be same length as timelines
 		*/
-		for($t=0; $t<count($timelines);$t++){
+		for ($t = 0; $t < count($timelines);$t++) {
 			// only mod from populated widget array
-			if (count($temp_widget_order) > 0){
+			if (count($temp_widget_order) > 0) {
 				$timelines[$t]['enable'] = $temp_widget_order[$t]['enable'];
 			}
 			// only mod from populated menu array
-			if (count($temp_menu_order) > 0){
+			if (count($temp_menu_order) > 0) {
 				$timelines[$t]['bookmark'] = $temp_menu_order[$t]['bookmark'];
 			}
 		}
-		
+
 		$first_day_of_week = $this->pConfig->get($uid, 'calendar', 'first_day_of_week', 0);
 		$weekdays          = [
 			0 => $this->t('Sunday'),
@@ -402,9 +402,9 @@ class Display extends BaseSettings
 			'$sortable'            => $this->t('Drag to reorder or tab to item with keyboard and move up/down with arrow keys'),
 			'$reset_widget'        => [
 				'0' => 'widget_timeline_reset',
-				'1'	=> $this->t('Reset order')
+				'1' => $this->t('Reset order')
 			],
-			'$reset_menu'		   => [
+			'$reset_menu' => [
 				'0' => 'menu_timeline_reset',
 				'1' => $this->t('Reset order')
 			],

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -364,8 +364,6 @@ class Display extends BaseSettings
 			'$timeline_descriptiom' => $this->t('Description'),
 			'$timeline_enable'      => $this->t('Channels Widget'),
 			'$timeline_bookmark'    => $this->t('Top Menu'),
-			'$timeline_enable'      => $this->t('Enable'),
-			'$timeline_bookmark'    => $this->t('Bookmark'),
 			'$timelines'            => $timelines,
 			'$timeline_explanation' => $this->t('Enable timelines that you want to see in the channels widget. Bookmark timelines that you want to see in the top menu.'),
 

--- a/src/Module/Settings/Features.php
+++ b/src/Module/Settings/Features.php
@@ -82,6 +82,7 @@ class Features extends BaseSettings
 			'$form_security_token' => BaseSettings::getFormSecurityToken('settings_features'),
 			'$title'               => $this->t('Additional Features'),
 			'$sortable'            => $this->t('Drag to reorder or tab to item with keyboard and move up/down with arrow keys'),
+			'$sort_key'			   => self::NETWORK_KEY,
 			'$reset'               => [
 				'0'	=> 'feature_resetorder',
 				'1'	=> $this->t('Reset order')

--- a/src/Module/Settings/Features.php
+++ b/src/Module/Settings/Features.php
@@ -37,7 +37,7 @@ class Features extends BaseSettings
 			if (strpos($k, 'feature_') === 0) {
 				if (substr($k, 8) == 'widgetorder') { // not boolean, stringified array
 					$this->pConfig->set($this->session->getLocalUserId(), 'feature', 'widgetorder', $v);
-				} elseif (substr($k, 8) == 'resetorder' && (bool)$v == 1) {
+				} elseif (substr($k, 8) == 'resetorder' && $v) {
 					$this->pConfig->delete($this->session->getLocalUserId(), 'feature', 'widgetorder');
 				} else {
 					$this->pConfig->set($this->session->getLocalUserId(), 'feature', substr($k, 8), (bool)$v);

--- a/src/Module/Settings/Features.php
+++ b/src/Module/Settings/Features.php
@@ -21,7 +21,7 @@ use Psr\Log\LoggerInterface;
 class Features extends BaseSettings
 {
 	const NETWORK_KEY = "network";
-	
+
 	/** @var IManagePersonalConfigValues */
 	private $pConfig;
 
@@ -66,8 +66,8 @@ class Features extends BaseSettings
 		if (!empty($widgetorder)) {
 			$tmp = [];
 			// iterate through widgetorder and network items
-			foreach($widgetorder as $widget) {
-				foreach($arr['network'][1] as $list_item) {
+			foreach ($widgetorder as $widget) {
+				foreach ($arr['network'][1] as $list_item) {
 					if ($list_item[0] == 'feature_'.$widget) {
 						$tmp[] = $list_item;
 					}
@@ -82,13 +82,13 @@ class Features extends BaseSettings
 			'$form_security_token' => BaseSettings::getFormSecurityToken('settings_features'),
 			'$title'               => $this->t('Additional Features'),
 			'$sortable'            => $this->t('Drag to reorder or tab to item with keyboard and move up/down with arrow keys'),
-			'$sort_key'			   => self::NETWORK_KEY,
+			'$sort_key'            => self::NETWORK_KEY,
 			'$reset'               => [
-				'0'	=> 'feature_resetorder',
-				'1'	=> $this->t('Reset order')
+				'0' => 'feature_resetorder',
+				'1' => $this->t('Reset order')
 			],
-			'$features'            => $arr,
-			'$submit'              => $this->t('Save Settings'),
+			'$features' => $arr,
+			'$submit'   => $this->t('Save Settings'),
 		]);
 	}
 }

--- a/src/Module/Settings/Features.php
+++ b/src/Module/Settings/Features.php
@@ -35,7 +35,13 @@ class Features extends BaseSettings
 		BaseSettings::checkFormSecurityTokenRedirectOnError('/settings/features', 'settings_features');
 		foreach ($request as $k => $v) {
 			if (strpos($k, 'feature_') === 0) {
-				$this->pConfig->set($this->session->getLocalUserId(), 'feature', substr($k, 8), (bool)$v);
+				if (substr($k, 8) == 'widgetorder'){ // not boolean, stringified array
+					$this->pConfig->set($this->session->getLocalUserId(), 'feature', 'widgetorder', $v);	
+				} else if (substr($k, 8) == 'resetorder' && (bool)$v == 1){
+					$this->pConfig->delete($this->session->getLocalUserId(), 'feature', 'widgetorder');			
+				} else {
+					$this->pConfig->set($this->session->getLocalUserId(), 'feature', substr($k, 8), (bool)$v);
+				}
 			}
 		}
 	}
@@ -52,11 +58,28 @@ class Features extends BaseSettings
 				$arr[$name][1][] = ['feature_' . $f[0], $f[1], Feature::isEnabled($this->session->getLocalUserId(), $f[0]), $f[2]];
 			}
 		}
+		// try to get widget order preference
+		$widgetorder = json_decode($this->pConfig->get($this->session->getLocalUserId(), 'feature', 'widgetorder'));
+		if (!empty($widgetorder)){
+			$tmp = [];
+			// iterate through widgetorder and network items
+			foreach($widgetorder as $widget){
+				foreach($arr['network'][1] as $list_item){
+					if ($list_item[0] == 'feature_'.$widget){
+						$tmp[] = $list_item;
+					}
+				}
+			}
+			// replace network order with temp array order
+			$arr['network'][1] = $tmp;
+		};
 
 		$tpl = Renderer::getMarkupTemplate('settings/features.tpl');
 		return Renderer::replaceMacros($tpl, [
 			'$form_security_token' => BaseSettings::getFormSecurityToken('settings_features'),
 			'$title'               => $this->t('Additional Features'),
+			'$sortable'			   => $this->t('Drag to reorder or tab to item with keyboard and move up/down with arrow keys'),
+			'$reset_label'		   => $this->t('Reset order'),
 			'$features'            => $arr,
 			'$submit'              => $this->t('Save Settings'),
 		]);

--- a/src/Module/Settings/Features.php
+++ b/src/Module/Settings/Features.php
@@ -43,7 +43,7 @@ class Features extends BaseSettings
 				} elseif ($key == 'resetorder' && $v) {
 					$this->pConfig->delete($this->session->getLocalUserId(), 'feature', 'widgetorder');
 				} else {
-					$this->pConfig->set($this->session->getLocalUserId(), 'feature', $key, (bool)$v);
+					$this->pConfig->set($this->session->getLocalUserId(), 'feature', $key, $v);
 				}
 			}
 		}

--- a/src/Module/Settings/Features.php
+++ b/src/Module/Settings/Features.php
@@ -35,10 +35,10 @@ class Features extends BaseSettings
 		BaseSettings::checkFormSecurityTokenRedirectOnError('/settings/features', 'settings_features');
 		foreach ($request as $k => $v) {
 			if (strpos($k, 'feature_') === 0) {
-				if (substr($k, 8) == 'widgetorder'){ // not boolean, stringified array
-					$this->pConfig->set($this->session->getLocalUserId(), 'feature', 'widgetorder', $v);	
-				} else if (substr($k, 8) == 'resetorder' && (bool)$v == 1){
-					$this->pConfig->delete($this->session->getLocalUserId(), 'feature', 'widgetorder');			
+				if (substr($k, 8) == 'widgetorder') { // not boolean, stringified array
+					$this->pConfig->set($this->session->getLocalUserId(), 'feature', 'widgetorder', $v);
+				} elseif (substr($k, 8) == 'resetorder' && (bool)$v == 1) {
+					$this->pConfig->delete($this->session->getLocalUserId(), 'feature', 'widgetorder');
 				} else {
 					$this->pConfig->set($this->session->getLocalUserId(), 'feature', substr($k, 8), (bool)$v);
 				}
@@ -60,12 +60,12 @@ class Features extends BaseSettings
 		}
 		// try to get widget order preference
 		$widgetorder = json_decode($this->pConfig->get($this->session->getLocalUserId(), 'feature', 'widgetorder'));
-		if (!empty($widgetorder)){
+		if (!empty($widgetorder)) {
 			$tmp = [];
 			// iterate through widgetorder and network items
-			foreach($widgetorder as $widget){
-				foreach($arr['network'][1] as $list_item){
-					if ($list_item[0] == 'feature_'.$widget){
+			foreach($widgetorder as $widget) {
+				foreach($arr['network'][1] as $list_item) {
+					if ($list_item[0] == 'feature_'.$widget) {
 						$tmp[] = $list_item;
 					}
 				}
@@ -78,8 +78,8 @@ class Features extends BaseSettings
 		return Renderer::replaceMacros($tpl, [
 			'$form_security_token' => BaseSettings::getFormSecurityToken('settings_features'),
 			'$title'               => $this->t('Additional Features'),
-			'$sortable'			   => $this->t('Drag to reorder or tab to item with keyboard and move up/down with arrow keys'),
-			'$reset_label'		   => $this->t('Reset order'),
+			'$sortable'            => $this->t('Drag to reorder or tab to item with keyboard and move up/down with arrow keys'),
+			'$reset_label'         => $this->t('Reset order'),
 			'$features'            => $arr,
 			'$submit'              => $this->t('Save Settings'),
 		]);

--- a/src/Module/Settings/Features.php
+++ b/src/Module/Settings/Features.php
@@ -20,6 +20,8 @@ use Psr\Log\LoggerInterface;
 
 class Features extends BaseSettings
 {
+	const NETWORK_KEY = "network";
+	
 	/** @var IManagePersonalConfigValues */
 	private $pConfig;
 
@@ -35,12 +37,13 @@ class Features extends BaseSettings
 		BaseSettings::checkFormSecurityTokenRedirectOnError('/settings/features', 'settings_features');
 		foreach ($request as $k => $v) {
 			if (strpos($k, 'feature_') === 0) {
-				if (substr($k, 8) == 'widgetorder') { // not boolean, stringified array
+				$key = substr($k, 8);
+				if ($key == 'widgetorder') { // not boolean, stringified array
 					$this->pConfig->set($this->session->getLocalUserId(), 'feature', 'widgetorder', $v);
-				} elseif (substr($k, 8) == 'resetorder' && $v) {
+				} elseif ($key == 'resetorder' && $v) {
 					$this->pConfig->delete($this->session->getLocalUserId(), 'feature', 'widgetorder');
 				} else {
-					$this->pConfig->set($this->session->getLocalUserId(), 'feature', substr($k, 8), (bool)$v);
+					$this->pConfig->set($this->session->getLocalUserId(), 'feature', $key, (bool)$v);
 				}
 			}
 		}
@@ -79,7 +82,10 @@ class Features extends BaseSettings
 			'$form_security_token' => BaseSettings::getFormSecurityToken('settings_features'),
 			'$title'               => $this->t('Additional Features'),
 			'$sortable'            => $this->t('Drag to reorder or tab to item with keyboard and move up/down with arrow keys'),
-			'$reset_label'         => $this->t('Reset order'),
+			'$reset'               => [
+				'0'	=> 'feature_resetorder',
+				'1'	=> $this->t('Reset order')
+			],
 			'$features'            => $arr,
 			'$submit'              => $this->t('Save Settings'),
 		]);

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-18 18:33+0100\n"
+"POT-Creation-Date: 2025-12-24 17:15+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -70,7 +70,7 @@ msgstr ""
 #: src/Module/Settings/ContactImport.php:49
 #: src/Module/Settings/ContactImport.php:96
 #: src/Module/Settings/Delegation.php:76 src/Module/Settings/Display.php:81
-#: src/Module/Settings/Display.php:193
+#: src/Module/Settings/Display.php:206
 #: src/Module/Settings/Profile/Photo/Crop.php:148
 #: src/Module/Settings/Profile/Photo/Index.php:96
 #: src/Module/Settings/RemoveMe.php:103 src/Module/Settings/UserExport.php:64
@@ -1643,178 +1643,178 @@ msgstr ""
 msgid "Favourite Posts"
 msgstr ""
 
-#: src/Content/Feature.php:104
+#: src/Content/Feature.php:105
 msgid "General Features"
 msgstr ""
 
-#: src/Content/Feature.php:106
+#: src/Content/Feature.php:107
 msgid "Photo Location"
 msgstr ""
 
-#: src/Content/Feature.php:106
+#: src/Content/Feature.php:107
 msgid "Photo metadata is normally stripped. This extracts the location (if present) prior to stripping metadata and links it to a map."
 msgstr ""
 
-#: src/Content/Feature.php:107
+#: src/Content/Feature.php:108
 msgid "Display the community in the navigation"
 msgstr ""
 
-#: src/Content/Feature.php:107
+#: src/Content/Feature.php:108
 msgid "If enabled, the community can be accessed via the navigation menu. Independent from this setting, the community timelines can always be accessed via the channels."
 msgstr ""
 
-#: src/Content/Feature.php:112
+#: src/Content/Feature.php:113
 msgid "Post Composition Features"
 msgstr ""
 
-#: src/Content/Feature.php:113
+#: src/Content/Feature.php:114
 msgid "Explicit Mentions"
 msgstr ""
 
-#: src/Content/Feature.php:113
+#: src/Content/Feature.php:114
 msgid "Add explicit mentions to comment box for manual control over who gets mentioned in replies."
 msgstr ""
 
-#: src/Content/Feature.php:114
+#: src/Content/Feature.php:115
 msgid "Add an abstract from ActivityPub content warnings"
 msgstr ""
 
-#: src/Content/Feature.php:114
+#: src/Content/Feature.php:115
 msgid "Add an abstract when commenting on ActivityPub posts with a content warning. Abstracts are displayed as content warning on systems like Mastodon or Pleroma."
 msgstr ""
 
-#: src/Content/Feature.php:119
+#: src/Content/Feature.php:120
 msgid "Post/Comment Tools"
 msgstr ""
 
-#: src/Content/Feature.php:120
+#: src/Content/Feature.php:121
 msgid "Post Categories"
 msgstr ""
 
-#: src/Content/Feature.php:120
+#: src/Content/Feature.php:121
 msgid "Add categories to your posts"
 msgstr ""
 
-#: src/Content/Feature.php:125
+#: src/Content/Feature.php:126
 msgid "Network Widgets"
 msgstr ""
 
-#: src/Content/Feature.php:126 src/Content/Widget.php:233
+#: src/Content/Feature.php:127 src/Content/Widget.php:233
 #: src/Model/Circle.php:587 src/Module/Contact.php:385
 #: src/Module/Welcome.php:63
 msgid "Circles"
 msgstr ""
 
-#: src/Content/Feature.php:126
+#: src/Content/Feature.php:127
 msgid "Display posts that have been created by accounts of the selected circle."
 msgstr ""
 
-#: src/Content/Feature.php:127 src/Content/GroupManager.php:128
+#: src/Content/Feature.php:128 src/Content/GroupManager.php:128
 #: src/Content/Nav.php:276 src/Content/Text/HTML.php:877
 #: src/Content/Widget.php:558 src/Model/User.php:1400
 msgid "Groups"
 msgstr ""
 
-#: src/Content/Feature.php:127
+#: src/Content/Feature.php:128
 msgid "Display posts that have been distributed by the selected group."
 msgstr ""
 
-#: src/Content/Feature.php:128 src/Content/Widget.php:527
+#: src/Content/Feature.php:129 src/Content/Widget.php:527
 msgid "Archives"
 msgstr ""
 
-#: src/Content/Feature.php:128
+#: src/Content/Feature.php:129
 msgid "Display an archive where posts can be selected by month and year."
 msgstr ""
 
-#: src/Content/Feature.php:129 src/Content/Widget.php:306
+#: src/Content/Feature.php:130 src/Content/Widget.php:306
 msgid "Protocols"
 msgstr ""
 
-#: src/Content/Feature.php:129
+#: src/Content/Feature.php:130
 msgid "Display posts with the selected protocols."
 msgstr ""
 
-#: src/Content/Feature.php:130 src/Content/Widget.php:564
+#: src/Content/Feature.php:131 src/Content/Widget.php:564
 #: src/Module/Settings/Account.php:391
 msgid "Account Types"
 msgstr ""
 
-#: src/Content/Feature.php:130
+#: src/Content/Feature.php:131
 msgid "Display posts done by accounts with the selected account type."
 msgstr ""
 
-#: src/Content/Feature.php:131 src/Content/Widget.php:613
+#: src/Content/Feature.php:132 src/Content/Widget.php:626
 #: src/Module/Admin/Site.php:474 src/Module/BaseSettings.php:113
-#: src/Module/Settings/Channels.php:216 src/Module/Settings/Display.php:322
+#: src/Module/Settings/Channels.php:216 src/Module/Settings/Display.php:333
 msgid "Channels"
 msgstr ""
 
-#: src/Content/Feature.php:131
+#: src/Content/Feature.php:132
 msgid "Display posts in the system channels and user defined channels."
 msgstr ""
 
-#: src/Content/Feature.php:132 src/Content/Widget/SavedSearches.php:46
+#: src/Content/Feature.php:133 src/Content/Widget/SavedSearches.php:46
 msgid "Saved Searches"
 msgstr ""
 
-#: src/Content/Feature.php:132
+#: src/Content/Feature.php:133
 msgid "Display posts that contain subscribed hashtags."
 msgstr ""
 
-#: src/Content/Feature.php:133 src/Content/Widget.php:336
+#: src/Content/Feature.php:134 src/Content/Widget.php:336
 msgid "Saved Folders"
 msgstr ""
 
-#: src/Content/Feature.php:133
+#: src/Content/Feature.php:134
 msgid "Display a list of folders in which posts are stored."
 msgstr ""
 
-#: src/Content/Feature.php:134 src/Module/Conversation/Timeline.php:190
+#: src/Content/Feature.php:135 src/Module/Conversation/Timeline.php:190
 msgid "Own Contacts"
 msgstr ""
 
-#: src/Content/Feature.php:134
+#: src/Content/Feature.php:135
 msgid "Include or exclude posts from subscribed accounts. This widget is not visible on all channels."
 msgstr ""
 
-#: src/Content/Feature.php:135 src/Content/Widget/TrendingTags.php:39
+#: src/Content/Feature.php:136 src/Content/Widget/TrendingTags.php:39
 msgid "Trending Tags"
 msgstr ""
 
-#: src/Content/Feature.php:135
+#: src/Content/Feature.php:136
 msgid "Display a list of the most popular tags in recent public posts."
 msgstr ""
 
-#: src/Content/Feature.php:140
+#: src/Content/Feature.php:141
 msgid "Advanced Profile Settings"
 msgstr ""
 
-#: src/Content/Feature.php:141
+#: src/Content/Feature.php:142
 msgid "Tag Cloud"
 msgstr ""
 
-#: src/Content/Feature.php:141
+#: src/Content/Feature.php:142
 msgid "Provide a personal tag cloud on your profile page"
 msgstr ""
 
-#: src/Content/Feature.php:142
+#: src/Content/Feature.php:143
 msgid "Display Membership Date"
 msgstr ""
 
-#: src/Content/Feature.php:142
+#: src/Content/Feature.php:143
 msgid "Display membership date in profile"
 msgstr ""
 
-#: src/Content/Feature.php:147
+#: src/Content/Feature.php:148
 msgid "Advanced Calendar Settings"
 msgstr ""
 
-#: src/Content/Feature.php:148
+#: src/Content/Feature.php:149
 msgid "Allow anonymous access to your calendar"
 msgstr ""
 
-#: src/Content/Feature.php:148
+#: src/Content/Feature.php:149
 msgid "Allows anonymous visitors to consult your calendar and your public events. Contact birthday events are private to you."
 msgstr ""
 
@@ -2027,7 +2027,7 @@ msgstr ""
 #: src/Content/Nav.php:231 src/Content/Nav.php:291
 #: src/Module/BaseProfile.php:70 src/Module/BaseProfile.php:73
 #: src/Module/BaseProfile.php:81 src/Module/BaseProfile.php:84
-#: src/Module/Settings/Display.php:323 view/theme/frio/theme.php:224
+#: src/Module/Settings/Display.php:334 view/theme/frio/theme.php:224
 #: view/theme/frio/theme.php:228
 msgid "Calendar"
 msgstr ""
@@ -2874,37 +2874,37 @@ msgid "%s (%s)"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:421
-#: src/Module/Settings/Display.php:290
+#: src/Module/Settings/Display.php:301
 msgid "Monday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:422
-#: src/Module/Settings/Display.php:291
+#: src/Module/Settings/Display.php:302
 msgid "Tuesday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:423
-#: src/Module/Settings/Display.php:292
+#: src/Module/Settings/Display.php:303
 msgid "Wednesday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:424
-#: src/Module/Settings/Display.php:293
+#: src/Module/Settings/Display.php:304
 msgid "Thursday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:425
-#: src/Module/Settings/Display.php:294
+#: src/Module/Settings/Display.php:305
 msgid "Friday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:426
-#: src/Module/Settings/Display.php:295
+#: src/Module/Settings/Display.php:306
 msgid "Saturday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:420
-#: src/Module/Settings/Display.php:289
+#: src/Module/Settings/Display.php:300
 msgid "Sunday"
 msgstr ""
 
@@ -3332,17 +3332,17 @@ msgid "today"
 msgstr ""
 
 #: src/Model/Event.php:454 src/Module/Calendar/Show.php:118
-#: src/Module/Settings/Display.php:300 src/Util/Temporal.php:343
+#: src/Module/Settings/Display.php:311 src/Util/Temporal.php:343
 msgid "month"
 msgstr ""
 
 #: src/Model/Event.php:455 src/Module/Calendar/Show.php:119
-#: src/Module/Settings/Display.php:301 src/Util/Temporal.php:344
+#: src/Module/Settings/Display.php:312 src/Util/Temporal.php:344
 msgid "week"
 msgstr ""
 
 #: src/Model/Event.php:456 src/Module/Calendar/Show.php:120
-#: src/Module/Settings/Display.php:302 src/Util/Temporal.php:345
+#: src/Module/Settings/Display.php:313 src/Util/Temporal.php:345
 msgid "day"
 msgstr ""
 
@@ -3894,7 +3894,7 @@ msgid "Disable"
 msgstr ""
 
 #: src/Module/Admin/Addons/Details.php:78
-#: src/Module/Admin/Themes/Details.php:41 src/Module/Settings/Display.php:352
+#: src/Module/Admin/Themes/Details.php:41
 msgid "Enable"
 msgstr ""
 
@@ -3948,8 +3948,8 @@ msgstr ""
 #: src/Module/Settings/Connectors.php:143
 #: src/Module/Settings/Connectors.php:228
 #: src/Module/Settings/ContactImport.php:110
-#: src/Module/Settings/Delegation.php:179 src/Module/Settings/Display.php:315
-#: src/Module/Settings/Features.php:61
+#: src/Module/Settings/Delegation.php:179 src/Module/Settings/Display.php:326
+#: src/Module/Settings/Features.php:84
 #: src/Module/Settings/Profile/Index.php:272
 msgid "Save Settings"
 msgstr ""
@@ -4300,11 +4300,11 @@ msgstr ""
 msgid "%s is no valid input for maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:364 src/Module/Settings/Display.php:211
+#: src/Module/Admin/Site.php:364 src/Module/Settings/Display.php:224
 msgid "No special theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:381 src/Module/Settings/Display.php:221
+#: src/Module/Admin/Site.php:381 src/Module/Settings/Display.php:234
 #, php-format
 msgid "%s - (Experimental)"
 msgstr ""
@@ -5231,7 +5231,7 @@ msgid "Can be \"all\" or \"tags\". \"all\" means that every public post should b
 msgstr ""
 
 #: src/Module/Admin/Site.php:596 src/Module/Contact/Profile.php:354
-#: src/Module/Settings/Display.php:256
+#: src/Module/Settings/Display.php:269
 #: src/Module/Settings/TwoFactor/Index.php:132
 msgid "Disabled"
 msgstr ""
@@ -5506,7 +5506,7 @@ msgid "Screenshot"
 msgstr ""
 
 #: src/Module/Admin/Themes/Details.php:83 src/Module/Admin/Themes/Index.php:104
-#: src/Module/BaseAdmin.php:78 src/Module/Settings/Display.php:318
+#: src/Module/BaseAdmin.php:78 src/Module/Settings/Display.php:329
 msgid "Themes"
 msgstr ""
 
@@ -5786,7 +5786,7 @@ msgstr ""
 #: src/Module/BaseProfile.php:141 src/Module/Contact.php:395
 #: src/Module/Contact.php:542 src/Module/Conversation/Channel.php:98
 #: src/Module/Conversation/Community.php:91
-#: src/Module/Conversation/Network.php:347
+#: src/Module/Conversation/Network.php:384
 #: src/Module/Moderation/BaseUsers.php:130 src/Object/Post.php:615
 msgid "More"
 msgstr ""
@@ -5994,7 +5994,7 @@ msgstr ""
 msgid "New Event"
 msgstr ""
 
-#: src/Module/Calendar/Show.php:121 src/Module/Settings/Display.php:303
+#: src/Module/Calendar/Show.php:121 src/Module/Settings/Display.php:314
 msgid "list"
 msgstr ""
 
@@ -6773,21 +6773,21 @@ msgstr ""
 msgid "Not available."
 msgstr ""
 
-#: src/Module/Conversation/Network.php:252
+#: src/Module/Conversation/Network.php:276
 msgid "No such circle"
 msgstr ""
 
-#: src/Module/Conversation/Network.php:256
+#: src/Module/Conversation/Network.php:280
 #, php-format
 msgid "Circle: %s"
 msgstr ""
 
-#: src/Module/Conversation/Network.php:276
+#: src/Module/Conversation/Network.php:300
 #, php-format
 msgid "Error %d (%s) while fetching the timeline."
 msgstr ""
 
-#: src/Module/Conversation/Network.php:359
+#: src/Module/Conversation/Network.php:396
 msgid "Network feed not available."
 msgstr ""
 
@@ -9554,12 +9554,12 @@ msgid "When selected, the channel results are reshared. This only works for publ
 msgstr ""
 
 #: src/Module/Settings/Channels.php:176 src/Module/Settings/Channels.php:202
-#: src/Module/Settings/Display.php:350
+#: src/Module/Settings/Display.php:363
 msgid "Label"
 msgstr ""
 
 #: src/Module/Settings/Channels.php:177 src/Module/Settings/Channels.php:203
-#: src/Module/Settings/Display.php:351
+#: src/Module/Settings/Display.php:364
 #: src/Module/Settings/TwoFactor/AppSpecific.php:123
 msgid "Description"
 msgstr ""
@@ -9946,243 +9946,255 @@ msgstr ""
 msgid "No entries."
 msgstr ""
 
-#: src/Module/Settings/Display.php:179
+#: src/Module/Settings/Display.php:192
 msgid "The theme you chose isn't available."
 msgstr ""
 
-#: src/Module/Settings/Display.php:219
+#: src/Module/Settings/Display.php:232
 #, php-format
 msgid "%s - (Unsupported)"
 msgstr ""
 
-#: src/Module/Settings/Display.php:257
+#: src/Module/Settings/Display.php:270
 msgid "Color/Black"
 msgstr ""
 
-#: src/Module/Settings/Display.php:258 view/theme/frio/php/scheme.php:95
+#: src/Module/Settings/Display.php:271 view/theme/frio/php/scheme.php:95
 msgid "Black"
 msgstr ""
 
-#: src/Module/Settings/Display.php:259
+#: src/Module/Settings/Display.php:272
 msgid "Color/White"
 msgstr ""
 
-#: src/Module/Settings/Display.php:260
+#: src/Module/Settings/Display.php:273
 msgid "White"
 msgstr ""
 
-#: src/Module/Settings/Display.php:265
+#: src/Module/Settings/Display.php:278
 msgid "No preview"
 msgstr ""
 
-#: src/Module/Settings/Display.php:266
+#: src/Module/Settings/Display.php:279
 msgid "No image"
 msgstr ""
 
-#: src/Module/Settings/Display.php:267
+#: src/Module/Settings/Display.php:280
 msgid "Small Image"
 msgstr ""
 
-#: src/Module/Settings/Display.php:268
+#: src/Module/Settings/Display.php:281
 msgid "Large Image"
 msgstr ""
 
-#: src/Module/Settings/Display.php:269
+#: src/Module/Settings/Display.php:282
 msgid "Automatic image size"
 msgstr ""
 
-#: src/Module/Settings/Display.php:314
+#: src/Module/Settings/Display.php:325
 msgid "Display Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:316
+#: src/Module/Settings/Display.php:327
 msgid "Content Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:317 view/theme/duepuntozero/config.php:74
+#: src/Module/Settings/Display.php:328 view/theme/duepuntozero/config.php:74
 #: view/theme/frio/config.php:159 view/theme/quattro/config.php:76
 #: view/theme/vier/config.php:124
 msgid "Theme settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:319
+#: src/Module/Settings/Display.php:330
 #, php-format
 msgid "Settings for %s"
 msgstr ""
 
-#: src/Module/Settings/Display.php:320
+#: src/Module/Settings/Display.php:331
 msgid "Note: If you switch the theme, you need to save changes before you can see the settings for the new theme below."
 msgstr ""
 
-#: src/Module/Settings/Display.php:321
+#: src/Module/Settings/Display.php:332
 msgid "Timelines"
 msgstr ""
 
-#: src/Module/Settings/Display.php:328
+#: src/Module/Settings/Display.php:335 src/Module/Settings/Features.php:81
+msgid "Drag to reorder or tab to item with keyboard and move up/down with arrow keys"
+msgstr ""
+
+#: src/Module/Settings/Display.php:336 src/Module/Settings/Features.php:82
+msgid "Reset order"
+msgstr ""
+
+#: src/Module/Settings/Display.php:341
 msgid "Display theme"
 msgstr ""
 
-#: src/Module/Settings/Display.php:329
+#: src/Module/Settings/Display.php:342
 msgid "Mobile theme"
 msgstr ""
 
-#: src/Module/Settings/Display.php:332
+#: src/Module/Settings/Display.php:345
 msgid "Number of items to display per page:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:332 src/Module/Settings/Display.php:333
+#: src/Module/Settings/Display.php:345 src/Module/Settings/Display.php:346
 msgid "Maximum of 100 items"
 msgstr ""
 
-#: src/Module/Settings/Display.php:333
+#: src/Module/Settings/Display.php:346
 msgid "Number of items to display per page when viewed from mobile device:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:334
+#: src/Module/Settings/Display.php:347
 msgid "Regularly update the page content"
 msgstr ""
 
-#: src/Module/Settings/Display.php:334
+#: src/Module/Settings/Display.php:347
 msgid "When enabled, new content on network, community and channels are added on top."
 msgstr ""
 
-#: src/Module/Settings/Display.php:335
+#: src/Module/Settings/Display.php:348
 msgid "Display emoticons"
 msgstr ""
 
-#: src/Module/Settings/Display.php:335
+#: src/Module/Settings/Display.php:348
 msgid "When enabled, emoticons are replaced with matching symbols."
 msgstr ""
 
-#: src/Module/Settings/Display.php:336
+#: src/Module/Settings/Display.php:349
 msgid "Infinite scroll"
 msgstr ""
 
-#: src/Module/Settings/Display.php:336
+#: src/Module/Settings/Display.php:349
 msgid "Automatic fetch new items when reaching the page end."
 msgstr ""
 
-#: src/Module/Settings/Display.php:337
+#: src/Module/Settings/Display.php:350
 msgid "Enable Smart Threading"
 msgstr ""
 
-#: src/Module/Settings/Display.php:337
+#: src/Module/Settings/Display.php:350
 msgid "Enable the automatic suppression of extraneous thread indentation."
 msgstr ""
 
-#: src/Module/Settings/Display.php:338
+#: src/Module/Settings/Display.php:351
 msgid "Display the Dislike feature"
 msgstr ""
 
-#: src/Module/Settings/Display.php:338
+#: src/Module/Settings/Display.php:351
 msgid "Display the Dislike button and dislike reactions on posts and comments."
 msgstr ""
 
-#: src/Module/Settings/Display.php:339
+#: src/Module/Settings/Display.php:352
 msgid "Display the resharer"
 msgstr ""
 
-#: src/Module/Settings/Display.php:339
+#: src/Module/Settings/Display.php:352
 msgid "Display the first resharer as icon and text on a reshared item."
 msgstr ""
 
-#: src/Module/Settings/Display.php:340
+#: src/Module/Settings/Display.php:353
 msgid "Stay local"
 msgstr ""
 
-#: src/Module/Settings/Display.php:340
+#: src/Module/Settings/Display.php:353
 msgid "Don't go to a remote system when following a contact link."
 msgstr ""
 
-#: src/Module/Settings/Display.php:341
+#: src/Module/Settings/Display.php:354
 msgid "Show the post deletion checkbox"
 msgstr ""
 
-#: src/Module/Settings/Display.php:341
+#: src/Module/Settings/Display.php:354
 msgid "Display the checkbox for the post deletion on the network page."
 msgstr ""
 
-#: src/Module/Settings/Display.php:342
+#: src/Module/Settings/Display.php:355
 msgid "DIsplay the event list"
 msgstr ""
 
-#: src/Module/Settings/Display.php:342
+#: src/Module/Settings/Display.php:355
 msgid "Display the birthday reminder and event list on the network page."
 msgstr ""
 
-#: src/Module/Settings/Display.php:343
+#: src/Module/Settings/Display.php:356
 msgid "Link preview mode"
 msgstr ""
 
-#: src/Module/Settings/Display.php:343
+#: src/Module/Settings/Display.php:356
 msgid "Appearance of the link preview that is added to each post with a link."
 msgstr ""
 
-#: src/Module/Settings/Display.php:344
+#: src/Module/Settings/Display.php:357
 msgid "Hide pictures with empty alternative text"
 msgstr ""
 
-#: src/Module/Settings/Display.php:344
+#: src/Module/Settings/Display.php:357
 msgid "Don't display pictures that are missing the alternative text."
 msgstr ""
 
-#: src/Module/Settings/Display.php:345
+#: src/Module/Settings/Display.php:358
 msgid "Hide custom emojis"
 msgstr ""
 
-#: src/Module/Settings/Display.php:345
+#: src/Module/Settings/Display.php:358
 msgid "Don't display custom emojis."
 msgstr ""
 
-#: src/Module/Settings/Display.php:346
+#: src/Module/Settings/Display.php:359
 msgid "Platform icons style"
 msgstr ""
 
-#: src/Module/Settings/Display.php:346
+#: src/Module/Settings/Display.php:359
 msgid "Style of the platform icons"
 msgstr ""
 
-#: src/Module/Settings/Display.php:347
+#: src/Module/Settings/Display.php:360
 msgid "Embed remote media"
 msgstr ""
 
-#: src/Module/Settings/Display.php:347
+#: src/Module/Settings/Display.php:360
 msgid "When enabled, remote media will be embedded in the post, like for example YouTube videos."
 msgstr ""
 
-#: src/Module/Settings/Display.php:348
+#: src/Module/Settings/Display.php:361
 msgid "Embed supported media"
 msgstr ""
 
-#: src/Module/Settings/Display.php:348
+#: src/Module/Settings/Display.php:361
 msgid "When enabled, remote media will be embedded in the post instead of using the local player if this is supported by the remote system. This is useful for media where the remote player is better than the local one, like for example Peertube videos."
 msgstr ""
 
-#: src/Module/Settings/Display.php:353
-msgid "Bookmark"
+#: src/Module/Settings/Display.php:365
+msgid "Channels Widget"
 msgstr ""
 
-#: src/Module/Settings/Display.php:355
+#: src/Module/Settings/Display.php:366
+msgid "Top Menu"
+msgstr ""
+
+#: src/Module/Settings/Display.php:368
 msgid "Enable timelines that you want to see in the channels widget. Bookmark timelines that you want to see in the top menu."
 msgstr ""
 
-#: src/Module/Settings/Display.php:357
+#: src/Module/Settings/Display.php:370
 msgid "Channel languages:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:357
+#: src/Module/Settings/Display.php:370
 msgid "Select all the languages you want to see in your channels. \"Unspecified\" describes all posts for which no language information was detected (e.g. posts with just an image or too little text to be sure of the language). If you want to see all languages, you will need to select all items in the list."
 msgstr ""
 
-#: src/Module/Settings/Display.php:359
+#: src/Module/Settings/Display.php:372
 msgid "Beginning of week:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:360
+#: src/Module/Settings/Display.php:373
 msgid "Default calendar view:"
 msgstr ""
 
-#: src/Module/Settings/Features.php:59
+#: src/Module/Settings/Features.php:80
 msgid "Additional Features"
 msgstr ""
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-24 17:15+0100\n"
+"POT-Creation-Date: 2025-12-24 17:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1746,7 +1746,7 @@ msgstr ""
 
 #: src/Content/Feature.php:132 src/Content/Widget.php:626
 #: src/Module/Admin/Site.php:474 src/Module/BaseSettings.php:113
-#: src/Module/Settings/Channels.php:216 src/Module/Settings/Display.php:333
+#: src/Module/Settings/Channels.php:216 src/Module/Settings/Display.php:400
 msgid "Channels"
 msgstr ""
 
@@ -2027,7 +2027,7 @@ msgstr ""
 #: src/Content/Nav.php:231 src/Content/Nav.php:291
 #: src/Module/BaseProfile.php:70 src/Module/BaseProfile.php:73
 #: src/Module/BaseProfile.php:81 src/Module/BaseProfile.php:84
-#: src/Module/Settings/Display.php:334 view/theme/frio/theme.php:224
+#: src/Module/Settings/Display.php:401 view/theme/frio/theme.php:224
 #: view/theme/frio/theme.php:228
 msgid "Calendar"
 msgstr ""
@@ -2874,37 +2874,37 @@ msgid "%s (%s)"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:421
-#: src/Module/Settings/Display.php:301
+#: src/Module/Settings/Display.php:368
 msgid "Monday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:422
-#: src/Module/Settings/Display.php:302
+#: src/Module/Settings/Display.php:369
 msgid "Tuesday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:423
-#: src/Module/Settings/Display.php:303
+#: src/Module/Settings/Display.php:370
 msgid "Wednesday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:424
-#: src/Module/Settings/Display.php:304
+#: src/Module/Settings/Display.php:371
 msgid "Thursday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:425
-#: src/Module/Settings/Display.php:305
+#: src/Module/Settings/Display.php:372
 msgid "Friday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:426
-#: src/Module/Settings/Display.php:306
+#: src/Module/Settings/Display.php:373
 msgid "Saturday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:420
-#: src/Module/Settings/Display.php:300
+#: src/Module/Settings/Display.php:367
 msgid "Sunday"
 msgstr ""
 
@@ -3332,17 +3332,17 @@ msgid "today"
 msgstr ""
 
 #: src/Model/Event.php:454 src/Module/Calendar/Show.php:118
-#: src/Module/Settings/Display.php:311 src/Util/Temporal.php:343
+#: src/Module/Settings/Display.php:378 src/Util/Temporal.php:343
 msgid "month"
 msgstr ""
 
 #: src/Model/Event.php:455 src/Module/Calendar/Show.php:119
-#: src/Module/Settings/Display.php:312 src/Util/Temporal.php:344
+#: src/Module/Settings/Display.php:379 src/Util/Temporal.php:344
 msgid "week"
 msgstr ""
 
 #: src/Model/Event.php:456 src/Module/Calendar/Show.php:120
-#: src/Module/Settings/Display.php:313 src/Util/Temporal.php:345
+#: src/Module/Settings/Display.php:380 src/Util/Temporal.php:345
 msgid "day"
 msgstr ""
 
@@ -3948,8 +3948,8 @@ msgstr ""
 #: src/Module/Settings/Connectors.php:143
 #: src/Module/Settings/Connectors.php:228
 #: src/Module/Settings/ContactImport.php:110
-#: src/Module/Settings/Delegation.php:179 src/Module/Settings/Display.php:326
-#: src/Module/Settings/Features.php:84
+#: src/Module/Settings/Delegation.php:179 src/Module/Settings/Display.php:393
+#: src/Module/Settings/Features.php:91
 #: src/Module/Settings/Profile/Index.php:272
 msgid "Save Settings"
 msgstr ""
@@ -5506,7 +5506,7 @@ msgid "Screenshot"
 msgstr ""
 
 #: src/Module/Admin/Themes/Details.php:83 src/Module/Admin/Themes/Index.php:104
-#: src/Module/BaseAdmin.php:78 src/Module/Settings/Display.php:329
+#: src/Module/BaseAdmin.php:78 src/Module/Settings/Display.php:396
 msgid "Themes"
 msgstr ""
 
@@ -5994,7 +5994,7 @@ msgstr ""
 msgid "New Event"
 msgstr ""
 
-#: src/Module/Calendar/Show.php:121 src/Module/Settings/Display.php:314
+#: src/Module/Calendar/Show.php:121 src/Module/Settings/Display.php:381
 msgid "list"
 msgstr ""
 
@@ -9554,12 +9554,12 @@ msgid "When selected, the channel results are reshared. This only works for publ
 msgstr ""
 
 #: src/Module/Settings/Channels.php:176 src/Module/Settings/Channels.php:202
-#: src/Module/Settings/Display.php:363
+#: src/Module/Settings/Display.php:437
 msgid "Label"
 msgstr ""
 
 #: src/Module/Settings/Channels.php:177 src/Module/Settings/Channels.php:203
-#: src/Module/Settings/Display.php:364
+#: src/Module/Settings/Display.php:438
 #: src/Module/Settings/TwoFactor/AppSpecific.php:123
 msgid "Description"
 msgstr ""
@@ -9991,210 +9991,211 @@ msgstr ""
 msgid "Automatic image size"
 msgstr ""
 
-#: src/Module/Settings/Display.php:325
+#: src/Module/Settings/Display.php:392
 msgid "Display Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:327
+#: src/Module/Settings/Display.php:394
 msgid "Content Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:328 view/theme/duepuntozero/config.php:74
+#: src/Module/Settings/Display.php:395 view/theme/duepuntozero/config.php:74
 #: view/theme/frio/config.php:159 view/theme/quattro/config.php:76
 #: view/theme/vier/config.php:124
 msgid "Theme settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:330
+#: src/Module/Settings/Display.php:397
 #, php-format
 msgid "Settings for %s"
 msgstr ""
 
-#: src/Module/Settings/Display.php:331
+#: src/Module/Settings/Display.php:398
 msgid "Note: If you switch the theme, you need to save changes before you can see the settings for the new theme below."
 msgstr ""
 
-#: src/Module/Settings/Display.php:332
+#: src/Module/Settings/Display.php:399
 msgid "Timelines"
 msgstr ""
 
-#: src/Module/Settings/Display.php:335 src/Module/Settings/Features.php:81
+#: src/Module/Settings/Display.php:402 src/Module/Settings/Features.php:84
 msgid "Drag to reorder or tab to item with keyboard and move up/down with arrow keys"
 msgstr ""
 
-#: src/Module/Settings/Display.php:336 src/Module/Settings/Features.php:82
+#: src/Module/Settings/Display.php:405 src/Module/Settings/Display.php:409
+#: src/Module/Settings/Features.php:88
 msgid "Reset order"
 msgstr ""
 
-#: src/Module/Settings/Display.php:341
+#: src/Module/Settings/Display.php:415
 msgid "Display theme"
 msgstr ""
 
-#: src/Module/Settings/Display.php:342
+#: src/Module/Settings/Display.php:416
 msgid "Mobile theme"
 msgstr ""
 
-#: src/Module/Settings/Display.php:345
+#: src/Module/Settings/Display.php:419
 msgid "Number of items to display per page:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:345 src/Module/Settings/Display.php:346
+#: src/Module/Settings/Display.php:419 src/Module/Settings/Display.php:420
 msgid "Maximum of 100 items"
 msgstr ""
 
-#: src/Module/Settings/Display.php:346
+#: src/Module/Settings/Display.php:420
 msgid "Number of items to display per page when viewed from mobile device:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:347
+#: src/Module/Settings/Display.php:421
 msgid "Regularly update the page content"
 msgstr ""
 
-#: src/Module/Settings/Display.php:347
+#: src/Module/Settings/Display.php:421
 msgid "When enabled, new content on network, community and channels are added on top."
 msgstr ""
 
-#: src/Module/Settings/Display.php:348
+#: src/Module/Settings/Display.php:422
 msgid "Display emoticons"
 msgstr ""
 
-#: src/Module/Settings/Display.php:348
+#: src/Module/Settings/Display.php:422
 msgid "When enabled, emoticons are replaced with matching symbols."
 msgstr ""
 
-#: src/Module/Settings/Display.php:349
+#: src/Module/Settings/Display.php:423
 msgid "Infinite scroll"
 msgstr ""
 
-#: src/Module/Settings/Display.php:349
+#: src/Module/Settings/Display.php:423
 msgid "Automatic fetch new items when reaching the page end."
 msgstr ""
 
-#: src/Module/Settings/Display.php:350
+#: src/Module/Settings/Display.php:424
 msgid "Enable Smart Threading"
 msgstr ""
 
-#: src/Module/Settings/Display.php:350
+#: src/Module/Settings/Display.php:424
 msgid "Enable the automatic suppression of extraneous thread indentation."
 msgstr ""
 
-#: src/Module/Settings/Display.php:351
+#: src/Module/Settings/Display.php:425
 msgid "Display the Dislike feature"
 msgstr ""
 
-#: src/Module/Settings/Display.php:351
+#: src/Module/Settings/Display.php:425
 msgid "Display the Dislike button and dislike reactions on posts and comments."
 msgstr ""
 
-#: src/Module/Settings/Display.php:352
+#: src/Module/Settings/Display.php:426
 msgid "Display the resharer"
 msgstr ""
 
-#: src/Module/Settings/Display.php:352
+#: src/Module/Settings/Display.php:426
 msgid "Display the first resharer as icon and text on a reshared item."
 msgstr ""
 
-#: src/Module/Settings/Display.php:353
+#: src/Module/Settings/Display.php:427
 msgid "Stay local"
 msgstr ""
 
-#: src/Module/Settings/Display.php:353
+#: src/Module/Settings/Display.php:427
 msgid "Don't go to a remote system when following a contact link."
 msgstr ""
 
-#: src/Module/Settings/Display.php:354
+#: src/Module/Settings/Display.php:428
 msgid "Show the post deletion checkbox"
 msgstr ""
 
-#: src/Module/Settings/Display.php:354
+#: src/Module/Settings/Display.php:428
 msgid "Display the checkbox for the post deletion on the network page."
 msgstr ""
 
-#: src/Module/Settings/Display.php:355
+#: src/Module/Settings/Display.php:429
 msgid "DIsplay the event list"
 msgstr ""
 
-#: src/Module/Settings/Display.php:355
+#: src/Module/Settings/Display.php:429
 msgid "Display the birthday reminder and event list on the network page."
 msgstr ""
 
-#: src/Module/Settings/Display.php:356
+#: src/Module/Settings/Display.php:430
 msgid "Link preview mode"
 msgstr ""
 
-#: src/Module/Settings/Display.php:356
+#: src/Module/Settings/Display.php:430
 msgid "Appearance of the link preview that is added to each post with a link."
 msgstr ""
 
-#: src/Module/Settings/Display.php:357
+#: src/Module/Settings/Display.php:431
 msgid "Hide pictures with empty alternative text"
 msgstr ""
 
-#: src/Module/Settings/Display.php:357
+#: src/Module/Settings/Display.php:431
 msgid "Don't display pictures that are missing the alternative text."
 msgstr ""
 
-#: src/Module/Settings/Display.php:358
+#: src/Module/Settings/Display.php:432
 msgid "Hide custom emojis"
 msgstr ""
 
-#: src/Module/Settings/Display.php:358
+#: src/Module/Settings/Display.php:432
 msgid "Don't display custom emojis."
 msgstr ""
 
-#: src/Module/Settings/Display.php:359
+#: src/Module/Settings/Display.php:433
 msgid "Platform icons style"
 msgstr ""
 
-#: src/Module/Settings/Display.php:359
+#: src/Module/Settings/Display.php:433
 msgid "Style of the platform icons"
 msgstr ""
 
-#: src/Module/Settings/Display.php:360
+#: src/Module/Settings/Display.php:434
 msgid "Embed remote media"
 msgstr ""
 
-#: src/Module/Settings/Display.php:360
+#: src/Module/Settings/Display.php:434
 msgid "When enabled, remote media will be embedded in the post, like for example YouTube videos."
 msgstr ""
 
-#: src/Module/Settings/Display.php:361
+#: src/Module/Settings/Display.php:435
 msgid "Embed supported media"
 msgstr ""
 
-#: src/Module/Settings/Display.php:361
+#: src/Module/Settings/Display.php:435
 msgid "When enabled, remote media will be embedded in the post instead of using the local player if this is supported by the remote system. This is useful for media where the remote player is better than the local one, like for example Peertube videos."
 msgstr ""
 
-#: src/Module/Settings/Display.php:365
+#: src/Module/Settings/Display.php:439
 msgid "Channels Widget"
 msgstr ""
 
-#: src/Module/Settings/Display.php:366
+#: src/Module/Settings/Display.php:440
 msgid "Top Menu"
 msgstr ""
 
-#: src/Module/Settings/Display.php:368
+#: src/Module/Settings/Display.php:442
 msgid "Enable timelines that you want to see in the channels widget. Bookmark timelines that you want to see in the top menu."
 msgstr ""
 
-#: src/Module/Settings/Display.php:370
+#: src/Module/Settings/Display.php:444
 msgid "Channel languages:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:370
+#: src/Module/Settings/Display.php:444
 msgid "Select all the languages you want to see in your channels. \"Unspecified\" describes all posts for which no language information was detected (e.g. posts with just an image or too little text to be sure of the language). If you want to see all languages, you will need to select all items in the list."
 msgstr ""
 
-#: src/Module/Settings/Display.php:372
+#: src/Module/Settings/Display.php:446
 msgid "Beginning of week:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:373
+#: src/Module/Settings/Display.php:447
 msgid "Default calendar view:"
 msgstr ""
 
-#: src/Module/Settings/Features.php:80
+#: src/Module/Settings/Features.php:83
 msgid "Additional Features"
 msgstr ""
 

--- a/view/templates/notifications/notification.tpl
+++ b/view/templates/notifications/notification.tpl
@@ -8,7 +8,6 @@
 <div class="notif-item {{if !$item_seen}}unseen{{/if}}" {{if $item_seen}}aria-hidden="true"{{/if}}>
 	<a href="{{$notification.link}}">
 		<img src="{{$notification.image}}" aria-hidden="true" class="notif-image">
-		<link rel="stylesheet" href="view/global.css">
 		<div>
 			<p class="notif-text">{{$notification.text}}</p>
 			<p class="notif-when"><small data-toggle="tooltip" title="{{$notification.when}}">{{$notification.ago}}</small></p>

--- a/view/templates/settings/display.tpl
+++ b/view/templates/settings/display.tpl
@@ -42,8 +42,7 @@
 			{{include file="field_checkbox.tpl" field=$t.enable}}
 		{{/foreach}}
 		<div class="settings-submit-wrapper">
-			<input type="hidden" name="widget_timeline_reset" value="0"/>
-			<input type="checkbox" id="widget_timeline_reset" name="widget_timeline_reset" value="1"/> <label for="widget_timeline_reset">{{$reset_label}}</label>
+			{{include file="field_checkbox.tpl" field=$reset_widget}}
 		</div>
 	</div>
 	<h3 tabindex="0">{{$timeline_bookmark}}</h3>
@@ -53,8 +52,7 @@
 			{{include file="field_checkbox.tpl" field=$t.bookmark}}
 		{{/foreach}}
 		<div class="settings-submit-wrapper">
-			<input type="hidden" name="menu_timeline_reset" value="0"/>
-			<input type="checkbox" id="menu_timeline_reset" name="menu_timeline_reset" value="1"/> <label for="menu_timeline_reset">{{$reset_label}}</label>
+			{{include file="field_checkbox.tpl" field=$reset_menu}}
 		</div>
 	</div>
 

--- a/view/templates/settings/display.tpl
+++ b/view/templates/settings/display.tpl
@@ -33,28 +33,30 @@
 	{{include file="field_select.tpl" field=$platform_icon_style}}
 	{{include file="field_checkbox.tpl" field=$embed_remote_media}}
 	{{include file="field_checkbox.tpl" field=$embed_media}}
-	<h2>{{$timeline_title}}</h2>
-	{{$timeline_explanation}}
-	<table class="table table-condensed table-striped table-bordered">
-	<thead>
-	<tr>
-		<th>{{$timeline_label}}</th>
-		<th>{{$timeline_descriptiom}}</th>
-		<th>{{$timeline_enable}}</th>
-		<th>{{$timeline_bookmark}}</th>
-	</tr>
-	</thead>
-	<tbody>
-	{{foreach $timelines as $t}}
-		<tr>
-			<td>{{$t.label}}</td>
-			<td>{{$t.description}}</td>
-			<td>{{include file="field_checkbox.tpl" field=$t.enable}}</td>
-			<td>{{include file="field_checkbox.tpl" field=$t.bookmark}}</td>
-		</tr>
-	{{/foreach}}
-	</tbody>
-	</table>
+	<h2 tabindex="0">{{$timeline_title}}</h2>
+	<p tabindex="0">{{$timeline_explanation}} {{$sortable}}</p>
+	<h3 tabindex="0">{{$timeline_enable}}</h3>
+	<div class="select timelines-widget sortable">
+		<input type="hidden" id="widget_timelineorder" name="widget_timelineorder" value=""/>
+		{{foreach $timelines as $t}}
+			{{include file="field_checkbox.tpl" field=$t.enable}}
+		{{/foreach}}
+		<div class="settings-submit-wrapper">
+			<input type="hidden" name="widget_timeline_reset" value="0"/>
+			<input type="checkbox" id="widget_timeline_reset" name="widget_timeline_reset" value="1"/> <label for="widget_timeline_reset">{{$reset_label}}</label>
+		</div>
+	</div>
+	<h3 tabindex="0">{{$timeline_bookmark}}</h3>
+	<div class="select timelines-menu sortable">
+		<input type="hidden" id="menu_timelineorder" name="menu_timelineorder" value=""/>
+		{{foreach $timelines as $t}}
+			{{include file="field_checkbox.tpl" field=$t.bookmark}}
+		{{/foreach}}
+		<div class="settings-submit-wrapper">
+			<input type="hidden" name="menu_timeline_reset" value="0"/>
+			<input type="checkbox" id="menu_timeline_reset" name="menu_timeline_reset" value="1"/> <label for="menu_timeline_reset">{{$reset_label}}</label>
+		</div>
+	</div>
 
 	<h2>{{$channel_title}}</h2>
 	{{include file="field_select.tpl" field=$channel_languages}}

--- a/view/templates/settings/features.tpl
+++ b/view/templates/settings/features.tpl
@@ -9,14 +9,21 @@
 <form action="settings/features" method="post" autocomplete="off">
 	<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
 
-	{{foreach $features as $f}}
+	{{foreach $features as $key => $f}}
 		<h2 class="settings-heading"><a href="javascript:;">{{$f.0}}</a></h2>
-		<div class="settings-content-block">
-
+		<div class="settings-content-block {{if $key=="network"}}network sortable{{/if}}">
+			{{if $key == "network"}}
+			<input type="hidden" id="feature_widgetorder" name="feature_widgetorder" value=""/>
+			<p tabindex="0">{{$sortable}}</p>
+			{{/if}}
 			{{foreach $f.1 as $fcat}}
 				{{include file="field_checkbox.tpl" field=$fcat}}
 			{{/foreach}}
 			<div class="settings-submit-wrapper">
+				{{if $key == "network"}}
+				<input type="hidden" name="feature_resetorder" value="0"/>
+				<input type="checkbox" id="feature_resetorder" name="feature_resetorder" value="1"/> <label for="feature_resetorder">{{$reset_label}}</label>
+				{{/if}}
 				<input type="submit" name="submit" class="settings-features-submit" value="{{$submit}}"/>
 			</div>
 		</div>

--- a/view/templates/settings/features.tpl
+++ b/view/templates/settings/features.tpl
@@ -12,7 +12,7 @@
 	{{foreach $features as $key => $f}}
 		<h2 class="settings-heading"><a href="javascript:;">{{$f.0}}</a></h2>
 		<div class="settings-content-block {{if $key=="network"}}network sortable{{/if}}">
-			{{if $key == "network"}}
+			{{if $key == $sort_key}}
 			<input type="hidden" id="feature_widgetorder" name="feature_widgetorder" value=""/>
 			<p tabindex="0">{{$sortable}}</p>
 			{{/if}}
@@ -20,9 +20,8 @@
 				{{include file="field_checkbox.tpl" field=$fcat}}
 			{{/foreach}}
 			<div class="settings-submit-wrapper">
-				{{if $key == "network"}}
-				<input type="hidden" name="feature_resetorder" value="0"/>
-				<input type="checkbox" id="feature_resetorder" name="feature_resetorder" value="1"/> <label for="feature_resetorder">{{$reset_label}}</label>
+				{{if $key == $sort_key}}
+					{{include file="field_checkbox.tpl" field=$reset}}
 				{{/if}}
 				<input type="submit" name="submit" class="settings-features-submit" value="{{$submit}}"/>
 			</div>

--- a/view/templates/settings/head.tpl
+++ b/view/templates/settings/head.tpl
@@ -150,22 +150,22 @@
 	border: 1px dashed black;
 	list-style: none;
 }
-.sortable .field {
+.sortable > .field {
 	position: relative;
 	border: 1px solid #eee;
 	padding: 10px 30px 10px 30px;
 	margin: 0;
 	box-sizing: border-box;
 }
-	.sortable .field:first-of-type {
+	.sortable > .field:first-of-type {
 		border-top-left-radius: 8px;
 		border-top-right-radius: 8px;
 	}
-	.sortable .field:nth-last-of-type(2) {
+	.sortable > .field:nth-last-of-type(2) {
 		border-bottom-left-radius: 8px;
 		border-bottom-right-radius: 8px;
 	}
-	.sortable .field::after {
+	.sortable > .field::after {
 		content: '\2B0D';	/* unicode double-arrow */
 		position: absolute;
 		font-size: 18px;
@@ -173,10 +173,10 @@
 		top: 40%;
 		opacity: .2;
 	}
-	.sortable .field:hover::after,
-	.sortable .field:focus::after,
-	.sortable .field:active::after,
-	.sortable .field:focus-within::after {
+	.sortable > .field:hover::after,
+	.sortable > .field:focus::after,
+	.sortable > .field:active::after,
+	.sortable > .field:focus-within::after {
 		opacity: 1;
 	}
 	.dragged {

--- a/view/templates/settings/head.tpl
+++ b/view/templates/settings/head.tpl
@@ -161,7 +161,7 @@
 		border-top-left-radius: 8px;
 		border-top-right-radius: 8px;
 	}
-	.sortable .field:last-of-type {
+	.sortable .field:nth-last-of-type(2) {
 		border-bottom-left-radius: 8px;
 		border-bottom-right-radius: 8px;
 	}

--- a/view/templates/settings/head.tpl
+++ b/view/templates/settings/head.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 
-
+<script type="text/javascript" src="view/asset/es-jquery-sortable/source/js/jquery-sortable.js"></script>
 <script>
 	var ispublic = "{{$ispublic nofilter}}";
 
@@ -31,8 +31,227 @@
 			$('.settings-content-block').hide();
 			$(this).next('.settings-content-block').toggle();
 		});
-
+		$( function() {
+			var $container; // or onDrop loses reference
+			$(".sortable").sortable({
+				connectWith : ".sortable",
+				containerSelector: "div",
+				containerPath : ".sortable > .field",
+				itemSelector : ".field",
+				placeholder : '<div class="placeholder"></div>',
+				nested: false, 
+    			onDragStart: function ($item, container, _super, event) {
+      				$item.css({
+        				height: $item.outerHeight(),
+       				 	width: $item.outerWidth()
+      				});
+      				$item.addClass(container.group.options.draggedClass);
+      				$("body").addClass(container.group.options.bodyClass);
+      				$container = container;
+    			},
+				onDrop : function($item, container, _super, event){
+					if(!container){ container = $container;};
+      				$item.removeClass(container.group.options.draggedClass).removeAttr("style");
+      				$("body").removeClass(container.group.options.bodyClass);
+      				console.log(container);
+      			},
+      			afterMove : function($placeholder, container, $closestItemOrContainer){
+      				// need a delay so drag-n-drop is done before we re-index
+      				setTimeout(function(){
+      					if ($(".network").length > 0){
+      						indexList('#feature_widgetorder','.network','.field');
+      					}
+      					if ($(".timelines-widget").length > 0){
+      						indexList('#widget_timelineorder','.timelines-widget','.field');
+      					}
+      					if ($(".timelines-menu").length > 0){
+      						indexList('#menu_timelineorder','.timelines-menu','.field');
+      					} 
+      				},1000);
+      			}					
+			});
+		});
+		// make widget indexing generic
+		function indexList(input,widgets,children){
+			var items = $(widgets).children(children);
+			var order = [];
+			for(let i=0; i < items.length; i++){
+				$(items[i]).attr('data-order',i);
+				$(items[i]).attr('tabindex',0);
+				order.push(items[i].id.replace('div_id_feature_','').replace('div_id_enable[','').replace('div_id_bookmark[','').replace(']',''));
+			}
+			$(input).val(JSON.stringify(order));
+		}
+		// initial order index
+		indexList('#feature_widgetorder','.network','.field');
+		indexList('#widget_timelineorder','.timelines-widget','.field');
+		indexList('#menu_timelineorder','.timelines-menu','.field');
+		// accessible sorting with keyboard gives feedback to screenreaders
+		$('.network .field, .timelines-widget .field, .timelines-menu .field').bind('keydown', function(event){
+			let total = $('.network .field').length;
+			console.log('total = '+total);
+			// get the currently selected item index
+			let index = parseInt($(this).attr('data-order'));
+			let before = parseInt(index-1);
+			let after  = parseInt(index+1);
+			if(event.which == 38){ // up arrow
+				console.log('up arrow');
+				if (index != 0){
+					console.log('insert before '+before);
+					$(this).attr('title','Moved up one space, position '+index+' in list');
+					$(this).insertBefore( $('[data-order="'+before+'"]') );
+					setTimeout(function(that){
+      					if ($(".network").length > 0){
+      						indexList('#feature_widgetorder','.network','.field');
+      					}
+      					if ($(".timelines-widget").length > 0){
+      						indexList('#widget_timelineorder','.timelines-widget','.field');
+      					}
+      					if ($(".timelines-menu").length > 0){
+      						indexList('#menu_timelineorder','.timelines-menu','.field');
+      					} 
+						$(that).attr('title','');
+					},1000, $(this));
+				}
+				$(this).focus();
+			}
+			if (event.which == 40){ //down arrow
+				console.log('down arrow');
+				if (index != (total-1)){
+					console.log('insert after'+after);
+					$(this).attr('title','Moved down one space, position '+parseInt(after+1)+' in list');
+					$(this).insertAfter( $('[data-order="'+after+'"]') );
+					setTimeout(function(that){
+      					if ($(".network").length > 0){
+      						indexList('#feature_widgetorder','.network','.field');
+      					}
+      					if ($(".timelines-widget").length > 0){
+      						indexList('#widget_timelineorder','.timelines-widget','.field');
+      					}
+      					if ($(".timelines-menu").length > 0){
+      						indexList('#menu_timelineorder','.timelines-menu','.field');
+      					} 
+						$(that).attr('title','');
+					},1000, $(this));
+				}
+				$(this).focus();
+			}
+		});	
 	});
 
 </script>
 
+<style>
+/* styling for sortable lists */
+.placeholder {
+	height: 60px;
+	width: 100%;
+	background-color: rgba(255,255,255,.3);
+	border: 1px dashed black;
+	list-style: none;
+}
+.sortable .field {
+	position: relative;
+	border: 1px solid #eee;
+	padding: 10px 30px 10px 30px;
+	margin: 0;
+	box-sizing: border-box;
+}
+	.sortable .field:first-of-type {
+		border-top-left-radius: 8px;
+		border-top-right-radius: 8px;
+	}
+	.sortable .field:last-of-type {
+		border-bottom-left-radius: 8px;
+		border-bottom-right-radius: 8px;
+	}
+	.sortable .field::after {
+		content: '\2B0D';	/* unicode double-arrow */
+		position: absolute;
+		font-size: 18px;
+		right: 15px;
+		top: 40%;
+		opacity: .2;
+	}
+	.sortable .field:hover::after,
+	.sortable .field:focus::after,
+	.sortable .field:active::after,
+	.sortable .field:focus-within::after {
+		opacity: 1;
+	}
+	.dragged {
+		position: absolute !important;
+	}
+</style>
+
+<script>
+/*
+ * Content-Type:text/javascript
+ *
+ * A bridge between iPad and iPhone touch events and jquery draggable, 
+ * sortable etc. mouse interactions.
+ * @author Oleg Slobodskoi  
+ * 
+ * modified by John Hardy to use with any touch device
+ * fixed breakage caused by jquery.ui so that mouseHandled internal flag is reset 
+ * before each touchStart event
+ * 
+ */
+(function( $ ) {
+
+    $.support.touch = typeof Touch === 'object';
+
+    if (!$.support.touch) {
+        return;
+    }
+
+    var proto =  $.ui.mouse.prototype,
+    _mouseInit = proto._mouseInit;
+
+    $.extend( proto, {
+        _mouseInit: function() {
+            this.element
+            .bind( "touchstart." + this.widgetName, $.proxy( this, "_touchStart" ) );
+            _mouseInit.apply( this, arguments );
+        },
+
+        _touchStart: function( event ) {
+            if ( event.originalEvent.targetTouches.length != 1 ) {
+                return false;
+            }
+
+            this.element
+            .bind( "touchmove." + this.widgetName, $.proxy( this, "_touchMove" ) )
+            .bind( "touchend." + this.widgetName, $.proxy( this, "_touchEnd" ) );
+
+            this._modifyEvent( event );
+
+            $( document ).trigger($.Event("mouseup")); //reset mouseHandled flag in ui.mouse
+            this._mouseDown( event );
+
+            return false;           
+        },
+
+        _touchMove: function( event ) {
+            this._modifyEvent( event );
+            this._mouseMove( event );   
+        },
+
+        _touchEnd: function( event ) {
+            this.element
+            .unbind( "touchmove." + this.widgetName )
+            .unbind( "touchend." + this.widgetName );
+            this._mouseUp( event ); 
+        },
+
+        _modifyEvent: function( event ) {
+            event.which = 1;
+            var target = event.originalEvent.targetTouches[0];
+            event.pageX = target.clientX;
+            event.pageY = target.clientY;
+        }
+
+    });
+
+})( jQuery );
+</script>

--- a/view/theme/frio/templates/settings/display.tpl
+++ b/view/theme/frio/templates/settings/display.tpl
@@ -94,8 +94,7 @@
 							{{include file="field_checkbox.tpl" field=$t.enable}}
 						{{/foreach}}
 						<div class="panel-footer">
-							<input type="hidden" name="widget_timeline_reset" value="0"/>
-							<input type="checkbox" id="widget_timeline_reset" name="widget_timeline_reset" value="1"/> <label for="widget_timeline_reset">{{$reset_label}}</label>
+							{{include file="field_checkbox.tpl" field=$reset_widget}}
 							<button type="submit" name="submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
 						</div>
 					</div>
@@ -106,8 +105,7 @@
 							{{include file="field_checkbox.tpl" field=$t.bookmark}}
 						{{/foreach}}						
 					<div class="panel-footer">
-						<input type="hidden" name="menu_timeline_reset" value="0"/>
-						<input type="checkbox" id="menu_timeline_reset" name="menu_timeline_reset" value="1"/> <label for="menu_timeline_reset">{{$reset_label}}</label>
+						{{include file="field_checkbox.tpl" field=$reset_menu}}
 						<button type="submit" name="submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
 					</div>
 				</div>

--- a/view/theme/frio/templates/settings/display.tpl
+++ b/view/theme/frio/templates/settings/display.tpl
@@ -86,30 +86,28 @@
 					</h2>
 				</div>
 				<div id="timeline-settings-content" class="panel-collapse collapse{{if !$theme && !$mobile_theme && !$theme_config}} in{{/if}}" role="tabpanel" aria-labelledby="timeline-settings">
-					<div class="panel-body">
-						{{$timeline_explanation}}
-						<table class="table table-condensed table-striped table-bordered">
-						<thead>
-						<tr>
-							<th>{{$timeline_label}}</th>
-							<th>{{$timeline_descriptiom}}</th>
-							<th>{{$timeline_enable}}</th>
-							<th>{{$timeline_bookmark}}</th>
-						</tr>
-						</thead>
-						<tbody>
+						<p tabindex="0">{{$timeline_explanation}} {{$sortable}}</p>
+						<h3 tabindex="0">{{$timeline_enable}}</h3>
+					<div class="panel-body timelines-widget sortable">
+						<input type="hidden" id="widget_timelineorder" name="widget_timelineorder" value=""/>
 						{{foreach $timelines as $t}}
-							<tr>
-								<td>{{$t.label}}</td>
-								<td>{{$t.description}}</td>
-								<td>{{include file="field_checkbox.tpl" field=$t.enable}}</td>
-								<td>{{include file="field_checkbox.tpl" field=$t.bookmark}}</td>
-							</tr>
+							{{include file="field_checkbox.tpl" field=$t.enable}}
 						{{/foreach}}
-						</tbody>
-						</table>
+						<div class="panel-footer">
+							<input type="hidden" name="widget_timeline_reset" value="0"/>
+							<input type="checkbox" id="widget_timeline_reset" name="widget_timeline_reset" value="1"/> <label for="widget_timeline_reset">{{$reset_label}}</label>
+							<button type="submit" name="submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
+						</div>
 					</div>
+						<h3 tabindex="0">{{$timeline_bookmark}}</h3>
+						<input type="hidden" id="menu_timelineorder" name="menu_timelineorder" value=""/>
+					<div class="panel-body timelines-menu sortable">
+						{{foreach $timelines as $t}}
+							{{include file="field_checkbox.tpl" field=$t.bookmark}}
+						{{/foreach}}						
 					<div class="panel-footer">
+						<input type="hidden" name="menu_timeline_reset" value="0"/>
+						<input type="checkbox" id="menu_timeline_reset" name="menu_timeline_reset" value="1"/> <label for="menu_timeline_reset">{{$reset_label}}</label>
 						<button type="submit" name="submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
 					</div>
 				</div>

--- a/view/theme/frio/templates/settings/features.tpl
+++ b/view/theme/frio/templates/settings/features.tpl
@@ -28,6 +28,7 @@
 						{{foreach $f.1 as $fcat}}
 							{{include file="field_checkbox.tpl" field=$fcat}}
 						{{/foreach}}
+						<div class="clear"></div>
 					</div>
 					<div class="panel-footer">
 						{{if $g == "network"}}

--- a/view/theme/frio/templates/settings/features.tpl
+++ b/view/theme/frio/templates/settings/features.tpl
@@ -21,7 +21,7 @@
 				</div>
 				<div id="{{$g}}-settings-content" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{$g}}-settings-title">
 					<div class="panel-body {{if $g == "network"}}network sortable{{/if}}">
-						{{if $g == "network"}}
+						{{if $g == $sort_key}}
 						<input type="hidden" id="feature_widgetorder" name="feature_widgetorder" value=""/>
 						<p tabindex="0">{{$sortable}}</p>
 						{{/if}}
@@ -31,9 +31,8 @@
 						<div class="clear"></div>
 					</div>
 					<div class="panel-footer">
-						{{if $g == "network"}}
-						<input type="hidden" name="feature_resetorder" value="0"/>
-						<input type="checkbox" id="feature_resetorder" name="feature_resetorder" value="1"/> <label for="feature_resetorder">{{$reset_label}}</label>
+						{{if $g == $sort_key}}
+							{{include file="field_checkbox.tpl" field=$reset}}
 						{{/if}}
 						<button type="submit" name="submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
 					</div>

--- a/view/theme/frio/templates/settings/features.tpl
+++ b/view/theme/frio/templates/settings/features.tpl
@@ -20,12 +20,20 @@
 					</h2>
 				</div>
 				<div id="{{$g}}-settings-content" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{$g}}-settings-title">
-					<div class="panel-body">
+					<div class="panel-body {{if $g == "network"}}network sortable{{/if}}">
+						{{if $g == "network"}}
+						<input type="hidden" id="feature_widgetorder" name="feature_widgetorder" value=""/>
+						<p tabindex="0">{{$sortable}}</p>
+						{{/if}}
 						{{foreach $f.1 as $fcat}}
 							{{include file="field_checkbox.tpl" field=$fcat}}
 						{{/foreach}}
 					</div>
 					<div class="panel-footer">
+						{{if $g == "network"}}
+						<input type="hidden" name="feature_resetorder" value="0"/>
+						<input type="checkbox" id="feature_resetorder" name="feature_resetorder" value="1"/> <label for="feature_resetorder">{{$reset_label}}</label>
+						{{/if}}
 						<button type="submit" name="submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
 					</div>
 				</div>


### PR DESCRIPTION
The changes in this PR are related to the discussion in this thread: [https://forum.friendi.ca/display/373ebf56-7868-f87a-02b8-4aa456938304](https://forum.friendi.ca/display/373ebf56-7868-f87a-02b8-4aa456938304)

I'm leveraging the the jQuery Sortable plugin that is _already_ present in Friendica, though I have no idea if or where it is normally loaded or used at: _/view/asset/es-jquery-sortable/source/js/jquery-sortable-min.js_

This turns the list under **Settings > Additional Features > Network Widgets**  into a drag-n-drop sortable list to change the order in which they appear in the sidebar on the Network page.

The same method is also applied to the list under **Settings > Display > Timelines** which is changed from a table to two sortable lists, one for the order they appear in the "Channels" sidebar widget and another for the "Top Menu" on the Network page.

They can also be sorted via keyboard control by tabbing into the list and using the up/down arrows to move the item in the list. For screen readers there is also feedback about the action and position.

Drag-and-Drop does not work very well on touch devices, of course. When you try to drag on a phone or tablet it thinks you want to scroll. I included a compatibility script that at least makes it work on touch devices, though it's still a terrible experience and I wouldn't recommend sorting the lists that way. But that's a touchscreen limitation.

Here is a gif of a screen recording of it in action:

![Screen Recording 2025-10-28 at 9 29 43 PM](https://github.com/user-attachments/assets/e0f79db0-b18c-44b1-b547-0bd809f95e8e)

