### PR TITLE
Hide HLS video if it can't be loaded

### DIFF
--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -173,6 +173,22 @@ class Media
 			'" type="' . $media['mimetype'] . '" title="' . $media['description'] . '"[/attach]';
 	}
 
+	private static function setModified(array $media, string $lastModified): array
+	{
+		if (isset($media['modified']) && $media['modified'] != '') {
+			return $media;
+		}
+
+		if ($lastModified == '') {
+			return $media;
+		}
+
+		$media['modified']  = DateTimeFormat::utc($lastModified);
+		$media['published'] = $media['published'] ?? $media['modified'];
+
+		return $media;
+	}
+
 	/**
 	 * Fetch additional data for the provided media array
 	 *
@@ -204,7 +220,7 @@ class Media
 
 				// Workaround for systems that can't handle a HEAD request
 				if (!$curlResult->isSuccess() && in_array($curlResult->getReturnCode(), [400, 403, 405])) {
-					$curlResult = DI::httpClient()->get($media['url'], HttpClientAccept::AS_DEFAULT, [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::HEADERS => ['Range' => 'bytes=0-100000']]);
+					$curlResult = DI::httpClient()->get($media['url'], HttpClientAccept::AS_DEFAULT, [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::HEADERS => ['Range' => 'bytes=0-100000'], HttpClientOptions::REQUEST => HttpClientRequest::CONTENTTYPE]);
 					$is_head    = false;
 				}
 				if ($curlResult->isSuccess()) {
@@ -214,12 +230,7 @@ class Media
 					if (empty($media['size']) && $is_head) {
 						$media['size'] = (int)($curlResult->getHeader('Content-Length')[0] ?? strlen($curlResult->getBodyString() ?? ''));
 					}
-					if (empty($media['modified']) && !empty($curlResult->getHeader('Last-Modified')[0])) {
-						$media['modified'] = DateTimeFormat::utc($curlResult->getHeader('Last-Modified')[0]);
-						if (empty($media['published'])) {
-							$media['published'] = $media['modified'];
-						}
-					}
+					$media = self::setModified($media, $curlResult->getHeader('Last-Modified')[0] ?? '');
 				} else {
 					DI::logger()->notice('Could not fetch head', ['media' => $media, 'code' => $curlResult->getReturnCode()]);
 				}
@@ -258,6 +269,10 @@ class Media
 		if ($media['type'] === self::VIDEO) {
 			$media = self::getVideoInformationByFFMPEG($media);
 			$media = self::getVideoDimensionsByID3($media);
+		}
+
+		if ($media['type'] === self::HLS) {
+			$media = self::getHLSVideoDimensions($media);
 		}
 
 		if (in_array($media['type'], [self::TEXT, self::ACTIVITY, self::LD, self::JSON, self::HTML, self::XML, self::PLAIN])) {
@@ -509,11 +524,6 @@ class Media
 			return;
 		}
 
-		if (($element['mimetype'] ?? '') === 'application/x-mpegURL') {
-			// Until we can detect live streaming, we don't store HLS streams
-			return;
-		}
-
 		$media                = ['uri-id' => $uri_id];
 		$media['type']        = Post\Media::UNKNOWN;
 		$media['url']         = $element['src'];
@@ -602,9 +612,11 @@ class Media
 
 		if ($filetype == 'image') {
 			$type = self::IMAGE;
+		} elseif (($filetype == 'video') && in_array($subtype, ['x-mpegurl', 'mpegurl'])) {
+			$type = self::HLS;
 		} elseif ($filetype == 'video') {
 			$type = self::VIDEO;
-		} elseif (($filetype == 'audio') && ($subtype == 'x-mpegurl')) {
+		} elseif (($filetype == 'audio') && in_array($subtype, ['x-mpegurl', 'mpegurl'])) {
 			$type = self::HLS;
 		} elseif ($filetype == 'audio') {
 			$type = self::AUDIO;
@@ -618,7 +630,7 @@ class Media
 			$type = self::TEXT;
 		} elseif (($filetype == 'application') && ($subtype == 'x-bittorrent')) {
 			$type = self::TORRENT;
-		} elseif (($filetype == 'application') && in_array($subtype, ['vnd.apple.mpegurl', 'x-mpegurl'])) {
+		} elseif (($filetype == 'application') && in_array($subtype, ['vnd.apple.mpegurl', 'x-mpegurl', 'mpegurl'])) {
 			$type = self::HLS;
 		} elseif (($filetype == 'application') && ($subtype == 'activity+json')) {
 			$type = self::ACTIVITY;
@@ -711,19 +723,14 @@ class Media
 		DI::logger()->debug('Fetch video dimensions', ['uri-id' => $media['uri-id'], 'url' => $media['url']]);
 		$timestamp  = microtime(true);
 		$timeout    = DI::config()->get('system', 'xrd_timeout');
-		$options    = [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::HEADERS => ['Range' => 'bytes=0-100000']];
-		$curlResult = DI::httpClient()->get($media['url'], HttpClientAccept::AS_DEFAULT, $options);
+		$options    = [HttpClientOptions::TIMEOUT => $timeout, HttpClientOptions::HEADERS => ['Range' => 'bytes=0-1000000'], HttpClientOptions::REQUEST => HttpClientRequest::MEDIAVERIFIER];
+		$curlResult = DI::httpClient()->get($media['url'], HttpClientAccept::VIDEO, $options);
 		if (!$curlResult->isSuccess()) {
 			DI::logger()->notice('Could not fetch video', ['uri-id' => $media['uri-id'], 'url' => $media['url'], 'code' => $curlResult->getReturnCode()]);
 			return $media;
 		}
 
-		if ((!isset($media['modified']) || !$media['modified']) && isset($curlResult->getHeader('Last-Modified')[0]) && $curlResult->getHeader('Last-Modified')[0] != '') {
-			$media['modified'] = DateTimeFormat::utc($curlResult->getHeader('Last-Modified')[0]);
-			if (!isset($media['published']) || !$media['published']) {
-				$media['published'] = $media['modified'];
-			}
-		}
+		$media = self::setModified($media, $curlResult->getHeader('Last-Modified')[0] ?? '');
 
 		$video = $curlResult->getBodyString() ?? '';
 		if (!$video) {
@@ -751,6 +758,52 @@ class Media
 		} else {
 			DI::logger()->info('No video dimensions found', ['runtime' => $runtime, 'uri-id' => $media['uri-id'], 'url' => $media['url'], 'info' => $info]);
 		}
+		return $media;
+	}
+
+	/**
+	 * Fetch HLS video dimensions from the playlist
+	 *
+	 * @param array $media Media array
+	 * @return array media with added dimensions
+	 */
+	private static function getHLSVideoDimensions(array $media): array
+	{
+		if (isset($media['width']) && isset($media['height']) && is_numeric($media['width']) && is_numeric($media['height'])) {
+			return $media;
+		}
+
+		$resolutions = [];
+
+		$curlResult = DI::httpClient()->get($media['url'], HttpClientAccept::HLS, [HttpClientOptions::REQUEST => HttpClientRequest::MEDIAVERIFIER]);
+		if (!$curlResult->isSuccess()) {
+			DI::logger()->notice('Could not fetch video', ['uri-id' => $media['uri-id'], 'url' => $media['url'], 'code' => $curlResult->getReturnCode()]);
+			return $media;
+		}
+
+		$media = self::setModified($media, $curlResult->getHeader('Last-Modified')[0] ?? '');
+
+		foreach (explode("\n", $curlResult->getBodyString() ?? '') as $line) {
+			if (strpos(trim($line), '#EXT-X-STREAM-INF') === 0) {
+				if (preg_match('/RESOLUTION=([\d]+)x([\d]+)/', $line, $matches)) {
+					$resolutions[$matches[1]] = [(int)$matches[1], (int)$matches[2]];
+				}
+			}
+		}
+
+		if (!$resolutions) {
+			DI::logger()->debug('No resolutions found', ['uri-id' => $media['uri-id'], 'url' => $media['url']]);
+			return $media;
+		}
+
+		krsort($resolutions);
+		$resolution = current($resolutions);
+
+		$media['width']  = $resolution[0];
+		$media['height'] = $resolution[1];
+
+		DI::logger()->debug('Detected HLS resolutions', ['uri-id' => $media['uri-id'], 'url' => $media['url'], 'resolution' => $resolution]);
+
 		return $media;
 	}
 

--- a/src/Network/HTTPClient/Client/HttpClientAccept.php
+++ b/src/Network/HTTPClient/Client/HttpClientAccept.php
@@ -32,4 +32,5 @@ class HttpClientAccept
 	public const VIDEO     = 'video/mp4,video/*;q=0.9,*/*;q=0.8';
 	public const XRD_XML   = 'application/xrd+xml,text/xml;q=0.9,*/*;q=0.8';
 	public const XML       = 'application/xml,text/xml;q=0.9,*/*;q=0.8';
+	public const HLS       = 'application/vnd.apple.mpegurl,application/x-mpegURL;q=0.9,*/*;q=0.8';
 }

--- a/src/Protocol/ActivityPub/Receiver.php
+++ b/src/Protocol/ActivityPub/Receiver.php
@@ -1895,13 +1895,14 @@ class Receiver
 			}
 
 			$filetype = strtolower(substr($mediatype, 0, strpos($mediatype, '/')));
+			$type     = Post\Media::getType($mediatype);
 
 			$height = JsonLD::fetchElement($url, 'as:height', '@value');
 			$width  = JsonLD::fetchElement($url, 'as:width', '@value');
 
-			if ($filetype == 'audio') {
+			if ($type == Post\Media::AUDIO) {
 				$attachments[] = ['type' => $filetype, 'mediaType' => $mediatype, 'url' => $href, 'height' => $height, 'width' => $width, 'size' => null, 'name' => '', 'image' => $icon];
-			} elseif ($filetype == 'video') {
+			} elseif ($type == Post\Media::VIDEO) {
 				// PeerTube audio-only track
 				if (!$height) {
 					continue;
@@ -1910,14 +1911,14 @@ class Receiver
 				$size = (int)JsonLD::fetchElement($url, 'pt:size', '@value');
 
 				$attachments[] = ['type' => $filetype, 'mediaType' => $mediatype, 'url' => $href, 'height' => $height, 'width' => $width, 'size' => $size, 'name' => '', 'image' => $icon];
-			} elseif (in_array($mediatype, ['application/x-bittorrent', 'application/x-bittorrent;x-scheme-handler/magnet'])) {
+			} elseif ($type == Post\Media::TORRENT) {
 				// For Torrent links we always store the highest resolution
 				if (!empty($attachments[$mediatype]['height']) && ($height < $attachments[$mediatype]['height'])) {
 					continue;
 				}
 
 				$attachments[$mediatype] = ['type' => $mediatype, 'mediaType' => $mediatype, 'url' => $href, 'height' => $height, 'width' => $width, 'size' => null, 'name' => ''];
-			} elseif ($mediatype == 'application/x-mpegURL') {
+			} elseif ($type == Post\Media::HLS) {
 				$attachment = ['type' => $filetype, 'mediaType' => $mediatype, 'url' => $href, 'height' => $height, 'width' => $width, 'size' => null, 'name' => '', 'image' => $icon];
 				if (is_array($player)) {
 					$attachment['player-url']    = $player['embed']  ?? null;

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -1289,7 +1289,7 @@ class ParseUrl
 
 		$content = JsonLD::fetchElement($jsonld, 'uploadDate');
 		if (!empty($content) && is_string($content)) {
-			$media['uploaded'] = trim($content);
+			$media['uploaded'] = DateTimeFormat::utc($content);
 		}
 
 		$content = JsonLD::fetchElement($jsonld, 'image');

--- a/view/templates/content/embed-iframe-resize.tpl
+++ b/view/templates/content/embed-iframe-resize.tpl
@@ -6,20 +6,16 @@
   *}}
 <span class="embedded-media">
   <iframe class="embed" id="{{$id}}" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;style&gt;html,body{margin:0;padding:0;height:100%;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;{{$src}}&lt;script&gt;
-  function sendResize() {
-      parent.postMessage({type:'resize',height:document.body.scrollHeight},'*');
-  }
   window.onload = function() {
-      sendResize();
-      setTimeout(sendResize, 2000);
+      parent.postMessage({type:'resize-{{$id}}',height:document.body.scrollHeight},'*');
+      setTimeout(function() {parent.postMessage({type:'resize-{{$id}}',height:document.body.scrollHeight},'*');}, 2000);
   };
   &lt;/script&gt;&lt;/body&gt;&lt;/html&gt;" width="{{$width}}" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts"></iframe>
   <script>
     window.addEventListener('message', function(event) {
-      if (event.data && event.data.type === 'resize') {
-        var iframe = document.getElementById('{{$id}}');
-        if (iframe) {
-          iframe.style.height = event.data.height + 'px';
+      if (event.data && event.data.type === 'resize-{{$id}}') {
+        if (document.getElementById('{{$id}}')) {
+          document.getElementById('{{$id}}').style.height = event.data.height + 'px';
         }
       }
     });

--- a/view/templates/content/hls.tpl
+++ b/view/templates/content/hls.tpl
@@ -16,8 +16,19 @@
 			var hls = new Hls();
 			hls.loadSource(videoSrc);
 			hls.attachMedia(video);
-		} else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+			hls.on(Hls.Events.ERROR, function (event, data) {
+				var errorType = data.type;
+				var errorDetails = data.details;
+				var errorFatal = data.fatal;
+				console.error('HLS.js error:', errorType, errorDetails, 'Fatal:', errorFatal);
+				if (errorFatal) {
+					document.getElementById('video-top-wrapper-{{$video.id}}').style.display = 'none';
+				}
+			});
+		} else if (video.canPlayType('{{$video.mime}}')) {
 			video.src = videoSrc;
+		} else {
+			document.getElementById('video-top-wrapper-{{$video.id}}').style.display = 'none';
 		}
 	</script>
 </div>


### PR DESCRIPTION
When "add_page_media" is activated, the system will add audio or video attachments to posts if they had been detected on the linked page. But there is a problem with some HLS videos because of CORS problems. We now check if the HLS file is reachable and if not, we hide the video.

Also some code is added to ensure that HLS videos always have got dimensions.

This PR also contains an enhancement for the automatic resize of embedded inline frames.