### PR TITLE
More sysmsg notifications -> text on page

### DIFF
--- a/src/Module/BaseSearch.php
+++ b/src/Module/BaseSearch.php
@@ -111,8 +111,10 @@ class BaseSearch extends BaseModule
 	protected static function printResult(ResultList $results, Pager $pager, string $header = ''): string
 	{
 		if ($results->getTotal() == 0) {
-			DI::sysmsg()->addNotice(DI::l10n()->t('No matches'));
-			return '';
+			$o = Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), [
+				'$title' => DI::l10n()->t('No results.')
+			]);
+			return $o;
 		}
 
 		$filtered = 0;

--- a/src/Module/Contact/MatchInterests.php
+++ b/src/Module/Contact/MatchInterests.php
@@ -85,8 +85,11 @@ class MatchInterests extends BaseModule
 		$this->page['aside'] .= Widget::follow();
 
 		if (empty($profile['pub_keywords']) && empty($profile['prv_keywords'])) {
-			$this->systemMessages->addNotice($this->t('No keywords to match. Please add keywords to your profile.'));
-			return '';
+			$o = Renderer::replaceMacros(Renderer::getMarkupTemplate('contact/list.tpl'), [
+				'$title'           => $this->t('Profile Match'),
+				'$additional_text' => $this->t('No keywords to match. Please add keywords to your profile.')
+			]);
+			return $o;
 		}
 
 		if ($this->mode->isMobile()) {
@@ -132,14 +135,16 @@ class MatchInterests extends BaseModule
 			$entries = $this->parseContacts(json_decode($result->getBodyString()), $entries, $limit);
 		}
 
+		$additional_text = '';
 		if (empty($entries)) {
-			$this->systemMessages->addNotice($this->t('No matches'));
+			$additional_text = $this->t('No matches');
 		}
 
 		$tpl = Renderer::getMarkupTemplate('contact/list.tpl');
 		return Renderer::replaceMacros($tpl, [
-			'$title'    => $this->t('Profile Match'),
-			'$contacts' => array_slice($entries, 0, $limit),
+			'$title'           => $this->t('Profile Match'),
+			'$contacts'        => array_slice($entries, 0, $limit),
+			'$additional_text' => $additional_text,
 		]);
 	}
 

--- a/src/Module/Conversation/Community.php
+++ b/src/Module/Conversation/Community.php
@@ -111,7 +111,9 @@ class Community extends Timeline
 		$items = $this->getCommunityItems();
 
 		if (!$this->database->isResult($items)) {
-			$this->systemMessages->addNotice($this->l10n->t('No results.'));
+			$o .= Renderer::replaceMacros(Renderer::getMarkupTemplate('section_title.tpl'), [
+				'$title' => $this->l10n->t('No results.')
+			]);
 			return $o;
 		}
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-08 12:54+0000\n"
+"POT-Creation-Date: 2025-11-12 18:13+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%1$s was tagged in %2$s by %3$s"
 msgstr ""
 
-#: mod/photos.php:538 src/Module/Conversation/Community.php:148
+#: mod/photos.php:538 src/Module/Conversation/Community.php:150
 #: src/Module/Directory.php:34 src/Module/Profile/Photos.php:337
 #: src/Module/Search/Index.php:50
 msgid "Public access denied."
@@ -5756,11 +5756,13 @@ msgstr ""
 msgid "Group Search - %s"
 msgstr ""
 
-#: src/Module/BaseSearch.php:114 src/Module/Contact/MatchInterests.php:136
-msgid "No matches"
+#: src/Module/BaseSearch.php:115 src/Module/Conversation/Channel.php:125
+#: src/Module/Conversation/Community.php:115 src/Module/Search/Index.php:140
+#: src/Module/Search/Index.php:192
+msgid "No results."
 msgstr ""
 
-#: src/Module/BaseSearch.php:140
+#: src/Module/BaseSearch.php:142
 #, php-format
 msgid "%d result was filtered out because your node blocks the domain it is registered on. You can review the list of domains your node is currently blocking in the <a href=\"/friendica\">About page</a>."
 msgid_plural "%d results were filtered out because your node blocks the domain they are registered on. You can review the list of domains your node is currently blocking in the <a href=\"/friendica\">About page</a>."
@@ -6267,7 +6269,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/Module/Contact/Follow.php:56 src/Module/Contact/Redir.php:47
-#: src/Module/Contact/Redir.php:208 src/Module/Conversation/Community.php:154
+#: src/Module/Contact/Redir.php:208 src/Module/Conversation/Community.php:156
 #: src/Module/Debug/ItemBody.php:30 src/Module/Diaspora/Receive.php:45
 #: src/Module/Item/Display.php:82 src/Module/Item/Feed.php:45
 #: src/Module/Item/Follow.php:27 src/Module/Item/Ignore.php:27
@@ -6342,12 +6344,17 @@ msgstr ""
 msgid "Invalid request."
 msgstr ""
 
-#: src/Module/Contact/MatchInterests.php:88
+#: src/Module/Contact/MatchInterests.php:89
+#: src/Module/Contact/MatchInterests.php:145
+msgid "Profile Match"
+msgstr ""
+
+#: src/Module/Contact/MatchInterests.php:90
 msgid "No keywords to match. Please add keywords to your profile."
 msgstr ""
 
-#: src/Module/Contact/MatchInterests.php:141
-msgid "Profile Match"
+#: src/Module/Contact/MatchInterests.php:140
+msgid "No matches"
 msgstr ""
 
 #: src/Module/Contact/Profile.php:157
@@ -6677,12 +6684,6 @@ msgstr ""
 msgid "Unable to unfollow this contact, please contact your administrator"
 msgstr ""
 
-#: src/Module/Conversation/Channel.php:125
-#: src/Module/Conversation/Community.php:114 src/Module/Search/Index.php:140
-#: src/Module/Search/Index.php:192
-msgid "No results."
-msgstr ""
-
 #: src/Module/Conversation/Channel.php:163
 msgid "Channel not available."
 msgstr ""
@@ -6691,11 +6692,11 @@ msgstr ""
 msgid "This community stream shows all public posts received by this node. They may not reflect the opinions of this node’s users."
 msgstr ""
 
-#: src/Module/Conversation/Community.php:168
+#: src/Module/Conversation/Community.php:170
 msgid "Community option not available."
 msgstr ""
 
-#: src/Module/Conversation/Community.php:184
+#: src/Module/Conversation/Community.php:186
 msgid "Not available."
 msgstr ""
 

--- a/view/templates/contact/list.tpl
+++ b/view/templates/contact/list.tpl
@@ -9,6 +9,8 @@
 
 {{$tab_str nofilter}}
 
+{{$additional_text}}
+
 <div id="viewcontact_wrapper-{{$id}}">
 {{foreach $contacts as $contact}}
 	{{include file="contact/entry.tpl"}}

--- a/view/theme/frio/templates/contact/list.tpl
+++ b/view/theme/frio/templates/contact/list.tpl
@@ -11,6 +11,8 @@ at the suggest page and also at many other places *}}
 
 	{{$tab_str nofilter}}
 
+	{{$additional_text}}
+
 	<ul id="viewcontact_wrapper{{if $id}}-{{$id}}{{/if}}" class="viewcontact_wrapper media-list">
 {{foreach $contacts as $contact}}
 		<li>{{include file="contact/entry.tpl"}}</li>


### PR DESCRIPTION
Sort of related: #12295

Replaces more of those in-page notification/popups with text on the page, on:

- BaseSearch (e.g. when searching for users with @abc)
- Similar interests friend suggestion page, when you have no keywords or there are no matches
- Community page when there are no posts

messages.po is updated but no new strings are added.

# Before

Things like this:
<img width="1135" height="199" alt="image" src="https://github.com/user-attachments/assets/389f76a5-52be-45c2-a3ac-9d25a6da223f" />

# After

## Similar interests friend suggestion page

Frio example:
<img width="671" height="261" alt="image" src="https://github.com/user-attachments/assets/e995c260-2ad4-4109-948e-d80a7df2835f" />

Vier example:
<img width="459" height="100" alt="image" src="https://github.com/user-attachments/assets/446a37d0-ec03-43da-a3f2-83628cc62389" />

...when there are no matches:
<img width="677" height="137" alt="image" src="https://github.com/user-attachments/assets/debe4707-0f44-4aa5-a511-4a166d04cfec" />

## BaseSearch

<img width="550" height="205" alt="image" src="https://github.com/user-attachments/assets/57dee644-9e52-4d6b-b355-812a0320364c" />

## Community page

<img width="656" height="514" alt="image" src="https://github.com/user-attachments/assets/af095516-ae74-4046-a0ec-eb827dd795d0" />