### PR TITLE
Notifications: Add link to all (system) notification, UI adjustments (Frio)

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -308,7 +308,7 @@ class Nav
 			// Don't show notifications for public communities
 			if ($this->session->get('page_flags', '') != User::PAGE_FLAGS_COMMUNITY) {
 				$nav['introductions']         = ['notifications/intros', $this->l10n->t('Introductions'), '', $this->l10n->t('Friend Requests')];
-				$nav['notifications']         = ['notifications',	$this->l10n->t('Notifications'), '', $this->l10n->t('Notifications')];
+				$nav['notifications']         = ['notifications', $this->l10n->t('Notifications'), '', $this->l10n->t('Notifications')];
 				$nav['notifications']['all']  = ['notifications/system?show=all', $this->l10n->t('View all'), '', ''];
 				$nav['notifications']['mark'] = ['', $this->l10n->t('Mark as read'), '', $this->l10n->t('Mark all system notifications as seen')];
 			}

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -309,7 +309,7 @@ class Nav
 			if ($this->session->get('page_flags', '') != User::PAGE_FLAGS_COMMUNITY) {
 				$nav['introductions']         = ['notifications/intros', $this->l10n->t('Introductions'), '', $this->l10n->t('Friend Requests')];
 				$nav['notifications']         = ['notifications',	$this->l10n->t('Notifications'), '', $this->l10n->t('Notifications')];
-				$nav['notifications']['all']  = ['notifications/system', $this->l10n->t('See all notifications'), '', ''];
+				$nav['notifications']['all']  = ['notifications/system?show=all', $this->l10n->t('View all'), '', ''];
 				$nav['notifications']['mark'] = ['', $this->l10n->t('Mark as seen'), '', $this->l10n->t('Mark all system notifications as seen')];
 			}
 

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -310,7 +310,7 @@ class Nav
 				$nav['introductions']         = ['notifications/intros', $this->l10n->t('Introductions'), '', $this->l10n->t('Friend Requests')];
 				$nav['notifications']         = ['notifications',	$this->l10n->t('Notifications'), '', $this->l10n->t('Notifications')];
 				$nav['notifications']['all']  = ['notifications/system?show=all', $this->l10n->t('View all'), '', ''];
-				$nav['notifications']['mark'] = ['', $this->l10n->t('Mark as seen'), '', $this->l10n->t('Mark all system notifications as seen')];
+				$nav['notifications']['mark'] = ['', $this->l10n->t('Mark as read'), '', $this->l10n->t('Mark all system notifications as seen')];
 			}
 
 			$nav['messages']           = ['message', $this->l10n->t('Messages'), '', $this->l10n->t('Private mail')];

--- a/src/Module/Settings/Connectors.php
+++ b/src/Module/Settings/Connectors.php
@@ -63,15 +63,15 @@ class Connectors extends BaseSettings
 			$this->pconfig->set($this->session->getLocalUserId(), 'system', 'api_auto_attach', intval($request['api_auto_attach']));
 			$this->pconfig->set($this->session->getLocalUserId(), 'system', 'article_mode', intval($request['article_mode']));
 		} elseif (!empty($request['mail-submit']) && function_exists('imap_open') && !$this->config->get('system', 'imap_disabled')) {
-			$mail_server       =                 $request['mail_server'] ?? '';
-			$mail_port         =                 $request['mail_port'] ?? '';
+			$mail_server       = $request['mail_server'] ?? '';
+			$mail_port         = $request['mail_port']   ?? '';
 			$mail_ssl          = strtolower(trim($request['mail_ssl'] ?? ''));
-			$mail_user         =                 $request['mail_user'] ?? '';
-			$mail_pass         =            trim($request['mail_pass'] ?? '');
-			$mail_action       =            trim($request['mail_action'] ?? '');
-			$mail_movetofolder =            trim($request['mail_movetofolder'] ?? '');
-			$mail_replyto      =                 $request['mail_replyto'] ?? '';
-			$mail_pubmail      =                 $request['mail_pubmail'] ?? '';
+			$mail_user         = $request['mail_user'] ?? '';
+			$mail_pass         = trim($request['mail_pass'] ?? '');
+			$mail_action       = trim($request['mail_action'] ?? '');
+			$mail_movetofolder = trim($request['mail_movetofolder'] ?? '');
+			$mail_replyto      = $request['mail_replyto'] ?? '';
+			$mail_pubmail      = $request['mail_pubmail'] ?? '';
 
 			if (!$this->database->exists('mailacct', ['uid' => $this->session->getLocalUserId()])) {
 				$this->database->insert('mailacct', ['uid' => $this->session->getLocalUserId()]);
@@ -118,14 +118,14 @@ class Connectors extends BaseSettings
 	{
 		parent::content($request);
 
-		$accept_only_sharer      =  intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'accept_only_sharer'));
+		$accept_only_sharer      = intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'accept_only_sharer'));
 		$enable_cw               = !intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'disable_cw'));
 		$enable_smart_shortening = !intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'no_intelligent_shortening'));
-		$simple_shortening       =  intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'simple_shortening'));
-		$attach_link_title       =  intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'attach_link_title'));
-		$api_spoiler_title       =  intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'api_spoiler_title', true));
-		$api_auto_attach         =  intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'api_auto_attach', false));
-		$article_mode            =  intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'article_mode'));
+		$simple_shortening       = intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'simple_shortening'));
+		$attach_link_title       = intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'attach_link_title'));
+		$api_spoiler_title       = intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'api_spoiler_title', true));
+		$api_auto_attach         = intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'api_auto_attach', false));
+		$article_mode            = intval($this->pconfig->get($this->session->getLocalUserId(), 'system', 'article_mode'));
 
 		$connector_settings_forms = [];
 		foreach ($this->database->selectToArray('hook', ['file', 'function'], ['hook' => 'connector_settings']) as $hook) {
@@ -136,10 +136,10 @@ class Connectors extends BaseSettings
 			$connector_settings_forms[$data['connector']] = Renderer::replaceMacros($tpl, [
 				'$connector' => $data['connector'],
 				'$title'     => $data['title'],
-				'$image'     => $data['image'] ?? '',
+				'$image'     => $data['image']   ?? '',
 				'$enabled'   => $data['enabled'] ?? true,
 				'$open'      => ($this->parameters['connector'] ?? '') === $data['connector'],
-				'$html'      => $data['html'] ?? '',
+				'$html'      => $data['html']   ?? '',
 				'$submit'    => $data['submit'] ?? $this->t('Save Settings'),
 			]);
 		}
@@ -161,7 +161,7 @@ class Connectors extends BaseSettings
 			$mail_disabled = $this->t('Email access is disabled on this site.');
 		}
 
-		$mail_server       = $mail_account['server']       ?? '';
+		$mail_server       = $mail_account['server'] ?? '';
 		$mail_port         = (!empty($mail_account['port']) && is_numeric($mail_account['port'])) ? (int)$mail_account['port'] : '';
 		$mail_ssl          = $mail_account['ssltype']      ?? '';
 		$mail_user         = $mail_account['user']         ?? '';
@@ -223,7 +223,7 @@ class Connectors extends BaseSettings
 			'$mail_pass'         => ['mail_pass', $this->t('Email password:'), '', ''],
 			'$mail_replyto'      => ['mail_replyto', $this->t('Reply-to address:'), $mail_replyto, 'Optional'],
 			'$mail_pubmail'      => ['mail_pubmail', $this->t('Send public posts to all email contacts:'), $mail_pubmail, ''],
-			'$mail_action'       => ['mail_action', $this->t('Action after import:'), $mail_action, '', [0 => $this->t('None'), 1 => $this->t('Delete'), 2 => $this->t('Mark as seen'), 3 => $this->t('Move to folder')]],
+			'$mail_action'       => ['mail_action', $this->t('Action after import:'), $mail_action, '', [0 => $this->t('None'), 1 => $this->t('Delete'), 2 => $this->t('Mark as read'), 3 => $this->t('Move to folder')]],
 			'$mail_movetofolder' => ['mail_movetofolder', $this->t('Move to folder:'), $mail_movetofolder, ''],
 			'$submit'            => $this->t('Save Settings'),
 		]);

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-17 20:00+0100\n"
+"POT-Creation-Date: 2025-12-17 20:39+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2175,11 +2175,11 @@ msgid "Notifications"
 msgstr ""
 
 #: src/Content/Nav.php:312
-msgid "See all notifications"
+msgid "View all"
 msgstr ""
 
 #: src/Content/Nav.php:313 src/Module/Settings/Connectors.php:226
-msgid "Mark as seen"
+msgid "Mark as read"
 msgstr ""
 
 #: src/Content/Nav.php:313

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -560,7 +560,7 @@ header #banner #logo-img,
 	padding: 3px 10px;
 	margin-bottom: 10px;
 	font-weight: 300;
-	color: white;
+	color: $font_color_darker;
 }
 #nav-notifications-menu {
 	margin-top: 4px;
@@ -572,7 +572,7 @@ header #banner #logo-img,
 }
 #notifications-header {
 	align-items: center;
-	background: $nav_bg;
+	background: $background_color;
 	display: flex;
 	justify-content: space-between;
 	margin-top: 0;
@@ -580,7 +580,7 @@ header #banner #logo-img,
  }
  #notifications-header a, #notifications-header button
 {
-	color: white !important;
+	color: $link_color!important;
 	font-size: 14px;
 	font-weight: 400;
 	text-decoration: underline;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -571,19 +571,31 @@ header #banner #logo-img,
 	padding: 0;
 }
 #notifications-header {
-	align-items: center;
-	background: $background_color;
-	display: flex;
-	justify-content: space-between;
+	border-bottom: 2px solid $link_color;
 	margin-top: 0;
 	padding: 3px 13px;
  }
- #notifications-header a, #notifications-header button
-{
+#notifications-subheader {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+ }
+ #notifications-title {
+	font-size: 17px;
+	font-weight: 500;
+	margin: 0;
+ }
+ #notifications-header a, #notifications-header button {
 	color: $link_color!important;
 	font-size: 14px;
 	font-weight: 400;
-	text-decoration: underline;
+}
+.media time.notif-when {
+	color: #666666;
+	float: right;
+	line-height: 1.8;
+	padding-left: 25px;
 }
 #topbar-first,
 nav.navbar {
@@ -769,8 +781,9 @@ nav.navbar .nav > li > button:focus {
 }
 
 /* Notification Menu */
-#topbar-first #nav-notifications-menu {
-	max-height: 400px;
+#topbar-first .topbar-nav #nav-notifications-menu {
+	max-height: 600px;
+	width: clamp(200px, 100vw, 350px);
 }
 #topbar-first #nav-notifications-menu a {
 	color: $font_color_darker;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -560,21 +560,30 @@ header #banner #logo-img,
 	padding: 3px 10px;
 	margin-bottom: 10px;
 	font-weight: 300;
-	color: #bebebe;
+	color: white;
 }
-.topbar .dropdown-header .dropdown-header-link {
-	position: absolute;
-	top: 2px;
-	right: 10px;
+#nav-notifications-menu {
+	margin-top: 4px;
+	padding: 0;
 }
-.topbar .dropdown-header .dropdown-header-link a,
-.topbar .dropdown-header .dropdown-header-link .btn-link {
-	color: $link_color !important;
-	font-size: 12px;
+#nav-notifications-mark-all {
+	margin: 0;
+	padding: 0;
+}
+#notifications-header {
+	align-items: center;
+	background: $nav_bg;
+	display: flex;
+	justify-content: space-between;
+	margin-top: 0;
+	padding: 3px 13px;
+ }
+ #notifications-header a, #notifications-header button
+{
+	color: white !important;
+	font-size: 14px;
 	font-weight: 400;
-}
-.topbar .dropdown-header:hover {
-	color: #bebebe;
+	text-decoration: underline;
 }
 #topbar-first,
 nav.navbar {
@@ -2414,7 +2423,6 @@ ul.dropdown-menu li:hover {
 	box-sizing: border-box;
 }
 /* Dropdown Menu */
-.dropdown-menu li .btn-link,
 .dropdown-menu li a,
 .tabs .dropdown-menu li a {
 	padding: 6px 20px;

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -125,14 +125,15 @@
 									<li id="nav-notifications-mark-all" class="dropdown-header">
 										<div class="arrow"></div>
 										<header id="notifications-header">
-											<span style="font-size: 18px;">{{$nav.notifications.1}}</span>
-											<a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a>
-											<div class="dropdown-header-link">
-												<button role="menuitem" type="button" class="btn-link"
-													onclick="notificationMarkAll();" data-toggle="tooltip"
-													aria-label="{{$nav.notifications.mark.3}}"
-													title="{{$nav.notifications.mark.3}}">{{$nav.notifications.mark.1}}</button>
-											</div>
+											<p id="notifications-title">{{$nav.notifications.1}}</p>
+											<header id="notifications-subheader">
+												<a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a>
+												<div class="dropdown-header-link">
+													<button role="menuitem" type="button" class="btn-link"
+														onclick="notificationMarkAll();" data-toggle="tooltip">{{$nav.notifications.mark.1}}
+													</button>
+												</div>
+											</header>
 										</header>
 
 									</li>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -124,13 +124,16 @@
 									{{* the following list entry must have the id "nav-notifications-mark-all". Without it this isn't visible. ....strange behavior :-/ *}}
 									<li id="nav-notifications-mark-all" class="dropdown-header">
 										<div class="arrow"></div>
-										{{$nav.notifications.1}}
-										<div class="dropdown-header-link">
-											<button role="menuitem" type="button" class="btn-link"
-												onclick="notificationMarkAll();" data-toggle="tooltip"
-												aria-label="{{$nav.notifications.mark.3}}"
-												title="{{$nav.notifications.mark.3}}">{{$nav.notifications.mark.1}}</button>
-										</div>
+										<header id="notifications-header">
+											<span style="font-size: 20px;">{{$nav.notifications.1}}</span>
+											<a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a>
+											<div class="dropdown-header-link">
+												<button role="menuitem" type="button" class="btn-link"
+													onclick="notificationMarkAll();" data-toggle="tooltip"
+													aria-label="{{$nav.notifications.mark.3}}"
+													title="{{$nav.notifications.mark.3}}">{{$nav.notifications.mark.1}}</button>
+											</div>
+										</header>
 
 									</li>
 

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -125,7 +125,7 @@
 									<li id="nav-notifications-mark-all" class="dropdown-header">
 										<div class="arrow"></div>
 										<header id="notifications-header">
-											<span style="font-size: 20px;">{{$nav.notifications.1}}</span>
+											<span style="font-size: 18px;">{{$nav.notifications.1}}</span>
 											<a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a>
 											<div class="dropdown-header-link">
 												<button role="menuitem" type="button" class="btn-link"

--- a/view/theme/frio/templates/notifications/nav/notify.tpl
+++ b/view/theme/frio/templates/notifications/nav/notify.tpl
@@ -10,8 +10,10 @@
 			<a href="{{$notify.contact.url}}" class="userinfo click-card" tabIndex="-1"><img data-src="{{$notify.contact.photo}}" alt="" loading="lazy"></a>
 		</div>
 		<a href="{{$notify.href}}" class="notif-desc-wrapper media-body">
-            {{$notify.richtext nofilter}}
-			<div><time class="notif-when time" data-toggle="tooltip" title="{{$notify.localdate}}">{{$notify.ago}}</time></div>
+			<div>
+			{{$notify.richtext nofilter}}
+			<time class="notif-when time" data-toggle="tooltip" title="{{$notify.localdate}}">{{$notify.ago}}</time>
+			<div class="clear"></div>
 		</a>
 	</div>
 </li>


### PR DESCRIPTION
Closes #15300 

This adds a link to view all notifications, also updating the link already used by Vier.

It  **adds a new source string**, so should it target `develop`?
It could be avoided if the text was "See all notifications" but I think it's too long, or by making the Notifications title the link that goes there, but I don't think it's as obvious what it does in this case...?

The UI changes is a suggestion, now a second item was added to that header.
That's mostly why it's "draft", but I'd also want to double check the changes before a merge.

Thoughts? Is the coloured header good/bad?
Alternatively it could have a grey background. Maybe that would be better.

# Before

<img width="543" height="230" alt="image" src="https://github.com/user-attachments/assets/d5c16059-8542-47d9-a99c-95693000ab96" />

# After

## Current version

<img width="536" height="440" alt="image" src="https://github.com/user-attachments/assets/8e793ac5-03fb-4f46-9ea0-3c566e46fdf6" />

## Older versions

<img width="552" height="439" alt="image" src="https://github.com/user-attachments/assets/da3ea7b6-7910-4f93-bafa-6ec512a272fb" />


<img width="566" height="338" alt="image" src="https://github.com/user-attachments/assets/186f3835-0249-490a-b62a-62c6d474467d" />


<img width="542" height="189" alt="image" src="https://github.com/user-attachments/assets/7c1bca83-d064-457e-b623-c80b42932ad5" />


<img width="543" height="230" alt="image" src="https://github.com/user-attachments/assets/13608c16-d9c6-443b-a2ed-ed1e93669b2b" />