### PR TITLE
Settings: Join theme sections + UI polish (frio)

### DIFF
--- a/src/Module/Help.php
+++ b/src/Module/Help.php
@@ -12,6 +12,7 @@ use Friendica\Content\Nav;
 use Friendica\Content\Text\Markdown;
 use Friendica\DI;
 use Friendica\Network\HTTPException;
+use Friendica\Util\Strings;
 
 /**
  * Shows the friendica help based on the /doc/ directory
@@ -40,7 +41,7 @@ class Help extends BaseModule
 
 				$path .= DI::args()->get($x);
 			}
-			$title              = mb_ucfirst(basename($path));
+			$title              = Strings::ucFirst(basename($path));
 			$filename           = $path;
 			$text               = self::loadDocFile($path . '.md', $lang);
 			DI::page()['title'] = DI::l10n()->t('Help:') . ' ' . str_replace('-', ' ', $title);

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -312,10 +312,11 @@ class Display extends BaseSettings
 		return Renderer::replaceMacros($tpl, [
 			'$ptitle'         => $this->t('Display Settings'),
 			'$submit'         => $this->t('Save Settings'),
-			'$d_tset'         => $this->t('General Theme Settings'),
-			'$d_ctset'        => $this->t('Custom Theme Settings'),
 			'$d_cset'         => $this->t('Content Settings'),
 			'$stitle'         => $this->t('Theme settings'),
+			'$themes_title'   => $this->t('Themes'),
+			'$themes_settings_for' => $this->t('Settings for %s', $theme_selected),
+      '$theme_changed_text' => $this->t('Note: If you change the theme, you need to save changes to see the settings for the new theme below!'),
 			'$timeline_title' => $this->t('Timelines'),
 			'$channel_title'  => $this->t('Channels'),
 			'$calendar_title' => $this->t('Calendar'),
@@ -323,8 +324,8 @@ class Display extends BaseSettings
 			'$form_security_token' => self::getFormSecurityToken('settings_display'),
 			'$uid'                 => $uid,
 
-			'$theme'        => ['theme', $this->t('Display Theme:'), $theme_selected, '', $themes, true],
-			'$mobile_theme' => ['mobile_theme', $this->t('Mobile Theme:'), $mobile_theme_selected, '', $mobile_themes, false],
+			'$theme'        => ['theme', $this->t('Display theme'), $theme_selected, '', $themes, true],
+			'$mobile_theme' => ['mobile_theme', $this->t('Mobile theme'), $mobile_theme_selected, '', $mobile_themes, false],
 			'$theme_config' => $theme_config,
 
 			'$itemspage_network'        => ['itemspage_network', $this->t('Number of items to display per page:'), $itemspage_network, $this->t('Maximum of 100 items')],

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -32,6 +32,7 @@ use Friendica\Module\Response;
 use Friendica\Navigation\SystemMessages;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Profiler;
+use Friendica\Util\Strings;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -310,16 +311,16 @@ class Display extends BaseSettings
 
 		$tpl = Renderer::getMarkupTemplate('settings/display.tpl');
 		return Renderer::replaceMacros($tpl, [
-			'$ptitle'         => $this->t('Display Settings'),
-			'$submit'         => $this->t('Save Settings'),
-			'$d_cset'         => $this->t('Content Settings'),
-			'$stitle'         => $this->t('Theme settings'),
-			'$themes_title'   => $this->t('Themes'),
-			'$themes_settings_for' => $this->t('Settings for %s', $theme_selected),
-      '$theme_changed_text' => $this->t('Note: If you change the theme, you need to save changes to see the settings for the new theme below!'),
-			'$timeline_title' => $this->t('Timelines'),
-			'$channel_title'  => $this->t('Channels'),
-			'$calendar_title' => $this->t('Calendar'),
+			'$ptitle'              => $this->t('Display Settings'),
+			'$submit'              => $this->t('Save Settings'),
+			'$d_cset'              => $this->t('Content Settings'),
+			'$stitle'              => $this->t('Theme settings'),
+			'$themes_title'        => $this->t('Themes'),
+			'$themes_settings_for' => $this->t('Settings for %s', Strings::ucFirst($theme_selected)),
+			'$theme_changed_text'  => $this->t('Note: If you switch the theme, you need to save changes before you can see the settings for the new theme below.'),
+			'$timeline_title'      => $this->t('Timelines'),
+			'$channel_title'       => $this->t('Channels'),
+			'$calendar_title'      => $this->t('Calendar'),
 
 			'$form_security_token' => self::getFormSecurityToken('settings_display'),
 			'$uid'                 => $uid,

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -1115,11 +1115,11 @@ function previewTheme(elm) {
 	$.getJSON('pretheme?theme=' + theme,function(data) {
 			$('#theme-preview').html(`
 		<div id="theme-desc">${data.desc}</div>
-		<div id="theme-version">${data.version}</div>
 		<div id="theme-credits">${data.credits}</div>
 		<a href="${data.img}">
 			<img src="${data.img}" width="320" height="240" alt="${theme}" />
 		</a>
+		<div id="theme-version">${data.version}</div>
 	`);
 	});
 }

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -248,14 +248,14 @@ $(function() {
 	var notifications_all = unescape($('<div>').append($("#nav-notifications-see-all").clone()).html()); //outerHtml hack
 	var notifications_mark = unescape($('<div>').append($("#nav-notifications-mark-all").clone()).html()); //outerHtml hack
 	var notifications_empty = unescape($("#nav-notifications-menu").html());
-	
+
 	/* Ensure loading is visible when notifications menu is opened (if no notifications loaded yet)*/
 	$('#nav-notifications-linkmenu, #nav-notifications-menu-btn').on('click', function() {
 		if ($("#nav-notifications-loading").length && $("#nav-notifications-empty").length) {
 			// Only show loading if we haven't loaded notifications yet
 			var menu = $("#nav-notifications-menu");
 			var hasNotifications = menu.find('.notif-item, li').not('#nav-notifications-loading, #nav-notifications-empty').length > 0;
-			var hasContent = menu.html().indexOf('nav-notifications-see-all') > -1;			
+			var hasContent = menu.html().indexOf('nav-notifications-see-all') > -1;
 			if (!hasNotifications && !hasContent) {
 				$("#nav-notifications-loading").show();
 				$("#nav-notifications-empty").hide();
@@ -319,7 +319,7 @@ $(function() {
 
 		// Hide loading state when we receive notification data
 		$("#nav-notifications-loading").hide();
-		
+
 		if (data.notifications.length == 0) {
 			$("#nav-notifications-empty").show();
 		} else {
@@ -328,9 +328,9 @@ $(function() {
 			// Preserve the loading and empty state elements when rebuilding the menu
 			var loadingElement = nnm.find("#nav-notifications-loading");
 			var emptyElement = nnm.find("#nav-notifications-empty");
-			
+
 			nnm.html(notifications_all + notifications_mark);
-			
+
 			// Re-add the loading and empty elements if they existed
 			if (loadingElement.length > 0) {
 				nnm.append(loadingElement);
@@ -1110,12 +1110,24 @@ Array.prototype.remove = function(item) {
 	return this.push.apply(this, rest);
 };
 
-function previewTheme(elm) {
+function previewTheme(elm, theme_changed_display=false) {
+	// This part is currently Frio-specific
+	if (theme_changed_display) {
+	  const theme_changed = document.getElementById("theme-changed")
+	  theme_changed.style.display = "block"
+	}
+	// General
 	theme = $(elm).val();
 	$.getJSON('pretheme?theme=' + theme,function(data) {
-			$('#theme-preview').html('<div id="theme-desc">' + data.desc + '</div><div id="theme-version">' + data.version + '</div><div id="theme-credits">' + data.credits + '</div><a href="' + data.img + '"><img src="' + data.img + '" width="320" height="240" alt="' + theme + '" /></a>');
+			$('#theme-preview').html(`
+		<div id="theme-desc">${data.desc}</div>
+		<div id="theme-version">${data.version}</div>
+		<div id="theme-credits">${data.credits}</div>
+		<a href="${data.img}">
+			<img src="${data.img}" width="320" height="240" alt="${theme}" />
+		</a>
+	`);
 	});
-
 }
 
 // notification permission settings in localstorage

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -1110,13 +1110,7 @@ Array.prototype.remove = function(item) {
 	return this.push.apply(this, rest);
 };
 
-function previewTheme(elm, theme_changed_display=false) {
-	// This part is currently Frio-specific
-	if (theme_changed_display) {
-	  const theme_changed = document.getElementById("theme-changed")
-	  theme_changed.style.display = "block"
-	}
-	// General
+function previewTheme(elm) {
 	theme = $(elm).val();
 	$.getJSON('pretheme?theme=' + theme,function(data) {
 			$('#theme-preview').html(`

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-12 18:13+0100\n"
+"POT-Creation-Date: 2025-11-16 11:33+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -69,8 +69,8 @@ msgstr ""
 #: src/Module/Settings/Channels.php:52 src/Module/Settings/Channels.php:127
 #: src/Module/Settings/ContactImport.php:49
 #: src/Module/Settings/ContactImport.php:96
-#: src/Module/Settings/Delegation.php:76 src/Module/Settings/Display.php:80
-#: src/Module/Settings/Display.php:192
+#: src/Module/Settings/Delegation.php:76 src/Module/Settings/Display.php:81
+#: src/Module/Settings/Display.php:193
 #: src/Module/Settings/Profile/Photo/Crop.php:148
 #: src/Module/Settings/Profile/Photo/Index.php:96
 #: src/Module/Settings/RemoveMe.php:103 src/Module/Settings/UserExport.php:64
@@ -1750,7 +1750,7 @@ msgstr ""
 
 #: src/Content/Feature.php:131 src/Content/Widget.php:613
 #: src/Module/Admin/Site.php:459 src/Module/BaseSettings.php:113
-#: src/Module/Settings/Channels.php:216 src/Module/Settings/Display.php:320
+#: src/Module/Settings/Channels.php:216 src/Module/Settings/Display.php:322
 msgid "Channels"
 msgstr ""
 
@@ -1955,7 +1955,7 @@ msgid "Nothing new here"
 msgstr ""
 
 #: src/Content/Nav.php:118 src/Content/Nav.php:249 src/Content/Nav.php:306
-#: src/Module/Help.php:67
+#: src/Module/Help.php:68
 msgid "Home"
 msgstr ""
 
@@ -2027,7 +2027,7 @@ msgstr ""
 #: src/Content/Nav.php:231 src/Content/Nav.php:291
 #: src/Module/BaseProfile.php:70 src/Module/BaseProfile.php:73
 #: src/Module/BaseProfile.php:81 src/Module/BaseProfile.php:84
-#: src/Module/Settings/Display.php:321 view/theme/frio/theme.php:223
+#: src/Module/Settings/Display.php:323 view/theme/frio/theme.php:223
 #: view/theme/frio/theme.php:227
 msgid "Calendar"
 msgstr ""
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Create an account"
 msgstr ""
 
-#: src/Content/Nav.php:259 src/Module/Help.php:53
+#: src/Content/Nav.php:259 src/Module/Help.php:54
 #: src/Module/Settings/TwoFactor/AppSpecific.php:118
 #: src/Module/Settings/TwoFactor/Index.php:125
 #: src/Module/Settings/TwoFactor/Recovery.php:96
@@ -2267,8 +2267,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3649
-#: src/Model/Item.php:3655 src/Model/Item.php:3656
+#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3655
+#: src/Model/Item.php:3661 src/Model/Item.php:3662
 msgid "Link to source"
 msgstr ""
 
@@ -2878,37 +2878,37 @@ msgid "%s (%s)"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:421
-#: src/Module/Settings/Display.php:289
+#: src/Module/Settings/Display.php:290
 msgid "Monday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:422
-#: src/Module/Settings/Display.php:290
+#: src/Module/Settings/Display.php:291
 msgid "Tuesday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:423
-#: src/Module/Settings/Display.php:291
+#: src/Module/Settings/Display.php:292
 msgid "Wednesday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:424
-#: src/Module/Settings/Display.php:292
+#: src/Module/Settings/Display.php:293
 msgid "Thursday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:425
-#: src/Module/Settings/Display.php:293
+#: src/Module/Settings/Display.php:294
 msgid "Friday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:426
-#: src/Module/Settings/Display.php:294
+#: src/Module/Settings/Display.php:295
 msgid "Saturday"
 msgstr ""
 
 #: src/Core/L10n.php:512 src/Model/Event.php:420
-#: src/Module/Settings/Display.php:288
+#: src/Module/Settings/Display.php:289
 msgid "Sunday"
 msgstr ""
 
@@ -3336,17 +3336,17 @@ msgid "today"
 msgstr ""
 
 #: src/Model/Event.php:454 src/Module/Calendar/Show.php:118
-#: src/Module/Settings/Display.php:299 src/Util/Temporal.php:343
+#: src/Module/Settings/Display.php:300 src/Util/Temporal.php:343
 msgid "month"
 msgstr ""
 
 #: src/Model/Event.php:455 src/Module/Calendar/Show.php:119
-#: src/Module/Settings/Display.php:300 src/Util/Temporal.php:344
+#: src/Module/Settings/Display.php:301 src/Util/Temporal.php:344
 msgid "week"
 msgstr ""
 
 #: src/Model/Event.php:456 src/Module/Calendar/Show.php:120
-#: src/Module/Settings/Display.php:301 src/Util/Temporal.php:345
+#: src/Module/Settings/Display.php:302 src/Util/Temporal.php:345
 msgid "day"
 msgstr ""
 
@@ -3444,44 +3444,44 @@ msgstr ""
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3549
+#: src/Model/Item.php:3555
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3580
+#: src/Model/Item.php:3586
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3582
+#: src/Model/Item.php:3588
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3587
+#: src/Model/Item.php:3593
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3589
+#: src/Model/Item.php:3595
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3591
+#: src/Model/Item.php:3597
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3632 src/Model/Item.php:3633
+#: src/Model/Item.php:3638 src/Model/Item.php:3639
 msgid "View on separate page"
 msgstr ""
 
@@ -3889,7 +3889,7 @@ msgid "Disable"
 msgstr ""
 
 #: src/Module/Admin/Addons/Details.php:78
-#: src/Module/Admin/Themes/Details.php:41 src/Module/Settings/Display.php:350
+#: src/Module/Admin/Themes/Details.php:41 src/Module/Settings/Display.php:352
 msgid "Enable"
 msgstr ""
 
@@ -3943,7 +3943,7 @@ msgstr ""
 #: src/Module/Settings/Connectors.php:143
 #: src/Module/Settings/Connectors.php:228
 #: src/Module/Settings/ContactImport.php:110
-#: src/Module/Settings/Delegation.php:179 src/Module/Settings/Display.php:314
+#: src/Module/Settings/Delegation.php:179 src/Module/Settings/Display.php:315
 #: src/Module/Settings/Features.php:61
 #: src/Module/Settings/Profile/Index.php:272
 msgid "Save Settings"
@@ -4295,11 +4295,11 @@ msgstr ""
 msgid "%s is no valid input for maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:357 src/Module/Settings/Display.php:210
+#: src/Module/Admin/Site.php:357 src/Module/Settings/Display.php:211
 msgid "No special theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:374 src/Module/Settings/Display.php:220
+#: src/Module/Admin/Site.php:374 src/Module/Settings/Display.php:221
 #, php-format
 msgid "%s - (Experimental)"
 msgstr ""
@@ -5186,7 +5186,7 @@ msgid "Can be \"all\" or \"tags\". \"all\" means that every public post should b
 msgstr ""
 
 #: src/Module/Admin/Site.php:578 src/Module/Contact/Profile.php:349
-#: src/Module/Settings/Display.php:255
+#: src/Module/Settings/Display.php:256
 #: src/Module/Settings/TwoFactor/Index.php:132
 msgid "Disabled"
 msgstr ""
@@ -5461,7 +5461,7 @@ msgid "Screenshot"
 msgstr ""
 
 #: src/Module/Admin/Themes/Details.php:83 src/Module/Admin/Themes/Index.php:104
-#: src/Module/BaseAdmin.php:78
+#: src/Module/BaseAdmin.php:78 src/Module/Settings/Display.php:318
 msgid "Themes"
 msgstr ""
 
@@ -5927,7 +5927,7 @@ msgstr ""
 msgid "New Event"
 msgstr ""
 
-#: src/Module/Calendar/Show.php:121 src/Module/Settings/Display.php:302
+#: src/Module/Calendar/Show.php:121 src/Module/Settings/Display.php:303
 msgid "list"
 msgstr ""
 
@@ -6328,11 +6328,11 @@ msgstr ""
 msgid "Add a personal note:"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:177 src/Module/Contact/Unfollow.php:124
+#: src/Module/Contact/Follow.php:178 src/Module/Contact/Unfollow.php:124
 msgid "Posts and Replies"
 msgstr ""
 
-#: src/Module/Contact/Follow.php:206
+#: src/Module/Contact/Follow.php:207
 msgid "The contact could not be added."
 msgstr ""
 
@@ -6936,7 +6936,7 @@ msgstr ""
 msgid "Method Not Allowed."
 msgstr ""
 
-#: src/Module/Help.php:46
+#: src/Module/Help.php:47
 msgid "Help:"
 msgstr ""
 
@@ -9396,12 +9396,12 @@ msgid "When selected, the channel results are reshared. This only works for publ
 msgstr ""
 
 #: src/Module/Settings/Channels.php:176 src/Module/Settings/Channels.php:202
-#: src/Module/Settings/Display.php:348
+#: src/Module/Settings/Display.php:350
 msgid "Label"
 msgstr ""
 
 #: src/Module/Settings/Channels.php:177 src/Module/Settings/Channels.php:203
-#: src/Module/Settings/Display.php:349
+#: src/Module/Settings/Display.php:351
 #: src/Module/Settings/TwoFactor/AppSpecific.php:123
 msgid "Description"
 msgstr ""
@@ -9788,238 +9788,239 @@ msgstr ""
 msgid "No entries."
 msgstr ""
 
-#: src/Module/Settings/Display.php:178
+#: src/Module/Settings/Display.php:179
 msgid "The theme you chose isn't available."
 msgstr ""
 
-#: src/Module/Settings/Display.php:218
+#: src/Module/Settings/Display.php:219
 #, php-format
 msgid "%s - (Unsupported)"
 msgstr ""
 
-#: src/Module/Settings/Display.php:256
+#: src/Module/Settings/Display.php:257
 msgid "Color/Black"
 msgstr ""
 
-#: src/Module/Settings/Display.php:257 view/theme/frio/php/scheme.php:95
+#: src/Module/Settings/Display.php:258 view/theme/frio/php/scheme.php:95
 msgid "Black"
 msgstr ""
 
-#: src/Module/Settings/Display.php:258
+#: src/Module/Settings/Display.php:259
 msgid "Color/White"
 msgstr ""
 
-#: src/Module/Settings/Display.php:259
+#: src/Module/Settings/Display.php:260
 msgid "White"
 msgstr ""
 
-#: src/Module/Settings/Display.php:264
+#: src/Module/Settings/Display.php:265
 msgid "No preview"
 msgstr ""
 
-#: src/Module/Settings/Display.php:265
+#: src/Module/Settings/Display.php:266
 msgid "No image"
 msgstr ""
 
-#: src/Module/Settings/Display.php:266
+#: src/Module/Settings/Display.php:267
 msgid "Small Image"
 msgstr ""
 
-#: src/Module/Settings/Display.php:267
+#: src/Module/Settings/Display.php:268
 msgid "Large Image"
 msgstr ""
 
-#: src/Module/Settings/Display.php:268
+#: src/Module/Settings/Display.php:269
 msgid "Automatic image size"
 msgstr ""
 
-#: src/Module/Settings/Display.php:313
+#: src/Module/Settings/Display.php:314
 msgid "Display Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:315
-msgid "General Theme Settings"
-msgstr ""
-
 #: src/Module/Settings/Display.php:316
-msgid "Custom Theme Settings"
-msgstr ""
-
-#: src/Module/Settings/Display.php:317
 msgid "Content Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:318 view/theme/duepuntozero/config.php:74
+#: src/Module/Settings/Display.php:317 view/theme/duepuntozero/config.php:74
 #: view/theme/frio/config.php:156 view/theme/quattro/config.php:76
 #: view/theme/vier/config.php:124
 msgid "Theme settings"
 msgstr ""
 
 #: src/Module/Settings/Display.php:319
+#, php-format
+msgid "Settings for %s"
+msgstr ""
+
+#: src/Module/Settings/Display.php:320
+msgid "Note: If you switch the theme, you need to save changes before you can see the settings for the new theme below."
+msgstr ""
+
+#: src/Module/Settings/Display.php:321
 msgid "Timelines"
 msgstr ""
 
-#: src/Module/Settings/Display.php:326
-msgid "Display Theme:"
+#: src/Module/Settings/Display.php:328
+msgid "Display theme"
 msgstr ""
 
-#: src/Module/Settings/Display.php:327
-msgid "Mobile Theme:"
+#: src/Module/Settings/Display.php:329
+msgid "Mobile theme"
 msgstr ""
 
-#: src/Module/Settings/Display.php:330
+#: src/Module/Settings/Display.php:332
 msgid "Number of items to display per page:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:330 src/Module/Settings/Display.php:331
+#: src/Module/Settings/Display.php:332 src/Module/Settings/Display.php:333
 msgid "Maximum of 100 items"
 msgstr ""
 
-#: src/Module/Settings/Display.php:331
+#: src/Module/Settings/Display.php:333
 msgid "Number of items to display per page when viewed from mobile device:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:332
+#: src/Module/Settings/Display.php:334
 msgid "Regularly update the page content"
 msgstr ""
 
-#: src/Module/Settings/Display.php:332
+#: src/Module/Settings/Display.php:334
 msgid "When enabled, new content on network, community and channels are added on top."
 msgstr ""
 
-#: src/Module/Settings/Display.php:333
+#: src/Module/Settings/Display.php:335
 msgid "Display emoticons"
 msgstr ""
 
-#: src/Module/Settings/Display.php:333
+#: src/Module/Settings/Display.php:335
 msgid "When enabled, emoticons are replaced with matching symbols."
 msgstr ""
 
-#: src/Module/Settings/Display.php:334
+#: src/Module/Settings/Display.php:336
 msgid "Infinite scroll"
 msgstr ""
 
-#: src/Module/Settings/Display.php:334
+#: src/Module/Settings/Display.php:336
 msgid "Automatic fetch new items when reaching the page end."
 msgstr ""
 
-#: src/Module/Settings/Display.php:335
+#: src/Module/Settings/Display.php:337
 msgid "Enable Smart Threading"
 msgstr ""
 
-#: src/Module/Settings/Display.php:335
+#: src/Module/Settings/Display.php:337
 msgid "Enable the automatic suppression of extraneous thread indentation."
 msgstr ""
 
-#: src/Module/Settings/Display.php:336
+#: src/Module/Settings/Display.php:338
 msgid "Display the Dislike feature"
 msgstr ""
 
-#: src/Module/Settings/Display.php:336
+#: src/Module/Settings/Display.php:338
 msgid "Display the Dislike button and dislike reactions on posts and comments."
 msgstr ""
 
-#: src/Module/Settings/Display.php:337
+#: src/Module/Settings/Display.php:339
 msgid "Display the resharer"
 msgstr ""
 
-#: src/Module/Settings/Display.php:337
+#: src/Module/Settings/Display.php:339
 msgid "Display the first resharer as icon and text on a reshared item."
 msgstr ""
 
-#: src/Module/Settings/Display.php:338
+#: src/Module/Settings/Display.php:340
 msgid "Stay local"
 msgstr ""
 
-#: src/Module/Settings/Display.php:338
+#: src/Module/Settings/Display.php:340
 msgid "Don't go to a remote system when following a contact link."
 msgstr ""
 
-#: src/Module/Settings/Display.php:339
+#: src/Module/Settings/Display.php:341
 msgid "Show the post deletion checkbox"
 msgstr ""
 
-#: src/Module/Settings/Display.php:339
+#: src/Module/Settings/Display.php:341
 msgid "Display the checkbox for the post deletion on the network page."
 msgstr ""
 
-#: src/Module/Settings/Display.php:340
+#: src/Module/Settings/Display.php:342
 msgid "DIsplay the event list"
 msgstr ""
 
-#: src/Module/Settings/Display.php:340
+#: src/Module/Settings/Display.php:342
 msgid "Display the birthday reminder and event list on the network page."
 msgstr ""
 
-#: src/Module/Settings/Display.php:341
+#: src/Module/Settings/Display.php:343
 msgid "Link preview mode"
 msgstr ""
 
-#: src/Module/Settings/Display.php:341
+#: src/Module/Settings/Display.php:343
 msgid "Appearance of the link preview that is added to each post with a link."
 msgstr ""
 
-#: src/Module/Settings/Display.php:342
+#: src/Module/Settings/Display.php:344
 msgid "Hide pictures with empty alternative text"
 msgstr ""
 
-#: src/Module/Settings/Display.php:342
+#: src/Module/Settings/Display.php:344
 msgid "Don't display pictures that are missing the alternative text."
 msgstr ""
 
-#: src/Module/Settings/Display.php:343
+#: src/Module/Settings/Display.php:345
 msgid "Hide custom emojis"
 msgstr ""
 
-#: src/Module/Settings/Display.php:343
+#: src/Module/Settings/Display.php:345
 msgid "Don't display custom emojis."
 msgstr ""
 
-#: src/Module/Settings/Display.php:344
+#: src/Module/Settings/Display.php:346
 msgid "Platform icons style"
 msgstr ""
 
-#: src/Module/Settings/Display.php:344
+#: src/Module/Settings/Display.php:346
 msgid "Style of the platform icons"
 msgstr ""
 
-#: src/Module/Settings/Display.php:345
+#: src/Module/Settings/Display.php:347
 msgid "Embed remote media"
 msgstr ""
 
-#: src/Module/Settings/Display.php:345
+#: src/Module/Settings/Display.php:347
 msgid "When enabled, remote media will be embedded in the post, like for example YouTube videos."
 msgstr ""
 
-#: src/Module/Settings/Display.php:346
+#: src/Module/Settings/Display.php:348
 msgid "Embed supported media"
 msgstr ""
 
-#: src/Module/Settings/Display.php:346
+#: src/Module/Settings/Display.php:348
 msgid "When enabled, remote media will be embedded in the post instead of using the local player if this is supported by the remote system. This is useful for media where the remote player is better than the local one, like for example Peertube videos."
 msgstr ""
 
-#: src/Module/Settings/Display.php:351
+#: src/Module/Settings/Display.php:353
 msgid "Bookmark"
 msgstr ""
 
-#: src/Module/Settings/Display.php:353
+#: src/Module/Settings/Display.php:355
 msgid "Enable timelines that you want to see in the channels widget. Bookmark timelines that you want to see in the top menu."
 msgstr ""
 
-#: src/Module/Settings/Display.php:355
+#: src/Module/Settings/Display.php:357
 msgid "Channel languages:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:355
+#: src/Module/Settings/Display.php:357
 msgid "Select all the languages you want to see in your channels. \"Unspecified\" describes all posts for which no language information was detected (e.g. posts with just an image or too little text to be sure of the language). If you want to see all languages, you will need to select all items in the list."
 msgstr ""
 
-#: src/Module/Settings/Display.php:357
+#: src/Module/Settings/Display.php:359
 msgid "Beginning of week:"
 msgstr ""
 
-#: src/Module/Settings/Display.php:358
+#: src/Module/Settings/Display.php:360
 msgid "Default calendar view:"
 msgstr ""
 
@@ -11797,26 +11798,6 @@ msgstr ""
 
 #: view/theme/frio/config.php:158
 msgid "Accent color"
-msgstr ""
-
-#: view/theme/frio/config.php:158
-msgid "Blue"
-msgstr ""
-
-#: view/theme/frio/config.php:158
-msgid "Red"
-msgstr ""
-
-#: view/theme/frio/config.php:158
-msgid "Purple"
-msgstr ""
-
-#: view/theme/frio/config.php:158
-msgid "Green"
-msgstr ""
-
-#: view/theme/frio/config.php:158
-msgid "Pink"
 msgstr ""
 
 #: view/theme/frio/config.php:159

--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -155,7 +155,7 @@ function frio_form($arr)
 		'$submit'           => DI::l10n()->t('Submit'),
 		'$title'            => DI::l10n()->t('Theme settings'),
 		'$scheme'           => ['frio_scheme', DI::l10n()->t('Appearance'), $arr['scheme'], frio_scheme_get_list()],
-		'$scheme_accent'    => !$scheme_info['accented'] ? '' : ['frio_scheme_accent', DI::l10n()->t('Accent color'), $arr['scheme_accent'], ['blue' => DI::l10n()->t('Blue'), 'red' => DI::l10n()->t('Red'), 'purple' => DI::l10n()->t('Purple'), 'green' => DI::l10n()->t('Green'), 'pink' => DI::l10n()->t('Pink')]],
+		'$scheme_accent'    => !$scheme_info['accented'] ? '' : ['frio_scheme_accent', DI::l10n()->t('Accent color'), $arr['scheme_accent']],
 		'$share_string'     => $arr['scheme'] != FRIO_CUSTOM_SCHEME ? '' : ['frio_share_string', DI::l10n()->t('Copy or paste schemestring'), $arr['share_string'], DI::l10n()->t('You can copy this string to share your theme with others. Pasting here applies the schemestring'), false, false],
 		'$nav_bg'           => array_key_exists('nav_bg', $disable) ? '' : ['frio_nav_bg', DI::l10n()->t('Navigation bar background color'), $arr['nav_bg'], '', false],
 		'$nav_icon_color'   => array_key_exists('nav_icon_color', $disable) ? '' : ['frio_nav_icon_color', DI::l10n()->t('Navigation bar icon color '), $arr['nav_icon_color'], '', false],

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3184,8 +3184,7 @@ details.profile-jot-net[open] summary:before {
 }
 /* This text is only shown after the theme was changed */
 #theme-changed {
-	color: $link_color;
-	display: none;
+	margin: 25px 0;
 }
 
 #frio-colors {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3146,6 +3146,10 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 }
 
 /* Settings */
+#settings h3 {
+	font-size: 18px
+}
+
 .section-subtitle-wrapper {
 	padding: 1px 10px;
 }
@@ -3177,6 +3181,43 @@ details.profile-jot-net[open] summary:before {
 }
 .group {
 	margin-left: 20px;
+}
+/* This text is only shown after the theme was changed */
+#theme-changed {
+	color: $link_color;
+	display: none;
+}
+
+#frio-colors {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-evenly;
+}
+
+#frio-colors input {
+	display: none;
+}
+
+#frio-colors label {
+	align-items: center;
+	cursor: pointer;
+}
+
+#frio-colors input[type="radio"]:checked + label {
+	border: 3px solid white!important;
+}
+
+.frio-color-option {
+	border-radius: 50px;
+	display: inline-block;
+	margin-right: 15px;
+	height: 75px;
+	width: 75px;
+}
+
+#field-theme-select-container select {
+	margin-bottom: 15px
 }
 
 /* Emulates Bootstrap display */

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3187,32 +3187,35 @@ details.profile-jot-net[open] summary:before {
 	margin: 25px 0;
 }
 
-#frio-colors {
+#frio-accents {
 	align-items: center;
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: space-evenly;
+	justify-content: flex-start;
 }
 
-#frio-colors input {
+#frio-accents input {
 	display: none;
 }
 
-#frio-colors label {
+#frio-accents label {
 	align-items: center;
 	cursor: pointer;
 }
 
-#frio-colors input[type="radio"]:checked + label {
-	border: 3px solid white!important;
+#frio-accents input[type="radio"]:checked + label {
+	border: 5px solid $font_color_darker!important;
 }
 
-.frio-color-option {
+.frio-accent {
+	align-items: center;
 	border-radius: 50px;
-	display: inline-block;
-	margin-right: 15px;
-	height: 75px;
-	width: 75px;
+	display: flex;
+	font-size: 25px;
+	justify-content: center;
+	margin-right: 20px;
+	height: 45px;
+	width: 45px;
 }
 
 #field-theme-select-container select {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3203,15 +3203,17 @@ details.profile-jot-net[open] summary:before {
 	cursor: pointer;
 }
 
-#frio-accents input[type="radio"]:checked + label {
-	border: 5px solid $font_color_darker!important;
+#frio-accents input[type="radio"]:checked + label::before {
+	content: '\f00c';
+	font-family: ForkAwesome;
+	font-weight: normal;
+	font-size: 18px;
 }
 
 .frio-accent {
 	align-items: center;
 	border-radius: 50px;
 	display: flex;
-	font-size: 25px;
 	justify-content: center;
 	margin-right: 20px;
 	height: 45px;

--- a/view/theme/frio/templates/field_themeselect.tpl
+++ b/view/theme/frio/templates/field_themeselect.tpl
@@ -10,7 +10,7 @@
 {{/if}}
 	<div id="field-theme-select-container" class="form-group field select">
 		<label for="id_{{$field.0}}">{{$field.1}}</label>
-		<select class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" {{if $field.5=="preview"}}onchange="previewTheme(this, true);"{{/if}} aria-describedby="{{$field.0}}_tip">
+		<select class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" {{if $field.5=="preview"}}onchange="previewTheme(this);"{{/if}} aria-describedby="{{$field.0}}_tip">
 	{{foreach $field.4 as $opt=>$val}}
 			<option value="{{$opt}}" {{if $opt==$field.2}}selected{{/if}}>{{$val}}</option>
 	{{/foreach}}

--- a/view/theme/frio/templates/field_themeselect.tpl
+++ b/view/theme/frio/templates/field_themeselect.tpl
@@ -8,9 +8,9 @@
 {{if $field.5=="preview"}}
 	<script type="text/javascript">$(document).ready(function(){ previewTheme($("#id_{{$field.0}}")[0]); });</script>
 {{/if}}
-	<div class="form-group field select">
+	<div id="field-theme-select-container" class="form-group field select">
 		<label for="id_{{$field.0}}">{{$field.1}}</label>
-		<select class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" {{if $field.5=="preview"}}onchange="previewTheme(this);"{{/if}} aria-describedby="{{$field.0}}_tip">
+		<select class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" {{if $field.5=="preview"}}onchange="previewTheme(this, true);"{{/if}} aria-describedby="{{$field.0}}_tip">
 	{{foreach $field.4 as $opt=>$val}}
 			<option value="{{$opt}}" {{if $opt==$field.2}}selected{{/if}}>{{$val}}</option>
 	{{/foreach}}

--- a/view/theme/frio/templates/settings/display.tpl
+++ b/view/theme/frio/templates/settings/display.tpl
@@ -28,7 +28,7 @@
 						{{include file="field_themeselect.tpl" field=$mobile_theme}}
 						{{/if}}
 
-						<p id="theme-changed"><strong>{{$theme_changed_text}}</p>
+						<p class="alert alert-info" id="theme-changed">{{$theme_changed_text}}</p>
 
 					{{if $theme_config}}
 						<h3>{{$themes_settings_for}}</h3>

--- a/view/theme/frio/templates/settings/display.tpl
+++ b/view/theme/frio/templates/settings/display.tpl
@@ -14,7 +14,7 @@
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="theme-settings-title">
 					<h2>
 						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#theme-settings-content" aria-expanded="true" aria-controls="theme-settings-content">
-							{{$d_tset}}
+							{{$themes_title}}
 						</button>
 					</h2>
 				</div>
@@ -27,28 +27,18 @@
 						{{if count($mobile_theme.4) > 1}}
 						{{include file="field_themeselect.tpl" field=$mobile_theme}}
 						{{/if}}
-					</div>
-					<div class="panel-footer">
-						<button type="submit" name="submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
-					</div>
-				</div>
-			</div>
 
-			<div class="panel">
-				<div class="section-subtitle-wrapper panel-heading" role="tab" id="custom-settings-title">
-					<h2>
-						<button class="btn-link accordion-toggle collapsed" data-toggle="collapse" data-parent="#settings" href="#custom-settings-content" aria-expanded="false" aria-controls="custom-settings-content">
-							{{$d_ctset}}
-						</button>
-					</h2>
-				</div>
-				<div id="custom-settings-content" class="panel-collapse collapse{{if !$theme && !$mobile_theme}} in{{/if}}" role="tabpanel" aria-labelledby="custom-settings">
-					<div class="panel-body">
+						<p id="theme-changed"><strong>{{$theme_changed_text}}</p>
 
 					{{if $theme_config}}
+						<h3>{{$themes_settings_for}}</h3>
 						{{$theme_config nofilter}}
 					{{/if}}
+					</div>
 
+					<div class="panel-footer">
+						{{*Technically the variable below could just be hardcoded, but it's relevant if at some point this template is copied to the main template dir so other themes starting using it *}}
+						<button type="submit" name="{{$theme.2}}-settings-submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
 					</div>
 				</div>
 			</div>
@@ -124,7 +114,7 @@
 					</div>
 				</div>
 			</div>
-		
+
 			<div class="panel">
 				<div class="section-subtitle-wrapper panel-heading" role="tab" id="channel-settings-title">
 					<h2>

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -19,26 +19,26 @@
 {{if $scheme_accent}}
 <div class="form-group">
 	<p><label>{{$scheme_accent.1}}</label></p>
-	<div id="frio-colors">
+	<div id="frio-accents">
 		<div>
 			<input id="blue" type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_BLUE}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_BLUE}} checked{{/if}}>
-			<label for="blue" class="frio-color-option" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_BLUE}}"></label>
+			<label for="blue" class="frio-accent" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_BLUE}}"></label>
 		</div>
 		<div>
 			<input id="red" type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_RED}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_RED}} checked{{/if}}>
-			<label for="red" class="frio-color-option" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_RED}}"></label>
+			<label for="red" class="frio-accent" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_RED}}"></label>
 		</div>
 		<div>
 			<input id="purple" type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_PURPLE}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_PURPLE}} checked{{/if}}>
-			<label for="purple" class="frio-color-option" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_PURPLE}}"></label>
+			<label for="purple" class="frio-accent" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_PURPLE}}"></label>
 		</div>
 		<div>
 			<input id="green" type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_GREEN}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_GREEN}} checked{{/if}}>
-			<label for="green" class="frio-color-option" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_GREEN}}"></label>
+			<label for="green" class="frio-accent" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_GREEN}}"></label>
 		</div>
 		<div>
 			<input id="pink" type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_PINK}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_PINK}} checked{{/if}}>
-			<label for="pink" class="frio-color-option" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_PINK}}"></label>
+			<label for="pink" class="frio-accent" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_PINK}}"></label>
 		</div>
 	</div>
 </div>

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -19,31 +19,28 @@
 {{if $scheme_accent}}
 <div class="form-group">
 	<p><label>{{$scheme_accent.1}}</label></p>
-	<label class="radio-inline">
-		<input type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_BLUE}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_BLUE}} checked{{/if}}>
-		<span style="border-radius: 10px; background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_BLUE}}; width: 20px; display: inline-block">&nbsp;</span>
-		{{$scheme_accent.3.blue}}
-	</label>
-	<label class="radio-inline">
-		<input type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_RED}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_RED}} checked{{/if}}>
-		<span style="border-radius: 10px; background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_RED}}; width: 20px; display: inline-block">&nbsp;</span>
-		{{$scheme_accent.3.red}}
-	</label>
-	<label class="radio-inline">
-		<input type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_PURPLE}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_PURPLE}} checked{{/if}}>
-		<span style="border-radius: 10px; background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_PURPLE}}; width: 20px; display: inline-block">&nbsp;</span>
-		{{$scheme_accent.3.purple}}
-	</label>
-	<label class="radio-inline">
-		<input type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_GREEN}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_GREEN}} checked{{/if}}>
-		<span style="border-radius: 10px; background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_GREEN}}; width: 20px; display: inline-block">&nbsp;</span>
-		{{$scheme_accent.3.green}}
-	</label>
-	<label class="radio-inline">
-		<input type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_PINK}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_PINK}} checked{{/if}}>
-		<span style="border-radius: 10px; background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_PINK}}; width: 20px; display: inline-block">&nbsp;</span>
-		{{$scheme_accent.3.pink}}
-	</label>
+	<div id="frio-colors">
+		<div>
+			<input id="blue" type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_BLUE}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_BLUE}} checked{{/if}}>
+			<label for="blue" class="frio-color-option" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_BLUE}}"></label>
+		</div>
+		<div>
+			<input id="red" type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_RED}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_RED}} checked{{/if}}>
+			<label for="red" class="frio-color-option" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_RED}}"></label>
+		</div>
+		<div>
+			<input id="purple" type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_PURPLE}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_PURPLE}} checked{{/if}}>
+			<label for="purple" class="frio-color-option" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_PURPLE}}"></label>
+		</div>
+		<div>
+			<input id="green" type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_GREEN}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_GREEN}} checked{{/if}}>
+			<label for="green" class="frio-color-option" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_GREEN}}"></label>
+		</div>
+		<div>
+			<input id="pink" type="radio" name="{{$scheme_accent.0}}" value="{{$smarty.const.FRIO_SCHEME_ACCENT_PINK}}" {{if $scheme_accent.2 == $smarty.const.FRIO_SCHEME_ACCENT_PINK}} checked{{/if}}>
+			<label for="pink" class="frio-color-option" style="background-color: {{$smarty.const.FRIO_SCHEME_ACCENT_PINK}}"></label>
+		</div>
+	</div>
 </div>
 {{/if}}
 
@@ -211,7 +208,4 @@
 
 {{include file="field_checkbox.tpl" field=$always_open_compose}}
 
-<div class="settings-submit-wrapper pull-right">
-	<button type="submit" value="{{$submit}}" class="settings-submit btn btn-primary" name="frio-settings-submit">{{$submit}}</button>
-</div>
 <div class="clearfix"></div>

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -11,7 +11,7 @@
  * Author: Ike <http://pirati.ca/profile/heluecht>
  * Author: Beanow <https://fc.oscp.info/profile/beanow>
  * Maintainer: Ike <http://pirati.ca/profile/heluecht>
- * Description: "Vier" is a very compact and modern theme. It uses the font awesome font library: http://fortawesome.github.com/Font-Awesome/
+ * Description: "Vier" is a compact and modern theme. It uses the font awesome font library: https://fontawesome.com
  */
 
 use Friendica\App\Mode;


### PR DESCRIPTION
Closes #15307 #12265

The two theme sections - theme selection and theme settings are joined into one. One still needs to save changes to see settings for the new theme, though, so added an info text explaining that. (Currently "save changes" is also needed to get the settings for the newly selected theme, so that's unchanged, but perhaps it could be a bit more confusing now they're right next to each other. On the other hand I think it's less confusing that all theme related settings are in the same section).

Highlight colors are selected is changed mostly following the suggestions in #12265.

The description for Vier is updated minimally.

Also did some minor refactoring in main.js by using the more readable template literals over of a lot of appending.

Source strings **are** changed/updated.

# Questions

I haven't tested out when there's a mobile theme set. Even on the backend I don't see an option to enable it. There's just a dropdown with this one option:
<img width="603" height="104" alt="image" src="https://github.com/user-attachments/assets/6f258a96-29c9-4d0d-969d-bd80f17bac89" />
Maybe I'm looking in the wrong place?

# Before

<img width="677" height="637" alt="image" src="https://github.com/user-attachments/assets/b9fdf283-c798-4b28-947a-26215067dc2e" />

<img width="647" height="429" alt="image" src="https://github.com/user-attachments/assets/c0c84e61-dae4-4c68-9953-13e47d474fb7" />

# After

Current version:
<img width="672" height="1017" alt="image" src="https://github.com/user-attachments/assets/27d71a2d-e550-4116-bf34-6cf762fb1d87" />

Earlier versions:
<img width="676" height="1034" alt="image" src="https://github.com/user-attachments/assets/1c8e65ab-6dd7-41b6-ae65-b0d458f36ddf" />

<img width="669" height="1049" alt="image" src="https://github.com/user-attachments/assets/258558ca-0c16-4c0b-a334-acfeb2cc474d" />