### PR TITLE
Issue 14850: Fetch all posts of a thread

### DIFF
--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -373,11 +373,15 @@ class Item
 	public function photoMenu(array $item, string $formSecurityToken): string
 	{
 		$this->profiler->startRecording('rendering');
-		$sub_link    = $contact_url = $pm_url = $status_link = '';
+		$sub_link    = $contact_url = $pm_url = $status_link = $complete_url = '';
 		$photos_link = $posts_link = $block_link = $ignore_link = $collapse_link = $ignoreserver_link = '';
 
 		if ($this->userSession->getLocalUserId() && $this->userSession->getLocalUserId() == $item['uid'] && $item['gravity'] == ItemModel::GRAVITY_PARENT && !$item['self'] && !$item['mention']) {
 			$sub_link = 'javascript:doFollowThread(' . $item['id'] . '); return false;';
+		}
+
+		if ($this->userSession->getLocalUserId() && $this->userSession->getLocalUserId() === $item['uid'] && $item['network'] === Protocol::ACTIVITYPUB && $item['gravity'] === ItemModel::GRAVITY_PARENT && !$item['self']) {
+			$complete_url = 'javascript:doCompleteThread(' . $item['uri-id'] . '); return false;';
 		}
 
 		$author = [
@@ -429,6 +433,7 @@ class Item
 		if ($this->userSession->getLocalUserId()) {
 			$menu = [
 				$this->l10n->t('Follow Thread')                               => $sub_link,
+				$this->l10n->t('Complete Thread')                             => $complete_url,
 				$this->l10n->t('View Status')                                 => $status_link,
 				$this->l10n->t('View Profile')                                => $profile_link,
 				$this->l10n->t('View Photos')                                 => $photos_link,

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1493,4 +1493,14 @@ class Worker
 
 		return $execute;
 	}
+
+	/**
+	 * Check if we are in worker mode
+	 *
+	 * @return boolean
+	 */
+	public static function isInWorkerMode(): bool
+	{
+		return (DI::logger() instanceof WorkerLogger);
+	}
 }

--- a/src/Module/ActivityPub/Objects.php
+++ b/src/Module/ActivityPub/Objects.php
@@ -81,7 +81,13 @@ class Objects extends BaseModule
 		$last_modified = $item['changed'];
 		Network::checkEtagModified($etag, $last_modified);
 
-		if (empty($this->parameters['activity']) && ($item['gravity'] != Item::GRAVITY_ACTIVITY)) {
+		if (($this->parameters['activity'] ?? '') === 'replies') {
+			$posts         = Post::toArray(Post::selectPosts(['uri'], ['thr-parent-id' => $item['uri-id'], 'gravity' => Item::GRAVITY_COMMENT, 'deleted' => false, 'private' => [Item::PUBLIC, Item::UNLISTED]]));
+			$data          = ['@context' => ActivityPub::CONTEXT];
+			$data['id']    = DI::baseUrl() . '/' . DI::args()->getQueryString();
+			$data['type']  = 'OrderedCollection';
+			$data['items'] = array_column($posts, 'uri');
+		} elseif (!isset($this->parameters['activity']) && ($item['gravity'] !== Item::GRAVITY_ACTIVITY)) {
 			$activity = ActivityPub\Transmitter::createCachedActivityFromItem($item['id'], false, true);
 			if (empty($activity['type'])) {
 				throw new HTTPException\NotFoundException();

--- a/src/Module/Admin/Site.php
+++ b/src/Module/Admin/Site.php
@@ -19,6 +19,7 @@ use Friendica\Model\User;
 use Friendica\Module\BaseAdmin;
 use Friendica\Module\Conversation\Community;
 use Friendica\Module\Register;
+use Friendica\Protocol\ActivityPub\Processor;
 use Friendica\Protocol\Relay;
 use Friendica\Util\BasePath;
 use Friendica\Util\EMailer\MailBuilder;
@@ -134,6 +135,7 @@ class Site extends BaseAdmin
 		$worker_load_cooldown = (!empty($_POST['worker_load_cooldown'])       ? intval($_POST['worker_load_cooldown'])          : 0);
 		$worker_fastlane      = !empty($_POST['worker_fastlane']);
 		$decoupled_receiver   = (!empty($_POST['decoupled_receiver'])         ? intval(trim($_POST['decoupled_receiver'])) : false);
+		$fetch_replies        = (!empty($_POST['fetch_replies'])              ? intval(trim($_POST['fetch_replies']))      : Processor::FETCH_REPLIES_ALL);
 		$cron_interval        = (!empty($_POST['cron_interval'])              ? intval($_POST['cron_interval'])            : 1);
 		$worker_defer_limit   = (!empty($_POST['worker_defer_limit'])         ? intval($_POST['worker_defer_limit'])       : 15);
 		$worker_fetch_limit   = (!empty($_POST['worker_fetch_limit'])         ? intval($_POST['worker_fetch_limit'])       : 1);
@@ -313,6 +315,7 @@ class Site extends BaseAdmin
 		$transactionConfig->set('system', 'worker_load_cooldown', $worker_load_cooldown);
 		$transactionConfig->set('system', 'worker_fastlane', $worker_fastlane);
 		$transactionConfig->set('system', 'decoupled_receiver', $decoupled_receiver);
+		$transactionConfig->set('system', 'fetch_replies', $fetch_replies);
 		$transactionConfig->set('system', 'cron_interval', max($cron_interval, 1));
 		$transactionConfig->set('system', 'worker_defer_limit', $worker_defer_limit);
 		$transactionConfig->set('system', 'worker_fetch_limit', max($worker_fetch_limit, 1));
@@ -380,6 +383,14 @@ class Site extends BaseAdmin
 				}
 			}
 		}
+
+		/* Reply fetch options */
+		$fetch_replies_choices = [
+			Processor::FETCH_REPLIES_ALL         => DI::l10n()->t('Fetch replies on all posts'),
+			Processor::FETCH_REPLIES_NONE        => DI::l10n()->t('Don\'t fetch replies'),
+			Processor::FETCH_REPLIES_FOLLOWED    => DI::l10n()->t('Fetch replies on posts from followed contacts only'),
+			Processor::FETCH_REPLIES_INTERACTION => DI::l10n()->t('Fetch replies on posts with interactions only')
+		];
 
 		/* Community page style */
 		$community_page_style_choices = [
@@ -570,6 +581,7 @@ class Site extends BaseAdmin
 			'$worker_load_cooldown' => ['worker_load_cooldown', DI::l10n()->t('Maximum load for workers'), DI::config()->get('system', 'worker_load_cooldown'), DI::l10n()->t('Maximum load that causes a cooldown before each worker function call.')],
 			'$worker_fastlane'      => ['worker_fastlane', DI::l10n()->t('Enable fastlane'), DI::config()->get('system', 'worker_fastlane'), DI::l10n()->t('When enabed, the fastlane mechanism starts an additional worker if processes with higher priority are blocked by processes of lower priority.')],
 			'$decoupled_receiver'   => ['decoupled_receiver', DI::l10n()->t('Decoupled receiver'), DI::config()->get('system', 'decoupled_receiver'), DI::l10n()->t('Decouple incoming ActivityPub posts by processing them in the background via a worker process. Only enable this on fast systems.')],
+			'$fetch_replies'        => ['fetch_replies', DI::l10n()->t('Fetch replies mode'), DI::config()->get('system', 'fetch_replies'), DI::l10n()->t('Missing replies can be fetched upon receipt of an ActivityPub post.'), $fetch_replies_choices],
 			'$cron_interval'        => ['cron_interval', DI::l10n()->t('Cron interval'), DI::config()->get('system', 'cron_interval'), DI::l10n()->t('Minimal period in minutes between two calls of the "Cron" worker job.')],
 			'$worker_defer_limit'   => ['worker_defer_limit', DI::l10n()->t('Worker defer limit'), DI::config()->get('system', 'worker_defer_limit'), DI::l10n()->t('Per default the systems tries delivering for 15 times before dropping it.')],
 			'$worker_fetch_limit'   => ['worker_fetch_limit', DI::l10n()->t('Worker fetch limit'), DI::config()->get('system', 'worker_fetch_limit'), DI::l10n()->t('Number of worker tasks that are fetched in a single query. Higher values should increase the performance, too high values will mostly likely decrease it. Only change it, when you know how to measure the performance of your system.')],

--- a/src/Module/Item/Complete.php
+++ b/src/Module/Item/Complete.php
@@ -1,0 +1,46 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Module\Item;
+
+use Friendica\BaseModule;
+use Friendica\Core\Worker;
+use Friendica\DI;
+use Friendica\Network\HTTPException;
+
+/**
+ * Module for completing threads
+ */
+final class Complete extends BaseModule
+{
+	protected function post(array $request = [])
+	{
+		$l10n = DI::l10n();
+		DI::logger()->debug('Complete thread requested.', ['parameters' => $this->parameters]);
+		if (!DI::userSession()->isAuthenticated()) {
+			throw new HttpException\ForbiddenException($l10n->t('Access denied.'));
+		}
+
+		if (!isset($this->parameters['id'])) {
+			throw new HTTPException\BadRequestException();
+		}
+
+		$itemId = intval($this->parameters['id']);
+
+		Worker::add(Worker::PRIORITY_MEDIUM, 'FetchMissingReplies', $itemId);
+
+		$return = [
+			'status'  => 'ok',
+			'item_id' => $itemId,
+			'verb'    => 'complete',
+			'state'   => 1
+		];
+
+		DI::logger()->debug('Complete thread executed.', ['parameters' => $this->parameters]);
+		$this->jsonExit($return);
+	}
+}

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -279,6 +279,8 @@ class ActivityPub
 			$items = $data['first']['items'];
 		} elseif (!empty($data['first']) && is_string($data['first']) && ($data['first'] != $url)) {
 			return self::fetchItems($data['first'], $uid, $start_timestamp);
+		} elseif (isset($data['first']) && isset($data['first']['next']) && ($data['first']['next'] != $url)) {
+			return self::fetchItems($data['first']['next'], $uid, $start_timestamp);
 		} else {
 			return [];
 		}

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -46,6 +46,11 @@ class Processor
 	const CACHEKEY_FETCH_ACTIVITY = 'processor:fetchMissingActivity:';
 	const CACHEKEY_JUST_FETCHED   = 'processor:isJustFetched:';
 
+	const FETCH_REPLIES_ALL         = 0;
+	const FETCH_REPLIES_NONE        = 1;
+	const FETCH_REPLIES_FOLLOWED    = 2;
+	const FETCH_REPLIES_INTERACTION = 3;
+
 	/**
 	 * Add an object id to the list of processed ids
 	 *
@@ -260,7 +265,60 @@ class Processor
 				self::updateEvent($post['event-id'], $activity);
 			}
 		}
-		self::processReplies($activity, $item);
+
+		if (self::shouldCompleteThread($item)) {
+			if (Worker::isInWorkerMode()) {
+				self::processReplies($activity, $item);
+			} else {
+				Worker::add(Worker::PRIORITY_MEDIUM, 'FetchMissingReplies', $item['uri-id'], $activity);
+			}
+		}
+	}
+
+	private static function shouldCompleteThread(array $item): bool
+	{
+		switch (DI::config()->get('system', 'fetch_replies')) {
+			case self::FETCH_REPLIES_ALL:
+				DI::logger()->debug('Fetch all replies is enabled');
+				return true;
+
+			case self::FETCH_REPLIES_FOLLOWED:
+				DI::logger()->debug('Fetch replies from followed users is enabled');
+				return Post::exists(["`parent-uri-id` = ? AND `gravity` IN (?, ?) AND `uid` != ?", $item['parent-uri-id'], Item::GRAVITY_PARENT, Item::GRAVITY_COMMENT, 0]);
+
+			case self::FETCH_REPLIES_INTERACTION:
+				DI::logger()->debug('Fetch replies with interaction is enabled');
+				return Post::exists(["`parent-uri-id` = ? AND `origin`", $item['parent-uri-id']]);
+		}
+
+		DI::logger()->debug('No reply fetching is enabled');
+		return false;
+	}
+
+	/**
+	 * Fetch replies for a given uri id
+	 *
+	 * @param int   $uriId Uri-id of the parent item
+	 * @param array $child Child activity data
+	 */
+	public static function fetchRepliesByUriId(int $uriId, array $child = [])
+	{
+		$item = Post::selectFirstPost(['thr-parent', 'parent-uri', 'replies'], ['uri-id' => $uriId, 'private' => [Item::PUBLIC, Item::UNLISTED]]);
+		if (!$item) {
+			return;
+		}
+
+		if (!$child) {
+			$activity = DBA::selectFirst('post-activity', [], ['uri-id' => $uriId]);
+			$data     = json_decode($activity['activity'], true);
+			$activity = JsonLD::compact($data);
+
+			$trust_source = true;
+			$child        = Receiver::prepareObjectData($activity, 0, false, $trust_source);
+		}
+
+		DI::logger()->debug('Process replies', ['uri-id' => $uriId, 'replies' => !$item['replies']]);
+		self::processReplies($child, $item);
 	}
 
 	/**
@@ -520,29 +578,28 @@ class Processor
 
 	private static function processReplies(array $activity, array $item)
 	{
-		// @todo fetch replies not only in the decoupled mode
-		if (!DI::config()->get('system', 'decoupled_receiver')) {
+		if (isset($item['parent-uri-id'])) {
+			$condition = ['parent-uri-id' => $item['parent-uri-id']];
+		} elseif (isset($item['thr-parent-id'])) {
+			$parent = Post::selectFirstPost(['parent-uri-id'], ['uri-id' => $item['thr-parent-id']]);
+			if (isset($parent['parent-uri-id'])) {
+				$condition = ['parent-uri-id' => $parent['parent-uri-id']];
+			} else {
+				$condition = ['uri-id' => [$item['thr-parent-id'], $item['uri-id']]];
+			}
+		} elseif (isset($item['replies'])) {
+			self::fetchReplies($item['replies'], $activity);
+			return;
+		} else {
 			return;
 		}
 
-		$replies = [$item['thr-parent']];
-		if (!empty($item['parent-uri'])) {
-			$replies[] = $item['parent-uri'];
-		}
-		$condition = DBA::mergeConditions(['uri' => $replies], ["`replies-id` IS NOT NULL"]);
+		$condition = DBA::mergeConditions($condition, ["`replies-id` IS NOT NULL"]);
 		$posts     = Post::select(['replies', 'replies-id'], $condition);
 		while ($post = Post::fetch($posts)) {
-			$cachekey = 'Processor-CreateItem-Replies-' . $post['replies-id'];
-			if (!DI::cache()->get($cachekey)) {
-				self::fetchReplies($post['replies'], $activity);
-				DI::cache()->set($cachekey, true);
-			}
+			self::fetchReplies($post['replies'], $activity);
 		}
-		DBA::close($replies);
-
-		if (!empty($item['replies'])) {
-			self::fetchReplies($item['replies'], $activity);
-		}
+		DBA::close($posts);
 	}
 
 	/**
@@ -1246,8 +1303,12 @@ class Processor
 			}
 		}
 
-		if ($success) {
-			self::processReplies($activity, $item);
+		if ($success && self::shouldCompleteThread($item)) {
+			if (Worker::isInWorkerMode()) {
+				self::processReplies($activity, $item);
+			} else {
+				Worker::add(Worker::PRIORITY_MEDIUM, 'FetchMissingReplies', $item['uri-id'], $activity);
+			}
 		}
 	}
 
@@ -1850,6 +1911,16 @@ class Processor
 
 	private static function fetchReplies(string $url, array $child)
 	{
+		if (DI::baseUrl()->isLocalUrl($url)) {
+			return;
+		}
+
+		if (self::isFetched($url)) {
+			DI::logger()->debug('Url is already processed', ['url' => $url]);
+			return;
+		}
+		self::addActivityId($url);
+
 		$callstack_count = 0;
 		foreach ($child['callstack'] ?? [] as $function) {
 			if ($function == __FUNCTION__) {
@@ -1903,6 +1974,7 @@ class Processor
 				$id = $reply;
 			}
 			if (!self::alreadyKnown($id, $child['id'] ?? '')) {
+				DI::logger()->debug('Fetch missing activity', ['url' => $url, 'id' => $id]);
 				self::fetchMissingActivity($id, $child, '', Receiver::COMPLETION_REPLIES);
 				++$fetched;
 			}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1527,9 +1527,9 @@ class Transmitter
 	 *
 	 * @param array $tags Tag array
 	 * @param string $text Text containing tags like :tag:
-	 * @return string normalized text
+ 	 * @return string|null normalized text or null
 	 */
-	private static function addEmojiTags(array &$tags, string $text): string
+	private static function addEmojiTags(array &$tags, string $text): ?string
 	{
 		$emojis = Smilies::extractUsedSmilies($text, $normalized);
 		foreach ($emojis as $name => $url) {
@@ -1956,6 +1956,12 @@ class Transmitter
 
 		$data['attachment'] = self::createAttachmentList($item);
 		$data['tag']        = array_merge(self::createTagList($item, $data['quoteUrl'] ?? ''), $emojis);
+
+		$data['replies'] = [
+			'id'         => $item['uri'] . '/replies',
+			'type'       => 'Collection',
+			'totalItems' => Post::countPosts(['thr-parent-id' => $item['uri-id'], 'gravity' => Item::GRAVITY_COMMENT, 'deleted' => false, 'private' => [Item::PUBLIC, Item::UNLISTED]])
+		];
 
 		if (empty($data['location']) && (!empty($item['coord']) || !empty($item['location']))) {
 			$data['location'] = self::createLocation($item);

--- a/src/Worker/FetchMissingReplies.php
+++ b/src/Worker/FetchMissingReplies.php
@@ -1,0 +1,28 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Worker;
+
+use Friendica\DI;
+use Friendica\Protocol\ActivityPub\Processor;
+
+class FetchMissingReplies
+{
+	/**
+	 * Fetch missing replies for a given post.
+	 * @param int   $uriId Uri-Id of a post
+	 * @param array $child Child activity that initiated the thread completion
+	 *
+	 * @return void
+	 */
+	public static function execute(int $uriId, array $child = [])
+	{
+		DI::logger()->info('Start fetching missing replies', ['url' => $uriId]);
+		Processor::fetchRepliesByUriId($uriId, $child);
+		DI::logger()->info('Fetched missing replies', ['url' => $uriId]);
+	}
+}

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -467,6 +467,7 @@ return [
 	'/item/{id:\d+}'            => [
 		'/activity/{verb}' => [Module\Item\Activity::class,    [        R::POST]],
 		'/follow'          => [Module\Item\Follow::class,      [        R::POST]],
+		'/complete'        => [Module\Item\Complete::class,    [        R::POST]],
 		'/ignore'          => [Module\Item\Ignore::class,      [        R::POST]],
 		'/language'        => [Module\Item\Language::class,    [R::GET]],
 		'/pin'             => [Module\Item\Pin::class,         [        R::POST]],

--- a/static/settings.config.php
+++ b/static/settings.config.php
@@ -122,6 +122,15 @@ return [
 		// Default value comprises classic role names from RFC 2142.
 		'forbidden_nicknames' => 'info, marketing, sales, support, abuse, noc, security, postmaster, hostmaster, usenet, news, webmaster, www, uucp, ftp, root, sysop',
 
+		// fetch_replies (Constant)
+		// Defines which missing replies should be fetched from remote servers.
+		// Your choices are:
+		// FETCH_REPLIES_ALL         = 0; // Fetch all missing replies (default)
+		// FETCH_REPLIES_NONE        = 1; // Do not fetch any missing replies
+		// FETCH_REPLIES_FOLLOWED    = 2; // Fetch only replies to posts from followed accounts
+		// FETCH_REPLIES_INTERACTION = 2; // Fetch only replies to posts with local interaction (likes, shares, replies
+		'fetch_replies' => \Friendica\Protocol\ActivityPub\Processor::FETCH_REPLIES_ALL,
+
 		// compute_circle_counts (Boolean)
 		// Compute contact circle level when counting unseen network posts.
 		'compute_circle_counts' => true,

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -754,6 +754,15 @@ function doFollowThread(ident) {
 	update_item = ident.toString();
 }
 
+function doCompleteThread(ident) {
+	unpause();
+	$('#like-rotator-' + ident.toString()).show();
+	$.post('item/' + ident.toString() + '/complete', NavUpdate);
+	liking = 1;
+	force_update = true;
+	update_item = ident.toString();
+}
+
 function doStar(ident) {
 	ident = ident.toString();
 	$('#like-rotator-' + ident).show();

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-16 11:33+0100\n"
+"POT-Creation-Date: 2025-11-19 19:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -211,7 +211,7 @@ msgid "Your password has been changed at %s"
 msgstr ""
 
 #: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:316
-#: view/theme/frio/theme.php:228
+#: view/theme/frio/theme.php:229
 msgid "Messages"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Public post"
 msgstr ""
 
-#: src/Content/Conversation.php:417 src/Content/Item.php:437
+#: src/Content/Conversation.php:417 src/Content/Item.php:442
 #: src/Content/Widget/VCard.php:120 src/Model/Contact.php:1304
 #: src/Model/Profile.php:460 src/Module/Admin/Logs/View.php:80
 #: src/Module/Post/Edit.php:177
@@ -1749,7 +1749,7 @@ msgid "Display posts done by accounts with the selected account type."
 msgstr ""
 
 #: src/Content/Feature.php:131 src/Content/Widget.php:613
-#: src/Module/Admin/Site.php:459 src/Module/BaseSettings.php:113
+#: src/Module/Admin/Site.php:470 src/Module/BaseSettings.php:113
 #: src/Module/Settings/Channels.php:216 src/Module/Settings/Display.php:322
 msgid "Channels"
 msgstr ""
@@ -1857,35 +1857,39 @@ msgstr ""
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: src/Content/Item.php:431 view/theme/frio/theme.php:249
+#: src/Content/Item.php:435 view/theme/frio/theme.php:250
 msgid "Follow Thread"
 msgstr ""
 
-#: src/Content/Item.php:432 src/Model/Contact.php:1299
+#: src/Content/Item.php:436 view/theme/frio/theme.php:267
+msgid "Complete Thread"
+msgstr ""
+
+#: src/Content/Item.php:437 src/Model/Contact.php:1299
 msgid "View Status"
 msgstr ""
 
-#: src/Content/Item.php:433 src/Content/Item.php:456 src/Model/Contact.php:1234
+#: src/Content/Item.php:438 src/Content/Item.php:461 src/Model/Contact.php:1234
 #: src/Model/Contact.php:1290 src/Model/Contact.php:1300
 #: src/Module/Directory.php:143 src/Module/Settings/Profile/Index.php:279
 msgid "View Profile"
 msgstr ""
 
-#: src/Content/Item.php:434 src/Model/Contact.php:1301
+#: src/Content/Item.php:439 src/Model/Contact.php:1301
 msgid "View Photos"
 msgstr ""
 
-#: src/Content/Item.php:435 src/Model/Contact.php:1268
+#: src/Content/Item.php:440 src/Model/Contact.php:1268
 #: src/Model/Profile.php:443
 msgid "Network Posts"
 msgstr ""
 
-#: src/Content/Item.php:436 src/Model/Contact.php:1292
+#: src/Content/Item.php:441 src/Model/Contact.php:1292
 #: src/Model/Contact.php:1303
 msgid "View Contact"
 msgstr ""
 
-#: src/Content/Item.php:438 src/Module/Contact.php:453
+#: src/Content/Item.php:443 src/Module/Contact.php:453
 #: src/Module/Contact/Profile.php:564
 #: src/Module/Moderation/Blocklist/Contact.php:104
 #: src/Module/Moderation/Users/Active.php:93
@@ -1893,7 +1897,7 @@ msgstr ""
 msgid "Block"
 msgstr ""
 
-#: src/Content/Item.php:439 src/Module/Contact.php:454
+#: src/Content/Item.php:444 src/Module/Contact.php:454
 #: src/Module/Contact/Profile.php:572
 #: src/Module/Notifications/Introductions.php:126
 #: src/Module/Notifications/Introductions.php:200
@@ -1901,49 +1905,49 @@ msgstr ""
 msgid "Ignore"
 msgstr ""
 
-#: src/Content/Item.php:440 src/Module/Contact.php:455
+#: src/Content/Item.php:445 src/Module/Contact.php:455
 #: src/Module/Contact/Profile.php:580
 msgid "Collapse"
 msgstr ""
 
-#: src/Content/Item.php:441 src/Object/Post.php:291
+#: src/Content/Item.php:446 src/Object/Post.php:291
 #, php-format
 msgid "Ignore %s server"
 msgstr ""
 
-#: src/Content/Item.php:445 src/Object/Post.php:512
+#: src/Content/Item.php:450 src/Object/Post.php:512
 msgid "Detected languages"
 msgstr ""
 
-#: src/Content/Item.php:448 src/Object/Post.php:595
+#: src/Content/Item.php:453 src/Object/Post.php:595
 msgid "Raw content"
 msgstr ""
 
-#: src/Content/Item.php:453 src/Content/Widget.php:65
+#: src/Content/Item.php:458 src/Content/Widget.php:65
 #: src/Model/Contact.php:1293 src/Model/Contact.php:1305
 #: src/Module/Contact/Follow.php:152 view/theme/vier/theme.php:182
 msgid "Connect/Follow"
 msgstr ""
 
-#: src/Content/Item.php:884
+#: src/Content/Item.php:889
 msgid "Unable to fetch user."
 msgstr ""
 
-#: src/Content/Item.php:1346 src/Core/L10n.php:453
+#: src/Content/Item.php:1351 src/Core/L10n.php:453
 msgid "Undetermined"
 msgstr ""
 
-#: src/Content/Item.php:1353
+#: src/Content/Item.php:1358
 #, php-format
 msgid "%s (%s - %s): %s"
 msgstr ""
 
-#: src/Content/Item.php:1355
+#: src/Content/Item.php:1360
 #, php-format
 msgid "%s (%s): %s"
 msgstr ""
 
-#: src/Content/Item.php:1358
+#: src/Content/Item.php:1363
 #, php-format
 msgid ""
 "Detected languages in this post:\n"
@@ -1997,42 +2001,42 @@ msgstr ""
 #: src/Content/Nav.php:228 src/Module/BaseProfile.php:34
 #: src/Module/BaseSettings.php:86 src/Module/Contact.php:489
 #: src/Module/Contact/Profile.php:466 src/Module/Profile/Profile.php:282
-#: src/Module/Welcome.php:44 view/theme/frio/theme.php:217
+#: src/Module/Welcome.php:44 view/theme/frio/theme.php:218
 msgid "Profile"
 msgstr ""
 
-#: src/Content/Nav.php:228 view/theme/frio/theme.php:217
+#: src/Content/Nav.php:228 view/theme/frio/theme.php:218
 msgid "Your profile page"
 msgstr ""
 
 #: src/Content/Nav.php:229 src/Module/BaseProfile.php:50
-#: src/Module/Media/Photo/Browser.php:62 view/theme/frio/theme.php:221
+#: src/Module/Media/Photo/Browser.php:62 view/theme/frio/theme.php:222
 msgid "Photos"
 msgstr ""
 
-#: src/Content/Nav.php:229 view/theme/frio/theme.php:221
+#: src/Content/Nav.php:229 view/theme/frio/theme.php:222
 msgid "Your photos"
 msgstr ""
 
 #: src/Content/Nav.php:230 src/Module/BaseProfile.php:58
 #: src/Module/BaseProfile.php:61 src/Module/Contact.php:513
-#: view/theme/frio/theme.php:222
+#: view/theme/frio/theme.php:223
 msgid "Media"
 msgstr ""
 
-#: src/Content/Nav.php:230 view/theme/frio/theme.php:222
+#: src/Content/Nav.php:230 view/theme/frio/theme.php:223
 msgid "Your postings with media"
 msgstr ""
 
 #: src/Content/Nav.php:231 src/Content/Nav.php:291
 #: src/Module/BaseProfile.php:70 src/Module/BaseProfile.php:73
 #: src/Module/BaseProfile.php:81 src/Module/BaseProfile.php:84
-#: src/Module/Settings/Display.php:323 view/theme/frio/theme.php:223
-#: view/theme/frio/theme.php:227
+#: src/Module/Settings/Display.php:323 view/theme/frio/theme.php:224
+#: view/theme/frio/theme.php:228
 msgid "Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:231 view/theme/frio/theme.php:223
+#: src/Content/Nav.php:231 view/theme/frio/theme.php:224
 msgid "Your calendar"
 msgstr ""
 
@@ -2100,7 +2104,7 @@ msgstr ""
 #: src/Content/Text/HTML.php:873 src/Module/BaseProfile.php:112
 #: src/Module/BaseProfile.php:115 src/Module/Contact.php:181
 #: src/Module/Contact.php:411 src/Module/Contact.php:521
-#: view/theme/frio/theme.php:230
+#: view/theme/frio/theme.php:231
 msgid "Contacts"
 msgstr ""
 
@@ -2139,15 +2143,15 @@ msgstr ""
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:304 view/theme/frio/theme.php:226
+#: src/Content/Nav.php:304 view/theme/frio/theme.php:227
 msgid "Network"
 msgstr ""
 
-#: src/Content/Nav.php:304 view/theme/frio/theme.php:226
+#: src/Content/Nav.php:304 view/theme/frio/theme.php:227
 msgid "Conversations from your friends"
 msgstr ""
 
-#: src/Content/Nav.php:306 view/theme/frio/theme.php:216
+#: src/Content/Nav.php:306 view/theme/frio/theme.php:217
 msgid "Your posts and conversations"
 msgstr ""
 
@@ -2176,7 +2180,7 @@ msgstr ""
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:316 view/theme/frio/theme.php:228
+#: src/Content/Nav.php:316 view/theme/frio/theme.php:229
 msgid "Private mail"
 msgstr ""
 
@@ -2198,15 +2202,15 @@ msgstr ""
 
 #: src/Content/Nav.php:325 src/Module/Admin/Addons/Details.php:140
 #: src/Module/Admin/Themes/Details.php:85 src/Module/BaseSettings.php:177
-#: src/Module/Welcome.php:39 view/theme/frio/theme.php:229
+#: src/Module/Welcome.php:39 view/theme/frio/theme.php:230
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:325 view/theme/frio/theme.php:229
+#: src/Content/Nav.php:325 view/theme/frio/theme.php:230
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:327 view/theme/frio/theme.php:230
+#: src/Content/Nav.php:327 view/theme/frio/theme.php:231
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
@@ -3900,7 +3904,7 @@ msgstr ""
 #: src/Module/Admin/Addons/Details.php:137 src/Module/Admin/Addons/Index.php:83
 #: src/Module/Admin/Federation.php:218 src/Module/Admin/Logs/Settings.php:74
 #: src/Module/Admin/Logs/View.php:71 src/Module/Admin/Queue.php:59
-#: src/Module/Admin/Site.php:442 src/Module/Admin/Storage.php:124
+#: src/Module/Admin/Site.php:453 src/Module/Admin/Storage.php:124
 #: src/Module/Admin/Summary.php:183 src/Module/Admin/Themes/Details.php:82
 #: src/Module/Admin/Themes/Index.php:103 src/Module/Admin/Tos.php:63
 #: src/Module/Moderation/Users/Pending.php:82
@@ -3937,7 +3941,7 @@ msgid "Addon %s failed to install."
 msgstr ""
 
 #: src/Module/Admin/Addons/Index.php:85 src/Module/Admin/Features.php:69
-#: src/Module/Admin/Logs/Settings.php:76 src/Module/Admin/Site.php:445
+#: src/Module/Admin/Logs/Settings.php:76 src/Module/Admin/Site.php:456
 #: src/Module/Admin/Themes/Index.php:105 src/Module/Admin/Tos.php:72
 #: src/Module/Settings/Account.php:507 src/Module/Settings/Addons.php:64
 #: src/Module/Settings/Connectors.php:143
@@ -4139,8 +4143,8 @@ msgid "Enable Debugging"
 msgstr ""
 
 #: src/Module/Admin/Logs/Settings.php:80 src/Module/Admin/Logs/Settings.php:81
-#: src/Module/Admin/Logs/Settings.php:82 src/Module/Admin/Site.php:465
-#: src/Module/Admin/Site.php:473
+#: src/Module/Admin/Logs/Settings.php:82 src/Module/Admin/Site.php:476
+#: src/Module/Admin/Site.php:484
 msgid "<strong>Read-only</strong> because it is set by an environment variable"
 msgstr ""
 
@@ -4285,257 +4289,273 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/Module/Admin/Site.php:227
+#: src/Module/Admin/Site.php:229
 #, php-format
 msgid "%s is no valid input for maximum media size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:232
+#: src/Module/Admin/Site.php:234
 #, php-format
 msgid "%s is no valid input for maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:357 src/Module/Settings/Display.php:211
+#: src/Module/Admin/Site.php:360 src/Module/Settings/Display.php:211
 msgid "No special theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:374 src/Module/Settings/Display.php:221
+#: src/Module/Admin/Site.php:377 src/Module/Settings/Display.php:221
 #, php-format
 msgid "%s - (Experimental)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:386
-msgid "No community page"
-msgstr ""
-
-#: src/Module/Admin/Site.php:387
-msgid "No community page for visitors"
-msgstr ""
-
-#: src/Module/Admin/Site.php:388
-msgid "Public postings from users of this site"
-msgstr ""
-
 #: src/Module/Admin/Site.php:389
-msgid "Public postings from the federated network"
+msgid "Fetch replies on all posts"
 msgstr ""
 
 #: src/Module/Admin/Site.php:390
+msgid "Don't fetch replies"
+msgstr ""
+
+#: src/Module/Admin/Site.php:391
+msgid "Fetch replies on posts from followed contacts only"
+msgstr ""
+
+#: src/Module/Admin/Site.php:392
+msgid "Fetch replies on posts with interactions only"
+msgstr ""
+
+#: src/Module/Admin/Site.php:397
+msgid "No community page"
+msgstr ""
+
+#: src/Module/Admin/Site.php:398
+msgid "No community page for visitors"
+msgstr ""
+
+#: src/Module/Admin/Site.php:399
+msgid "Public postings from users of this site"
+msgstr ""
+
+#: src/Module/Admin/Site.php:400
+msgid "Public postings from the federated network"
+msgstr ""
+
+#: src/Module/Admin/Site.php:401
 msgid "Public postings from local users and the federated network"
 msgstr ""
 
-#: src/Module/Admin/Site.php:396
+#: src/Module/Admin/Site.php:407
 msgid "Multi user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:419
+#: src/Module/Admin/Site.php:430
 msgid "Closed"
 msgstr ""
 
-#: src/Module/Admin/Site.php:420
+#: src/Module/Admin/Site.php:431
 msgid "Requires approval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:421
+#: src/Module/Admin/Site.php:432
 msgid "Open"
 msgstr ""
 
-#: src/Module/Admin/Site.php:425
+#: src/Module/Admin/Site.php:436
 msgid "Don't check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:426
+#: src/Module/Admin/Site.php:437
 msgid "check the stable version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:427
+#: src/Module/Admin/Site.php:438
 msgid "check the development version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:431
+#: src/Module/Admin/Site.php:442
 msgid "none"
 msgstr ""
 
-#: src/Module/Admin/Site.php:432
+#: src/Module/Admin/Site.php:443
 msgid "Local contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:433
+#: src/Module/Admin/Site.php:444
 msgid "Interactors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:443 src/Module/BaseAdmin.php:75
+#: src/Module/Admin/Site.php:454 src/Module/BaseAdmin.php:75
 msgid "Site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:444
+#: src/Module/Admin/Site.php:455
 msgid "General Information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:446
+#: src/Module/Admin/Site.php:457
 msgid "Republish users to directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:447
+#: src/Module/Admin/Site.php:458
 msgid "Registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:448
+#: src/Module/Admin/Site.php:459
 msgid "File upload"
 msgstr ""
 
-#: src/Module/Admin/Site.php:449
+#: src/Module/Admin/Site.php:460
 msgid "Policies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:450 src/Module/Calendar/Event/Form.php:238
+#: src/Module/Admin/Site.php:461 src/Module/Calendar/Event/Form.php:238
 #: src/Module/Contact.php:532 src/Module/Profile/Profile.php:290
 msgid "Advanced"
 msgstr ""
 
-#: src/Module/Admin/Site.php:451
+#: src/Module/Admin/Site.php:462
 msgid "Auto Discovered Contact Directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:452
+#: src/Module/Admin/Site.php:463
 msgid "Performance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:453
+#: src/Module/Admin/Site.php:464
 msgid "Worker"
 msgstr ""
 
-#: src/Module/Admin/Site.php:454
+#: src/Module/Admin/Site.php:465
 msgid "Message Relay"
 msgstr ""
 
-#: src/Module/Admin/Site.php:455
+#: src/Module/Admin/Site.php:466
 msgid "Use the command \"console relay\" in the command line to add or remove relays."
 msgstr ""
 
-#: src/Module/Admin/Site.php:456
+#: src/Module/Admin/Site.php:467
 msgid "The system is not subscribed to any relays at the moment."
 msgstr ""
 
-#: src/Module/Admin/Site.php:457
+#: src/Module/Admin/Site.php:468
 msgid "The system is currently subscribed to the following relays:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:460
+#: src/Module/Admin/Site.php:471
 msgid "Relocate Node"
 msgstr ""
 
-#: src/Module/Admin/Site.php:461
+#: src/Module/Admin/Site.php:472
 msgid "Relocating your node enables you to change the DNS domain of this node and keep all the existing users and posts. This process takes a while and can only be started from the relocate console command like this:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:462
+#: src/Module/Admin/Site.php:473
 msgid "(Friendica directory)# bin/console relocate https://newdomain.com"
 msgstr ""
 
-#: src/Module/Admin/Site.php:465
+#: src/Module/Admin/Site.php:476
 msgid "Site name"
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:477
 msgid "Sender Email"
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:477
 msgid "The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:478
 msgid "Name of the system actor"
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:478
 msgid "Name of the internal system account that is used to perform ActivityPub requests. This must be an unused username. If set, this can't be changed again."
 msgstr ""
 
-#: src/Module/Admin/Site.php:468
+#: src/Module/Admin/Site.php:479
 msgid "Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:469
+#: src/Module/Admin/Site.php:480
 msgid "Email Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:470
+#: src/Module/Admin/Site.php:481
 msgid "Shortcut icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:470
+#: src/Module/Admin/Site.php:481
 msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:471
+#: src/Module/Admin/Site.php:482
 msgid "Touch icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:471
+#: src/Module/Admin/Site.php:482
 msgid "Link to an icon that will be used for tablets and mobiles."
 msgstr ""
 
-#: src/Module/Admin/Site.php:472
+#: src/Module/Admin/Site.php:483
 msgid "Additional Info"
 msgstr ""
 
-#: src/Module/Admin/Site.php:472
+#: src/Module/Admin/Site.php:483
 #, php-format
 msgid "For public servers: you can add additional information here that will be listed at %s/servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:473
+#: src/Module/Admin/Site.php:484
 msgid "System language"
 msgstr ""
 
-#: src/Module/Admin/Site.php:474
+#: src/Module/Admin/Site.php:485
 msgid "System theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:474
+#: src/Module/Admin/Site.php:485
 #, php-format
 msgid "Default system theme - may be over-ridden by user profiles - <a href=\"%s\" id=\"cnftheme\">Change default theme settings</a>"
 msgstr ""
 
-#: src/Module/Admin/Site.php:475
+#: src/Module/Admin/Site.php:486
 msgid "Mobile system theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:475
+#: src/Module/Admin/Site.php:486
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:476
+#: src/Module/Admin/Site.php:487
 msgid "Force SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:476
+#: src/Module/Admin/Site.php:487
 msgid "Force all Non-SSL requests to SSL - Attention: on some systems it could lead to endless loops."
 msgstr ""
 
-#: src/Module/Admin/Site.php:477
+#: src/Module/Admin/Site.php:488
 msgid "Show help entry from navigation menu"
 msgstr ""
 
-#: src/Module/Admin/Site.php:477
+#: src/Module/Admin/Site.php:488
 msgid "Displays the menu entry for the Help pages from the navigation menu. It is always accessible by calling /help directly."
 msgstr ""
 
-#: src/Module/Admin/Site.php:478
+#: src/Module/Admin/Site.php:489
 msgid "Single user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:478
+#: src/Module/Admin/Site.php:489
 msgid "Make this instance multi-user or single-user for the named user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:491
 msgid "Maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:491
 #, php-format
 msgid ""
 "Maximum size in bytes of uploaded images. Default is 0, which means no limits. You can put k, m, or g behind the desired value for KiB, MiB, GiB, respectively.\n"
@@ -4543,27 +4563,27 @@ msgid ""
 "\t\t\t\t\t\t\t\t\t\t\t\t\tCurrently <code>upload_max_filesize</code> is set to %s (%s byte)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Site.php:495
 msgid "Maximum image length"
 msgstr ""
 
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Site.php:495
 msgid "Maximum length in pixels of the longest side of uploaded images. Default is -1, which means no limits."
 msgstr ""
 
-#: src/Module/Admin/Site.php:485
+#: src/Module/Admin/Site.php:496
 msgid "JPEG image quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:485
+#: src/Module/Admin/Site.php:496
 msgid "Uploaded JPEGS will be saved at this quality setting [0-100]. Default is 100, which is full quality."
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:497
 msgid "Maximum media file size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:497
 #, php-format
 msgid ""
 "Maximum size in bytes of uploaded media files. Default is 0, which means no limits. You can put k, m, or g behind the desired value for KiB, MiB, GiB, respectively.\n"
@@ -4571,731 +4591,739 @@ msgid ""
 "\t\t\t\t\t\t\t\t\t\t\t\t\tCurrently <code>upload_max_filesize</code> is set to %s (%s byte)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
+#: src/Module/Admin/Site.php:502
 msgid "Register policy"
 msgstr ""
 
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:503
 msgid "Maximum Users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:503
 msgid "If defined, the register policy is automatically closed when the given number of users is reached and reopens the registry when the number drops below the limit. It only works when the policy is set to open or close, but not when the policy is set to approval."
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:504
 msgid "Maximum Daily Registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:504
 msgid "If registration is permitted above, this sets the maximum number of new user registrations to accept per day.  If register is set to closed, this setting has no effect."
 msgstr ""
 
-#: src/Module/Admin/Site.php:494
+#: src/Module/Admin/Site.php:505
 msgid "Register text"
 msgstr ""
 
-#: src/Module/Admin/Site.php:494
+#: src/Module/Admin/Site.php:505
 msgid "Will be displayed prominently on the registration page. You can use BBCode here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:506
 msgid "Forbidden Nicknames"
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:506
 msgid "Comma separated list of nicknames that are forbidden from registration. Preset is a list of role names according RFC 2142."
 msgstr ""
 
-#: src/Module/Admin/Site.php:496
+#: src/Module/Admin/Site.php:507
 msgid "Accounts abandoned after x days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:496
+#: src/Module/Admin/Site.php:507
 msgid "Will not waste system resources polling external sites for abandonded accounts. Enter 0 for no time limit."
 msgstr ""
 
-#: src/Module/Admin/Site.php:497
+#: src/Module/Admin/Site.php:508
 msgid "Allowed friend domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:497
+#: src/Module/Admin/Site.php:508
 msgid "Comma separated list of domains which are allowed to establish friendships with this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:498
+#: src/Module/Admin/Site.php:509
 msgid "Allowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:498
+#: src/Module/Admin/Site.php:509
 msgid "Comma separated list of domains which are allowed in email addresses for registrations to this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:499
+#: src/Module/Admin/Site.php:510
 msgid "Disallowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:499
+#: src/Module/Admin/Site.php:510
 msgid "Comma separated list of domains which are rejected as email addresses for registrations to this site. Wildcards are accepted."
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:511
 msgid "Block public"
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:511
 msgid "Check to block public access to all otherwise public personal pages on this site unless you are currently logged in."
 msgstr ""
 
-#: src/Module/Admin/Site.php:501
+#: src/Module/Admin/Site.php:512
 msgid "Force publish"
 msgstr ""
 
-#: src/Module/Admin/Site.php:501
+#: src/Module/Admin/Site.php:512
 msgid "Check to force all profiles on this site to be listed in the site directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:501
+#: src/Module/Admin/Site.php:512
 msgid "Enabling this may violate privacy laws like the GDPR"
 msgstr ""
 
-#: src/Module/Admin/Site.php:502
+#: src/Module/Admin/Site.php:513
 msgid "Global directory URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:502
+#: src/Module/Admin/Site.php:513
 msgid "URL to the global directory. If this is not set, the global directory is completely unavailable to the application."
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:514
 msgid "Private posts by default for new users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:514
 msgid "Set default post permissions for all new members to the default privacy circle rather than public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:515
 msgid "Don't include post content in email notifications"
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:515
 msgid "Don't include the content of a post/comment/private message/etc. in the email notifications that are sent out from this site, as a privacy measure."
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:516
 msgid "Disallow public access to addons listed in the apps menu."
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:516
 msgid "Checking this box will restrict addons listed in the apps menu to members only."
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:517
 msgid "Don't embed private images in posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:517
 msgid "Don't replace locally-hosted private photos in posts with an embedded copy of the image. This means that contacts who receive posts containing private photos will have to authenticate and load each image, which may take a while."
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:518
 msgid "Explicit Content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:518
 msgid "Set this to announce that your node is used mostly for explicit content that might not be suited for minors. This information will be published in the node information and might be used, e.g. by the global directory, to filter your node from listings of nodes to join. Additionally a note about this will be shown at the user registration page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:508
+#: src/Module/Admin/Site.php:519
 msgid "Only local search"
 msgstr ""
 
-#: src/Module/Admin/Site.php:508
+#: src/Module/Admin/Site.php:519
 msgid "Blocks search for users who are not logged in to prevent crawlers from blocking your system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:509
+#: src/Module/Admin/Site.php:520
 msgid "Blocked tags for trending tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:509
+#: src/Module/Admin/Site.php:520
 msgid "Comma separated list of hashtags that shouldn't be displayed in the trending tags."
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:521
 msgid "Cache contact avatars"
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:521
 msgid "Locally store the avatar pictures of the contacts. This uses a lot of storage space but it increases the performance."
 msgstr ""
 
-#: src/Module/Admin/Site.php:511
+#: src/Module/Admin/Site.php:522
 msgid "Allow Users to set remote_self"
 msgstr ""
 
-#: src/Module/Admin/Site.php:511
+#: src/Module/Admin/Site.php:522
 msgid "With checking this, every user is allowed to mark every contact as a remote_self in the repair contact dialog. Setting this flag on a contact causes mirroring every posting of that contact in the users stream."
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:523
 msgid "Allow Users to set up relay channels"
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:523
 msgid "If enabled, it is possible to create relay users that are used to reshare content based on user defined channels."
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:524
 msgid "Adjust the feed poll frequency"
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:524
 msgid "Automatically detect and set the best feed poll frequency."
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:525
 msgid "Minimum poll interval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:525
 msgid "Minimal distance in minutes between two polls for mail and feed contacts. Reasonable values are between 1 and 59."
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:526
 msgid "Enable multiple registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:526
 msgid "Enable users to register additional accounts for use as pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:527
 msgid "Enable OpenID"
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:527
 msgid "Enable OpenID support for registration and logins."
 msgstr ""
 
-#: src/Module/Admin/Site.php:517
+#: src/Module/Admin/Site.php:528
 msgid "Enable full name check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:517
+#: src/Module/Admin/Site.php:528
 msgid "Prevents users from registering with a display name with fewer than two parts separated by spaces."
 msgstr ""
 
-#: src/Module/Admin/Site.php:518
+#: src/Module/Admin/Site.php:529
 msgid "Email administrators on new registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:518
+#: src/Module/Admin/Site.php:529
 msgid "If enabled and the system is set to an open registration, an email for each new registration is sent to the administrators."
 msgstr ""
 
-#: src/Module/Admin/Site.php:519
+#: src/Module/Admin/Site.php:530
 msgid "Community pages for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:519
+#: src/Module/Admin/Site.php:530
 msgid "Which community pages should be available for visitors. Local users always see both pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:520
+#: src/Module/Admin/Site.php:531
 msgid "Posts per user on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:520
+#: src/Module/Admin/Site.php:531
 msgid "The maximum number of posts per user on the local community page. This is useful, when a single user floods the local community page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:521
+#: src/Module/Admin/Site.php:532
 msgid "Posts per server on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:521
+#: src/Module/Admin/Site.php:532
 msgid "The maximum number of posts per server on the global community page. This is useful, when posts from a single server flood the global community page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:523
+#: src/Module/Admin/Site.php:534
 msgid "Enable Mail support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:523
+#: src/Module/Admin/Site.php:534
 msgid "Enable built-in mail support to poll IMAP folders and to reply via mail."
 msgstr ""
 
-#: src/Module/Admin/Site.php:524
+#: src/Module/Admin/Site.php:535
 msgid "Mail support can't be enabled because the PHP IMAP module is not installed."
 msgstr ""
 
-#: src/Module/Admin/Site.php:526
+#: src/Module/Admin/Site.php:537
 msgid "Diaspora support can't be enabled because Friendica was installed into a sub directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:527
+#: src/Module/Admin/Site.php:538
 msgid "Enable Diaspora support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:527
+#: src/Module/Admin/Site.php:538
 msgid "Enable built-in Diaspora network compatibility for communicating with diaspora servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:528
+#: src/Module/Admin/Site.php:539
 msgid "Verify SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:528
+#: src/Module/Admin/Site.php:539
 msgid "If you wish, you can turn on strict certificate checking. This will mean you cannot connect (at all) to self-signed SSL sites."
 msgstr ""
 
-#: src/Module/Admin/Site.php:529
+#: src/Module/Admin/Site.php:540
 msgid "Proxy user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:529
+#: src/Module/Admin/Site.php:540
 msgid "User name for the proxy server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:530
+#: src/Module/Admin/Site.php:541
 msgid "Proxy URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:530
+#: src/Module/Admin/Site.php:541
 msgid "If you want to use a proxy server that Friendica should use to connect to the network, put the URL of the proxy here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:531
+#: src/Module/Admin/Site.php:542
 msgid "Network timeout"
 msgstr ""
 
-#: src/Module/Admin/Site.php:531
+#: src/Module/Admin/Site.php:542
 msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:532
+#: src/Module/Admin/Site.php:543
 msgid "Maximum Load Average"
 msgstr ""
 
-#: src/Module/Admin/Site.php:532
+#: src/Module/Admin/Site.php:543
 #, php-format
 msgid "Maximum system load before delivery and poll processes are deferred - default %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:533
+#: src/Module/Admin/Site.php:544
 msgid "Minimal Memory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:533
+#: src/Module/Admin/Site.php:544
 msgid "Minimal free memory in MB for the worker. Needs access to /proc/meminfo - default 0 (deactivated)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:534
+#: src/Module/Admin/Site.php:545
 msgid "Periodically optimize tables"
 msgstr ""
 
-#: src/Module/Admin/Site.php:534
+#: src/Module/Admin/Site.php:545
 msgid "Periodically optimize tables like the cache and the workerqueue"
 msgstr ""
 
-#: src/Module/Admin/Site.php:536
+#: src/Module/Admin/Site.php:547
 msgid "Discover followers/followings from contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:536
+#: src/Module/Admin/Site.php:547
 msgid "If enabled, contacts are checked for their followers and following contacts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:537
+#: src/Module/Admin/Site.php:548
 msgid "None - deactivated"
 msgstr ""
 
-#: src/Module/Admin/Site.php:538
+#: src/Module/Admin/Site.php:549
 msgid "Local contacts - contacts of our local contacts are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:539
+#: src/Module/Admin/Site.php:550
 msgid "Interactors - contacts of our local contacts and contacts who interacted on locally visible postings are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:541
+#: src/Module/Admin/Site.php:552
 msgid "Only update contacts/servers with local data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:541
+#: src/Module/Admin/Site.php:552
 msgid "If enabled, the system will only look for changes in contacts and servers that engaged on this system by either being in a contact list of a user or when posts or comments exists from the contact on this system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:553
 msgid "Only update contacts with relations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:553
 msgid "If enabled, the system will only look for changes in contacts that are in a contact list of a user on this system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:543
+#: src/Module/Admin/Site.php:554
 msgid "Synchronize the contacts with the directory server"
 msgstr ""
 
-#: src/Module/Admin/Site.php:543
+#: src/Module/Admin/Site.php:554
 msgid "if enabled, the system will check periodically for new contacts on the defined directory server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:556
 msgid "Discover contacts from other servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:556
 msgid "Periodically query other servers for contacts and servers that they know of. The system queries Friendica, Mastodon and Hubzilla servers. Keep it deactivated on small machines to decrease the database size and load."
 msgstr ""
 
-#: src/Module/Admin/Site.php:546
+#: src/Module/Admin/Site.php:557
 msgid "Days between requery"
 msgstr ""
 
-#: src/Module/Admin/Site.php:546
+#: src/Module/Admin/Site.php:557
 msgid "Number of days after which a server is requeried for their contacts and servers it knows of. This is only used when the discovery is activated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:547
+#: src/Module/Admin/Site.php:558
 msgid "Search the local directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:547
+#: src/Module/Admin/Site.php:558
 msgid "Search the local directory instead of the global directory. When searching locally, every search will be executed on the global directory in the background. This improves the search results when the search is repeated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:549
+#: src/Module/Admin/Site.php:560
 msgid "Publish server information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:549
+#: src/Module/Admin/Site.php:560
 msgid "If enabled, general server and usage data will be published. The data contains the name and version of the server, number of users with public profiles, number of posts and the activated protocols and connectors. See <a href=\"http://the-federation.info/\">the-federation.info</a> for details."
 msgstr ""
 
-#: src/Module/Admin/Site.php:551
+#: src/Module/Admin/Site.php:562
 msgid "Check upstream version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:551
+#: src/Module/Admin/Site.php:562
 msgid "Enables checking for new Friendica versions at github. If there is a new version, you will be informed in the admin panel overview."
 msgstr ""
 
-#: src/Module/Admin/Site.php:552
+#: src/Module/Admin/Site.php:563
 msgid "Suppress Tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:552
+#: src/Module/Admin/Site.php:563
 msgid "Suppress showing a list of hashtags at the end of the posting."
 msgstr ""
 
-#: src/Module/Admin/Site.php:553
+#: src/Module/Admin/Site.php:564
 msgid "Clean database"
 msgstr ""
 
-#: src/Module/Admin/Site.php:553
+#: src/Module/Admin/Site.php:564
 msgid "Remove old remote items, orphaned database records and old content from some other helper tables."
 msgstr ""
 
-#: src/Module/Admin/Site.php:554
+#: src/Module/Admin/Site.php:565
 msgid "Lifespan of remote items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:554
+#: src/Module/Admin/Site.php:565
 msgid "When the database cleanup is enabled, this defines the days after which remote items will be deleted. Own items, and marked or filed items are always kept. 0 disables this behaviour."
 msgstr ""
 
-#: src/Module/Admin/Site.php:555
+#: src/Module/Admin/Site.php:566
 msgid "Lifespan of unclaimed items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:555
+#: src/Module/Admin/Site.php:566
 msgid "When the database cleanup is enabled, this defines the days after which unclaimed remote items (mostly content from the relay) will be deleted. Default value is 90 days. Defaults to the general lifespan value of remote items if set to 0."
 msgstr ""
 
-#: src/Module/Admin/Site.php:556
+#: src/Module/Admin/Site.php:567
 msgid "Lifespan of raw conversation data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:556
+#: src/Module/Admin/Site.php:567
 msgid "The conversation data is used for ActivityPub, as well as for debug purposes. It should be safe to remove it after 14 days, default is 90 days."
 msgstr ""
 
-#: src/Module/Admin/Site.php:557
+#: src/Module/Admin/Site.php:568
 msgid "Maximum numbers of comments per post"
 msgstr ""
 
-#: src/Module/Admin/Site.php:557
+#: src/Module/Admin/Site.php:568
 msgid "How much comments should be shown for each post? Default value is 100."
 msgstr ""
 
-#: src/Module/Admin/Site.php:558
+#: src/Module/Admin/Site.php:569
 msgid "Maximum numbers of comments per post on the display page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:558
+#: src/Module/Admin/Site.php:569
 msgid "How many comments should be shown on the single view for each post? Default value is 1000."
 msgstr ""
 
-#: src/Module/Admin/Site.php:559
+#: src/Module/Admin/Site.php:570
 msgid "Items per page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:559
+#: src/Module/Admin/Site.php:570
 msgid "Number of items per page in stream pages (network, community, profile/contact statuses, search)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:560
+#: src/Module/Admin/Site.php:571
 msgid "Items per page for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:560
+#: src/Module/Admin/Site.php:571
 msgid "Number of items per page in stream pages (network, community, profile/contact statuses, search) for mobile devices."
 msgstr ""
 
-#: src/Module/Admin/Site.php:561
+#: src/Module/Admin/Site.php:572
 msgid "Temp path"
 msgstr ""
 
-#: src/Module/Admin/Site.php:561
+#: src/Module/Admin/Site.php:572
 msgid "If you have a restricted system where the webserver can't access the system temp path, enter another path here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:562
+#: src/Module/Admin/Site.php:573
 msgid "Only search in tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:562
+#: src/Module/Admin/Site.php:573
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: src/Module/Admin/Site.php:563
+#: src/Module/Admin/Site.php:574
 msgid "Limited search scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:563
+#: src/Module/Admin/Site.php:574
 msgid "If enabled, searches will only be performed in the data used for the channels and not in all posts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:564
+#: src/Module/Admin/Site.php:575
 msgid "Maximum age of items in the search table"
 msgstr ""
 
-#: src/Module/Admin/Site.php:564
+#: src/Module/Admin/Site.php:575
 msgid "Maximum age of items in the search table in days. Lower values will increase the performance and reduce disk usage. 0 means no age restriction."
 msgstr ""
 
-#: src/Module/Admin/Site.php:565
+#: src/Module/Admin/Site.php:576
 msgid "Generate counts per contact circle when calculating network count"
 msgstr ""
 
-#: src/Module/Admin/Site.php:565
+#: src/Module/Admin/Site.php:576
 msgid "On systems with users that heavily use contact circles the query can be very expensive."
 msgstr ""
 
-#: src/Module/Admin/Site.php:566
+#: src/Module/Admin/Site.php:577
 msgid "Process \"view\" activities"
 msgstr ""
 
-#: src/Module/Admin/Site.php:566
+#: src/Module/Admin/Site.php:577
 msgid "\"view\" activities are mostly geberated by Peertube systems. Per default they are not processed for performance reasons. Only activate this option on performant system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:567
+#: src/Module/Admin/Site.php:578
 msgid "Days, after which a contact is archived"
 msgstr ""
 
-#: src/Module/Admin/Site.php:567
+#: src/Module/Admin/Site.php:578
 msgid "Number of days that we try to deliver content or to update the contact data before we archive a contact."
 msgstr ""
 
-#: src/Module/Admin/Site.php:569
+#: src/Module/Admin/Site.php:580
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:569
+#: src/Module/Admin/Site.php:580
 #, php-format
 msgid "On shared hosters set this to %d. On larger systems, values of %d are great. Default value is %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:570
+#: src/Module/Admin/Site.php:581
 msgid "Maximum load for workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:570
+#: src/Module/Admin/Site.php:581
 msgid "Maximum load that causes a cooldown before each worker function call."
 msgstr ""
 
-#: src/Module/Admin/Site.php:571
+#: src/Module/Admin/Site.php:582
 msgid "Enable fastlane"
 msgstr ""
 
-#: src/Module/Admin/Site.php:571
+#: src/Module/Admin/Site.php:582
 msgid "When enabed, the fastlane mechanism starts an additional worker if processes with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: src/Module/Admin/Site.php:572
+#: src/Module/Admin/Site.php:583
 msgid "Decoupled receiver"
 msgstr ""
 
-#: src/Module/Admin/Site.php:572
+#: src/Module/Admin/Site.php:583
 msgid "Decouple incoming ActivityPub posts by processing them in the background via a worker process. Only enable this on fast systems."
 msgstr ""
 
-#: src/Module/Admin/Site.php:573
+#: src/Module/Admin/Site.php:584
+msgid "Fetch replies mode"
+msgstr ""
+
+#: src/Module/Admin/Site.php:584
+msgid "Missing replies can be fetched upon receipt of an ActivityPub post."
+msgstr ""
+
+#: src/Module/Admin/Site.php:585
 msgid "Cron interval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:573
+#: src/Module/Admin/Site.php:585
 msgid "Minimal period in minutes between two calls of the \"Cron\" worker job."
 msgstr ""
 
-#: src/Module/Admin/Site.php:574
+#: src/Module/Admin/Site.php:586
 msgid "Worker defer limit"
 msgstr ""
 
-#: src/Module/Admin/Site.php:574
+#: src/Module/Admin/Site.php:586
 msgid "Per default the systems tries delivering for 15 times before dropping it."
 msgstr ""
 
-#: src/Module/Admin/Site.php:575
+#: src/Module/Admin/Site.php:587
 msgid "Worker fetch limit"
 msgstr ""
 
-#: src/Module/Admin/Site.php:575
+#: src/Module/Admin/Site.php:587
 msgid "Number of worker tasks that are fetched in a single query. Higher values should increase the performance, too high values will mostly likely decrease it. Only change it, when you know how to measure the performance of your system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:577
+#: src/Module/Admin/Site.php:589
 msgid "Direct relay transfer"
 msgstr ""
 
-#: src/Module/Admin/Site.php:577
+#: src/Module/Admin/Site.php:589
 msgid "Enables the direct transfer to other servers without using the relay servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:578
+#: src/Module/Admin/Site.php:590
 msgid "Relay scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:578
+#: src/Module/Admin/Site.php:590
 msgid "Can be \"all\" or \"tags\". \"all\" means that every public post should be received. \"tags\" means that only posts with selected tags should be received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:578 src/Module/Contact/Profile.php:349
+#: src/Module/Admin/Site.php:590 src/Module/Contact/Profile.php:349
 #: src/Module/Settings/Display.php:256
 #: src/Module/Settings/TwoFactor/Index.php:132
 msgid "Disabled"
 msgstr ""
 
-#: src/Module/Admin/Site.php:578
+#: src/Module/Admin/Site.php:590
 msgid "all"
 msgstr ""
 
-#: src/Module/Admin/Site.php:578
+#: src/Module/Admin/Site.php:590
 msgid "tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:579
+#: src/Module/Admin/Site.php:591
 msgid "Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:579
+#: src/Module/Admin/Site.php:591
 msgid "Comma separated list of tags for the \"tags\" subscription."
 msgstr ""
 
-#: src/Module/Admin/Site.php:580
+#: src/Module/Admin/Site.php:592
 msgid "Deny Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:580
+#: src/Module/Admin/Site.php:592
 msgid "Comma separated list of tags that are rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:581
+#: src/Module/Admin/Site.php:593
 msgid "Maximum amount of tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:581
+#: src/Module/Admin/Site.php:593
 msgid "Maximum amount of tags in a post before it is rejected as spam. The post has to contain at least one link. Posts from subscribed accounts will not be rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:582
+#: src/Module/Admin/Site.php:594
 msgid "Allow user tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:582
+#: src/Module/Admin/Site.php:594
 msgid "If enabled, the tags from the saved searches will used for the \"tags\" subscription in addition to the \"relay_server_tags\"."
 msgstr ""
 
-#: src/Module/Admin/Site.php:583
+#: src/Module/Admin/Site.php:595
 msgid "Deny undetected languages"
 msgstr ""
 
-#: src/Module/Admin/Site.php:583
+#: src/Module/Admin/Site.php:595
 msgid "If enabled, posts with undetected languages will be rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:584
+#: src/Module/Admin/Site.php:596
 msgid "Language Quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:584
+#: src/Module/Admin/Site.php:596
 msgid "The minimum language quality that is required to accept the post."
 msgstr ""
 
-#: src/Module/Admin/Site.php:585
+#: src/Module/Admin/Site.php:597
 msgid "Number of languages for the language detection"
 msgstr ""
 
-#: src/Module/Admin/Site.php:585
+#: src/Module/Admin/Site.php:597
 msgid "The system detects a list of languages per post. Only if the desired languages are in the list, the message will be accepted. The higher the number, the more posts will be falsely detected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:587
+#: src/Module/Admin/Site.php:599
 msgid "Maximum age of channel"
 msgstr ""
 
-#: src/Module/Admin/Site.php:587
+#: src/Module/Admin/Site.php:599
 msgid "This defines the maximum age in hours of items that should be displayed in channels. This affects the channel performance."
 msgstr ""
 
-#: src/Module/Admin/Site.php:588
+#: src/Module/Admin/Site.php:600
 msgid "Maximum number of channel posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:588
+#: src/Module/Admin/Site.php:600
 msgid "For performance reasons, the channels use a dedicated table to store content. The higher the value the slower the channels."
 msgstr ""
 
-#: src/Module/Admin/Site.php:589
+#: src/Module/Admin/Site.php:601
 msgid "Interaction score days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:589
+#: src/Module/Admin/Site.php:601
 msgid "Number of days that are used to calculate the interaction score."
 msgstr ""
 
-#: src/Module/Admin/Site.php:590
+#: src/Module/Admin/Site.php:602
 msgid "Maximum number of posts per author"
 msgstr ""
 
-#: src/Module/Admin/Site.php:590
+#: src/Module/Admin/Site.php:602
 msgid "Maximum number of posts per page by author if the contact frequency is set to \"Display only few posts\". If there are more posts, then the post with the most interactions will be displayed."
 msgstr ""
 
-#: src/Module/Admin/Site.php:591
+#: src/Module/Admin/Site.php:603
 msgid "Sharer interaction days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:591
+#: src/Module/Admin/Site.php:603
 msgid "Number of days of the last interaction that are used to define which sharers are used for the \"sharers of sharers\" channel."
 msgstr ""
 
-#: src/Module/Admin/Site.php:594
+#: src/Module/Admin/Site.php:606
 msgid "Start Relocation"
 msgstr ""
 
@@ -6271,11 +6299,12 @@ msgstr[1] ""
 #: src/Module/Contact/Follow.php:56 src/Module/Contact/Redir.php:47
 #: src/Module/Contact/Redir.php:208 src/Module/Conversation/Community.php:156
 #: src/Module/Debug/ItemBody.php:30 src/Module/Diaspora/Receive.php:45
-#: src/Module/Item/Display.php:82 src/Module/Item/Feed.php:45
-#: src/Module/Item/Follow.php:27 src/Module/Item/Ignore.php:27
-#: src/Module/Item/Language.php:43 src/Module/Item/Pin.php:27
-#: src/Module/Item/Pin.php:42 src/Module/Item/Searchtext.php:39
-#: src/Module/Item/Star.php:28 src/Module/Update/Display.php:23
+#: src/Module/Item/Complete.php:25 src/Module/Item/Display.php:82
+#: src/Module/Item/Feed.php:45 src/Module/Item/Follow.php:27
+#: src/Module/Item/Ignore.php:27 src/Module/Item/Language.php:43
+#: src/Module/Item/Pin.php:27 src/Module/Item/Pin.php:42
+#: src/Module/Item/Searchtext.php:39 src/Module/Item/Star.php:28
+#: src/Module/Update/Display.php:23
 msgid "Access denied."
 msgstr ""
 
@@ -6556,7 +6585,7 @@ msgid "Actions"
 msgstr ""
 
 #: src/Module/Contact/Profile.php:464
-#: src/Module/Settings/TwoFactor/Index.php:126 view/theme/frio/theme.php:216
+#: src/Module/Settings/TwoFactor/Index.php:126 view/theme/frio/theme.php:217
 msgid "Status"
 msgstr ""
 
@@ -11904,11 +11933,11 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: view/theme/frio/theme.php:198
+#: view/theme/frio/theme.php:199
 msgid "Guest"
 msgstr ""
 
-#: view/theme/frio/theme.php:201
+#: view/theme/frio/theme.php:202
 msgid "Visitor"
 msgstr ""
 

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -145,6 +145,7 @@
 		{{include file="field_input.tpl" field=$worker_load_cooldown}}
 		{{include file="field_checkbox.tpl" field=$worker_fastlane}}
 		{{include file="field_checkbox.tpl" field=$decoupled_receiver}}
+		{{include file="field_select.tpl" field=$fetch_replies}}
 		{{include file="field_input.tpl" field=$worker_defer_limit}}
 		{{include file="field_input.tpl" field=$worker_fetch_limit}}
 

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -297,6 +297,7 @@
 						{{include file="field_input.tpl" field=$worker_load_cooldown}}
 						{{include file="field_checkbox.tpl" field=$worker_fastlane}}
 						{{include file="field_checkbox.tpl" field=$decoupled_receiver}}
+						{{include file="field_select.tpl" field=$fetch_replies}}
 						{{include file="field_input.tpl" field=$worker_defer_limit}}
 						{{include file="field_input.tpl" field=$worker_fetch_limit}}
 					</div>

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -225,6 +225,12 @@
 							</li>
 						{{/if}}
 
+						{{if $item.complete_thread}}
+							<li role="menuitem">
+								<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="fa fa-download" aria-hidden="true"></i>&nbsp;{{$item.complete_thread.title}}</a>
+							</li>
+						{{/if}}
+
 						{{if $item.language}}
 						<li role="menuitem">
 							<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&nbsp;{{$item.language}}</a>
@@ -241,7 +247,7 @@
 							</li>
 						{{/if}}
 
-						{{if ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread) && ($item.ignore || $item.drop.dropping)}}
+						{{if ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.complete_thread) && ($item.ignore || $item.drop.dropping)}}
 							<li class="divider"><hr></li>
 						{{/if}}
 

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -441,6 +441,12 @@ as the value of $top_child_total (this is done at the end of this file)
 				</li>
 				{{/if}}
 
+				{{if $item.complete_thread}}
+				<li role="menuitem">
+						<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="fa fa-download" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
+				</li>
+				{{/if}}
+
 				{{if $item.language}}
 				<li role="menuitem">
 						<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
@@ -457,7 +463,7 @@ as the value of $top_child_total (this is done at the end of this file)
 				</li>
 				{{/if}}
 
-				{{if ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread) && ($item.ignore || ($item.drop && $item.drop.dropping))}}
+				{{if ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.complete_thread) && ($item.ignore || ($item.drop && $item.drop.dropping))}}
 				<li class="divider"><hr></li>
 				{{/if}}
 
@@ -628,6 +634,12 @@ as the value of $top_child_total (this is done at the end of this file)
 								</li>
 							{{/if}}
 
+							{{if $item.complete_thread}}
+								<li role="menuitem">
+									<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="fa fa-download" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
+								</li>
+							{{/if}}
+
 							{{if $item.language}}
 								<li role="menuitem">
 									<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
@@ -638,7 +650,7 @@ as the value of $top_child_total (this is done at the end of this file)
 								<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
 							</li>
 
-							{{if ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread) && ($item.ignore || ($item.drop && $item.drop.dropping))}}
+							{{if ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.complete_thread) && ($item.ignore || ($item.drop && $item.drop.dropping))}}
 								<li class="divider"><hr></li>
 							{{/if}}
 

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -16,6 +16,7 @@ use Friendica\App\Mode;
 use Friendica\AppHelper;
 use Friendica\Content\Text\Plaintext;
 use Friendica\Core\Hook;
+use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\DI;
@@ -252,4 +253,21 @@ function frio_display_item(&$arr)
 		];
 	}
 	$arr['output']['follow_thread'] = $followThread;
+
+	$completeThread = [];
+	if (
+		DI::userSession()->getLocalUserId()
+		&& in_array($arr['item']['uid'], [0, DI::userSession()->getLocalUserId()])
+		&& $arr['item']['network'] == Protocol::ACTIVITYPUB
+		&& $arr['item']['gravity'] == Item::GRAVITY_PARENT
+		&& !$arr['item']['self']
+	) {
+		$completeThread = [
+			'menu'   => 'complete_thread',
+			'title'  => DI::l10n()->t('Complete Thread'),
+			'action' => 'doCompleteThread(' . $arr['item']['uri-id'] . ');',
+			'href'   => '#'
+		];
+	}
+	$arr['output']['complete_thread'] = $completeThread;
 }


### PR DESCRIPTION
Fixes #14850, fixes #14572. This partially fixes it by fetching all replies when a post is received or updated. Also we now offer the needed endpoints to support the fetching of replies. And finally there is a new menu action to complete threads.