### PR TITLE
Issue 15321: Fetch the latest posts from contacts

### DIFF
--- a/src/Module/Contact/Profile.php
+++ b/src/Module/Contact/Profile.php
@@ -22,6 +22,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
+use Friendica\Core\Worker;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\Event\ArrayFilterEvent;
@@ -212,6 +213,10 @@ class Profile extends BaseModule
 
 			if ($cmd === 'updateprofile') {
 				$this->updateContactFromProbe($contact['id']);
+			}
+
+			if ($cmd === 'fetchoutbox') {
+				Worker::add(Worker::PRIORITY_MEDIUM, 'FetchOutbox', $contact['id'], 0);
 			}
 
 			if ($cmd === 'block') {
@@ -557,6 +562,16 @@ class Profile extends BaseModule
 				'title' => '',
 				'sel'   => '',
 				'id'    => 'updateprofile',
+			];
+		}
+
+		if (in_array($contact['network'], [Protocol::ACTIVITYPUB, Protocol::DFRN])) {
+			$contact_actions['fetchoutbox'] = [
+				'label' => $this->t('Fetch latest posts'),
+				'url'   => 'contact/' . $contact['id'] . '/fetchoutbox?t=' . $formSecurityToken,
+				'title' => '',
+				'sel'   => '',
+				'id'    => 'fetchoutbox',
 			];
 		}
 

--- a/src/Protocol/ActivityPub.php
+++ b/src/Protocol/ActivityPub.php
@@ -214,10 +214,11 @@ class ActivityPub
 	 *
 	 * @param string  $url
 	 * @param integer $uid User ID
+	 * @param integer $max Maximum number of activities to fetch (0 = all)
 	 * @return void
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public static function fetchOutbox(string $url, int $uid)
+	public static function fetchOutbox(string $url, int $uid, int $max = 0)
 	{
 		$data = HTTPSignature::fetch($url, $uid);
 		if (empty($data)) {
@@ -235,9 +236,14 @@ class ActivityPub
 			$items = [];
 		}
 
+		$count = 0;
 		foreach ($items as $activity) {
 			$ldactivity = JsonLD::compact($activity);
 			ActivityPub\Receiver::processActivity($ldactivity, '', $uid, true);
+			if ($max > 0 && ++$count >= $max) {
+				DI::logger()->info('Reached maximum number of activities to fetch', ['url' => $url, 'uid' => $uid, 'max' => $max]);
+				return;
+			}
 		}
 	}
 

--- a/src/Worker/FetchOutbox.php
+++ b/src/Worker/FetchOutbox.php
@@ -1,0 +1,34 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Worker;
+
+use Friendica\DI;
+use Friendica\Model\Contact;
+use Friendica\Protocol\ActivityPub;
+
+class FetchOutbox
+{
+	/**
+	 * Fetch posts for a given contact..
+	 * @param int $cid Contact ID
+	 * @param int $uid User ID
+	 *
+	 * @return void
+	 */
+	public static function execute(int $cid, int $uid)
+	{
+		DI::logger()->info('Start fetching posts for a given contact', ['cid' => $cid, 'uid' => $uid]);
+		$account = Contact::getAccountById($cid, ['ap-outbox']);
+		if (!isset($account['ap-outbox'])) {
+			DI::logger()->info('No outbox found for the given contact', ['cid' => $cid, 'uid' => $uid]);
+			return;
+		}
+		ActivityPub::fetchOutbox($account['ap-outbox'], $uid, DI::config()->get('system', 'max_feed_items'));
+		DI::logger()->info('Fetched posts for a given contact', ['cid' => $cid, 'uid' => $uid]);
+	}
+}

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -386,7 +386,7 @@ return [
 	'/contact'   => [
 		'[/]'                         => [Module\Contact::class,                [R::GET]],
 		'/{id:\d+}[/]'                => [Module\Contact\Profile::class,        [R::GET, R::POST]],
-		'/{id:\d+}/{action:block|ignore|collapse|update|updateprofile}'
+		'/{id:\d+}/{action:block|ignore|collapse|update|updateprofile|fetchoutbox}'
 		                              => [Module\Contact\Profile::class,        [R::GET]],
 		'/{id:\d+}/advanced'          => [Module\Contact\Advanced::class,       [R::GET, R::POST]],
 		'/{id:\d+}/conversations'     => [Module\Contact\Conversations::class,  [R::GET]],

--- a/view/templates/contact_edit.tpl
+++ b/view/templates/contact_edit.tpl
@@ -27,6 +27,7 @@
 							{{if $lblsuggest}}<li role="menuitem"><a href="{{$contact_actions.suggest.url}}" title="{{$contact_actions.suggest.title}}">{{$contact_actions.suggest.label}}</a></li>{{/if}}
 							{{if $poll_enabled}}<li role="menuitem"><a href="{{$contact_actions.update.url}}" title="{{$contact_actions.update.title}}">{{$contact_actions.update.label}}</a></li>{{/if}}
 							{{if $contact_actions.updateprofile}}<li role="menuitem"><a href="{{$contact_actions.updateprofile.url}}" title="{{$contact_actions.updateprofile.title}}">{{$contact_actions.updateprofile.label}}</a></li>{{/if}}
+							{{if $contact_actions.}}<li role="menuitem"><a href="{{$contact_actions.fetchoutbox.url}}" title="{{$contact_actions.fetchoutbox.title}}">{{$contact_actions.fetchoutbox.label}}</a></li>{{/if}}
 							<li class="divider"></li>
 							<li role="menuitem"><a href="#" title="{{$contact_actions.block.title}}" onclick="window.location.href='{{$contact_actions.block.url}}'; return false;">{{$contact_actions.block.label}}</a></li>
 							<li role="menuitem"><a href="#" title="{{$contact_actions.ignore.title}}" onclick="window.location.href='{{$contact_actions.ignore.url}}'; return false;">{{$contact_actions.ignore.label}}</a></li>

--- a/view/theme/frio/templates/contact_edit.tpl
+++ b/view/theme/frio/templates/contact_edit.tpl
@@ -30,6 +30,7 @@
 							{{if $lblsuggest}}<li><a role="menuitem" href="{{$contact_actions.suggest.url}}" title="{{$contact_actions.suggest.title}}">{{$contact_actions.suggest.label}}</a></li>{{/if}}
 							{{if $poll_enabled}}<li><a role="menuitem" href="{{$contact_actions.update.url}}" title="{{$contact_actions.update.title}}">{{$contact_actions.update.label}}</a></li>{{/if}}
 							{{if $contact_actions.updateprofile}}<li><a role="menuitem" href="{{$contact_actions.updateprofile.url}}" title="{{$contact_actions.updateprofile.title}}">{{$contact_actions.updateprofile.label}}</a></li>{{/if}}
+							{{if $contact_actions.fetchoutbox}}<li><a role="menuitem" href="{{$contact_actions.fetchoutbox.url}}" title="{{$contact_actions.fetchoutbox.title}}">{{$contact_actions.fetchoutbox.label}}</a></li>{{/if}}
 							{{if $lblsuggest || $poll_enabled || $contact_actions.updateprofile}}
 							<li class="divider"></li>
 							{{/if}}


### PR DESCRIPTION
Fixes #15321.

There is a new action called "fetch latest posts" on the contact page that will fetch the latest 20 posts of a contact:
<img width="228" height="231" alt="image" src="https://github.com/user-attachments/assets/ef4d6d61-8c33-410b-8a1b-fd708fd80300" />

In the future this could be extended so that the posts are fetched whenever a user adds a new contact.