### PR TITLE
Settings: Theme - Minor adjustment to accent colour selection

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3205,6 +3205,7 @@ details.profile-jot-net[open] summary:before {
 
 #frio-accents input[type="radio"]:checked + label::before {
 	content: '\f00c';
+	color: white;
 	font-family: ForkAwesome;
 	font-weight: normal;
 	font-size: 18px;


### PR DESCRIPTION
This one line change just makes the checkmark on the selected accent colour white, to make it stand out more.