### PR TITLE
Fix message transmission to Diaspora

### DIFF
--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -223,7 +223,7 @@ class Mail
 		}
 
 		if ($post_id) {
-			Worker::add(Worker::PRIORITY_HIGH, "Notifier", Delivery::MAIL, $post_id);
+			Worker::add(Worker::PRIORITY_HIGH, "Notifier", Delivery::MAIL, $post_id, $sender_uid);
 			return intval($post_id);
 		} else {
 			return -3;

--- a/src/Model/Photo.php
+++ b/src/Model/Photo.php
@@ -436,6 +436,10 @@ class Photo
 		$storage     = '';
 		$img_str     = $image->asString();
 
+		if (!is_string($img_str)) {
+			return false;
+		}
+
 		try {
 			if (DBA::isResult($existing_photo)) {
 				$backend_ref = (string)$existing_photo['backend-ref'];


### PR DESCRIPTION
Private messages (mails) to Diaspora hadn't worked any more. This is now fixed. Also (unrelated) this PR contains a a precaution for a possible problem during the photo storage.