### PR TITLE
fix file browser icons

### DIFF
--- a/src/Module/Media/Attachment/Browser.php
+++ b/src/Module/Media/Attachment/Browser.php
@@ -76,12 +76,12 @@ class Browser extends BaseModule
 	protected function map_files(array $record): array
 	{
 		list($m1, $m2) = explode('/', $record['filetype']);
-		$filetype      = file_exists(sprintf('images/icons/%s.png', $m1) ? $m1 : 'text');
+		$filetype      = file_exists(sprintf('images/icons/%s.png', $m1)) ? $m1 : 'text';
 
 		return [
 			sprintf('%s/attach/%s', $this->baseUrl, $record['id']),
 			$record['filename'],
-			sprintf('%s/images/icon/16/%s.png', $this->baseUrl, $filetype),
+			sprintf('%s/images/icons/%s.png', $this->baseUrl, $filetype),
 		];
 	}
 }


### PR DESCRIPTION
In the file browser when viewing attachments the icons are missing. This was due to a misplaced parenthesis and "icon" instead of "icons" (plural) in the image path. My change does not load the 16x16 pixel image but the 72x72, which IMO should then be scaled to the desired size in global.css, so it can be overridden in a theme stylesheet and not be stuck with a tiny image that is blurry if you make it bigger.

Despite my opinion that this feature either needs to be removed or the file manager finished so you can at least organize/delete files, and until that happens people should be discouraged from using it all, at the very least it should display the file type icons.