### PR TITLE
file browser attachment icon size

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -352,7 +352,7 @@ img.acpopup-img {
 .fbrowser.photo a img, .fbrowser.photo .btn-link img { height: 48px; }
 .fbrowser.photo a p, .fbrowser.photo .btn-link p { display: none;}
 .fbrowser.attachment .photo-album-image-wrapper { float:none;  white-space: nowrap; }
-.fbrowser.attachment img { display: inline; }
+.fbrowser.attachment img { display: inline; height: 16px; width: 16px; }
 .fbrowser.attachment p  { display: inline; white-space: nowrap; }
 .fbrowser .upload { clear: both; padding-top: 1em;}
 .fbrowser .error { background: #ffeeee; border: 1px solid #994444; color: #994444; padding: 0.5em;}


### PR DESCRIPTION
Sets file browser attachment icon size to 16x16 pixels rather than loading the 16x16 sized image so themes can override for other sizes. To make it work with my other commit about this. Sorry, I still have no clue how to combine multiple commits into one PR or if it's even possible to do with the GitHub web UI.