### PR TITLE
Show new posts immediately after posting

### DIFF
--- a/view/theme/frio/templates/jot-header.tpl
+++ b/view/theme/frio/templates/jot-header.tpl
@@ -107,6 +107,8 @@
 			// This cancels the automatic redirection after item submission
 			formData.delete('return');
 
+			let isNewPost = !formData.get('post_id');
+
 			$.ajax({
 				url: 'item',
 				data: formData,
@@ -129,10 +131,17 @@
 				$share.button('reset');
 				$sharePreview.button('reset');
 
-				// Force the display update of the edited post/comment
+				force_update = true;
 				if (formData.get('post_id')) {
-					force_update = true;
 					update_item = formData.get('post_id');
+				}
+
+				if (isNewPost) {
+					let scrollHandler = function() {
+						$('html, body').animate({ scrollTop: 0 }, 400);
+						document.removeEventListener('postprocess_liveupdate', scrollHandler);
+					};
+					document.addEventListener('postprocess_liveupdate', scrollHandler);
 				}
 
 				NavUpdate();


### PR DESCRIPTION
When users post from the modal, they're returned to the timeline but their new post isn't visible - they need to manually refresh the page.

What was changed:
- Sets `force_update = true` for all posts (not just edits)
- Automatically scrolls to the top after the timeline updates
- Only scrolls for new posts, not when editing existing ones

Tested with new posts and edits - both work as expected.

fixes #12167, #15312