### PR TITLE
Show alert with link after posting instead of scrolling

### DIFF
--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -323,16 +323,18 @@ class Conversation
 
 		$tpl = Renderer::getMarkupTemplate('jot-header.tpl');
 		$this->page['htmlhead'] .= Renderer::replaceMacros($tpl, [
-			'$newpost'   => 'true',
-			'$geotag'    => $geotag,
-			'$nickname'  => $x['nickname'],
-			'$ispublic'  => $this->l10n->t('Visible to <strong>everybody</strong>'),
-			'$linkurl'   => $this->l10n->t('Please enter a image/video/audio/webpage URL:'),
-			'$term'      => $this->l10n->t('Tag term:'),
-			'$fileas'    => $this->l10n->t('Save to Folder'),
-			'$whereareu' => $this->l10n->t('Where are you right now?'),
-			'$delitems'  => $this->l10n->t("Delete item\x28s\x29?"),
-			'$is_mobile' => $this->mode->isMobile(),
+			'$newpost'       => 'true',
+			'$geotag'        => $geotag,
+			'$nickname'      => $x['nickname'],
+			'$ispublic'      => $this->l10n->t('Visible to <strong>everybody</strong>'),
+			'$linkurl'       => $this->l10n->t('Please enter a image/video/audio/webpage URL:'),
+			'$term'          => $this->l10n->t('Tag term:'),
+			'$fileas'        => $this->l10n->t('Save to Folder'),
+			'$whereareu'     => $this->l10n->t('Where are you right now?'),
+			'$delitems'      => $this->l10n->t("Delete item\x28s\x29?"),
+			'$postPublished' => $this->l10n->t('Post published.'),
+			'$goToPost'      => $this->l10n->t('Go to post'),
+			'$is_mobile'     => $this->mode->isMobile(),
 		]);
 
 		$jotplugins = $this->eventDispatcher->dispatch(

--- a/src/Module/Post/Edit.php
+++ b/src/Module/Post/Edit.php
@@ -99,10 +99,12 @@ class Edit extends BaseModule
 		]);
 
 		$this->page['htmlhead'] .= Renderer::replaceMacros(Renderer::getMarkupTemplate('jot-header.tpl'), [
-			'$ispublic'  => '&nbsp;',
-			'$geotag'    => '',
-			'$nickname'  => $this->session->getLocalUserNickname(),
-			'$is_mobile' => $this->mode->isMobile(),
+			'$ispublic'      => '&nbsp;',
+			'$geotag'        => '',
+			'$nickname'      => $this->session->getLocalUserNickname(),
+			'$postPublished' => $this->t('Post published.'),
+			'$goToPost'      => $this->t('Go to post'),
+			'$is_mobile'     => $this->mode->isMobile(),
 		]);
 
 		if (strlen($item['allow_cid']) || strlen($item['allow_gid']) || strlen($item['deny_cid']) || strlen($item['deny_gid'])) {

--- a/view/global.css
+++ b/view/global.css
@@ -842,3 +842,33 @@ a:has(img.has-alt-description)::after {
 #change-profile-picture:hover {
 	opacity: 1;
 }
+
+/* Post published alert - toast notification style */
+#post-published-alert {
+	position: fixed;
+	bottom: 20px;
+	right: 20px;
+	z-index: 1050;
+	min-width: 250px;
+	max-width: 350px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+	border-radius: 4px;
+}
+
+#post-published-alert .alert-link {
+	text-decoration: underline;
+}
+
+/* Highlight animation for new posts */
+.highlight-post {
+	animation: highlight-fade 2s ease-out;
+}
+
+@keyframes highlight-fade {
+	0% {
+		background-color: rgba(49, 112, 143, 0.2);
+	}
+	100% {
+		background-color: transparent;
+	}
+}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-25 18:03+0100\n"
+"POT-Creation-Date: 2025-11-30 14:45+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -274,18 +274,18 @@ msgstr ""
 msgid "Your message:"
 msgstr ""
 
-#: mod/message.php:188 mod/message.php:345 src/Content/Conversation.php:362
-#: src/Module/Post/Edit.php:127
+#: mod/message.php:188 mod/message.php:345 src/Content/Conversation.php:364
+#: src/Module/Post/Edit.php:129
 msgid "Upload photo"
 msgstr ""
 
-#: mod/message.php:189 mod/message.php:346 src/Module/Post/Edit.php:131
+#: mod/message.php:189 mod/message.php:346 src/Module/Post/Edit.php:133
 msgid "Insert web link"
 msgstr ""
 
 #: mod/message.php:190 mod/message.php:348 mod/photos.php:1257
-#: src/Content/Conversation.php:393 src/Content/Conversation.php:1572
-#: src/Module/Item/Compose.php:205 src/Module/Post/Edit.php:141
+#: src/Content/Conversation.php:395 src/Content/Conversation.php:1574
+#: src/Module/Item/Compose.php:205 src/Module/Post/Edit.php:143
 #: src/Object/Post.php:617
 msgid "Please wait"
 msgstr ""
@@ -353,7 +353,7 @@ msgid "Personal notes are visible only by yourself."
 msgstr ""
 
 #: mod/notes.php:46 src/Module/Admin/Storage.php:128
-#: src/Module/Filer/SaveTag.php:60 src/Module/Post/Edit.php:125
+#: src/Module/Filer/SaveTag.php:60 src/Module/Post/Edit.php:127
 #: src/Module/Settings/Channels.php:220
 msgid "Save"
 msgstr ""
@@ -468,8 +468,8 @@ msgstr ""
 msgid "Do not show a status post for this upload"
 msgstr ""
 
-#: mod/photos.php:691 mod/photos.php:1052 src/Content/Conversation.php:395
-#: src/Module/Calendar/Event/Form.php:239 src/Module/Post/Edit.php:179
+#: mod/photos.php:691 mod/photos.php:1052 src/Content/Conversation.php:397
+#: src/Module/Calendar/Event/Form.php:239 src/Module/Post/Edit.php:181
 msgid "Permissions"
 msgstr ""
 
@@ -481,11 +481,11 @@ msgstr ""
 msgid "Delete Album"
 msgstr ""
 
-#: mod/photos.php:758 mod/photos.php:858 src/Content/Conversation.php:410
+#: mod/photos.php:758 mod/photos.php:858 src/Content/Conversation.php:412
 #: src/Module/Contact/Follow.php:158 src/Module/Contact/Revoke.php:92
 #: src/Module/Contact/Unfollow.php:112
 #: src/Module/Media/Attachment/Browser.php:64
-#: src/Module/Media/Photo/Browser.php:76 src/Module/Post/Edit.php:163
+#: src/Module/Media/Photo/Browser.php:76 src/Module/Post/Edit.php:165
 #: src/Module/Post/Tag/Remove.php:96 src/Module/Profile/RemoteFollow.php:120
 #: src/Module/Security/TwoFactor/SignOut.php:106
 msgid "Cancel"
@@ -600,23 +600,23 @@ msgid "Comment"
 msgstr ""
 
 #: mod/photos.php:1099 mod/photos.php:1155 mod/photos.php:1235
-#: src/Content/Conversation.php:407 src/Module/Calendar/Event/Form.php:234
-#: src/Module/Item/Compose.php:200 src/Module/Post/Edit.php:161
+#: src/Content/Conversation.php:409 src/Module/Calendar/Event/Form.php:234
+#: src/Module/Item/Compose.php:200 src/Module/Post/Edit.php:163
 #: src/Object/Post.php:1176
 msgid "Preview"
 msgstr ""
 
-#: mod/photos.php:1100 src/Content/Conversation.php:361 src/Content/Nav.php:113
-#: src/Module/Post/Edit.php:126 src/Object/Post.php:1164
+#: mod/photos.php:1100 src/Content/Conversation.php:363 src/Content/Nav.php:113
+#: src/Module/Post/Edit.php:128 src/Object/Post.php:1164
 msgid "Loading..."
 msgstr ""
 
-#: mod/photos.php:1192 src/Content/Conversation.php:1494
+#: mod/photos.php:1192 src/Content/Conversation.php:1496
 #: src/Object/Post.php:263
 msgid "Select"
 msgstr ""
 
-#: mod/photos.php:1193 mod/photos.php:1280 src/Content/Conversation.php:1495
+#: mod/photos.php:1193 mod/photos.php:1280 src/Content/Conversation.php:1497
 #: src/Module/Moderation/Users/Active.php:92
 #: src/Module/Moderation/Users/Blocked.php:92
 #: src/Module/Moderation/Users/Index.php:100
@@ -1256,256 +1256,264 @@ msgstr ""
 msgid "Delete item(s)?"
 msgstr ""
 
-#: src/Content/Conversation.php:347 src/Module/Item/Compose.php:174
+#: src/Content/Conversation.php:335 src/Module/Post/Edit.php:105
+msgid "Post published."
+msgstr ""
+
+#: src/Content/Conversation.php:336 src/Module/Post/Edit.php:106
+msgid "Go to post"
+msgstr ""
+
+#: src/Content/Conversation.php:349 src/Module/Item/Compose.php:174
 msgid "Created at"
 msgstr ""
 
-#: src/Content/Conversation.php:357
+#: src/Content/Conversation.php:359
 msgid "New Post"
 msgstr ""
 
-#: src/Content/Conversation.php:360
+#: src/Content/Conversation.php:362
 msgid "Share"
 msgstr ""
 
-#: src/Content/Conversation.php:363 src/Module/Post/Edit.php:128
+#: src/Content/Conversation.php:365 src/Module/Post/Edit.php:130
 msgid "upload photo"
 msgstr ""
 
-#: src/Content/Conversation.php:364 src/Module/Post/Edit.php:129
+#: src/Content/Conversation.php:366 src/Module/Post/Edit.php:131
 msgid "Attach file"
 msgstr ""
 
-#: src/Content/Conversation.php:365 src/Module/Post/Edit.php:130
+#: src/Content/Conversation.php:367 src/Module/Post/Edit.php:132
 msgid "attach file"
 msgstr ""
 
-#: src/Content/Conversation.php:366 src/Module/Item/Compose.php:189
-#: src/Module/Post/Edit.php:167 src/Object/Post.php:1165
+#: src/Content/Conversation.php:368 src/Module/Item/Compose.php:189
+#: src/Module/Post/Edit.php:169 src/Object/Post.php:1165
 msgid "Bold"
 msgstr ""
 
-#: src/Content/Conversation.php:367 src/Module/Item/Compose.php:190
-#: src/Module/Post/Edit.php:168 src/Object/Post.php:1166
+#: src/Content/Conversation.php:369 src/Module/Item/Compose.php:190
+#: src/Module/Post/Edit.php:170 src/Object/Post.php:1166
 msgid "Italic"
 msgstr ""
 
-#: src/Content/Conversation.php:368 src/Module/Item/Compose.php:191
-#: src/Module/Post/Edit.php:169 src/Object/Post.php:1167
+#: src/Content/Conversation.php:370 src/Module/Item/Compose.php:191
+#: src/Module/Post/Edit.php:171 src/Object/Post.php:1167
 msgid "Underline"
 msgstr ""
 
-#: src/Content/Conversation.php:369 src/Module/Item/Compose.php:192
-#: src/Module/Post/Edit.php:170 src/Object/Post.php:1169
+#: src/Content/Conversation.php:371 src/Module/Item/Compose.php:192
+#: src/Module/Post/Edit.php:172 src/Object/Post.php:1169
 msgid "Quote"
 msgstr ""
 
-#: src/Content/Conversation.php:370 src/Module/Item/Compose.php:193
-#: src/Module/Post/Edit.php:171 src/Object/Post.php:1170
+#: src/Content/Conversation.php:372 src/Module/Item/Compose.php:193
+#: src/Module/Post/Edit.php:173 src/Object/Post.php:1170
 msgid "Add emojis"
 msgstr ""
 
-#: src/Content/Conversation.php:371 src/Module/Item/Compose.php:194
+#: src/Content/Conversation.php:373 src/Module/Item/Compose.php:194
 #: src/Object/Post.php:1168
 msgid "Content Warning"
 msgstr ""
 
-#: src/Content/Conversation.php:372 src/Module/Item/Compose.php:195
-#: src/Module/Post/Edit.php:172 src/Object/Post.php:1171
+#: src/Content/Conversation.php:374 src/Module/Item/Compose.php:195
+#: src/Module/Post/Edit.php:174 src/Object/Post.php:1171
 msgid "Code"
 msgstr ""
 
-#: src/Content/Conversation.php:373 src/Module/Item/Compose.php:196
+#: src/Content/Conversation.php:375 src/Module/Item/Compose.php:196
 #: src/Object/Post.php:1172
 msgid "Image"
 msgstr ""
 
-#: src/Content/Conversation.php:374 src/Module/Item/Compose.php:197
-#: src/Module/Post/Edit.php:173 src/Object/Post.php:1173
+#: src/Content/Conversation.php:376 src/Module/Item/Compose.php:197
+#: src/Module/Post/Edit.php:175 src/Object/Post.php:1173
 msgid "Link"
 msgstr ""
 
-#: src/Content/Conversation.php:375 src/Module/Item/Compose.php:198
-#: src/Module/Post/Edit.php:174 src/Object/Post.php:1174
+#: src/Content/Conversation.php:377 src/Module/Item/Compose.php:198
+#: src/Module/Post/Edit.php:176 src/Object/Post.php:1174
 msgid "Link or Media"
 msgstr ""
 
-#: src/Content/Conversation.php:376
+#: src/Content/Conversation.php:378
 msgid "Video"
 msgstr ""
 
-#: src/Content/Conversation.php:377 src/Module/Item/Compose.php:201
-#: src/Module/Post/Edit.php:137
+#: src/Content/Conversation.php:379 src/Module/Item/Compose.php:201
+#: src/Module/Post/Edit.php:139
 msgid "Set your location"
 msgstr ""
 
-#: src/Content/Conversation.php:378 src/Module/Post/Edit.php:138
+#: src/Content/Conversation.php:380 src/Module/Post/Edit.php:140
 msgid "set location"
 msgstr ""
 
-#: src/Content/Conversation.php:379 src/Module/Post/Edit.php:139
+#: src/Content/Conversation.php:381 src/Module/Post/Edit.php:141
 msgid "Clear browser location"
 msgstr ""
 
-#: src/Content/Conversation.php:380 src/Module/Post/Edit.php:140
+#: src/Content/Conversation.php:382 src/Module/Post/Edit.php:142
 msgid "clear location"
 msgstr ""
 
-#: src/Content/Conversation.php:382 src/Module/Item/Compose.php:206
-#: src/Module/Post/Edit.php:153
+#: src/Content/Conversation.php:384 src/Module/Item/Compose.php:206
+#: src/Module/Post/Edit.php:155
 msgid "Set title"
 msgstr ""
 
-#: src/Content/Conversation.php:384 src/Module/Item/Compose.php:207
-#: src/Module/Post/Edit.php:155
+#: src/Content/Conversation.php:386 src/Module/Item/Compose.php:207
+#: src/Module/Post/Edit.php:157
 msgid "Categories (comma-separated list)"
 msgstr ""
 
-#: src/Content/Conversation.php:389 src/Module/Item/Compose.php:227
+#: src/Content/Conversation.php:391 src/Module/Item/Compose.php:227
 msgid "Scheduled at"
 msgstr ""
 
-#: src/Content/Conversation.php:394 src/Module/Post/Edit.php:142
+#: src/Content/Conversation.php:396 src/Module/Post/Edit.php:144
 msgid "Permission settings"
 msgstr ""
 
-#: src/Content/Conversation.php:403 src/Module/Post/Edit.php:151
+#: src/Content/Conversation.php:405 src/Module/Post/Edit.php:153
 msgid "Public post"
 msgstr ""
 
-#: src/Content/Conversation.php:417 src/Content/Item.php:442
+#: src/Content/Conversation.php:419 src/Content/Item.php:442
 #: src/Content/Widget/VCard.php:120 src/Model/Contact.php:1304
 #: src/Model/Profile.php:460 src/Module/Admin/Logs/View.php:80
-#: src/Module/Post/Edit.php:177
+#: src/Module/Post/Edit.php:179
 msgid "Message"
 msgstr ""
 
-#: src/Content/Conversation.php:418 src/Module/Post/Edit.php:178
+#: src/Content/Conversation.php:420 src/Module/Post/Edit.php:180
 msgid "Add file"
 msgstr ""
 
-#: src/Content/Conversation.php:420 src/Module/Post/Edit.php:181
+#: src/Content/Conversation.php:422 src/Module/Post/Edit.php:183
 msgid "Open Compose page"
 msgstr ""
 
-#: src/Content/Conversation.php:590
+#: src/Content/Conversation.php:592
 msgid "remove"
 msgstr ""
 
-#: src/Content/Conversation.php:594
+#: src/Content/Conversation.php:596
 msgid "Delete Selected Items"
 msgstr ""
 
-#: src/Content/Conversation.php:718 src/Content/Conversation.php:721
-#: src/Content/Conversation.php:724 src/Content/Conversation.php:727
-#: src/Content/Conversation.php:730
+#: src/Content/Conversation.php:720 src/Content/Conversation.php:723
+#: src/Content/Conversation.php:726 src/Content/Conversation.php:729
+#: src/Content/Conversation.php:732
 #, php-format
 msgid "You had been addressed (%s)."
 msgstr ""
 
-#: src/Content/Conversation.php:733
+#: src/Content/Conversation.php:735
 #, php-format
 msgid "You are following %s."
 msgstr ""
 
-#: src/Content/Conversation.php:738
+#: src/Content/Conversation.php:740
 #, php-format
 msgid "You subscribed to %s."
 msgstr ""
 
-#: src/Content/Conversation.php:740
+#: src/Content/Conversation.php:742
 msgid "You subscribed to one or more tags in this post."
 msgstr ""
 
-#: src/Content/Conversation.php:760
+#: src/Content/Conversation.php:762
 #, php-format
 msgid "%s reshared this."
 msgstr ""
 
-#: src/Content/Conversation.php:762
+#: src/Content/Conversation.php:764
 msgid "Reshared"
 msgstr ""
 
-#: src/Content/Conversation.php:762
+#: src/Content/Conversation.php:764
 #, php-format
 msgid "Reshared by %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation.php:765
+#: src/Content/Conversation.php:767
 #, php-format
 msgid "%s is participating in this thread."
 msgstr ""
 
-#: src/Content/Conversation.php:768
+#: src/Content/Conversation.php:770
 msgid "Stored for general reasons"
 msgstr ""
 
-#: src/Content/Conversation.php:771
+#: src/Content/Conversation.php:773
 msgid "Global post"
 msgstr ""
 
-#: src/Content/Conversation.php:774
+#: src/Content/Conversation.php:776
 msgid "Sent via an relay server"
 msgstr ""
 
-#: src/Content/Conversation.php:774
+#: src/Content/Conversation.php:776
 #, php-format
 msgid "Sent via the relay server %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation.php:777
+#: src/Content/Conversation.php:779
 msgid "Fetched"
 msgstr ""
 
-#: src/Content/Conversation.php:777
+#: src/Content/Conversation.php:779
 #, php-format
 msgid "Fetched because of %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation.php:780
+#: src/Content/Conversation.php:782
 msgid "Stored because of a child post to complete this thread."
 msgstr ""
 
-#: src/Content/Conversation.php:783
+#: src/Content/Conversation.php:785
 msgid "Local delivery"
 msgstr ""
 
-#: src/Content/Conversation.php:786
+#: src/Content/Conversation.php:788
 msgid "Stored because of your activity (like, comment, star, ...)"
 msgstr ""
 
-#: src/Content/Conversation.php:789
+#: src/Content/Conversation.php:791
 msgid "Distributed"
 msgstr ""
 
-#: src/Content/Conversation.php:792
+#: src/Content/Conversation.php:794
 msgid "Pushed to us"
 msgstr ""
 
-#: src/Content/Conversation.php:1514 src/Object/Post.php:250
+#: src/Content/Conversation.php:1516 src/Object/Post.php:250
 msgid "Pinned item"
 msgstr ""
 
-#: src/Content/Conversation.php:1531 src/Object/Post.php:552
+#: src/Content/Conversation.php:1533 src/Object/Post.php:552
 #: src/Object/Post.php:553
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: src/Content/Conversation.php:1545 src/Object/Post.php:540
+#: src/Content/Conversation.php:1547 src/Object/Post.php:540
 msgid "Categories:"
 msgstr ""
 
-#: src/Content/Conversation.php:1546 src/Object/Post.php:541
+#: src/Content/Conversation.php:1548 src/Object/Post.php:541
 msgid "Filed under:"
 msgstr ""
 
-#: src/Content/Conversation.php:1554 src/Object/Post.php:568
+#: src/Content/Conversation.php:1556 src/Object/Post.php:568
 #, php-format
 msgid "%s from %s"
 msgstr ""
 
-#: src/Content/Conversation.php:1570
+#: src/Content/Conversation.php:1572
 msgid "View in context"
 msgstr ""
 
@@ -2578,11 +2586,11 @@ msgstr ""
 msgid "Except to:"
 msgstr ""
 
-#: src/Core/ACL.php:322 src/Module/Post/Edit.php:150
+#: src/Core/ACL.php:322 src/Module/Post/Edit.php:152
 msgid "CC: email addresses"
 msgstr ""
 
-#: src/Core/ACL.php:323 src/Module/Post/Edit.php:156
+#: src/Core/ACL.php:323 src/Module/Post/Edit.php:158
 msgid "Example: bob@example.com, mary@example.com"
 msgstr ""
 
@@ -3492,7 +3500,7 @@ msgstr ""
 msgid "[no subject]"
 msgstr ""
 
-#: src/Model/Photo.php:1193 src/Module/Media/Photo/Upload.php:154
+#: src/Model/Photo.php:1197 src/Module/Media/Photo/Upload.php:154
 msgid "Wall Photos"
 msgstr ""
 
@@ -8348,23 +8356,23 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: src/Module/Post/Edit.php:132
+#: src/Module/Post/Edit.php:134
 msgid "web link"
 msgstr ""
 
-#: src/Module/Post/Edit.php:133
+#: src/Module/Post/Edit.php:135
 msgid "Insert video link"
 msgstr ""
 
-#: src/Module/Post/Edit.php:134
+#: src/Module/Post/Edit.php:136
 msgid "video link"
 msgstr ""
 
-#: src/Module/Post/Edit.php:135
+#: src/Module/Post/Edit.php:137
 msgid "Insert audio link"
 msgstr ""
 
-#: src/Module/Post/Edit.php:136
+#: src/Module/Post/Edit.php:138
 msgid "audio link"
 msgstr ""
 

--- a/view/theme/frio/templates/jot-header.tpl
+++ b/view/theme/frio/templates/jot-header.tpl
@@ -65,7 +65,19 @@
 <script type="text/javascript">
 	var ispublic = '{{$ispublic nofilter}}';
 	aStr.linkurl = '{{$linkurl}}';
+	aStr.postPublished = '{{$postPublished}}';
+	aStr.goToPost = '{{$goToPost}}';
 
+	function goToElement(elementId) {
+		let $element = $('#' + elementId);
+		if ($element.length) {
+			window.scrollTo(0, $element.offset().top - 100);
+			$element.addClass('highlight-post');
+			setTimeout(function() {
+				$element.removeClass('highlight-post');
+			}, 2000);
+		}
+	}
 
 	$(document).ready(function() {
 
@@ -109,6 +121,14 @@
 
 			let isNewPost = !formData.get('post_id');
 
+			// remember existing post IDs to find our new one later
+			let existingPostIds = new Set();
+			if (isNewPost) {
+				$('.toplevel_item').each(function() {
+					existingPostIds.add($(this).attr('id'));
+				});
+			}
+
 			$.ajax({
 				url: 'item',
 				data: formData,
@@ -137,11 +157,38 @@
 				}
 
 				if (isNewPost) {
-					let scrollHandler = function() {
-						$('html, body').animate({ scrollTop: 0 }, 400);
-						document.removeEventListener('postprocess_liveupdate', scrollHandler);
+					let alertHandler = function() {
+						// find our new post (has edit button)
+						let newPostElement = null;
+						$('.toplevel_item').each(function() {
+							if (!existingPostIds.has($(this).attr('id')) && $(this).find('.pencil').length > 0) {
+								newPostElement = $(this);
+								return false;
+							}
+						});
+
+						if (newPostElement) {
+							let postId = newPostElement.attr('id');
+							let alertHtml = '<div id="post-published-alert" class="alert alert-info alert-dismissible" role="alert">' +
+								'<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>' +
+								aStr.postPublished + ' ' +
+								'<a href="#' + postId + '" class="alert-link" onclick="goToElement(\'' + postId + '\'); return false;">' + aStr.goToPost + '</a>' +
+								'</div>';
+
+							$('#post-published-alert').remove();
+							$('body').append(alertHtml);
+
+							// auto-dismiss after 5 seconds
+							setTimeout(function() {
+								$('#post-published-alert').fadeOut(400, function() {
+									$(this).remove();
+								});
+							}, 5000);
+						}
+
+						document.removeEventListener('postprocess_liveupdate', alertHandler);
 					};
-					document.addEventListener('postprocess_liveupdate', scrollHandler);
+					document.addEventListener('postprocess_liveupdate', alertHandler);
 				}
 
 				NavUpdate();


### PR DESCRIPTION
After publishing a post, instead of automatically scrolling to the top of the timeline, a small notification appears in the bottom-right corner showing "Post published" with a "Go to post" link. The notification auto-dismisses after 5 seconds. 
Clicking the link scrolls to your post and highlights it.

**Desktop:**
![Unbenannt](https://github.com/user-attachments/assets/666bdbb2-c84c-47fb-8c3f-3cd75361e907)

**Mobile:**
![sdfsdfsdfsdfsdf](https://github.com/user-attachments/assets/b41eb210-5499-436d-a736-2b910894699a)

Since the backend only returns {success: 1} without the post ID after creating a post, the new post is identified client-side by comparing the timeline before and after submission, looking for a new entry that has an edit button (which only appears on your own posts).

If you see a more elegant way to handle this without backend changes, I'd be thankfull for any hint. :)