### PR TITLE
Update notifications view, make intros work better on small screens

### DIFF
--- a/src/Module/Notifications/Introductions.php
+++ b/src/Module/Notifications/Introductions.php
@@ -161,7 +161,7 @@ class Introductions extends BaseNotifications
 					$header .= ' (' . ContactSelector::networkToName($Introduction->getNetwork(), '', $gsid) . ')';
 
 					if ($Introduction->getNetwork() != Protocol::DIASPORA) {
-						$discard = $this->t('Discard');
+						$discard = $this->t('Remove');
 					} else {
 						$discard = '';
 					}

--- a/view/global.css
+++ b/view/global.css
@@ -789,10 +789,22 @@ summary.wall-item-summary {
 }
 
 /* css instructions notification.tpl */
+.notifications-content-wrapper h2 {
+	font-size: 24.5px;
+	margin-top: 10px;
+}
+
+#notifications-show-hide-link {
+	display: inline-block;
+	padding-bottom: 10px;
+}
+
 /* Flexbox layout to align the icon and text in a single line */
 .notif-item a {
-	display: flex;
 	align-items: flex-start;
+	color: black;
+	display: flex;
+	font-size: 14px;
 }
 
 /* Margin to create space between the icon and the text */
@@ -803,8 +815,13 @@ summary.wall-item-summary {
 /* Styles to ensure the text wraps properly after 70 characters */
 .notif-text {
 	display: inline-block;
-	max-width: 70ch;
+	max-width: 80ch;
 	overflow-wrap: break-word;
+}
+
+.notif-when {
+	color: #777777;
+	margin-bottom: 0;
 }
 
 /* Add alt tag indicators to the relevant images */

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-30 14:45+0100\n"
+"POT-Creation-Date: 2025-12-17 20:00+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -236,7 +236,6 @@ msgid "Message collection failure."
 msgstr ""
 
 #: mod/message.php:111 src/Module/Notifications/Introductions.php:127
-#: src/Module/Notifications/Introductions.php:164
 #: src/Module/Notifications/Notification.php:71
 msgid "Discard"
 msgstr ""
@@ -2278,8 +2277,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3657
-#: src/Model/Item.php:3663 src/Model/Item.php:3664
+#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3645
+#: src/Model/Item.php:3651 src/Model/Item.php:3652
 msgid "Link to source"
 msgstr ""
 
@@ -3455,44 +3454,44 @@ msgstr ""
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3557
+#: src/Model/Item.php:3545
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3588
+#: src/Model/Item.php:3576
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3590
+#: src/Model/Item.php:3578
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3595
+#: src/Model/Item.php:3583
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3597
+#: src/Model/Item.php:3585
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3599
+#: src/Model/Item.php:3587
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3640 src/Model/Item.php:3641
+#: src/Model/Item.php:3628 src/Model/Item.php:3629
 msgid "View on separate page"
 msgstr ""
 
@@ -6306,7 +6305,7 @@ msgstr[1] ""
 #: src/Module/Contact/Follow.php:56 src/Module/Contact/Redir.php:47
 #: src/Module/Contact/Redir.php:208 src/Module/Conversation/Community.php:156
 #: src/Module/Debug/ItemBody.php:30 src/Module/Diaspora/Receive.php:45
-#: src/Module/Item/Complete.php:25 src/Module/Item/Display.php:82
+#: src/Module/Item/Complete.php:25 src/Module/Item/Display.php:84
 #: src/Module/Item/Feed.php:45 src/Module/Item/Follow.php:27
 #: src/Module/Item/Ignore.php:27 src/Module/Item/Language.php:43
 #: src/Module/Item/Pin.php:27 src/Module/Item/Pin.php:42
@@ -7236,7 +7235,7 @@ msgstr ""
 msgid "You can make this page always open when you use the New Post button in the <a href=\"/settings/display\">Theme Customization settings</a>."
 msgstr ""
 
-#: src/Module/Item/Display.php:154
+#: src/Module/Item/Display.php:164
 #, php-format
 msgid "Post by %s"
 msgstr ""
@@ -8204,6 +8203,12 @@ msgstr ""
 msgid "Follower"
 msgstr ""
 
+#: src/Module/Notifications/Introductions.php:164
+#: src/Module/Post/Tag/Remove.php:95
+#: src/Module/Settings/TwoFactor/Trusted.php:133
+msgid "Remove"
+msgstr ""
+
 #: src/Module/Notifications/Introductions.php:198
 msgid "Accept request"
 msgstr ""
@@ -8382,11 +8387,6 @@ msgstr ""
 
 #: src/Module/Post/Tag/Remove.php:94
 msgid "Select a tag to remove: "
-msgstr ""
-
-#: src/Module/Post/Tag/Remove.php:95
-#: src/Module/Settings/TwoFactor/Trusted.php:133
-msgid "Remove"
 msgstr ""
 
 #: src/Module/Privacy/PermissionTooltip.php:76
@@ -11679,7 +11679,7 @@ msgstr ""
 msgid "Quote shared by: %s"
 msgstr ""
 
-#: src/Protocol/ActivityPub/Receiver.php:570
+#: src/Protocol/ActivityPub/Receiver.php:577
 msgid "Chat"
 msgstr ""
 

--- a/view/templates/notifications/notification.tpl
+++ b/view/templates/notifications/notification.tpl
@@ -9,7 +9,9 @@
 	<a href="{{$notification.link}}">
 		<img src="{{$notification.image}}" aria-hidden="true" class="notif-image">
 		<link rel="stylesheet" href="view/global.css">
-		<span class="notif-text">{{$notification.text}}</span>
-		<span class="notif-when">{{$notification.ago}}</span>
+		<div>
+			<p class="notif-text">{{$notification.text}}</p>
+			<p class="notif-when"><small data-toggle="tooltip" title="{{$notification.when}}">{{$notification.ago}}</small></p>
+		</div>
 	</a>
 </div>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -942,9 +942,16 @@ nav.navbar .nav > li > button:focus {
 	max-height: 400px;
 	overflow: auto;
 }
+
+.intro-block{
+  display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: center;
+}
 .intro-actions {
 	font-size: 2em;
-	padding: 1em;
+	padding: 0.5em;
 }
 .intro-wrapper button.intro-action-link {
 	padding-left: 10px;

--- a/view/theme/frio/templates/notifications/intros.tpl
+++ b/view/theme/frio/templates/notifications/intros.tpl
@@ -15,53 +15,56 @@
 	</div>
 
 	<div class="media-body">
-		<div class='intro-enty-name'><h4 class="media-heading"><a href="{{$zrl}}">{{$fullname}}</a></h4></div>
-		<div class="intro-desc"><span class="intro-desc-label">{{$str_notification_type}}</span>&nbsp;{{$str_type}}</div>
-		{{* if the contact was suggestested by another contact, the contact who made the suggestion is displayed*}}
-		{{if $madeby}}<div class="intro-madeby"><span class="intro-madeby-label">{{$lbl_madeby}}</span>&nbsp;<a href="{{$madeby_zrl}}">{{$madeby}}</a></div>{{/if}}
+		<div class="intro-block">
+			<div>
+				<div class='intro-enty-name'><h4 class="media-heading"><a href="{{$zrl}}">{{$fullname}}</a></h4></div>
+				<div class="intro-desc"><span class="intro-desc-label">{{$str_notification_type}}</span>&nbsp;{{$str_type}}</div>
+				{{* if the contact was suggestested by another contact, the contact who made the suggestion is displayed*}}
+				{{if $madeby}}<div class="intro-madeby"><span class="intro-madeby-label">{{$lbl_madeby}}</span>&nbsp;<a href="{{$madeby_zrl}}">{{$madeby}}</a></div>{{/if}}
 
-		{{* Additional information of the contact *}}
-		<div class="intro-contact-info hidden-xs">
-			<div class="intro-url"><span class="intro-url-label">{{$lbl_url}}:&nbsp;</span><a href="{{$zrl}}">{{$url}}</a></div>
-			{{if $network}}<div class="intro-network"><span class="intro-network-label">{{$lbl_network}}</span>&nbsp;{{$network}}</div>{{/if}}
-			{{if $location}}<div class="intro-location"><span class="intro-location-label">{{$lbl_location}}</span>&nbsp;{{$location}}</div>{{/if}}
-			{{if $keywords}}<div class="intro-keywords"><span class="intro-keywords-label">{{$lbl_keywords}}</span>&nbsp;{{$keywords}}</div>{{/if}}
-			{{if $about}}<div class="intro-about"><span class="intro-about-label">{{$lbl_about}}</span>&nbsp;{{$about nofilter}}</div>{{/if}}
-			<div class="intro-knowyou"><span class="intro-knowyou-label">{{$lbl_knowyou}}</span>{{$knowyou}}</div>
-			<div class="intro-note intro-note-{{$intro_id}}">{{$note}}</div>
-		</div>
+				{{* Additional information of the contact *}}
+				<div class="intro-contact-info hidden-xs">
+					<div class="intro-url"><span class="intro-url-label">{{$lbl_url}}&nbsp;</span><a href="{{$zrl}}">{{$url}}</a></div>
+					{{if $network}}<div class="intro-network"><span class="intro-network-label">{{$lbl_network}}</span>&nbsp;{{$network}}</div>{{/if}}
+					{{if $location}}<div class="intro-location"><span class="intro-location-label">{{$lbl_location}}</span>&nbsp;{{$location}}</div>{{/if}}
+					{{if $keywords}}<div class="intro-keywords"><span class="intro-keywords-label">{{$lbl_keywords}}</span>&nbsp;{{$keywords}}</div>{{/if}}
+					{{if $about}}<div class="intro-about"><span class="intro-about-label">{{$lbl_about}}</span>&nbsp;{{$about nofilter}}</div>{{/if}}
+					<div class="intro-knowyou"><span class="intro-knowyou-label">{{$lbl_knowyou}}</span>&nbsp;{{$knowyou}}</div>
+					<div class="intro-note intro-note-{{$intro_id}}">{{$note}}</div>
+				</div>
 
-		{{* Additional information of the contact for mobile view *}}
-		<div class="intro-contact-info xs hidden-lg hidden-md hidden-sm">
-			<div class="intro-url"><span class="intro-url-label">{{$lbl_url}}:</span><a href="{{$zrl}}">{{$url}}</a></div>
-			{{if $network}}<div class="intro-network"><span class="intro-network-label">{{$lbl_network}}</span>{{$network}}</div>{{/if}}
-			{{if $location}}<div class="intro-location"><span class="intro-location-label">{{$lbl_location}}</span>{{$location}}</div>{{/if}}
-			{{if $keywords}}<div class="intro-keywords"><span class="intro-keywords-label">{{$lbl_keywords}}</span>{{$keywords}}</div>{{/if}}
-			{{if $about}}<div class="intro-about"><span class="intro-about-label">{{$lbl_about}}</span>{{$about nofilter}}</div>{{/if}}
-			<div class="intro-knowyou"><span class="intro-knowyou-label">{{$lbl_knowyou}}</span>{{$knowyou}}</div>
-			<div class="intro-note intro-note-{{$intro_id}}">{{$note}}</div>
-		</div>
+				{{* Additional information of the contact for mobile view *}}
+				<div class="intro-contact-info xs hidden-lg hidden-md hidden-sm">
+					<div class="intro-url"><span class="intro-url-label">{{$lbl_url}}</span><a href="{{$zrl}}">{{$url}}</a></div>
+					{{if $network}}<div class="intro-network"><span class="intro-network-label">{{$lbl_network}}</span>{{$network}}</div>{{/if}}
+					{{if $location}}<div class="intro-location"><span class="intro-location-label">{{$lbl_location}}</span>{{$location}}</div>{{/if}}
+					{{if $keywords}}<div class="intro-keywords"><span class="intro-keywords-label">{{$lbl_keywords}}</span>{{$keywords}}</div>{{/if}}
+					{{if $about}}<div class="intro-about"><span class="intro-about-label">{{$lbl_about}}</span>{{$about nofilter}}</div>{{/if}}
+					<div class="intro-knowyou"><span class="intro-knowyou-label">{{$lbl_knowyou}}</span>{{$knowyou}}</div>
+					<div class="intro-note intro-note-{{$intro_id}}">{{$note}}</div>
+				</div>
+			</div>
 
-		{{* On mobile touch devices we use buttons for approve, ignore && discard to have a better UX *}}
-		{{if $is_mobile}}
-		<form class="intro-form" action="notification/{{$intro_id}}" method="post">
-			<button class="btn btn-small btn-primary" type="button" onclick="addElmToModal('#intro-approve-wrapper-{{$intro_id}}');"><i class="fa fa-check" aria-hidden="true"></i> {{$approve}}</button>
-			{{if $discard}}
-				<button class="btn btn-small btn-warning intro-submit-discard" type="submit" name="submit" value="{{$discard}}"><i class="fa fa-trash-o" aria-hidden="true"></i> {{$discard}}</button>
-			{{/if}}
-			<button class="btn btn-small btn-danger intro-submit-ignore" type="submit" name="submit" value="{{$ignore}}"><i class="fa fa-ban" aria-hidden="true"></i> {{$ignore}}</button>
-		</form>
-		{{else}}
-		{{* The intro actions like approve, ignore, discard intro*}}
-		<div class="intro-actions pull-right nav-pills preferences">
-			<button class="btn-link intro-action-link" onclick="addElmToModal('#intro-approve-wrapper-{{$intro_id}}');" aria-label="{{$approve}}" title="{{$approve}}" data-toggle="tooltip"><i class="fa fa-check" aria-hidden="true"></i></button>
-
+			{{* On mobile touch devices we use buttons for approve, ignore && discard to have a better UX *}}
+			{{if $is_mobile}}
 			<form class="intro-form" action="notification/{{$intro_id}}" method="post">
-				<button class="btn-link intro-submit-ignore intro-action-link" type="submit" name="submit" value="{{$ignore}}" aria-label="{{$ignore}}" title="{{$ignore}}" data-toggle="tooltip"><i class="fa fa-ban" aria-hidden="true"></i></button>
-				{{if $discard}}<button class="btn-link intro-submit-discard intro-action-link" type="submit" name="submit" value="{{$discard}}" aria-label="{{$discard}}" title="{{$discard}}" data-toggle="tooltip"><i class="fa fa-trash-o" aria-hidden="true"></i></button>{{/if}}
+				<button class="btn btn-small btn-primary" type="button" onclick="addElmToModal('#intro-approve-wrapper-{{$intro_id}}');"><i class="fa fa-check" aria-hidden="true"></i> {{$approve}}</button>
+				{{if $discard}}
+					<button class="btn btn-small btn-warning intro-submit-discard" type="submit" name="submit" value="{{$discard}}"><i class="fa fa-trash-o" aria-hidden="true"></i> {{$discard}}</button>
+				{{/if}}
+				<button class="btn btn-small btn-danger intro-submit-ignore" type="submit" name="submit" value="{{$ignore}}"><i class="fa fa-ban" aria-hidden="true"></i> {{$ignore}}</button>
 			</form>
+			{{else}}
+			{{* The intro actions like approve, ignore, discard intro*}}
+			<div class="intro-actions nav-pills">
+				<button class="btn-link intro-action-link" onclick="addElmToModal('#intro-approve-wrapper-{{$intro_id}}');" aria-label="{{$approve}}" title="{{$approve}}" data-toggle="tooltip"><i class="fa fa-check" aria-hidden="true"></i></button>
+				<form class="intro-form" action="notification/{{$intro_id}}" method="post">
+					<button class="btn-link intro-submit-ignore intro-action-link" type="submit" name="submit" value="{{$ignore}}" aria-label="{{$ignore}}" title="{{$ignore}}" data-toggle="tooltip"><i class="fa fa-ban" aria-hidden="true"></i></button>
+					{{if $discard}}<button class="btn-link intro-submit-discard intro-action-link" type="submit" name="submit" value="{{$discard}}" aria-label="{{$discard}}" title="{{$discard}}" data-toggle="tooltip"><i class="fa fa-trash-o" aria-hidden="true"></i></button>{{/if}}
+				</form>
+			</div>
+			{{/if}}
 		</div>
-		{{/if}}
 
 		{{* This sections contains special settings for contact approval. We hide it by default and load this section in
 		a bootstrap modal in the case of approval *}}


### PR DESCRIPTION
Makes some changes so notifications on the notifications page looks more like the ones in the dropdown.
Also makes the headers on each of the subpages under notifications consistent.
Also makes some adjustments to the buttons on introductions to accept/discard/block so they work better on smaller screens.

I would've liked to also highlight/bolden the display names, but that's not so easy with how things are currently setup. Ideally we moved to using the same logic/templates as the dropdown, but I haven't managed to figure out how to do that yet.

# Screenshots

## Before

<img width="668" height="394" alt="image" src="https://github.com/user-attachments/assets/83140a18-3282-4f58-894f-ca667bfa08c7" />

## After

<img width="668" height="394" alt="image" src="https://github.com/user-attachments/assets/fbf39cd6-cc1e-4cd5-a74c-c31fee4a145c" />

Notifications dropdown for comparison:
<img width="356" height="388" alt="image" src="https://github.com/user-attachments/assets/93584aba-b884-4cf1-83ef-80d332b55b40" />
