### PR TITLE
Don't display remote media

### DIFF
--- a/src/Content/Post/Repository/PostMedia.php
+++ b/src/Content/Post/Repository/PostMedia.php
@@ -188,9 +188,10 @@ class PostMedia extends BaseRepository
 	 * @param int    $uri_id URI id
 	 * @param array  $links list of links that shouldn't be added
 	 * @param bool   $has_media
+	 * @param bool   $display_remote_media
 	 * @return PostMediasCollection[] Three collections in "visual", "link" and "additional" keys
 	 */
-	public function splitAttachments(int $uri_id, array $links = [], bool $has_media = true): array
+	public function splitAttachments(int $uri_id, array $links = [], bool $has_media = true, bool $display_remote_media = true): array
 	{
 		$attachments = [
 			'visual'     => new PostMediasCollection(),
@@ -228,6 +229,10 @@ class PostMedia extends BaseRepository
 
 		/** @var PostMediaEntity $PostMedia */
 		foreach ($PostMedias as $PostMedia) {
+			if (!$display_remote_media && in_array($PostMedia->type, [PostMediaEntity::TYPE_IMAGE, PostMediaEntity::TYPE_AUDIO, PostMediaEntity::TYPE_HLS, PostMediaEntity::TYPE_VIDEO]) && !$this->baseURL->isLocalUri($PostMedia->url)) {
+				continue;
+			}
+
 			foreach ($links as $link) {
 				if (Strings::compareLink($link, $PostMedia->url)) {
 					continue 2;
@@ -323,7 +328,7 @@ class PostMedia extends BaseRepository
 	 * @param integer $uri_id The uri-id of the item that is rendered
 	 * @return string
 	 */
-	public function addEmbed(string $html, int $uid, int $uri_id): string
+	public function addEmbed(string $html, int $uid, int $uri_id, bool $display_remote_media = true): string
 	{
 		if ($html == '') {
 			return $html;
@@ -365,6 +370,10 @@ class PostMedia extends BaseRepository
 					$result = Post\Media::insert($fields);
 					$this->logger->debug('Media is now assigned to this post', ['uri-id' => $uri_id, 'uid' => $uid, 'result' => $result, 'fields' => $fields]);
 				}
+			}
+
+			if (!$display_remote_media && in_array($media->type, [PostMediaEntity::TYPE_IMAGE, PostMediaEntity::TYPE_AUDIO, PostMediaEntity::TYPE_HLS, PostMediaEntity::TYPE_VIDEO]) && !$this->baseURL->isLocalUri($media->url)) {
+				continue;
 			}
 
 			if ($media->type === Post\Media::AUDIO) {

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2960,14 +2960,14 @@ class Item
 		if (!empty($shared_item['uri-id'])) {
 			$shared_uri_id          = $shared_item['uri-id'];
 			$shared_links[]         = strtolower($shared_item['plink']);
-			$sharedSplitAttachments = DI::postMediaRepository()->splitAttachments($shared_uri_id, [], $shared_item['has-media']);
+			$sharedSplitAttachments = DI::postMediaRepository()->splitAttachments($shared_uri_id, [], $shared_item['has-media'], $uid != 0);
 			$shared_links           = array_merge($shared_links, $sharedSplitAttachments['visual']->column('url'));
 			$shared_links           = array_merge($shared_links, $sharedSplitAttachments['link']->column('url'));
 			$shared_links           = array_merge($shared_links, $sharedSplitAttachments['additional']->column('url'));
 			$item['body']           = self::replaceVisualAttachments($sharedSplitAttachments['visual'], $item['body']);
 		}
 
-		$itemSplitAttachments = DI::postMediaRepository()->splitAttachments($item['uri-id'], $shared_links, $item['has-media'] ?? false);
+		$itemSplitAttachments = DI::postMediaRepository()->splitAttachments($item['uri-id'], $shared_links, $item['has-media'] ?? false, $uid != 0);
 		$item['body']         = self::replaceVisualAttachments($itemSplitAttachments['visual'], $item['body'] ?? '');
 
 		self::putInCache($item);
@@ -3039,10 +3039,10 @@ class Item
 		}
 
 		if (!empty($sharedSplitAttachments)) {
-			$s    = self::addGallery($s, $sharedSplitAttachments['visual'], $uid);
+			$s    = self::addGallery($s, $sharedSplitAttachments['visual']);
 			$s    = self::addVisualAttachments($sharedSplitAttachments['visual'], $shared_item, $s, true, $uid);
 			$s    = self::addLinkAttachment($shared_uri_id ?: $item['uri-id'], $sharedSplitAttachments, $body, $s, true, $quote_shared_links, $uid, $shared_item);
-			$s    = self::addNonVisualAttachments($sharedSplitAttachments['additional'], $item, $s, $uid);
+			$s    = self::addNonVisualAttachments($sharedSplitAttachments['additional'], $item, $s);
 			$body = BBCode::removeSharedData($body);
 		}
 
@@ -3052,10 +3052,10 @@ class Item
 			$s           = substr($s, 0, $pos);
 		}
 
-		$s = self::addGallery($s, $itemSplitAttachments['visual'], $uid);
+		$s = self::addGallery($s, $itemSplitAttachments['visual']);
 		$s = self::addVisualAttachments($itemSplitAttachments['visual'], $item, $s, false, $uid);
 		$s = self::addLinkAttachment($item['uri-id'], $itemSplitAttachments, $body, $s, false, $shared_links, $uid, $item);
-		$s = self::addNonVisualAttachments($itemSplitAttachments['additional'], $item, $s, $uid);
+		$s = self::addNonVisualAttachments($itemSplitAttachments['additional'], $item, $s);
 		$s = self::addQuestions($item, $s);
 
 		// Map.
@@ -3076,7 +3076,7 @@ class Item
 			$s .= $shared_html;
 		}
 
-		$s = DI::postMediaRepository()->addEmbed($s, $uid, $item['uri-id']);
+		$s = DI::postMediaRepository()->addEmbed($s, $uid, $item['uri-id'], $uid != 0);
 
 		$s = HTML::applyContentFilter($s, $filter_reasons);
 
@@ -3136,12 +3136,8 @@ class Item
 	 * @param PostMedias $PostMedias
 	 * @return string
 	 */
-	private static function addGallery(string $s, PostMedias $PostMedias, $uid): string
+	private static function addGallery(string $s, PostMedias $PostMedias): string
 	{
-		if ($uid == 0) {
-			return $s;
-		}
-
 		/** @var PostMedia $PostMedia */
 		foreach ($PostMedias as $PostMedia) {
 			if (!$PostMedia->preview || ($PostMedia->type !== Post\Media::IMAGE)) {
@@ -3286,10 +3282,6 @@ class Item
 	 */
 	private static function addVisualAttachments(PostMedias $PostMedias, array $item, string $content, bool $shared, int $uid): string
 	{
-		if ($uid == 0) {
-			return $content;
-		}
-
 		DI::profiler()->startRecording('rendering');
 		$leading  = '';
 		$trailing = '';
@@ -3528,12 +3520,8 @@ class Item
 	 * @throws InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	private static function addNonVisualAttachments(PostMedias $PostMedias, array $item, string $content, int $uid): string
+	private static function addNonVisualAttachments(PostMedias $PostMedias, array $item, string $content): string
 	{
-		if ($uid == 0) {
-			return $content;
-		}
-
 		DI::profiler()->startRecording('rendering');
 		$trailing = '';
 		/** @var PostMedia $PostMedia */
@@ -3626,7 +3614,7 @@ class Item
 			$plink = $item['uri'];
 		}
 
-		if ((($item['post-reason'] ?? self::PR_NONE) == self::PR_ANNOUNCEMENT) && ($item['owner-contact-type'] == Contact::TYPE_COMMUNITY) && ($item['owner-network'] == Protocol::DFRN)) {
+		if (($item['owner-contact-type'] == Contact::TYPE_COMMUNITY) && ($item['owner-network'] == Protocol::DFRN)) {
 			$contact = Contact::getById($item['owner-id'], ['baseurl']);
 			if (!empty($contact['baseurl'])) {
 				$plink = $contact['baseurl'] . '/display/' . $item['guid'];

--- a/src/Module/Item/Display.php
+++ b/src/Module/Item/Display.php
@@ -31,6 +31,8 @@ use Friendica\Protocol\ActivityPub;
 use Friendica\Util\Profiler;
 use Friendica\Network\HTTPException;
 use Friendica\Content\Widget;
+use Friendica\Core\System;
+use Friendica\DI;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -87,7 +89,9 @@ class Display extends BaseModule
 		$item    = null;
 		$itemUid = $this->session->getLocalUserId();
 
-		$fields = ['uri-id', 'parent-uri-id', 'author-id', 'author-link', 'contact-id', 'contact-contact-type', 'body', 'uid', 'guid', 'gravity'];
+		$fields = ['uri-id', 'parent-uri-id', 'author-id', 'author-link', 'contact-id', 'contact-contact-type', 'body', 'uid', 'guid', 'gravity',
+			'plink', 'origin', 'uri', 'post-reason', 'owner-contact-type', 'owner-network', 'owner-id', 'guid',
+			'author-network', 'author-alias', 'private'];
 
 		// Does the local user have this item?
 		if ($this->session->getLocalUserId()) {
@@ -122,6 +126,12 @@ class Display extends BaseModule
 			$this->page['aside'] = '';
 			$displayNotFound     = new DisplayNotFound($this->l10n, $this->baseUrl, $this->args, $this->logger, $this->profiler, $this->response, $this->server, $this->parameters);
 			return $displayNotFound->content();
+		}
+
+		$plink = Item::getPlink($item);
+
+		if (!$this->session->getLocalUserId() && isset($plink['href']) && !DI::baseUrl()->isLocalUrl($plink['href'])) {
+			System::externalRedirect($plink['href']);
 		}
 
 		if ($item['gravity'] != Item::GRAVITY_PARENT) {


### PR DESCRIPTION
This is an improvement to one of the previous PRs that prohibited the displaying of any media, when you weren't logged in. 

This PR now don't display any media when you aren't logged in, as long as the media isn't local. Locally stored media will be displayed.

Also links to locally stored posts from remote system will now be redirected to the remote site.