### PR TITLE
Config option to show or hide media for visitors

### DIFF
--- a/src/Content/Post/Repository/PostMedia.php
+++ b/src/Content/Post/Repository/PostMedia.php
@@ -27,6 +27,14 @@ use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Repository for PostMedia entities.
+ *
+ * Provides persistence and rendering helpers for post media objects
+ * (images, audio, video, embeds, etc.).
+ *
+ * @package Friendica\Content\Post\Repository
+ */
 class PostMedia extends BaseRepository
 {
 	protected static $table_name = 'post-media';
@@ -42,6 +50,17 @@ class PostMedia extends BaseRepository
 	/** @var Item */
 	private $item;
 
+	/**
+	 * PostMedia repository constructor.
+	 *
+	 * @param Database $database Database connection wrapper
+	 * @param LoggerInterface $logger PSR-3 logger
+	 * @param PostMediaFactory $factory Factory for creating entities
+	 * @param IManagePersonalConfigValues $pConfig Personal configuration access
+	 * @param IManageConfigValues $config Global configuration access
+	 * @param BaseURL $baseURL Base URL helper
+	 * @param Item $item Item helper
+	 */
 	public function __construct(Database $database, LoggerInterface $logger, PostMediaFactory $factory, IManagePersonalConfigValues $pConfig, IManageConfigValues $config, BaseURL $baseURL, Item $item)
 	{
 		parent::__construct($database, $logger, $factory);
@@ -52,6 +71,16 @@ class PostMedia extends BaseRepository
 		$this->item    = $item;
 	}
 
+	/**
+	 * Low level select helper used by higher-level selectors.
+	 *
+	 * Queries the `post-media` table and maps rows to entities. Invalid rows
+	 * are logged and skipped.
+	 *
+	 * @param array $condition DBA-style condition array
+	 * @param array $params Optional positional parameters
+	 * @return PostMediasCollection Collection of PostMediaEntity objects
+	 */
 	protected function _select(array $condition, array $params = []): PostMediasCollection
 	{
 		$rows = $this->db->selectToArray(static::$table_name, [], $condition, $params);
@@ -69,10 +98,10 @@ class PostMedia extends BaseRepository
 	}
 
 	/**
-	 * Returns a single PostMedia entity, selected by their id.
+	 * Return a single PostMedia entity selected by its id.
 	 *
-	 * @param int $postMediaId
-	 * @return PostMediaEntity
+	 * @param int $postMediaId Primary key of the media row
+	 * @return PostMediaEntity The entity for the requested id
 	 * @throws NotFoundException
 	 */
 	public function selectById(int $postMediaId): PostMediaEntity
@@ -83,11 +112,11 @@ class PostMedia extends BaseRepository
 	}
 
 	/**
-	 * Select PostMedia collection for the given uri-id and the given types
+	 * Select PostMedia collection for the given uri-id and optional types.
 	 *
-	 * @param integer $uriId
-	 * @param array $types
-	 * @return PostMediasCollection
+	 * @param int $uriId URI id to select media for
+	 * @param array $types Optional list of media types to restrict the result
+	 * @return PostMediasCollection Collection of PostMedia entities
 	 */
 	public function selectByUriId(int $uriId, array $types = []): PostMediasCollection
 	{
@@ -101,12 +130,12 @@ class PostMedia extends BaseRepository
 	}
 
 	/**
-	 * Select PostMedia entity for the given uri-id, the media url and the given types
+	 * Select a single PostMedia entity for the given uri-id and media URL.
 	 *
-	 * @param integer $uriId
-	 * @param string $url
-	 * @param array $types
-	 * @return PostMediaEntity
+	 * @param int $uriId URI id to search within
+	 * @param string $url Full media URL to match
+	 * @param array $types Optional list of media types to restrict the search
+	 * @return PostMediaEntity|null Matching media entity or null when not found
 	 */
 	public function selectByURL(int $uriId, string $url, array $types = []): ?PostMediaEntity
 	{
@@ -120,6 +149,16 @@ class PostMedia extends BaseRepository
 		return $medias[0] ?? null;
 	}
 
+	/**
+	 * Map a PostMedia entity to an array of storage fields.
+	 *
+	 * The returned array is suitable for insert/update operations on the
+	 * `post-media` table. When $includeId is true the `id` field is included.
+	 *
+	 * @param PostMediaEntity $PostMedia Entity to map
+	 * @param bool $includeId Include the `id` field when true
+	 * @return array Associative array of storage fields
+	 */
 	public function getFields(PostMediaEntity $PostMedia, bool $includeId = false): array
 	{
 		$fields = [
@@ -164,6 +203,15 @@ class PostMedia extends BaseRepository
 		return $fields;
 	}
 
+	/**
+	 * Save a PostMedia entity to the database.
+	 *
+	 * Updates when an id is present, otherwise inserts and returns the
+	 * persisted entity.
+	 *
+	 * @param PostMediaEntity $PostMedia Entity to persist
+	 * @return PostMediaEntity Persisted entity
+	 */
 	public function save(PostMediaEntity $PostMedia): PostMediaEntity
 	{
 		$fields = $this->getFields($PostMedia);
@@ -183,20 +231,21 @@ class PostMedia extends BaseRepository
 
 
 	/**
-	 * Split the attachment media in the three segments "visual", "link" and "additional"
+	 * Split the attachment media into four segments: `visual`, `link`, `additional`, 'hidden'.
 	 *
-	 * @param int    $uri_id URI id
-	 * @param array  $links list of links that shouldn't be added
-	 * @param bool   $has_media
-	 * @param bool   $display_remote_media
-	 * @return PostMediasCollection[] Three collections in "visual", "link" and "additional" keys
+	 * @param int $uri_id URI id the attachments belong to
+	 * @param array $links List of link URLs that should be ignored
+	 * @param bool $has_media Whether the item has media at all
+	 * @param bool $local_visitor Whether the viewer is local (affects remote-media handling)
+	 * @return PostMediasCollection[] Associative array with keys `visual`, `link`, `additional`, 'hidden'
 	 */
-	public function splitAttachments(int $uri_id, array $links = [], bool $has_media = true, bool $display_remote_media = true): array
+	public function splitAttachments(int $uri_id, array $links = [], bool $has_media = true, bool $local_visitor = true): array
 	{
 		$attachments = [
 			'visual'     => new PostMediasCollection(),
 			'link'       => new PostMediasCollection(),
 			'additional' => new PostMediasCollection(),
+			'hidden'     => new PostMediasCollection(),
 		];
 
 		if (!$has_media) {
@@ -229,10 +278,6 @@ class PostMedia extends BaseRepository
 
 		/** @var PostMediaEntity $PostMedia */
 		foreach ($PostMedias as $PostMedia) {
-			if (!$display_remote_media && in_array($PostMedia->type, [PostMediaEntity::TYPE_IMAGE, PostMediaEntity::TYPE_AUDIO, PostMediaEntity::TYPE_HLS, PostMediaEntity::TYPE_VIDEO]) && !$this->baseURL->isLocalUri($PostMedia->url)) {
-				continue;
-			}
-
 			foreach ($links as $link) {
 				if (Strings::compareLink($link, $PostMedia->url)) {
 					continue 2;
@@ -262,15 +307,14 @@ class PostMedia extends BaseRepository
 				$previews[] = $PostMedia->preview;
 			}
 
-			//$PostMedia->filetype = $filetype;
-			//$PostMedia->subtype = $subtype;
-
 			if ($PostMedia->type == PostMediaEntity::TYPE_HTML) {
 				$attachments['link'][] = $PostMedia;
 				continue;
 			}
 
-			if (in_array($PostMedia->type, [PostMediaEntity::TYPE_AUDIO, PostMediaEntity::TYPE_IMAGE, PostMediaEntity::TYPE_HLS])) {
+			if (!$local_visitor && !$this->displayMedia($PostMedia)) {
+				$attachments['hidden'][] = $PostMedia;
+			} elseif (in_array($PostMedia->type, [PostMediaEntity::TYPE_AUDIO, PostMediaEntity::TYPE_IMAGE, PostMediaEntity::TYPE_HLS])) {
 				$attachments['visual'][] = $PostMedia;
 			} elseif ($PostMedia->type == PostMediaEntity::TYPE_VIDEO) {
 				if ($is_torrent) {
@@ -306,6 +350,31 @@ class PostMedia extends BaseRepository
 		return $attachments;
 	}
 
+	/**
+	 * Decide whether a media item should be displayed based on configuration.
+	 *
+	 * @param PostMediaEntity $PostMedia Media entity to check
+	 * @return bool display mode
+	 */
+	private function displayMedia(PostMediaEntity $PostMedia): bool
+	{
+		if (!in_array($PostMedia->type, [PostMediaEntity::TYPE_AUDIO, PostMediaEntity::TYPE_IMAGE, PostMediaEntity::TYPE_HLS, PostMediaEntity::TYPE_VIDEO])) {
+			return true;
+		}
+
+		if ($this->baseURL->isLocalUri($PostMedia->url)) {
+			return $this->config->get('system', 'display_local_media');
+		} else {
+			return $this->config->get('system', 'display_remote_media');
+		}
+	}
+
+	/**
+	 * Create a PostMedia entity from a remote URL using siteinfo parsing.
+	 *
+	 * @param string $url Remote resource URL
+	 * @return PostMediaEntity Created media entity
+	 */
 	public function createFromUrl(string $url): PostMediaEntity
 	{
 		$data  = ParseUrl::getSiteinfoCached($url);
@@ -313,6 +382,12 @@ class PostMedia extends BaseRepository
 		return $this->fetchAdditionalData($media);
 	}
 
+	/**
+	 * Fetch additional metadata for a PostMedia and return an updated entity.
+	 *
+	 * @param PostMediaEntity $postMedia Media entity to enrich
+	 * @return PostMediaEntity Enriched media entity
+	 */
 	public function fetchAdditionalData(PostMediaEntity $postMedia): PostMediaEntity
 	{
 		$data = $this->getFields($postMedia, true);
@@ -321,14 +396,15 @@ class PostMedia extends BaseRepository
 	}
 
 	/**
-	 * Embed remote media, that had been added with the [embed] element
+	 * Replace `[embed]` link placeholders in the provided HTML with embed markup.
 	 *
-	 * @param string $html    The already rendered HTML output
-	 * @param integer $uid    The user the output is rendered for
-	 * @param integer $uri_id The uri-id of the item that is rendered
-	 * @return string
+	 * @param string $html HTML that may contain anchor tags with class `embed`
+	 * @param int $uid Viewer user id used for personal preferences
+	 * @param int $uri_id URI id of the item being rendered
+	 * @param bool $local_visitor Whether the viewer is local
+	 * @return string Modified HTML with embeds replaced
 	 */
-	public function addEmbed(string $html, int $uid, int $uri_id, bool $display_remote_media = true): string
+	public function addEmbed(string $html, int $uid, int $uri_id, bool $local_visitor = true): string
 	{
 		if ($html == '') {
 			return $html;
@@ -372,11 +448,9 @@ class PostMedia extends BaseRepository
 				}
 			}
 
-			if (!$display_remote_media && in_array($media->type, [PostMediaEntity::TYPE_IMAGE, PostMediaEntity::TYPE_AUDIO, PostMediaEntity::TYPE_HLS, PostMediaEntity::TYPE_VIDEO]) && !$this->baseURL->isLocalUri($media->url)) {
-				continue;
-			}
-
-			if ($media->type === Post\Media::AUDIO) {
+			if (!$local_visitor && !$this->displayMedia($media)) {
+				$player = '<span></span>';
+			} elseif ($media->type === Post\Media::AUDIO) {
 				$player = $this->getAudioAttachment($media);
 			} elseif (in_array($media->type, [Post\Media::VIDEO, Post\Media::HLS])) {
 				$player = $this->getVideoAttachment($media, $uid);
@@ -405,6 +479,13 @@ class PostMedia extends BaseRepository
 		return $html;
 	}
 
+	/**
+	 * Render a video attachment as HTML.
+	 *
+	 * @param PostMediaEntity $postMedia Media entity to render
+	 * @param int $uid Viewer user id
+	 * @return string HTML snippet for the video attachment
+	 */
 	public function getVideoAttachment(PostMediaEntity $postMedia, int $uid): string
 	{
 		if ($postMedia->preview || ($postMedia->blurhash && $this->config->get('system', 'ffmpeg_installed'))) {
@@ -443,6 +524,12 @@ class PostMedia extends BaseRepository
 		return $media;
 	}
 
+	/**
+	 * Build an iframe-based player markup for the given media.
+	 *
+	 * @param PostMediaEntity $postMedia Media entity providing player URL and dimensions
+	 * @return string HTML markup for the iframe player
+	 */
 	public function getPlayerIframe(PostMediaEntity $postMedia): string
 	{
 		if ($postMedia->playerUrl == '') {
@@ -480,6 +567,12 @@ class PostMedia extends BaseRepository
 		]);
 	}
 
+	/**
+	 * Build an iframe wrapper for embed HTML provided by the media.
+	 *
+	 * @param PostMediaEntity $postMedia Media entity containing embed HTML and dimensions
+	 * @return string Rendered iframe embedding the media
+	 */
 	public function getEmbedIframe(PostMediaEntity $postMedia): string
 	{
 		if ($postMedia->embedHtml == '') {
@@ -518,6 +611,12 @@ class PostMedia extends BaseRepository
 		]);
 	}
 
+	/**
+	 * Render an audio attachment as HTML.
+	 *
+	 * @param PostMediaEntity $postMedia Media entity to render
+	 * @return string HTML snippet for the audio player
+	 */
 	public function getAudioAttachment(PostMediaEntity $postMedia): string
 	{
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('content/audio.tpl'), [
@@ -530,6 +629,12 @@ class PostMedia extends BaseRepository
 		]);
 	}
 
+	/**
+	 * Render a generic link attachment.
+	 *
+	 * @param PostMediaEntity $postMedia Media entity to render
+	 * @return string HTML snippet for the link attachment
+	 */
 	public function getLinkAttachment(PostMediaEntity $postMedia): string
 	{
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('content/link.tpl'), [

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3043,6 +3043,7 @@ class Item
 			$s    = self::addVisualAttachments($sharedSplitAttachments['visual'], $shared_item, $s, true, $uid);
 			$s    = self::addLinkAttachment($shared_uri_id ?: $item['uri-id'], $sharedSplitAttachments, $body, $s, true, $quote_shared_links, $uid, $shared_item);
 			$s    = self::addNonVisualAttachments($sharedSplitAttachments['additional'], $item, $s);
+			$s    = self::addHiddenAttachments($sharedSplitAttachments['hidden'], $item, $s);
 			$body = BBCode::removeSharedData($body);
 		}
 
@@ -3056,6 +3057,7 @@ class Item
 		$s = self::addVisualAttachments($itemSplitAttachments['visual'], $item, $s, false, $uid);
 		$s = self::addLinkAttachment($item['uri-id'], $itemSplitAttachments, $body, $s, false, $shared_links, $uid, $item);
 		$s = self::addNonVisualAttachments($itemSplitAttachments['additional'], $item, $s);
+		$s = self::addHiddenAttachments($itemSplitAttachments['hidden'], $item, $s);
 		$s = self::addQuestions($item, $s);
 
 		// Map.
@@ -3556,6 +3558,36 @@ class Item
 
 		DI::profiler()->stopRecording();
 		return $content;
+	}
+
+	/**
+	 * Add hidden attachments message to the content
+	 *
+	 * @param PostMedias $PostMedias
+	 * @param array      $item
+	 * @param string     $content
+	 * @return string modified content
+	 */
+	private static function addHiddenAttachments(PostMedias $PostMedias, array $item, string $content): string
+	{
+		if (count($PostMedias) == 0) {
+			return $content;
+		}
+
+
+		$plink = self::getPlink($item);
+
+		if (isset($plink['href']) && !DI::baseUrl()->isLocalUrl($plink['href'])) {
+			$message = DI::l10n()->t('The media in this post is not displayed to visitors. To view it, please go to the <a href="%s">original post</a>.', $plink['href']);
+		} else {
+			$message = DI::l10n()->t('The media in this post is not displayed to visitors. To view it, please log in.');
+		}
+
+		$media = Renderer::replaceMacros(Renderer::getMarkupTemplate('content/hidden.tpl'), [
+			'message' => $message,
+		]);
+
+		return $media . $content;
 	}
 
 	private static function addQuestions(array $item, string $content): string

--- a/src/Module/Admin/Site.php
+++ b/src/Module/Admin/Site.php
@@ -92,6 +92,8 @@ class Site extends BaseAdmin
 		$community_page_style            = (!empty($_POST['community_page_style']) ? intval(trim($_POST['community_page_style'])) : 0);
 		$max_author_posts_community_page = (!empty($_POST['max_author_posts_community_page']) ? intval(trim($_POST['max_author_posts_community_page'])) : 0);
 		$max_server_posts_community_page = (!empty($_POST['max_server_posts_community_page']) ? intval(trim($_POST['max_server_posts_community_page'])) : 0);
+		$display_local_media             = !empty($_POST['display_local_media']);
+		$display_remote_media            = !empty($_POST['display_remote_media']);
 
 		$verifyssl                = !empty($_POST['verifyssl']);
 		$proxyuser                = (!empty($_POST['proxyuser'])              ? trim($_POST['proxyuser']) : '');
@@ -271,6 +273,8 @@ class Site extends BaseAdmin
 		$transactionConfig->set('system', 'community_page_style', $community_page_style);
 		$transactionConfig->set('system', 'max_author_posts_community_page', $max_author_posts_community_page);
 		$transactionConfig->set('system', 'max_server_posts_community_page', $max_server_posts_community_page);
+		$transactionConfig->set('system', 'display_local_media', $display_local_media);
+		$transactionConfig->set('system', 'display_remote_media', $display_remote_media);
 		$transactionConfig->set('system', 'verifyssl', $verifyssl);
 		$transactionConfig->set('system', 'proxyuser', $proxyuser);
 		$transactionConfig->set('system', 'proxy', $proxy);
@@ -530,6 +534,8 @@ class Site extends BaseAdmin
 			'$community_page_style'            => ['community_page_style', DI::l10n()->t('Community pages for visitors'), DI::config()->get('system', 'community_page_style'), DI::l10n()->t('Which community pages should be available for visitors. Local users always see both pages.'), $community_page_style_choices],
 			'$max_author_posts_community_page' => ['max_author_posts_community_page', DI::l10n()->t('Posts per user on community page'), DI::config()->get('system', 'max_author_posts_community_page'), DI::l10n()->t('The maximum number of posts per user on the local community page. This is useful, when a single user floods the local community page.')],
 			'$max_server_posts_community_page' => ['max_server_posts_community_page', DI::l10n()->t('Posts per server on community page'), DI::config()->get('system', 'max_server_posts_community_page'), DI::l10n()->t('The maximum number of posts per server on the global community page. This is useful, when posts from a single server flood the global community page.')],
+			'$display_local_media'             => ['display_local_media', DI::l10n()->t('Display local media to visitors'), DI::config()->get('system', 'display_local_media'), DI::l10n()->t('When enabled, locally stored media, such as pictures and videos, will be displayed to visitors who are not logged in. When disabled, a message will appear informing visitors that the media is only available to logged-in users.')],
+			'$display_remote_media'            => ['display_remote_media', DI::l10n()->t('Display remote media to visitors'), DI::config()->get('system', 'display_remote_media'), DI::l10n()->t('When enabled, visitors who are not logged in will be able to view non-locally stored media such as pictures and videos. When disabled, visitors will see a message informing them that the media is available on the remote site.')],
 			'$mail_able'                       => function_exists('imap_open'),
 			'$mail_enabled'                    => ['mail_enabled', DI::l10n()->t('Enable Mail support'), !DI::config()->get('system', 'imap_disabled', !function_exists('imap_open')), DI::l10n()->t('Enable built-in mail support to poll IMAP folders and to reply via mail.')],
 			'$mail_not_able'                   => DI::l10n()->t('Mail support can\'t be enabled because the PHP IMAP module is not installed.'),

--- a/static/settings.config.php
+++ b/static/settings.config.php
@@ -113,6 +113,14 @@ return [
 		// URL of the global directory.
 		'directory' => 'https://dir.friendica.social',
 
+		// display_local_media (Boolean)
+		// Display local media to visitors.
+		'display_local_media' => true,
+
+		// display_remote_media (Boolean)
+		// Display non local media to visitors.
+		'display_remote_media' => false,
+
 		// explicit_content (Boolean)
 		// Set this to announce that your node is used mostly for explicit content that might not be suited for minors.
 		'explicit_content' => false,

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -1745,7 +1745,7 @@ msgid "Display posts done by accounts with the selected account type."
 msgstr ""
 
 #: src/Content/Feature.php:131 src/Content/Widget.php:613
-#: src/Module/Admin/Site.php:470 src/Module/BaseSettings.php:113
+#: src/Module/Admin/Site.php:474 src/Module/BaseSettings.php:113
 #: src/Module/Settings/Channels.php:216 src/Module/Settings/Display.php:322
 msgid "Channels"
 msgstr ""
@@ -2263,8 +2263,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3645
-#: src/Model/Item.php:3651 src/Model/Item.php:3652
+#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3677
+#: src/Model/Item.php:3683 src/Model/Item.php:3684
 msgid "Link to source"
 msgstr ""
 
@@ -3440,44 +3440,53 @@ msgstr ""
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3545
+#: src/Model/Item.php:3547
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3576
+#: src/Model/Item.php:3581
+#, php-format
+msgid "The media in this post is not displayed to visitors. To view it, please go to the <a href=\"%s\">original post</a>."
+msgstr ""
+
+#: src/Model/Item.php:3583
+msgid "The media in this post is not displayed to visitors. To view it, please log in."
+msgstr ""
+
+#: src/Model/Item.php:3608
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3578
+#: src/Model/Item.php:3610
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3583
+#: src/Model/Item.php:3615
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3585
+#: src/Model/Item.php:3617
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3587
+#: src/Model/Item.php:3619
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3628 src/Model/Item.php:3629
+#: src/Model/Item.php:3660 src/Model/Item.php:3661
 msgid "View on separate page"
 msgstr ""
 
@@ -3896,7 +3905,7 @@ msgstr ""
 #: src/Module/Admin/Addons/Details.php:137 src/Module/Admin/Addons/Index.php:83
 #: src/Module/Admin/Federation.php:218 src/Module/Admin/Logs/Settings.php:74
 #: src/Module/Admin/Logs/View.php:71 src/Module/Admin/Queue.php:59
-#: src/Module/Admin/Site.php:453 src/Module/Admin/Storage.php:124
+#: src/Module/Admin/Site.php:457 src/Module/Admin/Storage.php:124
 #: src/Module/Admin/Summary.php:183 src/Module/Admin/Themes/Details.php:82
 #: src/Module/Admin/Themes/Index.php:103 src/Module/Admin/Tos.php:63
 #: src/Module/Moderation/Users/Pending.php:82
@@ -3933,7 +3942,7 @@ msgid "Addon %s failed to install."
 msgstr ""
 
 #: src/Module/Admin/Addons/Index.php:85 src/Module/Admin/Features.php:69
-#: src/Module/Admin/Logs/Settings.php:76 src/Module/Admin/Site.php:456
+#: src/Module/Admin/Logs/Settings.php:76 src/Module/Admin/Site.php:460
 #: src/Module/Admin/Themes/Index.php:105 src/Module/Admin/Tos.php:72
 #: src/Module/Settings/Account.php:507 src/Module/Settings/Addons.php:64
 #: src/Module/Settings/Connectors.php:143
@@ -4135,8 +4144,8 @@ msgid "Enable Debugging"
 msgstr ""
 
 #: src/Module/Admin/Logs/Settings.php:80 src/Module/Admin/Logs/Settings.php:81
-#: src/Module/Admin/Logs/Settings.php:82 src/Module/Admin/Site.php:476
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Logs/Settings.php:82 src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:488
 msgid "<strong>Read-only</strong> because it is set by an environment variable"
 msgstr ""
 
@@ -4281,273 +4290,273 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/Module/Admin/Site.php:229
+#: src/Module/Admin/Site.php:231
 #, php-format
 msgid "%s is no valid input for maximum media size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:234
+#: src/Module/Admin/Site.php:236
 #, php-format
 msgid "%s is no valid input for maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:360 src/Module/Settings/Display.php:211
+#: src/Module/Admin/Site.php:364 src/Module/Settings/Display.php:211
 msgid "No special theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:377 src/Module/Settings/Display.php:221
+#: src/Module/Admin/Site.php:381 src/Module/Settings/Display.php:221
 #, php-format
 msgid "%s - (Experimental)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:389
+#: src/Module/Admin/Site.php:393
 msgid "Fetch replies on all posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:390
+#: src/Module/Admin/Site.php:394
 msgid "Don't fetch replies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:391
+#: src/Module/Admin/Site.php:395
 msgid "Fetch replies on posts from followed contacts only"
 msgstr ""
 
-#: src/Module/Admin/Site.php:392
+#: src/Module/Admin/Site.php:396
 msgid "Fetch replies on posts with interactions only"
 msgstr ""
 
-#: src/Module/Admin/Site.php:397
+#: src/Module/Admin/Site.php:401
 msgid "No community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:398
+#: src/Module/Admin/Site.php:402
 msgid "No community page for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:399
+#: src/Module/Admin/Site.php:403
 msgid "Public postings from users of this site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:400
+#: src/Module/Admin/Site.php:404
 msgid "Public postings from the federated network"
 msgstr ""
 
-#: src/Module/Admin/Site.php:401
+#: src/Module/Admin/Site.php:405
 msgid "Public postings from local users and the federated network"
 msgstr ""
 
-#: src/Module/Admin/Site.php:407
+#: src/Module/Admin/Site.php:411
 msgid "Multi user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:430
+#: src/Module/Admin/Site.php:434
 msgid "Closed"
 msgstr ""
 
-#: src/Module/Admin/Site.php:431
+#: src/Module/Admin/Site.php:435
 msgid "Requires approval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:432
+#: src/Module/Admin/Site.php:436
 msgid "Open"
 msgstr ""
 
-#: src/Module/Admin/Site.php:436
+#: src/Module/Admin/Site.php:440
 msgid "Don't check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:437
+#: src/Module/Admin/Site.php:441
 msgid "check the stable version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:438
+#: src/Module/Admin/Site.php:442
 msgid "check the development version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:442
+#: src/Module/Admin/Site.php:446
 msgid "none"
 msgstr ""
 
-#: src/Module/Admin/Site.php:443
+#: src/Module/Admin/Site.php:447
 msgid "Local contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:444
+#: src/Module/Admin/Site.php:448
 msgid "Interactors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:454 src/Module/BaseAdmin.php:75
+#: src/Module/Admin/Site.php:458 src/Module/BaseAdmin.php:75
 msgid "Site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:455
+#: src/Module/Admin/Site.php:459
 msgid "General Information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:457
+#: src/Module/Admin/Site.php:461
 msgid "Republish users to directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:458
+#: src/Module/Admin/Site.php:462
 msgid "Registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:459
+#: src/Module/Admin/Site.php:463
 msgid "File upload"
 msgstr ""
 
-#: src/Module/Admin/Site.php:460
+#: src/Module/Admin/Site.php:464
 msgid "Policies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:461 src/Module/Calendar/Event/Form.php:238
+#: src/Module/Admin/Site.php:465 src/Module/Calendar/Event/Form.php:238
 #: src/Module/Contact.php:532 src/Module/Profile/Profile.php:290
 msgid "Advanced"
 msgstr ""
 
-#: src/Module/Admin/Site.php:462
+#: src/Module/Admin/Site.php:466
 msgid "Auto Discovered Contact Directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:463
+#: src/Module/Admin/Site.php:467
 msgid "Performance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:464
+#: src/Module/Admin/Site.php:468
 msgid "Worker"
 msgstr ""
 
-#: src/Module/Admin/Site.php:465
+#: src/Module/Admin/Site.php:469
 msgid "Message Relay"
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:470
 msgid "Use the command \"console relay\" in the command line to add or remove relays."
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:471
 msgid "The system is not subscribed to any relays at the moment."
 msgstr ""
 
-#: src/Module/Admin/Site.php:468
+#: src/Module/Admin/Site.php:472
 msgid "The system is currently subscribed to the following relays:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:471
+#: src/Module/Admin/Site.php:475
 msgid "Relocate Node"
 msgstr ""
 
-#: src/Module/Admin/Site.php:472
+#: src/Module/Admin/Site.php:476
 msgid "Relocating your node enables you to change the DNS domain of this node and keep all the existing users and posts. This process takes a while and can only be started from the relocate console command like this:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:473
+#: src/Module/Admin/Site.php:477
 msgid "(Friendica directory)# bin/console relocate https://newdomain.com"
 msgstr ""
 
-#: src/Module/Admin/Site.php:476
+#: src/Module/Admin/Site.php:480
 msgid "Site name"
 msgstr ""
 
-#: src/Module/Admin/Site.php:477
+#: src/Module/Admin/Site.php:481
 msgid "Sender Email"
 msgstr ""
 
-#: src/Module/Admin/Site.php:477
+#: src/Module/Admin/Site.php:481
 msgid "The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: src/Module/Admin/Site.php:478
+#: src/Module/Admin/Site.php:482
 msgid "Name of the system actor"
 msgstr ""
 
-#: src/Module/Admin/Site.php:478
+#: src/Module/Admin/Site.php:482
 msgid "Name of the internal system account that is used to perform ActivityPub requests. This must be an unused username. If set, this can't be changed again."
 msgstr ""
 
-#: src/Module/Admin/Site.php:479
+#: src/Module/Admin/Site.php:483
 msgid "Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:484
 msgid "Email Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:481
+#: src/Module/Admin/Site.php:485
 msgid "Shortcut icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:481
+#: src/Module/Admin/Site.php:485
 msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:482
+#: src/Module/Admin/Site.php:486
 msgid "Touch icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:482
+#: src/Module/Admin/Site.php:486
 msgid "Link to an icon that will be used for tablets and mobiles."
 msgstr ""
 
-#: src/Module/Admin/Site.php:483
+#: src/Module/Admin/Site.php:487
 msgid "Additional Info"
 msgstr ""
 
-#: src/Module/Admin/Site.php:483
+#: src/Module/Admin/Site.php:487
 #, php-format
 msgid "For public servers: you can add additional information here that will be listed at %s/servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Site.php:488
 msgid "System language"
 msgstr ""
 
-#: src/Module/Admin/Site.php:485
+#: src/Module/Admin/Site.php:489
 msgid "System theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:485
+#: src/Module/Admin/Site.php:489
 #, php-format
 msgid "Default system theme - may be over-ridden by user profiles - <a href=\"%s\" id=\"cnftheme\">Change default theme settings</a>"
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:490
 msgid "Mobile system theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:490
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:487
+#: src/Module/Admin/Site.php:491
 msgid "Force SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:487
+#: src/Module/Admin/Site.php:491
 msgid "Force all Non-SSL requests to SSL - Attention: on some systems it could lead to endless loops."
 msgstr ""
 
-#: src/Module/Admin/Site.php:488
+#: src/Module/Admin/Site.php:492
 msgid "Show help entry from navigation menu"
 msgstr ""
 
-#: src/Module/Admin/Site.php:488
+#: src/Module/Admin/Site.php:492
 msgid "Displays the menu entry for the Help pages from the navigation menu. It is always accessible by calling /help directly."
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:493
 msgid "Single user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:493
 msgid "Make this instance multi-user or single-user for the named user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
+#: src/Module/Admin/Site.php:495
 msgid "Maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
+#: src/Module/Admin/Site.php:495
 #, php-format
 msgid ""
 "Maximum size in bytes of uploaded images. Default is 0, which means no limits. You can put k, m, or g behind the desired value for KiB, MiB, GiB, respectively.\n"
@@ -4555,27 +4564,27 @@ msgid ""
 "\t\t\t\t\t\t\t\t\t\t\t\t\tCurrently <code>upload_max_filesize</code> is set to %s (%s byte)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:499
 msgid "Maximum image length"
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:499
 msgid "Maximum length in pixels of the longest side of uploaded images. Default is -1, which means no limits."
 msgstr ""
 
-#: src/Module/Admin/Site.php:496
+#: src/Module/Admin/Site.php:500
 msgid "JPEG image quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:496
+#: src/Module/Admin/Site.php:500
 msgid "Uploaded JPEGS will be saved at this quality setting [0-100]. Default is 100, which is full quality."
 msgstr ""
 
-#: src/Module/Admin/Site.php:497
+#: src/Module/Admin/Site.php:501
 msgid "Maximum media file size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:497
+#: src/Module/Admin/Site.php:501
 #, php-format
 msgid ""
 "Maximum size in bytes of uploaded media files. Default is 0, which means no limits. You can put k, m, or g behind the desired value for KiB, MiB, GiB, respectively.\n"
@@ -4583,739 +4592,755 @@ msgid ""
 "\t\t\t\t\t\t\t\t\t\t\t\t\tCurrently <code>upload_max_filesize</code> is set to %s (%s byte)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:502
+#: src/Module/Admin/Site.php:506
 msgid "Register policy"
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:507
 msgid "Maximum Users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:503
+#: src/Module/Admin/Site.php:507
 msgid "If defined, the register policy is automatically closed when the given number of users is reached and reopens the registry when the number drops below the limit. It only works when the policy is set to open or close, but not when the policy is set to approval."
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:508
 msgid "Maximum Daily Registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:504
+#: src/Module/Admin/Site.php:508
 msgid "If registration is permitted above, this sets the maximum number of new user registrations to accept per day.  If register is set to closed, this setting has no effect."
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:509
 msgid "Register text"
 msgstr ""
 
-#: src/Module/Admin/Site.php:505
+#: src/Module/Admin/Site.php:509
 msgid "Will be displayed prominently on the registration page. You can use BBCode here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:510
 msgid "Forbidden Nicknames"
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:510
 msgid "Comma separated list of nicknames that are forbidden from registration. Preset is a list of role names according RFC 2142."
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:511
 msgid "Accounts abandoned after x days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:511
 msgid "Will not waste system resources polling external sites for abandonded accounts. Enter 0 for no time limit."
 msgstr ""
 
-#: src/Module/Admin/Site.php:508
+#: src/Module/Admin/Site.php:512
 msgid "Allowed friend domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:508
+#: src/Module/Admin/Site.php:512
 msgid "Comma separated list of domains which are allowed to establish friendships with this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:509
+#: src/Module/Admin/Site.php:513
 msgid "Allowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:509
+#: src/Module/Admin/Site.php:513
 msgid "Comma separated list of domains which are allowed in email addresses for registrations to this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:514
 msgid "Disallowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:514
 msgid "Comma separated list of domains which are rejected as email addresses for registrations to this site. Wildcards are accepted."
 msgstr ""
 
-#: src/Module/Admin/Site.php:511
+#: src/Module/Admin/Site.php:515
 msgid "Block public"
 msgstr ""
 
-#: src/Module/Admin/Site.php:511
+#: src/Module/Admin/Site.php:515
 msgid "Check to block public access to all otherwise public personal pages on this site unless you are currently logged in."
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:516
 msgid "Force publish"
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:516
 msgid "Check to force all profiles on this site to be listed in the site directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:516
 msgid "Enabling this may violate privacy laws like the GDPR"
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:517
 msgid "Global directory URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:517
 msgid "URL to the global directory. If this is not set, the global directory is completely unavailable to the application."
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:518
 msgid "Private posts by default for new users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:518
 msgid "Set default post permissions for all new members to the default privacy circle rather than public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:519
 msgid "Don't include post content in email notifications"
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:519
 msgid "Don't include the content of a post/comment/private message/etc. in the email notifications that are sent out from this site, as a privacy measure."
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:520
 msgid "Disallow public access to addons listed in the apps menu."
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:520
 msgid "Checking this box will restrict addons listed in the apps menu to members only."
 msgstr ""
 
-#: src/Module/Admin/Site.php:517
+#: src/Module/Admin/Site.php:521
 msgid "Don't embed private images in posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:517
+#: src/Module/Admin/Site.php:521
 msgid "Don't replace locally-hosted private photos in posts with an embedded copy of the image. This means that contacts who receive posts containing private photos will have to authenticate and load each image, which may take a while."
 msgstr ""
 
-#: src/Module/Admin/Site.php:518
+#: src/Module/Admin/Site.php:522
 msgid "Explicit Content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:518
+#: src/Module/Admin/Site.php:522
 msgid "Set this to announce that your node is used mostly for explicit content that might not be suited for minors. This information will be published in the node information and might be used, e.g. by the global directory, to filter your node from listings of nodes to join. Additionally a note about this will be shown at the user registration page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:519
+#: src/Module/Admin/Site.php:523
 msgid "Only local search"
 msgstr ""
 
-#: src/Module/Admin/Site.php:519
+#: src/Module/Admin/Site.php:523
 msgid "Blocks search for users who are not logged in to prevent crawlers from blocking your system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:520
+#: src/Module/Admin/Site.php:524
 msgid "Blocked tags for trending tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:520
+#: src/Module/Admin/Site.php:524
 msgid "Comma separated list of hashtags that shouldn't be displayed in the trending tags."
 msgstr ""
 
-#: src/Module/Admin/Site.php:521
+#: src/Module/Admin/Site.php:525
 msgid "Cache contact avatars"
 msgstr ""
 
-#: src/Module/Admin/Site.php:521
+#: src/Module/Admin/Site.php:525
 msgid "Locally store the avatar pictures of the contacts. This uses a lot of storage space but it increases the performance."
 msgstr ""
 
-#: src/Module/Admin/Site.php:522
+#: src/Module/Admin/Site.php:526
 msgid "Allow Users to set remote_self"
 msgstr ""
 
-#: src/Module/Admin/Site.php:522
+#: src/Module/Admin/Site.php:526
 msgid "With checking this, every user is allowed to mark every contact as a remote_self in the repair contact dialog. Setting this flag on a contact causes mirroring every posting of that contact in the users stream."
 msgstr ""
 
-#: src/Module/Admin/Site.php:523
+#: src/Module/Admin/Site.php:527
 msgid "Allow Users to set up relay channels"
 msgstr ""
 
-#: src/Module/Admin/Site.php:523
+#: src/Module/Admin/Site.php:527
 msgid "If enabled, it is possible to create relay users that are used to reshare content based on user defined channels."
 msgstr ""
 
-#: src/Module/Admin/Site.php:524
+#: src/Module/Admin/Site.php:528
 msgid "Adjust the feed poll frequency"
 msgstr ""
 
-#: src/Module/Admin/Site.php:524
+#: src/Module/Admin/Site.php:528
 msgid "Automatically detect and set the best feed poll frequency."
 msgstr ""
 
-#: src/Module/Admin/Site.php:525
+#: src/Module/Admin/Site.php:529
 msgid "Minimum poll interval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:525
+#: src/Module/Admin/Site.php:529
 msgid "Minimal distance in minutes between two polls for mail and feed contacts. Reasonable values are between 1 and 59."
 msgstr ""
 
-#: src/Module/Admin/Site.php:526
+#: src/Module/Admin/Site.php:530
 msgid "Enable multiple registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:526
+#: src/Module/Admin/Site.php:530
 msgid "Enable users to register additional accounts for use as pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:527
+#: src/Module/Admin/Site.php:531
 msgid "Enable OpenID"
 msgstr ""
 
-#: src/Module/Admin/Site.php:527
+#: src/Module/Admin/Site.php:531
 msgid "Enable OpenID support for registration and logins."
 msgstr ""
 
-#: src/Module/Admin/Site.php:528
+#: src/Module/Admin/Site.php:532
 msgid "Enable full name check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:528
+#: src/Module/Admin/Site.php:532
 msgid "Prevents users from registering with a display name with fewer than two parts separated by spaces."
 msgstr ""
 
-#: src/Module/Admin/Site.php:529
+#: src/Module/Admin/Site.php:533
 msgid "Email administrators on new registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:529
+#: src/Module/Admin/Site.php:533
 msgid "If enabled and the system is set to an open registration, an email for each new registration is sent to the administrators."
 msgstr ""
 
-#: src/Module/Admin/Site.php:530
+#: src/Module/Admin/Site.php:534
 msgid "Community pages for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:530
+#: src/Module/Admin/Site.php:534
 msgid "Which community pages should be available for visitors. Local users always see both pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:531
+#: src/Module/Admin/Site.php:535
 msgid "Posts per user on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:531
+#: src/Module/Admin/Site.php:535
 msgid "The maximum number of posts per user on the local community page. This is useful, when a single user floods the local community page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:532
+#: src/Module/Admin/Site.php:536
 msgid "Posts per server on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:532
+#: src/Module/Admin/Site.php:536
 msgid "The maximum number of posts per server on the global community page. This is useful, when posts from a single server flood the global community page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:534
-msgid "Enable Mail support"
-msgstr ""
-
-#: src/Module/Admin/Site.php:534
-msgid "Enable built-in mail support to poll IMAP folders and to reply via mail."
-msgstr ""
-
-#: src/Module/Admin/Site.php:535
-msgid "Mail support can't be enabled because the PHP IMAP module is not installed."
+#: src/Module/Admin/Site.php:537
+msgid "Display local media to visitors"
 msgstr ""
 
 #: src/Module/Admin/Site.php:537
+msgid "When enabled, locally stored media, such as pictures and videos, will be displayed to visitors who are not logged in. When disabled, a message will appear informing visitors that the media is only available to logged-in users."
+msgstr ""
+
+#: src/Module/Admin/Site.php:538
+msgid "Display remote media to visitors"
+msgstr ""
+
+#: src/Module/Admin/Site.php:538
+msgid "When enabled, visitors who are not logged in will be able to view non-locally stored media such as pictures and videos. When disabled, visitors will see a message informing them that the media is available on the remote site."
+msgstr ""
+
+#: src/Module/Admin/Site.php:540
+msgid "Enable Mail support"
+msgstr ""
+
+#: src/Module/Admin/Site.php:540
+msgid "Enable built-in mail support to poll IMAP folders and to reply via mail."
+msgstr ""
+
+#: src/Module/Admin/Site.php:541
+msgid "Mail support can't be enabled because the PHP IMAP module is not installed."
+msgstr ""
+
+#: src/Module/Admin/Site.php:543
 msgid "Diaspora support can't be enabled because Friendica was installed into a sub directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:538
+#: src/Module/Admin/Site.php:544
 msgid "Enable Diaspora support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:538
+#: src/Module/Admin/Site.php:544
 msgid "Enable built-in Diaspora network compatibility for communicating with diaspora servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:539
+#: src/Module/Admin/Site.php:545
 msgid "Verify SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:539
+#: src/Module/Admin/Site.php:545
 msgid "If you wish, you can turn on strict certificate checking. This will mean you cannot connect (at all) to self-signed SSL sites."
 msgstr ""
 
-#: src/Module/Admin/Site.php:540
+#: src/Module/Admin/Site.php:546
 msgid "Proxy user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:540
+#: src/Module/Admin/Site.php:546
 msgid "User name for the proxy server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:541
+#: src/Module/Admin/Site.php:547
 msgid "Proxy URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:541
+#: src/Module/Admin/Site.php:547
 msgid "If you want to use a proxy server that Friendica should use to connect to the network, put the URL of the proxy here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:548
 msgid "Network timeout"
 msgstr ""
 
-#: src/Module/Admin/Site.php:542
+#: src/Module/Admin/Site.php:548
 msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:543
+#: src/Module/Admin/Site.php:549
 msgid "Maximum Load Average"
 msgstr ""
 
-#: src/Module/Admin/Site.php:543
+#: src/Module/Admin/Site.php:549
 #, php-format
 msgid "Maximum system load before delivery and poll processes are deferred - default %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:544
+#: src/Module/Admin/Site.php:550
 msgid "Minimal Memory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:544
+#: src/Module/Admin/Site.php:550
 msgid "Minimal free memory in MB for the worker. Needs access to /proc/meminfo - default 0 (deactivated)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:551
 msgid "Periodically optimize tables"
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:551
 msgid "Periodically optimize tables like the cache and the workerqueue"
 msgstr ""
 
-#: src/Module/Admin/Site.php:547
+#: src/Module/Admin/Site.php:553
 msgid "Discover followers/followings from contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:547
+#: src/Module/Admin/Site.php:553
 msgid "If enabled, contacts are checked for their followers and following contacts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:548
+#: src/Module/Admin/Site.php:554
 msgid "None - deactivated"
 msgstr ""
 
-#: src/Module/Admin/Site.php:549
+#: src/Module/Admin/Site.php:555
 msgid "Local contacts - contacts of our local contacts are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:550
+#: src/Module/Admin/Site.php:556
 msgid "Interactors - contacts of our local contacts and contacts who interacted on locally visible postings are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:552
+#: src/Module/Admin/Site.php:558
 msgid "Only update contacts/servers with local data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:552
+#: src/Module/Admin/Site.php:558
 msgid "If enabled, the system will only look for changes in contacts and servers that engaged on this system by either being in a contact list of a user or when posts or comments exists from the contact on this system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:553
+#: src/Module/Admin/Site.php:559
 msgid "Only update contacts with relations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:553
+#: src/Module/Admin/Site.php:559
 msgid "If enabled, the system will only look for changes in contacts that are in a contact list of a user on this system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:554
+#: src/Module/Admin/Site.php:560
 msgid "Synchronize the contacts with the directory server"
 msgstr ""
 
-#: src/Module/Admin/Site.php:554
+#: src/Module/Admin/Site.php:560
 msgid "if enabled, the system will check periodically for new contacts on the defined directory server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:556
+#: src/Module/Admin/Site.php:562
 msgid "Discover contacts from other servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:556
+#: src/Module/Admin/Site.php:562
 msgid "Periodically query other servers for contacts and servers that they know of. The system queries Friendica, Mastodon and Hubzilla servers. Keep it deactivated on small machines to decrease the database size and load."
 msgstr ""
 
-#: src/Module/Admin/Site.php:557
+#: src/Module/Admin/Site.php:563
 msgid "Days between requery"
 msgstr ""
 
-#: src/Module/Admin/Site.php:557
+#: src/Module/Admin/Site.php:563
 msgid "Number of days after which a server is requeried for their contacts and servers it knows of. This is only used when the discovery is activated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:558
+#: src/Module/Admin/Site.php:564
 msgid "Search the local directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:558
+#: src/Module/Admin/Site.php:564
 msgid "Search the local directory instead of the global directory. When searching locally, every search will be executed on the global directory in the background. This improves the search results when the search is repeated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:560
+#: src/Module/Admin/Site.php:566
 msgid "Publish server information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:560
+#: src/Module/Admin/Site.php:566
 msgid "If enabled, general server and usage data will be published. The data contains the name and version of the server, number of users with public profiles, number of posts and the activated protocols and connectors. See <a href=\"http://the-federation.info/\">the-federation.info</a> for details."
 msgstr ""
 
-#: src/Module/Admin/Site.php:562
+#: src/Module/Admin/Site.php:568
 msgid "Check upstream version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:562
+#: src/Module/Admin/Site.php:568
 msgid "Enables checking for new Friendica versions at github. If there is a new version, you will be informed in the admin panel overview."
 msgstr ""
 
-#: src/Module/Admin/Site.php:563
+#: src/Module/Admin/Site.php:569
 msgid "Suppress Tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:563
+#: src/Module/Admin/Site.php:569
 msgid "Suppress showing a list of hashtags at the end of the posting."
 msgstr ""
 
-#: src/Module/Admin/Site.php:564
+#: src/Module/Admin/Site.php:570
 msgid "Clean database"
 msgstr ""
 
-#: src/Module/Admin/Site.php:564
+#: src/Module/Admin/Site.php:570
 msgid "Remove old remote items, orphaned database records and old content from some other helper tables."
 msgstr ""
 
-#: src/Module/Admin/Site.php:565
+#: src/Module/Admin/Site.php:571
 msgid "Lifespan of remote items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:565
+#: src/Module/Admin/Site.php:571
 msgid "When the database cleanup is enabled, this defines the days after which remote items will be deleted. Own items, and marked or filed items are always kept. 0 disables this behaviour."
 msgstr ""
 
-#: src/Module/Admin/Site.php:566
+#: src/Module/Admin/Site.php:572
 msgid "Lifespan of unclaimed items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:566
+#: src/Module/Admin/Site.php:572
 msgid "When the database cleanup is enabled, this defines the days after which unclaimed remote items (mostly content from the relay) will be deleted. Default value is 90 days. Defaults to the general lifespan value of remote items if set to 0."
 msgstr ""
 
-#: src/Module/Admin/Site.php:567
+#: src/Module/Admin/Site.php:573
 msgid "Lifespan of raw conversation data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:567
+#: src/Module/Admin/Site.php:573
 msgid "The conversation data is used for ActivityPub, as well as for debug purposes. It should be safe to remove it after 14 days, default is 90 days."
 msgstr ""
 
-#: src/Module/Admin/Site.php:568
+#: src/Module/Admin/Site.php:574
 msgid "Maximum numbers of comments per post"
 msgstr ""
 
-#: src/Module/Admin/Site.php:568
+#: src/Module/Admin/Site.php:574
 msgid "How much comments should be shown for each post? Default value is 100."
 msgstr ""
 
-#: src/Module/Admin/Site.php:569
+#: src/Module/Admin/Site.php:575
 msgid "Maximum numbers of comments per post on the display page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:569
+#: src/Module/Admin/Site.php:575
 msgid "How many comments should be shown on the single view for each post? Default value is 1000."
 msgstr ""
 
-#: src/Module/Admin/Site.php:570
+#: src/Module/Admin/Site.php:576
 msgid "Items per page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:570
+#: src/Module/Admin/Site.php:576
 msgid "Number of items per page in stream pages (network, community, profile/contact statuses, search)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:571
+#: src/Module/Admin/Site.php:577
 msgid "Items per page for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:571
+#: src/Module/Admin/Site.php:577
 msgid "Number of items per page in stream pages (network, community, profile/contact statuses, search) for mobile devices."
 msgstr ""
 
-#: src/Module/Admin/Site.php:572
+#: src/Module/Admin/Site.php:578
 msgid "Temp path"
 msgstr ""
 
-#: src/Module/Admin/Site.php:572
+#: src/Module/Admin/Site.php:578
 msgid "If you have a restricted system where the webserver can't access the system temp path, enter another path here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:573
+#: src/Module/Admin/Site.php:579
 msgid "Only search in tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:573
+#: src/Module/Admin/Site.php:579
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: src/Module/Admin/Site.php:574
+#: src/Module/Admin/Site.php:580
 msgid "Limited search scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:574
+#: src/Module/Admin/Site.php:580
 msgid "If enabled, searches will only be performed in the data used for the channels and not in all posts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:575
+#: src/Module/Admin/Site.php:581
 msgid "Maximum age of items in the search table"
 msgstr ""
 
-#: src/Module/Admin/Site.php:575
+#: src/Module/Admin/Site.php:581
 msgid "Maximum age of items in the search table in days. Lower values will increase the performance and reduce disk usage. 0 means no age restriction."
 msgstr ""
 
-#: src/Module/Admin/Site.php:576
+#: src/Module/Admin/Site.php:582
 msgid "Generate counts per contact circle when calculating network count"
 msgstr ""
 
-#: src/Module/Admin/Site.php:576
+#: src/Module/Admin/Site.php:582
 msgid "On systems with users that heavily use contact circles the query can be very expensive."
 msgstr ""
 
-#: src/Module/Admin/Site.php:577
+#: src/Module/Admin/Site.php:583
 msgid "Process \"view\" activities"
 msgstr ""
 
-#: src/Module/Admin/Site.php:577
+#: src/Module/Admin/Site.php:583
 msgid "\"view\" activities are mostly geberated by Peertube systems. Per default they are not processed for performance reasons. Only activate this option on performant system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:578
+#: src/Module/Admin/Site.php:584
 msgid "Days, after which a contact is archived"
 msgstr ""
 
-#: src/Module/Admin/Site.php:578
+#: src/Module/Admin/Site.php:584
 msgid "Number of days that we try to deliver content or to update the contact data before we archive a contact."
 msgstr ""
 
-#: src/Module/Admin/Site.php:580
+#: src/Module/Admin/Site.php:586
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:580
+#: src/Module/Admin/Site.php:586
 #, php-format
 msgid "On shared hosters set this to %d. On larger systems, values of %d are great. Default value is %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:581
+#: src/Module/Admin/Site.php:587
 msgid "Maximum load for workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:581
+#: src/Module/Admin/Site.php:587
 msgid "Maximum load that causes a cooldown before each worker function call."
 msgstr ""
 
-#: src/Module/Admin/Site.php:582
+#: src/Module/Admin/Site.php:588
 msgid "Enable fastlane"
 msgstr ""
 
-#: src/Module/Admin/Site.php:582
+#: src/Module/Admin/Site.php:588
 msgid "When enabed, the fastlane mechanism starts an additional worker if processes with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: src/Module/Admin/Site.php:583
+#: src/Module/Admin/Site.php:589
 msgid "Decoupled receiver"
 msgstr ""
 
-#: src/Module/Admin/Site.php:583
+#: src/Module/Admin/Site.php:589
 msgid "Decouple incoming ActivityPub posts by processing them in the background via a worker process. Only enable this on fast systems."
 msgstr ""
 
-#: src/Module/Admin/Site.php:584
+#: src/Module/Admin/Site.php:590
 msgid "Fetch replies mode"
 msgstr ""
 
-#: src/Module/Admin/Site.php:584
+#: src/Module/Admin/Site.php:590
 msgid "Missing replies can be fetched upon receipt of an ActivityPub post."
 msgstr ""
 
-#: src/Module/Admin/Site.php:585
+#: src/Module/Admin/Site.php:591
 msgid "Cron interval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:585
+#: src/Module/Admin/Site.php:591
 msgid "Minimal period in minutes between two calls of the \"Cron\" worker job."
 msgstr ""
 
-#: src/Module/Admin/Site.php:586
+#: src/Module/Admin/Site.php:592
 msgid "Worker defer limit"
 msgstr ""
 
-#: src/Module/Admin/Site.php:586
+#: src/Module/Admin/Site.php:592
 msgid "Per default the systems tries delivering for 15 times before dropping it."
 msgstr ""
 
-#: src/Module/Admin/Site.php:587
+#: src/Module/Admin/Site.php:593
 msgid "Worker fetch limit"
 msgstr ""
 
-#: src/Module/Admin/Site.php:587
+#: src/Module/Admin/Site.php:593
 msgid "Number of worker tasks that are fetched in a single query. Higher values should increase the performance, too high values will mostly likely decrease it. Only change it, when you know how to measure the performance of your system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:589
+#: src/Module/Admin/Site.php:595
 msgid "Direct relay transfer"
 msgstr ""
 
-#: src/Module/Admin/Site.php:589
+#: src/Module/Admin/Site.php:595
 msgid "Enables the direct transfer to other servers without using the relay servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:590
+#: src/Module/Admin/Site.php:596
 msgid "Relay scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:590
+#: src/Module/Admin/Site.php:596
 msgid "Can be \"all\" or \"tags\". \"all\" means that every public post should be received. \"tags\" means that only posts with selected tags should be received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:590 src/Module/Contact/Profile.php:354
+#: src/Module/Admin/Site.php:596 src/Module/Contact/Profile.php:354
 #: src/Module/Settings/Display.php:256
 #: src/Module/Settings/TwoFactor/Index.php:132
 msgid "Disabled"
 msgstr ""
 
-#: src/Module/Admin/Site.php:590
+#: src/Module/Admin/Site.php:596
 msgid "all"
 msgstr ""
 
-#: src/Module/Admin/Site.php:590
+#: src/Module/Admin/Site.php:596
 msgid "tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:591
+#: src/Module/Admin/Site.php:597
 msgid "Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:591
+#: src/Module/Admin/Site.php:597
 msgid "Comma separated list of tags for the \"tags\" subscription."
 msgstr ""
 
-#: src/Module/Admin/Site.php:592
+#: src/Module/Admin/Site.php:598
 msgid "Deny Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:592
+#: src/Module/Admin/Site.php:598
 msgid "Comma separated list of tags that are rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:593
+#: src/Module/Admin/Site.php:599
 msgid "Maximum amount of tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:593
+#: src/Module/Admin/Site.php:599
 msgid "Maximum amount of tags in a post before it is rejected as spam. The post has to contain at least one link. Posts from subscribed accounts will not be rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:594
+#: src/Module/Admin/Site.php:600
 msgid "Allow user tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:594
+#: src/Module/Admin/Site.php:600
 msgid "If enabled, the tags from the saved searches will used for the \"tags\" subscription in addition to the \"relay_server_tags\"."
 msgstr ""
 
-#: src/Module/Admin/Site.php:595
+#: src/Module/Admin/Site.php:601
 msgid "Deny undetected languages"
 msgstr ""
 
-#: src/Module/Admin/Site.php:595
+#: src/Module/Admin/Site.php:601
 msgid "If enabled, posts with undetected languages will be rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:596
+#: src/Module/Admin/Site.php:602
 msgid "Language Quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:596
+#: src/Module/Admin/Site.php:602
 msgid "The minimum language quality that is required to accept the post."
 msgstr ""
 
-#: src/Module/Admin/Site.php:597
+#: src/Module/Admin/Site.php:603
 msgid "Number of languages for the language detection"
 msgstr ""
 
-#: src/Module/Admin/Site.php:597
+#: src/Module/Admin/Site.php:603
 msgid "The system detects a list of languages per post. Only if the desired languages are in the list, the message will be accepted. The higher the number, the more posts will be falsely detected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:599
+#: src/Module/Admin/Site.php:605
 msgid "Maximum age of channel"
 msgstr ""
 
-#: src/Module/Admin/Site.php:599
+#: src/Module/Admin/Site.php:605
 msgid "This defines the maximum age in hours of items that should be displayed in channels. This affects the channel performance."
 msgstr ""
 
-#: src/Module/Admin/Site.php:600
+#: src/Module/Admin/Site.php:606
 msgid "Maximum number of channel posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:600
+#: src/Module/Admin/Site.php:606
 msgid "For performance reasons, the channels use a dedicated table to store content. The higher the value the slower the channels."
 msgstr ""
 
-#: src/Module/Admin/Site.php:601
+#: src/Module/Admin/Site.php:607
 msgid "Interaction score days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:601
+#: src/Module/Admin/Site.php:607
 msgid "Number of days that are used to calculate the interaction score."
 msgstr ""
 
-#: src/Module/Admin/Site.php:602
+#: src/Module/Admin/Site.php:608
 msgid "Maximum number of posts per author"
 msgstr ""
 
-#: src/Module/Admin/Site.php:602
+#: src/Module/Admin/Site.php:608
 msgid "Maximum number of posts per page by author if the contact frequency is set to \"Display only few posts\". If there are more posts, then the post with the most interactions will be displayed."
 msgstr ""
 
-#: src/Module/Admin/Site.php:603
+#: src/Module/Admin/Site.php:609
 msgid "Sharer interaction days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:603
+#: src/Module/Admin/Site.php:609
 msgid "Number of days of the last interaction that are used to define which sharers are used for the \"sharers of sharers\" channel."
 msgstr ""
 
-#: src/Module/Admin/Site.php:606
+#: src/Module/Admin/Site.php:612
 msgid "Start Relocation"
 msgstr ""
 
@@ -5927,7 +5952,7 @@ msgstr ""
 #: src/Module/Debug/ActivityPubConversion.php:128
 #: src/Module/Debug/Babel.php:280 src/Module/Debug/Localtime.php:50
 #: src/Module/Debug/Probe.php:40 src/Module/Debug/WebFinger.php:37
-#: src/Module/FriendSuggest.php:132 src/Module/Install.php:219
+#: src/Module/FriendSuggest.php:138 src/Module/Install.php:219
 #: src/Module/Install.php:259 src/Module/Install.php:296
 #: src/Module/Invite.php:162 src/Module/Item/Compose.php:188
 #: src/Module/Moderation/Item/Source.php:75
@@ -5999,6 +6024,7 @@ msgstr ""
 #: src/Module/Contact/Profile.php:178 src/Module/Contact/Profile.php:197
 #: src/Module/Contact/Redir.php:79 src/Module/Contact/Redir.php:133
 #: src/Module/FriendSuggest.php:58 src/Module/FriendSuggest.php:96
+#: src/Module/FriendSuggest.php:102
 msgid "Contact not found."
 msgstr ""
 
@@ -6917,11 +6943,11 @@ msgstr ""
 msgid "Friend suggestion sent."
 msgstr ""
 
-#: src/Module/FriendSuggest.php:124
+#: src/Module/FriendSuggest.php:130
 msgid "Suggest Friends"
 msgstr ""
 
-#: src/Module/FriendSuggest.php:127
+#: src/Module/FriendSuggest.php:133
 #, php-format
 msgid "Suggest a friend for %s"
 msgstr ""

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -63,6 +63,8 @@
 		{{include file="field_select.tpl" field=$community_page_style}}
 		{{include file="field_input.tpl" field=$max_author_posts_community_page}}
 		{{include file="field_input.tpl" field=$max_server_posts_community_page}}
+		{{include file="field_checkbox.tpl" field=$display_local_media}}
+		{{include file="field_checkbox.tpl" field=$display_remote_media}}
 
 		{{if $mail_able}}
 			{{include file="field_checkbox.tpl" field=$mail_enabled}}

--- a/view/templates/content/hidden.tpl
+++ b/view/templates/content/hidden.tpl
@@ -1,0 +1,10 @@
+{{*
+  * Copyright (C) 2010-2024, the Friendica project
+  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
+  *
+  * SPDX-License-Identifier: AGPL-3.0-or-later
+  *}}
+<div class="hidden-media">
+	{{$message nofilter}}
+</div>
+<hr class="hidden-media">

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -141,7 +141,8 @@
 						{{include file="field_select.tpl" field=$community_page_style}}
 						{{include file="field_input.tpl" field=$max_author_posts_community_page}}
 						{{include file="field_input.tpl" field=$max_server_posts_community_page}}
-
+						{{include file="field_checkbox.tpl" field=$display_local_media}}
+						{{include file="field_checkbox.tpl" field=$display_remote_media}}
 						{{if $mail_able}}
 							{{include file="field_checkbox.tpl" field=$mail_enabled}}
 						{{else}}


### PR DESCRIPTION
This is the next iteration of the display handling for media for visitors.

There is now a configuration that you can change in which admins can decide to configure it for local media (means on the same machine) or remote media:

<img width="633" height="209" alt="image" src="https://github.com/user-attachments/assets/deafcf2d-2331-4c84-9af1-c9e7831fa625" />

If displaying media is disabled (which will be the default for remote media), a visitor will see this text above the post:
<img width="591" height="95" alt="image" src="https://github.com/user-attachments/assets/f8ebe5d4-84ea-4680-a410-d2c4909dacbc" />

Additionally the PHPDoc header of the PostMedia entity are reworked.
