### PR TITLE
Photos: Small UI/UX adjustments

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -656,7 +656,7 @@ function photos_content()
 
 		$default_upload_box    = Renderer::replaceMacros(Renderer::getMarkupTemplate('photos_default_uploader_box.tpl'), []);
 		$default_upload_submit = Renderer::replaceMacros(Renderer::getMarkupTemplate('photos_default_uploader_submit.tpl'), [
-			'$submit' => DI::l10n()->t('Submit'),
+			'$submit' => DI::l10n()->t('Upload selected picture'),
 		]);
 
 		// Get the relevant size limits for uploads. Abbreviated var names: MaxImageSize -> mis; upload_max_filesize -> umf
@@ -772,12 +772,11 @@ function photos_content()
 				$album_e = $album;
 
 				$o .= Renderer::replaceMacros($edit_tpl, [
-					'$nametext'   => DI::l10n()->t('New album name: '),
-					'$nickname'   => $user['nickname'],
-					'$album'      => $album_e,
-					'$hexalbum'   => bin2hex($album),
-					'$submit'     => DI::l10n()->t('Submit'),
-					'$dropsubmit' => DI::l10n()->t('Delete Album')
+					'$nametext' => DI::l10n()->t('New album name: '),
+					'$nickname' => $user['nickname'],
+					'$album'    => $album_e,
+					'$hexalbum' => bin2hex($album),
+					'$submit'   => DI::l10n()->t('Save changes'),
 				]);
 			}
 		} elseif ($can_post) {
@@ -1022,7 +1021,7 @@ function photos_content()
 					];
 				}
 			}
-			$tags = ['title' => DI::l10n()->t('Tags: '), 'tags' => $tag_arr];
+			$tags = ['title' => DI::l10n()->t('Tags'), 'tags' => $tag_arr];
 			if ($cmd === 'edit' && !empty($tag_arr)) {
 				$tags['removeanyurl'] = 'post/' . $link_item['id'] . '/tag/remove?return=' . urlencode(DI::args()->getCommand());
 				$tags['removetitle']  = DI::l10n()->t('[Select tags to remove]');
@@ -1042,7 +1041,7 @@ function photos_content()
 				'$id'          => $ph[0]['id'],
 				'$album'       => ['albname', DI::l10n()->t('New album name'), $album_e, ''],
 				'$caption'     => ['desc', DI::l10n()->t('Caption'), $caption_e, ''],
-				'$tags'        => ['newtag', DI::l10n()->t('Add a Tag'), "", DI::l10n()->t('Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping')],
+				'$tags'        => ['newtag', DI::l10n()->t('Add a Tag'), "", "", "", "", "", DI::l10n()->t('Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping')],
 				'$rotate_none' => ['rotate', DI::l10n()->t('Do not rotate'), 0, '', true],
 				'$rotate_cw'   => ['rotate', DI::l10n()->t("Rotate CW \x28right\x29"), 1, ''],
 				'$rotate_ccw'  => ['rotate', DI::l10n()->t("Rotate CCW \x28left\x29"), 2, ''],
@@ -1053,7 +1052,7 @@ function photos_content()
 				'$aclselect'   => $aclselect_e,
 
 				'$item_id' => $link_item['id'] ?? 0,
-				'$submit'  => DI::l10n()->t('Submit'),
+				'$submit'  => DI::l10n()->t('Save changes'),
 				'$delete'  => DI::l10n()->t('Delete Photo'),
 
 				// ACL permissions box
@@ -1095,7 +1094,7 @@ function photos_content()
 						'$mytitle'     => DI::l10n()->t('This is you'),
 						'$myphoto'     => $contact['thumb'],
 						'$comment'     => DI::l10n()->t('Comment'),
-						'$submit'      => DI::l10n()->t('Submit'),
+						'$submit'      => DI::l10n()->t('Comment'),
 						'$preview'     => DI::l10n()->t('Preview'),
 						'$loading'     => DI::l10n()->t('Loading...'),
 						'$qcomment'    => $qcomment,
@@ -1151,7 +1150,7 @@ function photos_content()
 						'$mytitle'     => DI::l10n()->t('This is you'),
 						'$myphoto'     => $contact['thumb'],
 						'$comment'     => DI::l10n()->t('Comment'),
-						'$submit'      => DI::l10n()->t('Submit'),
+						'$submit'      => DI::l10n()->t('Comment'),
 						'$preview'     => DI::l10n()->t('Preview'),
 						'$qcomment'    => $qcomment,
 						'$rand_num'    => Crypto::randomDigits(12),
@@ -1231,7 +1230,7 @@ function photos_content()
 							'$mytitle'     => DI::l10n()->t('This is you'),
 							'$myphoto'     => $contact['thumb'],
 							'$comment'     => DI::l10n()->t('Comment'),
-							'$submit'      => DI::l10n()->t('Submit'),
+							'$submit'      => DI::l10n()->t('Comment'),
 							'$preview'     => DI::l10n()->t('Preview'),
 							'$qcomment'    => $qcomment,
 							'$rand_num'    => Crypto::randomDigits(12),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-17 20:39+0100\n"
+"POT-Creation-Date: 2025-12-18 18:33+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -282,7 +282,7 @@ msgstr ""
 msgid "Insert web link"
 msgstr ""
 
-#: mod/message.php:190 mod/message.php:348 mod/photos.php:1257
+#: mod/message.php:190 mod/message.php:348 mod/photos.php:1256
 #: src/Content/Conversation.php:395 src/Content/Conversation.php:1574
 #: src/Module/Item/Compose.php:205 src/Module/Post/Edit.php:143
 #: src/Object/Post.php:617
@@ -379,7 +379,7 @@ msgstr ""
 msgid "Recent Photos"
 msgstr ""
 
-#: mod/photos.php:91 mod/photos.php:682 mod/photos.php:827
+#: mod/photos.php:91 mod/photos.php:682 mod/photos.php:826
 #: src/Module/Profile/Photos.php:422 src/Module/Profile/Photos.php:442
 #: src/Module/Profile/Photos.php:445
 msgid "Upload Photos"
@@ -429,25 +429,8 @@ msgstr ""
 msgid "No photos selected"
 msgstr ""
 
-#: mod/photos.php:659 mod/photos.php:779 mod/photos.php:1056
-#: mod/photos.php:1098 mod/photos.php:1154 mod/photos.php:1234
-#: src/Module/Calendar/Event/Form.php:236 src/Module/Contact/Advanced.php:118
-#: src/Module/Contact/Profile.php:415
-#: src/Module/Debug/ActivityPubConversion.php:128
-#: src/Module/Debug/Babel.php:280 src/Module/Debug/Localtime.php:50
-#: src/Module/Debug/Probe.php:40 src/Module/Debug/WebFinger.php:37
-#: src/Module/FriendSuggest.php:132 src/Module/Install.php:219
-#: src/Module/Install.php:259 src/Module/Install.php:296
-#: src/Module/Invite.php:162 src/Module/Item/Compose.php:188
-#: src/Module/Moderation/Item/Source.php:75
-#: src/Module/Moderation/Report/Create.php:157
-#: src/Module/Moderation/Report/Create.php:172
-#: src/Module/Moderation/Report/Create.php:200
-#: src/Module/Moderation/Report/Create.php:260
-#: src/Module/Settings/Server/Action.php:65 src/Module/User/Delegation.php:181
-#: src/Object/Post.php:1163 view/theme/duepuntozero/config.php:73
-#: view/theme/quattro/config.php:75 view/theme/vier/config.php:123
-msgid "Submit"
+#: mod/photos.php:659 src/Module/Settings/Profile/Index.php:276
+msgid "Upload selected picture"
 msgstr ""
 
 #: mod/photos.php:675
@@ -467,7 +450,7 @@ msgstr ""
 msgid "Do not show a status post for this upload"
 msgstr ""
 
-#: mod/photos.php:691 mod/photos.php:1052 src/Content/Conversation.php:397
+#: mod/photos.php:691 mod/photos.php:1051 src/Content/Conversation.php:397
 #: src/Module/Calendar/Event/Form.php:239 src/Module/Post/Edit.php:181
 msgid "Permissions"
 msgstr ""
@@ -476,11 +459,11 @@ msgstr ""
 msgid "Do you really want to delete this photo album and all its photos?"
 msgstr ""
 
-#: mod/photos.php:757 mod/photos.php:780
+#: mod/photos.php:757
 msgid "Delete Album"
 msgstr ""
 
-#: mod/photos.php:758 mod/photos.php:858 src/Content/Conversation.php:412
+#: mod/photos.php:758 mod/photos.php:857 src/Content/Conversation.php:412
 #: src/Module/Contact/Follow.php:158 src/Module/Contact/Revoke.php:92
 #: src/Module/Contact/Unfollow.php:112
 #: src/Module/Media/Attachment/Browser.php:64
@@ -490,132 +473,139 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: mod/photos.php:784
+#: mod/photos.php:779 mod/photos.php:1055
+#: src/Module/Settings/Server/Index.php:98
+msgid "Save changes"
+msgstr ""
+
+#: mod/photos.php:783
 msgid "Edit Album"
 msgstr ""
 
-#: mod/photos.php:785
+#: mod/photos.php:784
 msgid "Delete album"
 msgstr ""
 
-#: mod/photos.php:789
+#: mod/photos.php:788
 msgid "Show Newest First"
 msgstr ""
 
-#: mod/photos.php:791
+#: mod/photos.php:790
 msgid "Show Oldest First"
 msgstr ""
 
-#: mod/photos.php:812 src/Module/Profile/Photos.php:390
+#: mod/photos.php:811 src/Module/Profile/Photos.php:390
 msgid "View Photo"
 msgstr ""
 
-#: mod/photos.php:844
+#: mod/photos.php:843
 msgid "Permission denied. Access to this item may be restricted."
 msgstr ""
 
-#: mod/photos.php:846
+#: mod/photos.php:845
 msgid "Photo not available"
 msgstr ""
 
-#: mod/photos.php:856
+#: mod/photos.php:855
 msgid "Do you really want to delete this photo?"
 msgstr ""
 
-#: mod/photos.php:857 mod/photos.php:1057
+#: mod/photos.php:856 mod/photos.php:1056
 msgid "Delete Photo"
 msgstr ""
 
-#: mod/photos.php:955
+#: mod/photos.php:954
 msgid "View photo"
 msgstr ""
 
-#: mod/photos.php:957
+#: mod/photos.php:956
 msgid "Edit photo"
 msgstr ""
 
-#: mod/photos.php:958
+#: mod/photos.php:957
 msgid "Delete photo"
 msgstr ""
 
-#: mod/photos.php:959 mod/photos.php:1281
+#: mod/photos.php:958 mod/photos.php:1280
 msgid "Use as profile picture"
 msgstr ""
 
-#: mod/photos.php:966
+#: mod/photos.php:965
 msgid "Private Photo"
 msgstr ""
 
-#: mod/photos.php:972
+#: mod/photos.php:971
 msgid "View Full Size"
 msgstr ""
 
-#: mod/photos.php:1025
-msgid "Tags: "
+#: mod/photos.php:1024 src/Content/Nav.php:271 src/Content/Text/HTML.php:872
+#: src/Content/Widget/TagCloud.php:54
+msgid "Tags"
 msgstr ""
 
-#: mod/photos.php:1028
+#: mod/photos.php:1027
 msgid "[Select tags to remove]"
 msgstr ""
 
-#: mod/photos.php:1043
+#: mod/photos.php:1042
 msgid "New album name"
 msgstr ""
 
-#: mod/photos.php:1044
+#: mod/photos.php:1043
 msgid "Caption"
 msgstr ""
 
-#: mod/photos.php:1045
+#: mod/photos.php:1044
 msgid "Add a Tag"
 msgstr ""
 
-#: mod/photos.php:1045
+#: mod/photos.php:1044
 msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
 msgstr ""
 
-#: mod/photos.php:1046
+#: mod/photos.php:1045
 msgid "Do not rotate"
 msgstr ""
 
-#: mod/photos.php:1047
+#: mod/photos.php:1046
 msgid "Rotate CW (right)"
 msgstr ""
 
-#: mod/photos.php:1048
+#: mod/photos.php:1047
 msgid "Rotate CCW (left)"
 msgstr ""
 
-#: mod/photos.php:1095 mod/photos.php:1151 mod/photos.php:1231
+#: mod/photos.php:1094 mod/photos.php:1150 mod/photos.php:1230
 #: src/Module/Contact.php:609 src/Module/Item/Compose.php:187
 #: src/Object/Post.php:1160
 msgid "This is you"
 msgstr ""
 
-#: mod/photos.php:1097 mod/photos.php:1153 mod/photos.php:1233
+#: mod/photos.php:1096 mod/photos.php:1097 mod/photos.php:1152
+#: mod/photos.php:1153 mod/photos.php:1232 mod/photos.php:1233
 #: src/Module/Moderation/Reports.php:110 src/Object/Post.php:611
 #: src/Object/Post.php:1162
 msgid "Comment"
 msgstr ""
 
-#: mod/photos.php:1099 mod/photos.php:1155 mod/photos.php:1235
+#: mod/photos.php:1098 mod/photos.php:1154 mod/photos.php:1234
 #: src/Content/Conversation.php:409 src/Module/Calendar/Event/Form.php:234
 #: src/Module/Item/Compose.php:200 src/Module/Post/Edit.php:163
 #: src/Object/Post.php:1176
 msgid "Preview"
 msgstr ""
 
-#: mod/photos.php:1100 src/Content/Conversation.php:363 src/Content/Nav.php:113
+#: mod/photos.php:1099 src/Content/Conversation.php:363 src/Content/Nav.php:113
 #: src/Module/Post/Edit.php:128 src/Object/Post.php:1164
 msgid "Loading..."
 msgstr ""
 
-#: mod/photos.php:1192 src/Content/Conversation.php:1496
+#: mod/photos.php:1191 src/Content/Conversation.php:1496
 #: src/Object/Post.php:263
 msgid "Select"
 msgstr ""
 
-#: mod/photos.php:1193 mod/photos.php:1280 src/Content/Conversation.php:1497
+#: mod/photos.php:1192 mod/photos.php:1279 src/Content/Conversation.php:1497
 #: src/Module/Moderation/Users/Active.php:92
 #: src/Module/Moderation/Users/Blocked.php:92
 #: src/Module/Moderation/Users/Index.php:100
@@ -624,31 +614,31 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: mod/photos.php:1254 src/Object/Post.php:435
+#: mod/photos.php:1253 src/Object/Post.php:435
 msgid "Like"
 msgstr ""
 
-#: mod/photos.php:1255 src/Object/Post.php:435
+#: mod/photos.php:1254 src/Object/Post.php:435
 msgid "I like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1256 src/Object/Post.php:436
+#: mod/photos.php:1255 src/Object/Post.php:436
 msgid "Dislike"
 msgstr ""
 
-#: mod/photos.php:1258 src/Object/Post.php:436
+#: mod/photos.php:1257 src/Object/Post.php:436
 msgid "I don't like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1279 src/Object/Post.php:228 src/Object/Post.php:230
+#: mod/photos.php:1278 src/Object/Post.php:228 src/Object/Post.php:230
 msgid "Edit"
 msgstr ""
 
-#: mod/photos.php:1282
+#: mod/photos.php:1281
 msgid "Back to viewing"
 msgstr ""
 
-#: mod/photos.php:1284
+#: mod/photos.php:1283
 msgid "Map"
 msgstr ""
 
@@ -2099,11 +2089,6 @@ msgstr ""
 
 #: src/Content/Nav.php:270 src/Content/Text/HTML.php:871
 msgid "Full Text"
-msgstr ""
-
-#: src/Content/Nav.php:271 src/Content/Text/HTML.php:872
-#: src/Content/Widget/TagCloud.php:54
-msgid "Tags"
 msgstr ""
 
 #: src/Content/Nav.php:272 src/Content/Nav.php:327
@@ -5931,6 +5916,25 @@ msgstr ""
 #: src/Module/Calendar/Event/Form.php:230
 #: src/Module/Calendar/Event/Form.php:231
 msgid "Share this event"
+msgstr ""
+
+#: src/Module/Calendar/Event/Form.php:236 src/Module/Contact/Advanced.php:118
+#: src/Module/Contact/Profile.php:415
+#: src/Module/Debug/ActivityPubConversion.php:128
+#: src/Module/Debug/Babel.php:280 src/Module/Debug/Localtime.php:50
+#: src/Module/Debug/Probe.php:40 src/Module/Debug/WebFinger.php:37
+#: src/Module/FriendSuggest.php:132 src/Module/Install.php:219
+#: src/Module/Install.php:259 src/Module/Install.php:296
+#: src/Module/Invite.php:162 src/Module/Item/Compose.php:188
+#: src/Module/Moderation/Item/Source.php:75
+#: src/Module/Moderation/Report/Create.php:157
+#: src/Module/Moderation/Report/Create.php:172
+#: src/Module/Moderation/Report/Create.php:200
+#: src/Module/Moderation/Report/Create.php:260
+#: src/Module/Settings/Server/Action.php:65 src/Module/User/Delegation.php:181
+#: src/Object/Post.php:1163 view/theme/duepuntozero/config.php:73
+#: view/theme/quattro/config.php:75 view/theme/vier/config.php:123
+msgid "Submit"
 msgstr ""
 
 #: src/Module/Calendar/Event/Form.php:237 src/Module/Profile/Profile.php:289
@@ -10137,10 +10141,6 @@ msgstr ""
 msgid "Upload new picture"
 msgstr ""
 
-#: src/Module/Settings/Profile/Index.php:276
-msgid "Upload selected picture"
-msgstr ""
-
 #: src/Module/Settings/Profile/Index.php:277
 msgid "Pick existing picture from photos"
 msgstr ""
@@ -10375,10 +10375,6 @@ msgstr ""
 
 #: src/Module/Settings/Server/Index.php:97
 msgid "Delete all your settings for the remote server"
-msgstr ""
-
-#: src/Module/Settings/Server/Index.php:98
-msgid "Save changes"
 msgstr ""
 
 #: src/Module/Settings/Server/Index.php:102

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2894,9 +2894,6 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 }
 
 /* photos */
-.photo-album-edit-name, #photo-album-edit-submit {
-	display: inline-block;
-}
 #photo-album-edit-name-label {
 	width: 100%;
 }
@@ -3133,6 +3130,12 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 	opacity: 1;
 	color: #fff;
 }
+#photo-like-div {
+	text-align: center;
+}
+#photo-like-div button.active {
+	color: $link_color;
+}
 .photo-comment-wrapper .comment {
 	position: relative;
 }
@@ -3140,7 +3143,7 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 	color: $font_color_darker;
 	font-size: 13px;
 }
-.photo-comment-wrapper .comment-wwedit-wrapper,
+#photo-like-div, .photo-comment-wrapper .comment-wwedit-wrapper,
 .photo-comment-wrapper .wall-item-outside-wrapper.media:first-child {
 	margin-top: 15px;
 }

--- a/view/theme/frio/templates/album_edit.tpl
+++ b/view/theme/frio/templates/album_edit.tpl
@@ -12,7 +12,7 @@
 		</div>
 
 		<div id="photo-album-edit-submit">
-			<input class="btn-primary btn btn-small" id="photo-album-edit-submit" type="submit" name="submit" value="{{$submit}}" />
+			<input class="btn btn-primary" id="photo-album-edit-submit" type="submit" name="submit" value="{{$submit}}" />
 		</div>
 	</form>
 </div>

--- a/view/theme/frio/templates/like_noshare.tpl
+++ b/view/theme/frio/templates/like_noshare.tpl
@@ -5,17 +5,16 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 
-<div class="wall-item-actions" id="wall-item-like-buttons-{{$id}}">
+<div id="wall-item-like-buttons-{{$id}}">
 	<button type="button"
-	        class="btn-link button-likes{{if $responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$id}}"
+	        class="btn btn-secondary button-likes{{if $responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$id}}"
 	        title="{{$like_title}}"
 	        onclick="doActivityItemAction({{$id}}, 'like'{{if $responses.like.self}}, true{{/if}});">
 		<i class="fa fa-thumbs-up" aria-hidden="true"></i>&nbsp;{{$like}}
 	</button>
 	{{if !$hide_dislike}}
-		<span class="icon-padding"> </span>
 	<button type="button"
-	        class="btn-link button-likes{{if $responses.dislike.self}} active" aria-pressed="true{{/if}}"
+	        class="btn btn-secondary button-likes{{if $responses.dislike.self}} active" aria-pressed="true{{/if}}"
 	        id="dislike-{{$id}}"
 	        title="{{$dislike_title}}"
 	        onclick="doActivityItemAction({{$id}}, 'dislike'{{if $responses.dislike.self}}, true{{/if}});">

--- a/view/theme/frio/templates/photo_edit.tpl
+++ b/view/theme/frio/templates/photo_edit.tpl
@@ -19,12 +19,12 @@
 	{{include file="field_radio.tpl" field=$rotate_ccw}}
 
 	<div id="photo-edit-perms">
-		<button class="btn btn-default btn-sm" data-toggle="modal" data-target="#photo-edit-permission-acl" onclick="return false;">
+		<button class="btn btn-default" data-toggle="modal" data-target="#photo-edit-permission-acl" onclick="return false;">
 			<i id="jot-perms-icon" class="fa {{$lockstate}}"></i> {{$permissions}}
 		</button>
 	</div>
 
-	<input id="photo-edit-submit-button" type="submit" name="submit" value="{{$submit}}" />
+	<input id="photo-edit-submit-button" class="btn btn-primary" type="submit" name="submit" value="{{$submit}}" />
 
 	{{* The modal for advanced-expire (photo permissions) *}}
 	<div id="photo-edit-permission-acl" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">

--- a/view/theme/frio/templates/photo_view.tpl
+++ b/view/theme/frio/templates/photo_view.tpl
@@ -72,8 +72,9 @@
 		<div id="photo-caption">{{$desc}}</div>
 
 		{{* Tags and mentions *}}
-		{{if $tags}}
-		<div id="photo-tags">{{$tags.title}}
+		{{if $tags.tags}}
+		<div id="photo-tags">
+			<p><strong>{{$tags.title}}</strong></p>
 			{{foreach $tags.tags as $t}}
 			<span class="category label btn-success sm">
 				<span class="p-category">{{$t.name nofilter}}</span>


### PR DESCRIPTION
Just let me know if this should target `develop` instead.

Makes a few changes under Photos:
- Change the styling of the like/dislike buttons to be regular sized and give them a background so it's clearer they're clickable
- Also make a few other buttons in there larger so they aren't as tiny (better for touch interfaces)
- Fix a "bug" where the tags section/header showed up even if an image has no tags.
- Change various submit button texts to indicate more clearly what they're doing, instead of just saying "Submit".
- Remove an unused template variable: `dropsubmit`.
- Move tag examples to placeholder

Does not add any new translations, though I did update messages since some references change.

# General observations about the photos section

- For some reason, it seems one can only comment on/like pictures in specific folders??
- It seems like the like/dislike state on pictures either isn't saved correctly, or the UI is just not reflecting it.
  That is, if I like/dislike a picture and then reload the page, there's no indication that I've liked/disliked it?

# Before

<img width="665" height="896" alt="image" src="https://github.com/user-attachments/assets/11047d1d-43d3-4524-8ba4-848cac180769" />

<img width="669" height="995" alt="image" src="https://github.com/user-attachments/assets/c7439a47-06ac-417d-96ea-212c09c77448" />

# After

<img width="669" height="899" alt="image" src="https://github.com/user-attachments/assets/f093499e-cfe1-4865-a18a-72c111946492" />

<img width="674" height="981" alt="image" src="https://github.com/user-attachments/assets/18a03496-c140-452a-9c19-58d85700f019" />