### PR TITLE
Calendar dropdown adjustments and hover indication

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1092,6 +1092,8 @@ ul li .intro-wrapper button.intro-action-link {
 .nav-pills .dropdown-menu li.selected a,
 .nav-tabs .dropdown-menu li.selected a,
 .account .dropdown-menu li.selected a,
+#fc-header .dropdown-menu li button:hover,
+#fc-header .dropdown-menu li button:focus,
 .contact-photo-wrapper .dropdown-menu li.selected a {
 	border-left: 3px solid $link_color;
 	color: #fff;
@@ -3937,6 +3939,15 @@ div.login-form, .login-content-wrapper,
 }
 #fc-header-right .dropdown > button {
 	color: inherit;
+}
+#fc-header .dropdown-menu {
+	padding: 0;
+}
+#fc-header .dropdown-menu li {
+	margin-top: 0;
+}
+#fc-header .dropdown-menu li button {
+	padding: 8px;
 }
 #event-calendar-title {
 	flex: 1;


### PR DESCRIPTION
Adds a hover effect and more spacing to the calendar dropdown for selecting the time range.
Uses the same hover colour as the user menu.

At some point the hover cover used in both places should arguably should be lightened for better contrast, but I'm not sure how to test that. If I change `menu_background_hover_color` in style.php it does not seem to take immediate effect. Maybe it's saved in the db?

Before:
<img width="671" height="443" alt="image" src="https://github.com/user-attachments/assets/5b6e4fa2-5d5d-4225-b63c-56d7b7f66c81" />

After:

<img width="671" height="443" alt="image" src="https://github.com/user-attachments/assets/1122da23-c930-47dd-beef-f6dcaee4fa89" />
