### PR TITLE
Fix: Additional checks on user import

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -35,7 +35,7 @@ jobs:
           tools: none
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       - name: Install PHP-CS-Fixer
         run: composer install --working-dir=bin/dev/php-cs-fixer
@@ -68,7 +68,7 @@ jobs:
           tools: none
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
@@ -100,7 +100,7 @@ jobs:
           tools: none
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
@@ -132,7 +132,7 @@ jobs:
           tools: none
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           tools: none
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
@@ -88,7 +88,7 @@ jobs:
           ini-values: apc.enabled=1, apc.enable_cli=1
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       # Install composer dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.woodpecker/.phpunit.yml
+++ b/.woodpecker/.phpunit.yml
@@ -57,7 +57,7 @@ steps:
   composer_install:
     image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     commands:
-      - git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+      - git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
       - export COMPOSER_HOME=.composer
       - ./bin/composer.phar validate
       - ./bin/composer.phar install --prefer-dist

--- a/src/Module/User/Import.php
+++ b/src/Module/User/Import.php
@@ -35,6 +35,7 @@ use Psr\Log\LoggerInterface;
 class Import extends \Friendica\BaseModule
 {
 	const IMPORT_DEBUG = false;
+	const MEMORY_LIMIT = 67108864; // 64MB
 
 	/** @var IManageConfigValues */
 	private $config;
@@ -201,7 +202,7 @@ class Import extends \Friendica\BaseModule
 		*/
 
 		$available_memory = Strings::getBytesFromShorthand(ini_get('memory_limit'));
-		$available_memory = $available_memory > 0 ? ($available_memory / 2) : 67108864;
+		$available_memory = $available_memory > 0 ? ($available_memory / 2) : self::MEMORY_LIMIT;
 		if ($file['size'] > $available_memory) {
 			$this->systemMessages->addNotice($this->t('Account file size is too high'));
 			return;

--- a/src/Module/User/Import.php
+++ b/src/Module/User/Import.php
@@ -21,6 +21,7 @@ use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
 use Friendica\Model\Photo;
 use Friendica\Model\Profile;
+use Friendica\Model\User;
 use Friendica\Module\Response;
 use Friendica\Navigation\SystemMessages;
 use Friendica\Network\HTTPException;
@@ -199,6 +200,13 @@ class Import extends \Friendica\BaseModule
 		5. send message to dfrn contacts
 		*/
 
+		$available_memory = Strings::getBytesFromShorthand(ini_get('memory_limit'));
+		$available_memory = $available_memory > 0 ? ($available_memory / 2) : 67108864;
+		if ($file['size'] > $available_memory) {
+			$this->systemMessages->addNotice($this->t('Account file size is too high'));
+			return;
+		}
+
 		$account = json_decode(file_get_contents($file['tmp_name']), true);
 		if ($account === null) {
 			$this->systemMessages->addNotice($this->t('Error decoding account file'));
@@ -218,8 +226,13 @@ class Import extends \Friendica\BaseModule
 			return;
 		}
 
+		if (in_array(strtolower($account['user']['email']), User::getAdminEmailList())) {
+			$this->systemMessages->addNotice($this->t('Cannot use that email.'));
+			return;
+		}
+
 		// Backward compatibility
-		$account['circle'] = $account['circle'] ?? $account['group'];
+		$account['circle']        = $account['circle']        ?? $account['group'];
 		$account['circle_member'] = $account['circle_member'] ?? $account['group_member'];
 
 		$oldBaseUrl = $account['baseurl'];
@@ -380,9 +393,17 @@ class Import extends \Friendica\BaseModule
 
 			$r = Photo::store(
 				new Image($photo['data'], $photo['type'], $photo['filename']),
-				$photo['uid'], $photo['contact-id'], //0
-				$photo['resource-id'], $photo['filename'], $photo['album'], $photo['scale'], $photo['profile'], //1
-				$photo['allow_cid'], $photo['allow_gid'], $photo['deny_cid'], $photo['deny_gid']
+				$photo['uid'],
+				$photo['contact-id'],
+				$photo['resource-id'],
+				$photo['filename'],
+				$photo['album'],
+				$photo['scale'],
+				$photo['profile'],
+				$photo['allow_cid'],
+				$photo['allow_gid'],
+				$photo['deny_cid'],
+				$photo['deny_gid']
 			);
 
 			if ($r === false) {

--- a/src/Util/Strings.php
+++ b/src/Util/Strings.php
@@ -530,7 +530,7 @@ class Strings
 	{
 		$shorthand = trim($shorthand);
 
-		if (ctype_digit($shorthand)) {
+		if (ctype_digit(ltrim($shorthand, '-'))) {
 			return (int) $shorthand;
 		}
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -78,7 +78,7 @@ msgstr ""
 #: src/Module/Settings/UserExport.php:199
 #: src/Module/Settings/UserExport.php:219
 #: src/Module/Settings/UserExport.php:284 src/Module/User/Delegation.php:146
-#: src/Module/User/Import.php:71 src/Module/User/Import.php:78
+#: src/Module/User/Import.php:72 src/Module/User/Import.php:79
 msgid "Permission denied."
 msgstr ""
 
@@ -3737,6 +3737,7 @@ msgid "The nickname was blocked from registration by the nodes admin."
 msgstr ""
 
 #: src/Model/User.php:1290 src/Model/User.php:1296
+#: src/Module/User/Import.php:230
 msgid "Cannot use that email."
 msgstr ""
 
@@ -8745,7 +8746,7 @@ msgstr ""
 msgid "Only parent users can create additional accounts."
 msgstr ""
 
-#: src/Module/Register.php:96 src/Module/User/Import.php:98
+#: src/Module/Register.php:96 src/Module/User/Import.php:99
 msgid "This site has exceeded the number of allowed daily account registrations. Please try again tomorrow."
 msgstr ""
 
@@ -8816,7 +8817,7 @@ msgstr ""
 msgid "Choose a nickname: "
 msgstr ""
 
-#: src/Module/Register.php:178 src/Module/User/Import.php:104
+#: src/Module/Register.php:178 src/Module/User/Import.php:105
 msgid "Import"
 msgstr ""
 
@@ -10890,63 +10891,67 @@ msgstr ""
 msgid "Select an identity to manage: "
 msgstr ""
 
-#: src/Module/User/Import.php:90
+#: src/Module/User/Import.php:91
 msgid "User imports on closed servers can only be done by an administrator."
 msgstr ""
 
-#: src/Module/User/Import.php:106
+#: src/Module/User/Import.php:107
 msgid "Move account"
 msgstr ""
 
-#: src/Module/User/Import.php:107
+#: src/Module/User/Import.php:108
 msgid "You can import an account from another Friendica server."
 msgstr ""
 
-#: src/Module/User/Import.php:108
+#: src/Module/User/Import.php:109
 msgid "You need to export your account from the old server and upload it here. We will recreate your old account here with all your contacts. We will try also to inform your friends that you moved here."
 msgstr ""
 
-#: src/Module/User/Import.php:109
+#: src/Module/User/Import.php:110
 msgid "This feature is experimental. We can't import contacts from the OStatus network (GNU Social/Statusnet) or from Diaspora"
 msgstr ""
 
-#: src/Module/User/Import.php:110
+#: src/Module/User/Import.php:111
 msgid "Account file"
 msgstr ""
 
-#: src/Module/User/Import.php:110
+#: src/Module/User/Import.php:111
 msgid "To export your account, go to \"Settings->Export your personal data\" and select \"Export account\""
 msgstr ""
 
-#: src/Module/User/Import.php:204
+#: src/Module/User/Import.php:206
+msgid "Account file size is too high"
+msgstr ""
+
+#: src/Module/User/Import.php:212
 msgid "Error decoding account file"
 msgstr ""
 
-#: src/Module/User/Import.php:209
+#: src/Module/User/Import.php:217
 msgid "Error! No version data in file! This is not a Friendica account file?"
 msgstr ""
 
-#: src/Module/User/Import.php:217
+#: src/Module/User/Import.php:225
 #, php-format
 msgid "User '%s' already exists on this server!"
 msgstr ""
 
-#: src/Module/User/Import.php:254
+#: src/Module/User/Import.php:267
 msgid "User creation error"
 msgstr ""
 
-#: src/Module/User/Import.php:303
+#: src/Module/User/Import.php:316
 #, php-format
 msgid "%d contact not imported"
 msgid_plural "%d contacts not imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/User/Import.php:352
+#: src/Module/User/Import.php:365
 msgid "User profile creation error"
 msgstr ""
 
-#: src/Module/User/Import.php:403
+#: src/Module/User/Import.php:416
 msgid "Done. You can now login with your username and password"
 msgstr ""
 


### PR DESCRIPTION
This PR introduces two additional checks on the user import.

1. When the file that is about to be imported is higher than the half of the available memory for the PHP process (or 64M in case of `unlimited`), the import is stopped.
2. When the mail address in the import is in the list of admin mail addresses, the import will be stopped as well.