### PR TITLE
Fix: Display the alias URL on follow requests

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -35,7 +35,7 @@ jobs:
           tools: none
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       - name: Install PHP-CS-Fixer
         run: composer install --working-dir=bin/dev/php-cs-fixer
@@ -68,7 +68,7 @@ jobs:
           tools: none
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
@@ -100,7 +100,7 @@ jobs:
           tools: none
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
@@ -132,7 +132,7 @@ jobs:
           tools: none
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           tools: none
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
@@ -88,7 +88,7 @@ jobs:
           ini-values: apc.enabled=1, apc.enable_cli=1
 
       - name: Clone addon repository
-        run: git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+        run: git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
 
       # Install composer dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.woodpecker/.phpunit.yml
+++ b/.woodpecker/.phpunit.yml
@@ -57,7 +57,7 @@ steps:
   composer_install:
     image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     commands:
-      - git clone -b develop --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
+      - git clone -b 2025.07-rc --single-branch https://git.friendi.ca/friendica/friendica-addons.git addon
       - export COMPOSER_HOME=.composer
       - ./bin/composer.phar validate
       - ./bin/composer.phar install --prefer-dist

--- a/src/Module/Contact/Follow.php
+++ b/src/Module/Contact/Follow.php
@@ -160,7 +160,7 @@ class Follow extends BaseModule
 			'$action'   => $requestUrl,
 			'$name'     => $contact['name'],
 			'$url'      => $contact['alias'] ?: $contact['url'],
-			'$zrl'      => OpenWebAuth::getZrlUrl($contact['url']),
+			'$zrl'      => OpenWebAuth::getZrlUrl($contact['alias'] ?: $contact['url']),
 			'$myaddr'   => $myaddr,
 			'$keywords' => $contact['keywords'],
 

--- a/src/Module/Notifications/Introductions.php
+++ b/src/Module/Notifications/Introductions.php
@@ -18,11 +18,13 @@ use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\DI;
+use Friendica\Model\Contact;
 use Friendica\Model\User;
 use Friendica\Module\BaseNotifications;
 use Friendica\Module\Response;
 use Friendica\Navigation\Notifications\Factory\Introduction as IntroductionFactory;
 use Friendica\Navigation\Notifications\ValueObject\Introduction;
+use Friendica\Security\OpenWebAuth;
 use Friendica\Util\Profiler;
 use Psr\Log\LoggerInterface;
 
@@ -102,6 +104,8 @@ class Introductions extends BaseNotifications
 			// We have to distinguish between these two because they use different data.
 			switch ($Introduction->getLabel()) {
 				case 'friend_suggestion':
+					$contact = Contact::getByURL($Introduction->getUrl());
+
 					$notificationContent[] = Renderer::replaceMacros($notificationSuggestions, [
 						'$type'                  => $Introduction->getLabel(),
 						'$str_notification_type' => $this->t('Notification type:'),
@@ -116,8 +120,8 @@ class Introductions extends BaseNotifications
 						'$photo'                 => $Introduction->getPhoto(),
 						'$fullname'              => $Introduction->getName(),
 						'$dfrn_url'              => $owner['url'],
-						'$url'                   => $Introduction->getUrl(),
-						'$zrl'                   => $Introduction->getZrl(),
+						'$url'                   => $contact['alias'] ?: $Introduction->getUrl(),
+						'$zrl'                   => OpenWebAuth::getZrlUrl($contact['alias'] ?: $Introduction->getUrl()),
 						'$lbl_url'               => $this->t('Profile URL'),
 						'$addr'                  => $Introduction->getAddr(),
 						'$action'                => 'contact/follow',
@@ -166,6 +170,8 @@ class Introductions extends BaseNotifications
 						$discard = '';
 					}
 
+					$contact = Contact::getByURL($Introduction->getUrl(), ['alias']);
+
 					$notificationContent[] = Renderer::replaceMacros($notificationTemplate, [
 						'$type'                  => $Introduction->getLabel(),
 						'$header'                => $header,
@@ -187,8 +193,8 @@ class Introductions extends BaseNotifications
 						'$lbl_connection_type'   => $helptext,
 						'$friend'                => $friend,
 						'$follower'              => $follower,
-						'$url'                   => $Introduction->getUrl(),
-						'$zrl'                   => $Introduction->getZrl(),
+						'$url'                   => $contact['alias'] ?: $Introduction->getUrl(),
+						'$zrl'                   => OpenWebAuth::getZrlUrl($contact['alias'] ?: $Introduction->getUrl()),
 						'$lbl_url'               => $this->t('Profile URL'),
 						'$addr'                  => $Introduction->getAddr(),
 						'$lbl_knowyou'           => $lbl_knowyou,


### PR DESCRIPTION
This fixes a "404" when a user receives a follow request and clicks on the provided link to the requester.