### PR TITLE
Fix for Issue #15350: Photo album hover caption CSS specificity for justified gallery

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1671,29 +1671,52 @@ textarea.comment-edit-text:focus + .comment-edit-form .preview {
 	display: inline-block;
 }
 
-.photo-top-image-wrapper .jg-caption {
+/* ALT badge for photos with descriptions in justified gallery */
+.photo-top-image-wrapper:has(img.has-alt-description)::after {
+	background: rgba(0, 0, 0, 0.69);
+	border-radius: 4px;
+	color: #eee;
+	content: "ALT";
+	font-size: 12px;
+	font-weight: bold;
+	padding: 4px 5px;
 	position: absolute;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	background-color: rgba(0, 0, 0, 0.7);
-	color: #fff;
-	padding: 8px 12px;
-	font-size: 14px;
-	text-align: center;
+	bottom: 8px;
+	right: 8px;
+	z-index: 1;
+	pointer-events: none;
+}
+
+.photo-top-image-wrapper .jg-caption,
+#photo-album-contents .photo-top-image-wrapper .jg-caption,
+.justified-gallery > .photo-top-image-wrapper > .jg-caption,
+#photo-album-contents.justified-gallery > .photo-top-image-wrapper > .jg-caption {
+	display: block !important;
+	position: absolute !important;
+	bottom: 0 !important;
+	left: 0 !important;
+	right: 0 !important;
+	background-color: rgba(0, 0, 0, 0.7) !important;
+	color: #fff !important;
+	padding: 8px 12px !important;
+	font-size: 14px !important;
+	text-align: center !important;
 	opacity: 0;
 	visibility: hidden;
 	transition: opacity 0.3s ease, visibility 0.3s ease;
 	pointer-events: none;
 }
 
-.photo-top-image-wrapper:hover .jg-caption {
-	opacity: 1;
-	visibility: visible;
+.photo-top-image-wrapper:hover .jg-caption,
+#photo-album-contents .photo-top-image-wrapper:hover .jg-caption,
+.justified-gallery > .photo-top-image-wrapper:hover > .jg-caption,
+#photo-album-contents.justified-gallery > .photo-top-image-wrapper:hover > .jg-caption {
+	opacity: 1 !important;
+	visibility: visible !important;
 }
 
 .photo-top-image-wrapper .jg-caption a {
-	color: #fff;
+	color: #fff !important;
 	text-decoration: none;
 }
 .fbrowser .profile-rotator-wrapper {

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -510,6 +510,7 @@ function justifyPhotos() {
 		.justifiedGallery({
 			margins: 3,
 			border: 0,
+			captions: false,
 			sizeRangeSuffixes: {
 				lt48: "-6",
 				lt80: "-5",

--- a/view/theme/frio/templates/photo_top.tpl
+++ b/view/theme/frio/templates/photo_top.tpl
@@ -5,8 +5,10 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div class="photo-top-image-wrapper" id="photo-top-image-wrapper-{{$photo.id}}">
-	<a href="{{$photo.link}}" id="photo-top-photo-link-{{$photo.id}}" title="{{$photo.title}}">
-		<img src="{{$photo.src}}" alt="{{if $photo.album.name}}{{$photo.album.name}}{{elseif $photo.desc}}{{$photo.desc}}{{elseif $photo.alt}}{{$photo.alt}}{{else}}{{$photo.unknown}}{{/if}}" title="{{$photo.title}}" id="photo-top-photo-{{$photo.id}}" />
+	<a href="{{$photo.link}}" id="photo-top-photo-link-{{$photo.id}}" title="{{$photo.title}}{{if $photo.desc}}: {{$photo.desc}}{{/if}}">
+		<img src="{{$photo.src}}" alt="{{if $photo.desc}}{{$photo.desc}}{{elseif $photo.alt}}{{$photo.alt}}{{else}}{{$photo.unknown}}{{/if}}" id="photo-top-photo-{{$photo.id}}" {{if $photo.desc}}class="has-alt-description"{{else}}class="empty-description"{{/if}} />
 	</a>
+	{{if $photo.album.name}}
 	<div class="jg-caption"><a href="{{$photo.album.link}}" class="photo-top-album-link" title="{{$photo.album.alt}}">{{$photo.album.name}}</a></div>
+	{{/if}}
 </div>


### PR DESCRIPTION
In the Frio theme photo album view, a black bar was appearing on photo hover due to Justified Gallery auto-creating captions from img alt/title attributes even when there was no attributes set.

- Disabled Justified Gallery's built-in captions (`captions: false`)
- Show album name overlay only in main photos overview (not in album view):

<img width="1365" height="478" alt="image" src="https://github.com/user-attachments/assets/0eb64e75-32ac-4ff4-b3d8-f38c624cdbc6" />

- Add ALT badge indicator for photos with descriptions (like we do in timeline images):

<img width="655" height="527" alt="image" src="https://github.com/user-attachments/assets/beb7042c-efd4-4954-9f13-e9b631352656" />

- Display photo description as browser tooltip: "View Photo: description":

<img width="748" height="526" alt="image" src="https://github.com/user-attachments/assets/37a2c8dd-2ce1-433a-94f0-34e9483d446d" />

Fixes #15350
