### PR TITLE
Fix connection request and suggestion removal

### DIFF
--- a/src/Module/Notifications/Introductions.php
+++ b/src/Module/Notifications/Introductions.php
@@ -124,7 +124,7 @@ class Introductions extends BaseNotifications
 						'$approve'               => $this->t('Approve'),
 						'$note'                  => $Introduction->getNote(),
 						'$ignore'                => $this->t('Ignore'),
-						'$discard'               => $this->t('Discard'),
+						'$discard'               => $this->t('Remove'),
 						'$is_mobile'             => $this->mode->isMobile(),
 					]);
 					break;

--- a/src/Module/Notifications/Notification.php
+++ b/src/Module/Notifications/Notification.php
@@ -68,11 +68,11 @@ class Notification extends BaseModule
 			$intro = $this->introductionRepo->selectOneById($request_id, DI::userSession()->getLocalUserId());
 
 			switch ($_POST['submit']) {
-				case $this->l10n->t('Discard'):
+				case "discard":
 					Contact\Introduction::discard($intro);
 					$this->introductionRepo->delete($intro);
 					break;
-				case $this->l10n->t('Ignore'):
+				case "ignore":
 					$intro->ignore();
 					$this->introductionRepo->save($intro);
 					break;

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-04 14:20+0100\n"
+"POT-Creation-Date: 2026-01-04 19:01+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -235,8 +235,7 @@ msgstr ""
 msgid "Message collection failure."
 msgstr ""
 
-#: mod/message.php:111 src/Module/Notifications/Introductions.php:127
-#: src/Module/Notifications/Notification.php:71
+#: mod/message.php:111
 msgid "Discard"
 msgstr ""
 
@@ -1897,7 +1896,6 @@ msgstr ""
 #: src/Module/Contact/Profile.php:587
 #: src/Module/Notifications/Introductions.php:126
 #: src/Module/Notifications/Introductions.php:200
-#: src/Module/Notifications/Notification.php:75
 msgid "Ignore"
 msgstr ""
 
@@ -8292,6 +8290,13 @@ msgstr ""
 msgid "Suggested by:"
 msgstr ""
 
+#: src/Module/Notifications/Introductions.php:127
+#: src/Module/Notifications/Introductions.php:164
+#: src/Module/Post/Tag/Remove.php:95
+#: src/Module/Settings/TwoFactor/Trusted.php:133
+msgid "Remove"
+msgstr ""
+
 #: src/Module/Notifications/Introductions.php:135
 msgid "Claims to be known to you: "
 msgstr ""
@@ -8319,12 +8324,6 @@ msgstr ""
 
 #: src/Module/Notifications/Introductions.php:150
 msgid "Follower"
-msgstr ""
-
-#: src/Module/Notifications/Introductions.php:164
-#: src/Module/Post/Tag/Remove.php:95
-#: src/Module/Settings/TwoFactor/Trusted.php:133
-msgid "Remove"
 msgstr ""
 
 #: src/Module/Notifications/Introductions.php:198

--- a/view/templates/fsuggest.tpl
+++ b/view/templates/fsuggest.tpl
@@ -9,7 +9,7 @@
 	<form id="fsuggest-form" action="fsuggest/{{$contact_id}}" method="post">
 		{{include file="field_select.tpl" field=$fsuggest_select}}
 		<div id="fsuggest-submit-wrapper">
-			<input id="fsuggest-submit" type="submit" name="submit" value="{{$submit}}" />
+			<button class="btn btn-primary" id="fsuggest-submit" type="submit" name="submit" value="{{$submit}}">{{$submit}}</button>
 		</div>
 	</form>
 </div>

--- a/view/templates/notifications/intros.tpl
+++ b/view/templates/notifications/intros.tpl
@@ -4,38 +4,39 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
+
 <h2>{{$header}}</h2>
 
 <div class="intro-wrapper" id="intro-{{$contact_id}}">
 
 <p class="intro-desc">{{$str_notification_type}} {{$str_type}}</p>
-<img id="photo-{{$contact_id}}" class="intro-photo" src="{{$photo}}" width="175" height=175" title="{{$fullname}}" alt="{{$fullname}}" />
-<dl><dt>{{$lbl_url}}</dt><dd><a target="blank" href="{{$zrl}}">{{$url}}</a></dd></dl>
-{{if $location}}<dl><dt>{{$lbl_location}}</dt><dd>{{$location}}</dd></dl>{{/if}}
-{{if $keywords}}<dl><dt>{{$lbl_keywords}}</dt><dd>{{$keywords}}</dd></dl>{{/if}}
-{{if $about}}<dl><dt>{{$lbl_about}}</dt><dd>{{$about nofilter}}</dd></dl>{{/if}}
-<div class="intro-knowyou">{{$lbl_knowyou}} {{$knowyou}}</div>
-<div class="intro-note" id="intro-note-{{$contact_id}}">{{$note}}</div>
-<div class="intro-wrapper-end" id="intro-wrapper-end-{{$contact_id}}"></div>
-<form class="intro-form" action="notification/{{$intro_id}}" method="post">
-<input class="intro-submit-ignore" type="submit" name="submit" value="{{$ignore}}" />
-{{if $discard}}<input class="intro-submit-discard" type="submit" name="submit" value="{{$discard}}" />{{/if}}
-</form>
-<div class="intro-form-end"></div>
+  <img id="photo-{{$contact_id}}" class="intro-photo" src="{{$photo}}" width="175" height=175" title="{{$fullname}}" alt="{{$fullname}}" />
+  <dl><dt>{{$lbl_url}}</dt><dd><a target="blank" href="{{$zrl}}">{{$url}}</a></dd></dl>
+  {{if $location}}<dl><dt>{{$lbl_location}}</dt><dd>{{$location}}</dd></dl>{{/if}}
+  {{if $keywords}}<dl><dt>{{$lbl_keywords}}</dt><dd>{{$keywords}}</dd></dl>{{/if}}
+  {{if $about}}<dl><dt>{{$lbl_about}}</dt><dd>{{$about nofilter}}</dd></dl>{{/if}}
+  <div class="intro-knowyou">{{$lbl_knowyou}} {{$knowyou}}</div>
+  <div class="intro-note" id="intro-note-{{$contact_id}}">{{$note}}</div>
+  <div class="intro-wrapper-end" id="intro-wrapper-end-{{$contact_id}}"></div>
+  <form class="intro-form" action="notification/{{$intro_id}}" method="post">
+    <button class="intro-submit-ignore" type="submit" name="submit" value="ignore"></button>
+   {{if $discard}}<button class="intro-submit-discard" type="submit" name="submit" value="discard"></button>{{/if}}
+  </form>
+  <div class="intro-form-end"></div>
 
-<form class="intro-approve-form" action="{{$action}}" method="post">
-{{include file="field_checkbox.tpl" field=$hidden}}
-<div role="radiogroup" aria-labelledby="connection_type">
-	<label id="connection_type">{{$lbl_connection_type}}</label>
-	{{include file="field_radio.tpl" field=$friend}}
-	{{include file="field_radio.tpl" field=$follower}}
-</div>
+  <form class="intro-approve-form" action="{{$action}}" method="post">
+  {{include file="field_checkbox.tpl" field=$hidden}}
+  <div role="radiogroup" aria-labelledby="connection_type">
+    <label id="connection_type">{{$lbl_connection_type}}</label>
+    {{include file="field_radio.tpl" field=$friend}}
+    {{include file="field_radio.tpl" field=$follower}}
+  </div>
 
-<input type="hidden" name="dfrn_id" value="{{$dfrn_id}}">
-<input type="hidden" name="intro_id" value="{{$intro_id}}">
-<input type="hidden" name="contact_id" value="{{$contact_id}}">
+  <input type="hidden" name="dfrn_id" value="{{$dfrn_id}}">
+  <input type="hidden" name="intro_id" value="{{$intro_id}}">
+  <input type="hidden" name="contact_id" value="{{$contact_id}}">
 
-<input class="intro-submit-approve" type="submit" name="submit" value="{{$approve}}" />
-</form>
+  <button class="intro-submit-approve" type="submit" name="submit" value="{{$approve}}"></button>
+  </form>
 </div>
 <div class="intro-end"></div>

--- a/view/templates/notifications/suggestions.tpl
+++ b/view/templates/notifications/suggestions.tpl
@@ -5,24 +5,22 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 
-
 <div class="intro-wrapper">
+  <p class="intro-desc">{{$str_notification_type}} {{$str_type}}</p>
+  {{if $madeby}}<div class="intro-madeby">{{$lbl_madeby}} {{$madeby}}</div>{{/if}}
+  <div class="intro-fullname">{{$fullname}}</div>
+  <a class="intro-url-link" href="{{$url}}"><img class="intro-photo lframe" src="{{$photo}}" width="175" height="175" title="{{$fullname}}" alt="{{$fullname}}" /></a>
+  <div class="intro-note">{{$note}}</div>
+  <div class="intro-wrapper-end"></div>
+  <form class="intro-form" action="notification/{{$intro_id}}" method="post">
+    <button class="intro-submit-ignore" type="submit" name="submit" value="ignore"></button>
+    <button class="intro-submit-discard" type="submit" name="submit" value="discard"></button>
+  </form>
+  <div class="intro-form-end"></div>
 
-<p class="intro-desc">{{$str_notification_type}} {{$str_type}}</p>
-{{if $madeby}}<div class="intro-madeby">{{$lbl_madeby}} {{$madeby}}</div>{{/if}}
-<div class="intro-fullname">{{$fullname}}</div>
-<a class="intro-url-link" href="{{$url}}"><img class="intro-photo lframe" src="{{$photo}}" width="175" height="175" title="{{$fullname}}" alt="{{$fullname}}" /></a>
-<div class="intro-note">{{$note}}</div>
-<div class="intro-wrapper-end"></div>
-<form class="intro-form" action="notification/{{$intro_id}}" method="post">
-<input class="intro-submit-ignore" type="submit" name="submit" value="{{$ignore}}" />
-<input class="intro-submit-discard" type="submit" name="submit" value="{{$discard}}" />
-</form>
-<div class="intro-form-end"></div>
-
-<form class="intro-approve-form" action="{{$request}}" method="get">
-{{include file="field_checkbox.tpl" field=$hidden}}
-<input class="intro-submit-approve" type="submit" name="submit" value="{{$approve}}" />
-</form>
+  <form class="intro-approve-form" action="{{$request}}" method="get">
+    {{include file="field_checkbox.tpl" field=$hidden}}
+    <button class="intro-submit-approve" type="submit" name="submit" value="{{$approve}}"></button>
+  </form>
 </div>
 <div class="intro-end"></div>

--- a/view/theme/frio/templates/notifications/intros.tpl
+++ b/view/theme/frio/templates/notifications/intros.tpl
@@ -50,17 +50,17 @@
 			<form class="intro-form" action="notification/{{$intro_id}}" method="post">
 				<button class="btn btn-small btn-primary" type="button" onclick="addElmToModal('#intro-approve-wrapper-{{$intro_id}}');"><i class="fa fa-check" aria-hidden="true"></i> {{$approve}}</button>
 				{{if $discard}}
-					<button class="btn btn-small btn-warning intro-submit-discard" type="submit" name="submit" value="{{$discard}}"><i class="fa fa-trash-o" aria-hidden="true"></i> {{$discard}}</button>
+					<button class="btn btn-small btn-warning intro-submit-discard" type="submit" name="submit" value="discard"><i class="fa fa-trash-o" aria-hidden="true"></i> {{$discard}}</button>
 				{{/if}}
-				<button class="btn btn-small btn-danger intro-submit-ignore" type="submit" name="submit" value="{{$ignore}}"><i class="fa fa-ban" aria-hidden="true"></i> {{$ignore}}</button>
+				<button class="btn btn-small btn-danger intro-submit-ignore" type="submit" name="submit" value="ignore"><i class="fa fa-ban" aria-hidden="true"></i> {{$ignore}}</button>
 			</form>
 			{{else}}
 			{{* The intro actions like approve, ignore, discard intro*}}
 			<div class="intro-actions nav-pills">
 				<button class="btn-link intro-action-link" onclick="addElmToModal('#intro-approve-wrapper-{{$intro_id}}');" aria-label="{{$approve}}" title="{{$approve}}" data-toggle="tooltip"><i class="fa fa-check" aria-hidden="true"></i></button>
 				<form class="intro-form" action="notification/{{$intro_id}}" method="post">
-					<button class="btn-link intro-submit-ignore intro-action-link" type="submit" name="submit" value="{{$ignore}}" aria-label="{{$ignore}}" title="{{$ignore}}" data-toggle="tooltip"><i class="fa fa-ban" aria-hidden="true"></i></button>
-					{{if $discard}}<button class="btn-link intro-submit-discard intro-action-link" type="submit" name="submit" value="{{$discard}}" aria-label="{{$discard}}" title="{{$discard}}" data-toggle="tooltip"><i class="fa fa-trash-o" aria-hidden="true"></i></button>{{/if}}
+					<button class="btn-link intro-submit-ignore intro-action-link" type="submit" name="submit" value="ignore" aria-label="{{$ignore}}" title="{{$ignore}}" data-toggle="tooltip"><i class="fa fa-ban" aria-hidden="true"></i></button>
+					{{if $discard}}<button class="btn-link intro-submit-discard intro-action-link" type="submit" name="submit" value="discard" aria-label="{{$discard}}" title="{{$discard}}" data-toggle="tooltip"><i class="fa fa-trash-o" aria-hidden="true"></i></button>{{/if}}
 				</form>
 			</div>
 			{{/if}}


### PR DESCRIPTION
Closes #15362 

A draft as I need to do a bit more testing, specifically of suggestions.
I'm wondering a little if instead of setting the "value" and identifying which submit button was pressed through that, if we should instead distinguish by "name".

Also did the following:
- Change the submit button hover text of suggestions to "Remove" so its consistent with the new text used for connection requests/introductions.
- Change input -> button

# Edit

I wanted to test suggestions but even though the page loads for me now after annando fixed it (thanks!), when I select a user and suggest a friend, it fails at that point with "Contact not found". Specifically this check on line 56 in FriendSuggest.php:
```php
// We do query the "uid" as well to ensure that it is our contact
if (!$this->dba->exists('contact', ['id' => $cid, 'uid' => DI::userSession()->getLocalUserId()])) {
	throw new NotFoundException($this->t('Contact not found.'));
}
```

...it could be a local test instance issue, though.

Here are all the `contact` entries in the database with the nicknames for either user:
```
+-----+-----+-------+
| id  | uid | nick  |
+-----+-----+-------+
|   3 |   0 | admin |
|   2 |   2 | admin |
|  53 |   5 | admin |
| 109 |   6 | admin |
|  60 |  10 | admin |
| 104 |  11 | admin |
| 100 |  64 | admin |
|  24 |   0 | werw  |
|  23 |   9 | werw  |
+-----+-----+-------+
```

...and it's a friend suggestion for "admin" from "werv", and so PHP is checking for:
ID = 3
UID = 6
...finding no matches.

Maybe I should create an issue for that if someone else can reproduce friend suggestions not working?