### PR TITLE
Adjustments to the admin and moderation summaries (mostly Frio)

### DIFF
--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -8,6 +8,7 @@
 namespace Friendica\Module\Admin;
 
 use Friendica\App;
+use Friendica\Core\Addon\Exception\InvalidAddonException;
 use Friendica\Core\Config\ValueObject\Cache;
 use Friendica\Core\Renderer;
 use Friendica\Core\Update;
@@ -178,18 +179,42 @@ class Summary extends BaseAdmin
 			]
 		];
 
+		$addons = [];
+
+		$addonHelper = DI::addonHelper();
+		foreach ($addonHelper->getEnabledAddons() as $addonId) {
+			try {
+				$addonInfo = $addonHelper->getAddonInfo($addonId);
+			} catch (InvalidAddonException $th) {
+				$this->logger->error('Invalid addon found: ' . $addonId, ['exception' => $th]);
+				continue;
+			}
+
+			$info = [
+				'name'        => $addonInfo->getName(),
+				'description' => $addonInfo->getDescription(),
+				'version'     => $addonInfo->getVersion(),
+			];
+
+			$addons[] = [
+				$addonId,
+				$info,
+			];
+		}
+
 		$t = Renderer::getMarkupTemplate('admin/summary.tpl');
 		return Renderer::replaceMacros($t, [
-			'$title'          => DI::l10n()->t('Administration'),
-			'$page'           => DI::l10n()->t('Summary'),
-			'$queues'         => $queues,
-			'$version_label'  => DI::l10n()->t('Version'),
-			'$platform'       => App::PLATFORM,
-			'$codename'       => App::CODENAME,
-			'$build'          => DI::config()->get('system', 'build'),
-			'$addons'         => [DI::l10n()->t('Active addons'), DI::addonHelper()->getEnabledAddons()],
-			'$serversettings' => $server_settings,
-			'$warningtext'    => $warningtext,
+			'$title'              => DI::l10n()->t('Administration'),
+			'$page'               => DI::l10n()->t('Summary'),
+			'$queues'             => $queues,
+			'$version_label'      => DI::l10n()->t('Version'),
+			'$platform'           => App::PLATFORM,
+			'$codename'           => App::CODENAME,
+			'$build'              => DI::config()->get('system', 'build'),
+			'$addons'             => [DI::l10n()->t('Active addons'), $addons],
+			'$serversettings'     => $server_settings,
+			'$warningtext'        => $warningtext,
+			'$link_enable_addons' => DI::l10n()->t('Enable new addons'),
 		]);
 	}
 

--- a/src/Module/Moderation/Summary.php
+++ b/src/Module/Moderation/Summary.php
@@ -61,12 +61,13 @@ class Summary extends BaseModeration
 
 		$t = Renderer::getMarkupTemplate('moderation/summary.tpl');
 		return Renderer::replaceMacros($t, [
-			'$title'       => $this->t('Moderation'),
-			'$page'        => $this->t('Summary'),
-			'$users'       => [$this->t('Registered users'), $users],
-			'$accounts'    => $accounts,
-			'$pending'     => [$this->t('Pending registrations'), $pending],
-			'$warningtext' => [],
+			'$title'               => $this->t('Moderation'),
+			'$page'                => $this->t('Summary'),
+			'$users'               => [$this->t('Registered users'), $users],
+			'$accounts'            => $accounts,
+			'$pending'             => [$this->t('Pending registrations'), $pending],
+			'$warningtext'         => [],
+			'$account_type_header' => $this->t('Registered accounts by type'),
 		]);
 	}
 }

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-04 20:49+0100\n"
+"POT-Creation-Date: 2026-01-06 15:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3594,7 +3594,7 @@ msgstr ""
 msgid "Title/Description:"
 msgstr ""
 
-#: src/Model/Profile.php:803 src/Module/Admin/Summary.php:184
+#: src/Model/Profile.php:803 src/Module/Admin/Summary.php:208
 #: src/Module/Moderation/Report/Create.php:282
 #: src/Module/Moderation/Summary.php:65
 msgid "Summary"
@@ -3908,7 +3908,7 @@ msgstr ""
 #: src/Module/Admin/Federation.php:218 src/Module/Admin/Logs/Settings.php:74
 #: src/Module/Admin/Logs/View.php:71 src/Module/Admin/Queue.php:59
 #: src/Module/Admin/Site.php:457 src/Module/Admin/Storage.php:124
-#: src/Module/Admin/Summary.php:183 src/Module/Admin/Themes/Details.php:82
+#: src/Module/Admin/Summary.php:207 src/Module/Admin/Themes/Details.php:82
 #: src/Module/Admin/Themes/Index.php:103 src/Module/Admin/Tos.php:63
 #: src/Module/Moderation/Users/Pending.php:82
 msgid "Administration"
@@ -5396,96 +5396,100 @@ msgstr ""
 msgid "Database (legacy)"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:39
+#: src/Module/Admin/Summary.php:40
 #, php-format
 msgid "Template engine (%s) error: %s"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:43
+#: src/Module/Admin/Summary.php:44
 #, php-format
 msgid "Your DB still runs with MyISAM tables. You should change the engine type to InnoDB. As Friendica will use InnoDB only features in the future, you should change this! See <a href=\"%s\">here</a> for a guide that may be helpful converting the table engines. You may also use the command <tt>php bin/console.php dbstructure toinnodb</tt> of your Friendica installation for an automatic conversion.<br />"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:48
+#: src/Module/Admin/Summary.php:49
 #, php-format
 msgid "Your DB still runs with InnoDB tables in the Antelope file format. You should change the file format to Barracuda. Friendica is using features that are not provided by the Antelope format. See <a href=\"%s\">here</a> for a guide that may be helpful converting the table engines. You may also use the command <tt>php bin/console.php dbstructure toinnodb</tt> of your Friendica installation for an automatic conversion.<br />"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:58
+#: src/Module/Admin/Summary.php:59
 #, php-format
 msgid "Your table_definition_cache is too low (%d). This can lead to the database error \"Prepared statement needs to be re-prepared\". Please set it at least to %d. See <a href=\"%s\">here</a> for more information.<br />"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:66
+#: src/Module/Admin/Summary.php:67
 #, php-format
 msgid "There is a new version of Friendica available for download. Your current version is %1$s, upstream version is %2$s"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:74
+#: src/Module/Admin/Summary.php:75
 msgid "The database update failed. Please run \"php bin/console.php dbstructure update\" from the command line and have a look at the errors that might appear."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:78
+#: src/Module/Admin/Summary.php:79
 msgid "The last update failed. Please run \"php bin/console.php dbstructure update\" from the command line and have a look at the errors that might appear. (Some of the errors are possibly inside the logfile.)"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:82
+#: src/Module/Admin/Summary.php:83
 msgid "The system.url entry is missing. This is a low level setting and can lead to unexpected behavior. Please add a valid entry as soon as possible in the config file or per console command!"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:87
+#: src/Module/Admin/Summary.php:88
 msgid "The worker was never executed. Please check your database structure!"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:89
+#: src/Module/Admin/Summary.php:90
 #, php-format
 msgid "The last worker execution was on %s UTC. This is older than one hour. Please check your crontab settings."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:94
+#: src/Module/Admin/Summary.php:95
 #, php-format
 msgid "Friendica's configuration now is stored in config/local.config.php, please copy config/local-sample.config.php and move your config from <code>.htconfig.php</code>. See <a href=\"%s\">the Config help page</a> for help with the transition."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:98
+#: src/Module/Admin/Summary.php:99
 #, php-format
 msgid "Friendica's configuration now is stored in config/local.config.php, please copy config/local-sample.config.php and move your config from <code>config/local.ini.php</code>. See <a href=\"%s\">the Config help page</a> for help with the transition."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:105
+#: src/Module/Admin/Summary.php:106
 #, php-format
 msgid "<a href=\"%s\">%s</a> is not reachable on your system. This is a severe configuration issue that prevents server to server communication. See <a href=\"%s\">the installation page</a> for help."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:133
+#: src/Module/Admin/Summary.php:134
 #, php-format
 msgid "Friendica's system.basepath was updated from '%s' to '%s'. Please remove the system.basepath from your db to avoid differences."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:143
+#: src/Module/Admin/Summary.php:144
 #, php-format
 msgid "Friendica's current system.basepath '%s' is wrong and the config file '%s' isn't used."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:153
+#: src/Module/Admin/Summary.php:154
 #, php-format
 msgid "Friendica's current system.basepath '%s' is not equal to the config file '%s'. Please fix your configuration."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:165
+#: src/Module/Admin/Summary.php:166
 msgid "Message queues"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:168
+#: src/Module/Admin/Summary.php:169
 msgid "Server Settings"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:186
+#: src/Module/Admin/Summary.php:210
 msgid "Version"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:190
+#: src/Module/Admin/Summary.php:214
 msgid "Active addons"
+msgstr ""
+
+#: src/Module/Admin/Summary.php:217
+msgid "Enable new addons"
 msgstr ""
 
 #: src/Module/Admin/Themes/Details.php:49 src/Module/Admin/Themes/Index.php:57
@@ -8083,6 +8087,10 @@ msgstr ""
 
 #: src/Module/Moderation/Summary.php:68
 msgid "Pending registrations"
+msgstr ""
+
+#: src/Module/Moderation/Summary.php:70
+msgid "Registered accounts by type"
 msgstr ""
 
 #: src/Module/Moderation/Users/Active.php:29

--- a/view/templates/admin/addons/index.tpl
+++ b/view/templates/admin/addons/index.tpl
@@ -12,7 +12,7 @@
 	{{$noplugshint}}
 	</div>
 {{else}}
-	<a class="btn" href="{{$baseurl}}/admin/{{$function}}?action=reload&amp;t={{$form_security_token}}">{{$reload}}</a>
+	<p><a class="btn btn-primary" href="{{$baseurl}}/admin/{{$function}}?action=reload&amp;t={{$form_security_token}}">{{$reload}}</a></p>
 	<ul id="addonslist">
 	{{foreach $addons as $p}}
 		<li class="addon {{$p.1}}">

--- a/view/templates/admin/summary.tpl
+++ b/view/templates/admin/summary.tpl
@@ -23,8 +23,8 @@
 	<dl>
 		<dt>{{$addons.0}}</dt>
 
-		{{foreach $addons.1 as $p}}
-			<dd><a href="{{$baseurl}}/admin/addons/{{$p}}/">{{$p}}</a></dd>
+		{{foreach $addons.1 as $a}}
+			<dd><a href="{{$baseurl}}/admin/addons/{{$a.0}}/">{{$a.1.name}}</a></dd>
 		{{/foreach}}
 
 	</dl>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3507,6 +3507,14 @@ section.help-content-wrapper li {
 #admin-summary-wrapper {
 	padding-top: 10px;
 }
+#admin-summary-wrapper h2 {
+	font-size: 21px;
+	padding-top: 13px;
+	padding-bottom: 8px;
+}
+#admin-summary-addons tr td:first-child {
+	width: clamp(30px, 20vw, 200px);
+}
 #adminpage ul#addonslist,
 li.addon {
 	list-style: none;

--- a/view/theme/frio/templates/admin/summary.tpl
+++ b/view/theme/frio/templates/admin/summary.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 
-<div id='adminpage-summery' class="adminpage generic-page-wrapper">
+<div id='adminpage-summary' class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}}</h1>
 
 	{{if $warningtext|count}}
@@ -17,35 +17,36 @@
 	{{/if}}
 
 	<div id="admin-summary-wrapper">
-		{{* The work queues short statistic. *}}
-		<div id="admin-summary-queues" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 admin-summary">
-			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$queues.label}}</div>
-			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry"><a href="{{$baseurl}}/admin/queue/deferred">{{$queues.deferred}}</a> - <a href="{{$baseurl}}/admin/queue">{{$queues.workerq}}</a></div>
-		</div>
+		{{* The work queues short statistic and the friendica version. *}}
+		<table id="admin-summary-queues" class="table">
+			<tr>
+				<td>{{$queues.label}}</td>
+				<td class="admin-summary-entry"><a href="{{$baseurl}}/admin/queue/deferred">{{$queues.deferred}}</a> - <a href="{{$baseurl}}/admin/queue">{{$queues.workerq}}</a></td>
+			</tr>
+			<tr>
+				<td>{{$version_label}}</td>
+				<td class="admin-summary-entry">{{$platform}} '{{$codename}}' {{$VERSION}} - {{$build}}</td>
+			</tr>
+		</table>
 
 		{{* List enabled addons. *}}
-		<div id="admin-summary-addons" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 admin-summary">
-			<hr class="admin-summary-separator">
-			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$addons.0}}</div>
-			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">
-				{{foreach $addons.1 as $p}}
-				<a href="{{$baseurl}}/admin/addons/{{$p}}/">{{$p}}</a><br>
+		<div id="admin-summary-addons">
+			<h2>{{$addons.0}}</h2>
+			<table class="table">
+				{{foreach $addons.1 as $a}}
+				<tr>
+					<td><a href="{{$baseurl}}/admin/addons/{{$a.0}}/">{{$a.1.name}}</a></td>
+					<td>{{$a.1.description}}</td>
+				</tr>
 				{{/foreach}}
-			</div>
+			</table>
 		</div>
-
-		{{* The Friendica version. *}}
-		<div id="admin-summary-version" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 admin-summary">
-			<hr class="admin-summary-separator">
-			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$version_label}}</div>
-			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">{{$platform}} '{{$codename}}' {{$VERSION}} - {{$build}}</div>
-		</div>
+		<p><a class="btn btn-primary" href="/admin/addons">{{$link_enable_addons}}</a></p>
 
 		{{* Server Settings. *}}
-		<div id="admin-summary-php" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 admin-summary">
-			<hr class="admin-summary-separator">
-			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$serversettings.label}}</div>
-			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">
+		<div id="admin-summary-php">
+			<h2>{{$serversettings.label}}</h2>
+			<div class="admin-summary-entry">
 				<table class="table">
 				<tbody>
 					<tr class="info"><td colspan="2">PHP</td></tr>
@@ -62,7 +63,5 @@
 		</div>
 
 	</div>
-
-	<div class="clear"></div>
 
 </div>

--- a/view/theme/frio/templates/moderation/summary.tpl
+++ b/view/theme/frio/templates/moderation/summary.tpl
@@ -5,35 +5,33 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 
-<div id='adminpage-summery' class="adminpage generic-page-wrapper">
+<div id='adminpage-summary' class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}}</h1>
 
 	<div id="admin-summary-wrapper">
-		{{* Number of pending registrations. *}}
-		<div id="admin-summary-pending" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 admin-summary">
-			<hr class="admin-summary-separator">
-			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$pending.0}}</div>
-			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">{{$pending.1}}</div>
-		</div>
+		<table class="table">
+			{{* Number of pending registrations. *}}
+			<tr>
+				<td>{{$pending.0}}</td>
+				<td>{{$pending.1}}</td>
+			</tr>
 
-		{{* Number of registered users *}}
-		<div id="admin-summary-users" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 admin-summary">
-			<hr class="admin-summary-separator">
-			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$users.0}}</div>
-			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">{{$users.1}}</div>
-		</div>
+			{{* Number of registered users *}}
+			<tr>
+				<td>{{$users.0}}</td>
+				<td>{{$users.1}}</td>
+			</tr>
+		</table>
 
 		{{* Account types of registered users. *}}
-		{{foreach $accounts as $p}}
-		<div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 admin-summary">
-			<hr class="admin-summary-separator">
-			<div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 admin-summary-label-name text-muted">{{$p.0}}</div>
-			<div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 admin-summary-entry">{{if $p.1}}{{$p.1}}{{else}}0{{/if}}</div>
-		</div>
-		{{/foreach}}
-
+		<h2>{{$account_type_header}}</h2>
+		<table class="table">
+			{{foreach $accounts as $p}}
+			<tr>
+				<td>{{$p.0}}</td>
+				<td>{{if $p.1}}{{$p.1}}{{else}}0{{/if}}</td>
+			</tr>
+			{{/foreach}}
+		</table>
 	</div>
-
-	<div class="clear"></div>
-
 </div>


### PR DESCRIPTION
Makes some adjustments to the admin and moderation summaries, mostly to show the names and descriptions of addons there as well, instead of the IDs, because in several cases I don't think the IDs explain what an addon does well enough.

As a result of wanting to add that, I needed some more space, so I changed the layout from two column to single column, and then added tables where relevant instead. In that process I simplified the HTML **a lot**.

Also added a link to the page where new addons are added, and made the stats on users by type its own subsection.

Almost exclusively updated Frio, but did check that Vier isn't broken in the process.

Doesn't modify any translations, but two new ones are added.

Thoughts? A little better? Worse? Should the descriptions not be shown there, only the human readable name instead of the ID? Or should the ID be shown as well?

# Admin before

<img width="667" height="580" alt="image" src="https://github.com/user-attachments/assets/1bc38c61-d56f-4710-8c1c-3216d18d98e1" />

Vier:
<img width="794" height="447" alt="image" src="https://github.com/user-attachments/assets/1c98486d-8ad9-478e-a048-307a10fabf04" />

# Admin after
<img width="665" height="890" alt="image" src="https://github.com/user-attachments/assets/2f3f784d-9b2b-4784-9103-4a65ee8c19b0" />

...Vier:
<img width="794" height="447" alt="image" src="https://github.com/user-attachments/assets/f7a3a4cc-e78a-49d1-981a-41690be84108" />

# Moderation before

<img width="682" height="422" alt="image" src="https://github.com/user-attachments/assets/b0d59b74-da0d-4601-8fcb-d19b98005d99" />

# Moderation after

<img width="672" height="457" alt="image" src="https://github.com/user-attachments/assets/ffd61047-e931-45ed-a035-185c6eff1198" />