### PR TITLE
Simplify the UI: User menu redundancy

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -227,7 +227,6 @@ class Nav
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('Your profile page'), 'fa-user'];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Conversations'), '', $this->l10n->t('Conversations you started'), 'fa-commenting'];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos'), 'fa-picture-o'];
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/media', $this->l10n->t('Media'), '', $this->l10n->t('Your postings with media'), 'fa-edit'];
 			$nav['usermenu'][] = ['calendar/', $this->l10n->t('Calendar'), '', $this->l10n->t('Your calendar'), 'fa-calendar'];
 			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Your personal notes'), 'fa-book'];
 

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -224,8 +224,8 @@ class Nav
 
 		if ($this->session->isAuthenticated()) {
 			// user menu
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Conversations'), '', $this->l10n->t('Conversations you started'), 'fa-commenting'];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('Your profile page'), 'fa-user'];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Conversations'), '', $this->l10n->t('Conversations you started'), 'fa-commenting'];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos'), 'fa-picture-o'];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/media', $this->l10n->t('Media'), '', $this->l10n->t('Your postings with media'), 'fa-edit'];
 			$nav['usermenu'][] = ['calendar/', $this->l10n->t('Calendar'), '', $this->l10n->t('Your calendar'), 'fa-calendar'];

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-08 14:11+0100\n"
+"POT-Creation-Date: 2026-02-09 20:34+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -210,12 +210,12 @@ msgstr ""
 msgid "Your password has been changed at %s"
 msgstr ""
 
-#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:316
+#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:315
 #: view/theme/frio/theme.php:229
 msgid "Messages"
 msgstr ""
 
-#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:319
+#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:318
 msgid "New Message"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "View Full Size"
 msgstr ""
 
-#: mod/photos.php:1024 src/Content/Nav.php:271 src/Content/Text/HTML.php:872
+#: mod/photos.php:1024 src/Content/Nav.php:270 src/Content/Text/HTML.php:872
 #: src/Content/Widget/TagCloud.php:54
 msgid "Tags"
 msgstr ""
@@ -1719,7 +1719,7 @@ msgid "Display posts that have been created by accounts of the selected circle."
 msgstr ""
 
 #: src/Content/Feature.php:128 src/Content/GroupManager.php:131
-#: src/Content/Nav.php:276 src/Content/Text/HTML.php:877
+#: src/Content/Nav.php:275 src/Content/Text/HTML.php:877
 #: src/Content/Widget.php:558 src/Model/User.php:1400
 msgid "Groups"
 msgstr ""
@@ -1966,7 +1966,7 @@ msgstr ""
 msgid "Nothing new here"
 msgstr ""
 
-#: src/Content/Nav.php:118 src/Content/Nav.php:249 src/Content/Nav.php:306
+#: src/Content/Nav.php:118 src/Content/Nav.php:248 src/Content/Nav.php:305
 #: src/Module/Help.php:68
 msgid "Home"
 msgstr ""
@@ -1997,24 +1997,24 @@ msgstr ""
 msgid "Sign in"
 msgstr ""
 
-#: src/Content/Nav.php:227 src/Module/BaseProfile.php:42
-#: src/Module/Contact.php:497
-msgid "Conversations"
-msgstr ""
-
-#: src/Content/Nav.php:227
-msgid "Conversations you started"
-msgstr ""
-
-#: src/Content/Nav.php:228 src/Module/BaseProfile.php:34
+#: src/Content/Nav.php:227 src/Module/BaseProfile.php:34
 #: src/Module/BaseSettings.php:86 src/Module/Contact.php:489
 #: src/Module/Contact/Profile.php:471 src/Module/Profile/Profile.php:282
 #: src/Module/Welcome.php:44 view/theme/frio/theme.php:218
 msgid "Profile"
 msgstr ""
 
-#: src/Content/Nav.php:228 view/theme/frio/theme.php:218
+#: src/Content/Nav.php:227 view/theme/frio/theme.php:218
 msgid "Your profile page"
+msgstr ""
+
+#: src/Content/Nav.php:228 src/Module/BaseProfile.php:42
+#: src/Module/Contact.php:497
+msgid "Conversations"
+msgstr ""
+
+#: src/Content/Nav.php:228
+msgid "Conversations you started"
 msgstr ""
 
 #: src/Content/Nav.php:229 src/Module/BaseProfile.php:50
@@ -2026,17 +2026,7 @@ msgstr ""
 msgid "Your photos"
 msgstr ""
 
-#: src/Content/Nav.php:230 src/Module/BaseProfile.php:58
-#: src/Module/BaseProfile.php:61 src/Module/Contact.php:513
-#: view/theme/frio/theme.php:223
-msgid "Media"
-msgstr ""
-
-#: src/Content/Nav.php:230 view/theme/frio/theme.php:223
-msgid "Your postings with media"
-msgstr ""
-
-#: src/Content/Nav.php:231 src/Content/Nav.php:291
+#: src/Content/Nav.php:230 src/Content/Nav.php:290
 #: src/Module/BaseProfile.php:70 src/Module/BaseProfile.php:73
 #: src/Module/BaseProfile.php:81 src/Module/BaseProfile.php:84
 #: src/Module/Calendar/Show.php:113 src/Module/Settings/Display.php:435
@@ -2044,33 +2034,33 @@ msgstr ""
 msgid "Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:231 view/theme/frio/theme.php:224
+#: src/Content/Nav.php:230 view/theme/frio/theme.php:224
 msgid "Your calendar"
 msgstr ""
 
-#: src/Content/Nav.php:232
+#: src/Content/Nav.php:231
 msgid "Personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:232
+#: src/Content/Nav.php:231
 msgid "Your personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:249 src/Module/Settings/OAuth.php:59
+#: src/Content/Nav.php:248 src/Module/Settings/OAuth.php:59
 msgid "Home Page"
 msgstr ""
 
-#: src/Content/Nav.php:253 src/Module/Register.php:173
+#: src/Content/Nav.php:252 src/Module/Register.php:173
 #: src/Module/Security/Login.php:128
 msgid "Register"
 msgstr ""
 
-#: src/Content/Nav.php:253 src/Module/Register.php:157
+#: src/Content/Nav.php:252 src/Module/Register.php:157
 #: src/Module/Security/Login.php:127
 msgid "Create an account"
 msgstr ""
 
-#: src/Content/Nav.php:259 src/Module/Help.php:54
+#: src/Content/Nav.php:258 src/Module/Help.php:54
 #: src/Module/Settings/TwoFactor/AppSpecific.php:118
 #: src/Module/Settings/TwoFactor/Index.php:125
 #: src/Module/Settings/TwoFactor/Recovery.php:96
@@ -2078,32 +2068,32 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: src/Content/Nav.php:259
+#: src/Content/Nav.php:258
 msgid "Help and documentation"
 msgstr ""
 
-#: src/Content/Nav.php:263
+#: src/Content/Nav.php:262
 msgid "Apps"
 msgstr ""
 
-#: src/Content/Nav.php:263
+#: src/Content/Nav.php:262
 msgid "Addon applications, utilities, games"
 msgstr ""
 
-#: src/Content/Nav.php:267 src/Content/Text/HTML.php:862
+#: src/Content/Nav.php:266 src/Content/Text/HTML.php:862
 #: src/Module/Admin/Logs/View.php:74 src/Module/Search/Index.php:99
 msgid "Search"
 msgstr ""
 
-#: src/Content/Nav.php:267
+#: src/Content/Nav.php:266
 msgid "Search site content"
 msgstr ""
 
-#: src/Content/Nav.php:270 src/Content/Text/HTML.php:871
+#: src/Content/Nav.php:269 src/Content/Text/HTML.php:871
 msgid "Full Text"
 msgstr ""
 
-#: src/Content/Nav.php:272 src/Content/Nav.php:327
+#: src/Content/Nav.php:271 src/Content/Nav.php:326
 #: src/Content/Text/HTML.php:873 src/Module/BaseProfile.php:112
 #: src/Module/BaseProfile.php:115 src/Module/Contact.php:181
 #: src/Module/Contact.php:411 src/Module/Contact.php:521
@@ -2111,121 +2101,121 @@ msgstr ""
 msgid "Contacts"
 msgstr ""
 
-#: src/Content/Nav.php:287
+#: src/Content/Nav.php:286
 msgid "Community"
 msgstr ""
 
-#: src/Content/Nav.php:287
+#: src/Content/Nav.php:286
 msgid "Conversations on this and other servers"
 msgstr ""
 
-#: src/Content/Nav.php:294
+#: src/Content/Nav.php:293
 msgid "Directory"
 msgstr ""
 
-#: src/Content/Nav.php:294
+#: src/Content/Nav.php:293
 msgid "People directory"
 msgstr ""
 
-#: src/Content/Nav.php:296 src/Module/BaseAdmin.php:70
+#: src/Content/Nav.php:295 src/Module/BaseAdmin.php:70
 #: src/Module/BaseModeration.php:97
 msgid "Information"
 msgstr ""
 
-#: src/Content/Nav.php:296
+#: src/Content/Nav.php:295
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:299 src/Module/Admin/Tos.php:64
+#: src/Content/Nav.php:298 src/Module/Admin/Tos.php:64
 #: src/Module/BaseAdmin.php:80 src/Module/Register.php:181
 #: src/Module/Tos.php:87
 msgid "Terms of Service"
 msgstr ""
 
-#: src/Content/Nav.php:299
+#: src/Content/Nav.php:298
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:304 view/theme/frio/theme.php:227
+#: src/Content/Nav.php:303 view/theme/frio/theme.php:227
 msgid "Network"
 msgstr ""
 
-#: src/Content/Nav.php:304 view/theme/frio/theme.php:227
+#: src/Content/Nav.php:303 view/theme/frio/theme.php:227
 msgid "Conversations from your friends"
 msgstr ""
 
-#: src/Content/Nav.php:306 view/theme/frio/theme.php:217
+#: src/Content/Nav.php:305 view/theme/frio/theme.php:217
 msgid "Your posts and conversations"
 msgstr ""
 
-#: src/Content/Nav.php:310
+#: src/Content/Nav.php:309
 msgid "Introductions"
 msgstr ""
 
-#: src/Content/Nav.php:310
+#: src/Content/Nav.php:309
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:311 src/Module/BaseNotifications.php:134
+#: src/Content/Nav.php:310 src/Module/BaseNotifications.php:134
 #: src/Module/Notifications/Introductions.php:63
 msgid "Notifications"
 msgstr ""
 
-#: src/Content/Nav.php:312
+#: src/Content/Nav.php:311
 msgid "View all"
 msgstr ""
 
-#: src/Content/Nav.php:313 src/Module/Settings/Connectors.php:226
+#: src/Content/Nav.php:312 src/Module/Settings/Connectors.php:226
 msgid "Mark as read"
 msgstr ""
 
-#: src/Content/Nav.php:313
+#: src/Content/Nav.php:312
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:316 view/theme/frio/theme.php:229
+#: src/Content/Nav.php:315 view/theme/frio/theme.php:229
 msgid "Private mail"
 msgstr ""
 
-#: src/Content/Nav.php:317
+#: src/Content/Nav.php:316
 msgid "Inbox"
 msgstr ""
 
-#: src/Content/Nav.php:318
+#: src/Content/Nav.php:317
 msgid "Outbox"
 msgstr ""
 
-#: src/Content/Nav.php:322
+#: src/Content/Nav.php:321
 msgid "Accounts"
 msgstr ""
 
-#: src/Content/Nav.php:322
+#: src/Content/Nav.php:321
 msgid "Manage other accounts, including groups and pages"
 msgstr ""
 
-#: src/Content/Nav.php:325 src/Module/Admin/Addons/Details.php:140
+#: src/Content/Nav.php:324 src/Module/Admin/Addons/Details.php:140
 #: src/Module/Admin/Themes/Details.php:85 src/Module/BaseSettings.php:177
 #: src/Module/Welcome.php:39 view/theme/frio/theme.php:230
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:325 view/theme/frio/theme.php:230
+#: src/Content/Nav.php:324 view/theme/frio/theme.php:230
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:327 view/theme/frio/theme.php:231
+#: src/Content/Nav.php:326 view/theme/frio/theme.php:231
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:332 src/Module/BaseAdmin.php:114
+#: src/Content/Nav.php:331 src/Module/BaseAdmin.php:114
 msgid "Admin"
 msgstr ""
 
-#: src/Content/Nav.php:332
+#: src/Content/Nav.php:331
 msgid "Site setup and configuration"
 msgstr ""
 
-#: src/Content/Nav.php:333 src/Module/BaseModeration.php:117
+#: src/Content/Nav.php:332 src/Module/BaseModeration.php:117
 #: src/Module/Moderation/Blocklist/Contact.php:98
 #: src/Module/Moderation/Blocklist/Contact/Import.php:101
 #: src/Module/Moderation/Blocklist/Server/Add.php:110
@@ -2242,15 +2232,15 @@ msgstr ""
 msgid "Moderation"
 msgstr ""
 
-#: src/Content/Nav.php:333
+#: src/Content/Nav.php:332
 msgid "Content and user moderation"
 msgstr ""
 
-#: src/Content/Nav.php:336
+#: src/Content/Nav.php:335
 msgid "Navigation"
 msgstr ""
 
-#: src/Content/Nav.php:336
+#: src/Content/Nav.php:335
 msgid "Site map"
 msgstr ""
 
@@ -5782,6 +5772,11 @@ msgstr ""
 
 #: src/Module/BaseProfile.php:45
 msgid "Conversations started"
+msgstr ""
+
+#: src/Module/BaseProfile.php:58 src/Module/BaseProfile.php:61
+#: src/Module/Contact.php:513 view/theme/frio/theme.php:223
+msgid "Media"
 msgstr ""
 
 #: src/Module/BaseProfile.php:96
@@ -12116,6 +12111,10 @@ msgstr ""
 
 #: view/theme/frio/theme.php:202
 msgid "Visitor"
+msgstr ""
+
+#: view/theme/frio/theme.php:223
+msgid "Your postings with media"
 msgstr ""
 
 #: view/theme/quattro/config.php:77

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -197,24 +197,16 @@
 									{{/if}}
 									{{foreach $nav.usermenu as $usermenu}}
 										<li>
-											<a role="menuitem" class="{{$usermenu.2}}" href="{{$usermenu.0}}"
+											<a role="menuitem" class="{{$usermenu.2}}{{if $usermenu.0|str_ends_with:"calendar/"}}visible-xs{{/if}}" href="{{$usermenu.0}}"
 												title="{{$usermenu.3}}">
 												<i class="fa {{$usermenu.4}}"></i>
 												{{$usermenu.1}}
 											</a>
 										</li>
 									{{/foreach}}
-									<li class="divider"><hr></li>
-									{{if $nav.notifications}}
-										<li>
-											<a role="menuitem" href="{{$nav.notifications.all.0}}" title="{{$nav.notifications.1}}">
-												<i class="fa fa-bell fa-fw" aria-hidden="true"></i>
-												{{$nav.notifications.1}}
-											</a>
-										</li>
-									{{/if}}
+									<li class="divider visible-xs"><hr></li>
 									{{if $nav.messages}}
-										<li>
+										<li class="visible-xs">
 											<a role="menuitem"
 												class="nav-commlink {{$nav.messages.2}} {{$sel.messages}}"
 												href="{{$nav.messages.0}}" title="{{$nav.messages.3}}">
@@ -224,9 +216,8 @@
 											</a>
 										</li>
 									{{/if}}
-									<li class="divider"><hr></li>
 									{{if $nav.contacts}}
-										<li>
+										<li class="visible-xs">
 											<a role="menuitem" id="nav-menu-contacts-link"
 												class="nav-link {{$nav.contacts.2}}" href="{{$nav.contacts.0}}"
 												title="{{$nav.contacts.3}}">
@@ -362,16 +353,8 @@
 									</a>
 								</li>
 							{{/foreach}}
-							{{if $nav.notifications || $nav.contacts || $nav.messages || $nav.delegation}}
+							{{if $nav.contacts || $nav.messages || $nav.delegation}}
 								<li class="divider"><hr></li>
-							{{/if}}
-							{{if $nav.notifications}}
-								<li class="list-group-item">
-									<a role="menuitem"
-										href="{{$nav.notifications.all.0}}" title="{{$nav.notifications.1}}"><i
-											class="fa fa-bell fa-fw" aria-hidden="true"></i> {{$nav.notifications.1}}
-									</a>
-								</li>
 							{{/if}}
 							{{if $nav.contacts}}
 								<li class="list-group-item">


### PR DESCRIPTION
Closes #14905, replaces the former PR #14958

Makes the following changes:
- "Calendar", "Contacts" and "Messages" are hidden from the user menu **unless** the width is narrow enough so they're no longer in the top menu
- "Notifications" is **removed** from the user menu, because now the bell icon has a link there, not only in Vier but also Frio
- The link to the profile is moved one step up to be at the top of the user menu, because with that name and being first in the navigation I see it as the "main" profile page?

It's currently also removing the link to "Media"/"Media posts" because:
1. I don't find it very useful and imagine others don't use it much either???
2. It can be reached in just one further step/click from e.g. the profile or photos page
3. Scheduled posts is also a profile tab, and it's not in the user menu, so it's not like everything from the profile is directly accessible there~~

...and I wonder if the same is the case for "Personal notes"?

Thoughts?

This should possibly target develop/the next release, unless people think some parts should be added now. I've set it to draft for now, but it should be ready/in a working state.

# Before

<img width="172" height="710" alt="image" src="https://github.com/user-attachments/assets/b5828cc0-e00a-4f31-be16-60aec7bf2cea" />

# After

Non-small window widths:
<img width="185" height="534" alt="image" src="https://github.com/user-attachments/assets/0a0aa1c8-94c5-46dd-8182-33b0fc3a3fa5" />

At small window widths, Calendar, Contacts and Messages, no longer visible in the top bar, are still shown in the user menu:
<img width="492" height="686" alt="image" src="https://github.com/user-attachments/assets/f429a29a-5f4d-4a6c-b338-6b0a421d242e" />

Below ~314px~ (now 269px) width the layout falls apart, but that's already the case. I wonder if anyone expects to read it at such a small width?

<img width="264" height="166" alt="image" src="https://github.com/user-attachments/assets/40619a50-c669-40aa-b892-5244e1546ebc" />

## Hypothetical scenario (not the PR in its current state)

Here's a mockup if Personal notes wasn't there either :
<img width="167" height="469" alt="image" src="https://github.com/user-attachments/assets/ae1c13cd-d736-45c3-957e-16a7228425d4" />

...and then "Help" could also be moved to the top menu for larger window widths, like random penguin has done in their new theme.