### PR TITLE
FRIO: Use modal for photo deletion confirmation

### DIFF
--- a/view/theme/frio/js/mod_photos.js
+++ b/view/theme/frio/js/mod_photos.js
@@ -39,6 +39,15 @@ $(document).ready(function () {
 			addToModal(modalUrl);
 		}
 	});
+
+	// Click event listener for the photo delete link/button.
+	$("body").on("click", "#photo-delete-link", function () {
+		var modalUrl = $(this).attr("data-modal-url");
+
+		if (typeof modalUrl !== "undefined") {
+			addToModal(modalUrl);
+		}
+	});
 });
 
 $(window).load(function () {

--- a/view/theme/frio/templates/photo_view.tpl
+++ b/view/theme/frio/templates/photo_view.tpl
@@ -31,10 +31,10 @@
 		</a>
 	{{/if}}
 	{{if $tools.delete}}
-		<a id="photo-delete-link" class="btn btn-primary" href="{{$tools.delete.0}}">
+		<button id="photo-delete-link" class="btn btn-primary" type="button" data-modal-url="{{$tools.delete.0}}">
 			<i class="page-action fa fa-trash"></i>
 			{{$delete_text}}
-		</a>
+		</button>
 	{{/if}}
 	{{if $tools.profile}}
 		<a id="photo-toprofile-link" class="btn btn-primary" href="{{$tools.profile.0}}">


### PR DESCRIPTION
Instead of redirecting to a new site, a modal is now asking for confirmation of deleting photos.

Before:

<img width="1149" height="724" alt="image" src="https://github.com/user-attachments/assets/5f65280e-3d46-4467-9c79-7d756cea0d86" />

After:

<img width="1170" height="856" alt="image" src="https://github.com/user-attachments/assets/0e4c01fd-0a73-49d9-aa43-82bba46ed1bd" />

Closes #15349