### PR TITLE
FRIO: Fix styling for revoke follow in profile dropdown

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1054,6 +1054,7 @@ ul li .intro-wrapper button.intro-action-link {
 	border-bottom: none;
 }
 .nav-pills .dropdown-menu li > a,
+.nav-pills .dropdown-menu li > button,
 .nav-tabs .dropdown-menu li > a,
 .account .dropdown-menu li > a,
 .contact-photo-wrapper .dropdown-menu li > a {
@@ -1086,6 +1087,7 @@ ul li .intro-wrapper button.intro-action-link {
 	width: 14px;
 }
 .nav-pills .dropdown-menu li > a:hover,
+.nav-pills .dropdown-menu li > button:hover,
 .nav-tabs .dropdown-menu li > a:hover,
 .account .dropdown-menu li > a:hover,
 .contact-photo-wrapper .dropdown-menu li > a:hover,
@@ -2439,6 +2441,7 @@ ul.dropdown-menu li:hover {
 }
 /* Dropdown Menu */
 .dropdown-menu li a,
+.dropdown-menu li button,
 .tabs .dropdown-menu li a {
 	padding: 6px 20px;
 	font-size: 14px;


### PR DESCRIPTION
Fixes the styling of "Revoke follow" on the profile, in the dropdown.

At some point I think we should cleanup the dropdown styling in general, with a lot less special casing for different sections.
I think a lot of CSS could be deleted this way, and some UI inconsistencies and bugs could probably also be dealt with in the process.

# Before

<img width="682" height="476" alt="image" src="https://github.com/user-attachments/assets/41c0f155-f8d9-4844-b0ca-9abf233ac12b" />

# After

<img width="682" height="476" alt="image" src="https://github.com/user-attachments/assets/43562c5c-2a78-4f1d-84f0-ede0b24e1000" />