### PR TITLE
If groupdirectory is enabled, add a link to it from the network widget (Frio)

### DIFF
--- a/src/Content/GroupManager.php
+++ b/src/Content/GroupManager.php
@@ -122,18 +122,23 @@ class GroupManager
 
 		$tpl = Renderer::getMarkupTemplate('widget/group_list.tpl');
 
+
+		$addonHelper = DI::addonHelper();
+
 		return Renderer::replaceMacros(
 			$tpl,
 			[
-				'$title'            => DI::l10n()->t('Groups'),
-				'$groups'           => $entries,
-				'$link_desc'        => DI::l10n()->t('External link to group'),
-				'$new_group_page'   => 'register/',
-				'$total'            => $total,
-				'$visible_groups'   => $visibleGroups,
-				'$showless'         => DI::l10n()->t('show less'),
-				'$showmore'         => DI::l10n()->t('show more'),
-				'$create_new_group' => DI::l10n()->t('Create new group')
+				'$title'                         => DI::l10n()->t('Groups'),
+				'$groups'                        => $entries,
+				'$link_desc'                     => DI::l10n()->t('External link to group'),
+				'$new_group_page'                => 'register/',
+				'$total'                         => $total,
+				'$visible_groups'                => $visibleGroups,
+				'$showless'                      => DI::l10n()->t('show less'),
+				'$showmore'                      => DI::l10n()->t('show more'),
+				'$create_new_group'              => DI::l10n()->t('Create new group'),
+				'$addon_group_directory_enabled' => $addonHelper->isAddonEnabled("groupdirectory"),
+				'$visit_groupdirectory'          => DI::l10n()->t('Find groups to join'),
 			],
 		);
 	}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2025.07-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-04 19:01+0100\n"
+"POT-Creation-Date: 2026-01-04 20:49+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1708,7 +1708,7 @@ msgstr ""
 msgid "Display posts that have been created by accounts of the selected circle."
 msgstr ""
 
-#: src/Content/Feature.php:128 src/Content/GroupManager.php:128
+#: src/Content/Feature.php:128 src/Content/GroupManager.php:131
 #: src/Content/Nav.php:276 src/Content/Text/HTML.php:877
 #: src/Content/Widget.php:558 src/Model/User.php:1400
 msgid "Groups"
@@ -1817,21 +1817,25 @@ msgstr ""
 msgid "Allows anonymous visitors to consult your calendar and your public events. Contact birthday events are private to you."
 msgstr ""
 
-#: src/Content/GroupManager.php:130
+#: src/Content/GroupManager.php:133
 msgid "External link to group"
 msgstr ""
 
-#: src/Content/GroupManager.php:134 src/Content/Widget.php:533
+#: src/Content/GroupManager.php:137 src/Content/Widget.php:533
 msgid "show less"
 msgstr ""
 
-#: src/Content/GroupManager.php:135 src/Content/Widget.php:428
+#: src/Content/GroupManager.php:138 src/Content/Widget.php:428
 #: src/Content/Widget.php:534
 msgid "show more"
 msgstr ""
 
-#: src/Content/GroupManager.php:136
+#: src/Content/GroupManager.php:139
 msgid "Create new group"
+msgstr ""
+
+#: src/Content/GroupManager.php:141
+msgid "Find groups to join"
 msgstr ""
 
 #: src/Content/Item.php:336 src/Model/Item.php:2787

--- a/view/templates/widget/group_list.tpl
+++ b/view/templates/widget/group_list.tpl
@@ -28,10 +28,16 @@
 			<button class="fakelink" onclick="openCloseWidget('group-list-sidebar', 'group-list-sidebar-inflated');" aria-expanded="true">
 				<h3>{{$title}}</h3>
 			</button>
-			<a class="group-new-tool pull-right widget-action faded-icon" id="sidebar-new-group"
+			<a class="pull-right widget-action widget-action-top faded-icon" id="sidebar-new-group"
 				href="{{$new_group_page}}" data-toggle="tooltip" title="{{$create_new_group}}">
 				<i class="fa fa-plus" aria-hidden="true"></i>
 			</a>
+			{{if $addon_group_directory_enabled}}
+				<a class="pull-right widget-action widget-action-top faded-icon" id="sidebar-group-directory"
+					href="/groupdirectory" data-toggle="tooltip" title="{{$visit_groupdirectory}}">
+					<i class="fa fa-search" aria-hidden="true"></i>
+				</a>
+			{{/if}}
 		</div>
 		<div id="sidebar-group-list" class="sidebar-widget-list">
 			{{* The list of available groups *}}

--- a/view/templates/widget/saved_searches.tpl
+++ b/view/templates/widget/saved_searches.tpl
@@ -25,7 +25,7 @@
 			{{/foreach}}
 		</ul>
 		<div class="clear"></div>
-	</div>>
+	</div>
 </nav>
 <script>
 	initWidget('saved-search-list', 'saved-search-list-inflated');

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1397,19 +1397,14 @@ div#sidebar-group-list {
 	clear: both;
 }
 
-.circle-edit-tool,
-.widget-action-top {
-	padding-top: 0;
-	color: $font_color_darker;
-}
-.sidebar-widget-header .circle-edit-tool,
 .widget-action-top {
 	margin-top: -5px;
+	padding-top: 0;
 }
 
 .faded-icon {
-	color: $font_color_darker;
-	opacity: 0.3;
+	color: $font_color;
+	opacity: 0.58;
 	transition: all 0.1s ease-in-out;
 }
 .faded-icon:hover {
@@ -1423,27 +1418,19 @@ div#sidebar-group-list {
 aside .widget-action {
 	padding: 5px 10px;
 }
-aside #circle-sidebar .sidebar-circle-li .circle-edit-tool.faded-icon:hover,
-aside #group-sidebar .widget-action-top.faded-icon:hover,
+aside .widget-action-top.faded-icon:hover,
 aside #saved-search-list .saved-search-li .savedsearchdrop.faded-icon:hover,
 aside .widget.widget-action.faded-icon:hover {
 	opacity: 0.8;
 	transition: all 0.25s ease-in-out;
 }
-aside #circle-sidebar .sidebar-circle-li .circle-edit-tool.faded-icon:hover,
-aside #group-sidebar .widget-action-top.faded-icon:hover,
+aside .widget-action-top.faded-icon:hover,
 aside #saved-search-list .saved-search-li .savedsearchdrop.faded-icon:hover,
 aside .widget .widget-action.faded-icon:hover {
 	opacity: 1;
 }
 aside #circle-sidebar li .circle-checkbox {
 	margin: 6px 0 0;
-}
-aside #circle-sidebar li .circle-edit-tool {
-	padding-right: 10px;
-}
-aside #circle-sidebar li .circle-edit-tool:first-child {
-	padding-right: 0px;
 }
 
 /* contact block widget */
@@ -1455,8 +1442,6 @@ aside #circle-sidebar li .circle-edit-tool:first-child {
 .contact-block-div {
 	float: left;
 	margin: 0px 5px 5px 0px;
-}
-.contact-block-link {
 }
 .contact-block-img {
 	height: 75px;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1398,12 +1398,12 @@ div#sidebar-group-list {
 }
 
 .circle-edit-tool,
-.group-new-tool {
+.widget-action-top {
 	padding-top: 0;
 	color: $font_color_darker;
 }
 .sidebar-widget-header .circle-edit-tool,
-.group-new-tool {
+.widget-action-top {
 	margin-top: -5px;
 }
 
@@ -1424,14 +1424,14 @@ aside .widget-action {
 	padding: 5px 10px;
 }
 aside #circle-sidebar .sidebar-circle-li .circle-edit-tool.faded-icon:hover,
-aside #group-sidebar .group-new-tool.faded-icon:hover,
+aside #group-sidebar .widget-action-top.faded-icon:hover,
 aside #saved-search-list .saved-search-li .savedsearchdrop.faded-icon:hover,
 aside .widget.widget-action.faded-icon:hover {
 	opacity: 0.8;
 	transition: all 0.25s ease-in-out;
 }
 aside #circle-sidebar .sidebar-circle-li .circle-edit-tool.faded-icon:hover,
-aside #group-sidebar .group-new-tool.faded-icon:hover,
+aside #group-sidebar .widget-action-top.faded-icon:hover,
 aside #saved-search-list .saved-search-li .savedsearchdrop.faded-icon:hover,
 aside .widget .widget-action.faded-icon:hover {
 	opacity: 1;

--- a/view/theme/frio/templates/circle_side.tpl
+++ b/view/theme/frio/templates/circle_side.tpl
@@ -16,11 +16,11 @@
 				<h3>{{$title}}</h3>
 			</button>
 			{{if ! $new_circle}}
-				<a class="circle-edit-tool pull-right widget-action faded-icon" id="sidebar-edit-circle" href="{{$circle_page}}" data-toggle="tooltip" title="{{$edit_circles_text}}">
+				<a class="widget-action-top pull-right widget-action faded-icon" id="sidebar-edit-circle" href="{{$circle_page}}" data-toggle="tooltip" title="{{$edit_circles_text}}">
 					<i class="fa fa-pencil" aria-hidden="true"></i>
 				</a>
 			{{else}}
-				<a class="circle-edit-tool pull-right widget-action faded-icon" id="sidebar-new-circle"
+				<a class="widget-action-top pull-right widget-action faded-icon" id="sidebar-new-circle"
 					onclick="javascript:$('#circle-new-form').fadeIn('fast');" data-toggle="tooltip" title="{{$createtext}}">
 					<i class="fa fa-plus" aria-hidden="true"></i>
 				</a>
@@ -47,7 +47,7 @@
 						{{/if}}
 						{{if $circle.edit}}
 							{{* if the circle is editable show a little pencil for editing *}}
-							<a id="edit-sidebar-circle-element-{{$circle.id}}" class="circle-edit-tool pull-right faded-icon" href="{{$circle.edit.href}}" data-toggle="tooltip" title="{{$edittext}}">
+							<a id="edit-sidebar-circle-element-{{$circle.id}}" class="widget-action-top pull-right faded-icon" href="{{$circle.edit.href}}" data-toggle="tooltip" title="{{$edittext}}">
 								<i class="fa fa-pencil" aria-hidden="true"></i>
 							</a>
 						{{/if}}


### PR DESCRIPTION
After creating #15353 I learned there's already a way to conditionally check whether an addon is enabled via `AddonHelper`, so groupdirectory doesn't have to be moved to core in order to have a link to it. The link to just has to be added only if groupdirectory is enabled.

I still think adding groupdirectory to core would be a good idea, though, because then we could integrate the user and group directories more closely with each other and with the rest of the interface, fx. having a unified menu in there that can navigate between them. That can also be done now but it would require adding a lot more conditionals and that does not seem ideal?

Frio: Also updated the sidebar action icons to be less faded to improve accessibility, and because some people have been saying they were so dim they hadn't even noticed they were there in dark mode.

Adds one new source string: The hover text displayed below

The code standards check fails currently but it appears to be a pipeline issue.

# Before

<img width="302" height="260" alt="image" src="https://github.com/user-attachments/assets/c61b56be-a0d1-4845-a2f7-53ce75877aa4" />

Dark mode widget action icons are currently this faded:
<img width="289" height="289" alt="image" src="https://github.com/user-attachments/assets/40f27775-6c44-4a1d-aa5f-41bc17cb725e" />

# After

...which also has less faded icons:

<img width="289" height="289" alt="image" src="https://github.com/user-attachments/assets/c7c95a2b-2c5a-42d1-a6ef-a19f99ac12e0" />

...including in dark mode:
<img width="289" height="289" alt="image" src="https://github.com/user-attachments/assets/21dd07ab-8efe-45ed-93e8-0d9e0767d9c8" />