### PR TITLE
Fix long links overflowing profile custom fields layout

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -889,3 +889,13 @@ a:has(img.has-alt-description)::after {
 		background-color: transparent;
 	}
 }
+
+/* Profile page custom fields - prevent long links from overflowing */
+#profile-page .profile-entry {
+	overflow-wrap: break-word;
+	word-break: break-word;
+}
+
+#profile-page .profile-entry a {
+	word-break: break-all;
+}


### PR DESCRIPTION
When users add custom profile fields containing long URLs (e.g., Deltachat profile links), the links overflow the layout and break the page design.

Added CSS rules in global.css to properly wrap long URLs within the profile entry container:

- overflow-wrap: break-word and word-break: break-word for .profile-entry
- word-break: break-all for links inside .profile-entry This fix applies globally to all themes (frio, vier, quattro, etc.) since they all load global.css.

Frio:

<img width="947" height="631" alt="image" src="https://github.com/user-attachments/assets/ab1b3e61-c8d6-495a-990b-87993c3b482c" />

Vier:

<img width="1231" height="663" alt="image" src="https://github.com/user-attachments/assets/c23ee04f-ab6b-4f73-90f3-25c2c77fe68e" />

Fixes #15379