### PR TITLE
BUG: Fix custom profile field deletion by skipping empty labels

### DIFF
--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -362,6 +362,11 @@ class Index extends BaseSettings
 		unset($profileFieldOrder['new']);
 
 		foreach ($profileFieldInputs as $id => $profileFieldInput) {
+			// Skip fields with empty labels - they will be deleted by saveCollectionForUser
+			if (empty($profileFieldInput['label'])) {
+				continue;
+			}
+
 			$permissionSet = $this->permissionSetRepo->selectOrCreate($this->permissionSetFactory->createFromString(
 				$uid,
 				$this->aclFormatter->toString($profileFieldInput['contact_allow'] ?? ''),


### PR DESCRIPTION
Custom profile fields couldn't be deleted by emptying the label field as documented.

I discovered this while testing long text values with line breaks in custom profile fields. After the test, I wanted to remove the field but it just wouldn't delete.

The issue was in getProfileFieldsFromInput() - fields with empty labels were still added to the collection, preventing the deletion logic in saveCollectionForUser() from recognizing them as removed.

Now fields with empty labels are skipped, so they get properly deleted.