### PR TITLE
Notifications UI consistency fix (Frio)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -563,7 +563,7 @@ header #banner #logo-img,
 	color: $font_color_darker;
 }
 #nav-notifications-menu {
-	margin-top: 4px;
+	margin-top: 0;
 	padding: 0;
 }
 #nav-notifications-mark-all {
@@ -580,7 +580,11 @@ header #banner #logo-img,
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
+	padding: 5px 0;
  }
+#notifications-mark-as-read {
+	padding: 0;
+}
  #notifications-title {
 	font-size: 17px;
 	font-weight: 500;

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -128,11 +128,9 @@
 											<p id="notifications-title">{{$nav.notifications.1}}</p>
 											<header id="notifications-subheader">
 												<a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a>
-												<div class="dropdown-header-link">
-													<button role="menuitem" type="button" class="btn-link"
-														onclick="notificationMarkAll();" data-toggle="tooltip">{{$nav.notifications.mark.1}}
-													</button>
-												</div>
+												<button role="menuitem" type="button" id="notifications-mark-as-read" class="btn-link"
+													onclick="notificationMarkAll();" data-toggle="tooltip">{{$nav.notifications.mark.1}}
+												</button>
 											</header>
 										</header>
 


### PR DESCRIPTION
Restores the consistent spacing of the actions (view all/mark as read) in the notifications dropdown.
Resists the desire to refactor further.

# Before

<img width="396" height="182" alt="image" src="https://github.com/user-attachments/assets/28b4541c-615f-497e-bd7d-78b62a1869cc" />

# After

<img width="396" height="182" alt="image" src="https://github.com/user-attachments/assets/8e187420-a659-4f38-badb-bba2d3509406" />