### PR TITLE
Fix cutoff vcard buttons at medium resolutions (Frio)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1306,7 +1306,7 @@ aside .vcard .icon {
 aside .vcard #subscribe-feed-link-button,
 aside .vcard #dfrn-request-link-button,
 aside .vcard #wallmessage-link-button {
-	width: 50%;
+	min-width: 119px;
 	margin: 0 0 0 -5px;
 	float: left;
 	padding: 0 5px;


### PR DESCRIPTION
Closes #15386

It seems the related styling should really be rewritten to not hardcode button sizes with percentages and maybe use flexbox instead, but due to the release I stuck with a more targeted change, to hopefully avoid accidentally breaking something else.

It turned out that the other buttons in the vcard could also get cut off.

# After

<img width="217" height="429" alt="image" src="https://github.com/user-attachments/assets/f67e3034-ffd9-4d63-a8b0-716c2fd9c4ea" />