### PR TITLE
Fix circle edit icon position (Frio)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1432,6 +1432,12 @@ aside .widget .widget-action.faded-icon:hover {
 aside #circle-sidebar li .circle-checkbox {
 	margin: 6px 0 0;
 }
+aside #circle-sidebar li .circle-edit-tool {
+	padding-right: 10px;
+}
+aside #circle-sidebar li .circle-edit-tool:first-child {
+	padding-right: 0px;
+}
 
 /* contact block widget */
 .contact-block-content {

--- a/view/theme/frio/templates/circle_side.tpl
+++ b/view/theme/frio/templates/circle_side.tpl
@@ -47,7 +47,7 @@
 						{{/if}}
 						{{if $circle.edit}}
 							{{* if the circle is editable show a little pencil for editing *}}
-							<a id="edit-sidebar-circle-element-{{$circle.id}}" class="widget-action-top pull-right faded-icon" href="{{$circle.edit.href}}" data-toggle="tooltip" title="{{$edittext}}">
+							<a id="edit-sidebar-circle-element-{{$circle.id}}" class="circle-edit-tool pull-right faded-icon" href="{{$circle.edit.href}}" data-toggle="tooltip" title="{{$edittext}}">
 								<i class="fa fa-pencil" aria-hidden="true"></i>
 							</a>
 						{{/if}}


### PR DESCRIPTION
Turns out they got a bit messed up by #15374 so this restores a bit of what was removed/changed.

# Before

<img width="294" height="204" alt="image" src="https://github.com/user-attachments/assets/84a82c3d-b50c-4aea-860d-d12782e371aa" />

# After

<img width="294" height="204" alt="image" src="https://github.com/user-attachments/assets/98d66620-4d10-4c7b-a15f-03beafbe5770" />