### PR TITLE
Omit alt tag indicator on images in profile descriptions

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1699,7 +1699,7 @@ textarea.comment-edit-text:focus + .comment-edit-form .preview {
 	display: inline-block;
 }
 
-/* ALT badge for photos with descriptions in justified gallery */
+/* ALT badge for images with descriptions */
 .photo-top-image-wrapper:has(img.has-alt-description)::after {
 	background: rgba(0, 0, 0, 0.69);
 	border-radius: 4px;
@@ -1713,6 +1713,10 @@ textarea.comment-edit-text:focus + .comment-edit-form .preview {
 	right: 8px;
 	z-index: 1;
 	pointer-events: none;
+}
+/* ...omit alt tags on images in these cases: profile description */
+.profile-header a:has(img.has-alt-description)::after {
+	display: none;
 }
 
 .photo-top-image-wrapper .jg-caption,


### PR DESCRIPTION
Closes #15313

I'm not sure if it should be indicated, but at least in the buggy way it's shown there right now (see the issue), it shouldn't.

Also if it was correctly overlayed on the image in that example, it would cover maybe one third of the entire image.
Not sure what an ideal solution would be there. If it was scaled with the image size it would be unreadable. If it was added with JS maybe images below a certain size could be skipped?