### PR TITLE
add daemon.pid to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ tests/.phpunit.result.cache
 
 #ignore .php_cs (local copy)
 .php_cs
+
+#ignore daemon.pid file
+daemon.pid


### PR DESCRIPTION
It would be quite good to ignore the daemon.pid file if you want to place it in the project's root path.