### PR TITLE
FIX: Message page hang after sending in an existing conversation

### DIFF
--- a/mod/message.php
+++ b/mod/message.php
@@ -382,25 +382,20 @@ function get_messages(int $uid, int $start, int $limit): array
 			c.`url`,
 			c.`thumb`,
 			c.`network`,
-			m2.`count`,
-			m2.`mailcreated`,
-			m2.`mailseen`
+			(SELECT COUNT(*) FROM `mail` WHERE `parent-uri` = m.`parent-uri` AND `uid` = ?) AS `count`,
+			(SELECT MAX(`created`) FROM `mail` WHERE `parent-uri` = m.`parent-uri` AND `uid` = ?) AS `mailcreated`,
+			(SELECT MIN(`seen`) FROM `mail` WHERE `parent-uri` = m.`parent-uri` AND `uid` = ?) AS `mailseen`
 		FROM `mail` m
-		JOIN (
-			SELECT
-				`parent-uri`,
-				MIN(`id`)      AS `id`,
-				COUNT(*)       AS `count`,
-				MAX(`created`) AS `mailcreated`,
-				MIN(`seen`)    AS `mailseen`
-			FROM `mail`
-			WHERE `uid` = ?
-			GROUP BY `parent-uri`
-		) m2 ON m.`parent-uri` = m2.`parent-uri` AND m.`id` = m2.`id`
 		LEFT JOIN `contact` c ON m.`contact-id` = c.`id`
 		WHERE m.`uid` = ?
-		ORDER BY m2.`mailcreated` DESC
-		LIMIT ?, ?', $uid, $uid, $start, $limit));
+			AND m.`id` IN (
+				SELECT MIN(`id`)
+				FROM `mail`
+				WHERE `uid` = ?
+				GROUP BY `parent-uri`
+			)
+		ORDER BY `mailcreated` DESC
+		LIMIT ?, ?', $uid, $uid, $uid, $uid, $uid, $start, $limit));
 }
 
 function render_messages(array $msg, string $t): string

--- a/src/Model/Mail.php
+++ b/src/Model/Mail.php
@@ -53,10 +53,10 @@ class Mail
 		$msg['uri-id']        = ItemURI::insert(['uri' => $msg['uri'], 'guid' => $msg['guid']]);
 		$msg['parent-uri-id'] = ItemURI::getIdByURI($msg['parent-uri']);
 
-		DBA::lock('mail');
+		DBA::transaction();
 
 		if (DBA::exists('mail', ['uri' => $msg['uri'], 'uid' => $msg['uid']])) {
-			DBA::unlock();
+			DBA::rollback();
 			DI::logger()->info('duplicate message already delivered.');
 			return false;
 		}
@@ -73,7 +73,7 @@ class Mail
 
 		$msg['id'] = DBA::lastInsertId();
 
-		DBA::unlock();
+		DBA::commit();
 
 		if (!empty($msg['convid'])) {
 			DBA::update('conv', ['updated' => DateTimeFormat::utcNow()], ['id' => $msg['convid']]);


### PR DESCRIPTION
Fixes the message page hanging/freezing after sending a message in an existing conversation.

The problem was caused by a table lock in `Mail::insert()` that blocked all other database queries to the mail table, including the page load after redirect.

- Replaced `DBA::lock()`/`unlock()` with `DBA::transaction()`/`commit()` for row-level locking
- Optimized the `get_messages()` query to avoid slow subquery joins

The page now loads immediately after sending a message.
