### PR TITLE
Disable send button when private message text is empty

### DIFF
--- a/view/templates/msg-header.tpl
+++ b/view/templates/msg-header.tpl
@@ -23,6 +23,16 @@
 		);
 
 		$("#prvmail-text").bbco_autocomplete('bbcode');
+
+		// Validate message form - disable submit button if message is empty
+		function validateMessageForm() {
+			var messageText = $('#prvmail-text').val().trim();
+			$('#prvmail-submit').prop('disabled', messageText.length === 0);
+		}
+
+		// Check on page load and on input
+		validateMessageForm();
+		$('#prvmail-text').on('input keyup', validateMessageForm);
 	});
 
 	function jotGetLink() {

--- a/view/theme/frio/templates/msg-header.tpl
+++ b/view/theme/frio/templates/msg-header.tpl
@@ -17,5 +17,15 @@
 		if ($el.length) {
 			$el.scrollTop($el.get(0).scrollHeight);
 		}
+
+		// Validate message form - disable submit button if message is empty
+		function validateMessageForm() {
+			var messageText = $('#comment-edit-text-input').val().trim();
+			$('#prvmail-submit').prop('disabled', messageText.length === 0);
+		}
+
+		// Check on page load and on input
+		validateMessageForm();
+		$('#comment-edit-text-input').on('input keyup', validateMessageForm);
 	});
 </script>


### PR DESCRIPTION
Currently, users can send empty private messages by clicking the send button without typing any text. This PR adds client-side validation to prevent this.   

- Added JavaScript validation that disables the send button when the message textarea is empty
- Implemented for both the default theme and Frio theme

Frio empty message:
<img width="1235" height="552" alt="image" src="https://github.com/user-attachments/assets/76e4ff81-a771-4ac9-935c-026721b5b722" />

Frio non empty message:
<img width="1200" height="568" alt="image" src="https://github.com/user-attachments/assets/2dd169ca-3b2d-4969-8c18-3f20d71779b2" />

Vier empty message:
<img width="757" height="511" alt="image" src="https://github.com/user-attachments/assets/87813c17-a00c-4896-a0ec-aa8e7f79428c" />

Vier non empty message:
<img width="794" height="500" alt="image" src="https://github.com/user-attachments/assets/47158688-e459-4c24-a890-990eb01f7cbe" />

closes #10718
