### PR TITLE
Channel cache now supports the 'Following' and 'Followers' circles

### DIFF
--- a/src/Content/Conversation/Factory/ChannelPost.php
+++ b/src/Content/Conversation/Factory/ChannelPost.php
@@ -103,7 +103,7 @@ final class ChannelPost
 
 		$engagement = $this->dba->selectFirst('post-engagement', ['searchtext', 'media-type', 'owner-id', 'language'], ['uri-id' => $uri_id]);
 		if ($engagement === false || $engagement === []) {
-			$this->logger->debug('No engagement found', ['uri-id' => $uri_id]);
+			$this->logger->debug('No engagement found', ['uri-id' => $uri_id, 'uid' => $uid, 'reshare_id' => $reshare_id, 'engagement' => $engagement]);
 			return;
 		}
 
@@ -121,7 +121,15 @@ final class ChannelPost
 		}
 
 		foreach ($channels as $channel) {
-			if ($uid == 0 && in_array($channel->circle, [-3, -4, -5]) && !Contact::isSharing($engagement['owner-id'], $channel->uid)) {
+			if ($uid === 0 && in_array($channel->circle, [-3, -4, -5]) && !Contact::isSharing($engagement['owner-id'], $channel->uid)) {
+				continue;
+			}
+
+			if ($channel->circle === -1 && !Contact::isSharing($engagement['owner-id'], $channel->uid)) {
+				continue;
+			}
+
+			if ($channel->circle === -2 && (!Contact::isFollower($engagement['owner-id'], $channel->uid) || Contact::isSharing($engagement['owner-id'], $channel->uid))) {
 				continue;
 			}
 

--- a/src/Content/Conversation/Factory/SystemChannelPost.php
+++ b/src/Content/Conversation/Factory/SystemChannelPost.php
@@ -75,7 +75,7 @@ final class SystemChannelPost
 
 		$engagement = $this->dba->selectFirst('post-engagement', ['searchtext', 'media-type', 'owner-id', 'language', 'activities', 'comments', 'contact-type', 'created'], ['uri-id' => $uri_id]);
 		if ($engagement === false || $engagement === []) {
-			$this->logger->debug('No engagement found', ['uri-id' => $uri_id, 'post-uid' => $post_uid, 'reshare_id' => $reshare_id]);
+			$this->logger->debug('No engagement found', ['uri-id' => $uri_id, 'post-uid' => $post_uid, 'reshare_id' => $reshare_id, 'engagement' => $engagement]);
 			return;
 		}
 


### PR DESCRIPTION
The channel cache will now work for user defined channels as well that are based on the two circles "following" and "followers".