### PR TITLE
The channel cache creation can now be activated separately

### DIFF
--- a/src/Content/Conversation/Factory/ChannelPost.php
+++ b/src/Content/Conversation/Factory/ChannelPost.php
@@ -90,33 +90,31 @@ final class ChannelPost
 	 * This will insert entries into the `channel-post` cache table when the
 	 * system's channel caching is enabled and matching channels are found.
 	 *
-	 * @param int $uri_id URI id of the post.
+	 * @param array $engagement post-engagement record
 	 * @param int $uid User id context.
 	 * @param int $reshare_id Optional reshare id.
 	 * @return void
 	 */
-	public function add(int $uri_id, int $uid, int $reshare_id = 0): void
+	public function add(array $engagement, int $uid, int $reshare_id = 0): void
 	{
 		if (!$this->config->get('system', 'channel_cache')) {
 			return;
 		}
 
-		$engagement = $this->dba->selectFirst('post-engagement', ['searchtext', 'media-type', 'owner-id', 'language'], ['uri-id' => $uri_id]);
-		if ($engagement === false || $engagement === []) {
-			$this->logger->debug('No engagement found', ['uri-id' => $uri_id, 'uid' => $uid, 'reshare_id' => $reshare_id, 'engagement' => $engagement]);
-			return;
-		}
+		$this->logger->debug('Adding channel post', ['uri-id' => $engagement['uri-id'], 'uid' => $uid, 'reshare_id' => $reshare_id]);
 
 		$language = $engagement['language'] !== L10n::UNDETERMINED_LANGUAGE ? $engagement['language'] : '';
-		$tags     = array_column(Tag::getByURIId($uri_id, [Tag::HASHTAG]), 'name');
+		$tags     = array_column(Tag::getByURIId($engagement['uri-id'], [Tag::HASHTAG]), 'name');
 
 		$channels = $this->channelRepository->getMatchingChannels($engagement['searchtext'], $language, $tags, $engagement['media-type'], $engagement['owner-id'], $reshare_id, $uid);
 		if (!($channels instanceof \Friendica\Content\Conversation\Collection\UserDefinedChannels) || $channels->count() === 0) {
+			$this->logger->debug('No channels found', ['uri-id' => $engagement['uri-id'], 'uid' => $uid, 'reshare_id' => $reshare_id]);
 			return;
 		}
 
-		$post = Post::selectFirstPost(['created', 'received', 'commented'], ['uri-id' => $uri_id]);
+		$post = Post::selectFirstPost(['created', 'received', 'commented'], ['uri-id' => $engagement['uri-id']]);
 		if ($post === false || $post === []) {
+			$this->logger->debug('Post not found', ['uri-id' => $engagement['uri-id'], 'uid' => $uid, 'reshare_id' => $reshare_id]);
 			return;
 		}
 
@@ -136,13 +134,13 @@ final class ChannelPost
 			$cache = [
 				'channel'   => (int)$channel->code,
 				'uid'       => $channel->uid,
-				'uri-id'    => $uri_id,
+				'uri-id'    => $engagement['uri-id'],
 				'created'   => $post['created'],
 				'received'  => $post['received'],
 				'commented' => $post['commented'],
 			];
 			$ret = $this->dba->insert('channel-post', $cache, Database::INSERT_UPDATE);
-			$this->logger->debug('Added channel post', ['uri-id' => $uri_id, 'cache' => $cache, 'ret' => $ret]);
+			$this->logger->debug('Added channel post', ['uri-id' => $engagement['uri-id'], 'cache' => $cache, 'ret' => $ret]);
 		}
 	}
 }

--- a/src/Content/Conversation/Factory/SystemChannelPost.php
+++ b/src/Content/Conversation/Factory/SystemChannelPost.php
@@ -13,7 +13,6 @@ use Friendica\Content\Conversation\Repository\UserDefinedChannel;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Content\Conversation\Entity\Channel;
 use Friendica\Database\Database;
-use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Post;
 use Friendica\Model\User;
@@ -59,30 +58,25 @@ final class SystemChannelPost
 	 * should be stored in various system channels for the given user(s)
 	 * and inserts cache entries into `system-channel-post`.
 	 *
-	 * @param int $uri_id URI id of the post.
+	 * @param array $engagement post-engagement record
 	 * @param int $post_uid User id context (0 for all users).
 	 * @param string $network Network identifier.
 	 * @param int $reshare_id Optional reshare id.
 	 * @return void
 	 */
-	public function add(int $uri_id, int $post_uid, string $network, int $reshare_id = 0): void
+	public function add(array $engagement, int $post_uid, string $network, int $reshare_id = 0): void
 	{
-		if (!$this->config->get('system', 'channel_cache')) {
+		if (!$this->config->get('system', 'system_channel_cache')) {
 			return;
 		}
 
-		DI::logger()->debug('Adding system channel post', ['uri-id' => $uri_id, 'post_uid' => $post_uid, 'reshare_id' => $reshare_id]);
-
-		$engagement = $this->dba->selectFirst('post-engagement', ['searchtext', 'media-type', 'owner-id', 'language', 'activities', 'comments', 'contact-type', 'created'], ['uri-id' => $uri_id]);
-		if ($engagement === false || $engagement === []) {
-			$this->logger->debug('No engagement found', ['uri-id' => $uri_id, 'post-uid' => $post_uid, 'reshare_id' => $reshare_id, 'engagement' => $engagement]);
-			return;
-		}
+		$this->logger->debug('Adding system channel post', ['uri-id' => $engagement['uri-id'], 'post_uid' => $post_uid, 'reshare_id' => $reshare_id]);
 
 		$owner = $reshare_id ?: $engagement['owner-id'];
 
-		$post = Post::selectFirstPost(['created', 'received', 'commented'], ['uri-id' => $uri_id]);
+		$post = Post::selectFirstPost(['created', 'received', 'commented'], ['uri-id' => $engagement['uri-id']]);
 		if ($post === false || $post === []) {
+			$this->logger->debug('Post not found', ['uri-id' => $engagement['uri-id'], 'post_uid' => $post_uid, 'reshare_id' => $reshare_id]);
 			return;
 		}
 
@@ -98,7 +92,7 @@ final class SystemChannelPost
 
 		foreach ($uids as $uid) {
 			foreach ([Channel::WHATSHOT, Channel::FORYOU, Channel::DISCOVER, Channel::FOLLOWERS, Channel::SHARERSOFSHARERS, Channel::QUIETSHARERS, Channel::IMAGE, Channel::VIDEO, Channel::AUDIO, Channel::LANGUAGE] as $channel) {
-				if ($this->dba->exists('system-channel-post', ['channel' => $channel, 'uid' => $uid, 'uri-id' => $uri_id])) {
+				if ($this->dba->exists('system-channel-post', ['channel' => $channel, 'uid' => $uid, 'uri-id' => $engagement['uri-id']])) {
 					continue;
 				}
 				$store = false;
@@ -203,13 +197,13 @@ final class SystemChannelPost
 				$cache = [
 					'channel'   => $channel,
 					'uid'       => $uid,
-					'uri-id'    => $uri_id,
+					'uri-id'    => $engagement['uri-id'],
 					'created'   => $post['created'],
 					'received'  => $post['received'],
 					'commented' => $post['commented'],
 				];
 				$ret = $this->dba->insert('system-channel-post', $cache, Database::INSERT_UPDATE);
-				$this->logger->debug('Added system channel post', ['uri-id' => $uri_id, 'cache' => $cache, 'ret' => $ret]);
+				$this->logger->debug('Added system channel post', ['uri-id' => $engagement['uri-id'], 'cache' => $cache, 'ret' => $ret]);
 			}
 		}
 	}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1161,15 +1161,18 @@ class Item
 				self::reshareChannelPost($engagement_uri_id);
 			}
 
-			if (DI::ChannelPost()->isValidChannelPostBase($posted_item['uid'], $posted_item['private'], $posted_item['network'])) {
-				if (($posted_item['gravity'] === self::GRAVITY_ACTIVITY) && ($posted_item['verb'] === Activity::ANNOUNCE) && ($posted_item['author-contact-type'] === Contact::TYPE_COMMUNITY) && ($posted_item['parent-uri-id'] === $posted_item['thr-parent-id'])) {
-					DI::ChannelPost()->add($posted_item['thr-parent-id'], $posted_item['uid'], $posted_item['author-id']);
-					DI::SystemChannelPost()->add($posted_item['thr-parent-id'], $posted_item['uid'], $posted_item['network'], $posted_item['author-id']);
-				} else {
-					if ($posted_item['gravity'] === self::GRAVITY_PARENT) {
-						DI::ChannelPost()->add($posted_item['uri-id'], $posted_item['uid']);
+			if ((DI::config()->get('system', 'channel_cache') || DI::config()->get('system', 'system_channel_cache')) && DI::ChannelPost()->isValidChannelPostBase($posted_item['uid'], $posted_item['private'], $posted_item['network'])) {
+				$engagement = DBA::selectFirst('post-engagement', [], ['uri-id' => $posted_item['parent-uri-id']]);
+				if (isset($engagement['uri-id'])) {
+					if (($posted_item['gravity'] === self::GRAVITY_ACTIVITY) && ($posted_item['verb'] === Activity::ANNOUNCE) && ($posted_item['author-contact-type'] === Contact::TYPE_COMMUNITY) && ($posted_item['parent-uri-id'] === $posted_item['thr-parent-id'])) {
+						DI::ChannelPost()->add($engagement, $posted_item['uid'], $posted_item['author-id']);
+						DI::SystemChannelPost()->add($engagement, $posted_item['uid'], $posted_item['network'], $posted_item['author-id']);
+					} else {
+						if ($posted_item['gravity'] === self::GRAVITY_PARENT) {
+							DI::ChannelPost()->add($engagement, $posted_item['uid']);
+						}
+						DI::SystemChannelPost()->add($engagement, $posted_item['uid'], $posted_item['network']);
 					}
-					DI::SystemChannelPost()->add($posted_item['thr-parent-id'], $posted_item['uid'], $posted_item['network']);
 				}
 			}
 		}

--- a/src/Module/Conversation/Timeline.php
+++ b/src/Module/Conversation/Timeline.php
@@ -306,7 +306,7 @@ class Timeline extends BaseModule
 	 */
 	private function getRawChannelItems(array $request, int $uid): array
 	{
-		$cache = $this->config->get('system', 'channel_cache');
+		$cache = $this->config->get('system', 'system_channel_cache');
 
 		if ($cache) {
 			$table     = 'system-channel-post-view';
@@ -393,7 +393,7 @@ class Timeline extends BaseModule
 				$condition = ["`language` = ?", User::getLanguageCode($uid)];
 			}
 		} elseif (is_numeric($this->selectedTab) && !empty($channel = $this->channelRepository->selectById($this->selectedTab, $uid))) {
-			if (!$cache) {
+			if (!$this->config->get('system', 'channel_cache')) {
 				$condition = $this->channelRepository->getCondition($channel, $uid);
 				if (in_array($channel->circle, [-3, -4, -5])) {
 					$table     = SearchIndex::getSearchView();

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -591,6 +591,10 @@ return [
 		// A random string to be added to the /stats?key=... endpoint to enable the monitoring statistics
 		'stats_key' => '',
 
+		// system_channel_cache (Boolean)
+		// Pregenerate system channel posts.
+		'system_channel_cache' => false,
+
 		// throttle_limit_day (Integer)
 		// Maximum number of posts that a user can send per day with the API. 0 to disable daily throttling.
 		'throttle_limit_day' => 0,


### PR DESCRIPTION
The channel cache creation seems to put a higher load onto systems. For this reason the cache creation can now be activated separately for system channels and user channels.