### PR TITLE
Restyle vcard profile actions to be like Bookface's (Frio)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1304,21 +1304,18 @@ aside .vcard .icon {
 	width: 30px;
 }
 #profile-extra-links {
+	display: flex;
+	flex-direction: column;
+	gap: 7px;
 	overflow: auto;
 	margin-bottom: 10px;
 }
-aside .vcard #subscribe-feed-link-button,
-aside .vcard #dfrn-request-link-button,
-aside .vcard #wallmessage-link-button {
-	min-width: 119px;
-	margin: 0 0 0 -5px;
-	float: left;
-	padding: 0 5px;
-}
-aside .vcard #subscribe-feed-link,
-aside .vcard #dfrn-request-link,
-aside .vcard #wallmessage-link {
-	width: 100%;
+#profile-extra-links a, #profile-extra-links button {
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+	white-space: wrap;
+	width: 75%;
 }
 /* vcard-short-info */
 #vcard-short-info,


### PR DESCRIPTION
Closes #12754

After working on #15386, I thought maybe it would be better if Frio basically upstreamed the vcard action design from Bookface.
Simplified the CSS in the process.

# Before

<img width="278" height="482" alt="image" src="https://github.com/user-attachments/assets/6e2693ca-f7d1-409b-9845-81dc314a3997" />

# After

<img width="279" height="543" alt="image" src="https://github.com/user-attachments/assets/72141eac-b35c-442c-b8b1-b3b290b2a85f" />