### PR TITLE
Frio: Improve topnav handling for tiny widths/displays

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -4276,4 +4276,22 @@ div.login-form, .login-content-wrapper,
 		margin-top: 10px;
 		border: none;
 	}
+
+}/* Even smaller mobile displays */
+@media (width < 315px) {
+	/* Less topnav padding */
+	.navbar-left {
+		float: none!important;
+		display: flex;
+		justify-content: space-between;
+	}
+	.topbar-nav .nav-segment a.nav-menu {
+		padding-left: 0;
+		padding-right: 7px;
+	}
+	.topbar-nav .offcanvas-right-toggle,
+	.topbar-nav #mobile-left-menu {
+		padding-right: 3px;
+		padding-left: 3px;
+	}
 }

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -24,6 +24,7 @@
 				<div class="topbar-nav">
 
 					{{* Buttons for the mobile view *}}
+					{{* Mobile user menu dropdown button *}}
 					<button type="button" class="navbar-toggle offcanvas-right-toggle pull-right"
 						aria-controls="offcanvasUsermenu" aria-haspopup="true">
 						<span class="sr-only">Toggle navigation</span>
@@ -34,7 +35,8 @@
 						<span class="sr-only">Toggle Search</span>
 						<i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
 					</button>
-					<button type="button" class="navbar-toggle collapsed pull-left visible-sm visible-xs"
+					{{* Mobile left menu dropdown button *}}
+					<button type="button" id="mobile-left-menu" class="navbar-toggle collapsed pull-left visible-sm visible-xs"
 						data-toggle="offcanvas" data-target="aside" aria-haspopup="true">
 						<span class="sr-only">Toggle navigation</span>
 						<i class="fa fa-angle-double-right fa-fw fa-lg" aria-hidden="true"></i>


### PR DESCRIPTION
Decided to separate out the better support for tiny widths/screens from #15369 to hopefully get it into the RC to hopefully help #15412

All CSS changes are in a media query affecting widths lower than 315px to not make them affect anything else.

# After

An example that's *very* narrow hopefully just for illustration purposes:
<img width="223" height="169" alt="image" src="https://github.com/user-attachments/assets/eb97a882-0730-4f4b-9c84-e8c2762bf70a" />