### PR TITLE
Cached user channels now work with timeline posts like uncached ones

### DIFF
--- a/src/Content/Conversation/Factory/ChannelPost.php
+++ b/src/Content/Conversation/Factory/ChannelPost.php
@@ -76,11 +76,7 @@ final class ChannelPost
 			return true;
 		}
 
-		// For federated public/unlisted posts we only allow caching when uid = 0 to make them reachable to all users
-		if (in_array($network, Protocol::FEDERATED) && in_array($private, [Item::PUBLIC, Item::UNLISTED]) && $uid === 0) {
-			return true;
-		}
-
+		// Public federated public/unlisted posts don't need to be checked here, they are distributed elsewhere
 		return false;
 	}
 
@@ -119,8 +115,17 @@ final class ChannelPost
 		}
 
 		foreach ($channels as $channel) {
-			if ($uid === 0 && in_array($channel->circle, [-3, -4, -5]) && !Contact::isSharing($engagement['owner-id'], $channel->uid)) {
-				continue;
+			if (in_array($channel->circle, [-3, -4, -5])) {
+				if ($store = ($uid !== 0)) {
+					$this->logger->debug('Valid post for user. Post is stored for the user.', ['channel_code' => $channel->code, 'channel_uid' => $channel->uid, 'post_uri_id' => $engagement['uri-id'], 'owner_id' => $engagement['owner-id']]);
+				}
+				if (!$store && Post::exists(['parent-uri-id' => $engagement['uri-id'], 'uid' => $channel->uid])) {
+					$store = true;
+					$this->logger->debug('Valid post for user. The thread exists for the user.', ['channel_code' => $channel->code, 'channel_uid' => $channel->uid, 'post_uri_id' => $engagement['uri-id'], 'owner_id' => $engagement['owner-id']]);
+				}
+				if (!$store) {
+					continue;
+				}
 			}
 
 			if ($channel->circle === -1 && !Contact::isSharing($engagement['owner-id'], $channel->uid)) {
@@ -139,7 +144,7 @@ final class ChannelPost
 				'received'  => $post['received'],
 				'commented' => $post['commented'],
 			];
-			$ret = $this->dba->insert('channel-post', $cache, Database::INSERT_UPDATE);
+			$ret = $this->dba->insert('channel-post', $cache, Database::INSERT_IGNORE);
 			$this->logger->debug('Added channel post', ['uri-id' => $engagement['uri-id'], 'cache' => $cache, 'ret' => $ret]);
 		}
 	}

--- a/src/Content/Conversation/Factory/ChannelPost.php
+++ b/src/Content/Conversation/Factory/ChannelPost.php
@@ -116,7 +116,9 @@ final class ChannelPost
 
 		foreach ($channels as $channel) {
 			if (in_array($channel->circle, [-3, -4, -5])) {
-				if ($store = ($uid !== 0)) {
+				$store = false;
+				if ($uid !== 0) {
+					$store = true;
 					$this->logger->debug('Valid post for user. Post is stored for the user.', ['channel_code' => $channel->code, 'channel_uid' => $channel->uid, 'post_uri_id' => $engagement['uri-id'], 'owner_id' => $engagement['owner-id']]);
 				}
 				if (!$store && Post::exists(['parent-uri-id' => $engagement['uri-id'], 'uid' => $channel->uid])) {

--- a/src/Content/Conversation/Factory/SystemChannelPost.php
+++ b/src/Content/Conversation/Factory/SystemChannelPost.php
@@ -202,7 +202,7 @@ final class SystemChannelPost
 					'received'  => $post['received'],
 					'commented' => $post['commented'],
 				];
-				$ret = $this->dba->insert('system-channel-post', $cache, Database::INSERT_UPDATE);
+				$ret = $this->dba->insert('system-channel-post', $cache, Database::INSERT_IGNORE);
 				$this->logger->debug('Added system channel post', ['uri-id' => $engagement['uri-id'], 'cache' => $cache, 'ret' => $ret]);
 			}
 		}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1182,7 +1182,13 @@ class Item
 		return $post_user_id;
 	}
 
-	public static function addPublicPostToChannel(int $uri_id)
+	/**
+	 * Add public posts to channel and system channel caches
+	 *
+	 * @param int $uri_id
+	 * @return void
+	 */
+	public static function addPublicPostToChannel(int $uri_id): void
 	{
 		if (!DI::config()->get('system', 'channel_cache') && !DI::config()->get('system', 'system_channel_cache')) {
 			return;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1161,14 +1161,16 @@ class Item
 				self::reshareChannelPost($engagement_uri_id);
 			}
 
-			if ((DI::config()->get('system', 'channel_cache') || DI::config()->get('system', 'system_channel_cache')) && DI::ChannelPost()->isValidChannelPostBase($posted_item['uid'], $posted_item['private'], $posted_item['network'])) {
+			if ((DI::config()->get('system', 'channel_cache') || DI::config()->get('system', 'system_channel_cache')) && (DI::ChannelPost()->isValidChannelPostBase($posted_item['uid'], $posted_item['private'], $posted_item['network']) || $posted_item['origin'])) {
 				$engagement = DBA::selectFirst('post-engagement', [], ['uri-id' => $posted_item['parent-uri-id']]);
 				if (isset($engagement['uri-id'])) {
-					if (($posted_item['gravity'] === self::GRAVITY_ACTIVITY) && ($posted_item['verb'] === Activity::ANNOUNCE) && ($posted_item['author-contact-type'] === Contact::TYPE_COMMUNITY) && ($posted_item['parent-uri-id'] === $posted_item['thr-parent-id'])) {
+					if (($posted_item['gravity'] === self::GRAVITY_ACTIVITY) && ($posted_item['verb'] === Activity::ANNOUNCE) && ($posted_item['parent-uri-id'] === $posted_item['thr-parent-id'])) {
 						DI::ChannelPost()->add($engagement, $posted_item['uid'], $posted_item['author-id']);
 						DI::SystemChannelPost()->add($engagement, $posted_item['uid'], $posted_item['network'], $posted_item['author-id']);
 					} else {
-						if ($posted_item['gravity'] === self::GRAVITY_PARENT) {
+						if ($posted_item['origin']) {
+							DI::ChannelPost()->add($engagement, $posted_item['uid'], $posted_item['author-id']);
+						} elseif ($posted_item['gravity'] === self::GRAVITY_PARENT) {
 							DI::ChannelPost()->add($engagement, $posted_item['uid']);
 						}
 						DI::SystemChannelPost()->add($engagement, $posted_item['uid'], $posted_item['network']);
@@ -1178,6 +1180,38 @@ class Item
 		}
 
 		return $post_user_id;
+	}
+
+	public static function addPublicPostToChannel(int $uri_id)
+	{
+		if (!DI::config()->get('system', 'channel_cache') && !DI::config()->get('system', 'system_channel_cache')) {
+			return;
+		}
+
+		$item = Post::selectFirstPost(['parent-uri-id', 'thr-parent-id', 'private', 'gravity', 'verb', 'author-id', 'network'], ['uri-id' => $uri_id]);
+		if (!isset($item['parent-uri-id'])) {
+			return;
+		}
+
+		if ($item['private'] == Item::PRIVATE) {
+			return;
+		}
+
+		$engagement = DBA::selectFirst('post-engagement', [], ['uri-id' => $item['parent-uri-id']]);
+		if (!isset($engagement['uri-id'])) {
+			return;
+		}
+
+
+		if (($item['gravity'] === self::GRAVITY_ACTIVITY) && ($item['verb'] === Activity::ANNOUNCE) && ($item['parent-uri-id'] === $item['thr-parent-id'])) {
+			DI::ChannelPost()->add($engagement, 0, $item['author-id']);
+			DI::SystemChannelPost()->add($engagement, 0, $item['network'], $item['author-id']);
+		} else {
+			if ($item['gravity'] === self::GRAVITY_PARENT) {
+				DI::ChannelPost()->add($engagement, 0);
+			}
+			DI::SystemChannelPost()->add($engagement, 0, $item['network']);
+		}
 	}
 
 	private static function reshareChannelPost(int $uri_id, int $reshare_id = 0)
@@ -1459,6 +1493,7 @@ class Item
 			$item['post-reason'] = self::PR_DISTRIBUTE;
 			self::storeForUser($item, $uid);
 		}
+		self::addPublicPostToChannel($item['uri-id']);
 	}
 
 	/**

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1317,6 +1317,7 @@ class Processor
 				Worker::add(Worker::PRIORITY_MEDIUM, 'FetchMissingReplies', $item['uri-id'], $activity);
 			}
 		}
+		Item::addPublicPostToChannel($item['uri-id']);
 	}
 
 	/**

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -400,6 +400,8 @@ class Notifier
 
 				Post\DeliveryData::incrementQueueCount($target_item['uri-id'], $delivery_queue_count);
 			}
+
+			Item::addPublicPostToChannel($target_item['parent-uri-id']);
 		}
 
 		return;


### PR DESCRIPTION
There had been reports that user channels based on the user timeline hadn't got all posts. This is now fixed. They now should contain exactly the same posts, cached and uncached.