### PR TITLE
APIs: Don't expose admin e-mail addresses

### DIFF
--- a/src/Module/Api/Mastodon/InstanceV2.php
+++ b/src/Module/Api/Mastodon/InstanceV2.php
@@ -140,7 +140,7 @@ class InstanceV2 extends BaseApi
 
 	private function buildContactInfo(): InstanceEntity\Contact
 	{
-		$email         = implode(',', User::getAdminEmailList());
+		$email         = $this->config->get('config', 'sender_email');
 		$administrator = User::getFirstAdmin();
 		$account       = null;
 

--- a/src/Object/Api/Mastodon/Instance.php
+++ b/src/Object/Api/Mastodon/Instance.php
@@ -13,7 +13,6 @@ use Friendica\BaseDataTransferObject;
 use Friendica\Contact\Header;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Database\Database;
-use Friendica\Model\User;
 use Friendica\Module\Register;
 use Friendica\Object\Api\Mastodon\InstanceV2\Configuration;
 
@@ -50,7 +49,7 @@ class Instance extends BaseDataTransferObject
 		$this->uri               = $baseUrl->getHost();
 		$this->title             = $config->get('config', 'sitename');
 		$this->short_description = $this->description = $config->get('config', 'info');
-		$this->email             = implode(',', User::getAdminEmailList());
+		$this->email             = $config->get('config', 'sender_email');
 		$this->version           = '2.8.0 (compatible; Friendica ' . App::VERSION . ')';
 		$this->urls              = ['streaming_api' => '']; // Not supported
 		$this->stats             = new Stats($config, $database);


### PR DESCRIPTION
Related to #8166 (may or may not close it?)

Stops exposing the list of admins/their e-mail addresses on /api/v1/instance and /api/v2/instance, instead showing mail address used for sending mail, as suggested in the related issue.