### PR TITLE
Don't cut off profile address in vcard (Frio)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1282,11 +1282,9 @@ aside .vcard .fn {
 }
 aside .vcard .p-addr {
 	font-style: italic;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 	padding-bottom: 2px;
 	text-align: center;
+	word-wrap: break-word;
 }
 aside .vcard .title {
 	margin-top: 10px;


### PR DESCRIPTION
If the profile address (nickname + domain) is sufficiently long it's currently cutoff, hidng the full name for sharing or tagging. 

That's not ideal.

This makes it line break instead.

# Before

<img width="270" height="378" alt="image" src="https://github.com/user-attachments/assets/e90edc06-2645-4dcf-9cb2-4627fd7498d7" />

# After

<img width="276" height="394" alt="image" src="https://github.com/user-attachments/assets/5b432adc-0878-4582-b21c-a0e156e77e1a" />