### PR TITLE
Make usermenu icons work in mobile, simplify implementation

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -224,12 +224,12 @@ class Nav
 
 		if ($this->session->isAuthenticated()) {
 			// user menu
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Conversations'), '', $this->l10n->t('Conversations you started')];
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('Your profile page')];
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos')];
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/media', $this->l10n->t('Media'), '', $this->l10n->t('Your postings with media')];
-			$nav['usermenu'][] = ['calendar/', $this->l10n->t('Calendar'), '', $this->l10n->t('Your calendar')];
-			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Your personal notes')];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Conversations'), '', $this->l10n->t('Conversations you started'), 'fa-commenting'];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('Your profile page'), 'fa-user'];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos'), 'fa-picture-o'];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/media', $this->l10n->t('Media'), '', $this->l10n->t('Your postings with media'), 'fa-edit'];
+			$nav['usermenu'][] = ['calendar/', $this->l10n->t('Calendar'), '', $this->l10n->t('Your calendar'), 'fa-calendar'];
+			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Your personal notes'), 'fa-book'];
 
 			// user info
 			$contact  = $this->database->selectFirst('contact', ['id', 'url', 'avatar', 'micro', 'name', 'nick', 'baseurl', 'updated'], ['uid' => $this->session->getLocalUserId(), 'self' => true]);

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -199,20 +199,7 @@
 										<li>
 											<a role="menuitem" class="{{$usermenu.2}}" href="{{$usermenu.0}}"
 												title="{{$usermenu.3}}">
-
-												{{if $usermenu.0|str_ends_with:$nickname}}
-													<i class="fa fa-commenting"></i>
-												{{elseif $usermenu.0|str_ends_with:"/profile"}}
-													<i class="fa fa-user"></i>
-												{{elseif $usermenu.0|str_ends_with:"/photos"}}
-													<i class="fa fa-picture-o"></i>
-												{{elseif $usermenu.0|str_ends_with:"/media"}}
-													<i class="fa fa-edit"></i>
-												{{elseif $usermenu.0|str_ends_with:"calendar/"}}
-													<i class="fa fa-calendar"></i>
-												{{elseif $usermenu.0|str_ends_with:"notes/"}}
-													<i class="fa fa-book"></i>
-												{{/if}}
+												<i class="fa {{$usermenu.4}}"></i>
 												{{$usermenu.1}}
 											</a>
 										</li>
@@ -363,13 +350,15 @@
 							{{/if}}
 							<li class="list-group-item">
 								<img src="{{$userinfo.icon}}" alt="{{$userinfo.name}}"
-									style="max-width:15px; max-height:15px; min-width:15px; min-height:15px; width:15px; height:15px;">
+									style="max-width:15px; max-height:15px; min-width:15px; min-height:15px; width:15px; height:15px;">&nbsp;
 								{{$userinfo.name}}{{if $nav.remote}} ({{$nav.remote}}){{/if}}
 							</li>
 							{{foreach $nav.usermenu as $usermenu}}
 								<li class="list-group-item">
 									<a role="menuitem" class="{{$usermenu.2}}"
-										href="{{$usermenu.0}}" title="{{$usermenu.3}}">{{$usermenu.1}}
+										href="{{$usermenu.0}}" title="{{$usermenu.3}}">
+										<i class="fa {{$usermenu.4}}"></i>&nbsp;
+										{{$usermenu.1}}
 									</a>
 								</li>
 							{{/foreach}}


### PR DESCRIPTION
This makes the usermenu icons work in mobile, whereas the old version was just in the desktop view.
It also simplifies the implementation for it, not hardcoding paths.

# Before

<img width="400" height="435" alt="image" src="https://github.com/user-attachments/assets/b14ad48b-133f-4145-ae92-d21474376fa0" />

# After

<img width="299" height="430" alt="image" src="https://github.com/user-attachments/assets/a464b8cd-b82c-47db-a2ba-522b258de1c2" />