### PR TITLE
C2S: Access-Control-Allow-Origin header for already authorized users

### DIFF
--- a/src/Module/ActivityPub/Inbox.php
+++ b/src/Module/ActivityPub/Inbox.php
@@ -50,11 +50,12 @@ class Inbox extends BaseApi
 			}
 			$inbox = ActivityPub\ClientToServer::getInbox($uid, $page, $request['max_id'] ?? null);
 
-			// Relaxed CORS header already authorized
-			header('Access-Control-Allow-Origin: *');
 		} else {
 			$inbox = ActivityPub\ClientToServer::getPublicInbox($uid, $page, $request['max_id'] ?? null);
 		}
+
+		// Relaxed CORS header already authorized
+		header('Access-Control-Allow-Origin: *');
 
 		$this->jsonExit($inbox, 'application/activity+json');
 	}

--- a/src/Module/ActivityPub/Inbox.php
+++ b/src/Module/ActivityPub/Inbox.php
@@ -49,7 +49,6 @@ class Inbox extends BaseApi
 				throw new \Friendica\Network\HTTPException\ForbiddenException();
 			}
 			$inbox = ActivityPub\ClientToServer::getInbox($uid, $page, $request['max_id'] ?? null);
-
 		} else {
 			$inbox = ActivityPub\ClientToServer::getPublicInbox($uid, $page, $request['max_id'] ?? null);
 		}

--- a/src/Module/ActivityPub/Inbox.php
+++ b/src/Module/ActivityPub/Inbox.php
@@ -49,6 +49,9 @@ class Inbox extends BaseApi
 				throw new \Friendica\Network\HTTPException\ForbiddenException();
 			}
 			$inbox = ActivityPub\ClientToServer::getInbox($uid, $page, $request['max_id'] ?? null);
+
+			// Relaxed CORS header already authorized
+			header('Access-Control-Allow-Origin: *');
 		} else {
 			$inbox = ActivityPub\ClientToServer::getPublicInbox($uid, $page, $request['max_id'] ?? null);
 		}


### PR DESCRIPTION
Added CORS header to allow requests from any origin.

Allows fetching inbox & sharedInbox via c2s

Fixes: https://github.com/friendica/friendica/issues/15404