### PR TITLE
Execute more contact workers by "add" functions

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -36,6 +36,9 @@ use Friendica\Util\Images;
 use Friendica\Util\Network;
 use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
+use Friendica\Worker\AddContact;
+use Friendica\Worker\ContactDiscovery;
+use Friendica\Worker\ContactDiscoveryForUser;
 use Friendica\Worker\UpdateContact;
 
 /**
@@ -3004,7 +3007,7 @@ class Contact
 			self::updateContact($id, $uid, $uriid, $contact['url'], ['failed' => false, 'local-data' => $has_local_data, 'last-update' => $updated, 'next-update' => $success_next_update, 'success_update' => $updated]);
 
 			if (Contact\Relation::isDiscoverable($ret['url'])) {
-				Worker::add(Worker::PRIORITY_LOW, 'ContactDiscovery', $ret['url']);
+				ContactDiscovery::add(Worker::PRIORITY_LOW, $ret['url']);
 			}
 
 			// Update the public contact
@@ -3048,7 +3051,7 @@ class Contact
 		self::updateContact($id, $uid, $ret['uri-id'], $ret['url'], $ret);
 
 		if (Contact\Relation::isDiscoverable($ret['url'])) {
-			Worker::add(Worker::PRIORITY_LOW, 'ContactDiscovery', $ret['url']);
+			ContactDiscovery::add(Worker::PRIORITY_LOW, $ret['url']);
 		}
 
 		return true;
@@ -3512,7 +3515,7 @@ class Contact
 			return;
 		}
 
-		Worker::add(Worker::PRIORITY_LOW, 'ContactDiscoveryForUser', $contact['uid']);
+		ContactDiscoveryForUser::add(Worker::PRIORITY_LOW, $contact['uid']);
 
 		self::clearFollowerFollowingEndpointCache($contact['uid']);
 
@@ -3544,7 +3547,7 @@ class Contact
 			self::update(['rel' => self::FOLLOWER, 'pending' => false], ['id' => $contact['id']]);
 		}
 
-		Worker::add(Worker::PRIORITY_LOW, 'ContactDiscoveryForUser', $contact['uid']);
+		ContactDiscoveryForUser::add(Worker::PRIORITY_LOW, $contact['uid']);
 	}
 
 	/**
@@ -3846,7 +3849,7 @@ class Contact
 			}
 			$contact = self::getByURL($url, false, ['id', 'network', 'next-update']);
 			if (empty($contact['id']) && Network::isValidHttpUrl($url)) {
-				Worker::add(Worker::PRIORITY_LOW, 'AddContact', 0, $url);
+				AddContact::add(Worker::PRIORITY_LOW, 0, $url);
 				++$added;
 			} elseif (!empty($contact['network']) && Protocol::supportsProbe($contact['network']) && ($contact['next-update'] < DateTimeFormat::utcNow())) {
 				try {

--- a/src/Module/Settings/ContactImport.php
+++ b/src/Module/Settings/ContactImport.php
@@ -20,6 +20,7 @@ use Friendica\Navigation\SystemMessages;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Network;
 use Friendica\Util\Profiler;
+use Friendica\Worker\AddContact;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -72,7 +73,7 @@ class ContactImport extends BaseSettings
 						// "http" or "@" to be present in the string.
 						// All other fields from the row will be ignored
 						if ((strpos($csvRow[0], '@') !== false) || Network::isValidHttpUrl($csvRow[0])) {
-							Worker::add(Worker::PRIORITY_MEDIUM, 'AddContact', $this->session->getLocalUserId(), trim($csvRow[0], '@'));
+							AddContact::add(Worker::PRIORITY_MEDIUM, $this->session->getLocalUserId(), trim($csvRow[0], '@'));
 						} else {
 							$this->logger->notice('Invalid account', ['url' => $csvRow[0]]);
 						}

--- a/src/Worker/ContactDiscovery.php
+++ b/src/Worker/ContactDiscovery.php
@@ -7,6 +7,8 @@
 
 namespace Friendica\Worker;
 
+use Friendica\Core\Worker;
+use Friendica\DI;
 use Friendica\Model\Contact;
 
 class ContactDiscovery
@@ -18,5 +20,16 @@ class ContactDiscovery
 	public static function execute(string $url)
 	{
 		Contact\Relation::discoverByUrl($url);
+	}
+
+	/**
+	 * @param array|int $run_parameters Priority constant or array of options described in Worker::add
+	 * @param string    $url
+	 * @return int
+	 */
+	public static function add($run_parameters, string $url): int
+	{
+		DI::logger()->debug('Contact discovery', ['url' => $url]);
+		return Worker::add($run_parameters, 'ContactDiscovery', $url);
 	}
 }

--- a/src/Worker/ContactDiscoveryForUser.php
+++ b/src/Worker/ContactDiscoveryForUser.php
@@ -7,6 +7,8 @@
 
 namespace Friendica\Worker;
 
+use Friendica\Core\Worker;
+use Friendica\DI;
 use Friendica\Model\Contact;
 
 class ContactDiscoveryForUser
@@ -17,5 +19,16 @@ class ContactDiscoveryForUser
 	public static function execute(int $uid)
 	{
 		Contact\Relation::discoverByUser($uid);
+	}
+
+	/**
+	 * @param array|int $run_parameters Priority constant or array of options described in Worker::add
+	 * @param int       $uid
+	 * @return int
+	 */
+	public static function add($run_parameters, int $uid): int
+	{
+		DI::logger()->debug('Contact discovery for user', ['uid' => $uid]);
+		return Worker::add($run_parameters, 'ContactDiscoveryForUser', $uid);
 	}
 }

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -141,7 +141,8 @@ class Cron
 			// Update contact relations for our users
 			$users = DBA::select('user', ['uid'], ["`verified` AND NOT `blocked` AND NOT `account_removed` AND NOT `account_expired` AND `uid` > ?", 0]);
 			while ($user = DBA::fetch($users)) {
-				Worker::add(Worker::PRIORITY_LOW, 'ContactDiscoveryForUser', $user['uid']);
+				ContactDiscoveryForUser::add(Worker::PRIORITY_LOW, $user['uid']);
+
 			}
 			DBA::close($users);
 


### PR DESCRIPTION
This PR should help in tracing down possible problems with masses of "addcontact" and "updatecontact" workers. It should now be easier to see what caused this.