### PR TITLE
Added worker limit check

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -412,7 +412,7 @@ class Contact
 		}
 
 		// Update the contact in the background if needed
-		if (UpdateContact::isUpdatable($contact['id'])) {
+		if (UpdateContact::isUpdatable($contact['id']) && !UpdateContact::workerLimitReached()) {
 			try {
 				UpdateContact::add(['priority' => Worker::PRIORITY_LOW, 'dont_fork' => true], $contact['id']);
 			} catch (\InvalidArgumentException $e) {
@@ -1384,7 +1384,7 @@ class Contact
 		if (!empty($contact)) {
 			$contact_id = $contact['id'];
 
-			if (UpdateContact::isUpdatable($contact['id'])) {
+			if (UpdateContact::isUpdatable($contact['id']) && !UpdateContact::workerLimitReached()) {
 				try {
 					UpdateContact::add(['priority' => Worker::PRIORITY_LOW, 'dont_fork' => true], $contact['id']);
 				} catch (\InvalidArgumentException $e) {
@@ -3006,7 +3006,7 @@ class Contact
 		if (!$update) {
 			self::updateContact($id, $uid, $uriid, $contact['url'], ['failed' => false, 'local-data' => $has_local_data, 'last-update' => $updated, 'next-update' => $success_next_update, 'success_update' => $updated]);
 
-			if (Contact\Relation::isDiscoverable($ret['url'])) {
+			if (Contact\Relation::isDiscoverable($ret['url']) && !ContactDiscovery::workerLimitReached()) {
 				ContactDiscovery::add(Worker::PRIORITY_LOW, $ret['url']);
 			}
 
@@ -3050,7 +3050,7 @@ class Contact
 
 		self::updateContact($id, $uid, $ret['uri-id'], $ret['url'], $ret);
 
-		if (Contact\Relation::isDiscoverable($ret['url'])) {
+		if (Contact\Relation::isDiscoverable($ret['url']) && !ContactDiscovery::workerLimitReached()) {
 			ContactDiscovery::add(Worker::PRIORITY_LOW, $ret['url']);
 		}
 

--- a/src/Model/Contact/Relation.php
+++ b/src/Model/Contact/Relation.php
@@ -178,7 +178,7 @@ class Relation
 					DBA::insert('contact-relation', $fields, Database::INSERT_UPDATE);
 					$following_counter++;
 				}
-			} else {
+			} elseif (!AddContact::workerLimitReached()) {
 				AddContact::add(Worker::PRIORITY_LOW, 0, $contact_url);
 			}
 		}

--- a/src/Worker/AddContact.php
+++ b/src/Worker/AddContact.php
@@ -57,4 +57,19 @@ class AddContact
 		DI::logger()->debug('Add contact', ['uid' => $uid, 'url' => $url]);
 		return Worker::add($run_parameters, 'AddContact', 0, $url);
 	}
+
+	/**
+	 * Checks if the maximum number of allowed workers for this task is reached
+	 *
+	 * @return boolean
+	 */
+	public static function workerLimitReached(): bool
+	{
+		$add_limit = (int)DI::config()->get('system', 'contact_add_limit');
+		$adding    = Worker::countWorkersByCommand('AddContact');
+		if ($adding >= $add_limit) {
+			DI::logger()->info('The number of currently running jobs exceed the limit', ['adding' => $adding, 'limit' => $add_limit]);
+		}
+		return ($adding >= $add_limit);
+	}
 }

--- a/src/Worker/ContactDiscovery.php
+++ b/src/Worker/ContactDiscovery.php
@@ -32,4 +32,19 @@ class ContactDiscovery
 		DI::logger()->debug('Contact discovery', ['url' => $url]);
 		return Worker::add($run_parameters, 'ContactDiscovery', $url);
 	}
+
+	/**
+	 * Checks if the maximum number of allowed workers for this task is reached
+	 *
+	 * @return boolean
+	 */
+	public static function workerLimitReached(): bool
+	{
+		$discovery_limit = (int)DI::config()->get('system', 'contact_discovery_limit');
+		$discovering     = Worker::countWorkersByCommand('ContactDiscovery');
+		if ($discovering >= $discovery_limit) {
+			DI::logger()->info('The number of currently running jobs exceed the limit', ['discovering' => $discovering, 'limit' => $discovery_limit]);
+		}
+		return ($discovering >= $discovery_limit);
+	}
 }

--- a/src/Worker/UpdateContact.php
+++ b/src/Worker/UpdateContact.php
@@ -57,6 +57,21 @@ class UpdateContact
 		return Worker::add($run_parameters, 'UpdateContact', $contact_id);
 	}
 
+	/**
+	 * Checks if the maximum number of allowed workers for this task is reached
+	 *
+	 * @return boolean
+	 */
+	public static function workerLimitReached(): bool
+	{
+		$update_limit = (int)DI::config()->get('system', 'contact_update_limit');
+		$updating     = Worker::countWorkersByCommand('UpdateContact');
+		if ($updating >= $update_limit) {
+			DI::logger()->info('The number of currently running jobs exceed the limit', ['updating' => $updating, 'limit' => $update_limit]);
+		}
+		return ($updating >= $update_limit);
+	}
+
 	public static function isUpdatable(int $contact_id): bool
 	{
 		$contact = Contact::selectFirst(['next-update', 'local-data', 'url', 'network', 'uid'], ['id' => $contact_id]);

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -147,6 +147,14 @@ return [
 		// Pregenerate channel posts.
 		'channel_cache' => false,
 
+		// contact_add_limit (Integer)
+		// How many contacts should be added at a time?
+		'contact_add_limit' => 10,
+
+		// contact_discovery_limit (Integer)
+		// How many contacts relations should be checked at a time?
+		'contact_discovery_limit' => 10,
+
 		// contact_update_limit (Integer)
 		// How many contacts should be checked at a time?
 		'contact_update_limit' => 100,


### PR DESCRIPTION
This PR solves the problem that the contact discovery can lead to the creation of thousands of worker jobs that can clog the system.

This PR introduces a check for the current number of open worker tasks for the contact discovery. The system will only continue, when that number wasn't reached.