### PR TITLE
Make like and dislike mutually exclusive for posts and comments

### DIFF
--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -261,19 +261,19 @@ class Page implements ArrayAccess
 				'dictMaxFilesExceeded'         => $l10n->t("You can't upload any more files."),
 			],
 
-		'$local_user'             => $localUID,
-		'$generator'              => 'Friendica' . ' ' . App::VERSION,
-		'$update_content'         => (int)$pConfig->get($localUID, 'system', 'update_content'),
-		'$exclusive_like_dislike' => (int)$pConfig->get($localUID, 'system', 'exclusive_like_dislike', false),
-		'$shortcut_icon'          => $shortcut_icon,
-		'$touch_icon'             => $touch_icon,
-		'$block_public'           => intval($config->get('system', 'block_public')),
-		'$stylesheets'            => $this->stylesheets,
+			'$local_user'             => $localUID,
+			'$generator'              => 'Friendica' . ' ' . App::VERSION,
+			'$update_content'         => (int)$pConfig->get($localUID, 'system', 'update_content'),
+			'$exclusive_like_dislike' => (int)$pConfig->get($localUID, 'system', 'exclusive_like_dislike', false),
+			'$shortcut_icon'          => $shortcut_icon,
+			'$touch_icon'             => $touch_icon,
+			'$block_public'           => intval($config->get('system', 'block_public')),
+			'$stylesheets'            => $this->stylesheets,
 
-		// Dropzone
-		'$max_imagesize' => round(Images::getMaxUploadBytes() / 1000000, 0),
+			// Dropzone
+			'$max_imagesize' => round(Images::getMaxUploadBytes() / 1000000, 0),
 
-	]) . $this->page['htmlhead'];
+		]) . $this->page['htmlhead'];
 
 		if ($pConfig->get($localUID, 'accessibility', 'hide_empty_descriptions')) {
 			$this->page['htmlhead'] .= "<style>.empty-description {display: none;}</style>\n";
@@ -284,8 +284,6 @@ class Page implements ArrayAccess
 	}
 
 	/**
-	 * Returns the complete URL of the current page, e.g.: http(s)://something.com/network
-	 *
 	 * Taken from http://webcheatsheet.com/php/get_current_page_url.php
 	 */
 	private function curPageURL(): string

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -261,22 +261,19 @@ class Page implements ArrayAccess
 				'dictMaxFilesExceeded'         => $l10n->t("You can't upload any more files."),
 			],
 
-		'$local_user'                => $localUID,
-		'$generator'                 => 'Friendica' . ' ' . App::VERSION,
-		'$update_content'            => (int)$pConfig->get($localUID, 'system', 'update_content'),
-		'$exclusive_like_dislike'    => (int)$pConfig->get($localUID, 'system', 'exclusive_like_dislike', false),
-		'$shortcut_icon'             => $shortcut_icon,
-		'$touch_icon'                => $touch_icon,
-		'$block_public'              => intval($config->get('system', 'block_public')),
-		'$stylesheets'               => $this->stylesheets,
+		'$local_user'             => $localUID,
+		'$generator'              => 'Friendica' . ' ' . App::VERSION,
+		'$update_content'         => (int)$pConfig->get($localUID, 'system', 'update_content'),
+		'$exclusive_like_dislike' => (int)$pConfig->get($localUID, 'system', 'exclusive_like_dislike', false),
+		'$shortcut_icon'          => $shortcut_icon,
+		'$touch_icon'             => $touch_icon,
+		'$block_public'           => intval($config->get('system', 'block_public')),
+		'$stylesheets'            => $this->stylesheets,
 
 		// Dropzone
 		'$max_imagesize' => round(Images::getMaxUploadBytes() / 1000000, 0),
 
 	]) . $this->page['htmlhead'];
-
-		if ($pConfig->get($localUID, 'accessibility', 'hide_empty_descriptions')) {
-			$this->page['htmlhead'] .= "<style>.empty-description {display: none;}</style>\n";
 		}
 		if ($pConfig->get($localUID, 'accessibility', 'hide_custom_emojis')) {
 			$this->page['htmlhead'] .= "<style>span.emoji.mastodon img {display: none;}</style>\n";

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -274,6 +274,29 @@ class Page implements ArrayAccess
 		'$max_imagesize' => round(Images::getMaxUploadBytes() / 1000000, 0),
 
 	]) . $this->page['htmlhead'];
+
+		if ($pConfig->get($localUID, 'accessibility', 'hide_empty_descriptions')) {
+			$this->page['htmlhead'] .= "<style>.empty-description {display: none;}</style>\n";
+		}
+		if ($pConfig->get($localUID, 'accessibility', 'hide_custom_emojis')) {
+			$this->page['htmlhead'] .= "<style>span.emoji.mastodon img {display: none;}</style>\n";
+		}
+	}
+
+	/**
+	 * Returns the complete URL of the current page, e.g.: http(s)://something.com/network
+	 *
+	 * Taken from http://webcheatsheet.com/php/get_current_page_url.php
+	 */
+	private function curPageURL(): string
+	{
+		$pageURL = 'http';
+		if (!empty($_SERVER["HTTPS"]) && ($_SERVER["HTTPS"] == "on")) {
+			$pageURL .= "s";
+		}
+
+		$pageURL .= "://";
+
 		if ($_SERVER["SERVER_PORT"] != "80" && $_SERVER["SERVER_PORT"] != "443") {
 			$pageURL .= $_SERVER["SERVER_NAME"] . ":" . $_SERVER["SERVER_PORT"] . $_SERVER["REQUEST_URI"];
 		} else {

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -274,9 +274,6 @@ class Page implements ArrayAccess
 		'$max_imagesize' => round(Images::getMaxUploadBytes() / 1000000, 0),
 
 	]) . $this->page['htmlhead'];
-
-		if ($pConfig->get($localUID, 'accessibility', 'hide_empty_descriptions')) {
-			$this->page['htmlhead'] .= "<style>.empty-description {display: none;}</style>\n";
 		}
 		if ($pConfig->get($localUID, 'accessibility', 'hide_custom_emojis')) {
 			$this->page['htmlhead'] .= "<style>span.emoji.mastodon img {display: none;}</style>\n";

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -261,41 +261,19 @@ class Page implements ArrayAccess
 				'dictMaxFilesExceeded'         => $l10n->t("You can't upload any more files."),
 			],
 
-			'$local_user'     => $localUID,
-			'$generator'      => 'Friendica' . ' ' . App::VERSION,
-			'$update_content' => (int)$pConfig->get($localUID, 'system', 'update_content'),
-			'$shortcut_icon'  => $shortcut_icon,
-			'$touch_icon'     => $touch_icon,
-			'$block_public'   => intval($config->get('system', 'block_public')),
-			'$stylesheets'    => $this->stylesheets,
+		'$local_user'                => $localUID,
+		'$generator'                 => 'Friendica' . ' ' . App::VERSION,
+		'$update_content'            => (int)$pConfig->get($localUID, 'system', 'update_content'),
+		'$exclusive_like_dislike'    => (int)$pConfig->get($localUID, 'system', 'exclusive_like_dislike', false),
+		'$shortcut_icon'             => $shortcut_icon,
+		'$touch_icon'                => $touch_icon,
+		'$block_public'              => intval($config->get('system', 'block_public')),
+		'$stylesheets'               => $this->stylesheets,
 
-			// Dropzone
-			'$max_imagesize' => round(Images::getMaxUploadBytes() / 1000000, 0),
+		// Dropzone
+		'$max_imagesize' => round(Images::getMaxUploadBytes() / 1000000, 0),
 
-		]) . $this->page['htmlhead'];
-
-		if ($pConfig->get($localUID, 'accessibility', 'hide_empty_descriptions')) {
-			$this->page['htmlhead'] .= "<style>.empty-description {display: none;}</style>\n";
-		}
-		if ($pConfig->get($localUID, 'accessibility', 'hide_custom_emojis')) {
-			$this->page['htmlhead'] .= "<style>span.emoji.mastodon img {display: none;}</style>\n";
-		}
-	}
-
-	/**
-	 * Returns the complete URL of the current page, e.g.: http(s)://something.com/network
-	 *
-	 * Taken from http://webcheatsheet.com/php/get_current_page_url.php
-	 */
-	private function curPageURL(): string
-	{
-		$pageURL = 'http';
-		if (!empty($_SERVER["HTTPS"]) && ($_SERVER["HTTPS"] == "on")) {
-			$pageURL .= "s";
-		}
-
-		$pageURL .= "://";
-
+	]) . $this->page['htmlhead'];
 		if ($_SERVER["SERVER_PORT"] != "80" && $_SERVER["SERVER_PORT"] != "443") {
 			$pageURL .= $_SERVER["SERVER_NAME"] . ":" . $_SERVER["SERVER_PORT"] . $_SERVER["REQUEST_URI"];
 		} else {

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -274,6 +274,9 @@ class Page implements ArrayAccess
 		'$max_imagesize' => round(Images::getMaxUploadBytes() / 1000000, 0),
 
 	]) . $this->page['htmlhead'];
+
+		if ($pConfig->get($localUID, 'accessibility', 'hide_empty_descriptions')) {
+			$this->page['htmlhead'] .= "<style>.empty-description {display: none;}</style>\n";
 		}
 		if ($pConfig->get($localUID, 'accessibility', 'hide_custom_emojis')) {
 			$this->page['htmlhead'] .= "<style>span.emoji.mastodon img {display: none;}</style>\n";

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2643,7 +2643,7 @@ class Item
 
 		// Enable activity toggling instead of on/off
 		$event_verb_flag = $activity === Activity::ATTEND || $activity === Activity::ATTENDNO || $activity === Activity::ATTENDMAYBE;
-		$like_verb_flag = $activity === Activity::LIKE || $activity === Activity::DISLIKE;
+		$like_verb_flag  = $activity === Activity::LIKE || $activity === Activity::DISLIKE;
 
 		// Look for an existing verb row
 		// Event participation activities are mutually exclusive, only one of them can exist at all times.

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -29,7 +29,6 @@ use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Network\HTTPException\ServiceUnavailableException;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\ActivityPub;
-use Friendica\Protocol\ActivityPub\Processor;
 use Friendica\Protocol\Delivery;
 use Friendica\Protocol\Diaspora;
 use Friendica\Util\DateTimeFormat;
@@ -40,6 +39,7 @@ use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 use Friendica\Util\Temporal;
 use GuzzleHttp\Psr7\Uri;
+use LanguageDetection\Language;
 
 class Item
 {
@@ -159,7 +159,6 @@ class Item
 	const CANT_REPLY    = 1;
 	const CANT_LIKE     = 2;
 	const CANT_ANNOUNCE = 4;
-	const CANT_QUOTE    = 8;
 
 	/**
 	 * Update existing item entries
@@ -997,10 +996,6 @@ class Item
 			return 0;
 		}
 
-		if (!isset($item['restrictions']) || is_null($item['restrictions'])) {
-			$item['restrictions'] = Processor::getRestrictions($item['uri-id'], $item['author-id'], $item['uid']);
-		}
-
 		$post_user_id = Post\User::insert($item['uri-id'], $item['uid'], $item);
 		if (!$post_user_id) {
 			DI::logger()->notice('Post-User is already inserted - aborting', ['uid' => $item['uid'], 'uri-id' => $item['uri-id']]);
@@ -1019,7 +1014,7 @@ class Item
 
 	private static function handleCreatedItem(array $orig_item, int $post_user_id, int $uid, int $notify, bool $copy_permissions, $parent_origin, int $priority, string $notify_type, bool $inserted, $source): int
 	{
-		$posted_item = Post::selectFirst(array_merge(self::ITEM_FIELDLIST, ['author-contact-type']), ['post-user-id' => $post_user_id]);
+		$posted_item = Post::selectFirst(self::ITEM_FIELDLIST, ['post-user-id' => $post_user_id]);
 		if (!DBA::isResult($posted_item)) {
 			// On failure store the data into a spool file so that the "SpoolPost" worker can try again later.
 			DI::logger()->warning('Could not store item. it will be spooled', ['id' => $post_user_id]);
@@ -1027,9 +1022,7 @@ class Item
 			return 0;
 		}
 
-		DI::logger()->debug('Handle created item', ['id' => $post_user_id, 'uri-id' => $posted_item['uri-id'], 'uid' => $posted_item['uid']]);
-
-		if ($posted_item['origin'] && $posted_item['gravity'] === self::GRAVITY_PARENT) {
+		if ($posted_item['origin'] && $posted_item['gravity'] == self::GRAVITY_PARENT) {
 			$posts = (int)(DI::keyValue()->get('nodeinfo_local_posts') ?? 0);
 			DI::keyValue()->set('nodeinfo_local_posts', $posts + 1);
 		} elseif ($posted_item['origin'] && $posted_item['gravity'] == self::GRAVITY_COMMENT) {
@@ -1050,7 +1043,6 @@ class Item
 
 		if ($update_commented) {
 			$fields = ['commented' => $posted_item['received'], 'changed' => $posted_item['received']];
-			DBA::update('channel-post', ['commented' => $posted_item['received']], ['uri-id' => $posted_item['parent-uri-id']]);
 		} else {
 			$fields = ['changed' => $posted_item['received']];
 		}
@@ -1131,7 +1123,7 @@ class Item
 		}
 
 		if ($inserted) {
-			if ($posted_item['gravity'] === self::GRAVITY_PARENT) {
+			if ($posted_item['gravity'] == self::GRAVITY_PARENT) {
 				$posts = (int)(DI::keyValue()->get('nodeinfo_total_posts') ?? 0);
 				DI::keyValue()->set('nodeinfo_total_posts', $posts + 1);
 			} elseif ($posted_item['gravity'] == self::GRAVITY_COMMENT) {
@@ -1368,16 +1360,14 @@ class Item
 			return;
 		}
 
-		$languages = $item['language'] ? json_decode($item['language'], true) : [];
-		$quality   = DI::config()->get('system', 'relay_language_quality');
+		$languages = $item['language'] ? array_keys(json_decode($item['language'], true)) : [];
 
 		foreach (Tag::getUIDListByURIId($item['uri-id']) as $uid => $tags) {
 			if (!empty($languages)) {
 				$keep           = false;
 				$user_languages = User::getWantedLanguages($uid);
 				foreach ($user_languages as $language) {
-					if (in_array($language, array_keys($languages)) && $languages[$language] > $quality) {
-						DI::logger()->debug('Wanted language found', ['uid' => $uid, 'language' => $language, 'quality' => $languages[$language], 'limit' => $quality]);
+					if (in_array($language, $languages)) {
 						$keep = true;
 					}
 				}
@@ -1887,7 +1877,7 @@ class Item
 	 * @return string Unique guid
 	 * @throws \Exception
 	 */
-	public static function guidFromUri(string $uri, ?string $host = null): string
+	public static function guidFromUri(string $uri, string $host = null): string
 	{
 		// Our regular guid routine is using this kind of prefix as well
 		// We have to avoid that different routines could accidentally create the same value
@@ -2289,7 +2279,7 @@ class Item
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function fixPrivatePhotos(string $s, int $uid, ?array $item = null, int $cid = 0): string
+	public static function fixPrivatePhotos(string $s, int $uid, array $item = null, int $cid = 0): string
 	{
 		if (DI::config()->get('system', 'disable_embedded')) {
 			return $s;
@@ -2555,7 +2545,7 @@ class Item
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function performActivity(int $item_id, string $verb, int $uid, ?string $allow_cid = null, ?string $allow_gid = null, ?string $deny_cid = null, ?string $deny_gid = null): bool
+	public static function performActivity(int $item_id, string $verb, int $uid, string $allow_cid = null, string $allow_gid = null, string $deny_cid = null, string $deny_gid = null): bool
 	{
 		if (empty($uid)) {
 			return false;
@@ -2643,11 +2633,13 @@ class Item
 
 		// Enable activity toggling instead of on/off
 		$event_verb_flag = $activity === Activity::ATTEND || $activity === Activity::ATTENDNO || $activity === Activity::ATTENDMAYBE;
-		$like_verb_flag  = $activity === Activity::LIKE || $activity === Activity::DISLIKE;
+		// Like and dislike activities are mutually exclusive if the user has enabled this setting
+		$exclusive_like_dislike = DI::pConfig()->get($uid, 'system', 'exclusive_like_dislike', false);
+		$like_verb_flag = $exclusive_like_dislike && ($activity === Activity::LIKE || $activity === Activity::DISLIKE);
 
 		// Look for an existing verb row
 		// Event participation activities are mutually exclusive, only one of them can exist at all times.
-		// Like and dislike activities are also mutually exclusive.
+		// Like and dislike activities are also mutually exclusive if the user setting is enabled.
 		if ($event_verb_flag) {
 			$verbs = [Activity::ATTEND, Activity::ATTENDNO, Activity::ATTENDMAYBE];
 
@@ -3024,14 +3016,14 @@ class Item
 		if (!empty($shared_item['uri-id'])) {
 			$shared_uri_id          = $shared_item['uri-id'];
 			$shared_links[]         = strtolower($shared_item['plink']);
-			$sharedSplitAttachments = DI::postMediaRepository()->splitAttachments($shared_uri_id, [], $shared_item['has-media'], $uid != 0);
+			$sharedSplitAttachments = DI::postMediaRepository()->splitAttachments($shared_uri_id, [], $shared_item['has-media']);
 			$shared_links           = array_merge($shared_links, $sharedSplitAttachments['visual']->column('url'));
 			$shared_links           = array_merge($shared_links, $sharedSplitAttachments['link']->column('url'));
 			$shared_links           = array_merge($shared_links, $sharedSplitAttachments['additional']->column('url'));
 			$item['body']           = self::replaceVisualAttachments($sharedSplitAttachments['visual'], $item['body']);
 		}
 
-		$itemSplitAttachments = DI::postMediaRepository()->splitAttachments($item['uri-id'], $shared_links, $item['has-media'] ?? false, $uid != 0);
+		$itemSplitAttachments = DI::postMediaRepository()->splitAttachments($item['uri-id'], $shared_links, $item['has-media'] ?? false);
 		$item['body']         = self::replaceVisualAttachments($itemSplitAttachments['visual'], $item['body'] ?? '');
 
 		self::putInCache($item);
@@ -3105,9 +3097,8 @@ class Item
 		if (!empty($sharedSplitAttachments)) {
 			$s    = self::addGallery($s, $sharedSplitAttachments['visual']);
 			$s    = self::addVisualAttachments($sharedSplitAttachments['visual'], $shared_item, $s, true, $uid);
-			$s    = self::addLinkAttachment($shared_uri_id ?: $item['uri-id'], $sharedSplitAttachments, $body, $s, true, $quote_shared_links, $uid, $shared_item);
+			$s    = self::addLinkAttachment($shared_uri_id ?: $item['uri-id'], $sharedSplitAttachments, $body, $s, true, $quote_shared_links, $uid);
 			$s    = self::addNonVisualAttachments($sharedSplitAttachments['additional'], $item, $s);
-			$s    = self::addHiddenAttachments($sharedSplitAttachments['hidden'], $item, $s);
 			$body = BBCode::removeSharedData($body);
 		}
 
@@ -3119,9 +3110,8 @@ class Item
 
 		$s = self::addGallery($s, $itemSplitAttachments['visual']);
 		$s = self::addVisualAttachments($itemSplitAttachments['visual'], $item, $s, false, $uid);
-		$s = self::addLinkAttachment($item['uri-id'], $itemSplitAttachments, $body, $s, false, $shared_links, $uid, $item);
+		$s = self::addLinkAttachment($item['uri-id'], $itemSplitAttachments, $body, $s, false, $shared_links, $uid);
 		$s = self::addNonVisualAttachments($itemSplitAttachments['additional'], $item, $s);
-		$s = self::addHiddenAttachments($itemSplitAttachments['hidden'], $item, $s);
 		$s = self::addQuestions($item, $s);
 
 		// Map.
@@ -3142,7 +3132,7 @@ class Item
 			$s .= $shared_html;
 		}
 
-		$s = DI::postMediaRepository()->addEmbed($s, $uid, $item['uri-id'], $uid != 0);
+		$s = DI::postMediaRepository()->addEmbed($s, $uid, $item['uri-id']);
 
 		$s = HTML::applyContentFilter($s, $filter_reasons);
 
@@ -3204,7 +3194,6 @@ class Item
 	 */
 	private static function addGallery(string $s, PostMedias $PostMedias): string
 	{
-		/** @var PostMedia $PostMedia */
 		foreach ($PostMedias as $PostMedia) {
 			if (!$PostMedia->preview || ($PostMedia->type !== Post\Media::IMAGE)) {
 				continue;
@@ -3309,7 +3298,6 @@ class Item
 	{
 		DI::profiler()->startRecording('rendering');
 
-		/** @var PostMedia $PostMedia */
 		foreach ($PostMedias as $PostMedia) {
 			if ($PostMedia->preview) {
 				if (DI::baseUrl()->isLocalUri($PostMedia->preview)) {
@@ -3354,7 +3342,6 @@ class Item
 		$images   = new PostMedias();
 
 		// @todo In the future we should make a single for the template engine with all media in it. This allows more flexibilty.
-		/** @var PostMedia $PostMedia */
 		foreach ($PostMedias as $PostMedia) {
 			if (self::containsLink($item['body'], $PostMedia->preview ?? $PostMedia->url, $PostMedia->type) || self::containsEmbed($item['body'], $PostMedia->url)) {
 				continue;
@@ -3435,24 +3422,19 @@ class Item
 	 * @param bool         $shared
 	 * @param array        $ignore_links A list of URLs to ignore
 	 * @param int          $uid
-	 * @param array        $item
 	 * @return string modified content
 	 * @throws InternalServerErrorException
 	 * @throws ServiceUnavailableException
 	 */
-	private static function addLinkAttachment(int $uriid, array $attachments, string $body, string $content, bool $shared, array $ignore_links, int $uid, array $item): string
+	private static function addLinkAttachment(int $uriid, array $attachments, string $body, string $content, bool $shared, array $ignore_links, int $uid): string
 	{
 		DI::profiler()->startRecording('rendering');
 		// Don't show a preview when there is a visual attachment (audio or video)
-		$types      = $attachments['visual']->column('type');
-		$preview    = !in_array(PostMedia::TYPE_IMAGE, $types) && !in_array(PostMedia::TYPE_VIDEO, $types);
-		$has_media  = in_array($item['post-type'] ?? null, [Item::PT_AUDIO, Item::PT_VIDEO]);
-		$is_article = false;
+		$types   = $attachments['visual']->column('type');
+		$preview = !in_array(PostMedia::TYPE_IMAGE, $types) && !in_array(PostMedia::TYPE_VIDEO, $types);
 
 		/** @var ?PostMedia $attachment */
 		$attachment = null;
-
-		/** @var PostMedia $PostMedia */
 		foreach ($attachments['link'] as $PostMedia) {
 			$found = false;
 			foreach ($ignore_links as $ignore_link) {
@@ -3490,9 +3472,7 @@ class Item
 				'embed_html'    => $attachment->embedHtml,
 				'embed_width'   => $attachment->embedWidth,
 				'embed_height'  => $attachment->embedHeight,
-				'page_type'     => $attachment->pageType,
 			];
-			$is_article = $attachment->isArticle();
 
 			if ($preview && $attachment->preview) {
 				if ($attachment->previewWidth >= 500) {
@@ -3542,13 +3522,8 @@ class Item
 				}
 
 				// @todo Use a template
-				$preview_mode = DI::pConfig()->get($uid, 'system', 'preview_mode', BBCode::PREVIEW_AUTO);
-				if ($uid == 0) {
-					$preview_mode = BBCode::PREVIEW_NO_IMAGE;
-				} elseif ($preview_mode == BBCode::PREVIEW_AUTO) {
-					$preview_mode = $is_article ? BBCode::PREVIEW_SMALL : BBCode::PREVIEW_LARGE;
-				}
-				if (!$has_media && $preview_mode != BBCode::PREVIEW_NONE && !self::containsEmbed($body, $data['url'])) {
+				$preview_mode = DI::pConfig()->get($uid, 'system', 'preview_mode', BBCode::PREVIEW_LARGE);
+				if ($preview_mode != BBCode::PREVIEW_NONE && !self::containsEmbed($body, $data['url'])) {
 					$rendered = BBCode::convertAttachment('', BBCode::INTERNAL, $data, $uriid, $preview_mode, DI::pConfig()->get($uid, 'system', 'embed_remote_media', false));
 				} elseif (!self::containsLink($content, $data['url'], Post\Media::HTML)) {
 					$rendered = Renderer::replaceMacros(Renderer::getMarkupTemplate('content/link.tpl'), [
@@ -3590,7 +3565,6 @@ class Item
 	{
 		DI::profiler()->startRecording('rendering');
 		$trailing = '';
-		/** @var PostMedia $PostMedia */
 		foreach ($PostMedias as $PostMedia) {
 			if (strpos($item['body'], (string)$PostMedia->url)) {
 				continue;
@@ -3622,36 +3596,6 @@ class Item
 
 		DI::profiler()->stopRecording();
 		return $content;
-	}
-
-	/**
-	 * Add hidden attachments message to the content
-	 *
-	 * @param PostMedias $PostMedias
-	 * @param array      $item
-	 * @param string     $content
-	 * @return string modified content
-	 */
-	private static function addHiddenAttachments(PostMedias $PostMedias, array $item, string $content): string
-	{
-		if (count($PostMedias) == 0) {
-			return $content;
-		}
-
-
-		$plink = self::getPlink($item);
-
-		if (isset($plink['href']) && !DI::baseUrl()->isLocalUrl($plink['href'])) {
-			$message = DI::l10n()->t('The media in this post is not displayed to visitors. To view it, please go to the <a href="%s">original post</a>.', $plink['href']);
-		} else {
-			$message = DI::l10n()->t('The media in this post is not displayed to visitors. To view it, please log in.');
-		}
-
-		$media = Renderer::replaceMacros(Renderer::getMarkupTemplate('content/hidden.tpl'), [
-			'message' => $message,
-		]);
-
-		return $media . $content;
 	}
 
 	private static function addQuestions(array $item, string $content): string
@@ -3710,7 +3654,7 @@ class Item
 			$plink = $item['uri'];
 		}
 
-		if (isset($item['owner-contact-type']) && isset($item['owner-network']) && ($item['owner-contact-type'] == Contact::TYPE_COMMUNITY) && ($item['owner-network'] == Protocol::DFRN)) {
+		if (($item['post-reason'] == self::PR_ANNOUNCEMENT) && ($item['owner-contact-type'] == Contact::TYPE_COMMUNITY) && ($item['owner-network'] == Protocol::DFRN)) {
 			$contact = Contact::getById($item['owner-id'], ['baseurl']);
 			if (!empty($contact['baseurl'])) {
 				$plink = $contact['baseurl'] . '/display/' . $item['guid'];

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2643,11 +2643,21 @@ class Item
 
 		// Enable activity toggling instead of on/off
 		$event_verb_flag = $activity === Activity::ATTEND || $activity === Activity::ATTENDNO || $activity === Activity::ATTENDMAYBE;
+		$like_verb_flag = $activity === Activity::LIKE || $activity === Activity::DISLIKE;
 
 		// Look for an existing verb row
 		// Event participation activities are mutually exclusive, only one of them can exist at all times.
+		// Like and dislike activities are also mutually exclusive.
 		if ($event_verb_flag) {
 			$verbs = [Activity::ATTEND, Activity::ATTENDNO, Activity::ATTENDMAYBE];
+
+			// Translate to the index based activity index
+			$vids = [];
+			foreach ($verbs as $verb) {
+				$vids[] = Verb::getID($verb);
+			}
+		} elseif ($like_verb_flag) {
+			$verbs = [Activity::LIKE, Activity::DISLIKE];
 
 			// Translate to the index based activity index
 			$vids = [];
@@ -2692,7 +2702,7 @@ class Item
 				self::markForDeletionById($like_item['id']);
 			}
 
-			if (!$event_verb_flag || $like_item['verb'] == $activity) {
+			if ((!$event_verb_flag && !$like_verb_flag) || $like_item['verb'] == $activity) {
 				return true;
 			}
 		}

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -2636,7 +2636,7 @@ class Item
 		$event_verb_flag = $activity === Activity::ATTEND || $activity === Activity::ATTENDNO || $activity === Activity::ATTENDMAYBE;
 		// Like and dislike activities are mutually exclusive if the user has enabled this setting
 		$exclusive_like_dislike = DI::pConfig()->get($uid, 'system', 'exclusive_like_dislike', false);
-		$like_verb_flag = $exclusive_like_dislike && ($activity === Activity::LIKE || $activity === Activity::DISLIKE);
+		$like_verb_flag         = $exclusive_like_dislike && ($activity === Activity::LIKE || $activity === Activity::DISLIKE);
 
 		// Look for an existing verb row
 		// Event participation activities are mutually exclusive, only one of them can exist at all times.

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -159,6 +159,7 @@ class Item
 	const CANT_REPLY    = 1;
 	const CANT_LIKE     = 2;
 	const CANT_ANNOUNCE = 4;
+	const CANT_QUOTE    = 8;
 
 	/**
 	 * Update existing item entries

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -102,6 +102,7 @@ class Display extends BaseSettings
 		$infinite_scroll         = (bool)$request['infinite_scroll'];
 		$enable_smart_threading  = (bool)$request['enable_smart_threading'];
 		$enable_dislike          = (bool)$request['enable_dislike'];
+		$exclusive_like_dislike  = (bool)$request['exclusive_like_dislike'];
 		$display_resharer        = (bool)$request['display_resharer'];
 		$stay_local              = (bool)$request['stay_local'];
 		$hide_empty_descriptions = (bool)$request['hide_empty_descriptions'];
@@ -156,6 +157,7 @@ class Display extends BaseSettings
 		$this->pConfig->set($uid, 'system', 'infinite_scroll', $infinite_scroll);
 		$this->pConfig->set($uid, 'system', 'no_smart_threading', !$enable_smart_threading);
 		$this->pConfig->set($uid, 'system', 'hide_dislike', !$enable_dislike);
+		$this->pConfig->set($uid, 'system', 'exclusive_like_dislike', $exclusive_like_dislike);
 		$this->pConfig->set($uid, 'system', 'display_resharer', $display_resharer);
 		$this->pConfig->set($uid, 'system', 'stay_local', $stay_local);
 		$this->pConfig->set($uid, 'system', 'show_page_drop', $show_page_drop);
@@ -268,6 +270,7 @@ class Display extends BaseSettings
 		$infinite_scroll        = $this->pConfig->get($uid, 'system', 'infinite_scroll', true);
 		$enable_smart_threading = !$this->pConfig->get($uid, 'system', 'no_smart_threading', false);
 		$enable_dislike         = !$this->pConfig->get($uid, 'system', 'hide_dislike', false);
+		$exclusive_like_dislike = $this->pConfig->get($uid, 'system', 'exclusive_like_dislike', false);
 		$display_resharer       = $this->pConfig->get($uid, 'system', 'display_resharer', false);
 		$stay_local             = $this->pConfig->get($uid, 'system', 'stay_local', true);
 		$show_page_drop         = $this->pConfig->get($uid, 'system', 'show_page_drop', true);
@@ -457,6 +460,7 @@ class Display extends BaseSettings
 			'$infinite_scroll'          => ['infinite_scroll', $this->t('Infinite scroll'), $infinite_scroll, $this->t('Automatic fetch new items when reaching the page end.')],
 			'$enable_smart_threading'   => ['enable_smart_threading', $this->t('Enable Smart Threading'), $enable_smart_threading, $this->t('Enable the automatic suppression of extraneous thread indentation.')],
 			'$enable_dislike'           => ['enable_dislike', $this->t('Display the Dislike feature'), $enable_dislike, $this->t('Display the Dislike button and dislike reactions on posts and comments.')],
+			'$exclusive_like_dislike'   => ['exclusive_like_dislike', $this->t('Make Like and Dislike mutually exclusive'), $exclusive_like_dislike, $this->t('When enabled, clicking Like removes any existing Dislike and vice versa, similar to event attendance.')],
 			'$display_resharer'         => ['display_resharer', $this->t('Display the resharer'), $display_resharer, $this->t('Display the first resharer as icon and text on a reshared item.')],
 			'$stay_local'               => ['stay_local', $this->t('Stay local'), $stay_local, $this->t("Don't go to a remote system when following a contact link.")],
 			'$show_page_drop'           => ['show_page_drop', $this->t('Show the post deletion checkbox'), $show_page_drop, $this->t("Display the checkbox for the post deletion on the network page.")],

--- a/view/templates/settings/display.tpl
+++ b/view/templates/settings/display.tpl
@@ -23,6 +23,7 @@
 	{{include file="field_checkbox.tpl" field=$infinite_scroll}}
 	{{include file="field_checkbox.tpl" field=$enable_smart_threading}}
 	{{include file="field_checkbox.tpl" field=$enable_dislike}}
+	{{include file="field_checkbox.tpl" field=$exclusive_like_dislike}}
 	{{include file="field_checkbox.tpl" field=$display_resharer}}
 	{{include file="field_checkbox.tpl" field=$stay_local}}
 	{{include file="field_checkbox.tpl" field=$show_page_drop}}

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -762,6 +762,11 @@ function htmlToText(htmlString) {
  * @param {boolean} un    Whether to perform an activity removal instead of creation
  */
 function doActivityItemAction(ident, verb, un) {
+	// Prevent multiple simultaneous requests for the same action
+	if ($('img[id^=waitfor-' + verb + '-' + ident.toString() + ']').length > 0) {
+		return false;
+	}
+	
 	_verb = un ? 'un' + verb : verb;
 	var thumbsClass = '';
 	switch (verb) {
@@ -814,6 +819,16 @@ function doActivityItemAction(ident, verb, un) {
 				$('button#attendyes-' + ident.toString()).attr('onclick', 'javascript:doActivityItemAction(' + ident +', "attendyes")');
 				$('button#attendno-' + ident.toString()).attr('onclick', 'javascript:doActivityItemAction(' + ident +', "attendno")');
 				$('button#attendmaybe-' + ident.toString()).attr('onclick', 'javascript:doActivityItemAction(' + ident +', "attendmaybe")');
+			}
+			// Like and dislike are mutually exclusive, ensure opposite button is deactivated
+			if (verb === 'like' && data.verb === 'like') {
+				$('button[id^=dislike-' + ident.toString() + ']')
+					.removeClass('active')
+					.attr('onclick', 'doActivityItemAction(' + ident +', "dislike")');
+			} else if (verb === 'dislike' && data.verb === 'dislike') {
+				$('button[id^=like-' + ident.toString() + ']')
+					.removeClass('active')
+					.attr('onclick', 'doActivityItemAction(' + ident +', "like")');
 			}
 			if (data.verb == 'un' + verb) {
 				// like/dislike buttons

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -510,7 +510,6 @@ function justifyPhotos() {
 		.justifiedGallery({
 			margins: 3,
 			border: 0,
-			captions: false,
 			sizeRangeSuffixes: {
 				lt48: "-6",
 				lt80: "-5",
@@ -762,11 +761,11 @@ function htmlToText(htmlString) {
  * @param {boolean} un    Whether to perform an activity removal instead of creation
  */
 function doActivityItemAction(ident, verb, un) {
-	// Prevent multiple simultaneous requests for the same action
-	if ($('img[id^=waitfor-' + verb + '-' + ident.toString() + ']').length > 0) {
+	// Prevent multiple simultaneous requests for the same action if exclusive like/dislike is enabled
+	if (exclusiveLikeDislike && $('img[id^=waitfor-' + verb + '-' + ident.toString() + ']').length > 0) {
 		return false;
 	}
-	
+
 	_verb = un ? 'un' + verb : verb;
 	var thumbsClass = '';
 	switch (verb) {
@@ -820,15 +819,17 @@ function doActivityItemAction(ident, verb, un) {
 				$('button#attendno-' + ident.toString()).attr('onclick', 'javascript:doActivityItemAction(' + ident +', "attendno")');
 				$('button#attendmaybe-' + ident.toString()).attr('onclick', 'javascript:doActivityItemAction(' + ident +', "attendmaybe")');
 			}
-			// Like and dislike are mutually exclusive, ensure opposite button is deactivated
-			if (verb === 'like' && data.verb === 'like') {
-				$('button[id^=dislike-' + ident.toString() + ']')
-					.removeClass('active')
-					.attr('onclick', 'doActivityItemAction(' + ident +', "dislike")');
-			} else if (verb === 'dislike' && data.verb === 'dislike') {
-				$('button[id^=like-' + ident.toString() + ']')
-					.removeClass('active')
-					.attr('onclick', 'doActivityItemAction(' + ident +', "like")');
+			// Like and dislike are mutually exclusive if the user setting is enabled
+			if (exclusiveLikeDislike) {
+				if (verb === 'like' && data.verb === 'like') {
+					$('button[id^=dislike-' + ident.toString() + ']')
+						.removeClass('active')
+						.attr('onclick', 'doActivityItemAction(' + ident +', "dislike")');
+				} else if (verb === 'dislike' && data.verb === 'dislike') {
+					$('button[id^=like-' + ident.toString() + ']')
+						.removeClass('active')
+						.attr('onclick', 'doActivityItemAction(' + ident +', "like")');
+				}
 			}
 			if (data.verb == 'un' + verb) {
 				// like/dislike buttons

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -113,6 +113,7 @@
 	</script>
 	<script type="text/javascript">
 		const updateContent = {{$update_content}};
+		const exclusiveLikeDislike = {{$exclusive_like_dislike}};
 		const localUser = {{if $local_user}}{{$local_user}}{{else}}false{{/if}};
 	</script>
 	<script type="text/javascript" src="view/js/main.js?v={{$VERSION}}"></script>

--- a/view/theme/frio/templates/settings/display.tpl
+++ b/view/theme/frio/templates/settings/display.tpl
@@ -59,8 +59,9 @@
 						{{include file="field_checkbox.tpl" field=$update_content}}
 						{{include file="field_checkbox.tpl" field=$infinite_scroll}}
 						{{include file="field_checkbox.tpl" field=$enable_smart_threading}}
-						{{include file="field_checkbox.tpl" field=$enable_dislike}}
-						{{include file="field_checkbox.tpl" field=$display_resharer}}
+					{{include file="field_checkbox.tpl" field=$enable_dislike}}
+					{{include file="field_checkbox.tpl" field=$exclusive_like_dislike}}
+					{{include file="field_checkbox.tpl" field=$display_resharer}}
 						{{include file="field_checkbox.tpl" field=$stay_local}}
 						{{include file="field_checkbox.tpl" field=$show_page_drop}}
 						{{include file="field_checkbox.tpl" field=$display_eventlist}}


### PR DESCRIPTION
Currently you can both like and dislike the same post or comment. This PR fixes that - clicking like removes any existing dislike and vice versa, similar to how event attendance already works (yes/no/maybe).

- When creating a like/dislike, the opposite reaction is automatically removed
- Button states update immediately when switching 
- Added duplicate-click protection

Counters and reaction lists update through the normal item refresh. Tested with Frio and Vier theme - both work correctly. Frio just has optimistic UI updates for instant visual feedback.

closes #14901 