### PR TITLE
Always show all personal notifications, remove related link to toggle

### DIFF
--- a/src/Module/BaseNotifications.php
+++ b/src/Module/BaseNotifications.php
@@ -155,7 +155,7 @@ abstract class BaseNotifications extends BaseModule
 		foreach (self::URL_TYPES as $type => $url) {
 			$tabs[] = [
 				'label'     => $this->t(self::PRINT_TYPES[$type]),
-				'url'       => 'notifications/' . $url,
+				'url'       => 'notifications/' . $url . (($url == "personal") ? "?show=all" : ""),
 				'sel'       => (($selected == $url) ? 'active' : ''),
 				'id'        => $type . '-tab',
 				'accesskey' => self::ACCESS_KEYS[$type],

--- a/src/Module/Notifications/Notifications.php
+++ b/src/Module/Notifications/Notifications.php
@@ -44,32 +44,32 @@ class Notifications extends BaseNotifications
 	public function getNotifications()
 	{
 		$notificationHeader = '';
-		$notifications = [];
+		$notifications      = [];
 
 		$factory = $this->formattedNotifyFactory;
 
 		if (($this->args->get(1) == 'network')) {
 			$notificationHeader = $this->t('Network Notifications');
 			$notifications      = [
-				'ident'        => FormattedNotify::NETWORK,
+				'ident'         => FormattedNotify::NETWORK,
 				'notifications' => $factory->getNetworkList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
 		} elseif (($this->args->get(1) == 'system')) {
 			$notificationHeader = $this->t('System Notifications');
 			$notifications      = [
-				'ident'        => FormattedNotify::SYSTEM,
+				'ident'         => FormattedNotify::SYSTEM,
 				'notifications' => $factory->getSystemList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
 		} elseif (($this->args->get(1) == 'personal')) {
 			$notificationHeader = $this->t('Personal Notifications');
 			$notifications      = [
-				'ident'        => FormattedNotify::PERSONAL,
-				'notifications' => $factory->getPersonalList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
+				'ident'         => FormattedNotify::PERSONAL,
+				'notifications' => $factory->getPersonalList(true, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
 		} elseif (($this->args->get(1) == 'home')) {
 			$notificationHeader = $this->t('Home Notifications');
 			$notifications      = [
-				'ident'        => FormattedNotify::HOME,
+				'ident'         => FormattedNotify::HOME,
 				'notifications' => $factory->getHomeList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
 		} else {
@@ -97,7 +97,7 @@ class Notifications extends BaseNotifications
 
 		$notificationResult = $this->getNotifications();
 		$notifications      = $notificationResult['notifications'] ?? [];
-		$notificationHeader = $notificationResult['header'] ?? '';
+		$notificationHeader = $notificationResult['header']        ?? '';
 
 		if (!empty($notifications['notifications'])) {
 			$notificationTemplates = [
@@ -127,10 +127,13 @@ class Notifications extends BaseNotifications
 			$notificationNoContent = $this->t('No more %s notifications.', $notificationResult['ident']);
 		}
 
-		$notificationShowLink = [
-			'href' => ($this->showAll ? 'notifications/' . $notifications['ident'] : 'notifications/' . $notifications['ident'] . '?show=all'),
-			'text' => ($this->showAll ? $this->t('Show unread') : $this->t('Show all')),
-		];
+		$notificationShowLink = [];
+		if ($notifications['ident'] != "personal") {
+			$notificationShowLink = [
+				'href' => ($this->showAll ? 'notifications/' . $notifications['ident'] : 'notifications/' . $notifications['ident'] . '?show=all'),
+				'text' => ($this->showAll ? $this->t('Show unread') : $this->t('Show all')),
+			];
+		}
 
 		return $this->printContent($notificationHeader, $notificationContent, $notificationNoContent, $notificationShowLink);
 	}

--- a/src/Module/Notifications/Notifications.php
+++ b/src/Module/Notifications/Notifications.php
@@ -64,7 +64,7 @@ class Notifications extends BaseNotifications
 			$notificationHeader = $this->t('Personal Notifications');
 			$notifications      = [
 				'ident'         => FormattedNotify::PERSONAL,
-				'notifications' => $factory->getPersonalList(true, $this->firstItemNum, self::ITEMS_PER_PAGE),
+				'notifications' => $factory->getPersonalList($this->showAll, $this->firstItemNum, self::ITEMS_PER_PAGE),
 			];
 		} elseif (($this->args->get(1) == 'home')) {
 			$notificationHeader = $this->t('Home Notifications');


### PR DESCRIPTION
Closes #15439

Alternatively one could generally ignore `show_all` for personal notifications, instead of changing the URL to it.
Then it would automatically work for all links to it. Is that better or worse?

# Before

<img width="436" height="162" alt="image" src="https://github.com/user-attachments/assets/ad56b387-5e86-4485-a242-908b4d099289" />

# After

<img width="462" height="272" alt="image" src="https://github.com/user-attachments/assets/43c3d4bb-5962-46c1-9b73-6003a4ef0063" />