### PR TITLE
Issue 15392: Support for quotes in the api

### DIFF
--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -382,7 +382,13 @@ class Status extends BaseFactory
 
 		if (!empty($quote_id) && ($quote_id != $item['uri-id'])) {
 			try {
-				$quote = $this->createFromUriId($quote_id, $uid, false, false, false)->toArray();
+				$quoted_status = $this->createFromUriId($quote_id, $uid, false, false, false)->toArray();
+				$quote         = [
+					'state'         => 'accepted',
+					'quoted_status' => $quoted_status,
+					'account'       => $quoted_status['account'],
+				];
+				$quote = array_merge($quote, $quoted_status);
 			} catch (\Exception $exception) {
 				DI::logger()->info('Quote not fetchable', ['uri-id' => $item['uri-id'], 'uid' => $uid, 'exception' => $exception]);
 				$quote = [];

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -363,8 +363,9 @@ class BaseApi extends BaseModule
 	 */
 	public static function appSupportsQuotes(): bool
 	{
-		$token = OAuth::getCurrentApplicationToken();
-		return (!empty($token['name']) && in_array($token['name'], ['Fedilab']));
+		// $token = OAuth::getCurrentApplicationToken();
+		// return (!empty($token['name']) && in_array($token['name'], ['Fedilab']));
+		return true;
 	}
 
 	/**

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -363,8 +363,7 @@ class BaseApi extends BaseModule
 	 */
 	public static function appSupportsQuotes(): bool
 	{
-		// $token = OAuth::getCurrentApplicationToken();
-		// return (!empty($token['name']) && in_array($token['name'], ['Fedilab']));
+		// @todo Clean up the whole functionality since it isn't of any use anymore.
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #15392

With this we will now support both the Mastodon client and Fedilab with displaying quoted posts. Also we will now always assume that clients support quotes.