### PR TITLE
Fix duplicate key error in fetched-activity table

### DIFF
--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -14,6 +14,7 @@ use Friendica\Core\Cache\Enum\Duration;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Core\Worker;
+use Friendica\Database\Database;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\APContact;
@@ -61,7 +62,7 @@ class Processor
 	private static function addActivityId(string $id)
 	{
 		DBA::delete('fetched-activity', ["`received` < ?", DateTimeFormat::utc('now - 5 minutes')]);
-		DBA::insert('fetched-activity', ['object-id' => $id, 'received' => DateTimeFormat::utcNow()]);
+		DBA::insert('fetched-activity', ['object-id' => $id, 'received' => DateTimeFormat::utcNow()], Database::INSERT_IGNORE);
 	}
 
 	/**


### PR DESCRIPTION
Fixes DB error 1062 when multiple workers simultaneously fetch the same activity.

This typically happens when an old post gets new replies or likes - multiple workers try to fetch the same parent post and replies at the same time, causing duplicate insert attempts.

Uses INSERT IGNORE to handle this instead of throwing an error.

<img width="334" height="992" alt="image" src="https://github.com/user-attachments/assets/3e50ae03-83ce-4d44-a7af-3f2286d023b9" />

<img width="1225" height="562" alt="image" src="https://github.com/user-attachments/assets/c34d02f4-bc87-49f8-ab41-9281b18f6dc8" />

