### PR TITLE
Check to store the user defined channel cache for all posts

### DIFF
--- a/src/Content/Conversation/Entity/UserDefinedChannel.php
+++ b/src/Content/Conversation/Entity/UserDefinedChannel.php
@@ -9,4 +9,10 @@ namespace Friendica\Content\Conversation\Entity;
 
 class UserDefinedChannel extends Channel
 {
+	const CIRCLE_GLOBAL    = 0;
+	const CIRCLE_ACTIVITY  = -5;
+	const CIRCLE_POSTS     = -4;
+	const CIRCLE_CREATION  = -3;
+	const CIRCLE_FOLLOWING = -1;
+	const CIRCLE_FOLLOWERS = -2;
 }

--- a/src/Content/Conversation/Factory/ChannelPost.php
+++ b/src/Content/Conversation/Factory/ChannelPost.php
@@ -9,11 +9,13 @@ declare(strict_types=1);
 
 namespace Friendica\Content\Conversation\Factory;
 
+use Friendica\Content\Conversation\Entity\UserDefinedChannel as UserDefinedChannelEntity;
 use Friendica\Content\Conversation\Repository\UserDefinedChannel;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Database\Database;
 use Friendica\Model\Contact;
+use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Psr\Log\LoggerInterface;
@@ -56,11 +58,12 @@ final class ChannelPost
 	 * system's channel caching is enabled and matching channels are found.
 	 *
 	 * @param array $engagement post-engagement record
+	 * @param int $gravity Gravity of the post
 	 * @param int $uid User id context.
 	 * @param int $reshare_id Optional reshare id.
 	 * @return void
 	 */
-	public function add(array $engagement, int $uid, int $reshare_id = 0): void
+	public function add(array $engagement, int $gravity, int $uid, int $reshare_id = 0): void
 	{
 		if (!$this->config->get('system', 'channel_cache')) {
 			return;
@@ -80,8 +83,9 @@ final class ChannelPost
 
 		$language = $engagement['language'] !== L10n::UNDETERMINED_LANGUAGE ? $engagement['language'] : '';
 		$tags     = array_column(Tag::getByURIId($engagement['uri-id'], [Tag::HASHTAG]), 'name');
+		$circles  = ($gravity != Item::GRAVITY_PARENT) ? [UserDefinedChannelEntity::CIRCLE_CREATION, UserDefinedChannelEntity::CIRCLE_POSTS, UserDefinedChannelEntity::CIRCLE_ACTIVITY] : [];
 
-		$channels = $this->channelRepository->getMatchingChannels($engagement['searchtext'], $language, $tags, $engagement['media-type'], $engagement['owner-id'], $reshare_id, $uids);
+		$channels = $this->channelRepository->getMatchingChannels($engagement['searchtext'], $language, $tags, $engagement['media-type'], $engagement['owner-id'], $reshare_id, $uids, $circles);
 		if (!($channels instanceof \Friendica\Content\Conversation\Collection\UserDefinedChannels) || $channels->count() === 0) {
 			$this->logger->debug('No channels found', ['uri-id' => $engagement['uri-id'], 'uids' => $uids, 'reshare_id' => $reshare_id]);
 			return;

--- a/src/Content/Conversation/Repository/UserDefinedChannel.php
+++ b/src/Content/Conversation/Repository/UserDefinedChannel.php
@@ -316,9 +316,10 @@ class UserDefinedChannel extends BaseRepository
 	 * @param int    $owner_id Owner contact id.
 	 * @param int    $reshare_id Reshare contact id.
 	 * @param array  $uids User IDs to filter channels.
+	 * @param array  $circles circle IDs to filter channels.
 	 * @return UserDefinedChannels|null Collection of matching channels or null.
 	 */
-	public function getMatchingChannels(string $searchtext, string $language, array $tags, int $media_type, int $owner_id, int $reshare_id, array $uids): ?UserDefinedChannels
+	public function getMatchingChannels(string $searchtext, string $language, array $tags, int $media_type, int $owner_id, int $reshare_id, array $uids, array $circles): ?UserDefinedChannels
 	{
 		if (!in_array($language, User::getLanguages())) {
 			$this->logger->debug('Unwanted language found. No matched channel found.', ['language' => $language, 'searchtext' => $searchtext]);
@@ -327,7 +328,12 @@ class UserDefinedChannel extends BaseRepository
 
 		$disposableFullTextSearch = new DisposableFullTextSearch($this->db, $searchtext);
 
-		$filteredChannels = $this->select(['uid' => $uids, 'valid' => true])->filter(
+		$condition = ['uid' => $uids, 'valid' => true];
+		if ($circles) {
+			$condition = DBA::mergeConditions($condition, ['circle' => $circles]);
+		}
+
+		$filteredChannels = $this->select($condition)->filter(
 			function (UserDefinedChannelEntity $channel) use ($owner_id, $reshare_id, $language, $tags, $media_type, $disposableFullTextSearch, $searchtext) {
 				if (
 					($channel->circle > 0)

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1196,13 +1196,13 @@ class Item
 		DI::logger()->debug('Post accepted for channels', ['uri-id' => $uri_id, 'uid' => $uid, 'network' => $item['network']]);
 
 		if (($item['gravity'] === self::GRAVITY_ACTIVITY) && ($item['verb'] === Activity::ANNOUNCE) && ($item['parent-uri-id'] === $item['thr-parent-id'])) {
-			DI::ChannelPost()->add($engagement, $uid, $item['author-id']);
+			DI::ChannelPost()->add($engagement, self::GRAVITY_PARENT, $uid, $item['author-id']);
 			DI::SystemChannelPost()->add($engagement, self::GRAVITY_PARENT, $uid, $item['network'], $item['author-id']);
 		} else {
 			if ($item['origin']) {
-				DI::ChannelPost()->add($engagement, $uid, $item['author-id']);
-			} elseif ($item['gravity'] === self::GRAVITY_PARENT) {
-				DI::ChannelPost()->add($engagement, $uid);
+				DI::ChannelPost()->add($engagement, $item['gravity'], $uid, $item['author-id']);
+			} else {
+				DI::ChannelPost()->add($engagement, $item['gravity'], $uid);
 			}
 			DI::SystemChannelPost()->add($engagement, $item['gravity'], $uid, $item['network']);
 		}


### PR DESCRIPTION
This PR introduces new constants for the circles that can be used in the channel definition. They are by now only used at one place but will be extended to other places in upcoming pull requests.

Also this PR now adds a check for the user channel cache not only for starting posts but for every action on a post. This hadn't been done in the RC, since the performance impact was unknown.