### PR TITLE
Quote check is removed

### DIFF
--- a/src/Factory/Api/Mastodon/Notification.php
+++ b/src/Factory/Api/Mastodon/Notification.php
@@ -33,12 +33,11 @@ class Notification extends BaseFactory
 
 	/**
 	 * @param NotificationEntity $Notification
-	 * @param bool $display_quotes Display quoted posts
 	 *
 	 * @return MstdnNotification
 	 * @throws UnexpectedNotificationTypeException
 	 */
-	public function createFromNotification(NotificationEntity $Notification, bool $display_quotes): MstdnNotification
+	public function createFromNotification(NotificationEntity $Notification): MstdnNotification
 	{
 		$type = self::getType($Notification);
 
@@ -50,7 +49,7 @@ class Notification extends BaseFactory
 
 		if ($Notification->targetUriId) {
 			try {
-				$status = $this->mstdnStatusFactory->createFromUriId($Notification->targetUriId, $Notification->uid, $display_quotes);
+				$status = $this->mstdnStatusFactory->createFromUriId($Notification->targetUriId, $Notification->uid);
 			} catch (\Exception $exception) {
 				$status = null;
 			}

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -87,7 +87,6 @@ class Status extends BaseFactory
 	/**
 	 * @param int  $uriId           Uri-ID of the item
 	 * @param int  $uid             Item user
-	 * @param bool $display_quote   Display quoted posts
 	 * @param bool $reblog          Check for reblogged post
 	 * @param bool $in_reply_status Add an "in_reply_status" element
 	 *
@@ -95,7 +94,7 @@ class Status extends BaseFactory
 	 * @throws InternalServerErrorException
 	 * @throws ImagickException|NotFoundException
 	 */
-	public function createFromUriId(int $uriId, int $uid = 0, bool $display_quote = false, bool $reblog = true, bool $in_reply_status = true): \Friendica\Object\Api\Mastodon\Status
+	public function createFromUriId(int $uriId, int $uid = 0, bool $reblog = true, bool $in_reply_status = true): \Friendica\Object\Api\Mastodon\Status
 	{
 		$fields = ['uri-id', 'uid', 'author-id', 'causer-id', 'author-uri-id', 'author-link', 'author-gsid', 'causer-uri-id', 'post-reason', 'starred', 'app', 'title', 'body', 'raw-body', 'content-warning', 'question-id',
 			'created', 'edited', 'commented', 'received', 'changed', 'network', 'thr-parent-id', 'parent-author-id', 'language', 'uri', 'plink', 'private', 'vid', 'gravity', 'featured', 'has-media', 'quote-uri-id',
@@ -261,56 +260,12 @@ class Status extends BaseFactory
 			$poll = null;
 		}
 
-		if ($display_quote) {
-			$quote = self::createQuote($item, $uid);
+		$quote = self::createQuote($item, $uid);
 
-			$item['body'] = BBCode::removeSharedData($item['body']);
+		$item['body'] = BBCode::removeSharedData($item['body']);
 
-			if (!is_null($item['raw-body'])) {
-				$item['raw-body'] = BBCode::removeSharedData($item['raw-body']);
-			}
-		} else {
-			// We can always safely add attached activities. Real quotes are added to the body via "addSharedPost".
-			if (empty($item['quote-uri-id'])) {
-				$quote = self::createQuote($item, $uid);
-			} else {
-				$quote = [];
-			}
-
-			$shared = $this->contentItem->getSharedPost($item, ['uri-id']);
-			if (!empty($shared)) {
-				$shared_uri_id = $shared['post']['uri-id'];
-
-				foreach ($this->mstdnMentionFactory->createFromUriId($shared_uri_id)->getArrayCopy() as $mention) {
-					if (!in_array($mention, $mentions)) {
-						$mentions[] = $mention;
-					}
-				}
-
-				foreach ($this->mstdnTagFactory->createFromUriId($shared_uri_id) as $tag) {
-					if (!in_array($tag, $tags)) {
-						$tags[] = $tag;
-					}
-				}
-
-				foreach ($this->mstdnAttachmentFactory->createFromUriId($shared_uri_id) as $attachment) {
-					if (!in_array($attachment, $attachments)) {
-						$attachments[] = $attachment;
-					}
-				}
-
-				if (empty($card->toArray())) {
-					$card = $this->mstdnCardFactory->createFromUriId($shared_uri_id);
-				}
-			}
-
-			if (!is_null($item['raw-body'])) {
-				$item['raw-body'] = $this->contentItem->addSharedPost($item, $item['raw-body']);
-				$item['raw-body'] = Post\Media::addHTMLLinkToBody($uriId, $item['raw-body']);
-			} else {
-				$item['body'] = $this->contentItem->addSharedPost($item);
-				$item['body'] = Post\Media::addHTMLLinkToBody($uriId, $item['body']);
-			}
+		if (!is_null($item['raw-body'])) {
+			$item['raw-body'] = BBCode::removeSharedData($item['raw-body']);
 		}
 
 		$emojis = null;
@@ -330,7 +285,7 @@ class Status extends BaseFactory
 
 		if ($is_reshare) {
 			try {
-				$reshare = $this->createFromUriId($uriId, $uid, $display_quote, false, false)->toArray();
+				$reshare = $this->createFromUriId($uriId, $uid, false, false)->toArray();
 			} catch (\Exception $exception) {
 				DI::logger()->info('Reshare not fetchable', ['uri-id' => $item['uri-id'], 'uid' => $uid, 'exception' => $exception]);
 				$reshare = [];
@@ -341,7 +296,7 @@ class Status extends BaseFactory
 
 		if ($in_reply_status && ($item['gravity'] == Item::GRAVITY_COMMENT)) {
 			try {
-				$in_reply = $this->createFromUriId($item['thr-parent-id'], $uid, $display_quote, false, false)->toArray();
+				$in_reply = $this->createFromUriId($item['thr-parent-id'], $uid, false, false)->toArray();
 			} catch (\Exception $exception) {
 				DI::logger()->info('Reply post not fetchable', ['uri-id' => $item['uri-id'], 'uid' => $uid, 'exception' => $exception]);
 				$in_reply = [];
@@ -382,7 +337,7 @@ class Status extends BaseFactory
 
 		if (!empty($quote_id) && ($quote_id != $item['uri-id'])) {
 			try {
-				$quoted_status = $this->createFromUriId($quote_id, $uid, false, false, false)->toArray();
+				$quoted_status = $this->createFromUriId($quote_id, $uid, false, false)->toArray();
 				$quote         = [
 					'state'         => 'accepted',
 					'quoted_status' => $quoted_status,

--- a/src/Module/Api/Friendica/Statuses/Dislike.php
+++ b/src/Module/Api/Friendica/Statuses/Dislike.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Module\Api\Friendica\Statuses;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
@@ -35,6 +34,6 @@ class Dislike extends BaseApi
 
 		Item::performActivity($item['id'], 'dislike', $uid);
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Friendica/Statuses/Undislike.php
+++ b/src/Module/Api/Friendica/Statuses/Undislike.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Module\Api\Friendica\Statuses;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
@@ -35,6 +34,6 @@ class Undislike extends BaseApi
 
 		Item::performActivity($item['id'], 'undislike', $uid);
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes())->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Statuses.php
+++ b/src/Module/Api/Mastodon/Accounts/Statuses.php
@@ -93,12 +93,10 @@ class Statuses extends BaseApi
 			$items = Post::selectTimelineForUser($uid, ['uri-id'], $condition, $params);
 		}
 
-		$display_quotes = self::appSupportsQuotes();
-
 		$statuses = [];
 		while ($item = Post::fetch($items)) {
 			try {
-				$status = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, $display_quotes);
+				$status = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid);
 				$this->updateBoundaries($status, $item, $request['friendica_order']);
 				$statuses[] = $status;
 			} catch (\Throwable $th) {

--- a/src/Module/Api/Mastodon/Bookmarks.php
+++ b/src/Module/Api/Mastodon/Bookmarks.php
@@ -54,13 +54,11 @@ class Bookmarks extends BaseApi
 
 		$items = Post::selectThreadForUser($uid, ['uri-id'], $condition, $params);
 
-		$display_quotes = self::appSupportsQuotes();
-
 		$statuses = [];
 		while ($item = Post::fetch($items)) {
 			self::setBoundaries($item['uri-id']);
 			try {
-				$statuses[] = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, $display_quotes);
+				$statuses[] = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid);
 			} catch (\Exception $exception) {
 				$this->logger->info('Post not fetchable', ['uri-id' => $item['uri-id'], 'uid' => $uid, 'exception' => $exception]);
 			}

--- a/src/Module/Api/Mastodon/Favourited.php
+++ b/src/Module/Api/Mastodon/Favourited.php
@@ -56,13 +56,11 @@ class Favourited extends BaseApi
 
 		$items = Post::selectForUser($uid, ['thr-parent-id'], $condition, $params);
 
-		$display_quotes = self::appSupportsQuotes();
-
 		$statuses = [];
 		while ($item = Post::fetch($items)) {
 			self::setBoundaries($item['thr-parent-id']);
 			try {
-				$statuses[] = DI::mstdnStatus()->createFromUriId($item['thr-parent-id'], $uid, $display_quotes);
+				$statuses[] = DI::mstdnStatus()->createFromUriId($item['thr-parent-id'], $uid);
 			} catch (\Exception $exception) {
 				$this->logger->info('Post not fetchable', ['uri-id' => $item['thr-parent-id'], 'uid' => $uid, 'exception' => $exception]);
 			}

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Module\Api\Mastodon;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
@@ -34,7 +33,7 @@ class Notifications extends BaseApi
 			$id = $this->parameters['id'];
 			try {
 				$notification = DI::notification()->selectOneForUser($uid, ['id' => $id]);
-				$this->jsonExit(DI::mstdnNotification()->createFromNotification($notification, self::appSupportsQuotes()));
+				$this->jsonExit(DI::mstdnNotification()->createFromNotification($notification));
 			} catch (\Exception $e) {
 				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
@@ -132,7 +131,7 @@ class Notifications extends BaseApi
 
 			foreach ($Notifications as $Notification) {
 				try {
-					$mstdnNotifications[] = DI::mstdnNotification()->createFromNotification($Notification, self::appSupportsQuotes());
+					$mstdnNotifications[] = DI::mstdnNotification()->createFromNotification($Notification);
 					self::setBoundaries($Notification->id);
 				} catch (\Exception $e) {
 					// Skip this notification

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -102,7 +102,7 @@ class Search extends BaseApi
 			// If the user-specific search failed, we search and probe a public post
 			$item_id = Item::fetchByLink($q, $uid) ?: Item::fetchByLink($q);
 			if ($item_id && $item = Post::selectFirst(['uri-id'], ['id' => $item_id])) {
-				$result['statuses'] = [DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, self::appSupportsQuotes())];
+				$result['statuses'] = [DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid)];
 				$this->jsonExit($result);
 			}
 		}
@@ -190,13 +190,11 @@ class Search extends BaseApi
 
 		$items = DBA::select($table, ['uri-id'], $condition, $params);
 
-		$display_quotes = self::appSupportsQuotes();
-
 		$statuses = [];
 		while ($item = Post::fetch($items)) {
 			self::setBoundaries($item['uri-id']);
 			try {
-				$statuses[] = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, $display_quotes);
+				$statuses[] = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid);
 			} catch (\Exception $exception) {
 				$this->logger->info('Post not fetchable', ['uri-id' => $item['uri-id'], 'uid' => $uid, 'exception' => $exception]);
 			}

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -183,7 +183,7 @@ class Statuses extends BaseApi
 
 		Item::updateDisplayCache($post['uri-id']);
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($post['uri-id'], $uid, self::appSupportsQuotes()));
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($post['uri-id'], $uid));
 	}
 
 	protected function post(array $request = [])
@@ -345,7 +345,7 @@ class Statuses extends BaseApi
 		if (!empty($id)) {
 			$item = Post::selectFirst(['uri-id'], ['id' => $id]);
 			if (!empty($item['uri-id'])) {
-				$this->jsonExit(DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, self::appSupportsQuotes()));
+				$this->jsonExit(DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid));
 			}
 		}
 
@@ -396,7 +396,7 @@ class Statuses extends BaseApi
 			}
 		}
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), false));
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, false));
 	}
 
 	private function getApp(): string

--- a/src/Module/Api/Mastodon/Statuses/Bookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Bookmark.php
@@ -55,6 +55,6 @@ class Bookmark extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Module\Api\Mastodon\Statuses;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
@@ -46,7 +45,7 @@ class Context extends BaseApi
 
 		$parent = Post::selectOriginal(['uri-id', 'parent-uri-id'], ['uri-id' => $id]);
 		if (DBA::isResult($parent)) {
-			$id = $parent['uri-id'];
+			$id        = $parent['uri-id'];
 			$params    = ['order' => ['uri-id' => true]];
 			$condition = ['parent-uri-id' => $parent['parent-uri-id'], 'gravity' => [Item::GRAVITY_PARENT, Item::GRAVITY_COMMENT]];
 
@@ -59,7 +58,7 @@ class Context extends BaseApi
 			}
 
 			if (!empty($request['min_id'])) {
-				$condition = DBA::mergeConditions($condition, ["`uri-id` > ?", $request['min_id']]);
+				$condition       = DBA::mergeConditions($condition, ["`uri-id` > ?", $request['min_id']]);
 				$params['order'] = ['uri-id'];
 			}
 
@@ -112,11 +111,9 @@ class Context extends BaseApi
 
 		asort($ancestors);
 
-		$display_quotes = self::appSupportsQuotes();
-
 		foreach (array_slice($ancestors, 0, $request['limit']) as $ancestor) {
 			try {
-				$statuses['ancestors'][] = DI::mstdnStatus()->createFromUriId($ancestor, $uid, $display_quotes);
+				$statuses['ancestors'][] = DI::mstdnStatus()->createFromUriId($ancestor, $uid);
 			} catch (\Throwable $th) {
 				$this->logger->info('Post not fetchable', ['uri-id' => $ancestor, 'uid' => $uid, 'error' => $th]);
 			}
@@ -128,7 +125,7 @@ class Context extends BaseApi
 
 		foreach (array_slice($descendants, 0, $request['limit']) as $descendant) {
 			try {
-				$statuses['descendants'][] = DI::mstdnStatus()->createFromUriId($descendant, $uid, $display_quotes);
+				$statuses['descendants'][] = DI::mstdnStatus()->createFromUriId($descendant, $uid);
 			} catch (\Throwable $th) {
 				$this->logger->info('Post not fetchable', ['uri-id' => $descendant, 'uid' => $uid, 'error' => $th]);
 			}

--- a/src/Module/Api/Mastodon/Statuses/Favourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Favourite.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Module\Api\Mastodon\Statuses;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
@@ -40,6 +39,6 @@ class Favourite extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Mute.php
+++ b/src/Module/Api/Mastodon/Statuses/Mute.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Module\Api\Mastodon\Statuses;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
@@ -44,6 +43,6 @@ class Mute extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Module\Api\Mastodon\Statuses;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
@@ -39,6 +38,6 @@ class Pin extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(),$isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Reblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Reblog.php
@@ -9,7 +9,6 @@ namespace Friendica\Module\Api\Mastodon\Statuses;
 
 use Friendica\Content\ContactSelector;
 use Friendica\Core\Protocol;
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
@@ -52,6 +51,6 @@ class Reblog extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unbookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Unbookmark.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Module\Api\Mastodon\Statuses;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
@@ -56,6 +55,6 @@ class Unbookmark extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unfavourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Unfavourite.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Module\Api\Mastodon\Statuses;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
@@ -40,6 +39,6 @@ class Unfavourite extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unmute.php
+++ b/src/Module/Api/Mastodon/Statuses/Unmute.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Module\Api\Mastodon\Statuses;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
@@ -44,6 +43,6 @@ class Unmute extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Module\Api\Mastodon\Statuses;
 
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
@@ -39,6 +38,6 @@ class Unpin extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unreblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Unreblog.php
@@ -9,7 +9,6 @@ namespace Friendica\Module\Api\Mastodon\Statuses;
 
 use Friendica\Content\ContactSelector;
 use Friendica\Core\Protocol;
-use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Item;
@@ -58,6 +57,6 @@ class Unreblog extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, self::appSupportsQuotes(), $isReblog)->toArray());
+		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/Home.php
+++ b/src/Module/Api/Mastodon/Timelines/Home.php
@@ -69,12 +69,10 @@ class Home extends BaseApi
 
 		$items = Post::selectTimelineForUser($uid, ['uri-id'], $condition, $params);
 
-		$display_quotes = self::appSupportsQuotes();
-
 		$statuses = [];
 		while ($item = Post::fetch($items)) {
 			try {
-				$status = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, $display_quotes);
+				$status = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid);
 				$this->updateBoundaries($status, $item, $request['friendica_order']);
 				$statuses[] = $status;
 			} catch (\Throwable $th) {

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -66,8 +66,6 @@ class ListTimeline extends BaseApi
 			'friendica_order' => TimelineOrderByTypes::ID, // Sort order options (defaults to ID)
 		], $request);
 
-		$display_quotes = self::appSupportsQuotes();
-
 		if (substr($this->parameters['id'], 0, 6) == 'group:') {
 			$items = $this->getStatusesForGroup($uid, $request);
 		} elseif (substr($this->parameters['id'], 0, 8) == 'channel:') {
@@ -79,7 +77,7 @@ class ListTimeline extends BaseApi
 		$statuses = [];
 		foreach ($items as $item) {
 			try {
-				$status = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, $display_quotes);
+				$status = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid);
 				$this->updateBoundaries($status, $item, $request['friendica_order']);
 				$statuses[] = $status;
 			} catch (\Throwable $th) {

--- a/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
@@ -103,12 +103,10 @@ class PublicTimeline extends BaseApi
 			$items = Post::selectTimelineForUser($uid, ['uri-id'], $condition, $params);
 		}
 
-		$display_quotes = self::appSupportsQuotes();
-
 		$statuses = [];
 		while ($item = Post::fetch($items)) {
 			try {
-				$status = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, $display_quotes);
+				$status = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid);
 				$this->updateBoundaries($status, $item, $request['friendica_order']);
 				$statuses[] = $status;
 			} catch (\Throwable $th) {

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -97,13 +97,11 @@ class Tag extends BaseApi
 
 		$items = DBA::select('tag-search-view', ['uri-id'], $condition, $params);
 
-		$display_quotes = self::appSupportsQuotes();
-
 		$statuses = [];
 		while ($item = Post::fetch($items)) {
 			self::setBoundaries($item['uri-id']);
 			try {
-				$statuses[] = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid, $display_quotes);
+				$statuses[] = DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid);
 			} catch (\Exception $exception) {
 				$this->logger->info('Post not fetchable', ['uri-id' => $item['uri-id'], 'uid' => $uid, 'exception' => $exception]);
 			}

--- a/src/Module/Api/Mastodon/Trends/Statuses.php
+++ b/src/Module/Api/Mastodon/Trends/Statuses.php
@@ -58,13 +58,11 @@ class Statuses extends BaseApi
 		$condition = ["NOT `private` AND `commented` > ? AND `created` > ?", DateTimeFormat::utc('now -1 day'), DateTimeFormat::utc('now -1 week')];
 		$condition = DBA::mergeConditions($condition, ['network' => Protocol::FEDERATED]);
 
-		$display_quotes = self::appSupportsQuotes();
-
 		$trending = [];
 		$statuses = Post::selectPostThread(['uri-id'], $condition, ['limit' => [$request['offset'], $request['limit']],  'order' => ['total-actors' => true]]);
 		while ($status = Post::fetch($statuses)) {
 			try {
-				$trending[] = DI::mstdnStatus()->createFromUriId($status['uri-id'], $uid, $display_quotes);
+				$trending[] = DI::mstdnStatus()->createFromUriId($status['uri-id'], $uid);
 			} catch (\Exception $exception) {
 				$this->logger->info('Post not fetchable', ['uri-id' => $status['uri-id'], 'uid' => $uid, 'exception' => $exception]);
 			}

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -357,17 +357,6 @@ class BaseApi extends BaseModule
 	}
 
 	/**
-	 * Check if the app is known to support quoted posts
-	 *
-	 * @return bool
-	 */
-	public static function appSupportsQuotes(): bool
-	{
-		// @todo Clean up the whole functionality since it isn't of any use anymore.
-		return true;
-	}
-
-	/**
 	 * Get current application token
 	 *
 	 * @return array token


### PR DESCRIPTION
In one of the last PRs before the release we removed the check for the API client that was used to check whether we can display quotes. This is now cleaned up.