### PR TITLE
Make link from contacts to global directory pass on user language

### DIFF
--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -48,6 +48,12 @@ class Widget
 	 */
 	public static function findPeople(): string
 	{
+		// Langs in friendica are all lowercase and dash separated (e.g. da-dk) - in the directory
+		// they're underscore separated, with the latter part being uppercase (e.g. da_DK)
+		$directory_user_lang_string = "";
+		if (DI::userSession()->get('language')) {
+			$directory_user_lang_string = "&lang=" . DI::l10n()->langToLocaleCode(DI::userSession()->get('language'));
+		}
 		$global_dir = Search::getGlobalDirectory();
 
 		if (DI::config()->get('system', 'invitation_only')) {
@@ -70,7 +76,7 @@ class Widget
 		$nv['random']          = DI::l10n()->t('Random Profile');
 		$nv['inv']             = DI::l10n()->t('Invite Friends');
 		$nv['directory']       = DI::l10n()->t('Global Directory');
-		$nv['global_dir']      = OpenWebAuth::getZrlUrl($global_dir, true);
+		$nv['global_dir']      = OpenWebAuth::getZrlUrl($global_dir, true) . $directory_user_lang_string;
 		$nv['local_directory'] = DI::l10n()->t('Local Directory');
 
 		$aside        = [];
@@ -611,9 +617,9 @@ class Widget
 		$widget_timelineorder = json_decode(DI::pConfig()->get($uid, 'system', 'widget_timeline_order'));
 		if (!empty($widget_timelineorder)) {
 			$tmp = [];
-			foreach($widget_timelineorder as $order) {
-				foreach($channels as $channel) {
-					if($channel['ref'] == $order) {
+			foreach ($widget_timelineorder as $order) {
+				foreach ($channels as $channel) {
+					if ($channel['ref'] == $order) {
 						$tmp[] = $channel;
 					}
 				}

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -470,6 +470,17 @@ class L10n
 	}
 
 	/**
+	 * Converts e.g. en-gb to en_GB and da-dk to da_DK, which is the format some other systems expect
+	 *
+	 * @param string $lang
+	 * @return string
+	 * */
+	public function langToLocaleCode($lang)
+	{
+		return preg_replace_callback("/([a-z]+)-([a-z]+)/", fn ($m) => $m[1] . "_" . strtoupper($m[2]), $lang);
+	}
+
+	/**
 	 * Convert the language code to ISO639-1
 	 * It also converts old codes to their new counterparts.
 	 *


### PR DESCRIPTION
The default target branch should probably be changed back to `develop`?

The Friendica directory is translated into different languages, but it seems it does not auto-detect the browser language like Friendica does?? Instead one can change the language through a menu, or pass a GET parameter with a specific language.
The format is a bit different than in Friendica,, though, as languages are written in what I'm used to as the locale format.

Instead of being e.g. da-dk and en-gb like in Friendica, it's da_DK and en_GB.

This PR attempts to fetch the current user language and adds a function to L10n that converts between Friendicas format and that format, and then it includes it in the link to the directory from the Contacts page:
<img width="496" height="383" alt="image" src="https://github.com/user-attachments/assets/d0afc04f-49ee-42f0-b91b-ae83a86db44a" />

Specifically the URL to the directory is changed from e.g.:
`https://dir.friendica.social/?zrl=<somebackurl>`
...to:
`https://dir.friendica.social/?zrl=<somebackurl>&lang=en_UK`

It would probably be better to make the directory auto-detect the language, for when people visit it directly, but I imagine that's more work?

If it's decided to go that route instead, maybe the conversion function could be added anyway as it could perhaps be useful in other cases where Friendica communicates with or links to other systems?