### PR TITLE
Terminology: Media -> Media posts

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -227,7 +227,7 @@ class Nav
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Conversations'), '', $this->l10n->t('Conversations you started'), 'fa-commenting'];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('Your profile page'), 'fa-user'];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos'), 'fa-picture-o'];
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/media', $this->l10n->t('Media'), '', $this->l10n->t('Your postings with media'), 'fa-edit'];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/media', $this->l10n->t('Media posts'), '', $this->l10n->t('Your postings with media'), 'fa-edit'];
 			$nav['usermenu'][] = ['calendar/', $this->l10n->t('Calendar'), '', $this->l10n->t('Your calendar'), 'fa-calendar'];
 			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Your personal notes'), 'fa-book'];
 

--- a/src/Module/BaseProfile.php
+++ b/src/Module/BaseProfile.php
@@ -55,10 +55,10 @@ class BaseProfile extends BaseModule
 				'accesskey' => 'h',
 			],
 			[
-				'label'     => DI::l10n()->t('Media'),
+				'label'     => DI::l10n()->t('Media posts'),
 				'url'       => $baseProfileUrl . '/media',
 				'sel'       => $current == 'media' ? 'active' : '',
-				'title'     => DI::l10n()->t('Media'),
+				'title'     => DI::l10n()->t('Media posts'),
 				'id'        => 'media-tab',
 				'accesskey' => 'd',
 			],

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -510,7 +510,7 @@ class Contact extends BaseModule
 				'accesskey' => 'p',
 			],
 			[
-				'label'     => DI::l10n()->t('Media'),
+				'label'     => DI::l10n()->t('Media posts'),
 				'url'       => 'contact/' . $pcid . '/media',
 				'sel'       => (($active_tab == self::TAB_MEDIA) ? 'active' : ''),
 				'title'     => DI::l10n()->t('Posts containing media objects'),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-06 11:45+0100\n"
+"POT-Creation-Date: 2026-02-08 13:54+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1848,7 +1848,7 @@ msgstr ""
 msgid "Find groups to join"
 msgstr ""
 
-#: src/Content/Item.php:336 src/Model/Item.php:2834
+#: src/Content/Item.php:336 src/Model/Item.php:2841
 msgid "event"
 msgstr ""
 
@@ -1856,7 +1856,7 @@ msgstr ""
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:345 src/Model/Item.php:2836
+#: src/Content/Item.php:345 src/Model/Item.php:2843
 #: src/Module/Post/Tag/Add.php:112
 msgid "photo"
 msgstr ""
@@ -2029,7 +2029,7 @@ msgstr ""
 #: src/Content/Nav.php:230 src/Module/BaseProfile.php:58
 #: src/Module/BaseProfile.php:61 src/Module/Contact.php:513
 #: view/theme/frio/theme.php:223
-msgid "Media"
+msgid "Media posts"
 msgstr ""
 
 #: src/Content/Nav.php:230 view/theme/frio/theme.php:223
@@ -2275,8 +2275,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3724
-#: src/Model/Item.php:3730 src/Model/Item.php:3731
+#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3731
+#: src/Model/Item.php:3737 src/Model/Item.php:3738
 msgid "Link to source"
 msgstr ""
 
@@ -3421,84 +3421,84 @@ msgstr ""
 msgid "Happy Birthday %s"
 msgstr ""
 
-#: src/Model/Item.php:2838
+#: src/Model/Item.php:2845
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2840
+#: src/Model/Item.php:2847
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2843 src/Module/Post/Tag/Add.php:112
+#: src/Model/Item.php:2850 src/Module/Post/Tag/Add.php:112
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3032
+#: src/Model/Item.php:3039
 #, php-format
 msgid "%s is blocked"
 msgstr ""
 
-#: src/Model/Item.php:3034
+#: src/Model/Item.php:3041
 #, php-format
 msgid "%s is ignored"
 msgstr ""
 
-#: src/Model/Item.php:3036
+#: src/Model/Item.php:3043
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:3040
+#: src/Model/Item.php:3047
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3594
+#: src/Model/Item.php:3601
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3628
+#: src/Model/Item.php:3635
 #, php-format
 msgid "The media in this post is not displayed to visitors. To view it, please go to the <a href=\"%s\">original post</a>."
 msgstr ""
 
-#: src/Model/Item.php:3630
+#: src/Model/Item.php:3637
 msgid "The media in this post is not displayed to visitors. To view it, please log in."
 msgstr ""
 
-#: src/Model/Item.php:3655
+#: src/Model/Item.php:3662
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3657
+#: src/Model/Item.php:3664
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3662
+#: src/Model/Item.php:3669
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3664
+#: src/Model/Item.php:3671
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3666
+#: src/Model/Item.php:3673
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3707 src/Model/Item.php:3708
+#: src/Model/Item.php:3714 src/Model/Item.php:3715
 msgid "View on separate page"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgstr ""
 msgid "You can make this page always open when you use the New Post button in the <a href=\"/settings/display\">Theme Customization settings</a>."
 msgstr ""
 
-#: src/Module/Item/Display.php:164
+#: src/Module/Item/Display.php:168
 #, php-format
 msgid "Post by %s"
 msgstr ""

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -220,7 +220,7 @@ function frio_remote_nav(array &$nav_info)
 			// @TODO Switch with the new routes by version 2023.12
 			//$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'] . '/photos', DI::l10n()->t('Photos'), '', DI::l10n()->t('Your photos')];
 			$nav_info['nav']['usermenu'][] = [$server_url . '/photos/' . $remoteUser['nick'], DI::l10n()->t('Photos'), '', DI::l10n()->t('Your photos')];
-			$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'] . '/media', DI::l10n()->t('Media'), '', DI::l10n()->t('Your postings with media')];
+			$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'] . '/media', DI::l10n()->t('Media posts'), '', DI::l10n()->t('Your postings with media')];
 			$nav_info['nav']['usermenu'][] = [$server_url . '/calendar/', DI::l10n()->t('Calendar'), '', DI::l10n()->t('Your calendar')];
 
 			// navbar links


### PR DESCRIPTION
Changes the name of the "Media" section to "Media posts", because that's what it is.

# After

<img width="678" height="191" alt="image" src="https://github.com/user-attachments/assets/9e1d1eca-8fb1-4cd5-8060-8ba18576c596" />