### PR TITLE
Fix event participation responses not delivered to event organizers

### DIFF
--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -766,6 +766,7 @@ class Transmitter
 							if (($profile['type'] == 'Group') && ($profile['url'] != ($actor_profile['url'] ?? ''))) {
 								$data['to'][] = $profile['url'];
 							} else {
+								// Event participation (Accept/Reject/TentativeAccept) must be directly addressed to the event organizer
 								if (in_array($item['verb'] ?? '', [Activity::ATTEND, Activity::ATTENDNO, Activity::ATTENDMAYBE])) {
 									$data['to'][] = $profile['url'];
 								} else {

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -763,7 +763,9 @@ class Transmitter
 							// But comments to groups aren't directed to the followers collection
 							// This rule is only valid when the actor isn't the group.
 							// The group needs to transmit their content to their followers.
-							if (($profile['type'] == 'Group') && ($profile['url'] != ($actor_profile['url'] ?? ''))) {
+							// Event participation (Accept/Reject/TentativeAccept) must be directly addressed to the event organizer
+							$is_event_participation = in_array($item['verb'] ?? '', [Activity::ATTEND, Activity::ATTENDNO, Activity::ATTENDMAYBE]);
+							if (($profile['type'] == 'Group' && $profile['url'] != ($actor_profile['url'] ?? '')) || $is_event_participation) {
 								$data['to'][] = $profile['url'];
 							} else {
 								$data['cc'][] = $profile['url'];

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -763,12 +763,14 @@ class Transmitter
 							// But comments to groups aren't directed to the followers collection
 							// This rule is only valid when the actor isn't the group.
 							// The group needs to transmit their content to their followers.
-							// Event participation (Accept/Reject/TentativeAccept) must be directly addressed to the event organizer
-							$is_event_participation = in_array($item['verb'] ?? '', [Activity::ATTEND, Activity::ATTENDNO, Activity::ATTENDMAYBE]);
-							if (($profile['type'] == 'Group' && $profile['url'] != ($actor_profile['url'] ?? '')) || $is_event_participation) {
+							if (($profile['type'] == 'Group') && ($profile['url'] != ($actor_profile['url'] ?? ''))) {
 								$data['to'][] = $profile['url'];
 							} else {
-								$data['cc'][] = $profile['url'];
+								if (in_array($item['verb'] ?? '', [Activity::ATTEND, Activity::ATTENDNO, Activity::ATTENDMAYBE])) {
+									$data['to'][] = $profile['url'];
+								} else {
+									$data['cc'][] = $profile['url'];
+								}
 								if (($item['private'] != Item::PRIVATE) && !empty($actor_profile['followers']) && (!$exclusive || !$is_group_thread)) {
 									$data['cc'][] = $actor_profile['followers'];
 								}


### PR DESCRIPTION
Event participation responses (Accept/Reject/TentativeAccept) from Friendica users weren't reflected on Mobilizon and Soapbox instances. The ActivityPub activities were sent successfully but not processed by the remote servers.

## Root Cause

Event organizers were added to the 'cc' field instead of 'to' field in the ActivityPub activity addressing. Remote servers require event participation responses to be directly addressed (in 'to') to properly process them.

## Changes

Modified `createPermissionBlockForItem()` in `/src/Protocol/ActivityPub/Transmitter.php` to add event organizers to the 'to' field when the activity is an event participation response:

```php
// Event participation (Accept/Reject/TentativeAccept) must be directly addressed to the event organizer
$is_event_participation = in_array($item['verb'] ?? '', [Activity::ATTEND, Activity::ATTENDNO, Activity::ATTENDMAYBE]);
if (($profile['type'] == 'Group' && $profile['url'] != ($actor_profile['url'] ?? '')) || $is_event_participation) {
    $data['to'][] = $profile['url'];
} else {
    $data['cc'][] = $profile['url'];
    // ...
}
```

The check for event participation verbs is performed inside the loop where parent items are processed, ensuring the organizer's profile URL is added to the primary recipient list.

- Fixes #12840