### PR TITLE
Store "View" activity as "seen" marker

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2026.04-dev (Blutwurz)
--- DB_UPDATE_VERSION 1587
+-- DB_UPDATE_VERSION 1588
 -- ------------------------------------------
 
 
@@ -1353,6 +1353,7 @@ CREATE TABLE IF NOT EXISTS `post-engagement` (
 	`restricted` boolean NOT NULL DEFAULT '0' COMMENT 'If true, this post is either unlisted or not from a federated network',
 	`comments` mediumint unsigned COMMENT 'Number of comments',
 	`activities` mediumint unsigned COMMENT 'Number of activities (like, dislike, ...)',
+	`views` mediumint unsigned COMMENT 'Number of views',
 	 PRIMARY KEY(`uri-id`),
 	 INDEX `owner-id` (`owner-id`),
 	 INDEX `created` (`created`),
@@ -2118,8 +2119,9 @@ CREATE VIEW `channel-post-view` AS SELECT
 	`post-engagement`.`network` AS `network`,
 	`ownercontact`.`contact-type` AS `contact-type`,
 	`post-engagement`.`restricted` AS `restricted`,
-	0 AS `comments`,
-	0 AS `activities`
+	`post-engagement`.`comments` AS `comments`,
+	`post-engagement`.`activities` AS `activities`,
+	`post-engagement`.`views` AS `views`
 	FROM `channel-post`
 			INNER JOIN `post-engagement` ON `post-engagement`.`uri-id` = `channel-post`.`uri-id`
 			INNER JOIN `post-thread` ON `post-thread`.`uri-id` = `channel-post`.`uri-id`
@@ -2148,8 +2150,9 @@ CREATE VIEW `system-channel-post-view` AS SELECT
 	`post-engagement`.`network` AS `network`,
 	`ownercontact`.`contact-type` AS `contact-type`,
 	`post-engagement`.`restricted` AS `restricted`,
-	0 AS `comments`,
-	0 AS `activities`
+	`post-engagement`.`comments` AS `comments`,
+	`post-engagement`.`activities` AS `activities`,
+	`post-engagement`.`views` AS `views`
 	FROM `system-channel-post`
 			INNER JOIN `post-engagement` ON `post-engagement`.`uri-id` = `system-channel-post`.`uri-id`
 			INNER JOIN `post-thread` ON `post-thread`.`uri-id` = `system-channel-post`.`uri-id`
@@ -2220,8 +2223,9 @@ CREATE VIEW `post-engagement-user-view` AS SELECT
 	`post-thread-user`.`network` AS `network`,
 	`post-user`.`protocol` AS `protocol`,
 	`post-engagement`.`restricted` AS `restricted`,
-	0 AS `comments`,
-	0 AS `activities`
+	`post-engagement`.`comments` AS `comments`,
+	`post-engagement`.`activities` AS `activities`,
+	`post-engagement`.`views` AS `views`
 	FROM `post-thread-user`
 			INNER JOIN `post-engagement` ON `post-engagement`.`uri-id` = `post-thread-user`.`uri-id`
 			INNER JOIN `post-user` ON `post-user`.`id` = `post-thread-user`.`post-user-id`
@@ -2245,9 +2249,9 @@ CREATE VIEW `post-timeline-view` AS SELECT
 	`post-user`.`gravity` AS `gravity`,
 	`post-user`.`created` AS `created`,
 	`post-user`.`edited` AS `edited`,
-	`post-thread-user`.`commented` AS `commented`,
+	`post-thread`.`commented` AS `commented`,
 	`post-user`.`received` AS `received`,
-	`post-thread-user`.`changed` AS `changed`,
+	`post-thread`.`changed` AS `changed`,
 	`post-user`.`private` AS `private`,
 	`post-user`.`visible` AS `visible`,
 	`post-user`.`deleted` AS `deleted`,
@@ -2273,11 +2277,11 @@ CREATE VIEW `post-timeline-view` AS SELECT
 	`post-user`.`causer-id` AS `causer-id`,
 	`causer`.`blocked` AS `causer-blocked`,
 	`causer`.`gsid` AS `causer-gsid`,
-	`post-thread-user`.`network` AS `parent-network`,
-	`post-thread-user`.`owner-id` AS `parent-owner-id`,
-	`post-thread-user`.`author-id` AS `parent-author-id`
+	`post-thread`.`network` AS `parent-network`,
+	`post-thread`.`owner-id` AS `parent-owner-id`,
+	`post-thread`.`author-id` AS `parent-author-id`
 	FROM `post-user`
-			LEFT JOIN `post-thread-user` ON `post-thread-user`.`uri-id` = `post-user`.`parent-uri-id` AND `post-thread-user`.`uid` = `post-user`.`uid`
+			LEFT JOIN `post-thread` ON `post-thread`.`uri-id` = `post-user`.`parent-uri-id`
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `post-user`.`contact-id`
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `post-user`.`author-id`
 			STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = `post-user`.`owner-id`
@@ -2293,9 +2297,9 @@ CREATE VIEW `post-timeline-origin-view` AS SELECT
 	`post-origin`.`gravity` AS `gravity`,
 	`post-origin`.`created` AS `created`,
 	`post-user`.`edited` AS `edited`,
-	`post-thread-user`.`commented` AS `commented`,
+	`post-thread`.`commented` AS `commented`,
 	`post-origin`.`received` AS `received`,
-	`post-thread-user`.`changed` AS `changed`,
+	`post-thread`.`changed` AS `changed`,
 	`post-origin`.`private` AS `private`,
 	`post-user`.`visible` AS `visible`,
 	`post-user`.`deleted` AS `deleted`,
@@ -2323,7 +2327,7 @@ CREATE VIEW `post-timeline-origin-view` AS SELECT
 	`causer`.`gsid` AS `causer-gsid`
 	FROM `post-origin`
 			INNER JOIN `post-user` ON `post-user`.`id` = `post-origin`.`id`
-			LEFT JOIN `post-thread-user` ON `post-thread-user`.`uri-id` = `post-origin`.`parent-uri-id` AND `post-thread-user`.`uid` = `post-origin`.`uid`
+			LEFT JOIN `post-thread` ON `post-thread`.`uri-id` = `post-origin`.`parent-uri-id`
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `post-user`.`contact-id`
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `post-user`.`author-id`
 			STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = `post-user`.`owner-id`
@@ -2348,7 +2352,8 @@ CREATE VIEW `post-searchindex-user-view` AS SELECT
 	`post-user`.`protocol` AS `protocol`,
 	`post-searchindex`.`restricted` AS `restricted`,
 	0 AS `comments`,
-	0 AS `activities`
+	0 AS `activities`,
+	0 AS `views`
 	FROM `post-thread-user`
 			INNER JOIN `post-searchindex` ON `post-searchindex`.`uri-id` = `post-thread-user`.`uri-id`
 			INNER JOIN `post-user` ON `post-user`.`id` = `post-thread-user`.`post-user-id`
@@ -2767,9 +2772,9 @@ CREATE VIEW `post-user-view` AS SELECT
 	`thr-parent-item-uri`.`uri` AS `thr-parent`,
 	`post-user`.`thr-parent-id` AS `thr-parent-id`,
 	`conversation-item-uri`.`uri` AS `conversation`,
-	`post-thread-user`.`conversation-id` AS `conversation-id`,
+	`post-thread`.`conversation-id` AS `conversation-id`,
 	`context-item-uri`.`uri` AS `context`,
-	`post-thread-user`.`context-id` AS `context-id`,
+	`post-thread`.`context-id` AS `context-id`,
 	`quote-item-uri`.`uri` AS `quote-uri`,
 	`post-content`.`quote-uri-id` AS `quote-uri-id`,
 	`item-uri`.`guid` AS `guid`,
@@ -2781,9 +2786,9 @@ CREATE VIEW `post-user-view` AS SELECT
 	`post-user`.`replies-id` AS `replies-id`,
 	`post-user`.`created` AS `created`,
 	`post-user`.`edited` AS `edited`,
-	`post-thread-user`.`commented` AS `commented`,
+	`post-thread`.`commented` AS `commented`,
 	`post-user`.`received` AS `received`,
-	`post-thread-user`.`changed` AS `changed`,
+	`post-thread`.`changed` AS `changed`,
 	`post-user`.`post-type` AS `post-type`,
 	`post-user`.`post-reason` AS `post-reason`,
 	`post-user`.`private` AS `private`,
@@ -2915,15 +2920,16 @@ CREATE VIEW `post-user-view` AS SELECT
 	EXISTS(SELECT `id` FROM `post-media` WHERE `post-media`.`uri-id` = `post-user`.`uri-id`) AS `has-media`,
 	`diaspora-interaction`.`interaction` AS `signed_text`,
 	`parent-item-uri`.`guid` AS `parent-guid`,
-	`post-thread-user`.`network` AS `parent-network`,
-	`post-thread-user`.`owner-id` AS `parent-owner-id`,
-	`post-thread-user`.`author-id` AS `parent-author-id`,
+	`post-thread`.`network` AS `parent-network`,
+	`post-thread`.`owner-id` AS `parent-owner-id`,
+	`post-thread`.`author-id` AS `parent-author-id`,
 	`parent-post-author`.`url` AS `parent-author-link`,
 	`parent-post-author`.`name` AS `parent-author-name`,
 	`parent-post-author`.`nick` AS `parent-author-nick`,
 	`parent-post-author`.`network` AS `parent-author-network`
 	FROM `post-user`
-			INNER JOIN `post-thread-user` ON `post-thread-user`.`uri-id` = `post-user`.`parent-uri-id` AND `post-thread-user`.`uid` = `post-user`.`uid`
+			LEFT JOIN `post-thread-user` ON `post-thread-user`.`uri-id` = `post-user`.`parent-uri-id` AND `post-thread-user`.`uid` = `post-user`.`uid`
+			INNER JOIN `post-thread` ON `post-thread`.`uri-id` = `post-user`.`parent-uri-id`
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `post-user`.`contact-id`
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `post-user`.`author-id`
 			STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = `post-user`.`owner-id`
@@ -2931,8 +2937,8 @@ CREATE VIEW `post-user-view` AS SELECT
 			LEFT JOIN `item-uri` ON `item-uri`.`id` = `post-user`.`uri-id`
 			LEFT JOIN `item-uri` AS `thr-parent-item-uri` ON `thr-parent-item-uri`.`id` = `post-user`.`thr-parent-id`
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post-user`.`parent-uri-id`
-			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread-user`.`conversation-id`
-			LEFT JOIN `item-uri` AS `context-item-uri` ON `context-item-uri`.`id` = `post-thread-user`.`context-id`
+			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread`.`conversation-id`
+			LEFT JOIN `item-uri` AS `context-item-uri` ON `context-item-uri`.`id` = `post-thread`.`context-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post-user`.`external-id`
 			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post-user`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post-user`.`vid`
@@ -2943,7 +2949,7 @@ CREATE VIEW `post-user-view` AS SELECT
 			LEFT JOIN `post-delivery-data` ON `post-delivery-data`.`uri-id` = `post-user`.`uri-id` AND `post-user`.`origin`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-user`.`uri-id`
 			LEFT JOIN `permissionset` ON `permissionset`.`id` = `post-user`.`psid`
-			LEFT JOIN `contact` AS `parent-post-author` ON `parent-post-author`.`id` = `post-thread-user`.`author-id`;
+			LEFT JOIN `contact` AS `parent-post-author` ON `parent-post-author`.`id` = `post-thread`.`author-id`;
 
 --
 -- VIEW post-thread-user-view

--- a/doc/en/spec/database/db-post-engagement.md
+++ b/doc/en/spec/database/db-post-engagement.md
@@ -18,6 +18,7 @@ Engagement data per post
 | restricted   | If true, this post is either unlisted or not from a federated network | boolean            | NO   |     | 0       |       |
 | comments     | Number of comments                                                    | mediumint unsigned | YES  |     | NULL    |       |
 | activities   | Number of activities (like, dislike, ...)                             | mediumint unsigned | YES  |     | NULL    |       |
+| views        | Number of views                                                       | mediumint unsigned | YES  |     | NULL    |       |
 
 ## Indexes
 

--- a/src/Content/Conversation/Factory/ChannelPost.php
+++ b/src/Content/Conversation/Factory/ChannelPost.php
@@ -18,6 +18,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
+use Friendica\Protocol\Activity;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -92,7 +93,7 @@ final class ChannelPost
 		}
 
 		foreach ($channels as $channel) {
-			$in_timeline = Post::exists(['parent-uri-id' => $engagement['uri-id'], 'uid' => $channel->uid]);
+			$in_timeline = Post::exists(["`parent-uri-id` = ? AND `uid` = ? AND NOT `verb` IN (?, ?, ?)", $engagement['uri-id'], $channel->uid, Activity::FOLLOW, Activity::VIEW, Activity::READ]);
 
 			if ($engagement['restricted'] && !$in_timeline) {
 				continue;

--- a/src/Content/Conversation/Factory/SystemChannelPost.php
+++ b/src/Content/Conversation/Factory/SystemChannelPost.php
@@ -17,6 +17,7 @@ use Friendica\Model\Contact;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Model\User;
+use Friendica\Protocol\Activity;
 use Friendica\Util\DateTimeFormat;
 use Psr\Log\LoggerInterface;
 
@@ -108,7 +109,7 @@ final class SystemChannelPost
 				$store = false;
 				switch ($channel) {
 					case Channel::WHATSHOT:
-						$store = ($engagement['comments'] > $this->channelRepository->getMedianComments($uid, 4, $network) || $engagement['activities'] > $this->channelRepository->getMedianActivities($uid, 4, $network)) && $engagement['contact-type'] != Contact::TYPE_COMMUNITY;
+						$store = ($engagement['comments'] > $this->channelRepository->getMedianComments($uid, 4, $network) || $engagement['activities'] > $this->channelRepository->getMedianActivities($uid, 4, $network) || $engagement['views'] > $this->channelRepository->getMedianViews($uid, 4, $network)) && $engagement['contact-type'] != Contact::TYPE_COMMUNITY;
 						break;
 
 					case Channel::FORYOU:
@@ -117,7 +118,7 @@ final class SystemChannelPost
 						if ($relation = $this->dba->selectFirst('contact-relation', ['relation-thread-score', 'follows'], ['relation-cid' => $cid, 'cid' => $owner])) {
 							$store = $relation['relation-thread-score'] > $this->channelRepository->getMedianRelationThreadScore($cid, 4);
 							if (!$store && $relation['follows']) {
-								$store = ($engagement['comments'] >= $this->channelRepository->getMedianComments($uid, 4, $network) || $engagement['activities'] >= $this->channelRepository->getMedianActivities($uid, 4, $network));
+								$store = ($engagement['comments'] >= $this->channelRepository->getMedianComments($uid, 4, $network) || $engagement['activities'] >= $this->channelRepository->getMedianActivities($uid, 4, $network) || $engagement['views'] >= $this->channelRepository->getMedianViews($uid, 4, $network));
 							}
 						}
 
@@ -139,7 +140,7 @@ final class SystemChannelPost
 								$store = $this->dba->exists('contact-relation', ["`relation-cid` = ? AND `cid` = ? AND `follows` AND `relation-thread-score` > ?",
 									$owner, $cid, 0]);
 							}
-							if (!$store && ($engagement['comments'] >= $this->channelRepository->getMedianComments($uid, 4, $network) || $engagement['activities'] >= $this->channelRepository->getMedianActivities($uid, 4, $network))) {
+							if (!$store && ($engagement['comments'] >= $this->channelRepository->getMedianComments($uid, 4, $network) || $engagement['activities'] >= $this->channelRepository->getMedianActivities($uid, 4, $network)) || $engagement['views'] >= $this->channelRepository->getMedianViews($uid, 4, $network)) {
 								$store = $this->dba->exists('contact-relation', ["`relation-cid` = ? AND `cid` = ? AND `relation-thread-score` > ?", $owner, $cid, 0]);
 								if (!$store) {
 									$store = $this->dba->exists('contact-relation', ["`cid` = ? AND `relation-cid` = ? AND `relation-thread-score` > ?", $owner, $cid, 0]);
@@ -208,7 +209,7 @@ final class SystemChannelPost
 					'channel'     => $channel,
 					'uid'         => $uid,
 					'uri-id'      => $engagement['uri-id'],
-					'in-timeline' => Post::exists(['parent-uri-id' => $engagement['uri-id'], 'uid' => $uid]),
+					'in-timeline' => Post::exists(["`parent-uri-id` = ? AND `uid` = ? AND NOT `verb` IN (?, ?, ?)", $engagement['uri-id'], $uid, Activity::FOLLOW, Activity::VIEW, Activity::READ]),
 					'created'     => $post['created'],
 					'received'    => $post['received'],
 					'commented'   => $post['commented'],

--- a/src/Content/Conversation/Repository/UserDefinedChannel.php
+++ b/src/Content/Conversation/Repository/UserDefinedChannel.php
@@ -750,6 +750,42 @@ class UserDefinedChannel extends BaseRepository
 	}
 
 	/**
+	 * Compute median views for a user's wanted languages.
+	 *
+	 * @param int $uid User id.
+	 * @param int $divider Divider used to determine median index.
+	 * @param string $network Optional network filter.
+	 * @return int Median views value.
+	 */
+	public function getMedianViews(int $uid, int $divider, string $network = ''): int
+	{
+		$languages = User::getWantedLanguages($uid);
+		$cache_key = 'Channel:getMedianViews:' . $divider . ':' . implode(':', $languages) . $network;
+		$views     = $this->cache->get($cache_key);
+		if (!empty($views)) {
+			return $views;
+		}
+
+		$condition = ["`contact-type` != ? AND `views` > ? AND NOT `restricted`", Contact::TYPE_COMMUNITY, 0];
+		$condition = $this->addLanguageCondition($uid, $condition);
+
+		if ($network) {
+			$condition = DBA::mergeConditions($condition, ["`network` = ?", $network]);
+		}
+
+		$limit = $this->db->count('post-engagement', $condition) / $divider;
+		$post  = $this->db->selectToArray('post-engagement', ['views'], $condition, ['order' => ['views' => true], 'limit' => [$limit, 1]]);
+		$views = $post[0]['views'] ?? 0;
+		if (empty($views)) {
+			return 0;
+		}
+
+		$this->cache->set($cache_key, $views, Duration::HALF_HOUR);
+		$this->logger->debug('Calculated median views', ['divider' => $divider, 'languages' => $languages, 'network' => $network, 'median' => $views]);
+		return $views;
+	}
+
+	/**
 	 * Compute median relation thread score for a contact id.
 	 *
 	 * @param int $cid Contact id.

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -1363,4 +1363,24 @@ class Item
 		$used_languages = $this->l10n->t("Detected languages in this post:\n%s", $used_languages);
 		return $used_languages;
 	}
+
+	public function setViewed(int $uri_id, int $uid)
+	{
+		if (Post::exists(['thr-parent-id' => $uri_id, 'verb' => Activity::VIEW, 'uid' => $uid])) {
+			return;
+		}
+
+		$item = Post::selectFirst(['id'], ['uri-id' => $uri_id, 'gravity' => ItemModel::GRAVITY_PARENT, 'uid' => [0, $uid]], ['order' => ['uid' => true]]);
+		if (!DBA::isResult($item)) {
+			return;
+		}
+
+		$self = DBA::selectFirst('contact', ['id'], ['uid' => $uid, 'self' => true]);
+		if (!DBA::isResult($self)) {
+			return;
+		}
+
+		$this->logger->debug('Marking item as viewed.', ['uri-id' => $uri_id, 'uid' => $uid]);
+		ItemModel::performActivity($item['id'], 'view', $uid, '<' . $self['id'] . '>', '', '', '');
+	}
 }

--- a/src/Model/Contact/Relation.php
+++ b/src/Model/Contact/Relation.php
@@ -829,27 +829,23 @@ class Relation
 		DI::logger()->debug('Calculation - start', ['uid' => $uid, 'cid' => $contact_id, 'days' => $days]);
 
 		$follow = Verb::getID(Activity::FOLLOW);
-		$view   = Verb::getID(Activity::VIEW);
-		$read   = Verb::getID(Activity::READ);
 
 		DBA::update('contact-relation', ['score' => 0, 'relation-score' => 0, 'thread-score' => 0, 'relation-thread-score' => 0], ['relation-cid' => $contact_id]);
 
 		$total = DBA::fetchFirst(
-			"SELECT count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post`.`uri-id` = `post-user`.`thr-parent-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND NOT `post`.`vid` IN (?, ?, ?)",
+			"SELECT count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post`.`uri-id` = `post-user`.`thr-parent-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND `post`.`vid` != ?",
 			$contact_id,
 			DateTimeFormat::utc('now - ' . $days . ' day'),
 			$uid,
 			$contact_id,
-			$follow,
-			$view,
-			$read
+			$follow
 		);
 
 		DI::logger()->debug('Calculate relation-score', ['uid' => $uid, 'total' => $total['activity']]);
 
 		$interactions = DBA::p(
 			"SELECT `post`.`author-id`, count(*) AS `activity`, EXISTS(SELECT `pid` FROM `account-user-view` WHERE `pid` = `post`.`author-id` AND `uid` = ? AND `rel` IN (?, ?)) AS `follows`
-			FROM `post-user` INNER JOIN `post` ON `post`.`uri-id` = `post-user`.`thr-parent-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND NOT `post`.`vid` IN (?, ?, ?) GROUP BY `post`.`author-id`",
+			FROM `post-user` INNER JOIN `post` ON `post`.`uri-id` = `post-user`.`thr-parent-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND `post`.`vid` != ? GROUP BY `post`.`author-id`",
 			$uid,
 			Contact::SHARING,
 			Contact::FRIEND,
@@ -857,9 +853,7 @@ class Relation
 			DateTimeFormat::utc('now - ' . $days . ' day'),
 			$uid,
 			$contact_id,
-			$follow,
-			$view,
-			$read
+			$follow
 		);
 		while ($interaction = DBA::fetch($interactions)) {
 			$score = min((int)(($interaction['activity'] / $total['activity']) * 65535), 65535);
@@ -868,21 +862,19 @@ class Relation
 		DBA::close($interactions);
 
 		$total = DBA::fetchFirst(
-			"SELECT count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post`.`uri-id` = `post-user`.`parent-uri-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND NOT `post`.`vid` IN (?, ?, ?)",
+			"SELECT count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post`.`uri-id` = `post-user`.`parent-uri-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND `post`.`vid` != ?",
 			$contact_id,
 			DateTimeFormat::utc('now - ' . $days . ' day'),
 			$uid,
 			$contact_id,
-			$follow,
-			$view,
-			$read
+			$follow
 		);
 
 		DI::logger()->debug('Calculate relation-thread-score', ['uid' => $uid, 'total' => $total['activity']]);
 
 		$interactions = DBA::p(
 			"SELECT `post`.`author-id`, count(*) AS `activity`, EXISTS(SELECT `pid` FROM `account-user-view` WHERE `pid` = `post`.`author-id` AND `uid` = ? AND `rel` IN (?, ?)) AS `follows`
-			FROM `post-user` INNER JOIN `post` ON `post`.`uri-id` = `post-user`.`parent-uri-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND NOT `post`.`vid` IN (?, ?, ?) GROUP BY `post`.`author-id`",
+			FROM `post-user` INNER JOIN `post` ON `post`.`uri-id` = `post-user`.`parent-uri-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND `post`.`vid` != ? GROUP BY `post`.`author-id`",
 			$uid,
 			Contact::SHARING,
 			Contact::FRIEND,
@@ -890,9 +882,7 @@ class Relation
 			DateTimeFormat::utc('now - ' . $days . ' day'),
 			$uid,
 			$contact_id,
-			$follow,
-			$view,
-			$read
+			$follow
 		);
 		while ($interaction = DBA::fetch($interactions)) {
 			$score = min((int)(($interaction['activity'] / $total['activity']) * 65535), 65535);
@@ -901,27 +891,23 @@ class Relation
 		DBA::close($interactions);
 
 		$total = DBA::fetchFirst(
-			"SELECT count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post-user`.`uri-id` = `post`.`thr-parent-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND NOT `post`.`vid` IN (?, ?, ?)",
+			"SELECT count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post-user`.`uri-id` = `post`.`thr-parent-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND `post`.`vid` != ?",
 			$contact_id,
 			DateTimeFormat::utc('now - ' . $days . ' day'),
 			$uid,
 			$contact_id,
-			$follow,
-			$view,
-			$read
+			$follow
 		);
 
 		DI::logger()->debug('Calculate score', ['uid' => $uid, 'total' => $total['activity']]);
 
 		$interactions = DBA::p(
-			"SELECT `post`.`author-id`, count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post-user`.`uri-id` = `post`.`thr-parent-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND NOT `post`.`vid` IN (?, ?, ?) GROUP BY `post`.`author-id`",
+			"SELECT `post`.`author-id`, count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post-user`.`uri-id` = `post`.`thr-parent-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND `post`.`vid` != ? GROUP BY `post`.`author-id`",
 			$contact_id,
 			DateTimeFormat::utc('now - ' . $days . ' day'),
 			$uid,
 			$contact_id,
-			$follow,
-			$view,
-			$read
+			$follow
 		);
 		while ($interaction = DBA::fetch($interactions)) {
 			$score = min((int)(($interaction['activity'] / $total['activity']) * 65535), 65535);
@@ -930,27 +916,23 @@ class Relation
 		DBA::close($interactions);
 
 		$total = DBA::fetchFirst(
-			"SELECT count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post-user`.`uri-id` = `post`.`parent-uri-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND NOT `post`.`vid` IN (?, ?, ?)",
+			"SELECT count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post-user`.`uri-id` = `post`.`parent-uri-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND `post`.`vid` != ?",
 			$contact_id,
 			DateTimeFormat::utc('now - ' . $days . ' day'),
 			$uid,
 			$contact_id,
-			$follow,
-			$view,
-			$read
+			$follow
 		);
 
 		DI::logger()->debug('Calculate thread-score', ['uid' => $uid, 'total' => $total['activity']]);
 
 		$interactions = DBA::p(
-			"SELECT `post`.`author-id`, count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post-user`.`uri-id` = `post`.`parent-uri-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND NOT `post`.`vid` IN (?, ?, ?) GROUP BY `post`.`author-id`",
+			"SELECT `post`.`author-id`, count(*) AS `activity` FROM `post-user` INNER JOIN `post` ON `post-user`.`uri-id` = `post`.`parent-uri-id` WHERE `post-user`.`author-id` = ? AND `post-user`.`received` >= ? AND `post-user`.`uid` = ? AND `post`.`author-id` != ? AND `post`.`vid` != ? GROUP BY `post`.`author-id`",
 			$contact_id,
 			DateTimeFormat::utc('now - ' . $days . ' day'),
 			$uid,
 			$contact_id,
-			$follow,
-			$view,
-			$read
+			$follow
 		);
 		while ($interaction = DBA::fetch($interactions)) {
 			$score = min((int)(($interaction['activity'] / $total['activity']) * 65535), 65535);

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1162,6 +1162,9 @@ class Item
 				self::reshareChannelPost($engagement_uri_id);
 			}
 
+			if ($posted_item['origin'] && in_array($posted_item['verb'], [Activity::LIKE, Activity::DISLIKE, Activity::ATTEND, Activity::ATTENDNO, Activity::ATTENDMAYBE, Activity::ANNOUNCE, Activity::POST])) {
+				DI::contentItem()->setViewed($posted_item['thr-parent-id'], $posted_item['uid']);
+			}
 		}
 
 		if ($posted_item['uid'] !== 0 && ($posted_item['origin'] || !in_array($posted_item['network'], Protocol::FEDERATED))) {
@@ -2572,7 +2575,7 @@ class Item
 			return false;
 		}
 
-		if (!Post::exists(['uri-id' => $item['parent-uri-id'], 'uid' => $uid])) {
+		if (!in_array($verb, ['view', 'unview']) && !Post::exists(['uri-id' => $item['parent-uri-id'], 'uid' => $uid])) {
 			$stored = self::storeForUserByUriId($item['parent-uri-id'], $uid, ['post-reason' => Item::PR_ACTIVITY]);
 			if (($item['parent-uri-id'] == $item['uri-id']) && !empty($stored)) {
 				$item = Post::selectFirst(self::ITEM_FIELDLIST, ['id' => $stored]);
@@ -2626,6 +2629,10 @@ class Item
 			case 'announce':
 			case 'unannounce':
 				$activity = Activity::ANNOUNCE;
+				break;
+			case 'view':
+			case 'unview':
+				$activity = Activity::VIEW;
 				break;
 			default:
 				DI::logger()->warning('unknown verb', ['verb' => $verb, 'item' => $item_id]);

--- a/src/Model/ItemHelper.php
+++ b/src/Model/ItemHelper.php
@@ -266,7 +266,10 @@ final class ItemHelper
 			'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid',
 			'wall', 'private', 'origin', 'author-id'
 		];
-		$condition = ['uri-id' => [$item['thr-parent-id'], $item['parent-uri-id']], 'uid' => $item['uid']];
+
+		$uids = $item['verb'] === Activity::VIEW ? [0, $item['uid']] : $item['uid'];
+
+		$condition = ['uri-id' => [$item['thr-parent-id'], $item['parent-uri-id']], 'uid' => $uids];
 		$params    = ['order' => ['id' => false]];
 		$parent    = Post::selectFirst($fields, $condition, $params);
 

--- a/src/Model/Post/Engagement.php
+++ b/src/Model/Post/Engagement.php
@@ -108,11 +108,12 @@ class Engagement
 			'network'      => $parent['network'],
 			'restricted'   => !in_array($item['network'], Protocol::FEDERATED) || ($parent['private'] != Item::PUBLIC),
 			'comments'     => DBA::count('post', ['parent-uri-id' => $item['parent-uri-id'], 'gravity' => Item::GRAVITY_COMMENT]),
+			'views'        => DBA::count('post', ['parent-uri-id' => $item['parent-uri-id'], 'gravity' => Item::GRAVITY_ACTIVITY, 'vid' => [Verb::getID(Activity::VIEW), Verb::getID(Activity::READ)]]),
 			'activities'   => DBA::count('post', [
 				"`parent-uri-id` = ? AND `gravity` = ? AND NOT `vid` IN (?, ?, ?)",
 				$item['parent-uri-id'], Item::GRAVITY_ACTIVITY,
 				Verb::getID(Activity::FOLLOW), Verb::getID(Activity::VIEW), Verb::getID(Activity::READ)
-			])
+			]),
 		];
 		if (!$store && ($engagement['comments'] == 0) && ($engagement['activities'] == 0)) {
 			DI::logger()->debug('No media, follower, subscribed tags, comments or activities. Engagement not stored', ['fields' => $engagement]);

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -394,6 +394,7 @@ class Statuses extends BaseApi
 			if (Post::exists(['uri-id' => $this->parameters['id'], 'uid' => $uid, 'unseen' => true])) {
 				Post::update(['unseen' => false], ['uri-id' => $this->parameters['id'], 'uid' => $uid, 'unseen' => true]);
 			}
+			$this->item->setViewed($this->parameters['id'], $uid);
 		}
 
 		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, false));

--- a/src/Module/Conversation/Timeline.php
+++ b/src/Module/Conversation/Timeline.php
@@ -320,9 +320,9 @@ class Timeline extends BaseModule
 		if ($this->selectedTab == ChannelEntity::WHATSHOT) {
 			if (!$cache) {
 				if (!is_null($this->accountType)) {
-					$condition = ["(`comments` > ? OR `activities` > ?) AND `contact-type` = ?", $this->channelRepository->getMedianComments($uid, 4), $this->channelRepository->getMedianActivities($uid, 4), $this->accountType];
+					$condition = ["(`comments` > ? OR `activities` > ? OR `views` > ?) AND `contact-type` = ?", $this->channelRepository->getMedianComments($uid, 4), $this->channelRepository->getMedianActivities($uid, 4), $this->channelRepository->getMedianViews($uid, 4), $this->accountType];
 				} else {
-					$condition = ["(`comments` > ? OR `activities` > ?) AND `contact-type` != ?", $this->channelRepository->getMedianComments($uid, 4), $this->channelRepository->getMedianActivities($uid, 4), Contact::TYPE_COMMUNITY];
+					$condition = ["(`comments` > ? OR `activities` > ? OR `views` > ?) AND `contact-type` != ?", $this->channelRepository->getMedianComments($uid, 4), $this->channelRepository->getMedianActivities($uid, 4), $this->channelRepository->getMedianViews($uid, 4), Contact::TYPE_COMMUNITY];
 				}
 			}
 		} elseif ($this->selectedTab == ChannelEntity::FORYOU) {
@@ -331,9 +331,9 @@ class Timeline extends BaseModule
 
 				$condition = [
 					"(`owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` = ? AND `relation-thread-score` > ?) OR
-					((`comments` >= ? OR `activities` >= ?) AND `owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `follows` AND `relation-cid` = ?)) OR
+					((`comments` >= ? OR `activities` >= ? OR `views` >= ?) AND `owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `follows` AND `relation-cid` = ?)) OR
 					(`owner-id` IN (SELECT `cid` FROM `user-contact` WHERE `uid` = ? AND (`notify_new_posts` OR `channel-frequency` = ?))))",
-					$cid, $this->channelRepository->getMedianRelationThreadScore($cid, 4), $this->channelRepository->getMedianComments($uid, 4), $this->channelRepository->getMedianActivities($uid, 4), $cid,
+					$cid, $this->channelRepository->getMedianRelationThreadScore($cid, 4), $this->channelRepository->getMedianComments($uid, 4), $this->channelRepository->getMedianActivities($uid, 4), $this->channelRepository->getMedianViews($uid, 4), $cid,
 					$uid, Contact\User::FREQUENCY_ALWAYS
 				];
 			}
@@ -345,11 +345,11 @@ class Timeline extends BaseModule
 					"`owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` = ? AND NOT `follows`) AND
 					(`owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` = ? AND NOT `follows` AND `relation-thread-score` > ?) OR
 					`owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `cid` = ? AND `relation-thread-score` > ?) OR
-					((`comments` >= ? OR `activities` >= ?) AND
+					((`comments` >= ? OR `activities` >= ? OR `views` >= ?) AND
 					(`owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `cid` = ? AND `relation-thread-score` > ?)) OR
 					(`owner-id` IN (SELECT `cid` FROM `contact-relation` WHERE `relation-cid` = ? AND `relation-thread-score` > ?))))",
 					$cid, $cid, $this->channelRepository->getMedianRelationThreadScore($cid, 4), $cid, $this->channelRepository->getMedianRelationThreadScore($cid, 4),
-					$this->channelRepository->getMedianComments($uid, 4), $this->channelRepository->getMedianActivities($uid, 4), $cid, 0, $cid, 0
+					$this->channelRepository->getMedianComments($uid, 4), $this->channelRepository->getMedianActivities($uid, 4), $this->channelRepository->getMedianViews($uid, 4), $cid, 0, $cid, 0
 				];
 			}
 		} elseif ($this->selectedTab == ChannelEntity::FOLLOWERS) {

--- a/src/Module/Item/Display.php
+++ b/src/Module/Item/Display.php
@@ -89,7 +89,7 @@ class Display extends BaseModule
 		$item    = null;
 		$itemUid = $this->session->getLocalUserId();
 
-		$fields = ['uri-id', 'parent-uri-id', 'author-id', 'author-link', 'contact-id', 'contact-contact-type', 'body', 'uid', 'guid', 'gravity',
+		$fields = ['id', 'uri-id', 'parent-uri-id', 'author-id', 'author-link', 'contact-id', 'contact-contact-type', 'body', 'uid', 'guid', 'gravity',
 			'plink', 'origin', 'uri', 'post-reason', 'owner-contact-type', 'owner-network', 'owner-id', 'guid',
 			'author-network', 'author-alias', 'private'];
 
@@ -146,6 +146,10 @@ class Display extends BaseModule
 		if (!$this->pConfig->get($this->session->getLocalUserId(), 'system', 'detailed_notif')) {
 			$this->notification->setAllSeenForUser($this->session->getLocalUserId(), ['parent-uri-id' => $item['parent-uri-id']]);
 			$this->notify->setAllSeenForUser($this->session->getLocalUserId(), ['parent-uri-id' => $item['parent-uri-id']]);
+		}
+
+		if ($this->session->getLocalUserId() != 0) {
+			$this->contentItem->setViewed($item['uri-id'], $this->session->getLocalUserId());
 		}
 
 		$this->displaySidebar($item);

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -44,7 +44,7 @@ use Friendica\Database\DBA;
 
 // This file is required several times during the test in DbaDefinition which justifies this condition
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1587);
+	define('DB_UPDATE_VERSION', 1588);
 }
 
 return [
@@ -1359,6 +1359,7 @@ return [
 			"restricted" => ["type" => "boolean", "not null" => "1", "default" => "0", "comment" => "If true, this post is either unlisted or not from a federated network"],
 			"comments" => ["type" => "mediumint unsigned", "comment" => "Number of comments"],
 			"activities" => ["type" => "mediumint unsigned", "comment" => "Number of activities (like, dislike, ...)"],
+			"views" => ["type" => "mediumint unsigned", "comment" => "Number of views"],
 		],
 		"indexes" => [
 			"PRIMARY" => ["uri-id"],

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -65,8 +65,9 @@ return [
 			"network" => ["post-engagement", "network"],
 			"contact-type" => ["ownercontact", "contact-type"],
 			"restricted" => ["post-engagement", "restricted"],
-			"comments" => "0",
-			"activities" => "0",
+			"comments" => ["post-engagement", "comments"],
+			"activities" => ["post-engagement", "activities"],
+			"views" => ["post-engagement", "views"],
 		],
 		"query" => "FROM `channel-post`
 			INNER JOIN `post-engagement` ON `post-engagement`.`uri-id` = `channel-post`.`uri-id`
@@ -93,8 +94,9 @@ return [
 			"network" => ["post-engagement", "network"],
 			"contact-type" => ["ownercontact", "contact-type"],
 			"restricted" => ["post-engagement", "restricted"],
-			"comments" => "0",
-			"activities" => "0",
+			"comments" => ["post-engagement", "comments"],
+			"activities" => ["post-engagement", "activities"],
+			"views" => ["post-engagement", "views"],
 		],
 		"query" => "FROM `system-channel-post`
 			INNER JOIN `post-engagement` ON `post-engagement`.`uri-id` = `system-channel-post`.`uri-id`
@@ -159,8 +161,9 @@ return [
 			"network" => ["post-thread-user", "network"],
 			"protocol" => ["post-user", "protocol"],
 			"restricted" => ["post-engagement", "restricted"],
-			"comments" => "0",
-			"activities" => "0",
+			"comments" => ["post-engagement", "comments"],
+			"activities" => ["post-engagement", "activities"],
+			"views" => ["post-engagement", "views"],
 		],
 		"query" => "FROM `post-thread-user`
 			INNER JOIN `post-engagement` ON `post-engagement`.`uri-id` = `post-thread-user`.`uri-id`
@@ -182,9 +185,9 @@ return [
 			"gravity" => ["post-user", "gravity"],
 			"created" => ["post-user", "created"],
 			"edited" => ["post-user", "edited"],
-			"commented" => ["post-thread-user", "commented"],
+			"commented" => ["post-thread", "commented"],
 			"received" => ["post-user", "received"],
-			"changed" => ["post-thread-user", "changed"],
+			"changed" => ["post-thread", "changed"],
 			"private" => ["post-user", "private"],
 			"visible" => ["post-user", "visible"],
 			"deleted" => ["post-user", "deleted"],
@@ -210,12 +213,12 @@ return [
 			"causer-id" => ["post-user", "causer-id"],
 			"causer-blocked" => ["causer", "blocked"],
 			"causer-gsid" => ["causer", "gsid"],
-			"parent-network" => ["post-thread-user", "network"],
-			"parent-owner-id" => ["post-thread-user", "owner-id"],
-			"parent-author-id" => ["post-thread-user", "author-id"],
+			"parent-network" => ["post-thread", "network"],
+			"parent-owner-id" => ["post-thread", "owner-id"],
+			"parent-author-id" => ["post-thread", "author-id"],
 		],
 		"query" => "FROM `post-user`
-			LEFT JOIN `post-thread-user` ON `post-thread-user`.`uri-id` = `post-user`.`parent-uri-id` AND `post-thread-user`.`uid` = `post-user`.`uid`
+			LEFT JOIN `post-thread` ON `post-thread`.`uri-id` = `post-user`.`parent-uri-id`
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `post-user`.`contact-id`
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `post-user`.`author-id`
 			STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = `post-user`.`owner-id`
@@ -228,9 +231,9 @@ return [
 			"gravity" => ["post-origin", "gravity"],
 			"created" => ["post-origin", "created"],
 			"edited" => ["post-user", "edited"],
-			"commented" => ["post-thread-user", "commented"],
+			"commented" => ["post-thread", "commented"],
 			"received" => ["post-origin", "received"],
-			"changed" => ["post-thread-user", "changed"],
+			"changed" => ["post-thread", "changed"],
 			"private" => ["post-origin", "private"],
 			"visible" => ["post-user", "visible"],
 			"deleted" => ["post-user", "deleted"],
@@ -259,7 +262,7 @@ return [
 		],
 		"query" => "FROM `post-origin`
 			INNER JOIN `post-user` ON `post-user`.`id` = `post-origin`.`id`
-			LEFT JOIN `post-thread-user` ON `post-thread-user`.`uri-id` = `post-origin`.`parent-uri-id` AND `post-thread-user`.`uid` = `post-origin`.`uid`
+			LEFT JOIN `post-thread` ON `post-thread`.`uri-id` = `post-origin`.`parent-uri-id`
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `post-user`.`contact-id`
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `post-user`.`author-id`
 			STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = `post-user`.`owner-id`
@@ -282,6 +285,7 @@ return [
 			"restricted" => ["post-searchindex", "restricted"],
 			"comments" => "0",
 			"activities" => "0",
+			"views" => "0",
 		],
 		"query" => "FROM `post-thread-user`
 			INNER JOIN `post-searchindex` ON `post-searchindex`.`uri-id` = `post-thread-user`.`uri-id`
@@ -694,9 +698,9 @@ return [
 			"thr-parent" => ["thr-parent-item-uri", "uri"],
 			"thr-parent-id" => ["post-user", "thr-parent-id"],
 			"conversation" => ["conversation-item-uri", "uri"],
-			"conversation-id" => ["post-thread-user", "conversation-id"],
+			"conversation-id" => ["post-thread", "conversation-id"],
 			"context" => ["context-item-uri", "uri"],
-			"context-id" => ["post-thread-user", "context-id"],
+			"context-id" => ["post-thread", "context-id"],
 			"quote-uri" => ["quote-item-uri", "uri"],
 			"quote-uri-id" => ["post-content", "quote-uri-id"],
 			"guid" => ["item-uri", "guid"],
@@ -708,9 +712,9 @@ return [
 			"replies-id" => ["post-user", "replies-id"],
 			"created" => ["post-user", "created"],
 			"edited" => ["post-user", "edited"],
-			"commented" => ["post-thread-user", "commented"],
+			"commented" => ["post-thread", "commented"],
 			"received" => ["post-user", "received"],
-			"changed" => ["post-thread-user", "changed"],
+			"changed" => ["post-thread", "changed"],
 			"post-type" => ["post-user", "post-type"],
 			"post-reason" => ["post-user", "post-reason"],
 			"private" => ["post-user", "private"],
@@ -842,16 +846,17 @@ return [
 			"has-media" => "EXISTS(SELECT `id` FROM `post-media` WHERE `post-media`.`uri-id` = `post-user`.`uri-id`)",
 			"signed_text" => ["diaspora-interaction", "interaction"],
 			"parent-guid" => ["parent-item-uri", "guid"],
-			"parent-network" => ["post-thread-user", "network"],
-			"parent-owner-id" => ["post-thread-user", "owner-id"],
-			"parent-author-id" => ["post-thread-user", "author-id"],
+			"parent-network" => ["post-thread", "network"],
+			"parent-owner-id" => ["post-thread", "owner-id"],
+			"parent-author-id" => ["post-thread", "author-id"],
 			"parent-author-link" => ["parent-post-author", "url"],
 			"parent-author-name" => ["parent-post-author", "name"],
 			"parent-author-nick" => ["parent-post-author", "nick"],
 			"parent-author-network" => ["parent-post-author", "network"],
 		],
 		"query" => "FROM `post-user`
-			INNER JOIN `post-thread-user` ON `post-thread-user`.`uri-id` = `post-user`.`parent-uri-id` AND `post-thread-user`.`uid` = `post-user`.`uid`
+			LEFT JOIN `post-thread-user` ON `post-thread-user`.`uri-id` = `post-user`.`parent-uri-id` AND `post-thread-user`.`uid` = `post-user`.`uid`
+			INNER JOIN `post-thread` ON `post-thread`.`uri-id` = `post-user`.`parent-uri-id`
 			STRAIGHT_JOIN `contact` ON `contact`.`id` = `post-user`.`contact-id`
 			STRAIGHT_JOIN `contact` AS `author` ON `author`.`id` = `post-user`.`author-id`
 			STRAIGHT_JOIN `contact` AS `owner` ON `owner`.`id` = `post-user`.`owner-id`
@@ -859,8 +864,8 @@ return [
 			LEFT JOIN `item-uri` ON `item-uri`.`id` = `post-user`.`uri-id`
 			LEFT JOIN `item-uri` AS `thr-parent-item-uri` ON `thr-parent-item-uri`.`id` = `post-user`.`thr-parent-id`
 			LEFT JOIN `item-uri` AS `parent-item-uri` ON `parent-item-uri`.`id` = `post-user`.`parent-uri-id`
-			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread-user`.`conversation-id`
-			LEFT JOIN `item-uri` AS `context-item-uri` ON `context-item-uri`.`id` = `post-thread-user`.`context-id`
+			LEFT JOIN `item-uri` AS `conversation-item-uri` ON `conversation-item-uri`.`id` = `post-thread`.`conversation-id`
+			LEFT JOIN `item-uri` AS `context-item-uri` ON `context-item-uri`.`id` = `post-thread`.`context-id`
 			LEFT JOIN `item-uri` AS `external-item-uri` ON `external-item-uri`.`id` = `post-user`.`external-id`
 			LEFT JOIN `item-uri` AS `replies-item-uri` ON `replies-item-uri`.`id` = `post-user`.`replies-id`
 			LEFT JOIN `verb` ON `verb`.`id` = `post-user`.`vid`
@@ -871,7 +876,7 @@ return [
 			LEFT JOIN `post-delivery-data` ON `post-delivery-data`.`uri-id` = `post-user`.`uri-id` AND `post-user`.`origin`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-user`.`uri-id`
 			LEFT JOIN `permissionset` ON `permissionset`.`id` = `post-user`.`psid`
-			LEFT JOIN `contact` AS `parent-post-author` ON `parent-post-author`.`id` = `post-thread-user`.`author-id`"
+			LEFT JOIN `contact` AS `parent-post-author` ON `parent-post-author`.`id` = `post-thread`.`author-id`"
 	],
 	"post-thread-user-view" => [
 		"fields" => [


### PR DESCRIPTION
ActivityPub know the "View" activity which indicates if someone had seen the related content. This is already used by Peertube. We now store this activity as well, when someone views a post. The activity is not shared to anyone, it is just stored for the user.

This serves two purposes:
1. This can be used in the Client2Server mode as a "seen" marker.
2. Based on which posts had been seen, we can improve the suggestion for interesting posts in the system channels.