### PR TITLE
Two slow database queries fixed

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -236,6 +236,7 @@ CREATE TABLE IF NOT EXISTS `contact` (
 	 INDEX `next-update` (`next-update`),
 	 INDEX `local-data-next-update` (`local-data`,`next-update`),
 	 INDEX `uid_lastitem` (`uid`,`last-item`),
+	 INDEX `uid_created` (`uid`,`created`),
 	 INDEX `baseurl` (`baseurl`(64)),
 	 INDEX `uid_contact-type` (`uid`,`contact-type`),
 	 INDEX `uid_self_contact-type` (`uid`,`self`,`contact-type`),

--- a/doc/en/spec/database/db-contact.md
+++ b/doc/en/spec/database/db-contact.md
@@ -114,6 +114,7 @@ contact table
 | next-update                 | next-update                          |
 | local-data-next-update      | local-data, next-update              |
 | uid_lastitem                | uid, last-item                       |
+| uid_created                 | uid, created                         |
 | baseurl                     | baseurl(64)                          |
 | uid_contact-type            | uid, contact-type                    |
 | uid_self_contact-type       | uid, self, contact-type              |

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -403,7 +403,7 @@ class Item
 		Post\DeliveryData::delete($item['uri-id']);
 
 		// If it's the parent of a comment thread, kill all the kids
-		if ($item['gravity'] == self::GRAVITY_PARENT) {
+		if ($item['gravity'] == self::GRAVITY_PARENT && !is_null($item['parent'])) {
 			self::markForDeletion(['parent' => $item['parent'], 'deleted' => false], $priority);
 		}
 

--- a/src/Module/Api/Mastodon/Directory.php
+++ b/src/Module/Api/Mastodon/Directory.php
@@ -42,8 +42,10 @@ class Directory extends BaseApi
 			$condition = ['uid' => 0, 'hidden' => false, 'network' => Protocol::FEDERATED];
 		}
 
-		$params = ['limit' => [$request['offset'], $request['limit']],
-			'order'           => [($request['order'] == 'active') ? 'last-item' : 'created' => true]];
+		$params = [
+			'limit' => [$request['offset'], $request['limit']],
+			'order' => [($request['order'] == 'active') ? 'last-item' : 'created' => true]
+		];
 
 		$accounts = [];
 		$contacts = DBA::select($table, ['id', 'uid'], $condition, $params);

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -285,6 +285,7 @@ return [
 			"next-update" => ["next-update"],
 			"local-data-next-update" => ["local-data", "next-update"],
 			"uid_lastitem" => ["uid", "last-item"],
+			"uid_created" => ["uid", "created"],
 			"baseurl" => ["baseurl(64)"],
 			"uid_contact-type" => ["uid", "contact-type"],
 			"uid_self_contact-type" => ["uid", "self", "contact-type"],


### PR DESCRIPTION
This PR fixes two separates database issues. 

1. Querying the endpoint to list contacts ended in a slow query that lasted minutes. Due to the new index it now takes fractions of a second.
2. A problem during expiration is fixed that lead to an hour long query for a parent value that is `null`.