### PR TITLE
Respect robots.txt when fetching server data

### DIFF
--- a/src/DI.php
+++ b/src/DI.php
@@ -413,6 +413,11 @@ abstract class DI
 		return self::$dice->create(Network\HTTPClient\Capability\ICanSendHttpRequests::class);
 	}
 
+	public static function robotsTxt(): Network\RobotsTxt
+	{
+		return self::$dice->create(Network\RobotsTxt::class);
+	}
+
 	//
 	// "Repository" namespace
 	//

--- a/src/Database/Definition/DbaDefinition.php
+++ b/src/Database/Definition/DbaDefinition.php
@@ -70,7 +70,7 @@ class DbaDefinition
 
 		// Assign all field that are present in the table
 		foreach ($fieldNames as $field) {
-			if (isset($data[$field])) {
+			if (array_key_exists($field, $data)) {
 				// Limit the length of varchar, varbinary, char and binary fields
 				if (is_string($data[$field]) && preg_match("/char\((\d*)\)/", $definition[$table]['fields'][$field]['type'], $result)) {
 					if ($charset == 'latin1') {

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -29,6 +29,7 @@ use Friendica\Util\Network;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
 use Friendica\Network\HTTPException;
+use Friendica\Network\RobotsTxt;
 use Friendica\Worker\UpdateGServer;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;
@@ -77,6 +78,8 @@ class GServer
 	const DETECT_NODEINFO2_10    = 103; // Nodeinfo2 Version 1.0
 	const DETECT_NODEINFO_21     = 104; // Nodeinfo Version 2.1
 	const DETECT_NODEINFO_22     = 105; // Nodeinfo Version 2.2
+
+	private static RobotsTxt $robotsTxt;
 
 	/**
 	 * Check for the existence of a server and adds it in the background if not existant
@@ -630,6 +633,9 @@ class GServer
 
 		$in_webroot = empty(parse_url($url, PHP_URL_PATH));
 
+		self::$robotsTxt = DI::robotsTxt();
+		self::$robotsTxt->load($url);
+
 		// When a nodeinfo is present, we don't need to dig further
 		$curlResult = DI::httpClient()->get($url . '/.well-known/nodeinfo', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if ($curlResult->isTimeout()) {
@@ -641,6 +647,10 @@ class GServer
 			$serverdata = ['detection-method' => self::DETECT_MANUAL, 'network' => $network, 'platform' => '', 'version' => '', 'site_name' => '', 'info' => ''];
 		} else {
 			$serverdata = self::parseNodeinfo($url, $curlResult);
+
+			if (!empty($serverdata)) {
+				$serverdata = self::clearStatisticalData($serverdata);
+			}
 
 			if (empty($serverdata) || !in_array($serverdata['detection-method'], [self::DETECT_NODEINFO_20, self::DETECT_NODEINFO_21, self::DETECT_NODEINFO_22])) {
 				$curlResult = DI::httpClient()->get($url . '/.well-known/x-nodeinfo2', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
@@ -658,7 +668,7 @@ class GServer
 
 		// When there is no Nodeinfo, then use some protocol specific endpoints
 		if ($serverdata['network'] == Protocol::PHANTOM) {
-			if ($in_webroot) {
+			if ($in_webroot && self::$robotsTxt->isAllowed('/')) {
 				// Fetch the landing page, possibly it reveals some data
 				$accept     = 'application/activity+json,application/ld+json,application/json,*/*;q=0.9';
 				$curlResult = DI::httpClient()->get($url, $accept, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
@@ -814,11 +824,6 @@ class GServer
 
 		$serverdata['registered-users'] = $serverdata['registered-users'] ?? 0;
 
-		// Numbers above a reasonable value (10 millions) are ignored
-		if ($serverdata['registered-users'] > 10000000) {
-			$serverdata['registered-users'] = 0;
-		}
-
 		// On an active server there has to be at least a single user
 		if (!in_array($serverdata['network'], [Protocol::PHANTOM, Protocol::FEED]) && ($serverdata['registered-users'] <= 0)) {
 			$serverdata['registered-users'] = 1;
@@ -860,6 +865,53 @@ class GServer
 		}
 
 		return $ret;
+	}
+
+	/**
+	 * Clear statistical data from nodeinfo when we are not allowed to access it or when the data seems to be faked.
+	 *
+	 * GotoSocial is known for having an option to provide fake statistical data, so we apply some checks for this platform in particular.
+	 *
+	 * @param array $serverdata
+	 * @return array
+	 */
+	private static function clearStatisticalData(array $serverdata): array
+	{
+		// We don't clear the data when we are allowed to access the nodeinfo
+		$clear = !self::$robotsTxt->isAllowed('/.well-known/nodeinfo');
+
+		// Numbers above a reasonable value (10 millions) are a sign for faked data, so we clear the data in this case as well.
+		if (($serverdata['registered-users'] ?? 0) > 10000000) {
+			$clear = true;
+		}
+
+		// All the following checks are only applied for GoToSocial, so we can skip them for other platforms.
+		if (!$clear && $serverdata['platform'] !== 'gotosocial') {
+			return $serverdata;
+		}
+
+		// When the robots.txt couldn't be loaded, we clear the data as well.
+		if (!self::$robotsTxt->isLoaded()) {
+			$clear = true;
+		}
+
+		// We clear the data when there are more than 10.000 registered users, since this is an indicator for faked data.
+		if (($serverdata['registered-users'] ?? 0) > 10000) {
+			$clear = true;
+		}
+
+		if (!$clear) {
+			return $serverdata;
+		}
+
+		$serverdata['registered-users']      = null;
+		$serverdata['active-week-users']     = null;
+		$serverdata['active-month-users']    = null;
+		$serverdata['active-halfyear-users'] = null;
+		$serverdata['local-posts']           = null;
+		$serverdata['local-comments']        = null;
+
+		return $serverdata;
 	}
 
 	/**
@@ -905,6 +957,10 @@ class GServer
 	 */
 	private static function discoverRelay(string $server_url)
 	{
+		if (!self::$robotsTxt->isAllowed('/.well-known/x-social-relay')) {
+			return;
+		}
+
 		DI::logger()->info('Discover relay data', ['server' => $server_url]);
 
 		$curlResult = DI::httpClient()->get($server_url . '/.well-known/x-social-relay', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
@@ -1002,6 +1058,10 @@ class GServer
 	 */
 	private static function fetchStatistics(string $url, array $serverdata): array
 	{
+		if (!self::$robotsTxt->isAllowed('/statistics.json')) {
+			return $serverdata;
+		}
+
 		$curlResult = DI::httpClient()->get($url . '/statistics.json', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
@@ -1504,6 +1564,10 @@ class GServer
 	 */
 	private static function fetchSiteinfo(string $url, array $serverdata): array
 	{
+		if (!self::$robotsTxt->isAllowed('/siteinfo.json')) {
+			return $serverdata;
+		}
+
 		$curlResult = DI::httpClient()->get($url . '/siteinfo.json', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
@@ -1684,6 +1748,10 @@ class GServer
 	 */
 	private static function getNomadVersion(string $url): string
 	{
+		if (!self::$robotsTxt->isAllowed('/api/z/1.0/version')) {
+			return '';
+		}
+
 		$curlResult = DI::httpClient()->get($url . '/api/z/1.0/version', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if (!$curlResult->isSuccess() || ($curlResult->getBodyString() == '')) {
 			return '';
@@ -1777,6 +1845,10 @@ class GServer
 	 */
 	private static function validHostMeta(string $url): bool
 	{
+		if (!self::$robotsTxt->isAllowed(Probe::HOST_META)) {
+			return false;
+		}
+
 		$xrd_timeout = DI::config()->get('system', 'xrd_timeout');
 		$curlResult  = DI::httpClient()->get($url . Probe::HOST_META, HttpClientAccept::XRD_XML, [HttpClientOptions::TIMEOUT => $xrd_timeout, HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if (!$curlResult->isSuccess()) {
@@ -1866,6 +1938,10 @@ class GServer
 	{
 		$serverdata['poco'] = '';
 
+		if (!self::$robotsTxt->isAllowed('/poco')) {
+			return $serverdata;
+		}
+
 		$curlResult = DI::httpClient()->get($url . '/poco', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
@@ -1895,6 +1971,10 @@ class GServer
 	 */
 	public static function checkMastodonDirectory(string $url, array $serverdata): array
 	{
+		if (!self::$robotsTxt->isAllowed('/api/v1/directory')) {
+			return $serverdata;
+		}
+
 		$curlResult = DI::httpClient()->get($url . '/api/v1/directory?limit=1', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if (!$curlResult->isSuccess()) {
 			return $serverdata;
@@ -1927,6 +2007,10 @@ class GServer
 	 */
 	private static function detectPeertube(string $url, array $serverdata): array
 	{
+		if (!self::$robotsTxt->isAllowed('/api/v1/config')) {
+			return $serverdata;
+		}
+
 		$curlResult = DI::httpClient()->get($url . '/api/v1/config', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if (!$curlResult->isSuccess() || ($curlResult->getBodyString() == '')) {
 			return $serverdata;
@@ -1975,6 +2059,10 @@ class GServer
 	 */
 	private static function detectNextcloud(string $url, array $serverdata, bool $validHostMeta): array
 	{
+		if (!self::$robotsTxt->isAllowed('/status.php')) {
+			return $serverdata;
+		}
+
 		$curlResult = DI::httpClient()->get($url . '/status.php', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if (!$curlResult->isSuccess() || ($curlResult->getBodyString() == '')) {
 			return $serverdata;
@@ -2011,6 +2099,10 @@ class GServer
 	 */
 	private static function fetchWeeklyUsage(string $url, array $serverdata): array
 	{
+		if (!self::$robotsTxt->isAllowed('/api/v1/instance/activity')) {
+			return $serverdata;
+		}
+
 		$curlResult = DI::httpClient()->get($url . '/api/v1/instance/activity', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if (!$curlResult->isSuccess() || ($curlResult->getBodyString() == '')) {
 			return $serverdata;
@@ -2051,6 +2143,10 @@ class GServer
 	 */
 	private static function detectMastodonAlikes(string $url, array $serverdata): array
 	{
+		if (!self::$robotsTxt->isAllowed('/api/v1/instance')) {
+			return $serverdata;
+		}
+
 		$curlResult = DI::httpClient()->get($url . '/api/v1/instance', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if (!$curlResult->isSuccess() || ($curlResult->getBodyString() == '')) {
 			return $serverdata;
@@ -2128,6 +2224,10 @@ class GServer
 	 */
 	private static function detectHubzilla(string $url, array $serverdata): array
 	{
+		if (!self::$robotsTxt->isAllowed('/api/statusnet/config.json')) {
+			return $serverdata;
+		}
+
 		$curlResult = DI::httpClient()->get($url . '/api/statusnet/config.json', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
 		if (!$curlResult->isSuccess() || ($curlResult->getBodyString() == '')) {
 			return $serverdata;
@@ -2223,44 +2323,48 @@ class GServer
 	private static function detectGNUSocial(string $url, array $serverdata): array
 	{
 		// Test for GNU Social
-		$curlResult = DI::httpClient()->get($url . '/api/gnusocial/version.json', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
-		if ($curlResult->isSuccess() && ($curlResult->getBodyString() != '{"error":"not implemented"}') &&
+		if (self::$robotsTxt->isAllowed('/api/gnusocial/version.json')) {
+			$curlResult = DI::httpClient()->get($url . '/api/gnusocial/version.json', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
+			if ($curlResult->isSuccess() && ($curlResult->getBodyString() != '{"error":"not implemented"}') &&
 			($curlResult->getBodyString() != '') && (strlen($curlResult->getBodyString()) < 30)) {
-			$serverdata['platform'] = 'gnusocial';
-			// Remove junk that some GNU Social servers return
-			$serverdata['version'] = str_replace(chr(239) . chr(187) . chr(191), '', $curlResult->getBodyString());
-			$serverdata['version'] = str_replace(["\r", "\n", "\t"], '', $serverdata['version']);
-			$serverdata['version'] = trim($serverdata['version'], '"');
-			$serverdata['network'] = Protocol::OSTATUS;
+				$serverdata['platform'] = 'gnusocial';
+				// Remove junk that some GNU Social servers return
+				$serverdata['version'] = str_replace(chr(239) . chr(187) . chr(191), '', $curlResult->getBodyString());
+				$serverdata['version'] = str_replace(["\r", "\n", "\t"], '', $serverdata['version']);
+				$serverdata['version'] = trim($serverdata['version'], '"');
+				$serverdata['network'] = Protocol::OSTATUS;
 
-			if (in_array($serverdata['detection-method'], self::DETECT_UNSPECIFIC)) {
-				$serverdata['detection-method'] = self::DETECT_GNUSOCIAL;
+				if (in_array($serverdata['detection-method'], self::DETECT_UNSPECIFIC)) {
+					$serverdata['detection-method'] = self::DETECT_GNUSOCIAL;
+				}
+
+				return $serverdata;
 			}
-
-			return $serverdata;
 		}
 
 		// Test for Statusnet
-		$curlResult = DI::httpClient()->get($url . '/api/statusnet/version.json', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
-		if ($curlResult->isSuccess() && ($curlResult->getBodyString() != '{"error":"not implemented"}') &&
-			($curlResult->getBodyString() != '') && (strlen($curlResult->getBodyString()) < 30)) {
+		if (self::$robotsTxt->isAllowed('/api/statusnet/version.json')) {
+			$curlResult = DI::httpClient()->get($url . '/api/statusnet/version.json', HttpClientAccept::JSON, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);
+			if ($curlResult->isSuccess() && ($curlResult->getBodyString() != '{"error":"not implemented"}') &&
+				($curlResult->getBodyString() != '') && (strlen($curlResult->getBodyString()) < 30)) {
 
-			// Remove junk that some GNU Social servers return
-			$serverdata['version'] = str_replace(chr(239) . chr(187) . chr(191), '', $curlResult->getBodyString());
-			$serverdata['version'] = str_replace(["\r", "\n", "\t"], '', $serverdata['version']);
-			$serverdata['version'] = trim($serverdata['version'], '"');
+				// Remove junk that some GNU Social servers return
+				$serverdata['version'] = str_replace(chr(239) . chr(187) . chr(191), '', $curlResult->getBodyString());
+				$serverdata['version'] = str_replace(["\r", "\n", "\t"], '', $serverdata['version']);
+				$serverdata['version'] = trim($serverdata['version'], '"');
 
-			if (!empty($serverdata['version']) && strtolower(substr($serverdata['version'], 0, 7)) == 'pleroma') {
-				$serverdata['platform'] = 'pleroma';
-				$serverdata['version']  = trim(str_ireplace('pleroma', '', $serverdata['version']));
-				$serverdata['network']  = Protocol::ACTIVITYPUB;
-			} else {
-				$serverdata['platform'] = 'statusnet';
-				$serverdata['network']  = Protocol::OSTATUS;
-			}
+				if (!empty($serverdata['version']) && strtolower(substr($serverdata['version'], 0, 7)) == 'pleroma') {
+					$serverdata['platform'] = 'pleroma';
+					$serverdata['version']  = trim(str_ireplace('pleroma', '', $serverdata['version']));
+					$serverdata['network']  = Protocol::ACTIVITYPUB;
+				} else {
+					$serverdata['platform'] = 'statusnet';
+					$serverdata['network']  = Protocol::OSTATUS;
+				}
 
-			if (in_array($serverdata['detection-method'], self::DETECT_UNSPECIFIC)) {
-				$serverdata['detection-method'] = self::DETECT_STATUSNET;
+				if (in_array($serverdata['detection-method'], self::DETECT_UNSPECIFIC)) {
+					$serverdata['detection-method'] = self::DETECT_STATUSNET;
+				}
 			}
 		}
 
@@ -2277,6 +2381,10 @@ class GServer
 	 */
 	private static function detectFriendica(string $url, array $serverdata): array
 	{
+		if (!self::$robotsTxt->isAllowed('/friendica/json')) {
+			return $serverdata;
+		}
+
 		// There is a bug in some versions of Friendica that will return an ActivityStream actor when the content type "application/json" is requested.
 		// Because of this me must not use ACCEPT_JSON here.
 		$curlResult = DI::httpClient()->get($url . '/friendica/json', HttpClientAccept::DEFAULT, [HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]);

--- a/src/Network/RobotsTxt.php
+++ b/src/Network/RobotsTxt.php
@@ -1,0 +1,193 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Network;
+
+use Friendica\Network\HTTPClient\Capability\ICanSendHttpRequests;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
+use Friendica\Network\HTTPClient\Client\HttpClientOptions;
+use Friendica\Network\HTTPClient\Client\HttpClientRequest;
+
+/**
+ * This class handles robots.txt parsing and path validation
+ */
+class RobotsTxt
+{
+	/**
+	 * @var string The base URL of the server
+	 */
+	private string $url = '';
+
+	/**
+	 * @var array Disallow rules for user-agent *
+	 */
+	private array $disallowRules = [];
+
+	/**
+	 * @var array Allow rules for user-agent *
+	 */
+	private array $allowRules = [];
+
+	/**
+	 * @var bool Indicates whether the robots.txt has been loaded
+	 */
+	private bool $isLoaded = false;
+
+	protected ICanSendHttpRequests $httpClient;
+
+	public function __construct(ICanSendHttpRequests $httpClient)
+	{
+		$this->httpClient = $httpClient;
+	}
+
+	/**
+	 * Loads the RobotsTxt parser with a server URL
+	 *
+	 * @param string $url The base URL of the server
+	 * @return bool True if robots.txt was successfully loaded, false otherwise
+	 */
+	public function load(string $url): bool
+	{
+		$this->url           = rtrim($url, '/');
+		$this->disallowRules = [];
+		$this->allowRules    = [];
+		$this->isLoaded      = false;
+
+		$robotsUrl = $this->url . '/robots.txt';
+
+		try {
+			$curlResult = $this->httpClient->get(
+				$robotsUrl,
+				HttpClientAccept::TEXT,
+				[HttpClientOptions::REQUEST => HttpClientRequest::SERVERINFO]
+			);
+
+			if (!$curlResult->isSuccess()) {
+				return false;
+			}
+
+			if (empty($curlResult->getBodyString())) {
+				return false;
+			}
+
+			$this->isLoaded = $this->parseRobotsTxt($curlResult->getBodyString());
+			return $this->isLoaded;
+		} catch (\Exception $e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Check if the robots.txt has been loaded successfully
+	 *
+	 * @return bool True if loaded, false otherwise
+	 */
+	public function isLoaded(): bool
+	{
+		return $this->isLoaded;
+	}
+
+	/**
+	 * Parse the robots.txt content and extract rules for user-agent *
+	 *
+	 * @param string $content The content of robots.txt
+	 * @return bool True if parsing was successful
+	 */
+	private function parseRobotsTxt(string $content): bool
+	{
+		$lines = explode("\n", $content);
+
+		$isRelevantSection = false;
+
+		foreach ($lines as $line) {
+			$line = preg_replace('~\s*#.*$~', '', $line);
+			$line = trim($line);
+
+			if (empty($line)) {
+				continue;
+			}
+
+			if (stripos($line, 'User-Agent:') === 0) {
+				$agent = trim(substr($line, strlen('User-Agent:')));
+
+				$isRelevantSection = ($agent === '*');
+				continue;
+			}
+
+			if (!$isRelevantSection) {
+				continue;
+			}
+
+			if (stripos($line, 'Disallow:') === 0) {
+				$path = trim(substr($line, strlen('Disallow:')));
+				if (!empty($path)) {
+					$this->disallowRules[] = $path;
+				}
+				continue;
+			}
+
+			if (stripos($line, 'Allow:') === 0) {
+				$path = trim(substr($line, strlen('Allow:')));
+				if (!empty($path)) {
+					$this->allowRules[] = $path;
+				}
+				continue;
+			}
+
+			if (stripos($line, 'User-Agent:') === 0 && !$isRelevantSection) {
+				break;
+			}
+		}
+
+		return sizeof($this->disallowRules) > 0 || sizeof($this->allowRules) > 0;
+	}
+
+	/**
+	 * Check if a given path is allowed according to robots.txt rules
+	 *
+	 * @param string $path The path to check (e.g., "/api/v1/accounts")
+	 * @return bool True if the path is allowed, false otherwise
+	 */
+	public function isAllowed(string $path): bool
+	{
+		$path    = '/' . ltrim(parse_url($path, PHP_URL_PATH), '/');
+		$allowed = true;
+		$length  = 0;
+
+		foreach ($this->allowRules as $rule) {
+			if (strlen($rule) > $length && $this->pathMatches($path, $rule)) {
+				$length = strlen($rule);
+			}
+		}
+
+		foreach ($this->disallowRules as $rule) {
+			if (strlen($rule) > $length && $this->pathMatches($path, $rule)) {
+				$allowed = false;
+			}
+		}
+
+		return $allowed;
+	}
+
+	/**
+	 * Check if a path matches a robots.txt rule
+	 * Rules use prefix matching: /admin will block /admin, /admin/, /admin/page, etc.
+	 *
+	 * @param string $path The path to check
+	 * @param string $rule The robots.txt rule
+	 * @return bool True if the path matches the rule
+	 */
+	private function pathMatches(string $path, string $rule): bool
+	{
+		if (str_ends_with($rule, '*')) {
+			$rule = substr($rule, 0, -1);
+			return str_starts_with($path, $rule);
+		}
+
+		return str_starts_with($path, $rule);
+	}
+}


### PR DESCRIPTION
GoToSocial knows an option where the usage data (number of posts, number of users) is deliberately faked. This PR handles it by introducing a new mechanism to load the robots.txt and to check if we are allowed to fetch the given URL.

We will always process the nodeinfo data when the endpoint is present, although the robots.txt might tell otherwise. This is done, since we fetch server data for two separate purposes:
1. Usage statistics
2. Technical information about the server

While the first one can be considered as crawling (since the numbers only serve a purpose in our statistics), the second purpose is to ensure that the server exists and is alive. It is also crucial to provide some data about the remote system in case of technical problems. Because of that, we will fetch the data anyway but will set the usage data to `null` in case that the crawling is forbidden.