### PR TITLE
Adjustments to some strings around photos and events

### DIFF
--- a/mod/notes.php
+++ b/mod/notes.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (C) 2010-2024, the Friendica project
  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
@@ -42,29 +43,37 @@ function notes_content(bool $update = false)
 
 		$x = [
 			'lockstate' => 'lock',
-			'acl' => \Friendica\Core\ACL::getSelfOnlyHTML(DI::userSession()->getLocalUserId(), DI::l10n()->t('Personal notes are visible only by yourself.')),
-			'button' => DI::l10n()->t('Save'),
-			'acl_data' => '',
+			'acl'       => \Friendica\Core\ACL::getSelfOnlyHTML(DI::userSession()->getLocalUserId(), DI::l10n()->t('Personal notes are visible only by yourself.')),
+			'button'    => DI::l10n()->t('Save'),
+			'acl_data'  => '',
 		];
 
 		$o .= DI::conversation()->statusEditor($x, $contactId);
 	}
 
 	$condition = ['uid' => DI::userSession()->getLocalUserId(), 'post-type' => Item::PT_PERSONAL_NOTE, 'gravity' => Item::GRAVITY_PARENT,
-		'contact-id'=> $contactId];
+		'contact-id'       => $contactId];
 
 	if (DI::mode()->isMobile()) {
-		$itemsPerPage = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'itemspage_mobile_network',
-			DI::config()->get('system', 'itemspage_network_mobile'));
+		$itemsPerPage = DI::pConfig()->get(
+			DI::userSession()->getLocalUserId(),
+			'system',
+			'itemspage_mobile_network',
+			DI::config()->get('system', 'itemspage_network_mobile')
+		);
 	} else {
-		$itemsPerPage = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'itemspage_network',
-			DI::config()->get('system', 'itemspage_network'));
+		$itemsPerPage = DI::pConfig()->get(
+			DI::userSession()->getLocalUserId(),
+			'system',
+			'itemspage_network',
+			DI::config()->get('system', 'itemspage_network')
+		);
 	}
 
 	$pager = new Pager(DI::l10n(), DI::args()->getQueryString(), $itemsPerPage);
 
 	$params = ['order' => ['created' => true],
-		'limit' => [$pager->getStart(), $pager->getItemsPerPage()]];
+		'limit'           => [$pager->getStart(), $pager->getItemsPerPage()]];
 	$r = Post::selectThreadForUser(DI::userSession()->getLocalUserId(), ['uri-id'], $condition, $params);
 
 	$count = 0;

--- a/mod/notes.php
+++ b/mod/notes.php
@@ -38,7 +38,7 @@ function notes_content(bool $update = false)
 	$o = BaseProfile::getTabsHTML('notes', true, DI::userSession()->getLocalUserNickname(), false);
 
 	if (!$update) {
-		$o .= '<h3>' . DI::l10n()->t('Personal Notes') . '</h3>';
+		$o .= '<h3>' . DI::l10n()->t('Personal notes') . '</h3>';
 
 		$x = [
 			'lockstate' => 'lock',

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -88,7 +88,7 @@ function photos_init()
 				'$title'    => DI::l10n()->t('Photo Albums'),
 				'$recent'   => DI::l10n()->t('Recent Photos'),
 				'$albums'   => $ret['albums'],
-				'$upload'   => [DI::l10n()->t('Upload Photos'), 'photos/' . $owner['nickname'] . '/upload'],
+				'$upload'   => [DI::l10n()->t('Upload photo'), 'photos/' . $owner['nickname'] . '/upload'],
 				'$can_post' => $can_post
 			]);
 		}
@@ -656,7 +656,7 @@ function photos_content()
 
 		$default_upload_box    = Renderer::replaceMacros(Renderer::getMarkupTemplate('photos_default_uploader_box.tpl'), []);
 		$default_upload_submit = Renderer::replaceMacros(Renderer::getMarkupTemplate('photos_default_uploader_submit.tpl'), [
-			'$submit' => DI::l10n()->t('Upload selected picture'),
+			'$submit' => DI::l10n()->t('Upload selected photo'),
 		]);
 
 		// Get the relevant size limits for uploads. Abbreviated var names: MaxImageSize -> mis; upload_max_filesize -> umf
@@ -679,7 +679,7 @@ function photos_content()
 		$aclselect_e = ($visitor ? '' : ACL::getFullSelectorHTML(DI::page(), DI::userSession()->getLocalUserId()));
 
 		$o .= Renderer::replaceMacros($tpl, [
-			'$pagename'              => DI::l10n()->t('Upload Photos'),
+			'$pagename'              => DI::l10n()->t('Upload photo'),
 			'$sessid'                => session_id(),
 			'$usage'                 => $usage_message,
 			'$nickname'              => $user['nickname'],
@@ -823,7 +823,7 @@ function photos_content()
 			'$photos'   => $photos,
 			'$album'    => $album,
 			'$can_post' => $can_post,
-			'$upload'   => [DI::l10n()->t('Upload Photos'), 'photos/' . $user['nickname'] . '/upload/' . bin2hex($album)],
+			'$upload'   => [DI::l10n()->t('Upload photo'), 'photos/' . $user['nickname'] . '/upload/' . bin2hex($album)],
 			'$order'    => $order,
 			'$edit'     => $edit,
 			'$drop'     => $drop,

--- a/src/Module/BaseProfile.php
+++ b/src/Module/BaseProfile.php
@@ -90,7 +90,7 @@ class BaseProfile extends BaseModule
 
 		if ($is_owner) {
 			$tabs[] = [
-				'label'     => DI::l10n()->t('Personal Notes'),
+				'label'     => DI::l10n()->t('Personal notes'),
 				'url'       => DI::baseUrl() . '/notes',
 				'sel'       => $current == 'notes' ? 'active' : '',
 				'title'     => DI::l10n()->t('Only You Can See This'),

--- a/src/Module/BaseProfile.php
+++ b/src/Module/BaseProfile.php
@@ -76,7 +76,7 @@ class BaseProfile extends BaseModule
 			];
 		} else {
 			$owner = User::getByNickname($nickname, ['uid']);
-			if(DI::userSession()->isAuthenticated() || $owner && Feature::isEnabled($owner['uid'], Feature::PUBLIC_CALENDAR)) {
+			if (DI::userSession()->isAuthenticated() || $owner && Feature::isEnabled($owner['uid'], Feature::PUBLIC_CALENDAR)) {
 				$tabs[] = [
 					'label'     => DI::l10n()->t('Calendar'),
 					'url'       => DI::baseUrl() . '/calendar/show/' . $nickname,

--- a/src/Module/Calendar/Event/Form.php
+++ b/src/Module/Calendar/Event/Form.php
@@ -108,8 +108,10 @@ class Form extends BaseModule
 		$share_disabled = '';
 
 		if (empty($orig_event)) {
-			$orig_event = User::getById($this->session->getLocalUserId(),
-				['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']);
+			$orig_event = User::getById(
+				$this->session->getLocalUserId(),
+				['allow_cid', 'allow_gid', 'deny_cid', 'deny_gid']
+			);
 		} elseif ($orig_event['allow_cid'] !== '<' . $this->session->getLocalUserId() . '>'
 				   || $orig_event['allow_gid']
 				   || $orig_event['deny_cid']

--- a/src/Module/Calendar/Event/Form.php
+++ b/src/Module/Calendar/Event/Form.php
@@ -206,14 +206,14 @@ class Form extends BaseModule
 				true
 			),
 
-			'$n_text'    => $this->t('Finish date/time is not known or not relevant'),
+			'$n_text'    => $this->t('End date/time is unknown or irrelevant'),
 			'$n_checked' => $n_checked,
-			'$f_text'    => $this->t('Event Finishes:'),
+			'$f_text'    => $this->t('Event ends:'),
 			'$f_dsel'    => Temporal::getDateTimeField(
 				new \DateTime(),
 				\DateTime::createFromFormat('Y', intval($fyear) + 5),
 				\DateTime::createFromFormat('Y-m-d H:i', "$fyear-$fmonth-$fday $fhour:$fminute"),
-				$this->t('Event Finishes:'),
+				$this->t('Event ends:'),
 				'finish_text',
 				true,
 				true,
@@ -230,7 +230,7 @@ class Form extends BaseModule
 			'$sh_text'     => $this->t('Share this event'),
 			'$share'       => ['share', $this->t('Share this event'), $share_checked, '', $share_disabled],
 			'$sh_checked'  => $share_checked,
-			'$nofinish'    => ['nofinish', $this->t('Finish date/time is not known or not relevant'), $n_checked],
+			'$nofinish'    => ['nofinish', $this->t('End date/time is unknown or irrelevant'), $n_checked],
 			'$preview'     => $this->t('Preview'),
 			'$acl'         => $acl,
 			'$submit'      => $this->t('Submit'),

--- a/src/Module/Profile/Photos.php
+++ b/src/Module/Profile/Photos.php
@@ -439,10 +439,10 @@ class Photos extends \Friendica\Module\BaseProfile
 		$o .= Renderer::replaceMacros($tpl, [
 			'$title'      => $this->t('Recent Photos'),
 			'$can_post'   => $is_owner,
-			'$upload'     => [$this->t('Upload Photos'), 'photos/' . $this->owner['nickname'] . '/upload'],
+			'$upload'     => [$this->t('Upload photo'), 'photos/' . $this->owner['nickname'] . '/upload'],
 			'$photos'     => $photos,
 			'$paginate'   => $pager->renderFull($total),
-			'upload_text' => $this->t('Upload Photos'),
+			'upload_text' => $this->t('Upload photo'),
 		]);
 
 		return $o;

--- a/src/Module/Settings/Account.php
+++ b/src/Module/Settings/Account.php
@@ -504,7 +504,7 @@ class Account extends BaseSettings
 			'$ptitle' => DI::l10n()->t('Account Settings'),
 			'$desc'   => DI::l10n()->t("Your Identity Address is <strong>'%s'</strong> or '%s'.", $nickname . '@' . DI::baseUrl()->getHost() . DI::baseUrl()->getPath(), DI::baseUrl() . '/profile/' . $nickname),
 
-			'$submit'              => DI::l10n()->t('Save Settings'),
+			'$submit'              => DI::l10n()->t('Save settings'),
 			'$uid'                 => DI::userSession()->getLocalUserId(),
 			'$form_security_token' => self::getFormSecurityToken('settings'),
 			'$open'                => $this->parameters['open'] ?? 'password',
@@ -543,7 +543,7 @@ class Account extends BaseSettings
 			'$aclselect'           => ACL::getFullSelectorHTML(DI::page(), $this->session->getLocalUserId()),
 
 			'$expire' => [
-				'label'        => DI::l10n()->t('Expiration settings'),
+				'label'        => DI::l10n()->t('Post expiration'),
 				'days'         => ['expire', DI::l10n()->t("Automatically expire posts after this many days:"), $expire, DI::l10n()->t('If empty, posts will not expire. Expired posts will be deleted')],
 				'items'        => ['expire_items', DI::l10n()->t('Expire posts'), $expire_items, DI::l10n()->t('When activated, posts and comments will be expired.')],
 				'notes'        => ['expire_notes', DI::l10n()->t('Expire personal notes'), $expire_notes, DI::l10n()->t('When activated, the personal notes on your profile page will be expired.')],
@@ -551,17 +551,17 @@ class Account extends BaseSettings
 				'network_only' => ['expire_network_only', DI::l10n()->t('Only expire posts by others'), $expire_network_only, DI::l10n()->t('When activated, your own posts never expire. Then the settings above are only valid for posts you received.')],
 			],
 
-			'$h_not'   => DI::l10n()->t('Notification Settings'),
-			'$lbl_not' => DI::l10n()->t('Send a notification email when:'),
+			'$h_not'   => DI::l10n()->t('Notifications'),
+			'$lbl_not' => DI::l10n()->t('Send an email when:'),
 			'$notify1' => ['notify1', DI::l10n()->t('You receive an introduction'), ($notify & Notification\Type::INTRO), Notification\Type::INTRO, ''],
 			'$notify2' => ['notify2', DI::l10n()->t('Your introductions are confirmed'), ($notify & Notification\Type::CONFIRM), Notification\Type::CONFIRM, ''],
-			'$notify3' => ['notify3', DI::l10n()->t('Someone writes on your profile wall'), ($notify & Notification\Type::WALL), Notification\Type::WALL, ''],
+			'$notify3' => ['notify3', DI::l10n()->t('Someone writes on your wall'), ($notify & Notification\Type::WALL), Notification\Type::WALL, ''],
 			'$notify4' => ['notify4', DI::l10n()->t('Someone writes a followup comment'), ($notify & Notification\Type::COMMENT), Notification\Type::COMMENT, ''],
 			'$notify5' => ['notify5', DI::l10n()->t('You receive a private message'), ($notify & Notification\Type::MAIL), Notification\Type::MAIL, ''],
 			'$notify6' => ['notify6', DI::l10n()->t('You receive a friend suggestion'), ($notify & Notification\Type::SUGGEST), Notification\Type::SUGGEST, ''],
 			'$notify7' => ['notify7', DI::l10n()->t('You are tagged in a post'), ($notify & Notification\Type::TAG_SELF), Notification\Type::TAG_SELF, ''],
 
-			'$lbl_notify'                    => DI::l10n()->t('Create a desktop notification when:'),
+			'$lbl_notify'                    => DI::l10n()->t('Notify when:'),
 			'$notify_tagged'                 => ['notify_tagged', DI::l10n()->t('Someone tagged you'), is_null($notify_type) || $notify_type & UserNotification::TYPE_EXPLICIT_TAGGED, ''],
 			'$notify_direct_comment'         => ['notify_direct_comment', DI::l10n()->t('Someone directly commented on your post'), is_null($notify_type) || $notify_type & (UserNotification::TYPE_IMPLICIT_TAGGED + UserNotification::TYPE_DIRECT_COMMENT + UserNotification::TYPE_DIRECT_THREAD_COMMENT), ''],
 			'$notify_like'                   => ['notify_like', DI::l10n()->t('Someone liked your content'), DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'notify_like'), DI::l10n()->t('Can only be enabled, when the direct comment notification is enabled.')],

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -446,14 +446,14 @@ class Display extends BaseSettings
 			'$form_security_token' => self::getFormSecurityToken('settings_display'),
 			'$uid'                 => $uid,
 
-			'$theme'        => ['theme', $this->t('Display theme'), $theme_selected, '', $themes, true],
+			'$theme'        => ['theme', $this->t('Theme'), $theme_selected, '', $themes, true],
 			'$mobile_theme' => ['mobile_theme', $this->t('Mobile theme'), $mobile_theme_selected, '', $mobile_themes, false],
 			'$theme_config' => $theme_config,
 
 			'$itemspage_network'        => ['itemspage_network', $this->t('Number of items to display per page:'), $itemspage_network, $this->t('Maximum of 100 items')],
 			'$itemspage_mobile_network' => ['itemspage_mobile_network', $this->t('Number of items to display per page when viewed from mobile device:'), $itemspage_mobile_network, $this->t('Maximum of 100 items')],
 			'$update_content'           => ['update_content', $this->t('Regularly update the page content'), $update_content, $this->t('When enabled, new content on network, community and channels are added on top.')],
-			'$enable_smile'             => ['enable_smile', $this->t('Display emoticons'), $enable_smile, $this->t('When enabled, emoticons are replaced with matching symbols.')],
+			'$enable_smile'             => ['enable_smile', $this->t('Display emojis'), $enable_smile, $this->t('When enabled, emoticons are replaced with matching emojis.')],
 			'$infinite_scroll'          => ['infinite_scroll', $this->t('Infinite scroll'), $infinite_scroll, $this->t('Automatic fetch new items when reaching the page end.')],
 			'$enable_smart_threading'   => ['enable_smart_threading', $this->t('Enable Smart Threading'), $enable_smart_threading, $this->t('Enable the automatic suppression of extraneous thread indentation.')],
 			'$enable_dislike'           => ['enable_dislike', $this->t('Display the Dislike feature'), $enable_dislike, $this->t('Display the Dislike button and dislike reactions on posts and comments.')],

--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -313,8 +313,8 @@ class Index extends BaseSettings
 			'$xmpp'          => ['xmpp', $this->t('XMPP (Jabber) address:'), $owner['xmpp'], $this->t('The XMPP address will be published so that people can follow you there.')],
 			'$matrix'        => ['matrix', $this->t('Matrix (Element) address:'), $owner['matrix'], $this->t('The Matrix address will be published so that people can follow you there.')],
 			'$homepage'      => ['homepage', $this->t('Homepage URL:'), $owner['homepage'], $homepage_help_text],
-			'$pub_keywords'  => ['pub_keywords', $this->t('Public Keywords:'), $owner['pub_keywords'], $this->t('(Used for suggesting potential friends, can be seen by others)')],
-			'$prv_keywords'  => ['prv_keywords', $this->t('Private Keywords:'), $owner['prv_keywords'], $this->t('(Used for searching profiles, never shown to others)')],
+			'$pub_keywords'  => ['pub_keywords', $this->t('Public Keywords:'), $owner['pub_keywords'], $this->t('Used for suggesting potential friends, can be seen by others.')],
+			'$prv_keywords'  => ['prv_keywords', $this->t('Private Keywords:'), $owner['prv_keywords'], $this->t('Used for searching profiles, never shown to others.')],
 			'$custom_fields' => $custom_fields,
 		]);
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-12 18:06+0100\n"
+"POT-Creation-Date: 2026-02-12 23:20+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -272,8 +272,10 @@ msgstr ""
 msgid "Your message:"
 msgstr ""
 
-#: mod/message.php:188 mod/message.php:345 src/Content/Conversation.php:371
-#: src/Module/Post/Edit.php:129
+#: mod/message.php:188 mod/message.php:345 mod/photos.php:91 mod/photos.php:682
+#: mod/photos.php:826 src/Content/Conversation.php:371
+#: src/Module/Post/Edit.php:129 src/Module/Profile/Photos.php:442
+#: src/Module/Profile/Photos.php:445
 msgid "Upload photo"
 msgstr ""
 
@@ -342,8 +344,8 @@ msgid_plural "%d messages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/notes.php:41 src/Module/BaseProfile.php:93
-msgid "Personal Notes"
+#: mod/notes.php:41 src/Content/Nav.php:231 src/Module/BaseProfile.php:93
+msgid "Personal notes"
 msgstr ""
 
 #: mod/notes.php:45
@@ -376,12 +378,6 @@ msgstr ""
 #: mod/photos.php:89 src/Module/Profile/Photos.php:420
 #: src/Module/Profile/Photos.php:440
 msgid "Recent Photos"
-msgstr ""
-
-#: mod/photos.php:91 mod/photos.php:682 mod/photos.php:826
-#: src/Module/Profile/Photos.php:422 src/Module/Profile/Photos.php:442
-#: src/Module/Profile/Photos.php:445
-msgid "Upload Photos"
 msgstr ""
 
 #: mod/photos.php:103 src/Module/BaseSettings.php:60
@@ -428,8 +424,8 @@ msgstr ""
 msgid "No photos selected"
 msgstr ""
 
-#: mod/photos.php:659 src/Module/Settings/Profile/Index.php:276
-msgid "Upload selected picture"
+#: mod/photos.php:659
+msgid "Upload selected photo"
 msgstr ""
 
 #: mod/photos.php:675
@@ -2043,10 +2039,6 @@ msgid "Your calendar"
 msgstr ""
 
 #: src/Content/Nav.php:231
-msgid "Personal notes"
-msgstr ""
-
-#: src/Content/Nav.php:231
 msgid "Your personal notes"
 msgstr ""
 
@@ -2162,6 +2154,7 @@ msgstr ""
 
 #: src/Content/Nav.php:310 src/Module/BaseNotifications.php:134
 #: src/Module/Notifications/Introductions.php:63
+#: src/Module/Settings/Account.php:554
 msgid "Notifications"
 msgstr ""
 
@@ -3951,8 +3944,7 @@ msgstr ""
 #: src/Module/Admin/Addons/Index.php:85 src/Module/Admin/Features.php:69
 #: src/Module/Admin/Logs/Settings.php:76 src/Module/Admin/Site.php:460
 #: src/Module/Admin/Themes/Index.php:105 src/Module/Admin/Tos.php:72
-#: src/Module/Settings/Account.php:507 src/Module/Settings/Addons.php:64
-#: src/Module/Settings/Connectors.php:143
+#: src/Module/Settings/Addons.php:64 src/Module/Settings/Connectors.php:143
 #: src/Module/Settings/Connectors.php:228
 #: src/Module/Settings/ContactImport.php:111
 #: src/Module/Settings/Delegation.php:179 src/Module/Settings/Display.php:427
@@ -5937,12 +5929,12 @@ msgstr ""
 
 #: src/Module/Calendar/Event/Form.php:209
 #: src/Module/Calendar/Event/Form.php:233
-msgid "Finish date/time is not known or not relevant"
+msgid "End date/time is unknown or irrelevant"
 msgstr ""
 
 #: src/Module/Calendar/Event/Form.php:211
 #: src/Module/Calendar/Event/Form.php:216
-msgid "Event Finishes:"
+msgid "Event ends:"
 msgstr ""
 
 #: src/Module/Calendar/Event/Form.php:223
@@ -8647,6 +8639,10 @@ msgstr ""
 msgid "View Album"
 msgstr ""
 
+#: src/Module/Profile/Photos.php:422
+msgid "Upload Photos"
+msgstr ""
+
 #: src/Module/Profile/Profile.php:121 src/Module/Profile/Profile.php:156
 #: src/Module/Profile/Restricted.php:38
 msgid "Profile not found."
@@ -9272,6 +9268,10 @@ msgstr ""
 msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
 msgstr ""
 
+#: src/Module/Settings/Account.php:507 view/theme/frio/config.php:158
+msgid "Save settings"
+msgstr ""
+
 #: src/Module/Settings/Account.php:512
 msgid "Password Settings"
 msgstr ""
@@ -9401,7 +9401,7 @@ msgid "Default Post Permissions"
 msgstr ""
 
 #: src/Module/Settings/Account.php:546
-msgid "Expiration settings"
+msgid "Post expiration"
 msgstr ""
 
 #: src/Module/Settings/Account.php:547
@@ -9444,12 +9444,8 @@ msgstr ""
 msgid "When activated, your own posts never expire. Then the settings above are only valid for posts you received."
 msgstr ""
 
-#: src/Module/Settings/Account.php:554
-msgid "Notification Settings"
-msgstr ""
-
 #: src/Module/Settings/Account.php:555
-msgid "Send a notification email when:"
+msgid "Send an email when:"
 msgstr ""
 
 #: src/Module/Settings/Account.php:556
@@ -9461,7 +9457,7 @@ msgid "Your introductions are confirmed"
 msgstr ""
 
 #: src/Module/Settings/Account.php:558
-msgid "Someone writes on your profile wall"
+msgid "Someone writes on your wall"
 msgstr ""
 
 #: src/Module/Settings/Account.php:559
@@ -9481,7 +9477,7 @@ msgid "You are tagged in a post"
 msgstr ""
 
 #: src/Module/Settings/Account.php:564
-msgid "Create a desktop notification when:"
+msgid "Notify when:"
 msgstr ""
 
 #: src/Module/Settings/Account.php:565
@@ -10067,7 +10063,7 @@ msgid "Reset order"
 msgstr ""
 
 #: src/Module/Settings/Display.php:449
-msgid "Display theme"
+msgid "Theme"
 msgstr ""
 
 #: src/Module/Settings/Display.php:450
@@ -10095,11 +10091,11 @@ msgid "When enabled, new content on network, community and channels are added on
 msgstr ""
 
 #: src/Module/Settings/Display.php:456
-msgid "Display emoticons"
+msgid "Display emojis"
 msgstr ""
 
 #: src/Module/Settings/Display.php:456
-msgid "When enabled, emoticons are replaced with matching symbols."
+msgid "When enabled, emoticons are replaced with matching emojis."
 msgstr ""
 
 #: src/Module/Settings/Display.php:457
@@ -10324,6 +10320,10 @@ msgstr ""
 msgid "Upload new picture"
 msgstr ""
 
+#: src/Module/Settings/Profile/Index.php:276
+msgid "Upload selected picture"
+msgstr ""
+
 #: src/Module/Settings/Profile/Index.php:277
 msgid "Pick existing picture from photos"
 msgstr ""
@@ -10404,7 +10404,7 @@ msgid "Public Keywords:"
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:316
-msgid "(Used for suggesting potential friends, can be seen by others)"
+msgid "Used for suggesting potential friends, can be seen by others."
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:317
@@ -10412,7 +10412,7 @@ msgid "Private Keywords:"
 msgstr ""
 
 #: src/Module/Settings/Profile/Index.php:317
-msgid "(Used for searching profiles, never shown to others)"
+msgid "Used for searching profiles, never shown to others."
 msgstr ""
 
 #: src/Module/Settings/Profile/Photo/Crop.php:90
@@ -12013,10 +12013,6 @@ msgstr ""
 
 #: view/theme/frio/config.php:153
 msgid "Ensure that the image has the correct permissions, allowing all users to view it."
-msgstr ""
-
-#: view/theme/frio/config.php:158
-msgid "Save settings"
 msgstr ""
 
 #: view/theme/frio/config.php:160


### PR DESCRIPTION
Makes a couple of changes to the strings:
- Some regular notifications were called desktop notifications, even though desktop notifications is a separate feature, you can enable
- Indicate that photo uploading handles a single photo, not multiple...?
- Use "photo" consistently in the photos section, instead of pictures in some places. I think pictures/images is more accurate, but that would be a larger change, and consistency is more important
- Simplify a few strings under settings