### PR TITLE
Fix pagination by using array_key_first/last in Channel and Network module

### DIFF
--- a/src/Module/Conversation/Channel.php
+++ b/src/Module/Conversation/Channel.php
@@ -131,8 +131,8 @@ class Channel extends Timeline
 		$pager = new BoundariesPager(
 			$this->l10n,
 			$this->args->getQueryString(),
-			$items[0][$order],
-			$items[count($items) - 1][$order],
+			$items[array_key_first($items)][$order],
+			$items[array_key_last($items)][$order],
 			$this->itemsPerPage
 		);
 

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -307,8 +307,8 @@ class Network extends Timeline
 			$pager = new BoundariesPager(
 				$this->l10n,
 				$this->args->getQueryString(),
-				$items[0][$this->order]                 ?? null,
-				$items[count($items) - 1][$this->order] ?? null,
+				$items[array_key_first($items)][$this->order] ?? null,
+				$items[array_key_last($items)][$this->order]  ?? null,
 				$this->itemsPerPage
 			);
 


### PR DESCRIPTION
Fix pagination for channels and network timeline

Pagination links had empty max_id parameters because the code assumed  sequential array keys (0, 1, 2...), but items use uri-id as keys.
Changed to array_key_first()/array_key_last() to correctly get boundary values for the pagination.

fixes #15470 