### PR TITLE
Don't transmit "View" activities via Diaspora

### DIFF
--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -332,6 +332,11 @@ class Notifier
 		$ap_contacts = $apdelivery['contacts'];
 		$delivery_queue_count += $apdelivery['count'];
 
+		if ($target_item['verb'] === Activity::VIEW) {
+			DI::logger()->info('Not delivering view activities', ['guid' => $target_item['guid'], 'uri-id' => $target_item['uri-id']]);
+			return;
+		}
+
 		if (!$only_ap_delivery) {
 			if (empty($delivery_contacts_stmt)) {
 				$condition = ['id' => $recipients, 'self' => false, 'uid' => [0, $uid],
@@ -384,7 +389,7 @@ class Notifier
 			$delivery_queue_count += self::delivery($cmd, $post_uriid, $sender_uid, $target_item, $parent, $thr_parent, $owner, $batch_delivery, false, $contacts, $ap_contacts, $conversants);
 		}
 
-		if (!empty($target_item)) {
+		if ($target_item) {
 			DI::logger()->info('Calling hooks for ' . $cmd . ' ' . $target_id);
 
 			Hook::fork($appHelper->getQueueValue('priority'), 'notifier_normal', $target_item);


### PR DESCRIPTION
This fixes the problem if "View" messages on Diaspora:
<img width="212" height="48" alt="image" src="https://github.com/user-attachments/assets/cd15edac-619c-42a1-9814-83500abffc79" />