### PR TITLE
Admin logs rename settings page, minor ui adjustments

### DIFF
--- a/src/Module/Admin/Logs/Settings.php
+++ b/src/Module/Admin/Logs/Settings.php
@@ -71,20 +71,20 @@ class Settings extends BaseAdmin
 		$t = Renderer::getMarkupTemplate('admin/logs/settings.tpl');
 
 		return Renderer::replaceMacros($t, [
-			'$title' => DI::l10n()->t('Administration'),
-			'$page' => DI::l10n()->t('Logs'),
-			'$submit' => DI::l10n()->t('Save Settings'),
-			'$clear' => DI::l10n()->t('Clear'),
+			'$title'   => DI::l10n()->t('Administration'),
+			'$page'    => DI::l10n()->t('Log settings'),
+			'$submit'  => DI::l10n()->t('Save Settings'),
+			'$clear'   => DI::l10n()->t('Clear'),
 			'$logname' => DI::config()->get('system', 'logfile'),
 			// see /help/smarty3-templates#1_1 on any Friendica node
-			'$debugging' => ['debugging', DI::l10n()->t('Enable Debugging'), DI::config()->get('system', 'debugging'), !DI::config()->isWritable('system', 'debugging') ? DI::l10n()->t('<strong>Read-only</strong> because it is set by an environment variable') : '', !DI::config()->isWritable('system', 'debugging') ? 'disabled' : ''],
-			'$logfile' => ['logfile', DI::l10n()->t('Log file'), DI::config()->get('system', 'logfile'), DI::l10n()->t('Must be writable by web server. Relative to your Friendica top-level directory.') . (!DI::config()->isWritable('system', 'logfile') ? '<br>' . DI::l10n()->t('<strong>Read-only</strong> because it is set by an environment variable') : ''), '', !DI::config()->isWritable('system', 'logfile') ? 'disabled' : ''],
-			'$loglevel' => ['loglevel', DI::l10n()->t("Log level"), DI::config()->get('system', 'loglevel'), !DI::config()->isWritable('system', 'loglevel') ? DI::l10n()->t('<strong>Read-only</strong> because it is set by an environment variable') : '', $log_choices, !DI::config()->isWritable('system', 'loglevel') ? 'disabled' : ''],
+			'$debugging'           => ['debugging', DI::l10n()->t('Enable Debugging'), DI::config()->get('system', 'debugging'), !DI::config()->isWritable('system', 'debugging') ? DI::l10n()->t('<strong>Read-only</strong> because it is set by an environment variable') : '', !DI::config()->isWritable('system', 'debugging') ? 'disabled' : ''],
+			'$logfile'             => ['logfile', DI::l10n()->t('Log file'), DI::config()->get('system', 'logfile'), DI::l10n()->t('Must be writable by web server. Relative to your Friendica top-level directory.') . (!DI::config()->isWritable('system', 'logfile') ? '<br>' . DI::l10n()->t('<strong>Read-only</strong> because it is set by an environment variable') : ''), '', !DI::config()->isWritable('system', 'logfile') ? 'disabled' : ''],
+			'$loglevel'            => ['loglevel', DI::l10n()->t("Log level"), DI::config()->get('system', 'loglevel'), !DI::config()->isWritable('system', 'loglevel') ? DI::l10n()->t('<strong>Read-only</strong> because it is set by an environment variable') : '', $log_choices, !DI::config()->isWritable('system', 'loglevel') ? 'disabled' : ''],
 			'$form_security_token' => self::getFormSecurityToken("admin_logs"),
-			'$phpheader' => DI::l10n()->t("PHP logging"),
-			'$phphint' => DI::l10n()->t("To temporarily enable logging of PHP errors and warnings you can prepend the following to the index.php file of your installation. The filename set in the 'error_log' line is relative to the friendica top-level directory and must be writeable by the web server. The option '1' for 'log_errors' and 'display_errors' is to enable these options, set to '0' to disable them."),
-			'$phplogcode' => "error_reporting(E_ERROR | E_WARNING | E_PARSE);\nini_set('error_log','php.out');\nini_set('log_errors','1');\nini_set('display_errors', '1');",
-			'$phplogenabled' => $phplogenabled,
+			'$phpheader'           => DI::l10n()->t("PHP logging"),
+			'$phphint'             => DI::l10n()->t("To temporarily enable logging of PHP errors and warnings you can prepend the following to the index.php file of your installation. The filename set in the 'error_log' line is relative to the friendica top-level directory and must be writeable by the web server. The option '1' for 'log_errors' and 'display_errors' is to enable these options, set to '0' to disable them."),
+			'$phplogcode'          => "error_reporting(E_ERROR | E_WARNING | E_PARSE);\nini_set('error_log','php.out');\nini_set('log_errors','1');\nini_set('display_errors', '1');",
+			'$phplogenabled'       => $phplogenabled,
 		]);
 	}
 }

--- a/src/Module/Admin/Logs/View.php
+++ b/src/Module/Admin/Logs/View.php
@@ -45,7 +45,7 @@ class View extends BaseAdmin
 			'context' => ['', 'index', 'worker', 'daemon'],
 		];
 		$filters = [
-			'level'   => $_GET['level'] ?? '',
+			'level'   => $_GET['level']   ?? '',
 			'context' => $_GET['context'] ?? '',
 		];
 		foreach ($filters as $k => $v) {
@@ -68,9 +68,9 @@ class View extends BaseAdmin
 			}
 		}
 		return Renderer::replaceMacros($t, [
-			'$title'         => DI::l10n()->t('Administration'),
-			'$page'          => DI::l10n()->t('View Logs'),
-			'$l10n'          => [
+			'$title' => DI::l10n()->t('Administration'),
+			'$page'  => DI::l10n()->t('View Logs'),
+			'$l10n'  => [
 				'Search'                => DI::l10n()->t('Search'),
 				'Search_in_logs'        => DI::l10n()->t('Search in logs'),
 				'Show_all'              => DI::l10n()->t('Show all'),
@@ -96,7 +96,7 @@ class View extends BaseAdmin
 			'$filters'       => $filters,
 			'$filtersvalues' => $filters_valid_values,
 			'$error'         => $error,
-			'$logname'       => DI::config()->get('system', 'logfile'),
+			'$logname'       => DI::l10n()->t('Current log path: %s', DI::config()->get('system', 'logfile')),
 		]);
 	}
 }

--- a/src/Module/BaseAdmin.php
+++ b/src/Module/BaseAdmin.php
@@ -85,8 +85,8 @@ abstract class BaseAdmin extends BaseModule
 				'workerqueue' => ['admin/queue'       , DI::l10n()->t('Inspect worker Queue')    , 'workerqueue'],
 			]],
 			'logs' => [DI::l10n()->t('Logs'), [
-				'logsconfig' => ['admin/logs/', DI::l10n()->t('Logs')                           , 'logs'],
-				'logsview'   => ['admin/logs/view'    , DI::l10n()->t('View Logs')              , 'viewlogs'],
+				'logsconfig' => ['admin/logs/', DI::l10n()->t('Settings')                           , 'logs'],
+				'logsview'   => ['admin/logs/view'    , DI::l10n()->t('View')              , 'viewlogs'],
 			]],
 			'diagnostics' => [DI::l10n()->t('Diagnostics'), [
 				'phpinfo'   => ['admin/phpinfo?t=' . self::getFormSecurityToken('phpinfo'), DI::l10n()->t('PHP Info')                , 'phpinfo'],

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-12 23:20+0100\n"
+"POT-Creation-Date: 2026-02-13 20:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Item not found."
 msgstr ""
 
-#: mod/item.php:463 mod/message.php:56 mod/message.php:102 mod/notes.php:34
+#: mod/item.php:463 mod/message.php:56 mod/message.php:102 mod/notes.php:35
 #: mod/photos.php:132 mod/photos.php:624 src/Model/Event.php:511
 #: src/Module/Attach.php:40 src/Module/BaseApi.php:90
 #: src/Module/BaseNotifications.php:83 src/Module/BaseSettings.php:38
@@ -344,15 +344,15 @@ msgid_plural "%d messages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mod/notes.php:41 src/Content/Nav.php:231 src/Module/BaseProfile.php:93
+#: mod/notes.php:42 src/Content/Nav.php:231 src/Module/BaseProfile.php:93
 msgid "Personal notes"
 msgstr ""
 
-#: mod/notes.php:45
+#: mod/notes.php:46
 msgid "Personal notes are visible only by yourself."
 msgstr ""
 
-#: mod/notes.php:46 src/Module/Admin/Storage.php:128
+#: mod/notes.php:47 src/Module/Admin/Storage.php:128
 #: src/Module/Filer/SaveTag.php:60 src/Module/Post/Edit.php:127
 #: src/Module/Settings/Channels.php:228
 msgid "Save"
@@ -446,7 +446,7 @@ msgid "Do not show a status post for this upload"
 msgstr ""
 
 #: mod/photos.php:691 mod/photos.php:1051 src/Content/Conversation.php:404
-#: src/Module/Calendar/Event/Form.php:239 src/Module/Post/Edit.php:181
+#: src/Module/Calendar/Event/Form.php:241 src/Module/Post/Edit.php:181
 msgid "Permissions"
 msgstr ""
 
@@ -584,7 +584,7 @@ msgid "Comment"
 msgstr ""
 
 #: mod/photos.php:1098 mod/photos.php:1154 mod/photos.php:1234
-#: src/Content/Conversation.php:416 src/Module/Calendar/Event/Form.php:234
+#: src/Content/Conversation.php:416 src/Module/Calendar/Event/Form.php:236
 #: src/Module/Item/Compose.php:200 src/Module/Post/Edit.php:163
 #: src/Object/Post.php:1180
 msgid "Preview"
@@ -2191,8 +2191,9 @@ msgid "Manage other accounts, including groups and pages"
 msgstr ""
 
 #: src/Content/Nav.php:324 src/Module/Admin/Addons/Details.php:140
-#: src/Module/Admin/Themes/Details.php:85 src/Module/BaseSettings.php:177
-#: src/Module/Welcome.php:39 view/theme/frio/theme.php:230
+#: src/Module/Admin/Themes/Details.php:85 src/Module/BaseAdmin.php:88
+#: src/Module/BaseSettings.php:177 src/Module/Welcome.php:39
+#: view/theme/frio/theme.php:230
 msgid "Settings"
 msgstr ""
 
@@ -4129,9 +4130,8 @@ msgstr ""
 msgid "PHP log currently disabled."
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:75 src/Module/BaseAdmin.php:87
-#: src/Module/BaseAdmin.php:88
-msgid "Logs"
+#: src/Module/Admin/Logs/Settings.php:75
+msgid "Log settings"
 msgstr ""
 
 #: src/Module/Admin/Logs/Settings.php:77
@@ -4178,7 +4178,7 @@ msgstr ""
 msgid "Couldn't open <strong>%1$s</strong> log file.<br/>Check to see if file %1$s is readable."
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:72 src/Module/BaseAdmin.php:89
+#: src/Module/Admin/Logs/View.php:72
 msgid "View Logs"
 msgstr ""
 
@@ -4215,7 +4215,7 @@ msgstr ""
 msgid "Click to view details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:84 src/Module/Calendar/Event/Form.php:193
+#: src/Module/Admin/Logs/View.php:84 src/Module/Calendar/Event/Form.php:195
 msgid "Event details"
 msgstr ""
 
@@ -4246,6 +4246,11 @@ msgstr ""
 
 #: src/Module/Admin/Logs/View.php:91
 msgid "Process ID"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:99
+#, php-format
+msgid "Current log path: %s"
 msgstr ""
 
 #: src/Module/Admin/Queue.php:36
@@ -4408,7 +4413,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:465 src/Module/Calendar/Event/Form.php:238
+#: src/Module/Admin/Site.php:465 src/Module/Calendar/Event/Form.php:240
 #: src/Module/Contact.php:532 src/Module/Profile/Profile.php:290
 msgid "Advanced"
 msgstr ""
@@ -5667,6 +5672,14 @@ msgstr ""
 msgid "Inspect worker Queue"
 msgstr ""
 
+#: src/Module/BaseAdmin.php:87
+msgid "Logs"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:89 src/Module/Calendar/Show.php:114
+msgid "View"
+msgstr ""
+
 #: src/Module/BaseAdmin.php:91 src/Module/BaseModeration.php:109
 msgid "Diagnostics"
 msgstr ""
@@ -5894,17 +5907,17 @@ msgstr ""
 msgid "Event title and start time are required."
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:194
+#: src/Module/Calendar/Event/Form.php:196
 msgid "Starting date and Title are required."
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:195
-#: src/Module/Calendar/Event/Form.php:200
+#: src/Module/Calendar/Event/Form.php:197
+#: src/Module/Calendar/Event/Form.php:202
 msgid "Event Starts:"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:195
-#: src/Module/Calendar/Event/Form.php:223 src/Module/Debug/Probe.php:45
+#: src/Module/Calendar/Event/Form.php:197
+#: src/Module/Calendar/Event/Form.php:225 src/Module/Debug/Probe.php:45
 #: src/Module/Install.php:186 src/Module/Install.php:212
 #: src/Module/Install.php:217 src/Module/Install.php:231
 #: src/Module/Install.php:240 src/Module/Install.php:245
@@ -5927,35 +5940,35 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:209
-#: src/Module/Calendar/Event/Form.php:233
+#: src/Module/Calendar/Event/Form.php:211
+#: src/Module/Calendar/Event/Form.php:235
 msgid "End date/time is unknown or irrelevant"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:211
-#: src/Module/Calendar/Event/Form.php:216
+#: src/Module/Calendar/Event/Form.php:213
+#: src/Module/Calendar/Event/Form.php:218
 msgid "Event ends:"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:223
-#: src/Module/Calendar/Event/Form.php:229
+#: src/Module/Calendar/Event/Form.php:225
+#: src/Module/Calendar/Event/Form.php:231
 msgid "Title (BBCode not allowed)"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:225
+#: src/Module/Calendar/Event/Form.php:227
 msgid "Description (BBCode allowed)"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:227
+#: src/Module/Calendar/Event/Form.php:229
 msgid "Location (BBCode not allowed)"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:230
-#: src/Module/Calendar/Event/Form.php:231
+#: src/Module/Calendar/Event/Form.php:232
+#: src/Module/Calendar/Event/Form.php:233
 msgid "Share this event"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:236 src/Module/Contact/Advanced.php:118
+#: src/Module/Calendar/Event/Form.php:238 src/Module/Contact/Advanced.php:118
 #: src/Module/Contact/Profile.php:415
 #: src/Module/Debug/ActivityPubConversion.php:128
 #: src/Module/Debug/Babel.php:280 src/Module/Debug/Localtime.php:50
@@ -5974,7 +5987,7 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:237 src/Module/Profile/Profile.php:289
+#: src/Module/Calendar/Event/Form.php:239 src/Module/Profile/Profile.php:289
 msgid "Basic"
 msgstr ""
 
@@ -5988,10 +6001,6 @@ msgstr ""
 
 #: src/Module/Calendar/Export.php:99
 msgid "calendar"
-msgstr ""
-
-#: src/Module/Calendar/Show.php:114
-msgid "View"
 msgstr ""
 
 #: src/Module/Calendar/Show.php:115

--- a/view/templates/admin/logs/settings.tpl
+++ b/view/templates/admin/logs/settings.tpl
@@ -6,16 +6,16 @@
   *}}
 <div id='adminpage'>
     <h1>{{$title}} - {{$page}}</h1>
-	
+
 	<form action="{{$baseurl}}/admin/logs" method="post">
 	    <input type='hidden' name='form_security_token' value="{{$form_security_token}}">
 
 	    {{include file="field_checkbox.tpl" field=$debugging}}
 	    {{include file="field_input.tpl" field=$logfile}}
 	    {{include file="field_select.tpl" field=$loglevel}}
-	
-	    <div class="submit"><input type="submit" name="page_logs" value="{{$submit}}" /></div>
-	
+
+			<div class="submit"><button type"submit" class="btn btn-primary" name="page_logs" value="{{$submit}}">{{$submit}}</button></div>
+
 	</form>
 
 	<h2>{{$phpheader}}</h2>
@@ -24,5 +24,5 @@
 		<p>{{$phphint}}</p>
 		<pre>{{$phplogcode}}</pre>
 	</div>
-	
+
 </div>

--- a/view/templates/admin/logs/view.tpl
+++ b/view/templates/admin/logs/view.tpl
@@ -7,7 +7,7 @@
 <div id="adminpage">
 	<h1>{{$title}} - {{$page}}</h1>
 
-	<h2>{{$logname}}</h2>
+	<p>{{$logname}}</p>
 	{{if $error }}
 		<div id="admin-error-message-wrapper" class="alert alert-warning">
 			<p>{{$error nofilter}}</p>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -933,7 +933,7 @@ nav.navbar .nav > li > button:focus {
 	font-size: 1.6em;
 }
 
-#nav-search-input-field {
+#search-box #nav-search-input-field {
 	width: 296px;
 }
 
@@ -3595,6 +3595,10 @@ li.addon {
 #adminpage h2 {
 	word-break: break-all;
 }
+#adminpage .form-group-search {
+	display: flex;
+	align-items: center;
+}
 #adminpage .table-logs thead tr {
 	display: grid;
 	grid-auto-flow: row;
@@ -3612,6 +3616,10 @@ li.addon {
 }
 #logdetail td.log-message {
 	width: 80%;
+}
+#adminpage #nav-search-input-field {
+	display: inline;
+	max-width: 296px;
 }
 @media (min-width: 600px) {
 	#adminpage .table-logs thead tr {

--- a/view/theme/frio/templates/admin/logs/view.tpl
+++ b/view/theme/frio/templates/admin/logs/view.tpl
@@ -7,24 +7,22 @@
 <div id="adminpage">
 	<h1>{{$title}} - {{$page}}</h1>
 
-	<h2>{{$logname}}</h2>
+	<p>{{$logname}}</p>
 	{{if $error }}
 		<div id="admin-error-message-wrapper" class="alert alert-warning">
 			<p>{{$error nofilter}}</p>
 		</div>
 	{{else}}
 		<form method="get" class="row">
-			<div class="col-xs-8">
-				<div class="form-group form-group-search">
+			<div class="col-xs-12">
+				<div id="admin-logs-search" class="form-group form-group-search">
 					<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
 						type="text" name="q" data-toggle="tooltip" title="{{$l10n.Search_in_logs}}"
 						placeholder="{{$l10n.Search}}" value="{{$q}}">
-					<button class="btn btn-default btn-sm form-button-search"
-						type="submit">{{$l10n.Search}}</button>
+					<button class="btn btn-lg btn-primary"
+						type="submit"><i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i></button>
+						<a href="{{$baseurl}}/admin/logs/view" class="btn btn-default">{{$l10n.Show_all}}</a>
 				</div>
-			</div>
-			<div class="xol-xs-4">
-				<a href="{{$baseurl}}/admin/logs/view" class="btn btn-default">{{$l10n.Show_all}}</a>
 			</div>
 		</form>
 


### PR DESCRIPTION
Makes small adjustments to admin logs:

- Rename "Logs" -> "Settings"
- Rename "View logs" -> "View"
- Standard styling of the "Save changes" button
- Make some buttons larger and the search button and icon instead of text, matching the global search button more
- Reduce gigantic font size on the current log path, and add text explaining what it is

Does *not* fix that the log table headings currently don't align with the table content, though really that should be fixed at some point.

# After

<img width="282" height="142" alt="image" src="https://github.com/user-attachments/assets/d9bb0065-42bf-43a5-9ec9-7f514b50d27d" />

<img width="631" height="303" alt="image" src="https://github.com/user-attachments/assets/f1bf2ffe-ce91-4a42-9176-e24a1d036a47" />

<img width="631" height="303" alt="image" src="https://github.com/user-attachments/assets/a085abf4-a3a6-4c31-bcfa-38b133ed4082" />