### PR TITLE
Fix: Prevent not nullable fields set to null

### DIFF
--- a/src/Database/Definition/DbaDefinition.php
+++ b/src/Database/Definition/DbaDefinition.php
@@ -70,7 +70,7 @@ class DbaDefinition
 
 		// Assign all field that are present in the table
 		foreach ($fieldNames as $field) {
-			if (array_key_exists($field, $data)) {
+			if (isset($data[$field]) || (!isset($definition[$table]['fields'][$field]['not null']) && array_key_exists($field, $data))) {
 				// Limit the length of varchar, varbinary, char and binary fields
 				if (is_string($data[$field]) && preg_match("/char\((\d*)\)/", $definition[$table]['fields'][$field]['type'], $result)) {
 					if ($charset == 'latin1') {


### PR DESCRIPTION
This fixes the database error `DB Error {"code":1048,"error":"Column 'location' cannot be null"` that had been introduced as a side effect to one of the last PR.

We now check if the field is nullable. And only then `null` values will be allowed.