### PR TITLE
Don't set "mention" on view / don't display channels on "mention" timeline

### DIFF
--- a/src/Model/ItemHelper.php
+++ b/src/Model/ItemHelper.php
@@ -357,7 +357,7 @@ final class ItemHelper
 		}
 
 		// If its a post that originated here then tag the thread as "mention"
-		if ($item['origin'] && $item['uid']) {
+		if ($item['origin'] && $item['uid'] && $item['verb'] !== Activity::VIEW) {
 			$this->database->update('post-thread-user', ['mention' => true], ['uri-id' => $item['parent-uri-id'], 'uid' => $item['uid']]);
 			$this->logger->info('tagged thread as mention', ['parent' => $parent_id, 'parent-uri-id' => $item['parent-uri-id'], 'uid' => $item['uid']]);
 		}

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -561,11 +561,14 @@ class Network extends Timeline
 
 		$systemchannels = [];
 		$userchannels   = [];
-		foreach ($this->pConfig->get($this->session->getLocalUserId(), 'channel', 'timeline_channels') ?? [] as $channel) {
-			if (is_numeric($channel)) {
-				$userchannels[] = (int)$channel;
-			} else {
-				$systemchannels[] = $channel;
+
+		if (!$this->mention && !$this->star) {
+			foreach ($this->pConfig->get($this->session->getLocalUserId(), 'channel', 'timeline_channels') ?? [] as $channel) {
+				if (is_numeric($channel)) {
+					$userchannels[] = (int)$channel;
+				} else {
+					$systemchannels[] = $channel;
+				}
 			}
 		}
 


### PR DESCRIPTION
This fixes two "mention" related problems:
1. The "mention" timeline should only contain posts where the user participated. The mixing with other channels shouldn't happen here.
2. "mention" should only be set when the user really interacted, but not with "view" activities.