### PR TITLE
Don't copy permissions when permissions are already defined

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -631,7 +631,8 @@ class Item
 
 		$priority = Worker::PRIORITY_HIGH;
 
-		$copy_permissions = false;
+		$copy_permissions    = false;
+		$defined_permissions = isset($item['allow_cid']) && isset($item['allow_gid']) && isset($item['deny_cid']) && isset($item['deny_gid']) && isset($item['private']);
 
 		// If it is a posting where users should get notifications, then define it as wall posting
 		if ($notify) {
@@ -643,8 +644,12 @@ class Item
 			}
 
 			// Mastodon style API visibility
-			$copy_permissions = ($item['visibility'] ?? 'private') == 'private';
-			unset($item['visibility']);
+			if (isset($item['visibility'])) {
+				$copy_permissions = $item['visibility'] === 'private';
+				unset($item['visibility']);
+			} else {
+				$copy_permissions = !$defined_permissions;
+			}
 		} else {
 			$item['network'] = trim(($item['network'] ?? '') ?: Protocol::PHANTOM);
 		}
@@ -677,8 +682,6 @@ class Item
 		if (!isset($item['post-type'])) {
 			$item['post-type'] = empty($item['title']) ? self::PT_NOTE : self::PT_ARTICLE;
 		}
-
-		$defined_permissions = isset($item['allow_cid']) && isset($item['allow_gid']) && isset($item['deny_cid']) && isset($item['deny_gid']) && isset($item['private']);
 
 		$uid = intval($item['uid']);
 

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -217,7 +217,6 @@ class Statuses extends BaseApi
 		$item['body']       = $this->formatStatus($request['status'], $uid);
 		$item['app']        = $this->getApp();
 		$item['sensitive']  = $request['sensitive'];
-		$item['visibility'] = $request['visibility'];
 
 		switch ($request['visibility']) {
 			case 'public':
@@ -238,11 +237,15 @@ class Statuses extends BaseApi
 				if ($request['in_reply_to_id']) {
 					$parent_item = Post::selectFirst(Item::ITEM_FIELDLIST, ['uri-id' => $request['in_reply_to_id'], 'uid' => $uid, 'private' => Item::PRIVATE]);
 					if (!empty($parent_item)) {
-						$item['allow_cid'] = $parent_item['allow_cid'];
-						$item['allow_gid'] = $parent_item['allow_gid'];
-						$item['deny_cid']  = $parent_item['deny_cid'];
-						$item['deny_gid']  = $parent_item['deny_gid'];
-						$item['private']   = $parent_item['private'];
+						// When 'visibility' is set to 'private' we want the permissions be copied from the parent post in the "insert" function.
+						// But this must only happen when the parent post was private as well.
+						// In all other cases we want to keep the permissions we defined here. The copying is controlled via the 'visibility' field.
+						$item['visibility'] = $request['visibility'];
+						$item['allow_cid']  = $parent_item['allow_cid'];
+						$item['allow_gid']  = $parent_item['allow_gid'];
+						$item['deny_cid']   = $parent_item['deny_cid'];
+						$item['deny_gid']   = $parent_item['deny_gid'];
+						$item['private']    = $parent_item['private'];
 						break;
 					}
 				}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -891,13 +891,13 @@ class Transmitter
 	 * Store the receivers for the given item
 	 *
 	 * @param array $item
-	 * @return void
+	 * @return array List of receiers
 	 */
-	public static function storeReceiversForItem(array $item)
+	public static function storeReceiversForItem(array $item): array
 	{
 		$receivers = self::createPermissionBlockForItem($item, true);
 		if (empty($receivers)) {
-			return;
+			return [];
 		}
 
 		foreach (['to' => Tag::TO, 'cc' => Tag::CC, 'bto' => Tag::BTO, 'bcc' => Tag::BCC, 'audience' => Tag::AUDIENCE] as $element => $type) {
@@ -912,6 +912,7 @@ class Transmitter
 				}
 			}
 		}
+		return $receivers;
 	}
 
 	/**


### PR DESCRIPTION
We already technically support sending comments and activities with differing circles than the post they are reacting on. This currently can't be done via web frontend but we already supported this behaviour via API for some time.

This PR now ensures that the permissions will be handled in an expected way as well, when we won't work via API but wanted to change the permissions of an answer via coding or some future changes. That means that in a case of differing circles we won't copy the permissions from the post we are reacting on. 