### PR TITLE
Photo upload to album doesn't ask for album anymore when already viewing one / Fix for Redirect to empty Page when album is deleted

### DIFF
--- a/mod/photos.php
+++ b/mod/photos.php
@@ -160,13 +160,13 @@ function photos_post()
 
 	if (DI::args()->getArgc() > 3 && DI::args()->getArgv()[2] === 'album') {
 		if (!Strings::isHex(DI::args()->getArgv()[3] ?? '')) {
-			DI::baseUrl()->redirect('photos/' . $user['nickname'] . '/album');
+			DI::baseUrl()->redirect('profile/' . $user['nickname'] . '/photos');
 		}
 		$album = hex2bin(DI::args()->getArgv()[3]);
 
 		if (!DBA::exists('photo', ['album' => $album, 'uid' => $page_owner_uid, 'photo-type' => Photo::DEFAULT])) {
 			DI::sysmsg()->addNotice(DI::l10n()->t('Album not found.'));
-			DI::baseUrl()->redirect('photos/' . $user['nickname'] . '/album');
+			DI::baseUrl()->redirect('profile/' . $user['nickname'] . '/photos');
 			return; // NOTREACHED
 		}
 
@@ -227,7 +227,7 @@ function photos_post()
 			}
 		}
 
-		DI::baseUrl()->redirect('photos/' . $user['nickname'] . '/album');
+		DI::baseUrl()->redirect('profile/' . $user['nickname'] . '/photos');
 	}
 
 	if (DI::args()->getArgc() > 3 && DI::args()->getArgv()[2] === 'image') {
@@ -712,7 +712,7 @@ function photos_content()
 	if ($datatype === 'album') {
 		// if $datum is not a valid hex, redirect to the default page
 		if (is_null($datum) || !Strings::isHex($datum)) {
-			DI::baseUrl()->redirect('photos/' . $user['nickname'] . '/album');
+			DI::baseUrl()->redirect('profile/' . $user['nickname'] . '/photos');
 		}
 		$album = hex2bin($datum);
 

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -654,9 +654,12 @@ function photos_content()
 			new ArrayFilterEvent(ArrayFilterEvent::PHOTO_UPLOAD_FORM, $ret)
 		);
 
+		// Determine if we're in album context (uploading to a specific album)
+		$is_album_context = !empty($selname);
+
 		$default_upload_box    = Renderer::replaceMacros(Renderer::getMarkupTemplate('photos_default_uploader_box.tpl'), []);
 		$default_upload_submit = Renderer::replaceMacros(Renderer::getMarkupTemplate('photos_default_uploader_submit.tpl'), [
-			'$submit' => DI::l10n()->t('Upload selected photo'),
+			'$submit' => $is_album_context ? DI::l10n()->t('Upload photo to this album') : DI::l10n()->t('Upload selected photo'),
 		]);
 
 		// Get the relevant size limits for uploads. Abbreviated var names: MaxImageSize -> mis; upload_max_filesize -> umf
@@ -679,7 +682,7 @@ function photos_content()
 		$aclselect_e = ($visitor ? '' : ACL::getFullSelectorHTML(DI::page(), DI::userSession()->getLocalUserId()));
 
 		$o .= Renderer::replaceMacros($tpl, [
-			'$pagename'              => DI::l10n()->t('Upload photo'),
+			'$pagename'              => $is_album_context ? DI::l10n()->t('Upload Photos to %s', $selname) : DI::l10n()->t('Upload Photos'),
 			'$sessid'                => session_id(),
 			'$usage'                 => $usage_message,
 			'$nickname'              => $user['nickname'],
@@ -695,6 +698,8 @@ function photos_content()
 			'$default_upload_box'    => ($ret['default_upload'] ? $default_upload_box : ''),
 			'$default_upload_submit' => ($ret['default_upload'] ? $default_upload_submit : ''),
 			'$uploadurl'             => $ret['post_url'],
+			'$is_album_context'      => $is_album_context,
+			'$preselected_album'     => $selname,
 
 			// ACL permissions box
 			'$return_path' => DI::args()->getQueryString(),

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-17 11:01+0100\n"
+"POT-Creation-Date: 2026-02-17 11:08+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -274,7 +274,8 @@ msgstr ""
 
 #: mod/message.php:188 mod/message.php:345 mod/photos.php:91 mod/photos.php:831
 #: src/Content/Conversation.php:371 src/Module/Post/Edit.php:129
-#: src/Module/Profile/Photos.php:442 src/Module/Profile/Photos.php:445
+#: src/Module/Profile/Photos.php:422 src/Module/Profile/Photos.php:442
+#: src/Module/Profile/Photos.php:445
 msgid "Upload photo"
 msgstr ""
 
@@ -441,16 +442,16 @@ msgstr ""
 msgid "Upload Photos to %s"
 msgstr ""
 
-#: mod/photos.php:685 src/Module/Profile/Photos.php:422
+#: mod/photos.php:685
 msgid "Upload Photos"
 msgstr ""
 
-#: mod/photos.php:689 mod/photos.php:780
-msgid "New album name: "
+#: mod/photos.php:689
+msgid "Album name: "
 msgstr ""
 
 #: mod/photos.php:690
-msgid "or select existing album:"
+msgid "If you want to add this photo to an album, begin typing its name, and existing albums will be suggested, which you can select. If you choose something new, it will be created."
 msgstr ""
 
 #: mod/photos.php:691
@@ -478,6 +479,10 @@ msgstr ""
 #: src/Module/Post/Tag/Remove.php:96 src/Module/Profile/RemoteFollow.php:120
 #: src/Module/Security/TwoFactor/SignOut.php:106
 msgid "Cancel"
+msgstr ""
+
+#: mod/photos.php:780
+msgid "New album name: "
 msgstr ""
 
 #: mod/photos.php:784 mod/photos.php:1060
@@ -750,7 +755,7 @@ msgstr ""
 msgid "toggle mobile"
 msgstr ""
 
-#: src/App/Page.php:356 src/Module/Admin/Logs/View.php:92
+#: src/App/Page.php:356 src/Module/Admin/Logs/View.php:91
 #: src/Module/Media/Attachment/Browser.php:69
 #: src/Module/Media/Photo/Browser.php:81 view/theme/frio/php/minimal.php:39
 #: view/theme/frio/php/standard.php:138
@@ -1381,7 +1386,7 @@ msgstr ""
 
 #: src/Content/Conversation.php:426 src/Content/Item.php:442
 #: src/Content/Widget/VCard.php:120 src/Model/Contact.php:1307
-#: src/Model/Profile.php:460 src/Module/Admin/Logs/View.php:80
+#: src/Model/Profile.php:460 src/Module/Admin/Logs/View.php:79
 #: src/Module/Post/Edit.php:179
 msgid "Message"
 msgstr ""
@@ -1858,7 +1863,7 @@ msgstr ""
 msgid "Find groups to join"
 msgstr ""
 
-#: src/Content/Item.php:336 src/Model/Item.php:2841
+#: src/Content/Item.php:336 src/Model/Item.php:2858
 msgid "event"
 msgstr ""
 
@@ -1866,7 +1871,7 @@ msgstr ""
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:345 src/Model/Item.php:2843
+#: src/Content/Item.php:345 src/Model/Item.php:2860
 #: src/Module/Post/Tag/Add.php:112
 msgid "photo"
 msgstr ""
@@ -2089,7 +2094,7 @@ msgid "Addon applications, utilities, games"
 msgstr ""
 
 #: src/Content/Nav.php:266 src/Content/Text/HTML.php:862
-#: src/Module/Admin/Logs/View.php:74 src/Module/Search/Index.php:99
+#: src/Module/Search/Index.php:99
 msgid "Search"
 msgstr ""
 
@@ -2203,8 +2208,9 @@ msgid "Manage other accounts, including groups and pages"
 msgstr ""
 
 #: src/Content/Nav.php:324 src/Module/Admin/Addons/Details.php:140
-#: src/Module/Admin/Themes/Details.php:85 src/Module/BaseSettings.php:177
-#: src/Module/Welcome.php:39 view/theme/frio/theme.php:230
+#: src/Module/Admin/Themes/Details.php:85 src/Module/BaseAdmin.php:88
+#: src/Module/BaseSettings.php:177 src/Module/Welcome.php:39
+#: view/theme/frio/theme.php:230
 msgid "Settings"
 msgstr ""
 
@@ -2274,8 +2280,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3731
-#: src/Model/Item.php:3737 src/Model/Item.php:3738
+#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3751
+#: src/Model/Item.php:3757 src/Model/Item.php:3758
 msgid "Link to source"
 msgstr ""
 
@@ -2393,7 +2399,7 @@ msgstr ""
 msgid "Relationships"
 msgstr ""
 
-#: src/Content/Widget.php:273 src/Module/Circle.php:282
+#: src/Content/Widget.php:273 src/Module/Circle.php:293
 #: src/Module/Contact.php:329
 msgid "All Contacts"
 msgstr ""
@@ -3218,7 +3224,7 @@ msgstr ""
 msgid "Edit circle"
 msgstr ""
 
-#: src/Model/Circle.php:592 src/Module/Circle.php:186
+#: src/Model/Circle.php:592 src/Module/Circle.php:184
 msgid "Contacts not in any circle"
 msgstr ""
 
@@ -3226,8 +3232,8 @@ msgstr ""
 msgid "Create a new circle"
 msgstr ""
 
-#: src/Model/Circle.php:595 src/Module/Circle.php:169 src/Module/Circle.php:191
-#: src/Module/Circle.php:266
+#: src/Model/Circle.php:595 src/Module/Circle.php:167 src/Module/Circle.php:189
+#: src/Module/Circle.php:275
 msgid "Circle Name: "
 msgstr ""
 
@@ -3420,84 +3426,84 @@ msgstr ""
 msgid "Happy Birthday %s"
 msgstr ""
 
-#: src/Model/Item.php:2845
+#: src/Model/Item.php:2862
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2847
+#: src/Model/Item.php:2864
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2850 src/Module/Post/Tag/Add.php:112
+#: src/Model/Item.php:2867 src/Module/Post/Tag/Add.php:112
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3039
+#: src/Model/Item.php:3059
 #, php-format
 msgid "%s is blocked"
 msgstr ""
 
-#: src/Model/Item.php:3041
+#: src/Model/Item.php:3061
 #, php-format
 msgid "%s is ignored"
 msgstr ""
 
-#: src/Model/Item.php:3043
+#: src/Model/Item.php:3063
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:3047
+#: src/Model/Item.php:3067
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3601
+#: src/Model/Item.php:3621
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3635
+#: src/Model/Item.php:3655
 #, php-format
 msgid "The media in this post is not displayed to visitors. To view it, please go to the <a href=\"%s\">original post</a>."
 msgstr ""
 
-#: src/Model/Item.php:3637
+#: src/Model/Item.php:3657
 msgid "The media in this post is not displayed to visitors. To view it, please log in."
 msgstr ""
 
-#: src/Model/Item.php:3662
+#: src/Model/Item.php:3682
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3664
+#: src/Model/Item.php:3684
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3669
+#: src/Model/Item.php:3689
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3671
+#: src/Model/Item.php:3691
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3673
+#: src/Model/Item.php:3693
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3714 src/Model/Item.php:3715
+#: src/Model/Item.php:3734 src/Model/Item.php:3735
 msgid "View on separate page"
 msgstr ""
 
@@ -4141,9 +4147,8 @@ msgstr ""
 msgid "PHP log currently disabled."
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:75 src/Module/BaseAdmin.php:87
-#: src/Module/BaseAdmin.php:88
-msgid "Logs"
+#: src/Module/Admin/Logs/Settings.php:75
+msgid "Log settings"
 msgstr ""
 
 #: src/Module/Admin/Logs/Settings.php:77
@@ -4190,74 +4195,79 @@ msgstr ""
 msgid "Couldn't open <strong>%1$s</strong> log file.<br/>Check to see if file %1$s is readable."
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:72 src/Module/BaseAdmin.php:89
+#: src/Module/Admin/Logs/View.php:72
 msgid "View Logs"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:75
+#: src/Module/Admin/Logs/View.php:74
 msgid "Search in logs"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:76
+#: src/Module/Admin/Logs/View.php:75
 #: src/Module/Notifications/Notifications.php:134
 msgid "Show all"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:77
+#: src/Module/Admin/Logs/View.php:76
 msgid "Date"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:78
+#: src/Module/Admin/Logs/View.php:77
 msgid "Level"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:79
+#: src/Module/Admin/Logs/View.php:78
 msgid "Context"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:81
+#: src/Module/Admin/Logs/View.php:80
 msgid "ALL"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:82
+#: src/Module/Admin/Logs/View.php:81
 msgid "View details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:83
+#: src/Module/Admin/Logs/View.php:82
 msgid "Click to view details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:84 src/Module/Calendar/Event/Form.php:195
+#: src/Module/Admin/Logs/View.php:83 src/Module/Calendar/Event/Form.php:195
 msgid "Event details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:85
+#: src/Module/Admin/Logs/View.php:84
 msgid "Data"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:86
+#: src/Module/Admin/Logs/View.php:85
 #: src/Module/Debug/ActivityPubConversion.php:49
 msgid "Source"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:87
+#: src/Module/Admin/Logs/View.php:86
 msgid "File"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:88
+#: src/Module/Admin/Logs/View.php:87
 msgid "Line"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:89
+#: src/Module/Admin/Logs/View.php:88
 msgid "Function"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:90
+#: src/Module/Admin/Logs/View.php:89
 msgid "UID"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:91
+#: src/Module/Admin/Logs/View.php:90
 msgid "Process ID"
+msgstr ""
+
+#: src/Module/Admin/Logs/View.php:98
+#, php-format
+msgid "Current log path: %s"
 msgstr ""
 
 #: src/Module/Admin/Queue.php:36
@@ -5679,6 +5689,14 @@ msgstr ""
 msgid "Inspect worker Queue"
 msgstr ""
 
+#: src/Module/BaseAdmin.php:87
+msgid "Logs"
+msgstr ""
+
+#: src/Module/BaseAdmin.php:89 src/Module/Calendar/Show.php:114
+msgid "View"
+msgstr ""
+
 #: src/Module/BaseAdmin.php:91 src/Module/BaseModeration.php:109
 msgid "Diagnostics"
 msgstr ""
@@ -5704,7 +5722,7 @@ msgid "ActivityPub Conversion"
 msgstr ""
 
 #: src/Module/BaseAdmin.php:115
-msgid "Addon Features"
+msgid "Addon settings"
 msgstr ""
 
 #: src/Module/BaseAdmin.php:116 src/Module/BaseModeration.php:118
@@ -6002,10 +6020,6 @@ msgstr ""
 msgid "calendar"
 msgstr ""
 
-#: src/Module/Calendar/Show.php:114
-msgid "View"
-msgstr ""
-
 #: src/Module/Calendar/Show.php:115
 msgid "New Event"
 msgstr ""
@@ -6018,7 +6032,7 @@ msgstr ""
 msgid "Could not create circle."
 msgstr ""
 
-#: src/Module/Circle.php:54 src/Module/Circle.php:204 src/Module/Circle.php:228
+#: src/Module/Circle.php:54 src/Module/Circle.php:202 src/Module/Circle.php:237
 msgid "Circle not found."
 msgstr ""
 
@@ -6072,47 +6086,51 @@ msgstr ""
 msgid "Bad request."
 msgstr ""
 
-#: src/Module/Circle.php:161
+#: src/Module/Circle.php:159
 msgid "Save Circle"
 msgstr ""
 
-#: src/Module/Circle.php:162
+#: src/Module/Circle.php:160
 msgid "Filter"
 msgstr ""
 
-#: src/Module/Circle.php:168
+#: src/Module/Circle.php:166
 msgid "Create a circle of contacts/friends."
 msgstr ""
 
-#: src/Module/Circle.php:209
+#: src/Module/Circle.php:207
 msgid "Unable to remove circle."
 msgstr ""
 
-#: src/Module/Circle.php:260
+#: src/Module/Circle.php:269
 msgid "Delete Circle"
 msgstr ""
 
-#: src/Module/Circle.php:270
+#: src/Module/Circle.php:280
 msgid "Edit Circle Name"
 msgstr ""
 
-#: src/Module/Circle.php:280
+#: src/Module/Circle.php:281
+msgid "Mark all as read"
+msgstr ""
+
+#: src/Module/Circle.php:291
 msgid "Members"
 msgstr ""
 
-#: src/Module/Circle.php:283
+#: src/Module/Circle.php:294
 msgid "Circle is empty"
 msgstr ""
 
-#: src/Module/Circle.php:299
+#: src/Module/Circle.php:310
 msgid "Remove contact from circle"
 msgstr ""
 
-#: src/Module/Circle.php:322
+#: src/Module/Circle.php:333
 msgid "Click on a contact to add or remove."
 msgstr ""
 
-#: src/Module/Circle.php:339
+#: src/Module/Circle.php:351
 msgid "Add contact to circle"
 msgstr ""
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-15 19:40+0100\n"
+"POT-Creation-Date: 2026-02-17 11:01+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -272,9 +272,8 @@ msgstr ""
 msgid "Your message:"
 msgstr ""
 
-#: mod/message.php:188 mod/message.php:345 mod/photos.php:91 mod/photos.php:682
-#: mod/photos.php:826 src/Content/Conversation.php:371
-#: src/Module/Post/Edit.php:129 src/Module/Profile/Photos.php:422
+#: mod/message.php:188 mod/message.php:345 mod/photos.php:91 mod/photos.php:831
+#: src/Content/Conversation.php:371 src/Module/Post/Edit.php:129
 #: src/Module/Profile/Photos.php:442 src/Module/Profile/Photos.php:445
 msgid "Upload photo"
 msgstr ""
@@ -283,7 +282,7 @@ msgstr ""
 msgid "Insert web link"
 msgstr ""
 
-#: mod/message.php:190 mod/message.php:348 mod/photos.php:1256
+#: mod/message.php:190 mod/message.php:348 mod/photos.php:1261
 #: src/Content/Conversation.php:402 src/Content/Conversation.php:1611
 #: src/Module/Item/Compose.php:205 src/Module/Post/Edit.php:143
 #: src/Object/Post.php:621
@@ -424,41 +423,54 @@ msgstr ""
 msgid "No photos selected"
 msgstr ""
 
-#: mod/photos.php:659
+#: mod/photos.php:662
+msgid "Upload photo to this album"
+msgstr ""
+
+#: mod/photos.php:662
 msgid "Upload selected photo"
 msgstr ""
 
-#: mod/photos.php:675
+#: mod/photos.php:678
 #, php-format
 msgid "The maximum accepted image size is %s"
 msgstr ""
 
-#: mod/photos.php:686
-msgid "Album name: "
+#: mod/photos.php:685
+#, php-format
+msgid "Upload Photos to %s"
 msgstr ""
 
-#: mod/photos.php:687
-msgid "If you want to add this photo to an album, begin typing its name, and existing albums will be suggested, which you can select. If you choose something new, it will be created."
+#: mod/photos.php:685 src/Module/Profile/Photos.php:422
+msgid "Upload Photos"
 msgstr ""
 
-#: mod/photos.php:688
+#: mod/photos.php:689 mod/photos.php:780
+msgid "New album name: "
+msgstr ""
+
+#: mod/photos.php:690
+msgid "or select existing album:"
+msgstr ""
+
+#: mod/photos.php:691
 msgid "Do not show a status post for this upload"
 msgstr ""
 
-#: mod/photos.php:691 mod/photos.php:1051 src/Content/Conversation.php:404
+#: mod/photos.php:694 mod/photos.php:1056 src/Content/Conversation.php:404
 #: src/Module/Calendar/Event/Form.php:241 src/Module/Post/Edit.php:181
 msgid "Permissions"
 msgstr ""
 
-#: mod/photos.php:756
+#: mod/photos.php:761
 msgid "Do you really want to delete this photo album and all its photos?"
 msgstr ""
 
-#: mod/photos.php:757
+#: mod/photos.php:762
 msgid "Delete Album"
 msgstr ""
 
-#: mod/photos.php:758 mod/photos.php:857 src/Content/Conversation.php:419
+#: mod/photos.php:763 mod/photos.php:862 src/Content/Conversation.php:419
 #: src/Module/Contact/Follow.php:158 src/Module/Contact/Revoke.php:92
 #: src/Module/Contact/Unfollow.php:112
 #: src/Module/Media/Attachment/Browser.php:64
@@ -468,143 +480,139 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: mod/photos.php:775
-msgid "New album name: "
-msgstr ""
-
-#: mod/photos.php:779 mod/photos.php:1055
+#: mod/photos.php:784 mod/photos.php:1060
 #: src/Module/Settings/Server/Index.php:98
 msgid "Save changes"
 msgstr ""
 
-#: mod/photos.php:783
+#: mod/photos.php:788
 msgid "Edit Album"
 msgstr ""
 
-#: mod/photos.php:784
+#: mod/photos.php:789
 msgid "Delete album"
 msgstr ""
 
-#: mod/photos.php:788
+#: mod/photos.php:793
 msgid "Show Newest First"
 msgstr ""
 
-#: mod/photos.php:790
+#: mod/photos.php:795
 msgid "Show Oldest First"
 msgstr ""
 
-#: mod/photos.php:811 src/Module/Profile/Photos.php:390
+#: mod/photos.php:816 src/Module/Profile/Photos.php:390
 msgid "View Photo"
 msgstr ""
 
-#: mod/photos.php:843
+#: mod/photos.php:848
 msgid "Permission denied. Access to this item may be restricted."
 msgstr ""
 
-#: mod/photos.php:845
+#: mod/photos.php:850
 msgid "Photo not available"
 msgstr ""
 
-#: mod/photos.php:855
+#: mod/photos.php:860
 msgid "Do you really want to delete this photo?"
 msgstr ""
 
-#: mod/photos.php:856 mod/photos.php:1056
+#: mod/photos.php:861 mod/photos.php:1061
 msgid "Delete Photo"
 msgstr ""
 
-#: mod/photos.php:954
+#: mod/photos.php:959
 msgid "View photo"
 msgstr ""
 
-#: mod/photos.php:956
+#: mod/photos.php:961
 msgid "Edit photo"
 msgstr ""
 
-#: mod/photos.php:957
+#: mod/photos.php:962
 msgid "Delete photo"
 msgstr ""
 
-#: mod/photos.php:958 mod/photos.php:1280
+#: mod/photos.php:963 mod/photos.php:1285
 msgid "Use as profile picture"
 msgstr ""
 
-#: mod/photos.php:965
+#: mod/photos.php:970
 msgid "Private Photo"
 msgstr ""
 
-#: mod/photos.php:971
+#: mod/photos.php:976
 msgid "View Full Size"
 msgstr ""
 
-#: mod/photos.php:1024 src/Content/Nav.php:270 src/Content/Text/HTML.php:872
+#: mod/photos.php:1029 src/Content/Nav.php:270 src/Content/Text/HTML.php:872
 #: src/Content/Widget/TagCloud.php:54
 msgid "Tags"
 msgstr ""
 
-#: mod/photos.php:1027
+#: mod/photos.php:1032
 msgid "[Select tags to remove]"
 msgstr ""
 
-#: mod/photos.php:1042
+#: mod/photos.php:1047
 msgid "New album name"
 msgstr ""
 
-#: mod/photos.php:1043
+#: mod/photos.php:1048
 msgid "Caption"
 msgstr ""
 
-#: mod/photos.php:1044
+#: mod/photos.php:1049
 msgid "Add a Tag"
 msgstr ""
 
-#: mod/photos.php:1044
+#: mod/photos.php:1049
 msgid "Example: @bob, @Barbara_Jensen, @jim@example.com, #California, #camping"
 msgstr ""
 
-#: mod/photos.php:1045
+#: mod/photos.php:1050
 msgid "Do not rotate"
 msgstr ""
 
-#: mod/photos.php:1046
+#: mod/photos.php:1051
 msgid "Rotate CW (right)"
 msgstr ""
 
-#: mod/photos.php:1047
+#: mod/photos.php:1052
 msgid "Rotate CCW (left)"
 msgstr ""
 
-#: mod/photos.php:1094 mod/photos.php:1150 mod/photos.php:1230
+#: mod/photos.php:1099 mod/photos.php:1155 mod/photos.php:1235
 #: src/Module/Contact.php:609 src/Module/Item/Compose.php:187
 #: src/Object/Post.php:1164
 msgid "This is you"
 msgstr ""
 
-#: mod/photos.php:1096 mod/photos.php:1097 mod/photos.php:1152
-#: mod/photos.php:1153 mod/photos.php:1232 mod/photos.php:1233
+#: mod/photos.php:1101 mod/photos.php:1102 mod/photos.php:1157
+#: mod/photos.php:1158 mod/photos.php:1237 mod/photos.php:1238
 #: src/Module/Moderation/Reports.php:110 src/Object/Post.php:615
 #: src/Object/Post.php:1166
 msgid "Comment"
 msgstr ""
 
-#: mod/photos.php:1098 mod/photos.php:1154 mod/photos.php:1234
+#: mod/photos.php:1103 mod/photos.php:1159 mod/photos.php:1239
 #: src/Content/Conversation.php:416 src/Module/Calendar/Event/Form.php:236
 #: src/Module/Item/Compose.php:200 src/Module/Post/Edit.php:163
 #: src/Object/Post.php:1180
 msgid "Preview"
 msgstr ""
 
-#: mod/photos.php:1099 src/Content/Conversation.php:370 src/Content/Nav.php:113
+#: mod/photos.php:1104 src/Content/Conversation.php:370 src/Content/Nav.php:113
 #: src/Module/Post/Edit.php:128 src/Object/Post.php:1168
 msgid "Loading..."
 msgstr ""
 
-#: mod/photos.php:1191 src/Content/Conversation.php:1533
+#: mod/photos.php:1196 src/Content/Conversation.php:1533
 #: src/Object/Post.php:267
 msgid "Select"
 msgstr ""
 
-#: mod/photos.php:1192 mod/photos.php:1279 src/Content/Conversation.php:1534
+#: mod/photos.php:1197 mod/photos.php:1284 src/Content/Conversation.php:1534
 #: src/Module/Moderation/Users/Active.php:92
 #: src/Module/Moderation/Users/Blocked.php:92
 #: src/Module/Moderation/Users/Index.php:100
@@ -613,31 +621,31 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: mod/photos.php:1253 src/Object/Post.php:439
+#: mod/photos.php:1258 src/Object/Post.php:439
 msgid "Like"
 msgstr ""
 
-#: mod/photos.php:1254 src/Object/Post.php:439
+#: mod/photos.php:1259 src/Object/Post.php:439
 msgid "I like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1255 src/Object/Post.php:440
+#: mod/photos.php:1260 src/Object/Post.php:440
 msgid "Dislike"
 msgstr ""
 
-#: mod/photos.php:1257 src/Object/Post.php:440
+#: mod/photos.php:1262 src/Object/Post.php:440
 msgid "I don't like this (toggle)"
 msgstr ""
 
-#: mod/photos.php:1278 src/Object/Post.php:232 src/Object/Post.php:234
+#: mod/photos.php:1283 src/Object/Post.php:232 src/Object/Post.php:234
 msgid "Edit"
 msgstr ""
 
-#: mod/photos.php:1281
+#: mod/photos.php:1286
 msgid "Back to viewing"
 msgstr ""
 
-#: mod/photos.php:1283
+#: mod/photos.php:1288
 msgid "Map"
 msgstr ""
 
@@ -742,7 +750,7 @@ msgstr ""
 msgid "toggle mobile"
 msgstr ""
 
-#: src/App/Page.php:356 src/Module/Admin/Logs/View.php:91
+#: src/App/Page.php:356 src/Module/Admin/Logs/View.php:92
 #: src/Module/Media/Attachment/Browser.php:69
 #: src/Module/Media/Photo/Browser.php:81 view/theme/frio/php/minimal.php:39
 #: view/theme/frio/php/standard.php:138
@@ -1373,7 +1381,7 @@ msgstr ""
 
 #: src/Content/Conversation.php:426 src/Content/Item.php:442
 #: src/Content/Widget/VCard.php:120 src/Model/Contact.php:1307
-#: src/Model/Profile.php:460 src/Module/Admin/Logs/View.php:79
+#: src/Model/Profile.php:460 src/Module/Admin/Logs/View.php:80
 #: src/Module/Post/Edit.php:179
 msgid "Message"
 msgstr ""
@@ -1850,7 +1858,7 @@ msgstr ""
 msgid "Find groups to join"
 msgstr ""
 
-#: src/Content/Item.php:336 src/Model/Item.php:2844
+#: src/Content/Item.php:336 src/Model/Item.php:2841
 msgid "event"
 msgstr ""
 
@@ -1858,7 +1866,7 @@ msgstr ""
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:345 src/Model/Item.php:2846
+#: src/Content/Item.php:345 src/Model/Item.php:2843
 #: src/Module/Post/Tag/Add.php:112
 msgid "photo"
 msgstr ""
@@ -2081,7 +2089,7 @@ msgid "Addon applications, utilities, games"
 msgstr ""
 
 #: src/Content/Nav.php:266 src/Content/Text/HTML.php:862
-#: src/Module/Search/Index.php:99
+#: src/Module/Admin/Logs/View.php:74 src/Module/Search/Index.php:99
 msgid "Search"
 msgstr ""
 
@@ -2195,9 +2203,8 @@ msgid "Manage other accounts, including groups and pages"
 msgstr ""
 
 #: src/Content/Nav.php:324 src/Module/Admin/Addons/Details.php:140
-#: src/Module/Admin/Themes/Details.php:85 src/Module/BaseAdmin.php:88
-#: src/Module/BaseSettings.php:177 src/Module/Welcome.php:39
-#: view/theme/frio/theme.php:230
+#: src/Module/Admin/Themes/Details.php:85 src/Module/BaseSettings.php:177
+#: src/Module/Welcome.php:39 view/theme/frio/theme.php:230
 msgid "Settings"
 msgstr ""
 
@@ -2267,8 +2274,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3734
-#: src/Model/Item.php:3740 src/Model/Item.php:3741
+#: src/Content/Text/BBCode.php:945 src/Model/Item.php:3731
+#: src/Model/Item.php:3737 src/Model/Item.php:3738
 msgid "Link to source"
 msgstr ""
 
@@ -2386,7 +2393,7 @@ msgstr ""
 msgid "Relationships"
 msgstr ""
 
-#: src/Content/Widget.php:273 src/Module/Circle.php:300
+#: src/Content/Widget.php:273 src/Module/Circle.php:282
 #: src/Module/Contact.php:329
 msgid "All Contacts"
 msgstr ""
@@ -3211,7 +3218,7 @@ msgstr ""
 msgid "Edit circle"
 msgstr ""
 
-#: src/Model/Circle.php:592 src/Module/Circle.php:184
+#: src/Model/Circle.php:592 src/Module/Circle.php:186
 msgid "Contacts not in any circle"
 msgstr ""
 
@@ -3219,8 +3226,8 @@ msgstr ""
 msgid "Create a new circle"
 msgstr ""
 
-#: src/Model/Circle.php:595 src/Module/Circle.php:167 src/Module/Circle.php:189
-#: src/Module/Circle.php:282
+#: src/Model/Circle.php:595 src/Module/Circle.php:169 src/Module/Circle.php:191
+#: src/Module/Circle.php:266
 msgid "Circle Name: "
 msgstr ""
 
@@ -3413,84 +3420,84 @@ msgstr ""
 msgid "Happy Birthday %s"
 msgstr ""
 
-#: src/Model/Item.php:2848
+#: src/Model/Item.php:2845
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2850
+#: src/Model/Item.php:2847
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2853 src/Module/Post/Tag/Add.php:112
+#: src/Model/Item.php:2850 src/Module/Post/Tag/Add.php:112
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3042
+#: src/Model/Item.php:3039
 #, php-format
 msgid "%s is blocked"
 msgstr ""
 
-#: src/Model/Item.php:3044
+#: src/Model/Item.php:3041
 #, php-format
 msgid "%s is ignored"
 msgstr ""
 
-#: src/Model/Item.php:3046
+#: src/Model/Item.php:3043
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:3050
+#: src/Model/Item.php:3047
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3604
+#: src/Model/Item.php:3601
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3638
+#: src/Model/Item.php:3635
 #, php-format
 msgid "The media in this post is not displayed to visitors. To view it, please go to the <a href=\"%s\">original post</a>."
 msgstr ""
 
-#: src/Model/Item.php:3640
+#: src/Model/Item.php:3637
 msgid "The media in this post is not displayed to visitors. To view it, please log in."
 msgstr ""
 
-#: src/Model/Item.php:3665
+#: src/Model/Item.php:3662
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3667
+#: src/Model/Item.php:3664
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3672
+#: src/Model/Item.php:3669
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3674
+#: src/Model/Item.php:3671
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3676
+#: src/Model/Item.php:3673
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3717 src/Model/Item.php:3718
+#: src/Model/Item.php:3714 src/Model/Item.php:3715
 msgid "View on separate page"
 msgstr ""
 
@@ -4134,8 +4141,9 @@ msgstr ""
 msgid "PHP log currently disabled."
 msgstr ""
 
-#: src/Module/Admin/Logs/Settings.php:75
-msgid "Log settings"
+#: src/Module/Admin/Logs/Settings.php:75 src/Module/BaseAdmin.php:87
+#: src/Module/BaseAdmin.php:88
+msgid "Logs"
 msgstr ""
 
 #: src/Module/Admin/Logs/Settings.php:77
@@ -4182,79 +4190,74 @@ msgstr ""
 msgid "Couldn't open <strong>%1$s</strong> log file.<br/>Check to see if file %1$s is readable."
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:72
+#: src/Module/Admin/Logs/View.php:72 src/Module/BaseAdmin.php:89
 msgid "View Logs"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:74
+#: src/Module/Admin/Logs/View.php:75
 msgid "Search in logs"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:75
+#: src/Module/Admin/Logs/View.php:76
 #: src/Module/Notifications/Notifications.php:134
 msgid "Show all"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:76
+#: src/Module/Admin/Logs/View.php:77
 msgid "Date"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:77
+#: src/Module/Admin/Logs/View.php:78
 msgid "Level"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:78
+#: src/Module/Admin/Logs/View.php:79
 msgid "Context"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:80
+#: src/Module/Admin/Logs/View.php:81
 msgid "ALL"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:81
+#: src/Module/Admin/Logs/View.php:82
 msgid "View details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:82
+#: src/Module/Admin/Logs/View.php:83
 msgid "Click to view details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:83 src/Module/Calendar/Event/Form.php:195
+#: src/Module/Admin/Logs/View.php:84 src/Module/Calendar/Event/Form.php:195
 msgid "Event details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:84
+#: src/Module/Admin/Logs/View.php:85
 msgid "Data"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:85
+#: src/Module/Admin/Logs/View.php:86
 #: src/Module/Debug/ActivityPubConversion.php:49
 msgid "Source"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:86
+#: src/Module/Admin/Logs/View.php:87
 msgid "File"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:87
+#: src/Module/Admin/Logs/View.php:88
 msgid "Line"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:88
+#: src/Module/Admin/Logs/View.php:89
 msgid "Function"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:89
+#: src/Module/Admin/Logs/View.php:90
 msgid "UID"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:90
+#: src/Module/Admin/Logs/View.php:91
 msgid "Process ID"
-msgstr ""
-
-#: src/Module/Admin/Logs/View.php:98
-#, php-format
-msgid "Current log path: %s"
 msgstr ""
 
 #: src/Module/Admin/Queue.php:36
@@ -5676,14 +5679,6 @@ msgstr ""
 msgid "Inspect worker Queue"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:87
-msgid "Logs"
-msgstr ""
-
-#: src/Module/BaseAdmin.php:89 src/Module/Calendar/Show.php:114
-msgid "View"
-msgstr ""
-
 #: src/Module/BaseAdmin.php:91 src/Module/BaseModeration.php:109
 msgid "Diagnostics"
 msgstr ""
@@ -5709,7 +5704,7 @@ msgid "ActivityPub Conversion"
 msgstr ""
 
 #: src/Module/BaseAdmin.php:115
-msgid "Addon settings"
+msgid "Addon Features"
 msgstr ""
 
 #: src/Module/BaseAdmin.php:116 src/Module/BaseModeration.php:118
@@ -6007,6 +6002,10 @@ msgstr ""
 msgid "calendar"
 msgstr ""
 
+#: src/Module/Calendar/Show.php:114
+msgid "View"
+msgstr ""
+
 #: src/Module/Calendar/Show.php:115
 msgid "New Event"
 msgstr ""
@@ -6019,7 +6018,7 @@ msgstr ""
 msgid "Could not create circle."
 msgstr ""
 
-#: src/Module/Circle.php:54 src/Module/Circle.php:202 src/Module/Circle.php:244
+#: src/Module/Circle.php:54 src/Module/Circle.php:204 src/Module/Circle.php:228
 msgid "Circle not found."
 msgstr ""
 
@@ -6073,51 +6072,47 @@ msgstr ""
 msgid "Bad request."
 msgstr ""
 
-#: src/Module/Circle.php:159
+#: src/Module/Circle.php:161
 msgid "Save Circle"
 msgstr ""
 
-#: src/Module/Circle.php:160
+#: src/Module/Circle.php:162
 msgid "Filter"
 msgstr ""
 
-#: src/Module/Circle.php:166
+#: src/Module/Circle.php:168
 msgid "Create a circle of contacts/friends."
 msgstr ""
 
-#: src/Module/Circle.php:207
+#: src/Module/Circle.php:209
 msgid "Unable to remove circle."
 msgstr ""
 
-#: src/Module/Circle.php:276
+#: src/Module/Circle.php:260
 msgid "Delete Circle"
 msgstr ""
 
-#: src/Module/Circle.php:287
+#: src/Module/Circle.php:270
 msgid "Edit Circle Name"
 msgstr ""
 
-#: src/Module/Circle.php:288
-msgid "Mark all as read"
-msgstr ""
-
-#: src/Module/Circle.php:298
+#: src/Module/Circle.php:280
 msgid "Members"
 msgstr ""
 
-#: src/Module/Circle.php:301
+#: src/Module/Circle.php:283
 msgid "Circle is empty"
 msgstr ""
 
-#: src/Module/Circle.php:317
+#: src/Module/Circle.php:299
 msgid "Remove contact from circle"
 msgstr ""
 
-#: src/Module/Circle.php:340
+#: src/Module/Circle.php:322
 msgid "Click on a contact to add or remove."
 msgstr ""
 
-#: src/Module/Circle.php:358
+#: src/Module/Circle.php:339
 msgid "Add contact to circle"
 msgstr ""
 

--- a/view/templates/photos_upload.tpl
+++ b/view/templates/photos_upload.tpl
@@ -10,6 +10,9 @@
 <div id="photos-usage-message">{{$usage}}</div>
 
 <form action="profile/{{$nickname}}/photos" enctype="multipart/form-data" method="post" name="photos-upload-form" id="photos-upload-form">
+{{if $is_album_context}}
+	<input type="hidden" name="album" value="{{$preselected_album}}" />
+{{else}}
 	<div id="photos-upload-new-wrapper">
 		<div id="photos-upload-newalbum-div">
 			<label id="photos-upload-newalbum-text" for="photos-upload-newalbum">{{$albumtext_label}}</label>
@@ -24,6 +27,7 @@
 		</select>
 	</div>
 	<div id="photos-upload-exist-end"></div>
+{{/if}}
 
 	<div id="photos-upload-noshare-div" class="photos-upload-noshare-div">
 		<input id="photos-upload-noshare" type="checkbox" name="not_visible" value="1" checked/>

--- a/view/theme/frio/templates/photos_upload.tpl
+++ b/view/theme/frio/templates/photos_upload.tpl
@@ -11,6 +11,9 @@
 	<div id="photos-usage-message">{{$usage}}</div>
 
 	<form action="profile/{{$nickname}}/photos" enctype="multipart/form-data" method="post" name="photos-upload-form" id="photos-upload-form">
+{{if $is_album_context}}
+		<input type="hidden" name="album" value="{{$preselected_album}}" />
+{{else}}
 		<div id="photos-upload-div" class="form-group">
 			<label for="photos-upload-newalbum">{{$albumtext_label}}</label>
 			<input id="photos-upload-album-select" class="form-control" list="dl-photo-upload" type="text" name="album">
@@ -22,6 +25,7 @@
 			<p><small>{{$albumtext_description}}</small></p>
 		</div>
 		<div id="photos-upload-end" class="clearfix"></div>
+{{/if}}
 
 		<div id="photos-upload-noshare-div" class="photos-upload-noshare-div checkbox pull-left">
 			<input id="photos-upload-noshare" type="checkbox" name="not_visible" value="1" checked/>


### PR DESCRIPTION
When viewing an album and clicking upload, the album is now pre-selected automatically. No more manual selection needed.

- Button text: "Upload photo to this album" when in album context
- Album field hidden when already known

Available Albums on my Account:

<img width="388" height="359" alt="Fotoalben" src="https://github.com/user-attachments/assets/30ef8ab7-72b3-460f-a815-339d91221141" />

Before:
<img width="1190" height="492" alt="Baroun" src="https://github.com/user-attachments/assets/25a10d43-5cae-4b2a-b3ba-f744f92b8b3b" />

After:
<img width="1190" height="377" alt="0 -  " src="https://github.com/user-attachments/assets/3ec6eac2-a8ac-4344-b16d-084dd82542e2" />

fixes #15483 
fixes #15520 
