### PR TITLE
Hide the messages sidebar when its empty (no messages)

### DIFF
--- a/view/templates/message_side.tpl
+++ b/view/templates/message_side.tpl
@@ -4,15 +4,14 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<nav id="message-sidebar" class="widget">
-  <div id="message-new">
-    <a href="{{$new.url}}" accesskey="m" class="btn btn-primary {{if $new.sel}}newmessage-selected{{/if}}">{{$new.label}}</a>
-  </div>
+<div id="message-new">
+	<a href="{{$new.url}}" accesskey="m" class="btn btn-primary {{if $new.sel}}newmessage-selected{{/if}}">{{$new.label}}</a>
+</div>
+{{if $tabs}}
+	<nav id="message-sidebar" class="widget">
 
-  {{if $tabs}}
-    <div id="message-preview">
-      {{$tabs nofilter}}
-    </div>
-  {{/if}}
-
-</nav>
+		<div id="message-preview">
+			{{$tabs nofilter}}
+		</div>
+	</nav>
+{{/if}}

--- a/view/theme/frio/templates/message_side.tpl
+++ b/view/theme/frio/templates/message_side.tpl
@@ -4,13 +4,12 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<nav id="message-sidebar" class="widget">
-	{{if $tabs}}
+{{if $tabs}}
+	<nav id="message-sidebar" class="widget">
 		<div id="message-preview" class="panel panel-default">
 			<ul class="media-list">
 				{{$tabs nofilter}}
 			</ul>
 		</div>
-	{{/if}}
-
-</nav>
+	</nav>
+{{/if}}


### PR DESCRIPTION
Normally when there are no messages (fx. for new accounts), the sidebar is visible but empty.
That looks like a UI bug.
This removes it until it's populated.

It's done in both Vier and Frio. Screenshots from Frio below.

# Before

<img width="965" height="328" alt="image" src="https://github.com/user-attachments/assets/6cc9c949-34d7-4a96-9388-c126085109e9" />

<img width="965" height="328" alt="image" src="https://github.com/user-attachments/assets/ddfe0f64-3c4d-4bb0-a580-c64d585b5ce5" />

# After

<img width="965" height="328" alt="image" src="https://github.com/user-attachments/assets/2a756c33-85aa-4938-a0c7-0d25cbd09b40" />

<img width="965" height="328" alt="image" src="https://github.com/user-attachments/assets/c34923fd-6822-45c6-b662-18c8f2b27d39" />

<img width="965" height="328" alt="image" src="https://github.com/user-attachments/assets/ffe1accb-9383-4dc1-9536-03de4d942d68" />

