### PR TITLE
Remove "My posts" (the previous "Home") from main nav, add dedicated back link for visitors

### DIFF
--- a/doc/en/user/access-keys.md
+++ b/doc/en/user/access-keys.md
@@ -11,11 +11,11 @@ For example, for moving to profile page in Firefox, press these three keys simul
 
 ## General
 
-* p - Profile
-* n - Network
+* n - Home
 * l - Channel
 * c - Community
 * s - Search
+* b - Back to my instance (only when remotely signed in on another instance)
 * a - Admin
 * m - Moderation
 * f - Notifications

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -19,7 +19,6 @@ use Friendica\Event\HtmlFilterEvent;
 use Friendica\Model\Contact;
 use Friendica\Model\User;
 use Friendica\Module\Conversation\Community;
-use Friendica\Module\Home;
 use Friendica\Module\Security\Login;
 use Friendica\Network\HTTPException;
 use Friendica\Security\OpenWebAuth;
@@ -32,7 +31,6 @@ class Nav
 		'community'     => null,
 		'channel'       => null,
 		'network'       => null,
-		'home'          => null,
 		'profiles'      => null,
 		'introductions' => null,
 		'notifications' => null,
@@ -175,7 +173,6 @@ class Nav
 			'apps'          => null,
 			'community'     => null,
 			'channel'       => null,
-			'home'          => null,
 			'calendar'      => null,
 			'login'         => null,
 			'logout'        => null,
@@ -209,16 +206,6 @@ class Nav
 				'icon' => Contact::getMicro($contact),
 				'name' => $contact['name'],
 			];
-		}
-
-		// "Home" should also take you home from an authenticated remote profile connection
-		$homelink = $this->session->getMyUrl();
-		if (!$homelink) {
-			$homelink = $this->session->get('visitor_home', '');
-		}
-
-		if ($this->router->getModuleClass() != Home::class && !$this->session->getLocalUserId()) {
-			$nav['home'] = [$homelink, $this->l10n->t('Home'), '', $this->l10n->t('Home Page')];
 		}
 
 		if (\Friendica\Module\Register::getPolicy() === \Friendica\Module\Register::OPEN && !$this->session->isAuthenticated()) {
@@ -274,8 +261,6 @@ class Nav
 		// The following nav links are only show to logged-in users
 		if ($this->session->getLocalUserNickname()) {
 			$nav['network'] = ['network', $this->l10n->t('Home'), '', $this->l10n->t('Home')];
-
-			$nav['home'] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('My profile'), '', $this->l10n->t('My posts')];
 
 			// Don't show notifications for public communities
 			if ($this->session->get('page_flags', '') != User::PAGE_FLAGS_COMMUNITY) {

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.08-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-24 19:29+0000\n"
+"POT-Creation-Date: 2026-06-27 15:25+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,7 +46,7 @@ msgstr ""
 
 #: mod/item.php:479 mod/message.php:56 mod/message.php:102 mod/photos.php:117
 #: mod/photos.php:418 src/Model/Event.php:510 src/Module/Attach.php:40
-#: src/Module/BaseApi.php:91 src/Module/BaseNotifications.php:83
+#: src/Module/BaseApi.php:101 src/Module/BaseNotifications.php:83
 #: src/Module/BaseSettings.php:38 src/Module/Calendar/Event/API.php:75
 #: src/Module/Calendar/Event/Form.php:73 src/Module/Calendar/Export.php:79
 #: src/Module/Calendar/Show.php:71 src/Module/Circle.php:27
@@ -80,12 +80,12 @@ msgstr ""
 msgid "Permission denied."
 msgstr ""
 
-#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:288
-#: view/theme/frio/theme.php:226
+#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:273
+#: view/theme/frio/theme.php:227
 msgid "Messages"
 msgstr ""
 
-#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:291
+#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:276
 msgid "New Message"
 msgstr ""
 
@@ -158,7 +158,7 @@ msgid "Insert web link"
 msgstr ""
 
 #: mod/message.php:191 mod/message.php:349
-#: src/Content/Conversation/ConversationRenderer.php:537
+#: src/Content/Conversation/ConversationRenderer.php:546
 #: src/Content/Conversation/PostTemplateBuilder.php:391
 #: src/Content/Conversation/StatusEditor.php:182
 #: src/Module/Item/Compose.php:172 src/Module/Post/Edit.php:156
@@ -431,7 +431,7 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: mod/photos.php:828 src/Content/Conversation/ConversationRenderer.php:466
+#: mod/photos.php:828 src/Content/Conversation/ConversationRenderer.php:475
 #: src/Model/Event.php:654 src/Module/Calendar/Event/Show.php:79
 #: src/Module/Moderation/Users/Active.php:92
 #: src/Module/Moderation/Users/Blocked.php:92
@@ -571,15 +571,15 @@ msgstr ""
 msgid "No system theme config value set."
 msgstr ""
 
-#: src/BaseModule.php:409
+#: src/BaseModule.php:418
 msgid "The form security token was not correct. This probably happened because the form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
-#: src/BaseModule.php:436
+#: src/BaseModule.php:445
 msgid "All contacts"
 msgstr ""
 
-#: src/BaseModule.php:441 src/Content/Conversation/Factory/Channel.php:33
+#: src/BaseModule.php:450 src/Content/Conversation/Factory/Channel.php:33
 #: src/Content/Widget.php:263 src/Core/ACL.php:188 src/Module/Contact.php:398
 #: src/Module/Privacy/PermissionTooltip.php:167
 #: src/Module/Privacy/PermissionTooltip.php:189
@@ -587,17 +587,17 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: src/BaseModule.php:446 src/Content/Widget.php:264 src/Module/Contact.php:399
+#: src/BaseModule.php:455 src/Content/Widget.php:264 src/Module/Contact.php:399
 #: src/Module/Settings/Channels.php:153
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:451 src/Content/Widget.php:265 src/Model/User.php:1425
+#: src/BaseModule.php:460 src/Content/Widget.php:265 src/Model/User.php:1425
 #: src/Module/Contact.php:400
 msgid "Friends"
 msgstr ""
 
-#: src/BaseModule.php:459
+#: src/BaseModule.php:468
 msgid "Common"
 msgstr ""
 
@@ -1125,53 +1125,53 @@ msgstr ""
 
 #: src/Content/Conversation/ConversationRenderer.php:115
 #: src/Content/Conversation/ConversationRenderer.php:116
-#: src/Content/Conversation/ConversationRenderer.php:369
-#: src/Content/Conversation/ConversationRenderer.php:397
+#: src/Content/Conversation/ConversationRenderer.php:378
+#: src/Content/Conversation/ConversationRenderer.php:406
 msgid "Delete Selected Items"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:465
+#: src/Content/Conversation/ConversationRenderer.php:474
 #: src/Content/Conversation/PostTemplateBuilder.php:528
 msgid "Select"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:483
+#: src/Content/Conversation/ConversationRenderer.php:492
 msgid "Pinned item"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:499
+#: src/Content/Conversation/ConversationRenderer.php:508
 #: src/Content/Conversation/PostTemplateBuilder.php:322
 #: src/Content/Conversation/PostTemplateBuilder.php:323
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:512
+#: src/Content/Conversation/ConversationRenderer.php:521
 #: src/Content/Conversation/PostTemplateBuilder.php:310
 msgid "Categories:"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:513
+#: src/Content/Conversation/ConversationRenderer.php:522
 #: src/Content/Conversation/PostTemplateBuilder.php:311
 msgid "Filed under:"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:520
+#: src/Content/Conversation/ConversationRenderer.php:529
 #: src/Content/Conversation/PostTemplateBuilder.php:338
 #, php-format
 msgid "%s from %s"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:535
+#: src/Content/Conversation/ConversationRenderer.php:544
 msgid "View in context"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:538
+#: src/Content/Conversation/ConversationRenderer.php:547
 #: src/Content/Conversation/PostTemplateBuilder.php:392
 msgid "Loading ..."
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:569
+#: src/Content/Conversation/ConversationRenderer.php:578
 msgid "remove"
 msgstr ""
 
@@ -1662,7 +1662,7 @@ msgid "Post comment"
 msgstr ""
 
 #: src/Content/Conversation/PostTemplateBuilder.php:924
-#: src/Content/Conversation/StatusEditor.php:149 src/Content/Nav.php:89
+#: src/Content/Conversation/StatusEditor.php:149 src/Content/Nav.php:87
 #: src/Module/Post/Edit.php:141
 msgid "Loading..."
 msgstr ""
@@ -1936,7 +1936,7 @@ msgid "Display posts that have been created by accounts of the selected circle."
 msgstr ""
 
 #: src/Content/Feature.php:128 src/Content/GroupManager.php:132
-#: src/Content/Nav.php:248 src/Content/Text/HTML.php:884
+#: src/Content/Nav.php:235 src/Content/Text/HTML.php:884
 #: src/Content/Widget.php:564 src/Model/User.php:1439
 msgid "Groups"
 msgstr ""
@@ -2084,11 +2084,11 @@ msgstr ""
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: src/Content/Item.php:400 view/theme/frio/theme.php:247
+#: src/Content/Item.php:400 view/theme/frio/theme.php:248
 msgid "Turn on notifications for this post"
 msgstr ""
 
-#: src/Content/Item.php:401 view/theme/frio/theme.php:264
+#: src/Content/Item.php:401 view/theme/frio/theme.php:265
 msgid "Fetch more replies"
 msgstr ""
 
@@ -2106,7 +2106,7 @@ msgstr ""
 msgid "View Photos"
 msgstr ""
 
-#: src/Content/Item.php:405 src/Content/Nav.php:202 src/Model/Contact.php:1272
+#: src/Content/Item.php:405 src/Content/Nav.php:199 src/Model/Contact.php:1272
 #: src/Model/Profile.php:450 src/Module/BaseProfile.php:42
 #: src/Module/Contact.php:488 view/theme/frio/theme.php:218
 msgid "Posts"
@@ -2161,80 +2161,75 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/Content/Nav.php:88
+#: src/Content/Nav.php:86
 msgid "Nothing new here"
 msgstr ""
 
-#: src/Content/Nav.php:94 src/Content/Nav.php:221 src/Content/Nav.php:276
-#: src/Module/Help.php:68
+#: src/Content/Nav.php:92 src/Content/Nav.php:263 src/Module/Help.php:68
+#: view/theme/frio/theme.php:225
 msgid "Home"
 msgstr ""
 
-#: src/Content/Nav.php:95
+#: src/Content/Nav.php:93
 msgid "Skip to main content"
 msgstr ""
 
-#: src/Content/Nav.php:96
+#: src/Content/Nav.php:94
 msgid "Clear notifications"
 msgstr ""
 
-#: src/Content/Nav.php:97
+#: src/Content/Nav.php:95
 msgid "Search: @name, !group, #tags, content"
 msgstr ""
 
-#: src/Content/Nav.php:195 src/Module/Security/Login.php:159
+#: src/Content/Nav.php:192 src/Module/Security/Login.php:159
 #: src/Module/Security/TwoFactor/SignOut.php:114
 msgid "Sign out"
 msgstr ""
 
-#: src/Content/Nav.php:195
+#: src/Content/Nav.php:192
 msgid "End this session"
 msgstr ""
 
-#: src/Content/Nav.php:197 src/Module/Bookmarklet.php:30
+#: src/Content/Nav.php:194 src/Module/Bookmarklet.php:30
 #: src/Module/Security/Login.php:160
 msgid "Sign in"
 msgstr ""
 
-#: src/Content/Nav.php:202 src/Content/Nav.php:278
-#: view/theme/frio/theme.php:218
+#: src/Content/Nav.php:199 view/theme/frio/theme.php:218
 msgid "My posts"
 msgstr ""
 
-#: src/Content/Nav.php:203 src/Module/BaseProfile.php:50
+#: src/Content/Nav.php:200 src/Module/BaseProfile.php:50
 #: src/Module/Media/Attachment/Browser.php:67
 #: src/Module/Media/Photo/Browser.php:62 src/Module/Media/Photo/Browser.php:79
 #: view/theme/frio/theme.php:219
 msgid "Photos"
 msgstr ""
 
-#: src/Content/Nav.php:203 view/theme/frio/theme.php:219
+#: src/Content/Nav.php:200 view/theme/frio/theme.php:219
 msgid "My photos"
 msgstr ""
 
-#: src/Content/Nav.php:204 src/Module/BaseProfile.php:93
+#: src/Content/Nav.php:201 src/Module/BaseProfile.php:93
 #: src/Module/Profile/Notes.php:82
 msgid "Personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:204 src/Module/BaseProfile.php:96
+#: src/Content/Nav.php:201 src/Module/BaseProfile.php:96
 msgid "Only you can see these"
 msgstr ""
 
-#: src/Content/Nav.php:221 src/Module/Settings/OAuth.php:57
-msgid "Home Page"
-msgstr ""
-
-#: src/Content/Nav.php:225 src/Module/Security/Login.php:124
+#: src/Content/Nav.php:212 src/Module/Security/Login.php:124
 msgid "Register"
 msgstr ""
 
-#: src/Content/Nav.php:225 src/Module/Register.php:219
+#: src/Content/Nav.php:212 src/Module/Register.php:219
 #: src/Module/Security/Login.php:123
 msgid "Create an account"
 msgstr ""
 
-#: src/Content/Nav.php:231 src/Module/Help.php:54
+#: src/Content/Nav.php:218 src/Module/Help.php:54
 #: src/Module/Settings/TwoFactor/AppSpecific.php:130
 #: src/Module/Settings/TwoFactor/Index.php:125
 #: src/Module/Settings/TwoFactor/Recovery.php:96
@@ -2242,159 +2237,155 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: src/Content/Nav.php:231
+#: src/Content/Nav.php:218
 msgid "Help and documentation"
 msgstr ""
 
-#: src/Content/Nav.php:235
+#: src/Content/Nav.php:222
 msgid "Apps"
 msgstr ""
 
-#: src/Content/Nav.php:235
+#: src/Content/Nav.php:222
 msgid "Addon applications, utilities, games"
 msgstr ""
 
-#: src/Content/Nav.php:239 src/Content/Text/HTML.php:869
+#: src/Content/Nav.php:226 src/Content/Text/HTML.php:869
 #: src/Module/Moderation/Blocklist/Contact.php:112
 #: src/Module/Moderation/Blocklist/Server/Index.php:103
 #: src/Module/Search/Index.php:99
 msgid "Search"
 msgstr ""
 
-#: src/Content/Nav.php:239
+#: src/Content/Nav.php:226
 msgid "Search site content"
 msgstr ""
 
-#: src/Content/Nav.php:242 src/Content/Text/HTML.php:878
+#: src/Content/Nav.php:229 src/Content/Text/HTML.php:878
 msgid "Full Text"
 msgstr ""
 
-#: src/Content/Nav.php:243 src/Content/Text/HTML.php:879
+#: src/Content/Nav.php:230 src/Content/Text/HTML.php:879
 #: src/Content/Widget/TagCloud.php:54
 msgid "Tags"
 msgstr ""
 
-#: src/Content/Nav.php:244 src/Content/Nav.php:303
+#: src/Content/Nav.php:231 src/Content/Nav.php:288
 #: src/Content/Text/HTML.php:880 src/Module/BaseProfile.php:112
 #: src/Module/BaseProfile.php:115 src/Module/Contact.php:181
 #: src/Module/Contact.php:402 src/Module/Contact.php:512
-#: view/theme/frio/theme.php:228
+#: view/theme/frio/theme.php:229
 msgid "Contacts"
 msgstr ""
 
-#: src/Content/Nav.php:259
+#: src/Content/Nav.php:246
 msgid "Community"
 msgstr ""
 
-#: src/Content/Nav.php:263 src/Module/BaseProfile.php:70
+#: src/Content/Nav.php:250 src/Module/BaseProfile.php:70
 #: src/Module/BaseProfile.php:73 src/Module/BaseProfile.php:81
 #: src/Module/BaseProfile.php:84 src/Module/Calendar/Show.php:113
-#: src/Module/Settings/Display.php:424 view/theme/frio/theme.php:221
-#: view/theme/frio/theme.php:225
+#: src/Module/Settings/Display.php:424 view/theme/frio/theme.php:220
+#: view/theme/frio/theme.php:226
 msgid "Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:266
+#: src/Content/Nav.php:253
 msgid "Directory"
 msgstr ""
 
-#: src/Content/Nav.php:266
+#: src/Content/Nav.php:253
 msgid "People directory"
 msgstr ""
 
-#: src/Content/Nav.php:268 src/Module/BaseAdmin.php:70
+#: src/Content/Nav.php:255 src/Module/BaseAdmin.php:70
 #: src/Module/BaseModeration.php:97
 msgid "Information"
 msgstr ""
 
-#: src/Content/Nav.php:268
+#: src/Content/Nav.php:255
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:271 src/Module/Admin/Tos.php:64
+#: src/Content/Nav.php:258 src/Module/Admin/Tos.php:64
 #: src/Module/BaseAdmin.php:81 src/Module/Register.php:243
 #: src/Module/Tos.php:87
 msgid "Terms of Service"
 msgstr ""
 
-#: src/Content/Nav.php:271
+#: src/Content/Nav.php:258
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:278
-msgid "My profile"
-msgstr ""
-
-#: src/Content/Nav.php:282
+#: src/Content/Nav.php:267
 msgid "Introductions"
 msgstr ""
 
-#: src/Content/Nav.php:282
+#: src/Content/Nav.php:267
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:283 src/Module/BaseNotifications.php:134
+#: src/Content/Nav.php:268 src/Module/BaseNotifications.php:134
 #: src/Module/Notifications/Introductions.php:63
 #: src/Module/Settings/Account.php:560
 msgid "Notifications"
 msgstr ""
 
-#: src/Content/Nav.php:284
+#: src/Content/Nav.php:269
 msgid "View all"
 msgstr ""
 
-#: src/Content/Nav.php:285 src/Module/Settings/Connectors.php:215
+#: src/Content/Nav.php:270 src/Module/Settings/Connectors.php:215
 msgid "Mark as read"
 msgstr ""
 
-#: src/Content/Nav.php:285
+#: src/Content/Nav.php:270
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:288 view/theme/frio/theme.php:226
+#: src/Content/Nav.php:273
 msgid "Private mail"
 msgstr ""
 
-#: src/Content/Nav.php:289
+#: src/Content/Nav.php:274
 msgid "Inbox"
 msgstr ""
 
-#: src/Content/Nav.php:290
+#: src/Content/Nav.php:275
 msgid "Outbox"
 msgstr ""
 
-#: src/Content/Nav.php:293
+#: src/Content/Nav.php:278
 msgid "Accounts"
 msgstr ""
 
-#: src/Content/Nav.php:294
+#: src/Content/Nav.php:279
 msgid "Manage other accounts, including groups and pages"
 msgstr ""
 
-#: src/Content/Nav.php:301 src/Module/Admin/Addons/Details.php:140
+#: src/Content/Nav.php:286 src/Module/Admin/Addons/Details.php:140
 #: src/Module/Admin/Themes/Details.php:85 src/Module/BaseAdmin.php:89
 #: src/Module/BaseSettings.php:177 src/Module/Welcome.php:39
-#: view/theme/frio/theme.php:227
+#: view/theme/frio/theme.php:228
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:301 view/theme/frio/theme.php:227
+#: src/Content/Nav.php:286
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:303 view/theme/frio/theme.php:228
+#: src/Content/Nav.php:288 view/theme/frio/theme.php:229
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:308 src/Module/BaseAdmin.php:115
+#: src/Content/Nav.php:293 src/Module/BaseAdmin.php:115
 msgid "Admin"
 msgstr ""
 
-#: src/Content/Nav.php:308
+#: src/Content/Nav.php:293
 msgid "Site setup and configuration"
 msgstr ""
 
-#: src/Content/Nav.php:312 src/Module/BaseModeration.php:117
+#: src/Content/Nav.php:297 src/Module/BaseModeration.php:117
 #: src/Module/Moderation/Blocklist/Contact.php:99
 #: src/Module/Moderation/Blocklist/Contact/Import.php:101
 #: src/Module/Moderation/Blocklist/Server/Add.php:105
@@ -2412,15 +2403,15 @@ msgstr ""
 msgid "Moderation"
 msgstr ""
 
-#: src/Content/Nav.php:312
+#: src/Content/Nav.php:297
 msgid "Content and user moderation"
 msgstr ""
 
-#: src/Content/Nav.php:315
+#: src/Content/Nav.php:300
 msgid "Navigation"
 msgstr ""
 
-#: src/Content/Nav.php:315
+#: src/Content/Nav.php:300
 msgid "Site map"
 msgstr ""
 
@@ -5940,26 +5931,26 @@ msgstr ""
 msgid "User registrations waiting for confirmation"
 msgstr ""
 
-#: src/Module/BaseApi.php:443 src/Module/BaseApi.php:459
-#: src/Module/BaseApi.php:475
+#: src/Module/BaseApi.php:453 src/Module/BaseApi.php:469
+#: src/Module/BaseApi.php:485
 msgid "Too Many Requests"
 msgstr ""
 
-#: src/Module/BaseApi.php:444
+#: src/Module/BaseApi.php:454
 #, php-format
 msgid "Daily posting limit of %d post reached. The post was rejected."
 msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/BaseApi.php:460
+#: src/Module/BaseApi.php:470
 #, php-format
 msgid "Weekly posting limit of %d post reached. The post was rejected."
 msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/BaseApi.php:476
+#: src/Module/BaseApi.php:486
 #, php-format
 msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgid_plural "Monthly posting limit of %d posts reached. The post was rejected."
@@ -6018,7 +6009,6 @@ msgid "All posts"
 msgstr ""
 
 #: src/Module/BaseProfile.php:58 src/Module/Contact.php:504
-#: view/theme/frio/theme.php:220
 msgid "Media posts"
 msgstr ""
 
@@ -10989,6 +10979,10 @@ msgstr ""
 msgid "Connected Apps"
 msgstr ""
 
+#: src/Module/Settings/OAuth.php:57
+msgid "Home Page"
+msgstr ""
+
 #: src/Module/Settings/OAuth.php:59
 msgid "Remove authorization"
 msgstr ""
@@ -11223,8 +11217,8 @@ msgid "If this error persists, please contact your administrator."
 msgstr ""
 
 #: src/Module/Settings/RemoveMe.php:65
-#: src/Navigation/Notifications/Repository/Notify.php:468
-#: src/Navigation/Notifications/Repository/Notify.php:492
+#: src/Navigation/Notifications/Repository/Notify.php:470
+#: src/Navigation/Notifications/Repository/Notify.php:494
 msgid "[Friendica System Notify]"
 msgstr ""
 
@@ -12043,217 +12037,217 @@ msgstr ""
 msgid "%1$s commented on your thread %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:215
-#: src/Navigation/Notifications/Repository/Notify.php:773
+#: src/Navigation/Notifications/Repository/Notify.php:217
+#: src/Navigation/Notifications/Repository/Notify.php:775
 msgid "[Friendica:Notify]"
-msgstr ""
-
-#: src/Navigation/Notifications/Repository/Notify.php:283
-#, php-format
-msgid "%s New mail received at %s"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:285
 #, php-format
+msgid "%s New mail received at %s"
+msgstr ""
+
+#: src/Navigation/Notifications/Repository/Notify.php:287
+#, php-format
 msgid "%1$s sent you a new private message at %2$s."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:286
+#: src/Navigation/Notifications/Repository/Notify.php:288
 msgid "a private message"
-msgstr ""
-
-#: src/Navigation/Notifications/Repository/Notify.php:286
-#, php-format
-msgid "%1$s sent you %2$s."
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:288
 #, php-format
+msgid "%1$s sent you %2$s."
+msgstr ""
+
+#: src/Navigation/Notifications/Repository/Notify.php:290
+#, php-format
 msgid "Please visit %s to view and/or reply to your private messages."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:318
+#: src/Navigation/Notifications/Repository/Notify.php:320
 #, php-format
 msgid "%1$s commented on %2$s's %3$s %4$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:323
+#: src/Navigation/Notifications/Repository/Notify.php:325
 #, php-format
 msgid "%1$s commented on your %2$s %3$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:327
+#: src/Navigation/Notifications/Repository/Notify.php:329
 #, php-format
 msgid "%1$s commented on their %2$s %3$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:331
-#: src/Navigation/Notifications/Repository/Notify.php:810
+#: src/Navigation/Notifications/Repository/Notify.php:333
+#: src/Navigation/Notifications/Repository/Notify.php:812
 #, php-format
 msgid "%1$s Comment to conversation #%2$d by %3$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:333
+#: src/Navigation/Notifications/Repository/Notify.php:335
 #, php-format
 msgid "%s commented on an item/conversation you have been following."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:337
-#: src/Navigation/Notifications/Repository/Notify.php:353
-#: src/Navigation/Notifications/Repository/Notify.php:836
+#: src/Navigation/Notifications/Repository/Notify.php:339
+#: src/Navigation/Notifications/Repository/Notify.php:355
+#: src/Navigation/Notifications/Repository/Notify.php:838
 #, php-format
 msgid "Please visit %s to view and/or reply to the conversation."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:344
+#: src/Navigation/Notifications/Repository/Notify.php:346
 #, php-format
 msgid "%s %s posted to your profile wall"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:346
+#: src/Navigation/Notifications/Repository/Notify.php:348
 #, php-format
 msgid "%1$s posted to your profile wall at %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:348
+#: src/Navigation/Notifications/Repository/Notify.php:350
 #, php-format
 msgid "%1$s posted to [url=%2$s]your wall[/url]"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:361
+#: src/Navigation/Notifications/Repository/Notify.php:363
 #, php-format
 msgid "%s Introduction received"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:363
+#: src/Navigation/Notifications/Repository/Notify.php:365
 #, php-format
 msgid "You've received an introduction from '%1$s' at %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:365
+#: src/Navigation/Notifications/Repository/Notify.php:367
 #, php-format
 msgid "You've received [url=%1$s]an introduction[/url] from %2$s."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:370
-#: src/Navigation/Notifications/Repository/Notify.php:419
+#: src/Navigation/Notifications/Repository/Notify.php:372
+#: src/Navigation/Notifications/Repository/Notify.php:421
 #, php-format
 msgid "You may visit their profile at %s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:372
+#: src/Navigation/Notifications/Repository/Notify.php:374
 #, php-format
 msgid "Please visit %s to approve or reject the introduction."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:379
+#: src/Navigation/Notifications/Repository/Notify.php:381
 #, php-format
 msgid "%s You have a new friend"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:381
 #: src/Navigation/Notifications/Repository/Notify.php:383
+#: src/Navigation/Notifications/Repository/Notify.php:385
 #, php-format
 msgid "%1$s is your friend at %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:390
+#: src/Navigation/Notifications/Repository/Notify.php:392
 #, php-format
 msgid "%s You have a new follower"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:392
 #: src/Navigation/Notifications/Repository/Notify.php:394
+#: src/Navigation/Notifications/Repository/Notify.php:396
 #, php-format
 msgid "You have a new follower at %2$s : %1$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:407
+#: src/Navigation/Notifications/Repository/Notify.php:409
 #, php-format
 msgid "%s Friend suggestion received"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:409
+#: src/Navigation/Notifications/Repository/Notify.php:411
 #, php-format
 msgid "You've received a friend suggestion from '%1$s' at %2$s"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:411
+#: src/Navigation/Notifications/Repository/Notify.php:413
 #, php-format
 msgid "You've received [url=%1$s]a friend suggestion[/url] for %2$s from %3$s."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:417
+#: src/Navigation/Notifications/Repository/Notify.php:419
 msgid "Name:"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:418
+#: src/Navigation/Notifications/Repository/Notify.php:420
 msgid "Photo:"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:421
+#: src/Navigation/Notifications/Repository/Notify.php:423
 #, php-format
 msgid "Please visit %s to approve or reject the suggestion."
-msgstr ""
-
-#: src/Navigation/Notifications/Repository/Notify.php:429
-#: src/Navigation/Notifications/Repository/Notify.php:445
-#, php-format
-msgid "%s Connection accepted"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:431
 #: src/Navigation/Notifications/Repository/Notify.php:447
 #, php-format
-msgid "'%1$s' has accepted your connection request at %2$s"
+msgid "%s Connection accepted"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:433
 #: src/Navigation/Notifications/Repository/Notify.php:449
 #, php-format
+msgid "'%1$s' has accepted your connection request at %2$s"
+msgstr ""
+
+#: src/Navigation/Notifications/Repository/Notify.php:435
+#: src/Navigation/Notifications/Repository/Notify.php:451
+#, php-format
 msgid "%2$s has accepted your [url=%1$s]connection request[/url]."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:438
+#: src/Navigation/Notifications/Repository/Notify.php:440
 msgid "You are now friends and may exchange status updates, photos, and messages without restriction."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:440
+#: src/Navigation/Notifications/Repository/Notify.php:442
 #, php-format
 msgid "Please visit %s if you wish to make any changes to this relationship."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:454
+#: src/Navigation/Notifications/Repository/Notify.php:456
 #, php-format
 msgid "'%1$s' has chosen to accept you a fan, which restricts some forms of communication - such as private messaging and some profile interactions. If this is a celebrity or community page, these settings were applied automatically."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:456
+#: src/Navigation/Notifications/Repository/Notify.php:458
 #, php-format
 msgid "'%1$s' may choose to extend this into a two-way or more permissive relationship in the future."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:458
+#: src/Navigation/Notifications/Repository/Notify.php:460
 #, php-format
 msgid "Please visit %s  if you wish to make any changes to this relationship."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:468
-msgid "registration request"
-msgstr ""
-
 #: src/Navigation/Notifications/Repository/Notify.php:470
-#, php-format
-msgid "You've received a registration request from '%1$s' at %2$s"
+msgid "registration request"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:472
 #, php-format
+msgid "You've received a registration request from '%1$s' at %2$s"
+msgstr ""
+
+#: src/Navigation/Notifications/Repository/Notify.php:474
+#, php-format
 msgid "You've received a [url=%1$s]registration request[/url] from %2$s."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:478
-#: src/Navigation/Notifications/Repository/Notify.php:502
+#: src/Navigation/Notifications/Repository/Notify.php:480
+#: src/Navigation/Notifications/Repository/Notify.php:504
 #, php-format
 msgid ""
 "Display Name:\t%s\n"
@@ -12261,46 +12255,46 @@ msgid ""
 "Login Name:\t%s (%s)"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:485
+#: src/Navigation/Notifications/Repository/Notify.php:487
 #, php-format
 msgid "Please visit %s to approve or reject the request."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:492
-msgid "new registration"
-msgstr ""
-
 #: src/Navigation/Notifications/Repository/Notify.php:494
-#, php-format
-msgid "You've received a new registration from '%1$s' at %2$s"
+msgid "new registration"
 msgstr ""
 
 #: src/Navigation/Notifications/Repository/Notify.php:496
 #, php-format
+msgid "You've received a new registration from '%1$s' at %2$s"
+msgstr ""
+
+#: src/Navigation/Notifications/Repository/Notify.php:498
+#, php-format
 msgid "You've received a [url=%1$s]new registration[/url] from %2$s."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:509
+#: src/Navigation/Notifications/Repository/Notify.php:511
 #, php-format
 msgid "Please visit %s to have a look at the new registration."
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:804
+#: src/Navigation/Notifications/Repository/Notify.php:806
 #, php-format
 msgid "%s %s tagged you"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:807
+#: src/Navigation/Notifications/Repository/Notify.php:809
 #, php-format
 msgid "%s %s shared a new post"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:815
+#: src/Navigation/Notifications/Repository/Notify.php:817
 #, php-format
 msgid "%1$s %2$s liked your post #%3$d"
 msgstr ""
 
-#: src/Navigation/Notifications/Repository/Notify.php:818
+#: src/Navigation/Notifications/Repository/Notify.php:820
 #, php-format
 msgid "%1$s %2$s liked your comment on #%3$d"
 msgstr ""
@@ -12594,19 +12588,15 @@ msgid "Visitor"
 msgstr ""
 
 #: view/theme/frio/theme.php:220
-msgid "My posts containing media"
-msgstr ""
-
-#: view/theme/frio/theme.php:221
 msgid "Your calendar"
 msgstr ""
 
 #: view/theme/frio/theme.php:224
-msgid "Network"
+msgid "Back home"
 msgstr ""
 
 #: view/theme/frio/theme.php:224
-msgid "Conversations from your friends"
+msgid "Back to my instance"
 msgstr ""
 
 #: view/theme/vier/config.php:91

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -32,10 +32,6 @@
 	<a accesskey="n" id="nav-network-link" class="nav-commlink {{$nav.network.2}} {{$sel.network}}" href="{{$nav.network.0}}" title="{{$nav.network.3}}">{{$nav.network.1}}</a>
 	<span id="net-update" class="nav-ajax-left"></span>
 	{{/if}}
-	{{if $nav.home}}
-	<a accesskey="p" id="nav-home-link" class="nav-commlink {{$nav.home.2}} {{$sel.home}}" href="{{$nav.home.0}}" title="{{$nav.home.3}}">{{$nav.home.1}}</a>
-	<span id="home-update" class="nav-ajax-left"></span>
-	{{/if}}
 	{{if $nav.channel}}
 	<a accesskey="l" id="nav-channel-link" class="nav-commlink {{$nav.channel.2}} {{$sel.channel}}" href="{{$nav.channel.0}}" title="{{$nav.channel.3}}">{{$nav.channel.1}}</a>
 	{{/if}}

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -57,6 +57,16 @@
 						<li class="sr-only">
 							<a class="sr-only" href="{{$baseurl}}">{{$home}}</a>
 						</li>
+
+						{{if $nav.back}}
+							<!-- Link back home to one's own instance, only visible to visitors -->
+							<li class="nav-segment">
+								<a accesskey="b" class="nav-menu" href="{{$nav.back.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
+										aria-label="{{$nav.back.3}}" title="{{$nav.back.3}}"><i class="ri ri-xl ri-arrow-go-back-line ri-fw"
+										aria-hidden="true"></i> <span class="d-none">{{$nav.back.1}}</span></a>
+							</li>
+						{{/if}}
+
 						{{if $nav.network}}
 							<li class="nav-segment">
 								<a accesskey="n" class="nav-menu {{$sel.network}}" href="{{$nav.network.0}}"
@@ -83,19 +93,11 @@
 						{{/if}}
 
 						{{if $nav.channel}}
+							<!-- Note: This is currently never displayed -->
 							<li class="nav-segment">
 								<a accesskey="l" class="nav-menu {{$sel.channel}}" href="{{$nav.channel.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.channel.3}}" title="{{$nav.channel.3}}"><i
 										class="ri ri-xl ri-newspaper-{{if $sel.channel}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.channel.1}}</span></a>
-							</li>
-						{{/if}}
-
-						{{if $nav.home}}
-							<li class="nav-segment hidden-xs">
-								<a accesskey="p" class="nav-menu {{$sel.home}}" href="{{$nav.home.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
-										aria-label="{{$nav.home.3}}" title="{{$nav.home.3}}"><i class="ri ri-xl ri-user-{{if $sel.home}}fill{{else}}line{{/if}} ri-fw"
-										aria-hidden="true"></i> <span class="d-none">{{$nav.home.1}}</span><span id="home-update"
-										class="nav-home-badge badge nav-notification"></span></a>
 							</li>
 						{{/if}}
 
@@ -111,7 +113,7 @@
 								<a accesskey="k" id="nav-contacts-link" href="{{$nav.contacts.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.contacts.1}}" title="{{$nav.contacts.1}}"
 									class="nav-menu {{$sel.contacts}} {{$nav.contacts.2}}"><i
-										class="ri ri-contacts-{{if $sel.contacts}}fill{{else}}line{{/if}} ri-lg ri-fw"></i></a>
+										class="ri ri-contacts-{{if $sel.contacts}}fill{{else}}line{{/if}} ri-lg ri-fw"></i> <span class="d-none">{{$nav.contacts.1}}</span></a>
 							</li>
 						{{/if}}
 
@@ -120,7 +122,7 @@
 								<a accesskey="m" id="nav-messages-link" href="{{$nav.messages.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.messages.1}}" title="{{$nav.messages.1}}"
 									class="nav-menu {{$sel.messages}}"><i class="ri ri-mail-{{if $sel.messages}}fill{{else}}line{{/if}} ri-lg ri-fw"
-										aria-hidden="true"></i><span id="mail-update"
+										aria-hidden="true"></i> <span class="d-none">{{$nav.messages.1}}</span><span id="mail-update"
 										class="nav-mail-badge badge nav-notification"></span></a>
 							</li>
 						{{/if}}
@@ -132,7 +134,7 @@
 									type="button" aria-haspopup="true" aria-expanded="false"
 									aria-controls="nav-notifications-menu">
 									<span id="notification-update" class="nav-notification-badge badge nav-notification"></span>
-									<i class="ri ri-notification-line ri-lg" aria-label="{{$nav.notifications.1}}"></i>
+									<i class="ri ri-notification-line ri-lg" aria-label="{{$nav.notifications.1}}"></i>  <span class="d-none">{{$nav.notifications.1}}</span>
 								</button>
 								{{* The notifications dropdown menu. There are two parts of menu. The second is at the bottom of this file. It is loaded via js. Look at nav-notifications-template *}}
 								<ul id="nav-notifications-menu" class="dropdown-menu menu-popup" role="menu"

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -217,14 +217,15 @@ function frio_remote_nav(array &$nav_info): void
 			// user menu
 			$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'], DI::l10n()->t('Posts'), '', DI::l10n()->t('My posts')];
 			$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'] . '/photos', DI::l10n()->t('Photos'), '', DI::l10n()->t('My photos')];
-			$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'] . '/media', DI::l10n()->t('Media posts'), '', DI::l10n()->t('My posts containing media')];
 			$nav_info['nav']['usermenu'][] = [$server_url . '/calendar/', DI::l10n()->t('Calendar'), '', DI::l10n()->t('Your calendar')];
 
 			// navbar links
-			$nav_info['nav']['network']  = [$server_url . '/network', DI::l10n()->t('Network'), '', DI::l10n()->t('Conversations from your friends')];
+			// "Back" is exclusively visible when remote visiting another instance
+			$nav_info['nav']['back']     = [$server_url, DI::l10n()->t('Back home'), '', DI::l10n()->t('Back to my instance')];
+			$nav_info['nav']['network']  = [$server_url . '/network', DI::l10n()->t('Home'), '', DI::l10n()->t('Home')];
 			$nav_info['nav']['calendar'] = [$server_url . '/calendar', DI::l10n()->t('Calendar'), '', DI::l10n()->t('Calendar')];
-			$nav_info['nav']['messages'] = [$server_url . '/message', DI::l10n()->t('Messages'), '', DI::l10n()->t('Private mail')];
-			$nav_info['nav']['settings'] = [$server_url . '/settings', DI::l10n()->t('Settings'), '', DI::l10n()->t('Account settings')];
+			$nav_info['nav']['messages'] = [$server_url . '/message', DI::l10n()->t('Messages'), '', DI::l10n()->t('Messages')];
+			$nav_info['nav']['settings'] = [$server_url . '/settings', DI::l10n()->t('Settings'), '', DI::l10n()->t('Settings')];
 			$nav_info['nav']['contacts'] = [$server_url . '/contact', DI::l10n()->t('Contacts'), '', DI::l10n()->t('Manage/edit friends and contacts')];
 			$nav_info['nav']['sitename'] = DI::config()->get('config', 'sitename');
 		}

--- a/view/theme/vier/templates/nav.tpl
+++ b/view/theme/vier/templates/nav.tpl
@@ -16,12 +16,14 @@
 				<i class="icons icon-reorder"></i>
 			</a>
 		</li>
-		{{if $nav.home}}
-			<li role="menuitem" id="nav-home-link" class="nav-menu {{$sel.home}}">
-				<a accesskey="p" class="{{$nav.home.2}}" href="{{$nav.home.0}}" title="{{$nav.home.3}}">
-					<span class="desktop-view">{{$nav.home.1}}</span>
-					<i class="icon s22 icon-home mobile-view"><span class="sr-only">{{$nav.home.1}}</span></i>
-					<span id="home-update" class="nav-notification"></span>
+
+		{{if $nav.back}}
+			<!-- Link back home to one's own instance, only visible to visitors -->
+			<li role="menuitem" id="nav-back-link" class="nav-menu">
+				<a accesskey="b" class="{{$nav.back.2}}" href="{{$nav.back.0}}" title="{{$nav.back.3}}">
+					<span class="desktop-view">{{$nav.back.1}}</span>
+					<i class="ri ri-xl ri-arrow-go-back-line ri-fw" aria-hidden="true"></i>
+					<span class="sr-only">{{$nav.back.1}}</span>
 				</a>
 			</li>
 		{{/if}}
@@ -41,6 +43,7 @@
 			</li>
 		{{/if}}
 		{{if $nav.channel}}
+			<!-- Note: This is currently never displayed -->
 			<li role="menuitem" id="nav-channel-link" class="nav-menu {{$sel.channel}}">
 				<a accesskey="l" class="{{$nav.channel.2}} desktop-view" href="{{$nav.channel.0}}" title="{{$nav.channel.3}}">{{$nav.channel.1}}</a>
 				<a class="{{$nav.channel.2}} mobile-view" href="{{$nav.channel.0}}" title="{{$nav.channel.3}}"><i class="icon s22 icon-bullseye"></i></a>


### PR DESCRIPTION
Note: The "Original background" text is now mostly outdated since Network was since then updated to become "Home" in another PR.

The screenshots have been updated and the "This PR" section describes the PR in its current state.

# Original background

This PR suggests updating the main nav of Frio and Vier to remove "Home", which links to /conversations on one's own profile. That page is still easily accessible as the first option in the user menu:
<img width="213" height="88" alt="image" src="https://github.com/user-attachments/assets/2acbee30-f4d0-43fd-b44d-c04969570e2a" />

Instead "Network" gets renamed "Home" and gets its icon. Alternatively it could keep the "Network" name. In a future PR, I plan to make a PR that adds text next to each of those icons..
~~The PR currently also moves "Community" to the left of Home/Network. That part I'm the least sure of. Maybe it's better the other way?~~ (this is no longer the case)

The reasoning is: 
- "Home" in many other social networks is essentially equivalent to Network. It's the main news feed where you can find posts from others. (And not only those you follow, as the current hover text claims, as that depends on which circles/channels you select.) This should help new users understand Friendica more easily, as it will be a little bit more familiar.
- To simplify Friendicas main nav, also hoping to help new users understand Friendica more easily.
- I don't believe /conversations is important enough to be in the main nav, but others may have a different experience(?)

As for other social media platforms using "Home" for the mains news feed - two examples that I think a lot of users are coming/will come from:

Facebook :
<img width="134" height="65" alt="image" src="https://github.com/user-attachments/assets/1df560b9-ad0d-4dfb-8d29-105896ce2f0a" />

Mastodon:
<img width="158" height="115" alt="image" src="https://github.com/user-attachments/assets/f43fba05-1699-4498-8c4b-d08d840742f1" />

# This PR

- Remove the old Home/My posts from the main menu
- Add a "Back to my instance" nav entry to the main menu for visitors
- Update the menu shown to visitors (hidden in Frio's theme.php) to match the changes in the regular menu
- Side quest: Adds hidden text to the remaining parts of the main nav (mainly so Bookface can show them)

# Before

<img width="530" height="93" alt="image" src="https://github.com/user-attachments/assets/269862ae-e398-477e-95f8-1e047270593a" />

# After

<img width="530" height="93" alt="image" src="https://github.com/user-attachments/assets/a8b447aa-5757-468f-b6b0-b2503148ba92" />

When visiting another instance ("stay local" disabled):
<img width="437" height="55" alt="image" src="https://github.com/user-attachments/assets/d0353cb3-56f2-410d-8f2e-967a9b98ee24" />
^ Note: That screenshot is Bookface, while the others are regular Frio.