### PR TITLE
Enhancement: Add friendly message when registration is closed

### DIFF
--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -84,8 +84,13 @@ class Register extends BaseModule
 		}
 
 		if (!DI::userSession()->getLocalUserId() && self::getPolicy() === self::CLOSED) {
-			DI::sysmsg()->addNotice(DI::l10n()->t('Permission denied.'));
-			return '';
+			$tpl = Renderer::getMarkupTemplate('register_closed.tpl');
+			return Renderer::replaceMacros($tpl, [
+				'$title'       => DI::l10n()->t('Registration Closed'),
+				'$message'     => DI::l10n()->t('Registration is currently closed on this node.'),
+				'$explanation' => DI::l10n()->t('The administrators have decided to limit new registrations. This could be temporary or permanent.'),
+				'$find_server' => BBCode::convertForUriId(User::getSystemUriId(), DI::l10n()->t('You can find other open Friendica servers at %s where you can register.', '[url=https://dir.friendica.social/servers]dir.friendica.social/servers[/url]')),
+			]);
 		}
 
 		$max_dailies = intval(DI::config()->get('system', 'max_daily_registrations'));

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-17 11:08+0100\n"
+"POT-Creation-Date: 2026-02-18 13:49+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,10 +63,10 @@ msgstr ""
 #: src/Module/Profile/Common.php:63 src/Module/Profile/Contacts.php:66
 #: src/Module/Profile/Photos.php:100 src/Module/Profile/Schedule.php:27
 #: src/Module/Profile/Schedule.php:44 src/Module/Register.php:74
-#: src/Module/Register.php:87 src/Module/Register.php:216
-#: src/Module/Register.php:255 src/Module/Search/Directory.php:23
-#: src/Module/Settings/Account.php:34 src/Module/Settings/Account.php:337
-#: src/Module/Settings/Channels.php:54 src/Module/Settings/Channels.php:135
+#: src/Module/Register.php:220 src/Module/Register.php:259
+#: src/Module/Search/Directory.php:23 src/Module/Settings/Account.php:34
+#: src/Module/Settings/Account.php:337 src/Module/Settings/Channels.php:54
+#: src/Module/Settings/Channels.php:135
 #: src/Module/Settings/ContactImport.php:50
 #: src/Module/Settings/ContactImport.php:97
 #: src/Module/Settings/Delegation.php:76 src/Module/Settings/Display.php:85
@@ -366,7 +366,7 @@ msgstr ""
 #: src/Module/Profile/Contacts.php:52 src/Module/Profile/Contacts.php:60
 #: src/Module/Profile/Conversations.php:81 src/Module/Profile/Media.php:58
 #: src/Module/Profile/Photos.php:91 src/Module/Profile/RemoteFollow.php:57
-#: src/Module/Register.php:277
+#: src/Module/Register.php:281
 msgid "User not found."
 msgstr ""
 
@@ -2063,12 +2063,12 @@ msgstr ""
 msgid "Home Page"
 msgstr ""
 
-#: src/Content/Nav.php:252 src/Module/Register.php:173
+#: src/Content/Nav.php:252 src/Module/Register.php:177
 #: src/Module/Security/Login.php:128
 msgid "Register"
 msgstr ""
 
-#: src/Content/Nav.php:252 src/Module/Register.php:157
+#: src/Content/Nav.php:252 src/Module/Register.php:161
 #: src/Module/Security/Login.php:127
 msgid "Create an account"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgid "Information about this friendica instance"
 msgstr ""
 
 #: src/Content/Nav.php:298 src/Module/Admin/Tos.php:64
-#: src/Module/BaseAdmin.php:80 src/Module/Register.php:181
+#: src/Module/BaseAdmin.php:80 src/Module/Register.php:185
 #: src/Module/Tos.php:87
 msgid "Terms of Service"
 msgstr ""
@@ -4040,14 +4040,14 @@ msgstr ""
 
 #: src/Module/Admin/Features.php:53
 #: src/Module/Notifications/Introductions.php:140
-#: src/Module/OAuth/Acknowledge.php:41 src/Module/Register.php:128
+#: src/Module/OAuth/Acknowledge.php:41 src/Module/Register.php:132
 #: src/Module/Settings/TwoFactor/Trusted.php:115
 msgid "No"
 msgstr ""
 
 #: src/Module/Admin/Features.php:53 src/Module/Contact/Revoke.php:91
 #: src/Module/Notifications/Introductions.php:140
-#: src/Module/OAuth/Acknowledge.php:40 src/Module/Register.php:127
+#: src/Module/OAuth/Acknowledge.php:40 src/Module/Register.php:131
 #: src/Module/Settings/TwoFactor/Trusted.php:115
 msgid "Yes"
 msgstr ""
@@ -5949,7 +5949,7 @@ msgstr ""
 #: src/Module/Moderation/Blocklist/Server/Index.php:76
 #: src/Module/Moderation/Blocklist/Server/Index.php:104
 #: src/Module/Moderation/Blocklist/Server/Index.php:105
-#: src/Module/Moderation/Item/Delete.php:53 src/Module/Register.php:153
+#: src/Module/Moderation/Item/Delete.php:53 src/Module/Register.php:157
 #: src/Module/Security/TwoFactor/Verify.php:87
 #: src/Module/Settings/Channels.php:184 src/Module/Settings/Channels.php:210
 #: src/Module/Settings/TwoFactor/Index.php:147
@@ -8803,152 +8803,169 @@ msgstr ""
 msgid "Only parent users can create additional accounts."
 msgstr ""
 
-#: src/Module/Register.php:96 src/Module/User/Import.php:100
+#: src/Module/Register.php:88
+msgid "Registration Closed"
+msgstr ""
+
+#: src/Module/Register.php:89
+msgid "Registration is currently closed on this node."
+msgstr ""
+
+#: src/Module/Register.php:90
+msgid "The administrators have decided to limit new registrations. This could be temporary or permanent."
+msgstr ""
+
+#: src/Module/Register.php:91
+#, php-format
+msgid "You can find other open Friendica servers at %s where you can register."
+msgstr ""
+
+#: src/Module/Register.php:100 src/Module/User/Import.php:100
 msgid "This site has exceeded the number of allowed daily account registrations. Please try again tomorrow."
 msgstr ""
 
-#: src/Module/Register.php:113
+#: src/Module/Register.php:117
 msgid "You may (optionally) fill in this form via OpenID by supplying your OpenID and clicking \"Register\"."
 msgstr ""
 
-#: src/Module/Register.php:114
+#: src/Module/Register.php:118
 msgid "If you are not familiar with OpenID, please leave that field blank and fill in the rest of the items."
 msgstr ""
 
-#: src/Module/Register.php:115
+#: src/Module/Register.php:119
 msgid "Your OpenID (optional): "
 msgstr ""
 
-#: src/Module/Register.php:124
+#: src/Module/Register.php:128
 msgid "Include your profile in member directory?"
 msgstr ""
 
-#: src/Module/Register.php:153
+#: src/Module/Register.php:157
 msgid "Note for the admin"
 msgstr ""
 
-#: src/Module/Register.php:153
+#: src/Module/Register.php:157
 msgid "Leave a message for the admin, why you want to join this node"
 msgstr ""
 
-#: src/Module/Register.php:154
+#: src/Module/Register.php:158
 msgid "Membership on this site is by invitation only."
 msgstr ""
 
-#: src/Module/Register.php:155
+#: src/Module/Register.php:159
 msgid "Your invitation code: "
 msgstr ""
 
-#: src/Module/Register.php:163
+#: src/Module/Register.php:167
 msgid "Your Display Name (as you would like it to be displayed on this system):"
 msgstr ""
 
-#: src/Module/Register.php:164
+#: src/Module/Register.php:168
 msgid "Your Email Address (initial information will be sent there, so this must be a valid address):"
 msgstr ""
 
-#: src/Module/Register.php:165
+#: src/Module/Register.php:169
 msgid "Please repeat your e-mail address:"
 msgstr ""
 
-#: src/Module/Register.php:167 src/Module/Security/PasswordTooLong.php:86
+#: src/Module/Register.php:171 src/Module/Security/PasswordTooLong.php:86
 #: src/Module/Settings/Account.php:513
 msgid "New Password:"
 msgstr ""
 
-#: src/Module/Register.php:167
+#: src/Module/Register.php:171
 msgid "Leave empty for an auto generated password."
 msgstr ""
 
-#: src/Module/Register.php:168 src/Module/Security/PasswordTooLong.php:87
+#: src/Module/Register.php:172 src/Module/Security/PasswordTooLong.php:87
 #: src/Module/Settings/Account.php:514
 msgid "Confirm:"
 msgstr ""
 
-#: src/Module/Register.php:169
+#: src/Module/Register.php:173
 #, php-format
 msgid "Choose a profile nickname. This must begin with a text character. Your profile address on this site will then be \"<strong>nickname@%s</strong>\"."
 msgstr ""
 
-#: src/Module/Register.php:170
+#: src/Module/Register.php:174
 msgid "Choose a nickname: "
 msgstr ""
 
-#: src/Module/Register.php:178 src/Module/User/Import.php:106
+#: src/Module/Register.php:182 src/Module/User/Import.php:106
 msgid "Import"
 msgstr ""
 
-#: src/Module/Register.php:179
+#: src/Module/Register.php:183
 msgid "Import your profile to this friendica instance"
 msgstr ""
 
-#: src/Module/Register.php:186
+#: src/Module/Register.php:190
 msgid "Note: This node explicitly contains adult content"
 msgstr ""
 
-#: src/Module/Register.php:188 src/Module/Settings/Delegation.php:167
+#: src/Module/Register.php:192 src/Module/Settings/Delegation.php:167
 msgid "Parent Password:"
 msgstr ""
 
-#: src/Module/Register.php:188 src/Module/Settings/Delegation.php:167
+#: src/Module/Register.php:192 src/Module/Settings/Delegation.php:167
 msgid "Please enter the password of the parent account to legitimize your request."
 msgstr ""
 
-#: src/Module/Register.php:222
+#: src/Module/Register.php:226
 msgid "Password doesn't match."
 msgstr ""
 
-#: src/Module/Register.php:228
+#: src/Module/Register.php:232
 msgid "Please enter your password."
 msgstr ""
 
-#: src/Module/Register.php:270
+#: src/Module/Register.php:274
 msgid "You have entered too much information."
 msgstr ""
 
-#: src/Module/Register.php:293
+#: src/Module/Register.php:297
 msgid "Please enter the identical mail address in the second field."
 msgstr ""
 
-#: src/Module/Register.php:301
+#: src/Module/Register.php:305
 msgid "Nickname cannot start with a digit."
 msgstr ""
 
-#: src/Module/Register.php:303
+#: src/Module/Register.php:307
 msgid "Nickname can only contain US-ASCII characters."
 msgstr ""
 
-#: src/Module/Register.php:332
+#: src/Module/Register.php:336
 msgid "The additional account was created."
 msgstr ""
 
-#: src/Module/Register.php:357
+#: src/Module/Register.php:361
 msgid "Registration successful. Please check your email for further instructions."
 msgstr ""
 
-#: src/Module/Register.php:365
+#: src/Module/Register.php:369
 #, php-format
 msgid "Failed to send email message. Here your accout details:<br> login: %s<br> password: %s<br><br>You can change your password after login."
 msgstr ""
 
-#: src/Module/Register.php:372
+#: src/Module/Register.php:376
 msgid "Registration successful."
 msgstr ""
 
-#: src/Module/Register.php:381 src/Module/Register.php:388
-#: src/Module/Register.php:398
+#: src/Module/Register.php:385 src/Module/Register.php:392
+#: src/Module/Register.php:402
 msgid "Your registration can not be processed."
 msgstr ""
 
-#: src/Module/Register.php:387
+#: src/Module/Register.php:391
 msgid "You have to leave a request note for the admin."
 msgstr ""
 
-#: src/Module/Register.php:397
+#: src/Module/Register.php:401
 msgid "An internal error occured."
 msgstr ""
 
-#: src/Module/Register.php:419
+#: src/Module/Register.php:423
 msgid "Your registration is pending approval by the site owner."
 msgstr ""
 

--- a/view/templates/register_closed.tpl
+++ b/view/templates/register_closed.tpl
@@ -1,0 +1,12 @@
+{{*
+  * Copyright (C) 2010-2024, the Friendica project
+  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
+  *
+  * SPDX-License-Identifier: AGPL-3.0-or-later
+  *}}
+<div class="generic-page-wrapper" style="min-height: auto;">
+	<h2>{{$title}}</h2>
+	<p>{{$message}}</p>
+	<p>{{$explanation}}</p>
+	<p>{{$find_server nofilter}}</p>
+</div>


### PR DESCRIPTION
When registration is closed on a Friendica node, visitors navigating to /register (e.g., via a bookmark or direct link) were previously shown a blank page with only a "Permission denied" notice. Since the register button is hidden on closed instances, this page is only reached through direct access.

This change displays a friendly message explaining that registration is currently closed, and directs interested users to dir.friendica.social/servers where they can find other open Friendica servers.

Before:
<img width="1395" height="935" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/c7defce0-0adf-45db-a751-6a5f9049afdf" />

After:
<img width="1387" height="928" alt="LE Friendica" src="https://github.com/user-attachments/assets/b0149aae-6867-4601-ad64-c93ec126b017" />
