### PR TITLE
fix: downgrade str_ends_with() for PHP 7.4 support

### DIFF
--- a/src/Network/RobotsTxt.php
+++ b/src/Network/RobotsTxt.php
@@ -183,11 +183,11 @@ class RobotsTxt
 	 */
 	private function pathMatches(string $path, string $rule): bool
 	{
-		if (str_ends_with($rule, '*')) {
+		if (substr_compare($rule, '*', -strlen('*')) === 0) {
 			$rule = substr($rule, 0, -1);
-			return str_starts_with($path, $rule);
+			return strncmp($path, $rule, strlen($rule)) === 0;
 		}
 
-		return str_starts_with($path, $rule);
+		return strncmp($path, $rule, strlen($rule)) === 0;
 	}
 }


### PR DESCRIPTION
While working on #14989 with rector and php-cs-fixer I noticed that we are using the `str_starts_with()` and `str_ends_with()` functions, but the functions are only available since PHP 8.0.

This PR downgrades the functions. The downgrade was done by the `DowngradeStrEndsWithRector` and `DowngradeStrStartsWithRector` rector rules.