### PR TITLE
Review code style rules, change spaces_inside_parentheses rule

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -54,10 +54,20 @@ return $config
 		'list_syntax' => [
 			'syntax' => 'short',
 		],
+		'new_with_parentheses'        => true,
 		'no_unused_imports'           => true,
 		'single_import_per_statement' => true,
 		'ternary_operator_spaces'     => false,
-		'new_with_parentheses'        => true,
+		'trailing_comma_in_multiline' => [
+			'after_heredoc' => true,
+			'elements'      => [
+				'arguments',
+				'array_destructuring',
+				'arrays',
+				// 'match', /* activate `match` after PHP 7.4 support is dropped */
+				// 'parameters', /* activate `arguments` after PHP 7.4 support is dropped */
+			],
+		],
 	])
 	->setFinder($finder)
 	->setIndent("\t");

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -26,8 +26,6 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 return $config
 	->setRules([
-		'@PSR1'                   => true,
-		'@PSR2'                   => true,
 		'@PSR12'                  => true,
 		'align_multiline_comment' => true,
 		'array_indentation'       => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -26,7 +26,7 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 return $config
 	->setRules([
-		'@PSR12'                  => true,
+		'@PER-CS3x0'              => true,
 		'align_multiline_comment' => true,
 		'array_indentation'       => true,
 		'array_syntax'            => [

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2010 - 2024 the Friendica project
  *
@@ -11,24 +12,30 @@ require_once __DIR__ . '/bin/dev/php-cs-fixer/vendor/autoload.php';
 
 $finder = PhpCsFixer\Finder::create()
 	->in(__DIR__)
-	->notPath('addon')
-	->notPath('bin/dev')
-	->notPath('config')
-	->notPath('doc')
-	->notPath('images')
-	->notPath('mods')
-	->notPath('spec')
-	->notPath('vendor')
-	->notPath('view/asset')
-	->notPath('lang')
-	->notPath('view/smarty3/compiled');
+	->exclude([
+		'addon',
+		'bin/dev',
+		'config',
+		'doc',
+		'images',
+		'mods',
+		'spec',
+		'vendor',
+		'view/asset',
+		'lang',
+		'view/smarty3/compiled',
+	])
+	->append([
+		'.php-cs-fixer.dist.php',
+	])
+;
 
 $config = new PhpCsFixer\Config();
 return $config
 	->setRules([
 		'@PER-CS3x0'              => true,
 		'align_multiline_comment' => true,
-		'binary_operator_spaces' => [
+		'binary_operator_spaces'  => [
 			'default'   => 'single_space',
 			'operators' => [
 				'=>' => 'align_single_space_minimal',
@@ -36,7 +43,7 @@ return $config
 				'??' => 'align_single_space_minimal',
 			],
 		],
-		'braces_position'        => [
+		'braces_position' => [
 			'anonymous_classes_opening_brace'  => 'same_line',
 			'control_structures_opening_brace' => 'same_line',
 			'functions_opening_brace'          => 'next_line_unless_newline_at_signature_end',
@@ -44,13 +51,13 @@ return $config
 		'function_declaration' => [
 			'closure_function_spacing' => 'one',
 		],
-		'list_syntax'      => [
+		'list_syntax' => [
 			'syntax' => 'short',
 		],
-		'no_unused_imports'                  => true,
-		'single_import_per_statement'        => true,
-		'ternary_operator_spaces'            => false,
-		'new_with_parentheses' => true,
+		'no_unused_imports'           => true,
+		'single_import_per_statement' => true,
+		'ternary_operator_spaces'     => false,
+		'new_with_parentheses'        => true,
 	])
 	->setFinder($finder)
 	->setIndent("\t");

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -28,10 +28,6 @@ return $config
 	->setRules([
 		'@PER-CS3x0'              => true,
 		'align_multiline_comment' => true,
-		'array_indentation'       => true,
-		'array_syntax'            => [
-			'syntax' => 'short',
-		],
 		'binary_operator_spaces' => [
 			'default'   => 'single_space',
 			'operators' => [
@@ -40,36 +36,20 @@ return $config
 				'??' => 'align_single_space_minimal',
 			],
 		],
-		'blank_line_after_namespace'   => true,
 		'braces_position'        => [
 			'anonymous_classes_opening_brace'  => 'same_line',
 			'control_structures_opening_brace' => 'same_line',
 			'functions_opening_brace'          => 'next_line_unless_newline_at_signature_end',
 		],
-		'elseif'               => true,
-		'encoding'             => true,
-		'full_opening_tag'     => true,
 		'function_declaration' => [
 			'closure_function_spacing' => 'one',
 		],
-		'indentation_type' => true,
-		'line_ending'      => true,
 		'list_syntax'      => [
 			'syntax' => 'short',
 		],
-		'lowercase_keywords'                 => true,
-		'modifier_keywords'                  => true,
-		'no_closing_tag'                     => true,
-		'no_spaces_after_function_name'      => true,
 		'spaces_inside_parentheses'          => false,
-		'no_trailing_whitespace'             => true,
-		'no_trailing_whitespace_in_comment'  => true,
 		'no_unused_imports'                  => true,
-		'single_blank_line_at_eof'           => true,
-		'single_class_element_per_statement' => true,
 		'single_import_per_statement'        => true,
-		'single_line_after_imports'          => true,
-		'switch_case_space'                  => true,
 		'ternary_operator_spaces'            => false,
 		'new_with_parentheses' => true,
 	])

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -47,7 +47,6 @@ return $config
 		'list_syntax'      => [
 			'syntax' => 'short',
 		],
-		'spaces_inside_parentheses'          => false,
 		'no_unused_imports'                  => true,
 		'single_import_per_statement'        => true,
 		'ternary_operator_spaces'            => false,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -58,6 +58,7 @@ return $config
 			'syntax' => 'short',
 		],
 		'lowercase_keywords'                 => true,
+		'modifier_keywords'                  => true,
 		'no_closing_tag'                     => true,
 		'no_spaces_after_function_name'      => true,
 		'spaces_inside_parentheses'          => false,
@@ -70,9 +71,6 @@ return $config
 		'single_line_after_imports'          => true,
 		'switch_case_space'                  => true,
 		'ternary_operator_spaces'            => false,
-		'visibility_required'                => [
-			'elements' => ['property', 'method']
-		],
 		'new_with_parentheses' => true,
 	])
 	->setFinder($finder)

--- a/.rector.php
+++ b/.rector.php
@@ -21,6 +21,8 @@ return RectorConfig::configure()
 	])
 	->withIndent("\t", 4)
 	->withPhpVersion(70400)
+	->withPhpLevel(2)
+	->withDowngradeSets(php74: true)
 	// ->withPhp53Sets()
 	// ->withPhpSets()
 	// ->withTypeCoverageLevel(0)
@@ -28,5 +30,10 @@ return RectorConfig::configure()
 	// ->withCodeQualityLevel(0)
 	->withRules([
 		ListToArrayDestructRector::class,
+	])
+	->withSkip([
+		\Rector\DowngradePhp80\Rector\FuncCall\DowngradeSubstrFalsyRector::class,
+		\Rector\DowngradePhp80\Rector\FuncCall\DowngradeArrayFilterNullableCallbackRector::class,
+		\Rector\DowngradePhp82\Rector\FuncCall\DowngradeIteratorCountToArrayRector::class,
 	])
 ;

--- a/.rector.php
+++ b/.rector.php
@@ -19,21 +19,11 @@ return RectorConfig::configure()
 		__DIR__ . '/tests',
 		__DIR__ . '/view',
 	])
-	->withIndent("\t", 4)
-	->withPhpVersion(70400)
-	->withPhpLevel(2)
-	->withDowngradeSets(php74: true)
-	// ->withPhp53Sets()
 	// ->withPhpSets()
 	// ->withTypeCoverageLevel(0)
 	// ->withDeadCodeLevel(0)
 	// ->withCodeQualityLevel(0)
 	->withRules([
 		ListToArrayDestructRector::class,
-	])
-	->withSkip([
-		\Rector\DowngradePhp80\Rector\FuncCall\DowngradeSubstrFalsyRector::class,
-		\Rector\DowngradePhp80\Rector\FuncCall\DowngradeArrayFilterNullableCallbackRector::class,
-		\Rector\DowngradePhp82\Rector\FuncCall\DowngradeIteratorCountToArrayRector::class,
 	])
 ;

--- a/.rector.php
+++ b/.rector.php
@@ -19,6 +19,9 @@ return RectorConfig::configure()
 		__DIR__ . '/tests',
 		__DIR__ . '/view',
 	])
+	->withIndent("\t", 4)
+	->withPhpVersion(70400)
+	// ->withPhp53Sets()
 	// ->withPhpSets()
 	// ->withTypeCoverageLevel(0)
 	// ->withDeadCodeLevel(0)

--- a/mod/message.php
+++ b/mod/message.php
@@ -46,7 +46,7 @@ function message_init()
 
 	$head_tpl = Renderer::getMarkupTemplate('message-head.tpl');
 	DI::page()['htmlhead'] .= Renderer::replaceMacros($head_tpl, [
-		'$base' => (string)DI::baseUrl()
+		'$base' => (string) DI::baseUrl(),
 	]);
 }
 
@@ -167,7 +167,7 @@ function message_content()
 		$tpl = Renderer::getMarkupTemplate('msg-header.tpl');
 		DI::page()['htmlhead'] .= Renderer::replaceMacros($tpl, [
 			'$nickname' => DI::userSession()->getLocalUserNickname(),
-			'$linkurl'  => DI::l10n()->t('Please enter a link URL:')
+			'$linkurl'  => DI::l10n()->t('Please enter a link URL:'),
 		]);
 
 		$recipientId = DI::args()->getArgv()[2] ?? null;
@@ -188,7 +188,7 @@ function message_content()
 			'$upload'      => DI::l10n()->t('Upload photo'),
 			'$insert'      => DI::l10n()->t('Insert web link'),
 			'$wait'        => DI::l10n()->t('Please wait'),
-			'$submit'      => DI::l10n()->t('Send Message')
+			'$submit'      => DI::l10n()->t('Send Message'),
 		]);
 		return $o;
 	}
@@ -232,14 +232,14 @@ function message_content()
 			WHERE `mail`.`uid` = ? AND `mail`.`id` = ?
 			LIMIT 1",
 			DI::userSession()->getLocalUserId(),
-			DI::args()->getArgv()[1]
+			DI::args()->getArgv()[1],
 		);
 		if (DBA::isResult($message)) {
 			$contact_id = $message['contact-id'];
 
 			$params = [
 				DI::userSession()->getLocalUserId(),
-				$message['parent-uri']
+				$message['parent-uri'],
 			];
 
 			if ($message['convid']) {
@@ -256,7 +256,7 @@ function message_content()
 				WHERE `mail`.`uid` = ?
 				$sql_extra
 				ORDER BY `mail`.`created` ASC",
-				...$params
+				...$params,
 			);
 
 			$messages = DBA::toArray($messages_stmt);
@@ -274,7 +274,7 @@ function message_content()
 		$tpl = Renderer::getMarkupTemplate('msg-header.tpl');
 		DI::page()['htmlhead'] .= Renderer::replaceMacros($tpl, [
 			'$nickname' => DI::userSession()->getLocalUserNickname(),
-			'$linkurl'  => DI::l10n()->t('Please enter a link URL:')
+			'$linkurl'  => DI::l10n()->t('Please enter a link URL:'),
 		]);
 
 		$mails   = [];
@@ -345,7 +345,7 @@ function message_content()
 			'$upload'      => DI::l10n()->t('Upload photo'),
 			'$insert'      => DI::l10n()->t('Insert web link'),
 			'$submit'      => DI::l10n()->t('Send Message'),
-			'$wait'        => DI::l10n()->t('Please wait')
+			'$wait'        => DI::l10n()->t('Please wait'),
 		]);
 
 		return $o;

--- a/mod/message.php
+++ b/mod/message.php
@@ -147,7 +147,7 @@ function message_content()
 				DI::baseUrl()->redirect('message');
 			}
 
-			DI::baseUrl()->redirect('message/' . $conversation['id'] );
+			DI::baseUrl()->redirect('message/' . $conversation['id']);
 		} else {
 			$parentmail = DBA::selectFirst('mail', ['parent-uri'], ['id' => DI::args()->getArgv()[2], 'uid' => DI::userSession()->getLocalUserId()]);
 			if (DBA::isResult($parentmail)) {

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -26,7 +26,7 @@ use Psr\Log\LoggerInterface;
  */
 abstract class BaseRepository
 {
-	const LIMIT = 30;
+	public const LIMIT = 30;
 
 	/**
 	 * @var string This should be set to the main database table name the depository is using
@@ -75,7 +75,7 @@ abstract class BaseRepository
 		array $params = [],
 		int $min_id = null,
 		int $max_id = null,
-		int $limit = self::LIMIT
+		int $limit = self::LIMIT,
 	): BaseCollection {
 		$totalCount = $this->count($condition);
 

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -75,7 +75,7 @@ abstract class BaseRepository
 		array $params = [],
 		int $min_id = null,
 		int $max_id = null,
-		int $limit = self::LIMIT,
+		int $limit = self::LIMIT
 	): BaseCollection {
 		$totalCount = $this->count($condition);
 

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -156,7 +156,7 @@ abstract class BaseRepository
 	{
 		@trigger_error('`' . __METHOD__ . '()` is deprecated since 2025.07 and will be removed after 5 months, use `\Friendica\BaseRepository::_selectFirstRowAsArray()` instead.', E_USER_DEPRECATED);
 
-		$fields = $this->_selectFirstRowAsArray( $condition, $params);
+		$fields = $this->_selectFirstRowAsArray($condition, $params);
 
 		return $this->factory->createFromTableRow($fields);
 	}

--- a/src/Console/CreateDoxygen.php
+++ b/src/Console/CreateDoxygen.php
@@ -92,7 +92,7 @@ HELP;
 					$found = false;
 				}
 
-				if ($found && ( trim($previous) == "*/")) {
+				if ($found && (trim($previous) == "*/")) {
 					$found = false;
 				}
 

--- a/src/Console/CreateDoxygen.php
+++ b/src/Console/CreateDoxygen.php
@@ -117,33 +117,35 @@ HELP;
 	private function addDocumentation($line)
 	{
 		$trimmed = ltrim($line);
-		$length = strlen($line) - strlen($trimmed);
-		$space = substr($line, 0, $length);
+		$length  = strlen($line) - strlen($trimmed);
+		$space   = substr($line, 0, $length);
 
-		$block = $space . "/**\n" .
-			$space . " * \n" .
-			$space . " *\n"; /**/
+		$block = $space . "/**\n"
+			. $space . " * \n"
+			. $space . " *\n"; /**/
 
 
 		$left = strpos($line, "(");
 		$line = substr($line, $left + 1);
 
 		$right = strpos($line, ")");
-		$line = trim(substr($line, 0, $right));
+		$line  = trim(substr($line, 0, $right));
 
 		if ($line != "") {
 			$parameters = explode(",", $line);
 			foreach ($parameters as $parameter) {
 				$parameter = trim($parameter);
-				$splitted = explode("=", $parameter);
+				$splitted  = explode("=", $parameter);
 
 				$block .= $space . " * @param " . trim($splitted[0], "& ") . "\n";
 			}
-			if (count($parameters) > 0) $block .= $space . " *\n";
+			if (count($parameters) > 0) {
+				$block .= $space . " *\n";
+			}
 		}
 
-		$block .= $space . " * @return \n" .
-			$space . " */\n";
+		$block .= $space . " * @return \n"
+			. $space . " */\n";
 
 		return $block;
 	}

--- a/src/Contact/Introduction/Repository/Introduction.php
+++ b/src/Contact/Introduction/Repository/Introduction.php
@@ -35,7 +35,7 @@ class Introduction extends BaseRepository
 	 */
 	private function selectOne(array $condition, array $params = []): IntroductionEntity
 	{
-		$fields = $this->_selectFirstRowAsArray( $condition, $params);
+		$fields = $this->_selectFirstRowAsArray($condition, $params);
 
 		return $this->factory->createFromTableRow($fields);
 	}

--- a/src/Contact/Introduction/Repository/Introduction.php
+++ b/src/Contact/Introduction/Repository/Introduction.php
@@ -85,7 +85,7 @@ class Introduction extends BaseRepository
 				['order' => ['id' => 'DESC']],
 				$min_id,
 				$max_id,
-				$limit
+				$limit,
 			);
 		} catch (\Exception $e) {
 			throw new IntroductionPersistenceException(sprintf('Cannot select Introductions for used %d', $uid), $e);

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -82,7 +82,7 @@ class Worker
 		// Kill stale processes every 5 minutes
 		$last_cleanup = DI::keyValue()->get('worker_last_cleaned') ?? 0;
 		if (time() > ($last_cleanup + 300)) {
-			DI::keyValue()->set( 'worker_last_cleaned', time());
+			DI::keyValue()->set('worker_last_cleaned', time());
 			Worker\Cron::killStaleWorkers();
 		}
 

--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -27,25 +27,25 @@ class Worker
 	 * Process priority for the worker
 	 * @{
 	 */
-	const PRIORITY_UNDEFINED  = 0;
-	const PRIORITY_CRITICAL   = 10;
-	const PRIORITY_HIGH       = 20;
-	const PRIORITY_MEDIUM     = 30;
-	const PRIORITY_LOW        = 40;
-	const PRIORITY_NEGLIGIBLE = 50;
-	const PRIORITIES          = [self::PRIORITY_CRITICAL, self::PRIORITY_HIGH, self::PRIORITY_MEDIUM, self::PRIORITY_LOW, self::PRIORITY_NEGLIGIBLE];
+	public const PRIORITY_UNDEFINED  = 0;
+	public const PRIORITY_CRITICAL   = 10;
+	public const PRIORITY_HIGH       = 20;
+	public const PRIORITY_MEDIUM     = 30;
+	public const PRIORITY_LOW        = 40;
+	public const PRIORITY_NEGLIGIBLE = 50;
+	public const PRIORITIES          = [self::PRIORITY_CRITICAL, self::PRIORITY_HIGH, self::PRIORITY_MEDIUM, self::PRIORITY_LOW, self::PRIORITY_NEGLIGIBLE];
 	/* @}*/
 
-	const STATE_STARTUP    = 1; // Worker is in startup. This takes most time.
-	const STATE_LONG_LOOP  = 2; // Worker is processing the whole - long - loop.
-	const STATE_REFETCH    = 3; // Worker had refetched jobs in the execution loop.
-	const STATE_SHORT_LOOP = 4; // Worker is processing preassigned jobs, thus saving much time.
+	public const STATE_STARTUP    = 1; // Worker is in startup. This takes most time.
+	public const STATE_LONG_LOOP  = 2; // Worker is processing the whole - long - loop.
+	public const STATE_REFETCH    = 3; // Worker had refetched jobs in the execution loop.
+	public const STATE_SHORT_LOOP = 4; // Worker is processing preassigned jobs, thus saving much time.
 
-	const FAST_COMMANDS = ['APDelivery', 'Delivery'];
+	public const FAST_COMMANDS = ['APDelivery', 'Delivery'];
 
-	const LOCK_PROCESS = 'worker_process';
-	const LOCK_WORKER  = 'worker';
-	const LAST_CHECK   = 'worker::check';
+	public const LOCK_PROCESS = 'worker_process';
+	public const LOCK_WORKER  = 'worker';
+	public const LAST_CHECK   = 'worker::check';
 
 	private static $up_start;
 	private static $db_duration       = 0;
@@ -212,7 +212,7 @@ class Worker
 	 */
 	public static function entriesExists(): bool
 	{
-		$stamp  = (float)microtime(true);
+		$stamp  = (float) microtime(true);
 		$exists = DBA::exists('workerqueue', ["NOT `done` AND `pid` = 0 AND `next_try` < ?", DateTimeFormat::utcNow()]);
 		self::$db_duration += (microtime(true) - $stamp);
 		return $exists;
@@ -226,7 +226,7 @@ class Worker
 	 */
 	public static function deferredEntries(): int
 	{
-		$stamp = (float)microtime(true);
+		$stamp = (float) microtime(true);
 		$count = DBA::count('workerqueue', ["NOT `done` AND `pid` = 0 AND `retrial` > ?", 0]);
 		self::$db_duration += (microtime(true) - $stamp);
 		self::$db_duration_count += (microtime(true) - $stamp);
@@ -241,7 +241,7 @@ class Worker
 	 */
 	public static function totalEntries(): int
 	{
-		$stamp = (float)microtime(true);
+		$stamp = (float) microtime(true);
 		$count = DBA::count('workerqueue', ['done' => false, 'pid' => 0]);
 		self::$db_duration += (microtime(true) - $stamp);
 		self::$db_duration_count += (microtime(true) - $stamp);
@@ -256,7 +256,7 @@ class Worker
 	 */
 	private static function highestPriority(): int
 	{
-		$stamp       = (float)microtime(true);
+		$stamp       = (float) microtime(true);
 		$condition   = ["`pid` = 0 AND NOT `done` AND `next_try` < ?", DateTimeFormat::utcNow()];
 		$workerqueue = DBA::selectFirst('workerqueue', ['priority'], $condition, ['order' => ['priority']]);
 		self::$db_duration += (microtime(true) - $stamp);
@@ -367,7 +367,7 @@ class Worker
 			self::$last_update = time();
 
 			if ($age > 1) {
-				$stamp = (float)microtime(true);
+				$stamp = (float) microtime(true);
 				DBA::update('workerqueue', ['executed' => DateTimeFormat::utcNow()], ['pid' => $mypid, 'done' => false]);
 				self::$db_duration += (microtime(true) - $stamp);
 				self::$db_duration_write += (microtime(true) - $stamp);
@@ -377,7 +377,7 @@ class Worker
 
 			self::execFunction($queue, $include, $argv, true);
 
-			$stamp     = (float)microtime(true);
+			$stamp     = (float) microtime(true);
 			$condition = ["`id` = ? AND `next_try` < ?", $queue['id'], DateTimeFormat::utcNow()];
 			if (DBA::update('workerqueue', ['done' => true], $condition)) {
 				DI::keyValue()->set('last_worker_execution', DateTimeFormat::utcNow());
@@ -390,7 +390,7 @@ class Worker
 
 		if (!self::validateInclude($include)) {
 			DI::logger()->warning('Include file is not valid', ['file' => $argv[0]]);
-			$stamp = (float)microtime(true);
+			$stamp = (float) microtime(true);
 			DBA::delete('workerqueue', ['id' => $queue['id']]);
 			self::$db_duration = (microtime(true) - $stamp);
 			self::$db_duration_write += (microtime(true) - $stamp);
@@ -399,7 +399,7 @@ class Worker
 
 		require_once $include;
 
-		$funcname = str_replace('.php', '', basename($argv[0])) .'_run';
+		$funcname = str_replace('.php', '', basename($argv[0])) . '_run';
 
 		if (function_exists($funcname)) {
 			// We constantly update the "executed" date every minute to avoid being killed too soon
@@ -411,7 +411,7 @@ class Worker
 			self::$last_update = time();
 
 			if ($age > 1) {
-				$stamp = (float)microtime(true);
+				$stamp = (float) microtime(true);
 				DBA::update('workerqueue', ['executed' => DateTimeFormat::utcNow()], ['pid' => $mypid, 'done' => false]);
 				self::$db_duration += (microtime(true) - $stamp);
 				self::$db_duration_write += (microtime(true) - $stamp);
@@ -419,7 +419,7 @@ class Worker
 
 			self::execFunction($queue, $funcname, $argv, false);
 
-			$stamp = (float)microtime(true);
+			$stamp = (float) microtime(true);
 			if (DBA::update('workerqueue', ['done' => true], ['id' => $queue['id']])) {
 				DI::keyValue()->set('last_worker_execution', DateTimeFormat::utcNow());
 			}
@@ -427,7 +427,7 @@ class Worker
 			self::$db_duration_write += (microtime(true) - $stamp);
 		} else {
 			DI::logger()->warning('Function does not exist', ['function' => $funcname]);
-			$stamp = (float)microtime(true);
+			$stamp = (float) microtime(true);
 			DBA::delete('workerqueue', ['id' => $queue['id']]);
 			self::$db_duration = (microtime(true) - $stamp);
 			self::$db_duration_write += (microtime(true) - $stamp);
@@ -551,7 +551,7 @@ class Worker
 
 		DI::logger()->info('Process start.', ['priority' => $queue['priority'], 'id' => $queue['id']]);
 
-		$stamp = (float)microtime(true);
+		$stamp = (float) microtime(true);
 
 		// We use the callstack here to analyze the performance of executed worker entries.
 		// For this reason the variables have to be initialized.
@@ -648,7 +648,7 @@ class Worker
 				$max = $r['Value'];
 			}
 			// Or it can be granted. This overrides the system variable
-			$stamp = (float)microtime(true);
+			$stamp = (float) microtime(true);
 			$r     = DBA::p('SHOW GRANTS');
 			self::$db_duration += (microtime(true) - $stamp);
 			while ($grants = DBA::fetch($r)) {
@@ -662,7 +662,7 @@ class Worker
 			DBA::close($r);
 		}
 
-		$stamp = (float)microtime(true);
+		$stamp = (float) microtime(true);
 		$used  = 0;
 		$sleep = 0;
 		$data  = DBA::p("SHOW PROCESSLIST");
@@ -684,7 +684,7 @@ class Worker
 			$level = ($used / $max) * 100;
 
 			if ($level >= $maxlevel) {
-				DI::logger()->warning('Maximum level (' . $maxlevel . '%) of user connections reached: ' . $used .'/' . $max);
+				DI::logger()->warning('Maximum level (' . $maxlevel . '%) of user connections reached: ' . $used . '/' . $max);
 				return true;
 			}
 		}
@@ -756,16 +756,16 @@ class Worker
 					if ($interval == 0) {
 						continue;
 					} else {
-						$interval = (int)$interval;
+						$interval = (int) $interval;
 					}
 
-					$stamp = (float)microtime(true);
+					$stamp = (float) microtime(true);
 					$jobs  = DBA::count('workerqueue', ["`done` AND `executed` > ?", DateTimeFormat::utc('now - ' . $interval . ' minute')]);
 					self::$db_duration += (microtime(true) - $stamp);
 					self::$db_duration_stat += (microtime(true) - $stamp);
 					$jobs_per_minute[$interval] = number_format($jobs / $interval, 0);
 				}
-				$processlist = ' - jpm: '.implode('/', $jobs_per_minute);
+				$processlist = ' - jpm: ' . implode('/', $jobs_per_minute);
 			}
 
 			// Create a list of queue entries grouped by their priority
@@ -778,12 +778,12 @@ class Worker
 			if (DI::config()->get('system', 'worker_debug')) {
 				$waiting_processes = 0;
 				// Now adding all processes with workerqueue entries
-				$stamp = (float)microtime(true);
+				$stamp = (float) microtime(true);
 				$jobs  = DBA::p("SELECT COUNT(*) AS `entries`, `priority` FROM `workerqueue` WHERE NOT `done` GROUP BY `priority`");
 				self::$db_duration += (microtime(true) - $stamp);
 				self::$db_duration_stat += (microtime(true) - $stamp);
 				while ($entry = DBA::fetch($jobs)) {
-					$stamp   = (float)microtime(true);
+					$stamp   = (float) microtime(true);
 					$running = DBA::count('workerqueue-view', ['priority' => $entry['priority']]);
 					self::$db_duration += (microtime(true) - $stamp);
 					self::$db_duration_stat += (microtime(true) - $stamp);
@@ -794,7 +794,7 @@ class Worker
 				DBA::close($jobs);
 			} else {
 				$waiting_processes = self::totalEntries();
-				$stamp             = (float)microtime(true);
+				$stamp             = (float) microtime(true);
 				$jobs              = DBA::p("SELECT COUNT(*) AS `running`, `priority` FROM `workerqueue-view` GROUP BY `priority` ORDER BY `priority`");
 				self::$db_duration += (microtime(true) - $stamp);
 				self::$db_duration_stat += (microtime(true) - $stamp);
@@ -810,7 +810,7 @@ class Worker
 
 			$listitem[0] = '0:' . max(0, $idle_workers);
 
-			$processlist .= ' ('.implode(', ', $listitem).')';
+			$processlist .= ' (' . implode(', ', $listitem) . ')';
 
 			if (DI::config()->get('system', 'worker_fastlane', false) && ($queues > 0) && ($active >= $queues) && self::entriesExists()) {
 				$top_priority = self::highestPriority();
@@ -866,7 +866,7 @@ class Worker
 	 */
 	public static function activeWorkers(): int
 	{
-		$stamp = (float)microtime(true);
+		$stamp = (float) microtime(true);
 		$count = DI::process()->countCommand('Worker.php');
 		self::$db_duration += (microtime(true) - $stamp);
 		self::$db_duration_count += (microtime(true) - $stamp);
@@ -882,7 +882,7 @@ class Worker
 	private static function getWorkerPIDList(): array
 	{
 		$ids   = [];
-		$stamp = (float)microtime(true);
+		$stamp = (float) microtime(true);
 
 		$queues = DBA::p("SELECT `process`.`pid`, COUNT(`workerqueue`.`pid`) AS `entries` FROM `process`
 			LEFT JOIN `workerqueue` ON `workerqueue`.`pid` = `process`.`pid` AND NOT `workerqueue`.`done`
@@ -905,7 +905,7 @@ class Worker
 	 */
 	private static function getWaitingJobForPID()
 	{
-		$stamp = (float)microtime(true);
+		$stamp = (float) microtime(true);
 		$r     = DBA::select('workerqueue', [], ['pid' => getmypid(), 'done' => false]);
 		self::$db_duration += (microtime(true) - $stamp);
 		if (DBA::isResult($r)) {
@@ -931,7 +931,7 @@ class Worker
 		}
 
 		$ids       = [];
-		$stamp     = (float)microtime(true);
+		$stamp     = (float) microtime(true);
 		$condition = ["`priority` = ? AND `pid` = 0 AND NOT `done` AND `next_try` < ?", $priority, DateTimeFormat::utcNow()];
 		$tasks     = DBA::select('workerqueue', ['id', 'command', 'parameter'], $condition, ['limit' => $limit, 'order' => ['retrial', 'created']]);
 		self::$db_duration += (microtime(true) - $stamp);
@@ -965,7 +965,7 @@ class Worker
 		$waiting    = [];
 		$priorities = [self::PRIORITY_CRITICAL, self::PRIORITY_HIGH, self::PRIORITY_MEDIUM, self::PRIORITY_LOW, self::PRIORITY_NEGLIGIBLE];
 		foreach ($priorities as $priority) {
-			$stamp = (float)microtime(true);
+			$stamp = (float) microtime(true);
 			if (DBA::exists('workerqueue', ["`priority` = ? AND `pid` = 0 AND NOT `done` AND `next_try` < ?", $priority, DateTimeFormat::utcNow()])) {
 				$waiting[$priority] = true;
 			}
@@ -978,7 +978,7 @@ class Worker
 
 		$running       = [];
 		$running_total = 0;
-		$stamp         = (float)microtime(true);
+		$stamp         = (float) microtime(true);
 		$processes     = DBA::p("SELECT COUNT(DISTINCT(`pid`)) AS `running`, `priority` FROM `workerqueue-view` GROUP BY `priority`");
 		self::$db_duration += (microtime(true) - $stamp);
 		while ($process = DBA::fetch($processes)) {
@@ -1056,7 +1056,7 @@ class Worker
 
 		// If there is not enough results we check without priority limit
 		if ($limit > 0) {
-			$stamp     = (float)microtime(true);
+			$stamp     = (float) microtime(true);
 			$condition = ["`pid` = 0 AND NOT `done` AND `next_try` < ?", DateTimeFormat::utcNow()];
 			$tasks     = DBA::select('workerqueue', ['id', 'command', 'parameter'], $condition, ['limit' => $limit, 'order' => ['priority', 'retrial', 'created']]);
 			self::$db_duration += (microtime(true) - $stamp);
@@ -1090,13 +1090,13 @@ class Worker
 			$worker[$pid][] = $id;
 		}
 
-		$stamp = (float)microtime(true);
+		$stamp = (float) microtime(true);
 		foreach ($worker as $worker_pid => $worker_ids) {
 			DI::logger()->info('Set queue entry', ['pid' => $worker_pid, 'ids' => $worker_ids]);
 			DBA::update(
 				'workerqueue',
 				['executed' => DateTimeFormat::utcNow(), 'pid' => $worker_pid],
-				['id'       => $worker_ids, 'done' => false, 'pid' => 0]
+				['id'       => $worker_ids, 'done' => false, 'pid' => 0],
 			);
 		}
 		self::$db_duration += (microtime(true) - $stamp);
@@ -1117,7 +1117,7 @@ class Worker
 			return $waiting;
 		}
 
-		$stamp = (float)microtime(true);
+		$stamp = (float) microtime(true);
 		if (!DI::lock()->acquire(self::LOCK_PROCESS)) {
 			return [];
 		}
@@ -1142,7 +1142,7 @@ class Worker
 	 */
 	public static function unclaimProcess(Process $process)
 	{
-		$stamp = (float)microtime(true);
+		$stamp = (float) microtime(true);
 		DBA::update('workerqueue', ['executed' => DBA::NULL_DATETIME, 'pid' => 0], ['pid' => $process->pid, 'done' => false]);
 		self::$db_duration += (microtime(true) - $stamp);
 		self::$db_duration_write += (microtime(true) - $stamp);
@@ -1440,7 +1440,7 @@ class Worker
 
 		DI::logger()->info('Deferred task', ['id' => $id, 'retrial' => $new_retrial, 'created' => $queue['created'], 'next_execution' => $next, 'old_prio' => $queue['priority'], 'new_prio' => $priority]);
 
-		$stamp  = (float)microtime(true);
+		$stamp  = (float) microtime(true);
 		$fields = ['retrial' => $new_retrial, 'next_try' => $next, 'executed' => DBA::NULL_DATETIME, 'pid' => 0, 'priority' => $priority];
 		DBA::update('workerqueue', $fields, ['id' => $id]);
 		self::$db_duration += (microtime(true) - $stamp);

--- a/src/Model/ItemHelper.php
+++ b/src/Model/ItemHelper.php
@@ -39,7 +39,7 @@ final class ItemHelper
 		Activity $activity,
 		LoggerInterface $logger,
 		Database $database,
-		BaseURL $baseURL,
+		BaseURL $baseURL
 	) {
 		$this->itemContent = $itemContent;
 		$this->activity    = $activity;

--- a/src/Model/ItemHelper.php
+++ b/src/Model/ItemHelper.php
@@ -39,7 +39,7 @@ final class ItemHelper
 		Activity $activity,
 		LoggerInterface $logger,
 		Database $database,
-		BaseURL $baseURL
+		BaseURL $baseURL,
 	) {
 		$this->itemContent = $itemContent;
 		$this->activity    = $activity;
@@ -92,7 +92,7 @@ final class ItemHelper
 				$item['uid'],
 				Protocol::ACTIVITYPUB,
 				Protocol::DIASPORA,
-				Protocol::DFRN
+				Protocol::DFRN,
 			];
 
 			$existing = Post::selectFirst(['id', 'network'], $condition);
@@ -105,7 +105,7 @@ final class ItemHelper
 						'uid'              => $item['uid'],
 						'network'          => $item['network'],
 						'existing_id'      => $existing['id'],
-						'existing_network' => $existing['network']
+						'existing_network' => $existing['network'],
 					]);
 				}
 
@@ -134,7 +134,7 @@ final class ItemHelper
 
 		$condition = [
 			'uri-id'  => $item['uri-id'], 'uid' => $item['uid'],
-			'network' => [$item['network'], Protocol::DFRN]
+			'network' => [$item['network'], Protocol::DFRN],
 		];
 		if (Post::exists($condition)) {
 			$this->logger->notice('duplicated item with the same uri found.', $condition);
@@ -236,13 +236,13 @@ final class ItemHelper
 
 		$default = [
 			'url'   => $item['author-link'], 'name' => $item['author-name'],
-			'photo' => $item['author-avatar'], 'network' => $item['network']
+			'photo' => $item['author-avatar'], 'network' => $item['network'],
 		];
 		$item['author-id'] = ($item['author-id'] ?? 0) ?: Contact::getIdForURL($item['author-link'], 0, null, $default);
 
 		$default = [
 			'url'   => $item['owner-link'], 'name' => $item['owner-name'],
-			'photo' => $item['owner-avatar'], 'network' => $item['network']
+			'photo' => $item['owner-avatar'], 'network' => $item['network'],
 		];
 		$item['owner-id'] = ($item['owner-id'] ?? 0) ?: Contact::getIdForURL($item['owner-link'], 0, null, $default);
 
@@ -264,7 +264,7 @@ final class ItemHelper
 			'uid', 'uri', 'parent-uri', 'id', 'deleted',
 			'uri-id', 'parent-uri-id', 'restrictions', 'verb',
 			'allow_cid', 'allow_gid', 'deny_cid', 'deny_gid',
-			'wall', 'private', 'origin', 'author-id'
+			'wall', 'private', 'origin', 'author-id',
 		];
 
 		$uids = $item['verb'] === Activity::VIEW ? [0, $item['uid']] : $item['uid'];
@@ -301,7 +301,7 @@ final class ItemHelper
 		$condition = [
 			'uri-id'        => $parent['parent-uri-id'],
 			'parent-uri-id' => $parent['parent-uri-id'],
-			'uid'           => $parent['uid']
+			'uid'           => $parent['uid'],
 		];
 		$params          = ['order' => ['id' => false]];
 		$toplevel_parent = Post::selectFirst($fields, $condition, $params);

--- a/src/Model/ItemHelper.php
+++ b/src/Model/ItemHelper.php
@@ -214,15 +214,15 @@ final class ItemHelper
 		}
 
 		// We haven't invented time travel by now.
-		if ($item['edited'] > $item['received'] ) {
+		if ($item['edited'] > $item['received']) {
 			$item['edited'] = $item['received'] ;
 		}
 
-		if ($item['changed'] > $item['received'] ) {
+		if ($item['changed'] > $item['received']) {
 			$item['changed'] = $item['received'] ;
 		}
 
-		if ($item['commented'] > $item['received'] ) {
+		if ($item['commented'] > $item['received']) {
 			$item['commented'] = $item['received'] ;
 		}
 

--- a/src/Module/Admin/Storage.php
+++ b/src/Module/Admin/Storage.php
@@ -62,7 +62,7 @@ class Storage extends BaseAdmin
 			}
 		}
 
-		if (!empty($_POST['submit_save_set']) && DI::config()->isWritable('storage', 'name') ) {
+		if (!empty($_POST['submit_save_set']) && DI::config()->isWritable('storage', 'name')) {
 			try {
 				$newstorage = DI::storageManager()->getWritableStorageByName($storagebackend);
 

--- a/src/Module/Admin/Storage.php
+++ b/src/Module/Admin/Storage.php
@@ -13,7 +13,6 @@ use Friendica\Core\Storage\Exception\InvalidClassStorageException;
 use Friendica\Core\Storage\Capability\ICanConfigureStorage;
 use Friendica\Core\Storage\Capability\ICanWriteToStorage;
 use Friendica\Module\BaseAdmin;
-use Friendica\Util\Strings;
 
 class Storage extends BaseAdmin
 {

--- a/src/Module/Contact/Profile.php
+++ b/src/Module/Contact/Profile.php
@@ -78,7 +78,7 @@ class Profile extends BaseModule
 		Page $page,
 		IManageConfigValues $config,
 		array $server,
-		array $parameters = []
+		array $parameters = [],
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
@@ -320,9 +320,9 @@ class Profile extends BaseModule
 			$this->logger->notice('Empty gsid for contact', ['contact' => $contact]);
 		}
 
-		$serverIgnored = $contact['gsid'] &&
-			$this->userGServer->isIgnoredByUser($this->session->getLocalUserId(), $contact['gsid']) ?
-				$this->t('This contact is on a server you ignored.')
+		$serverIgnored = $contact['gsid']
+			&& $this->userGServer->isIgnoredByUser($this->session->getLocalUserId(), $contact['gsid'])
+				? $this->t('This contact is on a server you ignored.')
 				: '';
 
 		$last_update = (($contact['last-update'] <= DBA::NULL_DATETIME) ? $this->t('Never') : DateTimeFormat::local($contact['last-update'], 'D, j M Y, g:i A'));
@@ -354,8 +354,8 @@ class Profile extends BaseModule
 					LocalRelationshipEntity::FFI_NONE        => $this->t('Disabled'),
 					LocalRelationshipEntity::FFI_INFORMATION => $this->t('Fetch information'),
 					LocalRelationshipEntity::FFI_KEYWORD     => $this->t('Fetch keywords'),
-					LocalRelationshipEntity::FFI_BOTH        => $this->t('Fetch information and keywords')
-				]
+					LocalRelationshipEntity::FFI_BOTH        => $this->t('Fetch information and keywords'),
+				],
 			];
 		}
 
@@ -365,23 +365,23 @@ class Profile extends BaseModule
 		if ($contact['network'] == Protocol::FEED) {
 			$remote_self_options = [
 				LocalRelationshipEntity::MIRROR_DEACTIVATED => $this->t('No mirroring'),
-				LocalRelationshipEntity::MIRROR_OWN_POST    => $this->t('Mirror as my own posting')
+				LocalRelationshipEntity::MIRROR_OWN_POST    => $this->t('Mirror as my own posting'),
 			];
 		} elseif ($contact['network'] == Protocol::ACTIVITYPUB) {
 			$remote_self_options = [
 				LocalRelationshipEntity::MIRROR_DEACTIVATED    => $this->t('No mirroring'),
-				LocalRelationshipEntity::MIRROR_NATIVE_RESHARE => $this->t('Native reshare')
+				LocalRelationshipEntity::MIRROR_NATIVE_RESHARE => $this->t('Native reshare'),
 			];
 		} elseif ($contact['network'] == Protocol::DFRN) {
 			$remote_self_options = [
 				LocalRelationshipEntity::MIRROR_DEACTIVATED    => $this->t('No mirroring'),
 				LocalRelationshipEntity::MIRROR_OWN_POST       => $this->t('Mirror as my own posting'),
-				LocalRelationshipEntity::MIRROR_NATIVE_RESHARE => $this->t('Native reshare')
+				LocalRelationshipEntity::MIRROR_NATIVE_RESHARE => $this->t('Native reshare'),
 			];
 		} else {
 			$remote_self_options = [
 				LocalRelationshipEntity::MIRROR_DEACTIVATED => $this->t('No mirroring'),
-				LocalRelationshipEntity::MIRROR_OWN_POST    => $this->t('Mirror as my own posting')
+				LocalRelationshipEntity::MIRROR_OWN_POST    => $this->t('Mirror as my own posting'),
 			];
 		}
 
@@ -475,7 +475,7 @@ class Profile extends BaseModule
 				$this->t('Mirror postings from this contact'),
 				$localRelationship->remoteSelf,
 				$this->t('Mark this contact as remote_self, this will cause friendica to repost new entries from this contact.'),
-				$remote_self_options
+				$remote_self_options,
 			],
 			'$channel_settings_label' => $this->t('Channel Settings'),
 			'$frequency_label'        => $this->t('Frequency of this contact in relevant channels'),

--- a/src/Module/Contact/Profile.php
+++ b/src/Module/Contact/Profile.php
@@ -78,7 +78,7 @@ class Profile extends BaseModule
 		Page $page,
 		IManageConfigValues $config,
 		array $server,
-		array $parameters = [],
+		array $parameters = []
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 

--- a/src/Module/Contact/Profile.php
+++ b/src/Module/Contact/Profile.php
@@ -187,7 +187,7 @@ class Profile extends BaseModule
 			}
 		}
 
-		if (empty($contact['network']) && ContactModel::isLocal($contact['url']) ) {
+		if (empty($contact['network']) && ContactModel::isLocal($contact['url'])) {
 			$contact['network']  = Protocol::DFRN;
 			$contact['protocol'] = Protocol::ACTIVITYPUB;
 		}

--- a/src/Navigation/Notifications/Repository/Notification.php
+++ b/src/Navigation/Notifications/Repository/Notification.php
@@ -45,7 +45,7 @@ class Notification extends BaseRepository
 	 */
 	private function selectOne(array $condition, array $params = []): NotificationEntity
 	{
-		$fields = $this->_selectFirstRowAsArray( $condition, $params);
+		$fields = $this->_selectFirstRowAsArray($condition, $params);
 
 		return $this->factory->createFromTableRow($fields);
 	}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -45,9 +45,9 @@ use GuzzleHttp\Psr7\Uri;
  */
 class DFRN
 {
-	const TOP_LEVEL = 0; // Top level posting
-	const REPLY     = 1; // Regular reply that is stored locally
-	const REPLY_RC  = 2; // Reply that will be relayed
+	public const TOP_LEVEL = 0; // Top level posting
+	public const REPLY     = 1; // Regular reply that is stored locally
+	public const REPLY_RC  = 2; // Reply that will be relayed
 
 	/**
 	 * Generates an array of contact and user for DFRN imports
@@ -442,8 +442,8 @@ class DFRN
 
 		$author = $doc->createElement($authorelement);
 
-		$namdate = DateTimeFormat::utc($owner['name-date'].'+00:00', DateTimeFormat::ATOM);
-		$picdate = DateTimeFormat::utc($owner['avatar-date'].'+00:00', DateTimeFormat::ATOM);
+		$namdate = DateTimeFormat::utc($owner['name-date'] . '+00:00', DateTimeFormat::ATOM);
+		$picdate = DateTimeFormat::utc($owner['avatar-date'] . '+00:00', DateTimeFormat::ATOM);
 
 		$attributes = [];
 
@@ -452,7 +452,7 @@ class DFRN
 		}
 
 		XML::addElement($doc, $author, 'name', $owner['name'], $attributes);
-		XML::addElement($doc, $author, 'uri', DI::baseUrl().'/profile/' . $owner['nickname'], $attributes);
+		XML::addElement($doc, $author, 'uri', DI::baseUrl() . '/profile/' . $owner['nickname'], $attributes);
 		XML::addElement($doc, $author, 'dfrn:handle', $owner['addr'], $attributes);
 
 		$attributes = [
@@ -491,14 +491,14 @@ class DFRN
 		$profile = DBA::selectFirst(
 			'owner-view',
 			['about', 'name', 'homepage', 'nickname', 'timezone', 'locality', 'region', 'country-name', 'pub_keywords', 'xmpp', 'dob'],
-			['uid' => $owner['uid'], 'hidewall' => false]
+			['uid' => $owner['uid'], 'hidewall' => false],
 		);
 		if (DBA::isResult($profile)) {
 			XML::addElement($doc, $author, 'poco:displayName', $profile['name']);
 			XML::addElement($doc, $author, 'poco:updated', $namdate);
 
 			if (trim($profile['dob']) > DBA::NULL_DATE) {
-				XML::addElement($doc, $author, 'poco:birthday', '0000-'.date('m-d', strtotime($profile['dob'])));
+				XML::addElement($doc, $author, 'poco:birthday', '0000-' . date('m-d', strtotime($profile['dob'])));
 			}
 
 			XML::addElement($doc, $author, 'poco:note', $profile['about']);
@@ -809,7 +809,7 @@ class DFRN
 			[
 				'rel'  => 'alternate',
 				'type' => 'text/html',
-				'href' => DI::baseUrl() . '/display/' . $item['guid']
+				'href' => DI::baseUrl() . '/display/' . $item['guid'],
 			],
 		);
 
@@ -968,7 +968,7 @@ class DFRN
 			$path_parts = explode('/', $parts['path']);
 			array_pop($path_parts);
 			$parts['path']    = implode('/', $path_parts);
-			$contact['batch'] = (string)Uri::fromParts($parts);
+			$contact['batch'] = (string) Uri::fromParts($parts);
 		}
 
 		$dest_url = ($public_batch ? $contact['batch'] : $contact['notify']);
@@ -1021,7 +1021,7 @@ class DFRN
 		}
 
 		if (!empty($res->message)) {
-			DI::logger()->info('Transmit to ' . $dest_url . ' returned status '.$res->status.' - '.$res->message);
+			DI::logger()->info('Transmit to ' . $dest_url . ' returned status ' . $res->status . ' - ' . $res->message);
 		}
 
 		return intval($res->status);
@@ -1045,8 +1045,8 @@ class DFRN
 	private static function fetchauthor(\DOMXPath $xpath, \DOMNode $context, array $importer, string $element, bool $onlyfetch, string $xml = ''): array
 	{
 		$author         = [];
-		$author["name"] = XML::getFirstNodeValue($xpath, $element."/atom:name/text()", $context);
-		$author["link"] = XML::getFirstNodeValue($xpath, $element."/atom:uri/text()", $context);
+		$author["name"] = XML::getFirstNodeValue($xpath, $element . "/atom:name/text()", $context);
+		$author["link"] = XML::getFirstNodeValue($xpath, $element . "/atom:uri/text()", $context);
 
 		$fields = ['id', 'uid', 'url', 'network', 'avatar-date', 'avatar', 'name-date', 'uri-date', 'addr',
 			'name', 'nick', 'about', 'location', 'keywords', 'xmpp', 'bdyear', 'bd', 'hidden', 'contact-type'];
@@ -1303,7 +1303,7 @@ class DFRN
 		$objxml = $obj_doc->saveXML($obj_element);
 
 		/// @todo This isn't totally clean. We should find a way to transform the namespaces
-		$objxml = str_replace("<".$element.' xmlns="http://www.w3.org/2005/Atom">', "<".$element.">", $objxml);
+		$objxml = str_replace("<" . $element . ' xmlns="http://www.w3.org/2005/Atom">', "<" . $element . ">", $objxml);
 		return($objxml);
 	}
 
@@ -1393,7 +1393,7 @@ class DFRN
 			$suggest['cid'],
 			$suggest['body'],
 			null,
-			$cid
+			$cid,
 		));
 
 		DI::notify()->createFromArray([
@@ -1403,7 +1403,7 @@ class DFRN
 			'uid'   => $owner['uid'],
 			'cid'   => $from_contact['uid'],
 			'item'  => $suggest,
-			'link'  => DI::baseUrl().'/notifications/intros',
+			'link'  => DI::baseUrl() . '/notifications/intros',
 		]);
 
 		return true;
@@ -1753,7 +1753,7 @@ class DFRN
 
 		$current = Post::selectFirst(
 			['id', 'uid', 'edited', 'body'],
-			['uri' => $item['uri'], 'uid' => $importer['importer_uid']]
+			['uri' => $item['uri'], 'uid' => $importer['importer_uid']],
 		);
 		// Is there an existing item?
 		if (DBA::isResult($current) && !self::isEditedTimestampNewer($current, $item)) {
@@ -2063,7 +2063,7 @@ class DFRN
 			// This is my contact on another system, but it's really me.
 			// Turn this into a wall post.
 			$notify       = Item::isRemoteSelf($importer, $item);
-			$item['wall'] = (bool)$notify;
+			$item['wall'] = (bool) $notify;
 
 			$posted_id = Item::insert($item, $notify);
 
@@ -2135,7 +2135,7 @@ class DFRN
 			return;
 		}
 
-		DI::logger()->info('deleting item '.$item['id'].' uri='.$uri);
+		DI::logger()->info('deleting item ' . $item['id'] . ' uri=' . $uri);
 
 		Item::markForDeletion(['id' => $item['id']]);
 	}

--- a/src/Protocol/DFRN.php
+++ b/src/Protocol/DFRN.php
@@ -1271,7 +1271,7 @@ class DFRN
 		$obj_doc               = new DOMDocument("1.0", "utf-8");
 		$obj_doc->formatOutput = true;
 
-		$obj_element = $obj_doc->createElementNS( ActivityNamespace::ATOM1, $element);
+		$obj_element = $obj_doc->createElementNS(ActivityNamespace::ATOM1, $element);
 
 		$activity_type = $xpath->query("activity:object-type/text()", $activity)->item(0)->nodeValue;
 		XML::addElement($obj_doc, $obj_element, "type", $activity_type);

--- a/src/Protocol/Diaspora/Repository/DiasporaContact.php
+++ b/src/Protocol/Diaspora/Repository/DiasporaContact.php
@@ -51,7 +51,7 @@ class DiasporaContact extends BaseRepository
 	 */
 	public function selectOne(array $condition, array $params = []): DiasporaContactEntity
 	{
-		$fields = $this->_selectFirstRowAsArray( $condition, $params);
+		$fields = $this->_selectFirstRowAsArray($condition, $params);
 
 		return $this->factory->createFromTableRow($fields);
 	}

--- a/src/Protocol/Diaspora/Repository/DiasporaContact.php
+++ b/src/Protocol/Diaspora/Repository/DiasporaContact.php
@@ -28,9 +28,9 @@ use Psr\Log\LoggerInterface;
 
 class DiasporaContact extends BaseRepository
 {
-	const ALWAYS_UPDATE                 = true;
-	const NEVER_UPDATE                  = false;
-	const UPDATE_IF_MISSING_OR_OUTDATED = null;
+	public const ALWAYS_UPDATE                 = true;
+	public const NEVER_UPDATE                  = false;
+	public const UPDATE_IF_MISSING_OR_OUTDATED = null;
 
 	protected static $table_name = 'diaspora-contact-view';
 
@@ -105,18 +105,18 @@ class DiasporaContact extends BaseRepository
 		$fields = [
 			'uri-id'            => $uriId,
 			'addr'              => $DiasporaContact->addr,
-			'alias'             => (string)$DiasporaContact->alias,
+			'alias'             => (string) $DiasporaContact->alias,
 			'nick'              => $DiasporaContact->nick,
 			'name'              => $DiasporaContact->name,
 			'given-name'        => $DiasporaContact->givenName,
 			'family-name'       => $DiasporaContact->familyName,
-			'photo'             => (string)$DiasporaContact->photo,
-			'photo-medium'      => (string)$DiasporaContact->photoMedium,
-			'photo-small'       => (string)$DiasporaContact->photoSmall,
-			'batch'             => (string)$DiasporaContact->batch,
-			'notify'            => (string)$DiasporaContact->notify,
-			'poll'              => (string)$DiasporaContact->poll,
-			'subscribe'         => (string)$DiasporaContact->subscribe,
+			'photo'             => (string) $DiasporaContact->photo,
+			'photo-medium'      => (string) $DiasporaContact->photoMedium,
+			'photo-small'       => (string) $DiasporaContact->photoSmall,
+			'batch'             => (string) $DiasporaContact->batch,
+			'notify'            => (string) $DiasporaContact->notify,
+			'poll'              => (string) $DiasporaContact->poll,
+			'subscribe'         => (string) $DiasporaContact->subscribe,
 			'searchable'        => $DiasporaContact->searchable,
 			'pubkey'            => $DiasporaContact->pubKey,
 			'gsid'              => $DiasporaContact->gsid,
@@ -246,7 +246,7 @@ class DiasporaContact extends BaseRepository
 			new DateTime($contact['created'] ?? 'now', new DateTimeZone('UTC')),
 			$interacting_count ?? 0,
 			$interacted_count  ?? 0,
-			$post_count        ?? 0
+			$post_count        ?? 0,
 		);
 
 		$DiasporaContact = $this->save($DiasporaContact);

--- a/tests/src/Core/Hooks/Model/InstanceManagerTest.php
+++ b/tests/src/Core/Hooks/Model/InstanceManagerTest.php
@@ -168,7 +168,7 @@ class InstanceManagerTest extends MockedTestCase
 	 */
 	public function testWrongInstanceName()
 	{
-		self::expectException(HookInstanceException::class	);
+		self::expectException(HookInstanceException::class);
 		self::expectExceptionMessage(sprintf('The class with the name %s isn\'t registered for the class or interface %s', 'fake', IAmADecoratedInterface::class));
 
 		$instance = new DiceInstanceManager(new Dice(), $this->hookFileManager);

--- a/view/theme/frio/php/PHPColors/Color.php
+++ b/view/theme/frio/php/PHPColors/Color.php
@@ -34,15 +34,15 @@ class Color
 		$color = str_replace("#", "", $hex);
 
 		// Make sure it's 6 digits
-		if ( strlen($color) === 3 ) {
+		if (strlen($color) === 3) {
 			$color = $color[0].$color[0].$color[1].$color[1].$color[2].$color[2];
-		} elseif ( strlen($color) != 6 ) {
+		} elseif (strlen($color) != 6) {
 			throw new Exception("HEX color needs to be 6 or 3 digits long");
 		}
 
-		$this->_hsl = self::hexToHsl( $color );
+		$this->_hsl = self::hexToHsl($color);
 		$this->_hex = $color;
-		$this->_rgb = self::hexToRgb( $color );
+		$this->_rgb = self::hexToRgb($color);
 	}
 
 	// ====================
@@ -81,22 +81,22 @@ class Color
 			$H = 0;
 			$S = 0;
 		} else {
-			if ( $L < 0.5 ) {
-				$S = $del_Max / ( $var_Max + $var_Min );
+			if ($L < 0.5) {
+				$S = $del_Max / ($var_Max + $var_Min);
 			} else {
-				$S = $del_Max / ( 2 - $var_Max - $var_Min );
+				$S = $del_Max / (2 - $var_Max - $var_Min);
 			}
 
-			$del_R = ( ( ( $var_Max - $var_R ) / 6 ) + ( $del_Max / 2 ) ) / $del_Max;
-			$del_G = ( ( ( $var_Max - $var_G ) / 6 ) + ( $del_Max / 2 ) ) / $del_Max;
-			$del_B = ( ( ( $var_Max - $var_B ) / 6 ) + ( $del_Max / 2 ) ) / $del_Max;
+			$del_R = ((($var_Max - $var_R) / 6) + ($del_Max / 2)) / $del_Max;
+			$del_G = ((($var_Max - $var_G) / 6) + ($del_Max / 2)) / $del_Max;
+			$del_B = ((($var_Max - $var_B) / 6) + ($del_Max / 2)) / $del_Max;
 
 			if ($var_R == $var_Max) {
 				$H = $del_B - $del_G;
 			} elseif ($var_G == $var_Max) {
-				$H = ( 1 / 3 ) + $del_R - $del_B;
+				$H = (1 / 3) + $del_R - $del_B;
 			} elseif ($var_B == $var_Max) {
-				$H = ( 2 / 3 ) + $del_G - $del_R;
+				$H = (2 / 3) + $del_G - $del_R;
 			}
 
 			if ($H < 0) {
@@ -123,13 +123,13 @@ class Color
 	public static function hslToHex($hsl = [])
 	{
 		// Make sure it's HSL
-		if (empty($hsl) || !isset($hsl["H"]) || !isset($hsl["S"]) || !isset($hsl["L"]) ) {
+		if (empty($hsl) || !isset($hsl["H"]) || !isset($hsl["S"]) || !isset($hsl["L"])) {
 			throw new Exception("Param was not an HSL array");
 		}
 
 		[$H, $S, $L] = [ $hsl['H'] / 360,$hsl['S'],$hsl['L'] ];
 
-		if ( $S == 0 ) {
+		if ($S == 0) {
 			$r = $L * 255;
 			$g = $L * 255;
 			$b = $L * 255;
@@ -143,9 +143,9 @@ class Color
 
 			$var_1 = 2 * $L - $var_2;
 
-			$r = 255 * self::_huetorgb( $var_1, $var_2, $H + (1 / 3) );
-			$g = 255 * self::_huetorgb( $var_1, $var_2, $H );
-			$b = 255 * self::_huetorgb( $var_1, $var_2, $H - (1 / 3) );
+			$r = 255 * self::_huetorgb($var_1, $var_2, $H + (1 / 3));
+			$g = 255 * self::_huetorgb($var_1, $var_2, $H);
+			$b = 255 * self::_huetorgb($var_1, $var_2, $H - (1 / 3));
 
 		}
 
@@ -196,7 +196,7 @@ class Color
 	public static function rgbToHex($rgb = [])
 	{
 		// Make sure it's RGB
-		if (empty($rgb) || !isset($rgb["R"]) || !isset($rgb["G"]) || !isset($rgb["B"]) ) {
+		if (empty($rgb) || !isset($rgb["R"]) || !isset($rgb["G"]) || !isset($rgb["B"])) {
 			throw new Exception("Param was not an RGB array");
 		}
 
@@ -206,7 +206,7 @@ class Color
 		$hex[1] = str_pad(dechex($rgb['G']), 2, '0', STR_PAD_LEFT);
 		$hex[2] = str_pad(dechex($rgb['B']), 2, '0', STR_PAD_LEFT);
 
-		return implode( '', $hex );
+		return implode('', $hex);
 
 	}
 
@@ -261,7 +261,7 @@ class Color
 	public function makeGradient($amount = self::DEFAULT_ADJUST)
 	{
 		// Decide which color needs to be made
-		if ( $this->isLight() ) {
+		if ($this->isLight()) {
 			$lightColor = $this->_hex;
 			$darkColor  = $this->darken($amount);
 		} else {
@@ -290,7 +290,7 @@ class Color
 		$g = hexdec($color[2].$color[3]);
 		$b = hexdec($color[4].$color[5]);
 
-		return (( $r * 299 + $g * 587 + $b * 114 ) / 1000 > $lighterThan);
+		return (($r * 299 + $g * 587 + $b * 114) / 1000 > $lighterThan);
 	}
 
 	/**
@@ -309,7 +309,7 @@ class Color
 		$g = hexdec($color[2].$color[3]);
 		$b = hexdec($color[4].$color[5]);
 
-		return (( $r * 299 + $g * 587 + $b * 114 ) / 1000 <= $darkerThan);
+		return (($r * 299 + $g * 587 + $b * 114) / 1000 <= $darkerThan);
 	}
 
 	/**
@@ -374,7 +374,7 @@ class Color
 		$css .= "{$prefix}filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#".$g['light']."', endColorstr='#".$g['dark']."');{$suffix}";
 
 		/* Safari 4+, Chrome 1-9 */
-		if ( $vintageBrowsers ) {
+		if ($vintageBrowsers) {
 			$css .= "{$prefix}background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#".$g['light']."), to(#".$g['dark']."));{$suffix}";
 		}
 
@@ -382,12 +382,12 @@ class Color
 		$css .= "{$prefix}background-image: -webkit-linear-gradient(top, #".$g['light'].", #".$g['dark'].");{$suffix}";
 
 		/* Firefox 3.6+ */
-		if ( $vintageBrowsers ) {
+		if ($vintageBrowsers) {
 			$css .= "{$prefix}background-image: -moz-linear-gradient(top, #".$g['light'].", #".$g['dark'].");{$suffix}";
 		}
 
 		/* Opera 11.10+ */
-		if ( $vintageBrowsers ) {
+		if ($vintageBrowsers) {
 			$css .= "{$prefix}background-image: -o-linear-gradient(top, #".$g['light'].", #".$g['dark'].");{$suffix}";
 		}
 
@@ -412,7 +412,7 @@ class Color
 	private function _darken($hsl, $amount = self::DEFAULT_ADJUST)
 	{
 		// Check if we were provided a number
-		if ( $amount ) {
+		if ($amount) {
 			$hsl['L'] = ($hsl['L'] * 100) - $amount;
 			$hsl['L'] = ($hsl['L'] < 0) ? 0:$hsl['L'] / 100;
 		} else {
@@ -432,7 +432,7 @@ class Color
 	private function _lighten($hsl, $amount = self::DEFAULT_ADJUST)
 	{
 		// Check if we were provided a number
-		if ( $amount ) {
+		if ($amount) {
 			$hsl['L'] = ($hsl['L'] * 100) + $amount;
 			$hsl['L'] = ($hsl['L'] > 100) ? 1:$hsl['L'] / 100;
 		} else {
@@ -474,24 +474,24 @@ class Color
 	 */
 	private static function _huetorgb($v1, $v2, $vH)
 	{
-		if ( $vH < 0 ) {
+		if ($vH < 0) {
 			$vH += 1;
 		}
 
-		if ( $vH > 1 ) {
+		if ($vH > 1) {
 			$vH -= 1;
 		}
 
-		if ( (6 * $vH) < 1 ) {
+		if ((6 * $vH) < 1) {
 			return ($v1 + ($v2 - $v1) * 6 * $vH);
 		}
 
-		if ( (2 * $vH) < 1 ) {
+		if ((2 * $vH) < 1) {
 			return $v2;
 		}
 
-		if ( (3 * $vH) < 2 ) {
-			return ($v1 + ($v2 - $v1) * ( (2 / 3) - $vH ) * 6);
+		if ((3 * $vH) < 2) {
+			return ($v1 + ($v2 - $v1) * ((2 / 3) - $vH) * 6);
 		}
 
 		return $v1;
@@ -510,9 +510,9 @@ class Color
 		$color = str_replace("#", "", $hex);
 
 		// Make sure it's 6 digits
-		if ( strlen($color) == 3 ) {
+		if (strlen($color) == 3) {
 			$color = $color[0].$color[0].$color[1].$color[1].$color[2].$color[2];
-		} elseif ( strlen($color) != 6 ) {
+		} elseif (strlen($color) != 6) {
 			throw new Exception("HEX color needs to be 6 or 3 digits long");
 		}
 

--- a/view/theme/frio/php/PHPColors/Color.php
+++ b/view/theme/frio/php/PHPColors/Color.php
@@ -35,7 +35,7 @@ class Color
 
 		// Make sure it's 6 digits
 		if (strlen($color) === 3) {
-			$color = $color[0].$color[0].$color[1].$color[1].$color[2].$color[2];
+			$color = $color[0] . $color[0] . $color[1] . $color[1] . $color[2] . $color[2];
 		} elseif (strlen($color) != 6) {
 			throw new Exception("HEX color needs to be 6 or 3 digits long");
 		}
@@ -61,9 +61,9 @@ class Color
 		$color = self::_checkHex($color);
 
 		// Convert HEX to DEC
-		$R = hexdec($color[0].$color[1]);
-		$G = hexdec($color[2].$color[3]);
-		$B = hexdec($color[4].$color[5]);
+		$R = hexdec($color[0] . $color[1]);
+		$G = hexdec($color[2] . $color[3]);
+		$B = hexdec($color[4] . $color[5]);
 
 		$HSL = [];
 
@@ -155,11 +155,11 @@ class Color
 		$b = dechex(round($b));
 
 		// Make sure we get 2 digits for decimals
-		$r = (strlen("".$r) === 1) ? "0".$r:$r;
-		$g = (strlen("".$g) === 1) ? "0".$g:$g;
-		$b = (strlen("".$b) === 1) ? "0".$b:$b;
+		$r = (strlen("" . $r) === 1) ? "0" . $r:$r;
+		$g = (strlen("" . $g) === 1) ? "0" . $g:$g;
+		$b = (strlen("" . $b) === 1) ? "0" . $b:$b;
 
-		return $r.$g.$b;
+		return $r . $g . $b;
 	}
 
 
@@ -175,9 +175,9 @@ class Color
 		$color = self::_checkHex($color);
 
 		// Convert HEX to DEC
-		$R = hexdec($color[0].$color[1]);
-		$G = hexdec($color[2].$color[3]);
-		$B = hexdec($color[4].$color[5]);
+		$R = hexdec($color[0] . $color[1]);
+		$G = hexdec($color[2] . $color[3]);
+		$B = hexdec($color[4] . $color[5]);
 
 		$RGB['R'] = $R;
 		$RGB['G'] = $G;
@@ -286,9 +286,9 @@ class Color
 		$color = ($color) ? $color : $this->_hex;
 
 		// Calculate straight from rbg
-		$r = hexdec($color[0].$color[1]);
-		$g = hexdec($color[2].$color[3]);
-		$b = hexdec($color[4].$color[5]);
+		$r = hexdec($color[0] . $color[1]);
+		$g = hexdec($color[2] . $color[3]);
+		$b = hexdec($color[4] . $color[5]);
 
 		return (($r * 299 + $g * 587 + $b * 114) / 1000 > $lighterThan);
 	}
@@ -305,9 +305,9 @@ class Color
 		$color = ($color) ? $color:$this->_hex;
 
 		// Calculate straight from rbg
-		$r = hexdec($color[0].$color[1]);
-		$g = hexdec($color[2].$color[3]);
-		$b = hexdec($color[4].$color[5]);
+		$r = hexdec($color[0] . $color[1]);
+		$g = hexdec($color[2] . $color[3]);
+		$b = hexdec($color[4] . $color[5]);
 
 		return (($r * 299 + $g * 587 + $b * 114) / 1000 <= $darkerThan);
 	}
@@ -368,31 +368,31 @@ class Color
 
 		$css = "";
 		/* fallback/image non-cover color */
-		$css .= "{$prefix}background-color: #".$this->_hex.";{$suffix}";
+		$css .= "{$prefix}background-color: #" . $this->_hex . ";{$suffix}";
 
 		/* IE Browsers */
-		$css .= "{$prefix}filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#".$g['light']."', endColorstr='#".$g['dark']."');{$suffix}";
+		$css .= "{$prefix}filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#" . $g['light'] . "', endColorstr='#" . $g['dark'] . "');{$suffix}";
 
 		/* Safari 4+, Chrome 1-9 */
 		if ($vintageBrowsers) {
-			$css .= "{$prefix}background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#".$g['light']."), to(#".$g['dark']."));{$suffix}";
+			$css .= "{$prefix}background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#" . $g['light'] . "), to(#" . $g['dark'] . "));{$suffix}";
 		}
 
 		/* Safari 5.1+, Mobile Safari, Chrome 10+ */
-		$css .= "{$prefix}background-image: -webkit-linear-gradient(top, #".$g['light'].", #".$g['dark'].");{$suffix}";
+		$css .= "{$prefix}background-image: -webkit-linear-gradient(top, #" . $g['light'] . ", #" . $g['dark'] . ");{$suffix}";
 
 		/* Firefox 3.6+ */
 		if ($vintageBrowsers) {
-			$css .= "{$prefix}background-image: -moz-linear-gradient(top, #".$g['light'].", #".$g['dark'].");{$suffix}";
+			$css .= "{$prefix}background-image: -moz-linear-gradient(top, #" . $g['light'] . ", #" . $g['dark'] . ");{$suffix}";
 		}
 
 		/* Opera 11.10+ */
 		if ($vintageBrowsers) {
-			$css .= "{$prefix}background-image: -o-linear-gradient(top, #".$g['light'].", #".$g['dark'].");{$suffix}";
+			$css .= "{$prefix}background-image: -o-linear-gradient(top, #" . $g['light'] . ", #" . $g['dark'] . ");{$suffix}";
 		}
 
 		/* Unprefixed version (standards): FF 16+, IE10+, Chrome 26+, Safari 7+, Opera 12.1+ */
-		$css .= "{$prefix}background-image: linear-gradient(to bottom, #".$g['light'].", #".$g['dark'].");{$suffix}";
+		$css .= "{$prefix}background-image: linear-gradient(to bottom, #" . $g['light'] . ", #" . $g['dark'] . ");{$suffix}";
 
 		// Return our CSS
 		return $css;
@@ -511,7 +511,7 @@ class Color
 
 		// Make sure it's 6 digits
 		if (strlen($color) == 3) {
-			$color = $color[0].$color[0].$color[1].$color[1].$color[2].$color[2];
+			$color = $color[0] . $color[0] . $color[1] . $color[1] . $color[2] . $color[2];
 		} elseif (strlen($color) != 6) {
 			throw new Exception("HEX color needs to be 6 or 3 digits long");
 		}

--- a/view/theme/frio/php/frio_boot.php
+++ b/view/theme/frio/php/frio_boot.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (C) 2010-2024, the Friendica project
  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
@@ -42,12 +43,13 @@ function load_page(AppHelper $appHelper)
  *
  * @return bool
  */
-function is_modal() {
-	$is_modal = false;
+function is_modal()
+{
+	$is_modal   = false;
 	$modalpages = get_modalpage_list();
 
 	foreach ($modalpages as $r => $value) {
-		if(strpos($_REQUEST['pagename'],$value) !== false) {
+		if (strpos($_REQUEST['pagename'], $value) !== false) {
 			$is_modal = true;
 		}
 	}
@@ -63,13 +65,14 @@ function is_modal() {
  *
  * @return array Page names as path
  */
-function get_modalpage_list() {
+function get_modalpage_list()
+{
 	//Array of pages which getting bootstrap modal dialogs
 	$modalpages = [
 		'message/new',
 		'settings/oauth/add',
 		'calendar/event/new',
-//		'fbrowser/image/'
+		//		'fbrowser/image/'
 	];
 
 	return $modalpages;
@@ -83,10 +86,11 @@ function get_modalpage_list() {
  *
  * @return array Pagenames as path
  */
-function get_standard_page_list() {
+function get_standard_page_list()
+{
 	//Arry of pages wich getting the standard page template
 	$standardpages = [//'profile',
-//			'fbrowser/image/'
+		//			'fbrowser/image/'
 	];
 
 	return $standardpages;
@@ -101,12 +105,13 @@ function get_standard_page_list() {
  * @param string $pagetitle Title of the actual page
  * @return bool
  */
-function is_standard_page($pagetitle) {
+function is_standard_page($pagetitle)
+{
 	$is_standard_page = false;
-	$standardpages = get_standard_page_list();
+	$standardpages    = get_standard_page_list();
 
 	foreach ($standardpages as $r => $value) {
-		if(strpos($pagetitle,$value) !== false) {
+		if (strpos($pagetitle, $value) !== false) {
 			$is_standard_page = true;
 		}
 	}
@@ -119,16 +124,20 @@ function is_standard_page($pagetitle) {
  * @param type $pagetitle
  * @return string
  */
-function get_page_type($pagetitle) {
+function get_page_type($pagetitle)
+{
 	$page_type = "";
 
-	if(is_modal())
+	if (is_modal()) {
 		$page_type = "modal";
+	}
 
-	if(is_standard_page($pagetitle))
+	if (is_standard_page($pagetitle)) {
 		$page_type = "standard_page";
+	}
 
-	if($page_type)
+	if ($page_type) {
 		return $page_type;
+	}
 
 }

--- a/view/theme/frio/php/frio_boot.php
+++ b/view/theme/frio/php/frio_boot.php
@@ -25,7 +25,7 @@ function load_page(AppHelper $appHelper)
 		require 'view/theme/frio/none.php';
 	} else {
 		$template = 'view/theme/' . $appHelper->getCurrentTheme() . '/'
-			. ((DI::page()['template'] ?? '') ?: 'default' ) . '.php';
+			. ((DI::page()['template'] ?? '') ?: 'default') . '.php';
 		if (file_exists($template)) {
 			require_once $template;
 		} else {


### PR DESCRIPTION
Refs https://github.com/friendica/friendica/pull/14989#discussion_r2831148643

In this PR I reviewed the php-cs-fixer rules.

1. The rulesets `@PER1` and `@PER2` are part of `@PER12` and where removed
2. The ruleset `@PER12` is replaced with the current `PER-CS3x0` ruleset.
3. Rules, that are already defined and configured like in `@PER12` and `@PER-CS3x0`, where removed.
4. The rule `'spaces_inside_parentheses' => false,` was removed, so the default rule with `'spaces_inside_parentheses' => true` from `@PER-CS3x0` is activated.
5. The code style for the `spaces_inside_parentheses` rule was fixed in all files.
6. The code style for the all other rules was fixed.