### PR TITLE
Compose Editor: Maintain settings via modal

### DIFF
--- a/view/templates/item/compose.tpl
+++ b/view/templates/item/compose.tpl
@@ -1,10 +1,11 @@
 {{*
   * Copyright (C) 2010-2026, the Friendica project
-  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
+  * SPDX-FileCopyrightText: 2010-2026 the Friendica project
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<div class="generic-page-wrapper">
+
+<div class="generic-page-wrapper" id="jot-page-wrapper-{{$id}}">
     <h2>{{$l10n.compose_title}}</h2>
     {{if $l10n.always_open_compose}}
     <p>{{$l10n.always_open_compose nofilter}}</p>
@@ -24,42 +25,45 @@
                 </div>
             {{/if}}
 
-            <div class="comment-edit-bb-{{$id}} btn-toolbar clearfix" role="toolbar" style="margin-bottom: 12px;">
-                <div class="btn-group">
-                    <button type="button" class="btn btn-default bb-img" aria-label="{{$l10n.edimg}}" title="{{$l10n.edimg}}" data-role="insert-formatting" data-bbcode="img" data-id="{{$id}}" tabindex="6">
-                        <i class="fa fa-picture-o"></i>
-                    </button>
-                    <button type="button" class="btn btn-default bb-attach" aria-label="{{$l10n.edattach}}" title="{{$l10n.edattach}}" ondragenter="return commentLinkDrop(event, {{$id}});" ondragover="return commentLinkDrop(event, {{$id}});" ondrop="commentLinkDropper(event);" onclick="commentGetLink({{$id}}, '{{$l10n.prompttext}}');" tabindex="7">
-                        <i class="fa fa-paperclip"></i>
-                    </button>
+            <div class="comment-edit-bb-{{$id}} btn-toolbar clearfix" role="toolbar" style="margin-bottom: 15px;">
+                <div class="pull-left">
+                    <div class="btn-group">
+                        <button type="button" class="btn btn-sm btn-default template-icon bb-img" aria-label="{{$l10n.edimg}}" title="{{$l10n.edimg}}" data-role="insert-formatting" data-bbcode="img" data-id="{{$id}}" tabindex="6">
+                            <i class="fa fa-picture-o"></i>
+                        </button>
+                        <button type="button" class="btn btn-sm btn-default template-icon bb-attach" aria-label="{{$l10n.edattach}}" title="{{$l10n.edattach}}" ondragenter="return commentLinkDrop(event, {{$id}});" ondragover="return commentLinkDrop(event, {{$id}});" ondrop="commentLinkDropper(event);" onclick="commentGetLink({{$id}}, '{{$l10n.prompttext}}');" tabindex="7">
+                            <i class="fa fa-paperclip"></i>
+                        </button>
+                    </div>
                 </div>
 
                 <div class="pull-right">
                     <div class="btn-group">
-                        <button type="button" class="btn btn-default bb-url" aria-label="{{$l10n.edurl}}" title="{{$l10n.edurl}}" onclick="insertFormatting('url',{{$id}});" tabindex="8">
+                        <button type="button" class="btn btn-sm btn-default template-icon bb-url" aria-label="{{$l10n.edurl}}" title="{{$l10n.edurl}}" onclick="insertFormatting('url',{{$id}});" tabindex="8">
                             <i class="fa fa-link"></i>
                         </button>
-                        <button type="button" class="btn btn-default underline" aria-label="{{$l10n.eduline}}" title="{{$l10n.eduline}}" onclick="insertFormatting('u',{{$id}});" tabindex="9">
+                        <button type="button" class="btn btn-sm btn-default template-icon underline" aria-label="{{$l10n.eduline}}" title="{{$l10n.eduline}}" onclick="insertFormatting('u',{{$id}});" tabindex="9">
                             <i class="fa fa-underline"></i>
                         </button>
-                        <button type="button" class="btn btn-default italic" aria-label="{{$l10n.editalic}}" title="{{$l10n.editalic}}" onclick="insertFormatting('i',{{$id}});" tabindex="10">
+                        <button type="button" class="btn btn-sm btn-default template-icon italic" aria-label="{{$l10n.editalic}}" title="{{$l10n.editalic}}" onclick="insertFormatting('i',{{$id}});" tabindex="10">
                             <i class="fa fa-italic"></i>
                         </button>
-                        <button type="button" class="btn btn-default bold" aria-label="{{$l10n.edbold}}" title="{{$l10n.edbold}}" onclick="insertFormatting('b',{{$id}});" tabindex="11">
+                        <button type="button" class="btn btn-sm btn-default template-icon bold" aria-label="{{$l10n.edbold}}" title="{{$l10n.edbold}}" onclick="insertFormatting('b',{{$id}});" tabindex="11">
                             <i class="fa fa-bold"></i>
                         </button>
-                    </div>
-                    <div class="btn-group">
-                        <button type="button" class="btn btn-default quote" aria-label="{{$l10n.edquote}}" title="{{$l10n.edquote}}" onclick="insertFormatting('quote',{{$id}});" tabindex="12">
+                        <button type="button" class="btn btn-sm btn-default template-icon quote" aria-label="{{$l10n.edquote}}" title="{{$l10n.edquote}}" onclick="insertFormatting('quote',{{$id}});" tabindex="12">
                             <i class="fa fa-quote-left"></i>
                         </button>
-                        <button type="button" id="button_emojipicker"class="btn btn-default emojis" aria-label="{{$l10n.edemojis}}" title="{{$l10n.edemojis}}" tabindex="13">
+                    </div>
+
+                    <div class="btn-group">
+                        <button id="button_emojipicker" type="button" class="btn btn-sm btn-default template-icon emojis" aria-label="{{$l10n.edemojis}}" title="{{$l10n.edemojis}}" tabindex="13">
                             <i class="fa fa-smile-o"></i>
                         </button>
-                        <button type="button" class="btn btn-default bb-url" aria-label="{{$l10n.contentwarn}}" title="{{$l10n.contentwarn}}" onclick="insertFormatting('abstract',{{$id}});" tabindex="14">
+                        <button type="button" class="btn btn-sm btn-default template-icon bb-url" aria-label="{{$l10n.contentwarn}}" title="{{$l10n.contentwarn}}" onclick="insertFormatting('abstract',{{$id}});" tabindex="14">
                             <i class="fa fa-eye"></i>
                         </button>
-                        <button type="button" class="btn btn-default code" aria-label="{{$l10n.edcode}}" title="{{$l10n.edcode}}" onclick="insertFormatting('code',{{$id}});" tabindex="4">
+                        <button type="button" class="btn btn-sm btn-default template-icon code" aria-label="{{$l10n.edcode}}" title="{{$l10n.edcode}}" onclick="insertFormatting('code',{{$id}});" tabindex="4">
                             <i class="fa fa-code"></i>
                         </button>
                     </div>
@@ -71,14 +75,17 @@
                     <textarea id="comment-edit-text-{{$id}}" class="comment-edit-text form-control text-autosize expandable-textarea" name="body" placeholder="{{$l10n.default}}" rows="18" tabindex="3" dir="auto" onkeydown="sendOnCtrlEnter(event, 'comment-edit-submit-{{$id}}')">{{$body}}</textarea>
                 </p>
             </div>
+
             <div class="comment-edit-submit-wrapper clearfix">
                 {{if $type == 'post'}}
-                    <div id="compose-additional-settings-location">
-                        <button type="button" name="permissions" class="btn btn-default" id="toggle-permissions" title="{{$l10n.toggle_permissions_tooltip}}" onclick="togglePermissions()" tabindex="5">
+                    <div class="pull-left form-inline">
+                        <button type="button" name="permissions" class="btn btn-sm btn-default template-icon" id="toggle-permissions" title="{{$l10n.toggle_permissions_tooltip}}" onclick="togglePermissions()" style="margin-right: 10px;" tabindex="5">
                             <i class="fa fa-ellipsis-h"></i> {{$l10n.toggle_permissions}}
                         </button>
-                        <input type="text" name="location" class="form-control" id="jot-location" value="{{$location}}" placeholder="{{$l10n.location_set}}" tabindex="6" />
-                        <button type="button" class="btn btn-default" id="profile-location"
+
+                        <input type="text" name="location" class="form-control input-sm d-inline-block" id="jot-location" value="{{$location}}" placeholder="{{$l10n.location_set}}" tabindex="6" style="width: auto; display: inline-block; vertical-align: middle;" />
+
+                        <button type="button" class="btn btn-sm btn-default template-icon" id="profile-location"
                             data-title-set="{{$l10n.location_set}}"
                             data-title-disabled="{{$l10n.location_disabled}}"
                             data-title-unavailable="{{$l10n.location_unavailable}}"
@@ -89,41 +96,53 @@
                         </button>
                     </div>
                 {{/if}}
-                <div>
-                    <span role="presentation" id="profile-rotator-wrapper">
-                        <img role="presentation" id="profile-rotator" src="images/rotator.gif" alt="{{$l10n.wait}}" title="{{$l10n.wait}}" style="display: none;" />
-                    </span>
-                    <span role="presentation" id="character-counter" class="grey text-info"></span>
+
+                <div class="pull-right">
+                    <span role="presentation" id="character-counter" class="grey text-info" style="margin-right: 10px;"></span>
                     <button type="button" class="btn btn-default" onclick="preview_comment_toggle({{$id}}, '{{$l10n.preview}}');" id="comment-edit-preview-link-{{$id}}" tabindex="8">
                         <i class="fa fa-eye"></i> <span id="preview-btn-text-{{$id}}">{{$l10n.preview}}</span>
                     </button>
-                    <button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="fa fa-envelope"></i> {{$l10n.submit}}</button>
+                    <button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9">
+                        <i class="fa fa-envelope"></i> {{$l10n.submit}}
+                    </button>
                 </div>
             </div>
 
             <div id="comment-edit-preview-{{$id}}" class="comment-edit-preview" style="display:none;"></div>
 
-            <div id="permissions-section" style="display: none;">
-                {{if $type == 'post'}}
-                    <h3>{{$l10n.visibility_title}}</h3>
-                    {{$acl_selector nofilter}}
-
-                    <div class="jotplugins">
-                        {{$jotplugins nofilter}}
+            <div class="modal fade" id="permissions-modal-{{$id}}" tabindex="-1" role="dialog">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                            <h4 class="modal-title">{{$l10n.visibility_title}}</h4>
+                        </div>
+                        <div class="modal-body">
+                            <div id="permissions-section">
+                                {{if $type == 'post'}}
+                                    <h3>{{$l10n.visibility_title}}</h3>
+                                    {{$acl_selector nofilter}}
+                                    <div class="jotplugins">{{$jotplugins nofilter}}</div>
+                                    {{if $scheduled_at}}{{$scheduled_at nofilter}}{{/if}}
+                                    {{if $created_at}}{{$created_at nofilter}}{{/if}}
+                                {{else}}
+                                    <input type="hidden" name="circle_allow" value="{{$circle_allow}}"/>
+                                    <input type="hidden" name="contact_allow" value="{{$contact_allow}}"/>
+                                    <input type="hidden" name="circle_deny" value="{{$circle_deny}}"/>
+                                    <input type="hidden" name="contact_deny" value="{{$contact_deny}}"/>
+                                {{/if}}
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-primary" data-dismiss="modal">OK</button>
+                        </div>
                     </div>
-
-                    {{if $scheduled_at}}{{$scheduled_at nofilter}}{{/if}}
-                    {{if $created_at}}{{$created_at nofilter}}{{/if}}
-                {{else}}
-                    <input type="hidden" name="circle_allow" value="{{$circle_allow}}"/>
-                    <input type="hidden" name="contact_allow" value="{{$contact_allow}}"/>
-                    <input type="hidden" name="circle_deny" value="{{$circle_deny}}"/>
-                    <input type="hidden" name="contact_deny" value="{{$contact_deny}}"/>
-                {{/if}}
+                </div>
             </div>
         </form>
     </div>
 </div>
+
 <script>
     dzFactory.setupDropzone('#dropzone-{{$id}}', 'comment-edit-text-{{$id}}');
 
@@ -140,92 +159,65 @@
         }
     }
 
-    document.addEventListener("DOMContentLoaded", function() {
-        var textareas = document.querySelectorAll(".expandable-textarea");
-
-        textareas.forEach(function(textarea) {
-            textarea.addEventListener("input", function() {
-                this.style.height = "auto";
-                this.style.height = (this.scrollHeight) + "px";
-            });
-
-            // Set initial height
-            textarea.style.height = "auto";
-            textarea.style.height = (textarea.scrollHeight) + "px";
-        });
-    });
-
     function togglePermissions() {
-        var permissionsSection = document.getElementById('permissions-section');
-        if (permissionsSection.style.display === 'none' || permissionsSection.style.display === '') {
-            permissionsSection.style.display = 'block';
-        } else {
-            permissionsSection.style.display = 'none';
-        }
+        $('#permissions-modal-{{$id}}').modal('show');
     }
 
     var formSubmitting = false;
 
-    function setFormSubmitting() {
-        formSubmitting = true;
+    function clearManualSave(id) {
+        localStorage.removeItem(`comment-edit-text-${id}`);
+        localStorage.removeItem(`last-saved-${id}`);
     }
 
-    document.addEventListener("DOMContentLoaded", function() {
-        var textareas = document.querySelectorAll(".expandable-textarea");
-
-        textareas.forEach(function(textarea) {
-            textarea.style.height = "auto";
-            textarea.style.height = (textarea.scrollHeight) + "px";
-
-            const savedContent = localStorage.getItem(`comment-edit-text-${textarea.id}`);
-            const lastSaved = localStorage.getItem(`last-saved-${textarea.id}`);
-
-            if (savedContent && lastSaved) {
-                const currentTime = new Date().getTime();
-                const timeElapsed = currentTime - parseInt(lastSaved, 10);
-
-                if (timeElapsed <= 600000) {
-                    textarea.value = savedContent;
-                    textarea.style.height = "auto";
-                    textarea.style.height = (textarea.scrollHeight) + "px";
-                } else {
-                    localStorage.removeItem(`comment-edit-text-${textarea.id}`);
-                    localStorage.removeItem(`last-saved-${textarea.id}`);
-                }
-            }
-        });
+    document.getElementById('comment-edit-form-{{$id}}').addEventListener('submit', function() {
+        formSubmitting = true;
+        clearManualSave('comment-edit-text-{{$id}}'); 
     });
-
-    setInterval(() => {
-        var textareas = document.querySelectorAll(".expandable-textarea");
-        textareas.forEach(function(textarea) {
-            if (textarea.value.trim() !== "") {
-                localStorage.setItem(`comment-edit-text-${textarea.id}`, textarea.value);
-                const currentTime = new Date().getTime();
-                localStorage.setItem(`last-saved-${textarea.id}`, currentTime.toString());
-            }
-        });
-    }, 5000);
-
-    function setFormSubmitting() {
-        formSubmitting = true;
-        var textareas = document.querySelectorAll(".expandable-textarea");
-        textareas.forEach(function(textarea) {
-            localStorage.removeItem(`comment-edit-text-${textarea.id}`);
-            localStorage.removeItem(`last-saved-${textarea.id}`);
-        });
-    }
 
     window.addEventListener("beforeunload", function (event) {
         if (!formSubmitting) {
             var textField = document.getElementById('comment-edit-text-{{$id}}').value.trim();
             if (textField.length > 0) {
-                var confirmationMessage = 'Are you sure you want to reload the page? All unsaved changes will be lost.';
-                event.returnValue = confirmationMessage;
-                return confirmationMessage;
+                event.returnValue = 'Discard changes?';
             }
         }
     });
 
-    document.getElementById('comment-edit-form-{{$id}}').addEventListener('submit', setFormSubmitting);
+    document.addEventListener("DOMContentLoaded", function() {
+        var textarea = document.getElementById('comment-edit-text-{{$id}}');
+
+        if (textarea) {
+            const savedContent = localStorage.getItem(`comment-edit-text-${textarea.id}`);
+            const lastSaved = localStorage.getItem(`last-saved-${textarea.id}`);
+
+            if (savedContent && lastSaved) {
+                const currentTime = new Date().getTime();
+                if (currentTime - parseInt(lastSaved, 10) <= 600000) {
+                    textarea.value = savedContent;
+                } else {
+                    clearManualSave(textarea.id);
+                }
+            }
+
+            setInterval(() => {
+                if (textarea.value.trim() !== "" && !formSubmitting) {
+                    localStorage.setItem(`comment-edit-text-${textarea.id}`, textarea.value);
+                    localStorage.setItem(`last-saved-${textarea.id}`, new Date().getTime().toString());
+                }
+            }, 5000);
+        }
+
+        // Textarea-Resizing Logik (einmalig für alle Textareas)
+        var textareas = document.querySelectorAll(".expandable-textarea");
+        textareas.forEach(function(tx) {
+            tx.addEventListener("input", function() {
+                this.style.height = "auto";
+                this.style.height = (this.scrollHeight) + "px";
+            });
+
+            tx.style.height = "auto";
+            tx.style.height = (tx.scrollHeight) + "px";
+        });
+    });
 </script>


### PR DESCRIPTION
Previously, the settings and permissions for sending posts with the Compose Editor were managed in a list below the post and below the preview. With this change, the settings are opened in a modal window. 

There, they can be edited and saved before sending. This significantly shortens the dialog and improves user-friendliness.

Old:

<img width="341" height="961" alt="Screenshot 2026-02-20 at 21-08-52 Compose joinfriendica" src="https://github.com/user-attachments/assets/b9b9d78b-d5b8-4441-951e-3f06cc32c23d" />

New:

<img width="521" height="864" alt="Screenshot 2026-02-20 at 21-11-11 Compose ˈloma" src="https://github.com/user-attachments/assets/d93c3d09-8446-450d-858b-c5a9db0f469f" />

Settings via modal

<img width="609" height="960" alt="Screenshot 2026-02-20 at 21-11-29 Compose ˈloma" src="https://github.com/user-attachments/assets/88969290-66fc-40b6-bbe7-9bea5c179791" />


