### PR TITLE
fixes for sortable lists

### DIFF
--- a/view/templates/settings/head.tpl
+++ b/view/templates/settings/head.tpl
@@ -8,10 +8,82 @@
 <script type="text/javascript" src="view/asset/es-jquery-sortable/source/js/jquery-sortable.js"></script>
 <script>
 	var ispublic = "{{$ispublic nofilter}}";
+	
+	// make widget indexing generic
+	function indexList(input,widgets,children){
+		var items = $(widgets).children(children);
+		var order = [];
+		for(let i=0; i < items.length; i++){
+			$(items[i]).attr('data-order',i);
+			$(items[i]).attr('tabindex',0);
+			order.push(items[i].id.replace('div_id_feature_','').replace('div_id_enable[','').replace('div_id_bookmark[','').replace(']',''));
+		}
+		$(input).val(JSON.stringify(order));
+	}
 
+	// arrow buttons and keyboard reordering
+	function moveListItem(element,direction){
+		// adjust target list item depending on button or keyboard control
+		if (element.className == 'sorter-mvup' || element.className == 'sorter-mvdn'){
+			var target = $(element).parent();
+		} else {
+			var target = $(element);
+		}
+		let total = $('.network .field').length;
+		// get the currently selected item index
+		let index = parseInt($(target).attr('data-order'));
+		let before = parseInt(index-1);
+		let after  = parseInt(index+1);
+		if(direction == 'up'){ // insert before
+			if (index != 0){
+				$(target).addClass('borderani move-up');
+				// this is for screen readers to announce action
+				$(target).attr('title','Moved up one space, position '+index+' in list');
+				previous = $(target).prev();
+				$(target).insertBefore( previous );
+			}
+		}
+		if (direction == 'down'){ // insert after
+			if (index != (total-1)){
+				$(target).addClass('borderani move-dn');
+				// this is for screen readers to announce action
+				$(target).attr('title','Moved down one space, position '+parseInt(after+1)+' in list');
+				next = $(target).next();				
+				$(target).insertAfter( next );
+			}
+		};
+		// timeout to clear title for screen readers
+		setTimeout(function(that){	$(that).attr('title','');$(that).removeClass('borderani move-up move-dn'); },1000, $(target));
+		// immediately update list index numbers
+		if ($(".network").length > 0){
+			indexList('#feature_widgetorder','.network','.field');
+		}
+		if ($(".timelines-widget").length > 0){
+			indexList('#widget_timelineorder','.timelines-widget','.field');
+		}
+		if ($(".timelines-menu").length > 0){
+			indexList('#menu_timelineorder','.timelines-menu','.field');
+		}
+		// set focus on list item
+		$(target).focus();
+	}
+	
+	// check if icon font is loaded, if not load core stylesheet
+	document.fonts.ready.then((fontFaceSet) => {
+	  const fontFaces = [...fontFaceSet];
+	  var awesomeLoaded = false;
+	  for(var f=0; f < fontFaces.length; f++){
+		if (fontFaces[f]['family'] == '"FontAwesome"' || fontFaces[f]['family'] == '"ForkAwesome"' ||
+			fontFaces[f]['family'] == 'FontAwesome'   || fontFaces[f]['family'] == 'ForkAwesome' ){
+			awesomeLoaded = true;
+		}
+	  }
+	  if (!awesomeLoaded){
+		$('head').append('<link rel="stylesheet" type="text/css" href="'+baseurl+'/view/asset/fork-awesome/css/fork-awesome.css">');
+	  }
+	});
 
 	$(document).ready(function() {
-
 		$('#contact_allow, #contact_deny, #circle_allow, #circle_deny').change(function() {
 			var selstr;
 			$('#contact_allow option:selected, #contact_deny option:selected, #circle_allow option:selected, #circle_deny option:selected').each( function() {
@@ -32,6 +104,15 @@
 			$(this).next('.settings-content-block').toggle();
 		});
 		$( function() {
+			// check if primary input is touch
+			if(window.matchMedia("(hover: none) and (pointer: coarse)").matches){ 
+				return; 
+			} else if ('ontouchstart' in window){
+				// fallback for older devices
+				return;
+			} else {
+				// assume drag-n-drop will work
+			}
 			var $container; // or onDrop loses reference
 			$(".sortable").sortable({
 				connectWith : ".sortable",
@@ -53,7 +134,6 @@
 					if(!container){ container = $container;};
       				$item.removeClass(container.group.options.draggedClass).removeAttr("style");
       				$("body").removeClass(container.group.options.bodyClass);
-      				console.log(container);
       			},
       			afterMove : function($placeholder, container, $closestItemOrContainer){
       				// need a delay so drag-n-drop is done before we re-index
@@ -71,70 +151,24 @@
       			}					
 			});
 		});
-		// make widget indexing generic
-		function indexList(input,widgets,children){
-			var items = $(widgets).children(children);
-			var order = [];
-			for(let i=0; i < items.length; i++){
-				$(items[i]).attr('data-order',i);
-				$(items[i]).attr('tabindex',0);
-				order.push(items[i].id.replace('div_id_feature_','').replace('div_id_enable[','').replace('div_id_bookmark[','').replace(']',''));
-			}
-			$(input).val(JSON.stringify(order));
-		}
+
 		// initial order index
 		indexList('#feature_widgetorder','.network','.field');
 		indexList('#widget_timelineorder','.timelines-widget','.field');
 		indexList('#menu_timelineorder','.timelines-menu','.field');
+		
+		// add arrow buttons for touch devices that cannot drag-n-drop or keyboard sort
+		$('.network .field, .timelines-widget .field, .timelines-menu .field').each(function(){
+			$(this).append('<div class="sorter-mvup" onclick="moveListItem(this,\'up\');" aria-hidden="true"></div><div class="sorter-mvdn" onclick="moveListItem(this,\'down\');" aria-hidden="true"></div>');
+		});
+
 		// accessible sorting with keyboard gives feedback to screenreaders
 		$('.network .field, .timelines-widget .field, .timelines-menu .field').bind('keydown', function(event){
-			let total = $('.network .field').length;
-			console.log('total = '+total);
-			// get the currently selected item index
-			let index = parseInt($(this).attr('data-order'));
-			let before = parseInt(index-1);
-			let after  = parseInt(index+1);
-			if(event.which == 38){ // up arrow
-				console.log('up arrow');
-				if (index != 0){
-					console.log('insert before '+before);
-					$(this).attr('title','Moved up one space, position '+index+' in list');
-					$(this).insertBefore( $('[data-order="'+before+'"]') );
-					setTimeout(function(that){
-      					if ($(".network").length > 0){
-      						indexList('#feature_widgetorder','.network','.field');
-      					}
-      					if ($(".timelines-widget").length > 0){
-      						indexList('#widget_timelineorder','.timelines-widget','.field');
-      					}
-      					if ($(".timelines-menu").length > 0){
-      						indexList('#menu_timelineorder','.timelines-menu','.field');
-      					} 
-						$(that).attr('title','');
-					},1000, $(this));
-				}
-				$(this).focus();
+			if(event.which == 38){
+				moveListItem(this,'up');
 			}
-			if (event.which == 40){ //down arrow
-				console.log('down arrow');
-				if (index != (total-1)){
-					console.log('insert after'+after);
-					$(this).attr('title','Moved down one space, position '+parseInt(after+1)+' in list');
-					$(this).insertAfter( $('[data-order="'+after+'"]') );
-					setTimeout(function(that){
-      					if ($(".network").length > 0){
-      						indexList('#feature_widgetorder','.network','.field');
-      					}
-      					if ($(".timelines-widget").length > 0){
-      						indexList('#widget_timelineorder','.timelines-widget','.field');
-      					}
-      					if ($(".timelines-menu").length > 0){
-      						indexList('#menu_timelineorder','.timelines-menu','.field');
-      					} 
-						$(that).attr('title','');
-					},1000, $(this));
-				}
-				$(this).focus();
+			if (event.which == 40){
+				moveListItem(this,'down');
 			}
 		});	
 	});
@@ -144,18 +178,20 @@
 <style>
 /* styling for sortable lists */
 .placeholder {
-	height: 60px;
+	height: 75px;
 	width: 100%;
-	background-color: rgba(255,255,255,.3);
-	border: 1px dashed black;
+	background-color: rgba(128,128,128,.1);
+	border: 1px dashed var(--link-color, blue);
 	list-style: none;
 }
 .sortable > .field {
 	position: relative;
-	border: 1px solid #eee;
+	border: 1px solid var(--border-color, #eee);
 	padding: 10px 30px 10px 30px;
 	margin: 0;
 	box-sizing: border-box;
+	min-height: 75px;
+	overflow: visible;
 }
 	.sortable > .field:first-of-type {
 		border-top-left-radius: 8px;
@@ -165,93 +201,92 @@
 		border-bottom-left-radius: 8px;
 		border-bottom-right-radius: 8px;
 	}
-	.sortable > .field::after {
-		content: '\2B0D';	/* unicode double-arrow */
-		position: absolute;
-		font-size: 18px;
-		right: 15px;
-		top: 40%;
-		opacity: .2;
-	}
-	.sortable > .field:hover::after,
-	.sortable > .field:focus::after,
-	.sortable > .field:active::after,
-	.sortable > .field:focus-within::after {
-		opacity: 1;
-	}
 	.dragged {
 		position: absolute !important;
 	}
+	[class^="sorter-"] {
+		position: absolute;
+		right: 5px;
+		height: 24px;
+		width:  24px;
+		border-radius: 100%;
+		color: inherit;
+		text-align: center;
+		opacity: .5;
+		z-index: 1;
+	}
+		[class^="sorter-"]:hover,
+		[class^="sorter-"]:active {
+			background-color: var(--dimbright, rgba(128,128,128,.2));
+			color: var(--link-color, inherit);
+			opacity: 1;
+		}
+	.sorter-mvup {
+		top: 10px;
+	}
+		.sorter-mvup::before {
+			content: '\f106';
+			font-family: "ForkAwesome","FontAwesome";
+			font-size: 14px;
+			line-height: 24px;
+		}
+	.sorter-mvdn {
+		bottom: 10px;
+	}
+		.sorter-mvdn::before {
+			content: '\f107';
+			font-family: "ForkAwesome","FontAwesome";
+			font-size: 14px;
+			line-height: 24px;	
+		}
+	/* motion indicator animations */
+	@keyframes borderflash {
+	  0% {
+		border-color: var(--link-color, blue);
+	  }
+	  100% {
+		border-color:  var(--border-color, #eee);
+	  }
+	}
+	@keyframes aniUp {
+		0% {
+			top: 100%;
+		}
+		100% {
+			top: 0%;
+		}
+	}
+	@keyframes aniDn {
+		0% {
+			bottom: 100%;
+		}
+		100% {
+			bottom: 0%;
+		}
+	}
+	.borderani {
+		animation: borderflash .5s ease .5s infinite normal none;
+	}
+		.borderani.move-up:before {
+			content: '';
+			display: block;
+			position: absolute;
+			top: 0%;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			border: 1px solid var(--link-color, blue);
+			animation: aniUp .5s ease 0s 1 normal none; 
+		}
+		.borderani.move-dn:after {
+			content: '';
+			display: block;
+			position: absolute;
+			bottom: 0%;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			border: 1px solid var(--link-color, blue);
+			animation: aniDn .5s ease 0s 1 normal none;
+		}
 </style>
-
-<script>
-/*
- * Content-Type:text/javascript
- *
- * A bridge between iPad and iPhone touch events and jquery draggable, 
- * sortable etc. mouse interactions.
- * @author Oleg Slobodskoi  
- * 
- * modified by John Hardy to use with any touch device
- * fixed breakage caused by jquery.ui so that mouseHandled internal flag is reset 
- * before each touchStart event
- * 
- */
-(function( $ ) {
-
-    $.support.touch = typeof Touch === 'object';
-
-    if (!$.support.touch) {
-        return;
-    }
-
-    var proto =  $.ui.mouse.prototype,
-    _mouseInit = proto._mouseInit;
-
-    $.extend( proto, {
-        _mouseInit: function() {
-            this.element
-            .bind( "touchstart." + this.widgetName, $.proxy( this, "_touchStart" ) );
-            _mouseInit.apply( this, arguments );
-        },
-
-        _touchStart: function( event ) {
-            if ( event.originalEvent.targetTouches.length != 1 ) {
-                return false;
-            }
-
-            this.element
-            .bind( "touchmove." + this.widgetName, $.proxy( this, "_touchMove" ) )
-            .bind( "touchend." + this.widgetName, $.proxy( this, "_touchEnd" ) );
-
-            this._modifyEvent( event );
-
-            $( document ).trigger($.Event("mouseup")); //reset mouseHandled flag in ui.mouse
-            this._mouseDown( event );
-
-            return false;           
-        },
-
-        _touchMove: function( event ) {
-            this._modifyEvent( event );
-            this._mouseMove( event );   
-        },
-
-        _touchEnd: function( event ) {
-            this.element
-            .unbind( "touchmove." + this.widgetName )
-            .unbind( "touchend." + this.widgetName );
-            this._mouseUp( event ); 
-        },
-
-        _modifyEvent: function( event ) {
-            event.which = 1;
-            var target = event.originalEvent.targetTouches[0];
-            event.pageX = target.clientX;
-            event.pageY = target.clientY;
-        }
-
-    });
-
-})( jQuery );
-</script>


### PR DESCRIPTION
* Removed mobile drag-n-drop script that did not work Added button interface for moving list items
* Fixed duplication error for keyboard control
* Added animation to make it clear which way item moved

I tried half a dozen different scripts that claimed to make drag-n-drop work on touch devices and none of them really worked  right and some may have had incompatible licenses to be included in Friendica's core. So I removed any attempt to try and make drag-n-drop work on touch. I also added some code to make sure that the drag-n-drop functions won't even attach if the script detects touch is the primary input (hopefully this will accommodate hybrid devices). Because touch devices would still try to convert `touchstart` to `mousedown` and `touchend` to `mouseup` - so even without a script that tries to make it work on touch it still was active on touch and making a mess of things.

This should work with any theme. I was going to use Unicode symbols on the buttons but there's too much inconsistency in them depending on the font to position them properly. So instead I'm using a ForkAwesome icon since that font is in the Friendica core. Though some themes don't use it, so there's a check to see if that font is in use and if not it loads it. Unless "FontAwesome" is loaded, which has this same glyph. I purposely did not use the `<i class="fa fa-angle-up"></i>` or `<i class="icon icon-angle-up"></i>` method, I placed the glyph directly to avoid conflicts with themes (Vier uses the "icon" class and does some positioning that is problematic, some of the deprecated themes use PNG sprites, etc.).  These buttons are also purposely hidden from screenreaders because they would use the keyboard control method...

Which had an intermittent error where sometimes, instead of just moving the list item, it duplicates it. I figured out why and fixed that as well.

Lastly I added a CSS animation for both the buttons and keyboard sorting to make it clearer what had moved in which direction:

![480_trimmed](https://github.com/user-attachments/assets/a18f9143-88bf-45c6-b6d9-9dee359cd39b)
