### PR TITLE
Update codebase to PHP 5.5

### DIFF
--- a/.rector.php
+++ b/.rector.php
@@ -18,7 +18,7 @@ return \Rector\Config\RectorConfig::configure()
 	])
 	->withIndent("\t", 4)
 	->withPhpVersion(70400)
-	->withPhpLevel(9)
+	->withPhpLevel(15)
 	// ->withTypeCoverageLevel(0)
 	// ->withDeadCodeLevel(0)
 	// ->withCodeQualityLevel(0)
@@ -26,7 +26,7 @@ return \Rector\Config\RectorConfig::configure()
 		\Rector\Php71\Rector\List_\ListToArrayDestructRector::class,
 	])
 	->withSets([
-		\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_54,
+		\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_55,
 		\Rector\Set\ValueObject\DowngradeLevelSetList::DOWN_TO_PHP_74,
 	])
 ;

--- a/src/App.php
+++ b/src/App.php
@@ -339,7 +339,7 @@ class App
 
 	private function registerTemplateEngine(): void
 	{
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 	}
 
 	/**

--- a/src/App.php
+++ b/src/App.php
@@ -65,9 +65,9 @@ use Psr\Log\LoggerInterface;
  */
 class App
 {
-	const PLATFORM = 'Friendica';
-	const CODENAME = 'Blutwurz';
-	const VERSION  = '2026.04-dev';
+	public const PLATFORM = 'Friendica';
+	public const CODENAME = 'Blutwurz';
+	public const VERSION  = '2026.04-dev';
 
 	/**
 	 * @internal
@@ -195,7 +195,7 @@ class App
 			$addonHelper,
 			$this->container->create(ModuleHTTPException::class),
 			$start_time,
-			$request
+			$request,
 		);
 	}
 
@@ -467,11 +467,11 @@ class App
 
 			if (!$this->mode->isInstall()) {
 				// Force SSL redirection
-				if ($this->config->get('system', 'force_ssl') &&
-					(empty($serverVars['HTTPS']) || $serverVars['HTTPS'] === 'off') &&
-					(empty($serverVars['HTTP_X_FORWARDED_PROTO']) || $serverVars['HTTP_X_FORWARDED_PROTO'] === 'http') &&
-					!empty($serverVars['REQUEST_METHOD']) &&
-					$serverVars['REQUEST_METHOD'] === 'GET') {
+				if ($this->config->get('system', 'force_ssl')
+					&& (empty($serverVars['HTTPS']) || $serverVars['HTTPS'] === 'off')
+					&& (empty($serverVars['HTTP_X_FORWARDED_PROTO']) || $serverVars['HTTP_X_FORWARDED_PROTO'] === 'http')
+					&& !empty($serverVars['REQUEST_METHOD'])
+					&& $serverVars['REQUEST_METHOD'] === 'GET') {
 					System::externalRedirect($this->baseURL . '/' . $this->args->getQueryString());
 				}
 
@@ -484,8 +484,8 @@ class App
 			if (!empty($queryVars['zrl']) && $this->mode->isNormal() && !$this->mode->isBackend() && !$this->session->getLocalUserId()) {
 				// Only continue when the given profile link seems valid.
 				// Valid profile links contain a path with "/profile/" and no query parameters
-				if ((parse_url($queryVars['zrl'], PHP_URL_QUERY) == '') &&
-					strpos(parse_url($queryVars['zrl'], PHP_URL_PATH) ?? '', '/profile/') !== false) {
+				if ((parse_url($queryVars['zrl'], PHP_URL_QUERY) == '')
+					&& strpos(parse_url($queryVars['zrl'], PHP_URL_PATH) ?? '', '/profile/') !== false) {
 					$this->auth->setUnauthenticatedVisitor($queryVars['zrl']);
 					OpenWebAuth::zrlInit();
 				} else {
@@ -655,10 +655,10 @@ class App
 
 		@file_put_contents(
 			$logfile,
-			DateTimeFormat::utcNow() . "\t" . round($duration, 3) . "\t" .
-			$this->requestId . "\t" . $code . "\t" .
-			$request . "\t" . $agent . "\n",
-			FILE_APPEND
+			DateTimeFormat::utcNow() . "\t" . round($duration, 3) . "\t"
+			. $this->requestId . "\t" . $code . "\t"
+			. $request . "\t" . $agent . "\n",
+			FILE_APPEND,
 		);
 	}
 }

--- a/src/Console/Addon.php
+++ b/src/Console/Addon.php
@@ -72,7 +72,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/ArchiveContact.php
+++ b/src/Console/ArchiveContact.php
@@ -69,7 +69,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/ArchiveContact.php
+++ b/src/Console/ArchiveContact.php
@@ -62,8 +62,8 @@ HELP;
 		parent::__construct($argv);
 
 		$this->appMode = $appMode;
-		$this->dba = $dba;
-		$this->l10n = $l10n;
+		$this->dba     = $dba;
+		$this->l10n    = $l10n;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/Cache.php
+++ b/src/Console/Cache.php
@@ -80,7 +80,7 @@ HELP;
 	{
 		if ($this->getOption('v')) {
 			$this->out('Executable: ' . $this->executable);
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/Config.php
+++ b/src/Console/Config.php
@@ -85,7 +85,7 @@ HELP;
 		parent::__construct($argv);
 
 		$this->appMode = $appMode;
-		$this->config = $config;
+		$this->config  = $config;
 	}
 
 	protected function doExecute(): int
@@ -102,8 +102,8 @@ HELP;
 		}
 
 		if (count($this->args) == 3) {
-			$cat = $this->getArgument(0);
-			$key = $this->getArgument(1);
+			$cat   = $this->getArgument(0);
+			$key   = $this->getArgument(1);
 			$value = $this->getArgument(2);
 
 			if (is_array($this->config->get($cat, $key))) {
@@ -116,16 +116,16 @@ HELP;
 
 			$result = $this->config->set($cat, $key, $value);
 			if ($result) {
-				$this->out("{$cat}.{$key} <= " .
-				           $this->config->get($cat, $key));
+				$this->out("{$cat}.{$key} <= "
+						   . $this->config->get($cat, $key));
 			} else {
 				$this->out("Unable to set {$cat}.{$key}");
 			}
 		}
 
 		if (count($this->args) == 2) {
-			$cat = $this->getArgument(0);
-			$key = $this->getArgument(1);
+			$cat   = $this->getArgument(0);
+			$key   = $this->getArgument(1);
 			$value = $this->config->get($this->getArgument(0), $this->getArgument(1));
 
 			if (is_array($value)) {

--- a/src/Console/Config.php
+++ b/src/Console/Config.php
@@ -92,7 +92,7 @@ HELP;
 	{
 		if ($this->getOption('v')) {
 			$this->out('Executable: ' . $this->executable);
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/Contact.php
+++ b/src/Console/Contact.php
@@ -66,7 +66,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/CreateDoxygen.php
+++ b/src/Console/CreateDoxygen.php
@@ -34,7 +34,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/DatabaseStructure.php
+++ b/src/Console/DatabaseStructure.php
@@ -73,11 +73,11 @@ HELP;
 	{
 		parent::__construct($argv);
 
-		$this->dba = $dba;
-		$this->dbaDefinition = $dbaDefinition;
+		$this->dba            = $dba;
+		$this->dbaDefinition  = $dbaDefinition;
 		$this->viewDefinition = $viewDefinition;
-		$this->config = $config;
-		$this->basePath = $basePath->getPath();
+		$this->config         = $config;
+		$this->basePath       = $basePath->getPath();
 	}
 
 	protected function doExecute(): int
@@ -112,7 +112,7 @@ HELP;
 			case "update":
 				$force    = $this->getOption(['f', 'force'], false);
 				$override = $this->getOption(['o', 'override'], false);
-				$output = Update::run($basePath, $force, $override,true, false);
+				$output   = Update::run($basePath, $force, $override, true, false);
 				break;
 			case "drop":
 				$execute = $this->getOption(['e', 'execute'], false);

--- a/src/Console/DatabaseStructure.php
+++ b/src/Console/DatabaseStructure.php
@@ -83,7 +83,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/DocBloxErrorChecker.php
+++ b/src/Console/DocBloxErrorChecker.php
@@ -30,7 +30,6 @@ use Friendica\AppHelper;
  */
 class DocBloxErrorChecker extends \Asika\SimpleConsole\Console
 {
-
 	protected $helpOptions = ['h', 'help', '?'];
 
 	/** @var string */
@@ -108,7 +107,7 @@ HELP;
 
 		//check half of the set and discard if that half is okay
 		$res = $filelist;
-		$i = count($res);
+		$i   = count($res);
 		do {
 			$this->out($i . '/' . count($filelist) . ' elements remaining.');
 			$res = $this->reduce($res, count($res) / 2);
@@ -135,7 +134,7 @@ HELP;
 
 	private function commandExists($command)
 	{
-		$prefix = strpos(strtolower(PHP_OS),'win') > -1 ? 'where' : 'which';
+		$prefix = strpos(strtolower(PHP_OS), 'win') > -1 ? 'where' : 'which';
 		exec("{$prefix} {$command}", $output, $returnVal);
 		return $returnVal === 0;
 	}

--- a/src/Console/DocBloxErrorChecker.php
+++ b/src/Console/DocBloxErrorChecker.php
@@ -60,7 +60,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/Extract.php
+++ b/src/Console/Extract.php
@@ -41,7 +41,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/Extract.php
+++ b/src/Console/Extract.php
@@ -7,8 +7,8 @@
 
 namespace Friendica\Console;
 
-use \RecursiveDirectoryIterator;
-use \RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  * Extracts translation strings from the Friendica project's files to be exported
@@ -64,16 +64,16 @@ HELP;
 			['index.php'],
 			glob('mod/*'),
 			glob('addon/*/*'),
-			$this->globRecursive('src')
+			$this->globRecursive('src'),
 		);
 
 		foreach ($files as $file) {
 			$str = file_get_contents($file);
 
-			$pat = '|->t\(([^\)]*+)[\)]|';
+			$pat  = '|->t\(([^\)]*+)[\)]|';
 			$patt = '|->tt\(([^\)]*+)[\)]|';
 
-			$matches = [];
+			$matches   = [];
 			$matchestt = [];
 
 			preg_match_all($pat, $str, $matches);
@@ -86,7 +86,7 @@ HELP;
 			if (!empty($matches[1])) {
 				foreach ($matches[1] as $long_match) {
 					$match_arr = preg_split('/(?<=[\'"])\s*,/', $long_match);
-					$match = $match_arr[0];
+					$match     = $match_arr[0];
 					if (!in_array($match, $arr)) {
 						if (substr($match, 0, 1) == '$') {
 							continue;
@@ -139,7 +139,7 @@ HELP;
 	private function globRecursive(string $path): array
 	{
 		$dir_iterator = new RecursiveDirectoryIterator($path);
-		$iterator = new RecursiveIteratorIterator($dir_iterator, RecursiveIteratorIterator::SELF_FIRST);
+		$iterator     = new RecursiveIteratorIterator($dir_iterator, RecursiveIteratorIterator::SELF_FIRST);
 
 		$return = [];
 		foreach ($iterator as $file) {

--- a/src/Console/FixAPDeliveryWorkerTaskParameters.php
+++ b/src/Console/FixAPDeliveryWorkerTaskParameters.php
@@ -77,7 +77,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/FixAPDeliveryWorkerTaskParameters.php
+++ b/src/Console/FixAPDeliveryWorkerTaskParameters.php
@@ -70,8 +70,8 @@ HELP;
 		parent::__construct($argv);
 
 		$this->appMode = $appMode;
-		$this->dba = $dba;
-		$this->l10n = $l10n;
+		$this->dba     = $dba;
+		$this->l10n    = $l10n;
 	}
 
 	protected function doExecute(): int
@@ -90,9 +90,9 @@ HELP;
 			throw new RuntimeException('Friendica isn\'t properly installed yet.');
 		}
 
-		$this->examined = 0;
+		$this->examined  = 0;
 		$this->processed = 0;
-		$this->errored = 0;
+		$this->errored   = 0;
 
 		do {
 			$result = $this->dba->select('workerqueue', ['id', 'parameter'], ["`command` = ? AND `parameter` LIKE ?", "APDelivery", "[\"%\",\"\",%"], ['limit' => [$this->examined, 100]]);
@@ -134,7 +134,7 @@ HELP;
 
 		if (is_array($parameters[2])) {
 			$parameters[4] = $parameters[2];
-			$contact = Contact::getById(current($parameters[2]), ['url']);
+			$contact       = Contact::getById(current($parameters[2]), ['url']);
 			$parameters[2] = $contact['url'];
 		}
 

--- a/src/Console/GlobalCommunityBlock.php
+++ b/src/Console/GlobalCommunityBlock.php
@@ -59,7 +59,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/GlobalCommunityBlock.php
+++ b/src/Console/GlobalCommunityBlock.php
@@ -53,7 +53,7 @@ HELP;
 		parent::__construct($argv);
 
 		$this->appMode = $appMode;
-		$this->l10n = $l10n;
+		$this->l10n    = $l10n;
 	}
 
 	protected function doExecute(): int
@@ -83,7 +83,7 @@ HELP;
 		}
 
 		$block_reason = $this->getArgument(1);
-		if(Contact::block($contact_id, $block_reason)) {
+		if (Contact::block($contact_id, $block_reason)) {
 			$this->out($this->l10n->t('The contact has been blocked from the node'));
 		} else {
 			throw new \RuntimeException('The contact block failed.');

--- a/src/Console/GlobalCommunitySilence.php
+++ b/src/Console/GlobalCommunitySilence.php
@@ -64,7 +64,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/GlobalCommunitySilence.php
+++ b/src/Console/GlobalCommunitySilence.php
@@ -58,7 +58,7 @@ HELP;
 		parent::__construct($argv);
 
 		$this->appMode = $appMode;
-		$this->dba  =$dba;
+		$this->dba     = $dba;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/Lock.php
+++ b/src/Console/Lock.php
@@ -74,7 +74,7 @@ HELP;
 	{
 		if ($this->getOption('v')) {
 			$this->out('Executable: ' . $this->executable);
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/Maintenance.php
+++ b/src/Console/Maintenance.php
@@ -66,7 +66,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/Maintenance.php
+++ b/src/Console/Maintenance.php
@@ -60,7 +60,7 @@ HELP;
 		parent::__construct($argv);
 
 		$this->appMode = $appMode;
-		$this->config = $config;
+		$this->config  = $config;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/PhpToPo.php
+++ b/src/Console/PhpToPo.php
@@ -15,11 +15,10 @@ use stdClass;
  */
 class PhpToPo extends \Asika\SimpleConsole\Console
 {
-
 	protected $helpOptions = ['h', 'help', '?'];
 
-	private $normBaseMsgIds = [];
-	const NORM_REGEXP = "|[\\\]|";
+	private $normBaseMsgIds  = [];
+	public const NORM_REGEXP = "|[\\\]|";
 
 	/** @var AppHelper */
 	private $appHelper;
@@ -100,9 +99,9 @@ HELP;
 		$out .= '"Content-Transfer-Encoding: 8bit\n"' . "\n";
 
 		// search for plural info
-		$lang = "";
+		$lang       = "";
 		$lang_logic = "";
-		$lang_pnum = $this->getOption('p', 2);
+		$lang_pnum  = $this->getOption('p', 2);
 
 		$infile = file($phpfile);
 		foreach ($infile as $l) {
@@ -128,27 +127,27 @@ HELP;
 
 		// load base messages.po and extract msgids
 		$base_msgids = [];
-		$base_f = file($base_path);
+		$base_f      = file($base_path);
 		if (!$base_f) {
 			throw new \RuntimeException('The base ' . $base_path . ' file is missing or unavailable to read.');
 		}
 
 		$this->out('Loading base file ' . $base_path . '...');
 
-		$_f = 0;
-		$_mid = "";
+		$_f    = 0;
+		$_mid  = "";
 		$_mids = [];
 		foreach ($base_f as $l) {
 			$l = trim($l);
 
 			if ($this->startsWith($l, 'msgstr')) {
 				if ($_mid != '""') {
-					$base_msgids[$_mid] = $_mids;
+					$base_msgids[$_mid]                                               = $_mids;
 					$this->normBaseMsgIds[preg_replace(self::NORM_REGEXP, "", $_mid)] = $_mid;
 				}
 
-				$_f = 0;
-				$_mid = "";
+				$_f    = 0;
+				$_mid  = "";
 				$_mids = [];
 			}
 
@@ -156,7 +155,7 @@ HELP;
 				$_mids[count($_mids) - 1] .= "\n" . $l;
 			}
 			if ($this->startsWith($l, 'msgid_plural ')) {
-				$_f = 2;
+				$_f      = 2;
 				$_mids[] = str_replace('msgid_plural ', '', $l);
 			}
 
@@ -165,8 +164,8 @@ HELP;
 				$_mids[count($_mids) - 1] .= "\n" . $l;
 			}
 			if ($this->startsWith($l, 'msgid ')) {
-				$_f = 1;
-				$_mid = str_replace('msgid ', '', $l);
+				$_f    = 1;
+				$_mid  = str_replace('msgid ', '', $l);
 				$_mids = [$_mid];
 			}
 		}
@@ -215,7 +214,7 @@ HELP;
 	private function startsWith($haystack, $needle)
 	{
 		// search backwards starting from haystack length characters from the end
-		return $needle === "" || strrpos($haystack, $needle, -strlen($haystack)) !== FALSE;
+		return $needle === "" || strrpos($haystack, $needle, -strlen($haystack)) !== false;
 	}
 
 	/**

--- a/src/Console/PhpToPo.php
+++ b/src/Console/PhpToPo.php
@@ -53,7 +53,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/PoToPhp.php
+++ b/src/Console/PoToPhp.php
@@ -130,7 +130,7 @@ HELP;
 	private function createPluralSelectFunctionString(string $pluralForms, string $lang): string
 	{
 		$return = $this->convertCPluralConditionToPhpReturnStatement(
-			$pluralForms
+			$pluralForms,
 		);
 
 		$fnname = 'string_plural_select_' . $lang;

--- a/src/Console/PoToPhp.php
+++ b/src/Console/PoToPhp.php
@@ -39,7 +39,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/Relay.php
+++ b/src/Console/Relay.php
@@ -87,7 +87,7 @@ HELP;
 		}
 
 		if (count($this->args) == 2) {
-			$mode = $this->getArgument(0);
+			$mode  = $this->getArgument(0);
 			$actor = $this->getArgument(1);
 
 			$apcontact = APContact::getByURL($actor);

--- a/src/Console/Relay.php
+++ b/src/Console/Relay.php
@@ -67,7 +67,7 @@ HELP;
 	{
 		if ($this->getOption('v')) {
 			$this->out('Executable: ' . $this->executable);
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/Storage.php
+++ b/src/Console/Storage.php
@@ -65,7 +65,7 @@ HELP;
 	{
 		if ($this->getOption('v')) {
 			$this->out('Executable: ' . $this->executable);
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/Test.php
+++ b/src/Console/Test.php
@@ -31,7 +31,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/Typo.php
+++ b/src/Console/Typo.php
@@ -128,7 +128,7 @@ HELP;
 		}
 
 		$output = [];
-		$ret = 0;
+		$ret    = 0;
 		exec("$php_path -l $file", $output, $ret);
 		if ($ret !== 0) {
 			throw new \RuntimeException('Parse error found in ' . $file . ', scan stopped.');

--- a/src/Console/Typo.php
+++ b/src/Console/Typo.php
@@ -49,7 +49,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Console/User.php
+++ b/src/Console/User.php
@@ -490,9 +490,9 @@ HELP;
 					}
 				}
 
-				if (array_key_exists($category, $values) and
-					array_key_exists($key, $values[$category]) and
-					$values[$category][$key] == $value) {
+				if (array_key_exists($category, $values)
+					and array_key_exists($key, $values[$category])
+					and $values[$category][$key] == $value) {
 					throw new RuntimeException('Value not changed');
 				}
 

--- a/src/Console/User.php
+++ b/src/Console/User.php
@@ -86,7 +86,7 @@ HELP;
 	protected function doExecute(): int
 	{
 		if ($this->getOption('v')) {
-			$this->out('Class: ' . __CLASS__);
+			$this->out('Class: ' . self::class);
 			$this->out('Arguments: ' . var_export($this->args, true));
 			$this->out('Options: ' . var_export($this->options, true));
 		}

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -93,7 +93,7 @@ class Addon
 			$addons_admin[$name] = [
 				'url'   => 'admin/addons/' . $name,
 				'name'  => $name,
-				'class' => 'addon'
+				'class' => 'addon',
 			];
 		}
 
@@ -254,7 +254,7 @@ class Addon
 			'author'      => [],
 			'maintainer'  => [],
 			'version'     => "",
-			'status'      => ""
+			'status'      => "",
 		];
 
 		if (!is_file("addon/$addon/$addon.php")) {

--- a/src/Core/Addon.php
+++ b/src/Core/Addon.php
@@ -45,7 +45,7 @@ class Addon
 	 */
 	public static function getAvailableList(): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addons = [];
 		$files  = glob('addon/*/');
@@ -79,7 +79,7 @@ class Addon
 	 */
 	public static function getAdminList(): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addons_admin = [];
 		$addons       = array_filter(DI::config()->get('addons') ?? []);
@@ -115,7 +115,7 @@ class Addon
 	 */
 	public static function loadAddons()
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		self::$addons = array_keys(array_filter(DI::config()->get('addons') ?? []));
 	}
@@ -131,7 +131,7 @@ class Addon
 	 */
 	public static function uninstall(string $addon)
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addon = Strings::sanitizeFilePathItem($addon);
 
@@ -161,7 +161,7 @@ class Addon
 	 */
 	public static function install(string $addon): bool
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addon = Strings::sanitizeFilePathItem($addon);
 
@@ -203,7 +203,7 @@ class Addon
 	 */
 	public static function reload()
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addons = array_filter(DI::config()->get('addons') ?? []);
 
@@ -244,7 +244,7 @@ class Addon
 	 */
 	public static function getInfo(string $addon): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$addon = Strings::sanitizeFilePathItem($addon);
 
@@ -307,7 +307,7 @@ class Addon
 	 */
 	public static function isEnabled(string $addon): bool
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		return in_array($addon, self::$addons);
 	}
@@ -321,7 +321,7 @@ class Addon
 	 */
 	public static function getEnabledList(): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		return self::$addons;
 	}
@@ -336,7 +336,7 @@ class Addon
 	 */
 	public static function getVisibleList(): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$visible_addons = [];
 		$addons         = array_filter(DI::config()->get('addons') ?? []);

--- a/src/Core/Addon/Model/AddonLoader.php
+++ b/src/Core/Addon/Model/AddonLoader.php
@@ -19,7 +19,7 @@ use Psr\Log\LoggerInterface;
  */
 class AddonLoader implements ICanLoadAddons
 {
-	const STATIC_PATH = 'static';
+	public const STATIC_PATH = 'static';
 	/** @var string */
 	protected $basePath;
 	/** @var IManageConfigValues */

--- a/src/Core/Addon/Model/AddonLoader.php
+++ b/src/Core/Addon/Model/AddonLoader.php
@@ -27,7 +27,7 @@ class AddonLoader implements ICanLoadAddons
 
 	public function __construct(string $basePath, IManageConfigValues $config)
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use implementation of `Friendica\Core\Addon\AddonHelper` instead.', E_USER_DEPRECATED);
 
 		$this->basePath = $basePath;
 		$this->config   = $config;
@@ -38,7 +38,7 @@ class AddonLoader implements ICanLoadAddons
 	 */
 	public function getActiveAddonConfig(string $configName): array
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use `\Friendica\Core\Addon\AddonHelper::getAddonDependencyConfig()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use `\Friendica\Core\Addon\AddonHelper::getAddonDependencyConfig()` instead.', E_USER_DEPRECATED);
 
 		$addons       = array_keys(array_filter($this->config->get('addons') ?? []));
 		$returnConfig = [];

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -34,7 +34,7 @@ class Logger
 	 */
 	public static function emergency(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->emergency($message, $context);
 	}
@@ -53,7 +53,7 @@ class Logger
 	 */
 	public static function alert(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->alert($message, $context);
 	}
@@ -71,7 +71,7 @@ class Logger
 	 */
 	public static function critical(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->critical($message, $context);
 	}
@@ -88,7 +88,7 @@ class Logger
 	 */
 	public static function error(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->error($message, $context);
 	}
@@ -107,7 +107,7 @@ class Logger
 	 */
 	public static function warning(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->warning($message, $context);
 	}
@@ -123,7 +123,7 @@ class Logger
 	 */
 	public static function notice(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->notice($message, $context);
 	}
@@ -142,7 +142,7 @@ class Logger
 	 */
 	public static function info(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->info($message, $context);
 	}
@@ -158,7 +158,7 @@ class Logger
 	 */
 	public static function debug(string $message, array $context = [])
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, use constructor injection or `DI::logger()` instead.', E_USER_DEPRECATED);
 
 		self::getInstance()->debug($message, $context);
 	}

--- a/src/Core/Logger/Factory/AbstractLoggerTypeFactory.php
+++ b/src/Core/Logger/Factory/AbstractLoggerTypeFactory.php
@@ -27,7 +27,7 @@ abstract class AbstractLoggerTypeFactory
 	 */
 	public function __construct(IHaveCallIntrospections $introspection, string $channel)
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
 
 		$this->channel       = $channel;
 		$this->introspection = $introspection;

--- a/src/Core/Logger/Factory/Logger.php
+++ b/src/Core/Logger/Factory/Logger.php
@@ -28,7 +28,7 @@ class Logger
 
 	public function __construct(string $channel = LogChannel::DEFAULT)
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
 
 		$this->channel = $channel;
 	}

--- a/src/Core/Logger/Factory/StreamLogger.php
+++ b/src/Core/Logger/Factory/StreamLogger.php
@@ -80,8 +80,8 @@ class StreamLogger extends AbstractLoggerTypeFactory
 		$logfile     = $config->get('system', 'dlogfile');
 		$developerIp = $config->get('system', 'dlogip');
 
-		if ((!isset($developerIp) || !$debugging) &&
-			(!is_file($logfile) || is_writable($logfile))) {
+		if ((!isset($developerIp) || !$debugging)
+			&& (!is_file($logfile) || is_writable($logfile))) {
 			return new NullLogger();
 		}
 

--- a/src/Core/Logger/Factory/StreamLogger.php
+++ b/src/Core/Logger/Factory/StreamLogger.php
@@ -40,7 +40,7 @@ class StreamLogger extends AbstractLoggerTypeFactory
 	 */
 	public function create(IManageConfigValues $config, string $logfile = null, string $channel = null): LoggerInterface
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
 
 		$fileSystem = new FileSystem();
 

--- a/src/Core/Logger/Factory/SyslogLogger.php
+++ b/src/Core/Logger/Factory/SyslogLogger.php
@@ -33,7 +33,7 @@ class SyslogLogger extends AbstractLoggerTypeFactory
 	 */
 	public function create(IManageConfigValues $config): LoggerInterface
 	{
-		@trigger_error('Class `' . __CLASS__ . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
+		@trigger_error('Class `' . self::class . '` is deprecated since 2025.07 and will be removed after 5 months, implement `\Friendica\Core\Logger\Factory\LoggerFactory` instead.', E_USER_DEPRECATED);
 
 		$logOpts     = $config->get('system', 'syslog_flags')    ?? SyslogLoggerClass::DEFAULT_FLAGS;
 		$logFacility = $config->get('system', 'syslog_facility') ?? SyslogLoggerClass::DEFAULT_FACILITY;

--- a/src/Core/Logger/Util/Introspection.php
+++ b/src/Core/Logger/Util/Introspection.php
@@ -73,7 +73,7 @@ class Introspection implements IHaveCallIntrospections
 			'line'       => $trace[$i - 1]['line'] ?? null,
 			'function'   => $trace[$i]['function'] ?? null,
 			'request-id' => $this->requestId,
-			'stack'      => System::callstack(15, 1, ['Friendica\Core\Logger\Type\StreamLogger', 'Friendica\Core\Logger\Type\AbstractLogger', 'Friendica\Core\Logger\Type\WorkerLogger', 'Friendica\Core\Logger']),
+			'stack'      => System::callstack(15, 1, [\Friendica\Core\Logger\Type\StreamLogger::class, \Friendica\Core\Logger\Type\AbstractLogger::class, \Friendica\Core\Logger\Type\WorkerLogger::class, \Friendica\Core\Logger::class]),
 		];
 	}
 

--- a/src/Module/Api/ApiResponse.php
+++ b/src/Module/Api/ApiResponse.php
@@ -40,12 +40,12 @@ class ApiResponse extends Response
 
 	public function __construct(L10n $l10n, Arguments $args, LoggerInterface $logger, BaseURL $baseUrl, TwitterUser $twitterUser, array $server = [], string $jsonpCallback = '')
 	{
-		$this->l10n        = $l10n;
-		$this->args        = $args;
-		$this->logger      = $logger;
-		$this->baseUrl     = $baseUrl;
-		$this->twitterUser = $twitterUser;
-		$this->server      = $server;
+		$this->l10n          = $l10n;
+		$this->args          = $args;
+		$this->logger        = $logger;
+		$this->baseUrl       = $baseUrl;
+		$this->twitterUser   = $twitterUser;
+		$this->server        = $server;
 		$this->jsonpCallback = $jsonpCallback;
 	}
 
@@ -67,7 +67,7 @@ class ApiResponse extends Response
 			''          => 'http://api.twitter.com',
 			'statusnet' => 'http://status.net/schema/api/1/',
 			'friendica' => 'http://friendi.ca/schema/api/1/',
-			'georss'    => 'http://www.georss.org/georss'
+			'georss'    => 'http://www.georss.org/georss',
 		];
 
 		/// @todo Auto detection of needed namespaces
@@ -114,7 +114,7 @@ class ApiResponse extends Response
 		$user_info = $this->twitterUser->createFromContactId($cid)->toArray();
 
 		$arr['$user'] = $user_info;
-		$arr['$rss'] = [
+		$arr['$rss']  = [
 			'alternate'    => $user_info['url'],
 			'self'         => $this->baseUrl . '/' . $this->args->getQueryString(),
 			'base'         => $this->baseUrl,
@@ -143,6 +143,7 @@ class ApiResponse extends Response
 		switch ($type) {
 			case 'rss':
 				$data = $this->addRSSValues($data, $cid);
+				// no break
 			case 'atom':
 			case 'xml':
 				return $this->createXML($data, $root_element);
@@ -191,7 +192,7 @@ class ApiResponse extends Response
 		$error = [
 			'error'   => $message ?: $description,
 			'code'    => $code . ' ' . $description,
-			'request' => $this->args->getQueryString()
+			'request' => $this->args->getQueryString(),
 		];
 
 		$this->setHeader(($this->server['SERVER_PROTOCOL'] ?? 'HTTP/1.1') . ' ' . $code . ' ' . $description);
@@ -269,13 +270,15 @@ class ApiResponse extends Response
 	public function unsupported(string $method = 'all', array $request = [])
 	{
 		$path = $this->args->getQueryString();
-		$this->logger->info('Unimplemented API call',
+		$this->logger->info(
+			'Unimplemented API call',
 			[
 				'method'  => $method,
 				'path'    => $path,
 				'agent'   => $this->server['HTTP_USER_AGENT'] ?? '',
 				'request' => $request,
-			]);
+			],
+		);
 		$error = $this->l10n->t('API endpoint %s %s is not implemented but might be in the future.', strtoupper($method), $path);
 
 		$this->error(501, 'Not Implemented', $error);

--- a/src/Module/Api/ApiResponse.php
+++ b/src/Module/Api/ApiResponse.php
@@ -77,7 +77,7 @@ class ApiResponse extends Response
 
 		if (is_array($data2)) {
 			$key = key($data2);
-			Arrays::walkRecursive($data2, ['Friendica\Module\Api\ApiResponse', 'reformatXML']);
+			Arrays::walkRecursive($data2, [\Friendica\Module\Api\ApiResponse::class, 'reformatXML']);
 
 			if ($key == '0') {
 				$data4 = [];

--- a/src/Security/OAuth1/OAuthUtil.php
+++ b/src/Security/OAuth1/OAuthUtil.php
@@ -12,7 +12,7 @@ class OAuthUtil
 	public static function urlencode_rfc3986($input)
 	{
 		if (is_array($input)) {
-			return array_map(['Friendica\Security\OAuth1\OAuthUtil', 'urlencode_rfc3986'], $input);
+			return array_map([\Friendica\Security\OAuth1\OAuthUtil::class, 'urlencode_rfc3986'], $input);
 		} else if (is_scalar($input)) {
 			return str_replace(
 				'+',

--- a/src/Security/OAuth1/OAuthUtil.php
+++ b/src/Security/OAuth1/OAuthUtil.php
@@ -13,11 +13,11 @@ class OAuthUtil
 	{
 		if (is_array($input)) {
 			return array_map([\Friendica\Security\OAuth1\OAuthUtil::class, 'urlencode_rfc3986'], $input);
-		} else if (is_scalar($input)) {
+		} elseif (is_scalar($input)) {
 			return str_replace(
 				'+',
 				' ',
-				str_replace('%7E', '~', rawurlencode($input))
+				str_replace('%7E', '~', rawurlencode($input)),
 			);
 		} else {
 			return '';
@@ -72,10 +72,10 @@ class OAuthUtil
 			// request
 			$out = [];
 			foreach ($headers as $key => $value) {
-				$key       = str_replace(
+				$key = str_replace(
 					" ",
 					"-",
-					ucwords(strtolower(str_replace("-", " ", $key)))
+					ucwords(strtolower(str_replace("-", " ", $key))),
 				);
 				$out[$key] = $value;
 			}
@@ -83,20 +83,22 @@ class OAuthUtil
 			// otherwise we don't have apache and are just going to have to hope
 			// that $_SERVER actually contains what we need
 			$out = [];
-			if (isset($_SERVER['CONTENT_TYPE']))
+			if (isset($_SERVER['CONTENT_TYPE'])) {
 				$out['Content-Type'] = $_SERVER['CONTENT_TYPE'];
-			if (isset($_ENV['CONTENT_TYPE']))
+			}
+			if (isset($_ENV['CONTENT_TYPE'])) {
 				$out['Content-Type'] = $_ENV['CONTENT_TYPE'];
+			}
 
 			foreach ($_SERVER as $key => $value) {
 				if (substr($key, 0, 5) == "HTTP_") {
 					// this is chaos, basically it is just there to capitalize the first
 					// letter of every word that is not an initial HTTP and strip HTTP
 					// code from przemek
-					$key       = str_replace(
+					$key = str_replace(
 						" ",
 						"-",
-						ucwords(strtolower(str_replace("_", " ", substr($key, 5))))
+						ucwords(strtolower(str_replace("_", " ", substr($key, 5)))),
 					);
 					$out[$key] = $value;
 				}
@@ -110,7 +112,9 @@ class OAuthUtil
 	// array('a' => array('b','c'), 'd' => 'e')
 	public static function parse_parameters($input)
 	{
-		if (!isset($input) || !$input) return [];
+		if (!isset($input) || !$input) {
+			return [];
+		}
 
 		$pairs = explode('&', $input);
 

--- a/src/Util/Crypto.php
+++ b/src/Util/Crypto.php
@@ -163,7 +163,7 @@ class Crypto
 			DI::logger()->notice('no key. data: '.$data);
 		}
 		$fn = 'encrypt' . strtoupper($alg);
-		if (method_exists(__CLASS__, $fn)) {
+		if (method_exists(self::class, $fn)) {
 			$result         = ['encrypted' => true];
 			$key            = random_bytes(256);
 			$iv             = random_bytes(256);
@@ -262,7 +262,7 @@ class Crypto
 	{
 		$fn = 'decrypt' . strtoupper($alg);
 
-		if (method_exists(__CLASS__, $fn)) {
+		if (method_exists(self::class, $fn)) {
 			openssl_private_decrypt(Strings::base64UrlDecode($data['key']), $k, $prvkey);
 			openssl_private_decrypt(Strings::base64UrlDecode($data['iv']), $i, $prvkey);
 

--- a/src/Util/Crypto.php
+++ b/src/Util/Crypto.php
@@ -56,7 +56,7 @@ class Crypto
 	 */
 	public static function rsaToPem(string $key)
 	{
-		return (string)PublicKeyLoader::load($key);
+		return (string) PublicKeyLoader::load($key);
 	}
 
 	/**
@@ -69,7 +69,7 @@ class Crypto
 		$openssl_options = [
 			'digest_alg'       => 'sha1',
 			'private_key_bits' => $bits,
-			'encrypt_key'      => false
+			'encrypt_key'      => false,
 		];
 
 		$conf = DI::config()->get('system', 'openssl_conf_file');
@@ -160,7 +160,7 @@ class Crypto
 	private static function encapsulateOther($data, $pubkey, $alg)
 	{
 		if (!$pubkey) {
-			DI::logger()->notice('no key. data: '.$data);
+			DI::logger()->notice('no key. data: ' . $data);
 		}
 		$fn = 'encrypt' . strtoupper($alg);
 		if (method_exists(self::class, $fn)) {

--- a/src/Util/Temporal.php
+++ b/src/Util/Temporal.php
@@ -156,9 +156,9 @@ class Temporal
 					$value,
 					intval($age) > 0 ? DI::l10n()->t('Age: ') . DI::l10n()->tt('%d year old', '%d years old', $age) : '',
 					'',
-					'placeholder="' . DI::l10n()->t('YYYY-MM-DD or MM-DD') . '"'
-				]
-			]
+					'placeholder="' . DI::l10n()->t('YYYY-MM-DD or MM-DD') . '"',
+				],
+			],
 		);
 
 		return $o;
@@ -236,7 +236,7 @@ class Temporal
 		if (!in_array(
 			$lang,
 			['ar', 'ro', 'id', 'bg', 'fa', 'ru', 'uk', 'en', 'el', 'de', 'nl', 'tr', 'fr', 'es', 'th', 'pl', 'pt', 'ch', 'se', 'kr',
-				'it', 'da', 'no', 'ja', 'vi', 'sl', 'cs', 'hu']
+				'it', 'da', 'no', 'ja', 'vi', 'sl', 'cs', 'hu'],
 		)) {
 			$lang = 'en';
 		}
@@ -269,10 +269,10 @@ class Temporal
 				DI::l10n()->t(
 					'Time zone: <strong>%s</strong> <a href="%s">Change in Settings</a>',
 					str_replace('_', ' ', DI::appHelper()->getTimeZone()) . ' (GMT ' . DateTimeFormat::localNow('P') . ')',
-					DI::baseUrl() . '/settings'
+					DI::baseUrl() . '/settings',
 				),
 				$required ? '*' : '',
-				'placeholder="' . $readable_format . '"'
+				'placeholder="' . $readable_format . '"',
 			],
 			'$datetimepicker' => [
 				'minDate'     => $minDate,
@@ -451,7 +451,7 @@ class Temporal
 			'January', 'February', 'March',
 			'April', 'May', 'June',
 			'July', 'August', 'September',
-			'October', 'November', 'December'
+			'October', 'November', 'December',
 		];
 
 		$thisyear  = DateTimeFormat::localNow('Y');

--- a/src/Util/Temporal.php
+++ b/src/Util/Temporal.php
@@ -61,7 +61,7 @@ class Temporal
 
 		$o = '<select id="timezone_select" name="timezone">';
 
-		usort($timezone_identifiers, [__CLASS__, 'timezoneCompareCallback']);
+		usort($timezone_identifiers, [self::class, 'timezoneCompareCallback']);
 		$continent = '';
 		foreach ($timezone_identifiers as $value) {
 			$ex = explode("/", $value);

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -819,7 +819,7 @@ Lucas: For the right price, yes.[/share]',
 	 */
 	public function testConvertAttachment(string $expected, array $data)
 	{
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$actual = BBCode::convertAttachment('', BBCode::INTERNAL, $data, 0, BBCode::PREVIEW_LARGE, true);
 

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -765,7 +765,7 @@ Lucas: For the right price, yes.[/share]',
 					'embed_html'    => '<iframe src="http://domain.tld/player"></iframe>',
 					'embed_width'   => 620,
 					'embed_height'  => 480,
-				]
+				],
 			],
 			'player-video' => [
 				'expected' => 'text <div class="type-link"><iframe class="embed" src="http://domain.tld/player" style="aspect-ratio:620/480;" height="" width="100%" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts allow-popups"></iframe>' . "\n</div>",
@@ -806,8 +806,8 @@ Lucas: For the right price, yes.[/share]',
 					'embed_html'    => '<iframe src="http://domain.tld/player"></iframe>',
 					'embed_width'   => 620,
 					'embed_height'  => 480,
-				]
-			]
+				],
+			],
 		];
 	}
 

--- a/tests/src/Factory/Api/Twitter/StatusTest.php
+++ b/tests/src/Factory/Api/Twitter/StatusTest.php
@@ -36,7 +36,9 @@ class StatusTest extends FixtureTestCase
 			new Url(DI::logger()),
 			new Mention(DI::logger(), DI::baseUrl()),
 			new Activities(DI::logger(), DI::twitterUser()),
-			new Attachment(DI::logger()), DI::contentItem());
+			new Attachment(DI::logger()),
+			DI::contentItem(),
+		);
 	}
 
 	/**

--- a/tests/src/Factory/Api/Twitter/StatusTest.php
+++ b/tests/src/Factory/Api/Twitter/StatusTest.php
@@ -125,7 +125,7 @@ class StatusTest extends FixtureTestCase
 	public function testApiFormatItems()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$posts = DI::dba()->selectToArray('post-view', ['uri-id']);
 		foreach ($posts as $item) {

--- a/tests/src/Module/Api/Twitter/FavoritesTest.php
+++ b/tests/src/Module/Api/Twitter/FavoritesTest.php
@@ -23,7 +23,7 @@ class FavoritesTest extends ApiTestCase
 	public function testApiFavorites()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
@@ -46,7 +46,7 @@ class FavoritesTest extends ApiTestCase
 	public function testApiFavoritesWithRss()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_RSS

--- a/tests/src/Module/Api/Twitter/FavoritesTest.php
+++ b/tests/src/Module/Api/Twitter/FavoritesTest.php
@@ -49,12 +49,12 @@ class FavoritesTest extends ApiTestCase
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
-			'extension' => ICanCreateResponses::TYPE_RSS
+			'extension' => ICanCreateResponses::TYPE_RSS,
 		]))->run($this->httpExceptionMock);
 
 		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
 
-		self::assertXml((string)$response->getBody(), 'statuses');
+		self::assertXml((string) $response->getBody(), 'statuses');
 	}
 
 	/**

--- a/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
+++ b/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
@@ -34,7 +34,7 @@ class StatusesTest extends ApiTestCase
 	public function testApiListsStatusesWithListId()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
@@ -57,7 +57,7 @@ class StatusesTest extends ApiTestCase
 	public function testApiListsStatusesWithListIdAndRss()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
 			->run($this->httpExceptionMock, [

--- a/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
+++ b/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
@@ -40,7 +40,7 @@ class StatusesTest extends ApiTestCase
 			->run($this->httpExceptionMock, [
 				'list_id' => 1,
 				'page'    => -1,
-				'max_id'  => 10
+				'max_id'  => 10,
 			]);
 
 		$json = $this->toJson($response);
@@ -61,10 +61,10 @@ class StatusesTest extends ApiTestCase
 
 		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
 			->run($this->httpExceptionMock, [
-				'list_id' => 1
+				'list_id' => 1,
 			]);
 
-		self::assertXml((string)$response->getBody());
+		self::assertXml((string) $response->getBody());
 	}
 
 	/**

--- a/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
@@ -23,7 +23,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 	public function testApiStatusesNetworkpublicTimeline()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
@@ -48,7 +48,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 	public function testApiStatusesNetworkpublicTimelineWithNegativePage()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
@@ -87,7 +87,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 	public function testApiStatusesNetworkpublicTimelineWithRss()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_RSS

--- a/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
@@ -27,7 +27,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 
 		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
-				'max_id' => 10
+				'max_id' => 10,
 			]);
 
 		$json = $this->toJson($response);
@@ -52,7 +52,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 
 		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
-				'page' => -2
+				'page' => -2,
 			]);
 
 		$json = $this->toJson($response);
@@ -90,13 +90,13 @@ class NetworkPublicTimelineTest extends ApiTestCase
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
-			'extension' => ICanCreateResponses::TYPE_RSS
+			'extension' => ICanCreateResponses::TYPE_RSS,
 		]))->run($this->httpExceptionMock, [
-			'page' => -2
+			'page' => -2,
 		]);
 
 		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
 
-		self::assertXml((string)$response->getBody(), 'statuses');
+		self::assertXml((string) $response->getBody(), 'statuses');
 	}
 }

--- a/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
@@ -76,7 +76,7 @@ class RetweetTest extends ApiTestCase
 	public function testApiStatusesRepeatWithSharedId()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [

--- a/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
@@ -60,7 +60,7 @@ class RetweetTest extends ApiTestCase
 	{
 		$response = (new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
-				'id' => 1
+				'id' => 1,
 			]);
 
 		$json = $this->toJson($response);
@@ -80,7 +80,7 @@ class RetweetTest extends ApiTestCase
 
 		$response = (new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
-				'id' => 5
+				'id' => 5,
 			]);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
@@ -38,7 +38,7 @@ class ShowTest extends ApiTestCase
 	{
 		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
-				'id' => 1
+				'id' => 1,
 			]);
 
 		$json = $this->toJson($response);
@@ -60,7 +60,7 @@ class ShowTest extends ApiTestCase
 		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id'           => 1,
-				'conversation' => 1
+				'conversation' => 1,
 			]);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
@@ -55,7 +55,7 @@ class ShowTest extends ApiTestCase
 	public function testApiStatusesShowWithConversation()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [

--- a/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
@@ -48,7 +48,7 @@ class UserTimelineTest extends ApiTestCase
 	public function testApiStatusesUserTimelineWithNegativePage()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [

--- a/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
@@ -74,12 +74,12 @@ class UserTimelineTest extends ApiTestCase
 	public function testApiStatusesUserTimelineWithRss()
 	{
 		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
-			'extension' => ICanCreateResponses::TYPE_RSS
+			'extension' => ICanCreateResponses::TYPE_RSS,
 		]))->run($this->httpExceptionMock);
 
 		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
 
-		self::assertXml((string)$response->getBody(), 'statuses');
+		self::assertXml((string) $response->getBody(), 'statuses');
 	}
 
 	/**

--- a/tests/src/Module/Api/Twitter/Users/LookupTest.php
+++ b/tests/src/Module/Api/Twitter/Users/LookupTest.php
@@ -40,7 +40,7 @@ class LookupTest extends ApiTestCase
 
 		$response = (new Lookup(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
-				'user_id' => static::OTHER_USER['id']
+				'user_id' => static::OTHER_USER['id'],
 			]);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/Users/LookupTest.php
+++ b/tests/src/Module/Api/Twitter/Users/LookupTest.php
@@ -36,7 +36,7 @@ class LookupTest extends ApiTestCase
 	public function testApiUsersLookupWithUserId()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new Lookup(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [

--- a/tests/src/Module/Api/Twitter/Users/SearchTest.php
+++ b/tests/src/Module/Api/Twitter/Users/SearchTest.php
@@ -28,7 +28,7 @@ class SearchTest extends ApiTestCase
 
 		$response = (new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
-				'q' => static::OTHER_USER['name']
+				'q' => static::OTHER_USER['name'],
 			]);
 
 		$json = $this->toJson($response);
@@ -47,12 +47,12 @@ class SearchTest extends ApiTestCase
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
-			'extension' => ICanCreateResponses::TYPE_XML
+			'extension' => ICanCreateResponses::TYPE_XML,
 		]))->run($this->httpExceptionMock, [
-			'q' => static::OTHER_USER['name']
+			'q' => static::OTHER_USER['name'],
 		]);
 
-		self::assertXml((string)$response->getBody(), 'users');
+		self::assertXml((string) $response->getBody(), 'users');
 	}
 
 	/**

--- a/tests/src/Module/Api/Twitter/Users/SearchTest.php
+++ b/tests/src/Module/Api/Twitter/Users/SearchTest.php
@@ -24,7 +24,7 @@ class SearchTest extends ApiTestCase
 	public function testApiUsersSearch()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
@@ -44,7 +44,7 @@ class SearchTest extends ApiTestCase
 	public function testApiUsersSearchWithXml()
 	{
 		// @todo: This call is needed for this test
-		Renderer::registerTemplateEngine('Friendica\Render\FriendicaSmartyEngine');
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
 		$response = (new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_XML


### PR DESCRIPTION
Based on #15539 I refactored the codebase using Rector to bring it to PHP 5.5. This has run the following rectors:

- ClassConstantToSelfClassRector
- StringClassNameToClassConstantRector

You can look at the Diff between #15539 and this PR without the code style changes here: https://github.com/Art4/friendica/compare/update-codebase-to-php-5.4...4e3870e8355d0148f8ef570ae471e28bb3d75efb