### PR TITLE
Move profile edit to vcard

### DIFF
--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -452,7 +452,12 @@ class Profile
 
 		$tpl = Renderer::getMarkupTemplate('profile/vcard.tpl');
 		$o .= Renderer::replaceMacros($tpl, [
-			'$profile'                     => $p,
+			'$is_owner'          => DI::userSession()->getLocalUserId() == $profile['uid'],
+			'$profile'           => $p,
+			'$edit_profile_link' => [
+				'url'  => 'settings/profile',
+				'text' => DI::l10n()->t('Edit profile'),
+			],
 			'$picture_dest_url'            => $picture_dest_url,
 			'$change_profile_picture_text' => $change_profile_picture_text,
 			'$xmpp'                        => $xmpp,

--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -289,11 +289,7 @@ class Profile extends BaseProfile
 			'$custom_fields'         => $custom_fields,
 			'$profile'               => $profile,
 			'$homepage_verified'     => $this->l10n->t('This website has been verified to belong to the same person.'),
-			'$edit_link'             => [
-				'url'   => 'settings/profile', $this->t('Edit profile'),
-				'label' => $this->t('Edit profile'),
-			],
-			'$viewas_link' => [
+			'$viewas_link'           => [
 				'url'   => $this->args->getQueryString() . '#viewas',
 				'label' => $this->t('View as'),
 			],

--- a/view/global.css
+++ b/view/global.css
@@ -899,3 +899,7 @@ a:has(img.has-alt-description)::after {
 #profile-page .profile-entry a {
 	word-break: break-all;
 }
+
+.edit-profile-link-wrapper {
+	text-align: center;
+}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-03 22:25+0000\n"
+"POT-Creation-Date: 2026-03-04 20:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1311,7 +1311,7 @@ msgstr ""
 
 #: src/Content/Conversation.php:429 src/Content/Item.php:442
 #: src/Content/Widget/VCard.php:120 src/Model/Contact.php:1307
-#: src/Model/Profile.php:467 src/Module/Admin/Logs/View.php:79
+#: src/Model/Profile.php:472 src/Module/Admin/Logs/View.php:79
 #: src/Module/Post/Edit.php:181
 msgid "Message"
 msgstr ""
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Add categories to your posts"
 msgstr ""
 
-#: src/Content/Feature.php:121 src/Model/Profile.php:807
+#: src/Content/Feature.php:121 src/Model/Profile.php:812
 #: src/Module/Admin/Summary.php:207 src/Module/Item/Compose.php:188
 #: src/Module/Moderation/Report/Create.php:282
 #: src/Module/Moderation/Summary.php:65
@@ -2467,18 +2467,18 @@ msgstr ""
 msgid "Location:"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:114 src/Model/Profile.php:474
+#: src/Content/Widget/VCard.php:114 src/Model/Profile.php:479
 #: src/Module/Notifications/Introductions.php:201
 msgid "Network:"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:116 src/Model/Profile.php:461
+#: src/Content/Widget/VCard.php:116 src/Model/Profile.php:466
 #: src/Module/Contact/Profile.php:529
 msgid "Follow"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:118 src/Model/Contact.php:1297
-#: src/Model/Contact.php:1309 src/Model/Profile.php:463
+#: src/Model/Contact.php:1309 src/Model/Profile.php:468
 #: src/Module/Contact/Profile.php:521
 msgid "Unfollow"
 msgstr ""
@@ -3444,115 +3444,119 @@ msgstr ""
 msgid "Joined:"
 msgstr ""
 
-#: src/Model/Profile.php:465
+#: src/Model/Profile.php:459
+msgid "Edit profile"
+msgstr ""
+
+#: src/Model/Profile.php:470
 msgid "Atom feed"
 msgstr ""
 
-#: src/Model/Profile.php:472 src/Module/Profile/Profile.php:291
+#: src/Model/Profile.php:477 src/Module/Profile/Profile.php:291
 msgid "This website has been verified to belong to the same person."
 msgstr ""
 
-#: src/Model/Profile.php:593 src/Model/Profile.php:673
+#: src/Model/Profile.php:598 src/Model/Profile.php:678
 msgid "[today]"
 msgstr ""
 
-#: src/Model/Profile.php:602
+#: src/Model/Profile.php:607
 msgid "Birthday Reminders"
 msgstr ""
 
-#: src/Model/Profile.php:603
+#: src/Model/Profile.php:608
 msgid "Birthdays this week:"
 msgstr ""
 
-#: src/Model/Profile.php:660
+#: src/Model/Profile.php:665
 msgid "[No description]"
 msgstr ""
 
-#: src/Model/Profile.php:686
+#: src/Model/Profile.php:691
 msgid "Event Reminders"
 msgstr ""
 
-#: src/Model/Profile.php:687
+#: src/Model/Profile.php:692
 msgid "Upcoming events the next 7 days:"
 msgstr ""
 
-#: src/Model/Profile.php:797
+#: src/Model/Profile.php:802
 msgid "Hometown:"
 msgstr ""
 
-#: src/Model/Profile.php:798
+#: src/Model/Profile.php:803
 msgid "Marital Status:"
 msgstr ""
 
-#: src/Model/Profile.php:799
+#: src/Model/Profile.php:804
 msgid "With:"
 msgstr ""
 
-#: src/Model/Profile.php:800
+#: src/Model/Profile.php:805
 msgid "Since:"
 msgstr ""
 
-#: src/Model/Profile.php:801
+#: src/Model/Profile.php:806
 msgid "Sexual Preference:"
 msgstr ""
 
-#: src/Model/Profile.php:802
+#: src/Model/Profile.php:807
 msgid "Political Views:"
 msgstr ""
 
-#: src/Model/Profile.php:803
+#: src/Model/Profile.php:808
 msgid "Religious Views:"
 msgstr ""
 
-#: src/Model/Profile.php:804
+#: src/Model/Profile.php:809
 msgid "Likes:"
 msgstr ""
 
-#: src/Model/Profile.php:805
+#: src/Model/Profile.php:810
 msgid "Dislikes:"
 msgstr ""
 
-#: src/Model/Profile.php:806
+#: src/Model/Profile.php:811
 msgid "Title/Description:"
 msgstr ""
 
-#: src/Model/Profile.php:808
+#: src/Model/Profile.php:813
 msgid "Musical interests"
 msgstr ""
 
-#: src/Model/Profile.php:809
+#: src/Model/Profile.php:814
 msgid "Books, literature"
 msgstr ""
 
-#: src/Model/Profile.php:810
+#: src/Model/Profile.php:815
 msgid "Television"
 msgstr ""
 
-#: src/Model/Profile.php:811
+#: src/Model/Profile.php:816
 msgid "Film/dance/culture/entertainment"
 msgstr ""
 
-#: src/Model/Profile.php:812
+#: src/Model/Profile.php:817
 msgid "Hobbies/Interests"
 msgstr ""
 
-#: src/Model/Profile.php:813
+#: src/Model/Profile.php:818
 msgid "Love/romance"
 msgstr ""
 
-#: src/Model/Profile.php:814
+#: src/Model/Profile.php:819
 msgid "Work/employment"
 msgstr ""
 
-#: src/Model/Profile.php:815
+#: src/Model/Profile.php:820
 msgid "School/education"
 msgstr ""
 
-#: src/Model/Profile.php:816
+#: src/Model/Profile.php:821
 msgid "Contact information and Social Networks"
 msgstr ""
 
-#: src/Model/Profile.php:864
+#: src/Model/Profile.php:869
 #, php-format
 msgid "Responsible account: %s"
 msgstr ""
@@ -8550,19 +8554,19 @@ msgstr ""
 msgid "No contacts."
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:96 src/Module/Profile/Profile.php:361
+#: src/Module/Profile/Conversations.php:96 src/Module/Profile/Profile.php:357
 #: src/Protocol/Feed.php:1105
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:97 src/Module/Profile/Profile.php:362
+#: src/Module/Profile/Conversations.php:97 src/Module/Profile/Profile.php:358
 #: src/Protocol/Feed.php:1108
 #, php-format
 msgid "%s's comments"
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:98 src/Module/Profile/Profile.php:363
+#: src/Module/Profile/Conversations.php:98 src/Module/Profile/Profile.php:359
 #: src/Protocol/Feed.php:1101
 #, php-format
 msgid "%s's timeline"
@@ -8651,11 +8655,7 @@ msgstr ""
 msgid "View as selected profile"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:293 src/Module/Profile/Profile.php:294
-msgid "Edit profile"
-msgstr ""
-
-#: src/Module/Profile/Profile.php:298
+#: src/Module/Profile/Profile.php:294
 msgid "View as"
 msgstr ""
 

--- a/view/templates/profile/profile.tpl
+++ b/view/templates/profile/profile.tpl
@@ -21,11 +21,6 @@
 					<i class="fa fa-eye" aria-hidden="true"></i>&nbsp;{{$viewas_link.label}}
 				</a>
 			</li>
-			<li>
-				<a class="btn btn-primary" type="button" id="profile-edit-link" href="{{$edit_link.url}}">
-					<i class="fa fa-pencil" aria-hidden="true"></i>&nbsp;{{$edit_link.label}}
-				</a>
-			</li>
 		</ul>
 	</div>
 {{/if}}

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1292,7 +1292,7 @@ aside .vcard .fn {
 }
 aside .vcard .p-addr {
 	font-style: italic;
-	padding-bottom: 2px;
+	padding-bottom: 7px;
 	text-align: center;
 	word-wrap: break-word;
 }

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -5,10 +5,11 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div class="vcard h-card widget">
+
 	<div id="profile-photo-wrapper">
 		<a class="vcard-anchor" href="{{$picture_dest_url}}" style="position: relative;">
 			<img class="photo u-photo" src="{{$profile.photo}}" alt="{{$profile.name}}" />
-			{{if $change_profile_picture_text }}
+			{{if $is_owner }}
 				<div id="change-profile-picture">{{$change_profile_picture_text}}</div>
 			{{/if}}
 		</a>
@@ -32,7 +33,14 @@
 		<div class="profile-header">
 			<h3 class="fn p-name" dir="auto">{{$profile.name}}</h3>
 
-			{{if $profile.addr}}<div class="p-addr">{{include file="sub/punct_wrap.tpl" text=$profile.addr}}</div>
+			{{if $profile.addr}}<div class="p-addr">{{include file="sub/punct_wrap.tpl" text=$profile.addr}}</div>{{/if}}
+			{{if $is_owner }}
+				<div class="edit-profile-link-wrapper">
+					<a class="btn btn-primary" href="{{$edit_profile_link.url}}">
+						<i class="fa fa-pencil" aria-hidden="true"></i>
+						{{$edit_profile_link.text}}
+					</a>
+				</div>
 			{{/if}}
 
 			{{if $profile.about}}<div class="title" dir="auto">{{$profile.about nofilter}}</div>{{/if}}

--- a/view/theme/vier/templates/profile/vcard.tpl
+++ b/view/theme/vier/templates/profile/vcard.tpl
@@ -23,6 +23,14 @@
 
 	{{if $account_type}}<div class="account-type">{{$account_type}}</div>{{/if}}
 	{{if $profile.network_link}}<dl class="network"><dt class="network-label">{{$network}}</dt><dd class="x-network">{{$profile.network_link nofilter}}</dd></dl>{{/if}}
+	{{if $is_owner }}
+		<div class="edit-profile-link-wrapper">
+			<a class="btn btn-primary edit-profile-link" href="{{$edit_profile_link.url}}">
+				<i class="fa fa-pencil" aria-hidden="true"></i>
+				{{$edit_profile_link.text}}
+			</a>
+		</div>
+	{{/if}}
 	{{if $location}}
 		<dl class="location" dir="auto">
 			<dt class="location-label">{{$location}}</dt>


### PR DESCRIPTION
Related to #15548 (but doesn't close it)

Moves "Edit profile" out of /profile/user/profile and into the Vcard, only shown if you're viewing your own profile.
This also makes it accessible on all of the pages under your own profile that show the Vcard.
It also gets us closer to possibly being able to remove /profile/user/profile.

It's done in both Vier and Frio.

Sorry for using `DI`. If you want me to replace the calls I added I could use a refresh on how. :pray: 

# Before

<img width="966" height="516" alt="image" src="https://github.com/user-attachments/assets/41c49d24-e3bf-4e48-93f0-67fc69ec3ea3" />

# After

<img width="966" height="516" alt="image" src="https://github.com/user-attachments/assets/b3330155-1e09-402e-980c-402271fdc402" />

Vier:
<img width="547" height="420" alt="image" src="https://github.com/user-attachments/assets/1018213d-41c8-4821-80b7-95a5e1892ac5" />