### PR TITLE
API: verify_credentials can be called with any scope

### DIFF
--- a/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
@@ -11,13 +11,13 @@ use Friendica\DI;
 use Friendica\Module\BaseApi;
 
 /**
- * @see https://docs.joinmastodon.org/methods/apps/
+ * @see https://docs.joinmastodon.org/methods/apps/#verify_credentials
  */
 class VerifyCredentials extends BaseApi
 {
 	protected function rawContent(array $request = [])
 	{
-		$this->checkAllowedScope(self::SCOPE_READ);
+		$this->checkAllowedScope(self::SCOPE_ANY);
 		$application = self::getCurrentApplication();
 
 		if (empty($application['id'])) {

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -35,12 +35,13 @@ use Psr\Log\LoggerInterface;
 
 class BaseApi extends BaseModule
 {
-	const LOG_PREFIX = 'API {action} - ';
+	public const LOG_PREFIX = 'API {action} - ';
 
-	const SCOPE_READ   = 'read';
-	const SCOPE_WRITE  = 'write';
-	const SCOPE_FOLLOW = 'follow';
-	const SCOPE_PUSH   = 'push';
+	public const SCOPE_READ   = 'read';
+	public const SCOPE_WRITE  = 'write';
+	public const SCOPE_FOLLOW = 'follow';
+	public const SCOPE_PUSH   = 'push';
+	public const SCOPE_ANY    = 'any';
 
 	/**
 	 * @var array
@@ -385,14 +386,14 @@ class BaseApi extends BaseModule
 			$uid = BasicAuth::getCurrentUserID(false);
 		}
 
-		return (int)$uid;
+		return (int) $uid;
 	}
 
 	/**
 	 * Check if the provided scope does exist.
 	 * halts execution on missing scope or when not logged in.
 	 *
-	 * @param string $scope the requested scope (read, write, follow, push)
+	 * @param string $scope the requested scope (read, write, follow, push, any)
 	 */
 	public function checkAllowedScope(string $scope)
 	{
@@ -401,6 +402,10 @@ class BaseApi extends BaseModule
 		if (empty($token)) {
 			$this->logger->notice('Empty application token');
 			$this->logAndJsonError(403, $this->errorFactory->Forbidden());
+		}
+
+		if ($scope === self::SCOPE_ANY) {
+			return;
 		}
 
 		if (!isset($token[$scope])) {


### PR DESCRIPTION
See https://docs.joinmastodon.org/methods/apps/#verify_credentials

> 4.3.0 - removed needing read scope to access this API, now any valid App token can be used

This enables the access for apps that only want to have the `write` scope but not the `read` scope.