### PR TITLE
Update the date format for member since/joined

### DIFF
--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -609,6 +609,18 @@ class L10n
 	}
 
 	/**
+	 * Format a date string (date only) using MEDIUM date format according to current locale.
+	 *
+	 * @param string $datestring Date string
+	 * @return string Formatted date string
+	 * @throws \Exception If the date string cannot be parsed into a DateTime
+	 */
+	public function mediumDate(string $datestring): string
+	{
+		return $this->formatDateTime($datestring, IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE);
+	}
+
+	/**
 	 * Format a date string (date only) using LONG date format according to current locale.
 	 *
 	 * @param string $datestring Date string

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -447,7 +447,7 @@ class Profile
 
 		$member_since = null;
 		if (Feature::isEnabled($p['uid'], Feature::MEMBER_SINCE)) {
-			$member_since = [ DI::l10n()->t('Joined:'), DateTimeFormat::local($p['register_date']) ];
+			$member_since = [ DI::l10n()->t('Joined:'), DI::l10n()->mediumDate($p['register_date']) ];
 		}
 
 		$tpl = Renderer::getMarkupTemplate('profile/vcard.tpl');

--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -183,7 +183,7 @@ class Profile extends BaseProfile
 			$basic_fields += self::buildField(
 				'membersince',
 				$this->t('Joined:'),
-				$this->l10n->fullDate($profile['register_date']),
+				$this->l10n->mediumDate($profile['register_date']),
 			);
 		}
 


### PR DESCRIPTION
The new awesome date/time formatting had not been added to the vcard - and based on the suggestions in #15550 on using shorter formatting I added a "medium" date formatting so it doesn't show the day of the week.

I was wondering if it would be better if I made the formatting for date/time function arguments instead, but that isn't currently the case in the PR.

# Before

<img width="962" height="1212" alt="image" src="https://github.com/user-attachments/assets/c0f19395-0b4d-468c-b437-98c31a4386cc" />

# After

<img width="963" height="1207" alt="image" src="https://github.com/user-attachments/assets/07949085-3bfd-4ed6-9018-3390078b6cdf" />

Mastodon for comparison:
<img width="155" height="74" alt="image" src="https://github.com/user-attachments/assets/929e89fd-847c-4662-b9bb-54e675ecc809" />