### PR TITLE
Event reminder colorbox to fancybox + limit width

### DIFF
--- a/view/js/fancybox/fancybox.config.js
+++ b/view/js/fancybox/fancybox.config.js
@@ -1,10 +1,16 @@
 $(document).ready(function() {
-    $.fancybox.defaults.loop = "true";
+	$.fancybox.defaults.smallBtn = "true";
+	$.fancybox.defaults.loop = "true";
 	$.fancybox.defaults.afterLoad = function(instance, current) {
-		current.$image.attr('alt', current.opts.$orig.find('img').attr('alt') );
-		current.$image.attr('title', current.opts.$orig.find('img').attr('title') );
+
+		if (typeof $image !== 'undefined') {
+			current.$image.attr('alt', current.opts.$orig.find('img').attr('alt') );
+			current.$image.attr('title', current.opts.$orig.find('img').attr('title') );
+		}
 	};
-    $.fancybox.defaults.caption = function (instance, slide, caption) {
-		return slide.$thumb.attr('alt');
+  $.fancybox.defaults.caption = function (instance, slide, caption) {
+		if (typeof $thumb !== 'undefined') {
+			return slide.$thumb.attr('alt');
+		}
 	};
 });

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -233,13 +233,10 @@ $(function() {
 		close_last_popup_menu();
 	});
 
-	// fancyboxes
+	// Colorbox - related docs: https://www.jacklmoore.com/colorbox/
+	/* Not used by frio. Used in two photos templates */
 	$("a.popupbox").colorbox({
 		'inline' : true,
-		'transition' : 'elastic',
-		'maxWidth' : '100%'
-	});
-	$("a.ajax-popupbox").colorbox({
 		'transition' : 'elastic',
 		'maxWidth' : '100%'
 	});

--- a/view/templates/events_reminder.tpl
+++ b/view/templates/events_reminder.tpl
@@ -11,7 +11,7 @@
 		<div id="event-title-end"></div>
 		{{foreach $events as $event}}
 			<div class="event-list" id="event-{{$event.id}}">
-				<button class="btn-link" onclick='addToModal("calendar/event/show/{{$event.id}}")'>{{$event.title}}</button>
+				<a data-fancybox href="javascript:" data-type="ajax" data-src="calendar/event/show/{{$event.id}}" href="calendar/event/show/{{$event.id}}">{{$event.title}}</a>
 			  - {{$event.date}}
 			</div>
 		{{/foreach}}

--- a/view/templates/events_reminder.tpl
+++ b/view/templates/events_reminder.tpl
@@ -6,12 +6,15 @@
   *}}
 
 {{if $count}}
-<div id="event-notice" class="birthday-notice fakelink {{$classtoday}}" onclick="openClose('event-wrapper');">{{$event_reminders}} ({{$count}})</div>
-<div id="event-wrapper" style="display: none;"><div id="event-title">{{$event_title}}</div>
-<div id="event-title-end"></div>
-{{foreach $events as $event}}
-<div class="event-list" id="event-{{$event.id}}"> <a class="ajax-popupbox" href="calendar/event/show/{{$event.id}}">{{$event.title}}</a> - {{$event.date}} </div>
-{{/foreach}}
-</div>
+	<div id="event-notice" class="birthday-notice fakelink {{$classtoday}}" onclick="openClose('event-wrapper');">{{$event_reminders}} ({{$count}})</div>
+	<div id="event-wrapper" style="display: none;"><div id="event-title">{{$event_title}}</div>
+		<div id="event-title-end"></div>
+		{{foreach $events as $event}}
+			<div class="event-list" id="event-{{$event.id}}">
+				<button class="btn-link" onclick='addToModal("calendar/event/show/{{$event.id}}")'>{{$event.title}}</button>
+			  - {{$event.date}}
+			</div>
+		{{/foreach}}
+	</div>
 {{/if}}
 

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -4087,6 +4087,9 @@ div.login-form, .login-content-wrapper,
 	margin-left: 30px;
 	width: 60px;
 }
+.event-wrapper.fancybox-content {
+	width: clamp(200px, 80vw, 900px);
+}
 
 /**
  * The event-card


### PR DESCRIPTION
Closes #15535
...and some progress on #15089

- Makes the event reminder not take up the full screen width and scalable with the window width
- Convert event reminder from colorbox -> fancybox (wanted to use a modal, but Vier doesn't have that/bootstrap currently, sooo)
- Enable close buttons top right in fancybox
- Make some fancybox config only fire when certain elements exist (used to add captions to photos), to avoid JS errors making fancybox unable to load under other circumstances
- Cleanup some now unused colorbox JS

# Before

It's going all the way out to the side no matter the window width:
<img width="1008" height="265" alt="image" src="https://github.com/user-attachments/assets/8375733a-c676-4cfe-a660-50d9ad15f395" />

# After

<img width="885" height="307" alt="image" src="https://github.com/user-attachments/assets/593064df-2a1a-4eb8-a8af-0d37896df7b4" />