### PR TITLE
Require PHP 7.4 to 8.5 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"issues": "https://github.com/friendica/friendica/issues"
 	},
 	"require": {
-		"php": "^7.4 || ^8.0",
+		"php": "7.4.* || 8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.* || 8.5.*",
 		"ext-ctype": "*",
 		"ext-curl": "*",
 		"ext-dom": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d527ae9eae2fb9d84d097b0d543a152",
+    "content-hash": "2b4d6540f8af879e01ed418f2d5af7ab",
     "packages": [
         {
             "name": "alchemy/binary-driver",
@@ -10457,7 +10457,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ^8.0",
+        "php": "7.4.* || 8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.* || 8.5.*",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-dom": "*",


### PR DESCRIPTION
This PR sets the allowed PHP versions for friendica to 7.4 to 8.5, refs https://github.com/friendica/friendica/pull/15547#discussion_r2839821077

An alternative would be `"php": ">=7.4 <8.6"`.

> By specifying “>=7.4,” we are saying that this version of Friendica will also be executable in PHP 9, 10, and higher, but we cannot promise this.
> 
> By specifying “^7.4 || ^8.0,” we promise that (assuming that all further PHP 8.x versions have no or only minimal breaking changes) we will support all PHP versions from 7.4 to 8.x, but not PHP 9 or higher.
> 
> As soon as there is a dev version of PHP 9, we have set up our tests and made the necessary adjustments, we will specify “^7.4 || ^8.0 || ^9.0” to add PHP 9 as an additional supported PHP version (but not PHP 10 or higher).
> 
> Actually, a large application like Friendica should impose further restrictions on PHP versions, as even new PHP minor versions often contain minor breaking changes. By explicitly specifying which PHP versions Friendica supports, administrators can create an explicit PHP update path for their server. 
> 
> Consider the following scenario: An administrator runs a Friendica instance in version 2026.01, and in 2030, PHP 9.0 is released. If the administrator now switches their server to PHP 9.0 and runs composer run install:prod (without updating Friendica), this will theoretically work, but their instance will be in an unstable state and they run the risk of crashing their entire instance and lost their data.
> 
> With the specification “^7.4 || ^8.0,” Composer would refuse the installation when “composer run install:prod” is called, on the grounds that the admin is using an incompatible PHP version. The admin would then either have to switch back to PHP 8.x or first perform a Friendica update to a newer version that already supports PHP 9. In both cases, we protect the admin from damaging their Friendica instance.
> 