### PR TITLE
FRIO: Remove box shadow from action buttons in frio dark theme mobile view

### DIFF
--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -180,6 +180,11 @@ main .nav-tabs > li.active > a:hover {
 	background: none;
 	color: $font_color_darker;
 }
+
+.wall-item-actions .btn {
+	box-shadow: none;
+	-webkit-box-shadow: none;
+}
 .btn.focus,
 .btn:focus,
 .btn:hover {


### PR DESCRIPTION
Removes the box shadow from action buttons (Like, Unlike, Share, etc.) in the frio dark theme's mobile view. The shadow appeared as an unwanted light border around the buttons.

Before:
Buttons had a visible light border/shadow

![before](https://github.com/user-attachments/assets/81f485da-33f3-44dc-8925-d91d1443b484)

After:
Clean buttons without border
 
![after](https://github.com/user-attachments/assets/50cec47a-ffa5-4ff5-ae1f-99c24732cc07)
