### PR TITLE
Fix text overflow in admin queue page

### DIFF
--- a/src/Module/Admin/Queue.php
+++ b/src/Module/Admin/Queue.php
@@ -34,11 +34,11 @@ class Queue extends BaseAdmin
 		if ($status == 'deferred') {
 			$condition = ["NOT `done` AND `retrial` > ?", 0];
 			$sub_title = DI::l10n()->t('Inspect Deferred Worker Queue');
-			$info = DI::l10n()->t("This page lists the deferred worker jobs. This are jobs that couldn't be executed at the first time.");
+			$info      = DI::l10n()->t("This page lists the deferred worker jobs. This are jobs that couldn't be executed at the first time.");
 		} else {
 			$condition = ["NOT `done` AND `retrial` = ?", 0];
 			$sub_title = DI::l10n()->t('Inspect Worker Queue');
-			$info = DI::l10n()->t('This page lists the currently queued worker jobs. These jobs are handled by the worker cronjob you\'ve set up during install.');
+			$info      = DI::l10n()->t('This page lists the currently queued worker jobs. These jobs are handled by the worker cronjob you\'ve set up during install.');
 		}
 
 		// @TODO Move to Model\WorkerQueue::getEntries()
@@ -47,27 +47,32 @@ class Queue extends BaseAdmin
 		$r = [];
 		while ($entry = DBA::fetch($entries)) {
 			// fix GH-5469. ref: src/Core/Worker.php:217
-			$entry['parameter'] = Arrays::recursiveImplode(json_decode($entry['parameter'], true), ': ');
-			$entry['created'] = DateTimeFormat::local($entry['created']);
-			$entry['next_try'] = DateTimeFormat::local($entry['next_try']);
-			$r[] = $entry;
+			$param = Arrays::recursiveImplode(json_decode($entry['parameter'], true), ': ');
+			// Truncate long parameters to prevent text overflow
+			if (strlen($param) > 300) {
+				$param = substr($param, 0, 300) . '...';
+			}
+			$entry['parameter'] = $param;
+			$entry['created']   = DateTimeFormat::local($entry['created']);
+			$entry['next_try']  = DateTimeFormat::local($entry['next_try']);
+			$r[]                = $entry;
 		}
 		DBA::close($entries);
 
 		$t = Renderer::getMarkupTemplate('admin/queue.tpl');
 		return Renderer::replaceMacros($t, [
-			'$title' => DI::l10n()->t('Administration'),
-			'$page' => $sub_title,
-			'$count' => count($r),
-			'$id_header' => DI::l10n()->t('ID'),
-			'$command_header' => DI::l10n()->t('Command'),
-			'$param_header' => DI::l10n()->t('Job Parameters'),
-			'$created_header' => DI::l10n()->t('Created'),
+			'$title'           => DI::l10n()->t('Administration'),
+			'$page'            => $sub_title,
+			'$count'           => count($r),
+			'$id_header'       => DI::l10n()->t('ID'),
+			'$command_header'  => DI::l10n()->t('Command'),
+			'$param_header'    => DI::l10n()->t('Job Parameters'),
+			'$created_header'  => DI::l10n()->t('Created'),
 			'$next_try_header' => DI::l10n()->t('Next Try'),
-			'$prio_header' => DI::l10n()->t('Priority'),
-			'$info' => $info,
-			'$status' => $status,
-			'$entries' => $r,
+			'$prio_header'     => DI::l10n()->t('Priority'),
+			'$info'            => $info,
+			'$status'          => $status,
+			'$entries'         => $r,
 		]);
 	}
 }

--- a/view/templates/admin/queue.tpl
+++ b/view/templates/admin/queue.tpl
@@ -4,11 +4,19 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<div id='adminpage'>
+<div id='adminpage' class='adminpage'>
 	<h1>{{$title}} - {{$page}} ({{$count}})</h1>
 	
 	<p>{{$info}}</p>
 	<table>
+		<colgroup>
+			<col style="width: 80px;">
+			<col style="width: 120px;">
+			<col style="width: auto;">
+			<col style="width: 100px;">
+			{{if ($status == "deferred") }}<col style="width: 100px;">{{/if}}
+			<col style="width: 60px;">
+		</colgroup>
 		<tr>
 			<th>{{$id_header}}</th>
 			<th>{{$command_header}}</th>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3642,6 +3642,17 @@ li.addon {
 		width: 60%;
 	}
 }
+#adminpage td,
+.adminpage td,
+#adminpage .table td,
+.adminpage .table td,
+#adminpage.table > tbody > tr > td,
+.adminpage.table > tbody > tr > td,
+.table#adminpage > tbody > tr > td {
+	word-break: break-all !important;
+	white-space: normal !important;
+	vertical-align: top !important;
+}
 #admin-users #users tr.blocked {
 	background-color: #f8efc0;
 }
@@ -4342,3 +4353,4 @@ div.login-form, .login-content-wrapper,
 		padding-left: 3px;
 	}
 }
+

--- a/view/theme/frio/templates/admin/queue.tpl
+++ b/view/theme/frio/templates/admin/queue.tpl
@@ -4,11 +4,19 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<div id="adminpage">
+<div id="adminpage" class="adminpage">
 	<h1>{{$title}} - {{$page}} ({{$count}})</h1>
 	
 	<p>{{$info}}</p>
 	<table class="table">
+		<colgroup>
+			<col style="width: 80px;">
+			<col style="width: 120px;">
+			<col style="width: auto;">
+			<col style="width: 100px;">
+			{{if ($status == "deferred") }}<col style="width: 100px;">{{/if}}
+			<col style="width: 60px;">
+		</colgroup>
 		<tr>
 			<th>{{$id_header}}</th>
 			<th>{{$command_header}}</th>

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -25,6 +25,16 @@ img {
 	/* width: 80%; */
 }
 
+/* Fix text overflow in admin queue page */
+#adminpage td,
+.adminpage td,
+#adminpage .table td,
+.adminpage .table td {
+	word-break: break-all !important;
+	white-space: normal !important;
+	vertical-align: top !important;
+}
+
 #adminpage .screenshot img {
 	width: 640px;
 }


### PR DESCRIPTION
Fixes text overflow in admin queue inspection pages (/admin/queue and /admin/queue/deferred) where long URLs and JSON parameters broke the table layout.

- Optimized column widths (narrower ID/date/priority, wider parameter column)  
- Increased parameter truncation from 100 to 300 characters
- Added vertical-align: top for better readability

**FRIO before:**

<img width="1356" height="717" alt="image" src="https://github.com/user-attachments/assets/c5f3e78a-a5ab-4980-9aa9-9b8edf11f426" />

<img width="1356" height="717" alt="image" src="https://github.com/user-attachments/assets/0adcd026-64db-4ac4-9d15-a74bcd1f2ea7" />

**VIER before:**

<img width="1356" height="717" alt="image" src="https://github.com/user-attachments/assets/3a27b79c-0604-41c8-a37e-cb0c09fba417" />

<img width="1356" height="717" alt="image" src="https://github.com/user-attachments/assets/aa6d75ee-9e64-46e1-be75-5999d0d07ea6" />

**FRIO After:**

<img width="1356" height="717" alt="image" src="https://github.com/user-attachments/assets/8675665f-0526-4e57-a294-c8fcbda3c71f" />

<img width="1356" height="717" alt="image" src="https://github.com/user-attachments/assets/9eefcf7c-d3ce-4b94-b24c-14bebd7768e1" />

**VIER after:**

<img width="1356" height="717" alt="image" src="https://github.com/user-attachments/assets/dfa0ce39-b2e0-49c9-83a0-6887ffd48882" />

<img width="1356" height="717" alt="image" src="https://github.com/user-attachments/assets/bc5066ed-dc0a-4aaa-9698-81a8d8780010" />

