### PR TITLE
Feature: Cache fallback to default when configured caching driver fails

### DIFF
--- a/src/Core/Cache/Factory/Cache.php
+++ b/src/Core/Cache/Factory/Cache.php
@@ -13,7 +13,6 @@ use Friendica\Core\Cache\Exception\InvalidCacheDriverException;
 use Friendica\Core\Cache\Type;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Hooks\Capability\ICanCreateInstances;
-use Friendica\DI;
 use Friendica\Util\Profiler;
 
 /**
@@ -90,16 +89,6 @@ class Cache
 			// If the configured cache (e.g. Redis) is not available, fall back to database cache
 			// to keep the application functional with degraded performance
 			if ($strategy !== self::DEFAULT_TYPE) {
-				// Log the fallback if logger is already available
-				try {
-					DI::logger()->error('Configured cache driver is not available, application will fall back to default', [
-						'driver'   => $strategy,
-						'fallback' => self::DEFAULT_TYPE,
-						'error'    => $e->getMessage(),
-					]);
-				} catch (\Throwable $logEx) {
-					// Logger not available yet, ignore
-				}
 				/** @var ICanCache $cache */
 				$cache = $this->instanceCreator->create(ICanCache::class, self::DEFAULT_TYPE);
 			} else {

--- a/src/Core/Cache/Factory/Cache.php
+++ b/src/Core/Cache/Factory/Cache.php
@@ -13,6 +13,7 @@ use Friendica\Core\Cache\Exception\InvalidCacheDriverException;
 use Friendica\Core\Cache\Type;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Hooks\Capability\ICanCreateInstances;
+use Friendica\DI;
 use Friendica\Util\Profiler;
 
 /**
@@ -82,8 +83,30 @@ class Cache
 	 */
 	protected function create(string $strategy): ICanCache
 	{
-		/** @var ICanCache $cache */
-		$cache = $this->instanceCreator->create(ICanCache::class, $strategy);
+		try {
+			/** @var ICanCache $cache */
+			$cache = $this->instanceCreator->create(ICanCache::class, $strategy);
+		} catch (CachePersistenceException|InvalidCacheDriverException $e) {
+			// If the configured cache (e.g. Redis) is not available, fall back to database cache
+			// to keep the application functional with degraded performance
+			if ($strategy !== self::DEFAULT_TYPE) {
+				// Log the fallback if logger is already available
+				try {
+					DI::logger()->error('Configured cache driver {driver} is not available, application will fall back to {fallback}', [
+						'driver'   => $strategy,
+						'fallback' => self::DEFAULT_TYPE,
+						'error'    => $e->getMessage(),
+					]);
+				} catch (\Throwable $logEx) {
+					// Logger not available yet, ignore
+				}
+				/** @var ICanCache $cache */
+				$cache = $this->instanceCreator->create(ICanCache::class, self::DEFAULT_TYPE);
+			} else {
+				// Database cache itself failed - this is a critical issue
+				throw $e;
+			}
+		}
 
 		$profiling = $this->config->get('system', 'profiling', false);
 

--- a/src/Core/Cache/Factory/Cache.php
+++ b/src/Core/Cache/Factory/Cache.php
@@ -28,7 +28,7 @@ class Cache
 	/**
 	 * @var string The default cache if nothing set
 	 */
-	const DEFAULT_TYPE = Type\DatabaseCache::NAME;
+	public const DEFAULT_TYPE = Type\DatabaseCache::NAME;
 	/** @var ICanCreateInstances */
 	protected $instanceCreator;
 	/** @var IManageConfigValues */
@@ -92,7 +92,7 @@ class Cache
 			if ($strategy !== self::DEFAULT_TYPE) {
 				// Log the fallback if logger is already available
 				try {
-					DI::logger()->error('Configured cache driver {driver} is not available, application will fall back to {fallback}', [
+					DI::logger()->error('Configured cache driver is not available, application will fall back to default', [
 						'driver'   => $strategy,
 						'fallback' => self::DEFAULT_TYPE,
 						'error'    => $e->getMessage(),

--- a/src/Core/Cache/Type/RedisCache.php
+++ b/src/Core/Cache/Type/RedisCache.php
@@ -81,7 +81,11 @@ class RedisCache extends AbstractCache implements ICanCacheInMemory
 			$search = $prefix . '*';
 		}
 
-		$list = $this->redis->keys($this->getCacheKey($search));
+		try {
+			$list = $this->redis->keys($this->getCacheKey($search));
+		} catch (\RedisException $e) {
+			throw new CachePersistenceException('Redis connection failed during getAllKeys', $e);
+		}
 
 		return $this->getOriginalKeys($list);
 	}
@@ -94,9 +98,13 @@ class RedisCache extends AbstractCache implements ICanCacheInMemory
 		$return   = null;
 		$cacheKey = $this->getCacheKey($key);
 
-		$cached = $this->redis->get($cacheKey);
-		if ($cached === false && !$this->redis->exists($cacheKey)) {
-			return null;
+		try {
+			$cached = $this->redis->get($cacheKey);
+			if ($cached === false && !$this->redis->exists($cacheKey)) {
+				return null;
+			}
+		} catch (\RedisException $e) {
+			throw new CachePersistenceException('Redis connection failed during get', $e);
 		}
 
 		$value = unserialize($cached);
@@ -120,17 +128,21 @@ class RedisCache extends AbstractCache implements ICanCacheInMemory
 
 		$cached = serialize($value);
 
-		if ($ttl > 0) {
-			return $this->redis->setex(
-				$cacheKey,
-				$ttl,
-				$cached
-			);
-		} else {
-			return $this->redis->set(
-				$cacheKey,
-				$cached
-			);
+		try {
+			if ($ttl > 0) {
+				return $this->redis->setex(
+					$cacheKey,
+					$ttl,
+					$cached
+				);
+			} else {
+				return $this->redis->set(
+					$cacheKey,
+					$cached
+				);
+			}
+		} catch (\RedisException $e) {
+			throw new CachePersistenceException('Redis connection failed during set', $e);
 		}
 	}
 
@@ -140,7 +152,11 @@ class RedisCache extends AbstractCache implements ICanCacheInMemory
 	public function delete(string $key): bool
 	{
 		$cacheKey = $this->getCacheKey($key);
-		$this->redis->del($cacheKey);
+		try {
+			$this->redis->del($cacheKey);
+		} catch (\RedisException $e) {
+			throw new CachePersistenceException('Redis connection failed during delete', $e);
+		}
 		// Redis doesn't have an error state for del()
 		return true;
 	}
@@ -153,7 +169,11 @@ class RedisCache extends AbstractCache implements ICanCacheInMemory
 		if ($outdated) {
 			return true;
 		} else {
-			return $this->redis->flushAll();
+			try {
+				return $this->redis->flushAll();
+			} catch (\RedisException $e) {
+				throw new CachePersistenceException('Redis connection failed during clear', $e);
+			}
 		}
 	}
 
@@ -165,7 +185,11 @@ class RedisCache extends AbstractCache implements ICanCacheInMemory
 		$cacheKey = $this->getCacheKey($key);
 		$cached   = serialize($value);
 
-		return $this->redis->setnx($cacheKey, $cached);
+		try {
+			return $this->redis->setnx($cacheKey, $cached);
+		} catch (\RedisException $e) {
+			throw new CachePersistenceException('Redis connection failed during add', $e);
+		}
 	}
 
 	/**
@@ -177,17 +201,21 @@ class RedisCache extends AbstractCache implements ICanCacheInMemory
 
 		$newCached = serialize($newValue);
 
-		$this->redis->watch($cacheKey);
-		// If the old value isn't what we expected, somebody else changed the key meanwhile
-		if ($this->get($key) === $oldValue) {
-			if ($ttl > 0) {
-				$result = $this->redis->multi()->setex($cacheKey, $ttl, $newCached)->exec();
-			} else {
-				$result = $this->redis->multi()->set($cacheKey, $newCached)->exec();
+		try {
+			$this->redis->watch($cacheKey);
+			// If the old value isn't what we expected, somebody else changed the key meanwhile
+			if ($this->get($key) === $oldValue) {
+				if ($ttl > 0) {
+					$result = $this->redis->multi()->setex($cacheKey, $ttl, $newCached)->exec();
+				} else {
+					$result = $this->redis->multi()->set($cacheKey, $newCached)->exec();
+				}
+				return $result !== false;
 			}
-			return $result !== false;
+			$this->redis->unwatch();
+		} catch (\RedisException $e) {
+			throw new CachePersistenceException('Redis connection failed during compareSet', $e);
 		}
-		$this->redis->unwatch();
 		return false;
 	}
 
@@ -198,30 +226,38 @@ class RedisCache extends AbstractCache implements ICanCacheInMemory
 	{
 		$cacheKey = $this->getCacheKey($key);
 
-		$this->redis->watch($cacheKey);
-		// If the old value isn't what we expected, somebody else changed the key meanwhile
-		if ($this->get($key) === $value) {
-			$this->redis->multi()->del($cacheKey)->exec();
-			return true;
+		try {
+			$this->redis->watch($cacheKey);
+			// If the old value isn't what we expected, somebody else changed the key meanwhile
+			if ($this->get($key) === $value) {
+				$this->redis->multi()->del($cacheKey)->exec();
+				return true;
+			}
+			$this->redis->unwatch();
+		} catch (\RedisException $e) {
+			throw new CachePersistenceException('Redis connection failed during compareDelete', $e);
 		}
-		$this->redis->unwatch();
 		return false;
 	}
 
 	/** {@inheritDoc} */
 	public function getStats(): array
 	{
-		$info = $this->redis->info();
+		try {
+			$info = $this->redis->info();
 
-		return [
-			'version'           => $info['redis_version']     ?? null,
-			'entries'           => $this->redis->dbSize()     ?? null,
-			'used_memory'       => $info['used_memory']       ?? null,
-			'connected_clients' => $info['connected_clients'] ?? null,
-			'uptime'            => $info['uptime_in_seconds'] ?? null,
-			'hits'              => $info['keyspace_hits']     ?? null,
-			'misses'            => $info['keyspace_misses']   ?? null,
-			'evictions'         => $info['evicted_keys']      ?? null,
-		];
+			return [
+				'version'           => $info['redis_version']     ?? null,
+				'entries'           => $this->redis->dbSize()     ?? null,
+				'used_memory'       => $info['used_memory']       ?? null,
+				'connected_clients' => $info['connected_clients'] ?? null,
+				'uptime'            => $info['uptime_in_seconds'] ?? null,
+				'hits'              => $info['keyspace_hits']     ?? null,
+				'misses'            => $info['keyspace_misses']   ?? null,
+				'evictions'         => $info['evicted_keys']      ?? null,
+			];
+		} catch (\RedisException $e) {
+			throw new CachePersistenceException('Redis connection failed during getStats', $e);
+		}
 	}
 }

--- a/src/Core/Cache/Type/RedisCache.php
+++ b/src/Core/Cache/Type/RedisCache.php
@@ -19,7 +19,7 @@ use Redis;
  */
 class RedisCache extends AbstractCache implements ICanCacheInMemory
 {
-	const NAME = 'redis';
+	public const NAME = 'redis';
 
 	/**
 	 * @var Redis
@@ -43,7 +43,7 @@ class RedisCache extends AbstractCache implements ICanCacheInMemory
 		$redis_host = $config->get('system', 'redis_host');
 		$redis_port = $config->get('system', 'redis_port');
 		$redis_pw   = $config->get('system', 'redis_password');
-		$redis_db   = (int)$config->get('system', 'redis_db', 0);
+		$redis_db   = (int) $config->get('system', 'redis_db', 0);
 
 		try {
 			if (is_numeric($redis_port) && $redis_port > -1) {
@@ -133,12 +133,12 @@ class RedisCache extends AbstractCache implements ICanCacheInMemory
 				return $this->redis->setex(
 					$cacheKey,
 					$ttl,
-					$cached
+					$cached,
 				);
 			} else {
 				return $this->redis->set(
 					$cacheKey,
-					$cached
+					$cached,
 				);
 			}
 		} catch (\RedisException $e) {

--- a/src/Core/Lock/Type/CacheLock.php
+++ b/src/Core/Lock/Type/CacheLock.php
@@ -9,7 +9,6 @@ namespace Friendica\Core\Lock\Type;
 
 use Friendica\Core\Cache\Capability\ICanCacheInMemory;
 use Friendica\Core\Cache\Enum\Duration;
-use Friendica\Core\Cache\Exception\CachePersistenceException;
 
 class CacheLock extends AbstractLock
 {
@@ -45,34 +44,28 @@ class CacheLock extends AbstractLock
 
 		$lockKey = self::getLockKey($key);
 
-		try {
-			do {
-				$lock = $this->cache->get($lockKey);
-				// When we do want to lock something that was already locked by us.
-				if ((int) $lock == getmypid()) {
+		do {
+			$lock = $this->cache->get($lockKey);
+			// When we do want to lock something that was already locked by us.
+			if ((int) $lock == getmypid()) {
+				$got_lock = true;
+			}
+
+			// When we do want to lock something new
+			if (is_null($lock)) {
+				// At first initialize it with "0"
+				$this->cache->add($lockKey, 0);
+				// Now the value has to be "0" because otherwise the key was used by another process meanwhile
+				if ($this->cache->compareSet($lockKey, 0, getmypid(), $ttl)) {
 					$got_lock = true;
+					$this->markAcquire($key);
 				}
+			}
 
-				// When we do want to lock something new
-				if (is_null($lock)) {
-					// At first initialize it with "0"
-					$this->cache->add($lockKey, 0);
-					// Now the value has to be "0" because otherwise the key was used by another process meanwhile
-					if ($this->cache->compareSet($lockKey, 0, getmypid(), $ttl)) {
-						$got_lock = true;
-						$this->markAcquire($key);
-					}
-				}
-
-				if (!$got_lock && ($timeout > 0)) {
-					usleep(random_int(10000, 200000));
-				}
-			} while (!$got_lock && ((time() - $start) < $timeout));
-		} catch (CachePersistenceException $exception) {
-			// Cache unavailable (e.g. Redis down) - treat as lock not acquired
-			// This allows the application to continue with degraded performance
-			return false;
-		}
+			if (!$got_lock && ($timeout > 0)) {
+				usleep(random_int(10000, 200000));
+			}
+		} while (!$got_lock && ((time() - $start) < $timeout));
 
 		return $got_lock;
 	}
@@ -84,15 +77,10 @@ class CacheLock extends AbstractLock
 	{
 		$lockKey = self::getLockKey($key);
 
-		try {
-			if ($override) {
-				$return = $this->cache->delete($lockKey);
-			} else {
-				$return = $this->cache->compareDelete($lockKey, getmypid());
-			}
-		} catch (CachePersistenceException $exception) {
-			// Cache unavailable (e.g. Redis down) - treat as released
-			return true;
+		if ($override) {
+			$return = $this->cache->delete($lockKey);
+		} else {
+			$return = $this->cache->compareDelete($lockKey, getmypid());
 		}
 		$this->markRelease($key);
 
@@ -105,12 +93,7 @@ class CacheLock extends AbstractLock
 	public function isLocked(string $key): bool
 	{
 		$lockKey = self::getLockKey($key);
-		try {
-			$lock = $this->cache->get($lockKey);
-		} catch (CachePersistenceException $exception) {
-			// Cache unavailable (e.g. Redis down) - treat as not locked
-			return false;
-		}
+		$lock    = $this->cache->get($lockKey);
 		return isset($lock) && ($lock !== false);
 	}
 
@@ -127,12 +110,7 @@ class CacheLock extends AbstractLock
 	 */
 	public function getLocks(string $prefix = ''): array
 	{
-		try {
-			$locks = $this->cache->getAllKeys(self::CACHE_PREFIX . $prefix);
-		} catch (CachePersistenceException $exception) {
-			// Cache unavailable (e.g. Redis down) - return empty list
-			return [];
-		}
+		$locks = $this->cache->getAllKeys(self::CACHE_PREFIX . $prefix);
 
 		array_walk($locks, function (&$lock) {
 			$lock = substr($lock, strlen(self::CACHE_PREFIX));

--- a/src/Core/Lock/Type/CacheLock.php
+++ b/src/Core/Lock/Type/CacheLock.php
@@ -10,7 +10,6 @@ namespace Friendica\Core\Lock\Type;
 use Friendica\Core\Cache\Capability\ICanCacheInMemory;
 use Friendica\Core\Cache\Enum\Duration;
 use Friendica\Core\Cache\Exception\CachePersistenceException;
-use Friendica\Core\Lock\Exception\LockPersistenceException;
 
 class CacheLock extends AbstractLock
 {
@@ -70,7 +69,9 @@ class CacheLock extends AbstractLock
 				}
 			} while (!$got_lock && ((time() - $start) < $timeout));
 		} catch (CachePersistenceException $exception) {
-			throw new LockPersistenceException(sprintf('Cannot acquire lock for key %s', $key), $exception);
+			// Cache unavailable (e.g. Redis down) - treat as lock not acquired
+			// This allows the application to continue with degraded performance
+			return false;
 		}
 
 		return $got_lock;
@@ -90,7 +91,8 @@ class CacheLock extends AbstractLock
 				$return = $this->cache->compareDelete($lockKey, getmypid());
 			}
 		} catch (CachePersistenceException $exception) {
-			throw new LockPersistenceException(sprintf('Cannot release lock for key %s (override %b)', $key, $override), $exception);
+			// Cache unavailable (e.g. Redis down) - treat as released
+			return true;
 		}
 		$this->markRelease($key);
 
@@ -106,7 +108,8 @@ class CacheLock extends AbstractLock
 		try {
 			$lock = $this->cache->get($lockKey);
 		} catch (CachePersistenceException $exception) {
-			throw new LockPersistenceException(sprintf('Cannot check lock state for key %s', $key), $exception);
+			// Cache unavailable (e.g. Redis down) - treat as not locked
+			return false;
 		}
 		return isset($lock) && ($lock !== false);
 	}
@@ -127,7 +130,8 @@ class CacheLock extends AbstractLock
 		try {
 			$locks = $this->cache->getAllKeys(self::CACHE_PREFIX . $prefix);
 		} catch (CachePersistenceException $exception) {
-			throw new LockPersistenceException(sprintf('Cannot get locks with prefix %s', $prefix), $exception);
+			// Cache unavailable (e.g. Redis down) - return empty list
+			return [];
 		}
 
 		array_walk($locks, function (&$lock) {

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -109,6 +109,14 @@ class Summary extends BaseAdmin
 			);
 		}
 
+		// Check if cache fallback is active (e.g. Redis configured but DatabaseCache is running)
+		$configured_cache = DI::config()->get('system', 'cache_driver', 'database');
+		$distributed_cache = DI::config()->get('system', 'distributed_cache_driver', 'database');
+		$current_cache = DI::cache()->getName();
+		if ($current_cache === 'database' && ($configured_cache !== 'database' || $distributed_cache !== 'database')) {
+			$warningtext[] = DI::l10n()->t('Your cache is configured to use %s, but the system is currently using the database as fallback. This results in poor performance. Please check if your cache service is running.', $configured_cache !== 'database' ? $configured_cache : $distributed_cache);
+		}
+
 		// Check logfile permission
 		if (($return = DI::logCheck()->checkLogfile()) !== null) {
 			$warningtext[] = $return;

--- a/src/Module/Admin/Summary.php
+++ b/src/Module/Admin/Summary.php
@@ -110,9 +110,9 @@ class Summary extends BaseAdmin
 		}
 
 		// Check if cache fallback is active (e.g. Redis configured but DatabaseCache is running)
-		$configured_cache = DI::config()->get('system', 'cache_driver', 'database');
+		$configured_cache  = DI::config()->get('system', 'cache_driver', 'database');
 		$distributed_cache = DI::config()->get('system', 'distributed_cache_driver', 'database');
-		$current_cache = DI::cache()->getName();
+		$current_cache     = DI::cache()->getName();
 		if ($current_cache === 'database' && ($configured_cache !== 'database' || $distributed_cache !== 'database')) {
 			$warningtext[] = DI::l10n()->t('Your cache is configured to use %s, but the system is currently using the database as fallback. This results in poor performance. Please check if your cache service is running.', $configured_cache !== 'database' ? $configured_cache : $distributed_cache);
 		}

--- a/tests/CacheTestCase.php
+++ b/tests/CacheTestCase.php
@@ -8,7 +8,6 @@
 namespace Friendica\Test;
 
 use Friendica\Core\Cache\Capability\ICanCache;
-use Friendica\Test\MockedTestCase;
 use Friendica\Util\PidFile;
 
 abstract class CacheTestCase extends MockedTestCase
@@ -239,5 +238,18 @@ abstract class CacheTestCase extends MockedTestCase
 		} else {
 			self::expectNotToPerformAssertions();
 		}
+	}
+
+	/**
+	 * Test that cache operations work without throwing unexpected exceptions
+	 * This verifies the basic contract of the cache interface
+	 * @small
+	 */
+	public function testCacheOperations()
+	{
+		self::assertTrue($this->instance->set('test_key', 'test_value'));
+		self::assertEquals('test_value', $this->instance->get('test_key'));
+		self::assertTrue($this->instance->delete('test_key'));
+		self::assertNull($this->instance->get('test_key'));
 	}
 }

--- a/tests/src/Core/Cache/RedisCacheTest.php
+++ b/tests/src/Core/Cache/RedisCacheTest.php
@@ -74,4 +74,33 @@ class RedisCacheTest extends MemoryCacheTestCase
 		self::assertGreaterThan(0, $stats['connected_clients']);
 		self::assertGreaterThan(0, $stats['uptime']);
 	}
+
+	/**
+	 * Test that CachePersistenceException is thrown when Redis connection fails
+	 * @small
+	 */
+	public function testCachePersistenceExceptionOnConnectionFailure()
+	{
+		$configMock = Mockery::mock(IManageConfigValues::class);
+		$configMock
+			->shouldReceive('get')
+			->with('system', 'redis_host')
+			->andReturn('invalid_host_that_does_not_exist');
+		$configMock
+			->shouldReceive('get')
+			->with('system', 'redis_port')
+			->andReturn(12345);
+		$configMock
+			->shouldReceive('get')
+			->with('system', 'redis_db', 0)
+			->andReturn(0);
+		$configMock
+			->shouldReceive('get')
+			->with('system', 'redis_password')
+			->andReturn(null);
+
+		$this->expectException(\Friendica\Core\Cache\Exception\CachePersistenceException::class);
+
+		new RedisCache('localhost', $configMock);
+	}
 }

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-18 17:21+0100\n"
+"POT-Creation-Date: 2026-04-08 14:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -262,7 +262,7 @@ msgstr ""
 msgid "Failed to delete the photo."
 msgstr ""
 
-#: mod/photos.php:332 src/Module/Conversation/Community.php:145
+#: mod/photos.php:332 src/Module/Conversation/Community.php:146
 #: src/Module/Directory.php:34 src/Module/Profile/Photos.php:270
 #: src/Module/Search/Index.php:50
 msgid "Public access denied."
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:450 src/Content/Widget.php:265 src/Model/User.php:1386
+#: src/BaseModule.php:450 src/Content/Widget.php:265 src/Model/User.php:1409
 #: src/Module/Contact.php:405
 msgid "Friends"
 msgstr ""
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Enter user nickname: "
 msgstr ""
 
-#: src/Console/User.php:168 src/Model/User.php:837
+#: src/Console/User.php:168 src/Model/User.php:860
 #: src/Module/Api/Twitter/ContactEndpoint.php:62
 #: src/Module/Moderation/Users/Active.php:136
 #: src/Module/Moderation/Users/Blocked.php:135
@@ -917,10 +917,10 @@ msgid "Tumblr"
 msgstr ""
 
 #: src/Content/ContactSelector.php:137
-msgid "Bluesky"
+msgid "AT Protocol"
 msgstr ""
 
-#: src/Content/ContactSelector.php:165
+#: src/Content/ContactSelector.php:165 src/Content/ContactSelector.php:171
 #, php-format
 msgid "%s (via %s)"
 msgstr ""
@@ -1537,9 +1537,9 @@ msgstr ""
 msgid "Display posts that have been created by accounts of the selected circle."
 msgstr ""
 
-#: src/Content/Feature.php:128 src/Content/GroupManager.php:131
+#: src/Content/Feature.php:128 src/Content/GroupManager.php:132
 #: src/Content/Nav.php:275 src/Content/Text/HTML.php:884
-#: src/Content/Widget.php:564 src/Model/User.php:1400
+#: src/Content/Widget.php:564 src/Model/User.php:1423
 msgid "Groups"
 msgstr ""
 
@@ -1598,7 +1598,7 @@ msgstr ""
 msgid "Display a list of folders in which posts are stored."
 msgstr ""
 
-#: src/Content/Feature.php:135 src/Module/Conversation/Timeline.php:189
+#: src/Content/Feature.php:135 src/Module/Conversation/Timeline.php:192
 msgid "Own Contacts"
 msgstr ""
 
@@ -1646,24 +1646,24 @@ msgstr ""
 msgid "Allows anonymous visitors to consult your calendar and your public events. Contact birthday events are private to you."
 msgstr ""
 
-#: src/Content/GroupManager.php:133
+#: src/Content/GroupManager.php:134
 msgid "External link to group"
 msgstr ""
 
-#: src/Content/GroupManager.php:137 src/Content/Widget.php:539
+#: src/Content/GroupManager.php:138 src/Content/Widget.php:539
 msgid "show less"
 msgstr ""
 
-#: src/Content/GroupManager.php:138 src/Content/Widget.php:434
+#: src/Content/GroupManager.php:139 src/Content/Widget.php:434
 #: src/Content/Widget.php:540
 msgid "show more"
 msgstr ""
 
-#: src/Content/GroupManager.php:139
+#: src/Content/GroupManager.php:140
 msgid "Create new group"
 msgstr ""
 
-#: src/Content/GroupManager.php:141
+#: src/Content/GroupManager.php:142
 msgid "Find groups to join"
 msgstr ""
 
@@ -1868,7 +1868,7 @@ msgstr ""
 msgid "Your personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:248 src/Module/Settings/OAuth.php:59
+#: src/Content/Nav.php:248 src/Module/Settings/OAuth.php:62
 msgid "Home Page"
 msgstr ""
 
@@ -1886,7 +1886,7 @@ msgstr ""
 #: src/Module/Settings/TwoFactor/AppSpecific.php:118
 #: src/Module/Settings/TwoFactor/Index.php:125
 #: src/Module/Settings/TwoFactor/Recovery.php:96
-#: src/Module/Settings/TwoFactor/Verify.php:135 view/theme/vier/theme.php:227
+#: src/Module/Settings/TwoFactor/Verify.php:140 view/theme/vier/theme.php:227
 msgid "Help"
 msgstr ""
 
@@ -2094,28 +2094,28 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:950 src/Model/Item.php:3750
-#: src/Model/Item.php:3756 src/Model/Item.php:3757
+#: src/Content/Text/BBCode.php:950 src/Model/Item.php:3705
+#: src/Model/Item.php:3711 src/Model/Item.php:3712
 msgid "Link to source"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1740 src/Content/Text/HTML.php:908
+#: src/Content/Text/BBCode.php:1749 src/Content/Text/HTML.php:908
 msgid "Click to open/close"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1795
+#: src/Content/Text/BBCode.php:1804
 msgid "$1 wrote:"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1869 src/Content/Text/BBCode.php:1870
+#: src/Content/Text/BBCode.php:1878 src/Content/Text/BBCode.php:1879
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2186
+#: src/Content/Text/BBCode.php:2195
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2205
+#: src/Content/Text/BBCode.php:2214
 msgid "Invalid link protocol"
 msgstr ""
 
@@ -3240,53 +3240,53 @@ msgstr ""
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3620
+#: src/Model/Item.php:3573
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3654
+#: src/Model/Item.php:3607
 #, php-format
 msgid "The media in this post is not displayed to visitors. To view it, please go to the <a href=\"%s\">original post</a>."
 msgstr ""
 
-#: src/Model/Item.php:3656
+#: src/Model/Item.php:3609
 msgid "The media in this post is not displayed to visitors. To view it, please log in."
 msgstr ""
 
-#: src/Model/Item.php:3681
+#: src/Model/Item.php:3634
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3683
+#: src/Model/Item.php:3636
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3688
+#: src/Model/Item.php:3641
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3690
+#: src/Model/Item.php:3643
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3692
+#: src/Model/Item.php:3645
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3733 src/Model/Item.php:3734
+#: src/Model/Item.php:3688 src/Model/Item.php:3689
 msgid "View on separate page"
 msgstr ""
 
@@ -3433,135 +3433,135 @@ msgstr ""
 msgid "Responsible account: %s"
 msgstr ""
 
-#: src/Model/User.php:216 src/Model/User.php:1320
+#: src/Model/User.php:219 src/Model/User.php:1343
 msgid "SERIOUS ERROR: Generation of security keys failed."
 msgstr ""
 
-#: src/Model/User.php:739 src/Model/User.php:776
+#: src/Model/User.php:762 src/Model/User.php:799
 msgid "Login failed"
 msgstr ""
 
-#: src/Model/User.php:809
+#: src/Model/User.php:832
 msgid "Not enough information to authenticate"
 msgstr ""
 
-#: src/Model/User.php:936
+#: src/Model/User.php:959
 msgid "Password can't be empty"
 msgstr ""
 
-#: src/Model/User.php:978
+#: src/Model/User.php:1001
 msgid "Empty passwords are not allowed."
 msgstr ""
 
-#: src/Model/User.php:982
+#: src/Model/User.php:1005
 msgid "The new password has been exposed in a public data dump, please choose another."
 msgstr ""
 
-#: src/Model/User.php:986
+#: src/Model/User.php:1009
 msgid "The password length is limited to 72 characters."
 msgstr ""
 
-#: src/Model/User.php:990
+#: src/Model/User.php:1013
 msgid "The password can't contain white spaces nor accentuated letters"
 msgstr ""
 
-#: src/Model/User.php:1200
+#: src/Model/User.php:1223
 msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
-#: src/Model/User.php:1209
+#: src/Model/User.php:1232
 msgid "An invitation is required."
 msgstr ""
 
-#: src/Model/User.php:1213
+#: src/Model/User.php:1236
 msgid "Invitation could not be verified."
 msgstr ""
 
-#: src/Model/User.php:1221
+#: src/Model/User.php:1244
 msgid "Invalid OpenID url"
 msgstr ""
 
-#: src/Model/User.php:1235 src/Security/Authentication.php:235
+#: src/Model/User.php:1258 src/Security/Authentication.php:235
 msgid "We encountered a problem while logging in with the OpenID you provided. Please check the correct spelling of the ID."
 msgstr ""
 
-#: src/Model/User.php:1235 src/Security/Authentication.php:235
+#: src/Model/User.php:1258 src/Security/Authentication.php:235
 msgid "The error message was:"
 msgstr ""
 
-#: src/Model/User.php:1241
+#: src/Model/User.php:1264
 msgid "Please enter the required information."
 msgstr ""
 
-#: src/Model/User.php:1255
+#: src/Model/User.php:1278
 #, php-format
 msgid "system.username_min_length (%s) and system.username_max_length (%s) are excluding each other, swapping values."
 msgstr ""
 
-#: src/Model/User.php:1262
+#: src/Model/User.php:1285
 #, php-format
 msgid "Username should be at least %s character."
 msgid_plural "Username should be at least %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1266
+#: src/Model/User.php:1289
 #, php-format
 msgid "Username should be at most %s character."
 msgid_plural "Username should be at most %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1274
+#: src/Model/User.php:1297
 msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Model/User.php:1279
+#: src/Model/User.php:1302
 msgid "Your email domain is not among those allowed on this site."
 msgstr ""
 
-#: src/Model/User.php:1283
+#: src/Model/User.php:1306
 msgid "Not a valid email address."
 msgstr ""
 
-#: src/Model/User.php:1286
+#: src/Model/User.php:1309
 msgid "The nickname was blocked from registration by the nodes admin."
 msgstr ""
 
-#: src/Model/User.php:1290 src/Model/User.php:1296
+#: src/Model/User.php:1313 src/Model/User.php:1319
 #: src/Module/User/Import.php:231
 msgid "Cannot use that email."
 msgstr ""
 
-#: src/Model/User.php:1302
+#: src/Model/User.php:1325
 msgid "Your nickname can only contain a-z, 0-9 and _."
 msgstr ""
 
-#: src/Model/User.php:1310 src/Model/User.php:1360
+#: src/Model/User.php:1333 src/Model/User.php:1383
 msgid "Nickname is already registered. Please choose another."
 msgstr ""
 
-#: src/Model/User.php:1347 src/Model/User.php:1351
+#: src/Model/User.php:1370 src/Model/User.php:1374
 msgid "An error occurred during registration. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1374
+#: src/Model/User.php:1397
 msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1381
+#: src/Model/User.php:1404
 msgid "An error occurred creating your self contact. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1390
+#: src/Model/User.php:1413
 msgid "An error occurred creating your default contact circle. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1438
+#: src/Model/User.php:1461
 msgid "Profile Photos"
 msgstr ""
 
-#: src/Model/User.php:1636
+#: src/Model/User.php:1659
 #, php-format
 msgid ""
 "\n"
@@ -3569,7 +3569,7 @@ msgid ""
 "\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: src/Model/User.php:1639
+#: src/Model/User.php:1662
 #, php-format
 msgid ""
 "\n"
@@ -3600,12 +3600,12 @@ msgid ""
 "\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: src/Model/User.php:1671 src/Model/User.php:1777
+#: src/Model/User.php:1694 src/Model/User.php:1800
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
-#: src/Model/User.php:1691
+#: src/Model/User.php:1714
 #, php-format
 msgid ""
 "\n"
@@ -3620,12 +3620,12 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:1710
+#: src/Model/User.php:1733
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: src/Model/User.php:1734
+#: src/Model/User.php:1757
 #, php-format
 msgid ""
 "\n"
@@ -3634,7 +3634,7 @@ msgid ""
 "\t\t\t"
 msgstr ""
 
-#: src/Model/User.php:1742
+#: src/Model/User.php:1765
 #, php-format
 msgid ""
 "\n"
@@ -3665,7 +3665,7 @@ msgid ""
 "\t\t\tThank you and welcome to %2$s."
 msgstr ""
 
-#: src/Model/User.php:1804
+#: src/Model/User.php:1827
 msgid "User with delegates can't be removed, please remove delegate users first"
 msgstr ""
 
@@ -4076,7 +4076,7 @@ msgid "Job Parameters"
 msgstr ""
 
 #: src/Module/Admin/Queue.php:70 src/Module/Moderation/Reports.php:110
-#: src/Module/Settings/OAuth.php:60
+#: src/Module/Settings/OAuth.php:63
 msgid "Created"
 msgstr ""
 
@@ -5610,9 +5610,9 @@ msgid "Tips for New Members"
 msgstr ""
 
 #: src/Module/BaseProfile.php:141 src/Module/Contact.php:395
-#: src/Module/Contact.php:542 src/Module/Conversation/Channel.php:93
-#: src/Module/Conversation/Community.php:86
-#: src/Module/Conversation/Network.php:379
+#: src/Module/Contact.php:542 src/Module/Conversation/Channel.php:94
+#: src/Module/Conversation/Community.php:87
+#: src/Module/Conversation/Network.php:382
 #: src/Module/Moderation/BaseUsers.php:130 src/Object/Post.php:618
 msgid "More"
 msgstr ""
@@ -5627,8 +5627,8 @@ msgstr ""
 msgid "Group Search - %s"
 msgstr ""
 
-#: src/Module/BaseSearch.php:115 src/Module/Conversation/Channel.php:120
-#: src/Module/Conversation/Community.php:110 src/Module/Search/Index.php:140
+#: src/Module/BaseSearch.php:115 src/Module/Conversation/Channel.php:121
+#: src/Module/Conversation/Community.php:111 src/Module/Search/Index.php:140
 #: src/Module/Search/Index.php:192
 msgid "No results."
 msgstr ""
@@ -5741,7 +5741,7 @@ msgstr ""
 #: src/Module/Security/TwoFactor/Verify.php:87
 #: src/Module/Settings/Channels.php:184 src/Module/Settings/Channels.php:210
 #: src/Module/Settings/TwoFactor/Index.php:147
-#: src/Module/Settings/TwoFactor/Verify.php:144
+#: src/Module/Settings/TwoFactor/Verify.php:149
 msgid "Required"
 msgstr ""
 
@@ -6090,7 +6090,7 @@ msgstr ""
 #: src/Module/Moderation/Users/Deleted.php:69
 #: src/Module/Moderation/Users/Index.php:89
 #: src/Module/Moderation/Users/Index.php:109
-#: src/Module/Moderation/Users/Pending.php:85 src/Module/Settings/OAuth.php:58
+#: src/Module/Moderation/Users/Pending.php:85 src/Module/Settings/OAuth.php:61
 msgid "Name"
 msgstr ""
 
@@ -6164,7 +6164,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/Module/Contact/Follow.php:56 src/Module/Contact/Redir.php:47
-#: src/Module/Contact/Redir.php:208 src/Module/Conversation/Community.php:151
+#: src/Module/Contact/Redir.php:208 src/Module/Conversation/Community.php:152
 #: src/Module/Debug/ItemBody.php:30 src/Module/Diaspora/Receive.php:45
 #: src/Module/Item/Complete.php:25 src/Module/Item/Display.php:84
 #: src/Module/Item/Feed.php:45 src/Module/Item/Follow.php:27
@@ -6584,45 +6584,45 @@ msgstr ""
 msgid "Unable to unfollow this contact, please contact your administrator"
 msgstr ""
 
-#: src/Module/Conversation/Channel.php:158
+#: src/Module/Conversation/Channel.php:159
 msgid "Channel not available."
 msgstr ""
 
-#: src/Module/Conversation/Community.php:80
+#: src/Module/Conversation/Community.php:81
 msgid "This community stream shows all public posts received by this node. They may not reflect the opinions of this node’s users."
 msgstr ""
 
-#: src/Module/Conversation/Community.php:165
+#: src/Module/Conversation/Community.php:166
 msgid "Community option not available."
 msgstr ""
 
-#: src/Module/Conversation/Community.php:181
+#: src/Module/Conversation/Community.php:182
 msgid "Not available."
 msgstr ""
 
-#: src/Module/Conversation/Network.php:271
+#: src/Module/Conversation/Network.php:274
 msgid "No such circle"
 msgstr ""
 
-#: src/Module/Conversation/Network.php:275
+#: src/Module/Conversation/Network.php:278
 #, php-format
 msgid "Circle: %s"
 msgstr ""
 
-#: src/Module/Conversation/Network.php:295
+#: src/Module/Conversation/Network.php:298
 #, php-format
 msgid "Error %d (%s) while fetching the timeline."
 msgstr ""
 
-#: src/Module/Conversation/Network.php:391
+#: src/Module/Conversation/Network.php:394
 msgid "Network feed not available."
 msgstr ""
 
-#: src/Module/Conversation/Timeline.php:193
+#: src/Module/Conversation/Timeline.php:196
 msgid "Include"
 msgstr ""
 
-#: src/Module/Conversation/Timeline.php:194
+#: src/Module/Conversation/Timeline.php:197
 msgid "Hide"
 msgstr ""
 
@@ -9109,7 +9109,7 @@ msgid "If you do not have access to your authentication code you can use a <a hr
 msgstr ""
 
 #: src/Module/Security/TwoFactor/Verify.php:87
-#: src/Module/Settings/TwoFactor/Verify.php:144
+#: src/Module/Settings/TwoFactor/Verify.php:149
 msgid "Please enter a code from your authentication app"
 msgstr ""
 
@@ -10221,15 +10221,15 @@ msgstr ""
 msgid "Additional Features"
 msgstr ""
 
-#: src/Module/Settings/OAuth.php:57
+#: src/Module/Settings/OAuth.php:60
 msgid "Connected Apps"
 msgstr ""
 
-#: src/Module/Settings/OAuth.php:61
+#: src/Module/Settings/OAuth.php:64
 msgid "Remove authorization"
 msgstr ""
 
-#: src/Module/Settings/OAuth.php:62
+#: src/Module/Settings/OAuth.php:65
 msgid "You have no connected apps."
 msgstr ""
 
@@ -10757,7 +10757,7 @@ msgstr ""
 msgid "Two-factor authentication successfully activated."
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:114
+#: src/Module/Settings/TwoFactor/Verify.php:119
 #, php-format
 msgid ""
 "<p>Or you can submit the authentication settings manually:</p>\n"
@@ -10777,20 +10777,20 @@ msgid ""
 "</dl>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:134
+#: src/Module/Settings/TwoFactor/Verify.php:139
 msgid "Two-factor code verification"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:136
+#: src/Module/Settings/TwoFactor/Verify.php:141
 msgid "<p>Please scan this QR Code with your authenticator app and submit the provided code.</p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:138
+#: src/Module/Settings/TwoFactor/Verify.php:143
 #, php-format
 msgid "<p>Or you can open the following URL in your mobile device:</p><p><a href=\"%s\">%s</a></p>"
 msgstr ""
 
-#: src/Module/Settings/TwoFactor/Verify.php:145
+#: src/Module/Settings/TwoFactor/Verify.php:150
 msgid "Verify code and enable two-factor authentication"
 msgstr ""
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-15 22:51+0000\n"
+"POT-Creation-Date: 2026-03-18 17:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -917,7 +917,7 @@ msgid "Tumblr"
 msgstr ""
 
 #: src/Content/ContactSelector.php:137
-msgid "AT Protocol"
+msgid "Bluesky"
 msgstr ""
 
 #: src/Content/ContactSelector.php:165
@@ -1513,7 +1513,7 @@ msgid "Add categories to your posts"
 msgstr ""
 
 #: src/Content/Feature.php:121 src/Model/Profile.php:812
-#: src/Module/Admin/Summary.php:207 src/Module/Item/Compose.php:188
+#: src/Module/Admin/Summary.php:215 src/Module/Item/Compose.php:188
 #: src/Module/Moderation/Report/Create.php:282
 #: src/Module/Moderation/Summary.php:65
 msgid "Summary"
@@ -2089,33 +2089,33 @@ msgstr ""
 msgid "last"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:923
+#: src/Content/Text/BBCode.php:922
 #, php-format
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:951 src/Model/Item.php:3750
+#: src/Content/Text/BBCode.php:950 src/Model/Item.php:3750
 #: src/Model/Item.php:3756 src/Model/Item.php:3757
 msgid "Link to source"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1741 src/Content/Text/HTML.php:908
+#: src/Content/Text/BBCode.php:1740 src/Content/Text/HTML.php:908
 msgid "Click to open/close"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1796
+#: src/Content/Text/BBCode.php:1795
 msgid "$1 wrote:"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:1870 src/Content/Text/BBCode.php:1871
+#: src/Content/Text/BBCode.php:1869 src/Content/Text/BBCode.php:1870
 msgid "Encrypted content"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2187
+#: src/Content/Text/BBCode.php:2186
 msgid "Invalid source protocol"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:2206
+#: src/Content/Text/BBCode.php:2205
 msgid "Invalid link protocol"
 msgstr ""
 
@@ -3701,7 +3701,7 @@ msgstr ""
 #: src/Module/Admin/Federation.php:218 src/Module/Admin/Logs/Settings.php:74
 #: src/Module/Admin/Logs/View.php:71 src/Module/Admin/Queue.php:64
 #: src/Module/Admin/Site.php:457 src/Module/Admin/Storage.php:123
-#: src/Module/Admin/Summary.php:206 src/Module/Admin/Themes/Details.php:82
+#: src/Module/Admin/Summary.php:214 src/Module/Admin/Themes/Details.php:82
 #: src/Module/Admin/Themes/Index.php:103 src/Module/Admin/Tos.php:63
 #: src/Module/Moderation/Users/Pending.php:82
 msgid "Administration"
@@ -5259,38 +5259,43 @@ msgstr ""
 msgid "<a href=\"%s\">%s</a> is not reachable on your system. This is a severe configuration issue that prevents server to server communication. See <a href=\"%s\">the installation page</a> for help."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:133
+#: src/Module/Admin/Summary.php:117
+#, php-format
+msgid "Your cache is configured to use %s, but the system is currently using the database as fallback. This results in poor performance. Please check if your cache service is running."
+msgstr ""
+
+#: src/Module/Admin/Summary.php:141
 #, php-format
 msgid "Friendica's system.basepath was updated from '%s' to '%s'. Please remove the system.basepath from your db to avoid differences."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:143
+#: src/Module/Admin/Summary.php:151
 #, php-format
 msgid "Friendica's current system.basepath '%s' is wrong and the config file '%s' isn't used."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:153
+#: src/Module/Admin/Summary.php:161
 #, php-format
 msgid "Friendica's current system.basepath '%s' is not equal to the config file '%s'. Please fix your configuration."
 msgstr ""
 
-#: src/Module/Admin/Summary.php:165
+#: src/Module/Admin/Summary.php:173
 msgid "Message queues"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:168
+#: src/Module/Admin/Summary.php:176
 msgid "Server Settings"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:209
+#: src/Module/Admin/Summary.php:217
 msgid "Version"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:213
+#: src/Module/Admin/Summary.php:221
 msgid "Active addons"
 msgstr ""
 
-#: src/Module/Admin/Summary.php:216
+#: src/Module/Admin/Summary.php:224
 msgid "Enable new addons"
 msgstr ""
 


### PR DESCRIPTION
When Redis is configured but not available, Friendica throws a 500 error and becomes unusable.

The system now automatically detects when a configured cache driver is unavailable and falls back to the default database cache. This keeps the instance functional with degraded performance i.e when redis crashed.

Before:
<img width="1407" height="807" alt="image" src="https://github.com/user-attachments/assets/6f791a62-0739-4409-afaf-05ed14bd77ea" />

Changes:
    • Cache.php (Factory): Added try-catch with automatic fallback to DatabaseCache, logs error
    • RedisCache.php: All Redis operations wrapped in try-catch, throw CachePersistenceException on failure
    • CacheLock.php: Graceful handling of cache failures (returns false instead of crashing)
    • Admin/Summary.php: Added warning message when cache fallback is active
    
Behavior:
    • Redis configured & available → Uses Redis (normal operation)
    • Redis not available at startup → Falls back to DatabaseCache + log error + shows admin warning
    • Redis fails during runtime → Operations fail gracefully, instance is still up and running
    • Admin Notification: When fallback is active, admins see a warning on /admin:

<img width="1208" height="460" alt="image" src="https://github.com/user-attachments/assets/b8b0fa30-86a7-4524-9782-b773c0910300" />

You can test this by stopping redis while the instance is up and running (when redis is the default cache driver).

fixes #14863 