### PR TITLE
frio: remove more light box-shadows and general fixes in dark theme

### DIFF
--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -396,3 +396,67 @@ textarea#profile-jot-text:focus + #preview_profile-jot-text, textarea.comment-ed
 figure.img-allocated-height {
 	background-color: rgba(255, 255, 255, 0.05);
 }
+
+/* Jot/Composer modal specific fixes for dark theme */
+#jot-modal .btn,
+#jot-modal .input-group-addon {
+	box-shadow: none;
+	-webkit-box-shadow: none;
+}
+
+#jot-modal .dropzone .dz-preview.dz-image-preview {
+	background: transparent;
+}
+
+#jot-modal .dropzone .dz-preview.dz-file-preview .dz-image {
+	background: #555;
+	background: linear-gradient(to bottom, #666, #444);
+}
+
+#jot-modal .dropzone .dz-preview .dz-details .dz-filename:hover span {
+	background-color: rgba(0, 0, 0, 0.8);
+	border-color: rgba(100, 100, 100, 0.8);
+}
+
+#jot-modal .dropzone .dz-preview .dz-details .dz-filename span,
+#jot-modal .dropzone .dz-preview .dz-details .dz-size span {
+	background-color: rgba(0, 0, 0, 0.4);
+}
+
+#jot-modal .dropzone .dz-preview .dz-progress {
+	background: rgba(0, 0, 0, 0.9);
+}
+
+/* Filebrowser fixes for dark theme - buttons and breadcrumbs */
+/* Target ALL buttons in filebrowser with maximum specificity */
+#jot-fbrowser-wrapper #filebrowser button.btn,
+#jot-fbrowser-wrapper #filebrowser .breadcrumb button.btn-link,
+#jot-fbrowser-wrapper #filebrowser .fbswitcher button.btn-default,
+#jot-fbrowser-wrapper #filebrowser .upload button.btn-primary,
+#jot-fbrowser-wrapper #filebrowser .error button.btn-link,
+/* Album folder buttons (no btn class) */
+#jot-fbrowser-wrapper #filebrowser .folders button,
+#jot-fbrowser-wrapper #filebrowser nav.folders button {
+	background-color: transparent !important;
+	background-image: none !important;
+	box-shadow: none !important;
+	-webkit-box-shadow: none !important;
+	-moz-box-shadow: none !important;
+	border: 1px solid rgba(255, 255, 255, 0.2) !important;
+}
+
+#jot-fbrowser-wrapper #filebrowser button.btn:hover,
+#jot-fbrowser-wrapper #filebrowser .breadcrumb button.btn-link:hover,
+#jot-fbrowser-wrapper #filebrowser .fbswitcher button.btn-default:hover,
+#jot-fbrowser-wrapper #filebrowser .upload button.btn-primary:hover,
+#jot-fbrowser-wrapper #filebrowser .error button.btn-link:hover,
+/* Album folder buttons hover */
+#jot-fbrowser-wrapper #filebrowser .folders button:hover,
+#jot-fbrowser-wrapper #filebrowser nav.folders button:hover {
+	background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+#jot-fbrowser-wrapper #filebrowser .fbswitcher button.btn-default.active {
+	background-color: rgba(255, 255, 255, 0.15) !important;
+	border-color: rgba(255, 255, 255, 0.3) !important;
+}


### PR DESCRIPTION
This PR handles some more outer box shadows and background colors in the JOT modal when creating a post in the dark theme.

Before:
<img width="642" height="544" alt="Nachricht" src="https://github.com/user-attachments/assets/d0fabf5d-fb4e-4b11-b383-7af08b7a23be" />

After:
<img width="627" height="536" alt="image" src="https://github.com/user-attachments/assets/04da5eb0-91a7-44dc-aa79-2f5e4dd958ae" />
