### PR TITLE
Improved detection method for atproto pds

### DIFF
--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -1667,6 +1667,67 @@ class GServer
 	}
 
 	/**
+	 * Fetch server information from an AT Protocol PDS
+	 *
+	 * @param string $url        URL of the given server
+	 * @param array  $serverdata array with server data
+	 *
+	 * @return array server data
+	 */
+	private static function detectATProto(string $url, array $serverdata): array
+	{
+		$data = DI::atProtocol()->get($url . '/xrpc/com.atproto.server.describeServer');
+		if (!isset($data->did)) {
+			return $serverdata;
+		}
+
+		$serverdata['detection-method'] = self::DETECT_ATPROTO_PDS;
+		$serverdata['network']          = Protocol::BLUESKY;
+		$serverdata['version']          = $data->version ?? '';
+
+		if (isset($data->inviteCodeRequired)) {
+			$serverdata['register_policy'] = Register::APPROVE;
+		}
+
+		$data = DI::atProtocol()->get($url . '/xrpc/_health');
+		if (isset($data->version)) {
+			$serverdata['version'] = $data->version;
+		}
+
+		$versionparts = explode(' ', $serverdata['version']);
+		if (count($versionparts) == 2) {
+			$serverdata['platform'] = $versionparts[0];
+			$serverdata['version']  = $versionparts[1];
+		} else {
+			$serverdata['platform'] = self::getAtProtoProvider($url);
+		}
+
+		return $serverdata;
+	}
+
+	/**
+	 * Get the provider name for a given AT Protocol PDS url
+	 *
+	 * @param string $pds URL of the given server
+	 *
+	 * @return string provider name
+	 */
+	private static function getAtProtoProvider(string $pds): string
+	{
+		$host = parse_url($pds, PHP_URL_HOST);
+		if (str_ends_with($host, '.host.bsky.network')) {
+			return 'bluesky';
+		} elseif ($host === 'fed.brid.gy') {
+			return 'bridgy-fed';
+		} elseif ($host === 'eurosky.social') {
+			return 'eurosky';
+		} elseif ($host === 'blacksky.app') {
+			return 'blacksky';
+		}
+		return 'atprotocol';
+	}
+
+	/**
 	 * Fetches server data via an ActivityPub account with url of that server
 	 *
 	 * @param array  $serverdata array with server data

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -1648,24 +1648,6 @@ class GServer
 		return $serverdata;
 	}
 
-	private static function detectATProto(string $url, array $serverdata): array
-	{
-		$data = DI::atProtocol()->get($url . '/xrpc/com.atproto.server.describeServer');
-		if (!isset($data->did)) {
-			return $serverdata;
-		}
-
-		$serverdata['detection-method'] = self::DETECT_ATPROTO_PDS;
-		$serverdata['network']          = Protocol::ATPROTO;
-		$serverdata['platform']         = 'atproto';
-
-		if (isset($data->inviteCodeRequired)) {
-			$serverdata['register_policy'] = Register::APPROVE;
-		}
-
-		return $serverdata;
-	}
-
 	/**
 	 * Fetch server information from an AT Protocol PDS
 	 *
@@ -1682,7 +1664,7 @@ class GServer
 		}
 
 		$serverdata['detection-method'] = self::DETECT_ATPROTO_PDS;
-		$serverdata['network']          = Protocol::BLUESKY;
+		$serverdata['network']          = Protocol::ATPROTO;
 		$serverdata['version']          = $data->version ?? '';
 
 		if (isset($data->inviteCodeRequired)) {
@@ -1695,7 +1677,7 @@ class GServer
 		}
 
 		$versionparts = explode(' ', $serverdata['version']);
-		if (count($versionparts) == 2) {
+		if (count($versionparts) === 2) {
 			$serverdata['platform'] = $versionparts[0];
 			$serverdata['version']  = $versionparts[1];
 		} else {


### PR DESCRIPTION
This PR introduces a check if a server is a valid PDS in the AT Protocol world. It also sets the `platform` to either the used PDS software or the name of the PDS operator.