### PR TITLE
API: Don't show comments by  default

### DIFF
--- a/src/Module/Api/Mastodon/Timelines/Home.php
+++ b/src/Module/Api/Mastodon/Timelines/Home.php
@@ -37,7 +37,7 @@ class Home extends BaseApi
 			'with_muted'      => false, // Pleroma extension: return activities by muted (not by blocked!) users.
 			'only_media'      => false, // Show only statuses with media attached? Defaults to false.
 			'remote'          => false, // Show only remote statuses? Defaults to false.
-			'exclude_replies' => false, // Don't show comments
+			'exclude_replies' => true, // Don't show comments
 			'friendica_order' => TimelineOrderByTypes::ID, // Sort order options (defaults to ID)
 		], $request);
 
@@ -53,7 +53,7 @@ class Home extends BaseApi
 		if ($request['only_media']) {
 			$condition = DBA::mergeConditions($condition, [
 				"`uri-id` IN (SELECT `uri-id` FROM `post-media` WHERE `type` IN (?, ?, ?))",
-				Post\Media::AUDIO, Post\Media::IMAGE, Post\Media::VIDEO, Post\Media::HLS
+				Post\Media::AUDIO, Post\Media::IMAGE, Post\Media::VIDEO, Post\Media::HLS,
 			]);
 		}
 

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -62,7 +62,7 @@ class ListTimeline extends BaseApi
 			'only_media'      => false, // Show only statuses with media attached? Defaults to false.
 			'local'           => false, // Show only local statuses? Defaults to false.
 			'remote'          => false, // Show only remote statuses? Defaults to false.
-			'exclude_replies' => false, // Don't show comments
+			'exclude_replies' => true,  // Don't show comments
 			'friendica_order' => TimelineOrderByTypes::ID, // Sort order options (defaults to ID)
 		], $request);
 
@@ -95,7 +95,7 @@ class ListTimeline extends BaseApi
 
 	private function getStatusesForGroup(int $uid, array $request): array
 	{
-		$cid = Contact::getPublicContactId((int)substr($this->parameters['id'], 6), $uid);
+		$cid = Contact::getPublicContactId((int) substr($this->parameters['id'], 6), $uid);
 
 		$condition = ["(`uid` = ? OR (`uid` = ? AND NOT `global`))", 0, $uid];
 
@@ -103,7 +103,7 @@ class ListTimeline extends BaseApi
 
 		$condition2 = DBA::mergeConditions($condition, [
 			"`author-id` = ? AND `gravity` = ? AND `vid` = ? AND `protocol` != ? AND `thr-parent-id` = `parent-uri-id`",
-			$cid, Item::GRAVITY_ACTIVITY, Verb::getID(Activity::ANNOUNCE), Conversation::PARCEL_DIASPORA
+			$cid, Item::GRAVITY_ACTIVITY, Verb::getID(Activity::ANNOUNCE), Conversation::PARCEL_DIASPORA,
 		]);
 
 		$condition1 = $this->addPagingConditions($request, $condition1);
@@ -129,7 +129,7 @@ class ListTimeline extends BaseApi
 	{
 		$condition = [
 			"`uid` = ? AND `gravity` IN (?, ?) AND `contact-id` IN (SELECT `contact-id` FROM `group_member` WHERE `gid` = ?)",
-			$uid, Item::GRAVITY_PARENT, Item::GRAVITY_COMMENT, $this->parameters['id']
+			$uid, Item::GRAVITY_PARENT, Item::GRAVITY_COMMENT, $this->parameters['id'],
 		];
 
 		$condition = $this->addPagingConditions($request, $condition);
@@ -138,7 +138,7 @@ class ListTimeline extends BaseApi
 		if ($request['only_media']) {
 			$condition = DBA::mergeConditions($condition, [
 				"`uri-id` IN (SELECT `uri-id` FROM `post-media` WHERE `type` IN (?, ?, ?))",
-				Post\Media::AUDIO, Post\Media::IMAGE, Post\Media::VIDEO, Post\Media::HLS
+				Post\Media::AUDIO, Post\Media::IMAGE, Post\Media::VIDEO, Post\Media::HLS,
 			]);
 		}
 

--- a/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
@@ -54,7 +54,7 @@ class PublicTimeline extends BaseApi
 			'remote'          => false, // Show only remote statuses? Defaults to false.
 			'only_media'      => false, // Show only statuses with media attached? Defaults to false.
 			'with_muted'      => false, // Pleroma extension: return activities by muted (not by blocked!) users.
-			'exclude_replies' => false, // Don't show comments
+			'exclude_replies' => true,  // Don't show comments
 			'friendica_order' => TimelineOrderByTypes::ID, // Sort order options (defaults to ID)
 		], $request);
 
@@ -70,7 +70,7 @@ class PublicTimeline extends BaseApi
 
 		$condition = [
 			'gravity' => [Item::GRAVITY_PARENT, Item::GRAVITY_COMMENT], 'private' => Item::PUBLIC,
-			'network' => Protocol::FEDERATED, 'author-blocked' => false, 'author-hidden' => false
+			'network' => Protocol::FEDERATED, 'author-blocked' => false, 'author-hidden' => false,
 		];
 
 		$condition = $this->addPagingConditions($request, $condition);
@@ -89,7 +89,7 @@ class PublicTimeline extends BaseApi
 		if ($request['only_media']) {
 			$condition = DBA::mergeConditions($condition, [
 				"`uri-id` IN (SELECT `uri-id` FROM `post-media` WHERE `type` IN (?, ?, ?))",
-				Post\Media::AUDIO, Post\Media::IMAGE, Post\Media::VIDEO, Post\Media::HLS
+				Post\Media::AUDIO, Post\Media::IMAGE, Post\Media::VIDEO, Post\Media::HLS,
 			]);
 		}
 

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -48,7 +48,7 @@ class Tag extends BaseApi
 			'min_id'          => 0,     // Return results immediately newer than this ID.
 			'limit'           => 20,    // Maximum number of results to return. Defaults to 20.
 			'with_muted'      => false, // Pleroma extension: return activities by muted (not by blocked!) users.
-			'exclude_replies' => false, // Don't show comments
+			'exclude_replies' => true,  // Don't show comments
 		], $request);
 
 		$params = ['order' => ['uri-id' => true], 'limit' => $request['limit']];
@@ -91,7 +91,7 @@ class Tag extends BaseApi
 		if (!empty($uid)) {
 			$condition = DBA::mergeConditions(
 				$condition,
-				["NOT `author-id` IN (SELECT `cid` FROM `user-contact` WHERE `uid` = ? AND (`blocked` OR `ignored` OR `is-blocked`) AND `cid` = `author-id`)", $uid]
+				["NOT `author-id` IN (SELECT `cid` FROM `user-contact` WHERE `uid` = ? AND (`blocked` OR `ignored` OR `is-blocked`) AND `cid` = `author-id`)", $uid],
 			);
 		}
 


### PR DESCRIPTION
By now we displayed all posts when the timeline is queried via the API. This is not how the same API call is processed my Mastodon. We now by default will only display thread starting posts in the timeline.
