### PR TITLE
Fix: contact `failed` field allows NULL causing contacts to be excluded from Circles

### DIFF
--- a/src/Model/Contact/Circle.php
+++ b/src/Model/Contact/Circle.php
@@ -29,10 +29,11 @@ class Circle
 		$return = [];
 
 		if (intval($gid)) {
-			$networks = Widget::unavailableNetworks();
+			$networks   = Widget::unavailableNetworks();
 			$sql_values = array_merge([$gid, DI::userSession()->getLocalUserId()], $networks);
 
-			$stmt = DBA::p('SELECT `circle_member`.`contact-id`, `contact`.*
+			$stmt = DBA::p(
+				'SELECT `circle_member`.`contact-id`, `contact`.*
 				FROM `contact`
 				INNER JOIN `group_member` AS `circle_member`
 					ON `contact`.`id` = `circle_member`.`contact-id`
@@ -44,7 +45,7 @@ class Circle
 				AND NOT `contact`.`pending`
 				AND NOT `contact`.`network` IN (' . substr(str_repeat('?, ', count($networks)), 0, -2) . ')
 				ORDER BY `contact`.`name` ASC',
-				$sql_values
+				$sql_values,
 			);
 
 			if (DBA::isResult($stmt)) {
@@ -68,7 +69,7 @@ class Circle
 	public static function listUncircled(int $uid)
 	{
 		$networks = Widget::unavailableNetworks();
-		$query = "`uid` = ? AND NOT `self` AND NOT `deleted` AND NOT `blocked` AND NOT `pending` AND NOT `failed`
+		$query    = "`uid` = ? AND NOT `self` AND NOT `deleted` AND NOT `blocked` AND NOT `pending` AND (`failed` IS NULL OR NOT `failed`)
 			AND NOT `network` IN (" . substr(str_repeat('?, ', count($networks)), 0, -2) . ")
 			AND `id` NOT IN (SELECT DISTINCT(`contact-id`) FROM `group_member` AS `circle_member` INNER JOIN `group` AS `circle` ON `circle`.`id` = `circle_member`.`gid`
 			WHERE `circle`.`uid` = ? AND `contact-id` = `contact`.`id`)";

--- a/src/Module/Circle.php
+++ b/src/Module/Circle.php
@@ -99,7 +99,7 @@ class Circle extends BaseModule
 					throw new \Exception(DI::l10n()->t('Contact is deleted.'), 410);
 				}
 
-				switch($this->parameters['command']) {
+				switch ($this->parameters['command']) {
 					case 'add':
 						if (!Model\Circle::addMember($circle_id, $cdata['user'])) {
 							throw new \Exception(DI::l10n()->t('Unable to add the contact to the circle.'), 500);
@@ -175,8 +175,8 @@ class Circle extends BaseModule
 		$preselected = [];
 
 		// @TODO: Replace with parameter from router
-		if ((DI::args()->getArgc() == 2) && (DI::args()->getArgv()[1] === 'none') ||
-			(DI::args()->getArgc() == 1) && (DI::args()->getArgv()[0] === 'nocircle')) {
+		if ((DI::args()->getArgc() == 2) && (DI::args()->getArgv()[1] === 'none')
+			|| (DI::args()->getArgc() == 1) && (DI::args()->getArgv()[0] === 'nocircle')) {
 			$id       = -1;
 			$nocircle = true;
 			$circle   = [
@@ -310,7 +310,7 @@ class Circle extends BaseModule
 					'title'     => DI::l10n()->t('Remove contact from circle'),
 					'gid'       => $circle['id'],
 					'cid'       => $member['id'],
-					'sec_token' => $sec_token
+					'sec_token' => $sec_token,
 				];
 
 				$circle_editor['members'][] = $entry;
@@ -323,7 +323,7 @@ class Circle extends BaseModule
 			$contacts = Model\Contact\Circle::listUncircled(DI::userSession()->getLocalUserId());
 		} else {
 			$networks = Widget::unavailableNetworks();
-			$query    = "`uid` = ? AND NOT `self` AND NOT `deleted` AND NOT `blocked` AND NOT `pending` AND NOT `failed`
+			$query    = "`uid` = ? AND NOT `self` AND NOT `deleted` AND NOT `blocked` AND NOT `pending` AND (`failed` IS NULL OR NOT `failed`)
 				AND `rel` IN (?, ?, ?)
 				AND NOT `network` IN (" . substr(str_repeat('?, ', count($networks)), 0, -2) . ")";
 			$condition = array_merge([$query], [DI::userSession()->getLocalUserId(), Model\Contact::FOLLOWER, Model\Contact::FRIEND, Model\Contact::SHARING], $networks);
@@ -351,7 +351,7 @@ class Circle extends BaseModule
 							'title'     => DI::l10n()->t('Add contact to circle'),
 							'gid'       => $circle['id'],
 							'cid'       => $member['id'],
-							'sec_token' => $sec_token
+							'sec_token' => $sec_token,
 						];
 					}
 


### PR DESCRIPTION
## Problem
The `failed` field in the `contact` table accepts NULL values. The Circle 
query filters with `NOT \`failed\``, which evaluates to NULL (not TRUE) 
when the field is NULL — silently excluding those contacts from Circles.

## Fix
- Set `failed` to `NOT NULL DEFAULT 0` in `dbstructure.config.php` and `database.sql`
- Add migration `update_1574()` to convert existing NULL rows to `false`

## Related issue
Fixes #<paste the issue number here>