### PR TITLE
Fix QR code page crash when XMLWriter extension is missing

### DIFF
--- a/src/Module/Settings/TwoFactor/Verify.php
+++ b/src/Module/Settings/TwoFactor/Verify.php
@@ -100,14 +100,19 @@ class Verify extends BaseSettings
 
 		$otpauthUrl = (new Google2FA())->getQRCodeUrl($company, $holder, $secret);
 
-		$renderer = new ImageRenderer(
-			new RendererStyle(256),
-			new SvgImageBackEnd()
-		);
+		$qrcode_image = '';
+		try {
+			$renderer = new ImageRenderer(
+				new RendererStyle(256),
+				new SvgImageBackEnd()
+			);
 
-		$writer = new Writer($renderer);
+			$writer = new Writer($renderer);
 
-		$qrcode_image = str_replace('<?xml version="1.0" encoding="UTF-8"?>', '', $writer->writeString($otpauthUrl));
+			$qrcode_image = str_replace('<?xml version="1.0" encoding="UTF-8"?>', '', $writer->writeString($otpauthUrl));
+		} catch (\Throwable $e) {
+			$this->logger->warning('QR code generation failed, libxml/XMLWriter extension may be missing.', ['exception' => $e]);
+		}
 
 		$shortOtpauthUrl = explode('?', $otpauthUrl)[0];
 

--- a/src/Module/Settings/TwoFactor/Verify.php
+++ b/src/Module/Settings/TwoFactor/Verify.php
@@ -95,8 +95,8 @@ class Verify extends BaseSettings
 		parent::content();
 
 		$company = 'Friendica';
-		$holder = $this->session->get('my_address');
-		$secret = $this->pConfig->get($this->session->getLocalUserId(), '2fa', 'secret');
+		$holder  = $this->session->get('my_address');
+		$secret  = $this->pConfig->get($this->session->getLocalUserId(), '2fa', 'secret');
 
 		$otpauthUrl = (new Google2FA())->getQRCodeUrl($company, $holder, $secret);
 
@@ -104,7 +104,7 @@ class Verify extends BaseSettings
 		try {
 			$renderer = new ImageRenderer(
 				new RendererStyle(256),
-				new SvgImageBackEnd()
+				new SvgImageBackEnd(),
 			);
 
 			$writer = new Writer($renderer);

--- a/tests/Unit/Module/Settings/TwoFactor/VerifyQrCodeTest.php
+++ b/tests/Unit/Module/Settings/TwoFactor/VerifyQrCodeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Test\Unit\Module\Settings\TwoFactor;
+
+use BaconQrCode\Renderer\Image\SvgImageBackEnd;
+use BaconQrCode\Renderer\ImageRenderer;
+use BaconQrCode\Renderer\RendererStyle\RendererStyle;
+use BaconQrCode\Writer;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class VerifyQrCodeTest extends TestCase
+{
+	/**
+	 * Asserts that valid SVG is produced when the xmlwriter extension is available.
+	 */
+	public function testQrCodeGeneratesValidSvgWhenXmlWriterIsAvailable()
+	{
+		if (!class_exists(\XMLWriter::class)) {
+			$this->markTestSkipped('XMLWriter (ext-xmlwriter) is not available on this system.');
+		}
+
+		$otpauthUrl = 'otpauth://totp/Friendica:test%40example.com?secret=BASE32SECRET&issuer=Friendica';
+
+		$qrcode_image = '';
+		try {
+			$renderer = new ImageRenderer(
+				new RendererStyle(256),
+				new SvgImageBackEnd()
+			);
+			$writer       = new Writer($renderer);
+			$qrcode_image = str_replace('<?xml version="1.0" encoding="UTF-8"?>', '', $writer->writeString($otpauthUrl));
+		} catch (\Throwable $e) {
+			// Should not reach here when XMLWriter is available
+		}
+
+		self::assertNotEmpty($qrcode_image, 'QR code SVG should not be empty when XMLWriter is available');
+		self::assertStringContainsString('<svg', $qrcode_image, 'QR code output should be an SVG element');
+	}
+
+	/**
+	 * Asserts that when QR code generation throws (e.g. XMLWriter missing),
+	 * the exception is caught, the logger receives a warning, and
+	 * $qrcode_image stays an empty string so the page can still render.
+	 */
+	public function testQrCodeGenerationFailureIsCaughtAndLogged()
+	{
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())
+			->method('warning')
+			->with(
+				$this->stringContains('QR code generation failed'),
+				$this->arrayHasKey('exception')
+			);
+
+		$qrcode_image = '';
+
+		try {
+			throw new \BaconQrCode\Exception\RuntimeException(
+				'You need to install the libxml extension to use this back end'
+			);
+		} catch (\Throwable $e) {
+			$logger->warning(
+				'QR code generation failed, libxml/XMLWriter extension may be missing.',
+				['exception' => $e]
+			);
+		}
+
+		self::assertSame('', $qrcode_image, '$qrcode_image must stay empty on failure so the page still renders');
+	}
+}

--- a/tests/Unit/Module/Settings/TwoFactor/VerifyQrCodeTest.php
+++ b/tests/Unit/Module/Settings/TwoFactor/VerifyQrCodeTest.php
@@ -31,7 +31,7 @@ class VerifyQrCodeTest extends TestCase
 		try {
 			$renderer = new ImageRenderer(
 				new RendererStyle(256),
-				new SvgImageBackEnd()
+				new SvgImageBackEnd(),
 			);
 			$writer       = new Writer($renderer);
 			$qrcode_image = str_replace('<?xml version="1.0" encoding="UTF-8"?>', '', $writer->writeString($otpauthUrl));
@@ -55,19 +55,19 @@ class VerifyQrCodeTest extends TestCase
 			->method('warning')
 			->with(
 				$this->stringContains('QR code generation failed'),
-				$this->arrayHasKey('exception')
+				$this->arrayHasKey('exception'),
 			);
 
 		$qrcode_image = '';
 
 		try {
 			throw new \BaconQrCode\Exception\RuntimeException(
-				'You need to install the libxml extension to use this back end'
+				'You need to install the libxml extension to use this back end',
 			);
 		} catch (\Throwable $e) {
 			$logger->warning(
 				'QR code generation failed, libxml/XMLWriter extension may be missing.',
-				['exception' => $e]
+				['exception' => $e],
 			);
 		}
 


### PR DESCRIPTION
## Problem
When the `xmlwriter` PHP extension is not enabled, `SvgImageBackEnd` throws a
`RuntimeException` in `Verify::content()`. Because it was uncaught, the entire
page failed to render — showing a blank page with no QR code and no buttons.

The error message from the library says "libxml extension", which is misleading
since `libxml` may be enabled while `xmlwriter` is a separate extension that is
not.

Fixes #15597

## Solution
Wrap the QR code generation in a `try/catch (\Throwable)` block. On failure, a
warning is logged and `$qrcode_image` is set to an empty string. The page still
renders fully, including the verify form and the manual secret key entry section,
so users can complete 2FA setup without the QR code.