### PR TITLE
API: Avoid nested quotes

### DIFF
--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -89,12 +89,13 @@ class Status extends BaseFactory
 	 * @param int  $uid             Item user
 	 * @param bool $reblog          Check for reblogged post
 	 * @param bool $in_reply_status Add an "in_reply_status" element
+	 * @param int  $level           Recursion level for quotes
 	 *
 	 * @return \Friendica\Object\Api\Mastodon\Status
 	 * @throws InternalServerErrorException
 	 * @throws ImagickException|NotFoundException
 	 */
-	public function createFromUriId(int $uriId, int $uid = 0, bool $reblog = true, bool $in_reply_status = true): \Friendica\Object\Api\Mastodon\Status
+	public function createFromUriId(int $uriId, int $uid = 0, bool $reblog = true, bool $in_reply_status = true, int $level = 0): \Friendica\Object\Api\Mastodon\Status
 	{
 		$fields = ['uri-id', 'uid', 'author-id', 'causer-id', 'author-uri-id', 'author-link', 'author-gsid', 'causer-uri-id', 'post-reason', 'starred', 'app', 'title', 'body', 'raw-body', 'content-warning', 'question-id',
 			'created', 'edited', 'commented', 'received', 'changed', 'network', 'thr-parent-id', 'parent-author-id', 'language', 'uri', 'plink', 'private', 'vid', 'gravity', 'featured', 'has-media', 'quote-uri-id',
@@ -260,7 +261,7 @@ class Status extends BaseFactory
 			$poll = null;
 		}
 
-		$quote = self::createQuote($item, $uid);
+		$quote = self::createQuote($item, $uid, $level);
 
 		$item['body'] = BBCode::removeSharedData($item['body']);
 
@@ -316,11 +317,15 @@ class Status extends BaseFactory
 	 * Create a quote status object
 	 *
 	 * @param array $item
-	 * @param integer $uid
+	 * @param int   $uid
+	 * @param int   $level
 	 * @return array
 	 */
-	private function createQuote(array $item, int $uid): array
+	private function createQuote(array $item, int $uid, int $level): array
 	{
+		if ($level > 2) {
+			return [];
+		}
 		if (empty($item['quote-uri-id'])) {
 			$media = Post\Media::getByURIId($item['uri-id'], [Post\Media::ACTIVITY]);
 			if (!empty($media)) {
@@ -337,7 +342,7 @@ class Status extends BaseFactory
 
 		if (!empty($quote_id) && ($quote_id != $item['uri-id'])) {
 			try {
-				$quoted_status = $this->createFromUriId($quote_id, $uid, false, false)->toArray();
+				$quoted_status = $this->createFromUriId($quote_id, $uid, false, false, ++$level)->toArray();
 				$quote         = [
 					'state'         => 'accepted',
 					'quoted_status' => $quoted_status,

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -138,32 +138,32 @@ class Status extends BaseFactory
 			'thr-parent-id' => $uriId,
 			'gravity'       => Item::GRAVITY_ACTIVITY,
 			'vid'           => Verb::getID(Activity::ANNOUNCE),
-			'deleted'       => false
+			'deleted'       => false,
 		]) + Post::countPosts([
 			'quote-uri-id' => $uriId,
 			'body'         => '',
-			'deleted'      => false
+			'deleted'      => false,
 		]);
 
 		$count_like = Post::countPosts([
 			'thr-parent-id' => $uriId,
 			'gravity'       => Item::GRAVITY_ACTIVITY,
 			'vid'           => Verb::getID(Activity::LIKE),
-			'deleted'       => false
+			'deleted'       => false,
 		]);
 
 		$count_dislike = Post::countPosts([
 			'thr-parent-id' => $uriId,
 			'gravity'       => Item::GRAVITY_ACTIVITY,
 			'vid'           => Verb::getID(Activity::DISLIKE),
-			'deleted'       => false
+			'deleted'       => false,
 		]);
 
 		$counts = new \Friendica\Object\Api\Mastodon\Status\Counts(
 			Post::countPosts(['thr-parent-id' => $uriId, 'gravity' => Item::GRAVITY_COMMENT, 'deleted' => false], []),
 			$count_announce,
 			$count_like,
-			$count_dislike
+			$count_dislike,
 		);
 
 		$origin_like = $count_like > 0 && Post::exists([
@@ -172,7 +172,7 @@ class Status extends BaseFactory
 			'origin'        => true,
 			'gravity'       => Item::GRAVITY_ACTIVITY,
 			'vid'           => Verb::getID(Activity::LIKE),
-			'deleted'       => false
+			'deleted'       => false,
 		]);
 		$origin_dislike = $count_dislike > 0 && Post::exists([
 			'thr-parent-id' => $uriId,
@@ -180,7 +180,7 @@ class Status extends BaseFactory
 			'origin'        => true,
 			'gravity'       => Item::GRAVITY_ACTIVITY,
 			'vid'           => Verb::getID(Activity::DISLIKE),
-			'deleted'       => false
+			'deleted'       => false,
 		]);
 		$origin_announce = $count_announce > 0 && (Post::exists([
 			'thr-parent-id' => $uriId,
@@ -188,23 +188,23 @@ class Status extends BaseFactory
 			'origin'        => true,
 			'gravity'       => Item::GRAVITY_ACTIVITY,
 			'vid'           => Verb::getID(Activity::ANNOUNCE),
-			'deleted'       => false
+			'deleted'       => false,
 		]) || Post::exists([
 			'quote-uri-id' => $uriId,
 			'uid'          => $uid,
 			'origin'       => true,
 			'body'         => '',
-			'deleted'      => false
+			'deleted'      => false,
 		]));
 		$userAttributes = new \Friendica\Object\Api\Mastodon\Status\UserAttributes(
 			$origin_like,
 			$origin_announce,
 			Post\ThreadUser::getIgnored($uriId, $uid),
 			$item['starred'] && $item['gravity'] == Item::GRAVITY_PARENT,
-			$item['featured']
+			$item['featured'],
 		);
 
-		$sensitive = (bool)$item['sensitive'];
+		$sensitive = (bool) $item['sensitive'];
 
 		$network  = ContactSelector::networkToName($item['network']);
 		$sitename = '';


### PR DESCRIPTION
To avoid memory issues, we limit the depth of nested quotes.