### PR TITLE
Last constant removed in atproto / removed deprecated constants

### DIFF
--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -50,8 +50,6 @@ class BBCode
 	public const BACKLINK     = 8;
 	public const ACTIVITYPUB  = 9;
 	public const ATPROTOCOL   = 10;
-	/** @deprecated use @see ATPROTOCOL instead */
-	public const BLUESKY = 10; // @deprecated
 
 	public const SHARED_ANCHOR = '<hr class="shared-anchor">';
 	public const TOP_ANCHOR    = '<br class="top-anchor">';

--- a/src/Core/Protocol.php
+++ b/src/Core/Protocol.php
@@ -35,8 +35,6 @@ class Protocol
 	public const SUPPORT_PRIVATE = [self::DFRN, self::DIASPORA, self::MAIL, self::ACTIVITYPUB, self::PUMPIO];
 
 	// Supported through a connector
-	/** @deprecated use @see ATPROTO instead */
-	public const BLUESKY   = 'bsky';    // @deprecated name for the AT Protocol
 	public const ATPROTO   = 'bsky';    // AT Protocol, short name "atproto" (Formerly known as Bluesky)
 	public const DIASPORA2 = 'dspc';    // Diaspora connector
 	public const DISCOURSE = 'dscs';    // Discourse

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -3602,12 +3602,7 @@ class Contact
 	public static function getProfileLink(array $contact): string
 	{
 		if ($contact['network'] === Protocol::ATPROTO) {
-			$web       = DI::atProtocol()->getWebForUser(DI::userSession()->getLocalUserId());
-			$frontends = DI::config()->get('atprotocol', 'frontends');
-			if ($web && is_array($frontends) && isset($frontends[$web])) {
-				return str_replace('{did}', $contact['url'], $frontends[$web][1]);
-			}
-			return $contact['alias'];
+			return DI::atpActor()->getProfileLink($contact['url'], DI::userSession()->getLocalUserId()) ?: $contact['alias'];
 		}
 		if (!empty($contact['alias']) && Network::isValidHttpUrl($contact['alias']) && (($contact['network'] ?? '') != Protocol::DFRN)) {
 			return $contact['alias'];

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3667,19 +3667,7 @@ class Item
 	public static function getPlink(array $item)
 	{
 		if ($item['network'] === Protocol::ATPROTO) {
-			$web       = DI::atProtocol()->getWebForUser(DI::userSession()->getLocalUserId());
-			$plink     = $item['plink'];
-			$frontends = DI::config()->get('atprotocol', 'frontends');
-			if ($web && is_array($frontends) && isset($frontends[$web])) {
-				$parts = explode('/', $item['uri']);
-				if (count($parts) === 5) {
-					$did        = $parts[2];
-					$collection = $parts[3];
-					$rkeyparts  = explode(':', $parts[4]);
-					$rkey       = $rkeyparts[0];
-					$plink      = str_replace(['{did}', '{collection}', '{rkey}'], [$did, $collection, $rkey], $frontends[$web][2]);
-				}
-			}
+			$plink = DI::atProtocol()->getPostLink($item['uri'], DI::userSession()->getLocalUserId()) ?: $item['plink'];
 		} elseif (!empty($item['plink']) && Network::isValidHttpUrl($item['plink'])) {
 			$plink = $item['plink'];
 		} elseif (!empty($item['uri']) && Network::isValidHttpUrl($item['uri']) && !DI::baseUrl()->isLocalUrl($item['uri'])) {

--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -596,12 +596,12 @@ final class ATProtocol
 	 * @param integer $uid User id to get the web for (0 for global)
 	 * @return string Profile link
 	 */
-	public function getPostLink(string $uri, int $uid = 0): string
+	public function getPostLink(string $did, int $uid = 0): string
 	{
 		$web       = $this->getWebForUser($uid);
 		$frontends = $this->config->get('atprotocol', 'frontends');
 		if ($web && is_array($frontends) && isset($frontends[$web])) {
-			$parts = explode('/', $uri);
+			$parts = explode('/', $did);
 			if (count($parts) === 5) {
 				$did        = $parts[2];
 				$collection = $parts[3];

--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -35,12 +35,6 @@ final class ATProtocol
 	public const STATUS_PDS_FAIL   = 12;
 	public const STATUS_TOKEN_FAIL = 13;
 
-	/**
-	 * Path to the web interface with the user profile and posts.
-	 * This string can then be replaced when displaying the post and profile url.
-	 */
-	public const WEB = 'https://bsky.app';
-
 	/** @var LoggerInterface */
 	private $logger;
 
@@ -593,5 +587,29 @@ final class ATProtocol
 		$this->pConfig->set($uid, 'bluesky', 'status', self::STATUS_TOKEN_OK);
 		$this->pConfig->set($uid, 'bluesky', 'status-message', '');
 		return $data->accessJwt;
+	}
+
+	/**
+	 * Get the profile link for a given DID and user id
+	 *
+	 * @param string  $did The contact DID
+	 * @param integer $uid User id to get the web for (0 for global)
+	 * @return string Profile link
+	 */
+	public function getPostLink(string $uri, int $uid = 0): string
+	{
+		$web       = $this->getWebForUser($uid);
+		$frontends = $this->config->get('atprotocol', 'frontends');
+		if ($web && is_array($frontends) && isset($frontends[$web])) {
+			$parts = explode('/', $uri);
+			if (count($parts) === 5) {
+				$did        = $parts[2];
+				$collection = $parts[3];
+				$rkeyparts  = explode(':', $parts[4]);
+				$rkey       = $rkeyparts[0];
+				return str_replace(['{did}', '{collection}', '{rkey}'], [$did, $collection, $rkey], $frontends[$web][2]);
+			}
+		}
+		return '';
 	}
 }

--- a/src/Protocol/ATProtocol/Actor.php
+++ b/src/Protocol/ATProtocol/Actor.php
@@ -11,6 +11,7 @@
 namespace Friendica\Protocol\ATProtocol;
 
 use Friendica\Content\Text\HTML;
+use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Protocol;
 use Friendica\Model\Contact;
 use Friendica\Model\GServer;
@@ -29,10 +30,14 @@ class Actor
 	/** @var ATProtocol */
 	private $atprotocol;
 
-	public function __construct(LoggerInterface $logger, ATProtocol $atprotocol)
+	/** @var \Friendica\Core\Config\Capability\IManageConfigValues */
+	private $config;
+
+	public function __construct(LoggerInterface $logger, ATProtocol $atprotocol, IManageConfigValues $config)
 	{
 		$this->logger     = $logger;
 		$this->atprotocol = $atprotocol;
+		$this->config     = $config;
 	}
 
 	/**
@@ -225,8 +230,20 @@ class Actor
 		return Contact::getById($cid);
 	}
 
-	public function getProfileLink(string $did): string
+	/**
+	 * Get the profile link for a given DID and user id
+	 *
+	 * @param string  $did The contact DID
+	 * @param integer $uid User id to get the web for (0 for global)
+	 * @return string Profile link
+	 */
+	public function getProfileLink(string $did, int $uid = 0): string
 	{
-		return ATProtocol::WEB . '/profile/' . $did;
+		$web       = $this->atprotocol->getWebForUser($uid);
+		$frontends = $this->config->get('atprotocol', 'frontends');
+		if ($web && is_array($frontends) && isset($frontends[$web])) {
+			return str_replace('{did}', $did, $frontends[$web][1]);
+		}
+		return '';
 	}
 }

--- a/src/Protocol/ATProtocol/Processor.php
+++ b/src/Protocol/ATProtocol/Processor.php
@@ -355,9 +355,10 @@ class Processor
 			'owner-name'    => $contact['name'],
 			'owner-link'    => $contact['url'],
 			'owner-avatar'  => $contact['avatar'],
-			'plink'         => $contact['alias'] . '/post/' . $data->commit->rkey,
 			'source'        => json_encode($data),
 		];
+
+		$item['plink'] = $this->atprotocol->getPostLink($item['uri']);
 
 		if ((time() - strtotime($item['created'])) > 600) {
 			$item['received'] = $item['created'];


### PR DESCRIPTION
This is a clean up PR. unneeded constants for atproto are removed and functionality has been replaced to now use no more constants at all in the atproto handling that refer to any Bluesky server out there.