### PR TITLE
atproto: use public api in jetstream / fetch root post

### DIFF
--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -642,7 +642,7 @@ final class ATProtocol
 	/**
 	 * Get the profile link for a given uri and user id
 	 *
-	 * @param string  $did The post uri
+	 * @param string  $uri The post uri
 	 * @param integer $uid User id to get the web for (0 for global)
 	 * @return string Profile link
 	 */

--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -640,26 +640,120 @@ final class ATProtocol
 	}
 
 	/**
-	 * Get the profile link for a given DID and user id
+	 * Get the profile link for a given uri and user id
 	 *
-	 * @param string  $did The contact DID
+	 * @param string  $did The post uri
 	 * @param integer $uid User id to get the web for (0 for global)
 	 * @return string Profile link
 	 */
-	public function getPostLink(string $did, int $uid = 0): string
+	public function getPostLink(string $uri, int $uid = 0): string
 	{
 		$web       = $this->getWebForUser($uid);
 		$frontends = $this->config->get('atprotocol', 'frontends');
 		if ($web && is_array($frontends) && isset($frontends[$web])) {
-			$parts = explode('/', $did);
-			if (count($parts) === 5) {
-				$did        = $parts[2];
-				$collection = $parts[3];
-				$rkeyparts  = explode(':', $parts[4]);
-				$rkey       = $rkeyparts[0];
-				return str_replace(['{did}', '{collection}', '{rkey}'], [$did, $collection, $rkey], $frontends[$web][2]);
+			$parts = $this->getUriObject($uri);
+			if (is_object($parts)) {
+				return str_replace(['{did}', '{collection}', '{rkey}'], [$parts->repo, $parts->collection, $parts->rkey], $frontends[$web][2]);
 			}
 		}
 		return '';
+	}
+
+	/**
+	 * Fetch a record from the AT Protocol repository
+	 *
+	 * @param string $uri AT URI in the format at://did/collection/rkey
+	 * @return stdClass|null The fetched record or null on failure
+	 */
+	public function getRecord(string $uri): ?stdClass
+	{
+		$parts = $this->getUriObject($uri);
+		if (!is_object($parts)) {
+			return null;
+		}
+
+		$url = $this->getPdsOfDid($parts->repo);
+		if (!$url) {
+			return null;
+		}
+
+		$url .= '/xrpc/com.atproto.repo.getRecord?' . http_build_query(['repo' => $parts->repo, 'collection' => $parts->collection, 'rkey' => $parts->rkey]);
+		return $this->get($url);
+	}
+
+	/**
+	 * Create a new record in the AT Protocol repository
+	 *
+	 * @param integer        $uid        User ID
+	 * @param string         $collection Collection name, e.g. "app.bsky.feed.post"
+	 * @param array|stdClass $record     The record data to create
+	 * @return stdClass|null The created record response or null on failure
+	 */
+	public function createRecord(int $uid, string $collection, $record): ?stdClass
+	{
+		$post = [
+			'collection' => $collection,
+			'repo'       => $this->getUserDid($uid),
+			'record'     => $record,
+		];
+
+		return $this->XRPCPost($uid, 'com.atproto.repo.createRecord', $post);
+	}
+
+	/**
+	 * Delete a record from the AT Protocol repository
+	 *
+	 * @param integer $uid User ID
+	 * @param string  $uri AT URI in the format at://did/collection/rkey
+	 * @return stdClass|null The deletion response or null on failure
+	 */
+	public function deleteRecord(int $uid, string $uri): ?stdClass
+	{
+		$parts = $this->getUriObject($uri);
+		if (!is_object($parts)) {
+			return null;
+		}
+
+		return $this->XRPCPost($uid, 'com.atproto.repo.deleteRecord', ['repo' => $parts->repo, 'collection' => $parts->collection, 'rkey' => $parts->rkey]);
+	}
+
+	/**
+	 * Update an existing record in the AT Protocol repository
+	 *
+	 * @param integer        $uid    User ID
+	 * @param string         $uri    AT URI in the format at://did/collection/rkey
+	 * @param array|stdClass $record The updated record data
+	 * @return stdClass|null The update response or null on failure
+	 */
+	public function putRecord(int $uid, string $uri, $record): ?stdClass
+	{
+		$parts = $this->getUriObject($uri);
+		if (!is_object($parts)) {
+			return null;
+		}
+
+		return $this->XRPCPost($uid, 'com.atproto.repo.putRecord', ['repo' => $parts->repo, 'collection' => $parts->collection, 'rkey' => $parts->rkey, 'record' => $record]);
+	}
+
+	/**
+	 * Parse an AT URI into repository, collection and record key.
+	 *
+	 * @param string $uri
+	 * @return stdClass|null
+	 */
+	public function getUriObject(string $uri): ?stdClass
+	{
+		$parts = explode('/', $uri);
+		if (!$parts || count($parts) !== 5 || $parts[0] !== 'at:' || $parts[1] !== '') {
+			return null;
+		}
+
+		$class = new stdClass();
+
+		$class->repo       = $parts[2];
+		$class->collection = $parts[3];
+		$class->rkey       = explode(':', $parts[4])[0];
+
+		return $class;
 	}
 }

--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -51,7 +51,7 @@ final class ATProtocol
 	/** @var ICanSendHttpRequests */
 	private $httpClient;
 
-	private int $uid;
+	private ?int $uid = null;
 
 	/**
 	 * Initialize the AT Protocol service.

--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -11,6 +11,7 @@ use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
 use Friendica\Core\Protocol;
 use Friendica\Database\Database;
+use Friendica\Model\Conversation;
 use Friendica\Model\Item;
 use Friendica\Model\User;
 use Friendica\Network\HTTPClient\Capability\ICanSendHttpRequests;
@@ -53,6 +54,15 @@ final class ATProtocol
 	private string $api;
 	private int $uid = 0;
 
+	/**
+	 * Initialize the AT Protocol service.
+	 *
+	 * @param LoggerInterface $logger
+	 * @param Database $database
+	 * @param IManageConfigValues $config
+	 * @param IManagePersonalConfigValues $pConfig
+	 * @param ICanSendHttpRequests $httpClient
+	 */
 	public function __construct(LoggerInterface $logger, Database $database, IManageConfigValues $config, IManagePersonalConfigValues $pConfig, ICanSendHttpRequests $httpClient)
 	{
 		$this->logger     = $logger;
@@ -77,7 +87,7 @@ final class ATProtocol
 	}
 
 	/**
-	 * Returns an array of user ids who want to import the AT Protocol timeline
+	 * Get user IDs that import the AT Protocol timeline
 	 *
 	 * @return array user ids
 	 */
@@ -108,21 +118,21 @@ final class ATProtocol
 	}
 
 	/**
-	 * Fetches XRPC data
+	 * Fetch XRPC data
 	 * @see https://atproto.com/specs/xrpc#lexicon-http-endpoints
 	 *
 	 * @param string  $url        for example "app.bsky.feed.getTimeline"
 	 * @param array   $parameters Array with parameters
-	 * @param integer $uid        User ID
+	 * @param integer $uid        User ID. When set to null, the value from "setApiForUser" will be used
 	 * @return stdClass|null Fetched data
 	 */
-	public function XRPCGet(string $url, array $parameters = [], int $uid = 0): ?stdClass
+	public function XRPCGet(string $url, array $parameters = [], ?int $uid = null): ?stdClass
 	{
 		if (!empty($parameters)) {
 			$url .= '?' . http_build_query($parameters);
 		}
 
-		if ($uid === 0 && $this->uid !== 0) {
+		if (is_null($uid)) {
 			$uid = $this->uid;
 		}
 
@@ -407,7 +417,7 @@ final class ATProtocol
 	}
 
 	/**
-	 * Fetches the DID of a given handle via a DND request.
+	 * Fetches the DID of a given handle via a DNS request.
 	 * This is one of the ways, custom handles can be authorized.
 	 *
 	 * @param string $handle The user handle
@@ -433,7 +443,7 @@ final class ATProtocol
 	}
 
 	/**
-	 * Fetch the PDS of a given DID
+	 * Fetch the PDS URL for a given DID
 	 *
 	 * @param string $did DID (did:plc:...)
 	 * @return string|null URL of the PDS, e.g. https://enoki.us-east.host.bsky.network
@@ -455,7 +465,7 @@ final class ATProtocol
 	}
 
 	/**
-	 * Set the AppView API for this class for a given uid
+	 * Set the AppView API for this class for a given user ID
 	 *
 	 * @param integer $uid
 	 * @return void
@@ -463,13 +473,48 @@ final class ATProtocol
 	public function setApiForUser(int $uid)
 	{
 		$this->api = $this->config->get('atprotocol', 'appview_api');
-		if ($uid !== 0 && $this->getUserPds($uid)) {
-			$this->uid = $uid;
+		$this->uid = 0;
+		if ($uid !== 0) {
+			$userPds = $this->getUserPds($uid);
+			if ($userPds) {
+				$this->api = $userPds;
+				$this->uid = $uid;
+			}
 		}
 	}
 
 	/**
-	 * Get the DID PLC Directory
+	 * Get the user ID for which the API URL is set
+	 *
+	 * @return integer
+	 */
+	public function getUser(): int
+	{
+		return $this->uid;
+	}
+
+	/**
+	 * Get the user ID for the selected protocol
+	 *
+	 * @param integer $protocol
+	 * @return integer|null
+	 */
+	public function getUserForProtocol(int $protocol): ?int
+	{
+		switch ($protocol) {
+			case Conversation::PARCEL_JETSTREAM:
+				return 0;
+
+			case Conversation::PARCEL_CONNECTOR:
+				return $this->uid;
+
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Get the DID PLC directory
 	 *
 	 * @return string
 	 */
@@ -489,7 +534,7 @@ final class ATProtocol
 	}
 
 	/**
-	 * Get the web address for a given uid
+	 * Get the web address for a given user ID
 	 *
 	 * @param integer $uid
 	 * @return string

--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -195,14 +195,16 @@ final class ATProtocol
 		}
 
 		$data = json_decode($curlResult->getBodyString());
+		if (!$data || !is_object($data)) {
+			$this->logger->notice('Invalid data returned', ['url' => $url, 'code' => $curlResult->getReturnCode()]);
+			return null;
+		}
+
 		if (!$curlResult->isSuccess()) {
-			$this->logger->notice('API Error', ['url' => $url, 'code' => $curlResult->getReturnCode(), 'error' => $data ?: $curlResult->getBodyString()]);
-			if (!$data || !is_object($data)) {
-				return null;
-			}
+			$this->logger->notice('API Error', ['url' => $url, 'code' => $curlResult->getReturnCode(), 'error' => $data]);
 			$data->code = $curlResult->getReturnCode();
 		} elseif (($curlResult->getReturnCode() < 200) || ($curlResult->getReturnCode() >= 400)) {
-			$this->logger->notice('Unexpected return code', ['url' => $url, 'code' => $curlResult->getReturnCode(), 'error' => $data ?: $curlResult->getBodyString()]);
+			$this->logger->notice('Unexpected return code', ['url' => $url, 'code' => $curlResult->getReturnCode(), 'error' => $data]);
 			$data->code = $curlResult->getReturnCode();
 		}
 

--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -51,8 +51,7 @@ final class ATProtocol
 	/** @var ICanSendHttpRequests */
 	private $httpClient;
 
-	private string $api;
-	private int $uid = 0;
+	private int $uid;
 
 	/**
 	 * Initialize the AT Protocol service.
@@ -79,11 +78,14 @@ final class ATProtocol
 	 */
 	public function getApi(): string
 	{
-		if (!isset($this->api)) {
-			$this->logger->notice('Public API not set.');
-			$this->setApiForUser(0);
+		$uid = $this->getUser();
+		$api = $this->getUserPds($uid);
+		if ($api) {
+			return $api;
 		}
-		return $this->api;
+
+		$this->logger->warning('PDS for user could not be fetched', ['uid' => $uid]);
+		return $this->getUserPds(0);
 	}
 
 	/**
@@ -133,16 +135,16 @@ final class ATProtocol
 		}
 
 		if (is_null($uid)) {
-			$uid = $this->uid;
-		}
-
-		if ($uid === 0) {
-			return $this->get($this->getApi() . '/xrpc/' . $url);
+			$uid = $this->getUser();
 		}
 
 		$pds = $this->getUserPds($uid);
 		if (empty($pds)) {
 			return null;
+		}
+
+		if ($uid === 0) {
+			return $this->get($pds . '/xrpc/' . $url);
 		}
 
 		$headers = ['Authorization' => ['Bearer ' . $this->getUserToken($uid)]];
@@ -292,7 +294,7 @@ final class ATProtocol
 	private function getUserPds(int $uid): ?string
 	{
 		if ($uid == 0) {
-			return $this->getApi();
+			return $this->config->get('atprotocol', 'appview_api');
 		}
 
 		$pds = $this->pConfig->get($uid, 'bluesky', 'pds');
@@ -472,14 +474,10 @@ final class ATProtocol
 	 */
 	public function setApiForUser(int $uid)
 	{
-		$this->api = $this->config->get('atprotocol', 'appview_api');
-		$this->uid = 0;
-		if ($uid !== 0) {
-			$userPds = $this->getUserPds($uid);
-			if ($userPds) {
-				$this->api = $userPds;
-				$this->uid = $uid;
-			}
+		$this->uid = $uid;
+
+		if (!$this->getUserPds($uid)) {
+			$this->uid = 0;
 		}
 	}
 
@@ -490,6 +488,11 @@ final class ATProtocol
 	 */
 	public function getUser(): int
 	{
+		if (is_null($this->uid)) {
+			$this->logger->notice('API user not set.');
+			$this->uid = 0;
+		}
+
 		return $this->uid;
 	}
 
@@ -506,7 +509,7 @@ final class ATProtocol
 				return 0;
 
 			case Conversation::PARCEL_CONNECTOR:
-				return $this->uid;
+				return $this->getUser();
 
 			default:
 				return null;

--- a/src/Protocol/ATProtocol/Actor.php
+++ b/src/Protocol/ATProtocol/Actor.php
@@ -33,6 +33,13 @@ class Actor
 	/** @var \Friendica\Core\Config\Capability\IManageConfigValues */
 	private $config;
 
+	/**
+	 * Initialize the actor service.
+	 *
+	 * @param LoggerInterface $logger
+	 * @param ATProtocol $atprotocol
+	 * @param IManageConfigValues $config
+	 */
 	public function __construct(LoggerInterface $logger, ATProtocol $atprotocol, IManageConfigValues $config)
 	{
 		$this->logger     = $logger;
@@ -41,7 +48,7 @@ class Actor
 	}
 
 	/**
-	 * Syncronize the contacts (followers, sharers) for the given user
+	 * Synchronize the contacts (followers, sharers) for the given user
 	 *
 	 * @param integer $uid User ID
 	 * @return void
@@ -62,7 +69,7 @@ class Actor
 				'cursor' => $cursor,
 			];
 
-			$data = $this->atprotocol->XRPCGet('app.bsky.graph.getFollows', $parameters);
+			$data = $this->atprotocol->XRPCGet('app.bsky.graph.getFollows', $parameters, $uid);
 
 			foreach ($data->follows ?? [] as $follow) {
 				$profiles[$follow->did] = $follow;
@@ -80,7 +87,7 @@ class Actor
 				'cursor' => $cursor,
 			];
 
-			$data = $this->atprotocol->XRPCGet('app.bsky.graph.getFollowers', $parameters);
+			$data = $this->atprotocol->XRPCGet('app.bsky.graph.getFollowers', $parameters, $uid);
 
 			foreach ($data->followers ?? [] as $follow) {
 				$profiles[$follow->did] = $follow;
@@ -113,7 +120,7 @@ class Actor
 	 */
 	public function updateContactByDID(string $did, int $contact_uid): void
 	{
-		$profile = $this->atprotocol->XRPCGet('app.bsky.actor.getProfile', ['actor' => $did], $contact_uid);
+		$profile = $this->atprotocol->XRPCGet('app.bsky.actor.getProfile', ['actor' => $did]);
 		if (empty($profile) || empty($profile->did)) {
 			return;
 		}
@@ -186,7 +193,7 @@ class Actor
 	}
 
 	/**
-	 * Fetch and possibly create a contact array for a given DID
+	 * Fetch and possibly create a contact for a given DID
 	 *
 	 * @param string  $did         The contact DID
 	 * @param integer $uid         "0" when either the public contact or the user contact is desired
@@ -231,10 +238,10 @@ class Actor
 	}
 
 	/**
-	 * Get the profile link for a given DID and user id
+	 * Get the profile link for a given DID and user ID
 	 *
 	 * @param string  $did The contact DID
-	 * @param integer $uid User id to get the web for (0 for global)
+	 * @param integer $uid User ID to get the web for (0 for global)
 	 * @return string Profile link
 	 */
 	public function getProfileLink(string $did, int $uid = 0): string

--- a/src/Protocol/ATProtocol/Jetstream.php
+++ b/src/Protocol/ATProtocol/Jetstream.php
@@ -82,6 +82,16 @@ class Jetstream
 	/** @var \WebSocket\Client */
 	private $client;
 
+	/**
+	 * Initialize the Jetstream service.
+	 *
+	 * @param LoggerInterface $logger
+	 * @param IManageConfigValues $config
+	 * @param IManageKeyValuePairs $keyValue
+	 * @param ATProtocol $atprotocol
+	 * @param Actor $actor
+	 * @param Processor $processor
+	 */
 	public function __construct(LoggerInterface $logger, IManageConfigValues $config, IManageKeyValuePairs $keyValue, ATProtocol $atprotocol, Actor $actor, Processor $processor)
 	{
 		$this->logger     = $logger;
@@ -95,7 +105,7 @@ class Jetstream
 	}
 
 	/**
-	 * Listen to incoming webstream messages from Jetstream
+	 * Listen to incoming Jetstream WebSocket messages
 	 *
 	 * @return void
 	 */
@@ -204,7 +214,7 @@ class Jetstream
 	}
 
 	/**
-	 * Set options like the followed DIDs
+	 * Set stream options like the followed DIDs
 	 *
 	 * @return void
 	 */
@@ -257,7 +267,7 @@ class Jetstream
 		$update = [
 			'type'    => 'options_update',
 			'payload' => [
-				'wantedCollections'   => ['app.bsky.feed.post', 'app.bsky.feed.repost', 'app.bsky.feed.like', 'app.bsky.graph.block', 'app.bsky.actor.profile', 'app.bsky.graph.follow'],
+				'wantedCollections'   => ['app.bsky.feed.post', 'app.bsky.feed.repost', 'app.bsky.feed.like', 'app.bsky.graph.block', 'app.bsky.actor.profile', 'app.bsky.graph.follow', 'site.standard.publication', 'site.standard.document', 'site.standard.graph.subscription'],
 				'wantedDids'          => $dids,
 				'maxMessageSizeBytes' => 1000000,
 			],
@@ -309,6 +319,7 @@ class Jetstream
 		}
 
 		Item::incrementInbound(Protocol::ATPROTO);
+		$this->atprotocol->setApiForUser(0);
 
 		switch ($data->kind) {
 			case 'account':
@@ -426,7 +437,7 @@ class Jetstream
 
 			case 'create':
 				if ($drift < self::MAX_DRIFT_CREATE_POSTS) {
-					$this->processor->createPost($data, $this->uids[$data->did] ?? [0], ($drift > self::MAX_DRIFT_THREAD_COMPLETION));
+					$this->processor->createPost($data, $this->uids[$data->did] ?? [0], true);
 				}
 				break;
 

--- a/src/Protocol/ATProtocol/Processor.php
+++ b/src/Protocol/ATProtocol/Processor.php
@@ -47,6 +47,15 @@ class Processor
 	/** @var Actor */
 	private $actor;
 
+	/**
+	 * Processor constructor.
+	 *
+	 * @param Database $database
+	 * @param LoggerInterface $logger
+	 * @param BaseURL $baseURL
+	 * @param ATProtocol $atprotocol
+	 * @param Actor $actor
+	 */
 	public function __construct(Database $database, LoggerInterface $logger, BaseURL $baseURL, ATProtocol $atprotocol, Actor $actor)
 	{
 		$this->db         = $database;
@@ -56,6 +65,12 @@ class Processor
 		$this->actor      = $actor;
 	}
 
+	/**
+	 * Process account events and update contact archive state.
+	 *
+	 * @param stdClass $data
+	 * @return void
+	 */
 	public function processAccount(stdClass $data)
 	{
 		$fields = [
@@ -69,6 +84,12 @@ class Processor
 		Contact::update($fields, ['nurl' => $data->identity->did, 'network' => Protocol::ATPROTO]);
 	}
 
+	/**
+	 * Process identity events and update contact aliases.
+	 *
+	 * @param stdClass $data
+	 * @return void
+	 */
 	public function processIdentity(stdClass $data)
 	{
 		if (!isset($data->identity->handle)) {
@@ -88,6 +109,13 @@ class Processor
 		Contact::update($fields, ['nurl' => $data->identity->did, 'network' => Protocol::ATPROTO]);
 	}
 
+	/**
+	 * Apply block or unblock events for local users.
+	 *
+	 * @param stdClass $data
+	 * @param int $uid
+	 * @return void
+	 */
 	public function performBlocks(stdClass $data, int $uid)
 	{
 		if (!$uid) {
@@ -111,6 +139,12 @@ class Processor
 		$this->logger->info('Contact blocked', ['id' => $contact['id'], 'did' => $data->commit->record->subject, 'uid' => $uid]);
 	}
 
+	/**
+	 * Delete an existing record identified by DID, collection and rkey.
+	 *
+	 * @param stdClass $data
+	 * @return void
+	 */
 	public function deleteRecord(stdClass $data)
 	{
 		$uri     = 'at://' . $data->did . '/' . $data->commit->collection . '/' . $data->commit->rkey;
@@ -129,6 +163,14 @@ class Processor
 		$this->logger->info('Record deleted', $condition);
 	}
 
+	/**
+	 * Create a post from Jetstream data
+	 *
+	 * @param stdClass $data
+	 * @param array $uids
+	 * @param boolean $dont_fetch
+	 * @return void
+	 */
 	public function createPost(stdClass $data, array $uids, bool $dont_fetch)
 	{
 		$parent = '';
@@ -168,7 +210,7 @@ class Processor
 			if (!empty($data->commit->record->embed)) {
 				if (empty($post)) {
 					$uri  = 'at://' . $data->did . '/' . $data->commit->collection . '/' . $data->commit->rkey;
-					$post = $this->atprotocol->XRPCGet('app.bsky.feed.getPostThread', ['uri' => $uri]);
+					$post = $this->atprotocol->XRPCGet('app.bsky.feed.getPostThread', ['uri' => $uri], 0);
 					if (empty($post->thread->post->embed)) {
 						$this->logger->notice('Post was not fetched', ['uri' => $uri, 'post' => $post]);
 						return;
@@ -190,6 +232,14 @@ class Processor
 		}
 	}
 
+	/**
+	 * Create repost activity items from Jetstream data.
+	 *
+	 * @param stdClass $data
+	 * @param array $uids
+	 * @param bool $dont_fetch
+	 * @return void
+	 */
 	public function createRepost(stdClass $data, array $uids, bool $dont_fetch)
 	{
 		if ($dont_fetch && !$this->getPostUids($this->getUri($data->commit->record->subject), true)) {
@@ -206,13 +256,16 @@ class Processor
 			$item['gravity']    = Item::GRAVITY_ACTIVITY;
 			$item['body']       = $item['verb'] = Activity::ANNOUNCE;
 			$item['thr-parent'] = $this->getUri($data->commit->record->subject);
-			$item['thr-parent'] = $this->fetchMissingPost($item['thr-parent'], 0, Item::PR_FETCHED, $item['contact-id'], 0, $item['thr-parent'], !$dont_fetch, Conversation::PARCEL_JETSTREAM);
+			$item['thr-parent'] = $this->fetchMissingPost($item['thr-parent'], 0, Item::PR_FETCHED, $item['contact-id'], 0, $item['thr-parent'], false, Conversation::PARCEL_JETSTREAM);
 
+			if (!Post::exists(['uri' => $item['thr-parent'], 'uid' => [0, $uid]])) {
+				$this->logger->warning('Thread parent does not exist', ['uid' => $uid, 'thr-parent' => $item['thr-parent']]);
+			}
 			$id = Item::insert($item);
 
 			if ($id) {
 				$this->logger->info('Repost inserted', ['id' => $id]);
-			} elseif (Post::exists(['uid' => $uid, 'uri-id' => $item['uri-id']])) {
+			} elseif (Post::exists(['uid' => $item['uid'], 'uri-id' => $item['uri-id']])) {
 				$this->logger->notice('Repost was found', ['uri' => $item['uri']]);
 			} else {
 				$this->logger->warning('Repost was not inserted', ['uri' => $item['uri']]);
@@ -220,6 +273,12 @@ class Processor
 		}
 	}
 
+	/**
+	 * Create like activity items for existing posts.
+	 *
+	 * @param stdClass $data
+	 * @return void
+	 */
 	public function createLike(stdClass $data)
 	{
 		$uids = $this->getPostUids($this->getUri($data->commit->record->subject), false);
@@ -228,6 +287,11 @@ class Processor
 			return;
 		}
 		foreach ($uids as $uid) {
+			$parent = $this->getPostUri($this->getUri($data->commit->record->subject), $uid);
+			if (!$parent) {
+				$this->logger->debug('Parent for like does not exist. Like will not be inserted.', ['uid' => $uid, 'uri' => $parent]);
+				continue;
+			}
 			$item = $this->getHeaderFromJetstream($data, $uid);
 			if (empty($item)) {
 				continue;
@@ -235,7 +299,7 @@ class Processor
 
 			$item['gravity']    = Item::GRAVITY_ACTIVITY;
 			$item['body']       = $item['verb'] = Activity::LIKE;
-			$item['thr-parent'] = $this->getPostUri($this->getUri($data->commit->record->subject), $uid);
+			$item['thr-parent'] = $parent;
 
 			$id = Item::insert($item);
 
@@ -249,11 +313,25 @@ class Processor
 		}
 	}
 
+	/**
+	 * Determine whether a follow-delete event targets a local account.
+	 *
+	 * @param stdClass $data
+	 * @param array $self
+	 * @return bool
+	 */
 	public function deleteFollow(stdClass $data, array $self): bool
 	{
 		return !empty($self[$data->did]);
 	}
 
+	/**
+	 * Create follow relationships for local users based on follow events.
+	 *
+	 * @param stdClass $data
+	 * @param array $self
+	 * @return bool
+	 */
 	public function createFollow(stdClass $data, array $self): bool
 	{
 		if (!empty($self[$data->did])) {
@@ -279,6 +357,17 @@ class Processor
 		return true;
 	}
 
+	/**
+	 * Import a post and related metadata into Friendica.
+	 *
+	 * @param stdClass $post
+	 * @param int $uid
+	 * @param int $post_reason
+	 * @param int $causer
+	 * @param int $level
+	 * @param int $protocol
+	 * @return int
+	 */
 	public function processPost(stdClass $post, int $uid, int $post_reason, int $causer, int $level, int $protocol): int
 	{
 		$uri = $this->getUri($post);
@@ -298,7 +387,20 @@ class Processor
 		if (empty($item)) {
 			return 0;
 		}
-		$item = $this->getContent($item, $post->record, $uri, $uid, $level);
+
+		if (isset($post->record->reply->root)) {
+			$root   = $this->getUri($post->record->reply->root);
+			$parent = $this->getPostUri($root, $uid);
+			if (!$parent) {
+				$parent = $this->fetchMissingPost($root, $uid, Item::PR_COMPLETION, $item['contact-id'], $level, '', false, $protocol);
+			}
+			if (!$parent) {
+				$this->logger->warning('Root post could not be fetched', ['uri' => $uri, 'root' => $root]);
+				return 0;
+			}
+		}
+
+		$item = $this->getContent($item, $post->record, $uri, $uid);
 		if (empty($item)) {
 			return 0;
 		}
@@ -330,6 +432,14 @@ class Processor
 		return $this->fetchUriId($uri, $uid);
 	}
 
+	/**
+	 * Build the common item header from a Jetstream payload.
+	 *
+	 * @param stdClass $data
+	 * @param int $uid
+	 * @param int $protocol
+	 * @return array
+	 */
 	private function getHeaderFromJetstream(stdClass $data, int $uid, int $protocol = Conversation::PARCEL_JETSTREAM): array
 	{
 		$contact = $this->actor->getContactByDID($data->did, $uid, 0, true);
@@ -371,7 +481,7 @@ class Processor
 
 		$account          = Contact::selectAccountUserById($contact['id'], ['pid']);
 		$item['owner-id'] = $item['author-id'] = $account['pid'];
-		$item['uri-id']   = ItemURI::getIdByURI($item['uri']);
+		$item['uri-id']   = ItemURI::insert(['uri' => $item['uri'], 'guid' => $item['guid']]);
 
 		if (in_array($contact['rel'], [Contact::SHARING, Contact::FRIEND])) {
 			$item['post-reason'] = Item::PR_FOLLOWER;
@@ -392,6 +502,15 @@ class Processor
 		return $item;
 	}
 
+	/**
+	 * Build the common item header from a fetched ATProto post.
+	 *
+	 * @param stdClass $post
+	 * @param string $uri
+	 * @param int $uid
+	 * @param int $protocol
+	 * @return array
+	 */
 	public function getHeaderFromPost(stdClass $post, string $uri, int $uid, int $protocol): array
 	{
 		$parts = $this->getUriParts($uri);
@@ -454,7 +573,16 @@ class Processor
 		return $item;
 	}
 
-	private function getContent(array $item, stdClass $record, string $uri, int $uid, int $level): array
+	/**
+	 * Fill an item with body, parent linkage and language metadata.
+	 *
+	 * @param array $item
+	 * @param stdClass $record
+	 * @param string $uri
+	 * @param int $uid
+	 * @return array
+	 */
+	private function getContent(array $item, stdClass $record, string $uri, int $uid): array
 	{
 		if (empty($item)) {
 			return [];
@@ -483,6 +611,13 @@ class Processor
 		return $item;
 	}
 
+	/**
+	 * Convert ATProto facets to BBCode links and store hashtags.
+	 *
+	 * @param stdClass $record
+	 * @param int $uri_id
+	 * @return string
+	 */
 	private function parseFacets(stdClass $record, int $uri_id): string
 	{
 		$text = $record->text ?? '';
@@ -537,6 +672,14 @@ class Processor
 		return $text;
 	}
 
+	/**
+	 * Add media and quoted-post references from an embed payload.
+	 *
+	 * @param stdClass $embed
+	 * @param array $item
+	 * @param int $level
+	 * @return array
+	 */
 	private function addMedia(stdClass $embed, array $item, int $level): array
 	{
 		$type = '$type';
@@ -630,6 +773,13 @@ class Processor
 		return $item;
 	}
 
+	/**
+	 * Add starter pack metadata as HTML media to the post.
+	 *
+	 * @param array $item
+	 * @param stdClass $record
+	 * @return void
+	 */
 	private function addStarterpack(array $item, stdClass $record)
 	{
 		$this->logger->debug('Received starterpack', ['uri-id' => $item['uri-id'], 'guid' => $item['guid'], 'uri' => $record->uri]);
@@ -654,6 +804,14 @@ class Processor
 		Post\Media::update($fields, ['uri-id' => $media['uri-id'], 'url' => $media['url']]);
 	}
 
+	/**
+	 * Determine reply restrictions for a user based on threadgate rules.
+	 *
+	 * @param stdClass $post
+	 * @param array $item
+	 * @param int $post_reason
+	 * @return int|null
+	 */
 	private function getRestrictionsForUser(stdClass $post, array $item, int $post_reason): ?int
 	{
 		if (!empty($post->viewer->replyDisabled)) {
@@ -700,6 +858,19 @@ class Processor
 		return $restrict ? Item::CANT_REPLY : null;
 	}
 
+	/**
+	 * Fetch, import and return the canonical URI of a missing post.
+	 *
+	 * @param string $uri
+	 * @param int $uid
+	 * @param int $post_reason
+	 * @param int $causer
+	 * @param int $level
+	 * @param string $fallback
+	 * @param bool $complete_thread
+	 * @param int $Protocol
+	 * @return string
+	 */
 	public function fetchMissingPost(string $uri, int $uid, int $post_reason, int $causer, int $level, string $fallback = '', bool $complete_thread = false, int $Protocol = Conversation::PARCEL_JETSTREAM): string
 	{
 		$timestamp = microtime(true);
@@ -726,13 +897,21 @@ class Processor
 		$fetch_uri = $class->uri;
 
 		$this->logger->debug('Fetch missing post', ['level' => $level, 'uid' => $uid, 'uri' => $uri]);
-		$data = $this->atprotocol->XRPCGet('app.bsky.feed.getPostThread', ['uri' => $fetch_uri]);
+		$data = $this->atprotocol->XRPCGet('app.bsky.feed.getPostThread', ['uri' => $fetch_uri], $this->atprotocol->getUserForProtocol($Protocol));
 		if (empty($data) || empty($data->thread)) {
 			$this->logger->info('Thread was not fetched', ['level' => $level, 'uid' => $uid, 'uri' => $uri, 'fallback' => $fallback]);
 			if (microtime(true) - $timestamp > 2) {
 				$this->logger->debug('Not fetched', ['duration' => round(microtime(true) - $timestamp, 3), 'uri' => $uri, 'stamp' => $stamp]);
 			}
 			return $fallback;
+		}
+
+		if (isset($data->thread->post->record->reply->root)) {
+			$parent = $this->getUri($data->thread->post->record->reply->root);
+			if (!$this->getPostUri($parent, $uid)) {
+				$result = $this->fetchMissingPost($parent, $uid, $post_reason, $causer, $level, $parent, $complete_thread, $Protocol);
+				$this->logger->debug('Root parent created', ['parent' => $result]);
+			}
 		}
 
 		$this->logger->debug('Reply count', ['level' => $level, 'uid' => $uid, 'uri' => $uri]);
@@ -743,13 +922,6 @@ class Processor
 
 		if (!empty($data->thread->parent) && $complete_thread) {
 			$parents = $this->fetchParents($data->thread->parent, $uid);
-
-			if (!empty($parents)) {
-				if ($data->thread->post->record->reply->root->uri != $parents[0]->uri) {
-					$parent_uri = $this->getUri($data->thread->post->record->reply->root);
-					$this->fetchMissingPost($parent_uri, $uid, $post_reason, $causer, $level, $data->thread->post->record->reply->root->uri, $complete_thread, $Protocol);
-				}
-			}
 
 			foreach ($parents as $parent) {
 				$uri_id = $this->processPost($parent, $uid, Item::PR_FETCHED, $causer, $level, $Protocol);
@@ -764,6 +936,14 @@ class Processor
 		return $uri;
 	}
 
+	/**
+	 * Collect parent posts in top-down order that are not stored yet.
+	 *
+	 * @param stdClass $parent
+	 * @param int $uid
+	 * @param array $parents
+	 * @return array
+	 */
 	private function fetchParents(stdClass $parent, int $uid, array $parents = []): array
 	{
 		if (!empty($parent->parent)) {
@@ -777,6 +957,18 @@ class Processor
 		return $parents;
 	}
 
+	/**
+	 * Process a thread node and optionally recurse into replies.
+	 *
+	 * @param stdClass $thread
+	 * @param int $uid
+	 * @param int $post_reason
+	 * @param int $causer
+	 * @param int $level
+	 * @param int $protocol
+	 * @param bool $complete_thread
+	 * @return string
+	 */
 	private function processThread(stdClass $thread, int $uid, int $post_reason, int $causer, int $level, int $protocol, bool $complete_thread): string
 	{
 		if (empty($thread->post)) {
@@ -810,6 +1002,12 @@ class Processor
 		return $uri;
 	}
 
+	/**
+	 * Parse an AT URI into repository, collection and record key.
+	 *
+	 * @param string $uri
+	 * @return stdClass|null
+	 */
 	public function getUriParts(string $uri): ?stdClass
 	{
 		$class = $this->getUriClass($uri);
@@ -828,6 +1026,12 @@ class Processor
 		return $class;
 	}
 
+	/**
+	 * Normalize a URI into its ATProto URI and CID components.
+	 *
+	 * @param string $uri
+	 * @return stdClass|null
+	 */
 	public function getUriClass(string $uri): ?stdClass
 	{
 		if (empty($uri)) {
@@ -853,6 +1057,13 @@ class Processor
 		return $class;
 	}
 
+	/**
+	 * Look up the item URI identifier for a post URI or extid.
+	 *
+	 * @param string $uri
+	 * @param int $uid
+	 * @return int
+	 */
 	public function fetchUriId(string $uri, int $uid): int
 	{
 		$reply = Post::selectFirst(['uri-id'], ['uri' => $uri, 'uid' => [$uid, 0]]);
@@ -868,6 +1079,13 @@ class Processor
 		return 0;
 	}
 
+	/**
+	 * Find user IDs that already contain a specific post URI.
+	 *
+	 * @param string $uri
+	 * @param bool $with_public_user
+	 * @return array
+	 */
 	private function getPostUids(string $uri, bool $with_public_user): array
 	{
 		$condition = $with_public_user ? [] : ["`uid` != ?", 0];
@@ -887,6 +1105,13 @@ class Processor
 		return array_unique($uids);
 	}
 
+	/**
+	 * Check whether a post already exists by URI or extid for one of the given users.
+	 *
+	 * @param string $uri
+	 * @param array $uids
+	 * @return bool
+	 */
 	private function postExists(string $uri, array $uids): bool
 	{
 		if (Post::exists(['uri' => $uri, 'uid' => $uids])) {
@@ -896,6 +1121,12 @@ class Processor
 		return Post::exists(['extid' => $uri, 'uid' => $uids]);
 	}
 
+	/**
+	 * Build the canonical URI with CID from a post object.
+	 *
+	 * @param stdClass $post
+	 * @return string
+	 */
 	public function getUri(stdClass $post): string
 	{
 		if (empty($post->cid)) {
@@ -905,6 +1136,13 @@ class Processor
 		return $post->uri . ':' . $post->cid;
 	}
 
+	/**
+	 * Resolve a post URI to a stored canonical URI for a user.
+	 *
+	 * @param string $uri
+	 * @param int $uid
+	 * @return string
+	 */
 	public function getPostUri(string $uri, int $uid): string
 	{
 		if (Post::exists(['uri' => $uri, 'uid' => [$uid, 0]])) {

--- a/src/Protocol/ATProtocol/Processor.php
+++ b/src/Protocol/ATProtocol/Processor.php
@@ -217,7 +217,7 @@ class Processor
 					}
 				}
 				$item['source'] = json_encode($post);
-				$item           = $this->addMedia($post->thread->post->embed, $item, 0);
+				$item           = $this->addMedia($post->thread->post->embed, $item, Conversation::PARCEL_JETSTREAM, 0);
 			}
 
 			$id = Item::insert($item);
@@ -406,7 +406,7 @@ class Processor
 		}
 
 		if (!empty($post->embed)) {
-			$item = $this->addMedia($post->embed, $item, $level);
+			$item = $this->addMedia($post->embed, $item, $protocol, $level);
 		}
 
 		$item['restrictions'] = $this->getRestrictionsForUser($post, $item, $post_reason);
@@ -677,10 +677,11 @@ class Processor
 	 *
 	 * @param stdClass $embed
 	 * @param array $item
+	 * @param int $protocol
 	 * @param int $level
 	 * @return array
 	 */
-	private function addMedia(stdClass $embed, array $item, int $level): array
+	private function addMedia(stdClass $embed, array $item, int $protocol, int $level): array
 	{
 		$type = '$type';
 		switch ($embed->$type) {
@@ -736,7 +737,7 @@ class Processor
 				}
 				$fetched_uri = $this->getPostUri($uri, $item['uid']);
 				if (!$fetched_uri) {
-					$uri = $this->fetchMissingPost($uri, 0, Item::PR_FETCHED, $item['contact-id'], $level, $uri);
+					$uri = $this->fetchMissingPost($uri, 0, Item::PR_FETCHED, $item['contact-id'], $level, $uri, false, $protocol);
 				} else {
 					$uri = $fetched_uri;
 				}
@@ -752,9 +753,9 @@ class Processor
 				break;
 
 			case 'app.bsky.embed.recordWithMedia#view':
-				$this->addMedia($embed->media, $item, $level);
+				$this->addMedia($embed->media, $item, $protocol, $level);
 				$original_uri = $uri = $this->getUri($embed->record->record);
-				$uri          = $this->fetchMissingPost($uri, 0, Item::PR_FETCHED, $item['contact-id'], $level, $uri);
+				$uri          = $this->fetchMissingPost($uri, 0, Item::PR_FETCHED, $item['contact-id'], $level, $uri, false, $protocol);
 				if ($uri) {
 					$shared = Post::selectFirst(['uri-id'], ['uri' => $uri, 'uid' => [$item['uid'], 0]]);
 					$uri_id = $shared['uri-id'] ?? 0;

--- a/src/Protocol/ATProtocol/Processor.php
+++ b/src/Protocol/ATProtocol/Processor.php
@@ -1016,15 +1016,7 @@ class Processor
 			return null;
 		}
 
-		$parts = explode('/', substr($class->uri, 5));
-
-		$class = new stdClass();
-
-		$class->repo       = $parts[0];
-		$class->collection = $parts[1];
-		$class->rkey       = $parts[2];
-
-		return $class;
+		return $this->atprotocol->getUriObject($class->uri);
 	}
 
 	/**

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -626,7 +626,7 @@ class Network
 	 */
 	public static function isValidAtUrl(string $url): bool
 	{
-		return str_starts_with($url, 'at://');
+		return is_object(DI::atProtocol()->getUriObject($url));
 	}
 
 	/**

--- a/tests/src/Util/NetworkTest.php
+++ b/tests/src/Util/NetworkTest.php
@@ -33,28 +33,28 @@ class NetworkTest extends TestCase
 	{
 		// Valid AT Protocol URL with proper format at://repo/collection/rkey
 		self::assertTrue(Network::isValidAtUrl('at://did:plc:geqiabvo4b4jnfv2paplzcge/app.bsky.feed.post/abc123'));
-		
+
 		// Another valid AT Protocol URL
 		self::assertTrue(Network::isValidAtUrl('at://did:key:z6MkhaXgBZDvotDkL5257faWYB3cbRwEeAe1YvyQbxC/app.bsky.actor.profile/self'));
 
 		// HTTP URL (not AT Protocol)
 		self::assertFalse(Network::isValidAtUrl('https://example.com'));
-		
+
 		// HTTP URL (valid URL but wrong protocol)
 		self::assertFalse(Network::isValidAtUrl('http://test.example.com/profile'));
-		
+
 		// Malformed AT URL - missing parts
 		self::assertFalse(Network::isValidAtUrl('at://did:plc:abc/collection'));
-		
+
 		// Malformed AT URL - too many parts
 		self::assertFalse(Network::isValidAtUrl('at://did:plc:abc/collection/rkey/extra'));
-		
+
 		// Invalid format - no at:// prefix
 		self::assertFalse(Network::isValidAtUrl('did:plc:geqiabvo4b4jnfv2paplzcge/app.bsky.feed.post/abc123'));
-		
+
 		// Empty string
 		self::assertFalse(Network::isValidAtUrl(''));
-		
+
 		// Whitespace only
 		self::assertFalse(Network::isValidAtUrl('   '));
 	}

--- a/tests/src/Util/NetworkTest.php
+++ b/tests/src/Util/NetworkTest.php
@@ -24,4 +24,38 @@ class NetworkTest extends TestCase
 		self::assertNull(Network::createUriFromString(''));
 		self::assertNull(Network::createUriFromString(null));
 	}
+
+	/**
+	 * Test for isValidAtUrl function
+	 * Tests valid and invalid AT Protocol URLs
+	 */
+	public function testIsValidAtUrl()
+	{
+		// Valid AT Protocol URL with proper format at://repo/collection/rkey
+		self::assertTrue(Network::isValidAtUrl('at://did:plc:geqiabvo4b4jnfv2paplzcge/app.bsky.feed.post/abc123'));
+		
+		// Another valid AT Protocol URL
+		self::assertTrue(Network::isValidAtUrl('at://did:key:z6MkhaXgBZDvotDkL5257faWYB3cbRwEeAe1YvyQbxC/app.bsky.actor.profile/self'));
+
+		// HTTP URL (not AT Protocol)
+		self::assertFalse(Network::isValidAtUrl('https://example.com'));
+		
+		// HTTP URL (valid URL but wrong protocol)
+		self::assertFalse(Network::isValidAtUrl('http://test.example.com/profile'));
+		
+		// Malformed AT URL - missing parts
+		self::assertFalse(Network::isValidAtUrl('at://did:plc:abc/collection'));
+		
+		// Malformed AT URL - too many parts
+		self::assertFalse(Network::isValidAtUrl('at://did:plc:abc/collection/rkey/extra'));
+		
+		// Invalid format - no at:// prefix
+		self::assertFalse(Network::isValidAtUrl('did:plc:geqiabvo4b4jnfv2paplzcge/app.bsky.feed.post/abc123'));
+		
+		// Empty string
+		self::assertFalse(Network::isValidAtUrl(''));
+		
+		// Whitespace only
+		self::assertFalse(Network::isValidAtUrl('   '));
+	}
 }


### PR DESCRIPTION
This PR contains improvements for atproto:

1. We now always fetch the root post of an incoming post/comment. In the past it happened that posts hadn't been stored because of missing parent posts. This should now be a thing of the past (at least it hadn't happened in the last 12 hours, after I applied the last changes)
2. Because of how the addons are executed, it happened that the Jetstream API requests had been done against the user PDS and not the public API. This sometimes lead to the problem that for example a post arrived via Jetstream where the root post wasn't yet available on the PDS. We now ensure to always query the public API in the Jetstream mode.
3. All atproto functions now have got meaningful headers.
4. New functions are created to handle atproto records.
5. The function "isValidAtUrl" has now got some tests.

Together with PR https://git.friendi.ca/friendica/friendica-addons/pulls/1646 we ensure that requests done by the connector are always done against the user's PDS.