### PR TITLE
[CI] Bump PHP versions

### DIFF
--- a/.woodpecker/.code_standards_check.yml
+++ b/.woodpecker/.code_standards_check.yml
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+matrix:
+  include:
+    - PHP_MAJOR_VERSION: 8.5
+      PHP_VERSION: 8.5.5
+
 # The code standard check is just triggered for PRs and pushes to non-stable branches of Friendica
 when:
   branch:
@@ -22,7 +27,7 @@ steps:
       - /tmp/drone-cache:/tmp/cache
 
   composer_install:
-    image: friendicaci/php8.3:php8.3.17
+    image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     commands:
       - mkdir addon # create empty addon folder to appease composer
       - export COMPOSER_HOME=.composer

--- a/.woodpecker/.continuous-deployment-allinone.yml
+++ b/.woodpecker/.continuous-deployment-allinone.yml
@@ -13,6 +13,11 @@ labels:
   location: friendica
   type: releaser
 
+matrix:
+  include:
+    - PHP_MAJOR_VERSION: 8.5
+      PHP_VERSION: 8.5.5
+
 # CD is triggered after pushing new code to the develop or *-rc branch, excluding the stable branch
 when:
   repo: friendica/friendica
@@ -52,7 +57,7 @@ steps:
     volumes:
       - /tmp/drone-cache:/tmp/cache
   composer_install:
-    image: friendicaci/php8.2:php8.2.28
+    image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     commands:
       - export COMPOSER_HOME=.composer
       - composer validate

--- a/.woodpecker/.continuous-deployment.yml
+++ b/.woodpecker/.continuous-deployment.yml
@@ -13,6 +13,11 @@ labels:
   location: friendica
   type: releaser
 
+matrix:
+  include:
+    - PHP_MAJOR_VERSION: 8.5
+      PHP_VERSION: 8.5.5
+
 # CD is triggered after pushing new code to the develop or *-rc branch, excluding the stable branch
 when:
   repo: friendica/friendica
@@ -44,7 +49,7 @@ steps:
     volumes:
       - /tmp/drone-cache:/tmp/cache
   composer_install:
-    image: friendicaci/php8.2:php8.2.28
+    image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     commands:
       - mkdir addon # create empty addon folder to appease composer
       - export COMPOSER_HOME=.composer

--- a/.woodpecker/.database_checks.yml
+++ b/.woodpecker/.database_checks.yml
@@ -4,8 +4,8 @@
 
 matrix:
   include:
-    - PHP_MAJOR_VERSION: 8.2
-      PHP_VERSION: 8.2.28
+    - PHP_MAJOR_VERSION: 8.5
+      PHP_VERSION: 8.5.5
 
 when:
   branch:

--- a/.woodpecker/.phpmd_check.yml
+++ b/.woodpecker/.phpmd_check.yml
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+matrix:
+  include:
+    - PHP_MAJOR_VERSION: 8.5
+      PHP_VERSION: 8.5.5
+
 # The phpmd check is just triggered for PRs and pushes to non-stable branches of Friendica
 when:
   branch:
@@ -26,7 +31,7 @@ steps:
       - /tmp/drone-cache:/tmp/cache
 
   composer_install:
-    image: friendicaci/php8.3:php8.3.17
+    image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     commands:
       - mkdir addon # create empty addon folder to appease composer
       - export COMPOSER_HOME=.composer
@@ -45,6 +50,6 @@ steps:
       - /tmp/drone-cache:/tmp/cache
 
   phpmd:
-    image: friendicaci/php8.3:php8.3.17
+    image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     commands:
       - ./bin/composer.phar run phpmd

--- a/.woodpecker/.phpunit.yml
+++ b/.woodpecker/.phpunit.yml
@@ -9,13 +9,15 @@ matrix:
     - PHP_MAJOR_VERSION: 8.0
       PHP_VERSION: 8.0.30
     - PHP_MAJOR_VERSION: 8.1
-      PHP_VERSION: 8.1.31
+      PHP_VERSION: 8.1.34
     - PHP_MAJOR_VERSION: 8.2
-      PHP_VERSION: 8.2.28
+      PHP_VERSION: 8.2.30
     - PHP_MAJOR_VERSION: 8.3
-      PHP_VERSION: 8.3.17
+      PHP_VERSION: 8.3.30
     - PHP_MAJOR_VERSION: 8.4
-      PHP_VERSION: 8.4.5
+      PHP_VERSION: 8.4.20
+    - PHP_MAJOR_VERSION: 8.5
+      PHP_VERSION: 8.5.5
 
 # This forces PHP Unit executions at the "opensocial" labeled location (because of much more power...)
 labels:

--- a/.woodpecker/.releaser-allinone.yml
+++ b/.woodpecker/.releaser-allinone.yml
@@ -9,6 +9,11 @@ labels:
 
 skip_clone: true
 
+matrix:
+  include:
+    - PHP_MAJOR_VERSION: 8.5
+      PHP_VERSION: 8.5.5
+
 when:
   repo: friendica/friendica
   branch: stable
@@ -45,7 +50,7 @@ steps:
     volumes:
       - /tmp/drone-cache:/tmp/cache
   composer_install:
-    image: friendicaci/php8.2:php8.2.28
+    image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     commands:
       - export COMPOSER_HOME=.composer
       - composer validate

--- a/.woodpecker/.releaser.yml
+++ b/.woodpecker/.releaser.yml
@@ -9,6 +9,11 @@ labels:
 
 skip_clone: true
 
+matrix:
+  include:
+    - PHP_MAJOR_VERSION: 8.5
+      PHP_VERSION: 8.5.5
+
 when:
   repo: friendica/friendica
   branch: stable
@@ -35,7 +40,7 @@ steps:
     volumes:
       - /tmp/drone-cache:/tmp/cache
   composer_install:
-    image: friendicaci/php8.2:php8.2.28
+    image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     commands:
       - mkdir addon # create empty addon folder to appease composer
       - export COMPOSER_HOME=.composer


### PR DESCRIPTION
- new PHP versions
- Include missing extensions "gmp" and "imagick"

Images are from https://git.friendi.ca/friendica/friendica-docker-ci.git 

And are pushed to https://hub.docker.com/orgs/friendicaci/repositories

Hmmm.. I maybe push it directly as packages in git.friendi.ca - next PR ;)

update it before #15652 and #15595 

