### PR TITLE
Issue 15654: Avoid public contact being blocked

### DIFF
--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -192,7 +192,9 @@ class Contact
 		if (empty($contact)) {
 			return false;
 		}
-		$contact['uid'] = 0;
+		$contact['uid']     = 0;
+		$contact['blocked'] = false;
+		$contact['pending'] = false;
 		return (bool) self::insert($contact);
 	}
 


### PR DESCRIPTION
Fixes #15654

This PR will prevent further blocks, but will not unblock accidentally blocked contacts.