### PR TITLE
Add Bootstrap table styling to rendered tables

### DIFF
--- a/doc/de/user/bbcode.md
+++ b/doc/de/user/bbcode.md
@@ -269,7 +269,7 @@ Zeilen</code></td>
   [/tr]<br>
 [/table]</td>
   <td>
-	<table>
+	<table class="table">
       <tbody>
         <tr>
           <th>Kopfzeile 1</th>
@@ -293,7 +293,7 @@ Zeilen</code></td>
 <tr>
   <td>[table border=0]</td>
   <td>
-	<table border="0">
+	<table class="table" border="0">
       <tbody>
         <tr>
           <th>Kopfzeile 1</th>
@@ -317,7 +317,7 @@ Zeilen</code></td>
 <tr>
   <td>[table border=1]</td>
   <td>
-	<table border="1">
+	<table class="table" border="1">
       <tbody>
         <tr>
           <th>Kopfzeile 1</th>

--- a/doc/en/user/bbcode.md
+++ b/doc/en/user/bbcode.md
@@ -291,7 +291,7 @@ code</code></td>
   [/tr]<br>
 [/table]</td>
   <td>
-	<table>
+	<table class="table">
       <tbody>
         <tr>
           <th>Header 1</th>
@@ -315,7 +315,7 @@ code</code></td>
 <tr>
   <td>[table border=0]</td>
   <td>
-	<table border="0">
+	<table class="table" border="0">
       <tbody>
         <tr>
           <th>Header 1</th>
@@ -339,7 +339,7 @@ code</code></td>
 <tr>
   <td>[table border=1]</td>
   <td>
-	<table border="1">
+	<table class="table" border="1">
       <tbody>
         <tr>
           <th>Header 1</th>

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -1707,10 +1707,10 @@ class BBCode
 		$text = preg_replace("/\[th\](.*?)\[\/th\]/sm", '<th>$1</th>', $text);
 		$text = preg_replace("/\[td\](.*?)\[\/td\]/sm", '<td>$1</td>', $text);
 		$text = preg_replace("/\[tr\](.*?)\[\/tr\]/sm", '<tr>$1</tr>', $text);
-		$text = preg_replace("/\[table\](.*?)\[\/table\]/sm", '</p><table>$1</table><p>', $text);
+		$text = preg_replace("/\[table\](.*?)\[\/table\]/sm", '</p><table class="table">$1</table><p>', $text);
 
-		$text = preg_replace("/\[table border=1\](.*?)\[\/table\]/sm", '</p><table border="1" >$1</table><p>', $text);
-		$text = preg_replace("/\[table border=0\](.*?)\[\/table\]/sm", '</p><table border="0" >$1</table><p>', $text);
+		$text = preg_replace("/\[table border=1\](.*?)\[\/table\]/sm", '</p><table class="table" border="1">$1</table><p>', $text);
+		$text = preg_replace("/\[table border=0\](.*?)\[\/table\]/sm", '</p><table class="table" border="0">$1</table><p>', $text);
 
 		return $text;
 	}


### PR DESCRIPTION
Markdown and BBCode tables were rendered without any styling, making them hard to read. This adds Bootstrap's table class so tables get proper borders, padding and spacing.

Before:
<img width="661" height="218" alt="image" src="https://github.com/user-attachments/assets/de19de50-e7e6-44e6-9b21-47fb92554c07" />

After:
<img width="665" height="256" alt="image" src="https://github.com/user-attachments/assets/c3cdca1b-f7c1-4f53-afdd-d8237e7c6f0d" />

fixes #15373 
