### PR TITLE
[CI] Fixup for "rmdir" Issue and wrong composer_cache

### DIFF
--- a/.woodpecker/.continuous-deployment-allinone.yml
+++ b/.woodpecker/.continuous-deployment-allinone.yml
@@ -24,19 +24,7 @@ when:
   branch: [ develop, '*-rc' ]
   event: push
 
-skip_clone: true
-
 steps:
-  clone_friendica_base:
-    image: alpine/git
-    commands:
-      - git config --global user.email "no-reply@friendi.ca"
-      - git config --global user.name "Friendica"
-      - git config --global --add safe.directory $CI_WORKSPACE
-      - git clone $CI_REPO_CLONE_URL .
-      - git checkout $CI_COMMIT_BRANCH
-      - git fetch origin $CI_COMMIT_REF
-      - git merge $CI_COMMIT_SHA
   clone_friendica_addon:
     image: alpine/git
     commands:

--- a/.woodpecker/.continuous-deployment-allinone.yml
+++ b/.woodpecker/.continuous-deployment-allinone.yml
@@ -38,7 +38,7 @@ steps:
     settings:
       backend: "filesystem"
       restore: true
-      cache_key: "{{ .Repo.Name }}_php7.4_{{ arch }}_{{ os }}"
+      cache_key: "{{ .Repo.Name }}_php{{PHP_MAJOR_VERSION}}_{{ arch }}_{{ os }}"
       archive_format: "gzip"
       mount:
         - '.composer'

--- a/.woodpecker/.continuous-deployment.yml
+++ b/.woodpecker/.continuous-deployment.yml
@@ -30,7 +30,7 @@ steps:
     settings:
       backend: "filesystem"
       restore: true
-      cache_key: "{{ .Repo.Name }}_php7.4_{{ arch }}_{{ os }}"
+      cache_key: "{{ .Repo.Name }}_php{{PHP_MAJOR_VERSION}}_{{ arch }}_{{ os }}"
       archive_format: "gzip"
       mount:
         - '.composer'

--- a/.woodpecker/.continuous-deployment.yml
+++ b/.woodpecker/.continuous-deployment.yml
@@ -24,19 +24,7 @@ when:
   branch: [ develop, '*-rc' ]
   event: push
 
-skip_clone: true
-
 steps:
-  clone:
-    image: alpine/git
-    commands:
-      - git config --global user.email "no-reply@friendi.ca"
-      - git config --global user.name "Friendica"
-      - git config --global --add safe.directory $CI_WORKSPACE
-      - git clone $CI_REPO_CLONE_URL .
-      - git checkout $CI_COMMIT_BRANCH
-      - git fetch origin $CI_COMMIT_REF
-      - git merge $CI_COMMIT_SHA
   restore_cache:
     image: meltwater/drone-cache:dev
     settings:

--- a/.woodpecker/.phpunit.yml
+++ b/.woodpecker/.phpunit.yml
@@ -93,7 +93,7 @@ steps:
       - cp config/local-sample.config.php config/local.config.php
       - if ! bin/wait-for-connection $MYSQL_HOST $MYSQL_PORT 300; then echo "[ERROR] Waited 300 seconds, no response" >&2; exit 1; fi
       - mysql -h$MYSQL_HOST -P$MYSQL_PORT -p$MYSQL_PASSWORD -u$MYSQL_USER $MYSQL_DATABASE < database.sql
-      - if [ "${PHP_MAJOR_VERSION}" = "8.2" -a "${CI_REPO}" = "friendica/friendica" ]; then
+      - if [ "${PHP_MAJOR_VERSION}" = "8.5" -a "${CI_REPO}" = "friendica/friendica" ]; then
           phpenmod xdebug;
           export XDEBUG_MODE=coverage;
           phpunit --configuration tests/phpunit.xml -d memory_limit=-1 --coverage-clover clover.xml;

--- a/.woodpecker/.phpunit.yml
+++ b/.woodpecker/.phpunit.yml
@@ -28,19 +28,7 @@ when:
     exclude: [ stable ]
   event: [ pull_request, push ]
 
-skip_clone: true
-
 steps:
-  clone:
-    image: alpine/git
-    commands:
-      - git config --global user.email "no-reply@friendi.ca"
-      - git config --global user.name "Friendica"
-      - git config --global --add safe.directory $CI_WORKSPACE
-      - git clone $CI_REPO_CLONE_URL .
-      - git checkout $CI_COMMIT_BRANCH
-      - git fetch origin $CI_COMMIT_REF
-      - git merge $CI_COMMIT_SHA
   php-lint:
     image: php:${PHP_MAJOR_VERSION}
     commands:
@@ -80,14 +68,14 @@ steps:
     image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     when:
       matrix:
-        PHP_MAJOR_VERSION: 8.3
+        PHP_MAJOR_VERSION: 8.5
     commands:
       - bin/composer.phar run phpstan;
   phpstan-addons:
     image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     when:
       matrix:
-        PHP_MAJOR_VERSION: 8.3
+        PHP_MAJOR_VERSION: 8.5
     commands:
       - bin/composer.phar run phpstan-addons;
   test:
@@ -116,8 +104,7 @@ steps:
     image: friendicaci/codecov
     when:
       matrix:
-        PHP_MAJOR_VERSION: 8.2
-        PHP_VERSION: 8.2.28
+        PHP_MAJOR_VERSION: 8.5
       repo:
         - friendica/friendica
     commands:

--- a/.woodpecker/.releaser-allinone.yml
+++ b/.woodpecker/.releaser-allinone.yml
@@ -31,7 +31,7 @@ steps:
     settings:
       backend: "filesystem"
       restore: true
-      cache_key: "{{ .Repo.Name }}_php7.4_{{ arch }}_{{ os }}"
+      cache_key: "{{ .Repo.Name }}_php{{PHP_MAJOR_VERSION}}_{{ arch }}_{{ os }}"
       archive_format: "gzip"
       mount:
         - '.composer'

--- a/.woodpecker/.releaser-allinone.yml
+++ b/.woodpecker/.releaser-allinone.yml
@@ -7,8 +7,6 @@ labels:
   location: friendica
   type: releaser
 
-skip_clone: true
-
 matrix:
   include:
     - PHP_MAJOR_VERSION: 8.5
@@ -20,16 +18,6 @@ when:
   event: tag
 
 steps:
-  clone_friendica_base:
-    image: alpine/git
-    commands:
-      - git config --global user.email "no-reply@friendi.ca"
-      - git config --global user.name "Friendica"
-      - git config --global --add safe.directory $CI_WORKSPACE
-      - git clone $CI_REPO_CLONE_URL .
-      - git checkout $CI_COMMIT_BRANCH
-      - git fetch origin $CI_COMMIT_REF
-      - git merge $CI_COMMIT_SHA
   clone_friendica_addon:
     image: alpine/git
     commands:

--- a/.woodpecker/.releaser.yml
+++ b/.woodpecker/.releaser.yml
@@ -7,8 +7,6 @@ labels:
   location: friendica
   type: releaser
 
-skip_clone: true
-
 matrix:
   include:
     - PHP_MAJOR_VERSION: 8.5
@@ -20,14 +18,6 @@ when:
   event: tag
 
 steps:
-  clone:
-    image: alpine/git
-    commands:
-      - git clone $CI_REPO_CLONE_URL .
-      - git checkout $CI_COMMIT_BRANCH
-      - git fetch origin $CI_COMMIT_REF
-      - git merge $CI_COMMIT_SHA
-
   restore_cache:
     image: meltwater/drone-cache:dev
     settings:

--- a/.woodpecker/.releaser.yml
+++ b/.woodpecker/.releaser.yml
@@ -23,7 +23,7 @@ steps:
     settings:
       backend: "filesystem"
       restore: true
-      cache_key: "{{ .Repo.Name }}_php7.4_{{ arch }}_{{ os }}"
+      cache_key: "{{ .Repo.Name }}_php{{PHP_MAJOR_VERSION}}_{{ arch }}_{{ os }}"
       archive_format: "gzip"
       mount:
         - '.composer'


### PR DESCRIPTION
I possible found a solution for the "rmdir" issue

I assume that skip_clone: true skips the initial directory creation during the default-clone step by woordpecker too. So the pipeline steps AND the services are starting parallel and sometimes try to create the same directory multiple times, which leads to this error ..

But I'm not totaly sure, so let's give it a try ;)

And it fixes the wrong composer_cache key, which lead to errors during packaging after merges