### PR TITLE
Add Account Type drop-down selector to Register form

### DIFF
--- a/src/Content/GroupManager.php
+++ b/src/Content/GroupManager.php
@@ -132,7 +132,7 @@ class GroupManager
 				'$title'                         => DI::l10n()->t('Groups'),
 				'$groups'                        => $entries,
 				'$link_desc'                     => DI::l10n()->t('External link to group'),
-				'$new_group_page'                => 'register/',
+				'$new_group_page'                => 'register/?type=group',
 				'$total'                         => $total,
 				'$visible_groups'                => $visibleGroups,
 				'$showless'                      => DI::l10n()->t('show less'),

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -94,13 +94,13 @@ class User
 	 * @}
 	 */
 
-	 /**
-	  * Account type value strings
-	  *
-	  * Used for drop-down select option values
-	  * so as to not expose the database values
-	  * @{
-	  */
+	/**
+	 * Account type value strings
+	 *
+	 * Used for drop-down select option values
+	 * so as to not expose the database values
+	 * @{
+	 */
 	public const PERSONAL = "personal";
 	public const SOAPBOX  = "soapbox";
 	public const LOVEALL  = "loveall";
@@ -112,7 +112,7 @@ class User
 	/**
 	 * @}
 	 */
-	
+
 	private static $owner;
 
 	/**

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -94,6 +94,25 @@ class User
 	 * @}
 	 */
 
+	 /**
+	  * Account type value strings
+	  *
+	  * Used for drop-down select option values
+	  * so as to not expose the database values
+	  * @{
+	  */
+	public const PERSONAL = "personal";
+	public const SOAPBOX  = "soapbox";
+	public const LOVEALL  = "loveall";
+	public const ORGPAGE  = "page";
+	public const NEWSPAGE = "newspage";
+	public const PUBGROUP = "group";
+	public const RESGROUP = "group-restricted";
+	public const PRIGROUP = "group-private";
+	/**
+	 * @}
+	 */
+	
 	private static $owner;
 
 	/**

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -35,15 +35,6 @@ class Register extends BaseModule
 	const CLOSED  = 0;
 	const APPROVE = 1;
 	const OPEN    = 2;
-	/** account types for drop-down **/
-	const PERSONAL = "personal";
-	const SOAPBOX  = "soapbox";
-	const LOVEALL  = "loveall";
-	const ORGPAGE  = "page";
-	const NEWSPAGE = "newspage";
-	const PUBGROUP = "group";
-	const RESGROUP = "group-restricted";
-	const PRIGROUP = "group-private";
 	
 	/** @var Tos */
 	protected $tos;
@@ -145,44 +136,44 @@ class Register extends BaseModule
 			]);
 		}
 
-		$regbutton_label = DI::l10n()->t('Register Account');
+		$regbutton_label = DI::l10n()->t('Create Account');
 
 		/* ACCOUNT TYPE SELECT */
 		$acct_list = [	// value => label
-			Register::PERSONAL	=> DI::l10n()->t('Personal (standard account)'),
-			Register::SOAPBOX	=> DI::l10n()->t('Soap-Box (auto-approve Follow requests)'),
-			Register::LOVEALL	=> DI::l10n()->t('Love-All (auto-approve Friend requests)'),
-			Register::ORGPAGE	=> DI::l10n()->t('Organization Page'),
-			Register::NEWSPAGE	=> DI::l10n()->t('News Page'),
-			Register::PUBGROUP	=> DI::l10n()->t('Public Group'),
-			Register::RESGROUP	=> DI::l10n()->t('Restricted Group'),
-			Register::PRIGROUP	=> DI::l10n()->t('Private Group')
+			User::PERSONAL	=> DI::l10n()->t('Personal (standard account)'),
+			User::SOAPBOX	=> DI::l10n()->t('Soap-Box (auto-approve Follow requests)'),
+			User::LOVEALL	=> DI::l10n()->t('Love-All (auto-approve Friend requests)'),
+			User::ORGPAGE	=> DI::l10n()->t('Organization Page'),
+			User::NEWSPAGE	=> DI::l10n()->t('News Page'),
+			User::PUBGROUP	=> DI::l10n()->t('Public Group'),
+			User::RESGROUP	=> DI::l10n()->t('Restricted Group'),
+			User::PRIGROUP	=> DI::l10n()->t('Private Group')
 		];
 		$selected = '';
 		/* get any URL params */	
 		$which_types = $_GET['type'] ?? '';
 		/* tailor options based on type param */		
 		if (!empty($which_types)){
-			if ($which_types == Register::PUBGROUP || $which_types == Register::RESGROUP || $which_types == Register::PRIGROUP){
+			if ($which_types == User::PUBGROUP || $which_types == User::RESGROUP || $which_types == User::PRIGROUP){
 				$acct_list = [
-					Register::PUBGROUP	=> DI::l10n()->t('Public Group'),
-					Register::RESGROUP	=> DI::l10n()->t('Restricted Group'),
-					Register::PRIGROUP	=> DI::l10n()->t('Private Group')				
+					User::PUBGROUP	=> DI::l10n()->t('Public Group'),
+					User::RESGROUP	=> DI::l10n()->t('Restricted Group'),
+					User::PRIGROUP	=> DI::l10n()->t('Private Group')				
 				];
-				$regbutton_label = DI::l10n()->t('Register Group');
+				$regbutton_label = DI::l10n()->t('Create Group');
 			}
-			if ($which_types == Register::ORGPAGE || $which_types == Register::NEWSPAGE){
+			if ($which_types == User::ORGPAGE || $which_types == User::NEWSPAGE){
 				$acct_list = [
-					Register::ORGPAGE	=> DI::l10n()->t('Organization Page'),
-					Register::NEWSPAGE	=> DI::l10n()->t('News Page'),				
+					User::ORGPAGE	=> DI::l10n()->t('Organization Page'),
+					User::NEWSPAGE	=> DI::l10n()->t('News Page'),				
 				];
-				$regbutton_label = DI::l10n()->t('Register Page');
+				$regbutton_label = DI::l10n()->t('Create Page');
 			}
-			if ($which_types == Register::PERSONAL || $which_types == Register::SOAPBOX || $which_types == Register::LOVEALL){
+			if ($which_types == User::PERSONAL || $which_types == User::SOAPBOX || $which_types == User::LOVEALL){
 				$acct_list = [
-					Register::PERSONAL	=> DI::l10n()->t('Personal (standard account)'),
-					Register::SOAPBOX	=> DI::l10n()->t('Personal Soap-Box (auto-approve Follow requests)'),
-					Register::LOVEALL	=> DI::l10n()->t('Personal Love-All (auto-approve Friend requests)'),	
+					User::PERSONAL	=> DI::l10n()->t('Personal (standard account)'),
+					User::SOAPBOX	=> DI::l10n()->t('Personal Soap-Box (auto-approve Follow requests)'),
+					User::LOVEALL	=> DI::l10n()->t('Personal Love-All (auto-approve Friend requests)'),	
 				];				
 			}
 			/* select the option (if it is not valid it just won't select anything) */
@@ -399,45 +390,45 @@ class Register extends BaseModule
 		if ($additional_account) {
 			if (!empty($arr['register_type'])){
 				switch($arr['register_type']){
-					case Register::PERSONAL:
-						$acct_type = 0;
-						$acct_flag = 0;
+					case User::PERSONAL:
+						$acct_type = User::ACCOUNT_TYPE_PERSON;
+						$acct_flag = User::PAGE_FLAGS_NORMAL;
 						break;
-					case Register::SOAPBOX:
-						$acct_type = 0;
-						$acct_flag = 1;
+					case User::SOAPBOX:
+						$acct_type = User::ACCOUNT_TYPE_PERSON;
+						$acct_flag = User::PAGE_FLAGS_SOAPBOX;
 						break;
-					case Register::LOVEALL:
-						$acct_type = 0;
-						$acct_flag = 3;
+					case User::LOVEALL:
+						$acct_type = User::ACCOUNT_TYPE_PERSON;
+						$acct_flag = User::PAGE_FLAGS_FREELOVE;
 						break;
-					case Register::ORGPAGE:
-						$acct_type = 1;
-						$acct_flag = 1;
+					case User::ORGPAGE:
+						$acct_type = User::ACCOUNT_TYPE_ORGANISATION;
+						$acct_flag = User::PAGE_FLAGS_SOAPBOX;
 						break;
-					case Register::NEWSPAGE:
-						$acct_type = 2;
-						$acct_flag = 1;
+					case User::NEWSPAGE:
+						$acct_type = User::ACCOUNT_TYPE_NEWS;
+						$acct_flag = User::PAGE_FLAGS_SOAPBOX;
 						break;
-					case Register::PUBGROUP:
-						$acct_type = 3;
-						$acct_flag = 2;
+					case User::PUBGROUP:
+						$acct_type = User::ACCOUNT_TYPE_COMMUNITY;
+						$acct_flag = User::PAGE_FLAGS_COMMUNITY;
 						break;
-					case Register::RESGROUP:
-						$acct_type = 3;
-						$acct_flag = 6;
+					case User::RESGROUP:
+						$acct_type = User::ACCOUNT_TYPE_COMMUNITY;
+						$acct_flag = User::PAGE_FLAGS_COMM_MAN;
 						break;
-					case Register::PRIGROUP:
-						$acct_type = 3;
-						$acct_flag = 5;
+					case User::PRIGROUP:
+						$acct_type = User::ACCOUNT_TYPE_COMMUNITY;
+						$acct_flag = User::PAGE_FLAGS_PRVGROUP;
 						break;
 					default:
-						$acct_type = 0;
-						$acct_flag = 0;
+						$acct_type = User::ACCOUNT_TYPE_PERSON;
+						$acct_flag = User::PAGE_FLAGS_NORMAL;
 				};
 			} else {
-				$acct_type = 0;
-				$acct_flag = 0;
+				$acct_type = User::ACCOUNT_TYPE_PERSON;
+				$acct_flag = User::PAGE_FLAGS_NORMAL;
 			}
 			
 			DBA::update('user', ['parent-uid' => DI::userSession()->getLocalUserId(), 'account-type' => $acct_type, 'page-flags' => $acct_flag], ['uid' => $user['uid']]);

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -145,6 +145,8 @@ class Register extends BaseModule
 			]);
 		}
 
+		$regbutton_label = DI::l10n()->t('Register Account');
+
 		/* ACCOUNT TYPE SELECT */
 		$acct_list = [	// value => label
 			Register::PERSONAL	=> DI::l10n()->t('Personal (standard account)'),
@@ -167,12 +169,14 @@ class Register extends BaseModule
 					Register::RESGROUP	=> DI::l10n()->t('Restricted Group'),
 					Register::PRIGROUP	=> DI::l10n()->t('Private Group')				
 				];
+				$regbutton_label = DI::l10n()->t('Register Group');
 			}
 			if ($which_types == Register::ORGPAGE || $which_types == Register::NEWSPAGE){
 				$acct_list = [
 					Register::ORGPAGE	=> DI::l10n()->t('Organization Page'),
 					Register::NEWSPAGE	=> DI::l10n()->t('News Page'),				
 				];
+				$regbutton_label = DI::l10n()->t('Register Page');
 			}
 			if ($which_types == Register::PERSONAL || $which_types == Register::SOAPBOX || $which_types == Register::LOVEALL){
 				$acct_list = [
@@ -234,7 +238,7 @@ class Register extends BaseModule
 			'$nicklabel'             => DI::l10n()->t('Choose a nickname: '),
 			'$photo'                 => $photo,
 			'$publish'               => $profile_publish,
-			'$regbutt'               => DI::l10n()->t('Register'),
+			'$regbutt'               => $regbutton_label,
 			'$username'              => $username,
 			'$email'                 => $email,
 			'$nickname'              => $nickname,

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -35,7 +35,16 @@ class Register extends BaseModule
 	const CLOSED  = 0;
 	const APPROVE = 1;
 	const OPEN    = 2;
-
+	/** account types for drop-down **/
+	const PERSONAL = "personal";
+	const SOAPBOX  = "soapbox";
+	const LOVEALL  = "loveall";
+	const ORGPAGE  = "page";
+	const NEWSPAGE = "newspage";
+	const PUBGROUP = "group";
+	const RESGROUP = "group-restricted";
+	const PRIGROUP = "group-private";
+	
 	/** @var Tos */
 	protected $tos;
 
@@ -109,6 +118,8 @@ class Register extends BaseModule
 		$nickname   = $_REQUEST['nickname']   ?? '';
 		$photo      = $_REQUEST['photo']      ?? '';
 		$invite_id  = $_REQUEST['invite_id']  ?? '';
+		
+		$which_types = $_GET['type'] ?? '';
 
 		if (DI::userSession()->getLocalUserId() || DI::config()->get('system', 'no_openid')) {
 			$fillwith = '';
@@ -133,6 +144,54 @@ class Register extends BaseModule
 				'$str_no'       => DI::l10n()->t('No'),
 			]);
 		}
+
+		/* ACCOUNT TYPE SELECT */
+		$acct_list = [	// value => label
+			Register::PERSONAL	=> DI::l10n()->t('Personal (standard account)'),
+			Register::SOAPBOX	=> DI::l10n()->t('Soap-Box (auto-approve Follow requests)'),
+			Register::LOVEALL	=> DI::l10n()->t('Love-All (auto-approve Friend requests)'),
+			Register::ORGPAGE	=> DI::l10n()->t('Organization Page'),
+			Register::NEWSPAGE	=> DI::l10n()->t('News Page'),
+			Register::PUBGROUP	=> DI::l10n()->t('Public Group'),
+			Register::RESGROUP	=> DI::l10n()->t('Restricted Group'),
+			Register::PRIGROUP	=> DI::l10n()->t('Private Group')
+		];
+		$selected = '';
+		/* get any URL params */	
+		$which_types = $_GET['type'] ?? '';
+		/* tailor options based on type param */		
+		if (!empty($which_types)){
+			if ($which_types == Register::PUBGROUP || $which_types == Register::RESGROUP || $which_type == Register::PRIGROUP){
+				$acct_list = [
+					Register::PUBGROUP	=> DI::l10n()->t('Public Group'),
+					Register::RESGROUP	=> DI::l10n()->t('Restricted Group'),
+					Register::PRIGROUP	=> DI::l10n()->t('Private Group')				
+				];
+			}
+			if ($which_types == Register::ORGPAGE || $which_types == Register::NEWSPAGE){
+				$acct_list = [
+					Register::ORGPAGE	=> DI::l10n()->t('Organization Page'),
+					Register::NEWSPAGE	=> DI::l10n()->t('News Page'),				
+				];
+			}
+			if ($which_types == Register::PERSONAL || $which_types == Register::SOAPBOX || $which_types == Register::LOVEALL){
+				$acct_list = [
+					Register::PERSONAL	=> DI::l10n()->t('Personal (standard account)'),
+					Register::SOAPBOX	=> DI::l10n()->t('Personal Soap-Box (auto-approve Follow requests)'),
+					Register::LOVEALL	=> DI::l10n()->t('Personal Love-All (auto-approve Friend requests)'),	
+				];				
+			}
+			/* select the option (if it is not valid it just won't select anything) */
+			$selected = $which_types;
+		}
+		/* build Select array */
+		$acct_type = [
+			'0'	=> 'register_type', // id
+			'1'	=> DI::l10n()->t('Account type:'),	//label
+			'2'	=> $selected,
+			'3'	=> DI::l10n()->t('You can change the account type later. (<a href="'.DI::baseUrl().'/help/user/accounts-groups-pages" target="_blank">Account type help</a>)'), // tip
+			'4'	=> $acct_list
+		];
 
 		$ask_password = !DBA::count('contact');
 
@@ -190,7 +249,8 @@ class Register extends BaseModule
 			'$explicit_content'      => DI::config()->get('system', 'explicit_content', false),
 			'$explicit_content_note' => DI::l10n()->t('Note: This node explicitly contains adult content'),
 			'$additional'            => !empty(DI::userSession()->getLocalUserId()),
-			'$parent_password'       => ['parent_password', DI::l10n()->t('Parent Password:'), '', DI::l10n()->t('Please enter the password of the parent account to legitimize your request.')]
+			'$parent_password'       => ['parent_password', DI::l10n()->t('Parent Password:'), '', DI::l10n()->t('Please enter the password of the parent account to legitimize your request.')],
+			'$acct_type'             => $acct_type
 
 		]);
 
@@ -333,7 +393,50 @@ class Register extends BaseModule
 		}
 
 		if ($additional_account) {
-			DBA::update('user', ['parent-uid' => DI::userSession()->getLocalUserId()], ['uid' => $user['uid']]);
+			if (!empty($arr['register_type'])){
+				switch($arr['register_type']){
+					case Register::PERSONAL:
+						$acct_type = 0;
+						$acct_flag = 0;
+						break;
+					case Register::SOAPBOX:
+						$acct_type = 0;
+						$acct_flag = 1;
+						break;
+					case Register::LOVEALL:
+						$acct_type = 0;
+						$acct_flag = 3;
+						break;
+					case Register::ORGPAGE:
+						$acct_type = 1;
+						$acct_flag = 1;
+						break;
+					case Register::NEWSPAGE:
+						$acct_type = 2;
+						$acct_flag = 1;
+						break;
+					case Register::PUBGROUP:
+						$acct_type = 3;
+						$acct_flag = 2;
+						break;
+					case Register::RESGROUP:
+						$acct_type = 3;
+						$acct_flag = 6;
+						break;
+					case Register::PRIGROUP:
+						$acct_type = 3;
+						$acct_flag = 5;
+						break;
+					default:
+						$acct_type = 0;
+						$acct_flag = 0;
+				};
+			} else {
+				$acct_type = 0;
+				$acct_flag = 0;
+			}
+			
+			DBA::update('user', ['parent-uid' => DI::userSession()->getLocalUserId(), 'account-type' => $acct_type, 'page-flags' => $acct_flag], ['uid' => $user['uid']]);
 			DI::sysmsg()->addInfo(DI::l10n()->t('The additional account was created.'));
 			DI::baseUrl()->redirect('delegation');
 		}

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -35,7 +35,7 @@ class Register extends BaseModule
 	const CLOSED  = 0;
 	const APPROVE = 1;
 	const OPEN    = 2;
-	
+
 	/** @var Tos */
 	protected $tos;
 
@@ -109,7 +109,7 @@ class Register extends BaseModule
 		$nickname   = $_REQUEST['nickname']   ?? '';
 		$photo      = $_REQUEST['photo']      ?? '';
 		$invite_id  = $_REQUEST['invite_id']  ?? '';
-		
+
 		$which_types = $_GET['type'] ?? '';
 
 		if (DI::userSession()->getLocalUserId() || DI::config()->get('system', 'no_openid')) {
@@ -150,22 +150,22 @@ class Register extends BaseModule
 			User::PRIGROUP	=> DI::l10n()->t('Private Group')
 		];
 		$selected = '';
-		/* get any URL params */	
+		/* get any URL params */
 		$which_types = $_GET['type'] ?? '';
-		/* tailor options based on type param */		
+		/* tailor options based on type param */
 		if (!empty($which_types)){
 			if ($which_types == User::PUBGROUP || $which_types == User::RESGROUP || $which_types == User::PRIGROUP){
 				$acct_list = [
 					User::PUBGROUP	=> DI::l10n()->t('Public Group'),
 					User::RESGROUP	=> DI::l10n()->t('Restricted Group'),
-					User::PRIGROUP	=> DI::l10n()->t('Private Group')				
+					User::PRIGROUP	=> DI::l10n()->t('Private Group')
 				];
 				$regbutton_label = DI::l10n()->t('Create Group');
 			}
 			if ($which_types == User::ORGPAGE || $which_types == User::NEWSPAGE){
 				$acct_list = [
 					User::ORGPAGE	=> DI::l10n()->t('Organization Page'),
-					User::NEWSPAGE	=> DI::l10n()->t('News Page'),				
+					User::NEWSPAGE	=> DI::l10n()->t('News Page'),
 				];
 				$regbutton_label = DI::l10n()->t('Create Page');
 			}
@@ -173,19 +173,19 @@ class Register extends BaseModule
 				$acct_list = [
 					User::PERSONAL	=> DI::l10n()->t('Personal (standard account)'),
 					User::SOAPBOX	=> DI::l10n()->t('Personal Soap-Box (auto-approve Follow requests)'),
-					User::LOVEALL	=> DI::l10n()->t('Personal Love-All (auto-approve Friend requests)'),	
-				];				
+					User::LOVEALL	=> DI::l10n()->t('Personal Love-All (auto-approve Friend requests)'),
+				];
 			}
 			/* select the option (if it is not valid it just won't select anything) */
 			$selected = $which_types;
 		}
 		/* build Select array */
 		$acct_type = [
-			'0'	=> 'register_type', // id
-			'1'	=> DI::l10n()->t('Account type:'),	//label
-			'2'	=> $selected,
-			'3'	=> DI::l10n()->t('You can change the account type later. (<a href="'.DI::baseUrl().'/help/user/accounts-groups-pages" target="_blank">Account type help</a>)'), // tip
-			'4'	=> $acct_list
+			'register_type', // id
+			DI::l10n()->t('Account type:'),	//label
+			$selected,
+			DI::l10n()->t('You can change the account type later. (<a href="' . DI::baseUrl() . '/help/user/accounts-groups-pages" target="_blank">Account type help</a>)'), // tip
+			$acct_list,
 		];
 
 		$ask_password = !DBA::count('contact');
@@ -430,7 +430,7 @@ class Register extends BaseModule
 				$acct_type = User::ACCOUNT_TYPE_PERSON;
 				$acct_flag = User::PAGE_FLAGS_NORMAL;
 			}
-			
+
 			DBA::update('user', ['parent-uid' => DI::userSession()->getLocalUserId(), 'account-type' => $acct_type, 'page-flags' => $acct_flag], ['uid' => $user['uid']]);
 			DI::sysmsg()->addInfo(DI::l10n()->t('The additional account was created.'));
 			DI::baseUrl()->redirect('delegation');

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -163,7 +163,7 @@ class Register extends BaseModule
 		$which_types = $_GET['type'] ?? '';
 		/* tailor options based on type param */		
 		if (!empty($which_types)){
-			if ($which_types == Register::PUBGROUP || $which_types == Register::RESGROUP || $which_type == Register::PRIGROUP){
+			if ($which_types == Register::PUBGROUP || $which_types == Register::RESGROUP || $which_types == Register::PRIGROUP){
 				$acct_list = [
 					Register::PUBGROUP	=> DI::l10n()->t('Public Group'),
 					Register::RESGROUP	=> DI::l10n()->t('Restricted Group'),

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -32,9 +32,9 @@ use Psr\Log\LoggerInterface;
  */
 class Register extends BaseModule
 {
-	const CLOSED  = 0;
-	const APPROVE = 1;
-	const OPEN    = 2;
+	public const CLOSED  = 0;
+	public const APPROVE = 1;
+	public const OPEN    = 2;
 
 	/** @var Tos */
 	protected $tos;
@@ -140,40 +140,40 @@ class Register extends BaseModule
 
 		/* ACCOUNT TYPE SELECT */
 		$acct_list = [	// value => label
-			User::PERSONAL	=> DI::l10n()->t('Personal (standard account)'),
-			User::SOAPBOX	=> DI::l10n()->t('Soap-Box (auto-approve Follow requests)'),
-			User::LOVEALL	=> DI::l10n()->t('Love-All (auto-approve Friend requests)'),
-			User::ORGPAGE	=> DI::l10n()->t('Organization Page'),
-			User::NEWSPAGE	=> DI::l10n()->t('News Page'),
-			User::PUBGROUP	=> DI::l10n()->t('Public Group'),
-			User::RESGROUP	=> DI::l10n()->t('Restricted Group'),
-			User::PRIGROUP	=> DI::l10n()->t('Private Group')
+			User::PERSONAL => DI::l10n()->t('Personal (standard account)'),
+			User::SOAPBOX  => DI::l10n()->t('Soap-Box (auto-approve Follow requests)'),
+			User::LOVEALL  => DI::l10n()->t('Love-All (auto-approve Friend requests)'),
+			User::ORGPAGE  => DI::l10n()->t('Organization Page'),
+			User::NEWSPAGE => DI::l10n()->t('News Page'),
+			User::PUBGROUP => DI::l10n()->t('Public Group'),
+			User::RESGROUP => DI::l10n()->t('Restricted Group'),
+			User::PRIGROUP => DI::l10n()->t('Private Group'),
 		];
 		$selected = '';
 		/* get any URL params */
 		$which_types = $_GET['type'] ?? '';
 		/* tailor options based on type param */
-		if (!empty($which_types)){
-			if ($which_types == User::PUBGROUP || $which_types == User::RESGROUP || $which_types == User::PRIGROUP){
+		if (!empty($which_types)) {
+			if ($which_types == User::PUBGROUP || $which_types == User::RESGROUP || $which_types == User::PRIGROUP) {
 				$acct_list = [
-					User::PUBGROUP	=> DI::l10n()->t('Public Group'),
-					User::RESGROUP	=> DI::l10n()->t('Restricted Group'),
-					User::PRIGROUP	=> DI::l10n()->t('Private Group')
+					User::PUBGROUP => DI::l10n()->t('Public Group'),
+					User::RESGROUP => DI::l10n()->t('Restricted Group'),
+					User::PRIGROUP => DI::l10n()->t('Private Group'),
 				];
 				$regbutton_label = DI::l10n()->t('Create Group');
 			}
-			if ($which_types == User::ORGPAGE || $which_types == User::NEWSPAGE){
+			if ($which_types == User::ORGPAGE || $which_types == User::NEWSPAGE) {
 				$acct_list = [
-					User::ORGPAGE	=> DI::l10n()->t('Organization Page'),
-					User::NEWSPAGE	=> DI::l10n()->t('News Page'),
+					User::ORGPAGE  => DI::l10n()->t('Organization Page'),
+					User::NEWSPAGE => DI::l10n()->t('News Page'),
 				];
 				$regbutton_label = DI::l10n()->t('Create Page');
 			}
-			if ($which_types == User::PERSONAL || $which_types == User::SOAPBOX || $which_types == User::LOVEALL){
+			if ($which_types == User::PERSONAL || $which_types == User::SOAPBOX || $which_types == User::LOVEALL) {
 				$acct_list = [
-					User::PERSONAL	=> DI::l10n()->t('Personal (standard account)'),
-					User::SOAPBOX	=> DI::l10n()->t('Personal Soap-Box (auto-approve Follow requests)'),
-					User::LOVEALL	=> DI::l10n()->t('Personal Love-All (auto-approve Friend requests)'),
+					User::PERSONAL => DI::l10n()->t('Personal (standard account)'),
+					User::SOAPBOX  => DI::l10n()->t('Personal Soap-Box (auto-approve Follow requests)'),
+					User::LOVEALL  => DI::l10n()->t('Personal Love-All (auto-approve Friend requests)'),
 				];
 			}
 			/* select the option (if it is not valid it just won't select anything) */
@@ -245,7 +245,7 @@ class Register extends BaseModule
 			'$explicit_content_note' => DI::l10n()->t('Note: This node explicitly contains adult content'),
 			'$additional'            => !empty(DI::userSession()->getLocalUserId()),
 			'$parent_password'       => ['parent_password', DI::l10n()->t('Parent Password:'), '', DI::l10n()->t('Please enter the password of the parent account to legitimize your request.')],
-			'$acct_type'             => $acct_type
+			'$acct_type'             => $acct_type,
 
 		]);
 
@@ -380,7 +380,7 @@ class Register extends BaseModule
 
 		$user = $result['user'];
 
-		$base_url = (string)DI::baseUrl();
+		$base_url = (string) DI::baseUrl();
 
 		if ($netpublish && self::getPolicy() !== self::APPROVE) {
 			$url = $base_url . '/profile/' . $user['nickname'];
@@ -388,8 +388,8 @@ class Register extends BaseModule
 		}
 
 		if ($additional_account) {
-			if (!empty($arr['register_type'])){
-				switch($arr['register_type']){
+			if (!empty($arr['register_type'])) {
+				switch ($arr['register_type']) {
 					case User::PERSONAL:
 						$acct_type = User::ACCOUNT_TYPE_PERSON;
 						$acct_flag = User::PAGE_FLAGS_NORMAL;
@@ -453,7 +453,7 @@ class Register extends BaseModule
 					$user,
 					DI::config()->get('config', 'sitename'),
 					$base_url,
-					$result['password']
+					$result['password'],
 				);
 
 				if ($res) {
@@ -467,8 +467,8 @@ class Register extends BaseModule
 						DI::l10n()->t(
 							'Failed to send email message. Here your accout details:<br> login: %s<br> password: %s<br><br>You can change your password after login.',
 							$user['email'],
-							$result['password']
-						)
+							$result['password'],
+						),
 					);
 				}
 			} else {
@@ -516,7 +516,7 @@ class Register extends BaseModule
 				$user,
 				DI::config()->get('config', 'sitename'),
 				$base_url,
-				$result['password']
+				$result['password'],
 			);
 
 			DI::sysmsg()->addInfo(DI::l10n()->t('Your registration is pending approval by the site owner.'));
@@ -537,7 +537,7 @@ class Register extends BaseModule
 				'source_nick'               => $user['nickname'],
 				'source_link'               => DI::baseUrl() . '/moderation/users/',
 				'source_photo'              => User::getAvatarUrl($user, Proxy::SIZE_THUMB),
-				'show_in_notification_page' => false
+				'show_in_notification_page' => false,
 			]);
 		}
 	}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-03 18:00+0000\n"
+"POT-Creation-Date: 2026-05-09 21:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,7 +63,7 @@ msgstr ""
 #: src/Module/Profile/Common.php:63 src/Module/Profile/Contacts.php:66
 #: src/Module/Profile/Photos.php:97 src/Module/Profile/Schedule.php:27
 #: src/Module/Profile/Schedule.php:44 src/Module/Register.php:74
-#: src/Module/Register.php:221 src/Module/Register.php:260
+#: src/Module/Register.php:276 src/Module/Register.php:315
 #: src/Module/Search/Directory.php:23 src/Module/Settings/Account.php:34
 #: src/Module/Settings/Account.php:337 src/Module/Settings/Channels.php:54
 #: src/Module/Settings/Channels.php:135
@@ -235,7 +235,7 @@ msgstr[1] ""
 #: src/Module/Profile/Contacts.php:52 src/Module/Profile/Contacts.php:60
 #: src/Module/Profile/Conversations.php:81 src/Module/Profile/Media.php:58
 #: src/Module/Profile/Photos.php:88 src/Module/Profile/RemoteFollow.php:57
-#: src/Module/Register.php:282
+#: src/Module/Register.php:337
 msgid "User not found."
 msgstr ""
 
@@ -590,7 +590,7 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:450 src/Content/Widget.php:265 src/Model/User.php:1409
+#: src/BaseModule.php:450 src/Content/Widget.php:265 src/Model/User.php:1428
 #: src/Module/Contact.php:405
 msgid "Friends"
 msgstr ""
@@ -749,7 +749,7 @@ msgstr ""
 msgid "Enter user nickname: "
 msgstr ""
 
-#: src/Console/User.php:168 src/Model/User.php:860
+#: src/Console/User.php:168 src/Model/User.php:879
 #: src/Module/Api/Twitter/ContactEndpoint.php:62
 #: src/Module/Moderation/Users/Active.php:136
 #: src/Module/Moderation/Users/Blocked.php:135
@@ -1551,7 +1551,7 @@ msgstr ""
 
 #: src/Content/Feature.php:128 src/Content/GroupManager.php:132
 #: src/Content/Nav.php:275 src/Content/Text/HTML.php:884
-#: src/Content/Widget.php:564 src/Model/User.php:1423
+#: src/Content/Widget.php:564 src/Model/User.php:1442
 msgid "Groups"
 msgstr ""
 
@@ -1884,12 +1884,11 @@ msgstr ""
 msgid "Home Page"
 msgstr ""
 
-#: src/Content/Nav.php:252 src/Module/Register.php:178
-#: src/Module/Security/Login.php:128
+#: src/Content/Nav.php:252 src/Module/Security/Login.php:128
 msgid "Register"
 msgstr ""
 
-#: src/Content/Nav.php:252 src/Module/Register.php:162
+#: src/Content/Nav.php:252 src/Module/Register.php:216
 #: src/Module/Security/Login.php:127
 msgid "Create an account"
 msgstr ""
@@ -1966,7 +1965,7 @@ msgid "Information about this friendica instance"
 msgstr ""
 
 #: src/Content/Nav.php:298 src/Module/Admin/Tos.php:64
-#: src/Module/BaseAdmin.php:80 src/Module/Register.php:186
+#: src/Module/BaseAdmin.php:80 src/Module/Register.php:240
 #: src/Module/Tos.php:87
 msgid "Terms of Service"
 msgstr ""
@@ -3445,135 +3444,135 @@ msgstr ""
 msgid "Responsible account: %s"
 msgstr ""
 
-#: src/Model/User.php:219 src/Model/User.php:1343
+#: src/Model/User.php:238 src/Model/User.php:1362
 msgid "SERIOUS ERROR: Generation of security keys failed."
 msgstr ""
 
-#: src/Model/User.php:762 src/Model/User.php:799
+#: src/Model/User.php:781 src/Model/User.php:818
 msgid "Login failed"
 msgstr ""
 
-#: src/Model/User.php:832
+#: src/Model/User.php:851
 msgid "Not enough information to authenticate"
 msgstr ""
 
-#: src/Model/User.php:959
+#: src/Model/User.php:978
 msgid "Password can't be empty"
 msgstr ""
 
-#: src/Model/User.php:1001
+#: src/Model/User.php:1020
 msgid "Empty passwords are not allowed."
 msgstr ""
 
-#: src/Model/User.php:1005
+#: src/Model/User.php:1024
 msgid "The new password has been exposed in a public data dump, please choose another."
 msgstr ""
 
-#: src/Model/User.php:1009
+#: src/Model/User.php:1028
 msgid "The password length is limited to 72 characters."
 msgstr ""
 
-#: src/Model/User.php:1013
+#: src/Model/User.php:1032
 msgid "The password can't contain white spaces nor accentuated letters"
 msgstr ""
 
-#: src/Model/User.php:1223
+#: src/Model/User.php:1242
 msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
-#: src/Model/User.php:1232
+#: src/Model/User.php:1251
 msgid "An invitation is required."
 msgstr ""
 
-#: src/Model/User.php:1236
+#: src/Model/User.php:1255
 msgid "Invitation could not be verified."
 msgstr ""
 
-#: src/Model/User.php:1244
+#: src/Model/User.php:1263
 msgid "Invalid OpenID url"
 msgstr ""
 
-#: src/Model/User.php:1258 src/Security/Authentication.php:235
+#: src/Model/User.php:1277 src/Security/Authentication.php:235
 msgid "We encountered a problem while logging in with the OpenID you provided. Please check the correct spelling of the ID."
 msgstr ""
 
-#: src/Model/User.php:1258 src/Security/Authentication.php:235
+#: src/Model/User.php:1277 src/Security/Authentication.php:235
 msgid "The error message was:"
 msgstr ""
 
-#: src/Model/User.php:1264
+#: src/Model/User.php:1283
 msgid "Please enter the required information."
 msgstr ""
 
-#: src/Model/User.php:1278
+#: src/Model/User.php:1297
 #, php-format
 msgid "system.username_min_length (%s) and system.username_max_length (%s) are excluding each other, swapping values."
 msgstr ""
 
-#: src/Model/User.php:1285
+#: src/Model/User.php:1304
 #, php-format
 msgid "Username should be at least %s character."
 msgid_plural "Username should be at least %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1289
+#: src/Model/User.php:1308
 #, php-format
 msgid "Username should be at most %s character."
 msgid_plural "Username should be at most %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1297
+#: src/Model/User.php:1316
 msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Model/User.php:1302
+#: src/Model/User.php:1321
 msgid "Your email domain is not among those allowed on this site."
 msgstr ""
 
-#: src/Model/User.php:1306
+#: src/Model/User.php:1325
 msgid "Not a valid email address."
 msgstr ""
 
-#: src/Model/User.php:1309
+#: src/Model/User.php:1328
 msgid "The nickname was blocked from registration by the nodes admin."
 msgstr ""
 
-#: src/Model/User.php:1313 src/Model/User.php:1319
+#: src/Model/User.php:1332 src/Model/User.php:1338
 #: src/Module/User/Import.php:231
 msgid "Cannot use that email."
 msgstr ""
 
-#: src/Model/User.php:1325
+#: src/Model/User.php:1344
 msgid "Your nickname can only contain a-z, 0-9 and _."
 msgstr ""
 
-#: src/Model/User.php:1333 src/Model/User.php:1383
+#: src/Model/User.php:1352 src/Model/User.php:1402
 msgid "Nickname is already registered. Please choose another."
 msgstr ""
 
-#: src/Model/User.php:1370 src/Model/User.php:1374
+#: src/Model/User.php:1389 src/Model/User.php:1393
 msgid "An error occurred during registration. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1397
+#: src/Model/User.php:1416
 msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1404
+#: src/Model/User.php:1423
 msgid "An error occurred creating your self contact. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1413
+#: src/Model/User.php:1432
 msgid "An error occurred creating your default contact circle. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1461
+#: src/Model/User.php:1480
 msgid "Profile Photos"
 msgstr ""
 
-#: src/Model/User.php:1659
+#: src/Model/User.php:1678
 #, php-format
 msgid ""
 "\n"
@@ -3581,7 +3580,7 @@ msgid ""
 "\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: src/Model/User.php:1662
+#: src/Model/User.php:1681
 #, php-format
 msgid ""
 "\n"
@@ -3612,12 +3611,12 @@ msgid ""
 "\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: src/Model/User.php:1694 src/Model/User.php:1800
+#: src/Model/User.php:1713 src/Model/User.php:1819
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
-#: src/Model/User.php:1714
+#: src/Model/User.php:1733
 #, php-format
 msgid ""
 "\n"
@@ -3632,12 +3631,12 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:1733
+#: src/Model/User.php:1752
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: src/Model/User.php:1757
+#: src/Model/User.php:1776
 #, php-format
 msgid ""
 "\n"
@@ -3646,7 +3645,7 @@ msgid ""
 "\t\t\t"
 msgstr ""
 
-#: src/Model/User.php:1765
+#: src/Model/User.php:1784
 #, php-format
 msgid ""
 "\n"
@@ -3677,7 +3676,7 @@ msgid ""
 "\t\t\tThank you and welcome to %2$s."
 msgstr ""
 
-#: src/Model/User.php:1827
+#: src/Model/User.php:1846
 msgid "User with delegates can't be removed, please remove delegate users first"
 msgstr ""
 
@@ -3829,14 +3828,14 @@ msgstr ""
 
 #: src/Module/Admin/Features.php:53
 #: src/Module/Notifications/Introductions.php:140
-#: src/Module/OAuth/Acknowledge.php:41 src/Module/Register.php:133
+#: src/Module/OAuth/Acknowledge.php:41 src/Module/Register.php:135
 #: src/Module/Settings/TwoFactor/Trusted.php:115
 msgid "No"
 msgstr ""
 
 #: src/Module/Admin/Features.php:53 src/Module/Contact/Revoke.php:91
 #: src/Module/Notifications/Introductions.php:140
-#: src/Module/OAuth/Acknowledge.php:40 src/Module/Register.php:132
+#: src/Module/OAuth/Acknowledge.php:40 src/Module/Register.php:134
 #: src/Module/Settings/TwoFactor/Trusted.php:115
 msgid "Yes"
 msgstr ""
@@ -5752,7 +5751,7 @@ msgstr ""
 #: src/Module/Moderation/Blocklist/Server/Index.php:76
 #: src/Module/Moderation/Blocklist/Server/Index.php:104
 #: src/Module/Moderation/Blocklist/Server/Index.php:105
-#: src/Module/Moderation/Item/Delete.php:53 src/Module/Register.php:158
+#: src/Module/Moderation/Item/Delete.php:53 src/Module/Register.php:212
 #: src/Module/Security/TwoFactor/Verify.php:87
 #: src/Module/Settings/Channels.php:184 src/Module/Settings/Channels.php:210
 #: src/Module/Settings/TwoFactor/Index.php:147
@@ -7374,7 +7373,8 @@ msgstr ""
 msgid "Soapbox Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:140 src/Module/Settings/Account.php:445
+#: src/Module/Moderation/BaseUsers.php:140 src/Module/Register.php:148
+#: src/Module/Register.php:159 src/Module/Settings/Account.php:445
 msgid "Public Group"
 msgstr ""
 
@@ -7386,7 +7386,8 @@ msgstr ""
 msgid "Automatic Friend Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:143
+#: src/Module/Moderation/BaseUsers.php:143 src/Module/Register.php:150
+#: src/Module/Register.php:161
 msgid "Private Group"
 msgstr ""
 
@@ -7401,6 +7402,7 @@ msgid "Organisation Page"
 msgstr ""
 
 #: src/Module/Moderation/BaseUsers.php:148 src/Module/Moderation/Summary.php:44
+#: src/Module/Register.php:147 src/Module/Register.php:168
 #: src/Module/Settings/Account.php:416
 msgid "News Page"
 msgstr ""
@@ -8774,148 +8776,196 @@ msgstr ""
 msgid "This site has exceeded the number of allowed daily account registrations. Please try again tomorrow."
 msgstr ""
 
-#: src/Module/Register.php:118
+#: src/Module/Register.php:120
 msgid "You may (optionally) fill in this form via OpenID by supplying your OpenID and clicking \"Register\"."
 msgstr ""
 
-#: src/Module/Register.php:119
+#: src/Module/Register.php:121
 msgid "If you are not familiar with OpenID, please leave that field blank and fill in the rest of the items."
 msgstr ""
 
-#: src/Module/Register.php:120
+#: src/Module/Register.php:122
 msgid "Your OpenID (optional): "
 msgstr ""
 
-#: src/Module/Register.php:129
+#: src/Module/Register.php:131
 msgid "Include your profile in member directory?"
 msgstr ""
 
-#: src/Module/Register.php:158
-msgid "Note for the admin"
+#: src/Module/Register.php:139
+msgid "Create Account"
 msgstr ""
 
-#: src/Module/Register.php:158
-msgid "Leave a message for the admin, why you want to join this node"
+#: src/Module/Register.php:143 src/Module/Register.php:174
+msgid "Personal (standard account)"
 msgstr ""
 
-#: src/Module/Register.php:159
-msgid "Membership on this site is by invitation only."
+#: src/Module/Register.php:144
+msgid "Soap-Box (auto-approve Follow requests)"
 msgstr ""
 
-#: src/Module/Register.php:160
-msgid "Your invitation code: "
+#: src/Module/Register.php:145
+msgid "Love-All (auto-approve Friend requests)"
 msgstr ""
 
-#: src/Module/Register.php:168
-msgid "Your Display Name (as you would like it to be displayed on this system):"
+#: src/Module/Register.php:146 src/Module/Register.php:167
+msgid "Organization Page"
 msgstr ""
 
-#: src/Module/Register.php:169
-msgid "Your Email Address (initial information will be sent there, so this must be a valid address):"
+#: src/Module/Register.php:149 src/Module/Register.php:160
+msgid "Restricted Group"
+msgstr ""
+
+#: src/Module/Register.php:163
+msgid "Create Group"
 msgstr ""
 
 #: src/Module/Register.php:170
+msgid "Create Page"
+msgstr ""
+
+#: src/Module/Register.php:175
+msgid "Personal Soap-Box (auto-approve Follow requests)"
+msgstr ""
+
+#: src/Module/Register.php:176
+msgid "Personal Love-All (auto-approve Friend requests)"
+msgstr ""
+
+#: src/Module/Register.php:185
+msgid "Account type:"
+msgstr ""
+
+#: src/Module/Register.php:187
+msgid "You can change the account type later. (<a href=\""
+msgstr ""
+
+#: src/Module/Register.php:212
+msgid "Note for the admin"
+msgstr ""
+
+#: src/Module/Register.php:212
+msgid "Leave a message for the admin, why you want to join this node"
+msgstr ""
+
+#: src/Module/Register.php:213
+msgid "Membership on this site is by invitation only."
+msgstr ""
+
+#: src/Module/Register.php:214
+msgid "Your invitation code: "
+msgstr ""
+
+#: src/Module/Register.php:222
+msgid "Your Display Name (as you would like it to be displayed on this system):"
+msgstr ""
+
+#: src/Module/Register.php:223
+msgid "Your Email Address (initial information will be sent there, so this must be a valid address):"
+msgstr ""
+
+#: src/Module/Register.php:224
 msgid "Please repeat your e-mail address:"
 msgstr ""
 
-#: src/Module/Register.php:172 src/Module/Security/PasswordTooLong.php:86
+#: src/Module/Register.php:226 src/Module/Security/PasswordTooLong.php:86
 #: src/Module/Settings/Account.php:513
 msgid "New Password:"
 msgstr ""
 
-#: src/Module/Register.php:172
+#: src/Module/Register.php:226
 msgid "Leave empty for an auto generated password."
 msgstr ""
 
-#: src/Module/Register.php:173 src/Module/Security/PasswordTooLong.php:87
+#: src/Module/Register.php:227 src/Module/Security/PasswordTooLong.php:87
 #: src/Module/Settings/Account.php:514
 msgid "Confirm:"
 msgstr ""
 
-#: src/Module/Register.php:174
+#: src/Module/Register.php:228
 #, php-format
 msgid "Choose a profile nickname. This must begin with a text character. Your profile address on this site will then be \"<strong>nickname@%s</strong>\"."
 msgstr ""
 
-#: src/Module/Register.php:175
+#: src/Module/Register.php:229
 msgid "Choose a nickname: "
 msgstr ""
 
-#: src/Module/Register.php:183 src/Module/User/Import.php:106
+#: src/Module/Register.php:237 src/Module/User/Import.php:106
 msgid "Import"
 msgstr ""
 
-#: src/Module/Register.php:184
+#: src/Module/Register.php:238
 msgid "Import your profile to this friendica instance"
 msgstr ""
 
-#: src/Module/Register.php:191
+#: src/Module/Register.php:245
 msgid "Note: This node explicitly contains adult content"
 msgstr ""
 
-#: src/Module/Register.php:193 src/Module/Settings/Delegation.php:167
+#: src/Module/Register.php:247 src/Module/Settings/Delegation.php:167
 msgid "Parent Password:"
 msgstr ""
 
-#: src/Module/Register.php:193 src/Module/Settings/Delegation.php:167
+#: src/Module/Register.php:247 src/Module/Settings/Delegation.php:167
 msgid "Please enter the password of the parent account to legitimize your request."
 msgstr ""
 
-#: src/Module/Register.php:227
+#: src/Module/Register.php:282
 msgid "Password doesn't match."
 msgstr ""
 
-#: src/Module/Register.php:233
+#: src/Module/Register.php:288
 msgid "Please enter your password."
 msgstr ""
 
-#: src/Module/Register.php:275
+#: src/Module/Register.php:330
 msgid "You have entered too much information."
 msgstr ""
 
-#: src/Module/Register.php:298
+#: src/Module/Register.php:353
 msgid "Please enter the identical mail address in the second field."
 msgstr ""
 
-#: src/Module/Register.php:306
+#: src/Module/Register.php:361
 msgid "Nickname cannot start with a digit."
 msgstr ""
 
-#: src/Module/Register.php:308
+#: src/Module/Register.php:363
 msgid "Nickname can only contain US-ASCII characters."
 msgstr ""
 
-#: src/Module/Register.php:337
+#: src/Module/Register.php:435
 msgid "The additional account was created."
 msgstr ""
 
-#: src/Module/Register.php:362
+#: src/Module/Register.php:460
 msgid "Registration successful. Please check your email for further instructions."
 msgstr ""
 
-#: src/Module/Register.php:370
+#: src/Module/Register.php:468
 #, php-format
 msgid "Failed to send email message. Here your accout details:<br> login: %s<br> password: %s<br><br>You can change your password after login."
 msgstr ""
 
-#: src/Module/Register.php:377
+#: src/Module/Register.php:475
 msgid "Registration successful."
 msgstr ""
 
-#: src/Module/Register.php:386 src/Module/Register.php:393
-#: src/Module/Register.php:403
+#: src/Module/Register.php:484 src/Module/Register.php:491
+#: src/Module/Register.php:501
 msgid "Your registration can not be processed."
 msgstr ""
 
-#: src/Module/Register.php:392
+#: src/Module/Register.php:490
 msgid "You have to leave a request note for the admin."
 msgstr ""
 
-#: src/Module/Register.php:402
+#: src/Module/Register.php:500
 msgid "An internal error occured."
 msgstr ""
 
-#: src/Module/Register.php:424
+#: src/Module/Register.php:522
 msgid "Your registration is pending approval by the site owner."
 msgstr ""
 

--- a/view/templates/register.tpl
+++ b/view/templates/register.tpl
@@ -79,6 +79,11 @@
 	<input type="input" id=tarpit" name="email" style="display: none;" placeholder="Don't enter anything here"/>
 
 	{{if $additional}}
+		<div id="register-type-wrapper" class="form-group">
+			{{include file="field_select.tpl" field=$acct_type}}
+		</div>
+		<div id="register-type-end"></div>	
+		{{assign var="label" value="true"}}
 		{{include file="field_password.tpl" field=$parent_password}}
 	{{/if}}
 

--- a/view/templates/settings/delegation.tpl
+++ b/view/templates/settings/delegation.tpl
@@ -10,7 +10,7 @@
 {{if !$is_child_user}}
 	<h3>{{$l10n.account_header}}</h3>
 	<div id="add-account-desc" class="add-account-desc"><p>{{$l10n.account_desc}}</p></div>
-	<p><a href="register">{{$l10n.add_account}}</a></p>
+	<p><a class="btn btn-default" href="register">{{$l10n.add_account}}</a></p>
 {{/if}}
 
 {{if $parent_user}}

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3694,8 +3694,7 @@ li.addon {
 #profile-publish-wrapper {
 	margin-top: 20px;
 }
-#register-openid-end,
-#register-nickname-end {
+#register-openid-end {
 	margin-top: 40px;
 }
 

--- a/view/theme/frio/templates/register.tpl
+++ b/view/theme/frio/templates/register.tpl
@@ -76,6 +76,11 @@
 		<div id="register-nickname-end"></div>
 
 		{{if $additional}}
+			<div id="register-type-wrapper" class="form-group">
+				{{include file="field_select.tpl" field=$acct_type}}
+			</div>
+			<div id="register-type-end"></div>	
+			{{assign var="label" value="true"}}
 			{{include file="field_password.tpl" field=$parent_password}}
 		{{/if}}
 


### PR DESCRIPTION

<img width="690" height="767" alt="add_account_type" src="https://github.com/user-attachments/assets/cc121f17-e5c1-4887-b4a8-f49d569873c1" />
<img width="690" height="767" alt="acct_type_drop_list" src="https://github.com/user-attachments/assets/456b5497-390a-47bc-b8d5-7c7940170bae" />


PROBLEM: New users have heard you can create Groups and Pages on Friendica but it isn't very clear _how_ to do that.

Current flow to create a Group or Page:
1. Go to **Main Menu > Settings**
2. Select **Settings > Manage Accounts**
3. Click "Register an additional account" link that is not very prominent.
-or- click on the "Create new group" link on the Groups Widget to get to the form directly
5. Fill out Register form for new account and submit it.
6. On _/delegation_ page Switch to new account.
7. Go to **Main Menu > Settings**
8. Select **Settings > Account**
9. Select "Advanced Account Types" section
10. Change Account Type to one of the "Group" or "Page" options.
11. Post Group/Page content.

New Flow:
1. Click the "Create a new group" link on the Groups Widget or "Create a new page" link on the Pages Widget in the sidebar,
-or- follow a link ending in /register/?type=group or /register/?type=page
-or- do steps 1-3 above
2. Fill out the form, selecting a Group/Page sub-type if desired, and submit it.
3. On /delegation page Switch to the new account to post Group/Page content.

Note: Once you've created at least one additional account then you can use **Main Menu > Accounts** to get to the _/delegation_ page where you can switch accounts.

What this PR does:
* Adds the "Account Type" drop-down list to the Register form for additional accounts
* Customizes and auto-selects the options in the drop-down based on URL parameters
* Customizes the Register form submit button based on URL parameters
* Modifies the Group Widget link with URL parameter
* Restyles the "Register additional account" link on /delegation page to look like a button.

Note that currently the submit button of the Register form says "Sign Up Now >>" because it is getting changed by `DI::l10n()->t('Register');` in Register.php, but now it will be either "Register Account," "Register Group," or "Register Page" depending on whether there are URL params.

The "Pages Widget" does not exist yet. I will be submitting that as a separate PR. My Bookface scheme for Frio will also be updated to accommodate these PRs.

_(I expect like every PR that I've submitting this will fail the automatic checks, some of which I can't do anything about because there is no apparent way to do so through GitHub's web UI and I do not know how to use the CLI)_