### PR TITLE
Disable Multiviews in Apache .htaccess-dist, rehome compose file

### DIFF
--- a/.docker/compose.yaml
+++ b/.docker/compose.yaml
@@ -6,13 +6,13 @@ services:
   php:
     build:
       context: .
-      dockerfile: ./.docker/php/Dockerfile
+      dockerfile: ./php/Dockerfile
     working_dir: /var/www/html
     volumes:
-      - .:/var/www/html
-      - ./.docker/php/php.ini:/usr/local/etc/php/conf.d/custom.ini:ro
+      - ../:/var/www/html
+      - ./php/php.ini:/usr/local/etc/php/conf.d/custom.ini:ro
     env_file:
-      - path: ./.docker/.dist.env
+      - path: ./.dist.env
         required: true # default
       - path: ./.env.local
         required: false
@@ -34,15 +34,15 @@ services:
   nginx:
     image: nginx:latest
     env_file:
-      - path: ./.docker/.dist.env
+      - path: ./.dist.env
         required: true # default
       - path: ./.env.local
         required: false
     ports:
       - "${SERVER_PORT:-8080}:80"
     volumes:
-      - .:/var/www/html
-      - ./.docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ../:/var/www/html
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       - php
     networks:
@@ -51,7 +51,7 @@ services:
   db:
     image: mariadb:latest
     env_file:
-      - path: ./.docker/.dist.env
+      - path: ./.dist.env
         required: true # default
       - path: ./.env.local
         required: false
@@ -64,7 +64,7 @@ services:
       - MYSQL_COLLATION=utf8mb4_unicode_ci
     volumes:
       - mariadb_data:/var/lib/mysql
-      - ./.docker/mariadb/01-init.sh:/docker-entrypoint-initdb.d/01-init.sh
+      - ./mariadb/01-init.sh:/docker-entrypoint-initdb.d/01-init.sh
     ports:
       - "${MYSQL_PORT:-3306}:3306"
     networks:
@@ -79,7 +79,7 @@ services:
   phpmyadmin:
     image: phpmyadmin:latest
     env_file:
-      - path: ./.docker/.dist.env
+      - path: ./.dist.env
         required: false
       - path: ./.env.local
         required: false

--- a/.htaccess-dist
+++ b/.htaccess-dist
@@ -5,6 +5,9 @@
 # This file is meant to be copied to ".htaccess" on Apache-powered web servers.
 # The created .htaccess file can be edited manually and will not be overwritten by Friendica updates.
 
+# /compose stops successfully pointing to the editor if this is removed, due to compose.yaml
+Options -Multiviews
+
 Options -Indexes
 AddType application/x-java-archive .jar
 AddType audio/ogg .oga


### PR DESCRIPTION
Closes #15672

Edit: Alternatives to this that I can think of:
- Rename `compose.yml` back to `docker-compose.yml`. The former is the new canonical name for it, though.
- Move `compose.yml` into the `.docker` directory. But maybe fellow devs wouldn't find/use it quite as easily.

...but maybe by *not* disabling we'd just risk running into the same thing in the future and/or have something work in Apache but not in nginx or another proxy/webserver, because of this "magic" behaviour.