### PR TITLE
Admin logs: Align table headers with content, simplify styling

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -3593,19 +3593,10 @@ li.addon {
 	display: flex;
 	align-items: center;
 }
-#adminpage .table-logs thead tr {
-	display: grid;
-	grid-auto-flow: row;
-}
-#adminpage .table-logs tbody {
-	display: table;
-	width: 100%;
-	table-layout: fixed;
-}
 #adminpage .table-logs td {
 	word-break: break-word;
 }
-#adminpage .table-logs td.log-message {
+#adminpage .table-logs th.log-message, #adminpage .table-logs td.log-message {
 	width: 40%;
 }
 #logdetail td.log-message {
@@ -3616,11 +3607,8 @@ li.addon {
 	max-width: 296px;
 }
 @media (min-width: 600px) {
-	#adminpage .table-logs thead tr {
-		grid-auto-flow: column;
-	}
-	#adminpage .table-logs td.log-message {
-		width: 60%;
+	#adminpage .table-logs th.log-message, #adminpage .table-logs td.log-message {
+		width: 57%;
 	}
 }
 #adminpage td,

--- a/view/theme/frio/templates/admin/logs/view.tpl
+++ b/view/theme/frio/templates/admin/logs/view.tpl
@@ -32,7 +32,7 @@
 					<th>{{$l10n.Date}}</th>
 					<th class="dropdown">
 						<a class="dropdown-toggle text-nowrap" type="button" id="level" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-							{{$l10n.Level}} {{if $filters.level}}({{$filters.level}}){{/if}}<span class="caret"></span>
+							{{$l10n.Level}}{{if $filters.level}}({{$filters.level}}){{/if}}<span class="caret"></span>
 						</a>
 						<ul class="dropdown-menu" aria-labelledby="level">
 							{{foreach $filtersvalues.level as $v }}
@@ -46,7 +46,7 @@
 					</th>
 					<th class="dropdown">
 						<a class="dropdown-toggle text-nowrap" type="button" id="context" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-							{{$l10n.Context}} {{if $filters.context}}({{$filters.context}}){{/if}}<span class="caret"></span>
+							{{$l10n.Context}}{{if $filters.context}}({{$filters.context}}){{/if}}<span class="caret"></span>
 						</a>
 						<ul class="dropdown-menu" aria-labelledby="context">
 							{{foreach $filtersvalues.context as $v }}
@@ -58,7 +58,7 @@
 							{{/foreach}}
 						</ul>
 					</th>
-					<th>{{$l10n.Message}}</th>
+					<th class="log-message">{{$l10n.Message}}</th>
 				</tr>
 			</thead>
 			<tbody>


### PR DESCRIPTION
Currently the admin logs' table headers don't align with the content.
I tried to fix that ~~+ display the date and time in a more readable way.~~
Also I tried to compress the headers a tiny bit more to make more space for the logs on smaller viewports.

# After

<img width="666" height="415" alt="image" src="https://github.com/user-attachments/assets/61b6b06d-6a6a-4d11-9fb9-8f7af86edc58" />

Small viewports:
<img width="441" height="538" alt="image" src="https://github.com/user-attachments/assets/c2874d7f-6ead-4874-a56b-e6005d6ac8cc" />

# Before

<img width="689" height="505" alt="image" src="https://github.com/user-attachments/assets/368d032c-3c62-467d-9d67-aab905d20d55" />

Small viewports:
<img width="397" height="670" alt="image" src="https://github.com/user-attachments/assets/6950e79d-fa91-4475-af46-03a5fdddfef6" />