### PR TITLE
ci: install xgettext in docker php container

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     unzip \
     mariadb-client \
+    gettext \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHP extensions with docker-php-extension-installer


### PR DESCRIPTION
`xgettext` is missing in the new .docker environment. This PR installs xgettext, so we can run `docker compose exec php composer run lang:recreate` againt to update the lang file.