### PR TITLE
New table to store quote data

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,6 +1,6 @@
 -- ------------------------------------------
 -- Friendica 2026.04-dev (Blutwurz)
--- DB_UPDATE_VERSION 1594
+-- DB_UPDATE_VERSION 1595
 -- ------------------------------------------
 
 
@@ -1302,7 +1302,7 @@ CREATE TABLE IF NOT EXISTS `post-content` (
 	`content-warning` varchar(500) NOT NULL DEFAULT '' COMMENT '',
 	`body` mediumtext COMMENT 'item body content',
 	`raw-body` mediumtext COMMENT 'Body without embedded media links',
-	`quote-uri-id` int unsigned COMMENT 'Id of the item-uri table that contains the quoted uri',
+	`quote-uri-id` int unsigned COMMENT 'Deprecated. It is replaced by the field quote-uri-id in the table post-quote',
 	`location` varchar(255) NOT NULL DEFAULT '' COMMENT 'text location where this item originated',
 	`coord` varchar(255) NOT NULL DEFAULT '' COMMENT 'longitude/latitude pair representing location where this item originated',
 	`language` text COMMENT 'Language information about this post',
@@ -1320,9 +1320,20 @@ CREATE TABLE IF NOT EXISTS `post-content` (
 	 INDEX `plink` (`plink`(191)),
 	 INDEX `resource-id` (`resource-id`),
 	 INDEX `quote-uri-id` (`quote-uri-id`),
+	FOREIGN KEY (`uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
+) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Content for all posts';
+
+--
+-- TABLE post-quote
+--
+CREATE TABLE IF NOT EXISTS `post-quote` (
+	`uri-id` int unsigned NOT NULL COMMENT 'Id of the item-uri table entry that contains the item uri',
+	`quote-uri-id` int unsigned COMMENT 'Id of the item-uri table that contains the quoted uri',
+	 PRIMARY KEY(`uri-id`),
+	 INDEX `quote-uri-id` (`quote-uri-id`),
 	FOREIGN KEY (`uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE,
 	FOREIGN KEY (`quote-uri-id`) REFERENCES `item-uri` (`id`) ON UPDATE RESTRICT ON DELETE CASCADE
-) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Content for all posts';
+) DEFAULT COLLATE utf8mb4_general_ci COMMENT='Quotes';
 
 --
 -- TABLE post-delivery
@@ -2503,7 +2514,7 @@ CREATE VIEW `post-origin-view` AS SELECT
 	`context-item-uri`.`uri` AS `context`,
 	`post-thread-user`.`context-id` AS `context-id`,
 	`quote-item-uri`.`uri` AS `quote-uri`,
-	`post-content`.`quote-uri-id` AS `quote-uri-id`,
+	`post-quote`.`quote-uri-id` AS `quote-uri-id`,
 	`item-uri`.`guid` AS `guid`,
 	`post-origin`.`wall` AS `wall`,
 	`post-origin`.`gravity` AS `gravity`,
@@ -2672,7 +2683,8 @@ CREATE VIEW `post-origin-view` AS SELECT
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post-origin`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post-origin`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-delivery-data` ON `post-delivery-data`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `permissionset` ON `permissionset`.`id` = `post-user`.`psid`
@@ -2698,7 +2710,7 @@ CREATE VIEW `post-thread-origin-view` AS SELECT
 	`context-item-uri`.`uri` AS `context`,
 	`post-thread-user`.`context-id` AS `context-id`,
 	`quote-item-uri`.`uri` AS `quote-uri`,
-	`post-content`.`quote-uri-id` AS `quote-uri-id`,
+	`post-quote`.`quote-uri-id` AS `quote-uri-id`,
 	`item-uri`.`guid` AS `guid`,
 	`post-origin`.`wall` AS `wall`,
 	`post-origin`.`gravity` AS `gravity`,
@@ -2867,7 +2879,8 @@ CREATE VIEW `post-thread-origin-view` AS SELECT
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post-origin`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post-origin`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-delivery-data` ON `post-delivery-data`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `permissionset` ON `permissionset`.`id` = `post-thread-user`.`psid`;
@@ -2892,7 +2905,7 @@ CREATE VIEW `post-user-view` AS SELECT
 	`context-item-uri`.`uri` AS `context`,
 	`post-thread`.`context-id` AS `context-id`,
 	`quote-item-uri`.`uri` AS `quote-uri`,
-	`post-content`.`quote-uri-id` AS `quote-uri-id`,
+	`post-quote`.`quote-uri-id` AS `quote-uri-id`,
 	`item-uri`.`guid` AS `guid`,
 	`post-user`.`wall` AS `wall`,
 	`post-user`.`gravity` AS `gravity`,
@@ -3061,7 +3074,8 @@ CREATE VIEW `post-user-view` AS SELECT
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-user`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post-user`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post-user`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-delivery-data` ON `post-delivery-data`.`uri-id` = `post-user`.`uri-id` AND `post-user`.`origin`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-user`.`uri-id`
 			LEFT JOIN `permissionset` ON `permissionset`.`id` = `post-user`.`psid`
@@ -3087,7 +3101,7 @@ CREATE VIEW `post-thread-user-view` AS SELECT
 	`context-item-uri`.`uri` AS `context`,
 	`post-thread-user`.`context-id` AS `context-id`,
 	`quote-item-uri`.`uri` AS `quote-uri`,
-	`post-content`.`quote-uri-id` AS `quote-uri-id`,
+	`post-quote`.`quote-uri-id` AS `quote-uri-id`,
 	`item-uri`.`guid` AS `guid`,
 	`post-thread-user`.`wall` AS `wall`,
 	`post-user`.`gravity` AS `gravity`,
@@ -3255,7 +3269,8 @@ CREATE VIEW `post-thread-user-view` AS SELECT
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-thread-user`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post-thread-user`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post-thread-user`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-delivery-data` ON `post-delivery-data`.`uri-id` = `post-thread-user`.`uri-id` AND `post-thread-user`.`origin`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-thread-user`.`uri-id`
 			LEFT JOIN `permissionset` ON `permissionset`.`id` = `post-thread-user`.`psid`;
@@ -3276,7 +3291,7 @@ CREATE VIEW `post-view` AS SELECT
 	`context-item-uri`.`uri` AS `context`,
 	`post-thread`.`context-id` AS `context-id`,
 	`quote-item-uri`.`uri` AS `quote-uri`,
-	`post-content`.`quote-uri-id` AS `quote-uri-id`,
+	`post-quote`.`quote-uri-id` AS `quote-uri-id`,
 	`item-uri`.`guid` AS `guid`,
 	`post`.`gravity` AS `gravity`,
 	`external-item-uri`.`uri` AS `extid`,
@@ -3411,7 +3426,8 @@ CREATE VIEW `post-view` AS SELECT
 			LEFT JOIN `verb` ON `verb`.`id` = `post`.`vid`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post`.`uri-id`
 			LEFT JOIN `contact` AS `parent-post-author` ON `parent-post-author`.`id` = `post-thread`.`author-id`;
 
@@ -3431,7 +3447,7 @@ CREATE VIEW `post-thread-view` AS SELECT
 	`context-item-uri`.`uri` AS `context`,
 	`post-thread`.`context-id` AS `context-id`,
 	`quote-item-uri`.`uri` AS `quote-uri`,
-	`post-content`.`quote-uri-id` AS `quote-uri-id`,
+	`post-quote`.`quote-uri-id` AS `quote-uri-id`,
 	`item-uri`.`guid` AS `guid`,
 	`post`.`gravity` AS `gravity`,
 	`external-item-uri`.`uri` AS `extid`,
@@ -3568,7 +3584,8 @@ CREATE VIEW `post-thread-view` AS SELECT
 			LEFT JOIN `verb` ON `verb`.`id` = `post`.`vid`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-thread`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post-thread`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post-thread`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-thread`.`uri-id`;
 
 --

--- a/doc/en/spec/database/db-post-content.md
+++ b/doc/en/spec/database/db-post-content.md
@@ -11,7 +11,7 @@ Content for all posts
 | content-warning |                                                                                                                           | varchar(500)   | NO   |     |         |       |
 | body            | item body content                                                                                                         | mediumtext     | YES  |     | NULL    |       |
 | raw-body        | Body without embedded media links                                                                                         | mediumtext     | YES  |     | NULL    |       |
-| quote-uri-id    | Id of the item-uri table that contains the quoted uri                                                                     | int unsigned   | YES  |     | NULL    |       |
+| quote-uri-id    | Deprecated. It is replaced by the field quote-uri-id in the table post-quote                                              | int unsigned   | YES  |     | NULL    |       |
 | location        | text location where this item originated                                                                                  | varchar(255)   | NO   |     |         |       |
 | coord           | longitude/latitude pair representing location where this item originated                                                  | varchar(255)   | NO   |     |         |       |
 | language        | Language information about this post                                                                                      | text           | YES  |     | NULL    |       |
@@ -40,6 +40,5 @@ Content for all posts
 | Field | Target Table | Target Field |
 |-------|--------------|--------------|
 | uri-id | [item-uri](help/spec/database/db-item-uri) | id |
-| quote-uri-id | [item-uri](help/spec/database/db-item-uri) | id |
 
 Return to [database documentation](help/spec/database/index)

--- a/doc/en/spec/database/db-post-quote.md
+++ b/doc/en/spec/database/db-post-quote.md
@@ -1,0 +1,26 @@
+# Table post-quote
+
+Quotes
+
+## Fields
+
+| Field        | Description                                               | Type         | Null | Key | Default | Extra |
+| ------------ | --------------------------------------------------------- | ------------ | ---- | --- | ------- | ----- |
+| uri-id       | Id of the item-uri table entry that contains the item uri | int unsigned | NO   | PRI | NULL    |       |
+| quote-uri-id | Id of the item-uri table that contains the quoted uri     | int unsigned | YES  |     | NULL    |       |
+
+## Indexes
+
+| Name         | Fields       |
+| ------------ | ------------ |
+| PRIMARY      | uri-id       |
+| quote-uri-id | quote-uri-id |
+
+## Foreign keys
+
+| Field | Target Table | Target Field |
+|-------|--------------|--------------|
+| uri-id | [item-uri](help/spec/database/db-item-uri) | id |
+| quote-uri-id | [item-uri](help/spec/database/db-item-uri) | id |
+
+Return to [database documentation](help/spec/database/index)

--- a/doc/en/spec/database/index.md
+++ b/doc/en/spec/database/index.md
@@ -70,6 +70,7 @@
 | [post-origin](help/spec/database/db-post-origin) | Posts from local users |
 | [post-question](help/spec/database/db-post-question) | Question |
 | [post-question-option](help/spec/database/db-post-question-option) | Question option |
+| [post-quote](help/spec/database/db-post-quote) | Quotes |
 | [post-searchindex](help/spec/database/db-post-searchindex) | Content for all posts |
 | [post-tag](help/spec/database/db-post-tag) | post relation to tags |
 | [post-thread](help/spec/database/db-post-thread) | Thread related data |

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -1128,7 +1128,7 @@ class Conversation
 		$condition = DBA::mergeConditions(['quote-uri-id' => $uriids], ["NOT `quote-uri-id` IS NULL"]);
 		$separator = chr(255) . chr(255) . chr(255);
 
-		$sql = "SELECT `quote-uri-id`, COUNT(*) AS `total`, GROUP_CONCAT(REPLACE(`name`, '" . $separator . "', ' ') SEPARATOR '" . $separator . "' LIMIT 50) AS `title` FROM `post-content` INNER JOIN `post` ON `post`.`uri-id` = `post-content`.`uri-id` INNER JOIN `contact` ON `post`.`author-id` = `contact`.`id` WHERE " . array_shift($condition) . " GROUP BY `quote-uri-id`";
+		$sql = "SELECT `quote-uri-id`, COUNT(*) AS `total`, GROUP_CONCAT(REPLACE(`name`, '" . $separator . "', ' ') SEPARATOR '" . $separator . "' LIMIT 50) AS `title` FROM `post-quote` INNER JOIN `post` ON `post`.`uri-id` = `post-quote`.`uri-id` INNER JOIN `contact` ON `post`.`author-id` = `contact`.`id` WHERE " . array_shift($condition) . " GROUP BY `quote-uri-id`";
 
 		$quotes = [];
 

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -934,6 +934,10 @@ class Item
 			}
 		}
 
+		if (isset($item['quote-uri-id'])) {
+			Post\Quote::insert($item['uri-id'], $item);
+		}
+
 		// The content of activities normally doesn't matter - except for emoji activities
 		if (in_array($item['gravity'], [self::GRAVITY_PARENT, self::GRAVITY_COMMENT]) || in_array($item['verb'], [Activity::LIKE, Activity::DISLIKE, Activity::EMOJIREACT]) && !empty($item['body']) && (mb_strlen($item['body']) == 1)) {
 			if (!Post\Content::exists($item['uri-id']) && !Post\Content::insert($item['uri-id'], $item)) {

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -685,6 +685,7 @@ class Post
 		}
 
 		$update_fields = DI::dbaDefinition()->truncateFieldsForTable('post-content', $fields);
+		unset($update_fields['quote-uri-id']);
 		if (!empty($update_fields)) {
 			$affected_count = 0;
 			$posts          = DBA::select('post-user-view', ['uri-id'], $condition, ['group_by' => ['uri-id']]);

--- a/src/Model/Post/Content.php
+++ b/src/Model/Post/Content.php
@@ -28,6 +28,7 @@ class Content
 		}
 
 		$fields = DI::dbaDefinition()->truncateFieldsForTable('post-content', $data);
+		unset($fields['quote-uri-id']);
 
 		// Additionally assign the key fields
 		$fields['uri-id'] = $uri_id;
@@ -51,6 +52,7 @@ class Content
 		}
 
 		$fields = DI::dbaDefinition()->truncateFieldsForTable('post-content', $data);
+		unset($fields['quote-uri-id']);
 
 		// Remove the key fields
 		unset($fields['uri-id']);
@@ -84,17 +86,6 @@ class Content
 	public static function exists(int $uri_id): bool
 	{
 		return DBA::exists('post-content', ['uri-id' => $uri_id]);
-	}
-
-	/**
-	 * Check if a post-content entry exists that quotes the given URI ID
-	 *
-	 * @param integer $uri_id
-	 * @return boolean exists?
-	 */
-	public static function existsQuote(int $uri_id): bool
-	{
-		return DBA::exists('post-content', ['quote-uri-id' => $uri_id]);
 	}
 
 	/**

--- a/src/Model/Post/Quote.php
+++ b/src/Model/Post/Quote.php
@@ -1,0 +1,101 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Model\Post;
+
+use BadMethodCallException;
+use Friendica\Database\Database;
+use Friendica\Database\DBA;
+use Friendica\DI;
+
+class Quote
+{
+	/**
+	 * Insert a new post-quote entry
+	 *
+	 * @return bool   success
+	 * @throws \Exception
+	 */
+	public static function insert(int $uri_id, array $data = [])
+	{
+		if (empty($uri_id)) {
+			throw new BadMethodCallException('Empty URI_id');
+		}
+
+		$fields = DI::dbaDefinition()->truncateFieldsForTable('post-quote', $data);
+
+		// Additionally assign the key fields
+		$fields['uri-id'] = $uri_id;
+
+		return DBA::insert('post-quote', $fields, Database::INSERT_UPDATE);
+	}
+
+	/**
+	 * Update a post quote entry
+	 *
+	 * @param integer $uri_id
+	 * @param array   $data
+	 * @param bool    $insert_if_missing
+	 * @return bool
+	 * @throws \Exception
+	 */
+	public static function update(int $uri_id, array $data = [], bool $insert_if_missing = false)
+	{
+		if (empty($uri_id)) {
+			throw new BadMethodCallException('Empty URI_id');
+		}
+
+		$fields = DI::dbaDefinition()->truncateFieldsForTable('post-quote', $data);
+
+		// Remove the key fields
+		if (isset($fields['uri-id'])) {
+			DI::logger()->debug('Blubb-1', ['uri-id' => $uri_id, 'fields' => $fields]);
+		}
+		unset($fields['uri-id']);
+
+		if (empty($fields)) {
+			return true;
+		}
+
+		return DBA::update('post-quote', $fields, ['uri-id' => $uri_id], $insert_if_missing ? true : []);
+	}
+
+	/**
+	 * Delete a row from the post-quote table
+	 *
+	 * @param array        $conditions Field condition(s)
+	 *
+	 * @return boolean was the delete successful?
+	 * @throws \Exception
+	 */
+	public static function delete(array $conditions)
+	{
+		return DBA::delete('post-quote', $conditions);
+	}
+
+	/**
+	 * Check if a post-quote entry exists for the given URI ID
+	 *
+	 * @param integer $uri_id
+	 * @return boolean exists?
+	 */
+	public static function exists(int $uri_id): bool
+	{
+		return DBA::exists('post-quote', ['uri-id' => $uri_id]);
+	}
+
+	/**
+	 * Check if a post-quote entry exists that quotes the given URI ID
+	 *
+	 * @param integer $uri_id
+	 * @return boolean exists?
+	 */
+	public static function existsQuote(int $uri_id): bool
+	{
+		return DBA::exists('post-quote', ['quote-uri-id' => $uri_id]);
+	}
+}

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -1095,7 +1095,7 @@ class Processor
 	 */
 	private static function isSolicitedMessage(array $activity, array $item): bool
 	{
-		if (Post\Content::existsQuote($item['uri-id'])) {
+		if (Post\Quote::existsQuote($item['uri-id'])) {
 			DI::logger()->debug('Message is used in a quote - accepted', ['uri-id' => $item['uri-id'], 'guid' => $item['guid'], 'url' => $item['uri']]);
 			return true;
 		}

--- a/src/Worker/ExpirePosts.php
+++ b/src/Worker/ExpirePosts.php
@@ -108,7 +108,7 @@ class ExpirePosts
 		DI::logger()->notice('Delete orphaned entries');
 
 		// "post-user" is the leading table. So we delete every entry that isn't found there
-		$tables = ['item', 'post', 'post-content', 'post-thread', 'post-thread-user'];
+		$tables = ['item', 'post', 'post-content', 'post-quote', 'post-thread', 'post-thread-user'];
 		foreach ($tables as $table) {
 			if (($table == 'item') && !DBStructure::existsTable('item')) {
 				continue;
@@ -217,6 +217,7 @@ class ExpirePosts
 			LEFT JOIN `post-user` pu5 ON i.id = pu5.`replies-id`
 			LEFT JOIN `post-thread` pt1 ON i.id = pt1.`context-id`
 			LEFT JOIN `post-thread` pt2 ON i.id = pt2.`conversation-id`
+			LEFT JOIN `post-quote` pq ON i.id = pq.`quote-uri-id`
 			LEFT JOIN `mail` m1 ON i.id = m1.`uri-id`
 			LEFT JOIN `event` e ON i.id = e.`uri-id`
 			LEFT JOIN `user-contact` uc ON i.id = uc.`uri-id`
@@ -237,6 +238,7 @@ class ExpirePosts
 			  pu5.`replies-id` IS NULL AND
 			  pt1.`context-id` IS NULL AND
 			  pt2.`conversation-id` IS NULL AND
+			  pq.`quote-uri-id` IS NULL AND
 			  m1.`uri-id` IS NULL AND
 			  e.`uri-id` IS NULL AND
 			  uc.`uri-id` IS NULL AND

--- a/src/Worker/ExpirePosts.php
+++ b/src/Worker/ExpirePosts.php
@@ -199,7 +199,7 @@ class ExpirePosts
 		$item = Post::selectFirstThread(
 			['uri-id'],
 			["`uid` = ? AND `received` < ?", 0, DateTimeFormat::utc('now - 1 day')],
-			['order' => ['received' => true]]
+			['order' => ['received' => true]],
 		);
 		if (empty($item['uri-id'])) {
 			DI::logger()->warning('No item with uri-id found - we better quit here');
@@ -252,7 +252,7 @@ class ExpirePosts
 			  m3.`thr-parent-id` IS NULL
 			LIMIT ?',
 			$item['uri-id'],
-			$limit
+			$limit,
 		];
 		$pass = 0;
 		do {
@@ -307,7 +307,7 @@ class ExpirePosts
 					WHERE (`origin` OR `event-id` != 0 OR `post-type` = ?) AND `parent-uri-id` = `post-thread`.`uri-id`)
 				AND NOT `uri-id` IN (SELECT `uri-id` FROM `post-content`
 					WHERE `resource-id` != 0 AND `uri-id` = `post-thread`.`uri-id`)",
-				DateTimeFormat::utc('now - ' . (int)$expire_days . ' days'), Item::PT_PERSONAL_NOTE
+				DateTimeFormat::utc('now - ' . (int) $expire_days . ' days'), Item::PT_PERSONAL_NOTE,
 			];
 			$pass = 0;
 			do {
@@ -335,7 +335,7 @@ class ExpirePosts
 					AND `i`.`parent-uri-id` = `post-user`.`uri-id`)
 				AND NOT `uri-id` IN (SELECT `parent-uri-id` FROM `post-user` AS `i` WHERE `i`.`uid` = ?
 					AND `i`.`parent-uri-id` = `post-user`.`uri-id` AND `i`.`received` > ?)",
-				Item::GRAVITY_PARENT, 0, DateTimeFormat::utc('now - ' . (int)$expire_days_unclaimed . ' days'), 0, 0, DateTimeFormat::utc('now - ' . (int)$expire_days_unclaimed . ' days')
+				Item::GRAVITY_PARENT, 0, DateTimeFormat::utc('now - ' . (int) $expire_days_unclaimed . ' days'), 0, 0, DateTimeFormat::utc('now - ' . (int) $expire_days_unclaimed . ' days'),
 			];
 			$pass = 0;
 			do {

--- a/src/Worker/OptimizeTables.php
+++ b/src/Worker/OptimizeTables.php
@@ -51,6 +51,7 @@ class OptimizeTables
 			DBA::optimizeTable('photo');
 			DBA::optimizeTable('post');
 			DBA::optimizeTable('post-content');
+			DBA::optimizeTable('post-quote');
 			DBA::optimizeTable('post-delivery-data');
 			DBA::optimizeTable('post-link');
 			DBA::optimizeTable('post-thread');

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -1335,8 +1335,8 @@ return [
 	"post-quote" => [
 		"comment" => "Quotes",
 		"fields"  => [
-			"uri-id"          => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
-			"quote-uri-id"    => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table that contains the quoted uri"],
+			"uri-id"       => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
+			"quote-uri-id" => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table that contains the quoted uri"],
 		],
 		"indexes" => [
 			"PRIMARY"      => ["uri-id"],

--- a/static/dbstructure.config.php
+++ b/static/dbstructure.config.php
@@ -44,7 +44,7 @@ use Friendica\Database\DBA;
 
 // This file is required several times during the test in DbaDefinition which justifies this condition
 if (!defined('DB_UPDATE_VERSION')) {
-	define('DB_UPDATE_VERSION', 1594);
+	define('DB_UPDATE_VERSION', 1595);
 }
 
 return [
@@ -1310,7 +1310,7 @@ return [
 			"content-warning" => ["type" => "varchar(500)", "not null" => "1", "default" => "", "comment" => ""],
 			"body"            => ["type" => "mediumtext", "comment" => "item body content"],
 			"raw-body"        => ["type" => "mediumtext", "comment" => "Body without embedded media links"],
-			"quote-uri-id"    => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table that contains the quoted uri"],
+			"quote-uri-id"    => ["type" => "int unsigned", "comment" => "Deprecated. It is replaced by the field quote-uri-id in the table post-quote"],
 			"location"        => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "text location where this item originated"],
 			"coord"           => ["type" => "varchar(255)", "not null" => "1", "default" => "", "comment" => "longitude/latitude pair representing location where this item originated"],
 			"language"        => ["type" => "text", "comment" => "Language information about this post"],
@@ -1329,6 +1329,17 @@ return [
 			"PRIMARY"      => ["uri-id"],
 			"plink"        => ["plink(191)"],
 			"resource-id"  => ["resource-id"],
+			"quote-uri-id" => ["quote-uri-id"],
+		],
+	],
+	"post-quote" => [
+		"comment" => "Quotes",
+		"fields"  => [
+			"uri-id"          => ["type" => "int unsigned", "not null" => "1", "primary" => "1", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table entry that contains the item uri"],
+			"quote-uri-id"    => ["type" => "int unsigned", "foreign" => ["item-uri" => "id"], "comment" => "Id of the item-uri table that contains the quoted uri"],
+		],
+		"indexes" => [
+			"PRIMARY"      => ["uri-id"],
 			"quote-uri-id" => ["quote-uri-id"],
 		],
 	],

--- a/static/dbview.config.php
+++ b/static/dbview.config.php
@@ -363,7 +363,7 @@ return [
 			"context"               => ["context-item-uri", "uri"],
 			"context-id"            => ["post-thread-user", "context-id"],
 			"quote-uri"             => ["quote-item-uri", "uri"],
-			"quote-uri-id"          => ["post-content", "quote-uri-id"],
+			"quote-uri-id"          => ["post-quote", "quote-uri-id"],
 			"guid"                  => ["item-uri", "guid"],
 			"wall"                  => ["post-origin", "wall"],
 			"gravity"               => ["post-origin", "gravity"],
@@ -533,7 +533,8 @@ return [
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post-origin`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post-origin`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-delivery-data` ON `post-delivery-data`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `permissionset` ON `permissionset`.`id` = `post-user`.`psid`
@@ -556,7 +557,7 @@ return [
 			"context"               => ["context-item-uri", "uri"],
 			"context-id"            => ["post-thread-user", "context-id"],
 			"quote-uri"             => ["quote-item-uri", "uri"],
-			"quote-uri-id"          => ["post-content", "quote-uri-id"],
+			"quote-uri-id"          => ["post-quote", "quote-uri-id"],
 			"guid"                  => ["item-uri", "guid"],
 			"wall"                  => ["post-origin", "wall"],
 			"gravity"               => ["post-origin", "gravity"],
@@ -726,7 +727,8 @@ return [
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post-origin`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post-origin`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-delivery-data` ON `post-delivery-data`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-origin`.`uri-id`
 			LEFT JOIN `permissionset` ON `permissionset`.`id` = `post-thread-user`.`psid`",
@@ -748,7 +750,7 @@ return [
 			"context"               => ["context-item-uri", "uri"],
 			"context-id"            => ["post-thread", "context-id"],
 			"quote-uri"             => ["quote-item-uri", "uri"],
-			"quote-uri-id"          => ["post-content", "quote-uri-id"],
+			"quote-uri-id"          => ["post-quote", "quote-uri-id"],
 			"guid"                  => ["item-uri", "guid"],
 			"wall"                  => ["post-user", "wall"],
 			"gravity"               => ["post-user", "gravity"],
@@ -918,7 +920,8 @@ return [
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-user`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post-user`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post-user`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-delivery-data` ON `post-delivery-data`.`uri-id` = `post-user`.`uri-id` AND `post-user`.`origin`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-user`.`uri-id`
 			LEFT JOIN `permissionset` ON `permissionset`.`id` = `post-user`.`psid`
@@ -941,7 +944,7 @@ return [
 			"context"               => ["context-item-uri", "uri"],
 			"context-id"            => ["post-thread-user", "context-id"],
 			"quote-uri"             => ["quote-item-uri", "uri"],
-			"quote-uri-id"          => ["post-content", "quote-uri-id"],
+			"quote-uri-id"          => ["post-quote", "quote-uri-id"],
 			"guid"                  => ["item-uri", "guid"],
 			"wall"                  => ["post-thread-user", "wall"],
 			"gravity"               => ["post-user", "gravity"],
@@ -1110,7 +1113,8 @@ return [
 			LEFT JOIN `event` ON `event`.`id` = `post-user`.`event-id`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-thread-user`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post-thread-user`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post-thread-user`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-delivery-data` ON `post-delivery-data`.`uri-id` = `post-thread-user`.`uri-id` AND `post-thread-user`.`origin`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-thread-user`.`uri-id`
 			LEFT JOIN `permissionset` ON `permissionset`.`id` = `post-thread-user`.`psid`",
@@ -1128,7 +1132,7 @@ return [
 			"context"               => ["context-item-uri", "uri"],
 			"context-id"            => ["post-thread", "context-id"],
 			"quote-uri"             => ["quote-item-uri", "uri"],
-			"quote-uri-id"          => ["post-content", "quote-uri-id"],
+			"quote-uri-id"          => ["post-quote", "quote-uri-id"],
 			"guid"                  => ["item-uri", "guid"],
 			"gravity"               => ["post", "gravity"],
 			"extid"                 => ["external-item-uri", "uri"],
@@ -1264,7 +1268,8 @@ return [
 			LEFT JOIN `verb` ON `verb`.`id` = `post`.`vid`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post`.`uri-id`
 			LEFT JOIN `contact` AS `parent-post-author` ON `parent-post-author`.`id` = `post-thread`.`author-id`",
 	],
@@ -1281,7 +1286,7 @@ return [
 			"context"               => ["context-item-uri", "uri"],
 			"context-id"            => ["post-thread", "context-id"],
 			"quote-uri"             => ["quote-item-uri", "uri"],
-			"quote-uri-id"          => ["post-content", "quote-uri-id"],
+			"quote-uri-id"          => ["post-quote", "quote-uri-id"],
 			"guid"                  => ["item-uri", "guid"],
 			"gravity"               => ["post", "gravity"],
 			"extid"                 => ["external-item-uri", "uri"],
@@ -1419,7 +1424,8 @@ return [
 			LEFT JOIN `verb` ON `verb`.`id` = `post`.`vid`
 			LEFT JOIN `diaspora-interaction` ON `diaspora-interaction`.`uri-id` = `post-thread`.`uri-id`
 			LEFT JOIN `post-content` ON `post-content`.`uri-id` = `post-thread`.`uri-id`
-			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-content`.`quote-uri-id`
+			LEFT JOIN `post-quote` ON `post-quote`.`uri-id` = `post-thread`.`uri-id`
+			LEFT JOIN `item-uri` AS `quote-item-uri` ON `quote-item-uri`.`id` = `post-quote`.`quote-uri-id`
 			LEFT JOIN `post-question` ON `post-question`.`uri-id` = `post-thread`.`uri-id`",
 	],
 	"category-view" => [

--- a/update.php
+++ b/update.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (C) 2010-2024, the Friendica project
  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
@@ -189,8 +190,8 @@ function update_1330()
 	}
 
 	// Update attachments and photos
-	if (!DBA::e("UPDATE `photo` SET `photo`.`backend-class` = SUBSTR(`photo`.`backend-class`, 25) WHERE `photo`.`backend-class` LIKE 'Friendica\\\Model\\\Storage\\\%' ESCAPE '|'") ||
-		!DBA::e("UPDATE `attach` SET `attach`.`backend-class` = SUBSTR(`attach`.`backend-class`, 25) WHERE `attach`.`backend-class` LIKE 'Friendica\\\Model\\\Storage\\\%' ESCAPE '|'")) {
+	if (!DBA::e("UPDATE `photo` SET `photo`.`backend-class` = SUBSTR(`photo`.`backend-class`, 25) WHERE `photo`.`backend-class` LIKE 'Friendica\\\Model\\\Storage\\\%' ESCAPE '|'")
+		|| !DBA::e("UPDATE `attach` SET `attach`.`backend-class` = SUBSTR(`attach`.`backend-class`, 25) WHERE `attach`.`backend-class` LIKE 'Friendica\\\Model\\\Storage\\\%' ESCAPE '|'")) {
 		return Update::FAILED;
 	};
 
@@ -653,7 +654,7 @@ function update_1380()
 	if (!DBA::e(
 		"UPDATE `notify` INNER JOIN `item` ON `item`.`id` = `notify`.`iid` SET `notify`.`uri-id` = `item`.`uri-id` WHERE `notify`.`uri-id` IS NULL AND `notify`.`otype` IN (?, ?)",
 		Notification\ObjectType::ITEM,
-		Notification\ObjectType::PERSON
+		Notification\ObjectType::PERSON,
 	)) {
 		return Update::FAILED;
 	}
@@ -661,7 +662,7 @@ function update_1380()
 	if (!DBA::e(
 		"UPDATE `notify` INNER JOIN `item` ON `item`.`id` = `notify`.`parent` SET `notify`.`parent-uri-id` = `item`.`uri-id` WHERE `notify`.`parent-uri-id` IS NULL AND `notify`.`otype` IN (?, ?)",
 		Notification\ObjectType::ITEM,
-		Notification\ObjectType::PERSON
+		Notification\ObjectType::PERSON,
 	)) {
 		return Update::FAILED;
 	}
@@ -1151,9 +1152,9 @@ function update_1505()
 	}
 
 	$conditions = [
-		"((`cat`  = ?) AND ((`k` LIKE ?) OR (`k` = ?) OR (`k` LIKE ?) OR (`k` = ?))) OR " .
-		"((`cat` != ?) AND  (`k` LIKE ?)) OR " .
-		"((`cat`  = ?) AND  (`k` LIKE ?))",
+		"((`cat`  = ?) AND ((`k` LIKE ?) OR (`k` = ?) OR (`k` LIKE ?) OR (`k` = ?))) OR "
+		. "((`cat` != ?) AND  (`k` LIKE ?)) OR "
+		. "((`cat`  = ?) AND  (`k` LIKE ?))",
 		"system",
 		"post_update_%",
 		"worker_last_cleaned",
@@ -1202,7 +1203,7 @@ function update_1509()
 	foreach ($addons as $addon) {
 		$newConfig->set('addons', $addon['name'], [
 			'last_update' => $addon['timestamp'],
-			'admin'       => (bool)$addon['plugin_admin'],
+			'admin'       => (bool) $addon['plugin_admin'],
 		]);
 	}
 

--- a/update.php
+++ b/update.php
@@ -1532,3 +1532,15 @@ function update_1573()
 	DBA::close($media);
 	return Update::SUCCESS;
 }
+
+function update_1595()
+{
+	if (!DBA::e("INSERT IGNORE INTO `post-quote` (`uri-id`, `quote-uri-id`)
+		SELECT `uri-id`, `quote-uri-id`
+		FROM `post-content`
+		WHERE NOT `quote-uri-id` IS NULL")) {
+		return Update::FAILED;
+	}
+
+	return Update::SUCCESS;
+}


### PR DESCRIPTION
This fixes a second problem resulting in the problem described in PR #15395. When the quoted post can't be fetched, the reserved entry in `item-uri` will eventually be cleaned up in the daily database cleanup routines. This results in an empty body, because it deletes the `item-content` entry.

This is fixed now by introducing a new table for quotes.