### PR TITLE
Calendar: Move event create/edit out of modal, restore button to add images, merge tabs

### DIFF
--- a/doc/en/user/events.md
+++ b/doc/en/user/events.md
@@ -26,13 +26,13 @@ Following one of the methods mentioned above you reach a form to enter the event
 Fields marked with a *** have to be filled.
 
 * **Event Starts**: enter the date/time of the start of the event here
-* **Event Finishes**: enter the finishing date/time for the event here
+* **Event Ends**: enter the end date/time for the event here
 
 When you click in one of these fields a pop-up will be opened that allows you to pick the day and the time.
 If you double-clicked on the day box in the calendar these fields will be pre-filled for you.
-The finishing date/time has to be after the beginning date/time of the event.
+The end date/time has to be after the beginning date/time of the event.
 But you don't have to specify it.
-If the event is open-ended or the finishing date/time does not matter, just select the box below the two first fields.
+If the event is open-ended or the end date/time does not matter, just select the box below the two first fields.
 
 * **Title**: a title for the event
 * **Description**: a longer description for the event

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -60,7 +60,7 @@ class Event
 			$o .= "<h4>" . DI::l10n()->t('Starts:') . "</h4><p>" . $event_start . "</p>";
 
 			if (!$event['nofinish']) {
-				$o .= "<h4>" . DI::l10n()->t('Finishes:') . "</h4><p>" . $event_end . "</p>";
+				$o .= "<h4>" . DI::l10n()->t('Ends:') . "</h4><p>" . $event_end . "</p>";
 			}
 
 			if (!empty($event['location'])) {
@@ -74,13 +74,13 @@ class Event
 
 		$o .= '<div class="summary event-summary">' . BBCode::convertForUriId($uriid, $event['summary'], $simple) . '</div>' . "\r\n";
 
-		$o .= '<div class="event-start"><span class="event-label">' . DI::l10n()->t('Starts:') . '</span>&nbsp;<span class="dtstart" title="'
+		$o .= '<div class="event-start"><span class="event-label">' . DI::l10n()->t('Starts:') . '</span><br/><span class="dtstart" title="'
 			. DateTimeFormat::local($event['start'], DateTimeFormat::ATOM)
 			. '" >' . $event_start
 			. '</span></div>' . "\r\n";
 
 		if (!$event['nofinish']) {
-			$o .= '<div class="event-end" ><span class="event-label">' . DI::l10n()->t('Finishes:') . '</span>&nbsp;<span class="dtend" title="'
+			$o .= '<div class="event-end" ><span class="event-label">' . DI::l10n()->t('Ends:') . '</span><br/><span class="dtend" title="'
 				. DateTimeFormat::local($event['finish'], DateTimeFormat::ATOM)
 				. '" >' . $event_end
 				. '</span></div>' . "\r\n";
@@ -457,7 +457,7 @@ class Event
 			'noevent' => DI::l10n()->t('No events to display'),
 
 			'dtstart_label'  => DI::l10n()->t('Starts:'),
-			'dtend_label'    => DI::l10n()->t('Finishes:'),
+			'dtend_label'    => DI::l10n()->t('Ends:'),
 			'location_label' => DI::l10n()->t('Location:'),
 		];
 	}
@@ -649,9 +649,9 @@ class Event
 		$copy = null;
 		$drop = null;
 		if (DI::userSession()->getLocalUserId() && DI::userSession()->getLocalUserId() == $event['uid'] && $event['type'] == 'event') {
-			$edit = !$event['cid'] ? ['calendar/event/edit/' . $event['id'], DI::l10n()->t('Edit event'), '', ''] : null;
-			$copy = !$event['cid'] ? ['calendar/event/copy/' . $event['id'], DI::l10n()->t('Duplicate event'), '', ''] : null;
-			$drop = ['calendar/api/delete/' . $event['id'], DI::l10n()->t('Delete event'), '', ''];
+			$edit = !$event['cid'] ? ['calendar/event/edit/' . $event['id'], DI::l10n()->t('Edit'), '', ''] : null;
+			$copy = !$event['cid'] ? ['calendar/event/copy/' . $event['id'], DI::l10n()->t('Duplicate'), '', ''] : null;
+			$drop = ['calendar/api/delete/' . $event['id'], DI::l10n()->t('Delete'), '', ''];
 		}
 
 		$title = strip_tags(BBCode::convertForUriId($event['uri-id'], $event['summary']));
@@ -929,7 +929,7 @@ class Event
 			'$dtstart_title'  => $dtstart_title,
 			'$dtstart_dt'     => $dtstart_dt,
 			'$finish'         => $finish,
-			'$dtend_label'    => DI::l10n()->t('Finishes:'),
+			'$dtend_label'    => DI::l10n()->t('Ends:'),
 			'$dtend_title'    => $dtend_title,
 			'$dtend_dt'       => $dtend_dt,
 			'$month_short'    => $month_short,

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -3689,8 +3689,8 @@ class Item
 			$ret = [
 				'href'       => "display/" . $item['guid'],
 				'orig'       => "display/" . $item['guid'],
-				'title'      => DI::l10n()->t('View on separate page'),
-				'orig_title' => DI::l10n()->t('View on separate page'),
+				'title'      => DI::l10n()->t('View related post'),
+				'orig_title' => DI::l10n()->t('View related post'),
 			];
 
 			if (!empty($plink) && ($item['private'] == self::PRIVATE)) {

--- a/src/Module/Calendar/Event/Form.php
+++ b/src/Module/Calendar/Event/Form.php
@@ -9,6 +9,7 @@ namespace Friendica\Module\Calendar\Event;
 
 use Friendica\App;
 use Friendica\BaseModule;
+use Friendica\Content\Nav;
 use Friendica\Content\Widget\CalendarExport;
 use Friendica\Core\ACL;
 use Friendica\Core\L10n;
@@ -66,6 +67,8 @@ class Form extends BaseModule
 			throw new BadRequestException($this->t('Invalid Request'));
 		}
 
+		Nav::setSelected('calendar');
+
 		if (!$this->session->getLocalUserId()) {
 			$this->sysMessages->addNotice($this->t('Permission denied.'));
 			return Login::form();
@@ -118,7 +121,7 @@ class Form extends BaseModule
 				   || $orig_event['deny_cid']
 				   || $orig_event['deny_gid']) {
 			$share_checked = ' checked="checked" ';
-			$submit        = $this->t("Edit event");
+			$submit        = $this->t("Save changes");
 		}
 
 		// In case of an error the browser is redirected back here, with these parameters filled in with the previous values
@@ -186,63 +189,81 @@ class Form extends BaseModule
 
 		$this->page['aside'] .= CalendarExport::getHTML($this->session->getLocalUserId());
 
-		$tpl   = Renderer::getMarkupTemplate('calendar/event_form.tpl');
-		$no_bb = $this->t("Can't use BBCode here");
+		$tpl           = Renderer::getMarkupTemplate('calendar/event_form.tpl');
+		$no_formatting = $this->t("Formatting is not supported for this field");
+
+		if (str_contains($_SERVER['REQUEST_URI'], "/calendar/event/edit")) {
+			$title = $this->t('Edit event');
+		} else {
+			$title = $this->t('New event'); // Used when creating or duplicating an event
+		}
+
+		$ends_text = $this->t('Ends');
 
 		return Renderer::replaceMacros($tpl, [
-			'$post' => 'calendar/api/create',
-			'$eid'  => $eid,
-			'$cid'  => $cid,
-			'$uri'  => $uri,
+			'$post'      => 'calendar/api/create',
+			'$eid'       => $eid,
+			'$cid'       => $cid,
+			'$uri'       => $uri,
+			'$back_text' => $this->t('Back to the calendar'),
 
-			'$title'  => $this->t('Event details'),
+			'$title'  => $title,
 			'$desc'   => $this->t('Starting date and Title are required.'),
-			'$s_text' => $this->t('Event starts') . ' <span class="required" title="' . $this->t('Required') . '">*</span>',
+			'$s_text' => $this->t('Starts') . ' <span class="required" title="' . $this->t('Required') . '">*</span>',
 			'$s_dsel' => Temporal::getDateTimeField(
 				new \DateTime(),
 				\DateTime::createFromFormat('Y', intval($syear) + 5),
 				\DateTime::createFromFormat('Y-m-d H:i', "$syear-$smonth-$sday $shour:$sminute"),
-				$this->t('Event starts'),
+				$this->t('Starts'),
 				'start_text',
 				true,
 				true,
 				'',
 				'',
 				true,
+				false,
 			),
 
-			'$n_text'    => $this->t('End date/time is unknown or irrelevant'),
-			'$n_checked' => $n_checked,
-			'$f_text'    => $this->t('Event ends'),
-			'$f_dsel'    => Temporal::getDateTimeField(
+			'$section_time'       => $this->t('When does it happen?'),
+			'$section_additional' => $this->t('Further details'),
+			'$timezone_help'      => Temporal::timeZoneHelper(),
+			'$n_text'             => $this->t("Don't specify ending"),
+			'$n_checked'          => $n_checked,
+			'$f_text'             => $ends_text,
+			'$f_dsel'             => Temporal::getDateTimeField(
 				new \DateTime(),
 				\DateTime::createFromFormat('Y', intval($fyear) + 5),
 				\DateTime::createFromFormat('Y-m-d H:i', "$fyear-$fmonth-$fday $fhour:$fminute"),
-				$this->t('Event ends'),
+				$ends_text,
 				'finish_text',
 				true,
 				true,
 				'start_text',
+				'',
+				false,
+				false,
 			),
 
-			'$no_bb'       => $no_bb,
-			'$t_text'      => $this->t('Title') . ' <span class="required" title="' . $this->t('Required') . '">*</span>',
-			'$t_orig'      => $t_orig,
-			'$d_text'      => $this->t('Description'),
-			'$d_orig'      => $d_orig,
-			'$l_text'      => $this->t('Location'),
-			'$l_orig'      => $l_orig,
-			'$summary'     => ['summary', $this->t('Title'), $t_orig, $no_bb, '*'],
-			'$sh_text'     => $this->t('Share this event'),
-			'$share'       => ['share', $this->t('Share this event'), $share_checked, '', $share_disabled],
-			'$sh_checked'  => $share_checked,
-			'$nofinish'    => ['nofinish', $this->t('End date/time is unknown or irrelevant'), $n_checked],
-			'$preview'     => $this->t('Preview'),
-			'$acl'         => $acl,
-			'$submit'      => $submit,
-			'$basic'       => $this->t('Basic'),
-			'$advanced'    => $this->t('Advanced'),
-			'$permissions' => $this->t('Permissions'),
+			'$no_formatting' => $no_formatting,
+			'$t_text'        => $this->t('Title') . ' <span class="required" title="' . $this->t('Required') . '">*</span>',
+			'$t_orig'        => $t_orig,
+			'$l_text'        => $this->t('Location'),
+			'$l_placeholder' => $this->t('Where does it happen?'),
+			'$l_orig'        => $l_orig,
+			'$d_text'        => $this->t('Description'),
+			'$d_placeholder' => $this->t('What are the details?'),
+			'$d_orig'        => $d_orig,
+			'$summary'       => ['summary', $this->t('Event title'), $t_orig, $no_formatting, '*'],
+			'$sh_text'       => $this->t('Share this event'),
+			'$share'         => ['share', $this->t('Share this event'), $share_checked, '', $share_disabled],
+			'$sh_checked'    => $share_checked,
+			'$nofinish'      => ['nofinish', $this->t("Don't specify ending"), $n_checked],
+			'$preview'       => $this->t('Preview'),
+			'$acl'           => $acl,
+			'$submit'        => $submit,
+			'$basic'         => $this->t('Basic'),
+			'$advanced'      => $this->t('Advanced'),
+			'$permissions'   => $this->t('Permissions'),
 		]);
 	}
 }

--- a/src/Module/Calendar/Event/Show.php
+++ b/src/Module/Calendar/Event/Show.php
@@ -47,7 +47,7 @@ class Show extends BaseModule
 
 		$owner = Event::getOwnerForNickname($nickname);
 
-		$event = Event::getByIdAndUid($owner['uid'], (int)$this->parameters['id'] ?? 0);
+		$event = Event::getByIdAndUid($owner['uid'], (int) $this->parameters['id'] ?? 0);
 		if (empty($event)) {
 			throw new HTTPException\NotFoundException($this->t('Event not found.'));
 		}
@@ -63,7 +63,11 @@ class Show extends BaseModule
 		$tpl = Renderer::getMarkupTemplate('calendar/event.tpl');
 
 		$o = Renderer::replaceMacros($tpl, [
-			'$event' => $tplEvent,
+			'$event'                 => $tplEvent,
+			'$action_edit_text'      => $this->t('Edit'),
+			'$action_duplicate_text' => $this->t('Duplicate'),
+			'$action_drop_text'      => $this->t('Delete'),
+			'$action_orig_text'      => $this->t('View related post'),
 		]);
 
 		$this->httpExit($o);

--- a/src/Util/Temporal.php
+++ b/src/Util/Temporal.php
@@ -196,6 +196,20 @@ class Temporal
 	}
 
 	/**
+	 * Returns a help text containing the current time zone and how to change it
+	 *
+	 * @return string A help text containing the current time zone and how to change it
+	 */
+	public static function timeZoneHelper()
+	{
+		return DI::l10n()->t(
+			'Time zone: <strong>%s</strong> <a href="%s">Change in Settings</a>',
+			str_replace('_', ' ', DI::appHelper()->getTimeZone()) . ' (GMT ' . DateTimeFormat::localNow('P') . ')',
+			DI::baseUrl() . '/settings',
+		);
+	}
+
+	/**
 	 * Returns a datetime selector.
 	 *
 	 * @param DateTime $minDate     Minimum date
@@ -226,6 +240,7 @@ class Temporal
 		string $minfrom = '',
 		string $maxfrom = '',
 		bool $required = false,
+		bool $show_tip = true
 	): string {
 		// First day of the week (0 = Sunday)
 		$firstDay = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'calendar', 'first_day_of_week') ?: 0;
@@ -266,11 +281,7 @@ class Temporal
 				$id,
 				$label,
 				$input_text,
-				DI::l10n()->t(
-					'Time zone: <strong>%s</strong> <a href="%s">Change in Settings</a>',
-					str_replace('_', ' ', DI::appHelper()->getTimeZone()) . ' (GMT ' . DateTimeFormat::localNow('P') . ')',
-					DI::baseUrl() . '/settings',
-				),
+				$show_tip ? self::timeZoneHelper() : '',
 				$required ? '*' : '',
 				'placeholder="' . $readable_format . '"',
 			],

--- a/src/Util/Temporal.php
+++ b/src/Util/Temporal.php
@@ -240,7 +240,7 @@ class Temporal
 		string $minfrom = '',
 		string $maxfrom = '',
 		bool $required = false,
-		bool $show_tip = true
+		bool $show_tip = true,
 	): string {
 		// First day of the week (0 = Sunday)
 		$firstDay = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'calendar', 'first_day_of_week') ?: 0;

--- a/view/js/ajaxupload.js
+++ b/view/js/ajaxupload.js
@@ -8,16 +8,16 @@
 (function () {
     /* global window */
     /* jslint browser: true, devel: true, undef: true, nomen: true, bitwise: true, regexp: true, newcap: true, immed: true */
-    
+
     /**
      * Wrapper for FireBug's console.log
      */
     function log(){
-        if (typeof(console) != 'undefined' && typeof(console.log) == 'function'){            
+        if (typeof(console) != 'undefined' && typeof(console.log) == 'function'){
             Array.prototype.unshift.call(arguments, '[Ajax Upload]');
             console.log( Array.prototype.join.call(arguments, ' '));
         }
-    } 
+    }
 
     /**
      * Attaches event to a dom element.
@@ -35,28 +35,28 @@
 	    } else {
             throw new Error('not supported or DOM not loaded');
         }
-    }   
-    
+    }
+
     /**
      * Attaches resize event to a window, limiting
      * number of event fired. Fires only when encounters
      * delay of 100 after series of events.
-     * 
+     *
      * Some browsers fire event multiple times when resizing
      * http://www.quirksmode.org/dom/events/resize.html
-     * 
+     *
      * @param fn callback This refers to the passed element
      */
     function addResizeEvent(fn){
         var timeout;
-               
+
 	    addEvent(window, 'resize', function(){
             if (timeout){
                 clearTimeout(timeout);
             }
-            timeout = setTimeout(fn, 100);                        
+            timeout = setTimeout(fn, 100);
         });
-    }    
+    }
 
     // Get offset adding all offsets, slow fall-back method
     var getOffsetSlow = function(el){
@@ -66,15 +66,15 @@
             left += el.offsetLeft || 0;
             el = el.offsetParent;
         } while (el);
-        
+
         return {
             left: left,
             top: top
         };
     };
 
-    
-    // Needs more testing, will be rewritten for next version        
+
+    // Needs more testing, will be rewritten for next version
     // getOffset function copied from jQuery lib (http://jquery.com/)
     if (document.documentElement.getBoundingClientRect){
         // Get Offset using getBoundingClientRect
@@ -83,13 +83,13 @@
             var box = el.getBoundingClientRect();
             var doc = el.ownerDocument;
             var body = doc.body;
-            var docElem = doc.documentElement; // for ie 
+            var docElem = doc.documentElement; // for ie
             var clientTop = docElem.clientTop || body.clientTop || 0;
             var clientLeft = docElem.clientLeft || body.clientLeft || 0;
-             
+
             // In Internet Explorer 7 getBoundingClientRect property is treated as physical,
-            // while others are logical. Make all logical, like in IE8.	
-            var zoom = 1;            
+            // while others are logical. Make all logical, like in IE8.
+            var zoom = 1;
             if (body.getBoundingClientRect) {
                 var bound = body.getBoundingClientRect();
                 zoom = (bound.right - bound.left) / body.clientWidth;
@@ -99,23 +99,23 @@
             // in this case we fall back to the slow method
             if (zoom == 0 || body.clientWidth == 0)
                 return getOffsetSlow(el);
-            
+
             if (zoom > 1) {
                 clientTop = 0;
                 clientLeft = 0;
             }
-            
+
             var top = box.top / zoom + (window.pageYOffset || docElem && docElem.scrollTop / zoom || body.scrollTop / zoom) - clientTop, left = box.left / zoom + (window.pageXOffset || docElem && docElem.scrollLeft / zoom || body.scrollLeft / zoom) - clientLeft;
-            
+
             return {
                 top: top,
                 left: left
             };
-        };        
+        };
     } else {
       var getOffset = getOffsetSlow;
     }
-    
+
     /**
      * Returns left, top, right and bottom properties describing the border-box,
      * in pixels, with the top-left relative to the body
@@ -127,10 +127,10 @@
         var offset = getOffset(el);
         left = offset.left;
         top = offset.top;
-        
+
         right = left + el.offsetWidth;
         bottom = top + el.offsetHeight;
-        
+
         return {
             left: left,
             right: right,
@@ -138,7 +138,7 @@
             bottom: bottom
         };
     }
-    
+
     /**
      * Helper that takes object literal
      * and add all properties to element.style
@@ -152,24 +152,24 @@
             }
         }
     }
-        
+
     /**
      * Function places an absolutely positioned
      * element on top of the specified element
      * copying position and dimensions.
      * @param {Element} from
      * @param {Element} to
-     */    
+     */
     function copyLayout(from, to){
 	    var box = getBox(from);
-        
+
         addStyles(to, {
-	        position: 'absolute',                    
+	        position: 'absolute',
 	        left : box.left + 'px',
 	        top : box.top + 'px',
 	        width : from.offsetWidth + 'px',
 	        height : from.offsetHeight + 'px'
-	    });        
+	    });
 	to.title = from.title;
 
     }
@@ -186,50 +186,50 @@
             return div.removeChild(el);
         };
     })();
-            
+
     /**
      * Function generates unique id
-     * @return unique id 
+     * @return unique id
      */
     var getUID = (function(){
         var id = 0;
         return function(){
             return 'ValumsAjaxUpload' + id++;
         };
-    })();        
- 
+    })();
+
     /**
      * Get file name from path
      * @param {String} file path to file
      * @return filename
-     */  
+     */
     function fileFromPath(file){
         return file.replace(/.*(\/|\\)/, "");
     }
-    
+
     /**
      * Get file extension lowercase
      * @param {String} file name
      * @return file extension
-     */    
+     */
     function getExt(file){
         return (-1 !== file.indexOf('.')) ? file.replace(/.*[.]/, '') : '';
     }
 
-    function hasClass(el, name){        
-        var re = new RegExp('\\b' + name + '\\b');        
+    function hasClass(el, name){
+        var re = new RegExp('\\b' + name + '\\b');
         return re.test(el.className);
-    }    
+    }
     function addClass(el, name){
-        if ( ! hasClass(el, name)){   
+        if ( ! hasClass(el, name)){
             el.className += ' ' + name;
         }
-    }    
-    function removeClass(el, name){
-        var re = new RegExp('\\b' + name + '\\b');                
-        el.className = el.className.replace(re, '');        
     }
-    
+    function removeClass(el, name){
+        var re = new RegExp('\\b' + name + '\\b');
+        el.className = el.className.replace(re, '');
+    }
+
     function removeNode(el){
         el.parentNode.removeChild(el);
     }
@@ -237,7 +237,7 @@
     /**
      * Easy styling and uploading
      * @constructor
-     * @param button An element you want convert to 
+     * @param button An element you want convert to
      * upload button. Tested dimensions up to 500x500px
      * @param {Object} options See defaults below.
      */
@@ -254,16 +254,16 @@
             // The type of data that you're expecting back from the server.
             // html and xml are detected automatically.
             // Only useful when you are using json data as a response.
-            // Set to "json" in that case. 
+            // Set to "json" in that case.
             responseType: false,
             // Class applied to button when mouse is hovered
             hoverClass: 'hover',
             // Class applied to button when button is focused
             focusClass: 'focus',
             // Class applied to button when AU is disabled
-            disabledClass: 'disabled',            
+            disabledClass: 'disabled',
             // When user selects a file, useful with autoSubmit disabled
-            // You can return false to cancel upload			
+            // You can return false to cancel upload
             onChange: function(file, extension){
             },
             // Callback to fire before file is uploaded
@@ -275,33 +275,33 @@
             onComplete: function(file, response){
             }
         };
-                        
+
         // Merge the users options with our defaults
         for (var i in options) {
             if (options.hasOwnProperty(i)){
                 this._settings[i] = options[i];
             }
         }
-                
+
         // button isn't necessary a dom element
         if (button.jquery){
             // jQuery object was passed
             button = button[0];
         } else if (typeof button == "string") {
             if (/^#.*/.test(button)){
-                // If jQuery user passes #elementId don't break it					
-                button = button.slice(1);                
+                // If jQuery user passes #elementId don't break it
+                button = button.slice(1);
             }
-            
+
             button = document.getElementById(button);
         }
-        
+
         if ( ! button || button.nodeType !== 1){
-            throw new Error("Please make sure that you're passing a valid element"); 
+            throw new Error("Please make sure that you're passing a valid element");
         }
-                
+
         if ( button.nodeName.toUpperCase() == 'A'){
-            // disable link                       
+            // disable link
             addEvent(button, 'click', function(e){
                 if (e && e.preventDefault){
                     e.preventDefault();
@@ -310,40 +310,40 @@
                 }
             });
         }
-                    
+
         // DOM element
-        this._button = button;        
-        // DOM element                 
+        this._button = button;
+        // DOM element
         this._input = null;
         // If disabled clicking on button won't do anything
         this._disabled = false;
-        
+
         // if the button was disabled before refresh if will remain
         // disabled in FireFox, let's fix it
-        this.enable();        
-        
+        this.enable();
+
         this._rerouteClicks();
     };
-    
+
     // assigning methods to our class
     AjaxUpload.prototype = {
         setData: function(data){
             this._settings.data = data;
         },
-        disable: function(){            
+        disable: function(){
             addClass(this._button, this._settings.disabledClass);
             this._disabled = true;
-            
-            var nodeName = this._button.nodeName.toUpperCase();            
+
+            var nodeName = this._button.nodeName.toUpperCase();
             if (nodeName == 'INPUT' || nodeName == 'BUTTON'){
                 this._button.setAttribute('disabled', 'disabled');
-            }            
-            
+            }
+
             // hide input
             if (this._input){
                 // We use visibility instead of display to fix problem with Safari 4
-                // The problem is that the value of input doesn't change if it 
-                // has display none when user selects a file           
+                // The problem is that the value of input doesn't change if it
+                // has display none when user selects a file
                 this._input.parentNode.style.visibility = 'hidden';
             }
         },
@@ -351,16 +351,16 @@
             removeClass(this._button, this._settings.disabledClass);
             this._button.removeAttribute('disabled');
             this._disabled = false;
-            
+
         },
         /**
-         * Creates invisible file input 
+         * Creates invisible file input
          * that will hover above the button
          * <div><input type='file' /></div>
          */
-        _createInput: function(){ 
+        _createInput: function(){
             var self = this;
-                        
+
             var input = document.createElement("input");
             input.setAttribute('type', 'file');
             input.setAttribute('name', this._settings.name);
@@ -378,7 +378,7 @@
                 // 'inherit' the input doesn't work
                 'fontFamily' : 'sans-serif',
                 'cursor' : 'pointer'
-            });            
+            });
 
             var div = document.createElement("div");
             div.setAttribute('class', 'ajaxbutton-wrapper');
@@ -387,7 +387,7 @@
                 'position' : 'absolute',
                 'overflow' : 'hidden',
                 'margin' : 0,
-                'padding' : 0,                
+                'padding' : 0,
                 'opacity' : 0,
                 // Make sure browse button is in the right side
                 // in Internet Explorer
@@ -397,75 +397,75 @@
 				'cursor' : 'pointer'
 
             });
-            
+
             // Make sure that element opacity exists.
-            // Otherwise use IE filter            
+            // Otherwise use IE filter
             if ( div.style.opacity !== "0") {
                 if (typeof(div.filters) == 'undefined'){
                     throw new Error('Opacity not supported by the browser');
                 }
                 div.style.filter = "alpha(opacity=0)";
-            }            
-            
+            }
+
             addEvent(input, 'change', function(){
-                 
-                if ( ! input || input.value === ''){                
-                    return;                
-                }
-                            
-                // Get filename from input, required                
-                // as some browsers have path instead of it          
-                var file = fileFromPath(input.value);
-                                
-                if (false === self._settings.onChange.call(self, file, getExt(file))){
-                    self._clearInput();                
+
+                if ( ! input || input.value === ''){
                     return;
                 }
-                
+
+                // Get filename from input, required
+                // as some browsers have path instead of it
+                var file = fileFromPath(input.value);
+
+                if (false === self._settings.onChange.call(self, file, getExt(file))){
+                    self._clearInput();
+                    return;
+                }
+
                 // Submit form when value is changed
                 if (self._settings.autoSubmit) {
                     self.submit();
                 }
-            });            
+            });
 
             addEvent(input, 'mouseover', function(){
                 addClass(self._button, self._settings.hoverClass);
             });
-            
+
             addEvent(input, 'mouseout', function(){
                 removeClass(self._button, self._settings.hoverClass);
                 removeClass(self._button, self._settings.focusClass);
-                
+
                 // We use visibility instead of display to fix problem with Safari 4
-                // The problem is that the value of input doesn't change if it 
-                // has display none when user selects a file           
+                // The problem is that the value of input doesn't change if it
+                // has display none when user selects a file
                 input.parentNode.style.visibility = 'hidden';
 
-            });   
-                        
+            });
+
             addEvent(input, 'focus', function(){
                 addClass(self._button, self._settings.focusClass);
             });
-            
+
             addEvent(input, 'blur', function(){
                 removeClass(self._button, self._settings.focusClass);
             });
-            
+
 	        div.appendChild(input);
             document.body.appendChild(div);
-              
+
             this._input = input;
         },
         _clearInput : function(){
             if (!this._input){
                 return;
-            }            
-                             
-            // this._input.value = ''; Doesn't work in IE6                               
+            }
+
+            // this._input.value = ''; Doesn't work in IE6
             removeNode(this._input.parentNode);
-            this._input = null;                                                                   
+            this._input = null;
             this._createInput();
-            
+
             removeClass(this._button, this._settings.hoverClass);
             removeClass(this._button, this._settings.focusClass);
         },
@@ -475,7 +475,7 @@
          */
         _rerouteClicks: function(){
             var self = this;
-            
+
             // IE will later display 'access denied' error
             // if you use using self._input.click()
             // other browsers just ignore click()
@@ -484,21 +484,21 @@
                 if (self._disabled){
                     return;
                 }
-                                
+
                 if ( ! self._input){
 	                self._createInput();
                 }
-                
-                var div = self._input.parentNode;                            
+
+                var div = self._input.parentNode;
                 copyLayout(self._button, div);
                 div.style.visibility = 'visible';
-                                
+
             });
-            
-            
+
+
             // commented because we now hide input on mouseleave
             /**
-             * When the window is resized the elements 
+             * When the window is resized the elements
              * can be misaligned if button position depends
              * on window size
              */
@@ -506,8 +506,8 @@
             //    if (self._input){
             //        copyLayout(self._button, self._input.parentNode);
             //    }
-            //});            
-                                         
+            //});
+
         },
         /**
          * Creates iframe with unique name
@@ -516,24 +516,24 @@
         _createIframe: function(){
             // We can't use getTime, because it sometimes return
             // same value in safari :(
-            var id = getUID();            
-             
+            var id = getUID();
+
             // We can't use following code as the name attribute
             // won't be properly registered in IE6, and new window
             // on form submit will open
             // var iframe = document.createElement('iframe');
-            // iframe.setAttribute('name', id);                        
- 
+            // iframe.setAttribute('name', id);
+
             var iframe = toElement('<iframe src="javascript:false;" name="' + id + '" />');
             // src="javascript:false; was added
-            // because it possibly removes ie6 prompt 
+            // because it possibly removes ie6 prompt
             // "This page contains both secure and nonsecure items"
-            // Anyway, it doesn't do any harm.            
+            // Anyway, it doesn't do any harm.
             iframe.setAttribute('id', id);
-            
+
             iframe.style.display = 'none';
             document.body.appendChild(iframe);
-            
+
             return iframe;
         },
         /**
@@ -543,19 +543,19 @@
          */
         _createForm: function(iframe){
             var settings = this._settings;
-                        
+
             // We can't use the following code in IE6
             // var form = document.createElement('form');
             // form.setAttribute('method', 'post');
             // form.setAttribute('enctype', 'multipart/form-data');
-            // Because in this case file won't be attached to request                    
+            // Because in this case file won't be attached to request
             var form = toElement('<form method="post" enctype="multipart/form-data"></form>');
-                        
+
             form.setAttribute('action', settings.action);
-            form.setAttribute('target', iframe.name);                                   
+            form.setAttribute('target', iframe.name);
             form.style.display = 'none';
             document.body.appendChild(form);
-            
+
             // Create hidden input element for each data key
             for (var prop in settings.data) {
                 if (settings.data.hasOwnProperty(prop)){
@@ -571,34 +571,34 @@
         /**
          * Gets response from iframe and fires onComplete event when ready
          * @param iframe
-         * @param file Filename to use in onComplete callback 
+         * @param file Filename to use in onComplete callback
          */
-        _getResponse : function(iframe, file){            
+        _getResponse : function(iframe, file){
             // getting response
-            var toDeleteFlag = false, self = this, settings = this._settings;   
-               
-            addEvent(iframe, 'load', function(){                
-                
-                if (// For Safari 
+            var toDeleteFlag = false, self = this, settings = this._settings;
+
+            addEvent(iframe, 'load', function(){
+
+                if (// For Safari
                     iframe.src == "javascript:'%3Chtml%3E%3C/html%3E';" ||
                     // For FF, IE
-                    iframe.src == "javascript:'<html></html>';"){                                                                        
+                    iframe.src == "javascript:'<html></html>';"){
                         // First time around, do not delete.
                         // We reload to blank page, so that reloading main page
                         // does not re-submit the post.
-                        
+
                         if (toDeleteFlag) {
                             // Fix busy state in FF3
                             setTimeout(function(){
                                 removeNode(iframe);
                             }, 0);
                         }
-                                                
+
                         return;
                 }
-                
+
                 var doc = iframe.contentDocument ? iframe.contentDocument : window.frames[iframe.id].document;
-                
+
                 // fixing Opera 9.26,10.00
                 if (doc.readyState && doc.readyState != 'complete') {
                    // Opera fires load event multiple times
@@ -606,24 +606,24 @@
                    // this fix should not affect other browsers
                    return;
                 }
-                
+
                 // fixing Opera 9.64
                 if (doc.body && doc.body.innerHTML == "false") {
                     // In Opera 9.64 event was fired second time
-                    // when body.innerHTML changed from false 
+                    // when body.innerHTML changed from false
                     // to server response approx. after 1 sec
                     return;
                 }
-                
+
                 var response;
-                
+
                 if (doc.XMLDocument) {
                     // response is a xml document Internet Explorer property
                     response = doc.XMLDocument;
                 } else if (doc.body){
                     // response is html document or plain text
                     response = doc.body.innerHTML;
-                    
+
                     if (settings.responseType && settings.responseType.toLowerCase() == 'json') {
                         // If the document was sent as 'application/javascript' or
                         // 'text/javascript', then the browser wraps the text in a <pre>
@@ -635,7 +635,7 @@
                             doc.normalize();
                             response = doc.body.firstChild.firstChild.nodeValue;
                         }
-                        
+
                         if (response) {
                             response = eval("(" + response + ")");
                         } else {
@@ -646,60 +646,60 @@
                     // response is a xml document
                     response = doc;
                 }
-                
+
                 settings.onComplete.call(self, file, response);
-                
+
                 // Reload blank page, so that reloading main page
                 // does not re-submit the post. Also, remember to
                 // delete the frame
                 toDeleteFlag = true;
-                
+
                 // Fix IE mixed content issue
                 iframe.src = "javascript:'<html></html>';";
-            });            
-        },        
+            });
+        },
         /**
          * Upload file contained in this._input
          */
-        submit: function(){                        
+        submit: function(){
             var self = this, settings = this._settings;
-            
-            if ( ! this._input || this._input.value === ''){                
-                return;                
-            }
-                                    
-            var file = fileFromPath(this._input.value);
-            
-            // user returned false to cancel upload
-            if (false === settings.onSubmit.call(this, file, getExt(file))){
-                this._clearInput();                
+
+            if ( ! this._input || this._input.value === ''){
                 return;
             }
-            
-            // sending request    
+
+            var file = fileFromPath(this._input.value);
+
+            // user returned false to cancel upload
+            if (false === settings.onSubmit.call(this, file, getExt(file))){
+                this._clearInput();
+                return;
+            }
+
+            // sending request
             var iframe = this._createIframe();
             var form = this._createForm(iframe);
-            
+
             // assuming following structure
             // div -> input type='file'
-            removeNode(this._input.parentNode);            
+            removeNode(this._input.parentNode);
             removeClass(self._button, self._settings.hoverClass);
             removeClass(self._button, self._settings.focusClass);
-                        
+
             form.appendChild(this._input);
-                        
+
             form.submit();
 
-            // request set, clean up                
-            removeNode(form); form = null;                          
-            removeNode(this._input); this._input = null;            
-            
-            // Get response from iframe and fire onComplete event when ready
-            this._getResponse(iframe, file);            
+            // request set, clean up
+            removeNode(form); form = null;
+            removeNode(this._input); this._input = null;
 
-            // get ready for next request            
+            // Get response from iframe and fire onComplete event when ready
+            this._getResponse(iframe, file);
+
+            // get ready for next request
             this._createInput();
         }
     };
-})(); 
+})();
 // @license-end

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-09 21:17+0200\n"
+"POT-Creation-Date: 2026-05-09 22:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,7 +48,7 @@ msgstr ""
 #: mod/photos.php:418 src/Model/Event.php:510 src/Module/Attach.php:40
 #: src/Module/BaseApi.php:91 src/Module/BaseNotifications.php:83
 #: src/Module/BaseSettings.php:38 src/Module/Calendar/Event/API.php:75
-#: src/Module/Calendar/Event/Form.php:70 src/Module/Calendar/Export.php:68
+#: src/Module/Calendar/Event/Form.php:73 src/Module/Calendar/Export.php:68
 #: src/Module/Calendar/Show.php:71 src/Module/Circle.php:27
 #: src/Module/Circle.php:70 src/Module/Contact/Advanced.php:46
 #: src/Module/Contact/Follow.php:77 src/Module/Contact/Follow.php:145
@@ -83,7 +83,7 @@ msgid "Permission denied."
 msgstr ""
 
 #: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:315
-#: view/theme/frio/theme.php:229
+#: view/theme/frio/theme.php:230
 msgid "Messages"
 msgstr ""
 
@@ -315,7 +315,7 @@ msgid "If you want to add this photo to an album, begin typing its name, and exi
 msgstr ""
 
 #: mod/photos.php:487 mod/photos.php:806 src/Content/Conversation.php:407
-#: src/Module/Calendar/Event/Form.php:245 src/Module/Post/Edit.php:183
+#: src/Module/Calendar/Event/Form.php:266 src/Module/Post/Edit.php:183
 msgid "Permissions"
 msgstr ""
 
@@ -341,7 +341,7 @@ msgstr ""
 msgid "New album name: "
 msgstr ""
 
-#: mod/photos.php:577 mod/photos.php:809
+#: mod/photos.php:577 mod/photos.php:809 src/Module/Calendar/Event/Form.php:124
 #: src/Module/Settings/Server/Index.php:98
 msgid "Save changes"
 msgstr ""
@@ -426,11 +426,14 @@ msgstr ""
 msgid "Rotate CCW (left)"
 msgstr ""
 
-#: mod/photos.php:827 src/Object/Post.php:231 src/Object/Post.php:233
+#: mod/photos.php:827 src/Model/Event.php:652
+#: src/Module/Calendar/Event/Show.php:67 src/Object/Post.php:231
+#: src/Object/Post.php:233
 msgid "Edit"
 msgstr ""
 
-#: mod/photos.php:828 src/Content/Conversation.php:1537
+#: mod/photos.php:828 src/Content/Conversation.php:1537 src/Model/Event.php:654
+#: src/Module/Calendar/Event/Show.php:69
 #: src/Module/Moderation/Users/Active.php:92
 #: src/Module/Moderation/Users/Blocked.php:92
 #: src/Module/Moderation/Users/Index.php:100
@@ -569,15 +572,15 @@ msgstr ""
 msgid "No system theme config value set."
 msgstr ""
 
-#: src/BaseModule.php:408
+#: src/BaseModule.php:400
 msgid "The form security token was not correct. This probably happened because the form has been opened for too long (>3 hours) before submitting it."
 msgstr ""
 
-#: src/BaseModule.php:435
+#: src/BaseModule.php:427
 msgid "All contacts"
 msgstr ""
 
-#: src/BaseModule.php:440 src/Content/Conversation/Factory/Channel.php:33
+#: src/BaseModule.php:432 src/Content/Conversation/Factory/Channel.php:33
 #: src/Content/Widget.php:263 src/Core/ACL.php:185 src/Module/Contact.php:399
 #: src/Module/Privacy/PermissionTooltip.php:181
 #: src/Module/Privacy/PermissionTooltip.php:203
@@ -585,17 +588,17 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: src/BaseModule.php:445 src/Content/Widget.php:264 src/Module/Contact.php:402
+#: src/BaseModule.php:437 src/Content/Widget.php:264 src/Module/Contact.php:402
 #: src/Module/Settings/Channels.php:153
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:450 src/Content/Widget.php:265 src/Model/User.php:1428
+#: src/BaseModule.php:442 src/Content/Widget.php:265 src/Model/User.php:1428
 #: src/Module/Contact.php:405
 msgid "Friends"
 msgstr ""
 
-#: src/BaseModule.php:458
+#: src/BaseModule.php:450
 msgid "Common"
 msgstr ""
 
@@ -1187,7 +1190,7 @@ msgstr ""
 msgid "Public post"
 msgstr ""
 
-#: src/Content/Conversation.php:419 src/Module/Calendar/Event/Form.php:240
+#: src/Content/Conversation.php:419 src/Module/Calendar/Event/Form.php:261
 #: src/Module/Item/Compose.php:203 src/Module/Post/Edit.php:165
 #: src/Object/Post.php:1179
 msgid "Preview"
@@ -1697,11 +1700,11 @@ msgstr ""
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: src/Content/Item.php:435 view/theme/frio/theme.php:250
+#: src/Content/Item.php:435 view/theme/frio/theme.php:251
 msgid "Follow Thread"
 msgstr ""
 
-#: src/Content/Item.php:436 view/theme/frio/theme.php:267
+#: src/Content/Item.php:436 view/theme/frio/theme.php:268
 msgid "Complete Thread"
 msgstr ""
 
@@ -1831,11 +1834,11 @@ msgstr ""
 #: src/Content/Nav.php:227 src/Module/BaseProfile.php:34
 #: src/Module/BaseSettings.php:86 src/Module/Contact.php:489
 #: src/Module/Contact/Profile.php:471 src/Module/Profile/Profile.php:277
-#: src/Module/Welcome.php:44 view/theme/frio/theme.php:218
+#: src/Module/Welcome.php:44 view/theme/frio/theme.php:219
 msgid "Profile"
 msgstr ""
 
-#: src/Content/Nav.php:227 view/theme/frio/theme.php:218
+#: src/Content/Nav.php:227 view/theme/frio/theme.php:219
 msgid "Your profile page"
 msgstr ""
 
@@ -1851,11 +1854,11 @@ msgstr ""
 #: src/Content/Nav.php:229 src/Module/BaseProfile.php:50
 #: src/Module/Media/Attachment/Browser.php:67
 #: src/Module/Media/Photo/Browser.php:62 src/Module/Media/Photo/Browser.php:79
-#: view/theme/frio/theme.php:222
+#: view/theme/frio/theme.php:223
 msgid "Photos"
 msgstr ""
 
-#: src/Content/Nav.php:229 view/theme/frio/theme.php:222
+#: src/Content/Nav.php:229 view/theme/frio/theme.php:223
 msgid "Your photos"
 msgstr ""
 
@@ -1863,11 +1866,11 @@ msgstr ""
 #: src/Module/BaseProfile.php:70 src/Module/BaseProfile.php:73
 #: src/Module/BaseProfile.php:81 src/Module/BaseProfile.php:84
 #: src/Module/Calendar/Show.php:113 src/Module/Settings/Display.php:434
-#: view/theme/frio/theme.php:224 view/theme/frio/theme.php:228
+#: view/theme/frio/theme.php:225 view/theme/frio/theme.php:229
 msgid "Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:230 view/theme/frio/theme.php:224
+#: src/Content/Nav.php:230 view/theme/frio/theme.php:225
 msgid "Your calendar"
 msgstr ""
 
@@ -1935,7 +1938,7 @@ msgstr ""
 #: src/Content/Text/HTML.php:880 src/Module/BaseProfile.php:112
 #: src/Module/BaseProfile.php:115 src/Module/Contact.php:181
 #: src/Module/Contact.php:411 src/Module/Contact.php:521
-#: view/theme/frio/theme.php:231
+#: view/theme/frio/theme.php:232
 msgid "Contacts"
 msgstr ""
 
@@ -1974,15 +1977,15 @@ msgstr ""
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:303 view/theme/frio/theme.php:227
+#: src/Content/Nav.php:303 view/theme/frio/theme.php:228
 msgid "Network"
 msgstr ""
 
-#: src/Content/Nav.php:303 view/theme/frio/theme.php:227
+#: src/Content/Nav.php:303 view/theme/frio/theme.php:228
 msgid "Conversations from your friends"
 msgstr ""
 
-#: src/Content/Nav.php:305 view/theme/frio/theme.php:217
+#: src/Content/Nav.php:305 view/theme/frio/theme.php:218
 msgid "Your posts and conversations"
 msgstr ""
 
@@ -2012,7 +2015,7 @@ msgstr ""
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:315 view/theme/frio/theme.php:229
+#: src/Content/Nav.php:315 view/theme/frio/theme.php:230
 msgid "Private mail"
 msgstr ""
 
@@ -2035,15 +2038,15 @@ msgstr ""
 #: src/Content/Nav.php:328 src/Module/Admin/Addons/Details.php:140
 #: src/Module/Admin/Themes/Details.php:85 src/Module/BaseAdmin.php:88
 #: src/Module/BaseSettings.php:177 src/Module/Welcome.php:39
-#: view/theme/frio/theme.php:230
+#: view/theme/frio/theme.php:231
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:328 view/theme/frio/theme.php:230
+#: src/Content/Nav.php:328 view/theme/frio/theme.php:231
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:330 view/theme/frio/theme.php:231
+#: src/Content/Nav.php:330 view/theme/frio/theme.php:232
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
@@ -2425,108 +2428,108 @@ msgstr ""
 msgid "Connectors"
 msgstr ""
 
-#: src/Core/Installer.php:166
+#: src/Core/Installer.php:165
 msgid "The database configuration file \"config/local.config.php\" could not be written. Please use the enclosed text to create a configuration file in your web server root."
 msgstr ""
 
-#: src/Core/Installer.php:183
+#: src/Core/Installer.php:182
 msgid "You may need to import the file \"database.sql\" manually using phpmyadmin or mysql."
 msgstr ""
 
-#: src/Core/Installer.php:184 src/Module/Install.php:192
+#: src/Core/Installer.php:183 src/Module/Install.php:192
 #: src/Module/Install.php:337
 msgid "Please see the file \"doc/INSTALL.md\"."
 msgstr ""
 
-#: src/Core/Installer.php:245
+#: src/Core/Installer.php:244
 msgid "Could not find a command line version of PHP in the web server PATH."
 msgstr ""
 
-#: src/Core/Installer.php:246
+#: src/Core/Installer.php:245
 msgid "If you don't have a command line version of PHP installed on your server, you will not be able to run the background processing. See <a href='https://github.com/friendica/friendica/blob/stable/doc/Install.md#set-up-the-worker'>'Setup the worker'</a>"
 msgstr ""
 
-#: src/Core/Installer.php:251
+#: src/Core/Installer.php:250
 msgid "PHP executable path"
 msgstr ""
 
-#: src/Core/Installer.php:251
+#: src/Core/Installer.php:250
 msgid "Enter full path to php executable. You can leave this blank to continue the installation."
 msgstr ""
 
-#: src/Core/Installer.php:256
+#: src/Core/Installer.php:255
 msgid "Command line PHP"
 msgstr ""
 
-#: src/Core/Installer.php:265
+#: src/Core/Installer.php:264
 msgid "PHP executable is not the php cli binary (could be cgi-fgci version)"
 msgstr ""
 
-#: src/Core/Installer.php:266
+#: src/Core/Installer.php:265
 msgid "Found PHP version: "
 msgstr ""
 
-#: src/Core/Installer.php:268
+#: src/Core/Installer.php:267
 msgid "PHP cli binary"
 msgstr ""
 
-#: src/Core/Installer.php:281
+#: src/Core/Installer.php:280
 msgid "The command line version of PHP on your system does not have \"register_argc_argv\" enabled."
 msgstr ""
 
-#: src/Core/Installer.php:282
+#: src/Core/Installer.php:281
 msgid "This is required for message delivery to work."
 msgstr ""
 
-#: src/Core/Installer.php:287
+#: src/Core/Installer.php:286
 msgid "PHP register_argc_argv"
 msgstr ""
 
-#: src/Core/Installer.php:319
+#: src/Core/Installer.php:318
 msgid "Error: the \"openssl_pkey_new\" function on this system is not able to generate encryption keys"
 msgstr ""
 
-#: src/Core/Installer.php:320
+#: src/Core/Installer.php:319
 msgid "If running under Windows, please see \"http://www.php.net/manual/en/openssl.installation.php\"."
 msgstr ""
 
-#: src/Core/Installer.php:323
+#: src/Core/Installer.php:322
 msgid "Generate encryption keys"
 msgstr ""
 
-#: src/Core/Installer.php:374
+#: src/Core/Installer.php:373
 msgid "Error: Apache webserver mod-rewrite module is required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:378
+#: src/Core/Installer.php:377
 msgid "Apache mod_rewrite module"
 msgstr ""
 
-#: src/Core/Installer.php:384
+#: src/Core/Installer.php:383
 msgid "Error: PDO or MySQLi PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:388
+#: src/Core/Installer.php:387
 msgid "Error: The MySQL driver for PDO is not installed."
 msgstr ""
 
-#: src/Core/Installer.php:391
+#: src/Core/Installer.php:390
 msgid "PDO or MySQLi PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:397
+#: src/Core/Installer.php:396
 msgid "Error: The IntlChar module is not installed."
 msgstr ""
 
-#: src/Core/Installer.php:400
+#: src/Core/Installer.php:399
 msgid "IntlChar PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:408
+#: src/Core/Installer.php:407
 msgid "Error, XML PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:412
+#: src/Core/Installer.php:411
 msgid "XML PHP module"
 msgstr ""
 
@@ -2538,175 +2541,175 @@ msgstr ""
 msgid "Error: libCURL PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:422
+#: src/Core/Installer.php:423
 msgid "GD graphics PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:423
+#: src/Core/Installer.php:424
 msgid "Error: GD graphics PHP module with JPEG support required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:429
+#: src/Core/Installer.php:431
 msgid "OpenSSL PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:430
+#: src/Core/Installer.php:432
 msgid "Error: openssl PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:436
+#: src/Core/Installer.php:439
 msgid "mb_string PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:437
+#: src/Core/Installer.php:440
 msgid "Error: mb_string PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:443
+#: src/Core/Installer.php:447
 msgid "iconv PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:444
+#: src/Core/Installer.php:448
 msgid "Error: iconv PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:450
+#: src/Core/Installer.php:455
 msgid "POSIX PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:451
+#: src/Core/Installer.php:456
 msgid "Error: POSIX PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:457
+#: src/Core/Installer.php:463
 msgid "Program execution functions"
 msgstr ""
 
-#: src/Core/Installer.php:458
+#: src/Core/Installer.php:464
 msgid "Error: Program execution functions (proc_open) required but not enabled."
 msgstr ""
 
-#: src/Core/Installer.php:464
+#: src/Core/Installer.php:471
 msgid "JSON PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:465
+#: src/Core/Installer.php:472
 msgid "Error: JSON PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:471
+#: src/Core/Installer.php:479
 msgid "File Information PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:472
+#: src/Core/Installer.php:480
 msgid "Error: File Information PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:478
+#: src/Core/Installer.php:487
 msgid "GNU Multiple Precision PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:479
+#: src/Core/Installer.php:488
 msgid "Error: GNU Multiple Precision PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:485
+#: src/Core/Installer.php:495
 msgid "IDN Functions PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:486
+#: src/Core/Installer.php:496
 msgid "Error: IDN Functions PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:509
+#: src/Core/Installer.php:519
 msgid "The web installer needs to be able to create a file called \"local.config.php\" in the \"config\" folder of your web server and it is unable to do so."
 msgstr ""
 
-#: src/Core/Installer.php:510
+#: src/Core/Installer.php:520
 msgid "This is most often a permission setting, as the web server may not be able to write files in your folder - even if you can."
 msgstr ""
 
-#: src/Core/Installer.php:511
+#: src/Core/Installer.php:521
 msgid "At the end of this procedure, we will give you a text to save in a file named local.config.php in your Friendica \"config\" folder."
 msgstr ""
 
-#: src/Core/Installer.php:512
+#: src/Core/Installer.php:522
 msgid "You can alternatively skip this procedure and perform a manual installation. Please see the file \"doc/INSTALL.md\" for instructions."
 msgstr ""
 
-#: src/Core/Installer.php:515
+#: src/Core/Installer.php:525
 msgid "config/local.config.php is writable"
 msgstr ""
 
-#: src/Core/Installer.php:535
+#: src/Core/Installer.php:545
 msgid "Friendica uses the Smarty3 template engine to render its web views. Smarty3 compiles templates to PHP to speed up rendering."
 msgstr ""
 
-#: src/Core/Installer.php:536
+#: src/Core/Installer.php:546
 msgid "In order to store these compiled templates, the web server needs to have write access to the directory view/smarty3/ under the Friendica top level folder."
 msgstr ""
 
-#: src/Core/Installer.php:537
+#: src/Core/Installer.php:547
 msgid "Please ensure that the user that your web server runs as (e.g. www-data) has write access to this folder."
 msgstr ""
 
-#: src/Core/Installer.php:538
+#: src/Core/Installer.php:548
 msgid "Note: as a security measure, you should give the web server write access to view/smarty3/ only--not the template files (.tpl) that it contains."
 msgstr ""
 
-#: src/Core/Installer.php:541
+#: src/Core/Installer.php:551
 msgid "view/smarty3 is writable"
 msgstr ""
 
-#: src/Core/Installer.php:569
+#: src/Core/Installer.php:579
 msgid "Url rewrite in .htaccess seems not working. Make sure you copied .htaccess-dist to .htaccess."
 msgstr ""
 
-#: src/Core/Installer.php:570
+#: src/Core/Installer.php:580
 msgid "In some circumstances (like running inside containers), you can skip this error."
 msgstr ""
 
-#: src/Core/Installer.php:572
+#: src/Core/Installer.php:582
 msgid "Error message from Curl when fetching"
 msgstr ""
 
-#: src/Core/Installer.php:578
+#: src/Core/Installer.php:588
 msgid "Url rewrite is working"
 msgstr ""
 
-#: src/Core/Installer.php:607
+#: src/Core/Installer.php:617
 msgid "The detection of TLS to secure the communication between the browser and the new Friendica server failed."
 msgstr ""
 
-#: src/Core/Installer.php:608
+#: src/Core/Installer.php:618
 msgid "It is highly encouraged to use Friendica only over a secure connection as sensitive information like passwords will be transmitted."
 msgstr ""
 
-#: src/Core/Installer.php:609
+#: src/Core/Installer.php:619
 msgid "Please ensure that the connection to the server is secure."
 msgstr ""
 
-#: src/Core/Installer.php:610
+#: src/Core/Installer.php:620
 msgid "No TLS detected"
 msgstr ""
 
-#: src/Core/Installer.php:612
+#: src/Core/Installer.php:622
 msgid "TLS detected"
 msgstr ""
 
-#: src/Core/Installer.php:629
+#: src/Core/Installer.php:639
 msgid "ImageMagick PHP extension is not installed"
 msgstr ""
 
-#: src/Core/Installer.php:631
+#: src/Core/Installer.php:641
 msgid "ImageMagick PHP extension is installed"
 msgstr ""
 
-#: src/Core/Installer.php:652
+#: src/Core/Installer.php:662
 msgid "Database already in use."
 msgstr ""
 
-#: src/Core/Installer.php:657
+#: src/Core/Installer.php:667
 msgid "Could not connect to database."
 msgstr ""
 
@@ -2998,7 +3001,7 @@ msgstr ""
 
 #: src/Model/Event.php:63 src/Model/Event.php:83 src/Model/Event.php:460
 #: src/Model/Event.php:932
-msgid "Finishes:"
+msgid "Ends:"
 msgstr ""
 
 #: src/Model/Event.php:409
@@ -3154,22 +3157,22 @@ msgid "December"
 msgstr ""
 
 #: src/Model/Event.php:452 src/Module/Calendar/Show.php:117
-#: src/Util/Temporal.php:333
+#: src/Util/Temporal.php:344
 msgid "today"
 msgstr ""
 
 #: src/Model/Event.php:453 src/Module/Calendar/Show.php:118
-#: src/Module/Settings/Display.php:411 src/Util/Temporal.php:343
+#: src/Module/Settings/Display.php:411 src/Util/Temporal.php:354
 msgid "month"
 msgstr ""
 
 #: src/Model/Event.php:454 src/Module/Calendar/Show.php:119
-#: src/Module/Settings/Display.php:412 src/Util/Temporal.php:344
+#: src/Module/Settings/Display.php:412 src/Util/Temporal.php:355
 msgid "week"
 msgstr ""
 
 #: src/Model/Event.php:455 src/Module/Calendar/Show.php:120
-#: src/Module/Settings/Display.php:413 src/Util/Temporal.php:345
+#: src/Module/Settings/Display.php:413 src/Util/Temporal.php:356
 msgid "day"
 msgstr ""
 
@@ -3190,16 +3193,8 @@ msgstr ""
 msgid "l, F j"
 msgstr ""
 
-#: src/Model/Event.php:652 src/Module/Calendar/Event/Form.php:121
-msgid "Edit event"
-msgstr ""
-
-#: src/Model/Event.php:653
-msgid "Duplicate event"
-msgstr ""
-
-#: src/Model/Event.php:654
-msgid "Delete event"
+#: src/Model/Event.php:653 src/Module/Calendar/Event/Show.php:68
+msgid "Duplicate"
 msgstr ""
 
 #: src/Model/Event.php:948 src/Model/Event.php:950
@@ -3298,7 +3293,8 @@ msgid "Poll end: %s"
 msgstr ""
 
 #: src/Model/Item.php:3692 src/Model/Item.php:3693
-msgid "View on separate page"
+#: src/Module/Calendar/Event/Show.php:70
+msgid "View related post"
 msgstr ""
 
 #: src/Model/Mail.php:120
@@ -4020,7 +4016,7 @@ msgstr ""
 msgid "Click to view details"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:83 src/Module/Calendar/Event/Form.php:198
+#: src/Module/Admin/Logs/View.php:83
 msgid "Event details"
 msgstr ""
 
@@ -4218,7 +4214,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:465 src/Module/Calendar/Event/Form.php:244
+#: src/Module/Admin/Site.php:465 src/Module/Calendar/Event/Form.php:265
 #: src/Module/Contact.php:532 src/Module/Profile/Profile.php:285
 msgid "Advanced"
 msgstr ""
@@ -5595,7 +5591,7 @@ msgid "Conversations started"
 msgstr ""
 
 #: src/Module/BaseProfile.php:58 src/Module/BaseProfile.php:61
-#: src/Module/Contact.php:513 view/theme/frio/theme.php:223
+#: src/Module/Contact.php:513 view/theme/frio/theme.php:224
 msgid "Media"
 msgstr ""
 
@@ -5698,7 +5694,7 @@ msgid "The post was created"
 msgstr ""
 
 #: src/Module/Calendar/Event/API.php:87 src/Module/Calendar/Event/API.php:122
-#: src/Module/Calendar/Event/Form.php:66
+#: src/Module/Calendar/Event/Form.php:67
 msgid "Invalid Request"
 msgstr ""
 
@@ -5718,25 +5714,41 @@ msgstr ""
 msgid "Event title and start time are required."
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:110
+#: src/Module/Calendar/Event/Form.php:113
 msgid "Create event"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:190
-msgid "Can't use BBCode here"
+#: src/Module/Calendar/Event/Form.php:193
+msgid "Formatting is not supported for this field"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:199
+#: src/Module/Calendar/Event/Form.php:196
+msgid "Edit event"
+msgstr ""
+
+#: src/Module/Calendar/Event/Form.php:198
+msgid "New event"
+msgstr ""
+
+#: src/Module/Calendar/Event/Form.php:201
+msgid "Ends"
+msgstr ""
+
+#: src/Module/Calendar/Event/Form.php:208
+msgid "Back to the calendar"
+msgstr ""
+
+#: src/Module/Calendar/Event/Form.php:211
 msgid "Starting date and Title are required."
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:200
-#: src/Module/Calendar/Event/Form.php:205
-msgid "Event starts"
+#: src/Module/Calendar/Event/Form.php:212
+#: src/Module/Calendar/Event/Form.php:217
+msgid "Starts"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:200
-#: src/Module/Calendar/Event/Form.php:229 src/Module/Debug/Probe.php:45
+#: src/Module/Calendar/Event/Form.php:212
+#: src/Module/Calendar/Event/Form.php:248 src/Module/Debug/Probe.php:45
 #: src/Module/Install.php:186 src/Module/Install.php:212
 #: src/Module/Install.php:217 src/Module/Install.php:231
 #: src/Module/Install.php:240 src/Module/Install.php:245
@@ -5759,38 +5771,52 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:214
-#: src/Module/Calendar/Event/Form.php:239
-msgid "End date/time is unknown or irrelevant"
+#: src/Module/Calendar/Event/Form.php:227
+msgid "When does it happen?"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:216
-#: src/Module/Calendar/Event/Form.php:221
-msgid "Event ends"
+#: src/Module/Calendar/Event/Form.php:228
+msgid "Further details"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:229
-#: src/Module/Calendar/Event/Form.php:235
+#: src/Module/Calendar/Event/Form.php:230
+#: src/Module/Calendar/Event/Form.php:260
+msgid "Don't specify ending"
+msgstr ""
+
+#: src/Module/Calendar/Event/Form.php:248
 msgid "Title"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:231 src/Module/Settings/Channels.php:185
+#: src/Module/Calendar/Event/Form.php:250
+#: src/Module/Settings/Profile/Index.php:282
+msgid "Location"
+msgstr ""
+
+#: src/Module/Calendar/Event/Form.php:251
+msgid "Where does it happen?"
+msgstr ""
+
+#: src/Module/Calendar/Event/Form.php:253 src/Module/Settings/Channels.php:185
 #: src/Module/Settings/Channels.php:211 src/Module/Settings/Display.php:471
 #: src/Module/Settings/TwoFactor/AppSpecific.php:123
 msgid "Description"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:233
-#: src/Module/Settings/Profile/Index.php:282
-msgid "Location"
+#: src/Module/Calendar/Event/Form.php:254
+msgid "What are the details?"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:236
-#: src/Module/Calendar/Event/Form.php:237
+#: src/Module/Calendar/Event/Form.php:256
+msgid "Event title"
+msgstr ""
+
+#: src/Module/Calendar/Event/Form.php:257
+#: src/Module/Calendar/Event/Form.php:258
 msgid "Share this event"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:243 src/Module/Profile/Profile.php:284
+#: src/Module/Calendar/Event/Form.php:264 src/Module/Profile/Profile.php:284
 msgid "Basic"
 msgstr ""
 
@@ -6466,7 +6492,7 @@ msgid "Actions"
 msgstr ""
 
 #: src/Module/Contact/Profile.php:469
-#: src/Module/Settings/TwoFactor/Index.php:126 view/theme/frio/theme.php:217
+#: src/Module/Settings/TwoFactor/Index.php:126 view/theme/frio/theme.php:218
 msgid "Status"
 msgstr ""
 
@@ -11988,69 +12014,69 @@ msgstr ""
 msgid "YYYY-MM-DD or MM-DD"
 msgstr ""
 
-#: src/Util/Temporal.php:270
+#: src/Util/Temporal.php:206
 #, php-format
 msgid "Time zone: <strong>%s</strong> <a href=\"%s\">Change in Settings</a>"
 msgstr ""
 
-#: src/Util/Temporal.php:310 src/Util/Temporal.php:319
+#: src/Util/Temporal.php:321 src/Util/Temporal.php:330
 msgid "never"
 msgstr ""
 
-#: src/Util/Temporal.php:333
+#: src/Util/Temporal.php:344
 msgid "less than a second ago"
 msgstr ""
 
-#: src/Util/Temporal.php:342
+#: src/Util/Temporal.php:353
 msgid "year"
 msgstr ""
 
-#: src/Util/Temporal.php:342
+#: src/Util/Temporal.php:353
 msgid "years"
 msgstr ""
 
-#: src/Util/Temporal.php:343
+#: src/Util/Temporal.php:354
 msgid "months"
 msgstr ""
 
-#: src/Util/Temporal.php:344
+#: src/Util/Temporal.php:355
 msgid "weeks"
 msgstr ""
 
-#: src/Util/Temporal.php:345
+#: src/Util/Temporal.php:356
 msgid "days"
 msgstr ""
 
-#: src/Util/Temporal.php:346
+#: src/Util/Temporal.php:357
 msgid "hour"
 msgstr ""
 
-#: src/Util/Temporal.php:346
+#: src/Util/Temporal.php:357
 msgid "hours"
 msgstr ""
 
-#: src/Util/Temporal.php:347
+#: src/Util/Temporal.php:358
 msgid "minute"
 msgstr ""
 
-#: src/Util/Temporal.php:347
+#: src/Util/Temporal.php:358
 msgid "minutes"
 msgstr ""
 
-#: src/Util/Temporal.php:348
+#: src/Util/Temporal.php:359
 msgid "second"
 msgstr ""
 
-#: src/Util/Temporal.php:348
+#: src/Util/Temporal.php:359
 msgid "seconds"
 msgstr ""
 
-#: src/Util/Temporal.php:357
+#: src/Util/Temporal.php:368
 #, php-format
 msgid "in %1$d %2$s"
 msgstr ""
 
-#: src/Util/Temporal.php:359
+#: src/Util/Temporal.php:370
 #, php-format
 msgid "%1$d %2$s ago"
 msgstr ""
@@ -12183,15 +12209,15 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: view/theme/frio/theme.php:199
+#: view/theme/frio/theme.php:200
 msgid "Guest"
 msgstr ""
 
-#: view/theme/frio/theme.php:202
+#: view/theme/frio/theme.php:203
 msgid "Visitor"
 msgstr ""
 
-#: view/theme/frio/theme.php:223
+#: view/theme/frio/theme.php:224
 msgid "Your postings with media"
 msgstr ""
 

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2563,6 +2563,11 @@ p.wall-item-announce,
 }
 
 .help-block {
+	color: #636363;
+}
+
+/* Darker text color for help-blocks in settings because they're more prevalent and important there */
+.settings-content-wrapper .help-block {
 	color: $font_color_darker;
 }
 
@@ -3017,6 +3022,10 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 	color: $link_hover_color;
 	text-decoration: none;
 }
+#event-header {
+	display: flex;
+	justify-content: space-between;
+}
 .event-wrapper .event-owner {
 	margin-bottom: 15px;
 	word-break: break-all;
@@ -3038,9 +3047,6 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 .event-wrapper .event-buttons {
 	margin-top: 15px;
 }
-#event-form-wrapper {
-	padding-top: 5px;
-}
 #event-edit-form-wrapper {
 	padding-top: 15px;
 }
@@ -3048,7 +3054,7 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 	color: $font_color_darker;
 }
 #event-edit-form-wrapper #event-edit-time {
-	padding: 10px 0;
+	padding: 0;
 }
 .event-buttons .plink-event-link {
 	margin-left: 20px;
@@ -3063,7 +3069,7 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 	font-size: inherit;
 	color: inherit;
 }
-.modal-body .vevent .event-summary {
+.vevent .event-summary {
 	display: none;
 }
 #event-preview .vevent .event-summary {
@@ -3147,6 +3153,21 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 .event-card .description {
 	margin-top: 10px;
 	box-shadow: 0 1.5px 0 0 rgba(0, 0, 0, 0.1) inset;
+}
+#event-edit-time > section  {
+	align-items: flex-start;
+	display: flex;
+	gap: 10px;
+}
+.calendar-content-wrapper h3 {
+	font-size: 20px;
+}
+.share-checkbox > div {
+	display: inline;
+	padding-right: 15px;
+}
+#summary_tip {
+	font-size: 85%; /* Equivalent to the <small> tag */
 }
 /* Photos Pages */
 #photo-photo {

--- a/view/theme/frio/js/mod_events.js
+++ b/view/theme/frio/js/mod_events.js
@@ -364,8 +364,8 @@ function toggleEventNav(elm) {
 
 // Disable the input for the finish date if it is not available.
 function enableDisableFinishDate() {
-	if ($("#id_nofinish").is(":checked")) $("#id_finish_text").prop("disabled", true);
-	else $("#id_finish_text").prop("disabled", false);
+	if ($("#id_nofinish").is(":checked")) $("#id_finish_text_wrapper").prop("disabled", true).css("visibility", "hidden");
+	else $("#id_finish_text_wrapper").prop("disabled", false).css("visibility", "visible");
 }
 
 // @license-end

--- a/view/theme/frio/js/modal.js
+++ b/view/theme/frio/js/modal.js
@@ -206,7 +206,6 @@
 
 		// Initialize the filebrowser
 		if (typeof window.loadScript === "function") {
-			window.loadScript("view/js/ajaxupload.js");
 			window.loadScript("view/theme/frio/js/module/media/browser.js", function () {
 				if (typeof window.Browser !== "undefined" && typeof window.Browser.init === "function") {
 					window.Browser.init(filebrowser.dataset.nickname, filebrowser.dataset.type, match[1]);

--- a/view/theme/frio/js/modal.js
+++ b/view/theme/frio/js/modal.js
@@ -226,13 +226,7 @@
 
 		let title = "";
 
-		// Special handling for event modals
-		if ($("#modal-body .event-wrapper .event-summary").length) {
-			const eventsum = $("#modal-body .event-wrapper .event-summary").html();
-			title = '<i class="fa fa-calendar" aria-hidden="true"></i>&nbsp;' + eventsum;
-		} else {
-			title = $heading.html();
-		}
+		title = $heading.html();
 
 		if (title) {
 			$("#modal-title").append(title);
@@ -285,12 +279,6 @@
 	 * @param {string} url - The edit post URL
 	 */
 	function editpost(url) {
-		// Check if this is an event post
-		const splitURL = window.parseUrl ? window.parseUrl(url) : { path: "" };
-		if (splitURL.path && splitURL.path.indexOf("calendar/event/show") > -1) {
-			addToModal(splitURL.path);
-			return;
-		}
 
 		const $modal = $("#jot-modal").modal();
 		const loadUrl = url + " #jot-sections";
@@ -387,29 +375,12 @@
 		}
 	}
 
-	/**
-	 * Load the content of an edit URL into a modal.
-	 *
-	 * @param {string} url - The event edit URL
-	 */
-	function eventEdit(url) {
-		const char = window.qOrAmp ? window.qOrAmp(url) : (url.indexOf("?") < 0 ? "?" : "&");
-		const fullUrl = url + char + "mode=none";
-
-		$.get(fullUrl, function (data) {
-			$("#modal-body").empty().append(data);
-		}).done(function () {
-			loadModalTitle();
-		});
-	}
-
 	// Expose functions to global scope
 	window.addToModal = addToModal;
 	window.addElmToModal = addElmToModal;
 	window.editpost = editpost;
 	window.toggleJotNav = toggleJotNav;
 	window.openWallMessage = openWallMessage;
-	window.eventEdit = eventEdit;
 	// jotreset is no longer needed as a public function since we bind the handler once
 	// But keep it for backward compatibility just in case
 	window.jotreset = function () {

--- a/view/theme/frio/js/textedit.js
+++ b/view/theme/frio/js/textedit.js
@@ -170,7 +170,7 @@ function jotTextOpenUI(obj) {
 	if (obj.value === "" || obj.value === obj.dataset.default) {
 		var $el = $(".modal-body #profile-jot-text");
 		$el.addClass("profile-jot-text-full").removeClass("profile-jot-text-empty");
-		// initiale autosize for the jot
+		// initialize autosize for the jot
 		autosize($el);
 	}
 }

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -526,6 +526,7 @@ function justifyPhotos() {
 }
 
 // Load a js script to the html head.
+// Currently Only used to load browser.js, which could possibly be handled in a better way
 function loadScript(url, callback) {
 	// Check if the script is already in the html head.
 	var oscript = $('head script[src="' + url + '"]');

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -443,7 +443,7 @@ $(document).ready(function () {
 		$('.button-browser-share').hide();
 	}
 
-	// initiale autosize for the textareas
+	// initialize autosize for the textareas
 	autosize($("textarea.text-autosize"));
 });
 

--- a/view/theme/frio/php/frio_boot.php
+++ b/view/theme/frio/php/frio_boot.php
@@ -71,7 +71,6 @@ function get_modalpage_list()
 	$modalpages = [
 		'message/new',
 		'settings/oauth/add',
-		'calendar/event/new',
 		//		'fbrowser/image/'
 	];
 

--- a/view/theme/frio/templates/calendar/calendar.tpl
+++ b/view/theme/frio/templates/calendar/calendar.tpl
@@ -11,10 +11,10 @@
 	{{* The link to create a new event *}}
 	{{if $new_event.0}}
 	<div class="pull-right" id="new-event-link">
-		<button type="button" class="btn btn-primary page-action" onclick="addToModal('{{$new_event.0}}')" data-toggle="tooltip">
+		<a class="btn btn-primary page-action" href="{{$new_event.0}}">
 			<i class="fa fa-plus"></i>
 			<span>{{$new_event.1}}</span>
-		</button>
+		</a>
 	</div>
 	{{/if}}
 

--- a/view/theme/frio/templates/calendar/event.tpl
+++ b/view/theme/frio/templates/calendar/event.tpl
@@ -19,11 +19,31 @@
 			</div>
 		</div>
 
-		<div class="event-buttons pull-right">
-			{{if $event.edit}}<button type="button" class="btn" onclick="eventEdit('{{$event.edit.0}}')" title="{{$event.edit.1}}"><i class="fa fa-pencil" aria-hidden="true"></i></button>{{/if}}
-			{{if $event.copy}}<button type="button" class="btn" onclick="eventEdit('{{$event.copy.0}}')" title="{{$event.copy.1}}"><i class="fa fa-files-o" aria-hidden="true"></i></button>{{/if}}
-			{{if $event.drop}}<a href="{{$event.drop.0}}" onclick="return confirmDelete();" title="{{$event.drop.1}}" class="drop-event-link btn"><i class="fa fa-trash-o" aria-hidden="true"></i></a>{{/if}}
-			{{if $event.plink.orig}}<a href="{{$event.plink.orig}}" title="{{$event.plink.orig_title}}" class="plink-event-link btn" aria-label="{{$event.plink.1}}"><i class="fa fa-external-link" aria-hidden="true"></i></a>{{/if}}
+		<div class="event-buttons">
+			{{if $event.edit}}
+				<a class="btn btn-primary" href="{{$event.edit.0}}">
+					<i class="fa fa-pencil" aria-hidden="true"></i>
+					{{$event.edit.1}}
+				</a>
+			{{/if}}
+			{{if $event.copy}}
+				<a class="btn btn-secondary" href="{{$event.copy.0}}">
+					<i class="fa fa-files-o" aria-hidden="true"></i>
+					{{$event.copy.1}}
+				</a>
+				{{/if}}
+			{{if $event.drop}}
+				<a href="{{$event.drop.0}}" onclick="return confirmDelete();" class="drop-event-link btn btn-secondary">
+					<i class="fa fa-trash-o" aria-hidden="true"></i>
+					{{$event.drop.1}}
+				</a>
+			{{/if}}
+			{{if $event.plink.orig}}
+				<a href="{{$event.plink.orig}}" class="plink-event-link btn btn-primary pull-right" aria-label="{{$event.plink.1}}">
+					<i class="fa fa-external-link" aria-hidden="true"></i>
+					{{$event.plink.orig_title}}
+				</a>
+			{{/if}}
 		</div>
 		<div class="clear"></div>
 	</div>

--- a/view/theme/frio/templates/calendar/event.tpl
+++ b/view/theme/frio/templates/calendar/event.tpl
@@ -27,13 +27,13 @@
 				</a>
 			{{/if}}
 			{{if $event.copy}}
-				<a class="btn btn-secondary" href="{{$event.copy.0}}">
+				<a class="btn btn-default" href="{{$event.copy.0}}">
 					<i class="fa fa-files-o" aria-hidden="true"></i>
 					{{$event.copy.1}}
 				</a>
 				{{/if}}
 			{{if $event.drop}}
-				<a href="{{$event.drop.0}}" onclick="return confirmDelete();" class="drop-event-link btn btn-secondary">
+				<a href="{{$event.drop.0}}" onclick="return confirmDelete();" class="drop-event-link btn btn-default">
 					<i class="fa fa-trash-o" aria-hidden="true"></i>
 					{{$event.drop.1}}
 				</a>

--- a/view/theme/frio/templates/calendar/event_form.tpl
+++ b/view/theme/frio/templates/calendar/event_form.tpl
@@ -94,25 +94,25 @@
 					</div>
 
 					<div class="btn-group">
-						<button type="button" class="btn btn-secondary icon bb-url" style="cursor: pointer;" title="{{$edurl}}" data-role="insert-formatting" data-comment=" " data-bbcode="url" data-id="desc">
+						<button type="button" class="btn btn-default icon bb-url" style="cursor: pointer;" title="{{$edurl}}" data-role="insert-formatting" data-comment=" " data-bbcode="url" data-id="desc">
 							<i class="fa fa-link"></i>
 						</button>
-						<button type="button" class="btn btn-secondary icon bb-embed" style="cursor: pointer;" title="{{$edembed}}" data-role="insert-formatting" data-comment=" " data-bbcode="embed" data-id="desc">
+						<button type="button" class="btn btn-default icon bb-embed" style="cursor: pointer;" title="{{$edembed}}" data-role="insert-formatting" data-comment=" " data-bbcode="embed" data-id="desc">
 							<i class="fa fa-play"></i>
 						</button>
-						<button type="button" class="btn btn-secondary icon underline" style="cursor: pointer;" title="{{$eduline}}" data-role="insert-formatting" data-comment=" " data-bbcode="u" data-id="desc">
+						<button type="button" class="btn btn-default icon underline" style="cursor: pointer;" title="{{$eduline}}" data-role="insert-formatting" data-comment=" " data-bbcode="u" data-id="desc">
 							<i class="fa fa-underline"></i>
 						</button>
-						<button type="button" class="btn btn-secondary icon italic" style="cursor: pointer;" title="{{$editalic}}" data-role="insert-formatting" data-comment=" " data-bbcode="i" data-id="desc">
+						<button type="button" class="btn btn-default icon italic" style="cursor: pointer;" title="{{$editalic}}" data-role="insert-formatting" data-comment=" " data-bbcode="i" data-id="desc">
 							<i class="fa fa-italic"></i>
 						</button>
-						<button type="button" class="btn btn-secondary icon bold" style="cursor: pointer;"  title="{{$edbold}}" data-role="insert-formatting" data-comment=" " data-bbcode="b" data-id="desc">
+						<button type="button" class="btn btn-default icon bold" style="cursor: pointer;"  title="{{$edbold}}" data-role="insert-formatting" data-comment=" " data-bbcode="b" data-id="desc">
 							<i class="fa fa-bold"></i>
 						</button>
-						<button type="button" class="btn btn-secondary icon quote" style="cursor: pointer;" title="{{$edquote}}" data-role="insert-formatting" data-comment=" " data-bbcode="quote" data-id="desc">
+						<button type="button" class="btn btn-default icon quote" style="cursor: pointer;" title="{{$edquote}}" data-role="insert-formatting" data-comment=" " data-bbcode="quote" data-id="desc">
 							<i class="fa fa-quote-left"></i>
 						</button>
-						<button type="button" class="btn btn-secondary icon code" style="cursor: pointer;" title="{{$edcode}}" data-role="insert-formatting" data-comment=" " data-bbcode="code" data-id="desc">
+						<button type="button" class="btn btn-default icon code" style="cursor: pointer;" title="{{$edcode}}" data-role="insert-formatting" data-comment=" " data-bbcode="code" data-id="desc">
 							<i class="fa fa-code"></i>
 						</button>
 					</div>

--- a/view/theme/frio/templates/calendar/event_form.tpl
+++ b/view/theme/frio/templates/calendar/event_form.tpl
@@ -4,8 +4,19 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<div id="event-form-wrapper">
-	<h3 class="heading">{{$title}}</h3>
+<div class="generic-page-wrapper">
+	<header id="event-header">
+		<div class="section-title-wrapper">
+			<h2 class="heading">{{$title}}</h2>
+		</div>
+
+		<div class="event-actions">
+			<a class="btn btn-primary photos-upload-link page-action" href="calendar">
+				<i class="fa fa-mail-reply"></i>
+				{{$back_text}}
+			</a>
+		</div>
+	</header>
 
 	{{* The event edit navigation menu (text input, permissions, preview, filebrowser) *}}
 	<ul id="event-nav" class="nav nav-tabs event-nav" role="menubar" data-tabs="tabs">
@@ -13,9 +24,6 @@
 			the modal. Changing of the activity status is done by js in calendar_head.tpl *}}
 		<li class="active" role="menuitem">
 			<a id="event-edit-lnk" onclick="eventEditActive(); return false;">{{$basic}}</a>
-		</li>
-		<li role="menuitem">
-			<a id="event-desc-lnk" onclick="eventDescActive(); return false;">{{$advanced}}</a>
 		</li>
 		{{if $acl}}
 		<li role="menuitem" {{if !$sh_checked}} style="display: none"{{/if}}>
@@ -47,44 +55,42 @@
 			{{include file="field_input.tpl" field=$summary}}
 
 			<div id="event-edit-time">
-				{{* The field for event starting time *}}
-				{{$s_dsel nofilter}}
-
-				{{* The field for event finish time *}}
-				{{$f_dsel nofilter}}
-
+				<h3>{{$section_time}}</h3>
+				<p>{{$timezone_help nofilter}}</p>
 				{{* checkbox if the event doesn't have a finish time *}}
 				{{include file="field_checkbox.tpl" field=$nofinish}}
+				<section>
+					<div>
+						{{* The field for event starting time *}}
+						{{$s_dsel nofilter}}
+					</div>
+					<div>
+						{{* The field for event finish time *}}
+						{{$f_dsel nofilter}}
+					</div>
+				</section>
 			</div>
 
-			{{* checkbox to enable event sharing and the permissions tab *}}
-			{{if ! $eid}}
-			{{include file="field_checkbox.tpl" field=$share}}
-			{{/if}}
+				<h3>{{$section_additional}}</h3>
 
-			{{* The submit button - saves the event *}}
-			<div class="pull-right">
-				<button id="event-submit" type="submit" name="submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
+			{{* The textarea for the event location *}}
+			<div class="form-group">
+				<label for="comment-edit-text-loc">{{$l_text}}</label>
+				<textarea id="comment-edit-text-loc" class="form-control text-autosize" name="location" placeholder="{{$l_placeholder}}" rows="1" dir="auto">{{$l_orig}}</textarea>
+				<p><small class="help-block">{{$no_formatting}}</small></p>
 			</div>
-			<div class="clear"></div>
-		</div>
-
-		{{* The advanced tab *}}
-		<div id="event-desc-wrapper" style="display: none">
 
 			{{* The textarea for the event description *}}
 			<div class="form-group">
 				<div id="event-desc-text"><b>{{$d_text}}</b></div>
 				<div id="event-desc-text-edit-bb" class="comment-edit-bb comment-icon-list">
 					<div class="btn-group">
-					  {{* commented out because it isn't implemented yet
-					  <button type="button" class="btn btn-secondary icon bb-img" style="cursor: pointer;" title="{{$edimg}}" data-role="insert-formatting" data-comment=" " data-bbcode="img" data-id="desc">
-					  	<i class="fa fa-picture-o"></i>
-					  </button>
-					  *}}
-	        <button type="button" class="btn btn-default emojis" style="cursor: pointer;" aria-label="{{$edemojis}}" title="{{$edemojis}}">
-				    <i class="fa fa-smile-o"></i>
-			    </button>
+						<button type="button" class="btn btn-default icon bb-img" style="cursor: pointer;" title="{{$edimg}}" data-role="insert-formatting" data-comment=" " data-bbcode="img" data-id="desc">
+							<i class="fa fa-picture-o"></i>
+						</button>
+						<button type="button" class="btn btn-default emojis" style="cursor: pointer;" aria-label="{{$edemojis}}" title="{{$edemojis}}">
+							<i class="fa fa-smile-o"></i>
+						</button>
 					</div>
 
 					<div class="btn-group">
@@ -111,15 +117,19 @@
 						</button>
 					</div>
 				</div>
-				<textarea id="comment-edit-text-desc" class="form-control text-autosize emojis-target" name="desc" rows="8" dir="auto">{{$d_orig}}</textarea>
+				<textarea id="comment-edit-text-desc" class="form-control text-autosize emojis-target" placeholder="{{$d_placeholder}}" name="desc" rows="3" dir="auto">{{$d_orig}}</textarea>
 			</div>
 
-			{{* The textarea for the event location *}}
-			<div class="form-group">
-				<label for="comment-edit-text-loc">{{$l_text}}</label>
-				<textarea id="comment-edit-text-loc" class="form-control text-autosize" name="location" dir="auto">{{$l_orig}}</textarea>
-				<p>{{$no_bb}}</p>
+			{{* checkbox to enable event sharing and the permissions tab *}}
+			<div class="pull-right share-checkbox">
+			{{if ! $eid}}
+			{{include file="field_checkbox.tpl" field=$share}}
+			{{/if}}
+
+			{{* The submit button - saves the event *}}
+				<button id="event-submit" type="submit" name="submit" class="btn btn-primary" value="{{$submit}}">{{$submit}}</button>
 			</div>
+			<div class="clear"></div>
 		</div>
 
 		{{* The tab for the permissions (if event sharing is enabled) *}}

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -145,6 +145,7 @@
 	{{* own js files *}}
 	<script type="text/javascript" src="view/theme/frio/js/theme.js?v={{$VERSION}}"></script>
 	<script type="text/javascript" src="view/theme/frio/js/modal.js?v={{$VERSION}}"></script>
+	<script type="text/javascript" src="view/js/ajaxupload.js?v={{$VERSION}}"></script>
 	{{if ! $block_public}}
 		<script type="text/javascript" src="view/theme/frio/js/hovercard.js?v={{$VERSION}}"></script>
 	{{/if}}

--- a/view/theme/frio/templates/jot-header.tpl
+++ b/view/theme/frio/templates/jot-header.tpl
@@ -5,7 +5,6 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 
-<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{$VERSION}}"></script>
 <script type="text/javascript" src="{{$baseurl}}/view/js/linkPreview.js?v={{$VERSION}}"></script>
 <script type="text/javascript" src="{{$baseurl}}/view/theme/frio/js/jot.js?v={{$VERSION}}"></script>
 

--- a/view/theme/frio/templates/like_noshare.tpl
+++ b/view/theme/frio/templates/like_noshare.tpl
@@ -7,14 +7,14 @@
 
 <div id="wall-item-like-buttons-{{$id}}">
 	<button type="button"
-	        class="btn btn-secondary button-likes{{if $responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$id}}"
+	        class="btn btn-default button-likes{{if $responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$id}}"
 	        title="{{$like_title}}"
 	        onclick="doActivityItemAction({{$id}}, 'like'{{if $responses.like.self}}, true{{/if}});">
 		<i class="fa fa-thumbs-up" aria-hidden="true"></i>&nbsp;{{$like}}
 	</button>
 	{{if !$hide_dislike}}
 	<button type="button"
-	        class="btn btn-secondary button-likes{{if $responses.dislike.self}} active" aria-pressed="true{{/if}}"
+	        class="btn btn-default button-likes{{if $responses.dislike.self}} active" aria-pressed="true{{/if}}"
 	        id="dislike-{{$id}}"
 	        title="{{$dislike_title}}"
 	        onclick="doActivityItemAction({{$id}}, 'dislike'{{if $responses.dislike.self}}, true{{/if}});">

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -5,7 +5,6 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <script src="{{$baseurl}}/view/theme/frio/js/jquery.tools.min.js?v={{$VERSION}}"></script>
-<script type="text/javascript" src="{{$baseurl}}/view/js/ajaxupload.js?v={{$VERSION}}"></script>
 
 <div class="form-group field select">
 	<label for="id_{{$scheme.0}}">{{$scheme.1}}</label>


### PR DESCRIPTION
Gets us closer to closing #14564, except the occasional timing issue I discovered and described in there remains.
I could create a new issue for that?

- Move event creation and editing to a page instead of a modal
- Now event creation is not a modal: restore button to add a picture, which opens a modal
- Merge "Basic" and "Advanced" tabs
- Event "finish" -> "end"
- Add text to event edit buttons
- Hide "ending" field when end time is disabled
- Fix missing hover effect on BBCode buttons in the calendar and a couple of other places
- Some formatting changes in ajaxupload.js

**Suggested TODO's after this:**
- ~~Investigate and fix JS timing issue~~
- ~~Make the timezone help text only display once, maybe at the top~~ (done)
- Move preview out of the tab so all tabs can be removed, and put it either below, or into a modal

# Screenshots

## Creation/Editing

After:
<img width="666" height="753" alt="image" src="https://github.com/user-attachments/assets/ceff1fda-67dc-4330-acf6-f09720e6e86a" />

Before:

<img width="668" height="599" alt="image" src="https://github.com/user-attachments/assets/3671302f-d453-41dd-82e7-867f7394ffd2" />

<img width="657" height="529" alt="image" src="https://github.com/user-attachments/assets/26e8ba11-80a7-4cda-aeca-5626f1e0ab14" />

## Viewing

After:
<img width="661" height="253" alt="image" src="https://github.com/user-attachments/assets/d47a4249-7639-46b6-8925-1e17d46a592c" />

Before:
<img width="660" height="258" alt="image" src="https://github.com/user-attachments/assets/42b72af5-eeff-4c0e-8585-513a9ba8067a" />