### PR TITLE
Fix back-to-top button scroll direction and mobile sizing

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -195,6 +195,16 @@ details summary {
 	line-height: 1.5;
 }
 
+@media (max-width: 768px) {
+	#back-to-top {
+		font-size: 1.8em;
+		padding: 0 8px 0 8px;
+		right: 10px;
+		bottom: 10px;
+		line-height: 1.4;
+	}
+}
+
 #item-delete-selected {
 	cursor: pointer;
 	color: white;

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -16,14 +16,14 @@ $(document).ready(function () {
 	$(window).scroll(function () {
 		let currentScroll = $(this).scrollTop();
 
-		// Top of the page or going down = hide the button
-		if (!scrollStart || !currentScroll || currentScroll > scrollStart) {
+		// Top of the page or going up = hide the button
+		if (!scrollStart || !currentScroll || currentScroll < scrollStart) {
 			$("#back-to-top").fadeOut();
 			scrollStart = currentScroll;
 		}
 
-		// Going up enough = show the button
-		if (scrollStart - currentScroll > 100) {
+		// Going down enough = show the button
+		if (currentScroll - scrollStart > 100) {
 			$("#back-to-top").fadeIn();
 			scrollStart = currentScroll;
 		}


### PR DESCRIPTION
- Corrected scroll logic so button appears when scrolling down and hides when scrolling up or at top of page
- Add mobile CSS to reduce button size on screens <= 768px to avoid covering too much content

After:

<img width="660" height="1434" alt="IMG_3960" src="https://github.com/user-attachments/assets/a30427f6-813f-44c3-bb59-774f9a997ab6" />

Fixes #15689 