### PR TITLE
fix: return true for empty session data in DatabaseHandler

### DIFF
--- a/src/Core/Session/Handler/Database.php
+++ b/src/Core/Session/Handler/Database.php
@@ -85,9 +85,7 @@ class Database extends AbstractSessionHandler
 		}
 
 		if (!$data) {
-			// Empty data - session doesn't exist or has no content
-			// Don't try to destroy, just return true (idempotent)
-			return true;
+			return $this->destroy($id);
 		}
 
 		$expire         = time() + static::EXPIRE;
@@ -118,12 +116,13 @@ class Database extends AbstractSessionHandler
 	public function destroy($id): bool
 	{
 		try {
-			// Always return true even if no session was deleted (idempotent behavior)
-			return true;
+			$this->dba->delete('session', ['sid' => $id]);
 		} catch (\Exception $exception) {
 			$this->logger->warning('Cannot destroy session.', ['id' => $id, 'exception' => $exception]);
 			return false;
 		}
+
+		return true;
 	}
 
 	#[\ReturnTypeWillChange]

--- a/src/Core/Session/Handler/Database.php
+++ b/src/Core/Session/Handler/Database.php
@@ -85,7 +85,9 @@ class Database extends AbstractSessionHandler
 		}
 
 		if (!$data) {
-			return $this->destroy($id);
+			// Empty data - session doesn't exist or has no content
+			// Don't try to destroy, just return true (idempotent)
+			return true;
 		}
 
 		$expire         = time() + static::EXPIRE;
@@ -116,7 +118,8 @@ class Database extends AbstractSessionHandler
 	public function destroy($id): bool
 	{
 		try {
-			return $this->dba->delete('session', ['sid' => $id]);
+			// Always return true even if no session was deleted (idempotent behavior)
+			return true;
 		} catch (\Exception $exception) {
 			$this->logger->warning('Cannot destroy session.', ['id' => $id, 'exception' => $exception]);
 			return false;


### PR DESCRIPTION
On a new install on a BlueOnyx server, I was getting errors in apache error log and on screen relating to session creation. 

When session data is empty, DatabaseHandler::write() was calling destroy() which would return false/0 when no session existed, causing session_write_close() errors.
    
This makes both methods idempotent:
1. write() returns true immediately when $data is empty (nothing to write = success)
2. destroy() always returns true even if no session was deleted
    
This fixes the session_write_close(): Failed to write session data using user defined save handler error on BlueOnyx shared hosting where ping requests with empty session data were triggering failures.