### PR TITLE
Fix post visibility

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -452,12 +452,10 @@ class Post
 			["`visible` AND NOT `deleted`
 			AND NOT `author-blocked` AND NOT `owner-blocked`
 			AND (NOT `causer-blocked` OR `causer-id` = ? OR `causer-id` IS NULL) AND NOT `contact-blocked`
-			AND ((NOT `contact-readonly` AND NOT `contact-pending` AND (`contact-rel` IN (?, ?)))
-				OR `self` OR `contact-uid` = ?)
 			AND NOT EXISTS(SELECT `uri-id` FROM `post-user`    WHERE `uid` = ? AND `uri-id` = " . DBA::quoteIdentifier($view) . ".`uri-id` AND `hidden`)
 			AND NOT EXISTS(SELECT `cid`    FROM `user-contact` WHERE `uid` = ? AND `cid` IN (`author-id`, `owner-id`) AND (`blocked` OR `ignored` OR `is-blocked`))
 			AND NOT EXISTS(SELECT `gsid`   FROM `user-gserver` WHERE `uid` = ? AND `gsid` IN (`author-gsid`, `owner-gsid`, `causer-gsid`) AND `ignored`)",
-				0, Contact::SHARING, Contact::FRIEND, 0, $uid, $uid, $uid],
+				0, $uid, $uid, $uid],
 		);
 
 		$select_string = implode(', ', array_map([DBA::class, 'quoteIdentifier'], $selected));


### PR DESCRIPTION
The function `selectViewForUser` fetches posts for a given user. It contains multiple checks concerning blocked users or blocked servers. Historically it also contained a check whether the user follows the contact or if a contact request is pending.

This doesn't really make sense, because you might want to see posts from these users anyway.