### PR TITLE
Post/Comment menu UI/text adjustments

### DIFF
--- a/doc/en/user/access-keys.md
+++ b/doc/en/user/access-keys.md
@@ -81,7 +81,7 @@ For example, for moving to profile page in Firefox, press these three keys simul
 * q - Sort by Creation Date
 * r - Conversation (Posts that mention or involve you)
 * w - New posts
-* m - Favourite Posts
+* m - Bookmark posts
 
 ## ../notifications
 

--- a/doc/en/user/text-comment.md
+++ b/doc/en/user/text-comment.md
@@ -14,7 +14,7 @@ Here you can find an overview of the different ways to comment and sort existing
 <img src="doc/assets/img/post_share.png" width="27" height="32" alt="post_share.png" align="left" style="padding-bottom: 10px;"> This symbol is used to share a post. A copy of this post will automatically appear in your status editor and add a link to the original post.
 <p style="clear:both;"></p>
 
-<img src="doc/assets/img/post_mark.png" width="27" height="32" alt="post_mark.png" align="left" style="padding-bottom: 10px;"> This symbol is used to mark a post. Marked posts will appear on your network page at the "starred" tab (from "star"). Click it twice to undo your choice.
+<img src="doc/assets/img/post_mark.png" width="27" height="32" alt="post_mark.png" align="left" style="padding-bottom: 10px;"> This symbol is used to mark a post. Marked posts will appear on your network page at the "bookmarked" tab (from "bookmark"). Click it twice to undo your choice.
 <p style="clear:both;"></p>
 
 <img src="doc/assets/img/post_tag.png" width="27" height="41" alt="post_tag.png" align="left" style="padding-bottom: 10px;"> This symbol is used to tag a post with a self-chosen keyword. When you click at the word, you'll get a list of all posts with this tag. Attention: you can't delete the tag once you've set one.

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -676,7 +676,7 @@ class Conversation
 				$item['pagedrop'] = $pagedrop;
 
 				if ($item['gravity'] == ItemModel::GRAVITY_PARENT) {
-					$item_object = new PostObject($item, $this->mode);
+					$item_object = new PostObject($item);
 					$conv->addParent($item_object);
 				}
 			}

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -803,7 +803,7 @@ class Conversation
 				$row['direction'] = ['direction' => 6, 'title' => $this->l10n->t('Local delivery')];
 				break;
 			case ItemModel::PR_ACTIVITY:
-				$row['direction'] = ['direction' => 2, 'title' => $this->l10n->t('Stored because of your activity (like, comment, star, ...)')];
+				$row['direction'] = ['direction' => 2, 'title' => $this->l10n->t('Stored because of your activity (like, comment, bookmark, ...)')];
 				break;
 			case ItemModel::PR_DISTRIBUTE:
 				$row['direction'] = ['direction' => 6, 'title' => $this->l10n->t('Distributed')];

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -676,7 +676,7 @@ class Conversation
 				$item['pagedrop'] = $pagedrop;
 
 				if ($item['gravity'] == ItemModel::GRAVITY_PARENT) {
-					$item_object = new PostObject($item);
+					$item_object = new PostObject($item, $this->mode);
 					$conv->addParent($item_object);
 				}
 			}

--- a/src/Content/Conversation/Factory/Network.php
+++ b/src/Content/Conversation/Factory/Network.php
@@ -25,7 +25,7 @@ final class Network extends Timeline
 			new NetworkEntity(NetworkEntity::RECEIVED, $this->l10n->t('Latest Posts'), $this->l10n->t('Sort by post received date'), 't', $command . '?' . http_build_query(['order' => 'received'])),
 			new NetworkEntity(NetworkEntity::CREATED, $this->l10n->t('Latest Creation'), $this->l10n->t('Sort by post creation date'), 'q', $command . '?' . http_build_query(['order' => 'created'])),
 			new NetworkEntity(NetworkEntity::MENTION, $this->l10n->t('Personal'), $this->l10n->t('Posts that mention or involve you'), 'r', $command . '?' . http_build_query(['mention' => true])),
-			new NetworkEntity(NetworkEntity::STAR, $this->l10n->t('Starred'), $this->l10n->t('Favourite Posts'), 'm', $command . '?' . http_build_query(['star' => true])),
+			new NetworkEntity(NetworkEntity::STAR, $this->l10n->t('Bookmarked'), $this->l10n->t('Favourite Posts'), 'm', $command . '?' . http_build_query(['star' => true])),
 		];
 		return new Timelines($tabs);
 	}

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -432,17 +432,17 @@ class Item
 
 		if ($this->userSession->getLocalUserId()) {
 			$menu = [
-				$this->l10n->t('Follow Thread')                               => $sub_link,
-				$this->l10n->t('Complete Thread')                             => $complete_url,
+				$this->l10n->t('Turn on notifications for this post')         => $sub_link,
+				$this->l10n->t('Fetch more replies')                          => $complete_url,
 				$this->l10n->t('View Status')                                 => $status_link,
 				$this->l10n->t('View Profile')                                => $profile_link,
 				$this->l10n->t('View Photos')                                 => $photos_link,
 				$this->l10n->t('Network Posts')                               => $posts_link,
 				$this->l10n->t('View Contact')                                => $contact_url,
 				$this->l10n->t('Message')                                     => $pm_url,
-				$this->l10n->t('Block')                                       => $block_link,
-				$this->l10n->t('Ignore')                                      => $ignore_link,
 				$this->l10n->t('Collapse')                                    => $collapse_link,
+				$this->l10n->t('Ignore user')                                 => $ignore_link,
+				$this->l10n->t('Block user')                                  => $block_link,
 				$this->l10n->t("Ignore %s server", $authorBaseUri->getHost()) => $ignoreserver_link,
 			];
 

--- a/src/Module/Settings/Account.php
+++ b/src/Module/Settings/Account.php
@@ -170,7 +170,7 @@ class Account extends BaseSettings
 			$profile_fields = [
 				'publish'      => $publish,
 				'net-publish'  => $net_publish,
-				'hide-friends' => $hide_friends
+				'hide-friends' => $hide_friends,
 			];
 
 			if (!User::update($fields, DI::userSession()->getLocalUserId()) || !Profile::update($profile_fields, DI::userSession()->getLocalUserId())) {
@@ -380,7 +380,7 @@ class Account extends BaseSettings
 				DI::l10n()->t('Channel Relay'),
 				User::ACCOUNT_TYPE_RELAY,
 				DI::l10n()->t('Account for a service that automatically shares content based on user defined channels.'),
-				$user['account-type'] == User::ACCOUNT_TYPE_RELAY
+				$user['account-type'] == User::ACCOUNT_TYPE_RELAY,
 			];
 		} else {
 			$account_relay = null;
@@ -402,28 +402,28 @@ class Account extends BaseSettings
 				DI::l10n()->t('Personal Page'),
 				User::ACCOUNT_TYPE_PERSON,
 				DI::l10n()->t('Account for a personal profile.'),
-				$user['account-type'] == User::ACCOUNT_TYPE_PERSON
+				$user['account-type'] == User::ACCOUNT_TYPE_PERSON,
 			],
 			'$account_organisation' => [
 				'account-type',
 				DI::l10n()->t('Organisation Page'),
 				User::ACCOUNT_TYPE_ORGANISATION,
 				DI::l10n()->t('Account for an organisation that automatically approves contact requests as "Followers".'),
-				$user['account-type'] == User::ACCOUNT_TYPE_ORGANISATION
+				$user['account-type'] == User::ACCOUNT_TYPE_ORGANISATION,
 			],
 			'$account_news' => [
 				'account-type',
 				DI::l10n()->t('News Page'),
 				User::ACCOUNT_TYPE_NEWS,
 				DI::l10n()->t('Account for a news reflector that automatically approves contact requests as "Followers".'),
-				$user['account-type'] == User::ACCOUNT_TYPE_NEWS
+				$user['account-type'] == User::ACCOUNT_TYPE_NEWS,
 			],
 			'$account_community' => [
 				'account-type',
 				DI::l10n()->t('Community Group'),
 				User::ACCOUNT_TYPE_COMMUNITY,
 				DI::l10n()->t('Account for community discussions.'),
-				$user['account-type'] == User::ACCOUNT_TYPE_COMMUNITY
+				$user['account-type'] == User::ACCOUNT_TYPE_COMMUNITY,
 			],
 			'$account_relay' => $account_relay,
 			'$page_normal'   => [
@@ -431,42 +431,42 @@ class Account extends BaseSettings
 				DI::l10n()->t('Normal Account Page'),
 				User::PAGE_FLAGS_NORMAL,
 				DI::l10n()->t('Account for a regular personal profile that requires manual approval of "Friends" and "Followers".'),
-				$user['page-flags'] == User::PAGE_FLAGS_NORMAL
+				$user['page-flags'] == User::PAGE_FLAGS_NORMAL,
 			],
 			'$page_soapbox' => [
 				'page-flags',
 				DI::l10n()->t('Soapbox Page'),
 				User::PAGE_FLAGS_SOAPBOX,
 				DI::l10n()->t('Account for a public profile that automatically approves contact requests as "Followers".'),
-				$user['page-flags'] == User::PAGE_FLAGS_SOAPBOX
+				$user['page-flags'] == User::PAGE_FLAGS_SOAPBOX,
 			],
 			'$page_community' => [
 				'page-flags',
 				DI::l10n()->t('Public Group'),
 				User::PAGE_FLAGS_COMMUNITY,
 				DI::l10n()->t('Automatically approves all contact requests.'),
-				$user['page-flags'] == User::PAGE_FLAGS_COMMUNITY
+				$user['page-flags'] == User::PAGE_FLAGS_COMMUNITY,
 			],
 			'$page_community_manually' => [
 				'page-flags',
 				DI::l10n()->t('Public Group - Restricted'),
 				User::PAGE_FLAGS_COMM_MAN,
 				DI::l10n()->t('Contact requests have to be manually approved.'),
-				$user['page-flags'] == User::PAGE_FLAGS_COMM_MAN
+				$user['page-flags'] == User::PAGE_FLAGS_COMM_MAN,
 			],
 			'$page_freelove' => [
 				'page-flags',
 				DI::l10n()->t('Automatic Friend Page'),
 				User::PAGE_FLAGS_FREELOVE,
 				DI::l10n()->t('Account for a popular profile that automatically approves contact requests as "Friends".'),
-				$user['page-flags'] == User::PAGE_FLAGS_FREELOVE
+				$user['page-flags'] == User::PAGE_FLAGS_FREELOVE,
 			],
 			'$page_prvgroup' => [
 				'page-flags',
 				DI::l10n()->t('Private Group [Experimental]'),
 				User::PAGE_FLAGS_PRVGROUP,
 				DI::l10n()->t('Requires manual approval of contact requests.'),
-				$user['page-flags'] == User::PAGE_FLAGS_PRVGROUP
+				$user['page-flags'] == User::PAGE_FLAGS_PRVGROUP,
 			],
 		]);
 
@@ -482,7 +482,7 @@ class Account extends BaseSettings
 		} else {
 			$opt_tpl        = Renderer::getMarkupTemplate("field_checkbox.tpl");
 			$profile_in_dir = Renderer::replaceMacros($opt_tpl, [
-				'$field' => ['profile_in_directory', DI::l10n()->t('Publish your profile in your local site directory?'), $profile['publish'], DI::l10n()->t('Your profile will be published in this node\'s <a href="%s">local directory</a>. Your profile details may be publicly visible depending on the system settings.', DI::baseUrl() . '/directory')]
+				'$field' => ['profile_in_directory', DI::l10n()->t('Publish your profile in your local site directory?'), $profile['publish'], DI::l10n()->t('Your profile will be published in this node\'s <a href="%s">local directory</a>. Your profile details may be publicly visible depending on the system settings.', DI::baseUrl() . '/directory')],
 			]);
 		}
 
@@ -547,7 +547,7 @@ class Account extends BaseSettings
 				'days'         => ['expire', DI::l10n()->t("Automatically expire posts after this many days:"), $expire, DI::l10n()->t('If empty, posts will not expire. Expired posts will be deleted')],
 				'items'        => ['expire_items', DI::l10n()->t('Expire posts'), $expire_items, DI::l10n()->t('When activated, posts and comments will be expired.')],
 				'notes'        => ['expire_notes', DI::l10n()->t('Expire personal notes'), $expire_notes, DI::l10n()->t('When activated, the personal notes on your profile page will be expired.')],
-				'starred'      => ['expire_starred', DI::l10n()->t('Expire starred posts'), $expire_starred, DI::l10n()->t('Starring posts keeps them from being expired. That behaviour is overwritten by this setting.')],
+				'starred'      => ['expire_starred', DI::l10n()->t('Expire bookmarked posts'), $expire_starred, DI::l10n()->t('Bookmarking posts keeps them from being expired. That behaviour is overwritten by this setting.')],
 				'network_only' => ['expire_network_only', DI::l10n()->t('Only expire posts by others'), $expire_network_only, DI::l10n()->t('When activated, your own posts never expire. Then the settings above are only valid for posts you received.')],
 			],
 
@@ -576,19 +576,19 @@ class Account extends BaseSettings
 				'email_textonly',
 				DI::l10n()->t('Text-only notification emails'),
 				DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'email_textonly'),
-				DI::l10n()->t('Send text only notification emails, without the html part')
+				DI::l10n()->t('Send text only notification emails, without the html part'),
 			],
 			'$detailed_notif' => [
 				'detailed_notif',
 				DI::l10n()->t('Show detailled notifications'),
 				DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'detailed_notif'),
-				DI::l10n()->t('Per default, notifications are condensed to a single notification per item. When enabled every notification is displayed.')
+				DI::l10n()->t('Per default, notifications are condensed to a single notification per item. When enabled every notification is displayed.'),
 			],
 			'$notify_ignored' => [
 				'notify_ignored',
 				DI::l10n()->t('Show notifications of ignored contacts'),
 				DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'notify_ignored', true),
-				DI::l10n()->t("You don't see posts from ignored contacts. But you still see their comments. This setting controls if you want to still receive regular notifications that are caused by ignored contacts or not.")
+				DI::l10n()->t("You don't see posts from ignored contacts. But you still see their comments. This setting controls if you want to still receive regular notifications that are caused by ignored contacts or not."),
 			],
 
 			'$h_advn'     => DI::l10n()->t('Advanced Account/Page Type Settings'),

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Object;
 
-use Friendica\App\Mode;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Feature;
 use Friendica\Core\Protocol;
@@ -41,8 +40,6 @@ class Post
 	private $comment_box_template = 'comment_item.tpl';
 	private $toplevel             = false;
 	private $writable             = false;
-	/** @var Mode */
-	protected $mode;
 	/**
 	 * @var Post[]
 	 */
@@ -64,13 +61,11 @@ class Post
 	 * Constructor
 	 *
 	 * @param array $data data array
-	 * @param Mode $mode
 	 * @throws \Exception
 	 */
-	public function __construct(array $data, Mode $mode)
+	public function __construct(array $data)
 	{
 		$this->data = $data;
-		$this->mode = $mode;
 		$this->setTemplate('wall');
 		$this->toplevel = $this->getId() == $this->getDataValue('parent');
 
@@ -107,7 +102,7 @@ class Post
 				}
 
 				$item['pagedrop'] = $data['pagedrop'];
-				$child            = new Post($item, $mode);
+				$child            = new Post($item);
 				$this->addChild($child);
 			}
 		}
@@ -585,7 +580,6 @@ class Post
 			'owner_photo'            => DI::baseUrl()->remove(DI::contentItem()->getOwnerAvatar($item)),
 			'owner_name'             => $this->getOwnerName(),
 			'plink'                  => Item::getPlink($item),
-			'is_mobile'              => $this->mode->isMobile(),
 			'browsershare'           => $browsershare,
 			'edpost'                 => $edpost,
 			'ispinned'               => $ispinned,

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -389,8 +389,10 @@ class Post
 				$ignored_thread = PostModel\ThreadUser::getIgnored($item['uri-id'], DI::userSession()->getLocalUserId());
 				if ($item['mention'] || $ignored_thread) {
 					$ignore_thread = [
-						'do'        => DI::l10n()->t('Turn off notifications for this post'),
-						'undo'      => DI::l10n()->t('Turn on notifications for this post'),
+						'do'   => DI::l10n()->t('Turn off notifications for this post'),
+						'undo' => DI::l10n()->t('Turn on notifications for this post'),
+						// NOTE: Toggle is currently unused
+						//'toggle'    => DI::l10n()->t('Toggle notifications for this post'),
 						'classdo'   => $ignored_thread ? 'hidden' : '',
 						'classundo' => $ignored_thread ? '' : 'hidden',
 						'ignored'   => DI::l10n()->t('Notifications turned off for this post'),
@@ -400,8 +402,10 @@ class Post
 				$isstarred = (($item['starred']) ? 'starred' : 'unstarred');
 
 				$star = [
-					'do'        => DI::l10n()->t('Favourite'),
-					'undo'      => DI::l10n()->t('Unfavourite'),
+					'do'   => DI::l10n()->t('Bookmark'),
+					'undo' => DI::l10n()->t('Remove bookmark'),
+					// NOTE: Toggle is currently unused
+					//'toggle'    => DI::l10n()->t('Toggle bookmark status'),
 					'classdo'   => $item['starred'] ? 'hidden' : '',
 					'classundo' => $item['starred'] ? '' : 'hidden',
 					'starred'   => DI::l10n()->t('Starred'),
@@ -412,8 +416,10 @@ class Post
 						$ispinned = ($item['featured'] ? 'pinned' : 'unpinned');
 
 						$pin = [
-							'do'        => DI::l10n()->t('Pin to your wall'),
-							'undo'      => DI::l10n()->t('Unpin from your wall'),
+							'do'   => DI::l10n()->t('Pin to your wall'),
+							'undo' => DI::l10n()->t('Unpin from your wall'),
+							// NOTE: Toggle is currently unused
+							//'toggle'    => DI::l10n()->t('Toggle pin status'),
 							'classdo'   => $item['featured'] ? 'hidden' : '',
 							'classundo' => $item['featured'] ? '' : 'hidden',
 							'pinned'    => DI::l10n()->t('Pinned to your wall'),
@@ -421,7 +427,7 @@ class Post
 					}
 
 					$tagger = [
-						'add'   => DI::l10n()->t('Add tag'),
+						'add'   => DI::l10n()->t('Add tag to post'),
 						'class' => '',
 					];
 				}

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -7,6 +7,7 @@
 
 namespace Friendica\Object;
 
+use Friendica\App\Mode;
 use Friendica\Content\ContactSelector;
 use Friendica\Content\Feature;
 use Friendica\Core\Protocol;
@@ -40,6 +41,8 @@ class Post
 	private $comment_box_template = 'comment_item.tpl';
 	private $toplevel             = false;
 	private $writable             = false;
+	/** @var Mode */
+	protected $mode;
 	/**
 	 * @var Post[]
 	 */
@@ -61,11 +64,13 @@ class Post
 	 * Constructor
 	 *
 	 * @param array $data data array
+	 * @param Mode $mode
 	 * @throws \Exception
 	 */
-	public function __construct(array $data)
+	public function __construct(array $data, Mode $mode)
 	{
 		$this->data = $data;
+		$this->mode = $mode;
 		$this->setTemplate('wall');
 		$this->toplevel = $this->getId() == $this->getDataValue('parent');
 
@@ -102,7 +107,7 @@ class Post
 				}
 
 				$item['pagedrop'] = $data['pagedrop'];
-				$child            = new Post($item);
+				$child            = new Post($item, $mode);
 				$this->addChild($child);
 			}
 		}
@@ -228,9 +233,9 @@ class Post
 
 			if (Strings::compareLink(DI::session()->get('my_url'), $item['author-link'])) {
 				if ($item['event-id'] != 0) {
-					$edpost = ['calendar/event/edit/' . $item['event-id'], DI::l10n()->t('Edit')];
+					$edpost = ['calendar/event/edit/' . $item['event-id'], DI::l10n()->t('Edit event')];
 				} else {
-					$edpost = [sprintf('post/%s/edit', $item['id']), DI::l10n()->t('Edit')];
+					$edpost = [sprintf('post/%s/edit', $item['id']), DI::l10n()->t('Edit post')];
 				}
 			}
 			$dropping = in_array($item['uid'], [0, DI::userSession()->getLocalUserId()]);
@@ -250,7 +255,7 @@ class Post
 		$origin = $item['origin'] || $item['parent-origin'];
 
 		if (!empty($item['featured'])) {
-			$pinned = DI::l10n()->t('Pinned item');
+			$pinned = DI::l10n()->t('Pinned to your wall');
 		}
 
 		$drop         = false;
@@ -389,21 +394,19 @@ class Post
 				$ignored_thread = PostModel\ThreadUser::getIgnored($item['uri-id'], DI::userSession()->getLocalUserId());
 				if ($item['mention'] || $ignored_thread) {
 					$ignore_thread = [
-						'do'        => DI::l10n()->t('Ignore thread'),
-						'undo'      => DI::l10n()->t('Unignore thread'),
-						'toggle'    => DI::l10n()->t('Toggle ignore status'),
+						'do'        => DI::l10n()->t('Turn off notifications for this post'),
+						'undo'      => DI::l10n()->t('Turn on notifications for this post'),
 						'classdo'   => $ignored_thread ? 'hidden' : '',
 						'classundo' => $ignored_thread ? '' : 'hidden',
-						'ignored'   => DI::l10n()->t('Ignored'),
+						'ignored'   => DI::l10n()->t('Notifications turned off for this post'),
 					];
 				}
 
 				$isstarred = (($item['starred']) ? 'starred' : 'unstarred');
 
 				$star = [
-					'do'        => DI::l10n()->t('Add star'),
-					'undo'      => DI::l10n()->t('Remove star'),
-					'toggle'    => DI::l10n()->t('Toggle star status'),
+					'do'        => DI::l10n()->t('Favourite'),
+					'undo'      => DI::l10n()->t('Unfavourite'),
 					'classdo'   => $item['starred'] ? 'hidden' : '',
 					'classundo' => $item['starred'] ? '' : 'hidden',
 					'starred'   => DI::l10n()->t('Starred'),
@@ -414,12 +417,11 @@ class Post
 						$ispinned = ($item['featured'] ? 'pinned' : 'unpinned');
 
 						$pin = [
-							'do'        => DI::l10n()->t('Pin'),
-							'undo'      => DI::l10n()->t('Unpin'),
-							'toggle'    => DI::l10n()->t('Toggle pin status'),
+							'do'        => DI::l10n()->t('Pin to your wall'),
+							'undo'      => DI::l10n()->t('Unpin from your wall'),
 							'classdo'   => $item['featured'] ? 'hidden' : '',
 							'classundo' => $item['featured'] ? '' : 'hidden',
-							'pinned'    => DI::l10n()->t('Pinned'),
+							'pinned'    => DI::l10n()->t('Pinned to your wall'),
 						];
 					}
 
@@ -435,8 +437,8 @@ class Post
 
 		if ($conv->isWritable()) {
 			if ($likeable) {
-				$buttons['like']    = [DI::l10n()->t("I like this \x28toggle\x29"), DI::l10n()->t('Like')];
-				$buttons['dislike'] = [DI::l10n()->t("I don't like this \x28toggle\x29"), DI::l10n()->t('Dislike')];
+				$buttons['like']    = [DI::l10n()->t("I like this (toggle)"), DI::l10n()->t('Like')];
+				$buttons['dislike'] = [DI::l10n()->t("I don't like this (toggle)"), DI::l10n()->t('Dislike')];
 			}
 			if ($shareable) {
 				$buttons['share'] = [DI::l10n()->t('Quote share this'), DI::l10n()->t('Quote Share')];
@@ -583,6 +585,7 @@ class Post
 			'owner_photo'            => DI::baseUrl()->remove(DI::contentItem()->getOwnerAvatar($item)),
 			'owner_name'             => $this->getOwnerName(),
 			'plink'                  => Item::getPlink($item),
+			'is_mobile'              => $this->mode->isMobile(),
 			'browsershare'           => $browsershare,
 			'edpost'                 => $edpost,
 			'ispinned'               => $ispinned,

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -285,7 +285,7 @@ class Post
 				'author_id'  => $item['author-id'],
 			];
 			$report = [
-				'label' => DI::l10n()->t('Report post'),
+				'label' => DI::l10n()->t('Report this post'),
 				'href'  => 'moderation/report/create?' . http_build_query(['cid' => $item['author-id'], 'uri-ids' => [$item['uri-id']]]),
 			];
 			$authorBaseUri = new Uri($item['author-baseurl'] ?? '');
@@ -389,8 +389,8 @@ class Post
 				$ignored_thread = PostModel\ThreadUser::getIgnored($item['uri-id'], DI::userSession()->getLocalUserId());
 				if ($item['mention'] || $ignored_thread) {
 					$ignore_thread = [
-						'do'   => DI::l10n()->t('Turn off notifications for this post'),
-						'undo' => DI::l10n()->t('Turn on notifications for this post'),
+						'do'   => DI::l10n()->t('Turn off related notifications'),
+						'undo' => DI::l10n()->t('Turn on related notifications'),
 						// NOTE: Toggle is currently unused
 						//'toggle'    => DI::l10n()->t('Toggle notifications for this post'),
 						'classdo'   => $ignored_thread ? 'hidden' : '',

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-10 01:18+0200\n"
+"POT-Creation-Date: 2026-05-10 10:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1699,8 +1699,7 @@ msgstr ""
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: src/Content/Item.php:435 src/Object/Post.php:393
-#: view/theme/frio/theme.php:251
+#: src/Content/Item.php:435 view/theme/frio/theme.php:251
 msgid "Turn on notifications for this post"
 msgstr ""
 
@@ -11710,7 +11709,7 @@ msgid "Collapse %s"
 msgstr ""
 
 #: src/Object/Post.php:288
-msgid "Report post"
+msgid "Report this post"
 msgstr ""
 
 #: src/Object/Post.php:299
@@ -11730,7 +11729,11 @@ msgid "I might attend"
 msgstr ""
 
 #: src/Object/Post.php:392
-msgid "Turn off notifications for this post"
+msgid "Turn off related notifications"
+msgstr ""
+
+#: src/Object/Post.php:393
+msgid "Turn on related notifications"
 msgstr ""
 
 #: src/Object/Post.php:398

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.04-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-09 22:47+0200\n"
+"POT-Creation-Date: 2026-05-10 01:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -161,7 +161,7 @@ msgstr ""
 
 #: mod/message.php:191 mod/message.php:349 src/Content/Conversation.php:405
 #: src/Content/Conversation.php:1614 src/Module/Item/Compose.php:208
-#: src/Module/Post/Edit.php:143 src/Object/Post.php:620
+#: src/Module/Post/Edit.php:143 src/Object/Post.php:623
 msgid "Please wait"
 msgstr ""
 
@@ -427,8 +427,7 @@ msgid "Rotate CCW (left)"
 msgstr ""
 
 #: mod/photos.php:827 src/Model/Event.php:652
-#: src/Module/Calendar/Event/Show.php:67 src/Object/Post.php:231
-#: src/Object/Post.php:233
+#: src/Module/Calendar/Event/Show.php:67
 msgid "Edit"
 msgstr ""
 
@@ -1031,7 +1030,7 @@ msgid "Visible to <strong>everybody</strong>"
 msgstr ""
 
 #: src/Content/Conversation.php:337 src/Module/Item/Compose.php:202
-#: src/Object/Post.php:1178
+#: src/Object/Post.php:1181
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
@@ -1072,7 +1071,7 @@ msgid "Post"
 msgstr ""
 
 #: src/Content/Conversation.php:370 src/Content/Nav.php:113
-#: src/Module/Post/Edit.php:128 src/Object/Post.php:1167
+#: src/Module/Post/Edit.php:128 src/Object/Post.php:1170
 msgid "Loading..."
 msgstr ""
 
@@ -1089,52 +1088,52 @@ msgid "attach file"
 msgstr ""
 
 #: src/Content/Conversation.php:375 src/Module/Item/Compose.php:192
-#: src/Module/Post/Edit.php:171 src/Object/Post.php:1168
+#: src/Module/Post/Edit.php:171 src/Object/Post.php:1171
 msgid "Bold"
 msgstr ""
 
 #: src/Content/Conversation.php:376 src/Module/Item/Compose.php:193
-#: src/Module/Post/Edit.php:172 src/Object/Post.php:1169
+#: src/Module/Post/Edit.php:172 src/Object/Post.php:1172
 msgid "Italic"
 msgstr ""
 
 #: src/Content/Conversation.php:377 src/Module/Item/Compose.php:194
-#: src/Module/Post/Edit.php:173 src/Object/Post.php:1170
+#: src/Module/Post/Edit.php:173 src/Object/Post.php:1173
 msgid "Underline"
 msgstr ""
 
 #: src/Content/Conversation.php:378 src/Module/Item/Compose.php:195
-#: src/Module/Post/Edit.php:174 src/Object/Post.php:1172
+#: src/Module/Post/Edit.php:174 src/Object/Post.php:1175
 msgid "Quote"
 msgstr ""
 
 #: src/Content/Conversation.php:379 src/Module/Item/Compose.php:196
-#: src/Module/Post/Edit.php:175 src/Object/Post.php:1173
+#: src/Module/Post/Edit.php:175 src/Object/Post.php:1176
 msgid "Add emojis"
 msgstr ""
 
 #: src/Content/Conversation.php:380 src/Module/Item/Compose.php:197
-#: src/Object/Post.php:1171
+#: src/Object/Post.php:1174
 msgid "Content Warning"
 msgstr ""
 
 #: src/Content/Conversation.php:381 src/Module/Item/Compose.php:198
-#: src/Module/Post/Edit.php:176 src/Object/Post.php:1174
+#: src/Module/Post/Edit.php:176 src/Object/Post.php:1177
 msgid "Code"
 msgstr ""
 
 #: src/Content/Conversation.php:382 src/Module/Item/Compose.php:199
-#: src/Object/Post.php:1175
+#: src/Object/Post.php:1178
 msgid "Image"
 msgstr ""
 
 #: src/Content/Conversation.php:383 src/Module/Item/Compose.php:200
-#: src/Module/Post/Edit.php:177 src/Object/Post.php:1176
+#: src/Module/Post/Edit.php:177 src/Object/Post.php:1179
 msgid "Link"
 msgstr ""
 
 #: src/Content/Conversation.php:384 src/Module/Item/Compose.php:201
-#: src/Module/Post/Edit.php:178 src/Object/Post.php:1177
+#: src/Module/Post/Edit.php:178 src/Object/Post.php:1180
 msgid "Link or Media"
 msgstr ""
 
@@ -1192,7 +1191,7 @@ msgstr ""
 
 #: src/Content/Conversation.php:419 src/Module/Calendar/Event/Form.php:261
 #: src/Module/Item/Compose.php:203 src/Module/Post/Edit.php:165
-#: src/Object/Post.php:1179
+#: src/Object/Post.php:1182
 msgid "Preview"
 msgstr ""
 
@@ -1294,7 +1293,7 @@ msgid "Local delivery"
 msgstr ""
 
 #: src/Content/Conversation.php:806
-msgid "Stored because of your activity (like, comment, star, ...)"
+msgid "Stored because of your activity (like, comment, bookmark, ...)"
 msgstr ""
 
 #: src/Content/Conversation.php:809
@@ -1319,25 +1318,25 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#: src/Content/Conversation.php:1556 src/Object/Post.php:253
+#: src/Content/Conversation.php:1556
 msgid "Pinned item"
 msgstr ""
 
-#: src/Content/Conversation.php:1573 src/Object/Post.php:555
-#: src/Object/Post.php:556
+#: src/Content/Conversation.php:1573 src/Object/Post.php:558
+#: src/Object/Post.php:559
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: src/Content/Conversation.php:1587 src/Object/Post.php:543
+#: src/Content/Conversation.php:1587 src/Object/Post.php:546
 msgid "Categories:"
 msgstr ""
 
-#: src/Content/Conversation.php:1588 src/Object/Post.php:544
+#: src/Content/Conversation.php:1588 src/Object/Post.php:547
 msgid "Filed under:"
 msgstr ""
 
-#: src/Content/Conversation.php:1596 src/Object/Post.php:571
+#: src/Content/Conversation.php:1596 src/Object/Post.php:574
 #, php-format
 msgid "%s from %s"
 msgstr ""
@@ -1475,8 +1474,8 @@ msgstr ""
 msgid "Posts that mention or involve you"
 msgstr ""
 
-#: src/Content/Conversation/Factory/Network.php:28 src/Object/Post.php:409
-msgid "Starred"
+#: src/Content/Conversation/Factory/Network.php:28
+msgid "Bookmarked"
 msgstr ""
 
 #: src/Content/Conversation/Factory/Network.php:28
@@ -1700,12 +1699,13 @@ msgstr ""
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: src/Content/Item.php:435 view/theme/frio/theme.php:251
-msgid "Follow Thread"
+#: src/Content/Item.php:435 src/Object/Post.php:393
+#: view/theme/frio/theme.php:251
+msgid "Turn on notifications for this post"
 msgstr ""
 
 #: src/Content/Item.php:436 view/theme/frio/theme.php:268
-msgid "Complete Thread"
+msgid "Fetch more replies"
 msgstr ""
 
 #: src/Content/Item.php:437 src/Model/Contact.php:1303
@@ -1732,24 +1732,17 @@ msgstr ""
 msgid "View Contact"
 msgstr ""
 
-#: src/Content/Item.php:443 src/Module/Contact.php:453
-#: src/Module/Contact/Profile.php:579
-#: src/Module/Moderation/Blocklist/Contact.php:107
-#: src/Module/Moderation/Users/Active.php:93
-#: src/Module/Moderation/Users/Index.php:101
-msgid "Block"
-msgstr ""
-
-#: src/Content/Item.php:444 src/Module/Contact.php:454
-#: src/Module/Contact/Profile.php:587
-#: src/Module/Notifications/Introductions.php:130
-#: src/Module/Notifications/Introductions.php:206
-msgid "Ignore"
-msgstr ""
-
-#: src/Content/Item.php:445 src/Module/Contact.php:455
+#: src/Content/Item.php:443 src/Module/Contact.php:455
 #: src/Module/Contact/Profile.php:595
 msgid "Collapse"
+msgstr ""
+
+#: src/Content/Item.php:444
+msgid "Ignore user"
+msgstr ""
+
+#: src/Content/Item.php:445
+msgid "Block user"
 msgstr ""
 
 #: src/Content/Item.php:446 src/Object/Post.php:294
@@ -1757,11 +1750,11 @@ msgstr ""
 msgid "Ignore %s server"
 msgstr ""
 
-#: src/Content/Item.php:450 src/Object/Post.php:515
+#: src/Content/Item.php:450 src/Object/Post.php:518
 msgid "Detected languages"
 msgstr ""
 
-#: src/Content/Item.php:453 src/Object/Post.php:598
+#: src/Content/Item.php:453 src/Object/Post.php:601
 msgid "Raw content"
 msgstr ""
 
@@ -5615,7 +5608,7 @@ msgstr ""
 #: src/Module/Contact.php:542 src/Module/Conversation/Channel.php:94
 #: src/Module/Conversation/Community.php:87
 #: src/Module/Conversation/Network.php:382
-#: src/Module/Moderation/BaseUsers.php:130 src/Object/Post.php:618
+#: src/Module/Moderation/BaseUsers.php:130 src/Object/Post.php:621
 msgid "More"
 msgstr ""
 
@@ -5722,7 +5715,7 @@ msgstr ""
 msgid "Formatting is not supported for this field"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:196
+#: src/Module/Calendar/Event/Form.php:196 src/Object/Post.php:231
 msgid "Edit event"
 msgstr ""
 
@@ -5976,7 +5969,7 @@ msgid "Only show blocked contacts"
 msgstr ""
 
 #: src/Module/Contact.php:353 src/Module/Contact.php:425
-#: src/Module/Settings/Server/Index.php:94 src/Object/Post.php:397
+#: src/Module/Settings/Server/Index.php:94
 msgid "Ignored"
 msgstr ""
 
@@ -6026,10 +6019,23 @@ msgid "Update"
 msgstr ""
 
 #: src/Module/Contact.php:453 src/Module/Contact/Profile.php:579
+#: src/Module/Moderation/Blocklist/Contact.php:107
+#: src/Module/Moderation/Users/Active.php:93
+#: src/Module/Moderation/Users/Index.php:101
+msgid "Block"
+msgstr ""
+
+#: src/Module/Contact.php:453 src/Module/Contact/Profile.php:579
 #: src/Module/Moderation/Blocklist/Contact.php:108
 #: src/Module/Moderation/Users/Blocked.php:94
 #: src/Module/Moderation/Users/Index.php:103
 msgid "Unblock"
+msgstr ""
+
+#: src/Module/Contact.php:454 src/Module/Contact/Profile.php:587
+#: src/Module/Notifications/Introductions.php:130
+#: src/Module/Notifications/Introductions.php:206
+msgid "Ignore"
 msgstr ""
 
 #: src/Module/Contact.php:454 src/Module/Contact/Profile.php:587
@@ -6089,7 +6095,7 @@ msgid "Pending incoming contact request"
 msgstr ""
 
 #: src/Module/Contact.php:609 src/Module/Item/Compose.php:190
-#: src/Object/Post.php:1163
+#: src/Object/Post.php:1166
 msgid "This is you"
 msgstr ""
 
@@ -8085,8 +8091,8 @@ msgstr ""
 msgid "No report exists at this node."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:131 src/Object/Post.php:614
-#: src/Object/Post.php:1165
+#: src/Module/Moderation/Reports.php:131 src/Object/Post.php:617
+#: src/Object/Post.php:1168
 msgid "Comment"
 msgstr ""
 
@@ -8522,7 +8528,7 @@ msgstr ""
 msgid "Post not found."
 msgstr ""
 
-#: src/Module/Post/Edit.php:98
+#: src/Module/Post/Edit.php:98 src/Object/Post.php:233
 msgid "Edit post"
 msgstr ""
 
@@ -8761,7 +8767,7 @@ msgstr ""
 msgid "Private Message"
 msgstr ""
 
-#: src/Module/Profile/Schedule.php:101 src/Object/Post.php:558
+#: src/Module/Profile/Schedule.php:101 src/Object/Post.php:561
 msgid "via"
 msgstr ""
 
@@ -9498,11 +9504,11 @@ msgid "When activated, the personal notes on your profile page will be expired."
 msgstr ""
 
 #: src/Module/Settings/Account.php:550
-msgid "Expire starred posts"
+msgid "Expire bookmarked posts"
 msgstr ""
 
 #: src/Module/Settings/Account.php:550
-msgid "Starring posts keeps them from being expired. That behaviour is overwritten by this setting."
+msgid "Bookmarking posts keeps them from being expired. That behaviour is overwritten by this setting."
 msgstr ""
 
 #: src/Module/Settings/Account.php:551
@@ -11676,6 +11682,10 @@ msgstr ""
 msgid "Connector Message"
 msgstr ""
 
+#: src/Object/Post.php:253 src/Object/Post.php:425
+msgid "Pinned to your wall"
+msgstr ""
+
 #: src/Object/Post.php:267
 msgid "Delete globally"
 msgstr ""
@@ -11720,231 +11730,219 @@ msgid "I might attend"
 msgstr ""
 
 #: src/Object/Post.php:392
-msgid "Ignore thread"
+msgid "Turn off notifications for this post"
 msgstr ""
 
-#: src/Object/Post.php:393
-msgid "Unignore thread"
-msgstr ""
-
-#: src/Object/Post.php:394
-msgid "Toggle ignore status"
-msgstr ""
-
-#: src/Object/Post.php:404
-msgid "Add star"
+#: src/Object/Post.php:398
+msgid "Notifications turned off for this post"
 msgstr ""
 
 #: src/Object/Post.php:405
-msgid "Remove star"
+msgid "Bookmark"
 msgstr ""
 
 #: src/Object/Post.php:406
-msgid "Toggle star status"
+msgid "Remove bookmark"
 msgstr ""
 
-#: src/Object/Post.php:417
-msgid "Pin"
-msgstr ""
-
-#: src/Object/Post.php:418
-msgid "Unpin"
+#: src/Object/Post.php:411
+msgid "Starred"
 msgstr ""
 
 #: src/Object/Post.php:419
-msgid "Toggle pin status"
+msgid "Pin to your wall"
 msgstr ""
 
-#: src/Object/Post.php:422
-msgid "Pinned"
+#: src/Object/Post.php:420
+msgid "Unpin from your wall"
 msgstr ""
 
-#: src/Object/Post.php:427
-msgid "Add tag"
+#: src/Object/Post.php:430
+msgid "Add tag to post"
 msgstr ""
 
-#: src/Object/Post.php:438
+#: src/Object/Post.php:441
 msgid "I like this (toggle)"
 msgstr ""
 
-#: src/Object/Post.php:438
+#: src/Object/Post.php:441
 msgid "Like"
 msgstr ""
 
-#: src/Object/Post.php:439
+#: src/Object/Post.php:442
 msgid "I don't like this (toggle)"
 msgstr ""
 
-#: src/Object/Post.php:439
+#: src/Object/Post.php:442
 msgid "Dislike"
 msgstr ""
 
-#: src/Object/Post.php:442
+#: src/Object/Post.php:445
 msgid "Quote share this"
 msgstr ""
 
-#: src/Object/Post.php:442
+#: src/Object/Post.php:445
 msgid "Quote Share"
 msgstr ""
 
-#: src/Object/Post.php:445
+#: src/Object/Post.php:448
 msgid "Reshare this"
 msgstr ""
 
-#: src/Object/Post.php:445
+#: src/Object/Post.php:448
 msgid "Reshare"
 msgstr ""
 
-#: src/Object/Post.php:446
+#: src/Object/Post.php:449
 msgid "Cancel your Reshare"
 msgstr ""
 
-#: src/Object/Post.php:446
+#: src/Object/Post.php:449
 msgid "Unshare"
 msgstr ""
 
-#: src/Object/Post.php:490
+#: src/Object/Post.php:493
 #, php-format
 msgid "%s (Received %s)"
 msgstr ""
 
-#: src/Object/Post.php:496
+#: src/Object/Post.php:499
 msgid "Comment this item on your system"
 msgstr ""
 
-#: src/Object/Post.php:496
+#: src/Object/Post.php:499
 msgid "Remote comment"
 msgstr ""
 
-#: src/Object/Post.php:520
+#: src/Object/Post.php:523
 msgid "Share via ..."
 msgstr ""
 
-#: src/Object/Post.php:520
+#: src/Object/Post.php:523
 msgid "Share via external services"
 msgstr ""
 
-#: src/Object/Post.php:527
+#: src/Object/Post.php:530
 msgid "Unknown parent"
 msgstr ""
 
-#: src/Object/Post.php:531
+#: src/Object/Post.php:534
 #, php-format
 msgid "in reply to %s"
 msgstr ""
 
-#: src/Object/Post.php:533
+#: src/Object/Post.php:536
 msgid "Parent is probably private or not federated."
 msgstr ""
 
-#: src/Object/Post.php:557
+#: src/Object/Post.php:560
 msgid "to"
 msgstr ""
 
-#: src/Object/Post.php:559
+#: src/Object/Post.php:562
 msgid "Wall-to-Wall"
 msgstr ""
 
-#: src/Object/Post.php:560
+#: src/Object/Post.php:563
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: src/Object/Post.php:615
+#: src/Object/Post.php:618
 #, php-format
 msgid "Reply to %s"
 msgstr ""
 
-#: src/Object/Post.php:637
+#: src/Object/Post.php:640
 msgid "Notifier task is pending"
 msgstr ""
 
-#: src/Object/Post.php:638
+#: src/Object/Post.php:641
 msgid "Delivery to remote servers is pending"
 msgstr ""
 
-#: src/Object/Post.php:639
+#: src/Object/Post.php:642
 msgid "Delivery to remote servers is underway"
 msgstr ""
 
-#: src/Object/Post.php:640
+#: src/Object/Post.php:643
 msgid "Delivery to remote servers is mostly done"
 msgstr ""
 
-#: src/Object/Post.php:641
+#: src/Object/Post.php:644
 msgid "Delivery to remote servers is done"
 msgstr ""
 
-#: src/Object/Post.php:666
+#: src/Object/Post.php:669
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Object/Post.php:667
+#: src/Object/Post.php:670
 msgid "Show more"
 msgstr ""
 
-#: src/Object/Post.php:668
+#: src/Object/Post.php:671
 msgid "Show fewer"
 msgstr ""
 
-#: src/Object/Post.php:705
+#: src/Object/Post.php:708
 #, php-format
 msgid "Reshared by: %s"
 msgstr ""
 
-#: src/Object/Post.php:710
+#: src/Object/Post.php:713
 #, php-format
 msgid "Viewed by: %s"
 msgstr ""
 
-#: src/Object/Post.php:715
+#: src/Object/Post.php:718
 #, php-format
 msgid "Read by: %s"
 msgstr ""
 
-#: src/Object/Post.php:720
+#: src/Object/Post.php:723
 #, php-format
 msgid "Liked by: %s"
 msgstr ""
 
-#: src/Object/Post.php:725
+#: src/Object/Post.php:728
 #, php-format
 msgid "Disliked by: %s"
 msgstr ""
 
-#: src/Object/Post.php:730
+#: src/Object/Post.php:733
 #, php-format
 msgid "Attended by: %s"
 msgstr ""
 
-#: src/Object/Post.php:735
+#: src/Object/Post.php:738
 #, php-format
 msgid "Maybe attended by: %s"
 msgstr ""
 
-#: src/Object/Post.php:740
+#: src/Object/Post.php:743
 #, php-format
 msgid "Not attended by: %s"
 msgstr ""
 
-#: src/Object/Post.php:745
+#: src/Object/Post.php:748
 #, php-format
 msgid "Commented by: %s"
 msgstr ""
 
-#: src/Object/Post.php:750
+#: src/Object/Post.php:753
 #, php-format
 msgid "Reacted with %s by: %s"
 msgstr ""
 
-#: src/Object/Post.php:773
+#: src/Object/Post.php:776
 #, php-format
 msgid "Quote shared by: %s"
 msgstr ""
 
-#: src/Object/Post.php:1166
+#: src/Object/Post.php:1169
 msgid "Post comment"
 msgstr ""
 

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -151,8 +151,8 @@
 									<a role="button" id="unpin-{{$item.id}}" onclick="doPin({{$item.id}}); return false;" class="{{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="icon-remove-circle icon-large"><span class="sr-only">{{$item.pin.undo}}</span></i></a>
                                 {{/if}}
                                 {{if $item.star}}
-									<a role="button" id="star-{{$item.id}}" onclick="doStar({{$item.id}}); return false;" class="{{$item.star.classdo}}" title="{{$item.star.do}}"><i class="icon-star icon-large"><span class="sr-only">{{$item.star.do}}</span></i></a>
-									<a role="button" id="unstar-{{$item.id}}" onclick="doStar({{$item.id}}); return false;" class="{{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="icon-star-empty icon-large"><span class="sr-only">{{$item.star.undo}}</span></i></a>
+									<a role="button" id="star-{{$item.id}}" onclick="doStar({{$item.id}}); return false;" class="{{$item.star.classdo}}" title="{{$item.star.do}}"><i class="icon-bookmark icon-large"><span class="sr-only">{{$item.star.do}}</span></i></a>
+									<a role="button" id="unstar-{{$item.id}}" onclick="doStar({{$item.id}}); return false;" class="{{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="icon-bookmark-empty icon-large"><span class="sr-only">{{$item.star.undo}}</span></i></a>
                                 {{/if}}
                                 {{if $item.ignore}}
 									<a role="button" id="ignore-{{$item.id}}" onclick="doIgnoreThread({{$item.id}}); return false;"  class="{{$item.ignore.classdo}}"  title="{{$item.ignore.do}}"><i class="icon-bell-slash icon-large"><span class="sr-only">{{$item.ignore.do}}</span></i></a>

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -214,8 +214,8 @@
 
 						{{if $item.star}}
 							<li role="menuitem">
-								<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-star-o" aria-hidden="true"></i>&nbsp;{{$item.star.do}}</a>
-								<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-star" aria-hidden="true"></i>&nbsp;{{$item.star.undo}}</a>
+								<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-bookmark-o" aria-hidden="true"></i>&nbsp;{{$item.star.do}}</a>
+								<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-bookmark" aria-hidden="true"></i>&nbsp;{{$item.star.undo}}</a>
 							</li>
 						{{/if}}
 

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -403,24 +403,15 @@ as the value of $top_child_total (this is done at the end of this file)
 		<span class="more-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}">
 			<button type="button" class="btn-link dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="fa fa-ellipsis-h" aria-hidden="true"></i></button>
 			<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenuOptions-{{$item.id}}">
+
+				{{* Available: On your own posts and comments *}}
 				{{if $item.edpost}} {{* edit the posting *}}
 				<li role="menuitem">
 						<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" title="{{$item.edpost.1}}" class="btn-link navicon pencil"><i class="fa fa-pencil" aria-hidden="true"></i>&ensp;{{$item.edpost.1}}</a>
 				</li>
 				{{/if}}
 
-				{{if $item.tagger}} {{* tag the post *}}
-				<li role="menuitem">
-						<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
-				</li>
-				{{/if}}
-
-				{{if $item.filer}}
-				<li role="menuitem">
-						<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="fa fa-folder" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
-				</li>
-				{{/if}}
-
+				{{* Available: On your own posts *}}
 				{{if $item.pin}}
 				<li role="menuitem">
 						<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-circle-o" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
@@ -428,6 +419,7 @@ as the value of $top_child_total (this is done at the end of this file)
 				</li>
 				{{/if}}
 
+				{{* Available: On posts made by anyone *}}
 				{{if $item.star}}
 				<li role="menuitem">
 						<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-star-o" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
@@ -435,38 +427,39 @@ as the value of $top_child_total (this is done at the end of this file)
 				</li>
 				{{/if}}
 
-				{{if $item.follow_thread}}
+				{{* Available: On all posts and comments *}}
+				{{if $item.filer}}
 				<li role="menuitem">
-						<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="fa fa-plus" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
+						<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="fa fa-folder" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
 				</li>
 				{{/if}}
 
+				{{* Available: On (some) posts made by others? *}}
+				{{* Likely only works on mobile devices/tablets *}}
+				{{* Not supported by Firefox as of 2026-05 *}}
+				{{* Requires HTTPS, requires the permission is enabled *}}
+				{{if $is_mobile AND $item.browsershare}}
+				<li role="menuitem" class="button-browser-share">
+						<a id="browser-share-{{$item.id}}" href="javascript:navigator.share({url: '{{$item.plink.orig}}'})" class="btn-link button-browser-share" title="{{$item.browsershare.1}}"><i class="fa fa-share-alt" aria-hidden="true"></i>&ensp;{{$item.browsershare.0}}</a>
+				</li>
+				{{/if}}
+
+				{{* Available: On posts made by others *}}
 				{{if $item.complete_thread}}
 				<li role="menuitem">
 						<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="fa fa-download" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
 				</li>
 				{{/if}}
 
-				{{if $item.language}}
+				{{* Available: On posts made by others *}}
+				{{* Identical to unignore in functionality but only seen on posts you haven't liked/commented on - could they be merged? *}}
+				{{if $item.follow_thread}}
 				<li role="menuitem">
-						<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
+						<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="fa fa-bell" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
 				</li>
 				{{/if}}
 
-				<li role="menuitem">
-						<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
-				</li>
-
-				{{if $item.browsershare}}
-				<li role="menuitem" class="button-browser-share">
-						<a id="browser-share-{{$item.id}}" href="javascript:navigator.share({url: '{{$item.plink.orig}}'})" class="btn-link button-browser-share" title="{{$item.browsershare.1}}"><i class="fa fa-share-alt" aria-hidden="true"></i>&ensp;{{$item.browsershare.0}}</a>
-				</li>
-				{{/if}}
-
-				{{if ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.complete_thread) && ($item.ignore || ($item.drop && $item.drop.dropping))}}
-				<li class="divider"><hr></li>
-				{{/if}}
-
+				{{* Available: On all posts *}}
 				{{if $item.ignore}}
 				<li role="menuitem">
 						<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-bell-slash" aria-hidden="true"></i>&ensp;{{$item.ignore.do}}</a>
@@ -476,35 +469,72 @@ as the value of $top_child_total (this is done at the end of this file)
 				</li>
 				{{/if}}
 
-				{{if $item.drop && $item.drop.dropping}}
+				{{* Available: On your own posts *}}
+				{{* TODO: This currently creates a duplicate post according to: https://forum.friendi.ca/display/373ebf56-2469-ed09-ccc0-ecd539065051 *}}
+				{{if $item.tagger}} {{* tag the post *}}
 				<li role="menuitem">
-						<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="fa fa-trash" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
+						<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
 				</li>
 				{{/if}}
 
-				{{if $item.block}}
-				<li role="menuitem">
-						<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.block.label}}"><i class="fa fa-ban" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
-				</li>
+				{{if ($item.edpost || $item.star || $item.tagger || $item.filer || $item.pin || $item.follow_thread || $item.complete_thread) && ($item.ignore || ($item.drop && $item.drop.dropping))}}
+				<li class="divider"><hr></li>
 				{{/if}}
-				{{if $item.ignore_author}}
-				<li role="menuitem">
-						<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.ignore_author.label}}"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
-				</li>
-				{{/if}}
+
+				{{* Available: On posts made by others *}}
 				{{if $item.collapse}}
 				<li role="menuitem">
 						<a class="btn-link navicon collapse" href="javascript:collapseAuthor('item/collapse/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.collapse.label}}"><i class="fa fa-minus-square" aria-hidden="true"></i>&ensp;{{$item.collapse.label}}</a>
 				</li>
 				{{/if}}
+
+				{{* Available: On posts made by others *}}
+				{{if $item.ignore_author}}
+				<li role="menuitem">
+						<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.ignore_author.label}}"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
+				</li>
+				{{/if}}
+
+				{{* Available: On posts made by others *}}
+				{{if $item.block}}
+				<li role="menuitem">
+						<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.block.label}}"><i class="fa fa-ban" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
+				</li>
+				{{/if}}
+
+				{{if $item.collapse || $item.ignore_author || $item.block }}
+				<li class="divider"><hr></li>
+				{{/if}}
+
+				{{* Available: On posts made by others *}}
 				{{if $item.ignore_server}}
 				<li role="menuitem">
 						<a class="btn-link navicon ignoreServer" href="javascript:ignoreServer('settings/server/{{$item.author_gsid}}/ignore', 'item-{{$item.guid}}');" title="{{$item.ignore_server.label}}"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_server.label}}</a>
 				</li>
 				{{/if}}
+
+				<li role="menuitem">
+						<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
+				</li>
+
+				{{* Available: All posts and comments *}}
+				{{if $item.language}}
+				<li role="menuitem">
+						<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
+				</li>
+				{{/if}}
+
+				{{* Available: All posts and comments made by others *}}
 				{{if $item.report}}
 				<li role="menuitem">
 						<a class="btn-link navicon ignore" href="{{$item.report.href}}"><i class="fa fa-flag" aria-hidden="true"></i>&ensp;{{$item.report.label}}</a>
+				</li>
+				{{/if}}
+
+				{{* Available: If you're an admin, on all posts and comments on your instance *}}
+				{{if $item.drop && $item.drop.dropping}}
+				<li role="menuitem">
+						<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="fa fa-trash" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
 				</li>
 				{{/if}}
 			</ul>
@@ -602,18 +632,6 @@ as the value of $top_child_total (this is done at the end of this file)
 							</li>
 							{{/if}}
 
-							{{if $item.tagger}} {{* tag the post *}}
-								<li role="menuitem">
-									<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
-								</li>
-							{{/if}}
-
-							{{if $item.filer}}
-								<li role="menuitem">
-									<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="fa fa-folder" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
-								</li>
-							{{/if}}
-
 							{{if $item.pin}}
 								<li role="menuitem">
 									<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-circle-o" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
@@ -621,10 +639,22 @@ as the value of $top_child_total (this is done at the end of this file)
 								</li>
 							{{/if}}
 
+							{{if $item.tagger}} {{* tag the post *}}
+								<li role="menuitem">
+									<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
+								</li>
+							{{/if}}
+
 							{{if $item.star}}
 								<li role="menuitem">
 									<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-star-o" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
 									<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-star" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
+								</li>
+							{{/if}}
+
+							{{if $item.filer}}
+								<li role="menuitem">
+									<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="fa fa-folder" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
 								</li>
 							{{/if}}
 
@@ -663,12 +693,6 @@ as the value of $top_child_total (this is done at the end of this file)
 								</li>
 							{{/if}}
 
-							{{if $item.drop && $item.drop.dropping}}
-								<li role="menuitem">
-                                                			<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="fa fa-trash" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
-								</li>
-							{{/if}}
-
 							{{if $item.block}}
 								<li role="menuitem">
 									<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.block.label}}"><i class="fa fa-ban" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
@@ -692,6 +716,11 @@ as the value of $top_child_total (this is done at the end of this file)
 							{{if $item.report}}
 								<li role="menuitem">
 									<a class="btn-link navicon ignore" href="{{$item.report.href}}"><i class="fa fa-flag" aria-hidden="true"></i>&ensp;{{$item.report.label}}</a>
+								</li>
+							{{/if}}
+							{{if $item.drop && $item.drop.dropping}}
+								<li role="menuitem">
+                                                			<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="fa fa-trash" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
 								</li>
 							{{/if}}
 						</ul>

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -414,16 +414,24 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Available: On your own posts *}}
 				{{if $item.pin}}
 				<li role="menuitem">
-						<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-circle-o" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
-						<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="fa fa-dot-circle-o" aria-hidden="true"></i>&ensp;{{$item.pin.undo}}</a>
+						<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
+						<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.undo}}</a>
+				</li>
+				{{/if}}
+
+				{{* Available: On your own posts *}}
+				{{* TODO: This currently creates a duplicate post according to: https://forum.friendi.ca/display/373ebf56-2469-ed09-ccc0-ecd539065051 *}}
+				{{if $item.tagger}} {{* tag the post *}}
+				<li role="menuitem">
+						<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On posts made by anyone *}}
 				{{if $item.star}}
 				<li role="menuitem">
-						<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-star-o" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
-						<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-star" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
+						<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-bookmark-o" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
+						<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-bookmark" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
 				</li>
 				{{/if}}
 
@@ -434,20 +442,13 @@ as the value of $top_child_total (this is done at the end of this file)
 				</li>
 				{{/if}}
 
-				{{* Available: On (some) posts made by others? *}}
-				{{* Likely only works on mobile devices/tablets *}}
-				{{* Not supported by Firefox as of 2026-05 *}}
-				{{* Requires HTTPS, requires the permission is enabled *}}
-				{{if $is_mobile AND $item.browsershare}}
+				{{* Available: On (some) posts and comments? *}}
+				{{* Not supported by Firefox desktop as of 2026-05 *}}
+				{{* Requires HTTPS and requires that the permission is enabled *}}
+				{{* TODO: Add the relevant checks so this is only available/clickable when on a device where its supported *}}
+				{{if $item.browsershare}}
 				<li role="menuitem" class="button-browser-share">
 						<a id="browser-share-{{$item.id}}" href="javascript:navigator.share({url: '{{$item.plink.orig}}'})" class="btn-link button-browser-share" title="{{$item.browsershare.1}}"><i class="fa fa-share-alt" aria-hidden="true"></i>&ensp;{{$item.browsershare.0}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On posts made by others *}}
-				{{if $item.complete_thread}}
-				<li role="menuitem">
-						<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="fa fa-download" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
 				</li>
 				{{/if}}
 
@@ -469,17 +470,14 @@ as the value of $top_child_total (this is done at the end of this file)
 				</li>
 				{{/if}}
 
-				{{* Available: On your own posts *}}
-				{{* TODO: This currently creates a duplicate post according to: https://forum.friendi.ca/display/373ebf56-2469-ed09-ccc0-ecd539065051 *}}
-				{{if $item.tagger}} {{* tag the post *}}
+				{{* Available: On posts made by others *}}
+				{{if $item.complete_thread}}
 				<li role="menuitem">
-						<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
+						<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="fa fa-download" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
 				</li>
 				{{/if}}
 
-				{{if ($item.edpost || $item.star || $item.tagger || $item.filer || $item.pin || $item.follow_thread || $item.complete_thread) && ($item.ignore || ($item.drop && $item.drop.dropping))}}
 				<li class="divider"><hr></li>
-				{{/if}}
 
 				{{* Available: On posts made by others *}}
 				{{if $item.collapse}}
@@ -513,18 +511,19 @@ as the value of $top_child_total (this is done at the end of this file)
 				</li>
 				{{/if}}
 
+				{{* Available: On all posts and comments *}}
 				<li role="menuitem">
 						<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
 				</li>
 
-				{{* Available: All posts and comments *}}
+				{{* Available: On all posts and comments *}}
 				{{if $item.language}}
 				<li role="menuitem">
 						<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
 				</li>
 				{{/if}}
 
-				{{* Available: All posts and comments made by others *}}
+				{{* Available: On all posts and comments made by others *}}
 				{{if $item.report}}
 				<li role="menuitem">
 						<a class="btn-link navicon ignore" href="{{$item.report.href}}"><i class="fa fa-flag" aria-hidden="true"></i>&ensp;{{$item.report.label}}</a>
@@ -634,8 +633,8 @@ as the value of $top_child_total (this is done at the end of this file)
 
 							{{if $item.pin}}
 								<li role="menuitem">
-									<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-circle-o" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
-									<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="fa fa-dot-circle-o" aria-hidden="true"></i>&ensp;{{$item.pin.undo}}</a>
+									<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
+									<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.undo}}</a>
 								</li>
 							{{/if}}
 
@@ -647,8 +646,8 @@ as the value of $top_child_total (this is done at the end of this file)
 
 							{{if $item.star}}
 								<li role="menuitem">
-									<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-star-o" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
-									<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-star" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
+									<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-bookmark-o" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
+									<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-bookmark" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
 								</li>
 							{{/if}}
 
@@ -660,28 +659,8 @@ as the value of $top_child_total (this is done at the end of this file)
 
 							{{if $item.follow_thread}}
 								<li role="menuitem">
-									<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="fa fa-plus" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
+									<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="fa fa-bell" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
 								</li>
-							{{/if}}
-
-							{{if $item.complete_thread}}
-								<li role="menuitem">
-									<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="fa fa-download" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
-								</li>
-							{{/if}}
-
-							{{if $item.language}}
-								<li role="menuitem">
-									<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
-								</li>
-							{{/if}}
-
-							<li role="menuitem">
-								<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
-							</li>
-
-							{{if ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.complete_thread) && ($item.ignore || ($item.drop && $item.drop.dropping))}}
-								<li class="divider"><hr></li>
 							{{/if}}
 
 							{{if $item.ignore}}
@@ -693,31 +672,58 @@ as the value of $top_child_total (this is done at the end of this file)
 								</li>
 							{{/if}}
 
-							{{if $item.block}}
+							{{if $item.complete_thread}}
 								<li role="menuitem">
-									<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.block.label}}"><i class="fa fa-ban" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
+									<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="fa fa-download" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
 								</li>
 							{{/if}}
-							{{if $item.ignore_author}}
-								<li role="menuitem">
-									<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.ignore_author.label}}"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
-								</li>
-							{{/if}}
+
+							<li class="divider"><hr></li>
+
 							{{if $item.collapse}}
 								<li role="menuitem">
 									<a class="btn-link navicon collapse" href="javascript:collapseAuthor('item/collapse/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.collapse.label}}"><i class="fa fa-minus-square" aria-hidden="true"></i>&ensp;{{$item.collapse.label}}</a>
 								</li>
 							{{/if}}
+
+							{{if $item.ignore_author}}
+								<li role="menuitem">
+									<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.ignore_author.label}}"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
+								</li>
+							{{/if}}
+
+							{{if $item.block}}
+								<li role="menuitem">
+									<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.block.label}}"><i class="fa fa-ban" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
+								</li>
+							{{/if}}
+
+							{{if $item.collapse || $item.ignore_author || $item.block }}
+								<li class="divider"><hr></li>
+							{{/if}}
+
 							{{if $item.ignore_server}}
 								<li role="menuitem">
 									<a class="btn-link navicon ignoreServer" href="javascript:ignoreServer('settings/server/{{$item.author_gsid}}/ignore', 'item-{{$item.guid}}');" title="{{$item.ignore_server.label}}"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_server.label}}</a>
 								</li>
 							{{/if}}
+
+							<li role="menuitem">
+								<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
+							</li>
+
+							{{if $item.language}}
+								<li role="menuitem">
+									<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
+								</li>
+							{{/if}}
+
 							{{if $item.report}}
 								<li role="menuitem">
 									<a class="btn-link navicon ignore" href="{{$item.report.href}}"><i class="fa fa-flag" aria-hidden="true"></i>&ensp;{{$item.report.label}}</a>
 								</li>
 							{{/if}}
+
 							{{if $item.drop && $item.drop.dropping}}
 								<li role="menuitem">
                                                 			<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="fa fa-trash" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -407,15 +407,15 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Available: On your own posts and comments *}}
 				{{if $item.edpost}} {{* edit the posting *}}
 				<li role="menuitem">
-						<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" title="{{$item.edpost.1}}" class="btn-link navicon pencil"><i class="fa fa-pencil" aria-hidden="true"></i>&ensp;{{$item.edpost.1}}</a>
+						<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" class="btn-link navicon pencil"><i class="fa fa-pencil" aria-hidden="true"></i>&ensp;{{$item.edpost.1}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On your own posts *}}
 				{{if $item.pin}}
 				<li role="menuitem">
-						<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
-						<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.undo}}</a>
+						<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
+						<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.undo}}</a>
 				</li>
 				{{/if}}
 
@@ -423,22 +423,22 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* TODO: This currently creates a duplicate post according to: https://forum.friendi.ca/display/373ebf56-2469-ed09-ccc0-ecd539065051 *}}
 				{{if $item.tagger}} {{* tag the post *}}
 				<li role="menuitem">
-						<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
+						<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}"><i class="fa fa-tag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On posts made by anyone *}}
 				{{if $item.star}}
 				<li role="menuitem">
-						<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-bookmark-o" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
-						<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-bookmark" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
+						<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}"><i class="fa fa-bookmark-o" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
+						<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}"><i class="fa fa-bookmark" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On all posts and comments *}}
 				{{if $item.filer}}
 				<li role="menuitem">
-						<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="fa fa-folder" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
+						<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon"><i class="fa fa-folder" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
 				</li>
 				{{/if}}
 
@@ -456,24 +456,24 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Identical to unignore in functionality but only seen on posts you haven't liked/commented on - could they be merged? *}}
 				{{if $item.follow_thread}}
 				<li role="menuitem">
-						<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="fa fa-bell" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
+						<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link"><i class="fa fa-bell" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On all posts *}}
 				{{if $item.ignore}}
 				<li role="menuitem">
-						<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-bell-slash" aria-hidden="true"></i>&ensp;{{$item.ignore.do}}</a>
+						<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}"><i class="fa fa-bell-slash" aria-hidden="true"></i>&ensp;{{$item.ignore.do}}</a>
 				</li>
 				<li role="menuitem">
-						<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-bell" aria-hidden="true"></i>&ensp;{{$item.ignore.undo}}</a>
+						<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"><i class="fa fa-bell" aria-hidden="true"></i>&ensp;{{$item.ignore.undo}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On posts made by others *}}
 				{{if $item.complete_thread}}
 				<li role="menuitem">
-						<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="fa fa-download" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
+						<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link"><i class="fa fa-download" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
 				</li>
 				{{/if}}
 
@@ -482,21 +482,21 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Available: On posts made by others *}}
 				{{if $item.collapse}}
 				<li role="menuitem">
-						<a class="btn-link navicon collapse" href="javascript:collapseAuthor('item/collapse/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.collapse.label}}"><i class="fa fa-minus-square" aria-hidden="true"></i>&ensp;{{$item.collapse.label}}</a>
+						<a class="btn-link navicon collapse" href="javascript:collapseAuthor('item/collapse/{{$item.id}}', 'item-{{$item.guid}}');"><i class="fa fa-minus-square" aria-hidden="true"></i>&ensp;{{$item.collapse.label}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On posts made by others *}}
 				{{if $item.ignore_author}}
 				<li role="menuitem">
-						<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.ignore_author.label}}"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
+						<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On posts made by others *}}
 				{{if $item.block}}
 				<li role="menuitem">
-						<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.block.label}}"><i class="fa fa-ban" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
+						<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');"><i class="fa fa-ban" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
 				</li>
 				{{/if}}
 
@@ -507,19 +507,19 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Available: On posts made by others *}}
 				{{if $item.ignore_server}}
 				<li role="menuitem">
-						<a class="btn-link navicon ignoreServer" href="javascript:ignoreServer('settings/server/{{$item.author_gsid}}/ignore', 'item-{{$item.guid}}');" title="{{$item.ignore_server.label}}"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_server.label}}</a>
+						<a class="btn-link navicon ignoreServer" href="javascript:ignoreServer('settings/server/{{$item.author_gsid}}/ignore', 'item-{{$item.guid}}');"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_server.label}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On all posts and comments *}}
 				<li role="menuitem">
-						<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
+						<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
 				</li>
 
 				{{* Available: On all posts and comments *}}
 				{{if $item.language}}
 				<li role="menuitem">
-						<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
+						<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
 				</li>
 				{{/if}}
 
@@ -533,7 +533,7 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Available: If you're an admin, on all posts and comments on your instance *}}
 				{{if $item.drop && $item.drop.dropping}}
 				<li role="menuitem">
-						<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="fa fa-trash" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
+						<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');"><i class="fa fa-trash" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
 				</li>
 				{{/if}}
 			</ul>

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -248,7 +248,7 @@ function frio_display_item(&$arr)
 	) {
 		$followThread = [
 			'menu'   => 'follow_thread',
-			'title'  => DI::l10n()->t('Follow Thread'),
+			'title'  => DI::l10n()->t('Turn on notifications for this post'),
 			'action' => 'doFollowThread(' . $arr['item']['id'] . ');',
 			'href'   => '#',
 		];
@@ -265,7 +265,7 @@ function frio_display_item(&$arr)
 	) {
 		$completeThread = [
 			'menu'   => 'complete_thread',
-			'title'  => DI::l10n()->t('Complete Thread'),
+			'title'  => DI::l10n()->t('Fetch more replies'),
 			'action' => 'doCompleteThread(' . $arr['item']['uri-id'] . ');',
 			'href'   => '#',
 		];


### PR DESCRIPTION
Some adjustments to the Post/Comment menu:

- Reorder things according to expected frequency of use, severity from least to most severe and putting related things together
- Group things a bit further, so collapsing, ignoring and blocking a user is grouped together 
- Ignore/Unignore on a post and "Follow thread" are made indistinguishable in the UI (in both name and icon), because "Follow" seems to be equivalent to "Unignore".  Also the wording is changed to "Turn on/off notifications for this post", which aligns with Facebook.
- "Star" is renamed ~~"Favourite"~~ Bookmark, arguably making its functionality clearer. Also considered "Bookmark" but I think randompenguin recommended the former
- Make it clearer what the most things in the menu do, by being more explicit in the wording, even though it's more verbose
- "Complete thread" is renamed to "Fetch more replies" based on suggestions here: https://forum.friendi.ca/display/fcc8f939-8569-ed04-d186-960513870760
- Consistently make pin/unpin/unpinned use the "thumb tack" icon
- In the code: Document when each item is being shown

I'm considering if we can do something about "Detected languages" in #15709 and got confused that "Add tag" is settable on the posts of other users if you're an admin, which I created an issue on here: #15708

After - example:
<img width="256" height="459" alt="image" src="https://github.com/user-attachments/assets/197be30f-b2d0-4eaa-bf97-a90aa6bcfe2c" />

Before - example:
<img width="204" height="397" alt="image" src="https://github.com/user-attachments/assets/98eccd2b-7b4c-41db-8bb8-710f1106fe3e" />
