### PR TITLE
BBCode auto complete: Remove audio and video now embed has been generalized/improved?

### DIFF
--- a/view/js/autocomplete.js
+++ b/view/js/autocomplete.js
@@ -352,7 +352,7 @@ function string2bb(element) {
 
 	$.fn.bbco_autocomplete = function(type) {
 		if (type === 'bbcode') {
-			var open_close_elements = ['bold', 'italic', 'underline', 'overline', 'strike', 'quote', 'code', 'spoiler', 'map', 'img', 'url', 'audio', 'video', 'embed', 'list', 'ul', 'ol', 'li', 'table', 'tr', 'th', 'td', 'center', 'color', 'font', 'size', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'nobb', 'noparse', 'pre', 'abstract', 'share', 'attachment', 'mark'];
+			var open_close_elements = ['bold', 'italic', 'underline', 'overline', 'strike', 'quote', 'code', 'spoiler', 'map', 'img', 'url', 'embed', 'list', 'ul', 'ol', 'li', 'table', 'tr', 'th', 'td', 'center', 'color', 'font', 'size', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'nobb', 'noparse', 'pre', 'abstract', 'share', 'attachment', 'mark'];
 			var open_elements = ['*', 'hr'];
 
 			var elements = open_close_elements.concat(open_elements);


### PR DESCRIPTION
Do we want to do this based on the points made in #15678 ? 