### PR TITLE
Frio: Load global.css between bootstrap and Frio's own styling and related adjustments

### DIFF
--- a/src/Module/Profile/Notes.php
+++ b/src/Module/Profile/Notes.php
@@ -92,7 +92,7 @@ class Notes extends BaseProfile
 
 		$o = parent::getTabsHTML('notes', true, $this->userSession->getLocalUserNickname(), false);
 
-		$o .= '<h3>' . $this->l10n->t('Personal notes') . '</h3>';
+		$o .= '<h2>' . $this->l10n->t('Personal notes') . '</h2>';
 
 		$x = [
 			'lockstate' => 'lock',

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -40,6 +40,16 @@ body a[name]:not([href]) {
 	visibility: hidden;
 }
 
+/* Undo a global.css change */
+.nav-pills .btn, .fbrowser-content .btn {
+	background-color: transparent;
+}
+
+/* Undo a global.css change */
+#vcard-short-desc .media-heading {
+	line-height: 1.1;
+}
+
 body a:hover,
 .btn-link:hover,
 body a:focus,

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -12,7 +12,6 @@
 <meta name="viewport" content="initial-scale=1.0">
 
 {{* All needed css files - Note: css must be inserted before js files *}}
-<link rel="stylesheet" href="view/global.css?v={{$VERSION}}" type="text/css" media="all" />
 <link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 <link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css?v={{$VERSION}}"
@@ -59,6 +58,7 @@
 	type="text/css" media="screen" />
 
 {{* own css files *}}
+<link rel="stylesheet" href="view/global.css?v={{$VERSION}}" type="text/css" media="all" />
 <link rel="stylesheet" href="view/theme/frio/css/hovercard.css?v={{$VERSION}}" type="text/css"
 	media="screen" />
 <link rel="stylesheet" href="view/theme/frio/css/font-awesome.custom.css?v={{$VERSION}}"

--- a/view/theme/frio/templates/jot.tpl
+++ b/view/theme/frio/templates/jot.tpl
@@ -15,7 +15,7 @@
 		<div class="modal-header">
 			<button type="button" class="close" data-dismiss="modal" aria-label="Close" style="float: right;">&times;</button>
 
-			<a href="/compose" class="btn compose-link" title="{{$compose_link_title}}" aria-label="{{$compose_link_title}}">
+			<a href="/compose" class="btn btn-secondary compose-link" title="{{$compose_link_title}}" aria-label="{{$compose_link_title}}">
 				<i class="fa fa-pencil-square-o" aria-hidden="true"></i>
 			</a>
 


### PR DESCRIPTION
Closes #15690

...which also means the global.css font sizing begins to takes precedence over Bootstraps.

**Note:** This could have all sorts of styling side effects, so maybe it should target the next release?
I took a look around and only saw small things, though, which I fixed where I thought it made sense.