### PR TITLE
Make PMs visible in the top nav on smaller viewports

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -4318,7 +4318,7 @@ div.login-form, .login-content-wrapper,
 	}
 
 }/* Even smaller mobile displays */
-@media (width < 315px) {
+@media (width < 358px) {
 	/* Less topnav padding */
 	.navbar-left {
 		float: none!important;

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -85,7 +85,7 @@
 						{{/if}}
 
 						{{if $nav.messages}}
-							<li class="nav-segment hidden-xs">
+							<li class="nav-segment">
 								<a accesskey="m" id="nav-messages-link" href="{{$nav.messages.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.messages.1}}" title="{{$nav.messages.1}}"
 									class="nav-menu {{$sel.messages}}"><i class="fa fa-envelope fa-lg fa-fw"


### PR DESCRIPTION
Closes #15723   

# Screenshots

<img width="323" height="277" alt="image" src="https://github.com/user-attachments/assets/68e3dc06-471a-4210-9956-94d05a259d65" />