### PR TITLE
Issue 15720: Fix expire posts

### DIFF
--- a/src/Worker/ExpirePosts.php
+++ b/src/Worker/ExpirePosts.php
@@ -299,8 +299,6 @@ class ExpirePosts
 					WHERE `uri-id` = `post-thread`.`uri-id`)
 				AND NOT `uri-id` IN (SELECT `uri-id` FROM `post-collection`
 					WHERE `uri-id` = `post-thread`.`uri-id`)
-				AND NOT `uri-id` IN (SELECT `uri-id` FROM `post-media`
-					WHERE `uri-id` = `post-thread`.`uri-id`)
 				AND NOT `uri-id` IN (SELECT `parent-uri-id` FROM `post-user` INNER JOIN `contact` ON `contact`.`id` = `contact-id` AND `notify_new_posts`
 					WHERE `parent-uri-id` = `post-thread`.`uri-id`)
 				AND NOT `uri-id` IN (SELECT `parent-uri-id` FROM `post-user`


### PR DESCRIPTION
This fixes #15720. The expiry query originally checked if any media was connected to the post and then hasn't removed it - which doesn't make sense. This had been added in 2021, so the expiry job will now likely delete some million entries.