### PR TITLE
Rector update codebase to phplevel 83

### DIFF
--- a/.rector.php
+++ b/.rector.php
@@ -16,12 +16,13 @@ return \Rector\Config\RectorConfig::configure()
 		__DIR__ . '/tests',
 		__DIR__ . '/view',
 	])
+	->withSkipPath(__DIR__ . '/view/smarty3/compiled')
 	->withIndent("\t", 4)
 	->withPhpVersion(80200)
 	// ->withTypeCoverageLevel(0)
 	// ->withDeadCodeLevel(0)
 	// ->withCodeQualityLevel(0)
-	->withPhpLevel(82)
+	->withPhpLevel(83)
 	->withSets([
 		//\Rector\Set\ValueObject\LevelSetList::UP_TO_PHP_85,
 	])

--- a/src/App.php
+++ b/src/App.php
@@ -78,11 +78,6 @@ class App
 	}
 
 	/**
-	 * @var Container
-	 */
-	private $container;
-
-	/**
 	 * @var Mode The Mode of the Application
 	 */
 	private $mode;
@@ -133,10 +128,9 @@ class App
 	 */
 	private $appHelper;
 
-	private function __construct(Container $container)
-	{
-		$this->container = $container;
-	}
+	private function __construct(private Container $container)
+				{
+							}
 
 	/**
 	 * @internal

--- a/src/App.php
+++ b/src/App.php
@@ -128,9 +128,7 @@ class App
 	 */
 	private $appHelper;
 
-	private function __construct(private Container $container)
-				{
-							}
+	private function __construct(private Container $container) {}
 
 	/**
 	 * @internal

--- a/src/App/Arguments.php
+++ b/src/App/Arguments.php
@@ -16,36 +16,34 @@ namespace Friendica\App;
  */
 class Arguments
 {
-	const DEFAULT_MODULE = 'home';
+	public const DEFAULT_MODULE = 'home';
 
 	public function __construct(
-								/**
-								 * @var string The complete query string
-								 */
-								private string $queryString = '',
-								/**
-								 * @var string The current Friendica command
-								 */
-								private string $command = '',
-								/**
-								 * @var string The name of the current module
-								 */
-								private string $moduleName = '',
-								/**
-								 * @var array The arguments of the current execution
-								 */
-								private array $argv = [],
-								/**
-								 * @var int The count of arguments
-								 */
-								private int $argc = 0,
-								/**
-								 * @var string The used HTTP method
-								 */
-								private string $method = Router::GET
-							)
-							{
-										}
+		/**
+		 * @var string The complete query string
+		 */
+		private string $queryString = '',
+		/**
+		 * @var string The current Friendica command
+		 */
+		private string $command = '',
+		/**
+		 * @var string The name of the current module
+		 */
+		private string $moduleName = '',
+		/**
+		 * @var array The arguments of the current execution
+		 */
+		private array $argv = [],
+		/**
+		 * @var int The count of arguments
+		 */
+		private int $argc = 0,
+		/**
+		 * @var string The used HTTP method
+		 */
+		private string $method = Router::GET,
+	) {}
 
 	/**
 	 * @return string The whole query string of this call with url-encoded query parameters

--- a/src/App/Arguments.php
+++ b/src/App/Arguments.php
@@ -18,40 +18,34 @@ class Arguments
 {
 	const DEFAULT_MODULE = 'home';
 
-	/**
-	 * @var string The complete query string
-	 */
-	private $queryString;
-	/**
-	 * @var string The current Friendica command
-	 */
-	private $command;
-	/**
-	 * @var string The name of the current module
-	 */
-	private $moduleName;
-	/**
-	 * @var array The arguments of the current execution
-	 */
-	private $argv;
-	/**
-	 * @var int The count of arguments
-	 */
-	private $argc;
-	/**
-	 * @var string The used HTTP method
-	 */
-	private $method;
-
-	public function __construct(string $queryString = '', string $command = '', string $moduleName = '', array $argv = [], int $argc = 0, string $method = Router::GET)
-	{
-		$this->queryString = $queryString;
-		$this->command     = $command;
-		$this->moduleName  = $moduleName;
-		$this->argv        = $argv;
-		$this->argc        = $argc;
-		$this->method      = $method;
-	}
+	public function __construct(
+								/**
+								 * @var string The complete query string
+								 */
+								private string $queryString = '',
+								/**
+								 * @var string The current Friendica command
+								 */
+								private string $command = '',
+								/**
+								 * @var string The name of the current module
+								 */
+								private string $moduleName = '',
+								/**
+								 * @var array The arguments of the current execution
+								 */
+								private array $argv = [],
+								/**
+								 * @var int The count of arguments
+								 */
+								private int $argc = 0,
+								/**
+								 * @var string The used HTTP method
+								 */
+								private string $method = Router::GET
+							)
+							{
+										}
 
 	/**
 	 * @return string The whole query string of this call with url-encoded query parameters

--- a/src/App/Mode.php
+++ b/src/App/Mode.php
@@ -66,26 +66,24 @@ class Mode
 	private $executor = self::UNDEFINED;
 
 	public function __construct(
-								private int $mode = 0,
-								/**
-								 * @var bool True, if the call is a backend call
-								 */
-								private bool $isBackend = false,
-								/**
-								 * @var bool True, if the call is a ajax call
-								 */
-								private bool $isAjax = false,
-								/**
-								 * @var bool True, if the call is from a mobile device
-								 */
-								private bool $isMobile = false,
-								/**
-								 * @var bool True, if the call is from a tablet device
-								 */
-								private bool $isTablet = false
-							)
-							{
-										}
+		private int $mode = 0,
+		/**
+		 * @var bool True, if the call is a backend call
+		 */
+		private bool $isBackend = false,
+		/**
+		 * @var bool True, if the call is a ajax call
+		 */
+		private bool $isAjax = false,
+		/**
+		 * @var bool True, if the call is from a mobile device
+		 */
+		private bool $isMobile = false,
+		/**
+		 * @var bool True, if the call is from a tablet device
+		 */
+		private bool $isTablet = false,
+	) {}
 
 	/**
 	 * Sets the App mode

--- a/src/App/Mode.php
+++ b/src/App/Mode.php
@@ -60,45 +60,32 @@ class Mode
 	];
 
 	/***
-	 * @var int The mode of this Application
-	 *
-	 */
-	private $mode;
-
-	/***
 	 * @var int Who executes this Application
 	 *
 	 */
 	private $executor = self::UNDEFINED;
 
-	/**
-	 * @var bool True, if the call is a backend call
-	 */
-	private $isBackend;
-
-	/**
-	 * @var bool True, if the call is a ajax call
-	 */
-	private $isAjax;
-
-	/**
-	 * @var bool True, if the call is from a mobile device
-	 */
-	private $isMobile;
-
-	/**
-	 * @var bool True, if the call is from a tablet device
-	 */
-	private $isTablet;
-
-	public function __construct(int $mode = 0, bool $isBackend = false, bool $isAjax = false, bool $isMobile = false, bool $isTablet = false)
-	{
-		$this->mode      = $mode;
-		$this->isBackend = $isBackend;
-		$this->isAjax    = $isAjax;
-		$this->isMobile  = $isMobile;
-		$this->isTablet  = $isTablet;
-	}
+	public function __construct(
+								private int $mode = 0,
+								/**
+								 * @var bool True, if the call is a backend call
+								 */
+								private bool $isBackend = false,
+								/**
+								 * @var bool True, if the call is a ajax call
+								 */
+								private bool $isAjax = false,
+								/**
+								 * @var bool True, if the call is from a mobile device
+								 */
+								private bool $isMobile = false,
+								/**
+								 * @var bool True, if the call is from a tablet device
+								 */
+								private bool $isTablet = false
+							)
+							{
+										}
 
 	/**
 	 * Sets the App mode

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -73,11 +73,11 @@ class Page implements ArrayAccess
 	private $command   = '';
 
 	/**
-				 * @param string $basePath The Page basepath
-				 */
-				public function __construct(private string $basePath, private EventDispatcherInterface $eventDispatcher)
+	 * @param string $basePath The Page basepath
+	 */
+	public function __construct(private string $basePath, private EventDispatcherInterface $eventDispatcher)
 	{
-		$this->timestamp       = microtime(true);
+		$this->timestamp = microtime(true);
 	}
 
 	public function setLogging(string $method, string $module, string $command)
@@ -186,7 +186,7 @@ class Page implements ArrayAccess
 		L10n $l10n,
 		IManageConfigValues $config,
 		IManagePersonalConfigValues $pConfig,
-		int $localUID
+		int $localUID,
 	) {
 		// Default title: current module called
 		if (empty($this->page['title']) && $args->getModuleName()) {
@@ -215,7 +215,7 @@ class Page implements ArrayAccess
 		}
 
 		$this->page['htmlhead'] = $this->eventDispatcher->dispatch(
-			new HtmlFilterEvent(HtmlFilterEvent::HEAD, $this->page['htmlhead'])
+			new HtmlFilterEvent(HtmlFilterEvent::HEAD, $this->page['htmlhead']),
 		)->getHtml();
 
 		$tpl = Renderer::getMarkupTemplate('head.tpl');
@@ -255,7 +255,7 @@ class Page implements ArrayAccess
 
 			'$local_user'     => $localUID,
 			'$generator'      => 'Friendica' . ' ' . App::VERSION,
-			'$update_content' => (int)$pConfig->get($localUID, 'system', 'update_content'),
+			'$update_content' => (int) $pConfig->get($localUID, 'system', 'update_content'),
 			'$shortcut_icon'  => $shortcut_icon,
 			'$touch_icon'     => $touch_icon,
 			'$block_public'   => intval($config->get('system', 'block_public')),
@@ -334,12 +334,12 @@ class Page implements ArrayAccess
 			}
 			$this->page['footer'] .= Renderer::replaceMacros(Renderer::getMarkupTemplate("toggle_mobile_footer.tpl"), [
 				'$toggle_link' => $link,
-				'$toggle_text' => $l10n->t('toggle mobile')
+				'$toggle_text' => $l10n->t('toggle mobile'),
 			]);
 		}
 
 		$this->page['footer'] = $this->eventDispatcher->dispatch(
-			new HtmlFilterEvent(HtmlFilterEvent::FOOTER, $this->page['footer'])
+			new HtmlFilterEvent(HtmlFilterEvent::FOOTER, $this->page['footer']),
 		)->getHtml();
 
 		$tpl                  = Renderer::getMarkupTemplate('footer.tpl');
@@ -366,11 +366,11 @@ class Page implements ArrayAccess
 		// initialise content region
 		if ($mode->isNormal()) {
 			$this->page['content'] = $this->eventDispatcher->dispatch(
-				new HtmlFilterEvent(HtmlFilterEvent::PAGE_CONTENT_TOP, $this->page['content'])
+				new HtmlFilterEvent(HtmlFilterEvent::PAGE_CONTENT_TOP, $this->page['content']),
 			)->getHtml();
 		}
 
-		$this->page['content'] .= (string)$response->getBody();
+		$this->page['content'] .= (string) $response->getBody();
 	}
 
 	/**
@@ -421,7 +421,7 @@ class Page implements ArrayAccess
 		IManageConfigValues $config,
 		IManagePersonalConfigValues $pconfig,
 		Nav $nav,
-		int $localUID
+		int $localUID,
 	) {
 		$moduleName = $args->getModuleName();
 
@@ -466,7 +466,7 @@ class Page implements ArrayAccess
 
 		if (!$mode->isAjax()) {
 			$this->page['content'] = $this->eventDispatcher->dispatch(
-				new HtmlFilterEvent(HtmlFilterEvent::PAGE_END, $this->page['content'])
+				new HtmlFilterEvent(HtmlFilterEvent::PAGE_END, $this->page['content']),
 			)->getHtml();
 		}
 

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -66,12 +66,6 @@ class Page implements ArrayAccess
 		'section'     => '',
 		'module'      => '',
 	];
-	/**
-	 * @var string The basepath of the page
-	 */
-	private $basePath;
-
-	private EventDispatcherInterface $eventDispatcher;
 
 	private $timestamp = 0;
 	private $method    = '';
@@ -79,13 +73,11 @@ class Page implements ArrayAccess
 	private $command   = '';
 
 	/**
-	 * @param string $basepath The Page basepath
-	 */
-	public function __construct(string $basepath, EventDispatcherInterface $eventDispatcher)
+				 * @param string $basePath The Page basepath
+				 */
+				public function __construct(private string $basePath, private EventDispatcherInterface $eventDispatcher)
 	{
 		$this->timestamp       = microtime(true);
-		$this->basePath        = $basepath;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	public function setLogging(string $method, string $module, string $command)

--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -68,36 +68,8 @@ class Router
 	 */
 	protected $parameters = [];
 
-	/** @var L10n */
-	private $l10n;
-
-	/** @var ICanCache */
-	private $cache;
-
-	/** @var ICanLock */
-	private $lock;
-
-	/** @var Arguments */
-	private $args;
-
-	/** @var IManageConfigValues */
-	private $config;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	private EventDispatcherInterface $eventDispatcher;
-
-	private AddonHelper $addonHelper;
-
 	/** @var bool */
 	private $isLocalUser;
-
-	/** @var string */
-	private $baseRoutesFilepath;
-
-	/** @var array */
-	private $server;
 
 	/** @var string|null */
 	protected $moduleClass = null;
@@ -114,18 +86,8 @@ class Router
 	 * @param IHandleUserSessions $userSession
 	 * @param RouteCollector|null $routeCollector
 	 */
-	public function __construct(array $server, string $baseRoutesFilepath, L10n $l10n, ICanCache $cache, ICanLock $lock, IManageConfigValues $config, Arguments $args, LoggerInterface $logger, EventDispatcherInterface $eventDispatcher, AddonHelper $addonHelper, IHandleUserSessions $userSession, RouteCollector $routeCollector = null)
+	public function __construct(private array $server, private string $baseRoutesFilepath, private L10n $l10n, private ICanCache $cache, private ICanLock $lock, private IManageConfigValues $config, private Arguments $args, private LoggerInterface $logger, private EventDispatcherInterface $eventDispatcher, private AddonHelper $addonHelper, IHandleUserSessions $userSession, RouteCollector $routeCollector = null)
 	{
-		$this->baseRoutesFilepath = $baseRoutesFilepath;
-		$this->l10n               = $l10n;
-		$this->cache              = $cache;
-		$this->lock               = $lock;
-		$this->args               = $args;
-		$this->config             = $config;
-		$this->server             = $server;
-		$this->logger             = $logger;
-		$this->eventDispatcher    = $eventDispatcher;
-		$this->addonHelper        = $addonHelper;
 		$this->isLocalUser        = !empty($userSession->getLocalUserId());
 
 		$this->routeCollector = $routeCollector ?? new RouteCollector(new Std(), new GroupCountBased());

--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -88,7 +88,7 @@ class Router
 	 */
 	public function __construct(private array $server, private string $baseRoutesFilepath, private L10n $l10n, private ICanCache $cache, private ICanLock $lock, private IManageConfigValues $config, private Arguments $args, private LoggerInterface $logger, private EventDispatcherInterface $eventDispatcher, private AddonHelper $addonHelper, IHandleUserSessions $userSession, RouteCollector $routeCollector = null)
 	{
-		$this->isLocalUser        = !empty($userSession->getLocalUserId());
+		$this->isLocalUser = !empty($userSession->getLocalUserId());
 
 		$this->routeCollector = $routeCollector ?? new RouteCollector(new Std(), new GroupCountBased());
 

--- a/src/AppLegacy.php
+++ b/src/AppLegacy.php
@@ -56,28 +56,26 @@ final class AppLegacy implements AppHelper
 	];
 
 	public function __construct(
-								/**
-								 * @var Database The Friendica database connection
-								 */
-								private Database $database,
-								/**
-								 * @var IManageConfigValues The config
-								 */
-								private IManageConfigValues $config,
-								/**
-								 * @var Mode The Mode of the Application
-								 */
-								private Mode $mode,
-								private BaseURL $baseURL,
-								/**
-								 * @var L10n The translator
-								 */
-								private L10n $l10n,
-								private IManagePersonalConfigValues $pConfig,
-								private IHandleUserSessions $session
-							)
-							{
-										}
+		/**
+		 * @var Database The Friendica database connection
+		 */
+		private Database $database,
+		/**
+		 * @var IManageConfigValues The config
+		 */
+		private IManageConfigValues $config,
+		/**
+		 * @var Mode The Mode of the Application
+		 */
+		private Mode $mode,
+		private BaseURL $baseURL,
+		/**
+		 * @var L10n The translator
+		 */
+		private L10n $l10n,
+		private IManagePersonalConfigValues $pConfig,
+		private IHandleUserSessions $session,
+	) {}
 
 	/**
 	 * Set the profile owner ID
@@ -341,8 +339,7 @@ final class AppLegacy implements AppHelper
 
 		$mobile_theme_name = Strings::sanitizeFilePathItem($mobile_theme_name);
 		if ($mobile_theme_name == '---'
-			||
-			in_array($mobile_theme_name, Theme::getAllowedList())
+			|| in_array($mobile_theme_name, Theme::getAllowedList())
 			&& (file_exists('view/theme/' . $mobile_theme_name . '/style.css')
 				|| file_exists('view/theme/' . $mobile_theme_name . '/style.php'))
 		) {

--- a/src/AppLegacy.php
+++ b/src/AppLegacy.php
@@ -55,58 +55,29 @@ final class AppLegacy implements AppHelper
 	private $theme_info = [
 	];
 
-	/**
-	 * @var Database The Friendica database connection
-	 */
-	private $database;
-
-	/**
-	 * @var IManageConfigValues The config
-	 */
-	private $config;
-
-	/**
-	 * @var Mode The Mode of the Application
-	 */
-	private $mode;
-
-	/**
-	 * @var BaseURL
-	 */
-	private $baseURL;
-
-	/**
-	 * @var L10n The translator
-	 */
-	private $l10n;
-
-	/**
-	 * @var IManagePersonalConfigValues
-	 */
-	private $pConfig;
-
-	/**
-	 * @var IHandleUserSessions
-	 */
-	private $session;
-
 	public function __construct(
-		Database $database,
-		IManageConfigValues $config,
-		Mode $mode,
-		BaseURL $baseURL,
-		L10n $l10n,
-		IManagePersonalConfigValues $pConfig,
-		IHandleUserSessions $session
-	) {
-		$this->database = $database;
-		$this->config   = $config;
-		$this->mode     = $mode;
-		$this->l10n     = $l10n;
-		$this->baseURL  = $baseURL;
-		$this->pConfig  = $pConfig;
-		$this->session  = $session;
-	}
+								/**
+								 * @var Database The Friendica database connection
+								 */
+								private Database $database,
+								/**
+								 * @var IManageConfigValues The config
+								 */
+								private IManageConfigValues $config,
+								/**
+								 * @var Mode The Mode of the Application
+								 */
+								private Mode $mode,
+								private BaseURL $baseURL,
+								/**
+								 * @var L10n The translator
+								 */
+								private L10n $l10n,
+								private IManagePersonalConfigValues $pConfig,
+								private IHandleUserSessions $session
+							)
+							{
+										}
 
 	/**
 	 * Set the profile owner ID

--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -25,15 +25,6 @@ abstract class BaseModel extends BaseDataTransferObject
 	protected $logger;
 
 	/**
-	 * Model record abstraction.
-	 * Child classes never have to interact directly with it.
-	 * Please use the magic getter instead.
-	 *
-	 * @var array
-	 */
-	private $data = [];
-
-	/**
 	 * Used to limit/avoid updates if no data was changed.
 	 *
 	 * @var array
@@ -43,12 +34,16 @@ abstract class BaseModel extends BaseDataTransferObject
 	/**
 	 * @param array           $data   Table row attributes
 	 */
-	public function __construct(Database $dba, LoggerInterface $logger, array $data = [])
+	public function __construct(Database $dba, LoggerInterface $logger, /**
+				 * Model record abstraction.
+				 * Child classes never have to interact directly with it.
+				 * Please use the magic getter instead.
+				 */
+				private array $data = [])
 	{
 		$this->dba = $dba;
 		$this->logger = $logger;
-		$this->data = $data;
-		$this->originalData = $data;
+		$this->originalData = $this->data;
 	}
 
 	public function getOriginalData(): array

--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -29,7 +29,7 @@ abstract class BaseModel extends BaseDataTransferObject
 	 *
 	 * @var array
 	 */
-    private $originalData = [];
+	private $originalData = [];
 
 	/**
 	 * @param array           $data   Table row attributes
@@ -39,10 +39,10 @@ abstract class BaseModel extends BaseDataTransferObject
 				 * Child classes never have to interact directly with it.
 				 * Please use the magic getter instead.
 				 */
-				private array $data = [])
+		private array $data = [])
 	{
-		$this->dba = $dba;
-		$this->logger = $logger;
+		$this->dba          = $dba;
+		$this->logger       = $logger;
 		$this->originalData = $this->data;
 	}
 
@@ -65,8 +65,8 @@ abstract class BaseModel extends BaseDataTransferObject
 	 */
 	public static function createFromPrototype(BaseModel $prototype, array $data): BaseModel
 	{
-		$model = clone $prototype;
-		$model->data = $data;
+		$model               = clone $prototype;
+		$model->data         = $data;
 		$model->originalData = $data;
 
 		return $model;

--- a/src/Console/Addon.php
+++ b/src/Console/Addon.php
@@ -22,20 +22,6 @@ class Addon extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Mode
-	 */
-	private $appMode;
-	/**
-	 * @var L10n
-	 */
-	private $l10n;
-	/**
-	 * @var Database
-	 */
-	private $dba;
-	private AddonHelper $addonHelper;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -57,14 +43,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Mode $appMode, L10n $l10n, Database $dba, AddonHelper $addonHelper, array $argv = null)
+	public function __construct(private Mode $appMode, private L10n $l10n, private Database $dba, private AddonHelper $addonHelper, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode     = $appMode;
-		$this->l10n        = $l10n;
-		$this->dba         = $dba;
-		$this->addonHelper = $addonHelper;
 
 		$this->addonHelper->loadAddons();
 	}

--- a/src/Console/ArchiveContact.php
+++ b/src/Console/ArchiveContact.php
@@ -27,19 +27,6 @@ class ArchiveContact extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Mode
-	 */
-	private $appMode;
-	/**
-	 * @var Database
-	 */
-	private $dba;
-	/**
-	 * @var \Friendica\Core\L10n
-	 */
-	private $l10n;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -57,13 +44,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Mode $appMode, Database $dba, \Friendica\Core\L10n $l10n, array $argv = null)
+	public function __construct(private Mode $appMode, private Database $dba, private \Friendica\Core\L10n $l10n, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode = $appMode;
-		$this->dba     = $dba;
-		$this->l10n    = $l10n;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/AutomaticInstallation.php
+++ b/src/Console/AutomaticInstallation.php
@@ -20,15 +20,6 @@ use RuntimeException;
 
 class AutomaticInstallation extends Console
 {
-	/** @var Mode */
-	private $appMode;
-	/** @var \Friendica\Core\Config\ValueObject\Cache */
-	private $configCache;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var Database */
-	private $dba;
-
 	protected function getHelp()
 	{
 		return <<<HELP
@@ -86,14 +77,9 @@ Examples
 HELP;
 	}
 
-	public function __construct(Mode $appMode, Cache $configCache, IManageConfigValues $config, Database $dba, array $argv = null)
+	public function __construct(private Mode $appMode, private Cache $configCache, private IManageConfigValues $config, private Database $dba, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode     = $appMode;
-		$this->configCache = $configCache;
-		$this->config      = $config;
-		$this->dba         = $dba;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/AutomaticInstallation.php
+++ b/src/Console/AutomaticInstallation.php
@@ -129,19 +129,34 @@ HELP;
 
 			$save_db = $this->getOption(['s', 'savedb'], false);
 
-			$db_host = $this->getOption(['H', 'dbhost'], ($save_db) ? (getenv('MYSQL_HOST')) : Installer::DEFAULT_HOST);
-			$db_port = $this->getOption(['p', 'dbport'], ($save_db) ? getenv('MYSQL_PORT') : null);
+			$db_host   = $this->getOption(['H', 'dbhost'], ($save_db) ? (getenv('MYSQL_HOST')) : Installer::DEFAULT_HOST);
+			$db_port   = $this->getOption(['p', 'dbport'], ($save_db) ? getenv('MYSQL_PORT') : null);
 			$db_socket = $this->getOption(['s', 'dbsocket'], ($save_db) ? getenv('MYSQL_SOCKET') : null);
 			$configCache->set('database', 'hostname', $db_host . (!empty($db_port) ? ':' . $db_port : ''));
-			$configCache->set('database', 'database',
-				$this->getOption(['d', 'dbdata'],
-					($save_db) ? getenv('MYSQL_DATABASE') : ''));
-			$configCache->set('database', 'username',
-				$this->getOption(['u', 'dbuser'],
-					($save_db) ? getenv('MYSQL_USER') . getenv('MYSQL_USERNAME') : ''));
-			$configCache->set('database', 'password',
-				$this->getOption(['P', 'dbpass'],
-					($save_db) ? getenv('MYSQL_PASSWORD') : ''));
+			$configCache->set(
+				'database',
+				'database',
+				$this->getOption(
+					['d', 'dbdata'],
+					($save_db) ? getenv('MYSQL_DATABASE') : '',
+				),
+			);
+			$configCache->set(
+				'database',
+				'username',
+				$this->getOption(
+					['u', 'dbuser'],
+					($save_db) ? getenv('MYSQL_USER') . getenv('MYSQL_USERNAME') : '',
+				),
+			);
+			$configCache->set(
+				'database',
+				'password',
+				$this->getOption(
+					['P', 'dbpass'],
+					($save_db) ? getenv('MYSQL_PASSWORD') : '',
+				),
+			);
 
 			$php_path = $this->getOption(['b', 'phppath'], !empty('FRIENDICA_PHP_PATH') ? getenv('FRIENDICA_PHP_PATH') : null);
 			if (!empty($php_path)) {
@@ -150,15 +165,30 @@ HELP;
 				$configCache->set('config', 'php_path', $installer->getPHPPath());
 			}
 
-			$configCache->set('config', 'admin_email',
-				$this->getOption(['A', 'admin'],
-					!empty(getenv('FRIENDICA_ADMIN_MAIL')) ? getenv('FRIENDICA_ADMIN_MAIL') : ''));
-			$configCache->set('system', 'default_timezone',
-				$this->getOption(['T', 'tz'],
-					!empty(getenv('FRIENDICA_TZ')) ? getenv('FRIENDICA_TZ') : Installer::DEFAULT_TZ));
-			$configCache->set('system', 'language',
-				$this->getOption(['L', 'lang'],
-					!empty(getenv('FRIENDICA_LANG')) ? getenv('FRIENDICA_LANG') : Installer::DEFAULT_LANG));
+			$configCache->set(
+				'config',
+				'admin_email',
+				$this->getOption(
+					['A', 'admin'],
+					!empty(getenv('FRIENDICA_ADMIN_MAIL')) ? getenv('FRIENDICA_ADMIN_MAIL') : '',
+				),
+			);
+			$configCache->set(
+				'system',
+				'default_timezone',
+				$this->getOption(
+					['T', 'tz'],
+					!empty(getenv('FRIENDICA_TZ')) ? getenv('FRIENDICA_TZ') : Installer::DEFAULT_TZ,
+				),
+			);
+			$configCache->set(
+				'system',
+				'language',
+				$this->getOption(
+					['L', 'lang'],
+					!empty(getenv('FRIENDICA_LANG')) ? getenv('FRIENDICA_LANG') : Installer::DEFAULT_LANG,
+				),
+			);
 
 			$basepath = $this->getOption(['b', 'basepath'], !empty(getenv('FRIENDICA_BASE_PATH')) ? getenv('FRIENDICA_BASE_PATH') : null);
 			if (!empty($basepath)) {

--- a/src/Console/Cache.php
+++ b/src/Console/Cache.php
@@ -24,16 +24,6 @@ class Cache extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Mode
-	 */
-	private $appMode;
-
-	/**
-	 * @var ICanCache
-	 */
-	private $cache;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -68,12 +58,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Mode $appMode, ICanCache $cache, array $argv = null)
+	public function __construct(private Mode $appMode, private ICanCache $cache, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode = $appMode;
-		$this->cache   = $cache;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/ClearAvatarCache.php
+++ b/src/Console/ClearAvatarCache.php
@@ -10,7 +10,6 @@ namespace Friendica\Console;
 use Friendica\App\BaseURL;
 use Friendica\Contact\Avatar;
 use Friendica\Core\L10n;
-use Friendica\Database\Database;
 use Friendica\Model\Contact;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 

--- a/src/Console/ClearAvatarCache.php
+++ b/src/Console/ClearAvatarCache.php
@@ -21,26 +21,6 @@ class ClearAvatarCache extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Database
-	 */
-	private $dba;
-
-	/**
-	 * @var BaseURL
-	 */
-	private $baseUrl;
-
-	/**
-	 * @var L10n
-	 */
-	private $l10n;
-
-	/**
-	 * @var IManageConfigValues
-	 */
-	private $config;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -58,14 +38,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(\Friendica\Database\Database $dba, BaseURL $baseUrl, L10n $l10n, IManageConfigValues $config, array $argv = null)
+	public function __construct(private \Friendica\Database\Database $dba, private BaseURL $baseUrl, private L10n $l10n, private IManageConfigValues $config, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->dba     = $dba;
-		$this->baseUrl = $baseUrl;
-		$this->l10n    = $l10n;
-		$this->config  = $config;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/Config.php
+++ b/src/Console/Config.php
@@ -37,15 +37,6 @@ class Config extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Mode
-	 */
-	private $appMode;
-	/**
-	 * @var IManageConfigValues
-	 */
-	private $config;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -80,12 +71,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Mode $appMode, IManageConfigValues $config, array $argv = null)
+	public function __construct(private Mode $appMode, private IManageConfigValues $config, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode = $appMode;
-		$this->config  = $config;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/Contact.php
+++ b/src/Console/Contact.php
@@ -24,11 +24,6 @@ use Seld\CliPrompt\CliPrompt;
 class Contact extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
-
-	/**
-	 * @var Mode
-	 */
-	private $appMode;
 	/**
 	 * @var IManagePersonalConfigValues
 	 */
@@ -56,11 +51,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Mode $appMode, ?array $argv = null)
+	public function __construct(private Mode $appMode, ?array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode = $appMode;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/Daemon.php
+++ b/src/Console/Daemon.php
@@ -29,15 +29,6 @@ use RuntimeException;
  */
 final class Daemon extends Console
 {
-	private Mode $mode;
-	private IManageConfigValues $config;
-	private IManageKeyValuePairs $keyValue;
-	private BasePath $basePath;
-	private System $system;
-	private LoggerInterface $logger;
-	private Database $dba;
-	private SysDaemon $daemon;
-
 	/**
 	 * @param Mode                 $mode
 	 * @param IManageConfigValues  $config
@@ -49,18 +40,9 @@ final class Daemon extends Console
 	 * @param SysDaemon            $daemon
 	 * @param array|null           $argv
 	 */
-	public function __construct(Mode $mode, IManageConfigValues $config, IManageKeyValuePairs $keyValue, BasePath $basePath, System $system, LoggerInterface $logger, Database $dba, SysDaemon $daemon, array $argv = null)
+	public function __construct(private Mode $mode, private IManageConfigValues $config, private IManageKeyValuePairs $keyValue, private BasePath $basePath, private System $system, private LoggerInterface $logger, private Database $dba, private SysDaemon $daemon, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->mode     = $mode;
-		$this->config   = $config;
-		$this->keyValue = $keyValue;
-		$this->basePath = $basePath;
-		$this->system   = $system;
-		$this->logger   = $logger;
-		$this->dba      = $dba;
-		$this->daemon   = $daemon;
 	}
 
 	protected function getHelp(): string

--- a/src/Console/Daemon.php
+++ b/src/Console/Daemon.php
@@ -89,7 +89,7 @@ HELP;
 						'system' => [
 							'pidfile' => '/path/to/daemon.pid',
 						],
-					TXT
+					TXT,
 			);
 		}
 
@@ -181,7 +181,7 @@ HELP;
 						$arg   = (($seconds + 1) / ($wait_interval / 9)) + 1;
 						$sleep = min(1000000, round(log10($arg) * 1000000, 0));
 
-						$this->daemon->sleep((int)$sleep);
+						$this->daemon->sleep((int) $sleep);
 
 						$timeout = ($seconds >= $wait_interval);
 					} while (!$timeout && !Worker\IPC::JobsExists());

--- a/src/Console/DatabaseStructure.php
+++ b/src/Console/DatabaseStructure.php
@@ -60,7 +60,7 @@ HELP;
 	public function __construct(private Database $dba, private DbaDefinition $dbaDefinition, private ViewDefinition $viewDefinition, BasePath $basePath, private IManageConfigValues $config, $argv = null)
 	{
 		parent::__construct($argv);
-		$this->basePath       = $basePath->getPath();
+		$this->basePath = $basePath->getPath();
 	}
 
 	protected function doExecute(): int

--- a/src/Console/DatabaseStructure.php
+++ b/src/Console/DatabaseStructure.php
@@ -26,18 +26,6 @@ class DatabaseStructure extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/** @var Database */
-	private $dba;
-
-	/** @var IManageConfigValues */
-	private $config;
-
-	/** @var DbaDefinition */
-	private $dbaDefinition;
-
-	/** @var ViewDefinition */
-	private $viewDefinition;
-
 	/** @var string */
 	private $basePath;
 
@@ -69,14 +57,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Database $dba, DbaDefinition $dbaDefinition, ViewDefinition $viewDefinition, BasePath $basePath, IManageConfigValues $config, $argv = null)
+	public function __construct(private Database $dba, private DbaDefinition $dbaDefinition, private ViewDefinition $viewDefinition, BasePath $basePath, private IManageConfigValues $config, $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->dba            = $dba;
-		$this->dbaDefinition  = $dbaDefinition;
-		$this->viewDefinition = $viewDefinition;
-		$this->config         = $config;
 		$this->basePath       = $basePath->getPath();
 	}
 

--- a/src/Console/FixAPDeliveryWorkerTaskParameters.php
+++ b/src/Console/FixAPDeliveryWorkerTaskParameters.php
@@ -20,19 +20,6 @@ use RuntimeException;
 class FixAPDeliveryWorkerTaskParameters extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
-
-	/**
-	 * @var Mode
-	 */
-	private $appMode;
-	/**
-	 * @var Database
-	 */
-	private $dba;
-	/**
-	 * @var L10n
-	 */
-	private $l10n;
 	/**
 	 * @var int
 	 */
@@ -65,13 +52,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Mode $appMode, Database $dba, L10n $l10n, array $argv = null)
+	public function __construct(private Mode $appMode, private Database $dba, private L10n $l10n, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode = $appMode;
-		$this->dba     = $dba;
-		$this->l10n    = $l10n;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/GlobalCommunityBlock.php
+++ b/src/Console/GlobalCommunityBlock.php
@@ -21,15 +21,6 @@ class GlobalCommunityBlock extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Mode
-	 */
-	private $appMode;
-	/**
-	 * @var \Friendica\Core\L10n
-	 */
-	private $l10n;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -48,12 +39,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Mode $appMode, L10n $l10n, $argv = null)
+	public function __construct(private Mode $appMode, private L10n $l10n, $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode = $appMode;
-		$this->l10n    = $l10n;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/GlobalCommunitySilence.php
+++ b/src/Console/GlobalCommunitySilence.php
@@ -24,15 +24,6 @@ class GlobalCommunitySilence extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var App\Mode
-	 */
-	private $appMode;
-	/**
-	 * @var Database
-	 */
-	private $dba;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -53,12 +44,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(App\Mode $appMode, Database $dba, array $argv = null)
+	public function __construct(private App\Mode $appMode, private Database $dba, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode = $appMode;
-		$this->dba     = $dba;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/JetstreamDaemon.php
+++ b/src/Console/JetstreamDaemon.php
@@ -24,13 +24,6 @@ use RuntimeException;
  */
 final class JetstreamDaemon extends Console
 {
-	private Mode $mode;
-	private IManageConfigValues $config;
-	private IManageKeyValuePairs $keyValue;
-	private SysDaemon $daemon;
-	private Jetstream $jetstream;
-	private AddonHelper $addonHelper;
-
 	/**
 	 * @param Mode                 $mode
 	 * @param IManageConfigValues  $config
@@ -39,16 +32,9 @@ final class JetstreamDaemon extends Console
 	 * @param Jetstream            $jetstream
 	 * @param array|null           $argv
 	 */
-	public function __construct(Mode $mode, IManageConfigValues $config, IManageKeyValuePairs $keyValue, SysDaemon $daemon, Jetstream $jetstream, AddonHelper $addonHelper, array $argv = null)
+	public function __construct(private Mode $mode, private IManageConfigValues $config, private IManageKeyValuePairs $keyValue, private SysDaemon $daemon, private Jetstream $jetstream, private AddonHelper $addonHelper, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->mode        = $mode;
-		$this->config      = $config;
-		$this->keyValue    = $keyValue;
-		$this->jetstream   = $jetstream;
-		$this->daemon      = $daemon;
-		$this->addonHelper = $addonHelper;
 	}
 
 	protected function getHelp(): string

--- a/src/Console/Lock.php
+++ b/src/Console/Lock.php
@@ -22,16 +22,6 @@ class Lock extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Mode
-	 */
-	private $appMode;
-
-	/**
-	 * @var ICanLock
-	 */
-	private $lock;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -62,12 +52,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Mode $appMode, ICanLock $lock, array $argv = null)
+	public function __construct(private Mode $appMode, private ICanLock $lock, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode = $appMode;
-		$this->lock    = $lock;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/Maintenance.php
+++ b/src/Console/Maintenance.php
@@ -17,15 +17,6 @@ class Maintenance extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Mode
-	 */
-	private $appMode;
-	/**
-	 * @var IManageConfigValues
-	 */
-	private $config;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -55,12 +46,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Mode $appMode, IManageConfigValues $config, $argv = null)
+	public function __construct(private Mode $appMode, private IManageConfigValues $config, $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode = $appMode;
-		$this->config  = $config;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/MergeContacts.php
+++ b/src/Console/MergeContacts.php
@@ -18,16 +18,6 @@ class MergeContacts extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Database
-	 */
-	private $dba;
-
-	/**
-	 * @var L10n
-	 */
-	private $l10n;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -46,12 +36,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Database $dba, L10n $l10n, array $argv = null)
+	public function __construct(private Database $dba, private L10n $l10n, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->dba  = $dba;
-		$this->l10n = $l10n;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/MoveToAvatarCache.php
+++ b/src/Console/MoveToAvatarCache.php
@@ -12,7 +12,6 @@ use Friendica\Contact\Avatar;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Core\Protocol;
-use Friendica\Database\Database;
 use Friendica\Model\Contact;
 use Friendica\Model\Photo;
 use Friendica\Object\Image;
@@ -53,7 +52,7 @@ HELP;
 			return 2;
 		}
 
-		$fields = ['id', 'avatar', 'photo', 'thumb', 'micro', 'uri-id', 'url', 'avatar', 'network'];
+		$fields    = ['id', 'avatar', 'photo', 'thumb', 'micro', 'uri-id', 'url', 'avatar', 'network'];
 		$condition = ["NOT `self` AND `avatar` != ? AND `photo` LIKE ? AND `uid` = ? AND `uri-id` != ? AND NOT `uri-id` IS NULL AND NOT `network` IN (?, ?)",
 			'', $this->baseUrl . '/photo/%', 0, 0, Protocol::MAIL, Protocol::FEED];
 

--- a/src/Console/MoveToAvatarCache.php
+++ b/src/Console/MoveToAvatarCache.php
@@ -24,26 +24,6 @@ class MoveToAvatarCache extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Database
-	 */
-	private $dba;
-
-	/**
-	 * @var BaseURL
-	 */
-	private $baseUrl;
-
-	/**
-	 * @var L10n
-	 */
-	private $l10n;
-
-	/**
-	 * @var IManageConfigValues
-	 */
-	private $config;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -61,14 +41,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(\Friendica\Database\Database $dba, BaseURL $baseUrl, L10n $l10n, IManageConfigValues $config, array $argv = null)
+	public function __construct(private \Friendica\Database\Database $dba, private BaseURL $baseUrl, private L10n $l10n, private IManageConfigValues $config, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->dba     = $dba;
-		$this->baseUrl = $baseUrl;
-		$this->l10n    = $l10n;
-		$this->config = $config;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/PhpToPo.php
+++ b/src/Console/PhpToPo.php
@@ -20,14 +20,9 @@ class PhpToPo extends \Asika\SimpleConsole\Console
 	private $normBaseMsgIds  = [];
 	public const NORM_REGEXP = "|[\\\]|";
 
-	/** @var AppHelper */
-	private $appHelper;
-
-	public function __construct(AppHelper $appHelper, array $argv = null)
+	public function __construct(private AppHelper $appHelper, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appHelper = $appHelper;
 	}
 
 	protected function getHelp()

--- a/src/Console/PostUpdate.php
+++ b/src/Console/PostUpdate.php
@@ -19,19 +19,6 @@ use Friendica\DI;
 class PostUpdate extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
-
-	/**
-	 * @var Mode
-	 */
-	private $appMode;
-	/**
-	 * @var IManageKeyValuePairs
-	 */
-	private $keyValue;
-	/**
-	 * @var L10n
-	 */
-	private $l10n;
 	/**
 	 * @var string
 	 */
@@ -51,13 +38,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Mode $appMode, IManageKeyValuePairs $keyValue, L10n $l10n, array $argv = null)
+	public function __construct(private Mode $appMode, private IManageKeyValuePairs $keyValue, private L10n $l10n, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode  = $appMode;
-		$this->keyValue = $keyValue;
-		$this->l10n     = $l10n;
 		$this->basePath = DI::appHelper()->getBasePath();
 	}
 

--- a/src/Console/Relay.php
+++ b/src/Console/Relay.php
@@ -23,11 +23,6 @@ class Relay extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Database
-	 */
-	private $dba;
-
 
 	protected function getHelp()
 	{
@@ -56,11 +51,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(\Friendica\Database\Database $dba, array $argv = null)
+	public function __construct(private \Friendica\Database\Database $dba, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->dba = $dba;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/Relay.php
+++ b/src/Console/Relay.php
@@ -8,7 +8,6 @@
 namespace Friendica\Console;
 
 use Asika\SimpleConsole\CommandArgsException;
-use Friendica\Database\Database;
 use Friendica\Model\APContact;
 use Friendica\Protocol\ActivityPub\Transmitter;
 use Friendica\Protocol\Relay as ProtocolRelay;

--- a/src/Console/Relocate.php
+++ b/src/Console/Relocate.php
@@ -63,7 +63,7 @@ HELP;
 
 		$this->out(sprintf('Relocation started from %s to %s. Could take a while to complete.', $this->baseUrl, $this->getArgument(0)));
 
-		$old_url = (string)$this->baseUrl;
+		$old_url = (string) $this->baseUrl;
 
 		// Generate host names for relocation the addresses in the format user@address.tld
 		$new_host = str_replace('http://', '@', Strings::normaliseLink($new_url));

--- a/src/Console/Relocate.php
+++ b/src/Console/Relocate.php
@@ -17,19 +17,6 @@ class Relocate extends Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var IManageConfigValues
-	 */
-	private $config;
-	/**
-	 * @var \Friendica\App\BaseURL
-	 */
-	private $baseUrl;
-	/**
-	 * @var \Friendica\Database\Database
-	 */
-	private $database;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -51,13 +38,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(\Friendica\App\BaseURL $baseUrl, \Friendica\Database\Database $database, IManageConfigValues $config, $argv = null)
+	public function __construct(private \Friendica\App\BaseURL $baseUrl, private \Friendica\Database\Database $database, private IManageConfigValues $config, $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->baseUrl  = $baseUrl;
-		$this->database = $database;
-		$this->config   = $config;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/ServerBlock.php
+++ b/src/Console/ServerBlock.php
@@ -23,9 +23,6 @@ class ServerBlock extends Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/** @var DomainPatternBlocklist */
-	private $blocklist;
-
 	protected function getHelp(): string
 	{
 		return <<<HELP
@@ -54,11 +51,9 @@ Options
 HELP;
 	}
 
-	public function __construct(DomainPatternBlocklist $blocklist, $argv = null)
+	public function __construct(private DomainPatternBlocklist $blocklist, $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->blocklist = $blocklist;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/Storage.php
+++ b/src/Console/Storage.php
@@ -22,17 +22,12 @@ class Storage extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/** @var StorageManager */
-	private $storageManager;
-
 	/**
 	 * @param StorageManager $storageManager
 	 */
-	public function __construct(StorageManager $storageManager, array $argv = [])
+	public function __construct(private StorageManager $storageManager, array $argv = [])
 	{
 		parent::__construct($argv);
-
-		$this->storageManager = $storageManager;
 	}
 
 	protected function getHelp()

--- a/src/Console/Typo.php
+++ b/src/Console/Typo.php
@@ -17,11 +17,6 @@ class Typo extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var IManageConfigValues
-	 */
-	private $config;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -39,11 +34,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(IManageConfigValues $config, array $argv = null)
+	public function __construct(private IManageConfigValues $config, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->config = $config;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/User.php
+++ b/src/Console/User.php
@@ -25,19 +25,6 @@ class User extends \Asika\SimpleConsole\Console
 {
 	protected $helpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Mode
-	 */
-	private $appMode;
-	/**
-	 * @var L10n
-	 */
-	private $l10n;
-	/**
-	 * @var IManagePersonalConfigValues
-	 */
-	private $pConfig;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -74,13 +61,9 @@ HELP;
 		return $help;
 	}
 
-	public function __construct(Mode $appMode, L10n $l10n, IManagePersonalConfigValues $pConfig, array $argv = null)
+	public function __construct(private Mode $appMode, private L10n $l10n, private IManagePersonalConfigValues $pConfig, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->appMode = $appMode;
-		$this->l10n    = $l10n;
-		$this->pConfig = $pConfig;
 	}
 
 	protected function doExecute(): int

--- a/src/Console/Worker.php
+++ b/src/Console/Worker.php
@@ -21,23 +21,15 @@ use Friendica\Util\BasePath;
  */
 final class Worker extends Console
 {
-	private Mode $mode;
-	private BasePath $basePath;
-	private ProcessRepository $processRepo;
-
 	/**
 	 * @param Mode              $mode
 	 * @param BasePath          $basePath
 	 * @param ProcessRepository $processRepo
 	 * @param array|null        $argv
 	 */
-	public function __construct(Mode $mode, BasePath $basePath, ProcessRepository $processRepo, array $argv = null)
+	public function __construct(private Mode $mode, private BasePath $basePath, private ProcessRepository $processRepo, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->mode        = $mode;
-		$this->basePath    = $basePath;
-		$this->processRepo = $processRepo;
 	}
 
 	protected function getHelp(): string

--- a/src/Contact/Header.php
+++ b/src/Contact/Header.php
@@ -11,9 +11,7 @@ use Friendica\Core\Config\Capability\IManageConfigValues;
 
 class Header
 {
-	public function __construct(private IManageConfigValues $config)
-				{
-							}
+	public function __construct(private IManageConfigValues $config) {}
 
 	/**
 	 * Returns the Mastodon banner path relative to the Friendica folder.

--- a/src/Contact/Header.php
+++ b/src/Contact/Header.php
@@ -11,13 +11,9 @@ use Friendica\Core\Config\Capability\IManageConfigValues;
 
 class Header
 {
-	/** @var IManageConfigValues */
-	private $config;
-
-	public function __construct(IManageConfigValues $config)
-	{
-		$this->config = $config;
-	}
+	public function __construct(private IManageConfigValues $config)
+				{
+							}
 
 	/**
 	 * Returns the Mastodon banner path relative to the Friendica folder.

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -61,55 +61,9 @@ class Conversation
 	public const MODE_SEARCH        = 'search';
 	public const MODE_PROFILE       = 'profile';
 
-	/** @var Activity */
-	private $activity;
-	/** @var L10n */
-	private $l10n;
-	/** @var Profiler */
-	private $profiler;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var Item */
-	private $item;
-	/** @var Arguments */
-	private $args;
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-	/** @var BaseURL */
-	private $baseURL;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var Page */
-	private $page;
-	/** @var Mode */
-	private $mode;
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var UserGServerRepository */
-	private $userGServer;
-	private EventDispatcherInterface $eventDispatcher;
-	private Channel $channel;
-	private UserDefinedChannel $userDefinedChannel;
-
-	public function __construct(UserGServerRepository $userGServer, Channel $channel, UserDefinedChannel $userDefinedChannel, LoggerInterface $logger, Profiler $profiler, Activity $activity, L10n $l10n, Item $item, Arguments $args, BaseURL $baseURL, IManageConfigValues $config, IManagePersonalConfigValues $pConfig, Page $page, Mode $mode, EventDispatcherInterface $eventDispatcher, IHandleUserSessions $session)
-	{
-		$this->activity           = $activity;
-		$this->item               = $item;
-		$this->config             = $config;
-		$this->mode               = $mode;
-		$this->baseURL            = $baseURL;
-		$this->profiler           = $profiler;
-		$this->logger             = $logger;
-		$this->l10n               = $l10n;
-		$this->args               = $args;
-		$this->pConfig            = $pConfig;
-		$this->page               = $page;
-		$this->eventDispatcher    = $eventDispatcher;
-		$this->session            = $session;
-		$this->userGServer        = $userGServer;
-		$this->channel            = $channel;
-		$this->userDefinedChannel = $userDefinedChannel;
-	}
+	public function __construct(private UserGServerRepository $userGServer, private Channel $channel, private UserDefinedChannel $userDefinedChannel, private LoggerInterface $logger, private Profiler $profiler, private Activity $activity, private L10n $l10n, private Item $item, private Arguments $args, private BaseURL $baseURL, private IManageConfigValues $config, private IManagePersonalConfigValues $pConfig, private Page $page, private Mode $mode, private EventDispatcherInterface $eventDispatcher, private IHandleUserSessions $session)
+				{
+							}
 
 	/**
 	 * Checks item to see if it is one of the builtin activities (like/dislike, event attendance, consensus items, etc.)

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -61,9 +61,7 @@ class Conversation
 	public const MODE_SEARCH        = 'search';
 	public const MODE_PROFILE       = 'profile';
 
-	public function __construct(private UserGServerRepository $userGServer, private Channel $channel, private UserDefinedChannel $userDefinedChannel, private LoggerInterface $logger, private Profiler $profiler, private Activity $activity, private L10n $l10n, private Item $item, private Arguments $args, private BaseURL $baseURL, private IManageConfigValues $config, private IManagePersonalConfigValues $pConfig, private Page $page, private Mode $mode, private EventDispatcherInterface $eventDispatcher, private IHandleUserSessions $session)
-				{
-							}
+	public function __construct(private UserGServerRepository $userGServer, private Channel $channel, private UserDefinedChannel $userDefinedChannel, private LoggerInterface $logger, private Profiler $profiler, private Activity $activity, private L10n $l10n, private Item $item, private Arguments $args, private BaseURL $baseURL, private IManageConfigValues $config, private IManagePersonalConfigValues $pConfig, private Page $page, private Mode $mode, private EventDispatcherInterface $eventDispatcher, private IHandleUserSessions $session) {}
 
 	/**
 	 * Checks item to see if it is one of the builtin activities (like/dislike, event attendance, consensus items, etc.)

--- a/src/Content/Conversation/Entity/Activity.php
+++ b/src/Content/Conversation/Entity/Activity.php
@@ -14,17 +14,6 @@ namespace Friendica\Content\Conversation\Entity;
  */
 final class Activity
 {
-	public int $uid;
-	public string $network;
-	public array $languages;
-	public int $cid;
-	public string $expires;
-	public int $medianComments;
-	public int $medianActivities;
-	public int $medianViews;
-	public int $medianThreadScore;
-	public int $medianPostScore;
-
 	/**
 	 * Activity constructor.
 	 *
@@ -39,29 +28,9 @@ final class Activity
 	 * @param int $medianThreadScore
 	 * @param int $medianPostScore
 	 */
-	public function __construct(
-		int $uid,
-		string $network,
-		array $languages,
-		int $cid,
-		string $expires,
-		int $medianComments,
-		int $medianActivities,
-		int $medianViews,
-		int $medianThreadScore,
-		int $medianPostScore
-	) {
-		$this->uid               = $uid;
-		$this->network           = $network;
-		$this->languages         = $languages;
-		$this->cid               = $cid;
-		$this->expires           = $expires;
-		$this->medianComments    = $medianComments;
-		$this->medianActivities  = $medianActivities;
-		$this->medianViews       = $medianViews;
-		$this->medianThreadScore = $medianThreadScore;
-		$this->medianPostScore   = $medianPostScore;
-	}
+	public function __construct(public int $uid, public string $network, public array $languages, public int $cid, public string $expires, public int $medianComments, public int $medianActivities, public int $medianViews, public int $medianThreadScore, public int $medianPostScore)
+				{
+							}
 
 	/**
 	 * Create an Activity instance from an array.

--- a/src/Content/Conversation/Entity/Activity.php
+++ b/src/Content/Conversation/Entity/Activity.php
@@ -28,9 +28,7 @@ final class Activity
 	 * @param int $medianThreadScore
 	 * @param int $medianPostScore
 	 */
-	public function __construct(public int $uid, public string $network, public array $languages, public int $cid, public string $expires, public int $medianComments, public int $medianActivities, public int $medianViews, public int $medianThreadScore, public int $medianPostScore)
-				{
-							}
+	public function __construct(public int $uid, public string $network, public array $languages, public int $cid, public string $expires, public int $medianComments, public int $medianActivities, public int $medianViews, public int $medianThreadScore, public int $medianPostScore) {}
 
 	/**
 	 * Create an Activity instance from an array.

--- a/src/Content/Conversation/Factory/Activity.php
+++ b/src/Content/Conversation/Factory/Activity.php
@@ -31,9 +31,7 @@ final class Activity
 	 * @param ActivityRepository $activityRepository
 	 * @param UserDefinedChannel $channelRepository
 	 */
-	public function __construct(private ActivityRepository $activityRepository, private UserDefinedChannel $channelRepository, private Database $database, private LoggerInterface $logger)
-				{
-							}
+	public function __construct(private ActivityRepository $activityRepository, private UserDefinedChannel $channelRepository, private Database $database, private LoggerInterface $logger) {}
 
 	/**
 	 * Get activities for a user and network.

--- a/src/Content/Conversation/Factory/Activity.php
+++ b/src/Content/Conversation/Factory/Activity.php
@@ -25,24 +25,15 @@ use Psr\Log\LoggerInterface;
  */
 final class Activity
 {
-	private ActivityRepository $activityRepository;
-	private UserDefinedChannel $channelRepository;
-	private Database $database;
-	private LoggerInterface $logger;
-
 	/**
 	 * ActivityFactory constructor.
 	 *
 	 * @param ActivityRepository $activityRepository
 	 * @param UserDefinedChannel $channelRepository
 	 */
-	public function __construct(ActivityRepository $activityRepository, UserDefinedChannel $channelRepository, Database $database, LoggerInterface $logger)
-	{
-		$this->activityRepository = $activityRepository;
-		$this->channelRepository  = $channelRepository;
-		$this->database           = $database;
-		$this->logger             = $logger;
-	}
+	public function __construct(private ActivityRepository $activityRepository, private UserDefinedChannel $channelRepository, private Database $database, private LoggerInterface $logger)
+				{
+							}
 
 	/**
 	 * Get activities for a user and network.

--- a/src/Content/Conversation/Factory/ChannelPost.php
+++ b/src/Content/Conversation/Factory/ChannelPost.php
@@ -32,16 +32,14 @@ use Psr\Log\LoggerInterface;
 final class ChannelPost
 {
 	/**
-				 * ChannelPost constructor.
-				 *
-				 * @param Database $dba Database access object.
-				 * @param UserDefinedChannel $channelRepository Channel repository.
-				 * @param LoggerInterface $logger Logger instance.
-				 * @param IManageConfigValues $config Configuration manager.
-				 */
-				public function __construct(private Database $dba, private UserDefinedChannel $channelRepository, private LoggerInterface $logger, private IManageConfigValues $config)
-				{
-							}
+	 * ChannelPost constructor.
+	 *
+	 * @param Database $dba Database access object.
+	 * @param UserDefinedChannel $channelRepository Channel repository.
+	 * @param LoggerInterface $logger Logger instance.
+	 * @param IManageConfigValues $config Configuration manager.
+	 */
+	public function __construct(private Database $dba, private UserDefinedChannel $channelRepository, private LoggerInterface $logger, private IManageConfigValues $config) {}
 
 	/**
 	 * Add a post to matching user-defined channels.
@@ -103,7 +101,7 @@ final class ChannelPost
 			}
 
 			$cache = [
-				'channel'     => (int)$channel->code,
+				'channel'     => (int) $channel->code,
 				'uid'         => $channel->uid,
 				'uri-id'      => $engagement['uri-id'],
 				'in-timeline' => $in_timeline,

--- a/src/Content/Conversation/Factory/ChannelPost.php
+++ b/src/Content/Conversation/Factory/ChannelPost.php
@@ -31,26 +31,17 @@ use Psr\Log\LoggerInterface;
  */
 final class ChannelPost
 {
-	private LoggerInterface $logger;
-	private UserDefinedChannel $channelRepository;
-	private Database $dba;
-	private IManageConfigValues $config;
-
 	/**
-	 * ChannelPost constructor.
-	 *
-	 * @param Database $dba Database access object.
-	 * @param UserDefinedChannel $channel Channel repository.
-	 * @param LoggerInterface $logger Logger instance.
-	 * @param IManageConfigValues $config Configuration manager.
-	 */
-	public function __construct(Database $dba, UserDefinedChannel $channel, LoggerInterface $logger, IManageConfigValues $config)
-	{
-		$this->dba               = $dba;
-		$this->logger            = $logger;
-		$this->channelRepository = $channel;
-		$this->config            = $config;
-	}
+				 * ChannelPost constructor.
+				 *
+				 * @param Database $dba Database access object.
+				 * @param UserDefinedChannel $channelRepository Channel repository.
+				 * @param LoggerInterface $logger Logger instance.
+				 * @param IManageConfigValues $config Configuration manager.
+				 */
+				public function __construct(private Database $dba, private UserDefinedChannel $channelRepository, private LoggerInterface $logger, private IManageConfigValues $config)
+				{
+							}
 
 	/**
 	 * Add a post to matching user-defined channels.

--- a/src/Content/Conversation/Factory/SystemChannelPost.php
+++ b/src/Content/Conversation/Factory/SystemChannelPost.php
@@ -35,29 +35,18 @@ use Psr\Log\LoggerInterface;
  */
 final class SystemChannelPost
 {
-	private LoggerInterface $logger;
-	private UserDefinedChannel $channelRepository;
-	private Database $dba;
-	private IManageConfigValues $config;
-	private ActivityFactory $activityFactory;
-
 	/**
-	 * SystemChannelPost constructor.
-	 *
-	 * @param Database $dba Database access object.
-	 * @param UserDefinedChannel $channel Channel repository.
-	 * @param LoggerInterface $logger Logger instance.
-	 * @param IManageConfigValues $config Configuration manager.
-	 * @param ActivityFactory $activityFactory Activity factory.
-	 */
-	public function __construct(Database $dba, UserDefinedChannel $channel, LoggerInterface $logger, IManageConfigValues $config, ActivityFactory $activityFactory)
-	{
-		$this->dba               = $dba;
-		$this->logger            = $logger;
-		$this->channelRepository = $channel;
-		$this->config            = $config;
-		$this->activityFactory   = $activityFactory;
-	}
+				 * SystemChannelPost constructor.
+				 *
+				 * @param Database $dba Database access object.
+				 * @param UserDefinedChannel $channelRepository Channel repository.
+				 * @param LoggerInterface $logger Logger instance.
+				 * @param IManageConfigValues $config Configuration manager.
+				 * @param ActivityFactory $activityFactory Activity factory.
+				 */
+				public function __construct(private Database $dba, private UserDefinedChannel $channelRepository, private LoggerInterface $logger, private IManageConfigValues $config, private ActivityFactory $activityFactory)
+				{
+							}
 
 	/**
 	 * Add a post to matching system channels for one or many users.

--- a/src/Content/Conversation/Factory/SystemChannelPost.php
+++ b/src/Content/Conversation/Factory/SystemChannelPost.php
@@ -36,17 +36,15 @@ use Psr\Log\LoggerInterface;
 final class SystemChannelPost
 {
 	/**
-				 * SystemChannelPost constructor.
-				 *
-				 * @param Database $dba Database access object.
-				 * @param UserDefinedChannel $channelRepository Channel repository.
-				 * @param LoggerInterface $logger Logger instance.
-				 * @param IManageConfigValues $config Configuration manager.
-				 * @param ActivityFactory $activityFactory Activity factory.
-				 */
-				public function __construct(private Database $dba, private UserDefinedChannel $channelRepository, private LoggerInterface $logger, private IManageConfigValues $config, private ActivityFactory $activityFactory)
-				{
-							}
+	 * SystemChannelPost constructor.
+	 *
+	 * @param Database $dba Database access object.
+	 * @param UserDefinedChannel $channelRepository Channel repository.
+	 * @param LoggerInterface $logger Logger instance.
+	 * @param IManageConfigValues $config Configuration manager.
+	 * @param ActivityFactory $activityFactory Activity factory.
+	 */
+	public function __construct(private Database $dba, private UserDefinedChannel $channelRepository, private LoggerInterface $logger, private IManageConfigValues $config, private ActivityFactory $activityFactory) {}
 
 	/**
 	 * Add a post to matching system channels for one or many users.

--- a/src/Content/Conversation/Repository/Activity.php
+++ b/src/Content/Conversation/Repository/Activity.php
@@ -18,17 +18,14 @@ use Friendica\Util\DateTimeFormat;
  */
 final class Activity
 {
-	private Database $dba;
-
 	/**
 	 * ActivityRepository constructor.
 	 *
 	 * @param Database $dba
 	 */
-	public function __construct(Database $dba)
-	{
-		$this->dba = $dba;
-	}
+	public function __construct(private Database $dba)
+				{
+							}
 
 	/**
 	 * Find an activity by uid and network.

--- a/src/Content/Conversation/Repository/Activity.php
+++ b/src/Content/Conversation/Repository/Activity.php
@@ -23,9 +23,7 @@ final class Activity
 	 *
 	 * @param Database $dba
 	 */
-	public function __construct(private Database $dba)
-				{
-							}
+	public function __construct(private Database $dba) {}
 
 	/**
 	 * Find an activity by uid and network.

--- a/src/Content/Conversation/Repository/UserDefinedChannel.php
+++ b/src/Content/Conversation/Repository/UserDefinedChannel.php
@@ -40,9 +40,6 @@ class UserDefinedChannel extends BaseRepository
 	/** @var UserDefinedChannelFactory */
 	protected $factory;
 
-	private ICanCache $cache;
-	private IManageConfigValues $config;
-
 	/**
 	 * UserDefinedChannel repository constructor.
 	 *
@@ -52,12 +49,9 @@ class UserDefinedChannel extends BaseRepository
 	 * @param IManageConfigValues $config Configuration manager.
 	 * @param ICanCache $cache Cache capability.
 	 */
-	public function __construct(Database $database, LoggerInterface $logger, UserDefinedChannelFactory $factory, IManageConfigValues $config, ICanCache $cache)
+	public function __construct(Database $database, LoggerInterface $logger, UserDefinedChannelFactory $factory, private IManageConfigValues $config, private ICanCache $cache)
 	{
 		parent::__construct($database, $logger, $factory);
-
-		$this->config = $config;
-		$this->cache  = $cache;
 	}
 
 	/**

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -53,27 +53,6 @@ use Psr\Log\LoggerInterface;
  */
 class Item
 {
-	/** @var Activity */
-	private $activity;
-	/** @var L10n */
-	private $l10n;
-	/** @var Profiler */
-	private $profiler;
-	/** @var IHandleUserSessions */
-	private $userSession;
-	/** @var Video */
-	private $bbCodeVideo;
-	/** @var ACLFormatter */
-	private $aclFormatter;
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var BaseURL */
-	private $baseURL;
-	/** @var Emailer */
-	private $emailer;
-	private EventDispatcherInterface $eventDispatcher;
 	/** @var LoggerInterface */
 	protected $logger;
 	/** @var PostMediaRepository */
@@ -81,19 +60,8 @@ class Item
 	/** @var PostMediaFactory */
 	protected $postMediaFactory;
 
-	public function __construct(LoggerInterface $logger, Profiler $profiler, Activity $activity, L10n $l10n, IHandleUserSessions $userSession, Video $bbCodeVideo, ACLFormatter $aclFormatter, IManagePersonalConfigValues $pConfig, IManageConfigValues $config, BaseURL $baseURL, Emailer $emailer, EventDispatcherInterface $eventDispatcher, PostMediaRepository $postMediaRepository, PostMediaFactory $postMediaFactory)
+	public function __construct(LoggerInterface $logger, private Profiler $profiler, private Activity $activity, private L10n $l10n, private IHandleUserSessions $userSession, private Video $bbCodeVideo, private ACLFormatter $aclFormatter, private IManagePersonalConfigValues $pConfig, private IManageConfigValues $config, private BaseURL $baseURL, private Emailer $emailer, private EventDispatcherInterface $eventDispatcher, PostMediaRepository $postMediaRepository, PostMediaFactory $postMediaFactory)
 	{
-		$this->profiler            = $profiler;
-		$this->activity            = $activity;
-		$this->l10n                = $l10n;
-		$this->userSession         = $userSession;
-		$this->bbCodeVideo         = $bbCodeVideo;
-		$this->aclFormatter        = $aclFormatter;
-		$this->baseURL             = $baseURL;
-		$this->pConfig             = $pConfig;
-		$this->config              = $config;
-		$this->emailer             = $emailer;
-		$this->eventDispatcher     = $eventDispatcher;
 		$this->logger              = $logger;
 		$this->postMediaRepository = $postMediaRepository;
 		$this->postMediaFactory    = $postMediaFactory;

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -52,31 +52,9 @@ class Nav
 	 */
 	private $appMenu = null;
 
-	/** @var BaseURL */
-	private $baseUrl;
-	/** @var L10n */
-	private $l10n;
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var Database */
-	private $database;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var Router */
-	private $router;
-
-	private EventDispatcherInterface $eventDispatcher;
-
-	public function __construct(BaseURL $baseUrl, L10n $l10n, IHandleUserSessions $session, Database $database, IManageConfigValues $config, Router $router, EventDispatcherInterface $eventDispatcher)
-	{
-		$this->baseUrl         = $baseUrl;
-		$this->l10n            = $l10n;
-		$this->session         = $session;
-		$this->database        = $database;
-		$this->config          = $config;
-		$this->router          = $router;
-		$this->eventDispatcher = $eventDispatcher;
-	}
+	public function __construct(private BaseURL $baseUrl, private L10n $l10n, private IHandleUserSessions $session, private Database $database, private IManageConfigValues $config, private Router $router, private EventDispatcherInterface $eventDispatcher)
+				{
+							}
 
 	/**
 	 * Set a menu item in navbar as selected

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -42,7 +42,7 @@ class Nav
 		'contacts'      => null,
 		'delegation'    => null,
 		'calendar'      => null,
-		'register'      => null
+		'register'      => null,
 	];
 
 	/**
@@ -52,9 +52,7 @@ class Nav
 	 */
 	private $appMenu = null;
 
-	public function __construct(private BaseURL $baseUrl, private L10n $l10n, private IHandleUserSessions $session, private Database $database, private IManageConfigValues $config, private Router $router, private EventDispatcherInterface $eventDispatcher)
-				{
-							}
+	public function __construct(private BaseURL $baseUrl, private L10n $l10n, private IHandleUserSessions $session, private Database $database, private IManageConfigValues $config, private Router $router, private EventDispatcherInterface $eventDispatcher) {}
 
 	/**
 	 * Set a menu item in navbar as selected
@@ -96,11 +94,11 @@ class Nav
 			'$home'                 => $this->l10n->t('Home'),
 			'$skip'                 => $this->l10n->t('Skip to main content'),
 			'$clear_notifs'         => $this->l10n->t('Clear notifications'),
-			'$search_placeholder'   => $this->l10n->t('Search: @name, !group, #tags, content')
+			'$search_placeholder'   => $this->l10n->t('Search: @name, !group, #tags, content'),
 		]);
 
 		$nav = $this->eventDispatcher->dispatch(
-			new HtmlFilterEvent(HtmlFilterEvent::PAGE_HEADER, $nav)
+			new HtmlFilterEvent(HtmlFilterEvent::PAGE_HEADER, $nav),
 		)->getHtml();
 
 		return $nav;
@@ -139,7 +137,7 @@ class Nav
 			$arr = ['app_menu' => $appMenu];
 
 			$arr = $this->eventDispatcher->dispatch(
-				new ArrayFilterEvent(ArrayFilterEvent::APP_MENU, $arr)
+				new ArrayFilterEvent(ArrayFilterEvent::APP_MENU, $arr),
 			)->getArray();
 
 			$appMenu = $arr['app_menu'] ?? [];
@@ -246,7 +244,7 @@ class Nav
 			$nav['searchoption'] = [
 				$this->l10n->t('Full Text'),
 				$this->l10n->t('Tags'),
-				$this->l10n->t('Contacts')
+				$this->l10n->t('Contacts'),
 			];
 
 			if ($this->config->get('system', 'poco_local_search')) {
@@ -259,8 +257,8 @@ class Nav
 			$gdirpath = OpenWebAuth::getZrlUrl($this->config->get('system', 'directory'), true);
 		}
 
-		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::COMMUNITY) && (($this->session->getLocalUserId() || $this->config->get('system', 'community_page_style') != Community::DISABLED_VISITOR) &&
-			!($this->config->get('system', 'community_page_style') == Community::DISABLED))) {
+		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::COMMUNITY) && (($this->session->getLocalUserId() || $this->config->get('system', 'community_page_style') != Community::DISABLED_VISITOR)
+			&& !($this->config->get('system', 'community_page_style') == Community::DISABLED))) {
 			$nav['community'] = ['community', $this->l10n->t('Community'), '', $this->l10n->t('Conversations on this and other servers')];
 		}
 
@@ -331,7 +329,7 @@ class Nav
 		];
 
 		$nav_info = $this->eventDispatcher->dispatch(
-			new ArrayFilterEvent(ArrayFilterEvent::NAV_INFO, $nav_info)
+			new ArrayFilterEvent(ArrayFilterEvent::NAV_INFO, $nav_info),
 		)->getArray();
 
 		return $nav_info;

--- a/src/Content/Post/Factory/PostMedia.php
+++ b/src/Content/Post/Factory/PostMedia.php
@@ -21,14 +21,9 @@ use stdClass;
 
 class PostMedia extends BaseFactory implements ICanCreateFromTableRow
 {
-	/** @var MimeTypeFactory */
-	private $mimeTypeFactory;
-
-	public function __construct(MimeTypeFactory $mimeTypeFactory, LoggerInterface $logger)
+	public function __construct(private MimeTypeFactory $mimeTypeFactory, LoggerInterface $logger)
 	{
 		parent::__construct($logger);
-
-		$this->mimeTypeFactory = $mimeTypeFactory;
 	}
 
 	/**

--- a/src/Content/Post/Repository/PostMedia.php
+++ b/src/Content/Post/Repository/PostMedia.php
@@ -41,14 +41,6 @@ class PostMedia extends BaseRepository
 
 	/** @var PostMediaFactory */
 	protected $factory;
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var BaseURL */
-	private $baseURL;
-	/** @var Item */
-	private $item;
 
 	/**
 	 * PostMedia repository constructor.
@@ -61,14 +53,9 @@ class PostMedia extends BaseRepository
 	 * @param BaseURL $baseURL Base URL helper
 	 * @param Item $item Item helper
 	 */
-	public function __construct(Database $database, LoggerInterface $logger, PostMediaFactory $factory, IManagePersonalConfigValues $pConfig, IManageConfigValues $config, BaseURL $baseURL, Item $item)
+	public function __construct(Database $database, LoggerInterface $logger, PostMediaFactory $factory, private IManagePersonalConfigValues $pConfig, private IManageConfigValues $config, private BaseURL $baseURL, private Item $item)
 	{
 		parent::__construct($database, $logger, $factory);
-
-		$this->baseURL = $baseURL;
-		$this->pConfig = $pConfig;
-		$this->config  = $config;
-		$this->item    = $item;
 	}
 
 	/**

--- a/src/Core/Addon/AddonManagerHelper.php
+++ b/src/Core/Addon/AddonManagerHelper.php
@@ -28,9 +28,7 @@ final class AddonManagerHelper implements AddonHelper
 	/** @var string[] */
 	private array $addons = [];
 
-	public function __construct(private string $addonPath, private Database $database, private IManageConfigValues $config, private ICanCache $cache, private LoggerInterface $logger, private Profiler $profiler)
-				{
-							}
+	public function __construct(private string $addonPath, private Database $database, private IManageConfigValues $config, private ICanCache $cache, private LoggerInterface $logger, private Profiler $profiler) {}
 	/**
 	 * Returns the absolute path to the addon folder
 	 *

--- a/src/Core/Addon/AddonManagerHelper.php
+++ b/src/Core/Addon/AddonManagerHelper.php
@@ -25,36 +25,12 @@ use Psr\Log\LoggerInterface;
  */
 final class AddonManagerHelper implements AddonHelper
 {
-	private string $addonPath;
-
-	private Database $database;
-
-	private IManageConfigValues $config;
-
-	private ICanCache $cache;
-
-	private LoggerInterface $logger;
-
-	private Profiler $profiler;
-
 	/** @var string[] */
 	private array $addons = [];
 
-	public function __construct(
-		string $addonPath,
-		Database $database,
-		IManageConfigValues $config,
-		ICanCache $cache,
-		LoggerInterface $logger,
-		Profiler $profiler,
-	) {
-		$this->addonPath = $addonPath;
-		$this->database  = $database;
-		$this->config    = $config;
-		$this->cache     = $cache;
-		$this->logger    = $logger;
-		$this->profiler  = $profiler;
-	}
+	public function __construct(private string $addonPath, private Database $database, private IManageConfigValues $config, private ICanCache $cache, private LoggerInterface $logger, private Profiler $profiler)
+				{
+							}
 	/**
 	 * Returns the absolute path to the addon folder
 	 *

--- a/src/Core/Cache/Type/AbstractCache.php
+++ b/src/Core/Cache/Type/AbstractCache.php
@@ -16,15 +16,14 @@ abstract class AbstractCache implements ICanCache
 {
 	public const NAME = '';
 
-	/**
-	 * @var string The hostname
-	 */
-	private $hostName;
-
-	public function __construct(string $hostName)
-	{
-		$this->hostName = $hostName;
-	}
+	public function __construct(
+								/**
+								 * @var string The hostname
+								 */
+								private string $hostName
+							)
+							{
+										}
 
 	/**
 	 * Returns the prefix (to avoid namespace conflicts)

--- a/src/Core/Cache/Type/AbstractCache.php
+++ b/src/Core/Cache/Type/AbstractCache.php
@@ -17,13 +17,11 @@ abstract class AbstractCache implements ICanCache
 	public const NAME = '';
 
 	public function __construct(
-								/**
-								 * @var string The hostname
-								 */
-								private string $hostName
-							)
-							{
-										}
+		/**
+		 * @var string The hostname
+		 */
+		private string $hostName,
+	) {}
 
 	/**
 	 * Returns the prefix (to avoid namespace conflicts)

--- a/src/Core/Cache/Type/DatabaseCache.php
+++ b/src/Core/Cache/Type/DatabaseCache.php
@@ -18,7 +18,7 @@ use Friendica\Util\DateTimeFormat;
  */
 class DatabaseCache extends AbstractCache implements ICanCache
 {
-	const NAME = 'database';
+	public const NAME = 'database';
 
 	public function __construct(string $hostname, private Database $dba)
 	{
@@ -65,7 +65,7 @@ class DatabaseCache extends AbstractCache implements ICanCache
 	{
 		try {
 			$cache = $this->dba->selectFirst('cache', ['v'], [
-				'`k` = ? AND (`expires` >= ? OR `expires` = -1)', $key, DateTimeFormat::utcNow()
+				'`k` = ? AND (`expires` >= ? OR `expires` = -1)', $key, DateTimeFormat::utcNow(),
 			]);
 
 			if ($this->dba->isResult($cache)) {
@@ -96,13 +96,13 @@ class DatabaseCache extends AbstractCache implements ICanCache
 				$fields = [
 					'v'       => serialize($value),
 					'expires' => DateTimeFormat::utc('now + ' . $ttl . 'seconds'),
-					'updated' => DateTimeFormat::utcNow()
+					'updated' => DateTimeFormat::utcNow(),
 				];
 			} else {
 				$fields = [
 					'v'       => serialize($value),
 					'expires' => -1,
-					'updated' => DateTimeFormat::utcNow()
+					'updated' => DateTimeFormat::utcNow(),
 				];
 			}
 

--- a/src/Core/Cache/Type/DatabaseCache.php
+++ b/src/Core/Cache/Type/DatabaseCache.php
@@ -20,16 +20,9 @@ class DatabaseCache extends AbstractCache implements ICanCache
 {
 	const NAME = 'database';
 
-	/**
-	 * @var Database
-	 */
-	private $dba;
-
-	public function __construct(string $hostname, Database $dba)
+	public function __construct(string $hostname, private Database $dba)
 	{
 		parent::__construct($hostname);
-
-		$this->dba = $dba;
 	}
 
 	/**

--- a/src/Core/Cache/Type/MemcachedCache.php
+++ b/src/Core/Cache/Type/MemcachedCache.php
@@ -31,11 +31,6 @@ class MemcachedCache extends AbstractCache implements ICanCacheInMemory
 	private $memcached;
 
 	/**
-	 * @var LoggerInterface
-	 */
-	private $logger;
-
-	/**
 	 * Due to limitations of the INI format, the expected configuration for Memcached servers is the following:
 	 * array {
 	 *   0 => "hostname, port(, weight)",
@@ -49,15 +44,13 @@ class MemcachedCache extends AbstractCache implements ICanCacheInMemory
 	 * @throws InvalidCacheDriverException
 	 * @throws CachePersistenceException
 	 */
-	public function __construct(string $hostname, IManageConfigValues $config, LoggerInterface $logger)
+	public function __construct(string $hostname, IManageConfigValues $config, private LoggerInterface $logger)
 	{
 		if (!class_exists('Memcached', false)) {
 			throw new InvalidCacheDriverException('Memcached class isn\'t available');
 		}
 
 		parent::__construct($hostname);
-
-		$this->logger = $logger;
 
 		$this->memcached = new Memcached();
 

--- a/src/Core/Cache/Type/MemcachedCache.php
+++ b/src/Core/Cache/Type/MemcachedCache.php
@@ -23,7 +23,7 @@ class MemcachedCache extends AbstractCache implements ICanCacheInMemory
 	use CompareSetTrait;
 	use CompareDeleteTrait;
 	use MemcacheCommandTrait;
-	const NAME = 'memcached';
+	public const NAME = 'memcached';
 
 	/**
 	 * @var \Memcached
@@ -125,12 +125,12 @@ class MemcachedCache extends AbstractCache implements ICanCacheInMemory
 			return $this->memcached->set(
 				$cacheKey,
 				$value,
-				$ttl
+				$ttl,
 			);
 		} else {
 			return $this->memcached->set(
 				$cacheKey,
-				$value
+				$value,
 			);
 		}
 	}

--- a/src/Core/Cache/Type/ProfilerCacheDecorator.php
+++ b/src/Core/Cache/Type/ProfilerCacheDecorator.php
@@ -19,21 +19,18 @@ use Friendica\Util\Profiler;
  */
 class ProfilerCacheDecorator implements ICanCache, ICanCacheInMemory
 {
-	/**
-	 * @var ICanCache The original cache driver
-	 */
-	private $cache;
-
-	/**
-	 * @var Profiler The profiler of Friendica
-	 */
-	private $profiler;
-
-	public function __construct(ICanCache $cache, Profiler $profiler)
-	{
-		$this->cache    = $cache;
-		$this->profiler = $profiler;
-	}
+	public function __construct(
+								/**
+								 * @var ICanCache The original cache driver
+								 */
+								private ICanCache $cache,
+								/**
+								 * @var Profiler The profiler of Friendica
+								 */
+								private Profiler $profiler
+							)
+							{
+										}
 
 	/**
 	 * {@inheritDoc}

--- a/src/Core/Cache/Type/ProfilerCacheDecorator.php
+++ b/src/Core/Cache/Type/ProfilerCacheDecorator.php
@@ -20,17 +20,15 @@ use Friendica\Util\Profiler;
 class ProfilerCacheDecorator implements ICanCache, ICanCacheInMemory
 {
 	public function __construct(
-								/**
-								 * @var ICanCache The original cache driver
-								 */
-								private ICanCache $cache,
-								/**
-								 * @var Profiler The profiler of Friendica
-								 */
-								private Profiler $profiler
-							)
-							{
-										}
+		/**
+		 * @var ICanCache The original cache driver
+		 */
+		private ICanCache $cache,
+		/**
+		 * @var Profiler The profiler of Friendica
+		 */
+		private Profiler $profiler,
+	) {}
 
 	/**
 	 * {@inheritDoc}

--- a/src/Core/Config/Util/ConfigFileManager.php
+++ b/src/Core/Config/Util/ConfigFileManager.php
@@ -42,37 +42,13 @@ class ConfigFileManager
 	public const SAMPLE_END = '-sample';
 
 	/**
-	 * @var string
-	 */
-	private $baseDir;
-	private string $addonDir;
-	/**
-	 * @var string
-	 */
-	private $configDir;
-	/**
-	 * @var string
-	 */
-	private $staticDir;
-
-	/**
-	 * @var array
-	 */
-	private $server;
-
-	/**
 	 * @param string $baseDir   The base
 	 * @param string $configDir
 	 * @param string $staticDir
 	 */
-	public function __construct(string $baseDir, string $addonDir, string $configDir, string $staticDir, array $server = [])
-	{
-		$this->baseDir   = $baseDir;
-		$this->addonDir  = $addonDir;
-		$this->configDir = $configDir;
-		$this->staticDir = $staticDir;
-		$this->server    = $server;
-	}
+	public function __construct(private string $baseDir, private string $addonDir, private string $configDir, private string $staticDir, private array $server = [])
+				{
+							}
 
 	/**
 	 * Load the configuration files into an configuration cache

--- a/src/Core/Config/Util/ConfigFileManager.php
+++ b/src/Core/Config/Util/ConfigFileManager.php
@@ -46,9 +46,7 @@ class ConfigFileManager
 	 * @param string $configDir
 	 * @param string $staticDir
 	 */
-	public function __construct(private string $baseDir, private string $addonDir, private string $configDir, private string $staticDir, private array $server = [])
-				{
-							}
+	public function __construct(private string $baseDir, private string $addonDir, private string $configDir, private string $staticDir, private array $server = []) {}
 
 	/**
 	 * Load the configuration files into an configuration cache

--- a/src/Core/Config/ValueObject/Cache.php
+++ b/src/Core/Config/ValueObject/Cache.php
@@ -18,7 +18,7 @@ use ParagonIE\HiddenString\HiddenString;
 class Cache
 {
 	/** @var int[] A list of valid config source  */
-	const VALID_SOURCES = [
+	public const VALID_SOURCES = [
 		self::SOURCE_STATIC,
 		self::SOURCE_FILE,
 		self::SOURCE_DATA,
@@ -27,18 +27,18 @@ class Cache
 	];
 
 	/** @var int Indicates that the cache entry is a default value - Lowest Priority */
-	const SOURCE_STATIC = 0;
+	public const SOURCE_STATIC = 0;
 	/** @var int Indicates that the cache entry is set by file - Low Priority */
-	const SOURCE_FILE = 1;
+	public const SOURCE_FILE = 1;
 	/** @var int Indicates that the cache entry is manually set by the application (per admin page/console) - Middle Priority */
-	const SOURCE_DATA = 2;
+	public const SOURCE_DATA = 2;
 	/** @var int Indicates that the cache entry is set by a server environment variable - High Priority */
-	const SOURCE_ENV = 3;
+	public const SOURCE_ENV = 3;
 	/** @var int Indicates that the cache entry is fixed and must not be changed */
-	const SOURCE_FIX = 5;
+	public const SOURCE_FIX = 5;
 
 	/** @var int Default value for a config source */
-	const SOURCE_DEFAULT = self::SOURCE_FILE;
+	public const SOURCE_DEFAULT = self::SOURCE_FILE;
 
 	/**
 	 * @var array
@@ -167,16 +167,16 @@ class Cache
 			$this->source[$cat] = [];
 		}
 
-		if (isset($this->source[$cat][$key]) &&
-			$source < $this->source[$cat][$key]) {
+		if (isset($this->source[$cat][$key])
+			&& $source < $this->source[$cat][$key]) {
 			return false;
 		}
 
-		if ($this->hidePasswordOutput &&
-			$key == 'password' &&
-			is_string($value)) {
-			$this->config[$cat][$key] = new HiddenString((string)$value);
-		} else if (is_string($value)) {
+		if ($this->hidePasswordOutput
+			&& $key == 'password'
+			&& is_string($value)) {
+			$this->config[$cat][$key] = new HiddenString((string) $value);
+		} elseif (is_string($value)) {
 			$this->config[$cat][$key] = self::toConfigValue($value);
 		} else {
 			$this->config[$cat][$key] = $value;
@@ -321,7 +321,7 @@ class Cache
 			}
 		}
 
-		$newCache = new Cache();
+		$newCache         = new Cache();
 		$newCache->config = $newConfig;
 		$newCache->source = $newSource;
 

--- a/src/Core/Config/ValueObject/Cache.php
+++ b/src/Core/Config/ValueObject/Cache.php
@@ -56,18 +56,12 @@ class Cache
 	private $delConfig = [];
 
 	/**
-	 * @var bool
-	 */
-	private $hidePasswordOutput;
-
-	/**
 	 * @param array $config             A initial config array
 	 * @param bool  $hidePasswordOutput True, if cache variables should take extra care of password values
 	 * @param int   $source             Sets a source of the initial config values
 	 */
-	public function __construct(array $config = [], bool $hidePasswordOutput = true, int $source = self::SOURCE_DEFAULT)
+	public function __construct(array $config = [], private bool $hidePasswordOutput = true, int $source = self::SOURCE_DEFAULT)
 	{
-		$this->hidePasswordOutput = $hidePasswordOutput;
 		$this->load($config, $source);
 	}
 

--- a/src/Core/Console.php
+++ b/src/Core/Console.php
@@ -30,11 +30,6 @@ class Console extends \Asika\SimpleConsole\Console
 	protected $helpOptions             = [];
 	protected array $customHelpOptions = ['h', 'help', '?'];
 
-	/**
-	 * @var Container The Container
-	 */
-	protected Container $container;
-
 	protected function getHelp()
 	{
 		$help = <<<HELP
@@ -124,11 +119,9 @@ HELP;
 	 *
 	 * @param Container $container The Friendica container
 	 */
-	public function __construct(Container $container, array $argv = null)
+	public function __construct(protected Container $container, array $argv = null)
 	{
 		parent::__construct($argv);
-
-		$this->container = $container;
 	}
 
 	public static function create(Container $container, array $argv = null): Console

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -27,9 +27,7 @@ final class DiceContainer implements Container
 		return new self($dice);
 	}
 
-	private function __construct(private Dice $container)
-				{
-							}
+	private function __construct(private Dice $container) {}
 
 	/**
 	 * Returns a fully constructed object based on $name using $args and $share as constructor arguments if supplied

--- a/src/Core/DiceContainer.php
+++ b/src/Core/DiceContainer.php
@@ -27,12 +27,9 @@ final class DiceContainer implements Container
 		return new self($dice);
 	}
 
-	private Dice $container;
-
-	private function __construct(Dice $container)
-	{
-		$this->container = $container;
-	}
+	private function __construct(private Dice $container)
+				{
+							}
 
 	/**
 	 * Returns a fully constructed object based on $name using $args and $share as constructor arguments if supplied

--- a/src/Core/Hooks/Util/StrategiesFileManager.php
+++ b/src/Core/Hooks/Util/StrategiesFileManager.php
@@ -27,16 +27,13 @@ class StrategiesFileManager
 	public const STRATEGY_DEFAULT_KEY = '';
 	public const STATIC_DIR           = 'static';
 	public const CONFIG_NAME          = 'strategies';
-
-	private IManageConfigValues $configuration;
 	protected array $config = [];
 	/** @var string */
 	protected $basePath;
 
-	public function __construct(string $basePath, IManageConfigValues $configuration)
+	public function __construct(string $basePath, private IManageConfigValues $configuration)
 	{
 		$this->basePath      = $basePath;
-		$this->configuration = $configuration;
 	}
 
 	/**

--- a/src/Core/Hooks/Util/StrategiesFileManager.php
+++ b/src/Core/Hooks/Util/StrategiesFileManager.php
@@ -27,13 +27,13 @@ class StrategiesFileManager
 	public const STRATEGY_DEFAULT_KEY = '';
 	public const STATIC_DIR           = 'static';
 	public const CONFIG_NAME          = 'strategies';
-	protected array $config = [];
+	protected array $config           = [];
 	/** @var string */
 	protected $basePath;
 
 	public function __construct(string $basePath, private IManageConfigValues $configuration)
 	{
-		$this->basePath      = $basePath;
+		$this->basePath = $basePath;
 	}
 
 	/**

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -81,26 +81,12 @@ class L10n
 	 */
 	private $strings = [];
 
-	/**
-	 * @var Database
-	 */
-	private $dba;
-	/**
-	 * @var IManageConfigValues
-	 */
-	private $config;
-	private IHandleSessions $session;
-
-	public function __construct(IManageConfigValues $config, Database $dba, IHandleSessions $session, array $server, array $get)
+	public function __construct(private IManageConfigValues $config, private Database $dba, private IHandleSessions $session, array $server, array $get)
 	{
-		$this->dba     = $dba;
-		$this->config  = $config;
-		$this->session = $session;
-
-		$this->loadTranslationTable(L10n::detectLanguage($server, $get, $config->get('system', 'language', self::DEFAULT)));
+		$this->loadTranslationTable(L10n::detectLanguage($server, $get, $this->config->get('system', 'language', self::DEFAULT)));
 		$this->setLocale($server);
-		$this->setSessionVariable($session);
-		$this->setLangFromSession($session);
+		$this->setSessionVariable($this->session);
+		$this->setLangFromSession($this->session);
 	}
 
 	/**

--- a/src/Core/Lock/Factory/Lock.php
+++ b/src/Core/Lock/Factory/Lock.php
@@ -28,28 +28,26 @@ class Lock
 	/**
 	 * @var string The default driver for caching
 	 */
-	const DEFAULT_DRIVER = 'default';
+	public const DEFAULT_DRIVER = 'default';
 
 	public function __construct(
-								/**
-								 * @var Cache The memory cache driver in case we use it
-								 */
-								private Cache $cacheFactory,
-								/**
-								 * @var IManageConfigValues The configuration to read parameters out of the config
-								 */
-								private IManageConfigValues $config,
-								/**
-								 * @var Database The database connection in case that the cache is used the dba connection
-								 */
-								private Database $dba,
-								/**
-								 * @var LoggerInterface The Friendica Logger
-								 */
-								private LoggerInterface $logger
-							)
-							{
-										}
+		/**
+		 * @var Cache The memory cache driver in case we use it
+		 */
+		private Cache $cacheFactory,
+		/**
+		 * @var IManageConfigValues The configuration to read parameters out of the config
+		 */
+		private IManageConfigValues $config,
+		/**
+		 * @var Database The database connection in case that the cache is used the dba connection
+		 */
+		private Database $dba,
+		/**
+		 * @var LoggerInterface The Friendica Logger
+		 */
+		private LoggerInterface $logger,
+	) {}
 
 	public function create()
 	{
@@ -67,6 +65,7 @@ class Lock
 					} else {
 						throw new \Exception(sprintf('Incompatible cache driver \'%s\' for lock used', $lock_type));
 					}
+					// no break
 				case 'database':
 					return new LockType\DatabaseLock($this->dba);
 				case 'semaphore':

--- a/src/Core/Lock/Factory/Lock.php
+++ b/src/Core/Lock/Factory/Lock.php
@@ -30,33 +30,26 @@ class Lock
 	 */
 	const DEFAULT_DRIVER = 'default';
 
-	/**
-	 * @var IManageConfigValues The configuration to read parameters out of the config
-	 */
-	private $config;
-
-	/**
-	 * @var Database The database connection in case that the cache is used the dba connection
-	 */
-	private $dba;
-
-	/**
-	 * @var Cache The memory cache driver in case we use it
-	 */
-	private $cacheFactory;
-
-	/**
-	 * @var LoggerInterface The Friendica Logger
-	 */
-	private $logger;
-
-	public function __construct(Cache $cacheFactory, IManageConfigValues $config, Database $dba, LoggerInterface $logger)
-	{
-		$this->cacheFactory = $cacheFactory;
-		$this->config       = $config;
-		$this->dba          = $dba;
-		$this->logger       = $logger;
-	}
+	public function __construct(
+								/**
+								 * @var Cache The memory cache driver in case we use it
+								 */
+								private Cache $cacheFactory,
+								/**
+								 * @var IManageConfigValues The configuration to read parameters out of the config
+								 */
+								private IManageConfigValues $config,
+								/**
+								 * @var Database The database connection in case that the cache is used the dba connection
+								 */
+								private Database $dba,
+								/**
+								 * @var LoggerInterface The Friendica Logger
+								 */
+								private LoggerInterface $logger
+							)
+							{
+										}
 
 	public function create()
 	{

--- a/src/Core/Lock/Type/CacheLock.php
+++ b/src/Core/Lock/Type/CacheLock.php
@@ -26,9 +26,7 @@ class CacheLock extends AbstractLock
 	 *
 	 * @param ICanCacheInMemory $cache The CacheDriver for this type of lock
 	 */
-	public function __construct(private ICanCacheInMemory $cache)
-				{
-							}
+	public function __construct(private ICanCacheInMemory $cache) {}
 
 	/**
 	 * (@inheritdoc)

--- a/src/Core/Lock/Type/CacheLock.php
+++ b/src/Core/Lock/Type/CacheLock.php
@@ -22,19 +22,13 @@ class CacheLock extends AbstractLock
 	public const CACHE_PREFIX = 'lock:';
 
 	/**
-	 * @var ICanCacheInMemory
-	 */
-	private $cache;
-
-	/**
 	 * CacheLock constructor.
 	 *
 	 * @param ICanCacheInMemory $cache The CacheDriver for this type of lock
 	 */
-	public function __construct(ICanCacheInMemory $cache)
-	{
-		$this->cache = $cache;
-	}
+	public function __construct(private ICanCacheInMemory $cache)
+				{
+							}
 
 	/**
 	 * (@inheritdoc)

--- a/src/Core/Lock/Type/DatabaseLock.php
+++ b/src/Core/Lock/Type/DatabaseLock.php
@@ -26,16 +26,13 @@ class DatabaseLock extends AbstractLock
 	private $pid;
 
 	/**
-	 * @var Database The database connection of Friendica
-	 */
-	private $dba;
-
-	/**
 	 * @param int|null $pid The id of the current process (null means determine automatically)
 	 */
-	public function __construct(Database $dba, ?int $pid = null)
+	public function __construct(/**
+				 * @var Database The database connection of Friendica
+				 */
+				private Database $dba, ?int $pid = null)
 	{
-		$this->dba = $dba;
 		$this->pid = $pid ?? getmypid();
 	}
 

--- a/src/Core/Lock/Type/DatabaseLock.php
+++ b/src/Core/Lock/Type/DatabaseLock.php
@@ -31,8 +31,9 @@ class DatabaseLock extends AbstractLock
 	public function __construct(/**
 				 * @var Database The database connection of Friendica
 				 */
-				private Database $dba, ?int $pid = null)
-	{
+		private Database $dba,
+		?int $pid = null,
+	) {
 		$this->pid = $pid ?? getmypid();
 	}
 

--- a/src/Core/Logger/Factory/DelegatingLoggerFactory.php
+++ b/src/Core/Logger/Factory/DelegatingLoggerFactory.php
@@ -23,9 +23,7 @@ final class DelegatingLoggerFactory implements LoggerFactory
 	/** @var array<string,LoggerFactory> */
 	private array $factories = [];
 
-	public function __construct(private IManageConfigValues $config)
-				{
-							}
+	public function __construct(private IManageConfigValues $config) {}
 
 	public function registerFactory(string $name, LoggerFactory $factory): void
 	{

--- a/src/Core/Logger/Factory/DelegatingLoggerFactory.php
+++ b/src/Core/Logger/Factory/DelegatingLoggerFactory.php
@@ -20,15 +20,12 @@ use Psr\Log\NullLogger;
  */
 final class DelegatingLoggerFactory implements LoggerFactory
 {
-	private IManageConfigValues $config;
-
 	/** @var array<string,LoggerFactory> */
 	private array $factories = [];
 
-	public function __construct(IManageConfigValues $config)
-	{
-		$this->config = $config;
-	}
+	public function __construct(private IManageConfigValues $config)
+				{
+							}
 
 	public function registerFactory(string $name, LoggerFactory $factory): void
 	{

--- a/src/Core/Logger/Factory/StreamLoggerFactory.php
+++ b/src/Core/Logger/Factory/StreamLoggerFactory.php
@@ -26,9 +26,7 @@ use Psr\Log\LoggerInterface;
  */
 final class StreamLoggerFactory implements LoggerFactory
 {
-	public function __construct(private IManageConfigValues $config, private IHaveCallIntrospections $introspection, private FileSystemUtil $fileSystem)
-				{
-							}
+	public function __construct(private IManageConfigValues $config, private IHaveCallIntrospections $introspection, private FileSystemUtil $fileSystem) {}
 
 	/**
 	 * Creates and returns a PSR-3 Logger instance.
@@ -58,7 +56,7 @@ final class StreamLoggerFactory implements LoggerFactory
 			$this->introspection,
 			$this->fileSystem->createStream($logfile),
 			StreamLogger::levelToInt[$logLevel],
-			getmypid()
+			getmypid(),
 		);
 	}
 }

--- a/src/Core/Logger/Factory/StreamLoggerFactory.php
+++ b/src/Core/Logger/Factory/StreamLoggerFactory.php
@@ -26,21 +26,9 @@ use Psr\Log\LoggerInterface;
  */
 final class StreamLoggerFactory implements LoggerFactory
 {
-	private IManageConfigValues $config;
-
-	private IHaveCallIntrospections $introspection;
-
-	private FileSystemUtil $fileSystem;
-
-	public function __construct(
-		IManageConfigValues $config,
-		IHaveCallIntrospections $introspection,
-		FileSystemUtil $fileSystem
-	) {
-		$this->config        = $config;
-		$this->introspection = $introspection;
-		$this->fileSystem    = $fileSystem;
-	}
+	public function __construct(private IManageConfigValues $config, private IHaveCallIntrospections $introspection, private FileSystemUtil $fileSystem)
+				{
+							}
 
 	/**
 	 * Creates and returns a PSR-3 Logger instance.

--- a/src/Core/Logger/Factory/SyslogLoggerFactory.php
+++ b/src/Core/Logger/Factory/SyslogLoggerFactory.php
@@ -24,17 +24,9 @@ use Psr\Log\LoggerInterface;
  */
 final class SyslogLoggerFactory implements LoggerFactory
 {
-	private IManageConfigValues $config;
-
-	private IHaveCallIntrospections $introspection;
-
-	public function __construct(
-		IManageConfigValues $config,
-		IHaveCallIntrospections $introspection
-	) {
-		$this->config        = $config;
-		$this->introspection = $introspection;
-	}
+	public function __construct(private IManageConfigValues $config, private IHaveCallIntrospections $introspection)
+				{
+							}
 
 	/**
 	 * Creates and returns a PSR-3 Logger instance.

--- a/src/Core/Logger/Factory/SyslogLoggerFactory.php
+++ b/src/Core/Logger/Factory/SyslogLoggerFactory.php
@@ -24,9 +24,7 @@ use Psr\Log\LoggerInterface;
  */
 final class SyslogLoggerFactory implements LoggerFactory
 {
-	public function __construct(private IManageConfigValues $config, private IHaveCallIntrospections $introspection)
-				{
-							}
+	public function __construct(private IManageConfigValues $config, private IHaveCallIntrospections $introspection) {}
 
 	/**
 	 * Creates and returns a PSR-3 Logger instance.
@@ -52,7 +50,7 @@ final class SyslogLoggerFactory implements LoggerFactory
 			$this->introspection,
 			SyslogLogger::logLevels[$logLevel],
 			$logOpts,
-			$logFacility
+			$logFacility,
 		);
 	}
 }

--- a/src/Core/Logger/Handler/ErrorHandler.php
+++ b/src/Core/Logger/Handler/ErrorHandler.php
@@ -43,9 +43,7 @@ class ErrorHandler
 	/** @var int[] */
 	private static $fatalErrors = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR];
 
-	public function __construct(private LoggerInterface $logger)
-				{
-							}
+	public function __construct(private LoggerInterface $logger) {}
 
 	/**
 	 * Registers a new ErrorHandler for a given Logger

--- a/src/Core/Logger/Handler/ErrorHandler.php
+++ b/src/Core/Logger/Handler/ErrorHandler.php
@@ -20,9 +20,6 @@ use Throwable;
  */
 class ErrorHandler
 {
-	/** @var LoggerInterface */
-	private $logger;
-
 	/** @var ?callable */
 	private $previousExceptionHandler = null;
 	/** @var array<class-string, LogLevel::*> an array of class name to LogLevel::* constant mapping */
@@ -46,10 +43,9 @@ class ErrorHandler
 	/** @var int[] */
 	private static $fatalErrors = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR];
 
-	public function __construct(LoggerInterface $logger)
-	{
-		$this->logger = $logger;
-	}
+	public function __construct(private LoggerInterface $logger)
+				{
+							}
 
 	/**
 	 * Registers a new ErrorHandler for a given Logger

--- a/src/Core/Logger/LoggerManager.php
+++ b/src/Core/Logger/LoggerManager.php
@@ -40,24 +40,17 @@ final class LoggerManager
 	 */
 	private static string $logChannel = LogChannel::DEFAULT;
 
-	private IManageConfigValues $config;
-
-	private LoggerFactory $factory;
-
 	private bool $debug;
 
 	private string $logLevel;
 
 	private bool $profiling;
 
-	public function __construct(IManageConfigValues $config, LoggerFactory $factory)
+	public function __construct(private IManageConfigValues $config, private LoggerFactory $factory)
 	{
-		$this->config  = $config;
-		$this->factory = $factory;
-
-		$this->debug     = (bool) $config->get('system', 'debugging')  ?? false;
-		$this->logLevel  = (string) $config->get('system', 'loglevel') ?? LogLevel::NOTICE;
-		$this->profiling = (bool) $config->get('system', 'profiling')  ?? false;
+		$this->debug     = (bool) $this->config->get('system', 'debugging')  ?? false;
+		$this->logLevel  = (string) $this->config->get('system', 'loglevel') ?? LogLevel::NOTICE;
+		$this->profiling = (bool) $this->config->get('system', 'profiling')  ?? false;
 	}
 
 	public function changeLogChannel(string $logChannel): void

--- a/src/Core/Logger/Type/ProfilerLogger.php
+++ b/src/Core/Logger/Type/ProfilerLogger.php
@@ -30,8 +30,9 @@ class ProfilerLogger implements LoggerInterface
 	public function __construct(/**
 				 * The Logger of the current call
 				 */
-				private LoggerInterface $logger, Profiler $profiler)
-	{
+		private LoggerInterface $logger,
+		Profiler $profiler,
+	) {
 		$this->profiler = $profiler;
 	}
 

--- a/src/Core/Logger/Type/ProfilerLogger.php
+++ b/src/Core/Logger/Type/ProfilerLogger.php
@@ -17,12 +17,6 @@ use Psr\Log\LoggerInterface;
 class ProfilerLogger implements LoggerInterface
 {
 	/**
-	 * The Logger of the current call
-	 * @var LoggerInterface
-	 */
-	private $logger;
-
-	/**
 	 * The Profiler for the current call
 	 * @var Profiler
 	 */
@@ -33,9 +27,11 @@ class ProfilerLogger implements LoggerInterface
 	 * @param LoggerInterface $logger   The Logger of the current call
 	 * @param Profiler        $profiler The profiler of the current call
 	 */
-	public function __construct(LoggerInterface $logger, Profiler $profiler)
+	public function __construct(/**
+				 * The Logger of the current call
+				 */
+				private LoggerInterface $logger, Profiler $profiler)
 	{
-		$this->logger   = $logger;
 		$this->profiler = $profiler;
 	}
 

--- a/src/Core/Logger/Type/StreamLogger.php
+++ b/src/Core/Logger/Type/StreamLogger.php
@@ -18,7 +18,7 @@ use Psr\Log\LogLevel;
  */
 class StreamLogger extends AbstractLogger
 {
-	const NAME = 'stream';
+	public const NAME = 'stream';
 
 	/**
 	 * Translates LogLevel log levels to integer values
@@ -36,19 +36,19 @@ class StreamLogger extends AbstractLogger
 	];
 
 	/**
-				 * {@inheritdoc}
-				 * @param int $logLevel The minimum loglevel at which this logger will be triggered
-				 *
-				 * @throws LoggerException
-				 * @param resource|null $stream
-				 */
-				public function __construct(string $channel, IHaveCallIntrospections $introspection, /**
+	 * {@inheritdoc}
+	 * @param int $logLevel The minimum loglevel at which this logger will be triggered
+	 *
+	 * @throws LoggerException
+	 * @param resource|null $stream
+	 */
+	public function __construct(string $channel, IHaveCallIntrospections $introspection, /**
 				 * The stream, where the current logger is writing into
 				 */
-				private $stream, private int $logLevel, /**
+		private $stream, private int $logLevel, /**
 				 * The current process ID
 				 */
-				private int $pid)
+		private int $pid)
 	{
 		parent::__construct($channel, $introspection);
 	}

--- a/src/Core/Logger/Type/StreamLogger.php
+++ b/src/Core/Logger/Type/StreamLogger.php
@@ -21,22 +21,6 @@ class StreamLogger extends AbstractLogger
 	const NAME = 'stream';
 
 	/**
-	 * The minimum loglevel at which this logger will be triggered
-	 */
-	private int $logLevel;
-
-	/**
-	 * The stream, where the current logger is writing into
-	 * @var resource|null
-	 */
-	private $stream;
-
-	/**
-	 * The current process ID
-	 */
-	private int $pid;
-
-	/**
 	 * Translates LogLevel log levels to integer values
 	 * @var array
 	 */
@@ -52,18 +36,21 @@ class StreamLogger extends AbstractLogger
 	];
 
 	/**
-	 * {@inheritdoc}
-	 * @param int $logLevel The minimum loglevel at which this logger will be triggered
-	 *
-	 * @throws LoggerException
-	 */
-	public function __construct(string $channel, IHaveCallIntrospections $introspection, $stream, int $logLevel, int $pid)
+				 * {@inheritdoc}
+				 * @param int $logLevel The minimum loglevel at which this logger will be triggered
+				 *
+				 * @throws LoggerException
+				 * @param resource|null $stream
+				 */
+				public function __construct(string $channel, IHaveCallIntrospections $introspection, /**
+				 * The stream, where the current logger is writing into
+				 */
+				private $stream, private int $logLevel, /**
+				 * The current process ID
+				 */
+				private int $pid)
 	{
 		parent::__construct($channel, $introspection);
-
-		$this->stream   = $stream;
-		$this->pid      = $pid;
-		$this->logLevel = $logLevel;
 	}
 
 	public function close()

--- a/src/Core/Logger/Type/SyslogLogger.php
+++ b/src/Core/Logger/Type/SyslogLogger.php
@@ -18,14 +18,14 @@ use Psr\Log\LogLevel;
  */
 class SyslogLogger extends AbstractLogger
 {
-	const NAME = 'syslog';
+	public const NAME = 'syslog';
 
-	const IDENT = 'Friendica';
+	public const IDENT = 'Friendica';
 
 	/** @var int The default syslog flags */
-	const DEFAULT_FLAGS = LOG_PID | LOG_ODELAY | LOG_CONS;
+	public const DEFAULT_FLAGS = LOG_PID | LOG_ODELAY | LOG_CONS;
 	/** @var int The default syslog facility */
-	const DEFAULT_FACILITY = LOG_USER;
+	public const DEFAULT_FACILITY = LOG_USER;
 
 	/**
 	 * Translates LogLevel log levels to syslog log priorities.
@@ -54,7 +54,7 @@ class SyslogLogger extends AbstractLogger
 		LOG_ERR     => 'ERROR',
 		LOG_CRIT    => 'CRITICAL',
 		LOG_ALERT   => 'ALERT',
-		LOG_EMERG   => 'EMERGENCY'
+		LOG_EMERG   => 'EMERGENCY',
 	];
 
 	/**
@@ -63,13 +63,13 @@ class SyslogLogger extends AbstractLogger
 	private string $errorMessage;
 
 	/**
-				 * {@inheritdoc}
-				 *
-				 * @param int $logLevel    The minimum loglevel at which this logger will be triggered
-				 * @param int $logOpts
-				 * @param int $logFacility
-				 */
-				public function __construct(string $channel, IHaveCallIntrospections $introspection, private int $logLevel, private int $logOpts, private int $logFacility)
+	 * {@inheritdoc}
+	 *
+	 * @param int $logLevel    The minimum loglevel at which this logger will be triggered
+	 * @param int $logOpts
+	 * @param int $logFacility
+	 */
+	public function __construct(string $channel, IHaveCallIntrospections $introspection, private int $logLevel, private int $logOpts, private int $logFacility)
 	{
 		parent::__construct($channel, $introspection);
 	}

--- a/src/Core/Logger/Type/SyslogLogger.php
+++ b/src/Core/Logger/Type/SyslogLogger.php
@@ -58,41 +58,20 @@ class SyslogLogger extends AbstractLogger
 	];
 
 	/**
-	 * Indicates what logging options will be used when generating a log message
-	 * @see http://php.net/manual/en/function.openlog.php#refsect1-function.openlog-parameters
-	 */
-	private int $logOpts;
-
-	/**
-	 * Used to specify what type of program is logging the message
-	 * @see http://php.net/manual/en/function.openlog.php#refsect1-function.openlog-parameters
-	 */
-	private int $logFacility;
-
-	/**
-	 * The minimum loglevel at which this logger will be triggered
-	 */
-	private int $logLevel;
-
-	/**
 	 * A error message of the current operation
 	 */
 	private string $errorMessage;
 
 	/**
-	 * {@inheritdoc}
-	 *
-	 * @param int $logLevel    The minimum loglevel at which this logger will be triggered
-	 * @param int $logOptions
-	 * @param int $logFacility
-	 */
-	public function __construct(string $channel, IHaveCallIntrospections $introspection, int $logLevel, int $logOptions, int $logFacility)
+				 * {@inheritdoc}
+				 *
+				 * @param int $logLevel    The minimum loglevel at which this logger will be triggered
+				 * @param int $logOpts
+				 * @param int $logFacility
+				 */
+				public function __construct(string $channel, IHaveCallIntrospections $introspection, private int $logLevel, private int $logOpts, private int $logFacility)
 	{
 		parent::__construct($channel, $introspection);
-
-		$this->logOpts     = $logOptions;
-		$this->logFacility = $logFacility;
-		$this->logLevel    = $logLevel;
 	}
 
 	/**

--- a/src/Core/Logger/Type/WorkerLogger.php
+++ b/src/Core/Logger/Type/WorkerLogger.php
@@ -19,7 +19,7 @@ use Psr\Log\LoggerInterface;
 class WorkerLogger implements LoggerInterface, DefaultContextLogger
 {
 	/** @var int Length of the unique worker id */
-	const WORKER_ID_LENGTH = 7;
+	public const WORKER_ID_LENGTH = 7;
 
 	/**
 	 * @var string the current worker ID

--- a/src/Core/Logger/Type/WorkerLogger.php
+++ b/src/Core/Logger/Type/WorkerLogger.php
@@ -22,11 +22,6 @@ class WorkerLogger implements LoggerInterface, DefaultContextLogger
 	const WORKER_ID_LENGTH = 7;
 
 	/**
-	 * @var LoggerInterface The original Logger instance
-	 */
-	private $logger;
-
-	/**
 	 * @var string the current worker ID
 	 */
 	private $workerId;
@@ -43,9 +38,8 @@ class WorkerLogger implements LoggerInterface, DefaultContextLogger
 	 *
 	 * @throws LoggerException
 	 */
-	public function __construct(LoggerInterface $logger)
+	public function __construct(private LoggerInterface $logger)
 	{
-		$this->logger = $logger;
 		try {
 			$this->workerId = Strings::getRandomHex(self::WORKER_ID_LENGTH);
 		} catch (\Exception $exception) {

--- a/src/Core/Logger/Util/Introspection.php
+++ b/src/Core/Logger/Util/Introspection.php
@@ -30,7 +30,7 @@ class Introspection implements IHaveCallIntrospections
 	 */
 	public function __construct(Request $request, private array $skipClassesPartials = [], private int $skipStackFramesCount = 0)
 	{
-		$this->requestId            = $request->getRequestId();
+		$this->requestId = $request->getRequestId();
 	}
 
 	/**

--- a/src/Core/Logger/Util/Introspection.php
+++ b/src/Core/Logger/Util/Introspection.php
@@ -19,12 +19,6 @@ class Introspection implements IHaveCallIntrospections
 	/** @var string */
 	private $requestId;
 
-	/** @var int  */
-	private $skipStackFramesCount;
-
-	/** @var string[] */
-	private $skipClassesPartials;
-
 	private $skipFunctions = [
 		'call_user_func',
 		'call_user_func_array',
@@ -34,11 +28,9 @@ class Introspection implements IHaveCallIntrospections
 	 * @param string[] $skipClassesPartials  An array of classes to skip during logging
 	 * @param int      $skipStackFramesCount If the logger should use information from other hierarchy levels of the call
 	 */
-	public function __construct(Request $request, array $skipClassesPartials = [], int $skipStackFramesCount = 0)
+	public function __construct(Request $request, private array $skipClassesPartials = [], private int $skipStackFramesCount = 0)
 	{
 		$this->requestId            = $request->getRequestId();
-		$this->skipClassesPartials  = $skipClassesPartials;
-		$this->skipStackFramesCount = $skipStackFramesCount;
 	}
 
 	/**

--- a/src/Core/PConfig/ValueObject/Cache.php
+++ b/src/Core/PConfig/ValueObject/Cache.php
@@ -20,17 +20,11 @@ class Cache
 	private $config = [];
 
 	/**
-	 * @var bool
-	 */
-	private $hidePasswordOutput;
-
-	/**
 	 * @param bool $hidePasswordOutput True, if cache variables should take extra care of password values
 	 */
-	public function __construct(bool $hidePasswordOutput = true)
-	{
-		$this->hidePasswordOutput = $hidePasswordOutput;
-	}
+	public function __construct(private bool $hidePasswordOutput = true)
+				{
+							}
 
 	/**
 	 * Tries to load the specified configuration array into the user specific config array.

--- a/src/Core/PConfig/ValueObject/Cache.php
+++ b/src/Core/PConfig/ValueObject/Cache.php
@@ -22,9 +22,7 @@ class Cache
 	/**
 	 * @param bool $hidePasswordOutput True, if cache variables should take extra care of password values
 	 */
-	public function __construct(private bool $hidePasswordOutput = true)
-				{
-							}
+	public function __construct(private bool $hidePasswordOutput = true) {}
 
 	/**
 	 * Tries to load the specified configuration array into the user specific config array.
@@ -105,10 +103,10 @@ class Cache
 			$this->config[$uid][$cat] = [];
 		}
 
-		if ($this->hidePasswordOutput &&
-			$key == 'password' &&
-			!empty($value) && is_string($value)) {
-			$this->config[$uid][$cat][$key] = new HiddenString((string)$value);
+		if ($this->hidePasswordOutput
+			&& $key == 'password'
+			&& !empty($value) && is_string($value)) {
+			$this->config[$uid][$cat][$key] = new HiddenString((string) $value);
 		} else {
 			$this->config[$uid][$cat][$key] = $value;
 		}

--- a/src/Core/Session/Handler/Cache.php
+++ b/src/Core/Session/Handler/Cache.php
@@ -16,16 +16,9 @@ use Psr\Log\LoggerInterface;
  */
 class Cache extends AbstractSessionHandler
 {
-	/** @var ICanCache */
-	private $cache;
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(ICanCache $cache, LoggerInterface $logger)
-	{
-		$this->cache  = $cache;
-		$this->logger = $logger;
-	}
+	public function __construct(private ICanCache $cache, private LoggerInterface $logger)
+				{
+							}
 
 	public function open($path, $name): bool
 	{

--- a/src/Core/Session/Handler/Cache.php
+++ b/src/Core/Session/Handler/Cache.php
@@ -16,9 +16,7 @@ use Psr\Log\LoggerInterface;
  */
 class Cache extends AbstractSessionHandler
 {
-	public function __construct(private ICanCache $cache, private LoggerInterface $logger)
-				{
-							}
+	public function __construct(private ICanCache $cache, private LoggerInterface $logger) {}
 
 	public function open($path, $name): bool
 	{

--- a/src/Core/Session/Handler/Database.php
+++ b/src/Core/Session/Handler/Database.php
@@ -25,9 +25,7 @@ class Database extends AbstractSessionHandler
 	 * @param LoggerInterface $logger
 	 * @param array           $server
 	 */
-	public function __construct(private DBA $dba, private LoggerInterface $logger, private array $server)
-				{
-							}
+	public function __construct(private DBA $dba, private LoggerInterface $logger, private array $server) {}
 
 	public function open($path, $name): bool
 	{

--- a/src/Core/Session/Handler/Database.php
+++ b/src/Core/Session/Handler/Database.php
@@ -15,12 +15,6 @@ use Psr\Log\LoggerInterface;
  */
 class Database extends AbstractSessionHandler
 {
-	/** @var DBA */
-	private $dba;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var array The $_SERVER variable */
-	private $server;
 	/** @var bool global check, if the current Session exists */
 	private $sessionExists = false;
 
@@ -31,12 +25,9 @@ class Database extends AbstractSessionHandler
 	 * @param LoggerInterface $logger
 	 * @param array           $server
 	 */
-	public function __construct(DBA $dba, LoggerInterface $logger, array $server)
-	{
-		$this->dba    = $dba;
-		$this->logger = $logger;
-		$this->server = $server;
-	}
+	public function __construct(private DBA $dba, private LoggerInterface $logger, private array $server)
+				{
+							}
 
 	public function open($path, $name): bool
 	{

--- a/src/Core/Session/Model/UserSession.php
+++ b/src/Core/Session/Model/UserSession.php
@@ -17,15 +17,12 @@ use Friendica\Model\User;
  */
 class UserSession implements IHandleUserSessions
 {
-	/** @var IHandleSessions */
-	private $session;
 	/** @var int|bool saves the public Contact ID for later usage */
 	protected $publicContactId = false;
 
-	public function __construct(IHandleSessions $session)
-	{
-		$this->session = $session;
-	}
+	public function __construct(private IHandleSessions $session)
+				{
+							}
 
 	/** {@inheritDoc} */
 	public function getLocalUserId()

--- a/src/Core/Session/Model/UserSession.php
+++ b/src/Core/Session/Model/UserSession.php
@@ -20,9 +20,7 @@ class UserSession implements IHandleUserSessions
 	/** @var int|bool saves the public Contact ID for later usage */
 	protected $publicContactId = false;
 
-	public function __construct(private IHandleSessions $session)
-				{
-							}
+	public function __construct(private IHandleSessions $session) {}
 
 	/** {@inheritDoc} */
 	public function getLocalUserId()
@@ -70,7 +68,7 @@ class UserSession implements IHandleUserSessions
 		}
 
 		if (!empty($this->session->get('visitor_id'))) {
-			return (int)$this->session->get('visitor_id');
+			return (int) $this->session->get('visitor_id');
 		}
 
 		return false;

--- a/src/Core/Storage/Repository/StorageManager.php
+++ b/src/Core/Storage/Repository/StorageManager.php
@@ -66,7 +66,7 @@ class StorageManager
 	 */
 	public function __construct(private Database $dba, private IManageConfigValues $config, private LoggerInterface $logger, private EventDispatcherInterface $eventDispatcher, private L10n $l10n, bool $includeAddon = true)
 	{
-		$this->validBackends   = $this->config->get('storage', 'backends', self::DEFAULT_BACKENDS);
+		$this->validBackends = $this->config->get('storage', 'backends', self::DEFAULT_BACKENDS);
 
 		$currentName = $this->config->get('storage', 'name');
 

--- a/src/Core/Storage/Repository/StorageManager.php
+++ b/src/Core/Storage/Repository/StorageManager.php
@@ -51,16 +51,6 @@ class StorageManager
 	 */
 	private $backendInstances = [];
 
-	/** @var Database */
-	private $dba;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var LoggerInterface */
-	private $logger;
-	private EventDispatcherInterface $eventDispatcher;
-	/** @var L10n */
-	private $l10n;
-
 	/** @var ICanWriteToStorage */
 	private $currentBackend;
 
@@ -74,14 +64,9 @@ class StorageManager
 	 * @throws InvalidClassStorageException in case the active backend class is invalid
 	 * @throws StorageException in case of unexpected errors during the active backend class loading
 	 */
-	public function __construct(Database $dba, IManageConfigValues $config, LoggerInterface $logger, EventDispatcherInterface $eventDispatcher, L10n $l10n, bool $includeAddon = true)
+	public function __construct(private Database $dba, private IManageConfigValues $config, private LoggerInterface $logger, private EventDispatcherInterface $eventDispatcher, private L10n $l10n, bool $includeAddon = true)
 	{
-		$this->dba             = $dba;
-		$this->config          = $config;
-		$this->logger          = $logger;
-		$this->eventDispatcher = $eventDispatcher;
-		$this->l10n            = $l10n;
-		$this->validBackends   = $config->get('storage', 'backends', self::DEFAULT_BACKENDS);
+		$this->validBackends   = $this->config->get('storage', 'backends', self::DEFAULT_BACKENDS);
 
 		$currentName = $this->config->get('storage', 'name');
 

--- a/src/Core/Storage/Type/Database.php
+++ b/src/Core/Storage/Type/Database.php
@@ -20,14 +20,12 @@ use Friendica\Database\Database as DBA;
  */
 class Database implements ICanWriteToStorage
 {
-	const NAME = 'Database';
+	public const NAME = 'Database';
 
 	/**
 	 * @param DBA             $dba
 	 */
-	public function __construct(private DBA $dba)
-				{
-							}
+	public function __construct(private DBA $dba) {}
 
 	/**
 	 * @inheritDoc

--- a/src/Core/Storage/Type/Database.php
+++ b/src/Core/Storage/Type/Database.php
@@ -22,16 +22,12 @@ class Database implements ICanWriteToStorage
 {
 	const NAME = 'Database';
 
-	/** @var DBA */
-	private $dba;
-
 	/**
 	 * @param DBA             $dba
 	 */
-	public function __construct(DBA $dba)
-	{
-		$this->dba = $dba;
-	}
+	public function __construct(private DBA $dba)
+				{
+							}
 
 	/**
 	 * @inheritDoc

--- a/src/Core/Storage/Type/FilesystemConfig.php
+++ b/src/Core/Storage/Type/FilesystemConfig.php
@@ -19,14 +19,8 @@ class FilesystemConfig implements ICanConfigureStorage
 	// Default base folder
 	const DEFAULT_BASE_FOLDER = 'storage';
 
-	/** @var IManageConfigValues */
-	private $config;
-
 	/** @var string */
 	private $storagePath;
-
-	/** @var L10n */
-	private $l10n;
 
 	/**
 	 * Returns the current storage path
@@ -44,11 +38,8 @@ class FilesystemConfig implements ICanConfigureStorage
 	 * @param IManageConfigValues $config
 	 * @param L10n                $l10n
 	 */
-	public function __construct(IManageConfigValues $config, L10n $l10n)
+	public function __construct(private IManageConfigValues $config, private L10n $l10n)
 	{
-		$this->config = $config;
-		$this->l10n   = $l10n;
-
 		$path              = $this->config->get('storage', 'filesystem_path', self::DEFAULT_BASE_FOLDER);
 		$this->storagePath = rtrim($path, '/');
 	}

--- a/src/Core/Storage/Type/FilesystemConfig.php
+++ b/src/Core/Storage/Type/FilesystemConfig.php
@@ -17,7 +17,7 @@ use Friendica\Core\Storage\Capability\ICanConfigureStorage;
 class FilesystemConfig implements ICanConfigureStorage
 {
 	// Default base folder
-	const DEFAULT_BASE_FOLDER = 'storage';
+	public const DEFAULT_BASE_FOLDER = 'storage';
 
 	/** @var string */
 	private $storagePath;
@@ -54,8 +54,8 @@ class FilesystemConfig implements ICanConfigureStorage
 				'input',
 				$this->l10n->t('Storage base path'),
 				$this->storagePath,
-				$this->l10n->t('Folder where uploaded files are saved. For maximum security, This should be a path outside web server folder tree')
-			]
+				$this->l10n->t('Folder where uploaded files are saved. For maximum security, This should be a path outside web server folder tree'),
+			],
 		];
 	}
 
@@ -67,7 +67,7 @@ class FilesystemConfig implements ICanConfigureStorage
 		$storagePath = $data['storagepath'] ?? '';
 		if ($storagePath === '' || !is_dir($storagePath)) {
 			return [
-				'storagepath' => $this->l10n->t('Enter a valid existing folder')
+				'storagepath' => $this->l10n->t('Enter a valid existing folder'),
 			];
 		};
 		$this->config->set('storage', 'filesystem_path', $storagePath);

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -25,27 +25,9 @@ use Psr\Log\LoggerInterface;
  */
 class System
 {
-	/**
-	 * @var LoggerInterface
-	 */
-	private $logger;
-
-	/**
-	 * @var IManageConfigValues
-	 */
-	private $config;
-
-	/**
-	 * @var string
-	 */
-	private $basePath;
-
-	public function __construct(LoggerInterface $logger, IManageConfigValues $config, string $basepath)
-	{
-		$this->logger   = $logger;
-		$this->config   = $config;
-		$this->basePath = $basepath;
-	}
+	public function __construct(private LoggerInterface $logger, private IManageConfigValues $config, private string $basePath)
+				{
+							}
 
 	/**
 	 * Checks if the maximum number of database processes is reached

--- a/src/Core/System.php
+++ b/src/Core/System.php
@@ -25,9 +25,7 @@ use Psr\Log\LoggerInterface;
  */
 class System
 {
-	public function __construct(private LoggerInterface $logger, private IManageConfigValues $config, private string $basePath)
-				{
-							}
+	public function __construct(private LoggerInterface $logger, private IManageConfigValues $config, private string $basePath) {}
 
 	/**
 	 * Checks if the maximum number of database processes is reached

--- a/src/Database/DisposableFullTextSearch.php
+++ b/src/Database/DisposableFullTextSearch.php
@@ -15,14 +15,11 @@ namespace Friendica\Database;
  */
 class DisposableFullTextSearch
 {
-	private Database $db;
 	/** @var int Unique identifier of the haystack in the database. */
 	private int $identifier;
 
-	public function __construct(Database $database, string $haystack)
+	public function __construct(private Database $db, string $haystack)
 	{
-		$this->db = $database;
-
 		// Unique identifier generation. Two DisposableFullTextSearch object should never have the same as the first object destruction
 		// would delete both check-full-text-search rows before the second object destruction is called, leading to unexpected behavior.
 		do {

--- a/src/Event/ArrayFilterEvent.php
+++ b/src/Event/ArrayFilterEvent.php
@@ -172,13 +172,9 @@ final class ArrayFilterEvent extends Event
 
 	public const DB_VIEW_DEFINITION = 'friendica.data.db_view_definition';
 
-	private array $array;
-
-	public function __construct(string $name, array $array)
+	public function __construct(string $name, private array $array)
 	{
 		parent::__construct($name);
-
-		$this->array = $array;
 	}
 
 	public function getArray(): array

--- a/src/Event/CollectRoutesEvent.php
+++ b/src/Event/CollectRoutesEvent.php
@@ -20,13 +20,9 @@ final class CollectRoutesEvent extends Event
 {
 	public const COLLECT_ROUTES = 'friendica.collect_routes';
 
-	private RouteCollector $routeCollector;
-
-	public function __construct(string $name, RouteCollector $routeCollector)
+	public function __construct(string $name, private RouteCollector $routeCollector)
 	{
 		parent::__construct($name);
-
-		$this->routeCollector = $routeCollector;
 	}
 
 	public function getRouteCollector(): RouteCollector

--- a/src/Event/ConfigLoadedEvent.php
+++ b/src/Event/ConfigLoadedEvent.php
@@ -20,13 +20,9 @@ final class ConfigLoadedEvent extends Event
 {
 	public const CONFIG_LOADED = 'friendica.config_loaded';
 
-	private ConfigFileManager $config;
-
-	public function __construct(string $name, ConfigFileManager $config)
+	public function __construct(string $name, private ConfigFileManager $config)
 	{
 		parent::__construct($name);
-
-		$this->config = $config;
 	}
 
 	public function getConfig(): ConfigFileManager

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -23,12 +23,9 @@ class Event implements NamedEvent
 
 	public const HOME_INIT = 'friendica.home_init';
 
-	private string $name;
-
-	public function __construct(string $name)
-	{
-		$this->name = $name;
-	}
+	public function __construct(private string $name)
+				{
+							}
 
 	public function getName(): string
 	{

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -23,9 +23,7 @@ class Event implements NamedEvent
 
 	public const HOME_INIT = 'friendica.home_init';
 
-	public function __construct(private string $name)
-				{
-							}
+	public function __construct(private string $name) {}
 
 	public function getName(): string
 	{

--- a/src/Event/HtmlFilterEvent.php
+++ b/src/Event/HtmlFilterEvent.php
@@ -36,13 +36,9 @@ final class HtmlFilterEvent extends Event
 
 	public const CONTACT_BLOCK_END = 'friendica.html.contact_block_end';
 
-	private string $html;
-
-	public function __construct(string $name, string $html)
+	public function __construct(string $name, private string $html)
 	{
 		parent::__construct($name);
-
-		$this->html = $html;
 	}
 
 	public function getHtml(): string

--- a/src/Factory/Api/Friendica/Activities.php
+++ b/src/Factory/Api/Friendica/Activities.php
@@ -19,7 +19,7 @@ use Friendica\Factory\Api\Twitter\User as TwitterUser;
 class Activities extends BaseFactory
 {
 	public function __construct(LoggerInterface $logger, /** @var twitterUser entity */
-				private TwitterUser $twitterUser)
+		private TwitterUser $twitterUser)
 	{
 		parent::__construct($logger);
 	}

--- a/src/Factory/Api/Friendica/Activities.php
+++ b/src/Factory/Api/Friendica/Activities.php
@@ -18,14 +18,10 @@ use Friendica\Factory\Api\Twitter\User as TwitterUser;
 
 class Activities extends BaseFactory
 {
-	/** @var twitterUser entity */
-	private $twitterUser;
-
-	public function __construct(LoggerInterface $logger, TwitterUser $twitteruser)
+	public function __construct(LoggerInterface $logger, /** @var twitterUser entity */
+				private TwitterUser $twitterUser)
 	{
 		parent::__construct($logger);
-
-		$this->twitterUser = $twitteruser;
 	}
 
 	/**

--- a/src/Factory/Api/Friendica/Circle.php
+++ b/src/Factory/Api/Friendica/Circle.php
@@ -16,7 +16,7 @@ use Friendica\Factory\Api\Twitter\User as TwitterUser;
 class Circle extends BaseFactory
 {
 	public function __construct(LoggerInterface $logger, /** @var twitterUser entity */
-				private TwitterUser $twitterUser, private Database $dba)
+		private TwitterUser $twitterUser, private Database $dba)
 	{
 		parent::__construct($logger);
 	}

--- a/src/Factory/Api/Friendica/Circle.php
+++ b/src/Factory/Api/Friendica/Circle.php
@@ -15,17 +15,10 @@ use Friendica\Factory\Api\Twitter\User as TwitterUser;
 
 class Circle extends BaseFactory
 {
-	/** @var twitterUser entity */
-	private $twitterUser;
-	/** @var Database */
-	private $dba;
-
-	public function __construct(LoggerInterface $logger, TwitterUser $twitteruser, Database $dba)
+	public function __construct(LoggerInterface $logger, /** @var twitterUser entity */
+				private TwitterUser $twitterUser, private Database $dba)
 	{
 		parent::__construct($logger);
-
-		$this->twitterUser = $twitteruser;
-		$this->dba         = $dba;
 	}
 
 	/**

--- a/src/Factory/Api/Friendica/Photo.php
+++ b/src/Factory/Api/Friendica/Photo.php
@@ -20,20 +20,9 @@ use Friendica\Util\Images;
 
 class Photo extends BaseFactory
 {
-	/** @var BaseURL */
-	private $baseUrl;
-	/** @var Status */
-	private $status;
-	/** @var Activities */
-	private $activities;
-
-	public function __construct(LoggerInterface $logger, BaseURL $baseURL, Status $status, Activities $activities)
+	public function __construct(LoggerInterface $logger, private BaseURL $baseUrl, private Status $status, private Activities $activities)
 	{
 		parent::__construct($logger);
-
-		$this->activities = $activities;
-		$this->status     = $status;
-		$this->baseUrl    = $baseURL;
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Account.php
+++ b/src/Factory/Api/Mastodon/Account.php
@@ -23,23 +23,9 @@ use Psr\Log\LoggerInterface;
 
 class Account extends BaseFactory
 {
-	/** @var BaseURL */
-	private $baseUrl;
-	/** @var ProfileFieldRepository */
-	private $profileFieldRepo;
-	/** @var Field */
-	private $mstdnFieldFactory;
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-
-	public function __construct(IManagePersonalConfigValues $pConfig, LoggerInterface $logger, BaseURL $baseURL, ProfileFieldRepository $profileFieldRepo, Field $mstdnFieldFactory)
+	public function __construct(private IManagePersonalConfigValues $pConfig, LoggerInterface $logger, private BaseURL $baseUrl, private ProfileFieldRepository $profileFieldRepo, private Field $mstdnFieldFactory)
 	{
 		parent::__construct($logger);
-
-		$this->baseUrl           = $baseURL;
-		$this->profileFieldRepo  = $profileFieldRepo;
-		$this->mstdnFieldFactory = $mstdnFieldFactory;
-		$this->pConfig           = $pConfig;
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Application.php
+++ b/src/Factory/Api/Mastodon/Application.php
@@ -15,13 +15,9 @@ use Psr\Log\LoggerInterface;
 
 class Application extends BaseFactory
 {
-	/** @var Database */
-	private $dba;
-
-	public function __construct(LoggerInterface $logger, Database $dba)
+	public function __construct(LoggerInterface $logger, private Database $dba)
 	{
 		parent::__construct($logger);
-		$this->dba = $dba;
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Attachment.php
+++ b/src/Factory/Api/Mastodon/Attachment.php
@@ -19,14 +19,9 @@ use Psr\Log\LoggerInterface;
 
 class Attachment extends BaseFactory
 {
-	/** @var BaseURL */
-	private $baseUrl;
-
-	public function __construct(LoggerInterface $logger, BaseURL $baseURL)
+	public function __construct(LoggerInterface $logger, private BaseURL $baseUrl)
 	{
 		parent::__construct($logger);
-
-		$this->baseUrl = $baseURL;
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Conversation.php
+++ b/src/Factory/Api/Mastodon/Conversation.php
@@ -16,19 +16,9 @@ use Psr\Log\LoggerInterface;
 
 class Conversation extends BaseFactory
 {
-	/** @var Database */
-	private $dba;
-	/** @var Status */
-	private $mstdnStatusFactory;
-	/** @var Account */
-	private $mstdnAccountFactory;
-
-	public function __construct(LoggerInterface $logger, Database $dba, Status $mstdnStatusFactory, Account $mstdnAccountFactoryFactory)
+	public function __construct(LoggerInterface $logger, private Database $dba, private Status $mstdnStatusFactory, private Account $mstdnAccountFactory)
 	{
 		parent::__construct($logger);
-		$this->dba                 = $dba;
-		$this->mstdnStatusFactory  = $mstdnStatusFactory;
-		$this->mstdnAccountFactory = $mstdnAccountFactoryFactory;
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Error.php
+++ b/src/Factory/Api/Mastodon/Error.php
@@ -14,13 +14,9 @@ use Psr\Log\LoggerInterface;
 /** @todo A Factory shouldn't return something to the frontpage, it's for creating content, not showing it */
 class Error extends BaseFactory
 {
-	/** @var L10n */
-	private $l10n;
-
-	public function __construct(LoggerInterface $logger, L10n $l10n)
+	public function __construct(LoggerInterface $logger, private L10n $l10n)
 	{
 		parent::__construct($logger);
-		$this->l10n   = $l10n;
 	}
 
 	public function RecordNotFound(): \Friendica\Object\Api\Mastodon\Error

--- a/src/Factory/Api/Mastodon/Error.php
+++ b/src/Factory/Api/Mastodon/Error.php
@@ -35,7 +35,7 @@ class Error extends BaseFactory
 
 	public function Unauthorized(string $error = '', string $error_description = ''): \Friendica\Object\Api\Mastodon\Error
 	{
-		$error             = $error ?: $this->l10n->t('Unauthorized');
+		$error = $error ?: $this->l10n->t('Unauthorized');
 		return new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
 	}
 

--- a/src/Factory/Api/Mastodon/ListEntity.php
+++ b/src/Factory/Api/Mastodon/ListEntity.php
@@ -15,13 +15,9 @@ use Psr\Log\LoggerInterface;
 
 class ListEntity extends BaseFactory
 {
-	/** @var Database */
-	private $dba;
-
-	public function __construct(LoggerInterface $logger, Database $dba)
+	public function __construct(LoggerInterface $logger, private Database $dba)
 	{
 		parent::__construct($logger);
-		$this->dba = $dba;
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Mention.php
+++ b/src/Factory/Api/Mastodon/Mention.php
@@ -17,14 +17,9 @@ use Psr\Log\LoggerInterface;
 
 class Mention extends BaseFactory
 {
-	/** @var BaseURL */
-	private $baseUrl;
-
-	public function __construct(LoggerInterface $logger, BaseURL $baseURL)
+	public function __construct(LoggerInterface $logger, private BaseURL $baseUrl)
 	{
 		parent::__construct($logger);
-
-		$this->baseUrl = $baseURL;
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Notification.php
+++ b/src/Factory/Api/Mastodon/Notification.php
@@ -19,16 +19,9 @@ use Friendica\Model\Post;
 
 class Notification extends BaseFactory
 {
-	/** @var Account */
-	private $mstdnAccountFactory;
-	/** @var Status */
-	private $mstdnStatusFactory;
-
-	public function __construct(LoggerInterface $logger, Account $mstdnAccountFactory, Status $mstdnStatusFactoryFactory)
+	public function __construct(LoggerInterface $logger, private Account $mstdnAccountFactory, private Status $mstdnStatusFactory)
 	{
 		parent::__construct($logger);
-		$this->mstdnAccountFactory = $mstdnAccountFactory;
-		$this->mstdnStatusFactory  = $mstdnStatusFactoryFactory;
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/ScheduledStatus.php
+++ b/src/Factory/Api/Mastodon/ScheduledStatus.php
@@ -48,7 +48,7 @@ class ScheduledStatus extends BaseFactory
 		foreach ($parameters['attachments'] as $attachment) {
 			$id = Photo::getIdForName($attachment['url']);
 
-			$media_ids[]         = (string)$id;
+			$media_ids[]         = (string) $id;
 			$media_attachments[] = DI::mstdnAttachment()->createFromPhoto($id);
 		}
 

--- a/src/Factory/Api/Mastodon/ScheduledStatus.php
+++ b/src/Factory/Api/Mastodon/ScheduledStatus.php
@@ -19,13 +19,9 @@ use Psr\Log\LoggerInterface;
 
 class ScheduledStatus extends BaseFactory
 {
-	/** @var Database */
-	private $dba;
-
-	public function __construct(LoggerInterface $logger, Database $dba)
+	public function __construct(LoggerInterface $logger, private Database $dba)
 	{
 		parent::__construct($logger);
-		$this->dba = $dba;
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -34,54 +34,21 @@ use Psr\Log\LoggerInterface;
 
 class Status extends BaseFactory
 {
-	/** @var Database */
-	private $dba;
-	/** @var Account */
-	private $mstdnAccountFactory;
-	/** @var Mention */
-	private $mstdnMentionFactory;
-	/** @var Tag */
-	private $mstdnTagFactory;
-	/** @var Card */
-	private $mstdnCardFactory;
-	/** @var Attachment */
-	private $mstdnAttachmentFactory;
-	/** @var Emoji */
-	private $mstdnEmojiFactory;
-	/** @var Poll */
-	private $mstdnPollFactory;
-	/** @var ContentItem */
-	private $contentItem;
-	/** @var ACLFormatter */
-	private $aclFormatter;
-	private EventDispatcherInterface $eventDispatcher;
-
 	public function __construct(
-		EventDispatcherInterface $eventDispatcher,
+		private EventDispatcherInterface $eventDispatcher,
 		LoggerInterface $logger,
-		Database $dba,
-		Account $mstdnAccountFactory,
-		Mention $mstdnMentionFactory,
-		Tag $mstdnTagFactory,
-		Card $mstdnCardFactory,
-		Attachment $mstdnAttachmentFactory,
-		Emoji $mstdnEmojiFactory,
-		Poll $mstdnPollFactory,
-		ContentItem $contentItem,
-		ACLFormatter $aclFormatter,
+		private Database $dba,
+		private Account $mstdnAccountFactory,
+		private Mention $mstdnMentionFactory,
+		private Tag $mstdnTagFactory,
+		private Card $mstdnCardFactory,
+		private Attachment $mstdnAttachmentFactory,
+		private Emoji $mstdnEmojiFactory,
+		private Poll $mstdnPollFactory,
+		private ContentItem $contentItem,
+		private ACLFormatter $aclFormatter,
 	) {
 		parent::__construct($logger);
-		$this->dba                    = $dba;
-		$this->mstdnAccountFactory    = $mstdnAccountFactory;
-		$this->mstdnMentionFactory    = $mstdnMentionFactory;
-		$this->mstdnTagFactory        = $mstdnTagFactory;
-		$this->mstdnCardFactory       = $mstdnCardFactory;
-		$this->mstdnAttachmentFactory = $mstdnAttachmentFactory;
-		$this->mstdnEmojiFactory      = $mstdnEmojiFactory;
-		$this->mstdnPollFactory       = $mstdnPollFactory;
-		$this->contentItem            = $contentItem;
-		$this->aclFormatter           = $aclFormatter;
-		$this->eventDispatcher        = $eventDispatcher;
 	}
 
 	/**

--- a/src/Factory/Api/Mastodon/Tag.php
+++ b/src/Factory/Api/Mastodon/Tag.php
@@ -15,14 +15,9 @@ use Psr\Log\LoggerInterface;
 
 class Tag extends BaseFactory
 {
-	/** @var BaseURL */
-	private $baseUrl;
-
-	public function __construct(LoggerInterface $logger, BaseURL $baseURL)
+	public function __construct(LoggerInterface $logger, private BaseURL $baseUrl)
 	{
 		parent::__construct($logger);
-
-		$this->baseUrl = $baseURL;
 	}
 
 	/**

--- a/src/Factory/Api/Twitter/DirectMessage.php
+++ b/src/Factory/Api/Twitter/DirectMessage.php
@@ -18,16 +18,10 @@ use Psr\Log\LoggerInterface;
 
 class DirectMessage extends BaseFactory
 {
-	/** @var Database */
-	private $dba;
-	/** @var twitterUser entity */
-	private $twitterUser;
-
-	public function __construct(LoggerInterface $logger, Database $dba, TwitterUser $twitteruser)
+	public function __construct(LoggerInterface $logger, private Database $dba, /** @var twitterUser entity */
+				private TwitterUser $twitterUser)
 	{
 		parent::__construct($logger);
-		$this->dba         = $dba;
-		$this->twitterUser = $twitteruser;
 	}
 
 	/**

--- a/src/Factory/Api/Twitter/DirectMessage.php
+++ b/src/Factory/Api/Twitter/DirectMessage.php
@@ -19,7 +19,7 @@ use Psr\Log\LoggerInterface;
 class DirectMessage extends BaseFactory
 {
 	public function __construct(LoggerInterface $logger, private Database $dba, /** @var twitterUser entity */
-				private TwitterUser $twitterUser)
+		private TwitterUser $twitterUser)
 	{
 		parent::__construct($logger);
 	}
@@ -53,7 +53,7 @@ class DirectMessage extends BaseFactory
 				$text = HTML::toPlaintext(BBCode::convertForUriId($mail['uri-id'], $mail['body'], BBCode::TWITTER_API), 0);
 			}
 		} else {
-			$text  = $mail['title'] . "\n" . HTML::toPlaintext(BBCode::convertForUriId($mail['uri-id'], $mail['body'], BBCode::TWITTER_API), 0);
+			$text = $mail['title'] . "\n" . HTML::toPlaintext(BBCode::convertForUriId($mail['uri-id'], $mail['body'], BBCode::TWITTER_API), 0);
 		}
 
 		$pcid = Contact::getPublicIdByUserId($uid);

--- a/src/Factory/Api/Twitter/Media.php
+++ b/src/Factory/Api/Twitter/Media.php
@@ -15,14 +15,9 @@ use Psr\Log\LoggerInterface;
 
 class Media extends BaseFactory
 {
-	/** @var BaseURL */
-	private $baseUrl;
-
-	public function __construct(LoggerInterface $logger, BaseURL $baseURL)
+	public function __construct(LoggerInterface $logger, private BaseURL $baseUrl)
 	{
 		parent::__construct($logger);
-
-		$this->baseUrl = $baseURL;
 	}
 
 	/**

--- a/src/Factory/Api/Twitter/Mention.php
+++ b/src/Factory/Api/Twitter/Mention.php
@@ -16,14 +16,9 @@ use Psr\Log\LoggerInterface;
 
 class Mention extends BaseFactory
 {
-	/** @var BaseURL */
-	private $baseUrl;
-
-	public function __construct(LoggerInterface $logger, BaseURL $baseURL)
+	public function __construct(LoggerInterface $logger, private BaseURL $baseUrl)
 	{
 		parent::__construct($logger);
-
-		$this->baseUrl = $baseURL;
 	}
 
 	/**

--- a/src/Factory/Api/Twitter/Status.php
+++ b/src/Factory/Api/Twitter/Status.php
@@ -26,13 +26,13 @@ use Psr\Log\LoggerInterface;
 class Status extends BaseFactory
 {
 	public function __construct(LoggerInterface $logger, private Database $dba, /** @var twitterUser entity */
-				private TwitterUser $twitterUser, /** @var Hashtag entity */
-				private Hashtag $hashtag, /** @var Media entity */
-				private Media $media, /** @var Url entity */
-				private Url $url, /** @var Mention entity */
-				private Mention $mention, /** @var Activities entity */
-				private Activities $activities, /** @var Attachment entity */
-				private Attachment $attachment, private ContentItem $contentItem)
+		private TwitterUser $twitterUser, /** @var Hashtag entity */
+		private Hashtag $hashtag, /** @var Media entity */
+		private Media $media, /** @var Url entity */
+		private Url $url, /** @var Mention entity */
+		private Mention $mention, /** @var Activities entity */
+		private Activities $activities, /** @var Attachment entity */
+		private Attachment $attachment, private ContentItem $contentItem)
 	{
 		parent::__construct($logger);
 	}
@@ -124,7 +124,7 @@ class Status extends BaseFactory
 			if (count($coords) == 2) {
 				$geo = [
 					'type'        => 'Point',
-					'coordinates' => [(float) $coords[0], (float) $coords[1]]
+					'coordinates' => [(float) $coords[0], (float) $coords[1]],
 				];
 			}
 		}
@@ -135,7 +135,7 @@ class Status extends BaseFactory
 			'origin'        => true,
 			'gravity'       => Item::GRAVITY_ACTIVITY,
 			'vid'           => Verb::getID(Activity::LIKE),
-			'deleted'       => false
+			'deleted'       => false,
 		]);
 
 		if ($include_entities) {

--- a/src/Factory/Api/Twitter/Status.php
+++ b/src/Factory/Api/Twitter/Status.php
@@ -25,37 +25,16 @@ use Psr\Log\LoggerInterface;
 
 class Status extends BaseFactory
 {
-	/** @var Database */
-	private $dba;
-	/** @var twitterUser entity */
-	private $twitterUser;
-	/** @var Hashtag entity */
-	private $hashtag;
-	/** @var Media entity */
-	private $media;
-	/** @var Url entity */
-	private $url;
-	/** @var Mention entity */
-	private $mention;
-	/** @var Activities entity */
-	private $activities;
-	/** @var Attachment entity */
-	private $attachment;
-	/** @var ContentItem */
-	private $contentItem;
-
-	public function __construct(LoggerInterface $logger, Database $dba, TwitterUser $twitteruser, Hashtag $hashtag, Media $media, Url $url, Mention $mention, Activities $activities, Attachment $attachment, ContentItem $contentItem)
+	public function __construct(LoggerInterface $logger, private Database $dba, /** @var twitterUser entity */
+				private TwitterUser $twitterUser, /** @var Hashtag entity */
+				private Hashtag $hashtag, /** @var Media entity */
+				private Media $media, /** @var Url entity */
+				private Url $url, /** @var Mention entity */
+				private Mention $mention, /** @var Activities entity */
+				private Activities $activities, /** @var Attachment entity */
+				private Attachment $attachment, private ContentItem $contentItem)
 	{
 		parent::__construct($logger);
-		$this->dba         = $dba;
-		$this->twitterUser = $twitteruser;
-		$this->hashtag     = $hashtag;
-		$this->media       = $media;
-		$this->url         = $url;
-		$this->mention     = $mention;
-		$this->activities  = $activities;
-		$this->attachment  = $attachment;
-		$this->contentItem = $contentItem;
 	}
 
 	/**

--- a/src/Factory/Api/Twitter/User.php
+++ b/src/Factory/Api/Twitter/User.php
@@ -17,13 +17,10 @@ use Psr\Log\LoggerInterface;
 
 class User extends BaseFactory
 {
-	/** @var Status entity */
-	private $status;
-
-	public function __construct(LoggerInterface $logger, Status $status)
+	public function __construct(LoggerInterface $logger, /** @var Status entity */
+				private Status $status)
 	{
 		parent::__construct($logger);
-		$this->status = $status;
 
 	}
 

--- a/src/Factory/Api/Twitter/User.php
+++ b/src/Factory/Api/Twitter/User.php
@@ -18,7 +18,7 @@ use Psr\Log\LoggerInterface;
 class User extends BaseFactory
 {
 	public function __construct(LoggerInterface $logger, /** @var Status entity */
-				private Status $status)
+		private Status $status)
 	{
 		parent::__construct($logger);
 
@@ -39,10 +39,10 @@ class User extends BaseFactory
 		$cdata = Contact::getPublicAndUserContactID($contactId, $uid);
 		if (!empty($cdata)) {
 			$publicContact = Contact::getById($cdata['public']);
-			$userContact = Contact::getById($cdata['user']);
+			$userContact   = Contact::getById($cdata['user']);
 		} else {
 			$publicContact = Contact::getById($contactId);
-			$userContact = [];
+			$userContact   = [];
 		}
 
 		$apcontact = APContact::getByURL($publicContact['url'], false);
@@ -50,9 +50,11 @@ class User extends BaseFactory
 		$status = null;
 
 		if (!$skip_status) {
-			$post = Post::selectFirstPost(['uri-id'],
-				['author-id' => $publicContact['id'], 'gravity' => [Item::GRAVITY_COMMENT, Item::GRAVITY_PARENT], 'private'  => [Item::PUBLIC, Item::UNLISTED]],
-				['order' => ['uri-id' => true]]);
+			$post = Post::selectFirstPost(
+				['uri-id'],
+				['author-id' => $publicContact['id'], 'gravity' => [Item::GRAVITY_COMMENT, Item::GRAVITY_PARENT], 'private' => [Item::PUBLIC, Item::UNLISTED]],
+				['order'     => ['uri-id' => true]],
+			);
 			if (!empty($post['uri-id'])) {
 				$status = $this->status->createFromUriId($post['uri-id'], $uid);
 			}

--- a/src/Federation/Entity/DeliveryQueueAggregate.php
+++ b/src/Federation/Entity/DeliveryQueueAggregate.php
@@ -13,14 +13,7 @@ namespace Friendica\Federation\Entity;
  */
 final class DeliveryQueueAggregate extends \Friendica\BaseEntity
 {
-	/** @var int */
-	protected $targetServerId;
-	/** @var int */
-	protected $failed;
-
-	public function __construct(int $targetServerId, int $failed)
-	{
-		$this->targetServerId = $targetServerId;
-		$this->failed         = $failed;
-	}
+	public function __construct(protected int $targetServerId, protected int $failed)
+				{
+							}
 }

--- a/src/Federation/Entity/DeliveryQueueAggregate.php
+++ b/src/Federation/Entity/DeliveryQueueAggregate.php
@@ -13,7 +13,5 @@ namespace Friendica\Federation\Entity;
  */
 final class DeliveryQueueAggregate extends \Friendica\BaseEntity
 {
-	public function __construct(protected int $targetServerId, protected int $failed)
-				{
-							}
+	public function __construct(protected int $targetServerId, protected int $failed) {}
 }

--- a/src/Federation/Entity/DeliveryQueueItem.php
+++ b/src/Federation/Entity/DeliveryQueueItem.php
@@ -20,29 +20,7 @@ use DateTimeImmutable;
  */
 final class DeliveryQueueItem extends \Friendica\BaseEntity
 {
-	/** @var int */
-	protected $targetServerId;
-	/** @var int */
-	protected $postUriId;
-	/** @var DateTimeImmutable */
-	protected $created;
-	/** @var string */
-	protected $command;
-	/** @var int */
-	protected $targetContactId;
-	/** @var int */
-	protected $senderUserId;
-	/** @var int */
-	protected $failed;
-
-	public function __construct(int $targetServerId, int $postUriId, DateTimeImmutable $created, string $command, int $targetContactId, int $senderUserId, int $failed = 0)
-	{
-		$this->targetServerId  = $targetServerId;
-		$this->postUriId       = $postUriId;
-		$this->created         = $created;
-		$this->command         = $command;
-		$this->targetContactId = $targetContactId;
-		$this->senderUserId    = $senderUserId;
-		$this->failed          = $failed;
-	}
+	public function __construct(protected int $targetServerId, protected int $postUriId, protected DateTimeImmutable $created, protected string $command, protected int $targetContactId, protected int $senderUserId, protected int $failed = 0)
+				{
+							}
 }

--- a/src/Federation/Entity/DeliveryQueueItem.php
+++ b/src/Federation/Entity/DeliveryQueueItem.php
@@ -20,7 +20,5 @@ use DateTimeImmutable;
  */
 final class DeliveryQueueItem extends \Friendica\BaseEntity
 {
-	public function __construct(protected int $targetServerId, protected int $postUriId, protected DateTimeImmutable $created, protected string $command, protected int $targetContactId, protected int $senderUserId, protected int $failed = 0)
-				{
-							}
+	public function __construct(protected int $targetServerId, protected int $postUriId, protected DateTimeImmutable $created, protected string $command, protected int $targetContactId, protected int $senderUserId, protected int $failed = 0) {}
 }

--- a/src/Federation/Repository/GServer.php
+++ b/src/Federation/Repository/GServer.php
@@ -16,15 +16,9 @@ final class GServer
 {
 	private string $table_name = 'gserver';
 
-	private Database $db;
-
-	private GServerFactory $factory;
-
-	public function __construct(Database $database, GServerFactory $factory)
-	{
-		$this->db      = $database;
-		$this->factory = $factory;
-	}
+	public function __construct(private Database $db, private GServerFactory $factory)
+				{
+							}
 
 	/**
 	 * @param int $gsid

--- a/src/Federation/Repository/GServer.php
+++ b/src/Federation/Repository/GServer.php
@@ -16,9 +16,7 @@ final class GServer
 {
 	private string $table_name = 'gserver';
 
-	public function __construct(private Database $db, private GServerFactory $factory)
-				{
-							}
+	public function __construct(private Database $db, private GServerFactory $factory) {}
 
 	/**
 	 * @param int $gsid

--- a/src/Model/ItemHelper.php
+++ b/src/Model/ItemHelper.php
@@ -24,27 +24,15 @@ use Psr\Log\LoggerInterface;
  */
 final class ItemHelper
 {
-	private ItemContent $itemContent;
-
-	private Activity $activity;
-
-	private LoggerInterface $logger;
-
-	private Database $database;
-
 	private string $baseUrl;
 
 	public function __construct(
-		ItemContent $itemContent,
-		Activity $activity,
-		LoggerInterface $logger,
-		Database $database,
+		private ItemContent $itemContent,
+		private Activity $activity,
+		private LoggerInterface $logger,
+		private Database $database,
 		BaseURL $baseURL
 	) {
-		$this->itemContent = $itemContent;
-		$this->activity    = $activity;
-		$this->logger      = $logger;
-		$this->database    = $database;
 		$this->baseUrl     = $baseURL->__toString();
 	}
 

--- a/src/Model/ItemHelper.php
+++ b/src/Model/ItemHelper.php
@@ -31,9 +31,9 @@ final class ItemHelper
 		private Activity $activity,
 		private LoggerInterface $logger,
 		private Database $database,
-		BaseURL $baseURL
+		BaseURL $baseURL,
 	) {
-		$this->baseUrl     = $baseURL->__toString();
+		$this->baseUrl = $baseURL->__toString();
 	}
 
 	public function prepareOriginPost(array $item): array

--- a/src/Model/Log/ParsedLogIterator.php
+++ b/src/Model/Log/ParsedLogIterator.php
@@ -30,9 +30,7 @@ class ParsedLogIterator implements \Iterator
 	/** @var string search term */
 	private $search = '';
 
-	public function __construct(private ReversedFileReader $reader)
-				{
-							}
+	public function __construct(private ReversedFileReader $reader) {}
 
 	/**
 	 * @param string $filename	File to open

--- a/src/Model/Log/ParsedLogIterator.php
+++ b/src/Model/Log/ParsedLogIterator.php
@@ -18,9 +18,6 @@ use Friendica\Object\Log\ParsedLogLine;
  */
 class ParsedLogIterator implements \Iterator
 {
-	/** @var ReversedFileReader */
-	private $reader;
-
 	/** @var ParsedLogLine|null current iterator value*/
 	private $value = null;
 
@@ -33,10 +30,9 @@ class ParsedLogIterator implements \Iterator
 	/** @var string search term */
 	private $search = '';
 
-	public function __construct(ReversedFileReader $reader)
-	{
-		$this->reader = $reader;
-	}
+	public function __construct(private ReversedFileReader $reader)
+				{
+							}
 
 	/**
 	 * @param string $filename	File to open

--- a/src/Moderation/DomainPatternBlocklist.php
+++ b/src/Moderation/DomainPatternBlocklist.php
@@ -9,16 +9,10 @@ namespace Friendica\Moderation;
 
 use Exception;
 use Friendica\Core\Config\Capability\IManageConfigValues;
-use Friendica\Core\L10n;
-use Friendica\Database\Database;
-use Friendica\Network\HTTPException;
-use Friendica\Util\Emailer;
 
 class DomainPatternBlocklist
 {
-	public function __construct(private IManageConfigValues $config)
-				{
-							}
+	public function __construct(private IManageConfigValues $config) {}
 
 	public function get(): array
 	{

--- a/src/Moderation/DomainPatternBlocklist.php
+++ b/src/Moderation/DomainPatternBlocklist.php
@@ -16,13 +16,9 @@ use Friendica\Util\Emailer;
 
 class DomainPatternBlocklist
 {
-	/** @var IManageConfigValues */
-	private $config;
-
-	public function __construct(IManageConfigValues $config)
-	{
-		$this->config = $config;
-	}
+	public function __construct(private IManageConfigValues $config)
+				{
+							}
 
 	public function get(): array
 	{

--- a/src/Moderation/Entity/Report.php
+++ b/src/Moderation/Entity/Report.php
@@ -59,40 +59,40 @@ final class Report extends \Friendica\BaseEntity
 
 	public function __construct(
 		/** @var int ID of the contact making a moderation report */
-								protected int $reporterCid,
+		protected int $reporterCid,
 		/** @var int ID of the contact being reported */
-								protected int $cid,
+		protected int $cid,
 		/** @var int ID of the gserver of the contact being reported */
-								protected int $gsid,
+		protected int $gsid,
 		/** @var \DateTimeImmutable When the report was created */
-								protected \DateTimeImmutable $created,
+		protected \DateTimeImmutable $created,
 		/** @var int One of CATEGORY_* */
-								protected int $category,
+		protected int $category,
 		/** @var int ID of the user making a moderation report, null in case of an incoming forwarded report */
-								protected ?int $reporterUid = null,
+		protected ?int $reporterUid = null,
 		/** @var string Reporter comment */
-								protected string $comment = '',
+		protected string $comment = '',
 		/** @var bool Whether this report should be forwarded to the remote server */
-								protected bool $forward = false,
+		protected bool $forward = false,
 		Collection\Report\Posts $posts = null,
 		Collection\Report\Rules $rules = null,
 		/** @var string Remarks shared with the reporter */
-								protected string $publicRemarks = '',
+		protected string $publicRemarks = '',
 		/** @var string Remarks shared with the moderation team */
-								protected string $privateRemarks = '',
+		protected string $privateRemarks = '',
 		/** @var \DateTimeImmutable|null When the report was last edited */
-								protected ?\DateTimeImmutable $edited = null,
+		protected ?\DateTimeImmutable $edited = null,
 		/** @var int One of STATUS_* */
-								protected int $status = self::STATUS_OPEN,
+		protected int $status = self::STATUS_OPEN,
 		/** @var int|null One of RESOLUTION_* if any */
-								protected ?int $resolution = null,
+		protected ?int $resolution = null,
 		/** @var int|null Assigned moderator user id if any */
-								protected ?int $assignedUid = null,
+		protected ?int $assignedUid = null,
 		/** @var int|null Last editor user ID if any */
-								protected ?int $lastEditorUid = null,
-		protected ?int $id = null
+		protected ?int $lastEditorUid = null,
+		protected ?int $id = null,
 	) {
-		$this->posts          = $posts ?? new Collection\Report\Posts();
-		$this->rules          = $rules ?? new Collection\Report\Rules();
+		$this->posts = $posts ?? new Collection\Report\Posts();
+		$this->rules = $rules ?? new Collection\Report\Rules();
 	}
 }

--- a/src/Moderation/Entity/Report.php
+++ b/src/Moderation/Entity/Report.php
@@ -52,81 +52,47 @@ final class Report extends \Friendica\BaseEntity
 
 	public const RESOLUTION_ACCEPTED = 0;
 	public const RESOLUTION_REJECTED = 1;
-
-	/** @var int|null */
-	protected $id;
-	/** @var int ID of the contact making a moderation report */
-	protected $reporterCid;
-	/** @var int ID of the contact being reported */
-	protected $cid;
-	/** @var int ID of the gserver of the contact being reported */
-	protected $gsid;
-	/** @var string Reporter comment */
-	protected $comment;
-	/** @var int One of CATEGORY_* */
-	protected $category;
-	/** @var int ID of the user making a moderation report, null in case of an incoming forwarded report */
-	protected $reporterUid;
-	/** @var bool Whether this report should be forwarded to the remote server */
-	protected $forward;
-	/** @var \DateTimeImmutable When the report was created */
-	protected $created;
 	/** @var Collection\Report\Rules List of terms of service rule lines being possibly violated */
 	protected $rules;
 	/** @var Collection\Report\Posts List of URI IDs of posts supporting the report */
 	protected $posts;
-	/** @var string Remarks shared with the reporter */
-	protected $publicRemarks;
-	/** @var string Remarks shared with the moderation team */
-	protected $privateRemarks;
-	/** @var \DateTimeImmutable|null When the report was last edited */
-	protected $edited;
-	/** @var int One of STATUS_* */
-	protected $status;
-	/** @var int|null One of RESOLUTION_* if any */
-	protected $resolution;
-	/** @var int|null Assigned moderator user id if any */
-	protected $assignedUid;
-	/** @var int|null Last editor user ID if any */
-	protected $lastEditorUid;
 
 	public function __construct(
-		int $reporterCid,
-		int $cid,
-		int $gsid,
-		\DateTimeImmutable $created,
-		int $category,
-		int $reporterUid = null,
-		string $comment = '',
-		bool $forward = false,
+		/** @var int ID of the contact making a moderation report */
+								protected int $reporterCid,
+		/** @var int ID of the contact being reported */
+								protected int $cid,
+		/** @var int ID of the gserver of the contact being reported */
+								protected int $gsid,
+		/** @var \DateTimeImmutable When the report was created */
+								protected \DateTimeImmutable $created,
+		/** @var int One of CATEGORY_* */
+								protected int $category,
+		/** @var int ID of the user making a moderation report, null in case of an incoming forwarded report */
+								protected ?int $reporterUid = null,
+		/** @var string Reporter comment */
+								protected string $comment = '',
+		/** @var bool Whether this report should be forwarded to the remote server */
+								protected bool $forward = false,
 		Collection\Report\Posts $posts = null,
 		Collection\Report\Rules $rules = null,
-		string $publicRemarks = '',
-		string $privateRemarks = '',
-		\DateTimeImmutable $edited = null,
-		int $status = self::STATUS_OPEN,
-		int $resolution = null,
-		int $assignedUid = null,
-		int $lastEditorUid = null,
-		int $id = null
+		/** @var string Remarks shared with the reporter */
+								protected string $publicRemarks = '',
+		/** @var string Remarks shared with the moderation team */
+								protected string $privateRemarks = '',
+		/** @var \DateTimeImmutable|null When the report was last edited */
+								protected ?\DateTimeImmutable $edited = null,
+		/** @var int One of STATUS_* */
+								protected int $status = self::STATUS_OPEN,
+		/** @var int|null One of RESOLUTION_* if any */
+								protected ?int $resolution = null,
+		/** @var int|null Assigned moderator user id if any */
+								protected ?int $assignedUid = null,
+		/** @var int|null Last editor user ID if any */
+								protected ?int $lastEditorUid = null,
+		protected ?int $id = null
 	) {
-		$this->reporterCid    = $reporterCid;
-		$this->cid            = $cid;
-		$this->gsid           = $gsid;
-		$this->created        = $created;
-		$this->category       = $category;
-		$this->reporterUid    = $reporterUid;
-		$this->comment        = $comment;
-		$this->forward        = $forward;
 		$this->posts          = $posts ?? new Collection\Report\Posts();
 		$this->rules          = $rules ?? new Collection\Report\Rules();
-		$this->publicRemarks  = $publicRemarks;
-		$this->privateRemarks = $privateRemarks;
-		$this->edited         = $edited;
-		$this->status         = $status;
-		$this->resolution     = $resolution;
-		$this->assignedUid    = $assignedUid;
-		$this->lastEditorUid  = $lastEditorUid;
-		$this->id             = $id;
 	}
 }

--- a/src/Moderation/Entity/Report/Post.php
+++ b/src/Moderation/Entity/Report/Post.php
@@ -17,14 +17,7 @@ final class Post extends \Friendica\BaseEntity
 	const STATUS_UNLISTED  = 1;
 	const STATUS_DELETED   = 2;
 
-	/** @var int */
-	protected $uriId;
-	/** @var int|null */
-	protected $status;
-
-	public function __construct(int $uriId, int $status = self::STATUS_NO_ACTION)
-	{
-		$this->uriId  = $uriId;
-		$this->status = $status;
-	}
+	public function __construct(protected int $uriId, protected int $status = self::STATUS_NO_ACTION)
+				{
+							}
 }

--- a/src/Moderation/Entity/Report/Post.php
+++ b/src/Moderation/Entity/Report/Post.php
@@ -13,11 +13,9 @@ namespace Friendica\Moderation\Entity\Report;
  */
 final class Post extends \Friendica\BaseEntity
 {
-	const STATUS_NO_ACTION = 0;
-	const STATUS_UNLISTED  = 1;
-	const STATUS_DELETED   = 2;
+	public const STATUS_NO_ACTION = 0;
+	public const STATUS_UNLISTED  = 1;
+	public const STATUS_DELETED   = 2;
 
-	public function __construct(protected int $uriId, protected int $status = self::STATUS_NO_ACTION)
-				{
-							}
+	public function __construct(protected int $uriId, protected int $status = self::STATUS_NO_ACTION) {}
 }

--- a/src/Moderation/Entity/Report/Rule.php
+++ b/src/Moderation/Entity/Report/Rule.php
@@ -13,14 +13,7 @@ namespace Friendica\Moderation\Entity\Report;
  */
 final class Rule extends \Friendica\BaseEntity
 {
-	/** @var int */
-	protected $lineId;
-	/** @var string */
-	protected $text;
-
-	public function __construct(int $lineId, string $text)
-	{
-		$this->lineId = $lineId;
-		$this->text   = $text;
-	}
+	public function __construct(protected int $lineId, protected string $text)
+				{
+							}
 }

--- a/src/Moderation/Entity/Report/Rule.php
+++ b/src/Moderation/Entity/Report/Rule.php
@@ -13,7 +13,5 @@ namespace Friendica\Moderation\Entity\Report;
  */
 final class Rule extends \Friendica\BaseEntity
 {
-	public function __construct(protected int $lineId, protected string $text)
-				{
-							}
+	public function __construct(protected int $lineId, protected string $text) {}
 }

--- a/src/Moderation/Factory/Report.php
+++ b/src/Moderation/Factory/Report.php
@@ -17,14 +17,9 @@ use Psr\Log\LoggerInterface;
 
 class Report extends \Friendica\BaseFactory implements ICanCreateFromTableRow
 {
-	/** @var ClockInterface */
-	private $clock;
-
-	public function __construct(LoggerInterface $logger, ClockInterface $clock)
+	public function __construct(LoggerInterface $logger, private ClockInterface $clock)
 	{
 		parent::__construct($logger);
-
-		$this->clock = $clock;
 	}
 
 	/**

--- a/src/Moderation/Repository/Report.php
+++ b/src/Moderation/Repository/Report.php
@@ -25,18 +25,12 @@ final class Report extends \Friendica\BaseRepository
 
 	/** @var ReportFactory */
 	protected $factory;
-	/** @var PostFactory */
-	protected $postFactory;
-	/** @var RuleFactory */
-	protected $ruleFactory;
 
-	public function __construct(Database $database, LoggerInterface $logger, ReportFactory $factory, PostFactory $postFactory, RuleFactory $ruleFactory)
+	public function __construct(Database $database, LoggerInterface $logger, ReportFactory $factory, protected PostFactory $postFactory, protected RuleFactory $ruleFactory)
 	{
 		parent::__construct($database, $logger, $factory);
 
 		$this->factory     = $factory;
-		$this->postFactory = $postFactory;
-		$this->ruleFactory = $ruleFactory;
 	}
 
 	public function selectOneById(int $lastInsertId): ReportEntity

--- a/src/Moderation/Repository/Report.php
+++ b/src/Moderation/Repository/Report.php
@@ -30,7 +30,7 @@ final class Report extends \Friendica\BaseRepository
 	{
 		parent::__construct($database, $logger, $factory);
 
-		$this->factory     = $factory;
+		$this->factory = $factory;
 	}
 
 	public function selectOneById(int $lastInsertId): ReportEntity

--- a/src/Module/Api/Friendica/DirectMessages/Search.php
+++ b/src/Module/Api/Friendica/DirectMessages/Search.php
@@ -26,18 +26,9 @@ use Psr\Log\LoggerInterface;
  */
 class Search extends BaseApi
 {
-	/** @var Database */
-	private $dba;
-
-	/** @var DirectMessage */
-	private $directMessage;
-
-	public function __construct(DirectMessage $directMessage, Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private DirectMessage $directMessage, private Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->dba           = $dba;
-		$this->directMessage = $directMessage;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Api/Friendica/Photo.php
+++ b/src/Module/Api/Friendica/Photo.php
@@ -21,15 +21,9 @@ use Psr\Log\LoggerInterface;
 
 class Photo extends BaseApi
 {
-	/** @var FriendicaPhoto */
-	private $friendicaPhoto;
-
-
-	public function __construct(FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->friendicaPhoto = $friendicaPhoto;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Api/Friendica/Photo/Create.php
+++ b/src/Module/Api/Friendica/Photo/Create.php
@@ -25,15 +25,9 @@ use Psr\Log\LoggerInterface;
  */
 class Create extends BaseApi
 {
-	/** @var FriendicaPhoto */
-	private $friendicaPhoto;
-
-
-	public function __construct(FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->friendicaPhoto = $friendicaPhoto;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Api/Friendica/Photo/Lists.php
+++ b/src/Module/Api/Friendica/Photo/Lists.php
@@ -27,15 +27,9 @@ use Psr\Log\LoggerInterface;
  */
 class Lists extends BaseApi
 {
-	/** @var FriendicaPhoto */
-	private $friendicaPhoto;
-
-
-	public function __construct(FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->friendicaPhoto = $friendicaPhoto;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Api/Friendica/Photo/Lists.php
+++ b/src/Module/Api/Friendica/Photo/Lists.php
@@ -38,8 +38,11 @@ class Lists extends BaseApi
 		$uid  = BaseApi::getCurrentUserID();
 		$type = $this->getRequestValue($this->parameters, 'extension', 'json');
 
-		$photos = Photo::selectToArray(['resource-id'], ["`uid` = ? AND NOT `photo-type` IN (?, ?)", $uid, Photo::CONTACT_AVATAR, Photo::CONTACT_BANNER],
-			['order' => ['id'], 'group_by' => ['resource-id']]);
+		$photos = Photo::selectToArray(
+			['resource-id'],
+			["`uid` = ? AND NOT `photo-type` IN (?, ?)", $uid, Photo::CONTACT_AVATAR, Photo::CONTACT_BANNER],
+			['order' => ['id'], 'group_by' => ['resource-id']],
+		);
 
 		$data = ['photo' => []];
 		if (DBA::isResult($photos)) {

--- a/src/Module/Api/Friendica/Photo/Update.php
+++ b/src/Module/Api/Friendica/Photo/Update.php
@@ -25,15 +25,9 @@ use Psr\Log\LoggerInterface;
  */
 class Update extends BaseApi
 {
-	/** @var FriendicaPhoto */
-	private $friendicaPhoto;
-
-
-	public function __construct(FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->friendicaPhoto = $friendicaPhoto;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Api/Friendica/Photoalbum/Show.php
+++ b/src/Module/Api/Friendica/Photoalbum/Show.php
@@ -27,15 +27,9 @@ use Psr\Log\LoggerInterface;
  */
 class Show extends BaseApi
 {
-	/** @var FriendicaPhoto */
-	private $friendicaPhoto;
-
-
-	public function __construct(FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private FriendicaPhoto $friendicaPhoto, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->friendicaPhoto = $friendicaPhoto;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Api/Mastodon/Instance.php
+++ b/src/Module/Api/Mastodon/Instance.php
@@ -30,22 +30,9 @@ use Psr\Log\LoggerInterface;
  */
 class Instance extends BaseApi
 {
-	/** @var Database */
-	private $database;
-
-	/** @var IManageConfigValues */
-	private $config;
-
-	/** @var AccountFactory */
-	private $accountFactory;
-
-	public function __construct(AccountFactory $accountFactory, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, Database $database, IManageConfigValues $config, array $server, array $parameters = [])
+	public function __construct(private AccountFactory $accountFactory, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, private Database $database, private IManageConfigValues $config, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->database = $database;
-		$this->config = $config;
-		$this->accountFactory = $accountFactory;
 	}
 
 	/**

--- a/src/Module/Api/Mastodon/Instance.php
+++ b/src/Module/Api/Mastodon/Instance.php
@@ -45,7 +45,7 @@ class Instance extends BaseApi
 	{
 		$administrator = User::getFirstAdmin(['nickname']);
 		if ($administrator) {
-			$adminContact = $this->database->selectFirst('contact', ['uri-id'], ['nick' => $administrator['nickname'], 'self' => true]);
+			$adminContact    = $this->database->selectFirst('contact', ['uri-id'], ['nick' => $administrator['nickname'], 'self' => true]);
 			$contact_account = $this->accountFactory->createFromUriId($adminContact['uri-id']);
 		}
 
@@ -54,10 +54,10 @@ class Instance extends BaseApi
 
 	private function buildConfigurationInfo(): InstanceV2Entity\Configuration
 	{
-		$statuses_config = new InstanceV2Entity\StatusesConfig((int)$this->config->get(
+		$statuses_config = new InstanceV2Entity\StatusesConfig((int) $this->config->get(
 			'config',
 			'api_import_size',
-			$this->config->get('config', 'max_import_size')
+			$this->config->get('config', 'max_import_size'),
 		), 99, 23);
 
 		$image_size_limit = Strings::getBytesFromShorthand($this->config->get('system', 'maximagesize') ?? 0);

--- a/src/Module/Api/Mastodon/Instance/ExtendedDescription.php
+++ b/src/Module/Api/Mastodon/Instance/ExtendedDescription.php
@@ -26,13 +26,9 @@ use Psr\Log\LoggerInterface;
  */
 class ExtendedDescription extends BaseApi
 {
-	private IManageConfigValues $config;
-
-	public function __construct(\Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, IManageConfigValues $config, array $server, array $parameters = [])
+	public function __construct(\Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, private IManageConfigValues $config, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config = $config;
 	}
 
 	/**

--- a/src/Module/Api/Mastodon/InstanceV2.php
+++ b/src/Module/Api/Mastodon/InstanceV2.php
@@ -33,12 +33,6 @@ use Psr\Log\LoggerInterface;
  */
 class InstanceV2 extends BaseApi
 {
-	/** @var Database */
-	private $database;
-
-	/** @var IManageConfigValues */
-	private $config;
-
 	/** @var Header */
 	private $contactHeader;
 
@@ -51,16 +45,13 @@ class InstanceV2 extends BaseApi
 		LoggerInterface $logger,
 		Profiler $profiler,
 		ApiResponse $response,
-		Database $database,
-		IManageConfigValues $config,
+		private Database $database,
+		private IManageConfigValues $config,
 		array $server,
 		array $parameters = []
 	) {
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->database      = $database;
-		$this->config        = $config;
-		$this->contactHeader = new Header($config);
+		$this->contactHeader = new Header($this->config);
 	}
 
 	/**

--- a/src/Module/Api/Mastodon/InstanceV2.php
+++ b/src/Module/Api/Mastodon/InstanceV2.php
@@ -48,7 +48,7 @@ class InstanceV2 extends BaseApi
 		private Database $database,
 		private IManageConfigValues $config,
 		array $server,
-		array $parameters = []
+		array $parameters = [],
 	) {
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 		$this->contactHeader = new Header($this->config);
@@ -89,16 +89,16 @@ class InstanceV2 extends BaseApi
 			$registration,
 			$contact,
 			$friendica_extensions,
-			$rules
+			$rules,
 		));
 	}
 
 	private function buildConfigurationInfo(): InstanceEntity\Configuration
 	{
-		$statuses_config = new InstanceEntity\StatusesConfig((int)$this->config->get(
+		$statuses_config = new InstanceEntity\StatusesConfig((int) $this->config->get(
 			'config',
 			'api_import_size',
-			$this->config->get('config', 'max_import_size')
+			$this->config->get('config', 'max_import_size'),
 		), 99, 23);
 
 		$image_size_limit = Strings::getBytesFromShorthand($this->config->get('system', 'maximagesize') ?? 0);
@@ -139,7 +139,7 @@ class InstanceV2 extends BaseApi
 			$adminContact = $this->database->selectFirst(
 				'contact',
 				['uri-id'],
-				['nick' => $administrator['nickname'], 'self' => true]
+				['nick' => $administrator['nickname'], 'self' => true],
 			);
 			$account = DI::mstdnAccount()->createFromUriId($adminContact['uri-id']);
 		}
@@ -152,7 +152,7 @@ class InstanceV2 extends BaseApi
 		return new InstanceEntity\FriendicaExtensions(
 			App::VERSION,
 			App::CODENAME,
-			$this->config->get('system', 'build')
+			$this->config->get('system', 'build'),
 		);
 	}
 

--- a/src/Module/Api/Mastodon/Reports.php
+++ b/src/Module/Api/Mastodon/Reports.php
@@ -57,7 +57,7 @@ class Reports extends BaseApi
 			$request['forward'],
 			$request['status_ids'],
 			$request['rule_ids'],
-			self::getCurrentUserID()
+			self::getCurrentUserID(),
 		);
 
 		$this->reportRepo->save($report);

--- a/src/Module/Api/Mastodon/Reports.php
+++ b/src/Module/Api/Mastodon/Reports.php
@@ -24,17 +24,9 @@ use Psr\Log\LoggerInterface;
  */
 class Reports extends BaseApi
 {
-	/** @var \Friendica\Moderation\Factory\Report */
-	private $reportFactory;
-	/** @var \Friendica\Moderation\Repository\Report */
-	private $reportRepo;
-
-	public function __construct(\Friendica\Moderation\Repository\Report $reportRepo, \Friendica\Moderation\Factory\Report $reportFactory, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private \Friendica\Moderation\Repository\Report $reportRepo, private \Friendica\Moderation\Factory\Report $reportFactory, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->reportFactory = $reportFactory;
-		$this->reportRepo    = $reportRepo;
 	}
 
 	public function post(array $request = [])

--- a/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
@@ -30,15 +30,9 @@ use Psr\Log\LoggerInterface;
  */
 class PublicTimeline extends BaseApi
 {
-	/**
-	 * @var IManageConfigValues
-	 */
-	private $config;
-
-	public function __construct(IManageConfigValues $config, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private IManageConfigValues $config, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-		$this->config = $config;
 	}
 	/**
 	 * @throws HTTPException\InternalServerErrorException

--- a/src/Module/Api/Mastodon/Trends/Statuses.php
+++ b/src/Module/Api/Mastodon/Trends/Statuses.php
@@ -28,15 +28,9 @@ use Psr\Log\LoggerInterface;
  */
 class Statuses extends BaseApi
 {
-	/**
-	 * @var IManageConfigValues
-	 */
-	private $config;
-
-	public function __construct(IManageConfigValues $config, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private IManageConfigValues $config, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-		$this->config = $config;
 	}
 
 	/**

--- a/src/Module/Api/Twitter/DirectMessages/Destroy.php
+++ b/src/Module/Api/Twitter/DirectMessages/Destroy.php
@@ -26,14 +26,9 @@ use Psr\Log\LoggerInterface;
  */
 class Destroy extends BaseApi
 {
-	/** @var Database */
-	private $dba;
-
-	public function __construct(Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->dba = $dba;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Api/Twitter/DirectMessages/NewDM.php
+++ b/src/Module/Api/Twitter/DirectMessages/NewDM.php
@@ -28,18 +28,9 @@ use Psr\Log\LoggerInterface;
  */
 class NewDM extends BaseApi
 {
-	/** @var Database */
-	private $dba;
-
-	/** @var DirectMessage */
-	private $directMessage;
-
-	public function __construct(DirectMessage $directMessage, Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private DirectMessage $directMessage, private Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->dba           = $dba;
-		$this->directMessage = $directMessage;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Api/Twitter/DirectMessagesEndpoint.php
+++ b/src/Module/Api/Twitter/DirectMessagesEndpoint.php
@@ -22,18 +22,9 @@ use Psr\Log\LoggerInterface;
 
 abstract class DirectMessagesEndpoint extends BaseApi
 {
-	/** @var Database */
-	private $dba;
-
-	/** @var DirectMessage */
-	private $directMessage;
-
-	public function __construct(DirectMessage $directMessage, Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private DirectMessage $directMessage, private Database $dba, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->dba           = $dba;
-		$this->directMessage = $directMessage;
 	}
 
 	/**

--- a/src/Module/Api/Twitter/Friendships/Destroy.php
+++ b/src/Module/Api/Twitter/Friendships/Destroy.php
@@ -29,14 +29,9 @@ use Psr\Log\LoggerInterface;
  */
 class Destroy extends ContactEndpoint
 {
-	/** @var TwitterUser */
-	private $twitterUser;
-
-	public function __construct(\Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, TwitterUser $twitterUser, array $server, array $parameters = [])
+	public function __construct(\Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, private TwitterUser $twitterUser, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->twitterUser = $twitterUser;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Api/Twitter/Lists/Create.php
+++ b/src/Module/Api/Twitter/Lists/Create.php
@@ -28,18 +28,9 @@ use Psr\Log\LoggerInterface;
  */
 class Create extends BaseApi
 {
-	/** @var FriendicaCircle */
-	private $friendicaCircle;
-
-	/** @var Database */
-	private $dba;
-
-	public function __construct(Database $dba, FriendicaCircle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private Database $dba, private FriendicaCircle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->dba             = $dba;
-		$this->friendicaCircle = $friendicaCircle;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Api/Twitter/Lists/Destroy.php
+++ b/src/Module/Api/Twitter/Lists/Destroy.php
@@ -28,18 +28,9 @@ use Psr\Log\LoggerInterface;
  */
 class Destroy extends BaseApi
 {
-	/** @var FriendicaCirle */
-	private $friendicaCircle;
-
-	/** @var Database */
-	private $dba;
-
-	public function __construct(Database $dba, FriendicaCirle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private Database $dba, private FriendicaCirle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->dba             = $dba;
-		$this->friendicaCircle = $friendicaCircle;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Api/Twitter/Lists/Ownership.php
+++ b/src/Module/Api/Twitter/Lists/Ownership.php
@@ -26,18 +26,9 @@ use Psr\Log\LoggerInterface;
  */
 class Ownership extends BaseApi
 {
-	/** @var FriendicaCircle */
-	private $friendicaCircle;
-
-	/** @var Database */
-	private $dba;
-
-	public function __construct(Database $dba, FriendicaCircle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private Database $dba, private FriendicaCircle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->dba             = $dba;
-		$this->friendicaCircle = $friendicaCircle;
 	}
 	protected function rawContent(array $request = [])
 	{

--- a/src/Module/Api/Twitter/Lists/Statuses.php
+++ b/src/Module/Api/Twitter/Lists/Statuses.php
@@ -30,18 +30,9 @@ use Psr\Log\LoggerInterface;
  */
 class Statuses extends BaseApi
 {
-	/** @var TwitterStatus */
-	private $twitterStatus;
-
-	/** @var Database */
-	private $dba;
-
-	public function __construct(Database $dba, TwitterStatus $twitterStatus, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private Database $dba, private TwitterStatus $twitterStatus, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->dba           = $dba;
-		$this->twitterStatus = $twitterStatus;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Api/Twitter/Lists/Update.php
+++ b/src/Module/Api/Twitter/Lists/Update.php
@@ -28,18 +28,9 @@ use Psr\Log\LoggerInterface;
  */
 class Update extends BaseApi
 {
-	/** @var FriendicaCircle */
-	private $friendicaCircle;
-
-	/** @var Database */
-	private $dba;
-
-	public function __construct(Database $dba, FriendicaCircle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private Database $dba, private FriendicaCircle $friendicaCircle, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->dba             = $dba;
-		$this->friendicaCircle = $friendicaCircle;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Blocklist/Domain/Download.php
+++ b/src/Module/Blocklist/Domain/Download.php
@@ -20,17 +20,9 @@ use Psr\Log\LoggerInterface;
 
 class Download extends \Friendica\BaseModule
 {
-	private DomainPatternBlocklist $blocklist;
-	private IManageConfigValues $config;
-	private IHandleUserSessions $session;
-
-	public function __construct(DomainPatternBlocklist $blocklist, IHandleUserSessions $session, IManageConfigValues $config, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private DomainPatternBlocklist $blocklist, private IHandleUserSessions $session, private IManageConfigValues $config, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->blocklist = $blocklist;
-		$this->config    = $config;
-		$this->session   = $session;
 	}
 
 	/**

--- a/src/Module/Contact/Contacts.php
+++ b/src/Module/Contact/Contacts.php
@@ -24,17 +24,9 @@ use Psr\Log\LoggerInterface;
 
 class Contacts extends BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $userSession;
-	/** @var App\Page */
-	private $page;
-
-	public function __construct(App\Page $page, IHandleUserSessions $userSession, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private App\Page $page, private IHandleUserSessions $userSession, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->userSession = $userSession;
-		$this->page        = $page;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Contact/Contacts.php
+++ b/src/Module/Contact/Contacts.php
@@ -101,7 +101,7 @@ class Contacts extends BaseModule
 				$title   = $this->tt('Friend (%s)', 'Friends (%s)', $total);
 				$desc    = $this->t(
 					'These contacts both follow and are followed by <strong>%s</strong>.',
-					htmlentities($contact['name'], ENT_COMPAT, 'UTF-8')
+					htmlentities($contact['name'], ENT_COMPAT, 'UTF-8'),
 				);
 				break;
 			case 'common':
@@ -109,7 +109,7 @@ class Contacts extends BaseModule
 				$title   = $this->tt('Common contact (%s)', 'Common contacts (%s)', $total);
 				$desc    = $this->t(
 					'Both <strong>%s</strong> and yourself have publicly interacted with these contacts (follow, comment or likes on public posts).',
-					htmlentities($contact['name'], ENT_COMPAT, 'UTF-8')
+					htmlentities($contact['name'], ENT_COMPAT, 'UTF-8'),
 				);
 				break;
 			default:
@@ -129,11 +129,11 @@ class Contacts extends BaseModule
 				$contact = Model\Contact::selectFirst(
 					[],
 					['uri-id' => $contact['uri-id'], 'uid' => [0, $this->userSession->getLocalUserId()]],
-					['order'  => ['uid' => 'DESC']]
+					['order'  => ['uid' => 'DESC']],
 				);
 				return Module\Contact::getContactTemplateVars($contact);
 			},
-			$friends
+			$friends,
 		);
 
 		$tpl = Renderer::getMarkupTemplate('profile/contacts.tpl');

--- a/src/Module/Contact/Conversations.php
+++ b/src/Module/Contact/Conversations.php
@@ -33,31 +33,9 @@ use Psr\Log\LoggerInterface;
  */
 class Conversations extends BaseModule
 {
-	/**
-	 * @var Page
-	 */
-	private $page;
-	/**
-	 * @var Conversation
-	 */
-	private $conversation;
-	/**
-	 * @var LocalRelationship
-	 */
-	private $localRelationship;
-	/**
-	 * @var IHandleUserSessions
-	 */
-	private $userSession;
-
-	public function __construct(L10n $l10n, LocalRelationship $localRelationship, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, Page $page, Conversation $conversation, IHandleUserSessions $userSession, $server, array $parameters = [])
+	public function __construct(L10n $l10n, private LocalRelationship $localRelationship, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, private Page $page, private Conversation $conversation, private IHandleUserSessions $userSession, $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->page              = $page;
-		$this->conversation      = $conversation;
-		$this->localRelationship = $localRelationship;
-		$this->userSession       = $userSession;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Contact/Hovercard.php
+++ b/src/Module/Contact/Hovercard.php
@@ -25,17 +25,9 @@ use Psr\Log\LoggerInterface;
  */
 class Hovercard extends BaseModule
 {
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var IHandleUserSessions */
-	private $userSession;
-
-	public function __construct(IHandleUserSessions $userSession, IManageConfigValues $config, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private IHandleUserSessions $userSession, private IManageConfigValues $config, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config      = $config;
-		$this->userSession = $userSession;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Contact/Media.php
+++ b/src/Module/Contact/Media.php
@@ -26,16 +26,9 @@ use Psr\Log\LoggerInterface;
  */
 class Media extends BaseModule
 {
-	/**
-	 * @var IHandleUserSessions
-	 */
-	private $userSession;
-
-	public function __construct(L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IHandleUserSessions $userSession, $server, array $parameters = [])
+	public function __construct(L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, private IHandleUserSessions $userSession, $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->userSession = $userSession;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Contact/Posts.php
+++ b/src/Module/Contact/Posts.php
@@ -29,26 +29,9 @@ use Psr\Log\LoggerInterface;
  */
 class Posts extends BaseModule
 {
-	/**
-	 * @var LocalRelationship
-	 */
-	private $localRelationship;
-	/**
-	 * @var App\Page
-	 */
-	private $page;
-	/**
-	 * @var IHandleUserSessions
-	 */
-	private $userSession;
-
-	public function __construct(L10n $l10n, LocalRelationship $localRelationship, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, App\Page $page, IHandleUserSessions $userSession, $server, array $parameters = [])
+	public function __construct(L10n $l10n, private LocalRelationship $localRelationship, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, private App\Page $page, private IHandleUserSessions $userSession, $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->localRelationship = $localRelationship;
-		$this->page              = $page;
-		$this->userSession       = $userSession;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Contact/Profile.php
+++ b/src/Module/Contact/Profile.php
@@ -46,50 +46,25 @@ use Psr\Log\LoggerInterface;
  */
 class Profile extends BaseModule
 {
-	/** @var LocalRelationshipRepository */
-	private $localRelationship;
-	/** @var Page */
-	private $page;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var SystemMessages */
-	private $systemMessages;
-	/** @var Database */
-	private $db;
-	/** @var UserGServerRepository */
-	private $userGServer;
-	private EventDispatcherInterface $eventDispatcher;
-
 	public function __construct(
-		UserGServerRepository $userGServer,
-		EventDispatcherInterface $eventDispatcher,
-		Database $db,
-		SystemMessages $systemMessages,
-		IHandleUserSessions $session,
+		private UserGServerRepository $userGServer,
+		private EventDispatcherInterface $eventDispatcher,
+		private Database $db,
+		private SystemMessages $systemMessages,
+		private IHandleUserSessions $session,
 		L10n $l10n,
-		LocalRelationshipRepository $localRelationship,
+		private LocalRelationshipRepository $localRelationship,
 		BaseURL $baseUrl,
 		Arguments $args,
 		LoggerInterface $logger,
 		Profiler $profiler,
 		Response $response,
-		Page $page,
-		IManageConfigValues $config,
+		private Page $page,
+		private IManageConfigValues $config,
 		array $server,
 		array $parameters = [],
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->localRelationship = $localRelationship;
-		$this->page              = $page;
-		$this->config            = $config;
-		$this->session           = $session;
-		$this->systemMessages    = $systemMessages;
-		$this->db                = $db;
-		$this->userGServer       = $userGServer;
-		$this->eventDispatcher   = $eventDispatcher;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Contact/Redir.php
+++ b/src/Module/Contact/Redir.php
@@ -25,20 +25,9 @@ use Psr\Log\LoggerInterface;
 
 class Redir extends \Friendica\BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var Database */
-	private $database;
-	/** @var AppHelper */
-	private $appHelper;
-
-	public function __construct(AppHelper $appHelper, Database $database, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private AppHelper $appHelper, private Database $database, private IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session    = $session;
-		$this->database   = $database;
-		$this->appHelper  = $appHelper;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Contact/Redir.php
+++ b/src/Module/Contact/Redir.php
@@ -75,7 +75,7 @@ class Redir extends \Friendica\BaseModule
 		$this->checkUrl($contact_url, $url);
 		$target_url = $url ?: $contact_url;
 
-		$gserver = $this->database->selectFirst('gserver', ['url', 'network', 'openwebauth'], ['id' => $contact['gsid']]);
+		$gserver  = $this->database->selectFirst('gserver', ['url', 'network', 'openwebauth'], ['id' => $contact['gsid']]);
 		$basepath = $gserver['url'];
 
 		// This part can be removed, when all server entries had been updated. So removing it in 2025 should be safe.

--- a/src/Module/Contact/Suggestions.php
+++ b/src/Module/Contact/Suggestions.php
@@ -21,17 +21,9 @@ use Friendica\Network\HTTPException;
 
 class Suggestions extends \Friendica\BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var App\Page */
-	private $page;
-
-	public function __construct(App\Page $page, IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private App\Page $page, private IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session = $session;
-		$this->page    = $page;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Contact/Unfollow.php
+++ b/src/Module/Contact/Unfollow.php
@@ -24,26 +24,9 @@ use Psr\Log\LoggerInterface;
 
 class Unfollow extends \Friendica\BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $userSession;
-
-	/** @var SystemMessages */
-	private $systemMessages;
-
-	/** @var Database */
-	private $database;
-
-	/** @var App\Page */
-	private $page;
-
-	public function __construct(App\Page $page, Database $database, SystemMessages $systemMessages, IHandleUserSessions $userSession, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private App\Page $page, private Database $database, private SystemMessages $systemMessages, private IHandleUserSessions $userSession, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->userSession    = $userSession;
-		$this->systemMessages = $systemMessages;
-		$this->database       = $database;
-		$this->page           = $page;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -90,7 +90,6 @@ class Network extends Timeline
 	protected $community;
 	/** @var NetworkFactory */
 	protected $networkFactory;
-	private EventDispatcherInterface $eventDispatcher;
 
 	public function __construct(
 		UserDefinedChannelFactory $userDefinedChannel,
@@ -99,7 +98,7 @@ class Network extends Timeline
 		ChannelFactory $channelFactory,
 		UserDefinedChannel $channel,
 		AppHelper $appHelper,
-		EventDispatcherInterface $eventDispatcher,
+		private EventDispatcherInterface $eventDispatcher,
 		TimelineFactory $timeline,
 		SystemMessages $systemMessages,
 		Mode $mode,
@@ -140,7 +139,6 @@ class Network extends Timeline
 		);
 
 		$this->appHelper          = $appHelper;
-		$this->eventDispatcher    = $eventDispatcher;
 		$this->timeline           = $timeline;
 		$this->systemMessages     = $systemMessages;
 		$this->conversation       = $conversation;

--- a/src/Module/Conversation/Timeline.php
+++ b/src/Module/Conversation/Timeline.php
@@ -85,9 +85,8 @@ class Timeline extends BaseModule
 	protected $cache;
 	/** @var UserDefinedChannel */
 	protected $channelRepository;
-	protected ActivityFactory $activityFactory;
 
-	public function __construct(UserDefinedChannel $channel, Mode $mode, IHandleUserSessions $session, Database $database, IManagePersonalConfigValues $pConfig, IManageConfigValues $config, ICanCache $cache, ActivityFactory $activityFactory, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server = [], array $parameters = [])
+	public function __construct(UserDefinedChannel $channel, Mode $mode, IHandleUserSessions $session, Database $database, IManagePersonalConfigValues $pConfig, IManageConfigValues $config, ICanCache $cache, protected ActivityFactory $activityFactory, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server = [], array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
@@ -98,7 +97,6 @@ class Timeline extends BaseModule
 		$this->pConfig           = $pConfig;
 		$this->config            = $config;
 		$this->cache             = $cache;
-		$this->activityFactory   = $activityFactory;
 	}
 
 	/**

--- a/src/Module/Filer/RemoveTag.php
+++ b/src/Module/Filer/RemoveTag.php
@@ -75,7 +75,7 @@ class RemoveTag extends BaseModule
 		$this->logger->info('Filer - Remove Tag', [
 			'term' => $term,
 			'item' => $item_id,
-			'type' => $type
+			'type' => $type,
 		]);
 
 		if (!$item_id || !strlen($term)) {

--- a/src/Module/Filer/RemoveTag.php
+++ b/src/Module/Filer/RemoveTag.php
@@ -24,17 +24,9 @@ use Psr\Log\LoggerInterface;
  */
 class RemoveTag extends BaseModule
 {
-	/** @var SystemMessages */
-	private $systemMessages;
-	/** @var IHandleUserSessions */
-	private $userSession;
-
-	public function __construct(SystemMessages $systemMessages, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IHandleUserSessions $userSession, array $server, array $parameters = [])
+	public function __construct(private SystemMessages $systemMessages, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, private IHandleUserSessions $userSession, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->systemMessages = $systemMessages;
-		$this->userSession    = $userSession;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -32,21 +32,12 @@ use Psr\Log\LoggerInterface;
  */
 class Friendica extends BaseModule
 {
-	private AddonHelper $addonHelper;
-	private EventDispatcherInterface $eventDispatcher;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var IManageKeyValuePairs */
-	private $keyValue;
-	/** @var IHandleUserSessions */
-	private $session;
-
 	public function __construct(
-		AddonHelper $addonHelper,
-		EventDispatcherInterface $eventDispatcher,
-		IHandleUserSessions $session,
-		IManageKeyValuePairs $keyValue,
-		IManageConfigValues $config,
+		private AddonHelper $addonHelper,
+		private EventDispatcherInterface $eventDispatcher,
+		private IHandleUserSessions $session,
+		private IManageKeyValuePairs $keyValue,
+		private IManageConfigValues $config,
 		L10n $l10n,
 		BaseURL $baseUrl,
 		Arguments $args,
@@ -57,12 +48,6 @@ class Friendica extends BaseModule
 		array $parameters = [],
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config          = $config;
-		$this->keyValue        = $keyValue;
-		$this->session         = $session;
-		$this->eventDispatcher = $eventDispatcher;
-		$this->addonHelper     = $addonHelper;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -31,23 +31,23 @@ class Install extends BaseModule
 	/**
 	 * Step one - System check
 	 */
-	const SYSTEM_CHECK = 1;
+	public const SYSTEM_CHECK = 1;
 	/**
 	 * Step two - Base information
 	 */
-	const BASE_CONFIG = 2;
+	public const BASE_CONFIG = 2;
 	/**
 	 * Step three - Database configuration
 	 */
-	const DATABASE_CONFIG = 3;
+	public const DATABASE_CONFIG = 3;
 	/**
 	 * Step four - Adapt site settings
 	 */
-	const SITE_SETTINGS = 4;
+	public const SITE_SETTINGS = 4;
 	/**
 	 * Step five - All steps finished
 	 */
-	const FINISHED = 5;
+	public const FINISHED = 5;
 
 	/**
 	 * @var int The current step of the wizard
@@ -62,7 +62,7 @@ class Install extends BaseModule
 	public function __construct(AppHelper $appHelper, BasePath $basePath, Mode $mode, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, /**
 				 * @var Installer The installer
 				 */
-				private Installer $installer, array $server, array $parameters = [])
+		private Installer $installer, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
@@ -194,9 +194,9 @@ class Install extends BaseModule
 				break;
 
 			case self::BASE_CONFIG:
-				$baseUrl = $this->configCache->get('system', 'url') ?
-					new Uri($this->configCache->get('system', 'url')) :
-					$this->baseUrl;
+				$baseUrl = $this->configCache->get('system', 'url')
+					? new Uri($this->configCache->get('system', 'url'))
+					: $this->baseUrl;
 
 				$tpl = Renderer::getMarkupTemplate('install/02_base_config.tpl');
 				$output .= Renderer::replaceMacros($tpl, [
@@ -209,7 +209,7 @@ class Install extends BaseModule
 						$this->t('Required')],
 					'$system_url' => ['system-url',
 						$this->t('The Friendica system URL'),
-						(string)$baseUrl,
+						(string) $baseUrl,
 						$this->t("Overwrite this field in case the system URL determination isn't right, otherwise leave it as is."),
 						$this->t('Required')],
 					'$php_path' => $this->configCache->get('config', 'php_path'),
@@ -253,7 +253,7 @@ class Install extends BaseModule
 						$this->t('Required')],
 					'$lbl_10'   => $this->t('Please select a default timezone for your website'),
 					'$php_path' => $this->configCache->get('config', 'php_path'),
-					'$submit'   => $this->t('Submit')
+					'$submit'   => $this->t('Submit'),
 				]);
 				break;
 
@@ -282,7 +282,7 @@ class Install extends BaseModule
 						'system-default_timezone',
 						$this->t('Please select a default timezone for your website'),
 						$this->configCache->get('system', 'default_timezone'),
-						''
+						'',
 					),
 					'$language' => ['system-language',
 						$this->t('System Language:'),
@@ -290,7 +290,7 @@ class Install extends BaseModule
 						$this->t('Set the default language for your Friendica installation interface and to send emails.'),
 						$lang_choices],
 					'$php_path' => $this->configCache->get('config', 'php_path'),
-					'$submit'   => $this->t('Submit')
+					'$submit'   => $this->t('Submit'),
 				]);
 				break;
 
@@ -327,7 +327,7 @@ class Install extends BaseModule
 	 */
 	private function whatNext(): string
 	{
-		$baseurl = (string)$this->baseUrl;
+		$baseurl = (string) $this->baseUrl;
 		return
 			$this->t('<h1>What next</h1>')
 			. "<p>" . $this->t('IMPORTANT: You will need to [manually] setup a scheduled task for the worker.')

--- a/src/Module/Install.php
+++ b/src/Module/Install.php
@@ -54,23 +54,20 @@ class Install extends BaseModule
 	 */
 	private $currentWizardStep;
 
-	/**
-	 * @var Installer The installer
-	 */
-	private $installer;
-
 	/** @var Cache */
 	protected $configCache;
 	/** @var Mode */
 	protected $mode;
 
-	public function __construct(AppHelper $appHelper, BasePath $basePath, Mode $mode, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, Installer $installer, array $server, array $parameters = [])
+	public function __construct(AppHelper $appHelper, BasePath $basePath, Mode $mode, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, /**
+				 * @var Installer The installer
+				 */
+				private Installer $installer, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->configCache = $appHelper->getConfigCache();
 		$this->mode        = $mode;
-		$this->installer   = $installer;
 
 		if (!$this->mode->isInstall()) {
 			throw new HTTPException\ForbiddenException();

--- a/src/Module/Item/Compose.php
+++ b/src/Module/Item/Compose.php
@@ -39,41 +39,9 @@ use Psr\Log\LoggerInterface;
 
 class Compose extends BaseModule
 {
-	/** @var SystemMessages */
-	private $systemMessages;
-
-	/** @var ACLFormatter */
-	private $ACLFormatter;
-
-	/** @var Page */
-	private $page;
-
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-
-	/** @var IManageConfigValues */
-	private $config;
-
-	/** @var UserSession */
-	private $session;
-
-	/** @var AppHelper */
-	private $appHelper;
-
-	private EventDispatcherInterface $eventDispatcher;
-
-	public function __construct(EventDispatcherInterface $eventDispatcher, AppHelper $appHelper, UserSession $session, IManageConfigValues $config, IManagePersonalConfigValues $pConfig, Page $page, ACLFormatter $ACLFormatter, SystemMessages $systemMessages, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private EventDispatcherInterface $eventDispatcher, private AppHelper $appHelper, private UserSession $session, private IManageConfigValues $config, private IManagePersonalConfigValues $pConfig, private Page $page, private ACLFormatter $ACLFormatter, private SystemMessages $systemMessages, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->systemMessages  = $systemMessages;
-		$this->ACLFormatter    = $ACLFormatter;
-		$this->page            = $page;
-		$this->pConfig         = $pConfig;
-		$this->config          = $config;
-		$this->session         = $session;
-		$this->appHelper       = $appHelper;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Item/Language.php
+++ b/src/Module/Item/Language.php
@@ -24,17 +24,9 @@ use Psr\Log\LoggerInterface;
  */
 class Language extends BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var ContentItem */
-	private $item;
-
-	public function __construct(ContentItem $item, IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private ContentItem $item, private IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session = $session;
-		$this->item    = $item;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Item/Searchtext.php
+++ b/src/Module/Item/Searchtext.php
@@ -23,14 +23,9 @@ use Psr\Log\LoggerInterface;
  */
 class Searchtext extends BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $session;
-
-	public function __construct(IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(private IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session = $session;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/LostPass.php
+++ b/src/Module/LostPass.php
@@ -29,10 +29,6 @@ use Psr\Log\LoggerInterface;
  */
 final class LostPass extends BaseModule
 {
-	private SystemMessages $sysMessages;
-	private IManageConfigValues $config;
-	private Emailer $emailer;
-
 	/**
 	 * Initialize the module
 	 *
@@ -48,13 +44,9 @@ final class LostPass extends BaseModule
 	 * @param array $server
 	 * @param array $parameters
 	 */
-	public function __construct(L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, SystemMessages $sysMessages, IManageConfigValues $config, Emailer $emailer, array $server, array $parameters = [])
+	public function __construct(L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, private SystemMessages $sysMessages, private IManageConfigValues $config, private Emailer $emailer, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->sysMessages = $sysMessages;
-		$this->config      = $config;
-		$this->emailer     = $emailer;
 	}
 
 	/**

--- a/src/Module/Media/Attachment/Upload.php
+++ b/src/Module/Media/Attachment/Upload.php
@@ -28,29 +28,12 @@ use Psr\Log\LoggerInterface;
  */
 class Upload extends \Friendica\BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $userSession;
-
-	/** @var IManageConfigValues */
-	private $config;
-
-	/** @var SystemMessages */
-	private $systemMessages;
-
 	/** @var bool */
 	private $isJson;
 
-	/** @var App\Page */
-	private $page;
-
-	public function __construct(App\Page $page, SystemMessages $systemMessages, IManageConfigValues $config, IHandleUserSessions $userSession, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private App\Page $page, private SystemMessages $systemMessages, private IManageConfigValues $config, private IHandleUserSessions $userSession, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->userSession    = $userSession;
-		$this->config         = $config;
-		$this->systemMessages = $systemMessages;
-		$this->page           = $page;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Media/Photo/Upload.php
+++ b/src/Module/Media/Photo/Upload.php
@@ -29,29 +29,12 @@ use Psr\Log\LoggerInterface;
  */
 class Upload extends \Friendica\BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $userSession;
-
-	/** @var SystemMessages */
-	private $systemMessages;
-
-	/** @var IManageConfigValues */
-	private $config;
-
 	/** @var bool */
 	private $isJson = false;
 
-	/** @var App\Page */
-	private $page;
-
-	public function __construct(App\Page $page, IManageConfigValues $config, SystemMessages $systemMessages, IHandleUserSessions $userSession, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private App\Page $page, private IManageConfigValues $config, private SystemMessages $systemMessages, private IHandleUserSessions $userSession, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->userSession    = $userSession;
-		$this->systemMessages = $systemMessages;
-		$this->config         = $config;
-		$this->page           = $page;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Moderation/BaseUsers.php
+++ b/src/Module/Moderation/BaseUsers.php
@@ -32,11 +32,9 @@ abstract class BaseUsers extends BaseModeration
 	/** @var Database */
 	protected $database;
 
-	private EventDispatcherInterface $eventDispatcher;
-
 	public function __construct(
 		Database $database,
-		EventDispatcherInterface $eventDispatcher,
+		private EventDispatcherInterface $eventDispatcher,
 		Page $page,
 		AppHelper $appHelper,
 		SystemMessages $systemMessages,
@@ -53,7 +51,6 @@ abstract class BaseUsers extends BaseModeration
 		parent::__construct($page, $appHelper, $systemMessages, $session, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->database        = $database;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	/**

--- a/src/Module/Moderation/BaseUsers.php
+++ b/src/Module/Moderation/BaseUsers.php
@@ -46,11 +46,11 @@ abstract class BaseUsers extends BaseModeration
 		Profiler $profiler,
 		Response $response,
 		array $server,
-		array $parameters = []
+		array $parameters = [],
 	) {
 		parent::__construct($page, $appHelper, $systemMessages, $session, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
-		$this->database        = $database;
+		$this->database = $database;
 	}
 
 	/**
@@ -137,7 +137,7 @@ abstract class BaseUsers extends BaseModeration
 				User::PAGE_FLAGS_COMMUNITY => $this->t('Public Group'),
 				User::PAGE_FLAGS_COMM_MAN  => $this->t('Public Group - Restricted'),
 				User::PAGE_FLAGS_FREELOVE  => $this->t('Automatic Friend Page'),
-				User::PAGE_FLAGS_PRVGROUP  => $this->t('Private Group')
+				User::PAGE_FLAGS_PRVGROUP  => $this->t('Private Group'),
 			];
 			$account_types = [
 				User::ACCOUNT_TYPE_PERSON       => $this->t('Personal Page'),

--- a/src/Module/Moderation/Blocklist/Contact.php
+++ b/src/Module/Moderation/Blocklist/Contact.php
@@ -26,14 +26,9 @@ use Psr\Log\LoggerInterface;
 
 class Contact extends BaseModeration
 {
-	/** @var Database */
-	private $database;
-
-	public function __construct(Database $database, Page $page, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Database $database, Page $page, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($page, $appHelper, $systemMessages, $session, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->database = $database;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Moderation/Blocklist/Server/Add.php
+++ b/src/Module/Moderation/Blocklist/Server/Add.php
@@ -29,14 +29,9 @@ use Psr\Log\LoggerInterface;
 
 class Add extends BaseModeration
 {
-	/** @var DomainPatternBlocklist */
-	private $blocklist;
-
-	public function __construct(DomainPatternBlocklist $blocklist, Page $page, AppHelper $app, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private DomainPatternBlocklist $blocklist, Page $page, AppHelper $app, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($page, $app, $systemMessages, $session, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->blocklist = $blocklist;
 	}
 
 	/**

--- a/src/Module/Moderation/Blocklist/Server/Add.php
+++ b/src/Module/Moderation/Blocklist/Server/Add.php
@@ -93,7 +93,7 @@ class Add extends BaseModeration
 		}
 
 		array_walk($gservers, function (array &$gserver) {
-			$gserver['domain'] = (new Uri($gserver['url']))->getHost();
+			$gserver['domain']       = (new Uri($gserver['url']))->getHost();
 			$gserver['network_svg']  = ContactSelector::networkToSVG($gserver['network']);
 			$gserver['network_name'] = ContactSelector::networkToName($gserver['network']);
 		});
@@ -122,7 +122,7 @@ class Add extends BaseModeration
 			'$newreason'           => ['reason', $this->t('Block reason'), $request['reason'] ?? '', $this->t('The reason why you blocked this server domain pattern. This reason will be shown publicly in the server information page.'), $this->t('Required'), '', ''],
 			'$pattern'             => $pattern,
 			'$gservers'            => $gservers,
-			'$form_security_token' => self::getFormSecurityToken('moderation_blocklist_add')
+			'$form_security_token' => self::getFormSecurityToken('moderation_blocklist_add'),
 		]);
 	}
 }

--- a/src/Module/Moderation/Blocklist/Server/Import.php
+++ b/src/Module/Moderation/Blocklist/Server/Import.php
@@ -24,17 +24,12 @@ use Psr\Log\LoggerInterface;
 
 class Import extends \Friendica\Module\BaseModeration
 {
-	/** @var DomainPatternBlocklist */
-	private $localBlocklist;
-
 	/** @var array of blocked server domain patterns */
 	private $blocklist = [];
 
-	public function __construct(DomainPatternBlocklist $localBlocklist, Page $page, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private DomainPatternBlocklist $localBlocklist, Page $page, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($page, $appHelper, $systemMessages, $session, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->localBlocklist = $localBlocklist;
 	}
 
 	/**

--- a/src/Module/Moderation/Blocklist/Server/Index.php
+++ b/src/Module/Moderation/Blocklist/Server/Index.php
@@ -24,14 +24,9 @@ use Psr\Log\LoggerInterface;
 
 class Index extends BaseModeration
 {
-	/** @var DomainPatternBlocklist */
-	private $blocklist;
-
-	public function __construct(DomainPatternBlocklist $blocklist, Page $page, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private DomainPatternBlocklist $blocklist, Page $page, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($page, $appHelper, $systemMessages, $session, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->blocklist = $blocklist;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Moderation/Blocklist/Server/Index.php
+++ b/src/Module/Moderation/Blocklist/Server/Index.php
@@ -41,14 +41,14 @@ class Index extends BaseModeration
 
 		// Edit the entries from blocklist
 		$blocklist = [];
-		foreach ((array)$request['domain'] as $id => $domain) {
+		foreach ((array) $request['domain'] as $id => $domain) {
 			// Trimming whitespaces as well as any lingering slashes
 			$domain = trim($domain);
 			$reason = trim($request['reason'][$id]);
 			if (empty($request['delete'][$id]) && !empty($domain)) {
 				$blocklist[] = [
 					'domain' => $domain,
-					'reason' => $reason
+					'reason' => $reason,
 				];
 			}
 		}
@@ -69,7 +69,7 @@ class Index extends BaseModeration
 			$blocklistform[] = [
 				'domain' => ["domain[$id]", $this->t('Blocked server domain pattern'), $b['domain'], '', $this->t('Required'), '', ''],
 				'reason' => ["reason[$id]", $this->t("Reason for the block"), $b['reason'], '', $this->t('Required'), '', ''],
-				'delete' => ["delete[$id]", $this->t("Delete server domain pattern") . ' (' . $b['domain'] . ')', false, $this->t("Check to delete this entry from the blocklist")]
+				'delete' => ["delete[$id]", $this->t("Delete server domain pattern") . ' (' . $b['domain'] . ')', false, $this->t("Check to delete this entry from the blocklist")],
 			];
 		}
 

--- a/src/Module/Moderation/Item/Source.php
+++ b/src/Module/Moderation/Item/Source.php
@@ -24,14 +24,9 @@ use Psr\Log\LoggerInterface;
 
 class Source extends BaseModeration
 {
-	/** @var IManageConfigValues */
-	private $config;
-
-	public function __construct(IManageConfigValues $config, Page $page, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private IManageConfigValues $config, Page $page, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($page, $appHelper, $systemMessages, $session, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config = $config;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Moderation/Report/Create.php
+++ b/src/Module/Moderation/Report/Create.php
@@ -42,7 +42,7 @@ class Create extends BaseModule
 	public function __construct(private \Friendica\Moderation\Repository\Report $repository, ReportUtil $reportUtil, private \Friendica\Moderation\Factory\Report $factory, private UserSession $session, private App\Page $page, private SystemMessages $systemMessages, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-		$this->reportUtil     = $reportUtil;
+		$this->reportUtil = $reportUtil;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Moderation/Report/Create.php
+++ b/src/Module/Moderation/Report/Create.php
@@ -36,30 +36,13 @@ class Create extends BaseModule
 	public const CONTACT_ACTION_COLLAPSE = 1;
 	public const CONTACT_ACTION_IGNORE   = 2;
 	public const CONTACT_ACTION_BLOCK    = 3;
-
-	/** @var SystemMessages */
-	private $systemMessages;
-	/** @var App\Page */
-	private $page;
-	/** @var UserSession */
-	private $session;
-	/** @var \Friendica\Moderation\Factory\Report */
-	private $factory;
-	/** @var \Friendica\Moderation\Repository\Report */
-	private $repository;
 	/** @var ReportUtil */
 	protected $reportUtil;
 
-	public function __construct(\Friendica\Moderation\Repository\Report $repository, ReportUtil $reportUtil, \Friendica\Moderation\Factory\Report $factory, UserSession $session, App\Page $page, SystemMessages $systemMessages, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private \Friendica\Moderation\Repository\Report $repository, ReportUtil $reportUtil, private \Friendica\Moderation\Factory\Report $factory, private UserSession $session, private App\Page $page, private SystemMessages $systemMessages, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->systemMessages = $systemMessages;
-		$this->page           = $page;
 		$this->reportUtil     = $reportUtil;
-		$this->session        = $session;
-		$this->factory        = $factory;
-		$this->repository     = $repository;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Moderation/Reports.php
+++ b/src/Module/Moderation/Reports.php
@@ -29,20 +29,13 @@ use Psr\Log\LoggerInterface;
 
 class Reports extends BaseModeration
 {
-	/** @var Database */
-	private $database;
 	/** @var ReportUtil */
 	protected $reportUtil;
-	/** @var ReportRepository */
-	private $reportRepository;
 
-	public function __construct(Database $database, Page $page, ReportUtil $reportUtil, ReportRepository $reportRepository, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Database $database, Page $page, ReportUtil $reportUtil, private ReportRepository $reportRepository, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($page, $appHelper, $systemMessages, $session, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->database         = $database;
 		$this->reportUtil       = $reportUtil;
-		$this->reportRepository = $reportRepository;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Moderation/Reports.php
+++ b/src/Module/Moderation/Reports.php
@@ -35,7 +35,7 @@ class Reports extends BaseModeration
 	public function __construct(private Database $database, Page $page, ReportUtil $reportUtil, private ReportRepository $reportRepository, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($page, $appHelper, $systemMessages, $session, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-		$this->reportUtil       = $reportUtil;
+		$this->reportUtil = $reportUtil;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Moderation/Summary.php
+++ b/src/Module/Moderation/Summary.php
@@ -24,14 +24,9 @@ use Psr\Log\LoggerInterface;
 
 class Summary extends BaseModeration
 {
-	/** @var Database */
-	private $database;
-
-	public function __construct(Database $database, Page $page, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Database $database, Page $page, AppHelper $appHelper, SystemMessages $systemMessages, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($page, $appHelper, $systemMessages, $session, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->database = $database;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Moderation/Utils/ReportUtil.php
+++ b/src/Module/Moderation/Utils/ReportUtil.php
@@ -12,12 +12,9 @@ use Friendica\Moderation\Entity\Report;
 
 final class ReportUtil
 {
-	private L10n $l10n;
-
-	public function __construct(L10n $l10n)
-	{
-		$this->l10n = $l10n;
-	}
+	public function __construct(private L10n $l10n)
+				{
+							}
 
 	public function getReportCategoryName(int $category): string
 	{

--- a/src/Module/Moderation/Utils/ReportUtil.php
+++ b/src/Module/Moderation/Utils/ReportUtil.php
@@ -12,9 +12,7 @@ use Friendica\Moderation\Entity\Report;
 
 final class ReportUtil
 {
-	public function __construct(private L10n $l10n)
-				{
-							}
+	public function __construct(private L10n $l10n) {}
 
 	public function getReportCategoryName(int $category): string
 	{

--- a/src/Module/Notifications/Notification.php
+++ b/src/Module/Notifications/Notification.php
@@ -134,7 +134,7 @@ class Notification extends BaseModule
 			$this->notificationRepo->setAllSeenForUser($Notify->uid, ['target-uri-id' => $Notify->uriId]);
 		}
 
-		if ((string)$Notify->link) {
+		if ((string) $Notify->link) {
 			System::externalRedirect($Notify->link);
 		}
 

--- a/src/Module/Notifications/Notification.php
+++ b/src/Module/Notifications/Notification.php
@@ -25,26 +25,9 @@ use Psr\Log\LoggerInterface;
 
 class Notification extends BaseModule
 {
-	/** @var Introduction */
-	private $introductionRepo;
-	/** @var Repository\Notification */
-	private $notificationRepo;
-	/** @var Repository\Notify */
-	private $notifyRepo;
-	/** @var IManagePersonalConfigValues */
-	private $pconfig;
-	/** @var Factory\Notification */
-	private $notificationFactory;
-
-	public function __construct(Introduction $introductionRepo, Repository\Notification $notificationRepo, Factory\Notification $notificationFactory, Repository\Notify $notifyRepo, IManagePersonalConfigValues $pconfig, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Introduction $introductionRepo, private Repository\Notification $notificationRepo, private Factory\Notification $notificationFactory, private Repository\Notify $notifyRepo, private IManagePersonalConfigValues $pconfig, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->introductionRepo    = $introductionRepo;
-		$this->notificationRepo    = $notificationRepo;
-		$this->notificationFactory = $notificationFactory;
-		$this->notifyRepo          = $notifyRepo;
-		$this->pconfig             = $pconfig;
 	}
 
 	/**

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -42,44 +42,9 @@ use Psr\Log\LoggerInterface;
 
 class Ping extends BaseModule
 {
-	/** @var SystemMessages */
-	private $systemMessages;
-	/** @var Repository\Notification */
-	private $notificationRepo;
-	/** @var Introduction */
-	private $introductionRepo;
-	/** @var Factory\FormattedNavNotification */
-	private $formattedNavNotification;
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var IManagePersonalConfigValues */
-	private $pconfig;
-	/** @var Database */
-	private $database;
-	/** @var ICanCache */
-	private $cache;
-	/** @var Repository\Notify */
-	private $notify;
-	/** @var AppHelper */
-	private $appHelper;
-
-	public function __construct(AppHelper $appHelper, Repository\Notify $notify, ICanCache $cache, Database $database, IManagePersonalConfigValues $pconfig, IManageConfigValues $config, IHandleUserSessions $session, SystemMessages $systemMessages, Repository\Notification $notificationRepo, Introduction $introductionRepo, Factory\FormattedNavNotification $formattedNavNotification, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private AppHelper $appHelper, private Repository\Notify $notify, private ICanCache $cache, private Database $database, private IManagePersonalConfigValues $pconfig, private IManageConfigValues $config, private IHandleUserSessions $session, private SystemMessages $systemMessages, private Repository\Notification $notificationRepo, private Introduction $introductionRepo, private Factory\FormattedNavNotification $formattedNavNotification, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->systemMessages           = $systemMessages;
-		$this->notificationRepo         = $notificationRepo;
-		$this->introductionRepo         = $introductionRepo;
-		$this->formattedNavNotification = $formattedNavNotification;
-		$this->session                  = $session;
-		$this->config                   = $config;
-		$this->pconfig                  = $pconfig;
-		$this->database                 = $database;
-		$this->cache                    = $cache;
-		$this->notify                   = $notify;
-		$this->appHelper                = $appHelper;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/OpenSearch.php
+++ b/src/Module/OpenSearch.php
@@ -55,7 +55,7 @@ class OpenSearch extends BaseModule
 				],
 			],
 			/** @var DOMDocument $xml */
-			$xml
+			$xml,
 		);
 
 		/** @var DOMElement $parent */
@@ -69,7 +69,7 @@ class OpenSearch extends BaseModule
 
 		if (!empty($shortcut_icon)) {
 			$shortcut_icon = Network::addBasePath($shortcut_icon, $this->baseUrl);
-			$imagedata = getimagesize($shortcut_icon);
+			$imagedata     = getimagesize($shortcut_icon);
 		}
 
 		if (!empty($imagedata)) {
@@ -79,12 +79,17 @@ class OpenSearch extends BaseModule
 				'type'   => $imagedata['mime'],
 			]);
 		} else {
-			XML::addElement($xml, $parent, 'Image',
-			$this->baseUrl . '/images/friendica-16.png', [
-				'height' => 16,
-				'width'  => 16,
-				'type'   => 'image/png',
-			]);
+			XML::addElement(
+				$xml,
+				$parent,
+				'Image',
+				$this->baseUrl . '/images/friendica-16.png',
+				[
+					'height' => 16,
+					'width'  => 16,
+					'type'   => 'image/png',
+				],
+			);
 		}
 
 		XML::addElement($xml, $parent, 'Url', '', [

--- a/src/Module/OpenSearch.php
+++ b/src/Module/OpenSearch.php
@@ -26,17 +26,12 @@ use Psr\Log\LoggerInterface;
  */
 class OpenSearch extends BaseModule
 {
-	/** @var IManageConfigValues */
-	private $config;
-
 	/** @var string */
 	private $basePath;
 
-	public function __construct(BasePath $basePath, IManageConfigValues $config, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(BasePath $basePath, private IManageConfigValues $config, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config   = $config;
 		$this->basePath = $basePath->getPath();
 	}
 

--- a/src/Module/ParseUrl.php
+++ b/src/Module/ParseUrl.php
@@ -27,14 +27,11 @@ class ParseUrl extends BaseModule
 	/** @var IHandleUserSessions */
 	protected $userSession;
 
-	private EventDispatcherInterface $eventDispatcher;
-
-	public function __construct(L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IHandleUserSessions $userSession, EventDispatcherInterface $eventDispatcher, $server, array $parameters = [])
+	public function __construct(L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IHandleUserSessions $userSession, private EventDispatcherInterface $eventDispatcher, $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->userSession     = $userSession;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/ParseUrl.php
+++ b/src/Module/ParseUrl.php
@@ -31,7 +31,7 @@ class ParseUrl extends BaseModule
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
-		$this->userSession     = $userSession;
+		$this->userSession = $userSession;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Ping/Network.php
+++ b/src/Module/Ping/Network.php
@@ -64,7 +64,7 @@ class Network extends NetworkModule
 		Profiler $profiler,
 		Response $response,
 		array $server,
-		array $parameters = []
+		array $parameters = [],
 	) {
 		parent::__construct(
 			$userDefinedChannel,

--- a/src/Module/Ping/Network.php
+++ b/src/Module/Ping/Network.php
@@ -37,13 +37,8 @@ use Psr\Log\LoggerInterface;
 
 class Network extends NetworkModule
 {
-	/**
-	 * @var ICanLock
-	 */
-	private $lock;
-
 	public function __construct(
-		ICanLock $lock,
+		private ICanLock $lock,
 		UserDefinedChannelFactory $userDefinedChannel,
 		NetworkFactory $network,
 		CommunityFactory $community,
@@ -99,8 +94,6 @@ class Network extends NetworkModule
 			$server,
 			$parameters,
 		);
-
-		$this->lock = $lock;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Post/Edit.php
+++ b/src/Module/Post/Edit.php
@@ -53,11 +53,11 @@ class Edit extends BaseModule
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
-		$this->session         = $session;
-		$this->sysMessages     = $sysMessages;
-		$this->page            = $page;
-		$this->mode            = $mode;
-		$this->appHelper       = $appHelper;
+		$this->session     = $session;
+		$this->sysMessages = $sysMessages;
+		$this->page        = $page;
+		$this->mode        = $mode;
+		$this->appHelper   = $appHelper;
 	}
 
 

--- a/src/Module/Post/Edit.php
+++ b/src/Module/Post/Edit.php
@@ -46,12 +46,10 @@ class Edit extends BaseModule
 	/** @var AppHelper */
 	protected $appHelper;
 
-	private EventDispatcherInterface $eventDispatcher;
-
 	/** @var bool */
 	protected $isModal = false;
 
-	public function __construct(L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IHandleUserSessions $session, SystemMessages $sysMessages, Page $page, Mode $mode, AppHelper $appHelper, EventDispatcherInterface $eventDispatcher, array $server, array $parameters = [])
+	public function __construct(L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IHandleUserSessions $session, SystemMessages $sysMessages, Page $page, Mode $mode, AppHelper $appHelper, private EventDispatcherInterface $eventDispatcher, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
@@ -60,7 +58,6 @@ class Edit extends BaseModule
 		$this->page            = $page;
 		$this->mode            = $mode;
 		$this->appHelper       = $appHelper;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 

--- a/src/Module/Post/Share.php
+++ b/src/Module/Post/Share.php
@@ -12,7 +12,6 @@ use Friendica\Content;
 use Friendica\Core\L10n;
 use Friendica\Core\Protocol;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
-use Friendica\Core\System;
 use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Module\Response;

--- a/src/Module/Post/Share.php
+++ b/src/Module/Post/Share.php
@@ -26,17 +26,9 @@ use Psr\Log\LoggerInterface;
  */
 class Share extends \Friendica\BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var Content\Item */
-	private $contentItem;
-
-	public function __construct(Content\Item $contentItem, IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Content\Item $contentItem, private IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session     = $session;
-		$this->contentItem = $contentItem;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Post/Tag/Add.php
+++ b/src/Module/Post/Tag/Add.php
@@ -30,16 +30,9 @@ use Psr\Log\LoggerInterface;
  */
 class Add extends \Friendica\BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $session;
-	private EventDispatcherInterface $eventDispatcher;
-
-	public function __construct(IHandleUserSessions $session, EventDispatcherInterface $eventDispatcher, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private IHandleUserSessions $session, private EventDispatcherInterface $eventDispatcher, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session         = $session;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Post/Tag/Add.php
+++ b/src/Module/Post/Tag/Add.php
@@ -151,7 +151,7 @@ EOT;
 		];
 
 		$hook_data = $this->eventDispatcher->dispatch(
-			new ArrayFilterEvent(ArrayFilterEvent::INSERT_POST_LOCAL_END, $hook_data)
+			new ArrayFilterEvent(ArrayFilterEvent::INSERT_POST_LOCAL_END, $hook_data),
 		)->getArray();
 
 		$post = $hook_data['item'] ?? $post;

--- a/src/Module/Post/Tag/Remove.php
+++ b/src/Module/Post/Tag/Remove.php
@@ -20,14 +20,9 @@ use Psr\Log\LoggerInterface;
 
 class Remove extends \Friendica\BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $session;
-
-	public function __construct(IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session = $session;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Privacy/PermissionTooltip.php
+++ b/src/Module/Privacy/PermissionTooltip.php
@@ -47,7 +47,7 @@ class PermissionTooltip extends BaseModule
 		Profiler $profiler,
 		Response $response,
 		array $server,
-		array $parameters = []
+		array $parameters = [],
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 	}

--- a/src/Module/Privacy/PermissionTooltip.php
+++ b/src/Module/Privacy/PermissionTooltip.php
@@ -33,20 +33,13 @@ use Psr\Log\LoggerInterface;
  */
 class PermissionTooltip extends BaseModule
 {
-	private Database $dba;
-	private ACLFormatter $aclFormatter;
-	private IHandleUserSessions $session;
-	private IManageConfigValues $config;
-	private PermissionSet $permissionSet;
-	private EventDispatcherInterface $eventDispatcher;
-
 	public function __construct(
-		PermissionSet $permissionSet,
-		IManageConfigValues $config,
-		IHandleUserSessions $session,
-		ACLFormatter $aclFormatter,
-		Database $dba,
-		EventDispatcherInterface $eventDispatcher,
+		private PermissionSet $permissionSet,
+		private IManageConfigValues $config,
+		private IHandleUserSessions $session,
+		private ACLFormatter $aclFormatter,
+		private Database $dba,
+		private EventDispatcherInterface $eventDispatcher,
 		L10n $l10n,
 		BaseURL $baseUrl,
 		Arguments $args,
@@ -57,13 +50,6 @@ class PermissionTooltip extends BaseModule
 		array $parameters = []
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->dba             = $dba;
-		$this->aclFormatter    = $aclFormatter;
-		$this->session         = $session;
-		$this->config          = $config;
-		$this->permissionSet   = $permissionSet;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Profile/Common.php
+++ b/src/Module/Profile/Common.php
@@ -28,20 +28,9 @@ use Psr\Log\LoggerInterface;
 
 class Common extends BaseProfile
 {
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var IHandleUserSessions */
-	private $userSession;
-	/** @var AppHelper */
-	private $appHelper;
-
-	public function __construct(AppHelper $appHelper, IHandleUserSessions $userSession, IManageConfigValues $config, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private AppHelper $appHelper, private IHandleUserSessions $userSession, private IManageConfigValues $config, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config = $config;
-		$this->userSession = $userSession;
-		$this->appHelper = $appHelper;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Profile/Common.php
+++ b/src/Module/Profile/Common.php
@@ -83,26 +83,26 @@ class Common extends BaseProfile
 				$contact = Contact::selectFirst(
 					[],
 					['uri-id' => $contact['uri-id'], 'uid' => [0, $this->userSession->getLocalUserId()]],
-					['order' => ['uid' => 'DESC']]
+					['order'  => ['uid' => 'DESC']],
 				);
 				return Module\Contact::getContactTemplateVars($contact);
 			},
-			$commonFollows
+			$commonFollows,
 		);
 
 		$title = $this->tt('Common contact (%s)', 'Common contacts (%s)', $total);
-		$desc = $this->t(
+		$desc  = $this->t(
 			'Both <strong>%s</strong> and yourself have publicly interacted with these contacts (follow, comment or likes on public posts).',
-			htmlentities($profile['name'], ENT_COMPAT, 'UTF-8')
+			htmlentities($profile['name'], ENT_COMPAT, 'UTF-8'),
 		);
 
 		$tpl = Renderer::getMarkupTemplate('profile/contacts.tpl');
 		$o .= Renderer::replaceMacros($tpl, [
-			'$title'    => $title,
-			'$desc'     => $desc,
-			'$tabs'     => $tabs,
+			'$title' => $title,
+			'$desc'  => $desc,
+			'$tabs'  => $tabs,
 
-			'$noresult_label'  => $this->t('No common contacts.'),
+			'$noresult_label' => $this->t('No common contacts.'),
 
 			'$contacts' => $contacts,
 			'$paginate' => $pager->renderFull($total),

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -66,7 +66,7 @@ class Contacts extends Module\BaseProfile
 			'archive' => false,
 			'failed'  => false,
 			'self'    => false,
-			'network' => [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA]
+			'network' => [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA],
 		];
 
 		switch ($type) {
@@ -93,11 +93,11 @@ class Contacts extends Module\BaseProfile
 				$contact = Model\Contact::selectFirst(
 					[],
 					['uri-id' => $contact['uri-id'], 'uid' => [0, $this->userSession->getLocalUserId()]],
-					['order'  => ['uid' => 'DESC']]
+					['order'  => ['uid' => 'DESC']],
 				);
 				return $contact ? Module\Contact::getContactTemplateVars($contact) : null;
 			},
-			Model\Contact::selectToArray(['uri-id'], $condition, $params)
+			Model\Contact::selectToArray(['uri-id'], $condition, $params),
 		);
 
 		// Remove nonexistent contacts
@@ -115,7 +115,7 @@ class Contacts extends Module\BaseProfile
 				$title = $this->tt('Friend (%s)', 'Friends (%s)', $total);
 				$desc  = $this->t(
 					'These contacts both follow and are followed by <strong>%s</strong>.',
-					htmlentities($profile['name'], ENT_COMPAT, 'UTF-8')
+					htmlentities($profile['name'], ENT_COMPAT, 'UTF-8'),
 				);
 				break;
 			case 'all':

--- a/src/Module/Profile/Contacts.php
+++ b/src/Module/Profile/Contacts.php
@@ -27,23 +27,9 @@ use Psr\Log\LoggerInterface;
 
 class Contacts extends Module\BaseProfile
 {
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var IHandleUserSessions */
-	private $userSession;
-	/** @var AppHelper */
-	private $appHelper;
-	/** @var Database */
-	private $database;
-
-	public function __construct(Database $database, AppHelper $appHelper, IHandleUserSessions $userSession, IManageConfigValues $config, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Database $database, private AppHelper $appHelper, private IHandleUserSessions $userSession, private IManageConfigValues $config, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config      = $config;
-		$this->userSession = $userSession;
-		$this->appHelper   = $appHelper;
-		$this->database    = $database;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Profile/Conversations.php
+++ b/src/Module/Profile/Conversations.php
@@ -135,12 +135,12 @@ class Conversations extends BaseProfile
 
 		if (!empty($category)) {
 			$condition = DBA::mergeConditions($condition, ["`uri-id` IN (SELECT `uri-id` FROM `category-view` WHERE `name` = ? AND `type` = ? AND `uid` = ?)",
-			                                               $category, Category::CATEGORY, $profile['uid']]);
+				$category, Category::CATEGORY, $profile['uid']]);
 		}
 
 		if (!empty($hashtags)) {
 			$condition = DBA::mergeConditions($condition, ["`uri-id` IN (SELECT `uri-id` FROM `tag-search-view` WHERE `name` = ? AND `uid` = ?)",
-			                                               $hashtags, $profile['uid']]);
+				$hashtags, $profile['uid']]);
 		}
 
 		if (!empty($datequery)) {
@@ -158,20 +158,28 @@ class Conversations extends BaseProfile
 		}
 
 		if ($this->mode->isMobile()) {
-			$itemspage_network = $this->pConfig->get($this->session->getLocalUserId(), 'system', 'itemspage_mobile_network',
-				$this->config->get('system', 'itemspage_network_mobile'));
+			$itemspage_network = $this->pConfig->get(
+				$this->session->getLocalUserId(),
+				'system',
+				'itemspage_mobile_network',
+				$this->config->get('system', 'itemspage_network_mobile'),
+			);
 		} else {
-			$itemspage_network = $this->pConfig->get($this->session->getLocalUserId(), 'system', 'itemspage_network',
-				$this->config->get('system', 'itemspage_network'));
+			$itemspage_network = $this->pConfig->get(
+				$this->session->getLocalUserId(),
+				'system',
+				'itemspage_network',
+				$this->config->get('system', 'itemspage_network'),
+			);
 		}
 
 		$condition = DBA::mergeConditions($condition, ["((`gravity` = ? AND `wall`) OR
 			(`gravity` = ? AND `vid` = ? AND `origin`
 			AND EXISTS(SELECT `uri-id` FROM `post` WHERE `uri-id` = `post-origin-view`.`thr-parent-id` AND `gravity` = ? AND `network` IN (?, ?))))",
-		                                               Item::GRAVITY_PARENT, Item::GRAVITY_ACTIVITY, Verb::getID(Activity::ANNOUNCE), Item::GRAVITY_PARENT, Protocol::ACTIVITYPUB, Protocol::DFRN]);
+			Item::GRAVITY_PARENT, Item::GRAVITY_ACTIVITY, Verb::getID(Activity::ANNOUNCE), Item::GRAVITY_PARENT, Protocol::ACTIVITYPUB, Protocol::DFRN]);
 
-		$condition = DBA::mergeConditions($condition, ['uid'     => $profile['uid'], 'network' => Protocol::FEDERATED,
-		                                               'visible' => true, 'deleted' => false]);
+		$condition = DBA::mergeConditions($condition, ['uid' => $profile['uid'], 'network' => Protocol::FEDERATED,
+			'visible'                                           => true, 'deleted' => false]);
 
 		$pager  = new Pager($this->l10n, $this->args->getQueryString(), $itemspage_network);
 		$params = ['limit' => [$pager->getStart(), $pager->getItemsPerPage()], 'order' => ['received' => true]];

--- a/src/Module/Profile/Conversations.php
+++ b/src/Module/Profile/Conversations.php
@@ -43,35 +43,9 @@ use Psr\Log\LoggerInterface;
 
 class Conversations extends BaseProfile
 {
-	/** @var AppHelper */
-	private $appHelper;
-	/** @var Page */
-	private $page;
-	/** @var DateTimeFormat */
-	private $dateTimeFormat;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var Conversation */
-	private $conversation;
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-	/** @var Mode */
-	private $mode;
-
-	public function __construct(Mode $mode, IManagePersonalConfigValues $pConfig, Conversation $conversation, IHandleUserSessions $session, IManageConfigValues $config, DateTimeFormat $dateTimeFormat, Page $page, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Mode $mode, private IManagePersonalConfigValues $pConfig, private Conversation $conversation, private IHandleUserSessions $session, private IManageConfigValues $config, private DateTimeFormat $dateTimeFormat, private Page $page, private AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->appHelper      = $appHelper;
-		$this->page           = $page;
-		$this->dateTimeFormat = $dateTimeFormat;
-		$this->config         = $config;
-		$this->session        = $session;
-		$this->conversation   = $conversation;
-		$this->pConfig        = $pConfig;
-		$this->mode           = $mode;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Profile/Index.php
+++ b/src/Module/Profile/Index.php
@@ -37,40 +37,18 @@ use Psr\Log\LoggerInterface;
  */
 class Index extends BaseModule
 {
-	/** @var Database */
-	private $database;
-	/** @var AppHelper */
-	private $appHelper;
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var Page */
-	private $page;
-	/** @var ProfileField */
-	private $profileField;
-	/** @var DateTimeFormat */
-	private $dateTimeFormat;
-	/** @var Conversation */
-	private $conversation;
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-	/** @var Mode */
-	private $mode;
-	private EventDispatcherInterface $eventDispatcher;
-
 	public function __construct(
-		Mode $mode,
-		IManagePersonalConfigValues $pConfig,
-		Conversation $conversation,
-		DateTimeFormat $dateTimeFormat,
-		ProfileField $profileField,
-		Page $page,
-		IManageConfigValues $config,
-		IHandleUserSessions $session,
-		AppHelper $appHelper,
-		Database $database,
-		EventDispatcherInterface $eventDispatcher,
+		private Mode $mode,
+		private IManagePersonalConfigValues $pConfig,
+		private Conversation $conversation,
+		private DateTimeFormat $dateTimeFormat,
+		private ProfileField $profileField,
+		private Page $page,
+		private IManageConfigValues $config,
+		private IHandleUserSessions $session,
+		private AppHelper $appHelper,
+		private Database $database,
+		private EventDispatcherInterface $eventDispatcher,
 		L10n $l10n,
 		BaseURL $baseUrl,
 		Arguments $args,
@@ -81,18 +59,6 @@ class Index extends BaseModule
 		array $parameters = []
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->database        = $database;
-		$this->appHelper       = $appHelper;
-		$this->session         = $session;
-		$this->config          = $config;
-		$this->page            = $page;
-		$this->profileField    = $profileField;
-		$this->dateTimeFormat  = $dateTimeFormat;
-		$this->conversation    = $conversation;
-		$this->pConfig         = $pConfig;
-		$this->mode            = $mode;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Profile/Index.php
+++ b/src/Module/Profile/Index.php
@@ -56,7 +56,7 @@ class Index extends BaseModule
 		Profiler $profiler,
 		Response $response,
 		array $server,
-		array $parameters = []
+		array $parameters = [],
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 	}

--- a/src/Module/Profile/Media.php
+++ b/src/Module/Profile/Media.php
@@ -33,7 +33,7 @@ class Media extends BaseProfile
 		Response $response,
 		private IHandleUserSessions $userSession,
 		$server,
-		array $parameters = []
+		array $parameters = [],
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 	}

--- a/src/Module/Profile/Media.php
+++ b/src/Module/Profile/Media.php
@@ -23,32 +23,19 @@ use Psr\Log\LoggerInterface;
 
 class Media extends BaseProfile
 {
-	/**
-	 * @var AppHelper
-	 */
-	private $appHelper;
-
-	/**
-	 * @var IHandleUserSessions
-	 */
-	private $userSession;
-
 	public function __construct(
 		L10n $l10n,
 		BaseURL $baseUrl,
 		Arguments $args,
-		AppHelper $appHelper,
+		private AppHelper $appHelper,
 		LoggerInterface $logger,
 		Profiler $profiler,
 		Response $response,
-		IHandleUserSessions $userSession,
+		private IHandleUserSessions $userSession,
 		$server,
 		array $parameters = []
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->appHelper   = $appHelper;
-		$this->userSession = $userSession;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Profile/Notes.php
+++ b/src/Module/Profile/Notes.php
@@ -37,13 +37,6 @@ use Psr\Log\LoggerInterface;
  */
 class Notes extends BaseProfile
 {
-	protected AppHelper $appHelper;
-	protected UserSession $userSession;
-	protected Mode $mode;
-	protected IManagePersonalConfigValues $pConfig;
-	protected IManageConfigValues $config;
-	protected Conversation $conversation;
-
 	/**
 	 * Notes constructor.
 	 *
@@ -62,15 +55,9 @@ class Notes extends BaseProfile
 	 * @param IManageConfigValues $config
 	 * @param Conversation $conversation
 	 */
-	public function __construct(AppHelper $appHelper, UserSession $userSession, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, \Friendica\Module\Response $response, array $server, array $parameters, Mode $mode, IManagePersonalConfigValues $pConfig, IManageConfigValues $config, Conversation $conversation)
+	public function __construct(protected AppHelper $appHelper, protected UserSession $userSession, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, \Friendica\Module\Response $response, array $server, array $parameters, protected Mode $mode, protected IManagePersonalConfigValues $pConfig, protected IManageConfigValues $config, protected Conversation $conversation)
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-		$this->appHelper    = $appHelper;
-		$this->userSession  = $userSession;
-		$this->mode         = $mode;
-		$this->pConfig      = $pConfig;
-		$this->config       = $config;
-		$this->conversation = $conversation;
 	}
 
 	/**

--- a/src/Module/Profile/Photos.php
+++ b/src/Module/Profile/Photos.php
@@ -36,33 +36,18 @@ use Psr\Log\LoggerInterface;
 
 class Photos extends \Friendica\Module\BaseProfile
 {
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var Page */
-	private $page;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var AppHelper */
-	private $appHelper;
-	/** @var Database */
-	private $database;
-	/** @var SystemMessages */
-	private $systemMessages;
-	/** @var ACLFormatter */
-	private $aclFormatter;
-	private EventDispatcherInterface $eventDispatcher;
 	/** @var array owner-view record */
 	private $owner;
 
 	public function __construct(
-		ACLFormatter $aclFormatter,
-		SystemMessages $systemMessages,
-		Database $database,
-		AppHelper $appHelper,
-		IManageConfigValues $config,
-		Page $page,
-		IHandleUserSessions $session,
-		EventDispatcherInterface $eventDispatcher,
+		private ACLFormatter $aclFormatter,
+		private SystemMessages $systemMessages,
+		private Database $database,
+		private AppHelper $appHelper,
+		private IManageConfigValues $config,
+		private Page $page,
+		private IHandleUserSessions $session,
+		private EventDispatcherInterface $eventDispatcher,
 		L10n $l10n,
 		BaseURL $baseUrl,
 		Arguments $args,
@@ -73,15 +58,6 @@ class Photos extends \Friendica\Module\BaseProfile
 		array $parameters = [],
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session         = $session;
-		$this->page            = $page;
-		$this->config          = $config;
-		$this->appHelper       = $appHelper;
-		$this->database        = $database;
-		$this->systemMessages  = $systemMessages;
-		$this->aclFormatter    = $aclFormatter;
-		$this->eventDispatcher = $eventDispatcher;
 
 		$owner = Profile::load($this->appHelper, $this->parameters['nickname'] ?? '', false);
 		if (!$owner || $owner['account_removed'] || $owner['account_expired']) {

--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -44,28 +44,14 @@ use Psr\Log\LoggerInterface;
 
 class Profile extends BaseProfile
 {
-	/** @var Database */
-	private $database;
-	/** @var AppHelper */
-	private $appHelper;
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var Page */
-	private $page;
-	/** @var ProfileField */
-	private $profileField;
-	private EventDispatcherInterface $eventDispatcher;
-
 	public function __construct(
-		ProfileField $profileField,
-		Page $page,
-		IManageConfigValues $config,
-		IHandleUserSessions $session,
-		AppHelper $appHelper,
-		Database $database,
-		EventDispatcherInterface $eventDispatcher,
+		private ProfileField $profileField,
+		private Page $page,
+		private IManageConfigValues $config,
+		private IHandleUserSessions $session,
+		private AppHelper $appHelper,
+		private Database $database,
+		private EventDispatcherInterface $eventDispatcher,
 		L10n $l10n,
 		BaseURL $baseUrl,
 		Arguments $args,
@@ -76,14 +62,6 @@ class Profile extends BaseProfile
 		array $parameters = [],
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->database        = $database;
-		$this->appHelper       = $appHelper;
-		$this->session         = $session;
-		$this->config          = $config;
-		$this->page            = $page;
-		$this->profileField    = $profileField;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Profile/RemoteFollow.php
+++ b/src/Module/Profile/RemoteFollow.php
@@ -34,23 +34,16 @@ use Psr\Log\LoggerInterface;
  */
 class RemoteFollow extends BaseModule
 {
-	/** @var SystemMessages */
-	private $systemMessages;
 	/** @var Page */
 	protected $page;
-	/** @var IHandleUserSessions */
-	private $userSession;
 
 	/** @var array */
 	protected $owner;
 
-	public function __construct(IHandleUserSessions $userSession, SystemMessages $systemMessages, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, App\Page $page, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private IHandleUserSessions $userSession, private SystemMessages $systemMessages, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, App\Page $page, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->systemMessages = $systemMessages;
 		$this->page           = $page;
-		$this->userSession    = $userSession;
 
 		$this->owner = User::getOwnerDataByNick($this->parameters['nickname']);
 		if (!$this->owner) {

--- a/src/Module/Profile/RemoteFollow.php
+++ b/src/Module/Profile/RemoteFollow.php
@@ -12,15 +12,12 @@ use Friendica\App\Page;
 use Friendica\BaseModule;
 use Friendica\Content\Widget;
 use Friendica\Core\L10n;
-use Friendica\Core\Logger;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Core\Search;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Core\System;
-use Friendica\DI;
 use Friendica\Model\Contact;
-use Friendica\Model\Profile;
 use Friendica\Model\User;
 use Friendica\Module\Response;
 use Friendica\Navigation\SystemMessages;
@@ -43,7 +40,7 @@ class RemoteFollow extends BaseModule
 	public function __construct(private IHandleUserSessions $userSession, private SystemMessages $systemMessages, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, App\Page $page, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-		$this->page           = $page;
+		$this->page = $page;
 
 		$this->owner = User::getOwnerDataByNick($this->parameters['nickname']);
 		if (!$this->owner) {
@@ -104,17 +101,17 @@ class RemoteFollow extends BaseModule
 
 		$tpl = Renderer::getMarkupTemplate('auto_request.tpl');
 		return Renderer::replaceMacros($tpl, [
-			'$header'        => $this->t('Friend/Connection Request'),
-			'$page_desc'     => $this->t('Enter your Webfinger address (user@domain.tld) or profile URL here. If this isn\'t supported by your system, you have to subscribe to <strong>%s</strong> or <strong>%s</strong> directly on your system.', $target_addr, $target_url),
-			'$invite_desc'   => $this->t('If you are not yet a member of the free social web, <a href="%s">follow this link to find a public Friendica node and join us today</a>.', Search::getGlobalDirectory() . '/servers'),
-			'$your_address'  => $this->t('Your Webfinger address or profile URL:'),
-			'$pls_answer'    => $this->t('Please answer the following:'),
-			'$submit'        => $this->t('Submit Request'),
-			'$cancel'        => $this->t('Cancel'),
+			'$header'       => $this->t('Friend/Connection Request'),
+			'$page_desc'    => $this->t('Enter your Webfinger address (user@domain.tld) or profile URL here. If this isn\'t supported by your system, you have to subscribe to <strong>%s</strong> or <strong>%s</strong> directly on your system.', $target_addr, $target_url),
+			'$invite_desc'  => $this->t('If you are not yet a member of the free social web, <a href="%s">follow this link to find a public Friendica node and join us today</a>.', Search::getGlobalDirectory() . '/servers'),
+			'$your_address' => $this->t('Your Webfinger address or profile URL:'),
+			'$pls_answer'   => $this->t('Please answer the following:'),
+			'$submit'       => $this->t('Submit Request'),
+			'$cancel'       => $this->t('Cancel'),
 
-			'$action'        => 'profile/' . $this->parameters['nickname'] . '/remote_follow',
-			'$name'          => $this->owner['name'],
-			'$myaddr'        => $this->userSession->getMyUrl(),
+			'$action' => 'profile/' . $this->parameters['nickname'] . '/remote_follow',
+			'$name'   => $this->owner['name'],
+			'$myaddr' => $this->userSession->getMyUrl(),
 		]);
 	}
 }

--- a/src/Module/Profile/Restricted.php
+++ b/src/Module/Profile/Restricted.php
@@ -21,14 +21,9 @@ use Psr\Log\LoggerInterface;
 
 class Restricted extends BaseModule
 {
-	/** @var AppHelper */
-	private $appHelper;
-
-	public function __construct(AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->appHelper = $appHelper;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -39,19 +39,11 @@ class Register extends BaseModule
 	/** @var Tos */
 	protected $tos;
 
-	/** @var IHandleUserSessions */
-	private $session;
-
-	private EventDispatcherInterface $eventDispatcher;
-
-	public function __construct(IHandleUserSessions $session, EventDispatcherInterface $eventDispatcher, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IManageConfigValues $config, array $server, array $parameters = [])
+	public function __construct(private IHandleUserSessions $session, private EventDispatcherInterface $eventDispatcher, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IManageConfigValues $config, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
 		$this->tos = new Tos($l10n, $baseUrl, $args, $logger, $profiler, $response, $config, $server, $parameters);
-
-		$this->session         = $session;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	/**

--- a/src/Module/Search/Acl.php
+++ b/src/Module/Search/Acl.php
@@ -41,16 +41,10 @@ class Acl extends BaseModule
 	const TYPE_PRIVATE_MESSAGE        = 'm';
 	const TYPE_ANY_CONTACT            = 'a';
 
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var Database */
-	private $database;
-	private EventDispatcherInterface $eventDispatcher;
-
 	public function __construct(
-		Database $database,
-		IHandleUserSessions $session,
-		EventDispatcherInterface $eventDispatcher,
+		private Database $database,
+		private IHandleUserSessions $session,
+		private EventDispatcherInterface $eventDispatcher,
 		L10n $l10n,
 		BaseURL $baseUrl,
 		Arguments $args,
@@ -61,10 +55,6 @@ class Acl extends BaseModule
 		array $parameters = []
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session         = $session;
-		$this->database        = $database;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Search/Acl.php
+++ b/src/Module/Search/Acl.php
@@ -33,13 +33,13 @@ use Psr\Log\LoggerInterface;
  */
 class Acl extends BaseModule
 {
-	const TYPE_GLOBAL_CONTACT         = 'x';
-	const TYPE_MENTION_CONTACT        = 'c';
-	const TYPE_MENTION_CIRCLE         = 'g';
-	const TYPE_MENTION_CONTACT_CIRCLE = '';
-	const TYPE_MENTION_GROUP          = 'f';
-	const TYPE_PRIVATE_MESSAGE        = 'm';
-	const TYPE_ANY_CONTACT            = 'a';
+	public const TYPE_GLOBAL_CONTACT         = 'x';
+	public const TYPE_MENTION_CONTACT        = 'c';
+	public const TYPE_MENTION_CIRCLE         = 'g';
+	public const TYPE_MENTION_CONTACT_CIRCLE = '';
+	public const TYPE_MENTION_GROUP          = 'f';
+	public const TYPE_PRIVATE_MESSAGE        = 'm';
+	public const TYPE_ANY_CONTACT            = 'a';
 
 	public function __construct(
 		private Database $database,
@@ -52,7 +52,7 @@ class Acl extends BaseModule
 		Profiler $profiler,
 		Response $response,
 		array $server,
-		array $parameters = []
+		array $parameters = [],
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 	}
@@ -149,23 +149,23 @@ class Acl extends BaseModule
 				$condition = DBA::mergeConditions(
 					$condition,
 					["NOT `self` AND NOT `blocked`",
-					]
+					],
 				);
 				break;
 
 			case self::TYPE_MENTION_GROUP:
 				$condition = DBA::mergeConditions(
 					$condition,
-					["NOT `self` AND NOT `blocked` AND (NOT `ap-posting-restricted` OR `ap-posting-restricted` IS NULL) AND `contact-type` = ?", Contact::TYPE_COMMUNITY
-					]
+					["NOT `self` AND NOT `blocked` AND (NOT `ap-posting-restricted` OR `ap-posting-restricted` IS NULL) AND `contact-type` = ?", Contact::TYPE_COMMUNITY,
+					],
 				);
 				break;
 
 			case self::TYPE_PRIVATE_MESSAGE:
 				$condition = DBA::mergeConditions(
 					$condition,
-					["NOT `self` AND NOT `blocked` AND `network` IN (?, ?, ?)", Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA
-					]
+					["NOT `self` AND NOT `blocked` AND `network` IN (?, ?, ?)", Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA,
+					],
 				);
 				break;
 		}
@@ -191,7 +191,7 @@ class Acl extends BaseModule
 				LIMIT ?, ?",
 				$this->session->getLocalUserId(),
 				$start,
-				$count
+				$count,
 			));
 
 			foreach ($circles as $circle) {
@@ -202,7 +202,7 @@ class Acl extends BaseModule
 					'id'    => intval($circle['id']),
 					'uids'  => array_map('intval', explode(',', $circle['uids'])),
 					'link'  => '',
-					'group' => '0'
+					'group' => '0',
 				];
 			}
 			if ((count($resultCircles) > 0) && ($search == '')) {
@@ -282,7 +282,7 @@ class Acl extends BaseModule
 						'link'    => $contact['url'],
 						'nick'    => htmlentities(($contact['nick'] ?? '') ?: $contact['addr']),
 						'addr'    => htmlentities(($contact['addr'] ?? '') ?: $contact['url']),
-						'group'   => $contact['forum']
+						'group'   => $contact['forum'],
 					];
 				}
 			}

--- a/src/Module/Security/Login.php
+++ b/src/Module/Security/Login.php
@@ -78,7 +78,7 @@ class Login extends BaseModule
 				trim($request['username']),
 				trim($request['password']),
 				!empty($request['remember']),
-				$request['return_path'] ?? ''
+				$request['return_path'] ?? '',
 			);
 		}
 	}
@@ -113,7 +113,7 @@ class Login extends BaseModule
 			$reg = [
 				'title' => DI::l10n()->t('Create an account'),
 				'desc'  => DI::l10n()->t('Register'),
-				'url'   => self::getRegisterURL()
+				'url'   => self::getRegisterURL(),
 			];
 		}
 
@@ -123,7 +123,7 @@ class Login extends BaseModule
 			DI::page()['htmlhead'] .= Renderer::replaceMacros(
 				Renderer::getMarkupTemplate('login_head.tpl'),
 				[
-				]
+				],
 			);
 
 			$tpl = Renderer::getMarkupTemplate('login.tpl');
@@ -170,7 +170,7 @@ class Login extends BaseModule
 
 				'$privacytitle' => DI::l10n()->t('Website Privacy Policy'),
 				'$privacylink'  => DI::l10n()->t('privacy policy'),
-			]
+			],
 		);
 
 		Hook::callAll('login_hook', $o);

--- a/src/Module/Security/Login.php
+++ b/src/Module/Security/Login.php
@@ -26,22 +26,9 @@ use Psr\Log\LoggerInterface;
  */
 class Login extends BaseModule
 {
-	/** @var Authentication */
-	private $auth;
-
-	/** @var IManageConfigValues */
-	private $config;
-
-	/** @var IHandleUserSessions */
-	private $session;
-
-	public function __construct(Authentication $auth, IManageConfigValues $config, IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Authentication $auth, private IManageConfigValues $config, private IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->auth    = $auth;
-		$this->config  = $config;
-		$this->session = $session;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Security/PasswordTooLong.php
+++ b/src/Module/Security/PasswordTooLong.php
@@ -20,17 +20,9 @@ use Psr\Log\LoggerInterface;
 
 class PasswordTooLong extends \Friendica\BaseModule
 {
-	/** @var SystemMessages */
-	private $sysmsg;
-	/** @var IHandleUserSessions */
-	private $userSession;
-
-	public function __construct(SystemMessages $sysmsg, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IHandleUserSessions $userSession, $server, array $parameters = [])
+	public function __construct(private SystemMessages $sysmsg, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, private IHandleUserSessions $userSession, $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->sysmsg      = $sysmsg;
-		$this->userSession = $userSession;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/Addons.php
+++ b/src/Module/Settings/Addons.php
@@ -20,14 +20,9 @@ use Psr\Log\LoggerInterface;
 
 class Addons extends BaseSettings
 {
-	/** @var Database */
-	private $database;
-
-	public function __construct(Database $database, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Database $database, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->database = $database;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/Channels.php
+++ b/src/Module/Settings/Channels.php
@@ -28,23 +28,9 @@ use Psr\Log\LoggerInterface;
 
 class Channels extends BaseSettings
 {
-	/** @var UserDefinedChannel */
-	private $channel;
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-	/** @var Factory\UserDefinedChannel */
-	private $userDefinedChannel;
-	/** @var IManageConfigValues */
-	private $config;
-
-	public function __construct(Factory\UserDefinedChannel $userDefinedChannel, UserDefinedChannel $channel, App\Page $page, IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, IManagePersonalConfigValues $pConfig, IManageConfigValues $config, array $server, array $parameters = [])
+	public function __construct(private Factory\UserDefinedChannel $userDefinedChannel, private UserDefinedChannel $channel, App\Page $page, IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, private IManagePersonalConfigValues $pConfig, private IManageConfigValues $config, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->userDefinedChannel = $userDefinedChannel;
-		$this->channel            = $channel;
-		$this->config             = $config;
-		$this->pConfig            = $pConfig;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/Connectors.php
+++ b/src/Module/Settings/Connectors.php
@@ -28,23 +28,9 @@ use Psr\Log\LoggerInterface;
 
 class Connectors extends BaseSettings
 {
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var IManagePersonalConfigValues */
-	private $pconfig;
-	/** @var Database */
-	private $database;
-	/** @var SystemMessages */
-	private $systemMessages;
-
-	public function __construct(SystemMessages $systemMessages, Database $database, IManagePersonalConfigValues $pconfig, IManageConfigValues $config, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private SystemMessages $systemMessages, private Database $database, private IManagePersonalConfigValues $pconfig, private IManageConfigValues $config, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config         = $config;
-		$this->pconfig        = $pconfig;
-		$this->database       = $database;
-		$this->systemMessages = $systemMessages;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/ContactImport.php
+++ b/src/Module/Settings/ContactImport.php
@@ -33,17 +33,11 @@ use Psr\Log\LoggerInterface;
  **/
 class ContactImport extends BaseSettings
 {
-	private IManageConfigValues $config;
 	protected SystemMessages $systemMessages;
-	private ICanSendHttpRequests $httpClient;
 
-	public function __construct(ICanSendHttpRequests $httpClient, SystemMessages $systemMessages, IManageConfigValues $config, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private ICanSendHttpRequests $httpClient, SystemMessages $systemMessages, private IManageConfigValues $config, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config         = $config;
-		$this->systemMessages = $systemMessages;
-		$this->httpClient     = $httpClient;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/ContactImport.php
+++ b/src/Module/Settings/ContactImport.php
@@ -38,6 +38,8 @@ class ContactImport extends BaseSettings
 	public function __construct(private ICanSendHttpRequests $httpClient, SystemMessages $systemMessages, private IManageConfigValues $config, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+
+		$this->systemMessages = $systemMessages;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/Delegation.php
+++ b/src/Module/Settings/Delegation.php
@@ -27,17 +27,9 @@ use Psr\Log\LoggerInterface;
  */
 class Delegation extends BaseSettings
 {
-	/** @var SystemMessages */
-	private $systemMessages;
-	/** @var Database */
-	private $db;
-
-	public function __construct(Database $db, SystemMessages $systemMessages, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Database $db, private SystemMessages $systemMessages, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->systemMessages = $systemMessages;
-		$this->db             = $db;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -43,14 +43,6 @@ use Psr\Log\LoggerInterface;
  */
 class Display extends BaseSettings
 {
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-	/** @var AppHelper */
-	private $appHelper;
-	/** @var SystemMessages */
-	private $systemMessages;
 	/** @var ChannelFactory */
 	protected $channel;
 	/** @var Repository\UserDefinedChannel */
@@ -62,14 +54,9 @@ class Display extends BaseSettings
 	/** @var TimelineFactory */
 	protected $timeline;
 
-	public function __construct(Repository\UserDefinedChannel $userDefinedChannel, NetworkFactory $network, CommunityFactory $community, ChannelFactory $channel, TimelineFactory $timeline, SystemMessages $systemMessages, AppHelper $appHelper, IManagePersonalConfigValues $pConfig, IManageConfigValues $config, IHandleUserSessions $session, Page $page, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(Repository\UserDefinedChannel $userDefinedChannel, NetworkFactory $network, CommunityFactory $community, ChannelFactory $channel, TimelineFactory $timeline, private SystemMessages $systemMessages, private AppHelper $appHelper, private IManagePersonalConfigValues $pConfig, private IManageConfigValues $config, IHandleUserSessions $session, Page $page, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config             = $config;
-		$this->pConfig            = $pConfig;
-		$this->appHelper          = $appHelper;
-		$this->systemMessages     = $systemMessages;
 		$this->timeline           = $timeline;
 		$this->channel            = $channel;
 		$this->community          = $community;

--- a/src/Module/Settings/Features.php
+++ b/src/Module/Settings/Features.php
@@ -21,14 +21,9 @@ use Psr\Log\LoggerInterface;
 
 class Features extends BaseSettings
 {
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-
-	public function __construct(IManagePersonalConfigValues $pConfig, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private IManagePersonalConfigValues $pConfig, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->pConfig = $pConfig;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/OAuth.php
+++ b/src/Module/Settings/OAuth.php
@@ -19,14 +19,9 @@ use Psr\Log\LoggerInterface;
 
 class OAuth extends BaseSettings
 {
-	/** @var Database */
-	private $database;
-
-	public function __construct(Database $database, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Database $database, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->database = $database;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/Profile/Index.php
+++ b/src/Module/Settings/Profile/Index.php
@@ -38,28 +38,14 @@ use Psr\Log\LoggerInterface;
 
 class Index extends BaseSettings
 {
-	/** @var ProfileField\Repository\ProfileField */
-	private $profileFieldRepo;
-	/** @var ProfileField\Factory\ProfileField */
-	private $profileFieldFactory;
-	/** @var SystemMessages */
-	private $systemMessages;
-	/** @var PermissionSet\Repository\PermissionSet */
-	private $permissionSetRepo;
-	/** @var PermissionSet\Factory\PermissionSet */
-	private $permissionSetFactory;
-	/** @var ACLFormatter */
-	private $aclFormatter;
-	private EventDispatcherInterface $eventDispatcher;
-
 	public function __construct(
-		ACLFormatter $aclFormatter,
-		PermissionSet\Factory\PermissionSet $permissionSetFactory,
-		PermissionSet\Repository\PermissionSet $permissionSetRepo,
-		SystemMessages $systemMessages,
-		ProfileField\Factory\ProfileField $profileFieldFactory,
-		ProfileField\Repository\ProfileField $profileFieldRepo,
-		EventDispatcherInterface $eventDispatcher,
+		private ACLFormatter $aclFormatter,
+		private PermissionSet\Factory\PermissionSet $permissionSetFactory,
+		private PermissionSet\Repository\PermissionSet $permissionSetRepo,
+		private SystemMessages $systemMessages,
+		private ProfileField\Factory\ProfileField $profileFieldFactory,
+		private ProfileField\Repository\ProfileField $profileFieldRepo,
+		private EventDispatcherInterface $eventDispatcher,
 		IHandleUserSessions $session,
 		Page $page,
 		L10n $l10n,
@@ -72,14 +58,6 @@ class Index extends BaseSettings
 		array $parameters = [],
 	) {
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->profileFieldRepo     = $profileFieldRepo;
-		$this->profileFieldFactory  = $profileFieldFactory;
-		$this->systemMessages       = $systemMessages;
-		$this->permissionSetRepo    = $permissionSetRepo;
-		$this->permissionSetFactory = $permissionSetFactory;
-		$this->aclFormatter         = $aclFormatter;
-		$this->eventDispatcher      = $eventDispatcher;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/RemoveMe.php
+++ b/src/Module/Settings/RemoveMe.php
@@ -64,7 +64,8 @@ class RemoveMe extends BaseSettings
 				->withMessage(
 					$l10n->t('[Friendica System Notify]') . ' ' . $l10n->t('User deleted their account'),
 					$l10n->t('On your Friendica node an user deleted their account. Please ensure that their data is removed from the backups.'),
-					$l10n->t('The user id is %d', $this->session->getLocalUserId()))
+					$l10n->t('The user id is %d', $this->session->getLocalUserId()),
+				)
 				->forUser($admin)
 				->withRecipient($admin['email'])
 				->build();

--- a/src/Module/Settings/RemoveMe.php
+++ b/src/Module/Settings/RemoveMe.php
@@ -25,20 +25,9 @@ use Psr\Log\LoggerInterface;
 
 class RemoveMe extends BaseSettings
 {
-	/** @var Emailer */
-	private $emailer;
-	/** @var SystemMessages */
-	private $systemMessages;
-	/** @var Cookie */
-	private $cookie;
-
-	public function __construct(Cookie $cookie, SystemMessages $systemMessages, Emailer $emailer, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private Cookie $cookie, private SystemMessages $systemMessages, private Emailer $emailer, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->emailer        = $emailer;
-		$this->systemMessages = $systemMessages;
-		$this->cookie         = $cookie;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/Server/Action.php
+++ b/src/Module/Settings/Server/Action.php
@@ -21,20 +21,9 @@ use Psr\Log\LoggerInterface;
 
 class Action extends \Friendica\BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var UserGServer */
-	private $repository;
-	/** @var GServer */
-	private $gserverRepo;
-
-	public function __construct(GServer $gserverRepo, UserGServer $repository, IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private GServer $gserverRepo, private UserGServer $repository, private IHandleUserSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session     = $session;
-		$this->repository  = $repository;
-		$this->gserverRepo = $gserverRepo;
 	}
 
 	public function content(array $request = []): string

--- a/src/Module/Settings/Server/Index.php
+++ b/src/Module/Settings/Server/Index.php
@@ -23,17 +23,9 @@ use Psr\Log\LoggerInterface;
 
 class Index extends BaseSettings
 {
-	/** @var Repository\UserGServer */
-	private $repository;
-	/** @var SystemMessages */
-	private $systemMessages;
-
-	public function __construct(SystemMessages $systemMessages, Repository\UserGServer $repository, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private SystemMessages $systemMessages, private Repository\UserGServer $repository, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->repository     = $repository;
-		$this->systemMessages = $systemMessages;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/Settings/UserExport.php
+++ b/src/Module/Settings/UserExport.php
@@ -32,13 +32,9 @@ use Psr\Log\LoggerInterface;
  **/
 class UserExport extends BaseSettings
 {
-	private DbaDefinition $dbaDefinition;
-
-	public function __construct(DbaDefinition $dbaDefinition, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private DbaDefinition $dbaDefinition, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->dbaDefinition = $dbaDefinition;
 	}
 
 	/**

--- a/src/Module/Settings/UserExport.php
+++ b/src/Module/Settings/UserExport.php
@@ -67,7 +67,7 @@ class UserExport extends BaseSettings
 		 * list of array( 'link url', 'link text', 'help text' )
 		 */
 
-		$t = self::getFormSecurityToken('userexport');
+		$t       = self::getFormSecurityToken('userexport');
 		$options = [
 			['settings/userexport/account?t=' . $t, $this->l10n->t('Export account'), $this->l10n->t('Export your account info and contacts. Use this to make a backup of your account and/or to move it to another server.')],
 			['settings/userexport/backup?t=' . $t, $this->l10n->t('Export all'), $this->l10n->t('Export your account info, contacts and all your items as json. Could be a very big file, and could take a lot of time. Use this to make a full backup of your account (photos are not exported)')],
@@ -77,8 +77,8 @@ class UserExport extends BaseSettings
 
 		$tpl = Renderer::getMarkupTemplate('settings/userexport.tpl');
 		return Renderer::replaceMacros($tpl, [
-			'$title' => $this->l10n->t('Export personal data'),
-			'$options' => $options
+			'$title'   => $this->l10n->t('Export personal data'),
+			'$options' => $options,
 		]);
 	}
 
@@ -132,7 +132,7 @@ class UserExport extends BaseSettings
 		$table = $match[1];
 
 		$result = [];
-		$rows = DBA::p($query);
+		$rows   = DBA::p($query);
 		while ($row = DBA::fetch($rows)) {
 			$p = [];
 			foreach ($dbStructure[$table]['fields'] as $column => $field) {
@@ -161,7 +161,7 @@ class UserExport extends BaseSettings
 		$table = $match[1];
 
 		$result = [];
-		$rows = DBA::p($query);
+		$rows   = DBA::p($query);
 		while ($row = DBA::fetch($rows)) {
 			foreach ($row as $k => $v) {
 				if (empty($dbStructure[$table]['fields'][$k])) {
@@ -216,53 +216,53 @@ class UserExport extends BaseSettings
 		}
 
 		$user = $this->exportRow(
-			sprintf("SELECT * FROM `user` WHERE `uid` = %d LIMIT 1", $user_id)
+			sprintf("SELECT * FROM `user` WHERE `uid` = %d LIMIT 1", $user_id),
 		);
 
 		$contact = $this->exportMultiRow(
-			sprintf("SELECT * FROM `contact` WHERE `uid` = %d ", $user_id)
+			sprintf("SELECT * FROM `contact` WHERE `uid` = %d ", $user_id),
 		);
 
 
 		$profile = $this->exportMultiRow(
-			sprintf("SELECT *, 'default' AS `profile_name`, 1 AS `is-default` FROM `profile` WHERE `uid` = %d ", $user_id)
+			sprintf("SELECT *, 'default' AS `profile_name`, 1 AS `is-default` FROM `profile` WHERE `uid` = %d ", $user_id),
 		);
 
 		$profile_fields = $this->exportMultiRow(
-			sprintf("SELECT * FROM `profile_field` WHERE `uid` = %d ", $user_id)
+			sprintf("SELECT * FROM `profile_field` WHERE `uid` = %d ", $user_id),
 		);
 
 		$photo = $this->exportMultiRow(
-			sprintf("SELECT * FROM `photo` WHERE uid = %d AND profile = 1", $user_id)
+			sprintf("SELECT * FROM `photo` WHERE uid = %d AND profile = 1", $user_id),
 		);
 		foreach ($photo as &$p) {
 			$p['data'] = bin2hex($p['data']);
 		}
 
 		$pconfig = $this->exportMultiRow(
-			sprintf("SELECT * FROM `pconfig` WHERE uid = %d", $user_id)
+			sprintf("SELECT * FROM `pconfig` WHERE uid = %d", $user_id),
 		);
 
 		$circle = $this->exportMultiRow(
-			sprintf("SELECT * FROM `group` WHERE uid = %d", $user_id)
+			sprintf("SELECT * FROM `group` WHERE uid = %d", $user_id),
 		);
 
 		$circle_member = $this->exportMultiRow(
-			sprintf("SELECT `circle_member`.`gid`, `circle_member`.`contact-id` FROM `group_member` AS `circle_member` INNER JOIN `group` AS `circle` ON `circle`.`id` = `circle_member`.`gid` WHERE `circle`.`uid` = %d", $user_id)
+			sprintf("SELECT `circle_member`.`gid`, `circle_member`.`contact-id` FROM `group_member` AS `circle_member` INNER JOIN `group` AS `circle` ON `circle`.`id` = `circle_member`.`gid` WHERE `circle`.`uid` = %d", $user_id),
 		);
 
 		$output = [
-			'version' => App::VERSION,
-			'schema' => DB_UPDATE_VERSION,
-			'baseurl' => $this->baseUrl,
-			'user' => $user,
-			'contact' => $contact,
-			'profile' => $profile,
+			'version'        => App::VERSION,
+			'schema'         => DB_UPDATE_VERSION,
+			'baseurl'        => $this->baseUrl,
+			'user'           => $user,
+			'contact'        => $contact,
+			'profile'        => $profile,
 			'profile_fields' => $profile_fields,
-			'photo' => $photo,
-			'pconfig' => $pconfig,
-			'circle' => $circle,
-			'circle_member' => $circle_member,
+			'photo'          => $photo,
+			'pconfig'        => $pconfig,
+			'circle'         => $circle,
+			'circle_member'  => $circle_member,
 		];
 
 		echo json_encode($output, JSON_PARTIAL_OUTPUT_ON_ERROR);
@@ -287,7 +287,7 @@ class UserExport extends BaseSettings
 		// chunk the output to avoid exhausting memory
 
 		for ($x = 0; $x < $total; $x += 500) {
-			$items = Post::selectToArray(Item::ITEM_FIELDLIST, ['uid' => $user_id], ['limit' => [$x, 500]]);
+			$items  = Post::selectToArray(Item::ITEM_FIELDLIST, ['uid' => $user_id], ['limit' => [$x, 500]]);
 			$output = ['item' => $items];
 			echo json_encode($output, JSON_PARTIAL_OUTPUT_ON_ERROR) . "\n";
 		}

--- a/src/Module/Statistics.php
+++ b/src/Module/Statistics.php
@@ -25,7 +25,6 @@ class Statistics extends BaseModule
 	protected $config;
 	/** @var IManageKeyValuePairs */
 	protected $keyValue;
-	private AddonHelper $addonHelper;
 
 	public function __construct(
 		L10n $l10n,
@@ -35,7 +34,7 @@ class Statistics extends BaseModule
 		Profiler $profiler,
 		IManageConfigValues $config,
 		IManageKeyValuePairs $keyValue,
-		AddonHelper $addonHelper,
+		private AddonHelper $addonHelper,
 		Response $response,
 		array $server,
 		array $parameters = []
@@ -44,7 +43,6 @@ class Statistics extends BaseModule
 
 		$this->config      = $config;
 		$this->keyValue    = $keyValue;
-		$this->addonHelper = $addonHelper;
 
 		if (!$this->config->get("system", "nodeinfo")) {
 			throw new NotFoundException();

--- a/src/Module/Statistics.php
+++ b/src/Module/Statistics.php
@@ -37,12 +37,12 @@ class Statistics extends BaseModule
 		private AddonHelper $addonHelper,
 		Response $response,
 		array $server,
-		array $parameters = []
+		array $parameters = [],
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
-		$this->config      = $config;
-		$this->keyValue    = $keyValue;
+		$this->config   = $config;
+		$this->keyValue = $keyValue;
 
 		if (!$this->config->get("system", "nodeinfo")) {
 			throw new NotFoundException();

--- a/src/Module/Stats.php
+++ b/src/Module/Stats.php
@@ -55,13 +55,13 @@ class Stats extends BaseModule
 		private AddonHelper $addonHelper,
 		Response $response,
 		array $server,
-		array $parameters = []
+		array $parameters = [],
 	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
-		$this->config      = $config;
-		$this->keyValue    = $keyValue;
-		$this->dba         = $dba;
+		$this->config   = $config;
+		$this->keyValue = $keyValue;
+		$this->dba      = $dba;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Stats.php
+++ b/src/Module/Stats.php
@@ -42,7 +42,6 @@ class Stats extends BaseModule
 	protected $logger;
 	/** @var IManageKeyValuePairs */
 	protected $keyValue;
-	private AddonHelper $addonHelper;
 
 	public function __construct(
 		L10n $l10n,
@@ -53,7 +52,7 @@ class Stats extends BaseModule
 		IManageConfigValues $config,
 		IManageKeyValuePairs $keyValue,
 		Database $dba,
-		AddonHelper $addonHelper,
+		private AddonHelper $addonHelper,
 		Response $response,
 		array $server,
 		array $parameters = []
@@ -63,7 +62,6 @@ class Stats extends BaseModule
 		$this->config      = $config;
 		$this->keyValue    = $keyValue;
 		$this->dba         = $dba;
-		$this->addonHelper = $addonHelper;
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/StatsCaching.php
+++ b/src/Module/StatsCaching.php
@@ -27,17 +27,9 @@ use Friendica\Network\HTTPException;
  */
 class StatsCaching extends BaseModule
 {
-	private IManageConfigValues $config;
-	private ICanCache $cache;
-	private ICanLock $lock;
-
-	public function __construct(L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, IManageConfigValues $config, ICanCache $cache, ICanLock $lock, array $parameters = [])
+	public function __construct(L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, private IManageConfigValues $config, private ICanCache $cache, private ICanLock $lock, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config = $config;
-		$this->cache  = $cache;
-		$this->lock   = $lock;
 	}
 
 	private function isAllowed(array $request): bool

--- a/src/Module/ToggleMobile.php
+++ b/src/Module/ToggleMobile.php
@@ -22,14 +22,9 @@ use Psr\Log\LoggerInterface;
  */
 class ToggleMobile extends BaseModule
 {
-	/** @var IHandleSessions */
-	private $session;
-
-	public function __construct(IHandleSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Util\Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private IHandleSessions $session, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Util\Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session = $session;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/ToggleMobile.php
+++ b/src/Module/ToggleMobile.php
@@ -39,6 +39,6 @@ class ToggleMobile extends BaseModule
 
 		$this->session->set('show-mobile', !isset($request['off']));
 
-		System::externalRedirect((string)$uri);
+		System::externalRedirect((string) $uri);
 	}
 }

--- a/src/Module/Update/Contact.php
+++ b/src/Module/Update/Contact.php
@@ -32,8 +32,6 @@ use Psr\Log\LoggerInterface;
  */
 final class Contact extends ContactModule
 {
-	private UserSession $userSession;
-
 	/**
 	 * Contact update module constructor.
 	 *
@@ -47,10 +45,9 @@ final class Contact extends ContactModule
 	 * @param array $parameters
 	 * @param UserSession $userSession
 	 */
-	public function __construct(L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters, UserSession $userSession)
+	public function __construct(L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters, private UserSession $userSession)
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-		$this->userSession = $userSession;
 	}
 
 	/**

--- a/src/Module/User/Delegation.php
+++ b/src/Module/User/Delegation.php
@@ -33,34 +33,9 @@ use Psr\Log\LoggerInterface;
  */
 class Delegation extends BaseModule
 {
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var Database */
-	private $db;
-	/** @var Authentication */
-	private $auth;
-	/** @var SystemMessages */
-	private $systemMessages;
-	/** @var Notify */
-	private $notify;
-	/** @var Introduction */
-	private $intro;
-	/** @var AppHelper */
-	private $appHelper;
-	private EventDispatcherInterface $eventDispatcher;
-
-	public function __construct(EventDispatcherInterface $eventDispatcher, AppHelper $appHelper, Introduction $intro, Notify $notify, SystemMessages $systemMessages, Authentication $auth, Database $db, IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Util\Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private EventDispatcherInterface $eventDispatcher, private AppHelper $appHelper, private Introduction $intro, private Notify $notify, private SystemMessages $systemMessages, private Authentication $auth, private Database $db, private IHandleUserSessions $session, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Util\Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->session         = $session;
-		$this->db              = $db;
-		$this->auth            = $auth;
-		$this->systemMessages  = $systemMessages;
-		$this->notify          = $notify;
-		$this->intro           = $intro;
-		$this->appHelper       = $appHelper;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/User/Delegation.php
+++ b/src/Module/User/Delegation.php
@@ -86,8 +86,7 @@ class Delegation extends BaseModule
 			if (!$this->db->isResult($user)
 				&& (
 					$orig_record['parent-uid'] && $orig_record['parent-uid'] === $identity
-					||
-					$orig_record['uid'] && $orig_record['uid'] === $identity
+					|| $orig_record['uid'] && $orig_record['uid'] === $identity
 				)
 			) {
 				$user = User::getById($identity);
@@ -107,7 +106,7 @@ class Delegation extends BaseModule
 		}
 
 		$this->eventDispatcher->dispatch(
-			new Event(Event::HOME_INIT)
+			new Event(Event::HOME_INIT),
 		);
 
 		$this->systemMessages->addNotice($this->t('You are now logged in as %s', $user['username']));
@@ -132,13 +131,13 @@ class Delegation extends BaseModule
 			$notifications = $this->notify->countForUser(
 				$identity['uid'],
 				["`msg` != '' AND NOT (`type` IN (?, ?)) AND NOT `seen`", Notification\Type::INTRO, Notification\Type::MAIL],
-				['distinct' => true, 'expression' => 'parent']
+				['distinct' => true, 'expression' => 'parent'],
 			);
 
 			$notifications += $this->db->count(
 				'mail',
 				['uid'      => $identity['uid'], 'seen' => false],
-				['distinct' => true, 'expression' => 'convid']
+				['distinct' => true, 'expression' => 'convid'],
 			);
 
 			$notifications += $this->intro->countActiveForUser($identity['uid']);

--- a/src/Module/User/Import.php
+++ b/src/Module/User/Import.php
@@ -35,36 +35,11 @@ use Psr\Log\LoggerInterface;
 class Import extends \Friendica\BaseModule
 {
 	public const IMPORT_DEBUG = false;
-	public const MEMORY_LIMIT = 67108864; // 64MB
+	public const MEMORY_LIMIT = 67108864;
 
-	/** @var IManageConfigValues */
-	private $config;
-
-	/** @var IManagePersonalConfigValues */
-	private $pconfig;
-
-	/** @var SystemMessages */
-	private $systemMessages;
-
-	/** @var Database */
-	private $database;
-
-	/** @var PermissionSet */
-	private $permissionSet;
-
-	/** @var UserSession */
-	private $session;
-
-	public function __construct(UserSession $session, PermissionSet $permissionSet, IManagePersonalConfigValues $pconfig, Database $database, SystemMessages $systemMessages, IManageConfigValues $config, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private UserSession $session, private PermissionSet $permissionSet, private IManagePersonalConfigValues $pconfig, private Database $database, private SystemMessages $systemMessages, private IManageConfigValues $config, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config         = $config;
-		$this->pconfig        = $pconfig;
-		$this->systemMessages = $systemMessages;
-		$this->database       = $database;
-		$this->permissionSet  = $permissionSet;
-		$this->session        = $session;
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/User/PortableContacts.php
+++ b/src/Module/User/PortableContacts.php
@@ -31,20 +31,9 @@ use Psr\Log\LoggerInterface;
  */
 class PortableContacts extends BaseModule
 {
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var Database */
-	private $database;
-	/** @var ICanCache */
-	private $cache;
-
-	public function __construct(ICanCache $cache, Database $database, IManageConfigValues $config, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private ICanCache $cache, private Database $database, private IManageConfigValues $config, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
-
-		$this->config   = $config;
-		$this->database = $database;
-		$this->cache    = $cache;
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/User/PortableContacts.php
+++ b/src/Module/User/PortableContacts.php
@@ -17,7 +17,6 @@ use Friendica\Core\Cache\Capability\ICanCache;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Core\Protocol;
-use Friendica\Core\System;
 use Friendica\Database\Database;
 use Friendica\Module\Response;
 use Friendica\Network\HTTPException;
@@ -96,7 +95,7 @@ class PortableContacts extends BaseModule
 			'tags'              => false,
 			'address'           => false,
 			'contactType'       => false,
-			'generation'        => false
+			'generation'        => false,
 		];
 
 		if (empty($request['fields']) || $request['fields'] == '@all') {
@@ -146,7 +145,7 @@ class PortableContacts extends BaseModule
 
 			$entry = [];
 			if ($selectedFields['id']) {
-				$entry['id'] = (int)$contact['id'];
+				$entry['id'] = (int) $contact['id'];
 			}
 
 			if ($selectedFields['displayName']) {
@@ -162,7 +161,7 @@ class PortableContacts extends BaseModule
 			}
 
 			if ($selectedFields['generation']) {
-				$entry['generation'] = (int)$contact['generation'];
+				$entry['generation'] = (int) $contact['generation'];
 			}
 
 			if ($selectedFields['urls']) {

--- a/src/Navigation/Notifications/Factory/FormattedNavNotification.php
+++ b/src/Navigation/Notifications/Factory/FormattedNavNotification.php
@@ -27,26 +27,12 @@ use Psr\Log\LoggerInterface;
 class FormattedNavNotification extends BaseFactory
 {
 	private static $contacts = [];
-
-	/** @var Notification */
-	private $notification;
-	/** @var \Friendica\App\BaseURL */
-	private $baseUrl;
-	/** @var \Friendica\Core\L10n */
-	private $l10n;
-	/** @var IHandleUserSessions */
-	private $userSession;
 	/** @var string */
 	private $tpl;
 
-	public function __construct(Notification $notification, \Friendica\App\BaseURL $baseUrl, \Friendica\Core\L10n $l10n, LoggerInterface $logger, IHandleUserSessions $userSession)
+	public function __construct(private Notification $notification, private \Friendica\App\BaseURL $baseUrl, private \Friendica\Core\L10n $l10n, LoggerInterface $logger, private IHandleUserSessions $userSession)
 	{
 		parent::__construct($logger);
-
-		$this->notification = $notification;
-		$this->baseUrl      = $baseUrl;
-		$this->l10n         = $l10n;
-		$this->userSession  = $userSession;
 
 		$this->tpl = Renderer::getMarkupTemplate('notifications/nav/notify.tpl');
 	}

--- a/src/Navigation/Notifications/Factory/FormattedNavNotification.php
+++ b/src/Navigation/Notifications/Factory/FormattedNavNotification.php
@@ -140,7 +140,7 @@ class FormattedNavNotification extends BaseFactory
 			self::$contacts[$intro->cid]['url'],
 			$msg,
 			$intro->datetime,
-			new Uri($this->baseUrl . '/notifications/intros/' . $intro->id)
+			new Uri($this->baseUrl . '/notifications/intros/' . $intro->id),
 		);
 	}
 }

--- a/src/Navigation/Notifications/Factory/FormattedNotify.php
+++ b/src/Navigation/Notifications/Factory/FormattedNotify.php
@@ -42,26 +42,9 @@ use Psr\Log\LoggerInterface;
  */
 class FormattedNotify extends BaseFactory
 {
-	/** @var Database */
-	private $dba;
-	/** @var Repository\Notify */
-	private $notify;
-	/** @var BaseURL */
-	private $baseUrl;
-	/** @var L10n */
-	private $l10n;
-	/** @var IHandleUserSessions */
-	private $userSession;
-
-	public function __construct(LoggerInterface $logger, Database $dba, Repository\Notify $notification, BaseURL $baseUrl, L10n $l10n, IHandleUserSessions $userSession)
+	public function __construct(LoggerInterface $logger, private Database $dba, private Repository\Notify $notify, private BaseURL $baseUrl, private L10n $l10n, private IHandleUserSessions $userSession)
 	{
 		parent::__construct($logger);
-
-		$this->dba         = $dba;
-		$this->notify      = $notification;
-		$this->baseUrl     = $baseUrl;
-		$this->l10n        = $l10n;
-		$this->userSession = $userSession;
 	}
 
 	/**

--- a/src/Navigation/Notifications/Factory/Introduction.php
+++ b/src/Navigation/Notifications/Factory/Introduction.php
@@ -30,29 +30,13 @@ use Psr\Log\LoggerInterface;
  */
 class Introduction extends BaseFactory
 {
-	/** @var Database */
-	private $dba;
-	/** @var BaseURL */
-	private $baseUrl;
-	/** @var L10n */
-	private $l10n;
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-	/** @var IHandleUserSessions */
-	private $session;
 	/** @var string */
 	private $nick;
 
-	public function __construct(LoggerInterface $logger, Database $dba, BaseURL $baseUrl, L10n $l10n, IManagePersonalConfigValues $pConfig, IHandleUserSessions $session)
+	public function __construct(LoggerInterface $logger, private Database $dba, private BaseURL $baseUrl, private L10n $l10n, private IManagePersonalConfigValues $pConfig, private IHandleUserSessions $session)
 	{
 		parent::__construct($logger);
-
-		$this->dba     = $dba;
-		$this->baseUrl = $baseUrl;
-		$this->l10n    = $l10n;
-		$this->pConfig = $pConfig;
-		$this->session = $session;
-		$this->nick    = $session->getLocalUserNickname() ?? '';
+		$this->nick    = $this->session->getLocalUserNickname() ?? '';
 	}
 
 	/**

--- a/src/Navigation/Notifications/Factory/Introduction.php
+++ b/src/Navigation/Notifications/Factory/Introduction.php
@@ -36,7 +36,7 @@ class Introduction extends BaseFactory
 	public function __construct(LoggerInterface $logger, private Database $dba, private BaseURL $baseUrl, private L10n $l10n, private IManagePersonalConfigValues $pConfig, private IHandleUserSessions $session)
 	{
 		parent::__construct($logger);
-		$this->nick    = $this->session->getLocalUserNickname() ?? '';
+		$this->nick = $this->session->getLocalUserNickname() ?? '';
 	}
 
 	/**
@@ -78,7 +78,7 @@ class Introduction extends BaseFactory
 			LIMIT ?, ?",
 				$this->session->getLocalUserId(),
 				$start,
-				$limit
+				$limit,
 			);
 
 			while ($intro = $this->dba->fetch($stmtNotifications)) {
@@ -86,16 +86,16 @@ class Introduction extends BaseFactory
 					continue;
 				}
 
-			// There are two kind of introduction. Contacts suggested by other contacts and normal connection requests.
+				// There are two kind of introduction. Contacts suggested by other contacts and normal connection requests.
 				// We have to distinguish between these two because they use different data.
 				// Contact suggestions
 				if ($intro['suggest-cid'] ?? '') {
 					if (empty($intro['furl'])) {
 						continue;
 					}
-					$return_addr = bin2hex($this->nick . '@' .
-					                       $this->baseUrl->getHost() .
-										   (($this->baseUrl->getPath()) ? '/' . $this->baseUrl->getPath() : ''));
+					$return_addr = bin2hex($this->nick . '@'
+										   . $this->baseUrl->getHost()
+										   . (($this->baseUrl->getPath()) ? '/' . $this->baseUrl->getPath() : ''));
 
 					$formattedIntroductions[] = new ValueObject\Introduction([
 						'label'          => 'friend_suggestion',
@@ -133,7 +133,7 @@ class Introduction extends BaseFactory
 						'photo'          => Contact::getPhoto($intro),
 						'name'           => $intro['name'],
 						'location'       => BBCode::convertForUriId($intro['uri-id'], $intro['location'], BBCode::EXTERNAL),
-						'about'          => BBCode::convertForUriId ($intro['uri-id'], $intro['about'], BBCode::EXTERNAL),
+						'about'          => BBCode::convertForUriId($intro['uri-id'], $intro['about'], BBCode::EXTERNAL),
 						'keywords'       => $intro['keywords'],
 						'hidden'         => $intro['hidden'] == 1,
 						'post_newfriend' => (intval($this->pConfig->get($this->session->getLocalUserId(), 'system', 'post_newfriend')) ? '1' : 0),

--- a/src/Navigation/Notifications/Factory/Notification.php
+++ b/src/Navigation/Notifications/Factory/Notification.php
@@ -7,15 +7,12 @@
 
 namespace Friendica\Navigation\Notifications\Factory;
 
-use Friendica\App\BaseURL;
 use Friendica\BaseFactory;
 use Friendica\Capabilities\ICanCreateFromTableRow;
-use Friendica\Contact\LocalRelationship\Repository\LocalRelationship;
 use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\Plaintext;
 use Friendica\Core\Cache\Enum\Duration;
 use Friendica\Core\Cache\Capability\ICanCache;
-use Friendica\Core\L10n;
 use Friendica\Model\Contact;
 use Friendica\Model\Post;
 use Friendica\Model\User;
@@ -56,7 +53,7 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 			$type,
 			$actorId,
 			$targetUriId,
-			$parentUriId
+			$parentUriId,
 		);
 	}
 
@@ -72,7 +69,7 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 			$uid,
 			$verb,
 			Post\UserNotification::TYPE_NONE,
-			$contactId
+			$contactId,
 		);
 	}
 
@@ -87,7 +84,7 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 		$message = [];
 
 		$cachekey = 'Notification:' . $Notification->id;
-		$result = $this->cache->get($cachekey);
+		$result   = $this->cache->get($cachekey);
 		if (!is_null($result)) {
 			return $result;
 		}
@@ -136,7 +133,7 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 
 				if (($Notification->verb == Activity::POST) || ($Notification->type === Post\UserNotification::TYPE_SHARED)) {
 					$thrparentid = $item['thr-parent-id'];
-					$item = Post::selectFirst([], ['uri-id' => $thrparentid, 'uid' => [0, $Notification->uid]], ['order' => ['uid' => true]]);
+					$item        = Post::selectFirst([], ['uri-id' => $thrparentid, 'uid' => [0, $Notification->uid]], ['order' => ['uid' => true]]);
 					if (empty($item)) {
 						$this->logger->info('Thread parent post not found', ['uri-id' => $thrparentid]);
 						return $message;
@@ -165,7 +162,7 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 
 			$link = $this->baseUrl . '/display/' . urlencode($link_item['guid']);
 
-			$body = BBCode::toPlaintext($item['body'], false);
+			$body  = BBCode::toPlaintext($item['body'], false);
 			$title = Plaintext::shorten($body, 70);
 			if (!empty($title)) {
 				$title = '"' . trim(str_replace("\n", " ", $title)) . '"';
@@ -256,7 +253,7 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 
 						case Post\UserNotification::TYPE_COMMENT_PARTICIPATION:
 						case Post\UserNotification::TYPE_ACTIVITY_PARTICIPATION:
-						case Post\UserNotification::TYPE_FOLLOW;
+						case Post\UserNotification::TYPE_FOLLOW:
 							if (($causer['id'] == $author['id']) && ($title != '')) {
 								$msg = $l10n->t('%1$s commented in their thread %2$s');
 							} elseif ($causer['id'] == $author['id']) {
@@ -300,10 +297,12 @@ class Notification extends BaseFactory implements ICanCreateFromTableRow
 			// Plain text for the web push api
 			$message['plain'] = sprintf($msg, $causer['name'], $title, $author['name']);
 			// Rich text for other purposes
-			$message['rich'] = sprintf($msg,
+			$message['rich'] = sprintf(
+				$msg,
 				'[url=' . $causer['url'] . ']' . $causer['name'] . '[/url]',
 				'[url=' . $link . ']' . $title . '[/url]',
-				'[url=' . $author['url'] . ']' . $author['name'] . '[/url]');
+				'[url=' . $author['url'] . ']' . $author['name'] . '[/url]',
+			);
 			$message['link'] = $link;
 			$this->cache->set($cachekey, $message, Duration::HOUR);
 		} else {

--- a/src/Navigation/Notifications/Factory/Notification.php
+++ b/src/Navigation/Notifications/Factory/Notification.php
@@ -27,23 +27,9 @@ use Psr\Log\LoggerInterface;
 
 class Notification extends BaseFactory implements ICanCreateFromTableRow
 {
-	/** @var BaseURL */
-	private $baseUrl;
-	/** @var L10n */
-	private $l10n;
-	/** @var LocalRelationship */
-	private $localRelationshipRepo;
-	/** @var ICanCache */
-	private $cache;
-
-	public function __construct(\Friendica\App\BaseURL $baseUrl, \Friendica\Core\L10n $l10n, \Friendica\Contact\LocalRelationship\Repository\LocalRelationship $localRelationshipRepo, LoggerInterface $logger, ICanCache $cache)
+	public function __construct(private \Friendica\App\BaseURL $baseUrl, private \Friendica\Core\L10n $l10n, private \Friendica\Contact\LocalRelationship\Repository\LocalRelationship $localRelationshipRepo, LoggerInterface $logger, private ICanCache $cache)
 	{
 		parent::__construct($logger);
-
-		$this->baseUrl = $baseUrl;
-		$this->l10n = $l10n;
-		$this->localRelationshipRepo = $localRelationshipRepo;
-		$this->cache = $cache;
 	}
 
 	public function createFromTableRow(array $row): Entity\Notification

--- a/src/Navigation/Notifications/Repository/Notification.php
+++ b/src/Navigation/Notifications/Repository/Notification.php
@@ -30,14 +30,9 @@ class Notification extends BaseRepository
 
 	protected static $table_name = 'notification';
 
-	/** @var IManagePersonalConfigValues */
-	private $pconfig;
-
-	public function __construct(IManagePersonalConfigValues $pconfig, Database $database, LoggerInterface $logger, Factory\Notification $factory)
+	public function __construct(private IManagePersonalConfigValues $pconfig, Database $database, LoggerInterface $logger, Factory\Notification $factory)
 	{
 		parent::__construct($database, $logger, $factory);
-
-		$this->pconfig = $pconfig;
 	}
 
 	/**

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -49,16 +49,11 @@ class Notify extends BaseRepository
 	/** @var IManageConfigValues */
 	protected $config;
 
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-
 	/** @var Emailer */
 	protected $emailer;
 
 	/** @var Factory\Notification */
 	protected $notification;
-
-	private EventDispatcherInterface $eventDispatcher;
 
 	protected static $table_name = 'notify';
 
@@ -68,19 +63,17 @@ class Notify extends BaseRepository
 		L10n $l10n,
 		BaseURL $baseUrl,
 		IManageConfigValues $config,
-		IManagePersonalConfigValues $pConfig,
+		private IManagePersonalConfigValues $pConfig,
 		Emailer $emailer,
 		Factory\Notification $notification,
-		EventDispatcherInterface $eventDispatcher,
+		private EventDispatcherInterface $eventDispatcher,
 		Factory\Notify $factory = null,
 	) {
 		$this->l10n            = $l10n;
 		$this->baseUrl         = $baseUrl;
 		$this->config          = $config;
-		$this->pConfig         = $pConfig;
 		$this->emailer         = $emailer;
 		$this->notification    = $notification;
-		$this->eventDispatcher = $eventDispatcher;
 
 		parent::__construct($database, $logger, $factory ?? new Factory\Notify($logger));
 	}

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -69,11 +69,11 @@ class Notify extends BaseRepository
 		private EventDispatcherInterface $eventDispatcher,
 		Factory\Notify $factory = null,
 	) {
-		$this->l10n            = $l10n;
-		$this->baseUrl         = $baseUrl;
-		$this->config          = $config;
-		$this->emailer         = $emailer;
-		$this->notification    = $notification;
+		$this->l10n         = $l10n;
+		$this->baseUrl      = $baseUrl;
+		$this->config       = $config;
+		$this->emailer      = $emailer;
+		$this->notification = $notification;
 
 		parent::__construct($database, $logger, $factory ?? new Factory\Notify($logger));
 	}

--- a/src/Navigation/SystemMessages.php
+++ b/src/Navigation/SystemMessages.php
@@ -21,9 +21,7 @@ use Friendica\Core\Session\Capability\IHandleSessions;
 
 class SystemMessages
 {
-	public function __construct(private IHandleSessions $session)
-				{
-							}
+	public function __construct(private IHandleSessions $session) {}
 
 	public function addNotice(string $message)
 	{

--- a/src/Navigation/SystemMessages.php
+++ b/src/Navigation/SystemMessages.php
@@ -21,15 +21,9 @@ use Friendica\Core\Session\Capability\IHandleSessions;
 
 class SystemMessages
 {
-	/**
-	 * @var IHandleSessions
-	 */
-	private $session;
-
-	public function __construct(IHandleSessions $session)
-	{
-		$this->session = $session;
-	}
+	public function __construct(private IHandleSessions $session)
+				{
+							}
 
 	public function addNotice(string $message)
 	{

--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -31,9 +31,7 @@ use Psr\Log\LoggerInterface;
  */
 class HttpClient implements ICanSendHttpRequests
 {
-	public function __construct(private LoggerInterface $logger, private Profiler $profiler, private Client $client, private URLResolver $resolver, private App\BaseURL $baseUrl)
-				{
-							}
+	public function __construct(private LoggerInterface $logger, private Profiler $profiler, private Client $client, private URLResolver $resolver, private App\BaseURL $baseUrl) {}
 
 	/**
 	 * {@inheritDoc}

--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -31,25 +31,9 @@ use Psr\Log\LoggerInterface;
  */
 class HttpClient implements ICanSendHttpRequests
 {
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var Profiler */
-	private $profiler;
-	/** @var Client */
-	private $client;
-	/** @var URLResolver */
-	private $resolver;
-	/** @var App\BaseURL */
-	private $baseUrl;
-
-	public function __construct(LoggerInterface $logger, Profiler $profiler, Client $client, URLResolver $resolver, App\BaseURL $baseUrl)
-	{
-		$this->logger   = $logger;
-		$this->profiler = $profiler;
-		$this->client   = $client;
-		$this->resolver = $resolver;
-		$this->baseUrl  = $baseUrl;
-	}
+	public function __construct(private LoggerInterface $logger, private Profiler $profiler, private Client $client, private URLResolver $resolver, private App\BaseURL $baseUrl)
+				{
+							}
 
 	/**
 	 * {@inheritDoc}

--- a/src/Network/HTTPClient/Factory/HttpClient.php
+++ b/src/Network/HTTPClient/Factory/HttpClient.php
@@ -28,19 +28,9 @@ require_once __DIR__ . '/../../../../static/dbstructure.config.php';
 
 class HttpClient extends BaseFactory
 {
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var Profiler */
-	private $profiler;
-	/** @var App\BaseURL */
-	private $baseUrl;
-
-	public function __construct(LoggerInterface $logger, IManageConfigValues $config, Profiler $profiler, App\BaseURL $baseUrl)
+	public function __construct(LoggerInterface $logger, private IManageConfigValues $config, private Profiler $profiler, private App\BaseURL $baseUrl)
 	{
 		parent::__construct($logger);
-		$this->config   = $config;
-		$this->profiler = $profiler;
-		$this->baseUrl  = $baseUrl;
 	}
 
 	/**

--- a/src/Network/HTTPClient/Factory/HttpClient.php
+++ b/src/Network/HTTPClient/Factory/HttpClient.php
@@ -57,7 +57,7 @@ class HttpClient extends BaseFactory
 		$onRedirect = function (
 			RequestInterface $request,
 			ResponseInterface $response,
-			UriInterface $uri
+			UriInterface $uri,
 		) use ($logger) {
 			$logger->info('Curl redirect.', ['url' => $request->getUri(), 'to' => $uri, 'method' => $request->getMethod()]);
 		};
@@ -82,10 +82,10 @@ class HttpClient extends BaseFactory
 			RequestOptions::TIMEOUT          => $this->config->get('system', 'curl_timeout', 60),
 			// by default, we will allow self-signed certs,
 			// but it can be overridden
-			RequestOptions::VERIFY  => (bool)$this->config->get('system', 'verifyssl'),
+			RequestOptions::VERIFY  => (bool) $this->config->get('system', 'verifyssl'),
 			RequestOptions::PROXY   => $proxy,
 			RequestOptions::HEADERS => [],
-			'handler' => $handlerStack ?? HandlerStack::create(),
+			'handler'               => $handlerStack ?? HandlerStack::create(),
 		]);
 
 		$resolver = new URLResolver();

--- a/src/Network/HTTPClient/Response/CurlResult.php
+++ b/src/Network/HTTPClient/Response/CurlResult.php
@@ -114,8 +114,8 @@ class CurlResult implements ICanHandleHttpResponses
 			throw new UnprocessableEntityException('CURL response doesn\'t contains a response HTTP code');
 		}
 
-		$this->returnCode  = $info['http_code'];
-		$this->info        = $info;
+		$this->returnCode = $info['http_code'];
+		$this->info       = $info;
 
 		$this->logger->debug('construct', ['url' => $this->url, 'returncode' => $this->returnCode, 'result' => $result]);
 

--- a/src/Network/HTTPClient/Response/CurlResult.php
+++ b/src/Network/HTTPClient/Response/CurlResult.php
@@ -48,11 +48,6 @@ class CurlResult implements ICanHandleHttpResponses
 	private $isGone;
 
 	/**
-	 * @var string the URL which was called
-	 */
-	private $url;
-
-	/**
 	 * @var string in case of redirect, content was finally retrieved from this URL
 	 */
 	private $redirectUrl;
@@ -83,16 +78,6 @@ class CurlResult implements ICanHandleHttpResponses
 	private $isTimeout;
 
 	/**
-	 * @var int the error number or 0 (zero) if no error
-	 */
-	private $errorNumber;
-
-	/**
-	 * @var string the error message or '' (the empty string) if no
-	 */
-	private $error;
-
-	/**
 	 * @var LoggerInterface
 	 */
 	protected $logger;
@@ -121,7 +106,7 @@ class CurlResult implements ICanHandleHttpResponses
 	 *
 	 * @throws UnprocessableEntityException when HTTP code of the CURL response is missing
 	 */
-	public function __construct(LoggerInterface $logger, string $url, string $result, array $info, int $errorNumber = 0, string $error = '')
+	public function __construct(LoggerInterface $logger, private string $url, string $result, array $info, private int $errorNumber = 0, private string $error = '')
 	{
 		$this->logger = $logger;
 
@@ -130,12 +115,9 @@ class CurlResult implements ICanHandleHttpResponses
 		}
 
 		$this->returnCode  = $info['http_code'];
-		$this->url         = $url;
 		$this->info        = $info;
-		$this->errorNumber = $errorNumber;
-		$this->error       = $error;
 
-		$this->logger->debug('construct', ['url' => $url, 'returncode' => $this->returnCode, 'result' => $result]);
+		$this->logger->debug('construct', ['url' => $this->url, 'returncode' => $this->returnCode, 'result' => $result]);
 
 		$this->parseBodyHeader($result);
 		$this->checkSuccess();

--- a/src/Network/HTTPClient/Response/GuzzleResponse.php
+++ b/src/Network/HTTPClient/Response/GuzzleResponse.php
@@ -18,23 +18,12 @@ use Psr\Http\Message\ResponseInterface;
  */
 class GuzzleResponse extends Response implements ICanHandleHttpResponses, ResponseInterface
 {
-	/** @var string The URL */
-	private $url;
 	/** @var boolean */
 	private $isTimeout;
 	/** @var boolean */
 	private $isSuccess;
 	/** @var boolean */
 	private $isGone;
-	/**
-	 * @var int the error number or 0 (zero) if no error
-	 */
-	private $errorNumber;
-
-	/**
-	 * @var string the error message or '' (the empty string) if no
-	 */
-	private $error;
 
 	/** @var string  */
 	private $redirectUrl = '';
@@ -43,12 +32,20 @@ class GuzzleResponse extends Response implements ICanHandleHttpResponses, Respon
 	/** @var bool */
 	private $redirectIsPermanent = false;
 
-	public function __construct(ResponseInterface $response, string $url, $errorNumber = 0, $error = '')
+	/**
+				 * @param int $errorNumber
+				 * @param string $error
+				 */
+				public function __construct(ResponseInterface $response, /** @var string The URL */
+				private string $url, /**
+				 * @var int the error number or 0 (zero) if no error
+				 */
+				private $errorNumber = 0, /**
+				 * @var string the error message or '' (the empty string) if no
+				 */
+				private $error = '')
 	{
 		parent::__construct($response->getStatusCode(), $response->getHeaders(), $response->getBody(), $response->getProtocolVersion(), $response->getReasonPhrase());
-		$this->url         = $url;
-		$this->error       = $error;
-		$this->errorNumber = $errorNumber;
 
 		$this->checkSuccess();
 		$this->checkGone();

--- a/src/Network/HTTPClient/Response/GuzzleResponse.php
+++ b/src/Network/HTTPClient/Response/GuzzleResponse.php
@@ -33,17 +33,17 @@ class GuzzleResponse extends Response implements ICanHandleHttpResponses, Respon
 	private $redirectIsPermanent = false;
 
 	/**
-				 * @param int $errorNumber
-				 * @param string $error
-				 */
-				public function __construct(ResponseInterface $response, /** @var string The URL */
-				private string $url, /**
+	 * @param int $errorNumber
+	 * @param string $error
+	 */
+	public function __construct(ResponseInterface $response, /** @var string The URL */
+		private string $url, /**
 				 * @var int the error number or 0 (zero) if no error
 				 */
-				private $errorNumber = 0, /**
+		private $errorNumber = 0, /**
 				 * @var string the error message or '' (the empty string) if no
 				 */
-				private $error = '')
+		private $error = '')
 	{
 		parent::__construct($response->getStatusCode(), $response->getHeaders(), $response->getBody(), $response->getProtocolVersion(), $response->getReasonPhrase());
 

--- a/src/Network/RobotsTxt.php
+++ b/src/Network/RobotsTxt.php
@@ -37,9 +37,7 @@ class RobotsTxt
 	 */
 	private bool $isLoaded = false;
 
-	public function __construct(protected ICanSendHttpRequests $httpClient)
-				{
-							}
+	public function __construct(protected ICanSendHttpRequests $httpClient) {}
 
 	/**
 	 * Loads the RobotsTxt parser with a server URL

--- a/src/Network/RobotsTxt.php
+++ b/src/Network/RobotsTxt.php
@@ -37,12 +37,9 @@ class RobotsTxt
 	 */
 	private bool $isLoaded = false;
 
-	protected ICanSendHttpRequests $httpClient;
-
-	public function __construct(ICanSendHttpRequests $httpClient)
-	{
-		$this->httpClient = $httpClient;
-	}
+	public function __construct(protected ICanSendHttpRequests $httpClient)
+				{
+							}
 
 	/**
 	 * Loads the RobotsTxt parser with a server URL

--- a/src/Object/Api/Mastodon/Instance.php
+++ b/src/Object/Api/Mastodon/Instance.php
@@ -52,7 +52,7 @@ class Instance extends BaseDataTransferObject
 		$this->stats             = new Stats($config, $database);
 		$this->thumbnail         = $baseUrl . (new Header($config))->getMastodonBannerPath();
 		$this->languages         = [$config->get('system', 'language')];
-		$this->max_toot_chars    = (int)$config->get('config', 'api_import_size', $config->get('config', 'max_import_size'));
+		$this->max_toot_chars    = (int) $config->get('config', 'api_import_size', $config->get('config', 'max_import_size'));
 		$this->registrations     = ($register_policy !== Register::CLOSED);
 		$this->approval_required = ($register_policy === Register::APPROVE);
 		$this->invites_enabled   = false;

--- a/src/Object/Api/Mastodon/Instance.php
+++ b/src/Object/Api/Mastodon/Instance.php
@@ -38,11 +38,8 @@ class Instance extends BaseDataTransferObject
 	protected bool $registrations;
 	protected bool $approval_required;
 	protected bool $invites_enabled;
-	protected Configuration $configuration;
-	protected ?Account $contact_account = null;
-	protected array $rules              = [];
 
-	public function __construct(IManageConfigValues $config, BaseURL $baseUrl, Database $database, Configuration $configuration, ?Account $contact_account, array $rules)
+	public function __construct(IManageConfigValues $config, BaseURL $baseUrl, Database $database, protected Configuration $configuration, protected ?Account $contact_account, protected array $rules)
 	{
 		$register_policy = Register::getPolicy();
 
@@ -59,8 +56,5 @@ class Instance extends BaseDataTransferObject
 		$this->registrations     = ($register_policy !== Register::CLOSED);
 		$this->approval_required = ($register_policy === Register::APPROVE);
 		$this->invites_enabled   = false;
-		$this->configuration     = $configuration;
-		$this->contact_account   = $contact_account;
-		$this->rules             = $rules;
 	}
 }

--- a/src/Object/Api/Mastodon/Preferences.php
+++ b/src/Object/Api/Mastodon/Preferences.php
@@ -18,43 +18,28 @@ use Friendica\BaseDataTransferObject;
 class Preferences extends BaseDataTransferObject
 {
 	/**
-	 * @var string (Enumerable, oneOf)
-	 */
-	private $visibility;
-
-	/**
-	 * @var bool
-	 */
-	private $sensitive;
-
-	/**
-	 * @var string (ISO 639-1 language two-letter code), or null
-	 */
-	private $language;
-
-	/**
-	 * @var string (Enumerable, oneOf)
-	 */
-	private $media;
-
-	/**
-	 * @var bool
-	 */
-	private $spoilers;
-
-	/**
 	 * Creates a preferences record.
 	 *
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function __construct(string $visibility, bool $sensitive, string $language, string $media, bool $spoilers)
-	{
-		$this->visibility = $visibility;
-		$this->sensitive = $sensitive;
-		$this->language = $language;
-		$this->media = $media;
-		$this->spoilers = $spoilers;
-	}
+	public function __construct(
+								/**
+								 * @var string (Enumerable, oneOf)
+								 */
+								private string $visibility,
+								private bool $sensitive,
+								/**
+								 * @var string (ISO 639-1 language two-letter code), or null
+								 */
+								private string $language,
+								/**
+								 * @var string (Enumerable, oneOf)
+								 */
+								private string $media,
+								private bool $spoilers
+							)
+							{
+										}
 
 	/**
 	 * Returns the current entity as an array

--- a/src/Object/Api/Mastodon/Preferences.php
+++ b/src/Object/Api/Mastodon/Preferences.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Object\Api\Mastodon;
 
-use Friendica\App\BaseURL;
 use Friendica\BaseDataTransferObject;
 
 /**
@@ -23,23 +22,21 @@ class Preferences extends BaseDataTransferObject
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
 	public function __construct(
-								/**
-								 * @var string (Enumerable, oneOf)
-								 */
-								private string $visibility,
-								private bool $sensitive,
-								/**
-								 * @var string (ISO 639-1 language two-letter code), or null
-								 */
-								private string $language,
-								/**
-								 * @var string (Enumerable, oneOf)
-								 */
-								private string $media,
-								private bool $spoilers
-							)
-							{
-										}
+		/**
+		 * @var string (Enumerable, oneOf)
+		 */
+		private string $visibility,
+		private bool $sensitive,
+		/**
+		 * @var string (ISO 639-1 language two-letter code), or null
+		 */
+		private string $language,
+		/**
+		 * @var string (Enumerable, oneOf)
+		 */
+		private string $media,
+		private bool $spoilers,
+	) {}
 
 	/**
 	 * Returns the current entity as an array
@@ -50,10 +47,10 @@ class Preferences extends BaseDataTransferObject
 	{
 		return [
 			'posting:default:visibility' => $this->visibility,
-			'posting:default:sensitive' => $this->sensitive,
-			'posting:default:language' => $this->language,
-			'reading:expand:media' => $this->media,
-			'reading:expand:spoilers' => $this->spoilers,
+			'posting:default:sensitive'  => $this->sensitive,
+			'posting:default:language'   => $this->language,
+			'reading:expand:media'       => $this->media,
+			'reading:expand:spoilers'    => $this->spoilers,
 		];
 	}
 }

--- a/src/Object/Email.php
+++ b/src/Object/Email.php
@@ -16,49 +16,20 @@ use Friendica\Object\EMail\IEmail;
  */
 class Email implements IEmail
 {
-	/** @var string */
-	private $fromName;
-	/** @var string */
-	private $fromAddress;
-	/** @var string */
-	private $replyTo;
-
-	/** @var string */
-	private $toAddress;
-
-	/** @var string */
-	private $subject;
-	/** @var string|null */
-	private $msgHtml;
-	/** @var string */
-	private $msgText;
-
-	/** @var string[][] */
-	private $additionalMailHeader;
-	/** @var int|null */
-	private $toUid;
-
 	public function __construct(
-		string $fromName,
-		string $fromAddress,
-		string $replyTo,
-		string $toAddress,
-		string $subject,
-		string $msgHtml,
-		string $msgText,
-		array $additionalMailHeader = [],
-		int $toUid = null,
-	) {
-		$this->fromName             = $fromName;
-		$this->fromAddress          = $fromAddress;
-		$this->replyTo              = $replyTo;
-		$this->toAddress            = $toAddress;
-		$this->subject              = $subject;
-		$this->msgHtml              = $msgHtml;
-		$this->msgText              = $msgText;
-		$this->additionalMailHeader = $additionalMailHeader;
-		$this->toUid                = $toUid;
-	}
+								private string $fromName,
+								private string $fromAddress,
+								private string $replyTo,
+								private string $toAddress,
+								private string $subject,
+								private string $msgHtml,
+								private string $msgText,
+								/** @var string[][] */
+								private array $additionalMailHeader = [],
+								private ?int $toUid = null
+							)
+							{
+										}
 
 	/**
 	 * {@inheritDoc}

--- a/src/Object/Email.php
+++ b/src/Object/Email.php
@@ -17,19 +17,17 @@ use Friendica\Object\EMail\IEmail;
 class Email implements IEmail
 {
 	public function __construct(
-								private string $fromName,
-								private string $fromAddress,
-								private string $replyTo,
-								private string $toAddress,
-								private string $subject,
-								private string $msgHtml,
-								private string $msgText,
-								/** @var string[][] */
-								private array $additionalMailHeader = [],
-								private ?int $toUid = null
-							)
-							{
-										}
+		private string $fromName,
+		private string $fromAddress,
+		private string $replyTo,
+		private string $toAddress,
+		private string $subject,
+		private string $msgHtml,
+		private string $msgText,
+		/** @var string[][] */
+		private array $additionalMailHeader = [],
+		private ?int $toUid = null,
+	) {}
 
 	/**
 	 * {@inheritDoc}

--- a/src/Object/Email.php
+++ b/src/Object/Email.php
@@ -77,7 +77,7 @@ class Email implements IEmail
 		if ($plain) {
 			return $this->msgText;
 		} else {
-			return $this->msgHtml ?? '';
+			return $this->msgHtml;
 		}
 	}
 

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -50,8 +50,8 @@ class Image implements \Stringable
 	 */
 	public function __construct(string $data, string $type = '', private string $filename = '', bool $imagick = true)
 	{
-		$type           = Images::addMimeTypeByDataIfInvalid($type, $data);
-		$type           = Images::addMimeTypeByExtensionIfInvalid($type, $this->filename);
+		$type = Images::addMimeTypeByDataIfInvalid($type, $data);
+		$type = Images::addMimeTypeByExtensionIfInvalid($type, $this->filename);
 
 		if (Images::isSupportedMimeType($type)) {
 			$this->originType = $this->outputType = Images::getImageTypeByMimeType($type);

--- a/src/Object/Image.php
+++ b/src/Object/Image.php
@@ -37,7 +37,6 @@ class Image implements \Stringable
 	private $valid;
 	private $outputType;
 	private $originType;
-	private $filename;
 
 	/**
 	 * Constructor
@@ -49,20 +48,19 @@ class Image implements \Stringable
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public function __construct(string $data, string $type = '', string $filename = '', bool $imagick = true)
+	public function __construct(string $data, string $type = '', private string $filename = '', bool $imagick = true)
 	{
-		$this->filename = $filename;
 		$type           = Images::addMimeTypeByDataIfInvalid($type, $data);
-		$type           = Images::addMimeTypeByExtensionIfInvalid($type, $filename);
+		$type           = Images::addMimeTypeByExtensionIfInvalid($type, $this->filename);
 
 		if (Images::isSupportedMimeType($type)) {
 			$this->originType = $this->outputType = Images::getImageTypeByMimeType($type);
 		} elseif (($type == '') || str_starts_with($type, 'image/') || substr($type, 0, 12) == ' application/') {
 			$this->originType = IMAGETYPE_UNKNOWN;
 			$this->outputType = IMAGETYPE_WEBP;
-			DI::logger()->debug('Unhandled image mime type, use WebP instead', ['type' => $type, 'filename' => $filename, 'size' => strlen($data)]);
+			DI::logger()->debug('Unhandled image mime type, use WebP instead', ['type' => $type, 'filename' => $this->filename, 'size' => strlen($data)]);
 		} else {
-			DI::logger()->debug('Unhandled mime type', ['type' => $type, 'filename' => $filename, 'size' => strlen($data)]);
+			DI::logger()->debug('Unhandled mime type', ['type' => $type, 'filename' => $this->filename, 'size' => strlen($data)]);
 			$this->valid = false;
 			return;
 		}

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -31,7 +31,6 @@ use InvalidArgumentException;
  */
 class Post
 {
-	private $data                = [];
 	private $template            = null;
 	private $available_templates = [
 		'wall'      => 'wall_thread.tpl',
@@ -63,9 +62,8 @@ class Post
 	 * @param array $data data array
 	 * @throws \Exception
 	 */
-	public function __construct(array $data)
+	public function __construct(private array $data)
 	{
-		$this->data = $data;
 		$this->setTemplate('wall');
 		$this->toplevel = $this->getId() == $this->getDataValue('parent');
 
@@ -87,8 +85,8 @@ class Post
 		}
 
 		// Prepare the children
-		if (!empty($data['children'])) {
-			foreach ($data['children'] as $item) {
+		if (!empty($this->data['children'])) {
+			foreach ($this->data['children'] as $item) {
 				// Only add will be displayed
 				if ($item['network'] === Protocol::MAIL && DI::userSession()->getLocalUserId() != $item['uid']) {
 					continue;
@@ -101,7 +99,7 @@ class Post
 					$item['writable'] = true;
 				}
 
-				$item['pagedrop'] = $data['pagedrop'];
+				$item['pagedrop'] = $this->data['pagedrop'];
 				$child            = new Post($item);
 				$this->addChild($child);
 			}

--- a/src/Object/Search/ContactResult.php
+++ b/src/Object/Search/ContactResult.php
@@ -100,7 +100,5 @@ class ContactResult implements IResult
 	 * @param int    $pCid
 	 * @param string $tags
 	 */
-	public function __construct(private $name, private $addr, private $item, private UriInterface $url, private $photo, private $network, private $cid = 0, private $pCid = 0, private $tags = '')
-				{
-							}
+	public function __construct(private $name, private $addr, private $item, private UriInterface $url, private $photo, private $network, private $cid = 0, private $pCid = 0, private $tags = '') {}
 }

--- a/src/Object/Search/ContactResult.php
+++ b/src/Object/Search/ContactResult.php
@@ -18,43 +18,6 @@ use Psr\Http\Message\UriInterface;
 class ContactResult implements IResult
 {
 	/**
-	 * @var int
-	 */
-	private $cid;
-	/**
-	 * @var int
-	 */
-	private $pCid;
-	/**
-	 * @var string
-	 */
-	private $name;
-	/**
-	 * @var string
-	 */
-	private $addr;
-	/**
-	 * @var string
-	 */
-	private $item;
-	/**
-	 * @var UriInterface
-	 */
-	private $url;
-	/**
-	 * @var string
-	 */
-	private $photo;
-	/**
-	 * @var string
-	 */
-	private $tags;
-	/**
-	 * @var string
-	 */
-	private $network;
-
-	/**
 	 * @return int
 	 */
 	public function getCid()
@@ -137,17 +100,7 @@ class ContactResult implements IResult
 	 * @param int    $pCid
 	 * @param string $tags
 	 */
-	public function __construct($name, $addr, $item, UriInterface $url, $photo, $network, $cid = 0, $pCid = 0, $tags = '')
-	{
-		$this->name    = $name;
-		$this->addr    = $addr;
-		$this->item    = $item;
-		$this->url     = $url;
-		$this->photo   = $photo;
-		$this->network = $network;
-
-		$this->cid  = $cid;
-		$this->pCid = $pCid;
-		$this->tags = $tags;
-	}
+	public function __construct(private $name, private $addr, private $item, private UriInterface $url, private $photo, private $network, private $cid = 0, private $pCid = 0, private $tags = '')
+				{
+							}
 }

--- a/src/Object/Search/ResultList.php
+++ b/src/Object/Search/ResultList.php
@@ -55,25 +55,23 @@ class ResultList
 	 * @param IResult[] $results
 	 */
 	public function __construct(
-								/**
-								 * Page of the result list
-								 */
-								private $page = 0,
-								/**
-								 * Total count of results
-								 */
-								private $total = 0,
-								/**
-								 * items per page
-								 */
-								private $itemsPage = 0,
-								/**
-								 * Array of results
-								 */
-								private array $results = []
-							)
-							{
-										}
+		/**
+		 * Page of the result list
+		 */
+		private $page = 0,
+		/**
+		 * Total count of results
+		 */
+		private $total = 0,
+		/**
+		 * items per page
+		 */
+		private $itemsPage = 0,
+		/**
+		 * Array of results
+		 */
+		private array $results = [],
+	) {}
 
 	/**
 	 * Adds a result to the result list

--- a/src/Object/Search/ResultList.php
+++ b/src/Object/Search/ResultList.php
@@ -17,28 +17,6 @@ use Friendica\Model\Search;
 class ResultList
 {
 	/**
-	 * Page of the result list
-	 * @var int
-	 */
-	private $page;
-	/**
-	 * Total count of results
-	 * @var int
-	 */
-	private $total;
-	/**
-	 * items per page
-	 * @var int
-	 */
-	private $itemsPage;
-	/**
-	 * Array of results
-	 *
-	 * @var IResult[]
-	 */
-	private $results;
-
-	/**
 	 * @return int
 	 */
 	public function getPage()
@@ -76,14 +54,26 @@ class ResultList
 	 * @param int             $itemsPage
 	 * @param IResult[] $results
 	 */
-	public function __construct($page = 0, $total = 0, $itemsPage = 0, array $results = [])
-	{
-		$this->page      = $page;
-		$this->total     = $total;
-		$this->itemsPage = $itemsPage;
-
-		$this->results = $results;
-	}
+	public function __construct(
+								/**
+								 * Page of the result list
+								 */
+								private $page = 0,
+								/**
+								 * Total count of results
+								 */
+								private $total = 0,
+								/**
+								 * items per page
+								 */
+								private $itemsPage = 0,
+								/**
+								 * Array of results
+								 */
+								private array $results = []
+							)
+							{
+										}
 
 	/**
 	 * Adds a result to the result list

--- a/src/Object/Thread.php
+++ b/src/Object/Thread.php
@@ -74,7 +74,7 @@ class Thread
 				$this->writable      = $writable;
 				break;
 			default:
-				DI::logger()->info('[ERROR] Conversation::setMode : Unhandled mode ('. $mode .').');
+				DI::logger()->info('[ERROR] Conversation::setMode : Unhandled mode (' . $mode . ').');
 				return;
 		}
 		$this->mode = $mode;
@@ -139,7 +139,7 @@ class Thread
 		}
 
 		if ($this->getParent($item->getId())) {
-			DI::logger()->info('[WARN] Conversation::addThread : Thread already exists ('. $item->getId() .').');
+			DI::logger()->info('[WARN] Conversation::addThread : Thread already exists (' . $item->getId() . ').');
 			return false;
 		}
 
@@ -147,12 +147,12 @@ class Thread
 		 * Only add will be displayed
 		 */
 		if ($item->getDataValue('network') === Protocol::MAIL && DI::userSession()->getLocalUserId() != $item->getDataValue('uid')) {
-			DI::logger()->info('[WARN] Conversation::addThread : Thread is a mail ('. $item->getId() .').');
+			DI::logger()->info('[WARN] Conversation::addThread : Thread is a mail (' . $item->getId() . ').');
 			return false;
 		}
 
 		if ($item->getDataValue('verb') === Activity::LIKE || $item->getDataValue('verb') === Activity::DISLIKE) {
-			DI::logger()->info('[WARN] Conversation::addThread : Thread is a (dis)like ('. $item->getId() .').');
+			DI::logger()->info('[WARN] Conversation::addThread : Thread is a (dis)like (' . $item->getId() . ').');
 			return false;
 		}
 
@@ -186,7 +186,7 @@ class Thread
 			$item_data = $item->getTemplateData($conv_responses, $formSecurityToken);
 
 			if (!$item_data) {
-				DI::logger()->info('[ERROR] Conversation::getTemplateData : Failed to get item template data ('. $item->getId() .').');
+				DI::logger()->info('[ERROR] Conversation::getTemplateData : Failed to get item template data (' . $item->getId() . ').');
 				return false;
 			}
 			$result[] = $item_data;

--- a/src/Object/Thread.php
+++ b/src/Object/Thread.php
@@ -25,7 +25,6 @@ class Thread
 	private $mode          = null;
 	private $writable      = false;
 	private $profile_owner = 0;
-	private $preview       = false;
 
 	/**
 	 * Constructor
@@ -35,10 +34,9 @@ class Thread
 	 * @param boolean $writable Override the writable check
 	 * @throws \Exception
 	 */
-	public function __construct($mode, $preview, $writable = false)
+	public function __construct($mode, private $preview, $writable = false)
 	{
 		$this->setMode($mode, $writable);
-		$this->preview = $preview;
 	}
 
 	/**

--- a/src/Privacy/Entity/AclReceivers.php
+++ b/src/Privacy/Entity/AclReceivers.php
@@ -11,9 +11,7 @@ use Friendica\BaseEntity;
 
 class AclReceivers extends BaseEntity
 {
-	public function __construct(protected array $allowContacts = [], protected array $allowCircles = [], protected array $denyContacts = [], protected array $denyCircles = [])
-				{
-							}
+	public function __construct(protected array $allowContacts = [], protected array $allowCircles = [], protected array $denyContacts = [], protected array $denyCircles = []) {}
 
 	public function isEmpty(): bool
 	{

--- a/src/Privacy/Entity/AclReceivers.php
+++ b/src/Privacy/Entity/AclReceivers.php
@@ -11,18 +11,9 @@ use Friendica\BaseEntity;
 
 class AclReceivers extends BaseEntity
 {
-	protected array $allowContacts   = [];
-	protected array $allowCircles = [];
-	protected array $denyContacts    = [];
-	protected array $denyCircles  = [];
-
-	public function __construct(array $allowContacts = [], array $allowCircles = [], array $denyContacts = [], array $denyCircles = [])
-	{
-		$this->allowContacts = $allowContacts;
-		$this->allowCircles  = $allowCircles;
-		$this->denyContacts  = $denyContacts;
-		$this->denyCircles   = $denyCircles;
-	}
+	public function __construct(protected array $allowContacts = [], protected array $allowCircles = [], protected array $denyContacts = [], protected array $denyCircles = [])
+				{
+							}
 
 	public function isEmpty(): bool
 	{

--- a/src/Privacy/Entity/AddressedReceivers.php
+++ b/src/Privacy/Entity/AddressedReceivers.php
@@ -11,9 +11,7 @@ use Friendica\BaseEntity;
 
 class AddressedReceivers extends BaseEntity
 {
-	public function __construct(protected array $to = [], protected array $cc = [], protected array $bcc = [], protected array $audience = [], protected array $attributed = [])
-				{
-							}
+	public function __construct(protected array $to = [], protected array $cc = [], protected array $bcc = [], protected array $audience = [], protected array $attributed = []) {}
 
 	public function isEmpty(): bool
 	{

--- a/src/Privacy/Entity/AddressedReceivers.php
+++ b/src/Privacy/Entity/AddressedReceivers.php
@@ -11,20 +11,9 @@ use Friendica\BaseEntity;
 
 class AddressedReceivers extends BaseEntity
 {
-	protected array $to         = [];
-	protected array $cc         = [];
-	protected array $bcc        = [];
-	protected array $audience   = [];
-	protected array $attributed = [];
-
-	public function __construct(array $to = [], array $cc = [], array $bcc = [], array $audience = [], array $attributed = [])
-	{
-		$this->to         = $to;
-		$this->cc         = $cc;
-		$this->bcc        = $bcc;
-		$this->audience   = $audience;
-		$this->attributed = $attributed;
-	}
+	public function __construct(protected array $to = [], protected array $cc = [], protected array $bcc = [], protected array $audience = [], protected array $attributed = [])
+				{
+							}
 
 	public function isEmpty(): bool
 	{

--- a/src/Profile/ProfileField/Factory/ProfileField.php
+++ b/src/Profile/ProfileField/Factory/ProfileField.php
@@ -18,14 +18,9 @@ use Psr\Log\LoggerInterface;
 
 class ProfileField extends BaseFactory implements ICanCreateFromTableRow
 {
-	/** @var PermissionSetFactory */
-	private $permissionSetFactory;
-
-	public function __construct(LoggerInterface $logger, PermissionSetFactory $permissionSetFactory)
+	public function __construct(LoggerInterface $logger, private PermissionSetFactory $permissionSetFactory)
 	{
 		parent::__construct($logger);
-
-		$this->permissionSetFactory = $permissionSetFactory;
 	}
 
 	/**

--- a/src/Profile/ProfileField/Factory/ProfileField.php
+++ b/src/Profile/ProfileField/Factory/ProfileField.php
@@ -30,8 +30,8 @@ class ProfileField extends BaseFactory implements ICanCreateFromTableRow
 	 */
 	public function createFromTableRow(array $row, PermissionSet $permissionSet = null): Entity\ProfileField
 	{
-		if (empty($permissionSet) &&
-			(!array_key_exists('psid', $row) || !array_key_exists('allow_cid', $row) || !array_key_exists('allow_gid', $row) || !array_key_exists('deny_cid', $row) || !array_key_exists('deny_gid', $row))
+		if (empty($permissionSet)
+			&& (!array_key_exists('psid', $row) || !array_key_exists('allow_cid', $row) || !array_key_exists('allow_gid', $row) || !array_key_exists('deny_cid', $row) || !array_key_exists('deny_gid', $row))
 		) {
 			throw new UnexpectedPermissionSetException('Either set the PermissionSet fields (join) or the PermissionSet itself');
 		}
@@ -51,10 +51,10 @@ class ProfileField extends BaseFactory implements ICanCreateFromTableRow
 				$row['allow_gid'],
 				$row['deny_cid'],
 				$row['deny_gid'],
-				$row['psid']
+				$row['psid'],
 			),
-			$row['id'] ?? null,
-			$owner['uri-id'] ?? null
+			$row['id']       ?? null,
+			$owner['uri-id'] ?? null,
 		);
 	}
 
@@ -77,7 +77,7 @@ class ProfileField extends BaseFactory implements ICanCreateFromTableRow
 		string $label,
 		string $value,
 		PermissionSet $permissionSet,
-		int $id = null
+		int $id = null,
 	): Entity\ProfileField {
 		return $this->createFromTableRow([
 			'uid'   => $uid,

--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -39,17 +39,15 @@ final class ATProtocol
 	private ?int $uid = null;
 
 	/**
-				 * Initialize the AT Protocol service.
-				 *
-				 * @param LoggerInterface $logger
-				 * @param Database $db
-				 * @param IManageConfigValues $config
-				 * @param IManagePersonalConfigValues $pConfig
-				 * @param ICanSendHttpRequests $httpClient
-				 */
-				public function __construct(private LoggerInterface $logger, private Database $db, private IManageConfigValues $config, private IManagePersonalConfigValues $pConfig, private ICanSendHttpRequests $httpClient)
-				{
-							}
+	 * Initialize the AT Protocol service.
+	 *
+	 * @param LoggerInterface $logger
+	 * @param Database $db
+	 * @param IManageConfigValues $config
+	 * @param IManagePersonalConfigValues $pConfig
+	 * @param ICanSendHttpRequests $httpClient
+	 */
+	public function __construct(private LoggerInterface $logger, private Database $db, private IManageConfigValues $config, private IManagePersonalConfigValues $pConfig, private ICanSendHttpRequests $httpClient) {}
 
 	/**
 	 * Get the AppView API URL

--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -36,40 +36,20 @@ final class ATProtocol
 	public const STATUS_PDS_FAIL   = 12;
 	public const STATUS_TOKEN_FAIL = 13;
 
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var Database */
-	private $db;
-
-	/** @var \Friendica\Core\Config\Capability\IManageConfigValues */
-	private $config;
-
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-
-	/** @var ICanSendHttpRequests */
-	private $httpClient;
-
 	private ?int $uid = null;
 
 	/**
-	 * Initialize the AT Protocol service.
-	 *
-	 * @param LoggerInterface $logger
-	 * @param Database $database
-	 * @param IManageConfigValues $config
-	 * @param IManagePersonalConfigValues $pConfig
-	 * @param ICanSendHttpRequests $httpClient
-	 */
-	public function __construct(LoggerInterface $logger, Database $database, IManageConfigValues $config, IManagePersonalConfigValues $pConfig, ICanSendHttpRequests $httpClient)
-	{
-		$this->logger     = $logger;
-		$this->db         = $database;
-		$this->config     = $config;
-		$this->pConfig    = $pConfig;
-		$this->httpClient = $httpClient;
-	}
+				 * Initialize the AT Protocol service.
+				 *
+				 * @param LoggerInterface $logger
+				 * @param Database $db
+				 * @param IManageConfigValues $config
+				 * @param IManagePersonalConfigValues $pConfig
+				 * @param ICanSendHttpRequests $httpClient
+				 */
+				public function __construct(private LoggerInterface $logger, private Database $db, private IManageConfigValues $config, private IManagePersonalConfigValues $pConfig, private ICanSendHttpRequests $httpClient)
+				{
+							}
 
 	/**
 	 * Get the AppView API URL

--- a/src/Protocol/ATProtocol/Actor.php
+++ b/src/Protocol/ATProtocol/Actor.php
@@ -24,15 +24,6 @@ use Psr\Log\LoggerInterface;
  */
 class Actor
 {
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var ATProtocol */
-	private $atprotocol;
-
-	/** @var \Friendica\Core\Config\Capability\IManageConfigValues */
-	private $config;
-
 	/**
 	 * Initialize the actor service.
 	 *
@@ -40,12 +31,9 @@ class Actor
 	 * @param ATProtocol $atprotocol
 	 * @param IManageConfigValues $config
 	 */
-	public function __construct(LoggerInterface $logger, ATProtocol $atprotocol, IManageConfigValues $config)
-	{
-		$this->logger     = $logger;
-		$this->atprotocol = $atprotocol;
-		$this->config     = $config;
-	}
+	public function __construct(private LoggerInterface $logger, private ATProtocol $atprotocol, private IManageConfigValues $config)
+				{
+							}
 
 	/**
 	 * Synchronize the contacts (followers, sharers) for the given user

--- a/src/Protocol/ATProtocol/Actor.php
+++ b/src/Protocol/ATProtocol/Actor.php
@@ -31,9 +31,7 @@ class Actor
 	 * @param ATProtocol $atprotocol
 	 * @param IManageConfigValues $config
 	 */
-	public function __construct(private LoggerInterface $logger, private ATProtocol $atprotocol, private IManageConfigValues $config)
-				{
-							}
+	public function __construct(private LoggerInterface $logger, private ATProtocol $atprotocol, private IManageConfigValues $config) {}
 
 	/**
 	 * Synchronize the contacts (followers, sharers) for the given user

--- a/src/Protocol/ATProtocol/Jetstream.php
+++ b/src/Protocol/ATProtocol/Jetstream.php
@@ -61,24 +61,6 @@ class Jetstream
 	private $self   = [];
 	private $capped = false;
 
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var \Friendica\Core\Config\Capability\IManageConfigValues */
-	private $config;
-
-	/** @var IManageKeyValuePairs */
-	private $keyValue;
-
-	/** @var ATProtocol */
-	private $atprotocol;
-
-	/** @var Actor */
-	private $actor;
-
-	/** @var Processor */
-	private $processor;
-
 	/** @var \WebSocket\Client */
 	private $client;
 
@@ -92,15 +74,8 @@ class Jetstream
 	 * @param Actor $actor
 	 * @param Processor $processor
 	 */
-	public function __construct(LoggerInterface $logger, IManageConfigValues $config, IManageKeyValuePairs $keyValue, ATProtocol $atprotocol, Actor $actor, Processor $processor)
+	public function __construct(private LoggerInterface $logger, private IManageConfigValues $config, private IManageKeyValuePairs $keyValue, private ATProtocol $atprotocol, private Actor $actor, private Processor $processor)
 	{
-		$this->logger     = $logger;
-		$this->config     = $config;
-		$this->keyValue   = $keyValue;
-		$this->atprotocol = $atprotocol;
-		$this->actor      = $actor;
-		$this->processor  = $processor;
-
 		$this->atprotocol->setApiForUser(0);
 	}
 

--- a/src/Protocol/ATProtocol/Processor.php
+++ b/src/Protocol/ATProtocol/Processor.php
@@ -33,17 +33,15 @@ use stdClass;
 class Processor
 {
 	/**
-				 * Processor constructor.
-				 *
-				 * @param Database $db
-				 * @param LoggerInterface $logger
-				 * @param BaseURL $baseURL
-				 * @param ATProtocol $atprotocol
-				 * @param Actor $actor
-				 */
-				public function __construct(private Database $db, private LoggerInterface $logger, private BaseURL $baseURL, private ATProtocol $atprotocol, private Actor $actor)
-				{
-							}
+	 * Processor constructor.
+	 *
+	 * @param Database $db
+	 * @param LoggerInterface $logger
+	 * @param BaseURL $baseURL
+	 * @param ATProtocol $atprotocol
+	 * @param Actor $actor
+	 */
+	public function __construct(private Database $db, private LoggerInterface $logger, private BaseURL $baseURL, private ATProtocol $atprotocol, private Actor $actor) {}
 
 	/**
 	 * Process account events and update contact archive state.

--- a/src/Protocol/ATProtocol/Processor.php
+++ b/src/Protocol/ATProtocol/Processor.php
@@ -32,38 +32,18 @@ use stdClass;
  */
 class Processor
 {
-	/** @var Database */
-	private $db;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var BaseURL */
-	private $baseURL;
-
-	/** @var ATProtocol */
-	private $atprotocol;
-
-	/** @var Actor */
-	private $actor;
-
 	/**
-	 * Processor constructor.
-	 *
-	 * @param Database $database
-	 * @param LoggerInterface $logger
-	 * @param BaseURL $baseURL
-	 * @param ATProtocol $atprotocol
-	 * @param Actor $actor
-	 */
-	public function __construct(Database $database, LoggerInterface $logger, BaseURL $baseURL, ATProtocol $atprotocol, Actor $actor)
-	{
-		$this->db         = $database;
-		$this->logger     = $logger;
-		$this->baseURL    = $baseURL;
-		$this->atprotocol = $atprotocol;
-		$this->actor      = $actor;
-	}
+				 * Processor constructor.
+				 *
+				 * @param Database $db
+				 * @param LoggerInterface $logger
+				 * @param BaseURL $baseURL
+				 * @param ATProtocol $atprotocol
+				 * @param Actor $actor
+				 */
+				public function __construct(private Database $db, private LoggerInterface $logger, private BaseURL $baseURL, private ATProtocol $atprotocol, private Actor $actor)
+				{
+							}
 
 	/**
 	 * Process account events and update contact archive state.

--- a/src/Protocol/Diaspora/Repository/DiasporaContact.php
+++ b/src/Protocol/Diaspora/Repository/DiasporaContact.php
@@ -36,14 +36,10 @@ class DiasporaContact extends BaseRepository
 
 	/** @var DiasporaContactFactory */
 	protected $factory;
-	/** @var DbaDefinition */
-	private $definition;
 
-	public function __construct(DbaDefinition $definition, Database $database, LoggerInterface $logger, DiasporaContactFactory $factory)
+	public function __construct(private DbaDefinition $definition, Database $database, LoggerInterface $logger, DiasporaContactFactory $factory)
 	{
 		parent::__construct($database, $logger, $factory);
-
-		$this->definition = $definition;
 	}
 
 	/**

--- a/src/Protocol/WebFingerUri.php
+++ b/src/Protocol/WebFingerUri.php
@@ -11,30 +11,8 @@ use GuzzleHttp\Psr7\Uri;
 
 class WebFingerUri implements \Stringable
 {
-	/**
-	 * @var string
-	 */
-	private $user;
-	/**
-	 * @var string
-	 */
-	private $host;
-	/**
-	 * @var int|null
-	 */
-	private $port;
-	/**
-	 * @var string|null
-	 */
-	private $path;
-
-	private function __construct(string $user, string $host, int $port = null, string $path = null)
+	private function __construct(private string $user, private string $host, private ?int $port = null, private ?string $path = null)
 	{
-		$this->user = $user;
-		$this->host = $host;
-		$this->port = $port;
-		$this->path = $path;
-
 		$this->validate();
 	}
 

--- a/src/Security/Authentication.php
+++ b/src/Security/Authentication.php
@@ -37,26 +37,6 @@ use Psr\Log\LoggerInterface;
  */
 class Authentication
 {
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var Mode */
-	private $mode;
-	/** @var BaseURL */
-	private $baseUrl;
-	/** @var L10n */
-	private $l10n;
-	/** @var Database */
-	private $dba;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var Cookie */
-	private $cookie;
-	/** @var IHandleUserSessions */
-	private $session;
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-	/** @var AppHelper */
-	private $appHelper;
 	/** @var string */
 	private $remoteAddress;
 
@@ -87,28 +67,18 @@ class Authentication
 	 * @param Request                     $request
 	 */
 	public function __construct(
-		IManageConfigValues $config,
-		Mode $mode,
-		BaseURL $baseUrl,
-		L10n $l10n,
-		Database $dba,
-		LoggerInterface $logger,
-		Cookie $cookie,
-		IHandleUserSessions $session,
-		IManagePersonalConfigValues $pConfig,
-		AppHelper $appHelper,
+		private IManageConfigValues $config,
+		private Mode $mode,
+		private BaseURL $baseUrl,
+		private L10n $l10n,
+		private Database $dba,
+		private LoggerInterface $logger,
+		private Cookie $cookie,
+		private IHandleUserSessions $session,
+		private IManagePersonalConfigValues $pConfig,
+		private AppHelper $appHelper,
 		Request $request,
 	) {
-		$this->config        = $config;
-		$this->mode          = $mode;
-		$this->baseUrl       = $baseUrl;
-		$this->l10n          = $l10n;
-		$this->dba           = $dba;
-		$this->logger        = $logger;
-		$this->cookie        = $cookie;
-		$this->session       = $session;
-		$this->pConfig       = $pConfig;
-		$this->appHelper     = $appHelper;
 		$this->remoteAddress = $request->getRemoteAddress();
 	}
 

--- a/src/Security/ExAuth.php
+++ b/src/Security/ExAuth.php
@@ -57,27 +57,6 @@ class ExAuth
 	private $host;
 
 	/**
-	 * @var App\Mode
-	 */
-	private $appMode;
-	/**
-	 * @var IManageConfigValues
-	 */
-	private $config;
-	/**
-	 * @var IManagePersonalConfigValues
-	 */
-	private $pConfig;
-	/**
-	 * @var Database
-	 */
-	private $dba;
-	/**
-	 * @var App\BaseURL
-	 */
-	private $baseURL;
-
-	/**
 	 * @param App\Mode                    $appMode
 	 * @param IManageConfigValues         $config
 	 * @param IManagePersonalConfigValues $pConfig
@@ -86,15 +65,9 @@ class ExAuth
 	 *
 	 * @throws Exception
 	 */
-	public function __construct(App\Mode $appMode, IManageConfigValues $config, IManagePersonalConfigValues $pConfig, Database $dba, App\BaseURL $baseURL)
+	public function __construct(private App\Mode $appMode, private IManageConfigValues $config, private IManagePersonalConfigValues $pConfig, private Database $dba, private App\BaseURL $baseURL)
 	{
-		$this->appMode = $appMode;
-		$this->config  = $config;
-		$this->pConfig = $pConfig;
-		$this->dba     = $dba;
-		$this->baseURL = $baseURL;
-
-		$this->bDebug = (int) $config->get('jabber', 'debug');
+		$this->bDebug = (int) $this->config->get('jabber', 'debug');
 
 		openlog('auth_ejabberd', LOG_PID, LOG_USER);
 

--- a/src/Security/OAuth1/OAuthConsumer.php
+++ b/src/Security/OAuth1/OAuthConsumer.php
@@ -9,16 +9,9 @@ namespace Friendica\Security\OAuth1;
 
 class OAuthConsumer implements \Stringable
 {
-	public $key;
-	public $secret;
-	public $callback_url;
-
-	public function __construct($key, $secret, $callback_url = null)
-	{
-		$this->key          = $key;
-		$this->secret       = $secret;
-		$this->callback_url = $callback_url;
-	}
+	public function __construct(public $key, public $secret, public $callback_url = null)
+				{
+							}
 
 	public function __toString(): string
 	{

--- a/src/Security/OAuth1/OAuthConsumer.php
+++ b/src/Security/OAuth1/OAuthConsumer.php
@@ -9,9 +9,7 @@ namespace Friendica\Security\OAuth1;
 
 class OAuthConsumer implements \Stringable
 {
-	public function __construct(public $key, public $secret, public $callback_url = null)
-				{
-							}
+	public function __construct(public $key, public $secret, public $callback_url = null) {}
 
 	public function __toString(): string
 	{

--- a/src/Security/OAuth1/OAuthRequest.php
+++ b/src/Security/OAuth1/OAuthRequest.php
@@ -12,19 +12,17 @@ use Friendica\Util\Strings;
 class OAuthRequest implements \Stringable
 {
 	private $parameters;
-	private $http_method;
 	private $http_url;
 	// for debug purposes
 	public $base_string;
 	public static $version    = '1.0';
 	public static $POST_INPUT = 'php://input';
 
-	public function __construct($http_method, $http_url, $parameters = null)
+	public function __construct(private $http_method, $http_url, $parameters = null)
 	{
 		@$parameters or $parameters = [];
 		$parameters                 = array_merge(OAuthUtil::parse_parameters(parse_url($http_url, PHP_URL_QUERY)), $parameters);
 		$this->parameters           = $parameters;
-		$this->http_method          = $http_method;
 		$this->http_url             = $http_url;
 	}
 

--- a/src/Security/OAuth1/OAuthToken.php
+++ b/src/Security/OAuth1/OAuthToken.php
@@ -20,9 +20,7 @@ class OAuthToken implements \Stringable
 	 * @param $key
 	 * @param $secret
 	 */
-	public function __construct(public $key, public $secret)
-				{
-							}
+	public function __construct(public $key, public $secret) {}
 
 	/**
 	 * generates the basic string serialization of a token that a server

--- a/src/Security/OAuth1/OAuthToken.php
+++ b/src/Security/OAuth1/OAuthToken.php
@@ -9,10 +9,6 @@ namespace Friendica\Security\OAuth1;
 
 class OAuthToken implements \Stringable
 {
-	// access tokens and request tokens
-	public $key;
-	public $secret;
-
 	public $expires;
 	public $scope;
 	public $uid;
@@ -24,11 +20,9 @@ class OAuthToken implements \Stringable
 	 * @param $key
 	 * @param $secret
 	 */
-	public function __construct($key, $secret)
-	{
-		$this->key    = $key;
-		$this->secret = $secret;
-	}
+	public function __construct(public $key, public $secret)
+				{
+							}
 
 	/**
 	 * generates the basic string serialization of a token that a server

--- a/src/Security/PermissionSet/Repository/PermissionSet.php
+++ b/src/Security/PermissionSet/Repository/PermissionSet.php
@@ -31,14 +31,9 @@ class PermissionSet extends BaseRepository
 
 	protected static $table_name = 'permissionset';
 
-	/** @var ACLFormatter */
-	private $aclFormatter;
-
-	public function __construct(Database $database, LoggerInterface $logger, PermissionSetFactory $factory, ACLFormatter $aclFormatter)
+	public function __construct(Database $database, LoggerInterface $logger, PermissionSetFactory $factory, private ACLFormatter $aclFormatter)
 	{
 		parent::__construct($database, $logger, $factory);
-
-		$this->aclFormatter = $aclFormatter;
 	}
 
 	/**

--- a/src/System/Daemon.php
+++ b/src/System/Daemon.php
@@ -15,8 +15,6 @@ use Psr\Log\LoggerInterface;
  */
 final class Daemon
 {
-	private LoggerInterface $logger;
-	private Database $dba;
 	private ?string $pidfile = null;
 	private ?int $pid        = null;
 
@@ -40,11 +38,9 @@ final class Daemon
 		return $this->pidfile;
 	}
 
-	public function __construct(LoggerInterface $logger, Database $dba)
-	{
-		$this->logger = $logger;
-		$this->dba    = $dba;
-	}
+	public function __construct(private LoggerInterface $logger, private Database $dba)
+				{
+							}
 
 	/**
 	 * Initialize the current daemon class with a given PID file

--- a/src/System/Daemon.php
+++ b/src/System/Daemon.php
@@ -38,9 +38,7 @@ final class Daemon
 		return $this->pidfile;
 	}
 
-	public function __construct(private LoggerInterface $logger, private Database $dba)
-				{
-							}
+	public function __construct(private LoggerInterface $logger, private Database $dba) {}
 
 	/**
 	 * Initialize the current daemon class with a given PID file

--- a/src/Util/BasePath.php
+++ b/src/Util/BasePath.php
@@ -13,9 +13,7 @@ class BasePath
 	 * @param string $baseDir The default base path
 	 * @param array  $server  server arguments
 	 */
-	public function __construct(private string $baseDir, private array $server = [])
-				{
-							}
+	public function __construct(private string $baseDir, private array $server = []) {}
 
 	/**
 	 * Returns the base Friendica filesystem path without trailing slash
@@ -30,7 +28,7 @@ class BasePath
 	public function getPath()
 	{
 		$baseDir = $this->baseDir;
-		$server = $this->server;
+		$server  = $this->server;
 
 		if ((!$baseDir || !is_dir($baseDir)) && !empty($server['DOCUMENT_ROOT'])) {
 			$baseDir = $server['DOCUMENT_ROOT'];

--- a/src/Util/BasePath.php
+++ b/src/Util/BasePath.php
@@ -10,23 +10,12 @@ namespace Friendica\Util;
 class BasePath
 {
 	/**
-	 * @var string
-	 */
-	private $baseDir;
-	/**
-	 * @var array
-	 */
-	private $server;
-
-	/**
 	 * @param string $baseDir The default base path
 	 * @param array  $server  server arguments
 	 */
-	public function __construct(string $baseDir, array $server = [])
-	{
-		$this->baseDir = $baseDir;
-		$this->server = $server;
-	}
+	public function __construct(private string $baseDir, private array $server = [])
+				{
+							}
 
 	/**
 	 * Returns the base Friendica filesystem path without trailing slash

--- a/src/Util/Emailer.php
+++ b/src/Util/Emailer.php
@@ -34,7 +34,7 @@ class Emailer
 		private IManagePersonalConfigValues $pConfig,
 		private BaseURL $baseUrl,
 		private LoggerInterface $logger,
-		private L10n $l10n
+		private L10n $l10n,
 	) {
 		$this->siteEmailAddress = $this->config->get('config', 'sender_email');
 		if (empty($this->siteEmailAddress)) {

--- a/src/Util/Emailer.php
+++ b/src/Util/Emailer.php
@@ -24,35 +24,18 @@ use Psr\Log\LoggerInterface;
  */
 class Emailer
 {
-	/** @var IManageConfigValues */
-	private $config;
-	/** @var IManagePersonalConfigValues */
-	private $pConfig;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var BaseURL */
-	private $baseUrl;
-	/** @var L10n */
-	private $l10n;
-
 	/** @var string */
 	private $siteEmailAddress;
 	/** @var string */
 	private $siteEmailName;
 
 	public function __construct(
-		IManageConfigValues $config,
-		IManagePersonalConfigValues $pConfig,
-		BaseURL $baseURL,
-		LoggerInterface $logger,
-		L10n $defaultLang
+		private IManageConfigValues $config,
+		private IManagePersonalConfigValues $pConfig,
+		private BaseURL $baseUrl,
+		private LoggerInterface $logger,
+		private L10n $l10n
 	) {
-		$this->config  = $config;
-		$this->pConfig = $pConfig;
-		$this->logger  = $logger;
-		$this->baseUrl = $baseURL;
-		$this->l10n    = $defaultLang;
-
 		$this->siteEmailAddress = $this->config->get('config', 'sender_email');
 		if (empty($this->siteEmailAddress)) {
 			$hostname = $this->baseUrl->getHost();

--- a/tests/Util/EntityDouble.php
+++ b/tests/Util/EntityDouble.php
@@ -19,13 +19,11 @@ class EntityDouble extends BaseEntity
 	protected $protString;
 	protected $protInt;
 	protected $protDateTime;
-	private $privString;
 
-	public function __construct(string $protString, int $protInt, \DateTime $protDateTime, string $privString)
+	public function __construct(string $protString, int $protInt, \DateTime $protDateTime, private string $privString)
 	{
 		$this->protString   = $protString;
 		$this->protInt      = $protInt;
 		$this->protDateTime = $protDateTime;
-		$this->privString   = $privString;
 	}
 }

--- a/tests/Util/SampleStorageBackend.php
+++ b/tests/Util/SampleStorageBackend.php
@@ -9,7 +9,6 @@ namespace Friendica\Test\Util;
 
 use Friendica\Core\Hook;
 use Friendica\Core\Storage\Capability\ICanWriteToStorage;
-
 use Friendica\Core\L10n;
 
 /**
@@ -17,7 +16,7 @@ use Friendica\Core\L10n;
  */
 class SampleStorageBackend implements ICanWriteToStorage
 {
-	const NAME = 'Sample Storage';
+	public const NAME = 'Sample Storage';
 
 	/** @var array */
 	private $options = [
@@ -40,9 +39,7 @@ class SampleStorageBackend implements ICanWriteToStorage
 	 * You can add here every dynamic class as dependency you like and add them to a private field
 	 * Friendica automatically creates these classes and passes them as argument to the constructor
 	 */
-	public function __construct(private L10n $l10n)
-				{
-							}
+	public function __construct(private L10n $l10n) {}
 
 	public function get(string $reference): string
 	{

--- a/tests/Util/SampleStorageBackend.php
+++ b/tests/Util/SampleStorageBackend.php
@@ -19,9 +19,6 @@ class SampleStorageBackend implements ICanWriteToStorage
 {
 	const NAME = 'Sample Storage';
 
-	/** @var L10n */
-	private $l10n;
-
 	/** @var array */
 	private $options = [
 		'filename' => [
@@ -43,10 +40,9 @@ class SampleStorageBackend implements ICanWriteToStorage
 	 * You can add here every dynamic class as dependency you like and add them to a private field
 	 * Friendica automatically creates these classes and passes them as argument to the constructor
 	 */
-	public function __construct(L10n $l10n)
-	{
-		$this->l10n = $l10n;
-	}
+	public function __construct(private L10n $l10n)
+				{
+							}
 
 	public function get(string $reference): string
 	{


### PR DESCRIPTION
This PR update the source code to use property assignment via constructor (available since PHP 8.0).

Used rector:

- [ClassPropertyAssignToConstructorPromotionRector](https://getrector.com/rule-detail/class-property-assign-to-constructor-promotion-rector)

Part of https://github.com/friendica/friendica/issues/14535