### PR TITLE
More uniform and distinctive hover and focus (Frio)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -300,6 +300,7 @@ details summary {
 	background: $nav_bg;
 	color: $btn_primary_color;
 }
+
 .btn.btn-primary:hover,
 .btn.btn-primary:focus {
 	color: $btn_primary_color;
@@ -1133,7 +1134,7 @@ ul li .intro-wrapper button.intro-action-link {
 .contact-photo-wrapper .dropdown-menu li.selected a {
 	border-left: 3px solid $link_color;
 	color: #fff;
-	background: $menu_background_hover_color;
+	background: $nav_icon_hover_color;
 }
 #photo-edit-link-wrap {
 	color: $font_color_darker;
@@ -1205,9 +1206,20 @@ aside .widget li a {
 	padding-top: 6px;
 	padding-bottom: 6px;
 }
-aside .widget li a,
+aside .widget li a {
+	color: $font_color_darker;
+}
+
 aside .widget li a:hover {
 	color: $font_color_darker;
+}
+
+aside .fakelink h3:hover {
+	color: $link_color;
+}
+
+aside .widget li.selected a {
+	color: $font_color;
 }
 
 /* group-list widget */
@@ -2161,10 +2173,13 @@ code > .hl-main {
 button[disabled] {
   	color: $font_color_lighter;
 }
-.wall-item-actions .active {
-	font-weight: bold;
-	color: $link_color;
+.wall-item-actions .active,
+.wall-item-actions button:focus,
+.wall-item-actions button:hover {
 	box-shadow: none;
+	color: $link_color;
+	font-weight: bold;
+	text-decoration: underline;
 }
 .wall-item-actions-left {
 	display: table-cell;
@@ -2204,9 +2219,6 @@ button[disabled] {
 		top: 8px;
 		right: 0;
 	}
-}
-.wall-item-actions button:hover {
-	text-decoration: underline;
 }
 .wall-item-actions .separator {
 	margin: 0 0.3em;
@@ -2763,6 +2775,10 @@ ul.viewcontact_wrapper > li {
 }
 .contact-wrapper .contact-photo-menu {
 	top: auto;
+}
+
+.contact-entry-details {
+  color: $font_color;
 }
 
 .contact-entry-desc {

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -9,6 +9,14 @@
     Created on : 11.08.2020
     Author     : Hypolite Petovan <hypolite@friendica.mrpetovan.com>
 */
+
+a:hover, button:focus, .btn-link:focus, .btn-primary:focus,
+a:hover, button:hover, .btn-link:hover, .btn-primary:hover,
+#topbar-first li a:hover, #topbar-first li button:hover,
+#topbar-first li a:focus, #topbar-first li button:focus {
+	color: white;
+}
+
 #topbar-first {
 	background-color: $background_color;
 }
@@ -33,6 +41,10 @@
 }
 #topbar-second ul.tabs li {
 	border_color: $link_color;
+}
+header #banner #logo-img:focus,
+header #banner #logo-img:hover {
+		background-color: $font_color;
 }
 
 .dropdown-menu,

--- a/view/theme/frio/style.php
+++ b/view/theme/frio/style.php
@@ -112,7 +112,7 @@ if (!isset($nav_icon_hover_color)) {
 	if ($nihc->isLight()) {
 		$nav_icon_hover_color = '#' . $nihc->darken(10);
 	} else {
-		$nav_icon_hover_color = '#' . $nihc->lighten(20);
+		$nav_icon_hover_color = '#' . $nihc->lighten(13);
 	}
 }
 if (!isset($link_hover_color)) {
@@ -120,9 +120,9 @@ if (!isset($link_hover_color)) {
 	$lcolor = $lhc->getHex();
 
 	if ($lhc->isLight($lcolor, 75)) {
-		$link_hover_color = '#' . $lhc->darken(5);
+		$link_hover_color = '#' . $lhc->darken(20);
 	} else {
-		$link_hover_color = '#' . $lhc->lighten(5);
+		$link_hover_color = '#' . $lhc->lighten(20);
 	}
 }
 
@@ -166,7 +166,7 @@ $options = [
 	'$link_hover_color'            => $link_hover_color,
 	'$menu_background_hover_color' => $menu_background_hover_color,
 	'$btn_primary_color'           => $nav_icon_color,
-	'$btn_primary_hover_color'     => $menu_background_hover_color,
+	'$btn_primary_hover_color'     => $nav_icon_hover_color,
 	'$background_color'            => $background_color,
 	'$contentbg_transp'            => $contentbg_transp,
 	'$background_image'            => $background_image,
@@ -212,7 +212,7 @@ if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && isset($_SERVER['HTTP_IF_NONE_MA
 	$cached_etag     = str_replace(
 		['"', '-gzip'],
 		['', ''],
-		stripslashes($_SERVER['HTTP_IF_NONE_MATCH'])
+		stripslashes($_SERVER['HTTP_IF_NONE_MATCH']),
 	);
 
 	if (($cached_modified == $modified) && ($cached_etag == $etag)) {


### PR DESCRIPTION
Makes the hover and focus effect more uniform and more distinctive (higher contrast) for buttons/links, but slighly less for the main menu.

Example:
<img width="230" height="99" alt="image" src="https://github.com/user-attachments/assets/c4e2dac3-2e02-4630-b7cd-9dd88073a6ef" />

Currently set to target `develop` but it probably would be fine for RC as well if wanted.