### PR TITLE
AT Protocol: Only check valid looking handles

### DIFF
--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -361,7 +361,12 @@ final class ATProtocol
 	 */
 	public function getDid(string $handle): string
 	{
+		$handle = trim($handle, '@');
 		if ($handle == '') {
+			return '';
+		}
+
+		if (str_contains($handle, '@') || str_contains($handle, '/') || !str_contains($handle, '.')) {
 			return '';
 		}
 


### PR DESCRIPTION
This is a small check that avoids a lot of unneeded atproto calls that would return an API Error.