### PR TITLE
[CI] Use bundled composer.phar in deployment and releaser pipelines

### DIFF
--- a/.woodpecker/.continuous-deployment-allinone.yml
+++ b/.woodpecker/.continuous-deployment-allinone.yml
@@ -48,8 +48,8 @@ steps:
     image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     commands:
       - export COMPOSER_HOME=.composer
-      - composer validate
-      - composer install --no-dev --optimize-autoloader
+      - ./bin/composer.phar validate
+      - ./bin/composer.phar install --no-dev --optimize-autoloader
     volumes:
       - /etc/hosts:/etc/hosts
   create_artifacts:

--- a/.woodpecker/.continuous-deployment.yml
+++ b/.woodpecker/.continuous-deployment.yml
@@ -41,8 +41,8 @@ steps:
     commands:
       - mkdir addon # create empty addon folder to appease composer
       - export COMPOSER_HOME=.composer
-      - composer validate
-      - composer install --no-dev --optimize-autoloader
+      - ./bin/composer.phar validate
+      - ./bin/composer.phar install --no-dev --optimize-autoloader
     volumes:
       - /etc/hosts:/etc/hosts
   create_artifacts:

--- a/.woodpecker/.releaser-allinone.yml
+++ b/.woodpecker/.releaser-allinone.yml
@@ -41,8 +41,8 @@ steps:
     image: friendicaci/php${PHP_MAJOR_VERSION}:php${PHP_VERSION}
     commands:
       - export COMPOSER_HOME=.composer
-      - composer validate
-      - composer install --no-dev --optimize-autoloader
+      - ./bin/composer.phar validate
+      - ./bin/composer.phar install --no-dev --optimize-autoloader
     volumes:
       - /etc/hosts:/etc/hosts
   create_artifacts:

--- a/.woodpecker/.releaser.yml
+++ b/.woodpecker/.releaser.yml
@@ -34,8 +34,8 @@ steps:
     commands:
       - mkdir addon # create empty addon folder to appease composer
       - export COMPOSER_HOME=.composer
-      - composer validate
-      - composer install --no-dev --optimize-autoloader
+      - ./bin/composer.phar validate
+      - ./bin/composer.phar install --no-dev --optimize-autoloader
     volumes:
       - /etc/hosts:/etc/hosts
   create_artifacts:


### PR DESCRIPTION
System composer (1.10.15) in the Docker images is incompatible with PHP 8.4+. 
All pipelines now use ./bin/composer.phar (2.x) consistently.

Merge https://git.friendi.ca/friendica/friendica-addons/pulls/1656 as well

Superseeds compose upgrade at #15705

-> in the end, I'll replace the CI-docker files as well with "standard" images like at .docker , so we can harmonize the three different type of usages ...