### PR TITLE
Add profile address (handles) to posts (Frio)

### DIFF
--- a/src/Content/Conversation/ConversationRenderer.php
+++ b/src/Content/Conversation/ConversationRenderer.php
@@ -500,6 +500,7 @@ final readonly class ConversationRenderer
 				'network_svg'          => ContactSelector::networkToSVG($item['network'], $item['author-gsid'], '', $viewerUid),
 				'linktitle'            => $this->l10n->t('View %s\'s profile @ %s', $profileName, $item['author-link']),
 				'profile_url'          => $profileLink,
+				'profile_addr'         => $item['author-addr'] ?? '',
 				'item_photo_menu_html' => $this->item->photoMenu($item, $formSecurityToken),
 				'name'                 => $profileName,
 				'sparkle'              => $sparkle,

--- a/src/Content/Conversation/PostTemplateBuilder.php
+++ b/src/Content/Conversation/PostTemplateBuilder.php
@@ -326,6 +326,7 @@ final class PostTemplateBuilder
 			'wall'                   => $this->l10n->t('Wall-to-Wall'),
 			'vwall'                  => $this->l10n->t('via Wall-To-Wall:'),
 			'profile_url'            => $profileUrl,
+			'profile_addr'           => $item['author-addr'] ?? '',
 			'name'                   => $profileName,
 			'item_photo_menu_html'   => $this->item->photoMenu($item, $formSecurityToken),
 			'thumb'                  => $this->baseURL->remove($this->item->getAuthorAvatar($item)),

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -632,7 +632,7 @@ class L10n
 	 */
 	public function relativeDateTime(string $datestring): string
 	{
-		return $this->formatDateTime($datestring, IntlDateFormatter::RELATIVE_FULL, IntlDateFormatter::SHORT);
+		return $this->formatDateTime($datestring, IntlDateFormatter::RELATIVE_MEDIUM, IntlDateFormatter::SHORT);
 	}
 
 	/**

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1945,6 +1945,11 @@ aside .panel-body {
 	transition: all 0.25s ease-in-out;
 }
 
+.wall-item-addr {
+	font-size: 13.6px;
+	font-weight: normal;
+}
+
 /* wall items */
 .wall-item-container {
 	border-top: 1px solid rgba(255, 255, 255, 0.8);
@@ -2027,18 +2032,20 @@ aside .panel-body {
 	position: relative;
 }
 
+.media .preferences {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
 /* Workaround for Firefox where the post heading covers the avatar, preventing hovercard interaction,
  48px is the width of the avatar image and should be adjusted accordingly if it ever changes. */
 .media .dropdown.pull-left + .contact-info {
 	margin-left: 48px;
 }
 
-.preferences {
-	position: absolute;
-	right: 0;
-	top: 0;
-}
 #profile-edit-links .preferences {
+	position: absolute;
 	top: 15px;
 	right: 15px;
 }
@@ -2081,9 +2088,6 @@ blockquote.shared_content {
 .contact-info h1.media-heading {
 	font-size: 15px;
 	font-weight: 700;
-}
-.media .contact-info-comment {
-	display: table-cell;
 }
 .media .contact-info-comment {
 	margin: 0 0 5px;
@@ -2442,7 +2446,7 @@ button[disabled] {
 	width: 20px;
 	height: 20px;
 	border-radius: 4px;
-	padding: 2px;
+	padding: 1px;
 }
 
 /*
@@ -2660,13 +2664,16 @@ ul.dropdown-menu li:hover {
 
 /* Media Classes */
 p.wall-item-announce,
-.media .time,
 .media .shared-time,
 .media .delivery,
 .media .location,
 .media .location a {
 	font-size: 11px;
 	color: $font_color_darker;
+}
+.media .time {
+	color: $font_color_darker;
+	font-size: 12px;
 }
 .media-list > li {
 	padding: 10px;
@@ -3953,6 +3960,12 @@ main .nav-tabs > li.active > a:hover {
 There are for some reasons empty <a> tags. I don't know why */
 .textcomplete-item .contact-wrapper a {
 	padding: 0;
+}
+
+.tread-wrapper h1, .contact-info-comment h2 {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
 }
 
 /* hovercard fix */

--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -444,3 +444,7 @@ figure.img-allocated-height {
 .dropzone:not(textarea) {
 	color: #ccc;
 }
+
+.text-muted {
+	color: $font_color_darker;
+}

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -489,3 +489,7 @@ figure.img-allocated-height {
 .dropzone:not(textarea) {
 	color: #ccc;
 }
+
+.text-muted {
+	color: $font_color_darker;
+}

--- a/view/theme/frio/templates/network_profile_address.tpl
+++ b/view/theme/frio/templates/network_profile_address.tpl
@@ -1,0 +1,18 @@
+{{*
+  * Copyright (C) 2010-2026, the Friendica project
+  * SPDX-FileCopyrightText: 2010-2026 the Friendica project
+  *
+  * SPDX-License-Identifier: AGPL-3.0-or-later
+  *}}
+						<div>
+							{{if $item.network_svg && $item.plink}}
+								<span class="wall-item-network"><a href="{{$item.plink.href}}" class="plink u-url" target="_blank"><img class="network-svg" src="{{$item.network_svg}}" alt="{{$item.network_name}} - {{$item.plink.title}}" title="{{$item.network_name}} - {{$item.plink.title}}" loading="lazy"/></a></span>
+							{{elseif $item.plink}}
+									<a href="{{$item.plink.href}}" class="plink u-url" aria-label="{{$item.plink.title}}" title="{{$item.network_name}} - {{$item.plink.title}}" target="_blank">{{$item.network_name}}</a>
+							{{elseif $item.network_svg}}
+								<span class="wall-item-network"><img class="network-svg" src="{{$item.network_svg}}" title="{{$item.network_name}}" loading="lazy" aria-hidden="true"/></span>
+							{{else}}
+									<span class="wall-item-network" title="{{$item.app}}">{{$item.network_name}}</span>
+							{{/if}}
+							<span class="wall-item-addr text-muted">@{{$item.profile_addr}}</span>
+						</div>

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -33,77 +33,46 @@
 
 
 			{{* contact info header*}}
-			<div class="contact-info hidden-sm hidden-xs media-body"><!-- Desktop -->
-				<div class="preferences">
-					{{if $item.network_svg && $item.plink}}
-						<span class="wall-item-network"><a href="{{$item.plink.href}}" class="plink u-url" target="_blank"><img class="network-svg" src="{{$item.network_svg}}" alt="{{$item.plink.title}}" title="{{$item.network_name}} - {{$item.plink.title}}" loading="lazy"/></a></span>
-					{{elseif $item.plink}}
-						<a href="{{$item.plink.href}}" class="plink u-url" aria-label="{{$item.plink.title}}" title="{{$item.network_name}} - {{$item.plink.title}}" target="_blank">{{$item.network_name}}</a>
-					{{elseif $item.network_svg}}
-						<span class="wall-item-network"><img class="network-svg" src="{{$item.network_svg}}" title="{{$item.network_name}}" loading="lazy" aria-hidden="true"/></span>
-					{{else}}
-						<span class="wall-item-network" title="{{$item.app}}">{{$item.network_name}}</span>
-					{{/if}}
-				</div>
+			<div class="contact-info media-body"><!-- Desktop -->
 				<h2 class="media-heading">
 					<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card">
 						<span class="wall-item-name {{$item.sparkle}}">{{$item.name}}</span>
 					</a>
-				{{if $item.owner_url}}
-					{{$item.via}}
-					<a href="{{$item.owner_url}}" target="redir" title="{{$item.olinktitle}}" class="wall-item-name-link userinfo hover-card">
-						<span class="wall-item-name {{$item.osparkle}}" id="wall-item-ownername-{{$item.id}}">{{$item.owner_name}}</span>
-					</a>
-				{{/if}}
-				{{if $item.lock}}
-					<span class="navicon lock fakelink" onClick="lockview(event, 'item', {{$item.id}});" title="{{$item.lock}}">
-						&nbsp;<small><i class="ri ri-lock-line" aria-hidden="true"></i></small>
-					</span>
-				{{elseif $item.connector}}
-					<span class="ri ri-lock-line" title="{{$item.connector}}"></span>
-				{{/if}}
-					<div class="additional-info text-muted">
-						<div id="wall-item-ago-{{$item.id}}" class="wall-item-ago">
-							<small>
-								<a href="{{$item.plink.orig}}">
-									<time class="time" title="{{$item.localtime}}" data-toggle="tooltip" datetime="{{$item.utc}}">{{$item.ago}}</time>
-								</a>
-								{{if $item.pinned}}
-									<span aria-hidden="true">&bull;</span> <i class="ri ri-pushpin-line" aria-hidden="true" title="{{$item.pinned}}"></i>
-									<span class="sr-only">{{$item.pinned}}</span>
-								{{/if}}
-							</small>
-						</div>
-
-						{{if $item.location_html}}
-						<div id="wall-item-location-{{$item.id}}" class="wall-item-location">
-							<small><span class="location">({{$item.location_html nofilter}})</span></small>
-						</div>
-						{{/if}}
-					</div>
-				{{* @todo $item.created have to be inserted *}}
-				</h2>
-			</div>
-
-			{{* contact info header for smartphones *}}
-			<div class="contact-info contact-info-xs hidden-lg hidden-md">
-				<div class="preferences">
-					{{if $item.network_svg && $item.plink}}
-						<span class="wall-item-network"><a href="{{$item.plink.href}}" class="plink u-url" target="_blank"><img class="network-svg" src="{{$item.network_svg}}" alt="{{$item.plink.title}}" title="{{$item.network_name}} - {{$item.plink.title}}" loading="lazy"/></a></span>
-					{{elseif $item.plink}}
-						<a href="{{$item.plink.href}}" class="plink u-url" aria-label="{{$item.plink.title}}" title="{{$item.network_name}} - {{$item.plink.title}}" target="_blank">{{$item.network_name}}</a>
-					{{elseif $item.network_svg}}
-						<span class="wall-item-network"><img class="network-svg" src="{{$item.network_svg}}" alt="{{$item.plink.title}}" title="{{$item.network_name}} - {{$item.plink.title}}" loading="lazy"/></span>
-					{{else}}
-						<span class="wall-item-network" title="{{$item.app}}">{{$item.network_name}}</span>
+					{{include file="network_profile_address.tpl" item=$item}}
+					{{if $item.owner_url}}
+						{{$item.via}}
+						<a href="{{$item.owner_url}}" target="redir" title="{{$item.olinktitle}}" class="wall-item-name-link userinfo hover-card">
+							<span class="wall-item-name {{$item.osparkle}}" id="wall-item-ownername-{{$item.id}}">{{$item.owner_name}}</span>
+							{{include file="network_profile_address.tpl" item=$item}}
+						</a>
 					{{/if}}
+					{{if $item.lock}}
+						<span class="navicon lock fakelink" onClick="lockview(event, 'item', {{$item.id}});" title="{{$item.lock}}">
+							&nbsp;<small><i class="ri ri-lock-line" aria-hidden="true"></i></small>
+						</span>
+					{{elseif $item.connector}}
+						<span class="ri ri-lock-line" title="{{$item.connector}}"></span>
+					{{/if}}
+				</h2>
+
+				<div class="additional-info text-muted">
+					{{if $item.location_html}}
+					<div id="wall-item-location-{{$item.id}}" class="wall-item-location">
+						<small><span class="location">({{$item.location_html nofilter}})</span></small>
+					</div>
+					{{/if}}
+					<div id="wall-item-ago-{{$item.id}}" class="wall-item-ago">
+						<small>
+							<a href="{{$item.plink.orig}}">
+								<time class="time" title="{{$item.localtime}}" data-toggle="tooltip" datetime="{{$item.utc}}">{{$item.ago}}</time>
+							</a>
+							{{if $item.pinned}}
+								<span aria-hidden="true">&middot;</span> <i class="fa fa-thumb-tack" aria-hidden="true" title="{{$item.pinned}}"></i>
+								<span class="sr-only">{{$item.pinned}}</span>
+							{{/if}}
+						</small>
+					</div>
 				</div>
-				<h5 class="media-heading">
-					<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card"><span>{{$item.name}}</span></a>
-					<p class="text-muted"><small>
-						<span class="wall-item-ago">{{$item.ago}}</span> {{if $item.location_html}}&nbsp;&mdash;&nbsp;({{$item.location_html nofilter}}){{/if}}</small>
-					</p>
-				</h5>
 			</div>
 
 			<div class="clearfix"></div>
@@ -113,7 +82,7 @@
 			{{* item content *}}
 			<article class="wall-item-content {{$item.type}}" id="wall-item-content-{{$item.id}}" lang="{{$item.lang}}" aria-posinset="{{$item.id}}" aria-setsize="-1">
 				{{if $item.title}}
-				<span class="wall-item-title" id="wall-item-title-{{$item.id}}"><h3 class="media-heading" dir="auto"><a href="{{$item.plink.href}}" class="{{$item.sparkle}}">{{$item.title}}</a></h3><br /></span>
+				<span class="wall-item-title" id="wall-item-title-{{$item.id}}"><h3 class="media-heading" dir="auto"><a href="{{$item.plink.href}}" class="{{$item.sparkle}}">{{$item.title}}</a></h3></span>
 				{{/if}}
 
 				<div class="wall-item-body" id="wall-item-body-{{$item.id}}" dir="auto">{{$item.body_html nofilter}}</div>

--- a/view/theme/frio/templates/sub/delivery_count.tpl
+++ b/view/theme/frio/templates/sub/delivery_count.tpl
@@ -6,7 +6,6 @@
   *}}
 {{if $delivery.queue_count >= -1 && $delivery.queue_count !== '' && $delivery.queue_count !== null}}
 <span class="delivery">
-	<span aria-hidden="true">&bull;</span>
 	{{if $delivery.queue_count == 0}}
 		<i class="ri ri-hourglass-line" aria-hidden="true" title="{{$delivery.notifier_pending}}"></i>
 		<span class="sr-only">{{$delivery.notifier_pending}}</span>

--- a/view/theme/frio/templates/sub/direction.tpl
+++ b/view/theme/frio/templates/sub/direction.tpl
@@ -6,7 +6,6 @@
   *}}
 {{if $direction.direction > 0}}
 	<span class="direction" title="{{$direction.title}}">
-		<span aria-hidden="true">&bull;</span>
 		{{if $direction.direction == 1}}
 			<i class="ri ri-inbox-line"></i>
 		{{elseif $direction.direction == 2}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -124,29 +124,42 @@ as the value of $top_child_total (this is done at the end of this file)
 
 		{{* contact info header*}}
 		<div class="contact-info">
-			<div class="preferences">
-				{{if $item.network_svg && $item.plink}}
-					<span class="wall-item-network"><a href="{{$item.plink.href}}" class="plink u-url" target="_blank"><img class="network-svg" src="{{$item.network_svg}}" alt="{{$item.network_name}} - {{$item.plink.title}}" title="{{$item.network_name}} - {{$item.plink.title}}" loading="lazy"/></a></span>
-				{{elseif $item.plink}}
-       				<a href="{{$item.plink.href}}" class="plink u-url" aria-label="{{$item.plink.title}}" title="{{$item.network_name}} - {{$item.plink.title}}" target="_blank">{{$item.network_name}}</a>
-				{{elseif $item.network_svg}}
-					<span class="wall-item-network"><img class="network-svg" src="{{$item.network_svg}}" title="{{$item.network_name}}" loading="lazy" aria-hidden="true"/></span>
-    			{{else}}
-        			<span class="wall-item-network" title="{{$item.app}}">{{$item.network_name}}</span>
-    			{{/if}}
-			</div>
 		{{if $item.thread_level==1}}
-			<div class="hidden-sm hidden-xs media-body"><!-- <= For computer -->
+			<div> <!-- <= Post header -->
 				<h1 class="media-heading">
-					<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card">
-						<span class="wall-item-name {{$item.sparkle}}">{{$item.name}}</span>
-					</a>
-				{{if $item.owner_url}}
-					{{$item.via}}
-					<a href="{{$item.owner_url}}" target="redir" title="{{$item.olinktitle}}" class="wall-item-name-link userinfo hover-card">
-						<span class="wall-item-name {{$item.osparkle}}" id="wall-item-ownername-{{$item.id}}">{{$item.owner_name}}</span>
-					</a>
-				{{/if}}
+					<div>
+						<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card">
+							<span class="wall-item-name {{$item.sparkle}}">{{$item.name}}</span>
+						</a>
+						{{include file="network_profile_address.tpl" item=$item}}
+					</div>
+					{{if $item.owner_url}}
+						<div>
+							{{$item.via}}
+							<a href="{{$item.owner_url}}" target="redir" title="{{$item.olinktitle}}" class="wall-item-name-link userinfo hover-card">
+								<span class="wall-item-name {{$item.osparkle}}" id="wall-item-ownername-{{$item.id}}">{{$item.owner_name}}</span>
+							</a>
+							{{include file="network_profile_address.tpl" item=$item}}
+						</div>
+					{{/if}}
+					<div class="preferences">
+						{{if $item.owner_self}}
+							{{include file="sub/delivery_count.tpl" delivery=$item.delivery}}
+							<span aria-hidden="true">&middot;</span>
+						{{/if}}
+						{{if $item.direction}}
+							{{include file="sub/direction.tpl" direction=$item.direction}}
+							<span aria-hidden="true">&middot;</span>
+						{{/if}}
+						{{if $item.drop.pagedrop}}
+							<span aria-hidden="true">
+								{{if $item.drop}}
+									<input type="checkbox" title="{{$item.drop.select}}" name="itemselected[]" id="checkbox-{{$item.id}}" class="item-select" value="{{$item.id}}" />
+									<label for="checkbox-{{$item.id}}"></label>
+								{{/if}}
+							</span>
+						{{/if}}
+					</div>
 				</h1>
 
 				<div class="additional-info text-muted">
@@ -154,73 +167,45 @@ as the value of $top_child_total (this is done at the end of this file)
 						<a href="{{$item.plink.orig}}">
 							<time class="time dt-published" title="{{$item.localtime}}" data-toggle="tooltip" datetime="{{$item.utc}}">{{$item.ago}}</time>
 						</a>
-						{{if $item.owner_self}}
-							{{include file="sub/delivery_count.tpl" delivery=$item.delivery}}
-						{{/if}}
-						{{if $item.direction}}
-							{{include file="sub/direction.tpl" direction=$item.direction}}
-						{{/if}}
 						{{if $item.pinned}}
-							<span aria-hidden="true">&bull;</span> <i class="ri ri-pushpin-line" aria-hidden="true" title="{{$item.pinned}}"></i>
+							<span aria-hidden="true">&middot;</span> <i class="ri ri-pushpin-line" aria-hidden="true" title="{{$item.pinned}}"></i>
 							<span class="sr-only">{{$item.pinned}}</span>
 						{{/if}}
 						{{if $item.connector}}
-							<span aria-hidden="true">&bull;</span>
+							<span aria-hidden="true">&middot;</span>
 							<i class="ri ri-plug-line" title="{{$item.connector}}" aria-hidden="true"></i>
 						{{else}}
-							<span aria-hidden="true">&bull;</span>
+							<span aria-hidden="true">&middot;</span>
 							<span class="navicon lock fakelink" onClick="lockview(event, 'item', {{$item.id}});" title="{{$item.privacy}}" data-toggle="tooltip">
 								<i class="ri {{if $item.private == 1}}ri-lock-line{{elseif $item.private == 0}}ri-global-line{{else}}ri-eye-off-line{{/if}}" aria-hidden="true"></i>
 							</span>
 						{{/if}}
+						{{if $item.location_html}}
+						<span id="wall-item-location-{{$item.id}}" class="wall-item-location">
+							<small><span class="location">({{$item.location_html nofilter}})</span></small>
+						</span>
+						{{/if}}
 					</div>
-
-					{{if $item.location_html}}
-					<div id="wall-item-location-{{$item.id}}" class="wall-item-location">
-						<small><span class="location">({{$item.location_html nofilter}})</span></small>
-					</div>
-					{{/if}}
 				</div>
 				{{* @todo $item.created have to be inserted *}}
 			</div>
 
-			{{* contact info header for smartphones *}}
-			<div class="contact-info-xs hidden-lg hidden-md"><!-- <= For smartphone (responsive) -->
-				<h1 class="media-heading">
-					<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card"><span>{{$item.name}}</span></a>
-					<p class="text-muted">
-						<small>
-							<a href="{{$item.plink.orig}}">
-								<time class="time" class="wall-item-ago" datetime="{{$item.utc}}">{{$item.ago}}</time>
-							</a>
-							{{if $item.location_html}}&nbsp;&mdash;&nbsp;({{$item.location_html nofilter}}){{/if}}
-							{{if $item.owner_self}}
-								{{include file="sub/delivery_count.tpl" delivery=$item.delivery}}
-							{{/if}}
-							{{if $item.direction}}
-								{{include file="sub/direction.tpl" direction=$item.direction}}
-							{{/if}}
-							{{if $item.connector}}
-								<span aria-hidden="true">&bull;</span>
-								<span title="{{$item.connector}}">
-									<i class="ri ri-plug-line" aria-hidden="true"></i>
-								</span>
-							{{else}}
-								<span aria-hidden="true">&bull;</span>
-								<span class="navicon lock fakelink" onClick="lockview(event, 'item', {{$item.id}});" title="{{$item.privacy}}" data-toggle="tooltip">
-								<i class="ri {{if $item.private == 1}}ri-lock-line{{elseif $item.private == 0}}ri-global-line{{else}}ri-eye-off-line{{/if}}" aria-hidden="true"></i>
-								</span>
-							{{/if}}
-						</small>
-					</p>
-				</h1>
-			</div>
 		{{else}} {{* End of if $item.thread_level == 1 *}}
 			{{* contact info header for comments *}}
 			<div class="contact-info-comment">
 				<h2 class="media-heading">
-					<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card"><span class="fakelink">{{$item.name}}</span></a>
-					<span class="text-muted">
+					<div>
+						<a href="{{$item.profile_url}}" title="{{$item.linktitle}}" class="wall-item-name-link userinfo hover-card">
+							<strong><span class="fakelink">{{$item.name}}</span></strong>
+						</a>
+						{{include file="network_profile_address.tpl" item=$item}}
+					</div>
+					{{if $item.owner_self}}
+						{{include file="sub/delivery_count.tpl" delivery=$item.delivery}}
+					{{/if}}
+					{{if $item.direction}}
+						{{include file="sub/direction.tpl" direction=$item.direction}}
+					{{/if}}
 				</h2>
 				<small>
 					{{if $item.parentguid}}
@@ -240,20 +225,14 @@ as the value of $top_child_total (this is done at the end of this file)
 						<time class="time" title="{{$item.localtime}}" data-toggle="tooltip" datetime="{{$item.utc}}">{{$item.ago}}</time>
 					</a>
 					{{if $item.location_html}}&nbsp;&mdash;&nbsp;({{$item.location_html nofilter}}){{/if}}
-					{{if $item.owner_self}}
-						{{include file="sub/delivery_count.tpl" delivery=$item.delivery}}
-					{{/if}}
-					{{if $item.direction}}
-						{{include file="sub/direction.tpl" direction=$item.direction}}
-					{{/if}}
 					{{if $item.connector}}
 						<span title="{{$item.connector}}">
-							<span aria-hidden="true">&bull;</span>
+							<span aria-hidden="true">&middot;</span>
 							<i class="ri ri-plug-line" aria-hidden="true"></i>
 						</span>
 					{{else}}
 						<span class="navicon lock fakelink" onClick="lockview(event, 'item', {{$item.id}});" title="{{$item.privacy}}" data-toggle="tooltip">
-							<span aria-hidden="true">&bull;</span>
+							<span aria-hidden="true">&middot;</span>
 							<i class="ri {{if $item.private == 1}}ri-lock-line{{elseif $item.private == 0}}ri-global-line{{else}}ri-eye-off-line{{/if}}" aria-hidden="true"></i>
 						</span>
 					{{/if}}
@@ -271,7 +250,7 @@ as the value of $top_child_total (this is done at the end of this file)
 		{{* item content *}}
 		<div class="wall-item-content {{$item.type}}" id="wall-item-content-{{$item.id}}" lang="{{$item.lang}}">
 			{{if $item.title}}
-			<span class="wall-item-title" id="wall-item-title-{{$item.id}}"><h3 class="media-heading" dir="auto"><a href="{{$item.plink.href}}" class="{{$item.sparkle}} p-name" target="_blank">{{$item.title}}</a></h3><br /></span>
+			<span class="wall-item-title" id="wall-item-title-{{$item.id}}"><h3 class="media-heading" dir="auto"><a href="{{$item.plink.href}}" class="{{$item.sparkle}} p-name" target="_blank">{{$item.title}}</a></h3></span>
 			{{/if}}
 			{{if $item.summary}}
 			<summary class="wall-item-summary" id="wall-item-summary-{{$item.id}}">{{$item.summary}}</summary>
@@ -541,14 +520,6 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{/if}}
 			</ul>
 		</span>
-		{{if $item.drop.pagedrop}}
-		<span class="pull-right checkbox" aria-hidden="true">
-			{{if $item.drop}}
-				<input type="checkbox" title="{{$item.drop.select}}" name="itemselected[]" id="checkbox-{{$item.id}}" class="item-select" value="{{$item.id}}" />
-				<label for="checkbox-{{$item.id}}"></label>
-			{{/if}}
-		</span>
-		{{/if}}
 		</span>
 			<div class="wall-item-actions-items btn-toolbar btn-group visible-xs" role="group">
 				<div class="wall-item-actions-row">


### PR DESCRIPTION
Closes #14706 

Adds handles to posts - specifically to wall posts, comments and search results.
Any places I've missed?

A discussion on the topic is how to handle extremely long names and handles - but it seems the existing CSS already handles that, specifically by wrapping onto multiple lines. We could change that to ellipses or just keep it as is.
See screenshot below.

We could also *always* move the handle/address down to the next line, though?
What do you prefer?

# Screenshots

Post with comments:

<img width="673" height="456" alt="image" src="https://github.com/user-attachments/assets/2ed8f1c2-2048-45ed-8f1b-b28ff35e2411" />

Very long name and handle (earlier screenshot):
<img width="647" height="162" alt="image" src="https://github.com/user-attachments/assets/9a302e0b-424f-406d-9940-d97be4b231e0" />
Not saying it's pretty, but it's rare and the layout isn't broken.