### PR TITLE
Fix adding links after attached links had been added

### DIFF
--- a/src/Module/ParseUrl.php
+++ b/src/Module/ParseUrl.php
@@ -14,6 +14,8 @@ use Friendica\Content\Text\BBCode;
 use Friendica\Core\L10n;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Event\ArrayFilterEvent;
+use Friendica\Model\Post;
+use Friendica\Network\HTTPClient\Client\HttpClientAccept;
 use Friendica\Network\HTTPException\BadRequestException;
 use Friendica\Util;
 use Friendica\Util\Profiler;
@@ -41,37 +43,26 @@ class ParseUrl extends BaseModule
 			throw new \Friendica\Network\HTTPException\ForbiddenException();
 		}
 
-		$format      = '';
+		$format      = $request['format'] ?? '';
 		$title       = '';
 		$description = '';
 		$ret         = ['success' => false, 'contentType' => ''];
 
-		if (!empty($_GET['binurl']) && Util\Strings::isHex($_GET['binurl'])) {
-			$url = trim(hex2bin($_GET['binurl']));
-		} elseif (!empty($_GET['url'])) {
-			$url = trim($_GET['url']);
+		if (!empty($request['binurl']) && Util\Strings::isHex($request['binurl'])) {
+			$url = trim(hex2bin($request['binurl']));
+		} elseif (!empty($request['url'])) {
+			$url = trim($request['url']);
 			// fallback in case no url is valid
 		} else {
 			throw new BadRequestException('No url given');
 		}
 
-		if (!empty($_GET['title'])) {
-			$title = strip_tags(trim($_GET['title']));
+		if (!empty($request['title'])) {
+			$title = strip_tags(trim($request['title']));
 		}
 
-		if (!empty($_GET['description'])) {
-			$description = strip_tags(trim($_GET['description']));
-		}
-
-		if (!empty($_GET['tags'])) {
-			$arr_tags = Util\ParseUrl::convertTagsToArray($_GET['tags']);
-			if (count($arr_tags)) {
-				$str_tags = "\n" . implode(' ', $arr_tags) . "\n";
-			}
-		}
-
-		if (isset($_GET['format']) && $_GET['format'] == 'json') {
-			$format = 'json';
+		if (!empty($request['description'])) {
+			$description = strip_tags(trim($request['description']));
 		}
 
 		// Add url scheme if it is missing
@@ -103,35 +94,39 @@ class ParseUrl extends BaseModule
 		}
 
 		if ($format == 'json') {
-			$siteinfo = Util\ParseUrl::getSiteinfoCached($url);
+			$siteinfo = ['url' => $url];
+			$embed    = false;
 
-			if (in_array($siteinfo['type'], ['image', 'video', 'audio'])) {
-				switch ($siteinfo['type']) {
-					case 'video':
-						$content_type = 'video';
-						break;
-					case 'audio':
-						$content_type = 'audio';
-						break;
-					default:
-						$content_type = 'image';
-						break;
-				}
+			$contentType = Util\ParseUrl::getContentType($url, HttpClientAccept::DEFAULT, 5);
+			$mediatype   = Post\Media::getType(implode('/', $contentType));
 
-				$ret['contentType'] = $content_type;
-				$ret['data']        = ['url' => $url];
-				$ret['success']     = true;
-			} else {
+			if ($mediatype === Post\Media::HTML) {
+				$siteinfo = Util\ParseUrl::getSiteinfoCached($url, implode('/', $contentType));
+				$title    = $siteinfo['title'] ?? $title;
+				$embed    = isset($siteinfo['embed']);
 				unset($siteinfo['keywords']);
+			}
 
-				$ret['data']        = $siteinfo;
+			$ret['data']    = $siteinfo;
+			$ret['success'] = true;
+
+			if ($mediatype === Post\Media::AUDIO) {
+				$ret['contentType'] = 'audio';
+			} elseif (in_array($mediatype, [Post\Media::VIDEO, Post\Media::HLS])) {
+				$ret['contentType'] = 'video';
+			} elseif ($mediatype === Post\Media::IMAGE) {
+				$ret['contentType'] = 'image';
+			} elseif ($mediatype === Post\Media::HTML && $embed) {
+				$ret['contentType'] = 'embed';
+			} elseif ($mediatype === Post\Media::HTML) {
 				$ret['contentType'] = 'attachment';
-				$ret['success']     = true;
+			} else {
+				$ret['contentType'] = 'url';
 			}
 
 			$this->jsonExit($ret);
 		} else {
-			$this->httpExit(BBCode::embedURL($url, empty($_GET['noAttachment']), $title, $description, $_GET['tags'] ?? ''));
+			$this->httpExit(BBCode::embedURL($url, empty($request['noAttachment']), $title, $description, $request['tags'] ?? ''));
 		}
 	}
 }

--- a/view/js/linkPreview.js
+++ b/view/js/linkPreview.js
@@ -128,11 +128,8 @@
 				isExtern = true;
 			}
 
-			// Don't process the textarea input if we have already
-			// an attachment preview.
-			if (!isExtern && isActive) {
-				return;
-			}
+			// Don't add an attachment if we have already an attachment preview.
+			attach = !isActive;
 
 			if (trim(text) !== "" && block === false && urlRegex.test(text)) {
 				binurl = bin2hex(text);
@@ -143,9 +140,9 @@
 
 				if (binurl in cache) {
 					isCrawling = false;
-					processContentData(cache[binurl]);
+					processContentData(cache[binurl], attach);
 				} else {
-					getContentData(binurl, processContentData);
+					getContentData(binurl, processContentData, attach);
 				}
 			}
 		};
@@ -157,18 +154,19 @@
 		 * @param {object} result
 		 * @returns {void}
 		 */
-		var processContentData = function(result) {
+		var processContentData = function(result, attach) {
 			if (result.contentType === 'image') {
 				insertImage(result.data);
-			}
-			if (result.contentType === 'audio') {
+			} else if (result.contentType === 'audio') {
 				insertAudio(result.data);
-			}
-			if (result.contentType === 'video') {
+			} else if (result.contentType === 'video') {
 				insertVideo(result.data);
-			}
-			if (result.contentType === 'attachment') {
+			} else if ((result.contentType === 'attachment' || result.contentType === 'embed') && attach) {
 				insertAttachment(result.data);
+			} else if (result.contentType === 'embed') {
+				insertEmbed(result.data);
+			} else {
+				insertUrl(result.data);
 			}
 			$('#profile-rotator').hide();
 		};
@@ -180,14 +178,14 @@
 		 * @param {type} callback
 		 * @returns {void}
 		 */
-		var getContentData = function(binurl, callback) {
+		var getContentData = function(binurl, callback, attach) {
 			$.get('parseurl?binurl='+ binurl + '&format=json', function (answer) {
 				obj = sanitizeInputData(answer);
 
 				// Put the data into a cache
 				cache[binurl] = obj;
 
-				callback(obj);
+				callback(obj, attach);
 
 				isCrawling = false;
 			});
@@ -232,6 +230,34 @@
 				return;
 			}
 			var bbcode = '\n[video]' + data.url + '[/video]\n';
+			addeditortext(bbcode);
+		};
+
+		/*
+		 * Add a [embed] bbtag with the embed url to the jot editor.
+		 *
+		 * @param {type} data
+		 * @returns {void}
+		 */
+		var insertEmbed = function(data) {
+			if (!isExtern) {
+				return;
+			}
+			var bbcode = '\n[embed]' + data.url + '[/embed]\n';
+			addeditortext(bbcode);
+		};
+
+		/*
+		 * Add a [url] bbtag with the url to the jot editor.
+		 *
+		 * @param {type} data
+		 * @returns {void}
+		 */
+		var insertUrl = function(data) {
+			if (!isExtern) {
+				return;
+			}
+			var bbcode = '\n[url=' + data.url + ']' + data.title + '[/url]\n';
 			addeditortext(bbcode);
 		};
 


### PR DESCRIPTION
Previously when you added a link via the link dialog it wasn't possible to add media after a link had been attached.
<img width="581" height="237" alt="image" src="https://github.com/user-attachments/assets/808ce02a-37b3-4373-8996-7a0efedc238d" />

So now the system checks if there is already an attached link. And if that is the case, then the link will be added as `url` element. Also we now can embed embedded media as well.