### PR TITLE
Don't display redundant summaries

### DIFF
--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -1588,6 +1588,10 @@ class Conversation
 				$pinned = '';
 			}
 
+			if ($this->item->redundantSummary($item['body'], $item['content-warning'])) {
+				$item['content-warning'] = '';
+			}
+
 			$tmp_item = [
 				'template'             => 'search_item.tpl',
 				'id'                   => ($preview ? 'P0' : $item['id']),

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -1404,15 +1404,15 @@ class Item
 	 */
 	public function redundantSummary(string $body, string $summary): bool
 	{
-		$normalize = function ($text) {
+		$normalize = function (string $text): string {
 			$text = mb_strtolower($text);
-			$text = str_replace(["\n", "\r"], ' ', $text);
+			$text = str_replace(["\n", "\r", "\t"], ' ', $text);
 			$text = preg_replace('/\s+/', ' ', $text);
 			return trim($text);
 		};
 
 		$summary_norm = $normalize($summary);
-		if (empty($summary_norm)) {
+		if ($summary_norm === '') {
 			return false;
 		}
 

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -1394,4 +1394,41 @@ class Item
 		$this->logger->debug('Marking item as viewed.', ['uri-id' => $uri_id, 'uid' => $uid]);
 		ItemModel::performActivity($item['id'], 'view', $uid, '<' . $self['id'] . '>', '', '', '');
 	}
+
+	/**
+	 * Check if the summary is redundant to the body
+	 *
+	 * @param string $body
+	 * @param string $summary
+	 * @return boolean summary is redundant
+	 */
+	public function redundantSummary(string $body, string $summary): bool
+	{
+		$normalize = function ($text) {
+			$text = mb_strtolower($text);
+			$text = str_replace(["\n", "\r"], ' ', $text);
+			$text = preg_replace('/\s+/', ' ', $text);
+			return trim($text);
+		};
+
+		$summary_norm = $normalize($summary);
+		if (empty($summary_norm)) {
+			return false;
+		}
+
+		$body_norm = $normalize(BBCode::toPlaintext($body, false));
+
+		$len        = mb_strlen($summary_norm);
+		$body_start = mb_substr($body_norm, 0, $len);
+
+		$distance = levenshtein($body_start, $summary_norm);
+		$max_len  = max($len, mb_strlen($body_start));
+
+		if ($max_len == 0) {
+			return false;
+		}
+
+		return (1 - ($distance / $max_len)) > 0.9;
+	}
+
 }

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -1428,7 +1428,7 @@ class Item
 			return false;
 		}
 
-		return (1 - ($distance / $max_len)) > 0.9;
+		return ($distance / $max_len) <= 0.1;
 	}
 
 }

--- a/src/Factory/Api/Mastodon/Status.php
+++ b/src/Factory/Api/Mastodon/Status.php
@@ -223,6 +223,10 @@ class Status extends BaseFactory
 			new ArrayFilterEvent(ArrayFilterEvent::PREPARE_POST_FILTER_CONTENT, $hook_data),
 		)->getArray();
 
+		if ($this->contentItem->redundantSummary($item['body'], $item['content-warning'])) {
+			$item['content-warning'] = '';
+		}
+
 		$filter_reasons = $hook_data['filter_reasons'];
 		unset($hook_data);
 		if (!empty($filter_reasons)) {

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -526,6 +526,10 @@ class Post
 		$parent_username = $thread_parent[$item['thr-parent-id']]['name'] ?? '';
 		$parent_unknown  = $parent_username ? '' : DI::l10n()->t('Unknown parent');
 
+		if (DI::contentItem()->redundantSummary($item['body'], $item['content-warning'])) {
+			$item['content-warning'] = '';
+		}
+
 		$tmp_item = [
 			'parentguid'             => $parent_guid,
 			'inreplyto'              => DI::l10n()->t('in reply to %s', $parent_username),

--- a/tests/src/Content/ItemTest.php
+++ b/tests/src/Content/ItemTest.php
@@ -35,12 +35,12 @@ class ItemTestDice
 
 	public function __construct($profiler, $eventDispatcher, $config, $l10n, $baseUrl, \Closure $mockFactory)
 	{
-		$this->profiler = $profiler;
+		$this->profiler        = $profiler;
 		$this->eventDispatcher = $eventDispatcher;
-		$this->config = $config;
-		$this->l10n = $l10n;
-		$this->baseUrl = $baseUrl;
-		$this->mockFactory = $mockFactory;
+		$this->config          = $config;
+		$this->l10n            = $l10n;
+		$this->baseUrl         = $baseUrl;
+		$this->mockFactory     = $mockFactory;
 	}
 
 	public function create($class)
@@ -123,7 +123,7 @@ class ItemTest extends MockedTestCase
 				['rendertime', 'callstack', null, false],
 			]);
 
-		$l10n = $this->createMock(L10n::class);
+		$l10n    = $this->createMock(L10n::class);
 		$baseUrl = $this->createMock(BaseURL::class);
 
 		$mockFactory = \Closure::bind(function ($class) {
@@ -145,33 +145,33 @@ class ItemTest extends MockedTestCase
 		return [
 			'empty-summary' => [
 				'expected' => false,
-				'body' => 'Some content here',
-				'summary' => '',
+				'body'     => 'Some content here',
+				'summary'  => '',
 			],
 			'identical-summary' => [
 				'expected' => true,
-				'body' => 'Some content here',
-				'summary' => 'Some content here',
+				'body'     => 'Some content here',
+				'summary'  => 'Some content here',
 			],
 			'same-start-different-case' => [
 				'expected' => true,
-				'body' => 'Some content here',
-				'summary' => 'some CONTENT here',
+				'body'     => 'Some content here',
+				'summary'  => 'some CONTENT here',
 			],
 			'prefix-match' => [
 				'expected' => true,
-				'body' => 'Some content here with extra text',
-				'summary' => 'Some content here',
+				'body'     => 'Some content here with extra text',
+				'summary'  => 'Some content here',
 			],
 			'different-summary' => [
 				'expected' => false,
-				'body' => 'Some content here',
-				'summary' => 'Completely different summary',
+				'body'     => 'Some content here',
+				'summary'  => 'Completely different summary',
 			],
 			'summary-longer-than-body' => [
 				'expected' => false,
-				'body' => 'Short',
-				'summary' => 'Short but longer summary',
+				'body'     => 'Short',
+				'summary'  => 'Short but longer summary',
 			],
 		];
 	}
@@ -206,7 +206,7 @@ class ItemTest extends MockedTestCase
 			$this->createMock(Emailer::class),
 			$this->createMock(EventDispatcherInterface::class),
 			$this->createMock(PostMediaRepository::class),
-			$this->createMock(PostMediaFactory::class)
+			$this->createMock(PostMediaFactory::class),
 		);
 	}
 }

--- a/tests/src/Content/ItemTest.php
+++ b/tests/src/Content/ItemTest.php
@@ -7,15 +7,206 @@
 
 namespace Friendica\Test\src\Content;
 
+use Friendica\App\BaseURL;
+use Friendica\Content\Item;
+use Friendica\Core\L10n;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
+use Friendica\Protocol\Activity;
+use Friendica\Core\Session\Capability\IHandleUserSessions;
+use Friendica\Content\Post\Factory\PostMedia as PostMediaFactory;
+use Friendica\Content\Post\Repository\PostMedia as PostMediaRepository;
+use Friendica\Content\Text\BBCode\Video;
 use Friendica\Test\MockedTestCase;
+use Friendica\Util\ACLFormatter;
+use Friendica\Util\Emailer;
+use Friendica\Util\Profiler;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+
+class ItemTestDice
+{
+	private $profiler;
+	private $eventDispatcher;
+	private $config;
+	private $l10n;
+	private $baseUrl;
+	private $mockFactory;
+
+	public function __construct($profiler, $eventDispatcher, $config, $l10n, $baseUrl, \Closure $mockFactory)
+	{
+		$this->profiler = $profiler;
+		$this->eventDispatcher = $eventDispatcher;
+		$this->config = $config;
+		$this->l10n = $l10n;
+		$this->baseUrl = $baseUrl;
+		$this->mockFactory = $mockFactory;
+	}
+
+	public function create($class)
+	{
+		if ($class === \Friendica\Util\Profiler::class) {
+			return $this->profiler;
+		}
+
+		if ($class === \Psr\EventDispatcher\EventDispatcherInterface::class) {
+			return $this->eventDispatcher;
+		}
+
+		if ($class === \Friendica\Core\Config\Capability\IManageConfigValues::class) {
+			return $this->config;
+		}
+
+		if ($class === \Friendica\Core\L10n::class) {
+			return $this->l10n;
+		}
+
+		if ($class === \Friendica\App\BaseURL::class) {
+			return $this->baseUrl;
+		}
+
+		return ($this->mockFactory)($class);
+	}
+}
 
 class ItemTest extends MockedTestCase
 {
-	/**
-	 * @doesNotPerformAssertions
-	 */
-	public function testDetermineCategoriesTerms()
+	/** @var object|null */
+	private $originalDice;
+
+	protected function setUp(): void
 	{
-		static::markTestIncomplete('Test data needed.');
+		parent::setUp();
+		$this->originalDice = $this->getDiceProperty();
+		$this->setDiceProfilerMock();
+	}
+
+	protected function tearDown(): void
+	{
+		$this->restoreDice();
+		parent::tearDown();
+	}
+
+	private function getDiceProperty()
+	{
+		$reflection = new \ReflectionClass(\Friendica\DI::class);
+		$property   = $reflection->getProperty('dice');
+		$property->setAccessible(true);
+
+		return $property->getValue();
+	}
+
+	private function setDiceProperty($value): void
+	{
+		$reflection = new \ReflectionClass(\Friendica\DI::class);
+		$property   = $reflection->getProperty('dice');
+		$property->setAccessible(true);
+		$property->setValue(null, $value);
+	}
+
+	private function setDiceProfilerMock(): void
+	{
+		$profiler = $this->createMock(Profiler::class);
+		$profiler->expects(self::any())->method('startRecording');
+		$profiler->expects(self::any())->method('stopRecording');
+
+		$eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+		$eventDispatcher->expects(self::any())
+			->method('dispatch')
+			->willReturnArgument(0);
+
+		$config = $this->createMock(IManageConfigValues::class);
+		$config->expects(self::any())
+			->method('get')
+			->willReturnMap([
+				['system', 'profiler', null, false],
+				['rendertime', 'callstack', null, false],
+			]);
+
+		$l10n = $this->createMock(L10n::class);
+		$baseUrl = $this->createMock(BaseURL::class);
+
+		$mockFactory = \Closure::bind(function ($class) {
+			return $this->createMock($class);
+		}, $this, self::class);
+
+		$mockDice = new ItemTestDice($profiler, $eventDispatcher, $config, $l10n, $baseUrl, $mockFactory);
+
+		$this->setDiceProperty($mockDice);
+	}
+
+	private function restoreDice(): void
+	{
+		$this->setDiceProperty($this->originalDice);
+	}
+
+	public function dataRedundantSummary()
+	{
+		return [
+			'empty-summary' => [
+				'expected' => false,
+				'body' => 'Some content here',
+				'summary' => '',
+			],
+			'identical-summary' => [
+				'expected' => true,
+				'body' => 'Some content here',
+				'summary' => 'Some content here',
+			],
+			'same-start-different-case' => [
+				'expected' => true,
+				'body' => 'Some content here',
+				'summary' => 'some CONTENT here',
+			],
+			'prefix-match' => [
+				'expected' => true,
+				'body' => 'Some content here with extra text',
+				'summary' => 'Some content here',
+			],
+			'different-summary' => [
+				'expected' => false,
+				'body' => 'Some content here',
+				'summary' => 'Completely different summary',
+			],
+			'summary-longer-than-body' => [
+				'expected' => false,
+				'body' => 'Short',
+				'summary' => 'Short but longer summary',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataRedundantSummary
+	 *
+	 * @param bool $expected
+	 * @param string $body
+	 * @param string $summary
+	 */
+	public function testRedundantSummary(bool $expected, string $body, string $summary)
+	{
+		$item = $this->createItem();
+
+		self::assertSame($expected, $item->redundantSummary($body, $summary));
+	}
+
+	private function createItem(): Item
+	{
+		return new Item(
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(Profiler::class),
+			new Activity(),
+			$this->createMock(L10n::class),
+			$this->createMock(IHandleUserSessions::class),
+			new Video(),
+			new ACLFormatter(),
+			$this->createMock(IManagePersonalConfigValues::class),
+			$this->createMock(IManageConfigValues::class),
+			$this->createMock(BaseURL::class),
+			$this->createMock(Emailer::class),
+			$this->createMock(EventDispatcherInterface::class),
+			$this->createMock(PostMediaRepository::class),
+			$this->createMock(PostMediaFactory::class)
+		);
 	}
 }

--- a/tests/src/Content/ItemTest.php
+++ b/tests/src/Content/ItemTest.php
@@ -24,51 +24,6 @@ use Friendica\Util\Profiler;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 
-class ItemTestDice
-{
-	private $profiler;
-	private $eventDispatcher;
-	private $config;
-	private $l10n;
-	private $baseUrl;
-	private $mockFactory;
-
-	public function __construct($profiler, $eventDispatcher, $config, $l10n, $baseUrl, \Closure $mockFactory)
-	{
-		$this->profiler        = $profiler;
-		$this->eventDispatcher = $eventDispatcher;
-		$this->config          = $config;
-		$this->l10n            = $l10n;
-		$this->baseUrl         = $baseUrl;
-		$this->mockFactory     = $mockFactory;
-	}
-
-	public function create($class)
-	{
-		if ($class === \Friendica\Util\Profiler::class) {
-			return $this->profiler;
-		}
-
-		if ($class === \Psr\EventDispatcher\EventDispatcherInterface::class) {
-			return $this->eventDispatcher;
-		}
-
-		if ($class === \Friendica\Core\Config\Capability\IManageConfigValues::class) {
-			return $this->config;
-		}
-
-		if ($class === \Friendica\Core\L10n::class) {
-			return $this->l10n;
-		}
-
-		if ($class === \Friendica\App\BaseURL::class) {
-			return $this->baseUrl;
-		}
-
-		return ($this->mockFactory)($class);
-	}
-}
-
 class ItemTest extends MockedTestCase
 {
 	/** @var object|null */

--- a/tests/src/Content/ItemTestDice.php
+++ b/tests/src/Content/ItemTestDice.php
@@ -1,0 +1,53 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Test\src\Content;
+
+class ItemTestDice
+{
+	private $profiler;
+	private $eventDispatcher;
+	private $config;
+	private $l10n;
+	private $baseUrl;
+	private $mockFactory;
+
+	public function __construct($profiler, $eventDispatcher, $config, $l10n, $baseUrl, \Closure $mockFactory)
+	{
+		$this->profiler        = $profiler;
+		$this->eventDispatcher = $eventDispatcher;
+		$this->config          = $config;
+		$this->l10n            = $l10n;
+		$this->baseUrl         = $baseUrl;
+		$this->mockFactory     = $mockFactory;
+	}
+
+	public function create($class)
+	{
+		if ($class === \Friendica\Util\Profiler::class) {
+			return $this->profiler;
+		}
+
+		if ($class === \Psr\EventDispatcher\EventDispatcherInterface::class) {
+			return $this->eventDispatcher;
+		}
+
+		if ($class === \Friendica\Core\Config\Capability\IManageConfigValues::class) {
+			return $this->config;
+		}
+
+		if ($class === \Friendica\Core\L10n::class) {
+			return $this->l10n;
+		}
+
+		if ($class === \Friendica\App\BaseURL::class) {
+			return $this->baseUrl;
+		}
+
+		return ($this->mockFactory)($class);
+	}
+}

--- a/view/js/linkPreview.js
+++ b/view/js/linkPreview.js
@@ -128,9 +128,6 @@
 				isExtern = true;
 			}
 
-			// Don't add an attachment if we have already an attachment preview.
-			attach = !isActive;
-
 			if (trim(text) !== "" && block === false && urlRegex.test(text)) {
 				binurl = bin2hex(text);
 				block = true;
@@ -140,9 +137,9 @@
 
 				if (binurl in cache) {
 					isCrawling = false;
-					processContentData(cache[binurl], attach);
+					processContentData(cache[binurl]);
 				} else {
-					getContentData(binurl, processContentData, attach);
+					getContentData(binurl, processContentData);
 				}
 			}
 		};
@@ -154,14 +151,14 @@
 		 * @param {object} result
 		 * @returns {void}
 		 */
-		var processContentData = function(result, attach) {
+		var processContentData = function(result) {
 			if (result.contentType === 'image') {
 				insertImage(result.data);
 			} else if (result.contentType === 'audio') {
 				insertAudio(result.data);
 			} else if (result.contentType === 'video') {
 				insertVideo(result.data);
-			} else if ((result.contentType === 'attachment' || result.contentType === 'embed') && attach) {
+			} else if ((result.contentType === 'attachment' || result.contentType === 'embed') && !isActive) {
 				insertAttachment(result.data);
 			} else if (result.contentType === 'embed') {
 				insertEmbed(result.data);
@@ -201,7 +198,7 @@
 			if (!isExtern) {
 				return;
 			}
-			var bbcode = '\n[img=' + data.url + '][/img]\n';
+			var bbcode = '[img=' + data.url + '][/img]';
 			addeditortext(bbcode);
 		};
 
@@ -215,7 +212,7 @@
 			if (!isExtern) {
 				return;
 			}
-			var bbcode = '\n[audio]' + data.url + '[/audio]\n';
+			var bbcode = '[audio]' + data.url + '[/audio]';
 			addeditortext(bbcode);
 		};
 
@@ -229,7 +226,7 @@
 			if (!isExtern) {
 				return;
 			}
-			var bbcode = '\n[video]' + data.url + '[/video]\n';
+			var bbcode = '[video]' + data.url + '[/video]';
 			addeditortext(bbcode);
 		};
 
@@ -243,7 +240,7 @@
 			if (!isExtern) {
 				return;
 			}
-			var bbcode = '\n[embed]' + data.url + '[/embed]\n';
+			var bbcode = '[embed]' + data.url + '[/embed]';
 			addeditortext(bbcode);
 		};
 
@@ -257,7 +254,7 @@
 			if (!isExtern) {
 				return;
 			}
-			var bbcode = '\n[url=' + data.url + ']' + data.title + '[/url]\n';
+			var bbcode = '[url=' + data.url + ']' + data.title + '[/url]';
 			addeditortext(bbcode);
 		};
 


### PR DESCRIPTION
This PR fixes the issue of redundant summary fields. Wordpress and possibly some more long format applications in the Fediverse now write part of the content in the summary field, since Mastodon doesn't display long format posts.

On Friendica such posts look ugly, since the content is displayed twice. We now compare the content and will clear the summary in case it is redundant.

This PR contains also a small enhancement to a prior PR. The adding of BBCodes via the link dialogue now doesn't place new lines around the newly added elements. This is now aligned to the behaviour of adding 