### PR TITLE
Fix ActivityPub webfinger probing

### DIFF
--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -422,6 +422,14 @@ class APContact
 			}
 		}
 
+		if (empty($apcontact['addr']) || empty($apcontact['baseurl'])) {
+			try {
+				$apcontact = array_merge($apcontact, self::fetchWebfingerData($apcontact['nick'] . '@' . (new Uri($apcontact['url']))->getAuthority()));
+			} catch (\Throwable $e) {
+				DI::logger()->warning('Unable to coerce APContact URL into a UriInterface object', ['url' => $apcontact['url'], 'error' => $e->getMessage()]);
+			}
+		}
+
 		if (empty($apcontact['baseurl'])) {
 			$apcontact['baseurl'] = null;
 		}


### PR DESCRIPTION
This PR fixes an issue with the webfinger probing. Not all system allow webfinger request for the URL, some seem to only allow webfinger requests via the handle.