### PR TITLE
Register: Move link out of translation (translation bug)

### DIFF
--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -182,9 +182,9 @@ class Register extends BaseModule
 		/* build Select array */
 		$acct_type = [
 			'register_type', // id
-			DI::l10n()->t('Account type:'),	//label
+			DI::l10n()->t('Account type:'), //label
 			$selected,
-			DI::l10n()->t('You can change the account type later. (<a href="' . DI::baseUrl() . '/help/user/accounts-groups-pages" target="_blank">Account type help</a>)'), // tip
+			DI::l10n()->t('You can change the account type later.') . ' <a href="' . DI::baseUrl() . '/help/user/accounts-groups-pages" target="_blank">' . DI::l10n()->t('(Account type help)') . '</a>',
 			$acct_list,
 		];
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.08-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-15 13:18+0200\n"
+"POT-Creation-Date: 2026-05-16 21:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -8824,7 +8824,11 @@ msgid "Account type:"
 msgstr ""
 
 #: src/Module/Register.php:187
-msgid "You can change the account type later. (<a href=\""
+msgid "You can change the account type later."
+msgstr ""
+
+#: src/Module/Register.php:187
+msgid "(Account type help)"
 msgstr ""
 
 #: src/Module/Register.php:212


### PR DESCRIPTION
Something, maybe gettext, got confused by the `<a>` tag inside the translation, so moving it out of there.