### PR TITLE
Frio main menu: Move messages and notifications to the right

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -667,18 +667,13 @@ nav.navbar .nav > li > button:focus {
 	background-color: $nav_icon_hover_color;
 }
 /* Current section highlighting */
-#topbar-first .nav > li > a.selected i,
-#nav-notification.dropdown.open {
-  border-bottom: 3px solid $nav_icon_color;
+#topbar-first .nav > li > a.selected i {
+	border-bottom: 3px solid $nav_icon_color;
 	padding-bottom: 7px;
 }
 /* Offset the overflow caused by the current section highlighting padding above by a lowered height */
 #topbar-first .nav > li > a.selected:hover {
 	height: 50px;
-}
-#topbar-first .nav > .account {
-	height: 50px;
-	margin-left: 20px;
 }
 #topbar-first .nav > .account img {
 	height: 32px;
@@ -764,33 +759,32 @@ nav.navbar .nav > li > button:focus {
 	top: -19px;
 	z-index: 1035;
 }
-#topbar-first .topbar-nav .dropdown-menu {
-	width: 350px;
-	margin-left: -148px;
+#topbar-first .topbar-actions .dropdown-menu {
+	margin-left: -200px;
 }
-#topbar-first .topbar-nav .dropdown-menu ul.media-list {
+#topbar-first .topbar-actions .dropdown-menu ul.media-list {
 	max-height: 400px;
 	overflow: auto;
 }
-#topbar-first .topbar-nav .dropdown-menu li {
+#topbar-first .topbar-actions .dropdown-menu li {
 	position: relative;
 }
-#topbar-first .topbar-nav .dropdown-menu li i.approval {
+#topbar-first .topbar-actions .dropdown-menu li i.approval {
 	position: absolute;
 	left: 2px;
 	top: 36px;
 	font-size: 14px;
 }
-#topbar-first .topbar-nav .dropdown-menu li i.accepted {
+#topbar-first .topbar-actions .dropdown-menu li i.accepted {
 	color: #5cb85c;
 }
-#topbar-first .topbar-nav .dropdown-menu li i.declined {
+#topbar-first .topbar-actions .dropdown-menu li i.declined {
 	color: #d9534f;
 }
-#topbar-first .topbar-nav .dropdown-menu li .media {
+#topbar-first .topbar-actions .dropdown-menu li .media {
 	position: relative;
 }
-#topbar-first .topbar-nav .dropdown-menu li .media .img-space {
+#topbar-first .topbar-actions .dropdown-menu li .media .img-space {
 	position: absolute;
 	top: 14px;
 	left: 14px;
@@ -816,9 +810,10 @@ nav.navbar .nav > li > button:focus {
 }
 
 /* Notification Menu */
-#topbar-first .topbar-nav #nav-notifications-menu {
+#topbar-first .topbar-actions #nav-notifications-menu {
 	max-height: 600px;
-	width: clamp(200px, 100vw, 350px);
+	margin-left: -300px;
+	width: 350px;
 }
 #topbar-first #nav-notifications-menu a {
 	color: $font_color_darker;
@@ -4363,17 +4358,21 @@ div.login-form, .login-content-wrapper,
 		border: none;
 	}
 
-}/* Even smaller mobile displays */
-@media (width < 358px) {
-	/* Less topnav padding */
-	.navbar-left {
-		float: none!important;
-		display: flex;
-		justify-content: space-between;
+  #nav-notifications-menu {
+		margin-inline: auto!important;
+		position: fixed;
+		inset: 0;
+		top: 50px;
+		min-width: 80vw!important;
+		max-width: 95vw;
 	}
-	.topbar-nav .nav-segment a.nav-menu {
-		padding-left: 0;
-		padding-right: 7px;
+}
+
+	/* Even smaller mobile displays */
+@media (width < 358px) {
+	.topbar-nav .nav-segment a.nav-menu, .topbar-actions .nav-segment a.nav-menu, .topbar-actions .nav-segment button, .topbar-nav .navbar-toggle {
+		padding-left: 0!important;
+		padding-right: 10px!important;
 	}
 	.topbar-nav .offcanvas-right-toggle,
 	.topbar-nav #mobile-left-menu {

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -84,16 +84,6 @@
 							</li>
 						{{/if}}
 
-						{{if $nav.messages}}
-							<li class="nav-segment">
-								<a accesskey="m" id="nav-messages-link" href="{{$nav.messages.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
-									aria-label="{{$nav.messages.1}}" title="{{$nav.messages.1}}"
-									class="nav-menu {{$sel.messages}}"><i class="fa fa-envelope fa-lg fa-fw"
-										aria-hidden="true"></i><span id="mail-update"
-										class="nav-mail-badge badge nav-notification"></span></a>
-							</li>
-						{{/if}}
-
 						{{if $nav.calendar}}
 							<li class="nav-segment hidden-xs">
 								<a accesskey="e" id="nav-calendar-link" href="{{$nav.calendar.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
@@ -108,6 +98,39 @@
 									aria-label="{{$nav.contacts.1}}" title="{{$nav.contacts.1}}"
 									class="nav-menu {{$sel.contacts}} {{$nav.contacts.2}}"><i
 										class="fa fa-users fa-lg fa-fw"></i></a>
+							</li>
+						{{/if}}
+
+					</ul>
+				</div>
+
+				{{* This is the right part of the NavBar. It includes the search and the user menu *}}
+				<div class="topbar-actions pull-right">
+					<ul class="nav">
+
+						{{* The search box *}}
+						{{if $nav.search}}
+							<li id="search-box" class="hidden-xs">
+								<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
+									<div class="form-group form-group-search">
+										<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
+											type="search" name="q" placeholder="{{$search_placeholder}}">
+										<button class="btn btn-primary btn-md form-button-search" type="submit">
+											<i class="fa fa-search" aria-hidden="true"></i>
+											<span class="sr-only">{{$nav.search.1}}</span>
+										</button>
+									</div>
+								</form>
+							</li>
+						{{/if}}
+
+						{{if $nav.messages}}
+							<li class="nav-segment">
+								<a accesskey="m" id="nav-messages-link" href="{{$nav.messages.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
+									aria-label="{{$nav.messages.1}}" title="{{$nav.messages.1}}"
+									class="nav-menu {{$sel.messages}}"><i class="fa fa-envelope fa-lg fa-fw"
+										aria-hidden="true"></i><span id="mail-update"
+										class="nav-mail-badge badge nav-notification"></span></a>
 							</li>
 						{{/if}}
 
@@ -145,29 +168,6 @@
 								<p role="menuitem" class="text-muted text-center"><i>{{$emptynotifications}}</i></p>
 							</li>
 								</ul>
-							</li>
-						{{/if}}
-
-					</ul>
-				</div>
-
-				{{* This is the right part of the NavBar. It includes the search and the user menu *}}
-				<div class="topbar-actions pull-right">
-					<ul class="nav">
-
-						{{* The search box *}}
-						{{if $nav.search}}
-							<li id="search-box" class="hidden-xs">
-								<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
-									<div class="form-group form-group-search">
-										<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
-											type="search" name="q" placeholder="{{$search_placeholder}}">
-										<button class="btn btn-primary btn-md form-button-search" type="submit">
-											<i class="fa fa-search" aria-hidden="true"></i>
-											<span class="sr-only">{{$nav.search.1}}</span>
-										</button>
-									</div>
-								</form>
 							</li>
 						{{/if}}
 


### PR DESCRIPTION
- Move notifications and PMs to the right
- Improve notifications dropdown view on small viewports

# Screenshots

After:
<img width="1155" height="88" alt="image" src="https://github.com/user-attachments/assets/b3a0613c-780d-48cb-8448-f7e2f3dd5182" />

Smaller viewport:
<img width="318" height="266" alt="image" src="https://github.com/user-attachments/assets/179ac6d8-a2d6-46dd-a2c8-e1549e95ab24" />

Before:
<img width="1155" height="88" alt="image" src="https://github.com/user-attachments/assets/6b2c537d-ff7a-44fb-976a-8a44d7ff8618" />
