### PR TITLE
Fixes an error when the parameters were null

### DIFF
--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -1402,7 +1402,7 @@ class Item
 	 * @param string $summary
 	 * @return boolean summary is redundant
 	 */
-	public function redundantSummary(string $body, string $summary): bool
+	public function redundantSummary(?string $body = '', ?string $summary = ''): bool
 	{
 		$normalize = function (string $text): string {
 			$text = mb_strtolower($text);


### PR DESCRIPTION
There had been a report that the call failed because of one parameter being `null`. This fixes it.