### PR TITLE
Remove unused/duplicate translation, increase spacing between menu items in settings

### DIFF
--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -218,8 +218,6 @@ class Conversation
 					break;
 				case 'dislike':
 					$dislike_translation_plural = '<button type="button" %2$s>%1$d people</button> don\'t like this';
-					// @deprecated 2026.01 this translation is scheduled for removal as a new translation has been added without the typo
-					$dislike_translation_plural = '<button type="button" %2$s>%1$d people</button> don\'t like this';
 					$phrase                     = $this->l10n->tt('<button type="button" %2$s>%1$d person</button> doesn\'t like this', $dislike_translation_plural, $total, $spanatts);
 					break;
 				case 'attendyes':

--- a/view/global.css
+++ b/view/global.css
@@ -217,10 +217,6 @@ blockquote.shared_content {
   font-weight: bold;
 }
 
-.settings-heading a:after{
-  content: ' »';
-}
-
 #profile-photo-wrapper {
   clear: both;
   overflow: hidden;
@@ -529,6 +525,13 @@ aside .help-aside-wrapper h1 {
 /* settings page */
 #settings-form .pageflags {
     margin: 0 0 20px 30px;
+}
+
+.settings-heading a:after{
+  content: ' »';
+}
+.settings-widget {
+	line-height: 2.2;
 }
 
 /* admin pending user notes */


### PR DESCRIPTION
- Remove and unused translation text
- Increase more spacing between menu items in settings