### PR TITLE
Frio main menu breakout - and additional UI adjustments

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -199,10 +199,8 @@ class Nav
 
 		if ($this->session->isAuthenticated()) {
 			// user menu
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('Your profile page'), 'ri-user-line'];
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Conversations'), '', $this->l10n->t('Conversations you started'), 'ri-chat-3-line'];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Posts'), '', $this->l10n->t('Conversations you started'), 'ri-user-line'];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos'), 'ri-image-line'];
-			$nav['usermenu'][] = ['calendar/', $this->l10n->t('Calendar'), '', $this->l10n->t('Your calendar'), 'ri-calendar-line'];
 			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Your personal notes'), 'ri-sticky-note-line'];
 
 			// user info
@@ -258,7 +256,7 @@ class Nav
 
 		if (Feature::isEnabled($this->session->getLocalUserId(), Feature::COMMUNITY) && (($this->session->getLocalUserId() || $this->config->get('system', 'community_page_style') != Community::DISABLED_VISITOR)
 			&& !($this->config->get('system', 'community_page_style') == Community::DISABLED))) {
-			$nav['community'] = ['community', $this->l10n->t('Community'), '', $this->l10n->t('Conversations on this and other servers')];
+			$nav['community'] = ['community', $this->l10n->t('Community'), '', $this->l10n->t('Community')];
 		}
 
 		if ($this->session->getLocalUserId()) {
@@ -275,9 +273,9 @@ class Nav
 
 		// The following nav links are only show to logged-in users
 		if ($this->session->getLocalUserNickname()) {
-			$nav['network'] = ['network', $this->l10n->t('Network'), '', $this->l10n->t('Conversations from your friends')];
+			$nav['network'] = ['network', $this->l10n->t('Home'), '', $this->l10n->t('Home')];
 
-			$nav['home'] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Home'), '', $this->l10n->t('Your posts and conversations')];
+			$nav['home'] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('My profile'), '', $this->l10n->t('My posts')];
 
 			// Don't show notifications for public communities
 			if ($this->session->get('page_flags', '') != User::PAGE_FLAGS_COMMUNITY) {

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -446,7 +446,7 @@ class Display extends BaseSettings
 			'$display_resharer'         => ['display_resharer', $this->t('Display the resharer'), $display_resharer, $this->t('Display the first resharer as icon and text on a reshared item.')],
 			'$stay_local'               => ['stay_local', $this->t('Stay local'), $stay_local, $this->t("Don't go to a remote system when following a contact link.")],
 			'$show_page_drop'           => ['show_page_drop', $this->t('Show the post deletion checkbox'), $show_page_drop, $this->t("Display the checkbox for the post deletion on the network page.")],
-			'$display_eventlist'        => ['display_eventlist', $this->t('DIsplay the event list'), $display_eventlist, $this->t("Display the birthday reminder and event list on the network page.")],
+			'$display_eventlist'        => ['display_eventlist', $this->t('Display the event list'), $display_eventlist, $this->t("Display the birthday reminder and event list on the network page.")],
 			'$preview_mode'             => ['preview_mode', $this->t('Link preview mode'), $preview_mode, $this->t('Appearance of the link preview that is added to each post with a link.'), $preview_modes, false],
 			'$hide_empty_descriptions'  => ['hide_empty_descriptions', $this->t('Hide pictures with empty alternative text'), $hide_empty_descriptions, $this->t("Don't display pictures that are missing the alternative text.")],
 			'$hide_custom_emojis'       => ['hide_custom_emojis', $this->t('Hide custom emojis'), $hide_custom_emojis, $this->t("Don't display custom emojis.")],

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.08-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-23 17:56+0000\n"
+"POT-Creation-Date: 2026-05-27 14:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -66,8 +66,8 @@ msgstr ""
 #: src/Module/Search/Directory.php:23 src/Module/Settings/Account.php:34
 #: src/Module/Settings/Account.php:337 src/Module/Settings/Channels.php:40
 #: src/Module/Settings/Channels.php:121
-#: src/Module/Settings/ContactImport.php:44
-#: src/Module/Settings/ContactImport.php:85
+#: src/Module/Settings/ContactImport.php:45
+#: src/Module/Settings/ContactImport.php:110
 #: src/Module/Settings/Delegation.php:68 src/Module/Settings/Display.php:71
 #: src/Module/Settings/Display.php:205
 #: src/Module/Settings/Profile/Photo/Crop.php:148
@@ -80,12 +80,12 @@ msgstr ""
 msgid "Permission denied."
 msgstr ""
 
-#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:290
+#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:288
 #: view/theme/frio/theme.php:230
 msgid "Messages"
 msgstr ""
 
-#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:293
+#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:291
 msgid "New Message"
 msgstr ""
 
@@ -274,7 +274,7 @@ msgstr ""
 
 #: mod/photos.php:332 src/Module/Conversation/Community.php:146
 #: src/Module/Directory.php:34 src/Module/Profile/Photos.php:253
-#: src/Module/Search/Index.php:50
+#: src/Module/Search/Index.php:56
 msgid "Public access denied."
 msgstr ""
 
@@ -1555,7 +1555,7 @@ msgid "Display posts that have been created by accounts of the selected circle."
 msgstr ""
 
 #: src/Content/Feature.php:128 src/Content/GroupManager.php:132
-#: src/Content/Nav.php:250 src/Content/Text/HTML.php:884
+#: src/Content/Nav.php:248 src/Content/Text/HTML.php:884
 #: src/Content/Widget.php:564 src/Model/User.php:1433
 msgid "Groups"
 msgstr ""
@@ -1770,7 +1770,7 @@ msgstr ""
 msgid "Unable to fetch user."
 msgstr ""
 
-#: src/Content/Item.php:1376 src/Core/L10n.php:467
+#: src/Content/Item.php:1376 src/Core/L10n.php:539
 msgid "Undetermined"
 msgstr ""
 
@@ -1795,7 +1795,7 @@ msgstr ""
 msgid "Nothing new here"
 msgstr ""
 
-#: src/Content/Nav.php:94 src/Content/Nav.php:223 src/Content/Nav.php:280
+#: src/Content/Nav.php:94 src/Content/Nav.php:221 src/Content/Nav.php:276
 #: src/Module/Help.php:68
 msgid "Home"
 msgstr ""
@@ -1826,72 +1826,48 @@ msgstr ""
 msgid "Sign in"
 msgstr ""
 
-#: src/Content/Nav.php:202 src/Module/BaseProfile.php:34
-#: src/Module/BaseSettings.php:86 src/Module/Contact.php:480
-#: src/Module/Contact/Profile.php:439 src/Module/Profile/Profile.php:276
-#: src/Module/Welcome.php:44 view/theme/frio/theme.php:219
-msgid "Profile"
+#: src/Content/Nav.php:202
+msgid "Posts"
 msgstr ""
 
-#: src/Content/Nav.php:202 view/theme/frio/theme.php:219
-msgid "Your profile page"
-msgstr ""
-
-#: src/Content/Nav.php:203 src/Module/BaseProfile.php:42
-#: src/Module/Contact.php:488
-msgid "Conversations"
-msgstr ""
-
-#: src/Content/Nav.php:203
+#: src/Content/Nav.php:202
 msgid "Conversations you started"
 msgstr ""
 
-#: src/Content/Nav.php:204 src/Module/BaseProfile.php:50
+#: src/Content/Nav.php:203 src/Module/BaseProfile.php:50
 #: src/Module/Media/Attachment/Browser.php:67
 #: src/Module/Media/Photo/Browser.php:62 src/Module/Media/Photo/Browser.php:79
 #: view/theme/frio/theme.php:223
 msgid "Photos"
 msgstr ""
 
-#: src/Content/Nav.php:204 view/theme/frio/theme.php:223
+#: src/Content/Nav.php:203 view/theme/frio/theme.php:223
 msgid "Your photos"
 msgstr ""
 
-#: src/Content/Nav.php:205 src/Content/Nav.php:265
-#: src/Module/BaseProfile.php:70 src/Module/BaseProfile.php:73
-#: src/Module/BaseProfile.php:81 src/Module/BaseProfile.php:84
-#: src/Module/Calendar/Show.php:113 src/Module/Settings/Display.php:421
-#: view/theme/frio/theme.php:225 view/theme/frio/theme.php:229
-msgid "Calendar"
-msgstr ""
-
-#: src/Content/Nav.php:205 view/theme/frio/theme.php:225
-msgid "Your calendar"
-msgstr ""
-
-#: src/Content/Nav.php:206 src/Module/BaseProfile.php:93
+#: src/Content/Nav.php:204 src/Module/BaseProfile.php:93
 #: src/Module/Profile/Notes.php:82
 msgid "Personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:206
+#: src/Content/Nav.php:204
 msgid "Your personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:223 src/Module/Settings/OAuth.php:57
+#: src/Content/Nav.php:221 src/Module/Settings/OAuth.php:57
 msgid "Home Page"
 msgstr ""
 
-#: src/Content/Nav.php:227 src/Module/Security/Login.php:115
+#: src/Content/Nav.php:225 src/Module/Security/Login.php:115
 msgid "Register"
 msgstr ""
 
-#: src/Content/Nav.php:227 src/Module/Register.php:208
+#: src/Content/Nav.php:225 src/Module/Register.php:208
 #: src/Module/Security/Login.php:114
 msgid "Create an account"
 msgstr ""
 
-#: src/Content/Nav.php:233 src/Module/Help.php:54
+#: src/Content/Nav.php:231 src/Module/Help.php:54
 #: src/Module/Settings/TwoFactor/AppSpecific.php:118
 #: src/Module/Settings/TwoFactor/Index.php:125
 #: src/Module/Settings/TwoFactor/Recovery.php:96
@@ -1899,39 +1875,39 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: src/Content/Nav.php:233
+#: src/Content/Nav.php:231
 msgid "Help and documentation"
 msgstr ""
 
-#: src/Content/Nav.php:237
+#: src/Content/Nav.php:235
 msgid "Apps"
 msgstr ""
 
-#: src/Content/Nav.php:237
+#: src/Content/Nav.php:235
 msgid "Addon applications, utilities, games"
 msgstr ""
 
-#: src/Content/Nav.php:241 src/Content/Text/HTML.php:869
+#: src/Content/Nav.php:239 src/Content/Text/HTML.php:869
 #: src/Module/Moderation/Blocklist/Contact.php:112
 #: src/Module/Moderation/Blocklist/Server/Index.php:103
 #: src/Module/Search/Index.php:99
 msgid "Search"
 msgstr ""
 
-#: src/Content/Nav.php:241
+#: src/Content/Nav.php:239
 msgid "Search site content"
 msgstr ""
 
-#: src/Content/Nav.php:244 src/Content/Text/HTML.php:878
+#: src/Content/Nav.php:242 src/Content/Text/HTML.php:878
 msgid "Full Text"
 msgstr ""
 
-#: src/Content/Nav.php:245 src/Content/Text/HTML.php:879
+#: src/Content/Nav.php:243 src/Content/Text/HTML.php:879
 #: src/Content/Widget/TagCloud.php:54
 msgid "Tags"
 msgstr ""
 
-#: src/Content/Nav.php:246 src/Content/Nav.php:305
+#: src/Content/Nav.php:244 src/Content/Nav.php:303
 #: src/Content/Text/HTML.php:880 src/Module/BaseProfile.php:112
 #: src/Module/BaseProfile.php:115 src/Module/Contact.php:181
 #: src/Module/Contact.php:402 src/Module/Contact.php:512
@@ -1939,123 +1915,123 @@ msgstr ""
 msgid "Contacts"
 msgstr ""
 
-#: src/Content/Nav.php:261
+#: src/Content/Nav.php:259
 msgid "Community"
 msgstr ""
 
-#: src/Content/Nav.php:261
-msgid "Conversations on this and other servers"
+#: src/Content/Nav.php:263 src/Module/BaseProfile.php:70
+#: src/Module/BaseProfile.php:73 src/Module/BaseProfile.php:81
+#: src/Module/BaseProfile.php:84 src/Module/Calendar/Show.php:113
+#: src/Module/Settings/Display.php:421 view/theme/frio/theme.php:225
+#: view/theme/frio/theme.php:229
+msgid "Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:268
+#: src/Content/Nav.php:266
 msgid "Directory"
 msgstr ""
 
-#: src/Content/Nav.php:268
+#: src/Content/Nav.php:266
 msgid "People directory"
 msgstr ""
 
-#: src/Content/Nav.php:270 src/Module/BaseAdmin.php:70
+#: src/Content/Nav.php:268 src/Module/BaseAdmin.php:70
 #: src/Module/BaseModeration.php:97
 msgid "Information"
 msgstr ""
 
-#: src/Content/Nav.php:270
+#: src/Content/Nav.php:268
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:273 src/Module/Admin/Tos.php:64
+#: src/Content/Nav.php:271 src/Module/Admin/Tos.php:64
 #: src/Module/BaseAdmin.php:80 src/Module/Register.php:232
 #: src/Module/Tos.php:87
 msgid "Terms of Service"
 msgstr ""
 
-#: src/Content/Nav.php:273
+#: src/Content/Nav.php:271
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:278 view/theme/frio/theme.php:228
-msgid "Network"
+#: src/Content/Nav.php:278
+msgid "My profile"
 msgstr ""
 
-#: src/Content/Nav.php:278 view/theme/frio/theme.php:228
-msgid "Conversations from your friends"
+#: src/Content/Nav.php:278
+msgid "My posts"
 msgstr ""
 
-#: src/Content/Nav.php:280 view/theme/frio/theme.php:218
-msgid "Your posts and conversations"
-msgstr ""
-
-#: src/Content/Nav.php:284
+#: src/Content/Nav.php:282
 msgid "Introductions"
 msgstr ""
 
-#: src/Content/Nav.php:284
+#: src/Content/Nav.php:282
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:285 src/Module/BaseNotifications.php:134
+#: src/Content/Nav.php:283 src/Module/BaseNotifications.php:134
 #: src/Module/Notifications/Introductions.php:63
 #: src/Module/Settings/Account.php:554
 msgid "Notifications"
 msgstr ""
 
-#: src/Content/Nav.php:286
+#: src/Content/Nav.php:284
 msgid "View all"
 msgstr ""
 
-#: src/Content/Nav.php:287 src/Module/Settings/Connectors.php:215
+#: src/Content/Nav.php:285 src/Module/Settings/Connectors.php:215
 msgid "Mark as read"
 msgstr ""
 
-#: src/Content/Nav.php:287
+#: src/Content/Nav.php:285
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:290 view/theme/frio/theme.php:230
+#: src/Content/Nav.php:288 view/theme/frio/theme.php:230
 msgid "Private mail"
 msgstr ""
 
-#: src/Content/Nav.php:291
+#: src/Content/Nav.php:289
 msgid "Inbox"
 msgstr ""
 
-#: src/Content/Nav.php:292
+#: src/Content/Nav.php:290
 msgid "Outbox"
 msgstr ""
 
-#: src/Content/Nav.php:295
+#: src/Content/Nav.php:293
 msgid "Accounts"
 msgstr ""
 
-#: src/Content/Nav.php:296
+#: src/Content/Nav.php:294
 msgid "Manage other accounts, including groups and pages"
 msgstr ""
 
-#: src/Content/Nav.php:303 src/Module/Admin/Addons/Details.php:140
+#: src/Content/Nav.php:301 src/Module/Admin/Addons/Details.php:140
 #: src/Module/Admin/Themes/Details.php:85 src/Module/BaseAdmin.php:88
 #: src/Module/BaseSettings.php:177 src/Module/Welcome.php:39
 #: view/theme/frio/theme.php:231
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:303 view/theme/frio/theme.php:231
+#: src/Content/Nav.php:301 view/theme/frio/theme.php:231
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:305 view/theme/frio/theme.php:232
+#: src/Content/Nav.php:303 view/theme/frio/theme.php:232
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:310 src/Module/BaseAdmin.php:114
+#: src/Content/Nav.php:308 src/Module/BaseAdmin.php:114
 msgid "Admin"
 msgstr ""
 
-#: src/Content/Nav.php:310
+#: src/Content/Nav.php:308
 msgid "Site setup and configuration"
 msgstr ""
 
-#: src/Content/Nav.php:311 src/Module/BaseModeration.php:117
+#: src/Content/Nav.php:309 src/Module/BaseModeration.php:117
 #: src/Module/Moderation/Blocklist/Contact.php:99
 #: src/Module/Moderation/Blocklist/Contact/Import.php:101
 #: src/Module/Moderation/Blocklist/Server/Add.php:105
@@ -2072,15 +2048,15 @@ msgstr ""
 msgid "Moderation"
 msgstr ""
 
-#: src/Content/Nav.php:311
+#: src/Content/Nav.php:309
 msgid "Content and user moderation"
 msgstr ""
 
-#: src/Content/Nav.php:314
+#: src/Content/Nav.php:312
 msgid "Navigation"
 msgstr ""
 
-#: src/Content/Nav.php:314
+#: src/Content/Nav.php:312
 msgid "Site map"
 msgstr ""
 
@@ -2710,7 +2686,7 @@ msgstr ""
 msgid "Could not connect to database."
 msgstr ""
 
-#: src/Core/L10n.php:477
+#: src/Core/L10n.php:549
 #, php-format
 msgid "%s (%s)"
 msgstr ""
@@ -3745,7 +3721,7 @@ msgstr ""
 #: src/Module/Admin/Themes/Index.php:105 src/Module/Admin/Tos.php:72
 #: src/Module/Settings/Addons.php:59 src/Module/Settings/Connectors.php:131
 #: src/Module/Settings/Connectors.php:217
-#: src/Module/Settings/ContactImport.php:93
+#: src/Module/Settings/ContactImport.php:118
 #: src/Module/Settings/Delegation.php:171 src/Module/Settings/Display.php:413
 #: src/Module/Settings/Features.php:85
 #: src/Module/Settings/Profile/Index.php:264
@@ -5579,8 +5555,19 @@ msgstr ""
 msgid "Item Source"
 msgstr ""
 
+#: src/Module/BaseProfile.php:34 src/Module/BaseSettings.php:86
+#: src/Module/Contact.php:480 src/Module/Contact/Profile.php:439
+#: src/Module/Profile/Profile.php:276 src/Module/Welcome.php:44
+#: view/theme/frio/theme.php:219
+msgid "Profile"
+msgstr ""
+
 #: src/Module/BaseProfile.php:37 src/Module/Contact.php:483
 msgid "Profile Details"
+msgstr ""
+
+#: src/Module/BaseProfile.php:42 src/Module/Contact.php:488
+msgid "Conversations"
 msgstr ""
 
 #: src/Module/BaseProfile.php:45
@@ -5670,7 +5657,7 @@ msgstr ""
 
 #: src/Module/BaseSettings.php:155
 #: src/Module/Moderation/Blocklist/Contact/Import.php:108
-#: src/Module/Settings/ContactImport.php:92
+#: src/Module/Settings/ContactImport.php:117
 msgid "Import Contacts"
 msgstr ""
 
@@ -5899,7 +5886,7 @@ msgstr ""
 msgid "Save Circle"
 msgstr ""
 
-#: src/Module/Circle.php:160 src/Module/Moderation/Blocklist/Contact.php:113
+#: src/Module/Circle.php:166 src/Module/Moderation/Blocklist/Contact.php:113
 #: src/Module/Moderation/Blocklist/Server/Index.php:104
 msgid "Filter"
 msgstr ""
@@ -8598,12 +8585,12 @@ msgstr ""
 msgid "%d more"
 msgstr ""
 
-#: src/Module/Profile/CircleExport.php:45 src/Module/Profile/Profile.php:98
+#: src/Module/Profile/CircleExport.php:49 src/Module/Profile/Profile.php:98
 #: src/Module/Profile/Profile.php:133 src/Module/Profile/Restricted.php:33
 msgid "Profile not found."
 msgstr ""
 
-#: src/Module/Profile/CircleExport.php:54
+#: src/Module/Profile/CircleExport.php:58
 msgid "Public circle not found."
 msgstr ""
 
@@ -9003,11 +8990,11 @@ msgstr ""
 msgid "You must be logged in to use this module."
 msgstr ""
 
-#: src/Module/Search/Index.php:54
+#: src/Module/Search/Index.php:60
 msgid "Only logged in users are permitted to perform a search."
 msgstr ""
 
-#: src/Module/Search/Index.php:76
+#: src/Module/Search/Index.php:82
 msgid "Only one search per minute is permitted for not logged in users."
 msgstr ""
 
@@ -9967,28 +9954,28 @@ msgstr ""
 msgid "Move to folder:"
 msgstr ""
 
-#: src/Module/Settings/ContactImport.php:54
-#: src/Module/Settings/ContactImport.php:73
+#: src/Module/Settings/ContactImport.php:55
+#: src/Module/Settings/ContactImport.php:98
 msgid "Importing Contacts done"
 msgstr ""
 
-#: src/Module/Settings/ContactImport.php:62
+#: src/Module/Settings/ContactImport.php:63
 msgid "Contact CSV file upload error"
 msgstr ""
 
-#: src/Module/Settings/ContactImport.php:95
+#: src/Module/Settings/ContactImport.php:120
 msgid "Upload a CSV file that contains the handle of your followed accounts in the first column you exported from the old account. Your contacts will be added in the background. This can take some time."
 msgstr ""
 
-#: src/Module/Settings/ContactImport.php:96
+#: src/Module/Settings/ContactImport.php:121
 msgid "Upload File"
 msgstr ""
 
-#: src/Module/Settings/ContactImport.php:98
+#: src/Module/Settings/ContactImport.php:123
 msgid "Your legacy ActivityPub/GNU Social account"
 msgstr ""
 
-#: src/Module/Settings/ContactImport.php:98
+#: src/Module/Settings/ContactImport.php:123
 msgid "If you enter your old account name from an ActivityPub based system or your GNU Social/Statusnet account name here (in the format user@domain.tld), your contacts will be added in the background. This can take some time."
 msgstr ""
 
@@ -10222,7 +10209,7 @@ msgid "Display the checkbox for the post deletion on the network page."
 msgstr ""
 
 #: src/Module/Settings/Display.php:449
-msgid "DIsplay the event list"
+msgid "Display the event list"
 msgstr ""
 
 #: src/Module/Settings/Display.php:449
@@ -12218,8 +12205,28 @@ msgstr ""
 msgid "Visitor"
 msgstr ""
 
+#: view/theme/frio/theme.php:218
+msgid "Your posts and conversations"
+msgstr ""
+
+#: view/theme/frio/theme.php:219
+msgid "Your profile page"
+msgstr ""
+
 #: view/theme/frio/theme.php:224
 msgid "Your postings with media"
+msgstr ""
+
+#: view/theme/frio/theme.php:225
+msgid "Your calendar"
+msgstr ""
+
+#: view/theme/frio/theme.php:228
+msgid "Network"
+msgstr ""
+
+#: view/theme/frio/theme.php:228
+msgid "Conversations from your friends"
 msgstr ""
 
 #: view/theme/vier/config.php:79

--- a/view/templates/circle_side.tpl
+++ b/view/templates/circle_side.tpl
@@ -8,7 +8,7 @@
 	<span id="circle-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="ri ri-group-3-line" aria-hidden="true"></i>
+				<i class="ri ri-bubble-chart-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -16,7 +16,7 @@
 	<div class="widget" id="circle-sidebar">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="ri ri-group-3-line" aria-hidden="true"></i>
+				<i class="ri ri-bubble-chart-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>

--- a/view/templates/hovercard.tpl
+++ b/view/templates/hovercard.tpl
@@ -43,7 +43,7 @@
 
 				</div>
 				<div class="hover-card-actions-connection">
-					{{if $profile.actions.network}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.network.1}}" aria-label="{{$profile.actions.network.0}}" title="{{$profile.actions.network.0}}"><i class="ri ri-{{($profile.contact_type==3) ? 'group-line' : 'cloud-line'}}" aria-hidden="true"></i></a>{{/if}}
+					{{if $profile.actions.network}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.network.1}}" aria-label="{{$profile.actions.network.0}}" title="{{$profile.actions.network.0}}"><i class="ri ri-{{($profile.contact_type==3) ? 'discuss-line' : 'cloud-line'}}" aria-hidden="true"></i></a>{{/if}}
 					{{if $profile.actions.edit}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.edit.1}}" aria-label="{{$profile.actions.edit.0}}" title="{{$profile.actions.edit.0}}"><i class="ri ri-user-line" aria-hidden="true"></i></a>{{/if}}
 					{{if $profile.actions.follow}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.follow.1}}" aria-label="{{$profile.actions.follow.0}}" title="{{$profile.actions.follow.0}}"><i class="ri ri-user-add-line" aria-hidden="true"></i></a>{{/if}}
 					{{if $profile.actions.unfollow}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.unfollow.1}}" aria-label="{{$profile.actions.unfollow.0}}" title="{{$profile.actions.unfollow.0}}"><i class="ri ri-user-unfollow-line" aria-hidden="true"></i></a>{{/if}}

--- a/view/templates/widget/filter.tpl
+++ b/view/templates/widget/filter.tpl
@@ -12,7 +12,7 @@
 	{{else if $type == "rel"}}
 		{{assign var="icon" value="ri-arrow-left-right-line"}}
 	{{else if $type == "circle"}}
-		{{assign var="icon" value="ri-user-community-line"}}
+		{{assign var="icon" value="ri-bubble-chart-line"}}
 	{{else if $type == "nets"}}
 		{{assign var="icon" value="ri-message-2-line"}}
 	{{else}} {{* fallback to type="file" *}}

--- a/view/templates/widget/group_list.tpl
+++ b/view/templates/widget/group_list.tpl
@@ -21,7 +21,7 @@
 		<button class="fakelink" onclick="openCloseWidget('group-list-sidebar', 'group-list-sidebar-inflated');"
 			aria-expanded="false">
 			<h3>
-				<i class="ri ri-chat-thread-line" aria-hidden="true"></i>
+				<i class="ri ri-discuss-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -30,7 +30,7 @@
 		<div id="sidebar-group-header" class="sidebar-widget-header">
 			<button class="fakelink" onclick="openCloseWidget('group-list-sidebar', 'group-list-sidebar-inflated');" aria-expanded="true">
 				<h3>
-					<i class="ri ri-chat-thread-line" aria-hidden="true"></i>
+					<i class="ri ri-discuss-line" aria-hidden="true"></i>
 					{{$title}}
 				</h3>
 			</button>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -184,6 +184,13 @@ details summary {
 		padding-left: 0;
 		padding-right: 0;
 	}
+	#topbar-first > .container-fluid {
+		padding-inline: 0;
+	}
+
+	ul#nav-user-menu {
+		margin-right: 10px;
+	}
 }
 /*
 * standard page elements
@@ -534,35 +541,22 @@ header #banner #logo-img,
 /* offcanvas section ends */
 
 /* NavBar */
+.topbar, #topbar-first-nav-container {
+	height: 50px;
+}
 .topbar {
 	position: fixed;
 	display: block;
-	height: 50px;
 	width: 100%;
-	padding-left: 15px;
-	padding-right: 15px;
-}
-.topbar ul.nav {
-	float: left;
-}
-.topbar ul.nav > li {
-	float: left;
 }
 
-@media (min-width: 992px) {
-	.topbar ul.nav > li > a,
-	.topbar ul.nav > li > button {
-		padding-top: 15px;
-		padding-bottom: 15px;
-		line-height: 20px;
-	}
+.topbar ul.nav > li > a,
+.topbar ul.nav > li > button {
+	padding-top: 15px;
+	padding-bottom: 15px;
+	line-height: 20px;
 }
-@media (max-width: 991px) {
-	.topbar ul.nav > li > a,
-	.topbar ul.nav > li > button {
-		padding: 15px 10px;
-	}
-}
+
 .topbar .dropdown-footer {
 	margin: 10px;
 }
@@ -619,12 +613,6 @@ nav.navbar {
 	z-index: 1030;
 	color: $nav_icon_color;
 }
-@media screen and (max-width: 795px) {
-	#topbar-first,
-	nav.navbar {
-		padding: 0 2px;
-	}
-}
 
 button#main-menu {
 	align-items: center;
@@ -634,11 +622,10 @@ button#main-menu {
 #topbar-first-nav-container {
 		display: flex;
 		justify-content: space-between;
+		align-items: center;
 }
 #topbar-first .navbar-toggle {
-	margin-top: 5px;
-	margin-bottom: 0;
-	margin-right: 0;
+	margin: 0;
 }
 #topbar-first .nav > li > a,
 #topbar-first .nav > li > button,
@@ -662,12 +649,9 @@ nav.navbar .nav > li > button:focus {
 }
 /* Current section highlighting */
 #topbar-first .nav > li > a.selected i {
-	border-bottom: 3px solid $nav_icon_color;
-	padding-bottom: 7px;
-}
-/* Offset the overflow caused by the current section highlighting padding above by a lowered height */
-#topbar-first .nav > li > a.selected:hover {
-	height: 50px;
+	text-decoration: underline;
+	text-underline-offset: 8px;
+	text-decoration-thickness: 3px;
 }
 #topbar-first .nav > .account img {
 	height: 32px;
@@ -682,20 +666,6 @@ nav.navbar .nav > li > button:focus {
 #topbar-first .nav > .account .dropdown-toggle span {
 	font-size: 12px;
 }
-#topbar-first .topbar-brand {
-	position: relative;
-	z-index: 2;
-}
-#topbar-first .topbar-actions {
-	position: relative;
-	z-index: 3;
-}
-#topbar-first .topbar-nav {
-	left: 0;
-	right: 0;
-	text-align: center;
-	z-index: 1;
-}
 /* Workaround for Safari bug where the notification icon jumps on the next line */
 #topbar-first .topbar-nav .nav > li + li {
 	margin-left: 1px;
@@ -704,10 +674,6 @@ nav.navbar .nav > li > button:focus {
 	margin-left: -1px;
 }
 /* End workaround */
-#topbar-first .topbar-nav .nav-segment {
-	position: relative;
-	text-align: left;
-}
 #topbar-first .topbar-nav .nav-segment > a {
 	display: inline-block;
 	text-decoration: none;
@@ -753,6 +719,14 @@ nav.navbar .nav > li > button:focus {
 	top: -19px;
 	z-index: 1035;
 }
+.topbar-nav, .topbar-actions, #topbar-first ul.nav {
+		align-items: center;
+		display: flex;
+		height: 100%;
+	}
+#topbar-first > ul.nav li, #topbar-first > ul.nav li a, .topbar-actions > ul.nav > li {
+		height: inherit;
+	}
 #topbar-first .topbar-actions .dropdown-menu {
 	margin-left: -200px;
 }
@@ -962,6 +936,7 @@ nav.navbar .nav > li > button:focus {
 	-moz-box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
 	box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
 	border-bottom: 1px solid #d4d4d4;
+	padding-inline: 15px;
 }
 #topbar-second > .container {
 	height: 100%;
@@ -4385,15 +4360,12 @@ div.login-form, .login-content-wrapper,
 
 	/* Even smaller mobile displays */
 @media (width < 392px) {
-	#topbar-first .container-fluid {
-		padding-inline: 0;
-	}
 	.topbar-nav .nav-segment a.nav-menu, .topbar-actions .nav-segment a.nav-menu, .topbar-actions .nav-segment button, .topbar-actions .navbar-toggle {
 		padding-left: 0!important;
 		padding-right: 10px!important;
 	}
-	.topbar-nav .offcanvas-right-toggle,
-	.topbar-nav #mobile-left-menu {
+	#topbar-first .offcanvas-right-toggle,
+	#topbar-first #mobile-left-menu {
 		padding-inline-end: 3px;
 		padding-inline-start: 3px;
 	}

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -434,18 +434,8 @@ header #site-location {
 	display: none;
 }
 header #banner {
-	position: fixed;
-	top: 0px;
-	z-index: 1040;
-	margin-top: 12.5px;
-	text-align: center;
-	text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
-	font-size: 14px;
-	font-family: tahoma, "Lucida Sans", sans;
-	color: #fff;
-	font-weight: bold;
-	white-space: nowrap;
-	padding-left: 20px;
+	padding-top: 12.5px;
+	width: min-content;
 }
 header #banner #logo-img,
 .navbar-brand #logo-img {
@@ -629,7 +619,7 @@ nav.navbar {
 	z-index: 1030;
 	color: $nav_icon_color;
 }
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 795px) {
 	#topbar-first,
 	nav.navbar {
 		padding: 0 2px;
@@ -640,6 +630,10 @@ button#main-menu {
 	align-items: center;
 	display: flex;
 	gap: 5px;
+}
+#topbar-first-nav-container {
+		display: flex;
+		justify-content: space-between;
 }
 #topbar-first .navbar-toggle {
 	margin-top: 5px;
@@ -2589,7 +2583,6 @@ input[type="range"].form-control {
 }
 .form-group-search {
 	position: relative;
-	width: 100%;
 }
 
 #search-box .ri-search-line {
@@ -4391,14 +4384,17 @@ div.login-form, .login-content-wrapper,
 }
 
 	/* Even smaller mobile displays */
-@media (width < 358px) {
-	.topbar-nav .nav-segment a.nav-menu, .topbar-actions .nav-segment a.nav-menu, .topbar-actions .nav-segment button, .topbar-nav .navbar-toggle {
+@media (width < 392px) {
+	#topbar-first .container-fluid {
+		padding-inline: 0;
+	}
+	.topbar-nav .nav-segment a.nav-menu, .topbar-actions .nav-segment a.nav-menu, .topbar-actions .nav-segment button, .topbar-actions .navbar-toggle {
 		padding-left: 0!important;
 		padding-right: 10px!important;
 	}
 	.topbar-nav .offcanvas-right-toggle,
 	.topbar-nav #mobile-left-menu {
-		padding-right: 3px;
-		padding-left: 3px;
+		padding-inline-end: 3px;
+		padding-inline-start: 3px;
 	}
 }

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -667,18 +667,13 @@ nav.navbar .nav > li > button:focus {
 	background-color: $nav_icon_hover_color;
 }
 /* Current section highlighting */
-#topbar-first .nav > li > a.selected i,
-#nav-notification.dropdown.open {
-  border-bottom: 3px solid $nav_icon_color;
+#topbar-first .nav > li > a.selected i {
+	border-bottom: 3px solid $nav_icon_color;
 	padding-bottom: 7px;
 }
 /* Offset the overflow caused by the current section highlighting padding above by a lowered height */
 #topbar-first .nav > li > a.selected:hover {
 	height: 50px;
-}
-#topbar-first .nav > .account {
-	height: 50px;
-	margin-left: 20px;
 }
 #topbar-first .nav > .account img {
 	height: 32px;
@@ -764,33 +759,32 @@ nav.navbar .nav > li > button:focus {
 	top: -19px;
 	z-index: 1035;
 }
-#topbar-first .topbar-nav .dropdown-menu {
-	width: 350px;
-	margin-left: -148px;
+#topbar-first .topbar-actions .dropdown-menu {
+	margin-left: -200px;
 }
-#topbar-first .topbar-nav .dropdown-menu ul.media-list {
+#topbar-first .topbar-actions .dropdown-menu ul.media-list {
 	max-height: 400px;
 	overflow: auto;
 }
-#topbar-first .topbar-nav .dropdown-menu li {
+#topbar-first .topbar-actions .dropdown-menu li {
 	position: relative;
 }
-#topbar-first .topbar-nav .dropdown-menu li i.approval {
+#topbar-first .topbar-actions .dropdown-menu li i.approval {
 	position: absolute;
 	left: 2px;
 	top: 36px;
 	font-size: 14px;
 }
-#topbar-first .topbar-nav .dropdown-menu li i.accepted {
+#topbar-first .topbar-actions .dropdown-menu li i.accepted {
 	color: #5cb85c;
 }
-#topbar-first .topbar-nav .dropdown-menu li i.declined {
+#topbar-first .topbar-actions .dropdown-menu li i.declined {
 	color: #d9534f;
 }
-#topbar-first .topbar-nav .dropdown-menu li .media {
+#topbar-first .topbar-actions .dropdown-menu li .media {
 	position: relative;
 }
-#topbar-first .topbar-nav .dropdown-menu li .media .img-space {
+#topbar-first .topbar-actions .dropdown-menu li .media .img-space {
 	position: absolute;
 	top: 14px;
 	left: 14px;
@@ -816,9 +810,10 @@ nav.navbar .nav > li > button:focus {
 }
 
 /* Notification Menu */
-#topbar-first .topbar-nav #nav-notifications-menu {
+#topbar-first .topbar-actions #nav-notifications-menu {
 	max-height: 600px;
-	width: clamp(200px, 100vw, 350px);
+	margin-left: -300px;
+	width: 350px;
 }
 #topbar-first #nav-notifications-menu a {
 	color: $font_color_darker;
@@ -4385,17 +4380,21 @@ div.login-form, .login-content-wrapper,
 		border: none;
 	}
 
-}/* Even smaller mobile displays */
-@media (width < 358px) {
-	/* Less topnav padding */
-	.navbar-left {
-		float: none!important;
-		display: flex;
-		justify-content: space-between;
+  #nav-notifications-menu {
+		margin-inline: auto!important;
+		position: fixed;
+		inset: 0;
+		top: 50px;
+		min-width: 80vw!important;
+		max-width: 95vw;
 	}
-	.topbar-nav .nav-segment a.nav-menu {
-		padding-left: 0;
-		padding-right: 7px;
+}
+
+	/* Even smaller mobile displays */
+@media (width < 358px) {
+	.topbar-nav .nav-segment a.nav-menu, .topbar-actions .nav-segment a.nav-menu, .topbar-actions .nav-segment button, .topbar-nav .navbar-toggle {
+		padding-left: 0!important;
+		padding-right: 10px!important;
 	}
 	.topbar-nav .offcanvas-right-toggle,
 	.topbar-nav #mobile-left-menu {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -184,12 +184,16 @@ details summary {
 		padding-left: 0;
 		padding-right: 0;
 	}
-	#topbar-first > .container-fluid {
-		padding-inline: 0;
+	#topbar-first > .container-fluid, #topbar-second > .container-fluid {
+		padding-inline: 2px;
 	}
 
 	ul#nav-user-menu {
 		margin-right: 10px;
+	}
+
+	#topbar-second #tabmenu {
+		text-align: unset;
 	}
 }
 /*
@@ -453,6 +457,7 @@ header #banner #logo-img,
 }
 
 #navbrand-container {
+	align-items: center;
 	display: flex;
 }
 #navbrand-container #navbar-brand-text {
@@ -541,9 +546,6 @@ header #banner #logo-img,
 /* offcanvas section ends */
 
 /* NavBar */
-.topbar, #topbar-first-nav-container {
-	height: 50px;
-}
 .topbar {
 	position: fixed;
 	display: block;
@@ -718,6 +720,9 @@ nav.navbar .nav > li > button:focus {
 	border-bottom-color: rgba(0, 0, 0, 0.15);
 	top: -19px;
 	z-index: 1035;
+}
+.topbar, #topbar-first-nav-container {
+	height: 50px;
 }
 .topbar-nav, .topbar-actions, #topbar-first ul.nav {
 		align-items: center;
@@ -936,16 +941,13 @@ nav.navbar .nav > li > button:focus {
 	-moz-box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
 	box-shadow: 0 1px 10px rgba(0, 0, 0, 0.1);
 	border-bottom: 1px solid #d4d4d4;
-	padding-inline: 15px;
 }
-#topbar-second > .container {
+#topbar-second > .container-fluid {
 	height: 100%;
 }
-@media screen and (max-width: 767px) {
-	#topbar-second > .container,
-	#topbar-second #navbar-button {
-		padding: 0;
-	}
+
+#topbar-second #navbar-button {
+	padding: 0;
 }
 #topbar-second .dropdown-menu {
 	padding-top: 0;
@@ -2402,6 +2404,9 @@ moved it to the nav through js */
 	padding-right: 10px;
 	padding-left: 10px;
 }
+#tabmenu {
+	text-align: center;
+}
 #tabmenu,
 .tabbar-wrapper,
 .tabbar,
@@ -2553,6 +2558,10 @@ input[type="range"].form-control {
 }
 
 /* Search form */
+#search-box {
+	padding-right: 0;
+}
+
 .form-control.form-search {
 	border-radius: 30px;
 }

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -67,6 +67,19 @@ body a.active,
 	text-decoration: underline;
 }
 
+/* A bootstrap helper class from more recent Bootstrap versions */
+.d-none {
+	display: none;
+}
+
+i {
+		font-size: 16px;
+}
+
+.wall-item-ago i {
+	font-size: 13px;
+}
+
 hr {
 	margin-top: 10px;
 	margin-bottom: 10px;
@@ -140,7 +153,7 @@ details summary {
 }
 
 /**
- * mobile aside
+ * mobile: Larger screens
  */
 @media screen and (max-width: 990px) {
 	body {
@@ -186,6 +199,10 @@ details summary {
 	}
 	#topbar-first > .container-fluid, #topbar-second > .container-fluid {
 		padding-inline: 2px;
+	}
+
+	#topbar-first .topbar-nav .nav-segment > a.nav-menu {
+		padding-inline: 15px;
 	}
 
 	ul#nav-user-menu {
@@ -611,9 +628,10 @@ header #banner #logo-img,
 #topbar-first,
 nav.navbar {
 	background-color: $nav_bg;
+	color: $nav_icon_color;
+	font-size: 15px;
 	top: 0;
 	z-index: 1030;
-	color: $nav_icon_color;
 }
 
 button#main-menu {
@@ -648,12 +666,13 @@ nav.navbar .nav > li > a:focus,
 nav.navbar .nav > li > button:hover,
 nav.navbar .nav > li > button:focus {
 	background-color: $nav_icon_hover_color;
+	border-radius: 10px;
 }
 /* Current section highlighting */
-#topbar-first .nav > li > a.selected i {
+#topbar-first .nav > li > a.selected {
 	text-decoration: underline;
 	text-underline-offset: 8px;
-	text-decoration-thickness: 3px;
+	text-decoration-thickness: 2px;
 }
 #topbar-first .nav > .account img {
 	height: 32px;
@@ -678,6 +697,7 @@ nav.navbar .nav > li > button:focus {
 /* End workaround */
 #topbar-first .topbar-nav .nav-segment > a {
 	display: inline-block;
+	padding-inline: 35px;
 	text-decoration: none;
 	text-align: left;
 }
@@ -2274,8 +2294,8 @@ button[disabled] {
 }
 
 .network-svg {
-	width: 18px;
-	height: 18px;
+	width: 20px;
+	height: 20px;
 	border-radius: 4px;
 	padding: 2px;
 }

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -80,7 +80,7 @@ i {
 		font-size: 16px;
 }
 
-.wall-item-ago i {
+.wall-item-ago i, small i {
 	font-size: 13px;
 }
 

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -9,6 +9,10 @@
     Author     : rabuzarus and contributors
 */
 
+:root {
+	--topbar-first-size: 50px;
+}
+
 body {
 	padding-top: 110px;
 	background-color: $background_color;
@@ -257,6 +261,10 @@ details summary {
 	background-color: $link_color;
 	line-height: 1.5;
 	display: none;
+}
+
+#item-delete-selected i {
+	font-size: inherit;
 }
 
 #toggle_mobile_link {
@@ -569,11 +577,9 @@ header #banner #logo-img,
 	width: 100%;
 }
 
-.topbar ul.nav > li > a,
-.topbar ul.nav > li > button {
-	padding-top: 15px;
-	padding-bottom: 15px;
-	line-height: 20px;
+.topbar ul.nav > li {
+	display: grid;
+	align-items: center;
 }
 
 .topbar .dropdown-footer {
@@ -679,11 +685,6 @@ nav.navbar .nav > li > button:focus {
 	width: 32px;
 	border-radius: 3px;
 }
-#topbar-first .nav > .account .dropdown-toggle {
-	padding: 8px 5px 0px;
-	line-height: 1.1em;
-	text-align: left;
-}
 #topbar-first .nav > .account .dropdown-toggle span {
 	font-size: 12px;
 }
@@ -742,7 +743,7 @@ nav.navbar .nav > li > button:focus {
 	z-index: 1035;
 }
 .topbar, #topbar-first-nav-container {
-	height: 50px;
+	height: var(--topbar-first-size);
 }
 .topbar-nav, .topbar-actions, #topbar-first ul.nav {
 		align-items: center;
@@ -858,7 +859,7 @@ nav.navbar .nav > li > button:focus {
 	background-color: #ff8989;
 }
 #offcanvasUsermenu {
-	top: 50px;
+	top: var(--topbar-first-size);
 	background-color: $background_color;
 	border-top: 0;
 	border-right: 0;
@@ -868,7 +869,7 @@ nav.navbar .nav > li > button:focus {
 }
 #offcanvasUsermenu .nav-container {
 	/* required to compensate for moving the container below the topnav bar */
-	margin-bottom: 50px;
+	margin-bottom: var(--topbar-first-size);
 }
 #offcanvasUsermenu li.divider {
 	background-color: transparent;
@@ -953,7 +954,7 @@ nav.navbar .nav > li > button:focus {
 /* second topbar */
 #topbar-second {
 	height: 40px;
-	top: 50px;
+	top: var(--topbar-first-size);
 	background-color: #fff;
 	z-index: 1029;
 	background-image: none;
@@ -2179,6 +2180,7 @@ button[disabled] {
 }
 .wall-item-actions-row {
 	display: flex;
+	padding: 5px;
 }
 .wall-item-actions-row .btn {
 	width: 100%;
@@ -4381,7 +4383,7 @@ div.login-form, .login-content-wrapper,
 		margin-inline: auto!important;
 		position: fixed;
 		inset: 0;
-		top: 50px;
+		top: var(--topbar-first-size);
 		min-width: 80vw!important;
 		max-width: 95vw;
 	}

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -61,7 +61,7 @@ $(document).ready(function () {
 	$(".field.select > select, .field.custom > select").addClass("form-control");
 
 	// move the tabbar to the second nav bar
-	$("section .tabbar-wrapper").first().appendTo("#topbar-second > .container > #tabmenu");
+	$("section .tabbar-wrapper").first().appendTo("#topbar-second > .container-fluid > #tabmenu");
 
 	// make responsive tabmenu with flexmenu.js
 	// the menupoints which doesn't fit in the second nav bar will moved to a
@@ -76,7 +76,7 @@ $(document).ready(function () {
 	// add Jot button to the second navbar
 	let $jotButton = $("#jotOpen");
 	if ($jotButton.length) {
-		$jotButton.appendTo("#topbar-second > .container > #navbar-button");
+		$jotButton.appendTo("#topbar-second > .container-fluid > #navbar-button");
 		if ($("#jot-popup").is(":hidden")) {
 			$jotButton.hide();
 		}
@@ -136,7 +136,7 @@ $(document).ready(function () {
 
 	// add search-heading to the second navbar
 	if ($(".search-heading").length) {
-		$(".search-heading").appendTo("#topbar-second > .container > #tabmenu");
+		$(".search-heading").appendTo("#topbar-second > .container-fluid > #tabmenu");
 	}
 
 	// add search results heading to the second navbar
@@ -154,7 +154,7 @@ $(document).ready(function () {
 		// insert the plain text in a <h4> heading and give it a class
 		var newText = '<h4 class="search-heading">' + searchText + "</h4>";
 		// append the new heading to the navbar
-		$("#topbar-second > .container > #tabmenu").append(newText);
+		$("#topbar-second > .container-fluid > #tabmenu").append(newText);
 
 		// try to get the value of the original search input to insert it
 		// as value in the nav-search-input
@@ -179,7 +179,7 @@ $(document).ready(function () {
 	}
 
 	// move the "Save the search" button to the second navbar
-	$(".search-content-wrapper #search-save").appendTo("#topbar-second > .container > #navbar-button");
+	$(".search-content-wrapper #search-save").appendTo("#topbar-second > .container-fluid > #navbar-button");
 
 	// append the vcard-short-info to the second nav after passing the element
 	// with .fn (vcard username). Use scrollspy to get the scroll position.
@@ -234,7 +234,7 @@ $(document).ready(function () {
 		// remove the old heading element
 		heading.remove(),
 			// put the new element to the second nav bar
-			$("#topbar-second > .container > #tabmenu").append(newText);
+			$("#topbar-second > .container-fluid > #tabmenu").append(newText);
 	}
 
 	// Dropdown menus with the class "dropdown-head" will display the active tab

--- a/view/theme/frio/templates/circle_side.tpl
+++ b/view/theme/frio/templates/circle_side.tpl
@@ -8,7 +8,7 @@
 	<span id="circle-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="ri ri-group-3-line" aria-hidden="true"></i>
+				<i class="ri ri-bubble-chart-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -17,7 +17,7 @@
 		<div id="sidebar-circle-header" class="sidebar-widget-header">
 			<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="true">
 				<h3>
-					<i class="ri ri-group-3-line" aria-hidden="true"></i>
+					<i class="ri ri-bubble-chart-line" aria-hidden="true"></i>
 					{{$title}}
 				</h3>
 			</button>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -17,7 +17,7 @@
 					<button type="button" id="mobile-left-menu" class="navbar-toggle collapsed visible-sm visible-xs"
 						data-toggle="offcanvas" data-target="aside" aria-haspopup="true">
 						<span class="sr-only">Toggle navigation</span>
-						<i class="fa fa-angle-double-right fa-fw fa-lg" aria-hidden="true"></i>
+						<i class="ri ri-arrow-right-double-line ri-fw ri-lg" aria-hidden="true"></i>
 					</button>
 
 					<div id="site-location" aria-hidden="true">{{$sitelocation}}</div>
@@ -33,7 +33,7 @@
 								<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
 									type="search" name="q" placeholder="{{$search_placeholder}}">
 								<button class="btn btn-primary btn-md form-button-search" type="submit">
-									<i class="fa fa-search" aria-hidden="true"></i>
+									<i class="ri ri-search-line" aria-hidden="true"></i>
 									<span class="sr-only">{{$nav.search.1}}</span>
 								</button>
 							</div>
@@ -42,7 +42,7 @@
 					<button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
 						data-target="#search-mobile" aria-expanded="false" aria-controls="search-mobile">
 						<span class="sr-only">Toggle Search</span>
-						<i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
+						<i class="ri ri-search-line ri-fw ri-lg" aria-hidden="true"></i>
 					</button>
 				</header>
 				<!-- div for navbar width-->
@@ -61,25 +61,8 @@
 							<li class="nav-segment">
 								<a accesskey="n" class="nav-menu {{$sel.network}}" href="{{$nav.network.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.network.3}}" title="{{$nav.network.3}}"><i
-										class="ri ri-lg ri-message-line ri-fw" aria-hidden="true"></i><span id="net-update"
+									 class="ri ri-lg ri-home-5-{{if $sel.network}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.network.1}}</span><span id="net-update"
 										class="nav-network-badge badge nav-notification"></span></a>
-							</li>
-						{{/if}}
-
-						{{if $nav.channel}}
-							<li class="nav-segment">
-								<a accesskey="l" class="nav-menu {{$sel.channel}}" href="{{$nav.channel.0}}"
-									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.channel.3}}" title="{{$nav.channel.3}}"><i
-										class="ri ri-lg ri-newspaper-line ri-fw" aria-hidden="true"></i></a>
-							</li>
-						{{/if}}
-
-						{{if $nav.home}}
-							<li class="nav-segment">
-								<a accesskey="p" class="nav-menu {{$sel.home}}" href="{{$nav.home.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
-									aria-label="{{$nav.home.3}}" title="{{$nav.home.3}}"><i class="ri ri-lg ri-user-line ri-fw"
-										aria-hidden="true"></i><span id="home-update"
-										class="nav-home-badge badge nav-notification"></span></a>
 							</li>
 						{{/if}}
 
@@ -87,15 +70,32 @@
 							<li class="nav-segment">
 								<a accesskey="c" class="nav-menu {{$sel.community}}" href="{{$nav.community.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.community.3}}" title="{{$nav.community.3}}"><i
-										class="ri ri-lg ri-user-community-line ri-fw" aria-hidden="true"></i></a>
+									  class="ri ri-lg ri-user-community-{{if $sel.community}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.community.1}}</span></a>
 							</li>
 						{{/if}}
 
 						{{if $nav.calendar}}
-							<li class="nav-segment hidden-xs">
+							<li class="nav-segment">
 								<a accesskey="e" id="nav-calendar-link" href="{{$nav.calendar.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
-									aria-label="{{$nav.calendar.1}}" title="{{$nav.calendar.1}}" class="nav-menu {{$sel.calendar}}"><i
-										class="ri ri-lg ri-calendar-line ri-fw"></i></a>
+									aria-label="{{$nav.calendar.1}}" title="{{$nav.calendar.3}}" class="nav-menu {{$sel.calendar}}"><i
+									class="ri ri-lg ri-calendar-2-{{if $sel.calendar}}fill{{else}}line{{/if}} ri-fw"></i> <span class="d-none">{{$nav.calendar.1}}</span></a>
+							</li>
+						{{/if}}
+
+						{{if $nav.channel}}
+							<li class="nav-segment">
+								<a accesskey="l" class="nav-menu {{$sel.channel}}" href="{{$nav.channel.0}}"
+									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.channel.3}}" title="{{$nav.channel.3}}"><i
+										class="ri ri-newspaper-{{if $sel.channel}}fill{{else}}line{{/if}} ri-lg ri-newspaper-line ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.channel.1}}</span></a>
+							</li>
+						{{/if}}
+
+						{{if $nav.home}}
+							<li class="nav-segment hidden-xs">
+								<a accesskey="p" class="nav-menu {{$sel.home}}" href="{{$nav.home.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
+										aria-label="{{$nav.home.3}}" title="{{$nav.home.3}}"><i class="ri ri-lg ri-user-{{if $sel.home}}fill{{else}}line{{/if}} ri-fw"
+										aria-hidden="true"></i> <span class="d-none">{{$nav.home.1}}</span><span id="home-update"
+										class="nav-home-badge badge nav-notification"></span></a>
 							</li>
 						{{/if}}
 
@@ -111,7 +111,7 @@
 								<a accesskey="k" id="nav-contacts-link" href="{{$nav.contacts.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.contacts.1}}" title="{{$nav.contacts.1}}"
 									class="nav-menu {{$sel.contacts}} {{$nav.contacts.2}}"><i
-										class="ri ri-contacts-line ri-lg ri-fw"></i></a>
+										class="ri ri-contacts-{{if $sel.contacts}}fill{{else}}line{{/if}} ri-lg ri-fw"></i></a>
 							</li>
 						{{/if}}
 
@@ -119,7 +119,7 @@
 							<li class="nav-segment">
 								<a accesskey="m" id="nav-messages-link" href="{{$nav.messages.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.messages.1}}" title="{{$nav.messages.1}}"
-									class="nav-menu {{$sel.messages}}"><i class="fa fa-envelope fa-lg fa-fw"
+									class="nav-menu {{$sel.messages}}"><i class="ri ri-mail-{{if $sel.messages}}fill{{else}}line{{/if}} ri-lg ri-fw"
 										aria-hidden="true"></i><span id="mail-update"
 										class="nav-mail-badge badge nav-notification"></span></a>
 							</li>
@@ -165,7 +165,7 @@
 					<button type="button" class="navbar-toggle offcanvas-right-toggle"
 						aria-controls="offcanvasUsermenu" aria-haspopup="true">
 						<span class="sr-only">Toggle navigation</span>
-						<i class="fa fa-ellipsis-v fa-fw fa-lg" aria-hidden="true"></i>
+						<i class="ri ri-more-2-line ri-fw ri-lg" aria-hidden="true"></i>
 					</button>
 
 						{{* The user dropdown menu *}}
@@ -194,7 +194,7 @@
 									{{/if}}
 									{{foreach $nav.usermenu as $usermenu}}
 										<li>
-											<a role="menuitem" class="{{$usermenu.2}}{{if $usermenu.0|str_ends_with:"calendar/"}}visible-xs{{/if}}" href="{{$usermenu.0}}"
+											<a role="menuitem" class="{{$usermenu.2}}" href="{{$usermenu.0}}"
 												title="{{$usermenu.3}}">
 												<i class="ri {{$usermenu.4}}"></i>
 												{{$usermenu.1}}

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -10,7 +10,16 @@
 		<div class="container-fluid">
 			<div id="topbar-first-nav-container" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding">
 
-				<header style="display: flex;" class="hidden-xs">
+				<header style="display: flex;">
+
+					{{* Buttons for the mobile view *}}
+					{{* Mobile left menu dropdown button *}}
+					<button type="button" id="mobile-left-menu" class="navbar-toggle collapsed visible-sm visible-xs"
+						data-toggle="offcanvas" data-target="aside" aria-haspopup="true">
+						<span class="sr-only">Toggle navigation</span>
+						<i class="fa fa-angle-double-right fa-fw fa-lg" aria-hidden="true"></i>
+					</button>
+
 					<div id="site-location" aria-hidden="true">{{$sitelocation}}</div>
 					<div id="banner" class="hidden-sm hidden-xs">
 						<a href="{{$baseurl}}" aria-hidden="true">
@@ -30,18 +39,15 @@
 							</div>
 						</form>
 					{{/if}}
+					<button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+						data-target="#search-mobile" aria-expanded="false" aria-controls="search-mobile">
+						<span class="sr-only">Toggle Search</span>
+						<i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
+					</button>
 				</header>
 				<!-- div for navbar width-->
 				<!-- Brand and toggle get grouped for better mobile display -->
 				<div class="topbar-nav">
-
-					{{* Buttons for the mobile view *}}
-					{{* Mobile left menu dropdown button *}}
-					<button type="button" id="mobile-left-menu" class="navbar-toggle collapsed pull-left visible-sm visible-xs"
-						data-toggle="offcanvas" data-target="aside" aria-haspopup="true">
-						<span class="sr-only">Toggle navigation</span>
-						<i class="ri ri-arrow-right-double-line ri-fw ri-lg" aria-hidden="true"></i>
-					</button>
 
 					{{* Left section of the NavBar with navigation shortcuts/icons *}}
 					<ul class="nav navbar-left">
@@ -93,6 +99,13 @@
 							</li>
 						{{/if}}
 
+					</ul>
+				</div>
+
+				{{* This is the right part of the NavBar. It includes the search and the user menu *}}
+				<div class="topbar-actions">
+					<ul class="nav">
+
 						{{if $nav.contacts}}
 							<li class="nav-segment hidden-xs">
 								<a accesskey="k" id="nav-contacts-link" href="{{$nav.contacts.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
@@ -101,13 +114,6 @@
 										class="ri ri-contacts-line ri-lg ri-fw"></i></a>
 							</li>
 						{{/if}}
-
-					</ul>
-				</div>
-
-				{{* This is the right part of the NavBar. It includes the search and the user menu *}}
-				<div class="topbar-actions">
-					<ul class="nav">
 
 						{{if $nav.messages}}
 							<li class="nav-segment">
@@ -156,15 +162,10 @@
 						{{/if}}
 
 					{{* Mobile user menu dropdown button *}}
-					<button type="button" class="navbar-toggle offcanvas-right-toggle pull-right"
+					<button type="button" class="navbar-toggle offcanvas-right-toggle"
 						aria-controls="offcanvasUsermenu" aria-haspopup="true">
 						<span class="sr-only">Toggle navigation</span>
 						<i class="fa fa-ellipsis-v fa-fw fa-lg" aria-hidden="true"></i>
-					</button>
-					<button type="button" class="navbar-toggle collapsed pull-right" data-toggle="collapse"
-						data-target="#search-mobile" aria-expanded="false" aria-controls="search-mobile">
-						<span class="sr-only">Toggle Search</span>
-						<i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
 					</button>
 
 						{{* The user dropdown menu *}}
@@ -440,7 +441,7 @@
 {{else}}
 	{{* The navbar for users which are not logged in *}}
 	<nav class="navbar navbar-fixed-top">
-		<div class="container">
+		<div class="container-fluid">
 		<div class="navbar-header pull-left">
 			<button type="button" class="navbar-toggle collapsed pull-left visible-sm visible-xs"
 					data-toggle="offcanvas" data-target="aside" aria-haspopup="true">

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -61,7 +61,7 @@
 							<li class="nav-segment">
 								<a accesskey="n" class="nav-menu {{$sel.network}}" href="{{$nav.network.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.network.3}}" title="{{$nav.network.3}}"><i
-									 class="ri ri-lg ri-home-5-{{if $sel.network}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.network.1}}</span><span id="net-update"
+									 class="ri ri-xl ri-home-5-{{if $sel.network}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.network.1}}</span><span id="net-update"
 										class="nav-network-badge badge nav-notification"></span></a>
 							</li>
 						{{/if}}
@@ -70,7 +70,7 @@
 							<li class="nav-segment">
 								<a accesskey="c" class="nav-menu {{$sel.community}}" href="{{$nav.community.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.community.3}}" title="{{$nav.community.3}}"><i
-									  class="ri ri-lg ri-user-community-{{if $sel.community}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.community.1}}</span></a>
+									  class="ri ri-xl ri-earth-{{if $sel.community}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.community.1}}</span></a>
 							</li>
 						{{/if}}
 
@@ -78,7 +78,7 @@
 							<li class="nav-segment">
 								<a accesskey="e" id="nav-calendar-link" href="{{$nav.calendar.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.calendar.1}}" title="{{$nav.calendar.3}}" class="nav-menu {{$sel.calendar}}"><i
-									class="ri ri-lg ri-calendar-2-{{if $sel.calendar}}fill{{else}}line{{/if}} ri-fw"></i> <span class="d-none">{{$nav.calendar.1}}</span></a>
+									class="ri ri-xl ri-calendar-2-{{if $sel.calendar}}fill{{else}}line{{/if}} ri-fw"></i> <span class="d-none">{{$nav.calendar.1}}</span></a>
 							</li>
 						{{/if}}
 
@@ -86,14 +86,14 @@
 							<li class="nav-segment">
 								<a accesskey="l" class="nav-menu {{$sel.channel}}" href="{{$nav.channel.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.channel.3}}" title="{{$nav.channel.3}}"><i
-										class="ri ri-newspaper-{{if $sel.channel}}fill{{else}}line{{/if}} ri-lg ri-newspaper-line ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.channel.1}}</span></a>
+										class="ri ri-xl ri-newspaper-{{if $sel.channel}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.channel.1}}</span></a>
 							</li>
 						{{/if}}
 
 						{{if $nav.home}}
 							<li class="nav-segment hidden-xs">
 								<a accesskey="p" class="nav-menu {{$sel.home}}" href="{{$nav.home.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
-										aria-label="{{$nav.home.3}}" title="{{$nav.home.3}}"><i class="ri ri-lg ri-user-{{if $sel.home}}fill{{else}}line{{/if}} ri-fw"
+										aria-label="{{$nav.home.3}}" title="{{$nav.home.3}}"><i class="ri ri-xl ri-user-{{if $sel.home}}fill{{else}}line{{/if}} ri-fw"
 										aria-hidden="true"></i> <span class="d-none">{{$nav.home.1}}</span><span id="home-update"
 										class="nav-home-badge badge nav-notification"></span></a>
 							</li>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -82,16 +82,6 @@
 							</li>
 						{{/if}}
 
-						{{if $nav.messages}}
-							<li class="nav-segment">
-								<a accesskey="m" id="nav-messages-link" href="{{$nav.messages.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
-									aria-label="{{$nav.messages.1}}" title="{{$nav.messages.1}}"
-									class="nav-menu {{$sel.messages}}"><i class="ri ri-mail-line ri-lg ri-fw"
-										aria-hidden="true"></i><span id="mail-update"
-										class="nav-mail-badge badge nav-notification"></span></a>
-							</li>
-						{{/if}}
-
 						{{if $nav.calendar}}
 							<li class="nav-segment hidden-xs">
 								<a accesskey="e" id="nav-calendar-link" href="{{$nav.calendar.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
@@ -106,6 +96,39 @@
 									aria-label="{{$nav.contacts.1}}" title="{{$nav.contacts.1}}"
 									class="nav-menu {{$sel.contacts}} {{$nav.contacts.2}}"><i
 										class="ri ri-contacts-line ri-lg ri-fw"></i></a>
+							</li>
+						{{/if}}
+
+					</ul>
+				</div>
+
+				{{* This is the right part of the NavBar. It includes the search and the user menu *}}
+				<div class="topbar-actions pull-right">
+					<ul class="nav">
+
+						{{* The search box *}}
+						{{if $nav.search}}
+							<li id="search-box" class="hidden-xs">
+								<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
+									<div class="form-group form-group-search">
+										<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
+											type="search" name="q" placeholder="{{$search_placeholder}}">
+										<button class="btn btn-primary btn-md form-button-search" type="submit">
+											<i class="fa fa-search" aria-hidden="true"></i>
+											<span class="sr-only">{{$nav.search.1}}</span>
+										</button>
+									</div>
+								</form>
+							</li>
+						{{/if}}
+
+						{{if $nav.messages}}
+							<li class="nav-segment">
+								<a accesskey="m" id="nav-messages-link" href="{{$nav.messages.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
+									aria-label="{{$nav.messages.1}}" title="{{$nav.messages.1}}"
+									class="nav-menu {{$sel.messages}}"><i class="fa fa-envelope fa-lg fa-fw"
+										aria-hidden="true"></i><span id="mail-update"
+										class="nav-mail-badge badge nav-notification"></span></a>
 							</li>
 						{{/if}}
 
@@ -143,29 +166,6 @@
 								<p role="menuitem" class="text-muted text-center"><i>{{$emptynotifications}}</i></p>
 							</li>
 								</ul>
-							</li>
-						{{/if}}
-
-					</ul>
-				</div>
-
-				{{* This is the right part of the NavBar. It includes the search and the user menu *}}
-				<div class="topbar-actions pull-right">
-					<ul class="nav">
-
-						{{* The search box *}}
-						{{if $nav.search}}
-							<li id="search-box" class="hidden-xs">
-								<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
-									<div class="form-group form-group-search">
-										<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
-											type="search" name="q" placeholder="{{$search_placeholder}}">
-										<button class="btn btn-primary btn-md form-button-search" type="submit">
-											<i class="ri ri-search-line" aria-hidden="true"></i>
-											<span class="sr-only">{{$nav.search.1}}</span>
-										</button>
-									</div>
-								</form>
 							</li>
 						{{/if}}
 

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -493,9 +493,9 @@
 
 {{* The second navbar which contains nav points of the actual page - (nav points are actual handled by this theme through js *}}
 <div id="topbar-second" class="topbar">
-	<div class="container">
-		<div class="col-lg-3 col-md-3 hidden-sm hidden-xs" id="nav-short-info"></div>
-		<div class="col-lg-7 col-md-7 col-sm-11 col-xs-10" id="tabmenu"></div>
-		<div class="col-lg-2 col-md-2 col-sm-1 col-xs-2" id="navbar-button"></div>
+	<div class="container-fluid">
+		<div class="col-lg-2 col-md-2 hidden-sm hidden-xs" id="nav-short-info"></div>
+		<div class="col-lg-9 col-md-9 col-sm-11 col-xs-7" id="tabmenu"></div>
+		<div class="col-lg-1 col-md-1 col-sm-1 col-xs-5" id="navbar-button"></div>
 	</div>
 </div>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -6,33 +6,36 @@
   *}}
 {{* we have modified the navmenu (look at function frio_remote_nav() ) to have remote links. *}}
 {{if $userinfo}}
-	<header>
-		<div id="site-location" aria-hidden="true">{{$sitelocation}}</div>
-		<div id="banner" class="hidden-sm hidden-xs">
-			<a href="{{$baseurl}}" aria-hidden="true">
-				<div id="logo-img" aria-label="{{$home}}"></div>
-			</a>
-		</div>
-	</header>
 	<nav id="topbar-first" class="topbar" role="menubar">
-		<div class="container">
-			<div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding">
+		<div class="container-fluid">
+			<div id="topbar-first-nav-container" class="col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding">
+
+				<header style="display: flex;" class="hidden-xs">
+					<div id="site-location" aria-hidden="true">{{$sitelocation}}</div>
+					<div id="banner" class="hidden-sm hidden-xs">
+						<a href="{{$baseurl}}" aria-hidden="true">
+							<div id="logo-img" aria-label="{{$home}}"></div>
+						</a>
+					</div>
+					{{* The search box *}}
+					{{if $nav.search}}
+						<form id="search-box" class="navbar-form hidden-xs form-group form-group-search" role="search" method="get" action="{{$nav.search.0}}">
+							<div class="form-group form-group-search">
+								<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
+									type="search" name="q" placeholder="{{$search_placeholder}}">
+								<button class="btn btn-primary btn-md form-button-search" type="submit">
+									<i class="fa fa-search" aria-hidden="true"></i>
+									<span class="sr-only">{{$nav.search.1}}</span>
+								</button>
+							</div>
+						</form>
+					{{/if}}
+				</header>
 				<!-- div for navbar width-->
 				<!-- Brand and toggle get grouped for better mobile display -->
 				<div class="topbar-nav">
 
 					{{* Buttons for the mobile view *}}
-					{{* Mobile user menu dropdown button *}}
-					<button type="button" class="navbar-toggle offcanvas-right-toggle pull-right"
-						aria-controls="offcanvasUsermenu" aria-haspopup="true">
-						<span class="sr-only">Toggle navigation</span>
-						<i class="ri ri-more-2-line ri-fw ri-lg" aria-hidden="true"></i>
-					</button>
-					<button type="button" class="navbar-toggle collapsed pull-right" data-toggle="collapse"
-						data-target="#search-mobile" aria-expanded="false" aria-controls="search-mobile">
-						<span class="sr-only">Toggle Search</span>
-						<i class="ri ri-search-line ri-fw ri-lg" aria-hidden="true"></i>
-					</button>
 					{{* Mobile left menu dropdown button *}}
 					<button type="button" id="mobile-left-menu" class="navbar-toggle collapsed pull-left visible-sm visible-xs"
 						data-toggle="offcanvas" data-target="aside" aria-haspopup="true">
@@ -103,24 +106,8 @@
 				</div>
 
 				{{* This is the right part of the NavBar. It includes the search and the user menu *}}
-				<div class="topbar-actions pull-right">
+				<div class="topbar-actions">
 					<ul class="nav">
-
-						{{* The search box *}}
-						{{if $nav.search}}
-							<li id="search-box" class="hidden-xs">
-								<form class="navbar-form" role="search" method="get" action="{{$nav.search.0}}">
-									<div class="form-group form-group-search">
-										<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
-											type="search" name="q" placeholder="{{$search_placeholder}}">
-										<button class="btn btn-primary btn-md form-button-search" type="submit">
-											<i class="fa fa-search" aria-hidden="true"></i>
-											<span class="sr-only">{{$nav.search.1}}</span>
-										</button>
-									</div>
-								</form>
-							</li>
-						{{/if}}
 
 						{{if $nav.messages}}
 							<li class="nav-segment">
@@ -156,7 +143,6 @@
 												</button>
 											</header>
 										</header>
-
 									</li>
 
 							<li id="nav-notifications-loading" class="loading" style="font-weight: bold; color: #555; padding-left: 10px;">
@@ -168,6 +154,18 @@
 								</ul>
 							</li>
 						{{/if}}
+
+					{{* Mobile user menu dropdown button *}}
+					<button type="button" class="navbar-toggle offcanvas-right-toggle pull-right"
+						aria-controls="offcanvasUsermenu" aria-haspopup="true">
+						<span class="sr-only">Toggle navigation</span>
+						<i class="fa fa-ellipsis-v fa-fw fa-lg" aria-hidden="true"></i>
+					</button>
+					<button type="button" class="navbar-toggle collapsed pull-right" data-toggle="collapse"
+						data-target="#search-mobile" aria-expanded="false" aria-controls="search-mobile">
+						<span class="sr-only">Toggle Search</span>
+						<i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
+					</button>
 
 						{{* The user dropdown menu *}}
 						{{if $userinfo}}

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -92,7 +92,7 @@
 				{{if $network_label}}
 					<div id="showgroup-button">
 						<a id="showgroup" class="btn btn-labeled btn-primary" href="{{$network_url}}">
-							<span><i class="ri ri-group-line"></i></span>
+							<span><i class="ri ri-discuss-line"></i></span>
 							<span>{{$network_label}}</span>
 						</a>
 					</div>

--- a/view/theme/frio/templates/widget/vcard.tpl
+++ b/view/theme/frio/templates/widget/vcard.tpl
@@ -76,7 +76,7 @@
 			{{if $showgroup_link}}
 				<div id="show-group-button">
 					<a type="button" id="show-group" class="btn btn-labeled btn-primary" href="{{$showgroup_link}}" title="{{$showgroup}}" aria-label="{{$showgroup}}">
-						<span class=""><i class="ri ri-group-line"></i></span>
+						<span class=""><i class="ri ri-discuss-line"></i></span>
 						<span class="">{{$showgroup}}</span>
 					</a>
 				</div>


### PR DESCRIPTION
Closes #15125 #15803 (besides many other changes)

Changes besides the referenced PR:

- Allow the main menu to break out of the boxed page width. Incidentally this moves Frio a bit closer to Vier, making better use of the available space.
- Put the main nav in the center and move search to the left to make space for it, matching Bookface.
- Move Notifications, Messages and Contacts to the right
- Rename "Network" to "Home" and use the "Home" icon (the old "Home" is still in the main menu, on the right)
- A couple additional icon updates
- Show the calendar in the main nav on smaller viewports as well (e.g. mobile)
- Better notifications dropdown on smaller viewports
- Somewhat larger icons in general
- Use filled icon for the current page
- Minor increase to main menu font size

I generally I try to make the templates a bit simpler, so where things are in the templates matches what's viewed a bit more, instead of using so much float and `position` to move things.

Next stop would be to do something similar to the main page content and/or add text to the main menu.

Because this makes quite a lot of changes I think it's ideal if something like this is merged long before a release to catch things I might've possibly missed. But I _have_ been going back and forth between various desktop and mobile widths to test.

Credits to @foss- for various suggestions!

# Screenshots

Wider view on something like a PC:
<img width="1521" height="686" alt="image" src="https://github.com/user-attachments/assets/3a116047-f497-4871-b484-9ad515fbe839" />

Narrow view down to around 250px:
<img width="253" height="533" alt="image" src="https://github.com/user-attachments/assets/d4fa292f-394d-4366-86f6-332c292682e0" />