### PR TITLE
Use Remix Icon as new Icon collection.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
 		"npm-asset/cropperjs": "1.2.2",
 		"npm-asset/dompurify": "^1.0",
 		"npm-asset/es-jquery-sortable": "^0.9.13",
-		"npm-asset/fork-awesome": "^1.1",
+		"npm-asset/remixicon": "^4.6",
 		"npm-asset/fullcalendar": "^3.10",
 		"npm-asset/imagesloaded": "4.1.4",
 		"npm-asset/jgrowl": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d0683679f45a6a7c6fd23ac03496a40",
+    "content-hash": "9e80fb50429d3ec539f41c3b92553038",
     "packages": [
         {
             "name": "alchemy/binary-driver",
@@ -560,6 +560,7 @@
                 "issues": "https://github.com/DivineOmega/DO-File-Cache/issues",
                 "source": "https://github.com/DivineOmega/DO-File-Cache/tree/master"
             },
+            "abandoned": "jord-jd/do-file-cache",
             "time": "2018-12-31T09:36:51+00:00"
         },
         {
@@ -603,8 +604,16 @@
             ],
             "description": "PSR-6 adapter for DO File Cache",
             "support": {
-                "source": "https://github.com/DivineOmega/DO-File-Cache-PSR-6/tree/master"
+                "issues": "https://github.com/Jord-JD/DO-File-Cache-PSR-6/issues",
+                "source": "https://github.com/Jord-JD/DO-File-Cache-PSR-6/tree/v2.0.1"
             },
+            "funding": [
+                {
+                    "url": "https://github.com/DivineOmega",
+                    "type": "github"
+                }
+            ],
+            "abandoned": "jord-jd/do-file-cache-psr-6",
             "time": "2018-07-13T08:32:36+00:00"
         },
         {
@@ -683,6 +692,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": "jord-jd/password_exposed",
             "time": "2021-04-20T09:34:23+00:00"
         },
         {
@@ -731,6 +741,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": "jord-jd/psr-18-guzzle-adapter",
             "time": "2021-04-20T08:50:57+00:00"
         },
         {
@@ -2325,18 +2336,6 @@
             ]
         },
         {
-            "name": "npm-asset/fork-awesome",
-            "version": "1.2.0",
-            "dist": {
-                "type": "tar",
-                "url": "https://registry.npmjs.org/fork-awesome/-/fork-awesome-1.2.0.tgz"
-            },
-            "type": "npm-asset",
-            "license": [
-                "(OFL-1.1 AND MIT)"
-            ]
-        },
-        {
             "name": "npm-asset/fullcalendar",
             "version": "3.10.5",
             "dist": {
@@ -2480,6 +2479,18 @@
             "type": "npm-asset",
             "license": [
                 "BSD-3-Clause"
+            ]
+        },
+        {
+            "name": "npm-asset/remixicon",
+            "version": "4.9.1",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/remixicon/-/remixicon-4.9.1.tgz"
+            },
+            "type": "npm-asset",
+            "license": [
+                "Apache-2.0"
             ]
         },
         {
@@ -2627,6 +2638,7 @@
                 "issues": "https://github.com/oomphinc/composer-installers-extender/issues",
                 "source": "https://github.com/oomphinc/composer-installers-extender/tree/2.0.1"
             },
+            "abandoned": true,
             "time": "2021-12-15T12:32:42+00:00"
         },
         {
@@ -3059,6 +3071,7 @@
                 "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Console_Table",
                 "source": "https://github.com/pear/Console_Table"
             },
+            "abandoned": true,
             "time": "2018-01-25T20:47:17+00:00"
         },
         {
@@ -8537,6 +8550,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2025-03-19T07:56:08+00:00"
         },
         {
@@ -8593,6 +8607,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2024-07-03T04:45:54+00:00"
         },
         {
@@ -10414,9 +10429,9 @@
         "ext-simplexml": "*",
         "ext-xml": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -203,7 +203,7 @@ class Nav
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Conversations'), '', $this->l10n->t('Conversations you started'), 'ri-chat-3-line'];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos'), 'ri-image-line'];
 			$nav['usermenu'][] = ['calendar/', $this->l10n->t('Calendar'), '', $this->l10n->t('Your calendar'), 'ri-calendar-line'];
-			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Your personal notes'), 'ri-book-line'];
+			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Your personal notes'), 'ri-sticky-note-line'];
 
 			// user info
 			$contact  = $this->database->selectFirst('contact', ['id', 'url', 'avatar', 'micro', 'name', 'nick', 'baseurl', 'updated'], ['uid' => $this->session->getLocalUserId(), 'self' => true]);

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -199,11 +199,11 @@ class Nav
 
 		if ($this->session->isAuthenticated()) {
 			// user menu
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('Your profile page'), 'fa-user'];
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Conversations'), '', $this->l10n->t('Conversations you started'), 'fa-commenting'];
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos'), 'fa-picture-o'];
-			$nav['usermenu'][] = ['calendar/', $this->l10n->t('Calendar'), '', $this->l10n->t('Your calendar'), 'fa-calendar'];
-			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Your personal notes'), 'fa-book'];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('Your profile page'), 'ri-user-line'];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Conversations'), '', $this->l10n->t('Conversations you started'), 'ri-chat-3-line'];
+			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('Your photos'), 'ri-image-line'];
+			$nav['usermenu'][] = ['calendar/', $this->l10n->t('Calendar'), '', $this->l10n->t('Your calendar'), 'ri-calendar-line'];
+			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Your personal notes'), 'ri-book-line'];
 
 			// user info
 			$contact  = $this->database->selectFirst('contact', ['id', 'url', 'avatar', 'micro', 'name', 'nick', 'baseurl', 'updated'], ['uid' => $this->session->getLocalUserId(), 'self' => true]);

--- a/src/Object/Post.php
+++ b/src/Object/Post.php
@@ -702,47 +702,47 @@ class Post
 			switch ($element['verb']) {
 				case Activity::ANNOUNCE:
 					$title = DI::l10n()->t('Reshared by: %s', $actors);
-					$icon  = ['fa' => 'fa-retweet', 'icon' => 'icon-retweet'];
+					$icon  = ['fa' => 'ri-repeat-line', 'icon' => 'icon-retweet'];
 					break;
 
 				case Activity::VIEW:
 					$title = DI::l10n()->t('Viewed by: %s', $actors);
-					$icon  = ['fa' => 'fa-eye', 'icon' => 'icon-eye-open'];
+					$icon  = ['fa' => 'ri-eye-line', 'icon' => 'icon-eye-open'];
 					break;
 
 				case Activity::READ:
 					$title = DI::l10n()->t('Read by: %s', $actors);
-					$icon  = ['fa' => 'fa-book', 'icon' => 'icon-book'];
+					$icon  = ['fa' => 'ri-book-line', 'icon' => 'icon-book'];
 					break;
 
 				case Activity::LIKE:
 					$title = DI::l10n()->t('Liked by: %s', $actors);
-					$icon  = ['fa' => 'fa-thumbs-up', 'icon' => 'icon-thumbs-up'];
+					$icon  = ['fa' => 'ri-thumb-up-line', 'icon' => 'icon-thumbs-up'];
 					break;
 
 				case Activity::DISLIKE:
 					$title = DI::l10n()->t('Disliked by: %s', $actors);
-					$icon  = ['fa' => 'fa-thumbs-down', 'icon' => 'icon-thumbs-down'];
+					$icon  = ['fa' => 'ri-thumb-down-line', 'icon' => 'icon-thumbs-down'];
 					break;
 
 				case Activity::ATTEND:
 					$title = DI::l10n()->t('Attended by: %s', $actors);
-					$icon  = ['fa' => 'fa-check', 'icon' => 'icon-ok'];
+					$icon  = ['fa' => 'ri-check-line', 'icon' => 'icon-ok'];
 					break;
 
 				case Activity::ATTENDMAYBE:
 					$title = DI::l10n()->t('Maybe attended by: %s', $actors);
-					$icon  = ['fa' => 'fa-question', 'icon' => 'icon-question'];
+					$icon  = ['fa' => 'ri-question-line', 'icon' => 'icon-question'];
 					break;
 
 				case Activity::ATTENDNO:
 					$title = DI::l10n()->t('Not attended by: %s', $actors);
-					$icon  = ['fa' => 'fa-times', 'icon' => 'icon-remove'];
+					$icon  = ['fa' => 'ri-close-line', 'icon' => 'icon-remove'];
 					break;
 
 				case Activity::POST:
 					$title = DI::l10n()->t('Commented by: %s', $actors);
-					$icon  = ['fa' => 'fa-commenting', 'icon' => 'icon-commenting'];
+					$icon  = ['fa' => 'ri-chat-3-line', 'icon' => 'icon-commenting'];
 					break;
 
 				default:

--- a/view/templates/acl/full_selector.tpl
+++ b/view/templates/acl/full_selector.tpl
@@ -9,7 +9,7 @@
 		<div class="panel panel-success">
 			<label class="panel-heading{{if $visibility != 'public'}} collapsed{{/if}}" id="visibility-public-heading-{{$input_group_id}}" aria-expanded="{{if $visibility == 'public'}}true{{else}}false{{/if}}">
 				<input type="radio" name="{{$input_names.visibility}}" id="visibility-public-{{$input_group_id}}" value="public" tabindex="14" {{if $visibility == 'public'}}checked{{/if}}>
-				<i class="fa fa-globe"></i> {{$public_title}}
+				<i class="ri ri-global-line"></i> {{$public_title}}
 			</label>
 			<fieldset id="visibility-public-panel-{{$input_group_id}}" class="panel-collapse collapse{{if $visibility == 'public'}} in{{/if}}" role="tabpanel" aria-labelledby="visibility-public-heading-{{$input_group_id}}" {{if $visibility != 'public'}}disabled{{/if}}>
 				<div class="panel-body">
@@ -44,7 +44,7 @@
 		<div class="panel panel-info">
 			<label class="panel-heading{{if $visibility != 'custom'}} collapsed{{/if}}" id="visibility-custom-heading-{{$input_group_id}}" aria-expanded="{{if $visibility == 'custom'}}true{{else}}false{{/if}}">
 				<input type="radio" name="{{$input_names.visibility}}" id="visibility-custom-{{$input_group_id}}" value="custom" tabindex="15" {{if $visibility == 'custom'}}checked{{/if}}>
-				<i class="fa fa-lock"></i> {{$custom_title}}
+				<i class="ri ri-lock-line"></i> {{$custom_title}}
 			</label>
 			<fieldset id="visibility-custom-panel-{{$input_group_id}}" class="panel-collapse collapse{{if $visibility == 'custom'}} in{{/if}}" role="tabpanel" aria-labelledby="visibility-custom-heading-{{$input_group_id}}" {{if $visibility != 'custom'}}disabled{{/if}}>
 				<input type="hidden" name="{{$input_names.circle_allow}}" value="{{$circle_allow}}"/>

--- a/view/templates/circle_edit.tpl
+++ b/view/templates/circle_edit.tpl
@@ -19,7 +19,7 @@
 		<div id="circle-edit-submit-wrapper">
 			<input type="submit" name="submit" value="{{$submit}}">
 			<button type="button" onclick="window.location.href='circle/markread/{{$gid}}?t={{$form_security_token_markread}}';" title="{{$markread_label}}">
-				<i class="fa fa-eye" aria-hidden="true"></i> {{$markread_label}}
+				<i class="ri ri-eye-line" aria-hidden="true"></i> {{$markread_label}}
 			</button>
 		</div>
 		<div id="circle-edit-select-end"></div>

--- a/view/templates/circle_side.tpl
+++ b/view/templates/circle_side.tpl
@@ -8,7 +8,7 @@
 	<span id="circle-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="ri ri-account-circle-line" aria-hidden="true"></i>
+				<i class="ri ri-user-community-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -16,7 +16,7 @@
 	<div class="widget" id="circle-sidebar">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="ri ri-account-circle-line" aria-hidden="true"></i>
+				<i class="ri ri-user-community-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>

--- a/view/templates/circle_side.tpl
+++ b/view/templates/circle_side.tpl
@@ -8,7 +8,7 @@
 	<span id="circle-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="fa fa-user-circle" aria-hidden="true"></i>
+				<i class="ri ri-account-circle-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -16,7 +16,7 @@
 	<div class="widget" id="circle-sidebar">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="fa fa-user-circle" aria-hidden="true"></i>
+				<i class="ri ri-account-circle-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>

--- a/view/templates/circle_side.tpl
+++ b/view/templates/circle_side.tpl
@@ -8,7 +8,7 @@
 	<span id="circle-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="ri ri-user-community-line" aria-hidden="true"></i>
+				<i class="ri ri-group-3-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -16,7 +16,7 @@
 	<div class="widget" id="circle-sidebar">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="ri ri-user-community-line" aria-hidden="true"></i>
+				<i class="ri ri-group-3-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>

--- a/view/templates/delegation.tpl
+++ b/view/templates/delegation.tpl
@@ -43,6 +43,6 @@
 	</div>
 
 	<p>
-		<a href="settings/delegation" class="btn btn-primary"><i class="fa fa-cog"></i> {{$l10n.settings_label}}</a>
+		<a href="settings/delegation" class="btn btn-primary"><i class="ri ri-settings-3-line"></i> {{$l10n.settings_label}}</a>
 	</p>
 </div>

--- a/view/templates/friendica.tpl
+++ b/view/templates/friendica.tpl
@@ -39,7 +39,7 @@
 			{{/foreach}}
 			</tbody>
 		</table>
-		<p><a rel="nofollow" href="/blocklist/domain/download"><i class="fa fa-download"></i> {{$block_list.download}}</a></p>
+		<p><a rel="nofollow" href="/blocklist/domain/download"><i class="ri ri-download-line"></i> {{$block_list.download}}</a></p>
 	</div>
 {{/if}}
 

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -7,7 +7,7 @@
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <base href="{{$baseurl}}/" />
 <meta name="generator" content="{{$generator}}" />
-<link rel="stylesheet" href="view/asset/fork-awesome/css/fork-awesome.min.css?v={{$VERSION}}" type="text/css" media="screen" />
+<link rel="stylesheet" href="view/asset/remixicon/fonts/remixicon.css?v={{$VERSION}}" type="text/css" media="screen" />
 <link rel="stylesheet" href="view/global.css?v={{$VERSION}}" type="text/css" media="all" />
 <link rel="stylesheet" href="view/asset/jquery-colorbox/example5/colorbox.css?v={{$VERSION}}" type="text/css" media="screen" />
 <link rel="stylesheet" href="view/asset/jgrowl/jquery.jgrowl.min.css?v={{$VERSION}}" type="text/css" media="screen" />

--- a/view/templates/hovercard.tpl
+++ b/view/templates/hovercard.tpl
@@ -43,7 +43,7 @@
 
 				</div>
 				<div class="hover-card-actions-connection">
-					{{if $profile.actions.network}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.network.1}}" aria-label="{{$profile.actions.network.0}}" title="{{$profile.actions.network.0}}"><i class="ri ri-{{($profile.contact_type==3) ? group-line : cloud-line}}" aria-hidden="true"></i></a>{{/if}}
+					{{if $profile.actions.network}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.network.1}}" aria-label="{{$profile.actions.network.0}}" title="{{$profile.actions.network.0}}"><i class="ri ri-{{($profile.contact_type==3) ? 'group-line' : 'cloud-line'}}" aria-hidden="true"></i></a>{{/if}}
 					{{if $profile.actions.edit}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.edit.1}}" aria-label="{{$profile.actions.edit.0}}" title="{{$profile.actions.edit.0}}"><i class="ri ri-user-line" aria-hidden="true"></i></a>{{/if}}
 					{{if $profile.actions.follow}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.follow.1}}" aria-label="{{$profile.actions.follow.0}}" title="{{$profile.actions.follow.0}}"><i class="ri ri-user-add-line" aria-hidden="true"></i></a>{{/if}}
 					{{if $profile.actions.unfollow}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.unfollow.1}}" aria-label="{{$profile.actions.unfollow.0}}" title="{{$profile.actions.unfollow.0}}"><i class="ri ri-user-unfollow-line" aria-hidden="true"></i></a>{{/if}}

--- a/view/templates/hovercard.tpl
+++ b/view/templates/hovercard.tpl
@@ -29,24 +29,24 @@
 				<div class="hover-card-actions-social">
 				{{if $profile.actions.pm}}
 					<a class="btn btn-labeled btn-primary btn-sm add-to-modal" href="{{$profile.actions.pm.1}}" title="{{$profile.actions.pm.0}}">
-						<i class="fa fa-envelope" aria-hidden="true"></i>
+						<i class="ri ri-mail-line" aria-hidden="true"></i>
 						<span class="sr-only">{{$profile.actions.pm.0}}</span>
 					</a>
 				{{/if}}
 
 				{{if $profile.addr && !$profile.self}}
 					<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.mention.1}}" title="{{$profile.actions.mention.0}}">
-						<i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+						<i class="ri ri-edit-box-line" aria-hidden="true"></i>
 						<span class="sr-only">{{$profile.actions.mention.0}}</span>
 					</a>
 				{{/if}}
 
 				</div>
 				<div class="hover-card-actions-connection">
-					{{if $profile.actions.network}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.network.1}}" aria-label="{{$profile.actions.network.0}}" title="{{$profile.actions.network.0}}"><i class="fa fa-{{($profile.contact_type==3) ? group : cloud}}" aria-hidden="true"></i></a>{{/if}}
-					{{if $profile.actions.edit}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.edit.1}}" aria-label="{{$profile.actions.edit.0}}" title="{{$profile.actions.edit.0}}"><i class="fa fa-user" aria-hidden="true"></i></a>{{/if}}
-					{{if $profile.actions.follow}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.follow.1}}" aria-label="{{$profile.actions.follow.0}}" title="{{$profile.actions.follow.0}}"><i class="fa fa-user-plus" aria-hidden="true"></i></a>{{/if}}
-					{{if $profile.actions.unfollow}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.unfollow.1}}" aria-label="{{$profile.actions.unfollow.0}}" title="{{$profile.actions.unfollow.0}}"><i class="fa fa-user-times" aria-hidden="true"></i></a>{{/if}}
+					{{if $profile.actions.network}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.network.1}}" aria-label="{{$profile.actions.network.0}}" title="{{$profile.actions.network.0}}"><i class="ri ri-{{($profile.contact_type==3) ? group-line : cloud-line}}" aria-hidden="true"></i></a>{{/if}}
+					{{if $profile.actions.edit}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.edit.1}}" aria-label="{{$profile.actions.edit.0}}" title="{{$profile.actions.edit.0}}"><i class="ri ri-user-line" aria-hidden="true"></i></a>{{/if}}
+					{{if $profile.actions.follow}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.follow.1}}" aria-label="{{$profile.actions.follow.0}}" title="{{$profile.actions.follow.0}}"><i class="ri ri-user-add-line" aria-hidden="true"></i></a>{{/if}}
+					{{if $profile.actions.unfollow}}<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.unfollow.1}}" aria-label="{{$profile.actions.unfollow.0}}" title="{{$profile.actions.unfollow.0}}"><i class="ri ri-user-unfollow-line" aria-hidden="true"></i></a>{{/if}}
 				</div>
 			</div>
 		</div>

--- a/view/templates/item/compose.tpl
+++ b/view/templates/item/compose.tpl
@@ -32,40 +32,40 @@
             <div class="comment-edit-bb-{{$id}} btn-toolbar clearfix" role="toolbar">
                 <div class="btn-group">
                     <button type="button" class="btn btn-default bb-img" aria-label="{{$l10n.edimg}}" title="{{$l10n.edimg}}" data-role="insert-formatting" data-bbcode="img" data-id="{{$id}}" tabindex="4">
-                        <i class="fa fa-picture-o"></i>
+                        <i class="ri ri-image-line"></i>
                     </button>
                     <button type="button" class="btn btn-default bb-attach" aria-label="{{$l10n.edattach}}" title="{{$l10n.edattach}}" ondragenter="return commentLinkDrop(event, {{$id}});" ondragover="return commentLinkDrop(event, {{$id}});" ondrop="commentLinkDropper(event);" onclick="commentGetLink({{$id}}, '{{$l10n.prompttext}}');" tabindex="5">
-                        <i class="fa fa-paperclip"></i>
+                        <i class="ri ri-attachment-2"></i>
                     </button>
                     <button type="button" id="button_emojipicker" class="btn btn-default emojis" aria-label="{{$l10n.edemojis}}" title="{{$l10n.edemojis}}" tabindex="6">
-                      <i class="fa fa-smile-o"></i>
+                      <i class="ri ri-emotion-line"></i>
                     </button>
                 </div>
 
                 <div class="pull-right">
                     <div class="btn-group">
                         <button type="button" class="btn btn-default bb-url" aria-label="{{$l10n.edurl}}" title="{{$l10n.edurl}}" onclick="insertFormatting('url',{{$id}});" tabindex="7">
-                            <i class="fa fa-link"></i>
+                            <i class="ri ri-link"></i>
                         </button>
                         <button type="button" class="btn btn-default underline" aria-label="{{$l10n.eduline}}" title="{{$l10n.eduline}}" onclick="insertFormatting('u',{{$id}});" tabindex="9">
-                            <i class="fa fa-underline"></i>
+                            <i class="ri ri-underline"></i>
                         </button>
                         <button type="button" class="btn btn-default italic" aria-label="{{$l10n.editalic}}" title="{{$l10n.editalic}}" onclick="insertFormatting('i',{{$id}});" tabindex="10">
-                            <i class="fa fa-italic"></i>
+                            <i class="ri ri-italic"></i>
                         </button>
                         <button type="button" class="btn btn-default bold" aria-label="{{$l10n.edbold}}" title="{{$l10n.edbold}}" onclick="insertFormatting('b',{{$id}});" tabindex="11">
-                            <i class="fa fa-bold"></i>
+                            <i class="ri ri-bold"></i>
                         </button>
                     </div>
                     <div class="btn-group">
                         <button type="button" class="btn btn-default quote" aria-label="{{$l10n.edquote}}" title="{{$l10n.edquote}}" onclick="insertFormatting('quote',{{$id}});" tabindex="12">
-                            <i class="fa fa-quote-left"></i>
+                            <i class="ri ri-double-quotes-l"></i>
                         </button>
                         <button type="button" class="btn btn-default bb-url" aria-label="{{$l10n.contentwarn}}" title="{{$l10n.contentwarn}}" onclick="insertFormatting('abstract',{{$id}});" tabindex="13">
-                            <i class="fa fa-eye"></i>
+                            <i class="ri ri-eye-line"></i>
                         </button>
                         <button type="button" class="btn btn-default code" aria-label="{{$l10n.edcode}}" title="{{$l10n.edcode}}" onclick="insertFormatting('code',{{$id}});" tabindex="14">
-                            <i class="fa fa-code"></i>
+                            <i class="ri ri-code-line"></i>
                         </button>
                     </div>
                 </div>
@@ -80,7 +80,7 @@
                 {{if $type == 'post'}}
                     <div id="compose-additional-settings-location">
                         <button type="button" name="permissions" class="btn btn-default" id="toggle-permissions" title="{{$l10n.toggle_permissions_tooltip}}" onclick="togglePermissions()" tabindex="5">
-                            <i class="fa fa-ellipsis-h"></i> {{$l10n.toggle_permissions}}
+                            <i class="ri ri-more-line"></i> {{$l10n.toggle_permissions}}
                         </button>
                         <input type="text" name="location" class="form-control" id="jot-location" value="{{$location}}" placeholder="{{$l10n.location_set}}" tabindex="6" />
                         <button type="button" class="btn btn-default" id="profile-location"
@@ -90,7 +90,7 @@
                             data-title-clear="{{$l10n.location_clear}}"
                             title="{{$l10n.location_set}}"
                             tabindex="7">
-                            <i class="fa fa-map-marker" aria-hidden="true"></i>
+                            <i class="ri ri-map-pin-line" aria-hidden="true"></i>
                         </button>
                     </div>
                 {{/if}}
@@ -100,9 +100,9 @@
                     </span>
                     <span role="presentation" id="character-counter" class="grey text-info"></span>
                     <button type="button" class="btn btn-default" onclick="preview_comment_toggle({{$id}}, '{{$l10n.preview}}');" id="comment-edit-preview-link-{{$id}}" tabindex="8">
-                        <i class="fa fa-eye"></i> <span id="preview-btn-text-{{$id}}">{{$l10n.preview}}</span>
+                        <i class="ri ri-eye-line"></i> <span id="preview-btn-text-{{$id}}">{{$l10n.preview}}</span>
                     </button>
-                    <button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="fa fa-paper-plane"></i> {{$l10n.submit}}</button>
+                    <button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="ri ri-send-plane-fill"></i> {{$l10n.submit}}</button>
                 </div>
             </div>
 

--- a/view/templates/item/compose.tpl
+++ b/view/templates/item/compose.tpl
@@ -102,7 +102,7 @@
                     <button type="button" class="btn btn-default" onclick="preview_comment_toggle({{$id}}, '{{$l10n.preview}}');" id="comment-edit-preview-link-{{$id}}" tabindex="8">
                         <i class="ri ri-eye-line"></i> <span id="preview-btn-text-{{$id}}">{{$l10n.preview}}</span>
                     </button>
-                    <button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="ri ri-send-plane-fill"></i> {{$l10n.submit}}</button>
+                    <button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="ri ri-send-plane-line"></i> {{$l10n.submit}}</button>
                 </div>
             </div>
 

--- a/view/templates/moderation/blocklist/server/add.tpl
+++ b/view/templates/moderation/blocklist/server/add.tpl
@@ -44,9 +44,9 @@
 					</td>
 					<th>{{$gserver.site_name|default:$gserver.domain}}</th>
 					<td>
-						<a href="{{$gserver.url}}" target="_blank" rel="noreferrer noopener">{{$gserver.domain}} <i class="fa fa-external-link"></i></a>
+						<a href="{{$gserver.url}}" target="_blank" rel="noreferrer noopener">{{$gserver.domain}} <i class="ri ri-external-link-line"></i></a>
 					</td>
-					<td class="text-right">{{$gserver.contacts}} <i class="fa fa-user"></i></td>
+					<td class="text-right">{{$gserver.contacts}} <i class="ri ri-user-line"></i></td>
 				</tr>
             {{/foreach}}
 			</tbody>

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -62,7 +62,7 @@
 		<ul id="nav-notifications-menu" class="menu-popup">
 			<li id="nav-notifications-see-all"><a href="{{$nav.notifications.all.0}}">{{$nav.notifications.all.1}}</a></li>
 			<li id="nav-notifications-mark-all"><a href="#" onclick="notificationMarkAll(); return false;">{{$nav.notifications.mark.3}}</a></li>
-			<li id="nav-notifications-loading" class="loading" style="font-weight: bold; color: #555; padding-left: 10px;"><i class="fa fa-spinner fa-spin" aria-hidden="true" style="vertical-align: middle;"></i> {{$loadingnotifications}}</li>
+			<li id="nav-notifications-loading" class="loading" style="font-weight: bold; color: #555; padding-left: 10px;"><i class="ri ri-loader-4-line ri-spin" aria-hidden="true" style="vertical-align: middle;"></i> {{$loadingnotifications}}</li>
 			<li id="nav-notifications-empty" class="empty" style="display: none; text-align: center;"><i>{{$emptynotifications}}</i></li>
 		</ul>
 	{{/if}}

--- a/view/templates/profile/profile.tpl
+++ b/view/templates/profile/profile.tpl
@@ -18,7 +18,7 @@
 		<ul class="nav nav-pills preferences">
 			<li>
 				<a class="btn btn-primary" type="button" id="profile-viewas-link" href="{{$viewas_link.url}}">
-					<i class="fa fa-eye" aria-hidden="true"></i>&nbsp;{{$viewas_link.label}}
+					<i class="ri ri-eye-line" aria-hidden="true"></i>&nbsp;{{$viewas_link.label}}
 				</a>
 			</li>
 		</ul>
@@ -91,7 +91,7 @@
 		<dt class="col-lg-4 col-md-4 col-sm-4 col-xs-12 profile-label-name text-muted">{{$basic_fields.pub_keywords.label}}</dt>
 		<dd class="col-lg-8 col-md-8 col-sm-8 col-xs-12 profile-entry">
             {{foreach $basic_fields.pub_keywords.value as $tag}}
-				<a href="{{$tag.url}}" class="tag label btn-info sm">{{$tag.label}} <i class="fa fa-bolt" aria-hidden="true"></i></a>
+				<a href="{{$tag.url}}" class="tag label btn-info sm">{{$tag.label}} <i class="ri ri-flashlight-line" aria-hidden="true"></i></a>
             {{/foreach}}
 		</dd>
 	</dl>

--- a/view/templates/settings/head.tpl
+++ b/view/templates/settings/head.tpl
@@ -210,8 +210,8 @@
 		top: 10px;
 	}
 		.sorter-mvup::before {
-			content: '\f106';
-			font-family: "ForkAwesome","FontAwesome";
+			content: '\ea78';
+			font-family: "remixicon";
 			font-size: 14px;
 			line-height: 24px;
 		}
@@ -219,8 +219,8 @@
 		bottom: 10px;
 	}
 		.sorter-mvdn::before {
-			content: '\f107';
-			font-family: "ForkAwesome","FontAwesome";
+			content: '\ea4e';
+			font-family: "remixicon";
 			font-size: 14px;
 			line-height: 24px;
 		}

--- a/view/templates/settings/removeme.tpl
+++ b/view/templates/settings/removeme.tpl
@@ -16,7 +16,7 @@
             {{include file="field_password.tpl" field=$password}}
 
 			<div class="form-group pull-right settings-submit-wrapper">
-				<button type="submit" name="submit" class="btn btn-primary" value="{{$l10n.title}}"><i class="fa fa-trash fa-fw"></i>&nbsp;{{$l10n.title}}</button>
+				<button type="submit" name="submit" class="btn btn-primary" value="{{$l10n.title}}"><i class="ri ri-delete-bin-line ri-fw"></i>&nbsp;{{$l10n.title}}</button>
 			</div>
 			<div class="clear"></div>
 		</form>

--- a/view/templates/settings/server/index.tpl
+++ b/view/templates/settings/server/index.tpl
@@ -23,12 +23,12 @@
 			<table class="table table-striped table-condensed table-bordered">
 				<tr>
 					<th>{{$l10n.siteName}}</th>
-					<th><span title="{{$l10n.ignored_title}}">{{$l10n.ignored}} <i class="fa fa-question-circle icon-question-sign"></i></span></th>
+					<th><span title="{{$l10n.ignored_title}}">{{$l10n.ignored}} <i class="ri ri-question-line icon-question-sign"></i></span></th>
 					<th>
 						<span title="{{$l10n.delete_title}}">
-							<i class="fa fa-trash icon-trash" aria-hidden="true" title="{{$l10n.delete}}"></i>
+							<i class="ri ri-delete-bin-line icon-trash" aria-hidden="true" title="{{$l10n.delete}}"></i>
 							<span class="sr-only">{{$l10n.delete}}</span>
-							<i class="fa fa-question-circle icon-question-sign"></i>
+							<i class="ri ri-question-line icon-question-sign"></i>
 						</span>
 					</th>
 				</tr>
@@ -36,7 +36,7 @@
 	{{foreach $servers as $index => $server}}
 				<tr>
 					<td>
-						<a href="{{$server->gserver->url}}">{{($server->gserver->siteName) ? $server->gserver->siteName : $server->gserver->url}} <i class="fa fa-external-link"></i></a>
+						<a href="{{$server->gserver->url}}">{{($server->gserver->siteName) ? $server->gserver->siteName : $server->gserver->url}} <i class="ri ri-external-link-line"></i></a>
 					</td>
 					<td>
 										{{include file="field_checkbox.tpl" field=$ignoredCheckboxes[$index]}}

--- a/view/templates/settings/twofactor/app_specific.tpl
+++ b/view/templates/settings/twofactor/app_specific.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div class="generic-page-wrapper">
-	<h1>{{$title}} <a href="help/user/two-factor-authentication" title="{{$help_label}}" class="btn btn-default btn-sm"><i aria-hidden="true" class="fa fa-question fa-2x"></i></a></h1>
+	<h1>{{$title}} <a href="help/user/two-factor-authentication" title="{{$help_label}}" class="btn btn-default btn-sm"><i aria-hidden="true" class="ri ri-question-line ri-2x"></i></a></h1>
 	<div>{{$message nofilter}}</div>
 
 {{if $generated_app_specific_password}}

--- a/view/templates/settings/twofactor/index.tpl
+++ b/view/templates/settings/twofactor/index.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div class="generic-page-wrapper">
-	<h1>{{$title}} <a href="help/user/two-factor-authentication" title="{{$help_label}}" class="btn btn-default btn-sm"><i aria-hidden="true" class="fa fa-question fa-2x"></i></a></h1>
+	<h1>{{$title}} <a href="help/user/two-factor-authentication" title="{{$help_label}}" class="btn btn-default btn-sm"><i aria-hidden="true" class="ri ri-question-line ri-2x"></i></a></h1>
 	<div>{{$message nofilter}}</div>
 	<h2>{{$status_title}}</h2>
 	<p><strong>{{$auth_app_label}}</strong>: {{$app_status}} </p>

--- a/view/templates/settings/twofactor/recovery.tpl
+++ b/view/templates/settings/twofactor/recovery.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div class="generic-page-wrapper">
-	<h1>{{$title}} <a href="help/user/two-factor-authentication" title="{{$help_label}}" class="btn btn-default btn-sm"><i aria-hidden="true" class="fa fa-question fa-2x"></i></a></h1>
+	<h1>{{$title}} <a href="help/user/two-factor-authentication" title="{{$help_label}}" class="btn btn-default btn-sm"><i aria-hidden="true" class="ri ri-question-line ri-2x"></i></a></h1>
 	<div>{{$message nofilter}}</div>
 
 	<ul class="recovery-codes">

--- a/view/templates/settings/twofactor/trusted_browsers.tpl
+++ b/view/templates/settings/twofactor/trusted_browsers.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div class="generic-page-wrapper">
-	<h1>{{$title}} <a href="help/user/two-factor-authentication" title="{{$help_label}}" class="btn btn-default btn-sm"><i aria-hidden="true" class="fa fa-question fa-2x"></i></a></h1>
+	<h1>{{$title}} <a href="help/user/two-factor-authentication" title="{{$help_label}}" class="btn btn-default btn-sm"><i aria-hidden="true" class="ri ri-question-line ri-2x"></i></a></h1>
 	<div>{{$message nofilter}}</div>
 
 	<form action="settings/2fa/trusted?t={{$password_security_token}}" method="post">

--- a/view/templates/settings/twofactor/verify.tpl
+++ b/view/templates/settings/twofactor/verify.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div class="generic-page-wrapper">
-	<h1>{{$title}} <a href="help/user/two-factor-authentication" title="{{$help_label}}" class="btn btn-default btn-sm"><i aria-hidden="true" class="fa fa-question fa-2x"></i></a></h1>
+	<h1>{{$title}} <a href="help/user/two-factor-authentication" title="{{$help_label}}" class="btn btn-default btn-sm"><i aria-hidden="true" class="ri ri-question-line ri-2x"></i></a></h1>
 	<div>{{$message nofilter}}</div>
 
 	<div class="text-center">

--- a/view/templates/widget/community_sharer.tpl
+++ b/view/templates/widget/community_sharer.tpl
@@ -8,7 +8,7 @@
 	<span id="sidebar-community-no-sharer-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('sidebar-community-no-sharer', 'sidebar-community-no-sharer-inflated');" aria-expanded="false">
 			<h3>
-				<i class="fa fa-user-o" aria-hidden="true"></i>
+				<i class="ri ri-user-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -16,7 +16,7 @@
 	<div id="sidebar-community-no-sharer" class="widget">
 		<button class="fakelink" onclick="openCloseWidget('sidebar-community-no-sharer', 'sidebar-community-no-sharer-inflated');" aria-expanded="true">
 			<h3>
-				<i class="fa fa-user-o" aria-hidden="true"></i>
+				<i class="ri ri-user-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>

--- a/view/templates/widget/events.tpl
+++ b/view/templates/widget/events.tpl
@@ -7,7 +7,7 @@
 
 <nav id="sidebar-calendar" class="widget">
   <h3>
-    <i class="fa fa-upload" aria-hidden="true"></i>
+    <i class="ri ri-upload-line" aria-hidden="true"></i>
     {{$etitle}}
   </h3>
 

--- a/view/templates/widget/filter.tpl
+++ b/view/templates/widget/filter.tpl
@@ -6,7 +6,7 @@
   *}}
 <nav>
 	{{if $type == "channel"}}
-		{{assign var="icon" value="ri-rss-line"}}
+		{{assign var="icon" value="ri-broadcast-line"}}
 	{{else if $type == "accounttype"}}
 		{{assign var="icon" value="ri-account-box-line"}}
 	{{else if $type == "rel"}}

--- a/view/templates/widget/filter.tpl
+++ b/view/templates/widget/filter.tpl
@@ -6,13 +6,15 @@
   *}}
 <nav>
 	{{if $type == "channel"}}
-		{{assign var="icon" value="ri-layout-grid-line"}}
+		{{assign var="icon" value="ri-rss-line"}}
 	{{else if $type == "accounttype"}}
-		{{assign var="icon" value="ri-umbrella-line"}}
+		{{assign var="icon" value="ri-account-box-line"}}
 	{{else if $type == "rel"}}
 		{{assign var="icon" value="ri-arrow-left-right-line"}}
 	{{else if $type == "circle"}}
-		{{assign var="icon" value="ri-account-circle-line"}}
+		{{assign var="icon" value="ri-user-community-line"}}
+	{{else if $type == "nets"}}
+		{{assign var="icon" value="ri-message-2-line"}}
 	{{else}} {{* fallback to type="file" *}}
 		{{assign var="icon" value="ri-folder-line"}}
 	{{/if}}

--- a/view/templates/widget/filter.tpl
+++ b/view/templates/widget/filter.tpl
@@ -6,20 +6,20 @@
   *}}
 <nav>
 	{{if $type == "channel"}}
-		{{assign var="icon" value="fa-th-large"}}
+		{{assign var="icon" value="ri-layout-grid-line"}}
 	{{else if $type == "accounttype"}}
-		{{assign var="icon" value="fa-umbrella"}}
+		{{assign var="icon" value="ri-umbrella-line"}}
 	{{else if $type == "rel"}}
-		{{assign var="icon" value="fa-exchange"}}
+		{{assign var="icon" value="ri-arrow-left-right-line"}}
 	{{else if $type == "circle"}}
-		{{assign var="icon" value="fa-user-circle"}}
+		{{assign var="icon" value="ri-account-circle-line"}}
 	{{else}} {{* fallback to type="file" *}}
-		{{assign var="icon" value="fa-folder"}}
+		{{assign var="icon" value="ri-folder-line"}}
 	{{/if}}
 	<span id="{{$type}}-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('{{$type}}-sidebar', '{{$type}}-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="fa {{$icon}}" aria-hidden="true"></i>
+				<i class="ri {{$icon}}" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -27,7 +27,7 @@
 	<div id="{{$type}}-sidebar" class="widget">
 		<button class="fakelink" onclick="openCloseWidget('{{$type}}-sidebar', '{{$type}}-sidebar-inflated');" aria-expanded="true">
 			<h3>
-				<i class="fa {{$icon}}" aria-hidden="true"></i>
+				<i class="ri {{$icon}}" aria-hidden="true"></i>
 			{{$title}}
 			</h3>
 		</button>

--- a/view/templates/widget/follow.tpl
+++ b/view/templates/widget/follow.tpl
@@ -7,7 +7,7 @@
 
 <nav id="follow-sidebar" class="widget">
   <h3>
-    <i class="fa fa-user-plus" aria-hidden="true"></i>
+    <i class="ri ri-user-add-line" aria-hidden="true"></i>
     {{$connect}}
   </h3>
   <div id="connect-desc">{{$desc nofilter}}</div>

--- a/view/templates/widget/group_list.tpl
+++ b/view/templates/widget/group_list.tpl
@@ -21,7 +21,7 @@
 		<button class="fakelink" onclick="openCloseWidget('group-list-sidebar', 'group-list-sidebar-inflated');"
 			aria-expanded="false">
 			<h3>
-				<i class="fa fa-users" aria-hidden="true"></i>
+				<i class="ri ri-team-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -30,18 +30,18 @@
 		<div id="sidebar-group-header" class="sidebar-widget-header">
 			<button class="fakelink" onclick="openCloseWidget('group-list-sidebar', 'group-list-sidebar-inflated');" aria-expanded="true">
 				<h3>
-					<i class="fa fa-users" aria-hidden="true"></i>
+					<i class="ri ri-team-line" aria-hidden="true"></i>
 					{{$title}}
 				</h3>
 			</button>
 			<a class="pull-right widget-action widget-action-top faded-icon" id="sidebar-new-group"
 				href="{{$new_group_page}}" data-toggle="tooltip" title="{{$create_new_group}}">
-				<i class="fa fa-plus" aria-hidden="true"></i>
+				<i class="ri ri-add-line" aria-hidden="true"></i>
 			</a>
 			{{if $addon_group_directory_enabled}}
 				<a class="pull-right widget-action widget-action-top faded-icon" id="sidebar-group-directory"
 					href="/groupdirectory" data-toggle="tooltip" title="{{$visit_groupdirectory}}">
-					<i class="fa fa-search" aria-hidden="true"></i>
+					<i class="ri ri-search-line" aria-hidden="true"></i>
 				</a>
 			{{/if}}
 		</div>

--- a/view/templates/widget/group_list.tpl
+++ b/view/templates/widget/group_list.tpl
@@ -21,7 +21,7 @@
 		<button class="fakelink" onclick="openCloseWidget('group-list-sidebar', 'group-list-sidebar-inflated');"
 			aria-expanded="false">
 			<h3>
-				<i class="ri ri-team-line" aria-hidden="true"></i>
+				<i class="ri ri-chat-thread-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -30,7 +30,7 @@
 		<div id="sidebar-group-header" class="sidebar-widget-header">
 			<button class="fakelink" onclick="openCloseWidget('group-list-sidebar', 'group-list-sidebar-inflated');" aria-expanded="true">
 				<h3>
-					<i class="ri ri-team-line" aria-hidden="true"></i>
+					<i class="ri ri-chat-thread-line" aria-hidden="true"></i>
 					{{$title}}
 				</h3>
 			</button>

--- a/view/templates/widget/peoplefind.tpl
+++ b/view/templates/widget/peoplefind.tpl
@@ -7,7 +7,7 @@
 
 <nav id="peoplefind-sidebar" class="widget">
 	<h3>
-		<i class="fa fa-search" aria-hidden="true"></i>
+		<i class="ri ri-search-line" aria-hidden="true"></i>
 		{{$nv.findpeople}}
 	</h3>
 	<div id="peoplefind-desc">{{$nv.desc}}</div>

--- a/view/templates/widget/posted_date.tpl
+++ b/view/templates/widget/posted_date.tpl
@@ -21,7 +21,7 @@
 	<span id="datebrowse-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('datebrowse-sidebar', 'datebrowse-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="fa fa-archive" aria-hidden="true"></i>
+				<i class="ri ri-archive-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -29,7 +29,7 @@
 	<div id="datebrowse-sidebar" class="widget">
 		<button class="fakelink" onclick="openCloseWidget('datebrowse-sidebar', 'datebrowse-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="fa fa-archive" aria-hidden="true"></i>
+				<i class="ri ri-archive-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>

--- a/view/templates/widget/saved_searches.tpl
+++ b/view/templates/widget/saved_searches.tpl
@@ -8,7 +8,7 @@
 	<span id="saved-search-list-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');" aria-expanded="false">
 			<h3>
-				<i class="fa fa-search" aria-hidden="true"></i>
+				<i class="ri ri-search-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -16,7 +16,7 @@
 	<div class="widget" id="saved-search-list">
 		<button class="fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');" aria-expanded="true">
 			<h3 id="search">
-				<i class="fa fa-search" aria-hidden="true"></i>
+				<i class="ri ri-search-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>

--- a/view/templates/widget/tagcloud.tpl
+++ b/view/templates/widget/tagcloud.tpl
@@ -8,7 +8,7 @@
 	<span id="tagblock-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('tagblock', 'tagblock-inflated');" aria-expanded="false">
 			<h3>
-					<i class="fa fa-tag" aria-hidden="true"></i>
+					<i class="ri ri-price-tag-3-line" aria-hidden="true"></i>
 					{{$title}}
 			</h3>
 		</button>
@@ -16,7 +16,7 @@
 	<div id="tagblock" class="tagblock widget">
 		<button class="fakelink" onclick="openCloseWidget('tagblock', 'tagblock-inflated');" aria-expanded="true">
 			<h3>
-					<i class="fa fa-tag" aria-hidden="true"></i>
+					<i class="ri ri-price-tag-3-line" aria-hidden="true"></i>
 					{{$title}}
 			</h3>
 		</button>

--- a/view/templates/widget/tagcloud.tpl
+++ b/view/templates/widget/tagcloud.tpl
@@ -8,7 +8,7 @@
 	<span id="tagblock-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('tagblock', 'tagblock-inflated');" aria-expanded="false">
 			<h3>
-					<i class="ri ri-price-tag-3-line" aria-hidden="true"></i>
+					<i class="ri ri-hashtag" aria-hidden="true"></i>
 					{{$title}}
 			</h3>
 		</button>
@@ -16,7 +16,7 @@
 	<div id="tagblock" class="tagblock widget">
 		<button class="fakelink" onclick="openCloseWidget('tagblock', 'tagblock-inflated');" aria-expanded="true">
 			<h3>
-					<i class="ri ri-price-tag-3-line" aria-hidden="true"></i>
+					<i class="ri ri-hashtag" aria-hidden="true"></i>
 					{{$title}}
 			</h3>
 		</button>

--- a/view/templates/widget/trending_tags.tpl
+++ b/view/templates/widget/trending_tags.tpl
@@ -8,7 +8,7 @@
 	<span id="trending-tags-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" style="display: flex; justify-content: space-between; width: 100%;" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="fa fa-tag" aria-hidden="true"></i>
+				<i class="ri ri-price-tag-3-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 			<small>{{$subtitle}}</small>
@@ -17,7 +17,7 @@
 	<div id="trending-tags-sidebar" class="widget">
 		<button class="fakelink" style="display: flex; justify-content: space-between; width: 100%;" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');">
 			<h3>
-					<i class="fa fa-tag" aria-hidden="true"></i>
+					<i class="ri ri-price-tag-3-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 			<small>{{$subtitle}}</small>
@@ -26,7 +26,7 @@
 			{{section name=ol loop=$tags max=10}}
 				<li style="margin-bottom: 5px;">
 					<a href="search?tag={{$tags[ol].term}}" style="text-decoration: none; color: inherit;">
-						<i class="fa fa-hashtag" aria-hidden="true"></i> {{$tags[ol].term}}
+						<i class="ri ri-hashtag" aria-hidden="true"></i> {{$tags[ol].term}}
 					</a>
 				</li>
 			{{/section}}
@@ -34,7 +34,7 @@
 		{{if $tags|count > 10}}
 			<div style="text-align: left; margin-top: 10px;">
 				<a href="#" onclick="toggleTags(event)" role="button" aria-expanded="false" aria-controls="more-tags" style="text-decoration: none; color: inherit; cursor: pointer; display: inline-flex; align-items: center; font-weight: bold;">
-					<i id="caret-icon" class="fa fa-caret-right" aria-hidden="true" style="margin-right: 5px;"></i>
+					<i id="caret-icon" class="ri ri-arrow-right-s-fill" aria-hidden="true" style="margin-right: 5px;"></i>
 					<span id="link-text">{{$showmore}}</span>
 				</a>
 			</div>
@@ -42,7 +42,7 @@
 				{{section name=ul loop=$tags start=10}}
 					<li style="margin-bottom: 5px;">
 						<a href="search?tag={{$tags[ul].term}}" style="text-decoration: none; color: inherit;">
-							<i class="fa fa-hashtag" aria-hidden="true"></i> {{$tags[ul].term}}
+							<i class="ri ri-hashtag" aria-hidden="true"></i> {{$tags[ul].term}}
 						</a>
 					</li>
 				{{/section}}
@@ -63,12 +63,12 @@
 			moreTags.style.display = 'block';
 			linkText.textContent = '{{$showless}}';
 			link.setAttribute('aria-expanded', 'true');
-			caretIcon.className = 'fa fa-caret-down';
+			caretIcon.className = 'ri ri-arrow-down-s-fill';
 		} else {
 			moreTags.style.display = 'none';
 			linkText.textContent = '{{$showmore}}';
 			link.setAttribute('aria-expanded', 'false');
-			caretIcon.className = 'fa fa-caret-right';
+			caretIcon.className = 'ri ri-arrow-right-s-fill';
 		}
 	}
 

--- a/view/templates/widget/trending_tags.tpl
+++ b/view/templates/widget/trending_tags.tpl
@@ -8,7 +8,7 @@
 	<span id="trending-tags-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" style="display: flex; justify-content: space-between; width: 100%;" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="ri ri-price-tag-3-line" aria-hidden="true"></i>
+				<i class="ri ri-hashtag" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 			<small>{{$subtitle}}</small>
@@ -17,7 +17,7 @@
 	<div id="trending-tags-sidebar" class="widget">
 		<button class="fakelink" style="display: flex; justify-content: space-between; width: 100%;" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');">
 			<h3>
-					<i class="ri ri-price-tag-3-line" aria-hidden="true"></i>
+					<i class="ri ri-hashtag" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 			<small>{{$subtitle}}</small>
@@ -34,7 +34,7 @@
 		{{if $tags|count > 10}}
 			<div style="text-align: left; margin-top: 10px;">
 				<a href="#" onclick="toggleTags(event)" role="button" aria-expanded="false" aria-controls="more-tags" style="text-decoration: none; color: inherit; cursor: pointer; display: inline-flex; align-items: center; font-weight: bold;">
-					<i id="caret-icon" class="ri ri-arrow-right-s-fill" aria-hidden="true" style="margin-right: 5px;"></i>
+				<i id="caret-icon" class="ri ri-arrow-right-s-line" aria-hidden="true" style="margin-right: 5px;"></i>
 					<span id="link-text">{{$showmore}}</span>
 				</a>
 			</div>
@@ -63,12 +63,12 @@
 			moreTags.style.display = 'block';
 			linkText.textContent = '{{$showless}}';
 			link.setAttribute('aria-expanded', 'true');
-			caretIcon.className = 'ri ri-arrow-down-s-fill';
-		} else {
-			moreTags.style.display = 'none';
-			linkText.textContent = '{{$showmore}}';
-			link.setAttribute('aria-expanded', 'false');
-			caretIcon.className = 'ri ri-arrow-right-s-fill';
+				caretIcon.className = 'ri ri-arrow-down-s-line';
+			} else {
+				moreTags.style.display = 'none';
+				linkText.textContent = '{{$showmore}}';
+				link.setAttribute('aria-expanded', 'false');
+				caretIcon.className = 'ri ri-arrow-right-s-line';
 		}
 	}
 

--- a/view/theme/frio/css/font-awesome.custom.css
+++ b/view/theme/frio/css/font-awesome.custom.css
@@ -6,11 +6,11 @@
 
 /*
 @file view/theme/frio/css/font-awesome.custom.css
-This file applies Font Awesome icons to some friendica standard classes
+This file applies Remix Icon glyphs to some friendica standard classes
 */
 
 .icon:before {
-	font-family: ForkAwesome;
+	font-family: remixicon;
 	font-weight: normal;
 	font-style: normal;
 	display: inline-block;
@@ -20,20 +20,20 @@ This file applies Font Awesome icons to some friendica standard classes
 }
 /* media icons */
 .icon.type-image:before {
-	content: "\f1c5";
+	content: "\ee4b";
 }
 .icon.type-video:before {
-	content: "\f1c8";
+	content: "\f282";
 }
 .icon.type-audio:before {
-	content: "\f1c7";
+	content: "\ef83";
 }
 .icon.type-text:before {
-	content: "\f0f6";
+	content: "\ed0f";
 }
 .icon.type-application:before {
-	content: "\f016";
+	content: "\eceb";
 }
 .icon.type-unkn:before {
-	content: "\f016";
+	content: "\eceb";
 }

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2598,7 +2598,7 @@ input[type="range"].form-control {
 }
 
 #search-box .ri-search-line {
-	font-size: 1.4em;
+	font-size: 1.1em;
 }
 
 /* Both desktop and mobile - multiple search fields */

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -950,7 +950,7 @@ nav.navbar .nav > li > button:focus {
 	top: 2px;
 }
 
-#search-mobile .form-button-search .fa {
+#search-mobile .form-button-search .ri {
 	font-size: 1.6em;
 }
 
@@ -1656,13 +1656,13 @@ textarea.comment-edit-text:focus + .comment-edit-form .preview {
 	overflow-y: overlay;
 }
 /* ACL */
-.fa.lock:before {
-	font-family: ForkAwesome;
-	content: "\f023";
+.ri.lock:before {
+	font-family: remixicon;
+	content: "\eece";
 }
-.fa.unlock:before {
-	font-family: ForkAwesome;
-	content: "\f09c";
+.ri.unlock:before {
+	font-family: remixicon;
+	content: "\eed2";
 }
 
 #acl-wrapper label.panel-heading {
@@ -1806,7 +1806,7 @@ textarea.comment-edit-text:focus + .comment-edit-form .preview {
 .fbrowser .profile-rotator-wrapper {
 	min-height: 200px;
 }
-.fbrowser .fa-spin {
+.fbrowser .ri-spin {
 	position: absolute;
 	left: 45%;
 	top: 40%;
@@ -2597,7 +2597,7 @@ input[type="range"].form-control {
 	width: 100%;
 }
 
-#search-box .fa-search {
+#search-box .ri-search-line {
 	font-size: 1.4em;
 }
 
@@ -2850,10 +2850,10 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 	font-size: 18px;
 }
 
-.contact-circle-actions .fa-times-circle {
+.contact-circle-actions .ri-close-circle-line {
 	color: #d00000;
 }
-.contact-circle-actions .fa-plus-circle {
+.contact-circle-actions .ri-add-circle-line {
 	color: #008000;
 }
 
@@ -3305,14 +3305,14 @@ ul li:hover .contact-wrapper .contact-action-link:hover {
 }
 details.profile-jot-net[open] summary:before,
 .panel .section-subtitle-wrapper .accordion-toggle:before {
-	font-family: ForkAwesome;
-	content: "\f0d7";
+	font-family: remixicon;
+	content: "\ea4e";
 	padding-right: 5px;
 }
 details.profile-jot-net summary:before,
 .panel .section-subtitle-wrapper .accordion-toggle.collapsed:before {
-	font-family: ForkAwesome;
-	content: "\f0da";
+	font-family: remixicon;
+	content: "\ea6e";
 }
 details.profile-jot-net summary:before {
 	padding-right: 5px;
@@ -3350,9 +3350,9 @@ details.profile-jot-net[open] summary:before {
 }
 
 #frio-accents input[type="radio"]:checked + label::before {
-	content: '\f00c';
+	content: '\eb7b';
 	color: white;
-	font-family: ForkAwesome;
+	font-family: remixicon;
 	font-weight: normal;
 	font-size: 18px;
 }
@@ -3426,15 +3426,15 @@ details.profile-jot-net[open] summary:before {
 	padding-right: 10px;
 }
 span.widget > .fakelink > h3:before {
-	font-family: ForkAwesome;
-	content: "\f0da"; /* Right Plain Pointer */
+	font-family: remixicon;
+	content: "\ea6e"; /* Right Pointer */
 	margin-left: 4px;
 }
 div.widget > .fakelink > h3:before,
 #sidebar-circle-header > .fakelink > h3:before,
 #sidebar-group-header > .fakelink > h3:before {
-	font-family: ForkAwesome;
-	content: "\f0d7"; /* Bottom Plain Pointer */
+	font-family: remixicon;
+	content: "\ea4e"; /* Down Pointer */
 }
 
 .widget button.fakelink {
@@ -3644,8 +3644,8 @@ li.addon {
 	transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
 }
 #adminpage li .icon.on:after {
-	font-family: "ForkAwesome";
-	content: "\f00c";
+	font-family: "remixicon";
+	content: "\eb7b";
 	display: inline-block;
 	position: absolute;
 	width: 16px;

--- a/view/theme/frio/frameworks/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.css
+++ b/view/theme/frio/frameworks/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.css
@@ -48,8 +48,8 @@
 }
 .checkbox input[type="checkbox"]:checked + label::after,
 .checkbox input[type="radio"]:checked + label::after {
-  font-family: "ForkAwesome";
-  content: "\f00c";
+  font-family: "remixicon";
+  content: "\eb7b";
 }
 .checkbox input[type="checkbox"]:indeterminate + label::after,
 .checkbox input[type="radio"]:indeterminate + label::after {
@@ -304,8 +304,8 @@
 
 input[type="checkbox"].styled:checked + label:after,
 input[type="radio"].styled:checked + label:after {
-  font-family: 'ForkAwesome';
-  content: "\f00c";
+  font-family: 'remixicon';
+  content: "\eb7b";
 }
 input[type="checkbox"] .styled:checked + label::before,
 input[type="radio"] .styled:checked + label::before {

--- a/view/theme/frio/frameworks/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.less
+++ b/view/theme/frio/frameworks/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.less
@@ -2,8 +2,8 @@
 // Checkboxes
 // --------------------------------------------------
 
-@font-family-icon: 'ForkAwesome';
-@fa-var-check: "\f00c";
+@font-family-icon: 'remixicon';
+@fa-var-check: "\eb7b";
 @check-icon: @fa-var-check;
 
 .checkbox-variant(@parent, @color) {

--- a/view/theme/frio/frameworks/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.scss
+++ b/view/theme/frio/frameworks/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.scss
@@ -3,8 +3,8 @@
 // --------------------------------------------------
 
 
-$font-family-icon: 'ForkAwesome' !default;
-$fa-var-check: "\f00c" !default;
+$font-family-icon: 'remixicon' !default;
+$fa-var-check: "\eb7b" !default;
 $check-icon: $fa-var-check !default;
 
 @mixin checkbox-variant($parent, $color) {

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -771,34 +771,34 @@ function doActivityItemAction(ident, verb, un) {
 	var thumbsClass = '';
 	switch (verb) {
 		case 'like':
-			thumbsClass = 'fa-thumbs-up';
+			thumbsClass = 'ri-thumb-up-line';
 			break;
 		case 'dislike':
-			thumbsClass = 'fa-thumbs-down';
+			thumbsClass = 'ri-thumb-down-line';
 			break;
 		case 'announce':
-			thumbsClass = 'fa-retweet';
+			thumbsClass = 'ri-repeat-line';
 			break;
 		case 'attendyes':
-			thumbsClass = 'fa-check';
+			thumbsClass = 'ri-check-line';
 			break;
 		case 'attendno':
-			thumbsClass = 'fa-times';
+			thumbsClass = 'ri-close-line';
 			break;
 		case 'attendmaybe':
-			thumbsClass = 'fa-question';
+			thumbsClass = 'ri-question-line';
 	}
 	if (verb.indexOf('announce') === 0 ) {
 		// Share-Button(s)
 		// remove share-symbol, to replace it by rotator
-		$('button[id^=shareMenuOptions-' + ident.toString() + '] i:first-child').removeClass('fa-share');
-		$('button[id^=announce-' + ident.toString() + '] i:first-child').removeClass('fa-retweet');
+		$('button[id^=shareMenuOptions-' + ident.toString() + '] i:first-child').removeClass('ri-share-forward-line');
+		$('button[id^=announce-' + ident.toString() + '] i:first-child').removeClass('ri-repeat-line');
 		// avoid multiple rotators on like/share-button if klicked multiple times.
 		if ($('img[id^=waitfor-' + verb + '-' + ident.toString() + ']').length == 0) {
 			// append rotator to the shareMenu-button for small media
 			$('<img>')
 				.attr({id: 'waitfor-' + verb + '-' + ident.toString(), src: 'images/rotator.gif'})
-				.addClass('fa')
+				.addClass('ri')
 				.appendTo($('button[id^=shareMenuOptions-' + ident.toString() + '] i:first-child' ));
 		}
 	}
@@ -807,7 +807,7 @@ function doActivityItemAction(ident, verb, un) {
 	if ($('button:not(button.dropdown-toggle) img#waitfor-' + verb + '-' + ident.toString()).length == 0) {
 		$('<img>')
 			.attr({id: 'waitfor-' + verb + '-' + ident.toString(), src: 'images/rotator.gif'})
-			.addClass('fa')
+			.addClass('ri')
 			.appendTo($('button[id^=' + verb + '-' + ident.toString() + '] i:first-child'));
 	}
 	$.post('item/' + ident.toString() + '/activity/' + _verb)
@@ -829,7 +829,7 @@ function doActivityItemAction(ident, verb, un) {
 				$('a[id^=' + verb + '-' + ident.toString() + ']' )
 					.removeClass('active')
 					.attr('href', 'javascript:doActivityItemAction(' + ident +', "' + verb + '")');
-				$('a[id^=' + verb + '-' + ident.toString() + '] i:first-child' ).addClass('fa-retweet').removeClass('fa-ban');
+				$('a[id^=' + verb + '-' + ident.toString() + '] i:first-child' ).addClass('ri-repeat-line').removeClass('ri-forbid-2-line');
 			} else {
 				// like/dislike buttons
 				$('button[id^=' + verb + '-' + ident.toString() + ']' )
@@ -839,12 +839,12 @@ function doActivityItemAction(ident, verb, un) {
 				$('a[id^=' + verb + '-' + ident.toString() + ']' )
 					.addClass('active')
 					.attr('href', 'javascript:doActivityItemAction(' + ident + ', "' + verb + '", true )');
-				$('a[id^=' + verb + '-' + ident.toString() + '] i:first-child' ).removeClass('fa-retweet').addClass('fa-ban');
+				$('a[id^=' + verb + '-' + ident.toString() + '] i:first-child' ).removeClass('ri-repeat-line').addClass('ri-forbid-2-line');
 			}
 			$('button[id^=' + verb + '-' + ident.toString() + '] i:first-child').addClass(thumbsClass);
 			if (verb.indexOf('announce') === 0 ) {
 				// ShareMenuButton
-				$('button[id^=shareMenuOptions-' + ident.toString() + '] i:first-child').addClass('fa-share');
+				$('button[id^=shareMenuOptions-' + ident.toString() + '] i:first-child').addClass('ri-share-forward-line');
 				if (data.verb == 'un' + verb) {
 					$('button[id^=shareMenuOptions-' + ident.toString() + ']').removeClass('active');
 				} else {
@@ -858,7 +858,7 @@ function doActivityItemAction(ident, verb, un) {
 			 * reset all buttons
 			 */
 			$('img[id^=waitfor-' + verb + '-' + ident.toString() + ']').remove();
-			$('button[id^=shareMenuOptions-' + ident.toString() + '] i:first-child').addClass('fa-share');
+			$('button[id^=shareMenuOptions-' + ident.toString() + '] i:first-child').addClass('ri-share-forward-line');
 			$('button[id^=' + verb + '-' + ident.toString() + '] i:first-child').addClass(thumbsClass);
 			$('a[id^=' + verb + '-' + ident.toString() + '] i:first-child').addClass(thumbsClass);
 			$.jGrowl(aActErr[verb] + '<br>(' + aErrType['srvErr'] + ')', {sticky: false, theme: 'info', life: 5000});
@@ -867,7 +867,7 @@ function doActivityItemAction(ident, verb, un) {
 	.error(function(data){
 		// Server could not be reached successfully
 		$('img[id^=waitfor-' + verb + '-' + ident.toString() + ']').remove();
-		$('button[id^=shareMenuOptions-' + ident.toString() + '] i:first-child').addClass('fa-share');
+		$('button[id^=shareMenuOptions-' + ident.toString() + '] i:first-child').addClass('ri-share-forward-line');
 		$('button[id^=' + verb + '-' + ident.toString() + '] i:first-child').addClass(thumbsClass);
 		$('a[id^=' + verb + '-' + ident.toString() + '] i:first-child').addClass(thumbsClass);
 		$.jGrowl(aActErr[verb] + '<br>(' + aErrType['netErr'] + ')', {sticky: false, theme: 'info', life: 5000});

--- a/view/theme/frio/templates/admin/logs/view.tpl
+++ b/view/theme/frio/templates/admin/logs/view.tpl
@@ -20,7 +20,7 @@
 						type="text" name="q"
 						placeholder="{{$l10n.Search}}" value="{{$q}}">
 					<button class="btn btn-lg btn-primary"
-						type="submit"><i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i></button>
+						type="submit"><i class="ri ri-search-line ri-fw ri-lg" aria-hidden="true"></i></button>
 						<a href="{{$baseurl}}/admin/logs/view" class="btn btn-default">{{$l10n.Show_all}}</a>
 				</div>
 			</div>

--- a/view/theme/frio/templates/calendar/calendar.tpl
+++ b/view/theme/frio/templates/calendar/calendar.tpl
@@ -12,7 +12,7 @@
 	{{if $new_event.0}}
 	<div class="pull-right" id="new-event-link">
 		<a class="btn btn-primary page-action" href="{{$new_event.0}}">
-			<i class="fa fa-plus"></i>
+			<i class="ri ri-add-line"></i>
 			<span>{{$new_event.1}}</span>
 		</a>
 	</div>
@@ -23,8 +23,8 @@
 
 		{{* The buttons to change the month/weeks/days *}}
 		<div id="fc-fc-header-left" class="btn-group">
-			<button class="btn btn-eventnav" onclick="changeView('prev', false);" title="{{$prev}}"><i class="fa fa-angle-up" aria-hidden="true"></i></button>
-			<button class="btn btn-eventnav btn-separator" onclick="changeView('next', false);" title="{{$next}}"><i class="fa fa-angle-down" aria-hidden="true"></i></button>
+			<button class="btn btn-eventnav" onclick="changeView('prev', false);" title="{{$prev}}"><i class="ri ri-arrow-up-s-line" aria-hidden="true"></i></button>
+			<button class="btn btn-eventnav btn-separator" onclick="changeView('next', false);" title="{{$next}}"><i class="ri ri-arrow-down-s-line" aria-hidden="true"></i></button>
 			<button class="btn btn-eventnav btn-separator" onclick="changeView('today', false);">{{$today}}</button>
 		</div>
 
@@ -36,7 +36,7 @@
 			<ul class="nav nav-pills">
 				<li class="dropdown pull-right">
 					<button class="btn btn-link dropdown-toggle" type="button" id="event-calendar-views" data-toggle="dropdown" aria-expanded="false">
-						<i class="fa fa-angle-down" aria-hidden="true"></i> {{$view}}
+						<i class="ri ri-arrow-down-s-line" aria-hidden="true"></i> {{$view}}
 					</button>
 					<ul class="dropdown-menu pull-right" role="menu" aria-labelledby="event-calendar-views">
 						<li>

--- a/view/theme/frio/templates/calendar/event.tpl
+++ b/view/theme/frio/templates/calendar/event.tpl
@@ -22,25 +22,25 @@
 		<div class="event-buttons">
 			{{if $event.edit}}
 				<a class="btn btn-primary" href="{{$event.edit.0}}">
-					<i class="fa fa-pencil" aria-hidden="true"></i>
+					<i class="ri ri-pencil-line" aria-hidden="true"></i>
 					{{$event.edit.1}}
 				</a>
 			{{/if}}
 			{{if $event.copy}}
 				<a class="btn btn-default" href="{{$event.copy.0}}">
-					<i class="fa fa-files-o" aria-hidden="true"></i>
+					<i class="ri ri-file-copy-line" aria-hidden="true"></i>
 					{{$event.copy.1}}
 				</a>
 				{{/if}}
 			{{if $event.drop}}
 				<a href="{{$event.drop.0}}" onclick="return confirmDelete();" class="drop-event-link btn btn-default">
-					<i class="fa fa-trash-o" aria-hidden="true"></i>
+					<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
 					{{$event.drop.1}}
 				</a>
 			{{/if}}
 			{{if $event.plink.orig}}
 				<a href="{{$event.plink.orig}}" class="plink-event-link btn btn-primary pull-right" aria-label="{{$event.plink.1}}">
-					<i class="fa fa-external-link" aria-hidden="true"></i>
+					<i class="ri ri-external-link-line" aria-hidden="true"></i>
 					{{$event.plink.orig_title}}
 				</a>
 			{{/if}}

--- a/view/theme/frio/templates/calendar/event_form.tpl
+++ b/view/theme/frio/templates/calendar/event_form.tpl
@@ -12,7 +12,7 @@
 
 		<div class="event-actions">
 			<a class="btn btn-primary photos-upload-link page-action" href="calendar">
-				<i class="fa fa-mail-reply"></i>
+				<i class="ri ri-reply-line"></i>
 				{{$back_text}}
 			</a>
 		</div>
@@ -86,31 +86,31 @@
 				<div id="event-desc-text-edit-bb" class="comment-edit-bb comment-icon-list">
 					<div class="btn-group">
 						<button type="button" class="btn btn-default icon bb-img" style="cursor: pointer;" title="{{$edimg}}" data-role="insert-formatting" data-comment=" " data-bbcode="img" data-id="desc">
-							<i class="fa fa-picture-o"></i>
+							<i class="ri ri-image-line"></i>
 						</button>
 						<button type="button" class="btn btn-default emojis" style="cursor: pointer;" aria-label="{{$edemojis}}" title="{{$edemojis}}">
-							<i class="fa fa-smile-o"></i>
+							<i class="ri ri-emotion-line"></i>
 						</button>
 					</div>
 
 					<div class="btn-group">
 						<button type="button" class="btn btn-default icon bb-url" style="cursor: pointer;" title="{{$edurl}}" data-role="insert-formatting" data-comment=" " data-bbcode="url" data-id="desc">
-							<i class="fa fa-link"></i>
+							<i class="ri ri-link"></i>
 						</button>
 						<button type="button" class="btn btn-default icon underline" style="cursor: pointer;" title="{{$eduline}}" data-role="insert-formatting" data-comment=" " data-bbcode="u" data-id="desc">
-							<i class="fa fa-underline"></i>
+							<i class="ri ri-underline"></i>
 						</button>
 						<button type="button" class="btn btn-default icon italic" style="cursor: pointer;" title="{{$editalic}}" data-role="insert-formatting" data-comment=" " data-bbcode="i" data-id="desc">
-							<i class="fa fa-italic"></i>
+							<i class="ri ri-italic"></i>
 						</button>
 						<button type="button" class="btn btn-default icon bold" style="cursor: pointer;"  title="{{$edbold}}" data-role="insert-formatting" data-comment=" " data-bbcode="b" data-id="desc">
-							<i class="fa fa-bold"></i>
+							<i class="ri ri-bold"></i>
 						</button>
 						<button type="button" class="btn btn-default icon quote" style="cursor: pointer;" title="{{$edquote}}" data-role="insert-formatting" data-comment=" " data-bbcode="quote" data-id="desc">
-							<i class="fa fa-quote-left"></i>
+							<i class="ri ri-double-quotes-l"></i>
 						</button>
 						<button type="button" class="btn btn-default icon code" style="cursor: pointer;" title="{{$edcode}}" data-role="insert-formatting" data-comment=" " data-bbcode="code" data-id="desc">
-							<i class="fa fa-code"></i>
+							<i class="ri ri-code-line"></i>
 						</button>
 					</div>
 				</div>

--- a/view/theme/frio/templates/circle_drop.tpl
+++ b/view/theme/frio/templates/circle_drop.tpl
@@ -7,5 +7,5 @@
 
 {{* Link for deleting contact circles *}}
 <a href="circle/drop/{{$id}}?t={{$form_security_token}}" onclick="return confirmDelete();" id="circle-delete-icon-{{$id}}" class="btn btn-clear" title="{{$delete}}" data-toggle="tooltip">
-	<i class="fa fa-trash" aria-hidden="true"></i>
+	<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
 </a>

--- a/view/theme/frio/templates/circle_edit.tpl
+++ b/view/theme/frio/templates/circle_edit.tpl
@@ -16,10 +16,10 @@
 	{{* The buttons for editing the contact circle (edit name / remove contact circle) *}}
 	<div class="circle-actions pull-right">
 		<button type="button" id="circle-rename" class="btn btn-clear" onclick="showHide('circle-edit-wrapper'); showHide('circle-edit-header'); return false;" title="{{$edit_name}}" data-toggle="tooltip">
-			<i class="fa fa-pencil" aria-hidden="true"></i>
+			<i class="ri ri-pencil-line" aria-hidden="true"></i>
 		</button>
 		<a href="circle/markread/{{$gid}}?t={{$form_security_token_markread}}" class="btn btn-clear" title="{{$markread_label}}" data-toggle="tooltip">
-			<i class="fa fa-eye" aria-hidden="true"></i>
+			<i class="ri ri-eye-line" aria-hidden="true"></i>
 		</a>
 		{{if $drop}}{{$drop nofilter}}{{/if}}
 	</div>
@@ -69,10 +69,10 @@
 	{{* The buttons to switch between the different view modes *}}
 	<div id="circle-list-view-switcher" class="btn-group btn-group-sm pull-right">
 		<button type="button" id="circle-list-big" class="active circle-list-switcher btn btn-default">
-			<i class="fa fa-align-justify" aria-hidden="true"></i>
+			<i class="ri ri-align-justify" aria-hidden="true"></i>
 		</button>
 		<button type="button" id="circle-list-small" class="btn btn-default circle-list-switcher">
-			<i class="fa fa-th-large" aria-hidden="true"></i>
+			<i class="ri ri-layout-grid-line" aria-hidden="true"></i>
 		</button>
 	</div>
 	<div class="clear"></div>

--- a/view/theme/frio/templates/circle_side.tpl
+++ b/view/theme/frio/templates/circle_side.tpl
@@ -8,7 +8,7 @@
 	<span id="circle-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="fa fa-user-circle" aria-hidden="true"></i>
+				<i class="ri ri-account-circle-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -17,18 +17,18 @@
 		<div id="sidebar-circle-header" class="sidebar-widget-header">
 			<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="true">
 				<h3>
-					<i class="fa fa-user-circle" aria-hidden="true"></i>
+					<i class="ri ri-account-circle-line" aria-hidden="true"></i>
 					{{$title}}
 				</h3>
 			</button>
 			{{if ! $new_circle}}
 				<a class="widget-action-top pull-right widget-action faded-icon" id="sidebar-edit-circle" href="{{$circle_page}}" data-toggle="tooltip" title="{{$edit_circles_text}}">
-					<i class="fa fa-pencil" aria-hidden="true"></i>
+					<i class="ri ri-pencil-line" aria-hidden="true"></i>
 				</a>
 			{{else}}
 				<a class="widget-action-top pull-right widget-action faded-icon" id="sidebar-new-circle"
 					onclick="javascript:$('#circle-new-form').fadeIn('fast');" data-toggle="tooltip" title="{{$createtext}}">
-					<i class="fa fa-plus" aria-hidden="true"></i>
+					<i class="ri ri-add-line" aria-hidden="true"></i>
 				</a>
 				<form id="circle-new-form" action="circle/new" method="post" style="display:none;">
 					<div class="form-group">
@@ -54,7 +54,7 @@
 						{{if $circle.edit}}
 							{{* if the circle is editable show a little pencil for editing *}}
 							<a id="edit-sidebar-circle-element-{{$circle.id}}" class="circle-edit-tool pull-right faded-icon" href="{{$circle.edit.href}}" data-toggle="tooltip" title="{{$edittext}}">
-								<i class="fa fa-pencil" aria-hidden="true"></i>
+								<i class="ri ri-pencil-line" aria-hidden="true"></i>
 							</a>
 						{{/if}}
 						<a id="sidebar-circle-element-{{$circle.id}}" class="sidebar-circle-element" href="{{$circle.href}}">{{$circle.text}}</a>

--- a/view/theme/frio/templates/circle_side.tpl
+++ b/view/theme/frio/templates/circle_side.tpl
@@ -8,7 +8,7 @@
 	<span id="circle-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="ri ri-user-community-line" aria-hidden="true"></i>
+				<i class="ri ri-group-3-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -17,7 +17,7 @@
 		<div id="sidebar-circle-header" class="sidebar-widget-header">
 			<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="true">
 				<h3>
-					<i class="ri ri-user-community-line" aria-hidden="true"></i>
+					<i class="ri ri-group-3-line" aria-hidden="true"></i>
 					{{$title}}
 				</h3>
 			</button>

--- a/view/theme/frio/templates/circle_side.tpl
+++ b/view/theme/frio/templates/circle_side.tpl
@@ -8,7 +8,7 @@
 	<span id="circle-sidebar-inflated" class="widget inflated fakelink">
 		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
 			<h3>
-				<i class="ri ri-account-circle-line" aria-hidden="true"></i>
+				<i class="ri ri-user-community-line" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
@@ -17,7 +17,7 @@
 		<div id="sidebar-circle-header" class="sidebar-widget-header">
 			<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="true">
 				<h3>
-					<i class="ri ri-account-circle-line" aria-hidden="true"></i>
+					<i class="ri ri-user-community-line" aria-hidden="true"></i>
 					{{$title}}
 				</h3>
 			</button>

--- a/view/theme/frio/templates/comment_item.tpl
+++ b/view/theme/frio/templates/comment_item.tpl
@@ -72,7 +72,7 @@
 {{if $preview}}
 			<button type="button" class="btn btn-default comment-edit-preview" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}"><i class="ri ri-eye-line"></i> {{$preview}}</button>
 {{/if}}
-			<button type="submit" class="btn btn-primary comment-edit-submit" id="comment-edit-submit-{{$id}}" name="submit" data-loading-text="{{$loading}}"><i class="ri ri-send-plane-fill"></i> {{$submit}}</button>
+			<button type="submit" class="btn btn-primary comment-edit-submit" id="comment-edit-submit-{{$id}}" name="submit" data-loading-text="{{$loading}}"><i class="ri ri-send-plane-line"></i> {{$submit}}</button>
 		</p>
 
 		<div class="comment-edit-end clear"></div>

--- a/view/theme/frio/templates/comment_item.tpl
+++ b/view/theme/frio/templates/comment_item.tpl
@@ -20,36 +20,36 @@
 		<p class="comment-edit-bb-{{$id}} comment-icon-list">
 			<span class="btn-group">
 				<button type="button" class="btn btn-default bb-img" style="cursor: pointer;" aria-label="{{$edimg}}" title="{{$edimg}}" data-role="insert-formatting" data-bbcode="img" data-id="{{$id}}">
-					<i class="fa fa-picture-o"></i>
+					<i class="ri ri-image-line"></i>
 				</button>
 				<button type="button" class="btn btn-default bb-attach" style="cursor: pointer;" aria-label="{{$edattach}}" title="{{$edattach}}" ondragenter="return commentLinkDrop(event, {{$id}});" ondragover="return commentLinkDrop(event, {{$id}});" ondrop="commentLinkDropper(event);" onclick="commentGetLink({{$id}}, '{{$prompttext}}');">
-					<i class="fa fa-paperclip"></i>
+					<i class="ri ri-attachment-2"></i>
 				</button>
 			</span>
 			<span class="btn-group">
 				<button type="button" class="btn btn-default bb-url" style="cursor: pointer;" aria-label="{{$edurl}}" title="{{$edurl}}" onclick="insertFormatting('url',{{$id}});">
-					<i class="fa fa-link"></i>
+					<i class="ri ri-link"></i>
 				</button>
 				<button type="button" class="btn btn-default underline" style="cursor: pointer;" aria-label="{{$eduline}}" title="{{$eduline}}" onclick="insertFormatting('u',{{$id}});">
-					<i class="fa fa-underline"></i>
+					<i class="ri ri-underline"></i>
 				</button>
 				<button type="button" class="btn btn-default italic" style="cursor: pointer;" aria-label="{{$editalic}}" title="{{$editalic}}" onclick="insertFormatting('i',{{$id}});">
-					<i class="fa fa-italic"></i>
+					<i class="ri ri-italic"></i>
 				</button>
 				<button type="button" class="btn btn-default bold" style="cursor: pointer;" aria-label="{{$edbold}}" title="{{$edbold}}" onclick="insertFormatting('b',{{$id}});">
-					<i class="fa fa-bold"></i>
+					<i class="ri ri-bold"></i>
 				</button>
 				<button type="button" class="btn btn-default quote" style="cursor: pointer;" aria-label="{{$edquote}}" title="{{$edquote}}" onclick="insertFormatting('quote',{{$id}});">
-					<i class="fa fa-quote-left"></i>
+					<i class="ri ri-double-quotes-l"></i>
 				</button>
 				<button type="button" class="btn btn-default emojis" style="cursor: pointer;" aria-label="{{$edemojis}}" title="{{$edemojis}}">
-					<i class="fa fa-smile-o"></i>
+					<i class="ri ri-emotion-line"></i>
 				</button>
 				<button type="button" class="btn btn-default eye" style="cursor: pointer;" aria-label="{{$contentwarn}}" title="{{$contentwarn}}" onclick="insertFormatting('abstract',{{$id}});">
-					<i class="fa fa-eye"></i>
+					<i class="ri ri-eye-line"></i>
 				</button>
 				<button type="button" class="btn btn-default code" style="cursor: pointer;" aria-label="{{$edcode}}" title="{{$edcode}}" onclick="insertFormatting('code',{{$id}});">
-					<i class="fa fa-code"></i>
+					<i class="ri ri-code-line"></i>
 				</button>
 			</span>
 			</p>
@@ -70,9 +70,9 @@
 {{/if}}
 		<p class="comment-edit-submit-wrapper">
 {{if $preview}}
-			<button type="button" class="btn btn-default comment-edit-preview" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}"><i class="fa fa-eye"></i> {{$preview}}</button>
+			<button type="button" class="btn btn-default comment-edit-preview" onclick="preview_comment({{$id}});" id="comment-edit-preview-link-{{$id}}"><i class="ri ri-eye-line"></i> {{$preview}}</button>
 {{/if}}
-			<button type="submit" class="btn btn-primary comment-edit-submit" id="comment-edit-submit-{{$id}}" name="submit" data-loading-text="{{$loading}}"><i class="fa fa-paper-plane"></i> {{$submit}}</button>
+			<button type="submit" class="btn btn-primary comment-edit-submit" id="comment-edit-submit-{{$id}}" name="submit" data-loading-text="{{$loading}}"><i class="ri ri-send-plane-fill"></i> {{$submit}}</button>
 		</p>
 
 		<div class="comment-edit-end clear"></div>

--- a/view/theme/frio/templates/common_tabs.tpl
+++ b/view/theme/frio/templates/common_tabs.tpl
@@ -28,7 +28,7 @@
 			<ul class="tabs tabs-extended" role="menu">
 				<li class="dropdown flex-target">
 					<button type="button" class="btn-link dropdown-toggle" id="dropdownMenuTools" data-toggle="dropdown" aria-expanded="false" title="{{$more}}">
-						<i class="fa fa-chevron-down" aria-hidden="true"></i>
+						<i class="ri ri-arrow-down-s-line" aria-hidden="true"></i>
 					</button>
 				</li>
 			</ul>
@@ -59,7 +59,7 @@
 			<ul class="tabs tabs-extended">
 				<li class="dropdown">
 					<button type="button" class="btn-link dropdown-toggle" id="dropdownMenuTools-xs" data-toggle="dropdown" aria-expanded="false" title="{{$more}}">
-						<i class="fa fa-chevron-down" aria-hidden="true"></i>
+						<i class="ri ri-arrow-down-s-line" aria-hidden="true"></i>
 					</button>
 					<ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenuTools">
 						{{foreach $exttabs as $tab}}

--- a/view/theme/frio/templates/contact/entry.tpl
+++ b/view/theme/frio/templates/contact/entry.tpl
@@ -25,7 +25,7 @@
 
 						{{* Overlay background on hover the avatar picture *}}
 						<div class="contact-photo-overlay">
-							<span class="contact-photo-overlay-content overlay-xs"><i class="fa fa-angle-down" aria-hidden="true"></i></span>
+							<span class="contact-photo-overlay-content overlay-xs"><i class="ri ri-arrow-down-s-line" aria-hidden="true"></i></span>
 						</div>
 					</div>
 				</button>
@@ -53,27 +53,27 @@
 			<div class="btn-group contact-actions pull-right nav-pills preferences hidden-xs" role="group">
 				{{if $contact.photo_menu.pm}}
 				<button type="button" class="contact-action-link btn btn-default" onclick="addToModal('{{$contact.photo_menu.pm.1}}'); return false;" data-toggle="tooltip" title="{{$contact.photo_menu.pm.0}}">
-					<i class="fa fa-envelope" aria-hidden="true"></i>
+					<i class="ri ri-mail-line" aria-hidden="true"></i>
 				</button>
 				{{/if}}
 				{{if $contact.photo_menu.network}}
 				<a class="contact-action-link btn btn-default" href="{{$contact.photo_menu.network.1}}" data-toggle="tooltip" title="{{$contact.photo_menu.network.0}}">
-					<i class="fa fa-cloud" aria-hidden="true"></i>
+					<i class="ri ri-cloud-line" aria-hidden="true"></i>
 				</a>
 				{{/if}}
 				{{if $contact.photo_menu.follow}}
 				<a class="contact-action-link btn btn-default" href="{{$contact.photo_menu.follow.1}}" data-toggle="tooltip" title="{{$contact.photo_menu.follow.0}}">
-					<i class="fa fa-user-plus" aria-hidden="true"></i>
+					<i class="ri ri-user-add-line" aria-hidden="true"></i>
 				</a>
 				{{/if}}
 				{{if $contact.photo_menu.unfollow}}
 				<a class="contact-action-link btn btn-default" href="{{$contact.photo_menu.unfollow.1}}" data-toggle="tooltip" title="{{$contact.photo_menu.unfollow.0}}">
-					<i class="fa fa-user-times" aria-hidden="true"></i>
+					<i class="ri ri-user-unfollow-line" aria-hidden="true"></i>
 				</a>
 				{{/if}}
 				{{if $contact.photo_menu.hide}}
 				<a class="contact-action-link btn btn-default" href="{{$contact.photo_menu.hide.1}}" data-toggle="tooltip" title="{{$contact.photo_menu.hide.0}}">
-					<i class="fa fa-times" aria-hidden="true"></i>
+					<i class="ri ri-close-line" aria-hidden="true"></i>
 				</a>
 				{{/if}}
 			</div>
@@ -84,9 +84,9 @@
 			<div class="contact-group-actions pull-right nav-pills preferences">
 				<button type="button" class="contact-action-link btn contact-group-link btn-default contact-circle-actions contact-circle-link" onclick="circleChangeMember({{$contact.change_member.gid}},{{$contact.change_member.cid}},'{{$contact.change_member.sec_token}}'); return true;" data-toggle="tooltip" title="{{$contact.change_member.title}}">
 					{{if $contact.label == "members"}}
-					<i class="fa fa-times-circle" aria-hidden="true"></i>
+					<i class="ri ri-close-circle-line" aria-hidden="true"></i>
 					{{elseif $contact.label == "contacts"}}
-					<i class="fa fa-plus-circle" aria-hidden="true"></i>
+					<i class="ri ri-add-circle-line" aria-hidden="true"></i>
 					{{/if}}
 				</button>
 			</div>
@@ -97,7 +97,7 @@
 				<div class="contact-entry-name" id="contact-entry-name-{{$contact.id}}">
 					<h4 class="media-heading"><a href="{{if !empty($contact.photo_menu.edit)}}{{$contact.photo_menu.edit.1}}{{else}}{{$contact.url}}{{/if}}">{{$contact.name}}</a>
 					{{if $contact.account_type}} <small class="contact-entry-details" id="contact-entry-accounttype-{{$contact.id}}">({{$contact.account_type}})</small>{{/if}}
-					{{if $contact.account_type == 'Group'}}<i class="fa fa-comments-o" aria-hidden="true"></i>{{/if}}
+					{{if $contact.account_type == 'Group'}}<i class="ri ri-chat-3-line" aria-hidden="true"></i>{{/if}}
 					{{* @todo this needs some changing in core because $contact.account_type contains a translated string which may not be the same in every language *}}
 					</h4>
 				</div>

--- a/view/theme/frio/templates/contact_edit.tpl
+++ b/view/theme/frio/templates/contact_edit.tpl
@@ -21,7 +21,7 @@
 				<ul id="contact-edit-actions" class="nav nav-pills preferences">
 					<li class="dropdown pull-right">
 						<button type="button" class="btn btn-link dropdown-toggle" id="contact-edit-actions-button" data-toggle="dropdown" aria-expanded="false">
-							<i class="fa fa-angle-down" aria-hidden="true"></i>&nbsp;{{$contact_action_button}}
+							<i class="ri ri-arrow-down-s-line" aria-hidden="true"></i>&nbsp;{{$contact_action_button}}
 						</button>
 
 						<ul class="dropdown-menu pull-right" role="menu" aria-labelledby="contact-edit-actions-button" aria-haspopup="true" id="contact-actions-menu">

--- a/view/theme/frio/templates/contacts-template.tpl
+++ b/view/theme/frio/templates/contacts-template.tpl
@@ -42,7 +42,7 @@
 		<ul class="nav nav-pills preferences">
 			<li class="dropdown pull-right">
 				<button type="button" class="btn btn-link dropdown-toggle" id="BatchActionDropdownMenuTools" data-toggle="dropdown" aria-expanded="false">
-					<i class="fa fa-angle-down"></i>&nbsp;{{$h_batch_actions}}
+					<i class="ri ri-arrow-down-s-line"></i>&nbsp;{{$h_batch_actions}}
 				</button>
 				<ul class="dropdown-menu pull-right" role="menu" aria-labelledby="BatchActionDropdownMenuTools">
 				{{foreach $batch_actions as $n=>$l}}

--- a/view/theme/frio/templates/field_fileinput.tpl
+++ b/view/theme/frio/templates/field_fileinput.tpl
@@ -8,7 +8,7 @@
 	<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
 	<div class="input-group" id="{{$field.0}}">
 		<input class="form-control file" name="{{$field.0}}" id="id_{{$field.0}}" type="text" value="{{$field.2}}" {{if $field.4}}required{{/if}} aria-describedby="{{$field.0}}_tip">
-		<span class="input-group-addon image-select"><i class="fa fa-picture-o"></i></span>
+		<span class="input-group-addon image-select"><i class="ri ri-image-line"></i></span>
 	</div>
 	{{if $field.3}}
 	<span class="help-block" id="{{$field.0}}_tip" role="tooltip">{{$field.3 nofilter}}</span>

--- a/view/theme/frio/templates/field_textarea.tpl
+++ b/view/theme/frio/templates/field_textarea.tpl
@@ -13,31 +13,31 @@
 		<div class="comment-icon-list">
 			<div class="btn-group">
 				<button type="button" class="btn btn-default icon bb-img" style="cursor: pointer;" title="{{$field.7.edimg}}" data-role="insert-formatting" data-comment=" " data-bbcode="img" data-id="id_{{$field.0}}">
-					<i class="fa fa-picture-o"></i>
+					<i class="ri ri-image-line"></i>
 				</button>
 				<button type="button" class="btn btn-default emojis" style="cursor: pointer;" aria-label="{{$field.7.edemojis}}" title="{{$edemojis}}">
-					<i class="fa fa-smile-o"></i>
+					<i class="ri ri-emotion-line"></i>
 				</button>
 			</div>
 
 			<div class="btn-group">
 				<button type="button" class="btn btn-default icon bb-url" style="cursor: pointer;" title="{{$field.7.edurl}}" data-role="insert-formatting" data-comment=" " data-bbcode="url" data-id="id_{{$field.0}}">
-					<i class="fa fa-link"></i>
+					<i class="ri ri-link"></i>
 				</button>
 				<button type="button" class="btn btn-default icon underline" style="cursor: pointer;" title="{{$field.7.eduline}}" data-role="insert-formatting" data-comment=" " data-bbcode="u" data-id="id_{{$field.0}}">
-					<i class="fa fa-underline"></i>
+					<i class="ri ri-underline"></i>
 				</button>
 				<button type="button" class="btn btn-default icon italic" style="cursor: pointer;" title="{{$field.7.editalic}}" data-role="insert-formatting" data-comment=" " data-bbcode="i" data-id="id_{{$field.0}}">
-					<i class="fa fa-italic"></i>
+					<i class="ri ri-italic"></i>
 				</button>
 				<button type="button" class="btn btn-default icon bold" style="cursor: pointer;"  title="{{$field.7.edbold}}" data-role="insert-formatting" data-comment=" " data-bbcode="b" data-id="id_{{$field.0}}">
-					<i class="fa fa-bold"></i>
+					<i class="ri ri-bold"></i>
 				</button>
 				<button type="button" class="btn btn-default icon quote" style="cursor: pointer;" title="{{$field.7.edquote}}" data-role="insert-formatting" data-comment=" " data-bbcode="quote" data-id="id_{{$field.0}}">
-					<i class="fa fa-quote-left"></i>
+					<i class="ri ri-double-quotes-l"></i>
 				</button>
 				<button type="button" class="btn btn-default icon code" style="cursor: pointer;" title="{{$field.7.edcode}}" data-role="insert-formatting" data-comment=" " data-bbcode="code" data-id="id_{{$field.0}}">
-					<i class="fa fa-code"></i>
+					<i class="ri ri-code-line"></i>
 				</button>
 			</div>
 		</div>

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -29,7 +29,7 @@
 <link rel="stylesheet"
 	href="view/theme/frio/frameworks/bootstrap/css/bootstrap-theme.min.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
-<link rel="stylesheet" href="view/asset/fork-awesome/css/fork-awesome.min.css?v={{$VERSION}}"
+<link rel="stylesheet" href="view/asset/remixicon/fonts/remixicon.css?v={{$VERSION}}"
 	type="text/css" media="screen" />
 <link rel="stylesheet"
 	href="view/theme/frio/frameworks/jasny/css/jasny-bootstrap.min.css?v={{$VERSION}}"

--- a/view/theme/frio/templates/jot-header.tpl
+++ b/view/theme/frio/templates/jot-header.tpl
@@ -229,7 +229,7 @@
 			const ItemsToDelete = {};
 
 			$('#item-delete-selected').prop('disabled', true);
-			$('#item-delete-selected i').toggleClass('fa-trash fa-hourglass fa-spin');
+			$('#item-delete-selected i').toggleClass('ri-delete-bin-line ri-hourglass-line ri-spin');
 
 			$('.item-select').each(function () {
 				if ($(this).is(':checked')) {
@@ -258,7 +258,7 @@
 					$(ItemsToDelete[key]).remove();
 				}
 
-				$('#item-delete-selected i').toggleClass('fa-trash fa-hourglass fa-spin')
+				$('#item-delete-selected i').toggleClass('ri-delete-bin-line ri-hourglass-line ri-spin')
 				$('#item-delete-selected').prop('disabled', false).hide();
 			});
 		}

--- a/view/theme/frio/templates/jot.tpl
+++ b/view/theme/frio/templates/jot.tpl
@@ -135,7 +135,7 @@
 
 						<li class="pull-right">
 							<button class="btn btn-primary" type="submit" id="profile-jot-submit" name="submit" data-loading-text="{{$loading}}">
-								<i class="ri ri-send-plane-fill ri-fw" aria-hidden="true"></i> {{$share}}
+							<i class="ri ri-send-plane-line ri-fw" aria-hidden="true"></i> {{$share}}
 							</button>
 						</li>
 						<li id="character-counter" class="grey jothidden text-info pull-right"></li>
@@ -162,7 +162,7 @@
 					<ul id="profile-jot-preview-submit-wrapper" class="jothidden nav nav-pills">
 						<li class="pull-right">
 							<button class="btn btn-primary" type="submit" id="profile-jot-preview-submit" name="submit" data-loading-text="{{$loading}}">
-								<i class="ri ri-send-plane-fill ri-fw" aria-hidden="true"></i> {{$share}}
+							<i class="ri ri-send-plane-line ri-fw" aria-hidden="true"></i> {{$share}}
 							</button>
 						</li>
 					</ul>

--- a/view/theme/frio/templates/jot.tpl
+++ b/view/theme/frio/templates/jot.tpl
@@ -6,7 +6,7 @@
   *}}
 {{* The button to open the jot - in This theme we move the button with js to the second nav bar *}}
 <a class="action-button btn btn-primary pull-right{{if !$always_open_compose}} modal-open{{/if}}" id="jotOpen" href="compose/{{$posttype}}{{if $content}}?body={{$content}}{{/if}}">
-	<i class="fa fa-lg fa-pencil"></i>
+	<i class="ri ri-lg ri-pencil-line"></i>
 	<span>{{$new_post}}</span>
 </a>
 
@@ -16,7 +16,7 @@
 			<button type="button" class="close" data-dismiss="modal" aria-label="Close" style="float: right;">&times;</button>
 
 			<a href="/compose" class="btn btn-secondary compose-link" title="{{$compose_link_title}}" aria-label="{{$compose_link_title}}">
-				<i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+				<i class="ri ri-edit-box-line" aria-hidden="true"></i>
 			</a>
 
 			{{* The Jot navigation menu for desktop user (text input, permissions, preview, filebrowser) *}}
@@ -25,28 +25,28 @@
 					the modal. Changing of the activity status is done by js in jot.tpl-header *}}
 				<li class="active">
 					<a href="#profile-jot-wrapper" class="jot-text-lnk jot-nav-lnk" id="jot-text-lnk" role="tab" aria-controls="profile-jot-wrapper">
-						<i class="fa fa-file-text-o" aria-hidden="true"></i>
+						<i class="ri ri-file-text-line" aria-hidden="true"></i>
 						{{$message}}
 					</a>
 				</li>
 				{{if $preview}}
 				<li>
 					<a href="#jot-preview-content" class="jot-preview-lnk jot-nav-lnk" id="jot-preview-lnk" role="tab" aria-controls="jot-preview-content">
-						<i class="fa fa-eye" aria-hidden="true"></i>
+						<i class="ri ri-eye-line" aria-hidden="true"></i>
 						{{$preview}}
 					</a>
 				</li>
 				{{/if}}
 				<li>
 					<a href="#jot-fbrowser-wrapper" class="jot-browser-lnk jot-nav-lnk" id="jot-browser-link" role="tab" aria-controls="jot-fbrowser-wrapper">
-						<i class="fa fa-picture-o" aria-hidden="true"></i>
+						<i class="ri ri-image-line" aria-hidden="true"></i>
 						{{$browser}}
 					</a>
 				</li>
 				{{if $acl}}
 				<li>
 					<a href="#profile-jot-acl-wrapper" class="jot-perms-lnk jot-nav-lnk" id="jot-perms-lnk" role="tab" aria-controls="profile-jot-acl-wrapper">
-						<i class="fa fa-shield" aria-hidden="true"></i>
+						<i class="ri ri-shield-line" aria-hidden="true"></i>
 						{{$shortpermset}}
 					</a>
 				</li>
@@ -118,24 +118,24 @@
 					</div>
 
 					<ul id="profile-jot-submit-wrapper" class="jothidden nav nav-pills">
-						<li><button type="button" class="btn-link" id="profile-attach"  ondragenter="return linkDropper(event);" ondragover="return linkDropper(event);" ondrop="linkDrop(event);" onclick="jotGetLink();" title="{{$edattach}}"><i class="fa fa-paperclip"></i></button></li>
-						<li><button type="button" class="hidden-xs btn-link icon emojis" style="cursor: pointer;" aria-label="{{$edemojis}}" title="{{$edemojis}}"><i class="fa fa-smile-o"></i></button></li>
+						<li><button type="button" class="btn-link" id="profile-attach"  ondragenter="return linkDropper(event);" ondragover="return linkDropper(event);" ondrop="linkDrop(event);" onclick="jotGetLink();" title="{{$edattach}}"><i class="ri ri-attachment-2"></i></button></li>
+						<li><button type="button" class="hidden-xs btn-link icon emojis" style="cursor: pointer;" aria-label="{{$edemojis}}" title="{{$edemojis}}"><i class="ri ri-emotion-line"></i></button></li>
 
-						<li><button type="button" class="btn-link icon" style="cursor: pointer;" aria-label="{{$edurl}}" title="{{$edurl}}" onclick="insertFormattingToPost('url');"><i class="fa fa-link"></i></button></li>
-						<li><button type="button" class="hidden-xs btn-link icon underline" style="cursor: pointer;" aria-label="{{$eduline}}" title="{{$eduline}}" onclick="insertFormattingToPost('u');"><i class="fa fa-underline"></i></button></li>
-						<li><button type="button" class="hidden-xs btn-link icon italic" style="cursor: pointer;" aria-label="{{$editalic}}" title="{{$editalic}}" onclick="insertFormattingToPost('i');"><i class="fa fa-italic"></i></button></li>
-						<li><button type="button" class="hidden-xs btn-link icon bold" style="cursor: pointer;" aria-label="{{$edbold}}" title="{{$edbold}}" onclick="insertFormattingToPost('b');"><i class="fa fa-bold"></i></button></li>
-						<li><button type="button" class="hidden-xs btn-link icon quote" style="cursor: pointer;" aria-label="{{$edquote}}" title="{{$edquote}}" onclick="insertFormattingToPost('quote');"><i class="fa fa-quote-left"></i></button></li>
-						<li><button type="button" class="btn-link" id="profile-location" onclick="jotGetLocation();" title="{{$setloc}}"><i class="fa fa-map-marker" aria-hidden="true"></i></button></li>
-						<li><button type="button" class="hidden-xs btn-link icon underline" style="cursor: pointer;" aria-label="{{$contentwarn}}" title="{{$contentwarn}}" onclick="insertFormattingToPost('abstract');"><i class="fa fa-eye"></i></button></li>
-						<li><button type="button" class="hidden-xs btn-link" style="cursor: pointer;" aria-label="{{$edcode}}" title="{{$edcode}}" onclick="insertFormattingToPost('code');"><i class="fa fa-code"></i></button></li>
+						<li><button type="button" class="btn-link icon" style="cursor: pointer;" aria-label="{{$edurl}}" title="{{$edurl}}" onclick="insertFormattingToPost('url');"><i class="ri ri-link"></i></button></li>
+						<li><button type="button" class="hidden-xs btn-link icon underline" style="cursor: pointer;" aria-label="{{$eduline}}" title="{{$eduline}}" onclick="insertFormattingToPost('u');"><i class="ri ri-underline"></i></button></li>
+						<li><button type="button" class="hidden-xs btn-link icon italic" style="cursor: pointer;" aria-label="{{$editalic}}" title="{{$editalic}}" onclick="insertFormattingToPost('i');"><i class="ri ri-italic"></i></button></li>
+						<li><button type="button" class="hidden-xs btn-link icon bold" style="cursor: pointer;" aria-label="{{$edbold}}" title="{{$edbold}}" onclick="insertFormattingToPost('b');"><i class="ri ri-bold"></i></button></li>
+						<li><button type="button" class="hidden-xs btn-link icon quote" style="cursor: pointer;" aria-label="{{$edquote}}" title="{{$edquote}}" onclick="insertFormattingToPost('quote');"><i class="ri ri-double-quotes-l"></i></button></li>
+						<li><button type="button" class="btn-link" id="profile-location" onclick="jotGetLocation();" title="{{$setloc}}"><i class="ri ri-map-pin-line" aria-hidden="true"></i></button></li>
+						<li><button type="button" class="hidden-xs btn-link icon underline" style="cursor: pointer;" aria-label="{{$contentwarn}}" title="{{$contentwarn}}" onclick="insertFormattingToPost('abstract');"><i class="ri ri-eye-line"></i></button></li>
+						<li><button type="button" class="hidden-xs btn-link" style="cursor: pointer;" aria-label="{{$edcode}}" title="{{$edcode}}" onclick="insertFormattingToPost('code');"><i class="ri ri-code-line"></i></button></li>
 						<!-- TODO: waiting for a better placement
 						<li><button type="button" class="btn-link" id="profile-nolocation" onclick="jotClearLocation();" title="{{$noloc}}">{{$shortnoloc}}</button></li>
 						-->
 
 						<li class="pull-right">
 							<button class="btn btn-primary" type="submit" id="profile-jot-submit" name="submit" data-loading-text="{{$loading}}">
-								<i class="fa fa-paper-plane fa-fw" aria-hidden="true"></i> {{$share}}
+								<i class="ri ri-send-plane-fill ri-fw" aria-hidden="true"></i> {{$share}}
 							</button>
 						</li>
 						<li id="character-counter" class="grey jothidden text-info pull-right"></li>
@@ -162,7 +162,7 @@
 					<ul id="profile-jot-preview-submit-wrapper" class="jothidden nav nav-pills">
 						<li class="pull-right">
 							<button class="btn btn-primary" type="submit" id="profile-jot-preview-submit" name="submit" data-loading-text="{{$loading}}">
-								<i class="fa fa-paper-plane fa-fw" aria-hidden="true"></i> {{$share}}
+								<i class="ri ri-send-plane-fill ri-fw" aria-hidden="true"></i> {{$share}}
 							</button>
 						</li>
 					</ul>

--- a/view/theme/frio/templates/like_noshare.tpl
+++ b/view/theme/frio/templates/like_noshare.tpl
@@ -10,7 +10,7 @@
 	        class="btn btn-default button-likes{{if $responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$id}}"
 	        title="{{$like_title}}"
 	        onclick="doActivityItemAction({{$id}}, 'like'{{if $responses.like.self}}, true{{/if}});">
-		<i class="fa fa-thumbs-up" aria-hidden="true"></i>&nbsp;{{$like}}
+		<i class="ri ri-thumb-up-line" aria-hidden="true"></i>&nbsp;{{$like}}
 	</button>
 	{{if !$hide_dislike}}
 	<button type="button"
@@ -18,7 +18,7 @@
 	        id="dislike-{{$id}}"
 	        title="{{$dislike_title}}"
 	        onclick="doActivityItemAction({{$id}}, 'dislike'{{if $responses.dislike.self}}, true{{/if}});">
-                <i class="fa fa-thumbs-down" aria-hidden="true"></i>&nbsp;{{$dislike}}
+                <i class="ri ri-thumb-down-line" aria-hidden="true"></i>&nbsp;{{$dislike}}
 	</button>
 	{{/if}}
 </div>

--- a/view/theme/frio/templates/mail_head.tpl
+++ b/view/theme/frio/templates/mail_head.tpl
@@ -12,12 +12,12 @@
 <div id="message-new" class="pull-right">
 	{{if $button.sel == "new"}}
 	<a href="{{$button.url}}" accesskey="m" class="btn btn-primary newmessage-selected page-action" data-toggle="tooltip">
-		<i class="fa fa-plus"></i>
+		<i class="ri ri-add-line"></i>
 		<span>{{$button.label}}</span>
 	</a>
 	{{else}}
 	<a href="{{$button.url}}" title="{{$button.label}}" class="faded-icon page-action" data-toggle="tooltip">
-		<i class="fa fa-close"></i>
+		<i class="ri ri-close-line"></i>
 	</a>
 	{{/if}}
 </div>

--- a/view/theme/frio/templates/mail_list.tpl
+++ b/view/theme/frio/templates/mail_list.tpl
@@ -38,7 +38,7 @@
 					</a>
 				</div>
 				<a href="message/dropconv/{{$id}}" onclick="return confirmDelete();"  title="{{$delete}}" class="pull-right" onmouseover="imgbright(this);" onmouseout="imgdull(this);">
-				<i class="faded-icon fa fa-trash"></i>
+				<i class="faded-icon ri ri-delete-bin-line"></i>
 				</a>
 				<p class="text-muted">{{$count}}</p>
 			</div>

--- a/view/theme/frio/templates/media/browser.tpl
+++ b/view/theme/frio/templates/media/browser.tpl
@@ -23,8 +23,8 @@
 
 			{{* Switch between image and file mode *}}
 			<div class="fbswitcher btn-group pull-right" aria-label="{{$aria_mode_switch}}">
-				<button type="button" class="btn btn-default" data-mode="photo"><i class="fa fa-picture-o" aria-hidden="true"></i> {{$photos_text}}</button>
-				<button type="button" class="btn btn-default" data-mode="attachment"><i class="fa fa-file-o" aria-hidden="true"></i> {{$files_text}}</button>
+				<button type="button" class="btn btn-default" data-mode="photo"><i class="ri ri-image-line" aria-hidden="true"></i> {{$photos_text}}</button>
+				<button type="button" class="btn btn-default" data-mode="attachment"><i class="ri ri-file-line" aria-hidden="true"></i> {{$files_text}}</button>
 			</div>
 		</ol>
 
@@ -66,6 +66,6 @@
 
 	{{* This part contains the content loader icon which is visible when new content is loaded *}}
 	<div class="profile-rotator-wrapper" aria-hidden="true" style="display: none;">
-		<i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i>
+		<i class="ri ri-loader-4-line ri-spin" aria-hidden="true"></i>
 	</div>
 </div>

--- a/view/theme/frio/templates/moderation/users/active.tpl
+++ b/view/theme/frio/templates/moderation/users/active.tpl
@@ -80,7 +80,7 @@
 							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PAGE_SOAPBOX *}}
 							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		{{* PAGE_COMMUNITY *}}
 							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		{{* PAGE_FREELOVE *}}
-							{{if $u.page_flags_raw==4}}ri-rss-line{{/if}}		{{* PAGE_BLOG *}}
+							{{if $u.page_flags_raw==4}}ri-broadcast-line{{/if}}		{{* PAGE_BLOG *}}
 							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	{{* PAGE_PRVGROUP *}}
 							{{if $u.page_flags_raw==6}}ri-team-line{{/if}}		{{* PAGE_COMM_MAN *}}
 							" title="{{$u.page_flags}}">

--- a/view/theme/frio/templates/moderation/users/active.tpl
+++ b/view/theme/frio/templates/moderation/users/active.tpl
@@ -10,7 +10,7 @@
 <div id="admin-users" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}} ({{$count}})</h1>
 	<p>
-		<a href="{{$base_url}}/moderation/users/create" class="btn btn-primary"><i class="fa fa-user-plus"></i> {{$h_newuser}}</a>
+		<a href="{{$base_url}}/moderation/users/create" class="btn btn-primary"><i class="ri ri-user-add-line"></i> {{$h_newuser}}</a>
 	</p>
 	<form action="{{$baseurl}}/{{$query_string}}" method="post">
 		<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
@@ -75,26 +75,26 @@
 
 				{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 					<td>
-						<i class="fa
-							{{if $u.page_flags_raw==0}}fa-user{{/if}}		{{* PAGE_NORMAL *}}
-							{{if $u.page_flags_raw==1}}fa-bullhorn{{/if}}		{{* PAGE_SOAPBOX *}}
-							{{if $u.page_flags_raw==2}}fa-users{{/if}}		{{* PAGE_COMMUNITY *}}
-							{{if $u.page_flags_raw==3}}fa-heart{{/if}}		{{* PAGE_FREELOVE *}}
-							{{if $u.page_flags_raw==4}}fa-rss{{/if}}		{{* PAGE_BLOG *}}
-							{{if $u.page_flags_raw==5}}fa-user-secret{{/if}}	{{* PAGE_PRVGROUP *}}
-							{{if $u.page_flags_raw==6}}fa-users{{/if}}		{{* PAGE_COMM_MAN *}}
+						<i class="ri
+							{{if $u.page_flags_raw==0}}ri-user-line{{/if}}		{{* PAGE_NORMAL *}}
+							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PAGE_SOAPBOX *}}
+							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		{{* PAGE_COMMUNITY *}}
+							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		{{* PAGE_FREELOVE *}}
+							{{if $u.page_flags_raw==4}}ri-rss-line{{/if}}		{{* PAGE_BLOG *}}
+							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	{{* PAGE_PRVGROUP *}}
+							{{if $u.page_flags_raw==6}}ri-team-line{{/if}}		{{* PAGE_COMM_MAN *}}
 							" title="{{$u.page_flags}}">
 						</i>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
-						<i class="fa
-							{{if $u.account_type_raw==1}}fa-sitemap{{/if}}		{{* ACCOUNT_TYPE_ORGANISATION *}}
-							{{if $u.account_type_raw==2}}fa-newspaper-o{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
-							{{if $u.account_type_raw==3}}fa-comments{{/if}}		{{* ACCOUNT_TYPE_COMMUNITY *}}
+						<i class="ri
+							{{if $u.account_type_raw==1}}ri-node-tree{{/if}}		{{* ACCOUNT_TYPE_ORGANISATION *}}
+							{{if $u.account_type_raw==2}}ri-newspaper-line{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
+							{{if $u.account_type_raw==3}}ri-chat-3-line{{/if}}		{{* ACCOUNT_TYPE_COMMUNITY *}}
 							" title="{{$u.account_type}}">
 						</i>
 						{{/if}}
-						{{if $u.is_admin}}<i class="fa fa-user-secret text-primary" title="{{$siteadmin}}"></i>{{/if}}
-						{{if $u.account_expired}}<i class="fa fa-clock-o text-warning" title="{{$accountexpired}}"></i>{{/if}}
+						{{if $u.is_admin}}<i class="ri ri-spy-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
+						{{if $u.account_expired}}<i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i>{{/if}}
 					</td>
 				{{/if}}
 
@@ -137,10 +137,10 @@
 					<td class="text-right">
 				{{if $u.is_deletable}}
 						<a href="{{$baseurl}}/moderation/users/active/block/{{$u.uid}}?t={{$form_security_token}}" class="admin-settings-action-link" title="{{$block}}">
-							<i class="fa fa-ban" aria-hidden="true"></i>
+							<i class="ri ri-forbid-2-line" aria-hidden="true"></i>
 						</a>
 						<a href="{{$baseurl}}/moderation/users/active/delete/{{$u.uid}}?t={{$form_security_token}}" class="admin-settings-action-link" title="{{$delete}}" onclick="return confirm_delete('{{$confirm_delete}}','{{$u.name}}')">
-							<i class="fa fa-trash" aria-hidden="true"></i>
+							<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
 						</a>
 				{{else}}
 						&nbsp;
@@ -152,10 +152,10 @@
 		</table>
 		<div class="panel-footer">
 			<button type="submit" name="page_users_block" value="1" class="btn btn-warning">
-				<i class="fa fa-ban" aria-hidden="true"></i> {{$block}}
+				<i class="ri ri-forbid-2-line" aria-hidden="true"></i> {{$block}}
 			</button>
 			<button type="submit" name="page_users_delete" value="1" class="btn btn-danger" onclick="return confirm_delete('{{$confirm_delete_multi}}')">
-				<i class="fa fa-trash" aria-hidden="true"></i> {{$delete}}
+				<i class="ri ri-delete-bin-line" aria-hidden="true"></i> {{$delete}}
 			</button>
 		</div>
 		{{$pager nofilter}}

--- a/view/theme/frio/templates/moderation/users/blocked.tpl
+++ b/view/theme/frio/templates/moderation/users/blocked.tpl
@@ -74,27 +74,27 @@
 
 				{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 					<td>
-						<i class="fa
-							{{if $u.page_flags_raw==0}}fa-user{{/if}}		{{* PAGE_NORMAL *}}
-							{{if $u.page_flags_raw==1}}fa-bullhorn{{/if}}		{{* PAGE_SOAPBOX *}}
-							{{if $u.page_flags_raw==2}}fa-users{{/if}}		{{* PAGE_COMMUNITY *}}
-							{{if $u.page_flags_raw==3}}fa-heart{{/if}}		{{* PAGE_FREELOVE *}}
-							{{if $u.page_flags_raw==4}}fa-rss{{/if}}		{{* PAGE_BLOG *}}
-							{{if $u.page_flags_raw==5}}fa-user-secret{{/if}}	{{* PAGE_PRVGROUP *}}
-							{{if $u.page_flags_raw==6}}fa-users{{/if}}		{{* PAGE_COMM_MAN *}}
+						<i class="ri
+							{{if $u.page_flags_raw==0}}ri-user-line{{/if}}		{{* PAGE_NORMAL *}}
+							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PAGE_SOAPBOX *}}
+							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		{{* PAGE_COMMUNITY *}}
+							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		{{* PAGE_FREELOVE *}}
+							{{if $u.page_flags_raw==4}}ri-rss-line{{/if}}		{{* PAGE_BLOG *}}
+							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	{{* PAGE_PRVGROUP *}}
+							{{if $u.page_flags_raw==6}}ri-team-line{{/if}}		{{* PAGE_COMM_MAN *}}
 								" title="{{$u.page_flags}}">
 						</i>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
-						<i class="fa
-							{{if $u.account_type_raw==1}}fa-sitemap{{/if}}		{{* ACCOUNT_TYPE_ORGANISATION *}}
-							{{if $u.account_type_raw==2}}fa-newspaper-o{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
-							{{if $u.account_type_raw==3}}fa-comments{{/if}}		{{* ACCOUNT_TYPE_COMMUNITY *}}
+						<i class="ri
+							{{if $u.account_type_raw==1}}ri-node-tree{{/if}}		{{* ACCOUNT_TYPE_ORGANISATION *}}
+							{{if $u.account_type_raw==2}}ri-newspaper-line{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
+							{{if $u.account_type_raw==3}}ri-chat-3-line{{/if}}		{{* ACCOUNT_TYPE_COMMUNITY *}}
 							" title="{{$u.account_type}}">
 						</i>
 						{{/if}}
-						{{if $u.is_admin}}<i class="fa fa-user-secret text-primary" title="{{$siteadmin}}"></i>{{/if}}
-						{{if $u.blocked}}<i class="fa fa-ban text-danger" title="{{$blocked}}"></i>{{/if}}
-						{{if $u.account_expired}}<i class="fa fa-clock-o text-warning" title="{{$accountexpired}}"></i>{{/if}}
+						{{if $u.is_admin}}<i class="ri ri-spy-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
+						{{if $u.blocked}}<i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i>{{/if}}
+						{{if $u.account_expired}}<i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i>{{/if}}
 					</td>
 				{{/if}}
 
@@ -138,11 +138,11 @@
 				{{if $u.is_deletable}}
 					{{if $u.blocked}}
 						<a href="{{$baseurl}}/moderation/users/blocked/unblock/{{$u.uid}}?t={{$form_security_token}}" class="admin-settings-action-link" title="{{$unblock}}">
-							<i class="fa fa-check-circle-o" aria-hidden="true"></i>
+							<i class="ri ri-checkbox-circle-line" aria-hidden="true"></i>
 						</a>
 					{{/if}}
 						<a href="{{$baseurl}}/moderation/users/blocked/delete/{{$u.uid}}?t={{$form_security_token}}" class="admin-settings-action-link" title="{{$delete}}" onclick="return confirm_delete('{{$confirm_delete}}','{{$u.name}}')">
-							<i class="fa fa-trash" aria-hidden="true"></i>
+							<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
 						</a>
 				{{else}}
 						&nbsp;
@@ -154,10 +154,10 @@
 		</table>
 		<div class="panel-footer">
 			<button type="submit" name="page_users_unblock" value="1" class="btn btn-primary">
-				<i class="fa fa-check-circle-o" aria-hidden="true"></i> {{$unblock}}
+				<i class="ri ri-checkbox-circle-line" aria-hidden="true"></i> {{$unblock}}
 			</button>
 			<button type="submit" name="page_users_delete" value="1" class="btn btn-danger" onclick="return confirm_delete('{{$confirm_delete_multi}}')">
-				<i class="fa fa-trash" aria-hidden="true"></i> {{$delete}}
+				<i class="ri ri-delete-bin-line" aria-hidden="true"></i> {{$delete}}
 			</button>
 		</div>
 		{{$pager nofilter}}

--- a/view/theme/frio/templates/moderation/users/blocked.tpl
+++ b/view/theme/frio/templates/moderation/users/blocked.tpl
@@ -79,7 +79,7 @@
 							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PAGE_SOAPBOX *}}
 							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		{{* PAGE_COMMUNITY *}}
 							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		{{* PAGE_FREELOVE *}}
-							{{if $u.page_flags_raw==4}}ri-rss-line{{/if}}		{{* PAGE_BLOG *}}
+							{{if $u.page_flags_raw==4}}ri-broadcast-line{{/if}}		{{* PAGE_BLOG *}}
 							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	{{* PAGE_PRVGROUP *}}
 							{{if $u.page_flags_raw==6}}ri-team-line{{/if}}		{{* PAGE_COMM_MAN *}}
 								" title="{{$u.page_flags}}">

--- a/view/theme/frio/templates/moderation/users/index.tpl
+++ b/view/theme/frio/templates/moderation/users/index.tpl
@@ -80,7 +80,7 @@
 							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PAGE_SOAPBOX *}}
 							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		{{* PAGE_COMMUNITY *}}
 							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		{{* PAGE_FREELOVE *}}
-							{{if $u.page_flags_raw==4}}ri-rss-line{{/if}}		{{* PAGE_BLOG *}}
+							{{if $u.page_flags_raw==4}}ri-broadcast-line{{/if}}		{{* PAGE_BLOG *}}
 							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	{{* PAGE_PRVGROUP *}}
 							{{if $u.page_flags_raw==6}}ri-team-line{{/if}}		{{* PAGE_COMM_MAN *}}
 							" title="{{$u.page_flags}}">

--- a/view/theme/frio/templates/moderation/users/index.tpl
+++ b/view/theme/frio/templates/moderation/users/index.tpl
@@ -10,7 +10,7 @@
 <div id="admin-users" class="adminpage generic-page-wrapper">
 	<h1>{{$title}} - {{$page}} ({{$count}})</h1>
 	<p>
-		<a href="{{$base_url}}/moderation/users/create" class="btn btn-primary"><i class="fa fa-user-plus"></i> {{$h_newuser}}</a>
+		<a href="{{$base_url}}/moderation/users/create" class="btn btn-primary"><i class="ri ri-user-add-line"></i> {{$h_newuser}}</a>
 	</p>
 	<form action="{{$baseurl}}/{{$query_string}}" method="post">
 		<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
@@ -75,28 +75,28 @@
 
 				{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 					<td>
-						<i class="fa
-							{{if $u.page_flags_raw==0}}fa-user{{/if}}		{{* PAGE_NORMAL *}}
-							{{if $u.page_flags_raw==1}}fa-bullhorn{{/if}}		{{* PAGE_SOAPBOX *}}
-							{{if $u.page_flags_raw==2}}fa-users{{/if}}		{{* PAGE_COMMUNITY *}}
-							{{if $u.page_flags_raw==3}}fa-heart{{/if}}		{{* PAGE_FREELOVE *}}
-							{{if $u.page_flags_raw==4}}fa-rss{{/if}}		{{* PAGE_BLOG *}}
-							{{if $u.page_flags_raw==5}}fa-user-secret{{/if}}	{{* PAGE_PRVGROUP *}}
-							{{if $u.page_flags_raw==6}}fa-users{{/if}}		{{* PAGE_COMM_MAN *}}
+						<i class="ri
+							{{if $u.page_flags_raw==0}}ri-user-line{{/if}}		{{* PAGE_NORMAL *}}
+							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PAGE_SOAPBOX *}}
+							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		{{* PAGE_COMMUNITY *}}
+							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		{{* PAGE_FREELOVE *}}
+							{{if $u.page_flags_raw==4}}ri-rss-line{{/if}}		{{* PAGE_BLOG *}}
+							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	{{* PAGE_PRVGROUP *}}
+							{{if $u.page_flags_raw==6}}ri-team-line{{/if}}		{{* PAGE_COMM_MAN *}}
 							" title="{{$u.page_flags}}">
 						</i>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
-						<i class="fa
-							{{if $u.account_type_raw==1}}fa-sitemap{{/if}}		{{* ACCOUNT_TYPE_ORGANISATION *}}
-							{{if $u.account_type_raw==2}}fa-newspaper-o{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
-							{{if $u.account_type_raw==3}}fa-comments{{/if}}		{{* ACCOUNT_TYPE_COMMUNITY *}}
+						<i class="ri
+							{{if $u.account_type_raw==1}}ri-node-tree{{/if}}		{{* ACCOUNT_TYPE_ORGANISATION *}}
+							{{if $u.account_type_raw==2}}ri-newspaper-line{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
+							{{if $u.account_type_raw==3}}ri-chat-3-line{{/if}}		{{* ACCOUNT_TYPE_COMMUNITY *}}
 							" title="{{$u.account_type}}">
 						</i>
 						{{/if}}
-						{{if $u.is_admin}}<i class="fa fa-user-secret text-primary" title="{{$siteadmin}}"></i>{{/if}}
-						{{if $u.blocked}}<i class="fa fa-ban text-danger" title="{{$blocked}}"></i>{{/if}}
-						{{if $u.deleted}}<i class="fa fa-user-times" title="{{$h_deleted}}"></i>{{/if}}
-						{{if $u.account_expired}}<i class="fa fa-clock-o text-warning" title="{{$accountexpired}}"></i>{{/if}}
+						{{if $u.is_admin}}<i class="ri ri-spy-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
+						{{if $u.blocked}}<i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i>{{/if}}
+						{{if $u.deleted}}<i class="ri ri-user-unfollow-line" title="{{$h_deleted}}"></i>{{/if}}
+						{{if $u.account_expired}}<i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i>{{/if}}
 					</td>
 				{{/if}}
 
@@ -140,15 +140,15 @@
 				{{if $u.is_deletable}}
 					{{if $u.blocked}}
 						<a href="{{$baseurl}}/moderation/users/unblock/{{$u.uid}}?t={{$form_security_token}}" class="admin-settings-action-link" title="{{$unblock}}">
-							<i class="fa fa-check-circle-o" aria-hidden="true"></i>
+							<i class="ri ri-checkbox-circle-line" aria-hidden="true"></i>
 						</a>
 					{{else}}
 						<a href="{{$baseurl}}/moderation/users/block/{{$u.uid}}?t={{$form_security_token}}" class="admin-settings-action-link" title="{{$block}}">
-							<i class="fa fa-ban" aria-hidden="true"></i>
+							<i class="ri ri-forbid-2-line" aria-hidden="true"></i>
 						</a>
 					{{/if}}
 						<a href="{{$baseurl}}/moderation/users/delete/{{$u.uid}}?t={{$form_security_token}}" class="admin-settings-action-link" title="{{$delete}}" onclick="return confirm_delete('{{$confirm_delete}}','{{$u.name}}')">
-							<i class="fa fa-trash" aria-hidden="true"></i>
+							<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
 						</a>
 				{{else}}
 						&nbsp;
@@ -160,13 +160,13 @@
 		</table>
 		<div class="panel-footer">
 			<button type="submit" name="page_users_block" value="1" class="btn btn-warning">
-				<i class="fa fa-ban" aria-hidden="true"></i> {{$block}}
+				<i class="ri ri-forbid-2-line" aria-hidden="true"></i> {{$block}}
 			</button>
 			<button type="submit" name="page_users_unblock" value="1" class="btn btn-default">
-				<i class="fa fa-check-circle-o" aria-hidden="true"></i> {{$unblock}}
+				<i class="ri ri-checkbox-circle-line" aria-hidden="true"></i> {{$unblock}}
 			</button>
 			<button type="submit" name="page_users_delete" value="1" class="btn btn-danger" onclick="return confirm_delete('{{$confirm_delete_multi}}')">
-				<i class="fa fa-trash" aria-hidden="true"></i> {{$delete}}
+				<i class="ri ri-delete-bin-line" aria-hidden="true"></i> {{$delete}}
 			</button>
 		</div>
 		{{$pager nofilter}}

--- a/view/theme/frio/templates/moderation/users/pending.tpl
+++ b/view/theme/frio/templates/moderation/users/pending.tpl
@@ -39,8 +39,8 @@
 					<td>{{$u.name}}</td>
 					<td>{{$u.email}}</td>
 					<td>
-						<a href="{{$baseurl}}/moderation/users/pending/allow/{{$u.uid}}?t={{$form_security_token}}" class="admin-settings-action-link btn btn-sm btn-primary" title="{{$approve}}"><i class="fa fa-check" aria-hidden="true"></i></a>
-						<a href="{{$baseurl}}/moderation/users/pending/deny/{{$u.uid}}?t={{$form_security_token}}" class="admin-settings-action-link btn btn-sm btn-warning" title="{{$deny}}"><i class="fa fa-trash-o" aria-hidden="true"></i></a>
+						<a href="{{$baseurl}}/moderation/users/pending/allow/{{$u.uid}}?t={{$form_security_token}}" class="admin-settings-action-link btn btn-sm btn-primary" title="{{$approve}}"><i class="ri ri-check-line" aria-hidden="true"></i></a>
+						<a href="{{$baseurl}}/moderation/users/pending/deny/{{$u.uid}}?t={{$form_security_token}}" class="admin-settings-action-link btn btn-sm btn-warning" title="{{$deny}}"><i class="ri ri-delete-bin-line" aria-hidden="true"></i></a>
 					</td>
 				</tr>
 			{{if $u.note}}
@@ -54,10 +54,10 @@
 			</tbody>
 		</table>
 		<button type="submit" name="page_users_approve" value="1" class="btn btn-primary">
-			<i class="fa fa-check" aria-hidden="true"></i> {{$approve}}
+			<i class="ri ri-check-line" aria-hidden="true"></i> {{$approve}}
 		</button>
 		<button type="submit" name="page_users_deny" value="1" class="btn btn-warning">
-			<i class="fa fa-trash-o" aria-hidden="true"></i> {{$deny}}
+			<i class="ri ri-delete-bin-line" aria-hidden="true"></i> {{$deny}}
 		</button>
 		{{$pager nofilter}}
 	</form>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -26,18 +26,18 @@
 					<button type="button" class="navbar-toggle offcanvas-right-toggle pull-right"
 						aria-controls="offcanvasUsermenu" aria-haspopup="true">
 						<span class="sr-only">Toggle navigation</span>
-						<i class="fa fa-ellipsis-v fa-fw fa-lg" aria-hidden="true"></i>
+						<i class="ri ri-more-2-line ri-fw ri-lg" aria-hidden="true"></i>
 					</button>
 					<button type="button" class="navbar-toggle collapsed pull-right" data-toggle="collapse"
 						data-target="#search-mobile" aria-expanded="false" aria-controls="search-mobile">
 						<span class="sr-only">Toggle Search</span>
-						<i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
+						<i class="ri ri-search-line ri-fw ri-lg" aria-hidden="true"></i>
 					</button>
 					{{* Mobile left menu dropdown button *}}
 					<button type="button" id="mobile-left-menu" class="navbar-toggle collapsed pull-left visible-sm visible-xs"
 						data-toggle="offcanvas" data-target="aside" aria-haspopup="true">
 						<span class="sr-only">Toggle navigation</span>
-						<i class="fa fa-angle-double-right fa-fw fa-lg" aria-hidden="true"></i>
+						<i class="ri ri-arrow-right-double-line ri-fw ri-lg" aria-hidden="true"></i>
 					</button>
 
 					{{* Left section of the NavBar with navigation shortcuts/icons *}}
@@ -52,7 +52,7 @@
 							<li class="nav-segment">
 								<a accesskey="n" class="nav-menu {{$sel.network}}" href="{{$nav.network.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.network.3}}" title="{{$nav.network.3}}"><i
-										class="fa fa-lg fa-th fa-fw" aria-hidden="true"></i><span id="net-update"
+										class="ri ri-lg ri-layout-grid-line ri-fw" aria-hidden="true"></i><span id="net-update"
 										class="nav-network-badge badge nav-notification"></span></a>
 							</li>
 						{{/if}}
@@ -61,14 +61,14 @@
 							<li class="nav-segment">
 								<a accesskey="l" class="nav-menu {{$sel.channel}}" href="{{$nav.channel.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.channel.3}}" title="{{$nav.channel.3}}"><i
-										class="fa fa-lg fa-newspaper-o fa-fw" aria-hidden="true"></i></a>
+										class="ri ri-lg ri-newspaper-line ri-fw" aria-hidden="true"></i></a>
 							</li>
 						{{/if}}
 
 						{{if $nav.home}}
 							<li class="nav-segment">
 								<a accesskey="p" class="nav-menu {{$sel.home}}" href="{{$nav.home.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
-									aria-label="{{$nav.home.3}}" title="{{$nav.home.3}}"><i class="fa fa-lg fa-home fa-fw"
+									aria-label="{{$nav.home.3}}" title="{{$nav.home.3}}"><i class="ri ri-lg ri-home-line ri-fw"
 										aria-hidden="true"></i><span id="home-update"
 										class="nav-home-badge badge nav-notification"></span></a>
 							</li>
@@ -78,7 +78,7 @@
 							<li class="nav-segment">
 								<a accesskey="c" class="nav-menu {{$sel.community}}" href="{{$nav.community.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.community.3}}" title="{{$nav.community.3}}"><i
-										class="fa fa-lg fa-bullseye fa-fw" aria-hidden="true"></i></a>
+										class="ri ri-lg ri-focus-3-line ri-fw" aria-hidden="true"></i></a>
 							</li>
 						{{/if}}
 
@@ -86,7 +86,7 @@
 							<li class="nav-segment">
 								<a accesskey="m" id="nav-messages-link" href="{{$nav.messages.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.messages.1}}" title="{{$nav.messages.1}}"
-									class="nav-menu {{$sel.messages}}"><i class="fa fa-envelope fa-lg fa-fw"
+									class="nav-menu {{$sel.messages}}"><i class="ri ri-mail-line ri-lg ri-fw"
 										aria-hidden="true"></i><span id="mail-update"
 										class="nav-mail-badge badge nav-notification"></span></a>
 							</li>
@@ -96,7 +96,7 @@
 							<li class="nav-segment hidden-xs">
 								<a accesskey="e" id="nav-calendar-link" href="{{$nav.calendar.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.calendar.1}}" title="{{$nav.calendar.1}}" class="nav-menu {{$sel.calendar}}"><i
-										class="fa fa-lg fa-calendar fa-fw"></i></a>
+										class="ri ri-lg ri-calendar-line ri-fw"></i></a>
 							</li>
 						{{/if}}
 
@@ -105,7 +105,7 @@
 								<a accesskey="k" id="nav-contacts-link" href="{{$nav.contacts.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.contacts.1}}" title="{{$nav.contacts.1}}"
 									class="nav-menu {{$sel.contacts}} {{$nav.contacts.2}}"><i
-										class="fa fa-users fa-lg fa-fw"></i></a>
+										class="ri ri-team-line ri-lg ri-fw"></i></a>
 							</li>
 						{{/if}}
 
@@ -116,7 +116,7 @@
 									type="button" aria-haspopup="true" aria-expanded="false"
 									aria-controls="nav-notifications-menu">
 									<span id="notification-update" class="nav-notification-badge badge nav-notification"></span>
-									<i class="fa fa-bell fa-lg" aria-label="{{$nav.notifications.1}}"></i>
+									<i class="ri ri-notification-3-line ri-lg" aria-label="{{$nav.notifications.1}}"></i>
 								</button>
 								{{* The notifications dropdown menu. There are two parts of menu. The second is at the bottom of this file. It is loaded via js. Look at nav-notifications-template *}}
 								<ul id="nav-notifications-menu" class="dropdown-menu menu-popup" role="menu"
@@ -137,7 +137,7 @@
 									</li>
 
 							<li id="nav-notifications-loading" class="loading" style="font-weight: bold; color: #555; padding-left: 10px;">
-								<i class="fa fa-spinner fa-spin" aria-hidden="true" style="vertical-align: middle;"></i> {{$loadingnotifications}}
+								<i class="ri ri-loader-4-line ri-spin" aria-hidden="true" style="vertical-align: middle;"></i> {{$loadingnotifications}}
 							</li>
 							<li id="nav-notifications-empty" class="empty" style="display: none;">
 								<p role="menuitem" class="text-muted text-center"><i>{{$emptynotifications}}</i></p>
@@ -161,7 +161,7 @@
 										<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
 											type="search" name="q" placeholder="{{$search_placeholder}}">
 										<button class="btn btn-primary btn-md form-button-search" type="submit">
-											<i class="fa fa-search" aria-hidden="true"></i>
+											<i class="ri ri-search-line" aria-hidden="true"></i>
 											<span class="sr-only">{{$nav.search.1}}</span>
 										</button>
 									</div>
@@ -197,7 +197,7 @@
 										<li>
 											<a role="menuitem" class="{{$usermenu.2}}{{if $usermenu.0|str_ends_with:"calendar/"}}visible-xs{{/if}}" href="{{$usermenu.0}}"
 												title="{{$usermenu.3}}">
-												<i class="fa {{$usermenu.4}}"></i>
+												<i class="ri {{$usermenu.4}}"></i>
 												{{$usermenu.1}}
 											</a>
 										</li>
@@ -208,7 +208,7 @@
 											<a role="menuitem"
 												class="nav-commlink {{$nav.messages.2}} {{$sel.messages}}"
 												href="{{$nav.messages.0}}" title="{{$nav.messages.3}}">
-												<i class="fa fa-envelope fa-fw" aria-hidden="true"></i>
+												<i class="ri ri-mail-line ri-fw" aria-hidden="true"></i>
 												{{$nav.messages.1}} <span id="mail-update-li"
 													class="nav-mail-badge badge nav-notification"></span>
 											</a>
@@ -219,7 +219,7 @@
 											<a role="menuitem" id="nav-menu-contacts-link"
 												class="nav-link {{$nav.contacts.2}}" href="{{$nav.contacts.0}}"
 												title="{{$nav.contacts.3}}">
-												<i class="fa fa-users fa-fw" aria-hidden="true"></i>
+												<i class="ri ri-team-line ri-fw" aria-hidden="true"></i>
 												{{$nav.contacts.1}}
 											</a>
 										</li>
@@ -229,14 +229,14 @@
 											<a role="menuitem" id="nav-delegation-link"
 												class="nav-commlink {{$nav.delegation.2}} {{$sel.delegation}}"
 												href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}">
-												<i class="fa fa-flag fa-fw" aria-hidden="true"></i> {{$nav.delegation.1}}
+												<i class="ri ri-flag-line ri-fw" aria-hidden="true"></i> {{$nav.delegation.1}}
 											</a>
 										</li>
 									{{/if}}
 									<li>
 										<a role="menuitem" id="nav-directory-link" class="nav-link {{$nav.directory.2}}"
 											href="{{$nav.directory.0}}" title="{{$nav.directory.3}}">
-											<i class="fa fa-sitemap fa-fw" aria-hidden="true"></i>{{$nav.directory.1}}
+											<i class="ri ri-node-tree ri-fw" aria-hidden="true"></i>{{$nav.directory.1}}
 										</a>
 									</li>
 									<li class="divider"><hr></li>
@@ -244,7 +244,7 @@
 										<li>
 											<a role="menuitem" id="nav-apps-link" class="nav-link {{$nav.apps.2}}"
 												href="{{$nav.apps.0}}" title="{{$nav.apps.3}}">
-												<i class="fa fa-puzzle-piece fa-fw" aria-hidden="true"></i> {{$nav.apps.1}}
+												<i class="ri ri-puzzle-line ri-fw" aria-hidden="true"></i> {{$nav.apps.1}}
 											</a>
 										</li>
 										<li class="divider"><hr></li>
@@ -253,7 +253,7 @@
 										<li>
 											<a role="menuitem" id="nav-help-link" class="nav-link {{$nav.help.2}}"
 												href="{{$nav.help.0}}" title="{{$nav.help.3}}">
-												<i class="fa fa-question-circle fa-fw" aria-hidden="true"></i> {{$nav.help.1}}
+												<i class="ri ri-question-line ri-fw" aria-hidden="true"></i> {{$nav.help.1}}
 											</a>
 										</li>
 									{{/if}}
@@ -261,7 +261,7 @@
 										<li>
 											<a role="menuitem" id="nav-settings-link" class="nav-link {{$nav.settings.2}}"
 												href="{{$nav.settings.0}}" title="{{$nav.settings.3}}">
-												<i class="fa fa-cog fa-fw" aria-hidden="true"></i> {{$nav.settings.1}}
+												<i class="ri ri-settings-3-line ri-fw" aria-hidden="true"></i> {{$nav.settings.1}}
 											</a>
 										</li>
 									{{/if}}
@@ -269,7 +269,7 @@
 										<li>
 											<a accesskey="a" role="menuitem" id="nav-admin-link"
 												class="nav-link {{$nav.admin.2}}" href="{{$nav.admin.0}}"
-												title="{{$nav.admin.3}}"><i class="fa fa-user-secret fa-fw" aria-hidden="true"></i>
+												title="{{$nav.admin.3}}"><i class="ri ri-spy-line ri-fw" aria-hidden="true"></i>
 												{{$nav.admin.1}}
 											</a>
 										</li>
@@ -278,7 +278,7 @@
 										<li>
 											<a accesskey="m" role="menuitem" id="nav-moderation-link"
 												class="nav-link {{$nav.moderation.2}}" href="{{$nav.moderation.0}}"
-												title="{{$nav.moderation.3}}"><i class="fa fa-gavel fa-fw" aria-hidden="true"></i>
+												title="{{$nav.moderation.3}}"><i class="ri ri-auction-line ri-fw" aria-hidden="true"></i>
 												{{$nav.moderation.1}}
 											</a>
 										</li>
@@ -287,13 +287,13 @@
 									<li>
 										<a role="menuitem" id="nav-about-link" class="nav-link {{$nav.about.2}}"
 											href="{{$nav.about.0}}" title="{{$nav.about.3}}">
-											<i class="fa fa-info fa-fw" aria-hidden="true"></i> {{$nav.about.1}}
+											<i class="ri ri-information-line ri-fw" aria-hidden="true"></i> {{$nav.about.1}}
 										</a>
 									</li>
 									{{if $nav.tos}}
 										<li>
 											<a role="menuitem" id="nav-tos-link" class="nav-link {{$nav.tos.2}}"
-												href="{{$nav.tos.0}}" title="{{$nav.tos.3}}"><i class="fa fa-file-text"
+												href="{{$nav.tos.0}}" title="{{$nav.tos.3}}"><i class="ri ri-file-text-line"
 													aria-hidden="true"></i> {{$nav.tos.1}}
 											</a>
 										</li>
@@ -303,7 +303,7 @@
 										<li>
 											<a role="menuitem" id="nav-logout-link"
 												class="nav-link {{$nav.logout.2}}" href="{{$nav.logout.0}}"
-												title="{{$nav.logout.3}}"><i class="fa fa fa-sign-out fa-fw" aria-hidden="true"></i>
+												title="{{$nav.logout.3}}"><i class="ri ri-logout-box-line ri-fw" aria-hidden="true"></i>
 												{{$nav.logout.1}}
 											</a>
 										</li>
@@ -311,7 +311,7 @@
 										<li>
 											<a role="menuitem" id="nav-login-link"
 												class="nav-login-link {{$nav.login.2}}" href="{{$nav.login.0}}"
-												title="{{$nav.login.3}}"><i class="fa fa-power-off fa-fw" aria-hidden="true"></i>
+												title="{{$nav.login.3}}"><i class="ri ri-shut-down-line ri-fw" aria-hidden="true"></i>
 												{{$nav.login.1}}
 											</a>
 										</li>
@@ -343,7 +343,7 @@
 								<li class="list-group-item">
 									<a role="menuitem" class="{{$usermenu.2}}"
 										href="{{$usermenu.0}}" title="{{$usermenu.3}}">
-										<i class="fa {{$usermenu.4}}"></i>&nbsp;
+										<i class="ri {{$usermenu.4}}"></i>&nbsp;
 										{{$usermenu.1}}
 									</a>
 								</li>
@@ -355,7 +355,7 @@
 								<li class="list-group-item">
 									<a role="menuitem"
 										class="nav-link {{$nav.contacts.2}}" href="{{$nav.contacts.0}}"
-										title="{{$nav.contacts.3}}"><i class="fa fa-users fa-fw" aria-hidden="true"></i>
+										title="{{$nav.contacts.3}}"><i class="ri ri-team-line ri-fw" aria-hidden="true"></i>
 										{{$nav.contacts.1}}
 									</a>
 								</li>
@@ -364,7 +364,7 @@
 								<li class="list-group-item">
 									<a role="menuitem"
 										class="nav-link {{$nav.messages.2}} {{$sel.messages}}" href="{{$nav.messages.0}}"
-										title="{{$nav.messages.3}}"><i class="fa fa-envelope fa-fw" aria-hidden="true"></i>
+										title="{{$nav.messages.3}}"><i class="ri ri-mail-line ri-fw" aria-hidden="true"></i>
 										{{$nav.messages.1}}
 									</a>
 								</li>
@@ -373,7 +373,7 @@
 								<li class="list-group-item">
 									<a role="menuitem"
 										class="nav-commlink {{$nav.delegation.2}} {{$sel.delegation}}"
-										href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}"><i class="fa fa-flag fa-fw"
+										href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}"><i class="ri ri-flag-line ri-fw"
 											aria-hidden="true"></i> {{$nav.delegation.1}}
 									</a>
 								</li>
@@ -384,7 +384,7 @@
 							{{if $nav.settings}}
 								<li class="list-group-item">
 									<a role="menuitem" class="nav-link {{$nav.settings.2}}" href="{{$nav.settings.0}}"
-										title="{{$nav.settings.3}}"><i class="fa fa-cog fa-fw" aria-hidden="true"></i>
+										title="{{$nav.settings.3}}"><i class="ri ri-settings-3-line ri-fw" aria-hidden="true"></i>
 										{{$nav.settings.1}}
 									</a>
 								</li>
@@ -393,7 +393,7 @@
 								<li class="list-group-item">
 									<a role="menuitem"
 										class="nav-link {{$nav.admin.2}}" href="{{$nav.admin.0}}" title="{{$nav.admin.3}}"><i
-											class="fa fa-user-secret fa-fw" aria-hidden="true"></i>
+											class="ri ri-spy-line ri-fw" aria-hidden="true"></i>
 										{{$nav.admin.1}}
 									</a>
 								</li>
@@ -402,7 +402,7 @@
 								<li class="list-group-item">
 									<a role="menuitem"
 										class="nav-link {{$nav.moderation.2}}" href="{{$nav.moderation.0}}" title="{{$nav.moderation.3}}"><i
-											class="fa fa-gavel fa-fw" aria-hidden="true"></i>
+											class="ri ri-auction-line ri-fw" aria-hidden="true"></i>
 										{{$nav.moderation.1}}
 									</a>
 								</li>
@@ -411,7 +411,7 @@
 						<li class="list-group-item">
 							<a role="menuitem" class="nav-link {{$nav.about.2}}"
 								href="{{$nav.about.0}}" title="{{$nav.about.3}}">
-								<i class="fa fa-info fa-fw" aria-hidden="true"></i> {{$nav.about.1}}
+								<i class="ri ri-information-line ri-fw" aria-hidden="true"></i> {{$nav.about.1}}
 							</a>
 						</li>
 							<li class="divider"><hr></li>
@@ -419,7 +419,7 @@
 								<li class="list-group-item">
 									<a role="menuitem"
 										class="nav-link {{$nav.logout.2}}" href="{{$nav.logout.0}}" title="{{$nav.logout.3}}"><i
-											class="fa fa fa-sign-out fa-fw" aria-hidden="true"></i>
+											class="ri ri ri-logout-box-line ri-fw" aria-hidden="true"></i>
 										{{$nav.logout.1}}
 									</a>
 								</li>
@@ -427,7 +427,7 @@
 								<li class="list-group-item">
 									<a role="menuitem"
 										class="nav-login-link {{$nav.login.2}}" href="{{$nav.login.0}}"
-										title="{{$nav.login.3}}"><i class="fa fa-power-off fa-fw" aria-hidden="true"></i>
+										title="{{$nav.login.3}}"><i class="ri ri-shut-down-line ri-fw" aria-hidden="true"></i>
 										{{$nav.login.1}}
 									</a>
 								</li>
@@ -447,7 +447,7 @@
 			<button type="button" class="navbar-toggle collapsed pull-left visible-sm visible-xs"
 					data-toggle="offcanvas" data-target="aside" aria-haspopup="true">
 				<span class="sr-only">Toggle navigation</span>
-				<i class="fa fa-ellipsis-v fa-fw fa-lg" aria-hidden="true"></i>
+				<i class="ri ri-more-2-line ri-fw ri-lg" aria-hidden="true"></i>
 			</button>
 			<a class="navbar-brand" href="#">
 				<div id="navbrand-container">
@@ -460,14 +460,14 @@
 				<ul class="nav navbar-nav navbar-right">
 					<li>
 						<a href="login?mode=none" id="nav-login" class="btn btn-primary">
-							<i class="fa fa-sign-in fa-fw" aria-hidden="true"></i>
+							<i class="ri ri-login-box-line ri-fw" aria-hidden="true"></i>
 							{{$nav.login.3}}
 						</a>
 					</li>
 					<li>
 						<a href="{{$nav.about.0}}" id="nav-about" data-toggle="tooltip" aria-label="{{$nav.about.3}}" class="btn btn-primary"
 							title="{{$nav.about.3}}">
-							<i class="fa fa-info fa-fw" aria-hidden="true"></i> {{$nav.about.1}}
+							<i class="ri ri-information-line ri-fw" aria-hidden="true"></i> {{$nav.about.1}}
 						</a>
 					</li>
 				</ul>
@@ -484,7 +484,7 @@
 				<input id="nav-search-input-field-mobile" class="form-control form-search" type="search" name="q"
 					placeholder="{{$search_placeholder}}">
 				<button class="btn btn-primary btn-sm form-button-search" type="submit">
-					<i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
+					<i class="ri ri-search-line ri-fw ri-lg" aria-hidden="true"></i>
 					<span class="sr-only">{{$nav.search.1}}</span>
 				</button>
 			</div>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -219,7 +219,7 @@
 											<a role="menuitem" id="nav-menu-contacts-link"
 												class="nav-link {{$nav.contacts.2}}" href="{{$nav.contacts.0}}"
 												title="{{$nav.contacts.3}}">
-												<i class="ri ri-team-line ri-fw" aria-hidden="true"></i>
+												<i class="ri ri-contacts-line ri-fw" aria-hidden="true"></i>
 												{{$nav.contacts.1}}
 											</a>
 										</li>
@@ -355,7 +355,7 @@
 								<li class="list-group-item">
 									<a role="menuitem"
 										class="nav-link {{$nav.contacts.2}}" href="{{$nav.contacts.0}}"
-										title="{{$nav.contacts.3}}"><i class="ri ri-team-line ri-fw" aria-hidden="true"></i>
+										title="{{$nav.contacts.3}}"><i class="ri ri-contacts-line ri-fw" aria-hidden="true"></i>
 										{{$nav.contacts.1}}
 									</a>
 								</li>

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -52,7 +52,7 @@
 							<li class="nav-segment">
 								<a accesskey="n" class="nav-menu {{$sel.network}}" href="{{$nav.network.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.network.3}}" title="{{$nav.network.3}}"><i
-										class="ri ri-lg ri-layout-grid-line ri-fw" aria-hidden="true"></i><span id="net-update"
+										class="ri ri-lg ri-message-line ri-fw" aria-hidden="true"></i><span id="net-update"
 										class="nav-network-badge badge nav-notification"></span></a>
 							</li>
 						{{/if}}
@@ -68,7 +68,7 @@
 						{{if $nav.home}}
 							<li class="nav-segment">
 								<a accesskey="p" class="nav-menu {{$sel.home}}" href="{{$nav.home.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
-									aria-label="{{$nav.home.3}}" title="{{$nav.home.3}}"><i class="ri ri-lg ri-home-line ri-fw"
+									aria-label="{{$nav.home.3}}" title="{{$nav.home.3}}"><i class="ri ri-lg ri-user-line ri-fw"
 										aria-hidden="true"></i><span id="home-update"
 										class="nav-home-badge badge nav-notification"></span></a>
 							</li>
@@ -78,7 +78,7 @@
 							<li class="nav-segment">
 								<a accesskey="c" class="nav-menu {{$sel.community}}" href="{{$nav.community.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.community.3}}" title="{{$nav.community.3}}"><i
-										class="ri ri-lg ri-focus-3-line ri-fw" aria-hidden="true"></i></a>
+										class="ri ri-lg ri-user-community-line ri-fw" aria-hidden="true"></i></a>
 							</li>
 						{{/if}}
 
@@ -105,7 +105,7 @@
 								<a accesskey="k" id="nav-contacts-link" href="{{$nav.contacts.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.contacts.1}}" title="{{$nav.contacts.1}}"
 									class="nav-menu {{$sel.contacts}} {{$nav.contacts.2}}"><i
-										class="ri ri-team-line ri-lg ri-fw"></i></a>
+										class="ri ri-contacts-line ri-lg ri-fw"></i></a>
 							</li>
 						{{/if}}
 
@@ -116,7 +116,7 @@
 									type="button" aria-haspopup="true" aria-expanded="false"
 									aria-controls="nav-notifications-menu">
 									<span id="notification-update" class="nav-notification-badge badge nav-notification"></span>
-									<i class="ri ri-notification-3-line ri-lg" aria-label="{{$nav.notifications.1}}"></i>
+									<i class="ri ri-notification-line ri-lg" aria-label="{{$nav.notifications.1}}"></i>
 								</button>
 								{{* The notifications dropdown menu. There are two parts of menu. The second is at the bottom of this file. It is loaded via js. Look at nav-notifications-template *}}
 								<ul id="nav-notifications-menu" class="dropdown-menu menu-popup" role="menu"
@@ -229,7 +229,7 @@
 											<a role="menuitem" id="nav-delegation-link"
 												class="nav-commlink {{$nav.delegation.2}} {{$sel.delegation}}"
 												href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}">
-												<i class="ri ri-flag-line ri-fw" aria-hidden="true"></i> {{$nav.delegation.1}}
+												<i class="ri ri-contacts-book-line ri-fw" aria-hidden="true"></i> {{$nav.delegation.1}}
 											</a>
 										</li>
 									{{/if}}
@@ -269,7 +269,7 @@
 										<li>
 											<a accesskey="a" role="menuitem" id="nav-admin-link"
 												class="nav-link {{$nav.admin.2}}" href="{{$nav.admin.0}}"
-												title="{{$nav.admin.3}}"><i class="ri ri-spy-line ri-fw" aria-hidden="true"></i>
+												title="{{$nav.admin.3}}"><i class="ri ri-admin-line ri-fw" aria-hidden="true"></i>
 												{{$nav.admin.1}}
 											</a>
 										</li>
@@ -278,7 +278,7 @@
 										<li>
 											<a accesskey="m" role="menuitem" id="nav-moderation-link"
 												class="nav-link {{$nav.moderation.2}}" href="{{$nav.moderation.0}}"
-												title="{{$nav.moderation.3}}"><i class="ri ri-auction-line ri-fw" aria-hidden="true"></i>
+												title="{{$nav.moderation.3}}"><i class="ri ri-shield-user-line ri-fw" aria-hidden="true"></i>
 												{{$nav.moderation.1}}
 											</a>
 										</li>
@@ -373,7 +373,7 @@
 								<li class="list-group-item">
 									<a role="menuitem"
 										class="nav-commlink {{$nav.delegation.2}} {{$sel.delegation}}"
-										href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}"><i class="ri ri-flag-line ri-fw"
+										href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}"><i class="ri ri-contacts-book-line ri-fw"
 											aria-hidden="true"></i> {{$nav.delegation.1}}
 									</a>
 								</li>
@@ -393,7 +393,7 @@
 								<li class="list-group-item">
 									<a role="menuitem"
 										class="nav-link {{$nav.admin.2}}" href="{{$nav.admin.0}}" title="{{$nav.admin.3}}"><i
-											class="ri ri-spy-line ri-fw" aria-hidden="true"></i>
+											class="ri ri-admin-line ri-fw" aria-hidden="true"></i>
 										{{$nav.admin.1}}
 									</a>
 								</li>
@@ -402,7 +402,7 @@
 								<li class="list-group-item">
 									<a role="menuitem"
 										class="nav-link {{$nav.moderation.2}}" href="{{$nav.moderation.0}}" title="{{$nav.moderation.3}}"><i
-											class="ri ri-auction-line ri-fw" aria-hidden="true"></i>
+											class="ri ri-shield-user-line ri-fw" aria-hidden="true"></i>
 										{{$nav.moderation.1}}
 									</a>
 								</li>

--- a/view/theme/frio/templates/notifications/intros.tpl
+++ b/view/theme/frio/templates/notifications/intros.tpl
@@ -48,19 +48,19 @@
 			{{* On mobile touch devices we use buttons for approve, ignore && discard to have a better UX *}}
 			{{if $is_mobile}}
 			<form class="intro-form" action="notification/{{$intro_id}}" method="post">
-				<button class="btn btn-small btn-primary" type="button" onclick="addElmToModal('#intro-approve-wrapper-{{$intro_id}}');"><i class="fa fa-check" aria-hidden="true"></i> {{$approve}}</button>
+				<button class="btn btn-small btn-primary" type="button" onclick="addElmToModal('#intro-approve-wrapper-{{$intro_id}}');"><i class="ri ri-check-line" aria-hidden="true"></i> {{$approve}}</button>
 				{{if $discard}}
-					<button class="btn btn-small btn-warning intro-submit-discard" type="submit" name="submit" value="discard"><i class="fa fa-trash-o" aria-hidden="true"></i> {{$discard}}</button>
+					<button class="btn btn-small btn-warning intro-submit-discard" type="submit" name="submit" value="discard"><i class="ri ri-delete-bin-line" aria-hidden="true"></i> {{$discard}}</button>
 				{{/if}}
-				<button class="btn btn-small btn-danger intro-submit-ignore" type="submit" name="submit" value="ignore"><i class="fa fa-ban" aria-hidden="true"></i> {{$ignore}}</button>
+				<button class="btn btn-small btn-danger intro-submit-ignore" type="submit" name="submit" value="ignore"><i class="ri ri-forbid-2-line" aria-hidden="true"></i> {{$ignore}}</button>
 			</form>
 			{{else}}
 			{{* The intro actions like approve, ignore, discard intro*}}
 			<div class="intro-actions nav-pills">
-				<button class="btn-link intro-action-link" onclick="addElmToModal('#intro-approve-wrapper-{{$intro_id}}');" aria-label="{{$approve}}" title="{{$approve}}" data-toggle="tooltip"><i class="fa fa-check" aria-hidden="true"></i></button>
+				<button class="btn-link intro-action-link" onclick="addElmToModal('#intro-approve-wrapper-{{$intro_id}}');" aria-label="{{$approve}}" title="{{$approve}}" data-toggle="tooltip"><i class="ri ri-check-line" aria-hidden="true"></i></button>
 				<form class="intro-form" action="notification/{{$intro_id}}" method="post">
-					<button class="btn-link intro-submit-ignore intro-action-link" type="submit" name="submit" value="ignore" aria-label="{{$ignore}}" title="{{$ignore}}" data-toggle="tooltip"><i class="fa fa-ban" aria-hidden="true"></i></button>
-					{{if $discard}}<button class="btn-link intro-submit-discard intro-action-link" type="submit" name="submit" value="discard" aria-label="{{$discard}}" title="{{$discard}}" data-toggle="tooltip"><i class="fa fa-trash-o" aria-hidden="true"></i></button>{{/if}}
+					<button class="btn-link intro-submit-ignore intro-action-link" type="submit" name="submit" value="ignore" aria-label="{{$ignore}}" title="{{$ignore}}" data-toggle="tooltip"><i class="ri ri-forbid-2-line" aria-hidden="true"></i></button>
+					{{if $discard}}<button class="btn-link intro-submit-discard intro-action-link" type="submit" name="submit" value="discard" aria-label="{{$discard}}" title="{{$discard}}" data-toggle="tooltip"><i class="ri ri-delete-bin-line" aria-hidden="true"></i></button>{{/if}}
 				</form>
 			</div>
 			{{/if}}

--- a/view/theme/frio/templates/photo_album.tpl
+++ b/view/theme/frio/templates/photo_album.tpl
@@ -12,20 +12,20 @@
 	<div class="photo-album-actions pull-right">
 		{{if $can_post}}
 		<a class="btn btn-primary photos-upload-link page-action" href="{{$upload.1}}">
-			<i class="fa fa-plus"></i>
+			<i class="ri ri-add-line"></i>
 			{{$upload.0}}
 		</a>
 		{{/if}}
 
 		{{if $edit}}
 		<button id="album-edit-link" class="btn btn-primary page-action" type="button" data-modal-url="{{$edit.1}}">
-			<i class="fa fa-pencil"></i>
+			<i class="ri ri-pencil-line"></i>
 			{{$edit.0}}
 		</button>
 		{{/if}}
 		{{if $drop}}
 		<button id="album-drop-link" class="btn btn-primary page-action" type="button" data-modal-url="{{$drop.1}}">
-			<i class="fa fa-trash"></i>
+			<i class="ri ri-delete-bin-line"></i>
 			{{$drop.0}}
 		</button>
 		{{/if}}
@@ -33,9 +33,9 @@
 		{{if ! $noorder}}
 		<a class="photos-order-link page-action" href="{{$order.1}}" title="{{$order.0}}" data-toggle="tooltip">
 			{{if $order.2 == "newest"}}
-			<i class="fa fa-sort-numeric-desc"></i>
+			<i class="ri ri-sort-desc"></i>
 			{{else}}
-			<i class="fa fa-sort-numeric-asc"></i>
+			<i class="ri ri-sort-asc"></i>
 			{{/if}}
 		</a>
 		{{/if}}

--- a/view/theme/frio/templates/photo_albums.tpl
+++ b/view/theme/frio/templates/photo_albums.tpl
@@ -13,7 +13,7 @@
 		{{if $can_post}}
 			<div class="photos-upload-link">
 				<a href="{{$upload.1}}" title="{{$upload.0}}" class="widget-action faded-icon" data-toggle="tooltip">
-					<i class="fa fa-plus"></i>
+					<i class="ri ri-add-line"></i>
 				</a>
 			</div>
 		{{/if}}

--- a/view/theme/frio/templates/photo_edit.tpl
+++ b/view/theme/frio/templates/photo_edit.tpl
@@ -18,7 +18,7 @@
 
 	<div id="photo-edit-perms">
 		<button class="btn btn-default" data-toggle="modal" data-target="#photo-edit-permission-acl" onclick="return false;">
-			<i id="jot-perms-icon" class="fa {{$lockstate}}"></i> {{$permissions}}
+			<i id="jot-perms-icon" class="ri {{$lockstate}}"></i> {{$permissions}}
 		</button>
 	</div>
 

--- a/view/theme/frio/templates/photo_item.tpl
+++ b/view/theme/frio/templates/photo_item.tpl
@@ -14,11 +14,11 @@
 		{{* Dropdown menu with actions (e.g. delete comment) *}}
 		{{if $drop.dropping }}
 		<li class="dropdown">
-			<a class="dropdown-toggle" data-toggle="dropdown" id="dropdownMenuTools-{{$id}}" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-angle-down" aria-hidden="true"></i></a>
+			<a class="dropdown-toggle" data-toggle="dropdown" id="dropdownMenuTools-{{$id}}" role="button" aria-haspopup="true" aria-expanded="false"><i class="ri ri-arrow-down-s-line" aria-hidden="true"></i></a>
 
 			<ul class="dropdown-menu pull-right" role="menu" aria-labelledby="dropdownMenuTools-{{$id}}">
 				<li role="menuitem">
-					<a onclick="dropItem('item/drop/{{$id}}', '#wall-item-outside-wrapper-{{$id}}'); return false;" class="delete" title="{{$drop.delete}}"><i class="fa fa-trash" aria-hidden="true"></i>&nbsp;{{$drop.delete}}</a>
+					<a onclick="dropItem('item/drop/{{$id}}', '#wall-item-outside-wrapper-{{$id}}'); return false;" class="delete" title="{{$drop.delete}}"><i class="ri ri-delete-bin-line" aria-hidden="true"></i>&nbsp;{{$drop.delete}}</a>
 				</li>
 			</ul>
 		</li>

--- a/view/theme/frio/templates/photo_view.tpl
+++ b/view/theme/frio/templates/photo_view.tpl
@@ -12,7 +12,7 @@
 <div id="photo-view-{{$id}}" class="generic-page-wrapper">
 	<div class="pull-left" id="photo-edit-link-wrap">
 		<a class="page-action faded-icon" id="photo-album-link" href="{{$album.0}}">
-			<i class="fa fa-folder-open"></i>
+			<i class="ri ri-folder-open-line"></i>
 			{{$album.1}}
 		</a>
 	</div>
@@ -20,31 +20,31 @@
 {{if $tools}}
 	{{if $tools.view}}
 		<a id="photo-edit-link" class="btn btn-primary photo-back-link" href="{{$tools.view.0}}">
-			<i class="page-action fa fa-mail-reply"></i>
+			<i class="page-action ri ri-reply-line"></i>
 			 {{$back_text}}
 		</a>
 	{{/if}}
 	{{if $tools.edit}}
 		<a id="photo-edit-link" class="btn btn-primary" href="{{$tools.edit.0}}">
-			 <i class="page-action fa fa-pencil"></i>
+			 <i class="page-action ri ri-pencil-line"></i>
 			 {{$edit_text}}
 		</a>
 	{{/if}}
 	{{if $tools.delete}}
 		<button id="photo-delete-link" class="btn btn-primary" type="button" data-modal-url="{{$tools.delete.0}}">
-			<i class="page-action fa fa-trash"></i>
+			<i class="page-action ri ri-delete-bin-line"></i>
 			{{$delete_text}}
 		</button>
 	{{/if}}
 	{{if $tools.profile}}
 		<a id="photo-toprofile-link" class="btn btn-primary" href="{{$tools.profile.0}}">
-			<i class="page-action fa fa-user"></i>
+			<i class="page-action ri ri-user-line"></i>
 			{{$use_as_profile_picture_text}}
 		</a>
 	{{/if}}
 	{{if $tools.lock}}
 		<a id="photo-lock-link" onclick="lockview(event, 'photo', {{$id}});" title="{{$tools.lock}}">
-			<i class="page-action fa fa-lg fa-lock faded-icon"></i>
+			<i class="page-action ri ri-lg ri-lock-line faded-icon"></i>
 		</a>
 	{{/if}}
 {{/if}}
@@ -60,10 +60,10 @@
 
 			{{* Overlay buttons for previous and next photo *}}
 			{{if $prevlink}}
-			<a class="photo-prev-link" href="{{$prevlink.0}}"><i class="fa fa-angle-left" aria-hidden="true"></i></a>
+			<a class="photo-prev-link" href="{{$prevlink.0}}"><i class="ri ri-arrow-left-s-line" aria-hidden="true"></i></a>
 			{{/if}}
 			{{if $nextlink}}
-			<a class="photo-next-link" href="{{$nextlink.0}}"><i class="fa fa-angle-right" aria-hidden="true"></i></a>
+			<a class="photo-next-link" href="{{$nextlink.0}}"><i class="ri ri-arrow-right-s-line" aria-hidden="true"></i></a>
 			{{/if}}
 		</div>
 

--- a/view/theme/frio/templates/photos_upload.tpl
+++ b/view/theme/frio/templates/photos_upload.tpl
@@ -30,7 +30,7 @@
 		{{if $alt_uploader}}
 			<div id="photos-upload-perms" class="pull-right">
 				<button class="btn btn-default btn-sm" data-toggle="modal" data-target="#photo-upload-permission-acl" onclick="return false;">
-					<i id="jot-perms-icon" class="fa {{$lockstate}}"></i> {{$permissions}}
+					<i id="jot-perms-icon" class="ri {{$lockstate}}"></i> {{$permissions}}
 				</button>
 			</div>
 			<div class="clearfix"></div>
@@ -49,7 +49,7 @@
 			<div class="photos-upload-wrapper">
 				<div id="photos-upload-perms" class="btn-group pull-right">
 					<button class="btn btn-default" data-toggle="modal" data-target="#photo-upload-permission-acl" onclick="return false;">
-						<i id="jot-perms-icon" class="fa {{$lockstate}}"></i>
+						<i id="jot-perms-icon" class="ri {{$lockstate}}"></i>
 					</button>
 
 					{{$default_upload_submit nofilter}}

--- a/view/theme/frio/templates/profile/schedule.tpl
+++ b/view/theme/frio/templates/profile/schedule.tpl
@@ -34,12 +34,12 @@
 					<div class="additional-info text-muted">
 						<div class="wall-item-ago" style="margin-left:0;">
 							<small> 
-							<span class="fa fa-clock"></span><time class="dt-scheduled" datetime="">{{$scheduled_at}} <span class="datetime">{{$row.scheduled_at}}</span></time>
+							<span class="ri ri-time-line"></span><time class="dt-scheduled" datetime="">{{$scheduled_at}} <span class="datetime">{{$row.scheduled_at}}</span></time>
 						{{** lockview() function will not work because post gets ID after going live **}}
 						{{if $row.item.private}}
 							<span class="navicon lock" title="{{$row.item.lock}}" data-toggle="tooltip">
 								<small>
-									<i class="fa fa-lock"></i>
+									<i class="ri ri-lock-line"></i>
 								</small>
 							</span>
 						{{/if}}
@@ -67,13 +67,13 @@
 				<div class="wall-item-links"></div>
 				<div class="wall-item-tags">
 					{{foreach $row.item.hashtags as $tag}}
-						<span class="tag label btn-info sm">{{$tag nofilter}} <i class="fa fa-bolt" aria-hidden="true"></i></span>
+						<span class="tag label btn-info sm">{{$tag nofilter}} <i class="ri ri-flashlight-line" aria-hidden="true"></i></span>
 					{{/foreach}}
 					{{foreach $row.item.mentions as $tag}}
-						<span class="mention label btn-warning sm">{{$tag nofilter}} <i class="fa fa-user" aria-hidden="true"></i></span>
+						<span class="mention label btn-warning sm">{{$tag nofilter}} <i class="ri ri-user-line" aria-hidden="true"></i></span>
 					{{/foreach}}
 					{{foreach $row.item.implicit_mentions as $tag}}
-						<span class="mention label label-default sm">{{$tag nofilter}} <i class="fa fa-eye-slash" aria-hidden="true"></i></span>
+						<span class="mention label label-default sm">{{$tag nofilter}} <i class="ri ri-eye-off-line" aria-hidden="true"></i></span>
 					{{/foreach}}
 				</div>
 			</div>
@@ -82,7 +82,7 @@
 							<span class="wall-item-actions-right">
 								<form action="{{$basefurl}}/profile/{{$nickname}}/schedule" method="post" style="width:100%;">
 									<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
-									<button type="submit" name="delete" value="{{$row.id}}" title="{{$delete}}" class="btn-link navicon fa fa-trash" style="float:right;border:none!important;background:transparent!important;box-shadow:none;"></button>
+									<button type="submit" name="delete" value="{{$row.id}}" title="{{$delete}}" class="btn-link navicon ri ri-delete-bin-line" style="float:right;border:none!important;background:transparent!important;box-shadow:none;"></button>
 								</form>
 							</span>						
 						</div>

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -68,7 +68,7 @@
 				{{if $subscribe_feed_link}}
 					<div id="subscribe-feed-link-button">
 						<a id="subscribe-feed-link" class="btn btn-labeled btn-primary" href="{{$subscribe_feed_link}}">
-							<span><i class="ri ri-rss-line"></i></span>
+							<span><i class="ri ri-broadcast-line"></i></span>
 							<span>{{$subscribe_feed}}</span>
 						</a>
 					</div>

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -37,7 +37,7 @@
 			{{if $is_owner }}
 				<div class="edit-profile-link-wrapper">
 					<a class="btn btn-primary" href="{{$edit_profile_link.url}}">
-						<i class="fa fa-pencil" aria-hidden="true"></i>
+						<i class="ri ri-pencil-line" aria-hidden="true"></i>
 						{{$edit_profile_link.text}}
 					</a>
 				</div>
@@ -54,12 +54,12 @@
 					<div id="dfrn-request-link-button">
 						{{if $unfollow_link}}
 							<a id="dfrn-request-link" class="btn btn-labeled btn-primary" href="{{$unfollow_link}}">
-								<span><i class="fa fa-user-times"></i></span>
+								<span><i class="ri ri-user-unfollow-line"></i></span>
 								<span>{{$unfollow}}</span>
 							</a>
 						{{else}}
 							<a id="dfrn-request-link" class="btn btn-labeled btn-primary" href="{{$follow_link}}">
-								<span><i class="fa fa-user-plus"></i></span>
+								<span><i class="ri ri-user-add-line"></i></span>
 								<span>{{$follow}}</span>
 							</a>
 						{{/if}}
@@ -68,7 +68,7 @@
 				{{if $subscribe_feed_link}}
 					<div id="subscribe-feed-link-button">
 						<a id="subscribe-feed-link" class="btn btn-labeled btn-primary" href="{{$subscribe_feed_link}}">
-							<span><i class="fa fa-rss"></i></span>
+							<span><i class="ri ri-rss-line"></i></span>
 							<span>{{$subscribe_feed}}</span>
 						</a>
 					</div>
@@ -76,7 +76,7 @@
 				{{if $wallmessage_link}}
 					<div id="wallmessage-link-button">
 						<button type="button" id="wallmessage-link" class="btn btn-labeled btn-primary" onclick="openWallMessage('{{$wallmessage_link}}')">
-							<span><i class="fa fa-envelope"></i></span>
+							<span><i class="ri ri-mail-line"></i></span>
 							<span>{{$wallmessage}}</span>
 						</button>
 					</div>
@@ -84,7 +84,7 @@
 				{{if $profile.addr}}
 					<div id="jotOpen" class="pull-right">
 						<button type="button" id="mention-link" class="action-button btn btn-labeled btn-primary" onclick="openWallMessage('{{$mention_url}}')">
-							<i class="fa fa-lg fa-pencil"></i>
+							<i class="ri ri-lg ri-pencil-line"></i>
 							<span>{{$mention_label}}</span>
 						</button>
 					</div>
@@ -92,7 +92,7 @@
 				{{if $network_label}}
 					<div id="showgroup-button">
 						<a id="showgroup" class="btn btn-labeled btn-primary" href="{{$network_url}}">
-							<span><i class="fa fa-group"></i></span>
+							<span><i class="ri ri-group-line"></i></span>
 							<span>{{$network_label}}</span>
 						</a>
 					</div>
@@ -104,7 +104,7 @@
 
 		{{if $location}}
 			<div class="location detail">
-				<span class="location-label icon"><i class="fa fa-map-marker" title="{{$location}}"></i></span>
+				<span class="location-label icon"><i class="ri ri-map-pin-line" title="{{$location}}"></i></span>
 				<span class="adr">
 					{{if $profile.address}}<p class="street-address p-street-address">{{$profile.address nofilter}}</p>
 					{{/if}}
@@ -115,14 +115,14 @@
 
 		{{if $profile.xmpp}}
 			<div class="xmpp">
-				<span class="xmpp-label icon"><i class="fa fa-xmpp" title="{{$xmpp}}"></i></span>
+				<span class="xmpp-label icon"><i class="ri ri-chat-3-line" title="{{$xmpp}}"></i></span>
 				<span class="xmpp-data"><a href="xmpp:{{$profile.xmpp}}" rel="me" target="_blank" rel="noopener noreferrer">{{include file="sub/punct_wrap.tpl" text=$profile.xmpp}}</a></span>
 			</div>
 		{{/if}}
 
 		{{if $profile.matrix}}
 			<div class="matrix">
-				<span class="matrix-label icon"><i class="fa fa-matrix-org" title="{{$matrix}}"></i></span>
+				<span class="matrix-label icon"><i class="ri ri-grid-line" title="{{$matrix}}"></i></span>
 				<span class="matrix-data"><a href="matrix:{{$profile.matrix}}" rel="me" target="_blank" rel="noopener noreferrer">{{include file="sub/punct_wrap.tpl" text=$profile.matrix}}</a></span>
 			</div>
 		{{/if}}
@@ -135,7 +135,7 @@
 
 		{{if $homepage}}
 			<div class="homepage detail">
-				<span class="homepage-label icon"><i class="fa fa-external-link" title="{{$homepage}}"></i></span>
+				<span class="homepage-label icon"><i class="ri ri-external-link-line" title="{{$homepage}}"></i></span>
 				<span class="homepage-url u-url"><a href="{{$profile.homepage}}" rel="me" target="_blank" rel="noopener noreferrer">{{include file="sub/punct_wrap.tpl" text=$profile.homepage}}</a>{{if $profile.homepage_verified}}
 					<span title="{{$homepage_verified}}">✔</span>{{/if}}</span>
 			</div>

--- a/view/theme/frio/templates/prv_message.tpl
+++ b/view/theme/frio/templates/prv_message.tpl
@@ -25,30 +25,30 @@
 	<div id="prvmail-text-edit-bb" class="comment-edit-bb comment-icon-list">
 		<div class="btn-group">
 			<button type="button" class="btn btn-default icon bb-img" style="cursor: pointer;" title="{{$edimg}}" data-role="insert-formatting" data-comment=" " data-bbcode="imgprv" data-id="input">
-					<i class="fa fa-picture-o" aria-hidden="true"></i>
+					<i class="ri ri-image-line" aria-hidden="true"></i>
 			</button>
 			<button type="button" class="btn btn-default emojis" style="cursor: pointer;" aria-label="{{$edemojis}}" title="{{$edemojis}}">
-				<i class="fa fa-smile-o"></i>
+				<i class="ri ri-emotion-line"></i>
 			</button>
 		</div>
 	 <div class="btn-group">
 			<button type="button" class="btn btn-default icon bb-url" style="cursor: pointer;" title="{{$edurl}}" data-role="insert-formatting" data-comment=" " data-bbcode="url" data-id="input">
-					<i class="fa fa-link" aria-hidden="true"></i>
+					<i class="ri ri-link" aria-hidden="true"></i>
 			</button>
 			<button type="button" class="btn btn-default icon underline" style="cursor: pointer;" title="{{$eduline}}" data-role="insert-formatting" data-comment=" " data-bbcode="u" data-id="input">
-				<i class="fa fa-underline" aria-hidden="true"></i>
+				<i class="ri ri-underline" aria-hidden="true"></i>
 			</button>
 			<button type="button" class="btn btn-default icon italic" style="cursor: pointer;" title="{{$editalic}}" data-role="insert-formatting" data-comment=" " data-bbcode="i" data-id="input">
-				<i class="fa fa-italic" aria-hidden="true"></i>
+				<i class="ri ri-italic" aria-hidden="true"></i>
 			</button>
 			<button type="button" class="btn btn-default icon bold" style="cursor: pointer;"  title="{{$edbold}}" data-role="insert-formatting" data-comment=" " data-bbcode="b" data-id="input">
-				<i class="fa fa-bold" aria-hidden="true"></i>
+				<i class="ri ri-bold" aria-hidden="true"></i>
 			</button>
 			<button type="button" class="btn btn-default icon quote" style="cursor: pointer;" title="{{$edquote}}" data-role="insert-formatting" data-comment=" " data-bbcode="quote" data-id="input">
-				<i class="fa fa-quote-left" aria-hidden="true"></i>
+				<i class="ri ri-double-quotes-l" aria-hidden="true"></i>
 			</button>
 			<button type="button" class="btn btn-default icon code" style="cursor: pointer;" title="{{$edquote}}" data-role="insert-formatting" data-comment=" " data-bbcode="code" data-id="input">
-				<i class="fa fa-code" aria-hidden="true"></i>
+				<i class="ri ri-code-line" aria-hidden="true"></i>
 			</button>
 		</div>
 	</div>
@@ -59,7 +59,7 @@
 	{{* The submit button *}}
 	<div id="prvmail-submit-wrapper">
 		<button type="submit" id="prvmail-submit" name="submit" value="{{$submit}}" class="btn btn-primary pull-right"  tabindex="13">
-			<i class="fa fa-envelope fa-fw" aria-hidden="true"></i>
+			<i class="ri ri-mail-line ri-fw" aria-hidden="true"></i>
 			{{$submit}}
 		</button>
 	</div>

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -57,10 +57,10 @@
 				{{/if}}
 				{{if $item.lock}}
 					<span class="navicon lock fakelink" onClick="lockview(event, 'item', {{$item.id}});" title="{{$item.lock}}">
-						&nbsp;<small><i class="fa fa-lock" aria-hidden="true"></i></small>
+						&nbsp;<small><i class="ri ri-lock-line" aria-hidden="true"></i></small>
 					</span>
 				{{elseif $item.connector}}
-					<span class="fa fa-lock" title="{{$item.connector}}"></span>
+					<span class="ri ri-lock-line" title="{{$item.connector}}"></span>
 				{{/if}}
 					<div class="additional-info text-muted">
 						<div id="wall-item-ago-{{$item.id}}" class="wall-item-ago">
@@ -69,7 +69,7 @@
 									<time class="time" title="{{$item.localtime}}" data-toggle="tooltip" datetime="{{$item.utc}}">{{$item.ago}}</time>
 								</a>
 								{{if $item.pinned}}
-									<span aria-hidden="true">&bull;</span> <i class="fa fa-thumb-tack" aria-hidden="true" title="{{$item.pinned}}"></i>
+									<span aria-hidden="true">&bull;</span> <i class="ri ri-pushpin-line" aria-hidden="true" title="{{$item.pinned}}"></i>
 									<span class="sr-only">{{$item.pinned}}</span>
 								{{/if}}
 							</small>
@@ -125,11 +125,11 @@
 				<div class="wall-item-tags">
 			{{if !$item.suppress_tags}}
 				{{foreach $item.hashtags as $tag}}
-					<span class="tag label btn-info sm">{{$tag nofilter}} <i class="fa fa-bolt" aria-hidden="true"></i></span>
+					<span class="tag label btn-info sm">{{$tag nofilter}} <i class="ri ri-flashlight-line" aria-hidden="true"></i></span>
 				{{/foreach}}
 
 				{{foreach $item.mentions as $tag}}
-					<span class="mention label btn-warning sm">{{$tag nofilter}} <i class="fa fa-user" aria-hidden="true"></i></span>
+					<span class="mention label btn-warning sm">{{$tag nofilter}} <i class="ri ri-user-line" aria-hidden="true"></i></span>
 				{{/foreach}}
 			{{/if}}
 
@@ -177,7 +177,7 @@
 							{{if $item.vote.like OR $item.vote.dislike OR $item.comment_html}}
 					<span class="separator"aria-hidden="true">•</span>
 							{{/if}}
-					<button type="button" class="btn btn-default" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="fa fa-retweet" aria-hidden="true"></i></button>
+					<button type="button" class="btn btn-default" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="ri ri-repeat-line" aria-hidden="true"></i></button>
 						{{/if}}
 					{{/if}}
 
@@ -185,65 +185,65 @@
 				{{if $item.menu && ($item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.ignore || $item.drop.dropping || $item.browsershare)}}
 					<span class="separator"></span>
 					<span class="more-links btn-group{{if $item.thread_level> 1}} dropup{{/if}}">
-						<button type="button" class="btn-link dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="fa fa-ellipsis-h" aria-hidden="true"></i>&nbsp;{{$item.menu}}</button>
+						<button type="button" class="btn-link dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="ri ri-more-line" aria-hidden="true"></i>&nbsp;{{$item.menu}}</button>
 						<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenuOptions-{{$item.id}}">
 						{{if $item.edpost}} {{* edit the posting *}}
 							<li role="menuitem">
-								<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" title="{{$item.edpost.1}}" class="btn-link navicon pencil"><i class="fa fa-pencil" aria-hidden="true"></i> {{$item.edpost.1}}</a>
+								<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" title="{{$item.edpost.1}}" class="btn-link navicon pencil"><i class="ri ri-pencil-line" aria-hidden="true"></i> {{$item.edpost.1}}</a>
 							</li>
 						{{/if}}
 
 						{{if $item.tagger}} {{* tag the post *}}
 							<li role="menuitem">
-								<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i> {{$item.tagger.add}}</a>
+								<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="ri ri-price-tag-3-line" aria-hidden="true"></i> {{$item.tagger.add}}</a>
 							</li>
 						{{/if}}
 
 						{{if $item.filer}}
 							<li role="menuitem">
-								<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="fa fa-folder" aria-hidden="true"></i>&nbsp;{{$item.filer}}</a>
+								<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="ri ri-folder-line" aria-hidden="true"></i>&nbsp;{{$item.filer}}</a>
 							</li>
 						{{/if}}
 
 						{{if $item.pin}}
 							<li role="menuitem">
-								<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-circle-o" aria-hidden="true"></i>&nbsp;{{$item.pin.do}}</a>
-								<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="fa fa-dot-circle-o" aria-hidden="true"></i>&nbsp;{{$item.pin.undo}}</a>
+								<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="ri ri-circle-line" aria-hidden="true"></i>&nbsp;{{$item.pin.do}}</a>
+								<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="ri ri-record-circle-line" aria-hidden="true"></i>&nbsp;{{$item.pin.undo}}</a>
 							</li>
 						{{/if}}
 
 						{{if $item.star}}
 							<li role="menuitem">
-								<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-bookmark-o" aria-hidden="true"></i>&nbsp;{{$item.star.do}}</a>
-								<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-bookmark" aria-hidden="true"></i>&nbsp;{{$item.star.undo}}</a>
+								<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="ri ri-bookmark-line" aria-hidden="true"></i>&nbsp;{{$item.star.do}}</a>
+								<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="ri ri-bookmark-fill" aria-hidden="true"></i>&nbsp;{{$item.star.undo}}</a>
 							</li>
 						{{/if}}
 
 						{{if $item.follow_thread}}
 							<li role="menuitem">
-								<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="fa fa-plus" aria-hidden="true"></i>&nbsp;{{$item.follow_thread.title}}</a>
+								<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="ri ri-add-line" aria-hidden="true"></i>&nbsp;{{$item.follow_thread.title}}</a>
 							</li>
 						{{/if}}
 
 						{{if $item.complete_thread}}
 							<li role="menuitem">
-								<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="fa fa-download" aria-hidden="true"></i>&nbsp;{{$item.complete_thread.title}}</a>
+								<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="ri ri-download-line" aria-hidden="true"></i>&nbsp;{{$item.complete_thread.title}}</a>
 							</li>
 						{{/if}}
 
 						{{if $item.language}}
 						<li role="menuitem">
-							<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&nbsp;{{$item.language}}</a>
+							<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="ri ri-translate-2" aria-hidden="true"></i>&nbsp;{{$item.language}}</a>
 						</li>
 						{{/if}}
 
 						<li role="menuitem">
-							<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&nbsp;{{$item.searchtext}}</a>
+							<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="ri ri-file-text-line" aria-hidden="true"></i>&nbsp;{{$item.searchtext}}</a>
 						</li>
 
 						{{if $item.browsershare}}
 							<li role="menuitem" class="button-browser-share">
-								<a id="browser-share-{{$item.id}}" href="javascript:navigator.share({url: '{{$item.plink.orig}}'});" class="btn-link button-browser-share" title="{{$item.browsershare.1}}"><i class="fa fa-share-alt" aria-hidden="true"></i>&nbsp;{{$item.browsershare.0}}</a>
+								<a id="browser-share-{{$item.id}}" href="javascript:navigator.share({url: '{{$item.plink.orig}}'});" class="btn-link button-browser-share" title="{{$item.browsershare.1}}"><i class="ri ri-share-line" aria-hidden="true"></i>&nbsp;{{$item.browsershare.0}}</a>
 							</li>
 						{{/if}}
 
@@ -253,16 +253,16 @@
 
 						{{if $item.ignore}}
 							<li role="menuitem">
-								<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-bell-slash" aria-hidden="true"></i> {{$item.ignore.do}}</a>
+								<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="ri ri-notification-off-line" aria-hidden="true"></i> {{$item.ignore.do}}</a>
 							</li>
 							<li role="menuitem">
-								<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-bell" aria-hidden="true"></i> {{$item.ignore.undo}}</a>
+								<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="ri ri-notification-3-line" aria-hidden="true"></i> {{$item.ignore.undo}}</a>
 							</li>
 						{{/if}}
 
 						{{if $item.drop && $item.drop.dropping}}
 							<li role="menuitem">
-								<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="fa fa-trash" aria-hidden="true"></i> {{$item.drop.label}}</a>
+								<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="ri ri-delete-bin-line" aria-hidden="true"></i> {{$item.drop.label}}</a>
 							</li>
 							{{/if}}
 						</ul>
@@ -277,9 +277,9 @@
 					{{* Event attendance buttons *}}
 				{{if $item.isevent}}
 					<span class="vote-event">
-						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});"><i class="fa fa-check" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i></button>
-						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});"><i class="fa fa-times" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i></button>
-						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});"><i class="fa fa-question" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i></button>
+						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});"><i class="ri ri-check-line" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i></button>
+						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});"><i class="ri ri-close-line" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i></button>
+						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});"><i class="ri ri-question-line" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i></button>
 					</span>
 				{{/if}}
 
@@ -296,7 +296,7 @@
 			{{if $item.emojis}}
 				{{foreach $item.emojis as $emoji}}
 					{{if $emoji.icon.fa}}
-						<span class="wall-item-emoji" title="{{$emoji.title}}"><i class="fa {{$emoji.icon.fa}}" aria-hidden="true"></i> {{$emoji.total}}</span>
+						<span class="wall-item-emoji" title="{{$emoji.title}}"><i class="ri {{$emoji.icon.fa}}" aria-hidden="true"></i> {{$emoji.total}}</span>
 					{{else}}
 						<span class="wall-item-emoji" title="{{$emoji.title}}">{{$emoji.emoji}} {{$emoji.total}}</span>
 					{{/if}}

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -195,7 +195,7 @@
 
 						{{if $item.tagger}} {{* tag the post *}}
 							<li role="menuitem">
-								<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="ri ri-price-tag-3-line" aria-hidden="true"></i> {{$item.tagger.add}}</a>
+								<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="ri ri-hashtag" aria-hidden="true"></i> {{$item.tagger.add}}</a>
 							</li>
 						{{/if}}
 

--- a/view/theme/frio/templates/searchbox.tpl
+++ b/view/theme/frio/templates/searchbox.tpl
@@ -53,7 +53,7 @@ Some parts of this template will be moved by js to other places (see theme.js) -
 
 {{if $s}}
 	<a href="search/saved/add?term={{$q}}&amp;return_url={{$return_url}}" class="action-button btn btn-primary pull-right" id="search-save">
-		<i class="fa fa-lg fa-floppy-o" aria-hidden="true"></i>
+		<i class="ri ri-lg ri-save-line" aria-hidden="true"></i>
 		<span>{{$action_text}}</span>
 	</a>
 {{/if}}

--- a/view/theme/frio/templates/settings/oauth.tpl
+++ b/view/theme/frio/templates/settings/oauth.tpl
@@ -30,7 +30,7 @@
 						<td>{{$app.created_at}}</td>
 						<td>
 							<button type="submit" class="btn" title="{{$delete}}" name="delete" value="{{$app.id}}">
-								<i class="fa fa-trash" aria-hidden="true"></i>
+								<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
 							</button>
 						</td>
 					</tr>

--- a/view/theme/frio/templates/settings/profile/index.tpl
+++ b/view/theme/frio/templates/settings/profile/index.tpl
@@ -11,7 +11,7 @@
 	<div id="profile-edit-links">
 		<ul class="nav nav-pills preferences">
 			<li>
-				<a class="btn btn-primary" href="profile/{{$nickname}}/profile"><i class="fa fa-eye" aria-hidden="true"></i>&nbsp;{{$l10n.viewprof}}</a>
+				<a class="btn btn-primary" href="profile/{{$nickname}}/profile"><i class="ri ri-eye-line" aria-hidden="true"></i>&nbsp;{{$l10n.viewprof}}</a>
 			</li>
 		</ul>
 	</div>

--- a/view/theme/frio/templates/sub/delivery_count.tpl
+++ b/view/theme/frio/templates/sub/delivery_count.tpl
@@ -8,19 +8,19 @@
 <span class="delivery">
 	<span aria-hidden="true">&bull;</span>
 	{{if $delivery.queue_count == 0}}
-		<i class="fa fa-hourglass-o" aria-hidden="true" title="{{$delivery.notifier_pending}}"></i>
+		<i class="ri ri-hourglass-line" aria-hidden="true" title="{{$delivery.notifier_pending}}"></i>
 		<span class="sr-only">{{$delivery.notifier_pending}}</span>
 	{{elseif $delivery.queue_done == 0}}
-		<i class="fa fa-hourglass" aria-hidden="true" title="{{$delivery.delivery_pending}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}"></i>
+		<i class="ri ri-hourglass-line" aria-hidden="true" title="{{$delivery.delivery_pending}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}"></i>
 		<span class="sr-only">{{$delivery.delivery_pending}}</span>
 	{{elseif $delivery.queue_done / $delivery.queue_count < 0.75}}
-		<i class="fa fa-paper-plane-o" aria-hidden="true" title="{{$delivery.delivery_underway}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}"></i>
+		<i class="ri ri-send-plane-line" aria-hidden="true" title="{{$delivery.delivery_underway}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}"></i>
 		<span class="sr-only">{{$delivery.delivery_underway}}</span>
 	{{elseif $delivery.queue_done < $delivery.queue_count}}
-		<i class="fa fa-paper-plane" aria-hidden="true" title="{{$delivery.delivery_almost}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}"></i>
+		<i class="ri ri-send-plane-fill" aria-hidden="true" title="{{$delivery.delivery_almost}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}"></i>
 		<span class="sr-only">{{$delivery.delivery_almost}}</span>
 	{{else}}
-		<i class="fa fa-check" aria-hidden="true" title="{{$delivery.delivery_done}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}"></i>
+		<i class="ri ri-check-line" aria-hidden="true" title="{{$delivery.delivery_done}} {{$item.delivery.queue_done}}/{{$item.delivery.queue_count}}"></i>
 		<span class="sr-only">{{$delivery.delivery_done}}</span>
 	{{/if}}
 </span>

--- a/view/theme/frio/templates/sub/direction.tpl
+++ b/view/theme/frio/templates/sub/direction.tpl
@@ -28,7 +28,7 @@
 		{{elseif $direction.direction == 10}}
 			<i class="ri ri-server-line"></i>
 		{{elseif $direction.direction == 11}}
-			<i class="ri ri-rss-line"></i>
+			<i class="ri ri-broadcast-line"></i>
 		{{/if}}
 	</span>
 {{/if}}

--- a/view/theme/frio/templates/sub/direction.tpl
+++ b/view/theme/frio/templates/sub/direction.tpl
@@ -22,13 +22,13 @@
 		{{elseif $direction.direction == 7}}
 			<i class="ri ri-at-line"></i>
 		{{elseif $direction.direction == 8}}
-			<i class="ri ri-share-forward-line"></i>
+			<i class="ri ri-save-line"></i>
 		{{elseif $direction.direction == 9}}
 			<i class="ri ri-global-line"></i>
 		{{elseif $direction.direction == 10}}
-			<i class="ri ri-inbox-line"></i>
+			<i class="ri ri-server-line"></i>
 		{{elseif $direction.direction == 11}}
-			<i class="ri ri-sticky-note-line"></i>
+			<i class="ri ri-rss-line"></i>
 		{{/if}}
 	</span>
 {{/if}}

--- a/view/theme/frio/templates/sub/direction.tpl
+++ b/view/theme/frio/templates/sub/direction.tpl
@@ -8,27 +8,27 @@
 	<span class="direction" title="{{$direction.title}}">
 		<span aria-hidden="true">&bull;</span>
 		{{if $direction.direction == 1}}
-			<i class="fa fa-inbox"></i>
+			<i class="ri ri-inbox-line"></i>
 		{{elseif $direction.direction == 2}}
-			<i class="fa fa-download"></i>
+			<i class="ri ri-download-line"></i>
 		{{elseif $direction.direction == 3}}
-			<i class="fa fa-retweet"></i>
+			<i class="ri ri-repeat-line"></i>
 		{{elseif $direction.direction == 4}}
-			<i class="fa fa-hashtag"></i>
+			<i class="ri ri-hashtag"></i>
 		{{elseif $direction.direction == 5}}
-			<i class="fa fa-comment-o"></i>
+			<i class="ri ri-chat-1-line"></i>
 		{{elseif $direction.direction == 6}}
-			<i class="fa fa-user"></i>
+			<i class="ri ri-user-line"></i>
 		{{elseif $direction.direction == 7}}
-			<i class="fa fa-at"></i>
+			<i class="ri ri-at-line"></i>
 		{{elseif $direction.direction == 8}}
-			<i class="fa fa-share"></i>
+			<i class="ri ri-share-forward-line"></i>
 		{{elseif $direction.direction == 9}}
-			<i class="fa fa-globe"></i>
+			<i class="ri ri-global-line"></i>
 		{{elseif $direction.direction == 10}}
-			<i class="fa fa-inbox"></i>
+			<i class="ri ri-inbox-line"></i>
 		{{elseif $direction.direction == 11}}
-			<i class="fa fa-sticky-note"></i>
+			<i class="ri ri-sticky-note-line"></i>
 		{{/if}}
 	</span>
 {{/if}}

--- a/view/theme/frio/templates/threaded_conversation.tpl
+++ b/view/theme/frio/templates/threaded_conversation.tpl
@@ -23,7 +23,7 @@
 
 {{if $dropping}}
 <button type="button" id="item-delete-selected" class="btn btn-link" title="{{$dropping}}" onclick="deleteCheckedItems();" data-toggle="tooltip">
-	<i class="fa fa-trash" aria-hidden="true"></i>
+	<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
 </button>
 {{/if}}
 {{/if}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -37,11 +37,11 @@ as the value of $top_child_total (this is done at the end of this file)
 	{{if $item.thread_level<3}}
 		<button type="button" class="hide-comments-outer fakelink" onclick="showHideComments({{$item.id}});">
 			<span id="hide-comments-total-{{$item.id}}" class="hide-comments-total">
-				<i class="ri ri-arrow-right-s-fill" aria-hidden="true"></i>
-				{{$item.num_comments}} - {{$item.show_text}}
-			</span>
-			<span id="hide-comments-{{$item.id}}" class="hide-comments" style="display: none">
-				<i class="ri ri-arrow-down-s-fill" aria-hidden="true"></i>
+					<i class="ri ri-arrow-right-s-line" aria-hidden="true"></i>
+					{{$item.num_comments}} - {{$item.show_text}}
+				</span>
+				<span id="hide-comments-{{$item.id}}" class="hide-comments" style="display: none">
+					<i class="ri ri-arrow-down-s-line" aria-hidden="true"></i>
 				{{$item.num_comments}} - {{$item.hide_text}}
 			</span>
 		</button>
@@ -423,7 +423,7 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* TODO: This currently creates a duplicate post according to: https://forum.friendi.ca/display/373ebf56-2469-ed09-ccc0-ecd539065051 *}}
 				{{if $item.tagger}} {{* tag the post *}}
 				<li role="menuitem">
-						<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}"><i class="ri ri-price-tag-3-line" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
+						<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}"><i class="ri ri-hashtag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
 				</li>
 				{{/if}}
 
@@ -640,7 +640,7 @@ as the value of $top_child_total (this is done at the end of this file)
 
 							{{if $item.tagger}} {{* tag the post *}}
 								<li role="menuitem">
-									<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="ri ri-price-tag-3-line" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
+									<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="ri ri-hashtag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
 								</li>
 							{{/if}}
 

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -37,11 +37,11 @@ as the value of $top_child_total (this is done at the end of this file)
 	{{if $item.thread_level<3}}
 		<button type="button" class="hide-comments-outer fakelink" onclick="showHideComments({{$item.id}});">
 			<span id="hide-comments-total-{{$item.id}}" class="hide-comments-total">
-				<i class="fa fa-caret-right" aria-hidden="true"></i>
+				<i class="ri ri-arrow-right-s-fill" aria-hidden="true"></i>
 				{{$item.num_comments}} - {{$item.show_text}}
 			</span>
 			<span id="hide-comments-{{$item.id}}" class="hide-comments" style="display: none">
-				<i class="fa fa-caret-down" aria-hidden="true"></i>
+				<i class="ri ri-arrow-down-s-fill" aria-hidden="true"></i>
 				{{$item.num_comments}} - {{$item.hide_text}}
 			</span>
 		</button>
@@ -62,7 +62,7 @@ as the value of $top_child_total (this is done at the end of this file)
 	<article class="media {{$item.shiny}}" aria-posinset="{{$item.id}}" aria-setsize="-1">
 	{{if $item.parentguid}}
 		<span class="visible-sm-inline visible-xs wall-item-responses time">
-			<i class="fa fa-reply" aria-hidden="true"></i> <a id="btn-{{$item.id}}" class="" href="javascript:;" onclick="scrollToItem('item-' + '{{$item.parentguid}}');">{{$item.inreplyto}}</a>
+			<i class="ri ri-reply-line" aria-hidden="true"></i> <a id="btn-{{$item.id}}" class="" href="javascript:;" onclick="scrollToItem('item-' + '{{$item.parentguid}}');">{{$item.inreplyto}}</a>
 			{{if $item.reshared}}<i class="hidden-xs "aria-hidden="true">&#x2022;</i>{{/if}}
 		</span>
 	{{else}}
@@ -74,7 +74,7 @@ as the value of $top_child_total (this is done at the end of this file)
 		{{/if}}
 	{{/if}}
 	{{if $item.reshared}}
-		<span class="wall-item-announce wall-item-responses time" id="wall-item-announce-{{$item.id}}"><i class="fa fa-retweet" aria-hidden="true"></i> {{$item.reshared nofilter}}</span>
+		<span class="wall-item-announce wall-item-responses time" id="wall-item-announce-{{$item.id}}"><i class="ri ri-repeat-line" aria-hidden="true"></i> {{$item.reshared nofilter}}</span>
 	{{/if}}
 		<p>
 		{{* The avatar picture and the photo-menu *}}
@@ -162,16 +162,16 @@ as the value of $top_child_total (this is done at the end of this file)
 							{{include file="sub/direction.tpl" direction=$item.direction}}
 						{{/if}}
 						{{if $item.pinned}}
-							<span aria-hidden="true">&bull;</span> <i class="fa fa-thumb-tack" aria-hidden="true" title="{{$item.pinned}}"></i>
+							<span aria-hidden="true">&bull;</span> <i class="ri ri-pushpin-line" aria-hidden="true" title="{{$item.pinned}}"></i>
 							<span class="sr-only">{{$item.pinned}}</span>
 						{{/if}}
 						{{if $item.connector}}
 							<span aria-hidden="true">&bull;</span>
-							<i class="fa fa-plug" title="{{$item.connector}}" aria-hidden="true"></i>
+							<i class="ri ri-plug-line" title="{{$item.connector}}" aria-hidden="true"></i>
 						{{else}}
 							<span aria-hidden="true">&bull;</span>
 							<span class="navicon lock fakelink" onClick="lockview(event, 'item', {{$item.id}});" title="{{$item.privacy}}" data-toggle="tooltip">
-								<i class="fa {{if $item.private == 1}}fa-lock{{elseif $item.private == 0}}fa-globe{{else}}fa-low-vision{{/if}}" aria-hidden="true"></i>
+								<i class="ri {{if $item.private == 1}}ri-lock-line{{elseif $item.private == 0}}ri-global-line{{else}}ri-eye-off-line{{/if}}" aria-hidden="true"></i>
 							</span>
 						{{/if}}
 					</div>
@@ -204,12 +204,12 @@ as the value of $top_child_total (this is done at the end of this file)
 							{{if $item.connector}}
 								<span aria-hidden="true">&bull;</span>
 								<span title="{{$item.connector}}">
-									<i class="fa fa-plug" aria-hidden="true"></i>
+									<i class="ri ri-plug-line" aria-hidden="true"></i>
 								</span>
 							{{else}}
 								<span aria-hidden="true">&bull;</span>
 								<span class="navicon lock fakelink" onClick="lockview(event, 'item', {{$item.id}});" title="{{$item.privacy}}" data-toggle="tooltip">
-								<i class="fa {{if $item.private == 1}}fa-lock{{elseif $item.private == 0}}fa-globe{{else}}fa-low-vision{{/if}}" aria-hidden="true"></i>
+								<i class="ri {{if $item.private == 1}}ri-lock-line{{elseif $item.private == 0}}ri-global-line{{else}}ri-eye-off-line{{/if}}" aria-hidden="true"></i>
 								</span>
 							{{/if}}
 						</small>
@@ -226,7 +226,7 @@ as the value of $top_child_total (this is done at the end of this file)
 				<small>
 					{{if $item.parentguid}}
 						<span class="hidden-xs hidden-sm">
-							<a id="btn-{{$item.id}}" class="time" href="javascript:;" onclick="scrollToItem('item-' + '{{$item.parentguid}}');"><i class="fa fa-reply" aria-hidden="true"></i> {{$item.inreplyto}}</a>
+							<a id="btn-{{$item.id}}" class="time" href="javascript:;" onclick="scrollToItem('item-' + '{{$item.parentguid}}');"><i class="ri ri-reply-line" aria-hidden="true"></i> {{$item.inreplyto}}</a>
 							<i class="hidden-xs" aria-hidden="true">&#x2022;</i>
 						</span>
 					{{else}}
@@ -250,12 +250,12 @@ as the value of $top_child_total (this is done at the end of this file)
 					{{if $item.connector}}
 						<span title="{{$item.connector}}">
 							<span aria-hidden="true">&bull;</span>
-							<i class="fa fa-plug" aria-hidden="true"></i>
+							<i class="ri ri-plug-line" aria-hidden="true"></i>
 						</span>
 					{{else}}
 						<span class="navicon lock fakelink" onClick="lockview(event, 'item', {{$item.id}});" title="{{$item.privacy}}" data-toggle="tooltip">
 							<span aria-hidden="true">&bull;</span>
-							<i class="fa {{if $item.private == 1}}fa-lock{{elseif $item.private == 0}}fa-globe{{else}}fa-low-vision{{/if}}" aria-hidden="true"></i>
+							<i class="ri {{if $item.private == 1}}ri-lock-line{{elseif $item.private == 0}}ri-global-line{{else}}ri-eye-off-line{{/if}}" aria-hidden="true"></i>
 						</span>
 					{{/if}}
 				</small>
@@ -286,15 +286,15 @@ as the value of $top_child_total (this is done at the end of this file)
 			<div class="wall-item-tags" lang="{{$item.lang}}">
 		{{if !$item.suppress_tags}}
 			{{foreach $item.hashtags as $tag}}
-				<span class="tag label btn-info sm">{{$tag nofilter}} <i class="fa fa-bolt" aria-hidden="true"></i></span>
+				<span class="tag label btn-info sm">{{$tag nofilter}} <i class="ri ri-flashlight-line" aria-hidden="true"></i></span>
 			{{/foreach}}
 
 			{{foreach $item.mentions as $tag}}
-				<span class="mention label btn-warning sm">{{$tag nofilter}} <i class="fa fa-user" aria-hidden="true"></i></span>
+				<span class="mention label btn-warning sm">{{$tag nofilter}} <i class="ri ri-user-line" aria-hidden="true"></i></span>
 			{{/foreach}}
 
 			{{*foreach $item.implicit_mentions as $tag}}
-				<span class="mention label label-default sm">{{$tag nofilter}} <i class="fa fa-eye-slash" aria-hidden="true"></i></span>
+				<span class="mention label label-default sm">{{$tag nofilter}} <i class="ri ri-eye-off-line" aria-hidden="true"></i></span>
 			{{/foreach*}}
 		{{/if}}
 			{{foreach $item.folders as $folder}}
@@ -318,12 +318,12 @@ as the value of $top_child_total (this is done at the end of this file)
 			{{* Button to open the comment text field *}}
 				<span class="wall-item-response">
 				{{if $item.comment_html}}
-					<button type="button" class="btn-link button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="fa fa-commenting" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="ri ri-chat-3-line" aria-hidden="true"></i></button>
 					<span title="{{$item.responses.comment.title}}">{{$item.responses.comment.total}}</span>
 				{{elseif $item.remote_comment}}
-					<a href="{{$item.remote_comment.2}}" class="btn-link button-comments" title="{{$item.remote_comment.0}}"><i class="fa fa-commenting" aria-hidden="true"></i></a>
+					<a href="{{$item.remote_comment.2}}" class="btn-link button-comments" title="{{$item.remote_comment.0}}"><i class="ri ri-chat-3-line" aria-hidden="true"></i></a>
 				{{else}}
-					<button type="button" class="btn-link button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" disabled><i class="fa fa-commenting-o" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" disabled><i class="ri ri-chat-3-line" aria-hidden="true"></i></button>
 				{{/if}}
 				</span>
 
@@ -331,18 +331,18 @@ as the value of $top_child_total (this is done at the end of this file)
 			{{if $item.vote}}
 				<span class="wall-item-response">
 				{{if $item.vote.announce}}
-					<button type="button" class="btn-link button-announces{{if $item.responses.announce.self}} active" aria-pressed="true{{/if}}" id="announce-{{$item.id}}" title="{{$item.vote.announce.0}}" onclick="doActivityItemAction({{$item.id}}, 'announce'{{if $item.responses.announce.self}}, true{{/if}});" ><i class="fa fa-retweet" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-announces{{if $item.responses.announce.self}} active" aria-pressed="true{{/if}}" id="announce-{{$item.id}}" title="{{$item.vote.announce.0}}" onclick="doActivityItemAction({{$item.id}}, 'announce'{{if $item.responses.announce.self}}, true{{/if}});" ><i class="ri ri-repeat-line" aria-hidden="true"></i></button>
 					<span title="{{$item.responses.announce.title}}">{{$item.responses.announce.total}}</span>
 				{{else}}
-					<button type="button" class="btn-link button-announces" id="announce-{{$item.id}}" title="{{$item.vote.announce.0}}" disabled><i class="fa fa-retweet" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-announces" id="announce-{{$item.id}}" title="{{$item.vote.announce.0}}" disabled><i class="ri ri-repeat-line" aria-hidden="true"></i></button>
 				{{/if}}
 				</span>
 				<span class="wall-item-response">
 				{{if $item.vote.share}}
-					<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="fa fa-quote-right" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="ri ri-double-quotes-r" aria-hidden="true"></i></button>
 					<span title="{{$item.quoteshares.title}}">{{$item.quoteshares.total}}</span>
 				{{else}}
-					<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" disabled><i class="fa fa-quote-right" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" disabled><i class="ri ri-double-quotes-r" aria-hidden="true"></i></button>
 				{{/if}}
 				</span>
 			{{/if}}
@@ -351,24 +351,24 @@ as the value of $top_child_total (this is done at the end of this file)
 			{{if $item.vote}}
 				<span class="wall-item-response">
 				{{if $item.vote.like}}
-					<button type="button" class="btn-link button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doActivityItemAction({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}});" ><i class="fa fa-thumbs-up" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doActivityItemAction({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}});" ><i class="ri ri-thumb-up-line" aria-hidden="true"></i></button>
 					<span title="{{$item.responses.like.title}}">{{$item.responses.like.total}}</span>
 				{{else}}
-					<button type="button" class="btn-link button-likes" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" disabled><i class="fa fa-thumbs-o-up" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-likes" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" disabled><i class="ri ri-thumb-up-line" aria-hidden="true"></i></button>
 				{{/if}}
 				</span>
 				<span class="wall-item-response">
 				{{if $item.vote.dislike}}
-					<button type="button" class="btn-link button-likes{{if $item.responses.dislike.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doActivityItemAction({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}});" ><i class="fa fa-thumbs-down" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-likes{{if $item.responses.dislike.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doActivityItemAction({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}});" ><i class="ri ri-thumb-down-line" aria-hidden="true"></i></button>
 					<span title="{{$item.responses.dislike.title}}">{{$item.responses.dislike.total}}</span>
 				{{elseif !$item.hide_dislike}}
-					<button type="button" class="btn-link button-likes" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" disabled><i class="fa fa-thumbs-o-down" aria-hidden="true"></i></button>
+					<button type="button" class="btn-link button-likes" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" disabled><i class="ri ri-thumb-down-line" aria-hidden="true"></i></button>
 				{{/if}}
 				</span>
 
 				{{foreach $item.reactions as $emoji}}
 					{{if $emoji.icon.fa}}
-						<span class="wall-item-emoji" title="{{$emoji.title}}"><i class="fa {{$emoji.icon.fa}}" aria-hidden="true"></i> {{$emoji.total}}</span>
+						<span class="wall-item-emoji" title="{{$emoji.title}}"><i class="ri {{$emoji.icon.fa}}" aria-hidden="true"></i> {{$emoji.total}}</span>
 					{{else}}
 						<span class="wall-item-emoji" title="{{$emoji.title}}">{{$emoji.emoji}} {{$emoji.total}}</span>
 					{{/if}}
@@ -379,15 +379,15 @@ as the value of $top_child_total (this is done at the end of this file)
 			<span class="vote-event">
 			{{if $item.isevent}}
 				<span class="wall-item-response">
-					<button type="button" class="btn-link button-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});"><i class="fa fa-check" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i></button>
+					<button type="button" class="btn-link button-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});"><i class="ri ri-check-line" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i></button>
 					<span title="{{$item.responses.attendyes.title}}">{{$item.responses.attendyes.total}}</span>
 				</span>
 				<span class="wall-item-response">
-					<button type="button" class="btn-link button-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});"><i class="fa fa-times" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i></button>
+					<button type="button" class="btn-link button-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});"><i class="ri ri-close-line" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i></button>
 					<span title="{{$item.responses.attendno.title}}">{{$item.responses.attendno.total}}</span>
 				</span>
 				<span class="wall-item-response">
-					<button type="button" class="btn-link button-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});"><i class="fa fa-question" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i></button>
+					<button type="button" class="btn-link button-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});"><i class="ri ri-question-line" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i></button>
 					<span title="{{$item.responses.attendmaybe.title}}">{{$item.responses.attendmaybe.total}}</span>
 				</span>
 			{{else}}
@@ -401,21 +401,21 @@ as the value of $top_child_total (this is done at the end of this file)
 			<span class="wall-item-actions-right hidden-xs">
 			{{* Put additional actions in a dropdown menu *}}
 		<span class="more-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}">
-			<button type="button" class="btn-link dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="fa fa-ellipsis-h" aria-hidden="true"></i></button>
+			<button type="button" class="btn-link dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="ri ri-more-line" aria-hidden="true"></i></button>
 			<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenuOptions-{{$item.id}}">
 
 				{{* Available: On your own posts and comments *}}
 				{{if $item.edpost}} {{* edit the posting *}}
 				<li role="menuitem">
-						<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" class="btn-link navicon pencil"><i class="fa fa-pencil" aria-hidden="true"></i>&ensp;{{$item.edpost.1}}</a>
+						<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" class="btn-link navicon pencil"><i class="ri ri-pencil-line" aria-hidden="true"></i>&ensp;{{$item.edpost.1}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On your own posts *}}
 				{{if $item.pin}}
 				<li role="menuitem">
-						<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
-						<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.undo}}</a>
+						<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}"><i class="ri ri-pushpin-line" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
+						<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}"><i class="ri ri-pushpin-line" aria-hidden="true"></i>&ensp;{{$item.pin.undo}}</a>
 				</li>
 				{{/if}}
 
@@ -423,22 +423,22 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* TODO: This currently creates a duplicate post according to: https://forum.friendi.ca/display/373ebf56-2469-ed09-ccc0-ecd539065051 *}}
 				{{if $item.tagger}} {{* tag the post *}}
 				<li role="menuitem">
-						<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}"><i class="fa fa-tag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
+						<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}"><i class="ri ri-price-tag-3-line" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On posts made by anyone *}}
 				{{if $item.star}}
 				<li role="menuitem">
-						<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}"><i class="fa fa-bookmark-o" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
-						<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}"><i class="fa fa-bookmark" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
+						<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}"><i class="ri ri-bookmark-line" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
+						<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}"><i class="ri ri-bookmark-fill" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On all posts and comments *}}
 				{{if $item.filer}}
 				<li role="menuitem">
-						<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon"><i class="fa fa-folder" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
+						<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon"><i class="ri ri-folder-line" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
 				</li>
 				{{/if}}
 
@@ -448,7 +448,7 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* TODO: Add the relevant checks so this is only available/clickable when on a device where its supported *}}
 				{{if $item.browsershare}}
 				<li role="menuitem" class="button-browser-share">
-						<a id="browser-share-{{$item.id}}" href="javascript:navigator.share({url: '{{$item.plink.orig}}'})" class="btn-link button-browser-share" title="{{$item.browsershare.1}}"><i class="fa fa-share-alt" aria-hidden="true"></i>&ensp;{{$item.browsershare.0}}</a>
+						<a id="browser-share-{{$item.id}}" href="javascript:navigator.share({url: '{{$item.plink.orig}}'})" class="btn-link button-browser-share" title="{{$item.browsershare.1}}"><i class="ri ri-share-line" aria-hidden="true"></i>&ensp;{{$item.browsershare.0}}</a>
 				</li>
 				{{/if}}
 
@@ -456,24 +456,24 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Identical to unignore in functionality but only seen on posts you haven't liked/commented on - could they be merged? *}}
 				{{if $item.follow_thread}}
 				<li role="menuitem">
-						<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link"><i class="fa fa-bell" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
+						<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link"><i class="ri ri-notification-3-line" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On all posts *}}
 				{{if $item.ignore}}
 				<li role="menuitem">
-						<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}"><i class="fa fa-bell-slash" aria-hidden="true"></i>&ensp;{{$item.ignore.do}}</a>
+						<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}"><i class="ri ri-notification-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore.do}}</a>
 				</li>
 				<li role="menuitem">
-						<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"><i class="fa fa-bell" aria-hidden="true"></i>&ensp;{{$item.ignore.undo}}</a>
+						<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"><i class="ri ri-notification-3-line" aria-hidden="true"></i>&ensp;{{$item.ignore.undo}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On posts made by others *}}
 				{{if $item.complete_thread}}
 				<li role="menuitem">
-						<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link"><i class="fa fa-download" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
+						<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link"><i class="ri ri-download-line" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
 				</li>
 				{{/if}}
 
@@ -482,21 +482,21 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Available: On posts made by others *}}
 				{{if $item.collapse}}
 				<li role="menuitem">
-						<a class="btn-link navicon collapse" href="javascript:collapseAuthor('item/collapse/{{$item.id}}', 'item-{{$item.guid}}');"><i class="fa fa-minus-square" aria-hidden="true"></i>&ensp;{{$item.collapse.label}}</a>
+						<a class="btn-link navicon collapse" href="javascript:collapseAuthor('item/collapse/{{$item.id}}', 'item-{{$item.guid}}');"><i class="ri ri-subtract-line" aria-hidden="true"></i>&ensp;{{$item.collapse.label}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On posts made by others *}}
 				{{if $item.ignore_author}}
 				<li role="menuitem">
-						<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
+						<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');"><i class="ri ri-eye-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On posts made by others *}}
 				{{if $item.block}}
 				<li role="menuitem">
-						<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');"><i class="fa fa-ban" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
+						<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');"><i class="ri ri-forbid-2-line" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
 				</li>
 				{{/if}}
 
@@ -507,33 +507,33 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Available: On posts made by others *}}
 				{{if $item.ignore_server}}
 				<li role="menuitem">
-						<a class="btn-link navicon ignoreServer" href="javascript:ignoreServer('settings/server/{{$item.author_gsid}}/ignore', 'item-{{$item.guid}}');"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_server.label}}</a>
+						<a class="btn-link navicon ignoreServer" href="javascript:ignoreServer('settings/server/{{$item.author_gsid}}/ignore', 'item-{{$item.guid}}');"><i class="ri ri-eye-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore_server.label}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On all posts and comments *}}
 				<li role="menuitem">
-						<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
+						<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item"><i class="ri ri-file-text-line" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
 				</li>
 
 				{{* Available: On all posts and comments *}}
 				{{if $item.language}}
 				<li role="menuitem">
-						<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
+						<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item"><i class="ri ri-translate-2" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: On all posts and comments made by others *}}
 				{{if $item.report}}
 				<li role="menuitem">
-						<a class="btn-link navicon ignore" href="{{$item.report.href}}"><i class="fa fa-flag" aria-hidden="true"></i>&ensp;{{$item.report.label}}</a>
+						<a class="btn-link navicon ignore" href="{{$item.report.href}}"><i class="ri ri-flag-line" aria-hidden="true"></i>&ensp;{{$item.report.label}}</a>
 				</li>
 				{{/if}}
 
 				{{* Available: If you're an admin, on all posts and comments on your instance *}}
 				{{if $item.drop && $item.drop.dropping}}
 				<li role="menuitem">
-						<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');"><i class="fa fa-trash" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
+						<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');"><i class="ri ri-delete-bin-line" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
 				</li>
 				{{/if}}
 			</ul>
@@ -551,7 +551,7 @@ as the value of $top_child_total (this is done at the end of this file)
 				<div class="wall-item-actions-row">
 				{{* Button to open the comment text field *}}
 				{{if $item.comment_html}}
-					<button type="button" class="btn button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="fa fa-commenting" aria-hidden="true"></i>
+					<button type="button" class="btn button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="ri ri-chat-3-line" aria-hidden="true"></i>
 						<span title="{{$item.responses.comment.title}}">{{$item.responses.comment.total}}</span>
 					</button>
 				{{/if}}
@@ -559,18 +559,18 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{if $item.vote.announce OR $item.vote.share}}
 					<div class="share-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}" role="group">
 						<button type="button" class="btn dropdown-toggle{{if $item.responses.announce.self}} active{{/if}}" data-toggle="dropdown" id="shareMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}">
-							<i class="fa fa-share" aria-hidden="true"></i>
+							<i class="ri ri-share-forward-line" aria-hidden="true"></i>
 						</button>
 						<ul class="dropdown-menu dropdown-menu-left" role="menu" aria-labelledby="shareMenuOptions-{{$item.id}}">
 							{{if $item.vote.announce}} {{* edit the posting *}}
 							<li role="menuitem">
 								{{if $item.responses.announce.self}}
 								<a class="btn-link" id="announce-{{$item.id}}" href="javascript:doActivityItemAction({{$item.id}}, 'announce', true);" title="{{$item.vote.unannounce.0}}">
-									<i class="fa fa-ban" aria-hidden="true"></i> {{$item.vote.unannounce.1}}
+									<i class="ri ri-forbid-2-line" aria-hidden="true"></i> {{$item.vote.unannounce.1}}
 								</a>
 								{{else}}
 								<a class="btn-link" id="announce-{{$item.id}}" href="javascript:doActivityItemAction({{$item.id}}, 'announce');" title="{{$item.vote.announce.0}}">
-									<i class="fa fa-retweet" aria-hidden="true"></i> {{$item.vote.announce.1}}
+									<i class="ri ri-repeat-line" aria-hidden="true"></i> {{$item.vote.announce.1}}
 								</a>
 								{{/if}}
 							</li>
@@ -578,14 +578,14 @@ as the value of $top_child_total (this is done at the end of this file)
 							{{if $item.vote.share}}
 							<li role="menuitem">
 								<a class="btn-link" id="share-{{$item.id}}" href="javascript:jotShare({{$item.id}});" title="{{$item.vote.share.0}}">
-									<i class="fa fa-quote-right" aria-hidden="true"></i> {{$item.vote.share.1}}
+									<i class="ri ri-double-quotes-r" aria-hidden="true"></i> {{$item.vote.share.1}}
 								</a>
 							</li>
 							{{/if}}
 							{{if $item.browsershare}}
 							<li role="menuitem">
 								<button type="button" class="btn-link button-browser-share" onclick="navigator.share({url: '{{$item.plink.orig}}'})" title="{{$item.browsershare.1}}">
-									<i class="fa fa-share-alt" aria-hidden="true"></i> {{$item.browsershare.0}}
+									<i class="ri ri-share-line" aria-hidden="true"></i> {{$item.browsershare.0}}
 								</button>
 							</li>
 							{{/if}}
@@ -596,12 +596,12 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Buttons for like and dislike *}}
 				{{if $item.vote}}
 					{{if $item.vote.like}}
-					<button type="button" class="btn button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doActivityItemAction({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}});" ><i class="fa fa-thumbs-up" aria-hidden="true"></i>
+					<button type="button" class="btn button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doActivityItemAction({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}});" ><i class="ri ri-thumb-up-line" aria-hidden="true"></i>
 						<span title="{{$item.responses.like.title}}">{{$item.responses.like.total}}</span>
 					</button>
 					{{/if}}
 					{{if $item.vote.dislike}}
-					<button type="button" class="btn button-likes{{if $item.responses.dislike.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doActivityItemAction({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}});" ><i class="fa fa-thumbs-down" aria-hidden="true"></i>
+					<button type="button" class="btn button-likes{{if $item.responses.dislike.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doActivityItemAction({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}});" ><i class="ri ri-thumb-down-line" aria-hidden="true"></i>
 						<span title="{{$item.responses.dislike.title}}">{{$item.responses.dislike.total}}</span>
 					</button>
 					{{/if}}
@@ -609,13 +609,13 @@ as the value of $top_child_total (this is done at the end of this file)
 
 				{{* Event attendance buttons *}}
 				{{if $item.isevent}}
-				<button type="button" class="btn button-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});"><i class="fa fa-check" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i>
+				<button type="button" class="btn button-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});"><i class="ri ri-check-line" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i>
 					<span title="{{$item.responses.attendyes.title}}">{{$item.responses.attendyes.total}}</span>
 				</button>
-				<button type="button" class="btn button-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});"><i class="fa fa-times" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i>
+				<button type="button" class="btn button-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});"><i class="ri ri-close-line" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i>
 					<span title="{{$item.responses.attendno.title}}">{{$item.responses.attendno.total}}</span>
 				</button>
-				<button type="button" class="btn button-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});"><i class="fa fa-question" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i>
+				<button type="button" class="btn button-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});"><i class="ri ri-question-line" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i>
 					<span title="{{$item.responses.attendmaybe.title}}">{{$item.responses.attendmaybe.total}}</span>
 				</button>
 				{{/if}}
@@ -623,58 +623,58 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Put additional actions in a dropdown menu *}}
 				{{if $item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.ignore || ($item.drop && $item.drop.dropping)}}
 					<div class="more-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}">
-						<button type="button" class="btn dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="fa fa-ellipsis-h" aria-hidden="true"></i></button>
+						<button type="button" class="btn dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="ri ri-more-line" aria-hidden="true"></i></button>
 						<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenuOptions-{{$item.id}}">
 							{{if $item.edpost}} {{* edit the posting *}}
 							<li role="menuitem">
-								<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" title="{{$item.edpost.1}}" class="btn-link navicon pencil"><i class="fa fa-pencil" aria-hidden="true"></i>&ensp;{{$item.edpost.1}}</a>
+								<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" title="{{$item.edpost.1}}" class="btn-link navicon pencil"><i class="ri ri-pencil-line" aria-hidden="true"></i>&ensp;{{$item.edpost.1}}</a>
 							</li>
 							{{/if}}
 
 							{{if $item.pin}}
 								<li role="menuitem">
-									<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
-									<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="fa fa-thumb-tack" aria-hidden="true"></i>&ensp;{{$item.pin.undo}}</a>
+									<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="ri ri-pushpin-line" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
+									<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}" title="{{$item.pin.undo}}"><i class="ri ri-pushpin-line" aria-hidden="true"></i>&ensp;{{$item.pin.undo}}</a>
 								</li>
 							{{/if}}
 
 							{{if $item.tagger}} {{* tag the post *}}
 								<li role="menuitem">
-									<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="fa fa-tag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
+									<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="ri ri-price-tag-3-line" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
 								</li>
 							{{/if}}
 
 							{{if $item.star}}
 								<li role="menuitem">
-									<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="fa fa-bookmark-o" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
-									<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="fa fa-bookmark" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
+									<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="ri ri-bookmark-line" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
+									<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}" title="{{$item.star.undo}}"><i class="ri ri-bookmark-fill" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
 								</li>
 							{{/if}}
 
 							{{if $item.filer}}
 								<li role="menuitem">
-									<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="fa fa-folder" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
+									<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="ri ri-folder-line" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
 								</li>
 							{{/if}}
 
 							{{if $item.follow_thread}}
 								<li role="menuitem">
-									<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="fa fa-bell" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
+									<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="ri ri-notification-3-line" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
 								</li>
 							{{/if}}
 
 							{{if $item.ignore}}
 								<li role="menuitem">
-									<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="fa fa-bell-slash" aria-hidden="true"></i>&ensp;{{$item.ignore.do}}</a>
+									<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="ri ri-notification-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore.do}}</a>
 								</li>
 								<li role="menuitem">
-									<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="fa fa-bell" aria-hidden="true"></i>&ensp;{{$item.ignore.undo}}</a>
+									<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"  title="{{$item.ignore.undo}}"><i class="ri ri-notification-3-line" aria-hidden="true"></i>&ensp;{{$item.ignore.undo}}</a>
 								</li>
 							{{/if}}
 
 							{{if $item.complete_thread}}
 								<li role="menuitem">
-									<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="fa fa-download" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
+									<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="ri ri-download-line" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
 								</li>
 							{{/if}}
 
@@ -682,19 +682,19 @@ as the value of $top_child_total (this is done at the end of this file)
 
 							{{if $item.collapse}}
 								<li role="menuitem">
-									<a class="btn-link navicon collapse" href="javascript:collapseAuthor('item/collapse/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.collapse.label}}"><i class="fa fa-minus-square" aria-hidden="true"></i>&ensp;{{$item.collapse.label}}</a>
+									<a class="btn-link navicon collapse" href="javascript:collapseAuthor('item/collapse/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.collapse.label}}"><i class="ri ri-subtract-line" aria-hidden="true"></i>&ensp;{{$item.collapse.label}}</a>
 								</li>
 							{{/if}}
 
 							{{if $item.ignore_author}}
 								<li role="menuitem">
-									<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.ignore_author.label}}"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
+									<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.ignore_author.label}}"><i class="ri ri-eye-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
 								</li>
 							{{/if}}
 
 							{{if $item.block}}
 								<li role="menuitem">
-									<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.block.label}}"><i class="fa fa-ban" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
+									<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.block.label}}"><i class="ri ri-forbid-2-line" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
 								</li>
 							{{/if}}
 
@@ -704,29 +704,29 @@ as the value of $top_child_total (this is done at the end of this file)
 
 							{{if $item.ignore_server}}
 								<li role="menuitem">
-									<a class="btn-link navicon ignoreServer" href="javascript:ignoreServer('settings/server/{{$item.author_gsid}}/ignore', 'item-{{$item.guid}}');" title="{{$item.ignore_server.label}}"><i class="fa fa-eye-slash" aria-hidden="true"></i>&ensp;{{$item.ignore_server.label}}</a>
+									<a class="btn-link navicon ignoreServer" href="javascript:ignoreServer('settings/server/{{$item.author_gsid}}/ignore', 'item-{{$item.guid}}');" title="{{$item.ignore_server.label}}"><i class="ri ri-eye-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore_server.label}}</a>
 								</li>
 							{{/if}}
 
 							<li role="menuitem">
-								<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="fa fa-file-text" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
+								<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="ri ri-file-text-line" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
 							</li>
 
 							{{if $item.language}}
 								<li role="menuitem">
-									<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="fa fa-language" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
+									<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="ri ri-translate-2" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
 								</li>
 							{{/if}}
 
 							{{if $item.report}}
 								<li role="menuitem">
-									<a class="btn-link navicon ignore" href="{{$item.report.href}}"><i class="fa fa-flag" aria-hidden="true"></i>&ensp;{{$item.report.label}}</a>
+									<a class="btn-link navicon ignore" href="{{$item.report.href}}"><i class="ri ri-flag-line" aria-hidden="true"></i>&ensp;{{$item.report.label}}</a>
 								</li>
 							{{/if}}
 
 							{{if $item.drop && $item.drop.dropping}}
 								<li role="menuitem">
-                                                			<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="fa fa-trash" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
+                                                			<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="ri ri-delete-bin-line" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
 								</li>
 							{{/if}}
 						</ul>

--- a/view/theme/frio/templates/widget/follow.tpl
+++ b/view/theme/frio/templates/widget/follow.tpl
@@ -7,7 +7,7 @@
 
 <nav id="follow-sidebar" class="widget">
 	<h3>
-		<i class="fa fa-user-plus" aria-hidden="true"></i>
+		<i class="ri ri-user-add-line" aria-hidden="true"></i>
 		{{$connect}}
 	</h3>
 

--- a/view/theme/frio/templates/widget/peoplefind.tpl
+++ b/view/theme/frio/templates/widget/peoplefind.tpl
@@ -6,7 +6,7 @@
   *}}
 <nav id="peoplefind-sidebar" class="widget">
 	<h3>
-		<i class="fa fa-search" aria-hidden="true"></i>
+		<i class="ri ri-search-line" aria-hidden="true"></i>
 		{{$nv.findpeople}}
 	</h3>
 

--- a/view/theme/frio/templates/widget/saved_searches.tpl
+++ b/view/theme/frio/templates/widget/saved_searches.tpl
@@ -9,7 +9,7 @@
 		<span id="saved-search-list-inflated" class="widget inflated fakelink">
 			<button class="fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');" aria-expanded="false">
 				<h3>
-					<i class="fa fa-search" aria-hidden="true"></i>
+					<i class="ri ri-search-line" aria-hidden="true"></i>
 					{{$title}}
 				</h3>
 			</button>
@@ -17,7 +17,7 @@
 		<div class="widget" id="saved-search-list">
 			<button class="fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');">
 				<h3 id="search">
-					<i class="fa fa-search" aria-hidden="true"></i>
+					<i class="ri ri-search-line" aria-hidden="true"></i>
 					{{$title}}
 				</h3>
 			</button>
@@ -25,7 +25,7 @@
 				{{foreach $saved as $search}}
 					<li class="saved-search-li clear">
 						<a href="search/saved/remove?term={{$search.encodedterm}}&amp;return_url={{$return_url}}" title="{{$search.delete}}" onclick="return confirmDelete();" id="drop-saved-search-term-{{$search.id}}" class="savedsearchdrop pull-right widget-action faded-icon">
-							<i class="fa fa-trash" aria-hidden="true"></i>
+							<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
 						</a>
 						<a href="{{$search.searchpath}}" id="saved-search-term-{{$search.id}}" class="savedsearchterm">{{$search.term}}</a>
 					</li>

--- a/view/theme/frio/templates/widget/vcard.tpl
+++ b/view/theme/frio/templates/widget/vcard.tpl
@@ -45,13 +45,13 @@
 			<div id="dfrn-request-link-button">
 				{{if $follow_link}}
 					<a id="dfrn-request-link" class="btn btn-labeled btn-primary" href="{{$follow_link}}"">
-						<span><i class="fa fa-user-plus"></i></span>
+						<span><i class="ri ri-user-add-line"></i></span>
 						<span>{{$follow}}</span>
 					</a>
 				{{/if}}
 				{{if $unfollow_link}}
 					<a id="dfrn-request-link" class="btn btn-labeled btn-primary" href="{{$unfollow_link}}">
-						<span><i class="fa fa-user-times"></i></span>
+						<span><i class="ri ri-user-unfollow-line"></i></span>
 						<span>{{$unfollow}}</span>
 					</a>
 				{{/if}}
@@ -59,7 +59,7 @@
 			{{if $wallmessage_link}}
 				<div id="wallmessage-link-button">
 					<button type="button" id="wallmessage-link" class="btn btn-labeled btn-primary" onclick="openWallMessage('{{$wallmessage_link}}')">
-						<span><i class="fa fa-envelope"></i></span>
+						<span><i class="ri ri-mail-line"></i></span>
 						<span>{{$wallmessage}}</span>
 					</button>
 				</div>
@@ -67,7 +67,7 @@
 			{{if $mention_link}}
 				<div id="jotOpen" class="pull-right">
 					<button type="button" id="mention-link" class="action-button btn btn-labeled btn-primary{{if !$always_open_compose}} modal-open{{/if}}" onclick="openWallMessage('{{$mention_link}}')" aria-label="{{$mention}}" oncontextmenu="openWallMessage('compose/0')">
-						<i class="fa fa-lg fa-pencil"></i>
+						<i class="ri ri-lg ri-pencil-line"></i>
 						<span>{{$mention}}</span>
 					</button>
 				</div>
@@ -76,7 +76,7 @@
 			{{if $showgroup_link}}
 				<div id="show-group-button">
 					<a type="button" id="show-group" class="btn btn-labeled btn-primary" href="{{$showgroup_link}}" title="{{$showgroup}}" aria-label="{{$showgroup}}">
-						<span class=""><i class="fa fa-group"></i></span>
+						<span class=""><i class="ri ri-group-line"></i></span>
 						<span class="">{{$showgroup}}</span>
 					</a>
 				</div>
@@ -87,21 +87,21 @@
 
 		{{if $contact.location}}
 		<div class="location detail">
-			<span class="location-label icon"><i class="fa fa-map-marker"></i></span>
+			<span class="location-label icon"><i class="ri ri-map-pin-line"></i></span>
 			<span class="adr p-location">{{$contact.location}}</span>
 		</div>
 		{{/if}}
 
 		{{if $contact.xmpp}}
 		<div class="xmpp detail">
-			<span class="xmpp-label icon"><i class="fa fa-xmpp"></i></span>
+			<span class="xmpp-label icon"><i class="ri ri-chat-3-line"></i></span>
 			<span class="xmpp-data"><a href="xmpp:{{$contact.xmpp}}" rel="me" target="_blank" rel="noopener noreferrer">{{include file="sub/punct_wrap.tpl" text=$contact.xmpp}}</a></span>
 		</div>
 		{{/if}}
 
 		{{if $contact.matrix}}
 		<div class="matrix detail">
-			<span class="matrix-label icon"><i class="fa fa-matrix-org"></i></span>
+			<span class="matrix-label icon"><i class="ri ri-grid-line"></i></span>
 			<span class="matrix-data"><a href="matrix:{{$contact.matrix}}" rel="me" target="_blank" rel="noopener noreferrer">{{include file="sub/punct_wrap.tpl" text=$contact.matrix}}</a></span>
 		</div>
 		{{/if}}
@@ -111,7 +111,7 @@
 			{{if $network_svg}}
 				<span class="network-label icon"><img class="network-svg" src="{{$network_svg}}" loading="lazy" aria-hidden="true"/></span>
 			{{else}}
-				<span class="network-label icon"><i class="fa fa-{{$network_avatar}}"></i></span>
+				<span class="network-label icon"><i class="ri ri-{{$network_avatar}}"></i></span>
 			{{/if}}
 			<span class="x-network">{{$network_link nofilter}}</span>
 		</div>


### PR DESCRIPTION
Fork Awesome is deprecated and archived, see here: https://github.com/ForkAwesome/Fork-Awesome

It is replaced by https://remixicon.com/

This seems to be a good and very complete replacement. It even has got Friendica icons :grin: 

The icons are offered in both filled and line. This means we can decide which to display. By now the line icons are selected, which is a difference to the existing icons.

Previously:
<img width="454" height="76" alt="grafik" src="https://github.com/user-attachments/assets/0eade890-dd75-4e0d-aa9e-4ae1793b60dc" />
<img width="656" height="43" alt="grafik" src="https://github.com/user-attachments/assets/00fee0dc-bf79-44e5-964a-4972a4ab4c27" />

Now:
<img width="454" height="76" alt="grafik" src="https://github.com/user-attachments/assets/039a83dd-31f3-4945-8528-8c443570186b" />
<img width="656" height="43" alt="grafik" src="https://github.com/user-attachments/assets/66447739-30c0-4762-b17b-aa807bc85f5f" />

@marcusxss since you do a lot of stuff in the templates lately, we should coordinate here to avoid too many merge conflicts.