### PR TITLE
Add hovercard styling to GNOME Adwaita color scheme

### DIFF
--- a/view/theme/frio/scheme/gnome.css
+++ b/view/theme/frio/scheme/gnome.css
@@ -367,6 +367,42 @@ aside {
   color: var(--text-primary) !important;
 }
 
+/* Hovercard */
+.hovercard {
+	background-color: var(--bg-secondary);
+	box-shadow: 0 10px 50px var(--shadow);
+}
+
+.hover-card-footer {
+	background-color: var(--bg-secondary);
+	border-top: 1px solid var(--border-color);
+	color: var(--text-secondary);
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.hovercard.top > .arrow:after {
+	border-top-color: var(--bg-secondary);
+}
+
+.hovercard.right > .arrow:after {
+	border-right-color: var(--bg-secondary);
+}
+
+.hovercard.bottom > .arrow:after {
+	border-bottom-color: var(--bg-secondary);
+}
+
+.hovercard.left > .arrow:after {
+	border-left-color: var(--bg-secondary);
+}
+
+.hover-card-content,
+.hover-card-content .profile-addr {
+	color: var(--text-secondary);
+}
+
+
 /* Dropdowns */
 .dropdown-menu {
   background-color: var(--bg-secondary) !important;


### PR DESCRIPTION
Add CSS variables for hovercard to the GNOME Adwaita scheme (`gnome.css`), ensuring consistency with the light and dark mode cards/panels styling.