### PR TITLE
Issue 8724: Moderation system

### DIFF
--- a/src/Console/GlobalCommunitySilence.php
+++ b/src/Console/GlobalCommunitySilence.php
@@ -71,8 +71,7 @@ HELP;
 		}
 
 		$contact_id = Contact::getIdForURL($this->getArgument(0));
-		if ($contact_id) {
-			Contact::update(['hidden' => true], ['id' => $contact_id]);
+		if (Contact::hide($contact_id)) {
 			$this->out('The account has been successfully silenced from the global community page.');
 		} else {
 			throw new RuntimeException('Could not find any public contact entry for this URL (' . $this->getArgument(0) . ')');

--- a/src/Factory/Api/Mastodon/Report.php
+++ b/src/Factory/Api/Mastodon/Report.php
@@ -1,0 +1,99 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Factory\Api\Mastodon;
+
+use Friendica\BaseFactory;
+use Friendica\Database\Database;
+use Friendica\Model\Contact;
+use Friendica\Moderation\Entity\Report as ReportEntity;
+use Friendica\Object\Api\Mastodon\Report as MstdnReport;
+use Friendica\Util\DateTimeFormat;
+use Psr\Log\LoggerInterface;
+
+class Report extends BaseFactory
+{
+	public function __construct(LoggerInterface $logger, private readonly Database $database, private readonly Account $mstdnAccountFactory, private readonly Status $mstdnStatusFactory)
+	{
+		parent::__construct($logger);
+	}
+
+	public function createFromReportEntity(ReportEntity $report): MstdnReport
+	{
+		$createdAt   = $report->created->format(DateTimeFormat::JSON);
+		$updatedAt   = $report->edited ? $report->edited->format(DateTimeFormat::JSON) : $createdAt;
+		$actionTaken = $report->status === ReportEntity::STATUS_CLOSED;
+		$reporterUid = $report->reporterUid ?? 0;
+
+		return new MstdnReport(
+			$report->id,
+			$actionTaken,
+			$actionTaken ? $updatedAt : null,
+			$this->idToCategory($report->category),
+			$report->comment,
+			$report->forward,
+			$createdAt,
+			$updatedAt,
+			$this->buildAccount($report->reporterCid, $reporterUid),
+			$this->buildAccount($report->cid, $reporterUid),
+			$report->assignedUid ? $this->buildAccountByUserId($report->assignedUid) : null,
+			$report->lastEditorUid ? $this->buildAccountByUserId($report->lastEditorUid) : null,
+			$this->buildStatuses($report->id, $reporterUid),
+			$this->buildRules($report->id),
+		);
+	}
+
+	private function buildAccount(int $contactId, int $uid): ?array
+	{
+		try {
+			return $this->mstdnAccountFactory->createFromContactId($contactId, $uid)->toArray();
+		} catch (\Throwable) {
+			return null;
+		}
+	}
+
+	private function buildAccountByUserId(int $userId): ?array
+	{
+		$contactId = Contact::getPublicIdByUserId($userId);
+		if (!$contactId) {
+			return null;
+		}
+
+		return $this->buildAccount($contactId, $userId);
+	}
+
+	private function buildStatuses(int $reportId, int $uid): array
+	{
+		$rows = $this->database->selectToArray('report-post', ['uri-id'], ['rid' => $reportId]);
+
+		$statuses = [];
+		foreach ($rows as $row) {
+			try {
+				$statuses[] = $this->mstdnStatusFactory->createFromUriId((int) $row['uri-id'], $uid)->toArray();
+			} catch (\Throwable) {
+				continue;
+			}
+		}
+
+		return $statuses;
+	}
+
+	private function buildRules(int $reportId): array
+	{
+		return $this->database->selectToArray('report-rule', ['line-id', 'text'], ['rid' => $reportId]);
+	}
+
+	private function idToCategory(int $category): string
+	{
+		return match ($category) {
+			ReportEntity::CATEGORY_SPAM      => 'spam',
+			ReportEntity::CATEGORY_ILLEGAL   => 'legal',
+			ReportEntity::CATEGORY_VIOLATION => 'violation',
+			default                          => 'other',
+		};
+	}
+}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1829,6 +1829,32 @@ class Contact
 	}
 
 	/**
+	 * Hides a contact
+	 *
+	 * @param int $cid Contact id to hide
+	 * @return bool Whether it was successful
+	 */
+	public static function hide(int $cid): bool
+	{
+		$return = self::update(['hidden' => true], ['id' => $cid]);
+
+		return $return;
+	}
+
+	/**
+	 * Unhide a contact
+	 *
+	 * @param int $cid Contact id to unhide
+	 * @return bool Whether it was successful
+	 */
+	public static function unhide(int $cid): bool
+	{
+		$return = self::update(['hidden' => false], ['id' => $cid]);
+
+		return $return;
+	}
+
+	/**
 	 * Ensure that cached avatar exist
 	 *
 	 * @param integer $cid Contact id

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1,7 +1,7 @@
 <?php
 
-// Copyright (C) 2010-2024, the Friendica project
-// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -1072,8 +1072,11 @@ class User
 	 */
 	public static function isModerator(int $uid): bool
 	{
-		// @todo Replace with a moderator check in the future
-		return self::isSiteAdmin($uid);
+		if (self::isSiteAdmin($uid)) {
+			return true;
+		}
+
+		return in_array($uid, self::getModeratorUids(), true);
 	}
 
 	/**
@@ -2105,6 +2108,61 @@ class User
 	{
 		$condition = [
 			'email'           => self::getAdminEmailList(),
+			'parent-uid'      => null,
+			'blocked'         => false,
+			'verified'        => true,
+			'account_removed' => false,
+			'account_expired' => false,
+		];
+
+		return DBA::selectToArray('user', $fields, $condition, ['order' => ['uid']]);
+	}
+
+	/**
+	 * Returns a list of moderator user IDs from the comma-separated list in the config
+	 *
+	 * @return array
+	 */
+	public static function getModeratorUids(): array
+	{
+		$moderatorUsers = DI::config()->get('system', 'moderator_users');
+		if (empty($moderatorUsers)) {
+			return [];
+		}
+
+		$uids = [];
+		foreach (explode(',', (string) $moderatorUsers) as $moderatorUid) {
+			$moderatorUid = (int) trim($moderatorUid);
+			if ($moderatorUid > 0) {
+				$uids[$moderatorUid] = $moderatorUid;
+			}
+		}
+
+		$uids = array_values($uids);
+		sort($uids);
+
+		return $uids;
+	}
+
+	/**
+	 * Returns the complete list of explicitly assigned moderator user accounts
+	 *
+	 * @param array $fields
+	 * @return array
+	 * @throws Exception
+	 */
+	public static function getModeratorList(array $fields = []): array
+	{
+		$moderatorUids = array_values(array_filter(self::getModeratorUids(), function (int $uid): bool {
+			return $uid !== 0;
+		}));
+		if (empty($moderatorUids)) {
+			return [];
+		}
+
+		$condition = [
+			'uid'             => $moderatorUids,
+			'account-type'    => self::ACCOUNT_TYPE_PERSON,
 			'parent-uid'      => null,
 			'blocked'         => false,
 			'verified'        => true,

--- a/src/Moderation/Repository/Report.php
+++ b/src/Moderation/Repository/Report.php
@@ -1,7 +1,7 @@
 <?php
 
-// Copyright (C) 2010-2024, the Friendica project
-// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -22,6 +22,16 @@ use Psr\Log\LoggerInterface;
 final class Report extends \Friendica\BaseRepository
 {
 	protected static $table_name = 'report';
+
+	private const ALLOWED_STATUSES = [
+		ReportEntity::STATUS_OPEN,
+		ReportEntity::STATUS_CLOSED,
+	];
+
+	private const ALLOWED_RESOLUTIONS = [
+		ReportEntity::RESOLUTION_ACCEPTED,
+		ReportEntity::RESOLUTION_REJECTED,
+	];
 
 	/** @var ReportFactory */
 	protected $factory;
@@ -108,6 +118,82 @@ final class Report extends \Friendica\BaseRepository
 	 */
 	public function setStatus(int $reportId, int $status): bool
 	{
-		return $this->db->update(self::$table_name, ['status' => $status], ['id' => $reportId]);
+		$this->assertStatus($status);
+
+		return $this->updateModerationFields($reportId, ['status' => $status]);
+	}
+
+	public function setAssignment(int $reportId, ?int $assignedUid, ?int $lastEditorUid = null): bool
+	{
+		$fields = ['assigned-uid' => $assignedUid];
+
+		if ($lastEditorUid !== null) {
+			$fields['last-editor-uid'] = $lastEditorUid;
+		}
+
+		return $this->updateModerationFields($reportId, $fields);
+	}
+
+	public function setRemarks(int $reportId, string $publicRemarks = '', string $privateRemarks = '', ?int $lastEditorUid = null): bool
+	{
+		$fields = [
+			'public-remarks'  => $publicRemarks,
+			'private-remarks' => $privateRemarks,
+		];
+
+		if ($lastEditorUid !== null) {
+			$fields['last-editor-uid'] = $lastEditorUid;
+		}
+
+		return $this->updateModerationFields($reportId, $fields);
+	}
+
+	public function setResolution(int $reportId, ?int $resolution, ?int $lastEditorUid = null): bool
+	{
+		if ($resolution !== null) {
+			$this->assertResolution($resolution);
+		}
+
+		$fields = ['resolution' => $resolution];
+
+		if ($lastEditorUid !== null) {
+			$fields['last-editor-uid'] = $lastEditorUid;
+		}
+
+		return $this->updateModerationFields($reportId, $fields);
+	}
+
+	public function updateModerationState(int $reportId, array $fields): bool
+	{
+		if (array_key_exists('status', $fields)) {
+			$this->assertStatus((int) $fields['status']);
+		}
+
+		if (array_key_exists('resolution', $fields) && $fields['resolution'] !== null) {
+			$this->assertResolution((int) $fields['resolution']);
+		}
+
+		return $this->updateModerationFields($reportId, $fields);
+	}
+
+	private function updateModerationFields(int $reportId, array $fields): bool
+	{
+		$fields['edited'] = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format(DateTimeFormat::MYSQL);
+
+		return $this->db->update(self::$table_name, $fields, ['id' => $reportId]);
+	}
+
+	private function assertStatus(int $status): void
+	{
+		if (!in_array($status, self::ALLOWED_STATUSES, true)) {
+			throw new \InvalidArgumentException('Invalid report status: ' . $status);
+		}
+	}
+
+	private function assertResolution(int $resolution): void
+	{
+		if (!in_array($resolution, self::ALLOWED_RESOLUTIONS, true)) {
+			throw new \InvalidArgumentException('Invalid report resolution: ' . $resolution);
+		}
 	}
 }

--- a/src/Module/Admin/Roles.php
+++ b/src/Module/Admin/Roles.php
@@ -1,0 +1,202 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Module\Admin;
+
+use Friendica\App;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\L10n;
+use Friendica\Core\Renderer;
+use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Model\User;
+use Friendica\Module\BaseAdmin;
+use Friendica\Module\Response;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
+class Roles extends BaseAdmin
+{
+	public function __construct(L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, private readonly IManageConfigValues $config, array $server, array $parameters = [])
+	{
+		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+	}
+
+	protected function post(array $request = [])
+	{
+		self::checkAdminAccess();
+
+		if (empty($_POST['page_roles'])) {
+			return;
+		}
+
+		self::checkFormSecurityTokenRedirectOnError('/admin/roles', 'admin_roles');
+
+		$action = (string) ($_POST['roles_action'] ?? '');
+		$uid    = (int) ($_POST['moderator_uid'] ?? 0);
+
+		if ($uid <= 0) {
+			DI::sysmsg()->addNotice($this->t('Please select a valid user.'));
+			$this->baseUrl->redirect('admin/roles');
+		}
+
+		$moderatorUids = array_values(array_filter(User::getModeratorUids(), function (int $moderatorUid): bool {
+			return $moderatorUid !== 0;
+		}));
+
+		switch ($action) {
+			case 'add':
+				$user = User::getById($uid, ['uid', 'nickname', 'blocked', 'verified', 'account_removed', 'account_expired', 'parent-uid', 'account-type']);
+				if (!DBA::isResult($user) || $uid === 0 || (int) $user['account-type'] !== User::ACCOUNT_TYPE_PERSON || !empty($user['parent-uid']) || !empty($user['blocked']) || empty($user['verified']) || !empty($user['account_removed']) || !empty($user['account_expired'])) {
+					DI::sysmsg()->addNotice($this->t('The selected user cannot be assigned moderation rights.'));
+					$this->baseUrl->redirect('admin/roles');
+				}
+
+				if (!in_array($uid, $moderatorUids, true)) {
+					$moderatorUids[] = $uid;
+					$this->persistModeratorUids($moderatorUids);
+					DI::sysmsg()->addInfo($this->t('Moderation rights have been granted.'));
+				}
+				break;
+
+			case 'remove':
+				$updatedModeratorUids = array_values(array_filter($moderatorUids, function (int $moderatorUid) use ($uid): bool {
+					return $moderatorUid !== $uid;
+				}));
+
+				if (count($updatedModeratorUids) !== count($moderatorUids)) {
+					$this->persistModeratorUids($updatedModeratorUids);
+					DI::sysmsg()->addInfo($this->t('Moderation rights have been removed.'));
+				}
+				break;
+
+			default:
+				DI::sysmsg()->addNotice($this->t('Unknown role action.'));
+		}
+
+		$this->baseUrl->redirect('admin/roles');
+	}
+
+	protected function content(array $request = []): string
+	{
+		parent::content();
+
+		$fields = ['uid', 'nickname', 'username', 'email', 'account-type'];
+
+		$adminUsers            = User::getAdminList($fields);
+		$adminUsers            = $this->filterRoleEligibleUsers($adminUsers);
+		$explicitModeratorList = User::getModeratorList($fields);
+		$moderationUsers       = $this->buildModerationUsers($adminUsers, $explicitModeratorList);
+
+		$availableUsers = DBA::selectToArray('user', $fields, [
+			"`uid` != ? AND `account-type` = ? AND `parent-uid` IS NULL AND NOT `blocked` AND `verified` AND NOT `account_removed` AND NOT `account_expired`",
+			0,
+			User::ACCOUNT_TYPE_PERSON,
+		], ['order' => ['nickname', 'username', 'uid']]);
+
+		$moderationUserUids = [];
+		foreach ($moderationUsers as $moderationUser) {
+			$moderationUserUids[(int) $moderationUser['uid']] = true;
+		}
+
+		$availableUsers = array_values(array_filter($availableUsers, function (array $user) use ($moderationUserUids): bool {
+			return empty($moderationUserUids[(int) $user['uid']]);
+		}));
+
+		$t = Renderer::getMarkupTemplate('admin/roles.tpl');
+
+		return Renderer::replaceMacros($t, [
+			'$title'               => $this->t('Administration'),
+			'$page'                => $this->t('Roles'),
+			'$intro'               => $this->t('Manage moderators for this node. Administrator rights are read-only and managed through the node configuration.'),
+			'$admin_title'         => $this->t('Users with administrator rights (read-only)'),
+			'$moderator_title'     => $this->t('Users with moderation rights'),
+			'$user_header'         => $this->t('User'),
+			'$email_header'        => $this->t('Email'),
+			'$source_header'       => $this->t('Source'),
+			'$actions_header'      => $this->t('Actions'),
+			'$no_admin_users'      => $this->t('No administrators found.'),
+			'$no_moderator_users'  => $this->t('No users with moderation rights found.'),
+			'$admin_source'        => $this->t('Administrator'),
+			'$moderator_source'    => $this->t('Moderator'),
+			'$combined_source'     => $this->t('Administrator + Moderator'),
+			'$remove'              => $this->t('Remove moderation rights'),
+			'$cannot_remove_admin' => $this->t('Administrators always keep moderation rights.'),
+			'$assign_title'        => $this->t('Assign moderation rights'),
+			'$assign_label'        => $this->t('User'),
+			'$assign_button'       => $this->t('Grant moderation rights'),
+			'$no_assignable_users' => $this->t('All active users already have moderation rights.'),
+			'$admin_users'         => $adminUsers,
+			'$moderation_users'    => $moderationUsers,
+			'$available_users'     => $availableUsers,
+			'$form_security_token' => self::getFormSecurityToken('admin_roles'),
+		]);
+	}
+
+	private function persistModeratorUids(array $moderatorUids): void
+	{
+		$uids = [];
+		foreach ($moderatorUids as $moderatorUid) {
+			$moderatorUid = (int) $moderatorUid;
+			if ($moderatorUid > 0) {
+				$uids[$moderatorUid] = $moderatorUid;
+			}
+		}
+
+		$uids = array_values($uids);
+		sort($uids);
+
+		$this->config->set('system', 'moderator_users', implode(',', $uids));
+	}
+
+	private function buildModerationUsers(array $adminUsers, array $explicitModeratorUsers): array
+	{
+		$moderationUsers = [];
+
+		foreach ($adminUsers as $adminUser) {
+			$uid = (int) $adminUser['uid'];
+			if ($uid === 0) {
+				continue;
+			}
+
+			$adminUser['source']     = 'admin';
+			$adminUser['can_remove'] = false;
+			$moderationUsers[$uid]   = $adminUser;
+		}
+
+		foreach ($explicitModeratorUsers as $explicitModeratorUser) {
+			$uid = (int) $explicitModeratorUser['uid'];
+			if (!empty($moderationUsers[$uid])) {
+				$moderationUsers[$uid]['source'] = 'both';
+				continue;
+			}
+
+			$explicitModeratorUser['source']     = 'moderator';
+			$explicitModeratorUser['can_remove'] = true;
+			$moderationUsers[$uid]               = $explicitModeratorUser;
+		}
+
+		ksort($moderationUsers);
+
+		return array_values($moderationUsers);
+	}
+
+	private function filterRoleEligibleUsers(array $users): array
+	{
+		return array_values(array_filter($users, function (array $user): bool {
+			if ($user['uid'] === 0) {
+				return false;
+			}
+
+			if ($user['account-type'] !== User::ACCOUNT_TYPE_PERSON) {
+				return false;
+			}
+
+			return true;
+		}));
+	}
+}

--- a/src/Module/Api/Mastodon/Admin/Accounts.php
+++ b/src/Module/Api/Mastodon/Admin/Accounts.php
@@ -1,0 +1,283 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Module\Api\Mastodon\Admin;
+
+use Friendica\App\Arguments;
+use Friendica\App\BaseURL;
+use Friendica\AppHelper;
+use Friendica\Core\L10n;
+use Friendica\Database\Database;
+use Friendica\Database\DBA;
+use Friendica\Model\Contact;
+use Friendica\Model\User;
+use Friendica\Module\Api\ApiResponse;
+use Friendica\Module\BaseApi;
+use Friendica\Moderation\Entity\Report as ReportEntity;
+use Friendica\Moderation\Repository\Report as ReportRepository;
+use Friendica\Network\HTTPException;
+use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @see https://docs.joinmastodon.org/methods/admin/accounts/
+ */
+class Accounts extends BaseApi
+{
+	public function __construct(
+		private readonly Database $database,
+		private readonly ReportRepository $reportRepository,
+		\Friendica\Factory\Api\Mastodon\Error $errorFactory,
+		AppHelper $appHelper,
+		L10n $l10n,
+		BaseURL $baseUrl,
+		Arguments $args,
+		LoggerInterface $logger,
+		Profiler $profiler,
+		ApiResponse $response,
+		array $server,
+		array $parameters = [],
+	) {
+		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+	}
+
+	/**
+	 * Perform an action against an account.
+	 *
+	 * @see POST /api/v1/admin/accounts/:id/action
+	 *
+	 * @throws HTTPException\ForbiddenException
+	 * @throws HTTPException\InternalServerErrorException
+	 */
+	protected function post(array $request = [])
+	{
+		$this->checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkModeratorAccess();
+
+		if (empty($this->parameters['id'])) {
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
+		}
+
+		$uid      = self::getCurrentUserID();
+		$action   = $this->parameters['action'] ?? '';
+		$targetId = (int) $this->parameters['id'];
+
+		$request = $this->getRequest([
+			'type'                    => '',
+			'report_id'               => '',
+			'warning_preset_id'       => '',
+			'text'                    => '',
+			'send_email_notification' => false,
+		], $request);
+
+		$targetId = Contact::getPublicContactId($targetId, 0);
+		if (empty($targetId)) {
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
+		}
+
+		$localUserId = User::getIdForContactId($targetId);
+
+		switch ($action) {
+			case 'action':
+				$this->performAccountAction(
+					$request['type'],
+					$targetId,
+					$localUserId,
+					$request['report_id'],
+					$uid,
+				);
+				break;
+			case 'approve':
+				if (!$localUserId) {
+					$this->logAndJsonError(403, $this->errorFactory->Forbidden());
+				}
+				$this->approveAccount($localUserId);
+				break;
+			case 'reject':
+				if (!$localUserId) {
+					$this->logAndJsonError(403, $this->errorFactory->Forbidden());
+				}
+				$this->rejectAccount($localUserId);
+				break;
+			case 'enable':
+				if (!$localUserId) {
+					$this->logAndJsonError(403, $this->errorFactory->Forbidden());
+				}
+				User::block($localUserId, false);
+				break;
+			case 'unsilence':
+				Contact::unhide($targetId);
+				break;
+			case 'unsuspend':
+				// Unsuspend: unblock the contact; for local users also re-enable the account.
+				// Note: User::remove() is irreversible, so unsuspend only works on blocked accounts.
+				Contact::unblock($targetId);
+				if ($localUserId) {
+					User::block($localUserId, false);
+				}
+				break;
+			case 'unsensitive':
+				$this->database->update('contact', ['sensitive' => false], ['id' => $targetId]);
+				break;
+			default:
+				$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
+		}
+
+		$this->jsonExit($this->buildAdminAccountResponse($targetId, $localUserId));
+	}
+
+	/**
+	 * Perform a typed moderation action against an account.
+	 *
+	 * Types: none, sensitive, disable, silence, suspend
+	 */
+	private function performAccountAction(string $type, int $publicContactId, int $localUserId, string $reportId, int $moderatorUid): void
+	{
+		switch ($type) {
+			case 'none':
+				// Warning: no system-level action, just note via report
+				break;
+			case 'sensitive':
+				// Mark all future posts from this account as sensitive
+				// @todo This most likely will not work at the moment
+				$this->database->update('contact', ['sensitive' => true], ['id' => $publicContactId]);
+				break;
+			case 'disable':
+				// Disable login for local users only
+				if (!$localUserId) {
+					$this->logAndJsonError(403, $this->errorFactory->Forbidden());
+				}
+				User::block($localUserId);
+				break;
+			case 'silence':
+				// Silence contact globally (Posts will not appear in federated timelines, but followers will still see them in their home timeline)
+				Contact::hide($publicContactId);
+				break;
+			case 'suspend':
+				// For local users: schedule removal; for remote: block globally
+				Contact::block($publicContactId);
+				if ($localUserId) {
+					try {
+						User::remove($localUserId);
+					} catch (\Throwable $e) {
+						$this->logger->warning('Could not remove local user during suspension', [
+							'uid'   => $localUserId,
+							'error' => $e->getMessage(),
+						]);
+					}
+				}
+				break;
+			default:
+				$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
+		}
+
+		// If a report_id was provided, resolve the associated report
+		if (!empty($reportId) && ctype_digit($reportId)) {
+			try {
+				$report = $this->reportRepository->selectOneById((int) $reportId);
+				if ($report->status === ReportEntity::STATUS_OPEN) {
+					$this->reportRepository->updateModerationState((int) $reportId, [
+						'resolution'      => ReportEntity::RESOLUTION_ACCEPTED,
+						'status'          => ReportEntity::STATUS_CLOSED,
+						'last-editor-uid' => $moderatorUid,
+					]);
+				}
+			} catch (\Throwable $e) {
+				$this->logger->warning('Could not resolve report after account action', [
+					'report_id' => $reportId,
+					'error'     => $e->getMessage(),
+				]);
+			}
+		}
+	}
+
+	/**
+	 * Approve a pending local account registration.
+	 */
+	private function approveAccount(int $localUserId): void
+	{
+		$user = User::getById($localUserId, ['verified', 'blocked', 'account_removed']);
+		if (empty($user)) {
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
+		}
+		// Mark as verified/approved
+		$this->database->update('user', ['verified' => true, 'blocked' => false], ['uid' => $localUserId]);
+		// Remove any pending register entry
+		$this->database->delete('register', ['uid' => $localUserId]);
+	}
+
+	/**
+	 * Reject a pending local account registration.
+	 */
+	private function rejectAccount(int $localUserId): void
+	{
+		$user = User::getById($localUserId, ['verified', 'blocked', 'account_removed']);
+		if (empty($user)) {
+			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
+		}
+		try {
+			User::remove($localUserId);
+		} catch (\Throwable $e) {
+			$this->logger->warning('Could not remove rejected account', [
+				'uid'   => $localUserId,
+				'error' => $e->getMessage(),
+			]);
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
+		}
+	}
+
+	/**
+	 * Build a minimal Admin::Account-compatible response array.
+	 *
+	 * @see https://docs.joinmastodon.org/entities/Admin_Account/
+	 */
+	private function buildAdminAccountResponse(int $publicContactId, int $localUserId): array
+	{
+		$contact = DBA::selectFirst('contact', ['id', 'name', 'nick', 'url', 'baseurl', 'network', 'created', 'blocked', 'sensitive'], ['id' => $publicContactId, 'uid' => 0]);
+		if (empty($contact)) {
+			return ['id' => (string) $publicContactId];
+		}
+
+		$domain = null;
+		if (!empty($contact['baseurl'])) {
+			$parsed = parse_url((string) $contact['baseurl']);
+			$domain = $parsed['host'] ?? null;
+		}
+
+		$response = [
+			'id'             => (string) $publicContactId,
+			'username'       => $contact['nick'] ?? '',
+			'domain'         => $domain,
+			'created_at'     => DateTimeFormat::utc($contact['created'], DateTimeFormat::JSON),
+			'ip'             => null,
+			'role'           => null,
+			'confirmed'      => true,
+			'suspended'      => false,
+			'silenced'       => (bool) ($contact['blocked'] ?? false),
+			'sensitized'     => (bool) ($contact['sensitive'] ?? false),
+			'disabled'       => false,
+			'approved'       => true,
+			'locale'         => null,
+			'invite_request' => null,
+			'ips'            => [],
+		];
+
+		if ($localUserId) {
+			$user = User::getById($localUserId, ['email', 'language', 'blocked', 'verified', 'account_removed', 'register_date']);
+			if (!empty($user)) {
+				$response['email']     = $user['email'] ?? '';
+				$response['confirmed'] = (bool) ($user['verified'] ?? false);
+				$response['disabled']  = (bool) ($user['blocked'] ?? false);
+				$response['suspended'] = (bool) ($user['account_removed'] ?? false);
+				$response['locale']    = $user['language'] ?? null;
+			}
+		}
+
+		return $response;
+	}
+}

--- a/src/Module/Api/Mastodon/Admin/Reports.php
+++ b/src/Module/Api/Mastodon/Admin/Reports.php
@@ -1,0 +1,232 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Module\Api\Mastodon\Admin;
+
+use Friendica\App\Arguments;
+use Friendica\App\BaseURL;
+use Friendica\AppHelper;
+use Friendica\Core\L10n;
+use Friendica\Database\Database;
+use Friendica\Database\DBA;
+use Friendica\Core\System;
+use Friendica\Factory\Api\Mastodon\Report as MastodonReportFactory;
+use Friendica\Module\Api\ApiResponse;
+use Friendica\Module\BaseApi;
+use Friendica\Moderation\Entity\Report as ReportEntity;
+use Friendica\Moderation\Repository\Report as ReportRepository;
+use Friendica\Network\HTTPException;
+use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @see https://docs.joinmastodon.org/methods/admin/reports/
+ */
+class Reports extends BaseApi
+{
+	public function __construct(private readonly Database $database, private readonly ReportRepository $reportRepository, private readonly MastodonReportFactory $mstdnReportFactory, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	{
+		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+	}
+
+	/**
+	 * @throws HTTPException\ForbiddenException
+	 * @throws HTTPException\InternalServerErrorException
+	 */
+	protected function get(array $request = [])
+	{
+		$this->checkAllowedScope(self::SCOPE_READ);
+		$this->checkModeratorAccess();
+
+		$request = $this->getRequest([
+			'resolved'          => null,
+			'account_id'        => '',
+			'target_account_id' => '',
+			'min_id'            => 0,
+			'max_id'            => 0,
+			'since_id'          => 0,
+			'limit'             => 100,
+		], $request);
+
+		if (!empty($this->parameters['id'])) {
+			$report = $this->mstdnReportFactory->createFromReportEntity($this->reportRepository->selectOneById((int) $this->parameters['id']));
+			$this->jsonExit($report);
+		}
+
+		$condition = [];
+		$params    = ['order' => ['id' => true], 'limit' => (int) $request['limit']];
+
+		if ($request['resolved'] !== null && $request['resolved'] !== '') {
+			$condition['status'] = filter_var($request['resolved'], FILTER_VALIDATE_BOOLEAN) ? ReportEntity::STATUS_CLOSED : ReportEntity::STATUS_OPEN;
+		}
+
+		$reporterId = $this->resolveAccountIdToContactId((string) $request['account_id']);
+		if ($reporterId) {
+			$condition['reporter-id'] = $reporterId;
+		}
+
+		$targetId = $this->resolveAccountIdToContactId((string) $request['target_account_id']);
+		if ($targetId) {
+			$condition['cid'] = $targetId;
+		}
+
+		if (!empty($request['max_id'])) {
+			$condition = DBA::mergeConditions($condition, ['`id` < ?', (int) $request['max_id']]);
+		}
+
+		if (!empty($request['since_id'])) {
+			$condition = DBA::mergeConditions($condition, ['`id` > ?', (int) $request['since_id']]);
+		}
+
+		if (!empty($request['min_id'])) {
+			$condition = DBA::mergeConditions($condition, ['`id` > ?', (int) $request['min_id']]);
+		}
+
+		$rows = $this->database->selectToArray('report', [], $condition, $params);
+
+		$reports = [];
+		foreach ($rows as $row) {
+			self::setBoundaries((int) $row['id']);
+			$reports[] = $this->mstdnReportFactory->createFromReportEntity($this->reportRepository->selectOneById((int) $row['id']));
+		}
+
+		self::setLinkHeader();
+		$this->jsonExit($reports);
+	}
+
+	/**
+	 * @throws HTTPException\ForbiddenException
+	 * @throws HTTPException\InternalServerErrorException
+	 */
+	public function put(array $request = [])
+	{
+		$this->checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkModeratorAccess();
+
+		if (empty($this->parameters['id'])) {
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
+		}
+
+		$request = $this->getRequest([
+			'category' => '',
+			'rule_ids' => [],
+		], $request);
+
+		$existing = $this->reportRepository->selectOneById((int) $this->parameters['id']);
+		if ($existing->status === ReportEntity::STATUS_CLOSED) {
+			$this->logAndJsonError(403, $this->errorFactory->Forbidden());
+		}
+
+		if ($request['category'] === '') {
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
+		}
+
+		$categoryId = $this->categoryToId($request['category']);
+		if ($categoryId === null) {
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
+		}
+
+		$this->database->update('report', [
+			'category-id'     => $categoryId,
+			'edited'          => DateTimeFormat::utcNow(),
+			'last-editor-uid' => self::getCurrentUserID(),
+		], ['id' => (int) $this->parameters['id']]);
+
+		$this->database->delete('report-rule', ['rid' => (int) $this->parameters['id']]);
+		if ($categoryId === ReportEntity::CATEGORY_VIOLATION && !empty($request['rule_ids'])) {
+			$rules = System::getRules(true);
+			foreach ((array) $request['rule_ids'] as $lineId) {
+				$this->database->insert('report-rule', [
+					'rid'     => (int) $this->parameters['id'],
+					'line-id' => (int) $lineId,
+					'text'    => $rules[(int) $lineId] ?? '',
+				]);
+			}
+		}
+
+		$this->jsonExit($this->mstdnReportFactory->createFromReportEntity($this->reportRepository->selectOneById((int) $this->parameters['id'])));
+	}
+
+	/**
+	 * @throws HTTPException\ForbiddenException
+	 * @throws HTTPException\InternalServerErrorException
+	 */
+	protected function post(array $request = [])
+	{
+		$this->checkAllowedScope(self::SCOPE_WRITE);
+		$this->checkModeratorAccess();
+
+		if (empty($this->parameters['id']) || empty($this->parameters['action'])) {
+			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
+		}
+
+		$reportId = (int) $this->parameters['id'];
+		$uid      = self::getCurrentUserID();
+		$existing = $this->reportRepository->selectOneById($reportId);
+
+		switch ($this->parameters['action']) {
+			case 'assign_to_self':
+				if ($existing->status === ReportEntity::STATUS_CLOSED) {
+					$this->logAndJsonError(403, $this->errorFactory->Forbidden());
+				}
+				$this->reportRepository->setAssignment($reportId, $uid, $uid);
+				break;
+			case 'unassign':
+				if ($existing->status === ReportEntity::STATUS_CLOSED) {
+					$this->logAndJsonError(403, $this->errorFactory->Forbidden());
+				}
+				$this->reportRepository->setAssignment($reportId, null, $uid);
+				break;
+			case 'resolve':
+				if ($existing->status === ReportEntity::STATUS_CLOSED) {
+					$this->logAndJsonError(403, $this->errorFactory->Forbidden());
+				}
+				$this->reportRepository->updateModerationState($reportId, [
+					'resolution'      => ReportEntity::RESOLUTION_ACCEPTED,
+					'status'          => ReportEntity::STATUS_CLOSED,
+					'last-editor-uid' => $uid,
+				]);
+				break;
+			case 'reopen':
+				if ($existing->status === ReportEntity::STATUS_OPEN) {
+					$this->logAndJsonError(403, $this->errorFactory->Forbidden());
+				}
+				$this->reportRepository->updateModerationState($reportId, [
+					'resolution'      => null,
+					'status'          => ReportEntity::STATUS_OPEN,
+					'last-editor-uid' => $uid,
+				]);
+				break;
+			default:
+				$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
+		}
+
+		$this->jsonExit($this->mstdnReportFactory->createFromReportEntity($this->reportRepository->selectOneById($reportId)));
+	}
+
+	private function categoryToId(string $category): ?int
+	{
+		return match ($category) {
+			'spam'      => ReportEntity::CATEGORY_SPAM,
+			'legal'     => ReportEntity::CATEGORY_ILLEGAL,
+			'violation' => ReportEntity::CATEGORY_VIOLATION,
+			'other'     => ReportEntity::CATEGORY_OTHER,
+			default     => null,
+		};
+	}
+
+	private function resolveAccountIdToContactId(string $accountId): ?int
+	{
+		if ($accountId === '' || !ctype_digit($accountId)) {
+			return null;
+		}
+
+		$contact = DBA::selectFirst('account-user-view', ['id'], ['pid' => (int) $accountId], ['order' => ['uid' => true]]);
+		return $contact['id'] ?? null;
+	}
+}

--- a/src/Module/Api/Mastodon/Reports.php
+++ b/src/Module/Api/Mastodon/Reports.php
@@ -1,7 +1,7 @@
 <?php
 
-// Copyright (C) 2010-2024, the Friendica project
-// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -12,6 +12,7 @@ use Friendica\App\BaseURL;
 use Friendica\AppHelper;
 use Friendica\Core\L10n;
 use Friendica\Core\System;
+use Friendica\Core\Worker;
 use Friendica\Model\Contact;
 use Friendica\Module\Api\ApiResponse;
 use Friendica\Module\BaseApi;
@@ -60,7 +61,11 @@ class Reports extends BaseApi
 			self::getCurrentUserID(),
 		);
 
-		$this->reportRepo->save($report);
+		$report = $this->reportRepo->save($report);
+
+		if ($report->forward && $report->id) {
+			Worker::add(Worker::PRIORITY_LOW, 'ForwardReport', (int) $report->id);
+		}
 
 		$this->jsonExit([]);
 	}

--- a/src/Module/BaseAdmin.php
+++ b/src/Module/BaseAdmin.php
@@ -1,7 +1,7 @@
 <?php
 
-// Copyright (C) 2010-2024, the Friendica project
-// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -69,10 +69,11 @@ abstract class BaseAdmin extends BaseModule
 		$aside_sub = [
 			'information' => [DI::l10n()->t('Information'), [
 				'overview'   => ['admin'             , DI::l10n()->t('Overview')                , 'overview'],
-				'federation' => ['admin/federation'  , DI::l10n()->t('Federation Statistics')   , 'federation']
+				'federation' => ['admin/federation'  , DI::l10n()->t('Federation Statistics')   , 'federation'],
 			]],
 			'configuration' => [DI::l10n()->t('Configuration'), [
 				'site'     => ['admin/site'        , DI::l10n()->t('Site')                    , 'site'],
+				'roles'    => ['admin/roles'       , DI::l10n()->t('Roles')                   , 'roles'],
 				'storage'  => ['admin/storage'     , DI::l10n()->t('Storage')                 , 'storage'],
 				'addons'   => ['admin/addons'      , DI::l10n()->t('Addons')                  , 'addons'],
 				'themes'   => ['admin/themes'      , DI::l10n()->t('Themes')                  , 'themes'],
@@ -114,7 +115,7 @@ abstract class BaseAdmin extends BaseModule
 			'$admtxt'     => DI::l10n()->t('Admin'),
 			'$plugadmtxt' => DI::l10n()->t('Addon settings'),
 			'$h_pending'  => DI::l10n()->t('User registrations waiting for confirmation'),
-			'$admurl'     => 'admin/'
+			'$admurl'     => 'admin/',
 		]);
 
 		return '';

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -1,7 +1,7 @@
 <?php
 
-// Copyright (C) 2010-2024, the Friendica project
-// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -372,6 +372,22 @@ class BaseApi extends BaseModule
 		}
 
 		return (int) $uid;
+	}
+
+	/**
+	 * Check whether the current API user has moderator privileges.
+	 * Halts execution with a 403 JSON error when access is missing.
+	 */
+	protected function checkModeratorAccess(): void
+	{
+		$uid = self::getCurrentUserID();
+		if (empty($uid) || !User::isModerator($uid)) {
+			$this->logger->warning('Denied access to moderation API endpoint', [
+				'uid'     => $uid,
+				'command' => $this->args->getCommand(),
+			]);
+			$this->logAndJsonError(403, $this->errorFactory->Forbidden());
+		}
 	}
 
 	/**

--- a/src/Module/Moderation/Report/Create.php
+++ b/src/Module/Moderation/Report/Create.php
@@ -1,7 +1,7 @@
 <?php
 
-// Copyright (C) 2010-2024, the Friendica project
-// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -17,6 +17,7 @@ use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session\Model\UserSession;
 use Friendica\Core\System;
+use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Contact;
@@ -82,9 +83,13 @@ class Create extends BaseModule
 				!empty($request['rule-ids']) ? explode(',', $request['rule-ids']) : [],
 				$this->session->get('report_comment') ?? '',
 				!empty($request['uri-ids']) ? explode(',', $request['uri-ids']) : [],
-				(bool) ($request['forward'] ?? false),
+				(bool) ($request['report_forward'] ?? false),
 			);
-			$this->repository->save($report);
+			$report = $this->repository->save($report);
+
+			if ($report->forward && $report->id) {
+				Worker::add(Worker::PRIORITY_LOW, 'ForwardReport', (int) $report->id);
+			}
 
 			switch ($request['contact_action'] ?? 0) {
 				case self::CONTACT_ACTION_COLLAPSE:
@@ -317,7 +322,7 @@ class Create extends BaseModule
 			'$block'    => ['contact_action', $this->t('Block contact'), self::CONTACT_ACTION_BLOCK, $this->t("Their posts won't appear in your Network page anymore, but their replies can appear in forum threads, with their content collapsed by default. They cannot follow you but still can have access to your public posts by other means.")],
 
 			'$display_forward' => !$this->baseUrl->isLocalUrl($contact['url']),
-			'$forward'         => ['report_forward', $this->t('Forward report'), self::CONTACT_ACTION_BLOCK, $forward_translation],
+			'$forward'         => ['report_forward', $this->t('Forward report'), false, $forward_translation],
 
 			'$summary' => $this->getAside($request),
 		]);

--- a/src/Module/Moderation/Reports.php
+++ b/src/Module/Moderation/Reports.php
@@ -1,7 +1,7 @@
 <?php
 
-// Copyright (C) 2010-2024, the Friendica project
-// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -15,12 +15,21 @@ use Friendica\Content\Pager;
 use Friendica\Content\Text\BBCode;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
+use Friendica\Core\System;
+use Friendica\Core\Worker;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Database\Database;
 use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Model\Contact;
+use Friendica\Model\Item;
+use Friendica\Model\Post;
+use Friendica\Model\User;
 use Friendica\Module\BaseModeration;
 use Friendica\Module\Moderation\Utils\ReportUtil;
 use Friendica\Module\Response;
+use Friendica\Moderation\Entity\Report\Post as ReportPostEntity;
+use Friendica\Moderation\Entity\Report as ReportEntity;
 use Friendica\Moderation\Repository\Report as ReportRepository;
 use Friendica\Navigation\SystemMessages;
 use Friendica\Util\DateTimeFormat;
@@ -56,6 +65,65 @@ class Reports extends BaseModeration
 			}
 		}
 
+		if (!empty($request['report_action']) && !empty($request['report_id'])) {
+			$reportId = (int) $request['report_id'];
+			$uid      = $this->session->getLocalUserId();
+			if ($this->isFinalizedReport($reportId)) {
+				$this->logger->notice('Skipping mutation on finalized report', ['report_id' => $reportId, 'action' => $request['report_action']]);
+				$this->content($request);
+				return;
+			}
+
+			try {
+				switch ($request['report_action']) {
+					case 'assign_self':
+						$this->reportRepository->setAssignment($reportId, $uid, $uid);
+						break;
+					case 'unassign':
+						$this->reportRepository->setAssignment($reportId, null, $uid);
+						break;
+					case 'resolve':
+						$this->reportRepository->updateModerationState($reportId, [
+							'resolution'      => ReportEntity::RESOLUTION_ACCEPTED,
+							'status'          => ReportEntity::STATUS_CLOSED,
+							'last-editor-uid' => $uid,
+						]);
+						break;
+					case 'save_remarks':
+						$this->reportRepository->setRemarks(
+							$reportId,
+							(string) ($request['public_remarks'] ?? ''),
+							(string) ($request['private_remarks'] ?? ''),
+							$uid,
+						);
+						break;
+					case 'save_metadata':
+						$this->saveMetadata($reportId, $request, $uid);
+						break;
+					case 'delete_reported_posts':
+						$this->deleteReportedPosts($reportId, $uid);
+						break;
+					case 'delete_reported_post':
+						$this->deleteReportedPost($reportId, (int) ($request['uri_id'] ?? 0), $uid);
+						break;
+					case 'block_target':
+						$this->blockReportTarget($reportId, false, $uid);
+						break;
+					case 'block_target_purge':
+						$this->blockReportTarget($reportId, true, $uid);
+						break;
+					case 'warn_target':
+						$this->warnReportTarget($reportId, trim((string) ($request['warning_message'] ?? '')), $uid);
+						break;
+					case 'silence_local_target':
+						$this->silenceLocalTarget($reportId, $uid);
+						break;
+				}
+			} catch (\Throwable $e) {
+				$this->logger->notice('Error handling report action', ['report_id' => $reportId, 'action' => $request['report_action'], 'exception' => $e]);
+			}
+		}
+
 		$this->content($request);
 	}
 
@@ -63,14 +131,45 @@ class Reports extends BaseModeration
 	{
 		parent::content();
 
-		$total = $this->database->count('report', ['status' => \Friendica\Moderation\Entity\Report::STATUS_OPEN]);
+		if (!empty($request['id'])) {
+			return $this->detail((int) $request['id'], $request);
+		}
+
+		return $this->overview($request);
+	}
+
+	private function overview(array $request = []): string
+	{
+		$statusFilter   = $request['status']   ?? 'open';
+		$categoryFilter = $request['category'] ?? 'all';
+		$assignedFilter = $request['assigned'] ?? 'all';
+		$currentUserId  = $this->session->getLocalUserId();
+		$condition      = [];
+
+		if ($statusFilter !== 'all') {
+			$condition['status'] = $statusFilter === 'closed' ? ReportEntity::STATUS_CLOSED : ReportEntity::STATUS_OPEN;
+		}
+
+		if ($categoryFilter !== 'all') {
+			$categoryId = $this->categoryNameToId((string) $categoryFilter);
+			if ($categoryId !== null) {
+				$condition['category-id'] = $categoryId;
+			}
+		}
+
+		if ($assignedFilter === 'mine') {
+			$condition['assigned-uid'] = $currentUserId;
+		} elseif ($assignedFilter === 'unassigned') {
+			$condition['assigned-uid'] = null;
+		}
+
+		$total = $this->database->count('report', $condition);
 
 		$pager = new Pager($this->l10n, $this->args->getQueryString(), 10);
 
-		$query = $this->database->p(
-			"SELECT
+		$reportSql = "SELECT
 	`report`.`id`, `report`.`cid`, `report`.`comment`, `report`.`forward`, `report`.`created`, `report`.`reporter-id`,
-	`report`.`category-id`,
+	`report`.`category-id`, `report`.`status`, `report`.`resolution`, `report`.`assigned-uid`, `report`.`last-editor-uid`,
 	(
 		SELECT GROUP_CONCAT(`report-rule`.`text` ORDER BY `report-rule`.`line-id` SEPARATOR \"\n\")
 		FROM `report-rule`
@@ -80,19 +179,38 @@ class Reports extends BaseModeration
 	`contact`.`micro`, `contact`.`name`, `contact`.`nick`, `contact`.`url`, `contact`.`addr`
 FROM report
 INNER JOIN `contact` ON `contact`.`id` = `report`.`cid`
-WHERE `report`.`status` = ?
-ORDER BY `report`.`created` DESC
-LIMIT ?, ?",
-			\Friendica\Moderation\Entity\Report::STATUS_OPEN,
-			$pager->getStart(),
-			$pager->getItemsPerPage(),
-		);
+		";
+		$reportParams = [];
+		$whereParts   = [];
+		if (isset($condition['status'])) {
+			$whereParts[]   = '`report`.`status` = ?';
+			$reportParams[] = $condition['status'];
+		}
+		if (isset($condition['category-id'])) {
+			$whereParts[]   = '`report`.`category-id` = ?';
+			$reportParams[] = $condition['category-id'];
+		}
+		if ($assignedFilter === 'mine') {
+			$whereParts[]   = '`report`.`assigned-uid` = ?';
+			$reportParams[] = $currentUserId;
+		} elseif ($assignedFilter === 'unassigned') {
+			$whereParts[] = '`report`.`assigned-uid` IS NULL';
+		}
+
+		$reportSql .= ' WHERE ' . (empty($whereParts) ? '1=1' : implode(' AND ', $whereParts));
+		$reportSql .= ' ORDER BY `report`.`created` DESC LIMIT ?, ?';
+		$reportParams[] = $pager->getStart();
+		$reportParams[] = $pager->getItemsPerPage();
+
+		$query = $this->database->p($reportSql, ...$reportParams);
 
 		$reports = [];
 		while ($report = $this->database->fetch($query)) {
-			$report['posts']    = [];
-			$report['created']  = DateTimeFormat::local($report['created'], DateTimeFormat::MYSQL);
-			$report['category'] = $this->reportUtil->getReportCategoryName($report['category-id']);
+			$report['posts']        = [];
+			$report['created']      = DateTimeFormat::local($report['created'], DateTimeFormat::MYSQL);
+			$report['category']     = $this->reportUtil->getReportCategoryName($report['category-id']);
+			$report['status_label'] = $report['status'] == ReportEntity::STATUS_CLOSED ? $this->t('Closed') : $this->t('Open');
+			$report['detail_url']   = 'moderation/reports?id=' . (int) $report['id'] . '&status=' . rawurlencode($statusFilter) . '&category=' . rawurlencode($categoryFilter) . '&assigned=' . rawurlencode($assignedFilter);
 
 			$reports[$report['id']] = $report;
 		}
@@ -120,10 +238,19 @@ LIMIT ?, ?",
 			'$description' => $this->t('This page display reports created by our or remote users.'),
 			'$no_data'     => $this->t('No report exists at this node.'),
 
-			'$h_reports'     => $this->t('Reports'),
-			'$th_reports'    => [$this->t('Created'), $this->t('Photo'), $this->t('Name'), $this->t('Comment'), $this->t('Category')],
-			'$select_all'    => $this->t('Select all'),
-			'$close_reports' => $this->t('Close selected reports'),
+			'$h_reports'             => $this->t('Reports'),
+			'$th_reports'            => [$this->t('Created'), $this->t('Photo'), $this->t('Name'), $this->t('Comment'), $this->t('Category'), $this->t('Status')],
+			'$select_all'            => $this->t('Select all'),
+			'$close_reports'         => $this->t('Close selected reports'),
+			'$open_reports'          => $this->t('Open reports'),
+			'$closed_reports'        => $this->t('Closed reports'),
+			'$all_reports'           => $this->t('All reports'),
+			'$filter_status'         => $statusFilter,
+			'$filter_assigned'       => $assignedFilter,
+			'$category_filter_value' => $categoryFilter,
+			'$category_filters'      => $this->buildCategoryFilterOptions($categoryFilter),
+			'$assigned_filters'      => $this->buildAssignmentFilterOptions($assignedFilter),
+			'$all_categories'        => $this->t('All categories'),
 
 			// values //
 			'$reports'       => $reports,
@@ -132,5 +259,381 @@ LIMIT ?, ?",
 
 			'$contacturl' => ['contact_url', $this->t('Profile URL'), '', $this->t('URL of the reported contact.')],
 		]);
+	}
+
+	private function detail(int $reportId, array $request = []): string
+	{
+		$report          = $this->reportRepository->selectOneById($reportId);
+		$target          = Contact::getById($report->cid, ['id', 'micro', 'name', 'nick', 'url', 'addr', 'nurl']);
+		$targetUserId    = !empty($target['url']) ? User::getIdForURL($target['url']) : 0;
+		$selectedRuleIds = [];
+		foreach ($report->rules as $rule) {
+			$selectedRuleIds[] = $rule->lineId;
+		}
+
+		$reportArray = [
+			'id'               => $report->id,
+			'created'          => DateTimeFormat::local($report->created->format(DateTimeFormat::MYSQL), DateTimeFormat::MYSQL),
+			'edited'           => $report->edited ? DateTimeFormat::local($report->edited->format(DateTimeFormat::MYSQL), DateTimeFormat::MYSQL) : null,
+			'category'         => $this->reportUtil->getReportCategoryName($report->category),
+			'category_id'      => $report->category,
+			'comment'          => $report->comment,
+			'public_remarks'   => $report->publicRemarks,
+			'private_remarks'  => $report->privateRemarks,
+			'forward'          => $report->forward,
+			'status'           => $report->status,
+			'status_label'     => $report->status === ReportEntity::STATUS_CLOSED ? $this->t('Closed') : $this->t('Open'),
+			'resolution'       => $report->resolution,
+			'assigned_uid'     => $report->assignedUid,
+			'reporter'         => Contact::getById($report->reporterCid, ['id', 'micro', 'name', 'nick', 'url', 'addr']),
+			'target'           => $target,
+			'target_is_local'  => $targetUserId > 0,
+			'target_user_id'   => $targetUserId,
+			'posts'            => [],
+			'rules'            => [],
+			'rules_available'  => $this->buildRuleOptions($selectedRuleIds),
+			'category_options' => $this->buildCategoryOptions($report->category),
+			'is_final'         => $report->status === ReportEntity::STATUS_CLOSED,
+		];
+
+		foreach ($report->posts as $post) {
+			$postRecord = Post::selectFirst(['uri-id', 'guid', 'plink', 'title', 'created'], ['uri-id' => $post->uriId, 'uid' => 0]);
+			if (empty($postRecord)) {
+				$postRecord = Post::selectFirst(['uri-id', 'guid', 'plink', 'title', 'created'], ['uri-id' => $post->uriId]);
+			}
+
+			$reportArray['posts'][] = [
+				'uri_id'  => $post->uriId,
+				'status'  => $post->status,
+				'guid'    => $postRecord['guid']  ?? '',
+				'plink'   => $postRecord['plink'] ?? '',
+				'title'   => $postRecord['title'] ?? '',
+				'created' => !empty($postRecord['created']) ? DateTimeFormat::local($postRecord['created'], DateTimeFormat::MYSQL) : '',
+			];
+		}
+
+		foreach ($report->rules as $rule) {
+			$reportArray['rules'][] = [
+				'line_id' => $rule->lineId,
+				'text'    => $rule->text,
+			];
+		}
+
+		$t                = Renderer::getMarkupTemplate('moderation/report/show.tpl');
+		$backToReportsUrl = 'moderation/reports?status=' . rawurlencode((string) ($request['status'] ?? 'open')) . '&category=' . rawurlencode((string) ($request['category'] ?? 'all')) . '&assigned=' . rawurlencode((string) ($request['assigned'] ?? 'all'));
+		return Renderer::replaceMacros($t, [
+			'$title'               => $this->t('Moderation'),
+			'$page'                => $this->t('Report details'),
+			'$back_to_reports'     => $this->t('Back to reports'),
+			'$back_to_reports_url' => $backToReportsUrl,
+			'$forwarded'           => $this->t('Forwarded'),
+			'$not_forwarded'       => $this->t('Not forwarded'),
+			'$assigned_user_id'    => $this->t('Assigned user id:'),
+			'$unassigned'          => $this->t('Unassigned'),
+			'$reporter_label'      => $this->t('Reporter:'),
+			'$target_label'        => $this->t('Target:'),
+			'$category_and_rules'  => $this->t('Category and rules'),
+			'$category_label'      => $this->t('Category'),
+			'$node_rules'          => $this->t('Node rules'),
+			'$attached_posts'      => $this->t('Attached posts'),
+			'$uri_id_label'        => $this->t('URI-ID'),
+			'$status_label'        => $this->t('status'),
+			'$guid_label'          => $this->t('GUID'),
+			'$actions_heading'     => $this->t('Actions'),
+			'$public_remarks'      => $this->t('Public remarks'),
+			'$private_remarks'     => $this->t('Private remarks'),
+			'$finalized_read_only' => $this->t('This report is finalized and read-only.'),
+			'$save_remarks'        => $this->t('Save remarks'),
+			'$assign_self'         => $this->t('Assign to me'),
+			'$unassign'            => $this->t('Unassign'),
+			'$resolve'             => $this->t('Mark resolved'),
+			'$save_metadata'       => $this->t('Save category and rules'),
+			'$delete_posts'        => $this->t('Delete all reported posts'),
+			'$block_local'         => $this->t('Block local user'),
+			'$block_remote'        => $this->t('Block remote contact'),
+			'$block_remote_purge'  => $this->t('Block remote contact and purge content'),
+			'$delete_post'         => $this->t('Delete this reported post'),
+			'$warn_target'         => $this->t('Warn user'),
+			'$warning_message'     => $this->t('Warning message'),
+			'$silence_local'       => $this->t('Silence local user (future posts unlisted)'),
+			'$report'              => $reportArray,
+		]);
+	}
+
+	private function deleteReportedPosts(int $reportId, int $uid): void
+	{
+		$report = $this->reportRepository->selectOneById($reportId);
+
+		$deletedCount = 0;
+		foreach ($report->posts as $post) {
+			Item::markForDeletion(['uri-id' => $post->uriId, 'deleted' => false]);
+			$this->database->update('report-post', ['status' => ReportPostEntity::STATUS_DELETED], ['rid' => $reportId, 'uri-id' => $post->uriId]);
+			$deletedCount++;
+		}
+
+		$this->reportRepository->updateModerationState($reportId, ['last-editor-uid' => $uid]);
+
+		if ($deletedCount > 0) {
+			$this->systemMessages->addInfo($this->tt('%s reported post marked for deletion', '%s reported posts marked for deletion', $deletedCount));
+		} else {
+			$this->systemMessages->addNotice($this->t('This report has no attached posts.'));
+		}
+	}
+
+	private function deleteReportedPost(int $reportId, int $uriId, int $uid): void
+	{
+		if ($uriId <= 0) {
+			$this->systemMessages->addNotice($this->t('Invalid reported post id.'));
+			return;
+		}
+
+		$report = $this->reportRepository->selectOneById($reportId);
+		$found  = false;
+		foreach ($report->posts as $post) {
+			if ($post->uriId === $uriId) {
+				$found = true;
+				break;
+			}
+		}
+
+		if (!$found) {
+			$this->systemMessages->addNotice($this->t('This post is not attached to the report.'));
+			return;
+		}
+
+		Item::markForDeletion(['uri-id' => $uriId, 'deleted' => false]);
+		$this->database->update('report-post', ['status' => ReportPostEntity::STATUS_DELETED], ['rid' => $reportId, 'uri-id' => $uriId]);
+		$this->reportRepository->updateModerationState($reportId, ['last-editor-uid' => $uid]);
+		$this->systemMessages->addInfo($this->t('Reported post marked for deletion.'));
+	}
+
+	private function blockReportTarget(int $reportId, bool $purge, int $uid): void
+	{
+		$report = $this->reportRepository->selectOneById($reportId);
+		$target = Contact::getById($report->cid, ['id', 'name', 'url', 'nurl']);
+
+		if (empty($target)) {
+			$this->systemMessages->addNotice($this->t('Reported target contact not found.'));
+			return;
+		}
+
+		$localUserId = !empty($target['url']) ? User::getIdForURL($target['url']) : 0;
+		if ($localUserId > 0) {
+			User::block($localUserId);
+			$this->reportRepository->updateModerationState($reportId, ['last-editor-uid' => $uid]);
+			$this->systemMessages->addInfo($this->t('The local user has been blocked.'));
+			return;
+		}
+
+		if (Contact::isLocalById($report->cid)) {
+			$this->systemMessages->addNotice($this->t('Could not map the reported local contact to a user account.'));
+			return;
+		}
+
+		if (!Contact::block($report->cid, 'Blocked from moderation report #' . $reportId)) {
+			$this->systemMessages->addNotice($this->t('Failed to block the remote contact.'));
+			return;
+		}
+
+		if ($purge && !empty($target['nurl'])) {
+			foreach (Contact::selectToArray(['id'], ['nurl' => $target['nurl']]) as $contact) {
+				Worker::add(Worker::PRIORITY_LOW, 'Contact\\RemoveContent', $contact['id']);
+			}
+		}
+
+		$this->reportRepository->updateModerationState($reportId, ['last-editor-uid' => $uid]);
+
+		if ($purge) {
+			$this->systemMessages->addInfo($this->t('The remote contact has been blocked and related content will be purged.'));
+		} else {
+			$this->systemMessages->addInfo($this->t('The remote contact has been blocked.'));
+		}
+	}
+
+	private function warnReportTarget(int $reportId, string $warningMessage, int $uid): void
+	{
+		$this->logger->alert('Moderator warning issued', ['report_id' => $reportId, 'warning_message' => $warningMessage, 'uid' => $uid]);
+		if ($warningMessage === '') {
+			$this->systemMessages->addNotice($this->t('Please provide a warning message.'));
+			return;
+		}
+
+		$report      = $this->reportRepository->selectOneById($reportId);
+		$target      = Contact::getById($report->cid, ['id', 'url']);
+		$localUserId = !empty($target['url']) ? User::getIdForURL($target['url']) : 0;
+
+		$publicRemarks = trim($report->publicRemarks);
+		if ($publicRemarks !== '') {
+			$publicRemarks .= "\n\n";
+		}
+		$publicRemarks .= '[' . DateTimeFormat::utcNow() . '] ' . $this->t('Moderator warning:') . "\n" . $warningMessage;
+
+		$this->reportRepository->setRemarks($reportId, $publicRemarks, $report->privateRemarks, $uid);
+
+		if ($localUserId <= 0) {
+			$this->systemMessages->addNotice($this->t('Warning text has been saved, but automatic delivery is only available for local users.'));
+			return;
+		}
+
+		$user = User::getById($localUserId, ['uid', 'username', 'email', 'language']);
+		if (empty($user['email'])) {
+			$this->systemMessages->addNotice($this->t('Warning text has been saved, but the local user has no deliverable email address.'));
+			return;
+		}
+
+		try {
+			$email = DI::emailer()
+				->newSystemMail()
+				->withMessage(
+					$this->t('Moderation warning from %s', $this->baseUrl->getHost()),
+					$this->t('Your recent activity was reported to the moderation team. Please review this warning message.'),
+					$warningMessage,
+				)
+				->forUser($user)
+				->withRecipient($user['email'])
+				->build();
+
+			if (DI::emailer()->send($email)) {
+				$this->logger->info('Moderator warning sent successfully', ['report_id' => $reportId, 'uid' => $uid, 'target_uid' => $localUserId]);
+				$this->systemMessages->addInfo($this->t('Warning sent to the local user and stored in public remarks.'));
+			} else {
+				$this->logger->notice('Warning delivery failed', ['report_id' => $reportId, 'uid' => $uid, 'target_uid' => $localUserId]);
+				$this->systemMessages->addNotice($this->t('Warning text was stored, but sending the email failed.'));
+			}
+		} catch (\Throwable $exception) {
+			$this->logger->notice('Warning delivery failed', ['report_id' => $reportId, 'uid' => $localUserId, 'exception' => $exception]);
+			$this->systemMessages->addNotice($this->t('Warning text was stored, but sending the email failed.'));
+		}
+	}
+
+	private function silenceLocalTarget(int $reportId, int $uid): void
+	{
+		$report      = $this->reportRepository->selectOneById($reportId);
+		$target      = Contact::getById($report->cid, ['id', 'url']);
+		$localUserId = !empty($target['url']) ? User::getIdForURL($target['url']) : 0;
+
+		if ($localUserId <= 0) {
+			$this->systemMessages->addNotice($this->t('This action is only available for local users.'));
+			return;
+		}
+
+		DI::pConfig()->set($localUserId, 'system', 'unlisted', true);
+
+		$publicContactId = Contact::getPublicIdByUserId($localUserId);
+		if (!empty($publicContactId)) {
+			Contact::hide($publicContactId);
+		}
+
+		$this->reportRepository->updateModerationState($reportId, ['last-editor-uid' => $uid]);
+		$this->systemMessages->addInfo($this->t('Local user silenced: future posts will be unlisted, and public community visibility is reduced.'));
+	}
+
+	private function isFinalizedReport(int $reportId): bool
+	{
+		try {
+			return $this->reportRepository->selectOneById($reportId)->status === ReportEntity::STATUS_CLOSED;
+		} catch (\Throwable) {
+			return false;
+		}
+	}
+
+	private function saveMetadata(int $reportId, array $request, int $uid): void
+	{
+		$category   = (string) ($request['category'] ?? '');
+		$categoryId = $this->categoryNameToId($category);
+		if ($categoryId === null) {
+			return;
+		}
+
+		$ruleIds = $request['rule_ids'] ?? [];
+		if (is_string($ruleIds)) {
+			$ruleIds = [$ruleIds];
+		}
+
+		$this->database->update('report', [
+			'category-id'     => $categoryId,
+			'edited'          => DateTimeFormat::utcNow(),
+			'last-editor-uid' => $uid,
+		], ['id' => $reportId]);
+
+		$this->database->delete('report-rule', ['rid' => $reportId]);
+		if ($categoryId === ReportEntity::CATEGORY_VIOLATION) {
+			$rules = System::getRules(true);
+			foreach ($ruleIds as $lineId) {
+				$lineId = (int) $lineId;
+				$this->database->insert('report-rule', [
+					'rid'     => $reportId,
+					'line-id' => $lineId,
+					'text'    => $rules[$lineId] ?? '',
+				]);
+			}
+		}
+	}
+
+	private function buildCategoryOptions(int $selectedCategory): array
+	{
+		return [
+			['value' => 'spam', 'label' => $this->t('Spam'), 'selected' => $selectedCategory === ReportEntity::CATEGORY_SPAM],
+			['value' => 'legal', 'label' => $this->t('Illegal Content'), 'selected' => $selectedCategory === ReportEntity::CATEGORY_ILLEGAL],
+			['value' => 'violation', 'label' => $this->t('Rules Violation'), 'selected' => $selectedCategory === ReportEntity::CATEGORY_VIOLATION],
+			['value' => 'other', 'label' => $this->t('Other'), 'selected' => $selectedCategory === ReportEntity::CATEGORY_OTHER],
+		];
+	}
+
+	private function buildCategoryFilterOptions(string $selectedCategory): array
+	{
+		$filters = [
+			['value' => 'all', 'label' => $this->t('All categories'), 'selected' => $selectedCategory === 'all'],
+			['value' => 'spam', 'label' => $this->t('Spam'), 'selected' => $selectedCategory === 'spam'],
+			['value' => 'legal', 'label' => $this->t('Illegal Content'), 'selected' => $selectedCategory === 'legal'],
+			['value' => 'violation', 'label' => $this->t('Rules Violation'), 'selected' => $selectedCategory === 'violation'],
+			['value' => 'other', 'label' => $this->t('Other'), 'selected' => $selectedCategory === 'other'],
+		];
+
+		foreach (array_keys($filters) as $index) {
+			$filters[$index]['last'] = $index === array_key_last($filters);
+		}
+
+		return $filters;
+	}
+
+	private function buildAssignmentFilterOptions(string $selectedAssigned): array
+	{
+		$filters = [
+			['value' => 'all', 'label' => $this->t('All assignments'), 'selected' => $selectedAssigned === 'all'],
+			['value' => 'mine', 'label' => $this->t('Assigned to me'), 'selected' => $selectedAssigned === 'mine'],
+			['value' => 'unassigned', 'label' => $this->t('Unassigned'), 'selected' => $selectedAssigned === 'unassigned'],
+		];
+
+		foreach (array_keys($filters) as $index) {
+			$filters[$index]['last'] = $index === array_key_last($filters);
+		}
+
+		return $filters;
+	}
+
+	private function buildRuleOptions(array $selectedRuleIds): array
+	{
+		$rules = [];
+		foreach (System::getRules(true) as $lineId => $text) {
+			$rules[] = [
+				'line_id'  => (int) $lineId,
+				'text'     => $text,
+				'selected' => in_array((int) $lineId, $selectedRuleIds, true),
+			];
+		}
+
+		return $rules;
+	}
+
+	private function categoryNameToId(string $category): ?int
+	{
+		return match ($category) {
+			'spam'      => ReportEntity::CATEGORY_SPAM,
+			'legal'     => ReportEntity::CATEGORY_ILLEGAL,
+			'violation' => ReportEntity::CATEGORY_VIOLATION,
+			'other'     => ReportEntity::CATEGORY_OTHER,
+			default     => null,
+		};
 	}
 }

--- a/src/Object/Api/Mastodon/Report.php
+++ b/src/Object/Api/Mastodon/Report.php
@@ -1,0 +1,79 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Object\Api\Mastodon;
+
+use Friendica\BaseDataTransferObject;
+
+/**
+ * Class Report
+ *
+ * @see https://docs.joinmastodon.org/entities/Admin_Report/
+ */
+class Report extends BaseDataTransferObject
+{
+	/** @var string */
+	protected $id;
+	/** @var bool */
+	protected $action_taken;
+	/** @var string|null (Datetime) */
+	protected $action_taken_at;
+	/** @var string */
+	protected $category;
+	/** @var string */
+	protected $comment;
+	/** @var bool */
+	protected $forwarded;
+	/** @var string (Datetime) */
+	protected $created_at;
+	/** @var string (Datetime) */
+	protected $updated_at;
+	/** @var array|null */
+	protected $account;
+	/** @var array|null */
+	protected $target_account;
+	/** @var array|null */
+	protected $assigned_account;
+	/** @var array|null */
+	protected $action_taken_by_account;
+	/** @var array */
+	protected $statuses;
+	/** @var array */
+	protected $rules;
+
+	public function __construct(
+		int $id,
+		bool $actionTaken,
+		?string $actionTakenAt,
+		string $category,
+		string $comment,
+		bool $forwarded,
+		string $createdAt,
+		string $updatedAt,
+		?array $account,
+		?array $targetAccount,
+		?array $assignedAccount,
+		?array $actionTakenByAccount,
+		array $statuses,
+		array $rules,
+	) {
+		$this->id                      = (string) $id;
+		$this->action_taken            = $actionTaken;
+		$this->action_taken_at         = $actionTakenAt;
+		$this->category                = $category;
+		$this->comment                 = $comment;
+		$this->forwarded               = $forwarded;
+		$this->created_at              = $createdAt;
+		$this->updated_at              = $updatedAt;
+		$this->account                 = $account;
+		$this->target_account          = $targetAccount;
+		$this->assigned_account        = $assignedAccount;
+		$this->action_taken_by_account = $actionTakenByAccount;
+		$this->statuses                = $statuses;
+		$this->rules                   = $rules;
+	}
+}

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -1,7 +1,7 @@
 <?php
 
-// Copyright (C) 2010-2024, the Friendica project
-// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -2308,6 +2308,85 @@ class Transmitter
 
 		$signed = LDSignature::sign($data, $owner);
 		return HTTPSignature::transmit($signed, $profile['inbox'], $owner);
+	}
+
+	/**
+	 * Forwards a moderation report to the remote server of the reported account via ActivityPub Flag.
+	 *
+	 * @param int $reportId Moderation report id
+	 * @return bool success
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws \Exception
+	 */
+	public static function sendModerationReport(int $reportId): bool
+	{
+		try {
+			$report = DI::report()->selectOneById($reportId);
+		} catch (\Throwable $e) {
+			DI::logger()->notice('Cannot forward report, report not found', ['report_id' => $reportId, 'exception' => $e]);
+			return false;
+		}
+
+		if (!$report->forward) {
+			DI::logger()->debug('Skipping report forwarding, forwarding disabled', ['report_id' => $reportId]);
+			return false;
+		}
+
+		if (empty($report->reporterUid)) {
+			DI::logger()->debug('Skipping report forwarding, no local reporter user', ['report_id' => $reportId]);
+			return false;
+		}
+
+		$target = Contact::getById($report->cid, ['url', 'addr']);
+		if (empty($target['url']) || DI::baseUrl()->isLocalUrl($target['url'])) {
+			DI::logger()->debug('Skipping report forwarding, target is local or missing URL', ['report_id' => $reportId, 'target' => $target]);
+			return false;
+		}
+
+		$profile = APContact::getByURL($target['url']);
+		if (empty($profile['inbox'])) {
+			DI::logger()->warning('Skipping report forwarding, no remote inbox found', ['report_id' => $reportId, 'target_url' => $target['url']]);
+			return false;
+		}
+
+		$owner = User::getOwnerDataById((int) $report->reporterUid);
+		if (empty($owner['url'])) {
+			DI::logger()->warning('Skipping report forwarding, owner data not found', ['report_id' => $reportId, 'uid' => $report->reporterUid]);
+			return false;
+		}
+
+		$objects = [['id' => $target['url']]];
+		foreach ($report->posts as $post) {
+			$postRow = Post::selectFirst(['uri'], ['uri-id' => $post->uriId]);
+			if (!empty($postRow['uri'])) {
+				$objects[] = ['id' => $postRow['uri']];
+			}
+		}
+
+		$data = [
+			'@context'   => ActivityPub::CONTEXT,
+			'id'         => DI::baseUrl() . '/activity/' . System::createGUID(),
+			'type'       => 'Flag',
+			'actor'      => $owner['url'],
+			'object'     => $objects,
+			'content'    => $report->comment,
+			'published'  => DateTimeFormat::utcNow(DateTimeFormat::ATOM),
+			'instrument' => self::getService(),
+			'to'         => [$profile['url'] ?? $target['url']],
+		];
+
+		DI::logger()->info('Sending moderation report via ActivityPub', ['report_id' => $reportId, 'target' => $target['url'], 'inbox' => $profile['inbox']]);
+
+		$signed  = LDSignature::sign($data, $owner);
+		$success = HTTPSignature::transmit($signed, $profile['inbox'], $owner);
+
+		if ($success) {
+			DI::logger()->info('Forwarded moderation report to remote server', ['report_id' => $reportId, 'target' => $target['url'], 'inbox' => $profile['inbox']]);
+		} else {
+			DI::logger()->warning('Failed forwarding moderation report to remote server', ['report_id' => $reportId, 'target' => $target['url'], 'inbox' => $profile['inbox']]);
+		}
+
+		return $success;
 	}
 
 	/**

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -1,7 +1,7 @@
 <?php
 
-// Copyright (C) 2010-2024, the Friendica project
-// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -103,6 +103,8 @@ class Cron
 			Worker::add(Worker::PRIORITY_LOW, 'UpdatePhotoAlbums');
 
 			Worker::add(Worker::PRIORITY_LOW, 'ExpirePosts');
+
+			Worker::add(Worker::PRIORITY_LOW, 'ExpireReports');
 
 			Worker::add(Worker::PRIORITY_LOW, 'ExpireActivities');
 

--- a/src/Worker/ExpireReports.php
+++ b/src/Worker/ExpireReports.php
@@ -1,0 +1,59 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Worker;
+
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Database\Database;
+use Friendica\DI;
+use Friendica\Moderation\Entity\Report as ReportEntity;
+use Friendica\Util\DateTimeFormat;
+use Psr\Log\LoggerInterface;
+
+class ExpireReports
+{
+	public static function execute()
+	{
+		self::cleanupExpiredReports(DI::dba(), DI::config(), DI::logger());
+	}
+
+	public static function cleanupExpiredReports(Database $database, IManageConfigValues $config, LoggerInterface $logger): void
+	{
+		$enabled = (int) ($config->get('system', 'dbclean-expire-limit') ?? 0);
+		if ($enabled <= 0) {
+			return;
+		}
+
+		self::deleteExpiredReports($database, $logger, ReportEntity::STATUS_CLOSED, DateTimeFormat::utc('now - 90 days'), 'closed');
+		self::deleteExpiredReports($database, $logger, ReportEntity::STATUS_OPEN, DateTimeFormat::utc('now - 365 days'), 'open');
+	}
+
+	private static function deleteExpiredReports(Database $database, LoggerInterface $logger, int $status, string $threshold, string $label): void
+	{
+		$condition = [
+			"`status` = ? AND COALESCE(`edited`, `created`) < ?",
+			$status,
+			$threshold,
+		];
+
+		$reports = $database->select('report', ['id'], $condition);
+		if (empty($reports)) {
+			return;
+		}
+
+		$rows = 0;
+		while ($row = $database->fetch($reports)) {
+			$database->delete('report-rule', ['rid' => $row['id']]);
+			$database->delete('report-post', ['rid' => $row['id']]);
+			$database->delete('report', ['id' => $row['id']]);
+			$rows++;
+		}
+		$database->close($reports);
+
+		$logger->notice('Deleted expired reports', ['label' => $label, 'rows' => $rows]);
+	}
+}

--- a/src/Worker/ForwardReport.php
+++ b/src/Worker/ForwardReport.php
@@ -1,0 +1,23 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Worker;
+
+use Friendica\Network\HTTPException;
+use Friendica\Protocol\ActivityPub\Transmitter;
+
+class ForwardReport
+{
+	/**
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws \Exception
+	 */
+	public static function execute(int $reportId): void
+	{
+		Transmitter::sendModerationReport($reportId);
+	}
+}

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -1,7 +1,7 @@
 <?php
 
-/* Copyright (C) 2010-2024, the Friendica project
- * SPDX-FileCopyrightText: 2010-2024 the Friendica project
+/* Copyright (C) 2010-2026, the Friendica project
+ * SPDX-FileCopyrightText: 2010-2026 the Friendica project
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
@@ -212,9 +212,9 @@ return [
 			'/admin/trends/links'                      => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // not supported
 			'/admin/trends/statuses'                   => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // not supported
 			'/admin/trends/tags'                       => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // not supported
-			'/admin/reports'                           => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // not supported
-			'/admin/reports/{id:\d+}'                  => [Module\Api\Mastodon\Unimplemented::class,            [R::GET         ]], // not supported
-			'/admin/reports/{id:\d+}/{action}'         => [Module\Api\Mastodon\Unimplemented::class,            [        R::POST]], // not supported
+			'/admin/reports'                           => [Module\Api\Mastodon\Admin\Reports::class,           [R::GET         ]],
+			'/admin/reports/{id:\d+}'                  => [Module\Api\Mastodon\Admin\Reports::class,           [R::GET, R::PUT ]],
+			'/admin/reports/{id:\d+}/{action}'         => [Module\Api\Mastodon\Admin\Reports::class,           [        R::POST]],
 			'/announcements'                           => [Module\Api\Mastodon\Announcements::class,            [R::GET         ]], // Dummy, not supported
 			'/announcements/{id:\d+}/dismiss'          => [Module\Api\Mastodon\Unimplemented::class,            [        R::POST]], // not supported
 			'/announcements/{id:\d+}/reactions/{name}' => [Module\Api\Mastodon\Unimplemented::class,      [R::PUT, R::DELETE]], // not supported
@@ -335,6 +335,8 @@ return [
 		'/logs'      => [Module\Admin\Logs\Settings::class, [R::GET, R::POST]],
 
 		'/phpinfo' => [Module\Admin\PhpInfo::class, [R::GET]],
+
+		'/roles' => [Module\Admin\Roles::class, [R::GET, R::POST]],
 
 		'/queue[/{status}]' => [Module\Admin\Queue::class, [R::GET]],
 

--- a/tests/src/Factory/Api/Mastodon/ReportTest.php
+++ b/tests/src/Factory/Api/Mastodon/ReportTest.php
@@ -1,0 +1,150 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Test\src\Factory\Api\Mastodon;
+
+use Friendica\Database\Database;
+use Friendica\Factory\Api\Mastodon\Account;
+use Friendica\Factory\Api\Mastodon\Report;
+use Friendica\Factory\Api\Mastodon\Status;
+use Friendica\Moderation\Collection\Report\Posts;
+use Friendica\Moderation\Collection\Report\Rules;
+use Friendica\Moderation\Entity\Report as ReportEntity;
+use Friendica\Moderation\Entity\Report\Post as ReportPost;
+use Friendica\Moderation\Entity\Report\Rule as ReportRule;
+use Friendica\Object\Api\Mastodon\Account as MstdnAccount;
+use Friendica\Object\Api\Mastodon\Status as MstdnStatus;
+use Friendica\Test\MockedTestCase;
+use Psr\Log\LoggerInterface;
+
+class ReportTest extends MockedTestCase
+{
+	public function testCreateFromReportEntityMapsFields(): void
+	{
+		$logger         = \Mockery::mock(LoggerInterface::class);
+		$database       = \Mockery::mock(Database::class);
+		$accountFactory = \Mockery::mock(Account::class);
+		$statusFactory  = \Mockery::mock(Status::class);
+
+		$factory = new Report($logger, $database, $accountFactory, $statusFactory);
+
+		$created = new \DateTimeImmutable('2026-01-01 10:00:00', new \DateTimeZone('UTC'));
+		$edited  = new \DateTimeImmutable('2026-01-02 10:00:00', new \DateTimeZone('UTC'));
+
+		$report = new ReportEntity(
+			reporterCid: 10,
+			cid: 20,
+			gsid: 30,
+			created: $created,
+			category: ReportEntity::CATEGORY_VIOLATION,
+			reporterUid: 99,
+			comment: 'Needs moderation',
+			forward: true,
+			posts: new Posts([
+				new ReportPost(1001),
+				new ReportPost(1002),
+			]),
+			rules: new Rules([
+				new ReportRule(7, 'Be kind'),
+			]),
+			edited: $edited,
+			status: ReportEntity::STATUS_CLOSED,
+			id: 42,
+		);
+
+		$reporterAccount = \Mockery::mock(MstdnAccount::class);
+		$reporterAccount->shouldReceive('toArray')->once()->andReturn(['id' => 'acc-10']);
+		$targetAccount = \Mockery::mock(MstdnAccount::class);
+		$targetAccount->shouldReceive('toArray')->once()->andReturn(['id' => 'acc-20']);
+
+		$accountFactory->shouldReceive('createFromContactId')->with(10, 99)->once()->andReturn($reporterAccount);
+		$accountFactory->shouldReceive('createFromContactId')->with(20, 99)->once()->andReturn($targetAccount);
+
+		$database->shouldReceive('selectToArray')->with('report-post', ['uri-id'], ['rid' => 42])->once()->andReturn([
+			['uri-id' => 1001],
+			['uri-id' => 1002],
+		]);
+		$database->shouldReceive('selectToArray')->with('report-rule', ['line-id', 'text'], ['rid' => 42])->once()->andReturn([
+			['line-id' => 7, 'text' => 'Be kind'],
+		]);
+
+		$statusA = \Mockery::mock(MstdnStatus::class);
+		$statusA->shouldReceive('toArray')->once()->andReturn(['id' => 'status-1001']);
+		$statusB = \Mockery::mock(MstdnStatus::class);
+		$statusB->shouldReceive('toArray')->once()->andReturn(['id' => 'status-1002']);
+
+		$statusFactory->shouldReceive('createFromUriId')->with(1001, 99)->once()->andReturn($statusA);
+		$statusFactory->shouldReceive('createFromUriId')->with(1002, 99)->once()->andReturn($statusB);
+
+		$result = $factory->createFromReportEntity($report)->toArray();
+
+		self::assertSame('42', $result['id']);
+		self::assertTrue($result['action_taken']);
+		self::assertNotNull($result['action_taken_at']);
+		self::assertSame('violation', $result['category']);
+		self::assertSame('Needs moderation', $result['comment']);
+		self::assertTrue($result['forwarded']);
+		self::assertSame(['id' => 'acc-10'], $result['account']);
+		self::assertSame(['id' => 'acc-20'], $result['target_account']);
+		self::assertNull($result['assigned_account']);
+		self::assertNull($result['action_taken_by_account']);
+		self::assertSame([['id' => 'status-1001'], ['id' => 'status-1002']], $result['statuses']);
+		self::assertSame([['line-id' => 7, 'text' => 'Be kind']], $result['rules']);
+	}
+
+	public function testCreateFromReportEntitySkipsBrokenDependencies(): void
+	{
+		$logger         = \Mockery::mock(LoggerInterface::class);
+		$database       = \Mockery::mock(Database::class);
+		$accountFactory = \Mockery::mock(Account::class);
+		$statusFactory  = \Mockery::mock(Status::class);
+
+		$factory = new Report($logger, $database, $accountFactory, $statusFactory);
+
+		$created = new \DateTimeImmutable('2026-01-03 10:00:00', new \DateTimeZone('UTC'));
+
+		$report = new ReportEntity(
+			reporterCid: 11,
+			cid: 21,
+			gsid: 31,
+			created: $created,
+			category: ReportEntity::CATEGORY_OTHER,
+			reporterUid: null,
+			comment: '',
+			forward: false,
+			posts: new Posts([
+				new ReportPost(2001),
+			]),
+			rules: new Rules([]),
+			edited: null,
+			status: ReportEntity::STATUS_OPEN,
+			id: 43,
+		);
+
+		$accountFactory->shouldReceive('createFromContactId')->with(11, 0)->once()->andThrow(new \RuntimeException('missing'));
+		$accountFactory->shouldReceive('createFromContactId')->with(21, 0)->once()->andThrow(new \RuntimeException('missing'));
+
+		$database->shouldReceive('selectToArray')->with('report-post', ['uri-id'], ['rid' => 43])->once()->andReturn([
+			['uri-id' => 2001],
+		]);
+		$database->shouldReceive('selectToArray')->with('report-rule', ['line-id', 'text'], ['rid' => 43])->once()->andReturn([]);
+
+		$statusFactory->shouldReceive('createFromUriId')->with(2001, 0)->once()->andThrow(new \RuntimeException('status failed'));
+
+		$result = $factory->createFromReportEntity($report)->toArray();
+
+		self::assertSame('43', $result['id']);
+		self::assertFalse($result['action_taken']);
+		self::assertNull($result['action_taken_at']);
+		self::assertSame('other', $result['category']);
+		self::assertFalse($result['forwarded']);
+		self::assertNull($result['account']);
+		self::assertNull($result['target_account']);
+		self::assertSame([], $result['statuses']);
+		self::assertSame([], $result['rules']);
+	}
+}

--- a/tests/src/Moderation/Repository/ReportTest.php
+++ b/tests/src/Moderation/Repository/ReportTest.php
@@ -1,0 +1,103 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Test\src\Moderation\Repository;
+
+use Friendica\Database\Database;
+use Friendica\Moderation\Entity;
+use Friendica\Moderation\Factory;
+use Friendica\Moderation\Repository\Report as ReportRepository;
+use Friendica\Test\MockedTestCase;
+use Friendica\Util\Clock\FrozenClock;
+use Psr\Log\NullLogger;
+
+class ReportTest extends MockedTestCase
+{
+	private function createRepositoryWithUpdateExpectation(?array $expectedFields, int $reportId = 7): ReportRepository
+	{
+		$database = $this->getMockBuilder(Database::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['update'])
+			->getMock();
+
+		if ($expectedFields !== null) {
+			$database->expects(self::once())
+				->method('update')
+				->with(
+					'report',
+					self::callback(function (array $fields) use ($expectedFields) {
+						foreach ($expectedFields as $key => $expectedValue) {
+							self::assertArrayHasKey($key, $fields);
+							self::assertSame($expectedValue, $fields[$key]);
+						}
+
+						self::assertArrayHasKey('edited', $fields);
+						self::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $fields['edited']);
+
+						return true;
+					}),
+					['id' => $reportId],
+				)
+				->willReturn(true);
+		}
+
+		return new ReportRepository(
+			$database,
+			new NullLogger(),
+			new Factory\Report(new NullLogger(), new FrozenClock()),
+			new Factory\Report\Post(new NullLogger()),
+			new Factory\Report\Rule(new NullLogger()),
+		);
+	}
+
+	public function testSetStatusUpdatesStatusAndEdited(): void
+	{
+		$repository = $this->createRepositoryWithUpdateExpectation([
+			'status' => Entity\Report::STATUS_CLOSED,
+		]);
+
+		self::assertTrue($repository->setStatus(7, Entity\Report::STATUS_CLOSED));
+	}
+
+	public function testSetRemarksUpdatesRemarksAndLastEditor(): void
+	{
+		$repository = $this->createRepositoryWithUpdateExpectation([
+			'public-remarks'  => 'Public feedback',
+			'private-remarks' => 'Internal note',
+			'last-editor-uid' => 23,
+		]);
+
+		self::assertTrue($repository->setRemarks(7, 'Public feedback', 'Internal note', 23));
+	}
+
+	public function testSetResolutionRejectsInvalidValue(): void
+	{
+		$repository = $this->createRepositoryWithUpdateExpectation(null);
+
+		self::expectException(\InvalidArgumentException::class);
+		self::expectExceptionMessage('Invalid report resolution: 9');
+
+		$repository->setResolution(7, 9);
+	}
+
+	public function testUpdateModerationStateAllowsCombinedUpdates(): void
+	{
+		$repository = $this->createRepositoryWithUpdateExpectation([
+			'status'          => Entity\Report::STATUS_OPEN,
+			'resolution'      => Entity\Report::RESOLUTION_REJECTED,
+			'assigned-uid'    => 17,
+			'last-editor-uid' => 42,
+		]);
+
+		self::assertTrue($repository->updateModerationState(7, [
+			'status'          => Entity\Report::STATUS_OPEN,
+			'resolution'      => Entity\Report::RESOLUTION_REJECTED,
+			'assigned-uid'    => 17,
+			'last-editor-uid' => 42,
+		]));
+	}
+}

--- a/tests/src/Module/Api/Mastodon/Admin/ReportsTest.php
+++ b/tests/src/Module/Api/Mastodon/Admin/ReportsTest.php
@@ -1,0 +1,187 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Test\src\Module\Api\Mastodon\Admin;
+
+use Friendica\App\Arguments;
+use Friendica\App\BaseURL;
+use Friendica\AppHelper;
+use Friendica\Core\L10n;
+use Friendica\Database\Database;
+use Friendica\Factory\Api\Mastodon\Error as ErrorFactory;
+use Friendica\Factory\Api\Mastodon\Report as MastodonReportFactory;
+use Friendica\Moderation\Factory\Report as ReportFactory;
+use Friendica\Moderation\Factory\Report\Post as ReportPostFactory;
+use Friendica\Moderation\Factory\Report\Rule as ReportRuleFactory;
+use Friendica\Moderation\Entity\Report as ReportEntity;
+use Friendica\Moderation\Repository\Report as ReportRepository;
+use Friendica\Module\Api\ApiResponse;
+use Friendica\Module\Api\Mastodon\Admin\Reports;
+use Friendica\Object\Api\Mastodon\Report as MastodonReport;
+use Friendica\Util\Profiler;
+use Friendica\Test\MockedTestCase;
+use Psr\Log\LoggerInterface;
+
+class ReportsTest extends MockedTestCase
+{
+	public function testGetReportByIdUsesFactoryOutput(): void
+	{
+		$database           = \Mockery::mock(Database::class);
+		$mstdnReportFactory = \Mockery::mock(MastodonReportFactory::class);
+
+		$report           = $this->createReportEntity(123, ReportEntity::CATEGORY_OTHER, 'Single report');
+		$mapped           = $this->createMastodonReport(123, 'other');
+		$reportRepository = $this->createReportRepository($database, [123 => $report]);
+
+		$database->shouldReceive('selectFirst')
+			->with('report', [], ['id' => 123], [])
+			->once()
+			->andReturn(['id' => 123]);
+		$database->shouldReceive('isResult')->with(['id' => 123])->once()->andReturn(true);
+		$database->shouldReceive('selectToArray')->with('report-post', ['uri-id', 'status'], ['rid' => 123])->once()->andReturn([]);
+		$database->shouldReceive('selectToArray')->with('report-rule', ['line-id', 'text'], ['rid' => 123])->once()->andReturn([]);
+
+		$mstdnReportFactory->shouldReceive('createFromReportEntity')->with($report)->once()->andReturn($mapped);
+
+		$module = $this->createModule(
+			$database,
+			$reportRepository,
+			$mstdnReportFactory,
+			['id' => '123'],
+		);
+
+		try {
+			$module->callGet([]);
+			self::fail('Expected JSON exit exception');
+		} catch (TestJsonExitException $e) {
+			self::assertSame($mapped, $e->payload);
+		}
+	}
+
+	public function testGetListMapsRowsThroughFactory(): void
+	{
+		$database           = \Mockery::mock(Database::class);
+		$mstdnReportFactory = \Mockery::mock(MastodonReportFactory::class);
+
+		$reportRepository = $this->createReportRepository($database, []);
+
+		$database->shouldReceive('selectToArray')
+			->with('report', [], [], ['order' => ['id' => true], 'limit' => 100])
+			->once()
+			->andReturn([]);
+
+		$mstdnReportFactory->shouldNotReceive('createFromReportEntity');
+
+		$module = $this->createModule($database, $reportRepository, $mstdnReportFactory);
+
+		try {
+			$module->callGet([]);
+			self::fail('Expected JSON exit exception');
+		} catch (TestJsonExitException $e) {
+			self::assertSame([], $e->payload);
+		}
+	}
+
+	private function createModule(Database $database, ReportRepository $reportRepository, MastodonReportFactory $mstdnReportFactory, array $parameters = []): TestableReports
+	{
+		$args = \Mockery::mock(Arguments::class);
+		$args->shouldReceive('getCommand')->andReturn('api/v1/admin/reports');
+
+		$logger = \Mockery::mock(LoggerInterface::class);
+		$logger->shouldIgnoreMissing();
+
+		return new TestableReports(
+			$database,
+			$reportRepository,
+			$mstdnReportFactory,
+			\Mockery::mock(ErrorFactory::class),
+			\Mockery::mock(AppHelper::class),
+			\Mockery::mock(L10n::class),
+			\Mockery::mock(BaseURL::class),
+			$args,
+			$logger,
+			\Mockery::mock(Profiler::class),
+			\Mockery::mock(ApiResponse::class),
+			[],
+			$parameters,
+		);
+	}
+
+	private function createReportRepository(Database $database, array $reportsById): ReportRepository
+	{
+		$logger        = \Mockery::mock(LoggerInterface::class);
+		$reportFactory = \Mockery::mock(ReportFactory::class);
+		$postFactory   = \Mockery::mock(ReportPostFactory::class);
+		$ruleFactory   = \Mockery::mock(ReportRuleFactory::class);
+
+		$reportFactory->shouldReceive('createFromTableRow')
+			->andReturnUsing(function (array $fields) use ($reportsById): ReportEntity {
+				return $reportsById[(int) $fields['id']];
+			});
+
+		return new ReportRepository($database, $logger, $reportFactory, $postFactory, $ruleFactory);
+	}
+
+	private function createReportEntity(int $id, int $category, string $comment): ReportEntity
+	{
+		return new ReportEntity(
+			reporterCid: 10,
+			cid: 20,
+			gsid: 30,
+			created: new \DateTimeImmutable('2026-01-01 10:00:00', new \DateTimeZone('UTC')),
+			category: $category,
+			reporterUid: 99,
+			comment: $comment,
+			id: $id,
+		);
+	}
+
+	private function createMastodonReport(int $id, string $category): MastodonReport
+	{
+		return new MastodonReport(
+			$id,
+			false,
+			null,
+			$category,
+			'',
+			false,
+			'2026-01-01T10:00:00.000Z',
+			'2026-01-01T10:00:00.000Z',
+			null,
+			null,
+			null,
+			null,
+			[],
+			[],
+		);
+	}
+}
+
+class TestJsonExitException extends \RuntimeException
+{
+	public function __construct(public mixed $payload)
+	{
+		parent::__construct('JSON exit');
+	}
+}
+
+class TestableReports extends Reports
+{
+	public function checkAllowedScope(string $scope) {}
+
+	protected function checkModeratorAccess(): void {}
+
+	public function callGet(array $request = []): void
+	{
+		$this->get($request);
+	}
+
+	public function jsonExit($content, string $content_type = 'application/json; charset=utf-8', int $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT): never
+	{
+		throw new TestJsonExitException($content);
+	}
+}

--- a/tests/src/Worker/ExpireReportsTest.php
+++ b/tests/src/Worker/ExpireReportsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Test\src\Worker;
+
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Database\Database;
+use Friendica\Moderation\Entity\Report as ReportEntity;
+use Friendica\Test\MockedTestCase;
+use Friendica\Worker\ExpireReports;
+use Psr\Log\LoggerInterface;
+
+class ExpireReportsTest extends MockedTestCase
+{
+	public function testCleanupExpiredReportsDeletesClosedAndOpenReports(): void
+	{
+		$database = \Mockery::mock(Database::class);
+		$config   = \Mockery::mock(IManageConfigValues::class);
+		$logger   = \Mockery::mock(LoggerInterface::class);
+
+		$closedResult = (object) ['status' => 'closed'];
+		$openResult   = (object) ['status' => 'open'];
+
+		$config->shouldReceive('get')
+			->with('system', 'dbclean-expire-limit')
+			->once()
+			->andReturn(2);
+
+		$database->shouldReceive('select')
+			->times(2)
+			->andReturnUsing(function (string $table, array $fields, array $condition) use ($closedResult, $openResult) {
+				self::assertSame('report', $table);
+				self::assertSame(['id'], $fields);
+				self::assertSame('`status` = ? AND COALESCE(`edited`, `created`) < ?', $condition[0]);
+				self::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $condition[2]);
+
+				if ($condition[1] === ReportEntity::STATUS_CLOSED) {
+					return $closedResult;
+				}
+
+				return $openResult;
+			});
+
+		$database->shouldReceive('fetch')
+			->with($closedResult)
+			->twice()
+			->andReturn(['id' => 11], false);
+		$database->shouldReceive('fetch')
+			->with($openResult)
+			->twice()
+			->andReturn(['id' => 22], false);
+
+		$database->shouldReceive('close')->with($closedResult)->once();
+		$database->shouldReceive('close')->with($openResult)->once();
+
+		$database->shouldReceive('delete')->with('report-rule', ['rid' => 11])->once();
+		$database->shouldReceive('delete')->with('report-post', ['rid' => 11])->once();
+		$database->shouldReceive('delete')->with('report', ['id' => 11])->once();
+		$database->shouldReceive('delete')->with('report-rule', ['rid' => 22])->once();
+		$database->shouldReceive('delete')->with('report-post', ['rid' => 22])->once();
+		$database->shouldReceive('delete')->with('report', ['id' => 22])->once();
+		$logger->shouldReceive('notice')
+			->twice()
+			->with('Deleted expired reports', \Mockery::on(static function (array $context): bool {
+				return isset($context['label'], $context['rows']) && !isset($context['pass']) && $context['rows'] === 1;
+			}));
+
+		ExpireReports::cleanupExpiredReports($database, $config, $logger);
+	}
+
+	public function testCleanupExpiredReportsSkipsWhenLimitDisabled(): void
+	{
+		$database = \Mockery::mock(Database::class);
+		$config   = \Mockery::mock(IManageConfigValues::class);
+		$logger   = \Mockery::mock(LoggerInterface::class);
+
+		$config->shouldReceive('get')
+			->with('system', 'dbclean-expire-limit')
+			->once()
+			->andReturn(0);
+
+		$database->shouldNotReceive('select');
+		$database->shouldNotReceive('fetch');
+		$database->shouldNotReceive('close');
+		$database->shouldNotReceive('delete');
+		$logger->shouldNotReceive('notice');
+
+		ExpireReports::cleanupExpiredReports($database, $config, $logger);
+
+		self::assertTrue(true);
+	}
+}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -590,7 +590,7 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: src/BaseModule.php:442 src/Content/Widget.php:265 src/Model/User.php:1419
+#: src/BaseModule.php:442 src/Content/Widget.php:265 src/Model/User.php:1422
 #: src/Module/Contact.php:400
 msgid "Friends"
 msgstr ""
@@ -861,7 +861,7 @@ msgstr ""
 msgid "RSS/Atom"
 msgstr ""
 
-#: src/Content/ContactSelector.php:122
+#: src/Content/ContactSelector.php:122 src/Module/Admin/Roles.php:124
 #: src/Module/Moderation/Users/Active.php:82
 #: src/Module/Moderation/Users/Blocked.php:82
 #: src/Module/Moderation/Users/Create.php:59
@@ -1531,7 +1531,7 @@ msgstr ""
 
 #: src/Content/Feature.php:121 src/Model/Profile.php:812
 #: src/Module/Admin/Summary.php:207 src/Module/Item/Compose.php:152
-#: src/Module/Moderation/Report/Create.php:302
+#: src/Module/Moderation/Report/Create.php:307
 #: src/Module/Moderation/Summary.php:60
 msgid "Summary"
 msgstr ""
@@ -1689,6 +1689,7 @@ msgid "event"
 msgstr ""
 
 #: src/Content/Item.php:304 src/Content/Item.php:314
+#: src/Module/Moderation/Reports.php:340
 msgid "status"
 msgstr ""
 
@@ -2039,7 +2040,8 @@ msgstr ""
 #: src/Module/Moderation/Blocklist/Server/Index.php:84
 #: src/Module/Moderation/Item/Delete.php:47
 #: src/Module/Moderation/Item/Source.php:66
-#: src/Module/Moderation/Reports.php:118 src/Module/Moderation/Summary.php:59
+#: src/Module/Moderation/Reports.php:236 src/Module/Moderation/Reports.php:325
+#: src/Module/Moderation/Summary.php:59
 #: src/Module/Moderation/Users/Active.php:89
 #: src/Module/Moderation/Users/Blocked.php:89
 #: src/Module/Moderation/Users/Create.php:47
@@ -2910,60 +2912,60 @@ msgstr ""
 msgid "Relay"
 msgstr ""
 
-#: src/Model/Contact.php:3112
+#: src/Model/Contact.php:3138
 msgid "Disallowed profile URL."
 msgstr ""
 
-#: src/Model/Contact.php:3117 src/Module/Friendica.php:91
+#: src/Model/Contact.php:3143 src/Module/Friendica.php:91
 msgid "Blocked domain"
 msgstr ""
 
-#: src/Model/Contact.php:3122
+#: src/Model/Contact.php:3148
 msgid "Connect URL missing."
 msgstr ""
 
-#: src/Model/Contact.php:3135
+#: src/Model/Contact.php:3161
 msgid "The contact could not be added. Please check the relevant network credentials in your Settings -> Social Networks page."
 msgstr ""
 
-#: src/Model/Contact.php:3153
+#: src/Model/Contact.php:3179
 #, php-format
 msgid "Expected network %s does not match actual network %s"
 msgstr ""
 
-#: src/Model/Contact.php:3170
+#: src/Model/Contact.php:3196
 msgid "This seems to be a relay account. They can't be followed by users."
 msgstr ""
 
-#: src/Model/Contact.php:3177
+#: src/Model/Contact.php:3203
 msgid "The profile address specified does not provide adequate information."
 msgstr ""
 
-#: src/Model/Contact.php:3179
+#: src/Model/Contact.php:3205
 msgid "No compatible communication protocols or feeds were discovered."
 msgstr ""
 
-#: src/Model/Contact.php:3182
+#: src/Model/Contact.php:3208
 msgid "An author or name was not found."
 msgstr ""
 
-#: src/Model/Contact.php:3185
+#: src/Model/Contact.php:3211
 msgid "No browser URL could be matched to this address."
 msgstr ""
 
-#: src/Model/Contact.php:3188
+#: src/Model/Contact.php:3214
 msgid "Unable to match @-style Identity Address with a known protocol or email contact."
 msgstr ""
 
-#: src/Model/Contact.php:3189
+#: src/Model/Contact.php:3215
 msgid "Use mailto: in front of address to force email check."
 msgstr ""
 
-#: src/Model/Contact.php:3195
+#: src/Model/Contact.php:3221
 msgid "Limited profile. This person will be unable to receive direct/personal notifications from you."
 msgstr ""
 
-#: src/Model/Contact.php:3254
+#: src/Model/Contact.php:3280
 msgid "Unable to retrieve contact information."
 msgstr ""
 
@@ -3413,7 +3415,7 @@ msgstr ""
 msgid "Responsible account: %s"
 msgstr ""
 
-#: src/Model/User.php:229 src/Model/User.php:1353
+#: src/Model/User.php:229 src/Model/User.php:1356
 msgid "SERIOUS ERROR: Generation of security keys failed."
 msgstr ""
 
@@ -3445,103 +3447,103 @@ msgstr ""
 msgid "The password can't contain white spaces nor accentuated letters"
 msgstr ""
 
-#: src/Model/User.php:1233
+#: src/Model/User.php:1236
 msgid "Passwords do not match. Password unchanged."
 msgstr ""
 
-#: src/Model/User.php:1242
+#: src/Model/User.php:1245
 msgid "An invitation is required."
 msgstr ""
 
-#: src/Model/User.php:1246
+#: src/Model/User.php:1249
 msgid "Invitation could not be verified."
 msgstr ""
 
-#: src/Model/User.php:1254
+#: src/Model/User.php:1257
 msgid "Invalid OpenID url"
 msgstr ""
 
-#: src/Model/User.php:1268 src/Security/Authentication.php:205
+#: src/Model/User.php:1271 src/Security/Authentication.php:205
 msgid "We encountered a problem while logging in with the OpenID you provided. Please check the correct spelling of the ID."
 msgstr ""
 
-#: src/Model/User.php:1268 src/Security/Authentication.php:205
+#: src/Model/User.php:1271 src/Security/Authentication.php:205
 msgid "The error message was:"
 msgstr ""
 
-#: src/Model/User.php:1274
+#: src/Model/User.php:1277
 msgid "Please enter the required information."
 msgstr ""
 
-#: src/Model/User.php:1288
+#: src/Model/User.php:1291
 #, php-format
 msgid "system.username_min_length (%s) and system.username_max_length (%s) are excluding each other, swapping values."
 msgstr ""
 
-#: src/Model/User.php:1295
+#: src/Model/User.php:1298
 #, php-format
 msgid "Username should be at least %s character."
 msgid_plural "Username should be at least %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1299
+#: src/Model/User.php:1302
 #, php-format
 msgid "Username should be at most %s character."
 msgid_plural "Username should be at most %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/User.php:1307
+#: src/Model/User.php:1310
 msgid "That doesn't appear to be your full (First Last) name."
 msgstr ""
 
-#: src/Model/User.php:1312
+#: src/Model/User.php:1315
 msgid "Your email domain is not among those allowed on this site."
 msgstr ""
 
-#: src/Model/User.php:1316
+#: src/Model/User.php:1319
 msgid "Not a valid email address."
 msgstr ""
 
-#: src/Model/User.php:1319
+#: src/Model/User.php:1322
 msgid "The nickname was blocked from registration by the nodes admin."
 msgstr ""
 
-#: src/Model/User.php:1323 src/Model/User.php:1329
+#: src/Model/User.php:1326 src/Model/User.php:1332
 #: src/Module/User/Import.php:206
 msgid "Cannot use that email."
 msgstr ""
 
-#: src/Model/User.php:1335
+#: src/Model/User.php:1338
 msgid "Your nickname can only contain a-z, 0-9 and _."
 msgstr ""
 
-#: src/Model/User.php:1343 src/Model/User.php:1393
+#: src/Model/User.php:1346 src/Model/User.php:1396
 msgid "Nickname is already registered. Please choose another."
 msgstr ""
 
-#: src/Model/User.php:1380 src/Model/User.php:1384
+#: src/Model/User.php:1383 src/Model/User.php:1387
 msgid "An error occurred during registration. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1407
+#: src/Model/User.php:1410
 msgid "An error occurred creating your default profile. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1414
+#: src/Model/User.php:1417
 msgid "An error occurred creating your self contact. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1423
+#: src/Model/User.php:1426
 msgid "An error occurred creating your default contact circle. Please try again."
 msgstr ""
 
-#: src/Model/User.php:1471
+#: src/Model/User.php:1474
 msgid "Profile Photos"
 msgstr ""
 
-#: src/Model/User.php:1669
+#: src/Model/User.php:1672
 #, php-format
 msgid ""
 "\n"
@@ -3549,7 +3551,7 @@ msgid ""
 "\t\t\tthe administrator of %2$s has set up an account for you."
 msgstr ""
 
-#: src/Model/User.php:1672
+#: src/Model/User.php:1675
 #, php-format
 msgid ""
 "\n"
@@ -3580,12 +3582,12 @@ msgid ""
 "\t\tThank you and welcome to %4$s."
 msgstr ""
 
-#: src/Model/User.php:1704 src/Model/User.php:1810
+#: src/Model/User.php:1707 src/Model/User.php:1813
 #, php-format
 msgid "Registration details for %s"
 msgstr ""
 
-#: src/Model/User.php:1724
+#: src/Model/User.php:1727
 #, php-format
 msgid ""
 "\n"
@@ -3600,12 +3602,12 @@ msgid ""
 "\t\t"
 msgstr ""
 
-#: src/Model/User.php:1743
+#: src/Model/User.php:1746
 #, php-format
 msgid "Registration at %s"
 msgstr ""
 
-#: src/Model/User.php:1767
+#: src/Model/User.php:1770
 #, php-format
 msgid ""
 "\n"
@@ -3614,7 +3616,7 @@ msgid ""
 "\t\t\t"
 msgstr ""
 
-#: src/Model/User.php:1775
+#: src/Model/User.php:1778
 #, php-format
 msgid ""
 "\n"
@@ -3645,7 +3647,7 @@ msgid ""
 "\t\t\tThank you and welcome to %2$s."
 msgstr ""
 
-#: src/Model/User.php:1837
+#: src/Model/User.php:1840
 msgid "User with delegates can't be removed, please remove delegate users first"
 msgstr ""
 
@@ -3680,15 +3682,15 @@ msgstr ""
 #: src/Module/Admin/Addons/Details.php:137 src/Module/Admin/Addons/Index.php:83
 #: src/Module/Admin/Federation.php:218 src/Module/Admin/Logs/Settings.php:74
 #: src/Module/Admin/Logs/View.php:71 src/Module/Admin/Queue.php:64
-#: src/Module/Admin/Site.php:457 src/Module/Admin/Storage.php:119
-#: src/Module/Admin/Summary.php:206 src/Module/Admin/Themes/Details.php:82
-#: src/Module/Admin/Themes/Index.php:103 src/Module/Admin/Tos.php:63
-#: src/Module/Moderation/Users/Pending.php:82
+#: src/Module/Admin/Roles.php:118 src/Module/Admin/Site.php:457
+#: src/Module/Admin/Storage.php:119 src/Module/Admin/Summary.php:206
+#: src/Module/Admin/Themes/Details.php:82 src/Module/Admin/Themes/Index.php:103
+#: src/Module/Admin/Tos.php:63 src/Module/Moderation/Users/Pending.php:82
 msgid "Administration"
 msgstr ""
 
 #: src/Module/Admin/Addons/Details.php:138 src/Module/Admin/Addons/Index.php:84
-#: src/Module/BaseAdmin.php:77 src/Module/BaseSettings.php:127
+#: src/Module/BaseAdmin.php:78 src/Module/BaseSettings.php:127
 msgid "Addons"
 msgstr ""
 
@@ -3818,7 +3820,8 @@ msgid "Manage Additional Features"
 msgstr ""
 
 #: src/Module/Admin/Federation.php:70
-#: src/Module/Moderation/Report/Create.php:200
+#: src/Module/Moderation/Report/Create.php:205
+#: src/Module/Moderation/Reports.php:576 src/Module/Moderation/Reports.php:587
 #: src/Module/Moderation/Utils/ReportUtil.php:25
 msgid "Other"
 msgstr ""
@@ -3997,7 +4000,7 @@ msgstr ""
 msgid "Data"
 msgstr ""
 
-#: src/Module/Admin/Logs/View.php:85
+#: src/Module/Admin/Logs/View.php:85 src/Module/Admin/Roles.php:125
 #: src/Module/Debug/ActivityPubConversion.php:49
 msgid "Source"
 msgstr ""
@@ -4055,7 +4058,7 @@ msgstr ""
 msgid "Job Parameters"
 msgstr ""
 
-#: src/Module/Admin/Queue.php:70 src/Module/Moderation/Reports.php:124
+#: src/Module/Admin/Queue.php:70 src/Module/Moderation/Reports.php:242
 #: src/Module/Settings/OAuth.php:58
 msgid "Created"
 msgstr ""
@@ -4066,6 +4069,92 @@ msgstr ""
 
 #: src/Module/Admin/Queue.php:72
 msgid "Priority"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:48
+msgid "Please select a valid user."
+msgstr ""
+
+#: src/Module/Admin/Roles.php:60
+msgid "The selected user cannot be assigned moderation rights."
+msgstr ""
+
+#: src/Module/Admin/Roles.php:67
+msgid "Moderation rights have been granted."
+msgstr ""
+
+#: src/Module/Admin/Roles.php:78
+msgid "Moderation rights have been removed."
+msgstr ""
+
+#: src/Module/Admin/Roles.php:83
+msgid "Unknown role action."
+msgstr ""
+
+#: src/Module/Admin/Roles.php:119 src/Module/BaseAdmin.php:76
+msgid "Roles"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:120
+msgid "Manage moderators for this node. Administrator rights are read-only and managed through the node configuration."
+msgstr ""
+
+#: src/Module/Admin/Roles.php:121
+msgid "Users with administrator rights (read-only)"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:122
+msgid "Users with moderation rights"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:123 src/Module/Admin/Roles.php:135
+msgid "User"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:126 src/Module/Contact/Profile.php:435
+#: src/Module/Moderation/Reports.php:342
+#: src/Module/Settings/TwoFactor/Index.php:146
+msgid "Actions"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:127
+msgid "No administrators found."
+msgstr ""
+
+#: src/Module/Admin/Roles.php:128
+msgid "No users with moderation rights found."
+msgstr ""
+
+#: src/Module/Admin/Roles.php:129
+msgid "Administrator"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:130
+msgid "Moderator"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:131
+msgid "Administrator + Moderator"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:132
+msgid "Remove moderation rights"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:133
+msgid "Administrators always keep moderation rights."
+msgstr ""
+
+#: src/Module/Admin/Roles.php:134
+msgid "Assign moderation rights"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:136
+msgid "Grant moderation rights"
+msgstr ""
+
+#: src/Module/Admin/Roles.php:137
+msgid "All active users already have moderation rights."
 msgstr ""
 
 #: src/Module/Admin/Site.php:231
@@ -4127,7 +4216,8 @@ msgstr ""
 msgid "Multi user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:434
+#: src/Module/Admin/Site.php:434 src/Module/Moderation/Reports.php:212
+#: src/Module/Moderation/Reports.php:285
 msgid "Closed"
 msgstr ""
 
@@ -4135,7 +4225,8 @@ msgstr ""
 msgid "Requires approval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:436
+#: src/Module/Admin/Site.php:436 src/Module/Moderation/Reports.php:212
+#: src/Module/Moderation/Reports.php:285
 msgid "Open"
 msgstr ""
 
@@ -5144,7 +5235,7 @@ msgstr ""
 msgid "Storage Configuration"
 msgstr ""
 
-#: src/Module/Admin/Storage.php:122 src/Module/BaseAdmin.php:76
+#: src/Module/Admin/Storage.php:122 src/Module/BaseAdmin.php:77
 msgid "Storage"
 msgstr ""
 
@@ -5294,7 +5385,7 @@ msgid "Screenshot"
 msgstr ""
 
 #: src/Module/Admin/Themes/Details.php:83 src/Module/Admin/Themes/Index.php:104
-#: src/Module/BaseAdmin.php:78 src/Module/Settings/Display.php:416
+#: src/Module/BaseAdmin.php:79 src/Module/Settings/Display.php:416
 msgid "Themes"
 msgstr ""
 
@@ -5432,86 +5523,86 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:79 src/Module/BaseSettings.php:98
+#: src/Module/BaseAdmin.php:80 src/Module/BaseSettings.php:98
 msgid "Additional features"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:82
+#: src/Module/BaseAdmin.php:83
 msgid "Database"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:83
+#: src/Module/BaseAdmin.php:84
 msgid "DB updates"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:84
+#: src/Module/BaseAdmin.php:85
 msgid "Inspect Deferred Workers"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:85
+#: src/Module/BaseAdmin.php:86
 msgid "Inspect worker Queue"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:87
+#: src/Module/BaseAdmin.php:88
 msgid "Logs"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:89 src/Module/Calendar/Show.php:114
+#: src/Module/BaseAdmin.php:90 src/Module/Calendar/Show.php:114
 msgid "View"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:91 src/Module/BaseModeration.php:109
+#: src/Module/BaseAdmin.php:92 src/Module/BaseModeration.php:109
 msgid "Diagnostics"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:92
+#: src/Module/BaseAdmin.php:93
 msgid "PHP Info"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:93
+#: src/Module/BaseAdmin.php:94
 msgid "probe address"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:94
+#: src/Module/BaseAdmin.php:95
 msgid "check webfinger"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:95
+#: src/Module/BaseAdmin.php:96
 msgid "Babel"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:96 src/Module/Debug/ActivityPubConversion.php:125
+#: src/Module/BaseAdmin.php:97 src/Module/Debug/ActivityPubConversion.php:125
 msgid "ActivityPub Conversion"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:115
+#: src/Module/BaseAdmin.php:116
 msgid "Addon settings"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:116 src/Module/BaseModeration.php:118
+#: src/Module/BaseAdmin.php:117 src/Module/BaseModeration.php:118
 msgid "User registrations waiting for confirmation"
 msgstr ""
 
-#: src/Module/BaseApi.php:427 src/Module/BaseApi.php:443
-#: src/Module/BaseApi.php:459
+#: src/Module/BaseApi.php:443 src/Module/BaseApi.php:459
+#: src/Module/BaseApi.php:475
 msgid "Too Many Requests"
 msgstr ""
 
-#: src/Module/BaseApi.php:428
+#: src/Module/BaseApi.php:444
 #, php-format
 msgid "Daily posting limit of %d post reached. The post was rejected."
 msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/BaseApi.php:444
+#: src/Module/BaseApi.php:460
 #, php-format
 msgid "Weekly posting limit of %d post reached. The post was rejected."
 msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/BaseApi.php:460
+#: src/Module/BaseApi.php:476
 #, php-format
 msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgid_plural "Monthly posting limit of %d posts reached. The post was rejected."
@@ -5526,7 +5617,7 @@ msgstr ""
 msgid "Submanaged account can't access the moderation pages. Please log back in as the main account."
 msgstr ""
 
-#: src/Module/BaseModeration.php:99 src/Module/Moderation/Reports.php:123
+#: src/Module/BaseModeration.php:99 src/Module/Moderation/Reports.php:241
 msgid "Reports"
 msgstr ""
 
@@ -6119,10 +6210,10 @@ msgstr ""
 #: src/Module/FriendSuggest.php:138 src/Module/Install.php:216
 #: src/Module/Install.php:256 src/Module/Install.php:293
 #: src/Module/Invite.php:162 src/Module/Moderation/Item/Source.php:70
-#: src/Module/Moderation/Report/Create.php:177
-#: src/Module/Moderation/Report/Create.php:192
-#: src/Module/Moderation/Report/Create.php:220
-#: src/Module/Moderation/Report/Create.php:280
+#: src/Module/Moderation/Report/Create.php:182
+#: src/Module/Moderation/Report/Create.php:197
+#: src/Module/Moderation/Report/Create.php:225
+#: src/Module/Moderation/Report/Create.php:285
 #: src/Module/Settings/Server/Action.php:54 src/Module/User/Delegation.php:155
 #: view/theme/vier/config.php:123
 msgid "Submit"
@@ -6130,7 +6221,7 @@ msgstr ""
 
 #: src/Module/Contact/Advanced.php:120
 #: src/Module/Moderation/Blocklist/Contact.php:118
-#: src/Module/Moderation/Reports.php:124
+#: src/Module/Moderation/Reports.php:242
 #: src/Module/Moderation/Users/Active.php:82
 #: src/Module/Moderation/Users/Blocked.php:82
 #: src/Module/Moderation/Users/Deleted.php:69
@@ -6249,7 +6340,7 @@ msgstr ""
 #: src/Module/Contact/Follow.php:155 src/Module/Contact/Profile.php:422
 #: src/Module/Contact/Unfollow.php:98
 #: src/Module/Moderation/Blocklist/Contact.php:128
-#: src/Module/Moderation/Reports.php:133
+#: src/Module/Moderation/Reports.php:260
 #: src/Module/Notifications/Introductions.php:125
 #: src/Module/Notifications/Introductions.php:198
 msgid "Profile URL"
@@ -6423,7 +6514,7 @@ msgid "Block/Unblock contact"
 msgstr ""
 
 #: src/Module/Contact/Profile.php:393
-#: src/Module/Moderation/Report/Create.php:316
+#: src/Module/Moderation/Report/Create.php:321
 msgid "Ignore contact"
 msgstr ""
 
@@ -6492,12 +6583,7 @@ msgstr ""
 msgid "Comma separated list of keywords that should not be converted to hashtags, when \"Fetch information and keywords\" is selected"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:435
-#: src/Module/Settings/TwoFactor/Index.php:146
-msgid "Actions"
-msgstr ""
-
-#: src/Module/Contact/Profile.php:437
+#: src/Module/Contact/Profile.php:437 src/Module/Moderation/Reports.php:242
 #: src/Module/Settings/TwoFactor/Index.php:126 view/theme/frio/theme.php:218
 msgid "Status"
 msgstr ""
@@ -7513,7 +7599,7 @@ msgid "Block New Remote Contact"
 msgstr ""
 
 #: src/Module/Moderation/Blocklist/Contact.php:118
-#: src/Module/Moderation/Reports.php:124
+#: src/Module/Moderation/Reports.php:242
 msgid "Photo"
 msgstr ""
 
@@ -7861,6 +7947,7 @@ msgid "You need to know the GUID of the item. You can find it e.g. by looking at
 msgstr ""
 
 #: src/Module/Moderation/Item/Delete.php:53
+#: src/Module/Moderation/Reports.php:341
 msgid "GUID"
 msgstr ""
 
@@ -7919,225 +8006,452 @@ msgstr ""
 msgid "Item Guid"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:67
+#: src/Module/Moderation/Report/Create.php:68
 msgid "Contact not found or their server is already blocked on this node."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:101
+#: src/Module/Moderation/Report/Create.php:106
 msgid "The moderation report has been submitted."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:145
+#: src/Module/Moderation/Report/Create.php:150
 msgid "Please login to access this page."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:174
-#: src/Module/Moderation/Report/Create.php:189
-#: src/Module/Moderation/Report/Create.php:217
-#: src/Module/Moderation/Report/Create.php:277
-#: src/Module/Moderation/Report/Create.php:301
+#: src/Module/Moderation/Report/Create.php:179
+#: src/Module/Moderation/Report/Create.php:194
+#: src/Module/Moderation/Report/Create.php:222
+#: src/Module/Moderation/Report/Create.php:282
+#: src/Module/Moderation/Report/Create.php:306
 msgid "Create Moderation Report"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:175
+#: src/Module/Moderation/Report/Create.php:180
 msgid "Pick Contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:176
+#: src/Module/Moderation/Report/Create.php:181
 msgid "Please enter below the contact address or profile URL you would like to create a moderation report about."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:180
+#: src/Module/Moderation/Report/Create.php:185
 msgid "Contact address/URL"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:190
+#: src/Module/Moderation/Report/Create.php:195
 msgid "Pick Category"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:191
+#: src/Module/Moderation/Report/Create.php:196
 msgid "Please pick below the category of your report."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:195
+#: src/Module/Moderation/Report/Create.php:200
+#: src/Module/Moderation/Reports.php:573 src/Module/Moderation/Reports.php:584
 #: src/Module/Moderation/Utils/ReportUtil.php:20
 msgid "Spam"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:195
+#: src/Module/Moderation/Report/Create.php:200
 msgid "This contact is publishing many repeated/overly long posts/replies or advertising their product/websites in otherwise irrelevant conversations."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:196
+#: src/Module/Moderation/Report/Create.php:201
+#: src/Module/Moderation/Reports.php:574 src/Module/Moderation/Reports.php:585
 #: src/Module/Moderation/Utils/ReportUtil.php:21
 msgid "Illegal Content"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:196
+#: src/Module/Moderation/Report/Create.php:201
 msgid "This contact is publishing content that is considered illegal in this node's hosting juridiction."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:197
+#: src/Module/Moderation/Report/Create.php:202
 #: src/Module/Moderation/Utils/ReportUtil.php:22
 msgid "Community Safety"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:197
+#: src/Module/Moderation/Report/Create.php:202
 msgid "This contact aggravated you or other people, by being provocative or insensitive, intentionally or not. This includes disclosing people's private information (doxxing), posting threats or offensive pictures in posts or replies."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:198
+#: src/Module/Moderation/Report/Create.php:203
 #: src/Module/Moderation/Utils/ReportUtil.php:23
 msgid "Unwanted Content/Behavior"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:198
+#: src/Module/Moderation/Report/Create.php:203
 msgid "This contact has repeatedly published content irrelevant to the node's theme or is openly criticizing the node's administration/moderation without directly engaging with the relevant people for example or repeatedly nitpicking on a sensitive topic."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:199
+#: src/Module/Moderation/Report/Create.php:204
+#: src/Module/Moderation/Reports.php:575 src/Module/Moderation/Reports.php:586
 #: src/Module/Moderation/Utils/ReportUtil.php:24
 msgid "Rules Violation"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:199
+#: src/Module/Moderation/Report/Create.php:204
 msgid "This contact violated one or more rules of this node. You will be able to pick which one(s) in the next step."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:200
+#: src/Module/Moderation/Report/Create.php:205
 msgid "Please elaborate below why you submitted this report. The more details you provide, the better your report can be handled."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:202
+#: src/Module/Moderation/Report/Create.php:207
 msgid "Additional Information"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:202
+#: src/Module/Moderation/Report/Create.php:207
 msgid "Please provide any additional information relevant to this particular report. You will be able to attach posts by this contact in the next step, but any context is welcome."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:218
+#: src/Module/Moderation/Report/Create.php:223
 msgid "Pick Rules"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:219
+#: src/Module/Moderation/Report/Create.php:224
 msgid "Please pick below the node rules you believe this contact violated."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:278
+#: src/Module/Moderation/Report/Create.php:283
 msgid "Pick Posts"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:279
+#: src/Module/Moderation/Report/Create.php:284
 msgid "Please optionally pick posts to attach to your report."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:295
+#: src/Module/Moderation/Report/Create.php:300
 msgid "Would you like to forward this report to the remote server?"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:297
+#: src/Module/Moderation/Report/Create.php:302
 msgid "Would you ike to forward this report to the remote server?"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:303
+#: src/Module/Moderation/Report/Create.php:308
 msgid "Submit Report"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:304
+#: src/Module/Moderation/Report/Create.php:309
 msgid "Further Action"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:305
+#: src/Module/Moderation/Report/Create.php:310
 msgid "You can also perform one of the following action on the contact you reported:"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:314
+#: src/Module/Moderation/Report/Create.php:319
 msgid "Nothing"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:315
+#: src/Module/Moderation/Report/Create.php:320
 msgid "Collapse contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:315
+#: src/Module/Moderation/Report/Create.php:320
 msgid "Their posts and replies will keep appearing in your Network page but their content will be collapsed by default."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:316
+#: src/Module/Moderation/Report/Create.php:321
 msgid "Their posts won't appear in your Network page anymore, but their replies can appear in forum threads. They still can follow you."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:317
+#: src/Module/Moderation/Report/Create.php:322
 msgid "Block contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:317
+#: src/Module/Moderation/Report/Create.php:322
 msgid "Their posts won't appear in your Network page anymore, but their replies can appear in forum threads, with their content collapsed by default. They cannot follow you but still can have access to your public posts by other means."
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:320
+#: src/Module/Moderation/Report/Create.php:325
 msgid "Forward report"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:342
+#: src/Module/Moderation/Report/Create.php:347
 msgid "1. Pick a contact"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:343
+#: src/Module/Moderation/Report/Create.php:348
 msgid "2. Pick a category"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:344
+#: src/Module/Moderation/Report/Create.php:349
 msgid "2a. Pick rules"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:345
+#: src/Module/Moderation/Report/Create.php:350
 msgid "2b. Add comment"
 msgstr ""
 
-#: src/Module/Moderation/Report/Create.php:346
+#: src/Module/Moderation/Report/Create.php:351
 msgid "3. Pick posts"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:119
+#: src/Module/Moderation/Reports.php:237
 msgid "List of reports"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:120
+#: src/Module/Moderation/Reports.php:238
 msgid "This page display reports created by our or remote users."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:121
+#: src/Module/Moderation/Reports.php:239
 msgid "No report exists at this node."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:124 src/Object/Post.php:613
+#: src/Module/Moderation/Reports.php:242 src/Object/Post.php:613
 #: src/Object/Post.php:1164
 msgid "Comment"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:124
+#: src/Module/Moderation/Reports.php:242 src/Module/Moderation/Reports.php:336
 msgid "Category"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:125
+#: src/Module/Moderation/Reports.php:243
 msgid "Select all"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:126
+#: src/Module/Moderation/Reports.php:244
 msgid "Close selected reports"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:130
+#: src/Module/Moderation/Reports.php:245
+msgid "Open reports"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:246
+msgid "Closed reports"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:247
+msgid "All reports"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:253 src/Module/Moderation/Reports.php:583
+msgid "All categories"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:257
 #, php-format
 msgid "%s total report"
 msgid_plural "%s total reports"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Moderation/Reports.php:133
+#: src/Module/Moderation/Reports.php:260
 msgid "URL of the reported contact."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:326
+msgid "Report details"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:327
+msgid "Back to reports"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:329
+msgid "Forwarded"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:330
+msgid "Not forwarded"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:331
+msgid "Assigned user id:"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:332 src/Module/Moderation/Reports.php:602
+msgid "Unassigned"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:333
+msgid "Reporter:"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:334
+msgid "Target:"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:335
+msgid "Category and rules"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:337
+msgid "Node rules"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:338
+msgid "Attached posts"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:339
+msgid "URI-ID"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:343
+msgid "Public remarks"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:344
+msgid "Private remarks"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:345
+msgid "This report is finalized and read-only."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:346
+msgid "Save remarks"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:347
+msgid "Assign to me"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:348
+msgid "Unassign"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:349
+msgid "Mark resolved"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:350
+msgid "Save category and rules"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:351
+msgid "Delete all reported posts"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:352
+msgid "Block local user"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:353
+msgid "Block remote contact"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:354
+msgid "Block remote contact and purge content"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:355
+msgid "Delete this reported post"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:356
+msgid "Warn user"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:357
+msgid "Warning message"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:358
+msgid "Silence local user (future posts unlisted)"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:377
+#, php-format
+msgid "%s reported post marked for deletion"
+msgid_plural "%s reported posts marked for deletion"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/Module/Moderation/Reports.php:379
+msgid "This report has no attached posts."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:386
+msgid "Invalid reported post id."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:400
+msgid "This post is not attached to the report."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:407
+msgid "Reported post marked for deletion."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:416
+msgid "Reported target contact not found."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:424
+msgid "The local user has been blocked."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:429
+msgid "Could not map the reported local contact to a user account."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:434
+msgid "Failed to block the remote contact."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:447
+msgid "The remote contact has been blocked and related content will be purged."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:449
+msgid "The remote contact has been blocked."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:456
+msgid "Please provide a warning message."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:468
+msgid "Moderator warning:"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:473
+msgid "Warning text has been saved, but automatic delivery is only available for local users."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:479
+msgid "Warning text has been saved, but the local user has no deliverable email address."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:487
+#, php-format
+msgid "Moderation warning from %s"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:488
+msgid "Your recent activity was reported to the moderation team. Please review this warning message."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:496
+msgid "Warning sent to the local user and stored in public remarks."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:498 src/Module/Moderation/Reports.php:502
+msgid "Warning text was stored, but sending the email failed."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:513
+msgid "This action is only available for local users."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:525
+msgid "Local user silenced: future posts will be unlisted, and public community visibility is reduced."
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:600
+msgid "All assignments"
+msgstr ""
+
+#: src/Module/Moderation/Reports.php:601
+msgid "Assigned to me"
 msgstr ""
 
 #: src/Module/Moderation/Summary.php:41 src/Module/Settings/Account.php:380

--- a/view/templates/admin/roles.tpl
+++ b/view/templates/admin/roles.tpl
@@ -1,0 +1,92 @@
+{{*
+  * Copyright (C) 2010-2026, the Friendica project
+  * SPDX-FileCopyrightText: 2010-2026 the Friendica project
+  *
+  * SPDX-License-Identifier: AGPL-3.0-or-later
+  *}}
+<div id="adminpage">
+	<h1>{{$title}} - {{$page}}</h1>
+	<p>{{$intro}}</p>
+
+	<h2>{{$admin_title}}</h2>
+	{{if $admin_users}}
+		<table>
+			<thead>
+				<tr>
+					<th>{{$user_header}}</th>
+					<th>{{$email_header}}</th>
+				</tr>
+			</thead>
+			<tbody>
+				{{foreach $admin_users as $user}}
+					<tr>
+						<td>{{$user.nickname}}</td>
+						<td>{{$user.email}}</td>
+					</tr>
+				{{/foreach}}
+			</tbody>
+		</table>
+	{{else}}
+		<p>{{$no_admin_users}}</p>
+	{{/if}}
+
+	<h2>{{$moderator_title}}</h2>
+	{{if $moderation_users}}
+		<table>
+			<thead>
+				<tr>
+					<th>{{$user_header}}</th>
+					<th>{{$email_header}}</th>
+					<th>{{$source_header}}</th>
+					<th>{{$actions_header}}</th>
+				</tr>
+			</thead>
+			<tbody>
+				{{foreach $moderation_users as $user}}
+					<tr>
+						<td>{{$user.nickname}}</td>
+						<td>{{$user.email}}</td>
+						<td>
+							{{if $user.source == 'admin'}}{{$admin_source}}
+							{{elseif $user.source == 'moderator'}}{{$moderator_source}}
+							{{else}}{{$combined_source}}{{/if}}
+						</td>
+						<td>
+							{{if $user.can_remove}}
+								<form action="{{$baseurl}}/admin/roles" method="post">
+									<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+									<input type="hidden" name="roles_action" value="remove">
+									<input type="hidden" name="moderator_uid" value="{{$user.uid}}">
+									<input type="submit" name="page_roles" value="{{$remove}}">
+								</form>
+							{{else}}
+								{{$cannot_remove_admin}}
+							{{/if}}
+						</td>
+					</tr>
+				{{/foreach}}
+			</tbody>
+		</table>
+	{{else}}
+		<p>{{$no_moderator_users}}</p>
+	{{/if}}
+
+	<h2>{{$assign_title}}</h2>
+	{{if $available_users}}
+		<form action="{{$baseurl}}/admin/roles" method="post">
+			<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+			<input type="hidden" name="roles_action" value="add">
+
+			<label for="moderator_uid">{{$assign_label}}</label>
+			<select id="moderator_uid" name="moderator_uid" required>
+				{{foreach $available_users as $user}}
+					<option value="{{$user.uid}}">{{$user.nickname}} ({{$user.email}})</option>
+				{{/foreach}}
+			</select>
+
+			<div class="submit"><input type="submit" name="page_roles" value="{{$assign_button}}"></div>
+		</form>
+	{{else}}
+		<p>{{$no_assignable_users}}</p>
+	{{/if}}
+</div>

--- a/view/templates/moderation/report/overview.tpl
+++ b/view/templates/moderation/report/overview.tpl
@@ -1,12 +1,47 @@
 {{*
-  * Copyright (C) 2010-2024, the Friendica project
-  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
+  * Copyright (C) 2010-2026, the Friendica project
+  * SPDX-FileCopyrightText: 2010-2026 the Friendica project
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div id="adminpage">
 	<h1>{{$title}} - {{$page}}</h1>
 	<p>{{$description nofilter}}</p>
+	<p>
+		{{if $filter_status == 'open'}}
+			<strong>{{$open_reports}}</strong>
+		{{else}}
+			<a href="moderation/reports?status=open&category={{$category_filter_value}}&assigned={{$filter_assigned}}">{{$open_reports}}</a>
+		{{/if}} |
+		{{if $filter_status == 'closed'}}
+			<strong>{{$closed_reports}}</strong>
+		{{else}}
+			<a href="moderation/reports?status=closed&category={{$category_filter_value}}&assigned={{$filter_assigned}}">{{$closed_reports}}</a>
+		{{/if}} |
+		{{if $filter_status == 'all'}}
+			<strong>{{$all_reports}}</strong>
+		{{else}}
+			<a href="moderation/reports?status=all&category={{$category_filter_value}}&assigned={{$filter_assigned}}">{{$all_reports}}</a>
+		{{/if}}
+	</p>
+	<p>
+		{{foreach $category_filters as $category_filter}}
+			{{if $category_filter.selected}}
+				<strong>{{$category_filter.label}}</strong>
+			{{else}}
+				<a href="moderation/reports?status={{$filter_status}}&category={{$category_filter.value}}&assigned={{$filter_assigned}}">{{$category_filter.label}}</a>
+			{{/if}}{{if !$category_filter.last}} | {{/if}}
+		{{/foreach}}
+	</p>
+	<p>
+		{{foreach $assigned_filters as $assigned_filter}}
+			{{if $assigned_filter.selected}}
+				<strong>{{$assigned_filter.label}}</strong>
+			{{else}}
+				<a href="moderation/reports?status={{$filter_status}}&category={{$category_filter_value}}&assigned={{$assigned_filter.value}}">{{$assigned_filter.label}}</a>
+			{{/if}}{{if !$assigned_filter.last}} | {{/if}}
+		{{/foreach}}
+	</p>
 
 	<h3>{{$h_reports}}</h3>
 	{{if $reports}}
@@ -31,24 +66,26 @@
 						<input type="checkbox" name="report_ids[]" value="{{$report.id}}" class="report-checkbox">
 					</td>
 					<td>
-						{{$report.created}}
+							<a href="{{$report.detail_url}}">{{$report.created}}</a>
 					</td>
 					<td><img class="icon" src="{{$report.micro}}" alt="{{$report.nickname}}" title="{{$report.nickname}}"></td>
 					<td class="name">
-						<a href="contact/{{$report.cid}}" title="{{$report.nickname}}">{{$report.name}}</><br>
+							{{$report.name}}<br>
+						<a href="contact/{{$report.cid}}" title="{{$report.nickname}}">{{if $report.nick}}{{$report.nick}}{{else}}{{$report.name}}{{/if}}</a><br>
 						<a href="{{$report.url}}" title="{{$report.nickname}}">{{if $report.addr}}{{$report.addr}}{{else}}{{$report.url}}{{/if}}</a>
 					</td>
 					<td class="comment">{{if $report.comment}}{{$report.comment}}{{else}}N/A{{/if}}</td>
 					<td class="category">{{if $report.category}}{{$report.category}}{{else}}N/A{{/if}}</td>
+					<td class="status">{{$report.status_label}}</td>
 				</tr>
 				{{if $report.posts}}
 				<tr>
-					<td colspan="6">
+					<td colspan="7">
 					<table class="table table-condensed table-striped table-bordered">
 					{{foreach $report.posts as $post}}
 						<tr>
 						<td>
-							<a href="display/{{$post.guid}}">{{$post.created}}</><br>
+							<a href="display/{{$post.guid}}">{{$post.created}}</a><br>
 						</td>
 						<td>
 							{{$post.body}}

--- a/view/templates/moderation/report/show.tpl
+++ b/view/templates/moderation/report/show.tpl
@@ -1,0 +1,167 @@
+{{*
+  * Copyright (C) 2010-2026, the Friendica project
+  * SPDX-FileCopyrightText: 2010-2026 the Friendica project
+  *
+  * SPDX-License-Identifier: AGPL-3.0-or-later
+  *}}
+<div id="adminpage">
+	<h1>{{$title}} - {{$page}}</h1>
+	<p><a href="{{$back_to_reports_url}}">{{$back_to_reports}}</a></p>
+
+	<div class="panel panel-default">
+		<div class="panel-heading"><strong>{{$report.category}}</strong> - {{$report.status_label}}</div>
+		<div class="panel-body">
+			<p><strong>{{$report.created}}</strong>{{if $report.edited}} · {{$report.edited}}{{/if}}</p>
+			<p><strong>{{$report.comment}}</strong></p>
+			<p>{{if $report.forward}}{{$forwarded}}{{else}}{{$not_forwarded}}{{/if}}</p>
+			<p>{{if $report.assigned_uid}}{{$assigned_user_id}} {{$report.assigned_uid}}{{else}}{{$unassigned}}{{/if}}</p>
+			{{if $report.reporter}}
+			<p><strong>{{$reporter_label}}</strong> {{$report.reporter.name}} ({{$report.reporter.nick}})</p>
+			{{/if}}
+			{{if $report.target}}
+			<p><strong>{{$target_label}}</strong> {{$report.target.name}} ({{$report.target.nick}})</p>
+			{{/if}}
+		</div>
+	</div>
+
+		{{if !$report.is_final}}
+		<div class="panel panel-default">
+			<div class="panel-heading"><strong>{{$category_and_rules}}</strong></div>
+			<div class="panel-body">
+				<form method="post">
+					<input type="hidden" name="report_id" value="{{$report.id}}">
+					<input type="hidden" name="report_action" value="save_metadata">
+					<div class="form-group">
+						<label for="category">{{$category_label}}</label>
+						<select id="category" name="category" class="form-control">
+							{{foreach $report.category_options as $option}}
+							<option value="{{$option.value}}"{{if $option.selected}} selected{{/if}}>{{$option.label}}</option>
+							{{/foreach}}
+						</select>
+					</div>
+					{{if $report.rules_available}}
+					<div class="form-group">
+						<label>{{$node_rules}}</label>
+						<div>
+							{{foreach $report.rules_available as $rule}}
+								<div class="checkbox">
+									<label>
+										<input type="checkbox" name="rule_ids[]" value="{{$rule.line_id}}"{{if $rule.selected}} checked{{/if}}>
+										{{$rule.text}}
+									</label>
+								</div>
+							{{/foreach}}
+						</div>
+					</div>
+					{{/if}}
+					<button type="submit" class="btn btn-primary">{{$save_metadata}}</button>
+				</form>
+
+				{{if $report.rules}}
+				<hr>
+				<ul>
+					{{foreach $report.rules as $rule}}
+					<li>{{$rule.text}}</li>
+					{{/foreach}}
+				</ul>
+				{{/if}}
+			</div>
+		</div>
+		{{else}}
+		<div class="panel panel-default">
+			<div class="panel-heading"><strong>{{$category_and_rules}}</strong></div>
+			<div class="panel-body">
+				<p>{{$report.category}}</p>
+				{{if $report.rules}}
+				<ul>
+					{{foreach $report.rules as $rule}}
+					<li>{{$rule.text}}</li>
+					{{/foreach}}
+				</ul>
+				{{/if}}
+			</div>
+		</div>
+		{{/if}}
+
+	{{if $report.posts}}
+	<div class="panel panel-default">
+		<div class="panel-heading"><strong>{{$attached_posts}}</strong></div>
+		<div class="panel-body">
+			<ul>
+				{{foreach $report.posts as $post}}
+				<li>
+					<strong>{{$uri_id_label}} {{$post.uri_id}}</strong>{{if $post.status}} · {{$status_label}} {{$post.status}}{{/if}}
+					{{if $post.created}} · {{$post.created}}{{/if}}
+					{{if $post.guid}} · {{$guid_label}} {{$post.guid}}{{/if}}
+					{{if $post.plink}} · <a href="{{$post.plink}}" target="_blank" rel="noopener noreferrer">{{$post.plink}}</a>{{/if}}
+					{{if $post.title}}<br>{{$post.title}}{{/if}}
+					{{if !$report.is_final}}
+					<form method="post" style="margin-top: 0.4em;">
+						<input type="hidden" name="report_id" value="{{$report.id}}">
+						<input type="hidden" name="uri_id" value="{{$post.uri_id}}">
+						<button type="submit" name="report_action" value="delete_reported_post" class="btn btn-danger btn-xs">{{$delete_post}}</button>
+					</form>
+					{{/if}}
+				</li>
+				{{/foreach}}
+			</ul>
+		</div>
+	</div>
+	{{/if}}
+
+	<div class="panel panel-default">
+		<div class="panel-heading"><strong>{{$actions_heading}}</strong></div>
+		<div class="panel-body">
+			{{if !$report.is_final}}
+			<form method="post" class="form-inline" style="margin-bottom: 1em;">
+				<input type="hidden" name="report_id" value="{{$report.id}}">
+				<button type="submit" name="report_action" value="assign_self" class="btn btn-primary">{{$assign_self}}</button>
+				<button type="submit" name="report_action" value="unassign" class="btn btn-default">{{$unassign}}</button>
+				<button type="submit" name="report_action" value="resolve" class="btn btn-success">{{$resolve}}</button>
+			</form>
+
+			<form method="post" class="form-inline" style="margin-bottom: 1em;">
+				<input type="hidden" name="report_id" value="{{$report.id}}">
+				<button type="submit" name="report_action" value="delete_reported_posts" class="btn btn-danger">{{$delete_posts}}</button>
+				{{if $report.target}}
+					{{if $report.target_is_local}}
+						<button type="submit" name="report_action" value="block_target" class="btn btn-warning">{{$block_local}}</button>
+						<button type="submit" name="report_action" value="silence_local_target" class="btn btn-default">{{$silence_local}}</button>
+					{{else}}
+						<button type="submit" name="report_action" value="block_target" class="btn btn-warning">{{$block_remote}}</button>
+						<button type="submit" name="report_action" value="block_target_purge" class="btn btn-warning">{{$block_remote_purge}}</button>
+					{{/if}}
+				{{/if}}
+			</form>
+
+			{{if $report.target && $report.target_is_local}}
+			<form method="post" style="margin-bottom: 1em;">
+				<input type="hidden" name="report_id" value="{{$report.id}}">
+				<input type="hidden" name="report_action" value="warn_target">
+				<div class="form-group">
+					<label for="warning_message">{{$warning_message}}</label>
+					<textarea id="warning_message" name="warning_message" class="form-control" rows="3"></textarea>
+				</div>
+				<button type="submit" class="btn btn-primary">{{$warn_target}}</button>
+			</form>
+			{{/if}}
+
+			<form method="post">
+				<input type="hidden" name="report_id" value="{{$report.id}}">
+				<input type="hidden" name="report_action" value="save_remarks">
+				<div class="form-group">
+					<label for="public_remarks">{{$public_remarks}}</label>
+					<textarea id="public_remarks" name="public_remarks" class="form-control" rows="4">{{$report.public_remarks}}</textarea>
+				</div>
+				<div class="form-group">
+					<label for="private_remarks">{{$private_remarks}}</label>
+					<textarea id="private_remarks" name="private_remarks" class="form-control" rows="4">{{$report.private_remarks}}</textarea>
+				</div>
+				<button type="submit" class="btn btn-primary">{{$save_remarks}}</button>
+			</form>
+			{{else}}
+			<p>{{$finalized_read_only}}</p>
+			{{/if}}
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
This fixes #8724 and #15662. This PR extends the moderation page, so that you can now assign reports to yourself, you can send local users an email, you can block users from there, ...

This PR also introduces the user role "moderator", so that finally the moderation task can be delegate to someone else.

The basic functionality is tested now, further testing will be needed, but this can be done by the users. The API is built according to the Mastodon API description. But it is totally untested, since I don't know how to test it.

Also the user interface is somehow ugly, but usable:
<img width="678" height="304" alt="image" src="https://github.com/user-attachments/assets/3f6b8999-f9d3-41da-9c1f-15376927209d" />