### PR TITLE
Compose: Handle smaller viewports better (BBCode buttons)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -4406,12 +4406,33 @@ div.login-form, .login-content-wrapper,
 	/* Even smaller mobile displays */
 @media (width < 382px) {
 	.topbar-nav .nav-segment a.nav-menu, .topbar-actions .nav-segment a.nav-menu, .topbar-actions .nav-segment button, .topbar-actions .navbar-toggle {
-		padding-left: 5px!important;
-		padding-right: 5px!important;
+		padding-left: 6px!important;
+		padding-right: 6px!important;
 	}
 	#topbar-first .offcanvas-right-toggle,
 	#topbar-first #mobile-left-menu {
 		padding-inline-end: 3px;
 		padding-inline-start: 3px;
+	}
+
+	/* Compose adjustments, mostly to improve the bbcode button experience at lower resolutions */
+
+	/* Reduce side padding */
+	.compose-content-wrapper .generic-page-wrapper {
+		padding-inline: 6px;
+	}
+
+	.compose-content-wrapper .generic-page-wrapper .btn-group {
+			display: inline!important;
+			float: unset;
+	}
+
+	.compose-content-wrapper #profile-jot-wrapper .btn-toolbar {
+		margin-right: -5px;
+	}
+
+	.compose-content-wrapper #profile-jot-wrapper .btn-toolbar div {
+		float: unset!important;
+		margin-left: 0;
 	}
 }


### PR DESCRIPTION
Trying to make the bbcode buttons in Compose handle smaller viewports better, based on the screenshot here:
https://forum.friendi.ca/display/f5430ab4-116a-1b3b-e671-e12275332595

# After

Two lines of BBCode buttons:

<img width="245" height="662" alt="image" src="https://github.com/user-attachments/assets/293aa5e4-5f94-4770-b7f7-38eb18f7cff2" />

# Before

Three lines of BBCode buttons:

<img width="245" height="662" alt="image" src="https://github.com/user-attachments/assets/b01be777-fedd-4be0-9e28-b3ef992c7340" />