### PR TITLE
Issue 15823: set default for language

### DIFF
--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -727,7 +727,7 @@ class L10n
 	public function formatDateTime(string $datestring, int $dateType, int $timeType, ?string $pattern = null): string
 	{
 		$formatter = new IntlDateFormatter(
-			$this->normaliseLocale($this->session->get('language')),
+			$this->normaliseLocale($this->session->get('language') ?? 'en'),
 			$dateType,
 			$timeType,
 			$this->session->get('timezone') ?? null,

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -727,7 +727,7 @@ class L10n
 	public function formatDateTime(string $datestring, int $dateType, int $timeType, ?string $pattern = null): string
 	{
 		$formatter = new IntlDateFormatter(
-			$this->normaliseLocale($this->session->get('language') ?? 'en'),
+			$this->normaliseLocale($this->session->get('language') ?? ''),
 			$dateType,
 			$timeType,
 			$this->session->get('timezone') ?? null,


### PR DESCRIPTION
fixes #15823

Non logged in visitors of the profile page of a user in 2026.08-dev (2026.05 is not affected) do not see the profile but an internal error 500 page. By setting a default locale the internal error is prevented and the profile is shown. For me in German which is my browser language.

The deeper problem might by the question, why the session has no language set for the visitor of the profile page. This was not investigated.