### PR TITLE
Fix TypeError in L10n::formatDateTime when session language is null

### DIFF
--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -465,11 +465,15 @@ class L10n
 	 * This function checks if the provided locale string matches any of the available locales using `Locale::lookup()`.
 	 * If a match is found, it returns the matched locale; otherwise, it returns a default locale.
 	 *
-	 * @param string $locale The locale string to normalise (e.g., 'en-US', 'de-DE')
+	 * @param string|null $locale The locale string to normalise (e.g., 'en-US', 'de-DE')
 	 * @return string The normalised locale if found, or the detected locale, the system default or finally 'en-US' as a fallback
 	 */
-	public function normaliseLocale(string $locale): string
+	public function normaliseLocale(?string $locale): string
 	{
+		if ($locale === null) {
+			return $this->locale ?: $this->config->get('system', 'language', 'en-US');
+		}
+
 		$normalised = Locale::lookup($this->getAvailableLocales(), $locale);
 		if ($normalised) {
 			return $normalised;

--- a/tests/src/Core/L10nTest.php
+++ b/tests/src/Core/L10nTest.php
@@ -131,7 +131,7 @@ class L10nTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataNormaliseLocale')]
-	public function testNormaliseLocale(string $locale, array $server, string $assert): void
+	public function testNormaliseLocale(?string $locale, array $server, string $assert): void
 	{
 		unset($_GET['lang']);
 

--- a/tests/src/Core/L10nTest.php
+++ b/tests/src/Core/L10nTest.php
@@ -122,6 +122,11 @@ class L10nTest extends MockedTestCase
 				'server' => [],
 				'assert' => 'en-US',
 			],
+			'null locale falls back to system default' => [
+				'locale' => null,
+				'server' => [],
+				'assert' => 'en-US',
+			],
 		];
 	}
 


### PR DESCRIPTION
When no language is set in the session(guest user), $this->session->get('language') returns null. This is passed to L10n::normaliseLocale(string $locale), which requires a string, causing an uncaught TypeError.

## Fix:

- Changed the parameter type of normaliseLocale() from string to ?string.
- Added an early return for null: the method now falls back to the default locale (config system.language or 'en-US').

## Stack trace

TypeError: Friendica\Core\L10n::normaliseLocale():
  Argument #1 ($locale) must be of type string, null given
  called in src/Core/L10n.php:730
  -> formatDateTime()
  -> mediumDate()
  -> Profile::getVCardHtml()