### PR TITLE
Automatically subscribe to tags.sub for subscribed tags

### DIFF
--- a/bin/rectify.sh
+++ b/bin/rectify.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2010 - 2024 the Friendica project
+#
+# SPDX-License-Identifier: CC0-1.0
+
+bin/composer.phar run-script rectify

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -635,6 +635,10 @@ class APContact
 			return false;
 		}
 
+		if ($apcontact['baseurl'] === 'https://tags.pub') {
+			return true;
+		}
+
 		$path = parse_url((string) $apcontact['url'], PHP_URL_PATH);
 		if (($apcontact['type'] == 'Group') && !empty($apcontact['followers']) && ($apcontact['nick'] == 'relay') && ($path == '/actor')) {
 			return true;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -999,6 +999,13 @@ class Item
 		return self::handleCreatedItem($orig_item, $post_user_id, $uid, $notify, $copy_permissions, $parent_origin, $priority, $notify_type, $inserted, $source);
 	}
 
+	/**
+	 * Store event data from item body if present
+	 *
+	 * @param array $item The item array containing potential event data
+	 * @return array The item array with event data
+	 * @throws \Exception
+	 */
 	private static function storeEvent(array $item): array
 	{
 		if (!empty($item['event-id'])) {

--- a/src/Module/Admin/Site.php
+++ b/src/Module/Admin/Site.php
@@ -142,12 +142,13 @@ class Site extends BaseAdmin
 		$worker_defer_limit   = (!empty($_POST['worker_defer_limit'])         ? intval($_POST['worker_defer_limit'])       : 15);
 		$worker_fetch_limit   = (!empty($_POST['worker_fetch_limit'])         ? intval($_POST['worker_fetch_limit'])       : 1);
 
-		$relay_directly    = !empty($_POST['relay_directly']);
-		$relay_scope       = (!empty($_POST['relay_scope'])       ? trim((string) $_POST['relay_scope'])        : '');
-		$relay_server_tags = (!empty($_POST['relay_server_tags']) ? trim((string) $_POST['relay_server_tags'])  : '');
-		$relay_deny_tags   = (!empty($_POST['relay_deny_tags'])   ? trim((string) $_POST['relay_deny_tags'])    : '');
-		$relay_max_tags    = (!empty($_POST['relay_max_tags'])    ? intval($_POST['relay_max_tags'])   : 0);
-		$relay_user_tags   = !empty($_POST['relay_user_tags']);
+		$relay_directly            = !empty($_POST['relay_directly']);
+		$relay_scope               = (!empty($_POST['relay_scope'])       ? trim((string) $_POST['relay_scope'])        : '');
+		$relay_server_tags         = (!empty($_POST['relay_server_tags']) ? trim((string) $_POST['relay_server_tags'])  : '');
+		$relay_deny_tags           = (!empty($_POST['relay_deny_tags'])   ? trim((string) $_POST['relay_deny_tags'])    : '');
+		$relay_max_tags            = (!empty($_POST['relay_max_tags'])    ? intval($_POST['relay_max_tags'])   : 0);
+		$relay_user_tags           = !empty($_POST['relay_user_tags']);
+		$relay_auto_subscribe_tags = !empty($_POST["relay_auto_subscribe_tags"]);
 
 		$relay_deny_undetected_language = !empty($_POST['relay_deny_undetected_language']);
 		$relay_language_quality         = (!empty($_POST['relay_language_quality']) ? (float) ($_POST['relay_language_quality']) : 0);
@@ -330,6 +331,7 @@ class Site extends BaseAdmin
 		$transactionConfig->set('system', 'relay_deny_tags', Strings::cleanTags($relay_deny_tags));
 		$transactionConfig->set('system', 'relay_max_tags', $relay_max_tags);
 		$transactionConfig->set('system', 'relay_user_tags', $relay_user_tags);
+		$transactionConfig->set('system', 'relay_auto_subscribe_tags', $relay_auto_subscribe_tags);
 		$transactionConfig->set('system', 'relay_deny_undetected_language', $relay_deny_undetected_language);
 		$transactionConfig->set('system', 'relay_language_quality', $relay_language_quality);
 		$transactionConfig->set('system', 'relay_languages', max($relay_languages, 1));
@@ -598,6 +600,7 @@ class Site extends BaseAdmin
 			'$relay_deny_tags'                => ['relay_deny_tags', DI::l10n()->t('Deny Server tags'), DI::config()->get('system', 'relay_deny_tags'), DI::l10n()->t('Comma separated list of tags that are rejected.')],
 			'$relay_max_tags'                 => ['relay_max_tags', DI::l10n()->t('Maximum amount of tags'), DI::config()->get('system', 'relay_max_tags'), DI::l10n()->t('Maximum amount of tags in a post before it is rejected as spam. The post has to contain at least one link. Posts from subscribed accounts will not be rejected.')],
 			'$relay_user_tags'                => ['relay_user_tags', DI::l10n()->t('Allow user tags'), DI::config()->get('system', 'relay_user_tags'), DI::l10n()->t('If enabled, the tags from the saved searches will used for the "tags" subscription in addition to the "relay_server_tags".')],
+			'$relay_auto_subscribe_tags'      => ['relay_auto_subscribe_tags', DI::l10n()->t('Automatically subscribe to tag relay'), DI::config()->get('system', 'relay_auto_subscribe_tags'), DI::l10n()->t('If enabled, the system will automatically follow and unfollow tags at the tags.pub service based on the configured tags. Additionally, all public posts will be automatically sent to this relay server for distribution.')],
 			'$relay_deny_undetected_language' => ['relay_deny_undetected_language', DI::l10n()->t('Deny undetected languages'), DI::config()->get('system', 'relay_deny_undetected_language'), DI::l10n()->t('If enabled, posts with undetected languages will be rejected.')],
 			'$relay_language_quality'         => ['relay_language_quality', DI::l10n()->t('Language Quality'), DI::config()->get('system', 'relay_language_quality'), DI::l10n()->t('The minimum language quality that is required to accept the post.')],
 			'$relay_languages'                => ['relay_languages', DI::l10n()->t('Number of languages for the language detection'), DI::config()->get('system', 'relay_languages'), DI::l10n()->t('The system detects a list of languages per post. Only if the desired languages are in the list, the message will be accepted. The higher the number, the more posts will be falsely detected.')],

--- a/src/Module/Settings/Account.php
+++ b/src/Module/Settings/Account.php
@@ -152,6 +152,7 @@ class Account extends BaseSettings
 			$str_circle_deny   = !empty($request['circle_deny'])   ? $aclFormatter->toString($request['circle_deny'])   : '';
 
 			DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'system', 'unlisted', !empty($request['unlisted']));
+			DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'system', 'prevent-relay', !empty($request['prevent_relay']));
 			DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'system', 'accessible-photos', !empty($request['accessible-photos']));
 			DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'system', 'default-group-gid', intval($request['circle-selection-group'] ?? $def_gid));
 
@@ -534,6 +535,7 @@ class Account extends BaseSettings
 			'$hide_friends'        => ['hide-friends', DI::l10n()->t('Hide your contact/friend list from viewers of your profile?'), $profile['hide-friends'], DI::l10n()->t('A list of your contacts is displayed on your profile page. Activate this option to disable the display of your contact list.')],
 			'$hide_wall'           => ['hidewall', $this->t('Hide your public content from anonymous viewers'), $user['hidewall'], $this->t('Anonymous visitors will only see your basic profile details. Your public posts and replies will still be freely accessible on the remote servers of your followers and through relays.')],
 			'$unlisted'            => ['unlisted', DI::l10n()->t('Make public posts unlisted'), DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'unlisted'), DI::l10n()->t('Your public posts will not appear on the community pages or in search results, nor be sent to relay servers. However they can still appear on public feeds on remote servers.')],
+			'$prevent_relay'       => ['prevent_relay', DI::l10n()->t('Do not send public posts to relay servers'), DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'prevent-relay'), DI::l10n()->t('Your public posts will not be forwarded to relay servers.')],
 			'$accessiblephotos'    => ['accessible-photos', DI::l10n()->t('Make all posted pictures accessible'), DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'system', 'accessible-photos'), DI::l10n()->t("This option makes every posted picture accessible via the direct link. This is a workaround for the problem that most other networks can't handle permissions on pictures. Non public pictures still won't be visible for the public on your photo albums though.")],
 			'$blockwall'           => ['blockwall', DI::l10n()->t('Allow friends to post to your profile page?'), (intval($user['blockwall']) ? '0' : '1'), DI::l10n()->t('Your contacts may write posts on your profile wall. These posts will be distributed to your contacts')],
 			'$blocktags'           => ['blocktags', DI::l10n()->t('Allow friends to tag your posts?'), (intval($user['blocktags']) ? '0' : '1'), DI::l10n()->t('Your contacts can add additional tags to your posts.')],

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -2512,6 +2512,7 @@ class Processor
 			$check_id = true;
 		}
 
+		// @todo this is triggered by follow request done by the system user. Question is if we should care.
 		if (empty($uid)) {
 			DI::logger()->notice('User could not be detected', ['activity' => $activity]);
 			Queue::remove($activity);

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -58,6 +58,10 @@ class Transmitter
 			$inboxes[$contact['inbox']] = $contact['inbox'];
 		}
 
+		if (DI::config()->get('system', 'relay_auto_subscribe_tags')) {
+			$inboxes['https://tags.pub/user/_____relay_____/inbox'] = 'https://tags.pub/user/_____relay_____/inbox';
+		}
+
 		return $inboxes;
 	}
 

--- a/src/Protocol/Relay.php
+++ b/src/Protocol/Relay.php
@@ -426,4 +426,42 @@ class Relay
 			DI::logger()->debug('Resubscribed', ['profile' => $server['url'], 'success' => $success]);
 		}
 	}
+
+
+	/**
+	 * Update tag relay subscriptions based on configured tags
+	 * Follows new tags and unfollows removed tags
+	 *
+	 * @return void
+	 */
+	public static function updateTagRelaySubscriptions()
+	{
+		if (!DI::config()->get('system', 'relay_auto_subscribe_tags')) {
+			return;
+		}
+
+		$currentTags = Relay::getSubscribedTags();
+		$oldTags     = json_decode(DI::keyValue()->get('relay_subscribed_tags') ?? '[]', true) ?? [];
+
+		// Follow new tags
+		foreach ($currentTags as $tag) {
+			if (!in_array($tag, $oldTags)) {
+				$url = 'https://tags.pub/user/' . urlencode((string) $tag);
+				DI::logger()->info('Following relay tag', ['url' => $url]);
+				ActivityPub\Transmitter::sendRelayFollow($url);
+			}
+		}
+
+		// Unfollow removed tags
+		foreach ($oldTags as $tag) {
+			if (!in_array($tag, $currentTags)) {
+				$url = 'https://tags.pub/user/' . urlencode((string) $tag);
+				DI::logger()->info('Unfollowing relay tag', ['url' => $url]);
+				ActivityPub\Transmitter::sendRelayUndoFollow($url);
+			}
+		}
+
+		// Save current state
+		DI::keyValue()->set('relay_subscribed_tags', json_encode($currentTags));
+	}
 }

--- a/src/Worker/Cron.php
+++ b/src/Worker/Cron.php
@@ -68,6 +68,9 @@ class Cron
 		// Call possible post update functions
 		Worker::add(Worker::PRIORITY_LOW, 'PostUpdate');
 
+		// Update tag relay subscriptions
+		Worker::add(Worker::PRIORITY_LOW, 'UpdateTagRelaySubscriptions');
+
 		// Hourly cron calls
 		if ((DI::keyValue()->get('last_cron_hourly') ?? 0) + 3600 < time()) {
 			// Update trending tags cache for the community page

--- a/src/Worker/Notifier.php
+++ b/src/Worker/Notifier.php
@@ -712,7 +712,7 @@ class Notifier
 		if ($target_item['origin']) {
 			$inboxes = ActivityPub\Transmitter::fetchTargetInboxes($target_item, $uid);
 
-			if (in_array($target_item['private'], [Item::PUBLIC])) {
+			if (in_array($target_item['private'], [Item::PUBLIC]) && in_array($target_item['gravity'], [Item::GRAVITY_PARENT, Item::GRAVITY_COMMENT]) && !DI::pConfig()->get($uid, 'system', 'prevent-relay', false)) {
 				$inboxes       = ActivityPub\Transmitter::addRelayServerInboxesForItem($target_item['id'], $inboxes);
 				$relay_inboxes = ActivityPub\Transmitter::addRelayServerInboxes();
 			}
@@ -725,7 +725,7 @@ class Notifier
 		} elseif ($parent['origin'] && ($target_item['private'] != Item::PRIVATE) && (($target_item['gravity'] != Item::GRAVITY_ACTIVITY) || DI::config()->get('system', 'redistribute_activities'))) {
 			$inboxes = ActivityPub\Transmitter::fetchTargetInboxes($parent, $uid);
 
-			if (in_array($target_item['private'], [Item::PUBLIC])) {
+			if (in_array($target_item['private'], [Item::PUBLIC]) && in_array($target_item['gravity'], [Item::GRAVITY_PARENT, Item::GRAVITY_COMMENT]) && !DI::pConfig()->get($uid, 'system', 'prevent-relay', false)) {
 				$inboxes = ActivityPub\Transmitter::addRelayServerInboxesForItem($parent['id'], $inboxes);
 			}
 

--- a/src/Worker/UpdateTagRelaySubscriptions.php
+++ b/src/Worker/UpdateTagRelaySubscriptions.php
@@ -1,0 +1,18 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Worker;
+
+use Friendica\Protocol\Relay;
+
+class UpdateTagRelaySubscriptions
+{
+	public static function execute()
+	{
+		Relay::updateTagRelaySubscriptions();
+	}
+}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.08-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-30 19:28+0200\n"
+"POT-Creation-Date: 2026-06-05 22:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -64,7 +64,7 @@ msgstr ""
 #: src/Module/Profile/Schedule.php:44 src/Module/Register.php:66
 #: src/Module/Register.php:268 src/Module/Register.php:307
 #: src/Module/Search/Directory.php:23 src/Module/Settings/Account.php:34
-#: src/Module/Settings/Account.php:337 src/Module/Settings/Channels.php:40
+#: src/Module/Settings/Account.php:338 src/Module/Settings/Channels.php:40
 #: src/Module/Settings/Channels.php:121
 #: src/Module/Settings/ContactImport.php:45
 #: src/Module/Settings/ContactImport.php:110
@@ -551,17 +551,17 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: src/App/Router.php:256
+#: src/App/Router.php:263
 #, php-format
 msgid "Method not allowed for this module. Allowed method(s): %s"
 msgstr ""
 
-#: src/App/Router.php:258 src/Module/HTTPException/PageNotFound.php:35
+#: src/App/Router.php:265 src/Module/HTTPException/PageNotFound.php:35
 #: src/Module/Stats.php:70 src/Module/StatsCaching.php:46
 msgid "Page not found."
 msgstr ""
 
-#: src/App/Router.php:270
+#: src/App/Router.php:277
 msgid "You must be logged in to use addons. "
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgid "Display posts with the selected protocols."
 msgstr ""
 
 #: src/Content/Feature.php:131 src/Content/Widget.php:570
-#: src/Module/Settings/Account.php:391
+#: src/Module/Settings/Account.php:392
 msgid "Account Types"
 msgstr ""
 
@@ -1590,7 +1590,7 @@ msgid "Display posts done by accounts with the selected account type."
 msgstr ""
 
 #: src/Content/Feature.php:132 src/Content/Widget.php:632
-#: src/Module/Admin/Site.php:474 src/Module/BaseSettings.php:113
+#: src/Module/Admin/Site.php:476 src/Module/BaseSettings.php:113
 #: src/Module/Settings/Channels.php:210 src/Module/Settings/Display.php:420
 msgid "Channels"
 msgstr ""
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Find groups to join"
 msgstr ""
 
-#: src/Content/Item.php:303 src/Model/Item.php:2870
+#: src/Content/Item.php:303 src/Model/Item.php:2877
 msgid "event"
 msgstr ""
 
@@ -1693,7 +1693,7 @@ msgstr ""
 msgid "status"
 msgstr ""
 
-#: src/Content/Item.php:310 src/Model/Item.php:2872
+#: src/Content/Item.php:310 src/Model/Item.php:2879
 #: src/Module/Post/Tag/Add.php:105
 msgid "photo"
 msgstr ""
@@ -1967,7 +1967,7 @@ msgstr ""
 
 #: src/Content/Nav.php:283 src/Module/BaseNotifications.php:134
 #: src/Module/Notifications/Introductions.php:63
-#: src/Module/Settings/Account.php:554
+#: src/Module/Settings/Account.php:556
 msgid "Notifications"
 msgstr ""
 
@@ -2077,8 +2077,8 @@ msgstr ""
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
 msgstr ""
 
-#: src/Content/Text/BBCode.php:950 src/Model/Item.php:3718
-#: src/Model/Item.php:3724 src/Model/Item.php:3725
+#: src/Content/Text/BBCode.php:950 src/Model/Item.php:3725
+#: src/Model/Item.php:3731 src/Model/Item.php:3732
 msgid "Link to source"
 msgstr ""
 
@@ -3184,84 +3184,84 @@ msgstr ""
 msgid "Happy Birthday %s"
 msgstr ""
 
-#: src/Model/Item.php:2874
+#: src/Model/Item.php:2881
 msgid "activity"
 msgstr ""
 
-#: src/Model/Item.php:2876
+#: src/Model/Item.php:2883
 msgid "comment"
 msgstr ""
 
-#: src/Model/Item.php:2879 src/Module/Post/Tag/Add.php:105
+#: src/Model/Item.php:2886 src/Module/Post/Tag/Add.php:105
 msgid "post"
 msgstr ""
 
-#: src/Model/Item.php:3071
+#: src/Model/Item.php:3078
 #, php-format
 msgid "%s is blocked"
 msgstr ""
 
-#: src/Model/Item.php:3073
+#: src/Model/Item.php:3080
 #, php-format
 msgid "%s is ignored"
 msgstr ""
 
-#: src/Model/Item.php:3075
+#: src/Model/Item.php:3082
 #, php-format
 msgid "Content from %s is collapsed"
 msgstr ""
 
-#: src/Model/Item.php:3079
+#: src/Model/Item.php:3086
 msgid "Sensitive content"
 msgstr ""
 
-#: src/Model/Item.php:3586
+#: src/Model/Item.php:3593
 msgid "bytes"
 msgstr ""
 
-#: src/Model/Item.php:3620
+#: src/Model/Item.php:3627
 #, php-format
 msgid "The media in this post is not displayed to visitors. To view it, please go to the <a href=\"%s\">original post</a>."
 msgstr ""
 
-#: src/Model/Item.php:3622
+#: src/Model/Item.php:3629
 msgid "The media in this post is not displayed to visitors. To view it, please log in."
 msgstr ""
 
-#: src/Model/Item.php:3647
+#: src/Model/Item.php:3654
 #, php-format
 msgid "%2$s (%3$d%%, %1$d vote)"
 msgid_plural "%2$s (%3$d%%, %1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3649
+#: src/Model/Item.php:3656
 #, php-format
 msgid "%2$s (%1$d vote)"
 msgid_plural "%2$s (%1$d votes)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3654
+#: src/Model/Item.php:3661
 #, php-format
 msgid "%d voter. Poll end: %s"
 msgid_plural "%d voters. Poll end: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3656
+#: src/Model/Item.php:3663
 #, php-format
 msgid "%d voter."
 msgid_plural "%d voters."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Model/Item.php:3658
+#: src/Model/Item.php:3665
 #, php-format
 msgid "Poll end: %s"
 msgstr ""
 
-#: src/Model/Item.php:3701 src/Model/Item.php:3702
+#: src/Model/Item.php:3708 src/Model/Item.php:3709
 #: src/Module/Calendar/Event/Show.php:70
 msgid "View related post"
 msgstr ""
@@ -3676,7 +3676,7 @@ msgstr ""
 #: src/Module/Admin/Addons/Details.php:137 src/Module/Admin/Addons/Index.php:83
 #: src/Module/Admin/Federation.php:218 src/Module/Admin/Logs/Settings.php:74
 #: src/Module/Admin/Logs/View.php:71 src/Module/Admin/Queue.php:64
-#: src/Module/Admin/Roles.php:113 src/Module/Admin/Site.php:457
+#: src/Module/Admin/Roles.php:113 src/Module/Admin/Site.php:459
 #: src/Module/Admin/Storage.php:119 src/Module/Admin/Summary.php:206
 #: src/Module/Admin/Themes/Details.php:82 src/Module/Admin/Themes/Index.php:103
 #: src/Module/Admin/Tos.php:63 src/Module/Moderation/Users/Pending.php:82
@@ -3713,7 +3713,7 @@ msgid "Addon %s failed to install."
 msgstr ""
 
 #: src/Module/Admin/Addons/Index.php:85 src/Module/Admin/Features.php:69
-#: src/Module/Admin/Logs/Settings.php:76 src/Module/Admin/Site.php:460
+#: src/Module/Admin/Logs/Settings.php:76 src/Module/Admin/Site.php:462
 #: src/Module/Admin/Themes/Index.php:105 src/Module/Admin/Tos.php:72
 #: src/Module/Settings/Addons.php:59 src/Module/Settings/Connectors.php:131
 #: src/Module/Settings/Connectors.php:217
@@ -3914,8 +3914,8 @@ msgid "Enable Debugging"
 msgstr ""
 
 #: src/Module/Admin/Logs/Settings.php:80 src/Module/Admin/Logs/Settings.php:81
-#: src/Module/Admin/Logs/Settings.php:82 src/Module/Admin/Site.php:480
-#: src/Module/Admin/Site.php:488
+#: src/Module/Admin/Logs/Settings.php:82 src/Module/Admin/Site.php:482
+#: src/Module/Admin/Site.php:490
 msgid "<strong>Read-only</strong> because it is set by an environment variable"
 msgstr ""
 
@@ -4151,275 +4151,275 @@ msgstr ""
 msgid "All active users already have moderation rights."
 msgstr ""
 
-#: src/Module/Admin/Site.php:231
+#: src/Module/Admin/Site.php:232
 #, php-format
 msgid "%s is no valid input for maximum media size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:236
+#: src/Module/Admin/Site.php:237
 #, php-format
 msgid "%s is no valid input for maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:364 src/Module/Settings/Display.php:223
+#: src/Module/Admin/Site.php:366 src/Module/Settings/Display.php:223
 msgid "No special theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:381 src/Module/Settings/Display.php:233
+#: src/Module/Admin/Site.php:383 src/Module/Settings/Display.php:233
 #, php-format
 msgid "%s - (Experimental)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:393
+#: src/Module/Admin/Site.php:395
 msgid "Fetch replies on all posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:394
+#: src/Module/Admin/Site.php:396
 msgid "Don't fetch replies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:395
+#: src/Module/Admin/Site.php:397
 msgid "Fetch replies on posts from followed contacts only"
 msgstr ""
 
-#: src/Module/Admin/Site.php:396
+#: src/Module/Admin/Site.php:398
 msgid "Fetch replies on posts with interactions only"
 msgstr ""
 
-#: src/Module/Admin/Site.php:401
+#: src/Module/Admin/Site.php:403
 msgid "No community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:402
+#: src/Module/Admin/Site.php:404
 msgid "No community page for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:403
+#: src/Module/Admin/Site.php:405
 msgid "Public postings from users of this site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:404
+#: src/Module/Admin/Site.php:406
 msgid "Public postings from the federated network"
 msgstr ""
 
-#: src/Module/Admin/Site.php:405
+#: src/Module/Admin/Site.php:407
 msgid "Public postings from local users and the federated network"
 msgstr ""
 
-#: src/Module/Admin/Site.php:411
+#: src/Module/Admin/Site.php:413
 msgid "Multi user instance"
-msgstr ""
-
-#: src/Module/Admin/Site.php:434 src/Module/Moderation/Reports.php:212
-#: src/Module/Moderation/Reports.php:285
-msgid "Closed"
-msgstr ""
-
-#: src/Module/Admin/Site.php:435
-msgid "Requires approval"
 msgstr ""
 
 #: src/Module/Admin/Site.php:436 src/Module/Moderation/Reports.php:212
 #: src/Module/Moderation/Reports.php:285
+msgid "Closed"
+msgstr ""
+
+#: src/Module/Admin/Site.php:437
+msgid "Requires approval"
+msgstr ""
+
+#: src/Module/Admin/Site.php:438 src/Module/Moderation/Reports.php:212
+#: src/Module/Moderation/Reports.php:285
 msgid "Open"
 msgstr ""
 
-#: src/Module/Admin/Site.php:440
+#: src/Module/Admin/Site.php:442
 msgid "Don't check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:441
+#: src/Module/Admin/Site.php:443
 msgid "check the stable version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:442
+#: src/Module/Admin/Site.php:444
 msgid "check the development version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:446
+#: src/Module/Admin/Site.php:448
 msgid "none"
 msgstr ""
 
-#: src/Module/Admin/Site.php:447
+#: src/Module/Admin/Site.php:449
 msgid "Local contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:448
+#: src/Module/Admin/Site.php:450
 msgid "Interactors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:458 src/Module/BaseAdmin.php:75
+#: src/Module/Admin/Site.php:460 src/Module/BaseAdmin.php:75
 msgid "Site"
 msgstr ""
 
-#: src/Module/Admin/Site.php:459
+#: src/Module/Admin/Site.php:461
 msgid "General Information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:461
+#: src/Module/Admin/Site.php:463
 msgid "Republish users to directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:462
+#: src/Module/Admin/Site.php:464
 msgid "Registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:463
+#: src/Module/Admin/Site.php:465
 msgid "File upload"
 msgstr ""
 
-#: src/Module/Admin/Site.php:464
+#: src/Module/Admin/Site.php:466
 msgid "Policies"
 msgstr ""
 
-#: src/Module/Admin/Site.php:465 src/Module/Calendar/Event/Form.php:265
+#: src/Module/Admin/Site.php:467 src/Module/Calendar/Event/Form.php:265
 #: src/Module/Contact.php:523 src/Module/Profile/Profile.php:284
 msgid "Advanced"
 msgstr ""
 
-#: src/Module/Admin/Site.php:466
+#: src/Module/Admin/Site.php:468
 msgid "Auto Discovered Contact Directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:467
+#: src/Module/Admin/Site.php:469
 msgid "Performance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:468
+#: src/Module/Admin/Site.php:470
 msgid "Worker"
 msgstr ""
 
-#: src/Module/Admin/Site.php:469
+#: src/Module/Admin/Site.php:471
 msgid "Message Relay"
 msgstr ""
 
-#: src/Module/Admin/Site.php:470
+#: src/Module/Admin/Site.php:472
 msgid "Use the command \"console relay\" in the command line to add or remove relays."
 msgstr ""
 
-#: src/Module/Admin/Site.php:471
+#: src/Module/Admin/Site.php:473
 msgid "The system is not subscribed to any relays at the moment."
 msgstr ""
 
-#: src/Module/Admin/Site.php:472
+#: src/Module/Admin/Site.php:474
 msgid "The system is currently subscribed to the following relays:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:475
+#: src/Module/Admin/Site.php:477
 msgid "Relocate Node"
 msgstr ""
 
-#: src/Module/Admin/Site.php:476
+#: src/Module/Admin/Site.php:478
 msgid "Relocating your node enables you to change the DNS domain of this node and keep all the existing users and posts. This process takes a while and can only be started from the relocate console command like this:"
 msgstr ""
 
-#: src/Module/Admin/Site.php:477
+#: src/Module/Admin/Site.php:479
 msgid "(Friendica directory)# bin/console relocate https://newdomain.com"
 msgstr ""
 
-#: src/Module/Admin/Site.php:480
+#: src/Module/Admin/Site.php:482
 msgid "Site name"
 msgstr ""
 
-#: src/Module/Admin/Site.php:481
+#: src/Module/Admin/Site.php:483
 msgid "Sender Email"
 msgstr ""
 
-#: src/Module/Admin/Site.php:481
+#: src/Module/Admin/Site.php:483
 msgid "The email address your server shall use to send notification emails from."
 msgstr ""
 
-#: src/Module/Admin/Site.php:482
+#: src/Module/Admin/Site.php:484
 msgid "Name of the system actor"
 msgstr ""
 
-#: src/Module/Admin/Site.php:482
+#: src/Module/Admin/Site.php:484
 msgid "Name of the internal system account that is used to perform ActivityPub requests. This must be an unused username. If set, this can't be changed again."
 msgstr ""
 
-#: src/Module/Admin/Site.php:483
+#: src/Module/Admin/Site.php:485
 msgid "Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:484
+#: src/Module/Admin/Site.php:486
 msgid "Email Banner/Logo"
 msgstr ""
 
-#: src/Module/Admin/Site.php:485
+#: src/Module/Admin/Site.php:487
 msgid "Shortcut icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:485
+#: src/Module/Admin/Site.php:487
 msgid "Link to an icon that will be used for browsers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:488
 msgid "Touch icon"
 msgstr ""
 
-#: src/Module/Admin/Site.php:486
+#: src/Module/Admin/Site.php:488
 msgid "Link to an icon that will be used for tablets and mobiles."
 msgstr ""
 
-#: src/Module/Admin/Site.php:487
+#: src/Module/Admin/Site.php:489
 msgid "Additional Info"
 msgstr ""
 
-#: src/Module/Admin/Site.php:487
+#: src/Module/Admin/Site.php:489
 #, php-format
 msgid "For public servers: you can add additional information here that will be listed at %s/servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:488
+#: src/Module/Admin/Site.php:490
 msgid "System language"
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:491
 msgid "System theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:489
+#: src/Module/Admin/Site.php:491
 #, php-format
 msgid "Default system theme - may be over-ridden by user profiles - <a href=\"%s\" id=\"cnftheme\">Change default theme settings</a>"
 msgstr ""
 
-#: src/Module/Admin/Site.php:490
+#: src/Module/Admin/Site.php:492
 msgid "Mobile system theme"
 msgstr ""
 
-#: src/Module/Admin/Site.php:490
+#: src/Module/Admin/Site.php:492
 msgid "Theme for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
+#: src/Module/Admin/Site.php:493
 msgid "Force SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:491
+#: src/Module/Admin/Site.php:493
 msgid "Force all Non-SSL requests to SSL - Attention: on some systems it could lead to endless loops."
 msgstr ""
 
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:494
 msgid "Show help entry from navigation menu"
 msgstr ""
 
-#: src/Module/Admin/Site.php:492
+#: src/Module/Admin/Site.php:494
 msgid "Displays the menu entry for the Help pages from the navigation menu. It is always accessible by calling /help directly."
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:495
 msgid "Single user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:493
+#: src/Module/Admin/Site.php:495
 msgid "Make this instance multi-user or single-user for the named user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:497
 msgid "Maximum image size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:495
+#: src/Module/Admin/Site.php:497
 #, php-format
 msgid ""
 "Maximum size in bytes of uploaded images. Default is 0, which means no limits. You can put k, m, or g behind the desired value for KiB, MiB, GiB, respectively.\n"
@@ -4427,27 +4427,27 @@ msgid ""
 "\t\t\t\t\t\t\t\t\t\t\t\t\tCurrently <code>upload_max_filesize</code> is set to %s (%s byte)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:499
+#: src/Module/Admin/Site.php:501
 msgid "Maximum image length"
 msgstr ""
 
-#: src/Module/Admin/Site.php:499
+#: src/Module/Admin/Site.php:501
 msgid "Maximum length in pixels of the longest side of uploaded images. Default is -1, which means no limits."
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:502
 msgid "JPEG image quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:500
+#: src/Module/Admin/Site.php:502
 msgid "Uploaded JPEGS will be saved at this quality setting [0-100]. Default is 100, which is full quality."
 msgstr ""
 
-#: src/Module/Admin/Site.php:501
+#: src/Module/Admin/Site.php:503
 msgid "Maximum media file size"
 msgstr ""
 
-#: src/Module/Admin/Site.php:501
+#: src/Module/Admin/Site.php:503
 #, php-format
 msgid ""
 "Maximum size in bytes of uploaded media files. Default is 0, which means no limits. You can put k, m, or g behind the desired value for KiB, MiB, GiB, respectively.\n"
@@ -4455,755 +4455,763 @@ msgid ""
 "\t\t\t\t\t\t\t\t\t\t\t\t\tCurrently <code>upload_max_filesize</code> is set to %s (%s byte)"
 msgstr ""
 
-#: src/Module/Admin/Site.php:506
+#: src/Module/Admin/Site.php:508
 msgid "Register policy"
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:509
 msgid "Maximum Users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:507
+#: src/Module/Admin/Site.php:509
 msgid "If defined, the register policy is automatically closed when the given number of users is reached and reopens the registry when the number drops below the limit. It only works when the policy is set to open or close, but not when the policy is set to approval."
 msgstr ""
 
-#: src/Module/Admin/Site.php:508
+#: src/Module/Admin/Site.php:510
 msgid "Maximum Daily Registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:508
+#: src/Module/Admin/Site.php:510
 msgid "If registration is permitted above, this sets the maximum number of new user registrations to accept per day.  If register is set to closed, this setting has no effect."
 msgstr ""
 
-#: src/Module/Admin/Site.php:509
+#: src/Module/Admin/Site.php:511
 msgid "Register text"
 msgstr ""
 
-#: src/Module/Admin/Site.php:509
+#: src/Module/Admin/Site.php:511
 msgid "Will be displayed prominently on the registration page. You can use BBCode here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:512
 msgid "Forbidden Nicknames"
 msgstr ""
 
-#: src/Module/Admin/Site.php:510
+#: src/Module/Admin/Site.php:512
 msgid "Comma separated list of nicknames that are forbidden from registration. Preset is a list of role names according RFC 2142."
 msgstr ""
 
-#: src/Module/Admin/Site.php:511
+#: src/Module/Admin/Site.php:513
 msgid "Accounts abandoned after x days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:511
+#: src/Module/Admin/Site.php:513
 msgid "Will not waste system resources polling external sites for abandonded accounts. Enter 0 for no time limit."
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:514
 msgid "Allowed friend domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:512
+#: src/Module/Admin/Site.php:514
 msgid "Comma separated list of domains which are allowed to establish friendships with this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:515
 msgid "Allowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:513
+#: src/Module/Admin/Site.php:515
 msgid "Comma separated list of domains which are allowed in email addresses for registrations to this site. Wildcards are accepted. Empty to allow any domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:516
 msgid "Disallowed email domains"
 msgstr ""
 
-#: src/Module/Admin/Site.php:514
+#: src/Module/Admin/Site.php:516
 msgid "Comma separated list of domains which are rejected as email addresses for registrations to this site. Wildcards are accepted."
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:517
 msgid "Block public"
 msgstr ""
 
-#: src/Module/Admin/Site.php:515
+#: src/Module/Admin/Site.php:517
 msgid "Check to block public access to all otherwise public personal pages on this site unless you are currently logged in."
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:518
 msgid "Force publish"
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:518
 msgid "Check to force all profiles on this site to be listed in the site directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:516
+#: src/Module/Admin/Site.php:518
 msgid "Enabling this may violate privacy laws like the GDPR"
 msgstr ""
 
-#: src/Module/Admin/Site.php:517
+#: src/Module/Admin/Site.php:519
 msgid "Global directory URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:517
+#: src/Module/Admin/Site.php:519
 msgid "URL to the global directory. If this is not set, the global directory is completely unavailable to the application."
 msgstr ""
 
-#: src/Module/Admin/Site.php:518
+#: src/Module/Admin/Site.php:520
 msgid "Private posts by default for new users"
 msgstr ""
 
-#: src/Module/Admin/Site.php:518
+#: src/Module/Admin/Site.php:520
 msgid "Set default post permissions for all new members to the default privacy circle rather than public."
 msgstr ""
 
-#: src/Module/Admin/Site.php:519
+#: src/Module/Admin/Site.php:521
 msgid "Don't include post content in email notifications"
 msgstr ""
 
-#: src/Module/Admin/Site.php:519
+#: src/Module/Admin/Site.php:521
 msgid "Don't include the content of a post/comment/private message/etc. in the email notifications that are sent out from this site, as a privacy measure."
 msgstr ""
 
-#: src/Module/Admin/Site.php:520
+#: src/Module/Admin/Site.php:522
 msgid "Disallow public access to addons listed in the apps menu."
 msgstr ""
 
-#: src/Module/Admin/Site.php:520
+#: src/Module/Admin/Site.php:522
 msgid "Checking this box will restrict addons listed in the apps menu to members only."
 msgstr ""
 
-#: src/Module/Admin/Site.php:521
+#: src/Module/Admin/Site.php:523
 msgid "Don't embed private images in posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:521
+#: src/Module/Admin/Site.php:523
 msgid "Don't replace locally-hosted private photos in posts with an embedded copy of the image. This means that contacts who receive posts containing private photos will have to authenticate and load each image, which may take a while."
 msgstr ""
 
-#: src/Module/Admin/Site.php:522
+#: src/Module/Admin/Site.php:524
 msgid "Explicit Content"
 msgstr ""
 
-#: src/Module/Admin/Site.php:522
+#: src/Module/Admin/Site.php:524
 msgid "Set this to announce that your node is used mostly for explicit content that might not be suited for minors. This information will be published in the node information and might be used, e.g. by the global directory, to filter your node from listings of nodes to join. Additionally a note about this will be shown at the user registration page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:523
+#: src/Module/Admin/Site.php:525
 msgid "Only local search"
 msgstr ""
 
-#: src/Module/Admin/Site.php:523
+#: src/Module/Admin/Site.php:525
 msgid "Blocks search for users who are not logged in to prevent crawlers from blocking your system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:524
+#: src/Module/Admin/Site.php:526
 msgid "Blocked tags for trending tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:524
+#: src/Module/Admin/Site.php:526
 msgid "Comma separated list of hashtags that shouldn't be displayed in the trending tags."
 msgstr ""
 
-#: src/Module/Admin/Site.php:525
+#: src/Module/Admin/Site.php:527
 msgid "Cache contact avatars"
 msgstr ""
 
-#: src/Module/Admin/Site.php:525
+#: src/Module/Admin/Site.php:527
 msgid "Locally store the avatar pictures of the contacts. This uses a lot of storage space but it increases the performance."
 msgstr ""
 
-#: src/Module/Admin/Site.php:526
+#: src/Module/Admin/Site.php:528
 msgid "Allow Users to set remote_self"
 msgstr ""
 
-#: src/Module/Admin/Site.php:526
+#: src/Module/Admin/Site.php:528
 msgid "With checking this, every user is allowed to mark every contact as a remote_self in the repair contact dialog. Setting this flag on a contact causes mirroring every posting of that contact in the users stream."
 msgstr ""
 
-#: src/Module/Admin/Site.php:527
+#: src/Module/Admin/Site.php:529
 msgid "Allow Users to set up relay channels"
 msgstr ""
 
-#: src/Module/Admin/Site.php:527
+#: src/Module/Admin/Site.php:529
 msgid "If enabled, it is possible to create relay users that are used to reshare content based on user defined channels."
 msgstr ""
 
-#: src/Module/Admin/Site.php:528
+#: src/Module/Admin/Site.php:530
 msgid "Adjust the feed poll frequency"
 msgstr ""
 
-#: src/Module/Admin/Site.php:528
+#: src/Module/Admin/Site.php:530
 msgid "Automatically detect and set the best feed poll frequency."
 msgstr ""
 
-#: src/Module/Admin/Site.php:529
+#: src/Module/Admin/Site.php:531
 msgid "Minimum poll interval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:529
+#: src/Module/Admin/Site.php:531
 msgid "Minimal distance in minutes between two polls for mail and feed contacts. Reasonable values are between 1 and 59."
 msgstr ""
 
-#: src/Module/Admin/Site.php:530
+#: src/Module/Admin/Site.php:532
 msgid "Enable multiple registrations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:530
+#: src/Module/Admin/Site.php:532
 msgid "Enable users to register additional accounts for use as pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:531
+#: src/Module/Admin/Site.php:533
 msgid "Enable OpenID"
 msgstr ""
 
-#: src/Module/Admin/Site.php:531
+#: src/Module/Admin/Site.php:533
 msgid "Enable OpenID support for registration and logins."
 msgstr ""
 
-#: src/Module/Admin/Site.php:532
+#: src/Module/Admin/Site.php:534
 msgid "Enable full name check"
 msgstr ""
 
-#: src/Module/Admin/Site.php:532
+#: src/Module/Admin/Site.php:534
 msgid "Prevents users from registering with a display name with fewer than two parts separated by spaces."
 msgstr ""
 
-#: src/Module/Admin/Site.php:533
+#: src/Module/Admin/Site.php:535
 msgid "Email administrators on new registration"
 msgstr ""
 
-#: src/Module/Admin/Site.php:533
+#: src/Module/Admin/Site.php:535
 msgid "If enabled and the system is set to an open registration, an email for each new registration is sent to the administrators."
 msgstr ""
 
-#: src/Module/Admin/Site.php:534
+#: src/Module/Admin/Site.php:536
 msgid "Community pages for visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:534
+#: src/Module/Admin/Site.php:536
 msgid "Which community pages should be available for visitors. Local users always see both pages."
 msgstr ""
 
-#: src/Module/Admin/Site.php:535
+#: src/Module/Admin/Site.php:537
 msgid "Posts per user on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:535
+#: src/Module/Admin/Site.php:537
 msgid "The maximum number of posts per user on the local community page. This is useful, when a single user floods the local community page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:536
+#: src/Module/Admin/Site.php:538
 msgid "Posts per server on community page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:536
+#: src/Module/Admin/Site.php:538
 msgid "The maximum number of posts per server on the global community page. This is useful, when posts from a single server flood the global community page."
 msgstr ""
 
-#: src/Module/Admin/Site.php:537
+#: src/Module/Admin/Site.php:539
 msgid "Display local media to visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:537
+#: src/Module/Admin/Site.php:539
 msgid "When enabled, locally stored media, such as pictures and videos, will be displayed to visitors who are not logged in. When disabled, a message will appear informing visitors that the media is only available to logged-in users."
 msgstr ""
 
-#: src/Module/Admin/Site.php:538
+#: src/Module/Admin/Site.php:540
 msgid "Display remote media to visitors"
 msgstr ""
 
-#: src/Module/Admin/Site.php:538
+#: src/Module/Admin/Site.php:540
 msgid "When enabled, visitors who are not logged in will be able to view non-locally stored media such as pictures and videos. When disabled, visitors will see a message informing them that the media is available on the remote site."
 msgstr ""
 
-#: src/Module/Admin/Site.php:540
+#: src/Module/Admin/Site.php:542
 msgid "Enable Mail support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:540
+#: src/Module/Admin/Site.php:542
 msgid "Enable built-in mail support to poll IMAP folders and to reply via mail."
 msgstr ""
 
-#: src/Module/Admin/Site.php:541
+#: src/Module/Admin/Site.php:543
 msgid "Mail support can't be enabled because the PHP IMAP module is not installed."
 msgstr ""
 
-#: src/Module/Admin/Site.php:543
+#: src/Module/Admin/Site.php:545
 msgid "Diaspora support can't be enabled because Friendica was installed into a sub directory."
 msgstr ""
 
-#: src/Module/Admin/Site.php:544
+#: src/Module/Admin/Site.php:546
 msgid "Enable Diaspora support"
 msgstr ""
 
-#: src/Module/Admin/Site.php:544
+#: src/Module/Admin/Site.php:546
 msgid "Enable built-in Diaspora network compatibility for communicating with diaspora servers."
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:547
 msgid "Verify SSL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:545
+#: src/Module/Admin/Site.php:547
 msgid "If you wish, you can turn on strict certificate checking. This will mean you cannot connect (at all) to self-signed SSL sites."
 msgstr ""
 
-#: src/Module/Admin/Site.php:546
+#: src/Module/Admin/Site.php:548
 msgid "Proxy user"
 msgstr ""
 
-#: src/Module/Admin/Site.php:546
+#: src/Module/Admin/Site.php:548
 msgid "User name for the proxy server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:547
+#: src/Module/Admin/Site.php:549
 msgid "Proxy URL"
 msgstr ""
 
-#: src/Module/Admin/Site.php:547
+#: src/Module/Admin/Site.php:549
 msgid "If you want to use a proxy server that Friendica should use to connect to the network, put the URL of the proxy here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:548
+#: src/Module/Admin/Site.php:550
 msgid "Network timeout"
 msgstr ""
 
-#: src/Module/Admin/Site.php:548
+#: src/Module/Admin/Site.php:550
 msgid "Value is in seconds. Set to 0 for unlimited (not recommended)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:549
+#: src/Module/Admin/Site.php:551
 msgid "Maximum Load Average"
 msgstr ""
 
-#: src/Module/Admin/Site.php:549
+#: src/Module/Admin/Site.php:551
 #, php-format
 msgid "Maximum system load before delivery and poll processes are deferred - default %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:550
+#: src/Module/Admin/Site.php:552
 msgid "Minimal Memory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:550
+#: src/Module/Admin/Site.php:552
 msgid "Minimal free memory in MB for the worker. Needs access to /proc/meminfo - default 0 (deactivated)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:551
+#: src/Module/Admin/Site.php:553
 msgid "Periodically optimize tables"
 msgstr ""
 
-#: src/Module/Admin/Site.php:551
+#: src/Module/Admin/Site.php:553
 msgid "Periodically optimize tables like the cache and the workerqueue"
 msgstr ""
 
-#: src/Module/Admin/Site.php:553
+#: src/Module/Admin/Site.php:555
 msgid "Discover followers/followings from contacts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:553
+#: src/Module/Admin/Site.php:555
 msgid "If enabled, contacts are checked for their followers and following contacts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:554
+#: src/Module/Admin/Site.php:556
 msgid "None - deactivated"
 msgstr ""
 
-#: src/Module/Admin/Site.php:555
+#: src/Module/Admin/Site.php:557
 msgid "Local contacts - contacts of our local contacts are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:556
+#: src/Module/Admin/Site.php:558
 msgid "Interactors - contacts of our local contacts and contacts who interacted on locally visible postings are discovered for their followers/followings."
 msgstr ""
 
-#: src/Module/Admin/Site.php:558
+#: src/Module/Admin/Site.php:560
 msgid "Only update contacts/servers with local data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:558
+#: src/Module/Admin/Site.php:560
 msgid "If enabled, the system will only look for changes in contacts and servers that engaged on this system by either being in a contact list of a user or when posts or comments exists from the contact on this system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:559
+#: src/Module/Admin/Site.php:561
 msgid "Only update contacts with relations"
 msgstr ""
 
-#: src/Module/Admin/Site.php:559
+#: src/Module/Admin/Site.php:561
 msgid "If enabled, the system will only look for changes in contacts that are in a contact list of a user on this system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:560
+#: src/Module/Admin/Site.php:562
 msgid "Synchronize the contacts with the directory server"
 msgstr ""
 
-#: src/Module/Admin/Site.php:560
+#: src/Module/Admin/Site.php:562
 msgid "if enabled, the system will check periodically for new contacts on the defined directory server."
 msgstr ""
 
-#: src/Module/Admin/Site.php:562
+#: src/Module/Admin/Site.php:564
 msgid "Discover contacts from other servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:562
+#: src/Module/Admin/Site.php:564
 msgid "Periodically query other servers for contacts and servers that they know of. The system queries Friendica, Mastodon and Hubzilla servers. Keep it deactivated on small machines to decrease the database size and load."
 msgstr ""
 
-#: src/Module/Admin/Site.php:563
+#: src/Module/Admin/Site.php:565
 msgid "Days between requery"
 msgstr ""
 
-#: src/Module/Admin/Site.php:563
+#: src/Module/Admin/Site.php:565
 msgid "Number of days after which a server is requeried for their contacts and servers it knows of. This is only used when the discovery is activated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:564
+#: src/Module/Admin/Site.php:566
 msgid "Search the local directory"
 msgstr ""
 
-#: src/Module/Admin/Site.php:564
+#: src/Module/Admin/Site.php:566
 msgid "Search the local directory instead of the global directory. When searching locally, every search will be executed on the global directory in the background. This improves the search results when the search is repeated."
 msgstr ""
 
-#: src/Module/Admin/Site.php:566
+#: src/Module/Admin/Site.php:568
 msgid "Publish server information"
 msgstr ""
 
-#: src/Module/Admin/Site.php:566
+#: src/Module/Admin/Site.php:568
 msgid "If enabled, general server and usage data will be published. The data contains the name and version of the server, number of users with public profiles, number of posts and the activated protocols and connectors. See <a href=\"http://the-federation.info/\">the-federation.info</a> for details."
 msgstr ""
 
-#: src/Module/Admin/Site.php:568
+#: src/Module/Admin/Site.php:570
 msgid "Check upstream version"
 msgstr ""
 
-#: src/Module/Admin/Site.php:568
+#: src/Module/Admin/Site.php:570
 msgid "Enables checking for new Friendica versions at github. If there is a new version, you will be informed in the admin panel overview."
 msgstr ""
 
-#: src/Module/Admin/Site.php:569
+#: src/Module/Admin/Site.php:571
 msgid "Suppress Tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:569
+#: src/Module/Admin/Site.php:571
 msgid "Suppress showing a list of hashtags at the end of the posting."
 msgstr ""
 
-#: src/Module/Admin/Site.php:570
+#: src/Module/Admin/Site.php:572
 msgid "Clean database"
 msgstr ""
 
-#: src/Module/Admin/Site.php:570
+#: src/Module/Admin/Site.php:572
 msgid "Remove old remote items, orphaned database records and old content from some other helper tables."
 msgstr ""
 
-#: src/Module/Admin/Site.php:571
+#: src/Module/Admin/Site.php:573
 msgid "Lifespan of remote items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:571
+#: src/Module/Admin/Site.php:573
 msgid "When the database cleanup is enabled, this defines the days after which remote items will be deleted. Own items, and marked or filed items are always kept. 0 disables this behaviour."
 msgstr ""
 
-#: src/Module/Admin/Site.php:572
+#: src/Module/Admin/Site.php:574
 msgid "Lifespan of unclaimed items"
 msgstr ""
 
-#: src/Module/Admin/Site.php:572
+#: src/Module/Admin/Site.php:574
 msgid "When the database cleanup is enabled, this defines the days after which unclaimed remote items (mostly content from the relay) will be deleted. Default value is 90 days. Defaults to the general lifespan value of remote items if set to 0."
 msgstr ""
 
-#: src/Module/Admin/Site.php:573
+#: src/Module/Admin/Site.php:575
 msgid "Lifespan of raw conversation data"
 msgstr ""
 
-#: src/Module/Admin/Site.php:573
+#: src/Module/Admin/Site.php:575
 msgid "The conversation data is used for ActivityPub, as well as for debug purposes. It should be safe to remove it after 14 days, default is 90 days."
 msgstr ""
 
-#: src/Module/Admin/Site.php:574
+#: src/Module/Admin/Site.php:576
 msgid "Maximum numbers of comments per post"
 msgstr ""
 
-#: src/Module/Admin/Site.php:574
+#: src/Module/Admin/Site.php:576
 msgid "How much comments should be shown for each post? Default value is 100."
 msgstr ""
 
-#: src/Module/Admin/Site.php:575
+#: src/Module/Admin/Site.php:577
 msgid "Maximum numbers of comments per post on the display page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:575
+#: src/Module/Admin/Site.php:577
 msgid "How many comments should be shown on the single view for each post? Default value is 1000."
 msgstr ""
 
-#: src/Module/Admin/Site.php:576
+#: src/Module/Admin/Site.php:578
 msgid "Items per page"
 msgstr ""
 
-#: src/Module/Admin/Site.php:576
+#: src/Module/Admin/Site.php:578
 msgid "Number of items per page in stream pages (network, community, profile/contact statuses, search)."
 msgstr ""
 
-#: src/Module/Admin/Site.php:577
+#: src/Module/Admin/Site.php:579
 msgid "Items per page for mobile devices"
 msgstr ""
 
-#: src/Module/Admin/Site.php:577
+#: src/Module/Admin/Site.php:579
 msgid "Number of items per page in stream pages (network, community, profile/contact statuses, search) for mobile devices."
 msgstr ""
 
-#: src/Module/Admin/Site.php:578
+#: src/Module/Admin/Site.php:580
 msgid "Temp path"
 msgstr ""
 
-#: src/Module/Admin/Site.php:578
+#: src/Module/Admin/Site.php:580
 msgid "If you have a restricted system where the webserver can't access the system temp path, enter another path here."
 msgstr ""
 
-#: src/Module/Admin/Site.php:579
+#: src/Module/Admin/Site.php:581
 msgid "Only search in tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:579
+#: src/Module/Admin/Site.php:581
 msgid "On large systems the text search can slow down the system extremely."
 msgstr ""
 
-#: src/Module/Admin/Site.php:580
+#: src/Module/Admin/Site.php:582
 msgid "Limited search scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:580
+#: src/Module/Admin/Site.php:582
 msgid "If enabled, searches will only be performed in the data used for the channels and not in all posts."
 msgstr ""
 
-#: src/Module/Admin/Site.php:581
+#: src/Module/Admin/Site.php:583
 msgid "Maximum age of items in the search table"
 msgstr ""
 
-#: src/Module/Admin/Site.php:581
+#: src/Module/Admin/Site.php:583
 msgid "Maximum age of items in the search table in days. Lower values will increase the performance and reduce disk usage. 0 means no age restriction."
 msgstr ""
 
-#: src/Module/Admin/Site.php:582
+#: src/Module/Admin/Site.php:584
 msgid "Generate counts per contact circle when calculating network count"
 msgstr ""
 
-#: src/Module/Admin/Site.php:582
+#: src/Module/Admin/Site.php:584
 msgid "On systems with users that heavily use contact circles the query can be very expensive."
 msgstr ""
 
-#: src/Module/Admin/Site.php:583
+#: src/Module/Admin/Site.php:585
 msgid "Process \"view\" activities"
 msgstr ""
 
-#: src/Module/Admin/Site.php:583
+#: src/Module/Admin/Site.php:585
 msgid "\"view\" activities are mostly geberated by Peertube systems. Per default they are not processed for performance reasons. Only activate this option on performant system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:584
+#: src/Module/Admin/Site.php:586
 msgid "Days, after which a contact is archived"
 msgstr ""
 
-#: src/Module/Admin/Site.php:584
+#: src/Module/Admin/Site.php:586
 msgid "Number of days that we try to deliver content or to update the contact data before we archive a contact."
 msgstr ""
 
-#: src/Module/Admin/Site.php:586
+#: src/Module/Admin/Site.php:588
 msgid "Maximum number of parallel workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:586
+#: src/Module/Admin/Site.php:588
 #, php-format
 msgid "On shared hosters set this to %d. On larger systems, values of %d are great. Default value is %d."
 msgstr ""
 
-#: src/Module/Admin/Site.php:587
+#: src/Module/Admin/Site.php:589
 msgid "Maximum load for workers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:587
+#: src/Module/Admin/Site.php:589
 msgid "Maximum load that causes a cooldown before each worker function call."
 msgstr ""
 
-#: src/Module/Admin/Site.php:588
+#: src/Module/Admin/Site.php:590
 msgid "Enable fastlane"
 msgstr ""
 
-#: src/Module/Admin/Site.php:588
+#: src/Module/Admin/Site.php:590
 msgid "When enabed, the fastlane mechanism starts an additional worker if processes with higher priority are blocked by processes of lower priority."
 msgstr ""
 
-#: src/Module/Admin/Site.php:589
+#: src/Module/Admin/Site.php:591
 msgid "Decoupled receiver"
 msgstr ""
 
-#: src/Module/Admin/Site.php:589
+#: src/Module/Admin/Site.php:591
 msgid "Decouple incoming ActivityPub posts by processing them in the background via a worker process. Only enable this on fast systems."
 msgstr ""
 
-#: src/Module/Admin/Site.php:590
+#: src/Module/Admin/Site.php:592
 msgid "Fetch replies mode"
 msgstr ""
 
-#: src/Module/Admin/Site.php:590
+#: src/Module/Admin/Site.php:592
 msgid "Missing replies can be fetched upon receipt of an ActivityPub post."
 msgstr ""
 
-#: src/Module/Admin/Site.php:591
+#: src/Module/Admin/Site.php:593
 msgid "Cron interval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:591
+#: src/Module/Admin/Site.php:593
 msgid "Minimal period in minutes between two calls of the \"Cron\" worker job."
 msgstr ""
 
-#: src/Module/Admin/Site.php:592
+#: src/Module/Admin/Site.php:594
 msgid "Worker defer limit"
 msgstr ""
 
-#: src/Module/Admin/Site.php:592
+#: src/Module/Admin/Site.php:594
 msgid "Per default the systems tries delivering for 15 times before dropping it."
 msgstr ""
 
-#: src/Module/Admin/Site.php:593
+#: src/Module/Admin/Site.php:595
 msgid "Worker fetch limit"
 msgstr ""
 
-#: src/Module/Admin/Site.php:593
+#: src/Module/Admin/Site.php:595
 msgid "Number of worker tasks that are fetched in a single query. Higher values should increase the performance, too high values will mostly likely decrease it. Only change it, when you know how to measure the performance of your system."
 msgstr ""
 
-#: src/Module/Admin/Site.php:595
+#: src/Module/Admin/Site.php:597
 msgid "Direct relay transfer"
 msgstr ""
 
-#: src/Module/Admin/Site.php:595
+#: src/Module/Admin/Site.php:597
 msgid "Enables the direct transfer to other servers without using the relay servers"
 msgstr ""
 
-#: src/Module/Admin/Site.php:596
+#: src/Module/Admin/Site.php:598
 msgid "Relay scope"
 msgstr ""
 
-#: src/Module/Admin/Site.php:596
+#: src/Module/Admin/Site.php:598
 msgid "Can be \"all\" or \"tags\". \"all\" means that every public post should be received. \"tags\" means that only posts with selected tags should be received."
 msgstr ""
 
-#: src/Module/Admin/Site.php:596 src/Module/Contact/Profile.php:322
+#: src/Module/Admin/Site.php:598 src/Module/Contact/Profile.php:322
 #: src/Module/Settings/Display.php:268
 #: src/Module/Settings/TwoFactor/Index.php:132
 msgid "Disabled"
 msgstr ""
 
-#: src/Module/Admin/Site.php:596
+#: src/Module/Admin/Site.php:598
 msgid "all"
 msgstr ""
 
-#: src/Module/Admin/Site.php:596
+#: src/Module/Admin/Site.php:598
 msgid "tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:597
+#: src/Module/Admin/Site.php:599
 msgid "Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:597
+#: src/Module/Admin/Site.php:599
 msgid "Comma separated list of tags for the \"tags\" subscription."
 msgstr ""
 
-#: src/Module/Admin/Site.php:598
+#: src/Module/Admin/Site.php:600
 msgid "Deny Server tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:598
+#: src/Module/Admin/Site.php:600
 msgid "Comma separated list of tags that are rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:599
+#: src/Module/Admin/Site.php:601
 msgid "Maximum amount of tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:599
+#: src/Module/Admin/Site.php:601
 msgid "Maximum amount of tags in a post before it is rejected as spam. The post has to contain at least one link. Posts from subscribed accounts will not be rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:600
+#: src/Module/Admin/Site.php:602
 msgid "Allow user tags"
 msgstr ""
 
-#: src/Module/Admin/Site.php:600
+#: src/Module/Admin/Site.php:602
 msgid "If enabled, the tags from the saved searches will used for the \"tags\" subscription in addition to the \"relay_server_tags\"."
 msgstr ""
 
-#: src/Module/Admin/Site.php:601
+#: src/Module/Admin/Site.php:603
+msgid "Automatically subscribe to tag relay"
+msgstr ""
+
+#: src/Module/Admin/Site.php:603
+msgid "If enabled, the system will automatically follow and unfollow tags at the tags.pub service based on the configured tags. Additionally, all public posts will be automatically sent to this relay server for distribution."
+msgstr ""
+
+#: src/Module/Admin/Site.php:604
 msgid "Deny undetected languages"
 msgstr ""
 
-#: src/Module/Admin/Site.php:601
+#: src/Module/Admin/Site.php:604
 msgid "If enabled, posts with undetected languages will be rejected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:602
+#: src/Module/Admin/Site.php:605
 msgid "Language Quality"
 msgstr ""
 
-#: src/Module/Admin/Site.php:602
+#: src/Module/Admin/Site.php:605
 msgid "The minimum language quality that is required to accept the post."
 msgstr ""
 
-#: src/Module/Admin/Site.php:603
+#: src/Module/Admin/Site.php:606
 msgid "Number of languages for the language detection"
 msgstr ""
 
-#: src/Module/Admin/Site.php:603
+#: src/Module/Admin/Site.php:606
 msgid "The system detects a list of languages per post. Only if the desired languages are in the list, the message will be accepted. The higher the number, the more posts will be falsely detected."
 msgstr ""
 
-#: src/Module/Admin/Site.php:605
+#: src/Module/Admin/Site.php:608
 msgid "Maximum age of channel"
 msgstr ""
 
-#: src/Module/Admin/Site.php:605
+#: src/Module/Admin/Site.php:608
 msgid "This defines the maximum age in hours of items that should be displayed in channels. This affects the channel performance."
 msgstr ""
 
-#: src/Module/Admin/Site.php:606
+#: src/Module/Admin/Site.php:609
 msgid "Maximum number of channel posts"
 msgstr ""
 
-#: src/Module/Admin/Site.php:606
+#: src/Module/Admin/Site.php:609
 msgid "For performance reasons, the channels use a dedicated table to store content. The higher the value the slower the channels."
 msgstr ""
 
-#: src/Module/Admin/Site.php:607
+#: src/Module/Admin/Site.php:610
 msgid "Interaction score days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:607
+#: src/Module/Admin/Site.php:610
 msgid "Number of days that are used to calculate the interaction score."
 msgstr ""
 
-#: src/Module/Admin/Site.php:608
+#: src/Module/Admin/Site.php:611
 msgid "Maximum number of posts per author"
 msgstr ""
 
-#: src/Module/Admin/Site.php:608
+#: src/Module/Admin/Site.php:611
 msgid "Maximum number of posts per page by author if the contact frequency is set to \"Display only few posts\". If there are more posts, then the post with the most interactions will be displayed."
 msgstr ""
 
-#: src/Module/Admin/Site.php:609
+#: src/Module/Admin/Site.php:612
 msgid "Sharer interaction days"
 msgstr ""
 
-#: src/Module/Admin/Site.php:609
+#: src/Module/Admin/Site.php:612
 msgid "Number of days of the last interaction that are used to define which sharers are used for the \"sharers of sharers\" channel."
 msgstr ""
 
-#: src/Module/Admin/Site.php:612
+#: src/Module/Admin/Site.php:615
 msgid "Start Relocation"
 msgstr ""
 
@@ -7464,24 +7472,24 @@ msgstr ""
 msgid "List of pending user deletions"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:135 src/Module/Settings/Account.php:431
+#: src/Module/Moderation/BaseUsers.php:135 src/Module/Settings/Account.php:432
 msgid "Normal Account Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:136 src/Module/Settings/Account.php:438
+#: src/Module/Moderation/BaseUsers.php:136 src/Module/Settings/Account.php:439
 msgid "Soapbox Page"
 msgstr ""
 
 #: src/Module/Moderation/BaseUsers.php:137 src/Module/Register.php:140
-#: src/Module/Register.php:151 src/Module/Settings/Account.php:445
+#: src/Module/Register.php:151 src/Module/Settings/Account.php:446
 msgid "Public Group"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:138 src/Module/Settings/Account.php:452
+#: src/Module/Moderation/BaseUsers.php:138 src/Module/Settings/Account.php:453
 msgid "Public Group - Restricted"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:139 src/Module/Settings/Account.php:459
+#: src/Module/Moderation/BaseUsers.php:139 src/Module/Settings/Account.php:460
 msgid "Automatic Friend Page"
 msgstr ""
 
@@ -7491,23 +7499,23 @@ msgid "Private Group"
 msgstr ""
 
 #: src/Module/Moderation/BaseUsers.php:143 src/Module/Moderation/Summary.php:37
-#: src/Module/Settings/Account.php:402
+#: src/Module/Settings/Account.php:403
 msgid "Personal Page"
 msgstr ""
 
 #: src/Module/Moderation/BaseUsers.php:144 src/Module/Moderation/Summary.php:38
-#: src/Module/Settings/Account.php:409
+#: src/Module/Settings/Account.php:410
 msgid "Organisation Page"
 msgstr ""
 
 #: src/Module/Moderation/BaseUsers.php:145 src/Module/Moderation/Summary.php:39
 #: src/Module/Register.php:139 src/Module/Register.php:160
-#: src/Module/Settings/Account.php:416
+#: src/Module/Settings/Account.php:417
 msgid "News Page"
 msgstr ""
 
 #: src/Module/Moderation/BaseUsers.php:146 src/Module/Moderation/Summary.php:40
-#: src/Module/Settings/Account.php:423
+#: src/Module/Settings/Account.php:424
 msgid "Community Group"
 msgstr ""
 
@@ -8435,7 +8443,7 @@ msgstr ""
 msgid "Assigned to me"
 msgstr ""
 
-#: src/Module/Moderation/Summary.php:41 src/Module/Settings/Account.php:380
+#: src/Module/Moderation/Summary.php:41 src/Module/Settings/Account.php:381
 msgid "Channel Relay"
 msgstr ""
 
@@ -8947,7 +8955,7 @@ msgstr ""
 msgid "You're currently viewing your profile as <b>%s</b> <a href=\"%s\" class=\"btn btn-sm pull-right\">Cancel</a>"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:158 src/Module/Settings/Account.php:522
+#: src/Module/Profile/Profile.php:158 src/Module/Settings/Account.php:523
 #: src/Module/Settings/Profile/Index.php:296
 msgid "Display name:"
 msgstr ""
@@ -9185,7 +9193,7 @@ msgid "Please repeat your e-mail address:"
 msgstr ""
 
 #: src/Module/Register.php:218 src/Module/Security/PasswordTooLong.php:78
-#: src/Module/Settings/Account.php:513
+#: src/Module/Settings/Account.php:514
 msgid "New Password:"
 msgstr ""
 
@@ -9194,7 +9202,7 @@ msgid "Leave empty for an auto generated password."
 msgstr ""
 
 #: src/Module/Register.php:219 src/Module/Security/PasswordTooLong.php:79
-#: src/Module/Settings/Account.php:514
+#: src/Module/Settings/Account.php:515
 msgid "Confirm:"
 msgstr ""
 
@@ -9401,22 +9409,22 @@ msgid "Update Password"
 msgstr ""
 
 #: src/Module/Security/PasswordTooLong.php:77
-#: src/Module/Settings/Account.php:515
+#: src/Module/Settings/Account.php:516
 msgid "Current Password:"
 msgstr ""
 
 #: src/Module/Security/PasswordTooLong.php:77
-#: src/Module/Settings/Account.php:515
+#: src/Module/Settings/Account.php:516
 msgid "Your current password to confirm the changes"
 msgstr ""
 
 #: src/Module/Security/PasswordTooLong.php:78
-#: src/Module/Settings/Account.php:499
+#: src/Module/Settings/Account.php:500
 msgid "Allowed characters are a-z, A-Z, 0-9 and special characters except white spaces and accentuated letters."
 msgstr ""
 
 #: src/Module/Security/PasswordTooLong.php:78
-#: src/Module/Settings/Account.php:500
+#: src/Module/Settings/Account.php:501
 msgid "Password length is limited to 72 characters."
 msgstr ""
 
@@ -9526,400 +9534,408 @@ msgstr ""
 msgid "Cannot change to that email."
 msgstr ""
 
-#: src/Module/Settings/Account.php:128 src/Module/Settings/Account.php:177
-#: src/Module/Settings/Account.php:198 src/Module/Settings/Account.php:282
-#: src/Module/Settings/Account.php:311
+#: src/Module/Settings/Account.php:128 src/Module/Settings/Account.php:178
+#: src/Module/Settings/Account.php:199 src/Module/Settings/Account.php:283
+#: src/Module/Settings/Account.php:312
 msgid "Settings were not updated."
 msgstr ""
 
-#: src/Module/Settings/Account.php:325
+#: src/Module/Settings/Account.php:326
 msgid "Relocate message has been send to your contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:342
+#: src/Module/Settings/Account.php:343
 msgid "Unable to find your profile. Please contact your admin."
 msgstr ""
 
-#: src/Module/Settings/Account.php:382
+#: src/Module/Settings/Account.php:383
 msgid "Account for a service that automatically shares content based on user defined channels."
 msgstr ""
 
-#: src/Module/Settings/Account.php:392
+#: src/Module/Settings/Account.php:393
 msgid "Personal Page Subtypes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:393
+#: src/Module/Settings/Account.php:394
 msgid "Community Group Subtypes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:404
+#: src/Module/Settings/Account.php:405
 msgid "Account for a personal profile."
 msgstr ""
 
-#: src/Module/Settings/Account.php:411
+#: src/Module/Settings/Account.php:412
 msgid "Account for an organisation that automatically approves contact requests as \"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:418
+#: src/Module/Settings/Account.php:419
 msgid "Account for a news reflector that automatically approves contact requests as \"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:425
+#: src/Module/Settings/Account.php:426
 msgid "Account for community discussions."
 msgstr ""
 
-#: src/Module/Settings/Account.php:433
+#: src/Module/Settings/Account.php:434
 msgid "Account for a regular personal profile that requires manual approval of \"Friends\" and \"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:440
+#: src/Module/Settings/Account.php:441
 msgid "Account for a public profile that automatically approves contact requests as \"Followers\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:447
+#: src/Module/Settings/Account.php:448
 msgid "Automatically approves all contact requests."
 msgstr ""
 
-#: src/Module/Settings/Account.php:454
+#: src/Module/Settings/Account.php:455
 msgid "Contact requests have to be manually approved."
 msgstr ""
 
-#: src/Module/Settings/Account.php:461
+#: src/Module/Settings/Account.php:462
 msgid "Account for a popular profile that automatically approves contact requests as \"Friends\"."
 msgstr ""
 
-#: src/Module/Settings/Account.php:466
+#: src/Module/Settings/Account.php:467
 msgid "Private Group [Experimental]"
 msgstr ""
 
-#: src/Module/Settings/Account.php:468
+#: src/Module/Settings/Account.php:469
 msgid "Requires manual approval of contact requests."
 msgstr ""
 
-#: src/Module/Settings/Account.php:477
+#: src/Module/Settings/Account.php:478
 msgid "OpenID:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:477
+#: src/Module/Settings/Account.php:478
 msgid "(Optional) Allow this OpenID to login to this account."
 msgstr ""
 
-#: src/Module/Settings/Account.php:485
+#: src/Module/Settings/Account.php:486
 msgid "Publish your profile in your local site directory?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:485
+#: src/Module/Settings/Account.php:486
 #, php-format
 msgid "Your profile will be published in this node's <a href=\"%s\">local directory</a>. Your profile details may be publicly visible depending on the system settings."
 msgstr ""
 
-#: src/Module/Settings/Account.php:491
+#: src/Module/Settings/Account.php:492
 #, php-format
 msgid "Your profile will also be published in the global friendica directories (e.g. <a href=\"%s\">%s</a>)."
 msgstr ""
 
-#: src/Module/Settings/Account.php:504
+#: src/Module/Settings/Account.php:505
 msgid "Account Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:505
+#: src/Module/Settings/Account.php:506
 #, php-format
 msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
 msgstr ""
 
-#: src/Module/Settings/Account.php:507 view/theme/frio/config.php:158
+#: src/Module/Settings/Account.php:508 view/theme/frio/config.php:158
 msgid "Save settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:512
+#: src/Module/Settings/Account.php:513
 msgid "Password Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:514
+#: src/Module/Settings/Account.php:515
 msgid "Leave password fields blank unless changing"
 msgstr ""
 
-#: src/Module/Settings/Account.php:516
+#: src/Module/Settings/Account.php:517
 msgid "Password:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:516
+#: src/Module/Settings/Account.php:517
 msgid "Your current password to confirm the changes of the email address"
 msgstr ""
 
-#: src/Module/Settings/Account.php:519
+#: src/Module/Settings/Account.php:520
 msgid "Delete OpenID URL"
 msgstr ""
 
-#: src/Module/Settings/Account.php:521
+#: src/Module/Settings/Account.php:522
 msgid "Basic Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:523
+#: src/Module/Settings/Account.php:524
 msgid "Email Address:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:524
+#: src/Module/Settings/Account.php:525
 msgid "Your Timezone:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:525
+#: src/Module/Settings/Account.php:526
 msgid "Your Language:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:525
+#: src/Module/Settings/Account.php:526
 msgid "Set the language we use to show you friendica interface and to send you emails"
 msgstr ""
 
-#: src/Module/Settings/Account.php:526
+#: src/Module/Settings/Account.php:527
 msgid "Default Post Location:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:527
+#: src/Module/Settings/Account.php:528
 msgid "Use browser location"
 msgstr ""
 
-#: src/Module/Settings/Account.php:529
+#: src/Module/Settings/Account.php:530
 msgid "Security and Privacy Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:531
+#: src/Module/Settings/Account.php:532
 msgid "Maximum Friend Requests/Day:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:531
+#: src/Module/Settings/Account.php:532
 msgid "(to prevent spam abuse)"
 msgstr ""
 
-#: src/Module/Settings/Account.php:533
+#: src/Module/Settings/Account.php:534
 msgid "Allow your profile to be searchable globally?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:533
+#: src/Module/Settings/Account.php:534
 msgid "Activate this setting if you want others to easily find and follow you. Your profile will be searchable on remote systems. This setting also determines whether Friendica will inform search engines that your profile should be indexed or not."
 msgstr ""
 
-#: src/Module/Settings/Account.php:534
+#: src/Module/Settings/Account.php:535
 msgid "Hide your contact/friend list from viewers of your profile?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:534
+#: src/Module/Settings/Account.php:535
 msgid "A list of your contacts is displayed on your profile page. Activate this option to disable the display of your contact list."
 msgstr ""
 
-#: src/Module/Settings/Account.php:535
+#: src/Module/Settings/Account.php:536
 msgid "Hide your public content from anonymous viewers"
 msgstr ""
 
-#: src/Module/Settings/Account.php:535
+#: src/Module/Settings/Account.php:536
 msgid "Anonymous visitors will only see your basic profile details. Your public posts and replies will still be freely accessible on the remote servers of your followers and through relays."
 msgstr ""
 
-#: src/Module/Settings/Account.php:536
+#: src/Module/Settings/Account.php:537
 msgid "Make public posts unlisted"
 msgstr ""
 
-#: src/Module/Settings/Account.php:536
+#: src/Module/Settings/Account.php:537
 msgid "Your public posts will not appear on the community pages or in search results, nor be sent to relay servers. However they can still appear on public feeds on remote servers."
 msgstr ""
 
-#: src/Module/Settings/Account.php:537
+#: src/Module/Settings/Account.php:538
+msgid "Do not send public posts to relay servers"
+msgstr ""
+
+#: src/Module/Settings/Account.php:538
+msgid "Your public posts will not be forwarded to relay servers."
+msgstr ""
+
+#: src/Module/Settings/Account.php:539
 msgid "Make all posted pictures accessible"
 msgstr ""
 
-#: src/Module/Settings/Account.php:537
+#: src/Module/Settings/Account.php:539
 msgid "This option makes every posted picture accessible via the direct link. This is a workaround for the problem that most other networks can't handle permissions on pictures. Non public pictures still won't be visible for the public on your photo albums though."
 msgstr ""
 
-#: src/Module/Settings/Account.php:538
+#: src/Module/Settings/Account.php:540
 msgid "Allow friends to post to your profile page?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:538
+#: src/Module/Settings/Account.php:540
 msgid "Your contacts may write posts on your profile wall. These posts will be distributed to your contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:539
+#: src/Module/Settings/Account.php:541
 msgid "Allow friends to tag your posts?"
 msgstr ""
 
-#: src/Module/Settings/Account.php:539
+#: src/Module/Settings/Account.php:541
 msgid "Your contacts can add additional tags to your posts."
 msgstr ""
 
-#: src/Module/Settings/Account.php:540
+#: src/Module/Settings/Account.php:542
 msgid "Default privacy circle for new contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:541
+#: src/Module/Settings/Account.php:543
 msgid "Default privacy circle for new group contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:542
+#: src/Module/Settings/Account.php:544
 msgid "Default Post Permissions"
 msgstr ""
 
-#: src/Module/Settings/Account.php:546
+#: src/Module/Settings/Account.php:548
 msgid "Post expiration"
 msgstr ""
 
-#: src/Module/Settings/Account.php:547
+#: src/Module/Settings/Account.php:549
 msgid "Automatically expire posts after this many days:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:547
+#: src/Module/Settings/Account.php:549
 msgid "If empty, posts will not expire. Expired posts will be deleted"
 msgstr ""
 
-#: src/Module/Settings/Account.php:548
+#: src/Module/Settings/Account.php:550
 msgid "Expire posts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:548
+#: src/Module/Settings/Account.php:550
 msgid "When activated, posts and comments will be expired."
 msgstr ""
 
-#: src/Module/Settings/Account.php:549
+#: src/Module/Settings/Account.php:551
 msgid "Expire personal notes"
 msgstr ""
 
-#: src/Module/Settings/Account.php:549
+#: src/Module/Settings/Account.php:551
 msgid "When activated, the personal notes on your profile page will be expired."
 msgstr ""
 
-#: src/Module/Settings/Account.php:550
+#: src/Module/Settings/Account.php:552
 msgid "Expire bookmarked posts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:550
+#: src/Module/Settings/Account.php:552
 msgid "Bookmarking posts keeps them from being expired. That behaviour is overwritten by this setting."
 msgstr ""
 
-#: src/Module/Settings/Account.php:551
+#: src/Module/Settings/Account.php:553
 msgid "Only expire posts by others"
 msgstr ""
 
-#: src/Module/Settings/Account.php:551
+#: src/Module/Settings/Account.php:553
 msgid "When activated, your own posts never expire. Then the settings above are only valid for posts you received."
 msgstr ""
 
-#: src/Module/Settings/Account.php:555
+#: src/Module/Settings/Account.php:557
 msgid "Send an email when:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:556
+#: src/Module/Settings/Account.php:558
 msgid "You receive an introduction"
 msgstr ""
 
-#: src/Module/Settings/Account.php:557
+#: src/Module/Settings/Account.php:559
 msgid "Your introductions are confirmed"
 msgstr ""
 
-#: src/Module/Settings/Account.php:558
+#: src/Module/Settings/Account.php:560
 msgid "Someone writes on your wall"
 msgstr ""
 
-#: src/Module/Settings/Account.php:559
+#: src/Module/Settings/Account.php:561
 msgid "Someone writes a followup comment"
 msgstr ""
 
-#: src/Module/Settings/Account.php:560
+#: src/Module/Settings/Account.php:562
 msgid "You receive a private message"
 msgstr ""
 
-#: src/Module/Settings/Account.php:561
+#: src/Module/Settings/Account.php:563
 msgid "You receive a friend suggestion"
 msgstr ""
 
-#: src/Module/Settings/Account.php:562
+#: src/Module/Settings/Account.php:564
 msgid "You are tagged in a post"
 msgstr ""
 
-#: src/Module/Settings/Account.php:564
+#: src/Module/Settings/Account.php:566
 msgid "Notify when:"
 msgstr ""
 
-#: src/Module/Settings/Account.php:565
+#: src/Module/Settings/Account.php:567
 msgid "Someone tagged you"
 msgstr ""
 
-#: src/Module/Settings/Account.php:566
+#: src/Module/Settings/Account.php:568
 msgid "Someone directly commented on your post"
 msgstr ""
 
-#: src/Module/Settings/Account.php:567
+#: src/Module/Settings/Account.php:569
 msgid "Someone liked your content"
 msgstr ""
 
-#: src/Module/Settings/Account.php:567 src/Module/Settings/Account.php:568
+#: src/Module/Settings/Account.php:569 src/Module/Settings/Account.php:570
 msgid "Can only be enabled, when the direct comment notification is enabled."
 msgstr ""
 
-#: src/Module/Settings/Account.php:568
+#: src/Module/Settings/Account.php:570
 msgid "Someone shared your content"
 msgstr ""
 
-#: src/Module/Settings/Account.php:569
+#: src/Module/Settings/Account.php:571
 msgid "Someone commented in your thread"
 msgstr ""
 
-#: src/Module/Settings/Account.php:570
+#: src/Module/Settings/Account.php:572
 msgid "Someone commented in a thread where you commented"
 msgstr ""
 
-#: src/Module/Settings/Account.php:571
+#: src/Module/Settings/Account.php:573
 msgid "Someone commented in a thread where you interacted"
 msgstr ""
 
-#: src/Module/Settings/Account.php:573
+#: src/Module/Settings/Account.php:575
 msgid "Activate desktop notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:573
+#: src/Module/Settings/Account.php:575
 msgid "Show desktop popup on new notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:577
+#: src/Module/Settings/Account.php:579
 msgid "Text-only notification emails"
 msgstr ""
 
-#: src/Module/Settings/Account.php:579
+#: src/Module/Settings/Account.php:581
 msgid "Send text only notification emails, without the html part"
 msgstr ""
 
-#: src/Module/Settings/Account.php:583
+#: src/Module/Settings/Account.php:585
 msgid "Show detailled notifications"
 msgstr ""
 
-#: src/Module/Settings/Account.php:585
+#: src/Module/Settings/Account.php:587
 msgid "Per default, notifications are condensed to a single notification per item. When enabled every notification is displayed."
 msgstr ""
 
-#: src/Module/Settings/Account.php:589
+#: src/Module/Settings/Account.php:591
 msgid "Show notifications of ignored contacts"
 msgstr ""
 
-#: src/Module/Settings/Account.php:591
+#: src/Module/Settings/Account.php:593
 msgid "You don't see posts from ignored contacts. But you still see their comments. This setting controls if you want to still receive regular notifications that are caused by ignored contacts or not."
 msgstr ""
 
-#: src/Module/Settings/Account.php:594
+#: src/Module/Settings/Account.php:596
 msgid "Advanced Account/Page Type Settings"
 msgstr ""
 
-#: src/Module/Settings/Account.php:595
+#: src/Module/Settings/Account.php:597
 msgid "Change the behaviour of this account for special situations"
 msgstr ""
 
-#: src/Module/Settings/Account.php:598
+#: src/Module/Settings/Account.php:600
 msgid "Relocate"
 msgstr ""
 
-#: src/Module/Settings/Account.php:599
+#: src/Module/Settings/Account.php:601
 msgid "If you have moved this profile from another server, and some of your contacts don't receive your updates, try pushing this button."
 msgstr ""
 
-#: src/Module/Settings/Account.php:600
+#: src/Module/Settings/Account.php:602
 msgid "Resend relocate message to contacts"
 msgstr ""
 

--- a/view/templates/admin/site.tpl
+++ b/view/templates/admin/site.tpl
@@ -170,6 +170,7 @@
 		{{include file="field_input.tpl" field=$relay_deny_tags}}
 		{{include file="field_input.tpl" field=$relay_max_tags}}
 		{{include file="field_checkbox.tpl" field=$relay_user_tags}}
+		{{include file="field_checkbox.tpl" field=$relay_auto_subscribe_tags}}
 		{{include file="field_checkbox.tpl" field=$relay_directly}}
 		{{include file="field_checkbox.tpl" field=$relay_deny_undetected_language}}
 		{{include file="field_input.tpl" field=$relay_language_quality}}

--- a/view/templates/settings/account.tpl
+++ b/view/templates/settings/account.tpl
@@ -56,7 +56,10 @@
 		{{include file="field_checkbox.tpl" field=$profile_in_net_dir}}
 		{{if not $is_community}}{{include file="field_checkbox.tpl" field=$hide_friends}}{{/if}}
 		{{include file="field_checkbox.tpl" field=$hide_wall}}
-		{{if not $is_community}}{{include file="field_checkbox.tpl" field=$unlisted}}{{/if}}
+		{{if not $is_community}}
+		{{include file="field_checkbox.tpl" field=$unlisted}}
+		{{include file="field_checkbox.tpl" field=$prevent_relay}}
+		{{/if}}
 		{{include file="field_checkbox.tpl" field=$accessiblephotos}}
 		{{if not $is_community}}
 		{{include file="field_checkbox.tpl" field=$blockwall}}

--- a/view/theme/frio/templates/admin/site.tpl
+++ b/view/theme/frio/templates/admin/site.tpl
@@ -338,6 +338,7 @@
 						{{include file="field_input.tpl" field=$relay_deny_tags}}
 						{{include file="field_input.tpl" field=$relay_max_tags}}
 						{{include file="field_checkbox.tpl" field=$relay_user_tags}}
+						{{include file="field_checkbox.tpl" field=$relay_auto_subscribe_tags}}
 						{{include file="field_checkbox.tpl" field=$relay_directly}}
 						{{include file="field_checkbox.tpl" field=$relay_deny_undetected_language}}
 						{{include file="field_input.tpl" field=$relay_language_quality}}

--- a/view/theme/frio/templates/settings/account.tpl
+++ b/view/theme/frio/templates/settings/account.tpl
@@ -88,7 +88,10 @@
 						{{include file="field_checkbox.tpl" field=$profile_in_net_dir}}
 						{{if not $is_community}}{{include file="field_checkbox.tpl" field=$hide_friends}}{{/if}}
 						{{include file="field_checkbox.tpl" field=$hide_wall}}
-						{{if not $is_community}}{{include file="field_checkbox.tpl" field=$unlisted}}{{/if}}
+						{{if not $is_community}}
+						{{include file="field_checkbox.tpl" field=$unlisted}}
+						{{include file="field_checkbox.tpl" field=$prevent_relay}}
+						{{/if}}
 						{{include file="field_checkbox.tpl" field=$accessiblephotos}}
 						{{if not $is_community}}
 						{{include file="field_checkbox.tpl" field=$blockwall}}


### PR DESCRIPTION
This PR adds bidirectional support for the services https://tags.pub which is a relay service that is focussed on tags. This PR consists of multiple parts:

- the system will now follow (and unfollow) all hashtags that users on the system subscribed to, including the hashtags that are configured in the site configuration. User hashtags are followed if the corresponding setup is activated.
- The tags.pub service is added to the list of relay servers, so that public posts can be distributed by that service as well
- tags.pub is marked as "relay" service. This means that users can't subscribe to this service by their own (they don't need to, they simply have to subscribe to a hashtag to do the same) and the "announce" messages of this services aren't displayed to the user, so they won't be annoyed by this.

There is a corresponding PR in the addons that adds `tags.pub` to the list of social media services in the blockbot addon: https://git.friendi.ca/friendica/friendica-addons/pulls/1662