### PR TITLE
Moderation: Fix missing account/page icons, reduce logic duplication

### DIFF
--- a/src/Module/Moderation/BaseUsers.php
+++ b/src/Module/Moderation/BaseUsers.php
@@ -132,23 +132,24 @@ abstract class BaseUsers extends BaseModeration
 		$adminlist = User::getAdminEmailList();
 		return function ($user) use ($adminlist) {
 			$page_types = [
-				User::PAGE_FLAGS_NORMAL    => $this->t('Normal Account Page'),
-				User::PAGE_FLAGS_SOAPBOX   => $this->t('Soapbox Page'),
-				User::PAGE_FLAGS_COMMUNITY => $this->t('Public Group'),
-				User::PAGE_FLAGS_COMM_MAN  => $this->t('Public Group - Restricted'),
-				User::PAGE_FLAGS_FREELOVE  => $this->t('Automatic Friend Page'),
-				User::PAGE_FLAGS_PRVGROUP  => $this->t('Private Group'),
+				// NOTE: Currently no PAGE_FLAGS_BLOG here, unlike Model/User.php?
+				User::PAGE_FLAGS_NORMAL    => [$this->t('Normal Account Page'), "ri-user-line"],
+				User::PAGE_FLAGS_SOAPBOX   => [$this->t('Soapbox Page'), "ri-megaphone-line"],
+				User::PAGE_FLAGS_COMMUNITY => [$this->t('Public Group'), "ri-team-line"],
+				User::PAGE_FLAGS_COMM_MAN  => [$this->t('Public Group - Restricted', "ri-team-line")],
+				User::PAGE_FLAGS_FREELOVE  => [$this->t('Automatic Friend Page'), "ri-heart-line"],
+				User::PAGE_FLAGS_PRVGROUP  => [$this->t('Private Group'), "ri-spy-line"],
 			];
 			$account_types = [
-				User::ACCOUNT_TYPE_PERSON       => $this->t('Personal Page'),
-				User::ACCOUNT_TYPE_ORGANISATION => $this->t('Organisation Page'),
-				User::ACCOUNT_TYPE_NEWS         => $this->t('News Page'),
-				User::ACCOUNT_TYPE_COMMUNITY    => $this->t('Community Group'),
-				User::ACCOUNT_TYPE_RELAY        => $this->t('Relay'),
+				User::ACCOUNT_TYPE_PERSON       => [$this->t('Personal Page'), ""],
+				User::ACCOUNT_TYPE_ORGANISATION => [$this->t('Organisation Page'), "ri-node-tree"],
+				User::ACCOUNT_TYPE_NEWS         => [$this->t('News Page'), "ri-newspaper-line"],
+				User::ACCOUNT_TYPE_COMMUNITY    => [$this->t('Community Group'), "ri-chat-3-line"],
+				User::ACCOUNT_TYPE_RELAY        => [$this->t('Relay'), ""],
 			];
 
 			$user['page_flags_raw'] = $user['page-flags'];
-			$user['page_flags']     = $page_types[$user['page-flags']];
+			$user['page_type']      = $page_types[$user['page-flags']];
 
 			$user['account_type_raw'] = ($user['page_flags_raw'] == 0) ? $user['account-type'] : -1;
 			$user['account_type']     = ($user['page_flags_raw'] == 0) ? $account_types[$user['account-type']] : '';

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.08-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-06 15:44+0200\n"
+"POT-Creation-Date: 2026-06-07 18:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2902,7 +2902,7 @@ msgstr ""
 msgid "Group"
 msgstr ""
 
-#: src/Model/Contact.php:1797 src/Module/Moderation/BaseUsers.php:147
+#: src/Model/Contact.php:1797 src/Module/Moderation/BaseUsers.php:148
 msgid "Relay"
 msgstr ""
 
@@ -7476,49 +7476,49 @@ msgstr ""
 msgid "List of pending user deletions"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:135 src/Module/Settings/Account.php:432
+#: src/Module/Moderation/BaseUsers.php:136 src/Module/Settings/Account.php:432
 msgid "Normal Account Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:136 src/Module/Settings/Account.php:439
+#: src/Module/Moderation/BaseUsers.php:137 src/Module/Settings/Account.php:439
 msgid "Soapbox Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:137 src/Module/Register.php:140
+#: src/Module/Moderation/BaseUsers.php:138 src/Module/Register.php:140
 #: src/Module/Register.php:151 src/Module/Settings/Account.php:446
 msgid "Public Group"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:138 src/Module/Settings/Account.php:453
+#: src/Module/Moderation/BaseUsers.php:139 src/Module/Settings/Account.php:453
 msgid "Public Group - Restricted"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:139 src/Module/Settings/Account.php:460
+#: src/Module/Moderation/BaseUsers.php:140 src/Module/Settings/Account.php:460
 msgid "Automatic Friend Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:140 src/Module/Register.php:142
+#: src/Module/Moderation/BaseUsers.php:141 src/Module/Register.php:142
 #: src/Module/Register.php:153
 msgid "Private Group"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:143 src/Module/Moderation/Summary.php:37
+#: src/Module/Moderation/BaseUsers.php:144 src/Module/Moderation/Summary.php:37
 #: src/Module/Settings/Account.php:403
 msgid "Personal Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:144 src/Module/Moderation/Summary.php:38
+#: src/Module/Moderation/BaseUsers.php:145 src/Module/Moderation/Summary.php:38
 #: src/Module/Settings/Account.php:410
 msgid "Organisation Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:145 src/Module/Moderation/Summary.php:39
+#: src/Module/Moderation/BaseUsers.php:146 src/Module/Moderation/Summary.php:39
 #: src/Module/Register.php:139 src/Module/Register.php:160
 #: src/Module/Settings/Account.php:417
 msgid "News Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:146 src/Module/Moderation/Summary.php:40
+#: src/Module/Moderation/BaseUsers.php:147 src/Module/Moderation/Summary.php:40
 #: src/Module/Settings/Account.php:424
 msgid "Community Group"
 msgstr ""

--- a/view/templates/moderation/users/active.tpl
+++ b/view/templates/moderation/users/active.tpl
@@ -56,7 +56,7 @@
 					<td class="register_date">{{$u.register_date}}</td>
 					<td class="login_date">{{$u.login_date}}</td>
 					<td class="lastitem_date">{{$u.lastitem_date}}</td>
-					<td class="login_date">{{$u.page_flags}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}} {{if $u.blocked}}{{$blocked}}{{/if}}</td>
+					<td class="login_date">{{$u.page_type.0}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}} {{if $u.blocked}}{{$blocked}}{{/if}}</td>
 					<td class="checkbox">
 						{{if $u.is_deletable}}
 						<input type="checkbox" class="users_ckbx" id="id_user_{{$u.uid}}" name="user[]" value="{{$u.uid}}"/>

--- a/view/templates/moderation/users/blocked.tpl
+++ b/view/templates/moderation/users/blocked.tpl
@@ -57,7 +57,7 @@
 					<td class="register_date">{{$u.register_date}}</td>
 					<td class="login_date">{{$u.login_date}}</td>
 					<td class="lastitem_date">{{$u.lastitem_date}}</td>
-					<td class="login_date">{{$u.page_flags}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}} {{if $u.blocked}}{{$blocked}}{{/if}}</td>
+					<td class="login_date">{{$u.page_type.0}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}} {{if $u.blocked}}{{$blocked}}{{/if}}</td>
 					<td class="checkbox">
 						{{if $u.is_deletable}}
 						<input type="checkbox" class="users_ckbx" id="id_user_{{$u.uid}}" name="user[]" value="{{$u.uid}}"/>

--- a/view/templates/moderation/users/index.tpl
+++ b/view/templates/moderation/users/index.tpl
@@ -56,7 +56,7 @@
 					<td class="register_date">{{$u.register_date}}</td>
 					<td class="login_date">{{$u.login_date}}</td>
 					<td class="lastitem_date">{{$u.lastitem_date}}</td>
-					<td class="login_date">{{$u.page_flags}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}} {{if $u.blocked}}{{$blocked}}{{/if}}</td>
+					<td class="login_date">{{$u.page_type.0}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}} {{if $u.blocked}}{{$blocked}}{{/if}}</td>create
 					<td class="checkbox">
 						{{if $u.is_deletable}}
 						<input type="checkbox" class="users_ckbx" id="id_user_{{$u.uid}}" name="user[]" value="{{$u.uid}}"/>

--- a/view/theme/frio/templates/moderation/users/active.tpl
+++ b/view/theme/frio/templates/moderation/users/active.tpl
@@ -75,23 +75,9 @@
 
 				{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 					<td>
-						<i class="ri
-							{{if $u.page_flags_raw==0}}ri-user-line{{/if}}		{{* PAGE_NORMAL *}}
-							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PAGE_SOAPBOX *}}
-							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		{{* PAGE_COMMUNITY *}}
-							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		{{* PAGE_FREELOVE *}}
-							{{if $u.page_flags_raw==4}}ri-broadcast-line{{/if}}		{{* PAGE_BLOG *}}
-							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	{{* PAGE_PRVGROUP *}}
-							{{if $u.page_flags_raw==6}}ri-team-line{{/if}}		{{* PAGE_COMM_MAN *}}
-							" title="{{$u.page_flags}}">
-						</i>
+						<i class="ri {{$u.page_type.1}}" title="{{$u.page_type.0}}"></i>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
-						<i class="ri
-							{{if $u.account_type_raw==1}}ri-node-tree{{/if}}		{{* ACCOUNT_TYPE_ORGANISATION *}}
-							{{if $u.account_type_raw==2}}ri-newspaper-line{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
-							{{if $u.account_type_raw==3}}ri-chat-3-line{{/if}}		{{* ACCOUNT_TYPE_COMMUNITY *}}
-							" title="{{$u.account_type}}">
-						</i>
+							<i class="ri {{$u.account_type.1" title"{{u.account_type.0}}"></i>
 						{{/if}}
 						{{if $u.is_admin}}<i class="ri ri-spy-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
 						{{if $u.account_expired}}<i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i>{{/if}}
@@ -129,7 +115,7 @@
 					{{if in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 						<p>
 							<a href="{{$baseurl}}/moderation/users/active?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.5.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.5.0}}</a> : {{$u.page_flags}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
+								&#8597; {{$th_users.5.0}}</a> : {{$u.page_type.0}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type.0}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
 						</p>
 					{{/if}}
 

--- a/view/theme/frio/templates/moderation/users/blocked.tpl
+++ b/view/theme/frio/templates/moderation/users/blocked.tpl
@@ -74,24 +74,11 @@
 
 				{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 					<td>
-						<i class="ri
-							{{if $u.page_flags_raw==0}}ri-user-line{{/if}}		{{* PAGE_NORMAL *}}
-							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PAGE_SOAPBOX *}}
-							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		{{* PAGE_COMMUNITY *}}
-							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		{{* PAGE_FREELOVE *}}
-							{{if $u.page_flags_raw==4}}ri-broadcast-line{{/if}}		{{* PAGE_BLOG *}}
-							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	{{* PAGE_PRVGROUP *}}
-							{{if $u.page_flags_raw==6}}ri-team-line{{/if}}		{{* PAGE_COMM_MAN *}}
-								" title="{{$u.page_flags}}">
-						</i>
+						<i class="ri {{$u.page_type.1}}" title="{{$u.page_type.0}}"></i>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
-						<i class="ri
-							{{if $u.account_type_raw==1}}ri-node-tree{{/if}}		{{* ACCOUNT_TYPE_ORGANISATION *}}
-							{{if $u.account_type_raw==2}}ri-newspaper-line{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
-							{{if $u.account_type_raw==3}}ri-chat-3-line{{/if}}		{{* ACCOUNT_TYPE_COMMUNITY *}}
-							" title="{{$u.account_type}}">
-						</i>
+							<i class="ri {{$u.account_type.1}}" title"{{u.account_type.0}}"></i>
 						{{/if}}
+						{{# NOTE: No u.deleted below here? #}}
 						{{if $u.is_admin}}<i class="ri ri-spy-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
 						{{if $u.blocked}}<i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i>{{/if}}
 						{{if $u.account_expired}}<i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i>{{/if}}
@@ -129,7 +116,7 @@
 					{{if in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 						<p>
 							<a href="{{$baseurl}}/moderation/users/blocked?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.5.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.5.0}}</a> : {{$u.page_flags}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
+								&#8597; {{$th_users.5.0}}</a> : {{$u.page_type.0}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type.0}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
 						</p>
 					{{/if}}
 

--- a/view/theme/frio/templates/moderation/users/index.tpl
+++ b/view/theme/frio/templates/moderation/users/index.tpl
@@ -75,23 +75,9 @@
 
 				{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 					<td>
-						<i class="ri
-							{{if $u.page_flags_raw==0}}ri-user-line{{/if}}		{{* PAGE_NORMAL *}}
-							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PAGE_SOAPBOX *}}
-							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		{{* PAGE_COMMUNITY *}}
-							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		{{* PAGE_FREELOVE *}}
-							{{if $u.page_flags_raw==4}}ri-broadcast-line{{/if}}		{{* PAGE_BLOG *}}
-							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	{{* PAGE_PRVGROUP *}}
-							{{if $u.page_flags_raw==6}}ri-team-line{{/if}}		{{* PAGE_COMM_MAN *}}
-							" title="{{$u.page_flags}}">
-						</i>
+						<i class="ri {{$u.page_type.1}}" title="{{$u.page_type.0}}"></i>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
-						<i class="ri
-							{{if $u.account_type_raw==1}}ri-node-tree{{/if}}		{{* ACCOUNT_TYPE_ORGANISATION *}}
-							{{if $u.account_type_raw==2}}ri-newspaper-line{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
-							{{if $u.account_type_raw==3}}ri-chat-3-line{{/if}}		{{* ACCOUNT_TYPE_COMMUNITY *}}
-							" title="{{$u.account_type}}">
-						</i>
+							<i class="ri {{$u.account_type.1}}" title"{{$u.account_type.0}}"></i>
 						{{/if}}
 						{{if $u.is_admin}}<i class="ri ri-spy-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
 						{{if $u.blocked}}<i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i>{{/if}}
@@ -131,7 +117,7 @@
 					{{if in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 						<p>
 							<a href="{{$baseurl}}/moderation/users/?o={{if $order_direction_users == "+"}}-{{/if}}{{$th_users.5.1}}" class="btn-link table-order">
-								&#8597; {{$th_users.5.0}}</a> : {{$u.page_flags}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
+								&#8597; {{$th_users.5.0}}</a> : {{$u.page_type.0}}{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}, {{$u.account_type.0}}{{/if}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}}
 						</p>
 					{{/if}}
 


### PR DESCRIPTION
Might close #15837 unless the icons are missing in more places?

- Fix missing icons in the moderation settings
- Centrally define the icons so they don't go out of sync and to reduce template logic duplication - especially now Frio and Vier are using the same icons

An even better solution IMO would be to move both the icon textual representation and the icon to User/Model.php, so Moderation/BaseUsers fetches them from there, instead of redefining them. If this was done really well we could update e.g. the text or icon in a single place, and it would be changed everywhere where the account type is listed/named.

<img width="667" height="717" alt="image" src="https://github.com/user-attachments/assets/c36afd89-7815-4eae-a33c-6dbb0949c7e4" />