### PR TITLE
Replace Hooks with EventDispatcher Part 4

### DIFF
--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -10,7 +10,6 @@ namespace Friendica;
 use Friendica\App\Router;
 use Friendica\Capabilities\ICanHandleRequests;
 use Friendica\Capabilities\ICanCreateResponses;
-use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\System;
 use Friendica\Event\ModuleContentEvent;
@@ -52,7 +51,7 @@ abstract class BaseModule implements ICanHandleRequests
 	protected $server;
 	/** @var ICanCreateResponses */
 	protected $response;
-	private EventDispatcherInterface $eventDispatcher;
+	private readonly EventDispatcherInterface $eventDispatcher;
 
 	public function __construct(L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [], ?EventDispatcherInterface $eventDispatcher = null)
 	{
@@ -212,7 +211,7 @@ abstract class BaseModule implements ICanHandleRequests
 		$timestamp = microtime(true);
 
 		$this->eventDispatcher->dispatch(
-			new ModuleInitEvent(ModuleInitEvent::MODULE_INIT, $this->args->getModuleName(), static::class)
+			new ModuleInitEvent(ModuleInitEvent::MODULE_INIT, $this->args->getModuleName(), static::class),
 		);
 
 		$this->profiler->set(microtime(true) - $timestamp, 'init');
@@ -226,7 +225,7 @@ abstract class BaseModule implements ICanHandleRequests
 				break;
 			case Router::POST:
 				$request = $this->eventDispatcher->dispatch(
-					new ModulePostEvent(ModulePostEvent::MODULE_POST, $this->args->getModuleName(), static::class, $request)
+					new ModulePostEvent(ModulePostEvent::MODULE_POST, $this->args->getModuleName(), static::class, $request),
 				)->getPost();
 
 				$this->post($request);
@@ -247,7 +246,7 @@ abstract class BaseModule implements ICanHandleRequests
 
 		try {
 			$content = $this->eventDispatcher->dispatch(
-				new ModuleContentEvent(ModuleContentEvent::MODULE_CONTENT, $this->args->getModuleName(), static::class, '')
+				new ModuleContentEvent(ModuleContentEvent::MODULE_CONTENT, $this->args->getModuleName(), static::class, ''),
 			)->getContent();
 			$this->response->addContent($content);
 			$this->response->addContent($this->content($request));

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -13,11 +13,15 @@ use Friendica\Capabilities\ICanCreateResponses;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\System;
+use Friendica\Event\ModuleContentEvent;
+use Friendica\Event\ModuleInitEvent;
+use Friendica\Event\ModulePostEvent;
 use Friendica\Model\User;
 use Friendica\Module\Response;
 use Friendica\Module\Special\HTTPException as ModuleHTTPException;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Profiler;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
@@ -48,17 +52,19 @@ abstract class BaseModule implements ICanHandleRequests
 	protected $server;
 	/** @var ICanCreateResponses */
 	protected $response;
+	private EventDispatcherInterface $eventDispatcher;
 
-	public function __construct(L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [], ?EventDispatcherInterface $eventDispatcher = null)
 	{
-		$this->parameters = $parameters;
-		$this->l10n       = $l10n;
-		$this->baseUrl    = $baseUrl;
-		$this->args       = $args;
-		$this->logger     = $logger;
-		$this->profiler   = $profiler;
-		$this->server     = $server;
-		$this->response   = $response;
+		$this->parameters      = $parameters;
+		$this->l10n            = $l10n;
+		$this->baseUrl         = $baseUrl;
+		$this->args            = $args;
+		$this->logger          = $logger;
+		$this->profiler        = $profiler;
+		$this->server          = $server;
+		$this->response        = $response;
+		$this->eventDispatcher = $eventDispatcher ?? DI::eventDispatcher();
 	}
 
 	/**
@@ -202,12 +208,12 @@ abstract class BaseModule implements ICanHandleRequests
 			$this->response->setHeader('false', 'Access-Control-Allow-Credentials');
 		}
 
-		$placeholder = '';
-
 		$this->profiler->set(microtime(true), 'ready');
 		$timestamp = microtime(true);
 
-		Core\Hook::callAll($this->args->getModuleName() . '_mod_init', $placeholder);
+		$this->eventDispatcher->dispatch(
+			new ModuleInitEvent(ModuleInitEvent::MODULE_INIT, $this->args->getModuleName(), static::class)
+		);
 
 		$this->profiler->set(microtime(true) - $timestamp, 'init');
 
@@ -219,7 +225,10 @@ abstract class BaseModule implements ICanHandleRequests
 				$this->patch($request);
 				break;
 			case Router::POST:
-				Core\Hook::callAll($this->args->getModuleName() . '_mod_post', $request);
+				$request = $this->eventDispatcher->dispatch(
+					new ModulePostEvent(ModulePostEvent::MODULE_POST, $this->args->getModuleName(), static::class, $request)
+				)->getPost();
+
 				$this->post($request);
 				break;
 			case Router::PUT:
@@ -237,9 +246,10 @@ abstract class BaseModule implements ICanHandleRequests
 		$this->rawContent($request);
 
 		try {
-			$arr = ['content' => ''];
-			Hook::callAll(static::class . '_mod_content', $arr);
-			$this->response->addContent($arr['content']);
+			$content = $this->eventDispatcher->dispatch(
+				new ModuleContentEvent(ModuleContentEvent::MODULE_CONTENT, $this->args->getModuleName(), static::class, '')
+			)->getContent();
+			$this->response->addContent($content);
 			$this->response->addContent($this->content($request));
 		} catch (HTTPException $e) {
 			// In case of System::externalRedirects(), we don't want to prettyprint the exception

--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -82,7 +82,7 @@ class ACL
 
 		return Contact::selectToArray(
 			['id', 'name', 'addr', 'micro', 'url', 'nick'],
-			DBA::mergeConditions($condition, ["`notify` != ''"])
+			DBA::mergeConditions($condition, ["`notify` != ''"]),
 		);
 	}
 
@@ -148,9 +148,9 @@ class ACL
 				'deleted' => false,
 				'pending' => false,
 				'network' => Protocol::FEDERATED,
-				'rel'     => [Contact::FOLLOWER, Contact::FRIEND]
+				'rel'     => [Contact::FOLLOWER, Contact::FRIEND],
 			], $condition),
-			$params
+			$params,
 		);
 
 		$acl_yourself         = Contact::selectFirst($fields, ['uid' => $user_id, 'self' => true]);
@@ -162,7 +162,7 @@ class ACL
 			$fields,
 			['uid'     => $user_id, 'self' => false, 'blocked' => false, 'archive' => false, 'deleted' => false,
 				'network' => Protocol::FEDERATED, 'pending' => false, 'contact-type' => Contact::TYPE_COMMUNITY],
-			$params
+			$params,
 		);
 
 		$acl_contacts = array_merge($acl_groups, $acl_contacts);
@@ -196,7 +196,7 @@ class ACL
 				'addr'  => '',
 				'micro' => 'images/twopeople.png',
 				'type'  => 'circle',
-			]
+			],
 		];
 		foreach (Circle::getByUserId($user_id) as $circle) {
 			$acl_circles[] = [
@@ -235,7 +235,7 @@ class ACL
 		bool $for_federation = false,
 		array $default_permissions = [],
 		array $condition = [],
-		$form_prefix = ''
+		$form_prefix = '',
 	) {
 		if (empty($uid)) {
 			return '';
@@ -285,8 +285,8 @@ class ACL
 						'field' => [
 							'pubmail_enable',
 							DI::l10n()->t('Post to Email'),
-							!empty($mailacct['pubmail'])
-						]
+							!empty($mailacct['pubmail']),
+						],
 					];
 
 				}

--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -12,6 +12,7 @@ use Friendica\App\Page;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Event\ArrayFilterEvent;
+use Friendica\Event\ModulePostRecipientEvent;
 use Friendica\Model\Contact;
 use Friendica\Model\Circle;
 use Friendica\Model\User;
@@ -59,7 +60,9 @@ class ACL
 			'$selected'      => $selected,
 		]);
 
-		Hook::callAll(DI::args()->getModuleName() . '_post_recipient', $o);
+		$o = DI::eventDispatcher()->dispatch(
+			new ModulePostRecipientEvent(ModulePostRecipientEvent::MODULE_POST_RECIPIENT, DI::args()->getModuleName(), DI::router()->getModuleClass(), $o),
+		)->getHtml();
 
 		return $o;
 	}

--- a/src/Core/Hooks/HookEventBridge.php
+++ b/src/Core/Hooks/HookEventBridge.php
@@ -18,6 +18,7 @@ use Friendica\Event\HtmlFilterEvent;
 use Friendica\Event\ModuleContentEvent;
 use Friendica\Event\ModuleInitEvent;
 use Friendica\Event\ModulePostEvent;
+use Friendica\Event\ModulePostRecipientEvent;
 use Friendica\Event\NamedEvent;
 
 /**
@@ -221,6 +222,7 @@ final class HookEventBridge
 			ModuleInitEvent::MODULE_INIT                      => 'onModuleInitEvent',
 			ModulePostEvent::MODULE_POST                      => 'onModulePostEvent',
 			ModuleContentEvent::MODULE_CONTENT                => 'onModuleContentEvent',
+			ModulePostRecipientEvent::MODULE_POST_RECIPIENT   => 'onModulePostRecipientEvent',
 		];
 	}
 
@@ -465,6 +467,13 @@ final class HookEventBridge
 		$arr = ['content' => $event->getContent()];
 		$arr = static::callHook($event->getModuleClass() . '_mod_content', $arr);
 		$event->setContent($arr['content']);
+	}
+
+	public static function onModulePostRecipientEvent(ModulePostRecipientEvent $event): void
+	{
+		$event->setHtml(
+			static::callHook($event->getModuleName() . '_post_recipient', $event->getHtml())
+		);
 	}
 
 	/**

--- a/src/Core/Hooks/HookEventBridge.php
+++ b/src/Core/Hooks/HookEventBridge.php
@@ -472,7 +472,7 @@ final class HookEventBridge
 	public static function onModulePostRecipientEvent(ModulePostRecipientEvent $event): void
 	{
 		$event->setHtml(
-			static::callHook($event->getModuleName() . '_post_recipient', $event->getHtml())
+			static::callHook($event->getModuleName() . '_post_recipient', $event->getHtml()),
 		);
 	}
 

--- a/src/Core/Hooks/HookEventBridge.php
+++ b/src/Core/Hooks/HookEventBridge.php
@@ -15,6 +15,9 @@ use Friendica\Event\CollectRoutesEvent;
 use Friendica\Event\ConfigLoadedEvent;
 use Friendica\Event\Event;
 use Friendica\Event\HtmlFilterEvent;
+use Friendica\Event\ModuleContentEvent;
+use Friendica\Event\ModuleInitEvent;
+use Friendica\Event\ModulePostEvent;
 use Friendica\Event\NamedEvent;
 
 /**
@@ -215,6 +218,9 @@ final class HookEventBridge
 			HtmlFilterEvent::MOD_PROFILE_CONTENT              => 'onHtmlFilterEvent',
 			HtmlFilterEvent::JOT_TOOL                         => 'onHtmlFilterEvent',
 			HtmlFilterEvent::CONTACT_BLOCK_END                => 'onHtmlFilterEvent',
+			ModuleInitEvent::MODULE_INIT                      => 'onModuleInitEvent',
+			ModulePostEvent::MODULE_POST                      => 'onModulePostEvent',
+			ModuleContentEvent::MODULE_CONTENT                => 'onModuleContentEvent',
 		];
 	}
 
@@ -440,6 +446,25 @@ final class HookEventBridge
 		$event->setHtml(
 			static::callHook($event->getName(), $event->getHtml())
 		);
+	}
+
+	public static function onModuleInitEvent(ModuleInitEvent $event): void
+	{
+		static::callHook($event->getModuleName() . '_mod_init', '');
+	}
+
+	public static function onModulePostEvent(ModulePostEvent $event): void
+	{
+		$event->setPost(
+			static::callHook($event->getModuleName() . '_mod_post', $event->getPost())
+		);
+	}
+
+	public static function onModuleContentEvent(ModuleContentEvent $event): void
+	{
+		$arr = ['content' => $event->getContent()];
+		$arr = static::callHook($event->getModuleClass() . '_mod_content', $arr);
+		$event->setContent($arr['content']);
 	}
 
 	/**

--- a/src/Core/Hooks/HookEventBridge.php
+++ b/src/Core/Hooks/HookEventBridge.php
@@ -237,7 +237,7 @@ final class HookEventBridge
 	public static function onCollectRoutesEvent(CollectRoutesEvent $event): void
 	{
 		$event->setRouteCollector(
-			static::callHook($event->getName(), $event->getRouteCollector())
+			static::callHook($event->getName(), $event->getRouteCollector()),
 		);
 	}
 
@@ -437,14 +437,14 @@ final class HookEventBridge
 	public static function onArrayFilterEvent(ArrayFilterEvent $event): void
 	{
 		$event->setArray(
-			static::callHook($event->getName(), $event->getArray())
+			static::callHook($event->getName(), $event->getArray()),
 		);
 	}
 
 	public static function onHtmlFilterEvent(HtmlFilterEvent $event): void
 	{
 		$event->setHtml(
-			static::callHook($event->getName(), $event->getHtml())
+			static::callHook($event->getName(), $event->getHtml()),
 		);
 	}
 
@@ -456,7 +456,7 @@ final class HookEventBridge
 	public static function onModulePostEvent(ModulePostEvent $event): void
 	{
 		$event->setPost(
-			static::callHook($event->getModuleName() . '_mod_post', $event->getPost())
+			static::callHook($event->getModuleName() . '_mod_post', $event->getPost()),
 		);
 	}
 

--- a/src/Event/ModuleContentEvent.php
+++ b/src/Event/ModuleContentEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Event;
+
+/**
+ * Allow modules to react on content rendering.
+ *
+ * @internal
+ */
+final class ModuleContentEvent extends Event
+{
+	public const MODULE_CONTENT = 'friendica.module_content';
+
+	/**
+	 * @param class-string<\Friendica\BaseModule> $moduleClass
+	 */
+	public function __construct(string $name, private readonly string $moduleName, private readonly string $moduleClass, private string $content)
+	{
+		parent::__construct($name);
+	}
+
+	public function getModuleName(): string
+	{
+		return $this->moduleName;
+	}
+
+	/**
+	 * @return class-string<\Friendica\BaseModule>
+	 */
+	public function getModuleClass(): string
+	{
+		return $this->moduleClass;
+	}
+
+	public function getContent(): string
+	{
+		return $this->content;
+	}
+
+	public function setContent(string $content): void
+	{
+		$this->content = $content;
+	}
+}

--- a/src/Event/ModuleInitEvent.php
+++ b/src/Event/ModuleInitEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Event;
+
+/**
+ * Allow modules to react on initialization.
+ *
+ * @internal
+ */
+final class ModuleInitEvent extends Event
+{
+	public const MODULE_INIT = 'friendica.module_init';
+
+	/**
+	 * @param class-string<\Friendica\BaseModule> $moduleClass
+	 */
+	public function __construct(string $name, private readonly string $moduleName, private readonly string $moduleClass)
+	{
+		parent::__construct($name);
+	}
+
+	public function getModuleName(): string
+	{
+		return $this->moduleName;
+	}
+
+	/**
+	 * @return class-string<\Friendica\BaseModule>
+	 */
+	public function getModuleClass(): string
+	{
+		return $this->moduleClass;
+	}
+}

--- a/src/Event/ModulePostEvent.php
+++ b/src/Event/ModulePostEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Event;
+
+/**
+ * Allow modules to react on POST requests.
+ *
+ * @internal
+ */
+final class ModulePostEvent extends Event
+{
+	public const MODULE_POST = 'friendica.module_post';
+
+	/**
+	 * @param class-string<\Friendica\BaseModule> $moduleClass
+	 */
+	public function __construct(string $name, private readonly string $moduleName, private readonly string $moduleClass, private array $post)
+	{
+		parent::__construct($name);
+	}
+
+	public function getModuleName(): string
+	{
+		return $this->moduleName;
+	}
+
+	/**
+	 * @return class-string<\Friendica\BaseModule>
+	 */
+	public function getModuleClass(): string
+	{
+		return $this->moduleClass;
+	}
+
+	public function getPost(): array
+	{
+		return $this->post;
+	}
+
+	public function setPost(array $post): void
+	{
+		$this->post = $post;
+	}
+}

--- a/src/Event/ModulePostRecipientEvent.php
+++ b/src/Event/ModulePostRecipientEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Event;
+
+/**
+ * Allow modules to react on post recipient rendering.
+ *
+ * @internal
+ */
+final class ModulePostRecipientEvent extends Event
+{
+	public const MODULE_POST_RECIPIENT = 'friendica.module_post_recipient';
+
+	/**
+	 * @param class-string<\Friendica\BaseModule> $moduleClass
+	 */
+	public function __construct(string $name, private readonly string $moduleName, private readonly string $moduleClass, private string $html)
+	{
+		parent::__construct($name);
+	}
+
+	public function getModuleName(): string
+	{
+		return $this->moduleName;
+	}
+
+	/**
+	 * @return class-string<\Friendica\BaseModule>
+	 */
+	public function getModuleClass(): string
+	{
+		return $this->moduleClass;
+	}
+
+	public function getHtml(): string
+	{
+		return $this->html;
+	}
+
+	public function setHtml(string $html): void
+	{
+		$this->html = $html;
+	}
+}

--- a/tests/Unit/Core/Hooks/HookEventBridgeTest.php
+++ b/tests/Unit/Core/Hooks/HookEventBridgeTest.php
@@ -117,7 +117,7 @@ class HookEventBridgeTest extends TestCase
 			ModuleInitEvent::MODULE_INIT                      => 'onModuleInitEvent',
 			ModulePostEvent::MODULE_POST                      => 'onModulePostEvent',
 			ModuleContentEvent::MODULE_CONTENT                => 'onModuleContentEvent',
-			ModulePostRecipientEvent::MODULE_POST_RECIPIENT  => 'onModulePostRecipientEvent',
+			ModulePostRecipientEvent::MODULE_POST_RECIPIENT   => 'onModulePostRecipientEvent',
 		];
 
 		$this->assertSame(
@@ -689,8 +689,8 @@ class HookEventBridgeTest extends TestCase
 	public static function getModulePostRecipientEventData(): array
 	{
 		return [
-			'Home'          => ['friendica.module_post_recipient', 'home_post_recipient', 'home', \Friendica\Module\Home::class],
-			'LegacyModule'  => ['friendica.module_post_recipient', 'photos_post_recipient', 'photos', \Friendica\LegacyModule::class],
+			'Home'         => ['friendica.module_post_recipient', 'home_post_recipient', 'home', \Friendica\Module\Home::class],
+			'LegacyModule' => ['friendica.module_post_recipient', 'photos_post_recipient', 'photos', \Friendica\LegacyModule::class],
 		];
 	}
 

--- a/tests/Unit/Core/Hooks/HookEventBridgeTest.php
+++ b/tests/Unit/Core/Hooks/HookEventBridgeTest.php
@@ -17,6 +17,9 @@ use Friendica\Event\CollectRoutesEvent;
 use Friendica\Event\ConfigLoadedEvent;
 use Friendica\Event\Event;
 use Friendica\Event\HtmlFilterEvent;
+use Friendica\Event\ModuleContentEvent;
+use Friendica\Event\ModuleInitEvent;
+use Friendica\Event\ModulePostEvent;
 use PHPUnit\Framework\TestCase;
 
 class HookEventBridgeTest extends TestCase
@@ -110,6 +113,9 @@ class HookEventBridgeTest extends TestCase
 			HtmlFilterEvent::MOD_PROFILE_CONTENT              => 'onHtmlFilterEvent',
 			HtmlFilterEvent::JOT_TOOL                         => 'onHtmlFilterEvent',
 			HtmlFilterEvent::CONTACT_BLOCK_END                => 'onHtmlFilterEvent',
+			ModuleInitEvent::MODULE_INIT                      => 'onModuleInitEvent',
+			ModulePostEvent::MODULE_POST                      => 'onModulePostEvent',
+			ModuleContentEvent::MODULE_CONTENT                => 'onModuleContentEvent',
 		];
 
 		$this->assertSame(
@@ -597,5 +603,84 @@ class HookEventBridgeTest extends TestCase
 		});
 
 		HookEventBridge::onHtmlFilterEvent($event);
+	}
+
+	public static function getModuleInitEventData(): array
+	{
+		return [
+			'Home'          => ['friendica.module_init', 'home_mod_init', 'home', \Friendica\Module\Home::class],
+			'LegacyModule'  => ['friendica.module_init', 'photos_mod_init', 'photos', \Friendica\LegacyModule::class],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('getModuleInitEventData')]
+	public function testOnModuleInitEventCallsHookWithCorrectValue($name, $expected, $moduleName, $moduleClass): void
+	{
+		$event = new ModuleInitEvent($name, $moduleName, $moduleClass);
+
+		$reflectionProperty = new \ReflectionProperty(HookEventBridge::class, 'mockedCallHook');
+
+		$reflectionProperty->setValue(null, function (string $name, $data) use ($expected) {
+			$this->assertSame($expected, $name);
+			$this->assertSame('', $data);
+
+			return $data;
+		});
+
+		HookEventBridge::onModuleInitEvent($event);
+	}
+
+	public static function getModulePostEventData(): array
+	{
+		return [
+			'Home'          => ['friendica.module_post', 'home_mod_post', 'home', \Friendica\Module\Home::class],
+			'LegacyModule'  => ['friendica.module_post', 'photos_mod_post', 'photos', \Friendica\LegacyModule::class],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('getModulePostEventData')]
+	public function testOnModulePostEventCallsHookWithCorrectValue($name, $expected, $moduleName, $moduleClass): void
+	{
+		$event = new ModulePostEvent($name, $moduleName, $moduleClass, ['original']);
+
+		$reflectionProperty = new \ReflectionProperty(HookEventBridge::class, 'mockedCallHook');
+
+		$reflectionProperty->setValue(null, function (string $name, $data) use ($expected) {
+			$this->assertSame($expected, $name);
+			$this->assertSame(['original'], $data);
+
+			return $data;
+		});
+
+		HookEventBridge::onModulePostEvent($event);
+	}
+
+	public static function getModuleContentEventData(): array
+	{
+		return [
+			'Home'          => ['friendica.module_content', 'Friendica\Module\Home_mod_content', 'home', \Friendica\Module\Home::class],
+			'LegacyModule'  => ['friendica.module_content', 'Friendica\LegacyModule_mod_content', 'photos', \Friendica\LegacyModule::class],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('getModuleContentEventData')]
+	public function testOnModuleContentEventCallsHookWithCorrectValue($name, $expected, $moduleName, $moduleClass): void
+	{
+		$event = new ModuleContentEvent($name, $moduleName, $moduleClass, 'original');
+
+		$reflectionProperty = new \ReflectionProperty(HookEventBridge::class, 'mockedCallHook');
+
+		$reflectionProperty->setValue(null, function (string $name, array $data) use ($expected) {
+			$this->assertSame($expected, $name);
+			$this->assertSame(['content' => 'original'], $data);
+
+			$data['content'] = 'changed';
+
+			return $data;
+		});
+
+		HookEventBridge::onModuleContentEvent($event);
+
+		$this->assertSame('changed', $event->getContent());
 	}
 }

--- a/tests/Unit/Core/Hooks/HookEventBridgeTest.php
+++ b/tests/Unit/Core/Hooks/HookEventBridgeTest.php
@@ -608,8 +608,8 @@ class HookEventBridgeTest extends TestCase
 	public static function getModuleInitEventData(): array
 	{
 		return [
-			'Home'          => ['friendica.module_init', 'home_mod_init', 'home', \Friendica\Module\Home::class],
-			'LegacyModule'  => ['friendica.module_init', 'photos_mod_init', 'photos', \Friendica\LegacyModule::class],
+			'Home'         => ['friendica.module_init', 'home_mod_init', 'home', \Friendica\Module\Home::class],
+			'LegacyModule' => ['friendica.module_init', 'photos_mod_init', 'photos', \Friendica\LegacyModule::class],
 		];
 	}
 
@@ -633,8 +633,8 @@ class HookEventBridgeTest extends TestCase
 	public static function getModulePostEventData(): array
 	{
 		return [
-			'Home'          => ['friendica.module_post', 'home_mod_post', 'home', \Friendica\Module\Home::class],
-			'LegacyModule'  => ['friendica.module_post', 'photos_mod_post', 'photos', \Friendica\LegacyModule::class],
+			'Home'         => ['friendica.module_post', 'home_mod_post', 'home', \Friendica\Module\Home::class],
+			'LegacyModule' => ['friendica.module_post', 'photos_mod_post', 'photos', \Friendica\LegacyModule::class],
 		];
 	}
 
@@ -658,8 +658,8 @@ class HookEventBridgeTest extends TestCase
 	public static function getModuleContentEventData(): array
 	{
 		return [
-			'Home'          => ['friendica.module_content', 'Friendica\Module\Home_mod_content', 'home', \Friendica\Module\Home::class],
-			'LegacyModule'  => ['friendica.module_content', 'Friendica\LegacyModule_mod_content', 'photos', \Friendica\LegacyModule::class],
+			'Home'         => ['friendica.module_content', 'Friendica\Module\Home_mod_content', 'home', \Friendica\Module\Home::class],
+			'LegacyModule' => ['friendica.module_content', 'Friendica\LegacyModule_mod_content', 'photos', \Friendica\LegacyModule::class],
 		];
 	}
 

--- a/tests/Unit/Core/Hooks/HookEventBridgeTest.php
+++ b/tests/Unit/Core/Hooks/HookEventBridgeTest.php
@@ -20,6 +20,7 @@ use Friendica\Event\HtmlFilterEvent;
 use Friendica\Event\ModuleContentEvent;
 use Friendica\Event\ModuleInitEvent;
 use Friendica\Event\ModulePostEvent;
+use Friendica\Event\ModulePostRecipientEvent;
 use PHPUnit\Framework\TestCase;
 
 class HookEventBridgeTest extends TestCase
@@ -116,6 +117,7 @@ class HookEventBridgeTest extends TestCase
 			ModuleInitEvent::MODULE_INIT                      => 'onModuleInitEvent',
 			ModulePostEvent::MODULE_POST                      => 'onModulePostEvent',
 			ModuleContentEvent::MODULE_CONTENT                => 'onModuleContentEvent',
+			ModulePostRecipientEvent::MODULE_POST_RECIPIENT  => 'onModulePostRecipientEvent',
 		];
 
 		$this->assertSame(
@@ -682,5 +684,30 @@ class HookEventBridgeTest extends TestCase
 		HookEventBridge::onModuleContentEvent($event);
 
 		$this->assertSame('changed', $event->getContent());
+	}
+
+	public static function getModulePostRecipientEventData(): array
+	{
+		return [
+			'Home'          => ['friendica.module_post_recipient', 'home_post_recipient', 'home', \Friendica\Module\Home::class],
+			'LegacyModule'  => ['friendica.module_post_recipient', 'photos_post_recipient', 'photos', \Friendica\LegacyModule::class],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('getModulePostRecipientEventData')]
+	public function testOnModulePostRecipientEventCallsHookWithCorrectValue($name, $expected, $moduleName, $moduleClass): void
+	{
+		$event = new ModulePostRecipientEvent($name, $moduleName, $moduleClass, 'original');
+
+		$reflectionProperty = new \ReflectionProperty(HookEventBridge::class, 'mockedCallHook');
+
+		$reflectionProperty->setValue(null, function (string $name, $data) use ($expected) {
+			$this->assertSame($expected, $name);
+			$this->assertSame('original', $data);
+
+			return $data;
+		});
+
+		HookEventBridge::onModulePostRecipientEvent($event);
 	}
 }

--- a/tests/Unit/Event/ModuleContentEventTest.php
+++ b/tests/Unit/Event/ModuleContentEventTest.php
@@ -1,0 +1,74 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Unit\Event;
+
+use Friendica\Event\ModuleContentEvent;
+use Friendica\Event\NamedEvent;
+use PHPUnit\Framework\TestCase;
+
+class ModuleContentEventTest extends TestCase
+{
+	public function testImplementationOfInstances(): void
+	{
+		$event = new ModuleContentEvent('test', 'moduleName', \stdClass::class, 'content');
+
+		$this->assertInstanceOf(NamedEvent::class, $event);
+	}
+
+	public static function getPublicConstants(): array
+	{
+		return [
+			[ModuleContentEvent::MODULE_CONTENT, 'friendica.module_content'],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('getPublicConstants')]
+	public function testPublicConstantsAreAvailable($value, $expected): void
+	{
+		$this->assertSame($expected, $value);
+	}
+
+	public function testGetNameReturnsName(): void
+	{
+		$event = new ModuleContentEvent('test', 'moduleName', \stdClass::class, 'content');
+
+		$this->assertSame('test', $event->getName());
+	}
+
+	public function testGetModuleNameReturnsModuleName(): void
+	{
+		$event = new ModuleContentEvent('test', 'moduleName', \stdClass::class, 'content');
+
+		$this->assertSame('moduleName', $event->getModuleName());
+	}
+
+	public function testGetModuleClassReturnsModuleClass(): void
+	{
+		$event = new ModuleContentEvent('test', 'moduleName', \stdClass::class, 'content');
+
+		$this->assertSame(\stdClass::class, $event->getModuleClass());
+	}
+
+	public function testGetContentReturnsCorrectString(): void
+	{
+		$event = new ModuleContentEvent('test', 'moduleName', \stdClass::class, 'myContent');
+
+		$this->assertSame('myContent', $event->getContent());
+	}
+
+	public function testSetContentUpdatesContent(): void
+	{
+		$event = new ModuleContentEvent('test', 'moduleName', \stdClass::class, 'oldContent');
+
+		$event->setContent('newContent');
+
+		$this->assertSame('newContent', $event->getContent());
+	}
+}

--- a/tests/Unit/Event/ModuleInitEventTest.php
+++ b/tests/Unit/Event/ModuleInitEventTest.php
@@ -1,0 +1,58 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Unit\Event;
+
+use Friendica\Event\ModuleInitEvent;
+use Friendica\Event\NamedEvent;
+use PHPUnit\Framework\TestCase;
+
+class ModuleInitEventTest extends TestCase
+{
+	public function testImplementationOfInstances(): void
+	{
+		$event = new ModuleInitEvent('test', 'moduleName', \stdClass::class);
+
+		$this->assertInstanceOf(NamedEvent::class, $event);
+	}
+
+	public static function getPublicConstants(): array
+	{
+		return [
+			[ModuleInitEvent::MODULE_INIT, 'friendica.module_init'],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('getPublicConstants')]
+	public function testPublicConstantsAreAvailable($value, $expected): void
+	{
+		$this->assertSame($expected, $value);
+	}
+
+	public function testGetNameReturnsName(): void
+	{
+		$event = new ModuleInitEvent('test', 'moduleName', \stdClass::class);
+
+		$this->assertSame('test', $event->getName());
+	}
+
+	public function testGetModuleNameReturnsModuleName(): void
+	{
+		$event = new ModuleInitEvent('test', 'moduleName', \stdClass::class);
+
+		$this->assertSame('moduleName', $event->getModuleName());
+	}
+
+	public function testGetModuleClassReturnsModuleClass(): void
+	{
+		$event = new ModuleInitEvent('test', 'moduleName', \stdClass::class);
+
+		$this->assertSame(\stdClass::class, $event->getModuleClass());
+	}
+}

--- a/tests/Unit/Event/ModulePostEventTest.php
+++ b/tests/Unit/Event/ModulePostEventTest.php
@@ -1,0 +1,78 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Unit\Event;
+
+use Friendica\Event\ModulePostEvent;
+use Friendica\Event\NamedEvent;
+use PHPUnit\Framework\TestCase;
+
+class ModulePostEventTest extends TestCase
+{
+	public function testImplementationOfInstances(): void
+	{
+		$event = new ModulePostEvent('test', 'moduleName', \stdClass::class, []);
+
+		$this->assertInstanceOf(NamedEvent::class, $event);
+	}
+
+	public static function getPublicConstants(): array
+	{
+		return [
+			[ModulePostEvent::MODULE_POST, 'friendica.module_post'],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('getPublicConstants')]
+	public function testPublicConstantsAreAvailable($value, $expected): void
+	{
+		$this->assertSame($expected, $value);
+	}
+
+	public function testGetNameReturnsName(): void
+	{
+		$event = new ModulePostEvent('test', 'moduleName', \stdClass::class, []);
+
+		$this->assertSame('test', $event->getName());
+	}
+
+	public function testGetModuleNameReturnsModuleName(): void
+	{
+		$event = new ModulePostEvent('test', 'moduleName', \stdClass::class, []);
+
+		$this->assertSame('moduleName', $event->getModuleName());
+	}
+
+	public function testGetModuleClassReturnsModuleClass(): void
+	{
+		$event = new ModulePostEvent('test', 'moduleName', \stdClass::class, []);
+
+		$this->assertSame(\stdClass::class, $event->getModuleClass());
+	}
+
+	public function testGetPostReturnsCorrectArray(): void
+	{
+		$post = ['key' => 'value'];
+
+		$event = new ModulePostEvent('test', 'moduleName', \stdClass::class, $post);
+
+		$this->assertSame($post, $event->getPost());
+	}
+
+	public function testSetPostUpdatesPost(): void
+	{
+		$event = new ModulePostEvent('test', 'moduleName', \stdClass::class, ['key' => 'value']);
+
+		$newPost = ['key2' => 'value2'];
+
+		$event->setPost($newPost);
+
+		$this->assertSame($newPost, $event->getPost());
+	}
+}

--- a/tests/Unit/Event/ModulePostRecipientEventTest.php
+++ b/tests/Unit/Event/ModulePostRecipientEventTest.php
@@ -1,0 +1,74 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Unit\Event;
+
+use Friendica\Event\ModulePostRecipientEvent;
+use Friendica\Event\NamedEvent;
+use PHPUnit\Framework\TestCase;
+
+class ModulePostRecipientEventTest extends TestCase
+{
+	public function testImplementationOfInstances(): void
+	{
+		$event = new ModulePostRecipientEvent('test', 'moduleName', \stdClass::class, 'html');
+
+		$this->assertInstanceOf(NamedEvent::class, $event);
+	}
+
+	public static function getPublicConstants(): array
+	{
+		return [
+			[ModulePostRecipientEvent::MODULE_POST_RECIPIENT, 'friendica.module_post_recipient'],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('getPublicConstants')]
+	public function testPublicConstantsAreAvailable($value, $expected): void
+	{
+		$this->assertSame($expected, $value);
+	}
+
+	public function testGetNameReturnsName(): void
+	{
+		$event = new ModulePostRecipientEvent('test', 'moduleName', \stdClass::class, 'html');
+
+		$this->assertSame('test', $event->getName());
+	}
+
+	public function testGetModuleNameReturnsModuleName(): void
+	{
+		$event = new ModulePostRecipientEvent('test', 'moduleName', \stdClass::class, 'html');
+
+		$this->assertSame('moduleName', $event->getModuleName());
+	}
+
+	public function testGetModuleClassReturnsModuleClass(): void
+	{
+		$event = new ModulePostRecipientEvent('test', 'moduleName', \stdClass::class, 'html');
+
+		$this->assertSame(\stdClass::class, $event->getModuleClass());
+	}
+
+	public function testGetHtmlReturnsCorrectString(): void
+	{
+		$event = new ModulePostRecipientEvent('test', 'moduleName', \stdClass::class, 'myHtml');
+
+		$this->assertSame('myHtml', $event->getHtml());
+	}
+
+	public function testSetHtmlUpdatesHtml(): void
+	{
+		$event = new ModulePostRecipientEvent('test', 'moduleName', \stdClass::class, 'oldHtml');
+
+		$event->setHtml('newHtml');
+
+		$this->assertSame('newHtml', $event->getHtml());
+	}
+}


### PR DESCRIPTION
This is a follow up PR of #14853 and replaces more calls of `Hook::callAll()` with the new EventDispatcher. This time I create events for the dynamic module hooks:

- `<module>_mod_init` -> ModuleInitEvent
- `<module>_mod_post` -> ModulePostEvent
- `<module>_mod_content` -> ModuleContentEvent
- `<module>_post_recipient` -> ModulePostRecipientEvent

Part of #14535