### PR TITLE
fix missing relation icons

### DIFF
--- a/view/templates/sub/direction.tpl
+++ b/view/templates/sub/direction.tpl
@@ -8,25 +8,25 @@
 <span class="direction">
 	&bull;
 	{{if $direction.direction == 1}}
-		<i class="icon-inbox" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="ri ri-inbox-line" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 2}}
-		<i class="icon-download" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="ri ri-download-line" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 3}}
-		<i class="icon-retweet" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="ri ri-repeat-line" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 4}}
-		<i class="icon-tag" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="ri ri-hashtag" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 5}}
-		<i class="icon-commenting" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="ri ri-chat-1-line" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 6}}
-		<i class="icon-user" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="ri ri-user-line" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 7}}
-		<i class="icon-forward" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="ri ri-at-line" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 8}}
-		<i class="icon-share" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="ri ri-save-line" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 9}}
-		<i class="icon-globe" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="ri ri-server-line" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{elseif $direction.direction == 10}}
-		<i class="icon-inbox" aria-hidden="true" title="{{$direction.title}}"></i>
+		<i class="ri ri-broadcast-line" aria-hidden="true" title="{{$direction.title}}"></i>
 	{{/if}}
 </span>
 {{/if}}


### PR DESCRIPTION
This adds the relation/direction icons back to the vier theme that went missing with the switch to the remix icons