### PR TITLE
Show profile hashtags on hovercards

### DIFF
--- a/src/Content/Widget/Hovercard.php
+++ b/src/Content/Widget/Hovercard.php
@@ -32,8 +32,8 @@ class Hovercard
 			$actions = [];
 		}
 
+		$tags = [];
 		if ($contact['keywords']) {
-			$tags = [];
 			// Separator is defined in Module\Settings\Profile\Index::cleanKeywords
 			foreach (explode(', ', (string) $contact['keywords']) as $tag_label) {
 				$tags[] = [

--- a/src/Content/Widget/Hovercard.php
+++ b/src/Content/Widget/Hovercard.php
@@ -12,6 +12,7 @@ use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Strings;
+use Friendica\Model\Tag;
 
 class Hovercard
 {
@@ -31,6 +32,17 @@ class Hovercard
 			$actions = [];
 		}
 
+		if ($contact['keywords']) {
+			$tags = [];
+			// Separator is defined in Module\Settings\Profile\Index::cleanKeywords
+			foreach (explode(', ', (string) $contact['keywords']) as $tag_label) {
+				$tags[] = [
+					'url'   => '/search?tag=' . urlencode($tag_label),
+					'label' => Tag::TAG_CHARACTER[Tag::HASHTAG] . $tag_label,
+				];
+			}
+		}
+
 		$contact_url = Contact::getProfileLink($contact);
 
 		// Move the contact data to the profile array so we can deliver it to
@@ -46,7 +58,7 @@ class Hovercard
 				'location'     => $contact['location'],
 				'about'        => $contact['about'],
 				'network_link' => Strings::formatNetworkName($contact['network'], $contact_url, $contact['gsid']),
-				'tags'         => $contact['keywords'],
+				'tags'         => $tags,
 				'bd'           => $contact['bd'] <= DBA::NULL_DATE ? '' : $contact['bd'],
 				'account_type' => Contact::getAccountType($contact['contact-type']),
 				'contact_type' => $contact['contact-type'],

--- a/view/templates/hovercard.tpl
+++ b/view/templates/hovercard.tpl
@@ -55,4 +55,10 @@
 
 	</div>
 </div>
-{{if $profile.tags}}<div class="hover-card-footer">{{$profile.tags}}</div>{{/if}}
+{{if $profile.tags}}
+	<div class="hover-card-footer">
+    {{foreach $profile.tags as $tag}}
+	<a href="{{$tag.url}}" class="tag label btn-info sm">{{$tag.label}} <i class="ri ri-flashlight-line" aria-hidden="true"></i></a>
+    {{/foreach}}
+	</div>
+{{/if}}


### PR DESCRIPTION
Currently the Hovercards show any profile keywords as a comma-separated list of plain text (which is how they are stored in the database):

<img width="351" height="184" alt="hovercard_commas" src="https://github.com/user-attachments/assets/aea51c61-2962-41ba-a81d-a6001713f30f" />

This PR changes those into clickable hashtags:

<img width="348" height="195" alt="hovercard_tags" src="https://github.com/user-attachments/assets/2ed3759a-cd85-41c6-a8c6-dbfc5291822d" />

Which is consistent with how they are shown on profiles:

<img width="647" height="311" alt="Profiles" src="https://github.com/user-attachments/assets/6f42a06b-552f-4b74-889f-4501eb7b566e" />

