### PR TITLE
Fix alignment & placement of jot plugins

### DIFF
--- a/view/templates/item/compose.tpl
+++ b/view/templates/item/compose.tpl
@@ -104,6 +104,9 @@
                     </button>
                     <button type="submit" class="btn btn-primary" id="comment-edit-submit-{{$id}}" name="submit" tabindex="9"><i class="ri ri-send-plane-line"></i> {{$l10n.submit}}</button>
                 </div>
+                <div class="jotplugins">
+                    {{$jotplugins nofilter}}
+                </div>
             </div>
 
             <div id="comment-edit-preview-{{$id}}" class="comment-edit-preview" style="display:none;"></div>
@@ -112,10 +115,6 @@
                 {{if $type == 'post'}}
                     <h3>{{$l10n.visibility_title}}</h3>
                     {{$acl_selector nofilter}}
-
-                    <div class="jotplugins">
-                        {{$jotplugins nofilter}}
-                    </div>
 
         			{{include file="field_checkbox.tpl" field=$sensitive}}
                     {{if $scheduled_at}}{{$scheduled_at nofilter}}{{/if}}

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1669,6 +1669,21 @@ textarea.comment-edit-text:focus + .comment-edit-form .preview {
 	overflow-y: auto;
 	overflow-y: overlay;
 }
+#profile-jot-plugin-wrapper,
+.jotplugins {
+	position: relative;
+	display: flex;
+	width: 100%;
+	justify-content: flex-start;
+	z-index: 10;
+}
+#profile-jot-plugin-wrapper > div > .btn {
+	padding: 10px 15px;
+}
+.jotplugins > div > .btn {
+	padding: 8px 16px;
+	margin-right: 4px;
+}
 /* ACL */
 .ri.lock:before {
 	font-family: remixicon;


### PR DESCRIPTION
In Frio in the compose modal there appears to be an assumption of space for one jot plugin, which causes misalignment if there are more:

<img width="648" height="81" alt="modal_misaligned" src="https://github.com/user-attachments/assets/87e5215e-f084-4474-a081-a76d6cd5318a" />

IMO the plugin space should be separate from the rest of the compose tools. This is how I aligned things in Bookface and it could just as well be done in Frio itself:

<img width="646" height="107" alt="modal_fixed" src="https://github.com/user-attachments/assets/030467e7-91f8-41bd-91d0-54e7c4879e41" />

If you choose to compose with the single page option the jot plugins are inexplicably placed _within_ the "Visibility" options:

<img width="670" height="575" alt="page_misplaced" src="https://github.com/user-attachments/assets/7f67bdfe-8534-431e-b2f1-8c9525af29df" />

This PR moves them to be consistent with their placement in the modal, below the post submit line:

<img width="668" height="126" alt="page_fixed" src="https://github.com/user-attachments/assets/2e1712be-ef26-488a-8eb1-05f4ad57b742" />


