### PR TITLE
Fix TypeError passing null languages to Timeline constructor in UserDefinedChannel

### DIFF
--- a/src/Content/Conversation/Factory/UserDefinedChannel.php
+++ b/src/Content/Conversation/Factory/UserDefinedChannel.php
@@ -23,6 +23,10 @@ final class UserDefinedChannel extends Timeline implements ICanCreateFromTableRo
 			$row['languages'] = unserialize($row['languages']);
 		}
 
+		if (!is_array($row['languages'])) {
+			$row['languages'] = [];
+		}
+
 		return new Entity\UserDefinedChannel(
 			$row['id'] ?? null,
 			$row['label'],
@@ -35,7 +39,7 @@ final class UserDefinedChannel extends Timeline implements ICanCreateFromTableRo
 			$row['full-text-search'] ?? null,
 			$row['media-type'] ?? null,
 			$row['circle'] ?? null,
-			$row['languages'] ?? null,
+			$row['languages'],
 			$row['publish'] ?? null,
 			$row['valid'] ?? null,
 			$row['min-size'] ?? null,

--- a/src/Content/Conversation/Factory/UserDefinedChannel.php
+++ b/src/Content/Conversation/Factory/UserDefinedChannel.php
@@ -39,7 +39,7 @@ final class UserDefinedChannel extends Timeline implements ICanCreateFromTableRo
 			$row['full-text-search'] ?? null,
 			$row['media-type'] ?? null,
 			$row['circle'] ?? null,
-			$row['languages'],
+			$row['languages'] ?? null,
 			$row['publish'] ?? null,
 			$row['valid'] ?? null,
 			$row['min-size'] ?? null,


### PR DESCRIPTION
`UserDefinedChannel::createFromTableRow()` passes the raw `languages` column value to `Timeline::__construct()`, which has `array $languages = []` as its type hint. When the column is `null` in the database, `null` is passed explicitly (the default `[]` only applies when the argument is omitted). Additionally, `unserialize()` returns `false` on failure, which also violates the `array` type hint. This causes an uncaught TypeError:

TypeError: Timeline::__construct(): Argument #12 ($languages) must be of type array, null given

See: https://forum.friendi.ca/display/6d9331c9-176a-3113-4fcf-4b0019762953