### PR TITLE
fix: call guzzle with uppercase method

### DIFF
--- a/src/Module/Magic.php
+++ b/src/Module/Magic.php
@@ -153,7 +153,7 @@ class Magic extends BaseModule
 
 		// Try to get an authentication token from the other instance.
 		try {
-			$curlResult = $this->httpClient->request('get', $openwebauth, [HttpClientOptions::HEADERS => $header]);
+			$curlResult = $this->httpClient->request('GET', $openwebauth, [HttpClientOptions::HEADERS => $header]);
 		} catch (Exception $exception) {
 			$this->logger->notice('URL is invalid, redirecting to destination.', ['url' => $openwebauth, 'error' => $exception, 'dest' => $dest]);
 			System::externalRedirect($dest);

--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -38,6 +38,7 @@ class HttpClient implements ICanSendHttpRequests
 	 */
 	public function request(string $method, string $url, array $opts = []): ICanHandleHttpResponses
 	{
+		$method = strtoupper($method);
 		$this->profiler->startRecording('network');
 		$this->logger->debug('Request start.', ['url' => $url, 'method' => $method]);
 
@@ -136,7 +137,7 @@ class HttpClient implements ICanSendHttpRequests
 			}
 		};
 
-		if (empty($conf[HttpClientOptions::HEADERS]['Accept']) && in_array($method, ['get', 'head'])) {
+		if (empty($conf[HttpClientOptions::HEADERS]['Accept']) && in_array($method, ['GET', 'HEAD'])) {
 			$this->logger->info('Accept header was missing, using default.', ['url' => $url]);
 			$conf[HttpClientOptions::HEADERS]['Accept'] = HttpClientAccept::DEFAULT;
 		}
@@ -178,7 +179,7 @@ class HttpClient implements ICanSendHttpRequests
 	 */
 	public function head(string $url, array $opts = []): ICanHandleHttpResponses
 	{
-		return $this->request('head', $url, $opts);
+		return $this->request('HEAD', $url, $opts);
 	}
 
 	/**
@@ -189,7 +190,7 @@ class HttpClient implements ICanSendHttpRequests
 		// In case there is no
 		$opts[HttpClientOptions::ACCEPT_CONTENT] ??= $accept_content;
 
-		return $this->request('get', $url, $opts);
+		return $this->request('GET', $url, $opts);
 	}
 
 	/**
@@ -217,7 +218,7 @@ class HttpClient implements ICanSendHttpRequests
 			$opts[HttpClientOptions::REQUEST] = $request;
 		}
 
-		return $this->request('post', $url, $opts);
+		return $this->request('POST', $url, $opts);
 	}
 
 	/**


### PR DESCRIPTION
Since guzzlehttp/guzzle 7.11: Passing a non-uppercase HTTP method to Client::request() is deprecated

Fixes https://github.com/friendica/friendica/issues/15818#issuecomment-4719951541