### PR TITLE
Fixes for page flags on ORG and NEWS accounts.

### DIFF
--- a/src/Module/Moderation/BaseUsers.php
+++ b/src/Module/Moderation/BaseUsers.php
@@ -151,8 +151,8 @@ abstract class BaseUsers extends BaseModeration
 			$user['page_flags_raw'] = $user['page-flags'];
 			$user['page_type']      = $page_types[$user['page-flags']];
 
-			$user['account_type_raw'] = ($user['page_flags_raw'] == 0) ? $user['account-type'] : -1;
-			$user['account_type']     = ($user['page_flags_raw'] == 0) ? $account_types[$user['account-type']] : '';
+			$user['account_type_raw'] = $user['account-type'];
+			$user['account_type']     = $account_types[$user['account-type']];
 
 			$user['register_date'] = Temporal::getRelativeDate($user['register_date']);
 			$user['login_date']    = Temporal::getRelativeDate($user['last-activity'], false);

--- a/src/Module/Moderation/BaseUsers.php
+++ b/src/Module/Moderation/BaseUsers.php
@@ -132,20 +132,19 @@ abstract class BaseUsers extends BaseModeration
 		$adminlist = User::getAdminEmailList();
 		return function ($user) use ($adminlist) {
 			$page_types = [
-				// NOTE: Currently no PAGE_FLAGS_BLOG here, unlike Model/User.php?
-				User::PAGE_FLAGS_NORMAL    => [$this->t('Normal Account Page'), "ri-user-line"],
-				User::PAGE_FLAGS_SOAPBOX   => [$this->t('Soapbox Page'), "ri-megaphone-line"],
-				User::PAGE_FLAGS_COMMUNITY => [$this->t('Public Group'), "ri-team-line"],
-				User::PAGE_FLAGS_COMM_MAN  => [$this->t('Public Group - Restricted', "ri-team-line")],
-				User::PAGE_FLAGS_FREELOVE  => [$this->t('Automatic Friend Page'), "ri-heart-line"],
-				User::PAGE_FLAGS_PRVGROUP  => [$this->t('Private Group'), "ri-spy-line"],
+				User::PAGE_FLAGS_NORMAL    => $this->t('Normal Account Page'),
+				User::PAGE_FLAGS_SOAPBOX   => $this->t('Soapbox Page'),
+				User::PAGE_FLAGS_COMMUNITY => $this->t('Public Group'),
+				User::PAGE_FLAGS_COMM_MAN  => $this->t('Public Group - Restricted'),
+				User::PAGE_FLAGS_FREELOVE  => $this->t('Automatic Friend Page'),
+				User::PAGE_FLAGS_PRVGROUP  => $this->t('Private Group'),
 			];
 			$account_types = [
-				User::ACCOUNT_TYPE_PERSON       => [$this->t('Personal Page'), ""],
-				User::ACCOUNT_TYPE_ORGANISATION => [$this->t('Organisation Page'), "ri-node-tree"],
-				User::ACCOUNT_TYPE_NEWS         => [$this->t('News Page'), "ri-newspaper-line"],
-				User::ACCOUNT_TYPE_COMMUNITY    => [$this->t('Community Group'), "ri-chat-3-line"],
-				User::ACCOUNT_TYPE_RELAY        => [$this->t('Relay'), ""],
+				User::ACCOUNT_TYPE_PERSON       => $this->t('Personal Page'),
+				User::ACCOUNT_TYPE_ORGANISATION => $this->t('Organisation Page'),
+				User::ACCOUNT_TYPE_NEWS         => $this->t('News Page'),
+				User::ACCOUNT_TYPE_COMMUNITY    => $this->t('Community Group'),
+				User::ACCOUNT_TYPE_RELAY        => $this->t('Relay'),
 			];
 
 			$user['page_flags_raw'] = $user['page-flags'];

--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -410,11 +410,11 @@ class Register extends BaseModule
 						break;
 					case User::ORGPAGE:
 						$acct_type = User::ACCOUNT_TYPE_ORGANISATION;
-						$acct_flag = User::PAGE_FLAGS_SOAPBOX;
+						$acct_flag = User::PAGE_FLAGS_NORMAL;
 						break;
 					case User::NEWSPAGE:
 						$acct_type = User::ACCOUNT_TYPE_NEWS;
-						$acct_flag = User::PAGE_FLAGS_SOAPBOX;
+						$acct_flag = User::PAGE_FLAGS_NORMAL;
 						break;
 					case User::PUBGROUP:
 						$acct_type = User::ACCOUNT_TYPE_COMMUNITY;

--- a/view/theme/frio/templates/moderation/users/index.tpl
+++ b/view/theme/frio/templates/moderation/users/index.tpl
@@ -75,9 +75,24 @@
 
 				{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 					<td>
-						<i class="ri {{$u.page_type.1}}" title="{{$u.page_type.0}}"></i>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
-							<i class="ri {{$u.account_type.1}}" title"{{$u.account_type.0}}"></i>
+						<i class="ri
+							{{if $u.account_type_raw==1}}ri-building-4-line{{/if}}		{{* ACCOUNT_TYPE_ORGANISATION *}}
+							{{if $u.account_type_raw==2}}ri-newspaper-line{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
+							{{if $u.account_type_raw==3}}ri-chat-3-line{{/if}}		{{* ACCOUNT_TYPE_COMMUNITY *}}
+							" data-flag="0" data-acct="{{$u.account_type_raw}}" title="{{$u.account_type}}">
+						</i>
+						{{else}}
+						<i class="ri
+							{{if $u.page_flags_raw==0}}ri-user-line{{/if}}		{{* PAGE_NORMAL *}}
+							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PAGE_SOAPBOX *}}
+							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		{{* PAGE_COMMUNITY *}}
+							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		{{* PAGE_FREELOVE *}}
+							{{if $u.page_flags_raw==4}}ri-broadcast-line{{/if}}		{{* PAGE_BLOG *}}
+							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	{{* PAGE_PRVGROUP *}}
+							{{if $u.page_flags_raw==6}}ri-group-3-line{{/if}}		{{* PAGE_COMM_MAN *}}
+							" data-flag="{{$u.page_flags_raw}}" data-acct="{{$u.account_type_raw}}" title="{{$u.page_flags}}">
+						</i>
 						{{/if}}
 						{{if $u.is_admin}}<i class="ri ri-spy-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
 						{{if $u.blocked}}<i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i>{{/if}}

--- a/view/theme/frio/templates/moderation/users/index.tpl
+++ b/view/theme/frio/templates/moderation/users/index.tpl
@@ -93,7 +93,7 @@
 							" data-flag="{{$u.page_flags_raw}}" data-acct="{{$u.account_type_raw}}" title="{{$u.page_flags}}">
 						</i>
 						{{/if}}
-						{{if $u.is_admin}}<i class="ri ri-spy-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
+						{{if $u.is_admin}}<i class="ri ri-key-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
 						{{if $u.blocked}}<i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i>{{/if}}
 						{{if $u.deleted}}<i class="ri ri-user-unfollow-line" title="{{$h_deleted}}"></i>{{/if}}
 						{{if $u.account_expired}}<i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i>{{/if}}

--- a/view/theme/frio/templates/moderation/users/index.tpl
+++ b/view/theme/frio/templates/moderation/users/index.tpl
@@ -76,23 +76,35 @@
 				{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 					<td>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
-						<i class="ri
-							{{if $u.account_type_raw==1}}ri-building-4-line{{/if}}		{{* ORGANIZATION PAGE *}}
-							{{if $u.account_type_raw==2}}ri-newspaper-line{{/if}}	    {{* NEWS PAGE *}}
-							" data-flag="0" data-acct="{{$u.account_type_raw}}" title="{{$u.account_type}}">
-						</i>
+							{{if $u.account_type_raw==1}}
+								{{$acct_icon = "ri-building-4-line"}} {{* ACCOUNT_TYPE_ORGANISATION *}}
+							{{else if $u.account_type_raw==2}}
+								{{$acct_icon = "ri-newspaper-line"}}  {{* ACCOUNT_TYPE_NEWS *}}
+							{{else if $u.account_type_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
 						{{else}}
-						<i class="ri
-							{{if $u.page_flags_raw==0}}ri-user-line{{/if}}		    {{* PERSON NORMAL *}}
-							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PERSON SOAPBOX *}}
-							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		    {{* PUBLIC GROUP *}}
-							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		    {{* PERSON FREELOVE *}}
-							{{if $u.page_flags_raw==4}}ri-broadcast-line{{/if}}		{{* PAGE BLOG *}}
-							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	        {{* GROUP PRIVATE *}}
-							{{if $u.page_flags_raw==6}}ri-group-3-line{{/if}}		{{* GROUP RESTRICTED *}}
-							" data-flag="{{$u.page_flags_raw}}" data-acct="{{$u.account_type_raw}}" title="{{$u.page_flags}}">
-						</i>
+							{{if $u.page_flags_raw==0}}
+								{{$acct_icon = "ri-user-line"}}		  {{* PERSON NORMAL *}}
+							{{else if $u.page_flags_raw==1}}
+								{{$acct_icon = "ri-megaphone-line"}}  {{* PERSON SOAPBOX *}}
+							{{else if $u.page_flags_raw==2}}
+								{{$acct_icon = "ri-team-line"}}		  {{* PUBLIC GROUP *}}
+							{{else if $u.page_flags_raw==3}}
+								{{$acct_icon = "ri-heart-line"}}	  {{* PERSON FREELOVE *}}
+							{{else if $u.page_flags_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}  {{* PAGE BLOG *}}
+							{{else if $u.page_flags_raw==5}}
+								{{$acct_icon = "ri-spy-line"}}	      {{* GROUP PRIVATE *}}
+							{{else if $u.page_flags_raw==6}}
+								{{$acct_icon = "ri-group-3-line"}}	  {{* GROUP RESTRICTED *}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
 						{{/if}}
+						<i class="ri {{$acct_icon}}" aria-hidden="true" data-acct="{{$u.account_type_raw}}" data-flag="{{$u.page_flags_raw}}"></i>
 						{{if $u.is_admin}}<i class="ri ri-key-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
 						{{if $u.blocked}}<i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i>{{/if}}
 						{{if $u.deleted}}<i class="ri ri-user-unfollow-line" title="{{$h_deleted}}"></i>{{/if}}

--- a/view/theme/frio/templates/moderation/users/index.tpl
+++ b/view/theme/frio/templates/moderation/users/index.tpl
@@ -77,20 +77,19 @@
 					<td>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
 						<i class="ri
-							{{if $u.account_type_raw==1}}ri-building-4-line{{/if}}		{{* ACCOUNT_TYPE_ORGANISATION *}}
-							{{if $u.account_type_raw==2}}ri-newspaper-line{{/if}}	{{* ACCOUNT_TYPE_NEWS *}}
-							{{if $u.account_type_raw==3}}ri-chat-3-line{{/if}}		{{* ACCOUNT_TYPE_COMMUNITY *}}
+							{{if $u.account_type_raw==1}}ri-building-4-line{{/if}}		{{* ORGANIZATION PAGE *}}
+							{{if $u.account_type_raw==2}}ri-newspaper-line{{/if}}	    {{* NEWS PAGE *}}
 							" data-flag="0" data-acct="{{$u.account_type_raw}}" title="{{$u.account_type}}">
 						</i>
 						{{else}}
 						<i class="ri
-							{{if $u.page_flags_raw==0}}ri-user-line{{/if}}		{{* PAGE_NORMAL *}}
-							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PAGE_SOAPBOX *}}
-							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		{{* PAGE_COMMUNITY *}}
-							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		{{* PAGE_FREELOVE *}}
-							{{if $u.page_flags_raw==4}}ri-broadcast-line{{/if}}		{{* PAGE_BLOG *}}
-							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	{{* PAGE_PRVGROUP *}}
-							{{if $u.page_flags_raw==6}}ri-group-3-line{{/if}}		{{* PAGE_COMM_MAN *}}
+							{{if $u.page_flags_raw==0}}ri-user-line{{/if}}		    {{* PERSON NORMAL *}}
+							{{if $u.page_flags_raw==1}}ri-megaphone-line{{/if}}		{{* PERSON SOAPBOX *}}
+							{{if $u.page_flags_raw==2}}ri-team-line{{/if}}		    {{* PUBLIC GROUP *}}
+							{{if $u.page_flags_raw==3}}ri-heart-line{{/if}}		    {{* PERSON FREELOVE *}}
+							{{if $u.page_flags_raw==4}}ri-broadcast-line{{/if}}		{{* PAGE BLOG *}}
+							{{if $u.page_flags_raw==5}}ri-spy-line{{/if}}	        {{* GROUP PRIVATE *}}
+							{{if $u.page_flags_raw==6}}ri-group-3-line{{/if}}		{{* GROUP RESTRICTED *}}
 							" data-flag="{{$u.page_flags_raw}}" data-acct="{{$u.account_type_raw}}" title="{{$u.page_flags}}">
 						</i>
 						{{/if}}


### PR DESCRIPTION
In _/src/Module/Register.php_ when posted it would create account types ORGANIZATION or NEWS page with a page flag set to "1" but that's the flag for a PERSON account sub-type of "Soapbox."  Org and News pages do not have any sub-types, therefore the correct page flag is "0" for "Normal."

While this fixes the registration of new Org and News page accounts it does not fix the errant flag assigned to existing page accounts. I wasn't sure where or how to implement a fix to update that in the database apart from changing the flag manually in the `user` table.

I discovered this error when trying to restyle icons in the **Moderation > Users** table, where it was showing the "Soapbox" icon for Org and News pages and the tooltip was also misidentifying them as a "Soapbox Page."

So I also had to fix the code for that table to show the correct icons. I think it was @marcusxss who had defined the Remix icons in _/src/Module/Moderation/BaseUser.php_ but I moved them out of there and back into _/view/templates/frio/moderation/users/index.tpl_ because I think that is the appropriate place for it.  I changed the icon indicator for Admin accounts from the "spy" to a "key" because the "spy" icon is already used for Private Groups. I also added `data-flag` and `data-acct` attributes so schemes can target these elements for styling overrides.

I think the core PHP should _only_ ever be sending **data** to the templates and _never_ sending any styling or pre-formatted HTML for that matter. We may agree to disagree on that point, but from my perspective working on the Bookface scheme and trying to get a new BookLook theme together, I don't want any styling or formatting coming from the core.

