### PR TITLE
Languages can be null

### DIFF
--- a/src/Content/Conversation/Entity/Timeline.php
+++ b/src/Content/Conversation/Entity/Timeline.php
@@ -72,7 +72,7 @@ class Timeline extends \Friendica\BaseEntity
 		?string $fullTextSearch = null,
 		?int $mediaType = null,
 		?int $circle = null,
-		array $languages = [],
+		?array $languages = null,
 		?bool $publish = null,
 		?bool $valid = null,
 		?int $minSize = null,


### PR DESCRIPTION
See  https://github.com/friendica/friendica/issues/15817#issuecomment-4740006648
This is an alternative to the PR https://github.com/friendica/friendica/pull/15875

The origin of the issue that the languages entity is meant to be null. This had been introduced here: https://github.com/friendica/friendica/pull/15877