### PR TITLE
Tag updates

### DIFF
--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -132,7 +132,7 @@ class Item
 			foreach (Post\Category::getArrayByURIId($item['uri-id'], $uid, Post\Category::FILE) as $savedFolderName) {
 				$folders[] = [
 					'name'      => $savedFolderName,
-					'url'       => "#",
+					'url'       => '/filed?file=' . $savedFolderName,
 					'removeurl' => $this->userSession->getLocalUserId() == $uid ? 'filerm/' . $item['id'] . '?term=' . rawurlencode((string) $savedFolderName) : '',
 					'first'     => $first,
 					'last'      => false,

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -556,8 +556,8 @@ class Tag
 						$item['body'] = str_replace($orig_tag, $tag['url'], $item['body']);
 					}
 
-					$return['hashtags'][] = '<bdi>' . $prefix . '<a href="' . $tag['url'] . '" target="_blank" rel="noopener noreferrer">' . htmlspecialchars((string) $tag['name']) . '</a></bdi>';
-					$return['tags'][]     = '<bdi>' . $prefix . '<a href="' . $tag['url'] . '" target="_blank" rel="noopener noreferrer">' . htmlspecialchars((string) $tag['name']) . '</a></bdi>';
+					$return['hashtags'][] = '<bdi>' . '<a href="' . $tag['url'] . '" target="_blank" rel="noopener noreferrer">' . $prefix . htmlspecialchars((string) $tag['name']) . '</a></bdi>';
+					$return['tags'][]     = '<bdi>' . '<a href="' . $tag['url'] . '" target="_blank" rel="noopener noreferrer">' . $prefix .  htmlspecialchars((string) $tag['name']) . '</a></bdi>';
 					break;
 
 				case self::MENTION:
@@ -567,8 +567,8 @@ class Tag
 					} else {
 						$tag['url'] = Contact::magicLink($tag['url']);
 					}
-					$return['mentions'][] = '<bdi>' . $prefix . '<a href="' . $tag['url'] . '" target="_blank" rel="noopener noreferrer">' . htmlspecialchars((string) $tag['name']) . '</a></bdi>';
-					$return['tags'][]     = '<bdi>' . $prefix . '<a href="' . $tag['url'] . '" target="_blank" rel="noopener noreferrer">' . htmlspecialchars((string) $tag['name']) . '</a></bdi>';
+					$return['mentions'][] = '<bdi>' . '<a href="' . $tag['url'] . '" target="_blank" rel="noopener noreferrer">' . $prefix . htmlspecialchars((string) $tag['name']) . '</a></bdi>';
+					$return['tags'][]     = '<bdi>' . '<a href="' . $tag['url'] . '" target="_blank" rel="noopener noreferrer">' . $prefix . htmlspecialchars((string) $tag['name']) . '</a></bdi>';
 					break;
 
 				case self::IMPLICIT_MENTION:

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -557,7 +557,7 @@ class Tag
 					}
 
 					$return['hashtags'][] = '<bdi>' . '<a href="' . $tag['url'] . '" target="_blank" rel="noopener noreferrer">' . $prefix . htmlspecialchars((string) $tag['name']) . '</a></bdi>';
-					$return['tags'][]     = '<bdi>' . '<a href="' . $tag['url'] . '" target="_blank" rel="noopener noreferrer">' . $prefix .  htmlspecialchars((string) $tag['name']) . '</a></bdi>';
+					$return['tags'][]     = '<bdi>' . '<a href="' . $tag['url'] . '" target="_blank" rel="noopener noreferrer">' . $prefix . htmlspecialchars((string) $tag['name']) . '</a></bdi>';
 					break;
 
 				case self::MENTION:

--- a/src/Module/Profile/Schedule.php
+++ b/src/Module/Profile/Schedule.php
@@ -70,7 +70,7 @@ class Schedule extends BaseProfile
 			// populate our $tags placeholder array:
 			if (!empty($extracted_tags)) {
 				foreach ($extracted_tags as $tag) {
-					$html = '<bdi>' . $tag[1] . '<a href="' . $tag[2] . '" target="_blank" rel="noopener noreferrer">' . $tag[3] . '</a></bdi>';
+					$html = '<bdi><a href="' . $tag[2] . '" target="_blank" rel="noopener noreferrer">' . $tag[1] . $tag[3] . '</a></bdi>';
 					if ($tag[1] == "#") {
 						$tags['hashtags'][] = $html;
 					} elseif ($tag[1] == "@") {

--- a/view/global.css
+++ b/view/global.css
@@ -560,51 +560,73 @@ td.pendingnote > p > span {
 img.invalid-src:after { vertical-align: top;}
 
 /* Tag cloud */
-.tag1, .tag1:hover {
+.tagblock .tag-cloud {
+  word-wrap: break-word;
+}
+.tagblock .tag-cloud .tag {
+	display: flex;
+	align-items: center;
+}
+
+.tagblock .tag-cloud .tag:focus {
+	color: black;
+}
+
+.tagblock .tag-cloud .tag1 {
   font-size: 0.9em ;
   color: DarkGray;
+	border-color: DarkGray;
 }
-.tag2, .tag2:hover {
+.tagblock .tag-cloud .tag2 {
   font-size: 1.0em;
   color: LawnGreen;
+	border-color: LawnGreen;
 }
-.tag3, .tag3:hover {
+.tagblock .tag-cloud .tag3 {
   font-size: 1.1em;
   color: DarkOrange;
+	border-color: DarkOrange;
 }
-.tag4, .tag4:hover {
+.tagblock .tag-cloud .tag4 {
   font-size: 1.2em;
   color: Red;
+	border-color: Red;
 }
-.tag5, .tag5:hover {
+.tagblock .tag-cloud .tag5 {
   font-size: 1.3em;
   color: Gold;
+	border-color: Gold;
 }
-.tag6, .tag6:hover {
+.tagblock .tag-cloud .tag6 {
   font-size: 1.4em;
   color: Teal;
+	border-color: Teal;
 }
-.tag7, .tag7:hover {
+.tagblock .tag-cloud .tag7 {
   font-size: 1.5em;
   color: DarkMagenta;
+	border-color: DarkMagenta;
 }
-.tag8, .tag8:hover {
+.tagblock .tag-cloud .tag8 {
   font-size: 1.6em;
   color: DarkGoldenRod;
+	border-color: DarkGoldenRod;
 }
-.tag9, .tag9:hover {
+.tagblock .tag-cloud .tag9 {
   font-size: 1.7em;
   color: DarkBlue;
+	border-color: DarkBlue;
 }
-.tag10 .tag10:hover {
+.tagblock .tag-cloud .tag10 {
   font-size: 1.8em;
   color: DeepPink;
+	border-color: DeepPink;
+}
+.tagblock .tag-cloud .tag:hover {
+	color: white;
 }
 .tags > a:hover {
   text-decoration: underline;
-}
-.tag-cloud {
-  word-wrap: break-word;
 }
 
 #register-explicit-content {

--- a/view/templates/hovercard.tpl
+++ b/view/templates/hovercard.tpl
@@ -56,9 +56,9 @@
 	</div>
 </div>
 {{if $profile.tags}}
-	<div class="hover-card-footer">
+	<div class="hover-card-footer tags">
     {{foreach $profile.tags as $tag}}
-	<a href="{{$tag.url}}" class="tag label btn-info sm">{{$tag.label}} <i class="ri ri-flashlight-line" aria-hidden="true"></i></a>
+	<a href="{{$tag.url}}" class="tag label border border-default">{{$tag.label}}</a>
     {{/foreach}}
 	</div>
 {{/if}}

--- a/view/templates/profile/profile.tpl
+++ b/view/templates/profile/profile.tpl
@@ -90,9 +90,9 @@
 		<hr class="profile-separator">
 		<dt class="col-lg-4 col-md-4 col-sm-4 col-xs-12 profile-label-name text-muted">{{$basic_fields.pub_keywords.label}}</dt>
 		<dd class="col-lg-8 col-md-8 col-sm-8 col-xs-12 profile-entry">
-            {{foreach $basic_fields.pub_keywords.value as $tag}}
-				<a href="{{$tag.url}}" class="tag label btn-info sm">{{$tag.label}} <i class="ri ri-flashlight-line" aria-hidden="true"></i></a>
-            {{/foreach}}
+			{{foreach $basic_fields.pub_keywords.value as $tag}}
+				<a href="{{$tag.url}}" class="tag label label-default">{{$tag.label}}</a>
+			{{/foreach}}
 		</dd>
 	</dl>
 {{/if}}

--- a/view/templates/profile/profile.tpl
+++ b/view/templates/profile/profile.tpl
@@ -89,9 +89,9 @@
 	<dl id="aprofile-tags" class="row {{$basic_fields.pub_keywords.class|default:'aprofile'}}">
 		<hr class="profile-separator">
 		<dt class="col-lg-4 col-md-4 col-sm-4 col-xs-12 profile-label-name text-muted">{{$basic_fields.pub_keywords.label}}</dt>
-		<dd class="col-lg-8 col-md-8 col-sm-8 col-xs-12 profile-entry">
+		<dd class="col-lg-8 col-md-8 col-sm-8 col-xs-12 profile-entry tags">
 			{{foreach $basic_fields.pub_keywords.value as $tag}}
-				<a href="{{$tag.url}}" class="tag label label-default">{{$tag.label}}</a>
+				<a href="{{$tag.url}}" class="tag hashtag label label-default border border-default">{{$tag.label}}</a>
 			{{/foreach}}
 		</dd>
 	</dl>

--- a/view/templates/profile/schedule.tpl
+++ b/view/templates/profile/schedule.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div class="generic-page-wrapper scheduled-posts-wrapper">
-	<h1>{{$title}}</h1>
+<h2>{{$title}}</h2>
 {{foreach $schedule as $row}}
 <div id="tread-wapper-{{$row.item['uri-id']}}" class="tread-wrapper h-entry {{$row.item.network}}">
 	<div class="wall-item-container {{$row.item.network}} thread_level_0" id="item-{{$row.item.guid}}">
@@ -51,7 +51,7 @@
 				<div class="wall-item-body e-content {{if !$row.item.title}}p-name{{/if}}" dir="auto">{{$row.item['rendered-html'] nofilter}}</div>
 				<div class="wall-item-bottom">
 					<div class="wall-item-links"></div>
-					<div class="wall-item-tags">
+					<div class="tags wall-item-tags">
 						{{foreach $row.item.hashtags as $tag}}
 							<span class="tag hashtag">{{$tag nofilter}}</span>
 						{{/foreach}}

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -91,7 +91,7 @@
 					<div class="wall-item-bottom">
 						<div class="wall-item-links">
 						</div>
-						<div class="wall-item-tags">
+						<div class="tags wall-item-tags">
 							{{if !$item.suppress_tags}}
 								{{foreach $item.hashtags as $tag}}
 									<span class="tag">{{$tag nofilter}}</span>
@@ -101,7 +101,7 @@
 								{{/foreach}}
 							{{/if}}
 							{{foreach $item.folders as $cat}}
-								<span class="folder">< href="{{$cat.url}}">{{$cat.name}}</a>{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
+								<span class="folder"><a href="{{$cat.url}}">{{$cat.name}}</a>{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
 							{{/foreach}}
 							{{foreach $item.categories as $cat}}
 								<span class="category"><a href="{{$cat.url}}">{{$cat.name}}</a>{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -92,20 +92,20 @@
 						<div class="wall-item-links">
 						</div>
 						<div class="wall-item-tags">
-                            {{if !$item.suppress_tags}}
-                                {{foreach $item.hashtags as $tag}}
+							{{if !$item.suppress_tags}}
+								{{foreach $item.hashtags as $tag}}
 									<span class="tag">{{$tag nofilter}}</span>
-                                {{/foreach}}
-                                {{foreach $item.mentions as $tag}}
+								{{/foreach}}
+								{{foreach $item.mentions as $tag}}
 									<span class="mention">{{$tag nofilter}}</span>
-                                {{/foreach}}
-                            {{/if}}
-                            {{foreach $item.folders as $cat}}
-								<span class="folder p-category">{{$cat.name}}{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
-                            {{/foreach}}
-                            {{foreach $item.categories as $cat}}
-								<span class="category p-category"><a href="{{$cat.url}}">{{$cat.name}}</a>{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
-                            {{/foreach}}
+								{{/foreach}}
+							{{/if}}
+							{{foreach $item.folders as $cat}}
+								<span class="folder">< href="{{$cat.url}}">{{$cat.name}}</a>{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
+							{{/foreach}}
+							{{foreach $item.categories as $cat}}
+								<span class="category"><a href="{{$cat.url}}">{{$cat.name}}</a>{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
+							{{/foreach}}
 						</div>
                         {{if $item.edited}}
 							<div class="itemedited text-muted">{{$item.edited['label']}} (<span title="{{$item.edited['date']}}">{{$item.edited['relative']}}</span>)</div>

--- a/view/templates/widget/tagcloud.tpl
+++ b/view/templates/widget/tagcloud.tpl
@@ -21,11 +21,9 @@
 			</h3>
 		</button>
 
-		<div class="tag-cloud">
+		<div class="tag-cloud tags">
 			{{foreach $tags as $tag}}
-				<span class="tags">
-					<span class="tag{{$tag.level}}">#</span><a href="{{$tag.url}}" class="tag{{$tag.level}}">{{$tag.name}}</a>
-				</span>
+				<a href="{{$tag.url}}" class="tag hashtag tag{{$tag.level}} label border border-default">#{{$tag.name}}</a>
 			{{/foreach}}
 		</div>
 		<div class="tagblock-widget-end clear"></div>

--- a/view/templates/widget/trending_tags.tpl
+++ b/view/templates/widget/trending_tags.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <nav>
-	<span id="trending-tags-sidebar-inflated" class="widget inflated fakelink">
+	<span id="trending-tags-sidebar-inflated" class="widget inflated">
 		<button class="fakelink" style="display: flex; justify-content: space-between; width: 100%;" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');" aria-expanded="false">
 			<h3>
 				<i class="ri ri-hashtag" aria-hidden="true"></i>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2159,29 +2159,62 @@ code > .hl-main {
 	margin: 0;
 	padding: 10px 0;
 }
-.wall-item-tags,
-.itemedited {
-	margin: 10px 0;
-	font-size: 13px;
-}
-.wall-item-tags:empty {
-	margin: 0;
-}
 
-.wall-item-tags a {
-	color: $font_color_darker;
-}
-
-.wall-item-tags a:hover {
-	text-decoration: none;
-}
 .wall-item-bottom .label,
 .wall-item-bottom .label a {
 	color: #fff;
 }
-.wall-item-tags .category,
-.wall-item-tags .folder {
-	margin-right: 3px;
+
+/* Tags, mentions, categories and folders */
+
+.wall-item-tags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 5px;
+	padding-block: 8px;
+}
+
+.tag {
+	font-size: 12.5px;
+	font-weight: normal;
+	padding: 0; /* The padding should be on the link instead, so it's clickable */
+}
+.tag:empty {
+	margin: 0;
+}
+.tag bdi a, .tag:has(.filerm) a:first-child {
+	display: inline-block;
+	padding: 6px 12px;
+}
+
+.filerm {
+	font-size: 16px;
+	padding-block: 3.5px;
+    padding-inline: 6.5px;
+}
+
+.tag a:hover {
+}
+
+.itemedited {
+	margin: 10px 0;
+	font-size: 13px;
+}
+
+/* Tags and mentions hover effect */
+.tag {
+    filter: grayscale(0.5);
+    opacity: 0.8;
+
+    -webkit-transition: all 0.25s ease-in-out;
+    -moz-transition: all 0.25s ease-in-out;
+    -o-transition: all 0.25s ease-in-out;
+    -ms-transition: all 0.25s ease-in-out;
+    transition: all 0.25s ease-in-out;
+}
+.wall-item-container:hover .tag {
+    filter: grayscale(0);
+    opacity: 1;
 }
 
 /* item social action buttons */
@@ -2263,31 +2296,8 @@ button[disabled] {
 	display: flex;
 	flex-basis: auto;
 }
-/* wall item hover effects */
 
 @media (min-width: 768px) {
-	/* Tags and mentions */
-	.wall-item-container .wall-item-bottom .wall-item-tags span.label {
-		filter: grayscale(0.5);
-		opacity: 0.8;
-
-		-webkit-transition: all 0.25s ease-in-out;
-		-moz-transition: all 0.25s ease-in-out;
-		-o-transition: all 0.25s ease-in-out;
-		-ms-transition: all 0.25s ease-in-out;
-		transition: all 0.25s ease-in-out;
-	}
-
-	.wall-item-container:hover .wall-item-bottom .wall-item-tags span.label {
-		filter: grayscale(0);
-		opacity: 1;
-
-		-webkit-transition: all 0.25s ease-in-out;
-		-moz-transition: all 0.25s ease-in-out;
-		-o-transition: all 0.25s ease-in-out;
-		-ms-transition: all 0.25s ease-in-out;
-		transition: all 0.25s ease-in-out;
-	}
 	/* Like/Comment/etc buttons */
 	.wall-item-container .wall-item-links,
 	.wall-item-container .wall-item-actions button > a {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -11,6 +11,39 @@
 
 :root {
 	--topbar-first-size: 50px;
+
+	/* Mostly just bootstraps own colours, available here to use them for things that there aren't helper classes for in Bootstrap 3, like border colour */
+	--default: #ededed; /* Not default */
+	--primary: $nav_bg; /* Not default */
+	--info: #5bc0de;
+	--success: #5cb85c;
+	--warning: #f0ad4e;
+	--danger: #d9534f;
+	/* Darker variants for when its text/thin borders on white background */
+	--success-darker: color-mix(in oklab, var(--success), black 20%);
+	--info-darker: color-mix(in oklab, var(--info), black 20%);
+	--warning-darker: color-mix(in oklab, var(--warning), black 20%);
+}
+
+/* Helper classes that should no longer be needed once Bootstrap is updated to at least 4 */
+.border {
+	border: 1px solid var(--border-color, #666);
+}
+
+.border-primary {
+	--border-color: var(--primary);
+}
+.border-info {
+	--border-color: var(--info-darker);
+}
+.border-success {
+	--border-color: var(--success-darker);
+}
+.border-warning {
+	--border-color: var(--warning);
+}
+.border-danger {
+	--border-color: var(--danger);
 }
 
 body {
@@ -2162,12 +2195,12 @@ code > .hl-main {
 
 .wall-item-bottom .label,
 .wall-item-bottom .label a {
-	color: #fff;
+	color: black;
 }
 
 /* Tags, mentions, categories and folders */
 
-.wall-item-tags {
+.tags {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 5px;
@@ -2179,21 +2212,40 @@ code > .hl-main {
 	font-weight: normal;
 	padding: 0; /* The padding should be on the link instead, so it's clickable */
 }
-.tag:empty {
-	margin: 0;
+
+/* Some tags are currently anchors while others are spans containing anchors - ideally they were all just anchors */
+
+/* Use somewhat darker colours for some of these to work better against white */
+.tags .border-primary a {
+	color: var(--primary);
 }
-.tag bdi a, .tag:has(.filerm) a:first-child {
+.tags .border-success a {
+	color: var(--success-darker);
+}
+.tags .border-info a {
+	color: var(--info-darker);
+}
+.tags .border-warning a {
+	color: var(--warning-darker);
+}
+.tags .border-danger a {
+	color: var(--danger);
+}
+
+.tag.category, .tag.folder, .filerm {
+	display: flex;
+}
+
+.tag bdi a, .tag:has(.filerm) a:first-child, a.tag {
 	display: inline-block;
 	padding: 6px 12px;
 }
 
-.filerm {
-	font-size: 16px;
-	padding-block: 3.5px;
-    padding-inline: 6.5px;
-}
-
-.tag a:hover {
+.tag.label .filerm {
+	align-items: center;
+	font-size: 15.5px;
+	padding-block: 0;
+	padding-inline: 6.5px;
 }
 
 .itemedited {
@@ -2203,18 +2255,43 @@ code > .hl-main {
 
 /* Tags and mentions hover effect */
 .tag {
-    filter: grayscale(0.5);
+    filter: grayscale(0.2);
     opacity: 0.8;
-
-    -webkit-transition: all 0.25s ease-in-out;
-    -moz-transition: all 0.25s ease-in-out;
-    -o-transition: all 0.25s ease-in-out;
-    -ms-transition: all 0.25s ease-in-out;
-    transition: all 0.25s ease-in-out;
 }
-.wall-item-container:hover .tag {
+.wall-item-container:hover .tag, .tags .tag {
     filter: grayscale(0);
     opacity: 1;
+}
+.tag a:hover, a.tag:hover {
+  text-decoration: none;
+  -webkit-transition: all 0.25s ease-in-out;
+  -moz-transition: all 0.25s ease-in-out;
+  -o-transition: all 0.25s ease-in-out;
+  -ms-transition: all 0.25s ease-in-out;
+  transition: all 0.25s ease-in-out;
+}
+.tags .border-primary a:hover, .tags .border-primary .tag:hover {
+	color: white;
+	background: var(--primary);
+}
+.tags .border-default a:hover, .tags .border-default:hover {
+	background: $font_color;
+	color: white;
+}
+.tag.border-success a:hover, .tags .border-success:hover {
+	background: var(--success);
+	color: white;
+}
+.tag.border-info a:hover, .tags .border-info:hover {
+	background: var(--info);
+}
+.tag.border-warning a:hover, .tags .border-warning:hover {
+	background: var(--warning);
+	color: white;
+}
+.tag.border-danger a:hover, .tag .border-danger:hover {
+	background: var(--danger);
+	color: white;
 }
 
 /* item social action buttons */

--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -349,6 +349,19 @@ input[type="submit"],
 	color: inherit;
 }
 
+.tag.label a {
+	background: $background_color;
+	color: $font_color;
+}
+
+.tag.border-primary {
+	--border-color: color-mix(in oklab, var(--success), white 30%);
+}
+
+.tag.border-primary a {
+	color: color-mix(in oklab, var(--success), white 30%);
+}
+
 code {
 	color: $font_color;
 	background-color: rgba(255, 255, 255, 0.2);

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -355,6 +355,19 @@ input[type="submit"],
 	color: inherit;
 }
 
+.tag.label a {
+	background: $background_color;
+	color: $font_color;
+}
+
+.tag.border-primary {
+	--border-color: color-mix(in oklab, var(--success), white 30%);
+}
+
+.tag.border-primary a {
+	color: color-mix(in oklab, var(--success), white 30%);
+}
+
 code {
 	color: $font_color;
 	background-color: rgba(255, 255, 255, 0.2);

--- a/view/theme/frio/templates/conversation.tpl
+++ b/view/theme/frio/templates/conversation.tpl
@@ -26,8 +26,11 @@
 {{if !$update}}
 <div id="conversation-end"></div>
     {{if $dropping}}
-		<button type="button" id="item-delete-selected" class="btn btn-link" title="{{$dropping}}" onclick="deleteCheckedItems();" data-toggle="tooltip">
-			<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
-		</button>
+<div id="item-delete-selected" class="fakelink" onclick="deleteCheckedItems();">
+	<div id="item-delete-selected-icon" class="ri ri-delete-bin-line drophide" title="{{$dropping}}"
+	     onmouseover="imgbright(this);" onmouseout="imgdull(this);"></div>
+	<div id="item-delete-selected-desc">{{$dropping}}</div>
+</div>
+<div id="item-delete-selected-end"></div>
     {{/if}}
 {{/if}}

--- a/view/theme/frio/templates/conversation.tpl
+++ b/view/theme/frio/templates/conversation.tpl
@@ -26,11 +26,8 @@
 {{if !$update}}
 <div id="conversation-end"></div>
     {{if $dropping}}
-<div id="item-delete-selected" class="fakelink" onclick="deleteCheckedItems();">
-	<div id="item-delete-selected-icon" class="icon drophide" title="{{$dropping}}"
-	     onmouseover="imgbright(this);" onmouseout="imgdull(this);"></div>
-	<div id="item-delete-selected-desc">{{$dropping}}</div>
-</div>
-<div id="item-delete-selected-end"></div>
+		<button type="button" id="item-delete-selected" class="btn btn-link" title="{{$dropping}}" onclick="deleteCheckedItems();" data-toggle="tooltip">
+			<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
+		</button>
     {{/if}}
 {{/if}}

--- a/view/theme/frio/templates/jot-header.tpl
+++ b/view/theme/frio/templates/jot-header.tpl
@@ -204,7 +204,7 @@
 			jotActive();
 		});
 
-		$('body').on('click', '.p-category .filerm', function(e){
+		$('body').on('click', '.filerm', function(e){
 			e.preventDefault();
 
 			let $href = $(e.target).attr('href');

--- a/view/theme/frio/templates/jot-header.tpl
+++ b/view/theme/frio/templates/jot-header.tpl
@@ -204,13 +204,14 @@
 			jotActive();
 		});
 
-		$('body').on('click', '.filerm', function(e){
+		$('body').on('click', '.tag .filerm', function(e){
 			e.preventDefault();
 
-			let $href = $(e.target).attr('href');
+			let t = e.currentTarget
+			let $href = $(t).attr('href');
 			// Prevents arbitrary Ajax requests
 			if ($href.substr(0, 7) === 'filerm/') {
-				$(e.target).parent().removeClass('btn-success btn-danger');
+				$(t).parent().fadeOut(500)
 				$.post($href)
 				.done(function() {
 					liking = 1;

--- a/view/theme/frio/templates/profile/schedule.tpl
+++ b/view/theme/frio/templates/profile/schedule.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div class="generic-page-wrapper scheduled-posts-wrapper" style="background-color:transparent !important;box-shadow:none !important;border:none !important;">
-	<h1>{{$title}}</h1>
+<h2>{{$title}}</h2>
 {{foreach $schedule as $row}}
 <div id="tread-wapper-{{$row.item['uri-id']}}" class="tread-wrapper toplevel_item {{$row.item.network}} panel-default panel">
 	<div class="item-{{$row.item['uri-id']}} wall-item-container {{$row.item.network}} thread_level_1 panel-body h-entry" id="item-{{$row.item.guid}}">
@@ -65,15 +65,15 @@
 			</div>
 			<div class="wall-item-bottom">
 				<div class="wall-item-links"></div>
-				<div class="wall-item-tags">
+				<div class="tags wall-item-tags">
 					{{foreach $row.item.hashtags as $tag}}
-						<span class="tag label label-default">{{$tag nofilter}}</span>
+						<span class="tag hashtag label border border-default">{{$tag nofilter}}</span>
 					{{/foreach}}
 					{{foreach $row.item.mentions as $tag}}
-						<span class="tag mention label label-warning">{{$tag nofilter}}</span>
+						<span class="tag mention label border border-primary">{{$tag nofilter}}</span>
 					{{/foreach}}
 					{{foreach $row.item.implicit_mentions as $tag}}
-						<span class="tag mention label label-default">{{$tag nofilter}}</span>
+						<span class="tag mention label border border-info">{{$tag nofilter}}</span>
 					{{/foreach}}
 				</div>
 			</div>

--- a/view/theme/frio/templates/profile/schedule.tpl
+++ b/view/theme/frio/templates/profile/schedule.tpl
@@ -67,13 +67,13 @@
 				<div class="wall-item-links"></div>
 				<div class="wall-item-tags">
 					{{foreach $row.item.hashtags as $tag}}
-						<span class="tag label btn-info sm">{{$tag nofilter}} <i class="ri ri-flashlight-line" aria-hidden="true"></i></span>
+						<span class="tag label label-default">{{$tag nofilter}}</span>
 					{{/foreach}}
 					{{foreach $row.item.mentions as $tag}}
-						<span class="mention label btn-warning sm">{{$tag nofilter}} <i class="ri ri-user-line" aria-hidden="true"></i></span>
+						<span class="tag mention label label-warning">{{$tag nofilter}}</span>
 					{{/foreach}}
 					{{foreach $row.item.implicit_mentions as $tag}}
-						<span class="mention label label-default sm">{{$tag nofilter}} <i class="ri ri-eye-off-line" aria-hidden="true"></i></span>
+						<span class="tag mention label label-default">{{$tag nofilter}}</span>
 					{{/foreach}}
 				</div>
 			</div>

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -125,20 +125,20 @@
 				<div class="wall-item-tags">
 			{{if !$item.suppress_tags}}
 				{{foreach $item.hashtags as $tag}}
-					<span class="tag label btn-info sm">{{$tag nofilter}} <i class="ri ri-flashlight-line" aria-hidden="true"></i></span>
+					<span class="tag label label-default">{{$tag nofilter}}</span>
 				{{/foreach}}
 
 				{{foreach $item.mentions as $tag}}
-					<span class="mention label btn-warning sm">{{$tag nofilter}} <i class="ri ri-user-line" aria-hidden="true"></i></span>
+					<span class="tag mention label label-warning">{{$tag nofilter}} <i class="ri ri-user-line" aria-hidden="true"></i></span>
 				{{/foreach}}
 			{{/if}}
 
 				{{foreach $item.folders as $cat}}
-					<span class="folder label btn-danger sm">{{$cat.name}}{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
+					<span class="tag folder label label-danger">{{$cat.name}}{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
 				{{/foreach}}
 
 				{{foreach $item.categories as $cat}}
-					<span class="category label btn-success sm">{{$cat.name}}{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
+					<span class="tag category label label-success">{{$cat.name}}{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
 				{{/foreach}}
 				</div>
 				{{if $item.edited}}<div class="itemedited text-muted">{{$item.edited['label']}} (<span title="{{$item.edited['date']}}">{{$item.edited['relative']}}</span>)</div>{{/if}}
@@ -152,14 +152,14 @@
 					{{* Buttons for like and dislike *}}
 					{{if $item.vote}}
 						{{if $item.vote.like}}
-					<button type="button" class="btn btn-defaultbutton-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doActivityItemAction({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}});"></button>
+					<button type="button" class="btn btn-default button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doActivityItemAction({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}});"></button>
 						{{/if}}
 						{{if $item.vote.like AND $item.vote.dislike}}
 					<span class="separator"aria-hidden="true">•</span>
 						{{/if}}
 
 						{{if $item.vote.dislike}}
-					<button type="button" class="btn btn-defaultbutton-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doActivityItemAction({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}});"></button>
+					<button type="button" class="btn btn-default button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doActivityItemAction({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}});"></button>
 						{{/if}}
 						{{if ($item.vote.like OR $item.vote.dislike) AND $item.comment_html}}
 					<span class="separator"aria-hidden="true">•</span>
@@ -277,9 +277,9 @@
 					{{* Event attendance buttons *}}
 				{{if $item.isevent}}
 					<span class="vote-event">
-						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});"><i class="ri ri-check-line" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i></button>
-						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});"><i class="ri ri-close-line" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i></button>
-						<button type="button" class="btn btn-defaultbutton-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});"><i class="ri ri-question-line" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i></button>
+						<button type="button" class="btn btn-default button-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});"><i class="ri ri-check-line" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i></button>
+						<button type="button" class="btn btn-default button-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});"><i class="ri ri-close-line" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i></button>
+						<button type="button" class="btn btn-default button-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});"><i class="ri ri-question-line" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i></button>
 					</span>
 				{{/if}}
 

--- a/view/theme/frio/templates/search_item.tpl
+++ b/view/theme/frio/templates/search_item.tpl
@@ -122,23 +122,25 @@
 			<!-- TODO -->
 			<div class="wall-item-bottom">
 				<div class="wall-item-links"></div>
-				<div class="wall-item-tags">
+				<div class="tags wall-item-tags">
 			{{if !$item.suppress_tags}}
 				{{foreach $item.hashtags as $tag}}
-					<span class="tag label label-default">{{$tag nofilter}}</span>
+					<span class="tag hashtag label border border-default">{{$tag nofilter}}</span>
 				{{/foreach}}
 
 				{{foreach $item.mentions as $tag}}
-					<span class="tag mention label label-warning">{{$tag nofilter}} <i class="ri ri-user-line" aria-hidden="true"></i></span>
+					<span class="tag mention label border border-primary">{{$tag nofilter}}</span>
 				{{/foreach}}
 			{{/if}}
 
+      {{* No implicit mentions unlike wall_thread? *}}
+
 				{{foreach $item.folders as $cat}}
-					<span class="tag folder label label-danger">{{$cat.name}}{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
+					<span class="tag folder label border border-success">{{$cat.name}}{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}"></a>) {{/if}} </span>
 				{{/foreach}}
 
 				{{foreach $item.categories as $cat}}
-					<span class="tag category label label-success">{{$cat.name}}{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}">x</a>) {{/if}} </span>
+					<span class="tag category label border border-danger">{{$cat.name}}{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" title="{{$remove}}"></a>) {{/if}} </span>
 				{{/foreach}}
 				</div>
 				{{if $item.edited}}<div class="itemedited text-muted">{{$item.edited['label']}} (<span title="{{$item.edited['date']}}">{{$item.edited['relative']}}</span>)</div>{{/if}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -283,26 +283,30 @@ as the value of $top_child_total (this is done at the end of this file)
 		<!-- TODO -->
 		<div class="wall-item-bottom">
 			<div class="wall-item-links"></div>
-			<div class="wall-item-tags" lang="{{$item.lang}}">
-		{{if !$item.suppress_tags}}
-			{{foreach $item.hashtags as $tag}}
-				<span class="tag label label-default">{{$tag nofilter}}</span>
-			{{/foreach}}
+			<div class="tags wall-item-tags" lang="{{$item.lang}}">
+			{{if !$item.suppress_tags}}
+				{{foreach $item.hashtags as $tag}}
+					<span class="tag hashtag label border border-default">{{$tag nofilter}}</span>
+				{{/foreach}}
 
-			{{foreach $item.mentions as $tag}}
-				<span class="tag mention label label-warning">{{$tag nofilter}}</span>
-			{{/foreach}}
+				{{foreach $item.mentions as $tag}}
+					<span class="tag mention label border border-primary">{{$tag nofilter}}</span>
+				{{/foreach}}
 
-			{{*foreach $item.implicit_mentions as $tag}}
-				<span class="tag mention label label-default">{{$tag nofilter}}</span>
-			{{/foreach*}}
-		{{/if}}
+				{{*foreach $item.implicit_mentions as $tag}}
+					<span class="tag mention label border border-info">{{$tag nofilter}}</span>
+				{{/foreach*}}
+			{{/if}}
 			{{foreach $item.folders as $folder}}
-				<span class="tag folder label label-danger"><a href="{{$folder.url}}">{{$folder.name}}</a>{{if $folder.removeurl}}<a href="{{$folder.removeurl}}" class="filerm" title="{{$remove}}">x</a>{{/if}}</span>
+				<span class="tag folder label border border-success">
+				  <a href="{{$folder.url}}">{{$folder.name}}</a>{{if $folder.removeurl}}<a href="{{$folder.removeurl}}" class="filerm" title="{{$remove}}"><i class="ri ri-close-circle-line" aria-hidden="true"></i></a>{{/if}}
+				</span>
 			{{/foreach}}
 
 			{{foreach $item.categories as $cat}}
-				<span class="tag category label btn-success"><a href="{{$cat.url}}">{{$cat.name}}</a>{{if $cat.removeurl}}<a href="{{$cat.removeurl}}" class="filerm" title="{{$remove}}">x</a>{{/if}}</span>
+				<span class="tag category label border border-danger">
+					<a href="{{$cat.url}}">{{$cat.name}}</a>{{if $cat.removeurl}}<a href="{{$cat.removeurl}}" class="filerm" title="{{$remove}}"><i class="ri ri-close-circle-line" aria-hidden="true"></i></a>{{/if}}
+				</span>
 			{{/foreach}}
 			</div>
 			{{if $item.edited}}<div class="itemedited text-muted">{{$item.edited['label']}} (<span title="{{$item.edited['date']}}">{{$item.edited['relative']}}</span>)</div>{{/if}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -286,23 +286,23 @@ as the value of $top_child_total (this is done at the end of this file)
 			<div class="wall-item-tags" lang="{{$item.lang}}">
 		{{if !$item.suppress_tags}}
 			{{foreach $item.hashtags as $tag}}
-				<span class="tag label btn-info sm">{{$tag nofilter}} <i class="ri ri-flashlight-line" aria-hidden="true"></i></span>
+				<span class="tag label label-default">{{$tag nofilter}}</span>
 			{{/foreach}}
 
 			{{foreach $item.mentions as $tag}}
-				<span class="mention label btn-warning sm">{{$tag nofilter}} <i class="ri ri-user-line" aria-hidden="true"></i></span>
+				<span class="tag mention label label-warning">{{$tag nofilter}}</span>
 			{{/foreach}}
 
 			{{*foreach $item.implicit_mentions as $tag}}
-				<span class="mention label label-default sm">{{$tag nofilter}} <i class="ri ri-eye-off-line" aria-hidden="true"></i></span>
+				<span class="tag mention label label-default">{{$tag nofilter}}</span>
 			{{/foreach*}}
 		{{/if}}
 			{{foreach $item.folders as $folder}}
-				<span class="folder label btn-danger sm p-category">{{$folder.name}}{{if $folder.removeurl}} (<a href="{{$folder.removeurl}}" class="filerm" title="{{$remove}}">x</a>){{/if}}</span>
+				<span class="tag folder label label-danger"><a href="{{$folder.url}}">{{$folder.name}}</a>{{if $folder.removeurl}}<a href="{{$folder.removeurl}}" class="filerm" title="{{$remove}}">x</a>{{/if}}</span>
 			{{/foreach}}
 
 			{{foreach $item.categories as $cat}}
-				<span class="category label btn-success sm p-category"><a href="{{$cat.url}}">{{$cat.name}}</a>{{if $cat.removeurl}} (<a href="{{$cat.removeurl}}" class="filerm" title="{{$remove}}">x</a>){{/if}}</span>
+				<span class="tag category label btn-success"><a href="{{$cat.url}}">{{$cat.name}}</a>{{if $cat.removeurl}}<a href="{{$cat.removeurl}}" class="filerm" title="{{$remove}}">x</a>{{/if}}</span>
 			{{/foreach}}
 			</div>
 			{{if $item.edited}}<div class="itemedited text-muted">{{$item.edited['label']}} (<span title="{{$item.edited['date']}}">{{$item.edited['relative']}}</span>)</div>{{/if}}

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -1883,6 +1883,13 @@ profile-jot-form #jot-title, #profile-jot-form #jot-category {
 	/* padding-right: 8px; */
 	color: rgb(153,153,153);
 }
+
+.tagblock .tag-cloud .tag {
+	display: unset;
+}
+.tagblock .tag-cloud .tag:hover {
+	color: black;
+}
 .wwto {
 	position: absolute !important;
 	width: 25px;

--- a/view/theme/vier/templates/photo_item.tpl
+++ b/view/theme/vier/templates/photo_item.tpl
@@ -28,7 +28,7 @@
 	<div class="wall-item-bottom">
 		<div class="wall-item-links">
 		</div>
-		<div class="wall-item-tags">
+		<div class="wall-item-tags tags">
 			{{foreach $tags as $tag}}
 				<span class='tag'>{{$tag nofilter}}</span>
 			{{/foreach}}

--- a/view/theme/vier/templates/search_item.tpl
+++ b/view/theme/vier/templates/search_item.tpl
@@ -45,7 +45,7 @@
 	<div class="wall-item-bottom">
 		<div class="wall-item-links">
 		</div>
-		<div class="wall-item-tags">
+		<div class="wall-item-tags tags">
 		{{if !$item.suppress_tags}}
 			{{foreach $item.tags as $tag}}
 				<span class="tag">{{$tag nofilter}}</span>


### PR DESCRIPTION
Closes #15814

- Remove icons from tags
- Make "tags" to folders links to those folders
- Make it easier to style tags in a uniform way, and do that
- Make tag styling more Bookface and Mastodon-like
- Fix it so the entire tag is clickable (currently this is not the case)
- Fix mismatching pointer cursor on trending tags widget
- Add missing post delete icon
- Fix error in some CSS class references: `btn-defaultbutton-likes` -> `btn-default button-likes`
- Add reusable colors and border color classes that are normally present in later Bootstrap versions

Thanks to foss for suggestions/feedback!

**TODO before this PR is ready:**

- ~~Fix deleted no longer disappearing before reload, that somehow I managed to break~~

**Ponderings:**

- Not sure how to get/create an "implicit mention" to test that?
- Implicit mentions are not shown in the search results, unlike all the other tag-like types. Is that intentional?
- Should we hide the hashtags (probably not mentions) from the post content itself? Mastodon seems to do this, at least. (this might be quite challenging to change, though, and it would certainly be a separate PR.)

# Screenshots

<img width="665" height="388" alt="image" src="https://github.com/user-attachments/assets/2ff8f63c-ca99-4d16-ae10-c5e2895cf0be" />

<img width="654" height="604" alt="image" src="https://github.com/user-attachments/assets/181641e7-364a-4a13-856c-5b1eda64fbc9" />

<img width="361" height="214" alt="image" src="https://github.com/user-attachments/assets/22539599-2622-462b-82bf-1c95532d54dc" />