### PR TITLE
Fixes Moderator not in menu if moderator but not admin

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -306,6 +306,8 @@ class Nav
 		// Show the link to the admin configuration page if user is admin
 		if ($this->session->isSiteAdmin()) {
 			$nav['admin']      = ['admin/', $this->l10n->t('Admin'), '', $this->l10n->t('Site setup and configuration')];
+		}
+		if ($this->session->isModerator()) {
 			$nav['moderation'] = ['moderation/', $this->l10n->t('Moderation'), '', $this->l10n->t('Content and user moderation')];
 		}
 

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -305,7 +305,7 @@ class Nav
 
 		// Show the link to the admin configuration page if user is admin
 		if ($this->session->isSiteAdmin()) {
-			$nav['admin']      = ['admin/', $this->l10n->t('Admin'), '', $this->l10n->t('Site setup and configuration')];
+			$nav['admin'] = ['admin/', $this->l10n->t('Admin'), '', $this->l10n->t('Site setup and configuration')];
 		}
 		// Show the link to the moderation page if user is a moderator
 		if ($this->session->isModerator()) {

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -307,6 +307,7 @@ class Nav
 		if ($this->session->isSiteAdmin()) {
 			$nav['admin']      = ['admin/', $this->l10n->t('Admin'), '', $this->l10n->t('Site setup and configuration')];
 		}
+		// Show the link to the moderation page if user is a moderator
 		if ($this->session->isModerator()) {
 			$nav['moderation'] = ['moderation/', $this->l10n->t('Moderation'), '', $this->l10n->t('Content and user moderation')];
 		}


### PR DESCRIPTION
If someone was assigned the new Moderator role but was not an Administrator the "Moderator" entry in the main drop-down menu would never appear for them. This fixes that.