### PR TITLE
[Refactor] Improve type coverage

### DIFF
--- a/.rector.php
+++ b/.rector.php
@@ -19,7 +19,7 @@ return \Rector\Config\RectorConfig::configure()
 	])
 	->withIndent("\t", 4)
 	->withPhpVersion(80200)
-	->withTypeCoverageLevel(3)
+	->withTypeCoverageLevel(6)
 	// ->withDeadCodeLevel(0)
 	// ->withCodeQualityLevel(0)
 	->withSets([

--- a/.rector.php
+++ b/.rector.php
@@ -19,7 +19,7 @@ return \Rector\Config\RectorConfig::configure()
 	])
 	->withIndent("\t", 4)
 	->withPhpVersion(80200)
-	->withTypeCoverageLevel(2)
+	->withTypeCoverageLevel(3)
 	// ->withDeadCodeLevel(0)
 	// ->withCodeQualityLevel(0)
 	->withSets([

--- a/.rector.php
+++ b/.rector.php
@@ -19,7 +19,7 @@ return \Rector\Config\RectorConfig::configure()
 	])
 	->withIndent("\t", 4)
 	->withPhpVersion(80200)
-	->withTypeCoverageLevel(1)
+	->withTypeCoverageLevel(2)
 	// ->withDeadCodeLevel(0)
 	// ->withCodeQualityLevel(0)
 	->withSets([

--- a/.rector.php
+++ b/.rector.php
@@ -19,7 +19,7 @@ return \Rector\Config\RectorConfig::configure()
 	])
 	->withIndent("\t", 4)
 	->withPhpVersion(80200)
-	->withTypeCoverageLevel(0)
+	->withTypeCoverageLevel(1)
 	// ->withDeadCodeLevel(0)
 	// ->withCodeQualityLevel(0)
 	->withSets([

--- a/.rector.php
+++ b/.rector.php
@@ -19,7 +19,7 @@ return \Rector\Config\RectorConfig::configure()
 	])
 	->withIndent("\t", 4)
 	->withPhpVersion(80200)
-	// ->withTypeCoverageLevel(0)
+	->withTypeCoverageLevel(0)
 	// ->withDeadCodeLevel(0)
 	// ->withCodeQualityLevel(0)
 	->withSets([

--- a/mod/item.php
+++ b/mod/item.php
@@ -32,7 +32,7 @@ use Friendica\Model\Post;
 use Friendica\Network\HTTPException;
 use Friendica\Util\DateTimeFormat;
 
-function item_post()
+function item_post(): void
 {
 	$uid = DI::userSession()->getLocalUserId();
 
@@ -74,7 +74,7 @@ function item_post()
 	}
 }
 
-function item_drop(int $uid, string $dropitems)
+function item_drop(int $uid, string $dropitems): void
 {
 	$arr_drop = explode(',', $dropitems);
 	foreach ($arr_drop as $item) {
@@ -84,7 +84,7 @@ function item_drop(int $uid, string $dropitems)
 	System::jsonExit(['success' => 1]);
 }
 
-function item_edit(int $uid, array $request, bool $preview, string $return_path)
+function item_edit(int $uid, array $request, bool $preview, string $return_path): void
 {
 	$post = Post::selectFirst(Item::ITEM_FIELDLIST, ['id' => $request['post_id'], 'uid' => $uid]);
 	if (!DBA::isResult($post)) {
@@ -132,7 +132,7 @@ function item_edit(int $uid, array $request, bool $preview, string $return_path)
 	throw new HTTPException\OKException(DI::l10n()->t('Post updated.'));
 }
 
-function item_insert(int $uid, array $request, bool $preview, string $return_path)
+function item_insert(int $uid, array $request, bool $preview, string $return_path): void
 {
 	$post = ['uid' => $uid];
 	$post = DI::contentItem()->initializePost($post);
@@ -344,7 +344,7 @@ function item_process(array $post, array $request, bool $preview, string $return
 	return $post;
 }
 
-function item_post_return($baseurl, $return_path)
+function item_post_return($baseurl, $return_path): void
 {
 	if ($return_path) {
 		DI::baseUrl()->redirect($return_path);
@@ -484,7 +484,7 @@ function drop_item(int $id, string $return = ''): string
 	return '';
 }
 
-function item_redirect_after_action(array $item, string $returnUrlHex)
+function item_redirect_after_action(array $item, string $returnUrlHex): void
 {
 	$return_url = hex2bin($returnUrlHex);
 

--- a/mod/message.php
+++ b/mod/message.php
@@ -22,7 +22,7 @@ use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
 use Friendica\Util\Temporal;
 
-function message_init()
+function message_init(): void
 {
 	$tabs               = '';
 	DI::page()['title'] = DI::l10n()->t('Messages');
@@ -50,7 +50,7 @@ function message_init()
 	]);
 }
 
-function message_post()
+function message_post(): void
 {
 	if (!DI::userSession()->getLocalUserId()) {
 		DI::sysmsg()->addNotice(DI::l10n()->t('Permission denied.'));

--- a/mod/photos.php
+++ b/mod/photos.php
@@ -28,7 +28,7 @@ use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
 use Friendica\Util\Strings;
 
-function photos_init()
+function photos_init(): void
 {
 	if (DI::config()->get('system', 'block_public') && !DI::userSession()->isAuthenticated()) {
 		return;
@@ -92,7 +92,7 @@ function photos_init()
 	return;
 }
 
-function photos_post()
+function photos_post(): void
 {
 	$user = User::getByNickname(DI::args()->getArgv()[1]);
 	if (!DBA::isResult($user)) {

--- a/src/App/Router.php
+++ b/src/App/Router.php
@@ -161,7 +161,7 @@ class Router
 	 */
 	private function addGroup(string $groupRoute, array $routes, RouteCollector $routeCollector)
 	{
-		$routeCollector->addGroup($groupRoute, function (RouteCollector $routeCollector) use ($routes) {
+		$routeCollector->addGroup($groupRoute, function (RouteCollector $routeCollector) use ($routes): void {
 			$this->addRoutes($routeCollector, $routes);
 		});
 	}

--- a/src/Console/Contact.php
+++ b/src/Console/Contact.php
@@ -231,7 +231,7 @@ HELP;
 		$table = new Console_Table();
 		$table->setHeaders(['ID', 'UID', 'Network', 'Name', 'Nick', 'URL', 'E-Mail', 'Created', 'Updated', 'Blocked', 'Deleted']);
 
-		$addRow = function ($row) use (&$table) {
+		$addRow = function ($row) use (&$table): void {
 			$table->addRow([
 				$row['id'],
 				$row['uid'],

--- a/src/Console/Daemon.php
+++ b/src/Console/Daemon.php
@@ -134,7 +134,7 @@ HELP;
 		if ($daemonMode == "start") {
 			$this->out("Starting Friendica daemon");
 
-			$this->daemon->start(function () {
+			$this->daemon->start(function (): void {
 				$wait_interval = intval($this->config->get('system', 'cron_interval', 5)) * 60;
 
 				$do_cron   = true;

--- a/src/Console/JetstreamDaemon.php
+++ b/src/Console/JetstreamDaemon.php
@@ -140,7 +140,7 @@ HELP;
 		if ($daemonMode == "start") {
 			$this->out("Starting Jetstream daemon");
 
-			$this->daemon->start(function () {
+			$this->daemon->start(function (): void {
 				$this->jetstream->listen();
 			}, $foreground);
 

--- a/src/Content/Conversation/Repository/UserDefinedChannel.php
+++ b/src/Content/Conversation/Repository/UserDefinedChannel.php
@@ -401,7 +401,7 @@ class UserDefinedChannel extends BaseRepository
 		if (empty($tags)) {
 			return false;
 		}
-		array_walk($tags, function (&$value) {
+		array_walk($tags, function (&$value): void {
 			$value = mb_strtolower($value);
 		});
 		foreach (explode(',', $tagList) as $tag) {

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2174,7 +2174,7 @@ class BBCode
 		// sanitizes src attributes (http and redir URLs for displaying in a web page, cid used for inline images in emails)
 		$allowed_src_protocols = ['//', 'http://', 'https://', 'contact/redir/', 'cid:'];
 
-		array_walk($allowed_src_protocols, function (&$value) {
+		array_walk($allowed_src_protocols, function (&$value): void {
 			$value = preg_quote($value, '#');
 		});
 
@@ -2194,7 +2194,7 @@ class BBCode
 		$allowed_link_protocols[] = 'https://';
 		$allowed_link_protocols[] = 'contact/redir/';
 
-		array_walk($allowed_link_protocols, function (&$value) {
+		array_walk($allowed_link_protocols, function (&$value): void {
 			$value = preg_quote($value, '#');
 		});
 
@@ -2386,7 +2386,7 @@ class BBCode
 		DI::profiler()->startRecording('rendering');
 		$ret = [];
 
-		self::performWithEscapedTags($string, ['noparse', 'pre', 'code', 'img', 'attachment'], function ($string) use (&$ret) {
+		self::performWithEscapedTags($string, ['noparse', 'pre', 'code', 'img', 'attachment'], function ($string) use (&$ret): void {
 			// Convert hashtag links to hashtags
 			$string = preg_replace('/#\[url\=([^\[\]]*)\](.*?)\[\/url\]/ism', '#$2 ', (string) $string);
 

--- a/src/Content/Text/HTML.php
+++ b/src/Content/Text/HTML.php
@@ -943,7 +943,7 @@ class HTML
 
 		$config->set('HTML.SafeIframe', true);
 
-		array_walk($allowedIframeDomains, function (&$domain) {
+		array_walk($allowedIframeDomains, function (&$domain): void {
 			// Allow the domain and all its eventual sub-domains
 			$domain = '(?:(?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)*' . preg_quote(trim($domain, '/'), '%');
 		});

--- a/src/Content/Widget.php
+++ b/src/Content/Widget.php
@@ -198,7 +198,7 @@ class Widget
 			$baseUrl = trim($baseUrl, '?') . '?';
 		}
 
-		array_walk($options, function (&$value) {
+		array_walk($options, function (&$value): void {
 			$value['ref'] = rawurlencode((string) $value['ref']);
 		});
 

--- a/src/Core/ACL.php
+++ b/src/Core/ACL.php
@@ -167,7 +167,7 @@ class ACL
 
 		$acl_contacts = array_merge($acl_groups, $acl_contacts);
 
-		array_walk($acl_contacts, function (&$value) {
+		array_walk($acl_contacts, function (&$value): void {
 			$value['type'] = 'contact';
 		});
 

--- a/src/Core/Cache/Type/AbstractCache.php
+++ b/src/Core/Cache/Type/AbstractCache.php
@@ -55,7 +55,7 @@ abstract class AbstractCache implements ICanCache
 			return [];
 		} else {
 			// Keys are prefixed with the node hostname, let's remove it
-			array_walk($keys, function (&$value) {
+			array_walk($keys, function (&$value): void {
 				$value = preg_replace('/^' . $this->hostName . ':/', '', $value);
 			});
 

--- a/src/Core/Cache/Type/MemcachedCache.php
+++ b/src/Core/Cache/Type/MemcachedCache.php
@@ -56,7 +56,7 @@ class MemcachedCache extends AbstractCache implements ICanCacheInMemory
 
 		$memcached_hosts = $config->get('system', 'memcached_hosts');
 
-		array_walk($memcached_hosts, function (&$value) {
+		array_walk($memcached_hosts, function (&$value): void {
 			if (is_string($value)) {
 				$value = array_map(trim(...), explode(',', $value));
 			}

--- a/src/Core/L10n.php
+++ b/src/Core/L10n.php
@@ -567,7 +567,7 @@ class L10n
 	 * */
 	public function langToLocaleCode($lang)
 	{
-		return preg_replace_callback("/([a-z]+)-([a-z]+)/", fn ($m) => $m[1] . "_" . strtoupper($m[2]), $lang);
+		return preg_replace_callback("/([a-z]+)-([a-z]+)/", fn ($m): string => $m[1] . "_" . strtoupper((string) $m[2]), $lang);
 	}
 
 	/**

--- a/src/Core/Lock/Type/CacheLock.php
+++ b/src/Core/Lock/Type/CacheLock.php
@@ -122,7 +122,7 @@ class CacheLock extends AbstractLock
 			throw new LockPersistenceException(sprintf('Cannot get locks with prefix %s', $prefix), $exception);
 		}
 
-		array_walk($locks, function (&$lock) {
+		array_walk($locks, function (&$lock): void {
 			$lock = substr($lock, strlen(self::CACHE_PREFIX));
 		});
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1428,7 +1428,7 @@ class Database
 			}
 		}
 
-		array_walk($fields, function (&$value, $key) use ($options) {
+		array_walk($fields, function (&$value, $key) use ($options): void {
 			$field = $value;
 			$value = DBA::quoteIdentifier($field);
 

--- a/src/Model/Tag.php
+++ b/src/Model/Tag.php
@@ -670,7 +670,7 @@ class Tag
 			return '';
 		}
 
-		array_walk($blocked, function (&$value) {
+		array_walk($blocked, function (&$value): void {
 			$value = "'" . DBA::escape(trim($value)) . "'";
 		});
 		return ' AND NOT `name` IN (' . implode(',', $blocked) . ')';

--- a/src/Module/Api/Twitter/ContactEndpoint.php
+++ b/src/Module/Api/Twitter/ContactEndpoint.php
@@ -160,7 +160,7 @@ abstract class ContactEndpoint extends BaseApi
 		}
 
 		if ($stringify_ids) {
-			array_walk($ids, function (&$contactId) {
+			array_walk($ids, function (&$contactId): void {
 				$contactId = (string) $contactId;
 			});
 		}

--- a/src/Module/Moderation/Blocklist/Server/Add.php
+++ b/src/Module/Moderation/Blocklist/Server/Add.php
@@ -92,7 +92,7 @@ class Add extends BaseModeration
 			$gservers = GServer::listByDomainPattern($pattern);
 		}
 
-		array_walk($gservers, function (array &$gserver) {
+		array_walk($gservers, function (array &$gserver): void {
 			$gserver['domain']       = (new Uri($gserver['url']))->getHost();
 			$gserver['network_svg']  = ContactSelector::networkToSVG($gserver['network']);
 			$gserver['network_name'] = ContactSelector::networkToName($gserver['network']);

--- a/src/Module/User/Import.php
+++ b/src/Module/User/Import.php
@@ -248,7 +248,7 @@ class Import extends \Friendica\BaseModule
 		unset($account['user']['account_expires_on']);
 		unset($account['user']['expire_notification_sent']);
 
-		array_walk($account['user'], function (&$user) use ($oldBaseUrl, $oldAddr, $newBaseUrl, $newAddr) {
+		array_walk($account['user'], function (&$user) use ($oldBaseUrl, $oldAddr, $newBaseUrl, $newAddr): void {
 			$user = str_replace([$oldBaseUrl, $oldAddr], [$newBaseUrl, $newAddr], $user);
 		});
 
@@ -265,9 +265,9 @@ class Import extends \Friendica\BaseModule
 
 		$errorCount = 0;
 
-		array_walk($account['contact'], function (&$contact) use (&$errorCount, $oldUid, $oldBaseUrl, $oldAddr, $newUid, $newBaseUrl, $newAddr) {
+		array_walk($account['contact'], function (&$contact) use (&$errorCount, $oldUid, $oldBaseUrl, $oldAddr, $newUid, $newBaseUrl, $newAddr): void {
 			if ($contact['uid'] == $oldUid && $contact['self'] == '1') {
-				array_walk($contact, function (&$field) use ($oldUid, $oldBaseUrl, $oldAddr, $newUid, $newBaseUrl, $newAddr) {
+				array_walk($contact, function (&$field) use ($oldUid, $oldBaseUrl, $oldAddr, $newUid, $newBaseUrl, $newAddr): void {
 					$field = str_replace([$oldBaseUrl, $oldAddr], [$newBaseUrl, $newAddr], $field);
 					foreach (['profile', 'avatar', 'micro'] as $key) {
 						$field = str_replace($oldBaseUrl . '/photo/' . $key . '/' . $oldUid . '.jpg', $newBaseUrl . '/photo/' . $key . '/' . $newUid . '.jpg', $field);
@@ -307,7 +307,7 @@ class Import extends \Friendica\BaseModule
 			$this->systemMessages->addNotice($this->tt('%d contact not imported', '%d contacts not imported', $errorCount));
 		}
 
-		array_walk($account['circle'], function (&$circle) use ($newUid) {
+		array_walk($account['circle'], function (&$circle) use ($newUid): void {
 			$circle['uid'] = $newUid;
 			if ($this->dbImportAssoc('group', $circle) === false) {
 				$this->logger->warning('Error inserting circle', ['name' => $circle['name'], 'error' => $this->database->errorMessage()]);
@@ -343,7 +343,7 @@ class Import extends \Friendica\BaseModule
 			unset($profile['id']);
 			$profile['uid'] = $newUid;
 
-			array_walk($profile, function (&$field) use ($oldUid, $oldBaseUrl, $oldAddr, $newUid, $newBaseUrl, $newAddr) {
+			array_walk($profile, function (&$field) use ($oldUid, $oldBaseUrl, $oldAddr, $newUid, $newBaseUrl, $newAddr): void {
 				$field = str_replace([$oldBaseUrl, $oldAddr], [$newBaseUrl, $newAddr], $field);
 				foreach (['profile', 'avatar'] as $key) {
 					$field = str_replace($oldBaseUrl . '/photo/' . $key . '/' . $oldUid . '.jpg', $newBaseUrl . '/photo/' . $key . '/' . $newUid . '.jpg', $field);

--- a/src/Navigation/Notifications/Collection/Notifications.php
+++ b/src/Navigation/Notifications/Collection/Notifications.php
@@ -19,7 +19,7 @@ class Notifications extends BaseCollection
 
 	public function setSeen(): Notifications
 	{
-		$notifications = $this->map(function (NotificationEntity $notification) {
+		$notifications = $this->map(function (NotificationEntity $notification): void {
 			$notification->setSeen();
 		});
 
@@ -37,7 +37,7 @@ class Notifications extends BaseCollection
 
 	public function setDismissed(): Notifications
 	{
-		$notifications = $this->map(function (NotificationEntity $notification) {
+		$notifications = $this->map(function (NotificationEntity $notification): void {
 			$notification->setDismissed();
 		});
 

--- a/src/Navigation/Notifications/Collection/Notifies.php
+++ b/src/Navigation/Notifications/Collection/Notifies.php
@@ -19,7 +19,7 @@ class Notifies extends BaseCollection
 
 	public function setSeen(): Notifies
 	{
-		$notifies = $this->map(function (NotifyEntity $notify) {
+		$notifies = $this->map(function (NotifyEntity $notify): void {
 			$notify->setSeen();
 		});
 

--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -128,7 +128,7 @@ class HttpClient implements ICanSendHttpRequests
 			$conf[RequestOptions::AUTH] = $opts[HttpClientOptions::AUTH];
 		}
 
-		$conf[RequestOptions::ON_HEADERS] = function (ResponseInterface $response) use ($opts) {
+		$conf[RequestOptions::ON_HEADERS] = function (ResponseInterface $response) use ($opts): void {
 			if (
 				!empty($opts[HttpClientOptions::CONTENT_LENGTH])
 				&& (int) $response->getHeaderLine('Content-Length') > $opts[HttpClientOptions::CONTENT_LENGTH]

--- a/src/Network/HTTPClient/Factory/HttpClient.php
+++ b/src/Network/HTTPClient/Factory/HttpClient.php
@@ -62,7 +62,7 @@ class HttpClient extends BaseFactory
 			RequestInterface $request,
 			ResponseInterface $response,
 			UriInterface $uri,
-		) use ($logger) {
+		) use ($logger): void {
 			$logger->info('Curl redirect.', ['url' => $request->getUri(), 'to' => $uri, 'method' => $request->getMethod()]);
 		};
 

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -942,7 +942,7 @@ class Diaspora
 	{
 		preg_replace_callback(
 			"=diaspora://.*?/post/([0-9A-Za-z\-_@.:]{15,254}[0-9A-Za-z])=ism",
-			function ($match) use ($item) {
+			function ($match) use ($item): void {
 				self::fetchGuidSub($match, $item);
 			},
 			(string) $item['body'],
@@ -950,7 +950,7 @@ class Diaspora
 
 		preg_replace_callback(
 			"&\[url=/?posts/([^\[\]]*)\](.*)\[\/url\]&Usi",
-			function ($match) use ($item) {
+			function ($match) use ($item): void {
 				self::fetchGuidSub($match, $item);
 			},
 			(string) $item['body'],

--- a/src/Protocol/HTTP/MediaType.php
+++ b/src/Protocol/HTTP/MediaType.php
@@ -129,7 +129,7 @@ final class MediaType implements \Stringable
 	{
 		$parameters = $this->parameters;
 
-		array_walk($parameters, function (&$value, $key) {
+		array_walk($parameters, function (&$value, $key): void {
 			$value = '; ' . $key . '=' . (self::isToken($value) ? $value : '"' . addcslashes($value, '"\\') . '"');
 		});
 

--- a/src/Security/TwoFactor/Model/AppSpecificPassword.php
+++ b/src/Security/TwoFactor/Model/AppSpecificPassword.php
@@ -71,7 +71,7 @@ class AppSpecificPassword
 
 		$appSpecificPasswords = DBA::toArray($appSpecificPasswordsStmt);
 
-		array_walk($appSpecificPasswords, function (&$value) {
+		array_walk($appSpecificPasswords, function (&$value): void {
 			$value['ago']   = Temporal::getRelativeDate($value['last_used']);
 			$value['utc']   = $value['last_used'] ? DateTimeFormat::utc($value['last_used'], 'c') : '';
 			$value['local'] = $value['last_used'] ? DateTimeFormat::local($value['last_used'], 'r') : '';

--- a/src/Util/Images.php
+++ b/src/Util/Images.php
@@ -407,7 +407,7 @@ class Images
 	 */
 	private static function sanitizeExifArray(array $exif): array
 	{
-		array_walk_recursive($exif, function (&$value) {
+		array_walk_recursive($exif, function (&$value): void {
 			if (is_string($value)) {
 				$value = trim(iconv('UTF-8', 'UTF-8//IGNORE', $value));
 			}

--- a/src/Util/JsonLD.php
+++ b/src/Util/JsonLD.php
@@ -119,7 +119,7 @@ class JsonLD
 	{
 		$valid = true;
 
-		array_walk_recursive($data, function (&$value, $key) use ($data, &$valid) {
+		array_walk_recursive($data, function (&$value, $key) use ($data, &$valid): void {
 			$suspicious = ['@graph', '@included', '@reverse'];
 			if (in_array((string) $key, $suspicious) || in_array((string) $value, $suspicious)) {
 				DI::logger()->warning('Document with suspicious commands.', ['key' => $key, 'value' => $value, 'document' => $data]);
@@ -249,7 +249,7 @@ class JsonLD
 		}
 
 		// Issue 14448: Peertube transmits an unexpected type and schema URL.
-		array_walk_recursive($json['@context'], function (&$value, $key) {
+		array_walk_recursive($json['@context'], function (&$value, $key): void {
 			if ($key == '@type' && $value == '@json') {
 				DI::logger()->debug('"@json" converted to "@id"');
 				$value = '@id';
@@ -266,7 +266,7 @@ class JsonLD
 		});
 
 		// Bookwyrm transmits "id" fields with "null", which isn't allowed.
-		array_walk_recursive($json, function (&$value, $key) {
+		array_walk_recursive($json, function (&$value, $key): void {
 			if ($key == 'id' && is_null($value)) {
 				DI::logger()->debug('Fixed null id');
 				$value = '';

--- a/src/Util/ParseUrl.php
+++ b/src/Util/ParseUrl.php
@@ -672,7 +672,7 @@ class ParseUrl
 	private static function checkMedia(string $page_url, array $siteinfo): array
 	{
 		if (!empty($siteinfo['images'])) {
-			array_walk($siteinfo['images'], function (&$image) use ($page_url) {
+			array_walk($siteinfo['images'], function (&$image) use ($page_url): void {
 				/*
 				 * According to the specifications someone could place a picture
 				 * URL into the content field as well. But this doesn't seem to
@@ -703,7 +703,7 @@ class ParseUrl
 
 		foreach (['audio', 'video'] as $element) {
 			if (!empty($siteinfo[$element])) {
-				array_walk($siteinfo[$element], function (&$media) use ($page_url) {
+				array_walk($siteinfo[$element], function (&$media) use ($page_url): void {
 					$url         = '';
 					$embed       = '';
 					$content     = '';
@@ -882,7 +882,7 @@ class ParseUrl
 			}
 		}
 
-		array_walk_recursive($siteinfo, function (&$element) {
+		array_walk_recursive($siteinfo, function (&$element): void {
 			if (is_string($element)) {
 				$element = trim(strip_tags(html_entity_decode($element, ENT_COMPAT, 'UTF-8')));
 			}

--- a/src/Util/Writer/DocWriter.php
+++ b/src/Util/Writer/DocWriter.php
@@ -51,7 +51,7 @@ class DocWriter
 				$lengths['fields'] = max($lengths['fields'], strlen($fieldlist));
 			}
 
-			array_walk_recursive($indexes, function (&$value, $key) use ($lengths) {
+			array_walk_recursive($indexes, function (&$value, $key) use ($lengths): void {
 				$value = str_pad((string) $value, $lengths[$key], $value === '-' ? '-' : ' ');
 			});
 
@@ -110,7 +110,7 @@ class DocWriter
 				}
 			}
 
-			array_walk_recursive($fields, function (&$value, $key) use ($lengths) {
+			array_walk_recursive($fields, function (&$value, $key) use ($lengths): void {
 				$value = str_pad((string) $value, $lengths[$key], $value === '-' ? '-' : ' ');
 			});
 

--- a/tests/CacheLockTestCase.php
+++ b/tests/CacheLockTestCase.php
@@ -19,7 +19,7 @@ abstract class CacheLockTestCase extends LockTestCase
 	/**
 	 * Test if the getStats() result is identically to the getCacheStats()
 	 */
-	public function testGetStats()
+	public function testGetStats(): void
 	{
 		self::assertSame(array_keys($this->getCache()->getStats()), array_keys($this->instance->getCacheStats()));
 	}

--- a/tests/CacheTestCase.php
+++ b/tests/CacheTestCase.php
@@ -79,7 +79,7 @@ abstract class CacheTestCase extends MockedTestCase
 	 * @param mixed $value2 a second
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSimple')]
-	public function testSimple($value1, $value2, $value3, $value4)
+	public function testSimple($value1, $value2, $value3, $value4): void
 	{
 		self::assertNull($this->instance->get('value1'));
 
@@ -110,7 +110,7 @@ abstract class CacheTestCase extends MockedTestCase
 	 * @param mixed $value4 a fourth
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSimple')]
-	public function testClear($value1, $value2, $value3, $value4)
+	public function testClear($value1, $value2, $value3, $value4): void
 	{
 		$this->instance->set('1_value1', $value1);
 		$this->instance->set('1_value2', $value2);
@@ -158,7 +158,7 @@ abstract class CacheTestCase extends MockedTestCase
 		]);
 	}
 
-	public function testTTL()
+	public function testTTL(): void
 	{
 		static::markTestSkipped('taking too much time without mocking');
 
@@ -178,7 +178,7 @@ abstract class CacheTestCase extends MockedTestCase
 	 * @param mixed $data the data to store in the cache
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTypesInCache')]
-	public function testDifferentTypesInCache($data)
+	public function testDifferentTypesInCache($data): void
 	{
 		$this->instance->set('val', $data);
 		$received = $this->instance->get('val');
@@ -191,7 +191,7 @@ abstract class CacheTestCase extends MockedTestCase
 	 * @param mixed $value3 a third
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSimple')]
-	public function testGetAllKeys($value1, $value2, $value3, $value4)
+	public function testGetAllKeys($value1, $value2, $value3, $value4): void
 	{
 		self::assertTrue($this->instance->set('value1', $value1));
 		self::assertTrue($this->instance->set('value2', $value2));
@@ -210,13 +210,13 @@ abstract class CacheTestCase extends MockedTestCase
 		self::assertNotContains('value2', $list);
 	}
 
-	public function testSpaceInKey()
+	public function testSpaceInKey(): void
 	{
 		self::assertTrue($this->instance->set('key space', 'value'));
 		self::assertEquals('value', $this->instance->get('key space'));
 	}
 
-	public function testGetName()
+	public function testGetName(): void
 	{
 		if (defined($this->instance::class . '::NAME')) {
 			self::assertEquals($this->instance::NAME, $this->instance->getName());

--- a/tests/Fixtures/legacy/legacy.php
+++ b/tests/Fixtures/legacy/legacy.php
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-function legacy_init()
+function legacy_init(): void
 {
 	// I don't do nothing
 }

--- a/tests/Functional/DependencyCheckTest.php
+++ b/tests/Functional/DependencyCheckTest.php
@@ -33,7 +33,7 @@ class DependencyCheckTest extends FixtureTestCase
 	/**
 	 * Test the creation of the BasePath
 	 */
-	public function testBasePath()
+	public function testBasePath(): void
 	{
 		/** @var BasePath $basePath */
 		$basePath = $this->dice->create(BasePath::class, [$this->root->url()]);
@@ -49,7 +49,7 @@ class DependencyCheckTest extends FixtureTestCase
 	 * Test the initial config cache
 	 * Should not need any other files
 	 */
-	public function testConfigFileLoader()
+	public function testConfigFileLoader(): void
 	{
 		/** @var ConfigFileManager $configFileManager */
 		$configFileManager = $this->dice->create(ConfigFileManager::class);
@@ -64,7 +64,7 @@ class DependencyCheckTest extends FixtureTestCase
 		self::assertArrayHasKey('system', $configCache->getAll());
 	}
 
-	public function testDatabase()
+	public function testDatabase(): void
 	{
 		/** @var Database $database */
 		$database = $this->dice->create(Database::class);
@@ -80,7 +80,7 @@ class DependencyCheckTest extends FixtureTestCase
 		self::assertTrue($database->connected(), 'The database is not connected');
 	}
 
-	public function testAppMode()
+	public function testAppMode(): void
 	{
 		/** @var App\Mode $mode */
 		$mode = $this->dice->create(App\Mode::class);
@@ -94,7 +94,7 @@ class DependencyCheckTest extends FixtureTestCase
 		self::assertTrue($mode->isNormal(), 'Not in normal mode');
 	}
 
-	public function testConfiguration()
+	public function testConfiguration(): void
 	{
 		/** @var IManageConfigValues $config */
 		$config = $this->dice->create(IManageConfigValues::class);
@@ -104,7 +104,7 @@ class DependencyCheckTest extends FixtureTestCase
 		self::assertNotEmpty($config->get('database', 'username'));
 	}
 
-	public function testLogger()
+	public function testLogger(): void
 	{
 		/** @var LoggerInterface $logger */
 		$logger = $this->dice->create(LoggerInterface::class, [['$channel' => 'test']]);
@@ -112,7 +112,7 @@ class DependencyCheckTest extends FixtureTestCase
 		self::assertInstanceOf(LoggerInterface::class, $logger);
 	}
 
-	public function testCache()
+	public function testCache(): void
 	{
 		/** @var ICanCache $cache */
 		$cache = $this->dice->create(ICanCache::class);
@@ -121,7 +121,7 @@ class DependencyCheckTest extends FixtureTestCase
 		self::assertInstanceOf(ICanCache::class, $cache);
 	}
 
-	public function testMemoryCache()
+	public function testMemoryCache(): void
 	{
 		/** @var ICanCacheInMemory $cache */
 		$cache = $this->dice->create(ICanCacheInMemory::class);
@@ -130,7 +130,7 @@ class DependencyCheckTest extends FixtureTestCase
 		self::assertInstanceOf(ICanCache::class, $cache);
 	}
 
-	public function testLock()
+	public function testLock(): void
 	{
 		/** @var ICanLock $cache */
 		$lock = $this->dice->create(ICanLock::class);

--- a/tests/LockTestCase.php
+++ b/tests/LockTestCase.php
@@ -36,7 +36,7 @@ abstract class LockTestCase extends MockedTestCase
 		parent::tearDown();
 	}
 
-	public function testLock()
+	public function testLock(): void
 	{
 		self::assertFalse($this->instance->isLocked('foo'));
 		self::assertTrue($this->instance->acquire('foo', 1));
@@ -44,7 +44,7 @@ abstract class LockTestCase extends MockedTestCase
 		self::assertFalse($this->instance->isLocked('bar'));
 	}
 
-	public function testDoubleLock()
+	public function testDoubleLock(): void
 	{
 		self::assertFalse($this->instance->isLocked('foo'));
 		self::assertTrue($this->instance->acquire('foo', 1));
@@ -53,7 +53,7 @@ abstract class LockTestCase extends MockedTestCase
 		self::assertTrue($this->instance->acquire('foo', 1));
 	}
 
-	public function testReleaseLock()
+	public function testReleaseLock(): void
 	{
 		self::assertFalse($this->instance->isLocked('foo'));
 		self::assertTrue($this->instance->acquire('foo', 1));
@@ -62,7 +62,7 @@ abstract class LockTestCase extends MockedTestCase
 		self::assertFalse($this->instance->isLocked('foo'));
 	}
 
-	public function testReleaseAll()
+	public function testReleaseAll(): void
 	{
 		self::assertTrue($this->instance->acquire('foo', 1));
 		self::assertTrue($this->instance->acquire('bar', 1));
@@ -79,7 +79,7 @@ abstract class LockTestCase extends MockedTestCase
 		self::assertFalse($this->instance->isLocked('nice'));
 	}
 
-	public function testReleaseAfterUnlock()
+	public function testReleaseAfterUnlock(): void
 	{
 		self::assertFalse($this->instance->isLocked('foo'));
 		self::assertFalse($this->instance->isLocked('bar'));
@@ -100,7 +100,7 @@ abstract class LockTestCase extends MockedTestCase
 		self::assertFalse($this->instance->isLocked('nice'));
 	}
 
-	public function testReleaseWitTTL()
+	public function testReleaseWitTTL(): void
 	{
 		self::assertFalse($this->instance->isLocked('test'));
 		self::assertTrue($this->instance->acquire('test', 1, 10));
@@ -109,7 +109,7 @@ abstract class LockTestCase extends MockedTestCase
 		self::assertFalse($this->instance->isLocked('test'));
 	}
 
-	public function testGetLocks()
+	public function testGetLocks(): void
 	{
 		self::assertTrue($this->instance->acquire('foo', 1));
 		self::assertTrue($this->instance->acquire('bar', 1));
@@ -126,7 +126,7 @@ abstract class LockTestCase extends MockedTestCase
 		self::assertContains('nice', $locks);
 	}
 
-	public function testGetLocksWithPrefix()
+	public function testGetLocksWithPrefix(): void
 	{
 		self::assertTrue($this->instance->acquire('foo', 1));
 		self::assertTrue($this->instance->acquire('test1', 1));
@@ -143,7 +143,7 @@ abstract class LockTestCase extends MockedTestCase
 		self::assertNotContains('foo', $locks);
 	}
 
-	public function testLockTTL()
+	public function testLockTTL(): void
 	{
 		static::markTestSkipped('taking too much time without mocking');
 
@@ -171,7 +171,7 @@ abstract class LockTestCase extends MockedTestCase
 	/**
 	 * Test if releasing a non-existing lock doesn't throw errors
 	 */
-	public function testReleaseLockWithoutLock()
+	public function testReleaseLockWithoutLock(): void
 	{
 		self::assertFalse($this->instance->isLocked('wrongLock'));
 		self::assertFalse($this->instance->release('wrongLock'));

--- a/tests/LoggerTestCase.php
+++ b/tests/LoggerTestCase.php
@@ -75,7 +75,7 @@ abstract class LoggerTestCase extends MockedTestCase
 	/**
 	 * Test if the logger works correctly
 	 */
-	public function testNormal()
+	public function testNormal(): void
 	{
 		$logger = $this->getInstance();
 		$logger->emergency('working!');
@@ -91,7 +91,7 @@ abstract class LoggerTestCase extends MockedTestCase
 	/**
 	 * Test if a log entry is correctly interpolated
 	 */
-	public function testPsrInterpolate()
+	public function testPsrInterpolate(): void
 	{
 		$logger = $this->getInstance();
 
@@ -105,7 +105,7 @@ abstract class LoggerTestCase extends MockedTestCase
 	/**
 	 * Test if a log entry contains all necessary information
 	 */
-	public function testContainsInformation()
+	public function testContainsInformation(): void
 	{
 		$logger = $this->getInstance();
 		$logger->emergency('A test');
@@ -119,7 +119,7 @@ abstract class LoggerTestCase extends MockedTestCase
 	/**
 	 * Test if the minimum level is working
 	 */
-	public function testMinimumLevel()
+	public function testMinimumLevel(): void
 	{
 		$logger = $this->getInstance(LogLevel::NOTICE);
 
@@ -140,7 +140,7 @@ abstract class LoggerTestCase extends MockedTestCase
 	 * Test with different logging data
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testDifferentTypes($function, $message, array $context)
+	public function testDifferentTypes($function, $message, array $context): void
 	{
 		$logger = $this->getInstance();
 		$logger->$function($message, $context);
@@ -155,7 +155,7 @@ abstract class LoggerTestCase extends MockedTestCase
 	/**
 	 * Test a message with an exception
 	 */
-	public function testExceptionHandling()
+	public function testExceptionHandling(): void
 	{
 		$e         = new \Exception("Test String", 123);
 		$eFollowUp = new \Exception("FollowUp", 456, $e);
@@ -171,7 +171,7 @@ abstract class LoggerTestCase extends MockedTestCase
 		self::assertStringContainsString(@json_encode($assertion, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE), $this->getContent());
 	}
 
-	public function testNoObjectHandling()
+	public function testNoObjectHandling(): void
 	{
 		$logger = $this->getInstance();
 		$logger->alert('test', ['e' => ['test' => 'test']]);

--- a/tests/MemoryCacheTestCase.php
+++ b/tests/MemoryCacheTestCase.php
@@ -27,7 +27,7 @@ abstract class MemoryCacheTestCase extends CacheTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSimple')]
-	public function testCompareSet($value1, $value2, $value3, $value4)
+	public function testCompareSet($value1, $value2, $value3, $value4): void
 	{
 		self::assertNull($this->instance->get('value1'));
 
@@ -41,7 +41,7 @@ abstract class MemoryCacheTestCase extends CacheTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSimple')]
-	public function testNegativeCompareSet($value1, $value2, $value3, $value4)
+	public function testNegativeCompareSet($value1, $value2, $value3, $value4): void
 	{
 		self::assertNull($this->instance->get('value1'));
 
@@ -56,7 +56,7 @@ abstract class MemoryCacheTestCase extends CacheTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSimple')]
-	public function testCompareDelete($value1, $value2, $value3, $value4)
+	public function testCompareDelete($value1, $value2, $value3, $value4): void
 	{
 		self::assertNull($this->instance->get('value1'));
 
@@ -68,7 +68,7 @@ abstract class MemoryCacheTestCase extends CacheTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSimple')]
-	public function testNegativeCompareDelete($value1, $value2, $value3, $value4)
+	public function testNegativeCompareDelete($value1, $value2, $value3, $value4): void
 	{
 		self::assertNull($this->instance->get('value1'));
 
@@ -83,7 +83,7 @@ abstract class MemoryCacheTestCase extends CacheTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSimple')]
-	public function testAdd($value1, $value2, $value3, $value4)
+	public function testAdd($value1, $value2, $value3, $value4): void
 	{
 		self::assertNull($this->instance->get('value1'));
 

--- a/tests/PConfigTestCase.php
+++ b/tests/PConfigTestCase.php
@@ -148,7 +148,7 @@ abstract class PConfigTestCase extends MockedTestCase
 	/**
 	 * Test the configuration initialization
 	 */
-	public function testSetUp()
+	public function testSetUp(): void
 	{
 		$this->testedConfig = $this->getInstance();
 		self::assertInstanceOf(Cache::class, $this->testedConfig->getCache());
@@ -159,7 +159,7 @@ abstract class PConfigTestCase extends MockedTestCase
 	/**
 	 * Test the configuration load() method
 	 */
-	public function testLoad(int $uid, array $data, array $possibleCats, array $load)
+	public function testLoad(int $uid, array $data, array $possibleCats, array $load): void
 	{
 		$this->testedConfig = $this->getInstance();
 		self::assertInstanceOf(Cache::class, $this->testedConfig->getCache());
@@ -242,7 +242,7 @@ abstract class PConfigTestCase extends MockedTestCase
 	/**
 	 * Test the configuration load() method with overwrite
 	 */
-	public function testCacheLoadDouble(int $uid, array $data1, array $data2, array $expect)
+	public function testCacheLoadDouble(int $uid, array $data1, array $data2, array $expect): void
 	{
 		$this->testedConfig = $this->getInstance();
 		self::assertInstanceOf(Cache::class, $this->testedConfig->getCache());
@@ -265,7 +265,7 @@ abstract class PConfigTestCase extends MockedTestCase
 	 * Test the configuration get() and set() methods without adapter
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetGetWithoutDB(int $uid, $data)
+	public function testSetGetWithoutDB(int $uid, $data): void
 	{
 		$this->testedConfig = $this->getInstance();
 		self::assertInstanceOf(Cache::class, $this->testedConfig->getCache());
@@ -280,7 +280,7 @@ abstract class PConfigTestCase extends MockedTestCase
 	 * Test the configuration get() and set() methods with a model/db
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetGetWithDB(int $uid, $data)
+	public function testSetGetWithDB(int $uid, $data): void
 	{
 		$this->configModel->shouldReceive('set')
 						  ->with($uid, 'test', 'it', $data)
@@ -299,7 +299,7 @@ abstract class PConfigTestCase extends MockedTestCase
 	/**
 	 * Test the configuration get() method with wrong value and no db
 	 */
-	public function testGetWrongWithoutDB()
+	public function testGetWrongWithoutDB(): void
 	{
 		$this->testedConfig = $this->getInstance();
 		self::assertInstanceOf(Cache::class, $this->testedConfig->getCache());
@@ -321,7 +321,7 @@ abstract class PConfigTestCase extends MockedTestCase
 	 * Test the configuration get() method with refresh
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testGetWithRefresh(int $uid, $data)
+	public function testGetWithRefresh(int $uid, $data): void
 	{
 		$this->configCache->load($uid, ['test' => ['it' => 'now']]);
 
@@ -345,7 +345,7 @@ abstract class PConfigTestCase extends MockedTestCase
 	 * Test the configuration delete() method without a model/db
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testDeleteWithoutDB(int $uid, $data)
+	public function testDeleteWithoutDB(int $uid, $data): void
 	{
 		$this->configCache->load($uid, ['test' => ['it' => $data]]);
 
@@ -365,7 +365,7 @@ abstract class PConfigTestCase extends MockedTestCase
 	/**
 	 * Test the configuration delete() method with a model/db
 	 */
-	public function testDeleteWithDB()
+	public function testDeleteWithDB(): void
 	{
 		$uid = 42;
 
@@ -443,7 +443,7 @@ abstract class PConfigTestCase extends MockedTestCase
 	 * Test if multiple uids for caching are usable without errors
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataMultiUid')]
-	public function testMultipleUidsWithCache(array $data1, array $data2)
+	public function testMultipleUidsWithCache(array $data1, array $data2): void
 	{
 		$this->configCache->load($data1['uid'], $data1['data']);
 		$this->configCache->load($data2['uid'], $data2['data']);
@@ -461,7 +461,7 @@ abstract class PConfigTestCase extends MockedTestCase
 	 * Test when using an invalid UID
 	 * @todo check it the clean way before using the config class
 	 */
-	public function testInvalidUid()
+	public function testInvalidUid(): void
 	{
 		// bad UID!
 		$uid = 0;

--- a/tests/StorageConfigTestCase.php
+++ b/tests/StorageConfigTestCase.php
@@ -20,7 +20,7 @@ abstract class StorageConfigTestCase extends MockedTestCase
 	/**
 	 * Test if the "getOption" is asserted
 	 */
-	public function testGetOptions()
+	public function testGetOptions(): void
 	{
 		$instance = $this->getInstance();
 

--- a/tests/StorageConfigTestCase.php
+++ b/tests/StorageConfigTestCase.php
@@ -8,7 +8,6 @@
 namespace Friendica\Test;
 
 use Friendica\Core\Storage\Capability\ICanConfigureStorage;
-use Friendica\Test\MockedTestCase;
 
 abstract class StorageConfigTestCase extends MockedTestCase
 {

--- a/tests/StorageTestCase.php
+++ b/tests/StorageTestCase.php
@@ -20,7 +20,7 @@ abstract class StorageTestCase extends MockedTestCase
 	/**
 	 * Test if the instance is "really" implementing the interface
 	 */
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$instance = $this->getInstance();
 		self::assertInstanceOf(ICanReadFromStorage::class, $instance);
@@ -29,7 +29,7 @@ abstract class StorageTestCase extends MockedTestCase
 	/**
 	 * Test basic put, get and delete operations
 	 */
-	public function testPutGetDelete()
+	public function testPutGetDelete(): void
 	{
 		$instance = $this->getInstance();
 
@@ -44,7 +44,7 @@ abstract class StorageTestCase extends MockedTestCase
 	/**
 	 * Test a delete with an invalid reference
 	 */
-	public function testInvalidDelete()
+	public function testInvalidDelete(): void
 	{
 		self::expectException(ReferenceStorageException::class);
 
@@ -56,7 +56,7 @@ abstract class StorageTestCase extends MockedTestCase
 	/**
 	 * Test a get with an invalid reference
 	 */
-	public function testInvalidGet()
+	public function testInvalidGet(): void
 	{
 		self::expectException(ReferenceStorageException::class);
 
@@ -68,7 +68,7 @@ abstract class StorageTestCase extends MockedTestCase
 	/**
 	 * Test an update with a given reference
 	 */
-	public function testUpdateReference()
+	public function testUpdateReference(): void
 	{
 		$instance = $this->getInstance();
 
@@ -84,7 +84,7 @@ abstract class StorageTestCase extends MockedTestCase
 	/**
 	 * Test that an invalid update results in an insert
 	 */
-	public function testInvalidUpdate()
+	public function testInvalidUpdate(): void
 	{
 		$instance = $this->getInstance();
 

--- a/tests/StorageTestCase.php
+++ b/tests/StorageTestCase.php
@@ -10,7 +10,6 @@ namespace Friendica\Test;
 use Friendica\Core\Storage\Capability\ICanReadFromStorage;
 use Friendica\Core\Storage\Capability\ICanWriteToStorage;
 use Friendica\Core\Storage\Exception\ReferenceStorageException;
-use Friendica\Test\MockedTestCase;
 
 abstract class StorageTestCase extends MockedTestCase
 {

--- a/tests/Unit/App/ArgumentsTest.php
+++ b/tests/Unit/App/ArgumentsTest.php
@@ -25,7 +25,7 @@ class ArgumentsTest extends TestCase
 	/**
 	 * Test the default argument without any determinations
 	 */
-	public function testDefault()
+	public function testDefault(): void
 	{
 		$arguments = new App\Arguments();
 
@@ -185,7 +185,7 @@ class ArgumentsTest extends TestCase
 	 * Test all variants of argument determination
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataArguments')]
-	public function testDetermine(array $server, array $get, array $expect)
+	public function testDetermine(array $server, array $get, array $expect): void
 	{
 		$arguments = (new App\Arguments())
 			->determine($server, $get);
@@ -197,7 +197,7 @@ class ArgumentsTest extends TestCase
 	 * Test if the get/has methods are working for the determined arguments
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataArguments')]
-	public function testGetHas(array $server, array $get, array $expect)
+	public function testGetHas(array $server, array $get, array $expect): void
 	{
 		$arguments = (new App\Arguments())
 			->determine($server, $get);
@@ -252,7 +252,7 @@ class ArgumentsTest extends TestCase
 	 * Test the ZRL and OWT stripping
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataStripped')]
-	public function testStrippedQueries(array $server, array $get, string $expect)
+	public function testStrippedQueries(array $server, array $get, string $expect): void
 	{
 		$arguments = (new App\Arguments())->determine($server, $get);
 
@@ -262,7 +262,7 @@ class ArgumentsTest extends TestCase
 	/**
 	 * Test that arguments are immutable
 	 */
-	public function testImmutable()
+	public function testImmutable(): void
 	{
 		$argument = new App\Arguments();
 

--- a/tests/Unit/App/BaseURLTest.php
+++ b/tests/Unit/App/BaseURLTest.php
@@ -32,7 +32,7 @@ class BaseURLTest extends TestCase
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('provideInputTestData')]
 	#[BackupGlobals(true)]
-	public function testDetermineWithConfigReturnsCorrectUrl(string $url, string $expect)
+	public function testDetermineWithConfigReturnsCorrectUrl(string $url, string $expect): void
 	{
 		$config = self::createStub(IManageConfigValues::class);
 		$config->method('get')->willReturnCallback(function (string $category, string $key, mixed $default) use ($url): mixed {
@@ -124,7 +124,7 @@ class BaseURLTest extends TestCase
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('provideServerTestData')]
 	#[BackupGlobals(true)]
-	public function testDetermineWithServerArrayReturnsCorrectUrl(array $server, string $expect)
+	public function testDetermineWithServerArrayReturnsCorrectUrl(array $server, string $expect): void
 	{
 		$_SERVER = array_merge($_SERVER, $server);
 
@@ -138,7 +138,7 @@ class BaseURLTest extends TestCase
 	}
 
 	#[BackupGlobals(true)]
-	public function testDetermineWithGlobalsReturnsCorrectUrl()
+	public function testDetermineWithGlobalsReturnsCorrectUrl(): void
 	{
 		$_SERVER['HTTP_HOST']   = 'localhost';
 		$_SERVER['SERVER_PORT'] = 80;
@@ -179,7 +179,7 @@ class BaseURLTest extends TestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('provideRemoveTestData')]
-	public function testRemove(string $url, string $origUrl, string $expect)
+	public function testRemove(string $url, string $origUrl, string $expect): void
 	{
 		$config = self::createStub(IManageConfigValues::class);
 		$config->method('get')->willReturnCallback(function (string $category, string $key, mixed $default) use ($url): mixed {
@@ -198,7 +198,7 @@ class BaseURLTest extends TestCase
 	/**
 	 * Test that redirect to external domains fails
 	 */
-	public function testRedirectWithExternalDomainThrowsException()
+	public function testRedirectWithExternalDomainThrowsException(): void
 	{
 		$config = self::createConfiguredStub(IManageConfigValues::class, [
 			'get' => 'https://friendica.local',

--- a/tests/Unit/App/ModeTest.php
+++ b/tests/Unit/App/ModeTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class ModeTest extends TestCase
 {
-	public function testMethodsReturnCorrectValuesByDefault()
+	public function testMethodsReturnCorrectValuesByDefault(): void
 	{
 		$mode = new Mode();
 
@@ -30,7 +30,7 @@ class ModeTest extends TestCase
 		self::assertFalse($mode->has(Mode::MAINTENANCEDISABLED));
 	}
 
-	public function testMethodsReturnCorrectValuesAfterDetermineWithoutConfigFile()
+	public function testMethodsReturnCorrectValuesAfterDetermineWithoutConfigFile(): void
 	{
 		$root = vfsStream::setup(__FUNCTION__ . '_friendica', 0777, []);
 
@@ -49,7 +49,7 @@ class ModeTest extends TestCase
 		self::assertFalse($mode->has(Mode::MAINTENANCEDISABLED));
 	}
 
-	public function testMethodsReturnCorrectValuesAfterDetermineWithoutDatabaseConnection()
+	public function testMethodsReturnCorrectValuesAfterDetermineWithoutDatabaseConnection(): void
 	{
 		$root = vfsStream::setup(__FUNCTION__ . '_friendica', 0777, ['config' => [
 			'local.config.php' => file_get_contents(realpath(dirname(__FILE__, 4) . '/config/local-sample.config.php')),
@@ -66,7 +66,7 @@ class ModeTest extends TestCase
 		self::assertFalse($mode->has(Mode::MAINTENANCEDISABLED));
 	}
 
-	public function testMethodsReturnCorrectValuesWithMaintenanceMode()
+	public function testMethodsReturnCorrectValuesWithMaintenanceMode(): void
 	{
 		$root = vfsStream::setup(__FUNCTION__ . '_friendica', 0777, ['config' => [
 			'local.config.php' => file_get_contents(realpath(dirname(__FILE__, 4) . '/config/local-sample.config.php')),
@@ -89,7 +89,7 @@ class ModeTest extends TestCase
 		self::assertFalse($mode->has(Mode::MAINTENANCEDISABLED));
 	}
 
-	public function testMethodsReturnCorrectValuesWithNormalMode()
+	public function testMethodsReturnCorrectValuesWithNormalMode(): void
 	{
 		$root = vfsStream::setup(__FUNCTION__ . '_friendica', 0777, ['config' => [
 			'local.config.php' => file_get_contents(realpath(dirname(__FILE__, 4) . '/config/local-sample.config.php')),
@@ -115,7 +115,7 @@ class ModeTest extends TestCase
 	/**
 	 * Test that modes are immutable
 	 */
-	public function testDetermineReturnsNewModeInstance()
+	public function testDetermineReturnsNewModeInstance(): void
 	{
 		$mode = new Mode();
 
@@ -127,7 +127,7 @@ class ModeTest extends TestCase
 	/**
 	 * Test if not called by index is backend
 	 */
-	public function testIsBackendReturnsTrue()
+	public function testIsBackendReturnsTrue(): void
 	{
 		$args         = self::createStub(Arguments::class);
 		$mobileDetect = self::createStub(MobileDetect::class);
@@ -140,7 +140,7 @@ class ModeTest extends TestCase
 	/**
 	 * Test is called by index but module is backend
 	 */
-	public function testIsBackendWithBackendModuleReturnsTrue()
+	public function testIsBackendWithBackendModuleReturnsTrue(): void
 	{
 		$args = self::createMock(Arguments::class);
 		$args->expects(self::once())->method('getModuleName')->willReturn(Mode::BACKEND_MODULES[0]);
@@ -155,7 +155,7 @@ class ModeTest extends TestCase
 	/**
 	 * Test is called by index and module is not backend
 	 */
-	public function testIsBackendWithDefaultModuleReturnsFalse()
+	public function testIsBackendWithDefaultModuleReturnsFalse(): void
 	{
 		$args = self::createMock(Arguments::class);
 		$args->expects(self::once())->method('getModuleName')->willReturn(Arguments::DEFAULT_MODULE);
@@ -170,7 +170,7 @@ class ModeTest extends TestCase
 	/**
 	 * Test if the call is an ajax call
 	 */
-	public function testIsAjaxReturnsTrue()
+	public function testIsAjaxReturnsTrue(): void
 	{
 		// This is the server environment variable to determine ajax calls
 		$server = [
@@ -188,7 +188,7 @@ class ModeTest extends TestCase
 	/**
 	 * Test if the call is not nan ajax call
 	 */
-	public function testIsAjaxReturnsFalse()
+	public function testIsAjaxReturnsFalse(): void
 	{
 		// header for ajax call is missing
 		$server = [];
@@ -204,7 +204,7 @@ class ModeTest extends TestCase
 	/**
 	 * Test if the call is a mobile and is a tablet call
 	 */
-	public function testIsMobileAndIsTabletReturnsTrue()
+	public function testIsMobileAndIsTabletReturnsTrue(): void
 	{
 		$args         = self::createStub(Arguments::class);
 		$mobileDetect = self::createMock(MobileDetect::class);
@@ -221,7 +221,7 @@ class ModeTest extends TestCase
 	/**
 	 * Test if the call is not a mobile and is not a tablet call
 	 */
-	public function testIsMobileAndIsTabletReturnsFalse()
+	public function testIsMobileAndIsTabletReturnsFalse(): void
 	{
 		$args         = self::createStub(Arguments::class);
 		$mobileDetect = self::createMock(MobileDetect::class);

--- a/tests/Unit/App/RequestTest.php
+++ b/tests/Unit/App/RequestTest.php
@@ -100,7 +100,7 @@ class RequestTest extends TestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataServerArray')]
-	public function testRemoteAddress(array $server, array $config, string $assertion)
+	public function testRemoteAddress(array $server, array $config, string $assertion): void
 	{
 		$configClass = self::createMock(IManageConfigValues::class);
 		$configClass->expects(self::atLeast(1))->method('get')->willReturnMap([

--- a/tests/Unit/Contact/FriendSuggest/Factory/FriendSuggestTest.php
+++ b/tests/Unit/Contact/FriendSuggest/Factory/FriendSuggestTest.php
@@ -85,7 +85,7 @@ class FriendSuggestTest extends TestCase
 		self::assertLessThanOrEqual($to->getTimestamp(), $created->getTimestamp());
 	}
 
-	public function testCreateNew()
+	public function testCreateNew(): void
 	{
 		$factory = new FriendSuggest(new NullLogger());
 
@@ -112,14 +112,14 @@ class FriendSuggestTest extends TestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCreate')]
-	public function testCreateFromTableRow(array $input, Entity\FriendSuggest $assertion)
+	public function testCreateFromTableRow(array $input, Entity\FriendSuggest $assertion): void
 	{
 		$factory = new FriendSuggest(new NullLogger());
 
 		$this->assertFriendSuggest($assertion, $factory->createFromTableRow($input));
 	}
 
-	public function testCreateFromMinimalTableRowDefaultsMissingFields()
+	public function testCreateFromMinimalTableRowDefaultsMissingFields(): void
 	{
 		$factory = new FriendSuggest(new NullLogger());
 
@@ -142,7 +142,7 @@ class FriendSuggestTest extends TestCase
 		$this->assertCreatedBetween($friendSuggest->created, $createdBefore, $createdAfter);
 	}
 
-	public function testCreateEmpty()
+	public function testCreateEmpty(): void
 	{
 		$factory = new FriendSuggest(new NullLogger());
 

--- a/tests/Unit/Contact/Introduction/Factory/IntroductionTest.php
+++ b/tests/Unit/Contact/Introduction/Factory/IntroductionTest.php
@@ -78,7 +78,7 @@ class IntroductionTest extends TestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataRow')]
-	public function testCreateFromTableRow(array $input, array $assertion)
+	public function testCreateFromTableRow(array $input, array $assertion): void
 	{
 		$factory = new Introduction(new NullLogger());
 
@@ -87,7 +87,7 @@ class IntroductionTest extends TestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataRow')]
-	public function testCreateNew(array $input, array $assertion)
+	public function testCreateNew(array $input, array $assertion): void
 	{
 		$factory = new Introduction(new NullLogger());
 
@@ -101,7 +101,7 @@ class IntroductionTest extends TestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataRow')]
-	public function testCreateDummy(array $input, array $assertion)
+	public function testCreateDummy(array $input, array $assertion): void
 	{
 		$factory = new Introduction(new NullLogger());
 

--- a/tests/Unit/Core/Logger/Type/WorkerLoggerTest.php
+++ b/tests/Unit/Core/Logger/Type/WorkerLoggerTest.php
@@ -63,7 +63,7 @@ class WorkerLoggerTest extends TestCase
 	 * Test the WorkerLogger with different log calls
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTest')]
-	public function testLogMethod($func, $msg, $context = [])
+	public function testLogMethod($func, $msg, $context = []): void
 	{
 		$logger = $this->createMock(LoggerInterface::class);
 
@@ -83,7 +83,7 @@ class WorkerLoggerTest extends TestCase
 	/**
 	 * Test the WorkerLogger with
 	 */
-	public function testLog()
+	public function testLog(): void
 	{
 		$logger = $this->createMock(LoggerInterface::class);
 
@@ -103,7 +103,7 @@ class WorkerLoggerTest extends TestCase
 	/**
 	 * Test the WorkerLogger after setting a worker function
 	 */
-	public function testChangedId()
+	public function testChangedId(): void
 	{
 		$logger = $this->createMock(LoggerInterface::class);
 
@@ -135,7 +135,7 @@ class WorkerLoggerTest extends TestCase
 		$workLogger->log('debug', 'a test', $context2);
 	}
 
-	public function testReplaceDefaultContextReturnsOldDefaultContext()
+	public function testReplaceDefaultContextReturnsOldDefaultContext(): void
 	{
 		$logger = $this->createStub(LoggerInterface::class);
 

--- a/tests/Unit/Event/EventDispatcherTest.php
+++ b/tests/Unit/Event/EventDispatcherTest.php
@@ -28,7 +28,7 @@ class EventDispatcherTest extends TestCase
 	{
 		$eventDispatcher = new EventDispatcher();
 
-		$eventDispatcher->addListener('test', function (NamedEvent $event) {
+		$eventDispatcher->addListener('test', function (NamedEvent $event): void {
 			$this->assertSame('test', $event->getName());
 		});
 

--- a/tests/Unit/Model/FileTagTest.php
+++ b/tests/Unit/Model/FileTagTest.php
@@ -57,7 +57,7 @@ class FileTagTest extends TestCase
 	 * @param string $file
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataArrayToFile')]
-	public function testArrayToFile(array $array, string $type, string $file)
+	public function testArrayToFile(array $array, string $type, string $file): void
 	{
 		self::assertEquals($file, FileTag::arrayToFile($array, $type));
 	}
@@ -117,7 +117,7 @@ class FileTagTest extends TestCase
 	 * @param array  $array
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataFileToArray')]
-	public function testFileToArray(string $file, string $type, array $array)
+	public function testFileToArray(string $file, string $type, array $array): void
 	{
 		self::assertEquals($array, FileTag::fileToArray($file, $type));
 	}

--- a/tests/Unit/Model/Log/ParsedLogIteratorTest.php
+++ b/tests/Unit/Model/Log/ParsedLogIteratorTest.php
@@ -34,23 +34,23 @@ class ParsedLogIteratorTest extends TestCase
 		$this->pli->open($logfile);
 	}
 
-	public function testIsIterable()
+	public function testIsIterable(): void
 	{
 		self::assertIsIterable($this->pli);
 	}
 
-	public function testEverything()
+	public function testEverything(): void
 	{
 		self::assertCount(3, iterator_to_array($this->pli, false));
 	}
 
-	public function testLimit()
+	public function testLimit(): void
 	{
 		$this->pli->withLimit(2);
 		self::assertCount(2, iterator_to_array($this->pli, false));
 	}
 
-	public function testFilterByLevel()
+	public function testFilterByLevel(): void
 	{
 		$this->pli->withFilters(['level' => 'INFO']);
 		$pls = iterator_to_array($this->pli, false);
@@ -68,7 +68,7 @@ class ParsedLogIteratorTest extends TestCase
 		);
 	}
 
-	public function testFilterByContext()
+	public function testFilterByContext(): void
 	{
 		$this->pli->withFilters(['context' => 'worker']);
 		$pls = iterator_to_array($this->pli, false);
@@ -86,7 +86,7 @@ class ParsedLogIteratorTest extends TestCase
 		);
 	}
 
-	public function testFilterCombined()
+	public function testFilterCombined(): void
 	{
 		$this->pli->withFilters(['level' => 'NOTICE', 'context' => 'worker']);
 		$pls = iterator_to_array($this->pli, false);
@@ -104,7 +104,7 @@ class ParsedLogIteratorTest extends TestCase
 		);
 	}
 
-	public function testSearch()
+	public function testSearch(): void
 	{
 		$this->pli->withSearch("maximum");
 		$pls = iterator_to_array($this->pli, false);
@@ -122,7 +122,7 @@ class ParsedLogIteratorTest extends TestCase
 		);
 	}
 
-	public function testFilterAndSearch()
+	public function testFilterAndSearch(): void
 	{
 		$this->pli
 			->withFilters(['context' => 'worker'])
@@ -131,7 +131,7 @@ class ParsedLogIteratorTest extends TestCase
 		self::assertCount(0, $pls);
 	}
 
-	public function testEmptyLogFile()
+	public function testEmptyLogFile(): void
 	{
 		$logfile = dirname(__DIR__) . '/../../Fixtures/log/empty.friendica.log.txt';
 

--- a/tests/Unit/Model/TagTest.php
+++ b/tests/Unit/Model/TagTest.php
@@ -15,7 +15,7 @@ class TagTest extends TestCase
 	/**
 	 *
 	 */
-	public function testGetFromBody()
+	public function testGetFromBody(): void
 	{
 		$body = '![url=https://pirati.ca/profile/test1]Testgruppe 1b[/url] Test, please ignore';
 

--- a/tests/Unit/Module/Settings/TwoFactor/VerifyQrCodeTest.php
+++ b/tests/Unit/Module/Settings/TwoFactor/VerifyQrCodeTest.php
@@ -19,7 +19,7 @@ class VerifyQrCodeTest extends TestCase
 	/**
 	 * Asserts that valid SVG is produced when the xmlwriter extension is available.
 	 */
-	public function testQrCodeGeneratesValidSvgWhenXmlWriterIsAvailable()
+	public function testQrCodeGeneratesValidSvgWhenXmlWriterIsAvailable(): void
 	{
 		if (!class_exists(\XMLWriter::class)) {
 			$this->markTestSkipped('XMLWriter (ext-xmlwriter) is not available on this system.');
@@ -48,7 +48,7 @@ class VerifyQrCodeTest extends TestCase
 	 * the exception is caught, the logger receives a warning, and
 	 * $qrcode_image stays an empty string so the page can still render.
 	 */
-	public function testQrCodeGenerationFailureIsCaughtAndLogged()
+	public function testQrCodeGenerationFailureIsCaughtAndLogged(): void
 	{
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger->expects($this->once())

--- a/tests/Unit/Network/HTTPClient/Response/CurlResultTest.php
+++ b/tests/Unit/Network/HTTPClient/Response/CurlResultTest.php
@@ -13,7 +13,7 @@ use Psr\Log\NullLogger;
 
 class CurlResultTest extends TestCase
 {
-	public function testNormal()
+	public function testNormal(): void
 	{
 		$header      = file_get_contents(__DIR__ . '/../../../../Fixtures/curl/about.head');
 		$headerArray = include(__DIR__ . '/../../../../Fixtures/curl/about.head.php');
@@ -38,7 +38,7 @@ class CurlResultTest extends TestCase
 
 	#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 	#[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
-	public function testRedirect()
+	public function testRedirect(): void
 	{
 		$header      = file_get_contents(__DIR__ . '/../../../../Fixtures/curl/about.head');
 		$headerArray = include(__DIR__ . '/../../../../Fixtures/curl/about.head.php');
@@ -62,7 +62,7 @@ class CurlResultTest extends TestCase
 		self::assertSame('https://test.other/test/it', $curlResult->getRedirectUrl());
 	}
 
-	public function testTimeout()
+	public function testTimeout(): void
 	{
 		$header      = file_get_contents(__DIR__ . '/../../../../Fixtures/curl/about.head');
 		$headerArray = include(__DIR__ . '/../../../../Fixtures/curl/about.head.php');
@@ -88,7 +88,7 @@ class CurlResultTest extends TestCase
 
 	#[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
 	#[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
-	public function testRedirectHeader()
+	public function testRedirectHeader(): void
 	{
 		$header      = file_get_contents(__DIR__ . '/../../../../Fixtures/curl/about.redirect');
 		$headerArray = include(__DIR__ . '/../../../../Fixtures/curl/about.redirect.php');
@@ -111,7 +111,7 @@ class CurlResultTest extends TestCase
 		self::assertSame('https://test.other/some/?key=value', $curlResult->getRedirectUrl());
 	}
 
-	public function testInHeader()
+	public function testInHeader(): void
 	{
 		$header = file_get_contents(__DIR__ . '/../../../../Fixtures/curl/about.head');
 		$body   = file_get_contents(__DIR__ . '/../../../../Fixtures/curl/about.body');
@@ -125,7 +125,7 @@ class CurlResultTest extends TestCase
 		self::assertFalse($curlResult->inHeader('wrongHeader'));
 	}
 
-	public function testGetHeaderArray()
+	public function testGetHeaderArray(): void
 	{
 		$header = file_get_contents(__DIR__ . '/../../../../Fixtures/curl/about.head');
 		$body   = file_get_contents(__DIR__ . '/../../../../Fixtures/curl/about.body');
@@ -142,7 +142,7 @@ class CurlResultTest extends TestCase
 		self::assertArrayHasKey('vary', $headers);
 	}
 
-	public function testGetHeaderWithParam()
+	public function testGetHeaderWithParam(): void
 	{
 		$header = file_get_contents(__DIR__ . '/../../../../Fixtures/curl/about.head');
 		$body   = file_get_contents(__DIR__ . '/../../../../Fixtures/curl/about.body');

--- a/tests/Unit/Network/MimeTypeTest.php
+++ b/tests/Unit/Network/MimeTypeTest.php
@@ -70,7 +70,7 @@ class MimeTypeTest extends TestCase
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCreateFromContentType')]
-	public function testCreateFromContentType(Entity\MimeType $expected, string $contentType)
+	public function testCreateFromContentType(Entity\MimeType $expected, string $contentType): void
 	{
 		$factory = new Factory\MimeType(new NullLogger());
 
@@ -109,7 +109,7 @@ class MimeTypeTest extends TestCase
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataToString')]
-	public function testToString(string $expected, Entity\MimeType $mimeType)
+	public function testToString(string $expected, Entity\MimeType $mimeType): void
 	{
 		$this->assertEquals($expected, $mimeType->__toString());
 	}
@@ -129,7 +129,7 @@ class MimeTypeTest extends TestCase
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataRoundtrip')]
-	public function testRoundtrip(string $expected)
+	public function testRoundtrip(string $expected): void
 	{
 		$factory = new Factory\MimeType(new NullLogger());
 

--- a/tests/Unit/Object/Log/ParsedLogLineTest.php
+++ b/tests/Unit/Object/Log/ParsedLogLineTest.php
@@ -26,7 +26,7 @@ class ParsedLogLineTest extends TestCase
 	/**
 	 * test parsing a generic log line
 	 */
-	public function testGenericLogLine()
+	public function testGenericLogLine(): void
 	{
 		self::do_log_line(
 			'2021-05-24T15:40:01Z worker [WARNING]: Spool file does not start with "item-" {"file":".","worker_id":"560c8b6","worker_cmd":"SpoolPost"} - {"file":"SpoolPost.php","line":40,"function":"execute","uid":"fd8c37","process_id":20846}',
@@ -44,7 +44,7 @@ class ParsedLogLineTest extends TestCase
 	/**
 	 * test parsing a log line with empty data
 	 */
-	public function testEmptyDataLogLine()
+	public function testEmptyDataLogLine(): void
 	{
 		self::do_log_line(
 			'2021-05-24T15:23:58Z index [INFO]: No HTTP_SIGNATURE header [] - {"file":"HTTPSignature.php","line":476,"function":"getSigner","uid":"0a3934","process_id":14826}',
@@ -62,7 +62,7 @@ class ParsedLogLineTest extends TestCase
 	/**
 	 * test parsing a log line with various " - " in it
 	 */
-	public function testTrickyDashLogLine()
+	public function testTrickyDashLogLine(): void
 	{
 		self::do_log_line(
 			'2021-05-24T15:30:01Z worker [NOTICE]: Load: 0.01/20 - processes: 0/1/6 (0:0, 30:1) - maximum: 10/10 {"worker_id":"ece8fc8","worker_cmd":"Cron"} - {"file":"Worker.php","line":786,"function":"tooMuchWorkers","uid":"364d3c","process_id":20754}',
@@ -80,7 +80,7 @@ class ParsedLogLineTest extends TestCase
 	/**
 	 * test non conforming log line
 	 */
-	public function testNonConformingLogLine()
+	public function testNonConformingLogLine(): void
 	{
 		self::do_log_line(
 			'this log line is not formatted as expected',
@@ -98,7 +98,7 @@ class ParsedLogLineTest extends TestCase
 	/**
 	 * test missing source
 	 */
-	public function testMissingSource()
+	public function testMissingSource(): void
 	{
 		self::do_log_line(
 			'2021-05-24T15:30:01Z worker [NOTICE]: Load: 0.01/20 - processes: 0/1/6 (0:0, 30:1) - maximum: 10/10 {"worker_id":"ece8fc8","worker_cmd":"Cron"}',
@@ -116,7 +116,7 @@ class ParsedLogLineTest extends TestCase
 	/**
 	 * test missing data
 	 */
-	public function testMissingData()
+	public function testMissingData(): void
 	{
 		self::do_log_line(
 			'2021-05-24T15:30:01Z worker [NOTICE]: Load: 0.01/20 - processes: 0/1/6 (0:0, 30:1) - maximum: 10/10 - {"file":"Worker.php","line":786,"function":"tooMuchWorkers","uid":"364d3c","process_id":20754}',
@@ -134,7 +134,7 @@ class ParsedLogLineTest extends TestCase
 	/**
 	 * test missing data and source
 	 */
-	public function testMissingDataAndSource()
+	public function testMissingDataAndSource(): void
 	{
 		self::do_log_line(
 			'2021-05-24T15:30:01Z worker [NOTICE]: Load: 0.01/20 - processes: 0/1/6 (0:0, 30:1) - maximum: 10/10',
@@ -152,7 +152,7 @@ class ParsedLogLineTest extends TestCase
 	/**
 	 * test missing source and invalid data
 	 */
-	public function testMissingSourceAndInvalidData()
+	public function testMissingSourceAndInvalidData(): void
 	{
 		self::do_log_line(
 			'2021-05-24T15:30:01Z worker [NOTICE]: Load: 0.01/20 - processes: 0/1/6 (0:0, 30:1) - maximum: 10/10 {"invalidjson {really',

--- a/tests/Unit/Protocol/ActivityPub/ProcessorTest.php
+++ b/tests/Unit/Protocol/ActivityPub/ProcessorTest.php
@@ -51,7 +51,7 @@ class ProcessorTest extends TestCase
 	 * @param string $body
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataNormalizeMentionLinks')]
-	public function testNormalizeMentionLinks(string $expected, string $body)
+	public function testNormalizeMentionLinks(string $expected, string $body): void
 	{
 		$this->assertEquals($expected, ProcessorMock::normalizeMentionLinks($body));
 	}
@@ -96,7 +96,7 @@ class ProcessorTest extends TestCase
 	 * @param array $tags
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataAddMentionLinks')]
-	public function testAddMentionLinks(string $expected, string $body, array $tags)
+	public function testAddMentionLinks(string $expected, string $body, array $tags): void
 	{
 		$this->assertEquals($expected, ProcessorMock::addMentionLinks($body, $tags));
 	}

--- a/tests/Unit/Protocol/WebFingerUriTest.php
+++ b/tests/Unit/Protocol/WebFingerUriTest.php
@@ -81,7 +81,7 @@ class WebFingerUriTest extends TestCase
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataFromString')]
-	public function testFromString(string $expectedLong, string $expectedShort, string $input)
+	public function testFromString(string $expectedLong, string $expectedShort, string $input): void
 	{
 		$uri = WebFingerUri::fromString($input);
 
@@ -115,7 +115,7 @@ class WebFingerUriTest extends TestCase
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataFromStringFailure')]
-	public function testFromStringFailure(string $input)
+	public function testFromStringFailure(string $input): void
 	{
 		$this->expectException(\InvalidArgumentException::class);
 

--- a/tests/Unit/Util/ACLFormatterTest.php
+++ b/tests/Unit/Util/ACLFormatterTest.php
@@ -99,7 +99,7 @@ class ACLFormatterTest extends TestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataExpand')]
-	public function testExpand($input, array $assert)
+	public function testExpand($input, array $assert): void
 	{
 		self::assertAcl($input, $assert);
 	}
@@ -107,7 +107,7 @@ class ACLFormatterTest extends TestCase
 	/**
 	 * Test nullable expand (=> no ACL set)
 	 */
-	public function testExpandNull()
+	public function testExpandNull(): void
 	{
 		$aclFormatter = new ACLFormatter();
 
@@ -165,7 +165,7 @@ class ACLFormatterTest extends TestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataAclToString')]
-	public function testAclToString($input, string $assert)
+	public function testAclToString($input, string $assert): void
 	{
 		$aclFormatter = new ACLFormatter();
 

--- a/tests/Unit/Util/ArraysTest.php
+++ b/tests/Unit/Util/ArraysTest.php
@@ -18,7 +18,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Tests if an empty array and an empty delimiter returns an empty string.
 	 */
-	public function testEmptyArrayEmptyDelimiter()
+	public function testEmptyArrayEmptyDelimiter(): void
 	{
 		$str = Arrays::recursiveImplode([], '');
 		self::assertEmpty($str);
@@ -27,7 +27,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Tests if an empty array and a non-empty delimiter returns an empty string.
 	 */
-	public function testEmptyArrayNonEmptyDelimiter()
+	public function testEmptyArrayNonEmptyDelimiter(): void
 	{
 		$str = Arrays::recursiveImplode([], ',');
 		self::assertEmpty($str);
@@ -36,7 +36,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Tests if a non-empty array and an empty delimiter returns the value (1).
 	 */
-	public function testNonEmptyArrayEmptyDelimiter()
+	public function testNonEmptyArrayEmptyDelimiter(): void
 	{
 		$str = Arrays::recursiveImplode([1], '');
 		self::assertSame($str, '1');
@@ -45,7 +45,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Tests if a non-empty array and an empty delimiter returns the value (12).
 	 */
-	public function testNonEmptyArray2EmptyDelimiter()
+	public function testNonEmptyArray2EmptyDelimiter(): void
 	{
 		$str = Arrays::recursiveImplode([1, 2], '');
 		self::assertSame($str, '12');
@@ -54,7 +54,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Tests if a non-empty array and a non-empty delimiter returns the value (1).
 	 */
-	public function testNonEmptyArrayNonEmptyDelimiter()
+	public function testNonEmptyArrayNonEmptyDelimiter(): void
 	{
 		$str = Arrays::recursiveImplode([1], ',');
 		self::assertSame($str, '1');
@@ -63,7 +63,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Tests if a non-empty array and a non-empty delimiter returns the value (1,2).
 	 */
-	public function testNonEmptyArray2NonEmptyDelimiter()
+	public function testNonEmptyArray2NonEmptyDelimiter(): void
 	{
 		$str = Arrays::recursiveImplode([1, 2], ',');
 		self::assertSame($str, '1,2');
@@ -72,7 +72,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Tests if a 2-dim array and an empty delimiter returns the expected string.
 	 */
-	public function testEmptyMultiArray2EmptyDelimiter()
+	public function testEmptyMultiArray2EmptyDelimiter(): void
 	{
 		$str = Arrays::recursiveImplode([[1], []], '');
 		self::assertSame($str, '{1}{}');
@@ -81,7 +81,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Tests if a 2-dim array and an empty delimiter returns the expected string.
 	 */
-	public function testEmptyMulti2Array2EmptyDelimiter()
+	public function testEmptyMulti2Array2EmptyDelimiter(): void
 	{
 		$str = Arrays::recursiveImplode([[1], [2]], '');
 		self::assertSame($str, '{1}{2}');
@@ -90,7 +90,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Tests if a 2-dim array and a non-empty delimiter returns the expected string.
 	 */
-	public function testEmptyMultiArray2NonEmptyDelimiter()
+	public function testEmptyMultiArray2NonEmptyDelimiter(): void
 	{
 		$str = Arrays::recursiveImplode([[1], []], ',');
 		self::assertSame($str, '{1},{}');
@@ -99,7 +99,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Tests if a 2-dim array and a non-empty delimiter returns the expected string.
 	 */
-	public function testEmptyMulti2Array2NonEmptyDelimiter()
+	public function testEmptyMulti2Array2NonEmptyDelimiter(): void
 	{
 		$str = Arrays::recursiveImplode([[1], [2]], ',');
 		self::assertSame($str, '{1},{2}');
@@ -108,7 +108,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Tests if a 3-dim array and a non-empty delimiter returns the expected string.
 	 */
-	public function testEmptyMulti3Array2NonEmptyDelimiter()
+	public function testEmptyMulti3Array2NonEmptyDelimiter(): void
 	{
 		$str = Arrays::recursiveImplode([[1], [2, [3]]], ',');
 		self::assertSame($str, '{1},{2,{3}}');
@@ -117,7 +117,7 @@ class ArraysTest extends TestCase
 	/**
 	 * Test the Arrays::walkRecursive() function.
 	 */
-	public function testApiWalkRecursive()
+	public function testApiWalkRecursive(): void
 	{
 		$array = ['item1'];
 		self::assertEquals(
@@ -137,7 +137,7 @@ class ArraysTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testApiWalkRecursiveWithArray()
+	public function testApiWalkRecursiveWithArray(): void
 	{
 		$array = [['item1'], ['item2']];
 		self::assertEquals(

--- a/tests/Unit/Util/CryptoTest.php
+++ b/tests/Unit/Util/CryptoTest.php
@@ -42,7 +42,7 @@ class CryptoTest extends TestCase
 			E6VXs4mFWpDHJ4q01QIDAQAB
 			-----END PUBLIC KEY-----
 			TXT),
-			Crypto::rsaToPem(base64_decode($key))
+			Crypto::rsaToPem(base64_decode($key)),
 		);
 	}
 }

--- a/tests/Unit/Util/CryptoTest.php
+++ b/tests/Unit/Util/CryptoTest.php
@@ -17,7 +17,7 @@ class CryptoTest extends TestCase
 {
 	use PHPMock;
 
-	public function testRandomDigitsRandomInt()
+	public function testRandomDigitsRandomInt(): void
 	{
 		$random_int = $this->getFunctionMock('Friendica\Util', 'random_int');
 		$random_int->expects($this->any())->willReturnCallback(function ($min, $max) {
@@ -28,7 +28,7 @@ class CryptoTest extends TestCase
 		self::assertSame('11111111', Crypto::randomDigits(8));
 	}
 
-	public function testDiasporaPubRsaToMe()
+	public function testDiasporaPubRsaToMe(): void
 	{
 		$key = 'LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0tDQpNSUdKQW9HQkFORjVLTmJzN2k3aTByNVFZckNpRExEZ09pU1BWbmgvdlFnMXpnSk9VZVRheWVETk5yZTR6T1RVDQpSVDcyZGlLQ294OGpYOE5paElJTFJtcUtTOWxVYVNzd21QcVNFenVpdE5xeEhnQy8xS2ZuaXM1Qm96NnRwUUxjDQpsZDMwQjJSMWZIVWdFTHZWd0JkV29pRDhSRUt1dFNuRVBGd1RwVmV6aVlWYWtNY25pclRWQWdNQkFBRT0NCi0tLS0tRU5EIFJTQSBQVUJMSUMgS0VZLS0tLS0';
 

--- a/tests/Unit/Util/JsonLDTest.php
+++ b/tests/Unit/Util/JsonLDTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 class JsonLDTest extends TestCase
 {
-	public function testFetchElementArrayNotFound()
+	public function testFetchElementArrayNotFound(): void
 	{
 		$object = [];
 
@@ -23,7 +23,7 @@ class JsonLDTest extends TestCase
 		self::assertNull($data);
 	}
 
-	public function testFetchElementArrayFoundEmptyArray()
+	public function testFetchElementArrayFoundEmptyArray(): void
 	{
 		$object = ['field' => []];
 
@@ -31,7 +31,7 @@ class JsonLDTest extends TestCase
 		self::assertSame([[]], $data);
 	}
 
-	public function testFetchElementArrayFoundID()
+	public function testFetchElementArrayFoundID(): void
 	{
 		$object = ['field' => ['value1', ['@id' => 'value2'], ['@id' => 'value3']]];
 
@@ -39,7 +39,7 @@ class JsonLDTest extends TestCase
 		self::assertSame(['value1', 'value2', 'value3'], $data);
 	}
 
-	public function testFetchElementArrayFoundID2()
+	public function testFetchElementArrayFoundID2(): void
 	{
 		$object = ['field' => [['subfield11' => 'value11', 'subfield12' => 'value12'],
 			['subfield21' => 'value21', 'subfield22' => 'value22'],
@@ -49,7 +49,7 @@ class JsonLDTest extends TestCase
 		self::assertSame(['value3', 'value4'], $data);
 	}
 
-	public function testFetchElementArrayFoundArrays()
+	public function testFetchElementArrayFoundArrays(): void
 	{
 		$object = ['field' => [['subfield11' => 'value11', 'subfield12' => 'value12'],
 			['subfield21' => 'value21', 'subfield22' => 'value22']]];
@@ -61,7 +61,7 @@ class JsonLDTest extends TestCase
 		self::assertSame($expect, $data);
 	}
 
-	public function testFetchElementArrayTypeValue()
+	public function testFetchElementArrayTypeValue(): void
 	{
 		$object = ['field' => [['subfield11' => 'value11', 'subfield12' => 'value12'],
 			['subfield21' => 'value21', 'subfield22' => 'value22']]];
@@ -72,7 +72,7 @@ class JsonLDTest extends TestCase
 		self::assertSame($expect, $data);
 	}
 
-	public function testFetchElementNotFound()
+	public function testFetchElementNotFound(): void
 	{
 		$object = [];
 
@@ -80,7 +80,7 @@ class JsonLDTest extends TestCase
 		self::assertNull($data);
 	}
 
-	public function testFetchElementFound()
+	public function testFetchElementFound(): void
 	{
 		$object = ['field' => 'value'];
 
@@ -88,7 +88,7 @@ class JsonLDTest extends TestCase
 		self::assertSame('value', $data);
 	}
 
-	public function testFetchElementFoundEmptyString()
+	public function testFetchElementFoundEmptyString(): void
 	{
 		$object = ['field' => ''];
 
@@ -96,7 +96,7 @@ class JsonLDTest extends TestCase
 		self::assertSame('', $data);
 	}
 
-	public function testFetchElementKeyFoundEmptyArray()
+	public function testFetchElementKeyFoundEmptyArray(): void
 	{
 		$object = ['field' => ['content' => []]];
 
@@ -104,7 +104,7 @@ class JsonLDTest extends TestCase
 		self::assertSame([], $data);
 	}
 
-	public function testFetchElementFoundID()
+	public function testFetchElementFoundID(): void
 	{
 		$object = ['field' => ['field2' => 'value2', '@id' => 'value', 'field3' => 'value3']];
 
@@ -112,7 +112,7 @@ class JsonLDTest extends TestCase
 		self::assertSame('value', $data);
 	}
 
-	public function testFetchElementType()
+	public function testFetchElementType(): void
 	{
 		$object = ['source' => ['content' => 'body', 'mediaType' => 'text/bbcode']];
 
@@ -120,7 +120,7 @@ class JsonLDTest extends TestCase
 		self::assertSame('body', $data);
 	}
 
-	public function testFetchElementTypeValueNotFound()
+	public function testFetchElementTypeValueNotFound(): void
 	{
 		$object = ['source' => ['content' => 'body', 'mediaType' => 'text/html']];
 
@@ -128,7 +128,7 @@ class JsonLDTest extends TestCase
 		self::assertNull($data);
 	}
 
-	public function testFetchElementTypeNotFound()
+	public function testFetchElementTypeNotFound(): void
 	{
 		$object = ['source' => ['content' => 'body', 'mediaType' => 'text/html']];
 
@@ -136,7 +136,7 @@ class JsonLDTest extends TestCase
 		self::assertNull($data);
 	}
 
-	public function testFetchElementKeyWithoutType()
+	public function testFetchElementKeyWithoutType(): void
 	{
 		$object = ['source' => ['content' => 'body', 'mediaType' => 'text/bbcode']];
 
@@ -144,7 +144,7 @@ class JsonLDTest extends TestCase
 		self::assertSame('body', $data);
 	}
 
-	public function testFetchElementTypeArray()
+	public function testFetchElementTypeArray(): void
 	{
 		$object = ['source' => [['content' => 'body2', 'mediaType' => 'text/html'],
 			['content' => 'body', 'mediaType' => 'text/bbcode']]];
@@ -153,7 +153,7 @@ class JsonLDTest extends TestCase
 		self::assertSame('body', $data);
 	}
 
-	public function testFetchElementTypeValueArrayNotFound()
+	public function testFetchElementTypeValueArrayNotFound(): void
 	{
 		$object = ['source' => [['content' => 'body2', 'mediaType' => 'text/html'],
 			['content' => 'body', 'mediaType' => 'text/bbcode']]];
@@ -162,7 +162,7 @@ class JsonLDTest extends TestCase
 		self::assertNull($data);
 	}
 
-	public function testFetchElementTypeArrayNotFound()
+	public function testFetchElementTypeArrayNotFound(): void
 	{
 		$object = ['source' => [['content' => 'body2', 'mediaType' => 'text/html'],
 			['content' => 'body', 'mediaType' => 'text/bbcode']]];

--- a/tests/Unit/Util/StringsTest.php
+++ b/tests/Unit/Util/StringsTest.php
@@ -18,7 +18,7 @@ class StringsTest extends TestCase
 	/**
 	 * randomnames should be random, even length
 	 */
-	public function testRandomEven()
+	public function testRandomEven(): void
 	{
 		$randomname1 = Strings::getRandomName(10);
 		$randomname2 = Strings::getRandomName(10);
@@ -29,7 +29,7 @@ class StringsTest extends TestCase
 	/**
 	 * randomnames should be random, odd length
 	 */
-	public function testRandomOdd()
+	public function testRandomOdd(): void
 	{
 		$randomname1 = Strings::getRandomName(9);
 		$randomname2 = Strings::getRandomName(9);
@@ -40,7 +40,7 @@ class StringsTest extends TestCase
 	/**
 	 * try to fail ramdonnames
 	 */
-	public function testRandomNameNoLength()
+	public function testRandomNameNoLength(): void
 	{
 		$randomname1 = Strings::getRandomName(0);
 		self::assertEquals(0, strlen($randomname1));
@@ -51,7 +51,7 @@ class StringsTest extends TestCase
 	 *
 	 * @todo What's correct behaviour here? An exception?
 	 */
-	public function testRandomNameNegativeLength()
+	public function testRandomNameNegativeLength(): void
 	{
 		$randomname1 = Strings::getRandomName(-23);
 		self::assertEquals(0, strlen($randomname1));
@@ -60,7 +60,7 @@ class StringsTest extends TestCase
 	/**
 	 * test with a length, that may be too short
 	 */
-	public function testRandomNameLength1()
+	public function testRandomNameLength1(): void
 	{
 		$randomname1 = Strings::getRandomName(1);
 		self::assertEquals(1, strlen($randomname1));
@@ -72,7 +72,7 @@ class StringsTest extends TestCase
 	/**
 	 * test, that tags are escaped
 	 */
-	public function testEscapeHtml()
+	public function testEscapeHtml(): void
 	{
 		$invalidstring = '<submit type="button" onclick="alert(\'failed!\');" />';
 
@@ -109,7 +109,7 @@ class StringsTest extends TestCase
 	 * @param bool   $valid Whether testing on valid or invalid
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsHex')]
-	public function testIsHex(string $input, bool $valid = false)
+	public function testIsHex(string $input, bool $valid = false): void
 	{
 		self::assertEquals($valid, Strings::isHex($input));
 	}
@@ -118,7 +118,7 @@ class StringsTest extends TestCase
 	 * Tests that Strings::substringReplace behaves the same as substr_replace with ASCII strings in all the possible
 	 * numerical parameter configurations (positive, negative, zero, out of bounds either side, null)
 	 */
-	public function testSubstringReplaceASCII()
+	public function testSubstringReplaceASCII(): void
 	{
 		for ($start = -10; $start <= 10; $start += 5) {
 			self::assertEquals(
@@ -160,7 +160,7 @@ class StringsTest extends TestCase
 	 * @param int|null $length
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSubstringReplaceMultiByte')]
-	public function testSubstringReplaceMultiByte(string $expected, string $string, string $replacement, int $start, ?int $length = null)
+	public function testSubstringReplaceMultiByte(string $expected, string $string, string $replacement, int $start, ?int $length = null): void
 	{
 		self::assertEquals(
 			$expected,
@@ -173,7 +173,7 @@ class StringsTest extends TestCase
 		);
 	}
 
-	public function testPerformWithEscapedBlocks()
+	public function testPerformWithEscapedBlocks(): void
 	{
 		$originalText = '[noparse][/noparse][nobb]nobb[/nobb][noparse]noparse[/noparse]';
 
@@ -184,7 +184,7 @@ class StringsTest extends TestCase
 		self::assertEquals($originalText, $text);
 	}
 
-	public function testPerformWithEscapedBlocksNested()
+	public function testPerformWithEscapedBlocksNested(): void
 	{
 		$originalText = '[noparse][/noparse][nobb]nobb[/nobb][noparse]noparse[/noparse]';
 
@@ -199,7 +199,7 @@ class StringsTest extends TestCase
 		self::assertEquals($originalText, $text);
 	}
 
-	public function testCleanTags()
+	public function testCleanTags(): void
 	{
 		$rawTags = 'Open, #Source, Friendica Software; Federation #Fediverse';
 		$cleaned = 'federation,fediverse,friendica,open,software,source';
@@ -207,7 +207,7 @@ class StringsTest extends TestCase
 		self::assertEquals($cleaned, Strings::cleanTags($rawTags));
 	}
 
-	public function testgetTagArrayByString()
+	public function testgetTagArrayByString(): void
 	{
 		$list = 'Open, #Source, Friendica Software; Federation #Fediverse';
 		$tags = ['federation', 'fediverse', 'friendica', 'open', 'software', 'source'];

--- a/tests/Unit/Util/XmlTest.php
+++ b/tests/Unit/Util/XmlTest.php
@@ -18,7 +18,7 @@ class XmlTest extends TestCase
 	/**
 	 * escape and unescape
 	 */
-	public function testEscapeUnescape()
+	public function testEscapeUnescape(): void
 	{
 		$text   = "<tag>I want to break\n this!11!<?hard?></tag>";
 		$xml    = XML::escape($text);
@@ -29,7 +29,7 @@ class XmlTest extends TestCase
 	/**
 	 * escape and put in a document
 	 */
-	public function testEscapeDocument()
+	public function testEscapeDocument(): void
 	{
 		$tag        = "<tag>I want to break</tag>";
 		$xml        = XML::escape($tag);

--- a/tests/Util/SampleStorageBackendInstance.php
+++ b/tests/Util/SampleStorageBackendInstance.php
@@ -10,7 +10,7 @@ use Friendica\Core\L10n;
 use Friendica\Test\Util\SampleStorageBackend;
 use Mockery\MockInterface;
 
-function create_instance(&$data)
+function create_instance(&$data): void
 {
 	/** @var L10n|MockInterface $l10n */
 	$l10n = \Mockery::mock(L10n::class);

--- a/tests/Util/SampleStorageBackendInstance.php
+++ b/tests/Util/SampleStorageBackendInstance.php
@@ -5,7 +5,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use Friendica\App;
 use Friendica\Core\L10n;
 use Friendica\Test\Util\SampleStorageBackend;
 use Mockery\MockInterface;

--- a/tests/Util/SmileyWhitespaceAddon.php
+++ b/tests/Util/SmileyWhitespaceAddon.php
@@ -7,7 +7,7 @@
 
 use Friendica\Content\Smilies;
 
-function add_test_unicode_smilies(array &$b)
+function add_test_unicode_smilies(array &$b): void
 {
 	// String-substitution smilies
 	// - no whitespaces

--- a/tests/Util/authtest/authtest.php
+++ b/tests/Util/authtest/authtest.php
@@ -14,12 +14,12 @@
 use Friendica\Core\Hook;
 use Friendica\Model\User;
 
-function authtest_install()
+function authtest_install(): void
 {
 	Hook::register('authenticate', 'tests/Util/authtest/authtest.php', 'authtest_authenticate');
 }
 
-function authtest_authenticate(&$b)
+function authtest_authenticate(&$b): void
 {
 	$b['authenticated'] = \Friendica\Test\Util\AuthTestConfig::$authenticated;
 	$b['user_record']   = User::getById(\Friendica\Test\Util\AuthTestConfig::$user_id);

--- a/tests/src/BaseCollectionTest.php
+++ b/tests/src/BaseCollectionTest.php
@@ -9,7 +9,6 @@ namespace Friendica\Test\src;
 
 use Friendica\BaseCollection;
 use Friendica\BaseEntity;
-use Mockery\Mock;
 use PHPUnit\Framework\TestCase;
 
 class BaseCollectionTest extends TestCase

--- a/tests/src/BaseCollectionTest.php
+++ b/tests/src/BaseCollectionTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class BaseCollectionTest extends TestCase
 {
-	public function testChunk()
+	public function testChunk(): void
 	{
 		$entity1 = \Mockery::mock(BaseEntity::class);
 		$entity2 = \Mockery::mock(BaseEntity::class);
@@ -39,7 +39,7 @@ class BaseCollectionTest extends TestCase
 		$this->assertEquals([new BaseCollection([$entity1, $entity2, $entity3, $entity4])], $collection->chunk(4));
 	}
 
-	public function testChunkLengthException()
+	public function testChunkLengthException(): void
 	{
 		$this->expectException(\RangeException::class);
 

--- a/tests/src/CollectionTest.php
+++ b/tests/src/CollectionTest.php
@@ -16,7 +16,7 @@ class CollectionTest extends MockedTestCase
 	/**
 	 * Test if the BaseCollection::column() works as expected
 	 */
-	public function testGetArrayCopy()
+	public function testGetArrayCopy(): void
 	{
 		$collection = new CollectionDouble();
 		$collection->append(new EntityDouble('test', 23, new \DateTime('now', new \DateTimeZone('UTC')), 'privTest'));

--- a/tests/src/Console/AutomaticInstallationConsoleTest.php
+++ b/tests/src/Console/AutomaticInstallationConsoleTest.php
@@ -98,7 +98,7 @@ class AutomaticInstallationConsoleTest extends ConsoleTestCase
 		$this->configMock->shouldReceive('get')->andReturnUsing(function ($cat, $key) {
 			return $this->configCache->get($cat, $key);
 		});
-		$this->configMock->shouldReceive('load')->andReturnUsing(function ($config, $overwrite = false) {
+		$this->configMock->shouldReceive('load')->andReturnUsing(function ($config, $overwrite = false): void {
 			$this->configCache->load($config, $overwrite);
 		});
 
@@ -558,7 +558,7 @@ CONF;
 
 		$console = new AutomaticInstallation($this->consoleArgv);
 
-		$option = function ($var, $cat, $key) use ($data, $console) {
+		$option = function ($var, $cat, $key) use ($data, $console): void {
 			if (!empty($data[$cat][$key])) {
 				$console->setOption($var, $data[$cat][$key]);
 			}

--- a/tests/src/Console/AutomaticInstallationConsoleTest.php
+++ b/tests/src/Console/AutomaticInstallationConsoleTest.php
@@ -357,7 +357,7 @@ FIN;
 	 * Test the automatic installation without any parameter/setting
 	 * Should stuck because of missing hostname
 	 */
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$console = new AutomaticInstallation($this->consoleArgv);
 
@@ -370,7 +370,7 @@ FIN;
 	 * Test the automatic installation without any parameter/setting
 	 * except URL
 	 */
-	public function testEmptyWithURL()
+	public function testEmptyWithURL(): void
 	{
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
@@ -395,7 +395,7 @@ FIN;
 	 * Test the automatic installation with a prepared config file
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataInstaller')]
-	public function testWithConfig(array $data)
+	public function testWithConfig(array $data): void
 	{
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
@@ -472,7 +472,7 @@ CONF;
 	 * Includes saving the DB credentials to the file
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataInstaller')]
-	public function testWithEnvironmentAndSave(array $data)
+	public function testWithEnvironmentAndSave(array $data): void
 	{
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
@@ -510,7 +510,7 @@ CONF;
 	 * Don't save the db credentials to the file
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataInstaller')]
-	public function testWithEnvironmentWithoutSave(array $data)
+	public function testWithEnvironmentWithoutSave(array $data): void
 	{
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
@@ -546,7 +546,7 @@ CONF;
 	 * Test the automatic installation with arguments
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataInstaller')]
-	public function testWithArguments(array $data)
+	public function testWithArguments(array $data): void
 	{
 		$this->mockConnect(true, 1);
 		$this->mockConnected(true, 1);
@@ -584,7 +584,7 @@ CONF;
 	/**
 	 * Test the automatic installation with a wrong database connection
 	 */
-	public function testNoDatabaseConnection()
+	public function testNoDatabaseConnection(): void
 	{
 		$this->mockConnect(false, 1);
 
@@ -602,7 +602,7 @@ CONF;
 		self::assertConfig(['config' => ['hostname' => 'friendica.local'], 'system' => ['url' => 'http://friendica.local', 'ssl_policy' => 0]], false, true, false, true);
 	}
 
-	public function testGetHelp()
+	public function testGetHelp(): void
 	{
 		// Usable to purposely fail if new commands are added without taking tests into account
 		$theHelp = <<<HELP

--- a/tests/src/Console/ConfigConsoleTest.php
+++ b/tests/src/Console/ConfigConsoleTest.php
@@ -33,7 +33,7 @@ class ConfigConsoleTest extends ConsoleTestCase
 		$this->configMock = Mockery::mock(IManageConfigValues::class);
 	}
 
-	public function testSetGetKeyValue()
+	public function testSetGetKeyValue(): void
 	{
 		$this->configMock
 			->shouldReceive('set')
@@ -83,7 +83,7 @@ class ConfigConsoleTest extends ConsoleTestCase
 		self::assertEquals("config.test => NULL\n", $txt);
 	}
 
-	public function testSetArrayValue()
+	public function testSetArrayValue(): void
 	{
 		$testArray = [1, 2, 3];
 		$this->configMock
@@ -101,7 +101,7 @@ class ConfigConsoleTest extends ConsoleTestCase
 		self::assertEquals("[Error] config.test is an array and can't be set using this command.\n", $txt);
 	}
 
-	public function testSetExistingValue()
+	public function testSetExistingValue(): void
 	{
 		$this->configMock
 			->shouldReceive('get')
@@ -118,7 +118,7 @@ class ConfigConsoleTest extends ConsoleTestCase
 		self::assertEquals("[Error] config.test already set to now.\n", $txt);
 	}
 
-	public function testTooManyArguments()
+	public function testTooManyArguments(): void
 	{
 		$console = new Config($this->configMock, $this->consoleArgv);
 		$console->setArgument(0, 'config');
@@ -131,7 +131,7 @@ class ConfigConsoleTest extends ConsoleTestCase
 		self::assertEquals($assertion, $firstline);
 	}
 
-	public function testVerbose()
+	public function testVerbose(): void
 	{
 		$this->configMock
 			->shouldReceive('get')
@@ -160,7 +160,7 @@ CONF;
 		self::assertEquals($assertion, $txt);
 	}
 
-	public function testUnableToSet()
+	public function testUnableToSet(): void
 	{
 		$this->configMock
 			->shouldReceive('set')
@@ -180,7 +180,7 @@ CONF;
 		self::assertSame("Unable to set test.it\n", $txt);
 	}
 
-	public function testGetHelp()
+	public function testGetHelp(): void
 	{
 		// Usable to purposely fail if new commands are added without taking tests into account
 		$theHelp = <<<HELP

--- a/tests/src/Console/LockConsoleTest.php
+++ b/tests/src/Console/LockConsoleTest.php
@@ -44,7 +44,7 @@ class LockConsoleTest extends ConsoleTestCase
 		$this->lockMock = Mockery::mock(ICanLock::class);
 	}
 
-	public function testList()
+	public function testList(): void
 	{
 		$this->lockMock
 			->shouldReceive('getLocks')
@@ -57,7 +57,7 @@ class LockConsoleTest extends ConsoleTestCase
 		self::assertEquals("Listing all Locks:\ntest\ntest2\n2 locks found\n", $txt);
 	}
 
-	public function testListPrefix()
+	public function testListPrefix(): void
 	{
 		$this->lockMock
 			->shouldReceive('getLocks')
@@ -72,7 +72,7 @@ class LockConsoleTest extends ConsoleTestCase
 		self::assertEquals("Listing all Locks starting with \"test\":\ntest\ntest2\n2 locks found\n", $txt);
 	}
 
-	public function testDelLock()
+	public function testDelLock(): void
 	{
 		$this->lockMock
 			->shouldReceive('release')
@@ -87,7 +87,7 @@ class LockConsoleTest extends ConsoleTestCase
 		self::assertEquals("Lock 'test' released.\n", $txt);
 	}
 
-	public function testDelUnknownLock()
+	public function testDelUnknownLock(): void
 	{
 		$this->lockMock
 			->shouldReceive('release')
@@ -102,7 +102,7 @@ class LockConsoleTest extends ConsoleTestCase
 		self::assertEquals("Couldn't release Lock 'test'\n", $txt);
 	}
 
-	public function testSetLock()
+	public function testSetLock(): void
 	{
 		$this->lockMock
 			->shouldReceive('isLocked')
@@ -122,7 +122,7 @@ class LockConsoleTest extends ConsoleTestCase
 		self::assertEquals("Lock 'test' acquired.\n", $txt);
 	}
 
-	public function testSetLockIsLocked()
+	public function testSetLockIsLocked(): void
 	{
 		$this->lockMock
 			->shouldReceive('isLocked')
@@ -137,7 +137,7 @@ class LockConsoleTest extends ConsoleTestCase
 		self::assertEquals("[Error] 'test' is already set.\n", $txt);
 	}
 
-	public function testSetLockNotWorking()
+	public function testSetLockNotWorking(): void
 	{
 		$this->lockMock
 			->shouldReceive('isLocked')
@@ -157,7 +157,7 @@ class LockConsoleTest extends ConsoleTestCase
 		self::assertEquals("[Error] Unable to lock 'test'.\n", $txt);
 	}
 
-	public function testReleaseAll()
+	public function testReleaseAll(): void
 	{
 		$this->lockMock
 			->shouldReceive('releaseAll')
@@ -170,7 +170,7 @@ class LockConsoleTest extends ConsoleTestCase
 		self::assertEquals("Locks successfully cleared.\n", $txt);
 	}
 
-	public function testReleaseAllFailed()
+	public function testReleaseAllFailed(): void
 	{
 		$this->lockMock
 			->shouldReceive('releaseAll')
@@ -183,7 +183,7 @@ class LockConsoleTest extends ConsoleTestCase
 		self::assertEquals("[Error] Unable to clear the locks.\n", $txt);
 	}
 
-	public function testGetHelp()
+	public function testGetHelp(): void
 	{
 		// Usable to purposely fail if new commands are added without taking tests into account
 		$theHelp = <<<HELP

--- a/tests/src/Console/LockConsoleTest.php
+++ b/tests/src/Console/LockConsoleTest.php
@@ -27,19 +27,19 @@ class LockConsoleTest extends ConsoleTestCase
 	 */
 	private $lockMock;
 
-	protected function setUp() : void
+	protected function setUp(): void
 	{
 		parent::setUp();
 
 		Mockery::getConfiguration()->setConstantsMap([
 			Mode::class => [
-				'DBCONFIGAVAILABLE' => 0
-			]
+				'DBCONFIGAVAILABLE' => 0,
+			],
 		]);
 
 		$this->appMode = Mockery::mock(App\Mode::class);
 		$this->appMode->shouldReceive('has')
-		        ->andReturn(true);
+				->andReturn(true);
 
 		$this->lockMock = Mockery::mock(ICanLock::class);
 	}

--- a/tests/src/Console/ServerBlockConsoleTest.php
+++ b/tests/src/Console/ServerBlockConsoleTest.php
@@ -51,7 +51,7 @@ class ServerBlockConsoleTest extends ConsoleTestCase
 	/**
 	 * Test to list the default blocked servers
 	 */
-	public function testBlockedServersList()
+	public function testBlockedServersList(): void
 	{
 		$this->blocklistMock
 			->shouldReceive('get')
@@ -74,7 +74,7 @@ CONS;
 	/**
 	 * Test blockedservers add command
 	 */
-	public function testAddBlockedServer()
+	public function testAddBlockedServer(): void
 	{
 		$this->blocklistMock
 			->shouldReceive('addPattern')
@@ -94,7 +94,7 @@ CONS;
 	/**
 	 * Test blockedservers add command on existed domain
 	 */
-	public function testUpdateBlockedServer()
+	public function testUpdateBlockedServer(): void
 	{
 		$this->blocklistMock
 			->shouldReceive('addPattern')
@@ -114,7 +114,7 @@ CONS;
 	/**
 	 * Test blockedservers remove command
 	 */
-	public function testRemoveBlockedServer()
+	public function testRemoveBlockedServer(): void
 	{
 		$this->blocklistMock
 			->shouldReceive('removePattern')
@@ -133,7 +133,7 @@ CONS;
 	/**
 	 * Test blockedservers with a wrong command
 	 */
-	public function testBlockedServersWrongCommand()
+	public function testBlockedServersWrongCommand(): void
 	{
 		$console = new ServerBlock($this->blocklistMock, $this->consoleArgv);
 		$console->setArgument(0, 'wrongcommand');
@@ -145,7 +145,7 @@ CONS;
 	/**
 	 * Test blockedservers remove with not existing domain
 	 */
-	public function testRemoveBlockedServerNotExist()
+	public function testRemoveBlockedServerNotExist(): void
 	{
 		$this->blocklistMock
 			->shouldReceive('removePattern')
@@ -164,7 +164,7 @@ CONS;
 	/**
 	 * Test blockedservers add command without argument
 	 */
-	public function testAddBlockedServerMissingArgument()
+	public function testAddBlockedServerMissingArgument(): void
 	{
 		$console = new ServerBlock($this->blocklistMock, $this->consoleArgv);
 		$console->setArgument(0, 'add');
@@ -183,7 +183,7 @@ CONS;
 	/**
 	 * Test blockedservers add command without save
 	 */
-	public function testAddBlockedServerNoSave()
+	public function testAddBlockedServerNoSave(): void
 	{
 		$this->blocklistMock
 			->shouldReceive('addPattern')
@@ -203,7 +203,7 @@ CONS;
 	/**
 	 * Test blockedservers remove command without save
 	 */
-	public function testRemoveBlockedServerNoSave()
+	public function testRemoveBlockedServerNoSave(): void
 	{
 		$this->blocklistMock
 			->shouldReceive('removePattern')
@@ -222,7 +222,7 @@ CONS;
 	/**
 	 * Test blockedservers remove command without argument
 	 */
-	public function testRemoveBlockedServerMissingArgument()
+	public function testRemoveBlockedServerMissingArgument(): void
 	{
 		$console = new ServerBlock($this->blocklistMock, $this->consoleArgv);
 		$console->setArgument(0, 'remove');
@@ -234,7 +234,7 @@ CONS;
 	/**
 	 * Test the blockedservers help
 	 */
-	public function testBlockedServersHelp()
+	public function testBlockedServersHelp(): void
 	{
 		$console = new ServerBlock($this->blocklistMock, $this->consoleArgv);
 		$console->setOption('help', true);

--- a/tests/src/Console/ServerBlockConsoleTest.php
+++ b/tests/src/Console/ServerBlockConsoleTest.php
@@ -25,14 +25,14 @@ class ServerBlockConsoleTest extends ConsoleTestCase
 		[
 			'domain' => 'pod.ordoevangelistarum.com',
 			'reason' => 'Illegal content',
-		]
+		],
 	];
 	/**
 	 * @var DomainPatternBlocklist|Mockery\LegacyMockInterface|Mockery\MockInterface
 	 */
 	private $blocklistMock;
 
-	protected function setUp() : void
+	protected function setUp(): void
 	{
 		parent::setUp();
 
@@ -59,7 +59,7 @@ class ServerBlockConsoleTest extends ConsoleTestCase
 			->once();
 
 		$console = new ServerBlock($this->blocklistMock, $this->consoleArgv);
-		$txt = $this->dumpExecute($console);
+		$txt     = $this->dumpExecute($console);
 
 		$php_eol = PHP_EOL;
 

--- a/tests/src/Content/ItemTest.php
+++ b/tests/src/Content/ItemTest.php
@@ -135,7 +135,7 @@ class ItemTest extends MockedTestCase
 	 * @param string $summary
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataRedundantSummary')]
-	public function testRedundantSummary(bool $expected, string $body, string $summary)
+	public function testRedundantSummary(bool $expected, string $body, string $summary): void
 	{
 		$item = $this->createItem();
 

--- a/tests/src/Content/PageInfoTest.php
+++ b/tests/src/Content/PageInfoTest.php
@@ -71,7 +71,7 @@ class PageInfoTest extends DatabaseTestCase
 	 * @param bool        $searchNakedUrls
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetRelevantUrlFromBody')]
-	public function testGetRelevantUrlFromBody($expected, string $body, bool $searchNakedUrls = false)
+	public function testGetRelevantUrlFromBody($expected, string $body, bool $searchNakedUrls = false): void
 	{
 		self::assertSame($expected, PageInfoMock::getRelevantUrlFromBody($body, $searchNakedUrls));
 	}
@@ -119,7 +119,7 @@ class PageInfoTest extends DatabaseTestCase
 	 * @param string $url
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataStripTrailingUrlFromBody')]
-	public function testStripTrailingUrlFromBody(string $expected, string $body, string $url)
+	public function testStripTrailingUrlFromBody(string $expected, string $body, string $url): void
 	{
 		self::assertSame($expected, PageInfoMock::stripTrailingUrlFromBody($body, $url));
 	}

--- a/tests/src/Content/Text/BBCode/VideoTest.php
+++ b/tests/src/Content/Text/BBCode/VideoTest.php
@@ -54,7 +54,7 @@ class VideoTest extends MockedTestCase
 	 * Test if the BBCode is successfully transformed for video links
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataVideo')]
-	public function testTransform(string $input, string $assert)
+	public function testTransform(string $input, string $assert): void
 	{
 		$bbCodeVideo = new Video();
 

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -131,7 +131,7 @@ class BBCodeTest extends FixtureTestCase
 	 * @throws InternalServerErrorException
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataLinks')]
-	public function testAutoLinking(string $data, bool $assertHTML)
+	public function testAutoLinking(string $data, bool $assertHTML): void
 	{
 		$output = BBCode::convert($data);
 		$assert = $this->HTMLPurifier->purify('<a href="' . $data . '" target="_blank" rel="noopener noreferrer">' . Strings::getStyledURL($data) . '</a>');
@@ -281,7 +281,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 	 * @throws InternalServerErrorException
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataBBCodes')]
-	public function testConvert(string $expectedHtml, string $text, bool $embed = true, int $simpleHtml = BBCode::INTERNAL, bool $forPlaintext = false)
+	public function testConvert(string $expectedHtml, string $text, bool $embed = true, int $simpleHtml = BBCode::INTERNAL, bool $forPlaintext = false): void
 	{
 		// This assumes system.remove_multiplicated_lines = false
 		$actual = BBCode::convert($text, $embed, $simpleHtml, $forPlaintext);
@@ -330,7 +330,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 	 * @throws InternalServerErrorException
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataBBCodesToMarkdown')]
-	public function testToMarkdown(string $expected, string $text, $for_diaspora = true)
+	public function testToMarkdown(string $expected, string $text, $for_diaspora = true): void
 	{
 		$actual = BBCode::toMarkdown($text, $for_diaspora);
 
@@ -353,7 +353,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 	 * @param string $text     Input text
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetTags')]
-	public function testGetTags(array $expected, string $text)
+	public function testGetTags(array $expected, string $text): void
 	{
 		$actual = BBCode::getTags($text);
 
@@ -380,7 +380,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 	 * @param string $text     Input text
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataExpandTags')]
-	public function testExpandTags(string $expected, string $text)
+	public function testExpandTags(string $expected, string $text): void
 	{
 		$actual = BBCode::expandTags($text);
 
@@ -436,7 +436,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 	 * @param string $text     Input text
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataExpandVideoLinks')]
-	public function testExpandVideoLinks(string $expected, string $text)
+	public function testExpandVideoLinks(string $expected, string $text): void
 	{
 		$actual = BBCode::expandVideoLinks($text);
 
@@ -506,7 +506,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 	 * @param string $addon    Optional addon we're searching the abstract for
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetAbstract')]
-	public function testGetAbstract(string $expected, string $text, string $addon)
+	public function testGetAbstract(string $expected, string $text, string $addon): void
 	{
 		$actual = BBCode::getAbstract($text, $addon);
 
@@ -558,7 +558,7 @@ Karl Marx - Die ursprüngliche Akkumulation
 	 * @param string $text     Input text
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataStripAbstract')]
-	public function testStripAbstract(string $expected, string $text)
+	public function testStripAbstract(string $expected, string $text): void
 	{
 		$actual = BBCode::stripAbstract($text);
 
@@ -690,7 +690,7 @@ Lucas: For the right price, yes.[/share]',
 	 * @param string $text    Input text
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataFetchShareAttributes')]
-	public function testFetchShareAttributes(array $expected, string $text)
+	public function testFetchShareAttributes(array $expected, string $text): void
 	{
 		$actual = BBCode::fetchShareAttributes($text);
 
@@ -713,7 +713,7 @@ Lucas: For the right price, yes.[/share]',
 	 * @param string $text     Input text
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataProfileLink')]
-	public function testProfileLink(string $expected, string $text)
+	public function testProfileLink(string $expected, string $text): void
 	{
 		$actual = BBCode::convertForUriId(0, $text);
 
@@ -814,7 +814,7 @@ Lucas: For the right price, yes.[/share]',
 	 * @param string $text     Input text
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataConvertAttachment')]
-	public function testConvertAttachment(string $expected, array $data)
+	public function testConvertAttachment(string $expected, array $data): void
 	{
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
@@ -839,7 +839,7 @@ Lucas: For the right price, yes.[/share]',
 	 * @param string $text     Input text
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('datasetMentionsToNicknames')]
-	public function testsetMentionsToNicknames(string $expected, string $text)
+	public function testsetMentionsToNicknames(string $expected, string $text): void
 	{
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 

--- a/tests/src/Content/Text/HTMLTest.php
+++ b/tests/src/Content/Text/HTMLTest.php
@@ -41,7 +41,7 @@ class HTMLTest extends FixtureTestCase
 	 * @throws Exception
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataHTML')]
-	public function testToPlaintext(string $input, string $expected)
+	public function testToPlaintext(string $input, string $expected): void
 	{
 		$output = HTML::toPlaintext($input, 0);
 
@@ -103,7 +103,7 @@ its surprisingly good",
 	 * @throws InternalServerErrorException
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataHTMLText')]
-	public function testToBBCode(string $expectedBBCode, string $html)
+	public function testToBBCode(string $expectedBBCode, string $html): void
 	{
 		$actual = HTML::toBBCode($html);
 
@@ -152,7 +152,7 @@ its surprisingly good",
 	 * @throws \DOMException
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataXpathQuote')]
-	public function testXpathQuote(string $value)
+	public function testXpathQuote(string $value): void
 	{
 		$dom              = new \DOMDocument();
 		$element          = $dom->createElement('test');
@@ -219,7 +219,7 @@ its surprisingly good",
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCheckRelMeLink')]
-	public function testCheckRelMeLink(\DOMDocument $doc, UriInterface $meUrl)
+	public function testCheckRelMeLink(\DOMDocument $doc, UriInterface $meUrl): void
 	{
 		$this->assertTrue(HTML::checkRelMeLink($doc, $meUrl));
 	}
@@ -253,7 +253,7 @@ its surprisingly good",
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCheckRelMeLinkFail')]
-	public function testCheckRelMeLinkFail(\DOMDocument $doc, UriInterface $meUrl)
+	public function testCheckRelMeLinkFail(\DOMDocument $doc, UriInterface $meUrl): void
 	{
 		$this->assertFalse(HTML::checkRelMeLink($doc, $meUrl));
 	}
@@ -1507,7 +1507,7 @@ Served from: blog.austria-insiderinfo.com @ 2023-01-07 10:50:10 by W3 Total Cach
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataExtractCharset')]
-	public function testExtractCharset(?string $expected, string $html)
+	public function testExtractCharset(?string $expected, string $html): void
 	{
 		$doc = new \DOMDocument();
 		@$doc->loadHTML($html, LIBXML_NOERROR);

--- a/tests/src/Content/Text/MarkdownTest.php
+++ b/tests/src/Content/Text/MarkdownTest.php
@@ -38,7 +38,7 @@ class MarkdownTest extends FixtureTestCase
 	 * @throws Exception
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataMarkdown')]
-	public function testConvert(string $input, string $expected)
+	public function testConvert(string $input, string $expected): void
 	{
 		$output = Markdown::convert($input);
 
@@ -63,7 +63,7 @@ class MarkdownTest extends FixtureTestCase
 	 * @param string $markdown       Markdown text
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataMarkdownText')]
-	public function testToBBCode(string $expectedBBCode, string $markdown)
+	public function testToBBCode(string $expectedBBCode, string $markdown): void
 	{
 		$actual = Markdown::toBBCode($markdown);
 

--- a/tests/src/Content/Text/PlaintextTest.php
+++ b/tests/src/Content/Text/PlaintextTest.php
@@ -56,7 +56,7 @@ class PlaintextTest extends FixtureTestCase
 	 * @throws InternalServerErrorException
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataMessage')]
-	public function testSplitMessage(string $text, array $expected)
+	public function testSplitMessage(string $text, array $expected): void
 	{
 		$item = [
 			'uri-id' => -1,

--- a/tests/src/Core/ACLTest.php
+++ b/tests/src/Core/ACLTest.php
@@ -17,7 +17,7 @@ class ACLTest extends FixtureTestCase
 	 *
 	 * @return void
 	 */
-	public function testCheckAclInput()
+	public function testCheckAclInput(): void
 	{
 		$result = ACL::isValidContact('<aclstring>', '42');
 		self::assertFalse($result);
@@ -28,7 +28,7 @@ class ACLTest extends FixtureTestCase
 	 *
 	 * @return void
 	 */
-	public function testCheckAclInputWithEmptyAclString()
+	public function testCheckAclInputWithEmptyAclString(): void
 	{
 		$result = ACL::isValidContact('', '42');
 		self::assertTrue($result);

--- a/tests/src/Core/Addon/Model/AddonLoaderTest.php
+++ b/tests/src/Core/Addon/Model/AddonLoaderTest.php
@@ -115,7 +115,7 @@ EOF;
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataHooks')]
-	public function testAddonLoader(array $structure, array $enabledAddons, array $files, array $assertion)
+	public function testAddonLoader(array $structure, array $enabledAddons, array $files, array $assertion): void
 	{
 		vfsStream::create($structure)->at($this->root);
 
@@ -141,7 +141,7 @@ EOF;
 	/**
 	 * Test the exception in case of a wrong addon content
 	 */
-	public function testWrongContent()
+	public function testWrongContent(): void
 	{
 		$filename     = 'addon/testaddon1/static/hooks.config.php';
 		$wrongContent = "<?php return 'wrong';";
@@ -171,7 +171,7 @@ EOF;
 	/**
 	 * Test that nothing happens in case there are wrong addons files, but they're not used
 	 */
-	public function testNoHooksConfig()
+	public function testNoHooksConfig(): void
 	{
 		$filename     = 'addon/testaddon1/static/hooks.config.php';
 		$wrongContent = "<?php return 'wrong';";

--- a/tests/src/Core/Cache/APCuCacheTest.php
+++ b/tests/src/Core/Cache/APCuCacheTest.php
@@ -36,7 +36,7 @@ class APCuCacheTest extends MemoryCacheTestCase
 		parent::tearDown();
 	}
 
-	public function testStats()
+	public function testStats(): void
 	{
 		$stats = $this->instance->getStats();
 

--- a/tests/src/Core/Cache/ArrayCacheTest.php
+++ b/tests/src/Core/Cache/ArrayCacheTest.php
@@ -25,11 +25,10 @@ class ArrayCacheTest extends MemoryCacheTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
-	public function testTTL()
+	public function testTTL(): void
 	{
 		// Array Cache doesn't support TTL
 		self::markTestSkipped("Array Cache doesn't support TTL");
-		return true;
 	}
 
 	public function testGetStats(): void

--- a/tests/src/Core/Cache/ArrayCacheTest.php
+++ b/tests/src/Core/Cache/ArrayCacheTest.php
@@ -32,7 +32,7 @@ class ArrayCacheTest extends MemoryCacheTestCase
 		return true;
 	}
 
-	public function testGetStats()
+	public function testGetStats(): void
 	{
 		self::assertEmpty($this->cache->getStats());
 	}

--- a/tests/src/Core/Cache/MemcacheCacheTest.php
+++ b/tests/src/Core/Cache/MemcacheCacheTest.php
@@ -54,7 +54,7 @@ class MemcacheCacheTest extends MemoryCacheTestCase
 		static::markTestIncomplete('Race condition because of too fast getAllKeys() which uses a workaround');
 	}
 
-	public function testStats()
+	public function testStats(): void
 	{
 		$stats = $this->instance->getStats();
 

--- a/tests/src/Core/Cache/MemcachedCacheTest.php
+++ b/tests/src/Core/Cache/MemcachedCacheTest.php
@@ -53,7 +53,7 @@ class MemcachedCacheTest extends MemoryCacheTestCase
 		static::markTestIncomplete('Race condition because of too fast getAllKeys() which uses a workaround');
 	}
 
-	public function testStats()
+	public function testStats(): void
 	{
 		$stats = $this->instance->getStats();
 

--- a/tests/src/Core/Cache/ProfilerCacheDecoratorTest.php
+++ b/tests/src/Core/Cache/ProfilerCacheDecoratorTest.php
@@ -32,11 +32,10 @@ class ProfilerCacheDecoratorTest extends MemoryCacheTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
-	public function testTTL()
+	public function testTTL(): void
 	{
 		// Array Cache doesn't support TTL
 		self::markTestSkipped("Array Cache doesn't support TTL");
-		return true;
 	}
 
 	public function testGetStats(): void

--- a/tests/src/Core/Cache/ProfilerCacheDecoratorTest.php
+++ b/tests/src/Core/Cache/ProfilerCacheDecoratorTest.php
@@ -39,12 +39,12 @@ class ProfilerCacheDecoratorTest extends MemoryCacheTestCase
 		return true;
 	}
 
-	public function testGetStats()
+	public function testGetStats(): void
 	{
 		self::assertEmpty($this->cache->getStats());
 	}
 
-	public function testGetName()
+	public function testGetName(): void
 	{
 		self::assertStringEndsWith(' (with profiler)', $this->instance->getName());
 	}

--- a/tests/src/Core/Cache/RedisCacheTest.php
+++ b/tests/src/Core/Cache/RedisCacheTest.php
@@ -56,7 +56,7 @@ class RedisCacheTest extends MemoryCacheTestCase
 		parent::tearDown();
 	}
 
-	public function testStats()
+	public function testStats(): void
 	{
 		$stats = $this->instance->getStats();
 

--- a/tests/src/Core/Config/Cache/CacheTest.php
+++ b/tests/src/Core/Config/Cache/CacheTest.php
@@ -48,7 +48,7 @@ class CacheTest extends MockedTestCase
 	 * Test the loadConfigArray() method without override
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testLoadConfigArray($data)
+	public function testLoadConfigArray($data): void
 	{
 		$configCache = new Cache();
 		$configCache->load($data);
@@ -60,7 +60,7 @@ class CacheTest extends MockedTestCase
 	 * Test the loadConfigArray() method with overrides
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testLoadConfigArrayOverride($data)
+	public function testLoadConfigArrayOverride($data): void
 	{
 		$override = [
 			'system' => [
@@ -99,7 +99,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test the loadConfigArray() method with only a category
 	 */
-	public function testLoadConfigArrayWithOnlyCategory()
+	public function testLoadConfigArrayWithOnlyCategory(): void
 	{
 		$configCache = new Cache();
 
@@ -121,7 +121,7 @@ class CacheTest extends MockedTestCase
 	 * Test the getAll() method
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testGetAll($data)
+	public function testGetAll($data): void
 	{
 		$configCache = new Cache();
 		$configCache->load($data);
@@ -136,7 +136,7 @@ class CacheTest extends MockedTestCase
 	 * Test the set() and get() method
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetGet($data)
+	public function testSetGet($data): void
 	{
 		$configCache = new Cache();
 
@@ -152,7 +152,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test the get() method without a value
 	 */
-	public function testGetEmpty()
+	public function testGetEmpty(): void
 	{
 		$configCache = new Cache();
 
@@ -162,7 +162,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test the get() method with a category
 	 */
-	public function testGetCat()
+	public function testGetCat(): void
 	{
 		$configCache = new Cache([
 			'system' => [
@@ -190,7 +190,7 @@ class CacheTest extends MockedTestCase
 	 * Test the delete() method
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testDelete($data)
+	public function testDelete($data): void
 	{
 		$configCache = new Cache($data);
 
@@ -207,7 +207,7 @@ class CacheTest extends MockedTestCase
 	 * Test the keyDiff() method with result
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testKeyDiffWithResult($data)
+	public function testKeyDiffWithResult($data): void
 	{
 		$configCache = new Cache($data);
 
@@ -224,7 +224,7 @@ class CacheTest extends MockedTestCase
 	 * Test the keyDiff() method without result
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testKeyDiffWithoutResult($data)
+	public function testKeyDiffWithoutResult($data): void
 	{
 		$configCache = new Cache($data);
 
@@ -236,7 +236,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test the default hiding of passwords inside the cache
 	 */
-	public function testPasswordHide()
+	public function testPasswordHide(): void
 	{
 		$configCache = new Cache([
 			'database' => [
@@ -253,7 +253,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test disabling the hiding of passwords inside the cache
 	 */
-	public function testPasswordShow()
+	public function testPasswordShow(): void
 	{
 		$configCache = new Cache([
 			'database' => [
@@ -270,7 +270,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test a empty password
 	 */
-	public function testEmptyPassword()
+	public function testEmptyPassword(): void
 	{
 		$configCache = new Cache([
 			'database' => [
@@ -284,7 +284,7 @@ class CacheTest extends MockedTestCase
 		self::assertEmpty($configCache->get('database', 'username'));
 	}
 
-	public function testWrongTypePassword()
+	public function testWrongTypePassword(): void
 	{
 		$configCache = new Cache([
 			'database' => [
@@ -311,7 +311,7 @@ class CacheTest extends MockedTestCase
 	 * Test the set() method with overrides
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetOverrides($data)
+	public function testSetOverrides($data): void
 	{
 
 		$configCache = new Cache();
@@ -334,7 +334,7 @@ class CacheTest extends MockedTestCase
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetData($data)
+	public function testSetData($data): void
 	{
 		$configCache = new Cache();
 		$configCache->load($data, Cache::SOURCE_FILE);
@@ -346,7 +346,7 @@ class CacheTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testMerge($data)
+	public function testMerge($data): void
 	{
 		$configCache = new Cache();
 		$configCache->load($data, Cache::SOURCE_FILE);
@@ -508,7 +508,7 @@ class CacheTest extends MockedTestCase
 	 * Tests that the Cache can return a whole category at once
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCat')]
-	public function testGetCategory($data, string $category, mixed $assertion)
+	public function testGetCategory($data, string $category, mixed $assertion): void
 	{
 		$cache = new Cache($data);
 
@@ -519,7 +519,7 @@ class CacheTest extends MockedTestCase
 	 * Test that the cache can get merged with different categories
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCat')]
-	public function testCatMerge($data, string $category, mixed $assertion)
+	public function testCatMerge($data, string $category, mixed $assertion): void
 	{
 		$cache = new Cache($data);
 
@@ -538,7 +538,7 @@ class CacheTest extends MockedTestCase
 	 *
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testDeleteRemovesKey($data)
+	public function testDeleteRemovesKey($data): void
 	{
 		$cache = new Cache();
 		$cache->load($data, Cache::SOURCE_FILE);
@@ -562,7 +562,7 @@ class CacheTest extends MockedTestCase
 	 * Test that deleted keys are working with merge
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testDeleteAndMergeWithDefault($data)
+	public function testDeleteAndMergeWithDefault($data): void
 	{
 		$cache = new Cache();
 		$cache->load($data, Cache::SOURCE_FILE);

--- a/tests/src/Core/Config/Cache/ConfigFileManagerTest.php
+++ b/tests/src/Core/Config/Cache/ConfigFileManagerTest.php
@@ -28,7 +28,7 @@ class ConfigFileManagerTest extends MockedTestCase
 	/**
 	 * Test the loadConfigFiles() method with default values
 	 */
-	public function testLoadConfigFiles()
+	public function testLoadConfigFiles(): void
 	{
 		$this->delConfigFile('local.config.php');
 
@@ -50,7 +50,7 @@ class ConfigFileManagerTest extends MockedTestCase
 	 * Test the loadConfigFiles() method with a wrong local.config.php
 	 *
 	 */
-	public function testLoadConfigWrong()
+	public function testLoadConfigWrong(): void
 	{
 		$this->expectExceptionMessageMatches("/Error loading config file \w+/");
 		$this->expectException(\Exception::class);
@@ -74,7 +74,7 @@ class ConfigFileManagerTest extends MockedTestCase
 	/**
 	 * Test the loadConfigFiles() method with a local.config.php file
 	 */
-	public function testLoadConfigFilesLocal()
+	public function testLoadConfigFilesLocal(): void
 	{
 		$this->delConfigFile('local.config.php');
 
@@ -112,7 +112,7 @@ class ConfigFileManagerTest extends MockedTestCase
 	/**
 	 * Test the loadConfigFile() method with a local.ini.php file
 	 */
-	public function testLoadConfigFilesINI()
+	public function testLoadConfigFilesINI(): void
 	{
 		$this->delConfigFile('local.config.php');
 
@@ -149,7 +149,7 @@ class ConfigFileManagerTest extends MockedTestCase
 	/**
 	 * Test the loadConfigFile() method with a .htconfig.php file
 	 */
-	public function testLoadConfigFilesHtconfig()
+	public function testLoadConfigFilesHtconfig(): void
 	{
 		$this->delConfigFile('local.config.php');
 
@@ -196,7 +196,7 @@ class ConfigFileManagerTest extends MockedTestCase
 		self::assertEquals('1', $configCache->get('system', 'no_regfullname'));
 	}
 
-	public function testLoadAddonConfig()
+	public function testLoadAddonConfig(): void
 	{
 		$structure = [
 			'addon' => [
@@ -240,7 +240,7 @@ class ConfigFileManagerTest extends MockedTestCase
 	/**
 	 * test loading multiple config files - the last config should work
 	 */
-	public function testLoadMultipleConfigs()
+	public function testLoadMultipleConfigs(): void
 	{
 		$this->delConfigFile('local.config.php');
 
@@ -275,7 +275,7 @@ class ConfigFileManagerTest extends MockedTestCase
 	/**
 	 * test loading multiple config files - the last config should work (INI-version)
 	 */
-	public function testLoadMultipleInis()
+	public function testLoadMultipleInis(): void
 	{
 		$this->delConfigFile('local.config.php');
 
@@ -310,7 +310,7 @@ class ConfigFileManagerTest extends MockedTestCase
 	/**
 	 * Test that sample-files (e.g. local-sample.config.php) is never loaded
 	 */
-	public function testNotLoadingSamples()
+	public function testNotLoadingSamples(): void
 	{
 		$this->delConfigFile('local.config.php');
 
@@ -346,7 +346,7 @@ class ConfigFileManagerTest extends MockedTestCase
 	/**
 	 * Test that using a wrong configuration directory leads to the "normal" config path
 	 */
-	public function testWrongEnvDir()
+	public function testWrongEnvDir(): void
 	{
 		$this->delConfigFile('local.config.php');
 
@@ -365,7 +365,7 @@ class ConfigFileManagerTest extends MockedTestCase
 	/**
 	 * Test that a different location of the configuration directory produces the expected output
 	 */
-	public function testRightEnvDir()
+	public function testRightEnvDir(): void
 	{
 		$this->delConfigFile('local.config.php');
 

--- a/tests/src/Core/Config/ConfigTest.php
+++ b/tests/src/Core/Config/ConfigTest.php
@@ -176,7 +176,7 @@ class ConfigTest extends DatabaseTestCase
 	 * Test the configuration initialization
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataConfigLoad')]
-	public function testSetUp(array $data, array $possibleCats, array $load)
+	public function testSetUp(array $data, array $possibleCats, array $load): void
 	{
 		$this->loadDirectFixture($this->configToDbArray($data), $this->getDbInstance());
 
@@ -194,7 +194,7 @@ class ConfigTest extends DatabaseTestCase
 	 * @param array $load
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataConfigLoad')]
-	public function testReload(array $data, array $possibleCats, array $load)
+	public function testReload(array $data, array $possibleCats, array $load): void
 	{
 		$this->loadDirectFixture($this->configToDbArray($data), $this->getDbInstance());
 
@@ -276,7 +276,7 @@ class ConfigTest extends DatabaseTestCase
 	 * Test the configuration load() method with overwrite
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataDoubleLoad')]
-	public function testCacheLoadDouble(array $data1, array $data2, array $expect = [])
+	public function testCacheLoadDouble(array $data1, array $data2, array $expect = []): void
 	{
 		$this->loadDirectFixture($this->configToDbArray($data1), $this->getDbInstance());
 
@@ -300,7 +300,7 @@ class ConfigTest extends DatabaseTestCase
 	/**
 	 * Test the configuration load without result
 	 */
-	public function testLoadWrong()
+	public function testLoadWrong(): void
 	{
 		$this->testedConfig = new ReadOnlyFileConfig(new Cache());
 		self::assertInstanceOf(Cache::class, $this->testedConfig->getCache());
@@ -312,7 +312,7 @@ class ConfigTest extends DatabaseTestCase
 	 * Test the configuration get() and set() methods
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetGet($data)
+	public function testSetGet($data): void
 	{
 		$this->testedConfig = $this->getInstance();
 		self::assertInstanceOf(Cache::class, $this->testedConfig->getCache());
@@ -326,7 +326,7 @@ class ConfigTest extends DatabaseTestCase
 	/**
 	 * Test the configuration get() method with wrong value and no db
 	 */
-	public function testGetWrongWithoutDB()
+	public function testGetWrongWithoutDB(): void
 	{
 		$this->testedConfig = $this->getInstance();
 		self::assertInstanceOf(Cache::class, $this->testedConfig->getCache());
@@ -348,7 +348,7 @@ class ConfigTest extends DatabaseTestCase
 	 * Test the configuration delete() method without a model/db
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testDelete($data)
+	public function testDelete($data): void
 	{
 		$this->configCache->load(['test' => ['it' => $data]], Cache::SOURCE_FILE);
 
@@ -366,7 +366,7 @@ class ConfigTest extends DatabaseTestCase
 	/**
 	 * Test the configuration get() and set() method where the db value has a higher prio than the config file
 	 */
-	public function testSetGetHighPrio()
+	public function testSetGetHighPrio(): void
 	{
 		$this->testedConfig = $this->getInstance();
 		self::assertInstanceOf(Cache::class, $this->testedConfig->getCache());
@@ -382,7 +382,7 @@ class ConfigTest extends DatabaseTestCase
 	/**
 	 * Test the configuration get() and set() method where the db value has a lower prio than the env
 	 */
-	public function testSetGetLowPrio()
+	public function testSetGetLowPrio(): void
 	{
 		$this->loadDirectFixture(['config' => [['cat' => 'config', 'k' => 'test', 'v' => 'it']]], $this->getDbInstance());
 
@@ -515,7 +515,7 @@ class ConfigTest extends DatabaseTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCat')]
-	public function testGetCategory(array $data, string $category, array $assertion)
+	public function testGetCategory(array $data, string $category, array $assertion): void
 	{
 		$this->configCache = new Cache($data);
 		$config            = new ReadOnlyFileConfig($this->configCache);
@@ -542,7 +542,7 @@ class ConfigTest extends DatabaseTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSerialized')]
-	public function testSerializedValues($value, $assertion)
+	public function testSerializedValues($value, $assertion): void
 	{
 		$config = $this->getInstance();
 
@@ -599,7 +599,7 @@ class ConfigTest extends DatabaseTestCase
 	 * Tests if environment variables can change the permission to write a config key
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataEnv')]
-	public function testIsWritable(array $data, array $server, array $assertDisabled)
+	public function testIsWritable(array $data, array $server, array $assertDisabled): void
 	{
 		$this->setConfigFile('static' . DIRECTORY_SEPARATOR . 'env.config.php', true);
 		$this->loadDirectFixture($this->configToDbArray($data), $this->getDbInstance());

--- a/tests/src/Core/Config/ConfigTransactionTest.php
+++ b/tests/src/Core/Config/ConfigTransactionTest.php
@@ -42,7 +42,7 @@ class ConfigTransactionTest extends FixtureTestCase
 		];
 	}
 
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$config            = new DatabaseConfig($this->dice->create(Database::class), new Cache());
 		$configTransaction = new ConfigTransaction($config);
@@ -51,7 +51,7 @@ class ConfigTransactionTest extends FixtureTestCase
 		self::assertInstanceOf(ConfigTransaction::class, $configTransaction);
 	}
 
-	public function testConfigTransaction()
+	public function testConfigTransaction(): void
 	{
 		$config = new DatabaseConfig($this->dice->create(Database::class), new Cache());
 		$config->set('config', 'key1', 'value1');
@@ -92,7 +92,7 @@ class ConfigTransactionTest extends FixtureTestCase
 	/**
 	 * This test asserts that in empty transactions, no saveData is called, thus no config file writing was performed
 	 */
-	public function testNothingToDo()
+	public function testNothingToDo(): void
 	{
 		$this->configFileManager = \Mockery::spy(ConfigFileManager::class);
 

--- a/tests/src/Core/Hooks/Model/InstanceManagerTest.php
+++ b/tests/src/Core/Hooks/Model/InstanceManagerTest.php
@@ -38,7 +38,7 @@ class InstanceManagerTest extends MockedTestCase
 		parent::tearDown();
 	}
 
-	public function testEqualButNotSameInstance()
+	public function testEqualButNotSameInstance(): void
 	{
 		$instance = new DiceInstanceManager(new Dice(), $this->hookFileManager);
 
@@ -78,7 +78,7 @@ class InstanceManagerTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testInstanceWithArgs(?string $aString = null, ?bool $cBool = null, ?string $bString = null)
+	public function testInstanceWithArgs(?string $aString = null, ?bool $cBool = null, ?string $bString = null): void
 	{
 		$instance = new DiceInstanceManager(new Dice(), $this->hookFileManager);
 
@@ -112,7 +112,7 @@ class InstanceManagerTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testInstanceWithTwoStrategies(?string $aString = null, ?bool $cBool = null, ?string $bString = null)
+	public function testInstanceWithTwoStrategies(?string $aString = null, ?bool $cBool = null, ?string $bString = null): void
 	{
 		$instance = new DiceInstanceManager(new Dice(), $this->hookFileManager);
 
@@ -149,7 +149,7 @@ class InstanceManagerTest extends MockedTestCase
 	/**
 	 * Test the exception in case the interface was already registered
 	 */
-	public function testDoubleRegister()
+	public function testDoubleRegister(): void
 	{
 		self::expectException(HookRegisterArgumentException::class);
 		self::expectExceptionMessage(sprintf('A class with the name %s is already set for the interface %s', 'fake', IAmADecoratedInterface::class));
@@ -162,7 +162,7 @@ class InstanceManagerTest extends MockedTestCase
 	/**
 	 * Test the exception in case the name of the instance isn't registered
 	 */
-	public function testWrongInstanceName()
+	public function testWrongInstanceName(): void
 	{
 		self::expectException(HookInstanceException::class);
 		self::expectExceptionMessage(sprintf('The class with the name %s isn\'t registered for the class or interface %s', 'fake', IAmADecoratedInterface::class));
@@ -175,7 +175,7 @@ class InstanceManagerTest extends MockedTestCase
 	 * Test in case there are already some rules
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testWithGivenRules(?string $aString = null, ?bool $cBool = null, ?string $bString = null)
+	public function testWithGivenRules(?string $aString = null, ?bool $cBool = null, ?string $bString = null): void
 	{
 		$args = [];
 
@@ -220,7 +220,7 @@ class InstanceManagerTest extends MockedTestCase
 	/**
 	 * @see https://github.com/friendica/friendica/issues/13318
 	 */
-	public function testCaseInsensitiveNames()
+	public function testCaseInsensitiveNames(): void
 	{
 		$instance = new DiceInstanceManager(new Dice(), $this->hookFileManager);
 

--- a/tests/src/Core/Hooks/Util/StrategiesFileManagerTest.php
+++ b/tests/src/Core/Hooks/Util/StrategiesFileManagerTest.php
@@ -146,7 +146,7 @@ class StrategiesFileManagerTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataHooks')]
-	public function testSetupHooks(string $content, string $addonContent, array $assertStrategies)
+	public function testSetupHooks(string $content, string $addonContent, array $assertStrategies): void
 	{
 		vfsStream::newFile(StrategiesFileManager::STATIC_DIR . '/' . StrategiesFileManager::CONFIG_NAME . '.config.php')
 			->withContent($content)
@@ -175,7 +175,7 @@ class StrategiesFileManagerTest extends MockedTestCase
 	/**
 	 * Test the exception in case the strategies.config.php file is missing
 	 */
-	public function testMissingStrategiesFile()
+	public function testMissingStrategiesFile(): void
 	{
 		$config          = \Mockery::mock(IManageConfigValues::class);
 		$instanceManager = \Mockery::mock(ICanRegisterStrategies::class);
@@ -193,7 +193,7 @@ class StrategiesFileManagerTest extends MockedTestCase
 	/**
 	 * Test the exception in case the strategies.config.php file is wrong
 	 */
-	public function testWrongStrategiesFile()
+	public function testWrongStrategiesFile(): void
 	{
 		$config          = \Mockery::mock(IManageConfigValues::class);
 		$instanceManager = \Mockery::mock(ICanRegisterStrategies::class);

--- a/tests/src/Core/InstallerTest.php
+++ b/tests/src/Core/InstallerTest.php
@@ -126,7 +126,7 @@ class InstallerTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('getCheckKeysData')]
-	public function testCheckKeys($function, $expected)
+	public function testCheckKeys($function, $expected): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) use ($function, $expected) {
@@ -142,7 +142,7 @@ class InstallerTest extends MockedTestCase
 		self::assertSame($expected, $install->checkKeys());
 	}
 
-	public function testCheckFunctionsWithoutIntlChar()
+	public function testCheckFunctionsWithoutIntlChar(): void
 	{
 		$class_exists = $this->getFunctionMock('Friendica\Core', 'class_exists');
 		$class_exists->expects($this->any())->willReturnCallback(function ($class_name) {
@@ -166,7 +166,7 @@ class InstallerTest extends MockedTestCase
 		);
 	}
 
-	public function testCheckFunctionsWithoutCurlInit()
+	public function testCheckFunctionsWithoutCurlInit(): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) {
@@ -190,7 +190,7 @@ class InstallerTest extends MockedTestCase
 		);
 	}
 
-	public function testCheckFunctionsWithoutImagecreateformjpeg()
+	public function testCheckFunctionsWithoutImagecreateformjpeg(): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) {
@@ -214,7 +214,7 @@ class InstallerTest extends MockedTestCase
 		);
 	}
 
-	public function testCheckFunctionsWithoutOpensslpublicencrypt()
+	public function testCheckFunctionsWithoutOpensslpublicencrypt(): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) {
@@ -238,7 +238,7 @@ class InstallerTest extends MockedTestCase
 		);
 	}
 
-	public function testCheckFunctionsWithoutMbStrlen()
+	public function testCheckFunctionsWithoutMbStrlen(): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) {
@@ -262,7 +262,7 @@ class InstallerTest extends MockedTestCase
 		);
 	}
 
-	public function testCheckFunctionsWithoutIconvStrlen()
+	public function testCheckFunctionsWithoutIconvStrlen(): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) {
@@ -286,7 +286,7 @@ class InstallerTest extends MockedTestCase
 		);
 	}
 
-	public function testCheckFunctionsWithoutPosixkill()
+	public function testCheckFunctionsWithoutPosixkill(): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) {
@@ -310,7 +310,7 @@ class InstallerTest extends MockedTestCase
 		);
 	}
 
-	public function testCheckFunctionsWithoutProcOpen()
+	public function testCheckFunctionsWithoutProcOpen(): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) {
@@ -334,7 +334,7 @@ class InstallerTest extends MockedTestCase
 		);
 	}
 
-	public function testCheckFunctionsWithoutJsonEncode()
+	public function testCheckFunctionsWithoutJsonEncode(): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) {
@@ -358,7 +358,7 @@ class InstallerTest extends MockedTestCase
 		);
 	}
 
-	public function testCheckFunctionsWithoutFinfoOpen()
+	public function testCheckFunctionsWithoutFinfoOpen(): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) {
@@ -382,7 +382,7 @@ class InstallerTest extends MockedTestCase
 		);
 	}
 
-	public function testCheckFunctionsWithoutGmpStrval()
+	public function testCheckFunctionsWithoutGmpStrval(): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) {
@@ -406,7 +406,7 @@ class InstallerTest extends MockedTestCase
 		);
 	}
 
-	public function testCheckFunctions()
+	public function testCheckFunctions(): void
 	{
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
 		$function_exists->expects($this->any())->willReturnCallback(function ($function_name) {
@@ -435,7 +435,7 @@ class InstallerTest extends MockedTestCase
 		self::assertTrue($install->checkFunctions());
 	}
 
-	public function testCheckLocalIni()
+	public function testCheckLocalIni(): void
 	{
 		$this->l10nMock->shouldReceive('t')->andReturnUsing(function ($args) { return $args; });
 
@@ -452,7 +452,7 @@ class InstallerTest extends MockedTestCase
 		self::assertTrue($install->checkLocalIni());
 	}
 
-	public function testCheckHtAccessFail()
+	public function testCheckHtAccessFail(): void
 	{
 		// Mocking that we can use CURL
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
@@ -500,7 +500,7 @@ class InstallerTest extends MockedTestCase
 		self::assertSame('test Error', $install->getChecks()[0]['error_msg']['msg']);
 	}
 
-	public function testCheckHtAccessWork()
+	public function testCheckHtAccessWork(): void
 	{
 		// Mocking that we can use CURL
 		$function_exists = $this->getFunctionMock('Friendica\Core', 'function_exists');
@@ -547,7 +547,7 @@ class InstallerTest extends MockedTestCase
 		self::assertTrue($install->checkHtAccess('https://test'));
 	}
 
-	public function testImagickNotInstalled()
+	public function testImagickNotInstalled(): void
 	{
 		$class_exists = $this->getFunctionMock('Friendica\Core', 'class_exists');
 		$class_exists->expects($this->any())->willReturnCallback(function ($class_name) {
@@ -576,7 +576,7 @@ class InstallerTest extends MockedTestCase
 	 * Test the setup of the config cache for installation
 	 */
 	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
-	public function testSetUpCache()
+	public function testSetUpCache(): void
 	{
 		$this->l10nMock->shouldReceive('t')->andReturnUsing(function ($args) { return $args; });
 

--- a/tests/src/Core/KeyValueStorage/DBKeyValueStorageTest.php
+++ b/tests/src/Core/KeyValueStorage/DBKeyValueStorageTest.php
@@ -43,7 +43,7 @@ class DBKeyValueStorageTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testUpdatedAt($k, $v)
+	public function testUpdatedAt($k, $v): void
 	{
 		$instance = $this->getInstance();
 
@@ -70,7 +70,7 @@ class DBKeyValueStorageTest extends MockedTestCase
 		self::assertGreaterThanOrEqual($updateAt, $updateAtAfter);
 	}
 
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$instance = $this->getInstance();
 
@@ -92,7 +92,7 @@ class DBKeyValueStorageTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testGetSetDelete($k, $v)
+	public function testGetSetDelete($k, $v): void
 	{
 		$instance = $this->getInstance();
 
@@ -108,7 +108,7 @@ class DBKeyValueStorageTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetOverride($k, $v)
+	public function testSetOverride($k, $v): void
 	{
 		$instance = $this->getInstance();
 
@@ -124,7 +124,7 @@ class DBKeyValueStorageTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testOffsetSetDelete($k, $v)
+	public function testOffsetSetDelete($k, $v): void
 	{
 		$instance = $this->getInstance();
 

--- a/tests/src/Core/L10nTest.php
+++ b/tests/src/Core/L10nTest.php
@@ -94,7 +94,7 @@ class L10nTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataDetectLanguage')]
-	public function testDetectLanguage(array $server, array $get, string $default, string $assert)
+	public function testDetectLanguage(array $server, array $get, string $default, string $assert): void
 	{
 		self::assertEquals($assert, L10n::detectLanguage($server, $get, $default));
 	}

--- a/tests/src/Core/Lock/SemaphoreLockTest.php
+++ b/tests/src/Core/Lock/SemaphoreLockTest.php
@@ -60,7 +60,7 @@ class SemaphoreLockTest extends LockTestCase
 	 * Test if semaphore locking works even when trying to release locks, where the file exists
 	 * but it shouldn't harm locking
 	 */
-	public function testMissingFileNotOverriding()
+	public function testMissingFileNotOverriding(): void
 	{
 		$file = System::getTempPath() . '/test.sem';
 		touch($file);
@@ -78,7 +78,7 @@ class SemaphoreLockTest extends LockTestCase
 	 *
 	 * @see https://github.com/friendica/friendica/issues/7298#issuecomment-521996540
 	 */
-	public function testMissingFileOverriding()
+	public function testMissingFileOverriding(): void
 	{
 		$file = System::getTempPath() . '/test.sem';
 		touch($file);
@@ -91,7 +91,7 @@ class SemaphoreLockTest extends LockTestCase
 	/**
 	 * Test acquire lock even the semaphore file exists, but isn't used
 	 */
-	public function testOverrideSemFile()
+	public function testOverrideSemFile(): void
 	{
 		$file = System::getTempPath() . '/test.sem';
 		touch($file);

--- a/tests/src/Core/Logger/ProfilerLoggerTest.php
+++ b/tests/src/Core/Logger/ProfilerLoggerTest.php
@@ -41,7 +41,7 @@ class ProfilerLoggerTest extends MockedTestCase
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
 	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
-	public function testProfiling($function, $message, array $context)
+	public function testProfiling($function, $message, array $context): void
 	{
 		$logger = new ProfilerLogger($this->logger, $this->profiler);
 
@@ -56,7 +56,7 @@ class ProfilerLoggerTest extends MockedTestCase
 	 * Test the log() function
 	 */
 	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
-	public function testProfilingLog()
+	public function testProfilingLog(): void
 	{
 		$logger = new ProfilerLogger($this->logger, $this->profiler);
 

--- a/tests/src/Core/Logger/StreamLoggerTest.php
+++ b/tests/src/Core/Logger/StreamLoggerTest.php
@@ -58,7 +58,7 @@ class StreamLoggerTest extends LoggerTestCase
 	/**
 	 * Test when a file isn't set
 	 */
-	public function testNoUrl()
+	public function testNoUrl(): void
 	{
 		$this->expectException(LoggerArgumentException::class);
 		$this->expectExceptionMessage(' is not a valid logfile');
@@ -74,7 +74,7 @@ class StreamLoggerTest extends LoggerTestCase
 	/**
 	 * Test when a file cannot be opened
 	 */
-	public function testWrongUrl()
+	public function testWrongUrl(): void
 	{
 		$this->expectException(LoggerArgumentException::class);
 
@@ -108,7 +108,7 @@ class StreamLoggerTest extends LoggerTestCase
 	/**
 	 * Test when the minimum level is not valid
 	 */
-	public function testWrongMinimumLevel()
+	public function testWrongMinimumLevel(): void
 	{
 		$this->expectException(LogLevelException::class);
 		$this->expectExceptionMessageMatches("/The level \".*\" is not valid./");
@@ -119,7 +119,7 @@ class StreamLoggerTest extends LoggerTestCase
 	/**
 	 * Test when the minimum level is not valid
 	 */
-	public function testWrongLogLevel()
+	public function testWrongLogLevel(): void
 	{
 		$this->expectException(LogLevelException::class);
 		$this->expectExceptionMessageMatches("/The level \".*\" is not valid./");

--- a/tests/src/Core/Logger/SyslogLoggerTest.php
+++ b/tests/src/Core/Logger/SyslogLoggerTest.php
@@ -55,7 +55,7 @@ class SyslogLoggerTest extends LoggerTestCase
 	/**
 	 * Test when the minimum level is not valid
 	 */
-	public function testWrongMinimumLevel()
+	public function testWrongMinimumLevel(): void
 	{
 		$this->expectException(LogLevelException::class);
 		$this->expectExceptionMessageMatches("/The level \".*\" is not valid./");
@@ -66,7 +66,7 @@ class SyslogLoggerTest extends LoggerTestCase
 	/**
 	 * Test when the minimum level is not valid
 	 */
-	public function testWrongLogLevel()
+	public function testWrongLogLevel(): void
 	{
 		$this->expectException(LogLevelException::class);
 		$this->expectExceptionMessageMatches("/The level \".*\" is not valid./");
@@ -80,7 +80,7 @@ class SyslogLoggerTest extends LoggerTestCase
 	 * Test the close() method
 	 */
 	#[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
-	public function testClose()
+	public function testClose(): void
 	{
 		$logger = $this->getInstance();
 		$logger->emergency('test');

--- a/tests/src/Core/PConfig/Cache/CacheTest.php
+++ b/tests/src/Core/PConfig/Cache/CacheTest.php
@@ -45,7 +45,7 @@ class CacheTest extends MockedTestCase
 	 * Test the setP() and getP() methods
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetGet($data)
+	public function testSetGet($data): void
 	{
 		$configCache = new \Friendica\Core\PConfig\ValueObject\Cache();
 		$uid         = 345;
@@ -63,7 +63,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test the getP() method with a category
 	 */
-	public function testGetCat()
+	public function testGetCat(): void
 	{
 		$configCache = new \Friendica\Core\PConfig\ValueObject\Cache();
 		$uid         = 345;
@@ -94,7 +94,7 @@ class CacheTest extends MockedTestCase
 	 * Test the deleteP() method
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testDelete($data)
+	public function testDelete($data): void
 	{
 		$configCache = new \Friendica\Core\PConfig\ValueObject\Cache();
 		$uid         = 345;
@@ -117,7 +117,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test the keyDiff() method with result
 	 */
-	public function testKeyDiffWithResult()
+	public function testKeyDiffWithResult(): void
 	{
 		$configCache = new \Friendica\Core\PConfig\ValueObject\Cache();
 
@@ -134,7 +134,7 @@ class CacheTest extends MockedTestCase
 	 * Test the keyDiff() method without result
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testKeyDiffWithoutResult($data)
+	public function testKeyDiffWithoutResult($data): void
 	{
 		$configCache = new \Friendica\Core\PConfig\ValueObject\Cache();
 
@@ -148,7 +148,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test the default hiding of passwords inside the cache
 	 */
-	public function testPasswordHide()
+	public function testPasswordHide(): void
 	{
 		$configCache = new \Friendica\Core\PConfig\ValueObject\Cache();
 
@@ -167,7 +167,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test disabling the hiding of passwords inside the cache
 	 */
-	public function testPasswordShow()
+	public function testPasswordShow(): void
 	{
 		$configCache = new \Friendica\Core\PConfig\ValueObject\Cache(false);
 
@@ -186,7 +186,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test a empty password
 	 */
-	public function testEmptyPassword()
+	public function testEmptyPassword(): void
 	{
 		$configCache = new \Friendica\Core\PConfig\ValueObject\Cache();
 
@@ -201,7 +201,7 @@ class CacheTest extends MockedTestCase
 		self::assertEmpty($configCache->get(1, 'database', 'username'));
 	}
 
-	public function testWrongTypePassword()
+	public function testWrongTypePassword(): void
 	{
 		$configCache = new \Friendica\Core\PConfig\ValueObject\Cache();
 
@@ -231,7 +231,7 @@ class CacheTest extends MockedTestCase
 	/**
 	 * Test two different UID configs and make sure that there is no overlapping possible
 	 */
-	public function testTwoUid()
+	public function testTwoUid(): void
 	{
 		$configCache = new \Friendica\Core\PConfig\ValueObject\Cache();
 

--- a/tests/src/Core/PConfig/JitPConfigTest.php
+++ b/tests/src/Core/PConfig/JitPConfigTest.php
@@ -18,7 +18,7 @@ class JitPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataConfigLoad')]
-	public function testLoad(int $uid, array $data, array $possibleCats, array $load)
+	public function testLoad(int $uid, array $data, array $possibleCats, array $load): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(true)
@@ -35,7 +35,7 @@ class JitPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataDoubleLoad')]
-	public function testCacheLoadDouble(int $uid, array $data1, array $data2, array $expect)
+	public function testCacheLoadDouble(int $uid, array $data1, array $data2, array $expect): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(true)
@@ -65,7 +65,7 @@ class JitPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetGetWithoutDB(int $uid, $data)
+	public function testSetGetWithoutDB(int $uid, $data): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(false)
@@ -75,7 +75,7 @@ class JitPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetGetWithDB(int $uid, $data)
+	public function testSetGetWithDB(int $uid, $data): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(true)
@@ -85,7 +85,7 @@ class JitPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testGetWithRefresh(int $uid, $data)
+	public function testGetWithRefresh(int $uid, $data): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(true)
@@ -113,7 +113,7 @@ class JitPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testDeleteWithoutDB(int $uid, $data)
+	public function testDeleteWithoutDB(int $uid, $data): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(false)
@@ -122,7 +122,7 @@ class JitPConfigTest extends PConfigTestCase
 		parent::testDeleteWithoutDB($uid, $data);
 	}
 
-	public function testDeleteWithDB()
+	public function testDeleteWithDB(): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(true)

--- a/tests/src/Core/PConfig/PreloadPConfigTest.php
+++ b/tests/src/Core/PConfig/PreloadPConfigTest.php
@@ -18,7 +18,7 @@ class PreloadPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataConfigLoad')]
-	public function testLoad(int $uid, array $data, array $possibleCats, array $load)
+	public function testLoad(int $uid, array $data, array $possibleCats, array $load): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(true)
@@ -38,7 +38,7 @@ class PreloadPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataDoubleLoad')]
-	public function testCacheLoadDouble(int $uid, array $data1, array $data2, array $expect)
+	public function testCacheLoadDouble(int $uid, array $data1, array $data2, array $expect): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(true)
@@ -58,7 +58,7 @@ class PreloadPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetGetWithoutDB(int $uid, $data)
+	public function testSetGetWithoutDB(int $uid, $data): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(false)
@@ -68,7 +68,7 @@ class PreloadPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testSetGetWithDB(int $uid, $data)
+	public function testSetGetWithDB(int $uid, $data): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(true)
@@ -83,7 +83,7 @@ class PreloadPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testGetWithRefresh(int $uid, $data)
+	public function testGetWithRefresh(int $uid, $data): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(true)
@@ -105,7 +105,7 @@ class PreloadPConfigTest extends PConfigTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataTests')]
-	public function testDeleteWithoutDB(int $uid, $data)
+	public function testDeleteWithoutDB(int $uid, $data): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(false)
@@ -114,7 +114,7 @@ class PreloadPConfigTest extends PConfigTestCase
 		parent::testDeleteWithoutDB($uid, $data);
 	}
 
-	public function testDeleteWithDB()
+	public function testDeleteWithDB(): void
 	{
 		$this->configModel->shouldReceive('isConnected')
 						  ->andReturn(true)

--- a/tests/src/Core/Session/UserSessionTest.php
+++ b/tests/src/Core/Session/UserSessionTest.php
@@ -53,7 +53,7 @@ class UserSessionTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataLocalUserId')]
-	public function testGetLocalUserId(array $data, $expected)
+	public function testGetLocalUserId(array $data, $expected): void
 	{
 		$userSession = new UserSession(new ArraySession($data));
 		$this->assertEquals($expected, $userSession->getLocalUserId());
@@ -104,7 +104,7 @@ class UserSessionTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetRemoteUserId')]
-	public function testGetRemoteUserId(array $data, $expected)
+	public function testGetRemoteUserId(array $data, $expected): void
 	{
 		$userSession = new UserSession(new ArraySession($data));
 		$this->assertEquals($expected, $userSession->getRemoteUserId());
@@ -125,7 +125,7 @@ class UserSessionTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetRemoteContactId')]
-	public function testGetRemoteContactId(int $uid, array $data, $expected)
+	public function testGetRemoteContactId(int $uid, array $data, $expected): void
 	{
 		$userSession = new UserSession(new ArraySession($data));
 		$this->assertEquals($expected, $userSession->getRemoteContactID($uid));
@@ -158,7 +158,7 @@ class UserSessionTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetUserIdForVisitorContactID')]
-	public function testGetUserIdForVisitorContactID(int $cid, array $data, $expected)
+	public function testGetUserIdForVisitorContactID(int $cid, array $data, $expected): void
 	{
 		$userSession = new UserSession(new ArraySession($data));
 		$this->assertSame($expected, $userSession->getUserIDForVisitorContactID($cid));
@@ -196,7 +196,7 @@ class UserSessionTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataAuthenticated')]
-	public function testIsAuthenticated(array $data, $expected)
+	public function testIsAuthenticated(array $data, $expected): void
 	{
 		$userSession = new UserSession(new ArraySession($data));
 		$this->assertEquals($expected, $userSession->isAuthenticated());
@@ -241,7 +241,7 @@ class UserSessionTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsVisitor')]
-	public function testIsVisitor(array $data, $expected)
+	public function testIsVisitor(array $data, $expected): void
 	{
 		$userSession = new UserSession(new ArraySession($data));
 		$this->assertEquals($expected, $userSession->isVisitor());
@@ -292,7 +292,7 @@ class UserSessionTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsUnauthenticated')]
-	public function testIsUnauthenticated(array $data, $expected)
+	public function testIsUnauthenticated(array $data, $expected): void
 	{
 		$userSession = new UserSession(new ArraySession($data));
 		$this->assertEquals($expected, $userSession->isUnauthenticated());

--- a/tests/src/Core/Storage/FilesystemStorageTest.php
+++ b/tests/src/Core/Storage/FilesystemStorageTest.php
@@ -35,7 +35,7 @@ class FilesystemStorageTest extends StorageTestCase
 	/**
 	 * Test the exception in case of missing directory permissions during put new files
 	 */
-	public function testMissingDirPermissionsDuringPut()
+	public function testMissingDirPermissionsDuringPut(): void
 	{
 		$this->expectException(StorageException::class);
 		$this->expectExceptionMessageMatches("/Filesystem storage failed to create \".*\". Check you write permissions./");
@@ -50,7 +50,7 @@ class FilesystemStorageTest extends StorageTestCase
 	/**
 	 * Test the exception in case the directory isn't writeable
 	 */
-	public function testMissingDirPermissions()
+	public function testMissingDirPermissions(): void
 	{
 		$this->expectException(StorageException::class);
 		$this->expectExceptionMessageMatches("/Path \".*\" does not exist or is not writeable./");
@@ -81,7 +81,7 @@ class FilesystemStorageTest extends StorageTestCase
 	/**
 	 * Test the backend storage of the Filesystem Storage class
 	 */
-	public function testDirectoryTree()
+	public function testDirectoryTree(): void
 	{
 		$instance = $this->getInstance();
 

--- a/tests/src/Core/Storage/Repository/StorageManagerTest.php
+++ b/tests/src/Core/Storage/Repository/StorageManagerTest.php
@@ -83,7 +83,7 @@ class StorageManagerTest extends DatabaseTestCase
 	/**
 	 * Test plain instancing first
 	 */
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$storageManager = new StorageManager(
 			$this->database,
@@ -142,7 +142,7 @@ class StorageManagerTest extends DatabaseTestCase
 	 * Test the getByName() method
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataStorages')]
-	public function testGetByName($name, $valid, $interface, $assert, $assertName)
+	public function testGetByName($name, $valid, $interface, $assert, $assertName): void
 	{
 		if (!$valid) {
 			$this->expectException(InvalidClassStorageException::class);
@@ -176,7 +176,7 @@ class StorageManagerTest extends DatabaseTestCase
 	 * Test the isValidBackend() method
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataStorages')]
-	public function testIsValidBackend($name, $valid, $interface, $assert, $assertName)
+	public function testIsValidBackend($name, $valid, $interface, $assert, $assertName): void
 	{
 		$storageManager = new StorageManager(
 			$this->database,
@@ -197,7 +197,7 @@ class StorageManagerTest extends DatabaseTestCase
 	/**
 	 * Test the method listBackends() with default setting
 	 */
-	public function testListBackends()
+	public function testListBackends(): void
 	{
 		$storageManager = new StorageManager(
 			$this->database,
@@ -215,7 +215,7 @@ class StorageManagerTest extends DatabaseTestCase
 	 * Test the method getBackend()
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataStorages')]
-	public function testGetBackend($name, $valid, $interface, $assert, $assertName)
+	public function testGetBackend($name, $valid, $interface, $assert, $assertName): void
 	{
 		if ($interface !== ICanWriteToStorage::class) {
 			static::markTestSkipped('only works for ICanWriteToStorage');
@@ -240,7 +240,7 @@ class StorageManagerTest extends DatabaseTestCase
 	 * Test the method getBackend() with a pre-configured backend
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataStorages')]
-	public function testPresetBackend($name, $valid, $interface, $assert, $assertName)
+	public function testPresetBackend($name, $valid, $interface, $assert, $assertName): void
 	{
 		$this->config->set('storage', 'name', $name);
 		if ($interface !== ICanWriteToStorage::class) {
@@ -266,7 +266,7 @@ class StorageManagerTest extends DatabaseTestCase
 	 *
 	 * @see SampleStorageBackend
 	 */
-	public function testRegisterUnregisterBackends()
+	public function testRegisterUnregisterBackends(): void
 	{
 		/// @todo Remove dice once "Hook" is dynamic and mockable
 		$dice = (new Dice())
@@ -301,7 +301,7 @@ class StorageManagerTest extends DatabaseTestCase
 	/**
 	 * tests that an active backend cannot get unregistered
 	 */
-	public function testUnregisterActiveBackend()
+	public function testUnregisterActiveBackend(): void
 	{
 		/// @todo Remove dice once "Hook" is dynamic and mockable
 		$dice = (new Dice())
@@ -354,7 +354,7 @@ class StorageManagerTest extends DatabaseTestCase
 	 * Test moving data to a new storage (currently testing db & filesystem)
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataStorages')]
-	public function testMoveStorage($name, $valid, $interface, $assert, $assertName)
+	public function testMoveStorage($name, $valid, $interface, $assert, $assertName): void
 	{
 		if ($interface !== ICanWriteToStorage::class) {
 			self::markTestSkipped("No user backend");
@@ -388,7 +388,7 @@ class StorageManagerTest extends DatabaseTestCase
 	/**
 	 * Test moving data to a WRONG storage
 	 */
-	public function testWrongWritableStorage()
+	public function testWrongWritableStorage(): void
 	{
 		$this->expectException(InvalidClassStorageException::class);
 		$this->expectExceptionMessage('Backend SystemResource is not valid');

--- a/tests/src/Core/SystemTest.php
+++ b/tests/src/Core/SystemTest.php
@@ -31,28 +31,28 @@ class SystemTest extends TestCase
 		self::assertMatchesRegularExpression("/^" . $prefix . "[a-z0-9]{" . $length . "}?$/", $guid);
 	}
 
-	public function testGuidWithoutParameter()
+	public function testGuidWithoutParameter(): void
 	{
 		$this->useBaseUrl();
 		$guid = System::createGUID();
 		self::assertGuid($guid, 16);
 	}
 
-	public function testGuidWithSize32()
+	public function testGuidWithSize32(): void
 	{
 		$this->useBaseUrl();
 		$guid = System::createGUID(32);
 		self::assertGuid($guid, 32);
 	}
 
-	public function testGuidWithSize64()
+	public function testGuidWithSize64(): void
 	{
 		$this->useBaseUrl();
 		$guid = System::createGUID(64);
 		self::assertGuid($guid, 64);
 	}
 
-	public function testGuidWithPrefix()
+	public function testGuidWithPrefix(): void
 	{
 		$guid = System::createGUID(23, 'test');
 		self::assertGuid($guid, 23, 'test');

--- a/tests/src/Core/Worker/Repository/ProcessTest.php
+++ b/tests/src/Core/Worker/Repository/ProcessTest.php
@@ -15,7 +15,7 @@ use Psr\Log\NullLogger;
 
 class ProcessTest extends FixtureTestCase
 {
-	public function testStandardProcess()
+	public function testStandardProcess(): void
 	{
 		$factory    = new Factory\Process(new NullLogger());
 		$repository = new Repository\Process(DI::dba(), new NullLogger(), $factory, []);
@@ -28,7 +28,7 @@ class ProcessTest extends FixtureTestCase
 		self::assertEquals(php_uname('n'), $entityNew->hostname);
 	}
 
-	public function testHostnameEnv()
+	public function testHostnameEnv(): void
 	{
 		$factory    = new Factory\Process(new NullLogger());
 		$repository = new Repository\Process(DI::dba(), new NullLogger(), $factory, [Repository\Process::NODE_ENV => 'test_node']);

--- a/tests/src/Database/DBATest.php
+++ b/tests/src/Database/DBATest.php
@@ -33,7 +33,7 @@ class DBATest extends DatabaseTestCase
 		DI::config()->set('system', 'theme', 'system_theme');
 	}
 
-	public function testExists()
+	public function testExists(): void
 	{
 		self::assertTrue(DBA::exists('user', []));
 		self::assertFalse(DBA::exists('notable', []));

--- a/tests/src/Database/DBStructureTest.php
+++ b/tests/src/Database/DBStructureTest.php
@@ -26,7 +26,7 @@ class DBStructureTest extends DatabaseTestCase
 		DI::init($dice);
 	}
 
-	public function testExists()
+	public function testExists(): void
 	{
 		self::assertTrue(DBStructure::existsTable('user'));
 		self::assertFalse(DBStructure::existsTable('nonexistent'));
@@ -36,7 +36,7 @@ class DBStructureTest extends DatabaseTestCase
 		self::assertFalse(DBStructure::existsColumn('user', ['uid', 'nonsense']));
 	}
 
-	public function testRename()
+	public function testRename(): void
 	{
 		$fromColumn = 'email';
 		$toColumn   = 'email_key';

--- a/tests/src/Database/DatabaseTest.php
+++ b/tests/src/Database/DatabaseTest.php
@@ -36,7 +36,7 @@ class DatabaseTest extends FixtureTestCase
 			$this->root->url(),
 			$this->root->url() . '/addon',
 			$this->root->url() . '/config',
-			$this->root->url() . '/static'
+			$this->root->url() . '/static',
 		);
 	}
 
@@ -64,24 +64,24 @@ class DatabaseTest extends FixtureTestCase
 		self::assertTrue($db->update('gserver', [
 			'site_name' => 'test', "`registered-users` = `registered-users` + 1",
 			'info'      => 'another test',
-			"`active-week-users` = `active-week-users` + 2"
+			"`active-week-users` = `active-week-users` + 2",
 		], [
-			'nurl' => 'http://friendica.local'
+			'nurl' => 'http://friendica.local',
 		]));
 		self::assertEquals(1, $db->selectFirst('gserver', ['registered-users'], ['nurl' => 'http://friendica.local'])['registered-users']);
 		self::assertEquals(2, $db->selectFirst('gserver', ['active-week-users'], ['nurl' => 'http://friendica.local'])['active-week-users']);
 		self::assertTrue($db->update('gserver', [
 			'site_name' => 'test', "`registered-users` = `registered-users` + 1",
-			'info'      => 'another test'
+			'info'      => 'another test',
 		], [
-			'nurl' => 'http://friendica.local'
+			'nurl' => 'http://friendica.local',
 		]));
 		self::assertEquals(2, $db->selectFirst('gserver', ['registered-users'], ['nurl' => 'http://friendica.local'])['registered-users']);
 		self::assertTrue($db->update('gserver', [
 			'site_name' => 'test', "`registered-users` = `registered-users` - 1",
-			'info'      => 'another test'
+			'info'      => 'another test',
 		], [
-			'nurl' => 'http://friendica.local'
+			'nurl' => 'http://friendica.local',
 		]));
 		self::assertEquals(1, $db->selectFirst('gserver', ['registered-users'], ['nurl' => 'http://friendica.local'])['registered-users']);
 	}

--- a/tests/src/Database/DatabaseTest.php
+++ b/tests/src/Database/DatabaseTest.php
@@ -43,7 +43,7 @@ class DatabaseTest extends FixtureTestCase
 	/**
 	 * Test, if directly updating a field is possible
 	 */
-	public function testUpdateIncrease()
+	public function testUpdateIncrease(): void
 	{
 		$db = $this->getDbInstance();
 
@@ -55,7 +55,7 @@ class DatabaseTest extends FixtureTestCase
 	/**
 	 * Test if combining directly field updates with normal updates is working
 	 */
-	public function testUpdateWithField()
+	public function testUpdateWithField(): void
 	{
 		$db = $this->getDbInstance();
 
@@ -86,7 +86,7 @@ class DatabaseTest extends FixtureTestCase
 		self::assertEquals(1, $db->selectFirst('gserver', ['registered-users'], ['nurl' => 'http://friendica.local'])['registered-users']);
 	}
 
-	public function testUpdateWithArray()
+	public function testUpdateWithArray(): void
 	{
 		$db = $this->getDbInstance();
 

--- a/tests/src/Factory/Api/Mastodon/EmojiTest.php
+++ b/tests/src/Factory/Api/Mastodon/EmojiTest.php
@@ -20,7 +20,7 @@ class EmojiTest extends FixtureTestCase
 		DI::config()->set('system', 'no_smilies', false);
 	}
 
-	public function testBuiltInCollection()
+	public function testBuiltInCollection(): void
 	{
 		$emoji      = DI::mstdnEmoji();
 		$collection = $emoji->createCollectionFromSmilies(Smilies::getList())->getArrayCopy(true);

--- a/tests/src/Factory/Api/Twitter/ActivitiesTest.php
+++ b/tests/src/Factory/Api/Twitter/ActivitiesTest.php
@@ -18,7 +18,7 @@ class ActivitiesTest extends FixtureTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFormatItemsActivities()
+	public function testApiFormatItemsActivities(): void
 	{
 		$item = ['uid' => 0, 'uri-id' => 1];
 
@@ -37,7 +37,7 @@ class ActivitiesTest extends FixtureTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFormatItemsActivitiesWithXml()
+	public function testApiFormatItemsActivitiesWithXml(): void
 	{
 		$item = ['uid' => 0, 'uri-id' => 1];
 

--- a/tests/src/Factory/Api/Twitter/DirectMessageTest.php
+++ b/tests/src/Factory/Api/Twitter/DirectMessageTest.php
@@ -19,7 +19,7 @@ class DirectMessageTest extends FixtureTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFormatMessages()
+	public function testApiFormatMessages(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../Fixtures/mail/mail.fixture.php', DI::dba());
 		$ids = DI::dba()->selectToArray('mail', ['id']);
@@ -42,7 +42,7 @@ class DirectMessageTest extends FixtureTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFormatMessagesWithHtmlText()
+	public function testApiFormatMessagesWithHtmlText(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../Fixtures/mail/mail.fixture.php', DI::dba());
 		$ids = DI::dba()->selectToArray('mail', ['id']);
@@ -61,7 +61,7 @@ class DirectMessageTest extends FixtureTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFormatMessagesWithPlainText()
+	public function testApiFormatMessagesWithPlainText(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../Fixtures/mail/mail.fixture.php', DI::dba());
 		$ids = DI::dba()->selectToArray('mail', ['id']);

--- a/tests/src/Factory/Api/Twitter/StatusTest.php
+++ b/tests/src/Factory/Api/Twitter/StatusTest.php
@@ -45,7 +45,7 @@ class StatusTest extends FixtureTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiConvertItem()
+	public function testApiConvertItem(): void
 	{
 		$status = $this->statusFactory
 			->createFromItemId(13, ApiTestCase::SELF_USER['id'])
@@ -106,7 +106,7 @@ class StatusTest extends FixtureTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiGetEntitiesWithIncludeEntities()
+	public function testApiGetEntitiesWithIncludeEntities(): void
 	{
 		$status = $this->statusFactory
 			->createFromItemId(13, ApiTestCase::SELF_USER['id'], true)
@@ -123,7 +123,7 @@ class StatusTest extends FixtureTestCase
 	/**
 	 * Test the api_format_items() function.
 	 */
-	public function testApiFormatItems()
+	public function testApiFormatItems(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);

--- a/tests/src/Factory/Api/Twitter/UserTest.php
+++ b/tests/src/Factory/Api/Twitter/UserTest.php
@@ -35,7 +35,7 @@ class UserTest extends FixtureTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiGetUser()
+	public function testApiGetUser(): void
 	{
 		$user = (new User(DI::logger(), DI::twitterStatus()))
 			->createFromUserId(ApiTestCase::SELF_USER['id'])
@@ -118,7 +118,7 @@ class UserTest extends FixtureTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiGetUserWithWrongGetId()
+	public function testApiGetUserWithWrongGetId(): void
 	{
 		$this->expectException(NotFoundException::class);
 

--- a/tests/src/Model/GServerTest.php
+++ b/tests/src/Model/GServerTest.php
@@ -55,7 +55,7 @@ class GServerTest extends \PHPUnit\Framework\TestCase
 	 * @throws \Exception
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCleanUri')]
-	public function testCleanUri(UriInterface $expected, UriInterface $dirtyUri)
+	public function testCleanUri(UriInterface $expected, UriInterface $dirtyUri): void
 	{
 		$this->assertEquals($expected, GServer::cleanUri($dirtyUri));
 	}

--- a/tests/src/Model/User/CookieTest.php
+++ b/tests/src/Model/User/CookieTest.php
@@ -44,7 +44,7 @@ class CookieTest extends MockedTestCase
 	/**
 	 * Test if we can create a basic cookie instance
 	 */
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$this->baseUrl->shouldReceive('getScheme')->andReturn('https')->once();
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn('1235')->once();
@@ -110,7 +110,7 @@ class CookieTest extends MockedTestCase
 	 * Test the get() method of the cookie class
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGet')]
-	public function testGet(array $cookieData, bool $hasValues, $uid, $hash, $ip)
+	public function testGet(array $cookieData, bool $hasValues, $uid, $hash, $ip): void
 	{
 		$this->baseUrl->shouldReceive('getScheme')->andReturn('https')->once();
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn('1235')->once();
@@ -170,7 +170,7 @@ class CookieTest extends MockedTestCase
 	 * Test the check() method of the cookie class
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCheck')]
-	public function testCheck(string $serverPrivateKey, string $userPrivateKey, string $password, string $assertHash, bool $assertTrue)
+	public function testCheck(string $serverPrivateKey, string $userPrivateKey, string $password, string $assertHash, bool $assertTrue): void
 	{
 		$this->baseUrl->shouldReceive('getScheme')->andReturn('https')->once();
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn($serverPrivateKey)->once();
@@ -230,7 +230,7 @@ class CookieTest extends MockedTestCase
 	 * Test the set() method of the cookie class
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSet')]
-	public function testSet($serverKey, $uid, $password, $privateKey, $assertHash, $remoteIp, $serverArray)
+	public function testSet($serverKey, $uid, $password, $privateKey, $assertHash, $remoteIp, $serverArray): void
 	{
 		$this->baseUrl->shouldReceive('getScheme')->andReturn('https')->once();
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn($serverKey)->once();
@@ -256,7 +256,7 @@ class CookieTest extends MockedTestCase
 	 * Test the set() method of the cookie class
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSet')]
-	public function testDoubleSet($serverKey, $uid, $password, $privateKey, $assertHash, $remoteIp, $serverArray)
+	public function testDoubleSet($serverKey, $uid, $password, $privateKey, $assertHash, $remoteIp, $serverArray): void
 	{
 		$this->baseUrl->shouldReceive('getScheme')->andReturn('https')->once();
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn($serverKey)->once();
@@ -278,7 +278,7 @@ class CookieTest extends MockedTestCase
 	/**
 	 * Test the clear() method of the cookie class
 	 */
-	public function testClear()
+	public function testClear(): void
 	{
 		StaticCookie::$_COOKIE = [
 			Cookie::NAME => 'test',

--- a/tests/src/Model/UserTest.php
+++ b/tests/src/Model/UserTest.php
@@ -36,28 +36,32 @@ class UserTest extends MockedTestCase
 		DI::init($diceMock, true);
 
 		$this->parent = [
-			'uid'             => 1,
-			'username'        => 'maxmuster',
-			'nickname'        => 'Max Muster',
+			'uid'      => 1,
+			'username' => 'maxmuster',
+			'nickname' => 'Max Muster',
 		];
 
 		$this->child = [
-			'uid'             => 2,
-			'username'        => 'johndoe',
-			'nickname'        => 'John Doe',
+			'uid'      => 2,
+			'username' => 'johndoe',
+			'nickname' => 'John Doe',
 		];
 
 		$this->manage = [
-			'uid'             => 3,
-			'username'        => 'janesmith',
-			'nickname'        => 'Jane Smith',
+			'uid'      => 3,
+			'username' => 'janesmith',
+			'nickname' => 'Jane Smith',
 		];
 	}
 
 	public function testIdentitiesEmpty(): void
 	{
-		$this->dbMock->shouldReceive('selectFirst')->with('user',
-			['uid', 'nickname', 'username', 'parent-uid'],['uid' => $this->parent['uid'], 'verified' => true, 'blocked' => false, 'account_removed' => false, 'account_expired' => false], [])->andReturn($this->parent)->once();
+		$this->dbMock->shouldReceive('selectFirst')->with(
+			'user',
+			['uid', 'nickname', 'username', 'parent-uid'],
+			['uid' => $this->parent['uid'], 'verified' => true, 'blocked' => false, 'account_removed' => false, 'account_expired' => false],
+			[],
+		)->andReturn($this->parent)->once();
 		$this->dbMock->shouldReceive('isResult')->with($this->parent)->andReturn(false)->once();
 
 		$record = User::identities($this->parent['uid']);
@@ -71,20 +75,27 @@ class UserTest extends MockedTestCase
 		$parentSelect['parent-uid'] = null;
 
 		// Select the user itself (=parent)
-		$this->dbMock->shouldReceive('selectFirst')->with('user',
-			['uid', 'nickname', 'username', 'parent-uid'],['uid' => $this->parent['uid'], 'verified' => true, 'blocked' => false, 'account_removed' => false, 'account_expired' => false], [])->andReturn($parentSelect)->once();
+		$this->dbMock->shouldReceive('selectFirst')->with(
+			'user',
+			['uid', 'nickname', 'username', 'parent-uid'],
+			['uid' => $this->parent['uid'], 'verified' => true, 'blocked' => false, 'account_removed' => false, 'account_expired' => false],
+			[],
+		)->andReturn($parentSelect)->once();
 		$this->dbMock->shouldReceive('isResult')->with($parentSelect)->andReturn(true)->once();
 
 		// Select one child
-		$this->dbMock->shouldReceive('select')->with('user',
+		$this->dbMock->shouldReceive('select')->with(
+			'user',
 			['uid', 'username', 'nickname'],
 			[
 				'parent-uid'      => $this->parent['uid'],
 				'verified'        => true,
 				'blocked'         => false,
 				'account_removed' => false,
-				'account_expired' => false
-			], [])->andReturn('objectReturn')->once();
+				'account_expired' => false,
+			],
+			[],
+		)->andReturn('objectReturn')->once();
 		$this->dbMock->shouldReceive('isResult')->with('objectReturn')->andReturn(true)->once();
 		$this->dbMock->shouldReceive('toArray')->with('objectReturn', true, 0)->andReturn([$this->child])->once();
 
@@ -98,7 +109,7 @@ class UserTest extends MockedTestCase
 		self::assertEquals([
 			$this->parent,
 			$this->child,
-			$this->manage
+			$this->manage,
 		], $record, 'testIdentitiesAsParent: ' . print_r($record, true));
 	}
 
@@ -108,33 +119,43 @@ class UserTest extends MockedTestCase
 		$childSelect['parent-uid'] = $this->parent['uid'];
 
 		// Select the user itself (=child)
-		$this->dbMock->shouldReceive('selectFirst')->with('user',
-			['uid', 'nickname', 'username', 'parent-uid'],['uid' => $this->child['uid'], 'verified' => true, 'blocked' => false, 'account_removed' => false, 'account_expired' => false], [])->andReturn($childSelect)->once();
+		$this->dbMock->shouldReceive('selectFirst')->with(
+			'user',
+			['uid', 'nickname', 'username', 'parent-uid'],
+			['uid' => $this->child['uid'], 'verified' => true, 'blocked' => false, 'account_removed' => false, 'account_expired' => false],
+			[],
+		)->andReturn($childSelect)->once();
 		$this->dbMock->shouldReceive('isResult')->with($childSelect)->andReturn(true)->once();
 
 		// Select the parent
-		$this->dbMock->shouldReceive('select')->with('user',
+		$this->dbMock->shouldReceive('select')->with(
+			'user',
 			['uid', 'username', 'nickname'],
 			[
 				'uid'             => $this->parent['uid'],
 				'verified'        => true,
 				'blocked'         => false,
 				'account_removed' => false,
-				'account_expired' => false
-			], [])->andReturn('objectReturn')->once();
+				'account_expired' => false,
+			],
+			[],
+		)->andReturn('objectReturn')->once();
 		$this->dbMock->shouldReceive('isResult')->with('objectReturn')->andReturn(true)->once();
 		$this->dbMock->shouldReceive('toArray')->with('objectReturn', true, 0)->andReturn([$this->parent])->once();
 
 		// Select the children (user & manage)
-		$this->dbMock->shouldReceive('select')->with('user',
+		$this->dbMock->shouldReceive('select')->with(
+			'user',
 			['uid', 'username', 'nickname'],
 			[
 				'parent-uid'      => $this->parent['uid'],
 				'verified'        => true,
 				'blocked'         => false,
 				'account_removed' => false,
-				'account_expired' => false
-			], [])->andReturn('objectReturn')->once();
+				'account_expired' => false,
+			],
+			[],
+		)->andReturn('objectReturn')->once();
 		$this->dbMock->shouldReceive('isResult')->with('objectReturn')->andReturn(true)->once();
 		$this->dbMock->shouldReceive('toArray')->with('objectReturn', true, 0)->andReturn([$this->child, $this->manage])->once();
 
@@ -147,7 +168,7 @@ class UserTest extends MockedTestCase
 		self::assertEquals([
 			$this->parent,
 			$this->child,
-			$this->manage
+			$this->manage,
 		], $record);
 	}
 }

--- a/tests/src/Model/UserTest.php
+++ b/tests/src/Model/UserTest.php
@@ -54,7 +54,7 @@ class UserTest extends MockedTestCase
 		];
 	}
 
-	public function testIdentitiesEmpty()
+	public function testIdentitiesEmpty(): void
 	{
 		$this->dbMock->shouldReceive('selectFirst')->with('user',
 			['uid', 'nickname', 'username', 'parent-uid'],['uid' => $this->parent['uid'], 'verified' => true, 'blocked' => false, 'account_removed' => false, 'account_expired' => false], [])->andReturn($this->parent)->once();
@@ -65,7 +65,7 @@ class UserTest extends MockedTestCase
 		self::assertEquals([], $record);
 	}
 
-	public function testIdentitiesAsParent()
+	public function testIdentitiesAsParent(): void
 	{
 		$parentSelect               = $this->parent;
 		$parentSelect['parent-uid'] = null;
@@ -102,7 +102,7 @@ class UserTest extends MockedTestCase
 		], $record, 'testIdentitiesAsParent: ' . print_r($record, true));
 	}
 
-	public function testIdentitiesAsChild()
+	public function testIdentitiesAsChild(): void
 	{
 		$childSelect               = $this->child;
 		$childSelect['parent-uid'] = $this->parent['uid'];

--- a/tests/src/Moderation/Factory/ReportTest.php
+++ b/tests/src/Moderation/Factory/ReportTest.php
@@ -132,7 +132,7 @@ class ReportTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCreateFromTableRow')]
-	public function testCreateFromTableRow(ClockInterface $clock, array $row, Collection\Report\Posts $posts, Collection\Report\Rules $rules, Entity\Report $assertion)
+	public function testCreateFromTableRow(ClockInterface $clock, array $row, Collection\Report\Posts $posts, Collection\Report\Rules $rules, Entity\Report $assertion): void
 	{
 		$factory = new Factory\Report(new NullLogger(), $clock);
 
@@ -247,7 +247,7 @@ class ReportTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCreateFromReportsRequest')]
-	public function testCreateFromReportsRequest(ClockInterface $clock, array $rules, int $reporterId, int $cid, int $gsid, string $comment, string $category, bool $forward, array $postUriIds, array $ruleIds, ?int $uid, Entity\Report $assertion)
+	public function testCreateFromReportsRequest(ClockInterface $clock, array $rules, int $reporterId, int $cid, int $gsid, string $comment, string $category, bool $forward, array $postUriIds, array $ruleIds, ?int $uid, Entity\Report $assertion): void
 	{
 		$factory = new Factory\Report(new NullLogger(), $clock);
 

--- a/tests/src/Module/Api/ApiResponseTest.php
+++ b/tests/src/Module/Api/ApiResponseTest.php
@@ -17,7 +17,7 @@ use Psr\Log\NullLogger;
 
 class ApiResponseTest extends MockedTestCase
 {
-	public function testErrorWithJson()
+	public function testErrorWithJson(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$args = \Mockery::mock(Arguments::class);
@@ -31,7 +31,7 @@ class ApiResponseTest extends MockedTestCase
 		self::assertEquals('{"error":"error_message","code":"200 OK","request":""}', $response->getContent());
 	}
 
-	public function testErrorWithXml()
+	public function testErrorWithXml(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$args = \Mockery::mock(Arguments::class);
@@ -56,7 +56,7 @@ class ApiResponseTest extends MockedTestCase
 		);
 	}
 
-	public function testErrorWithRss()
+	public function testErrorWithRss(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$args = \Mockery::mock(Arguments::class);
@@ -81,7 +81,7 @@ class ApiResponseTest extends MockedTestCase
 		);
 	}
 
-	public function testErrorWithAtom()
+	public function testErrorWithAtom(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$args = \Mockery::mock(Arguments::class);
@@ -106,7 +106,7 @@ class ApiResponseTest extends MockedTestCase
 		);
 	}
 
-	public function testUnsupported()
+	public function testUnsupported(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$l10n->shouldReceive('t')->andReturnUsing(function ($args) {
@@ -126,7 +126,7 @@ class ApiResponseTest extends MockedTestCase
 		self::assertEquals('{"error":"API endpoint %s %s is not implemented but might be in the future.","code":"501 Not Implemented","request":""}', $response->getContent());
 	}
 
-	public function testUnsupportedUserAgent()
+	public function testUnsupportedUserAgent(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$l10n->shouldReceive('t')->andReturnUsing(function ($args) {
@@ -151,7 +151,7 @@ class ApiResponseTest extends MockedTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiReformatXml()
+	public function testApiReformatXml(): void
 	{
 		$item = true;
 		$key  = '';
@@ -164,7 +164,7 @@ class ApiResponseTest extends MockedTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiReformatXmlWithStatusnetKey()
+	public function testApiReformatXmlWithStatusnetKey(): void
 	{
 		$item = '';
 		$key  = 'statusnet_api';
@@ -177,7 +177,7 @@ class ApiResponseTest extends MockedTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiReformatXmlWithFriendicaKey()
+	public function testApiReformatXmlWithFriendicaKey(): void
 	{
 		$item = '';
 		$key  = 'friendica_api';
@@ -190,7 +190,7 @@ class ApiResponseTest extends MockedTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiCreateXml()
+	public function testApiCreateXml(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$l10n->shouldReceive('t')->andReturnUsing(function ($args) {
@@ -219,7 +219,7 @@ class ApiResponseTest extends MockedTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiCreateXmlWithoutNamespaces()
+	public function testApiCreateXmlWithoutNamespaces(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$l10n->shouldReceive('t')->andReturnUsing(function ($args) {
@@ -246,7 +246,7 @@ class ApiResponseTest extends MockedTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFormatData()
+	public function testApiFormatData(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$l10n->shouldReceive('t')->andReturnUsing(function ($args) {
@@ -263,7 +263,7 @@ class ApiResponseTest extends MockedTestCase
 		self::assertEquals($data, $response->formatData('root_element', 'json', $data));
 	}
 
-	public function testApiExitWithJson()
+	public function testApiExitWithJson(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$l10n->shouldReceive('t')->andReturnUsing(function ($args) {
@@ -280,7 +280,7 @@ class ApiResponseTest extends MockedTestCase
 		self::assertEquals('["some_data"]', $response->getContent());
 	}
 
-	public function testApiExitWithJsonP()
+	public function testApiExitWithJsonP(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$l10n->shouldReceive('t')->andReturnUsing(function ($args) {
@@ -302,7 +302,7 @@ class ApiResponseTest extends MockedTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFormatDataWithXml()
+	public function testApiFormatDataWithXml(): void
 	{
 		$l10n = \Mockery::mock(L10n::class);
 		$l10n->shouldReceive('t')->andReturnUsing(function ($args) {

--- a/tests/src/Module/Api/Friendica/DirectMessages/SearchTest.php
+++ b/tests/src/Module/Api/Friendica/DirectMessages/SearchTest.php
@@ -15,7 +15,7 @@ use Psr\Log\NullLogger;
 
 class SearchTest extends ApiTestCase
 {
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$directMessage = new DirectMessage(new NullLogger(), DI::dba(), DI::twitterUser());
 
@@ -31,7 +31,7 @@ class SearchTest extends ApiTestCase
 		self::assertEquals($assert, $json);
 	}
 
-	public function testMail()
+	public function testMail(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/mail/mail.fixture.php', DI::dba());
 
@@ -54,7 +54,7 @@ class SearchTest extends ApiTestCase
 		}
 	}
 
-	public function testNothingFound()
+	public function testNothingFound(): void
 	{
 		$directMessage = new DirectMessage(new NullLogger(), DI::dba(), DI::twitterUser());
 

--- a/tests/src/Module/Api/Friendica/NotificationTest.php
+++ b/tests/src/Module/Api/Friendica/NotificationTest.php
@@ -40,7 +40,7 @@ class NotificationTest extends ApiTestCase
 		*/
 	}
 
-	public function testWithXmlResult()
+	public function testWithXmlResult(): void
 	{
 		$date    = DateTimeFormat::local('2020-01-01 12:12:02');
 		$dateRel = Temporal::getRelativeDate('2020-01-01 12:12:02');
@@ -62,7 +62,7 @@ XML;
 		], $response->getHeaders());
 	}
 
-	public function testWithJsonResult()
+	public function testWithJsonResult(): void
 	{
 		$response = (new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Api/Friendica/Photo/DeleteTest.php
+++ b/tests/src/Module/Api/Friendica/Photo/DeleteTest.php
@@ -22,7 +22,7 @@ class DeleteTest extends ApiTestCase
 		$this->useHttpMethod(Router::POST);
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$this->expectException(BadRequestException::class);
 		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock);
@@ -33,13 +33,13 @@ class DeleteTest extends ApiTestCase
 		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
 	}
 
-	public function testWrong()
+	public function testWrong(): void
 	{
 		$this->expectException(BadRequestException::class);
 		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock, ['photo_id' => 1]);
 	}
 
-	public function testValidWithPost()
+	public function testValidWithPost(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
 
@@ -54,7 +54,7 @@ class DeleteTest extends ApiTestCase
 		self::assertEquals('photo with id `709057080661a283a6aa598501504178` has been deleted from server.', $json->message);
 	}
 
-	public function testValidWithDelete()
+	public function testValidWithDelete(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
 

--- a/tests/src/Module/Api/Friendica/Photoalbum/DeleteTest.php
+++ b/tests/src/Module/Api/Friendica/Photoalbum/DeleteTest.php
@@ -22,7 +22,7 @@ class DeleteTest extends ApiTestCase
 		$this->useHttpMethod(Router::POST);
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$this->expectException(BadRequestException::class);
 		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
@@ -30,7 +30,7 @@ class DeleteTest extends ApiTestCase
 
 	}
 
-	public function testWrong()
+	public function testWrong(): void
 	{
 		$this->expectException(BadRequestException::class);
 		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
@@ -39,7 +39,7 @@ class DeleteTest extends ApiTestCase
 			]);
 	}
 
-	public function testValidWithDelete()
+	public function testValidWithDelete(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
 

--- a/tests/src/Module/Api/Friendica/Photoalbum/UpdateTest.php
+++ b/tests/src/Module/Api/Friendica/Photoalbum/UpdateTest.php
@@ -22,14 +22,14 @@ class UpdateTest extends ApiTestCase
 		$this->useHttpMethod(Router::POST);
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$this->expectException(BadRequestException::class);
 		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
 
-	public function testTooFewArgs()
+	public function testTooFewArgs(): void
 	{
 		$this->expectException(BadRequestException::class);
 		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
@@ -38,7 +38,7 @@ class UpdateTest extends ApiTestCase
 			]);
 	}
 
-	public function testWrongUpdate()
+	public function testWrongUpdate(): void
 	{
 		$this->expectException(BadRequestException::class);
 		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
@@ -53,7 +53,7 @@ class UpdateTest extends ApiTestCase
 		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
 	}
 
-	public function testValid()
+	public function testValid(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
 

--- a/tests/src/Module/Api/GnuSocial/GnuSocial/ConfigTest.php
+++ b/tests/src/Module/Api/GnuSocial/GnuSocial/ConfigTest.php
@@ -16,7 +16,7 @@ class ConfigTest extends ApiTestCase
 	/**
 	 * Test the api_statusnet_config() function.
 	 */
-	public function testApiStatusnetConfig()
+	public function testApiStatusnetConfig(): void
 	{
 		$response = (new Config(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Api/GnuSocial/GnuSocial/VersionTest.php
+++ b/tests/src/Module/Api/GnuSocial/GnuSocial/VersionTest.php
@@ -14,7 +14,7 @@ use Friendica\Test\ApiTestCase;
 
 class VersionTest extends ApiTestCase
 {
-	public function test()
+	public function test(): void
 	{
 		$response = (new Version(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Api/GnuSocial/GnuSocial/VersionTest.php
+++ b/tests/src/Module/Api/GnuSocial/GnuSocial/VersionTest.php
@@ -21,7 +21,7 @@ class VersionTest extends ApiTestCase
 
 		self::assertEquals([
 			'Content-type'                => ['application/json'],
-			ICanCreateResponses::X_HEADER => ['json']
+			ICanCreateResponses::X_HEADER => ['json'],
 		], $response->getHeaders());
 		self::assertEquals('"0.9.7"', $response->getBody());
 	}

--- a/tests/src/Module/Api/GnuSocial/Help/TestTest.php
+++ b/tests/src/Module/Api/GnuSocial/Help/TestTest.php
@@ -23,7 +23,7 @@ class TestTest extends ApiTestCase
 
 		self::assertEquals([
 			'Content-type'                => ['application/json'],
-			ICanCreateResponses::X_HEADER => ['json']
+			ICanCreateResponses::X_HEADER => ['json'],
 		], $response->getHeaders());
 		self::assertEquals('ok', $json);
 	}
@@ -35,7 +35,7 @@ class TestTest extends ApiTestCase
 
 		self::assertEquals([
 			'Content-type'                => ['text/xml'],
-			ICanCreateResponses::X_HEADER => ['xml']
+			ICanCreateResponses::X_HEADER => ['xml'],
 		], $response->getHeaders());
 		self::assertXml($response->getBody(), 'ok');
 	}

--- a/tests/src/Module/Api/GnuSocial/Help/TestTest.php
+++ b/tests/src/Module/Api/GnuSocial/Help/TestTest.php
@@ -14,7 +14,7 @@ use Friendica\Test\ApiTestCase;
 
 class TestTest extends ApiTestCase
 {
-	public function testJson()
+	public function testJson(): void
 	{
 		$response = (new Test(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
@@ -28,7 +28,7 @@ class TestTest extends ApiTestCase
 		self::assertEquals('ok', $json);
 	}
 
-	public function testXml()
+	public function testXml(): void
 	{
 		$response = (new Test(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Api/Mastodon/Accounts/VerifyCredentialsTest.php
+++ b/tests/src/Module/Api/Mastodon/Accounts/VerifyCredentialsTest.php
@@ -18,7 +18,7 @@ class VerifyCredentialsTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiAccountVerifyCredentials()
+	public function testApiAccountVerifyCredentials(): void
 	{
 		$response = (new VerifyCredentials(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Api/Twitter/Account/RateLimitStatusTest.php
+++ b/tests/src/Module/Api/Twitter/Account/RateLimitStatusTest.php
@@ -14,7 +14,7 @@ use Friendica\Test\ApiTestCase;
 
 class RateLimitStatusTest extends ApiTestCase
 {
-	public function testWithJson()
+	public function testWithJson(): void
 	{
 		$response = (new RateLimitStatus(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
@@ -30,7 +30,7 @@ class RateLimitStatusTest extends ApiTestCase
 		self::assertIsInt($result->reset_time_in_seconds);
 	}
 
-	public function testWithXml()
+	public function testWithXml(): void
 	{
 		$response = (new RateLimitStatus(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Api/Twitter/Account/RateLimitStatusTest.php
+++ b/tests/src/Module/Api/Twitter/Account/RateLimitStatusTest.php
@@ -23,7 +23,7 @@ class RateLimitStatusTest extends ApiTestCase
 
 		self::assertEquals([
 			'Content-type'                => ['application/json'],
-			ICanCreateResponses::X_HEADER => ['json']
+			ICanCreateResponses::X_HEADER => ['json'],
 		], $response->getHeaders());
 		self::assertEquals(150, $result->remaining_hits);
 		self::assertEquals(150, $result->hourly_limit);
@@ -37,7 +37,7 @@ class RateLimitStatusTest extends ApiTestCase
 
 		self::assertEquals([
 			'Content-type'                => ['text/xml'],
-			ICanCreateResponses::X_HEADER => ['xml']
+			ICanCreateResponses::X_HEADER => ['xml'],
 		], $response->getHeaders());
 		self::assertXml($response->getBody(), 'hash');
 	}

--- a/tests/src/Module/Api/Twitter/Account/UpdateProfileTest.php
+++ b/tests/src/Module/Api/Twitter/Account/UpdateProfileTest.php
@@ -24,7 +24,7 @@ class UpdateProfileTest extends ApiTestCase
 		$response = (new UpdateProfile(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'name'        => 'new_name',
-				'description' => 'new_description'
+				'description' => 'new_description',
 			]);
 
 		$json = $this->toJson($response);

--- a/tests/src/Module/Api/Twitter/Account/UpdateProfileTest.php
+++ b/tests/src/Module/Api/Twitter/Account/UpdateProfileTest.php
@@ -17,7 +17,7 @@ class UpdateProfileTest extends ApiTestCase
 	/**
 	 * Test the api_account_update_profile() function.
 	 */
-	public function testApiAccountUpdateProfile()
+	public function testApiAccountUpdateProfile(): void
 	{
 		$this->useHttpMethod(Router::POST);
 

--- a/tests/src/Module/Api/Twitter/Blocks/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Blocks/ListsTest.php
@@ -16,7 +16,7 @@ class ListsTest extends ApiTestCase
 	/**
 	 * Test the api_statuses_f() function.
 	 */
-	public function testApiStatusesFWithBlocks()
+	public function testApiStatusesFWithBlocks(): void
 	{
 		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Api/Twitter/DirectMessages/AllTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/AllTest.php
@@ -19,7 +19,7 @@ class AllTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesBoxWithAll()
+	public function testApiDirectMessagesBoxWithAll(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/mail/mail.fixture.php', DI::dba());
 

--- a/tests/src/Module/Api/Twitter/DirectMessages/ConversationTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/ConversationTest.php
@@ -19,7 +19,7 @@ class ConversationTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesBoxWithConversation()
+	public function testApiDirectMessagesBoxWithConversation(): void
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 

--- a/tests/src/Module/Api/Twitter/DirectMessages/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/DestroyTest.php
@@ -27,7 +27,7 @@ class DestroyTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesDestroy()
+	public function testApiDirectMessagesDestroy(): void
 	{
 		$this->expectException(\Friendica\Network\HTTPException\BadRequestException::class);
 
@@ -40,7 +40,7 @@ class DestroyTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesDestroyWithVerbose()
+	public function testApiDirectMessagesDestroyWithVerbose(): void
 	{
 		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
@@ -75,7 +75,7 @@ class DestroyTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesDestroyWithId()
+	public function testApiDirectMessagesDestroyWithId(): void
 	{
 		$this->expectException(\Friendica\Network\HTTPException\BadRequestException::class);
 		(new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
@@ -89,7 +89,7 @@ class DestroyTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesDestroyWithIdAndVerbose()
+	public function testApiDirectMessagesDestroyWithIdAndVerbose(): void
 	{
 		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
@@ -109,7 +109,7 @@ class DestroyTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesDestroyWithCorrectId()
+	public function testApiDirectMessagesDestroyWithCorrectId(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/mail/mail.fixture.php', DI::dba());
 		$ids = DBA::selectToArray('mail', ['id']);

--- a/tests/src/Module/Api/Twitter/DirectMessages/InboxTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/InboxTest.php
@@ -19,7 +19,7 @@ class InboxTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesBoxWithInbox()
+	public function testApiDirectMessagesBoxWithInbox(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/mail/mail.fixture.php', DI::dba());
 

--- a/tests/src/Module/Api/Twitter/DirectMessages/NewDMTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/NewDMTest.php
@@ -27,7 +27,7 @@ class NewDMTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesNew()
+	public function testApiDirectMessagesNew(): void
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
@@ -59,7 +59,7 @@ class NewDMTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesNewWithUserId()
+	public function testApiDirectMessagesNewWithUserId(): void
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
@@ -79,7 +79,7 @@ class NewDMTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesNewWithScreenName()
+	public function testApiDirectMessagesNewWithScreenName(): void
 	{
 		DI::session()->set('nickname', 'selfcontact');
 
@@ -103,7 +103,7 @@ class NewDMTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesNewWithTitle()
+	public function testApiDirectMessagesNewWithTitle(): void
 	{
 		DI::session()->set('nickname', 'selfcontact');
 
@@ -129,7 +129,7 @@ class NewDMTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesNewWithRss()
+	public function testApiDirectMessagesNewWithRss(): void
 	{
 		DI::session()->set('nickname', 'selfcontact');
 

--- a/tests/src/Module/Api/Twitter/DirectMessages/SentTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/SentTest.php
@@ -19,7 +19,7 @@ class SentTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesBoxWithVerbose()
+	public function testApiDirectMessagesBoxWithVerbose(): void
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
@@ -39,7 +39,7 @@ class SentTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDirectMessagesBoxWithRss()
+	public function testApiDirectMessagesBoxWithRss(): void
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 

--- a/tests/src/Module/Api/Twitter/Favorites/CreateTest.php
+++ b/tests/src/Module/Api/Twitter/Favorites/CreateTest.php
@@ -28,7 +28,7 @@ class CreateTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFavoritesCreateDestroyWithInvalidId()
+	public function testApiFavoritesCreateDestroyWithInvalidId(): void
 	{
 		$this->expectException(BadRequestException::class);
 
@@ -41,7 +41,7 @@ class CreateTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFavoritesCreateDestroyWithCreateAction()
+	public function testApiFavoritesCreateDestroyWithCreateAction(): void
 	{
 		$response = (new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
@@ -58,7 +58,7 @@ class CreateTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFavoritesCreateDestroyWithCreateActionAndRss()
+	public function testApiFavoritesCreateDestroyWithCreateActionAndRss(): void
 	{
 		$response = (new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]))
 			->run($this->httpExceptionMock, [

--- a/tests/src/Module/Api/Twitter/Favorites/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/Favorites/DestroyTest.php
@@ -27,7 +27,7 @@ class DestroyTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFavoritesCreateDestroyWithInvalidId()
+	public function testApiFavoritesCreateDestroyWithInvalidId(): void
 	{
 		$this->expectException(BadRequestException::class);
 
@@ -40,7 +40,7 @@ class DestroyTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFavoritesCreateDestroyWithDestroyAction()
+	public function testApiFavoritesCreateDestroyWithDestroyAction(): void
 	{
 		$response = (new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [

--- a/tests/src/Module/Api/Twitter/FavoritesTest.php
+++ b/tests/src/Module/Api/Twitter/FavoritesTest.php
@@ -20,7 +20,7 @@ class FavoritesTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFavorites()
+	public function testApiFavorites(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
@@ -43,7 +43,7 @@ class FavoritesTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFavoritesWithRss()
+	public function testApiFavoritesWithRss(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);

--- a/tests/src/Module/Api/Twitter/Followers/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Followers/ListsTest.php
@@ -16,7 +16,7 @@ class ListsTest extends ApiTestCase
 	/**
 	 * Test the api_statuses_f() function.
 	 */
-	public function testApiStatusesFWithFollowers()
+	public function testApiStatusesFWithFollowers(): void
 	{
 		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Api/Twitter/Friends/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Friends/ListsTest.php
@@ -18,7 +18,7 @@ class ListsTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesFWithFriends()
+	public function testApiStatusesFWithFriends(): void
 	{
 		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Api/Twitter/Friendships/IncomingTest.php
+++ b/tests/src/Module/Api/Twitter/Friendships/IncomingTest.php
@@ -18,7 +18,7 @@ class IncomingTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiFriendshipsIncoming()
+	public function testApiFriendshipsIncoming(): void
 	{
 		$response = (new Incoming(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
+++ b/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
@@ -20,7 +20,7 @@ class StatusesTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiListsStatuses()
+	public function testApiListsStatuses(): void
 	{
 		$this->expectException(BadRequestException::class);
 
@@ -31,7 +31,7 @@ class StatusesTest extends ApiTestCase
 	/**
 	 * Test the api_lists_statuses() function with a list ID.
 	 */
-	public function testApiListsStatusesWithListId()
+	public function testApiListsStatusesWithListId(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
@@ -54,7 +54,7 @@ class StatusesTest extends ApiTestCase
 	/**
 	 * Test the api_lists_statuses() function with a list ID and a RSS result.
 	 */
-	public function testApiListsStatusesWithListIdAndRss()
+	public function testApiListsStatusesWithListIdAndRss(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);

--- a/tests/src/Module/Api/Twitter/Media/UploadTest.php
+++ b/tests/src/Module/Api/Twitter/Media/UploadTest.php
@@ -28,7 +28,7 @@ class UploadTest extends ApiTestCase
 	/**
 	 * Test the \Friendica\Module\Api\Twitter\Media\Upload module.
 	 */
-	public function testApiMediaUpload()
+	public function testApiMediaUpload(): void
 	{
 		$this->expectException(BadRequestException::class);
 
@@ -41,7 +41,7 @@ class UploadTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiMediaUploadWithoutAuthenticatedUser()
+	public function testApiMediaUploadWithoutAuthenticatedUser(): void
 	{
 		$this->expectException(UnauthorizedException::class);
 		AuthTestConfig::$authenticated = false;
@@ -63,7 +63,7 @@ class UploadTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiMediaUploadWithMedia()
+	public function testApiMediaUploadWithMedia(): void
 	{
 		$this->expectException(InternalServerErrorException::class);
 		$_FILES = [
@@ -82,7 +82,7 @@ class UploadTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiMediaUploadWithValidMedia()
+	public function testApiMediaUploadWithValidMedia(): void
 	{
 		$_FILES = [
 			'media' => [

--- a/tests/src/Module/Api/Twitter/SavedSearchesTest.php
+++ b/tests/src/Module/Api/Twitter/SavedSearchesTest.php
@@ -14,7 +14,7 @@ use Friendica\Test\ApiTestCase;
 
 class SavedSearchesTest extends ApiTestCase
 {
-	public function test()
+	public function test(): void
 	{
 		$response = (new SavedSearches(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Api/Twitter/Statuses/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/DestroyTest.php
@@ -27,7 +27,7 @@ class DestroyTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesDestroy()
+	public function testApiStatusesDestroy(): void
 	{
 		$this->expectException(BadRequestException::class);
 
@@ -55,7 +55,7 @@ class DestroyTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesDestroyWithId()
+	public function testApiStatusesDestroyWithId(): void
 	{
 		$response = (new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [

--- a/tests/src/Module/Api/Twitter/Statuses/MentionsTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/MentionsTest.php
@@ -19,7 +19,7 @@ class MentionsTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesMentions()
+	public function testApiStatusesMentions(): void
 	{
 		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
@@ -37,7 +37,7 @@ class MentionsTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesMentionsWithNegativePage()
+	public function testApiStatusesMentionsWithNegativePage(): void
 	{
 		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
@@ -69,7 +69,7 @@ class MentionsTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesMentionsWithRss()
+	public function testApiStatusesMentionsWithRss(): void
 	{
 		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]))
 			->run($this->httpExceptionMock, [

--- a/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
@@ -20,7 +20,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesNetworkpublicTimeline()
+	public function testApiStatusesNetworkpublicTimeline(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
@@ -45,7 +45,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesNetworkpublicTimelineWithNegativePage()
+	public function testApiStatusesNetworkpublicTimelineWithNegativePage(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
@@ -84,7 +84,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesNetworkpublicTimelineWithRss()
+	public function testApiStatusesNetworkpublicTimelineWithRss(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);

--- a/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
@@ -28,7 +28,7 @@ class RetweetTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesRepeat()
+	public function testApiStatusesRepeat(): void
 	{
 		$this->expectException(BadRequestException::class);
 
@@ -56,7 +56,7 @@ class RetweetTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesRepeatWithId()
+	public function testApiStatusesRepeatWithId(): void
 	{
 		$response = (new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
@@ -73,7 +73,7 @@ class RetweetTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesRepeatWithSharedId()
+	public function testApiStatusesRepeatWithSharedId(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);

--- a/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
@@ -20,7 +20,7 @@ class ShowTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesShow()
+	public function testApiStatusesShow(): void
 	{
 		$this->expectException(BadRequestException::class);
 
@@ -34,7 +34,7 @@ class ShowTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesShowWithId()
+	public function testApiStatusesShowWithId(): void
 	{
 		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
@@ -52,7 +52,7 @@ class ShowTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesShowWithConversation()
+	public function testApiStatusesShowWithConversation(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);

--- a/tests/src/Module/Api/Twitter/Statuses/UpdateTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/UpdateTest.php
@@ -26,7 +26,7 @@ class UpdateTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesUpdate()
+	public function testApiStatusesUpdate(): void
 	{
 		$_FILES = [
 			'media' => [
@@ -60,7 +60,7 @@ class UpdateTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesUpdateWithHtml()
+	public function testApiStatusesUpdateWithHtml(): void
 	{
 		$response = (new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [

--- a/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
@@ -20,7 +20,7 @@ class UserTimelineTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesUserTimeline()
+	public function testApiStatusesUserTimeline(): void
 	{
 		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
@@ -45,7 +45,7 @@ class UserTimelineTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesUserTimelineWithNegativePage()
+	public function testApiStatusesUserTimelineWithNegativePage(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
@@ -71,7 +71,7 @@ class UserTimelineTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiStatusesUserTimelineWithRss()
+	public function testApiStatusesUserTimelineWithRss(): void
 	{
 		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_RSS,

--- a/tests/src/Module/Api/Twitter/Users/LookupTest.php
+++ b/tests/src/Module/Api/Twitter/Users/LookupTest.php
@@ -20,7 +20,7 @@ class LookupTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiUsersLookup()
+	public function testApiUsersLookup(): void
 	{
 		$this->expectException(NotFoundException::class);
 
@@ -33,7 +33,7 @@ class LookupTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiUsersLookupWithUserId()
+	public function testApiUsersLookupWithUserId(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);

--- a/tests/src/Module/Api/Twitter/Users/SearchTest.php
+++ b/tests/src/Module/Api/Twitter/Users/SearchTest.php
@@ -21,7 +21,7 @@ class SearchTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiUsersSearch()
+	public function testApiUsersSearch(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
@@ -41,7 +41,7 @@ class SearchTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiUsersSearchWithXml()
+	public function testApiUsersSearchWithXml(): void
 	{
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
@@ -60,7 +60,7 @@ class SearchTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiUsersSearchWithoutQuery()
+	public function testApiUsersSearchWithoutQuery(): void
 	{
 		$this->expectException(BadRequestException::class);
 

--- a/tests/src/Module/Api/Twitter/Users/ShowTest.php
+++ b/tests/src/Module/Api/Twitter/Users/ShowTest.php
@@ -42,11 +42,11 @@ class ShowTest extends ApiTestCase
 	public function testApiUsersShowWithXml(): void
 	{
 		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
-			'extension' => ICanCreateResponses::TYPE_XML
+			'extension' => ICanCreateResponses::TYPE_XML,
 		]))->run($this->httpExceptionMock);
 
 		self::assertEquals(ICanCreateResponses::TYPE_XML, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
 
-		self::assertXml((string)$response->getBody(), 'statuses');
+		self::assertXml((string) $response->getBody(), 'statuses');
 	}
 }

--- a/tests/src/Module/Api/Twitter/Users/ShowTest.php
+++ b/tests/src/Module/Api/Twitter/Users/ShowTest.php
@@ -19,7 +19,7 @@ class ShowTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiUsersShow()
+	public function testApiUsersShow(): void
 	{
 		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
@@ -39,7 +39,7 @@ class ShowTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiUsersShowWithXml()
+	public function testApiUsersShowWithXml(): void
 	{
 		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_XML

--- a/tests/src/Module/BaseApiTest.php
+++ b/tests/src/Module/BaseApiTest.php
@@ -40,7 +40,7 @@ class BaseApiTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiUser()
+	public function testApiUser(): void
 	{
 		self::assertEquals(parent::SELF_USER['id'], BaseApi::getCurrentUserID());
 	}

--- a/tests/src/Module/NodeInfoTest.php
+++ b/tests/src/Module/NodeInfoTest.php
@@ -29,7 +29,7 @@ class NodeInfoTest extends FixtureTestCase
 		$this->httpExceptionMock = \Mockery::mock(HTTPException::class);
 	}
 
-	public function testNodeInfo110()
+	public function testNodeInfo110(): void
 	{
 		$response = (new NodeInfo110(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), []))
 			->run($this->httpExceptionMock);
@@ -50,7 +50,7 @@ class NodeInfoTest extends FixtureTestCase
 		self::assertIsArray($json->services->outbound);
 	}
 
-	public function testNodeInfo120()
+	public function testNodeInfo120(): void
 	{
 		$response = (new NodeInfo120(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), []))
 			->run($this->httpExceptionMock);
@@ -70,7 +70,7 @@ class NodeInfoTest extends FixtureTestCase
 		self::assertIsArray($json->services->outbound);
 	}
 
-	public function testNodeInfo210()
+	public function testNodeInfo210(): void
 	{
 		$response = (new NodeInfo210(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), []))
 			->run($this->httpExceptionMock);

--- a/tests/src/Module/Special/OptionsTest.php
+++ b/tests/src/Module/Special/OptionsTest.php
@@ -27,7 +27,7 @@ class OptionsTest extends FixtureTestCase
 		$this->httpExceptionMock = \Mockery::mock(HTTPException::class);
 	}
 
-	public function testOptionsAll()
+	public function testOptionsAll(): void
 	{
 		$this->useHttpMethod(Router::OPTIONS);
 
@@ -43,7 +43,7 @@ class OptionsTest extends FixtureTestCase
 		self::assertEquals(implode(',', Router::ALLOWED_METHODS), $response->getHeaderLine('Allow'));
 	}
 
-	public function testOptionsSpecific()
+	public function testOptionsSpecific(): void
 	{
 		$this->useHttpMethod(Router::OPTIONS);
 

--- a/tests/src/Module/Special/OptionsTest.php
+++ b/tests/src/Module/Special/OptionsTest.php
@@ -33,7 +33,7 @@ class OptionsTest extends FixtureTestCase
 
 		$response = (new Options(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock);
 
-		self::assertEmpty((string)$response->getBody());
+		self::assertEmpty((string) $response->getBody());
 		self::assertEquals(204, $response->getStatusCode());
 		self::assertEquals('No Content', $response->getReasonPhrase());
 		self::assertEquals([
@@ -51,7 +51,7 @@ class OptionsTest extends FixtureTestCase
 			'AllowedMethods' => [Router::GET, Router::POST],
 		]))->run($this->httpExceptionMock);
 
-		self::assertEmpty((string)$response->getBody());
+		self::assertEmpty((string) $response->getBody());
 		self::assertEquals(204, $response->getStatusCode());
 		self::assertEquals('No Content', $response->getReasonPhrase());
 		self::assertEquals([

--- a/tests/src/Module/StatsCachingTest.php
+++ b/tests/src/Module/StatsCachingTest.php
@@ -43,7 +43,7 @@ class StatsCachingTest extends FixtureTestCase
 		$this->lock              = new CacheLock($this->cache);
 	}
 
-	public function testStatsCachingNotAllowed()
+	public function testStatsCachingNotAllowed(): void
 	{
 		$this->httpExceptionMock->shouldReceive('content')->andReturn('failed')->once();
 
@@ -55,7 +55,7 @@ class StatsCachingTest extends FixtureTestCase
 		self::assertEquals('failed', $response->getBody());
 	}
 
-	public function testStatsCachingWitMinimumCache()
+	public function testStatsCachingWitMinimumCache(): void
 	{
 		$request = [
 			'key' => '12345',
@@ -81,7 +81,7 @@ class StatsCachingTest extends FixtureTestCase
 		], $json['lock']);
 	}
 
-	public function testStatsCachingWithDatabase()
+	public function testStatsCachingWithDatabase(): void
 	{
 		$request = [
 			'key' => '12345',
@@ -105,7 +105,7 @@ class StatsCachingTest extends FixtureTestCase
 		self::assertEquals(['type' => 'database'], $json['lock']);
 	}
 
-	public function testStatsCachingWithCache()
+	public function testStatsCachingWithCache(): void
 	{
 		$request = [
 			'key' => '12345',
@@ -129,7 +129,7 @@ class StatsCachingTest extends FixtureTestCase
 		self::assertEquals(['type' => 'database'], $json['lock']);
 	}
 
-	public function testStatsCachingWithOpcacheAndNull()
+	public function testStatsCachingWithOpcacheAndNull(): void
 	{
 		$request = [
 			'key' => '12345',
@@ -160,7 +160,7 @@ class StatsCachingTest extends FixtureTestCase
 		self::assertEquals(['type' => 'database'], $json['lock']);
 	}
 
-	public function testStatsCachingWithOpcacheAndValues()
+	public function testStatsCachingWithOpcacheAndValues(): void
 	{
 		$request = [
 			'key' => '12345',

--- a/tests/src/Module/StatsCachingTest.php
+++ b/tests/src/Module/StatsCachingTest.php
@@ -179,7 +179,7 @@ class StatsCachingTest extends FixtureTestCase
 			'memory_usage' => [
 				'used_memory' => 3,
 				'free_memory' => 4,
-			]
+			],
 		]);
 
 		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, []))

--- a/tests/src/Navigation/Notifications/Entity/NotifyTest.php
+++ b/tests/src/Navigation/Notifications/Entity/NotifyTest.php
@@ -24,7 +24,7 @@ class NotifyTest extends FixtureTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataFormatNotify')]
-	public function testFormatNotify(string $name, string $message, string $assertion)
+	public function testFormatNotify(string $name, string $message, string $assertion): void
 	{
 		self::assertEquals($assertion, Notify::formatMessage($name, $message));
 	}

--- a/tests/src/Network/HTTPClient/Client/HTTPClientTest.php
+++ b/tests/src/Network/HTTPClient/Client/HTTPClientTest.php
@@ -34,7 +34,7 @@ class HTTPClientTest extends MockedTestCase
 	/**
 	 * Test for issue https://github.com/friendica/friendica/issues/10473#issuecomment-907749093
 	 */
-	public function testInvalidURI()
+	public function testInvalidURI(): void
 	{
 		$this->httpRequestHandler->setHandler(new MockHandler([
 			new Response(301, ['Location' => 'https:///']),
@@ -46,7 +46,7 @@ class HTTPClientTest extends MockedTestCase
 	/**
 	 * Test for issue https://github.com/friendica/friendica/issues/11726
 	 */
-	public function testRedirect()
+	public function testRedirect(): void
 	{
 		$this->httpRequestHandler->setHandler(new MockHandler([
 			new Response(302, ['Location' => 'https://mastodon.social/about']),

--- a/tests/src/Network/ProbeTest.php
+++ b/tests/src/Network/ProbeTest.php
@@ -97,7 +97,7 @@ class ProbeTest extends MockedTestCase
 		return $template;
 	}
 
-	public function testGetFeedLinkNoBase()
+	public function testGetFeedLinkNoBase(): void
 	{
 		foreach (self::EXPECTED as $url => $hrefs) {
 			foreach ($hrefs as $href => $expected) {
@@ -110,7 +110,7 @@ class ProbeTest extends MockedTestCase
 		}
 	}
 
-	public function testGetFeedLinkBase()
+	public function testGetFeedLinkBase(): void
 	{
 		foreach (self::EXPECTED as $url => $hrefs) {
 			foreach ($hrefs as $href => $expected) {
@@ -153,7 +153,7 @@ class ProbeTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataCleanUri')]
-	public function testCleanUri(string $expected, string $uri)
+	public function testCleanUri(string $expected, string $uri): void
 	{
 		self::assertEquals($expected, Probe::cleanURI($uri));
 	}
@@ -201,7 +201,7 @@ xQIDAQAB
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataUri')]
-	public function testProbeUri(string $uri, array $assertInfos)
+	public function testProbeUri(string $uri, array $assertInfos): void
 	{
 		self::markTestIncomplete('hard work due mocking 19 different http-requests');
 

--- a/tests/src/Profile/ProfileField/Entity/ProfileFieldTest.php
+++ b/tests/src/Profile/ProfileField/Entity/ProfileFieldTest.php
@@ -79,7 +79,7 @@ class ProfileFieldTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataEntity')]
-	public function testEntity(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null)
+	public function testEntity(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null): void
 	{
 		$entity = new ProfileField($uid, $order, $label, $value, $created, $edited, $this->permissionSetFactory->createFromTableRow($permissionSet), $id);
 
@@ -94,7 +94,7 @@ class ProfileFieldTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataEntity')]
-	public function testUpdate(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null)
+	public function testUpdate(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null): void
 	{
 		$permissionSet = $this->permissionSetFactory->createFromTableRow(['uid' => 2, 'id' => $psid]);
 
@@ -128,7 +128,7 @@ class ProfileFieldTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataEntity')]
-	public function testSetOrder(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null)
+	public function testSetOrder(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null): void
 	{
 		$permissionSet = $this->permissionSetFactory->createFromTableRow(['uid' => 2, 'id' => $psid]);
 
@@ -159,7 +159,7 @@ class ProfileFieldTest extends MockedTestCase
 	 * Test the exception because of a wrong property
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataEntity')]
-	public function testWrongGet(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null)
+	public function testWrongGet(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null): void
 	{
 		$entity = new ProfileField($uid, $order, $label, $value, $created, $edited, $this->permissionSetFactory->createFromTableRow($permissionSet), $id);
 
@@ -171,7 +171,7 @@ class ProfileFieldTest extends MockedTestCase
 	 * Test gathering the permissionset
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataEntity')]
-	public function testPermissionSet(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null)
+	public function testPermissionSet(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null): void
 	{
 		$entity = new ProfileField($uid, $order, $label, $value, $created, $edited, $this->permissionSetFactory->createFromTableRow($permissionSet), $id);
 
@@ -186,7 +186,7 @@ class ProfileFieldTest extends MockedTestCase
 	 * Test the exception because the factory cannot find a permissionSet ID, nor the permissionSet itself
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataEntity')]
-	public function testMissingPermissionFactory(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null)
+	public function testMissingPermissionFactory(int $uid, int $order, int $psid, string $label, string $value, \DateTime $created, \DateTime $edited, array $permissionSet, $id = null): void
 	{
 		self::expectException(UnexpectedPermissionSetException::class);
 		self::expectExceptionMessage('Either set the PermissionSet fields (join) or the PermissionSet itself');

--- a/tests/src/Profile/ProfileField/Repository/ProfileFieldTest.php
+++ b/tests/src/Profile/ProfileField/Repository/ProfileFieldTest.php
@@ -41,7 +41,7 @@ class ProfileFieldTest extends FixtureTestCase
 	/**
 	 * Test create ProfileField without a valid PermissionSet
 	 */
-	public function testSavingWithoutPermissionSet()
+	public function testSavingWithoutPermissionSet(): void
 	{
 		self::expectExceptionMessage('PermissionSet needs to be saved first.');
 		self::expectException(ProfileFieldPersistenceException::class);
@@ -56,7 +56,7 @@ class ProfileFieldTest extends FixtureTestCase
 	/**
 	 * Test saving a new entity
 	 */
-	public function testSaveNew()
+	public function testSaveNew(): void
 	{
 		$profileField = $this->factory->createFromValues(42, 0, 'public', 'value', $this->permissionSetRepository->save($this->permissionSetFactory->createFromString(42, '', '<~>')));
 
@@ -78,7 +78,7 @@ class ProfileFieldTest extends FixtureTestCase
 	/**
 	 * Test updating the order of a ProfileField
 	 */
-	public function testUpdateOrder()
+	public function testUpdateOrder(): void
 	{
 		$profileField = $this->factory->createFromValues(42, 0, 'public', 'value', $this->permissionSetRepository->save($this->permissionSetFactory->createFromString(42, '', '<~>')));
 
@@ -111,7 +111,7 @@ class ProfileFieldTest extends FixtureTestCase
 	/**
 	 * Test updating a whole entity
 	 */
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		$profileField = $this->factory->createFromValues(42, 0, 'public', 'value', $this->permissionSetRepository->save($this->permissionSetFactory->createFromString(42, '', '<~>')));
 

--- a/tests/src/Protocol/ActivityTest.php
+++ b/tests/src/Protocol/ActivityTest.php
@@ -53,14 +53,14 @@ class ActivityTest extends MockedTestCase
 	 * Test the different, possible matchings
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataMatch')]
-	public function testMatch(string $haystack, string $needle, bool $assert)
+	public function testMatch(string $haystack, string $needle, bool $assert): void
 	{
 		$activity = new Activity();
 
 		self::assertEquals($assert, $activity->match($haystack, $needle));
 	}
 
-	public function testIsHidden()
+	public function testIsHidden(): void
 	{
 		$activity = new Activity();
 

--- a/tests/src/Protocol/HTTP/MediaTypeTest.php
+++ b/tests/src/Protocol/HTTP/MediaTypeTest.php
@@ -60,7 +60,7 @@ class MediaTypeTest extends \PHPUnit\Framework\TestCase
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataValid')]
-	public function testValid(MediaType $expected, string $contentType)
+	public function testValid(MediaType $expected, string $contentType): void
 	{
 		$this->assertEquals($expected, MediaType::fromContentType($contentType));
 	}
@@ -85,7 +85,7 @@ class MediaTypeTest extends \PHPUnit\Framework\TestCase
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataInvalid')]
-	public function testInvalid(string $contentType)
+	public function testInvalid(string $contentType): void
 	{
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -129,7 +129,7 @@ class MediaTypeTest extends \PHPUnit\Framework\TestCase
 	 * @return void
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataToString')]
-	public function testToString(string $expected, MediaType $mediaType)
+	public function testToString(string $expected, MediaType $mediaType): void
 	{
 		$this->assertEquals($expected, $mediaType->__toString());
 	}

--- a/tests/src/Security/BasicAuthTest.php
+++ b/tests/src/Security/BasicAuthTest.php
@@ -17,7 +17,7 @@ class BasicAuthTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiSource()
+	public function testApiSource(): void
 	{
 		self::assertEquals('api', BasicAuth::getCurrentApplicationToken()['name']);
 	}
@@ -27,7 +27,7 @@ class BasicAuthTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiSourceWithTwidere()
+	public function testApiSourceWithTwidere(): void
 	{
 		$_SERVER['HTTP_USER_AGENT'] = 'Twidere';
 		self::assertEquals('Twidere', BasicAuth::getCurrentApplicationToken()['name']);
@@ -38,7 +38,7 @@ class BasicAuthTest extends ApiTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiSourceWithGet()
+	public function testApiSourceWithGet(): void
 	{
 		$_REQUEST['source'] = 'source_name';
 		self::assertEquals('source_name', BasicAuth::getCurrentApplicationToken()['name']);
@@ -74,7 +74,7 @@ class BasicAuthTest extends ApiTestCase
 	/**
 	 * Test the BasicAuth::getCurrentUserID() function with a correct login.
 	 */
-	public function testApiLoginWithCorrectLogin()
+	public function testApiLoginWithCorrectLogin(): void
 	{
 		BasicAuth::setCurrentUserID();
 		$_SERVER['PHP_AUTH_USER'] = 'Test user';

--- a/tests/src/Security/PermissionSet/Entity/PermissionSetTest.php
+++ b/tests/src/Security/PermissionSet/Entity/PermissionSetTest.php
@@ -30,7 +30,7 @@ class PermissionSetTest extends MockedTestCase
 	 * Test if the call "withAllowedContacts()" creates a clone
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dateAllowedContacts')]
-	public function testWithAllowedContacts(int $id, array $allow_cid, array $allow_gid, array $deny_cid, array $deny_gid, array $update_cid)
+	public function testWithAllowedContacts(int $id, array $allow_cid, array $allow_gid, array $deny_cid, array $deny_gid, array $update_cid): void
 	{
 		$permissionSetOrig = new PermissionSet(
 			$id,

--- a/tests/src/Security/PermissionSet/Factory/PermissionSetTest.php
+++ b/tests/src/Security/PermissionSet/Factory/PermissionSetTest.php
@@ -109,7 +109,7 @@ class PermissionSetTest extends MockedTestCase
 	 * Test the createFromTableRow method
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataInput')]
-	public function testCreateFromTableRow(array $input, array $assertion)
+	public function testCreateFromTableRow(array $input, array $assertion): void
 	{
 		$permissionSet = $this->permissionSet->createFromTableRow($input);
 
@@ -120,7 +120,7 @@ class PermissionSetTest extends MockedTestCase
 	 * Test the createFromString method
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataInput')]
-	public function testCreateFromString(array $input, array $assertion)
+	public function testCreateFromString(array $input, array $assertion): void
 	{
 		$permissionSet = $this->permissionSet->createFromString(
 			$input['uid'],

--- a/tests/src/Security/PermissionSet/Repository/PermissionSetTest.php
+++ b/tests/src/Security/PermissionSet/Repository/PermissionSetTest.php
@@ -31,7 +31,7 @@ class PermissionSetTest extends FixtureTestCase
 		$this->factory    = DI::permissionSetFactory();
 	}
 
-	public function testSelectOneByIdPublic()
+	public function testSelectOneByIdPublic(): void
 	{
 		$permissionSet = $this->repository->selectPublicForUser(1);
 
@@ -47,7 +47,7 @@ class PermissionSetTest extends FixtureTestCase
 	/**
 	 * Test create/update PermissionSets
 	 */
-	public function testSaving()
+	public function testSaving(): void
 	{
 		$permissionSet = $this->factory->createFromString(42, '', '<~>');
 
@@ -349,7 +349,7 @@ class PermissionSetTest extends FixtureTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSet')]
-	public function testSelectContactId(array $group_member, array $permissionSets, array $assertions)
+	public function testSelectContactId(array $group_member, array $permissionSets, array $assertions): void
 	{
 		/** @var Database $db */
 		$db = $this->dice->create(Database::class);
@@ -369,7 +369,7 @@ class PermissionSetTest extends FixtureTestCase
 		}
 	}
 
-	public function testSelectOneByIdInvalid()
+	public function testSelectOneByIdInvalid(): void
 	{
 		self::expectException(PermissionSetNotFoundException::class);
 		self::expectExceptionMessage('PermissionSet with id -1 for user 42 doesn\'t exist.');
@@ -378,7 +378,7 @@ class PermissionSetTest extends FixtureTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataSet')]
-	public function testSelectOneById(array $group_member, array $permissionSets, array $assertions)
+	public function testSelectOneById(array $group_member, array $permissionSets, array $assertions): void
 	{
 		if (count($permissionSets) === 0) {
 			self::markTestSkipped('Nothing to assert.');

--- a/tests/src/Security/TwoFactor/Factory/TrustedBrowserTest.php
+++ b/tests/src/Security/TwoFactor/Factory/TrustedBrowserTest.php
@@ -15,7 +15,7 @@ use Psr\Log\NullLogger;
 
 class TrustedBrowserTest extends MockedTestCase
 {
-	public function testCreateFromTableRowSuccess()
+	public function testCreateFromTableRowSuccess(): void
 	{
 		$factory = new TrustedBrowser(new NullLogger());
 
@@ -33,7 +33,7 @@ class TrustedBrowserTest extends MockedTestCase
 		$this->assertEquals($row, $trustedBrowser->toArray());
 	}
 
-	public function testCreateFromTableRowMissingData()
+	public function testCreateFromTableRowMissingData(): void
 	{
 		$this->expectException(\TypeError::class);
 
@@ -53,7 +53,7 @@ class TrustedBrowserTest extends MockedTestCase
 		$this->assertEquals($row, $trustedBrowser->toArray());
 	}
 
-	public function testCreateForUserWithUserAgent()
+	public function testCreateForUserWithUserAgent(): void
 	{
 		$factory = new TrustedBrowser(new NullLogger());
 

--- a/tests/src/Security/TwoFactor/Factory/TrustedBrowserTest.php
+++ b/tests/src/Security/TwoFactor/Factory/TrustedBrowserTest.php
@@ -21,11 +21,11 @@ class TrustedBrowserTest extends MockedTestCase
 
 		$row = [
 			'cookie_hash' => Strings::getRandomHex(),
-			'uid' => 42,
-			'user_agent' => 'PHPUnit',
-			'created' => DateTimeFormat::utcNow(),
-			'trusted' => true,
-			'last_used' => null,
+			'uid'         => 42,
+			'user_agent'  => 'PHPUnit',
+			'created'     => DateTimeFormat::utcNow(),
+			'trusted'     => true,
+			'last_used'   => null,
 		];
 
 		$trustedBrowser = $factory->createFromTableRow($row);
@@ -41,11 +41,11 @@ class TrustedBrowserTest extends MockedTestCase
 
 		$row = [
 			'cookie_hash' => null,
-			'uid' => null,
-			'user_agent' => null,
-			'created' => null,
-			'trusted' => true,
-			'last_used' => null,
+			'uid'         => null,
+			'user_agent'  => null,
+			'created'     => null,
+			'trusted'     => true,
+			'last_used'   => null,
 		];
 
 		$trustedBrowser = $factory->createFromTableRow($row);

--- a/tests/src/Security/TwoFactor/Model/TrustedBrowserTest.php
+++ b/tests/src/Security/TwoFactor/Model/TrustedBrowserTest.php
@@ -14,7 +14,7 @@ use Friendica\Util\Strings;
 
 class TrustedBrowserTest extends MockedTestCase
 {
-	public function test__construct()
+	public function test__construct(): void
 	{
 		$hash = Strings::getRandomHex();
 
@@ -33,7 +33,7 @@ class TrustedBrowserTest extends MockedTestCase
 		$this->assertNotEmpty($trustedBrowser->created);
 	}
 
-	public function testRecordUse()
+	public function testRecordUse(): void
 	{
 		$hash = Strings::getRandomHex();
 		$past = DateTimeFormat::utc('now - 5 minutes');

--- a/tests/src/Security/TwoFactor/Model/TrustedBrowserTest.php
+++ b/tests/src/Security/TwoFactor/Model/TrustedBrowserTest.php
@@ -23,7 +23,7 @@ class TrustedBrowserTest extends MockedTestCase
 			42,
 			'PHPUnit',
 			true,
-			DateTimeFormat::utcNow()
+			DateTimeFormat::utcNow(),
 		);
 
 		$this->assertEquals($hash, $trustedBrowser->cookie_hash);
@@ -44,7 +44,7 @@ class TrustedBrowserTest extends MockedTestCase
 			'PHPUnit',
 			true,
 			$past,
-			$past
+			$past,
 		);
 
 		$trustedBrowser->recordUse();

--- a/tests/src/Util/DateTimeFormatTest.php
+++ b/tests/src/Util/DateTimeFormatTest.php
@@ -55,7 +55,7 @@ class DateTimeFormatTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataYearMonth')]
-	public function testIsYearMonth(string $input, bool $assert)
+	public function testIsYearMonth(string $input, bool $assert): void
 	{
 		$dtFormat = new DateTimeFormat();
 
@@ -67,7 +67,7 @@ class DateTimeFormatTest extends MockedTestCase
 	 *
 	 * @return void
 	 */
-	public function testApiDate()
+	public function testApiDate(): void
 	{
 		self::assertEquals('Wed Oct 10 00:00:00 +0000 1990', DateTimeFormat::utc('1990-10-10', DateTimeFormat::API));
 	}
@@ -178,7 +178,7 @@ class DateTimeFormatTest extends MockedTestCase
 	 * @throws \Exception
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataFix')]
-	public function testFix($expectedDate, $dateString)
+	public function testFix($expectedDate, $dateString): void
 	{
 		$fixed = DateTimeFormat::fix($dateString);
 
@@ -191,7 +191,7 @@ class DateTimeFormatTest extends MockedTestCase
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function testConvertRelative()
+	public function testConvertRelative(): void
 	{
 		$now  = DateTimeFormat::utcNow('U');
 		$date = DateTimeFormat::utc('now - 3 days', 'U');
@@ -250,7 +250,7 @@ class DateTimeFormatTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataConvert')]
-	public function testConvert($expected, string $s = 'now', string $tz_to = 'UTC', string $tz_from = 'UTC', string $format = DateTimeFormat::MYSQL)
+	public function testConvert($expected, string $s = 'now', string $tz_to = 'UTC', string $tz_from = 'UTC', string $format = DateTimeFormat::MYSQL): void
 	{
 		$this->assertSame($expected, DateTimeFormat::convert($s, $tz_to, $tz_from, $format));
 	}
@@ -270,7 +270,7 @@ class DateTimeFormatTest extends MockedTestCase
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataConvertNow')]
-	public function testConvertNow(string $s = 'now', string $tz_to = 'UTC', string $tz_from = 'UTC', string $format = DateTimeFormat::MYSQL)
+	public function testConvertNow(string $s = 'now', string $tz_to = 'UTC', string $tz_from = 'UTC', string $format = DateTimeFormat::MYSQL): void
 	{
 		$this->assertSame(date(DateTimeFormat::MYSQL), DateTimeFormat::convert($s, $tz_to, $tz_from, $format));
 	}

--- a/tests/src/Util/EMailerTest.php
+++ b/tests/src/Util/EMailerTest.php
@@ -64,7 +64,7 @@ class EMailerTest extends MockedTestCase
 		parent::tearDown();
 	}
 
-	public function testEmail()
+	public function testEmail(): void
 	{
 		$this->pConfig->shouldReceive('get')->withArgs(['1', 'system', 'email_textonly'])->andReturn(false)->once();
 
@@ -97,7 +97,7 @@ class EMailerTest extends MockedTestCase
 		self::assertEquals("-f sender@friendica.local", EmailerSpy::$MAIL_DATA['parameters']);
 	}
 
-	public function testTwoMessageIds()
+	public function testTwoMessageIds(): void
 	{
 		$this->pConfig->shouldReceive('get')->withArgs(['1', 'system', 'email_textonly'])->andReturn(false)->once();
 

--- a/tests/src/Util/Emailer/MailBuilderTest.php
+++ b/tests/src/Util/Emailer/MailBuilderTest.php
@@ -68,7 +68,7 @@ class MailBuilderTest extends MockedTestCase
 	/**
 	 * Test if the builder instance can get created
 	 */
-	public function testBuilderInstance()
+	public function testBuilderInstance(): void
 	{
 		$builder = new SampleMailBuilder($this->l10n, $this->baseUrl, $this->config, new NullLogger());
 
@@ -89,7 +89,7 @@ class MailBuilderTest extends MockedTestCase
 	/**
 	 * Test if the builder can create a "simple" raw mail
 	 */
-	public function testBuilderWithRawEmail()
+	public function testBuilderWithRawEmail(): void
 	{
 		$builder = new SampleMailBuilder($this->l10n, $this->baseUrl, $this->config, new NullLogger());
 
@@ -117,7 +117,7 @@ class MailBuilderTest extends MockedTestCase
 	 * Test if the builder throws an exception in case no recipient
 	 *
 	 */
-	public function testBuilderWithEmptyMail()
+	public function testBuilderWithEmptyMail(): void
 	{
 		$this->expectException(UnprocessableEntityException::class);
 		$this->expectExceptionMessage("Recipient address is missing.");
@@ -130,7 +130,7 @@ class MailBuilderTest extends MockedTestCase
 	/**
 	 * Test if the builder throws an exception in case no sender
 	 */
-	public function testBuilderWithEmptySender()
+	public function testBuilderWithEmptySender(): void
 	{
 		$this->expectException(UnprocessableEntityException::class);
 		$this->expectExceptionMessage("Sender address or name is missing.");
@@ -145,7 +145,7 @@ class MailBuilderTest extends MockedTestCase
 	/**
 	 * Test if the builder is capable of creating "empty" mails if needed (not the decision of the builder if so ..)
 	 */
-	public function testBuilderWithoutMessage()
+	public function testBuilderWithoutMessage(): void
 	{
 		$builder = new SampleMailBuilder($this->l10n, $this->baseUrl, $this->config, new NullLogger());
 
@@ -166,7 +166,7 @@ class MailBuilderTest extends MockedTestCase
 	/**
 	 * Test if the builder sets for the text the same as for
 	 */
-	public function testBuilderWithJustPreamble()
+	public function testBuilderWithJustPreamble(): void
 	{
 		$builder = new SampleMailBuilder($this->l10n, $this->baseUrl, $this->config, new NullLogger());
 

--- a/tests/src/Util/Emailer/SystemMailBuilderTest.php
+++ b/tests/src/Util/Emailer/SystemMailBuilderTest.php
@@ -47,7 +47,7 @@ class SystemMailBuilderTest extends MockedTestCase
 	/**
 	 * Test if the builder instance can get created
 	 */
-	public function testBuilderInstance()
+	public function testBuilderInstance(): void
 	{
 		$builder = new SystemMailBuilder($this->l10n, $this->baseUrl, $this->config, new NullLogger(), 'moreply@friendica.local', 'FriendicaSite');
 

--- a/tests/src/Util/Emailer/SystemMailBuilderTest.php
+++ b/tests/src/Util/Emailer/SystemMailBuilderTest.php
@@ -33,9 +33,9 @@ class SystemMailBuilderTest extends MockedTestCase
 
 		$this->setUpVfsDir();
 
-		$this->config  = \Mockery::mock(IManageConfigValues::class);
+		$this->config = \Mockery::mock(IManageConfigValues::class);
 		$this->config->shouldReceive('get')->with('config', 'admin_name')->andReturn('Admin');
-		$this->l10n    = \Mockery::mock(L10n::class);
+		$this->l10n = \Mockery::mock(L10n::class);
 		$this->l10n->shouldReceive('t')->andReturnUsing(function ($msg) {
 			return $msg;
 		});

--- a/tests/src/Util/HTTPInputDataTest.php
+++ b/tests/src/Util/HTTPInputDataTest.php
@@ -122,7 +122,7 @@ class HTTPInputDataTest extends MockedTestCase
 	 * @see HTTPInputData::process()
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataStream')]
-	public function testHttpInput(string $contentType, string $input, array $expected)
+	public function testHttpInput(string $contentType, string $input, array $expected): void
 	{
 		$httpInput = new HTTPInputDataDouble(['CONTENT_TYPE' => $contentType]);
 		$httpInput->setPhpInputContent($input);

--- a/tests/src/Util/HTTPSignatureTest.php
+++ b/tests/src/Util/HTTPSignatureTest.php
@@ -119,14 +119,14 @@ G1vVmRgkLDqhc4+r3wDz3qy6JpV7tg==
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataParseSigned')]
-	public function testParseSigheader(string $signature, array $assertion)
+	public function testParseSigheader(string $signature, array $assertion): void
 	{
 		$headers = HTTPSignature::parseSigheader($signature);
 		self::assertEquals($assertion, $headers);
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataHeader')]
-	public function testSignHeader(string $privKey, string $keyId, array $header, string $signature)
+	public function testSignHeader(string $privKey, string $keyId, array $header, string $signature): void
 	{
 		$signed = HTTPSignature::createSig($header, $privKey, $keyId);
 		self::assertEquals($signature, $signed['Authorization'][0]);

--- a/tests/src/Util/ImagesTest.php
+++ b/tests/src/Util/ImagesTest.php
@@ -71,7 +71,7 @@ class ImagesTest extends MockedTestCase
 	 * Test the Images::getInfoFromURL() method (only remote images, not local/relative!)
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataImages')]
-	public function testGetInfoFromRemoteURL(string $url, array $headers, string $data, array $assertion)
+	public function testGetInfoFromRemoteURL(string $url, array $headers, string $data, array $assertion): void
 	{
 		$this->httpRequestHandler->setHandler(new MockHandler([
 			new Response(200, $headers, $data),
@@ -181,7 +181,7 @@ class ImagesTest extends MockedTestCase
 	 * Test the Images::getScalingDimensions() method
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataScalingDimensions')]
-	public function testGetScalingDimensions(int $width, int $height, int $max, array $assertion)
+	public function testGetScalingDimensions(int $width, int $height, int $max, array $assertion): void
 	{
 		$result = Images::getScalingDimensions($width, $height, $max);
 

--- a/tests/src/Util/NetworkTest.php
+++ b/tests/src/Util/NetworkTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 class NetworkTest extends TestCase
 {
-	public function testValidUri()
+	public function testValidUri(): void
 	{
 		self::assertNotNull(Network::createUriFromString('https://friendi.ca'));
 		self::assertNotNull(Network::createUriFromString('magnet:?xs=https%3A%2F%2Ftube.jeena.net%2Flazy-static%2Ftorrents%2F04bec7a8-34de-4847-b080-6ee00c4b3d49-1080-hls.torrent&xt=urn:btih:5def5a24dfa7307e999a0d4f0fcc29c3e2b13be2&dn=My+fediverse+setup+-+I+host+everything+myself&tr=https%3A%2F%2Ftube.jeena.net%2Ftracker%2Fannounce&tr=wss%3A%2F%2Ftube.jeena.net%3A443%2Ftracker%2Fsocket&ws=https%3A%2F%2Ftube.jeena.net%2Fstatic%2Fstreaming-playlists%2Fhls%2F23989f41-e230-4dbf-9111-936bc730bf50%2Fe5905de3-e488-4bb8-a1e8-eb7a53ac24ad-1080-fragmented.mp4'));
@@ -29,7 +29,7 @@ class NetworkTest extends TestCase
 	 * Test for isValidAtUrl function
 	 * Tests valid and invalid AT Protocol URLs
 	 */
-	public function testIsValidAtUrl()
+	public function testIsValidAtUrl(): void
 	{
 		// Valid AT Protocol URL with proper format at://repo/collection/rkey
 		self::assertTrue(Network::isValidAtUrl('at://did:plc:geqiabvo4b4jnfv2paplzcge/app.bsky.feed.post/abc123'));

--- a/tests/src/Util/ProfilerTest.php
+++ b/tests/src/Util/ProfilerTest.php
@@ -30,7 +30,7 @@ class ProfilerTest extends MockedTestCase
 	/**
 	 * Test the Profiler setup
 	 */
-	public function testSetUp()
+	public function testSetUp(): void
 	{
 		$config = \Mockery::mock(IManageConfigValues::class);
 		$config->shouldReceive('get')
@@ -107,7 +107,7 @@ class ProfilerTest extends MockedTestCase
 	 * Test the Profiler savetimestamp
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataPerformance')]
-	public function testSaveTimestamp($timestamp, $name, array $functions)
+	public function testSaveTimestamp($timestamp, $name, array $functions): void
 	{
 		$config = \Mockery::mock(IManageConfigValues::class);
 		$config->shouldReceive('get')
@@ -128,7 +128,7 @@ class ProfilerTest extends MockedTestCase
 	 * Test the Profiler reset
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataPerformance')]
-	public function testReset($timestamp, $name, array $functions)
+	public function testReset($timestamp, $name, array $functions): void
 	{
 		$config = \Mockery::mock(IManageConfigValues::class);
 		$config->shouldReceive('get')
@@ -183,7 +183,7 @@ class ProfilerTest extends MockedTestCase
 	 * Test the output of the Profiler
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataBig')]
-	public function testSaveLog($data)
+	public function testSaveLog($data): void
 	{
 		$this->logger
 			->shouldReceive('info')

--- a/tests/src/Util/Router/FriendicaGroupCountBasedTest.php
+++ b/tests/src/Util/Router/FriendicaGroupCountBasedTest.php
@@ -16,7 +16,7 @@ use Friendica\Util\Router\FriendicaGroupCountBased;
 
 class FriendicaGroupCountBasedTest extends MockedTestCase
 {
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$collector = new RouteCollector(new Std(), new GroupCountBased());
 		$collector->addRoute('GET', '/get', Options::class);

--- a/tests/src/Util/TemporalTest.php
+++ b/tests/src/Util/TemporalTest.php
@@ -21,7 +21,7 @@ class TemporalTest extends TestCase
 	/**
 	 * Checks for getRelativeDate()
 	 */
-	public function testGetRelativeDate()
+	public function testGetRelativeDate(): void
 	{
 		$clock = new FrozenClock();
 

--- a/tests/src/Util/TemporalTest.php
+++ b/tests/src/Util/TemporalTest.php
@@ -28,13 +28,13 @@ class TemporalTest extends TestCase
 		// "never" should be returned
 		self::assertEquals(
 			Temporal::getRelativeDate('', true, $clock),
-			DI::l10n()->t('never')
+			DI::l10n()->t('never'),
 		);
 
 		// Format current date/time into "MySQL" format
 		self::assertEquals(
 			Temporal::getRelativeDate($clock->now()->format(DateTimeFormat::MYSQL), true, $clock),
-			DI::l10n()->t('less than a second ago')
+			DI::l10n()->t('less than a second ago'),
 		);
 
 		// Format current date/time - 1 minute into "MySQL" format
@@ -44,25 +44,25 @@ class TemporalTest extends TestCase
 		// Should be both equal
 		self::assertEquals(
 			Temporal::getRelativeDate($minuteAgo, true, $clock),
-			sprintf($format, 1, DI::l10n()->t('minute'))
+			sprintf($format, 1, DI::l10n()->t('minute')),
 		);
 
-		$almostAnHourAgoInterval = new \DateInterval('PT59M59S');
+		$almostAnHourAgoInterval         = new \DateInterval('PT59M59S');
 		$almostAnHourAgoInterval->invert = 1;
-		$almostAnHourAgo = (clone $clock->now())->add($almostAnHourAgoInterval);
+		$almostAnHourAgo                 = (clone $clock->now())->add($almostAnHourAgoInterval);
 
 		self::assertEquals(
 			Temporal::getRelativeDate($almostAnHourAgo->format(DateTimeFormat::MYSQL), true, $clock),
-			sprintf($format, 59, DI::l10n()->t('minutes'))
+			sprintf($format, 59, DI::l10n()->t('minutes')),
 		);
 
-		$anHourAgoInterval = new \DateInterval('PT1H');
+		$anHourAgoInterval         = new \DateInterval('PT1H');
 		$anHourAgoInterval->invert = 1;
-		$anHourAgo = (clone $clock->now())->add($anHourAgoInterval);
+		$anHourAgo                 = (clone $clock->now())->add($anHourAgoInterval);
 
 		self::assertEquals(
 			Temporal::getRelativeDate($anHourAgo->format(DateTimeFormat::MYSQL), true, $clock),
-			sprintf($format, 1, DI::l10n()->t('hour'))
+			sprintf($format, 1, DI::l10n()->t('hour')),
 		);
 	}
 }

--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -16,7 +16,7 @@ use Friendica\DI;
 require_once 'view/theme/frio/php/Image.php';
 require_once 'view/theme/frio/php/scheme.php';
 
-function theme_post(AppHelper $appHelper)
+function theme_post(AppHelper $appHelper): void
 {
 	if (!DI::userSession()->getLocalUserId()) {
 		return;
@@ -63,7 +63,7 @@ function theme_post(AppHelper $appHelper)
 	}
 }
 
-function theme_admin_post()
+function theme_admin_post(): void
 {
 	if (!DI::userSession()->isSiteAdmin()) {
 		return;

--- a/view/theme/frio/php/frio_boot.php
+++ b/view/theme/frio/php/frio_boot.php
@@ -18,7 +18,7 @@ use Friendica\DI;
  *
  * @todo Check if this is really needed.
  */
-function load_page(AppHelper $appHelper)
+function load_page(AppHelper $appHelper): void
 {
 	if (isset($_GET['mode']) && ($_GET['mode'] == 'minimal')) {
 		require 'view/theme/frio/minimal.php';

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -37,7 +37,7 @@ const FRIO_CUSTOM_SCHEME  = '---';
  * This script can be included even when the app is in maintenance mode which requires us to avoid any config call
  */
 
-function frio_init(AppHelper $appHelper)
+function frio_init(AppHelper $appHelper): void
 {
 	global $frio;
 	$frio = 'view/theme/frio';
@@ -55,7 +55,7 @@ EOT;
 	}
 }
 
-function frio_install()
+function frio_install(): void
 {
 	Hook::register('prepare_body_final', 'view/theme/frio/theme.php', 'frio_item_photo_links');
 	Hook::register('item_photo_menu', 'view/theme/frio/theme.php', 'frio_item_photo_menu');
@@ -77,7 +77,7 @@ function frio_install()
  *
  * @param array $body_info The item and its html output
  */
-function frio_item_photo_links(&$body_info)
+function frio_item_photo_links(&$body_info): void
 {
 	$occurence = 0;
 	$p         = Plaintext::getBoundariesPosition($body_info['html'], '<a', '>');
@@ -112,7 +112,7 @@ function frio_item_photo_links(&$body_info)
  *
  * @param array $arr Contains item data and the original photo_menu
  */
-function frio_item_photo_menu(&$arr)
+function frio_item_photo_menu(&$arr): void
 {
 	foreach ($arr['menu'] as $k => $v) {
 		if (str_starts_with((string) $v, 'message/new/')) {
@@ -133,7 +133,7 @@ function frio_item_photo_menu(&$arr)
  *
  * @param array $args Contains contact data and the original photo_menu
  */
-function frio_contact_photo_menu(&$args)
+function frio_contact_photo_menu(&$args): void
 {
 	$cid = $args['contact']['id'];
 
@@ -181,7 +181,7 @@ function frio_contact_photo_menu(&$args)
  * @param array $nav_info The original nav info array: nav, banner, userinfo, sitelocation
  * @throws Exception
  */
-function frio_remote_nav(array &$nav_info)
+function frio_remote_nav(array &$nav_info): void
 {
 	if (DI::mode()->has(Mode::MAINTENANCEDISABLED)) {
 		// get the homelink from $_SESSION
@@ -231,7 +231,7 @@ function frio_remote_nav(array &$nav_info)
 	}
 }
 
-function frio_display_item(&$arr)
+function frio_display_item(&$arr): void
 {
 	// Add follow to the item menu
 	$followThread = [];

--- a/view/theme/vier/config.php
+++ b/view/theme/vier/config.php
@@ -44,7 +44,7 @@ function theme_content(AppHelper $appHelper)
 			$show_services, $show_friends, $show_lastusers);
 }
 
-function theme_post(AppHelper $appHelper)
+function theme_post(AppHelper $appHelper): void
 {
 	if (!DI::userSession()->getLocalUserId()) {
 		return;
@@ -91,7 +91,7 @@ function theme_admin(AppHelper $appHelper) {
 	return $o;
 }
 
-function theme_admin_post() {
+function theme_admin_post(): void {
 	if (isset($_POST['vier-settings-submit'])){
 		DI::config()->set('vier', 'style', $_POST['vier_style']);
 		DI::config()->set('vier', 'show_pages', $_POST['vier_show_pages']);

--- a/view/theme/vier/config.php
+++ b/view/theme/vier/config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (C) 2010-2024, the Friendica project
  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
@@ -33,15 +34,23 @@ function theme_content(AppHelper $appHelper)
 		$style = "plus";
 	}
 
-	$show_pages = get_vier_config('show_pages', true);
-	$show_profiles = get_vier_config('show_profiles', true);
-	$show_helpers = get_vier_config('show_helpers', true);
-	$show_services = get_vier_config('show_services', true);
-	$show_friends = get_vier_config('show_friends', true);
+	$show_pages     = get_vier_config('show_pages', true);
+	$show_profiles  = get_vier_config('show_profiles', true);
+	$show_helpers   = get_vier_config('show_helpers', true);
+	$show_services  = get_vier_config('show_services', true);
+	$show_friends   = get_vier_config('show_friends', true);
 	$show_lastusers = get_vier_config('show_lastusers', true);
 
-	return vier_form($appHelper,$style, $show_pages, $show_profiles, $show_helpers,
-			$show_services, $show_friends, $show_lastusers);
+	return vier_form(
+		$appHelper,
+		$style,
+		$show_pages,
+		$show_profiles,
+		$show_helpers,
+		$show_services,
+		$show_friends,
+		$show_lastusers,
+	);
 }
 
 function theme_post(AppHelper $appHelper): void
@@ -62,37 +71,49 @@ function theme_post(AppHelper $appHelper): void
 }
 
 
-function theme_admin(AppHelper $appHelper) {
+function theme_admin(AppHelper $appHelper)
+{
 
-	if (!function_exists('get_vier_config'))
+	if (!function_exists('get_vier_config')) {
 		return;
+	}
 
 	$style = DI::config()->get('vier', 'style');
 
 	$helperlist = DI::config()->get('vier', 'helperlist');
 
-	if ($helperlist == "")
+	if ($helperlist == "") {
 		$helperlist = "https://forum.friendi.ca/profile/helpers";
+	}
 
 	$t = Renderer::getMarkupTemplate("theme_admin_settings.tpl");
 	$o = Renderer::replaceMacros($t, [
 		'$helperlist' => ['vier_helperlist', DI::l10n()->t('Comma separated list of helper groups'), $helperlist, '', ''],
-		]);
+	]);
 
-	$show_pages = get_vier_config('show_pages', true, true);
-	$show_profiles = get_vier_config('show_profiles', true, true);
-	$show_helpers = get_vier_config('show_helpers', true, true);
-	$show_services = get_vier_config('show_services', true, true);
-	$show_friends = get_vier_config('show_friends', true, true);
+	$show_pages     = get_vier_config('show_pages', true, true);
+	$show_profiles  = get_vier_config('show_profiles', true, true);
+	$show_helpers   = get_vier_config('show_helpers', true, true);
+	$show_services  = get_vier_config('show_services', true, true);
+	$show_friends   = get_vier_config('show_friends', true, true);
 	$show_lastusers = get_vier_config('show_lastusers', true, true);
-	$o .= vier_form($appHelper,$style, $show_pages, $show_profiles, $show_helpers, $show_services,
-			$show_friends, $show_lastusers);
+	$o .= vier_form(
+		$appHelper,
+		$style,
+		$show_pages,
+		$show_profiles,
+		$show_helpers,
+		$show_services,
+		$show_friends,
+		$show_lastusers,
+	);
 
 	return $o;
 }
 
-function theme_admin_post(): void {
-	if (isset($_POST['vier-settings-submit'])){
+function theme_admin_post(): void
+{
+	if (isset($_POST['vier-settings-submit'])) {
 		DI::config()->set('vier', 'style', $_POST['vier_style']);
 		DI::config()->set('vier', 'show_pages', $_POST['vier_show_pages']);
 		DI::config()->set('vier', 'show_profiles', $_POST['vier_show_profiles']);
@@ -105,30 +126,31 @@ function theme_admin_post(): void {
 }
 
 /// @TODO $appHelper is no longer used
-function vier_form(AppHelper $appHelper, $style, $show_pages, $show_profiles, $show_helpers, $show_services, $show_friends, $show_lastusers) {
+function vier_form(AppHelper $appHelper, $style, $show_pages, $show_profiles, $show_helpers, $show_services, $show_friends, $show_lastusers)
+{
 	$styles = [
-		"breathe"=>"Breathe",
-		"netcolour"=>"Coloured Networks",
-		"dark"=>"Dark",
-		"flat"=>"Flat",
-		"plus"=>"Plus",
-		"plusminus"=>"Plus Minus",
-		"shadow"=>"Shadow"
+		"breathe"   => "Breathe",
+		"netcolour" => "Coloured Networks",
+		"dark"      => "Dark",
+		"flat"      => "Flat",
+		"plus"      => "Plus",
+		"plusminus" => "Plus Minus",
+		"shadow"    => "Shadow",
 	];
 
 	$show_or_not = ['0' => DI::l10n()->t("don't show"), '1' => DI::l10n()->t("show"),];
 
 	$t = Renderer::getMarkupTemplate("theme_settings.tpl");
 	$o = Renderer::replaceMacros($t, [
-		'$submit' => DI::l10n()->t('Submit'),
-		'$title' => DI::l10n()->t("Theme settings"),
-		'$style' => ['vier_style', DI::l10n()->t('Set style'), $style, '', $styles],
-		'$show_pages' => ['vier_show_pages', DI::l10n()->t('Community Pages'), $show_pages, '', $show_or_not],
-		'$show_profiles' => ['vier_show_profiles', DI::l10n()->t('Community Profiles'), $show_profiles, '', $show_or_not],
-		'$show_helpers' => ['vier_show_helpers', DI::l10n()->t('Help or @NewHere ?'), $show_helpers, '', $show_or_not],
-		'$show_services' => ['vier_show_services', DI::l10n()->t('Connect Services'), $show_services, '', $show_or_not],
-		'$show_friends' => ['vier_show_friends', DI::l10n()->t('Find Friends'), $show_friends, '', $show_or_not],
-		'$show_lastusers' => ['vier_show_lastusers', DI::l10n()->t('Last users'), $show_lastusers, '', $show_or_not]
+		'$submit'         => DI::l10n()->t('Submit'),
+		'$title'          => DI::l10n()->t("Theme settings"),
+		'$style'          => ['vier_style', DI::l10n()->t('Set style'), $style, '', $styles],
+		'$show_pages'     => ['vier_show_pages', DI::l10n()->t('Community Pages'), $show_pages, '', $show_or_not],
+		'$show_profiles'  => ['vier_show_profiles', DI::l10n()->t('Community Profiles'), $show_profiles, '', $show_or_not],
+		'$show_helpers'   => ['vier_show_helpers', DI::l10n()->t('Help or @NewHere ?'), $show_helpers, '', $show_or_not],
+		'$show_services'  => ['vier_show_services', DI::l10n()->t('Connect Services'), $show_services, '', $show_or_not],
+		'$show_friends'   => ['vier_show_friends', DI::l10n()->t('Find Friends'), $show_friends, '', $show_or_not],
+		'$show_lastusers' => ['vier_show_lastusers', DI::l10n()->t('Last users'), $show_lastusers, '', $show_or_not],
 	]);
 	return $o;
 }

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -28,7 +28,7 @@ use Friendica\Util\Strings;
  * This script can be included even when the app is in maintenance mode which requires us to avoid any config call
  */
 
-function vier_init()
+function vier_init(): void
 {
 	Renderer::setActiveTemplateEngine('smarty3');
 
@@ -115,7 +115,7 @@ function get_vier_config($key, $default = false, $admin = false)
 	return $default;
 }
 
-function vier_community_info()
+function vier_community_info(): void
 {
 	$show_pages     = get_vier_config("show_pages", 1);
 	$show_profiles  = get_vier_config("show_profiles", 1);


### PR DESCRIPTION
This PR improves the type coverage via Rector:

- AddClosureVoidReturnTypeWhereNoReturnRector
- AddFunctionVoidReturnTypeWhereNoReturnRector
- AddTestsVoidReturnTypeWhereNoReturnRector
- AddArrowFunctionReturnTypeRector