### PR TITLE
Fix broken Mention modal on other people's profiles

### DIFF
--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -87,7 +87,7 @@ class Conversation
 		]);
 
 		// If user is not owner do not insert jot composer, use Mention modal instead
-		if ($x['is_owner'] == false){
+		if ($x['is_owner'] == false) {
 			return $o;
 		}
 		

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -86,6 +86,11 @@ class Conversation
 			'$is_mobile'     => $this->mode->isMobile(),
 		]);
 
+		// If user is not owner do not insert jot composer, use Mention modal instead
+		if ($x['is_owner'] == false){
+			return $o;
+		}
+		
 		$jotplugins = $this->eventDispatcher->dispatch(
 			new HtmlFilterEvent(HtmlFilterEvent::JOT_TOOL, ''),
 		)->getHtml();

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -90,7 +90,7 @@ class Conversation
 		if ($x['is_owner'] == false) {
 			return $o;
 		}
-		
+
 		$jotplugins = $this->eventDispatcher->dispatch(
 			new HtmlFilterEvent(HtmlFilterEvent::JOT_TOOL, ''),
 		)->getHtml();

--- a/src/Content/Conversation.php
+++ b/src/Content/Conversation.php
@@ -87,7 +87,7 @@ class Conversation
 		]);
 
 		// If user is not owner do not insert jot composer, use Mention modal instead
-		if ($x['is_owner'] == false) {
+		if ($x['is_owner'] === false) {
 			return $o;
 		}
 


### PR DESCRIPTION
When viewing the Conversations tab on someone else's profile when you open the "Mention" modal compose window various things might be broken because there is already a jot compose modal at the top of the page, but it is normally hidden:
<img width="952" height="879" alt="too_many_modals" src="https://github.com/user-attachments/assets/acb6ea71-fae0-46b2-85b3-9c8ecd82200a" />

(Image shows the Mention Modal with the already present embedded Compose underneath revealed with `display: block;`)

Any jot plugins or other add-ons that target elements of the composer by a unique ID will target the elements of the hidden one because it is first in the code (as the Mention modal code gets appended when you open it). Another issue is if any add-ons related to the jot compose window load a script or have one inline it can cause runtime errors that break other things.

The one little edit in this PR prevents that extra jot compose modal from being written in above the first post.
