### PR TITLE
Make Mention compose editor open in separate page if user prefers that

### DIFF
--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -131,7 +131,7 @@ class VCard
 			'$unfollow_link'       => $unfollow_link,
 			'$wallmessage'         => DI::l10n()->t('Message'),
 			'$wallmessage_link'    => $wallmessage_link,
-			'$always_open_compose' => $always_open_compose,						   
+			'$always_open_compose' => $always_open_compose,
 			'$mention'             => $mention_label,
 			'$mention_link'        => $mention_link,
 			'$showgroup'           => DI::l10n()->t('Group posts'),

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -99,7 +99,7 @@ class VCard
 				$wallmessage_link = 'message/new/' . $id;
 			}
 
-			$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', true);
+			$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', false);
 
 			if ($contact['contact-type'] == Contact::TYPE_COMMUNITY) {
 				if (!$hide_mention) {

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -62,6 +62,7 @@ class VCard
 		$showgroup_link   = '';
 
 		$photo = Contact::getPhoto($contact);
+
 		$always_open_compose = false;
 
 		if (DI::userSession()->getLocalUserId()) {
@@ -98,7 +99,7 @@ class VCard
 				$wallmessage_link = 'message/new/' . $id;
 			}
 
-			$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose','1');
+			$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', '1');
 
 			if ($contact['contact-type'] == Contact::TYPE_COMMUNITY) {
 				if (!$hide_mention) {
@@ -113,28 +114,28 @@ class VCard
 		}
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('widget/vcard.tpl'), [
-			'$contact'          => $contact,
-			'$photo'            => $photo,
-			'$url'              => Contact::magicLinkByContact($contact, $contact_url),
-			'$about'            => BBCode::convertForUriId($contact['uri-id'] ?? 0, $contact['about'] ?? ''),
-			'$xmpp'             => DI::l10n()->t('XMPP:'),
-			'$matrix'           => DI::l10n()->t('Matrix:'),
-			'$location'         => DI::l10n()->t('Location:'),
-			'$network_link'     => $network_link,
-			'$network_svg'      => $network_svg,
-			'$network'          => DI::l10n()->t('Network:'),
-			'$account_type'     => Contact::getAccountType($contact['contact-type']),
-			'$follow'           => DI::l10n()->t('Follow'),
-			'$follow_link'      => $follow_link,
-			'$unfollow'         => DI::l10n()->t('Unfollow'),
-			'$unfollow_link'    => $unfollow_link,
-			'$wallmessage'      => DI::l10n()->t('Message'),
-			'$wallmessage_link' => $wallmessage_link,
+			'$contact'             => $contact,
+			'$photo'               => $photo,
+			'$url'                 => Contact::magicLinkByContact($contact, $contact_url),
+			'$about'               => BBCode::convertForUriId($contact['uri-id'] ?? 0, $contact['about'] ?? ''),
+			'$xmpp'                => DI::l10n()->t('XMPP:'),
+			'$matrix'              => DI::l10n()->t('Matrix:'),
+			'$location'            => DI::l10n()->t('Location:'),
+			'$network_link'        => $network_link,
+			'$network_svg'         => $network_svg,
+			'$network'             => DI::l10n()->t('Network:'),
+			'$account_type'        => Contact::getAccountType($contact['contact-type']),
+			'$follow'              => DI::l10n()->t('Follow'),
+			'$follow_link'         => $follow_link,
+			'$unfollow'            => DI::l10n()->t('Unfollow'),
+			'$unfollow_link'       => $unfollow_link,
+			'$wallmessage'         => DI::l10n()->t('Message'),
+			'$wallmessage_link'    => $wallmessage_link,
 			'$always_open_compose' => $always_open_compose,						   
-			'$mention'          => $mention_label,
-			'$mention_link'     => $mention_link,
-			'$showgroup'        => DI::l10n()->t('Group posts'),
-			'$showgroup_link'   => $showgroup_link,
+			'$mention'             => $mention_label,
+			'$mention_link'        => $mention_link,
+			'$showgroup'           => DI::l10n()->t('Group posts'),
+			'$showgroup_link'      => $showgroup_link,
 		]);
 	}
 }

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -62,6 +62,7 @@ class VCard
 		$showgroup_link   = '';
 
 		$photo = Contact::getPhoto($contact);
+		$always_open_compose = false;
 
 		if (DI::userSession()->getLocalUserId()) {
 			if (Contact\User::isIsBlocked($contact['id'], DI::userSession()->getLocalUserId())) {
@@ -97,6 +98,8 @@ class VCard
 				$wallmessage_link = 'message/new/' . $id;
 			}
 
+			$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose','1');
+
 			if ($contact['contact-type'] == Contact::TYPE_COMMUNITY) {
 				if (!$hide_mention) {
 					$mention_label = DI::l10n()->t('Post to group');
@@ -127,6 +130,7 @@ class VCard
 			'$unfollow_link'    => $unfollow_link,
 			'$wallmessage'      => DI::l10n()->t('Message'),
 			'$wallmessage_link' => $wallmessage_link,
+			'$always_open_compose' => $always_open_compose,						   
 			'$mention'          => $mention_label,
 			'$mention_link'     => $mention_link,
 			'$showgroup'        => DI::l10n()->t('Group posts'),

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -99,7 +99,7 @@ class VCard
 				$wallmessage_link = 'message/new/' . $id;
 			}
 
-			$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', '1');
+			$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', true);
 
 			if ($contact['contact-type'] == Contact::TYPE_COMMUNITY) {
 				if (!$hide_mention) {

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -442,7 +442,7 @@ class Profile
 			DI::logger()->warning('Missing hidewall key in profile array', ['profile' => $profile]);
 		}
 
-		$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', true);
+		$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', false);
 
 		if ($profile['account-type'] == Contact::TYPE_COMMUNITY) {
 			$mention_label = DI::l10n()->t('Post to group');

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -442,7 +442,7 @@ class Profile
 			DI::logger()->warning('Missing hidewall key in profile array', ['profile' => $profile]);
 		}
 
-		$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', '1');
+		$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', true);
 
 		if ($profile['account-type'] == Contact::TYPE_COMMUNITY) {
 			$mention_label = DI::l10n()->t('Post to group');

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -442,6 +442,8 @@ class Profile
 			DI::logger()->warning('Missing hidewall key in profile array', ['profile' => $profile]);
 		}
 
+		$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose','1');
+
 		if ($profile['account-type'] == Contact::TYPE_COMMUNITY) {
 			$mention_label = DI::l10n()->t('Post to group');
 			$mention_url   = 'compose/0?body=!' . $profile['addr'];
@@ -491,6 +493,7 @@ class Profile
 			'$updated'                     => $updated,
 			'$diaspora'                    => $diaspora,
 			'$contact_block'               => $contact_block,
+			'$always_open_compose'         => $always_open_compose,
 			'$mention_label'               => $mention_label,
 			'$mention_url'                 => $mention_url,
 			'$network_label'               => $network_label,

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -442,7 +442,7 @@ class Profile
 			DI::logger()->warning('Missing hidewall key in profile array', ['profile' => $profile]);
 		}
 
-		$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose','1');
+		$always_open_compose = DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', '1');
 
 		if ($profile['account-type'] == Contact::TYPE_COMMUNITY) {
 			$mention_label = DI::l10n()->t('Post to group');

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -83,7 +83,7 @@
 				{{/if}}
 				{{if $profile.addr}}
 					<div id="jotOpen" class="pull-right">
-						<button type="button" id="mention-link" class="action-button btn btn-labeled btn-primary" onclick="openWallMessage('{{$mention_url}}')">
+						<button type="button" id="mention-link" class="action-button btn btn-labeled btn-primary" onclick="{{if $always_open_compose}}window.location.href='{{$mention_url}}'{{else}}openWallMessage('{{$mention_url}}'){{/if}}">
 							<i class="ri ri-lg ri-pencil-line"></i>
 							<span>{{$mention_label}}</span>
 						</button>

--- a/view/theme/frio/templates/widget/vcard.tpl
+++ b/view/theme/frio/templates/widget/vcard.tpl
@@ -66,7 +66,7 @@
 			{{/if}}
 			{{if $mention_link}}
 				<div id="jotOpen" class="pull-right">
-					<button type="button" id="mention-link" class="action-button btn btn-labeled btn-primary{{if !$always_open_compose}} modal-open{{/if}}" onclick="openWallMessage('{{$mention_link}}')" aria-label="{{$mention}}" oncontextmenu="openWallMessage('compose/0')">
+					<button type="button" id="mention-link" class="action-button btn btn-labeled btn-primary{{if !$always_open_compose}} modal-open{{/if}}" onclick="{{if $always_open_compose}}window.location.href='{{$mention_link}}'{{else}}openWallMessage('{{$mention_link}}'){{/if}}" aria-label="{{$mention}}" oncontextmenu="openWallMessage('compose/0')">
 						<i class="ri ri-lg ri-pencil-line"></i>
 						<span>{{$mention}}</span>
 					</button>


### PR DESCRIPTION
If you clicked on the "Mention" button on someone else's profile it would always open in a floating modal even if you had checked the box in the Frio theme preferences to "Always open compose page."

This PR fixes that by changing the function of the "Mention" button based on that user preference setting.

Some of the code was already there, including a check for `$always_open_compose` in one of the Vcard templates, but the PHP files didn't check for that preference nor did they send that variable to the templates. So that's what I added.

I think this fully addresses the concern in Issue https://github.com/friendica/friendica/issues/13523