### PR TITLE
Tags: Fix hovercard text color, undo most tag cloud changes

### DIFF
--- a/view/templates/widget/filter.tpl
+++ b/view/templates/widget/filter.tpl
@@ -18,7 +18,7 @@
 	{{else}} {{* fallback to type="file" *}}
 		{{assign var="icon" value="ri-folder-line"}}
 	{{/if}}
-	<span id="{{$type}}-sidebar-inflated" class="widget inflated fakelink">
+	<span id="{{$type}}-sidebar-inflated" class="widget inflated">
 		<button class="fakelink" onclick="openCloseWidget('{{$type}}-sidebar', '{{$type}}-sidebar-inflated');" aria-expanded="false">
 			<h3>
 				<i class="ri {{$icon}}" aria-hidden="true"></i>

--- a/view/templates/widget/tagcloud.tpl
+++ b/view/templates/widget/tagcloud.tpl
@@ -21,9 +21,9 @@
 			</h3>
 		</button>
 
-		<div class="tag-cloud tags">
+		<div class="tag-cloud">
 			{{foreach $tags as $tag}}
-				<a href="{{$tag.url}}" class="tag hashtag tag{{$tag.level}} label border border-default">#{{$tag.name}}</a>
+				<a href="{{$tag.url}}" class="tag{{$tag.level}}">#{{$tag.name}}</a>
 			{{/foreach}}
 		</div>
 		<div class="tagblock-widget-end clear"></div>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2213,6 +2213,10 @@ code > .hl-main {
 	padding: 0; /* The padding should be on the link instead, so it's clickable */
 }
 
+.hovercard .tag {
+	color: $font_color;
+}
+
 /* Some tags are currently anchors while others are spans containing anchors - ideally they were all just anchors */
 
 /* Use somewhat darker colours for some of these to work better against white */


### PR DESCRIPTION
A small update to #15883 fixing hovercard text color, and generally undoing the tag cloud changes as I'm not sure they work too well.