### PR TITLE
Simplify widget templates, always show widget actions

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -443,15 +443,10 @@ td.federation-data {
   max-height: 80px;
 }
 
-/* group list widget */
-.group-list-img {
+.sidebar-widget-list img {
   height: 20px;
   width: 20px;
   vertical-align: middle;
-}
-
-#group-widget-collapse {
-  opacity: 0.3;
 }
 
 /* help widget */
@@ -469,8 +464,11 @@ aside .help-aside-wrapper h1 {
   background-color: #f9a3a3;
   color: #ffffff;
 }
+.widget-show-more {
+  opacity: 0.3;
+}
 
-#group-widget-collapse:hover {
+.widget-show-more:hover {
   opacity: 1.0;
 }
 

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -37,40 +37,34 @@ function _resizeIframe(obj, desth) {
 	setTimeout(_resizeIframe, 100, obj, ch);
 }
 
-function initWidget(inflated, deflated) {
-	var elInf = document.getElementById(inflated);
-	var elDef = document.getElementById(deflated);
+function initWidget(name) {
+	const widget = document.getElementById(name)
+	const list = widget.getElementsByClassName("sidebar-widget-list")[0];
+	const btn = widget.getElementsByClassName("widget-btn")[0]
 
-	if (!elInf || !elDef) {
-		return;
-	}
-	if (localStorage.getItem(window.location.pathname.split("/")[1] + ":" + inflated) != "none") {
-		elInf.style.display = "block";
-		elDef.style.display = "none";
+	if (localStorage.getItem(window.location.pathname.split("/")[1] + ":" + name) != "block") {
+		list.style.display = "none";
+		btn.setAttribute("aria-expanded", false)
 	} else {
-		elInf.style.display = "none";
-		elDef.style.display = "block";
+		list.style.display = "block";
+		btn.setAttribute("aria-expanded", true)
 	}
 }
 
-function openCloseWidget(inflated, deflated) {
-	var elInf = document.getElementById(inflated);
-	var elDef = document.getElementById(deflated);
+/* Consider switching to Bootstrap collapses or native "details" element to handle showing/hiding */
+function openCloseWidget(name) {
+	widget = document.getElementById(name)
+	const list = widget.getElementsByClassName("sidebar-widget-list")[0];
+	const btn = event.currentTarget
 
-	if (!elInf || !elDef) {
-		return;
-	}
+	btn.ariaExpanded = btn.ariaExpanded !== 'true';
 
-	if (window.getComputedStyle(elInf).display === "none") {
-		elInf.style.display = "block";
-		elDef.style.display = "none";
-		localStorage.setItem(window.location.pathname.split("/")[1] + ":" + inflated, "block");
-		elInf.querySelector("button").focus();
+	if (window.getComputedStyle(list).display === "block") {
+		list.style.display = "none";
+		localStorage.setItem(window.location.pathname.split("/")[1] + ":" + name, "none");
 	} else {
-		elInf.style.display = "none";
-		elDef.style.display = "block";
-		localStorage.setItem(window.location.pathname.split("/")[1] + ":" + inflated, "none");
-		elDef.querySelector("button").focus();
+		list.style.display = "block";
+		localStorage.setItem(window.location.pathname.split("/")[1] + ":" + name, "block");
 	}
 }
 

--- a/view/templates/circle_side.tpl
+++ b/view/templates/circle_side.tpl
@@ -4,57 +4,49 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<nav>
-	<span id="circle-sidebar-inflated" class="widget inflated fakelink">
-		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
-			<h3>
-				<i class="ri ri-bubble-chart-line" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-		</button>
-	</span>
-	<div class="widget" id="circle-sidebar">
-		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
-			<h3>
-				<i class="ri ri-bubble-chart-line" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-		</button>
+<!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
+{{* Overridden by Frio *}}
+<nav id="circle-sidebar" class="widget">
+	<button class="widget-btn, fakelink" onclick="openCloseWidget('circle-sidebar');" aria-expanded="false">
+		<h3>
+			<i class="ri ri-bubble-chart-line" aria-hidden="true"></i>
+			{{$title}}
+		</h3>
+	</button>
 
-		<div id="sidebar-circle-list">
-			<ul id="sidebar-circle-ul">
-				{{foreach $circles as $circle}}
-					<li class="sidebar-circle-li circle-{{$circle.id}}">
-						{{if ! $new_circle}}<span class="notify badge pull-right"></span>{{/if}}
-						{{if $circle.cid}}
-							<input type="checkbox" class="{{if $circle.selected}}ticked{{else}}unticked {{/if}} action" onclick="return contactCircleChangeMember(this, '{{$circle.id}}','{{$circle.cid}}');" {{if $circle.ismember}}checked="checked" {{/if}} />
-						{{/if}}
-						{{if $circle.edit}}
-							<a class="circlesideedit" href="{{$circle.edit.href}}" title="{{$edittext}}">
-								<span id="edit-sidebar-circle-element-{{$circle.id}}" class="circle-edit-icon iconspacer small-pencil"><span class="sr-only">{{$edittext}}</span></span>
-							</a>
-						{{/if}}
-						<a id="sidebar-circle-element-{{$circle.id}}" class="sidebar-circle-element {{if $circle.selected}}circle-selected{{/if}}" href="{{$circle.href}}">{{$circle.text}}</a>
-					</li>
-				{{/foreach}}
-			</ul>
-		</div>
-
-		{{if $new_circle}}
-			<div id="sidebar-new-circle">
-				<a onclick="javascript:$('#circle-new-form').fadeIn('fast');return false;">{{$createtext}}</a>
-				<form id="circle-new-form" action="circle/new" method="post" style="display:none;">
-					<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
-					<input name="circle_name" id="id_circle_name" placeholder="{{$create_circle}}">
-				</form>
-			</div>
-		{{else}}
-			<div id="sidebar-edit-circles"><a href="{{$circle_page}}">{{$edit_circles_text}}</a></div>
-		{{/if}}
-
-		{{if $uncircled}}<div id="sidebar-uncircled"><a class="{{if $uncircled_selected}}circle-selected{{/if}}" href="nocircle">{{$uncircled}}</a></div>{{/if}}
+	<div id="sidebar-circle-list" class="sidebar-widget-list">
+		<ul id="sidebar-circle-ul">
+			{{foreach $circles as $circle}}
+				<li class="sidebar-circle-li circle-{{$circle.id}}">
+					{{if ! $new_circle}}<span class="notify badge pull-right"></span>{{/if}}
+					{{if $circle.cid}}
+						<input type="checkbox" class="{{if $circle.selected}}ticked{{else}}unticked {{/if}} action" onclick="return contactCircleChangeMember(this, '{{$circle.id}}','{{$circle.cid}}');" {{if $circle.ismember}}checked="checked" {{/if}} />
+					{{/if}}
+					{{if $circle.edit}}
+						<a class="circlesideedit" href="{{$circle.edit.href}}" title="{{$edittext}}">
+							<span id="edit-sidebar-circle-element-{{$circle.id}}" class="circle-edit-icon iconspacer small-pencil"><span class="sr-only">{{$edittext}}</span></span>
+						</a>
+					{{/if}}
+					<a id="sidebar-circle-element-{{$circle.id}}" class="sidebar-circle-element {{if $circle.selected}}circle-selected{{/if}}" href="{{$circle.href}}">{{$circle.text}}</a>
+				</li>
+			{{/foreach}}
+		</ul>
 	</div>
+
+	{{if $new_circle}}
+		<div id="sidebar-new-circle">
+			<a onclick="javascript:$('#circle-new-form').fadeIn('fast');return false;">{{$createtext}}</a>
+			<form id="circle-new-form" action="circle/new" method="post" style="display:none;">
+				<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+				<input name="circle_name" id="id_circle_name" placeholder="{{$create_circle}}">
+			</form>
+		</div>
+	{{else}}
+		<div id="sidebar-edit-circles"><a href="{{$circle_page}}">{{$edit_circles_text}}</a></div>
+	{{/if}}
+
+	{{if $uncircled}}<div id="sidebar-uncircled"><a class="{{if $uncircled_selected}}circle-selected{{/if}}" href="nocircle">{{$uncircled}}</a></div>{{/if}}
 </nav>
 <script>
-	initWidget('circle-sidebar', 'circle-sidebar-inflated');
+	initWidget('circle-sidebar');
 </script>

--- a/view/templates/widget/community_sharer.tpl
+++ b/view/templates/widget/community_sharer.tpl
@@ -4,28 +4,19 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<nav>
-	<span id="sidebar-community-no-sharer-inflated" class="widget inflated fakelink">
-		<button class="fakelink" onclick="openCloseWidget('sidebar-community-no-sharer', 'sidebar-community-no-sharer-inflated');" aria-expanded="false">
-			<h3>
-				<i class="ri ri-user-line" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-		</button>
-	</span>
-	<div id="sidebar-community-no-sharer" class="widget">
-		<button class="fakelink" onclick="openCloseWidget('sidebar-community-no-sharer', 'sidebar-community-no-sharer-inflated');" aria-expanded="true">
-			<h3>
-				<i class="ri ri-user-line" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-		</button>
-		<ul class="sidebar-community-no-sharer-ul">
-			<li class="sidebar-community-no-sharer-li{{if !$no_sharer}} selected{{/if}}"><a href="{{$base}}/{{$path_all}}">{{$all}}</a></li>
-			<li class="sidebar-community-no-sharer-li{{if $no_sharer}} selected{{/if}}"><a href="{{$base}}/{{$path_no_sharer}}">{{$no_sharer_label}}</a></li>
-		</ul>
-	</div>
+<!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
+<nav id="community-no-sharer-sidebar" class="widget fakelink">
+	<button class="widget-btn fakelink" onclick="openCloseWidget('community-no-sharer-sidebar');" aria-expanded="false">
+		<h3>
+			<i class="ri ri-user-line" aria-hidden="true"></i>
+			{{$title}}
+		</h3>
+	</button>
+	<ul class="sidebar-community-no-sharer-ul sidebar-widget-list">
+		<li class="sidebar-community-no-sharer-li{{if !$no_sharer}} selected{{/if}}"><a href="{{$base}}/{{$path_all}}">{{$all}}</a></li>
+		<li class="sidebar-community-no-sharer-li{{if $no_sharer}} selected{{/if}}"><a href="{{$base}}/{{$path_no_sharer}}">{{$no_sharer_label}}</a></li>
+	</ul>
 </nav>
 <script>
-	initWidget('sidebar-community-no-sharer', 'sidebar-community-no-sharer-inflated');
+	initWidget('community-no-sharer-sidebar');
 </script>

--- a/view/templates/widget/filter.tpl
+++ b/view/templates/widget/filter.tpl
@@ -4,7 +4,8 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<nav>
+<!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
+<nav id='{{$type}}-sidebar' class="widget">
 	{{if $type == "channel"}}
 		{{assign var="icon" value="ri-broadcast-line"}}
 	{{else if $type == "accounttype"}}
@@ -18,34 +19,29 @@
 	{{else}} {{* fallback to type="file" *}}
 		{{assign var="icon" value="ri-folder-line"}}
 	{{/if}}
-	<span id="{{$type}}-sidebar-inflated" class="widget inflated">
-		<button class="fakelink" onclick="openCloseWidget('{{$type}}-sidebar', '{{$type}}-sidebar-inflated');" aria-expanded="false">
+	<div>
+		<!-- TODO: Modify aria-expanded and set it to true/false in JS? -->
+		<button class="widget-btn fakelink" onclick="openCloseWidget('{{$type}}-sidebar');" aria-expanded="false">
 			<h3>
 				<i class="ri {{$icon}}" aria-hidden="true"></i>
 				{{$title}}
 			</h3>
 		</button>
-	</span>
-	<div id="{{$type}}-sidebar" class="widget">
-		<button class="fakelink" onclick="openCloseWidget('{{$type}}-sidebar', '{{$type}}-sidebar-inflated');" aria-expanded="true">
-			<h3>
-				<i class="ri {{$icon}}" aria-hidden="true"></i>
-			{{$title}}
-			</h3>
-		</button>
-		<div id="{{$type}}-desc">{{$desc nofilter}}</div>
-		<ul class="{{$type}}-ul">
-			{{if $all_label}}
-				<li {{if !is_null($selected) && !$selected}}class="selected" {{/if}}><a href="{{$base}}" class="{{$type}}-link{{if !$selected}} {{$type}}-selected{{/if}} {{$type}}-all">{{$all_label}}</a>
-				</li>
-			{{/if}}
-			{{foreach $options as $option}}
-				<li {{if $selected == $option.ref}}class="selected" {{/if}}><a href="{{$base}}{{$type}}={{$option.ref}}" class="{{$type}}-link{{if $selected == $option.ref}} {{$type}}-selected{{/if}}">{{$option.name}}</a>
-				</li>
-			{{/foreach}}
-		</ul>
+		<div id="{{$type}}-sidebar" class="sidebar-widget-list">
+			<div id="{{$type}}-desc">{{$desc nofilter}}</div>
+			<ul class="{{$type}}-ul">
+				{{if $all_label}}
+					<li {{if !is_null($selected) && !$selected}}class="selected" {{/if}}><a href="{{$base}}" class="{{$type}}-link{{if !$selected}} {{$type}}-selected{{/if}} {{$type}}-all">{{$all_label}}</a>
+					</li>
+				{{/if}}
+				{{foreach $options as $option}}
+					<li {{if $selected == $option.ref}}class="selected" {{/if}}><a href="{{$base}}{{$type}}={{$option.ref}}" class="{{$type}}-link{{if $selected == $option.ref}} {{$type}}-selected{{/if}}">{{$option.name}}</a>
+					</li>
+				{{/foreach}}
+			</ul>
+		</div>
 	</div>
 </nav>
 <script>
-	initWidget('{{$type}}-sidebar', '{{$type}}-sidebar-inflated');
+	initWidget('{{$type}}-sidebar');
 </script>

--- a/view/templates/widget/group_list.tpl
+++ b/view/templates/widget/group_list.tpl
@@ -4,7 +4,9 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
+<!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
 <script>
+	/* TODO: Consider making a reusable version of this in e.g. main.js instead */
 	function showHideGroupList() {
 		if ($("li[id^='group-widget-entry-extended-']").is(':visible')) {
 			$("li[id^='group-widget-entry-extended-']").hide();
@@ -16,67 +18,55 @@
 		}
 	}
 </script>
-<nav id="group-list-sidebar-frame">
-	<span id="group-list-sidebar-inflated" class="widget inflated fakelink">
-		<button class="fakelink" onclick="openCloseWidget('group-list-sidebar', 'group-list-sidebar-inflated');"
-			aria-expanded="false">
-			<h3>
-				<i class="ri ri-discuss-line" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-		</button>
-	</span>
-	<div id="group-list-sidebar" class="widget">
-		<div id="sidebar-group-header" class="sidebar-widget-header">
-			<button class="fakelink" onclick="openCloseWidget('group-list-sidebar', 'group-list-sidebar-inflated');" aria-expanded="true">
-				<h3>
-					<i class="ri ri-discuss-line" aria-hidden="true"></i>
-					{{$title}}
-				</h3>
-			</button>
-			<a class="pull-right widget-action widget-action-top faded-icon" id="sidebar-new-group"
-				href="{{$new_group_page}}" data-toggle="tooltip" title="{{$create_new_group}}">
-				<i class="ri ri-add-line" aria-hidden="true"></i>
-			</a>
-			{{if $addon_group_directory_enabled}}
-				<a class="pull-right widget-action widget-action-top faded-icon" id="sidebar-group-directory"
-					href="/groupdirectory" data-toggle="tooltip" title="{{$visit_groupdirectory}}">
-					<i class="ri ri-search-line" aria-hidden="true"></i>
-				</a>
-			{{/if}}
-		</div>
-		<div id="sidebar-group-list" class="sidebar-widget-list">
-			{{* The list of available groups *}}
-			<ul id="group-list-sidebar-ul">
-				{{foreach $groups as $group}}
-					{{if $group.id <= $visible_groups}}
-						<li class="group-widget-entry group-{{$group.cid}}" id="group-widget-entry-{{$group.id}}">
-							<span class="notify badge pull-right"></span>
-							<a href="{{$group.external_url}}" title="{{$group.link_desc}}" class="label sparkle" target="_blank" rel="noopener noreferrer">
-								<img class="group-list-img" src="{{$group.micro}}" alt="{{$group.link_desc}}" />
-							</a>
-							<a class="group-widget-link" id="group-widget-link-{{$group.id}}" href="{{$group.url}}">{{$group.name}}</a>
-						</li>
-					{{/if}}
+<nav id="group-sidebar" class="widget">
+	<button class="widget-btn fakelink" onclick="openCloseWidget('group-sidebar');" aria-expanded="false">
+		<h3>
+			<i class="ri ri-discuss-line" aria-hidden="true"></i>
+			{{$title}}
+		</h3>
+	</button>
+	<a class="pull-right widget-action widget-action-top faded-icon" id="sidebar-new-group"
+		href="{{$new_group_page}}" data-toggle="tooltip" title="{{$create_new_group}}">
+		<i class="ri ri-add-line" aria-hidden="true"></i>
+	</a>
+	{{if $addon_group_directory_enabled}}
+		<a class="pull-right widget-action widget-action-top faded-icon" id="sidebar-group-directory"
+			href="/groupdirectory" data-toggle="tooltip" title="{{$visit_groupdirectory}}">
+			<i class="ri ri-search-line" aria-hidden="true"></i>
+		</a>
+	{{/if}}
 
-					{{if $group.id > $visible_groups}}
-						<li class="group-widget-entry group-{{$group.cid}}" id="group-widget-entry-extended-{{$group.id}}" style="display: none;">
-							<span class="notify badge pull-right"></span>
-							<a href="{{$group.external_url}}" title="{{$group.link_desc}}" class="label sparkle" target="_blank" rel="noopener noreferrer">
-								<img class="group-list-img" src="{{$group.micro}}" alt="{{$group.link_desc}}" />
-							</a>
-							<a class="group-widget-link" id="group-widget-link-{{$group.id}}" href="{{$group.url}}">{{$group.name}}</a>
-						</li>
-					{{/if}}
-				{{/foreach}}
-
-				{{if $total > $visible_groups }}
-					<li onclick="showHideGroupList(); return false;" id="group-widget-collapse" class="group-widget-link fakelink tool">{{$showmore}}</li>
+	<div id="group-list-sidebar" class="sidebar-widget-list">
+		{{* The list of available groups *}}
+		<ul id="group-list-sidebar-ul">
+			{{foreach $groups as $group}}
+				{{if $group.id <= $visible_groups}}
+					<li class="group-widget-entry group-{{$group.cid}}" id="group-widget-entry-{{$group.id}}">
+						<span class="notify badge pull-right"></span>
+						<a href="{{$group.external_url}}" title="{{$group.link_desc}}" class="label sparkle" target="_blank" rel="noopener noreferrer">
+							<img src="{{$group.micro}}" alt="{{$group.link_desc}}" />
+						</a>
+						<a class="group-widget-link" id="group-widget-link-{{$group.id}}" href="{{$group.url}}">{{$group.name}}</a>
+					</li>
 				{{/if}}
-			</ul>
-		</div>
+
+				{{if $group.id > $visible_groups}}
+					<li class="group-widget-entry group-{{$group.cid}}" id="group-widget-entry-extended-{{$group.id}}" style="display: none;">
+						<span class="notify badge pull-right"></span>
+						<a href="{{$group.external_url}}" title="{{$group.link_desc}}" class="label sparkle" target="_blank" rel="noopener noreferrer">
+							<img src="{{$group.micro}}" alt="{{$group.link_desc}}" />
+						</a>
+						<a class="group-widget-link" id="group-widget-link-{{$group.id}}" href="{{$group.url}}">{{$group.name}}</a>
+					</li>
+				{{/if}}
+			{{/foreach}}
+
+			{{if $total > $visible_groups }}
+				<li onclick="showHideGroupList(); return false;" id="group-widget-collapse" class="group-widget-link widget-show-more fakelink tool">{{$showmore}}</li>
+			{{/if}}
+		</ul>
 	</div>
 </nav>
 <script>
-	initWidget('group-list-sidebar', 'group-list-sidebar-inflated');
+	initWidget('group-sidebar');
 </script>

--- a/view/templates/widget/posted_date.tpl
+++ b/view/templates/widget/posted_date.tpl
@@ -4,6 +4,7 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
+<!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
 <script>
 	function showHideDates() {
 		if ($('#posted-date-selector-drop').is(':visible')) {
@@ -17,22 +18,14 @@
 	}
 </script>
 
-<nav>
-	<span id="datebrowse-sidebar-inflated" class="widget inflated fakelink">
-		<button class="fakelink" onclick="openCloseWidget('datebrowse-sidebar', 'datebrowse-sidebar-inflated');" aria-expanded="false">
-			<h3>
-				<i class="ri ri-archive-line" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-		</button>
-	</span>
-	<div id="datebrowse-sidebar" class="widget">
-		<button class="fakelink" onclick="openCloseWidget('datebrowse-sidebar', 'datebrowse-sidebar-inflated');" aria-expanded="false">
-			<h3>
-				<i class="ri ri-archive-line" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-		</button>
+<nav id="datebrowse-sidebar" class="widget">
+	<button class="widget-btn fakelink" onclick="openCloseWidget('datebrowse-sidebar');" aria-expanded="false">
+		<h3>
+			<i class="ri ri-archive-line" aria-hidden="true"></i>
+			{{$title}}
+		</h3>
+	</button>
+	<div class="sidebar-widget-list">
 		<ul id="posted-date-selector" class="datebrowse-ul">
 			{{foreach $dates as $y => $arr}}
 
@@ -70,5 +63,5 @@
 	</div>
 </nav>
 <script>
-	initWidget('datebrowse-sidebar', 'datebrowse-sidebar-inflated');
+	initWidget('datebrowse-sidebar');
 </script>

--- a/view/templates/widget/saved_searches.tpl
+++ b/view/templates/widget/saved_searches.tpl
@@ -4,35 +4,26 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<nav>
-	<span id="saved-search-list-inflated" class="widget inflated fakelink">
-		<button class="fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');" aria-expanded="false">
-			<h3>
-				<i class="ri ri-search-line" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-		</button>
-	</span>
-	<div class="widget" id="saved-search-list">
-		<button class="fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');" aria-expanded="true">
-			<h3 id="search">
-				<i class="ri ri-search-line" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-		</button>
-		{{$searchbox nofilter}}
+<!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
+{{* Overridden by Frio *}}
+<nav id="saved-search-sidebar" class="widget">
+	<button class="widget-btn fakelink" onclick="openCloseWidget('saved-search-sidebar');" aria-expanded="false">
+		<h3 id="search">
+			<i class="ri ri-search-line" aria-hidden="true"></i>
+			{{$title}}
+		</h3>
+	</button>
+	{{$searchbox nofilter}}
 
-		<ul id="saved-search-ul">
-			{{foreach $saved as $search}}
-				<li class="saved-search-li clear">
-					<a href="search/saved/remove?term={{$search.encodedterm}}&amp;return_url={{$return_url}}" title="{{$search.delete}}" onclick="return confirmDelete();" id="drop-saved-search-term-{{$search.id}}" class="iconspacer savedsearchdrop"></a>
-					<a href="{{$search.searchpath}}" id="saved-search-term-{{$search.id}}" class="savedsearchterm">{{$search.term}}</a>
-				</li>
-			{{/foreach}}
-		</ul>
-		<div class="clear"></div>
-	</div>
+	<ul id="saved-search-list" class="sidebar-widget-list">
+		{{foreach $saved as $search}}
+			<li class="saved-search-li clear">
+				<a href="search/saved/remove?term={{$search.encodedterm}}&amp;return_url={{$return_url}}" title="{{$search.delete}}" onclick="return confirmDelete();" id="drop-saved-search-term-{{$search.id}}" class="iconspacer savedsearchdrop"></a>
+				<a href="{{$search.searchpath}}" id="saved-search-term-{{$search.id}}" class="savedsearchterm">{{$search.term}}</a>
+			</li>
+		{{/foreach}}
+	</ul>
 </nav>
 <script>
-	initWidget('saved-search-list', 'saved-search-list-inflated');
+	initWidget('saved-search-sidebar');
 </script>

--- a/view/templates/widget/tagcloud.tpl
+++ b/view/templates/widget/tagcloud.tpl
@@ -4,31 +4,22 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<nav>
-	<span id="tagblock-inflated" class="widget inflated fakelink">
-		<button class="fakelink" onclick="openCloseWidget('tagblock', 'tagblock-inflated');" aria-expanded="false">
-			<h3>
-					<i class="ri ri-hashtag" aria-hidden="true"></i>
-					{{$title}}
-			</h3>
-		</button>
-	</span>
-	<div id="tagblock" class="tagblock widget">
-		<button class="fakelink" onclick="openCloseWidget('tagblock', 'tagblock-inflated');" aria-expanded="true">
-			<h3>
-					<i class="ri ri-hashtag" aria-hidden="true"></i>
-					{{$title}}
-			</h3>
-		</button>
+<!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
+<nav id="tagblock" class="tagblock widget">
+	<button class="widget-btn fakelink" onclick="openCloseWidget('tagblock');" aria-expanded="false">
+		<h3>
+				<i class="ri ri-hashtag" aria-hidden="true"></i>
+				{{$title}}
+		</h3>
+	</button>
 
-		<div class="tag-cloud">
-			{{foreach $tags as $tag}}
+	<div class="tag-cloud" class="sidebar-widget-list">
+		{{foreach $tags as $tag}}
 				<a href="{{$tag.url}}" class="tag{{$tag.level}}">#{{$tag.name}}</a>
-			{{/foreach}}
-		</div>
-		<div class="tagblock-widget-end clear"></div>
+		{{/foreach}}
 	</div>
+	<div class="tagblock-widget-end clear"></div>
 </nav>
 <script>
-	initWidget('tagblock', 'tagblock-inflated');
+	initWidget('tagblock');
 </script>

--- a/view/templates/widget/trending_tags.tpl
+++ b/view/templates/widget/trending_tags.tpl
@@ -4,24 +4,17 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<nav>
-	<span id="trending-tags-sidebar-inflated" class="widget inflated">
-		<button class="fakelink" style="display: flex; justify-content: space-between; width: 100%;" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');" aria-expanded="false">
-			<h3>
+<!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
+<nav id="trending-tags-sidebar" class="widget">
+	<!-- TODO: To myself: Figure out if the button element should contain all the widget actions or not -->
+	<button class="widget-btn fakelink" style="display: flex; justify-content: space-between; width: 100%;" onclick="openCloseWidget('trending-tags-sidebar');" aria-expanded="false">
+		<h3>
 				<i class="ri ri-hashtag" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-			<small>{{$subtitle}}</small>
-		</button>
-	</span>
-	<div id="trending-tags-sidebar" class="widget">
-		<button class="fakelink" style="display: flex; justify-content: space-between; width: 100%;" onclick="openCloseWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');">
-			<h3>
-					<i class="ri ri-hashtag" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-			<small>{{$subtitle}}</small>
-		</button>
+			{{$title}}
+		</h3>
+		<small>{{$subtitle}}</small>
+	</button>
+	<div id="trending-tags-list" class="sidebar-widget-list">
 		<ul id="tags-list">
 			{{section name=ol loop=$tags max=10}}
 				<li style="margin-bottom: 5px;">
@@ -52,6 +45,7 @@
 </nav>
 
 <script>
+	/* TODO: Consider generalising and moving to e.g. main.js for reuse by any widget */
 	function toggleTags(event) {
 		event.preventDefault();
 		var moreTags = document.getElementById('more-tags');
@@ -72,5 +66,5 @@
 		}
 	}
 
-	initWidget('trending-tags-sidebar', 'trending-tags-sidebar-inflated');
+	initWidget('trending-tags-sidebar');
 </script>

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1269,27 +1269,7 @@ aside .widget li.selected a {
 	color: $font_color;
 }
 
-/* group-list widget */
-aside > #datebrowse-sidebar li.posted-date-selector-months {
-	margin-bottom: 10px;
-	padding: 0;
-	width: 100%;
-}
-aside > #datebrowse-sidebar li.posted-date-selector-months:hover {
-	border-left: none !important;
-	background-color: transparent !important;
-}
-aside > #datebrowse-sidebar .posted-date-selector-months > ul {
-	margin: 0;
-}
-aside > #datebrowse-sidebar .posted-date-selector-months > ul > li {
-	padding-left: 30px;
-}
-aside > #datebrowse-sidebar .posted-date-selector-months > ul > li:hover {
-	padding-left: 27px;
-}
-
-.group-list-img {
+.sidebar-widget-list img {
 	-webkit-filter: grayscale(100%);
 	filter: grayscale(100%);
 	opacity: 0.5;
@@ -1300,10 +1280,22 @@ aside > #datebrowse-sidebar .posted-date-selector-months > ul > li:hover {
 	-ms-transition: all 0.2s ease-in-out;
 	transition: all 0.2s ease-in-out;
 }
-#group-list-sidebar-ul li:hover a > .group-list-img {
+
+.widget .sidebar-widget-list li:hover a > img {
 	-webkit-filter: unset;
 	filter: unset;
 	opacity: unset;
+}
+
+/* Widget caret expand/collapse symbols */
+.widget .fakelink[aria-expanded="false"] h3::before {
+	font-family: remixicon;
+	content: "\EA6E";
+}
+
+.widget .fakelink[aria-expanded="true"] h3::before {
+	font-family: remixicon;
+	content: "\EA4E";
 }
 
 /* help page widget */
@@ -1474,13 +1466,7 @@ aside #follow-sidebar .form-group-search .form-button-search {
 	padding: 2px 8px;
 }
 
-div#sidebar-circle-header h3,
-div#sidebar-group-header h3 {
-	float: left;
-}
-
-div#sidebar-circle-list,
-div#sidebar-group-list {
+div.sidebar-widget-list {
 	clear: both;
 }
 
@@ -3557,17 +3543,6 @@ details.profile-jot-net[open] summary:before {
 
 .fakelink > h3:before {
 	padding-right: 10px;
-}
-span.widget > .fakelink > h3:before {
-	font-family: remixicon;
-	content: "\ea6e"; /* Right Pointer */
-	margin-left: 4px;
-}
-div.widget > .fakelink > h3:before,
-#sidebar-circle-header > .fakelink > h3:before,
-#sidebar-group-header > .fakelink > h3:before {
-	font-family: remixicon;
-	content: "\ea4e"; /* Down Pointer */
 }
 
 .widget button.fakelink {

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -40,14 +40,10 @@ $(document).ready(function () {
 		return false;
 	});
 
+	// TODO: Make PHP add the selected class to the relevant HTML element(s) and remove these
 	// add the class "selected" to circle widgets li if li > a does have the class circle-selected
 	if ($("#sidebar-circle-ul li a").hasClass("circle-selected")) {
 		$("#sidebar-circle-ul li a.circle-selected").parent("li").addClass("selected");
-	}
-
-	// add the class "selected" to groups widgets li if li > a does have the class group-selected
-	if ($("#group-list-sidebar-ul li a").hasClass("group-selected")) {
-		$("#group-list-sidebar-ul li a.group-selected").parent("li").addClass("selected");
 	}
 
 	// add the class "active" to tabmenuli if li > a does have the class active

--- a/view/theme/frio/templates/circle_side.tpl
+++ b/view/theme/frio/templates/circle_side.tpl
@@ -4,68 +4,59 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<nav>
-	<span id="circle-sidebar-inflated" class="widget inflated fakelink">
-		<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="false">
-			<h3>
-				<i class="ri ri-bubble-chart-line" aria-hidden="true"></i>
-				{{$title}}
-			</h3>
-		</button>
-	</span>
-	<div class="widget" id="circle-sidebar">
-		<div id="sidebar-circle-header" class="sidebar-widget-header">
-			<button class="fakelink" onclick="openCloseWidget('circle-sidebar', 'circle-sidebar-inflated');" aria-expanded="true">
-				<h3>
-					<i class="ri ri-bubble-chart-line" aria-hidden="true"></i>
-					{{$title}}
-				</h3>
-			</button>
-			{{if ! $new_circle}}
-				<a class="widget-action-top pull-right widget-action faded-icon" id="sidebar-edit-circle" href="{{$circle_page}}" data-toggle="tooltip" title="{{$edit_circles_text}}">
-					<i class="ri ri-pencil-line" aria-hidden="true"></i>
-				</a>
-			{{else}}
-				<a class="widget-action-top pull-right widget-action faded-icon" id="sidebar-new-circle"
-					onclick="javascript:$('#circle-new-form').fadeIn('fast');" data-toggle="tooltip" title="{{$createtext}}">
-					<i class="ri ri-add-line" aria-hidden="true"></i>
-				</a>
-				<form id="circle-new-form" action="circle/new" method="post" style="display:none;">
-					<div class="form-group">
-						<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
-						<input name="circle_name" id="id_circle_name" class="form-control input-sm" placeholder="{{$create_circle}}">
-					</div>
-				</form>
-			{{/if}}
-		</div>
-		<div id="sidebar-circle-list" class="sidebar-widget-list">
-			{{* The list of available circles *}}
-			<ul id="sidebar-circle-ul">
-				{{foreach $circles as $circle}}
-					<li class="sidebar-circle-li circle-{{$circle.id}} {{if $circle.selected}}selected{{/if}}">
-						{{if ! $new_circle}}<span class="notify badge pull-right"></span>{{/if}}
-						{{if $circle.cid}}
-							<div class="checkbox pull-right circle-checkbox ">
-								<input type="checkbox" id="sidebar-circle-checkbox-{{$circle.id}}" class="{{if $circle.selected}}ticked{{else}}unticked {{/if}} action" onclick="return contactCircleChangeMember(this, '{{$circle.id}}','{{$circle.cid}}');" {{if $circle.ismember}}checked="checked" {{/if}} aria-checked="{{if $circle.ismember}}true{{else}}false{{/if}}" />
-								<label for="sidebar-circle-checkbox-{{$circle.id}}"></label>
-								<div class="clearfix"></div>
-							</div>
-						{{/if}}
-						{{if $circle.edit}}
-							{{* if the circle is editable show a little pencil for editing *}}
-							<a id="edit-sidebar-circle-element-{{$circle.id}}" class="circle-edit-tool pull-right faded-icon" href="{{$circle.edit.href}}" data-toggle="tooltip" title="{{$edittext}}">
-								<i class="ri ri-pencil-line" aria-hidden="true"></i>
-							</a>
-						{{/if}}
-						<a id="sidebar-circle-element-{{$circle.id}}" class="sidebar-circle-element" href="{{$circle.href}}">{{$circle.text}}</a>
-					</li>
-				{{/foreach}}
+<!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
+<nav id="circle-sidebar" class="widget">
+	<button class="widget-btn fakelink" onclick="openCloseWidget('circle-sidebar');" aria-expanded="false">
+		<h3>
+			<i class="ri ri-bubble-chart-line" aria-hidden="true"></i>
+			{{$title}}
+		</h3>
+	</button>
 
-				{{if $uncircled}}<li class="{{if $uncircled_selected}}selected{{/if}} sidebar-circle-li" id="sidebar-uncircled"><a href="nocircle">{{$uncircled}}</a></li>{{/if}}
-			</ul>
-		</div>
+	{{if ! $new_circle}}
+		<a class="widget-action-top pull-right widget-action faded-icon" id="sidebar-edit-circle" href="{{$circle_page}}" data-toggle="tooltip" title="{{$edit_circles_text}}">
+			<i class="ri ri-pencil-line" aria-hidden="true"></i>
+		</a>
+	{{else}}
+		<a class="widget-action-top pull-right widget-action faded-icon" id="sidebar-new-circle"
+			onclick="javascript:$('#circle-new-form').fadeIn('fast');" data-toggle="tooltip" title="{{$createtext}}">
+			<i class="ri ri-add-line" aria-hidden="true"></i>
+		</a>
+		<form id="circle-new-form" action="circle/new" method="post" style="display:none;">
+			<div class="form-group">
+				<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+				<input name="circle_name" id="id_circle_name" class="form-control input-sm" placeholder="{{$create_circle}}">
+			</div>
+		</form>
+	{{/if}}
+
+	<div id="sidebar-circle-list" class="sidebar-widget-list">
+		{{* The list of available circles *}}
+		<ul id="sidebar-circle-ul">
+			{{foreach $circles as $circle}}
+				<li class="sidebar-circle-li circle-{{$circle.id}} {{if $circle.selected}}selected{{/if}}">
+					{{if ! $new_circle}}<span class="notify badge pull-right"></span>{{/if}}
+					{{if $circle.cid}}
+						<div class="checkbox pull-right circle-checkbox ">
+							<input type="checkbox" id="sidebar-circle-checkbox-{{$circle.id}}" class="{{if $circle.selected}}ticked{{else}}unticked {{/if}} action" onclick="return contactCircleChangeMember(this, '{{$circle.id}}','{{$circle.cid}}');" {{if $circle.ismember}}checked="checked" {{/if}} aria-checked="{{if $circle.ismember}}true{{else}}false{{/if}}" />
+							<label for="sidebar-circle-checkbox-{{$circle.id}}"></label>
+							<div class="clearfix"></div>
+						</div>
+					{{/if}}
+					{{if $circle.edit}}
+						{{* if the circle is editable show a little pencil for editing *}}
+						<a id="edit-sidebar-circle-element-{{$circle.id}}" class="circle-edit-tool pull-right faded-icon" href="{{$circle.edit.href}}" data-toggle="tooltip" title="{{$edittext}}">
+							<i class="ri ri-pencil-line" aria-hidden="true"></i>
+						</a>
+					{{/if}}
+					<a id="sidebar-circle-element-{{$circle.id}}" class="sidebar-circle-element" href="{{$circle.href}}">{{$circle.text}}</a>
+				</li>
+			{{/foreach}}
+
+			{{if $uncircled}}<li class="{{if $uncircled_selected}}selected{{/if}} sidebar-circle-li" id="sidebar-uncircled"><a href="nocircle">{{$uncircled}}</a></li>{{/if}}
+		</ul>
 	</div>
 </nav>
 <script>
-	initWidget('circle-sidebar', 'circle-sidebar-inflated');
+	initWidget('circle-sidebar');
 </script>

--- a/view/theme/frio/templates/widget/saved_searches.tpl
+++ b/view/theme/frio/templates/widget/saved_searches.tpl
@@ -4,37 +4,28 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
+<!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
 {{if $saved}}
-	<nav>
-		<span id="saved-search-list-inflated" class="widget inflated fakelink">
-			<button class="fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');" aria-expanded="false">
-				<h3>
-					<i class="ri ri-search-line" aria-hidden="true"></i>
-					{{$title}}
-				</h3>
-			</button>
-		</span>
-		<div class="widget" id="saved-search-list">
-			<button class="fakelink" onclick="openCloseWidget('saved-search-list', 'saved-search-list-inflated');">
-				<h3 id="search">
-					<i class="ri ri-search-line" aria-hidden="true"></i>
-					{{$title}}
-				</h3>
-			</button>
-			<ul id="saved-search-ul">
-				{{foreach $saved as $search}}
-					<li class="saved-search-li clear">
-						<a href="search/saved/remove?term={{$search.encodedterm}}&amp;return_url={{$return_url}}" title="{{$search.delete}}" onclick="return confirmDelete();" id="drop-saved-search-term-{{$search.id}}" class="savedsearchdrop pull-right widget-action faded-icon">
-							<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
-						</a>
-						<a href="{{$search.searchpath}}" id="saved-search-term-{{$search.id}}" class="savedsearchterm">{{$search.term}}</a>
-					</li>
-				{{/foreach}}
-			</ul>
-			<div class="clearfix"></div>
-		</div>
+	<nav id="saved-search-sidebar" class="widget">
+		<button class="widget-btn fakelink" onclick="openCloseWidget('saved-search-sidebar');" aria-expanded="false">
+			<h3 id="search">
+				<i class="ri ri-search-line" aria-hidden="true"></i>
+				{{$title}}
+			</h3>
+		</button>
+		<ul id="saved-search-list" class="sidebar-widget-list">
+			{{foreach $saved as $search}}
+				<li class="saved-search-li clear">
+					<a href="search/saved/remove?term={{$search.encodedterm}}&amp;return_url={{$return_url}}" title="{{$search.delete}}" onclick="return confirmDelete();" id="drop-saved-search-term-{{$search.id}}" class="savedsearchdrop pull-right widget-action faded-icon">
+						<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
+					</a>
+					<a href="{{$search.searchpath}}" id="saved-search-term-{{$search.id}}" class="savedsearchterm">{{$search.term}}</a>
+				</li>
+			{{/foreach}}
+		</ul>
+		<div class="clearfix"></div>
 	</nav>
 	<script>
-		initWidget('saved-search-list', 'saved-search-list-inflated');
+		initWidget('saved-search-sidebar');
 	</script>
 {{/if}}

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -418,37 +418,19 @@ pre code {
 	background-color: #737373;
 	opacity: 0.4;
 }
-#saved-search-ul .tool:hover,
-#nets-sidebar .tool:hover,
-#sidebar-circle-list .tool:hover {
+#sidebar-widget-list .tool:hover {
 	background: #EEE;
 }
-/*#sidebar-circle-list .notify {
-	min-width: 10px;
-	text-align: center;
-	color: #FFF;
-	background-color: #CB4437;
-	font: bold 10px Arial;
-	padding: 3px;
-	border-radius: 10px;
-	display: none;
-}*/
 #sidebar-circle-list .notify {
 	display: none;
 }
 #sidebar-circle-list .notify.show {
 	display: inline-block;
 }
-.tool .label {
-	/* float: left; */
-}
 .tool .action {
 	float: right;
 }
-.tool a {
-	/* color: #000; */
-}
-.tool a:hover, .widget a:hover, #nets-sidebar a:hover, #group-widget-collapse:hover, .admin.link a:hover, aside h4 a:hover, right_aside h4 a:hover {
+.tool a:hover, .widget a:hover, #group-widget-collapse:hover, .admin.link a:hover, aside h4 a:hover, right_aside h4 a:hover {
 	/* text-decoration: underline; */
 	text-decoration: none;
 	color: black;
@@ -473,10 +455,6 @@ pre code {
 
 #message-new a {
 	color: black;
-}
-
-.sidebar-circle-element {
-	/* color: #000; */
 }
 
 .widget .selected, .group-selected {

--- a/view/theme/vier/wide.css
+++ b/view/theme/vier/wide.css
@@ -8,9 +8,7 @@ right_aside {
   display: block;
 }
 
-aside #group-list-sidebar-frame,
-aside #group-list-sidebar,
-#group-list-sidebar-inflated {
+aside #group-sidebar {
   display: none;
 }
 


### PR DESCRIPTION
Closes #15706 

- Rewrites all widgets so less code is duplicated (the header doesn't exist twice for the open/closed state)
- Simplified initWidget and openCloseWidget.
- Also tried to standardize widget templates.
- Collapse widgets by default, as suggested by Booklook, some users and the linked issue
- Always show actions (like the button to create a group). This is also done precisely since they're collapsed by default, so the buttons to find/create groups are not hidden

Considered adding the fold/unfold indicator carets to Vier as well, but there isn't really space for them currently, so I didn't.

More things could be done to simplify and standardize widgets further, but I think it's better done in a future PR.

I would've added screenshots, but it's generally not visually different, except the collapsed widgets for new users.

~~CI "code-quality-check" error is under addons, so it seems unrelated?~~