### PR TITLE
Fix Mention Modal functions on other people's profiles.

### DIFF
--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -14,6 +14,7 @@ use Friendica\Core\Renderer;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Util\Strings;
+use Friendica\Core\Theme;
 
 /**
  * VCard widget
@@ -35,6 +36,13 @@ class VCard
 		if (!isset($contact['network']) || !isset($contact['id'])) {
 			DI::logger()->warning('Incomplete contact', ['contact' => $contact]);
 		}
+
+		$page = DI::page();
+
+		$page->registerFooterScript(Theme::getPathForFile('asset/typeahead.js/dist/typeahead.bundle.js'));
+		$page->registerFooterScript(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput.js'));
+		$page->registerStylesheet(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput.css'));
+		$page->registerStylesheet(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput-typeahead.css'));
 
 		$contact_url = Contact::getProfileLink($contact);
 

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -269,7 +269,7 @@ class Profile
 		$page->registerFooterScript(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput.js'));
 		$page->registerStylesheet(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput.css'));
 		$page->registerStylesheet(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput-typeahead.css'));
-		
+
 		$o        = '';
 		$location = false;
 

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -27,6 +27,7 @@ use Friendica\Security\PermissionSet\Entity\PermissionSet;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
+use Friendica\Core\Theme;
 
 class Profile
 {
@@ -262,6 +263,13 @@ class Profile
 	 */
 	public static function getVCardHtml(array $profile, bool $block, bool $show_contacts, int $view_as_contact_id = 0): string
 	{
+		$page = DI::page();
+
+		$page->registerFooterScript(Theme::getPathForFile('asset/typeahead.js/dist/typeahead.bundle.js'));
+		$page->registerFooterScript(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput.js'));
+		$page->registerStylesheet(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput.css'));
+		$page->registerStylesheet(Theme::getPathForFile('js/friendica-tagsinput/friendica-tagsinput-typeahead.css'));
+		
 		$o        = '';
 		$location = false;
 


### PR DESCRIPTION
When viewing someone else's profile if you are on the "Profile" or "Contacts" sub-pages and press the "Mention" button it opens a modal compose window in which you cannot expand the permission (ACL) portion nor can you show the Preview because loading the modal triggers a JS console error of "Uncaught Reference: Bloodhound is not defined":

<img width="992" height="88" alt="jserror" src="https://github.com/user-attachments/assets/683209ab-dc65-4ff4-97e6-2eef593dd485" />

The reason is that the on those sub-pages the "_typeahead.bundle.min.js_" script is never loaded. This doesn't matter on your **own** profile because there is no button to open the composer on your own "Profile" and "Contacts" sub-pages (it's also not present on the "Photos" sub-page, but again doesn't matter on your own profile). But this _does_ matter on **other** people's profiles where there is a "Mention" button to open the compose modal.

This PR makes sure that on Profiles/Contacts that script is loaded and the modal buttons work as intended. I'm really not sure why those resources aren't just loaded in the main head used across the entire site?