### PR TITLE
docs: correct stale facts in test, docker and install docs

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -25,7 +25,7 @@ docker compose exec php bin/console autoinstall -av -f .docker/autoinstall.confi
 ```bash
 docker compose logs -f php
 docker compose logs -f nginx
-docker compose logs -f mariadb
+docker compose logs -f db
 ```
 
 ### Stop environment:

--- a/.docker/README.md
+++ b/.docker/README.md
@@ -38,13 +38,13 @@ docker compose down
 - **Friendica application**: http://localhost:8080
 - **MySQL/MariaDB**: localhost:3306
   - User: `friendica`
-  - Password: `friendica_`
+  - Password: `friendica`
   - Database: `friendica`
 
 ## Database access via CLI
 
 ```bash
-docker compose exec mariadb mysql -u friendica -p friendica friendica
+docker compose exec db mariadb -ufriendica -pfriendica friendica
 ```
 
 ## Container names

--- a/doc/en/admin/install.md
+++ b/doc/en/admin/install.md
@@ -433,57 +433,6 @@ Retry the installation. As soon as the database has been created,
 chmod 644 config/local.config.php
 ```
 
-### Suhosin issues
-
-Some configurations with "suhosin" security are configured without an ability to
-run external processes. Friendica requires this ability. Following are some notes
-provided by one of our members.
-
-> On my server I use the php protection system Suhosin [http://www.hardened-php.net/suhosin/].
-> One of the things it does is to block certain functions like proc_open, as
-> configured in `/etc/php5/conf.d/suhosin.ini`:
->
->     suhosin.executor.func.blacklist = proc_open, ...
->
-> For those sites like Friendica that really need these functions they can be
-> enabled, e.g. in `/etc/apache2/sites-available/friendica`:
->
-> 	<Directory /var/www/friendica/>
-> 	  php_admin_value suhosin.executor.func.blacklist none
-> 	  php_admin_value suhosin.executor.eval.blacklist none
-> 	</Directory>
->
-> This enables every function for Friendica if accessed via browser, but not for
-> the cronjob that is called via php command line. I attempted to enable it for
-> cron by using something like:
->
-> 	*/10 * * * * cd /var/www/friendica/friendica/ && sudo -u www-data /usr/bin/php \
->       -d suhosin.executor.func.blacklist=none \
->       -d suhosin.executor.eval.blacklist=none -f bin/console.php
->
-> This worked well for simple test cases, but the friendica-cron still failed
-> with a fatal error:
->
-> 	suhosin[22962]: ALERT - function within blacklist called: proc_open()
->     (attacker 'REMOTE_ADDR not set', file '/var/www/friendica/friendica/boot.php',
->     line 1341)
->
-> After a while I noticed, that `bin/console.php worker` calls further PHP scripts via `proc_open`.
-> These scripts themselves also use `proc_open` and fail, because they are NOT
-> called with `-d suhosin.executor.func.blacklist=none`.
->
->  So the simple solution is to put the correct parameters into `config/local.config.php`:
->
-> 	'config' => [
-> 		//Location of PHP command line processor
-> 		'php_path' => '/usr/bin/php -d suhosin.executor.func.blacklist=none \
->               -d suhosin.executor.eval.blacklist=none',
-> 	],
->
-> This is obvious as soon as you notice that the friendica-cron uses `proc_open`
-> to execute PHP scripts that also use `proc_open`, but it took me quite some time to find that out.
-> I hope this saves some time for other people using suhosin with function blocklists.
-
 ### Unable to create all mysql tables on MySQL 5.7.17 or newer
 
 If the setup fails to create all the database tables and/or manual creation from

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,12 +35,12 @@ sudo apt install php-mysql php-curl php-gd php-xml php-intl php-gmp php-mbstring
 
 ## Create Local Database
 
-The default database name is `test`, username `friendica`, password
-`friendica`.  These can be overridden using environment variables
-`DATABASE_NAME`, `DATABASE_USER`, `DATABASE_HOST`, and
-`DATABASE_PASSWORD`.  Whatever settings you choose, you must give the
-corresponding user the necessary privileges to create and destroy the
-chosen database.
+The test harness reads its connection from the environment variables
+`MYSQL_HOST`, `MYSQL_USER`, `MYSQL_PASSWORD`, and `MYSQL_DATABASE`
+(optional `MYSQL_PORT`). There is no built-in default — they must be set,
+otherwise the harness aborts with "Host, User or Database missing".
+Whatever settings you choose, you must give the corresponding user the
+necessary privileges to create and destroy the chosen database.
 
 ```
 GRANT ALL PRIVILEGES ON test.* TO 'friendica'@'localhost' IDENTIFIED BY 'friendica' WITH GRANT OPTION;


### PR DESCRIPTION
- tests/README.md: the DB test harness reads MYSQL_* env vars (not DATABASE_*); no built-in default
- .docker/README.md: fix DB password and CLI service name (db, not mariadb)
- admin/install.md: drop obsolete Suhosin section (PHP 5 only, unusable on the required PHP 8.2+)