### PR TITLE
docs: developer guidelines for new PHP and frontend code

### DIFF
--- a/doc/en/developer/first-change.md
+++ b/doc/en/developer/first-change.md
@@ -74,7 +74,7 @@ protected function content(array $request = []): string
 ## Step 3 — A canonical module showing the target pattern
 
 Use this as your starting point for new modules.
-It shows the target pattern from the [Architecture Guidelines](php-architecture): constructor injection, no superglobals, no direct DB access, explicit auth and CSRF checks, typed input.
+It shows the target pattern from the [Architecture Guidelines](php-architecture): constructor injection, no superglobals, no direct DB access, explicit auth and CSRF ([Cross-Site Request Forgery](https://owasp.org/www-community/attacks/csrf)) checks, typed input.
 Replace the illustrative `WidgetService` with your own before using it.
 
 ```php
@@ -507,4 +507,4 @@ Several predate the current guidelines and use `DI::`, `$_REQUEST`, or `DBA::` d
 | Entity / Factory / Repository | `src/Navigation/Notifications/`                                  | Modern DDD pattern                                  | Predates the `declare(strict_types=1)` rule ([Architecture §4.4](php-architecture)) — new classes still require it                                                                    |
 | Unit test structure           | `tests/Unit/Contact/FriendSuggest/Factory/FriendSuggestTest.php` | Test isolation and data-provider structure          | `dataCreate()` predates the return-type rule                                                                                                                                          |
 
-For request handling, DI, and CSRF, **p refer the skeleton in [Step 3](#skeleton)** over any of these files.
+For request handling, DI, and CSRF, **prefer the skeleton in [Step 3](#skeleton)** over any of these files.

--- a/doc/en/developer/first-change.md
+++ b/doc/en/developer/first-change.md
@@ -455,7 +455,7 @@ Dice resolves concrete classes with typed constructors automatically.
 
 ```bash
 # 1. Apply automatic fixes (Rector + CS-Fixer + translations). Modifies files.
-composer run rectify
+composer run rectify   # shorthand: bin/rectify.sh
 
 # 2. Review what changed
 git diff

--- a/doc/en/developer/first-change.md
+++ b/doc/en/developer/first-change.md
@@ -1,0 +1,510 @@
+# Your First Change in Friendica
+
+* [Developer Intro](index)
+* [PHP Architecture Guidelines](php-architecture)
+* [Frontend Guidelines](frontend)
+
+This guide walks you through making your first real change to Friendica.
+
+**Who this is for:**
+- **New PHP developers** — follow it step by step, the order matters
+- **UI/UX contributors** — if you change *only templates or CSS*, Steps 1 and 8 plus the [Frontend Guidelines](frontend) are enough. If you *add or change a form or any Module logic*, read Steps 1–8 in full — input validation (Step 4) and authorization (Step 5) are not optional
+- **Experienced Friendica developers** — the canonical module skeleton in Step 3 shows the target pattern for new code; legacy code in `mod/` and `src/Model/` continues to work as-is
+
+---
+
+<a name="step1" id="step1"></a>
+## Step 1 — Find the right file
+
+Most user-facing features live in `src/Module/`. The URL maps to the class through
+`static/routes.config.php`:
+
+```php
+'/profile/{nickname}' => $profileRoutes,
+'/settings/server'    => [Module\Settings\Server\Index::class, [R::GET, R::POST]],
+```
+
+Routes are often nested under a group (e.g. `/settings` → `/server` → `[Index::class, ...]`), so search `routes.config.php` for the **Module class name** rather than the full URL path.
+
+Route parameters such as `{nickname}` are available as `$this->parameters['nickname']` inside the module.
+
+If you are fixing a visual issue, the template is usually in `view/templates/` with the same path as the module:
+
+```
+src/Module/Settings/Server/Index.php   →  view/templates/settings/server/index.tpl
+```
+
+---
+
+<a name="lifecycle" id="lifecycle"></a>
+## Step 2 — Understand the module lifecycle
+
+Every module extends `BaseModule`.
+On every request, `BaseModule::run()` calls methods in this fixed order regardless of HTTP method:
+
+```
+1.  method handler   →  get() / post() / put() / patch() / delete()
+2.  rawContent()     →  for API/technical endpoints that exit themselves
+3.  content()        →  always runs after the method handler
+```
+
+**This is the most important thing to understand:** after a POST, `content()` always runs unless the handler redirects, throws, or exits via `rawContent()`.
+
+The normal pattern for a form that changes data:
+
+```php
+protected function post(array $request = []): void
+{
+    // 1. Check login and permissions
+    // 2. Verify CSRF token
+    // 3. Do the work
+    // 4. Redirect — prevents re-POST on browser reload
+    $this->baseUrl->redirect($this->args->getQueryString());
+}
+
+protected function content(array $request = []): string
+{
+    // Renders the page for GET, and for POST if post() did not redirect
+}
+```
+
+---
+
+<a name="skeleton" id="skeleton"></a>
+## Step 3 — A canonical module showing the target pattern
+
+Use this as your starting point for new modules.
+It shows the target pattern from the [Architecture Guidelines](php-architecture): constructor injection, no superglobals, no direct DB access, explicit auth and CSRF checks, typed input.
+Replace the illustrative `WidgetService` with your own before using it.
+
+```php
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Module\Example;
+
+use Friendica\App;
+use Friendica\BaseModule;
+use Friendica\Core\L10n;
+use Friendica\Core\Renderer;
+use Friendica\Core\Session\Capability\IHandleUserSessions;
+use Friendica\Example\Service\WidgetService;  // illustrative — your own service class
+use Friendica\Module\Response;
+use Friendica\Network\HTTPException;
+use Friendica\Util\Profiler;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+
+class Widget extends BaseModule
+{
+    public function __construct(
+        private readonly IHandleUserSessions $session,
+        private readonly WidgetService $widgetService,  // your injected business-logic service
+        L10n $l10n,
+        App\BaseURL $baseUrl,
+        App\Arguments $args,
+        LoggerInterface $logger,
+        Profiler $profiler,
+        Response $response,
+        array $server,
+        array $parameters,
+        EventDispatcherInterface $eventDispatcher, // must be explicit — omitting triggers DI:: fallback in BaseModule
+    ) {
+        parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters, $eventDispatcher);
+    }
+
+    /**
+     * Returns the logged-in local user ID or throws. getLocalUserId() returns int|false,
+     * so we validate the type once and reuse the result.
+     */
+    private function requireLocalUserId(): int
+    {
+        $uid = $this->session->getLocalUserId();
+        if (!is_int($uid) || $uid <= 0) {
+            throw new HTTPException\UnauthorizedException($this->t('Please login to continue.'));
+        }
+
+        return $uid;
+    }
+
+    protected function post(array $request = []): void
+    {
+        $uid = $this->requireLocalUserId();
+
+        self::checkFormSecurityTokenRedirectOnError(
+            $this->args->getQueryString(),
+            'example-widget'
+        );
+
+        // Read directly from the passed $request (NOT a superglobal) so we can type-check.
+        // getRequestValue() with a string default would coerce an array like name[]=x to "Array".
+        $rawName = $request['name'] ?? null;
+        if (!is_string($rawName)) {
+            throw new HTTPException\BadRequestException($this->t('Please enter a valid name.'));
+        }
+
+        $name = trim($rawName);
+        if ($name === '' || mb_strlen($name) > 100) {
+            throw new HTTPException\BadRequestException($this->t('Please enter a valid name.'));
+        }
+
+        // Delegate to the injected service. The Service holds business logic;
+        // the Repository (called by the Service) does the persistence.
+        $this->widgetService->updateName($uid, $name);
+
+        $this->baseUrl->redirect($this->args->getQueryString());
+    }
+
+    protected function content(array $request = []): string
+    {
+        $this->requireLocalUserId();
+
+        $tpl = Renderer::getMarkupTemplate('example/widget.tpl');
+
+        return Renderer::replaceMacros($tpl, [
+            '$title'               => $this->t('My Widget'),
+            '$form_security_token' => self::getFormSecurityToken('example-widget'),
+        ]);
+    }
+}
+```
+
+> **This skeleton extends `BaseModule` directly.** If you instead extend `BaseSettings` or `BaseAdmin`, their parent constructor starts with different arguments (`parent::__construct($session, $page, $l10n, …)`) — copy the `parent::__construct(...)` call from an existing subclass of that base, not from here.
+>
+> **Why `EventDispatcherInterface` is in the constructor:** `BaseModule` falls back to `DI::eventDispatcher()` when the parameter is omitted.
+> Injecting it explicitly avoids that hidden service-locator call.
+> Dice wires it automatically.
+>
+> **This Module is not yet a fully isolated unit-test candidate.**
+> It still calls the accepted legacy static framework APIs (`Renderer::*`, `self::getFormSecurityToken*()`) which use `DI::` internally.
+> The *Service* it delegates to is the part that is cleanly unit-testable.
+> A functional test usually covers a Module like this.
+>
+> **`WidgetService` is illustrative — replace it before using this file.**
+> The block is a pattern, not compile-ready code.
+> `WidgetService` is a plain injectable service (see the [Architecture Guidelines](php-architecture) for what belongs in a Service vs a Repository).
+> Note the method is `updateName()`, not `save()` — a Service exposes intent-named operations; persistence happens in the Repository it calls.
+
+### How the layers fit together
+
+The Module does not contain the business logic — it hands typed values to a Service:
+
+```
+HTTP request
+     │
+     ▼
+   Module          auth · CSRF · input type-checking & validation
+     │  (typed values)
+     ▼
+   Service         business decisions
+     │
+     ▼
+Repository / Read Repository
+     │
+     ▼
+ Database
+```
+
+A minimal version of the `WidgetService` the Module calls:
+
+```php
+final class WidgetService
+{
+    public function __construct(
+        private readonly WidgetRepository $widgets,
+    ) {}
+
+    public function updateName(int $uid, string $name): void
+    {
+        $widget = $this->widgets->selectByUserId($uid);
+        $widget->rename($name);
+        $this->widgets->save($widget);
+    }
+}
+```
+
+The Service holds the "what should happen" decision; the Repository does the actual database work.
+No `DBA::`, no `$_REQUEST`, no HTTP concerns reach this far down.
+
+---
+
+<a name="request" id="request"></a>
+## Step 4 — Read request values safely
+
+Never use `$_GET`, `$_POST`, `$_REQUEST`, or `$_SERVER` directly.
+Read values from the passed `$request` array.
+Use `$this->getRequestValue()` where its coercion semantics fit;
+for untrusted strings, read `$request[...]` and check `is_string()` explicitly.
+
+`getRequestValue()` applies **type-dependent filtering** based on the type of the default value.
+It is **not** full input validation — it does not check length, allowed values, or business rules, and with a string default it coerces an array input (`name[]=x`) to the literal string `"Array"`.
+Validate separately before calling a service or repository.
+
+`getRequestValue()` is fine for simple `int` and `float` fields, and for `bool` fields *only* when treating missing, invalid, and explicit-`false` values identically is acceptable:
+
+```php
+$page   = $this->getRequestValue($request, 'page', 0);     // int filter
+$active = $this->getRequestValue($request, 'active', false); // bool filter
+```
+
+For **strings**, do not use the string-default form — read directly and type-check:
+
+```php
+$rawKeyword = $request['q'] ?? null;
+if (!is_string($rawKeyword)) {
+    throw new HTTPException\BadRequestException($this->t('Invalid input.'));
+}
+$keyword = trim($rawKeyword);
+```
+
+For `int` and `float` defaults without min/max bounds, the filter returns `false` on invalid input — **not** the default.
+Always check:
+
+```php
+$page = $this->getRequestValue($request, 'page', 0);
+if ($page === false) {
+    $page = 0;
+}
+```
+
+Do not use the optional min/max arguments when you need to detect invalid numeric input.
+`getRequestValue()` clamps after filtering; an invalid value can become the minimum instead of staying `false`.
+Validate first, clamp second.
+
+**Quick reference — how to read each input type safely:**
+
+| Input type      | Recommended approach                                                                                                              |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| String          | `$request[...]` + `is_string()`, then validate length/content                                                                     |
+| Integer / Float | `getRequestValue()` with a numeric default, then check for `false`                                                                |
+| Boolean         | `getRequestValue()` only when missing/invalid/`false` may be treated the same; otherwise check the raw submitted value explicitly |
+| Array           | `is_array()`, then validate every element individually                                                                            |
+
+
+> For `bool` defaults, `FILTER_VALIDATE_BOOLEAN` returns `false` for both a valid `false` value **and** invalid input.
+> You cannot distinguish between them.
+> Do not use `getRequestValue()` to detect whether a boolean field was submitted at all.
+>
+> **`checkDefaults()` logs request data.**
+> It logs undeclared field names with their values, and the normalized request at debug level.
+> Do not use it for forms containing passwords, tokens, or secrets.
+
+
+---
+
+<a name="auth" id="auth"></a>
+## Step 5 — Check login and permissions
+
+Because `content()` always runs after `post()`, each protected method needs its own auth check — you cannot rely on `content()` to protect `post()`.
+
+**For login-required modules** (as shown in the skeleton):
+
+```php
+// Read and type-check the user ID once
+$uid = $this->session->getLocalUserId();
+
+// Not logged in → choose ONE of these two approaches:
+
+// (a) Throw 401 — best for API-style endpoints
+if (!is_int($uid) || $uid <= 0) {
+    throw new HTTPException\UnauthorizedException($this->t('Please login to continue.'));
+}
+
+// (b) Redirect to login — best for interactive pages (use instead of the throw above)
+// if (!is_int($uid) || $uid <= 0) {
+//     $this->baseUrl->redirect('login');
+// }
+```
+
+Logged in but not permitted is a separate, 403-level check — see **ownership checks** below.
+
+**For admin-only modules** — extend `BaseAdmin`, and call `self::checkAdminAccess()` at the start of every admin-only request handler that reads or mutates protected data.
+`BaseAdmin::content()` runs the check, but only when rendering — too late to protect `post()`:
+
+```php
+protected function post(array $request = []): void
+{
+    self::checkAdminAccess();   // ← must be here, not only in content()
+    self::checkFormSecurityTokenRedirectOnError(
+        $this->args->getQueryString(), 'admin-my-action'
+    );
+    // mutation, then redirect
+}
+
+protected function content(array $request = []): string
+{
+    parent::content($request);  // runs checkAdminAccess() inside BaseAdmin
+    // render
+}
+```
+
+**For ownership checks** (reuse the `$uid` you already read and type-checked):
+
+```php
+// A raw DB-row value may be a numeric string ('42'), so cast at the legacy boundary
+// to avoid a strict-comparison mismatch ('42' !== 42 is true).
+if ((int) $record['uid'] !== $uid) {
+    throw new HTTPException\ForbiddenException();
+}
+
+// With a typed Entity, no cast is needed:
+// if ($record->uid !== $uid) { ... }
+```
+
+---
+
+<a name="csrf" id="csrf"></a>
+## Step 6 — Protect POST forms against CSRF
+
+The action name must match between token generation and verification.
+The token value itself travels through the hidden field.
+The current helpers are accepted legacy static APIs; on failure they read and log `$_REQUEST` internally.
+
+```php
+// In content() — generate:
+'$form_security_token' => self::getFormSecurityToken('my-action'),
+```
+
+```smarty
+{{* In the template — hidden field: *}}
+<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+```
+
+```php
+// In post() — verify (same action name):
+self::checkFormSecurityTokenRedirectOnError(
+    $this->args->getQueryString(),
+    'my-action'
+);
+```
+
+---
+
+<a name="service" id="service"></a>
+## Step 7 — Call a service or repository
+
+Data should come from an injected repository or service.
+See the [Architecture Guidelines](php-architecture) for the full layer model.
+
+If no repository exists for what you need, calling an existing legacy `Model\*` method in a focused fix is acceptable —
+**do not introduce a new `DBA::` call in a Module or Service**.
+If you add a `@todo`, make it concrete:
+
+```php
+// @todo Replace LegacyModel::loadByAlias() once a UserRepository lookup exists.
+// Tracked in issue #NNNN.
+```
+
+A bare `// @todo migrate` is not a justification — explain the legacy decision in your PR description instead.
+
+---
+
+<a name="template" id="template"></a>
+## Step 8 — Render a template
+
+```php
+protected function content(array $request = []): string
+{
+    $tpl = Renderer::getMarkupTemplate('mymodule/index.tpl');
+    return Renderer::replaceMacros($tpl, [
+        '$title'               => $this->t('My Page Title'),
+        '$form_security_token' => self::getFormSecurityToken('my-action'),
+        '$items'               => $items,
+    ]);
+}
+```
+
+Template variables are HTML-escaped automatically by Smarty in normal HTML text and attribute contexts.
+All user-visible strings go through `$this->t()`.
+See the [Frontend Guidelines](frontend) for URL validation, JSON-to-JS, `nofilter`, forms, and output safety.
+
+---
+
+<a name="route" id="route"></a>
+## Step 9 — Add a route (new feature only)
+
+```php
+// In static/routes.config.php:
+'/my-path[/{id:\d+}]' => [Module\Example\Widget::class, [R::GET, R::POST]],
+```
+
+---
+
+<a name="dice" id="dice"></a>
+## Step 10 — Register a Dice dependency (new class only)
+
+Dice resolves concrete classes with typed constructors automatically.
+**Interfaces, scalars, and runtime values** need an explicit rule in `static/dependencies.config.php`:
+
+```php
+\Friendica\Example\Capability\IDoSomething::class => [
+    'instanceOf' => \Friendica\Example\Model\MyImplementation::class,
+],
+```
+
+---
+
+<a name="checks" id="checks"></a>
+## Step 11 — Run the checks
+
+```bash
+# 1. Apply automatic fixes (Rector + CS-Fixer + translations). Modifies files.
+composer run rectify
+
+# 2. Review what changed
+git diff
+
+# 3. Validate
+composer run lint       # parse errors
+composer run cs:check   # code style (read-only)
+composer run phpstan    # static type analysis
+composer run phpmd      # complexity
+
+# 4. Tests
+composer run test:unit  # fast, no database needed
+# Also run the relevant functional or integration tests for the layer you changed, if they exist
+```
+
+Database-dependent tests need a few `MYSQL_*` environment variables — see [Tests](tests) for the full suite list and setup.
+
+---
+
+<a name="checklist" id="checklist"></a>
+## Quick checklist before pushing
+
+- [ ] Each protected entry point (get, post, put, patch, delete, rawContent, content) is covered by authentication and authorization — directly or through a verified base-class guard
+- [ ] Admin modules call `self::checkAdminAccess()` at the start of every admin-only request handler that reads or mutates protected data
+- [ ] CSRF action name matches between `getFormSecurityToken()` and the verify call
+- [ ] No `$_GET` / `$_POST` / `$_REQUEST` / `$_SERVER` direct access
+- [ ] `getRequestValue()` int/float results checked for `false` before use
+- [ ] `checkDefaults()` not used for forms with passwords, tokens, or secrets; it logs undeclared field values and the normalized request
+- [ ] No new `DBA::` call in a Module or Service
+- [ ] `EventDispatcherInterface` injected in new BaseModule subclasses
+- [ ] All user-visible strings go through `$this->t()`
+- [ ] `composer run rectify` run and diff reviewed
+- [ ] `phpstan` passes with no new errors
+- [ ] Relevant functional or integration tests for the changed layer run and pass (if they exist)
+
+---
+
+<a name="examples" id="examples"></a>
+## Reference examples — read the caveats
+
+These existing files are useful for specific things only.
+Several predate the current guidelines and use `DI::`, `$_REQUEST`, or `DBA::` directly.
+
+| What to study                 | File                                                             | What to take from it                                | What to ignore                                                                                                                                                                        |
+|-------------------------------|------------------------------------------------------------------|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Repository injection          | `src/Module/Settings/Server/Index.php`                           | How to inject and call a repository                 | Auth — `post()` has no explicit login check; it relies on `checkFormSecurityToken` redirect + `getLocalUserId()` inside repository calls; see [Step 5](#auth) for the correct pattern |
+| Admin access + CSRF sequence  | `src/Module/Admin/Logs/Settings.php`                             | The `checkAdminAccess()` + CSRF + redirect sequence | Uses `DI::` and missing return types                                                                                                                                                  |
+| Route and template wiring     | `src/Module/Profile/Schedule.php`                                | How routes map to modules and templates             | Uses `DI::`, `$_REQUEST`, `DBA::` — do not copy request or DB patterns                                                                                                                |
+| Entity / Factory / Repository | `src/Navigation/Notifications/`                                  | Modern DDD pattern                                  | Predates the `declare(strict_types=1)` rule ([Architecture §4.4](php-architecture)) — new classes still require it                                                                    |
+| Unit test structure           | `tests/Unit/Contact/FriendSuggest/Factory/FriendSuggestTest.php` | Test isolation and data-provider structure          | `dataCreate()` predates the return-type rule                                                                                                                                          |
+
+For request handling, DI, and CSRF, **p refer the skeleton in [Step 3](#skeleton)** over any of these files.

--- a/doc/en/developer/frontend.md
+++ b/doc/en/developer/frontend.md
@@ -6,19 +6,21 @@
 
 ---
 
-## Navigation by role
+<a name="at-a-glance" id="at-a-glance"></a>
+## At a glance
 
-**Find your starting point here before reading further.**
+Find your area, check the rule, and read the linked section for the background and examples.
 
-| I want to…                             | Read                                                                                                              |
-|----------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| Fix a colour, spacing, or layout issue | [§5 CSS and Themes](#css)                                                                                         |
-| Change or create a Smarty template     | [§1 Templates](#templates) + [§2 XSS](#xss) + [§3 Translations](#translations)                                    |
-| Add or change JavaScript behaviour     | [§6 JavaScript](#javascript) + [§6.6 DOM-XSS](#dom-xss)                                                           |
-| Add or change a form                   | [§4 Forms](#forms) + [First Change Steps 4–6](first-change#request) (input validation, auth, CSRF) |
-| Pull new data from PHP into a page     | [First Change](first-change) + [§1 Templates](#templates)                                                         |
-| Build or change a `Content/` renderer (PHP) | [PHP Architecture §2.4 Presentation layer](php-architecture#presentation-layer-content)                       |
-| Add accessibility to an element        | [§7 Accessibility](#accessibility)                                                                                |
+- [ ] **Templates** — find the PHP behind the template and what data it passes; keep output escaped → [§1](#templates), [§2](#xss)
+- [ ] **External or user-supplied URLs** — validated in PHP before output → [§2.2](#xss)
+- [ ] **User-visible strings** — all translated (PHP, templates, JS) → [§3](#translations)
+- [ ] **Forms** — CSRF token present and verified; input validated and authorised → [§4](#forms), [First Change Steps 4–6](first-change#request)
+- [ ] **CSS / themes** — data in PHP, structure in templates, appearance in CSS → [§5](#css)
+- [ ] **JavaScript** — JSON→JS via `json_encode()` + `JSON_HEX_*`; DOM updates via `textContent` → [§6](#javascript)
+- [ ] **Accessibility** — native elements, `alt` text, visible focus → [§7](#accessibility)
+- [ ] **Backend / `Content/` renderer (PHP)** — presentation logic belongs here, not in the Module → [PHP Architecture §2.4](php-architecture#presentation-layer-content)
+
+Before pushing, run the per-change testing matrix → [§8](#checklist).
 
 ---
 
@@ -74,6 +76,24 @@ Friendica uses double curly braces `{{ }}`:
 {{/foreach}}
 ```
 
+### 1.4 Finding the PHP file behind a template (and vice versa)
+
+Friendica does not name templates after their module, so the link between a page, its template, and the variables it receives is not obvious.
+Two reliable ways to trace it:
+
+**From something visible on the page → the template → the PHP.**
+Pick a unique marker in the rendered HTML (an `id`, a class, an icon name) using your browser's dev tools, then `grep` for it to find the template, then `grep` the template's file name to find the PHP that renders it:
+
+```bash
+grep -rn "ri-hashtag" view/          # marker → template file
+grep -rn "tag_cloud.tpl" src/ mod/   # template name → the PHP that loads it
+```
+
+**From a URL → the PHP → the template.**
+Look up the URL pattern in `static/routes.config.php` to find the Module class, then read that class: the `Renderer::getMarkupTemplate('…')` call names the template, and the `replaceMacros()` array shows exactly which `$variables` are passed into it.
+
+The template variables a page receives are defined in that PHP file — read it to see what data is available before changing the template.
+
 ---
 
 <a name="xss" id="xss"></a>
@@ -86,7 +106,7 @@ Friendica uses double curly braces `{{ }}`:
 
 Friendica sets `escape_html = true` in `src/Render/FriendicaSmarty.php`.
 Every `{{$variable}}` is HTML-escaped automatically.
-This is your primary XSS defense — **for normal HTML text and ordinary HTML attribute values.**
+This is your primary [XSS](#abbreviations) defense — **for normal HTML text and ordinary HTML attribute values.**
 
 ```smarty
 {{* Safe — HTML text context *}}
@@ -96,13 +116,14 @@ This is your primary XSS defense — **for normal HTML text and ordinary HTML at
 <input type="text" value="{{$current_value}}">
 ```
 
-> HTML-escaping is **not** enough for every context. Do **not** interpolate
-> dynamic values directly into:
-> - JavaScript (`<script>var x = "{{$v}}";</script>`) — use the JSON pattern in [§6.3](#javascript)
-> - CSS or `style` attributes
-> - URL attributes without scheme validation ([§2.2](#xss))
-> - event-handler attributes (`onclick`, etc.)
-> - raw HTML via `nofilter`
+> HTML-escaping is **not** enough for every context, because it only neutralizes HTML syntax (`<`, `>`, `&`, `"`).
+> It does nothing inside other languages.
+> Do **not** interpolate dynamic values directly into:
+> - JavaScript (`<script>var x = "{{$v}}";</script>`) — a `"` or `</script>` in the value breaks out of the string into executable code; use the JSON pattern in [§6.3](#javascript)
+> - CSS or `style` attributes — CSS syntax survives HTML-escaping, so a value can inject `url(...)` exfiltration or layout-breaking rules
+> - URL attributes without scheme validation — a `javascript:` or `data:` URL stays intact through HTML-escaping and runs on click ([§2.2](#xss))
+> - event-handler attributes (`onclick`, etc.) — the attribute value is JavaScript, not HTML, so HTML-escaping leaves the injected code executable
+> - raw HTML via `nofilter` — this disables escaping entirely, so any markup in the value is rendered as-is
 
 ### 2.2 External URLs need PHP-side scheme validation first
 
@@ -181,81 +202,59 @@ $this->t('Hello, %s!', $username);
 
 > ### Form Safety Minimum
 >
-> Before submitting a form change, verify all five — even if you only touched the template:
+> **If you only changed the template or CSS**, you own the two markup-level items:
 >
-> 1. The server checks **authentication and authorization** ([First Change Step 5](first-change#auth))
-> 2. Every mutating form **has and verifies a CSRF token** ([§4.2](#forms) and [First Change Step 6](first-change#csrf))
-> 3. Input **type, required state, and length** are validated in the Module ([First Change Step 4](first-change#request))
-> 4. **Business rules** are handled by a Service, not the Module or template
-> 5. Dynamic output stays **escaped** — no new `nofilter` ([§2](#xss))
+> - The form **includes a CSRF token** field ([§4.2](#forms))
+> - Dynamic output stays **escaped** — no new `nofilter` ([§2](#xss))
+>
+> **Full form requirements** — the server-side items below.
+> Confirm them yourself if you wrote the PHP:
+>
+> - The server checks **authentication and authorization** ([First Change Step 5](first-change#auth))
+> - The CSRF token is **verified** in `post()` ([First Change Step 6](first-change#csrf))
+> - Input **type, required state, and length** are validated in the Module ([First Change Step 4](first-change#request))
+> - **Business rules** are handled by a Service, not the Module or template
 
 
 ### 4.1 Standard form field templates
 
-Friendica provides Smarty include templates for consistent form fields.
-The array is positional and **the structure differs between templates and between core and frio overrides**.
-Always inspect the actual template file before passing dynamic values — some slots are rendered with `nofilter`.
+Friendica provides Smarty include templates for consistent form fields (`field_input.tpl`, `field_checkbox.tpl`, `field_select.tpl`, …; the full set lives in `view/templates/` and `view/theme/frio/templates/`).
+Each takes a single **positional array**, and the slot order, meaning, and escaping **differ between templates and between core and frio overrides**.
 
-**`field_input.tpl` only — verified slot map:**
+**Always open the actual template file before passing dynamic values.**
+Some slots — typically the label, help text, and extra-attributes slots — are rendered with `nofilter` (raw, unescaped), and exactly which ones varies by template and theme.
 
-| Index | Meaning                                | Frio nofilter? | Core nofilter? |
-|-------|----------------------------------------|----------------|----------------|
-| 0     | Field name (HTML `name`)               | —              | —              |
-| 1     | Label                                  | **Yes**        | No             |
-| 2     | Current value                          | No             | No             |
-| 3     | Help text                              | **Yes**        | **Yes**        |
-| 4     | Required flag / tooltip text           | No             | No             |
-| 5     | Extra HTML attributes                  | **Yes**        | **Yes**        |
-| 6     | Input type (`'text'`, `'email'`, etc.) | —              | —              |
-| 7     | Placeholder text                       | No             | No             |
+Security rules that hold regardless of the exact slot layout:
 
-> **Security — `nofilter` slots in field templates:**
-> In frio's `field_input.tpl`, slots 1, 3, and 5 are rendered raw.
-> In the core template, slots 3 and 5 are rendered raw.
-> This map is only for `field_input.tpl`.
-> Other templates (checkbox, textarea, password, select\_raw…) have different slot meanings and raw slots — inspect each template before use.
->
-> **Rules:**
-> - Index 1 (label): a `$this->t()` literal — never user or remote data
-> - Index 3 (help text): trusted translated HTML or plain text only
-> - Index 4 (required tooltip): use `$this->t('Required')`, not the string `'required'`
-> - Index 5 (extra attributes): only hardcoded attribute strings, never dynamic values
->
-> **A "translated string" is not automatically safe.** Translation with substitution does NOT HTML-escape the substituted values:
->
-> ```php
-> // ✗ Unsafe in a nofilter slot — $remoteName is not escaped by t()
-> $this->t('Account: %s', $remoteName);
-> ```
->
-> Never put user- or remote-derived values into a `nofilter` slot, even through `t()`.
-> For dynamic content, use a normally auto-escaped template slot instead, or split the template so the dynamic part is output without `nofilter`.
+- Put only **trusted, server-generated** values into a raw slot — a `$this->t()` literal or a hardcoded attribute string. Never user- or remote-derived data.
+- **A translated string is not automatically safe.** `t()` with substitution does **not** HTML-escape the substituted value:
+
+  ```php
+  // ✗ Unsafe in a nofilter slot — $remoteName is not escaped by t()
+  $this->t('Account: %s', $remoteName);
+  ```
+
+  For dynamic content, use a normally auto-escaped slot, or split the template so the dynamic part is output without `nofilter`.
+
+Example using `field_input.tpl` (open the file to confirm the current slot order):
 
 ```php
-// ✓ Safe usage
+// ✓ Safe usage — every value is a trusted translated string or an auto-escaped value
 '$email' => [
-    'email',                          // 0: name
-    $this->t('Email address'),        // 1: label — trusted translated string ✓
-    $currentEmail,                    // 2: value — auto-escaped ✓
-    $this->t('Your login email.'),    // 3: help — trusted translated string ✓
-    $this->t('Required'),             // 4: tooltip — translated ✓
-    '',                               // 5: extra attributes — empty is safest ✓
-    'email',                          // 6: type
-    $this->t('name@example.com'),     // 7: placeholder — translated ✓
+    'email',                       // name
+    $this->t('Email address'),     // label
+    $currentEmail,                 // current value (auto-escaped)
+    $this->t('Your login email.'), // help text
+    $this->t('Required'),          // required tooltip
+    '',                            // extra attributes — empty is safest
+    'email',                       // input type
+    $this->t('name@example.com'),  // placeholder
 ],
 ```
 
 ```smarty
 {{include file="field_input.tpl" field=$email}}
 ```
-
-**Available field templates** (verified against `view/templates/` and
-`view/theme/frio/templates/`):
-`field_checkbox.tpl`, `field_colorinput.tpl` (frio only), `field_combobox.tpl`,
-`field_custom.tpl`, `field_datetime.tpl`, `field_fileinput.tpl` (frio only),
-`field_input.tpl`, `field_intcheckbox.tpl`, `field_openid.tpl`,
-`field_password.tpl`, `field_radio.tpl`, `field_select.tpl`,
-`field_select_raw.tpl`, `field_textarea.tpl`, `field_themeselect.tpl`
 
 ### 4.2 Every mutating form MUST have a CSRF token
 
@@ -272,6 +271,15 @@ See [First Change — CSRF](first-change#csrf) for the PHP side.
 
 <a name="css" id="css"></a>
 ## 5. CSS and Themes
+
+> **Keep the three layers separate.**
+>
+> - Data and content manipulation belong in the **PHP** (Module/Service/Presentation)
+> - structure and markup in the **template**
+> - appearance in the **CSS**
+>
+> Don't emit formatted HTML, hardcoded styles, or pre-joined strings from PHP when the template or stylesheet could do the presentation — e.g. pass a list as an array the template can render as a `<ul>`, comma-separated text, or anything else, instead of a fixed comma-separated string.
+> This keeps a change of look possible in the template or stylesheet alone, which is what makes themes and schemes practical to build.
 
 ### 5.1 Frio and Vier — two themes, separate codebases
 
@@ -330,22 +338,13 @@ Edit `view/theme/frio/css/style.css`. This does not affect vier.
 
 Edit `view/theme/vier/style.css`. This does not affect frio.
 
-### 5.3 Frio color system
+### 5.3 Frio colors
 
-Frio generates much of its CSS dynamically from admin-configured color values in `style.php`.
-Most theme colors are still emitted as literal values or PHP template variables, not as reusable CSS custom properties.
-The stable layout variable you are most likely to need is:
+Frio colors are **not** exposed as reusable CSS custom properties — they are emitted as literal values or PHP template variables per scheme. When writing frio CSS, copy color patterns from the existing `style.css` or scheme files rather than inventing global CSS variables.
 
-```css
-:root {
-    --topbar-first-size: 50px;  /* defined in view/theme/frio/css/style.css */
-}
-```
+The one stable layout variable you are likely to need is `--topbar-first-size` (defined in `view/theme/frio/css/style.css`); use `var(--topbar-first-size)` for layout that depends on the topbar height.
 
-When writing frio CSS:
-- Use `var(--topbar-first-size)` for layout that depends on the topbar height
-- For colors, copy patterns from existing `style.css` or scheme files — do not invent global CSS variables without adding them deliberately
-- Test the four frio schemes (light, dark, black, gnome); color changes also need the custom scheme and the accent-color variants (the `scheme_accent` setting)
+Test color changes across the four frio schemes (light, dark, black, gnome), the custom scheme, and the accent-color variants (the `scheme_accent` setting).
 
 ### 5.4 Static presentation styles belong in CSS, not inline
 
@@ -367,8 +366,9 @@ Inline `style=""` attributes are hard to theme and maintain. Use CSS classes ins
 
 ### 6.2 Use the existing IIFE pattern — not ES modules
 
-Scripts load as `<script type="text/javascript" src="...">`. ES module syntax
-(`export` / `import`) is not supported and causes errors.
+Scripts load as `<script type="text/javascript" src="...">`. Wrap your code in an
+[IIFE](#abbreviations) — the `(function () { ... })()` wrapper shown below.
+[ES](#abbreviations) module syntax (`export` / `import`) is not supported and causes errors.
 
 ```javascript
 // SPDX-License-Identifier: AGPL-3.0-or-later
@@ -515,12 +515,12 @@ document.querySelectorAll('.my-action').forEach(function (btn) {
 
 Target [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/). The rules below come up most in Friendica frontend work; the §8 checklist enforces them.
 
-| Rule                                          | Do                                                              | Avoid                                                                |
-|-----------------------------------------------|----------------------------------------------------------------|---------------------------------------------------------------------|
-| Use native elements (keyboard-accessible)     | `<button type="button">`, `<a href="…">`, `<input>`            | `<div class="clickable">` (an `<a>` without `href` isn't focusable) |
-| `alt` on every image                          | `alt="{{$display_name}}"` informative · `alt=""` decorative    | missing `alt`                                                       |
-| Keep a visible focus ring                     | a custom focus style if you override the default               | `outline: none` with no replacement                                 |
-| Don't rely on colour alone to convey meaning  | pair colour with an icon or text                               | colour as the only signal                                           |
+| Rule                                         | Do                                                          | Avoid                                                               |
+|----------------------------------------------|-------------------------------------------------------------|---------------------------------------------------------------------|
+| Use native elements (keyboard-accessible)    | `<button type="button">`, `<a href="…">`, `<input>`         | `<div class="clickable">` (an `<a>` without `href` isn't focusable) |
+| `alt` on every image                         | `alt="{{$display_name}}"` informative · `alt=""` decorative | missing `alt`                                                       |
+| Keep a visible focus ring                    | a custom focus style if you override the default            | `outline: none` with no replacement                                 |
+| Don't rely on colour alone to convey meaning | pair colour with an icon or text                            | colour as the only signal                                           |
 
 **Dynamic updates** — announce changes with an ARIA live region:
 
@@ -534,6 +534,8 @@ Target [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/). The rules below c
 
 <a name="checklist" id="checklist"></a>
 ## 8. Frontend checklist before pushing
+
+The rule checklist lives at the top ([At a glance](#at-a-glance)); this section covers the automated and manual checks to run before pushing.
 
 ```bash
 # PHP checks (templates are rendered by PHP)
@@ -556,17 +558,14 @@ composer run phpstan
 | Structural / semantic change    | Affected theme(s) + keyboard + screen-reader spot-check                                              |
 | Colour change                   | Every scheme/theme actually affected; verify contrast ≥ 4.5:1 (normal text)                          |
 
-**Code checklist:**
+---
 
-- [ ] No hardcoded English strings in `.tpl` or `.js` files visible to users
-- [ ] `nofilter` only for output from an approved rendering path
-- [ ] For every field template used: checked the actual core AND active-theme template file for `nofilter` slots; labels and help text in raw slots are trusted translated strings; raw attribute slots contain only hardcoded server-generated values, never user or remote content
-- [ ] External URLs validated with `Network::isValidHttpUrl()` before output
-- [ ] JSON-to-JS uses `json_encode()` with all four `JSON_HEX_*` flags
-- [ ] DOM manipulation uses `textContent` / `createElement`, never `innerHTML` with untrusted data
-- [ ] Mutating form has CSRF token in template and verified in `post()`
-- [ ] No new `onclick=""` inline handlers
-- [ ] Native HTML elements are used where possible; custom elements have ARIA + keyboard handling
-- [ ] Images have `alt` attributes
-- [ ] Focus indicators aren’t removed without replacement
-- [ ] CSS changes registered via `App\Page` or placed in the correct theme file
+<a name="abbreviations" id="abbreviations"></a>
+## Abbreviations
+
+| Abbr.    | Term                                          | Reference                                                           |
+|----------|-----------------------------------------------|---------------------------------------------------------------------|
+| **CSRF** | Cross-Site Request Forgery                    | [OWASP](https://owasp.org/www-community/attacks/csrf)               |
+| **XSS**  | Cross-Site Scripting                          | [OWASP](https://owasp.org/www-community/attacks/xss/)               |
+| **IIFE** | Immediately Invoked Function Expression       | [MDN](https://developer.mozilla.org/en-US/docs/Glossary/IIFE)       |
+| **ES**   | ECMAScript (the JavaScript language standard) | [MDN](https://developer.mozilla.org/en-US/docs/Glossary/ECMAScript) |

--- a/doc/en/developer/frontend.md
+++ b/doc/en/developer/frontend.md
@@ -338,13 +338,17 @@ Edit `view/theme/frio/css/style.css`. This does not affect vier.
 
 Edit `view/theme/vier/style.css`. This does not affect frio.
 
-### 5.3 Frio colors
+### 5.3 Frio colors and schemes
 
-Frio colors are **not** exposed as reusable CSS custom properties — they are emitted as literal values or PHP template variables per scheme. When writing frio CSS, copy color patterns from the existing `style.css` or scheme files rather than inventing global CSS variables.
+Frio exposes a few status colors as CSS custom properties in `style.css` (`--primary`, `--info`, `--success`, `--warning`, `--danger`, …), but there is no complete design-token system.
+Most colors are still emitted as literal values or PHP template variables per scheme.
+So reuse an existing variable where one fits, but copy color patterns from `style.css` or the scheme files rather than inventing new global variables.
 
-The one stable layout variable you are likely to need is `--topbar-first-size` (defined in `view/theme/frio/css/style.css`); use `var(--topbar-first-size)` for layout that depends on the topbar height.
+A scheme (light / dark / black / gnome) is the user's **explicit choice**, not the operating system's — vier's light/dark variants work the same way.
+So **don't** add dark mode with `@media (prefers-color-scheme: dark)` in a base or component stylesheet: the OS preference is a different signal as the chosen scheme.
+Assuming they match would hand a light-scheme user a dark component, or the reverse.
 
-Test color changes across the four frio schemes (light, dark, black, gnome), the custom scheme, and the accent-color variants (the `scheme_accent` setting).
+Test color changes across all four frio schemes, the custom scheme, and the accent-color variants (`scheme_accent`).
 
 ### 5.4 Static presentation styles belong in CSS, not inline
 
@@ -400,51 +404,31 @@ if ($script !== '') {
 }
 ```
 
-### 6.3 Pass translations to JavaScript via the template
+### 6.3 Pass data and translations to JS via a JSON block
 
-Never hardcode English strings in `.js` files.
-Encode translated strings as JSON in PHP and read them in JavaScript:
+In new code, don't hardcode English strings in `.js` files and don't inject PHP values straight into a `<script>`.
+Encode any data — translated strings or structured config — as JSON with the `JSON_HEX_*` flags, then read it in JS:
 
 ```php
-// In PHP:
-'$strings_json' => json_encode([
+'$data_json' => json_encode([
     'saved'  => $this->t('Settings saved.'),
     'failed' => $this->t('Saving failed.'),
 ], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR),
 ```
 
 ```smarty
-{{* nofilter is safe here: value came directly from json_encode() with JSON_HEX_* flags *}}
-<script type="application/json" id="my-strings">{{$strings_json nofilter}}</script>
+{{* nofilter is safe here: the value came straight from json_encode() with JSON_HEX_* flags *}}
+<script type="application/json" id="my-data">{{$data_json nofilter}}</script>
 ```
 
 ```javascript
-var strings = JSON.parse(
-    document.getElementById('my-strings').textContent
-);
-// strings.saved, strings.failed are now available
+var data = JSON.parse(document.getElementById('my-data').textContent);
+// data.saved, data.failed
 ```
 
-### 6.4 Pass structured data via JSON script block
+The `JSON_HEX_*` flags escape `<`, `>`, `&`, `'`, `"`, so the JSON cannot break out of the `<script>` element.
 
-```php
-'$config_json' => json_encode(
-    $widgetConfig,
-    JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR
-),
-```
-
-```smarty
-<script type="application/json" id="my-config">{{$config_json nofilter}}</script>
-```
-
-```javascript
-var config = JSON.parse(document.getElementById('my-config').textContent);
-```
-
-The `JSON_HEX_*` flags escape `<`, `>`, `&`, `'`, `"` — the JSON cannot break out of the `<script>` element.
-
-### 6.5 Pass small scalar values via data attributes
+### 6.4 Pass small scalar values via data attributes
 
 ```smarty
 <div id="my-widget" data-uid="{{$uid}}" data-url="{{$validated_url}}"></div>
@@ -455,7 +439,7 @@ var uid = document.getElementById('my-widget').dataset.uid;
 ```
 
 <a name="dom-xss" id="dom-xss"></a>
-### 6.6 DOM-XSS — safe JavaScript DOM manipulation
+### 6.5 DOM-XSS — safe JavaScript DOM manipulation
 
 Receiving JSON safely is not enough.
 Inserting data into the DOM can also be an XSS vector.
@@ -492,7 +476,7 @@ element.innerHTML = html;
 
 For content that is intentionally pre-rendered HTML (e.g. from `Item::prepareBody()` fetched via API), use a specifically approved sanitizer before setting `innerHTML`.
 
-### 6.7 No new inline event handlers
+### 6.6 No new inline event handlers
 
 ```smarty
 {{* ✗ *}}

--- a/doc/en/developer/frontend.md
+++ b/doc/en/developer/frontend.md
@@ -1,0 +1,572 @@
+# Frontend Guidelines
+
+* [Developer Intro](index)
+* [Your First Change in Friendica](first-change)
+* [Smarty Templates](smarty3-templates)
+
+---
+
+## Navigation by role
+
+**Find your starting point here before reading further.**
+
+| I want to…                             | Read                                                                                                              |
+|----------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| Fix a colour, spacing, or layout issue | [§5 CSS and Themes](#css)                                                                                         |
+| Change or create a Smarty template     | [§1 Templates](#templates) + [§2 XSS](#xss) + [§3 Translations](#translations)                                    |
+| Add or change JavaScript behaviour     | [§6 JavaScript](#javascript) + [§6.6 DOM-XSS](#dom-xss)                                                           |
+| Add or change a form                   | [§4 Forms](#forms) + [First Change Steps 4–6](first-change#request) (input validation, auth, CSRF) |
+| Pull new data from PHP into a page     | [First Change](first-change) + [§1 Templates](#templates)                                                         |
+| Build or change a `Content/` renderer (PHP) | [PHP Architecture §2.4 Presentation layer](php-architecture#presentation-layer-content)                       |
+| Add accessibility to an element        | [§7 Accessibility](#accessibility)                                                                                |
+
+---
+
+<a name="templates" id="templates"></a>
+## 1. Templates
+
+### 1.1 File locations
+
+| Purpose         | Location                       |
+|-----------------|--------------------------------|
+| Core templates  | `view/templates/`              |
+| Frio overrides  | `view/theme/frio/templates/`   |
+| Vier overrides  | `view/theme/vier/templates/`   |
+| Addon templates | `addon/{addonname}/templates/` |
+
+Core templates in `view/templates/` are the **fallback** used by any theme that does not provide its own override.
+If a theme has its own copy of a template (e.g. `view/theme/frio/templates/example.tpl`), a change to the core `view/templates/example.tpl` will **not** be visible in that theme.
+Check whether the active theme overrides a template before editing the core version.
+
+### 1.2 Rendering from PHP
+
+```php
+$tpl = Renderer::getMarkupTemplate('mymodule/index.tpl');
+return Renderer::replaceMacros($tpl, [
+    '$title'               => $this->t('Page Title'),
+    '$items'               => $items,
+    '$form_security_token' => self::getFormSecurityToken('my-action'),
+]);
+```
+
+By Friendica convention, template variable keys are prefixed with `$`.
+
+### 1.3 Smarty syntax
+
+Friendica uses double curly braces `{{ }}`:
+
+```smarty
+{{* Comment — not shown in output *}}
+
+{{$title}}
+
+{{if $condition}}
+    ...
+{{elseif $other}}
+    ...
+{{else}}
+    ...
+{{/if}}
+
+{{foreach $items as $item}}
+    {{$item.name}}        {{* dot notation for array/object access *}}
+    {{$item['key']}}      {{* bracket notation also works *}}
+{{/foreach}}
+```
+
+---
+
+<a name="xss" id="xss"></a>
+## 2. Output Escaping and XSS Prevention
+
+> **Read this section before touching any template.**
+> One wrong `nofilter` can expose every user of the instance to a cross-site scripting attack.
+
+### 2.1 Auto-escaping is ON — rely on it for all normal variables
+
+Friendica sets `escape_html = true` in `src/Render/FriendicaSmarty.php`.
+Every `{{$variable}}` is HTML-escaped automatically.
+This is your primary XSS defense — **for normal HTML text and ordinary HTML attribute values.**
+
+```smarty
+{{* Safe — HTML text context *}}
+<span>{{$username}}</span>
+
+{{* Safe — ordinary attribute value *}}
+<input type="text" value="{{$current_value}}">
+```
+
+> HTML-escaping is **not** enough for every context. Do **not** interpolate
+> dynamic values directly into:
+> - JavaScript (`<script>var x = "{{$v}}";</script>`) — use the JSON pattern in [§6.3](#javascript)
+> - CSS or `style` attributes
+> - URL attributes without scheme validation ([§2.2](#xss))
+> - event-handler attributes (`onclick`, etc.)
+> - raw HTML via `nofilter`
+
+### 2.2 External URLs need PHP-side scheme validation first
+
+Auto-escaping protects HTML attribute syntax but does NOT stop `javascript:` URLs in `href` or `src`.
+Before passing any external or user-supplied URL to a template:
+
+```php
+// ✓ Validate in PHP — use the project helper
+use Friendica\Util\Network;
+
+if (!Network::isValidHttpUrl($rawUrl)) {
+    $rawUrl = '';
+}
+```
+
+> `Network::isValidHttpUrl()` checks for an `http`/`https` scheme and a host.
+> It does **not** check for private IP ranges, loopback, or DNS rebinding — do not use it as a clearance to fetch the URL from the server.
+
+Internal paths generated by the router or `BaseURL` (e.g. `settings/server`) do not need validation.
+
+### 2.3 `nofilter` — only for approved rendering paths
+
+```smarty
+{{* Only for HTML that has gone through an approved renderer or sanitizer *}}
+<div class="wall-item-body">{{$rendered_html nofilter}}</div>
+```
+
+The key question is not where the data *came from* but whether it went through a *trusted rendering path* — for example `Item::prepareBody()`.
+
+**Never** use `nofilter` for raw user input, content from remote servers without sanitization, or strings assembled by concatenation.
+
+---
+
+<a name="translations" id="translations"></a>
+## 3. Translations
+
+### 3.1 All user-visible strings — PHP, templates, AND JavaScript — must be translated
+
+**In PHP modules:**
+
+```php
+$this->t('Permission denied.')
+$this->t('Welcome, %s!', $username)        // substitution
+$this->tt('%d item', '%d items', $count)   // plural
+```
+
+**Pass translated values to templates; never hardcode English in `.tpl` or `.js` files:**
+
+```php
+'$l10n' => [
+    'title'  => $this->t('Settings'),
+    'submit' => $this->t('Save changes'),
+    'saved'  => $this->t('Settings saved.'),  // also used by JS via §6.3
+],
+```
+
+```smarty
+<h1>{{$l10n.title}}</h1>
+<button type="submit">{{$l10n.submit}}</button>
+```
+
+### 3.2 No string concatenation across word boundaries
+
+```php
+// ✗
+$this->t('Hello') . ', ' . $username . '!';
+
+// ✓
+$this->t('Hello, %s!', $username);
+```
+
+---
+
+<a name="forms" id="forms"></a>
+## 4. Forms
+
+> ### Form Safety Minimum
+>
+> Before submitting a form change, verify all five — even if you only touched the template:
+>
+> 1. The server checks **authentication and authorization** ([First Change Step 5](first-change#auth))
+> 2. Every mutating form **has and verifies a CSRF token** ([§4.2](#forms) and [First Change Step 6](first-change#csrf))
+> 3. Input **type, required state, and length** are validated in the Module ([First Change Step 4](first-change#request))
+> 4. **Business rules** are handled by a Service, not the Module or template
+> 5. Dynamic output stays **escaped** — no new `nofilter` ([§2](#xss))
+
+
+### 4.1 Standard form field templates
+
+Friendica provides Smarty include templates for consistent form fields.
+The array is positional and **the structure differs between templates and between core and frio overrides**.
+Always inspect the actual template file before passing dynamic values — some slots are rendered with `nofilter`.
+
+**`field_input.tpl` only — verified slot map:**
+
+| Index | Meaning                                | Frio nofilter? | Core nofilter? |
+|-------|----------------------------------------|----------------|----------------|
+| 0     | Field name (HTML `name`)               | —              | —              |
+| 1     | Label                                  | **Yes**        | No             |
+| 2     | Current value                          | No             | No             |
+| 3     | Help text                              | **Yes**        | **Yes**        |
+| 4     | Required flag / tooltip text           | No             | No             |
+| 5     | Extra HTML attributes                  | **Yes**        | **Yes**        |
+| 6     | Input type (`'text'`, `'email'`, etc.) | —              | —              |
+| 7     | Placeholder text                       | No             | No             |
+
+> **Security — `nofilter` slots in field templates:**
+> In frio's `field_input.tpl`, slots 1, 3, and 5 are rendered raw.
+> In the core template, slots 3 and 5 are rendered raw.
+> This map is only for `field_input.tpl`.
+> Other templates (checkbox, textarea, password, select\_raw…) have different slot meanings and raw slots — inspect each template before use.
+>
+> **Rules:**
+> - Index 1 (label): a `$this->t()` literal — never user or remote data
+> - Index 3 (help text): trusted translated HTML or plain text only
+> - Index 4 (required tooltip): use `$this->t('Required')`, not the string `'required'`
+> - Index 5 (extra attributes): only hardcoded attribute strings, never dynamic values
+>
+> **A "translated string" is not automatically safe.** Translation with substitution does NOT HTML-escape the substituted values:
+>
+> ```php
+> // ✗ Unsafe in a nofilter slot — $remoteName is not escaped by t()
+> $this->t('Account: %s', $remoteName);
+> ```
+>
+> Never put user- or remote-derived values into a `nofilter` slot, even through `t()`.
+> For dynamic content, use a normally auto-escaped template slot instead, or split the template so the dynamic part is output without `nofilter`.
+
+```php
+// ✓ Safe usage
+'$email' => [
+    'email',                          // 0: name
+    $this->t('Email address'),        // 1: label — trusted translated string ✓
+    $currentEmail,                    // 2: value — auto-escaped ✓
+    $this->t('Your login email.'),    // 3: help — trusted translated string ✓
+    $this->t('Required'),             // 4: tooltip — translated ✓
+    '',                               // 5: extra attributes — empty is safest ✓
+    'email',                          // 6: type
+    $this->t('name@example.com'),     // 7: placeholder — translated ✓
+],
+```
+
+```smarty
+{{include file="field_input.tpl" field=$email}}
+```
+
+**Available field templates** (verified against `view/templates/` and
+`view/theme/frio/templates/`):
+`field_checkbox.tpl`, `field_colorinput.tpl` (frio only), `field_combobox.tpl`,
+`field_custom.tpl`, `field_datetime.tpl`, `field_fileinput.tpl` (frio only),
+`field_input.tpl`, `field_intcheckbox.tpl`, `field_openid.tpl`,
+`field_password.tpl`, `field_radio.tpl`, `field_select.tpl`,
+`field_select_raw.tpl`, `field_textarea.tpl`, `field_themeselect.tpl`
+
+### 4.2 Every mutating form MUST have a CSRF token
+
+```smarty
+<form method="post" action="{{$baseurl}}/my-path">
+    <input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+    ...
+</form>
+```
+
+See [First Change — CSRF](first-change#csrf) for the PHP side.
+
+---
+
+<a name="css" id="css"></a>
+## 5. CSS and Themes
+
+### 5.1 Frio and Vier — two themes, separate codebases
+
+| Theme    | Location           | Status                                                                                                                                                                                   |
+|----------|--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **frio** | `view/theme/frio/` | Default; actively maintained                                                                                                                                                             |
+| **vier** | `view/theme/vier/` | Ships with Friendica, but the user documentation describes it as "no longer officially maintained". Check the current project review policy before requiring vier-specific work in a PR. |
+
+A CSS change in `view/theme/frio/css/style.css` does **not** affect vier, and vice versa.
+If your fix should apply to both themes, you need separate changes in each.
+
+### 5.2 How to add styles — three strategies
+
+**Strategy A: Page-specific stylesheet for new theme-overridable components**
+
+Register a stylesheet for one page via injected `App\Page`, resolving the path with `Theme::getPathForFile()`.
+Use this when a new component needs a base stylesheet that themes may override.
+For narrow fixes in existing theme CSS, use Strategy B or C instead.
+This is a new-page pattern, not a broad existing convention in the repository.
+
+If you choose it, create a path under `css/module/`:
+- base fallback: `view/css/module/mymodule.css`
+- frio override: `view/theme/frio/css/module/mymodule.css`
+- vier override: `view/theme/vier/css/module/mymodule.css`
+
+```php
+use Friendica\App;
+use Friendica\Core\Theme;
+
+// In your module constructor — see first-change.md for the full constructor.
+// BaseSettings and BaseModeration already provide $this->page.
+// In a plain BaseModule subclass, inject App\Page yourself and store it.
+
+protected function content(array $request = []): string
+{
+    // getPathForFile() searches view/theme/{current}/ → view/theme/{parent}/ → view/
+    // and returns the FIRST match, or '' if nothing is found — always check before registering.
+    $stylesheet = Theme::getPathForFile('css/module/mymodule.css');
+    if ($stylesheet !== '') {
+        $this->page->registerStylesheet($stylesheet);
+    }
+}
+```
+
+> **A theme copy fully replaces the base file — it does not cascade.**
+> Because `getPathForFile()` returns only the first match, a `view/theme/frio/css/module/mymodule.css` shadows the base `view/css/module/mymodule.css` entirely.
+> If a theme override should keep the base rules, `@import` or duplicate them.
+
+> **Avoid `DI::page()` in new code** — inject `App\Page` through the constructor instead.
+
+**Strategy B: Frio-specific CSS fix**
+
+Edit `view/theme/frio/css/style.css`. This does not affect vier.
+
+**Strategy C: Vier-specific CSS fix**
+
+Edit `view/theme/vier/style.css`. This does not affect frio.
+
+### 5.3 Frio color system
+
+Frio generates much of its CSS dynamically from admin-configured color values in `style.php`.
+Most theme colors are still emitted as literal values or PHP template variables, not as reusable CSS custom properties.
+The stable layout variable you are most likely to need is:
+
+```css
+:root {
+    --topbar-first-size: 50px;  /* defined in view/theme/frio/css/style.css */
+}
+```
+
+When writing frio CSS:
+- Use `var(--topbar-first-size)` for layout that depends on the topbar height
+- For colors, copy patterns from existing `style.css` or scheme files — do not invent global CSS variables without adding them deliberately
+- Test the four frio schemes (light, dark, black, gnome); color changes also need the custom scheme and the accent-color variants (the `scheme_accent` setting)
+
+### 5.4 Static presentation styles belong in CSS, not inline
+
+Inline `style=""` attributes are hard to theme and maintain. Use CSS classes instead.
+
+---
+
+<a name="javascript" id="javascript"></a>
+## 6. JavaScript
+
+### 6.1 File locations
+
+| Purpose            | Location                      |
+|--------------------|-------------------------------|
+| Core JS            | `view/js/main.js`, `view/js/` |
+| Page-specific JS   | `view/js/module/{page-name}/` |
+| Frio JS            | `view/theme/frio/js/`         |
+| Vendored libraries | `view/js/` or `view/asset/`   |
+
+### 6.2 Use the existing IIFE pattern — not ES modules
+
+Scripts load as `<script type="text/javascript" src="...">`. ES module syntax
+(`export` / `import`) is not supported and causes errors.
+
+```javascript
+// SPDX-License-Identifier: AGPL-3.0-or-later
+(function () {
+    'use strict';
+
+    function init() {
+        document.querySelectorAll('.my-element').forEach(function (el) {
+            el.addEventListener('click', handleClick);
+        });
+    }
+
+    function handleClick(event) {
+        // ...
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();
+```
+
+Register via injected `App\Page`:
+
+```php
+use Friendica\Core\Theme;
+
+$script = Theme::getPathForFile('js/module/my-feature/index.js');
+if ($script !== '') {
+    $this->page->registerFooterScript($script);
+}
+```
+
+### 6.3 Pass translations to JavaScript via the template
+
+Never hardcode English strings in `.js` files.
+Encode translated strings as JSON in PHP and read them in JavaScript:
+
+```php
+// In PHP:
+'$strings_json' => json_encode([
+    'saved'  => $this->t('Settings saved.'),
+    'failed' => $this->t('Saving failed.'),
+], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR),
+```
+
+```smarty
+{{* nofilter is safe here: value came directly from json_encode() with JSON_HEX_* flags *}}
+<script type="application/json" id="my-strings">{{$strings_json nofilter}}</script>
+```
+
+```javascript
+var strings = JSON.parse(
+    document.getElementById('my-strings').textContent
+);
+// strings.saved, strings.failed are now available
+```
+
+### 6.4 Pass structured data via JSON script block
+
+```php
+'$config_json' => json_encode(
+    $widgetConfig,
+    JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR
+),
+```
+
+```smarty
+<script type="application/json" id="my-config">{{$config_json nofilter}}</script>
+```
+
+```javascript
+var config = JSON.parse(document.getElementById('my-config').textContent);
+```
+
+The `JSON_HEX_*` flags escape `<`, `>`, `&`, `'`, `"` — the JSON cannot break out of the `<script>` element.
+
+### 6.5 Pass small scalar values via data attributes
+
+```smarty
+<div id="my-widget" data-uid="{{$uid}}" data-url="{{$validated_url}}"></div>
+```
+
+```javascript
+var uid = document.getElementById('my-widget').dataset.uid;
+```
+
+<a name="dom-xss" id="dom-xss"></a>
+### 6.6 DOM-XSS — safe JavaScript DOM manipulation
+
+Receiving JSON safely is not enough.
+Inserting data into the DOM can also be an XSS vector.
+Follow these rules whenever you put a value into the page via JavaScript:
+
+```javascript
+// ✓ — textContent creates a text node; no markup parsing, no XSS
+element.textContent = config.displayName;
+
+// ✓ For text attributes — safe
+anchor.setAttribute('title', config.label);
+
+// ✓ For URL attributes — safe only after PHP-side scheme validation
+anchor.setAttribute('href', validatedUrl);
+
+// ✗ Never set event-handler attributes from data
+element.setAttribute('onclick', config.code);
+
+// ✗ Never with untrusted data — innerHTML parses markup and can create
+// executable DOM content (event handlers, dangerous URLs, SVG scripts)
+element.innerHTML = config.displayName;
+
+// ✗ Never — insertAdjacentHTML with untrusted content
+element.insertAdjacentHTML('beforeend', data.html);
+
+// ✗ Never — building HTML strings from data
+var html = '<span>' + config.name + '</span>';
+element.innerHTML = html;
+```
+
+**Rule:** Use `textContent` for text. Use `createElement` + `setAttribute` +
+`appendChild` when you need to build elements. Never use `innerHTML`,
+`insertAdjacentHTML`, or string concatenation into HTML with untrusted data.
+
+For content that is intentionally pre-rendered HTML (e.g. from `Item::prepareBody()` fetched via API), use a specifically approved sanitizer before setting `innerHTML`.
+
+### 6.7 No new inline event handlers
+
+```smarty
+{{* ✗ *}}
+<button onclick="doSomething()">Click</button>
+
+{{* ✓ *}}
+<button type="button" class="my-action">Click</button>
+```
+
+```javascript
+document.querySelectorAll('.my-action').forEach(function (btn) {
+    btn.addEventListener('click', handleAction);
+});
+```
+
+---
+
+<a name="accessibility" id="accessibility"></a>
+## 7. Accessibility
+
+Target [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/). The rules below come up most in Friendica frontend work; the §8 checklist enforces them.
+
+| Rule                                          | Do                                                              | Avoid                                                                |
+|-----------------------------------------------|----------------------------------------------------------------|---------------------------------------------------------------------|
+| Use native elements (keyboard-accessible)     | `<button type="button">`, `<a href="…">`, `<input>`            | `<div class="clickable">` (an `<a>` without `href` isn't focusable) |
+| `alt` on every image                          | `alt="{{$display_name}}"` informative · `alt=""` decorative    | missing `alt`                                                       |
+| Keep a visible focus ring                     | a custom focus style if you override the default               | `outline: none` with no replacement                                 |
+| Don't rely on colour alone to convey meaning  | pair colour with an icon or text                               | colour as the only signal                                           |
+
+**Dynamic updates** — announce changes with an ARIA live region:
+
+```smarty
+<div role="status" aria-live="polite" id="notification-count">{{$notification_count}}</div>
+```
+
+**Contrast** — verify ≥ 4.5:1 (normal text) / 3:1 (large) in **every** scheme your change touches: frio light/dark/black/gnome (plus the custom scheme and accent colours for colour changes) and vier. Reusing a theme variable does not guarantee contrast.
+
+---
+
+<a name="checklist" id="checklist"></a>
+## 8. Frontend checklist before pushing
+
+```bash
+# PHP checks (templates are rendered by PHP)
+composer run lint
+composer run phpstan
+
+# Note: lint and phpstan do NOT check JavaScript syntax, CSS, Smarty,
+# accessibility, or browser behaviour. Those require manual testing.
+```
+
+**Manual checks:**
+
+| Change type                     | Minimum testing                                                                                      |
+|---------------------------------|------------------------------------------------------------------------------------------------------|
+| Frio-only CSS file              | Affected frio schemes (light / dark / black / gnome) — no need to test vier                          |
+| Vier-only CSS file              | Vier                                                                                                 |
+| Core template                   | Check first whether frio/vier override it; test only the themes where the change is actually visible |
+| Core JS loaded by all themes    | Every theme in which the script is loaded                                                            |
+| New form or interactive element | The theme(s) it appears in + keyboard + focus + contrast                                             |
+| Structural / semantic change    | Affected theme(s) + keyboard + screen-reader spot-check                                              |
+| Colour change                   | Every scheme/theme actually affected; verify contrast ≥ 4.5:1 (normal text)                          |
+
+**Code checklist:**
+
+- [ ] No hardcoded English strings in `.tpl` or `.js` files visible to users
+- [ ] `nofilter` only for output from an approved rendering path
+- [ ] For every field template used: checked the actual core AND active-theme template file for `nofilter` slots; labels and help text in raw slots are trusted translated strings; raw attribute slots contain only hardcoded server-generated values, never user or remote content
+- [ ] External URLs validated with `Network::isValidHttpUrl()` before output
+- [ ] JSON-to-JS uses `json_encode()` with all four `JSON_HEX_*` flags
+- [ ] DOM manipulation uses `textContent` / `createElement`, never `innerHTML` with untrusted data
+- [ ] Mutating form has CSRF token in template and verified in `post()`
+- [ ] No new `onclick=""` inline handlers
+- [ ] Native HTML elements are used where possible; custom elements have ARIA + keyboard handling
+- [ ] Images have `alt` attributes
+- [ ] Focus indicators aren’t removed without replacement
+- [ ] CSS changes registered via `App\Page` or placed in the correct theme file

--- a/doc/en/developer/php-architecture.md
+++ b/doc/en/developer/php-architecture.md
@@ -712,6 +712,22 @@ DBA::insert('contact', $fields, Database::INSERT_IGNORE);
 
 For a longer read → modify → write sequence that must be all-or-nothing, wrap it in an explicit transaction (`DBA::transaction()` / `DBA::commit()`).
 
+### 10.5 Schema changes and data migrations — what goes where
+
+| What you are doing                                              | Where it goes                                                                                              |
+|----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| Add or change a table or column                                | `static/dbstructure.config.php`                                                                            |
+| Add or change a database view                                  | `static/dbview.config.php`                                                                                 |
+| Migrate data, **critical** — must finish during the update     | `update_<version>()` in `update.php` (use `pre_update_<version>()` if it must run *before* the structure change) |
+| Migrate data, **heavy but non-critical** — can run afterwards  | `update<version>()` in `src/Database/PostUpdate.php` — the cron worker runs it in the background           |
+
+The choice between the last two is about timing: `update.php` runs **synchronously** as part of the update (use it only when the data must be correct before the new code serves requests); `PostUpdate` runs **in the background** afterwards (use it for large back-fills that would otherwise block the upgrade).
+
+After any of the above:
+
+1. Increment `DB_UPDATE_VERSION` in `static/dbstructure.config.php` — the migration function/method name must match that number.
+2. Regenerate the committed `database.sql` with `composer run db:update-structure`.
+
 ## 11. Interface Naming
 
 The `ICan` / `IHandle` / `IManage` convention is used in Capability namespaces:

--- a/doc/en/developer/php-architecture.md
+++ b/doc/en/developer/php-architecture.md
@@ -6,6 +6,7 @@
 
 This document defines what new PHP code in `src/` should look like.
 It is also the reference for Friendica's Domain-Driven Design building blocks — Entity, Factory, Repository, Collection — defined in §2 and the [Key Terms appendix](#key-terms).
+The [layered model](#target-architecture) section shows how these building blocks group into the four tiers `src/` is converging on.
 
 **Scope:** These rules apply to new classes and new methods.
 A small bug fix in legacy code does not require a full migration of the surrounding area.
@@ -43,6 +44,8 @@ Does it turn domain data into template data / HTML?  → Presentation
 
 > **A note against overengineering:** A small read-only feature does not require creating an Entity, Factory, Collection, and Repository if a focused Read Repository returning a documented array shape is enough.
 > Use the full pattern when the entity genuinely has behavior or when multiple callers need the same typed object.
+
+For how these blocks group into the four tiers `src/` is converging on — the same "where does my code go?" one zoom-level out — see [The layered model](#target-architecture) below.
 
 ---
 
@@ -184,6 +187,43 @@ The one thing you are **not** required to do: clean up the legacy file you extra
 
 ---
 
+<a name="target-architecture" id="target-architecture"></a>
+## The target architecture
+
+The Quick decision card above places one class; this is the shape all of `src/` is moving toward — the same building blocks, grouped into four **tiers** by what each may depend on.
+It is the destination the [incremental migration above](#migrating-legacy) aims at, so a boundary you draw today points the right way.
+
+**The direction rule (our main heuristic):** code dependencies point the same way as the foreign keys — never back, no cycles.
+It is not imported theory, it is our own schema: the small tables everything points at (`item-uri`, `user`, `contact`) are the core **nouns**, the tables pointing at them are **features**, code that only delivers or displays is **delivery**, and the plumbing is the **base**.
+So `Model\Contact` must not know about `Notifications` — just as the `contact` table does not point at `notification`, but the other way round.
+
+```
+  Tier 3 · Delivery   Modules · Content renderers · Workers · Protocol adapters · Console   (nothing depends on these)
+     ▼   feature ↔ feature: cross-feature effects via the event bus (src/Event/), not direct imports
+  Tier 2 · Features   <Feature> = Service + Entity/Factory/Repository (write) + Read Repository (read)
+     ▼
+  Tier 1 · Domain     Contact · Post (item-uri) · User   (the big Model/ classes today)
+     ▼
+  Tier 0 · Base       Database · Cache · Lock · Logger · Config · shared enums / value objects
+```
+
+The [§2 building blocks](#layers) are what you write *inside* a tier — the tier only decides who may depend on whom:
+
+| Building block                                                                | Tier                                                               |
+|-------------------------------------------------------------------------------|--------------------------------------------------------------------|
+| `Module`, `Worker`, `Console`, `Protocol` adapters, and the **renderer/presenter** classes in `Content/` | **Delivery**                                                       |
+| `Service`, `Repository`, `Read Repository`, `Factory`, `Entity`, `Collection` | **Features** — or **Domain** for a core noun (Contact, Item, User) |
+| `Database`, `Cache`, `Logger`, `Config`, shared enums / value objects         | **Base**                                                           |
+
+**A tier is a property of a class, not a folder.**
+Names stay flat — there is no physical `src/Domain/` parent (it would rename every namespace and break every import).
+Folders like `Core/`, `Model/`, `Protocol/` still mix tiers, and one folder can span tiers: `Content/<Feature>/` keeps that feature's Delivery renderers next to its Feature/Domain classes ([§2.4](#presentation-layer-content)).
+Those mixed folders are what we untangle over time.
+
+These tiers are boundaries for **new** code; existing violations are unwound by baseline-backed follow-up work — how much exists today, and the order to get there, is tracked in [issue #15981](https://github.com/friendica/friendica/issues/15981), not here.
+
+---
+
 ## 1. Dependency Injection
 
 ### 1.1 New classes MUST use constructor injection
@@ -233,7 +273,11 @@ Use constructor injection or a Factory.
 
 ---
 
+<a name="layers" id="layers"></a>
 ## 2. Layer Separation
+
+The layers below are the building blocks from the [layered model](#target-architecture); each class built from them lives in a single tier.
+These rules keep each block in its lane, which is what keeps the tier dependencies clean.
 
 ### 2.1 Responsibility by layer
 
@@ -260,6 +304,7 @@ Reference: `Protocol\ActivityPub\Firehose` — injected dependencies (incl. the 
 2. **Orchestration** that changes state or enforces a policy → **Service**; that only assembles data for display → **Presentation** ([§2.4](#presentation-layer-content)).
 3. **Auth**: "logged in?", CSRF, own-uid ownership → **Module**; "may this user do X?" (domain policy) → **Service** / **Entity**.
 
+<a name="db-access" id="db-access"></a>
 ### 2.2 DB access MUST stay inside Repositories
 
 `DBA::` and direct use of the injected `Database` object for application queries belong only in Repository classes.
@@ -290,6 +335,11 @@ Do not force complex reads into an entity Repository to satisfy this rule, and d
 
 **Legacy exception:** `DBA::` calls in `mod/` and in `src/Model/` classes are expected.
 Do not add new `DBA::` calls into otherwise clean classes.
+
+**Each table should have one owning Repository — the only class that writes it** (read the owner off the schema: the primary key, the foreign key the row hangs off, or the `uid` for per-user copies).
+This is the target direction, not a rule you can always satisfy today: for a core table the owner is often still a static `Model` class, so new write code routes through the owning Repository once it exists, and otherwise extracts the smallest owner seam or notes the migration exception in the PR — it just does not add a fresh `DBA::` write on a core table (`user`, `contact`, `post*`) from an unrelated class.
+Schema migrations (`update.php`, `PostUpdate`, `DBStructure`) and low-level database-maintenance jobs write directly by design; ordinary application Workers do not — they go through the owning Repository like any other code.
+Derived tables (`post-engagement`, `post-searchindex`) are rebuilt by the read side, never written by hand.
 
 <a name="request-not-superglobals" id="request-not-superglobals"></a>
 ### 2.3 Modules MUST use `$request` — not superglobals
@@ -324,6 +374,7 @@ In Friendica this layer lives mostly under `src/Content/` (and `src/Object/`).
 Presentation code may call read repositories and orchestrate formatters and template rendering, but it should not make business decisions; if the answer changes domain state or decides whether an action is allowed, that belongs in a Service or Entity.
 
 **`Content/<Feature>/` is a feature package, not a layer bucket.** It holds the feature's domain (`Entity/`, `Repository/`, `Factory/`, `Collection/`) *and* its presentation classes together — this package-by-feature layout is intended.
+In tier terms the renderers are Delivery while the `Entity/`/`Repository/` are the feature's Feature (or Domain) classes — one folder, each class keeping its own tier ([the layered model](#target-architecture)).
 Keep new conversation code under `Content/Conversation/`, new notification code under `Navigation/Notifications/`, and so on.
 Do not split a feature across a top-level `Presentation/` vs `Domain/` tree by default.
 If one domain is reused by several unrelated presentation surfaces, introduce a shared domain package deliberately and keep the presentation adapters near their surfaces.
@@ -352,6 +403,7 @@ Prefer a typed view-model object over an untyped `array` for structured presenta
 
 Static calls hide coupling, cannot be injected into a constructor, and are harder to replace with test doubles than instance methods.
 The large static classes in `src/Model/` (Contact, User, Item, Post) are a known problem, not a model to follow.
+In the [target architecture](#target-architecture) these nouns belong in Tier-1 **Domain**; the static classes are temporary shims that shrink as it is adopted.
 
 **Acceptable static use:**
 - Pure functions with no dependencies and no side effects

--- a/doc/en/developer/php-architecture.md
+++ b/doc/en/developer/php-architecture.md
@@ -730,16 +730,15 @@ After any of the above:
 
 ## 11. Interface Naming
 
-The `ICan` / `IHandle` / `IManage` convention is used in Capability namespaces:
+The `I` convention is used in Capability namespaces:
 
 ```
-ICanCache                    IHandleUserSessions
-ICanCreateFromTableRow       IManagePersonalConfigValues
-ICanLock
+ICacheStore           IUserSessionStore
+ITableRowMapper       IPersonalConfigStore
+ILockable             IRequestHandler
 ```
 
-This applies to Capability interfaces that describe what a class does.
-It does not apply universally.
+This is a convention which is not implemented yet, but anytime soon.
 Other interfaces may follow standard PHP naming (`Container`, `LoggerInterface`, `EventDispatcherInterface`).
 Match the style of the namespace you are working in.
 

--- a/doc/en/developer/php-architecture.md
+++ b/doc/en/developer/php-architecture.md
@@ -27,7 +27,7 @@ Before reading further, use this table to find the right place for your code:
 | Turn a database row into a typed object                                                                     | **Factory** (`src/*/Factory/`)                 |
 | Hold a typed list of entities                                                                               | **Collection** (`src/*/Collection/`)           |
 | Represent an immutable value                                                                                | **Value Object** — standalone `readonly class` |
-| Turn domain objects into template data or HTML ([§2.4](#presentation-layer-content))                         | **Presentation** (`src/Content/<Feature>/`)    |
+| Turn domain objects into template data or HTML ([§2.4](#presentation-layer-content))                        | **Presentation** (`src/Content/<Feature>/`)    |
 
 **Decision tree:**
 
@@ -35,7 +35,7 @@ Before reading further, use this table to find the right place for your code:
 Is it HTTP-specific (request, response, redirect)?   → Module
 Does it touch the database?
     One domain object + its consistent data          → Repository
-    Complex read across tables                       → Read Repository
+    Complex read across tables                       → Read Repository/Data Provider
 Does it contain business decisions?                  → Service
 Does it create a typed object from raw data?         → Factory
 Does it turn domain data into template data / HTML?  → Presentation
@@ -119,12 +119,12 @@ final class ProfileService
 
 What moved where:
 
-| Code                                       | Layer      | Reason                              |
-|--------------------------------------------|------------|-------------------------------------|
-| Session check, CSRF, input filtering       | Module     | HTTP-layer concerns                 |
-| Basic input validation (length, emptiness) | Module     | Cheap fail-fast before service call |
-| Domain rules ("is this nickname allowed?") | Service    | Business logic                      |
-| The actual DB call                         | Repository | Persistence layer                   |
+| Code                                                              | Layer      | Reason                              |
+|-------------------------------------------------------------------|------------|-------------------------------------|
+| Session check, CSRF ([Cross-Site Request Forgery](https://owasp.org/www-community/attacks/csrf)), input filtering | Module     | HTTP-layer concerns                 |
+| Basic input validation (length, emptiness)                        | Module     | Cheap fail-fast before service call |
+| Domain rules ("is this nickname allowed?")                        | Service    | Business logic                      |
+| The actual DB call                                                | Repository | Persistence layer                   |
 
 
 ---
@@ -237,16 +237,16 @@ Use constructor injection or a Factory.
 
 ### 2.1 Responsibility by layer
 
-| Layer             | Responsibility                                            | Must not                              |
-|-------------------|----------------------------------------------------------|---------------------------------------|
-| `Module`          | HTTP, input validation, auth, CSRF, ownership (uid match) | Business rules, DB calls, rendering   |
-| `Service`         | Orchestrate a use case + its business rules              | SQL, HTTP, rendering                  |
-| `Repository`      | Read/write one aggregate                                 | Business rules, HTTP                  |
-| `Read Repository` | Complex/multi-table reads, projections                   | Business rules, HTTP                  |
-| `Factory`         | Create typed objects from raw data                       | Persistence, HTTP                     |
-| `Entity`          | Domain data + its own invariants                         | External deps, DB access              |
-| `Collection`      | Typed list of Entities                                   | Business rules                        |
-| `Presentation`    | Template data / HTML ([§2.4](#presentation-layer-content)) | SQL, request access, domain mutation |
+| Layer             | Responsibility                                             | Must not                                                                                                                               |
+|-------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `Module`          | HTTP, input validation, auth, CSRF, ownership (uid match)  | Business rules, DB calls, HTML/markup building (it may call the renderer with prepared data — see [§2.4](#presentation-layer-content)) |
+| `Service`         | Orchestrate a use case + its business rules                | SQL, HTTP, rendering                                                                                                                   |
+| `Repository`      | Read/write one aggregate                                   | Business rules, HTTP                                                                                                                   |
+| `Read Repository` | Complex/multi-table reads, projections                     | Business rules, HTTP                                                                                                                   |
+| `Factory`         | Create typed objects from raw data                         | Persistence, HTTP                                                                                                                      |
+| `Entity`          | Domain data + its own invariants                           | External deps, DB access                                                                                                               |
+| `Collection`      | Typed list of Entities                                     | Business rules                                                                                                                         |
+| `Presentation`    | Template data / HTML ([§2.4](#presentation-layer-content)) | SQL, request access, domain mutation                                                                                                   |
 
 #### The `Service` layer
 
@@ -330,11 +330,11 @@ If one domain is reused by several unrelated presentation surfaces, introduce a 
 
 A new presentation class follows every rule in this document, plus three of its own:
 
-| Rule | Why |
-|------|-----|
-| **No SQL** — DB reads for the feature go in the package's `Repository/` (a Read Repository for complex reads), not in the renderer | A renderer that queries is doing two jobs; the read is not testable or reusable |
-| **No request access** — the Module reads `$request` and passes typed values in | `$_GET`/`$_POST` in a renderer couples it to HTTP and breaks unit testing ([§2.3](#request-not-superglobals)) |
-| **Build data, not markup strings** — hand data to Smarty (`Renderer::replaceMacros`); do not concatenate HTML or `<script>` strings in PHP | String building is where request access and XSS leak into the render layer |
+| Rule                                                                                                                                       | Why                                                                                                           |
+|--------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| **No SQL** — DB reads for the feature go in the package's `Repository/` (a Read Repository for complex reads), not in the renderer         | A renderer that queries is doing two jobs; the read is not testable or reusable                               |
+| **No request access** — the Module reads `$request` and passes typed values in                                                             | `$_GET`/`$_POST` in a renderer couples it to HTTP and breaks unit testing ([§2.3](#request-not-superglobals)) |
+| **Build data, not markup strings** — hand data to Smarty (`Renderer::replaceMacros`); do not concatenate HTML or `<script>` strings in PHP | String building is where request access and XSS leak into the render layer                                    |
 
 #### Pass a typed view model to the template (SHOULD)
 
@@ -642,25 +642,9 @@ public function testCreateFromTableRow(array $input, Entity\FriendSuggest $asser
 
 ## 9. Tooling Reference
 
-Run automatic modifications **first**, review the diff, then validate:
-
-```bash
-# Automatic changes (Rector + CS-Fixer + translation recreation)
-# Modifies files — review with git diff before committing
-composer run rectify
-
-# Validate
-composer run lint          # syntax check (parse errors)
-composer run cs:check      # code style, read-only
-composer run phpstan       # static type analysis (level 4)
-composer run phpmd         # complexity
-
-# Tests
-composer run test:unit     # fast, no database required
-composer run test:integration  # requires a database
-```
-
-For the full suite list and the `MYSQL_*` database environment variables the harness needs, see [Tests](tests).
+Run automatic fixes first, review the diff, then validate.
+The full command sequence — `rectify` → `lint` → `cs:check` → `phpstan` → `phpmd` → tests — is in [Your First Change — Step 11](first-change#checks).
+For the test suites and the `MYSQL_*` database variables the harness needs, see [Tests](tests).
 
 **PHPStan level:** Level 4 with partial strict rules.
 PHPStan does not enforce architectural boundaries such as `DI::` or `DBA::` in the wrong layer — those are reviewed manually.
@@ -708,13 +692,25 @@ $posts = $this->postRepo->selectByUser($uid); // could return thousands
 $posts = $this->postRepo->selectByUserWithPagination($uid, $pager);
 ```
 
-### 10.4 Check for race conditions and locking in multi-step operations
+### 10.4 Check for race conditions and locking in multistep operations
 
 When a sequence of DB operations must be atomic (read → check → write), consider whether a concurrent request can produce an inconsistent result.
 
 **Application-side existence checks alone are not concurrency-safe.**
-Prefer a database-enforced `UNIQUE` constraint as the final integrity boundary.
-For critical write paths, use an explicit transaction, handle duplicate-key errors, or use an atomic `INSERT ... ON DUPLICATE KEY UPDATE`.
+A concurrent request can interleave a "does this row already exist?" read followed by an insert, so two requests both pass the check and both write.
+Make the database the final integrity boundary with a `UNIQUE` constraint, and let the insert resolve the conflict atomically instead of hand-writing SQL.
+
+Friendica's `insert` command already supports this via its `$duplicate_mode` argument — you do not need a raw `INSERT ... ON DUPLICATE KEY UPDATE`:
+
+```php
+// Insert or update the existing row on a UNIQUE-key clash (upsert):
+DBA::insert('contact', $fields, Database::INSERT_UPDATE);
+
+// Insert or silently skip if the row already exists:
+DBA::insert('contact', $fields, Database::INSERT_IGNORE);
+```
+
+For a longer read → modify → write sequence that must be all-or-nothing, wrap it in an explicit transaction (`DBA::transaction()` / `DBA::commit()`).
 
 ## 11. Interface Naming
 
@@ -738,17 +734,17 @@ Match the style of the namespace you are working in.
 
 Brief definitions for readers coming from procedural or database-centric backgrounds.
 
-| Term                    | One-sentence definition                                                                                 | Friendica example                                                                                  |
-|-------------------------|---------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| **Entity**              | A domain object that has identity and may change over time                                              | `Navigation\Notifications\Entity\Notification`                                                     |
-| **Value Object**        | An immutable data holder defined by its values, not identity                                            | A normalised URI or validated email address — two objects with the same value are considered equal |
-| **Aggregate**           | A cluster of data that must stay consistent together                                                    | A notification with its actor, target URI, and read state                                          |
-| **Factory**             | A class whose only job is to create typed objects from raw data                                         | `Navigation\Notifications\Factory\Notification::createFromTableRow()`                              |
-| **Repository**          | A class that loads and saves one kind of aggregate to/from the DB                                       | `Navigation\Notifications\Repository\Notification`                                                 |
-| **Read Repository**     | Like a Repository, but optimised for complex read queries (newer pattern — no core example yet)         | A class that returns `array{id: int, url: string}[]` from a multi-table join                       |
-| **Service**             | Orchestrates a use case and holds its business rules; no SQL (named by what it does, not `*Service`)    | `Protocol\ActivityPub\Firehose` — injects a repository, orchestrates and decides, no SQL of its own |
-| **Collection**          | A typed list of Entities with helper methods                                                            | `Navigation\Notifications\Collection\Notifications`                                                |
-| **Presentation**        | Turns domain objects into template data or HTML; no SQL, no request access                             | `Content\Conversation\` renderers and formatters                                                   |
+| Term                | One-sentence definition                                                                              | Friendica example                                                                                   |
+|---------------------|------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| **Entity**          | A domain object that has identity and may change over time                                           | `Navigation\Notifications\Entity\Notification`                                                      |
+| **Value Object**    | An immutable data holder defined by its values, not identity                                         | A normalised URI or validated email address — two objects with the same value are considered equal  |
+| **Aggregate**       | A cluster of data that must stay consistent together                                                 | A notification with its actor, target URI, and read state                                           |
+| **Factory**         | A class whose only job is to create typed objects from raw data                                      | `Navigation\Notifications\Factory\Notification::createFromTableRow()`                               |
+| **Repository**      | A class that loads and saves one kind of aggregate to/from the DB                                    | `Navigation\Notifications\Repository\Notification`                                                  |
+| **Read Repository** | Like a Repository, but optimised for complex read queries (newer pattern — no core example yet)      | `Content\Conversation\ConversationDataProvider`                                                     |
+| **Service**         | Orchestrates a use case and holds its business rules; no SQL (named by what it does, not `*Service`) | `Protocol\ActivityPub\Firehose` — injects a repository, orchestrates and decides, no SQL of its own |
+| **Collection**      | A typed list of Entities with helper methods                                                         | `Navigation\Notifications\Collection\Notifications`                                                 |
+| **Presentation**    | Turns domain objects into template data or HTML; no SQL, no request access                           | `Content\Conversation\` renderers and formatters                                                    |
 
 ---
 

--- a/doc/en/developer/php-architecture.md
+++ b/doc/en/developer/php-architecture.md
@@ -1,0 +1,761 @@
+# PHP Architecture Guidelines
+
+* [Developer Intro](index)
+* [Your First Change in Friendica](first-change)
+* [Frontend Guidelines](frontend)
+
+This document defines what new PHP code in `src/` should look like.
+It is also the reference for Friendica's Domain-Driven Design building blocks — Entity, Factory, Repository, Collection — defined in §2 and the [Key Terms appendix](#key-terms).
+
+**Scope:** These rules apply to new classes and new methods.
+A small bug fix in legacy code does not require a full migration of the surrounding area.
+When you introduce a new standalone class or component, it should follow these patterns.
+
+---
+
+## Quick decision card — where does my code go?
+
+Before reading further, use this table to find the right place for your code:
+
+| I want to…                                                                                                  | Use                                            |
+|-------------------------------------------------------------------------------------------------------------|------------------------------------------------|
+| Receive a URL, read input, return a page                                                                    | **Module** (`src/Module/`)                     |
+| Check syntax and types of user input                                                                        | **Module** — at the top of `post()` / `get()`  |
+| Decide what should happen (business logic)                                                                  | **Service** (`src/*/`)                         |
+| Load or save one domain object and the data that must stay consistent with it ([what is this?](#key-terms)) | **Repository** (`src/*/Repository/`)           |
+| Run a complex query across multiple tables                                                                  | **Read Repository** (`src/*/Repository/`)      |
+| Turn a database row into a typed object                                                                     | **Factory** (`src/*/Factory/`)                 |
+| Hold a typed list of entities                                                                               | **Collection** (`src/*/Collection/`)           |
+| Represent an immutable value                                                                                | **Value Object** — standalone `readonly class` |
+| Turn domain objects into template data or HTML ([§2.4](#presentation-layer-content))                         | **Presentation** (`src/Content/<Feature>/`)    |
+
+**Decision tree:**
+
+```
+Is it HTTP-specific (request, response, redirect)?   → Module
+Does it touch the database?
+    One domain object + its consistent data          → Repository
+    Complex read across tables                       → Read Repository
+Does it contain business decisions?                  → Service
+Does it create a typed object from raw data?         → Factory
+Does it turn domain data into template data / HTML?  → Presentation
+```
+
+> **A note against overengineering:** A small read-only feature does not require creating an Entity, Factory, Collection, and Repository if a focused Read Repository returning a documented array shape is enough.
+> Use the full pattern when the entity genuinely has behavior or when multiple callers need the same typed object.
+
+---
+
+## Before / After — a representative Friendica-style example
+
+`ProfileService` and `ProfileRepository` are illustrative names for the layers in this example, not required suffixes or files to copy.
+
+**Before:**
+
+```php
+// Everything in the Module: DI::, $_POST, DBA::
+protected function post(array $request = []): void
+{
+    $uid = DI::userSession()->getLocalUserId();
+
+    if (DBA::exists('user', ['uid' => $uid])) {
+        DBA::update('user', [
+            'nickname' => $_POST['nickname'],
+        ], ['uid' => $uid]);
+    }
+}
+```
+
+**After (target pattern):**
+
+```php
+// Module: injected dependencies, explicit auth + CSRF + validation, then delegate
+protected function post(array $request = []): void
+{
+    // Read the user ID once and type-check it (getLocalUserId() returns int|false)
+    $uid = $this->session->getLocalUserId();
+    if (!is_int($uid) || $uid <= 0) {
+        throw new HTTPException\UnauthorizedException($this->t('Please login to continue.'));
+    }
+
+    self::checkFormSecurityTokenRedirectOnError(
+        $this->args->getQueryString(), 'update-nickname'
+    );
+
+    // Read from $request directly so we can type-check; a string default in
+    // getRequestValue() would coerce an array (nickname[]=x) to the string "Array"
+    $rawNickname = $request['nickname'] ?? null;
+    if (!is_string($rawNickname)) {
+        throw new HTTPException\BadRequestException($this->t('Please enter a valid nickname.'));
+    }
+
+    $nickname = trim($rawNickname);
+    if ($nickname === '' || mb_strlen($nickname) > 64) {
+        throw new HTTPException\BadRequestException($this->t('Please enter a valid nickname.'));
+    }
+
+    $this->profileService->updateNickname($uid, $nickname);
+
+    $this->baseUrl->redirect($this->args->getQueryString());
+}
+```
+
+```php
+// Service: business logic only — no HTTP concerns, no DBA::
+final class ProfileService
+{
+    public function __construct(
+        private readonly ProfileRepository $profiles,
+    ) {}
+
+    public function updateNickname(int $uid, string $nickname): void
+    {
+        $profile = $this->profiles->selectByUserId($uid);
+        $profile->setNickname($nickname);
+        $this->profiles->save($profile);
+    }
+}
+```
+
+What moved where:
+
+| Code                                       | Layer      | Reason                              |
+|--------------------------------------------|------------|-------------------------------------|
+| Session check, CSRF, input filtering       | Module     | HTTP-layer concerns                 |
+| Basic input validation (length, emptiness) | Module     | Cheap fail-fast before service call |
+| Domain rules ("is this nickname allowed?") | Service    | Business logic                      |
+| The actual DB call                         | Repository | Persistence layer                   |
+
+
+---
+
+## Norm labels
+
+| Label            | Meaning                                                                                                                                                                                                                                                            |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| MUST             | Hard rule. CI or review will block violations.                                                                                                                                                                                                                     |
+| SHOULD           | Standard; a justified exception with a brief comment is acceptable — explain the reason in the PR description. A `// @todo` is useful only when it points to a concrete, bounded follow-up (ideally with an issue number). A comment alone is not a justification. |
+| MAY              | Permitted option, not required.                                                                                                                                                                                                                                    |
+| Legacy exception | Existing code prevents the target pattern here. Note the reason with a `// @todo` that includes a concrete follow-up. Do not introduce a new violation merely because surrounding code already has similar issues.                                                 |
+| Migration task   | The improvement is welcome but not required in the current PR.                                                                                                                                                                                                     |
+
+---
+
+<a name="migrating-legacy" id="migrating-legacy"></a>
+## Migrating legacy code incrementally
+
+You do not have to rewrite a file to improve it.
+The goal is to draw one clean boundary each time you touch legacy code — not to convert everything at once.
+
+**Migrating one legacy method:**
+
+1. Keep the current public behavior unchanged.
+2. Add or identify a test that protects that behavior first.
+3. Move the direct `DBA::` query into a focused Repository method.
+4. Inject that Repository instead of adding another `DI::` call.
+5. Move business decisions out of the Module into a Service.
+6. Leave unrelated legacy code in the same file untouched.
+7. Add Entities or Collections only when they earn their place (see the overengineering note above).
+
+**Where to start, by what you see:**
+
+| Legacy code you're touching                | First useful step                                            |
+|--------------------------------------------|--------------------------------------------------------------|
+| `DBA::select()` inside a Module            | Extract it into a Repository method                          |
+| Several `DI::*` calls in one class         | Inject those dependencies one at a time                      |
+| A large static `Model` method              | Wrap it behind a Service or adapter first                    |
+| SQL and a business decision mixed together | SQL → Repository, decision → Service                         |
+| A complex read-only query                  | Read Repository — not a full Entity/Factory/Collection stack |
+| A huge "god" class                         | Extract only the responsibility you are changing right now   |
+
+Over time the islands of clean code grow without a big-bang rewrite.
+
+<a name="extracting-legacy" id="extracting-legacy"></a>
+### Extracting legacy into a new file
+
+A class you create while refactoring is new code, so it follows every rule in this document — SPDX header, `strict_types`, constructor injection, no superglobals, DB access only in a Repository.
+"Behavior-preserving" means the behavior is preserved, not the legacy style: a leak the move exposes (a renderer reading `$_GET`) is fixed in the extraction, not carried into the new class.
+
+Do not move an 800-line legacy method unchanged into a new class and call the result "new architecture".
+If the extracted code cannot meet the rules yet, keep it in the legacy file, or extract only the clean boundary you can name and test now.
+The new class should have one responsibility; remaining mixed responsibilities stay behind the legacy boundary until they are migrated deliberately.
+
+The one thing you are **not** required to do: clean up the legacy file you extracted *from*, or its other callers. Leave that surrounding legacy as-is.
+
+---
+
+## 1. Dependency Injection
+
+### 1.1 New classes MUST use constructor injection
+
+`DI::` is a global service locator kept for historical reasons and actively being phased out.
+New code that uses it is much harder to unit-test in isolation: dependencies are invisible and require manipulating global container state to replace with test doubles.
+
+```php
+// ✗ Do not use in new classes
+class MyService
+{
+    public function run(): void
+    {
+        DI::logger()->info('running');
+        $uid = DI::userSession()->getLocalUserId();
+    }
+}
+
+// ✓ Inject through the constructor
+class MyService
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly IHandleUserSessions $userSession,
+    ) {}
+
+    public function run(): void
+    {
+        $this->logger->info('running');
+        $uid = $this->userSession->getLocalUserId();
+    }
+}
+```
+
+Dice resolves concrete class dependencies automatically.
+Interfaces and scalar values need an explicit rule in `static/dependencies.config.php` (see [Your First Change — Step 10](first-change#dice)).
+
+**Legacy exception:** `DI::` calls in `mod/` and in `src/Model/` classes not yet migrated are expected.
+Do not add new `DI::` calls into otherwise injected classes.
+
+### 1.2 New classes SHOULD NOT call `new ServiceClass()` inside methods
+
+Constructing a service inside a method hides it from tests.
+Use constructor injection or a Factory.
+
+**Exception:** Value objects and Entities (`new Entity\Foo(...)`) are correctly created inside Factories.
+
+---
+
+## 2. Layer Separation
+
+### 2.1 Responsibility by layer
+
+| Layer             | Responsibility                                            | Must not                              |
+|-------------------|----------------------------------------------------------|---------------------------------------|
+| `Module`          | HTTP, input validation, auth, CSRF, ownership (uid match) | Business rules, DB calls, rendering   |
+| `Service`         | Orchestrate a use case + its business rules              | SQL, HTTP, rendering                  |
+| `Repository`      | Read/write one aggregate                                 | Business rules, HTTP                  |
+| `Read Repository` | Complex/multi-table reads, projections                   | Business rules, HTTP                  |
+| `Factory`         | Create typed objects from raw data                       | Persistence, HTTP                     |
+| `Entity`          | Domain data + its own invariants                         | External deps, DB access              |
+| `Collection`      | Typed list of Entities                                   | Business rules                        |
+| `Presentation`    | Template data / HTML ([§2.4](#presentation-layer-content)) | SQL, request access, domain mutation |
+
+#### The `Service` layer
+
+A `Service` orchestrates a use case and holds its business rules — one layer, named by what it does (no `*Service` suffix).
+Reference: `Protocol\ActivityPub\Firehose` — injected dependencies (incl. the `UserDefinedChannel` repository), no SQL of its own, a domain decision (`isSolicitedPost()`) next to the orchestration, `protected` seams for tests.
+(`ProfileService` / `WidgetService` elsewhere are illustrative layer labels, not required class names.)
+
+**Where does a piece of logic go?**
+
+1. **Business rule** about one entity's own data → that **Entity** (`setNickname()` rejects an invalid value). Needs a DB lookup or several entities ("is this nickname unique?") → **Service**.
+2. **Orchestration** that changes state or enforces a policy → **Service**; that only assembles data for display → **Presentation** ([§2.4](#presentation-layer-content)).
+3. **Auth**: "logged in?", CSRF, own-uid ownership → **Module**; "may this user do X?" (domain policy) → **Service** / **Entity**.
+
+### 2.2 DB access MUST stay inside Repositories
+
+`DBA::` and direct use of the injected `Database` object for application queries belong only in Repository classes.
+
+```php
+// ✗ Direct DB call in a Module or Service
+$rows = DBA::select('user', ['uid'], ['verified' => true]);
+
+// ✓ Delegate to a Repository
+$users = $this->userRepository->selectVerified();
+```
+
+**Complex queries:** Not every query maps to a single entity Repository.
+For multi-table reads, aggregates, timeline queries, or administrative reports, use a **Read Repository** (also called a Query Object):
+a class whose explicit job is data access.
+This is a **newer pattern** in Friendica — there is not yet an established example class to copy, so treat the rules below as the intended shape rather than a widespread one.
+A Read Repository MAY contain `DBA::` / `Database` queries — it is a persistence class, not a Service.
+
+Keep the distinction clear:
+
+| Class                          | DB access allowed? | Role                                                              |
+|--------------------------------|--------------------|-------------------------------------------------------------------|
+| Entity Repository              | Yes                | Persist and load one aggregate                                    |
+| Read Repository / Query Object | Yes                | Complex/read-optimised queries, projections                       |
+| Service                        | No                 | Orchestrates repositories; contains no `DBA::`/`Database` queries |
+
+Do not force complex reads into an entity Repository to satisfy this rule, and do not put SQL into a Service.
+
+**Legacy exception:** `DBA::` calls in `mod/` and in `src/Model/` classes are expected.
+Do not add new `DBA::` calls into otherwise clean classes.
+
+<a name="request-not-superglobals" id="request-not-superglobals"></a>
+### 2.3 Modules MUST use `$request` — not superglobals
+
+`$_GET`, `$_POST`, `$_REQUEST`, and `$_SERVER` MUST NOT appear in new module code.
+Use `$this->getRequestValue()` on the `$request` array, or read `$request[...]` directly when you need an explicit type check
+(reading the passed `$request` array is fine — it is the superglobals themselves that are forbidden).
+
+```php
+// ✗
+$id = (int) $_POST['id'];
+
+// ✓
+$id = $this->getRequestValue($request, 'id', 0);
+if ($id === false) {
+    throw new HTTPException\BadRequestException();
+}
+```
+
+> `getRequestValue()` is type-dependent filtering, **not** input validation, and its string and bool defaults have sharp edges (an array input is coerced to the literal `"Array"`; `false` is indistinguishable from invalid).
+> See [Your First Change — Step 4](first-change#request) for the per-type rules.
+> Validate length, allowed values, and domain constraints separately in the Service or before calling the Repository.
+
+**Legacy exception:** Direct superglobal access in existing `mod/` and `src/Model/` code is expected.
+Do not add superglobal access to a new class — including one you create by extracting legacy code (see [Extracting legacy into a new file](#extracting-legacy)).
+
+<a name="presentation-layer-content" id="presentation-layer-content"></a>
+### 2.4 Presentation layer (`Content/`)
+
+A class that turns domain objects into template data or HTML — a Renderer, Formatter, or Presenter — belongs in the presentation layer, not in a Module or a domain Service.
+In Friendica this layer lives mostly under `src/Content/` (and `src/Object/`).
+Presentation code may call read repositories and orchestrate formatters and template rendering, but it should not make business decisions; if the answer changes domain state or decides whether an action is allowed, that belongs in a Service or Entity.
+
+**`Content/<Feature>/` is a feature package, not a layer bucket.** It holds the feature's domain (`Entity/`, `Repository/`, `Factory/`, `Collection/`) *and* its presentation classes together — this package-by-feature layout is intended.
+Keep new conversation code under `Content/Conversation/`, new notification code under `Navigation/Notifications/`, and so on.
+Do not split a feature across a top-level `Presentation/` vs `Domain/` tree by default.
+If one domain is reused by several unrelated presentation surfaces, introduce a shared domain package deliberately and keep the presentation adapters near their surfaces.
+
+A new presentation class follows every rule in this document, plus three of its own:
+
+| Rule | Why |
+|------|-----|
+| **No SQL** — DB reads for the feature go in the package's `Repository/` (a Read Repository for complex reads), not in the renderer | A renderer that queries is doing two jobs; the read is not testable or reusable |
+| **No request access** — the Module reads `$request` and passes typed values in | `$_GET`/`$_POST` in a renderer couples it to HTTP and breaks unit testing ([§2.3](#request-not-superglobals)) |
+| **Build data, not markup strings** — hand data to Smarty (`Renderer::replaceMacros`); do not concatenate HTML or `<script>` strings in PHP | String building is where request access and XSS leak into the render layer |
+
+#### Pass a typed view model to the template (SHOULD)
+
+Prefer a typed view-model object over an untyped `array` for structured presentation data.
+
+> **Trade-off.** Friendica's established convention is to pass plain `array`s to Smarty.
+> Matching that convention is an accepted SHOULD exception — when you do, document the shape with `@return array{…}` so callers and templates know what is inside.
+> Reach for a typed view model when the data is reused, nested, built in several steps, or has helper behaviour; stay with a documented array for small one-template payloads that mirror surrounding Smarty code.
+
+---
+
+## 3. Static Methods
+
+### 3.1 New code SHOULD NOT introduce static methods
+
+Static calls hide coupling, cannot be injected into a constructor, and are harder to replace with test doubles than instance methods.
+The large static classes in `src/Model/` (Contact, User, Item, Post) are a known problem, not a model to follow.
+
+**Acceptable static use:**
+- Pure functions with no dependencies and no side effects
+- `BaseModule::getFormSecurityToken()` and `checkFormSecurityToken*()` — use as-is
+
+**Existing framework static APIs (temporarily accepted):**
+
+`Renderer::getMarkupTemplate()`, `Renderer::replaceMacros()`, and `Theme::getPathForFile()` are static methods that internally use `DI::`.
+They exist throughout the codebase and have no injected alternative yet.
+Calling them in new code is accepted for now.
+Do **not** create new static framework APIs following this pattern.
+
+---
+
+## 4. Type System
+
+### 4.1 New methods MUST declare a return type
+
+All new `public` and `protected` methods must have a native return type.
+Constructors are exempt — PHP does not allow a return type on `__construct`.
+
+```php
+// ✗
+public function getItems($uid) { return []; }
+
+// ✓
+public function getItems(int $uid): array { return []; }
+```
+
+### 4.2 Untyped `array` returns SHOULD be avoided
+
+Prefer a typed Collection, a typed Entity, or a documented shape via PHPDoc.
+
+```php
+// ✗ Caller has no idea what is inside
+public function getContacts(int $uid): array { ... }
+
+// ✓ Typed Collection (preferred for domain objects)
+public function getContacts(int $uid): Contacts { ... }
+
+// ✓ Document the shape when a Collection class does not exist yet
+/** @return array{id: int, url: string}[] */
+public function buildLinkList(): array { ... }
+```
+
+### 4.3 Use `never` only for methods that cannot return
+
+```php
+// ✓ PHPStan can then eliminate dead code paths after this call.
+private function failLogin(): never
+{
+    throw new HTTPException\UnauthorizedException($this->t('Login required.'));
+}
+```
+
+Do not put `never` on normal guard methods such as `requireLocalUserId(): int`.
+If a method may return on success, its return type is the successful value type, not `never`.
+
+### 4.4 Every new file MUST start with `declare(strict_types=1)` and the SPDX header
+
+```php
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\...;
+```
+
+> Most existing code — including the reference stacks this guide cites (`src/Navigation/Notifications/`) — predates this rule.
+> It applies to new code going forward, including classes you create by extracting legacy code; it is not applied retroactively to the examples.
+
+---
+
+## 5. Modern PHP (≥ 8.2 — the project minimum)
+
+### 5.1 Use `enum` for new closed value sets
+
+Do not add new abstract classes that serve only as constant containers.
+
+```php
+// ✗ Old pattern — still present, do not replicate
+abstract class Status
+{
+    const OPEN   = 0;
+    const CLOSED = 1;
+}
+
+// ✓ New code — a genuinely closed domain value set with no scalar API dependency
+enum ReportStatus: int
+{
+    case Open   = 0;
+    case Closed = 1;
+}
+
+// Usage — type-safe; passing an arbitrary int causes a runtime TypeError
+// (PHPStan detects it statically before runtime)
+function closeReport(int $id, ReportStatus $status): void { ... }
+closeReport(42, ReportStatus::Closed);
+```
+
+**When enums are NOT appropriate — do not convert existing scalar constants to enums when:**
+- The constant is passed directly to a scalar API (`int $ttl`, SQL values, library constants)
+  — doing so causes a `TypeError`.
+  Example: cache TTL constants (`Duration::HOUR`) are used as `int $ttl` in cache interfaces and cannot be replaced by an enum case without changing every caller.
+- Bitmasked or combinable flags (e.g. `Report::CATEGORY_SPAM | Report::CATEGORY_ILLEGAL`)
+- The set is open or defined externally (HTTP status codes, ActivityPub verbs)
+- Migration would be a public API break
+
+Migrating existing constants to enums is a separate Migration task; do not do it as a side effect of an unrelated fix.
+
+### 5.2 Use `readonly` for standalone Value Objects
+
+`readonly class` cannot extend a non-readonly class.
+Classes in the existing `BaseEntity` hierarchy MUST NOT be declared `readonly` until `BaseEntity` itself is migrated.
+Use `readonly` only for new standalone Value Objects.
+
+```php
+// ✓ Standalone Value Object — no parent class
+readonly class Money
+{
+    public function __construct(
+        public int $amount,
+        public string $currency,
+    ) {}
+}
+```
+
+### 5.3 Mark sensitive parameters with `#[SensitiveParameter]`
+
+```php
+// ✓
+public function authenticate(
+    string $username,
+    #[\SensitiveParameter] string $password,
+): bool { ... }
+```
+
+> This only redacts the value in PHP **stack traces**.
+> It does not redact explicit log context, full request dumps, exception messages, or serialized data.
+> Keeping secrets out of logs is a separate responsibility.
+
+### 5.4 Prefer `match` for expression-style branching
+
+```php
+// ✗ For simple value → result mappings
+switch ($type) {
+    case self::PT_NOTE:  return 'note';
+    default:             return 'unknown';
+}
+
+// ✓
+return match($type) {
+    self::PT_NOTE  => 'note',
+    self::PT_IMAGE => 'image',
+    default        => 'unknown',
+};
+```
+
+`switch` remains appropriate when individual cases contain multiple statements, use intentional fallthrough, or need `continue`/`break` in a loop context.
+
+### 5.5 Use first-class callable syntax
+
+```php
+// ✗
+$lower = array_map(function (string $s): string { return strtolower($s); }, $items);
+
+// ✓
+$lower = array_map(strtolower(...), $items);
+```
+
+---
+
+## 6. Named Constants — No Magic Numbers or Strings
+
+Values whose meaning is not obvious at the call site SHOULD have a named constant.
+
+```php
+// ✗ Reader cannot know what 2 means without reading Contact class
+if ($contact['rel'] === 2) { ... }
+
+// ✓ Contact::SHARING = 2 (Contact::FRIEND = 3 — a different value)
+if ($contact['rel'] === Contact::SHARING) { ... }
+
+// ✗ Constant does not exist
+if ($item['private'] === Item::PRIVATE_POST) { ... }
+
+// ✓ Correct constant name
+if ($item['private'] === Item::PRIVATE) { ... }
+```
+
+Not every literal needs a constant.
+Log messages, one-off limits, and self-explanatory values do not.
+Apply judgment: would a reader unfamiliar with this code understand the value's meaning at the call site?
+
+---
+
+## 7. Error Handling
+
+### 7.1 MUST NOT silently swallow exceptions
+
+```php
+// ✗ Never
+try {
+    $this->repo->save($entity);
+} catch (\Exception) {
+    // nothing
+}
+```
+
+### 7.2 Catch only where you can meaningfully handle
+
+Log the exception once, at the point where you have enough context to add value.
+Do not log and rethrow in every layer — that produces duplicate log entries for the same error.
+
+```php
+// ✓ Translate to a domain-specific exception with added context
+try {
+    $this->db->insert('friend_suggest', $data);
+} catch (\Exception $e) {
+    throw new FriendSuggestPersistenceException(
+        sprintf('Could not store FriendSuggest for uid %d', $uid),
+        previous: $e,
+    );
+}
+
+// ✓ Handle gracefully when appropriate
+try {
+    $entity = $this->repository->selectOneByUserAndServer($uid, $gsid);
+    $this->repository->delete($entity);
+} catch (NotFoundException) {
+    // Nothing to delete — expected case
+}
+```
+
+Use domain-specific exception classes from `src/{Domain}/Exception/`, not generic `\Exception`. Use `HTTPException\*` only in Module classes.
+
+---
+
+## 8. Testing
+
+### 8.1 Test type by layer
+
+| Layer                 | Primary test type           |
+|-----------------------|-----------------------------|
+| Value Object / Entity | Unit test                   |
+| Pure Service          | Unit test                   |
+| Factory / Mapper      | Unit test                   |
+| Repository            | Integration test            |
+| HTTP Client Adapter   | Integration / Contract test |
+| Module                | Functional test             |
+| Template              | Functional / Browser test   |
+
+Not every class needs a test. Marker interfaces, configuration objects,
+and simple DTOs with no logic do not need dedicated tests.
+
+### 8.2 Unit-testable classes SHOULD have unit tests
+
+A class is unit-testable when all its external dependencies and configuration values are explicit and controllable by the test — no `DI::`, no `DBA::`, no superglobals inside the methods.
+Scalar configuration values (a base path, a limit) passed through the constructor are fine.
+
+The `src/Contact/FriendSuggest/Factory/FriendSuggest.php` class and its test in `tests/Unit/Contact/FriendSuggest/Factory/FriendSuggestTest.php` are a clean reference example.
+The test uses `NullLogger`, no database, and no DI container.
+
+### 8.3 Use PHPUnit data providers for multiple input cases
+
+```php
+// ✓ PHPUnit 11 attribute syntax (the version the project currently uses)
+#[\PHPUnit\Framework\Attributes\DataProvider('dataCreate')]
+public function testCreateFromTableRow(array $input, Entity\FriendSuggest $assertion): void
+{
+    $factory = new FriendSuggest(new NullLogger());
+    $result  = $factory->createFromTableRow($input);
+
+    self::assertSame($assertion->uid, $result->uid);
+}
+```
+
+> This is a shortened illustration, not copy-paste-ready code.
+> The real test method name is `dataCreate` and its rows use the key `assertion`.
+> The `FriendSuggest` Entity constructor requires all nine parameters — copy the full field list and the complete provider from `tests/Unit/Contact/FriendSuggest/Factory/FriendSuggestTest.php`.
+
+---
+
+## 9. Tooling Reference
+
+Run automatic modifications **first**, review the diff, then validate:
+
+```bash
+# Automatic changes (Rector + CS-Fixer + translation recreation)
+# Modifies files — review with git diff before committing
+composer run rectify
+
+# Validate
+composer run lint          # syntax check (parse errors)
+composer run cs:check      # code style, read-only
+composer run phpstan       # static type analysis (level 4)
+composer run phpmd         # complexity
+
+# Tests
+composer run test:unit     # fast, no database required
+composer run test:integration  # requires a database
+```
+
+For the full suite list and the `MYSQL_*` database environment variables the harness needs, see [Tests](tests).
+
+**PHPStan level:** Level 4 with partial strict rules.
+PHPStan does not enforce architectural boundaries such as `DI::` or `DBA::` in the wrong layer — those are reviewed manually.
+
+---
+
+## 10. Database Performance
+
+These four rules matter more for Friendica's production behavior than most style choices.
+They apply to all new code that touches the database.
+
+### 10.1 No DB queries inside loops
+
+```php
+// ✗ N+1 queries — executes one query per item
+foreach ($items as $item) {
+    $contact = $this->contactRepo->selectById($item['author_id']); // inside loop!
+}
+
+// ✓ Load all necessary data before the loop
+$authorIds = array_column($items, 'author_id');
+$contacts  = $this->contactRepo->selectByIds($authorIds);
+```
+
+### 10.2 Select only the columns you need
+
+```php
+// Inside a Repository:
+// ✗ — empty field array means "all columns" in Friendica; wasteful
+$users = DBA::select('user', [], ['verified' => true]);
+
+// ✓ — inside a Repository only; name the columns the caller needs
+$users = DBA::select('user', ['uid', 'nickname', 'email'], ['verified' => true]);
+```
+
+### 10.3 Always limit or paginate large result sets
+
+A query with no `LIMIT` on a large table can kill the server under load.
+
+```php
+// ✗
+$posts = $this->postRepo->selectByUser($uid); // could return thousands
+
+// ✓
+$posts = $this->postRepo->selectByUserWithPagination($uid, $pager);
+```
+
+### 10.4 Check for race conditions and locking in multi-step operations
+
+When a sequence of DB operations must be atomic (read → check → write), consider whether a concurrent request can produce an inconsistent result.
+
+**Application-side existence checks alone are not concurrency-safe.**
+Prefer a database-enforced `UNIQUE` constraint as the final integrity boundary.
+For critical write paths, use an explicit transaction, handle duplicate-key errors, or use an atomic `INSERT ... ON DUPLICATE KEY UPDATE`.
+
+## 11. Interface Naming
+
+The `ICan` / `IHandle` / `IManage` convention is used in Capability namespaces:
+
+```
+ICanCache                    IHandleUserSessions
+ICanCreateFromTableRow       IManagePersonalConfigValues
+ICanLock
+```
+
+This applies to Capability interfaces that describe what a class does.
+It does not apply universally.
+Other interfaces may follow standard PHP naming (`Container`, `LoggerInterface`, `EventDispatcherInterface`).
+Match the style of the namespace you are working in.
+
+---
+
+<a name="key-terms" id="key-terms"></a>
+## Appendix: Key Terms
+
+Brief definitions for readers coming from procedural or database-centric backgrounds.
+
+| Term                    | One-sentence definition                                                                                 | Friendica example                                                                                  |
+|-------------------------|---------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| **Entity**              | A domain object that has identity and may change over time                                              | `Navigation\Notifications\Entity\Notification`                                                     |
+| **Value Object**        | An immutable data holder defined by its values, not identity                                            | A normalised URI or validated email address — two objects with the same value are considered equal |
+| **Aggregate**           | A cluster of data that must stay consistent together                                                    | A notification with its actor, target URI, and read state                                          |
+| **Factory**             | A class whose only job is to create typed objects from raw data                                         | `Navigation\Notifications\Factory\Notification::createFromTableRow()`                              |
+| **Repository**          | A class that loads and saves one kind of aggregate to/from the DB                                       | `Navigation\Notifications\Repository\Notification`                                                 |
+| **Read Repository**     | Like a Repository, but optimised for complex read queries (newer pattern — no core example yet)         | A class that returns `array{id: int, url: string}[]` from a multi-table join                       |
+| **Service**             | Orchestrates a use case and holds its business rules; no SQL (named by what it does, not `*Service`)    | `Protocol\ActivityPub\Firehose` — injects a repository, orchestrates and decides, no SQL of its own |
+| **Collection**          | A typed list of Entities with helper methods                                                            | `Navigation\Notifications\Collection\Notifications`                                                |
+| **Presentation**        | Turns domain objects into template data or HTML; no SQL, no request access                             | `Content\Conversation\` renderers and formatters                                                   |
+
+---
+
+## Further reading
+
+The patterns above are standard Domain-Driven Design building blocks. For background:
+
+- [Dependency Injection](https://designpatternsphp.readthedocs.io/en/latest/Structural/DependencyInjection/README.html)
+- [Simple Factory](https://designpatternsphp.readthedocs.io/en/latest/Creational/SimpleFactory/README.html) / [Factory Method](https://designpatternsphp.readthedocs.io/en/latest/Creational/FactoryMethod/README.html)
+- [Repository](https://designpatternsphp.readthedocs.io/en/latest/More/Repository/README.html)


### PR DESCRIPTION
Add three reference guides under doc/en/developer/:
- php-architecture.md: the layer model (Module/Service/Repository/Read Repository/Factory/Entity/Collection + Presentation), DI over DI::, typing, error handling, DB performance; also the reference for the Entity/Factory/Repository pattern
- first-change.md: step-by-step 'your first module' walkthrough with the canonical skeleton (auth, CSRF, typed input, no superglobals)
- frontend.md: templates, output escaping/XSS, translations, forms, JavaScript, accessibility

AI-Transparenxy: I created the base doc by myself, but enhanced it with AI and peer-reviewed it about 10 times, having AI as my red-team/sparring partner

plz review it @art4 , @annando 
for frontend plz @marcusxss @randompenguin1

The goal is to clear a lot of outdated and now even wrong developer-guidlines in the docs section (part of the followup PR)