### PR TITLE
Add Account Type Icons Everywhere + Admin & Moderator Badges

### DIFF
--- a/src/Content/Widget/Hovercard.php
+++ b/src/Content/Widget/Hovercard.php
@@ -49,25 +49,7 @@ readonly class Hovercard
 
 		$contact_url = Contact::getProfileLink($contact);
 
-		$administrator = false;
-		$moderator     = false;
-		if (Contact::isLocalById($contact['id'])) {
-			$local_id = User::getIdForURL($contact['url']);
-			// check if contact is a Moderator
-			if (User::isModerator($local_id)) {
-				$moderator = true;
-			}
-			// check if contact is an Admin
-			if (User::isSiteAdmin($local_id)) {
-				$administrator = true;
-				$moderator     = false;
-				// do not show as Admin if this is a sub-account of an Admin
-				$check = User::getById($local_id, ['parent-uid']);
-				if ($check['parent-uid']) {
-					$administrator = false;
-				}
-			}
-		}
+		[$administrator, $moderator] = Contact::getType($contact['id'], $contact['url']);
 
 		// Move the contact data to the profile array so we can deliver it to
 		$tpl = Renderer::getMarkupTemplate('hovercard.tpl');

--- a/src/Content/Widget/Hovercard.php
+++ b/src/Content/Widget/Hovercard.php
@@ -50,7 +50,7 @@ class Hovercard
 		$administrator = false;
 		$moderator     = false;
 		if (Contact::isLocalById($contact['id'])) {
-			$local_id = User::getIdForUrl($contact['url']);
+			$local_id = User::getIdForURL($contact['url']);
 			// check if contact is a Moderator
 			if (User::isModerator($local_id)) {
 				$moderator = true;

--- a/src/Content/Widget/Hovercard.php
+++ b/src/Content/Widget/Hovercard.php
@@ -49,22 +49,22 @@ class Hovercard
 
 		$administrator = false;
 		$moderator     = false;
-		if (Contact::isLocalById($contact['id'])){
-				$local_id = User::getIdForUrl($contact['url']);
-				// check if contact is a Moderator
-				if (User::isModerator($local_id)){
-					$moderator = true;
+		if (Contact::isLocalById($contact['id'])) {
+			$local_id = User::getIdForUrl($contact['url']);
+			// check if contact is a Moderator
+			if (User::isModerator($local_id)) {
+				$moderator = true;
+			}
+			// check if contact is an Admin
+			if (User::isSiteAdmin($local_id)) {
+				$administrator = true;
+				$moderator = false;
+				// do not show as Admin if this is a sub-account of an Admin
+				$check = User::getById($local_id,['parent-uid']);
+				if ($check['parent-uid']) {
+					$administrator = false;
 				}
-				// check if contact is an Admin
-				if (User::isSiteAdmin($local_id)){
-					$administrator = true;
-					$moderator = false;
-					// do not show as Admin if this is a sub-account of an Admin
-					$check = User::getById($local_id,['parent-uid']);
-					if ($check['parent-uid']){
-						$administrator = false;
-					}
-				}
+			}
 		}
 
 		// Move the contact data to the profile array so we can deliver it to
@@ -74,7 +74,7 @@ class Hovercard
 				'is_admin'          => $administrator,
 				'admin_title'       => DI::l10n()->t('Administrator'),
 				'is_mod'            => $moderator,
-				'moderator_title'	=> DI::l10n()->t('Moderator'),
+				'moderator_title'   => DI::l10n()->t('Moderator'),
 				'name'              => $contact['name'],
 				'nick'              => $contact['nick'],
 				'addr'              => $contact['addr'] ?: $contact_url,

--- a/src/Content/Widget/Hovercard.php
+++ b/src/Content/Widget/Hovercard.php
@@ -7,17 +7,19 @@
 
 namespace Friendica\Content\Widget;
 
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Strings;
 use Friendica\Model\Tag;
-use Friendica\DI;
 use Friendica\Model\User;
 
-class Hovercard
+readonly class Hovercard
 {
+	public function __construct(private L10n $l10n) {}
+
 	/**
 	 * @param array $contact
 	 * @param int   $localUid Used to show user actions
@@ -26,7 +28,7 @@ class Hovercard
 	 * @throws HTTPException\ServiceUnavailableException
 	 * @throws \ImagickException
 	 */
-	public static function getHTML(array $contact, int $localUid = 0): string
+	public function getHTML(array $contact, int $localUid = 0): string
 	{
 		if ($localUid) {
 			$actions = Contact::photoMenu($contact, $localUid);
@@ -72,9 +74,9 @@ class Hovercard
 		return Renderer::replaceMacros($tpl, [
 			'$profile' => [
 				'is_admin'          => $administrator,
-				'admin_title'       => DI::l10n()->t('Administrator'),
+				'admin_title'       => $this->l10n->t('Administrator'),
 				'is_mod'            => $moderator,
-				'moderator_title'   => DI::l10n()->t('Moderator'),
+				'moderator_title'   => $this->l10n->t('Moderator'),
 				'name'              => $contact['name'],
 				'nick'              => $contact['nick'],
 				'addr'              => $contact['addr'] ?: $contact_url,

--- a/src/Content/Widget/Hovercard.php
+++ b/src/Content/Widget/Hovercard.php
@@ -58,7 +58,7 @@ class Hovercard
 			// check if contact is an Admin
 			if (User::isSiteAdmin($local_id)) {
 				$administrator = true;
-				$moderator = false;
+				$moderator     = false;
 				// do not show as Admin if this is a sub-account of an Admin
 				$check = User::getById($local_id,['parent-uid']);
 				if ($check['parent-uid']) {

--- a/src/Content/Widget/Hovercard.php
+++ b/src/Content/Widget/Hovercard.php
@@ -60,7 +60,7 @@ class Hovercard
 				$administrator = true;
 				$moderator     = false;
 				// do not show as Admin if this is a sub-account of an Admin
-				$check = User::getById($local_id,['parent-uid']);
+				$check = User::getById($local_id, ['parent-uid']);
 				if ($check['parent-uid']) {
 					$administrator = false;
 				}

--- a/src/Content/Widget/Hovercard.php
+++ b/src/Content/Widget/Hovercard.php
@@ -13,6 +13,8 @@ use Friendica\Model\Contact;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Strings;
 use Friendica\Model\Tag;
+use Friendica\DI;
+use Friendica\Model\User;
 
 class Hovercard
 {
@@ -45,25 +47,52 @@ class Hovercard
 
 		$contact_url = Contact::getProfileLink($contact);
 
+		$administrator = false;
+		$moderator     = false;
+		if (Contact::isLocalById($contact['id'])){
+				$local_id = User::getIdForUrl($contact['url']);
+				// check if contact is a Moderator
+				if (User::isModerator($local_id)){
+					$moderator = true;
+				}
+				// check if contact is an Admin
+				if (User::isSiteAdmin($local_id)){
+					$administrator = true;
+					$moderator = false;
+					// do not show as Admin if this is a sub-account of an Admin
+					$check = User::getById($local_id,['parent-uid']);
+					if ($check['parent-uid']){
+						$administrator = false;
+					}
+				}
+		}
+
 		// Move the contact data to the profile array so we can deliver it to
 		$tpl = Renderer::getMarkupTemplate('hovercard.tpl');
 		return Renderer::replaceMacros($tpl, [
 			'$profile' => [
-				'name'         => $contact['name'],
-				'nick'         => $contact['nick'],
-				'addr'         => $contact['addr'] ?: $contact_url,
-				'thumb'        => Contact::getThumb($contact),
-				'url'          => Contact::magicLinkByContact($contact),
-				'nurl'         => $contact['nurl'],
-				'location'     => $contact['location'],
-				'about'        => $contact['about'],
-				'network_link' => Strings::formatNetworkName($contact['network'], $contact_url, $contact['gsid']),
-				'tags'         => $tags,
-				'bd'           => $contact['bd'] <= DBA::NULL_DATE ? '' : $contact['bd'],
-				'account_type' => Contact::getAccountType($contact['contact-type']),
-				'contact_type' => $contact['contact-type'],
-				'actions'      => $actions,
-				'self'         => $contact['self'],
+				'is_admin'          => $administrator,
+				'admin_title'       => DI::l10n()->t('Administrator'),
+				'is_mod'            => $moderator,
+				'moderator_title'	=> DI::l10n()->t('Moderator'),
+				'name'              => $contact['name'],
+				'nick'              => $contact['nick'],
+				'addr'              => $contact['addr'] ?: $contact_url,
+				'thumb'             => Contact::getThumb($contact),
+				'url'               => Contact::magicLinkByContact($contact),
+				'nurl'              => $contact['nurl'],
+				'location'          => $contact['location'],
+				'about'             => $contact['about'],
+				'network_link'      => Strings::formatNetworkName($contact['network'], $contact_url, $contact['gsid']),
+				'tags'              => $tags,
+				'bd'                => $contact['bd'] <= DBA::NULL_DATE ? '' : $contact['bd'],
+				'account_type_name' => Contact::getAccountType($contact['contact-type']),
+				'account_type'      => $contact['contact-type'],
+				'manually_approve'  => $contact['manually-approve'],
+				'private'           => $contact['prv'],
+				'contact_type'      => $contact['contact-type'],
+				'actions'           => $actions,
+				'self'              => $contact['self'],
 			],
 		]);
 	}

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -110,22 +110,22 @@ class VCard
 
 		$administrator = false;
 		$moderator     = false;
-		if (Contact::isLocalById($contact['id'])){
-				$local_id = User::getIdForUrl($contact['url']);
-				// check if contact is a Moderator
-				if (User::isModerator($local_id)){
-					$moderator = true;
+		if (Contact::isLocalById($contact['id'])) {
+			$local_id = User::getIdForUrl($contact['url']);
+			// check if contact is a Moderator
+			if (User::isModerator($local_id)) {
+				$moderator = true;
+			}
+			// check if contact is an Admin
+			if (User::isSiteAdmin($local_id)) {
+				$administrator = true;
+				$moderator = false;
+				// do not show as Admin if this is a sub-account of an Admin
+				$check = User::getById($local_id,['parent-uid']);
+				if ($check['parent-uid']) {
+					$administrator = false;
 				}
-				// check if contact is an Admin
-				if (User::isSiteAdmin($local_id)){
-					$administrator = true;
-					$moderator = false;
-					// do not show as Admin if this is a sub-account of an Admin
-					$check = User::getById($local_id,['parent-uid']);
-					if ($check['parent-uid']){
-						$administrator = false;
-					}
-				}
+			}
 		}
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('widget/vcard.tpl'), [

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -121,7 +121,7 @@ class VCard
 				$administrator = true;
 				$moderator     = false;
 				// do not show as Admin if this is a sub-account of an Admin
-				$check = User::getById($local_id,['parent-uid']);
+				$check = User::getById($local_id, ['parent-uid']);
 				if ($check['parent-uid']) {
 					$administrator = false;
 				}

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -114,6 +114,7 @@ class VCard
 			'$is_admin'            => $administrator,
 			'$admin_title'         => DI::l10n()->t('Administrator'),
 			'$is_mod'              => $moderator,
+			'$moderator_title'     => DI::l10n()->t('Moderator'),
 			'$photo'               => $photo,
 			'$url'                 => Contact::magicLinkByContact($contact, $contact_url),
 			'$about'               => BBCode::convertForUriId($contact['uri-id'] ?? 0, $contact['about'] ?? ''),

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -14,6 +14,7 @@ use Friendica\Core\Renderer;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Util\Strings;
+use Friendica\Core\User;
 
 /**
  * VCard widget
@@ -107,8 +108,31 @@ class VCard
 			}
 		}
 
+		$administrator = false;
+		$moderator     = false;
+		if (Contact::isLocalById($contact['id'])){
+				$local_id = User::getIdForUrl($contact['url']);
+				// check if contact is a Moderator
+				if (User::isModerator($local_id)){
+					$moderator = true;
+				}
+				// check if contact is an Admin
+				if (User::isSiteAdmin($local_id)){
+					$administrator = true;
+					$moderator = false;
+					// do not show as Admin if this is a sub-account of an Admin
+					$check = User::getById($local_id,['parent-uid']);
+					if ($check['parent-uid']){
+						$administrator = false;
+					}
+				}
+		}
+
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('widget/vcard.tpl'), [
 			'$contact'             => $contact,
+			'$is_admin'            => $administrator,
+			'$admin_title'         => DI::l10n()->t('Administrator'),
+			'$is_mod'              => $moderator,
 			'$photo'               => $photo,
 			'$url'                 => Contact::magicLinkByContact($contact, $contact_url),
 			'$about'               => BBCode::convertForUriId($contact['uri-id'] ?? 0, $contact['about'] ?? ''),
@@ -118,7 +142,9 @@ class VCard
 			'$network_link'        => $network_link,
 			'$network_svg'         => $network_svg,
 			'$network'             => DI::l10n()->t('Network:'),
-			'$account_type'        => Contact::getAccountType($contact['contact-type']),
+			'$account_type_name'   => Contact::getAccountType($contact['contact-type']),
+			'$account_type'        => $contact['contact-type'],
+			'$manually_approve'    => $contact['manually-approve'],
 			'$follow'              => DI::l10n()->t('Follow'),
 			'$follow_link'         => $follow_link,
 			'$unfollow'            => DI::l10n()->t('Unfollow'),

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -119,7 +119,7 @@ class VCard
 			// check if contact is an Admin
 			if (User::isSiteAdmin($local_id)) {
 				$administrator = true;
-				$moderator = false;
+				$moderator     = false;
 				// do not show as Admin if this is a sub-account of an Admin
 				$check = User::getById($local_id,['parent-uid']);
 				if ($check['parent-uid']) {

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -14,7 +14,6 @@ use Friendica\Core\Renderer;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Util\Strings;
-use Friendica\Model\User;
 
 /**
  * VCard widget

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -108,25 +108,7 @@ class VCard
 			}
 		}
 
-		$administrator = false;
-		$moderator     = false;
-		if (Contact::isLocalById($contact['id'])) {
-			$local_id = User::getIdForURL($contact['url']);
-			// check if contact is a Moderator
-			if (User::isModerator($local_id)) {
-				$moderator = true;
-			}
-			// check if contact is an Admin
-			if (User::isSiteAdmin($local_id)) {
-				$administrator = true;
-				$moderator     = false;
-				// do not show as Admin if this is a sub-account of an Admin
-				$check = User::getById($local_id, ['parent-uid']);
-				if ($check['parent-uid']) {
-					$administrator = false;
-				}
-			}
-		}
+		[$administrator, $moderator] = Contact::getType($contact['id'], $contact['url']);
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('widget/vcard.tpl'), [
 			'$contact'             => $contact,

--- a/src/Content/Widget/VCard.php
+++ b/src/Content/Widget/VCard.php
@@ -14,7 +14,7 @@ use Friendica\Core\Renderer;
 use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Util\Strings;
-use Friendica\Core\User;
+use Friendica\Model\User;
 
 /**
  * VCard widget
@@ -111,7 +111,7 @@ class VCard
 		$administrator = false;
 		$moderator     = false;
 		if (Contact::isLocalById($contact['id'])) {
-			$local_id = User::getIdForUrl($contact['url']);
+			$local_id = User::getIdForURL($contact['url']);
 			// check if contact is a Moderator
 			if (User::isModerator($local_id)) {
 				$moderator = true;

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -3890,4 +3890,37 @@ class Contact
 	{
 		return DBA::exists('contact', $condition);
 	}
+
+	/**
+	 * Returns the type of the given contact
+	 *
+	 * @param int    $id  The contact id
+	 * @param string $url The contact url
+	 * @return bool[] [administrator, moderator]
+	 * @throws \Exception
+	 */
+	public static function getType(int $id, string $url): array
+	{
+		$administrator = false;
+		$moderator     = false;
+		if (Contact::isLocalById($id)) {
+			$local_id = User::getIdForURL($url);
+			// check if contact is a Moderator
+			if (User::isModerator($local_id)) {
+				$moderator = true;
+			}
+			// check if contact is an Admin
+			if (User::isSiteAdmin($local_id)) {
+				$administrator = true;
+				$moderator     = false;
+				// do not show as Admin if this is a subaccount of an Admin
+				$check = User::getById($local_id, ['parent-uid']);
+				if ($check['parent-uid']) {
+					$administrator = false;
+				}
+			}
+		}
+
+		return [$administrator, $moderator];
+	}
 }

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -462,7 +462,7 @@ class Profile
 		$administrator = false;
 		$moderator     = false;
 		if (Contact::isLocalById($profile['id'])) {
-			$local_id = User::getIdForUrl($profile['url']);
+			$local_id = User::getIdForURL($profile['url']);
 			// check if contact is a Moderator
 			if (User::isModerator($local_id)) {
 				$moderator = true;

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -348,8 +348,8 @@ class Profile
 			$change_profile_picture_text = "";
 		}
 
-		// Fetch the account type
-		$account_type = Contact::getAccountType($profile['account-type']);
+		// Fetch the account type name string
+		$account_type_name = Contact::getAccountType($profile['account-type']);
 
 		if (!empty($profile['address']) || !empty($profile['location'])) {
 			$location = DI::l10n()->t('Location:');
@@ -470,7 +470,7 @@ class Profile
 				$administrator = true;
 				$moderator     = false;
 				// do not show as Admin if this is a sub-account of an Admin
-				$check = User::getById($local_id,['parent-uid']);
+				$check = User::getById($local_id, ['parent-uid']);
 				if ($check['parent-uid']) {
 					$administrator = false;
 				}

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -28,8 +28,6 @@ use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 use Friendica\Core\Theme;
-use Friendica\Model\Contact;
-use Friendica\Model\User;
 
 class Profile
 {
@@ -470,7 +468,7 @@ class Profile
 			// check if contact is an Admin
 			if (User::isSiteAdmin($local_id)) {
 				$administrator = true;
-				$moderator = false;
+				$moderator     = false;
 				// do not show as Admin if this is a sub-account of an Admin
 				$check = User::getById($local_id,['parent-uid']);
 				if ($check['parent-uid']) {

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -28,6 +28,8 @@ use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Proxy;
 use Friendica\Util\Strings;
 use Friendica\Core\Theme;
+use Friendica\Model\Contact;
+use Friendica\Model\User;
 
 class Profile
 {
@@ -457,8 +459,32 @@ class Profile
 			$member_since = [ DI::l10n()->t('Joined:'), DI::l10n()->mediumDate($p['register_date']) ];
 		}
 
+		$administrator = false;
+		$moderator     = false;
+		if (Contact::isLocalById($profile['id'])){
+				$local_id = User::getIdForUrl($profile['url']);
+				// check if contact is a Moderator
+				if (User::isModerator($local_id)){
+					$moderator = true;
+				}
+				// check if contact is an Admin
+				if (User::isSiteAdmin($local_id)){
+					$administrator = true;
+					$moderator = false;
+					// do not show as Admin if this is a sub-account of an Admin
+					$check = User::getById($local_id,['parent-uid']);
+					if ($check['parent-uid']){
+						$administrator = false;
+					}
+				}
+		}
+	
 		$tpl = Renderer::getMarkupTemplate('profile/vcard.tpl');
 		$o .= Renderer::replaceMacros($tpl, [
+			'is_admin'           => $administrator,
+			'admin_title'        => DI::l10n()->t('Administrator'),
+			'is_mod'             => $moderator,
+			'moderator_title'    => DI::l10n()->t('Moderator'),
 			'$is_owner'          => DI::userSession()->getLocalUserId() == $profile['uid'],
 			'$profile'           => $p,
 			'$edit_profile_link' => [
@@ -478,7 +504,9 @@ class Profile
 			'$subscribe_feed_link'         => $profile['hidewall'] ?? 0 ? '' : $profile['poll'],
 			'$wallmessage'                 => DI::l10n()->t('Message'),
 			'$wallmessage_link'            => $wallmessage_link,
-			'$account_type'                => $account_type,
+			'$account_type_name'           => $account_type_name,
+			'$account_type'                => $profile['account-type'],
+			'$page_flags'                  => $profile['page-flags'],
 			'$location'                    => $location,
 			'$homepage'                    => $homepage,
 			'$homepage_verified'           => DI::l10n()->t('This website has been verified to belong to the same person.'),

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -461,24 +461,24 @@ class Profile
 
 		$administrator = false;
 		$moderator     = false;
-		if (Contact::isLocalById($profile['id'])){
-				$local_id = User::getIdForUrl($profile['url']);
-				// check if contact is a Moderator
-				if (User::isModerator($local_id)){
-					$moderator = true;
+		if (Contact::isLocalById($profile['id'])) {
+			$local_id = User::getIdForUrl($profile['url']);
+			// check if contact is a Moderator
+			if (User::isModerator($local_id)) {
+				$moderator = true;
+			}
+			// check if contact is an Admin
+			if (User::isSiteAdmin($local_id)) {
+				$administrator = true;
+				$moderator = false;
+				// do not show as Admin if this is a sub-account of an Admin
+				$check = User::getById($local_id,['parent-uid']);
+				if ($check['parent-uid']) {
+					$administrator = false;
 				}
-				// check if contact is an Admin
-				if (User::isSiteAdmin($local_id)){
-					$administrator = true;
-					$moderator = false;
-					// do not show as Admin if this is a sub-account of an Admin
-					$check = User::getById($local_id,['parent-uid']);
-					if ($check['parent-uid']){
-						$administrator = false;
-					}
-				}
+			}
 		}
-	
+
 		$tpl = Renderer::getMarkupTemplate('profile/vcard.tpl');
 		$o .= Renderer::replaceMacros($tpl, [
 			'is_admin'           => $administrator,

--- a/src/Model/Profile.php
+++ b/src/Model/Profile.php
@@ -457,25 +457,7 @@ class Profile
 			$member_since = [ DI::l10n()->t('Joined:'), DI::l10n()->mediumDate($p['register_date']) ];
 		}
 
-		$administrator = false;
-		$moderator     = false;
-		if (Contact::isLocalById($profile['id'])) {
-			$local_id = User::getIdForURL($profile['url']);
-			// check if contact is a Moderator
-			if (User::isModerator($local_id)) {
-				$moderator = true;
-			}
-			// check if contact is an Admin
-			if (User::isSiteAdmin($local_id)) {
-				$administrator = true;
-				$moderator     = false;
-				// do not show as Admin if this is a sub-account of an Admin
-				$check = User::getById($local_id, ['parent-uid']);
-				if ($check['parent-uid']) {
-					$administrator = false;
-				}
-			}
-		}
+		[$administrator, $moderator] = Contact::getType($profile['id'], $profile['url']);
 
 		$tpl = Renderer::getMarkupTemplate('profile/vcard.tpl');
 		$o .= Renderer::replaceMacros($tpl, [

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -604,22 +604,22 @@ class Contact extends BaseModule
 
 		$administrator = false;
 		$moderator     = false;
-		if (Model\Contact::isLocalById($contact['id'])){
-				$local_id = Model\User::getIdForUrl($contact['url']);
-				// check if contact is a Moderator
-				if (Model\User::isModerator($local_id)){
-					$moderator = true;
+		if (Model\Contact::isLocalById($contact['id'])) {
+			$local_id = Model\User::getIdForUrl($contact['url']);
+			// check if contact is a Moderator
+			if (Model\User::isModerator($local_id)) {
+				$moderator = true;
+			}
+			// check if contact is an Admin
+			if (Model\User::isSiteAdmin($local_id)) {
+				$administrator = true;
+				$moderator = false;
+				// do not show as Admin if this is a sub-account of an Admin
+				$check = Model\User::getById($local_id,['parent-uid']);
+				if ($check['parent-uid']) {
+					$administrator = false;
 				}
-				// check if contact is an Admin
-				if (Model\User::isSiteAdmin($local_id)){
-					$administrator = true;
-					$moderator = false;
-					// do not show as Admin if this is a sub-account of an Admin
-					$check = Model\User::getById($local_id,['parent-uid']);
-					if ($check['parent-uid']){
-						$administrator = false;
-					}
-				}
+			}
 		}
 
 		return [

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -602,25 +602,7 @@ class Contact extends BaseModule
 			$sparkle  = '';
 		}
 
-		$administrator = false;
-		$moderator     = false;
-		if (Model\Contact::isLocalById($contact['id'])) {
-			$local_id = Model\User::getIdForURL($contact['url']);
-			// check if contact is a Moderator
-			if (Model\User::isModerator($local_id)) {
-				$moderator = true;
-			}
-			// check if contact is an Admin
-			if (Model\User::isSiteAdmin($local_id)) {
-				$administrator = true;
-				$moderator     = false;
-				// do not show as Admin if this is a sub-account of an Admin
-				$check = Model\User::getById($local_id, ['parent-uid']);
-				if ($check['parent-uid']) {
-					$administrator = false;
-				}
-			}
-		}
+		[$administrator, $moderator] = Model\Contact::getType($contact['id'], $contact['url']);
 
 		return [
 			'id'                => $contact['id'],

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -613,7 +613,7 @@ class Contact extends BaseModule
 			// check if contact is an Admin
 			if (Model\User::isSiteAdmin($local_id)) {
 				$administrator = true;
-				$moderator = false;
+				$moderator     = false;
 				// do not show as Admin if this is a sub-account of an Admin
 				$check = Model\User::getById($local_id,['parent-uid']);
 				if ($check['parent-uid']) {

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -638,6 +638,7 @@ class Contact extends BaseModule
 			'details'           => $contact['location'],
 			'tags'              => $contact['keywords'],
 			'about'             => $contact['about'],
+			'account_type_name' => Model\Contact::getAccountType($contact['contact-type']),
 			'account_type'      => $contact['contact-type'],
 			'manually_approve'  => $contact['manually-approve'],
 			'private'           => $contact['prv'],

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -615,7 +615,7 @@ class Contact extends BaseModule
 				$administrator = true;
 				$moderator     = false;
 				// do not show as Admin if this is a sub-account of an Admin
-				$check = Model\User::getById($local_id,['parent-uid']);
+				$check = Model\User::getById($local_id, ['parent-uid']);
 				if ($check['parent-uid']) {
 					$administrator = false;
 				}

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -605,7 +605,7 @@ class Contact extends BaseModule
 		$administrator = false;
 		$moderator     = false;
 		if (Model\Contact::isLocalById($contact['id'])) {
-			$local_id = Model\User::getIdForUrl($contact['url']);
+			$local_id = Model\User::getIdForURL($contact['url']);
 			// check if contact is a Moderator
 			if (Model\User::isModerator($local_id)) {
 				$moderator = true;

--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -602,22 +602,48 @@ class Contact extends BaseModule
 			$sparkle  = '';
 		}
 
+		$administrator = false;
+		$moderator     = false;
+		if (Model\Contact::isLocalById($contact['id'])){
+				$local_id = Model\User::getIdForUrl($contact['url']);
+				// check if contact is a Moderator
+				if (Model\User::isModerator($local_id)){
+					$moderator = true;
+				}
+				// check if contact is an Admin
+				if (Model\User::isSiteAdmin($local_id)){
+					$administrator = true;
+					$moderator = false;
+					// do not show as Admin if this is a sub-account of an Admin
+					$check = Model\User::getById($local_id,['parent-uid']);
+					if ($check['parent-uid']){
+						$administrator = false;
+					}
+				}
+		}
+
 		return [
-			'id'           => $contact['id'],
-			'url'          => $url,
-			'img_hover'    => DI::l10n()->t('Visit %s\'s profile [%s]', $contact['name'], $contact['url']),
-			'photo_menu'   => Model\Contact::photoMenu($contact, DI::userSession()->getLocalUserId()),
-			'thumb'        => Model\Contact::getThumb($contact, true),
-			'alt_text'     => $alt_text,
-			'name'         => $contact['name'],
-			'nick'         => $contact['nick'],
-			'details'      => $contact['location'],
-			'tags'         => $contact['keywords'],
-			'about'        => $contact['about'],
-			'account_type' => Model\Contact::getAccountType($contact['contact-type']),
-			'sparkle'      => $sparkle,
-			'itemurl'      => ($contact['addr'] ?? '') ?: $contact['url'],
-			'network'      => ContactSelector::networkToName($contact['network'], $contact['protocol'], $contact['gsid']),
+			'id'                => $contact['id'],
+			'is_admin'          => $administrator,
+			'adming_title'      => DI::l10n()->t('Administrator'),
+			'is_mod'            => $moderator,
+			'moderator_title'   => DI::l10n()->t('Moderator'),
+			'url'               => $url,
+			'img_hover'         => DI::l10n()->t('Visit %s\'s profile [%s]', $contact['name'], $contact['url']),
+			'photo_menu'        => Model\Contact::photoMenu($contact, DI::userSession()->getLocalUserId()),
+			'thumb'             => Model\Contact::getThumb($contact, true),
+			'alt_text'          => $alt_text,
+			'name'              => $contact['name'],
+			'nick'              => $contact['nick'],
+			'details'           => $contact['location'],
+			'tags'              => $contact['keywords'],
+			'about'             => $contact['about'],
+			'account_type'      => $contact['contact-type'],
+			'manually_approve'  => $contact['manually-approve'],
+			'private'           => $contact['prv'],
+			'sparkle'           => $sparkle,
+			'itemurl'           => ($contact['addr'] ?? '') ?: $contact['url'],
+			'network'           => ContactSelector::networkToName($contact['network'], $contact['protocol'], $contact['gsid']),
 		];
 	}
 }

--- a/src/Module/Contact/Hovercard.php
+++ b/src/Module/Contact/Hovercard.php
@@ -13,7 +13,6 @@ use Friendica\Content\Widget;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
-use Friendica\Core\System;
 use Friendica\Model\Contact;
 use Friendica\Module\Response;
 use Friendica\Network\HTTPException;
@@ -25,7 +24,7 @@ use Psr\Log\LoggerInterface;
  */
 class Hovercard extends BaseModule
 {
-	public function __construct(private readonly IHandleUserSessions $userSession, private readonly IManageConfigValues $config, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private readonly IHandleUserSessions $userSession, private readonly IManageConfigValues $config, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, private readonly Widget\Hovercard $hovercard, array $server, array $parameters = [])
 	{
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 	}
@@ -64,6 +63,6 @@ class Hovercard extends BaseModule
 			throw new HTTPException\NotFoundException();
 		}
 
-		$this->httpExit(Widget\Hovercard::getHTML($contact, $this->userSession->getLocalUserId()));
+		$this->httpExit($this->hovercard->getHTML($contact, $this->userSession->getLocalUserId()));
 	}
 }

--- a/src/Module/Moderation/BaseUsers.php
+++ b/src/Module/Moderation/BaseUsers.php
@@ -148,16 +148,31 @@ abstract class BaseUsers extends BaseModeration
 				User::ACCOUNT_TYPE_RELAY        => [$this->t('Relay'), ""],
 			];
 
-			$user['page_flags_raw'] = $user['page-flags'];
-			$user['page_type']      = $page_types[$user['page-flags']];
+			$moderator     = false;
+			$administrator = false;
+			if (User::isMOderator($user['uid'])){
+				$moderator = true;
+			}
+			if (User::isSiteAdmin($user['uid'])){
+				$administrator = true;
+				$moderator     = false;
+				// do not show admin for sub-accounts of admin
+				if ($user['parent-uid']){
+					$administrator = false;
+				}
+			}
+			$user['is_mod']   = $moderator;
+			$user['is_admin'] = $administrator;
 
-			$user['account_type_raw'] = ($user['page_flags_raw'] == 0) ? $user['account-type'] : -1;
-			$user['account_type']     = ($user['page_flags_raw'] == 0) ? $account_types[$user['account-type']] : '';
+			$user['page_flags_raw'] = $user['page-flags'];
+			$user['page_flags']     = $page_types[$user['page-flags']];
+
+			$user['account_type_raw'] = $user['account-type'];
+			$user['account_type']     = $account_types[$user['account-type']];
 
 			$user['register_date'] = Temporal::getRelativeDate($user['register_date']);
 			$user['login_date']    = Temporal::getRelativeDate($user['last-activity'], false);
 			$user['lastitem_date'] = Temporal::getRelativeDate($user['last-item']);
-			$user['is_admin']      = in_array($user['email'], $adminlist);
 			$user['is_deletable']  = !$user['account_removed'] && intval($user['uid']) != $this->session->getLocalUserId();
 			$user['deleted']       = $user['account_removed'] ? Temporal::getRelativeDate($user['account_expires_on']) : false;
 

--- a/src/Module/Moderation/BaseUsers.php
+++ b/src/Module/Moderation/BaseUsers.php
@@ -150,14 +150,14 @@ abstract class BaseUsers extends BaseModeration
 
 			$moderator     = false;
 			$administrator = false;
-			if (User::isMOderator($user['uid'])){
+			if (User::isMOderator($user['uid'])) {
 				$moderator = true;
 			}
-			if (User::isSiteAdmin($user['uid'])){
+			if (User::isSiteAdmin($user['uid'])) {
 				$administrator = true;
 				$moderator     = false;
 				// do not show admin for sub-accounts of admin
-				if ($user['parent-uid']){
+				if ($user['parent-uid']) {
 					$administrator = false;
 				}
 			}

--- a/src/Module/Moderation/BaseUsers.php
+++ b/src/Module/Moderation/BaseUsers.php
@@ -129,22 +129,21 @@ abstract class BaseUsers extends BaseModeration
 
 	protected function setupUserCallback(): \Closure
 	{
-		return function ($user) use ($adminlist) {
+		return function ($user) {
 			$page_types = [
-				// NOTE: Currently no PAGE_FLAGS_BLOG here, unlike Model/User.php?
-				User::PAGE_FLAGS_NORMAL    => [$this->t('Normal Account Page'), "ri-user-line"],
-				User::PAGE_FLAGS_SOAPBOX   => [$this->t('Soapbox Page'), "ri-megaphone-line"],
-				User::PAGE_FLAGS_COMMUNITY => [$this->t('Public Group'), "ri-team-line"],
-				User::PAGE_FLAGS_COMM_MAN  => [$this->t('Public Group - Restricted', "ri-team-line")],
-				User::PAGE_FLAGS_FREELOVE  => [$this->t('Automatic Friend Page'), "ri-heart-line"],
-				User::PAGE_FLAGS_PRVGROUP  => [$this->t('Private Group'), "ri-spy-line"],
+				User::PAGE_FLAGS_NORMAL    => $this->t('Normal Account Page'),
+				User::PAGE_FLAGS_SOAPBOX   => $this->t('Soapbox Page'),
+				User::PAGE_FLAGS_COMMUNITY => $this->t('Public Group'),
+				User::PAGE_FLAGS_COMM_MAN  => $this->t('Public Group - Restricted'),
+				User::PAGE_FLAGS_FREELOVE  => $this->t('Automatic Friend Page'),
+				User::PAGE_FLAGS_PRVGROUP  => $this->t('Private Group'),
 			];
 			$account_types = [
-				User::ACCOUNT_TYPE_PERSON       => [$this->t('Personal Page'), ""],
-				User::ACCOUNT_TYPE_ORGANISATION => [$this->t('Organisation Page'), "ri-node-tree"],
-				User::ACCOUNT_TYPE_NEWS         => [$this->t('News Page'), "ri-newspaper-line"],
-				User::ACCOUNT_TYPE_COMMUNITY    => [$this->t('Community Group'), "ri-chat-3-line"],
-				User::ACCOUNT_TYPE_RELAY        => [$this->t('Relay'), ""],
+				User::ACCOUNT_TYPE_PERSON       => $this->t('Personal Page'),
+				User::ACCOUNT_TYPE_ORGANISATION => $this->t('Organisation Page'),
+				User::ACCOUNT_TYPE_NEWS         => $this->t('News Page'),
+				User::ACCOUNT_TYPE_COMMUNITY    => $this->t('Community Group'),
+				User::ACCOUNT_TYPE_RELAY        => $this->t('Relay'),
 			];
 
 			$moderator     = false;

--- a/src/Module/Moderation/BaseUsers.php
+++ b/src/Module/Moderation/BaseUsers.php
@@ -129,7 +129,6 @@ abstract class BaseUsers extends BaseModeration
 
 	protected function setupUserCallback(): \Closure
 	{
-		$adminlist = User::getAdminEmailList();
 		return function ($user) use ($adminlist) {
 			$page_types = [
 				// NOTE: Currently no PAGE_FLAGS_BLOG here, unlike Model/User.php?
@@ -150,7 +149,7 @@ abstract class BaseUsers extends BaseModeration
 
 			$moderator     = false;
 			$administrator = false;
-			if (User::isMOderator($user['uid'])) {
+			if (User::isModerator($user['uid'])) {
 				$moderator = true;
 			}
 			if (User::isSiteAdmin($user['uid'])) {

--- a/src/Module/Moderation/Users/Active.php
+++ b/src/Module/Moderation/Users/Active.php
@@ -93,6 +93,7 @@ class Active extends BaseUsers
 			'$block'          => $this->t('Block'),
 			'$blocked'        => $this->t('User blocked'),
 			'$siteadmin'      => $this->t('Site admin'),
+			'$moderator'      => $this->t('Moderator'),
 			'$accountexpired' => $this->t('Account expired'),
 			'$h_newuser'      => $this->t('Create a new user'),
 

--- a/src/Module/Moderation/Users/Blocked.php
+++ b/src/Module/Moderation/Users/Blocked.php
@@ -93,6 +93,7 @@ class Blocked extends BaseUsers
 			'$blocked'        => $this->t('User blocked'),
 			'$unblock'        => $this->t('Unblock'),
 			'$siteadmin'      => $this->t('Site admin'),
+			'$moderator'      => $this->t('Moderator'),
 			'$accountexpired' => $this->t('Account expired'),
 
 			'$th_users'              => $th_users,

--- a/src/Module/Moderation/Users/Index.php
+++ b/src/Module/Moderation/Users/Index.php
@@ -102,6 +102,7 @@ class Index extends BaseUsers
 			'$blocked'        => $this->t('User blocked'),
 			'$unblock'        => $this->t('Unblock'),
 			'$siteadmin'      => $this->t('Site admin'),
+			'$moderator'      => $this->t('Moderator'),
 			'$accountexpired' => $this->t('Account expired'),
 
 			'$h_users'               => $this->t('Users'),

--- a/src/Module/Settings/RemoveMe.php
+++ b/src/Module/Settings/RemoveMe.php
@@ -25,7 +25,7 @@ use Psr\Log\LoggerInterface;
 
 class RemoveMe extends BaseSettings
 {
-	public function __construct(private readonly Cookie $cookie, private readonly SystemMessages $systemMessages, private readonly Emailer $emailer, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
+	public function __construct(private readonly Cookie $cookie, private readonly SystemMessages $systemMessages, private readonly Emailer $emailer, private readonly Widget\Hovercard $hovercard, IHandleUserSessions $session, App\Page $page, L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, array $server, array $parameters = [])
 	{
 		parent::__construct($session, $page, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 	}
@@ -105,7 +105,7 @@ class RemoveMe extends BaseSettings
 				'desc'  => DI::l10n()->t('This will completely remove your account. Once this has been done it is not recoverable.'),
 			],
 
-			'$hovercard' => Widget\Hovercard::getHTML(User::getOwnerDataById($this->session->getLocalUserId())),
+			'$hovercard' => $this->hovercard->getHTML(User::getOwnerDataById($this->session->getLocalUserId())),
 
 			'$password' => [$hash, $this->t('Please enter your password for verification:'), null, null, true],
 		]);

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.08-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-27 15:25+0200\n"
+"POT-Creation-Date: 2026-06-28 00:24+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -158,7 +158,7 @@ msgid "Insert web link"
 msgstr ""
 
 #: mod/message.php:191 mod/message.php:349
-#: src/Content/Conversation/ConversationRenderer.php:546
+#: src/Content/Conversation/ConversationRenderer.php:549
 #: src/Content/Conversation/PostTemplateBuilder.php:391
 #: src/Content/Conversation/StatusEditor.php:182
 #: src/Module/Item/Compose.php:172 src/Module/Post/Edit.php:156
@@ -431,7 +431,7 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: mod/photos.php:828 src/Content/Conversation/ConversationRenderer.php:475
+#: mod/photos.php:828 src/Content/Conversation/ConversationRenderer.php:478
 #: src/Model/Event.php:654 src/Module/Calendar/Event/Show.php:79
 #: src/Module/Moderation/Users/Active.php:92
 #: src/Module/Moderation/Users/Blocked.php:92
@@ -753,9 +753,9 @@ msgstr ""
 
 #: src/Console/User.php:144 src/Model/User.php:871
 #: src/Module/Api/Twitter/ContactEndpoint.php:72
-#: src/Module/Moderation/Users/Active.php:136
-#: src/Module/Moderation/Users/Blocked.php:135
-#: src/Module/Moderation/Users/Index.php:147
+#: src/Module/Moderation/Users/Active.php:137
+#: src/Module/Moderation/Users/Blocked.php:136
+#: src/Module/Moderation/Users/Index.php:148
 #: src/Module/Moderation/Users/Pending.php:53
 msgid "User not found"
 msgstr ""
@@ -869,7 +869,7 @@ msgstr ""
 #: src/Module/Moderation/Users/Create.php:59
 #: src/Module/Moderation/Users/Deleted.php:69
 #: src/Module/Moderation/Users/Index.php:89
-#: src/Module/Moderation/Users/Index.php:109
+#: src/Module/Moderation/Users/Index.php:110
 #: src/Module/Moderation/Users/Pending.php:84
 msgid "Email"
 msgstr ""
@@ -1025,153 +1025,153 @@ msgid_plural "<button type=\"button\" %2$s>%1$d people</button> reshared this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:861
-#: src/Content/Conversation/ConversationDataProvider.php:864
-#: src/Content/Conversation/ConversationDataProvider.php:867
-#: src/Content/Conversation/ConversationDataProvider.php:870
-#: src/Content/Conversation/ConversationDataProvider.php:873
+#: src/Content/Conversation/ConversationDataProvider.php:881
+#: src/Content/Conversation/ConversationDataProvider.php:884
+#: src/Content/Conversation/ConversationDataProvider.php:887
+#: src/Content/Conversation/ConversationDataProvider.php:890
+#: src/Content/Conversation/ConversationDataProvider.php:893
 #, php-format
 msgid "You had been addressed (%s)."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:876
+#: src/Content/Conversation/ConversationDataProvider.php:896
 #, php-format
 msgid "You are following %s."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:880
+#: src/Content/Conversation/ConversationDataProvider.php:900
 msgid "You subscribed to one or more tags in this post."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:880
+#: src/Content/Conversation/ConversationDataProvider.php:900
 #, php-format
 msgid "You subscribed to %s."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:898
+#: src/Content/Conversation/ConversationDataProvider.php:918
 #, php-format
 msgid "%s reshared this."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:900
+#: src/Content/Conversation/ConversationDataProvider.php:920
 msgid "Reshared"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:900
+#: src/Content/Conversation/ConversationDataProvider.php:920
 #, php-format
 msgid "Reshared by %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:903
+#: src/Content/Conversation/ConversationDataProvider.php:923
 #, php-format
 msgid "%s is participating in this thread."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:906
+#: src/Content/Conversation/ConversationDataProvider.php:926
 msgid "Stored for general reasons"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:909
+#: src/Content/Conversation/ConversationDataProvider.php:929
 msgid "Global post"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:912
+#: src/Content/Conversation/ConversationDataProvider.php:932
 msgid "Sent via an relay server"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:912
+#: src/Content/Conversation/ConversationDataProvider.php:932
 #, php-format
 msgid "Sent via the relay server %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:915
+#: src/Content/Conversation/ConversationDataProvider.php:935
 msgid "Fetched"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:915
+#: src/Content/Conversation/ConversationDataProvider.php:935
 #, php-format
 msgid "Fetched because of %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:918
+#: src/Content/Conversation/ConversationDataProvider.php:938
 msgid "Stored because of a child post to complete this thread."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:921
+#: src/Content/Conversation/ConversationDataProvider.php:941
 msgid "Local delivery"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:924
+#: src/Content/Conversation/ConversationDataProvider.php:944
 msgid "Stored because of your activity (like, comment, bookmark, ...)"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:927
+#: src/Content/Conversation/ConversationDataProvider.php:947
 msgid "Distributed"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:930
+#: src/Content/Conversation/ConversationDataProvider.php:950
 msgid "Pushed to us"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:935
+#: src/Content/Conversation/ConversationDataProvider.php:955
 #, php-format
 msgid "Channel \"%s\": %s"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:935
+#: src/Content/Conversation/ConversationDataProvider.php:955
 #, php-format
 msgid "Channel \"%s\""
 msgstr ""
 
 #: src/Content/Conversation/ConversationRenderer.php:115
 #: src/Content/Conversation/ConversationRenderer.php:116
-#: src/Content/Conversation/ConversationRenderer.php:378
-#: src/Content/Conversation/ConversationRenderer.php:406
+#: src/Content/Conversation/ConversationRenderer.php:381
+#: src/Content/Conversation/ConversationRenderer.php:409
 msgid "Delete Selected Items"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:474
+#: src/Content/Conversation/ConversationRenderer.php:477
 #: src/Content/Conversation/PostTemplateBuilder.php:528
 msgid "Select"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:492
+#: src/Content/Conversation/ConversationRenderer.php:495
 msgid "Pinned item"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:508
+#: src/Content/Conversation/ConversationRenderer.php:511
 #: src/Content/Conversation/PostTemplateBuilder.php:322
 #: src/Content/Conversation/PostTemplateBuilder.php:323
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:521
+#: src/Content/Conversation/ConversationRenderer.php:524
 #: src/Content/Conversation/PostTemplateBuilder.php:310
 msgid "Categories:"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:522
+#: src/Content/Conversation/ConversationRenderer.php:525
 #: src/Content/Conversation/PostTemplateBuilder.php:311
 msgid "Filed under:"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:529
+#: src/Content/Conversation/ConversationRenderer.php:532
 #: src/Content/Conversation/PostTemplateBuilder.php:338
 #, php-format
 msgid "%s from %s"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:544
+#: src/Content/Conversation/ConversationRenderer.php:547
 msgid "View in context"
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:547
+#: src/Content/Conversation/ConversationRenderer.php:550
 #: src/Content/Conversation/PostTemplateBuilder.php:392
 msgid "Loading ..."
 msgstr ""
 
-#: src/Content/Conversation/ConversationRenderer.php:578
+#: src/Content/Conversation/ConversationRenderer.php:581
 msgid "remove"
 msgstr ""
 
@@ -1791,7 +1791,7 @@ msgid "Created at"
 msgstr ""
 
 #: src/Content/Conversation/StatusEditor.php:139
-#: src/Content/Widget/VCard.php:100 src/Model/Contact.php:1266
+#: src/Content/Widget/VCard.php:101 src/Model/Contact.php:1266
 #: src/Model/Profile.php:443
 msgid "Post to group"
 msgstr ""
@@ -1852,8 +1852,8 @@ msgid "Permission settings"
 msgstr ""
 
 #: src/Content/Conversation/StatusEditor.php:203 src/Content/Item.php:407
-#: src/Content/Widget/VCard.php:126 src/Model/Contact.php:1308
-#: src/Model/Profile.php:479 src/Module/Admin/Logs/View.php:79
+#: src/Content/Widget/VCard.php:152 src/Model/Contact.php:1308
+#: src/Model/Profile.php:503 src/Module/Admin/Logs/View.php:79
 #: src/Module/Post/Edit.php:194
 msgid "Message"
 msgstr ""
@@ -1910,7 +1910,7 @@ msgstr ""
 msgid "Add categories to your posts"
 msgstr ""
 
-#: src/Content/Feature.php:121 src/Model/Profile.php:818
+#: src/Content/Feature.php:121 src/Model/Profile.php:844
 #: src/Module/Admin/Summary.php:207 src/Module/Item/Compose.php:152
 #: src/Module/Moderation/Report/Create.php:320
 #: src/Module/Moderation/Summary.php:60
@@ -2630,6 +2630,20 @@ msgstr[1] ""
 msgid "View Contacts"
 msgstr ""
 
+#: src/Content/Widget/Hovercard.php:77 src/Content/Widget/VCard.php:134
+#: src/Model/Profile.php:483 src/Module/Admin/Roles.php:141
+#: src/Module/Contact.php:628
+msgid "Administrator"
+msgstr ""
+
+#: src/Content/Widget/Hovercard.php:79 src/Model/Profile.php:485
+#: src/Module/Admin/Roles.php:142 src/Module/Contact.php:630
+#: src/Module/Moderation/Users/Active.php:96
+#: src/Module/Moderation/Users/Blocked.php:96
+#: src/Module/Moderation/Users/Index.php:105
+msgid "Moderator"
+msgstr ""
+
 #: src/Content/Widget/SavedSearches.php:33
 msgid "Remove term"
 msgstr ""
@@ -2653,22 +2667,22 @@ msgstr ""
 msgid "Show Less"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:105 src/Model/Contact.php:1270
+#: src/Content/Widget/VCard.php:106 src/Model/Contact.php:1270
 #: src/Model/Profile.php:448 src/Module/Moderation/Item/Source.php:76
 msgid "Mention"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:115 src/Model/Profile.php:360
+#: src/Content/Widget/VCard.php:139 src/Model/Profile.php:360
 #: src/Module/Contact/Profile.php:428 src/Module/Profile/Profile.php:186
 msgid "XMPP:"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:116 src/Model/Profile.php:361
+#: src/Content/Widget/VCard.php:140 src/Model/Profile.php:361
 #: src/Module/Contact/Profile.php:430 src/Module/Profile/Profile.php:190
 msgid "Matrix:"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:117 src/Model/Event.php:67
+#: src/Content/Widget/VCard.php:141 src/Model/Event.php:67
 #: src/Model/Event.php:94 src/Model/Event.php:461 src/Model/Event.php:940
 #: src/Model/Profile.php:355 src/Module/Contact/Profile.php:426
 #: src/Module/Directory.php:133 src/Module/Notifications/Introductions.php:187
@@ -2676,23 +2690,23 @@ msgstr ""
 msgid "Location:"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:120 src/Model/Profile.php:486
+#: src/Content/Widget/VCard.php:144 src/Model/Profile.php:512
 #: src/Module/Notifications/Introductions.php:201
 msgid "Network:"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:122 src/Model/Profile.php:473
+#: src/Content/Widget/VCard.php:148 src/Model/Profile.php:497
 #: src/Module/Contact/Profile.php:497
 msgid "Follow"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:124 src/Model/Contact.php:1298
-#: src/Model/Contact.php:1310 src/Model/Profile.php:475
+#: src/Content/Widget/VCard.php:150 src/Model/Contact.php:1298
+#: src/Model/Contact.php:1310 src/Model/Profile.php:499
 #: src/Module/Contact/Profile.php:489
 msgid "Unfollow"
 msgstr ""
 
-#: src/Content/Widget/VCard.php:131 src/Model/Contact.php:1268
+#: src/Content/Widget/VCard.php:157 src/Model/Contact.php:1268
 #: src/Model/Profile.php:445
 msgid "Group posts"
 msgstr ""
@@ -3256,7 +3270,7 @@ msgstr ""
 msgid "Group"
 msgstr ""
 
-#: src/Model/Contact.php:1797 src/Module/Moderation/BaseUsers.php:148
+#: src/Model/Contact.php:1797 src/Module/Moderation/BaseUsers.php:146
 msgid "Relay"
 msgstr ""
 
@@ -3646,115 +3660,115 @@ msgstr ""
 msgid "Joined:"
 msgstr ""
 
-#: src/Model/Profile.php:466
+#: src/Model/Profile.php:490
 msgid "Edit profile"
 msgstr ""
 
-#: src/Model/Profile.php:477
+#: src/Model/Profile.php:501
 msgid "Atom feed"
 msgstr ""
 
-#: src/Model/Profile.php:484 src/Module/Profile/Profile.php:290
+#: src/Model/Profile.php:510 src/Module/Profile/Profile.php:290
 msgid "This website has been verified to belong to the same person."
 msgstr ""
 
-#: src/Model/Profile.php:607 src/Model/Profile.php:684
+#: src/Model/Profile.php:633 src/Model/Profile.php:710
 msgid "[today]"
 msgstr ""
 
-#: src/Model/Profile.php:616
+#: src/Model/Profile.php:642
 msgid "Birthday Reminders"
 msgstr ""
 
-#: src/Model/Profile.php:617
+#: src/Model/Profile.php:643
 msgid "Birthdays this week:"
 msgstr ""
 
-#: src/Model/Profile.php:697
+#: src/Model/Profile.php:723
 msgid "Event Reminders"
 msgstr ""
 
-#: src/Model/Profile.php:698
+#: src/Model/Profile.php:724
 msgid "Upcoming events the next 7 days:"
 msgstr ""
 
-#: src/Model/Profile.php:808
+#: src/Model/Profile.php:834
 msgid "Hometown:"
 msgstr ""
 
-#: src/Model/Profile.php:809
+#: src/Model/Profile.php:835
 msgid "Marital Status:"
 msgstr ""
 
-#: src/Model/Profile.php:810
+#: src/Model/Profile.php:836
 msgid "With:"
 msgstr ""
 
-#: src/Model/Profile.php:811
+#: src/Model/Profile.php:837
 msgid "Since:"
 msgstr ""
 
-#: src/Model/Profile.php:812
+#: src/Model/Profile.php:838
 msgid "Sexual Preference:"
 msgstr ""
 
-#: src/Model/Profile.php:813
+#: src/Model/Profile.php:839
 msgid "Political Views:"
 msgstr ""
 
-#: src/Model/Profile.php:814
+#: src/Model/Profile.php:840
 msgid "Religious Views:"
 msgstr ""
 
-#: src/Model/Profile.php:815
+#: src/Model/Profile.php:841
 msgid "Likes:"
 msgstr ""
 
-#: src/Model/Profile.php:816
+#: src/Model/Profile.php:842
 msgid "Dislikes:"
 msgstr ""
 
-#: src/Model/Profile.php:817
+#: src/Model/Profile.php:843
 msgid "Title/Description:"
 msgstr ""
 
-#: src/Model/Profile.php:819
+#: src/Model/Profile.php:845
 msgid "Musical interests"
 msgstr ""
 
-#: src/Model/Profile.php:820
+#: src/Model/Profile.php:846
 msgid "Books, literature"
 msgstr ""
 
-#: src/Model/Profile.php:821
+#: src/Model/Profile.php:847
 msgid "Television"
 msgstr ""
 
-#: src/Model/Profile.php:822
+#: src/Model/Profile.php:848
 msgid "Film/dance/culture/entertainment"
 msgstr ""
 
-#: src/Model/Profile.php:823
+#: src/Model/Profile.php:849
 msgid "Hobbies/Interests"
 msgstr ""
 
-#: src/Model/Profile.php:824
+#: src/Model/Profile.php:850
 msgid "Love/romance"
 msgstr ""
 
-#: src/Model/Profile.php:825
+#: src/Model/Profile.php:851
 msgid "Work/employment"
 msgstr ""
 
-#: src/Model/Profile.php:826
+#: src/Model/Profile.php:852
 msgid "School/education"
 msgstr ""
 
-#: src/Model/Profile.php:827
+#: src/Model/Profile.php:853
 msgid "Contact information and Social Networks"
 msgstr ""
 
-#: src/Model/Profile.php:875
+#: src/Model/Profile.php:901
 #, php-format
 msgid "Responsible account: %s"
 msgstr ""
@@ -4467,14 +4481,6 @@ msgstr ""
 
 #: src/Module/Admin/Roles.php:140
 msgid "No users with moderation rights found."
-msgstr ""
-
-#: src/Module/Admin/Roles.php:141
-msgid "Administrator"
-msgstr ""
-
-#: src/Module/Admin/Roles.php:142
-msgid "Moderator"
 msgstr ""
 
 #: src/Module/Admin/Roles.php:143
@@ -5970,7 +5976,7 @@ msgid "Reports"
 msgstr ""
 
 #: src/Module/BaseModeration.php:102 src/Module/Moderation/Users/Index.php:97
-#: src/Module/Moderation/Users/Index.php:107
+#: src/Module/Moderation/Users/Index.php:108
 msgid "Users"
 msgstr ""
 
@@ -6507,7 +6513,7 @@ msgstr ""
 msgid "Pending incoming contact request"
 msgstr ""
 
-#: src/Module/Contact.php:608 src/Module/Contact/Profile.php:391
+#: src/Module/Contact.php:632 src/Module/Contact/Profile.php:391
 #, php-format
 msgid "Visit %s's profile [%s]"
 msgstr ""
@@ -6543,7 +6549,7 @@ msgstr ""
 #: src/Module/Moderation/Users/Blocked.php:82
 #: src/Module/Moderation/Users/Deleted.php:69
 #: src/Module/Moderation/Users/Index.php:89
-#: src/Module/Moderation/Users/Index.php:109
+#: src/Module/Moderation/Users/Index.php:110
 #: src/Module/Moderation/Users/Pending.php:84 src/Module/Settings/OAuth.php:56
 msgid "Name"
 msgstr ""
@@ -7808,49 +7814,49 @@ msgstr ""
 msgid "List of pending user deletions"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:136 src/Module/Settings/Account.php:432
+#: src/Module/Moderation/BaseUsers.php:134 src/Module/Settings/Account.php:432
 msgid "Normal Account Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:137 src/Module/Settings/Account.php:439
+#: src/Module/Moderation/BaseUsers.php:135 src/Module/Settings/Account.php:439
 msgid "Soapbox Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:138 src/Module/Register.php:151
+#: src/Module/Moderation/BaseUsers.php:136 src/Module/Register.php:151
 #: src/Module/Register.php:162 src/Module/Settings/Account.php:446
 msgid "Public Group"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:139 src/Module/Settings/Account.php:453
+#: src/Module/Moderation/BaseUsers.php:137 src/Module/Settings/Account.php:453
 msgid "Public Group - Restricted"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:140 src/Module/Settings/Account.php:460
+#: src/Module/Moderation/BaseUsers.php:138 src/Module/Settings/Account.php:460
 msgid "Automatic Friend Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:141 src/Module/Register.php:153
+#: src/Module/Moderation/BaseUsers.php:139 src/Module/Register.php:153
 #: src/Module/Register.php:164
 msgid "Private Group"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:144 src/Module/Moderation/Summary.php:37
+#: src/Module/Moderation/BaseUsers.php:142 src/Module/Moderation/Summary.php:37
 #: src/Module/Settings/Account.php:403
 msgid "Personal Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:145 src/Module/Moderation/Summary.php:38
+#: src/Module/Moderation/BaseUsers.php:143 src/Module/Moderation/Summary.php:38
 #: src/Module/Settings/Account.php:410
 msgid "Organisation Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:146 src/Module/Moderation/Summary.php:39
+#: src/Module/Moderation/BaseUsers.php:144 src/Module/Moderation/Summary.php:39
 #: src/Module/Register.php:150 src/Module/Register.php:171
 #: src/Module/Settings/Account.php:417
 msgid "News Page"
 msgstr ""
 
-#: src/Module/Moderation/BaseUsers.php:147 src/Module/Moderation/Summary.php:40
+#: src/Module/Moderation/BaseUsers.php:145 src/Module/Moderation/Summary.php:40
 #: src/Module/Settings/Account.php:424
 msgid "Community Group"
 msgstr ""
@@ -8799,11 +8805,11 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/Module/Moderation/Users/Active.php:37
-#: src/Module/Moderation/Users/Active.php:149
+#: src/Module/Moderation/Users/Active.php:150
 #: src/Module/Moderation/Users/Blocked.php:37
-#: src/Module/Moderation/Users/Blocked.php:148
+#: src/Module/Moderation/Users/Blocked.php:149
 #: src/Module/Moderation/Users/Index.php:44
-#: src/Module/Moderation/Users/Index.php:160
+#: src/Module/Moderation/Users/Index.php:161
 msgid "You can't remove yourself"
 msgstr ""
 
@@ -8820,7 +8826,7 @@ msgstr[1] ""
 #: src/Module/Moderation/Users/Blocked.php:82
 #: src/Module/Moderation/Users/Deleted.php:69
 #: src/Module/Moderation/Users/Index.php:89
-#: src/Module/Moderation/Users/Index.php:109
+#: src/Module/Moderation/Users/Index.php:110
 msgid "Register date"
 msgstr ""
 
@@ -8828,7 +8834,7 @@ msgstr ""
 #: src/Module/Moderation/Users/Blocked.php:82
 #: src/Module/Moderation/Users/Deleted.php:69
 #: src/Module/Moderation/Users/Index.php:89
-#: src/Module/Moderation/Users/Index.php:109
+#: src/Module/Moderation/Users/Index.php:110
 msgid "Last login"
 msgstr ""
 
@@ -8836,7 +8842,7 @@ msgstr ""
 #: src/Module/Moderation/Users/Blocked.php:82
 #: src/Module/Moderation/Users/Deleted.php:69
 #: src/Module/Moderation/Users/Index.php:89
-#: src/Module/Moderation/Users/Index.php:109
+#: src/Module/Moderation/Users/Index.php:110
 msgid "Last public item"
 msgstr ""
 
@@ -8856,38 +8862,38 @@ msgstr ""
 msgid "Site admin"
 msgstr ""
 
-#: src/Module/Moderation/Users/Active.php:96
-#: src/Module/Moderation/Users/Blocked.php:96
-#: src/Module/Moderation/Users/Index.php:105
+#: src/Module/Moderation/Users/Active.php:97
+#: src/Module/Moderation/Users/Blocked.php:97
+#: src/Module/Moderation/Users/Index.php:106
 msgid "Account expired"
 msgstr ""
 
-#: src/Module/Moderation/Users/Active.php:97
-#: src/Module/Moderation/Users/Index.php:108
+#: src/Module/Moderation/Users/Active.php:98
+#: src/Module/Moderation/Users/Index.php:109
 msgid "Create a new user"
-msgstr ""
-
-#: src/Module/Moderation/Users/Active.php:103
-#: src/Module/Moderation/Users/Blocked.php:102
-#: src/Module/Moderation/Users/Index.php:114
-msgid "Selected users will be deleted!\\n\\nEverything these users had posted on this site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
 #: src/Module/Moderation/Users/Active.php:104
 #: src/Module/Moderation/Users/Blocked.php:103
 #: src/Module/Moderation/Users/Index.php:115
+msgid "Selected users will be deleted!\\n\\nEverything these users had posted on this site will be permanently deleted!\\n\\nAre you sure?"
+msgstr ""
+
+#: src/Module/Moderation/Users/Active.php:105
+#: src/Module/Moderation/Users/Blocked.php:104
+#: src/Module/Moderation/Users/Index.php:116
 msgid "The user {0} will be deleted!\\n\\nEverything this user has posted on this site will be permanently deleted!\\n\\nAre you sure?"
 msgstr ""
 
-#: src/Module/Moderation/Users/Active.php:147
-#: src/Module/Moderation/Users/Blocked.php:146
-#: src/Module/Moderation/Users/Index.php:158
+#: src/Module/Moderation/Users/Active.php:148
+#: src/Module/Moderation/Users/Blocked.php:147
+#: src/Module/Moderation/Users/Index.php:159
 #, php-format
 msgid "User \"%s\" deleted"
 msgstr ""
 
-#: src/Module/Moderation/Users/Active.php:157
-#: src/Module/Moderation/Users/Index.php:168
+#: src/Module/Moderation/Users/Active.php:158
+#: src/Module/Moderation/Users/Index.php:169
 #, php-format
 msgid "User \"%s\" blocked"
 msgstr ""
@@ -8904,8 +8910,8 @@ msgstr[1] ""
 msgid "Blocked Users"
 msgstr ""
 
-#: src/Module/Moderation/Users/Blocked.php:155
-#: src/Module/Moderation/Users/Index.php:174
+#: src/Module/Moderation/Users/Blocked.php:156
+#: src/Module/Moderation/Users/Index.php:175
 #, php-format
 msgid "User \"%s\" unblocked"
 msgstr ""
@@ -8932,7 +8938,7 @@ msgid "Users awaiting permanent deletion"
 msgstr ""
 
 #: src/Module/Moderation/Users/Deleted.php:69
-#: src/Module/Moderation/Users/Index.php:109
+#: src/Module/Moderation/Users/Index.php:110
 msgid "Permanent deletion"
 msgstr ""
 

--- a/view/templates/contact/entry.tpl
+++ b/view/templates/contact/entry.tpl
@@ -38,7 +38,31 @@
 	<div class="contact-entry-desc">
 		<div class="contact-entry-name" id="contact-entry-name-{{$contact.id}}">
 			{{$contact.name}}
-			{{if $contact.account_type}} <span class="contact-entry-details" id="contact-entry-accounttype-{{$contact.id}}">({{$contact.account_type}})</span>{{/if}}
+			{{if $contact.account_type == 4}}
+				{{$acct_icon = "ri-broadcast-line"}}
+			{{else if $contact.account_type == 3}}
+				{{if $contact.private == 1}}
+					{{$acct_icon = "ri-spy-line"}}
+				{{else if $contact.manually_approve == 1}}
+					{{$acct_icon = "ri-group-3-line"}}
+				{{else}}
+					{{$acct_icon = "ri-team-line"}}
+				{{/if}}
+			{{else if $contact.account_type == 2}}
+				{{$acct_icon = "ri-newspaper-line"}}
+			{{else if $contact.account_type == 1}}
+				{{$acct_icon = "ri-building-4-line"}}
+			{{else if $contact.account_type == 0 && $contact.manually_approve == 0}}
+				{{$acct_icon = "ri-megaphone-line"}}
+			{{else}}
+				{{$acct_icon = ""}}
+			{{/if}}
+			{{if $contact.account_type_name}} <small class="contact-entry-details" id="contact-entry-accounttype-{{$contact.id}}">(<i class="ri {{$acct_icon}}" aria-hidden="true"></i> {{$contact.account_type_name}})</small>
+			{{else}}
+				<small class="contact-entry-details"><i class="ri {{$acct_icon}}" aria-hidden="true"></i></small>
+			{{/if}}
+			{{if $contact.is_admin}}<span class="badge badge-admin"><i class="ri ri-medal-2-fill" aria-hidden="true"></i> {{$contact.admin_title}}</span>{{/if}}
+			{{if $contact.is_mod}}<span class="badge badge-mod"><i class="ri ri-shield-user-line" aria-hidden="true"></i> {{$contact.moderator_title}}</span>{{/if}}
 		</div>
 		{{if $contact.alt_text}}<div class="contact-entry-details" id="contact-entry-rel-{{$contact.id}}">{{$contact.alt_text}}</div>{{/if}}
 		{{if $contact.itemurl}}<div class="contact-entry-details" id="contact-entry-url-{{$contact.id}}">{{$contact.itemurl}}</div>{{/if}}

--- a/view/templates/hovercard.tpl
+++ b/view/templates/hovercard.tpl
@@ -14,7 +14,32 @@
 			</div>
 			<div class="hover-card-content">
 				<div class="profile-entry-name">
-					<h4 class="left-align1"><a href="{{$profile.url}}">{{$profile.name}}</a></h4>{{if $profile.account_type}}<span>{{$profile.account_type}}</span>{{/if}}
+					<h4 class="left-align1"><a href="{{$profile.url}}">{{$profile.name}}</a></h4>
+					{{if $profile.is_admin}}<span class="badge badge-admin"><i class="ri ri-medal-2-fill" aria-hidden="true"></i> {{$profile.admin_title}}</span>{{/if}}
+					{{if $profile.is_mod}}<span class="badge badge-mod"><i class="ri ri-shield-user-line" aria-hidden="true"></i> {{$profile.moderator_title}}</span>{{/if}}
+					
+					{{if $profile.account_type_name}}
+						{{if $profile.account_type == 4}}
+							{{$acct_icon = "ri-broadcast-line"}}
+						{{else if $profile.account_type == 3}}
+							{{if $profile.private == 1}}
+								{{$acct_icon = "ri-spy-line"}}
+							{{else if $profile.manually_approve == 1}}
+								{{$acct_icon = "ri-group-3-line"}}
+							{{else}}
+								{{$acct_icon = "ri-team-line"}}
+							{{/if}}
+						{{else if $profile.account_type == 2}}
+								{{$acct_icon = "ri-newspaper-line"}}
+						{{else if $profile.account_type == 1}}
+								{{$acct_icon = "ri-building-4-line"}}
+						{{else if $profile.account_type == 0 && $profile.manually_approve == 0}}
+								{{$acct_icon = "ri-megaphone-line"}}
+						{{else}}
+							{{$acct_icon = ""}}
+						{{/if}}
+						<span><i class="{{$acct_icon}}" aria-hidden="true"></i> {{$profile.account_type_name}}</span>
+					{{/if}}
 				</div>
 				<div class="profile-details">
 					<span class="profile-addr">{{$profile.addr}}</span>

--- a/view/templates/moderation/users/active.tpl
+++ b/view/templates/moderation/users/active.tpl
@@ -56,7 +56,41 @@
 					<td class="register_date">{{$u.register_date}}</td>
 					<td class="login_date">{{$u.login_date}}</td>
 					<td class="lastitem_date">{{$u.lastitem_date}}</td>
-					<td class="login_date">{{$u.page_type.0}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}} {{if $u.blocked}}{{$blocked}}{{/if}}</td>
+					<td class="login_date">
+						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
+							{{if $u.account_type_raw==1}}
+								{{$acct_icon = "ri-building-4-line"}} {{* ACCOUNT_TYPE_ORGANISATION *}}
+							{{else if $u.account_type_raw==2}}
+								{{$acct_icon = "ri-newspaper-line"}}  {{* ACCOUNT_TYPE_NEWS *}}
+							{{else if $u.account_type_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
+						{{else}}
+							{{if $u.page_flags_raw==0}}
+								{{$acct_icon = "ri-user-line"}}		  {{* PERSON NORMAL *}}
+							{{else if $u.page_flags_raw==1}}
+								{{$acct_icon = "ri-megaphone-line"}}  {{* PERSON SOAPBOX *}}
+							{{else if $u.page_flags_raw==2}}
+								{{$acct_icon = "ri-team-line"}}		  {{* PUBLIC GROUP *}}
+							{{else if $u.page_flags_raw==3}}
+								{{$acct_icon = "ri-heart-line"}}	  {{* PERSON FREELOVE *}}
+							{{else if $u.page_flags_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}  {{* PAGE BLOG *}}
+							{{else if $u.page_flags_raw==5}}
+								{{$acct_icon = "ri-spy-line"}}	      {{* GROUP PRIVATE *}}
+							{{else if $u.page_flags_raw==6}}
+								{{$acct_icon = "ri-group-3-line"}}	  {{* GROUP RESTRICTED *}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
+						{{/if}}
+						<span class="acct-type"><i class="ri {{$acct_icon}}" aria-hidden="true" data-acct="{{$u.account_type_raw}}" data-flag="{{$u.page_flags_raw}}" title="{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}"></i> <span>{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}</span></span>
+						{{if $u.is_admin}}<span class="acct-type"><i class="ri ri-medal-2-fill text-primary" title="{{$siteadmin}}"></i> <span>{{$siteadmin}}</span>{{else if $u.is_mod}}<span class="acct-type"><i class="ri ri-shield-user-line" title="{{$moderator}}"></i> <span>{{$moderator}}</span>{{/if}}
+						{{if $u.account_expired}}<span class="acct-type"><i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i> <span>{{$accountexpired}}</span></span>{{/if}}				
+					</td>
+
 					<td class="checkbox">
 						{{if $u.is_deletable}}
 						<input type="checkbox" class="users_ckbx" id="id_user_{{$u.uid}}" name="user[]" value="{{$u.uid}}"/>

--- a/view/templates/moderation/users/blocked.tpl
+++ b/view/templates/moderation/users/blocked.tpl
@@ -57,7 +57,43 @@
 					<td class="register_date">{{$u.register_date}}</td>
 					<td class="login_date">{{$u.login_date}}</td>
 					<td class="lastitem_date">{{$u.lastitem_date}}</td>
-					<td class="login_date">{{$u.page_type.0}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}} {{if $u.blocked}}{{$blocked}}{{/if}}</td>
+					<td class="login_date">
+						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
+							{{if $u.account_type_raw==1}}
+								{{$acct_icon = "ri-building-4-line"}} {{* ACCOUNT_TYPE_ORGANISATION *}}
+							{{else if $u.account_type_raw==2}}
+								{{$acct_icon = "ri-newspaper-line"}}  {{* ACCOUNT_TYPE_NEWS *}}
+							{{else if $u.account_type_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
+						{{else}}
+							{{if $u.page_flags_raw==0}}
+								{{$acct_icon = "ri-user-line"}}		  {{* PERSON NORMAL *}}
+							{{else if $u.page_flags_raw==1}}
+								{{$acct_icon = "ri-megaphone-line"}}  {{* PERSON SOAPBOX *}}
+							{{else if $u.page_flags_raw==2}}
+								{{$acct_icon = "ri-team-line"}}		  {{* PUBLIC GROUP *}}
+							{{else if $u.page_flags_raw==3}}
+								{{$acct_icon = "ri-heart-line"}}	  {{* PERSON FREELOVE *}}
+							{{else if $u.page_flags_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}  {{* PAGE BLOG *}}
+							{{else if $u.page_flags_raw==5}}
+								{{$acct_icon = "ri-spy-line"}}	      {{* GROUP PRIVATE *}}
+							{{else if $u.page_flags_raw==6}}
+								{{$acct_icon = "ri-group-3-line"}}	  {{* GROUP RESTRICTED *}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
+						{{/if}}
+						<span class="acct-type"><i class="ri {{$acct_icon}}" aria-hidden="true" data-acct="{{$u.account_type_raw}}" data-flag="{{$u.page_flags_raw}}" title="{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}"></i> <span>{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}</span></span>
+						{{if $u.is_admin}}<span class="acct-type"><i class="ri ri-medal-2-fill text-primary" title="{{$siteadmin}}"></i> <span>{{$siteadmin}}</span>{{else if $u.is_mod}}<span class="acct-type"><i class="ri ri-shield-user-line" title="{{$moderator}}"></i> <span>{{$moderator}}</span>{{/if}}
+						{{if $u.blocked}}<span class="acct-type"><i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i> <span>{{$blocked}}</span></span>{{/if}}
+						{{if $u.deleted}}<span class="acct-type"><i class="ri ri-user-unfollow-line" title="{{$h_deleted}}"></i> <span>{{$h_deleted}}</span></span>{{/if}}
+						{{if $u.account_expired}}<span class="acct-type"><i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i> <span>{{$accountexpired}}</span></span>{{/if}}
+					</td>
+
 					<td class="checkbox">
 						{{if $u.is_deletable}}
 						<input type="checkbox" class="users_ckbx" id="id_user_{{$u.uid}}" name="user[]" value="{{$u.uid}}"/>

--- a/view/templates/moderation/users/index.tpl
+++ b/view/templates/moderation/users/index.tpl
@@ -56,7 +56,42 @@
 					<td class="register_date">{{$u.register_date}}</td>
 					<td class="login_date">{{$u.login_date}}</td>
 					<td class="lastitem_date">{{$u.lastitem_date}}</td>
-					<td class="login_date">{{$u.page_type.0}} {{if $u.is_admin}}({{$siteadmin}}){{/if}} {{if $u.account_expired}}({{$accountexpired}}){{/if}} {{if $u.blocked}}{{$blocked}}{{/if}}</td>
+					<td class="login_date acct-type-col">
+						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
+							{{if $u.account_type_raw==1}}
+								{{$acct_icon = "ri-building-4-line"}} {{* ACCOUNT_TYPE_ORGANISATION *}}
+							{{else if $u.account_type_raw==2}}
+								{{$acct_icon = "ri-newspaper-line"}}  {{* ACCOUNT_TYPE_NEWS *}}
+							{{else if $u.account_type_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
+						{{else}}
+							{{if $u.page_flags_raw==0}}
+								{{$acct_icon = "ri-user-line"}}		  {{* PERSON NORMAL *}}
+							{{else if $u.page_flags_raw==1}}
+								{{$acct_icon = "ri-megaphone-line"}}  {{* PERSON SOAPBOX *}}
+							{{else if $u.page_flags_raw==2}}
+								{{$acct_icon = "ri-team-line"}}		  {{* PUBLIC GROUP *}}
+							{{else if $u.page_flags_raw==3}}
+								{{$acct_icon = "ri-heart-line"}}	  {{* PERSON FREELOVE *}}
+							{{else if $u.page_flags_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}  {{* PAGE BLOG *}}
+							{{else if $u.page_flags_raw==5}}
+								{{$acct_icon = "ri-spy-line"}}	      {{* GROUP PRIVATE *}}
+							{{else if $u.page_flags_raw==6}}
+								{{$acct_icon = "ri-group-3-line"}}	  {{* GROUP RESTRICTED *}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
+						{{/if}}
+						<span class="acct-type"><i class="ri {{$acct_icon}}" aria-hidden="true" data-acct="{{$u.account_type_raw}}" data-flag="{{$u.page_flags_raw}}" title="{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}"></i> <span>{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}</span></span>
+						{{if $u.is_admin}}<span class="acct-type"><i class="ri ri-medal-2-fill text-primary" title="{{$siteadmin}}"></i> <span>{{$siteadmin}}</span>{{else if $u.is_mod}}<span class="acct-type"><i class="ri ri-shield-user-line" title="{{$moderator}}"></i> <span>{{$moderator}}</span>{{/if}}
+						{{if $u.blocked}}<span class="acct-type"><i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i> <span>{{$blocked}}</span></span>{{/if}}
+						{{if $u.deleted}}<span class="acct-type"><i class="ri ri-user-unfollow-line" title="{{$h_deleted}}"></i> <span>{{$h_deleted}}</span></span>{{/if}}
+						{{if $u.account_expired}}<span class="acct-type"><i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i> <span>{{$accountexpired}}</span></span>{{/if}}
+					</td>
 					<td class="checkbox">
 						{{if $u.is_deletable}}
 						<input type="checkbox" class="users_ckbx" id="id_user_{{$u.uid}}" name="user[]" value="{{$u.uid}}"/>

--- a/view/templates/profile/vcard.tpl
+++ b/view/templates/profile/vcard.tpl
@@ -10,7 +10,7 @@
 	<div class="fn p-name" dir="auto">{{$profile.name}}</div>
 	
 	{{if $profile.addr}}<div class="p-addr">{{$profile.addr}}</div>{{/if}}
-		{{if $is_admin}}<div class="badge badge-admin"><i class="ri ri-medal-2-fill" aria-hidden="true"></i> {{$admin_title}}</div>{{/if}}
+	{{if $is_admin}}<div class="badge badge-admin"><i class="ri ri-medal-2-fill" aria-hidden="true"></i> {{$admin_title}}</div>{{/if}}
 	{{if $is_mod}}<div class="badge badge-mod"><i class="ri ri-shield-user-line" aria-hidden="true"></i> {{$moderator_title}}</div>{{/if}}
 	<div id="profile-photo-wrapper"><a href="{{$profile.url}}"><img class="photo u-photo" width="175" height="175" src="{{$profile.photo}}" alt="{{$profile.name}}"></a></div>
 

--- a/view/templates/profile/vcard.tpl
+++ b/view/templates/profile/vcard.tpl
@@ -10,10 +10,27 @@
 	<div class="fn p-name" dir="auto">{{$profile.name}}</div>
 	
 	{{if $profile.addr}}<div class="p-addr">{{$profile.addr}}</div>{{/if}}
-	
+		{{if $is_admin}}<div class="badge badge-admin"><i class="ri ri-medal-2-fill" aria-hidden="true"></i> {{$admin_title}}</div>{{/if}}
+	{{if $is_mod}}<div class="badge badge-mod"><i class="ri ri-shield-user-line" aria-hidden="true"></i> {{$moderator_title}}</div>{{/if}}
 	<div id="profile-photo-wrapper"><a href="{{$profile.url}}"><img class="photo u-photo" width="175" height="175" src="{{$profile.photo}}" alt="{{$profile.name}}"></a></div>
 
-	{{if $account_type}}<div class="account-type">{{$account_type}}</div>{{/if}}
+	{{if $account_type == 1 }}
+		{{$acct_icon = "ri-building-4-line"}}
+	{{else if $account_type == 2}}
+		{{$acct_icon = "ri-newspaper-line"}}
+	{{else if $account_type == 3 && $page_flags == 2}}
+		{{$acct_icon = "ri-team-line"}}
+	{{else if $account_type == 3 && $page_flags == 6}}
+		{{$acct_icon = "ri-group-3-line"}}
+	{{else if $account_type == 3 && $page_flags == 5}}
+		{{$acct_icon = "ri-spy-line"}}
+	{{else if $account_type == 4}}
+		{{$acct_icon = "ri-broadcast-line"}}
+	{{else}}
+		{{$acct_icon = ''}}
+	{{/if}}
+	{{if $account_type_name}}<div class="account-type" data-acct="{{$account_type}}" data-flag="{{$page_flags}}">(<i class="ri {{$acct_icon}}" aria-hidden="true"></i> {{$account_type_name}})</div>{{/if}}
+
 	{{if $profile.network_link}}<dl class="network"><dt class="network-label">{{$network}}</dt><dd class="x-network">{{$profile.network_link nofilter}}</dd></dl>{{/if}}
 	{{if $location}}
 		<dl class="location" dir="auto">

--- a/view/templates/widget/vcard.tpl
+++ b/view/templates/widget/vcard.tpl
@@ -7,12 +7,34 @@
 <div class="vcard h-card">
 	<div class="fn p-name" dir="auto">{{$contact.name}}</div>
 	{{if $contact.addr}}<div class="p-addr">{{$contact.addr}}</div>{{/if}}
+	{{if $is_admin}}<div class="badge badge-admin"><i class="ri ri-medal-2-fill" aria-hidden="true"></i> {{$admin_title}}</div>{{/if}}
+	{{if $is_mod}}<div class="badge badge-mod"><i class="ri ri-shield-user-line" aria-hidden="true"></i> {{$moderator_title}}</div>{{/if}}
+
 	{{if $url}}
 	<div id="profile-photo-wrapper"><a href="{{$url}}"><img class="vcard-photo photo u-photo" style="width: 175px; height: 175px;" src="{{$photo}}" alt="{{$name}}" /></a></div>
 	{{else}}
 	<div id="profile-photo-wrapper"><img class="vcard-photo photo u-photo" style="width: 175px; height: 175px;" src="{{$photo}}" alt="{{$name}}" /></div>
 	{{/if}}
-	{{if $account_type}}<div class="account-type">{{$account_type}}</div>{{/if}}
+	{{if $account_type == 1}}
+		{{$acct_icon = "ri-building-4-line"}}
+	{{else if $account_type == 2}}
+		{{$acct_icon = "ri-newspaper-line"}}
+	{{else if $account_type == 3 && $page_flags == 2 || $account_type == 3 && $manually_approve == 0}}
+		{{$acct_icon = "ri-team-line"}}
+		{{$page_flags = 2}}
+	{{else if $account_type == 3 && $page_flags == 5 || $account_type == 3 && $manually_approve == 1 && $private == 1}}
+		{{$acct_icon = "ri-spy-line"}}
+		{{$page_flags = 5}}
+	{{else if $account_type == 3 && $page_flags == 6 || $account_type == 3 && $manually_approve == 1 && $private == 0}}
+		{{$acct_icon = "ri-group-3-line"}}
+		{{$page_flags = 6}}
+	{{else if $account_type == 4}}
+		{{$acct_icon = "ri-broadcast-line"}}
+	{{else}}
+		{{$acct_icon = ''}}
+	{{/if}}
+	{{if $account_type_name}}<div class="account-type" data-acct="{{$account_type}}" data-flag="{{$page_flags}}">(<i class="ri {{$acct_icon}}" aria-hidden="true"></i> {{$account_type_name}})</div>{{/if}}
+
 	{{if $about}}<div class="title p-about" dir="auto">{{$about nofilter}}</div>{{/if}}
 	{{if $contact.xmpp}}
 		<dl class="xmpp">

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -505,6 +505,24 @@ aside .badge {
 .sidebar-circle-li .badge {
 	margin-top: 6px;
 }
+.profile-header .badge {
+	opacity: 1;
+	display: block;
+	width: fit-content;
+	margin: 10px auto;
+}
+.profile-header .badge-admin,
+.badge-admin {
+	background-color: #eebc1d;
+}
+.profile-header .badge-mod,
+.badge-mod {
+	background-color: #32cd32;
+}
+	.vcard .badge-admin i,
+	.vcard .badge-mod i {
+		vertical-align: middle;
+	}
 
 /* disabled elements */
 .community-content-wrapper > h3,
@@ -3809,6 +3827,18 @@ li.addon {
 #admin-users #users tr.blocked {
 	background-color: #f8efc0;
 }
+	#admin-users #users span.acct-type span,
+	#admin-users-blocked #users span.acct-type span {
+		display: none;
+	}
+	#admin-users #users tr.opened span.acct-type,
+	#admin-users-blocked #users tr.opened span.acct-type {
+		display: block;
+	}
+		#admin-users #users tr.opened span.acct-type span,
+		#admin-users-blocked #users tr.opened span.acct-type span {
+			display: inline;
+		}
 .adminpage .table-hover > tbody > tr:hover + tr.details {
 	background-color: #f5f5f5;
 }

--- a/view/theme/frio/templates/contact/entry.tpl
+++ b/view/theme/frio/templates/contact/entry.tpl
@@ -96,8 +96,32 @@
 			<div class="contact-entry-desc">
 				<div class="contact-entry-name" id="contact-entry-name-{{$contact.id}}">
 					<h4 class="media-heading"><a href="{{if !empty($contact.photo_menu.edit)}}{{$contact.photo_menu.edit.1}}{{else}}{{$contact.url}}{{/if}}">{{$contact.name}}</a>
-					{{if $contact.account_type}} <small class="contact-entry-details" id="contact-entry-accounttype-{{$contact.id}}">({{$contact.account_type}})</small>{{/if}}
-					{{if $contact.account_type == 'Group'}}<i class="ri ri-chat-3-line" aria-hidden="true"></i>{{/if}}
+					{{if $contact.account_type == 4}}
+						{{$acct_icon = "ri-broadcast-line"}}
+					{{else if $contact.account_type == 3}}
+						{{if $contact.private == 1}}
+							{{$acct_icon = "ri-spy-line"}}
+						{{else if $contact.manually_approve == 1}}
+							{{$acct_icon = "ri-group-3-line"}}
+						{{else}}
+							{{$acct_icon = "ri-team-line"}}
+						{{/if}}
+					{{else if $contact.account_type == 2}}
+							{{$acct_icon = "ri-newspaper-line"}}
+					{{else if $contact.account_type == 1}}
+							{{$acct_icon = "ri-building-4-line"}}
+					{{else if $contact.account_type == 0 && $contact.manually_approve == 0}}
+							{{$acct_icon = "ri-megaphone-line"}}
+					{{else}}
+						{{$acct_icon = ""}}
+					{{/if}}
+					{{if $contact.account_type_name}} <small class="contact-entry-details" id="contact-entry-accounttype-{{$contact.id}}">(<i class="ri {{$acct_icon}}" aria-hidden="true"></i> {{$contact.account_type_name}})</small>
+					{{else}}
+						<small class="contact-entry-details"><i class="ri {{$acct_icon}}" aria-hidden="true"></i></small>
+					{{/if}}
+					</h4>
+					{{if $contact.is_admin}}<span class="badge badge-admin"><i class="ri ri-medal-2-fill" aria-hidden="true"></i> {{$contact.admin_title}}</span>{{/if}}
+					{{if $contact.is_mod}}<span class="badge badge-mod"><i class="ri ri-shield-user-line" aria-hidden="true"></i> {{$contact.moderator_title}}</span>{{/if}}
 					{{* @todo this needs some changing in core because $contact.account_type contains a translated string which may not be the same in every language *}}
 					</h4>
 				</div>

--- a/view/theme/frio/templates/moderation/users/active.tpl
+++ b/view/theme/frio/templates/moderation/users/active.tpl
@@ -75,12 +75,38 @@
 
 				{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 					<td>
-						<i class="ri {{$u.page_type.1}}" title="{{$u.page_type.0}}"></i>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
-							<i class="ri {{$u.account_type.1}}" title="{{$u.account_type.0}}"></i>
+							{{if $u.account_type_raw==1}}
+								{{$acct_icon = "ri-building-4-line"}} {{* ACCOUNT_TYPE_ORGANISATION *}}
+							{{else if $u.account_type_raw==2}}
+								{{$acct_icon = "ri-newspaper-line"}}  {{* ACCOUNT_TYPE_NEWS *}}
+							{{else if $u.account_type_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
+						{{else}}
+							{{if $u.page_flags_raw==0}}
+								{{$acct_icon = "ri-user-line"}}		  {{* PERSON NORMAL *}}
+							{{else if $u.page_flags_raw==1}}
+								{{$acct_icon = "ri-megaphone-line"}}  {{* PERSON SOAPBOX *}}
+							{{else if $u.page_flags_raw==2}}
+								{{$acct_icon = "ri-team-line"}}		  {{* PUBLIC GROUP *}}
+							{{else if $u.page_flags_raw==3}}
+								{{$acct_icon = "ri-heart-line"}}	  {{* PERSON FREELOVE *}}
+							{{else if $u.page_flags_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}  {{* PAGE BLOG *}}
+							{{else if $u.page_flags_raw==5}}
+								{{$acct_icon = "ri-spy-line"}}	      {{* GROUP PRIVATE *}}
+							{{else if $u.page_flags_raw==6}}
+								{{$acct_icon = "ri-group-3-line"}}	  {{* GROUP RESTRICTED *}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
 						{{/if}}
-						{{if $u.is_admin}}<i class="ri ri-spy-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
-						{{if $u.account_expired}}<i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i>{{/if}}
+						<span class="acct-type"><i class="ri {{$acct_icon}}" aria-hidden="true" data-acct="{{$u.account_type_raw}}" data-flag="{{$u.page_flags_raw}}" title="{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}"></i> <span>{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}</span></span>
+						{{if $u.is_admin}}<span class="acct-type"><i class="ri ri-medal-2-fill text-primary" title="{{$siteadmin}}"></i> <span>{{$siteadmin}}</span>{{else if $u.is_mod}}<span class="acct-type"><i class="ri ri-shield-user-line" title="{{$moderator}}"></i> <span>{{$moderator}}</span>{{/if}}
+						{{if $u.account_expired}}<span class="acct-type"><i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i> <span>{{$accountexpired}}</span></span>{{/if}}
 					</td>
 				{{/if}}
 

--- a/view/theme/frio/templates/moderation/users/blocked.tpl
+++ b/view/theme/frio/templates/moderation/users/blocked.tpl
@@ -74,14 +74,40 @@
 
 				{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 					<td>
-						<i class="ri {{$u.page_type.1}}" title="{{$u.page_type.0}}"></i>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
-							<i class="ri {{$u.account_type.1}}" title="{{$u.account_type.0}}"></i>
+							{{if $u.account_type_raw==1}}
+								{{$acct_icon = "ri-building-4-line"}} {{* ACCOUNT_TYPE_ORGANISATION *}}
+							{{else if $u.account_type_raw==2}}
+								{{$acct_icon = "ri-newspaper-line"}}  {{* ACCOUNT_TYPE_NEWS *}}
+							{{else if $u.account_type_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
+						{{else}}
+							{{if $u.page_flags_raw==0}}
+								{{$acct_icon = "ri-user-line"}}		  {{* PERSON NORMAL *}}
+							{{else if $u.page_flags_raw==1}}
+								{{$acct_icon = "ri-megaphone-line"}}  {{* PERSON SOAPBOX *}}
+							{{else if $u.page_flags_raw==2}}
+								{{$acct_icon = "ri-team-line"}}		  {{* PUBLIC GROUP *}}
+							{{else if $u.page_flags_raw==3}}
+								{{$acct_icon = "ri-heart-line"}}	  {{* PERSON FREELOVE *}}
+							{{else if $u.page_flags_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}  {{* PAGE BLOG *}}
+							{{else if $u.page_flags_raw==5}}
+								{{$acct_icon = "ri-spy-line"}}	      {{* GROUP PRIVATE *}}
+							{{else if $u.page_flags_raw==6}}
+								{{$acct_icon = "ri-group-3-line"}}	  {{* GROUP RESTRICTED *}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
 						{{/if}}
-						{{* NOTE: No u.deleted below here? *}}
-						{{if $u.is_admin}}<i class="ri ri-spy-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
-						{{if $u.blocked}}<i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i>{{/if}}
-						{{if $u.account_expired}}<i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i>{{/if}}
+						<span class="acct-type"><i class="ri {{$acct_icon}}" aria-hidden="true" data-acct="{{$u.account_type_raw}}" data-flag="{{$u.page_flags_raw}}" title="{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}"></i> <span>{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}</span></span>
+						{{if $u.is_admin}}<span class="acct-type"><i class="ri ri-medal-2-fill text-primary" title="{{$siteadmin}}"></i> <span>{{$siteadmin}}</span>{{else if $u.is_mod}}<span class="acct-type"><i class="ri ri-shield-user-line" title="{{$moderator}}"></i> <span>{{$moderator}}</span>{{/if}}
+						{{if $u.blocked}}<span class="acct-type"><i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i> <span>{{$blocked}}</span></span>{{/if}}
+						{{if $u.deleted}}<span class="acct-type"><i class="ri ri-user-unfollow-line" title="{{$h_deleted}}"></i> <span>{{$h_deleted}}</span></span>{{/if}}
+						{{if $u.account_expired}}<span class="acct-type"><i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i> <span>{{$accountexpired}}</span></span>{{/if}}
 					</td>
 				{{/if}}
 

--- a/view/theme/frio/templates/moderation/users/index.tpl
+++ b/view/theme/frio/templates/moderation/users/index.tpl
@@ -75,14 +75,41 @@
 
 				{{if !in_array($order_users,[$th_users.2.1, $th_users.3.1, $th_users.4.1]) }}
 					<td>
-						<i class="ri {{$u.page_type.1}}" title="{{$u.page_type.0}}"></i>
 						{{if $u.page_flags_raw==0 && $u.account_type_raw > 0}}
-							<i class="ri {{$u.account_type.1}}" title"{{$u.account_type.0}}"></i>
+							{{if $u.account_type_raw==1}}
+								{{$acct_icon = "ri-building-4-line"}} {{* ACCOUNT_TYPE_ORGANISATION *}}
+							{{else if $u.account_type_raw==2}}
+								{{$acct_icon = "ri-newspaper-line"}}  {{* ACCOUNT_TYPE_NEWS *}}
+							{{else if $u.account_type_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
+						{{else}}
+							{{if $u.page_flags_raw==0}}
+								{{$acct_icon = "ri-user-line"}}		  {{* PERSON NORMAL *}}
+							{{else if $u.page_flags_raw==1}}
+								{{$acct_icon = "ri-megaphone-line"}}  {{* PERSON SOAPBOX *}}
+							{{else if $u.page_flags_raw==2}}
+								{{$acct_icon = "ri-team-line"}}		  {{* PUBLIC GROUP *}}
+							{{else if $u.page_flags_raw==3}}
+								{{$acct_icon = "ri-heart-line"}}	  {{* PERSON FREELOVE *}}
+							{{else if $u.page_flags_raw==4}}
+								{{$acct_icon = "ri-broadcast-line"}}  {{* PAGE BLOG *}}
+							{{else if $u.page_flags_raw==5}}
+								{{$acct_icon = "ri-spy-line"}}	      {{* GROUP PRIVATE *}}
+							{{else if $u.page_flags_raw==6}}
+								{{$acct_icon = "ri-group-3-line"}}	  {{* GROUP RESTRICTED *}}
+							{{else}}
+								{{$acct_icon = ""}}
+							{{/if}}
 						{{/if}}
-						{{if $u.is_admin}}<i class="ri ri-spy-line text-primary" title="{{$siteadmin}}"></i>{{/if}}
-						{{if $u.blocked}}<i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i>{{/if}}
-						{{if $u.deleted}}<i class="ri ri-user-unfollow-line" title="{{$h_deleted}}"></i>{{/if}}
-						{{if $u.account_expired}}<i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i>{{/if}}
+						<span class="acct-type"><i class="ri {{$acct_icon}}" aria-hidden="true" data-acct="{{$u.account_type_raw}}" data-flag="{{$u.page_flags_raw}}" title="{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}"></i> <span>{{if $u.page_flags && $u.page_flags_raw !=0}}{{$u.page_flags}}{{else}}{{$u.account_type}}{{/if}}</span></span>
+						{{if $u.is_admin}}<span class="acct-type"><i class="ri ri-medal-2-fill text-primary" title="{{$siteadmin}}"></i> <span>{{$siteadmin}}</span>{{else if $u.is_mod}}<span class="acct-type"><i class="ri ri-shield-user-line" title="{{$moderator}}"></i> <span>{{$moderator}}</span>{{/if}}
+						{{if $u.blocked}}<span class="acct-type"><i class="ri ri-forbid-2-line text-danger" title="{{$blocked}}"></i> <span>{{$blocked}}</span></span>{{/if}}
+						{{if $u.deleted}}<span class="acct-type"><i class="ri ri-user-unfollow-line" title="{{$h_deleted}}"></i> <span>{{$h_deleted}}</span></span>{{/if}}
+						{{if $u.account_expired}}<span class="acct-type"><i class="ri ri-time-line text-warning" title="{{$accountexpired}}"></i> <span>{{$accountexpired}}</span></span>{{/if}}
+
 					</td>
 				{{/if}}
 

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -271,11 +271,10 @@
 										<li>
 											<a accesskey="a" role="menuitem" id="nav-admin-link"
 												class="nav-link {{$nav.admin.2}}" href="{{$nav.admin.0}}"
-												title="{{$nav.admin.3}}"><i class="ri ri-admin-line ri-fw" aria-hidden="true"></i>
+												title="{{$nav.admin.3}}"><i class="ri ri-medal-2-fill ri-fw" aria-hidden="true"></i>
 												{{$nav.admin.1}}
 											</a>
-										</li>
-									{{/if}}
+										</li>									{{/if}}
 									{{if $nav.moderation}}
 										<li>
 											<a accesskey="m" role="menuitem" id="nav-moderation-link"

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -44,8 +44,23 @@
 			{{/if}}
 
 			{{if $profile.about}}<div class="title" dir="auto">{{$profile.about nofilter}}</div>{{/if}}
+			{{if $account_type == 1 }}
+				{{$acct_icon = "ri-building-4-line"}}
+			{{else if $account_type == 2}}
+				{{$acct_icon = "ri-newspaper-line"}}
+			{{else if $account_type == 3 && $page_flags == 2}}
+				{{$acct_icon = "ri-team-line"}}
+			{{else if $account_type == 3 && $page_flags == 6}}
+				{{$acct_icon = "ri-group-3-line"}}
+			{{else if $account_type == 3 && $page_flags == 5}}
+				{{$acct_icon = "ri-spy-line"}}
+			{{else if $account_type == 4}}
+				{{$acct_icon = "ri-broadcast-line"}}
+			{{else}}
+				{{$acct_icon = ''}}
+			{{/if}}
+			{{if $account_type_name}}<div class="account-type" data-acct="{{$account_type}}" data-flag="{{$page_flags}}">(<i class="ri {{$acct_icon}}" aria-hidden="true"></i> {{$account_type_name}})</div>{{/if}}				{{* pengy *}}
 
-			{{if $account_type}}<div class="account-type">({{$account_type}})</div>{{/if}}
 		</div>
 
 		{{if $follow_link || $unfollow_link || $wallmessage_link}}

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -32,6 +32,8 @@
 	<div class="panel-body">
 		<div class="profile-header">
 			<h3 class="fn p-name" dir="auto">{{$profile.name}}</h3>
+			{{if $is_admin}}<span class="badge badge-admin"><i class="ri ri-medal-2-fill" aria-hidden="true"></i> {{$admin_title}}</span>{{/if}}
+			{{if $is_mod}}<span class="badge badge-mod"><i class="ri ri-shield-user-line" aria-hidden="true"></i> {{$moderator_title}}</span>{{/if}}
 
 			{{if $profile.addr}}<div class="p-addr">{{include file="sub/punct_wrap.tpl" text=$profile.addr}}</div>{{/if}}
 			{{if $is_owner }}

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -61,7 +61,7 @@
 			{{else}}
 				{{$acct_icon = ''}}
 			{{/if}}
-			{{if $account_type_name}}<div class="account-type" data-acct="{{$account_type}}" data-flag="{{$page_flags}}">(<i class="ri {{$acct_icon}}" aria-hidden="true"></i> {{$account_type_name}})</div>{{/if}}				{{* pengy *}}
+			{{if $account_type_name}}<div class="account-type" data-acct="{{$account_type}}" data-flag="{{$page_flags}}">(<i class="ri {{$acct_icon}}" aria-hidden="true"></i> {{$account_type_name}})</div>{{/if}}
 
 		</div>
 

--- a/view/theme/frio/templates/widget/vcard.tpl
+++ b/view/theme/frio/templates/widget/vcard.tpl
@@ -33,10 +33,30 @@
 	<div class="panel-body">
 		<div class="profile-header">
 			<h3 class="fn p-name" dir="auto">{{$contact.name}}</h3>
+			{{if $is_admin}}<span class="badge badge-admin"><i class="ri ri-medal-2-fill" aria-hidden="true"></i> {{$admin_title}}</span>{{/if}}
+			{{if $is_mod}}<span class="badge badge-mod"><i class="ri ri-shield-user-line" aria-hidden="true"></i> {{$moderator_title}}</span>{{/if}}
 
 			{{if $contact.addr}}<div class="p-addr">{{$contact.addr}}</div>{{/if}}
 
-			{{if $account_type}}<div class="account-type">({{$account_type}})</div>{{/if}}
+			{{if $account_type == 1}}
+				{{$acct_icon = "ri-building-4-line"}}
+			{{else if $account_type == 2}}
+				{{$acct_icon = "ri-newspaper-line"}}
+			{{else if $account_type == 3 && $page_flags == 2 || $account_type == 3 && $manually_approve == 0}}
+				{{$acct_icon = "ri-team-line"}}
+				{{$page_flags = 2}}
+			{{else if $account_type == 3 && $page_flags == 5 || $account_type == 3 && $manually_approve == 1 && $private == 1}}
+				{{$acct_icon = "ri-spy-line"}}
+				{{$page_flags = 5}}
+			{{else if $account_type == 3 && $page_flags == 6 || $account_type == 3 && $manually_approve == 1 && $private == 0}}
+				{{$acct_icon = "ri-group-3-line"}}
+				{{$page_flags = 6}}
+			{{else if $account_type == 4}}
+				{{$acct_icon = "ri-broadcast-line"}}
+			{{else}}
+				{{$acct_icon = ''}}
+			{{/if}}
+			{{if $account_type_name}}<div class="account-type" data-acct="{{$account_type}}" data-flag="{{$page_flags}}">(<i class="ri {{$acct_icon}}" aria-hidden="true"></i> {{$account_type_name}})</div>{{/if}}
 
 			{{if $about}}<div class="title" dir="auto">{{$about nofilter}}</div>{{/if}}
 		</div>

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -110,6 +110,14 @@ img {
 #adminpage table#users img { width: 16px; height: 16px; }
 #adminpage table tr:hover { background-color: #eeeeee; }
 #adminpage .selectall { text-align: right; }
+#adminpage table#users tr { box-shadow: 0 0 1px rgb(128,128,128); }
+#adminpage table#users td.acct-type-col {
+	white-space: normal !important;
+	word-break: break-word !important;
+}
+#adminpage table#users span.acct-type {
+	display: block;
+}
 /* icons */
 
 /*
@@ -383,6 +391,23 @@ pre code {
 	border-radius: 4px;
 	opacity: 0.3;
 }
+.vcard .badge-admin,
+.badge-admin {
+	margin: 10px 0;
+	background-color: #eebc1d;
+	opacity: 1;
+}
+.vcard .badge-mod,
+.badge-mod {
+	margin: 10px 0;
+	background-color: #32cd32;
+	opacity: 1;
+}
+	/* icon is slightly larger on vcard */
+	.vcard .badge-admin i,
+	.vcard .badge-mod i {
+		vertical-align: middle;
+	}
 #panel {
 	position: absolute;
 	width: 10em;

--- a/view/theme/vier/templates/contact/entry.tpl
+++ b/view/theme/vier/templates/contact/entry.tpl
@@ -39,7 +39,32 @@
 	<div class="contact-entry-desc">
 		<div class="contact-entry-name" id="contact-entry-name-{{$contact.id}}">
 			{{$contact.name}}
-			{{if $contact.account_type}} <span class="contact-entry-details" id="contact-entry-accounttype-{{$contact.id}}">({{$contact.account_type}})</span>{{/if}}
+			{{if $contact.account_type == 4}}
+				{{$acct_icon = "ri-broadcast-line"}}
+			{{else if $contact.account_type == 3}}
+				{{if $contact.private == 1}}
+					{{$acct_icon = "ri-spy-line"}}
+				{{else if $contact.manually_approve == 1}}
+					{{$acct_icon = "ri-group-3-line"}}
+				{{else}}
+					{{$acct_icon = "ri-team-line"}}
+				{{/if}}
+			{{else if $contact.account_type == 2}}
+				{{$acct_icon = "ri-newspaper-line"}}
+			{{else if $contact.account_type == 1}}
+				{{$acct_icon = "ri-building-4-line"}}
+			{{else if $contact.account_type == 0 && $contact.manually_approve == 0}}
+				{{$acct_icon = "ri-megaphone-line"}}
+			{{else}}
+				{{$acct_icon = ""}}
+			{{/if}}
+			{{if $contact.account_type_name}} <small class="contact-entry-details" id="contact-entry-accounttype-{{$contact.id}}">(<i class="ri {{$acct_icon}}" aria-hidden="true"></i> {{$contact.account_type_name}})</small>
+			{{else}}
+				<small class="contact-entry-details"><i class="ri {{$acct_icon}}" aria-hidden="true"></i></small>
+			{{/if}}
+			</h4>
+			{{if $contact.is_admin}}<span class="badge badge-admin"><i class="ri ri-medal-2-fill" aria-hidden="true"></i> {{$contact.admin_title}}</span>{{/if}}
+			{{if $contact.is_mod}}<span class="badge badge-mod"><i class="ri ri-shield-user-line" aria-hidden="true"></i> {{$contact.moderator_title}}</span>{{/if}}
 		</div>
 		{{if $contact.alt_text}}<div class="contact-entry-details" id="contact-entry-rel-{{$contact.id}}">{{$contact.alt_text}}</div>{{/if}}
 		<div class="contact-entry-details">

--- a/view/theme/vier/templates/profile/vcard.tpl
+++ b/view/theme/vier/templates/profile/vcard.tpl
@@ -11,6 +11,8 @@
 	</div>
 
 	{{if $profile.addr}}<div class="p-addr">{{$profile.addr}}</div>{{/if}}
+	{{if $is_admin}}<div class="badge badge-admin"><i class="ri ri-medal-2-fill" aria-hidden="true"></i> {{$admin_title}}</div>{{/if}}
+	{{if $is_mod}}<div class="badge badge-mod"><i class="ri ri-shield-user-line" aria-hidden="true"></i> {{$moderator_title}}</div>{{/if}}
 
 	<div id="profile-photo-wrapper">
 		<a class="vcard-anchor" href="{{$picture_dest_url}}" style="position: relative;">
@@ -21,7 +23,23 @@
 		</a>
 	</div>
 
-	{{if $account_type}}<div class="account-type">{{$account_type}}</div>{{/if}}
+			{{if $account_type == 1 }}
+				{{$acct_icon = "ri-building-4-line"}}
+			{{else if $account_type == 2}}
+				{{$acct_icon = "ri-newspaper-line"}}
+			{{else if $account_type == 3 && $page_flags == 2}}
+				{{$acct_icon = "ri-team-line"}}
+			{{else if $account_type == 3 && $page_flags == 6}}
+				{{$acct_icon = "ri-group-3-line"}}
+			{{else if $account_type == 3 && $page_flags == 5}}
+				{{$acct_icon = "ri-spy-line"}}
+			{{else if $account_type == 4}}
+				{{$acct_icon = "ri-broadcast-line"}}
+			{{else}}
+				{{$acct_icon = ''}}
+			{{/if}}
+			{{if $account_type_name}}<div class="account-type" data-acct="{{$account_type}}" data-flag="{{$page_flags}}">(<i class="ri {{$acct_icon}}" aria-hidden="true"></i> {{$account_type_name}})</div>{{/if}}
+
 	{{if $profile.network_link}}<dl class="network"><dt class="network-label">{{$network}}</dt><dd class="x-network">{{$profile.network_link nofilter}}</dd></dl>{{/if}}
 	{{if $is_owner }}
 		<div class="edit-profile-link-wrapper">


### PR DESCRIPTION
The title pretty much describes what these changes do. This is the solution for Issue https://github.com/friendica/friendica/issues/15868 

New Admin icon in User Menu (of course only Admins ever see it):
<img width="197" height="559" alt="Main_Menu" src="https://github.com/user-attachments/assets/8a032d26-eee1-4dd9-8c44-c1716003e569" />


In the Moderation > Users table:
* More accurately shows the user account type
* No longer shows sub-accounts of Admins as if they are admin accounts.
* Shows who is a Moderator to all moderators
 
<img width="653" height="847" alt="Users_Table" src="https://github.com/user-attachments/assets/7655471a-0d5d-44bd-96cf-d4dd5b003de9" />

On expanding an entry the account type icon shows the description text that is currently only available in a mouseover tooltip:
<img width="653" height="166" alt="User_Expanded" src="https://github.com/user-attachments/assets/df65a3a6-6e7a-49c3-9815-5b80607a8614" />

The logic to determine whether to show an Administrator of Moderator badge or icon first checks whether the account in question is a local account before running the `isSiteAdmin()` or `isModerator()` checks. Not really an issue on the backend, but Contacts lists, Profiles, and Hovercards on the front-end might be from anywhere. No point in running unnecessary checks.

On the front end the icons for account types and the Admin and Moderator badges appear in the Contacts lists:
<img width="654" height="537" alt="Contacts_List" src="https://github.com/user-attachments/assets/2200d058-f3c6-420e-9f8e-f4c69a98b3af" />

And in Hovercards:
<img width="371" height="266" alt="Moderator_Hovercard" src="https://github.com/user-attachments/assets/ba356be2-196c-4232-a377-343593d97880" />

<img width="358" height="235" alt="Admin_Hovercard" src="https://github.com/user-attachments/assets/b0e5ad8e-343b-44ef-bcc6-5e300b137d51" />

And when viewing Contact or Profile, which looks like this in Frio:
<img width="283" height="639" alt="Frio_Profile_Vcard" src="https://github.com/user-attachments/assets/4a3fb823-1f76-4ad0-8bbb-64fdb1dc3bcc" />

And this in Vier:
<img width="213" height="478" alt="Vier_Profile_Vcard" src="https://github.com/user-attachments/assets/33d53dd5-8feb-4f91-a9a8-275b5b535833" />

**Known Issue:** the only place this doesn't quite work as intended is on the "Posts" tab for a Contact (i.e., _/contact/{id}/conversations_) if the contact is a Private Group. This page/tab is controlled by _src/Module/Contact/Conversations.php_ which gets the contact via _src/Model/Contact.php_ using `getByAccountId()` instead of `getById()` - the result of which is it gets contact data from the `account-user-view` (which has no "prv" column) instead of the `contacts` table. Without the "prv" column data there is no way to distinguish a Private Group from a Restricted Group, so it shows the icon for the latter.  I know exactly where in the code it is doing this, and changing `getAccountById()` to `getById()` fixes the icon issue, but I don't know *why* this page/tab does that or what changing it might break, if anything, so I did not include the change in this PR. If you go to the Profile "posts" tab (i.e., /profile/{handle}) it pulls the right info and shows the correct icon. So it's literally that ONE context and is only an issue for Private Groups. Which is another reason I did not fix it, it's an edge case.

Any other themes would have to implement showing the icons or badges in its templates or use the default templates.

These commits add some new strings to the PHP but I still do not understand how Friendica's translation system works.








