### PR TITLE
Fix "Passing int to request option "headers.Content-Length" is deprecated;"

### DIFF
--- a/src/Util/HTTPSignature.php
+++ b/src/Util/HTTPSignature.php
@@ -275,7 +275,7 @@ class HTTPSignature
 		$host           = strtolower(parse_url($target, PHP_URL_HOST));
 		$path           = parse_url($target, PHP_URL_PATH);
 		$digest         = 'SHA-256=' . base64_encode(hash('sha256', $content, true));
-		$content_length = strlen($content);
+		$content_length = (string) strlen($content);
 		$date           = DateTimeFormat::utcNow(DateTimeFormat::HTTP);
 
 		$headers = [


### PR DESCRIPTION
This fixes the warning `E_USER_DEPRECATED: Since guzzlehttp/guzzle 7.11: Passing int to request option "headers.Content-Length" is deprecated; guzzlehttp/guzzle 8.0 requires string|non-empty-array<array-key, string>. It was called in `/var/www/virtual/pirati.ca/htdocs/vendor/guzzlehttp/guzzle/src/Client.php` in line 772.`

See https://github.com/friendica/friendica/issues/15818#issuecomment-4735263814

Although it will be fixed in https://github.com/friendica/friendica/pull/15880, I would like to get it merged sooner, since it clogs the log file.