### PR TITLE
Vier: Restore "profile" link in main menu

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -196,7 +196,6 @@ class Nav
 
 		if ($this->session->isAuthenticated()) {
 			// user menu
-			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Posts'), '', $this->l10n->t('My posts'), 'ri-chat-1-line'];
 			$nav['usermenu'][] = ['profile/' . $this->session->getLocalUserNickname() . '/photos', $this->l10n->t('Photos'), '', $this->l10n->t('My photos'), 'ri-image-line'];
 			$nav['usermenu'][] = ['notes/', $this->l10n->t('Personal notes'), '', $this->l10n->t('Only you can see these'), 'ri-sticky-note-line'];
 
@@ -205,6 +204,7 @@ class Nav
 			$userinfo = [
 				'icon' => Contact::getMicro($contact),
 				'name' => $contact['name'],
+				'link' => 'profile/' . $this->session->getLocalUserNickname(),
 			];
 		}
 
@@ -261,6 +261,9 @@ class Nav
 		// The following nav links are only show to logged-in users
 		if ($this->session->getLocalUserNickname()) {
 			$nav['network'] = ['network', $this->l10n->t('Home'), '', $this->l10n->t('Home')];
+
+			// Only used by Vier
+			$nav['my_profile'] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Profile'), '', ''];
 
 			// Don't show notifications for public communities
 			if ($this->session->get('page_flags', '') != User::PAGE_FLAGS_COMMUNITY) {

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.08-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-04 05:38+0000\n"
+"POT-Creation-Date: 2026-07-05 00:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -80,12 +80,12 @@ msgstr ""
 msgid "Permission denied."
 msgstr ""
 
-#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:273
+#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:276
 #: view/theme/frio/theme.php:237
 msgid "Messages"
 msgstr ""
 
-#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:276
+#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:279
 msgid "New Message"
 msgstr ""
 
@@ -1041,100 +1041,100 @@ msgid_plural "<button type=\"button\" %2$s>%1$d people</button> reshared this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:881
-#: src/Content/Conversation/ConversationDataProvider.php:884
-#: src/Content/Conversation/ConversationDataProvider.php:887
-#: src/Content/Conversation/ConversationDataProvider.php:890
-#: src/Content/Conversation/ConversationDataProvider.php:893
+#: src/Content/Conversation/ConversationDataProvider.php:876
+#: src/Content/Conversation/ConversationDataProvider.php:879
+#: src/Content/Conversation/ConversationDataProvider.php:882
+#: src/Content/Conversation/ConversationDataProvider.php:885
+#: src/Content/Conversation/ConversationDataProvider.php:888
 #, php-format
 msgid "You had been addressed (%s)."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:896
+#: src/Content/Conversation/ConversationDataProvider.php:891
 #, php-format
 msgid "You are following %s."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:900
+#: src/Content/Conversation/ConversationDataProvider.php:895
 msgid "You subscribed to one or more tags in this post."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:900
+#: src/Content/Conversation/ConversationDataProvider.php:895
 #, php-format
 msgid "You subscribed to %s."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:918
+#: src/Content/Conversation/ConversationDataProvider.php:913
 #, php-format
 msgid "%s reshared this."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:920
+#: src/Content/Conversation/ConversationDataProvider.php:915
 msgid "Reshared"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:920
+#: src/Content/Conversation/ConversationDataProvider.php:915
 #, php-format
 msgid "Reshared by %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:923
+#: src/Content/Conversation/ConversationDataProvider.php:918
 #, php-format
 msgid "%s is participating in this thread."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:926
+#: src/Content/Conversation/ConversationDataProvider.php:921
 msgid "Stored for general reasons"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:929
+#: src/Content/Conversation/ConversationDataProvider.php:924
 msgid "Global post"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:932
+#: src/Content/Conversation/ConversationDataProvider.php:927
 msgid "Sent via an relay server"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:932
+#: src/Content/Conversation/ConversationDataProvider.php:927
 #, php-format
 msgid "Sent via the relay server %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:935
+#: src/Content/Conversation/ConversationDataProvider.php:930
 msgid "Fetched"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:935
+#: src/Content/Conversation/ConversationDataProvider.php:930
 #, php-format
 msgid "Fetched because of %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:938
+#: src/Content/Conversation/ConversationDataProvider.php:933
 msgid "Stored because of a child post to complete this thread."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:941
+#: src/Content/Conversation/ConversationDataProvider.php:936
 msgid "Local delivery"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:944
+#: src/Content/Conversation/ConversationDataProvider.php:939
 msgid "Stored because of your activity (like, comment, bookmark, ...)"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:947
+#: src/Content/Conversation/ConversationDataProvider.php:942
 msgid "Distributed"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:950
+#: src/Content/Conversation/ConversationDataProvider.php:945
 msgid "Pushed to us"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:955
+#: src/Content/Conversation/ConversationDataProvider.php:950
 #, php-format
 msgid "Channel \"%s\": %s"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:955
+#: src/Content/Conversation/ConversationDataProvider.php:950
 #, php-format
 msgid "Channel \"%s\""
 msgstr ""
@@ -2120,9 +2120,9 @@ msgstr ""
 msgid "View Photos"
 msgstr ""
 
-#: src/Content/Item.php:405 src/Content/Nav.php:199 src/Model/Contact.php:1272
+#: src/Content/Item.php:405 src/Model/Contact.php:1272
 #: src/Model/Profile.php:450 src/Module/BaseProfile.php:42
-#: src/Module/Contact.php:488 view/theme/frio/theme.php:228
+#: src/Module/Contact.php:488
 msgid "Posts"
 msgstr ""
 
@@ -2210,27 +2210,23 @@ msgstr ""
 msgid "Sign in"
 msgstr ""
 
-#: src/Content/Nav.php:199 view/theme/frio/theme.php:228
-msgid "My posts"
-msgstr ""
-
-#: src/Content/Nav.php:200 src/Module/BaseProfile.php:50
+#: src/Content/Nav.php:199 src/Module/BaseProfile.php:50
 #: src/Module/Media/Attachment/Browser.php:67
 #: src/Module/Media/Photo/Browser.php:62 src/Module/Media/Photo/Browser.php:79
 #: view/theme/frio/theme.php:229
 msgid "Photos"
 msgstr ""
 
-#: src/Content/Nav.php:200 view/theme/frio/theme.php:229
+#: src/Content/Nav.php:199 view/theme/frio/theme.php:229
 msgid "My photos"
 msgstr ""
 
-#: src/Content/Nav.php:201 src/Module/BaseProfile.php:93
+#: src/Content/Nav.php:200 src/Module/BaseProfile.php:93
 #: src/Module/Profile/Notes.php:82
 msgid "Personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:201 src/Module/BaseProfile.php:96
+#: src/Content/Nav.php:200 src/Module/BaseProfile.php:96
 msgid "Only you can see these"
 msgstr ""
 
@@ -2283,7 +2279,7 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
-#: src/Content/Nav.php:231 src/Content/Nav.php:288
+#: src/Content/Nav.php:231 src/Content/Nav.php:291
 #: src/Content/Text/HTML.php:880 src/Module/BaseProfile.php:112
 #: src/Module/BaseProfile.php:115 src/Module/Contact.php:181
 #: src/Module/Contact.php:402 src/Module/Contact.php:512
@@ -2330,76 +2326,83 @@ msgstr ""
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:267
+#: src/Content/Nav.php:266 src/Module/BaseProfile.php:34
+#: src/Module/BaseSettings.php:86 src/Module/Contact.php:480
+#: src/Module/Contact/Profile.php:439 src/Module/Profile/Profile.php:276
+#: src/Module/Welcome.php:44
+msgid "Profile"
+msgstr ""
+
+#: src/Content/Nav.php:270
 msgid "Introductions"
 msgstr ""
 
-#: src/Content/Nav.php:267
+#: src/Content/Nav.php:270
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:268 src/Module/BaseNotifications.php:134
+#: src/Content/Nav.php:271 src/Module/BaseNotifications.php:134
 #: src/Module/Notifications/Introductions.php:63
 #: src/Module/Settings/Account.php:560
 msgid "Notifications"
 msgstr ""
 
-#: src/Content/Nav.php:269
+#: src/Content/Nav.php:272
 msgid "View all"
 msgstr ""
 
-#: src/Content/Nav.php:270 src/Module/Settings/Connectors.php:215
+#: src/Content/Nav.php:273 src/Module/Settings/Connectors.php:215
 msgid "Mark as read"
 msgstr ""
 
-#: src/Content/Nav.php:270
+#: src/Content/Nav.php:273
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:273
+#: src/Content/Nav.php:276
 msgid "Private mail"
 msgstr ""
 
-#: src/Content/Nav.php:274
+#: src/Content/Nav.php:277
 msgid "Inbox"
 msgstr ""
 
-#: src/Content/Nav.php:275
+#: src/Content/Nav.php:278
 msgid "Outbox"
 msgstr ""
 
-#: src/Content/Nav.php:278
+#: src/Content/Nav.php:281
 msgid "Accounts"
 msgstr ""
 
-#: src/Content/Nav.php:279
+#: src/Content/Nav.php:282
 msgid "Manage other accounts, including groups and pages"
 msgstr ""
 
-#: src/Content/Nav.php:286 src/Module/Admin/Addons/Details.php:140
+#: src/Content/Nav.php:289 src/Module/Admin/Addons/Details.php:140
 #: src/Module/Admin/Themes/Details.php:85 src/Module/BaseAdmin.php:89
 #: src/Module/BaseSettings.php:177 src/Module/Welcome.php:39
 #: view/theme/frio/theme.php:238
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:286
+#: src/Content/Nav.php:289
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:288 view/theme/frio/theme.php:239
+#: src/Content/Nav.php:291 view/theme/frio/theme.php:239
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:293 src/Module/BaseAdmin.php:115
+#: src/Content/Nav.php:296 src/Module/BaseAdmin.php:115
 msgid "Admin"
 msgstr ""
 
-#: src/Content/Nav.php:293
+#: src/Content/Nav.php:296
 msgid "Site setup and configuration"
 msgstr ""
 
-#: src/Content/Nav.php:297 src/Module/BaseModeration.php:117
+#: src/Content/Nav.php:300 src/Module/BaseModeration.php:117
 #: src/Module/Moderation/Blocklist/Contact.php:99
 #: src/Module/Moderation/Blocklist/Contact/Import.php:101
 #: src/Module/Moderation/Blocklist/Server/Add.php:105
@@ -2417,15 +2420,15 @@ msgstr ""
 msgid "Moderation"
 msgstr ""
 
-#: src/Content/Nav.php:297
+#: src/Content/Nav.php:300
 msgid "Content and user moderation"
 msgstr ""
 
-#: src/Content/Nav.php:300
+#: src/Content/Nav.php:303
 msgid "Navigation"
 msgstr ""
 
-#: src/Content/Nav.php:300
+#: src/Content/Nav.php:303
 msgid "Site map"
 msgstr ""
 
@@ -6012,12 +6015,6 @@ msgstr ""
 
 #: src/Module/BaseModeration.php:110 src/Module/Moderation/Item/Source.php:67
 msgid "Item Source"
-msgstr ""
-
-#: src/Module/BaseProfile.php:34 src/Module/BaseSettings.php:86
-#: src/Module/Contact.php:480 src/Module/Contact/Profile.php:439
-#: src/Module/Profile/Profile.php:276 src/Module/Welcome.php:44
-msgid "Profile"
 msgstr ""
 
 #: src/Module/BaseProfile.php:37 src/Module/Contact.php:483

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -56,6 +56,16 @@
 			</li>
 		{{/if}}
 
+		{{if $nav.my_profile}}
+			<li role="menuitem" id="nav-my-profile-link" class="nav-menu {{$sel.my_profile}}">
+				<a accesskey="p" class="{{$nav.my_profile.2}}" href="{{$nav.my_profile.0}}" title="{{$nav.my_profile.3}}">
+					<span class="desktop-view">{{$nav.my_profile.1}}</span>
+					<i class="ri ri-xl ri-user-line ri-fw mobile-view" aria-hidden="true"></i>
+					<span id="my-profile-update" class="nav-notification"></span>
+				</a>
+			</li>
+		{{/if}}
+
 		<li role="menu" aria-haspopup="true" id="nav-site-linkmenu" class="nav-menu-icon"><a><span class="icon s22 icon-question"><span class="sr-only">{{$nav.help.3}}</span></span></a>
 			<ul id="nav-site-menu" class="menu-popup">
 				{{if $nav.help}} <li role="menuitem"><a class="{{$nav.help.2}}" href="{{$nav.help.0}}" title="{{$nav.help.3}}">{{$nav.help.1}}</a></li>{{/if}}
@@ -98,7 +108,8 @@
 					{{if $nav.contacts}}<li role="menuitem"><a class="{{$nav.contacts.2}}" href="{{$nav.contacts.0}}" title="{{$nav.contacts.3}}">{{$nav.contacts.1}}</a></li>{{/if}}
 					{{if $nav.messages}}<li role="menuitem"><a class="{{$nav.messages.2}}" href="{{$nav.messages.0}}" title="{{$nav.messages.3}}">{{$nav.messages.1}} <span id="mail-update-li" class="nav-notification"></span></a></li>{{/if}}
 					{{if $nav.delegation}}<li role="menuitem"><a class="{{$nav.delegation.2}}" href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}">{{$nav.delegation.1}}</a></li>{{/if}}
-					{{if $nav.usermenu.1}}<li role="menuitem"><a class="{{$nav.usermenu.1.2}}" href="{{$nav.usermenu.1.0}}" title="{{$nav.usermenu.1.3}}">{{$nav.usermenu.1.1}}</a></li>{{/if}}
+					{{* This is a link to Photos: *}}
+					{{if $nav.usermenu.0}}<li role="menuitem"><a class="{{$nav.usermenu.0.2}}" href="{{$nav.usermenu.0.0}}" title="{{$nav.usermenu.0.3}}">{{$nav.usermenu.0.1}}</a></li>{{/if}}
 					{{if $nav.settings}}<li role="menuitem"><a class="{{$nav.settings.2}}" href="{{$nav.settings.0}}" title="{{$nav.settings.3}}">{{$nav.settings.1}}</a></li>{{/if}}
 					{{if $nav.admin}}
 					<li role="menuitem">

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -193,14 +193,31 @@ ul#nav-user-menu {
 	font-size: 15.3px;
 	padding-block: 0;
 	margin-top: 0;
-}
-ul#nav-user-menu a {
-	padding-block: 10px;
-}
-ul#nav-user-menu li:first-child {
-	margin-top: 0;
+
+	@media screen and (width < 990px) {
+		margin-right: 10px;
+	}
+
+	a {
+		padding-block: 10px;
+	}
+	li:first-child {
+		margin-top: 0;
+	}
 }
 
+/* Applies to the small screen (mobile) menu as well */
+.profile-link a {
+	font-weight: inherit;
+}
+.profile-link img {
+	max-width:25px;
+	max-height:25px;
+	min-width:25tpx;
+	min-height:25px;
+	width:25px;
+	height:25px;
+}
 
 /**
  * mobile: Larger screens
@@ -253,10 +270,6 @@ ul#nav-user-menu li:first-child {
 
 	#topbar-first .topbar-nav .nav-segment > a.nav-menu {
 		padding-inline: 15px;
-	}
-
-	ul#nav-user-menu {
-		margin-right: 10px;
 	}
 
 	#topbar-second #tabmenu {
@@ -931,6 +944,7 @@ nav.navbar .nav > li > button:focus {
 	right: -2px;
 	background-color: #ff8989;
 }
+
 #offcanvasUsermenu {
 	top: var(--topbar-first-size);
 	background-color: $background_color;

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -194,6 +194,13 @@
 											<li class="divider"><hr></li>
 										{{/if}}
 									{{/if}}
+
+									<li class="profile-link">
+										<a href="{{$userinfo.link}}">
+											<img src="{{$userinfo.icon}}" alt="{{$userinfo.name}}">&nbsp;
+											{{$userinfo.name}}{{if $nav.remote}} ({{$nav.remote}}){{/if}}
+										</a>
+									</li>
 									{{foreach $nav.usermenu as $usermenu}}
 										<li>
 											<a role="menuitem" class="{{$usermenu.2}}" href="{{$usermenu.0}}"
@@ -204,17 +211,6 @@
 										</li>
 									{{/foreach}}
 									<li class="divider visible-xs"><hr></li>
-									{{if $nav.messages}}
-										<li class="visible-xs">
-											<a role="menuitem"
-												class="nav-commlink {{$nav.messages.2}} {{$sel.messages}}"
-												href="{{$nav.messages.0}}" title="{{$nav.messages.3}}">
-												<i class="ri ri-mail-line ri-fw" aria-hidden="true"></i>
-												{{$nav.messages.1}} <span id="mail-update-li"
-													class="nav-mail-badge badge nav-notification"></span>
-											</a>
-										</li>
-									{{/if}}
 									{{if $nav.contacts}}
 										<li class="visible-xs">
 											<a role="menuitem" id="nav-menu-contacts-link"
@@ -335,10 +331,11 @@
 									<li role="menuitem" class="nav-sitename list-group-item">{{$nav.sitename}}</li>
 								{{/if}}
 							{{/if}}
-							<li class="list-group-item">
-								<img src="{{$userinfo.icon}}" alt="{{$userinfo.name}}"
-									style="max-width:15px; max-height:15px; min-width:15px; min-height:15px; width:15px; height:15px;">&nbsp;
-								{{$userinfo.name}}{{if $nav.remote}} ({{$nav.remote}}){{/if}}
+							<li class="list-group-item profile-link">
+								<a href="{{$userinfo.link}}">
+									<img src="{{$userinfo.icon}}" alt="{{$userinfo.name}}">&nbsp;
+									{{$userinfo.name}}{{if $nav.remote}} ({{$nav.remote}}){{/if}}
+								</a>
 							</li>
 							{{foreach $nav.usermenu as $usermenu}}
 								<li class="list-group-item">
@@ -349,7 +346,7 @@
 									</a>
 								</li>
 							{{/foreach}}
-							{{if $nav.contacts || $nav.messages || $nav.delegation}}
+							{{if $nav.contacts || $nav.delegation}}
 								<li class="divider"><hr></li>
 							{{/if}}
 							{{if $nav.contacts}}
@@ -358,15 +355,6 @@
 										class="nav-link {{$nav.contacts.2}}" href="{{$nav.contacts.0}}"
 										title="{{$nav.contacts.3}}"><i class="ri ri-contacts-line ri-fw" aria-hidden="true"></i>
 										{{$nav.contacts.1}}
-									</a>
-								</li>
-							{{/if}}
-							{{if $nav.messages}}
-								<li class="list-group-item">
-									<a role="menuitem"
-										class="nav-link {{$nav.messages.2}} {{$sel.messages}}" href="{{$nav.messages.0}}"
-										title="{{$nav.messages.3}}"><i class="ri ri-mail-line ri-fw" aria-hidden="true"></i>
-										{{$nav.messages.1}}
 									</a>
 								</li>
 							{{/if}}

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -219,13 +219,13 @@ function frio_remote_nav(array &$nav_info): void
 			$nav_info['userinfo'] = [
 				'icon' => Contact::getMicro($remoteUser),
 				'name' => $remoteUser['name'],
+				'link' => $server_url . '/profile/' . $remoteUser['nick'],
 			];
 			$server_url = $remoteUser['baseurl'];
 		}
 
 		if (!DI::userSession()->getLocalUserId() && !empty($server_url) && !is_null($remoteUser)) {
 			// user menu
-			$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'], DI::l10n()->t('Posts'), '', DI::l10n()->t('My posts')];
 			$nav_info['nav']['usermenu'][] = [$server_url . '/profile/' . $remoteUser['nick'] . '/photos', DI::l10n()->t('Photos'), '', DI::l10n()->t('My photos')];
 			$nav_info['nav']['usermenu'][] = [$server_url . '/calendar/', DI::l10n()->t('Calendar'), '', DI::l10n()->t('Your calendar')];
 


### PR DESCRIPTION
Hopefully addresses #15928 ...?

Vier:
- Restore "Profile" link in main menu

Alternatively we could put the "Profile" link in the right side of the main menu, maybe before or after the username dropdown, with the other user related options.

Both:
- Remove "Messages" from the user menu now it's in the main menu, including on small screens

Frio:
- Make the username and icon in the user menu link to the profile instead - and make it visible on large screens as well

# Screenshots

<img width="1314" height="448" alt="image" src="https://github.com/user-attachments/assets/2fe453fe-b93d-414f-ad35-ec8c17baaa52" />

The styling of the link here is still a work-in-progress:
<img width="274" height="274" alt="image" src="https://github.com/user-attachments/assets/1ade26a7-f319-4efb-93be-3032b044f67c" />