### PR TITLE
Adds a Pages Widget

### DIFF
--- a/src/Content/Contact/Repository/ContactByType.php
+++ b/src/Content/Contact/Repository/ContactByType.php
@@ -1,0 +1,107 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Content\Contact\Repository;
+
+use Friendica\Core\Protocol;
+use Friendica\Database\Database;
+use Friendica\Database\DBA;
+
+/**
+ * Read repository for user contacts grouped by contact type.
+ */
+class ContactByType
+{
+	private const FIELDS = ['id', 'url', 'alias', 'name', 'micro', 'thumb', 'avatar', 'network', 'uid'];
+
+	public function __construct(private readonly Database $database) {}
+
+	/**
+	 * Selects visible user contacts for the provided contact types.
+	 *
+	 * @return array<int, array{url: string, alias: string, name: string, id: int, micro: string, thumb: string, network: string}>
+	 * @throws \Exception
+	 */
+	public function selectForUser(int $uid, array $contactTypes, bool $lastItem, bool $showHidden = true, bool $showPrivate = false): array
+	{
+		if (empty($contactTypes)) {
+			return [];
+		}
+
+		$params = ['order' => $lastItem ? ['last-item' => true] : ['name']];
+
+		$condition = [
+			'contact-type' => $contactTypes,
+			'network'      => [Protocol::DFRN, Protocol::ACTIVITYPUB],
+			'uid'          => $uid,
+			'blocked'      => false,
+			'pending'      => false,
+			'archive'      => false,
+		];
+
+		$condition = DBA::mergeConditions($condition, ["`platform` NOT IN (?, ?)", 'peertube', 'wordpress']);
+
+		if (!$showPrivate) {
+			$condition = DBA::mergeConditions($condition, ['manually-approve' => false]);
+		}
+
+		if (!$showHidden) {
+			$condition = DBA::mergeConditions($condition, ['hidden' => false]);
+		}
+
+		$contacts = $this->database->selectToArray('account-user-view', self::FIELDS, $condition, $params);
+		foreach ($contacts as $key => $contact) {
+			$contacts[$key] = [
+				'url'     => $contact['url'],
+				'alias'   => $contact['alias'],
+				'name'    => $contact['name'],
+				'id'      => $contact['id'],
+				'micro'   => $contact['micro'],
+				'thumb'   => $contact['thumb'],
+				'network' => $contact['network'],
+			];
+		}
+
+		return $contacts;
+	}
+
+	/**
+	 * Counts unseen posts for the provided contact types.
+	 *
+	 * @return array<int, array{id: int, name: string, count: int}>
+	 * @throws \Exception
+	 */
+	public function countUnseenItems(int $uid, array $contactTypes): array
+	{
+		if (empty($contactTypes)) {
+			return [];
+		}
+
+		$typePlaceholders = implode(', ', array_fill(0, count($contactTypes), '?'));
+		$parameters       = array_merge(
+			[$uid, Protocol::DFRN, Protocol::ACTIVITYPUB],
+			$contactTypes,
+			[$uid],
+		);
+
+		$stmtContacts = $this->database->p(
+			"SELECT `contact`.`id`, `contact`.`name`, COUNT(*) AS `count` FROM `post-user-view`
+				INNER JOIN `contact` ON `post-user-view`.`contact-id` = `contact`.`id`
+				WHERE `post-user-view`.`uid` = ? AND `post-user-view`.`visible` AND NOT `post-user-view`.`deleted` AND `post-user-view`.`unseen`
+				AND `contact`.`network` IN (?, ?) AND `contact`.`contact-type` IN (" . $typePlaceholders . ")
+				AND NOT `contact`.`blocked` AND NOT `contact`.`hidden`
+				AND NOT `contact`.`pending` AND NOT `contact`.`archive`
+				AND `contact`.`uid` = ?
+				GROUP BY `contact`.`id`",
+			...$parameters,
+		);
+
+		return $this->database->toArray($stmtContacts);
+	}
+}

--- a/src/Content/Feature.php
+++ b/src/Content/Feature.php
@@ -27,6 +27,7 @@ class Feature
 	public const CHANNELS      = 'channels';
 	public const FOLDERS       = 'folders';
 	public const GROUPS        = 'forumlist_profile';
+	public const PAGES         = 'pages';
 	public const NETWORKS      = 'networks';
 	public const NOSHARER      = 'nosharer';
 	public const SEARCHES      = 'searches';
@@ -126,6 +127,7 @@ class Feature
 				$l10n->t('Network Widgets'),
 				[self::CIRCLES, $l10n->t('Circles'), $l10n->t('Display posts that have been created by accounts of the selected circle.'), true, $config->get('feature_lock', self::CIRCLES, false)],
 				[self::GROUPS, $l10n->t('Groups'), $l10n->t('Display posts that have been distributed by the selected group.'), true, $config->get('feature_lock', self::GROUPS, false)],
+				[self::PAGES, $l10n->t('Pages'), $l10n->t('Display posts from Organization and News Pages.'), true, $config->get('feature_lock', self::PAGES, false)],
 				[self::ARCHIVE, $l10n->t('Archives'), $l10n->t('Display an archive where posts can be selected by month and year.'), true, $config->get('feature_lock', self::ARCHIVE, false)],
 				[self::NETWORKS, $l10n->t('Protocols'), $l10n->t('Display posts with the selected protocols.'), true, $config->get('feature_lock', self::NETWORKS, false)],
 				[self::ACCOUNTS, $l10n->t('Account Types'), $l10n->t('Display posts done by accounts with the selected account type.'), true, $config->get('feature_lock', self::ACCOUNTS, false)],

--- a/src/Content/GroupManager.php
+++ b/src/Content/GroupManager.php
@@ -7,11 +7,13 @@
 
 namespace Friendica\Content;
 
+use Friendica\App\BaseURL;
+use Friendica\Content\Contact\Repository\ContactByType;
 use Friendica\Content\Text\HTML;
-use Friendica\Core\Protocol;
+use Friendica\Core\Addon\AddonHelper;
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Model\Contact;
 
 /**
@@ -19,6 +21,16 @@ use Friendica\Model\Contact;
  */
 class GroupManager
 {
+	private const CONTACT_TYPES = [Contact::TYPE_COMMUNITY];
+
+	public function __construct(
+		private readonly ContactByType $contacts,
+		private readonly AddonHelper $addonHelper,
+		private readonly BaseURL $baseUrl,
+		private readonly L10n $l10n,
+		private readonly IHandleUserSessions $session,
+	) {}
+
 	/**
 	 * Function to list all groups a user is connected with
 	 *
@@ -35,55 +47,9 @@ class GroupManager
 	 *    'thumb' => contact photo in format thumb
 	 * @throws \Exception
 	 */
-	public static function getList($uid, $lastitem, $showhidden = true, $showprivate = false)
+	public function getList(int $uid, bool $lastitem, bool $showhidden = true, bool $showprivate = false): array
 	{
-		if ($lastitem) {
-			$params = ['order' => ['last-item' => true]];
-		} else {
-			$params = ['order' => ['name']];
-		}
-
-		$condition = [
-			'contact-type' => Contact::TYPE_COMMUNITY,
-			'network'      => [Protocol::DFRN, Protocol::ACTIVITYPUB],
-			'uid'          => $uid,
-			'blocked'      => false,
-			'pending'      => false,
-			'archive'      => false,
-		];
-
-		$condition = DBA::mergeConditions($condition, ["`platform` NOT IN (?, ?)", 'peertube', 'wordpress']);
-
-		if (!$showprivate) {
-			$condition = DBA::mergeConditions($condition, ['manually-approve' => false]);
-		}
-
-		if (!$showhidden) {
-			$condition = DBA::mergeConditions($condition, ['hidden' => false]);
-		}
-
-		$groupList = [];
-
-		$fields   = ['id', 'url', 'alias', 'name', 'micro', 'thumb', 'avatar', 'network', 'uid'];
-		$contacts = DBA::select('account-user-view', $fields, $condition, $params);
-		if (!$contacts) {
-			return $groupList;
-		}
-
-		while ($contact = DBA::fetch($contacts)) {
-			$groupList[] = [
-				'url'     => $contact['url'],
-				'alias'   => $contact['alias'],
-				'name'    => $contact['name'],
-				'id'      => $contact['id'],
-				'micro'   => $contact['micro'],
-				'thumb'   => $contact['thumb'],
-				'network' => $contact['network'],
-			];
-		}
-		DBA::close($contacts);
-
-		return($groupList);
+		return $this->contacts->selectForUser($uid, self::CONTACT_TYPES, $lastitem, $showhidden, $showprivate);
 	}
 
 
@@ -98,10 +64,10 @@ class GroupManager
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function widget(int $uid): string
+	public function widget(int $uid): string
 	{
 		//sort by last updated item
-		$contacts      = self::getList($uid, true, true, true);
+		$contacts      = $this->getList($uid, true, true, true);
 		$total         = count($contacts);
 		$visibleGroups = 10;
 
@@ -115,7 +81,7 @@ class GroupManager
 				'external_url' => Contact::magicLinkByContact($contact),
 				'name'         => $contact['name'],
 				'cid'          => $contact['id'],
-				'micro'        => DI::baseUrl()->remove(Contact::getMicro($contact)),
+				'micro'        => $this->baseUrl->remove(Contact::getMicro($contact)),
 				'id'           => ++$id,
 			];
 			$entries[] = $entry;
@@ -123,23 +89,20 @@ class GroupManager
 
 		$tpl = Renderer::getMarkupTemplate('widget/group_list.tpl');
 
-
-		$addonHelper = DI::addonHelper();
-
 		return Renderer::replaceMacros(
 			$tpl,
 			[
-				'$title'                         => DI::l10n()->t('Groups'),
+				'$title'                         => $this->l10n->t('Groups'),
 				'$groups'                        => $entries,
-				'$link_desc'                     => DI::l10n()->t('External link to group'),
+				'$link_desc'                     => $this->l10n->t('External link to group'),
 				'$new_group_page'                => 'register/?type=group',
 				'$total'                         => $total,
 				'$visible_groups'                => $visibleGroups,
-				'$showless'                      => DI::l10n()->t('show less'),
-				'$showmore'                      => DI::l10n()->t('show more'),
-				'$create_new_group'              => DI::l10n()->t('Create new group'),
-				'$addon_group_directory_enabled' => $addonHelper->isAddonEnabled("groupdirectory"),
-				'$visit_groupdirectory'          => DI::l10n()->t('Find groups to join'),
+				'$showless'                      => $this->l10n->t('show less'),
+				'$showmore'                      => $this->l10n->t('show more'),
+				'$create_new_group'              => $this->l10n->t('Create new group'),
+				'$addon_group_directory_enabled' => $this->addonHelper->isAddonEnabled('groupdirectory'),
+				'$visit_groupdirectory'          => $this->l10n->t('Find groups to join'),
 			],
 		);
 	}
@@ -155,7 +118,7 @@ class GroupManager
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function profileAdvanced($uid)
+	public function profileAdvanced(int $uid): string
 	{
 		if (!Feature::isEnabled($uid, Feature::GROUPS)) {
 			return '';
@@ -169,7 +132,7 @@ class GroupManager
 		//don't sort by last updated item
 		$lastitem = false;
 
-		$contacts = self::getList($uid, $lastitem, false, false);
+		$contacts = $this->getList($uid, $lastitem, false, false);
 
 		$total_shown = 0;
 		foreach ($contacts as $contact) {
@@ -194,24 +157,13 @@ class GroupManager
 	 *    'count' => counted unseen group items
 	 * @throws \Exception
 	 */
-	public static function countUnseenItems()
+	public function countUnseenItems(): array
 	{
-		$stmtContacts = DBA::p(
-			"SELECT `contact`.`id`, `contact`.`name`, COUNT(*) AS `count` FROM `post-user-view`
-				INNER JOIN `contact` ON `post-user-view`.`contact-id` = `contact`.`id`
-				WHERE `post-user-view`.`uid` = ? AND `post-user-view`.`visible` AND NOT `post-user-view`.`deleted` AND `post-user-view`.`unseen`
-				AND `contact`.`network` IN (?, ?) AND `contact`.`contact-type` = ?
-				AND NOT `contact`.`blocked` AND NOT `contact`.`hidden`
-				AND NOT `contact`.`pending` AND NOT `contact`.`archive`
-				AND `contact`.`uid` = ?
-				GROUP BY `contact`.`id`",
-			DI::userSession()->getLocalUserId(),
-			Protocol::DFRN,
-			Protocol::ACTIVITYPUB,
-			Contact::TYPE_COMMUNITY,
-			DI::userSession()->getLocalUserId(),
-		);
+		$uid = $this->session->getLocalUserId();
+		if (!is_int($uid)) {
+			return [];
+		}
 
-		return DBA::toArray($stmtContacts);
+		return $this->contacts->countUnseenItems($uid, self::CONTACT_TYPES);
 	}
 }

--- a/src/Content/PagesManager.php
+++ b/src/Content/PagesManager.php
@@ -67,7 +67,7 @@ class PagesManager
 		$fields   = ['id', 'url', 'alias', 'name', 'micro', 'thumb', 'avatar', 'network', 'uid'];
 		$contacts = DBA::select('account-user-view', $fields, $condition, $params);
 		if (!$contacts) {
-			return $groupList;
+			return $pagesList;
 		}
 
 		while ($contact = DBA::fetch($contacts)) {

--- a/src/Content/PagesManager.php
+++ b/src/Content/PagesManager.php
@@ -186,7 +186,7 @@ class PagesManager
 	/**
 	 * count unread page items
 	 *
-	 * Count unread items of connected groups and private pages
+	 * Count unread items of connected pages
 	 *
 	 * @return array
 	 *    'id' => contact id

--- a/src/Content/PagesManager.php
+++ b/src/Content/PagesManager.php
@@ -7,11 +7,13 @@
 
 namespace Friendica\Content;
 
+use Friendica\App\BaseURL;
+use Friendica\Content\Contact\Repository\ContactByType;
 use Friendica\Content\Text\HTML;
-use Friendica\Core\Protocol;
+use Friendica\Core\Addon\AddonHelper;
+use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Model\Contact;
 
 /**
@@ -19,6 +21,16 @@ use Friendica\Model\Contact;
  */
 class PagesManager
 {
+	private const CONTACT_TYPES = [Contact::TYPE_ORGANISATION, Contact::TYPE_NEWS];
+
+	public function __construct(
+		private readonly ContactByType $contacts,
+		private readonly AddonHelper $addonHelper,
+		private readonly BaseURL $baseUrl,
+		private readonly L10n $l10n,
+		private readonly IHandleUserSessions $session,
+	) {}
+
 	/**
 	 * Function to list all pages a user is connected with
 	 *
@@ -35,55 +47,9 @@ class PagesManager
 	 *    'thumb' => contact photo in format thumb
 	 * @throws \Exception
 	 */
-	public static function getList($uid, $lastitem, $showhidden = true, $showprivate = false)
+	public function getList(int $uid, bool $lastitem, bool $showhidden = true, bool $showprivate = false): array
 	{
-		if ($lastitem) {
-			$params = ['order' => ['last-item' => true]];
-		} else {
-			$params = ['order' => ['name']];
-		}
-
-		$condition = [
-			'contact-type' => [Contact::TYPE_ORGANISATION, Contact::TYPE_NEWS],
-			'network'      => [Protocol::DFRN, Protocol::ACTIVITYPUB],
-			'uid'          => $uid,
-			'blocked'      => false,
-			'pending'      => false,
-			'archive'      => false,
-		];
-
-		$condition = DBA::mergeConditions($condition, ["`platform` NOT IN (?, ?)", 'peertube', 'wordpress']);
-
-		if (!$showprivate) {
-			$condition = DBA::mergeConditions($condition, ['manually-approve' => false]);
-		}
-
-		if (!$showhidden) {
-			$condition = DBA::mergeConditions($condition, ['hidden' => false]);
-		}
-
-		$pagesList = [];
-
-		$fields   = ['id', 'url', 'alias', 'name', 'micro', 'thumb', 'avatar', 'network', 'uid'];
-		$contacts = DBA::select('account-user-view', $fields, $condition, $params);
-		if (!$contacts) {
-			return $pagesList;
-		}
-
-		while ($contact = DBA::fetch($contacts)) {
-			$pagesList[] = [
-				'url'     => $contact['url'],
-				'alias'   => $contact['alias'],
-				'name'    => $contact['name'],
-				'id'      => $contact['id'],
-				'micro'   => $contact['micro'],
-				'thumb'   => $contact['thumb'],
-				'network' => $contact['network'],
-			];
-		}
-		DBA::close($contacts);
-
-		return($pagesList);
+		return $this->contacts->selectForUser($uid, self::CONTACT_TYPES, $lastitem, $showhidden, $showprivate);
 	}
 
 
@@ -98,12 +64,12 @@ class PagesManager
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function widget(int $uid): string
+	public function widget(int $uid): string
 	{
 		//sort by last updated item
-		$contacts      = self::getList($uid, true, true, true);
-		$total         = count($contacts);
-		$visibleGroups = 10;
+		$contacts     = $this->getList($uid, true, true, true);
+		$total        = count($contacts);
+		$visiblePages = 10;
 
 		$id = 0;
 
@@ -115,7 +81,7 @@ class PagesManager
 				'external_url' => Contact::magicLinkByContact($contact),
 				'name'         => $contact['name'],
 				'cid'          => $contact['id'],
-				'micro'        => DI::baseUrl()->remove(Contact::getMicro($contact)),
+				'micro'        => $this->baseUrl->remove(Contact::getMicro($contact)),
 				'id'           => ++$id,
 			];
 			$entries[] = $entry;
@@ -123,23 +89,20 @@ class PagesManager
 
 		$tpl = Renderer::getMarkupTemplate('widget/pages_list.tpl');
 
-
-		$addonHelper = DI::addonHelper();
-
 		return Renderer::replaceMacros(
 			$tpl,
 			[
-				'$title'                        => DI::l10n()->t('Pages'),
-				'$pages'                        => $entries,
-				'$link_desc'                    => DI::l10n()->t('External link to page'),
-				'$new_page'                     => 'register/?type=page',
-				'$total'                        => $total,
-				'$visible_pages'                => $visibleGroups,
-				'$showless'                     => DI::l10n()->t('show less'),
-				'$showmore'                     => DI::l10n()->t('show more'),
-				'$create_new_page'              => DI::l10n()->t('Create new page'),
-				'$addon_page_directory_enabled' => $addonHelper->isAddonEnabled("pagedirectory"),
-				'$visit_pagedirectory'          => DI::l10n()->t('Find pages to follow'),
+				'$title'                         => $this->l10n->t('Pages'),
+				'$pages'                         => $entries,
+				'$link_desc'                     => $this->l10n->t('External link to page'),
+				'$new_page'                      => 'register/?type=page',
+				'$total'                         => $total,
+				'$visible_pages'                 => $visiblePages,
+				'$showless'                      => $this->l10n->t('show less'),
+				'$showmore'                      => $this->l10n->t('show more'),
+				'$create_new_page'               => $this->l10n->t('Create new page'),
+				'$addon_pages_directory_enabled' => $this->addonHelper->isAddonEnabled('pagedirectory'),
+				'$visit_pagesdirectory'          => $this->l10n->t('Find pages to follow'),
 			],
 		);
 	}
@@ -155,7 +118,7 @@ class PagesManager
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function profileAdvanced($uid)
+	public function profileAdvanced(int $uid): string
 	{
 		if (!Feature::isEnabled($uid, Feature::PAGES)) {
 			return '';
@@ -169,7 +132,7 @@ class PagesManager
 		//don't sort by last updated item
 		$lastitem = false;
 
-		$contacts = self::getList($uid, $lastitem, false, false);
+		$contacts = $this->getList($uid, $lastitem, false, false);
 
 		$total_shown = 0;
 		foreach ($contacts as $contact) {
@@ -194,25 +157,13 @@ class PagesManager
 	 *    'count' => counted unseen page items
 	 * @throws \Exception
 	 */
-	public static function countUnseenItems()
+	public function countUnseenItems(): array
 	{
-		$stmtContacts = DBA::p(
-			"SELECT `contact`.`id`, `contact`.`name`, COUNT(*) AS `count` FROM `post-user-view`
-				INNER JOIN `contact` ON `post-user-view`.`contact-id` = `contact`.`id`
-				WHERE `post-user-view`.`uid` = ? AND `post-user-view`.`visible` AND NOT `post-user-view`.`deleted` AND `post-user-view`.`unseen`
-				AND `contact`.`network` IN (?, ?) AND `contact`.`contact-type` = ?
-				AND NOT `contact`.`blocked` AND NOT `contact`.`hidden`
-				AND NOT `contact`.`pending` AND NOT `contact`.`archive`
-				AND `contact`.`uid` = ?
-				GROUP BY `contact`.`id`",
-			DI::userSession()->getLocalUserId(),
-			Protocol::DFRN,
-			Protocol::ACTIVITYPUB,
-			Contact::TYPE_ORGANISATION,
-			Contact::TYPE_NEWS,
-			DI::userSession()->getLocalUserId(),
-		);
+		$uid = $this->session->getLocalUserId();
+		if (!is_int($uid)) {
+			return [];
+		}
 
-		return DBA::toArray($stmtContacts);
+		return $this->contacts->countUnseenItems($uid, self::CONTACT_TYPES);
 	}
 }

--- a/src/Content/PagesManager.php
+++ b/src/Content/PagesManager.php
@@ -1,0 +1,218 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Content;
+
+use Friendica\Content\Text\HTML;
+use Friendica\Core\Protocol;
+use Friendica\Core\Renderer;
+use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Model\Contact;
+
+/**
+ * This class handles methods related to the page functionality
+ */
+class PagesManager
+{
+	/**
+	 * Function to list all pages a user is connected with
+	 *
+	 * @param int     $uid         of the profile owner
+	 * @param boolean $lastitem    Sort by lastitem
+	 * @param boolean $showhidden  Show pages which are not hidden
+	 * @param boolean $showprivate Show private pages
+	 *
+	 * @return array
+	 *    'url'   => page url
+	 *    'name'  => page name
+	 *    'id'    => number of the key from the array
+	 *    'micro' => contact photo in format micro
+	 *    'thumb' => contact photo in format thumb
+	 * @throws \Exception
+	 */
+	public static function getList($uid, $lastitem, $showhidden = true, $showprivate = false)
+	{
+		if ($lastitem) {
+			$params = ['order' => ['last-item' => true]];
+		} else {
+			$params = ['order' => ['name']];
+		}
+
+		$condition = [
+			'contact-type' => [Contact::TYPE_ORGANISATION, Contact::TYPE_NEWS],
+			'network'      => [Protocol::DFRN, Protocol::ACTIVITYPUB],
+			'uid'          => $uid,
+			'blocked'      => false,
+			'pending'      => false,
+			'archive'      => false,
+		];
+
+		$condition = DBA::mergeConditions($condition, ["`platform` NOT IN (?, ?)", 'peertube', 'wordpress']);
+
+		if (!$showprivate) {
+			$condition = DBA::mergeConditions($condition, ['manually-approve' => false]);
+		}
+
+		if (!$showhidden) {
+			$condition = DBA::mergeConditions($condition, ['hidden' => false]);
+		}
+
+		$pagesList = [];
+
+		$fields   = ['id', 'url', 'alias', 'name', 'micro', 'thumb', 'avatar', 'network', 'uid'];
+		$contacts = DBA::select('account-user-view', $fields, $condition, $params);
+		if (!$contacts) {
+			return $groupList;
+		}
+
+		while ($contact = DBA::fetch($contacts)) {
+			$pagesList[] = [
+				'url'     => $contact['url'],
+				'alias'   => $contact['alias'],
+				'name'    => $contact['name'],
+				'id'      => $contact['id'],
+				'micro'   => $contact['micro'],
+				'thumb'   => $contact['thumb'],
+				'network' => $contact['network'],
+			];
+		}
+		DBA::close($contacts);
+
+		return($pagesList);
+	}
+
+
+	/**
+	 * Pages list widget
+	 *
+	 * Sidebar widget to show subscribed Friendica pages. If activated
+	 * in the settings, it appears in the network page sidebar
+	 *
+	 * @param int $uid The ID of the User
+	 * @return string
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws \ImagickException
+	 */
+	public static function widget(int $uid): string
+	{
+		//sort by last updated item
+		$contacts      = self::getList($uid, true, true, true);
+		$total         = count($contacts);
+		$visibleGroups = 10;
+
+		$id = 0;
+
+		$entries = [];
+
+		foreach ($contacts as $contact) {
+			$entry = [
+				'url'          => 'contact/' . $contact['id'] . '/conversations',
+				'external_url' => Contact::magicLinkByContact($contact),
+				'name'         => $contact['name'],
+				'cid'          => $contact['id'],
+				'micro'        => DI::baseUrl()->remove(Contact::getMicro($contact)),
+				'id'           => ++$id,
+			];
+			$entries[] = $entry;
+		}
+
+		$tpl = Renderer::getMarkupTemplate('widget/pages_list.tpl');
+
+
+		$addonHelper = DI::addonHelper();
+
+		return Renderer::replaceMacros(
+			$tpl,
+			[
+				'$title'                        => DI::l10n()->t('Pages'),
+				'$pages'                        => $entries,
+				'$link_desc'                    => DI::l10n()->t('External link to page'),
+				'$new_page'                     => 'register/?type=page',
+				'$total'                        => $total,
+				'$visible_pages'                => $visibleGroups,
+				'$showless'                     => DI::l10n()->t('show less'),
+				'$showmore'                     => DI::l10n()->t('show more'),
+				'$create_new_page'              => DI::l10n()->t('Create new page'),
+				'$addon_page_directory_enabled' => $addonHelper->isAddonEnabled("pagedirectory"),
+				'$visit_pagedirectory'          => DI::l10n()->t('Find pages to follow'),
+			],
+		);
+	}
+
+	/**
+	 * Format page list as contact block
+	 *
+	 * This function is used to show the page list in
+	 * the advanced profile.
+	 *
+	 * @param int $uid The ID of the User
+	 * @return string
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 * @throws \ImagickException
+	 */
+	public static function profileAdvanced($uid)
+	{
+		if (!Feature::isEnabled($uid, Feature::PAGES)) {
+			return '';
+		}
+
+		$o = '';
+
+		// placeholder in case somebody wants configurability
+		$show_total = 9999;
+
+		//don't sort by last updated item
+		$lastitem = false;
+
+		$contacts = self::getList($uid, $lastitem, false, false);
+
+		$total_shown = 0;
+		foreach ($contacts as $contact) {
+			$o .= HTML::micropro($contact, true, 'pagelist-profile-advanced');
+			$total_shown++;
+			if ($total_shown == $show_total) {
+				break;
+			}
+		}
+
+		return $o;
+	}
+
+	/**
+	 * count unread page items
+	 *
+	 * Count unread items of connected groups and private pages
+	 *
+	 * @return array
+	 *    'id' => contact id
+	 *    'name' => contact/page name
+	 *    'count' => counted unseen page items
+	 * @throws \Exception
+	 */
+	public static function countUnseenItems()
+	{
+		$stmtContacts = DBA::p(
+			"SELECT `contact`.`id`, `contact`.`name`, COUNT(*) AS `count` FROM `post-user-view`
+				INNER JOIN `contact` ON `post-user-view`.`contact-id` = `contact`.`id`
+				WHERE `post-user-view`.`uid` = ? AND `post-user-view`.`visible` AND NOT `post-user-view`.`deleted` AND `post-user-view`.`unseen`
+				AND `contact`.`network` IN (?, ?) AND `contact`.`contact-type` = ?
+				AND NOT `contact`.`blocked` AND NOT `contact`.`hidden`
+				AND NOT `contact`.`pending` AND NOT `contact`.`archive`
+				AND `contact`.`uid` = ?
+				GROUP BY `contact`.`id`",
+			DI::userSession()->getLocalUserId(),
+			Protocol::DFRN,
+			Protocol::ACTIVITYPUB,
+			Contact::TYPE_ORGANISATION,
+			Contact::TYPE_NEWS,
+			DI::userSession()->getLocalUserId(),
+		);
+
+		return DBA::toArray($stmtContacts);
+	}
+}

--- a/src/Module/Api/Mastodon/Lists.php
+++ b/src/Module/Api/Mastodon/Lists.php
@@ -31,7 +31,7 @@ class Lists extends BaseApi
 	/** @var Repository\UserDefinedChannel */
 	protected $userDefinedChannel;
 
-	public function __construct(Repository\UserDefinedChannel $userDefinedChannel, ChannelFactory $channel, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
+	public function __construct(Repository\UserDefinedChannel $userDefinedChannel, ChannelFactory $channel, private readonly GroupManager $groupManager, \Friendica\Factory\Api\Mastodon\Error $errorFactory, AppHelper $appHelper, L10n $l10n, BaseURL $baseUrl, Arguments $args, LoggerInterface $logger, Profiler $profiler, ApiResponse $response, array $server, array $parameters = [])
 	{
 		parent::__construct($errorFactory, $appHelper, $l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
@@ -125,7 +125,7 @@ class Lists extends BaseApi
 				}
 			}
 
-			foreach (GroupManager::getList($uid, true, true, true) as $group) {
+			foreach ($this->groupManager->getList($uid, true, true, true) as $group) {
 				$lists[] = DI::mstdnList()->createFromGroup($group);
 			}
 		} else {

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -108,6 +108,8 @@ class Network extends Timeline
 		Mode $mode,
 		ConversationRenderer $conversationRenderer,
 		StatusEditor $statusEditor,
+		private readonly GroupManager $groupManager,
+		private readonly PagesManager $pagesManager,
 		Page $page,
 		IHandleUserSessions $session,
 		Database $database,
@@ -199,10 +201,10 @@ class Network extends Timeline
 						$this->page['aside'] .= Circle::sidebarWidget($module, $module . '/circle', 'standard', $this->circleId);
 						break;
 					case Feature::GROUPS:
-						$this->page['aside'] .= GroupManager::widget($this->session->getLocalUserId());
+						$this->page['aside'] .= $this->groupManager->widget($this->session->getLocalUserId());
 						break;
 					case Feature::PAGES:
-						$this->page['aside'] .= PagesManager::widget($this->session->getLocalUserId());
+						$this->page['aside'] .= $this->pagesManager->widget($this->session->getLocalUserId());
 						break;
 					case Feature::ARCHIVE:
 						$this->page['aside'] .= Widget::postedByYear($module . '/archive', $this->session->getLocalUserId(), false);

--- a/src/Module/Conversation/Network.php
+++ b/src/Module/Conversation/Network.php
@@ -26,6 +26,7 @@ use Friendica\Content\Conversation\Factory\Community as CommunityFactory;
 use Friendica\Content\Conversation\Factory\Network as NetworkFactory;
 use Friendica\Content\Feature;
 use Friendica\Content\GroupManager;
+use Friendica\Content\PagesManager;
 use Friendica\Content\Nav;
 use Friendica\Content\Widget;
 use Friendica\Content\Text\HTML;
@@ -179,6 +180,7 @@ class Network extends Timeline
 			$widgetorder = [
 				Feature::CIRCLES,
 				Feature::GROUPS,
+				Feature::PAGES,
 				Feature::ARCHIVE,
 				Feature::NETWORKS,
 				Feature::ACCOUNTS,
@@ -198,6 +200,9 @@ class Network extends Timeline
 						break;
 					case Feature::GROUPS:
 						$this->page['aside'] .= GroupManager::widget($this->session->getLocalUserId());
+						break;
+					case Feature::PAGES:
+						$this->page['aside'] .= PagesManager::widget($this->session->getLocalUserId());
 						break;
 					case Feature::ARCHIVE:
 						$this->page['aside'] .= Widget::postedByYear($module . '/archive', $this->session->getLocalUserId(), false);

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -52,6 +52,7 @@ class Ping extends BaseModule
 		private readonly Repository\Notification $notificationRepo,
 		private readonly Introduction $introductionRepo,
 		private readonly Factory\FormattedNavNotification $formattedNavNotification,
+		private readonly GroupManager $groupManager,
 		L10n $l10n,
 		BaseURL $baseUrl,
 		Arguments $args,
@@ -105,7 +106,7 @@ class Ping extends BaseModule
 					}
 				}
 
-				foreach (GroupManager::countUnseenItems() as $group_count) {
+				foreach ($this->groupManager->countUnseenItems() as $group_count) {
 					if ($group_count['count'] > 0) {
 						$groups_unseen[] = $group_count;
 					}

--- a/src/Module/Ping/Network.php
+++ b/src/Module/Ping/Network.php
@@ -21,6 +21,8 @@ use Friendica\Content\Conversation\Factory\Channel as ChannelFactory;
 use Friendica\Content\Conversation\Factory\UserDefinedChannel as UserDefinedChannelFactory;
 use Friendica\Content\Conversation\Factory\Community as CommunityFactory;
 use Friendica\Content\Conversation\Factory\Network as NetworkFactory;
+use Friendica\Content\GroupManager;
+use Friendica\Content\PagesManager;
 use Friendica\Core\Cache\Capability\ICanCache;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
@@ -52,6 +54,8 @@ class Network extends NetworkModule
 		Mode $mode,
 		ConversationRenderer $conversationRenderer,
 		StatusEditor $statusEditor,
+		private readonly GroupManager $groupManager,
+		private readonly PagesManager $pagesManager,
 		Page $page,
 		IHandleUserSessions $session,
 		Database $database,
@@ -81,6 +85,8 @@ class Network extends NetworkModule
 			$mode,
 			$conversationRenderer,
 			$statusEditor,
+			$groupManager,
+			$pagesManager,
 			$page,
 			$session,
 			$database,

--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -52,6 +52,7 @@ class Profile extends BaseProfile
 		private readonly AppHelper $appHelper,
 		private readonly Database $database,
 		private readonly EventDispatcherInterface $eventDispatcher,
+		private readonly GroupManager $groupManager,
 		L10n $l10n,
 		BaseURL $baseUrl,
 		Arguments $args,
@@ -246,7 +247,7 @@ class Profile extends BaseProfile
 			$custom_fields += self::buildField(
 				'group_list',
 				$this->t('Groups:'),
-				GroupManager::profileAdvanced($profile['uid']),
+				$this->groupManager->profileAdvanced($profile['uid']),
 			);
 		}
 

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.08-dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-01 02:03+0200\n"
+"POT-Creation-Date: 2026-08-01 21:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1459,7 +1459,7 @@ msgstr ""
 #: src/Module/BaseProfile.php:141 src/Module/Contact.php:402
 #: src/Module/Contact.php:540 src/Module/Conversation/Channel.php:98
 #: src/Module/Conversation/Community.php:91
-#: src/Module/Conversation/Network.php:385
+#: src/Module/Conversation/Network.php:392
 #: src/Module/Moderation/BaseUsers.php:127
 msgid "More"
 msgstr ""
@@ -1888,202 +1888,211 @@ msgstr ""
 msgid "Open Compose page"
 msgstr ""
 
-#: src/Content/Feature.php:105
+#: src/Content/Feature.php:106
 msgid "General Features"
 msgstr ""
 
-#: src/Content/Feature.php:107
+#: src/Content/Feature.php:108
 msgid "Display the community in the navigation"
 msgstr ""
 
-#: src/Content/Feature.php:107
+#: src/Content/Feature.php:108
 msgid "If enabled, the community can be accessed via the navigation menu. Independent from this setting, the community timelines can always be accessed via the channels."
 msgstr ""
 
-#: src/Content/Feature.php:112
+#: src/Content/Feature.php:113
 msgid "Post Composition Features"
 msgstr ""
 
-#: src/Content/Feature.php:113
+#: src/Content/Feature.php:114
 msgid "Explicit Mentions"
 msgstr ""
 
-#: src/Content/Feature.php:113
+#: src/Content/Feature.php:114
 msgid "Add explicit mentions to comment box for manual control over who gets mentioned in replies."
 msgstr ""
 
-#: src/Content/Feature.php:114
+#: src/Content/Feature.php:115
 msgid "Add an abstract from ActivityPub content warnings"
 msgstr ""
 
-#: src/Content/Feature.php:114
+#: src/Content/Feature.php:115
 msgid "Add an abstract when commenting on ActivityPub posts with a content warning. Abstracts are displayed as content warning on systems like Mastodon or Pleroma."
 msgstr ""
 
-#: src/Content/Feature.php:119
+#: src/Content/Feature.php:120
 msgid "Post/Comment Tools"
 msgstr ""
 
-#: src/Content/Feature.php:120
+#: src/Content/Feature.php:121
 msgid "Post Categories"
 msgstr ""
 
-#: src/Content/Feature.php:120
+#: src/Content/Feature.php:121
 msgid "Add categories to your posts"
 msgstr ""
 
-#: src/Content/Feature.php:121 src/Model/Profile.php:826
+#: src/Content/Feature.php:122 src/Model/Profile.php:826
 #: src/Module/Admin/Summary.php:207 src/Module/Item/Compose.php:161
 #: src/Module/Moderation/Report/Create.php:320
 #: src/Module/Moderation/Summary.php:60
 msgid "Summary"
 msgstr ""
 
-#: src/Content/Feature.php:121
+#: src/Content/Feature.php:122
 msgid "Add a summary, abstract or spoiler text to your posts"
 msgstr ""
 
-#: src/Content/Feature.php:126
+#: src/Content/Feature.php:127
 msgid "Network Widgets"
 msgstr ""
 
-#: src/Content/Feature.php:127 src/Content/Widget.php:239
+#: src/Content/Feature.php:128 src/Content/Widget.php:239
 #: src/Model/Circle.php:593 src/Module/Circle.php:138
 #: src/Module/Contact.php:392 src/Module/Welcome.php:63
 msgid "Circles"
 msgstr ""
 
-#: src/Content/Feature.php:127
+#: src/Content/Feature.php:128
 msgid "Display posts that have been created by accounts of the selected circle."
 msgstr ""
 
-#: src/Content/Feature.php:128 src/Content/GroupManager.php:132
+#: src/Content/Feature.php:129 src/Content/GroupManager.php:95
 #: src/Content/Nav.php:235 src/Content/Text/HTML.php:886
 #: src/Content/Widget.php:564 src/Model/User.php:1418
 msgid "Groups"
 msgstr ""
 
-#: src/Content/Feature.php:128
+#: src/Content/Feature.php:129
 msgid "Display posts that have been distributed by the selected group."
 msgstr ""
 
-#: src/Content/Feature.php:129 src/Content/Widget.php:533
-msgid "Archives"
-msgstr ""
-
-#: src/Content/Feature.php:129
-msgid "Display an archive where posts can be selected by month and year."
-msgstr ""
-
-#: src/Content/Feature.php:130 src/Content/Widget.php:312
-msgid "Protocols"
+#: src/Content/Feature.php:130 src/Content/PagesManager.php:95
+msgid "Pages"
 msgstr ""
 
 #: src/Content/Feature.php:130
+msgid "Display posts from Organization and News Pages."
+msgstr ""
+
+#: src/Content/Feature.php:131 src/Content/Widget.php:533
+msgid "Archives"
+msgstr ""
+
+#: src/Content/Feature.php:131
+msgid "Display an archive where posts can be selected by month and year."
+msgstr ""
+
+#: src/Content/Feature.php:132 src/Content/Widget.php:312
+msgid "Protocols"
+msgstr ""
+
+#: src/Content/Feature.php:132
 msgid "Display posts with the selected protocols."
 msgstr ""
 
-#: src/Content/Feature.php:131 src/Content/Widget.php:570
+#: src/Content/Feature.php:133 src/Content/Widget.php:570
 #: src/Module/Settings/Account.php:392
 msgid "Account Types"
 msgstr ""
 
-#: src/Content/Feature.php:131
+#: src/Content/Feature.php:133
 msgid "Display posts done by accounts with the selected account type."
 msgstr ""
 
-#: src/Content/Feature.php:132 src/Content/Widget.php:632
+#: src/Content/Feature.php:134 src/Content/Widget.php:632
 #: src/Module/Admin/Site.php:476 src/Module/BaseSettings.php:113
 #: src/Module/Settings/Channels.php:231 src/Module/Settings/Display.php:447
 msgid "Channels"
 msgstr ""
 
-#: src/Content/Feature.php:132
+#: src/Content/Feature.php:134
 msgid "Display posts in the system channels and user defined channels."
 msgstr ""
 
-#: src/Content/Feature.php:133 src/Content/Widget/SavedSearches.php:46
+#: src/Content/Feature.php:135 src/Content/Widget/SavedSearches.php:46
 msgid "Saved Searches"
 msgstr ""
 
-#: src/Content/Feature.php:133
+#: src/Content/Feature.php:135
 msgid "Display posts that contain subscribed hashtags."
 msgstr ""
 
-#: src/Content/Feature.php:134 src/Content/Widget.php:342
+#: src/Content/Feature.php:136 src/Content/Widget.php:342
 msgid "Saved Folders"
 msgstr ""
 
-#: src/Content/Feature.php:134
+#: src/Content/Feature.php:136
 msgid "Display a list of folders in which posts are stored."
 msgstr ""
 
-#: src/Content/Feature.php:135 src/Module/Conversation/Timeline.php:206
+#: src/Content/Feature.php:137 src/Module/Conversation/Timeline.php:206
 msgid "Own Contacts"
 msgstr ""
 
-#: src/Content/Feature.php:135
+#: src/Content/Feature.php:137
 msgid "Include or exclude posts from subscribed accounts. This widget is not visible on all channels."
 msgstr ""
 
-#: src/Content/Feature.php:136 src/Content/Widget/TrendingTags.php:39
+#: src/Content/Feature.php:138 src/Content/Widget/TrendingTags.php:39
 msgid "Trending Tags"
 msgstr ""
 
-#: src/Content/Feature.php:136
+#: src/Content/Feature.php:138
 msgid "Display a list of the most popular tags in recent public posts."
 msgstr ""
 
-#: src/Content/Feature.php:141
+#: src/Content/Feature.php:143
 msgid "Advanced Profile Settings"
 msgstr ""
 
-#: src/Content/Feature.php:142
+#: src/Content/Feature.php:144
 msgid "Tag Cloud"
 msgstr ""
 
-#: src/Content/Feature.php:142
+#: src/Content/Feature.php:144
 msgid "Provide a personal tag cloud on your profile page"
 msgstr ""
 
-#: src/Content/Feature.php:143
+#: src/Content/Feature.php:145
 msgid "Display Membership Date"
 msgstr ""
 
-#: src/Content/Feature.php:143
+#: src/Content/Feature.php:145
 msgid "Display membership date in profile"
 msgstr ""
 
-#: src/Content/Feature.php:148
+#: src/Content/Feature.php:150
 msgid "Advanced Calendar Settings"
 msgstr ""
 
-#: src/Content/Feature.php:149
+#: src/Content/Feature.php:151
 msgid "Allow anonymous access to your calendar"
 msgstr ""
 
-#: src/Content/Feature.php:149
+#: src/Content/Feature.php:151
 msgid "Allows anonymous visitors to consult your calendar and your public events. Contact birthday events are private to you."
 msgstr ""
 
-#: src/Content/GroupManager.php:134
+#: src/Content/GroupManager.php:97
 msgid "External link to group"
 msgstr ""
 
-#: src/Content/GroupManager.php:138 src/Content/Widget.php:539
+#: src/Content/GroupManager.php:101 src/Content/PagesManager.php:101
+#: src/Content/Widget.php:539
 msgid "show less"
 msgstr ""
 
-#: src/Content/GroupManager.php:139 src/Content/Widget.php:434
-#: src/Content/Widget.php:540
+#: src/Content/GroupManager.php:102 src/Content/PagesManager.php:102
+#: src/Content/Widget.php:434 src/Content/Widget.php:540
 msgid "show more"
 msgstr ""
 
-#: src/Content/GroupManager.php:140
+#: src/Content/GroupManager.php:103
 msgid "Create new group"
 msgstr ""
 
-#: src/Content/GroupManager.php:142
+#: src/Content/GroupManager.php:105
 msgid "Find groups to join"
 msgstr ""
 
@@ -2154,7 +2163,7 @@ msgstr ""
 
 #: src/Content/Item.php:423 src/Content/Widget.php:71
 #: src/Model/Contact.php:1299 src/Model/Contact.php:1311
-#: src/Module/Contact/Follow.php:152 view/theme/vier/theme.php:183
+#: src/Module/Contact/Follow.php:152 view/theme/vier/theme.php:182
 msgid "Connect/Follow"
 msgstr ""
 
@@ -2252,7 +2261,7 @@ msgstr ""
 #: src/Module/Settings/TwoFactor/AppSpecific.php:130
 #: src/Module/Settings/TwoFactor/Index.php:125
 #: src/Module/Settings/TwoFactor/Recovery.php:96
-#: src/Module/Settings/TwoFactor/Verify.php:140 view/theme/vier/theme.php:228
+#: src/Module/Settings/TwoFactor/Verify.php:140 view/theme/vier/theme.php:221
 msgid "Help"
 msgstr ""
 
@@ -2337,7 +2346,7 @@ msgstr ""
 
 #: src/Content/Nav.php:266 src/Module/BaseProfile.php:34
 #: src/Module/BaseSettings.php:86 src/Module/Contact.php:487
-#: src/Module/Contact/Profile.php:439 src/Module/Profile/Profile.php:276
+#: src/Module/Contact/Profile.php:439 src/Module/Profile/Profile.php:277
 #: src/Module/Welcome.php:44
 msgid "Profile"
 msgstr ""
@@ -2457,6 +2466,18 @@ msgstr ""
 msgid "last"
 msgstr ""
 
+#: src/Content/PagesManager.php:97
+msgid "External link to page"
+msgstr ""
+
+#: src/Content/PagesManager.php:103
+msgid "Create new page"
+msgstr ""
+
+#: src/Content/PagesManager.php:105
+msgid "Find pages to follow"
+msgstr ""
+
 #: src/Content/Text/BBCode.php:910
 #, php-format
 msgid "<a href=\"%1$s\" target=\"_blank\" rel=\"noopener noreferrer\">%2$s</a> %3$s"
@@ -2526,46 +2547,46 @@ msgid_plural "%d invitations available"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/Widget.php:69 view/theme/vier/theme.php:181
+#: src/Content/Widget.php:69 view/theme/vier/theme.php:180
 msgid "Find People"
 msgstr ""
 
-#: src/Content/Widget.php:70 view/theme/vier/theme.php:182
+#: src/Content/Widget.php:70 view/theme/vier/theme.php:181
 msgid "Enter name or interest"
 msgstr ""
 
-#: src/Content/Widget.php:72 view/theme/vier/theme.php:184
+#: src/Content/Widget.php:72 view/theme/vier/theme.php:183
 msgid "Examples: Robert Morgenstein, Fishing"
 msgstr ""
 
 #: src/Content/Widget.php:73 src/Module/Contact.php:443
-#: src/Module/Directory.php:81 view/theme/vier/theme.php:185
+#: src/Module/Directory.php:81 view/theme/vier/theme.php:184
 msgid "Find"
 msgstr ""
 
 #: src/Content/Widget.php:74 src/Module/Contact/Suggestions.php:51
-#: view/theme/vier/theme.php:186
+#: view/theme/vier/theme.php:185
 msgid "Friend Suggestions"
 msgstr ""
 
-#: src/Content/Widget.php:75 view/theme/vier/theme.php:187
+#: src/Content/Widget.php:75 view/theme/vier/theme.php:186
 msgid "Similar Interests"
 msgstr ""
 
-#: src/Content/Widget.php:76 view/theme/vier/theme.php:188
+#: src/Content/Widget.php:76 view/theme/vier/theme.php:187
 msgid "Random Profile"
 msgstr ""
 
-#: src/Content/Widget.php:77 view/theme/vier/theme.php:189
+#: src/Content/Widget.php:77 view/theme/vier/theme.php:188
 msgid "Invite Friends"
 msgstr ""
 
 #: src/Content/Widget.php:78 src/Module/Directory.php:72
-#: view/theme/vier/theme.php:190
+#: view/theme/vier/theme.php:189
 msgid "Global Directory"
 msgstr ""
 
-#: src/Content/Widget.php:80 view/theme/vier/theme.php:192
+#: src/Content/Widget.php:80 view/theme/vier/theme.php:191
 msgid "Local Directory"
 msgstr ""
 
@@ -2699,12 +2720,12 @@ msgid "Mention"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:121 src/Model/Profile.php:360
-#: src/Module/Contact/Profile.php:428 src/Module/Profile/Profile.php:186
+#: src/Module/Contact/Profile.php:428 src/Module/Profile/Profile.php:187
 msgid "XMPP:"
 msgstr ""
 
 #: src/Content/Widget/VCard.php:122 src/Model/Profile.php:361
-#: src/Module/Contact/Profile.php:430 src/Module/Profile/Profile.php:190
+#: src/Module/Contact/Profile.php:430 src/Module/Profile/Profile.php:191
 msgid "Matrix:"
 msgstr ""
 
@@ -2712,7 +2733,7 @@ msgstr ""
 #: src/Model/Event.php:94 src/Model/Event.php:461 src/Model/Event.php:940
 #: src/Model/Profile.php:355 src/Module/Contact/Profile.php:426
 #: src/Module/Directory.php:133 src/Module/Notifications/Introductions.php:187
-#: src/Module/Profile/Profile.php:208
+#: src/Module/Profile/Profile.php:209
 msgid "Location:"
 msgstr ""
 
@@ -2737,7 +2758,7 @@ msgstr ""
 msgid "Group posts"
 msgstr ""
 
-#: src/Core/ACL.php:152 src/Module/Profile/Profile.php:277
+#: src/Core/ACL.php:152 src/Module/Profile/Profile.php:278
 msgid "Yourself"
 msgstr ""
 
@@ -3673,7 +3694,7 @@ msgid "Change profile picture"
 msgstr ""
 
 #: src/Model/Profile.php:358 src/Module/Directory.php:138
-#: src/Module/Profile/Profile.php:196
+#: src/Module/Profile/Profile.php:197
 msgid "Homepage:"
 msgstr ""
 
@@ -3682,7 +3703,7 @@ msgstr ""
 msgid "About:"
 msgstr ""
 
-#: src/Model/Profile.php:457 src/Module/Profile/Profile.php:163
+#: src/Model/Profile.php:457 src/Module/Profile/Profile.php:164
 msgid "Joined:"
 msgstr ""
 
@@ -3694,7 +3715,7 @@ msgstr ""
 msgid "Atom feed"
 msgstr ""
 
-#: src/Model/Profile.php:492 src/Module/Profile/Profile.php:290
+#: src/Model/Profile.php:492 src/Module/Profile/Profile.php:291
 msgid "This website has been verified to belong to the same person."
 msgstr ""
 
@@ -4655,7 +4676,7 @@ msgid "Policies"
 msgstr ""
 
 #: src/Module/Admin/Site.php:467 src/Module/Calendar/Event/Form.php:265
-#: src/Module/Contact.php:530 src/Module/Profile/Profile.php:284
+#: src/Module/Contact.php:530 src/Module/Profile/Profile.php:285
 msgid "Advanced"
 msgstr ""
 
@@ -6247,7 +6268,7 @@ msgstr ""
 msgid "Share this event"
 msgstr ""
 
-#: src/Module/Calendar/Event/Form.php:264 src/Module/Profile/Profile.php:283
+#: src/Module/Calendar/Event/Form.php:264 src/Module/Profile/Profile.php:284
 msgid "Basic"
 msgstr ""
 
@@ -6691,7 +6712,7 @@ msgstr ""
 
 #: src/Module/Contact/Follow.php:156 src/Module/Contact/Profile.php:434
 #: src/Module/Notifications/Introductions.php:191
-#: src/Module/Profile/Profile.php:221
+#: src/Module/Profile/Profile.php:222
 msgid "Tags:"
 msgstr ""
 
@@ -7075,21 +7096,21 @@ msgstr ""
 msgid "Not available."
 msgstr ""
 
-#: src/Module/Conversation/Network.php:277
+#: src/Module/Conversation/Network.php:284
 msgid "No such circle"
 msgstr ""
 
-#: src/Module/Conversation/Network.php:281
+#: src/Module/Conversation/Network.php:288
 #, php-format
 msgid "Circle: %s"
 msgstr ""
 
-#: src/Module/Conversation/Network.php:301
+#: src/Module/Conversation/Network.php:308
 #, php-format
 msgid "Error %d (%s) while fetching the timeline."
 msgstr ""
 
-#: src/Module/Conversation/Network.php:397
+#: src/Module/Conversation/Network.php:404
 msgid "Network feed not available."
 msgstr ""
 
@@ -9371,11 +9392,11 @@ msgstr ""
 msgid "Show unread"
 msgstr ""
 
-#: src/Module/Notifications/Ping.php:193
+#: src/Module/Notifications/Ping.php:194
 msgid "{0} requested registration"
 msgstr ""
 
-#: src/Module/Notifications/Ping.php:202
+#: src/Module/Notifications/Ping.php:203
 #, php-format
 msgid "{0} and %d others requested registration"
 msgstr ""
@@ -9537,8 +9558,8 @@ msgstr ""
 msgid "%d more"
 msgstr ""
 
-#: src/Module/Profile/CircleExport.php:49 src/Module/Profile/Profile.php:98
-#: src/Module/Profile/Profile.php:133 src/Module/Profile/Restricted.php:33
+#: src/Module/Profile/CircleExport.php:49 src/Module/Profile/Profile.php:99
+#: src/Module/Profile/Profile.php:134 src/Module/Profile/Restricted.php:33
 msgid "Profile not found."
 msgstr ""
 
@@ -9550,19 +9571,19 @@ msgstr ""
 msgid "No contacts."
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:71 src/Module/Profile/Profile.php:356
+#: src/Module/Profile/Conversations.php:71 src/Module/Profile/Profile.php:357
 #: src/Protocol/Feed.php:1108
 #, php-format
 msgid "%s's posts"
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:72 src/Module/Profile/Profile.php:357
+#: src/Module/Profile/Conversations.php:72 src/Module/Profile/Profile.php:358
 #: src/Protocol/Feed.php:1111
 #, php-format
 msgid "%s's comments"
 msgstr ""
 
-#: src/Module/Profile/Conversations.php:73 src/Module/Profile/Profile.php:358
+#: src/Module/Profile/Conversations.php:73 src/Module/Profile/Profile.php:359
 #: src/Protocol/Feed.php:1104
 #, php-format
 msgid "%s's timeline"
@@ -9599,30 +9620,30 @@ msgstr ""
 msgid "View Album"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:124
+#: src/Module/Profile/Profile.php:125
 #, php-format
 msgid "You're currently viewing your profile as <b>%s</b> <a href=\"%s\" class=\"btn btn-sm pull-right\">Cancel</a>"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:158 src/Module/Settings/Account.php:527
+#: src/Module/Profile/Profile.php:159 src/Module/Settings/Account.php:527
 #: src/Module/Settings/Profile/Index.php:296
 msgid "Display name:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:169
+#: src/Module/Profile/Profile.php:170
 msgid "d MMMM"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:174 src/Util/Temporal.php:155
+#: src/Module/Profile/Profile.php:175 src/Util/Temporal.php:155
 msgid "Birthday:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:177 src/Module/Settings/Profile/Index.php:304
+#: src/Module/Profile/Profile.php:178 src/Module/Settings/Profile/Index.php:304
 #: src/Util/Temporal.php:157
 msgid "Age: "
 msgstr ""
 
-#: src/Module/Profile/Profile.php:177 src/Module/Settings/Profile/Index.php:304
+#: src/Module/Profile/Profile.php:178 src/Module/Settings/Profile/Index.php:304
 #: src/Util/Temporal.php:157
 #, php-format
 msgid "%d year old"
@@ -9630,27 +9651,27 @@ msgid_plural "%d years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Profile/Profile.php:182 src/Module/Settings/Profile/Index.php:297
+#: src/Module/Profile/Profile.php:183 src/Module/Settings/Profile/Index.php:297
 msgid "Description:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:248
+#: src/Module/Profile/Profile.php:249
 msgid "Groups:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:268
+#: src/Module/Profile/Profile.php:269
 msgid "Public circles (CSV):"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:281
+#: src/Module/Profile/Profile.php:282
 msgid "View profile as:"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:282
+#: src/Module/Profile/Profile.php:283
 msgid "View as selected profile"
 msgstr ""
 
-#: src/Module/Profile/Profile.php:293
+#: src/Module/Profile/Profile.php:294
 msgid "View as"
 msgstr ""
 
@@ -12933,7 +12954,7 @@ msgstr ""
 msgid "Community Pages"
 msgstr ""
 
-#: view/theme/vier/config.php:149 view/theme/vier/theme.php:136
+#: view/theme/vier/config.php:149 view/theme/vier/theme.php:135
 msgid "Community Profiles"
 msgstr ""
 
@@ -12941,7 +12962,7 @@ msgstr ""
 msgid "Help or @NewHere ?"
 msgstr ""
 
-#: view/theme/vier/config.php:151 view/theme/vier/theme.php:309
+#: view/theme/vier/config.php:151 view/theme/vier/theme.php:302
 msgid "Connect Services"
 msgstr ""
 
@@ -12949,10 +12970,10 @@ msgstr ""
 msgid "Find Friends"
 msgstr ""
 
-#: view/theme/vier/config.php:153 view/theme/vier/theme.php:163
+#: view/theme/vier/config.php:153 view/theme/vier/theme.php:162
 msgid "Last users"
 msgstr ""
 
-#: view/theme/vier/theme.php:222
+#: view/theme/vier/theme.php:215
 msgid "Quick Start"
 msgstr ""

--- a/view/templates/widget/pages_list.tpl
+++ b/view/templates/widget/pages_list.tpl
@@ -1,0 +1,72 @@
+{{*
+  * Copyright (C) 2010-2024, the Friendica project
+  * SPDX-FileCopyrightText: 2010-2024 the Friendica project
+  *
+  * SPDX-License-Identifier: AGPL-3.0-or-later
+  *}}
+<!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
+<script>
+	/* TODO: Consider making a reusable version of this in e.g. main.js instead */
+	function showHidePagesList() {
+		if ($("li[id^='pages-widget-entry-extended-']").is(':visible')) {
+			$("li[id^='pages-widget-entry-extended-']").hide();
+			$("li#pages-widget-collapse").html('{{$showmore}}');
+
+		} else {
+			$("li[id^='pages-widget-entry-extended-']").show();
+			$("li#pages-widget-collapse").html('{{$showless}}');
+		}
+	}
+</script>
+<nav id="pages-sidebar" class="widget">
+	<button class="widget-btn fakelink" onclick="openCloseWidget('pages-sidebar');" aria-expanded="false">
+		<h3>
+			<i class="ri ri-discuss-line" aria-hidden="true"></i>
+			{{$title}}
+		</h3>
+	</button>
+	<a class="pull-right widget-action widget-action-top faded-icon" id="sidebar-new-pages"
+		href="{{$new_page}}" data-toggle="tooltip" title="{{$create_new_page}}">
+		<i class="ri ri-add-line" aria-hidden="true"></i>
+	</a>
+	{{if $addon_pages_directory_enabled}}
+		<a class="pull-right widget-action widget-action-top faded-icon" id="sidebar-pages-directory"
+			href="/pagesdirectory" data-toggle="tooltip" title="{{$visit_pagesdirectory}}">
+			<i class="ri ri-search-line" aria-hidden="true"></i>
+		</a>
+	{{/if}}
+
+	<div id="pages-list-sidebar" class="sidebar-widget-list">
+		{{* The list of available pages *}}
+		<ul id="pages-list-sidebar-ul">
+			{{foreach $pages as $page}}
+				{{if $page.id <= $visible_pages}}
+					<li class="pages-widget-entry pages-{{$page.cid}}" id="pages-widget-entry-{{$page.id}}">
+						<span class="notify badge pull-right"></span>
+						<a href="{{$page.external_url}}" title="{{$page.link_desc}}" class="label sparkle" target="_blank" rel="noopener noreferrer">
+							<img src="{{$page.micro}}" alt="{{$page.link_desc}}" />
+						</a>
+						<a class="pages-widget-link" id="pages-widget-link-{{$page.id}}" href="{{$page.url}}">{{$page.name}}</a>
+					</li>
+				{{/if}}
+
+				{{if $page.id > $visible_pages}}
+					<li class="pages-widget-entry pages-{{$page.cid}}" id="pages-widget-entry-extended-{{$page.id}}" style="display: none;">
+						<span class="notify badge pull-right"></span>
+						<a href="{{$page.external_url}}" title="{{$page.link_desc}}" class="label sparkle" target="_blank" rel="noopener noreferrer">
+							<img src="{{$page.micro}}" alt="{{$page.link_desc}}" />
+						</a>
+						<a class="pages-widget-link" id="pages-widget-link-{{$page.id}}" href="{{$page.url}}">{{$page.name}}</a>
+					</li>
+				{{/if}}
+			{{/foreach}}
+
+			{{if $total > $visible_pages}}
+				<li onclick="showHidePagesList(); return false;" id="pages-widget-collapse" class="pages-widget-link widget-show-more fakelink tool">{{$showmore}}</li>
+			{{/if}}
+		</ul>
+	</div>
+</nav>
+<script>
+	initWidget('pages-sidebar');
+</script>

--- a/view/templates/widget/pages_list.tpl
+++ b/view/templates/widget/pages_list.tpl
@@ -21,7 +21,7 @@
 <nav id="pages-sidebar" class="widget">
 	<button class="widget-btn fakelink" onclick="openCloseWidget('pages-sidebar');" aria-expanded="false">
 		<h3>
-			<i class="ri ri-discuss-line" aria-hidden="true"></i>
+			<i class="ri ri-file-copy-line" aria-hidden="true"></i>
 			{{$title}}
 		</h3>
 	</button>

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -471,7 +471,7 @@ pre code {
 	opacity: 1;
 }
 
-.sidebar-circle-li:hover, #sidebar-new-circle:hover, #sidebar-edit-circles:hover, #sidebar-new-group:hover, #group-widget-collapse:hover,
+.sidebar-circle-li:hover, #sidebar-new-circle:hover, #sidebar-edit-circles:hover, #sidebar-new-group:hover, #sidebar-new-pages:hover, #group-widget-collapse:hover,
 #pages-widget-collapse,#sidebar-uncircled:hover, .side-link:hover, .nets-ul li:hover, #group-list-sidebar li:hover, #group-list-sidebar-right li:hover,
 #pages-list-sidebar li:hover, #pages-list-sidebar-right li:hover, .nets-all:hover, .saved-search-li:hover, li.tool:hover, .admin.link:hover, 
 aside h4 a:hover, right_aside h4 a:hover, #message-new:hover, #sidebar-photos-albums li:hover, .photos-upload-link:hover, .textcomplete-item.active {
@@ -488,7 +488,7 @@ aside h4 a:hover, right_aside h4 a:hover, #message-new:hover, #sidebar-photos-al
 	font-weight: bold;
 }
 
-#group-widget-showmore, #sidebar-new-circle, #sidebar-edit-circles, #sidebar-new-group, #group-widget-collapse, #group-list-rsidebar-right, #sidebar-uncircled,
+#group-widget-showmore, #sidebar-new-circle, #sidebar-edit-circles, #sidebar-new-group, #sidebar-new-pages, #group-widget-collapse, #group-list-rsidebar-right, #sidebar-uncircled,
 .side-link, #peoplefind-desc, #connect-desc, .nets-all, .admin.link, #message-new {
 	padding-left: 10px;
 	padding-top: 3px;

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -446,16 +446,18 @@ pre code {
 #sidebar-widget-list .tool:hover {
 	background: #EEE;
 }
-#sidebar-circle-list .notify {
+#sidebar-circle-list .notify,
+#sidebar-pages-list .notify {
 	display: none;
 }
-#sidebar-circle-list .notify.show {
+#sidebar-circle-list .notify.show,
+#sidebar-pages-list .notify.show {
 	display: inline-block;
 }
 .tool .action {
 	float: right;
 }
-.tool a:hover, .widget a:hover, #group-widget-collapse:hover, .admin.link a:hover, aside h4 a:hover, right_aside h4 a:hover {
+.tool a:hover, .widget a:hover, #group-widget-collapse:hover, #pages-widget-collapse:hover, .admin.link a:hover, aside h4 a:hover, right_aside h4 a:hover {
 	/* text-decoration: underline; */
 	text-decoration: none;
 	color: black;
@@ -470,9 +472,9 @@ pre code {
 }
 
 .sidebar-circle-li:hover, #sidebar-new-circle:hover, #sidebar-edit-circles:hover, #sidebar-new-group:hover, #group-widget-collapse:hover,
-#sidebar-uncircled:hover, .side-link:hover, .nets-ul li:hover, #group-list-sidebar li:hover, #group-list-sidebar-right li:hover,
-.nets-all:hover, .saved-search-li:hover, li.tool:hover, .admin.link:hover, aside h4 a:hover, right_aside h4 a:hover, #message-new:hover,
-#sidebar-photos-albums li:hover, .photos-upload-link:hover, .textcomplete-item.active {
+#pages-widget-collapse,#sidebar-uncircled:hover, .side-link:hover, .nets-ul li:hover, #group-list-sidebar li:hover, #group-list-sidebar-right li:hover,
+#pages-list-sidebar li:hover, #pages-list-sidebar-right li:hover, .nets-all:hover, .saved-search-li:hover, li.tool:hover, .admin.link:hover, 
+aside h4 a:hover, right_aside h4 a:hover, #message-new:hover, #sidebar-photos-albums li:hover, .photos-upload-link:hover, .textcomplete-item.active {
 	/* background-color: #ddd; */
 	/* background-color: #e5e5e5; */
 	background-color: #F5F5F5;
@@ -512,10 +514,12 @@ pre code {
 	padding-right: 5px;
 }
 
+#pages-list-sidebar .notify, #pages-list-sidebar-right .notify,
 #group-list-sidebar .notify, #group-list-sidebar-right .notify {
 	display: none;
 }
 
+#pages-list-sidebar .notify.show, #pages-list-sidebar-right .notify.show,
 #group-list-sidebar .notify.show, #group-list-sidebar-right .notify.show {
 	display: inline-block;
 }

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -194,12 +194,6 @@ function vier_community_info(): void
 		$aside['$nv'] = $nv;
 	}
 
-	//Community_Pages at right_aside
-	if ($show_pages && DI::userSession()->getLocalUserId()) {
-		$aside['$page'] = GroupManager::widget(DI::userSession()->getLocalUserId());
-	}
-	// END Community Page
-
 	// helpers
 	if ($show_helpers) {
 		$r = [];

--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -16,7 +16,6 @@
  */
 
 use Friendica\App\Mode;
-use Friendica\Content\GroupManager;
 use Friendica\Core\Renderer;
 use Friendica\Core\Search;
 use Friendica\Database\DBA;

--- a/view/theme/vier/wide.css
+++ b/view/theme/vier/wide.css
@@ -8,10 +8,6 @@ right_aside {
   display: block;
 }
 
-aside #group-sidebar {
-  display: none;
-}
-
 right_aside span.sbox {
   margin-left: 10px;
 }


### PR DESCRIPTION

<img width="286" height="280" alt="pages_widget" src="https://github.com/user-attachments/assets/4485dc77-a512-4375-9bd9-6f684818dfd5" />


This is a re-do of the Add Pages Widget PR submitted back in April. It was too outdated so I just closed it, rebased, and redid it using the current develop code.

Based on the existing Groups Widget this new Pages Widget shows both Organization and News pages which you are following or administrate. It can be enabled/disabled/sorted like all the other widgets in the sidebar.
Like the Groups Widget it also has a "+" link to "Create a new page" on the end, which takes you to the Register form. It has _"/?type=page"_ on the end which auto-selected "Organization Page" from the drop-down in the form to Register an extra account.

This PR also changes the Groups Widget placement in Vier. Currently it only appears in the right-hand sidebar and cannot be made to appear in the left-hand sidebar. I've removed it from the right side and enabled it for the left side where users can actually control whether or not it appears and where it is in the order.

These two widgets will probably also be the primary means of discovery for new users on how to **create** a new group or page.

**Note:** once this patch is applied, if you have previously saved _Settings > Additional Features > Network Widgets_ you have to "Reset" the sortable list before the Pages Widget will appear because it is pulling the widget list from your saved prefs. You may also need to re-save _Admin > Additional features > Network Widgets_ before it shows in that list too for similar reasons.