### PR TITLE
Add phpstan deprecation check, fix deprecations

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -842,12 +842,6 @@ parameters:
 			path: src/Protocol/DFRN.php
 
 		-
-			message: '#^Call to deprecated function openssl_free_key\(\)\.$#'
-			identifier: function.deprecated
-			count: 2
-			path: src/Security/OAuth1/Signature/OAuthSignatureMethod_RSA_SHA1.php
-
-		-
 			message: '''
 				#^Access to constant on deprecated class Friendica\\Core\\Addon\\Model\\AddonLoader\:
 				2026\.01 Use implementation of `\\Friendica\\Core\\Addon\\AddonHelper` instead\.$#

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -1,12 +1,1034 @@
-# SPDX-FileCopyrightText: 2010 - 2024 the Friendica project
-#
-# SPDX-License-Identifier: CC0-1.0
-
 parameters:
 	ignoreErrors:
+		-
+			message: '#^Call to deprecated method getDice\(\) of class Friendica\\Core\\DiceContainer\.$#'
+			identifier: method.deprecated
+			count: 1
+			path: src/App.php
+
+		-
+			message: '''
+				#^Call to deprecated method getModuleName\(\) of class Friendica\\App\\Arguments\:
+				2022\.12 \- With the new \(sub\-\)routes, it's not trustworthy anymore, use the ModuleClass instead$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: src/App.php
+
+		-
+			message: '''
+				#^Call to deprecated method getModuleName\(\) of class Friendica\\App\\Arguments\:
+				2022\.12 \- With the new \(sub\-\)routes, it's not trustworthy anymore, use the ModuleClass instead$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/App/Mode.php
+
+		-
+			message: '''
+				#^Call to deprecated method getModuleName\(\) of class Friendica\\App\\Arguments\:
+				2022\.12 \- With the new \(sub\-\)routes, it's not trustworthy anymore, use the ModuleClass instead$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: src/App/Page.php
+
+		-
+			message: '''
+				#^Call to deprecated method getModuleName\(\) of class Friendica\\App\\Arguments\:
+				2022\.12 \- With the new \(sub\-\)routes, it's not trustworthy anymore, use the ModuleClass instead$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/App/Router.php
+
+		-
+			message: '''
+				#^Call to deprecated method getModuleName\(\) of class Friendica\\App\\Arguments\:
+				2022\.12 \- With the new \(sub\-\)routes, it's not trustworthy anymore, use the ModuleClass instead$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: src/BaseModule.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$factory of class Friendica\\BaseRepository\:
+				2026\.08 Implement getFactory\(\) instead$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: src/BaseRepository.php
+
+		-
+			message: '''
+				#^Call to deprecated method getFactory\(\) of class Friendica\\BaseRepository\:
+				2026\.08 This method will become abstract in a future release, implement it in your child class instead\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/BaseRepository.php
+
+		-
+			message: '''
+				#^Call to deprecated method getModuleName\(\) of class Friendica\\App\\Arguments\:
+				2022\.12 \- With the new \(sub\-\)routes, it's not trustworthy anymore, use the ModuleClass instead$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Core/ACL.php
+
+		-
+			message: '''
+				#^Call to deprecated method loadINIConfigFile\(\) of class Friendica\\Core\\Config\\Util\\ConfigFileManager\:
+				2018\.12 since version 2018\.12$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: src/Core/Config/Util/ConfigFileManager.php
+
+		-
+			message: '''
+				#^Call to deprecated method loadLegacyConfig\(\) of class Friendica\\Core\\Config\\Util\\ConfigFileManager\:
+				2018\.09 since version 2018\.09$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: src/Core/Config/Util/ConfigFileManager.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Friendica\\Core\\Logger\:
+				2026\.01 Use constructor injection or `DI\:\:logger\(\)` instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/Core/Logger/Capability/IHaveCallIntrospections.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Friendica\\Core\\Logger\\Factory\\Logger\:
+				2026\.01 Implement `\\Friendica\\Core\\Logger\\Factory\\LoggerFactory` instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/Core/Logger/Capability/IHaveCallIntrospections.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Friendica\\Core\\Logger\:
+				2026\.01 Use constructor injection or `DI\:\:logger\(\)` instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/Core/Logger/Util/Introspection.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Friendica\\Navigation\\Notifications\\Factory\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Factory\\FormattedNotification instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/DI.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Friendica\\Navigation\\Notifications\\Factory\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Factory\\Notification instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/DI.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/DI.php
+
+		-
+			message: '''
+				#^Return type of method Friendica\\DI\:\:formattedNotificationFactory\(\) has typehint with deprecated class Friendica\\Navigation\\Notifications\\Factory\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Factory\\FormattedNotification instead$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: src/DI.php
+
+		-
+			message: '''
+				#^Return type of method Friendica\\DI\:\:notify\(\) has typehint with deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: src/DI.php
+
+		-
+			message: '''
+				#^Return type of method Friendica\\DI\:\:notifyFactory\(\) has typehint with deprecated class Friendica\\Navigation\\Notifications\\Factory\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Factory\\Notification instead$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: src/DI.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanURL\(\) of class Friendica\\Model\\GServer\:
+				2023\.03 Use cleanUri instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: src/Database/PostUpdate.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$factory of class Friendica\\BaseRepository\:
+				2026\.08 Implement getFactory\(\) instead$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: src/Federation/Repository/DeliveryQueueItem.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Model/APContact.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: src/Model/Contact.php
+
+		-
+			message: '''
+				#^Call to method createFromArray\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Model/Contact.php
+
+		-
+			message: '#^Call to deprecated function strftime\(\)\.$#'
+			identifier: function.deprecated
+			count: 4
+			path: src/Model/Event.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanURL\(\) of class Friendica\\Model\\GServer\:
+				2023\.03 Use cleanUri instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: src/Model/GServer.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 8
+			path: src/Model/GServer.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: src/Model/Item.php
+
+		-
+			message: '''
+				#^Call to method deleteForItem\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Model/Item.php
+
+		-
+			message: '''
+				#^Call to method createFromArray\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Model/Mail.php
+
+		-
+			message: '''
+				#^Call to method createFromNotification\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Model/Subscription.php
+
+		-
+			message: '''
+				#^Call to method shouldShowOnDesktop\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Model/Subscription.php
+
+		-
+			message: '''
+				#^Call to method selectAllForUser\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$itemId of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Module/Api/Friendica/Notification/Seen.php
+
+		-
+			message: '''
+				#^Access to property \$otype of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Module/Api/Friendica/Notification/Seen.php
+
+		-
+			message: '''
+				#^Access to property \$uid of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 2
+			path: src/Module/Api/Friendica/Notification/Seen.php
+
+		-
+			message: '''
+				#^Access to property \$uriId of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 2
+			path: src/Module/Api/Friendica/Notification/Seen.php
+
+		-
+			message: '''
+				#^Call to method save\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Api/Friendica/Notification/Seen.php
+
+		-
+			message: '''
+				#^Call to method selectOneById\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Api/Friendica/Notification/Seen.php
+
+		-
+			message: '''
+				#^Call to method setSeen\(\) of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Api/Friendica/Notification/Seen.php
+
+		-
+			message: '''
+				#^Call to method existsForUser\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Api/Mastodon/Statuses.php
+
+		-
+			message: '''
+				#^Call to method setAllSeenForUser\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Api/Mastodon/Statuses.php
+
+		-
+			message: '''
+				#^Parameter \$notify of method Friendica\\Module\\Api\\Mastodon\\Statuses\:\:__construct\(\) has typehint with deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: src/Module/Api/Mastodon/Statuses.php
+
 		-
 			message: '#^PHPDoc type Friendica\\Module\\Api\\ApiResponse of property Friendica\\Module\\BaseApi\:\:\$response is not the same as PHPDoc type Friendica\\Capabilities\\ICanCreateResponses of overridden property Friendica\\BaseModule\:\:\$response\.$#'
 			identifier: property.phpDocType
 			count: 1
 			path: src/Module/BaseApi.php
+
+		-
+			message: '''
+				#^Fetching class constant HOME of deprecated class Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotification instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 3
+			path: src/Module/BaseNotifications.php
+
+		-
+			message: '''
+				#^Fetching class constant INTRO of deprecated class Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotification instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 3
+			path: src/Module/BaseNotifications.php
+
+		-
+			message: '''
+				#^Fetching class constant NETWORK of deprecated class Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotification instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 3
+			path: src/Module/BaseNotifications.php
+
+		-
+			message: '''
+				#^Fetching class constant PERSONAL of deprecated class Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotification instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 3
+			path: src/Module/BaseNotifications.php
+
+		-
+			message: '''
+				#^Fetching class constant SYSTEM of deprecated class Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotification instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 3
+			path: src/Module/BaseNotifications.php
+
+		-
+			message: '''
+				#^Call to method setAllSeenForUser\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Item/Display.php
+
+		-
+			message: '''
+				#^Parameter \$notify of method Friendica\\Module\\Item\\Display\:\:__construct\(\) has typehint with deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: src/Module/Item/Display.php
+
+		-
+			message: '''
+				#^Access to property \$link of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 2
+			path: src/Module/Notifications/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$uid of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 2
+			path: src/Module/Notifications/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$uriId of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 2
+			path: src/Module/Notifications/Notification.php
+
+		-
+			message: '''
+				#^Call to method save\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notification.php
+
+		-
+			message: '''
+				#^Call to method selectOneById\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notification.php
+
+		-
+			message: '''
+				#^Call to method setAllSeenForRelatedNotify\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notification.php
+
+		-
+			message: '''
+				#^Call to method setAllSeenForUser\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notification.php
+
+		-
+			message: '''
+				#^Call to method setSeen\(\) of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notification.php
+
+		-
+			message: '''
+				#^Parameter \$notifyRepo of method Friendica\\Module\\Notifications\\Notification\:\:__construct\(\) has typehint with deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notification.php
+
+		-
+			message: '''
+				#^Call to method getHomeList\(\) of deprecated class Friendica\\Navigation\\Notifications\\Factory\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Factory\\FormattedNotification instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notifications.php
+
+		-
+			message: '''
+				#^Call to method getNetworkList\(\) of deprecated class Friendica\\Navigation\\Notifications\\Factory\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Factory\\FormattedNotification instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notifications.php
+
+		-
+			message: '''
+				#^Call to method getPersonalList\(\) of deprecated class Friendica\\Navigation\\Notifications\\Factory\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Factory\\FormattedNotification instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notifications.php
+
+		-
+			message: '''
+				#^Call to method getSystemList\(\) of deprecated class Friendica\\Navigation\\Notifications\\Factory\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Factory\\FormattedNotification instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notifications.php
+
+		-
+			message: '''
+				#^Fetching class constant HOME of deprecated class Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotification instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notifications.php
+
+		-
+			message: '''
+				#^Fetching class constant NETWORK of deprecated class Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotification instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notifications.php
+
+		-
+			message: '''
+				#^Fetching class constant PERSONAL of deprecated class Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotification instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notifications.php
+
+		-
+			message: '''
+				#^Fetching class constant SYSTEM of deprecated class Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\ValueObject\\FormattedNotification instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notifications.php
+
+		-
+			message: '''
+				#^Parameter \$formattedNotifyFactory of method Friendica\\Module\\Notifications\\Notifications\:\:__construct\(\) has typehint with deprecated class Friendica\\Navigation\\Notifications\\Factory\\FormattedNotify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Factory\\FormattedNotification instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Notifications.php
+
+		-
+			message: '''
+				#^Call to method shouldShowOnDesktop\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Ping.php
+
+		-
+			message: '''
+				#^Parameter \$notify of method Friendica\\Module\\Notifications\\Ping\:\:__construct\(\) has typehint with deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: src/Module/Notifications/Ping.php
+
+		-
+			message: '''
+				#^Call to deprecated method httpExit\(\) of class Friendica\\Core\\System\:
+				since 2023\.09 Use BaseModule\-\>httpExit\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: src/Module/Ping/Network.php
+
+		-
+			message: '''
+				#^Call to method createFromArray\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Register.php
+
+		-
+			message: '''
+				#^Call to method setAllSeenForUser\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/Update/Display.php
+
+		-
+			message: '''
+				#^Call to method countForUser\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Module/User/Delegation.php
+
+		-
+			message: '''
+				#^Parameter \$notify of method Friendica\\Module\\User\\Delegation\:\:__construct\(\) has typehint with deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: src/Module/User/Delegation.php
+
+		-
+			message: '''
+				#^Call to method setSeen\(\) of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Navigation/Notifications/Collection/Notifies.php
+
+		-
+			message: '''
+				#^Call to method formatMessage\(\) of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: staticMethod.deprecatedClass
+			count: 1
+			path: src/Navigation/Notifications/Factory/FormattedNavNotification.php
+
+		-
+			message: '''
+				#^Call to deprecated method getConfig\(\) of class GuzzleHttp\\Client\:
+				ClientInterface\:\:getConfig will be removed in guzzlehttp/guzzle\:8\.0\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Network/HTTPClient/Client/HttpClient.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: src/Network/HTTPClient/Client/HttpClient.php
+
+		-
+			message: '''
+				#^Call to deprecated method getHeaderArray\(\) of class Friendica\\Network\\HTTPClient\\Response\\CurlResult\:
+				2021\.10 Use getHeaders\(\) instead$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: src/Network/HTTPClient/Response/CurlResult.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Network/Probe.php
+
+		-
+			message: '''
+				#^Access to property \$date of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 2
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$id of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$itemId of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$link of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$msg of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$msg_cache of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$name of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$name_cache of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$otype of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$parent of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$photo of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$seen of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$type of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$uid of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$uriId of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$url of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Access to property \$verb of deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: property.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Parameter \$notify of method Friendica\\Object\\Api\\Friendica\\Notification\:\:__construct\(\) has typehint with deprecated class Friendica\\Navigation\\Notifications\\Entity\\Notify\:
+				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Entity\\Notification instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: src/Object/Api/Friendica/Notification.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Object/Api/Mastodon/Relationship.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: src/Protocol/ActivityPub/Processor.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Protocol/ActivityPub/Transmitter.php
+
+		-
+			message: '''
+				#^Call to method createFromArray\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
+				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: src/Protocol/DFRN.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Protocol/Delivery.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Protocol/Diaspora.php
+
+		-
+			message: '#^Call to deprecated function openssl_free_key\(\)\.$#'
+			identifier: function.deprecated
+			count: 2
+			path: src/Security/OAuth1/Signature/OAuthSignatureMethod_RSA_SHA1.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Worker/AddContact.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Worker/UpdateBlockedServers.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Worker/UpdateGServer.php
+
+		-
+			message: '''
+				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
+				2023\.03 Use isUriBlocked instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Worker/UpdateServerPeers.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Friendica\\Core\\Addon\\Model\\AddonLoader\:
+				2026\.01 Use implementation of `\\Friendica\\Core\\Addon\\AddonHelper` instead\.$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: static/dependencies.config.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Friendica\\Core\\Logger\\Factory\\StreamLogger\:
+				2026\.01 Implement `\\Friendica\\Core\\Logger\\Factory\\LoggerFactory` instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: static/dependencies.config.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated class Friendica\\Core\\Logger\\Factory\\SyslogLogger\:
+				2026\.01 Implement `\\Friendica\\Core\\Logger\\Factory\\LoggerFactory` instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: static/dependencies.config.php
+
+		-
+			message: '''
+				#^Access to constant on deprecated interface Friendica\\Core\\Addon\\Capability\\ICanLoadAddons\:
+				2026\.01 Use implementation of `\\Friendica\\Core\\Addon\\AddonHelper` instead\.$#
+			'''
+			identifier: classConstant.deprecatedInterface
+			count: 1
+			path: static/dependencies.config.php
 

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2010 - 2024 the Friendica project
+#
+# SPDX-License-Identifier: CC0-1.0
+
 parameters:
 	ignoreErrors:
 		-
@@ -197,24 +201,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Model/APContact.php
-
-		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 2
-			path: src/Model/Contact.php
-
-		-
-			message: '''
 				#^Call to method createFromArray\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
 				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
 			'''
@@ -236,24 +222,6 @@ parameters:
 			identifier: staticMethod.deprecated
 			count: 3
 			path: src/Model/GServer.php
-
-		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 8
-			path: src/Model/GServer.php
-
-		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 2
-			path: src/Model/Item.php
 
 		-
 			message: '''
@@ -713,30 +681,12 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 2
-			path: src/Network/HTTPClient/Client/HttpClient.php
-
-		-
-			message: '''
 				#^Call to deprecated method getHeaderArray\(\) of class Friendica\\Network\\HTTPClient\\Response\\CurlResult\:
 				2021\.10 Use getHeaders\(\) instead$#
 			'''
 			identifier: method.deprecated
 			count: 3
 			path: src/Network/HTTPClient/Response/CurlResult.php
-
-		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Network/Probe.php
 
 		-
 			message: '''
@@ -902,33 +852,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Object/Api/Mastodon/Relationship.php
-
-		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 2
-			path: src/Protocol/ActivityPub/Processor.php
-
-		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Protocol/ActivityPub/Transmitter.php
-
-		-
-			message: '''
 				#^Call to method createFromArray\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
 				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
 			'''
@@ -937,64 +860,10 @@ parameters:
 			path: src/Protocol/DFRN.php
 
 		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Protocol/Delivery.php
-
-		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Protocol/Diaspora.php
-
-		-
 			message: '#^Call to deprecated function openssl_free_key\(\)\.$#'
 			identifier: function.deprecated
 			count: 2
 			path: src/Security/OAuth1/Signature/OAuthSignatureMethod_RSA_SHA1.php
-
-		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Worker/AddContact.php
-
-		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Worker/UpdateBlockedServers.php
-
-		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Worker/UpdateGServer.php
-
-		-
-			message: '''
-				#^Call to deprecated method isUrlBlocked\(\) of class Friendica\\Util\\Network\:
-				2023\.03 Use isUriBlocked instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Worker/UpdateServerPeers.php
 
 		-
 			message: '''
@@ -1031,4 +900,3 @@ parameters:
 			identifier: classConstant.deprecatedInterface
 			count: 1
 			path: static/dependencies.config.php
-

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -57,15 +57,6 @@ parameters:
 
 		-
 			message: '''
-				#^Access to deprecated property \$factory of class Friendica\\BaseRepository\:
-				2026\.08 Implement getFactory\(\) instead$#
-			'''
-			identifier: property.deprecated
-			count: 1
-			path: src/BaseRepository.php
-
-		-
-			message: '''
 				#^Call to deprecated method getFactory\(\) of class Friendica\\BaseRepository\:
 				2026\.08 This method will become abstract in a future release, implement it in your child class instead\.$#
 			'''
@@ -180,15 +171,6 @@ parameters:
 			identifier: return.deprecatedClass
 			count: 1
 			path: src/DI.php
-
-		-
-			message: '''
-				#^Access to deprecated property \$factory of class Friendica\\BaseRepository\:
-				2026\.08 Implement getFactory\(\) instead$#
-			'''
-			identifier: property.deprecated
-			count: 1
-			path: src/Federation/Repository/DeliveryQueueItem.php
 
 		-
 			message: '''

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -93,33 +93,6 @@ parameters:
 
 		-
 			message: '''
-				#^Access to constant on deprecated class Friendica\\Core\\Logger\:
-				2026\.01 Use constructor injection or `DI\:\:logger\(\)` instead$#
-			'''
-			identifier: classConstant.deprecatedClass
-			count: 1
-			path: src/Core/Logger/Capability/IHaveCallIntrospections.php
-
-		-
-			message: '''
-				#^Access to constant on deprecated class Friendica\\Core\\Logger\\Factory\\Logger\:
-				2026\.01 Implement `\\Friendica\\Core\\Logger\\Factory\\LoggerFactory` instead$#
-			'''
-			identifier: classConstant.deprecatedClass
-			count: 1
-			path: src/Core/Logger/Capability/IHaveCallIntrospections.php
-
-		-
-			message: '''
-				#^Access to constant on deprecated class Friendica\\Core\\Logger\:
-				2026\.01 Use constructor injection or `DI\:\:logger\(\)` instead$#
-			'''
-			identifier: classConstant.deprecatedClass
-			count: 1
-			path: src/Core/Logger/Util/Introspection.php
-
-		-
-			message: '''
 				#^Access to constant on deprecated class Friendica\\Navigation\\Notifications\\Factory\\FormattedNotify\:
 				2022\.05 Use \\Friendica\\Navigation\\Notifications\\Factory\\FormattedNotification instead$#
 			'''

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -573,15 +573,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method httpExit\(\) of class Friendica\\Core\\System\:
-				since 2023\.09 Use BaseModule\-\>httpExit\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 3
-			path: src/Module/Ping/Network.php
-
-		-
-			message: '''
 				#^Call to method createFromArray\(\) of deprecated class Friendica\\Navigation\\Notifications\\Repository\\Notify\:
 				2022\.05 Use `\\Friendica\\Navigation\\Notifications\\Repository\\Notification` instead$#
 			'''
@@ -642,15 +633,6 @@ parameters:
 			identifier: method.deprecated
 			count: 1
 			path: src/Network/HTTPClient/Client/HttpClient.php
-
-		-
-			message: '''
-				#^Call to deprecated method getHeaderArray\(\) of class Friendica\\Network\\HTTPClient\\Response\\CurlResult\:
-				2021\.10 Use getHeaders\(\) instead$#
-			'''
-			identifier: method.deprecated
-			count: 3
-			path: src/Network/HTTPClient/Response/CurlResult.php
 
 		-
 			message: '''

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -183,15 +183,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method cleanURL\(\) of class Friendica\\Model\\GServer\:
-				2023\.03 Use cleanUri instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 3
-			path: src/Database/PostUpdate.php
-
-		-
-			message: '''
 				#^Access to deprecated property \$factory of class Friendica\\BaseRepository\:
 				2026\.08 Implement getFactory\(\) instead$#
 			'''
@@ -213,15 +204,6 @@ parameters:
 			identifier: function.deprecated
 			count: 4
 			path: src/Model/Event.php
-
-		-
-			message: '''
-				#^Call to deprecated method cleanURL\(\) of class Friendica\\Model\\GServer\:
-				2023\.03 Use cleanUri instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 3
-			path: src/Model/GServer.php
 
 		-
 			message: '''

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 includes:
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
     - .phpstan-baseline.neon

--- a/composer.json
+++ b/composer.json
@@ -164,6 +164,7 @@
 		"php-mock/php-mock-phpunit": "^2.15",
 		"phpmd/phpmd": "^2.15",
 		"phpstan/phpstan": "^2.1.39",
+		"phpstan/phpstan-deprecation-rules": "^2.0",
 		"phpstan/phpstan-phpunit": "^2.0",
 		"phpstan/phpstan-strict-rules": "^2.0.10",
 		"phpunit/phpunit": "^11.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7bee376833783198f5eedc6b953e49a",
+    "content-hash": "578732c92907f7648eb5dcb789676e61",
     "packages": [
         {
             "name": "asika/simple-console",
@@ -7106,6 +7106,56 @@
                 }
             ],
             "time": "2026-06-05T09:00:01+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "6b5571001a7f04fa0422254c30a0017ec2f2cacc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/6b5571001a7f04fa0422254c30a0017ec2f2cacc",
+                "reference": "6b5571001a7f04fa0422254c30a0017ec2f2cacc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.39"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/2.0.4"
+            },
+            "time": "2026-02-09T13:21:14+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -54,7 +54,7 @@ abstract class BaseRepository
 	}
 
 	/**
-	 * Returns the TableRowFactor
+	 * Returns the TableRowFactory
 	 *
 	 * @deprecated 2026.08 This method will become abstract in a future release, implement it in your child class instead.
 	 */

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -50,7 +50,7 @@ abstract class BaseRepository
 	{
 		$this->db      = $database;
 		$this->logger  = $logger;
-		$this->factory = $factory;
+		$this->factory = $factory; // @phpstan-ignore property.deprecated (self-call in deprecated flow)
 	}
 
 	/**

--- a/src/Contact/FriendSuggest/Repository/FriendSuggest.php
+++ b/src/Contact/FriendSuggest/Repository/FriendSuggest.php
@@ -30,6 +30,7 @@ class FriendSuggest extends BaseRepository
 		parent::__construct($database, $logger, $entityFactory);
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): FriendSuggestFactory
 	{
 		return $this->entityFactory;

--- a/src/Contact/Introduction/Repository/Introduction.php
+++ b/src/Contact/Introduction/Repository/Introduction.php
@@ -30,6 +30,7 @@ class Introduction extends BaseRepository
 		parent::__construct($database, $logger, $entityFactory);
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): IntroductionFactory
 	{
 		return $this->entityFactory;

--- a/src/Contact/LocalRelationship/Repository/LocalRelationship.php
+++ b/src/Contact/LocalRelationship/Repository/LocalRelationship.php
@@ -61,6 +61,7 @@ class LocalRelationship extends BaseRepository
 		return $this->exists(['uid' => $uid, 'cid' => $cid]);
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): LocalRelationshipFactory
 	{
 		return $this->entityFactory;

--- a/src/Content/Conversation/Repository/UserDefinedChannel.php
+++ b/src/Content/Conversation/Repository/UserDefinedChannel.php
@@ -48,6 +48,7 @@ class UserDefinedChannel extends BaseRepository
 		parent::__construct($database, $logger, $entityFactory);
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): UserDefinedChannelFactory
 	{
 		return $this->entityFactory;

--- a/src/Content/Post/Repository/PostMedia.php
+++ b/src/Content/Post/Repository/PostMedia.php
@@ -53,6 +53,7 @@ class PostMedia extends BaseRepository
 		parent::__construct($database, $logger, $entityFactory);
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): PostMediaFactory
 	{
 		return $this->entityFactory;

--- a/src/Core/Logger/Capability/IHaveCallIntrospections.php
+++ b/src/Core/Logger/Capability/IHaveCallIntrospections.php
@@ -15,8 +15,8 @@ interface IHaveCallIntrospections
 	 * @var string[]
 	 */
 	public const IGNORE_CLASS_LIST = [
-		\Friendica\Core\Logger::class,
-		\Friendica\Core\Logger\Factory\Logger::class,
+		\Friendica\Core\Logger::class, // @phpstan-ignore classConstant.deprecatedClass
+		\Friendica\Core\Logger\Factory\Logger::class, // @phpstan-ignore classConstant.deprecatedClass
 		'Friendica\\Core\\Logger\\Type',
 		\Friendica\Util\Profiler::class,
 	];

--- a/src/Core/Logger/Util/Introspection.php
+++ b/src/Core/Logger/Util/Introspection.php
@@ -65,7 +65,7 @@ class Introspection implements IHaveCallIntrospections
 			'line'       => $trace[$i - 1]['line'] ?? null,
 			'function'   => $trace[$i]['function'] ?? null,
 			'request-id' => $this->requestId,
-			'stack'      => System::callstack(15, 1, [\Friendica\Core\Logger\Type\StreamLogger::class, \Friendica\Core\Logger\Type\AbstractLogger::class, \Friendica\Core\Logger\Type\WorkerLogger::class, \Friendica\Core\Logger::class]),
+			'stack'      => System::callstack(15, 1, [\Friendica\Core\Logger\Type\StreamLogger::class, \Friendica\Core\Logger\Type\AbstractLogger::class, \Friendica\Core\Logger\Type\WorkerLogger::class, \Friendica\Core\Logger::class]), // @phpstan-ignore classConstant.deprecatedClass
 		];
 	}
 

--- a/src/Core/Worker/Repository/Process.php
+++ b/src/Core/Worker/Repository/Process.php
@@ -86,6 +86,7 @@ class Process extends BaseRepository
 		}
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): ProcessFactory
 	{
 		return $this->entityFactory;

--- a/src/DI.php
+++ b/src/DI.php
@@ -657,7 +657,6 @@ abstract class DI
 
 	/**
 	 * @internal The EventDispatcher should never called outside of the core, like in addons or themes
-	 * @deprecated 2026.01 Use constructor injection instead
 	 */
 	public static function eventDispatcher(): \Psr\EventDispatcher\EventDispatcherInterface
 	{

--- a/src/Database/PostUpdate.php
+++ b/src/Database/PostUpdate.php
@@ -650,7 +650,7 @@ class PostUpdate
 
 			DBA::update(
 				'contact',
-				['gsid' => GServer::getRealID($contact['baseurl'], true), 'baseurl' => GServer::cleanURL($contact['baseurl'])],
+				['gsid' => GServer::getRealID($contact['baseurl'], true), 'baseurl' => (string) GServer::cleanUri(new Uri($contact['baseurl']))],
 				['id'   => $contact['id']],
 			);
 
@@ -705,7 +705,7 @@ class PostUpdate
 
 			DBA::update(
 				'apcontact',
-				['gsid' => GServer::getRealID($apcontact['baseurl'], true), 'baseurl' => GServer::cleanURL($apcontact['baseurl'])],
+				['gsid' => GServer::getRealID($apcontact['baseurl'], true), 'baseurl' => (string) GServer::cleanUri(new Uri($apcontact['baseurl']))],
 				['url'  => $apcontact['url']],
 			);
 
@@ -1243,7 +1243,7 @@ class PostUpdate
 
 			DBA::update(
 				'contact',
-				['gsid' => GServer::getRealID($server, true), 'baseurl' => GServer::cleanURL($server)],
+				['gsid' => GServer::getRealID($server, true), 'baseurl' => (string) GServer::cleanUri(new Uri($server))],
 				['id'   => $contact['id']],
 			);
 

--- a/src/Federation/Repository/DeliveryQueueItem.php
+++ b/src/Federation/Repository/DeliveryQueueItem.php
@@ -19,9 +19,18 @@ final class DeliveryQueueItem extends \Friendica\BaseRepository
 {
 	protected static $table_name = 'delivery-queue';
 
-	public function __construct(Database $database, LoggerInterface $logger, Factory\DeliveryQueueItem $factory)
+	public function __construct(
+		Database $database,
+		LoggerInterface $logger,
+		private readonly Factory\DeliveryQueueItem $entityFactory,
+	) {
+		parent::__construct($database, $logger, $entityFactory);
+	}
+
+	/** @not-deprecated */
+	protected function getFactory(): Factory\DeliveryQueueItem
 	{
-		parent::__construct($database, $logger, $factory);
+		return $this->entityFactory;
 	}
 
 	public function selectByServerId(int $gsid, int $maxFailedCount): Collection\DeliveryQueueItems
@@ -35,7 +44,7 @@ final class DeliveryQueueItem extends \Friendica\BaseRepository
 			['order' => ['created']]
 		);
 		while ($deliveryQueueItem = $this->db->fetch($deliveryQueueItems)) {
-			$Entities[] = $this->factory->createFromTableRow($deliveryQueueItem);
+			$Entities[] = $this->getFactory()->createFromTableRow($deliveryQueueItem);
 		}
 
 		$this->db->close($deliveryQueueItems);

--- a/src/Federation/Repository/DeliveryQueueItem.php
+++ b/src/Federation/Repository/DeliveryQueueItem.php
@@ -41,7 +41,7 @@ final class DeliveryQueueItem extends \Friendica\BaseRepository
 			self::$table_name,
 			[],
 			["`gsid` = ? AND `failed` < ?", $gsid, $maxFailedCount],
-			['order' => ['created']]
+			['order' => ['created']],
 		);
 		while ($deliveryQueueItem = $this->db->fetch($deliveryQueueItems)) {
 			$Entities[] = $this->getFactory()->createFromTableRow($deliveryQueueItem);
@@ -85,7 +85,7 @@ final class DeliveryQueueItem extends \Friendica\BaseRepository
 	{
 		return $this->db->delete(self::$table_name, [
 			'uri-id' => $deliveryQueueItem->postUriId,
-			'gsid'   => $deliveryQueueItem->targetServerId
+			'gsid'   => $deliveryQueueItem->targetServerId,
 		]);
 	}
 
@@ -97,11 +97,11 @@ final class DeliveryQueueItem extends \Friendica\BaseRepository
 	public function incrementFailed(Entity\DeliveryQueueItem $deliveryQueueItem): bool
 	{
 		return $this->db->update(self::$table_name, [
-			"`failed` = `failed` + 1"
+			"`failed` = `failed` + 1",
 		], [
 			"`uri-id` = ? AND `gsid` = ?",
 			$deliveryQueueItem->postUriId,
-			$deliveryQueueItem->targetServerId
+			$deliveryQueueItem->targetServerId,
 		]);
 	}
 

--- a/src/Model/APContact.php
+++ b/src/Model/APContact.php
@@ -107,7 +107,7 @@ class APContact
 	 */
 	public static function getByURL(string $url, ?bool $update = null): array
 	{
-		if (empty($url) || Network::isUrlBlocked($url)) {
+		if (empty($url) || Network::isUriBlocked(new Uri($url))) {
 			DI::logger()->info('Domain is blocked', ['url' => $url]);
 			return [];
 		}

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -39,6 +39,7 @@ use Friendica\Worker\AddContact;
 use Friendica\Worker\ContactDiscovery;
 use Friendica\Worker\ContactDiscoveryForUser;
 use Friendica\Worker\UpdateContact;
+use GuzzleHttp\Psr7\Uri;
 
 /**
  * functions for interacting with a contact
@@ -1592,7 +1593,7 @@ class Contact
 			return false;
 		}
 
-		if (Network::isUrlBlocked($blocked['url'])) {
+		if (Network::isUriBlocked(new Uri($blocked['url']))) {
 			return true;
 		}
 
@@ -3139,7 +3140,7 @@ class Contact
 			return $result;
 		}
 
-		if (Network::isUrlBlocked($url)) {
+		if (Network::isUriBlocked(new Uri($url))) {
 			$result['message'] = DI::l10n()->t('Blocked domain');
 			return $result;
 		}

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -109,7 +109,7 @@ class GServer
 	 */
 	public static function getID(string $url, bool $no_check = false): ?int
 	{
-		$url = self::cleanURL($url);
+		$url = (string) self::cleanUri(new Uri($url));
 
 		if (empty($url)) {
 			return null;
@@ -359,7 +359,7 @@ class GServer
 	 */
 	public static function check(string $server_url, string $network = '', bool $force = false, bool $only_nodeinfo = false): bool
 	{
-		$server_url = self::cleanURL($server_url);
+		$server_url = (string) self::cleanUri(new Uri($server_url));
 		if ($server_url == '') {
 			return false;
 		}
@@ -569,7 +569,7 @@ class GServer
 		$original_url = $url;
 
 		// Remove URL content that is not supposed to exist for a server url
-		$url = rtrim(self::cleanURL($url), '/');
+		$url = rtrim((string) self::cleanUri(new Uri($url)), '/');
 		if (empty($url)) {
 			DI::logger()->notice('Empty URL.');
 			return false;

--- a/src/Model/GServer.php
+++ b/src/Model/GServer.php
@@ -119,7 +119,7 @@ class GServer
 		if (DBA::isResult($gserver)) {
 			DI::logger()->debug('Got ID for URL', ['id' => $gserver['id'], 'url' => $url]);
 
-			if (Network::isUrlBlocked($url)) {
+			if (Network::isUriBlocked(new Uri($url))) {
 				self::setBlockedById($gserver['id']);
 			} else {
 				self::setUnblockedById($gserver['id']);
@@ -364,7 +364,7 @@ class GServer
 			return false;
 		}
 
-		if (Network::isUrlBlocked($server_url)) {
+		if (Network::isUriBlocked(new Uri($server_url))) {
 			DI::logger()->info('Server is blocked', ['url' => $server_url]);
 			self::setBlockedByUrl($server_url);
 			return false;
@@ -403,7 +403,7 @@ class GServer
 			return;
 		}
 
-		$blocked = Network::isUrlBlocked($gserver['url']);
+		$blocked = Network::isUriBlocked(new Uri($gserver['url']));
 		if ($gserver['failed']) {
 			$fields = ['failed' => false, 'blocked' => $blocked, 'last_contact' => DateTimeFormat::utcNow()];
 			if (!empty($network) && !in_array($gserver['network'], Protocol::FEDERATED)) {
@@ -431,7 +431,7 @@ class GServer
 	{
 		$gserver = DBA::selectFirst('gserver', ['url', 'failed', 'next_contact'], ['id' => $gsid]);
 		if (DBA::isResult($gserver) && !$gserver['failed']) {
-			self::update(['failed' => true, 'blocked' => Network::isUrlBlocked($gserver['url']), 'last_failure' => DateTimeFormat::utcNow()], ['id' => $gsid]);
+			self::update(['failed' => true, 'blocked' => Network::isUriBlocked(new Uri($gserver['url'])), 'last_failure' => DateTimeFormat::utcNow()], ['id' => $gsid]);
 			DI::logger()->info('Set failed status for server', ['url' => $gserver['url']]);
 
 			if (strtotime((string) $gserver['next_contact']) < time()) {
@@ -481,7 +481,7 @@ class GServer
 		if (DBA::isResult($gserver)) {
 			$next_update = self::getNextUpdateDate(false, $gserver['created'], $gserver['last_contact']);
 			self::update(
-				['url'          => $url, 'failed' => true, 'blocked' => Network::isUrlBlocked($url), 'last_failure' => DateTimeFormat::utcNow(),
+				['url'          => $url, 'failed' => true, 'blocked' => Network::isUriBlocked(new Uri($url)), 'last_failure' => DateTimeFormat::utcNow(),
 					'next_contact' => $next_update, 'network' => Protocol::PHANTOM, 'detection-method' => null],
 				['nurl' => $nurl],
 			);
@@ -578,7 +578,7 @@ class GServer
 		// If the URL mismatches, then we mark the old entry as failure
 		if (!Strings::compareLink($url, $original_url)) {
 			self::setFailureByUrl($original_url);
-			if (!self::getID($url, true) && !Network::isUrlBlocked($url)) {
+			if (!self::getID($url, true) && !Network::isUriBlocked(new Uri($url))) {
 				self::detect($url, $network, $only_nodeinfo);
 			}
 			return false;
@@ -600,7 +600,7 @@ class GServer
 				DI::logger()->debug('Found redirect. Mark old entry as failure', ['old' => $url, 'new' => $valid_url]);
 				self::setFailureByUrl($url);
 				$target_id = self::getID($valid_url, true);
-				if (!$target_id && !Network::isUrlBlocked($valid_url)) {
+				if (!$target_id && !Network::isUriBlocked(new Uri($valid_url))) {
 					self::detect($valid_url, $network, $only_nodeinfo);
 					$target_id = self::getID($valid_url, true);
 				}
@@ -618,7 +618,7 @@ class GServer
 				$valid_url = (string) Uri::fromParts($parts);
 
 				self::setFailureByUrl($url);
-				if (!self::getID($valid_url, true) && !Network::isUrlBlocked($valid_url)) {
+				if (!self::getID($valid_url, true) && !Network::isUriBlocked(new Uri($valid_url))) {
 					self::detect($valid_url, $network, $only_nodeinfo);
 				}
 				return false;

--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -552,7 +552,7 @@ class Item
 			return false;
 		}
 
-		if (!empty($item['author-link']) && Network::isUrlBlocked($item['author-link'])) {
+		if (!empty($item['author-link']) && Network::isUriBlocked(new Uri($item['author-link']))) {
 			DI::logger()->notice('Author server is blocked', ['author-link' => $item['author-link'], 'item-uri' => $item['uri']]);
 			return false;
 		}
@@ -562,7 +562,7 @@ class Item
 			return false;
 		}
 
-		if (!empty($item['owner-link']) && Network::isUrlBlocked($item['owner-link'])) {
+		if (!empty($item['owner-link']) && Network::isUriBlocked(new Uri($item['owner-link']))) {
 			DI::logger()->notice('Owner server is blocked', ['owner-link' => $item['owner-link'], 'item-uri' => $item['uri']]);
 			return false;
 		}

--- a/src/Moderation/Repository/Report.php
+++ b/src/Moderation/Repository/Report.php
@@ -101,6 +101,8 @@ final class Report extends \Friendica\BaseRepository
 
 	/**
 	 * @throws NotFoundException
+	 *
+	 * @not-deprecated
 	 */
 	protected function _selectOne(array $condition, array $params = []): ReportEntity
 	{

--- a/src/Moderation/Repository/Report.php
+++ b/src/Moderation/Repository/Report.php
@@ -93,6 +93,7 @@ final class Report extends \Friendica\BaseRepository
 		return $Report;
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): ReportFactory
 	{
 		return $this->entityFactory;

--- a/src/Module/Ping/Network.php
+++ b/src/Module/Ping/Network.php
@@ -116,13 +116,13 @@ class Network extends NetworkModule
 		$this->parseRequest($request);
 
 		if ($this->force || !is_null($this->maxId)) {
-			System::httpExit('');
+			$this->httpExit('');
 		}
 
 		$lockkey = 'network-ping-' . $this->session->getLocalUserId();
 		if (!$this->lock->acquire($lockkey, 0)) {
 			$this->logger->debug('Ping-1-lock', ['uid' => $this->session->getLocalUserId()]);
-			System::httpExit('');
+			$this->httpExit('');
 		}
 
 		$this->setPing(true);
@@ -137,6 +137,6 @@ class Network extends NetworkModule
 		}
 		$this->lock->release($lockkey);
 		$count = count($items);
-		System::httpExit(($count < 100) ? $count : '99+');
+		$this->httpExit(($count < 100) ? $count : '99+');
 	}
 }

--- a/src/Navigation/Notifications/Repository/Notification.php
+++ b/src/Navigation/Notifications/Repository/Notification.php
@@ -36,6 +36,7 @@ class Notification extends BaseRepository
 		parent::__construct($database, $logger, $entityFactory);
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): NotificationFactory
 	{
 		return $this->entityFactory;

--- a/src/Navigation/Notifications/Repository/Notify.php
+++ b/src/Navigation/Notifications/Repository/Notify.php
@@ -75,6 +75,7 @@ class Notify extends BaseRepository
 		parent::__construct($database, $logger, $this->entityFactory);
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): NotifyFactory
 	{
 		return $this->entityFactory;

--- a/src/Network/HTTPClient/Capability/ICanHandleHttpResponses.php
+++ b/src/Network/HTTPClient/Capability/ICanHandleHttpResponses.php
@@ -60,7 +60,7 @@ interface ICanHandleHttpResponses
 	/**
 	 * Returns the headers as an associated array
 	 * @see MessageInterface::getHeaders()
-	 * @deprecated
+	 * @deprecated 2021.10 Use getHeaders() instead
 	 *
 	 * @return string[][] associated header array
 	 */

--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -78,7 +78,7 @@ class HttpClient implements ICanSendHttpRequests
 		$parts['path'] = implode('/', $parts2);
 		$url           = (string) Uri::fromParts((array) $parts);
 
-		if (Network::isUrlBlocked($url)) {
+		if (Network::isUriBlocked(new Uri($url))) {
 			$this->logger->info('Domain is blocked.', ['url' => $url]);
 			$this->profiler->stopRecording();
 			return CurlResult::createErrorCurl($this->logger, $url);
@@ -232,7 +232,7 @@ class HttpClient implements ICanSendHttpRequests
 			$this->logger->debug('Local link', ['url' => $url]);
 		}
 
-		if (Network::isUrlBlocked($url)) {
+		if (Network::isUriBlocked(new Uri($url))) {
 			$this->logger->info('Domain is blocked.', ['url' => $url]);
 			return $url;
 		}

--- a/src/Network/HTTPClient/Response/CurlResult.php
+++ b/src/Network/HTTPClient/Response/CurlResult.php
@@ -287,7 +287,11 @@ class CurlResult implements ICanHandleHttpResponses
 		return array_key_exists($field, $headers);
 	}
 
-
+	/** {@inheritDoc} */
+	public function getHeaderArray(): array
+	{
+		return $this->getHeaders();
+	}
 
 	/** {@inheritDoc} */
 	public function isSuccess(): bool

--- a/src/Network/HTTPClient/Response/CurlResult.php
+++ b/src/Network/HTTPClient/Response/CurlResult.php
@@ -248,29 +248,13 @@ class CurlResult implements ICanHandleHttpResponses
 
 		$header = strtolower(trim($header));
 
-		$headers = $this->getHeaderArray();
+		$headers = $this->getHeaders();
 
 		return $headers[$header] ?? [];
 	}
 
 	/** {@inheritDoc} */
 	public function getHeaders(): array
-	{
-		return $this->getHeaderArray();
-	}
-
-	/** {@inheritDoc} */
-	public function inHeader(string $field): bool
-	{
-		$field = strtolower(trim($field));
-
-		$headers = $this->getHeaderArray();
-
-		return array_key_exists($field, $headers);
-	}
-
-	/** {@inheritDoc} */
-	public function getHeaderArray(): array
 	{
 		if (!empty($this->header_fields)) {
 			return $this->header_fields;
@@ -292,6 +276,18 @@ class CurlResult implements ICanHandleHttpResponses
 
 		return $this->header_fields;
 	}
+
+	/** {@inheritDoc} */
+	public function inHeader(string $field): bool
+	{
+		$field = strtolower(trim($field));
+
+		$headers = $this->getHeaders();
+
+		return array_key_exists($field, $headers);
+	}
+
+
 
 	/** {@inheritDoc} */
 	public function isSuccess(): bool

--- a/src/Network/Probe.php
+++ b/src/Network/Probe.php
@@ -474,7 +474,7 @@ class Probe
 	 */
 	private static function getWebfinger(string $template, string $type, string $uri, string $addr): ?array
 	{
-		if (Network::isUrlBlocked($template)) {
+		if (Network::isUriBlocked(new Uri($template))) {
 			DI::logger()->info('Domain is blocked', ['url' => $template]);
 			return null;
 		}

--- a/src/Object/Api/Mastodon/Relationship.php
+++ b/src/Object/Api/Mastodon/Relationship.php
@@ -10,6 +10,7 @@ namespace Friendica\Object\Api\Mastodon;
 use Friendica\BaseDataTransferObject;
 use Friendica\Model\Contact;
 use Friendica\Util\Network;
+use GuzzleHttp\Psr7\Uri;
 
 /**
  * Class Relationship
@@ -79,7 +80,7 @@ class Relationship extends BaseDataTransferObject
 		$this->showing_reblogs      = true;
 		$this->notifying            = false;
 		$this->blocking             = $blocked;
-		$this->domain_blocking      = Network::isUrlBlocked($contactRecord['url'] ?? '');
+		$this->domain_blocking      = Network::isUriBlocked(new Uri($contactRecord['url'] ?? ''));
 		$this->blocked_by           = false;
 		$this->note                 = '';
 

--- a/src/Profile/ProfileField/Repository/ProfileField.php
+++ b/src/Profile/ProfileField/Repository/ProfileField.php
@@ -39,6 +39,7 @@ class ProfileField extends BaseRepository
 		$this->permissionSetRepository = $permissionSetRepository;
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): ProfileFieldFactory
 	{
 		return $this->entityFactory;

--- a/src/Protocol/ActivityPub/Processor.php
+++ b/src/Protocol/ActivityPub/Processor.php
@@ -39,6 +39,7 @@ use Friendica\Util\JsonLD;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
 use Friendica\Worker\FetchMissingActivity;
+use GuzzleHttp\Psr7\Uri;
 
 /**
  * ActivityPub Processor Protocol class
@@ -703,7 +704,7 @@ class Processor
 	 */
 	public static function isActivityGone(string $url): bool
 	{
-		if (Network::isUrlBlocked($url)) {
+		if (Network::isUriBlocked(new Uri($url))) {
 			return true;
 		}
 
@@ -1762,7 +1763,7 @@ class Processor
 	 */
 	public static function fetchMissingActivity(string $url, array $child = [], string $relay_actor = '', int $completion = Receiver::COMPLETION_MANUAL, int $uid = 0): ?string
 	{
-		if (Network::isUrlBlocked($url)) {
+		if (Network::isUriBlocked(new Uri($url))) {
 			return null;
 		}
 

--- a/src/Protocol/ActivityPub/Transmitter.php
+++ b/src/Protocol/ActivityPub/Transmitter.php
@@ -34,6 +34,7 @@ use Friendica\Util\Map;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
+use GuzzleHttp\Psr7\Uri;
 
 /**
  * ActivityPub Transmitter Protocol class
@@ -1080,7 +1081,7 @@ class Transmitter
 			$blindcopy = in_array($element, ['bcc']);
 
 			foreach ($permissions[$element] as $receiver) {
-				if (empty($receiver) || Network::isUrlBlocked($receiver)) {
+				if (empty($receiver) || Network::isUriBlocked(new Uri($receiver))) {
 					continue;
 				}
 

--- a/src/Protocol/Delivery.php
+++ b/src/Protocol/Delivery.php
@@ -19,6 +19,7 @@ use Friendica\Model\Item;
 use Friendica\Model\Post;
 use Friendica\Model\User;
 use Friendica\Util\Network;
+use GuzzleHttp\Psr7\Uri;
 
 class Delivery
 {
@@ -195,7 +196,7 @@ class Delivery
 			return true;
 		}
 
-		if (Network::isUrlBlocked($contact['url'])) {
+		if (Network::isUriBlocked(new Uri($contact['url']))) {
 			self::setFailedQueue($cmd, $target_item);
 			return true;
 		}

--- a/src/Protocol/Diaspora.php
+++ b/src/Protocol/Diaspora.php
@@ -859,7 +859,7 @@ class Diaspora
 		//}
 
 		// Contact server is blocked
-		if (Network::isUrlBlocked($contact['url'])) {
+		if (Network::isUriBlocked(new Uri($contact['url']))) {
 			return false;
 			// We don't seem to like that person
 		} elseif ($contact['blocked']) {

--- a/src/Protocol/Diaspora/Repository/DiasporaContact.php
+++ b/src/Protocol/Diaspora/Repository/DiasporaContact.php
@@ -268,6 +268,7 @@ class DiasporaContact extends BaseRepository
 		return $diasporaContact['url'] ?? null;
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): DiasporaContactFactory
 	{
 		return $this->entityFactory;

--- a/src/Security/OAuth1/Signature/OAuthSignatureMethod_RSA_SHA1.php
+++ b/src/Security/OAuth1/Signature/OAuthSignatureMethod_RSA_SHA1.php
@@ -52,9 +52,6 @@ abstract class OAuthSignatureMethod_RSA_SHA1 extends OAuthSignatureMethod
 		// Sign using the key
 		openssl_sign($base_string, $signature, $privatekeyid);
 
-		// Release the key resource
-		openssl_free_key($privatekeyid);
-
 		return base64_encode((string) $signature);
 	}
 
@@ -72,9 +69,6 @@ abstract class OAuthSignatureMethod_RSA_SHA1 extends OAuthSignatureMethod
 
 		// Check the computed signature against the one passed in the query
 		$ok = openssl_verify($base_string, $decoded_sig, $publickeyid);
-
-		// Release the key resource
-		openssl_free_key($publickeyid);
 
 		return $ok == 1;
 	}

--- a/src/Security/PermissionSet/Repository/PermissionSet.php
+++ b/src/Security/PermissionSet/Repository/PermissionSet.php
@@ -37,6 +37,7 @@ class PermissionSet extends BaseRepository
 		parent::__construct($database, $logger, $entityFactory);
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): PermissionSetFactory
 	{
 		return $this->entityFactory;

--- a/src/User/Settings/Repository/UserGServer.php
+++ b/src/User/Settings/Repository/UserGServer.php
@@ -106,6 +106,7 @@ class UserGServer extends BaseRepository
 		return $this->entityFactory;
 	}
 
+	/** @not-deprecated */
 	protected function _selectOne(array $condition, array $params = [], bool $hydrate = true): UserGServerEntity
 	{
 		$fields = $this->db->selectFirst(static::$table_name, [], $condition, $params);

--- a/src/User/Settings/Repository/UserGServer.php
+++ b/src/User/Settings/Repository/UserGServer.php
@@ -100,6 +100,7 @@ class UserGServer extends BaseRepository
 		}
 	}
 
+	/** @not-deprecated */
 	protected function getFactory(): UserGServerFactory
 	{
 		return $this->entityFactory;

--- a/src/Worker/AddContact.php
+++ b/src/Worker/AddContact.php
@@ -14,6 +14,7 @@ use Friendica\Model\Contact;
 use Friendica\Network\HTTPException\InternalServerErrorException;
 use Friendica\Network\HTTPException\NotFoundException;
 use Friendica\Util\Network;
+use GuzzleHttp\Psr7\Uri;
 
 class AddContact
 {
@@ -67,7 +68,7 @@ class AddContact
 	 */
 	public static function add($run_parameters, int $uid, string $url, string $circle = ''): int
 	{
-		if (Network::isUrlBlocked($url)) {
+		if (Network::isUriBlocked(new Uri($url))) {
 			return 0;
 		}
 

--- a/src/Worker/UpdateBlockedServers.php
+++ b/src/Worker/UpdateBlockedServers.php
@@ -11,6 +11,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\GServer;
 use Friendica\Util\Network;
+use GuzzleHttp\Psr7\Uri;
 
 class UpdateBlockedServers
 {
@@ -24,7 +25,7 @@ class UpdateBlockedServers
 		$changed   = 0;
 		$unchanged = 0;
 		while ($gserver = DBA::fetch($gservers)) {
-			$blocked = Network::isUrlBlocked($gserver['url']);
+			$blocked = Network::isUriBlocked(new Uri($gserver['url']));
 			if (!is_null($gserver['blocked']) && ($blocked == $gserver['blocked'])) {
 				$unchanged++;
 				continue;

--- a/src/Worker/UpdateGServer.php
+++ b/src/Worker/UpdateGServer.php
@@ -77,7 +77,7 @@ class UpdateGServer
 	public static function add($run_parameters, string $serverUrl, bool $onlyNodeInfo = false): int
 	{
 		// Dropping the worker task if the server domain is blocked
-		if (Network::isUrlBlocked($serverUrl)) {
+		if (Network::isUriBlocked(new Uri($serverUrl))) {
 			GServer::setBlockedByUrl($serverUrl);
 			return 0;
 		}

--- a/src/Worker/UpdateServerPeers.php
+++ b/src/Worker/UpdateServerPeers.php
@@ -16,6 +16,7 @@ use Friendica\Network\HTTPClient\Client\HttpClientOptions;
 use Friendica\Network\HTTPClient\Client\HttpClientRequest;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
+use GuzzleHttp\Psr7\Uri;
 
 class UpdateServerPeers
 {
@@ -53,7 +54,7 @@ class UpdateServerPeers
 		$total = 0;
 		$added = 0;
 		foreach ($peers as $peer) {
-			if (Network::isUrlBlocked('https://' . $peer)) {
+			if (Network::isUriBlocked(new Uri('https://' . $peer))) {
 				// Ignore blocked systems as soon as possible in the loop to avoid being slowed down by tar pits
 				continue;
 			}

--- a/tests/Unit/Network/HTTPClient/Response/CurlResultTest.php
+++ b/tests/Unit/Network/HTTPClient/Response/CurlResultTest.php
@@ -136,7 +136,7 @@ class CurlResultTest extends TestCase
 			'url'          => 'https://test.local',
 		]);
 
-		$headers = $curlResult->getHeaderArray();
+		$headers = $curlResult->getHeaderArray(); // @phpstan-ignore method.deprecated (testing the deprecated method itself)
 
 		self::assertNotEmpty($headers);
 		self::assertArrayHasKey('vary', $headers);

--- a/tests/src/Core/Addon/Model/AddonLoaderTest.php
+++ b/tests/src/Core/Addon/Model/AddonLoaderTest.php
@@ -133,9 +133,9 @@ EOF;
 		$config = \Mockery::mock(IManageConfigValues::class);
 		$config->shouldReceive('get')->with('addons')->andReturn($configArray)->once();
 
-		$addonLoader = new AddonLoader($this->root->url(), $config);
+		$addonLoader = new AddonLoader($this->root->url(), $config); // @phpstan-ignore method.deprecatedClass, new.deprecatedClass (testing the deprecated class)
 
-		self::assertEquals($assertion, $addonLoader->getActiveAddonConfig('hooks'));
+		self::assertEquals($assertion, $addonLoader->getActiveAddonConfig('hooks')); // @phpstan-ignore method.deprecatedClass (testing the deprecated method on AddonLoader)
 	}
 
 	/**
@@ -160,12 +160,12 @@ EOF;
 		$config = \Mockery::mock(IManageConfigValues::class);
 		$config->shouldReceive('get')->with('addons')->andReturn($configArray)->once();
 
-		$addonLoader = new AddonLoader($this->root->url(), $config);
+		$addonLoader = new AddonLoader($this->root->url(), $config); // @phpstan-ignore method.deprecatedClass, new.deprecatedClass (testing the deprecated class)
 
 		self::expectException(AddonInvalidConfigFileException::class);
 		self::expectExceptionMessage(sprintf('Error loading config file %s', $this->root->getChild($filename)->url()));
 
-		$addonLoader->getActiveAddonConfig('hooks');
+		$addonLoader->getActiveAddonConfig('hooks'); // @phpstan-ignore method.deprecatedClass (testing the deprecated method on AddonLoader)
 	}
 
 	/**
@@ -190,7 +190,7 @@ EOF;
 		$config = \Mockery::mock(IManageConfigValues::class);
 		$config->shouldReceive('get')->with('addons')->andReturn($configArray)->once();
 
-		$addonLoader = new AddonLoader($this->root->url(), $config);
-		self::assertEmpty($addonLoader->getActiveAddonConfig('anythingElse'));
+		$addonLoader = new AddonLoader($this->root->url(), $config); // @phpstan-ignore method.deprecatedClass, new.deprecatedClass (testing the deprecated class)
+		self::assertEmpty($addonLoader->getActiveAddonConfig('anythingElse')); // @phpstan-ignore method.deprecatedClass (testing the deprecated method on AddonLoader)
 	}
 }

--- a/tests/src/Core/Logger/StreamLoggerTest.php
+++ b/tests/src/Core/Logger/StreamLoggerTest.php
@@ -43,8 +43,8 @@ class StreamLoggerTest extends LoggerTestCase
 		$this->config->shouldReceive('get')->with('system', 'logfile')->andReturn($this->logfile->url())->once();
 		$this->config->shouldReceive('get')->with('system', 'loglevel')->andReturn($level)->once();
 
-		$loggerFactory = new \Friendica\Core\Logger\Factory\StreamLogger($this->introspection, 'test');
-		return $loggerFactory->create($this->config);
+		$loggerFactory = new \Friendica\Core\Logger\Factory\StreamLogger($this->introspection, 'test'); // @phpstan-ignore method.deprecatedClass, new.deprecatedClass (testing the deprecated StreamLogger)
+		return $loggerFactory->create($this->config); // @phpstan-ignore method.deprecatedClass (testing deprecated create() on StreamLogger)
 	}
 
 	/**
@@ -65,8 +65,8 @@ class StreamLoggerTest extends LoggerTestCase
 
 		$this->config->shouldReceive('get')->with('system', 'logfile')->andReturn('')->once();
 
-		$loggerFactory = new \Friendica\Core\Logger\Factory\StreamLogger($this->introspection, 'test');
-		$logger        = $loggerFactory->create($this->config);
+		$loggerFactory = new \Friendica\Core\Logger\Factory\StreamLogger($this->introspection, 'test'); // @phpstan-ignore method.deprecatedClass, new.deprecatedClass (testing the deprecated StreamLogger)
+		$logger        = $loggerFactory->create($this->config); // @phpstan-ignore method.deprecatedClass (testing deprecated create() on StreamLogger)
 
 		$logger->emergency('not working');
 	}
@@ -83,8 +83,8 @@ class StreamLoggerTest extends LoggerTestCase
 
 		$this->config->shouldReceive('get')->with('system', 'logfile')->andReturn($logfile->url())->once();
 
-		$loggerFactory = new \Friendica\Core\Logger\Factory\StreamLogger($this->introspection, 'test');
-		$logger        = $loggerFactory->create($this->config);
+		$loggerFactory = new \Friendica\Core\Logger\Factory\StreamLogger($this->introspection, 'test'); // @phpstan-ignore method.deprecatedClass, new.deprecatedClass (testing the deprecated StreamLogger)
+		$logger        = $loggerFactory->create($this->config); // @phpstan-ignore method.deprecatedClass (testing deprecated create() on StreamLogger)
 
 		$logger->emergency('not working');
 	}

--- a/tests/src/Core/Logger/SyslogLoggerFactoryWrapper.php
+++ b/tests/src/Core/Logger/SyslogLoggerFactoryWrapper.php
@@ -12,13 +12,14 @@ use Friendica\Core\Logger\Exception\LogLevelException;
 use Friendica\Core\Logger\Factory\SyslogLogger;
 use Friendica\Core\Logger\Type\SyslogLogger as SyslogLoggerClass;
 
+/** @phpstan-ignore class.extendsDeprecatedClass (test wrapper for deprecated SyslogLogger) */
 class SyslogLoggerFactoryWrapper extends SyslogLogger
 {
 	public function create(IManageConfigValues $config): SyslogLoggerWrapper
 	{
 		$logOpts     = (int) ($config->get('system', 'syslog_flags') ?? SyslogLoggerClass::DEFAULT_FLAGS);
 		$logFacility = (int) ($config->get('system', 'syslog_facility') ?? SyslogLoggerClass::DEFAULT_FACILITY);
-		$loglevel    = SyslogLogger::mapLegacyConfigDebugLevel($config->get('system', 'loglevel'));
+		$loglevel    = SyslogLogger::mapLegacyConfigDebugLevel($config->get('system', 'loglevel')); // @phpstan-ignore staticMethod.deprecatedClass (testing deprecated mapLegacyConfigDebugLevel)
 
 		if (!array_key_exists($loglevel, SyslogLoggerClass::logLevels)) {
 			throw new LogLevelException(sprintf('The level "%s" is not valid.', $loglevel));
@@ -26,6 +27,12 @@ class SyslogLoggerFactoryWrapper extends SyslogLogger
 
 		$loglevel = SyslogLoggerClass::logLevels[$loglevel];
 
-		return new SyslogLoggerWrapper($this->channel, $this->introspection, $loglevel, $logOpts, $logFacility);
+		return new SyslogLoggerWrapper(
+			$this->channel,   // @phpstan-ignore property.deprecatedClass (testing deprecated property from AbstractLoggerTypeFactory)
+			$this->introspection, // @phpstan-ignore property.deprecatedClass (testing deprecated property from AbstractLoggerTypeFactory)
+			$loglevel,
+			$logOpts,
+			$logFacility
+		);
 	}
 }

--- a/tests/src/Core/Logger/SyslogLoggerFactoryWrapper.php
+++ b/tests/src/Core/Logger/SyslogLoggerFactoryWrapper.php
@@ -32,7 +32,7 @@ class SyslogLoggerFactoryWrapper extends SyslogLogger
 			$this->introspection, // @phpstan-ignore property.deprecatedClass (testing deprecated property from AbstractLoggerTypeFactory)
 			$loglevel,
 			$logOpts,
-			$logFacility
+			$logFacility,
 		);
 	}
 }

--- a/tests/src/Navigation/Notifications/Entity/NotifyTest.php
+++ b/tests/src/Navigation/Notifications/Entity/NotifyTest.php
@@ -26,6 +26,6 @@ class NotifyTest extends FixtureTestCase
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataFormatNotify')]
 	public function testFormatNotify(string $name, string $message, string $assertion): void
 	{
-		self::assertEquals($assertion, Notify::formatMessage($name, $message));
+		self::assertEquals($assertion, Notify::formatMessage($name, $message)); // @phpstan-ignore staticMethod.deprecatedClass (testing the deprecated Notify::formatMessage)
 	}
 }


### PR DESCRIPTION
This PR adds phpstan/phpstan-deprecation-rules to find places, where we use deprecated code. This PR also tries to fix some of the places and add the rest into the phpstan-baseline to fix them in the future. 

In a later PR I will add this check also to the addons phpstan check. This way the pipeline will give us feedback if we deprecated code that we are still using in our codebase or in the addons.