### PR TITLE
Frio UI adjustments

### DIFF
--- a/src/Module/Contact.php
+++ b/src/Module/Contact.php
@@ -607,7 +607,7 @@ class Contact extends BaseModule
 		return [
 			'id'                => $contact['id'],
 			'is_admin'          => $administrator,
-			'adming_title'      => DI::l10n()->t('Administrator'),
+			'admin_title'       => DI::l10n()->t('Administrator'),
 			'is_mod'            => $moderator,
 			'moderator_title'   => DI::l10n()->t('Moderator'),
 			'url'               => $url,

--- a/view/templates/widget/tagcloud.tpl
+++ b/view/templates/widget/tagcloud.tpl
@@ -13,7 +13,7 @@
 		</h3>
 	</button>
 
-	<div class="tag-cloud" class="sidebar-widget-list">
+	<div class="tag-cloud sidebar-widget-list">
 		{{foreach $tags as $tag}}
 				<a href="{{$tag.url}}" class="tag{{$tag.level}}">#{{$tag.name}}</a>
 		{{/foreach}}

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -10,7 +10,7 @@
 */
 
 :root {
-	--topbar-first-size: 50px;
+	--topbar-first-size: 55px;
 
 	/* Mostly just bootstraps own colours, available here to use them for things that there aren't helper classes for in Bootstrap 3, like border colour */
 	--default: #ededed; /* Not default */
@@ -282,8 +282,6 @@ ul#nav-user-menu {
 
 #back-to-top {
 	display: none;
-	cursor: pointer;
-	color: $nav_icon_color;
 	position: fixed;
 	z-index: 49;
 	right: 20px;
@@ -292,8 +290,6 @@ ul#nav-user-menu {
 	font-size: 2.9em;
 	padding: 0 12px 0 12px;
 	border-radius: 10px;
-	background-color: $nav_bg;
-	line-height: 1.5;
 }
 
 @media (max-width: 768px) {
@@ -307,18 +303,11 @@ ul#nav-user-menu {
 }
 
 #item-delete-selected {
-	cursor: pointer;
-	color: white;
 	position: fixed;
 	z-index: 49;
-	right: 20px;
-	top: 100px;
+	right: 15px;
+	top: calc(var(--topbar-first-size) + 50px);
 	opacity: 0.8;
-	font-size: 2.9em;
-	padding: 0 12px 0 12px;
-	border-radius: 10px;
-	background-color: $link_color;
-	line-height: 1.5;
 	display: none;
 }
 
@@ -547,15 +536,14 @@ header #site-location {
 	display: none;
 }
 header #banner {
-	padding-top: 12.5px;
+	display: flex;
+	align-items: center;
 	width: min-content;
 }
 header #banner #logo-img,
 .navbar-brand #logo-img {
-	-webkit-mask-image: url("img/friendica-25.png");
-	background-color: $nav_icon_color;
-	height: 25px;
-	width: 25px;
+	font-size: 36px;
+	color: White;
 }
 
 #navbrand-container {
@@ -712,13 +700,13 @@ header #banner #logo-img,
 nav.navbar {
 	background-color: $nav_bg;
 	color: $nav_icon_color;
-	font-size: 15px;
+	font-size: 16px;
 	top: 0;
 	z-index: 1030;
 }
 
 	#topbar-first .topbar-nav i {
-		font-size: 24.4px;
+		font-size: 27.5px;
 	}
 
 button#main-menu {
@@ -1031,6 +1019,7 @@ nav.navbar .nav > li > button:focus {
 }
 
 #search-box #nav-search-input-field {
+	height: 38px;
 	width: 296px;
 }
 
@@ -1181,6 +1170,10 @@ ul li .intro-wrapper button.intro-action-link {
 	font-weight: 400;
 	width: 100%;
 	text-align: left;
+}
+
+.tooltip {
+		font-size: 15px;
 }
 
 .nav-pills .dropdown-menu li > a:hover,
@@ -1367,7 +1360,6 @@ aside .vcard .tool .action {
 	width: 45px;
 	height: 45px;
 	background: rgba(0, 0, 0, 0.5);
-	text-align: center;
 	border-radius: 3px;
 	opacity: 0;
 	-webkit-transition: all 0.25s ease-in-out;
@@ -1385,37 +1377,30 @@ aside .vcard #profile-photo-wrapper:hover .tool .action {
 aside .vcard #profile-photo-wrapper.crop-preview {
 	padding: 0;
 }
+aside .vcard .panel-body {
+	text-align: center;
+}
 aside .vcard .profile-header {
 	padding: 5px 0px 20px 0px;
 }
 aside .vcard .fn {
 	font-weight: bold;
 	padding: 5px 0px 5px 0px;
-	text-align: center;
 }
 aside .vcard .p-addr {
 	font-style: italic;
 	padding-bottom: 7px;
-	text-align: center;
 	word-wrap: break-word;
 }
 aside .vcard .title {
 	margin-top: 10px;
-}
-aside .vcard .detail {
-	display: table;
-	padding: 2px 0;
+	text-align: left;
 }
 aside .xmpp, aside .matrix {
 	display: table;
 }
 aside .member-since {
 	padding-top: 5px;
-}
-aside .vcard .icon {
-	display: table-cell;
-	padding-right: 10px;
-	width: 30px;
 }
 #profile-extra-links {
 	display: flex;
@@ -1424,7 +1409,7 @@ aside .vcard .icon {
 	overflow: auto;
 	margin-bottom: 10px;
 }
-#profile-extra-links a, #profile-extra-links button {
+aside .vcard a.btn, aside .vcard button {
 	display: block;
 	margin-left: auto;
 	margin-right: auto;
@@ -2340,7 +2325,6 @@ button[disabled] {
 	box-shadow: none;
 	color: $link_color;
 	font-weight: bold;
-	text-decoration: underline;
 }
 .wall-item-actions-left {
 	display: table-cell;
@@ -2748,20 +2732,16 @@ input[type="range"].form-control {
 	position: relative;
 }
 
-#search-box .ri-search-line {
-	font-size: 1.1em;
-}
-
 /* Both desktop and mobile - multiple search fields */
 .form-group-search .form-button-search {
 	border-radius: 30px;
-	padding: 3px 10px;
+	padding: 5px 10px;
 	position: absolute;
 	right: 4px;
 	top: 2px;
 }
 #search-box .form-button-search {
-	top: 1px;
+	top: 2px;
 }
 
 #search-box .navbar-form {
@@ -2858,6 +2838,10 @@ body.mod-home nav.navbar .nav > li > a:hover {
 body.mod-home .navbar #nav-login,
 body.mod-login .navbar #nav-login {
 	display: none;
+}
+
+body.mod-home .navbar .navbar-toggle {
+	display: none!important;
 }
 
 .mod-lostpass #content {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1234,7 +1234,7 @@ aside .widget,
 	border-radius: 4px;
 	position: relative;
 	margin-bottom: 20px;
-	padding: 10px;
+	padding: 10px 15px;
 	overflow: auto;
 }
 aside .widget h3,
@@ -1531,6 +1531,10 @@ aside #circle-sidebar li .circle-edit-tool {
 }
 aside #circle-sidebar li .circle-edit-tool:first-child {
 	padding-right: 0px;
+}
+
+.x-network {
+	font-size: 15px;
 }
 
 /* contact block widget */

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -503,6 +503,9 @@ btn-eventnav:hover {
 aside .badge {
 	opacity: 0.7;
 }
+#sidebar-circle-ul {
+	display: grid;
+}
 .group-widget-entry .badge,
 .sidebar-circle-li .badge {
 	margin-top: 6px;

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -88,12 +88,6 @@ function initTheme() {
 		return false;
 	});
 
-	// TODO: Make PHP add the selected class to the relevant HTML element(s) and remove these
-	// add the class "selected" to circle widgets li if li > a does have the class circle-selected
-	if ($("#sidebar-circle-ul li a").hasClass("circle-selected")) {
-		$("#sidebar-circle-ul li a.circle-selected").parent("li").addClass("selected");
-	}
-
 	// add the class "active" to tabmenuli if li > a does have the class active
 	if ($("#tabmenu ul li a").hasClass("active")) {
 		$("#tabmenu ul li a.active").parent("li").addClass("active");

--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -143,7 +143,7 @@ if ($minimal) {
 				</div><!--row-->
 			</div><!-- container -->
 
-			<div id="back-to-top" title="<?php echo DI::l10n()->t('Back to top')?>">⇧</div>
+			<button id="back-to-top" class="btn btn-primary" data-toggle="tooltip" title="<?php echo DI::l10n()->t('Back to top')?>">⇧</button>
 		</main>
 
 		<footer id="page-footer">

--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -414,10 +414,6 @@ input[type="text"].tt-input {
 	box-shadow: none;
 }
 
-#back-to-top {
-	color: $link_color;
-}
-
 .acpopup {
 	background-color: $nav_bg;
 	box-shadow: 0px 6px 12px rgba(218, 218, 218, .18);

--- a/view/theme/frio/templates/conversation.tpl
+++ b/view/theme/frio/templates/conversation.tpl
@@ -25,12 +25,10 @@
 
 {{if !$update}}
 <div id="conversation-end"></div>
-    {{if $dropping}}
-<div id="item-delete-selected" class="fakelink" onclick="deleteCheckedItems();">
-	<div id="item-delete-selected-icon" class="ri ri-delete-bin-line drophide" title="{{$dropping}}"
-	     onmouseover="imgbright(this);" onmouseout="imgdull(this);"></div>
-	<div id="item-delete-selected-desc">{{$dropping}}</div>
-</div>
-<div id="item-delete-selected-end"></div>
-    {{/if}}
+{{if $dropping}}
+    <button id="item-delete-selected" class="btn btn-primary" onclick="deleteCheckedItems();">
+      <i id="item-delete-selected-icon" class="ri ri-delete-bin-line drophide"></i>
+      <span>{{$dropping}}</span>
+    </button>
+{{/if}}
 {{/if}}

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -23,7 +23,7 @@
 					<div id="site-location" aria-hidden="true">{{$sitelocation}}</div>
 					<div id="banner" class="hidden-sm hidden-xs">
 						<a href="{{$baseurl}}" aria-hidden="true">
-							<div id="logo-img" aria-label="{{$home}}"></div>
+							<i id="logo-img" aria-label="{{$home}}" class="ri ri-friendica-fill ri-fw ri-lg" aria-hidden="true"></i>
 						</a>
 					</div>
 					{{* The search box *}}
@@ -32,8 +32,8 @@
 							<div class="form-group form-group-search">
 								<input accesskey="s" id="nav-search-input-field" class="form-control form-search"
 									type="search" name="q" placeholder="{{$search_placeholder}}">
-								<button class="btn btn-primary btn-md form-button-search" type="submit">
-									<i class="ri ri-search-line" aria-hidden="true"></i>
+								<button class="btn btn-primary form-button-search" type="submit">
+									<i class="ri ri-search-line ri-lg" aria-hidden="true"></i>
 									<span class="sr-only">{{$nav.search.1}}</span>
 								</button>
 							</div>
@@ -177,7 +177,7 @@
 									data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false"
 									aria-controls="nav-user-menu">
 									<div aria-hidden="true" class="user-title pull-left hidden-xs hidden-sm hidden-md">
-										<strong>{{$userinfo.name}}</strong><br>
+										{{$userinfo.name}}<br>
 										{{if $nav.remote}}<span class="truncate">{{$nav.remote}}</span>{{/if}}
 									</div>
 
@@ -440,7 +440,7 @@
 			</button>
 			<a class="navbar-brand" href="#">
 				<div id="navbrand-container">
-					<div id="logo-img"></div>
+					<i id="logo-img" aria-label="{{$home}}" class="ri ri-friendica-fill ri-fw ri-lg" aria-hidden="true"></i>
 					<div id="navbar-brand-text"> Friendica</div>
 				</div>
 			</a>

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -45,7 +45,7 @@
 				</div>
 			{{/if}}
 
-			{{if $profile.about}}<div class="title" dir="auto">{{$profile.about nofilter}}</div>{{/if}}
+			{{if $profile.about}}<div class="title p-about" dir="auto">{{$profile.about nofilter}}</div>{{/if}}
 			{{if $account_type == 1 }}
 				{{$acct_icon = "ri-building-4-line"}}
 			{{else if $account_type == 2}}

--- a/view/theme/frio/templates/threaded_conversation.tpl
+++ b/view/theme/frio/templates/threaded_conversation.tpl
@@ -19,11 +19,12 @@
 </div><!--./tread-wrapper-->
 {{/foreach}}
 {{if !$update}}
-<div id="conversation-end"></div>
+  <div id="conversation-end"></div>
 
-{{if $dropping}}
-<button type="button" id="item-delete-selected" class="btn btn-link" title="{{$dropping}}" onclick="deleteCheckedItems();" data-toggle="tooltip">
-	<i class="ri ri-delete-bin-line" aria-hidden="true"></i>
-</button>
-{{/if}}
+  {{if $dropping}}
+    <button type="button" id="item-delete-selected" class="btn btn-primary" onclick="deleteCheckedItems();">
+      <i class="ri ri-delete-bin-line" aria-hidden="true"></i>
+      <span>{{$dropping}}</span>
+    </button>
+  {{/if}}
 {{/if}}


### PR DESCRIPTION
Closes #14898

Makes a couple of adjustments to Frio:

## Main nav

- Main nav is made slightly larger
- The content there is made a little larger as a result - especially the Friendica logo
- The user display name is no longer bold

<img width="1229" height="90" alt="image" src="https://github.com/user-attachments/assets/297e58ff-e384-4d3a-beca-b1beb44195e5" />

## Other changes

"Delete selected items", when it appears, is now the size of a regular button, and it has text:

<img width="1349" height="294" alt="image" src="https://github.com/user-attachments/assets/de10c54c-bf4d-4440-b00b-82386c4ec6f8" />

Add hover color to the "back to top" button, make it use a tooltip as well, instead of a regular title attribute:

<img width="106" height="123" alt="image" src="https://github.com/user-attachments/assets/1d8d589f-4c87-40c1-93f0-1f28d5f7b382" />

Larger text in tooltips:

<img width="119" height="96" alt="image" src="https://github.com/user-attachments/assets/9574ee1e-c8d4-4a8b-bc1c-0b14beb2c805" />

The link to the profile and "Joined date" are now also centered in the vcard:
<img width="275" height="484" alt="image" src="https://github.com/user-attachments/assets/864521ca-60d8-413d-bf89-ff8927c8a6a2" />

Increase widget and vcard padding:
<img width="293" height="816" alt="image" src="https://github.com/user-attachments/assets/898fd411-cce3-47ac-9f4f-997b04aa6b21" />

Fix circle widget spacing and remove redundant, related JS in Frio:
<img width="272" height="199" alt="image" src="https://github.com/user-attachments/assets/2c5e9653-d9e6-4202-8efe-4ccfd4e74527" />

### And finally - small things

- Fix typo in variable resulting in a missing administrator title on the contacts page
- Hide unused link to sidebar menu which is empty on the home screen.
- Fix tag cloud no longer collapsing after I broke it.
- Remove underline when hovering wall item actions