### PR TITLE
Make hovercard smaller on smaller viewports

### DIFF
--- a/view/theme/frio/css/hovercard.css
+++ b/view/theme/frio/css/hovercard.css
@@ -9,17 +9,17 @@
 	top: 0;
 	left: 0;
 	z-index: 1040;
-	display: none;
-	max-width: 400px;
-	padding: 1px;
-	text-align: left;
 	background-color: #ffffff;
 	background-clip: padding-box;
-	border: 1px solid #cccccc;
+	border: 1px solid rgba(0, 0, 0, 0);
+	border-radius: 4px;
 	border: 1px solid rgba(0, 0, 0, 0.2);
-	border-radius: 200px;
-	-webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-	box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+	box-shadow: 0 10px 100px rgba(0, 0, 0, 0.25);
+	display: none;
+	padding: 1px;
+	text-align: left;
+	width: clamp(250px, 90vw, 400px);
+	max-width: 400px;
 	white-space: normal;
 }
 
@@ -49,7 +49,6 @@
 	font-size: 14px;
 	font-weight: normal;
 	line-height: 18px;
-	background-color: #f7f7f7;
 	border-bottom: 1px solid #ebebeb;
 	border-radius: 199px 199px 0 0;
 	display: none;
@@ -238,19 +237,6 @@
 	margin-bottom: 0;
 }
 
-.hovercard {
-	-webkit-border-radius: 4px;
-	-moz-border-radius: 4px;
-	border-radius: 4px;
-	/*max-width: 250px;*/
-	max-width: 400px;
-	width: 350px;
-	-webkit-box-shadow: 0 10px 100px rgba(0, 0, 0, 0.25);
-	-moz-box-shadow: 0 10px 100px rgba(0, 0, 0, 0.25);
-	box-shadow: 0 10px 100px rgba(0, 0, 0, 0.25);
-	border: 1px solid rgba(0, 0, 0, 0);
-}
-
 .hovercard a:hover {
 	text-decoration: none;
 }
@@ -259,23 +245,7 @@
 	border-color: rgba(0, 0, 0, 0.05);
 }
 
-.advance-hovercard + .hovercard {
-	max-width: 445px;
-}
-
-.advance-hovercard + .hovercard .hovercard-content {
-	padding: 5px;
-}
-
-.basic-hovercard + .hovercard {
-	max-width: 445px;
-}
-
-.basic-hovercard + .hovercard .hovercard-content {
-	padding: 5px;
-}
-
-.hover-card-header {
+.hover-card-header, .hover-card-details, .hover-card-content {
 	width: 100%;
 }
 
@@ -287,10 +257,6 @@
 	font-size: 18px;
 	font-weight: bold;
 	letter-spacing: 0.03rem;
-}
-
-.hover-card-details {
-	width: 100%;
 }
 
 .hover-card-pic {
@@ -306,7 +272,6 @@
 
 .hover-card-content {
 	list-style-type: none;
-	width: 100%;
 	display: block;
 	padding: 0.3em 0 0.3em;
 }


### PR DESCRIPTION
Cleaned up the hovercard CSS a little, and in the process also made it able to resize downwards a bit, when the viewport is smaller:

# After

<img width="351" height="462" alt="image" src="https://github.com/user-attachments/assets/d01ca0c2-af1e-48de-823a-e0028ff95764" />

# Before

<img width="351" height="462" alt="image" src="https://github.com/user-attachments/assets/cf28c36b-2c15-45ba-b3d1-2dda9540d52c" />
