### PR TITLE
Fix: Make profile vcard location a span, preventing unneeded line wrap

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -882,7 +882,7 @@ nav.navbar .nav > li > button:focus {
 
 /* Notification Menu */
 #topbar-first .topbar-actions #nav-notifications-menu {
-	max-height: 600px;
+	max-height: 60vh;
 	margin-left: -300px;
 	width: 350px;
 }

--- a/view/theme/frio/templates/profile/vcard.tpl
+++ b/view/theme/frio/templates/profile/vcard.tpl
@@ -125,9 +125,9 @@
 			<div class="location detail">
 				<span class="location-label icon"><i class="ri ri-map-pin-line" title="{{$location}}"></i></span>
 				<span class="adr">
-					{{if $profile.address}}<p class="street-address p-street-address">{{$profile.address nofilter}}</p>
+					{{if $profile.address}}<span class="street-address p-street-address">{{$profile.address nofilter}}</span>
 					{{/if}}
-					{{if $profile.location}}<p class="p-location">{{$profile.location}}</p>{{/if}}
+					{{if $profile.location}}<span class="p-location">{{$profile.location}}</span>{{/if}}
 				</span>
 			</div>
 		{{/if}}


### PR DESCRIPTION
...and allow the notifications dropdown to be taller.

# After

<img width="275" height="188" alt="image" src="https://github.com/user-attachments/assets/dc8fe709-244a-4457-9986-e01607958896" />

# Before

<img width="275" height="188" alt="image" src="https://github.com/user-attachments/assets/560d1988-7b65-4fcc-b86e-3c30f56c2b0d" />