### PR TITLE
Refactor tests for deprecated ICanHandleRequests

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2010 - 2024 the Friendica project
+#
+# SPDX-License-Identifier: CC0-1.0
+
 parameters:
 	ignoreErrors:
 		-

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2010 - 2024 the Friendica project
-#
-# SPDX-License-Identifier: CC0-1.0
-
 parameters:
 	ignoreErrors:
 		-

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -44,4 +44,4 @@ parameters:
             message: '#^Call to an undefined method Mockery[\\\\](?:ExpectationInterface(?:[|]Mockery[\\\\]HigherOrderMessage)?|LegacyMockInterface)::(?:with|once|times|twice|withAnyArgs|andReturnUsing|addRules)\(\)\.$#'
             identifier: method.notFound
             path: tests/
-            count: 236
+            count: 228

--- a/doc/en/developer/upgrade-2026.08.md
+++ b/doc/en/developer/upgrade-2026.08.md
@@ -234,6 +234,41 @@ This section contains deprecation notices. This changes will become mandatory in
    }
    ```
 
+- Remove usage of `\Friendica\Capabilities\ICanHandleRequests` interface. Implement `\Friendica\Capabilities\IRequestHandler` instead.
+
+   The legacy `ICanHandleRequests` interface is deprecated. The `IRequestHandler` interface provides the same capability
+   through `handleRequest(\Friendica\App\Request)`.
+
+   *Before*
+   ```php
+   use Friendica\Capabilities\ICanHandleRequests;
+   use Friendica\Module\Special\HTTPException as ModuleHTTPException;
+
+   class MyModule extends BaseModule implements ICanHandleRequests
+   {
+       public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
+       {
+           // custom logic
+           return parent::run($httpException, $request);
+       }
+   }
+   ```
+
+   *After*
+   ```php
+   use Friendica\App\Request;
+   use Friendica\Capabilities\IRequestHandler;
+
+   class MyModule extends BaseModule implements IRequestHandler
+   {
+       public function handleRequest(Request $request): ResponseInterface
+       {
+           // custom logic — use $this->getServerRequest() for typed getters
+           return parent::handleRequest($request);
+       }
+   }
+   ```
+
 - Remove constructor injection of `\Friendica\App\Request`. Use `$this->getServerRequest()` inside modules or inject `Psr\Http\Message\ServerRequestInterface` instead.
 
    Constructor injection of `App\Request` via DICE is deprecated. If your addon service depends on the current request, receive the value directly (e.g. `string $remoteAddress`) or use the PSR-7 `ServerRequestInterface`.

--- a/doc/en/developer/upgrade-2026.08.md
+++ b/doc/en/developer/upgrade-2026.08.md
@@ -199,3 +199,65 @@ This section contains deprecation notices. This changes will become mandatory in
        // …
    }
    ```
+
+- Remove usage of `\Friendica\BaseModule::run()`, override `handleRequest(\Friendica\App\Request)` instead in your module class.
+
+   The legacy `run()` method still works but will trigger a deprecation warning if your module overrides it.
+
+   *Before*
+   ```php
+   use Friendica\BaseModule;
+   use Friendica\Module\Special\HTTPException as ModuleHTTPException;
+
+   class MyModule extends BaseModule
+   {
+       public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
+       {
+           // custom logic
+           return parent::run($httpException, $request);
+       }
+   }
+   ```
+
+   *After*
+   ```php
+   use Friendica\App\Request;
+   use Friendica\BaseModule;
+
+   class MyModule extends BaseModule
+   {
+       public function handleRequest(Request $request): ResponseInterface
+       {
+           // custom logic — use $this->getServerRequest() for typed getters
+           return parent::handleRequest($request);
+       }
+   }
+   ```
+
+- Remove constructor injection of `\Friendica\App\Request`. Use `$this->getServerRequest()` inside modules or inject `Psr\Http\Message\ServerRequestInterface` instead.
+
+   Constructor injection of `App\Request` via DICE is deprecated. If your addon service depends on the current request, receive the value directly (e.g. `string $remoteAddress`) or use the PSR-7 `ServerRequestInterface`.
+
+   *Before*
+   ```php
+   use Friendica\App\Request;
+
+   class MyService
+   {
+       public function __construct(Request $request)
+       {
+           $this->remoteAddress = $request->getRemoteAddress();
+       }
+   }
+   ```
+
+   *After*
+   ```php
+   class MyService
+   {
+       public function __construct(string $remoteAddress)
+       {
+           $this->remoteAddress = $remoteAddress;
+       }
+   }
+   ```

--- a/src/App.php
+++ b/src/App.php
@@ -135,9 +135,11 @@ class App
 	 */
 	public function processRequest(ServerRequestInterface $request, float $start_time): void
 	{
+		$appRequest = new Request($request, $this->container->create(IManageConfigValues::class));
+
 		$this->container->addRule(Mode::class, [
 			'call' => [
-				['determineRunMode', [false, $request->getServerParams()], Dice::CHAIN_CALL],
+				['determineRunMode', [false, $appRequest->getServerParams()], Dice::CHAIN_CALL],
 			],
 		]);
 
@@ -151,7 +153,7 @@ class App
 
 		$this->registerEventDispatcher();
 
-		$this->requestId = $this->container->create(Request::class)->getRequestId();
+		$this->requestId = $appRequest->getRequestId();
 		$this->auth      = $this->container->create(Authentication::class);
 		$this->config    = $this->container->create(IManageConfigValues::class);
 		$this->mode      = $this->container->create(Mode::class);
@@ -166,7 +168,7 @@ class App
 		$addonHelper = $this->container->create(AddonHelper::class);
 
 		$this->load(
-			$request->getServerParams(),
+			$appRequest->getServerParams(),
 			$this->container->create(DbaDefinition::class),
 			$this->container->create(ViewDefinition::class),
 			$this->mode,
@@ -187,7 +189,7 @@ class App
 			$addonHelper,
 			$this->container->create(ModuleHTTPException::class),
 			$start_time,
-			$request,
+			$appRequest,
 		);
 	}
 
@@ -423,7 +425,7 @@ class App
 		AddonHelper $addonHelper,
 		ModuleHTTPException $httpException,
 		float $start_time,
-		ServerRequestInterface $request,
+		Request $request,
 	) {
 		$this->mode->setExecutor(Mode::INDEX);
 
@@ -443,7 +445,6 @@ class App
 		$requeststring = ($serverVars['REQUEST_METHOD'] ?? '') . ' ' . ($serverVars['REQUEST_URI'] ?? '') . ' ' . ($serverVars['SERVER_PROTOCOL'] ?? '');
 		$this->logger->debug('Request received', ['address' => $serverVars['REMOTE_ADDR'] ?? '', 'request' => $requeststring, 'referer' => $serverVars['HTTP_REFERER'] ?? '', 'user-agent' => $serverVars['HTTP_USER_AGENT'] ?? '', 'requester' => $requester]);
 		$request_start = microtime(true);
-		$request       = $_REQUEST;
 
 		$this->profiler->set($start_time, 'start');
 		$this->profiler->set(microtime(true), 'classinit');
@@ -580,7 +581,9 @@ class App
 				$httpinput['files'] = [];
 			}
 
-			$input = array_merge($httpinput['variables'], $httpinput['files'], $request);
+			$request = $request->withHttpInput($httpinput['variables'] ?? []);
+
+			$input = array_merge($httpinput['files'], $request->getAllInput());
 
 			// Let the module run its internal process (init, get, post, ...)
 			$timestamp = microtime(true);

--- a/src/App.php
+++ b/src/App.php
@@ -140,14 +140,6 @@ class App
 
 		$appRequest = new Request($request, $this->container->create(IManageConfigValues::class));
 
-		$this->container->addRule('*', [
-			'substitutions' => [
-				Request::class                => $appRequest,
-				ServerRequestInterface::class => $appRequest,
-			],
-			'shared' => true,
-		]);
-
 		$this->container->addRule(Mode::class, [
 			'call' => [
 				['determineRunMode', [false, $appRequest->getServerParams()], Dice::CHAIN_CALL],

--- a/src/App.php
+++ b/src/App.php
@@ -142,7 +142,7 @@ class App
 
 		$this->container->addRule('*', [
 			'substitutions' => [
-				Request::class => $appRequest,
+				Request::class                => $appRequest,
 				ServerRequestInterface::class => $appRequest,
 			],
 			'shared' => true,

--- a/src/App.php
+++ b/src/App.php
@@ -15,7 +15,6 @@ use Friendica\App\Page;
 use Friendica\App\Request;
 use Friendica\App\Router;
 use Friendica\Capabilities\ICanCreateResponses;
-use Friendica\Capabilities\ICanHandleRequests;
 use Friendica\Capabilities\RequestHandler;
 use Friendica\Content\Nav;
 use Friendica\Core\Addon\AddonHelper;
@@ -139,6 +138,20 @@ class App
 		$request = $this->mergeRequestInput($request);
 
 		$appRequest = new Request($request, $this->container->create(IManageConfigValues::class));
+
+		// Register backward-compatible DICE resolution for Request
+		$this->container->addRule(Request::class, [
+			'shared' => true,
+			'constructParams' => [
+				[\Dice\Dice::INSTANCE => function () use ($request) {
+					@trigger_error('Constructing \Friendica\App\Request via DICE is deprecated since 2026.08, use handleRequest() or inject ServerRequestInterface instead.', E_USER_DEPRECATED);
+					return $request;
+				}],
+				[\Dice\Dice::INSTANCE => function (\Dice\Dice $dice) {
+					return $dice->create(IManageConfigValues::class);
+				}, 'params' => [[\Dice\Dice::INSTANCE => \Dice\Dice::SELF]]],
+			],
+		]);
 
 		$this->container->addRule(Mode::class, [
 			'call' => [
@@ -575,12 +588,7 @@ class App
 
 			// Let the module run its internal process (init, get, post, ...)
 			$timestamp = microtime(true);
-			if ($module instanceof RequestHandler) {
-				$response = $module->handleRequest($request);
-			} else {
-				trigger_error('Implement RequestHandler instead of ICanHandleRequests');
-				$response = $module->run($httpException, $request->getAllInput());
-			}
+			$response  = $module->handleRequest($request);
 			$this->profiler->set(microtime(true) - $timestamp, 'content');
 
 			// Wrapping HTML responses in the theme template
@@ -599,7 +607,7 @@ class App
 		$page->logRuntime($this->config, 'runFrontend');
 	}
 
-	private function createModuleInstance(?string $moduleClass = null): ICanHandleRequests
+	private function createModuleInstance(?string $moduleClass = null): RequestHandler
 	{
 		/** @var Router $router */
 		$router = $this->container->create(Router::class);
@@ -611,7 +619,7 @@ class App
 
 		$stamp = microtime(true);
 
-		/** @var ICanHandleRequests $module */
+		/** @var RequestHandler $module */
 		$module = $this->container->create($moduleClass, $parameters);
 
 		if ($dice_profiler_threshold > 0) {

--- a/src/App.php
+++ b/src/App.php
@@ -15,7 +15,7 @@ use Friendica\App\Page;
 use Friendica\App\Request;
 use Friendica\App\Router;
 use Friendica\Capabilities\ICanCreateResponses;
-use Friendica\Capabilities\RequestHandler;
+use Friendica\Capabilities\IRequestHandler;
 use Friendica\Content\Nav;
 use Friendica\Core\Addon\AddonHelper;
 use Friendica\Core\Config\Factory\Config;
@@ -607,7 +607,7 @@ class App
 		$page->logRuntime($this->config, 'runFrontend');
 	}
 
-	private function createModuleInstance(?string $moduleClass = null): RequestHandler
+	private function createModuleInstance(?string $moduleClass = null): IRequestHandler
 	{
 		/** @var Router $router */
 		$router = $this->container->create(Router::class);
@@ -619,7 +619,7 @@ class App
 
 		$stamp = microtime(true);
 
-		/** @var RequestHandler $module */
+		/** @var IRequestHandler $module */
 		$module = $this->container->create($moduleClass, $parameters);
 
 		if ($dice_profiler_threshold > 0) {

--- a/src/App.php
+++ b/src/App.php
@@ -16,6 +16,7 @@ use Friendica\App\Request;
 use Friendica\App\Router;
 use Friendica\Capabilities\ICanCreateResponses;
 use Friendica\Capabilities\ICanHandleRequests;
+use Friendica\Capabilities\RequestHandler;
 use Friendica\Content\Nav;
 use Friendica\Core\Addon\AddonHelper;
 use Friendica\Core\Config\Factory\Config;
@@ -135,6 +136,8 @@ class App
 	 */
 	public function processRequest(ServerRequestInterface $request, float $start_time): void
 	{
+		$request = $this->mergeRequestInput($request);
+
 		$appRequest = new Request($request, $this->container->create(IManageConfigValues::class));
 
 		$this->container->addRule(Mode::class, [
@@ -429,7 +432,6 @@ class App
 	) {
 		$this->mode->setExecutor(Mode::INDEX);
 
-		$httpInput  = new HTTPInputData($request->getServerParams());
 		$serverVars = $request->getServerParams();
 		$queryVars  = $request->getQueryParams();
 
@@ -571,23 +573,14 @@ class App
 			// Display can change depending on the requested language, so it shouldn't be cached whole
 			header('Vary: Accept-Language', false);
 
-			// Processes data from GET requests
-			$httpinput = $httpInput->process();
-
-			if (!is_array($httpinput['variables'])) {
-				$httpinput['variables'] = [];
-			}
-			if (!is_array($httpinput['files'])) {
-				$httpinput['files'] = [];
-			}
-
-			$request = $request->withHttpInput($httpinput['variables'] ?? []);
-
-			$input = array_merge($httpinput['files'], $request->getAllInput());
-
 			// Let the module run its internal process (init, get, post, ...)
 			$timestamp = microtime(true);
-			$response  = $module->run($httpException, $input);
+			if ($module instanceof RequestHandler) {
+				$response = $module->handleRequest($request);
+			} else {
+				trigger_error('Implement RequestHandler instead of ICanHandleRequests');
+				$response = $module->run($httpException, $request->getAllInput());
+			}
 			$this->profiler->set(microtime(true) - $timestamp, 'content');
 
 			// Wrapping HTML responses in the theme template
@@ -629,6 +622,25 @@ class App
 		}
 
 		return $module;
+	}
+
+	/**
+	 * Merges HTTP body input data into the PSR-7 request's parsed body.
+	 *
+	 * The PSR-7 request already contains UploadedFileInterface objects from Guzzle's
+	 * fromGlobals(), so uploaded files are preserved as-is.
+	 */
+	private function mergeRequestInput(ServerRequestInterface $request): ServerRequestInterface
+	{
+		$httpData  = new HTTPInputData($request->getServerParams(), $request);
+		$inputData = $httpData->process();
+
+		return $request->withParsedBody(
+			array_merge(
+				(array) $request->getParsedBody(),
+				$inputData['variables'],
+			),
+		);
 	}
 
 	/**

--- a/src/App.php
+++ b/src/App.php
@@ -140,6 +140,14 @@ class App
 
 		$appRequest = new Request($request, $this->container->create(IManageConfigValues::class));
 
+		$this->container->addRule('*', [
+			'substitutions' => [
+				Request::class => $appRequest,
+				ServerRequestInterface::class => $appRequest,
+			],
+			'shared' => true,
+		]);
+
 		$this->container->addRule(Mode::class, [
 			'call' => [
 				['determineRunMode', [false, $appRequest->getServerParams()], Dice::CHAIN_CALL],

--- a/src/App/Request.php
+++ b/src/App/Request.php
@@ -426,6 +426,8 @@ class Request implements ServerRequestInterface
 	 * and `forwarded_for_headers` has been configured then the IP address
 	 * specified in this header will be returned instead.
 	 *
+	 * @internal
+	 *
 	 * @param IManageConfigValues $config
 	 * @param array               $server The $_SERVER array
 	 *
@@ -470,6 +472,9 @@ class Request implements ServerRequestInterface
 		return $remoteAddress;
 	}
 
+	/**
+	 * @internal
+	 */
 	public static function determineRequestId(array $serverParams): string
 	{
 		return $serverParams[self::DEFAULT_REQUEST_ID_HEADER] ?? System::createGUID(8, false);

--- a/src/App/Request.php
+++ b/src/App/Request.php
@@ -38,7 +38,6 @@ class Request implements ServerRequestInterface
 	protected $remoteAddress;
 	/** @var string The request-id of the current request */
 	protected $requestId;
-	private array $httpInput = [];
 	private array $serverParams;
 
 	public function __construct(private ServerRequestInterface $request, private readonly IManageConfigValues $config)
@@ -251,17 +250,6 @@ class Request implements ServerRequestInterface
 	}
 
 	// ----------------------------------------------
-	// httpInput (immutable)
-	// ----------------------------------------------
-
-	public function withHttpInput(array $httpInput): static
-	{
-		$clone            = $this->withRequest($this->request);
-		$clone->httpInput = $httpInput;
-		return $clone;
-	}
-
-	// ----------------------------------------------
 	// Typed query parameter getters
 	// ----------------------------------------------
 
@@ -360,77 +348,9 @@ class Request implements ServerRequestInterface
 		return isset($files[$key]) && is_array($files[$key]) ? $files[$key] : [];
 	}
 
-	// ----------------------------------------------
-	// Convenience merged input (Query > Body > httpInput)
-	// ----------------------------------------------
-
 	public function getAllInput(): array
 	{
-		return array_merge($this->request->getQueryParams(), (array) $this->request->getParsedBody(), $this->httpInput);
-	}
-
-	public function getInput(string $key, mixed $default = null): mixed
-	{
-		return $this->getAllInput()[$key] ?? $default;
-	}
-
-	public function getInputString(string $key, string $default = ''): string
-	{
-		return $this->getString($this->getInput($key), $default);
-	}
-
-	public function getInputInt(string $key, int $default = 0): int
-	{
-		return $this->getInt($this->getInput($key), $default);
-	}
-
-	public function getInputFloat(string $key, float $default = 0.0): float
-	{
-		return $this->getFloat($this->getInput($key), $default);
-	}
-
-	public function getInputBool(string $key, bool $default = false): bool
-	{
-		return $this->getBool($this->getInput($key), $default);
-	}
-
-	public function getInputArray(string $key, array $default = []): array
-	{
-		return $this->getArray($this->getInput($key), $default);
-	}
-
-	// ----------------------------------------------
-	// HTTP helper methods
-	// ----------------------------------------------
-
-	public function isMethod(string $method): bool
-	{
-		return strtoupper($this->request->getMethod()) === strtoupper($method);
-	}
-
-	public function isGet(): bool
-	{
-		return $this->isMethod('GET');
-	}
-
-	public function isPost(): bool
-	{
-		return $this->isMethod('POST');
-	}
-
-	public function isPut(): bool
-	{
-		return $this->isMethod('PUT');
-	}
-
-	public function isPatch(): bool
-	{
-		return $this->isMethod('PATCH');
-	}
-
-	public function isDelete(): bool
-	{
-		return $this->isMethod('DELETE');
+		return array_merge($this->request->getQueryParams(), (array) $this->request->getParsedBody());
 	}
 
 	// ----------------------------------------------

--- a/src/App/Request.php
+++ b/src/App/Request.php
@@ -9,15 +9,17 @@ namespace Friendica\App;
 
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\System;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Container for the whole request
  *
  * @see https://www.php-fig.org/psr/psr-7/#321-psrhttpmessageserverrequestinterface
- *
- * @todo future container class for whole requests, currently it's not :-)
  */
-class Request
+class Request implements ServerRequestInterface
 {
 	/**
 	 * A comma separated list of default headers that could contain the client IP in a proxy request
@@ -36,6 +38,20 @@ class Request
 	protected $remoteAddress;
 	/** @var string The request-id of the current request */
 	protected $requestId;
+
+	private ServerRequestInterface $request;
+	private readonly IManageConfigValues $config;
+	private array $httpInput = [];
+	private array $serverParams;
+
+	public function __construct(ServerRequestInterface $request, IManageConfigValues $config)
+	{
+		$this->request      = $request;
+		$this->config       = $config;
+		$this->serverParams = $request->getServerParams();
+		$this->remoteAddress = $this->determineRemoteAddress($config, $this->serverParams);
+		$this->requestId     = $this->serverParams[static::DEFAULT_REQUEST_ID_HEADER] ?? System::createGUID(8, false);
+	}
 
 	/**
 	 * @return string The remote IP address of the current request
@@ -57,10 +73,401 @@ class Request
 		return $this->requestId;
 	}
 
-	public function __construct(IManageConfigValues $config, array $server = [])
+	private function withRequest(ServerRequestInterface $request): static
 	{
-		$this->remoteAddress = $this->determineRemoteAddress($config, $server);
-		$this->requestId     = $server[static::DEFAULT_REQUEST_ID_HEADER] ?? System::createGUID(8, false);
+		$clone = clone $this;
+		$clone->request = $request;
+		return $clone;
+	}
+
+	// ----------------------------------------------
+	// ServerRequestInterface
+	// ----------------------------------------------
+
+	public function getServerParams(): array
+	{
+		return $this->serverParams;
+	}
+
+	public function getCookieParams(): array
+	{
+		return $this->request->getCookieParams();
+	}
+
+	public function withCookieParams(array $cookies): static
+	{
+		return $this->withRequest($this->request->withCookieParams($cookies));
+	}
+
+	public function getQueryParams(): array
+	{
+		return $this->request->getQueryParams();
+	}
+
+	public function withQueryParams(array $query): static
+	{
+		return $this->withRequest($this->request->withQueryParams($query));
+	}
+
+	public function getUploadedFiles(): array
+	{
+		return $this->request->getUploadedFiles();
+	}
+
+	public function withUploadedFiles(array $uploadedFiles): static
+	{
+		return $this->withRequest($this->request->withUploadedFiles($uploadedFiles));
+	}
+
+	public function getParsedBody(): object|array|null
+	{
+		return $this->request->getParsedBody();
+	}
+
+	public function withParsedBody($data): static
+	{
+		return $this->withRequest($this->request->withParsedBody($data));
+	}
+
+	public function getAttributes(): array
+	{
+		return $this->request->getAttributes();
+	}
+
+	public function getAttribute(string $name, $default = null): mixed
+	{
+		return $this->request->getAttribute($name, $default);
+	}
+
+	public function withAttribute(string $name, $value): static
+	{
+		return $this->withRequest($this->request->withAttribute($name, $value));
+	}
+
+	public function withoutAttribute(string $name): static
+	{
+		return $this->withRequest($this->request->withoutAttribute($name));
+	}
+
+	// ----------------------------------------------
+	// RequestInterface
+	// ----------------------------------------------
+
+	public function getRequestTarget(): string
+	{
+		return $this->request->getRequestTarget();
+	}
+
+	public function withRequestTarget(string $requestTarget): static
+	{
+		return $this->withRequest($this->request->withRequestTarget($requestTarget));
+	}
+
+	public function getMethod(): string
+	{
+		return $this->request->getMethod();
+	}
+
+	public function withMethod(string $method): static
+	{
+		return $this->withRequest($this->request->withMethod($method));
+	}
+
+	public function getUri(): UriInterface
+	{
+		return $this->request->getUri();
+	}
+
+	public function withUri(UriInterface $uri, bool $preserveHost = false): static
+	{
+		return $this->withRequest($this->request->withUri($uri, $preserveHost));
+	}
+
+	// ----------------------------------------------
+	// MessageInterface
+	// ----------------------------------------------
+
+	public function getProtocolVersion(): string
+	{
+		return $this->request->getProtocolVersion();
+	}
+
+	public function withProtocolVersion(string $version): static
+	{
+		return $this->withRequest($this->request->withProtocolVersion($version));
+	}
+
+	public function getHeaders(): array
+	{
+		return $this->request->getHeaders();
+	}
+
+	public function hasHeader(string $name): bool
+	{
+		return $this->request->hasHeader($name);
+	}
+
+	public function getHeader(string $name): array
+	{
+		return $this->request->getHeader($name);
+	}
+
+	public function getHeaderLine(string $name): string
+	{
+		return $this->request->getHeaderLine($name);
+	}
+
+	public function withHeader(string $name, $value): static
+	{
+		return $this->withRequest($this->request->withHeader($name, $value));
+	}
+
+	public function withAddedHeader(string $name, $value): static
+	{
+		return $this->withRequest($this->request->withAddedHeader($name, $value));
+	}
+
+	public function withoutHeader(string $name): static
+	{
+		return $this->withRequest($this->request->withoutHeader($name));
+	}
+
+	public function getBody(): StreamInterface
+	{
+		return $this->request->getBody();
+	}
+
+	public function withBody(StreamInterface $body): static
+	{
+		return $this->withRequest($this->request->withBody($body));
+	}
+
+	// ----------------------------------------------
+	// withServerParams (not part of PSR-7 interface)
+	// ----------------------------------------------
+
+	public function withServerParams(array $serverParams): static
+	{
+		$clone = clone $this;
+		$clone->serverParams  = $serverParams;
+		$clone->remoteAddress = $clone->determineRemoteAddress($clone->config, $serverParams);
+		$clone->requestId     = $serverParams[static::DEFAULT_REQUEST_ID_HEADER] ?? System::createGUID(8, false);
+		return $clone;
+	}
+
+	// ----------------------------------------------
+	// httpInput (immutable)
+	// ----------------------------------------------
+
+	public function withHttpInput(array $httpInput): static
+	{
+		$clone = $this->withRequest($this->request);
+		$clone->httpInput = $httpInput;
+		return $clone;
+	}
+
+	// ----------------------------------------------
+	// Typed query parameter getters
+	// ----------------------------------------------
+
+	public function getQueryParam(string $key, mixed $default = null): mixed
+	{
+		return $this->request->getQueryParams()[$key] ?? $default;
+	}
+
+	public function getQueryString(string $key, string $default = ''): string
+	{
+		return $this->getString($this->getQueryParam($key), $default);
+	}
+
+	public function getQueryInt(string $key, int $default = 0): int
+	{
+		return $this->getInt($this->getQueryParam($key), $default);
+	}
+
+	public function getQueryFloat(string $key, float $default = 0.0): float
+	{
+		return $this->getFloat($this->getQueryParam($key), $default);
+	}
+
+	public function getQueryBool(string $key, bool $default = false): bool
+	{
+		return $this->getBool($this->getQueryParam($key), $default);
+	}
+
+	public function getQueryArray(string $key, array $default = []): array
+	{
+		return $this->getArray($this->getQueryParam($key), $default);
+	}
+
+	// ----------------------------------------------
+	// Typed body parameter getters
+	// ----------------------------------------------
+
+	public function getBodyParam(string $key, mixed $default = null): mixed
+	{
+		$body = $this->request->getParsedBody();
+		return is_array($body) ? ($body[$key] ?? $default) : $default;
+	}
+
+	public function getBodyString(string $key, string $default = ''): string
+	{
+		return $this->getString($this->getBodyParam($key), $default);
+	}
+
+	public function getBodyInt(string $key, int $default = 0): int
+	{
+		return $this->getInt($this->getBodyParam($key), $default);
+	}
+
+	public function getBodyFloat(string $key, float $default = 0.0): float
+	{
+		return $this->getFloat($this->getBodyParam($key), $default);
+	}
+
+	public function getBodyBool(string $key, bool $default = false): bool
+	{
+		return $this->getBool($this->getBodyParam($key), $default);
+	}
+
+	public function getBodyArray(string $key, array $default = []): array
+	{
+		return $this->getArray($this->getBodyParam($key), $default);
+	}
+
+	// ----------------------------------------------
+	// Server / Cookie parameter getters
+	// ----------------------------------------------
+
+	public function getServerParam(string $key, mixed $default = null): mixed
+	{
+		return $this->request->getServerParams()[$key] ?? $default;
+	}
+
+	public function getCookieParam(string $key, mixed $default = null): mixed
+	{
+		return $this->request->getCookieParams()[$key] ?? $default;
+	}
+
+	// ----------------------------------------------
+	// Uploaded file getters
+	// ----------------------------------------------
+
+	public function getUploadedFile(string $key): ?UploadedFileInterface
+	{
+		$files = $this->request->getUploadedFiles();
+		return isset($files[$key]) && $files[$key] instanceof UploadedFileInterface ? $files[$key] : null;
+	}
+
+	public function getUploadedFileArray(string $key): array
+	{
+		$files = $this->request->getUploadedFiles();
+		return isset($files[$key]) && is_array($files[$key]) ? $files[$key] : [];
+	}
+
+	// ----------------------------------------------
+	// Convenience merged input (Query > Body > httpInput)
+	// ----------------------------------------------
+
+	public function getAllInput(): array
+	{
+		return array_merge($this->request->getQueryParams(), (array) $this->request->getParsedBody(), $this->httpInput);
+	}
+
+	public function getInput(string $key, mixed $default = null): mixed
+	{
+		return $this->getAllInput()[$key] ?? $default;
+	}
+
+	public function getInputString(string $key, string $default = ''): string
+	{
+		return $this->getString($this->getInput($key), $default);
+	}
+
+	public function getInputInt(string $key, int $default = 0): int
+	{
+		return $this->getInt($this->getInput($key), $default);
+	}
+
+	public function getInputFloat(string $key, float $default = 0.0): float
+	{
+		return $this->getFloat($this->getInput($key), $default);
+	}
+
+	public function getInputBool(string $key, bool $default = false): bool
+	{
+		return $this->getBool($this->getInput($key), $default);
+	}
+
+	public function getInputArray(string $key, array $default = []): array
+	{
+		return $this->getArray($this->getInput($key), $default);
+	}
+
+	// ----------------------------------------------
+	// HTTP helper methods
+	// ----------------------------------------------
+
+	public function isMethod(string $method): bool
+	{
+		return strtoupper($this->request->getMethod()) === strtoupper($method);
+	}
+
+	public function isGet(): bool
+	{
+		return $this->isMethod('GET');
+	}
+
+	public function isPost(): bool
+	{
+		return $this->isMethod('POST');
+	}
+
+	public function isPut(): bool
+	{
+		return $this->isMethod('PUT');
+	}
+
+	public function isPatch(): bool
+	{
+		return $this->isMethod('PATCH');
+	}
+
+	public function isDelete(): bool
+	{
+		return $this->isMethod('DELETE');
+	}
+
+	// ----------------------------------------------
+	// Type casting helpers
+	// ----------------------------------------------
+
+	private function getString(mixed $value, string $default): string
+	{
+		return is_string($value) ? $value : $default;
+	}
+
+	private function getInt(mixed $value, int $default): int
+	{
+		return filter_var($value, FILTER_VALIDATE_INT) !== false ? (int) $value : $default;
+	}
+
+	private function getFloat(mixed $value, float $default): float
+	{
+		return filter_var($value, FILTER_VALIDATE_FLOAT) !== false ? (float) $value : $default;
+	}
+
+	private function getBool(mixed $value, bool $default): bool
+	{
+		if ($value === null) {
+			return $default;
+		}
+		return filter_var($value, FILTER_VALIDATE_BOOLEAN, ['flags' => FILTER_NULL_ON_FAILURE]) ?? $default;
+	}
+
+	private function getArray(mixed $value, array $default): array
+	{
+		return is_array($value) ? $value : $default;
 	}
 
 	/**

--- a/src/App/Request.php
+++ b/src/App/Request.php
@@ -433,7 +433,7 @@ class Request implements ServerRequestInterface
 	 */
 	public static function determineRemoteAddress(?IManageConfigValues $config, array $server): string
 	{
-		$remoteAddress  = $server['REMOTE_ADDR'] ?? '0.0.0.0';
+		$remoteAddress = $server['REMOTE_ADDR'] ?? '0.0.0.0';
 
 		if ($config === null) {
 			return $remoteAddress;

--- a/src/App/Request.php
+++ b/src/App/Request.php
@@ -43,8 +43,8 @@ class Request implements ServerRequestInterface
 	public function __construct(private ServerRequestInterface $request, private readonly IManageConfigValues $config)
 	{
 		$this->serverParams  = $this->request->getServerParams();
-		$this->remoteAddress = $this->determineRemoteAddress($this->config, $this->serverParams);
-		$this->requestId     = $this->serverParams[static::DEFAULT_REQUEST_ID_HEADER] ?? System::createGUID(8, false);
+		$this->remoteAddress = self::determineRemoteAddress($this->config, $this->serverParams);
+		$this->requestId     = self::determineRequestId($this->serverParams);
 	}
 
 	/**
@@ -385,7 +385,7 @@ class Request implements ServerRequestInterface
 	 *
 	 * @return boolean true if $remoteAddress matches $trustedProxy, false otherwise
 	 */
-	protected function matchesTrustedProxy(string $trustedProxy, string $remoteAddress): bool
+	private static function matchesTrustedProxy(string $trustedProxy, string $remoteAddress): bool
 	{
 		$cidrre = '/^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\/([0-9]{1,2})$/';
 
@@ -410,10 +410,10 @@ class Request implements ServerRequestInterface
 	 *
 	 * @return boolean true if $remoteAddress matches any entry in $trustedProxies, false otherwise
 	 */
-	protected function isTrustedProxy(array $trustedProxies, string $remoteAddress): bool
+	private static function isTrustedProxy(array $trustedProxies, string $remoteAddress): bool
 	{
 		foreach ($trustedProxies as $tp) {
-			if ($this->matchesTrustedProxy($tp, $remoteAddress)) {
+			if (self::matchesTrustedProxy($tp, $remoteAddress)) {
 				return true;
 			}
 		}
@@ -431,12 +431,17 @@ class Request implements ServerRequestInterface
 	 *
 	 * @return string
 	 */
-	protected function determineRemoteAddress(IManageConfigValues $config, array $server): string
+	public static function determineRemoteAddress(?IManageConfigValues $config, array $server): string
 	{
 		$remoteAddress  = $server['REMOTE_ADDR'] ?? '0.0.0.0';
+
+		if ($config === null) {
+			return $remoteAddress;
+		}
+
 		$trustedProxies = preg_split('/(\s*,*\s*)*,+(\s*,*\s*)*/', (string) $config->get('proxy', 'trusted_proxies', ''));
 
-		if (\is_array($trustedProxies) && $this->isTrustedProxy($trustedProxies, $remoteAddress)) {
+		if (\is_array($trustedProxies) && self::isTrustedProxy($trustedProxies, $remoteAddress)) {
 			$forwardedForHeaders = preg_split('/(\s*,*\s*)*,+(\s*,*\s*)*/', (string) $config->get('proxy', 'forwarded_for_headers', static::DEFAULT_FORWARD_FOR_HEADER));
 
 			foreach ($forwardedForHeaders as $header) {
@@ -450,7 +455,7 @@ class Request implements ServerRequestInterface
 						}
 
 						// skip trusted proxies in the list itself
-						if ($this->isTrustedProxy($trustedProxies, $IP)) {
+						if (self::isTrustedProxy($trustedProxies, $IP)) {
 							continue;
 						}
 
@@ -463,5 +468,10 @@ class Request implements ServerRequestInterface
 		}
 
 		return $remoteAddress;
+	}
+
+	public static function determineRequestId(array $serverParams): string
+	{
+		return $serverParams[self::DEFAULT_REQUEST_ID_HEADER] ?? System::createGUID(8, false);
 	}
 }

--- a/src/App/Request.php
+++ b/src/App/Request.php
@@ -38,18 +38,13 @@ class Request implements ServerRequestInterface
 	protected $remoteAddress;
 	/** @var string The request-id of the current request */
 	protected $requestId;
-
-	private ServerRequestInterface $request;
-	private readonly IManageConfigValues $config;
 	private array $httpInput = [];
 	private array $serverParams;
 
-	public function __construct(ServerRequestInterface $request, IManageConfigValues $config)
+	public function __construct(private ServerRequestInterface $request, private readonly IManageConfigValues $config)
 	{
-		$this->request      = $request;
-		$this->config       = $config;
-		$this->serverParams = $request->getServerParams();
-		$this->remoteAddress = $this->determineRemoteAddress($config, $this->serverParams);
+		$this->serverParams  = $this->request->getServerParams();
+		$this->remoteAddress = $this->determineRemoteAddress($this->config, $this->serverParams);
 		$this->requestId     = $this->serverParams[static::DEFAULT_REQUEST_ID_HEADER] ?? System::createGUID(8, false);
 	}
 
@@ -75,7 +70,7 @@ class Request implements ServerRequestInterface
 
 	private function withRequest(ServerRequestInterface $request): static
 	{
-		$clone = clone $this;
+		$clone          = clone $this;
 		$clone->request = $request;
 		return $clone;
 	}
@@ -248,7 +243,7 @@ class Request implements ServerRequestInterface
 
 	public function withServerParams(array $serverParams): static
 	{
-		$clone = clone $this;
+		$clone                = clone $this;
 		$clone->serverParams  = $serverParams;
 		$clone->remoteAddress = $clone->determineRemoteAddress($clone->config, $serverParams);
 		$clone->requestId     = $serverParams[static::DEFAULT_REQUEST_ID_HEADER] ?? System::createGUID(8, false);
@@ -261,7 +256,7 @@ class Request implements ServerRequestInterface
 
 	public function withHttpInput(array $httpInput): static
 	{
-		$clone = $this->withRequest($this->request);
+		$clone            = $this->withRequest($this->request);
 		$clone->httpInput = $httpInput;
 		return $clone;
 	}

--- a/src/App/Request.php
+++ b/src/App/Request.php
@@ -237,19 +237,6 @@ class Request implements ServerRequestInterface
 	}
 
 	// ----------------------------------------------
-	// withServerParams (not part of PSR-7 interface)
-	// ----------------------------------------------
-
-	public function withServerParams(array $serverParams): static
-	{
-		$clone                = clone $this;
-		$clone->serverParams  = $serverParams;
-		$clone->remoteAddress = $clone->determineRemoteAddress($clone->config, $serverParams);
-		$clone->requestId     = $serverParams[static::DEFAULT_REQUEST_ID_HEADER] ?? System::createGUID(8, false);
-		return $clone;
-	}
-
-	// ----------------------------------------------
 	// Typed query parameter getters
 	// ----------------------------------------------
 

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -11,7 +11,7 @@ use Friendica\App\Request;
 use Friendica\App\Router;
 use Friendica\Capabilities\ICanHandleRequests;
 use Friendica\Capabilities\ICanCreateResponses;
-use Friendica\Capabilities\RequestHandler;
+use Friendica\Capabilities\IRequestHandler;
 use Friendica\Core\L10n;
 use Friendica\Core\System;
 use Friendica\Event\ModuleContentEvent;
@@ -35,7 +35,7 @@ use Psr\Log\LoggerInterface;
  *
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
-abstract class BaseModule implements ICanHandleRequests, RequestHandler
+abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 {
 	/** @var array */
 	protected $parameters = [];

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -200,6 +200,16 @@ abstract class BaseModule implements ICanHandleRequests, RequestHandler
 	public function handleRequest(Request $request): ResponseInterface
 	{
 		$this->appRequest = $request;
+
+		// BC: If a child class overrides run(), route through the legacy path with deprecation warning
+		$refMethod = new \ReflectionMethod($this, 'run');
+		if ($refMethod->getDeclaringClass()->getName() !== self::class) {
+			@trigger_error(sprintf('%s::run() is deprecated since 2026.08, override handleRequest() instead.', static::class), E_USER_DEPRECATED);
+
+			$httpException = DI::getDice()->create(ModuleHTTPException::class);
+			return $this->run($httpException, $request->getAllInput());
+		}
+
 		try {
 			$this->dispatchRequestBase($request->getAllInput());
 			$this->dispatchRequestContent($request->getAllInput());
@@ -224,6 +234,8 @@ abstract class BaseModule implements ICanHandleRequests, RequestHandler
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @deprecated 2026.08 Use handleRequest() instead
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
 	{

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -35,7 +35,7 @@ use Psr\Log\LoggerInterface;
  *
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
-abstract class BaseModule implements ICanHandleRequests, IRequestHandler
+abstract class BaseModule implements ICanHandleRequests, IRequestHandler // @phpstan-ignore class.implementsDeprecatedInterface (BC: this class provides both old and new interface)
 {
 	/** @var array */
 	protected $parameters = [];
@@ -207,6 +207,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 			@trigger_error(sprintf('%s::run() is deprecated since 2026.08, override handleRequest() instead.', static::class), E_USER_DEPRECATED);
 
 			$httpException = DI::getDice()->create(ModuleHTTPException::class);
+			// @phpstan-ignore method.deprecated (BC bridge: delegate to run() if child class overrides it)
 			return $this->run($httpException, $request->getAllInput());
 		}
 

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -7,9 +7,11 @@
 
 namespace Friendica;
 
+use Friendica\App\Request;
 use Friendica\App\Router;
 use Friendica\Capabilities\ICanHandleRequests;
 use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Capabilities\RequestHandler;
 use Friendica\Core\L10n;
 use Friendica\Core\System;
 use Friendica\Event\ModuleContentEvent;
@@ -33,10 +35,12 @@ use Psr\Log\LoggerInterface;
  *
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
-abstract class BaseModule implements ICanHandleRequests
+abstract class BaseModule implements ICanHandleRequests, RequestHandler
 {
 	/** @var array */
 	protected $parameters = [];
+
+	private ?Request $appRequest = null;
 	/** @var L10n */
 	protected $l10n;
 	/** @var App\BaseURL */
@@ -73,6 +77,17 @@ abstract class BaseModule implements ICanHandleRequests
 		$this->server          = $server;
 		$this->response        = $response;
 		$this->eventDispatcher = $eventDispatcher ?? DI::eventDispatcher();
+	}
+
+	/**
+	 * @throws \RuntimeException when called outside of an HTTP request (e.g. from a CLI module context)
+	 */
+	protected function getServerRequest(): Request
+	{
+		if ($this->appRequest === null) {
+			throw new \RuntimeException('getServerRequest() cannot be called outside of an HTTP request context');
+		}
+		return $this->appRequest;
 	}
 
 	/**
@@ -182,10 +197,36 @@ abstract class BaseModule implements ICanHandleRequests
 	 */
 	protected function get(array $request = []) {}
 
+	public function handleRequest(Request $request): ResponseInterface
+	{
+		$this->appRequest = $request;
+		return $this->dispatchRequest($request->getAllInput());
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
+	{
+		try {
+			return $this->dispatchRequest($request);
+		} catch (HTTPException $e) {
+			// In case of System::externalRedirects(), we don't want to prettyprint the exception
+			// just redirect to the new location
+			if (($e instanceof HTTPException\FoundException)
+				|| ($e instanceof HTTPException\MovedPermanentlyException)
+				|| ($e instanceof HTTPException\TemporaryRedirectException)) {
+				throw $e;
+			}
+
+			$this->response->setStatus($e->getCode(), $e->getMessage());
+			$this->response->addContent($httpException->content($e));
+
+			return $this->response->generate();
+		}
+	}
+
+	private function dispatchRequest(array $request): ResponseInterface
 	{
 		// @see https://github.com/tootsuite/mastodon/blob/c3aef491d66aec743a3a53e934a494f653745b61/config/initializers/cors.rb
 		if (str_starts_with($this->args->getQueryString(), '.well-known/')) {
@@ -253,24 +294,11 @@ abstract class BaseModule implements ICanHandleRequests
 		// templating and is expected to exit on its own if it is set.
 		$this->rawContent($request);
 
-		try {
-			$content = $this->eventDispatcher->dispatch(
-				new ModuleContentEvent(ModuleContentEvent::MODULE_CONTENT, $this->args->getModuleName(), static::class, ''),
-			)->getContent();
-			$this->response->addContent($content);
-			$this->response->addContent($this->content($request));
-		} catch (HTTPException $e) {
-			// In case of System::externalRedirects(), we don't want to prettyprint the exception
-			// just redirect to the new location
-			if (($e instanceof HTTPException\FoundException)
-				|| ($e instanceof HTTPException\MovedPermanentlyException)
-				|| ($e instanceof HTTPException\TemporaryRedirectException)) {
-				throw $e;
-			}
-
-			$this->response->setStatus($e->getCode(), $e->getMessage());
-			$this->response->addContent($httpException->content($e));
-		}
+		$content = $this->eventDispatcher->dispatch(
+			new ModuleContentEvent(ModuleContentEvent::MODULE_CONTENT, $this->args->getModuleName(), static::class, ''),
+		)->getContent();
+		$this->response->addContent($content);
+		$this->response->addContent($this->content($request));
 
 		$this->profiler->set(microtime(true) - $timestamp, 'content');
 

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -200,7 +200,26 @@ abstract class BaseModule implements ICanHandleRequests, RequestHandler
 	public function handleRequest(Request $request): ResponseInterface
 	{
 		$this->appRequest = $request;
-		return $this->dispatchRequest($request->getAllInput());
+		try {
+			$this->dispatchRequestBase($request->getAllInput());
+			$this->dispatchRequestContent($request->getAllInput());
+			return $this->response->generate();
+		} catch (HTTPException $e) {
+			// In case of System::externalRedirects(), we don't want to prettyprint the exception
+			// just redirect to the new location
+			if (($e instanceof HTTPException\FoundException)
+				|| ($e instanceof HTTPException\MovedPermanentlyException)
+				|| ($e instanceof HTTPException\TemporaryRedirectException)) {
+				throw $e;
+			}
+
+			$httpException = DI::getDice()->create(ModuleHTTPException::class);
+
+			$this->response->setStatus($e->getCode(), $e->getMessage());
+			$this->response->addContent($httpException->content($e));
+
+			return $this->response->generate();
+		}
 	}
 
 	/**
@@ -208,8 +227,10 @@ abstract class BaseModule implements ICanHandleRequests, RequestHandler
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
 	{
+		$this->dispatchRequestBase($request);
 		try {
-			return $this->dispatchRequest($request);
+			$this->dispatchRequestContent($request);
+			return $this->response->generate();
 		} catch (HTTPException $e) {
 			// In case of System::externalRedirects(), we don't want to prettyprint the exception
 			// just redirect to the new location
@@ -226,7 +247,7 @@ abstract class BaseModule implements ICanHandleRequests, RequestHandler
 		}
 	}
 
-	private function dispatchRequest(array $request): ResponseInterface
+	private function dispatchRequestBase(array $request): void
 	{
 		// @see https://github.com/tootsuite/mastodon/blob/c3aef491d66aec743a3a53e934a494f653745b61/config/initializers/cors.rb
 		if (str_starts_with($this->args->getQueryString(), '.well-known/')) {
@@ -288,11 +309,15 @@ abstract class BaseModule implements ICanHandleRequests, RequestHandler
 				break;
 		}
 
-		$timestamp = microtime(true);
 		// "rawContent" is especially meant for technical endpoints.
 		// This endpoint doesn't need any theme initialization or
 		// templating and is expected to exit on its own if it is set.
 		$this->rawContent($request);
+	}
+
+	private function dispatchRequestContent(array $request): void
+	{
+		$timestamp = microtime(true);
 
 		$content = $this->eventDispatcher->dispatch(
 			new ModuleContentEvent(ModuleContentEvent::MODULE_CONTENT, $this->args->getModuleName(), static::class, ''),
@@ -301,8 +326,6 @@ abstract class BaseModule implements ICanHandleRequests, RequestHandler
 		$this->response->addContent($this->content($request));
 
 		$this->profiler->set(microtime(true) - $timestamp, 'content');
-
-		return $this->response->generate();
 	}
 
 	/**

--- a/src/Capabilities/ICanHandleRequests.php
+++ b/src/Capabilities/ICanHandleRequests.php
@@ -13,6 +13,8 @@ use Psr\Http\Message\ResponseInterface;
 
 /**
  * This interface provides the capability to handle requests from clients and returns the desired outcome
+ *
+ * @deprecated 2026.08 Use IRequestHandler::handleRequest() instead
  */
 interface ICanHandleRequests
 {

--- a/src/Capabilities/IRequestHandler.php
+++ b/src/Capabilities/IRequestHandler.php
@@ -10,7 +10,7 @@ namespace Friendica\Capabilities;
 use Friendica\App\Request;
 use Psr\Http\Message\ResponseInterface;
 
-interface RequestHandler
+interface IRequestHandler
 {
 	public function handleRequest(Request $request): ResponseInterface;
 }

--- a/src/Capabilities/RequestHandler.php
+++ b/src/Capabilities/RequestHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Capabilities;
+
+use Friendica\App\Request;
+use Psr\Http\Message\ResponseInterface;
+
+interface RequestHandler
+{
+	public function handleRequest(Request $request): ResponseInterface;
+}

--- a/src/Core/Logger/Util/Introspection.php
+++ b/src/Core/Logger/Util/Introspection.php
@@ -7,7 +7,6 @@
 
 namespace Friendica\Core\Logger\Util;
 
-use Friendica\App\Request;
 use Friendica\Core\Logger\Capability\IHaveCallIntrospections;
 use Friendica\Core\System;
 
@@ -16,9 +15,6 @@ use Friendica\Core\System;
  */
 class Introspection implements IHaveCallIntrospections
 {
-	/** @var string */
-	private $requestId;
-
 	private $skipFunctions = [
 		'call_user_func',
 		'call_user_func_array',
@@ -28,10 +24,11 @@ class Introspection implements IHaveCallIntrospections
 	 * @param string[] $skipClassesPartials  An array of classes to skip during logging
 	 * @param int      $skipStackFramesCount If the logger should use information from other hierarchy levels of the call
 	 */
-	public function __construct(Request $request, private array $skipClassesPartials = [], private readonly int $skipStackFramesCount = 0)
-	{
-		$this->requestId = $request->getRequestId();
-	}
+	public function __construct(
+		private readonly string $requestId,
+		private array $skipClassesPartials = [],
+		private readonly int $skipStackFramesCount = 0,
+	) {}
 
 	/**
 	 * Adds new classes to get skipped

--- a/src/Model/User/Cookie.php
+++ b/src/Model/User/Cookie.php
@@ -8,7 +8,6 @@
 namespace Friendica\Model\User;
 
 use Friendica\App\BaseURL;
-use Friendica\App\Request;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 
 /**
@@ -26,9 +25,6 @@ class Cookie
 	public const DOMAIN = '';
 	/** @var bool True, if the cookie should only be accessible through HTTP */
 	public const HTTPONLY = true;
-
-	/** @var string The remote address of this node */
-	private $remoteAddr;
 	/** @var bool True, if the connection is ssl enabled */
 	private $sslEnabled;
 	/** @var string The private key of this Friendica node */
@@ -39,13 +35,13 @@ class Cookie
 	private $data;
 
 	/**
-	 * @param Request             $request The current http request
+	 * @param string              $remoteAddr The client IP address
 	 * @param IManageConfigValues $config
 	 * @param BaseURL             $baseURL
 	 * @param array               $COOKIE The $_COOKIE array
 	 */
 	public function __construct(
-		Request $request,
+		private readonly string $remoteAddr,
 		IManageConfigValues $config,
 		BaseURL $baseURL,
 		array $COOKIE = [],
@@ -59,8 +55,6 @@ class Cookie
 			self::DEFAULT_EXPIRE,
 		);
 		$this->lifetime = $authCookieDays * 24 * 60 * 60;
-
-		$this->remoteAddr = $request->getRemoteAddress();
 
 		$this->data = json_decode($COOKIE[self::NAME] ?? '[]', true) ?: [];
 	}

--- a/src/Module/HTTPException/PageNotFound.php
+++ b/src/Module/HTTPException/PageNotFound.php
@@ -23,11 +23,19 @@ class PageNotFound extends BaseModule
 	/** @var string */
 	private $remoteAddress;
 
-	public function __construct(L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, App\Request $request, array $server, array $parameters = [])
-	{
+	public function __construct(
+		L10n $l10n,
+		App\BaseURL $baseUrl,
+		App\Arguments $args,
+		LoggerInterface $logger,
+		Profiler $profiler,
+		Response $response,
+		array $server,
+		array $parameters = [],
+	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
-		$this->remoteAddress = $request->getRemoteAddress();
+		$this->remoteAddress = $this->getServerRequest()->getRemoteAddress();
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Search/Index.php
+++ b/src/Module/Search/Index.php
@@ -35,11 +35,20 @@ class Index extends BaseSearch
 	/** @var string  */
 	private $remoteAddress;
 
-	public function __construct(L10n $l10n, App\BaseURL $baseUrl, App\Arguments $args, LoggerInterface $logger, Profiler $profiler, Response $response, App\Request $request, private readonly ConversationRenderer $conversationRenderer, array $server, array $parameters = [])
-	{
+	public function __construct(
+		L10n $l10n,
+		App\BaseURL $baseUrl,
+		App\Arguments $args,
+		LoggerInterface $logger,
+		Profiler $profiler,
+		Response $response,
+		private readonly ConversationRenderer $conversationRenderer,
+		array $server,
+		array $parameters = [],
+	) {
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 
-		$this->remoteAddress = $request->getRemoteAddress();
+		$this->remoteAddress = $this->getServerRequest()->getRemoteAddress();
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Security/PasswordTooLong.php
+++ b/src/Module/Security/PasswordTooLong.php
@@ -27,8 +27,8 @@ class PasswordTooLong extends \Friendica\BaseModule
 
 	protected function post(array $request = [])
 	{
-		$newpass = $request['password'];
-		$confirm = $request['password_confirm'];
+		$newpass = $this->getServerRequest()->getBodyString('password');
+		$confirm = $this->getServerRequest()->getBodyString('password_confirm');
 
 		try {
 			if ($newpass != $confirm) {
@@ -36,9 +36,9 @@ class PasswordTooLong extends \Friendica\BaseModule
 			}
 
 			//  check if the old password was supplied correctly before changing it to the new value
-			User::getIdFromPasswordAuthentication($this->userSession->getLocalUserId(), $request['password_current']);
+			User::getIdFromPasswordAuthentication($this->userSession->getLocalUserId(), $this->getServerRequest()->getBodyString('password_current'));
 
-			if (strlen($request['password_current']) <= 72) {
+			if (strlen($this->getServerRequest()->getBodyString('password_current')) <= 72) {
 				throw new \Exception($this->l10n->t('Password does not need changing.'));
 			}
 
@@ -49,7 +49,7 @@ class PasswordTooLong extends \Friendica\BaseModule
 
 			$this->sysmsg->addInfo($this->l10n->t('Password changed.'));
 
-			$this->baseUrl->redirect($request['return_url'] ?? '');
+			$this->baseUrl->redirect($this->getServerRequest()->getQueryString('return_url'));
 		} catch (\Exception $e) {
 			$this->sysmsg->addNotice($e->getMessage());
 			$this->sysmsg->addNotice($this->l10n->t('Password unchanged.'));
@@ -73,7 +73,7 @@ class PasswordTooLong extends \Friendica\BaseModule
 			],
 
 			'$form_security_token' => self::getFormSecurityToken('security/password_too_long'),
-			'$return_url'          => $request['return_url'] ?? '',
+			'$return_url'          => $this->getServerRequest()->getQueryString('return_url'),
 
 			'$password_current' => ['password_current', $this->l10n->t('Current Password:'), '', $this->l10n->t('Your current password to confirm the changes'), 'required', 'autocomplete="off"'],
 			'$password'         => ['password', $this->l10n->t('New Password:'), '', $this->l10n->t('Allowed characters are a-z, A-Z, 0-9 and special characters except white spaces and accentuated letters.') . ' ' . $this->l10n->t('Password length is limited to 72 characters.'), 'required', 'autocomplete="off"', User::getPasswordRegExp()],

--- a/src/Module/Special/HTTPException.php
+++ b/src/Module/Special/HTTPException.php
@@ -8,7 +8,6 @@
 namespace Friendica\Module\Special;
 
 use Friendica\App\Arguments;
-use Friendica\App\Request;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session\Model\UserSession;
@@ -38,14 +37,20 @@ class HTTPException
 	/** @var string */
 	protected $requestId;
 
-	public function __construct(L10n $l10n, LoggerInterface $logger, Arguments $args, UserSession $session, Request $request, array $server = [])
-	{
+	public function __construct(
+		L10n $l10n,
+		LoggerInterface $logger,
+		Arguments $args,
+		UserSession $session,
+		string $requestId,
+		array $server = [],
+	) {
 		$this->logger      = $logger;
 		$this->l10n        = $l10n;
 		$this->args        = $args;
 		$this->isSiteAdmin = $session->isSiteAdmin();
 		$this->server      = $server;
-		$this->requestId   = $request->getRequestId();
+		$this->requestId   = $requestId;
 	}
 
 	/**

--- a/src/Security/Authentication.php
+++ b/src/Security/Authentication.php
@@ -10,7 +10,6 @@ namespace Friendica\Security;
 use Exception;
 use Friendica\App\BaseURL;
 use Friendica\App\Mode;
-use Friendica\App\Request;
 use Friendica\AppHelper;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\PConfig\Capability\IManagePersonalConfigValues;
@@ -37,9 +36,6 @@ use Psr\Log\LoggerInterface;
  */
 class Authentication
 {
-	/** @var string */
-	private $remoteAddress;
-
 	/**
 	 * Sets the X-Account-Management-Status header
 	 *
@@ -64,7 +60,7 @@ class Authentication
 	 * @param Cookie                      $cookie
 	 * @param IHandleUserSessions         $session
 	 * @param IManagePersonalConfigValues $pConfig
-	 * @param Request                     $request
+	 * @param string                      $remoteAddress
 	 */
 	public function __construct(
 		private readonly IManageConfigValues $config,
@@ -77,10 +73,8 @@ class Authentication
 		private readonly IHandleUserSessions $session,
 		private readonly IManagePersonalConfigValues $pConfig,
 		private readonly AppHelper $appHelper,
-		Request $request,
-	) {
-		$this->remoteAddress = $request->getRemoteAddress();
-	}
+		private readonly string $remoteAddress,
+	) {}
 
 	/**
 	 * Tries to auth the user from the cookie or session

--- a/src/Util/HTTPInputData.php
+++ b/src/Util/HTTPInputData.php
@@ -7,6 +7,8 @@
 
 namespace Friendica\Util;
 
+use Psr\Http\Message\ServerRequestInterface;
+
 /**
  * Derived from the work of Reid Johnson <https://codereview.stackexchange.com/users/4020/reid-johnson>
  * @see https://codereview.stackexchange.com/questions/69882/parsing-multipart-form-data-in-php-for-put-requests
@@ -15,10 +17,13 @@ class HTTPInputData
 {
 	/** @var array The $_SERVER variable */
 	protected $server;
+	/** @var ServerRequestInterface|null A PSR-7 request as alternative source for the body */
+	protected $request;
 
-	public function __construct(array $server)
+	public function __construct(array $server, ?ServerRequestInterface $request = null)
 	{
-		$this->server = $server;
+		$this->server  = $server;
+		$this->request = $request;
 	}
 
 	/**
@@ -267,6 +272,14 @@ class HTTPInputData
 	 */
 	protected function getPhpInputStream()
 	{
+		if ($this->request !== null) {
+			$bodyContent = (string) $this->request->getBody();
+			$stream      = fopen('php://temp', 'rb+');
+			fwrite($stream, $bodyContent);
+			rewind($stream);
+			return $stream;
+		}
+
 		return fopen('php://input', 'rb');
 	}
 
@@ -278,6 +291,10 @@ class HTTPInputData
 	 */
 	protected function getPhpInputContent()
 	{
+		if ($this->request !== null) {
+			return (string) $this->request->getBody();
+		}
+
 		return file_get_contents('php://input');
 	}
 }

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -191,7 +191,7 @@ return (function (string $basepath, array $getVars, array $serverVars, array $co
 			'instanceOf'      => \Friendica\Core\Logger\Util\Introspection::class,
 			'constructParams' => [
 				[
-					\Dice\Dice::INSTANCE => function() use ($serverVars) {
+					\Dice\Dice::INSTANCE => function () use ($serverVars) {
 						return \Friendica\App\Request::determineRequestId($serverVars);
 					},
 				],
@@ -252,7 +252,7 @@ return (function (string $basepath, array $getVars, array $serverVars, array $co
 		\Friendica\Security\Authentication::class => [
 			'constructParams' => [
 				[
-					\Dice\Dice::INSTANCE => function(\Dice\Dice $dice) use ($serverVars) {
+					\Dice\Dice::INSTANCE => function (\Dice\Dice $dice) use ($serverVars) {
 						$config = $dice->create(\Friendica\Core\Config\Capability\IManageConfigValues::class);
 						return \Friendica\App\Request::determineRemoteAddress($config, $serverVars);
 					},
@@ -265,7 +265,7 @@ return (function (string $basepath, array $getVars, array $serverVars, array $co
 		\Friendica\Model\User\Cookie::class => [
 			'constructParams' => [
 				[
-					\Dice\Dice::INSTANCE => function(\Dice\Dice $dice) use ($serverVars) {
+					\Dice\Dice::INSTANCE => function (\Dice\Dice $dice) use ($serverVars) {
 						$config = $dice->create(\Friendica\Core\Config\Capability\IManageConfigValues::class);
 						return \Friendica\App\Request::determineRemoteAddress($config, $serverVars);
 					},
@@ -310,7 +310,7 @@ return (function (string $basepath, array $getVars, array $serverVars, array $co
 		\Friendica\Module\Special\HTTPException::class => [
 			'constructParams' => [
 				[
-					\Dice\Dice::INSTANCE => function() use ($serverVars) {
+					\Dice\Dice::INSTANCE => function () use ($serverVars) {
 						return \Friendica\App\Request::determineRequestId($serverVars);
 					},
 				],

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -277,11 +277,6 @@ return (function (string $basepath, array $getVars, array $serverVars, array $co
 				$serverVars,
 			],
 		],
-		\Friendica\App\Request::class => [
-			'constructParams' => [
-				$serverVars,
-			],
-		],
 		\Psr\Clock\ClockInterface::class => [
 			'instanceOf' => \Friendica\Util\Clock\SystemClock::class,
 		],

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -277,6 +277,12 @@ return (function (string $basepath, array $getVars, array $serverVars, array $co
 				$serverVars,
 			],
 		],
+		\Friendica\App\Request::class => [
+			'constructParams' => [
+				new \GuzzleHttp\Psr7\ServerRequest($serverVars['REQUEST_METHOD'] ?? 'GET', 'http://localhost', [], null, '1.1', $serverVars),
+				[Dice::INSTANCE => \Friendica\Core\Config\Capability\IManageConfigValues::class],
+			],
+		],
 		\Psr\Clock\ClockInterface::class => [
 			'instanceOf' => \Friendica\Util\Clock\SystemClock::class,
 		],

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -277,12 +277,6 @@ return (function (string $basepath, array $getVars, array $serverVars, array $co
 				$serverVars,
 			],
 		],
-		\Friendica\App\Request::class => [
-			'constructParams' => [
-				new \GuzzleHttp\Psr7\ServerRequest($serverVars['REQUEST_METHOD'] ?? 'GET', 'http://localhost', [], null, '1.1', $serverVars),
-				[Dice::INSTANCE => \Friendica\Core\Config\Capability\IManageConfigValues::class],
-			],
-		],
 		\Psr\Clock\ClockInterface::class => [
 			'instanceOf' => \Friendica\Util\Clock\SystemClock::class,
 		],

--- a/static/dependencies.config.php
+++ b/static/dependencies.config.php
@@ -190,6 +190,11 @@ return (function (string $basepath, array $getVars, array $serverVars, array $co
 		\Friendica\Core\Logger\Capability\IHaveCallIntrospections::class => [
 			'instanceOf'      => \Friendica\Core\Logger\Util\Introspection::class,
 			'constructParams' => [
+				[
+					\Dice\Dice::INSTANCE => function() use ($serverVars) {
+						return \Friendica\App\Request::determineRequestId($serverVars);
+					},
+				],
 				\Friendica\Core\Logger\Capability\IHaveCallIntrospections::IGNORE_CLASS_LIST,
 			],
 		],
@@ -244,8 +249,30 @@ return (function (string $basepath, array $getVars, array $serverVars, array $co
 		\Friendica\Core\Session\Capability\IHandleUserSessions::class => [
 			'instanceOf' => \Friendica\Core\Session\Model\UserSession::class,
 		],
+		\Friendica\Security\Authentication::class => [
+			'constructParams' => [
+				[
+					\Dice\Dice::INSTANCE => function(\Dice\Dice $dice) use ($serverVars) {
+						$config = $dice->create(\Friendica\Core\Config\Capability\IManageConfigValues::class);
+						return \Friendica\App\Request::determineRemoteAddress($config, $serverVars);
+					},
+					'params' => [
+						[\Dice\Dice::INSTANCE => \Dice\Dice::SELF],
+					],
+				],
+			],
+		],
 		\Friendica\Model\User\Cookie::class => [
 			'constructParams' => [
+				[
+					\Dice\Dice::INSTANCE => function(\Dice\Dice $dice) use ($serverVars) {
+						$config = $dice->create(\Friendica\Core\Config\Capability\IManageConfigValues::class);
+						return \Friendica\App\Request::determineRemoteAddress($config, $serverVars);
+					},
+					'params' => [
+						[\Dice\Dice::INSTANCE => \Dice\Dice::SELF],
+					],
+				],
 				$cookieVars,
 			],
 		],
@@ -282,6 +309,11 @@ return (function (string $basepath, array $getVars, array $serverVars, array $co
 		],
 		\Friendica\Module\Special\HTTPException::class => [
 			'constructParams' => [
+				[
+					\Dice\Dice::INSTANCE => function() use ($serverVars) {
+						return \Friendica\App\Request::determineRequestId($serverVars);
+					},
+				],
 				$serverVars,
 			],
 		],

--- a/tests/FixtureTestTrait.php
+++ b/tests/FixtureTestTrait.php
@@ -20,7 +20,6 @@ use Friendica\Database\DBStructure;
 use Friendica\DI;
 use Friendica\Test\Util\Database\StaticDatabase;
 use Friendica\Test\Util\VFSTrait;
-use Psr\Http\Message\ServerRequestInterface;
 
 trait FixtureTestTrait
 {
@@ -48,9 +47,6 @@ trait FixtureTestTrait
 				'call'       => [['createConfigFileManager', [$this->root->url(), $this->root->url() . '/addon', $server,], Dice::CHAIN_CALL]]])
 			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
 			->addRule(IHandleSessions::class, ['instanceOf' => Memory::class, 'shared' => true, 'call' => null])
-			->addRule('*', ['substitutions' => [
-				ServerRequestInterface::class => $this->createStub(ServerRequestInterface::class),
-			]])
 			->addRule(Arguments::class, [
 				'instanceOf' => Arguments::class,
 				'call'       => [

--- a/tests/FixtureTestTrait.php
+++ b/tests/FixtureTestTrait.php
@@ -20,6 +20,7 @@ use Friendica\Database\DBStructure;
 use Friendica\DI;
 use Friendica\Test\Util\Database\StaticDatabase;
 use Friendica\Test\Util\VFSTrait;
+use Psr\Http\Message\ServerRequestInterface;
 
 trait FixtureTestTrait
 {
@@ -47,6 +48,9 @@ trait FixtureTestTrait
 				'call'       => [['createConfigFileManager', [$this->root->url(), $this->root->url() . '/addon', $server,], Dice::CHAIN_CALL]]])
 			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
 			->addRule(IHandleSessions::class, ['instanceOf' => Memory::class, 'shared' => true, 'call' => null])
+			->addRule('*', ['substitutions' => [
+				ServerRequestInterface::class => $this->createStub(ServerRequestInterface::class),
+			]])
 			->addRule(Arguments::class, [
 				'instanceOf' => Arguments::class,
 				'call'       => [

--- a/tests/Unit/App/RequestTest.php
+++ b/tests/Unit/App/RequestTest.php
@@ -108,8 +108,235 @@ class RequestTest extends TestCase
 			['proxy', 'forwarded_for_headers', Request::DEFAULT_FORWARD_FOR_HEADER, $config['forwarded_for_headers']],
 		]);
 
-		$request = new Request($configClass, $server);
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', $server);
+		$request     = new Request($psr7Request, $configClass);
 
 		self::assertSame($assertion, $request->getRemoteAddress());
+	}
+
+	public function testPsr7Delegation(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('POST', 'http://example.com/test', ['X-Custom' => 'val'], 'body', '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$psr7Request = $psr7Request->withQueryParams(['foo' => 'bar']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		self::assertSame('POST', $request->getMethod());
+		self::assertSame('/test', $request->getRequestTarget());
+		self::assertSame('1.1', $request->getProtocolVersion());
+		self::assertTrue($request->hasHeader('X-Custom'));
+		self::assertSame(['val'], $request->getHeader('X-Custom'));
+		self::assertSame('val', $request->getHeaderLine('X-Custom'));
+		self::assertSame(['foo' => 'bar'], $request->getQueryParams());
+		self::assertSame('body', (string) $request->getBody());
+	}
+
+	public function testGetQueryParam(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$psr7Request = $psr7Request->withQueryParams(['foo' => 'bar', 'num' => '42', 'flag' => '1', 'price' => '9.99']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		self::assertSame('bar', $request->getQueryParam('foo'));
+		self::assertNull($request->getQueryParam('nonexistent'));
+		self::assertSame('default', $request->getQueryParam('nonexistent', 'default'));
+		self::assertSame('bar', $request->getQueryString('foo'));
+		self::assertSame('', $request->getQueryString('nonexistent'));
+		self::assertSame(42, $request->getQueryInt('num'));
+		self::assertSame(0, $request->getQueryInt('nonexistent'));
+		self::assertSame(9.99, $request->getQueryFloat('price'));
+		self::assertSame(0.0, $request->getQueryFloat('nonexistent'));
+		self::assertTrue($request->getQueryBool('flag'));
+		self::assertFalse($request->getQueryBool('nonexistent'));
+	}
+
+	public function testGetBodyParam(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('POST', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$psr7Request = $psr7Request->withParsedBody(['name' => 'Alice', 'age' => '30', 'score' => '9.5', 'active' => '1']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		self::assertSame('Alice', $request->getBodyParam('name'));
+		self::assertNull($request->getBodyParam('nonexistent'));
+		self::assertSame('Alice', $request->getBodyString('name'));
+		self::assertSame(30, $request->getBodyInt('age'));
+		self::assertSame(9.5, $request->getBodyFloat('score'));
+		self::assertTrue($request->getBodyBool('active'));
+	}
+
+	public function testGetInputMerged(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('POST', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$psr7Request = $psr7Request->withQueryParams(['query_key' => 'qv', 'overlap' => 'query_val']);
+		$psr7Request = $psr7Request->withParsedBody(['body_key' => 'bv', 'overlap' => 'body_wins']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		self::assertSame('qv', $request->getInput('query_key'));
+		self::assertSame('bv', $request->getInput('body_key'));
+		self::assertSame('body_wins', $request->getInput('overlap'));
+		self::assertNull($request->getInput('nonexistent'));
+	}
+
+	public function testGetInputWithHttpInput(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('POST', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+		$request     = $request->withHttpInput(['http_key' => 'hv']);
+
+		self::assertSame('hv', $request->getInput('http_key'));
+	}
+
+	public function testGetServerParam(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4', 'HTTP_HOST' => 'example.com']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		self::assertSame('1.2.3.4', $request->getServerParam('REMOTE_ADDR'));
+		self::assertSame('example.com', $request->getServerParam('HTTP_HOST'));
+		self::assertNull($request->getServerParam('nonexistent'));
+	}
+
+	public function testIsMethod(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		self::assertTrue($request->isGet());
+		self::assertTrue($request->isMethod('GET'));
+		self::assertFalse($request->isPost());
+		self::assertFalse($request->isPut());
+		self::assertFalse($request->isPatch());
+		self::assertFalse($request->isDelete());
+
+		$postRequest = new Request($psr7Request->withMethod('POST'), $configClass);
+		self::assertTrue($postRequest->isPost());
+	}
+
+	public function testWithMethodReturnsNewInstance(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		$newRequest = $request->withMethod('POST');
+
+		self::assertNotSame($request, $newRequest);
+		self::assertTrue($request->isGet());
+		self::assertTrue($newRequest->isPost());
+	}
+
+	public function testWithQueryParamsReturnsNewInstance(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		$newRequest = $request->withQueryParams(['new' => 'value']);
+
+		self::assertNotSame($request, $newRequest);
+		self::assertSame(['new' => 'value'], $newRequest->getQueryParams());
+		self::assertSame([], $request->getQueryParams());
+	}
+
+	public function testWithServerParamsUpdatesRemoteAddress(): void
+	{
+		$configClass = self::createMock(IManageConfigValues::class);
+		$configClass->expects(self::atLeast(2))->method('get')->willReturnMap([
+			['proxy', 'trusted_proxies', '', ''],
+			['proxy', 'forwarded_for_headers', Request::DEFAULT_FORWARD_FOR_HEADER, Request::DEFAULT_FORWARD_FOR_HEADER],
+		]);
+
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$request     = new Request($psr7Request, $configClass);
+
+		$newRequest = $request->withServerParams(['REMOTE_ADDR' => '5.6.7.8']);
+
+		self::assertNotSame($request, $newRequest);
+		self::assertSame('5.6.7.8', $newRequest->getRemoteAddress());
+	}
+
+	public function testWithHttpInputReturnsNewInstance(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		$newRequest = $request->withHttpInput(['key' => 'val']);
+
+		self::assertNotSame($request, $newRequest);
+		self::assertSame('val', $newRequest->getInput('key'));
+		self::assertNull($request->getInput('key'));
+	}
+
+	public function testGetCookieParam(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$psr7Request = $psr7Request->withCookieParams(['session' => 'abc123']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		self::assertSame('abc123', $request->getCookieParam('session'));
+		self::assertNull($request->getCookieParam('nonexistent'));
+	}
+
+	public function testTypedGettersDefaultValues(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		self::assertSame('', $request->getQueryString('nonexistent'));
+		self::assertSame(0, $request->getQueryInt('nonexistent'));
+		self::assertSame(0.0, $request->getQueryFloat('nonexistent'));
+		self::assertFalse($request->getQueryBool('nonexistent'));
+		self::assertSame([], $request->getQueryArray('nonexistent'));
+
+		self::assertSame('', $request->getBodyString('nonexistent'));
+		self::assertSame(0, $request->getBodyInt('nonexistent'));
+		self::assertSame(0.0, $request->getBodyFloat('nonexistent'));
+		self::assertFalse($request->getBodyBool('nonexistent'));
+		self::assertSame([], $request->getBodyArray('nonexistent'));
+
+		self::assertSame('', $request->getInputString('nonexistent'));
+		self::assertSame(42, $request->getInputInt('nonexistent', 42));
+		self::assertSame(1.5, $request->getInputFloat('nonexistent', 1.5));
+		self::assertTrue($request->getInputBool('nonexistent', true));
+		self::assertSame(['default'], $request->getInputArray('nonexistent', ['default']));
+	}
+
+	public function testTypeCastingEdgeCases(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$psr7Request = $psr7Request->withQueryParams(['str' => 'hello', 'int' => '42abc', 'float' => '3.14extra', 'bool_true' => '1', 'bool_false' => '0', 'arr' => ['1', '2']]);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		self::assertSame('hello', $request->getQueryString('str'));
+		self::assertSame(0, $request->getQueryInt('int'), '42abc should not validate as int');
+		self::assertSame(0.0, $request->getQueryFloat('float'), '3.14extra should not validate as float');
+		self::assertTrue($request->getQueryBool('bool_true'));
+		self::assertFalse($request->getQueryBool('bool_false'));
+		self::assertSame(['1', '2'], $request->getQueryArray('arr'));
+	}
+
+	public function testGetUploadedFile(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('POST', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
+		$upload = new \GuzzleHttp\Psr7\UploadedFile(\GuzzleHttp\Psr7\Utils::streamFor('test'), 4, UPLOAD_ERR_OK, 'file.txt');
+		$psr7Request = $psr7Request->withUploadedFiles(['avatar' => $upload]);
+		$configClass = self::createMock(IManageConfigValues::class);
+		$request     = new Request($psr7Request, $configClass);
+
+		$result = $request->getUploadedFile('avatar');
+		self::assertNotNull($result);
+		self::assertSame('file.txt', $result->getClientFilename());
+
+		self::assertNull($request->getUploadedFile('nonexistent'));
 	}
 }

--- a/tests/Unit/App/RequestTest.php
+++ b/tests/Unit/App/RequestTest.php
@@ -166,7 +166,7 @@ class RequestTest extends TestCase
 		self::assertTrue($request->getBodyBool('active'));
 	}
 
-	public function testGetInputMerged(): void
+	public function testGetAllInputMerged(): void
 	{
 		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('POST', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
 		$psr7Request = $psr7Request->withQueryParams(['query_key' => 'qv', 'overlap' => 'query_val']);
@@ -174,20 +174,12 @@ class RequestTest extends TestCase
 		$configClass = self::createMock(IManageConfigValues::class);
 		$request     = new Request($psr7Request, $configClass);
 
-		self::assertSame('qv', $request->getInput('query_key'));
-		self::assertSame('bv', $request->getInput('body_key'));
-		self::assertSame('body_wins', $request->getInput('overlap'));
-		self::assertNull($request->getInput('nonexistent'));
-	}
+		$allInput = $request->getAllInput();
 
-	public function testGetInputWithHttpInput(): void
-	{
-		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('POST', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
-		$configClass = self::createMock(IManageConfigValues::class);
-		$request     = new Request($psr7Request, $configClass);
-		$request     = $request->withHttpInput(['http_key' => 'hv']);
-
-		self::assertSame('hv', $request->getInput('http_key'));
+		self::assertSame('qv', $allInput['query_key']);
+		self::assertSame('bv', $allInput['body_key']);
+		self::assertSame('body_wins', $allInput['overlap']);
+		self::assertArrayNotHasKey('nonexistent', $allInput);
 	}
 
 	public function testGetServerParam(): void
@@ -201,23 +193,6 @@ class RequestTest extends TestCase
 		self::assertNull($request->getServerParam('nonexistent'));
 	}
 
-	public function testIsMethod(): void
-	{
-		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
-		$configClass = self::createMock(IManageConfigValues::class);
-		$request     = new Request($psr7Request, $configClass);
-
-		self::assertTrue($request->isGet());
-		self::assertTrue($request->isMethod('GET'));
-		self::assertFalse($request->isPost());
-		self::assertFalse($request->isPut());
-		self::assertFalse($request->isPatch());
-		self::assertFalse($request->isDelete());
-
-		$postRequest = new Request($psr7Request->withMethod('POST'), $configClass);
-		self::assertTrue($postRequest->isPost());
-	}
-
 	public function testWithMethodReturnsNewInstance(): void
 	{
 		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
@@ -227,8 +202,8 @@ class RequestTest extends TestCase
 		$newRequest = $request->withMethod('POST');
 
 		self::assertNotSame($request, $newRequest);
-		self::assertTrue($request->isGet());
-		self::assertTrue($newRequest->isPost());
+		self::assertSame('GET', $request->getMethod());
+		self::assertSame('POST', $newRequest->getMethod());
 	}
 
 	public function testWithQueryParamsReturnsNewInstance(): void
@@ -261,19 +236,6 @@ class RequestTest extends TestCase
 		self::assertSame('5.6.7.8', $newRequest->getRemoteAddress());
 	}
 
-	public function testWithHttpInputReturnsNewInstance(): void
-	{
-		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
-		$configClass = self::createMock(IManageConfigValues::class);
-		$request     = new Request($psr7Request, $configClass);
-
-		$newRequest = $request->withHttpInput(['key' => 'val']);
-
-		self::assertNotSame($request, $newRequest);
-		self::assertSame('val', $newRequest->getInput('key'));
-		self::assertNull($request->getInput('key'));
-	}
-
 	public function testGetCookieParam(): void
 	{
 		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
@@ -302,12 +264,6 @@ class RequestTest extends TestCase
 		self::assertSame(0.0, $request->getBodyFloat('nonexistent'));
 		self::assertFalse($request->getBodyBool('nonexistent'));
 		self::assertSame([], $request->getBodyArray('nonexistent'));
-
-		self::assertSame('', $request->getInputString('nonexistent'));
-		self::assertSame(42, $request->getInputInt('nonexistent', 42));
-		self::assertSame(1.5, $request->getInputFloat('nonexistent', 1.5));
-		self::assertTrue($request->getInputBool('nonexistent', true));
-		self::assertSame(['default'], $request->getInputArray('nonexistent', ['default']));
 	}
 
 	public function testTypeCastingEdgeCases(): void

--- a/tests/Unit/App/RequestTest.php
+++ b/tests/Unit/App/RequestTest.php
@@ -328,7 +328,7 @@ class RequestTest extends TestCase
 	public function testGetUploadedFile(): void
 	{
 		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('POST', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
-		$upload = new \GuzzleHttp\Psr7\UploadedFile(\GuzzleHttp\Psr7\Utils::streamFor('test'), 4, UPLOAD_ERR_OK, 'file.txt');
+		$upload      = new \GuzzleHttp\Psr7\UploadedFile(\GuzzleHttp\Psr7\Utils::streamFor('test'), 4, UPLOAD_ERR_OK, 'file.txt');
 		$psr7Request = $psr7Request->withUploadedFiles(['avatar' => $upload]);
 		$configClass = self::createMock(IManageConfigValues::class);
 		$request     = new Request($psr7Request, $configClass);

--- a/tests/Unit/App/RequestTest.php
+++ b/tests/Unit/App/RequestTest.php
@@ -219,23 +219,6 @@ class RequestTest extends TestCase
 		self::assertSame([], $request->getQueryParams());
 	}
 
-	public function testWithServerParamsUpdatesRemoteAddress(): void
-	{
-		$configClass = self::createMock(IManageConfigValues::class);
-		$configClass->expects(self::atLeast(2))->method('get')->willReturnMap([
-			['proxy', 'trusted_proxies', '', ''],
-			['proxy', 'forwarded_for_headers', Request::DEFAULT_FORWARD_FOR_HEADER, Request::DEFAULT_FORWARD_FOR_HEADER],
-		]);
-
-		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);
-		$request     = new Request($psr7Request, $configClass);
-
-		$newRequest = $request->withServerParams(['REMOTE_ADDR' => '5.6.7.8']);
-
-		self::assertNotSame($request, $newRequest);
-		self::assertSame('5.6.7.8', $newRequest->getRemoteAddress());
-	}
-
 	public function testGetCookieParam(): void
 	{
 		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', ['REMOTE_ADDR' => '1.2.3.4']);

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -39,12 +39,12 @@ class AppTest extends TestCase
 			['Content-Type' => 'application/x-www-form-urlencoded;charset=utf8'],
 			'title=Test2',
 			'1.1',
-			['CONTENT_TYPE' => 'application/x-www-form-urlencoded;charset=utf8']
+			['CONTENT_TYPE' => 'application/x-www-form-urlencoded;charset=utf8'],
 		);
 
 		$app = App::fromContainer($this->createStub(Container::class));
 
-		$method = new \ReflectionMethod(App::class, 'mergeRequestInput');
+		$method          = new \ReflectionMethod(App::class, 'mergeRequestInput');
 		$modifiedRequest = $method->invoke($app, $psr7Request);
 
 		$appRequest = new Request($modifiedRequest, $configMock);
@@ -65,13 +65,13 @@ class AppTest extends TestCase
 			['Content-Type' => 'application/x-www-form-urlencoded;charset=utf8'],
 			'title=Test',
 			'1.1',
-			['CONTENT_TYPE' => 'application/x-www-form-urlencoded;charset=utf8']
+			['CONTENT_TYPE' => 'application/x-www-form-urlencoded;charset=utf8'],
 		);
 		$psr7Request = $psr7Request->withUploadedFiles(['avatar' => $uploadedFile]);
 
 		$app = App::fromContainer($this->createStub(Container::class));
 
-		$method = new \ReflectionMethod(App::class, 'mergeRequestInput');
+		$method          = new \ReflectionMethod(App::class, 'mergeRequestInput');
 		$modifiedRequest = $method->invoke($app, $psr7Request);
 
 		self::assertArrayHasKey('avatar', $modifiedRequest->getUploadedFiles());

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -10,7 +10,10 @@ declare(strict_types=1);
 namespace Friendica\Test\Unit;
 
 use Friendica\App;
+use Friendica\App\Request;
+use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Container;
+use GuzzleHttp\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
 
 class AppTest extends TestCase
@@ -23,5 +26,55 @@ class AppTest extends TestCase
 		$app = App::fromContainer($container);
 
 		$this->assertInstanceOf(App::class, $app); // @phpstan-ignore method.alreadyNarrowedType
+	}
+
+	public function testMergeBodyIntoPsr7Request(): void
+	{
+		$configMock = $this->createMock(IManageConfigValues::class);
+		$configMock->method('get')->willReturn('');
+
+		$psr7Request = new ServerRequest(
+			'POST',
+			'http://example.com',
+			['Content-Type' => 'application/x-www-form-urlencoded;charset=utf8'],
+			'title=Test2',
+			'1.1',
+			['CONTENT_TYPE' => 'application/x-www-form-urlencoded;charset=utf8']
+		);
+
+		$app = App::fromContainer($this->createStub(Container::class));
+
+		$method = new \ReflectionMethod(App::class, 'mergeRequestInput');
+		$modifiedRequest = $method->invoke($app, $psr7Request);
+
+		$appRequest = new Request($modifiedRequest, $configMock);
+
+		self::assertSame('Test2', $appRequest->getBodyParam('title'));
+	}
+
+	public function testMergeRequestInputPreservesUploadedFiles(): void
+	{
+		$configMock = $this->createMock(IManageConfigValues::class);
+		$configMock->method('get')->willReturn('');
+
+		$uploadedFile = $this->createStub(\Psr\Http\Message\UploadedFileInterface::class);
+
+		$psr7Request = new ServerRequest(
+			'POST',
+			'http://example.com',
+			['Content-Type' => 'application/x-www-form-urlencoded;charset=utf8'],
+			'title=Test',
+			'1.1',
+			['CONTENT_TYPE' => 'application/x-www-form-urlencoded;charset=utf8']
+		);
+		$psr7Request = $psr7Request->withUploadedFiles(['avatar' => $uploadedFile]);
+
+		$app = App::fromContainer($this->createStub(Container::class));
+
+		$method = new \ReflectionMethod(App::class, 'mergeRequestInput');
+		$modifiedRequest = $method->invoke($app, $psr7Request);
+
+		self::assertArrayHasKey('avatar', $modifiedRequest->getUploadedFiles());
+		self::assertSame($uploadedFile, $modifiedRequest->getUploadedFiles()['avatar']);
 	}
 }

--- a/tests/Unit/BaseModuleTest.php
+++ b/tests/Unit/BaseModuleTest.php
@@ -13,7 +13,6 @@ use Friendica\App\Arguments;
 use Friendica\App\Request;
 use Friendica\App\Router;
 use Friendica\BaseModule;
-use Friendica\Event\ModuleContentEvent;
 use Friendica\Module\Response;
 use Friendica\Util\Profiler;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/BaseModuleTest.php
+++ b/tests/Unit/BaseModuleTest.php
@@ -1,0 +1,167 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Unit;
+
+use Friendica\App\Arguments;
+use Friendica\App\Request;
+use Friendica\App\Router;
+use Friendica\BaseModule;
+use Friendica\Event\ModuleContentEvent;
+use Friendica\Module\Response;
+use Friendica\Util\Profiler;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class BaseModuleTest extends TestCase
+{
+	public function testGetServerRequestReturnsPreviousSetRequest(): void
+	{
+		$module = (new \ReflectionClass(BaseModuleTestModule::class))->newInstanceWithoutConstructor();
+
+		$request = $this->createStub(Request::class);
+
+		$appRequestProp = new \ReflectionProperty(BaseModule::class, 'appRequest');
+		$appRequestProp->setValue($module, $request);
+
+		$method = new \ReflectionMethod(BaseModule::class, 'getServerRequest');
+		$this->assertSame($request, $method->invoke($module));
+	}
+
+	public function testGetServerRequestThrowsWhenUnset(): void
+	{
+		$module = (new \ReflectionClass(BaseModuleTestModule::class))->newInstanceWithoutConstructor();
+
+		$method = new \ReflectionMethod(BaseModule::class, 'getServerRequest');
+
+		$this->expectException(\RuntimeException::class);
+		$method->invoke($module);
+	}
+
+	public function testHandleRequestDispatchesToGet(): void
+	{
+		$module = $this->createModuleWithMocks();
+
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn(['key' => 'value']);
+
+		$module->handleRequest($request);
+
+		$this->assertSame(['key' => 'value'], $module->receivedInput);
+	}
+
+	public function testHandleRequestDispatchesToPost(): void
+	{
+		$module = $this->createModuleWithMocks(Router::POST);
+
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn(['post_key' => 'post_val']);
+
+		$module->handleRequest($request);
+
+		$this->assertSame(['post_key' => 'post_val'], $module->receivedInput);
+	}
+
+	public function testHandleRequestSetsServerRequest(): void
+	{
+		$module = $this->createModuleWithMocks();
+
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn([]);
+
+		$module->handleRequest($request);
+
+		$method = new \ReflectionMethod(BaseModule::class, 'getServerRequest');
+		$this->assertSame($request, $method->invoke($module));
+	}
+
+	public function testRunBcPathStillWorks(): void
+	{
+		$module = $this->createModuleWithMocks();
+
+		$httpException = $this->createStub(\Friendica\Module\Special\HTTPException::class);
+
+		$requestArray = ['key' => 'value'];
+		$module->run($httpException, $requestArray);
+
+		$this->assertSame($requestArray, $module->receivedInput);
+	}
+
+	public function testRunBcPathDoesNotSetServerRequest(): void
+	{
+		$module = $this->createModuleWithMocks();
+
+		$httpException = $this->createStub(\Friendica\Module\Special\HTTPException::class);
+		$module->run($httpException, ['key' => 'value']);
+
+		$method = new \ReflectionMethod(BaseModule::class, 'getServerRequest');
+
+		$this->expectException(\RuntimeException::class);
+		$method->invoke($module);
+	}
+
+	/**
+	 * @return BaseModuleTestModule
+	 */
+	private function createModuleWithMocks(string $method = Router::GET): BaseModuleTestModule
+	{
+		/** @var BaseModuleTestModule $module */
+		$module = (new \ReflectionClass(BaseModuleTestModule::class))->newInstanceWithoutConstructor();
+
+		$args = $this->createMock(Arguments::class);
+		$args->method('getMethod')->willReturn($method);
+		$args->method('getModuleName')->willReturn('test');
+		$args->method('getCommand')->willReturn('test');
+		$args->method('getQueryString')->willReturn('test');
+
+		$response = $this->createMock(Response::class);
+		$response->method('setHeader');
+		$response->method('addContent');
+		$response->method('generate')->willReturn($this->createStub(ResponseInterface::class));
+
+		$profiler = $this->createMock(Profiler::class);
+
+		$eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+		$eventDispatcher->method('dispatch')->willReturnArgument(0);
+
+		$this->setModuleProperty($module, 'args', $args);
+		$this->setModuleProperty($module, 'response', $response);
+		$this->setModuleProperty($module, 'profiler', $profiler);
+		$this->setModuleProperty($module, 'eventDispatcher', $eventDispatcher);
+
+		return $module;
+	}
+
+	private function setModuleProperty(BaseModule $module, string $name, mixed $value): void
+	{
+		$prop = new \ReflectionProperty(BaseModule::class, $name);
+		$prop->setValue($module, $value);
+	}
+}
+
+class BaseModuleTestModule extends BaseModule
+{
+	public array $receivedInput = [];
+
+	protected function get(array $request = []): void
+	{
+		$this->receivedInput = $request;
+	}
+
+	protected function post(array $request = []): void
+	{
+		$this->receivedInput = $request;
+	}
+
+	protected function content(array $request = []): string
+	{
+		return 'test';
+	}
+}

--- a/tests/Unit/BaseModuleTest.php
+++ b/tests/Unit/BaseModuleTest.php
@@ -88,7 +88,7 @@ class BaseModuleTest extends TestCase
 		$httpException = $this->createStub(\Friendica\Module\Special\HTTPException::class);
 
 		$requestArray = ['key' => 'value'];
-		$module->run($httpException, $requestArray);
+		$module->run($httpException, $requestArray); // @phpstan-ignore method.deprecated
 
 		$this->assertSame($requestArray, $module->receivedInput);
 	}
@@ -98,7 +98,7 @@ class BaseModuleTest extends TestCase
 		$module = $this->createModuleWithMocks();
 
 		$httpException = $this->createStub(\Friendica\Module\Special\HTTPException::class);
-		$module->run($httpException, ['key' => 'value']);
+		$module->run($httpException, ['key' => 'value']); // @phpstan-ignore method.deprecated
 
 		$method = new \ReflectionMethod(BaseModule::class, 'getServerRequest');
 

--- a/tests/Unit/Module/Security/PasswordTooLongTest.php
+++ b/tests/Unit/Module/Security/PasswordTooLongTest.php
@@ -26,7 +26,6 @@ use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
-use ReflectionClass;
 
 class PasswordTooLongTest extends TestCase
 {
@@ -37,7 +36,7 @@ class PasswordTooLongTest extends TestCase
 			$this->createStub(SystemMessages::class),
 			$this->createStub(L10n::class),
 			$this->createStub(BaseURL::class),
-			Router::GET
+			Router::GET,
 		);
 
 		$request = $this->createMock(Request::class);
@@ -50,7 +49,7 @@ class PasswordTooLongTest extends TestCase
 	public function testPostReadsPasswordFromTypedGetter(): void
 	{
 		$notices = [];
-		$sysmsg = $this->createMock(SystemMessages::class);
+		$sysmsg  = $this->createMock(SystemMessages::class);
 		$sysmsg->expects($this->atLeastOnce())
 			->method('addNotice')
 			->willReturnCallback(function (string $message) use (&$notices): void {
@@ -106,7 +105,7 @@ class PasswordTooLongTest extends TestCase
 		$eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 		$eventDispatcher->method('dispatch')->willReturnArgument(0);
 
-		$logger   = $this->createMock(LoggerInterface::class);
+		$logger      = $this->createMock(LoggerInterface::class);
 		$userSession = $this->createMock(IHandleUserSessions::class);
 
 		$this->setModuleProperty($module, 'baseUrl', $baseUrl);

--- a/tests/Unit/Module/Security/PasswordTooLongTest.php
+++ b/tests/Unit/Module/Security/PasswordTooLongTest.php
@@ -1,0 +1,139 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Unit\Module\Security;
+
+use Friendica\App\Arguments;
+use Friendica\App\BaseURL;
+use Friendica\App\Request;
+use Friendica\App\Router;
+use Friendica\BaseModule;
+use Friendica\Core\L10n;
+use Friendica\Core\Session\Capability\IHandleUserSessions;
+use Friendica\Module\Response;
+use Friendica\Module\Security\PasswordTooLong;
+use Friendica\Navigation\SystemMessages;
+use Friendica\Util\Profiler;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+class PasswordTooLongTest extends TestCase
+{
+	#[DoesNotPerformAssertions]
+	public function testGetDispatchesContentWithQueryString(): void
+	{
+		$module = $this->createPasswordTooLongModule(
+			$this->createStub(SystemMessages::class),
+			$this->createStub(L10n::class),
+			$this->createStub(BaseURL::class),
+			Router::GET
+		);
+
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$module->handleRequest($request);
+	}
+
+	public function testPostReadsPasswordFromTypedGetter(): void
+	{
+		$notices = [];
+		$sysmsg = $this->createMock(SystemMessages::class);
+		$sysmsg->expects($this->atLeastOnce())
+			->method('addNotice')
+			->willReturnCallback(function (string $message) use (&$notices): void {
+				$notices[] = $message;
+			});
+
+		$l10n = $this->createMock(L10n::class);
+		$l10n->method('t')->willReturnArgument(0);
+
+		$baseUrl = $this->createMock(BaseURL::class);
+		$baseUrl->expects($this->never())->method('redirect');
+
+		$module = $this->createPasswordTooLongModule($sysmsg, $l10n, $baseUrl);
+
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getBodyString')->willReturnMap([
+			['password', '', 'newpass_abc'],
+			['password_confirm', '', 'newpass_XYZ'],
+		]);
+
+		$module->handleRequest($request);
+
+		$this->assertContains('Passwords do not match.', $notices);
+	}
+
+	/**
+	 * @return PasswordTooLong&MockObject
+	 */
+	private function createPasswordTooLongModule(SystemMessages $sysmsg, L10n $l10n, BaseURL $baseUrl, string $method = Router::POST): PasswordTooLong
+	{
+		/** @var PasswordTooLong&MockObject $module */
+		$module = $this->getMockBuilder(PasswordTooLong::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['content'])
+			->getMock();
+
+		$module->method('content')->willReturn('');
+
+		$args = $this->createMock(Arguments::class);
+		$args->method('getMethod')->willReturn($method);
+		$args->method('getModuleName')->willReturn('security/password_too_long');
+		$args->method('getCommand')->willReturn('security/password_too_long');
+		$args->method('getQueryString')->willReturn('test');
+
+		$response = $this->createMock(Response::class);
+		$response->method('setHeader');
+		$response->method('addContent');
+		$response->method('generate')->willReturn($this->createStub(ResponseInterface::class));
+
+		$profiler = $this->createMock(Profiler::class);
+
+		$eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+		$eventDispatcher->method('dispatch')->willReturnArgument(0);
+
+		$logger   = $this->createMock(LoggerInterface::class);
+		$userSession = $this->createMock(IHandleUserSessions::class);
+
+		$this->setModuleProperty($module, 'baseUrl', $baseUrl);
+		$this->setModuleProperty($module, 'args', $args);
+		$this->setModuleProperty($module, 'response', $response);
+		$this->setModuleProperty($module, 'profiler', $profiler);
+		$this->setModuleProperty($module, 'eventDispatcher', $eventDispatcher);
+		$this->setModuleProperty($module, 'l10n', $l10n);
+		$this->setModuleProperty($module, 'logger', $logger);
+		$this->setModuleProperty($module, 'server', []);
+		$this->setModuleProperty($module, 'parameters', []);
+
+		$this->setModuleProperty($module, 'sysmsg', $sysmsg);
+		$this->setModuleProperty($module, 'userSession', $userSession);
+
+		return $module;
+	}
+
+	private function setModuleProperty(object $module, string $name, mixed $value): void
+	{
+		foreach ([PasswordTooLong::class, BaseModule::class] as $class) {
+			if ((new \ReflectionClass($class))->hasProperty($name)) {
+				$prop = new \ReflectionProperty($class, $name);
+				$prop->setValue($module, $value);
+				return;
+			}
+		}
+		throw new \InvalidArgumentException(sprintf('Property %s not found on %s or BaseModule', $name, $module::class));
+	}
+}

--- a/tests/Util/HTTPInputDataDouble.php
+++ b/tests/Util/HTTPInputDataDouble.php
@@ -8,6 +8,7 @@
 namespace Friendica\Test\Util;
 
 use Friendica\Util\HTTPInputData;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * This class is used to enable testability for HTTPInputData
@@ -21,6 +22,11 @@ class HTTPInputDataDouble extends HTTPInputData
 	protected $injectedContent = false;
 	/** @var false|string */
 	protected $injectedContentType = false;
+
+	public function __construct(array $server, ?ServerRequestInterface $request = null)
+	{
+		parent::__construct($server, $request);
+	}
 
 	/**
 	 * injects the PHP input stream for a test
@@ -55,13 +61,21 @@ class HTTPInputDataDouble extends HTTPInputData
 	/** {@inheritDoc} */
 	protected function getPhpInputStream()
 	{
-		return $this->injectedStream;
+		if ($this->injectedStream !== false) {
+			return $this->injectedStream;
+		}
+
+		return parent::getPhpInputStream();
 	}
 
 	/** {@inheritDoc} */
 	protected function getPhpInputContent()
 	{
-		return $this->injectedContent;
+		if ($this->injectedContent !== false) {
+			return $this->injectedContent;
+		}
+
+		return parent::getPhpInputContent();
 	}
 
 	protected function fetchFileData($stream, string $boundary, array $headers, string $filename)

--- a/tests/src/Core/Storage/Repository/StorageManagerTest.php
+++ b/tests/src/Core/Storage/Repository/StorageManagerTest.php
@@ -31,7 +31,6 @@ use Friendica\Test\Util\CreateDatabaseTrait;
 use Friendica\Test\Util\Database\StaticDatabase;
 use Friendica\Test\Util\FakeEventDispatcher;
 use org\bovigo\vfs\vfsStream;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\NullLogger;
 use Friendica\Test\Util\SampleStorageBackend;
 
@@ -274,10 +273,7 @@ class StorageManagerTest extends DatabaseTestCase
 		$dice = (new Dice())
 			->addRules(include __DIR__ . '/../../../../../static/dependencies.config.php')
 			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
-			->addRule(IHandleSessions::class, ['instanceOf' => Memory::class, 'shared' => true, 'call' => null])
-			->addRule('*', ['substitutions' => [
-				ServerRequestInterface::class => $this->createStub(ServerRequestInterface::class),
-			]]);
+			->addRule(IHandleSessions::class, ['instanceOf' => Memory::class, 'shared' => true, 'call' => null]);
 		DI::init($dice);
 
 		$storageManager = new StorageManager(
@@ -312,10 +308,7 @@ class StorageManagerTest extends DatabaseTestCase
 		$dice = (new Dice())
 			->addRules(include __DIR__ . '/../../../../../static/dependencies.config.php')
 			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
-			->addRule(IHandleSessions::class, ['instanceOf' => Memory::class, 'shared' => true, 'call' => null])
-			->addRule('*', ['substitutions' => [
-				ServerRequestInterface::class => $this->createStub(ServerRequestInterface::class),
-			]]);
+			->addRule(IHandleSessions::class, ['instanceOf' => Memory::class, 'shared' => true, 'call' => null]);
 		DI::init($dice);
 
 		/** @var \Friendica\Event\EventDispatcher */

--- a/tests/src/Core/Storage/Repository/StorageManagerTest.php
+++ b/tests/src/Core/Storage/Repository/StorageManagerTest.php
@@ -31,6 +31,7 @@ use Friendica\Test\Util\CreateDatabaseTrait;
 use Friendica\Test\Util\Database\StaticDatabase;
 use Friendica\Test\Util\FakeEventDispatcher;
 use org\bovigo\vfs\vfsStream;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\NullLogger;
 use Friendica\Test\Util\SampleStorageBackend;
 
@@ -273,7 +274,10 @@ class StorageManagerTest extends DatabaseTestCase
 		$dice = (new Dice())
 			->addRules(include __DIR__ . '/../../../../../static/dependencies.config.php')
 			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
-			->addRule(IHandleSessions::class, ['instanceOf' => Memory::class, 'shared' => true, 'call' => null]);
+			->addRule(IHandleSessions::class, ['instanceOf' => Memory::class, 'shared' => true, 'call' => null])
+			->addRule('*', ['substitutions' => [
+				ServerRequestInterface::class => $this->createStub(ServerRequestInterface::class),
+			]]);
 		DI::init($dice);
 
 		$storageManager = new StorageManager(
@@ -308,7 +312,10 @@ class StorageManagerTest extends DatabaseTestCase
 		$dice = (new Dice())
 			->addRules(include __DIR__ . '/../../../../../static/dependencies.config.php')
 			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
-			->addRule(IHandleSessions::class, ['instanceOf' => Memory::class, 'shared' => true, 'call' => null]);
+			->addRule(IHandleSessions::class, ['instanceOf' => Memory::class, 'shared' => true, 'call' => null])
+			->addRule('*', ['substitutions' => [
+				ServerRequestInterface::class => $this->createStub(ServerRequestInterface::class),
+			]]);
 		DI::init($dice);
 
 		/** @var \Friendica\Event\EventDispatcher */

--- a/tests/src/Database/DBATest.php
+++ b/tests/src/Database/DBATest.php
@@ -13,7 +13,6 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Test\DatabaseTestCase;
 use Friendica\Test\Util\Database\StaticDatabase;
-use Psr\Http\Message\ServerRequestInterface;
 
 class DBATest extends DatabaseTestCase
 {
@@ -23,10 +22,7 @@ class DBATest extends DatabaseTestCase
 
 		$dice = (new Dice())
 			->addRules(include __DIR__ . '/../../../static/dependencies.config.php')
-			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
-			->addRule('*', ['substitutions' => [
-				ServerRequestInterface::class => $this->createStub(ServerRequestInterface::class),
-			]]);
+			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true]);
 		DI::init($dice);
 
 		// Default config

--- a/tests/src/Database/DBATest.php
+++ b/tests/src/Database/DBATest.php
@@ -13,6 +13,7 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Test\DatabaseTestCase;
 use Friendica\Test\Util\Database\StaticDatabase;
+use Psr\Http\Message\ServerRequestInterface;
 
 class DBATest extends DatabaseTestCase
 {
@@ -22,7 +23,10 @@ class DBATest extends DatabaseTestCase
 
 		$dice = (new Dice())
 			->addRules(include __DIR__ . '/../../../static/dependencies.config.php')
-			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true]);
+			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
+			->addRule('*', ['substitutions' => [
+				ServerRequestInterface::class => $this->createStub(ServerRequestInterface::class),
+			]]);
 		DI::init($dice);
 
 		// Default config

--- a/tests/src/Database/DBStructureTest.php
+++ b/tests/src/Database/DBStructureTest.php
@@ -13,7 +13,6 @@ use Friendica\Database\DBStructure;
 use Friendica\DI;
 use Friendica\Test\DatabaseTestCase;
 use Friendica\Test\Util\Database\StaticDatabase;
-use Psr\Http\Message\ServerRequestInterface;
 
 class DBStructureTest extends DatabaseTestCase
 {
@@ -23,10 +22,7 @@ class DBStructureTest extends DatabaseTestCase
 
 		$dice = (new Dice())
 			->addRules(include __DIR__ . '/../../../static/dependencies.config.php')
-			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
-			->addRule('*', ['substitutions' => [
-				ServerRequestInterface::class => $this->createStub(ServerRequestInterface::class),
-			]]);
+			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true]);
 		DI::init($dice);
 	}
 

--- a/tests/src/Database/DBStructureTest.php
+++ b/tests/src/Database/DBStructureTest.php
@@ -13,6 +13,7 @@ use Friendica\Database\DBStructure;
 use Friendica\DI;
 use Friendica\Test\DatabaseTestCase;
 use Friendica\Test\Util\Database\StaticDatabase;
+use Psr\Http\Message\ServerRequestInterface;
 
 class DBStructureTest extends DatabaseTestCase
 {
@@ -22,7 +23,10 @@ class DBStructureTest extends DatabaseTestCase
 
 		$dice = (new Dice())
 			->addRules(include __DIR__ . '/../../../static/dependencies.config.php')
-			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true]);
+			->addRule(Database::class, ['instanceOf' => StaticDatabase::class, 'shared' => true])
+			->addRule('*', ['substitutions' => [
+				ServerRequestInterface::class => $this->createStub(ServerRequestInterface::class),
+			]]);
 		DI::init($dice);
 	}
 

--- a/tests/src/Factory/Api/Twitter/StatusTest.php
+++ b/tests/src/Factory/Api/Twitter/StatusTest.php
@@ -126,7 +126,7 @@ class StatusTest extends FixtureTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$posts = DI::dba()->selectToArray('post-view', ['uri-id']);
+		$posts = DI::dba()->selectToArray('post-user-view', ['uri-id'], ['uid' => [0, ApiTestCase::SELF_USER['id']]]);
 		foreach ($posts as $item) {
 			$status = $this->statusFactory
 				->createFromUriId($item['uri-id'], ApiTestCase::SELF_USER['id'])

--- a/tests/src/Model/User/CookieTest.php
+++ b/tests/src/Model/User/CookieTest.php
@@ -48,7 +48,6 @@ class CookieTest extends MockedTestCase
 		$this->baseUrl->shouldReceive('getScheme')->andReturn('https')->once();
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn('1235')->once();
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn('7')->once();
-		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
 		$remoteAddress = '1.2.3.4';
 
@@ -114,7 +113,6 @@ class CookieTest extends MockedTestCase
 		$this->baseUrl->shouldReceive('getScheme')->andReturn('https')->once();
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn('1235')->once();
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn('7')->once();
-		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
 		$remoteAddress = '1.2.3.4';
 
@@ -174,7 +172,6 @@ class CookieTest extends MockedTestCase
 		$this->baseUrl->shouldReceive('getScheme')->andReturn('https')->once();
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn($serverPrivateKey)->once();
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn('7')->once();
-		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
 		$remoteAddress = '1.2.3.4';
 
@@ -234,10 +231,8 @@ class CookieTest extends MockedTestCase
 		$this->baseUrl->shouldReceive('getScheme')->andReturn('https')->once();
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn($serverKey)->once();
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn(Cookie::DEFAULT_EXPIRE)->once();
-		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
-		$this->config->shouldReceive('get')->with('proxy', 'forwarded_for_headers')->andReturn('HTTP_X_FORWARDED_FOR');
 
-		$remoteAddress = $serverArray['REMOTE_ADDR'] ?? '';
+		$remoteAddress = $serverArray['REMOTE_ADDR'] ?? '0.0.0.0';
 
 		$cookie = new StaticCookie($remoteAddress, $this->config, $this->baseUrl);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
@@ -259,10 +254,8 @@ class CookieTest extends MockedTestCase
 		$this->baseUrl->shouldReceive('getScheme')->andReturn('https')->once();
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn($serverKey)->once();
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn(Cookie::DEFAULT_EXPIRE)->once();
-		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
-		$this->config->shouldReceive('get')->with('proxy', 'forwarded_for_headers')->andReturn('HTTP_X_FORWARDED_FOR');
 
-		$remoteAddress = $serverArray['REMOTE_ADDR'] ?? '';
+		$remoteAddress = $serverArray['REMOTE_ADDR'] ?? '0.0.0.0';
 
 		$cookie = new StaticCookie($remoteAddress, $this->config, $this->baseUrl, $serverArray);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
@@ -285,7 +278,6 @@ class CookieTest extends MockedTestCase
 		$this->baseUrl->shouldReceive('getScheme')->andReturn('https')->once();
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn(24)->once();
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn(Cookie::DEFAULT_EXPIRE)->once();
-		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
 		$remoteAddress = '1.2.3.4';
 

--- a/tests/src/Model/User/CookieTest.php
+++ b/tests/src/Model/User/CookieTest.php
@@ -34,6 +34,12 @@ class CookieTest extends MockedTestCase
 		$this->baseUrl = \Mockery::mock(BaseURL::class);
 	}
 
+	private function createRequest(array $server = []): Request
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', $server);
+		return new Request($psr7Request, $this->config);
+	}
+
 	protected function tearDown(): void
 	{
 		StaticCookie::clearStatic();
@@ -51,7 +57,7 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn('7')->once();
 		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
-		$request = new Request($this->config, static::SERVER_ARRAY);
+		$request = $this->createRequest(static::SERVER_ARRAY);
 
 		$cookie = new Cookie($request, $this->config, $this->baseUrl);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
@@ -117,7 +123,7 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn('7')->once();
 		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
-		$request = new Request($this->config, static::SERVER_ARRAY);
+		$request = $this->createRequest(static::SERVER_ARRAY);
 
 		$cookie = new Cookie($request, $this->config, $this->baseUrl, $cookieData);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
@@ -177,7 +183,7 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn('7')->once();
 		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
-		$request = new Request($this->config, static::SERVER_ARRAY);
+		$request = $this->createRequest(static::SERVER_ARRAY);
 
 		$cookie = new Cookie($request, $this->config, $this->baseUrl);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
@@ -239,7 +245,7 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('proxy', 'forwarded_for_headers')->andReturn(Request::DEFAULT_FORWARD_FOR_HEADER);
 
 
-		$request = new Request($this->config, $serverArray);
+		$request = $this->createRequest($serverArray);
 
 		$cookie = new StaticCookie($request, $this->config, $this->baseUrl);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
@@ -264,7 +270,7 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 		$this->config->shouldReceive('get')->with('proxy', 'forwarded_for_headers')->andReturn(Request::DEFAULT_FORWARD_FOR_HEADER);
 
-		$request = new Request($this->config, $serverArray);
+		$request = $this->createRequest($serverArray);
 
 		$cookie = new StaticCookie($request, $this->config, $this->baseUrl, $serverArray);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
@@ -289,7 +295,7 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn(Cookie::DEFAULT_EXPIRE)->once();
 		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
-		$request = new Request($this->config, static::SERVER_ARRAY);
+		$request = $this->createRequest(static::SERVER_ARRAY);
 
 		$cookie = new StaticCookie($request, $this->config, $this->baseUrl);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType

--- a/tests/src/Model/User/CookieTest.php
+++ b/tests/src/Model/User/CookieTest.php
@@ -8,7 +8,6 @@
 namespace Friendica\Test\src\Model\User;
 
 use Friendica\App\BaseURL;
-use Friendica\App\Request;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Model\User\Cookie;
 use Friendica\Test\MockedTestCase;
@@ -34,12 +33,6 @@ class CookieTest extends MockedTestCase
 		$this->baseUrl = \Mockery::mock(BaseURL::class);
 	}
 
-	private function createRequest(array $server = []): Request
-	{
-		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest('GET', 'http://example.com', [], null, '1.1', $server);
-		return new Request($psr7Request, $this->config);
-	}
-
 	protected function tearDown(): void
 	{
 		StaticCookie::clearStatic();
@@ -57,9 +50,9 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn('7')->once();
 		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
-		$request = $this->createRequest(static::SERVER_ARRAY);
+		$remoteAddress = '1.2.3.4';
 
-		$cookie = new Cookie($request, $this->config, $this->baseUrl);
+		$cookie = new Cookie($remoteAddress, $this->config, $this->baseUrl);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
 	}
 
@@ -123,9 +116,9 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn('7')->once();
 		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
-		$request = $this->createRequest(static::SERVER_ARRAY);
+		$remoteAddress = '1.2.3.4';
 
-		$cookie = new Cookie($request, $this->config, $this->baseUrl, $cookieData);
+		$cookie = new Cookie($remoteAddress, $this->config, $this->baseUrl, $cookieData);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
 
 		if (isset($uid)) {
@@ -183,9 +176,9 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn('7')->once();
 		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
-		$request = $this->createRequest(static::SERVER_ARRAY);
+		$remoteAddress = '1.2.3.4';
 
-		$cookie = new Cookie($request, $this->config, $this->baseUrl);
+		$cookie = new Cookie($remoteAddress, $this->config, $this->baseUrl);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
 
 		self::assertEquals($assertTrue, $cookie->comparePrivateDataHash($assertHash, $password, $userPrivateKey));
@@ -242,12 +235,11 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn($serverKey)->once();
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn(Cookie::DEFAULT_EXPIRE)->once();
 		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
-		$this->config->shouldReceive('get')->with('proxy', 'forwarded_for_headers')->andReturn(Request::DEFAULT_FORWARD_FOR_HEADER);
+		$this->config->shouldReceive('get')->with('proxy', 'forwarded_for_headers')->andReturn('HTTP_X_FORWARDED_FOR');
 
+		$remoteAddress = $serverArray['REMOTE_ADDR'] ?? '';
 
-		$request = $this->createRequest($serverArray);
-
-		$cookie = new StaticCookie($request, $this->config, $this->baseUrl);
+		$cookie = new StaticCookie($remoteAddress, $this->config, $this->baseUrl);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
 
 		$cookie->setMultiple([
@@ -268,11 +260,11 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('system', 'site_prvkey')->andReturn($serverKey)->once();
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn(Cookie::DEFAULT_EXPIRE)->once();
 		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
-		$this->config->shouldReceive('get')->with('proxy', 'forwarded_for_headers')->andReturn(Request::DEFAULT_FORWARD_FOR_HEADER);
+		$this->config->shouldReceive('get')->with('proxy', 'forwarded_for_headers')->andReturn('HTTP_X_FORWARDED_FOR');
 
-		$request = $this->createRequest($serverArray);
+		$remoteAddress = $serverArray['REMOTE_ADDR'] ?? '';
 
-		$cookie = new StaticCookie($request, $this->config, $this->baseUrl, $serverArray);
+		$cookie = new StaticCookie($remoteAddress, $this->config, $this->baseUrl, $serverArray);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
 
 		$cookie->set('uid', $uid);
@@ -295,9 +287,9 @@ class CookieTest extends MockedTestCase
 		$this->config->shouldReceive('get')->with('system', 'auth_cookie_lifetime', Cookie::DEFAULT_EXPIRE)->andReturn(Cookie::DEFAULT_EXPIRE)->once();
 		$this->config->shouldReceive('get')->with('proxy', 'trusted_proxies', '')->andReturn('')->once();
 
-		$request = $this->createRequest(static::SERVER_ARRAY);
+		$remoteAddress = '1.2.3.4';
 
-		$cookie = new StaticCookie($request, $this->config, $this->baseUrl);
+		$cookie = new StaticCookie($remoteAddress, $this->config, $this->baseUrl);
 		self::assertInstanceOf(Cookie::class, $cookie); // @phpstan-ignore staticMethod.alreadyNarrowedType
 
 		self::assertEquals('test', StaticCookie::$_COOKIE[Cookie::NAME]);

--- a/tests/src/Module/Api/Friendica/DirectMessages/SearchTest.php
+++ b/tests/src/Module/Api/Friendica/DirectMessages/SearchTest.php
@@ -19,7 +19,7 @@ class SearchTest extends ApiTestCase
 	{
 		$directMessage = new DirectMessage(new NullLogger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Search($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Search($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
@@ -37,7 +37,7 @@ class SearchTest extends ApiTestCase
 
 		$directMessage = new DirectMessage(new NullLogger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Search($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Search($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'searchstring' => 'item_body',
 			]);
@@ -58,10 +58,77 @@ class SearchTest extends ApiTestCase
 	{
 		$directMessage = new DirectMessage(new NullLogger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Search($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Search($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'searchstring' => 'test',
 			]);
+
+		$json = $this->toJson($response);
+
+		$assert                 = new \stdClass();
+		$assert->success        = false;
+		$assert->search_results = 'nothing found';
+
+		self::assertEquals($assert, $json);
+	}
+
+	public function testHandleRequestDirectMessagesSearchReturnsMessageList(): void
+	{
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/mail/mail.fixture.php', DI::dba());
+
+		$directMessage = new DirectMessage(new NullLogger(), DI::dba(), DI::twitterUser());
+		$module = new Search($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['searchstring' => 'item_body']);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertTrue($json->success);
+
+		foreach ($json->search_results as $searchResult) {
+			self::assertIsObject($searchResult->sender);
+			self::assertIsInt($searchResult->id);
+			self::assertIsInt($searchResult->sender_id);
+			self::assertIsObject($searchResult->recipient);
+		}
+	}
+
+	public function testHandleRequestDirectMessagesSearchWithIdReturnsMessage(): void
+	{
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/mail/mail.fixture.php', DI::dba());
+
+		$directMessage = new DirectMessage(new NullLogger(), DI::dba(), DI::twitterUser());
+		$module = new Search($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['searchstring' => 'item_body', 'id' => 1]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertTrue($json->success);
+
+		foreach ($json->search_results as $searchResult) {
+			self::assertIsObject($searchResult->sender);
+			self::assertIsInt($searchResult->id);
+			self::assertIsInt($searchResult->sender_id);
+			self::assertIsObject($searchResult->recipient);
+		}
+	}
+
+	public function testHandleRequestDirectMessagesSearchWithNoResultReturnsError(): void
+	{
+		$directMessage = new DirectMessage(new NullLogger(), DI::dba(), DI::twitterUser());
+		$module = new Search($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['searchstring' => 'test']);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
 
 		$json = $this->toJson($response);
 

--- a/tests/src/Module/Api/Friendica/NotificationTest.php
+++ b/tests/src/Module/Api/Friendica/NotificationTest.php
@@ -85,7 +85,7 @@ XML;
 
 	public function testHandleRequestFriendicaNotificationReturnsList(): void
 	{
-		$module = new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+		$module = new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
 
 		$request = $this->createMock(\Friendica\App\Request::class);
 		$request->method('getAllInput')->willReturn([]);
@@ -108,24 +108,4 @@ XML;
 		], $response->getHeaders());
 	}
 
-	public function testHandleRequestFriendicaNotificationWithIdReturnsNotification(): void
-	{
-		$module = new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
-
-		$request = $this->createMock(\Friendica\App\Request::class);
-		$request->method('getAllInput')->willReturn(['id' => 1]);
-		$request->method('getQueryString')->willReturn('');
-		$response = $module->handleRequest($request);
-
-		$json = $this->toJson($response);
-
-		self::assertIsInt($json->id);
-		self::assertIsInt($json->uid);
-		self::assertIsString($json->msg);
-
-		self::assertEquals([
-			'Content-type'                => ['application/json'],
-			ICanCreateResponses::X_HEADER => ['json'],
-		], $response->getHeaders());
-	}
 }

--- a/tests/src/Module/Api/Friendica/NotificationTest.php
+++ b/tests/src/Module/Api/Friendica/NotificationTest.php
@@ -52,7 +52,7 @@ class NotificationTest extends ApiTestCase
 </notes>
 XML;
 
-		$response = (new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
+		$response = (new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		self::assertXmlStringEqualsXmlString($assertXml, (string) $response->getBody());
@@ -64,7 +64,7 @@ XML;
 
 	public function testWithJsonResult(): void
 	{
-		$response = (new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
@@ -76,6 +76,52 @@ XML;
 			self::assertIsInt($note->uid);
 			self::assertIsString($note->msg);
 		}
+
+		self::assertEquals([
+			'Content-type'                => ['application/json'],
+			ICanCreateResponses::X_HEADER => ['json'],
+		], $response->getHeaders());
+	}
+
+	public function testHandleRequestFriendicaNotificationReturnsList(): void
+	{
+		$module = new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+
+		foreach ($json as $note) {
+			self::assertIsInt($note->id);
+			self::assertIsInt($note->uid);
+			self::assertIsString($note->msg);
+		}
+
+		self::assertEquals([
+			'Content-type'                => ['application/json'],
+			ICanCreateResponses::X_HEADER => ['json'],
+		], $response->getHeaders());
+	}
+
+	public function testHandleRequestFriendicaNotificationWithIdReturnsNotification(): void
+	{
+		$module = new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['id' => 1]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsInt($json->id);
+		self::assertIsInt($json->uid);
+		self::assertIsString($json->msg);
 
 		self::assertEquals([
 			'Content-type'                => ['application/json'],

--- a/tests/src/Module/Api/Friendica/Photo/DeleteTest.php
+++ b/tests/src/Module/Api/Friendica/Photo/DeleteTest.php
@@ -25,7 +25,7 @@ class DeleteTest extends ApiTestCase
 	public function testEmpty(): void
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock);
+		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock); // @phpstan-ignore method.deprecated
 	}
 
 	public function testWithoutAuthenticatedUser(): void
@@ -36,14 +36,14 @@ class DeleteTest extends ApiTestCase
 	public function testWrong(): void
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock, ['photo_id' => 1]);
+		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock, ['photo_id' => 1]); // @phpstan-ignore method.deprecated
 	}
 
 	public function testValidWithPost(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
 
-		$response = (new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'photo_id' => '709057080661a283a6aa598501504178',
 			]);
@@ -58,7 +58,7 @@ class DeleteTest extends ApiTestCase
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
 
-		$response = (new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'photo_id' => '709057080661a283a6aa598501504178',
 			]);
@@ -71,5 +71,71 @@ class DeleteTest extends ApiTestCase
 
 		self::assertEquals('deleted', $json->result);
 		self::assertEquals('photo with id `709057080661a283a6aa598501504178` has been deleted from server.', $json->message);
+	}
+
+	public function testHandleRequestPhotoDeleteThrowsBadRequestException(): void
+	{
+		$this->useHttpMethod(Router::POST);
+		$this->expectException(BadRequestException::class);
+
+		$module = new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$module->handleRequest($request);
+	}
+
+	public function testHandleRequestPhotoDeleteWithIdReturnsDeletedPhoto(): void
+	{
+		$this->useHttpMethod(Router::POST);
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
+
+		$module = new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['photo_id' => '709057080661a283a6aa598501504178']);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('deleted', $json->result);
+		self::assertEquals('photo with id `709057080661a283a6aa598501504178` has been deleted from server.', $json->message);
+	}
+
+	public function testHandleRequestPhotoDeleteWithIdAndJsonReturnsDeletedPhoto(): void
+	{
+		$this->useHttpMethod(Router::POST);
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
+
+		$module = new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['photo_id' => '709057080661a283a6aa598501504178']);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$responseText = (string) $response->getBody();
+
+		self::assertJson($responseText);
+
+		$json = json_decode($responseText);
+
+		self::assertEquals('deleted', $json->result);
+		self::assertEquals('photo with id `709057080661a283a6aa598501504178` has been deleted from server.', $json->message);
+	}
+
+	public function testHandleRequestPhotoDeleteWithWrongUserThrowsBadRequestException(): void
+	{
+		$this->useHttpMethod(Router::POST);
+		$this->expectException(BadRequestException::class);
+
+		$module = new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['photo_id' => 1]);
+		$request->method('getQueryString')->willReturn('');
+		$module->handleRequest($request);
 	}
 }

--- a/tests/src/Module/Api/Friendica/Photoalbum/DeleteTest.php
+++ b/tests/src/Module/Api/Friendica/Photoalbum/DeleteTest.php
@@ -25,7 +25,7 @@ class DeleteTest extends ApiTestCase
 	public function testEmpty(): void
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 	}
@@ -33,7 +33,7 @@ class DeleteTest extends ApiTestCase
 	public function testWrong(): void
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'album' => 'album_name',
 			]);
@@ -43,13 +43,66 @@ class DeleteTest extends ApiTestCase
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
 
-		$response = (new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run(
 				$this->httpExceptionMock,
 				['album' => 'test_album'],
 			);
 
 		$json = $this->toJson($response);
+
+		self::assertEquals('deleted', $json->result);
+		self::assertEquals('album `test_album` with all containing photos has been deleted.', $json->message);
+	}
+
+	public function testHandleRequestPhotoalbumDeleteThrowsBadRequestException(): void
+	{
+		$this->useHttpMethod(Router::POST);
+		$this->expectException(BadRequestException::class);
+
+		$module = new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$module->handleRequest($request);
+	}
+
+	public function testHandleRequestPhotoalbumDeleteWithAlbumReturnsResult(): void
+	{
+		$this->useHttpMethod(Router::POST);
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
+
+		$module = new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['album' => 'test_album']);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('deleted', $json->result);
+		self::assertEquals('album `test_album` with all containing photos has been deleted.', $json->message);
+	}
+
+	public function testHandleRequestPhotoalbumDeleteWithAlbumAndJsonReturnsResult(): void
+	{
+		$this->useHttpMethod(Router::POST);
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
+
+		$module = new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['album' => 'test_album']);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$responseText = (string) $response->getBody();
+
+		self::assertJson($responseText);
+
+		$json = json_decode($responseText);
 
 		self::assertEquals('deleted', $json->result);
 		self::assertEquals('album `test_album` with all containing photos has been deleted.', $json->message);

--- a/tests/src/Module/Api/Friendica/Photoalbum/UpdateTest.php
+++ b/tests/src/Module/Api/Friendica/Photoalbum/UpdateTest.php
@@ -25,14 +25,14 @@ class UpdateTest extends ApiTestCase
 	public function testEmpty(): void
 	{
 		$this->expectException(BadRequestException::class);
-		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 	}
 
 	public function testTooFewArgs(): void
 	{
 		$this->expectException(BadRequestException::class);
-		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'album' => 'album_name',
 			]);
@@ -41,7 +41,7 @@ class UpdateTest extends ApiTestCase
 	public function testWrongUpdate(): void
 	{
 		$this->expectException(BadRequestException::class);
-		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'album'     => 'album_name',
 				'album_new' => 'album_name',
@@ -57,7 +57,7 @@ class UpdateTest extends ApiTestCase
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
 
-		$response = (new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'album'     => 'test_album',
 				'album_new' => 'test_album_2',
@@ -67,5 +67,71 @@ class UpdateTest extends ApiTestCase
 
 		self::assertEquals('updated', $json->result);
 		self::assertEquals('album `test_album` with all containing photos has been renamed to `test_album_2`.', $json->message);
+	}
+
+	public function testHandleRequestPhotoalbumUpdateThrowsBadRequestException(): void
+	{
+		$this->useHttpMethod(Router::POST);
+		$this->expectException(BadRequestException::class);
+
+		$module = new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$module->handleRequest($request);
+	}
+
+	public function testHandleRequestPhotoalbumUpdateWithAlbumReturnsUpdatedAlbum(): void
+	{
+		$this->useHttpMethod(Router::POST);
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
+
+		$module = new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['album' => 'test_album', 'album_new' => 'test_album_2']);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('updated', $json->result);
+		self::assertEquals('album `test_album` with all containing photos has been renamed to `test_album_2`.', $json->message);
+	}
+
+	public function testHandleRequestPhotoalbumUpdateWithAlbumAndJsonReturnsUpdatedAlbum(): void
+	{
+		$this->useHttpMethod(Router::POST);
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
+
+		$module = new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['album' => 'test_album', 'album_new' => 'test_album_2']);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$responseText = (string) $response->getBody();
+
+		self::assertJson($responseText);
+
+		$json = json_decode($responseText);
+
+		self::assertEquals('updated', $json->result);
+		self::assertEquals('album `test_album` with all containing photos has been renamed to `test_album_2`.', $json->message);
+	}
+
+	public function testHandleRequestPhotoalbumUpdateOtherUserThrowsBadRequestException(): void
+	{
+		$this->useHttpMethod(Router::POST);
+		$this->expectException(BadRequestException::class);
+
+		$module = new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['album' => 'album_name', 'album_new' => 'album_name']);
+		$request->method('getQueryString')->willReturn('');
+		$module->handleRequest($request);
 	}
 }

--- a/tests/src/Module/Api/GnuSocial/GnuSocial/ConfigTest.php
+++ b/tests/src/Module/Api/GnuSocial/GnuSocial/ConfigTest.php
@@ -18,8 +18,30 @@ class ConfigTest extends ApiTestCase
 	 */
 	public function testApiStatusnetConfig(): void
 	{
-		$response = (new Config(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Config(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
+		$json = $this->toJson($response);
+
+		self::assertEquals(DI::baseUrl()->getHost(), $json->site->server);
+		self::assertEquals(DI::config()->get('system', 'theme'), $json->site->theme);
+		self::assertEquals(DI::baseUrl() . '/images/friendica-64.png', $json->site->logo);
+		self::assertTrue($json->site->fancy);
+		self::assertEquals(DI::config()->get('system', 'language'), $json->site->language);
+		self::assertEquals(DI::config()->get('system', 'default_timezone'), $json->site->timezone);
+		self::assertEquals(200000, $json->site->textlimit);
+		self::assertFalse($json->site->private);
+		self::assertEquals('always', $json->site->ssl);
+	}
+
+	public function testHandleRequestGnusocialConfigReturnsConfig(): void
+	{
+		$module = new Config(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
 		$json = $this->toJson($response);
 
 		self::assertEquals(DI::baseUrl()->getHost(), $json->site->server);

--- a/tests/src/Module/Api/GnuSocial/GnuSocial/VersionTest.php
+++ b/tests/src/Module/Api/GnuSocial/GnuSocial/VersionTest.php
@@ -16,8 +16,24 @@ class VersionTest extends ApiTestCase
 {
 	public function test(): void
 	{
-		$response = (new Version(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Version(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
+
+		self::assertEquals([
+			'Content-type'                => ['application/json'],
+			ICanCreateResponses::X_HEADER => ['json'],
+		], $response->getHeaders());
+		self::assertEquals('"0.9.7"', $response->getBody());
+	}
+
+	public function testHandleRequestGnusocialVersionReturnsVersion(): void
+	{
+		$module = new Version(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
 
 		self::assertEquals([
 			'Content-type'                => ['application/json'],

--- a/tests/src/Module/Api/GnuSocial/Help/TestTest.php
+++ b/tests/src/Module/Api/GnuSocial/Help/TestTest.php
@@ -16,7 +16,7 @@ class TestTest extends ApiTestCase
 {
 	public function testJson(): void
 	{
-		$response = (new Test(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Test(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
@@ -30,7 +30,7 @@ class TestTest extends ApiTestCase
 
 	public function testXml(): void
 	{
-		$response = (new Test(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
+		$response = (new Test(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		self::assertEquals([
@@ -38,5 +38,41 @@ class TestTest extends ApiTestCase
 			ICanCreateResponses::X_HEADER => ['xml'],
 		], $response->getHeaders());
 		self::assertXml($response->getBody(), 'ok');
+	}
+
+	public function testHandleRequestGnusocialHelpTestReturnsResult(): void
+	{
+		$module = new Test(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals([
+			'Content-type'                => ['application/json'],
+			ICanCreateResponses::X_HEADER => ['json'],
+		], $response->getHeaders());
+		self::assertEquals('ok', $json);
+	}
+
+	public function testHandleRequestGnusocialHelpTestWithTextReturnsResult(): void
+	{
+		$module = new Test(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['text' => 'test']);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals([
+			'Content-type'                => ['application/json'],
+			ICanCreateResponses::X_HEADER => ['json'],
+		], $response->getHeaders());
+		self::assertEquals('ok', $json);
 	}
 }

--- a/tests/src/Module/Api/Mastodon/Accounts/VerifyCredentialsTest.php
+++ b/tests/src/Module/Api/Mastodon/Accounts/VerifyCredentialsTest.php
@@ -20,8 +20,24 @@ class VerifyCredentialsTest extends ApiTestCase
 	 */
 	public function testApiAccountVerifyCredentials(): void
 	{
-		$response = (new VerifyCredentials(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new VerifyCredentials(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals(48, $json->id);
+		self::assertIsArray($json->emojis);
+		self::assertIsArray($json->fields);
+	}
+
+	public function testHandleRequestVerifyCredentialsReturnsAccount(): void
+	{
+		$module = new VerifyCredentials(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
 
 		$json = $this->toJson($response);
 

--- a/tests/src/Module/Api/Twitter/Account/RateLimitStatusTest.php
+++ b/tests/src/Module/Api/Twitter/Account/RateLimitStatusTest.php
@@ -16,7 +16,7 @@ class RateLimitStatusTest extends ApiTestCase
 {
 	public function testWithJson(): void
 	{
-		$response = (new RateLimitStatus(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new RateLimitStatus(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		$result = $this->toJson($response);
@@ -32,7 +32,7 @@ class RateLimitStatusTest extends ApiTestCase
 
 	public function testWithXml(): void
 	{
-		$response = (new RateLimitStatus(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
+		$response = (new RateLimitStatus(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		self::assertEquals([
@@ -40,5 +40,37 @@ class RateLimitStatusTest extends ApiTestCase
 			ICanCreateResponses::X_HEADER => ['xml'],
 		], $response->getHeaders());
 		self::assertXml($response->getBody(), 'hash');
+	}
+
+	public function testHandleRequestAccountRateLimitStatusReturnsLimit(): void
+	{
+		$module = new RateLimitStatus(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$result = $this->toJson($response);
+
+		self::assertEquals(150, $result->remaining_hits);
+		self::assertEquals(150, $result->hourly_limit);
+		self::assertIsInt($result->reset_time_in_seconds);
+	}
+
+	public function testHandleRequestAccountRateLimitStatusWithJsonExtensionReturnsLimit(): void
+	{
+		$module = new RateLimitStatus(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$result = $this->toJson($response);
+
+		self::assertEquals(150, $result->remaining_hits);
+		self::assertEquals(150, $result->hourly_limit);
+		self::assertIsInt($result->reset_time_in_seconds);
 	}
 }

--- a/tests/src/Module/Api/Twitter/Account/UpdateProfileTest.php
+++ b/tests/src/Module/Api/Twitter/Account/UpdateProfileTest.php
@@ -21,11 +21,31 @@ class UpdateProfileTest extends ApiTestCase
 	{
 		$this->useHttpMethod(Router::POST);
 
-		$response = (new UpdateProfile(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new UpdateProfile(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'name'        => 'new_name',
 				'description' => 'new_description',
 			]);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('new_name', $json->name);
+		self::assertEquals('new_description', $json->description);
+	}
+
+	public function testHandleRequestAccountUpdateProfileReturnsUser(): void
+	{
+		$this->useHttpMethod(Router::POST);
+
+		$module = new UpdateProfile(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([
+			'name'        => 'new_name',
+			'description' => 'new_description',
+		]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
 
 		$json = $this->toJson($response);
 

--- a/tests/src/Module/Api/Twitter/Blocks/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Blocks/ListsTest.php
@@ -18,7 +18,7 @@ class ListsTest extends ApiTestCase
 	 */
 	public function testApiStatusesFWithBlocks(): void
 	{
-		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
@@ -36,5 +36,19 @@ class ListsTest extends ApiTestCase
 
 		// $_GET['cursor'] = 'undefined';
 		// self::assertFalse(api_blocks_list('json'));
+	}
+
+	public function testHandleRequestBlocksListsReturnsBlockedIds(): void
+	{
+		$module = new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->users);
 	}
 }

--- a/tests/src/Module/Api/Twitter/DirectMessages/AllTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/AllTest.php
@@ -25,8 +25,31 @@ class AllTest extends ApiTestCase
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new All($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new All($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
+
+		$json = $this->toJson($response);
+
+		self::assertGreaterThan(0, count($json));
+
+		foreach ($json as $item) {
+			self::assertIsInt($item->id);
+			self::assertIsString($item->text);
+		}
+	}
+
+	public function testHandleRequestDirectMessagesAllReturnsMessageList(): void
+	{
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/mail/mail.fixture.php', DI::dba());
+
+		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
+
+		$module = new All($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
 
 		$json = $this->toJson($response);
 

--- a/tests/src/Module/Api/Twitter/DirectMessages/ConversationTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/ConversationTest.php
@@ -23,10 +23,27 @@ class ConversationTest extends ApiTestCase
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Conversation($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Conversation($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'friendica_verbose' => true,
 			]);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('error', $json->result);
+		self::assertEquals('no mails available', $json->message);
+	}
+
+	public function testHandleRequestDirectMessagesConversationReturnsErrorMessage(): void
+	{
+		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
+
+		$module = new Conversation($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['friendica_verbose' => true]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
 
 		$json = $this->toJson($response);
 

--- a/tests/src/Module/Api/Twitter/DirectMessages/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/DestroyTest.php
@@ -31,7 +31,7 @@ class DestroyTest extends ApiTestCase
 	{
 		$this->expectException(\Friendica\Network\HTTPException\BadRequestException::class);
 
-		(new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		(new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 	}
 
@@ -42,7 +42,7 @@ class DestroyTest extends ApiTestCase
 	 */
 	public function testApiDirectMessagesDestroyWithVerbose(): void
 	{
-		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'friendica_verbose' => true,
 			]);
@@ -77,7 +77,7 @@ class DestroyTest extends ApiTestCase
 	public function testApiDirectMessagesDestroyWithId(): void
 	{
 		$this->expectException(\Friendica\Network\HTTPException\BadRequestException::class);
-		(new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		(new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'id' => 1,
 			]);
@@ -90,7 +90,7 @@ class DestroyTest extends ApiTestCase
 	 */
 	public function testApiDirectMessagesDestroyWithIdAndVerbose(): void
 	{
-		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'id'                  => 1,
 				'friendica_parenturi' => 'parent_uri',
@@ -114,11 +114,91 @@ class DestroyTest extends ApiTestCase
 		$ids = DBA::selectToArray('mail', ['id']);
 		$id  = $ids[0]['id'];
 
-		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'id'                => $id,
 				'friendica_verbose' => true,
 			]);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('ok', $json->result);
+		self::assertEquals('message deleted', $json->message);
+	}
+
+	public function testHandleRequestDirectMessagesDestroyThrowsBadRequestException(): void
+	{
+		$this->expectException(\Friendica\Network\HTTPException\BadRequestException::class);
+
+		$module = new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$module->handleRequest($request);
+	}
+
+	public function testHandleRequestDirectMessagesDestroyWithVerboseReturnsError(): void
+	{
+		$module = new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['friendica_verbose' => true]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('error', $json->result);
+		self::assertEquals('message id or parenturi not specified', $json->message);
+	}
+
+	public function testHandleRequestDirectMessagesDestroyWithIdThrowsBadRequestException(): void
+	{
+		$this->expectException(\Friendica\Network\HTTPException\BadRequestException::class);
+
+		$module = new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['id' => 1]);
+		$request->method('getQueryString')->willReturn('');
+		$module->handleRequest($request);
+	}
+
+	public function testHandleRequestDirectMessagesDestroyWithIdAndVerboseReturnsError(): void
+	{
+		$module = new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([
+			'id'                  => 1,
+			'friendica_parenturi' => 'parent_uri',
+			'friendica_verbose'   => true,
+		]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('error', $json->result);
+		self::assertEquals('message id not in database', $json->message);
+	}
+
+	public function testHandleRequestDirectMessagesDestroyWithCorrectIdReturnsOk(): void
+	{
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/mail/mail.fixture.php', DI::dba());
+		$ids = DBA::selectToArray('mail', ['id']);
+		$id  = $ids[0]['id'];
+
+		$module = new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([
+			'id'                => $id,
+			'friendica_verbose' => true,
+		]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
 
 		$json = $this->toJson($response);
 

--- a/tests/src/Module/Api/Twitter/DirectMessages/InboxTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/InboxTest.php
@@ -25,8 +25,31 @@ class InboxTest extends ApiTestCase
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Inbox($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Inbox($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
+
+		$json = $this->toJson($response);
+
+		self::assertGreaterThan(0, count($json));
+
+		foreach ($json as $item) {
+			self::assertIsInt($item->id);
+			self::assertIsString($item->text);
+		}
+	}
+
+	public function testHandleRequestDirectMessagesInboxReturnsMessageList(): void
+	{
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/mail/mail.fixture.php', DI::dba());
+
+		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
+
+		$module = new Inbox($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
 
 		$json = $this->toJson($response);
 

--- a/tests/src/Module/Api/Twitter/DirectMessages/NewDMTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/NewDMTest.php
@@ -31,7 +31,7 @@ class NewDMTest extends ApiTestCase
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		self::assertEmpty((string) $response->getBody());
@@ -62,7 +62,7 @@ class NewDMTest extends ApiTestCase
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',
 				'user_id' => 43,
@@ -84,7 +84,7 @@ class NewDMTest extends ApiTestCase
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',
 				'user_id' => 44,
@@ -108,7 +108,7 @@ class NewDMTest extends ApiTestCase
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',
 				'user_id' => 44,
@@ -134,7 +134,7 @@ class NewDMTest extends ApiTestCase
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
+		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',
 				'user_id' => 44,
@@ -142,5 +142,61 @@ class NewDMTest extends ApiTestCase
 			]);
 
 		self::assertXml((string) $response->getBody(), 'direct-messages');
+	}
+
+	public function testHandleRequestDirectMessagesNewReturnsEmptyBody(): void
+	{
+		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
+
+		$module = new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		self::assertEmpty((string) $response->getBody());
+	}
+
+	public function testHandleRequestDirectMessagesNewWithUserIdReturnsError(): void
+	{
+		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
+
+		$module = new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([
+			'text'    => 'message_text',
+			'user_id' => 43,
+		]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals(-1, $json->error);
+	}
+
+	public function testHandleRequestDirectMessagesNewWithScreenNameReturnsMessage(): void
+	{
+		DI::session()->set('nickname', 'selfcontact');
+
+		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
+
+		$module = new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([
+			'text'    => 'message_text',
+			'user_id' => 44,
+		]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertStringContainsString('message_text', $json->text);
+		self::assertEquals('selfcontact', $json->sender_screen_name);
+		self::assertEquals(1, $json->friendica_seen);
 	}
 }

--- a/tests/src/Module/Api/Twitter/DirectMessages/SentTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/SentTest.php
@@ -23,7 +23,7 @@ class SentTest extends ApiTestCase
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Sent($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new Sent($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'friendica_verbose' => true,
 			]);
@@ -43,7 +43,7 @@ class SentTest extends ApiTestCase
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
-		$response = (new Sent($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
+		$response = (new Sent($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		self::assertXml((string) $response->getBody(), 'direct-messages');
@@ -60,5 +60,38 @@ class SentTest extends ApiTestCase
 		//$this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
 		//BasicAuth::setCurrentUserID();
 		//api_direct_messages_box('json', 'sentbox', 'false');
+	}
+
+	public function testHandleRequestDirectMessagesSentReturnsMessageList(): void
+	{
+		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
+
+		$module = new Sent($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+	}
+
+	public function testHandleRequestDirectMessagesSentWithVerboseReturnsMessages(): void
+	{
+		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
+
+		$module = new Sent($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['friendica_verbose' => true]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('error', $json->result);
+		self::assertEquals('no mails available', $json->message);
 	}
 }

--- a/tests/src/Module/Api/Twitter/Favorites/CreateTest.php
+++ b/tests/src/Module/Api/Twitter/Favorites/CreateTest.php
@@ -32,7 +32,7 @@ class CreateTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 	}
 
@@ -43,7 +43,7 @@ class CreateTest extends ApiTestCase
 	 */
 	public function testApiFavoritesCreateDestroyWithCreateAction(): void
 	{
-		$response = (new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'id' => 3,
 			]);
@@ -60,7 +60,7 @@ class CreateTest extends ApiTestCase
 	 */
 	public function testApiFavoritesCreateDestroyWithCreateActionAndRss(): void
 	{
-		$response = (new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]))
+		$response = (new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'id' => 3,
 			]);
@@ -85,5 +85,63 @@ class CreateTest extends ApiTestCase
 		$_SESSION['authenticated'] = false;
 		api_favorites_create_destroy('json');
 		*/
+	}
+
+	/**
+	 * Test the handleRequest() function with an invalid ID.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestFavoritesCreateWithInvalidIdThrowsBadRequestException(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$module = new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$module->handleRequest($request);
+	}
+
+	/**
+	 * Test the handleRequest() function with an ID.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestFavoritesCreateWithIdReturnsStatus(): void
+	{
+		$module = new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['id' => 3]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+	}
+
+	/**
+	 * Test the handleRequest() function with an ID and an RSS result.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestFavoritesCreateWithIdAndRssReturnsXml(): void
+	{
+		$module = new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['id' => 3]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
 	}
 }

--- a/tests/src/Module/Api/Twitter/Favorites/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/Favorites/DestroyTest.php
@@ -31,7 +31,7 @@ class DestroyTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 	}
 
@@ -42,7 +42,7 @@ class DestroyTest extends ApiTestCase
 	 */
 	public function testApiFavoritesCreateDestroyWithDestroyAction(): void
 	{
-		$response = (new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'id' => 3,
 			]);
@@ -67,5 +67,43 @@ class DestroyTest extends ApiTestCase
 		$_SESSION['authenticated'] = false;
 		api_favorites_create_destroy('json');
 		*/
+	}
+
+	/**
+	 * Test the handleRequest() function with an invalid ID.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestFavoritesDestroyWithInvalidIdThrowsBadRequestException(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$module = new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$module->handleRequest($request);
+	}
+
+	/**
+	 * Test the handleRequest() function with an ID.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestFavoritesDestroyWithIdReturnsStatus(): void
+	{
+		$module = new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['id' => 3]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
 	}
 }

--- a/tests/src/Module/Api/Twitter/FavoritesTest.php
+++ b/tests/src/Module/Api/Twitter/FavoritesTest.php
@@ -25,7 +25,7 @@ class FavoritesTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'page'   => -1,
 				'max_id' => 10,
@@ -48,7 +48,7 @@ class FavoritesTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+		$response = (new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [ // @phpstan-ignore method.deprecated
 			'extension' => ICanCreateResponses::TYPE_RSS,
 		]))->run($this->httpExceptionMock);
 
@@ -68,5 +68,53 @@ class FavoritesTest extends ApiTestCase
 		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
 		// BasicAuth::setCurrentUserID();
 		// api_favorites('json');
+	}
+
+	/**
+	 * Test the handleRequest() function.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestFavoritesReturnsStatusList(): void
+	{
+		// @todo: This call is needed for this test
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['page' => -1, 'max_id' => 10]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		foreach ($json as $status) {
+			$this->assertStatus($status);
+		}
+	}
+
+	/**
+	 * Test the handleRequest() function with an RSS result.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestFavoritesWithRssReturnsXml(): void
+	{
+		// @todo: This call is needed for this test
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
 	}
 }

--- a/tests/src/Module/Api/Twitter/Followers/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Followers/ListsTest.php
@@ -18,7 +18,7 @@ class ListsTest extends ApiTestCase
 	 */
 	public function testApiStatusesFWithFollowers(): void
 	{
-		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
@@ -36,5 +36,25 @@ class ListsTest extends ApiTestCase
 
 		// $_GET['cursor'] = 'undefined';
 		// self::assertFalse(api_statuses_followers('json'));
+	}
+
+	/**
+	 * Test the handleRequest() function.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestFollowersListsReturnsUserList(): void
+	{
+		$module = new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->users);
 	}
 }

--- a/tests/src/Module/Api/Twitter/Friends/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Friends/ListsTest.php
@@ -20,7 +20,7 @@ class ListsTest extends ApiTestCase
 	 */
 	public function testApiStatusesFWithFriends(): void
 	{
-		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
@@ -38,5 +38,25 @@ class ListsTest extends ApiTestCase
 
 		// $_GET['cursor'] = 'undefined';
 		// self::assertFalse(api_statuses_f('friends'));
+	}
+
+	/**
+	 * Test the handleRequest() function.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestFriendsListsReturnsUserList(): void
+	{
+		$module = new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->users);
 	}
 }

--- a/tests/src/Module/Api/Twitter/Friendships/IncomingTest.php
+++ b/tests/src/Module/Api/Twitter/Friendships/IncomingTest.php
@@ -20,7 +20,7 @@ class IncomingTest extends ApiTestCase
 	 */
 	public function testApiFriendshipsIncoming(): void
 	{
-		$response = (new Incoming(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Incoming(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
@@ -38,5 +38,25 @@ class IncomingTest extends ApiTestCase
 
 		// $_GET['cursor'] = 'undefined';
 		// self::assertFalse(api_friendships_incoming('json'));
+	}
+
+	/**
+	 * Test the handleRequest() function.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestFriendshipsIncomingReturnsIdList(): void
+	{
+		$module = new Incoming(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->ids);
 	}
 }

--- a/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
+++ b/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
@@ -7,6 +7,7 @@
 
 namespace Friendica\Test\src\Module\Api\Twitter\Lists;
 
+use Friendica\Capabilities\ICanCreateResponses;
 use Friendica\Core\Renderer;
 use Friendica\DI;
 use Friendica\Module\Api\Twitter\Lists\Statuses;
@@ -24,7 +25,7 @@ class StatusesTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 	}
 
@@ -36,7 +37,7 @@ class StatusesTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'list_id' => 1,
 				'page'    => -1,
@@ -59,7 +60,7 @@ class StatusesTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
+		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'list_id' => 1,
 			]);
@@ -78,5 +79,50 @@ class StatusesTest extends ApiTestCase
 		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
 		// BasicAuth::setCurrentUserID();
 		// api_lists_statuses('json');
+	}
+
+	public function testHandleRequestListsStatusesReturnsStatusList(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$module = new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$module->handleRequest($request);
+	}
+
+	public function testHandleRequestListsStatusesWithXmlReturnsXml(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_XML]);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['list_id' => 1]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		self::assertXml((string) $response->getBody());
+	}
+
+	public function testHandleRequestListsStatusesWithIdReturnsStatusList(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['list_id' => 1]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		foreach ($json as $status) {
+			self::assertIsString($status->text);
+			self::assertIsInt($status->id);
+		}
 	}
 }

--- a/tests/src/Module/Api/Twitter/Media/UploadTest.php
+++ b/tests/src/Module/Api/Twitter/Media/UploadTest.php
@@ -25,6 +25,12 @@ class UploadTest extends ApiTestCase
 		$this->useHttpMethod(Router::POST);
 	}
 
+	protected function tearDown(): void
+	{
+		$_FILES = [];
+		parent::tearDown();
+	}
+
 	/**
 	 * Test the \Friendica\Module\Api\Twitter\Media\Upload module.
 	 */

--- a/tests/src/Module/Api/Twitter/Media/UploadTest.php
+++ b/tests/src/Module/Api/Twitter/Media/UploadTest.php
@@ -38,7 +38,7 @@ class UploadTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Upload(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Upload(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 	}
 
@@ -52,7 +52,7 @@ class UploadTest extends ApiTestCase
 		$this->expectException(UnauthorizedException::class);
 		AuthTestConfig::$authenticated = false;
 
-		(new class (DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []) extends Upload {
+		(new class (DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []) extends Upload { // @phpstan-ignore method.deprecated
 			public function jsonError(int $httpCode, $content, string $content_type = 'application/json')
 			{
 				if ($httpCode === 401) {
@@ -79,7 +79,7 @@ class UploadTest extends ApiTestCase
 			],
 		];
 
-		(new Upload(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Upload(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 	}
 
@@ -102,8 +102,107 @@ class UploadTest extends ApiTestCase
 			],
 		];
 
-		$response = (new Upload(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Upload(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
+
+		$media = $this->toJson($response);
+
+		self::assertEquals('image/png', $media->image->image_type);
+		self::assertEquals(1, $media->image->w);
+		self::assertEquals(1, $media->image->h);
+		self::assertNotEmpty($media->image->friendica_preview_url);
+	}
+
+	public function testHandleRequestMediaUploadThrowsBadRequestException(): void
+	{
+		$this->expectException(\Friendica\Network\HTTPException\BadRequestException::class);
+
+		$module = new Upload(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$module->handleRequest($request);
+	}
+
+	public function testHandleRequestMediaUploadWithImageReturnsMedia(): void
+	{
+		$_FILES = [
+			'media' => [
+				'id'       => 666,
+				'size'     => 666,
+				'width'    => 666,
+				'height'   => 666,
+				'tmp_name' => $this->getTempImage(),
+				'name'     => 'spacer.png',
+				'type'     => 'image/png',
+			],
+		];
+
+		$module = new Upload(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['media' => $this->getTempImage()]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$media = $this->toJson($response);
+
+		self::assertEquals('image/png', $media->image->image_type);
+		self::assertEquals(1, $media->image->w);
+		self::assertEquals(1, $media->image->h);
+		self::assertNotEmpty($media->image->friendica_preview_url);
+	}
+
+	public function testHandleRequestMediaUploadWithOtherImageReturnsMedia(): void
+	{
+		$_FILES = [
+			'media' => [
+				'id'       => 667,
+				'size'     => 667,
+				'width'    => 667,
+				'height'   => 667,
+				'tmp_name' => $this->getTempImage(),
+				'name'     => 'spacer2.png',
+				'type'     => 'image/png',
+			],
+		];
+
+		$module = new Upload(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['media' => $this->getTempImage()]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$media = $this->toJson($response);
+
+		self::assertEquals('image/png', $media->image->image_type);
+		self::assertEquals(1, $media->image->w);
+		self::assertEquals(1, $media->image->h);
+		self::assertNotEmpty($media->image->friendica_preview_url);
+	}
+
+	public function testHandleRequestMediaUploadWithUrlReturnsMedia(): void
+	{
+		$_FILES = [
+			'media' => [
+				'id'       => 668,
+				'size'     => 668,
+				'width'    => 668,
+				'height'   => 668,
+				'tmp_name' => $this->getTempImage(),
+				'name'     => 'spacer3.png',
+				'type'     => 'image/png',
+			],
+		];
+
+		$module = new Upload(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['media_url' => 'http://example.com/image.jpg']);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
 
 		$media = $this->toJson($response);
 

--- a/tests/src/Module/Api/Twitter/SavedSearchesTest.php
+++ b/tests/src/Module/Api/Twitter/SavedSearchesTest.php
@@ -16,12 +16,29 @@ class SavedSearchesTest extends ApiTestCase
 {
 	public function test(): void
 	{
-		$response = (new SavedSearches(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
+		$response = (new SavedSearches(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json'])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		$result = $this->toJson($response);
 
 		self::assertEquals(['Content-type' => ['application/json'], ICanCreateResponses::X_HEADER => ['json']], $response->getHeaders());
+		self::assertEquals(1, $result[0]->id);
+		self::assertEquals(1, $result[0]->id_str);
+		self::assertEquals('Saved search', $result[0]->name);
+		self::assertEquals('Saved search', $result[0]->query);
+	}
+
+	public function testHandleRequestSavedSearchesReturnsSearchList(): void
+	{
+		$module = new SavedSearches(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = $module->handleRequest($request);
+
+		$result = $this->toJson($response);
+
 		self::assertEquals(1, $result[0]->id);
 		self::assertEquals(1, $result[0]->id_str);
 		self::assertEquals('Saved search', $result[0]->name);

--- a/tests/src/Module/Api/Twitter/Statuses/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/DestroyTest.php
@@ -31,7 +31,7 @@ class DestroyTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 	}
 
@@ -56,10 +56,44 @@ class DestroyTest extends ApiTestCase
 	 */
 	public function testApiStatusesDestroyWithId(): void
 	{
-		$response = (new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'id' => 1,
 			]);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals(1, $json->id);
+		self::assertIsObject($json->user);
+		self::assertIsObject($json->friendica_author);
+	}
+
+	public function testHandleRequestDestroyThrowsBadRequestException(): void
+	{
+		$this->useHttpMethod(Router::POST);
+
+		$this->expectException(BadRequestException::class);
+
+		$module = new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$module->handleRequest($request);
+	}
+
+	public function testHandleRequestDestroyWithIdReturnsDestroyedStatus(): void
+	{
+		$this->useHttpMethod(Router::POST);
+
+		$module = new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['id' => 1]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
 
 		$json = $this->toJson($response);
 

--- a/tests/src/Module/Api/Twitter/Statuses/MentionsTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/MentionsTest.php
@@ -21,7 +21,7 @@ class MentionsTest extends ApiTestCase
 	 */
 	public function testApiStatusesMentions(): void
 	{
-		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'max_id' => 10,
 			]);
@@ -39,7 +39,7 @@ class MentionsTest extends ApiTestCase
 	 */
 	public function testApiStatusesMentionsWithNegativePage(): void
 	{
-		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'page' => -2,
 			]);
@@ -70,10 +70,55 @@ class MentionsTest extends ApiTestCase
 	 */
 	public function testApiStatusesMentionsWithRss(): void
 	{
-		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]))
+		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'page' => -2,
 			]);
+
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
+	}
+
+	public function testHandleRequestMentionsReturnsEmptyList(): void
+	{
+		$module = new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['max_id' => 10]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEmpty($json);
+	}
+
+	public function testHandleRequestMentionsWithNegativePageReturnsEmptyList(): void
+	{
+		$module = new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['page' => -2]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEmpty($json);
+	}
+
+	public function testHandleRequestMentionsWithRssReturnsXml(): void
+	{
+		$module = new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['page' => -2]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
 
 		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
 

--- a/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
@@ -25,7 +25,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'max_id' => 10,
 			]);
@@ -50,7 +50,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'page' => -2,
 			]);
@@ -88,11 +88,74 @@ class NetworkPublicTimelineTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [ // @phpstan-ignore method.deprecated
 			'extension' => ICanCreateResponses::TYPE_RSS,
 		]))->run($this->httpExceptionMock, [
 			'page' => -2,
 		]);
+
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
+	}
+
+	public function testHandleRequestNetworkPublicTimelineReturnsStatusList(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['max_id' => 10]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertNotEmpty($json);
+		foreach ($json as $status) {
+			self::assertIsString($status->text);
+			self::assertIsInt($status->id);
+		}
+	}
+
+	public function testHandleRequestNetworkPublicTimelineWithNegativePageReturnsStatusList(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['page' => -2]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertNotEmpty($json);
+		foreach ($json as $status) {
+			self::assertIsString($status->text);
+			self::assertIsInt($status->id);
+		}
+	}
+
+	public function testHandleRequestNetworkPublicTimelineWithRssReturnsXml(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+			'extension' => ICanCreateResponses::TYPE_RSS,
+		]);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['page' => -2]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
 
 		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
 

--- a/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
@@ -32,7 +32,7 @@ class RetweetTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 	}
 
@@ -57,7 +57,7 @@ class RetweetTest extends ApiTestCase
 	 */
 	public function testApiStatusesRepeatWithId(): void
 	{
-		$response = (new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'id' => 1,
 			]);
@@ -77,10 +77,61 @@ class RetweetTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'id' => 5,
 			]);
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+	}
+
+	public function testHandleRequestRetweetThrowsBadRequestException(): void
+	{
+		$this->useHttpMethod(Router::POST);
+
+		$this->expectException(BadRequestException::class);
+
+		$module = new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$module->handleRequest($request);
+	}
+
+	public function testHandleRequestRetweetWithIdReturnsStatus(): void
+	{
+		$this->useHttpMethod(Router::POST);
+
+		$module = new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['id' => 1]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+	}
+
+	public function testHandleRequestRetweetWithSharedIdReturnsStatus(): void
+	{
+		$this->useHttpMethod(Router::POST);
+
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['id' => 5]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
 
 		$json = $this->toJson($response);
 

--- a/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
@@ -25,7 +25,7 @@ class ShowTest extends ApiTestCase
 		$this->expectException(BadRequestException::class);
 
 
-		(new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 	}
 
@@ -36,7 +36,7 @@ class ShowTest extends ApiTestCase
 	 */
 	public function testApiStatusesShowWithId(): void
 	{
-		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'id' => 1,
 			]);
@@ -57,7 +57,7 @@ class ShowTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'id'           => 1,
 				'conversation' => 1,
@@ -84,5 +84,56 @@ class ShowTest extends ApiTestCase
 		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
 		// BasicAuth::setCurrentUserID();
 		// api_statuses_show('json');
+	}
+
+	public function testHandleRequestShowThrowsBadRequestException(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$module = new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$module->handleRequest($request);
+	}
+
+	public function testHandleRequestShowWithIdReturnsStatus(): void
+	{
+		$module = new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['id' => 1]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsInt($json->id);
+		self::assertIsString($json->text);
+	}
+
+	public function testHandleRequestShowWithConversationReturnsStatusList(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['id' => 1, 'conversation' => 1]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+
+		foreach ($json as $status) {
+			self::assertIsInt($status->id);
+			self::assertIsString($status->text);
+		}
 	}
 }

--- a/tests/src/Module/Api/Twitter/Statuses/UpdateTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/UpdateTest.php
@@ -40,7 +40,7 @@ class UpdateTest extends ApiTestCase
 			],
 		];
 
-		$response = (new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'status'                => 'Status content #friendica',
 				'in_reply_to_status_id' => 0,
@@ -62,7 +62,7 @@ class UpdateTest extends ApiTestCase
 	 */
 	public function testApiStatusesUpdateWithHtml(): void
 	{
-		$response = (new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'htmlstatus' => '<b>Status content</b>',
 			]);
@@ -113,5 +113,48 @@ class UpdateTest extends ApiTestCase
 	public function testApiStatusesUpdateWithDayThrottleReached(): void
 	{
 		$this->markTestIncomplete();
+	}
+
+	public function testHandleRequestUpdateReturnsStatus(): void
+	{
+		$this->useHttpMethod(Router::POST);
+
+		$module = new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([
+			'status'                => 'Status content #friendica',
+			'in_reply_to_status_id' => 0,
+			'lat'                   => 48,
+			'long'                  => 7,
+		]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+		self::assertStringContainsString('Status content #friendica', $json->text);
+		self::assertStringContainsString('Status content #', $json->statusnet_html);
+	}
+
+	public function testHandleRequestUpdateWithHtmlReturnsStatus(): void
+	{
+		$this->useHttpMethod(Router::POST);
+
+		$module = new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([
+			'htmlstatus' => '<b>Status content</b>',
+		]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
 	}
 }

--- a/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
@@ -22,7 +22,7 @@ class UserTimelineTest extends ApiTestCase
 	 */
 	public function testApiStatusesUserTimeline(): void
 	{
-		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'user_id'         => 43, // Public contact id
 				'max_id'          => 10,
@@ -50,7 +50,7 @@ class UserTimelineTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'user_id' => 43, // Public contact id
 				'page'    => -2,
@@ -73,7 +73,7 @@ class UserTimelineTest extends ApiTestCase
 	 */
 	public function testApiStatusesUserTimelineWithRss(): void
 	{
-		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [ // @phpstan-ignore method.deprecated
 			'extension' => ICanCreateResponses::TYPE_RSS,
 		]))->run($this->httpExceptionMock);
 
@@ -93,5 +93,72 @@ class UserTimelineTest extends ApiTestCase
 		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
 		// BasicAuth::setCurrentUserID();
 		// api_statuses_user_timeline('json');
+	}
+
+	public function testHandleRequestUserTimelineReturnsStatusList(): void
+	{
+		$module = new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([
+			'user_id'         => 43,
+			'max_id'          => 10,
+			'exclude_replies' => true,
+			'conversation_id' => 1,
+		]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertNotEmpty($json);
+		foreach ($json as $status) {
+			self::assertIsString($status->text);
+			self::assertIsInt($status->id);
+		}
+	}
+
+	public function testHandleRequestUserTimelineWithNegativePageReturnsStatusList(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([
+			'user_id' => 43,
+			'page'    => -2,
+		]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertNotEmpty($json);
+		foreach ($json as $status) {
+			self::assertIsString($status->text);
+			self::assertIsInt($status->id);
+		}
+	}
+
+	public function testHandleRequestUserTimelineWithRssReturnsXml(): void
+	{
+		$module = new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+			'extension' => ICanCreateResponses::TYPE_RSS,
+		]);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
 	}
 }

--- a/tests/src/Module/Api/Twitter/Users/LookupTest.php
+++ b/tests/src/Module/Api/Twitter/Users/LookupTest.php
@@ -24,7 +24,7 @@ class LookupTest extends ApiTestCase
 	{
 		$this->expectException(NotFoundException::class);
 
-		(new Lookup(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Lookup(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 	}
 
@@ -38,10 +38,51 @@ class LookupTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new Lookup(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Lookup(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'user_id' => static::OTHER_USER['id'],
 			]);
+
+		$json = $this->toJson($response);
+
+		self::assertOtherUser($json[0]);
+	}
+
+	/**
+	 * Test the handleRequest() function.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestUsersLookupThrowsNotFoundException(): void
+	{
+		$this->expectException(NotFoundException::class);
+
+		$module = new Lookup(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$module->handleRequest($request);
+	}
+
+	/**
+	 * Test the handleRequest() function with an user ID.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestUsersLookupWithUserIdReturnsOtherUser(): void
+	{
+		// @todo: This call is needed for this test
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new Lookup(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['user_id' => static::OTHER_USER['id']]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
 
 		$json = $this->toJson($response);
 

--- a/tests/src/Module/Api/Twitter/Users/SearchTest.php
+++ b/tests/src/Module/Api/Twitter/Users/SearchTest.php
@@ -26,7 +26,7 @@ class SearchTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, [
 				'q' => static::OTHER_USER['name'],
 			]);
@@ -46,7 +46,7 @@ class SearchTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
-		$response = (new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+		$response = (new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [ // @phpstan-ignore method.deprecated
 			'extension' => ICanCreateResponses::TYPE_XML,
 		]))->run($this->httpExceptionMock, [
 			'q' => static::OTHER_USER['name'],
@@ -64,7 +64,69 @@ class SearchTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
-		(new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		(new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
+	}
+
+	/**
+	 * Test the handleRequest() function with a query.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestUsersSearchWithQueryReturnsUserList(): void
+	{
+		// @todo: This call is needed for this test
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['q' => static::OTHER_USER['name']]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertOtherUser($json[0]);
+	}
+
+	/**
+	 * Test the handleRequest() function with a query and an XML result.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestUsersSearchWithQueryAndXmlReturnsXml(): void
+	{
+		// @todo: This call is needed for this test
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_XML]);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn(['q' => static::OTHER_USER['name']]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		self::assertXml((string) $response->getBody(), 'users');
+	}
+
+	/**
+	 * Test the handleRequest() function without a query parameter.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestUsersSearchWithoutQueryThrowsBadRequestException(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$module = new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$module->handleRequest($request);
 	}
 }

--- a/tests/src/Module/Api/Twitter/Users/ShowTest.php
+++ b/tests/src/Module/Api/Twitter/Users/ShowTest.php
@@ -21,7 +21,7 @@ class ShowTest extends ApiTestCase
 	 */
 	public function testApiUsersShow(): void
 	{
-		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
@@ -41,9 +41,53 @@ class ShowTest extends ApiTestCase
 	 */
 	public function testApiUsersShowWithXml(): void
 	{
-		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [ // @phpstan-ignore method.deprecated
 			'extension' => ICanCreateResponses::TYPE_XML,
 		]))->run($this->httpExceptionMock);
+
+		self::assertEquals(ICanCreateResponses::TYPE_XML, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
+	}
+
+	/**
+	 * Test the handleRequest() function.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestUsersShowReturnsSelfUser(): void
+	{
+		$module = new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
+
+		$json = $this->toJson($response);
+
+		self::assertEquals(static::SELF_USER['id'], $json->cid);
+		self::assertEquals('DFRN', $json->location);
+		self::assertEquals(static::SELF_USER['name'], $json->name);
+		self::assertEquals(static::SELF_USER['nick'], $json->screen_name);
+		self::assertTrue($json->verified);
+	}
+
+	/**
+	 * Test the handleRequest() function with an XML result.
+	 *
+	 * @return void
+	 */
+	public function testHandleRequestUsersShowWithXmlReturnsXml(): void
+	{
+		$module = new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_XML]);
+
+		$request = $this->createMock(\Friendica\App\Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = $module->handleRequest($request);
 
 		self::assertEquals(ICanCreateResponses::TYPE_XML, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
 

--- a/tests/src/Module/NodeInfoTest.php
+++ b/tests/src/Module/NodeInfoTest.php
@@ -8,6 +8,7 @@
 namespace Friendica\Test\src\Module;
 
 use Friendica\App;
+use Friendica\App\Request;
 use Friendica\Capabilities\ICanCreateResponses;
 use Friendica\DI;
 use Friendica\Module\NodeInfo110;
@@ -31,7 +32,7 @@ class NodeInfoTest extends FixtureTestCase
 
 	public function testNodeInfo110(): void
 	{
-		$response = (new NodeInfo110(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), []))
+		$response = (new NodeInfo110(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		self::assertJson($response->getBody());
@@ -52,7 +53,7 @@ class NodeInfoTest extends FixtureTestCase
 
 	public function testNodeInfo120(): void
 	{
-		$response = (new NodeInfo120(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), []))
+		$response = (new NodeInfo120(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		self::assertJson($response->getBody());
@@ -72,7 +73,7 @@ class NodeInfoTest extends FixtureTestCase
 
 	public function testNodeInfo210(): void
 	{
-		$response = (new NodeInfo210(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), []))
+		$response = (new NodeInfo210(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		self::assertJson($response->getBody());
@@ -85,6 +86,70 @@ class NodeInfoTest extends FixtureTestCase
 		self::assertEquals('friendica', $json->server->software);
 		self::assertEquals(App::VERSION . '-' . DB_UPDATE_VERSION, $json->server->version);
 
+		self::assertIsArray($json->protocols);
+		self::assertIsArray($json->services->inbound);
+		self::assertIsArray($json->services->outbound);
+	}
+
+	public function testHandleRequestNodeInfo110ReturnsJson(): void
+	{
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = (new NodeInfo110(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), []))
+			->handleRequest($request);
+
+		self::assertJson($response->getBody());
+		self::assertEquals(['Content-type' => ['application/json'], ICanCreateResponses::X_HEADER => ['json']], $response->getHeaders());
+
+		$json = json_decode($response->getBody());
+
+		self::assertEquals('1.0', $json->version);
+		self::assertEquals('friendica', $json->software->name);
+		self::assertEquals(App::VERSION . '-' . DB_UPDATE_VERSION, $json->software->version);
+		self::assertIsArray($json->protocols->inbound);
+		self::assertIsArray($json->protocols->outbound);
+		self::assertIsArray($json->services->inbound);
+		self::assertIsArray($json->services->outbound);
+	}
+
+	public function testHandleRequestNodeInfo120ReturnsJson(): void
+	{
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = (new NodeInfo120(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), []))
+			->handleRequest($request);
+
+		self::assertJson($response->getBody());
+		self::assertEquals(['Content-type' => ['application/json; charset=utf-8'], ICanCreateResponses::X_HEADER => ['json']], $response->getHeaders());
+
+		$json = json_decode($response->getBody());
+
+		self::assertEquals('2.0', $json->version);
+		self::assertEquals('friendica', $json->software->name);
+		self::assertEquals(App::VERSION . '-' . DB_UPDATE_VERSION, $json->software->version);
+		self::assertIsArray($json->protocols);
+		self::assertIsArray($json->services->inbound);
+		self::assertIsArray($json->services->outbound);
+	}
+
+	public function testHandleRequestNodeInfo210ReturnsJson(): void
+	{
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = (new NodeInfo210(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), DI::config(), []))
+			->handleRequest($request);
+
+		self::assertJson($response->getBody());
+		self::assertEquals(['Content-type' => ['application/json; charset=utf-8'], ICanCreateResponses::X_HEADER => ['json']], $response->getHeaders());
+
+		$json = json_decode($response->getBody());
+
+		self::assertEquals('1.0', $json->version);
+		self::assertEquals('friendica', $json->server->software);
+		self::assertEquals(App::VERSION . '-' . DB_UPDATE_VERSION, $json->server->version);
 		self::assertIsArray($json->protocols);
 		self::assertIsArray($json->services->inbound);
 		self::assertIsArray($json->services->outbound);

--- a/tests/src/Module/Special/OptionsTest.php
+++ b/tests/src/Module/Special/OptionsTest.php
@@ -7,6 +7,7 @@
 
 namespace Friendica\Test\src\Module\Special;
 
+use Friendica\App\Request;
 use Friendica\App\Router;
 use Friendica\Capabilities\ICanCreateResponses;
 use Friendica\DI;
@@ -31,7 +32,7 @@ class OptionsTest extends FixtureTestCase
 	{
 		$this->useHttpMethod(Router::OPTIONS);
 
-		$response = (new Options(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock);
+		$response = (new Options(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock); // @phpstan-ignore method.deprecated
 
 		self::assertEmpty((string) $response->getBody());
 		self::assertEquals(204, $response->getStatusCode());
@@ -47,9 +48,52 @@ class OptionsTest extends FixtureTestCase
 	{
 		$this->useHttpMethod(Router::OPTIONS);
 
-		$response = (new Options(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+		$response = (new Options(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [ // @phpstan-ignore method.deprecated
 			'AllowedMethods' => [Router::GET, Router::POST],
 		]))->run($this->httpExceptionMock);
+
+		self::assertEmpty((string) $response->getBody());
+		self::assertEquals(204, $response->getStatusCode());
+		self::assertEquals('No Content', $response->getReasonPhrase());
+		self::assertEquals([
+			'Allow'                       => [implode(',', [Router::GET, Router::POST])],
+			ICanCreateResponses::X_HEADER => ['blank'],
+		], $response->getHeaders());
+		self::assertEquals(implode(',', [Router::GET, Router::POST]), $response->getHeaderLine('Allow'));
+	}
+
+	public function testHandleRequestOptionsAllReturns204(): void
+	{
+		$this->useHttpMethod(Router::OPTIONS);
+
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = (new Options(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
+			->handleRequest($request);
+
+		self::assertEmpty((string) $response->getBody());
+		self::assertEquals(204, $response->getStatusCode());
+		self::assertEquals('No Content', $response->getReasonPhrase());
+		self::assertEquals([
+			'Allow'                       => [implode(',', Router::ALLOWED_METHODS)],
+			ICanCreateResponses::X_HEADER => ['blank'],
+		], $response->getHeaders());
+		self::assertEquals(implode(',', Router::ALLOWED_METHODS), $response->getHeaderLine('Allow'));
+	}
+
+	public function testHandleRequestOptionsSpecificReturns204(): void
+	{
+		$this->useHttpMethod(Router::OPTIONS);
+
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+
+		$response = (new Options(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+			'AllowedMethods' => [Router::GET, Router::POST],
+		]))->handleRequest($request);
 
 		self::assertEmpty((string) $response->getBody());
 		self::assertEquals(204, $response->getStatusCode());

--- a/tests/src/Module/StatsCachingTest.php
+++ b/tests/src/Module/StatsCachingTest.php
@@ -204,7 +204,7 @@ class StatsCachingTest extends FixtureTestCase
 
 	public function testHandleRequestStatsCachingNotAllowedReturns404(): void
 	{
-		$config = $this->createMock(IManageConfigValues::class);
+		$config = $this->createStub(IManageConfigValues::class);
 		$request = $this->createMock(Request::class);
 		$request->method('getAllInput')->willReturn([]);
 		$request->method('getQueryString')->willReturn('');

--- a/tests/src/Module/StatsCachingTest.php
+++ b/tests/src/Module/StatsCachingTest.php
@@ -7,6 +7,7 @@
 
 namespace Friendica\Test\src\Module;
 
+use Friendica\App\Request;
 use Friendica\Capabilities\ICanCreateResponses;
 use Friendica\Core\Cache\Capability\ICanCache;
 use Friendica\Core\Cache\Type\ArrayCache;
@@ -47,7 +48,7 @@ class StatsCachingTest extends FixtureTestCase
 	{
 		$this->httpExceptionMock->shouldReceive('content')->andReturn('failed')->once();
 
-		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, []))
+		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock);
 
 		self::assertEquals('404', $response->getStatusCode());
@@ -63,7 +64,7 @@ class StatsCachingTest extends FixtureTestCase
 		$this->config->shouldReceive('get')->with('system', 'stats_key')->twice()->andReturn('12345');
 		PHPMockery::mock("Friendica\\Module", "function_exists")->with('opcache_get_status')->once()->andReturn(false);
 
-		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, []))
+		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, $request);
 
 		self::assertJson($response->getBody());
@@ -92,7 +93,7 @@ class StatsCachingTest extends FixtureTestCase
 		$this->lock  = new DatabaseLock(DI::dba());
 		PHPMockery::mock("Friendica\\Module", "function_exists")->with('opcache_get_status')->once()->andReturn(false);
 
-		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, []))
+		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, $request);
 
 		self::assertJson($response->getBody());
@@ -116,7 +117,7 @@ class StatsCachingTest extends FixtureTestCase
 		$this->lock  = new DatabaseLock(DI::dba());
 		PHPMockery::mock("Friendica\\Module", "function_exists")->with('opcache_get_status')->once()->andReturn(false);
 
-		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, []))
+		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, $request);
 
 		self::assertJson($response->getBody());
@@ -141,7 +142,7 @@ class StatsCachingTest extends FixtureTestCase
 		PHPMockery::mock("Friendica\\Module", "function_exists")->with('opcache_get_status')->once()->andReturn(true);
 		PHPMockery::mock("Friendica\\Module", "opcache_get_status")->with(false)->once()->andReturn(false);
 
-		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, []))
+		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, $request);
 
 		self::assertJson($response->getBody());
@@ -182,7 +183,7 @@ class StatsCachingTest extends FixtureTestCase
 			],
 		]);
 
-		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, []))
+		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $this->config, $this->cache, $this->lock, [])) // @phpstan-ignore method.deprecated
 			->run($this->httpExceptionMock, $request);
 
 		self::assertJson($response->getBody());
@@ -199,5 +200,42 @@ class StatsCachingTest extends FixtureTestCase
 		], $json['opcache']);
 		self::assertEquals(['type' => 'database'], $json['cache']);
 		self::assertEquals(['type' => 'database'], $json['lock']);
+	}
+
+	public function testHandleRequestStatsCachingNotAllowedReturns404(): void
+	{
+		$config = $this->createMock(IManageConfigValues::class);
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn([]);
+		$request->method('getQueryString')->willReturn('');
+		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $config, $this->cache, $this->lock, []))
+			->handleRequest($request);
+
+		self::assertEquals(404, $response->getStatusCode());
+	}
+
+	public function testHandleRequestStatsCachingWithMinimumReturnsJson(): void
+	{
+		$config = $this->createMock(IManageConfigValues::class);
+		$config->method('get')->with('system', 'stats_key')->willReturn('12345');
+		$request = $this->createMock(Request::class);
+		$request->method('getAllInput')->willReturn(['key' => '12345']);
+		$request->method('getQueryString')->willReturn('');
+		$response = (new StatsCaching(DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], $config, $this->cache, $this->lock, []))
+			->handleRequest($request);
+
+		self::assertJson($response->getBody());
+		self::assertEquals(['Content-type' => ['application/json; charset=utf-8'], ICanCreateResponses::X_HEADER => ['json']], $response->getHeaders());
+
+		$json = json_decode($response->getBody(), true);
+
+		self::assertEquals([
+			'type'  => 'array',
+			'stats' => [],
+		], $json['cache']);
+		self::assertEquals([
+			'type'  => 'array',
+			'stats' => [],
+		], $json['lock']);
 	}
 }

--- a/tests/src/Security/BasicAuthTest.php
+++ b/tests/src/Security/BasicAuthTest.php
@@ -12,6 +12,12 @@ use Friendica\Test\ApiTestCase;
 
 class BasicAuthTest extends ApiTestCase
 {
+	protected function tearDown(): void
+	{
+		unset($_REQUEST['source'], $_SERVER['HTTP_USER_AGENT'], $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+		parent::tearDown();
+	}
+
 	/**
 	 * Test the api_source() function.
 	 *

--- a/tests/src/Util/HTTPInputDataTest.php
+++ b/tests/src/Util/HTTPInputDataTest.php
@@ -25,7 +25,7 @@ class HTTPInputDataTest extends MockedTestCase
 			['Content-Type' => 'application/x-www-form-urlencoded;charset=utf8'],
 			'title=Test2',
 			'1.1',
-			['CONTENT_TYPE' => 'application/x-www-form-urlencoded;charset=utf8']
+			['CONTENT_TYPE' => 'application/x-www-form-urlencoded;charset=utf8'],
 		);
 
 		$httpInput = new HTTPInputDataDouble($psr7Request->getServerParams(), $psr7Request);

--- a/tests/src/Util/HTTPInputDataTest.php
+++ b/tests/src/Util/HTTPInputDataTest.php
@@ -17,6 +17,22 @@ use Friendica\Test\Util\HTTPInputDataDouble;
  */
 class HTTPInputDataTest extends MockedTestCase
 {
+	public function testProcessWithPsr7Body(): void
+	{
+		$psr7Request = new \GuzzleHttp\Psr7\ServerRequest(
+			'POST',
+			'http://example.com',
+			['Content-Type' => 'application/x-www-form-urlencoded;charset=utf8'],
+			'title=Test2',
+			'1.1',
+			['CONTENT_TYPE' => 'application/x-www-form-urlencoded;charset=utf8']
+		);
+
+		$httpInput = new HTTPInputDataDouble($psr7Request->getServerParams(), $psr7Request);
+		$output    = $httpInput->process();
+
+		$this->assertSame(['variables' => ['title' => 'Test2'], 'files' => []], $output);
+	}
 	/**
 	 * Returns the data stream for the unit test
 	 * Each array element of the first hierarchy represents one test run


### PR DESCRIPTION
Followup PR for #15914.

Requires:

- [ ] Merge of #15914

This PR deprecates the `ICanHandleRequests` interface and updates the tests.