### PR TITLE
Fix Page Flag for Page Registrations

### DIFF
--- a/src/Module/Register.php
+++ b/src/Module/Register.php
@@ -403,11 +403,11 @@ class Register extends BaseModule
 						break;
 					case User::ORGPAGE:
 						$acct_type = User::ACCOUNT_TYPE_ORGANISATION;
-						$acct_flag = User::PAGE_FLAGS_SOAPBOX;
+						$acct_flag = User::PAGE_FLAGS_NORMAL;
 						break;
 					case User::NEWSPAGE:
 						$acct_type = User::ACCOUNT_TYPE_NEWS;
-						$acct_flag = User::PAGE_FLAGS_SOAPBOX;
+						$acct_flag = User::PAGE_FLAGS_NORMAL;
 						break;
 					case User::PUBGROUP:
 						$acct_type = User::ACCOUNT_TYPE_COMMUNITY;


### PR DESCRIPTION
In _/src/Module/Register.php_ when the form is posted to create an ORGANISATION or NEWS page it sets the page flag to "1" but that's the flag for a PERSON account sub-type of "Soapbox." ORG and NEWS pages do not have any sub-stypes, therefore the correct page flag is "0" for "Normal."

While this fixes the page flag for any new ORG or NEWS pages registered in the future it does not fix the errant flag assigned to any existing page accounts.

I discovered this when trying to restyle icons in the *Moderation > Users* table, where it was showing the "Soapbox" icon for ORG and NEWS pages and the tooltip was also misidentifying them as a "Soapbox Page."  The user table icons have been fixed in another already merged PR.