### PR TITLE
Add Page Module Class to Body Tag in Vier

### DIFF
--- a/view/php/default.php
+++ b/view/php/default.php
@@ -18,7 +18,7 @@
   <script>var baseurl="<?php echo Friendica\DI::baseUrl() ?>";</script>
   <?php if(!empty($page['htmlhead'])) echo $page['htmlhead'] ?>
 </head>
-<body>
+<body class="mod-<?php echo $page['module'] ?>">
 	<?php if(!empty($page['nav'])) echo $page['nav']; ?>
 	<aside><?php if(!empty($page['aside'])) echo $page['aside']; ?></aside>
 	<section>

--- a/view/php/default.php
+++ b/view/php/default.php
@@ -14,19 +14,33 @@
 <!DOCTYPE html>
 <html itemscope itemtype="http://schema.org/Blog" lang="<?php echo $lang; ?>">
 <head>
-  <title><?php if(!empty($page['title'])) echo $page['title'] ?></title>
+  <title><?php if (!empty($page['title'])) {
+  	echo $page['title'];
+  } ?></title>
   <script>var baseurl="<?php echo Friendica\DI::baseUrl() ?>";</script>
-  <?php if(!empty($page['htmlhead'])) echo $page['htmlhead'] ?>
+  <?php if (!empty($page['htmlhead'])) {
+  	echo $page['htmlhead'];
+  } ?>
 </head>
 <body class="mod-<?php echo $page['module'] ?>">
-	<?php if(!empty($page['nav'])) echo $page['nav']; ?>
-	<aside><?php if(!empty($page['aside'])) echo $page['aside']; ?></aside>
+	<?php if (!empty($page['nav'])) {
+		echo $page['nav'];
+	} ?>
+	<aside><?php if (!empty($page['aside'])) {
+		echo $page['aside'];
+	} ?></aside>
 	<section>
-		<?php if(!empty($page['content'])) echo $page['content']; ?>
+		<?php if (!empty($page['content'])) {
+			echo $page['content'];
+		} ?>
 		<div id="pause"></div> <!-- The pause/resume Ajax indicator -->
 		<div id="page-footer"></div>
 	</section>
-	<right_aside><?php if(!empty($page['right_aside'])) echo $page['right_aside']; ?></right_aside>
-	<footer><?php if(!empty($page['footer'])) echo $page['footer']; ?></footer>
+	<right_aside><?php if (!empty($page['right_aside'])) {
+		echo $page['right_aside'];
+	} ?></right_aside>
+	<footer><?php if (!empty($page['footer'])) {
+		echo $page['footer'];
+	} ?></footer>
 </body>
 </html>


### PR DESCRIPTION
In the "Frio" theme the `<body>` tag of every page includes a classname for what section (module) the page falls under. When creating custom styles these classnames are incredibly useful for making exceptions or alternate layouts for different parts of Friendica.  You just preface it in your stylesheet with something like `body.mod-profile` and your restyling doesn't adversely affect other sections. It's confined to the profile pages.  I rely on this quite a bit for my Bookface schemes.

The "Vier" theme currently doesn't have this. Which makes it much more difficult to target styling to a specific Friendica section. You have to infer where you are based off of what you _hope_ are unique combinations of elements with convoluted styling like `section:has((:not(.coverphoto))::before` or `aside + section:has(#contacts-search-wrapper)`. But with this change you could know for sure you are on `body.mod-profile` or `body.mod-contacts` as the scope of your changes.

"Vier" is the basis for just about every third-party theme created for Friendica because of its simplicity. It also has more sub-styles (Breath, Plus, etc.) than "Frio" has schemes.  Now that most of "Vier" has been moved into the Friendica core it will make building custom themes based on it even easier, and if this project wants to encourage admins to create and experiment with custom themes for their server this change will make tweaking the styles easier.