### PR TITLE
Add PSR-7 support in Modules

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -45,3 +45,10 @@ parameters:
             identifier: method.notFound
             path: tests/
             count: 236
+        # Deprecated run() calls in tests are preserved for BC promise and
+        # will be replaced by handleRequest() tests in the future
+        -
+            message: '#^Call to deprecated method run\(\) of class#'
+            identifier: method.deprecated
+            path: tests/
+            count: 95

--- a/src/App.php
+++ b/src/App.php
@@ -16,6 +16,7 @@ use Friendica\App\Request;
 use Friendica\App\Router;
 use Friendica\Capabilities\ICanCreateResponses;
 use Friendica\Capabilities\ICanHandleRequests;
+use Friendica\Capabilities\IRequestHandler;
 use Friendica\Content\Nav;
 use Friendica\Core\Addon\AddonHelper;
 use Friendica\Core\Config\Factory\Config;
@@ -128,6 +129,9 @@ class App
 	 */
 	private $appHelper;
 
+	/** @var ServerRequestInterface */
+	private $psrRequest;
+
 	private function __construct(private readonly Container $container) {}
 
 	/**
@@ -135,6 +139,8 @@ class App
 	 */
 	public function processRequest(ServerRequestInterface $request, float $start_time): void
 	{
+		$this->psrRequest = $request;
+
 		$this->container->addRule(Mode::class, [
 			'call' => [
 				['determineRunMode', [false, $request->getServerParams()], Dice::CHAIN_CALL],
@@ -584,7 +590,7 @@ class App
 
 			// Let the module run its internal process (init, get, post, ...)
 			$timestamp = microtime(true);
-			$response  = $module->run($httpException, $input);
+			$response  = $module->handleRequest($this->psrRequest);
 			$this->profiler->set(microtime(true) - $timestamp, 'content');
 
 			// Wrapping HTML responses in the theme template
@@ -603,7 +609,7 @@ class App
 		$page->logRuntime($this->config, 'runFrontend');
 	}
 
-	private function createModuleInstance(?string $moduleClass = null): ICanHandleRequests
+	private function createModuleInstance(?string $moduleClass = null): ICanHandleRequests&IRequestHandler
 	{
 		/** @var Router $router */
 		$router = $this->container->create(Router::class);
@@ -615,7 +621,7 @@ class App
 
 		$stamp = microtime(true);
 
-		/** @var ICanHandleRequests $module */
+		/** @var ICanHandleRequests&IRequestHandler $module */
 		$module = $this->container->create($moduleClass, $parameters);
 
 		if ($dice_profiler_threshold > 0) {

--- a/src/App.php
+++ b/src/App.php
@@ -10,6 +10,7 @@ namespace Friendica;
 use Dice\Dice;
 use Friendica\App\Arguments;
 use Friendica\App\BaseURL;
+use Friendica\BaseModule;
 use Friendica\App\Mode;
 use Friendica\App\Page;
 use Friendica\App\Request;
@@ -38,6 +39,7 @@ use Friendica\Database\Definition\ViewDefinition;
 use Friendica\Event\ConfigLoadedEvent;
 use Friendica\Event\Event;
 use Friendica\Module\Maintenance;
+use Friendica\Module\Response;
 use Friendica\Module\Special\HTTPException as ModuleHTTPException;
 use Friendica\Network\HTTPException;
 use Friendica\Protocol\ATProtocol\DID;
@@ -590,7 +592,26 @@ class App
 
 			// Let the module run its internal process (init, get, post, ...)
 			$timestamp = microtime(true);
-			$response  = $module->handleRequest($this->psrRequest);
+			try {
+				$response = $module->handleRequest($this->psrRequest);
+			} catch (HTTPException $e) {
+				// In case of System::externalRedirects(), we don't want to prettyprint the exception
+				// just redirect to the new location
+				if (($e instanceof HTTPException\FoundException)
+					|| ($e instanceof HTTPException\MovedPermanentlyException)
+					|| ($e instanceof HTTPException\TemporaryRedirectException)) {
+					throw $e;
+				}
+
+				if ($module instanceof BaseModule) {
+					$errorResponse = $module->getResponse();
+				} else {
+					$errorResponse = new Response();
+				}
+				$errorResponse->setStatus($e->getCode(), $e->getMessage());
+				$errorResponse->addContent($httpException->content($e));
+				$response = $errorResponse->generate();
+			}
 			$this->profiler->set(microtime(true) - $timestamp, 'content');
 
 			// Wrapping HTML responses in the theme template

--- a/src/App.php
+++ b/src/App.php
@@ -10,7 +10,6 @@ namespace Friendica;
 use Dice\Dice;
 use Friendica\App\Arguments;
 use Friendica\App\BaseURL;
-use Friendica\BaseModule;
 use Friendica\App\Mode;
 use Friendica\App\Page;
 use Friendica\App\Request;

--- a/src/App.php
+++ b/src/App.php
@@ -603,13 +603,13 @@ class App
 				}
 
 				if ($module instanceof BaseModule) {
-					$errorResponse = $module->getResponse();
+					$responseBuilder = $module->getResponseBuilder();
 				} else {
-					$errorResponse = new Response();
+					$responseBuilder = new Response();
 				}
-				$errorResponse->setStatus($e->getCode(), $e->getMessage());
-				$errorResponse->addContent($httpException->content($e));
-				$response = $errorResponse->generate();
+				$responseBuilder->setStatus($e->getCode(), $e->getMessage());
+				$responseBuilder->addContent($httpException->content($e));
+				$response = $responseBuilder->generate();
 			}
 			$this->profiler->set(microtime(true) - $timestamp, 'content');
 

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -217,6 +217,16 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	}
 
 	/**
+	 * Hook for modules to perform scope or permission checks before dispatch
+	 *
+	 * @return void
+	 * @throws HTTPException
+	 */
+	protected function checkScope(): void
+	{
+	}
+
+	/**
 	 * Dispatches the module CORS headers, events and method handling
 	 *
 	 * @param array $request The request data
@@ -225,6 +235,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 */
 	final protected function dispatch(array $request): void
 	{
+		$this->checkScope();
 		// @see https://github.com/tootsuite/mastodon/blob/c3aef491d66aec743a3a53e934a494f653745b61/config/initializers/cors.rb
 		if (str_starts_with($this->args->getQueryString(), '.well-known/')) {
 			$this->response->setHeader('*', 'Access-Control-Allow-Origin');

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -223,7 +223,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 * @return void
 	 * @throws HTTPException
 	 */
-	protected function dispatch(array $request): void
+	final protected function dispatch(array $request): void
 	{
 		// @see https://github.com/tootsuite/mastodon/blob/c3aef491d66aec743a3a53e934a494f653745b61/config/initializers/cors.rb
 		if (str_starts_with($this->args->getQueryString(), '.well-known/')) {

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -198,7 +198,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
 	{
-		$this->dispatch($request);
+		$this->dispatch($request, $httpException);
 
 		return $this->response->generate();
 	}
@@ -214,11 +214,12 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	/**
 	 * Dispatches the module CORS headers, events and method handling
 	 *
-	 * @param array $request The request data
+	 * @param array                              $request The request data
+	 * @param ModuleHTTPException|null $httpException Optional exception renderer for the content phase
 	 * @return void
 	 * @throws HTTPException
 	 */
-	final protected function dispatch(array $request): void
+	final protected function dispatch(array $request, ?ModuleHTTPException $httpException = null): void
 	{
 		$this->checkScope();
 		// @see https://github.com/tootsuite/mastodon/blob/c3aef491d66aec743a3a53e934a494f653745b61/config/initializers/cors.rb
@@ -287,11 +288,27 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 		// templating and is expected to exit on its own if it is set.
 		$this->rawContent($request);
 
-		$content = $this->eventDispatcher->dispatch(
-			new ModuleContentEvent(ModuleContentEvent::MODULE_CONTENT, $this->args->getModuleName(), static::class, ''),
-		)->getContent();
-		$this->response->addContent($content);
-		$this->response->addContent($this->content($request));
+		try {
+			$content = $this->eventDispatcher->dispatch(
+				new ModuleContentEvent(ModuleContentEvent::MODULE_CONTENT, $this->args->getModuleName(), static::class, ''),
+			)->getContent();
+			$this->response->addContent($content);
+			$this->response->addContent($this->content($request));
+		} catch (HTTPException $e) {
+			if ($e instanceof HTTPException\FoundException
+				|| $e instanceof HTTPException\MovedPermanentlyException
+				|| $e instanceof HTTPException\TemporaryRedirectException
+			) {
+				throw $e;
+			}
+
+			if ($httpException) {
+				$this->response->setStatus($e->getCode(), $e->getMessage());
+				$this->response->addContent($httpException->content($e));
+			} else {
+				throw $e;
+			}
+		}
 
 		$this->profiler->set(microtime(true) - $timestamp, 'content');
 	}

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -186,6 +186,14 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	protected function get(array $request = []) {}
 
 	/**
+	 * @internal Used by App::runFrontend() to set error responses on the module's response instance
+	 */
+	public function getResponse(): ICanCreateResponses
+	{
+		return $this->response;
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
@@ -292,6 +300,9 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 		$this->profiler->set(microtime(true) - $timestamp, 'content');
 	}
 
+	/**
+	 * @throws HTTPException
+	 */
 	public function handleRequest(ServerRequestInterface $request): ResponseInterface
 	{
 		$httpInput  = new HTTPInputData($request->getServerParams());
@@ -306,7 +317,8 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 			is_array($parsedBody) ? $parsedBody : [],
 		);
 
-		return $this->run(DI::getDice()->create(ModuleHTTPException::class), $requestArray);
+		$this->dispatch($requestArray);
+		return $this->response->generate();
 	}
 
 	/**

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -208,7 +208,8 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	/**
 	 * Hook for modules to perform scope or permission checks before dispatch
 	 *
-	 * @return void
+	 * @internal
+	 *
 	 * @throws HTTPException
 	 */
 	protected function checkScope(): void {}

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -195,6 +195,8 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @deprecated Use {@see IRequestHandler::handleRequest()} instead
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
 	{

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -188,7 +188,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	/**
 	 * @internal Used by App::runFrontend() to set error responses on the module's response instance
 	 */
-	public function getResponse(): ICanCreateResponses
+	public function getResponseBuilder(): ICanCreateResponses
 	{
 		return $this->response;
 	}

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -198,20 +198,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
 	{
-		try {
-			$this->dispatch($request);
-		} catch (HTTPException $e) {
-			// In case of System::externalRedirects(), we don't want to prettyprint the exception
-			// just redirect to the new location
-			if (($e instanceof HTTPException\FoundException)
-				|| ($e instanceof HTTPException\MovedPermanentlyException)
-				|| ($e instanceof HTTPException\TemporaryRedirectException)) {
-				throw $e;
-			}
-
-			$this->response->setStatus($e->getCode(), $e->getMessage());
-			$this->response->addContent($httpException->content($e));
-		}
+		$this->dispatch($request);
 
 		return $this->response->generate();
 	}

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -190,6 +190,33 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
 	{
+		try {
+			$this->dispatch($request);
+		} catch (HTTPException $e) {
+			// In case of System::externalRedirects(), we don't want to prettyprint the exception
+			// just redirect to the new location
+			if (($e instanceof HTTPException\FoundException)
+				|| ($e instanceof HTTPException\MovedPermanentlyException)
+				|| ($e instanceof HTTPException\TemporaryRedirectException)) {
+				throw $e;
+			}
+
+			$this->response->setStatus($e->getCode(), $e->getMessage());
+			$this->response->addContent($httpException->content($e));
+		}
+
+		return $this->response->generate();
+	}
+
+	/**
+	 * Dispatches the module CORS headers, events and method handling
+	 *
+	 * @param array $request The request data
+	 * @return void
+	 * @throws HTTPException
+	 */
+	protected function dispatch(array $request): void
+	{
 		// @see https://github.com/tootsuite/mastodon/blob/c3aef491d66aec743a3a53e934a494f653745b61/config/initializers/cors.rb
 		if (str_starts_with($this->args->getQueryString(), '.well-known/')) {
 			$this->response->setHeader('*', 'Access-Control-Allow-Origin');
@@ -256,28 +283,13 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 		// templating and is expected to exit on its own if it is set.
 		$this->rawContent($request);
 
-		try {
-			$content = $this->eventDispatcher->dispatch(
-				new ModuleContentEvent(ModuleContentEvent::MODULE_CONTENT, $this->args->getModuleName(), static::class, ''),
-			)->getContent();
-			$this->response->addContent($content);
-			$this->response->addContent($this->content($request));
-		} catch (HTTPException $e) {
-			// In case of System::externalRedirects(), we don't want to prettyprint the exception
-			// just redirect to the new location
-			if (($e instanceof HTTPException\FoundException)
-				|| ($e instanceof HTTPException\MovedPermanentlyException)
-				|| ($e instanceof HTTPException\TemporaryRedirectException)) {
-				throw $e;
-			}
-
-			$this->response->setStatus($e->getCode(), $e->getMessage());
-			$this->response->addContent($httpException->content($e));
-		}
+		$content = $this->eventDispatcher->dispatch(
+			new ModuleContentEvent(ModuleContentEvent::MODULE_CONTENT, $this->args->getModuleName(), static::class, ''),
+		)->getContent();
+		$this->response->addContent($content);
+		$this->response->addContent($this->content($request));
 
 		$this->profiler->set(microtime(true) - $timestamp, 'content');
-
-		return $this->response->generate();
 	}
 
 	public function handleRequest(ServerRequestInterface $request): ResponseInterface

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -10,6 +10,7 @@ namespace Friendica;
 use Friendica\App\Router;
 use Friendica\Capabilities\ICanHandleRequests;
 use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Capabilities\IRequestHandler;
 use Friendica\Core\L10n;
 use Friendica\Core\System;
 use Friendica\Event\ModuleContentEvent;
@@ -19,9 +20,11 @@ use Friendica\Model\User;
 use Friendica\Module\Response;
 use Friendica\Module\Special\HTTPException as ModuleHTTPException;
 use Friendica\Network\HTTPException;
+use Friendica\Util\HTTPInputData;
 use Friendica\Util\Profiler;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -33,7 +36,7 @@ use Psr\Log\LoggerInterface;
  *
  * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
-abstract class BaseModule implements ICanHandleRequests
+abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 {
 	/** @var array */
 	protected $parameters = [];
@@ -275,6 +278,23 @@ abstract class BaseModule implements ICanHandleRequests
 		$this->profiler->set(microtime(true) - $timestamp, 'content');
 
 		return $this->response->generate();
+	}
+
+	public function handleRequest(ServerRequestInterface $request): ResponseInterface
+	{
+		$httpInput  = new HTTPInputData($request->getServerParams());
+		$httpinput  = $httpInput->process();
+		$queryVars  = $request->getQueryParams();
+		$parsedBody = $request->getParsedBody();
+
+		$requestArray = array_merge(
+			$httpinput['variables'] ?? [],
+			$httpinput['files'] ?? [],
+			$queryVars,
+			is_array($parsedBody) ? $parsedBody : [],
+		);
+
+		return $this->run(DI::getDice()->create(ModuleHTTPException::class), $requestArray);
 	}
 
 	/**

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -222,9 +222,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 * @return void
 	 * @throws HTTPException
 	 */
-	protected function checkScope(): void
-	{
-	}
+	protected function checkScope(): void {}
 
 	/**
 	 * Dispatches the module CORS headers, events and method handling
@@ -323,7 +321,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 
 		$requestArray = array_merge(
 			$httpinput['variables'] ?? [],
-			$httpinput['files'] ?? [],
+			$httpinput['files']     ?? [],
 			$queryVars,
 			is_array($parsedBody) ? $parsedBody : [],
 		);

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -196,7 +196,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @deprecated Use {@see IRequestHandler::handleRequest()} instead
+	 * @deprecated 2026.08 Use {@see IRequestHandler::handleRequest()} instead
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
 	{

--- a/src/Capabilities/ICanHandleRequests.php
+++ b/src/Capabilities/ICanHandleRequests.php
@@ -24,7 +24,7 @@ interface ICanHandleRequests
 	 *
 	 * @throws HTTPException\InternalServerErrorException
 	 *
-	 * @deprecated Use {@see IRequestHandler::handleRequest()} instead
+	 * @deprecated 2026.08 Use {@see IRequestHandler::handleRequest()} instead
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface;
 }

--- a/src/Capabilities/ICanHandleRequests.php
+++ b/src/Capabilities/ICanHandleRequests.php
@@ -23,6 +23,8 @@ interface ICanHandleRequests
 	 * @return ResponseInterface responding to the request handling
 	 *
 	 * @throws HTTPException\InternalServerErrorException
+	 *
+	 * @deprecated Use {@see IRequestHandler::handleRequest()} instead
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface;
 }

--- a/src/Capabilities/IRequestHandler.php
+++ b/src/Capabilities/IRequestHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Capabilities;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+interface IRequestHandler
+{
+	public function handleRequest(ServerRequestInterface $request): ResponseInterface;
+}

--- a/src/Module/ActivityPub/Inbox.php
+++ b/src/Module/ActivityPub/Inbox.php
@@ -23,9 +23,7 @@ use Friendica\Util\Network;
  */
 class Inbox extends BaseApi
 {
-	protected function checkScope(): void
-	{
-	}
+	protected function checkScope(): void {}
 
 	protected function rawContent(array $request = [])
 	{

--- a/src/Module/ActivityPub/Inbox.php
+++ b/src/Module/ActivityPub/Inbox.php
@@ -23,6 +23,9 @@ use Friendica\Util\Network;
  */
 class Inbox extends BaseApi
 {
+	/**
+	 * @internal
+	 */
 	protected function checkScope(): void {}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/ActivityPub/Inbox.php
+++ b/src/Module/ActivityPub/Inbox.php
@@ -14,20 +14,17 @@ use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\User;
 use Friendica\Module\BaseApi;
-use Friendica\Module\Special\HTTPException;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Util\HTTPSignature;
 use Friendica\Util\Network;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * ActivityPub Inbox
  */
 class Inbox extends BaseApi
 {
-	public function run(HTTPException $httpException, array $request = [], bool $scopecheck = true): ResponseInterface
+	protected function checkScope(): void
 	{
-		return parent::run($httpException, $request, false);
 	}
 
 	protected function rawContent(array $request = [])

--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -18,6 +18,9 @@ use Friendica\Util\Network;
  */
 class Apps extends BaseApi
 {
+	/**
+	 * @internal
+	 */
 	protected function checkScope(): void {}
 
 	/**

--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -10,9 +10,7 @@ namespace Friendica\Module\Api\Mastodon;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Module\BaseApi;
-use Friendica\Module\Special\HTTPException;
 use Friendica\Util\Network;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * Apps class to register new OAuth clients
@@ -20,9 +18,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 class Apps extends BaseApi
 {
-	public function run(HTTPException $httpException, array $request = [], bool $scopecheck = true): ResponseInterface
+	protected function checkScope(): void
 	{
-		return parent::run($httpException, $request, false);
 	}
 
 	/**

--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -18,9 +18,7 @@ use Friendica\Util\Network;
  */
 class Apps extends BaseApi
 {
-	protected function checkScope(): void
-	{
-	}
+	protected function checkScope(): void {}
 
 	/**
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -81,6 +81,25 @@ class BaseApi extends BaseModule
 	}
 
 	/**
+	 * {@inheritDoc}
+	 */
+	protected function checkScope(): void
+	{
+		switch ($this->args->getMethod()) {
+			case Router::DELETE:
+			case Router::PATCH:
+			case Router::POST:
+			case Router::PUT:
+				$this->checkAllowedScope(self::SCOPE_WRITE);
+
+				if (!self::getCurrentUserID()) {
+					throw new HTTPException\ForbiddenException($this->t('Permission denied.'));
+				}
+				break;
+		}
+	}
+
+	/**
 	 * Additionally checks, if the caller is permitted to do this action
 	 *
 	 * {@inheritDoc}
@@ -90,18 +109,7 @@ class BaseApi extends BaseModule
 	public function run(ModuleHTTPException $httpException, array $request = [], bool $scopecheck = true): ResponseInterface
 	{
 		if ($scopecheck) {
-			switch ($this->args->getMethod()) {
-				case Router::DELETE:
-				case Router::PATCH:
-				case Router::POST:
-				case Router::PUT:
-					$this->checkAllowedScope(self::SCOPE_WRITE);
-
-					if (!self::getCurrentUserID()) {
-						throw new HTTPException\ForbiddenException($this->t('Permission denied.'));
-					}
-					break;
-			}
+			$this->checkScope();
 		}
 
 		return parent::run($httpException, $request);

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -104,14 +104,14 @@ class BaseApi extends BaseModule
 	 *
 	 * {@inheritDoc}
 	 *
+	 * @param bool $scopecheck Deprecated parameter kept for BC promise, scope is now checked via dispatch()
+	 *
 	 * @throws HTTPException\ForbiddenException
+	 *
+	 * @deprecated 2026.08 Use {@see IRequestHandler::handleRequest()} instead
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = [], bool $scopecheck = true): ResponseInterface
 	{
-		if ($scopecheck) {
-			$this->checkScope();
-		}
-
 		return parent::run($httpException, $request);
 	}
 

--- a/src/Module/OAuth/Acknowledge.php
+++ b/src/Module/OAuth/Acknowledge.php
@@ -16,6 +16,9 @@ use Friendica\Module\BaseApi;
  */
 class Acknowledge extends BaseApi
 {
+	/**
+	 * @internal
+	 */
 	protected function checkScope(): void {}
 
 	protected function post(array $request = [])

--- a/src/Module/OAuth/Acknowledge.php
+++ b/src/Module/OAuth/Acknowledge.php
@@ -16,9 +16,7 @@ use Friendica\Module\BaseApi;
  */
 class Acknowledge extends BaseApi
 {
-	protected function checkScope(): void
-	{
-	}
+	protected function checkScope(): void {}
 
 	protected function post(array $request = [])
 	{

--- a/src/Module/OAuth/Acknowledge.php
+++ b/src/Module/OAuth/Acknowledge.php
@@ -10,17 +10,14 @@ namespace Friendica\Module\OAuth;
 use Friendica\Core\Renderer;
 use Friendica\DI;
 use Friendica\Module\BaseApi;
-use Friendica\Module\Special\HTTPException;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * Acknowledgement of OAuth requests
  */
 class Acknowledge extends BaseApi
 {
-	public function run(HTTPException $httpException, array $request = [], bool $scopecheck = true): ResponseInterface
+	protected function checkScope(): void
 	{
-		return parent::run($httpException, $request, false);
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/OAuth/Revoke.php
+++ b/src/Module/OAuth/Revoke.php
@@ -15,9 +15,7 @@ use Friendica\Module\BaseApi;
  */
 class Revoke extends BaseApi
 {
-	protected function checkScope(): void
-	{
-	}
+	protected function checkScope(): void {}
 
 	protected function post(array $request = [])
 	{
@@ -28,7 +26,7 @@ class Revoke extends BaseApi
 		], $request);
 
 		$condition = ['client_id' => $request['client_id'], 'client_secret' => $request['client_secret'], 'access_token' => $request['token']];
-		$token = DBA::selectFirst('application-view', ['id'], $condition);
+		$token     = DBA::selectFirst('application-view', ['id'], $condition);
 		if (empty($token['id'])) {
 			$this->logger->notice('Token not found', $condition);
 			$this->logAndJsonError(401, $this->errorFactory->Unauthorized());

--- a/src/Module/OAuth/Revoke.php
+++ b/src/Module/OAuth/Revoke.php
@@ -9,17 +9,14 @@ namespace Friendica\Module\OAuth;
 
 use Friendica\Database\DBA;
 use Friendica\Module\BaseApi;
-use Friendica\Module\Special\HTTPException;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * @see https://docs.joinmastodon.org/spec/oauth/
  */
 class Revoke extends BaseApi
 {
-	public function run(HTTPException $httpException, array $request = [], bool $scopecheck = true): ResponseInterface
+	protected function checkScope(): void
 	{
-		return parent::run($httpException, $request, false);
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/OAuth/Revoke.php
+++ b/src/Module/OAuth/Revoke.php
@@ -15,6 +15,9 @@ use Friendica\Module\BaseApi;
  */
 class Revoke extends BaseApi
 {
+	/**
+	 * @internal
+	 */
 	protected function checkScope(): void {}
 
 	protected function post(array $request = [])

--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -19,6 +19,9 @@ use Friendica\Util\DateTimeFormat;
  */
 class Token extends BaseApi
 {
+	/**
+	 * @internal
+	 */
 	protected function checkScope(): void {}
 
 	protected function post(array $request = [])

--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -19,9 +19,7 @@ use Friendica\Util\DateTimeFormat;
  */
 class Token extends BaseApi
 {
-	protected function checkScope(): void
-	{
-	}
+	protected function checkScope(): void {}
 
 	protected function post(array $request = [])
 	{

--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -10,10 +10,8 @@ namespace Friendica\Module\OAuth;
 use Friendica\Database\DBA;
 use Friendica\Model\User;
 use Friendica\Module\BaseApi;
-use Friendica\Module\Special\HTTPException;
 use Friendica\Security\OAuth;
 use Friendica\Util\DateTimeFormat;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * @see https://docs.joinmastodon.org/methods/oauth/#token
@@ -21,9 +19,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 class Token extends BaseApi
 {
-	public function run(HTTPException $httpException, array $request = [], bool $scopecheck = true): ResponseInterface
+	protected function checkScope(): void
 	{
-		return parent::run($httpException, $request, false);
 	}
 
 	protected function post(array $request = [])


### PR DESCRIPTION
Replacement for #15914

This PR introduces PSR-7 `ServerRequestInterface` support to the module system, laying the groundwork for a gradual migration away from the legacy `$_SERVER`/`$_REQUEST` superglobals. The core dispatch logic has been extracted into a shared `dispatch()` method that both the old `run()` and new `handleRequest()` entry points use, ensuring consistent behavior regardless of which path a module runs through. Along the way, the scope-checking logic was lifted into a clean `checkScope()` hook, eliminating several fragile `run()` overrides. `run()` and `ICanHandleRequests` are now soft-deprecated — they remain fully functional for addon compatibility, but new modules should implement `IRequestHandler::handleRequest()` instead.

Next steps are to add `handleRequest()` test coverage alongside the existing `run()` tests, then move toward hard deprecation and eventual removal once the 5-month BC window closes.