### PR TITLE
fix: Cast limit to prevent parsing error (partially fixes #15817)

### DIFF
--- a/src/Worker/ExpirePosts.php
+++ b/src/Worker/ExpirePosts.php
@@ -189,7 +189,7 @@ class ExpirePosts
 	 */
 	private static function deleteUnusedItemUri()
 	{
-		$limit = DI::config()->get('system', 'dbclean-expire-limit');
+		$limit = (int) DI::config()->get('system', 'dbclean-expire-limit');
 		if (empty($limit)) {
 			return;
 		}
@@ -252,7 +252,7 @@ class ExpirePosts
 			  m3.`thr-parent-id` IS NULL
 			LIMIT ?',
 			$item['uri-id'],
-			(int) $limit,
+			$limit,
 		];
 		$pass = 0;
 		do {

--- a/src/Worker/ExpirePosts.php
+++ b/src/Worker/ExpirePosts.php
@@ -252,7 +252,7 @@ class ExpirePosts
 			  m3.`thr-parent-id` IS NULL
 			LIMIT ?',
 			$item['uri-id'],
-			$limit,
+			(int) $limit,
 		];
 		$pass = 0;
 		do {

--- a/src/Worker/ExpirePosts.php
+++ b/src/Worker/ExpirePosts.php
@@ -190,7 +190,7 @@ class ExpirePosts
 	private static function deleteUnusedItemUri()
 	{
 		$limit = (int) DI::config()->get('system', 'dbclean-expire-limit');
-		if (empty($limit)) {
+		if ($limit == 0) {
 			return;
 		}
 


### PR DESCRIPTION
As explained in https://github.com/friendica/friendica/issues/15817#issuecomment-4915965683 , the function `deleteUnusedItemUri` currently fails with the following error:

```
2026-07-27T21:43:52Z worker [ERROR]: DB Error {"code":1064,"error":"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''1000'' at line 1","params":"SELECT i.id FROM `item-uri` i LEFT JOIN `post-user` pu1 ON i.id = pu1.`uri-id` LEFT JOIN `post-user` pu2 ON i.id = pu2.`parent-uri-id` LEFT JOIN `post-user` pu3 ON i.id = pu3.`thr-parent-id` LEFT JOIN `post-user` pu4 ON i.id = pu4.`external-id` LEFT JOIN `post-user` pu5 ON i.id = pu5.`replies-id` LEFT JOIN `post-thread` pt1 ON i.id = pt1.`context-id` LEFT JOIN `post-thread` pt2 ON i.id = pt2.`conversation-id` LEFT JOIN `post-quote` pq ON i.id = pq.`quote-uri-id` LEFT JOIN `mail` m1 ON i.id = m1.`uri-id` LEFT JOIN `event` e ON i.id = e.`uri-id` LEFT JOIN `user-contact` uc ON i.id = uc.`uri-id` LEFT JOIN `contact` c ON i.id = c.`uri-id` LEFT JOIN `apcontact` ac ON i.id = ac.`uri-id` LEFT JOIN `diaspora-contact` dc ON i.id = dc.`uri-id` LEFT JOIN `inbox-status` ins ON i.id = ins.`uri-id` LEFT JOIN `post-delivery` pd1 ON i.id = pd1.`uri-id` LEFT JOIN `post-delivery` pd2 ON i.id = pd2.`inbox-id` LEFT JOIN `mail` m2 ON i.id = m2.`parent-uri-id` LEFT JOIN `mail` m3 ON i.id = m3.`thr-parent-id` WHERE i.id < 186651430 AND pu1.`uri-id` IS NULL AND pu2.`parent-uri-id` IS NULL AND pu3.`thr-parent-id` IS NULL AND pu4.`external-id` IS NULL AND pu5.`replies-id` IS NULL AND pt1.`context-id` IS NULL AND pt2.`conversation-id` IS NULL AND pq.`quote-uri-id` IS NULL AND m1.`uri-id` IS NULL AND e.`uri-id` IS NULL AND uc.`uri-id` IS NULL AND c.`uri-id` IS NULL AND ac.`uri-id` IS NULL AND dc.`uri-id` IS NULL AND ins.`uri-id` IS NULL AND pd1.`uri-id` IS NULL AND pd2.`inbox-id` IS NULL AND m2.`parent-uri-id` IS NULL AND m3.`thr-parent-id` IS NULL LIMIT '1000'","worker_id":"72971f1","worker_cmd":null} - {"file":"Database.php","line":603,"function":"p","request-id":"6a67cfeb6104d","stack":"DBA::p (154), ExpirePosts::deleteUnusedItemUri (260), Worker::execFunction (569), Worker::execute (377), Worker::processQueue (111), Worker::doExecute (87), Console::execute (86), Console::doExecute (172), Console::execute (86), App::processConsole (225)","uid":"85c2d2","process_id":156557}
```

This patch correctly forces the `$limit` variable to be parsed as an integer, correcting the error.
