### PR TITLE
Fix PageNotFound module

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -52,11 +52,11 @@ parameters:
             message: '#^Call to an undefined method Mockery[\\\\](?:ExpectationInterface(?:[|]Mockery[\\\\]HigherOrderMessage)?|LegacyMockInterface)::(?:with|once|times|twice|withAnyArgs|andReturnUsing|addRules)\(\)\.$#'
             identifier: method.notFound
             path: tests/
-            count: 236
+            count: 237
         # Deprecated run() calls in tests are preserved for BC promise and
         # will be replaced by handleRequest() tests in the future
         -
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 95
+            count: 96

--- a/src/Module/HTTPException/PageNotFound.php
+++ b/src/Module/HTTPException/PageNotFound.php
@@ -16,6 +16,7 @@ use Friendica\Module\Special\HTTPException as ModuleHTTPException;
 use Friendica\Network\HTTPException;
 use Friendica\Util\Profiler;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 
 class PageNotFound extends BaseModule
@@ -37,19 +38,32 @@ class PageNotFound extends BaseModule
 
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
 	{
-		// The URL provided does not resolve to a valid module.
-		$queryString = $this->server['QUERY_STRING'];
-		// Stupid browser tried to pre-fetch our JavaScript img template. Don't log the event or return anything - just quietly exit.
-		if (!empty($queryString) && preg_match('/{[0-9]}/', (string) $queryString) !== 0) {
+		$this->preProcessServerVars($this->server);
+
+		return parent::run($httpException, $request);
+	}
+
+	public function handleRequest(ServerRequestInterface $request): ResponseInterface
+	{
+		$this->preProcessServerVars($request->getServerParams());
+
+		return parent::handleRequest($request);
+	}
+
+	/**
+	 * Check for JS template prefetch and log the 404 request
+	 */
+	private function preProcessServerVars(array $server): void
+	{
+		$queryString = $server['QUERY_STRING'] ?? '';
+		if (!empty($queryString) && preg_match('/{[0-9]}/', $queryString) !== 0) {
 			System::exit();
 		}
 
 		$this->logger->debug('index.php: page not found.', [
-			'request_uri' => $this->server['REQUEST_URI'],
+			'request_uri' => $server['REQUEST_URI'] ?? '',
 			'address'     => $this->remoteAddress,
-			'query'       => $this->server['QUERY_STRING'],
+			'query'       => $server['QUERY_STRING'] ?? '',
 		]);
-
-		return parent::run($httpException, $request);
 	}
 }

--- a/src/Module/HTTPException/PageNotFound.php
+++ b/src/Module/HTTPException/PageNotFound.php
@@ -55,7 +55,9 @@ class PageNotFound extends BaseModule
 	 */
 	private function preProcessServerVars(array $server): void
 	{
+		// The URL provided does not resolve to a valid module.
 		$queryString = $server['QUERY_STRING'] ?? '';
+		// Stupid browser tried to pre-fetch our JavaScript img template. Don't log the event or return anything - just quietly exit.
 		if (!empty($queryString) && preg_match('/{[0-9]}/', (string) $queryString) !== 0) {
 			System::exit();
 		}

--- a/src/Module/HTTPException/PageNotFound.php
+++ b/src/Module/HTTPException/PageNotFound.php
@@ -56,7 +56,7 @@ class PageNotFound extends BaseModule
 	private function preProcessServerVars(array $server): void
 	{
 		$queryString = $server['QUERY_STRING'] ?? '';
-		if (!empty($queryString) && preg_match('/{[0-9]}/', $queryString) !== 0) {
+		if (!empty($queryString) && preg_match('/{[0-9]}/', (string) $queryString) !== 0) {
 			System::exit();
 		}
 

--- a/tests/src/Module/HTTPException/PageNotFoundTest.php
+++ b/tests/src/Module/HTTPException/PageNotFoundTest.php
@@ -1,0 +1,68 @@
+<?php
+
+// Copyright (C) 2010-2024, the Friendica project
+// SPDX-FileCopyrightText: 2010-2024 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Test\src\Module\HTTPException;
+
+use Friendica\App;
+use Friendica\DI;
+use Friendica\Module\HTTPException\PageNotFound;
+use Friendica\Module\Response;
+use Friendica\Module\Special\HTTPException as ModuleHTTPException;
+use Friendica\Network\HTTPException\NotFoundException;
+use Friendica\Test\FixtureTestCase;
+use Mockery;
+use Mockery\MockInterface;
+
+class PageNotFoundTest extends FixtureTestCase
+{
+	/** @var MockInterface|ModuleHTTPException */
+	protected $httpExceptionMock;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->httpExceptionMock = Mockery::mock(ModuleHTTPException::class);
+	}
+
+	public function testPageNotFoundReturnsResponseForUnknownUrl(): void
+	{
+		$server = [
+			'QUERY_STRING' => '',
+			'REQUEST_URI'  => '/unknown',
+		];
+
+		$this->httpExceptionMock->shouldReceive('content')
+			->once()
+			->with(Mockery::type(NotFoundException::class))
+			->andReturn('');
+
+		$request      = new App\Request(DI::config(), $server);
+		$pageNotFound = new PageNotFound(
+			DI::l10n(),
+			DI::baseUrl(),
+			DI::args(),
+			DI::logger(),
+			DI::profiler(),
+			new Response(),
+			$request,
+			$server
+		);
+
+		$response = $pageNotFound->run($this->httpExceptionMock);
+
+		self::assertEquals(404, $response->getStatusCode());
+	}
+
+	public function testJavaScriptTemplatePrefetchCallsExit(): void
+	{
+		self::markTestIncomplete(
+			'Skipping JavaScript template prefetch test because System::exit() cannot be ' .
+			'mocked with PHPUnit. See tests/src/Mod/ItemTest.php for prior art on this limitation.'
+		);
+	}
+}

--- a/tests/src/Module/HTTPException/PageNotFoundTest.php
+++ b/tests/src/Module/HTTPException/PageNotFoundTest.php
@@ -50,7 +50,7 @@ class PageNotFoundTest extends FixtureTestCase
 			DI::profiler(),
 			new Response(),
 			$request,
-			$server
+			$server,
 		);
 
 		$response = $pageNotFound->run($this->httpExceptionMock);
@@ -61,8 +61,8 @@ class PageNotFoundTest extends FixtureTestCase
 	public function testJavaScriptTemplatePrefetchCallsExit(): void
 	{
 		self::markTestIncomplete(
-			'Skipping JavaScript template prefetch test because System::exit() cannot be ' .
-			'mocked with PHPUnit. See tests/src/Mod/ItemTest.php for prior art on this limitation.'
+			'Skipping JavaScript template prefetch test because System::exit() cannot be '
+			. 'mocked with PHPUnit. See tests/src/Mod/ItemTest.php for prior art on this limitation.',
 		);
 	}
 }


### PR DESCRIPTION
In #16012 I missed to migrate the PageNotFound::run() method to handleRequest(). This PR fixes this.