### PR TITLE
Introduce `EarlyExitException` to make internal modules testable via `handleRequest()`

### DIFF
--- a/doc/en/developer/upgrade-2026.08.md
+++ b/doc/en/developer/upgrade-2026.08.md
@@ -241,7 +241,7 @@ This section contains deprecation notices. This changes will become mandatory in
    $uri = DI::postUriGenerator()->newURI($guid);
    ```
 
-- `BaseModule::httpExit()` is deprecated. Throw `\Friendica\Core\EarlyExitException` instead:
+- `BaseModule::httpExit()` is deprecated. Use `BaseModule::earlyHttpExit()` instead:
 
    *Before*
    ```php
@@ -250,11 +250,10 @@ This section contains deprecation notices. This changes will become mandatory in
 
    *After*
    ```php
-   $this->response->addContent($content);
-   throw new \Friendica\Core\EarlyExitException($this->response->generate());
+   $this->earlyHttpExit($content);
    ```
 
-- `BaseModule::jsonExit()` is deprecated. Throw `\Friendica\Core\EarlyExitException` instead:
+- `BaseModule::jsonExit()` is deprecated. Use `BaseModule::earlyJsonExit()` instead:
 
    *Before*
    ```php
@@ -263,12 +262,10 @@ This section contains deprecation notices. This changes will become mandatory in
 
    *After*
    ```php
-   $this->response->setType(ICanCreateResponses::TYPE_JSON, 'application/json; charset=utf-8');
-   $this->response->addContent(json_encode($data));
-   throw new \Friendica\Core\EarlyExitException($this->response->generate());
+   $this->earlyJsonExit($data);
    ```
 
-- `BaseModule::jsonError()` is deprecated. Throw `\Friendica\Core\EarlyExitException` instead:
+- `BaseModule::jsonError()` is deprecated. Use `BaseModule::earlyJsonError()` instead:
 
    *Before*
    ```php
@@ -277,13 +274,10 @@ This section contains deprecation notices. This changes will become mandatory in
 
    *After*
    ```php
-   $this->response->setStatus(404);
-   $this->response->setType(ICanCreateResponses::TYPE_JSON);
-   $this->response->addContent(json_encode(['error' => 'not found']));
-   throw new \Friendica\Core\EarlyExitException($this->response->generate());
+   $this->earlyJsonError(404, ['error' => 'not found']);
    ```
 
-- `BaseModule::httpError()` is deprecated. Throw `\Friendica\Core\EarlyExitException` instead:
+- `BaseModule::httpError()` is deprecated. Throw `BaseModule::earlyHttpError()` instead:
 
    *Before*
    ```php
@@ -292,6 +286,5 @@ This section contains deprecation notices. This changes will become mandatory in
 
    *After*
    ```php
-   $this->response->setStatus(403, 'Forbidden');
-   throw new \Friendica\Core\EarlyExitException($this->response->generate());
+   $this->earlyHttpError(403, 'Forbidden');
    ```

--- a/doc/en/developer/upgrade-2026.08.md
+++ b/doc/en/developer/upgrade-2026.08.md
@@ -241,3 +241,57 @@ This section contains deprecation notices. This changes will become mandatory in
    $uri = DI::postUriGenerator()->newURI($guid);
    ```
 
+- `BaseModule::httpExit()` is deprecated. Throw `\Friendica\Core\EarlyExitException` instead:
+
+   *Before*
+   ```php
+   $this->httpExit($content);
+   ```
+
+   *After*
+   ```php
+   $this->response->addContent($content);
+   throw new \Friendica\Core\EarlyExitException($this->response->generate());
+   ```
+
+- `BaseModule::jsonExit()` is deprecated. Throw `\Friendica\Core\EarlyExitException` instead:
+
+   *Before*
+   ```php
+   $this->jsonExit($data);
+   ```
+
+   *After*
+   ```php
+   $this->response->setType(ICanCreateResponses::TYPE_JSON, 'application/json; charset=utf-8');
+   $this->response->addContent(json_encode($data));
+   throw new \Friendica\Core\EarlyExitException($this->response->generate());
+   ```
+
+- `BaseModule::jsonError()` is deprecated. Throw `\Friendica\Core\EarlyExitException` instead:
+
+   *Before*
+   ```php
+   $this->jsonError(404, ['error' => 'not found']);
+   ```
+
+   *After*
+   ```php
+   $this->response->setStatus(404);
+   $this->response->setType(ICanCreateResponses::TYPE_JSON);
+   $this->response->addContent(json_encode(['error' => 'not found']));
+   throw new \Friendica\Core\EarlyExitException($this->response->generate());
+   ```
+
+- `BaseModule::httpError()` is deprecated. Throw `\Friendica\Core\EarlyExitException` instead:
+
+   *Before*
+   ```php
+   $this->httpError(403, 'Forbidden');
+   ```
+
+   *After*
+   ```php
+   $this->response->setStatus(403, 'Forbidden');
+   throw new \Friendica\Core\EarlyExitException($this->response->generate());
+   ```

--- a/src/App.php
+++ b/src/App.php
@@ -19,6 +19,7 @@ use Friendica\Capabilities\ICanHandleRequests;
 use Friendica\Capabilities\IRequestHandler;
 use Friendica\Content\Nav;
 use Friendica\Core\Addon\AddonHelper;
+use Friendica\Core\EarlyExitException;
 use Friendica\Core\Config\Factory\Config;
 use Friendica\Core\Container;
 use Friendica\Core\Hooks\HookEventBridge;
@@ -610,6 +611,9 @@ class App
 				$responseBuilder->setStatus($e->getCode(), $e->getMessage());
 				$responseBuilder->addContent($httpException->content($e));
 				$response = $responseBuilder->generate();
+			} catch (EarlyExitException $e) {
+				System::echoResponse($e->getResponse());
+				System::exit();
 			}
 			$this->profiler->set(microtime(true) - $timestamp, 'content');
 

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -555,6 +555,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 */
 	public function httpExit(string $content, string $type = Response::TYPE_HTML, ?string $content_type = null)
 	{
+		@trigger_error('Method `' . __METHOD__ . '` is deprecated since 2026.08, use `earlyExit()` instead.', E_USER_DEPRECATED);
 		$this->response->setType($type, $content_type);
 		$this->response->addContent($content);
 		System::echoResponse($this->response->generate());
@@ -574,6 +575,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 */
 	public function httpError(int $httpCode, string $message = '', $content = '')
 	{
+		@trigger_error('Method `' . __METHOD__ . '` is deprecated since 2026.08, use `earlyHttpError()` instead.', E_USER_DEPRECATED);
 		if ($httpCode >= 400) {
 			$this->logger->debug('Exit with error', ['code' => $httpCode, 'message' => $message, 'method' => $this->args->getMethod(), 'agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
 		}
@@ -597,6 +599,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 */
 	public function jsonExit($content, string $content_type = 'application/json; charset=utf-8', int $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)
 	{
+		@trigger_error('Method `' . __METHOD__ . '` is deprecated since 2026.08, use `earlyJsonExit()` instead.', E_USER_DEPRECATED);
 		$this->httpExit(json_encode($content, $options), ICanCreateResponses::TYPE_JSON, $content_type);
 	}
 
@@ -613,6 +616,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 */
 	public function jsonError(int $httpCode, $content, string $content_type = 'application/json')
 	{
+		@trigger_error('Method `' . __METHOD__ . '` is deprecated since 2026.08, use `earlyJsonError()` instead.', E_USER_DEPRECATED);
 		if ($httpCode >= 400) {
 			$this->logger->debug('Exit with error', ['code' => $httpCode, 'content_type' => $content_type, 'method' => $this->args->getMethod(), 'agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
 		}

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -545,7 +545,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 * This function adds the content and a content-type HTTP header to the output.
 	 * After finishing the process is getting killed.
 	 *
-	 * @deprecated 2026.08 Use {@see earlyExit()} instead
+	 * @deprecated 2026.08 Use {@see earlyHttpExit()} instead
 	 *
 	 * @param string      $content
 	 * @param string      $type
@@ -555,7 +555,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 */
 	public function httpExit(string $content, string $type = Response::TYPE_HTML, ?string $content_type = null)
 	{
-		@trigger_error('Method `' . __METHOD__ . '` is deprecated since 2026.08, use `earlyExit()` instead.', E_USER_DEPRECATED);
+		@trigger_error('Method `' . __METHOD__ . '` is deprecated since 2026.08, use `earlyHttpExit()` instead.', E_USER_DEPRECATED);
 		$this->response->setType($type, $content_type);
 		$this->response->addContent($content);
 		System::echoResponse($this->response->generate());
@@ -626,15 +626,12 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	}
 
 	/**
-	 * @internal
-	 *
-	 * Same as httpExit(), but throws EarlyExitException instead of calling System::exit().
-	 * Use this in new code to allow interception via handleRequest() in tests.
+	 * Send content and a content-type HTTP header to the output and exit.
 	 *
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws EarlyExitException
 	 */
-	protected function earlyExit(string $content, string $type = Response::TYPE_HTML, ?string $contentType = null): never
+	protected function earlyHttpExit(string $content, string $type = Response::TYPE_HTML, ?string $contentType = null): never
 	{
 		$this->response->setType($type, $contentType);
 		$this->response->addContent($content);
@@ -643,9 +640,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	}
 
 	/**
-	 * @internal
-	 *
-	 * Same as httpError(), but calls earlyExit() instead of httpExit().
+	 * Send HTTP status header and exit.
 	 *
 	 * @param integer $httpCode HTTP status result value
 	 * @param string  $message  Error message. Optional.
@@ -660,26 +655,22 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 		}
 
 		$this->response->setStatus($httpCode, $message);
-		$this->earlyExit($content);
+		$this->earlyHttpExit($content);
 	}
 
 	/**
-	 * @internal
-	 *
-	 * Same as jsonExit(), but calls earlyExit() instead of httpExit().
+	 * Display the response using JSON to encode the content.
 	 *
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws EarlyExitException
 	 */
 	protected function earlyJsonExit(mixed $content, string $contentType = 'application/json; charset=utf-8', int $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT): never
 	{
-		$this->earlyExit(json_encode($content, $options), ICanCreateResponses::TYPE_JSON, $contentType);
+		$this->earlyHttpExit(json_encode($content, $options), ICanCreateResponses::TYPE_JSON, $contentType);
 	}
 
 	/**
-	 * @internal
-	 *
-	 * Same as jsonError(), but calls earlyJsonExit() instead of jsonExit().
+	 * Display a non-200 HTTP code response using JSON to encode the content and exit.
 	 *
 	 * @throws HTTPException\InternalServerErrorException
 	 * @throws EarlyExitException

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -545,6 +545,8 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 * This function adds the content and a content-type HTTP header to the output.
 	 * After finishing the process is getting killed.
 	 *
+	 * @deprecated 2026.08 Use {@see earlyExit()} instead
+	 *
 	 * @param string      $content
 	 * @param string      $type
 	 * @param string|null $content_type
@@ -562,6 +564,8 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 
 	/**
 	 * Send HTTP status header and exit.
+	 *
+	 * @deprecated 2026.08 Use {@see earlyHttpError()} instead
 	 *
 	 * @param integer $httpCode HTTP status result value
 	 * @param string  $message  Error message. Optional.
@@ -582,6 +586,8 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	/**
 	 * Display the response using JSON to encode the content
 	 *
+	 * @deprecated 2026.08 Use {@see earlyJsonExit()} instead
+	 *
 	 * @param mixed  $content
 	 * @param string $content_type
 	 * @param int    $options A combination of json_encode() binary flags
@@ -596,6 +602,8 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 
 	/**
 	 * Display a non-200 HTTP code response using JSON to encode the content and exit
+	 *
+	 * @deprecated 2026.08 Use {@see earlyJsonError()} instead
 	 *
 	 * @param int    $httpCode
 	 * @param mixed  $content

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -201,7 +201,12 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 */
 	public function run(ModuleHTTPException $httpException, array $request = []): ResponseInterface
 	{
-		$this->dispatch($request, $httpException);
+		try {
+			$this->dispatch($request, $httpException);
+		} catch (EarlyExitException $e) {
+			System::echoResponse($e->getResponse());
+			System::exit();
+		}
 
 		return $this->response->generate();
 	}

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -633,6 +633,27 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	/**
 	 * @internal
 	 *
+	 * Same as httpError(), but calls earlyExit() instead of httpExit().
+	 *
+	 * @param integer $httpCode HTTP status result value
+	 * @param string  $message  Error message. Optional.
+	 * @param mixed   $content  Response body. Optional.
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws EarlyExitException
+	 */
+	protected function earlyHttpError(int $httpCode, string $message = '', mixed $content = ''): never
+	{
+		if ($httpCode >= 400) {
+			$this->logger->debug('Exit with error', ['code' => $httpCode, 'message' => $message, 'method' => $this->args->getMethod(), 'agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
+		}
+
+		$this->response->setStatus($httpCode, $message);
+		$this->earlyExit($content);
+	}
+
+	/**
+	 * @internal
+	 *
 	 * Same as jsonExit(), but calls earlyExit() instead of httpExit().
 	 *
 	 * @throws HTTPException\InternalServerErrorException

--- a/src/BaseModule.php
+++ b/src/BaseModule.php
@@ -11,6 +11,7 @@ use Friendica\App\Router;
 use Friendica\Capabilities\ICanHandleRequests;
 use Friendica\Capabilities\ICanCreateResponses;
 use Friendica\Capabilities\IRequestHandler;
+use Friendica\Core\EarlyExitException;
 use Friendica\Core\L10n;
 use Friendica\Core\System;
 use Friendica\Event\ModuleContentEvent;
@@ -221,6 +222,7 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 	 * @param ModuleHTTPException|null $httpException Optional exception renderer for the content phase
 	 * @return void
 	 * @throws HTTPException
+	 * @throws EarlyExitException
 	 */
 	final protected function dispatch(array $request, ?ModuleHTTPException $httpException = null): void
 	{
@@ -604,5 +606,53 @@ abstract class BaseModule implements ICanHandleRequests, IRequestHandler
 
 		$this->response->setStatus($httpCode);
 		$this->jsonExit($content, $content_type);
+	}
+
+	/**
+	 * @internal
+	 *
+	 * Same as httpExit(), but throws EarlyExitException instead of calling System::exit().
+	 * Use this in new code to allow interception via handleRequest() in tests.
+	 *
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws EarlyExitException
+	 */
+	protected function earlyExit(string $content, string $type = Response::TYPE_HTML, ?string $contentType = null): never
+	{
+		$this->response->setType($type, $contentType);
+		$this->response->addContent($content);
+
+		throw new EarlyExitException($this->response->generate());
+	}
+
+	/**
+	 * @internal
+	 *
+	 * Same as jsonExit(), but calls earlyExit() instead of httpExit().
+	 *
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws EarlyExitException
+	 */
+	protected function earlyJsonExit(mixed $content, string $contentType = 'application/json; charset=utf-8', int $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT): never
+	{
+		$this->earlyExit(json_encode($content, $options), ICanCreateResponses::TYPE_JSON, $contentType);
+	}
+
+	/**
+	 * @internal
+	 *
+	 * Same as jsonError(), but calls earlyJsonExit() instead of jsonExit().
+	 *
+	 * @throws HTTPException\InternalServerErrorException
+	 * @throws EarlyExitException
+	 */
+	protected function earlyJsonError(int $httpCode, mixed $content, string $contentType = 'application/json'): never
+	{
+		if ($httpCode >= 400) {
+			$this->logger->debug('Exit with error', ['code' => $httpCode, 'content_type' => $contentType, 'method' => $this->args->getMethod(), 'agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
+		}
+
+		$this->response->setStatus($httpCode);
+		$this->earlyJsonExit($content, $contentType);
 	}
 }

--- a/src/Core/EarlyExitException.php
+++ b/src/Core/EarlyExitException.php
@@ -1,0 +1,32 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Core;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @internal
+ *
+ * Carries a ResponseInterface out of the dispatch flow to be returned by handleRequest().
+ * Replaces System::exit() for early-terminating modules.
+ */
+class EarlyExitException extends \RuntimeException
+{
+	public function __construct(
+		private readonly ResponseInterface $response,
+	) {
+		parent::__construct('Module requested early exit');
+	}
+
+	public function getResponse(): ResponseInterface
+	{
+		return $this->response;
+	}
+}

--- a/src/Core/EarlyExitException.php
+++ b/src/Core/EarlyExitException.php
@@ -12,10 +12,12 @@ namespace Friendica\Core;
 use Psr\Http\Message\ResponseInterface;
 
 /**
+ * @internal
+ *
  * Carries a ResponseInterface out of the dispatch flow to be returned by handleRequest().
  * Replaces System::exit() for early-terminating modules.
  *
- * Addon modules can throw this exception to terminate request processing early
+ * Modules can throw this exception to terminate request processing early
  * and provide a response directly, instead of calling httpExit() or similar.
  * The exception is caught by App::runFrontend() and BaseModule::run().
  */

--- a/src/Core/EarlyExitException.php
+++ b/src/Core/EarlyExitException.php
@@ -12,10 +12,12 @@ namespace Friendica\Core;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * @internal
- *
  * Carries a ResponseInterface out of the dispatch flow to be returned by handleRequest().
  * Replaces System::exit() for early-terminating modules.
+ *
+ * Addon modules can throw this exception to terminate request processing early
+ * and provide a response directly, instead of calling httpExit() or similar.
+ * The exception is caught by App::runFrontend() and BaseModule::run().
  */
 class EarlyExitException extends \RuntimeException
 {

--- a/src/Module/AccountManagementControlDocument.php
+++ b/src/Module/AccountManagementControlDocument.php
@@ -64,6 +64,6 @@ class AccountManagementControlDocument extends BaseModule
 			],
 		];
 
-		$this->jsonExit($output);
+		$this->earlyJsonExit($output);
 	}
 }

--- a/src/Module/AccountManagementControlDocument.php
+++ b/src/Module/AccountManagementControlDocument.php
@@ -16,7 +16,7 @@ use Friendica\BaseModule;
  */
 class AccountManagementControlDocument extends BaseModule
 {
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$output = [
 			'version'       => 1,

--- a/src/Module/ActivityPub/Featured.php
+++ b/src/Module/ActivityPub/Featured.php
@@ -31,6 +31,6 @@ class Featured extends BaseModule
 
 		$featured = ActivityPub\Transmitter::getFeatured($owner, $page);
 
-		$this->jsonExit($featured, 'application/activity+json');
+		$this->earlyJsonExit($featured, 'application/activity+json');
 	}
 }

--- a/src/Module/ActivityPub/Followers.php
+++ b/src/Module/ActivityPub/Followers.php
@@ -34,6 +34,6 @@ class Followers extends BaseModule
 
 		$followers = ActivityPub\Transmitter::getContacts($owner, [Contact::FOLLOWER, Contact::FRIEND], 'followers', $page, (string) HTTPSignature::getSigner('', $_SERVER));
 
-		$this->jsonExit($followers, 'application/activity+json');
+		$this->earlyJsonExit($followers, 'application/activity+json');
 	}
 }

--- a/src/Module/ActivityPub/Following.php
+++ b/src/Module/ActivityPub/Following.php
@@ -32,6 +32,6 @@ class Following extends BaseModule
 
 		$following = ActivityPub\Transmitter::getContacts($owner, [Contact::SHARING, Contact::FRIEND], 'following', $page);
 
-		$this->jsonExit($following, 'application/activity+json');
+		$this->earlyJsonExit($following, 'application/activity+json');
 	}
 }

--- a/src/Module/ActivityPub/Inbox.php
+++ b/src/Module/ActivityPub/Inbox.php
@@ -54,7 +54,7 @@ class Inbox extends BaseApi
 		// Relaxed CORS header already authorized
 		header('Access-Control-Allow-Origin: *');
 
-		$this->jsonExit($inbox, 'application/activity+json');
+		$this->earlyJsonExit($inbox, 'application/activity+json');
 	}
 
 	protected function post(array $request = [])

--- a/src/Module/ActivityPub/Objects.php
+++ b/src/Module/ActivityPub/Objects.php
@@ -123,9 +123,9 @@ class Objects extends BaseModule
 		header('Access-Control-Allow-Origin: *');
 
 		if ($item['deleted']) {
-			$this->jsonError(410, $data, 'application/activity+json');
+			$this->earlyJsonError(410, $data, 'application/activity+json');
 		} else {
-			$this->jsonExit($data, 'application/activity+json');
+			$this->earlyJsonExit($data, 'application/activity+json');
 		}
 	}
 }

--- a/src/Module/ActivityPub/Outbox.php
+++ b/src/Module/ActivityPub/Outbox.php
@@ -21,7 +21,7 @@ class Outbox extends BaseApi
 	protected function rawContent(array $request = [])
 	{
 		if (empty($this->parameters['nickname'])) {
-			$this->jsonExit([], 'application/activity+json');
+			$this->earlyJsonExit([], 'application/activity+json');
 		}
 
 		$owner = User::getOwnerDataByNick($this->parameters['nickname']);
@@ -38,7 +38,7 @@ class Outbox extends BaseApi
 
 		$outbox = ActivityPub\ClientToServer::getOutbox($owner, $uid, $page, !empty($request['max_id']) ? (int) $request['max_id'] : null, HTTPSignature::getSigner('', $_SERVER));
 
-		$this->jsonExit($outbox, 'application/activity+json');
+		$this->earlyJsonExit($outbox, 'application/activity+json');
 	}
 
 	protected function post(array $request = [])
@@ -64,6 +64,6 @@ class Outbox extends BaseApi
 			throw new \Friendica\Network\HTTPException\BadRequestException();
 		}
 
-		$this->jsonExit(ActivityPub\ClientToServer::processActivity($activity, $uid, self::getCurrentApplication() ?? []));
+		$this->earlyJsonExit(ActivityPub\ClientToServer::processActivity($activity, $uid, self::getCurrentApplication() ?? []));
 	}
 }

--- a/src/Module/ActivityPub/QuoteAuthorization.php
+++ b/src/Module/ActivityPub/QuoteAuthorization.php
@@ -49,6 +49,6 @@ class QuoteAuthorization extends BaseModule
 
 		// Relaxed CORS header for public items
 		header('Access-Control-Allow-Origin: *');
-		$this->jsonExit($data, 'application/activity+json');
+		$this->earlyJsonExit($data, 'application/activity+json');
 	}
 }

--- a/src/Module/ActivityPub/Whoami.php
+++ b/src/Module/ActivityPub/Whoami.php
@@ -86,6 +86,6 @@ class Whoami extends BaseApi
 		];
 
 		$data['generator'] = ActivityPub\Transmitter::getService();
-		$this->jsonExit($data, 'application/activity+json');
+		$this->earlyJsonExit($data, 'application/activity+json');
 	}
 }

--- a/src/Module/Api/Friendica/Statuses/Dislike.php
+++ b/src/Module/Api/Friendica/Statuses/Dislike.php
@@ -34,6 +34,6 @@ class Dislike extends BaseApi
 
 		Item::performActivity($item['id'], 'dislike', $uid);
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Friendica/Statuses/DislikedBy.php
+++ b/src/Module/Api/Friendica/Statuses/DislikedBy.php
@@ -42,6 +42,6 @@ class DislikedBy extends BaseApi
 			$accounts[] = DI::mstdnAccount()->createFromContactId($activity['author-id'], $uid);
 		}
 
-		$this->jsonExit($accounts);
+		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Friendica/Statuses/Undislike.php
+++ b/src/Module/Api/Friendica/Statuses/Undislike.php
@@ -34,6 +34,6 @@ class Undislike extends BaseApi
 
 		Item::performActivity($item['id'], 'undislike', $uid);
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts.php
+++ b/src/Module/Api/Mastodon/Accounts.php
@@ -43,6 +43,6 @@ class Accounts extends BaseApi
 		}
 
 		$account = DI::mstdnAccount()->createFromContactId($id, $uid);
-		$this->jsonExit($account);
+		$this->earlyJsonExit($account);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Block.php
+++ b/src/Module/Api/Mastodon/Accounts/Block.php
@@ -27,6 +27,6 @@ class Block extends BaseApi
 
 		Contact\User::setBlocked($this->parameters['id'], $uid, true);
 
-		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->earlyJsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/FeaturedTags.php
+++ b/src/Module/Api/Mastodon/Accounts/FeaturedTags.php
@@ -17,7 +17,7 @@ class FeaturedTags extends BaseApi
 	/**
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$this->checkAllowedScope(self::SCOPE_READ);
 

--- a/src/Module/Api/Mastodon/Accounts/FeaturedTags.php
+++ b/src/Module/Api/Mastodon/Accounts/FeaturedTags.php
@@ -21,6 +21,6 @@ class FeaturedTags extends BaseApi
 	{
 		$this->checkAllowedScope(self::SCOPE_READ);
 
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Follow.php
+++ b/src/Module/Api/Mastodon/Accounts/Follow.php
@@ -39,6 +39,6 @@ class Follow extends BaseApi
 
 		Contact::update(['notify_new_posts' => $request['notify']], ['id' => $result['cid']]);
 
-		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($result['cid'], $uid)->toArray());
+		$this->earlyJsonExit(DI::mstdnRelationship()->createFromContactId($result['cid'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Followers.php
+++ b/src/Module/Api/Mastodon/Accounts/Followers.php
@@ -104,6 +104,6 @@ class Followers extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($accounts);
+		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Following.php
+++ b/src/Module/Api/Mastodon/Accounts/Following.php
@@ -104,6 +104,6 @@ class Following extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($accounts);
+		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
+++ b/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
@@ -21,6 +21,6 @@ class IdentityProofs extends BaseApi
 	{
 		$this->checkAllowedScope(self::SCOPE_READ);
 
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
+++ b/src/Module/Api/Mastodon/Accounts/IdentityProofs.php
@@ -17,7 +17,7 @@ class IdentityProofs extends BaseApi
 	/**
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$this->checkAllowedScope(self::SCOPE_READ);
 

--- a/src/Module/Api/Mastodon/Accounts/Lists.php
+++ b/src/Module/Api/Mastodon/Accounts/Lists.php
@@ -45,6 +45,6 @@ class Lists extends BaseApi
 			DBA::close($circles);
 		}
 
-		$this->jsonExit($lists);
+		$this->earlyJsonExit($lists);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Lookup.php
+++ b/src/Module/Api/Mastodon/Accounts/Lookup.php
@@ -37,6 +37,6 @@ class Lookup extends BaseApi
 			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
-		$this->jsonExit(DI::mstdnAccount()->createFromContactId($contact['id'], $uid));
+		$this->earlyJsonExit(DI::mstdnAccount()->createFromContactId($contact['id'], $uid));
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Mute.php
+++ b/src/Module/Api/Mastodon/Accounts/Mute.php
@@ -27,6 +27,6 @@ class Mute extends BaseApi
 
 		Contact\User::setIgnored($this->parameters['id'], $uid, true);
 
-		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->earlyJsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Note.php
+++ b/src/Module/Api/Mastodon/Accounts/Note.php
@@ -36,6 +36,6 @@ class Note extends BaseApi
 
 		Contact::update(['info' => $request['comment']], ['id' => $ucid]);
 
-		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->earlyJsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Relationships.php
+++ b/src/Module/Api/Mastodon/Accounts/Relationships.php
@@ -28,7 +28,7 @@ class Relationships extends BaseApi
 		], $request);
 
 		if (empty($request['id'])) {
-			$this->jsonExit([]);
+			$this->earlyJsonExit([]);
 		}
 
 		if (!is_array($request['id'])) {
@@ -41,6 +41,6 @@ class Relationships extends BaseApi
 			$relationships[] = DI::mstdnRelationship()->createFromContactId($id, $uid);
 		}
 
-		$this->jsonExit($relationships);
+		$this->earlyJsonExit($relationships);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Search.php
+++ b/src/Module/Api/Mastodon/Accounts/Search.php
@@ -50,6 +50,6 @@ class Search extends BaseApi
 			}
 		}
 
-		$this->jsonExit($accounts);
+		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Statuses.php
+++ b/src/Module/Api/Mastodon/Accounts/Statuses.php
@@ -113,6 +113,6 @@ class Statuses extends BaseApi
 		}
 
 		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
-		$this->jsonExit($statuses);
+		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Unblock.php
+++ b/src/Module/Api/Mastodon/Accounts/Unblock.php
@@ -27,6 +27,6 @@ class Unblock extends BaseApi
 
 		Contact\User::setBlocked($this->parameters['id'], $uid, false);
 
-		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->earlyJsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Unfollow.php
+++ b/src/Module/Api/Mastodon/Accounts/Unfollow.php
@@ -34,6 +34,6 @@ class Unfollow extends BaseApi
 
 		Contact::unfollow($contact);
 
-		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->earlyJsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Unmute.php
+++ b/src/Module/Api/Mastodon/Accounts/Unmute.php
@@ -27,6 +27,6 @@ class Unmute extends BaseApi
 
 		Contact\User::setIgnored($this->parameters['id'], $uid, false);
 
-		$this->jsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
+		$this->earlyJsonExit(DI::mstdnRelationship()->createFromContactId($this->parameters['id'], $uid)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
+++ b/src/Module/Api/Mastodon/Accounts/UpdateCredentials.php
@@ -91,6 +91,6 @@ class UpdateCredentials extends BaseApi
 		}
 
 		$account = DI::mstdnAccount()->createFromContactId($ucid, $uid);
-		$this->jsonExit($account->toArray());
+		$this->earlyJsonExit($account->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Admin/Accounts.php
+++ b/src/Module/Api/Mastodon/Admin/Accounts.php
@@ -128,7 +128,7 @@ class Accounts extends BaseApi
 				$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
-		$this->jsonExit($this->buildAdminAccountResponse($targetId, $localUserId));
+		$this->earlyJsonExit($this->buildAdminAccountResponse($targetId, $localUserId));
 	}
 
 	/**

--- a/src/Module/Api/Mastodon/Admin/Reports.php
+++ b/src/Module/Api/Mastodon/Admin/Reports.php
@@ -55,7 +55,7 @@ class Reports extends BaseApi
 
 		if (!empty($this->parameters['id'])) {
 			$report = $this->mstdnReportFactory->createFromReportEntity($this->reportRepository->selectOneById((int) $this->parameters['id']));
-			$this->jsonExit($report);
+			$this->earlyJsonExit($report);
 		}
 
 		$condition = [];
@@ -96,7 +96,7 @@ class Reports extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($reports);
+		$this->earlyJsonExit($reports);
 	}
 
 	/**
@@ -149,7 +149,7 @@ class Reports extends BaseApi
 			}
 		}
 
-		$this->jsonExit($this->mstdnReportFactory->createFromReportEntity($this->reportRepository->selectOneById((int) $this->parameters['id'])));
+		$this->earlyJsonExit($this->mstdnReportFactory->createFromReportEntity($this->reportRepository->selectOneById((int) $this->parameters['id'])));
 	}
 
 	/**
@@ -206,7 +206,7 @@ class Reports extends BaseApi
 				$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
-		$this->jsonExit($this->mstdnReportFactory->createFromReportEntity($this->reportRepository->selectOneById($reportId)));
+		$this->earlyJsonExit($this->mstdnReportFactory->createFromReportEntity($this->reportRepository->selectOneById($reportId)));
 	}
 
 	private function categoryToId(string $category): ?int

--- a/src/Module/Api/Mastodon/Announcements.php
+++ b/src/Module/Api/Mastodon/Announcements.php
@@ -22,6 +22,6 @@ class Announcements extends BaseApi
 		$this->checkAllowedScope(self::SCOPE_READ);
 
 		// @todo Possibly use the message from the pageheader addon for this
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Announcements.php
+++ b/src/Module/Api/Mastodon/Announcements.php
@@ -17,7 +17,7 @@ class Announcements extends BaseApi
 	/**
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$this->checkAllowedScope(self::SCOPE_READ);
 

--- a/src/Module/Api/Mastodon/Apps.php
+++ b/src/Module/Api/Mastodon/Apps.php
@@ -69,7 +69,7 @@ class Apps extends BaseApi
 		$application = DBA::selectFirst('application', ['id'], $fields);
 		if (!empty($application['id'])) {
 			$this->logger->debug('Found existing application', ['request' => $request, 'id' => $application['id']]);
-			$this->jsonExit(DI::mstdnApplication()->createFromApplicationId($application['id'])->toArray());
+			$this->earlyJsonExit(DI::mstdnApplication()->createFromApplicationId($application['id'])->toArray());
 		}
 
 		$fields['read']          = (stripos((string) $request['scopes'], self::SCOPE_READ) !== false);
@@ -84,6 +84,6 @@ class Apps extends BaseApi
 		}
 
 		$this->logger->debug('Create new application', ['request' => $request, 'id' => DBA::lastInsertId()]);
-		$this->jsonExit(DI::mstdnApplication()->createFromApplicationId(DBA::lastInsertId())->toArray());
+		$this->earlyJsonExit(DI::mstdnApplication()->createFromApplicationId(DBA::lastInsertId())->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
+++ b/src/Module/Api/Mastodon/Apps/VerifyCredentials.php
@@ -24,6 +24,6 @@ class VerifyCredentials extends BaseApi
 			$this->logAndJsonError(401, $this->errorFactory->Unauthorized());
 		}
 
-		$this->jsonExit(DI::mstdnApplication()->createFromApplicationId($application['id']));
+		$this->earlyJsonExit(DI::mstdnApplication()->createFromApplicationId($application['id']));
 	}
 }

--- a/src/Module/Api/Mastodon/Blocks.php
+++ b/src/Module/Api/Mastodon/Blocks.php
@@ -62,6 +62,6 @@ class Blocks extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($accounts);
+		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Bookmarks.php
+++ b/src/Module/Api/Mastodon/Bookmarks.php
@@ -70,6 +70,6 @@ class Bookmarks extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($statuses);
+		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Conversations.php
+++ b/src/Module/Api/Mastodon/Conversations.php
@@ -29,7 +29,7 @@ class Conversations extends BaseApi
 		DBA::delete('conv', ['id' => $this->parameters['id'], 'uid' => $uid]);
 		DBA::delete('mail', ['convid' => $this->parameters['id'], 'uid' => $uid]);
 
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 
 	/**
@@ -85,6 +85,6 @@ class Conversations extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($conversations);
+		$this->earlyJsonExit($conversations);
 	}
 }

--- a/src/Module/Api/Mastodon/Conversations/Read.php
+++ b/src/Module/Api/Mastodon/Conversations/Read.php
@@ -29,7 +29,7 @@ class Read extends BaseApi
 		DBA::update('mail', ['seen' => true], ['convid' => $this->parameters['id'], 'uid' => $uid]);
 
 		try {
-			$this->jsonExit(DI::mstdnConversation()->createFromConvId($this->parameters['id'])->toArray());
+			$this->earlyJsonExit(DI::mstdnConversation()->createFromConvId($this->parameters['id'])->toArray());
 		} catch (NotFoundException) {
 			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}

--- a/src/Module/Api/Mastodon/CustomEmojis.php
+++ b/src/Module/Api/Mastodon/CustomEmojis.php
@@ -26,6 +26,6 @@ class CustomEmojis extends BaseApi
 	{
 		$emojis = DI::mstdnEmoji()->createCollectionFromSmilies(Smilies::getList());
 
-		$this->jsonExit($emojis->getArrayCopy());
+		$this->earlyJsonExit($emojis->getArrayCopy());
 	}
 }

--- a/src/Module/Api/Mastodon/CustomEmojis.php
+++ b/src/Module/Api/Mastodon/CustomEmojis.php
@@ -22,7 +22,7 @@ class CustomEmojis extends BaseApi
 	 * @throws \ImagickException
 	 * @see https://docs.joinmastodon.org/methods/accounts/follow_requests#pending-follows
 	 */
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$emojis = DI::mstdnEmoji()->createCollectionFromSmilies(Smilies::getList());
 

--- a/src/Module/Api/Mastodon/Directory.php
+++ b/src/Module/Api/Mastodon/Directory.php
@@ -54,6 +54,6 @@ class Directory extends BaseApi
 		}
 		DBA::close($contacts);
 
-		$this->jsonExit($accounts);
+		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Endorsements.php
+++ b/src/Module/Api/Mastodon/Endorsements.php
@@ -19,6 +19,6 @@ class Endorsements extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Endorsements.php
+++ b/src/Module/Api/Mastodon/Endorsements.php
@@ -17,7 +17,7 @@ class Endorsements extends BaseApi
 	/**
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$this->earlyJsonExit([]);
 	}

--- a/src/Module/Api/Mastodon/Favourited.php
+++ b/src/Module/Api/Mastodon/Favourited.php
@@ -72,6 +72,6 @@ class Favourited extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($statuses);
+		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Filters.php
+++ b/src/Module/Api/Mastodon/Filters.php
@@ -25,7 +25,7 @@ class Filters extends BaseApi
 	/**
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$this->checkAllowedScope(self::SCOPE_READ);
 

--- a/src/Module/Api/Mastodon/Filters.php
+++ b/src/Module/Api/Mastodon/Filters.php
@@ -29,6 +29,6 @@ class Filters extends BaseApi
 	{
 		$this->checkAllowedScope(self::SCOPE_READ);
 
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/FollowRequests.php
+++ b/src/Module/Api/Mastodon/FollowRequests.php
@@ -64,7 +64,7 @@ class FollowRequests extends BaseApi
 				throw new HTTPException\BadRequestException('Unexpected action parameter, expecting "authorize", "ignore" or "reject"');
 		}
 
-		$this->jsonExit($relationship);
+		$this->earlyJsonExit($relationship);
 	}
 
 	/**
@@ -100,6 +100,6 @@ class FollowRequests extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Api/Mastodon/FollowedTags.php
+++ b/src/Module/Api/Mastodon/FollowedTags.php
@@ -62,6 +62,6 @@ class FollowedTags extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Api/Mastodon/Instance.php
+++ b/src/Module/Api/Mastodon/Instance.php
@@ -49,7 +49,7 @@ class Instance extends BaseApi
 			$contact_account = $this->accountFactory->createFromUriId($adminContact['uri-id']);
 		}
 
-		$this->jsonExit(new InstanceEntity($this->config, $this->baseUrl, $this->database, $this->buildConfigurationInfo(), $contact_account ?? null, System::getRules()));
+		$this->earlyJsonExit(new InstanceEntity($this->config, $this->baseUrl, $this->database, $this->buildConfigurationInfo(), $contact_account ?? null, System::getRules()));
 	}
 
 	private function buildConfigurationInfo(): InstanceV2Entity\Configuration

--- a/src/Module/Api/Mastodon/Instance/ExtendedDescription.php
+++ b/src/Module/Api/Mastodon/Instance/ExtendedDescription.php
@@ -38,6 +38,6 @@ class ExtendedDescription extends BaseApi
 	{
 		$account = User::getSystemAccount();
 
-		$this->jsonExit(new Mastodon\ExtendedDescription(new DateTime($account['updated']), $this->config->get('config', 'info')));
+		$this->earlyJsonExit(new Mastodon\ExtendedDescription(new DateTime($account['updated']), $this->config->get('config', 'info')));
 	}
 }

--- a/src/Module/Api/Mastodon/Instance/ExtendedDescription.php
+++ b/src/Module/Api/Mastodon/Instance/ExtendedDescription.php
@@ -34,7 +34,7 @@ class ExtendedDescription extends BaseApi
 	/**
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$account = User::getSystemAccount();
 

--- a/src/Module/Api/Mastodon/Instance/Peers.php
+++ b/src/Module/Api/Mastodon/Instance/Peers.php
@@ -37,6 +37,6 @@ class Peers extends BaseApi
 		}
 		DBA::close($instances);
 
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Api/Mastodon/Instance/Rules.php
+++ b/src/Module/Api/Mastodon/Instance/Rules.php
@@ -19,7 +19,7 @@ class Rules extends BaseApi
 	/**
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$this->earlyJsonExit(System::getRules());
 	}

--- a/src/Module/Api/Mastodon/Instance/Rules.php
+++ b/src/Module/Api/Mastodon/Instance/Rules.php
@@ -21,6 +21,6 @@ class Rules extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		$this->jsonExit(System::getRules());
+		$this->earlyJsonExit(System::getRules());
 	}
 }

--- a/src/Module/Api/Mastodon/InstanceV2.php
+++ b/src/Module/Api/Mastodon/InstanceV2.php
@@ -61,7 +61,7 @@ class InstanceV2 extends BaseApi
 	 * @throws \ImagickException
 	 * @throws Exception
 	 */
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$domain               = $this->baseUrl->getHost();
 		$title                = $this->config->get('config', 'sitename');

--- a/src/Module/Api/Mastodon/InstanceV2.php
+++ b/src/Module/Api/Mastodon/InstanceV2.php
@@ -76,7 +76,7 @@ class InstanceV2 extends BaseApi
 		$contact              = $this->buildContactInfo();
 		$friendica_extensions = $this->buildFriendicaExtensionInfo();
 		$rules                = System::getRules();
-		$this->jsonExit(new InstanceEntity(
+		$this->earlyJsonExit(new InstanceEntity(
 			$domain,
 			$title,
 			$version,

--- a/src/Module/Api/Mastodon/Lists.php
+++ b/src/Module/Api/Mastodon/Lists.php
@@ -56,7 +56,7 @@ class Lists extends BaseApi
 			$this->logAndJsonError(500, $this->errorFactory->InternalError());
 		}
 
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 
 	protected function post(array $request = [])
@@ -79,7 +79,7 @@ class Lists extends BaseApi
 			$this->logAndJsonError(500, $this->errorFactory->InternalError());
 		}
 
-		$this->jsonExit(DI::mstdnList()->createFromCircleId($id));
+		$this->earlyJsonExit(DI::mstdnList()->createFromCircleId($id));
 	}
 
 	public function put(array $request = [])
@@ -137,6 +137,6 @@ class Lists extends BaseApi
 			$lists = DI::mstdnList()->createFromCircleId($id);
 		}
 
-		$this->jsonExit($lists);
+		$this->earlyJsonExit($lists);
 	}
 }

--- a/src/Module/Api/Mastodon/Lists/Accounts.php
+++ b/src/Module/Api/Mastodon/Lists/Accounts.php
@@ -112,6 +112,6 @@ class Accounts extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($accounts);
+		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Markers.php
+++ b/src/Module/Api/Mastodon/Markers.php
@@ -51,7 +51,7 @@ class Markers extends BaseApi
 	/**
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	protected function get(array $request = [])
+	protected function get(array $request = []): never
 	{
 		$this->checkAllowedScope(self::SCOPE_READ);
 		$uid         = self::getCurrentUserID();

--- a/src/Module/Api/Mastodon/Markers.php
+++ b/src/Module/Api/Mastodon/Markers.php
@@ -45,7 +45,7 @@ class Markers extends BaseApi
 
 		$fields = ['last_read_id' => $last_read_id, 'version' => $version, 'updated_at' => DateTimeFormat::utcNow()];
 		DBA::update('application-marker', $fields, $condition, true);
-		$this->jsonExit($this->fetchTimelines($application['id'], $uid));
+		$this->earlyJsonExit($this->fetchTimelines($application['id'], $uid));
 	}
 
 	/**
@@ -57,7 +57,7 @@ class Markers extends BaseApi
 		$uid         = self::getCurrentUserID();
 		$application = self::getCurrentApplication();
 
-		$this->jsonExit($this->fetchTimelines($application['id'], $uid));
+		$this->earlyJsonExit($this->fetchTimelines($application['id'], $uid));
 	}
 
 	private function fetchTimelines(int $application_id, int $uid): \stdClass

--- a/src/Module/Api/Mastodon/Media.php
+++ b/src/Module/Api/Mastodon/Media.php
@@ -51,7 +51,7 @@ class Media extends BaseApi
 			}
 
 			$this->logger->info('Uploaded photo', ['media' => $media]);
-			$this->jsonExit(DI::mstdnAttachment()->createFromPhoto($media['id']));
+			$this->earlyJsonExit(DI::mstdnAttachment()->createFromPhoto($media['id']));
 		}
 
 		$tempFileName = $request['file']['tmp_name'];
@@ -74,7 +74,7 @@ class Media extends BaseApi
 		$id = Attach::storeFile($tempFileName, self::getCurrentUserID(), $fileName, $request['file']['type'], '<' . Contact::getPublicIdByUserId(self::getCurrentUserID()) . '>');
 		@unlink($tempFileName);
 		$this->logger->info('Uploaded media', ['id' => $id]);
-		$this->jsonExit(DI::mstdnAttachment()->createFromAttach($id));
+		$this->earlyJsonExit(DI::mstdnAttachment()->createFromAttach($id));
 	}
 
 	public function put(array $request = [])
@@ -94,7 +94,7 @@ class Media extends BaseApi
 		}
 
 		if (DI::mstdnAttachment()->isAttach($this->parameters['id']) && Attach::exists(['id' => substr((string) $this->parameters['id'], 7)])) {
-			$this->jsonExit(DI::mstdnAttachment()->createFromAttach((int) substr((string) $this->parameters['id'], 7)));
+			$this->earlyJsonExit(DI::mstdnAttachment()->createFromAttach(substr((string) $this->parameters['id'], 7)));
 		}
 
 		$photo = Photo::selectFirst(['resource-id'], ['id' => $this->parameters['id'], 'uid' => $uid]);
@@ -117,12 +117,12 @@ class Media extends BaseApi
 				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
 
-			$this->jsonExit($attachment);
+			$this->earlyJsonExit($attachment);
 		}
 
 		Photo::update(['desc' => $request['description']], ['resource-id' => $photo['resource-id']]);
 
-		$this->jsonExit(DI::mstdnAttachment()->createFromPhoto($this->parameters['id']));
+		$this->earlyJsonExit(DI::mstdnAttachment()->createFromPhoto($this->parameters['id']));
 	}
 
 	/**
@@ -140,11 +140,11 @@ class Media extends BaseApi
 		$id = $this->parameters['id'];
 
 		if (Photo::exists(['id' => $id, 'uid' => $uid])) {
-			$this->jsonExit(DI::mstdnAttachment()->createFromPhoto($id));
+			$this->earlyJsonExit(DI::mstdnAttachment()->createFromPhoto($id));
 		}
 
 		if (DI::mstdnAttachment()->isAttach($id) && Attach::exists(['id' => substr((string) $id, 7)])) {
-			$this->jsonExit(DI::mstdnAttachment()->createFromAttach((int) substr((string) $id, 7)));
+			$this->earlyJsonExit(DI::mstdnAttachment()->createFromAttach(substr((string) $id, 7)));
 		}
 
 		$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());

--- a/src/Module/Api/Mastodon/Media.php
+++ b/src/Module/Api/Mastodon/Media.php
@@ -94,7 +94,7 @@ class Media extends BaseApi
 		}
 
 		if (DI::mstdnAttachment()->isAttach($this->parameters['id']) && Attach::exists(['id' => substr((string) $this->parameters['id'], 7)])) {
-			$this->earlyJsonExit(DI::mstdnAttachment()->createFromAttach(substr((string) $this->parameters['id'], 7)));
+			$this->earlyJsonExit(DI::mstdnAttachment()->createFromAttach((int) substr((string) $this->parameters['id'], 7)));
 		}
 
 		$photo = Photo::selectFirst(['resource-id'], ['id' => $this->parameters['id'], 'uid' => $uid]);
@@ -144,7 +144,7 @@ class Media extends BaseApi
 		}
 
 		if (DI::mstdnAttachment()->isAttach($id) && Attach::exists(['id' => substr((string) $id, 7)])) {
-			$this->earlyJsonExit(DI::mstdnAttachment()->createFromAttach(substr((string) $id, 7)));
+			$this->earlyJsonExit(DI::mstdnAttachment()->createFromAttach((int) substr((string) $id, 7)));
 		}
 
 		$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());

--- a/src/Module/Api/Mastodon/Mutes.php
+++ b/src/Module/Api/Mastodon/Mutes.php
@@ -62,6 +62,6 @@ class Mutes extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($accounts);
+		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -33,7 +33,7 @@ class Notifications extends BaseApi
 			$id = $this->parameters['id'];
 			try {
 				$notification = DI::notification()->selectOneForUser($uid, ['id' => $id]);
-				$this->jsonExit(DI::mstdnNotification()->createFromNotification($notification));
+				$this->earlyJsonExit(DI::mstdnNotification()->createFromNotification($notification));
 			} catch (\Exception) {
 				$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 			}
@@ -117,7 +117,7 @@ class Notifications extends BaseApi
 
 		if ($request['summary']) {
 			$count = DI::notification()->countForUser($uid, $condition);
-			$this->jsonExit(['count' => $count]);
+			$this->earlyJsonExit(['count' => $count]);
 		} else {
 			$mstdnNotifications = [];
 
@@ -139,7 +139,7 @@ class Notifications extends BaseApi
 			}
 
 			self::setLinkHeader();
-			$this->jsonExit($mstdnNotifications);
+			$this->earlyJsonExit($mstdnNotifications);
 		}
 	}
 }

--- a/src/Module/Api/Mastodon/Notifications/Clear.php
+++ b/src/Module/Api/Mastodon/Notifications/Clear.php
@@ -15,7 +15,7 @@ use Friendica\Module\BaseApi;
  */
 class Clear extends BaseApi
 {
-	protected function post(array $request = [])
+	protected function post(array $request = []): never
 	{
 		$this->checkAllowedScope(self::SCOPE_WRITE);
 		$uid = self::getCurrentUserID();

--- a/src/Module/Api/Mastodon/Notifications/Clear.php
+++ b/src/Module/Api/Mastodon/Notifications/Clear.php
@@ -22,6 +22,6 @@ class Clear extends BaseApi
 
 		DI::notification()->setAllDismissedForUser($uid);
 
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Notifications/Dismiss.php
+++ b/src/Module/Api/Mastodon/Notifications/Dismiss.php
@@ -29,6 +29,6 @@ class Dismiss extends BaseApi
 		$Notification->setDismissed();
 		DI::notification()->save($Notification);
 
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/Polls.php
+++ b/src/Module/Api/Mastodon/Polls.php
@@ -27,6 +27,6 @@ class Polls extends BaseApi
 			$this->logAndJsonError(422, $this->errorFactory->UnprocessableEntity());
 		}
 
-		$this->jsonExit(DI::mstdnPoll()->createFromId($this->parameters['id'], $uid));
+		$this->earlyJsonExit(DI::mstdnPoll()->createFromId($this->parameters['id'], $uid));
 	}
 }

--- a/src/Module/Api/Mastodon/Preferences.php
+++ b/src/Module/Api/Mastodon/Preferences.php
@@ -40,6 +40,6 @@ class Preferences extends BaseApi
 
 		$preferences = new \Friendica\Object\Api\Mastodon\Preferences($visibility, $sensitive, $language, $media, $spoilers);
 
-		$this->jsonExit($preferences);
+		$this->earlyJsonExit($preferences);
 	}
 }

--- a/src/Module/Api/Mastodon/Proofs.php
+++ b/src/Module/Api/Mastodon/Proofs.php
@@ -17,7 +17,7 @@ class Proofs extends BaseApi
 	/**
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$this->earlyJsonError(404, ['error' => 'Record not found']);
 	}

--- a/src/Module/Api/Mastodon/Proofs.php
+++ b/src/Module/Api/Mastodon/Proofs.php
@@ -19,6 +19,6 @@ class Proofs extends BaseApi
 	 */
 	protected function rawContent(array $request = [])
 	{
-		$this->jsonError(404, ['error' => 'Record not found']);
+		$this->earlyJsonError(404, ['error' => 'Record not found']);
 	}
 }

--- a/src/Module/Api/Mastodon/PushSubscription.php
+++ b/src/Module/Api/Mastodon/PushSubscription.php
@@ -66,7 +66,7 @@ class PushSubscription extends BaseApi
 		$this->logger->info('Subscription stored', ['ret' => $ret, 'subscription' => $subscription]);
 
 		$subscriptionObj = $this->subscriptionFac->createForApplicationIdAndUserId($application['id'], $uid);
-		$this->jsonExit($subscriptionObj->toArray());
+		$this->earlyJsonExit($subscriptionObj->toArray());
 	}
 
 	public function put(array $request = []): void
@@ -105,7 +105,7 @@ class PushSubscription extends BaseApi
 		]);
 
 		$subscriptionObj = $this->subscriptionFac->createForApplicationIdAndUserId($application['id'], $uid);
-		$this->jsonExit($subscriptionObj->toArray());
+		$this->earlyJsonExit($subscriptionObj->toArray());
 	}
 
 	private function setBoolean($input): bool
@@ -130,7 +130,7 @@ class PushSubscription extends BaseApi
 			'uid'            => $uid,
 		]);
 
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 
 	protected function get(array $request = []): void

--- a/src/Module/Api/Mastodon/Reports.php
+++ b/src/Module/Api/Mastodon/Reports.php
@@ -67,6 +67,6 @@ class Reports extends BaseApi
 			Worker::add(Worker::PRIORITY_LOW, 'ForwardReport', (int) $report->id);
 		}
 
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 }

--- a/src/Module/Api/Mastodon/ScheduledStatuses.php
+++ b/src/Module/Api/Mastodon/ScheduledStatuses.php
@@ -41,7 +41,7 @@ class ScheduledStatuses extends BaseApi
 
 		Post\Delayed::deleteById($this->parameters['id']);
 
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 
 	/**
@@ -53,7 +53,7 @@ class ScheduledStatuses extends BaseApi
 		$uid = self::getCurrentUserID();
 
 		if (isset($this->parameters['id'])) {
-			$this->jsonExit(DI::mstdnScheduledStatus()->createFromDelayedPostId($this->parameters['id'], $uid)->toArray());
+			$this->earlyJsonExit(DI::mstdnScheduledStatus()->createFromDelayedPostId($this->parameters['id'], $uid)->toArray());
 		}
 
 		$request = $this->getRequest([
@@ -94,6 +94,6 @@ class ScheduledStatuses extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($statuses);
+		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -81,7 +81,7 @@ class Search extends BaseApi
 			$result['hashtags'] = $this->searchHashtags($request['q'], $request['exclude_unreviewed'], $limit, $request['offset'], $this->parameters['version']);
 		}
 
-		$this->jsonExit($result);
+		$this->earlyJsonExit($result);
 	}
 
 	/**
@@ -108,7 +108,7 @@ class Search extends BaseApi
 			$item_id = Item::fetchByLink($q, $uid) ?: Item::fetchByLink($q);
 			if ($item_id && $item = Post::selectFirst(['uri-id'], ['id' => $item_id])) {
 				$result['statuses'] = [DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid)];
-				$this->jsonExit($result);
+				$this->earlyJsonExit($result);
 			}
 		}
 
@@ -116,12 +116,12 @@ class Search extends BaseApi
 			$id = Contact::getIdForURL($q, 0, false);
 			if ($id) {
 				$result['accounts'] = [DI::mstdnAccount()->createFromContactId($id, $uid)];
-				$this->jsonExit($result);
+				$this->earlyJsonExit($result);
 			}
 		}
 
 		if (in_array($data['type'], [PostMedia::TYPE_HTML, PostMedia::TYPE_TEXT, PostMedia::TYPE_ACCOUNT, PostMedia::TYPE_ACTIVITY, PostMedia::TYPE_UNKNOWN])) {
-			$this->jsonExit($result);
+			$this->earlyJsonExit($result);
 		}
 	}
 

--- a/src/Module/Api/Mastodon/Statuses.php
+++ b/src/Module/Api/Mastodon/Statuses.php
@@ -199,7 +199,7 @@ class Statuses extends BaseApi
 
 		Item::updateDisplayCache($post['uri-id']);
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($post['uri-id'], $uid));
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($post['uri-id'], $uid));
 	}
 
 	protected function post(array $request = [])
@@ -369,7 +369,7 @@ class Statuses extends BaseApi
 				DI::contentItem()->setAutomaticScheduledAt($uid, $scheduled_at);
 			}
 
-			$this->jsonExit(DI::mstdnScheduledStatus()->createFromDelayedPostId($id, $uid)->toArray());
+			$this->earlyJsonExit(DI::mstdnScheduledStatus()->createFromDelayedPostId($id, $uid)->toArray());
 		} elseif (!empty($request['scheduled_at'])) {
 			$item['created'] = $scheduled_at;
 		}
@@ -378,7 +378,7 @@ class Statuses extends BaseApi
 		if (!empty($id)) {
 			$item = Post::selectFirst(['uri-id'], ['id' => $id]);
 			if (!empty($item['uri-id'])) {
-				$this->jsonExit(DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid));
+				$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($item['uri-id'], $uid));
 			}
 		}
 
@@ -403,7 +403,7 @@ class Statuses extends BaseApi
 			$this->logAndJsonError(404, $this->errorFactory->RecordNotFound());
 		}
 
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 
 	/**
@@ -430,7 +430,7 @@ class Statuses extends BaseApi
 			$this->item->setViewed($this->parameters['id'], $uid);
 		}
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, false));
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, false));
 	}
 
 	private function getApp(): string

--- a/src/Module/Api/Mastodon/Statuses/Bookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Bookmark.php
@@ -55,6 +55,6 @@ class Bookmark extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Card.php
+++ b/src/Module/Api/Mastodon/Statuses/Card.php
@@ -34,6 +34,6 @@ class Card extends BaseApi
 
 		$card = DI::mstdnCard()->createFromUriId($post['uri-id']);
 
-		$this->jsonExit($card->toArray());
+		$this->earlyJsonExit($card->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -131,7 +131,7 @@ class Context extends BaseApi
 			}
 		}
 
-		$this->jsonExit($statuses);
+		$this->earlyJsonExit($statuses);
 	}
 
 	private static function getParents(int $id, array $parents, array $list = [])

--- a/src/Module/Api/Mastodon/Statuses/Favourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Favourite.php
@@ -39,6 +39,6 @@ class Favourite extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/FavouritedBy.php
@@ -41,6 +41,6 @@ class FavouritedBy extends BaseApi
 			$accounts[] = DI::mstdnAccount()->createFromContactId($activity['author-id'], $uid);
 		}
 
-		$this->jsonExit($accounts);
+		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Mute.php
+++ b/src/Module/Api/Mastodon/Statuses/Mute.php
@@ -43,6 +43,6 @@ class Mute extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Pin.php
+++ b/src/Module/Api/Mastodon/Statuses/Pin.php
@@ -38,6 +38,6 @@ class Pin extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Reblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Reblog.php
@@ -51,6 +51,6 @@ class Reblog extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
+++ b/src/Module/Api/Mastodon/Statuses/RebloggedBy.php
@@ -41,6 +41,6 @@ class RebloggedBy extends BaseApi
 			$accounts[] = DI::mstdnAccount()->createFromContactId($activity['author-id'], $uid);
 		}
 
-		$this->jsonExit($accounts);
+		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Source.php
+++ b/src/Module/Api/Mastodon/Statuses/Source.php
@@ -37,6 +37,6 @@ class Source extends BaseApi
 
 		$source = DI::mstdnStatusSource()->createFromUriId($id, $uid);
 
-		$this->jsonExit($source->toArray());
+		$this->earlyJsonExit($source->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unbookmark.php
+++ b/src/Module/Api/Mastodon/Statuses/Unbookmark.php
@@ -55,6 +55,6 @@ class Unbookmark extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unfavourite.php
+++ b/src/Module/Api/Mastodon/Statuses/Unfavourite.php
@@ -39,6 +39,6 @@ class Unfavourite extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unmute.php
+++ b/src/Module/Api/Mastodon/Statuses/Unmute.php
@@ -43,6 +43,6 @@ class Unmute extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unpin.php
+++ b/src/Module/Api/Mastodon/Statuses/Unpin.php
@@ -38,6 +38,6 @@ class Unpin extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Statuses/Unreblog.php
+++ b/src/Module/Api/Mastodon/Statuses/Unreblog.php
@@ -57,6 +57,6 @@ class Unreblog extends BaseApi
 		// Issue tracking the behavior of createFromUriId: https://github.com/friendica/friendica/issues/13350
 		$isReblog = $item['uri-id'] != $this->parameters['id'];
 
-		$this->jsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
+		$this->earlyJsonExit(DI::mstdnStatus()->createFromUriId($this->parameters['id'], $uid, $isReblog)->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Suggestions.php
+++ b/src/Module/Api/Mastodon/Suggestions.php
@@ -39,6 +39,6 @@ class Suggestions extends BaseApi
 			];
 		}
 
-		$this->jsonExit($accounts);
+		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Tags.php
+++ b/src/Module/Api/Mastodon/Tags.php
@@ -31,6 +31,6 @@ class Tags extends BaseApi
 		$following = DBA::exists('search', ['uid' => $uid, 'term' => '#' . $tag]);
 
 		$hashtag = new \Friendica\Object\Api\Mastodon\Tag($this->baseUrl, ['name' => $tag], [], $following);
-		$this->jsonExit($hashtag->toArray());
+		$this->earlyJsonExit($hashtag->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Tags/Follow.php
+++ b/src/Module/Api/Mastodon/Tags/Follow.php
@@ -30,6 +30,6 @@ class Follow extends BaseApi
 		}
 
 		$hashtag = new \Friendica\Object\Api\Mastodon\Tag($this->baseUrl, ['name' => ltrim((string) $this->parameters['hashtag'])], [], true);
-		$this->jsonExit($hashtag->toArray());
+		$this->earlyJsonExit($hashtag->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Tags/Unfollow.php
+++ b/src/Module/Api/Mastodon/Tags/Unfollow.php
@@ -29,6 +29,6 @@ class Unfollow extends BaseApi
 		DBA::delete('search', $term);
 
 		$hashtag = new \Friendica\Object\Api\Mastodon\Tag($this->baseUrl, ['name' => ltrim((string) $this->parameters['hashtag'])], [], false);
-		$this->jsonExit($hashtag->toArray());
+		$this->earlyJsonExit($hashtag->toArray());
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -76,6 +76,6 @@ class Direct extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($statuses);
+		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/Home.php
+++ b/src/Module/Api/Mastodon/Timelines/Home.php
@@ -88,6 +88,6 @@ class Home extends BaseApi
 
 
 		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
-		$this->jsonExit($statuses);
+		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -91,7 +91,7 @@ class ListTimeline extends BaseApi
 		}
 
 		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
-		$this->jsonExit($statuses);
+		$this->earlyJsonExit($statuses);
 	}
 
 	private function getStatusesForGroup(int $uid, array $request): array

--- a/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
@@ -54,7 +54,7 @@ class PublicTimeline extends BaseApi
 		], $request);
 
 		if ($this->config->get('system', 'community_page_style') == Community::DISABLED) {
-			$this->jsonExit([]);
+			$this->earlyJsonExit([]);
 		}
 
 		if ($this->authRequired($request)) {
@@ -118,7 +118,7 @@ class PublicTimeline extends BaseApi
 		}
 
 		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
-		$this->jsonExit($statuses);
+		$this->earlyJsonExit($statuses);
 	}
 
 	private function authRequired(array $request): bool

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -114,6 +114,6 @@ class Tag extends BaseApi
 		}
 
 		self::setLinkHeader();
-		$this->jsonExit($statuses);
+		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Trends/Links.php
+++ b/src/Module/Api/Mastodon/Trends/Links.php
@@ -49,6 +49,6 @@ class Links extends BaseApi
 			self::setLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
 		}
 
-		$this->jsonExit($trending);
+		$this->earlyJsonExit($trending);
 	}
 }

--- a/src/Module/Api/Mastodon/Trends/Statuses.php
+++ b/src/Module/Api/Mastodon/Trends/Statuses.php
@@ -67,6 +67,6 @@ class Statuses extends BaseApi
 			self::setLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
 		}
 
-		$this->jsonExit($trending);
+		$this->earlyJsonExit($trending);
 	}
 }

--- a/src/Module/Api/Mastodon/Trends/Tags.php
+++ b/src/Module/Api/Mastodon/Trends/Tags.php
@@ -45,6 +45,6 @@ class Tags extends BaseApi
 			self::setLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
 		}
 
-		$this->jsonExit($trending);
+		$this->earlyJsonExit($trending);
 	}
 }

--- a/src/Module/Api/Twitter/Blocks/Ids.php
+++ b/src/Module/Api/Twitter/Blocks/Ids.php
@@ -68,6 +68,6 @@ class Ids extends ContactEndpoint
 
 		self::setLinkHeader();
 
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Api/Twitter/Followers/Ids.php
+++ b/src/Module/Api/Twitter/Followers/Ids.php
@@ -99,6 +99,6 @@ class Ids extends ContactEndpoint
 
 		self::setLinkHeader();
 
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Api/Twitter/Friends/Ids.php
+++ b/src/Module/Api/Twitter/Friends/Ids.php
@@ -99,6 +99,6 @@ class Ids extends ContactEndpoint
 
 		self::setLinkHeader();
 
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -532,7 +532,7 @@ class BaseApi extends BaseModule
 	 * @return never
 	 * @throws HTTPException\InternalServerErrorException
 	 */
-	protected function logAndJsonError(int $errorno, Error $error)
+	protected function logAndJsonError(int $errorno, Error $error): never
 	{
 		$this->logger->info('API Error', ['no' => $errorno, 'error' => $error->toArray(), 'method' => $this->args->getMethod(), 'command' => $this->args->getQueryString(), 'user-agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
 		$this->earlyJsonError($errorno, $error->toArray());

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -461,7 +461,7 @@ class BaseApi extends BaseModule
 				$error             = $this->t('Too Many Requests');
 				$error_description = $this->tt("Daily posting limit of %d post reached. The post was rejected.", "Daily posting limit of %d posts reached. The post was rejected.", $throttle_day);
 				$errorobj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
-				$this->jsonError(429, $errorobj->toArray());
+				$this->earlyJsonError(429, $errorobj->toArray());
 			}
 		}
 
@@ -477,7 +477,7 @@ class BaseApi extends BaseModule
 				$error             = $this->t('Too Many Requests');
 				$error_description = $this->tt("Weekly posting limit of %d post reached. The post was rejected.", "Weekly posting limit of %d posts reached. The post was rejected.", $throttle_week);
 				$errorobj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
-				$this->jsonError(429, $errorobj->toArray());
+				$this->earlyJsonError(429, $errorobj->toArray());
 			}
 		}
 
@@ -493,7 +493,7 @@ class BaseApi extends BaseModule
 				$error             = $this->t('Too Many Requests');
 				$error_description = $this->tt('Monthly posting limit of %d post reached. The post was rejected.', 'Monthly posting limit of %d posts reached. The post was rejected.', $throttle_month);
 				$errorobj          = new \Friendica\Object\Api\Mastodon\Error($error, $error_description);
-				$this->jsonError(429, $errorobj->toArray());
+				$this->earlyJsonError(429, $errorobj->toArray());
 			}
 		}
 	}
@@ -535,6 +535,6 @@ class BaseApi extends BaseModule
 	protected function logAndJsonError(int $errorno, Error $error)
 	{
 		$this->logger->info('API Error', ['no' => $errorno, 'error' => $error->toArray(), 'method' => $this->args->getMethod(), 'command' => $this->args->getQueryString(), 'user-agent' => $this->server['HTTP_USER_AGENT'] ?? '']);
-		$this->jsonError($errorno, $error->toArray());
+		$this->earlyJsonError($errorno, $error->toArray());
 	}
 }

--- a/src/Module/BaseNotifications.php
+++ b/src/Module/BaseNotifications.php
@@ -106,7 +106,7 @@ abstract class BaseNotifications extends BaseModule
 			'page'          => $pager->getPage(),
 		];
 
-		$this->jsonExit($notifications);
+		$this->earlyJsonExit($notifications);
 	}
 
 	/**

--- a/src/Module/Calendar/Event/API.php
+++ b/src/Module/Calendar/Event/API.php
@@ -171,7 +171,7 @@ class API extends BaseModule
 
 		if (strcmp($finish, $start) < 0 && !$noFinish) {
 			if ($isPreview) {
-				$this->earlyExit($this->t('Event can not end before it has started.'));
+				$this->earlyHttpExit($this->t('Event can not end before it has started.'));
 			} else {
 				$this->sysMessages->addNotice($this->t('Event can not end before it has started.'));
 				$this->baseUrl->redirect($redirectOnError);
@@ -180,7 +180,7 @@ class API extends BaseModule
 
 		if (empty($summary) || ($start === DBA::NULL_DATETIME)) {
 			if ($isPreview) {
-				$this->earlyExit($this->t('Event title and start time are required.'));
+				$this->earlyHttpExit($this->t('Event title and start time are required.'));
 			} else {
 				$this->sysMessages->addNotice($this->t('Event title and start time are required.'));
 				$this->baseUrl->redirect($redirectOnError);
@@ -239,7 +239,7 @@ class API extends BaseModule
 		];
 
 		if (intval($request['preview'])) {
-			$this->earlyExit(Event::getHTML($datarray));
+			$this->earlyHttpExit(Event::getHTML($datarray));
 		}
 
 		$eventId = Event::store($datarray);

--- a/src/Module/Calendar/Event/API.php
+++ b/src/Module/Calendar/Event/API.php
@@ -171,7 +171,7 @@ class API extends BaseModule
 
 		if (strcmp($finish, $start) < 0 && !$noFinish) {
 			if ($isPreview) {
-				$this->httpExit($this->t('Event can not end before it has started.'));
+				$this->earlyExit($this->t('Event can not end before it has started.'));
 			} else {
 				$this->sysMessages->addNotice($this->t('Event can not end before it has started.'));
 				$this->baseUrl->redirect($redirectOnError);
@@ -180,7 +180,7 @@ class API extends BaseModule
 
 		if (empty($summary) || ($start === DBA::NULL_DATETIME)) {
 			if ($isPreview) {
-				$this->httpExit($this->t('Event title and start time are required.'));
+				$this->earlyExit($this->t('Event title and start time are required.'));
 			} else {
 				$this->sysMessages->addNotice($this->t('Event title and start time are required.'));
 				$this->baseUrl->redirect($redirectOnError);
@@ -239,7 +239,7 @@ class API extends BaseModule
 		];
 
 		if (intval($request['preview'])) {
-			$this->httpExit(Event::getHTML($datarray));
+			$this->earlyExit(Event::getHTML($datarray));
 		}
 
 		$eventId = Event::store($datarray);

--- a/src/Module/Calendar/Event/Get.php
+++ b/src/Module/Calendar/Event/Get.php
@@ -51,7 +51,7 @@ class Get extends \Friendica\BaseModule
 			$events = Event::getListByDate($owner['uid'], $request['start'] ?? '', $request['end'] ?? '');
 		}
 
-		$this->jsonExit($events ? self::map($events) : []);
+		$this->earlyJsonExit($events ? self::map($events) : []);
 	}
 
 	private static function map(array $events): array

--- a/src/Module/Calendar/Event/Show.php
+++ b/src/Module/Calendar/Event/Show.php
@@ -80,6 +80,6 @@ class Show extends BaseModule
 			'$action_orig_text'      => $this->t('View related post'),
 		]);
 
-		$this->httpExit($o);
+		$this->earlyExit($o);
 	}
 }

--- a/src/Module/Calendar/Event/Show.php
+++ b/src/Module/Calendar/Event/Show.php
@@ -80,6 +80,6 @@ class Show extends BaseModule
 			'$action_orig_text'      => $this->t('View related post'),
 		]);
 
-		$this->earlyExit($o);
+		$this->earlyHttpExit($o);
 	}
 }

--- a/src/Module/Circle.php
+++ b/src/Module/Circle.php
@@ -126,10 +126,10 @@ class Circle extends BaseModule
 			}
 
 			DI::sysmsg()->addInfo($message);
-			$this->jsonExit(['status' => 'OK', 'message' => $message]);
+			$this->earlyJsonExit(['status' => 'OK', 'message' => $message]);
 		} catch (\Exception $e) {
 			DI::sysmsg()->addNotice($e->getMessage());
-			$this->jsonError($e->getCode(), ['status' => 'error', 'message' => $e->getMessage()]);
+			$this->earlyJsonError($e->getCode(), ['status' => 'error', 'message' => $e->getMessage()]);
 		}
 	}
 

--- a/src/Module/Contact/Hovercard.php
+++ b/src/Module/Contact/Hovercard.php
@@ -63,6 +63,6 @@ class Hovercard extends BaseModule
 			throw new HTTPException\NotFoundException();
 		}
 
-		$this->httpExit($this->hovercard->getHTML($contact, $this->userSession->getLocalUserId()));
+		$this->earlyExit($this->hovercard->getHTML($contact, $this->userSession->getLocalUserId()));
 	}
 }

--- a/src/Module/Contact/Hovercard.php
+++ b/src/Module/Contact/Hovercard.php
@@ -63,6 +63,6 @@ class Hovercard extends BaseModule
 			throw new HTTPException\NotFoundException();
 		}
 
-		$this->earlyExit($this->hovercard->getHTML($contact, $this->userSession->getLocalUserId()));
+		$this->earlyHttpExit($this->hovercard->getHTML($contact, $this->userSession->getLocalUserId()));
 	}
 }

--- a/src/Module/DFRN/Notify.php
+++ b/src/Module/DFRN/Notify.php
@@ -133,6 +133,6 @@ class Notify extends BaseModule
 			$this->logger->notice('xml_status returning non_zero: ' . $status . " message=" . $message);
 		}
 
-		$this->earlyExit(XML::fromArray(['result' => $result]), Response::TYPE_XML);
+		$this->earlyHttpExit(XML::fromArray(['result' => $result]), Response::TYPE_XML);
 	}
 }

--- a/src/Module/DFRN/Notify.php
+++ b/src/Module/DFRN/Notify.php
@@ -133,6 +133,6 @@ class Notify extends BaseModule
 			$this->logger->notice('xml_status returning non_zero: ' . $status . " message=" . $message);
 		}
 
-		$this->httpExit(XML::fromArray(['result' => $result]), Response::TYPE_XML);
+		$this->earlyExit(XML::fromArray(['result' => $result]), Response::TYPE_XML);
 	}
 }

--- a/src/Module/Diaspora/Fetch.php
+++ b/src/Module/Diaspora/Fetch.php
@@ -71,6 +71,6 @@ class Fetch extends BaseModule
 		$xml = Diaspora::buildPostXml($status["type"], $status["message"]);
 
 		// Send the envelope
-		$this->earlyExit(Diaspora::buildMagicEnvelope($xml, $user), Response::TYPE_XML, 'application/magic-envelope+xml');
+		$this->earlyHttpExit(Diaspora::buildMagicEnvelope($xml, $user), Response::TYPE_XML, 'application/magic-envelope+xml');
 	}
 }

--- a/src/Module/Diaspora/Fetch.php
+++ b/src/Module/Diaspora/Fetch.php
@@ -71,6 +71,6 @@ class Fetch extends BaseModule
 		$xml = Diaspora::buildPostXml($status["type"], $status["message"]);
 
 		// Send the envelope
-		$this->httpExit(Diaspora::buildMagicEnvelope($xml, $user), Response::TYPE_XML, 'application/magic-envelope+xml');
+		$this->earlyExit(Diaspora::buildMagicEnvelope($xml, $user), Response::TYPE_XML, 'application/magic-envelope+xml');
 	}
 }

--- a/src/Module/Feed.php
+++ b/src/Module/Feed.php
@@ -60,6 +60,6 @@ class Feed extends BaseModule
 
 		$feed = ProtocolFeed::atom($owner, $last_update, 10, $type);
 
-		$this->httpExit($feed, Response::TYPE_ATOM);
+		$this->earlyExit($feed, Response::TYPE_ATOM);
 	}
 }

--- a/src/Module/Feed.php
+++ b/src/Module/Feed.php
@@ -60,6 +60,6 @@ class Feed extends BaseModule
 
 		$feed = ProtocolFeed::atom($owner, $last_update, 10, $type);
 
-		$this->earlyExit($feed, Response::TYPE_ATOM);
+		$this->earlyHttpExit($feed, Response::TYPE_ATOM);
 	}
 }

--- a/src/Module/Filer/RemoveTag.php
+++ b/src/Module/Filer/RemoveTag.php
@@ -39,7 +39,7 @@ class RemoveTag extends BaseModule
 		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
 	}
 
-	protected function post(array $request = [])
+	protected function post(array $request = []): never
 	{
 		$type = 0;
 		$term = '';

--- a/src/Module/Filer/RemoveTag.php
+++ b/src/Module/Filer/RemoveTag.php
@@ -43,7 +43,7 @@ class RemoveTag extends BaseModule
 	{
 		$type = 0;
 		$term = '';
-		$this->httpError($this->removeTag($request, $type, $term));
+		$this->earlyHttpError($this->removeTag($request, $type, $term));
 	}
 
 	protected function content(array $request = []): string

--- a/src/Module/Friendica.php
+++ b/src/Module/Friendica.php
@@ -136,9 +136,9 @@ class Friendica extends BaseModule
 				$data = ActivityPub\Transmitter::getProfile(0);
 				header('Access-Control-Allow-Origin: *');
 				header('Cache-Control: max-age=23200, stale-while-revalidate=23200');
-				$this->jsonExit($data, 'application/activity+json');
+				$this->earlyJsonExit($data, 'application/activity+json');
 			} catch (HTTPException\NotFoundException) {
-				$this->jsonError(404, ['error' => 'Record not found']);
+				$this->earlyJsonError(404, ['error' => 'Record not found']);
 			}
 		}
 
@@ -194,6 +194,6 @@ class Friendica extends BaseModule
 			'no_scrape_url'    => $this->baseUrl . '/noscrape',
 		];
 
-		$this->jsonExit($data);
+		$this->earlyJsonExit($data);
 	}
 }

--- a/src/Module/Hashtag.php
+++ b/src/Module/Hashtag.php
@@ -21,7 +21,7 @@ class Hashtag extends BaseModule
 		$result = [];
 
 		if (empty($request['t'])) {
-			$this->jsonExit($result);
+			$this->earlyJsonExit($result);
 		}
 
 		$taglist = DBA::select(
@@ -35,6 +35,6 @@ class Hashtag extends BaseModule
 		}
 		DBA::close($taglist);
 
-		$this->jsonExit($result);
+		$this->earlyJsonExit($result);
 	}
 }

--- a/src/Module/Home.php
+++ b/src/Module/Home.php
@@ -27,7 +27,7 @@ class Home extends BaseModule
 		if (ActivityPub::isRequest()) {
 			DI::baseUrl()->redirect(User::getActorName());
 		} elseif (ZOT::isRequest()) {
-			$this->jsonExit(ZOT::getSiteInfo(), 'application/x-zot+json');
+			$this->earlyJsonExit(ZOT::getSiteInfo(), 'application/x-zot+json');
 		}
 	}
 

--- a/src/Module/Item/Activity.php
+++ b/src/Module/Item/Activity.php
@@ -74,6 +74,6 @@ class Activity extends BaseModule
 			'state'   => 1,
 		];
 
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Item/Comments.php
+++ b/src/Module/Item/Comments.php
@@ -52,6 +52,6 @@ class Comments extends BaseModule
 
 		$viewerUid = $this->session->getLocalUserId();
 		$existing  = !empty($request['existing']) ? array_map(intval(...), explode(',', $request['existing'])) : [];
-		$this->httpExit($this->htmlRenderer->renderCommentsByUriId($uriId, $viewerUid, $existing));
+		$this->earlyExit($this->htmlRenderer->renderCommentsByUriId($uriId, $viewerUid, $existing));
 	}
 }

--- a/src/Module/Item/Comments.php
+++ b/src/Module/Item/Comments.php
@@ -52,6 +52,6 @@ class Comments extends BaseModule
 
 		$viewerUid = $this->session->getLocalUserId();
 		$existing  = !empty($request['existing']) ? array_map(intval(...), explode(',', $request['existing'])) : [];
-		$this->earlyExit($this->htmlRenderer->renderCommentsByUriId($uriId, $viewerUid, $existing));
+		$this->earlyHttpExit($this->htmlRenderer->renderCommentsByUriId($uriId, $viewerUid, $existing));
 	}
 }

--- a/src/Module/Item/Complete.php
+++ b/src/Module/Item/Complete.php
@@ -41,6 +41,6 @@ final class Complete extends BaseModule
 		];
 
 		DI::logger()->debug('Complete thread executed.', ['parameters' => $this->parameters]);
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Item/Feed.php
+++ b/src/Module/Item/Feed.php
@@ -71,6 +71,6 @@ class Feed extends BaseModule
 			throw new HTTPException\InternalServerErrorException($this->t('The feed for this item is unavailable.', ['uri-id' => $uriId]));
 		}
 
-		$this->httpExit($xml, Response::TYPE_ATOM);
+		$this->earlyExit($xml, Response::TYPE_ATOM);
 	}
 }

--- a/src/Module/Item/Feed.php
+++ b/src/Module/Item/Feed.php
@@ -71,6 +71,6 @@ class Feed extends BaseModule
 			throw new HTTPException\InternalServerErrorException($this->t('The feed for this item is unavailable.', ['uri-id' => $uriId]));
 		}
 
-		$this->earlyExit($xml, Response::TYPE_ATOM);
+		$this->earlyHttpExit($xml, Response::TYPE_ATOM);
 	}
 }

--- a/src/Module/Item/Follow.php
+++ b/src/Module/Item/Follow.php
@@ -55,6 +55,6 @@ class Follow extends BaseModule
 			'state'   => 1,
 		];
 
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Item/Ignore.php
+++ b/src/Module/Item/Ignore.php
@@ -67,6 +67,6 @@ class Ignore extends BaseModule
 			'state'   => $ignored,
 		];
 
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Item/Language.php
+++ b/src/Module/Item/Language.php
@@ -44,6 +44,6 @@ class Language extends BaseModule
 			throw new HTTPException\NotFoundException();
 		}
 
-		$this->httpExit($this->item->getLanguageMessage($item));
+		$this->earlyExit($this->item->getLanguageMessage($item));
 	}
 }

--- a/src/Module/Item/Language.php
+++ b/src/Module/Item/Language.php
@@ -44,6 +44,6 @@ class Language extends BaseModule
 			throw new HTTPException\NotFoundException();
 		}
 
-		$this->earlyExit($this->item->getLanguageMessage($item));
+		$this->earlyHttpExit($this->item->getLanguageMessage($item));
 	}
 }

--- a/src/Module/Item/Pin.php
+++ b/src/Module/Item/Pin.php
@@ -69,6 +69,6 @@ class Pin extends BaseModule
 			'state'   => (int) $pinned,
 		];
 
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Item/Searchtext.php
+++ b/src/Module/Item/Searchtext.php
@@ -45,9 +45,9 @@ class Searchtext extends BaseModule
 
 		$search = DBA::selectFirst('post-searchindex', [], ['uri-id' => $item['uri-id']]);
 		if (empty($search)) {
-			$this->earlyExit($this->l10n->t('No search text found for this item. This can happen when the author has set their account to be non-discoverable or their posts to be non-indexable for searches.'));
+			$this->earlyHttpExit($this->l10n->t('No search text found for this item. This can happen when the author has set their account to be non-discoverable or their posts to be non-indexable for searches.'));
 		}
 
-		$this->earlyExit(Post\Engagement::unescapeKeywords($search['searchtext']));
+		$this->earlyHttpExit(Post\Engagement::unescapeKeywords($search['searchtext']));
 	}
 }

--- a/src/Module/Item/Searchtext.php
+++ b/src/Module/Item/Searchtext.php
@@ -45,9 +45,9 @@ class Searchtext extends BaseModule
 
 		$search = DBA::selectFirst('post-searchindex', [], ['uri-id' => $item['uri-id']]);
 		if (empty($search)) {
-			$this->httpExit($this->l10n->t('No search text found for this item. This can happen when the author has set their account to be non-discoverable or their posts to be non-indexable for searches.'));
+			$this->earlyExit($this->l10n->t('No search text found for this item. This can happen when the author has set their account to be non-discoverable or their posts to be non-indexable for searches.'));
 		}
 
-		$this->httpExit(Post\Engagement::unescapeKeywords($search['searchtext']));
+		$this->earlyExit(Post\Engagement::unescapeKeywords($search['searchtext']));
 	}
 }

--- a/src/Module/Item/Star.php
+++ b/src/Module/Item/Star.php
@@ -76,6 +76,6 @@ class Star extends BaseModule
 			'state'   => (int) $starred,
 		];
 
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Manifest.php
+++ b/src/Module/Manifest.php
@@ -119,6 +119,6 @@ class Manifest extends BaseModule
 			$manifest['theme_color'] = $theme_color;
 		}
 
-		$this->jsonExit($manifest, 'application/manifest+json');
+		$this->earlyJsonExit($manifest, 'application/manifest+json');
 	}
 }

--- a/src/Module/Media/Attachment/Browser.php
+++ b/src/Module/Media/Attachment/Browser.php
@@ -74,7 +74,7 @@ class Browser extends BaseModule
 		]);
 
 		if (empty($request['mode'])) {
-			$this->earlyExit($output);
+			$this->earlyHttpExit($output);
 		}
 
 		return $output;

--- a/src/Module/Media/Attachment/Browser.php
+++ b/src/Module/Media/Attachment/Browser.php
@@ -74,7 +74,7 @@ class Browser extends BaseModule
 		]);
 
 		if (empty($request['mode'])) {
-			$this->httpExit($output);
+			$this->earlyExit($output);
 		}
 
 		return $output;

--- a/src/Module/Media/Photo/Browser.php
+++ b/src/Module/Media/Photo/Browser.php
@@ -86,7 +86,7 @@ class Browser extends BaseModule
 		]);
 
 		if (empty($request['mode'])) {
-			$this->earlyExit($output);
+			$this->earlyHttpExit($output);
 		}
 
 		return $output;

--- a/src/Module/Media/Photo/Browser.php
+++ b/src/Module/Media/Photo/Browser.php
@@ -86,7 +86,7 @@ class Browser extends BaseModule
 		]);
 
 		if (empty($request['mode'])) {
-			$this->httpExit($output);
+			$this->earlyExit($output);
 		}
 
 		return $output;

--- a/src/Module/NoScrape.php
+++ b/src/Module/NoScrape.php
@@ -28,13 +28,13 @@ class NoScrape extends BaseModule
 			// view infos about a known profile (needs a login)
 			$which = DI::userSession()->getLocalUserNickname();
 		} else {
-			$this->jsonError(403, 'Authentication required');
+			$this->earlyJsonError(403, 'Authentication required');
 		}
 
 		$owner = User::getOwnerDataByNick($which);
 
 		if (empty($owner['uid'])) {
-			$this->jsonError(404, 'Profile not found');
+			$this->earlyJsonError(404, 'Profile not found');
 		}
 
 		$json_info = [
@@ -54,7 +54,7 @@ class NoScrape extends BaseModule
 
 		if (!$owner['net-publish']) {
 			$json_info['hide'] = true;
-			$this->jsonExit($json_info);
+			$this->earlyJsonExit($json_info);
 		}
 
 		$keywords = $owner['pub_keywords'] ?? '';
@@ -90,6 +90,6 @@ class NoScrape extends BaseModule
 			}
 		}
 
-		$this->jsonExit($json_info);
+		$this->earlyJsonExit($json_info);
 	}
 }

--- a/src/Module/Notifications/Notification.php
+++ b/src/Module/Notifications/Notification.php
@@ -98,7 +98,7 @@ class Notification extends BaseModule
 				$success = false;
 			}
 
-			$this->jsonExit(['result' => (($success) ? 'success' : 'fail')]);
+			$this->earlyJsonExit(['result' => (($success) ? 'success' : 'fail')]);
 		}
 	}
 

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -246,9 +246,9 @@ class Ping extends BaseModule
 
 		if (isset($_GET['callback'])) {
 			// JSONP support
-			$this->httpExit($_GET['callback'] . '(' . json_encode(['result' => $data]) . ')', Response::TYPE_BLANK, 'application/javascript');
+			$this->earlyExit($_GET['callback'] . '(' . json_encode(['result' => $data]) . ')', Response::TYPE_BLANK, 'application/javascript');
 		} else {
-			$this->jsonExit(['result' => $data]);
+			$this->earlyJsonExit(['result' => $data]);
 		}
 	}
 }

--- a/src/Module/Notifications/Ping.php
+++ b/src/Module/Notifications/Ping.php
@@ -246,7 +246,7 @@ class Ping extends BaseModule
 
 		if (isset($_GET['callback'])) {
 			// JSONP support
-			$this->earlyExit($_GET['callback'] . '(' . json_encode(['result' => $data]) . ')', Response::TYPE_BLANK, 'application/javascript');
+			$this->earlyHttpExit($_GET['callback'] . '(' . json_encode(['result' => $data]) . ')', Response::TYPE_BLANK, 'application/javascript');
 		} else {
 			$this->earlyJsonExit(['result' => $data]);
 		}

--- a/src/Module/OAuth/Revoke.php
+++ b/src/Module/OAuth/Revoke.php
@@ -36,6 +36,6 @@ class Revoke extends BaseApi
 		}
 
 		DBA::delete('application-token', ['application-id' => $token['id']]);
-		$this->jsonExit([]);
+		$this->earlyJsonExit([]);
 	}
 }

--- a/src/Module/OAuth/Token.php
+++ b/src/Module/OAuth/Token.php
@@ -84,7 +84,7 @@ class Token extends BaseApi
 				null,
 			);
 
-			$this->jsonExit($object->toArray());
+			$this->earlyJsonExit($object->toArray());
 		}
 
 		// now check for $grant_type === 'authorization_code'
@@ -111,6 +111,6 @@ class Token extends BaseApi
 			$owner['url'],
 		);
 
-		$this->jsonExit($object->toArray());
+		$this->earlyJsonExit($object->toArray());
 	}
 }

--- a/src/Module/OpenSearch.php
+++ b/src/Module/OpenSearch.php
@@ -104,6 +104,6 @@ class OpenSearch extends BaseModule
 			'template' => $this->baseUrl . '/opensearch',
 		]);
 
-		$this->earlyExit($xml->saveXML(), Response::TYPE_XML, 'application/opensearchdescription+xml');
+		$this->earlyHttpExit($xml->saveXML(), Response::TYPE_XML, 'application/opensearchdescription+xml');
 	}
 }

--- a/src/Module/OpenSearch.php
+++ b/src/Module/OpenSearch.php
@@ -104,6 +104,6 @@ class OpenSearch extends BaseModule
 			'template' => $this->baseUrl . '/opensearch',
 		]);
 
-		$this->httpExit($xml->saveXML(), Response::TYPE_XML, 'application/opensearchdescription+xml');
+		$this->earlyExit($xml->saveXML(), Response::TYPE_XML, 'application/opensearchdescription+xml');
 	}
 }

--- a/src/Module/Owa.php
+++ b/src/Module/Owa.php
@@ -85,6 +85,6 @@ class Owa extends BaseModule
 				}
 			}
 		}
-		$this->jsonExit($ret, 'application/x-zot+json');
+		$this->earlyJsonExit($ret, 'application/x-zot+json');
 	}
 }

--- a/src/Module/ParseUrl.php
+++ b/src/Module/ParseUrl.php
@@ -85,9 +85,9 @@ class ParseUrl extends BaseModule
 
 		if ($hook_data['text']) {
 			if ($format == 'json') {
-				$this->jsonExit($hook_data['text']);
+				$this->earlyJsonExit($hook_data['text']);
 			} else {
-				$this->httpExit($hook_data['text']);
+				$this->earlyExit($hook_data['text']);
 			}
 		}
 
@@ -122,9 +122,9 @@ class ParseUrl extends BaseModule
 				$ret['contentType'] = 'url';
 			}
 
-			$this->jsonExit($ret);
+			$this->earlyJsonExit($ret);
 		} else {
-			$this->httpExit(BBCode::embedURL($url, empty($request['noAttachment']), $title, $description, $request['tags'] ?? ''));
+			$this->earlyExit(BBCode::embedURL($url, empty($request['noAttachment']), $title, $description, $request['tags'] ?? ''));
 		}
 	}
 }

--- a/src/Module/ParseUrl.php
+++ b/src/Module/ParseUrl.php
@@ -87,7 +87,7 @@ class ParseUrl extends BaseModule
 			if ($format == 'json') {
 				$this->earlyJsonExit($hook_data['text']);
 			} else {
-				$this->earlyExit($hook_data['text']);
+				$this->earlyHttpExit($hook_data['text']);
 			}
 		}
 
@@ -124,7 +124,7 @@ class ParseUrl extends BaseModule
 
 			$this->earlyJsonExit($ret);
 		} else {
-			$this->earlyExit(BBCode::embedURL($url, empty($request['noAttachment']), $title, $description, $request['tags'] ?? ''));
+			$this->earlyHttpExit(BBCode::embedURL($url, empty($request['noAttachment']), $title, $description, $request['tags'] ?? ''));
 		}
 	}
 }

--- a/src/Module/Ping/Network.php
+++ b/src/Module/Ping/Network.php
@@ -122,13 +122,13 @@ class Network extends NetworkModule
 		$this->parseRequest($request);
 
 		if ($this->force || !is_null($this->maxId)) {
-			$this->earlyExit('');
+			$this->earlyHttpExit('');
 		}
 
 		$lockkey = 'network-ping-' . $this->session->getLocalUserId();
 		if (!$this->lock->acquire($lockkey, 0)) {
 			$this->logger->debug('Ping-1-lock', ['uid' => $this->session->getLocalUserId()]);
-			$this->earlyExit('');
+			$this->earlyHttpExit('');
 		}
 
 		$this->setPing(true);
@@ -143,6 +143,6 @@ class Network extends NetworkModule
 		}
 		$this->lock->release($lockkey);
 		$count = count($items);
-		$this->earlyExit(($count < 100) ? $count : '99+');
+		$this->earlyHttpExit(($count < 100) ? $count : '99+');
 	}
 }

--- a/src/Module/Ping/Network.php
+++ b/src/Module/Ping/Network.php
@@ -122,13 +122,13 @@ class Network extends NetworkModule
 		$this->parseRequest($request);
 
 		if ($this->force || !is_null($this->maxId)) {
-			$this->httpExit('');
+			$this->earlyExit('');
 		}
 
 		$lockkey = 'network-ping-' . $this->session->getLocalUserId();
 		if (!$this->lock->acquire($lockkey, 0)) {
 			$this->logger->debug('Ping-1-lock', ['uid' => $this->session->getLocalUserId()]);
-			$this->httpExit('');
+			$this->earlyExit('');
 		}
 
 		$this->setPing(true);
@@ -143,6 +143,6 @@ class Network extends NetworkModule
 		}
 		$this->lock->release($lockkey);
 		$count = count($items);
-		$this->httpExit(($count < 100) ? $count : '99+');
+		$this->earlyExit(($count < 100) ? $count : '99+');
 	}
 }

--- a/src/Module/Post/Share.php
+++ b/src/Module/Post/Share.php
@@ -51,6 +51,6 @@ class Share extends \Friendica\BaseModule
 			$content = '[share]' . $item['uri'] . '[/share]';
 		}
 
-		$this->earlyExit($content);
+		$this->earlyHttpExit($content);
 	}
 }

--- a/src/Module/Post/Share.php
+++ b/src/Module/Post/Share.php
@@ -34,12 +34,12 @@ class Share extends \Friendica\BaseModule
 	{
 		$post_id = $this->parameters['post_id'];
 		if (!$post_id || !$this->session->getLocalUserId()) {
-			$this->httpError(403);
+			$this->earlyHttpError(403);
 		}
 
 		$item = Post::selectFirst(['private', 'body', 'uri', 'plink', 'network'], ['id' => $post_id]);
 		if (!$item || $item['private'] == Item::PRIVATE) {
-			$this->httpError(404);
+			$this->earlyHttpError(404);
 		}
 
 		$shared = $this->contentItem->getSharedPost($item, ['uri']);
@@ -51,6 +51,6 @@ class Share extends \Friendica\BaseModule
 			$content = '[share]' . $item['uri'] . '[/share]';
 		}
 
-		$this->httpExit($content);
+		$this->earlyExit($content);
 	}
 }

--- a/src/Module/Privacy/PermissionTooltip.php
+++ b/src/Module/Privacy/PermissionTooltip.php
@@ -143,7 +143,7 @@ class PermissionTooltip extends BaseModule
 			'$privacy'            => $privacy,
 		]);
 
-		$this->httpExit($output);
+		$this->earlyExit($output);
 	}
 
 	/**

--- a/src/Module/Privacy/PermissionTooltip.php
+++ b/src/Module/Privacy/PermissionTooltip.php
@@ -143,7 +143,7 @@ class PermissionTooltip extends BaseModule
 			'$privacy'            => $privacy,
 		]);
 
-		$this->earlyExit($output);
+		$this->earlyHttpExit($output);
 	}
 
 	/**

--- a/src/Module/Profile/Profile.php
+++ b/src/Module/Profile/Profile.php
@@ -74,9 +74,9 @@ class Profile extends BaseProfile
 					$data = ActivityPub\Transmitter::getProfile($user['uid'], ActivityPub::isAcceptedRequester($user['uid']));
 					header('Access-Control-Allow-Origin: *');
 					header('Cache-Control: max-age=23200, stale-while-revalidate=23200');
-					$this->jsonExit($data, 'application/activity+json');
+					$this->earlyJsonExit($data, 'application/activity+json');
 				} catch (HTTPException\NotFoundException) {
-					$this->jsonError(404, ['error' => 'Record not found']);
+					$this->earlyJsonError(404, ['error' => 'Record not found']);
 				}
 			}
 
@@ -84,10 +84,10 @@ class Profile extends BaseProfile
 				// Known deleted user
 				$data = ActivityPub\Transmitter::getDeletedUser($this->parameters['nickname']);
 
-				$this->jsonError(410, $data);
+				$this->earlyJsonError(410, $data);
 			} else {
 				// Any other case (unknown, blocked, nverified, expired, no profile, no self contact)
-				$this->jsonError(404, []);
+				$this->earlyJsonError(404, []);
 			}
 		}
 	}

--- a/src/Module/ReallySimpleDiscovery.php
+++ b/src/Module/ReallySimpleDiscovery.php
@@ -17,7 +17,7 @@ use Friendica\Util\XML;
  */
 class ReallySimpleDiscovery extends BaseModule
 {
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$content = XML::fromArray([
 			'rsd' => [

--- a/src/Module/ReallySimpleDiscovery.php
+++ b/src/Module/ReallySimpleDiscovery.php
@@ -52,6 +52,6 @@ class ReallySimpleDiscovery extends BaseModule
 				],
 			],
 		]);
-		$this->earlyExit($content, Response::TYPE_XML);
+		$this->earlyHttpExit($content, Response::TYPE_XML);
 	}
 }

--- a/src/Module/ReallySimpleDiscovery.php
+++ b/src/Module/ReallySimpleDiscovery.php
@@ -52,6 +52,6 @@ class ReallySimpleDiscovery extends BaseModule
 				],
 			],
 		]);
-		$this->httpExit($content, Response::TYPE_XML);
+		$this->earlyExit($content, Response::TYPE_XML);
 	}
 }

--- a/src/Module/Search/Acl.php
+++ b/src/Module/Search/Acl.php
@@ -75,7 +75,7 @@ class Acl extends BaseModule
 			$o = $this->regularContactSearch($request, $type);
 		}
 
-		$this->jsonExit($o);
+		$this->earlyJsonExit($o);
 	}
 
 	private function globalContactSearch(array $request): array

--- a/src/Module/Search/Tags.php
+++ b/src/Module/Search/Tags.php
@@ -44,7 +44,7 @@ class Tags extends BaseModule
 		$results = [];
 
 		if (empty($tags)) {
-			$this->jsonExit([
+			$this->earlyJsonExit([
 				'total'      => 0,
 				'items_page' => $perPage,
 				'page'       => $page,
@@ -59,7 +59,7 @@ class Tags extends BaseModule
 
 		$totalCount = $this->database->count('owner-view', $condition);
 		if ($totalCount === 0) {
-			$this->jsonExit([
+			$this->earlyJsonExit([
 				'total'      => 0,
 				'items_page' => $perPage,
 				'page'       => $page,
@@ -84,7 +84,7 @@ class Tags extends BaseModule
 
 		$this->database->close($searchStmt);
 
-		$this->jsonExit([
+		$this->earlyJsonExit([
 			'total'      => $totalCount,
 			'items_page' => $perPage,
 			'page'       => $page,

--- a/src/Module/Smilies.php
+++ b/src/Module/Smilies.php
@@ -25,7 +25,7 @@ class Smilies extends BaseModule
 			for ($i = 0; $i < count($smilies['texts']); $i++) {
 				$results[] = ['text' => $smilies['texts'][$i], 'icon' => $smilies['icons'][$i]];
 			}
-			$this->jsonExit($results);
+			$this->earlyJsonExit($results);
 		}
 	}
 

--- a/src/Module/Statistics.php
+++ b/src/Module/Statistics.php
@@ -49,7 +49,7 @@ class Statistics extends BaseModule
 		}
 	}
 
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$registration_open = Register::getPolicy() !== Register::CLOSED
 			&& !$this->config->get('config', 'invitation_only');

--- a/src/Module/Statistics.php
+++ b/src/Module/Statistics.php
@@ -81,6 +81,6 @@ class Statistics extends BaseModule
 		], $services);
 
 		$this->logger->debug("statistics.", ['statistics' => $statistics]);
-		$this->jsonExit($statistics);
+		$this->earlyJsonExit($statistics);
 	}
 }

--- a/src/Module/Stats.php
+++ b/src/Module/Stats.php
@@ -189,7 +189,7 @@ class Stats extends BaseModule
 
 		$statistics = $this->getJobsPerPriority($statistics);
 
-		$this->jsonExit($statistics);
+		$this->earlyJsonExit($statistics);
 	}
 
 	private function isAllowed(array $request): bool

--- a/src/Module/ThemeDetails.php
+++ b/src/Module/ThemeDetails.php
@@ -27,7 +27,7 @@ class ThemeDetails extends BaseModule
 			$version     = $info['version']     ?? '';
 			$credits     = $info['credits']     ?? '';
 
-			$this->jsonExit([
+			$this->earlyJsonExit([
 				'img'     => Theme::getScreenshot($theme),
 				'desc'    => $description,
 				'version' => $version,

--- a/src/Module/User/PortableContacts.php
+++ b/src/Module/User/PortableContacts.php
@@ -244,6 +244,6 @@ class PortableContacts extends BaseModule
 
 		$this->logger->info('End of poco');
 
-		$this->jsonExit($return);
+		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/WellKnown/NodeInfo.php
+++ b/src/Module/WellKnown/NodeInfo.php
@@ -39,6 +39,6 @@ class NodeInfo extends BaseModule
 			],
 		];
 
-		$this->jsonExit($nodeinfo);
+		$this->earlyJsonExit($nodeinfo);
 	}
 }

--- a/src/Module/WellKnown/NodeInfo.php
+++ b/src/Module/WellKnown/NodeInfo.php
@@ -16,7 +16,7 @@ use Friendica\DI;
  */
 class NodeInfo extends BaseModule
 {
-	protected function rawContent(array $request = [])
+	protected function rawContent(array $request = []): never
 	{
 		$nodeinfo = [
 			'links' => [

--- a/src/Module/WellKnown/XSocialRelay.php
+++ b/src/Module/WellKnown/XSocialRelay.php
@@ -42,6 +42,6 @@ class XSocialRelay extends BaseModule
 			$relay['protocols']['diaspora'] = ['receive' => DI::baseUrl() . '/receive/public'];
 		}
 
-		$this->jsonExit($relay);
+		$this->earlyJsonExit($relay);
 	}
 }

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -345,6 +345,6 @@ class Xrd extends BaseModule
 		]);
 
 		header('Access-Control-Allow-Origin: *');
-		$this->earlyExit($xmlString, Response::TYPE_XML, 'application/xrd+xml');
+		$this->earlyHttpExit($xmlString, Response::TYPE_XML, 'application/xrd+xml');
 	}
 }

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -174,7 +174,7 @@ class Xrd extends BaseModule
 			],
 		];
 		header('Access-Control-Allow-Origin: *');
-		$this->jsonExit($json, 'application/jrd+json; charset=utf-8');
+		$this->earlyJsonExit($json, 'application/jrd+json; charset=utf-8');
 	}
 
 	private function printJSON(string $alias, array $owner, array $avatar)
@@ -247,7 +247,7 @@ class Xrd extends BaseModule
 		];
 
 		header('Access-Control-Allow-Origin: *');
-		$this->jsonExit($json, 'application/jrd+json; charset=utf-8');
+		$this->earlyJsonExit($json, 'application/jrd+json; charset=utf-8');
 	}
 
 	private function printXML(string $alias, array $owner, array $avatar)
@@ -345,6 +345,6 @@ class Xrd extends BaseModule
 		]);
 
 		header('Access-Control-Allow-Origin: *');
-		$this->httpExit($xmlString, Response::TYPE_XML, 'application/xrd+xml');
+		$this->earlyExit($xmlString, Response::TYPE_XML, 'application/xrd+xml');
 	}
 }

--- a/src/Module/Xrd.php
+++ b/src/Module/Xrd.php
@@ -123,7 +123,7 @@ class Xrd extends BaseModule
 		}
 	}
 
-	private function printSystemJSON(array $owner)
+	private function printSystemJSON(array $owner): never
 	{
 		$baseURL = (string) $this->baseUrl;
 		$json    = [
@@ -177,7 +177,7 @@ class Xrd extends BaseModule
 		$this->earlyJsonExit($json, 'application/jrd+json; charset=utf-8');
 	}
 
-	private function printJSON(string $alias, array $owner, array $avatar)
+	private function printJSON(string $alias, array $owner, array $avatar): never
 	{
 		$baseURL = (string) $this->baseUrl;
 
@@ -250,7 +250,7 @@ class Xrd extends BaseModule
 		$this->earlyJsonExit($json, 'application/jrd+json; charset=utf-8');
 	}
 
-	private function printXML(string $alias, array $owner, array $avatar)
+	private function printXML(string $alias, array $owner, array $avatar): never
 	{
 		$baseURL = (string) $this->baseUrl;
 

--- a/tests/Unit/BaseModuleTest.php
+++ b/tests/Unit/BaseModuleTest.php
@@ -1,0 +1,132 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Unit;
+
+use Friendica\App;
+use Friendica\BaseModule;
+use Friendica\Core\EarlyExitException;
+use Friendica\Core\L10n;
+use Friendica\Module\Response;
+use Friendica\Util\Profiler;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+
+final class BaseModuleTest extends TestCase
+{
+	public function testEarlyExitCarriesResponseContent(): void
+	{
+		$module = self::createModule(exitContent: 'custom content');
+
+		try {
+			$module->handleRequest(self::createStub(ServerRequestInterface::class));
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) {
+			self::assertSame('custom content', (string) $e->getResponse()->getBody());
+		}
+	}
+
+	public function testEarlyJsonExitCarriesJsonBody(): void
+	{
+		$module = self::createModule(exitJson: ['key' => 'value']);
+
+		try {
+			$module->handleRequest(self::createStub(ServerRequestInterface::class));
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) {
+			self::assertJsonStringEqualsJsonString(
+				'{"key":"value"}',
+				(string) $e->getResponse()->getBody(),
+			);
+		}
+	}
+
+	public function testEarlyJsonErrorCarriesStatusCode(): void
+	{
+		$module = self::createModule(exitError: [404, ['error' => 'not found']]);
+
+		try {
+			$module->handleRequest(self::createStub(ServerRequestInterface::class));
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) {
+			self::assertSame(404, $e->getResponse()->getStatusCode());
+		}
+	}
+
+	public function testEarlyJsonErrorCarriesJsonBody(): void
+	{
+		$module = self::createModule(exitError: [422, ['message' => 'unprocessable']]);
+
+		try {
+			$module->handleRequest(self::createStub(ServerRequestInterface::class));
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) {
+			self::assertJsonStringEqualsJsonString(
+				'{"message":"unprocessable"}',
+				(string) $e->getResponse()->getBody(),
+			);
+		}
+	}
+
+	private static function createModule(?string $exitContent = null, mixed $exitJson = null, ?array $exitError = null): BaseModule
+	{
+		$args = self::createStub(App\Arguments::class);
+		$args->method('getMethod')->willReturn('GET');
+		$args->method('getModuleName')->willReturn('test');
+		$args->method('getQueryString')->willReturn('');
+
+		$eventDispatcher = self::createStub(EventDispatcherInterface::class);
+		$eventDispatcher->method('dispatch')->willReturnCallback(fn ($event) => $event);
+
+		return new class (
+			self::createStub(L10n::class),
+			self::createStub(App\BaseURL::class),
+			$args,
+			self::createStub(LoggerInterface::class),
+			self::createStub(Profiler::class),
+			new Response(),
+			[],
+			[],
+			$eventDispatcher,
+			$exitContent,
+			$exitJson,
+			$exitError,
+		) extends BaseModule {
+			public function __construct(
+				L10n $l10n,
+				App\BaseURL $baseUrl,
+				App\Arguments $args,
+				LoggerInterface $logger,
+				Profiler $profiler,
+				Response $response,
+				array $server,
+				array $parameters = [],
+				?EventDispatcherInterface $eventDispatcher = null,
+				private readonly ?string $exitContent = null,
+				private readonly mixed $exitJson = null,
+				private ?array $exitError = null,
+			) {
+				parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters, $eventDispatcher);
+			}
+
+			protected function get(array $request = []): void
+			{
+				if ($this->exitContent !== null) {
+					$this->earlyExit($this->exitContent);
+				} elseif ($this->exitError !== null) {
+					$this->earlyJsonError($this->exitError[0], $this->exitError[1]);
+				} elseif ($this->exitJson !== null) {
+					$this->earlyJsonExit($this->exitJson);
+				}
+			}
+		};
+	}
+}

--- a/tests/Unit/BaseModuleTest.php
+++ b/tests/Unit/BaseModuleTest.php
@@ -146,7 +146,7 @@ final class BaseModuleTest extends TestCase
 			protected function get(array $request = []): void
 			{
 				if ($this->exitContent !== null) {
-					$this->earlyExit($this->exitContent);
+					$this->earlyHttpExit($this->exitContent);
 				} elseif ($this->exitHttpError !== null) {
 					$this->earlyHttpError($this->exitHttpError[0], $this->exitHttpError[1] ?? '', $this->exitHttpError[2] ?? '');
 				} elseif ($this->exitError !== null) {

--- a/tests/Unit/BaseModuleTest.php
+++ b/tests/Unit/BaseModuleTest.php
@@ -76,7 +76,31 @@ final class BaseModuleTest extends TestCase
 		}
 	}
 
-	private static function createModule(?string $exitContent = null, mixed $exitJson = null, ?array $exitError = null): BaseModule
+	public function testEarlyHttpErrorCarriesStatusCode(): void
+	{
+		$module = self::createModule(exitHttpError: [403, 'Forbidden']);
+
+		try {
+			$module->handleRequest(self::createStub(ServerRequestInterface::class));
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) {
+			self::assertSame(403, $e->getResponse()->getStatusCode());
+		}
+	}
+
+	public function testEarlyHttpErrorCarriesBody(): void
+	{
+		$module = self::createModule(exitHttpError: [404, 'Not Found', 'Custom body']);
+
+		try {
+			$module->handleRequest(self::createStub(ServerRequestInterface::class));
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) {
+			self::assertSame('Custom body', (string) $e->getResponse()->getBody());
+		}
+	}
+
+	private static function createModule(?string $exitContent = null, mixed $exitJson = null, ?array $exitError = null, ?array $exitHttpError = null): BaseModule
 	{
 		$args = self::createStub(App\Arguments::class);
 		$args->method('getMethod')->willReturn('GET');
@@ -99,6 +123,7 @@ final class BaseModuleTest extends TestCase
 			$exitContent,
 			$exitJson,
 			$exitError,
+			$exitHttpError,
 		) extends BaseModule {
 			public function __construct(
 				L10n $l10n,
@@ -113,6 +138,7 @@ final class BaseModuleTest extends TestCase
 				private readonly ?string $exitContent = null,
 				private readonly mixed $exitJson = null,
 				private ?array $exitError = null,
+				private ?array $exitHttpError = null,
 			) {
 				parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters, $eventDispatcher);
 			}
@@ -121,6 +147,8 @@ final class BaseModuleTest extends TestCase
 			{
 				if ($this->exitContent !== null) {
 					$this->earlyExit($this->exitContent);
+				} elseif ($this->exitHttpError !== null) {
+					$this->earlyHttpError($this->exitHttpError[0], $this->exitHttpError[1] ?? '', $this->exitHttpError[2] ?? '');
 				} elseif ($this->exitError !== null) {
 					$this->earlyJsonError($this->exitError[0], $this->exitError[1]);
 				} elseif ($this->exitJson !== null) {

--- a/tests/Unit/Core/EarlyExitExceptionTest.php
+++ b/tests/Unit/Core/EarlyExitExceptionTest.php
@@ -37,6 +37,6 @@ class EarlyExitExceptionTest extends TestCase
 		$response  = $this->createStub(ResponseInterface::class);
 		$exception = new EarlyExitException($response);
 
-		self::assertInstanceOf(\RuntimeException::class, $exception);
+		self::assertInstanceOf(\RuntimeException::class, $exception); // @phpstan-ignore staticMethod.alreadyNarrowedType (intentional type hierarchy documentation)
 	}
 }

--- a/tests/Unit/Core/EarlyExitExceptionTest.php
+++ b/tests/Unit/Core/EarlyExitExceptionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Unit\Core;
+
+use Friendica\Core\EarlyExitException;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+class EarlyExitExceptionTest extends TestCase
+{
+	public function testConstructorStoresResponse(): void
+	{
+		$response = $this->createStub(ResponseInterface::class);
+
+		$exception = new EarlyExitException($response);
+
+		self::assertSame($response, $exception->getResponse());
+	}
+
+	public function testDefaultMessage(): void
+	{
+		$response  = $this->createStub(ResponseInterface::class);
+		$exception = new EarlyExitException($response);
+
+		self::assertSame('Module requested early exit', $exception->getMessage());
+	}
+
+	public function testIsRuntimeException(): void
+	{
+		$response  = $this->createStub(ResponseInterface::class);
+		$exception = new EarlyExitException($response);
+
+		self::assertInstanceOf(\RuntimeException::class, $exception);
+	}
+}

--- a/tests/src/Module/Api/Mastodon/Admin/ReportsTest.php
+++ b/tests/src/Module/Api/Mastodon/Admin/ReportsTest.php
@@ -180,7 +180,7 @@ class TestableReports extends Reports
 		$this->get($request);
 	}
 
-	public function jsonExit($content, string $content_type = 'application/json; charset=utf-8', int $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT): never
+	public function earlyJsonExit(mixed $content, string $contentType = 'application/json; charset=utf-8', int $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT): never
 	{
 		throw new TestJsonExitException($content);
 	}

--- a/tests/src/Module/Api/Twitter/Media/UploadTest.php
+++ b/tests/src/Module/Api/Twitter/Media/UploadTest.php
@@ -47,13 +47,13 @@ class UploadTest extends ApiTestCase
 		AuthTestConfig::$authenticated = false;
 
 		(new class (DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []) extends Upload {
-			public function jsonError(int $httpCode, $content, string $content_type = 'application/json')
+			public function earlyJsonError(int $httpCode, mixed $content, string $contentType = 'application/json'): never
 			{
 				if ($httpCode === 401) {
 					throw new UnauthorizedException(json_encode($content));
 				}
 
-				parent::jsonError($httpCode, $content, $content_type);
+				parent::earlyJsonError($httpCode, $content, $contentType);
 			}
 		})->run($this->httpExceptionMock);
 	}


### PR DESCRIPTION
### Background

Friendica modules use `httpExit()`, `jsonExit()`, `jsonError()` and `httpError()` to terminate request processing early — for example, when returning JSON API responses or HTTP error pages. All of these methods ultimately call `System::exit()`, which kills the PHP process immediately.

This design makes it impossible to test modules through `handleRequest()` in #16027, because `dispatch()` never returns a `ResponseInterface`. Tests have to work around `exit()` through various workarounds, limiting coverage and making refactoring harder.

### Changes

**1. `EarlyExitException` (new)**

A new exception class (`Friendica\Core\EarlyExitException`) that carries a fully built PSR-7 `ResponseInterface`. Instead of calling `exit()`, the new internal methods throw this exception.

**2. `@internal protected` replacement methods**

Four new methods on `BaseModule` — `earlyExit()`, `earlyJsonExit()`, `earlyJsonError()`, and `earlyHttpError()` — mirror the old public API but throw `EarlyExitException` instead of calling `System::exit()`. These are `@internal` and used only within Friendica's own modules.

**3. Production exit preserved**

Both code paths that invoke modules catch the exception and fall back to the original `exit()` behavior:
- `App::runFrontend()` catches `EarlyExitException` when calling `handleRequest()` and performs `echoResponse()` + `exit()`.
- The deprecated `BaseModule::run()` wraps `dispatch()` in a try/catch for `EarlyExitException`, preserving BC for any addon that still calls `run()`.

**4. Internal callers migrated**

All 209 internal calls to the old `exit()`-based methods across 147 module files were replaced with their `early*()` counterparts. The old `public` methods remain completely unchanged for addon use.

**5. Deprecation**

- **soft-deprecations:** All four old methods are marked `@deprecated` (version 2026.08).
- **hard-deprecations** All four old methods now trigger `E_USER_DEPRECATED` warnings via `@trigger_error()`.
- `EarlyExitException` is part of the public API so addons can throw it directly as a replacement.

**6. Upgrade documentation**

The `doc/en/developer/upgrade-2026.08.md` file includes Before/After migration examples for each deprecated method under Optional (Deprecations).

### Migration path for addons

```php
// Before
$this->httpExit($content);
$this->jsonExit($data);
$this->jsonError(404, ['error' => 'not found']);
$this->httpError(403, 'Forbidden');

// After
$this->response->addContent($content);
throw new \Friendica\Core\EarlyExitException($this->response->generate());

$this->response->setType(ICanCreateResponses::TYPE_JSON, 'application/json; charset=utf-8');
$this->response->addContent(json_encode($data));
throw new \Friendica\Core\EarlyExitException($this->response->generate());

$this->response->setStatus(404);
$this->response->setType(ICanCreateResponses::TYPE_JSON);
$this->response->addContent(json_encode(['error' => 'not found']));
throw new \Friendica\Core\EarlyExitException($this->response->generate());

$this->response->setStatus(403, 'Forbidden');
throw new \Friendica\Core\EarlyExitException($this->response->generate());
```

### BC Analysis

- All `public` methods (`httpExit()`, `jsonExit()`, `jsonError()`, `httpError()`) are untouched — addons relying on them continue to work (with deprecation warnings).
- New `early*()` methods are `@internal protected` (excluded from the BC promise).
- `run()` and `App::runFrontend()` both catch `EarlyExitException` and call `System::exit()`, so production behavior is identical.

### Why This Matters

This is the foundation for making Friendica modules testable via `handleRequest()`, see #16027. With `EarlyExitException`, tests can now make assertions on response status codes, headers, and body content for early-terminating modules:

```php
try {
    $module->handleRequest($request);
    $this->fail('Expected EarlyExitException');
} catch (EarlyExitException $e) {
    $this->assertSame(200, $e->getResponse()->getStatusCode());
}
```