### PR TITLE
CI: Create Github Actions for updating messages.po and rebasing

### DIFF
--- a/.github/workflows/rebase-pr.yml
+++ b/.github/workflows/rebase-pr.yml
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2010-2026 the Friendica project
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Rebase PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: 'Pull request number'
+        required: true
+        type: number
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  rebase:
+    name: Rebase pull request branch
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          startsWith(github.event.comment.body, '/rebase') &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        )
+      }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Read pull request metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_PR_NUMBER: ${{ inputs.pull_request }}
+          COMMENT_PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUMBER="$MANUAL_PR_NUMBER"
+          else
+            PR_NUMBER="$COMMENT_PR_NUMBER"
+          fi
+
+          state="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')"
+          if [ "$state" != "OPEN" ]; then
+            echo "::error::Pull request #$PR_NUMBER is $state, only open pull requests can be rebased."
+            exit 1
+          fi
+
+          head_repository="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRepository --jq '.headRepository.nameWithOwner')"
+          head_ref="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName --jq '.headRefName')"
+          base_ref="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq '.baseRefName')"
+
+          if [ "$head_repository" != "$GITHUB_REPOSITORY" ]; then
+            echo "same_repository=false" >> "$GITHUB_OUTPUT"
+            echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "number=$PR_NUMBER"
+            echo "head_ref=$head_ref"
+            echo "base_ref=$base_ref"
+            echo "same_repository=true"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment fork fallback
+        if: ${{ steps.pr.outputs.same_repository == 'false' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "I cannot automatically rebase fork pull request branches with the repository token. Please rebase the branch in the fork, then comment \`/create-messages.po\` if messages.po still needs to be regenerated."
+
+      - name: Checkout pull request branch
+        if: ${{ steps.pr.outputs.same_repository == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head_ref }}
+          path: worktree
+          fetch-depth: 0
+
+      - name: Rebase onto base branch
+        id: rebase
+        if: ${{ steps.pr.outputs.same_repository == 'true' }}
+        working-directory: worktree
+        env:
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+        run: |
+          set -euo pipefail
+
+          before="$(git rev-parse HEAD)"
+          git fetch origin "$BASE_REF"
+
+          if git merge-base --is-ancestor "origin/$BASE_REF" HEAD; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Pull request branch is already based on $BASE_REF." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if git rebase "origin/$BASE_REF"; then
+            after="$(git rev-parse HEAD)"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "before=$before" >> "$GITHUB_OUTPUT"
+            echo "after=$after" >> "$GITHUB_OUTPUT"
+          else
+            git rebase --abort || true
+            echo "::error::Automatic rebase failed because of conflicts."
+            exit 1
+          fi
+
+      - name: Push rebased branch
+        id: push_rebase
+        if: ${{ steps.rebase.outputs.changed == 'true' }}
+        working-directory: worktree
+        env:
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+        run: git push --force-with-lease origin "HEAD:$HEAD_REF"
+
+      - name: Comment no-op result
+        if: ${{ github.event_name == 'issue_comment' && steps.rebase.outputs.changed == 'false' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "This pull request branch is already up to date with the base branch."
+
+      - name: Comment rebase result
+        if: ${{ github.event_name == 'issue_comment' && steps.rebase.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+        run: gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Rebased this pull request branch onto \`$BASE_REF\`. If messages.po is still outdated, comment \`/create-messages.po\`."
+
+      - name: Comment conflict result
+        if: ${{ github.event_name == 'issue_comment' && failure() && steps.rebase.outcome == 'failure' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Automatic rebase failed because of conflicts. Please resolve the rebase manually, then comment \`/create-messages.po\` if messages.po still needs to be regenerated."
+
+      - name: Comment push failure
+        if: ${{ github.event_name == 'issue_comment' && failure() && steps.push_rebase.outcome == 'failure' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "The rebase completed locally, but pushing the rebased branch failed. The branch may have changed while this workflow was running. Please run \`/rebase\` again."

--- a/.github/workflows/update-messages-po.yml
+++ b/.github/workflows/update-messages-po.yml
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: 2010-2026 the Friendica project
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Create messages.po
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: 'Pull request number'
+        required: true
+        type: number
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  update:
+    name: Update messages.po
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          startsWith(github.event.comment.body, '/create-messages.po') &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        )
+      }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Read pull request metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_PR_NUMBER: ${{ inputs.pull_request }}
+          COMMENT_PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUMBER="$MANUAL_PR_NUMBER"
+          else
+            PR_NUMBER="$COMMENT_PR_NUMBER"
+          fi
+
+          state="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')"
+          if [ "$state" != "OPEN" ]; then
+            echo "::error::Pull request #$PR_NUMBER is $state, only open pull requests can be updated."
+            exit 1
+          fi
+
+          head_repository="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRepository --jq '.headRepository.nameWithOwner')"
+          head_ref="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName --jq '.headRefName')"
+          base_ref="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq '.baseRefName')"
+
+          if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
+            same_repository=true
+          else
+            same_repository=false
+          fi
+
+          {
+            echo "number=$PR_NUMBER"
+            echo "head_repository=$head_repository"
+            echo "head_ref=$head_ref"
+            echo "base_ref=$base_ref"
+            echo "same_repository=$same_repository"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout generator from base branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.base_ref }}
+          path: generator
+          persist-credentials: false
+
+      - name: Checkout pull request branch
+        if: ${{ steps.pr.outputs.same_repository == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head_ref }}
+          path: worktree
+
+      - name: Checkout pull request fork
+        if: ${{ steps.pr.outputs.same_repository == 'false' }}
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ steps.pr.outputs.head_repository }}
+          ref: ${{ steps.pr.outputs.head_ref }}
+          path: worktree
+          persist-credentials: false
+
+      - name: Regenerate messages.po
+        run: |
+          set -euo pipefail
+
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE/worktree:/data" \
+            -v "$GITHUB_WORKSPACE/generator/bin/run_xgettext.sh:/data/bin/run_xgettext.sh:ro" \
+            -w /data \
+            friendicaci/transifex \
+            /bin/sh /data/bin/run_xgettext.sh
+
+      - name: Prepare update
+        id: update
+        working-directory: worktree
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- view/lang/C/messages.po; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "messages.po is already up to date." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          git diff -- view/lang/C/messages.po > "$GITHUB_WORKSPACE/messages-po-update.patch"
+          cp view/lang/C/messages.po "$GITHUB_WORKSPACE/messages.po"
+
+      - name: Commit and push update
+        id: push
+        if: ${{ steps.update.outputs.has_changes == 'true' && steps.pr.outputs.same_repository == 'true' }}
+        working-directory: worktree
+        env:
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add view/lang/C/messages.po
+          git commit -m "Update messages.po"
+
+          if git push origin "HEAD:$HEAD_REF"; then
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+            echo "Committed and pushed an updated messages.po to $HEAD_REF." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Could not push the messages.po update. Uploading a patch artifact instead."
+          fi
+
+      - name: Upload update artifact
+        id: artifact
+        if: ${{ steps.update.outputs.has_changes == 'true' && (steps.pr.outputs.same_repository == 'false' || steps.push.outputs.pushed == 'false') }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: messages-po-update-pr-${{ steps.pr.outputs.number }}
+          path: |
+            messages.po
+            messages-po-update.patch
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Summarize artifact fallback
+        if: ${{ steps.update.outputs.has_changes == 'true' && (steps.pr.outputs.same_repository == 'false' || steps.push.outputs.pushed == 'false') }}
+        run: |
+          {
+            echo "messages.po was regenerated, but this workflow did not push to the pull request branch."
+            echo
+            echo "Download the messages-po-update-pr-${{ steps.pr.outputs.number }} artifact from this run and apply messages-po-update.patch, or replace view/lang/C/messages.po with the artifact copy."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment no-op result
+        if: ${{ github.event_name == 'issue_comment' && steps.update.outputs.has_changes == 'false' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "messages.po is already up to date."
+
+      - name: Comment push result
+        if: ${{ github.event_name == 'issue_comment' && steps.push.outputs.pushed == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Regenerated messages.po and pushed an \`Update messages.po\` commit to this pull request branch."
+
+      - name: Comment artifact fallback
+        if: ${{ github.event_name == 'issue_comment' && steps.update.outputs.has_changes == 'true' && (steps.pr.outputs.same_repository == 'false' || steps.push.outputs.pushed == 'false') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          ARTIFACT_URL: ${{ steps.artifact.outputs.artifact-url }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Regenerated messages.po, but I could not push to this pull request branch. Download the messages-po-update-pr-$PR_NUMBER artifact and apply messages-po-update.patch: $ARTIFACT_URL"

--- a/doc/en/developer/translations.md
+++ b/doc/en/developer/translations.md
@@ -35,6 +35,11 @@ docker run --rm -v $PWD:/data -w /data friendicaci/transifex bin/run_xgettext.sh
 
 Once you have added new translation strings in your code changes, please run `bin/run_xgettext.sh` from the base Friendica directory and commit the updated `view/lang/C/messages.po` to your branch.
 
+If a contributor cannot run the script locally, maintainers can comment `/create-messages.po` on the pull request or start the GitHub Actions workflow `Create messages.po` and enter the pull request number.
+For branches in the main Friendica repository, the workflow commits the regenerated `view/lang/C/messages.po` directly to the pull request branch.
+For forked pull requests or branches that cannot be pushed to, the workflow uploads a `messages-po-update-pr-<number>` artifact containing the updated file and a patch.
+If the branch needs to be rebased first, maintainers can comment `/rebase` on a pull request branch in the main Friendica repository or start the GitHub Actions workflow `Rebase PR`, then run `/create-messages.po` if needed.
+
 ### Addon
 
 If you have the `friendica-addons` repository in the `addon` directory of your Friendica cloned repository, just run `bin/run_xgettext.sh -a <addon_name>` from the base Friendica directory.


### PR DESCRIPTION
Because of the re-ocurring problem of recreating messages.po - and sometimes because a PR needs a "fast forward" rebase for it, I created two small workflows.

These two commands can now be added set as comment.
Both are currently only available with owner, member or collaborator rights (safety first :) )

- `/create-messages.po`: executes a full recreation of the current `messages.po` file and commits its output
- `/rebase`: tries to "fast forward" a Pull Request onto the current base-branch, so f.e. `messsages.po` will be created on the latest base (otherwise it will result in a merge-conflict sometime)

tbh I'm not totally sure if it will be really helpful, I read some articles about it and tried it :-) 