### PR TITLE
Issue #16028: Add private mentions via @!handle

### DIFF
--- a/doc/de/user/tags-and-mentions.md
+++ b/doc/de/user/tags-and-mentions.md
@@ -26,6 +26,10 @@ Dieses Protokoll wird von Friendica, GNU Social und anderen Systemen genutzt, is
 
 Friendica unterscheidet bei Tags nicht zwischen Personen und Gruppen (einige andere Netzwerke nutzen "!circle", um solche zu markieren).
 
+Um einen Kontakt privat zu adressieren, schreibe ein Ausrufezeichen zwischen das „@"-Zeichen und den Namen, z.B. <i>@!mike</i> oder <i>@!mike@macgirvin.com</i>.
+Ein neuer Beitrag mit einer solchen Erwähnung wird automatisch als privater Beitrag gesendet, der nur für die privat erwähnten Kontakte sichtbar ist.
+Normale @-Erwähnungen im selben Beitrag erhalten den Beitrag nicht.
+
 
 **Thematische Tags**
 

--- a/doc/en/user/tags-and-mentions.md
+++ b/doc/en/user/tags-and-mentions.md
@@ -32,6 +32,10 @@ If you want to post something exclusively to a group (e.g. the support group) pl
 So !helpers will be an exclusive posting to the support group if you are connected with the group.
 If you select a group from the ACL a !-mention will be added automatically to your posting.
 
+To address a contact privately, prefix the mention with an exclamation mark after the "@" character, e.g. @!mike or @!mike@macgirvin.com.
+A new post containing such a mention is automatically sent as a private post that is only visible to the privately mentioned contacts.
+Regular @-mentions in the same post will not receive the post.
+
 If you sort your contacts into circles, you cannot @-mention these circles.
 But you can select the circle in the access control when creating a new posting, to allow (or disallow) a certain circle of people to see the posting.
 See [Circles and privacy](help/user/circles-and-privacy) for more details about grouping your contacts.

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -157,7 +157,7 @@ class Item
 	 * @param string $tag         the tag to replace
 	 * @param string $network     The network of the post
 	 *
-	 * @return array|bool ['replaced' => $replaced, 'contact' => $contact] or "false" on if already replaced
+	 * @return array|bool ['replaced' => $replaced, 'contact' => $contact, 'private' => $private] or "false" on if already replaced
 	 * @throws InternalServerErrorException
 	 * @throws ImagickException
 	 */
@@ -165,17 +165,22 @@ class Item
 	{
 		$replaced = false;
 		$contact  = [];
+		$private  = false;
 
 		//is it a person tag?
 		if (Tag::isType($tag, Tag::MENTION, Tag::IMPLICIT_MENTION, Tag::EXCLUSIVE_MENTION)) {
-			$tag_type = substr($tag, 0, 1);
+			// A mention prefixed with "@!" addresses the contact privately,
+			// in the body it is expanded to a regular mention.
+			$private    = str_starts_with($tag, '@!');
+			$tag_type   = substr($tag, 0, 1);
+			$tag_prefix = $private ? '@!' : $tag_type;
 			//is it already replaced?
 			if (strpos($tag, '[url=')) {
 				return $replaced;
 			}
 
 			//get the person's name
-			$name = substr($tag, 1);
+			$name = substr($tag, strlen($tag_prefix));
 
 			// Sometimes the tag detection doesn't seem to work right
 			// This is some workaround
@@ -246,11 +251,11 @@ class Item
 				// create profile link
 				$profile = str_replace(',', '%2c', $profile);
 				$newtag  = $tag_type . '[url=' . $profile . ']' . $newname . '[/url]';
-				$body    = str_replace($tag_type . $name, $newtag, $body);
+				$body    = str_replace($tag_prefix . $name, $newtag, $body);
 			}
 		}
 
-		return ['replaced' => $replaced, 'contact' => $contact];
+		return ['replaced' => $replaced, 'contact' => $contact, 'private' => $private];
 	}
 
 	/**
@@ -478,8 +483,14 @@ class Item
 		$group_contact  = [];
 		$receivers      = [];
 
+		// Mentions prefixed with "@!" address the contact privately
+		$private_tags = array_filter(BBCode::getTags($item['body']), function ($tag) {
+			return str_starts_with($tag, '@!');
+		});
+
 		// Convert mentions in the body to a unified format
-		$item['body'] = BBCode::setMentions($item['body'], $item['uid'], $item['network']);
+		$private_contacts = [];
+		$item['body']     = BBCode::setMentions($item['body'], $item['uid'], $item['network'], $private_contacts);
 
 		// Search for group mentions
 		foreach (Tag::getFromBody($item['body'], Tag::TAG_CHARACTER[Tag::MENTION] . Tag::TAG_CHARACTER[Tag::EXCLUSIVE_MENTION]) as $tag) {
@@ -543,6 +554,32 @@ class Item
 				$item['allow_cid'] = '';
 				$item['allow_gid'] = '';
 			}
+		} elseif (!empty($private_tags) && ($item['gravity'] == ItemModel::GRAVITY_PARENT)) {
+			// The post contains privately addressed mentions ("@!"), it is only sent to these contacts
+			$private_receivers = [];
+			foreach ($private_contacts as $private_contact) {
+				$private_receivers[] = $private_contact['id'];
+			}
+
+			if (empty($private_receivers)) {
+				// For security reasons a post without any resolvable private mention receiver will be a post to yourself
+				$self = Contact::selectFirst(['id'], ['uid' => $item['uid'], 'self' => true]);
+				if (!empty($self)) {
+					$private_receivers[] = $self['id'];
+				}
+			}
+
+			$item['private']   = ItemModel::PRIVATE;
+			$item['allow_cid'] = '';
+			$item['allow_gid'] = '';
+			$item['deny_cid']  = '';
+			$item['deny_gid']  = '';
+
+			foreach (array_unique($private_receivers) as $receiver) {
+				$item['allow_cid'] .= '<' . $receiver . '>';
+			}
+
+			$this->logger->info('Post with privately addressed mentions', ['receivers' => $private_receivers]);
 		} elseif ($setPermissions) {
 			if (empty($receivers)) {
 				// For security reasons direct posts without any receiver will be posts to yourself

--- a/src/Content/Item.php
+++ b/src/Content/Item.php
@@ -182,6 +182,10 @@ class Item
 			//get the person's name
 			$name = substr($tag, strlen($tag_prefix));
 
+			if ($name === '') {
+				return $replaced;
+			}
+
 			// Sometimes the tag detection doesn't seem to work right
 			// This is some workaround
 			$nameparts = explode(' ', $name);
@@ -485,7 +489,7 @@ class Item
 
 		// Mentions prefixed with "@!" address the contact privately
 		$private_tags = array_filter(BBCode::getTags($item['body']), function ($tag) {
-			return str_starts_with($tag, '@!');
+			return str_starts_with($tag, '@!') && (strlen($tag) > 2);
 		});
 
 		// Convert mentions in the body to a unified format

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2486,17 +2486,18 @@ class BBCode
 	/**
 	 * Replaces mentions in the provided message body in BBCode links for the provided user and network if any
 	 *
-	 * @param string $body HTML/BBCode
-	 * @param int $profile_uid Profile user id
-	 * @param string $network Network name
+	 * @param string     $body             HTML/BBCode
+	 * @param int        $profile_uid      Profile user id
+	 * @param string     $network          Network name
+	 * @param array|null $private_contacts Filled with the contacts of mentions prefixed with "@!" when provided
 	 * @return string HTML/BBCode with inserted images
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 * @throws \ImagickException
 	 */
-	public static function setMentions(string $body, $profile_uid = 0, $network = '')
+	public static function setMentions(string $body, $profile_uid = 0, $network = '', ?array &$private_contacts = null)
 	{
 		DI::profiler()->startRecording('rendering');
-		$body = self::performWithEscapedTags($body, ['noparse', 'pre', 'code', 'img'], function ($body) use ($profile_uid, $network) {
+		$body = self::performWithEscapedTags($body, ['noparse', 'pre', 'code', 'img'], function ($body) use ($profile_uid, $network, &$private_contacts) {
 			$tags = self::getTags($body);
 
 			$tagged = [];
@@ -2520,6 +2521,10 @@ class BBCode
 
 				if (($success = Item::replaceTag($body, $profile_uid, $tag, $network)) && $success['replaced']) {
 					$tagged[] = $tag;
+
+					if (($private_contacts !== null) && !empty($success['private'])) {
+						$private_contacts[] = $success['contact'];
+					}
 				}
 			}
 

--- a/src/Content/Text/BBCode.php
+++ b/src/Content/Text/BBCode.php
@@ -2399,7 +2399,7 @@ class BBCode
 			// Match full names against @tags including the space between first and last
 			// We will look these up afterward to see if they are full names or not recognisable.
 
-			if (preg_match_all('/(@[^ \x0D\x0A,:?]+ [^ \x0D\x0A@,:?]+)([ \x0D\x0A@,:?]|$)/', (string) $string, $matches)) {
+			if (preg_match_all('/(@[^! \x0D\x0A,:?]+ [^ \x0D\x0A@,:?]+)([ \x0D\x0A@,:?]|$)/', (string) $string, $matches)) {
 				foreach ($matches[1] as $match) {
 					if (strstr($match, ']')) {
 						// we might be inside a bbcode color tag - leave it alone

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -344,6 +344,18 @@ Karl Marx - Die ursprüngliche Akkumulation
 				[],
 				'https://github.com/uBlockOrigin/uBOL-home/wiki/Frequently-asked-questions-(FAQ)#if-i-install-ubol-will-i-see-a-difference-with-ubo',
 			],
+			'private-mention-handle' => [
+				['@!alice@example.com'],
+				'@!alice@example.com',
+			],
+			'private-mention-nick' => [
+				['@!alice'],
+				'Hello @!alice',
+			],
+			'private-mention-mixed-with-regular-mention' => [
+				['@!alice', '@bob'],
+				'@!alice @bob',
+			],
 		];
 	}
 

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -356,6 +356,10 @@ Karl Marx - Die ursprüngliche Akkumulation
 				['@!alice', '@bob'],
 				'@!alice @bob',
 			],
+			'private-mention-not-swallowing-trailing-exclamation' => [
+				['@!righthandle'],
+				'@!righthandle heelo! i just want to test the @!',
+			],
 		];
 	}
 


### PR DESCRIPTION
This PR adds support for private mentions using the @!handle syntax.

A post containing @!mentions is automatically sent as a private post, visible only to the mentioned contacts. Regular @mentions in the same post do not receive it.

Changes:

`src/Content/Item.php: `Detect private mentions and set permissions
`src/Content/Text/BBCode.php:` Pass through private mention contacts
`tests/src/Content/Text/BBCodeTest.php`: Add test cases for @! mentions
`doc/en/user/tags-and-mentions.md `& `doc/de/user/tags-and-mentions.md`: Documentation

closes #16028 