### PR TITLE
fix(doc): remove .md extension from internal help links

### DIFF
--- a/doc/en/developer/addon-development.md
+++ b/doc/en/developer/addon-development.md
@@ -8,9 +8,9 @@ Modules work by intercepting specific page requests (by URL path).
 
 Addon developers should check the following upgrade notes for breaking changes and deprecations:
 
-- [Upgrade from 2026.05 to 2026.08](upgrade-2026.08.md)
-- [Upgrade from 2026.01 to 2026.05](upgrade-2026.05.md)
-- [Upgrade from 2024.12-1 to 2026.01](upgrade-2026.01.md)
+- [Upgrade from 2026.05 to 2026.08](upgrade-2026.08)
+- [Upgrade from 2026.01 to 2026.05](upgrade-2026.05)
+- [Upgrade from 2024.12-1 to 2026.01](upgrade-2026.01)
 
 ## Naming
 

--- a/doc/en/developer/addon-development.md
+++ b/doc/en/developer/addon-development.md
@@ -8,9 +8,9 @@ Modules work by intercepting specific page requests (by URL path).
 
 Addon developers should check the following upgrade notes for breaking changes and deprecations:
 
-- [Upgrade from 2026.05 to 2026.08](upgrade-2026.08)
-- [Upgrade from 2026.01 to 2026.05](upgrade-2026.05)
-- [Upgrade from 2024.12-1 to 2026.01](upgrade-2026.01)
+- [Upgrade from 2026.05 to 2026.08](help/developer/upgrade-2026.08)
+- [Upgrade from 2026.01 to 2026.05](help/developer/upgrade-2026.05)
+- [Upgrade from 2024.12-1 to 2026.01](help/developer/upgrade-2026.01)
 
 ## Naming
 

--- a/doc/en/developer/upgrade-2026.01.md
+++ b/doc/en/developer/upgrade-2026.01.md
@@ -4,7 +4,7 @@ Upgrade from 2024.12-1 to 2026.01
 All notable changes to **Friendica** will be documented in this file.
 As an *Addon or Theme maintainer* you can inform yourself about all breaking changes and deprecations.
 
-This project [promises Backward Compatibility](index#backward-compatibility).
+This project [promises Backward Compatibility](help/developer/index#backward-compatibility).
 
 Mandatory (Breaking changes)
 ----------------------------

--- a/doc/en/developer/upgrade-2026.01.md
+++ b/doc/en/developer/upgrade-2026.01.md
@@ -4,7 +4,7 @@ Upgrade from 2024.12-1 to 2026.01
 All notable changes to **Friendica** will be documented in this file.
 As an *Addon or Theme maintainer* you can inform yourself about all breaking changes and deprecations.
 
-This project [promises Backward Compatibility](index.md#backward-compatibility).
+This project [promises Backward Compatibility](index#backward-compatibility).
 
 Mandatory (Breaking changes)
 ----------------------------

--- a/doc/en/developer/upgrade-2026.05.md
+++ b/doc/en/developer/upgrade-2026.05.md
@@ -4,7 +4,7 @@ Upgrade from 2026.01 to 2026.05
 All notable changes to **Friendica** will be documented in this file.
 As an *Addon or Theme maintainer* you can inform yourself about all breaking changes and deprecations.
 
-This project [promises Backward Compatibility](index#backward-compatibility).
+This project [promises Backward Compatibility](help/developer/index#backward-compatibility).
 
 Mandatory (Breaking changes)
 ----------------------------

--- a/doc/en/developer/upgrade-2026.05.md
+++ b/doc/en/developer/upgrade-2026.05.md
@@ -4,7 +4,7 @@ Upgrade from 2026.01 to 2026.05
 All notable changes to **Friendica** will be documented in this file.
 As an *Addon or Theme maintainer* you can inform yourself about all breaking changes and deprecations.
 
-This project [promises Backward Compatibility](index.md#backward-compatibility).
+This project [promises Backward Compatibility](index#backward-compatibility).
 
 Mandatory (Breaking changes)
 ----------------------------

--- a/doc/en/developer/upgrade-2026.08.md
+++ b/doc/en/developer/upgrade-2026.08.md
@@ -4,7 +4,7 @@ Upgrade from 2026.04 to 2026.08
 All notable changes to **Friendica** will be documented in this file.
 As an *Addon or Theme maintainer* you can inform yourself about all breaking changes and deprecations.
 
-This project [promises Backward Compatibility](index#backward-compatibility).
+This project [promises Backward Compatibility](help/developer/index#backward-compatibility).
 
 > ℹ️ **Note:**
 > Friendica 2026.08 requires PHP 8.2 or higher! Support for PHP 7.4, 8.0 and 8.1 has been dropped.

--- a/doc/en/developer/upgrade-2026.08.md
+++ b/doc/en/developer/upgrade-2026.08.md
@@ -4,7 +4,7 @@ Upgrade from 2026.04 to 2026.08
 All notable changes to **Friendica** will be documented in this file.
 As an *Addon or Theme maintainer* you can inform yourself about all breaking changes and deprecations.
 
-This project [promises Backward Compatibility](index.md#backward-compatibility).
+This project [promises Backward Compatibility](index#backward-compatibility).
 
 > ℹ️ **Note:**
 > Friendica 2026.08 requires PHP 8.2 or higher! Support for PHP 7.4, 8.0 and 8.1 has been dropped.


### PR DESCRIPTION
Fix broken internal links in the developer documentation. The .md file extensions in markdown links caused 404 errors in the Friendica help system, since the Help module already appends .md when loading files from the URL path.