### PR TITLE
Nav & Action Button Labels + Streamlining

### DIFF
--- a/src/Content/Conversation/PostTemplateBuilder.php
+++ b/src/Content/Conversation/PostTemplateBuilder.php
@@ -284,6 +284,7 @@ final class PostTemplateBuilder
 		$eventData = $this->buildEventData($item, $writable);
 		$isevent   = $eventData['isevent'];
 		$attend    = $eventData['attend'];
+		$attend_label = $eventData['attend_label'];
 
 		$reactionData = $this->buildReactionData($item, $convResponses);
 		$emojis       = $reactionData['emojis'];
@@ -319,6 +320,7 @@ final class PostTemplateBuilder
 			'guid'                   => urlencode((string) $item['guid']),
 			'isevent'                => $isevent,
 			'attend'                 => $attend,
+			'attend_label'           => $attend_label,
 			'linktitle'              => $this->l10n->t('View %s\'s profile @ %s', $profileName, $item['author-link'] ?? ''),
 			'olinktitle'             => $this->l10n->t('View %s\'s profile @ %s', $owner_name, $item['owner-link'] ?? ''),
 			'to'                     => $this->l10n->t('to'),
@@ -574,6 +576,7 @@ final class PostTemplateBuilder
 	{
 		$isevent = false;
 		$attend  = [];
+		$attend_label = [];
 
 		if (($item['object-type'] ?? '') === Activity\ObjectType::EVENT
 			&& in_array($item['network'] ?? '', [Protocol::ACTIVITYPUB, Protocol::DFRN, Protocol::DIASPORA])) {
@@ -584,10 +587,15 @@ final class PostTemplateBuilder
 					$this->l10n->t('I will not attend'),
 					$this->l10n->t('I might attend'),
 				];
+				$attend_label = [
+					$this->l10n->t('Going'),
+					$this->l10n->t('Can\'t Go'),
+					$this->l10n->t('Maybe'),
+				]
 			}
 		}
 
-		return ['isevent' => $isevent, 'attend' => $attend];
+		return ['isevent' => $isevent, 'attend' => $attend, 'attend_label' => $attend_label];
 	}
 
 	/**

--- a/src/Content/Conversation/PostTemplateBuilder.php
+++ b/src/Content/Conversation/PostTemplateBuilder.php
@@ -570,7 +570,7 @@ final class PostTemplateBuilder
 	 *
 	 * @param array<string, mixed> $item
 	 * @param bool $writable
-	 * @return array{isevent: bool, attend: array, $attend_label: array}
+	 * @return array{isevent: bool, attend: array, attend_label: array}
 	 */
 	private function buildEventData(array $item, bool $writable): array
 	{

--- a/src/Content/Conversation/PostTemplateBuilder.php
+++ b/src/Content/Conversation/PostTemplateBuilder.php
@@ -281,9 +281,9 @@ final class PostTemplateBuilder
 		$ago          = $temporalData['ago'];
 
 		// process action responses - e.g. like/dislike/attend/agree/whatever
-		$eventData = $this->buildEventData($item, $writable);
-		$isevent   = $eventData['isevent'];
-		$attend    = $eventData['attend'];
+		$eventData    = $this->buildEventData($item, $writable);
+		$isevent      = $eventData['isevent'];
+		$attend       = $eventData['attend'];
 		$attend_label = $eventData['attend_label'];
 
 		$reactionData = $this->buildReactionData($item, $convResponses);

--- a/src/Content/Conversation/PostTemplateBuilder.php
+++ b/src/Content/Conversation/PostTemplateBuilder.php
@@ -570,7 +570,7 @@ final class PostTemplateBuilder
 	 *
 	 * @param array<string, mixed> $item
 	 * @param bool $writable
-	 * @return array{isevent: bool, attend: array}
+	 * @return array{isevent: bool, attend: array, $attend_label: array}
 	 */
 	private function buildEventData(array $item, bool $writable): array
 	{

--- a/src/Content/Conversation/PostTemplateBuilder.php
+++ b/src/Content/Conversation/PostTemplateBuilder.php
@@ -591,7 +591,7 @@ final class PostTemplateBuilder
 					$this->l10n->t('Going'),
 					$this->l10n->t('Can\'t Go'),
 					$this->l10n->t('Maybe'),
-				]
+				];
 			}
 		}
 

--- a/src/Content/Conversation/PostTemplateBuilder.php
+++ b/src/Content/Conversation/PostTemplateBuilder.php
@@ -574,8 +574,8 @@ final class PostTemplateBuilder
 	 */
 	private function buildEventData(array $item, bool $writable): array
 	{
-		$isevent = false;
-		$attend  = [];
+		$isevent      = false;
+		$attend       = [];
 		$attend_label = [];
 
 		if (($item['object-type'] ?? '') === Activity\ObjectType::EVENT

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -78,7 +78,7 @@ class Nav
 		$nav_info = $this->getInfo();
 
 		if ($this->session->getLocalUserNickname()) {
-			$profile_link = $this->session->getLocalUserNickname() . '/profile';
+			$profile_link = 'profile/' . $this->session->getLocalUserNickname() . '/profile';
 		} else {
 			$profile_link = false;
 		}

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -212,7 +212,7 @@ class Nav
 			$userinfo = [
 				'icon' => Contact::getMicro($contact),
 				'name' => $contact['name'],
-				'link' => 'profile/' . $this->session->getLocalUserNickname(),
+				'link' => ['profile/' . $this->session->getLocalUserNickname() . '/profile', $this->l10n->t('Profile'), '', $this->l10n->t('My profile')],
 			];
 		}
 

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -86,6 +86,8 @@ class Nav
 			'$emptynotifications'   => $this->l10n->t('Nothing new here'),
 			'$loadingnotifications' => $this->l10n->t('Loading...'),
 			'$userinfo'             => $nav_info['userinfo'],
+			'$profile_link'         => 'profile/' . $this->session->getLocalUserNickname() . '/profile',
+			'$profile_link_title'	=> $this->l10n->t('My Profile'),
 			'$nickname'             => $this->session->getLocalUserNickname(),
 			'$sel'                  => self::$selected,
 			'$apps'                 => $this->getAppMenu(),
@@ -262,9 +264,6 @@ class Nav
 		if ($this->session->getLocalUserNickname()) {
 			$nav['network'] = ['network', $this->l10n->t('Home'), '', $this->l10n->t('Home')];
 
-			// Only used by Vier
-			$nav['my_profile'] = ['profile/' . $this->session->getLocalUserNickname(), $this->l10n->t('Profile'), '', ''];
-
 			// Don't show notifications for public communities
 			if ($this->session->get('page_flags', '') != User::PAGE_FLAGS_COMMUNITY) {
 				$nav['introductions']         = ['notifications/intros', $this->l10n->t('Introductions'), '', $this->l10n->t('Friend Requests')];
@@ -278,11 +277,12 @@ class Nav
 			$nav['messages']['outbox'] = ['message/sent', $this->l10n->t('Outbox'), '', $this->l10n->t('Outbox')];
 			$nav['messages']['new']    = ['message/new', $this->l10n->t('New Message'), '', $this->l10n->t('New Message')];
 
-			$nav_accounts_name        = $this->l10n->t('Accounts');
 			$nav_accounts_description = $this->l10n->t('Manage other accounts, including groups and pages');
 			if (User::hasIdentities($this->session->getSubManagedUserId() ?: $this->session->getLocalUserId())) {
+				$nav_accounts_name = $this->l10n->t('Switch Accounts');
 				$nav['delegation'] = ['delegation', $nav_accounts_name, '', $nav_accounts_description];
 			} else {
+				$nav_accounts_name = $this->l10n->t('Add Account');
 				$nav['delegation'] = ['settings/delegation', $nav_accounts_name, '', $nav_accounts_description];
 			}
 

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -87,7 +87,7 @@ class Nav
 			'$loadingnotifications' => $this->l10n->t('Loading...'),
 			'$userinfo'             => $nav_info['userinfo'],
 			'$profile_link'         => 'profile/' . $this->session->getLocalUserNickname() . '/profile',
-			'$profile_link_title'	=> $this->l10n->t('My Profile'),
+			'$profile_link_title'   => $this->l10n->t('My Profile'),
 			'$nickname'             => $this->session->getLocalUserNickname(),
 			'$sel'                  => self::$selected,
 			'$apps'                 => $this->getAppMenu(),

--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -77,6 +77,12 @@ class Nav
 
 		$nav_info = $this->getInfo();
 
+		if ($this->session->getLocalUserNickname()) {
+			$profile_link = $this->session->getLocalUserNickname() . '/profile';
+		} else {
+			$profile_link = false;
+		}
+
 		$tpl = Renderer::getMarkupTemplate('nav.tpl');
 
 		$nav .= Renderer::replaceMacros($tpl, [
@@ -86,7 +92,7 @@ class Nav
 			'$emptynotifications'   => $this->l10n->t('Nothing new here'),
 			'$loadingnotifications' => $this->l10n->t('Loading...'),
 			'$userinfo'             => $nav_info['userinfo'],
-			'$profile_link'         => 'profile/' . $this->session->getLocalUserNickname() . '/profile',
+			'$profile_link'         => $profile_link,
 			'$profile_link_title'   => $this->l10n->t('My Profile'),
 			'$nickname'             => $this->session->getLocalUserNickname(),
 			'$sel'                  => self::$selected,

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.08-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-11 23:35+0200\n"
+"POT-Creation-Date: 2026-08-17 00:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,12 +81,12 @@ msgstr ""
 msgid "Permission denied."
 msgstr ""
 
-#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:276
+#: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:281
 #: view/theme/frio/theme.php:236
 msgid "Messages"
 msgstr ""
 
-#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:279
+#: mod/message.php:35 mod/message.php:117 src/Content/Nav.php:284
 msgid "New Message"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 
 #: mod/message.php:191 mod/message.php:349 src/App/Page.php:277
 #: src/Content/Conversation/ConversationRenderer.php:539
-#: src/Content/Conversation/PostTemplateBuilder.php:391
+#: src/Content/Conversation/PostTemplateBuilder.php:393
 #: src/Content/Conversation/StatusEditor.php:182
 #: src/Module/Item/Compose.php:181 src/Module/Post/Edit.php:156
 msgid "Please wait"
@@ -1157,7 +1157,7 @@ msgid "Delete Selected Items"
 msgstr ""
 
 #: src/Content/Conversation/ConversationRenderer.php:467
-#: src/Content/Conversation/PostTemplateBuilder.php:524
+#: src/Content/Conversation/PostTemplateBuilder.php:526
 msgid "Select"
 msgstr ""
 
@@ -1166,24 +1166,24 @@ msgid "Pinned item"
 msgstr ""
 
 #: src/Content/Conversation/ConversationRenderer.php:501
-#: src/Content/Conversation/PostTemplateBuilder.php:322
-#: src/Content/Conversation/PostTemplateBuilder.php:323
+#: src/Content/Conversation/PostTemplateBuilder.php:324
+#: src/Content/Conversation/PostTemplateBuilder.php:325
 #, php-format
 msgid "View %s's profile @ %s"
 msgstr ""
 
 #: src/Content/Conversation/ConversationRenderer.php:514
-#: src/Content/Conversation/PostTemplateBuilder.php:310
+#: src/Content/Conversation/PostTemplateBuilder.php:311
 msgid "Categories:"
 msgstr ""
 
 #: src/Content/Conversation/ConversationRenderer.php:515
-#: src/Content/Conversation/PostTemplateBuilder.php:311
+#: src/Content/Conversation/PostTemplateBuilder.php:312
 msgid "Filed under:"
 msgstr ""
 
 #: src/Content/Conversation/ConversationRenderer.php:522
-#: src/Content/Conversation/PostTemplateBuilder.php:338
+#: src/Content/Conversation/PostTemplateBuilder.php:340
 #, php-format
 msgid "%s from %s"
 msgstr ""
@@ -1193,7 +1193,7 @@ msgid "View in context"
 msgstr ""
 
 #: src/Content/Conversation/ConversationRenderer.php:540
-#: src/Content/Conversation/PostTemplateBuilder.php:392
+#: src/Content/Conversation/PostTemplateBuilder.php:394
 msgid "Loading ..."
 msgstr ""
 
@@ -1422,44 +1422,44 @@ msgstr ""
 msgid "Remote comment"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:324
+#: src/Content/Conversation/PostTemplateBuilder.php:326
 msgid "to"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:325
+#: src/Content/Conversation/PostTemplateBuilder.php:327
 #: src/Module/Profile/Schedule.php:101
 msgid "via"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:326
+#: src/Content/Conversation/PostTemplateBuilder.php:328
 msgid "Wall-to-Wall"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:327
+#: src/Content/Conversation/PostTemplateBuilder.php:329
 msgid "via Wall-To-Wall:"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:365
+#: src/Content/Conversation/PostTemplateBuilder.php:367
 #: src/Content/Item.php:443
 msgid "Raw content"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:380
+#: src/Content/Conversation/PostTemplateBuilder.php:382
 msgid "Load more comments"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:385
-#: src/Content/Conversation/PostTemplateBuilder.php:918
+#: src/Content/Conversation/PostTemplateBuilder.php:387
+#: src/Content/Conversation/PostTemplateBuilder.php:926
 #: src/Module/Moderation/Reports.php:242
 msgid "Comment"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:386
+#: src/Content/Conversation/PostTemplateBuilder.php:388
 #, php-format
 msgid "Reply to %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:389
+#: src/Content/Conversation/PostTemplateBuilder.php:391
 #: src/Module/BaseProfile.php:141 src/Module/Contact.php:402
 #: src/Module/Contact.php:540 src/Module/Conversation/Channel.php:98
 #: src/Module/Conversation/Community.php:91
@@ -1468,286 +1468,298 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:409
+#: src/Content/Conversation/PostTemplateBuilder.php:411
 msgid "Notifier task is pending"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:410
+#: src/Content/Conversation/PostTemplateBuilder.php:412
 msgid "Delivery to remote servers is pending"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:411
+#: src/Content/Conversation/PostTemplateBuilder.php:413
 msgid "Delivery to remote servers is underway"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:412
+#: src/Content/Conversation/PostTemplateBuilder.php:414
 msgid "Delivery to remote servers is mostly done"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:413
+#: src/Content/Conversation/PostTemplateBuilder.php:415
 msgid "Delivery to remote servers is done"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:421
+#: src/Content/Conversation/PostTemplateBuilder.php:423
 #, php-format
 msgid "in reply to %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:423
+#: src/Content/Conversation/PostTemplateBuilder.php:425
 msgid "Parent is probably private or not federated."
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:424
+#: src/Content/Conversation/PostTemplateBuilder.php:426
 msgid "Show comments"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:425
+#: src/Content/Conversation/PostTemplateBuilder.php:427
 msgid "Close comments"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:447
+#: src/Content/Conversation/PostTemplateBuilder.php:449
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:448
+#: src/Content/Conversation/PostTemplateBuilder.php:450
 msgid "Show more"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:449
+#: src/Content/Conversation/PostTemplateBuilder.php:451
 msgid "Show fewer"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:525
+#: src/Content/Conversation/PostTemplateBuilder.php:527
 msgid "Delete globally"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:525
+#: src/Content/Conversation/PostTemplateBuilder.php:527
 msgid "Remove locally"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:532
+#: src/Content/Conversation/PostTemplateBuilder.php:534
 #, php-format
 msgid "Block %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:537
+#: src/Content/Conversation/PostTemplateBuilder.php:539
 #, php-format
 msgid "Ignore %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:542
+#: src/Content/Conversation/PostTemplateBuilder.php:544
 #, php-format
 msgid "Collapse %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:546
+#: src/Content/Conversation/PostTemplateBuilder.php:548
 msgid "Report this post"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:557
+#: src/Content/Conversation/PostTemplateBuilder.php:559
 #: src/Content/Item.php:436
 #, php-format
 msgid "Ignore %s server"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:582
+#: src/Content/Conversation/PostTemplateBuilder.php:585
 msgid "I will attend"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:583
+#: src/Content/Conversation/PostTemplateBuilder.php:586
 msgid "I will not attend"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:584
+#: src/Content/Conversation/PostTemplateBuilder.php:587
 msgid "I might attend"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:608
+#: src/Content/Conversation/PostTemplateBuilder.php:590
+msgid "Going"
+msgstr ""
+
+#: src/Content/Conversation/PostTemplateBuilder.php:591
+msgid "Can't Go"
+msgstr ""
+
+#: src/Content/Conversation/PostTemplateBuilder.php:592
+msgid "Maybe"
+msgstr ""
+
+#: src/Content/Conversation/PostTemplateBuilder.php:616
 #, php-format
 msgid "%s (Received %s)"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:696
+#: src/Content/Conversation/PostTemplateBuilder.php:704
 msgid "I like this (toggle)"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:696
+#: src/Content/Conversation/PostTemplateBuilder.php:704
 msgid "Like"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:697
+#: src/Content/Conversation/PostTemplateBuilder.php:705
 msgid "I don't like this (toggle)"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:697
+#: src/Content/Conversation/PostTemplateBuilder.php:705
 msgid "Dislike"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:700
+#: src/Content/Conversation/PostTemplateBuilder.php:708
 msgid "Quote share this"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:700
+#: src/Content/Conversation/PostTemplateBuilder.php:708
 msgid "Quote Share"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:703
+#: src/Content/Conversation/PostTemplateBuilder.php:711
 msgid "Reshare this"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:703
+#: src/Content/Conversation/PostTemplateBuilder.php:711
 msgid "Reshare"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:704
+#: src/Content/Conversation/PostTemplateBuilder.php:712
 msgid "Cancel your Reshare"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:704
+#: src/Content/Conversation/PostTemplateBuilder.php:712
 msgid "Unshare"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:737
+#: src/Content/Conversation/PostTemplateBuilder.php:745
 #: src/Module/Profile/Schedule.php:93
 msgid "Private Message"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:738
+#: src/Content/Conversation/PostTemplateBuilder.php:746
 msgid "Public Message"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:739
+#: src/Content/Conversation/PostTemplateBuilder.php:747
 msgid "Unlisted Message"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:762
+#: src/Content/Conversation/PostTemplateBuilder.php:770
 #, php-format
 msgid "Reshared by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:767
+#: src/Content/Conversation/PostTemplateBuilder.php:775
 #, php-format
 msgid "Viewed by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:772
+#: src/Content/Conversation/PostTemplateBuilder.php:780
 #, php-format
 msgid "Read by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:777
+#: src/Content/Conversation/PostTemplateBuilder.php:785
 #, php-format
 msgid "Liked by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:782
+#: src/Content/Conversation/PostTemplateBuilder.php:790
 #, php-format
 msgid "Disliked by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:787
+#: src/Content/Conversation/PostTemplateBuilder.php:795
 #, php-format
 msgid "Attended by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:792
+#: src/Content/Conversation/PostTemplateBuilder.php:800
 #, php-format
 msgid "Maybe attended by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:797
+#: src/Content/Conversation/PostTemplateBuilder.php:805
 #, php-format
 msgid "Not attended by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:802
+#: src/Content/Conversation/PostTemplateBuilder.php:810
 #, php-format
 msgid "Commented by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:807
+#: src/Content/Conversation/PostTemplateBuilder.php:815
 #, php-format
 msgid "Reacted with %s by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:830
+#: src/Content/Conversation/PostTemplateBuilder.php:838
 #, php-format
 msgid "Quote shared by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:916
+#: src/Content/Conversation/PostTemplateBuilder.php:924
 #: src/Module/Contact.php:607 src/Module/Item/Compose.php:163
 msgid "This is you"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:919
+#: src/Content/Conversation/PostTemplateBuilder.php:927
 msgid "Post comment"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:920
-#: src/Content/Conversation/StatusEditor.php:149 src/Content/Nav.php:87
+#: src/Content/Conversation/PostTemplateBuilder.php:928
+#: src/Content/Conversation/StatusEditor.php:149 src/Content/Nav.php:93
 #: src/Module/Post/Edit.php:141
 msgid "Loading..."
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:921
+#: src/Content/Conversation/PostTemplateBuilder.php:929
 #: src/Content/Conversation/StatusEditor.php:152
 #: src/Module/Item/Compose.php:165 src/Module/Post/Edit.php:184
 #: src/Module/Settings/Profile/Index.php:247
 msgid "Bold"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:922
+#: src/Content/Conversation/PostTemplateBuilder.php:930
 #: src/Content/Conversation/StatusEditor.php:153
 #: src/Module/Item/Compose.php:166 src/Module/Post/Edit.php:185
 #: src/Module/Settings/Profile/Index.php:248
 msgid "Italic"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:923
+#: src/Content/Conversation/PostTemplateBuilder.php:931
 #: src/Content/Conversation/StatusEditor.php:154
 #: src/Module/Item/Compose.php:167 src/Module/Post/Edit.php:186
 #: src/Module/Settings/Profile/Index.php:249
 msgid "Underline"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:924
+#: src/Content/Conversation/PostTemplateBuilder.php:932
 #: src/Content/Conversation/StatusEditor.php:157
 #: src/Module/Item/Compose.php:170
 msgid "Content Warning"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:925
+#: src/Content/Conversation/PostTemplateBuilder.php:933
 #: src/Content/Conversation/StatusEditor.php:155
 #: src/Module/Item/Compose.php:168 src/Module/Post/Edit.php:187
 #: src/Module/Settings/Profile/Index.php:250
 msgid "Quote"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:926
+#: src/Content/Conversation/PostTemplateBuilder.php:934
 #: src/Content/Conversation/StatusEditor.php:156
 #: src/Module/Item/Compose.php:169 src/Module/Post/Edit.php:188
 #: src/Module/Settings/Profile/Index.php:251
 msgid "Add emojis"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:927
+#: src/Content/Conversation/PostTemplateBuilder.php:935
 #: src/Content/Conversation/StatusEditor.php:158
 #: src/Module/Item/Compose.php:171 src/Module/Post/Edit.php:189
 #: src/Module/Settings/Profile/Index.php:252
 msgid "Code"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:928
+#: src/Content/Conversation/PostTemplateBuilder.php:936
 #: src/Module/Item/Compose.php:172 src/Module/Settings/Profile/Index.php:253
 #: src/Module/Settings/Profile/Index.php:254
 msgid "Image"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:929
+#: src/Content/Conversation/PostTemplateBuilder.php:937
 #: src/Content/Conversation/StatusEditor.php:159
 #: src/Content/Conversation/StatusEditor.php:163
 #: src/Module/Item/Compose.php:173 src/Module/Post/Edit.php:190
@@ -1755,20 +1767,20 @@ msgstr ""
 msgid "Link"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:930
+#: src/Content/Conversation/PostTemplateBuilder.php:938
 #: src/Content/Conversation/StatusEditor.php:160
 #: src/Module/Item/Compose.php:174 src/Module/Post/Edit.php:191
 #: src/Module/Settings/Profile/Index.php:256
 msgid "Link or Media"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:931
+#: src/Content/Conversation/PostTemplateBuilder.php:939
 #: src/Content/Conversation/StatusEditor.php:103
 #: src/Module/Item/Compose.php:175
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:932
+#: src/Content/Conversation/PostTemplateBuilder.php:940
 #: src/Content/Conversation/StatusEditor.php:194
 #: src/Module/Calendar/Event/Form.php:261 src/Module/Item/Compose.php:176
 #: src/Module/Item/Compose.php:307 src/Module/Post/Edit.php:178
@@ -1962,7 +1974,7 @@ msgid "Display posts that have been created by accounts of the selected circle."
 msgstr ""
 
 #: src/Content/Feature.php:129 src/Content/GroupManager.php:95
-#: src/Content/Nav.php:235 src/Content/Text/HTML.php:886
+#: src/Content/Nav.php:243 src/Content/Text/HTML.php:886
 #: src/Content/Widget.php:564 src/Model/User.php:1418
 msgid "Groups"
 msgstr ""
@@ -2196,71 +2208,86 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/Content/Nav.php:86
+#: src/Content/Nav.php:92
 msgid "Nothing new here"
 msgstr ""
 
-#: src/Content/Nav.php:92 src/Content/Nav.php:263 src/Module/Help.php:68
+#: src/Content/Nav.php:96
+msgid "My Profile"
+msgstr ""
+
+#: src/Content/Nav.php:100 src/Content/Nav.php:271 src/Module/Help.php:68
 #: view/theme/frio/theme.php:234
 msgid "Home"
 msgstr ""
 
-#: src/Content/Nav.php:93
+#: src/Content/Nav.php:101
 msgid "Skip to main content"
 msgstr ""
 
-#: src/Content/Nav.php:94
+#: src/Content/Nav.php:102
 msgid "Clear notifications"
 msgstr ""
 
-#: src/Content/Nav.php:95
+#: src/Content/Nav.php:103
 msgid "Search: @name, !group, #tags, content"
 msgstr ""
 
-#: src/Content/Nav.php:192 src/Module/Security/Login.php:159
+#: src/Content/Nav.php:200 src/Module/Security/Login.php:159
 #: src/Module/Security/TwoFactor/SignOut.php:114
 msgid "Sign out"
 msgstr ""
 
-#: src/Content/Nav.php:192
+#: src/Content/Nav.php:200
 msgid "End this session"
 msgstr ""
 
-#: src/Content/Nav.php:194 src/Module/Bookmarklet.php:30
+#: src/Content/Nav.php:202 src/Module/Bookmarklet.php:30
 #: src/Module/Security/Login.php:160
 msgid "Sign in"
 msgstr ""
 
-#: src/Content/Nav.php:199 src/Module/BaseProfile.php:50
+#: src/Content/Nav.php:207 src/Module/BaseProfile.php:50
 #: src/Module/Media/Attachment/Browser.php:67
 #: src/Module/Media/Photo/Browser.php:62 src/Module/Media/Photo/Browser.php:79
 #: view/theme/frio/theme.php:228
 msgid "Photos"
 msgstr ""
 
-#: src/Content/Nav.php:199 view/theme/frio/theme.php:228
+#: src/Content/Nav.php:207 view/theme/frio/theme.php:228
 msgid "My photos"
 msgstr ""
 
-#: src/Content/Nav.php:200 src/Module/BaseProfile.php:93
+#: src/Content/Nav.php:208 src/Module/BaseProfile.php:93
 #: src/Module/Profile/Notes.php:82
 msgid "Personal notes"
 msgstr ""
 
-#: src/Content/Nav.php:200 src/Module/BaseProfile.php:96
+#: src/Content/Nav.php:208 src/Module/BaseProfile.php:96
 msgid "Only you can see these"
 msgstr ""
 
-#: src/Content/Nav.php:212 src/Module/Security/Login.php:124
+#: src/Content/Nav.php:215 src/Module/BaseProfile.php:34
+#: src/Module/BaseSettings.php:86 src/Module/Contact.php:487
+#: src/Module/Contact/Profile.php:439 src/Module/Profile/Profile.php:277
+#: src/Module/Welcome.php:44 view/theme/frio/theme.php:222
+msgid "Profile"
+msgstr ""
+
+#: src/Content/Nav.php:215 view/theme/frio/theme.php:222
+msgid "My profile"
+msgstr ""
+
+#: src/Content/Nav.php:220 src/Module/Security/Login.php:124
 msgid "Register"
 msgstr ""
 
-#: src/Content/Nav.php:212 src/Module/Register.php:219
+#: src/Content/Nav.php:220 src/Module/Register.php:219
 #: src/Module/Security/Login.php:123
 msgid "Create an account"
 msgstr ""
 
-#: src/Content/Nav.php:218 src/Module/Help.php:54
+#: src/Content/Nav.php:226 src/Module/Help.php:54
 #: src/Module/Settings/TwoFactor/AppSpecific.php:130
 #: src/Module/Settings/TwoFactor/Index.php:125
 #: src/Module/Settings/TwoFactor/Recovery.php:96
@@ -2268,39 +2295,39 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: src/Content/Nav.php:218
+#: src/Content/Nav.php:226
 msgid "Help and documentation"
 msgstr ""
 
-#: src/Content/Nav.php:222
+#: src/Content/Nav.php:230
 msgid "Apps"
 msgstr ""
 
-#: src/Content/Nav.php:222
+#: src/Content/Nav.php:230
 msgid "Addon applications, utilities, games"
 msgstr ""
 
-#: src/Content/Nav.php:226 src/Content/Text/HTML.php:871
+#: src/Content/Nav.php:234 src/Content/Text/HTML.php:871
 #: src/Module/Moderation/Blocklist/Contact.php:112
 #: src/Module/Moderation/Blocklist/Server/Index.php:103
 #: src/Module/Search/Index.php:99
 msgid "Search"
 msgstr ""
 
-#: src/Content/Nav.php:226
+#: src/Content/Nav.php:234
 msgid "Search site content"
 msgstr ""
 
-#: src/Content/Nav.php:229 src/Content/Text/HTML.php:880
+#: src/Content/Nav.php:237 src/Content/Text/HTML.php:880
 msgid "Full Text"
 msgstr ""
 
-#: src/Content/Nav.php:230 src/Content/Text/HTML.php:881
+#: src/Content/Nav.php:238 src/Content/Text/HTML.php:881
 #: src/Content/Widget/TagCloud.php:54
 msgid "Tags"
 msgstr ""
 
-#: src/Content/Nav.php:231 src/Content/Nav.php:291
+#: src/Content/Nav.php:239 src/Content/Nav.php:297
 #: src/Content/Text/HTML.php:882 src/Module/BaseProfile.php:112
 #: src/Module/BaseProfile.php:115 src/Module/Contact.php:191
 #: src/Module/Contact.php:409 src/Module/Contact.php:519
@@ -2308,11 +2335,11 @@ msgstr ""
 msgid "Contacts"
 msgstr ""
 
-#: src/Content/Nav.php:246
+#: src/Content/Nav.php:254
 msgid "Community"
 msgstr ""
 
-#: src/Content/Nav.php:250 src/Module/BaseProfile.php:70
+#: src/Content/Nav.php:258 src/Module/BaseProfile.php:70
 #: src/Module/BaseProfile.php:73 src/Module/BaseProfile.php:81
 #: src/Module/BaseProfile.php:84 src/Module/Calendar/Show.php:113
 #: src/Module/Settings/Display.php:448 view/theme/frio/theme.php:229
@@ -2320,110 +2347,107 @@ msgstr ""
 msgid "Calendar"
 msgstr ""
 
-#: src/Content/Nav.php:253
+#: src/Content/Nav.php:261
 msgid "Directory"
 msgstr ""
 
-#: src/Content/Nav.php:253
+#: src/Content/Nav.php:261
 msgid "People directory"
 msgstr ""
 
-#: src/Content/Nav.php:255 src/Module/BaseAdmin.php:70
+#: src/Content/Nav.php:263 src/Module/BaseAdmin.php:70
 #: src/Module/BaseModeration.php:97
 msgid "Information"
 msgstr ""
 
-#: src/Content/Nav.php:255
+#: src/Content/Nav.php:263
 msgid "Information about this friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:258 src/Module/Admin/Tos.php:64
+#: src/Content/Nav.php:266 src/Module/Admin/Tos.php:64
 #: src/Module/BaseAdmin.php:81 src/Module/Register.php:243
 #: src/Module/Tos.php:87
 msgid "Terms of Service"
 msgstr ""
 
-#: src/Content/Nav.php:258
+#: src/Content/Nav.php:266
 msgid "Terms of Service of this Friendica instance"
 msgstr ""
 
-#: src/Content/Nav.php:266 src/Module/BaseProfile.php:34
-#: src/Module/BaseSettings.php:86 src/Module/Contact.php:487
-#: src/Module/Contact/Profile.php:439 src/Module/Profile/Profile.php:277
-#: src/Module/Welcome.php:44
-msgid "Profile"
-msgstr ""
-
-#: src/Content/Nav.php:270
+#: src/Content/Nav.php:275
 msgid "Introductions"
 msgstr ""
 
-#: src/Content/Nav.php:270
+#: src/Content/Nav.php:275
 msgid "Friend Requests"
 msgstr ""
 
-#: src/Content/Nav.php:271 src/Module/BaseNotifications.php:134
+#: src/Content/Nav.php:276 src/Module/BaseNotifications.php:134
 #: src/Module/Notifications/Introductions.php:63
 #: src/Module/Settings/Account.php:560
 msgid "Notifications"
 msgstr ""
 
-#: src/Content/Nav.php:272
+#: src/Content/Nav.php:277
 msgid "View all"
 msgstr ""
 
-#: src/Content/Nav.php:273 src/Module/Settings/Connectors.php:232
+#: src/Content/Nav.php:278 src/Module/Settings/Connectors.php:232
 msgid "Mark as read"
 msgstr ""
 
-#: src/Content/Nav.php:273
+#: src/Content/Nav.php:278
 msgid "Mark all system notifications as seen"
 msgstr ""
 
-#: src/Content/Nav.php:276
+#: src/Content/Nav.php:281
 msgid "Private mail"
 msgstr ""
 
-#: src/Content/Nav.php:277
+#: src/Content/Nav.php:282
 msgid "Inbox"
 msgstr ""
 
-#: src/Content/Nav.php:278
+#: src/Content/Nav.php:283
 msgid "Outbox"
 msgstr ""
 
-#: src/Content/Nav.php:281
-msgid "Accounts"
-msgstr ""
-
-#: src/Content/Nav.php:282
+#: src/Content/Nav.php:286
 msgid "Manage other accounts, including groups and pages"
 msgstr ""
 
-#: src/Content/Nav.php:289 src/Module/Admin/Addons/Details.php:140
+#: src/Content/Nav.php:288
+msgid "Switch Accounts"
+msgstr ""
+
+#: src/Content/Nav.php:291
+msgid "Add Account"
+msgstr ""
+
+#: src/Content/Nav.php:295 src/Module/Admin/Addons/Details.php:140
 #: src/Module/Admin/Themes/Details.php:85 src/Module/BaseAdmin.php:89
 #: src/Module/BaseSettings.php:177 src/Module/Welcome.php:39
 #: view/theme/frio/theme.php:237
 msgid "Settings"
 msgstr ""
 
-#: src/Content/Nav.php:289
+#: src/Content/Nav.php:295
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:291 view/theme/frio/theme.php:238
+#: src/Content/Nav.php:297 view/theme/frio/theme.php:238
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
-#: src/Content/Nav.php:296 src/Module/BaseAdmin.php:115
+#: src/Content/Nav.php:302 src/Module/BaseAdmin.php:115
 msgid "Admin"
 msgstr ""
 
-#: src/Content/Nav.php:296
+#: src/Content/Nav.php:302
 msgid "Site setup and configuration"
 msgstr ""
 
-#: src/Content/Nav.php:300 src/Module/BaseModeration.php:117
+#: src/Content/Nav.php:306 src/Module/BaseModeration.php:117
 #: src/Module/Moderation/Blocklist/Contact.php:99
 #: src/Module/Moderation/Blocklist/Contact/Import.php:101
 #: src/Module/Moderation/Blocklist/Server/Add.php:105
@@ -2441,15 +2465,15 @@ msgstr ""
 msgid "Moderation"
 msgstr ""
 
-#: src/Content/Nav.php:300
+#: src/Content/Nav.php:306
 msgid "Content and user moderation"
 msgstr ""
 
-#: src/Content/Nav.php:303
+#: src/Content/Nav.php:309
 msgid "Navigation"
 msgstr ""
 
-#: src/Content/Nav.php:303
+#: src/Content/Nav.php:309
 msgid "Site map"
 msgstr ""
 
@@ -5987,26 +6011,26 @@ msgstr ""
 msgid "User registrations waiting for confirmation"
 msgstr ""
 
-#: src/Module/BaseApi.php:461 src/Module/BaseApi.php:477
-#: src/Module/BaseApi.php:493
+#: src/Module/BaseApi.php:565 src/Module/BaseApi.php:581
+#: src/Module/BaseApi.php:597
 msgid "Too Many Requests"
 msgstr ""
 
-#: src/Module/BaseApi.php:462
+#: src/Module/BaseApi.php:566
 #, php-format
 msgid "Daily posting limit of %d post reached. The post was rejected."
 msgid_plural "Daily posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/BaseApi.php:478
+#: src/Module/BaseApi.php:582
 #, php-format
 msgid "Weekly posting limit of %d post reached. The post was rejected."
 msgid_plural "Weekly posting limit of %d posts reached. The post was rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/BaseApi.php:494
+#: src/Module/BaseApi.php:598
 #, php-format
 msgid "Monthly posting limit of %d post reached. The post was rejected."
 msgid_plural "Monthly posting limit of %d posts reached. The post was rejected."
@@ -10299,7 +10323,7 @@ msgstr ""
 msgid "Your Identity Address is <strong>'%s'</strong> or '%s'."
 msgstr ""
 
-#: src/Module/Settings/Account.php:512 view/theme/frio/config.php:162
+#: src/Module/Settings/Account.php:512 view/theme/frio/config.php:170
 msgid "Save settings"
 msgstr ""
 
@@ -11072,7 +11096,7 @@ msgstr ""
 msgid "Content Settings"
 msgstr ""
 
-#: src/Module/Settings/Display.php:442 view/theme/frio/config.php:163
+#: src/Module/Settings/Display.php:442 view/theme/frio/config.php:171
 #: view/theme/vier/config.php:146
 msgid "Theme settings"
 msgstr ""
@@ -12800,83 +12824,99 @@ msgstr ""
 msgid "Empty Post"
 msgstr ""
 
-#: view/theme/frio/config.php:157
+#: view/theme/frio/config.php:165
 msgid "Note"
 msgstr ""
 
-#: view/theme/frio/config.php:157
+#: view/theme/frio/config.php:165
 msgid "Ensure that the image has the correct permissions, allowing all users to view it."
 msgstr ""
 
-#: view/theme/frio/config.php:164
+#: view/theme/frio/config.php:172
 msgid "Appearance"
 msgstr ""
 
-#: view/theme/frio/config.php:165
+#: view/theme/frio/config.php:173
 msgid "Accent color"
 msgstr ""
 
-#: view/theme/frio/config.php:166
+#: view/theme/frio/config.php:174
 msgid "Copy or paste theme settings"
 msgstr ""
 
-#: view/theme/frio/config.php:166
+#: view/theme/frio/config.php:174
 msgid "You can copy this text to share your theme settings with others. Pasting here updates the theme settings below. Afterwards, if you want, click the save button below to use the new settings."
 msgstr ""
 
-#: view/theme/frio/config.php:167
+#: view/theme/frio/config.php:175
 msgid "Navigation bar background color"
 msgstr ""
 
-#: view/theme/frio/config.php:168
+#: view/theme/frio/config.php:176
 msgid "Navigation bar icon color "
 msgstr ""
 
-#: view/theme/frio/config.php:169
+#: view/theme/frio/config.php:177
 msgid "Link color"
 msgstr ""
 
-#: view/theme/frio/config.php:170
+#: view/theme/frio/config.php:178
 msgid "Set the background color"
 msgstr ""
 
-#: view/theme/frio/config.php:171
+#: view/theme/frio/config.php:179
 msgid "Content background opacity"
 msgstr ""
 
-#: view/theme/frio/config.php:172
+#: view/theme/frio/config.php:180
 msgid "Set the background image"
 msgstr ""
 
-#: view/theme/frio/config.php:173
+#: view/theme/frio/config.php:181
 msgid "Background image style"
 msgstr ""
 
-#: view/theme/frio/config.php:176
+#: view/theme/frio/config.php:184
 msgid "Always open Compose page"
 msgstr ""
 
-#: view/theme/frio/config.php:176
+#: view/theme/frio/config.php:184
 msgid "If enabled, the button to make a new post always opens a dedicated page (the <a href=\"/compose\">Compose page</a>) instead of a small window on top of the current page. When disabled, the \"Compose page\" can be accessed with a middle click on the button to make a new post, or via a button in the small window."
 msgstr ""
 
-#: view/theme/frio/config.php:177
+#: view/theme/frio/config.php:185
 msgid "Enable Advanced Composer"
 msgstr ""
 
-#: view/theme/frio/config.php:177
+#: view/theme/frio/config.php:185
 msgid "When enabled, the Advanced Composer writing assistant will be available in the compose view."
 msgstr ""
 
-#: view/theme/frio/config.php:181
+#: view/theme/frio/config.php:186
+msgid "Show Navbar Button Labels"
+msgstr ""
+
+#: view/theme/frio/config.php:186
+msgid "Shows or hides the button labels under the main navigation bar buttons."
+msgstr ""
+
+#: view/theme/frio/config.php:187
+msgid "Show Action Button Labels"
+msgstr ""
+
+#: view/theme/frio/config.php:187
+msgid "Shows or hides the button labels under posts and replies."
+msgstr ""
+
+#: view/theme/frio/config.php:191
 msgid "Login page background image"
 msgstr ""
 
-#: view/theme/frio/config.php:185
+#: view/theme/frio/config.php:195
 msgid "Login page background color"
 msgstr ""
 
-#: view/theme/frio/config.php:185
+#: view/theme/frio/config.php:195
 msgid "Leave background image and color empty to use theme defaults."
 msgstr ""
 
@@ -12912,7 +12952,7 @@ msgstr ""
 msgid "Repeat image to fill the screen."
 msgstr ""
 
-#: view/theme/frio/php/default.php:146
+#: view/theme/frio/php/default.php:148
 msgid "Back to top"
 msgstr ""
 

--- a/view/templates/hovercard.tpl
+++ b/view/templates/hovercard.tpl
@@ -54,40 +54,39 @@
 				{{if $profile.actions.pm}}
 					<a class="btn btn-labeled btn-primary btn-sm add-to-modal" href="{{$profile.actions.pm.1}}">
 						<i class="ri ri-mail-line" aria-hidden="true"></i>
-						<span>{{$profile.actions.pm.0}}</span>
+						<span class="action-label">{{$profile.actions.pm.0}}</span>
 					</a>
 				{{/if}}
 
 				{{if $profile.addr && !$profile.self}}
 					<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.mention.1}}">
 						<i class="ri ri-edit-box-line" aria-hidden="true"></i>
-						<span>{{$profile.actions.mention.0}}</span>
+						<span class="action-label">{{$profile.actions.mention.0}}</span>
 					</a>
 				{{/if}}
-			</div>
-			<div class="hover-card-actions-connection">
+
 				{{if $profile.actions.network}}
 					<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.network.1}}">
 							<i class="ri ri-{{($profile.contact_type==3) ? 'discuss-line' : 'cloud-line'}}" aria-hidden="true"></i>
-							{{$profile.actions.network.0}}
+							<span class="action-label">{{$profile.actions.network.0}}</span>
 					</a>
 				{{/if}}
 				{{if $profile.actions.edit}}
 					<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.edit.1}}">
 						<i class="ri ri-user-line" aria-hidden="true"></i>
-						 {{$profile.actions.edit.0}}
+						 <span class="action-label">{{$profile.actions.edit.0}}</span>
 					</a>
 				{{/if}}
 				{{if $profile.actions.follow}}
 					<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.follow.1}}">
 						<i class="ri ri-user-add-line" aria-hidden="true"></i>
-						{{$profile.actions.follow.0}}
+						<span class="action-label">{{$profile.actions.follow.0}}</span>
 					</a>
 				 {{/if}}
 				{{if $profile.actions.unfollow}}
 					<a class="btn btn-labeled btn-primary btn-sm" href="{{$profile.actions.unfollow.1}}">
 						<i class="ri ri-user-unfollow-line" aria-hidden="true"></i>
-						{{$profile.actions.unfollow.0}}
+						<span class="action-label">{{$profile.actions.unfollow.0}}</span>
 					</a>
 				{{/if}}
 			</div>

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -56,10 +56,10 @@
 			</li>
 		{{/if}}
 
-		{{if $nav.my_profile}}
+		{{if $profile_link}}
 			<li role="menuitem" id="nav-my-profile-link" class="nav-menu {{$sel.my_profile}}">
-				<a accesskey="p" class="{{$nav.my_profile.2}}" href="{{$nav.my_profile.0}}" title="{{$nav.my_profile.3}}">
-					<span class="desktop-view">{{$nav.my_profile.1}}</span>
+				<a accesskey="p" class="" href="{{$profile_link}}" title="{{$profile_link_title}}">
+					<span class="desktop-view">{{$profile_link_title}}</span>
 					<i class="ri ri-xl ri-user-line ri-fw mobile-view" aria-hidden="true"></i>
 					<span id="my-profile-update" class="nav-notification"></span>
 				</a>
@@ -100,16 +100,19 @@
 		{{/if}}
 
 		{{if $userinfo}}
-			<li role="menu" aria-haspopup="true" id="nav-user-linkmenu" class="nav-menu">
+			<li role="menu" aria-haspopup="true" id="nav-user-linkmenu" class="nav-menu" tabindex="0">
 				<a accesskey="u" title="{{$sitelocation}}"><img src="{{$userinfo.icon}}" alt="{{$userinfo.name}}"><span id="nav-user-linklabel">{{$userinfo.name}}</span><span id="intro-update" class="nav-notification"></span></a>
 				<ul id="nav-user-menu" class="menu-popup">
+					{{if $nav.delegation}}<li role="menuitem"><a class="{{$nav.delegation.2}}" href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}">{{$nav.delegation.1}}</a></li>{{/if}}
 					<li role="menuitem"> <a  class="{{$nav.search.2}}" href="{{$nav.search.0}}" title="{{$nav.search.3}}">{{$nav.search.1}}</a> </li>
 					{{if $nav.introductions}}<li role="menuitem"><a class="{{$nav.introductions.2}}" href="{{$nav.introductions.0}}" title="{{$nav.introductions.3}}">{{$nav.introductions.1}}<span id="intro-update-li" class="nav-notification"></span></a></li>{{/if}}
 					{{if $nav.contacts}}<li role="menuitem"><a class="{{$nav.contacts.2}}" href="{{$nav.contacts.0}}" title="{{$nav.contacts.3}}">{{$nav.contacts.1}}</a></li>{{/if}}
 					{{if $nav.messages}}<li role="menuitem"><a class="{{$nav.messages.2}}" href="{{$nav.messages.0}}" title="{{$nav.messages.3}}">{{$nav.messages.1}} <span id="mail-update-li" class="nav-notification"></span></a></li>{{/if}}
 					{{if $nav.delegation}}<li role="menuitem"><a class="{{$nav.delegation.2}}" href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}">{{$nav.delegation.1}}</a></li>{{/if}}
-					{{* This is a link to Photos: *}}
-					{{if $nav.usermenu.0}}<li role="menuitem"><a class="{{$nav.usermenu.0.2}}" href="{{$nav.usermenu.0.0}}" title="{{$nav.usermenu.0.3}}">{{$nav.usermenu.0.1}}</a></li>{{/if}}
+					{{* Links to Profile: *}}
+					{{foreach $nav.usermenu as $usermenu}}
+					<li role="menuitem"><a role="menuitem" class="{{$usermenu.2}}" href="{{$usermenu.0}}" title="{{$usermenu.3}}">{{$usermenu.1}}</a></li>
+					{{/foreach}}
 					{{if $nav.settings}}<li role="menuitem"><a class="{{$nav.settings.2}}" href="{{$nav.settings.0}}" title="{{$nav.settings.3}}">{{$nav.settings.1}}</a></li>{{/if}}
 					{{if $nav.admin}}
 					<li role="menuitem">

--- a/view/templates/nav.tpl
+++ b/view/templates/nav.tpl
@@ -108,7 +108,6 @@
 					{{if $nav.introductions}}<li role="menuitem"><a class="{{$nav.introductions.2}}" href="{{$nav.introductions.0}}" title="{{$nav.introductions.3}}">{{$nav.introductions.1}}<span id="intro-update-li" class="nav-notification"></span></a></li>{{/if}}
 					{{if $nav.contacts}}<li role="menuitem"><a class="{{$nav.contacts.2}}" href="{{$nav.contacts.0}}" title="{{$nav.contacts.3}}">{{$nav.contacts.1}}</a></li>{{/if}}
 					{{if $nav.messages}}<li role="menuitem"><a class="{{$nav.messages.2}}" href="{{$nav.messages.0}}" title="{{$nav.messages.3}}">{{$nav.messages.1}} <span id="mail-update-li" class="nav-notification"></span></a></li>{{/if}}
-					{{if $nav.delegation}}<li role="menuitem"><a class="{{$nav.delegation.2}}" href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}">{{$nav.delegation.1}}</a></li>{{/if}}
 					{{* Links to Profile: *}}
 					{{foreach $nav.usermenu as $usermenu}}
 					<li role="menuitem"><a role="menuitem" class="{{$usermenu.2}}" href="{{$usermenu.0}}" title="{{$usermenu.3}}">{{$usermenu.1}}</a></li>

--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -40,7 +40,7 @@ function theme_post(AppHelper $appHelper): void
 			'always_open_compose',
 			'enable_advancedcomposer',
 			'show_nav_labels',
-			'sow_action_labels',
+			'show_action_labels',
 		] as $field) {
 			if (isset($_POST['frio_' . $field])) {
 				DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'frio', $field, $_POST['frio_' . $field]);

--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -118,8 +118,8 @@ function theme_content(AppHelper $appHelper): string
 		'bg_image_option'         => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'bg_image_option', DI::config()->get('frio', 'bg_image_option')),
 		'always_open_compose'     => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', DI::config()->get('frio', 'always_open_compose', false)),
 		'enable_advancedcomposer' => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'enable_advancedcomposer', DI::config()->get('frio', 'enable_advancedcomposer', false)),
-		'show_nav_labels'     => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'show_nav_labels', DI::config()->get('frio', 'show_nav_labels', false)),
-		'show_action_labels'  => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'show_action_labels', DI::config()->get('frio', 'show_action_labels', false)),
+		'show_nav_labels'         => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'show_nav_labels', DI::config()->get('frio', 'show_nav_labels', false)),
+		'show_action_labels'      => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'show_action_labels', DI::config()->get('frio', 'show_action_labels', false)),
 	];
 
 	return frio_form($arr);
@@ -147,8 +147,8 @@ function theme_admin(AppHelper $appHelper): string
 		'login_bg_color'          => DI::config()->get('frio', 'login_bg_color'),
 		'always_open_compose'     => DI::config()->get('frio', 'always_open_compose', false),
 		'enable_advancedcomposer' => DI::config()->get('frio', 'enable_advancedcomposer', false),
-		'show_nav_labels'      => DI::config()->get('frio', 'show_nav_labels', false),
-		'show_action_labels'   => DI::config()->get('frio', 'show_action_labels', false),
+		'show_nav_labels'         => DI::config()->get('frio', 'show_nav_labels', false),
+		'show_action_labels'      => DI::config()->get('frio', 'show_action_labels', false),
 	];
 
 	return frio_form($arr);
@@ -183,8 +183,8 @@ function frio_form($arr)
 
 		'$always_open_compose'     => ['frio_always_open_compose', DI::l10n()->t('Always open Compose page'), $arr['always_open_compose'], DI::l10n()->t('If enabled, the button to make a new post always opens a dedicated page (the <a href="/compose">Compose page</a>) instead of a small window on top of the current page. When disabled, the "Compose page" can be accessed with a middle click on the button to make a new post, or via a button in the small window.')],
 		'$enable_advancedcomposer' => ['frio_enable_advancedcomposer', DI::l10n()->t('Enable Advanced Composer'), $arr['enable_advancedcomposer'], DI::l10n()->t('When enabled, the Advanced Composer writing assistant will be available in the compose view.')],
-		'$show_nav_labels'     => ['frio_show_nav_labels',  DI::l10n()->t('Show Navbar Button Labels'),$arr['show_nav_labels'],  DI::l10n()->t('Shows or hides the button labels under the main navigation bar buttons.')],
-		'$show_action_labels'  => ['frio_show_action_labels',  DI::l10n()->t('Show Action Button Labels'),$arr['show_action_labels'],  DI::l10n()->t('Shows or hides the button labels under posts and replies.')],
+		'$show_nav_labels'         => ['frio_show_nav_labels',  DI::l10n()->t('Show Navbar Button Labels'),$arr['show_nav_labels'],  DI::l10n()->t('Shows or hides the button labels under the main navigation bar buttons.')],
+		'$show_action_labels'      => ['frio_show_action_labels',  DI::l10n()->t('Show Action Button Labels'),$arr['show_action_labels'],  DI::l10n()->t('Shows or hides the button labels under posts and replies.')],
 	];
 
 	if (array_key_exists('login_bg_image', $arr) && !array_key_exists('login_bg_image', $disable)) {

--- a/view/theme/frio/config.php
+++ b/view/theme/frio/config.php
@@ -39,6 +39,8 @@ function theme_post(AppHelper $appHelper): void
 			'login_bg_color',
 			'always_open_compose',
 			'enable_advancedcomposer',
+			'show_nav_labels',
+			'sow_action_labels',
 		] as $field) {
 			if (isset($_POST['frio_' . $field])) {
 				DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'frio', $field, $_POST['frio_' . $field]);
@@ -85,6 +87,8 @@ function theme_admin_post(): void
 			'login_bg_color',
 			'always_open_compose',
 			'enable_advancedcomposer',
+			'show_nav_labels',
+			'show_action_labels',
 		] as $field) {
 			if (isset($_POST['frio_' . $field])) {
 				DI::config()->set('frio', $field, $_POST['frio_' . $field]);
@@ -114,6 +118,8 @@ function theme_content(AppHelper $appHelper): string
 		'bg_image_option'         => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'bg_image_option', DI::config()->get('frio', 'bg_image_option')),
 		'always_open_compose'     => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'always_open_compose', DI::config()->get('frio', 'always_open_compose', false)),
 		'enable_advancedcomposer' => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'enable_advancedcomposer', DI::config()->get('frio', 'enable_advancedcomposer', false)),
+		'show_nav_labels'     => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'show_nav_labels', DI::config()->get('frio', 'show_nav_labels', false)),
+		'show_action_labels'  => DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'show_action_labels', DI::config()->get('frio', 'show_action_labels', false)),
 	];
 
 	return frio_form($arr);
@@ -141,6 +147,8 @@ function theme_admin(AppHelper $appHelper): string
 		'login_bg_color'          => DI::config()->get('frio', 'login_bg_color'),
 		'always_open_compose'     => DI::config()->get('frio', 'always_open_compose', false),
 		'enable_advancedcomposer' => DI::config()->get('frio', 'enable_advancedcomposer', false),
+		'show_nav_labels'      => DI::config()->get('frio', 'show_nav_labels', false),
+		'show_action_labels'   => DI::config()->get('frio', 'show_action_labels', false),
 	];
 
 	return frio_form($arr);
@@ -175,6 +183,8 @@ function frio_form($arr)
 
 		'$always_open_compose'     => ['frio_always_open_compose', DI::l10n()->t('Always open Compose page'), $arr['always_open_compose'], DI::l10n()->t('If enabled, the button to make a new post always opens a dedicated page (the <a href="/compose">Compose page</a>) instead of a small window on top of the current page. When disabled, the "Compose page" can be accessed with a middle click on the button to make a new post, or via a button in the small window.')],
 		'$enable_advancedcomposer' => ['frio_enable_advancedcomposer', DI::l10n()->t('Enable Advanced Composer'), $arr['enable_advancedcomposer'], DI::l10n()->t('When enabled, the Advanced Composer writing assistant will be available in the compose view.')],
+		'$show_nav_labels'     => ['frio_show_nav_labels',  DI::l10n()->t('Show Navbar Button Labels'),$arr['show_nav_labels'],  DI::l10n()->t('Shows or hides the button labels under the main navigation bar buttons.')],
+		'$show_action_labels'  => ['frio_show_action_labels',  DI::l10n()->t('Show Action Button Labels'),$arr['show_action_labels'],  DI::l10n()->t('Shows or hides the button labels under posts and replies.')],
 	];
 
 	if (array_key_exists('login_bg_image', $arr) && !array_key_exists('login_bg_image', $disable)) {

--- a/view/theme/frio/css/hovercard.css
+++ b/view/theme/frio/css/hovercard.css
@@ -297,7 +297,7 @@
 	display: inline-block;
 }
 
-body.show-action-labels .hovercard-actions a .action-label {
+body.show-action-labels .hover-card-actions a .action-label {
 	display: inline-block;
 }
 

--- a/view/theme/frio/css/hovercard.css
+++ b/view/theme/frio/css/hovercard.css
@@ -282,7 +282,7 @@
 	text-overflow: ellipsis;
 }
 
-.hover-card-actions, .hover-card-actions-connection {
+.hover-card-actions {
 	display: flex;
 	gap: 5px;
 	flex-wrap: wrap;
@@ -293,6 +293,10 @@
 }
 
 .hovercard .hovercard-content .hover-card-actions a.btn {
+	display: inline-block;
+}
+
+body.show-action-labels .hovercard-actions a .action-label {
 	display: inline-block;
 }
 

--- a/view/theme/frio/css/hovercard.css
+++ b/view/theme/frio/css/hovercard.css
@@ -286,6 +286,7 @@
 	display: flex;
 	gap: 5px;
 	flex-wrap: wrap;
+	justify-content: flex-end;
 }
 
 .hover-card-actions {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -214,7 +214,7 @@ ul#nav-user-menu {
 	border-radius: 4px;
 }
 #nav-delegation-link {										
-	background-color: white;
+	background-color: $nav_bg;
 	color: $link_color;
 	margin: 10px;
 	width: calc(100% - 20px);

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -299,7 +299,7 @@ ul#nav-user-menu {
 	border-radius: 0;
 	overflow-x: hidden;
 	overflow-y: auto;
-	background-color: #333;
+	background-color: $nav_bg;
 	transform: translateX(100%);
 	transition: 0.4s ease-in-out;
 	display: block;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -206,18 +206,34 @@ ul#nav-user-menu {
 	}
 }
 
-/* Applies to the small screen (mobile) menu as well */
-.profile-link a {
-	font-weight: inherit;
+#nav-profile-link {
+	background-color: inherit;
+	border: 1px solid white !important; /* important for gnome scheme */
+	margin: 10px;
+	width: calc(100% - 20px);
+	border-radius: 4px;
 }
-.profile-link img {
-	max-width:25px;
-	max-height:25px;
-	min-width:25tpx;
-	min-height:25px;
-	width:25px;
-	height:25px;
+#nav-delegation-link {										
+	background-color: white;
+	color: $link_color;
+	margin: 10px;
+	width: calc(100% - 20px);
+	border-radius: 4px;
+	border: none !important;
 }
+	#nav-delegation-link i {
+		margin-left: -4px;
+		margin-right: 4px;
+	}
+	#nav-delegation-link:hover,
+	#nav-delegation-link:focus {
+		background-color: #eee;
+		color: black;
+	}	
+	/* prevent XMPP chat add-on button appearing in modals and iframes */
+	body.minimal #toggle-controlbox {
+		display: none;
+	}
 
 /**
  * mobile: Larger screens
@@ -264,16 +280,58 @@ ul#nav-user-menu {
 		padding-left: 0;
 		padding-right: 0;
 	}
+	/* Narrower search field if navbar labels are show */
+	body.show-nav-labels #search-box #nav-search-input-field {
+		width: 150px;
+	}
 	#topbar-first > .container-fluid, #topbar-second > .container-fluid {
 		padding-inline: 2px;
 	}
-
-	#topbar-first .topbar-nav .nav-segment > a.nav-menu {
-		padding-inline: 15px;
-	}
+#nav-user-menu {
+	width: clamp(200px, 50vw, 275px);
+	position: fixed;
+	right: 0px;
+	top: 50px;
+	bottom: 0px;
+	height: 100%;
+	max-height: 100%;
+	margin: 0;
+	border-radius: 0;
+	overflow-x: hidden;
+	overflow-y: auto;
+	background-color: #333;
+	transform: translateX(100%);
+	transition: 0.4s ease-in-out;
+	display: block;
+	z-index: 1060;
+}
+#nav-user-linkmenu.open #nav-user-menu {
+	transform: translateX(0);
+}
+#nav-user-linkmenu::after {
+	content: '';						
+	position: fixed;
+	right: 0;
+	top: 50px;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0, 0, 0, 0.5);
+	z-index: 1050;
+	visibility: hidden;
+	opacity: 0;
+	transition: 0.4s ease-in-out;
+}
+#nav-user-linkmenu.open::after {
+	opacity: 1;
+	visibility: visible;
+}
 
 	#topbar-second #tabmenu {
 		text-align: unset;
+	}
+	body.show-nav-labels .nav-label,
+	body.show-action-labels .action-label {
+		font-size: 12px;
 	}
 }
 /*
@@ -575,23 +633,7 @@ header #banner #logo-img,
 	transition: 0.4s ease-in-out;
 	z-index: 1060;
 }
-#offcanvasUsermenu {
-	width: clamp(200px, 50vw, 275px);
-	position: fixed;
-	right: 0px;
-	top: 50px;
-	height: 100%;
-	overflow-x: hidden;
-	overflow-y: auto;
-	background-color: #333;
-	transform: translateX(100%);
-	transition: 0.4s ease-in-out;
-	z-index: 1060;
-}
 .offcanvas-active .off-canvas {
-	transform: translateX(0);
-}
-.offcanvas-right-active #offcanvasUsermenu {
 	transform: translateX(0);
 }
 .navbar-fixed-top {
@@ -619,20 +661,7 @@ header #banner #logo-img,
 	opacity: 0;
 	transition: 0.4s ease-in-out;
 }
-.offcanvas-right-overlay {
-	position: fixed;
-	right: 0;
-	top: 50px;
-	width: 100%;
-	height: 100%;
-	background-color: rgba(0, 0, 0, 0.5);
-	z-index: 1050;
-	visibility: hidden;
-	opacity: 0;
-	transition: 0.4s ease-in-out;
-}
-.offcanvas-active .offcanvas-overlay,
-.offcanvas-right-active .offcanvas-right-overlay {
+.offcanvas-active .offcanvas-overlay {
 	opacity: 1;
 	visibility: visible;
 }
@@ -705,7 +734,7 @@ nav.navbar {
 	color: $nav_icon_color;
 	font-size: 16px;
 	top: 0;
-	z-index: 1030;
+	z-index: 1050;
 }
 
 	#topbar-first .topbar-nav i {
@@ -718,7 +747,11 @@ button#main-menu {
 	gap: 5px;
 	padding-block: 0;
 	padding-right: 0;
+	min-width: 40px;
 }
+	button#main-menu > div:last-of-type {
+		width: 100%; /* ensure touch-target is large enough to touch */
+	}
 #topbar-first-nav-container {
 		display: flex;
 		justify-content: space-between;
@@ -748,15 +781,21 @@ nav.navbar .nav > li > button:focus {
 	background-color: $nav_icon_hover_color;
 	border-radius: 10px;
 }
-/* Current section highlighting */
+/* Current section highlighting needs to work with or without labels */
 #topbar-first .nav > li > a.selected {
-	text-decoration: underline;
-	text-underline-offset: 8px;
-	text-decoration-thickness: 2px;
+	text-decoration: none;
+	border-bottom: 2px solid $nav_icon_color;
+	border-radius: 0;
+}
+/* no need for hover effect we are already here */
+#topbar-first .nav > li > a.selected:hover,
+#topbar-first .nav > li > a.selected:focus {
+	background-color: transparent;
 }
 #topbar-first .nav > .account img {
 	height: 32px;
 	width: 32px;
+	max-width: 35px;
 	border-radius: 3px;
 }
 #topbar-first .nav > .account .dropdown-toggle span {
@@ -770,11 +809,12 @@ nav.navbar .nav > li > button:focus {
 	margin-left: -1px;
 }
 /* End workaround */
-#topbar-first .topbar-nav .nav-segment > a {
+#topbar-first .topbar-nav .nav-segment > a,
+#topbar-first .topbar-actions .nav-segment > a {
 	display: inline-block;
-	padding-inline: 35px;
 	text-decoration: none;
-	text-align: left;
+	text-align: center;
+	max-height: 50px;
 }
 #topbar-first .nav-segment .nav-notification {
 	position: absolute;
@@ -879,7 +919,9 @@ nav.navbar .nav > li > button:focus {
 .navbar-fixed-top ul.nav.navbar-nav.navbar-right {
 	display: flex;
 }
-
+#topbar-first #nav-notifications-menu-btn {
+	max-height: 50px;
+}
 /* Notification Menu */
 #topbar-first .topbar-actions #nav-notifications-menu {
 	max-height: 60vh;
@@ -1029,7 +1071,13 @@ nav.navbar .nav > li > button:focus {
 #nav-search-input-field::placeholder {
 	font-size: 13px;
 }
-
+/* navbar button labels */
+.nav-label {
+	display: none;
+}
+body.show-nav-labels .nav-label {
+	display: block;			/* could be block or inline-block, container is flex */
+}
 /* second topbar */
 #topbar-second {
 	height: 40px;
@@ -1044,10 +1092,12 @@ nav.navbar .nav > li > button:focus {
 }
 #topbar-second > .container-fluid {
 	height: 100%;
+	display: flex;
 }
 
 #topbar-second #navbar-button {
 	padding: 0;
+	width: fit-content;		/* Bootstrap calculates width wrong so override */
 }
 #topbar-second .dropdown-menu {
 	padding-top: 0;
@@ -2295,11 +2345,62 @@ code > .hl-main {
 }
 
 /* item social action buttons */
+.action-label {
+	display: none;
+}
+body.show-action-labels .action-label {
+	display: block;		/* MUST be block to prevent grid overflow errors */
+}
 .wall-item-actions {
 	display: flex;
 	margin: 0;
 	justify-content: space-between;
 }
+.wall-item-actions-row {
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr 1fr 1fr min-content;	/* collapse column if checkbox is hidden */
+	grid-auto-rows: 1fr min-height;							/* collapse row if not an event */
+	 grid-template-areas: 
+		"comments shares likes dislikes more delete"
+		"attend . decline . maybe ."; 
+	/* grid bug fix */
+	width: 100%;
+	min-width: 0;
+	justify-content: center;
+	align-content: start;
+}
+	.wall-item-actions-row > * {
+		/* grid bug fixes for items */
+		min-width: 0;
+		overflow-wrap: break-word;
+	}
+	.wall-item-actions-row .button-comments {
+		grid-area: comments;
+	}
+	.wall-item-actions-row .share-links {
+		grid-area: shares;
+	}
+	.wall-item-actions-row [id^="like-"] {
+		grid-area: likes;
+	}
+	.wall-item-actions-row [id^="dislike-"] {
+		grid-area: dislikes;
+	}
+	.wall-item-actions-row [id^="attendyes"] {
+		grid-area: attend;
+	}
+	.wall-item-actions-row [id^="attendno"] {
+		grid-area: decline;
+	}
+	.wall-item-actions-row [id^="attendmaybe"] {
+		grid-area: maybe;
+	}
+	.wall-item-actions-row .more-links {
+		grid-area: more;
+	}
+	.wall-item-actions-row .checkbox {
+		grid-area: delete;
+	}
 .wall-item-actions .btn,
 .wall-item-actions a,
 .wall-item-actions button {
@@ -2330,18 +2431,12 @@ button[disabled] {
 .wall-item-actions-items {
 	flex-grow: 1;
 }
-.wall-item-actions-row {
-	display: flex;
-	padding: 5px;
-}
 .wall-item-actions-row .btn {
 	width: 100%;
 }
-.wall-item-actions-row > * {
-	flex: 1 1 0;
-}
 .wall-item-actions .checkbox {
 	margin: 0 0 0 15px;
+	line-height: 40px;		/* align with icons */
 }
 @media screen and (max-width: 767px) {
 	.wall-item-actions .btn,
@@ -2362,6 +2457,10 @@ button[disabled] {
 }
 .wall-item-actions .separator {
 	margin: 0 0.3em;
+}
+.wall-emoji-responses {
+	display: flex;
+	flex-basis: auto;
 }
 .wall-item-responses {
 	margin-top: .3em;
@@ -2597,7 +2696,8 @@ ul.tabs li.active {
 .tabbar.visible-xs .tabs-extended {
 	padding-top: 0;
 }
-#dropdownMenuTools-xs {
+#dropdownMenuTools-xs,
+#dropdownMenuTools {
 	padding: 9px 15px;
 }
 ul.tabbar ul.tabs-extended:hover li.dropdown {
@@ -2716,6 +2816,16 @@ input[type="range"].form-control {
 			width: 288px!important;
 		}
 		padding-left: 7px;
+	}
+}
+body.show-nav-labels #search-box {
+	padding-right: 0;
+	
+	@media(width < 792px) {
+		& #nav-search-input-field {
+			width: 100px !important;
+		}
+		padding-left: 0px;
 	}
 }
 
@@ -4523,6 +4633,14 @@ div.login-form, .login-content-wrapper,
 		min-width: 80vw!important;
 		max-width: 95vw;
 	}
+  /* no room for one nav icon with labels shown */
+  body.show-nav-labels .navbar-left:has(a[href="community"]) #nav-calendar-link {
+  	display: none;
+  }
+  body.show-nav-labels #topbar-first a.nav-menu,
+  body.show-nav-labels #topbar-first button {
+  	padding: 5px;
+  }
 }
 
 	/* Even smaller mobile displays */
@@ -4557,4 +4675,8 @@ div.login-form, .login-content-wrapper,
 		float: unset!important;
 		margin-left: 0;
 	}
+	body.show-nav-labels .nav-label,
+	body.show-action-labels .action-label {
+	  	font-size: 8px; /* alternatively display:none; this is really small! */
+	}	
 }

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1077,6 +1077,7 @@ nav.navbar .nav > li > button:focus {
 }
 body.show-nav-labels .nav-label {
 	display: block;			/* could be block or inline-block, container is flex */
+	font-size: 12px;
 }
 /* second topbar */
 #topbar-second {

--- a/view/theme/frio/php/default.php
+++ b/view/theme/frio/php/default.php
@@ -29,6 +29,8 @@ $frio                = "view/theme/frio";
 $view_mode_class     = (DI::mode()->isMobile() || DI::mode()->isMobile()) ? 'mobile-view' : 'desktop-view';
 $is_singleuser       = DI::config()->get('system', 'singleuser');
 $is_singleuser_class = $is_singleuser ? "is-singleuser" : "is-not-singleuser";
+$show_action_labels  = (DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'show_action_labels', DI::config()->get('frio', 'show_action_labels', false))) ? 'show-action-labels' : '';
+$show_nav_labels     = (DI::pConfig()->get(DI::userSession()->getLocalUserId(), 'frio', 'show_nav_labels', DI::config()->get('frio', 'show_nav_labels', false))) ? 'show-nav-labels' : '';
 ?>
 <html lang="<?php echo DI::l10n()->getCurrentLang(); ?>">
 	<head>
@@ -67,7 +69,7 @@ echo '<meta name="theme-color" content="' . $nav_bg . '" />';
 ?>
 	</head>
 
-	<body id="top" class="mod-<?php echo $page['module'] . " " . $is_singleuser_class . " " . $view_mode_class;?>">
+	<body id="top" class="mod-<?php echo $page['module'] . " " . $is_singleuser_class . " " . $view_mode_class . " " . $show_action_labels . " " . $show_nav_labels;?>">
 <?php
 	if (!empty($page['nav']) && !$minimal) {
 		echo str_replace(

--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -51,7 +51,8 @@
 #nav-delegation-link:active {
 	background-color: rgba(0, 0, 0, $contentbg_transp);
 	color: white;
-}.dropdown-menu,
+}
+.dropdown-menu,
 .account .dropdown-menu {
 	background-color: $background_color;
 }

--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -39,8 +39,19 @@
 #topbar-second ul.tabs li {
 	border-color: $link_color;
 }
-
-.dropdown-menu,
+#nav-delegation-link {
+	background-color: rgba(255, 255, 255, $contentbg_transp);
+	box-shadow: 0 0 3px $link_color;
+  	-webkit-box-shadow: 0 0 3px $link_color;
+  	-moz-box-shadow: 0 0 3px $link_color;
+  	color: $link_color;
+}
+#nav-delegation-link:hover,
+#nav-delegation-link:focus,
+#nav-delegation-link:active {
+	background-color: rgba(0, 0, 0, $contentbg_transp);
+	color: white;
+}.dropdown-menu,
 .account .dropdown-menu {
 	background-color: $background_color;
 }

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -74,7 +74,8 @@ header #banner #logo-img:hover {
 #nav-delegation-link:active {
 	background-color: rgba(0, 0, 0, $contentbg_transp);
 	color: white;
-}.dropdown-menu > li > a:focus,
+}
+.dropdown-menu > li > a:focus,
 .dropdown-menu > li > a:hover {
 	background-image: none;
 	background-color: rgba(232, 232, 232, $contentbg_transp);

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -62,8 +62,19 @@ header #banner #logo-img:hover {
 .account .dropdown-menu li {
 	border-color: $background_color;
 }
-
-.dropdown-menu > li > a:focus,
+#nav-delegation-link {
+	background-color: rgba(255, 255, 255, $contentbg_transp);
+	box-shadow: 0 0 3px $link_color;
+  	-webkit-box-shadow: 0 0 3px $link_color;
+  	-moz-box-shadow: 0 0 3px $link_color;
+  	color: $link_color;
+}
+#nav-delegation-link:hover,
+#nav-delegation-link:focus,
+#nav-delegation-link:active {
+	background-color: rgba(0, 0, 0, $contentbg_transp);
+	color: white;
+}.dropdown-menu > li > a:focus,
 .dropdown-menu > li > a:hover {
 	background-image: none;
 	background-color: rgba(232, 232, 232, $contentbg_transp);

--- a/view/theme/frio/scheme/gnome.css
+++ b/view/theme/frio/scheme/gnome.css
@@ -410,7 +410,7 @@ aside {
     color: var(--text-primary) !important;
 
     &:hover {
-      background: var(--bg-tertiary)
+      background: var(--bg-tertiary) !important;
     }
   }
 

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -192,14 +192,6 @@
 											<li role="menuitem" class="nav-sitename list-group-item">{{$nav.sitename}}</li>
 										{{/if}}
 									{{/if}}
-									<!--// marcusxss edit
-									<li class="profile-link">
-										<a href="{{$userinfo.link}}">
-											<img src="{{$userinfo.icon}}" alt="{{$userinfo.name}}">&nbsp;
-											{{$userinfo.name}}{{if $nav.remote}} ({{$nav.remote}}){{/if}}
-										</a>
-									</li>
-									end marcusxss //-->
 									<li>
 										<a role="menuitem" id="nav-profile-link" href="{{$userinfo.link.0}}" title="{{$userinfo.link.3}}">
 										<img src="{{$userinfo.icon}}" alt="{{$userinfo.name}}"

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -64,7 +64,7 @@
 							<li class="nav-segment">
 								<a accesskey="b" class="nav-menu" href="{{$nav.back.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 										aria-label="{{$nav.back.3}}" title="{{$nav.back.3}}"><i class="ri ri-xl ri-arrow-go-back-line ri-fw"
-										aria-hidden="true"></i> <span class="d-none">{{$nav.back.1}}</span></a>
+										aria-hidden="true"></i> <span class="nav-label">{{$nav.back.1}}</span></a>
 							</li>
 						{{/if}}
 

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -211,7 +211,6 @@
 											</a>
 										</li>
 									{{/if}}
-									</li>
 									{{foreach $nav.usermenu as $usermenu}}
 										<li>
 											<a role="menuitem" class="{{$usermenu.2}}" href="{{$usermenu.0}}"
@@ -283,7 +282,8 @@
 												title="{{$nav.admin.3}}"><i class="ri ri-medal-2-fill ri-fw" aria-hidden="true"></i>
 												{{$nav.admin.1}}
 											</a>
-										</li>									{{/if}}
+										</li>
+									{{/if}}
 									{{if $nav.moderation}}
 										<li>
 											<a accesskey="m" role="menuitem" id="nav-moderation-link"
@@ -326,10 +326,9 @@
 											</a>
 										</li>
 									{{/if}}
-								</ul>
-							</li>{{* End of userinfo dropdown menu *}}
+								</ul>{{* End of userinfo dropdown menu *}}
+							</li>
 						{{/if}}
-
 					</ul>
 				</div>{{* End of right navbar *}}
 

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -72,7 +72,7 @@
 							<li class="nav-segment">
 								<a accesskey="n" class="nav-menu {{$sel.network}}" href="{{$nav.network.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.network.3}}" title="{{$nav.network.3}}"><i
-									 class="ri ri-xl ri-home-5-{{if $sel.network}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.network.1}}</span><span id="net-update"
+									 class="ri ri-xl ri-home-5-{{if $sel.network}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="nav-label">{{$nav.network.1}}</span><span id="net-update"
 										class="nav-network-badge badge nav-notification"></span></a>
 							</li>
 						{{/if}}
@@ -81,7 +81,7 @@
 							<li class="nav-segment">
 								<a accesskey="c" class="nav-menu {{$sel.community}}" href="{{$nav.community.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.community.3}}" title="{{$nav.community.3}}"><i
-									  class="ri ri-xl ri-earth-{{if $sel.community}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.community.1}}</span></a>
+									  class="ri ri-xl ri-earth-{{if $sel.community}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="nav-label">{{$nav.community.1}}</span></a>
 							</li>
 						{{/if}}
 
@@ -89,7 +89,7 @@
 							<li class="nav-segment">
 								<a accesskey="e" id="nav-calendar-link" href="{{$nav.calendar.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.calendar.1}}" title="{{$nav.calendar.3}}" class="nav-menu {{$sel.calendar}}"><i
-									class="ri ri-xl ri-calendar-2-{{if $sel.calendar}}fill{{else}}line{{/if}} ri-fw"></i> <span class="d-none">{{$nav.calendar.1}}</span></a>
+									class="ri ri-xl ri-calendar-2-{{if $sel.calendar}}fill{{else}}line{{/if}} ri-fw"></i> <span class="nav-label">{{$nav.calendar.1}}</span></a>
 							</li>
 						{{/if}}
 
@@ -98,7 +98,7 @@
 							<li class="nav-segment">
 								<a accesskey="l" class="nav-menu {{$sel.channel}}" href="{{$nav.channel.0}}"
 									data-toggle="tooltip" data-viewport="#topbar-first" aria-label="{{$nav.channel.3}}" title="{{$nav.channel.3}}"><i
-										class="ri ri-xl ri-newspaper-{{if $sel.channel}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="d-none">{{$nav.channel.1}}</span></a>
+										class="ri ri-xl ri-newspaper-{{if $sel.channel}}fill{{else}}line{{/if}} ri-fw" aria-hidden="true"></i> <span class="nav-label">{{$nav.channel.1}}</span></a>
 							</li>
 						{{/if}}
 
@@ -114,7 +114,7 @@
 								<a accesskey="k" id="nav-contacts-link" href="{{$nav.contacts.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.contacts.1}}" title="{{$nav.contacts.1}}"
 									class="nav-menu {{$sel.contacts}} {{$nav.contacts.2}}"><i
-										class="ri ri-contacts-{{if $sel.contacts}}fill{{else}}line{{/if}} ri-lg ri-fw"></i> <span class="d-none">{{$nav.contacts.1}}</span></a>
+										class="ri ri-contacts-{{if $sel.contacts}}fill{{else}}line{{/if}} ri-lg ri-fw"></i> <span class="nav-label">{{$nav.contacts.1}}</span></a>
 							</li>
 						{{/if}}
 
@@ -123,7 +123,7 @@
 								<a accesskey="m" id="nav-messages-link" href="{{$nav.messages.0}}" data-toggle="tooltip" data-viewport="#topbar-first"
 									aria-label="{{$nav.messages.1}}" title="{{$nav.messages.1}}"
 									class="nav-menu {{$sel.messages}}"><i class="ri ri-mail-{{if $sel.messages}}fill{{else}}line{{/if}} ri-lg ri-fw"
-										aria-hidden="true"></i> <span class="d-none">{{$nav.messages.1}}</span><span id="mail-update"
+										aria-hidden="true"></i> <span class="nav-label">{{$nav.messages.1}}</span><span id="mail-update"
 										class="nav-mail-badge badge nav-notification"></span></a>
 							</li>
 						{{/if}}
@@ -135,7 +135,7 @@
 									type="button" aria-haspopup="true" aria-expanded="false"
 									aria-controls="nav-notifications-menu">
 									<span id="notification-update" class="nav-notification-badge badge nav-notification"></span>
-									<i class="ri ri-notification-line ri-lg" aria-label="{{$nav.notifications.1}}"></i>  <span class="d-none">{{$nav.notifications.1}}</span>
+									<i class="ri ri-notification-line ri-lg" aria-label="{{$nav.notifications.1}}"></i>  <span class="nav-label">{{$nav.notifications.1}}</span>
 								</button>
 								{{* The notifications dropdown menu. There are two parts of menu. The second is at the bottom of this file. It is loaded via js. Look at nav-notifications-template *}}
 								<ul id="nav-notifications-menu" class="dropdown-menu menu-popup" role="menu"

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -43,6 +43,7 @@
 						data-target="#search-mobile" aria-expanded="false" aria-controls="search-mobile">
 						<span class="sr-only">Toggle Search</span>
 						<i class="ri ri-search-line ri-fw ri-lg" aria-hidden="true"></i>
+						<span class="nav-label">{{$nav.search.1}}</span>
 					</button>
 				</header>
 				<!-- div for navbar width-->
@@ -163,26 +164,24 @@
 							</li>
 						{{/if}}
 
-					{{* Mobile user menu dropdown button *}}
-					<button type="button" class="navbar-toggle offcanvas-right-toggle"
-						aria-controls="offcanvasUsermenu" aria-haspopup="true">
-						<span class="sr-only">Toggle navigation</span>
-						<i class="ri ri-more-2-line ri-fw ri-lg" aria-hidden="true"></i>
-					</button>
-
 						{{* The user dropdown menu *}}
 						{{if $userinfo}}
-							<li id="nav-user-linkmenu" class="dropdown account nav-menu hidden-xs">
+							<li id="nav-user-linkmenu" class="dropdown account nav-menu">
 								<button accesskey="u" id="main-menu" class="btn-link dropdown-toggle nav-avatar"
 									data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false"
 									aria-controls="nav-user-menu">
-									<div aria-hidden="true" class="user-title pull-left hidden-xs hidden-sm hidden-md">
-										{{$userinfo.name}}<br>
+									<div aria-hidden="true" class="user-title pull-left hidden-xs hidden-sm hidden-md nav-label">
+										<strong>{{$userinfo.name}}</strong><br>
 										{{if $nav.remote}}<span class="truncate">{{$nav.remote}}</span>{{/if}}
 									</div>
-
+									<div class="user-avatar hidden-xs">
 									<img id="avatar" src="{{$userinfo.icon}}" alt="{{$userinfo.name}}">
 									<span class="caret"></span>
+									</div>
+									<div aria-hidden="true" class="mobile-toggle visible-xs">
+										<span class="sr-only">Toggle navigation</span>
+										<i class="ri ri-more-2-line ri-fw ri-lg" aria-hidden="true"></i>
+									</div>
 								</button>
 
 								{{* The list of available usermenu links *}}
@@ -190,16 +189,36 @@
 									aria-labelledby="main-menu">
 									{{if $nav.remote}}
 										{{if $nav.sitename}}
-											<li id="nav-sitename" role="menuitem">{{$nav.sitename}}</li>
-											<li class="divider"><hr></li>
+											<li role="menuitem" class="nav-sitename list-group-item">{{$nav.sitename}}</li>
 										{{/if}}
 									{{/if}}
-
+									<!--// marcusxss edit
 									<li class="profile-link">
 										<a href="{{$userinfo.link}}">
 											<img src="{{$userinfo.icon}}" alt="{{$userinfo.name}}">&nbsp;
 											{{$userinfo.name}}{{if $nav.remote}} ({{$nav.remote}}){{/if}}
 										</a>
+									</li>
+									end marcusxss //-->
+									<li>
+										<a role="menuitem" id="nav-profile-link" href="{{$userinfo.link.0}}" title="{{$userinfo.link.3}}">
+										<img src="{{$userinfo.icon}}" alt="{{$userinfo.name}}"
+											style="max-width:15px; max-height:15px; min-width:15px; min-height:15px; width:15px; height:15px;"/>&nbsp;
+										{{$userinfo.name}}{{if $nav.remote}} ({{$nav.remote}}) {{/if}}
+										</a>
+									</li>
+									{{if $nav.delegation}}
+										<li>
+											<a role="menuitem" id="nav-delegation-link"
+												class="nav-commlink {{$nav.delegation.2}} {{$sel.delegation}}"
+												href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}">
+												{{if $nav.delegation.2}}
+												<i class="ri ri-user-add-line ri-fw" aria-hidden="true"></i>
+												{{else}}
+												<i class="ri ri-arrow-left-right-line ri-fw" aria-hidden="true"></i>{{/if}} {{$nav.delegation.1}}
+											</a>
+										</li>
+									{{/if}}
 									</li>
 									{{foreach $nav.usermenu as $usermenu}}
 										<li>
@@ -211,6 +230,17 @@
 										</li>
 									{{/foreach}}
 									<li class="divider visible-xs"><hr></li>
+									{{if $nav.messages}}
+										<li class="visible-xs">
+											<a role="menuitem"
+												class="nav-commlink {{$nav.messages.2}} {{$sel.messages}}"
+												href="{{$nav.messages.0}}" title="{{$nav.messages.3}}">
+												<i class="ri ri-mail-line ri-fw" aria-hidden="true"></i>
+												{{$nav.messages.1}} <span id="mail-update-li"
+													class="nav-mail-badge badge nav-notification"></span>
+											</a>
+										</li>
+									{{/if}}
 									{{if $nav.contacts}}
 										<li class="visible-xs">
 											<a role="menuitem" id="nav-menu-contacts-link"
@@ -218,15 +248,6 @@
 												title="{{$nav.contacts.3}}">
 												<i class="ri ri-contacts-line ri-fw" aria-hidden="true"></i>
 												{{$nav.contacts.1}}
-											</a>
-										</li>
-									{{/if}}
-									{{if $nav.delegation}}
-										<li>
-											<a role="menuitem" id="nav-delegation-link"
-												class="nav-commlink {{$nav.delegation.2}} {{$sel.delegation}}"
-												href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}">
-												<i class="ri ri-arrow-left-right-line ri-fw" aria-hidden="true"></i> {{$nav.delegation.1}}
 											</a>
 										</li>
 									{{/if}}
@@ -320,111 +341,6 @@
 					</ul>
 				</div>{{* End of right navbar *}}
 
-				{{* The usermenu dropdown for the mobile view. Offcanvas on the right side of the screen.
-					It is called via the buttons. Have a look at the top of this file *}}
-				<div class="offcanvas-right-overlay visible-xs-block"></div>
-				<div id="offcanvasUsermenu" class="offcanvas-right visible-xs-block">
-					<div class="nav-container">
-						<ul role="menu" class="list-group">
-							{{if $nav.remote}}
-								{{if $nav.sitename}}
-									<li role="menuitem" class="nav-sitename list-group-item">{{$nav.sitename}}</li>
-								{{/if}}
-							{{/if}}
-							<li class="list-group-item profile-link">
-								<a href="{{$userinfo.link}}">
-									<img src="{{$userinfo.icon}}" alt="{{$userinfo.name}}">&nbsp;
-									{{$userinfo.name}}{{if $nav.remote}} ({{$nav.remote}}){{/if}}
-								</a>
-							</li>
-							{{foreach $nav.usermenu as $usermenu}}
-								<li class="list-group-item">
-									<a role="menuitem" class="{{$usermenu.2}}"
-										href="{{$usermenu.0}}" title="{{$usermenu.3}}">
-										<i class="ri {{$usermenu.4}}"></i>&nbsp;
-										{{$usermenu.1}}
-									</a>
-								</li>
-							{{/foreach}}
-							{{if $nav.contacts || $nav.delegation}}
-								<li class="divider"><hr></li>
-							{{/if}}
-							{{if $nav.contacts}}
-								<li class="list-group-item">
-									<a role="menuitem"
-										class="nav-link {{$nav.contacts.2}}" href="{{$nav.contacts.0}}"
-										title="{{$nav.contacts.3}}"><i class="ri ri-contacts-line ri-fw" aria-hidden="true"></i>
-										{{$nav.contacts.1}}
-									</a>
-								</li>
-							{{/if}}
-							{{if $nav.delegation}}
-								<li class="list-group-item">
-									<a role="menuitem"
-										class="nav-commlink {{$nav.delegation.2}} {{$sel.delegation}}"
-										href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}"><i class="ri ri-arrow-left-right-line ri-fw"
-											aria-hidden="true"></i> {{$nav.delegation.1}}
-									</a>
-								</li>
-							{{/if}}
-							{{if $nav.settings || $nav.admin || $nav.logout}}
-								<li class="divider"><hr></li>
-							{{/if}}
-							{{if $nav.settings}}
-								<li class="list-group-item">
-									<a role="menuitem" class="nav-link {{$nav.settings.2}}" href="{{$nav.settings.0}}"
-										title="{{$nav.settings.3}}"><i class="ri ri-settings-3-line ri-fw" aria-hidden="true"></i>
-										{{$nav.settings.1}}
-									</a>
-								</li>
-							{{/if}}
-							{{if $nav.admin}}
-								<li class="list-group-item">
-									<a role="menuitem"
-										class="nav-link {{$nav.admin.2}}" href="{{$nav.admin.0}}" title="{{$nav.admin.3}}"><i
-											class="ri ri-admin-line ri-fw" aria-hidden="true"></i>
-										{{$nav.admin.1}}
-									</a>
-								</li>
-							{{/if}}
-							{{if $nav.moderation}}
-								<li class="list-group-item">
-									<a role="menuitem"
-										class="nav-link {{$nav.moderation.2}}" href="{{$nav.moderation.0}}" title="{{$nav.moderation.3}}"><i
-											class="ri ri-shield-user-line ri-fw" aria-hidden="true"></i>
-										{{$nav.moderation.1}}
-									</a>
-								</li>
-							{{/if}}
-							<li class="divider"><hr></li>
-						<li class="list-group-item">
-							<a role="menuitem" class="nav-link {{$nav.about.2}}"
-								href="{{$nav.about.0}}" title="{{$nav.about.3}}">
-								<i class="ri ri-information-line ri-fw" aria-hidden="true"></i> {{$nav.about.1}}
-							</a>
-						</li>
-							<li class="divider"><hr></li>
-							{{if $nav.logout}}
-								<li class="list-group-item">
-									<a role="menuitem"
-										class="nav-link {{$nav.logout.2}}" href="{{$nav.logout.0}}" title="{{$nav.logout.3}}"><i
-											class="ri ri ri-logout-box-line ri-fw" aria-hidden="true"></i>
-										{{$nav.logout.1}}
-									</a>
-								</li>
-							{{else}}
-								<li class="list-group-item">
-									<a role="menuitem"
-										class="nav-login-link {{$nav.login.2}}" href="{{$nav.login.0}}"
-										title="{{$nav.login.3}}"><i class="ri ri-shut-down-line ri-fw" aria-hidden="true"></i>
-										{{$nav.login.1}}
-									</a>
-								</li>
-							{{/if}}
-						</ul>
-					</div>
-				</div>
-				<!--/.sidebar-offcanvas-->
 			</div><!-- end of div for navbar width-->
 		</div><!-- /.container -->
 	</nav><!-- /.navbar -->

--- a/view/theme/frio/templates/theme_settings.tpl
+++ b/view/theme/frio/templates/theme_settings.tpl
@@ -207,6 +207,8 @@
 
 {{include file="field_checkbox.tpl" field=$always_open_compose}}
 {{include file="field_checkbox.tpl" field=$enable_advancedcomposer}}
+{{include file="field_checkbox.tpl" field=$show_nav_labels}}
+{{include file="field_checkbox.tpl" field=$show_action_labels}}
 
 {{if $admin_theme_settings}}
 <div class="settings-submit-wrapper pull-right">

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -323,6 +323,16 @@ as the value of $top_child_total (this is done at the end of this file)
 						<span class="total" title="{{$item.responses.comment.title}}">{{$item.responses.comment.total}}</span>
 						<span class="action-label">{{$item.switchcomment}}</span>
 					</button>
+				{{elseif $item.remote_comment}}
+					<a href="{{$item.remote_comment.2}}" class="btn button-comments" title="{{$item.remote_comment.0}}">
+						<i class="ri ri-chat-3-line" aria-hidden="true"></i>
+						<span class="action-label">{{$item.switchcomment}}</span>
+					</a>
+				{{else}}
+					<button type="button" class="btn button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" disabled>
+						<i class="ri ri-chat-3-line" aria-hidden="true"></i>
+						<span class="action-label">{{$item.switchcomment}}</span>
+					</button>
 				{{/if}}
 
 				{{if $item.vote.announce OR $item.vote.share}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -567,7 +567,15 @@ as the value of $top_child_total (this is done at the end of this file)
 		</div><!--./wall-item-actions-->
 
 		<div class="wall-item-links"></div>
-
+		<div class="wall-emoji-responses">
+				{{foreach $item.reactions as $emoji}}
+					{{if $emoji.icon.fa}}
+						<span class="wall-item-emoji" title="{{$emoji.title}}"><i class="ri {{$emoji.icon.fa}}" aria-hidden="true"></i> {{$emoji.total}}</span>
+					{{else}}
+						<span class="wall-item-emoji" title="{{$emoji.title}}">{{$emoji.emoji}} {{$emoji.total}}</span>
+					{{/if}}
+				{{/foreach}}		
+		</div>
 		{{* Display likes, dislike and attendance stats *}}
 		{{if $item.legacy_activities}}
 			<div class="wall-item-responses">

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -314,248 +314,14 @@ as the value of $top_child_total (this is done at the end of this file)
 
 		<!-- <hr /> -->
 		<div class="wall-item-actions">
-			{{* Action buttons to interact with the item (like: like, dislike, share and so on *}}
-			<div class="wall-item-actions-items btn-toolbar btn-group hidden-xs" role="group">
-				<div class="wall-item-actions-row">
-
-			{{* Button to open the comment text field *}}
-				<span class="wall-item-response">
-				{{if $item.comment_html}}
-					<button type="button" class="btn-link button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="ri ri-chat-3-line" aria-hidden="true"></i></button>
-					<span title="{{$item.responses.comment.title}}">{{$item.responses.comment.total}}</span>
-				{{elseif $item.remote_comment}}
-					<a href="{{$item.remote_comment.2}}" class="btn-link button-comments" title="{{$item.remote_comment.0}}"><i class="ri ri-chat-3-line" aria-hidden="true"></i></a>
-				{{else}}
-					<button type="button" class="btn-link button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" disabled><i class="ri ri-chat-3-line" aria-hidden="true"></i></button>
-				{{/if}}
-				</span>
-
-			{{* Button for sharing the item *}}
-			{{if $item.vote}}
-				<span class="wall-item-response">
-				{{if $item.vote.announce}}
-					<button type="button" class="btn-link button-announces{{if $item.responses.announce.self}} active" aria-pressed="true{{/if}}" id="announce-{{$item.id}}" title="{{$item.vote.announce.0}}" onclick="doActivityItemAction({{$item.id}}, 'announce'{{if $item.responses.announce.self}}, true{{/if}});" ><i class="ri ri-repeat-line" aria-hidden="true"></i></button>
-					<span title="{{$item.responses.announce.title}}">{{$item.responses.announce.total}}</span>
-				{{else}}
-					<button type="button" class="btn-link button-announces" id="announce-{{$item.id}}" title="{{$item.vote.announce.0}}" disabled><i class="ri ri-repeat-line" aria-hidden="true"></i></button>
-				{{/if}}
-				</span>
-				<span class="wall-item-response">
-				{{if $item.vote.share}}
-					<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" onclick="jotShare({{$item.id}});"><i class="ri ri-double-quotes-r" aria-hidden="true"></i></button>
-					<span title="{{$item.quoteshares.title}}">{{$item.quoteshares.total}}</span>
-				{{else}}
-					<button type="button" class="btn-link button-votes" id="share-{{$item.id}}" title="{{$item.vote.share.0}}" disabled><i class="ri ri-double-quotes-r" aria-hidden="true"></i></button>
-				{{/if}}
-				</span>
-			{{/if}}
-
-			{{* Buttons for like and dislike *}}
-			{{if $item.vote}}
-				<span class="wall-item-response">
-				{{if $item.vote.like}}
-					<button type="button" class="btn-link button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doActivityItemAction({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}});" ><i class="ri ri-thumb-up-line" aria-hidden="true"></i></button>
-					<span title="{{$item.responses.like.title}}">{{$item.responses.like.total}}</span>
-				{{else}}
-					<button type="button" class="btn-link button-likes" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" disabled><i class="ri ri-thumb-up-line" aria-hidden="true"></i></button>
-				{{/if}}
-				</span>
-				<span class="wall-item-response">
-				{{if $item.vote.dislike}}
-					<button type="button" class="btn-link button-likes{{if $item.responses.dislike.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doActivityItemAction({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}});" ><i class="ri ri-thumb-down-line" aria-hidden="true"></i></button>
-					<span title="{{$item.responses.dislike.title}}">{{$item.responses.dislike.total}}</span>
-				{{elseif !$item.hide_dislike}}
-					<button type="button" class="btn-link button-likes" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" disabled><i class="ri ri-thumb-down-line" aria-hidden="true"></i></button>
-				{{/if}}
-				</span>
-
-				{{foreach $item.reactions as $emoji}}
-					{{if $emoji.icon.fa}}
-						<span class="wall-item-emoji" title="{{$emoji.title}}"><i class="ri {{$emoji.icon.fa}}" aria-hidden="true"></i> {{$emoji.total}}</span>
-					{{else}}
-						<span class="wall-item-emoji" title="{{$emoji.title}}">{{$emoji.emoji}} {{$emoji.total}}</span>
-					{{/if}}
-				{{/foreach}}
-			{{/if}}
-
-			{{* Event attendance buttons *}}
-			<span class="vote-event">
-			{{if $item.isevent}}
-				<span class="wall-item-response">
-					<button type="button" class="btn-link button-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});"><i class="ri ri-check-line" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i></button>
-					<span title="{{$item.responses.attendyes.title}}">{{$item.responses.attendyes.total}}</span>
-				</span>
-				<span class="wall-item-response">
-					<button type="button" class="btn-link button-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});"><i class="ri ri-close-line" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i></button>
-					<span title="{{$item.responses.attendno.title}}">{{$item.responses.attendno.total}}</span>
-				</span>
-				<span class="wall-item-response">
-					<button type="button" class="btn-link button-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});"><i class="ri ri-question-line" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i></button>
-					<span title="{{$item.responses.attendmaybe.title}}">{{$item.responses.attendmaybe.total}}</span>
-				</span>
-			{{else}}
-				<span class="wall-item-response"></span>
-				<span class="wall-item-response"></span>
-				<span class="wall-item-response"></span>
-			{{/if}}
-			</span>
-			</div>
-			</div>
-			<span class="wall-item-actions-right hidden-xs">
-			{{* Put additional actions in a dropdown menu *}}
-		<span class="more-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}">
-			<button type="button" class="btn-link dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="ri ri-more-line" aria-hidden="true"></i></button>
-			<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenuOptions-{{$item.id}}">
-
-				{{* Available: On your own posts and comments *}}
-				{{if $item.edpost}} {{* edit the posting *}}
-				<li role="menuitem">
-						<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" class="btn-link navicon pencil"><i class="ri ri-pencil-line" aria-hidden="true"></i>&ensp;{{$item.edpost.1}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On your own posts *}}
-				{{if $item.pin}}
-				<li role="menuitem">
-						<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}"><i class="ri ri-pushpin-line" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
-						<a id="unpin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classundo}}"><i class="ri ri-pushpin-line" aria-hidden="true"></i>&ensp;{{$item.pin.undo}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On your own posts *}}
-				{{* TODO: This currently creates a duplicate post according to: https://forum.friendi.ca/display/373ebf56-2469-ed09-ccc0-ecd539065051 *}}
-				{{if $item.tagger}} {{* tag the post *}}
-				<li role="menuitem">
-						<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}"><i class="ri ri-hashtag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On posts made by anyone *}}
-				{{if $item.star}}
-				<li role="menuitem">
-						<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}"><i class="ri ri-bookmark-line" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
-						<a id="unstar-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classundo}}"><i class="ri ri-bookmark-fill" aria-hidden="true"></i>&ensp;{{$item.star.undo}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On all posts and comments *}}
-				{{if $item.filer}}
-				<li role="menuitem">
-						<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon"><i class="ri ri-folder-line" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On (some) posts and comments? *}}
-				{{* Not supported by Firefox desktop as of 2026-05 *}}
-				{{* Requires HTTPS and requires that the permission is enabled *}}
-				{{* TODO: Add the relevant checks so this is only available/clickable when on a device where its supported *}}
-				{{if $item.browsershare}}
-				<li role="menuitem" class="button-browser-share">
-						<a id="browser-share-{{$item.id}}" href="javascript:navigator.share({url: '{{$item.plink.orig}}'})" class="btn-link button-browser-share" title="{{$item.browsershare.1}}"><i class="ri ri-share-line" aria-hidden="true"></i>&ensp;{{$item.browsershare.0}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On posts made by others *}}
-				{{* Identical to unignore in functionality but only seen on posts you haven't liked/commented on - could they be merged? *}}
-				{{if $item.follow_thread}}
-				<li role="menuitem">
-						<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link"><i class="ri ri-notification-3-line" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On all posts *}}
-				{{if $item.ignore}}
-				<li role="menuitem">
-						<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}"><i class="ri ri-notification-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore.do}}</a>
-				</li>
-				<li role="menuitem">
-						<a id="unignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classundo}}"><i class="ri ri-notification-3-line" aria-hidden="true"></i>&ensp;{{$item.ignore.undo}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On posts made by others *}}
-				{{if $item.complete_thread}}
-				<li role="menuitem">
-						<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link"><i class="ri ri-download-line" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
-				</li>
-				{{/if}}
-
-				<li class="divider"><hr></li>
-
-				{{* Available: On posts made by others *}}
-				{{if $item.collapse}}
-				<li role="menuitem">
-						<a class="btn-link navicon collapse" href="javascript:collapseAuthor('item/collapse/{{$item.id}}', 'item-{{$item.guid}}');"><i class="ri ri-subtract-line" aria-hidden="true"></i>&ensp;{{$item.collapse.label}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On posts made by others *}}
-				{{if $item.ignore_author}}
-				<li role="menuitem">
-						<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');"><i class="ri ri-eye-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On posts made by others *}}
-				{{if $item.block}}
-				<li role="menuitem">
-						<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');"><i class="ri ri-forbid-2-line" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
-				</li>
-				{{/if}}
-
-				{{if $item.collapse || $item.ignore_author || $item.block }}
-				<li class="divider"><hr></li>
-				{{/if}}
-
-				{{* Available: On posts made by others *}}
-				{{if $item.ignore_server}}
-				<li role="menuitem">
-						<a class="btn-link navicon ignoreServer" href="javascript:ignoreServer('settings/server/{{$item.author_gsid}}/ignore', 'item-{{$item.guid}}');"><i class="ri ri-eye-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore_server.label}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On all posts and comments *}}
-				<li role="menuitem">
-						<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item"><i class="ri ri-file-text-line" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
-				</li>
-
-				{{* Available: On all posts and comments *}}
-				{{if $item.language}}
-				<li role="menuitem">
-						<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item"><i class="ri ri-translate-2" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: On all posts and comments made by others *}}
-				{{if $item.report}}
-				<li role="menuitem">
-						<a class="btn-link navicon ignore" href="{{$item.report.href}}"><i class="ri ri-flag-line" aria-hidden="true"></i>&ensp;{{$item.report.label}}</a>
-				</li>
-				{{/if}}
-
-				{{* Available: If you're an admin, on all posts and comments on your instance *}}
-				{{if $item.drop && $item.drop.dropping}}
-				<li role="menuitem">
-						<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');"><i class="ri ri-delete-bin-line" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
-				</li>
-				{{/if}}
-			</ul>
-		</span>
-		{{if $item.drop.pagedrop}}
-		<span class="pull-right checkbox" aria-hidden="true">
-			{{if $item.drop}}
-				<input type="checkbox" title="{{$item.drop.select}}" name="itemselected[]" id="checkbox-{{$item.id}}" class="item-select" value="{{$item.id}}" />
-				<label for="checkbox-{{$item.id}}"></label>
-			{{/if}}
-		</span>
-		{{/if}}
-		</span>
-			<div class="wall-item-actions-items btn-toolbar btn-group visible-xs" role="group">
+			<div class="wall-item-actions-items btn-toolbar btn-group" role="group">
 				<div class="wall-item-actions-row">
 				{{* Button to open the comment text field *}}
 				{{if $item.comment_html}}
-					<button type="button" class="btn button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}><i class="ri ri-chat-3-line" aria-hidden="true"></i>
-						<span title="{{$item.responses.comment.title}}">{{$item.responses.comment.total}}</span>
+					<button type="button" class="btn button-comments" id="comment-{{$item.id}}" title="{{$item.switchcomment}}" {{if $item.thread_level != 1}}onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});" {{else}} onclick="openClose('item-comments-{{$item.id}}'); commentExpand({{$item.id}});"{{/if}}>
+						<i class="ri ri-chat-3-line" aria-hidden="true"></i>
+						<span class="total" title="{{$item.responses.comment.title}}">{{$item.responses.comment.total}}</span>
+						<span class="action-label">{{$item.switchcomment}}</span>
 					</button>
 				{{/if}}
 
@@ -563,6 +329,18 @@ as the value of $top_child_total (this is done at the end of this file)
 					<div class="share-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}" role="group">
 						<button type="button" class="btn dropdown-toggle{{if $item.responses.announce.self}} active{{/if}}" data-toggle="dropdown" id="shareMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}">
 							<i class="ri ri-share-forward-line" aria-hidden="true"></i>
+							{{if $item.responses.announce.total}}
+							{{assign var=shares value=$item.responses.announce.total}}
+							{{else}}
+							{{assign var=shares value=0}}
+							{{/if}}
+							{{if $item.quoteshares.total}}
+							{{assign var=quotes value=$item.quoteshares.total}}
+							{{else}}
+							{{assign var=quotes value=0}}
+							{{/if}}
+							<span class="total" title="{{$item.responses.announce.title}} {{$item.responses.quoteshares.title}}">{{if $quotes+$shares > 0}}{{$quotes+$shares}}{{/if}}</span>
+							<span class="action-label">{{$item.vote.announce.1}}</span>
 						</button>
 						<ul class="dropdown-menu dropdown-menu-left" role="menu" aria-labelledby="shareMenuOptions-{{$item.id}}">
 							{{if $item.vote.announce}} {{* edit the posting *}}
@@ -599,41 +377,55 @@ as the value of $top_child_total (this is done at the end of this file)
 				{{* Buttons for like and dislike *}}
 				{{if $item.vote}}
 					{{if $item.vote.like}}
-					<button type="button" class="btn button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doActivityItemAction({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}});" ><i class="ri ri-thumb-up-line" aria-hidden="true"></i>
-						<span title="{{$item.responses.like.title}}">{{$item.responses.like.total}}</span>
+					<button type="button" class="btn button-likes{{if $item.responses.like.self}} active" aria-pressed="true{{/if}}" id="like-{{$item.id}}" title="{{$item.vote.like.0}}" onclick="doActivityItemAction({{$item.id}}, 'like'{{if $item.responses.like.self}}, true{{/if}});" >
+						<i class="ri ri-thumb-up-line" aria-hidden="true"></i>
+						<span class="total" title="{{$item.responses.like.title}}">{{$item.responses.like.total}}</span>
+						<span class="action-label">{{$item.vote.like.1}}</span>
 					</button>
 					{{/if}}
 					{{if $item.vote.dislike}}
-					<button type="button" class="btn button-likes{{if $item.responses.dislike.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doActivityItemAction({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}});" ><i class="ri ri-thumb-down-line" aria-hidden="true"></i>
-						<span title="{{$item.responses.dislike.title}}">{{$item.responses.dislike.total}}</span>
+					<button type="button" class="btn button-likes{{if $item.responses.dislike.self}} active" aria-pressed="true{{/if}}" id="dislike-{{$item.id}}" title="{{$item.vote.dislike.0}}" onclick="doActivityItemAction({{$item.id}}, 'dislike'{{if $item.responses.dislike.self}}, true{{/if}});" >
+						<i class="ri ri-thumb-down-line" aria-hidden="true"></i>
+						<span class="total" title="{{$item.responses.dislike.title}}">{{$item.responses.dislike.total}}</span>
+						<span class="action-label">{{$item.vote.dislike.1}}</span>
 					</button>
 					{{/if}}
 				{{/if}}
 
 				{{* Event attendance buttons *}}
 				{{if $item.isevent}}
-				<button type="button" class="btn button-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});"><i class="ri ri-check-line" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i>
-					<span title="{{$item.responses.attendyes.title}}">{{$item.responses.attendyes.total}}</span>
+				<button type="button" class="btn button-event{{if $item.responses.attendyes.self}} active" aria-pressed="true{{/if}}" id="attendyes-{{$item.id}}" title="{{$item.attend.0}}" onclick="doActivityItemAction({{$item.id}}, 'attendyes'{{if $item.responses.attendyes.self}}, true{{/if}});">
+					<i class="ri ri-check-line" aria-hidden="true"><span class="sr-only">{{$item.attend.0}}</span></i>
+					<span class="total" title="{{$item.responses.attendyes.title}}">{{$item.responses.attendyes.total}}</span>
+					<span class="action-label">{{$item.attend_label.0}}</span>
 				</button>
-				<button type="button" class="btn button-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});"><i class="ri ri-close-line" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i>
-					<span title="{{$item.responses.attendno.title}}">{{$item.responses.attendno.total}}</span>
+				<button type="button" class="btn button-event{{if $item.responses.attendno.self}} active" aria-pressed="true{{/if}}" id="attendno-{{$item.id}}" title="{{$item.attend.1}}" onclick="doActivityItemAction({{$item.id}}, 'attendno'{{if $item.responses.attendno.self}}, true{{/if}});">
+					<i class="ri ri-close-line" aria-hidden="true"><span class="sr-only">{{$item.attend.1}}</span></i>
+					<span class="total" title="{{$item.responses.attendno.title}}">{{$item.responses.attendno.total}}</span>
+					<span class="action-label">{{$item.attend_label.1}}</span>
 				</button>
-				<button type="button" class="btn button-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});"><i class="ri ri-question-line" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i>
-					<span title="{{$item.responses.attendmaybe.title}}">{{$item.responses.attendmaybe.total}}</span>
+				<button type="button" class="btn button-event{{if $item.responses.attendmaybe.self}} active" aria-pressed="true{{/if}}" id="attendmaybe-{{$item.id}}" title="{{$item.attend.2}}" onclick="doActivityItemAction({{$item.id}}, 'attendmaybe'{{if $item.responses.attendmaybe.self}}, true{{/if}});">
+					<i class="ri ri-question-line" aria-hidden="true"><span class="sr-only">{{$item.attend.2}}</span></i>
+					<span class="total" title="{{$item.responses.attendmaybe.title}}">{{$item.responses.attendmaybe.total}}</span>
+					<span class="action-label">{{$item.attend_label.2}}</span>
 				</button>
 				{{/if}}
 
 				{{* Put additional actions in a dropdown menu *}}
 				{{if $item.edpost || $item.tagger || $item.filer || $item.pin || $item.star || $item.follow_thread || $item.ignore || ($item.drop && $item.drop.dropping)}}
 					<div class="more-links btn-group{{if $item.thread_level > 1}} dropup{{/if}}">
-						<button type="button" class="btn dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}"><i class="ri ri-more-line" aria-hidden="true"></i></button>
+						<button type="button" class="btn dropdown-toggle" data-toggle="dropdown" id="dropdownMenuOptions-{{$item.id}}" aria-haspopup="true" aria-expanded="false" title="{{$item.menu}}">
+							<i class="ri ri-more-line" aria-hidden="true"></i>
+							<span class="action-label">{{$item.menu}}</span>
+						</button>
 						<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenuOptions-{{$item.id}}">
 							{{if $item.edpost}} {{* edit the posting *}}
 							<li role="menuitem">
 								<a href="javascript:editpost('{{$item.edpost.0}}?mode=none');" title="{{$item.edpost.1}}" class="btn-link navicon pencil"><i class="ri ri-pencil-line" aria-hidden="true"></i>&ensp;{{$item.edpost.1}}</a>
 							</li>
 							{{/if}}
-
+							
+							{{* Available: On your own posts *}}
 							{{if $item.pin}}
 								<li role="menuitem">
 									<a id="pin-{{$item.id}}" href="javascript:doPin({{$item.id}});" class="btn-link {{$item.pin.classdo}}" title="{{$item.pin.do}}"><i class="ri ri-pushpin-line" aria-hidden="true"></i>&ensp;{{$item.pin.do}}</a>
@@ -641,12 +433,15 @@ as the value of $top_child_total (this is done at the end of this file)
 								</li>
 							{{/if}}
 
+							{{* Available: On your own posts *}}
+							{{* TODO: This currently creates a duplicate post according to: https://forum.friendi.ca/display/373ebf56-2469-ed09-ccc0-ecd539065051 *}}
 							{{if $item.tagger}} {{* tag the post *}}
 								<li role="menuitem">
 									<a id="tagger-{{$item.id}}" href="javascript:itemTag({{$item.id}});" class="btn-link {{$item.tagger.class}}" title="{{$item.tagger.add}}"><i class="ri ri-hashtag" aria-hidden="true"></i>&ensp;{{$item.tagger.add}}</a>
 								</li>
 							{{/if}}
 
+							{{* Available: On posts made by anyone ("star" changed to "bookmark") *}}
 							{{if $item.star}}
 								<li role="menuitem">
 									<a id="star-{{$item.id}}" href="javascript:doStar({{$item.id}});" class="btn-link {{$item.star.classdo}}" title="{{$item.star.do}}"><i class="ri ri-bookmark-line" aria-hidden="true"></i>&ensp;{{$item.star.do}}</a>
@@ -654,18 +449,33 @@ as the value of $top_child_total (this is done at the end of this file)
 								</li>
 							{{/if}}
 
+							{{* Available: On all posts and comments *}}
 							{{if $item.filer}}
 								<li role="menuitem">
 									<a id="filer-{{$item.id}}" href="javascript:itemFiler({{$item.id}});" class="btn-link filer-item filer-icon" title="{{$item.filer}}"><i class="ri ri-folder-line" aria-hidden="true"></i>&ensp;{{$item.filer}}</a>
 								</li>
 							{{/if}}
 
+							{{* Available: On (some) posts and comments? *}}
+							{{* Not supported by Firefox desktop as of 2026-05 *}}
+							{{* Requires HTTPS and requires that the permission is enabled *}}
+							{{* TODO: Add the relevant checks so this is only available/clickable when on a device where its supported *}}
+							{{if $item.browsershare}}
+							<li role="menuitem" class="button-browser-share">
+									<a id="browser-share-{{$item.id}}" href="javascript:navigator.share({url: '{{$item.plink.orig}}'})" class="btn-link button-browser-share" title="{{$item.browsershare.1}}"><i class="ri ri-share-line" aria-hidden="true"></i>&ensp;{{$item.browsershare.0}}</a>
+							</li>
+							{{/if}}
+
+
+							{{* Available: On posts made by others *}}
+							{{* Identical to unignore in functionality but only seen on posts you haven't liked/commented on - could they be merged? *}}
 							{{if $item.follow_thread}}
 								<li role="menuitem">
 									<a id="follow_thread-{{$item.id}}" href="javascript:{{$item.follow_thread.action}}" class="btn-link" title="{{$item.follow_thread.title}}"><i class="ri ri-notification-3-line" aria-hidden="true"></i>&ensp;{{$item.follow_thread.title}}</a>
 								</li>
 							{{/if}}
 
+							{{* Available: On all posts *}}
 							{{if $item.ignore}}
 								<li role="menuitem">
 									<a id="ignore-{{$item.id}}" href="javascript:doIgnoreThread({{$item.id}});" class="btn-link {{$item.ignore.classdo}}" title="{{$item.ignore.do}}"><i class="ri ri-notification-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore.do}}</a>
@@ -675,6 +485,7 @@ as the value of $top_child_total (this is done at the end of this file)
 								</li>
 							{{/if}}
 
+							{{* Available: On posts made by others *}}
 							{{if $item.complete_thread}}
 								<li role="menuitem">
 									<a id="complete_thread-{{$item.id}}" href="javascript:{{$item.complete_thread.action}}" class="btn-link" title="{{$item.complete_thread.title}}"><i class="ri ri-download-line" aria-hidden="true"></i>&ensp;{{$item.complete_thread.title}}</a>
@@ -683,18 +494,21 @@ as the value of $top_child_total (this is done at the end of this file)
 
 							<li class="divider"><hr></li>
 
+							{{* Available: On posts made by others *}}
 							{{if $item.collapse}}
 								<li role="menuitem">
 									<a class="btn-link navicon collapse" href="javascript:collapseAuthor('item/collapse/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.collapse.label}}"><i class="ri ri-subtract-line" aria-hidden="true"></i>&ensp;{{$item.collapse.label}}</a>
 								</li>
 							{{/if}}
 
+							{{* Available: On posts made by others *}}
 							{{if $item.ignore_author}}
 								<li role="menuitem">
 									<a class="btn-link navicon ignore" href="javascript:ignoreAuthor('item/ignore/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.ignore_author.label}}"><i class="ri ri-eye-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore_author.label}}</a>
 								</li>
 							{{/if}}
 
+							{{* Available: On posts made by others *}}
 							{{if $item.block}}
 								<li role="menuitem">
 									<a class="btn-link navicon block" href="javascript:blockAuthor('item/block/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.block.label}}"><i class="ri ri-forbid-2-line" aria-hidden="true"></i>&ensp;{{$item.block.label}}</a>
@@ -705,31 +519,36 @@ as the value of $top_child_total (this is done at the end of this file)
 								<li class="divider"><hr></li>
 							{{/if}}
 
+							{{* Available: On posts made by others *}}
 							{{if $item.ignore_server}}
 								<li role="menuitem">
 									<a class="btn-link navicon ignoreServer" href="javascript:ignoreServer('settings/server/{{$item.author_gsid}}/ignore', 'item-{{$item.guid}}');" title="{{$item.ignore_server.label}}"><i class="ri ri-eye-off-line" aria-hidden="true"></i>&ensp;{{$item.ignore_server.label}}</a>
 								</li>
 							{{/if}}
 
+							{{* Available: On all posts and comments *}}
 							<li role="menuitem">
 								<a id="searchtext-{{$item.id}}" href="javascript:displaySearchText({{$item.uriid}});" class="btn-link filer-item" title="{{$item.searchtext}}"><i class="ri ri-file-text-line" aria-hidden="true"></i>&ensp;{{$item.searchtext}}</a>
 							</li>
 
+							{{* Available: On all posts and comments *}}
 							{{if $item.language}}
 								<li role="menuitem">
 									<a id="language-{{$item.id}}" href="javascript:displayLanguage({{$item.uriid}});" class="btn-link filer-item" title="{{$item.language}}"><i class="ri ri-translate-2" aria-hidden="true"></i>&ensp;{{$item.language}}</a>
 								</li>
 							{{/if}}
 
+							{{* Available: On all posts and comments made by others *}}
 							{{if $item.report}}
 								<li role="menuitem">
 									<a class="btn-link navicon ignore" href="{{$item.report.href}}"><i class="ri ri-flag-line" aria-hidden="true"></i>&ensp;{{$item.report.label}}</a>
 								</li>
 							{{/if}}
 
+							{{* Available: If you're an admin, on all posts and comments on your instance *}}
 							{{if $item.drop && $item.drop.dropping}}
 								<li role="menuitem">
-                                                			<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="ri ri-delete-bin-line" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
+                                	<a class="btn-link navicon delete" href="javascript:dropItem('item/drop/{{$item.id}}', 'item-{{$item.guid}}');" title="{{$item.drop.label}}"><i class="ri ri-delete-bin-line" aria-hidden="true"></i>&ensp;{{$item.drop.label}}</a>
 								</li>
 							{{/if}}
 						</ul>

--- a/view/theme/frio/theme.php
+++ b/view/theme/frio/theme.php
@@ -219,7 +219,7 @@ function frio_remote_nav(array &$nav_info): void
 			$nav_info['userinfo'] = [
 				'icon' => Contact::getMicro($remoteUser),
 				'name' => $remoteUser['name'],
-				'link' => $server_url . '/profile/' . $remoteUser['nick'],
+				'link' => [$server_url . '/profile/' . $remoteUser['nick'] . '/profile', DI::l10n()->t('Profile'), '', DI::l10n()->t('My profile')],
 			];
 		}
 


### PR DESCRIPTION
This PR applies the things discussed in this issue: https://github.com/friendica/friendica/issues/15977

It adds to the Frio Theme settings options to show/hide text labels on the main navigation icons and/or show text labels under the action buttons below each post. They are disabled by default.

This also streamlines both the main user menu and the action buttons. Currently there are two versions of each of those, one for desktop and one for mobile.  There is now only one version of each of those. The main menu converts from a drop-down to a slide-in panel. The action buttons are the mobile set, so now there isn't a different UI for them depending on screen size, and they are more in line with how those buttons are shown on both Mastodon and Bluesky.

There are also slight changes to the main menu of Vier because of changes in the core Nav.php file, but this is otherwise primarily a Frio theme thing.

I really hope I found all the bits and pieces I changed because this is one of about eight PRs I'm working on, which is to say someone else may want to apply this and check that it all works.