### PR TITLE
Multi-Image Layout & Functional Alt-Text Buttons

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -41,6 +41,11 @@
 		}],
 
 		"no-duplicate-selectors": [true, { "severity": "warning" }],
+		"selector-type-no-unknown": [true, {
+			"severity": "warning",
+			"ignoreTypes": ["right_aside"]
+		}],
+		"font-family-no-missing-generic-family-keyword": [true, { "severity": "warning" }],
 		"declaration-property-value-keyword-no-deprecated": [true, { "severity": "warning" }],
 		"property-no-deprecated": [true, { "severity": "warning" }],
 		"block-no-empty": [true, { "severity": "warning" }]

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -41,11 +41,6 @@
 		}],
 
 		"no-duplicate-selectors": [true, { "severity": "warning" }],
-		"selector-type-no-unknown": [true, {
-			"severity": "warning",
-			"ignoreTypes": ["right_aside"]
-		}],
-		"font-family-no-missing-generic-family-keyword": [true, { "severity": "warning" }],
 		"declaration-property-value-keyword-no-deprecated": [true, { "severity": "warning" }],
 		"property-no-deprecated": [true, { "severity": "warning" }],
 		"block-no-empty": [true, { "severity": "warning" }]

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
 		"lint:js:fix": "eslint --fix --pass-on-unpruned-suppressions",
 		"lint:js:prune": "eslint --prune-suppressions",
 
-		"lint:css": "stylelint \"view/**/*.css\" --max-warnings 111",
-		"lint:css:fix": "stylelint \"view/**/*.css\" --fix --max-warnings 111",
+		"lint:css": "stylelint \"view/**/*.css\" --max-warnings 107",
+		"lint:css:fix": "stylelint \"view/**/*.css\" --fix --max-warnings 107",
 		"lint:css:errors": "stylelint \"view/**/*.css\" --quiet"
 	},
 	"devDependencies": {

--- a/src/App/Page.php
+++ b/src/App/Page.php
@@ -283,7 +283,7 @@ class Page implements ArrayAccess
 		]) . $this->page['htmlhead'];
 
 		if ($pConfig->get($localUID, 'accessibility', 'hide_empty_descriptions')) {
-			$this->page['htmlhead'] .= "<style>.empty-description {display: none;}</style>\n";
+			$this->page['htmlhead'] .= "<style>a[data-alt='']{display:none;} a:has(.empty-description){display:none;} .empty-description {display: none;}</style>\n";
 		}
 		if ($pConfig->get($localUID, 'accessibility', 'hide_custom_emojis')) {
 			$this->page['htmlhead'] .= "<style>span.emoji.mastodon img {display: none;}</style>\n";

--- a/src/Content/Image.php
+++ b/src/Content/Image.php
@@ -47,19 +47,16 @@ class Image
 	 */
 	private static function getImageGridHtml(PostMedias $images): string
 	{
-		// Image for first column (fc) and second column (sc)
-		$images_fc = [];
-		$images_sc = [];
-
-		for ($i = 0; $i < count($images); $i++) {
-			($i % 2 == 0) ? ($images_fc[] = $images[$i]) : ($images_sc[] = $images[$i]);
+		// Pair images into rows
+		$images_rows = [];
+		
+		for ($i = 0; $i < count($images); $i++){
+			$images_rows[] = [ $images[$i], $images[$i+1] ];
+			$i++;	// NOT A DOUBLE-INCREMENT BUG! Makes sure no image appears in 2 pairs
 		}
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('content/image/grid.tpl'), [
-			'columns' => [
-				'fc' => $images_fc,
-				'sc' => $images_sc,
-			],
+			'rows'   => $images_rows,
 		]);
 	}
 
@@ -77,10 +74,6 @@ class Image
 
 		$rows = array_map(
 			function (PostMedias $PostMediaImages) {
-				if ($singleImageInRow = count($PostMediaImages) == 1) {
-					$PostMediaImages[] = $PostMediaImages[0];
-				}
-
 				$widths  = [];
 				$heights = [];
 				foreach ($PostMediaImages as $PostMediaImage) {

--- a/src/Content/Image.php
+++ b/src/Content/Image.php
@@ -98,10 +98,6 @@ class Image
 
 				$row_images2 = [];
 
-				if ($singleImageInRow) {
-					unset($PostMediaImages[1]);
-				}
-
 				foreach ($PostMediaImages as $i => $PostMediaImage) {
 					$row_images2[] = new MasonryImage(
 						$PostMediaImage->uriId,

--- a/src/Content/Image.php
+++ b/src/Content/Image.php
@@ -51,7 +51,7 @@ class Image
 		$images_rows = [];
 
 		for ($i = 0; $i < count($images); $i++) {
-			$images_rows[] = [ $images[$i], $images[$i +1 ] ];
+			$images_rows[] = [ $images[$i], $images[$i + 1 ] ];
 			$i++;	// NOT A DOUBLE-INCREMENT BUG! Makes sure no image appears in 2 pairs
 		}
 

--- a/src/Content/Image.php
+++ b/src/Content/Image.php
@@ -50,13 +50,13 @@ class Image
 		// Pair images into rows
 		$images_rows = [];
 
-		for ($i = 0; $i < count($images); $i++) {
-			$images_rows[] = [ $images[$i], $images[$i + 1 ] ];
-			$i++;	// NOT A DOUBLE-INCREMENT BUG! Makes sure no image appears in 2 pairs
+		// Two images per row, the last row may hold a single image
+		for ($i = 0; $i < count($images); $i += 2) {
+			$images_rows[] = isset($images[$i + 1]) ? [$images[$i], $images[$i + 1]] : [$images[$i]];
 		}
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('content/image/grid.tpl'), [
-			'rows' => $images_rows,
+			'$rows' => $images_rows,
 		]);
 	}
 

--- a/src/Content/Image.php
+++ b/src/Content/Image.php
@@ -49,7 +49,7 @@ class Image
 	{
 		// Pair images into rows
 		$images_rows = [];
-		
+
 		for ($i = 0; $i < count($images); $i++){
 			$images_rows[] = [ $images[$i], $images[$i+1] ];
 			$i++;	// NOT A DOUBLE-INCREMENT BUG! Makes sure no image appears in 2 pairs

--- a/src/Content/Image.php
+++ b/src/Content/Image.php
@@ -51,12 +51,12 @@ class Image
 		$images_rows = [];
 
 		for ($i = 0; $i < count($images); $i++) {
-			$images_rows[] = [ $images[$i], $images[$i+1] ];
+			$images_rows[] = [ $images[$i], $images[$i +1 ] ];
 			$i++;	// NOT A DOUBLE-INCREMENT BUG! Makes sure no image appears in 2 pairs
 		}
 
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('content/image/grid.tpl'), [
-			'rows'   => $images_rows,
+			'rows' => $images_rows,
 		]);
 	}
 

--- a/src/Content/Image.php
+++ b/src/Content/Image.php
@@ -50,7 +50,7 @@ class Image
 		// Pair images into rows
 		$images_rows = [];
 
-		for ($i = 0; $i < count($images); $i++){
+		for ($i = 0; $i < count($images); $i++) {
 			$images_rows[] = [ $images[$i], $images[$i+1] ];
 			$i++;	// NOT A DOUBLE-INCREMENT BUG! Makes sure no image appears in 2 pairs
 		}

--- a/src/Module/Media/Attachment/Browser.php
+++ b/src/Module/Media/Attachment/Browser.php
@@ -89,6 +89,7 @@ class Browser extends BaseModule
 			sprintf('%s/attach/%s', $this->baseUrl, $record['id']),
 			$record['filename'],
 			sprintf('%s/images/icons/%s.png', $this->baseUrl, $filetype),
+			$filetype,
 		];
 	}
 }

--- a/view/global.css
+++ b/view/global.css
@@ -81,7 +81,9 @@ span.connector {
 .type-video {
   float: left;
 }
-
+.wall-item-content {
+	position: relative;
+}
 .wall-item-container .wall-item-content .type-link img,
 .type-link img, .type-video img, img.attachment-preview {
   max-width: 160px;
@@ -696,6 +698,15 @@ span.required {
 audio {
   width: 100%;
 }
+figure {
+	position: relative;
+}
+figure > a {
+	position: relative;
+	height: 100%;
+	width:  100%;
+	display: block;
+}
 
 img {
   max-width: 100%;
@@ -710,19 +721,26 @@ img {
 	margin-top: 1em;
 	column-gap: 5px;
 }
-
-.imagegrid-column {
-	-ms-flex: 50%; /* IE10 */
-	flex: 50%;
-	display: -ms-flexbox; /* IE10 */
-	display: flex;
-	flex-direction: column;
-	row-gap: 5px;
+ .imagegrid-row figure {
+ 	flex-grow: 1;
+ 	margin: 0;
+	background-color: #000;
+ }
+.imagegrid-row figure a {
+	position: relative;
+	display: block;
+	height: 100%;
+	width:  100%;
 }
-
-.imagegrid-column img {
-	-ms-flex: 50%; /* IE10 */
-	flex: 50%;
+.imagegrid-row figure img {
+	position: relative;
+	height: 100%;
+	width:  100%;
+	object-fit: contain;	/* set to cover to fill figure container - cover crops images! */
+	object-position: top;
+}
+.imagegrid .imagegrid-row:first-of-type {
+	margin-top: 0px;
 }
 /**
  * Image grid settings END
@@ -759,6 +777,46 @@ figure.img-allocated-height img{
 }
 /**
  * Horizontal masonry settings AND
+ **/
+
+/**
+	* Faux Grid settings
+	* If any text comes after multiple images it breaks masonry or grid so fake it
+	* shrink and float any image container followed by a like-kind image container
+**/
+.wall-item-content .img-allocated-max-width:has(+ .img-allocated-max-width) {
+	width: 50%;
+	float: left; /* fallback for old browsers */
+	float: inline-start;
+	margin: 0;
+	padding: 0 5px 5px 5px;
+	display: block;
+	box-sizing: border-box;
+}
+	.wall-item-content .img-allocated-max-width:has(+ .img-allocated-max-width):nth-of-type(even) {
+		float: right; /* fallback for old browsers */
+		float: inline-end;
+	}
+/* in any group of 3 image container if the LAST one is not followed by a like-kind container clear float
+   note: we cannot use :last-of-type because this may not be the last container of its type in the post!
+*/
+.wall-item-content .img-allocated-max-width + .img-allocated-max-width + .img-allocated-max-width:not(:has(+ .img-allocated-max-width)) {
+	clear: both;
+}
+/* if there are only two images in a row just display them normally */
+.wall-item-content .img-allocated-max-width:first-of-type:has(+ .img-allocated-max-width:last-of-type) {
+	float: none;
+	width: auto;
+}
+/* faux grid uses floats which do NOT auto reverse if language is RTL so we need to manually do that */
+.wall-item-content[lang="ar"] .img-allocated-max-width:has(+ .img-allocated-max-width) {
+	float: right;
+}
+.wall-item-content[lang="ar"] .img-allocated-max-width:has(+ .img-allocated-max-width):nth-of-type(even) {
+	float: left;
+}
+/**
+ * Faux Grid settings AND
  **/
 
 #contactblock .icon {
@@ -843,10 +901,62 @@ summary.wall-item-summary {
 }
 
 /* Add alt tag indicators to the relevant images */
-a:has(img.has-alt-description)::after {
-	background: rgba(0, 0, 0, 0.69);
+	/* Jot Preview does not use src/content/image templates so force similar layout: */
+[id^="comment-edit-preview-"] figure:has(img),
+[id^="comment-edit-preview-"] a:has(img),
+#jot-preview-content figure:has(img),
+#jot-preview-content a:has(img){
+	position: relative;
+	display: table;
+}
+[id^="comment-edit-preview-"] a:has(img.has-alt-description)::after,
+#jot-preview-content a:has(img.has-alt-description)::after,
+.alt-text-button {
+  background: rgba(0, 0, 0, 0.69);
+  border-radius: 4px;
+  color: #eee;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 15px;
+  padding: 4px 5px;
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  border: none;
+}
+.alt-text-block {
+  position: absolute;
+  bottom: 100%;
+  right: 0px;
+  width: 250px;
+  font-size: 15px;
+  font-weight: normal;
+  background-color: rgba(0,0,0,.65);
+  border-radius: 4px;
+  padding: 10px;
+  text-align: left;
+  max-height: 30em;
+  overflow-y: auto;
+  display: none;
+}
+	/* try to make alt text box fit narrow screens */
+	@media screen and (max-width: 440px){
+		.alt-text-block {
+			width: 150px;
+		}
+	}
+.alt-text-button:focus .alt-text-block,
+.alt-text-button:active .alt-text-block,
+.alt-text-button:focus-within .alt-text-block {
+  display: block;
+}
+
+/* ALT badge indicator for images with descriptions */
+.photo-album-image-wrapper:has(img.has-alt-description)::after,
+.photo-top-image-wrapper:has(img.has-alt-description)::after {
+	background: rgba(255, 255, 255, 0.65);
 	border-radius: 4px;
-	color: #eee;
+	color: #666;
 	content: "ALT";
 	font-size: 12px;
 	font-weight: bold;
@@ -854,7 +964,29 @@ a:has(img.has-alt-description)::after {
 	position: absolute;
 	bottom: 8px;
 	right: 8px;
+	z-index: 1;
+	pointer-events: none;
 }
+/* ...omit alt tags on images in these cases: profile description */
+.profile-header a:has(img.has-alt-description)::after {
+	display: none;
+}
+/* preview can take a moment to process images so show it is doing something */
+@keyframes processing {
+	to {
+		background-color: #ccc;
+	}
+}
+.img-processing {
+	animation: processing;
+	animation-duration: .5s;
+	animation-iteration-count: infinite;
+	animation-direction: alternate-reverse;
+	animation-timing-function: ease;
+}
+/**
+  * End Alt-Tag Section
+**/
 
 #change-profile-picture {
 	background-color: rgba(0, 0, 0, 0.5);

--- a/view/global.css
+++ b/view/global.css
@@ -780,7 +780,6 @@ figure.img-allocated-height img{
 **/
 .wall-item-content .img-allocated-max-width:has(+ .img-allocated-max-width) {
 	width: 50%;
-	/* stylelint-disable-next-line declaration-block-no-duplicate-properties -- left is the fallback for browsers without logical float values */
 	float: left;
 	float: inline-start;
 	margin: 0;
@@ -789,7 +788,6 @@ figure.img-allocated-height img{
 	box-sizing: border-box;
 }
 	.wall-item-content .img-allocated-max-width:has(+ .img-allocated-max-width):nth-of-type(even) {
-		/* stylelint-disable-next-line declaration-block-no-duplicate-properties -- right is the fallback for browsers without logical float values */
 		float: right;
 		float: inline-end;
 	}

--- a/view/global.css
+++ b/view/global.css
@@ -780,7 +780,8 @@ figure.img-allocated-height img{
 **/
 .wall-item-content .img-allocated-max-width:has(+ .img-allocated-max-width) {
 	width: 50%;
-	float: left; /* fallback for old browsers */
+	/* stylelint-disable-next-line declaration-block-no-duplicate-properties -- left is the fallback for browsers without logical float values */
+	float: left;
 	float: inline-start;
 	margin: 0;
 	padding: 0 5px 5px 5px;
@@ -788,7 +789,8 @@ figure.img-allocated-height img{
 	box-sizing: border-box;
 }
 	.wall-item-content .img-allocated-max-width:has(+ .img-allocated-max-width):nth-of-type(even) {
-		float: right; /* fallback for old browsers */
+		/* stylelint-disable-next-line declaration-block-no-duplicate-properties -- right is the fallback for browsers without logical float values */
+		float: right;
 		float: inline-end;
 	}
 /* in any group of 3 image container if the LAST one is not followed by a like-kind container clear float

--- a/view/global.css
+++ b/view/global.css
@@ -701,12 +701,6 @@ audio {
 figure {
 	position: relative;
 }
-figure > a {
-	position: relative;
-	height: 100%;
-	width:  100%;
-	display: block;
-}
 
 img {
   max-width: 100%;

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -1400,7 +1400,7 @@ function preview_post_img(index){
 		// get images with alt text
 		$(parentElement+" img.has-alt-description").each(function(index, element){
 			var $alt_text = $(element).attr("alt");
-			$(element).parent().parent().append('<button class="alt-text-button" type="button" aria-hidden="true">ALT<div class="alt-text-block" dir="auto">'+$alt_text+'</div></button>');
+			$(element).parent().parent().append('<button class="alt-text-button" type="button" aria-hidden="true">ALT<span class="alt-text-block" dir="auto">'+$alt_text+'</span></button>');
 		});
 		// if we have multiple images do masonry layout
 		if ($images.length > 1 && gallery === true){

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -61,7 +61,7 @@ function initWidget(name) {
 	const widget = document.getElementById(name)
 	const list = widget.querySelector(".sidebar-widget-list");
 	const btn = widget.querySelector(".widget-btn");
-	if (!btn){ return; } // there are contexts in which not btn will be found
+	if (!btn || !list){ return; } // there are contexts in which not btn will be found
 	if (localStorage.getItem(window.location.pathname.split("/")[1] + ":" + name) != "block") {
 		list.style.display = "none";
 		btn.setAttribute("aria-expanded", false)

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -1399,7 +1399,7 @@ function preview_post_img(index){
 		$images.parent().wrap('<div></div>').wrap('<figure></figure>');
 		// get images with alt text
 		$(parentElement+" img.has-alt-description").each(function(index, element){
-			$alt_text = $(element).attr("alt");
+			var $alt_text = $(element).attr("alt");
 			$(element).parent().parent().append('<button class="alt-text-button" type="button" aria-hidden="true">ALT<div class="alt-text-block" dir="auto">'+$alt_text+'</div></button>');
 		});
 		// if we have multiple images do masonry layout

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -59,9 +59,9 @@ function _resizeIframe(obj, desth) {
 
 function initWidget(name) {
 	const widget = document.getElementById(name)
-	const list = widget.getElementsByClassName("sidebar-widget-list")[0];
-	const btn = widget.getElementsByClassName("widget-btn")[0]
-
+	const list = widget.querySelector(".sidebar-widget-list");
+	const btn = widget.querySelector(".widget-btn");
+	if (!btn){ return; } // there are contexts in which not btn will be found
 	if (localStorage.getItem(window.location.pathname.split("/")[1] + ":" + name) != "block") {
 		list.style.display = "none";
 		btn.setAttribute("aria-expanded", false)
@@ -1156,6 +1156,7 @@ function preview_comment(id) {
 		.always(function() {
 		hideLoading();
 	});
+	fix_preview_img_wrap(id);
 	return true;
 }
 
@@ -1252,9 +1253,279 @@ function preview_post() {
 		.always(function() {
 		hideLoading();
 	});
+	fix_preview_img_wrap();
 	return true;
 }
+function fix_preview_img_wrap(index){
+	/* We don't know how long it will take the server to do the ajax request
+	   so we need to monitor the preview pane for a DOM mutation.
+	   
+	   We also do not want to attach the mutation observer unless previewing
+	   and we do not need this on pages without the jot composer. This might
+	   be in feed, in modal, or on a separate page so check for parent obj.	   
+	   
+	   We only want ot use a Mutation Observer if the browser supports it
+	   (and most do) but just in case there is a fallback to a timeOut method.
+	*/
 
+	if ("MutationObserver" in window){
+		const targetElement = (!index && $('#jot-preview-content .tread-wrapper')) ? $('#jot-preview-content .tread-wrapper') : $('#comment-edit-preview-'+index+' .tread-wrapper');
+		const parentToWatch = (!index && document.getElementById('jot-preview-content')) ? document.getElementById('jot-preview-content') : document.getElementById('comment-edit-preview-'+index);	/* jQuery obj will not work! */
+		
+		const observer = new MutationObserver((mutationList, observer) => {
+			for (const mutation of mutationList) {
+				if (mutation.type === "childList") {
+					const newElement = targetElement;
+					if (newElement){
+						preview_post_img(index);
+						observer.disconnect();
+						break;
+					}
+				}
+			}
+		});
+		// attach the mutation observer IF we have a valid parent obj
+		if (parentToWatch){
+			observer.observe(parentToWatch, { childList: true, subtree: true });
+		}
+	} else {
+		// fallback if MutationObserver is not available
+		setTimeout(function(){preview_post_img(index);},3000);
+	}
+}
+
+
+function masonry_or_not(parentElement){
+	/* This convoluted function grabs the preview contents as rendered by Friendica
+	   and then tries to determine if it is one of the scenarios in which masonry
+	   layout will not be shown and returns boolean true|false to the caller.
+	   
+	   Normally the masonry layout is only shown if:
+	   * There are multiple images in the post
+	   * The images are consecutive
+	   * There are no other elements in between them.
+	   * There are no raw text nodes immediately before or after any of them.
+	   * There is no paragraph after the last one (a DIV is okay though)
+	   
+	   This function assumes a masonry layout could be shown, unless it should find
+	   one of the above conditions is not met.
+	*/
+
+	var gallery = true;
+	$(parentElement+" .wall-item-body").find('img.empty-description, img.has-alt-description').each(function(index, element){
+			if ( $(element).parent('a').length > 0 ){
+				// check if img has other stuff in with it
+				$(element).parent().parent().contents().filter(function(){
+					if (this.nodeType === 3){
+						// there is a text node in here with it, this is NOT a gallery
+						gallery = false;
+						return;
+					}
+				});
+				// if this element has a next sibling and it has an image in it
+				if ( $(element).parent().parent().next().length > 0 ){
+					if ( $(element).parent().parent().next().prop('tagName') == 'P' ){
+						// has to check <p> so it does not confuse with link preview <div>
+						if ( $(element).parent().parent().next('p:has(img)').length > 0 ){
+							// next sibling contains image so this is a gallery
+						} else {
+							// next sibling does NOT contain an image, this is not a gallery
+							gallery = false;
+							return;
+						}
+					} else {
+						// next sibling is some other kind of element
+					}
+				} else {
+					// there is no next sibling
+				}
+					
+			} else if( $(element).parent('p').length > 0 ){
+				// check if img has other stuff in with it
+				$(element).parent().contents().filter(function(){
+					if (this.nodeType === 3){
+						// there is a text node in it, this is NOT a gallery
+						gallery = false;
+						return;
+					}
+				});	
+				// if this element has a next sibling and it has an image in it
+				if ( $(element).parent().next().length > 0 ){
+					// there IS a next sibling
+					if( $(element).parent().next().prop('tagName') == 'P' ){
+						if ( $(element).parent().next('p:has(img)').length > 0 ){
+							// next sibling contains an image
+						} else {
+							// next sibling does NOT contain an image, NOT a gallery
+							gallery = false;
+							return;
+						}
+					} else {
+						// next sibling is some other kind of element
+					}
+				} else {
+					// there is no next sibling
+				}			
+			} else {
+				// no clue what element this is inside of so NOT a gallery
+				gallery = false;
+				return;
+			}
+		});
+		return gallery;
+}
+
+
+function preview_post_img(index){
+	if (!index){ 
+		index = 0;
+		var parentElement = '#jot-preview-content';
+	} else {
+		var parentElement = '#comment-edit-preview-'+index;
+	}
+	var $images = $(parentElement+" img.empty-description, "+parentElement+" img.has-alt-description");
+	if ($images.length === 0){
+		// no images to process
+		return;
+	} else {
+		// before we manipulate the DOM check if this could use masonry layout
+		var gallery = masonry_or_not(parentElement);
+		if ($images.length > 1 && ($images.parent().next(':has(img)') || $images.parent().parent('p').next(':has(img)')) ){
+			// this appears to be a sequence of images
+		} else {
+			var gallery = false;
+		}
+		// wrap attached images like they would be in feed
+		$images.parent().wrap('<div></div>').wrap('<figure></figure>');
+		// get images with alt text
+		$(parentElement+" img.has-alt-description").each(function(index, element){
+			$alt_text = $(element).attr("alt");
+			$(element).parent().parent().append('<button class="alt-text-button" type="button" aria-hidden="true">ALT<div class="alt-text-block" dir="auto">'+$alt_text+'</div></button>');
+		});
+		// if we have multiple images do masonry layout
+		if ($images.length > 1 && gallery === true){
+			// if processing takes too long pulse the container background
+			$(parentElement+" .wall-item-body").addClass('img-processing');
+			// show process spinner (if there is one)
+			$(parentElement+" .wall-item-decor img").show();
+			// hide container content during processing...
+			$(parentElement+" .wall-item-body").css({visibility: 'hidden'});
+
+
+			/* only setInterval or setTimeout work to trigger masonry function!
+			   jQuery promise().done() or count tracking or MutationObserver
+			   all cause infinite loops. The ONLY way to know if the above is
+			   done manipulating the DOM is to compare the number of FIGURE
+			   tags to the original IMAGE count. If they match, it's done.			
+			*/ 
+			var condition = setInterval(function(){
+				if( $(parentElement+" figure").length === $images.length ){
+					clearInterval(condition);
+					preview_masonry_rows(index);
+				}
+			}, 100);
+		} else {
+			$images.parent().wrap('<div class="body-attach"></div>');
+		}
+	}
+}
+
+function preview_masonry_rows(index) {
+	// first determine if there are multiple images (by this point they should all be wrapped in <figure> tags)
+	// and we do not want to accidentally scoop up jot and comment ones together
+	if (!index){
+		index = 0;
+		var parentElement = "#jot-preview-content";
+	} else {
+		var parentElement = "#comment-edit-preview-"+index;
+	}
+	$images = $(parentElement+" .wall-item-content").find("figure");
+	// if called by preview_post_image we should never have zero or one image but catch them anyway...
+	if ($images.length === 0){
+		$(parentElement+" .wall-item-decor img").hide();
+		$(parentElement+" .wall-item-body").removeClass('img-processing');
+		$(parentElement+" .wall-item-body").css({visibility: 'visible'});
+		return;
+	}
+	else if ($images.length === 1){ 
+		$images.parent().wrap('<div class="body-attach"></div>');
+		$(parentElement+" .wall-item-decor img").hide();
+		$(parentElement+" .wall-item-body").removeClass('img-processing');
+		$(parentElement+" .wall-item-body").css({visibility: 'visible'});
+		return; // no need to do masonry layout
+	} else { // do masonry layout	
+		const column_size = 2;
+		
+		var rows = [];
+		
+		var couples = [];
+		for(let i=0; i < $images.length; i++){
+			if (typeof($images[i+1]) == "undefined"){
+				var entry = [$images[i]];
+			} else {
+				var entry = [$images[i], $images[i+1]];
+			}
+			couples.push(entry);
+			i++;				// NOT a double increment bug! This pairs images
+		};
+		
+		for(let c=0; c < couples.length; c++){
+			var widths = [];
+			var heights = [];
+			var maxHeight = 0;
+			for(let i=0; i < couples[c].length; i++){
+				widths.push( $(couples[c][i]).find('img').first().width() );
+				heights.push( $(couples[c][i]).find('img').first().height() );
+			}
+			var maxHeight = Math.max(...heights);
+			// corrected width preserving aspect ratio when all images on a row are the same height
+			var correctedWidths = [];
+			for(let w=0; w < widths.length; w++){
+				correctedWidths.push( (widths[w] * maxHeight / heights[w]) );
+			}
+			var totalWidth = 0;
+			// total sum of all widths
+			for(let t=0; t < correctedWidths.length; t++){
+				totalWidth += correctedWidths[t];
+			}
+			// This magic value will stay constant for each image of any given row and is ultimately
+			// used to determine the height of the row container relative to the available width
+			var commonHeightRatio = (100 * correctedWidths[0] / totalWidth / (widths[0] / heights[0]));
+			
+			var first_image = [couples[c][0], (100 * correctedWidths[0]/totalWidth), (100 * maxHeight/correctedWidths[0])];
+			
+			if (couples[c].length == 1){ // single image
+				var second_image = [];
+			} else {
+				var second_image = [couples[c][1], (100 * correctedWidths[1]/totalWidth), (100 * maxHeight/correctedWidths[1])];
+			}
+			// push them onto a row
+			rows.push([widths, heights, maxHeight, totalWidth, commonHeightRatio, first_image, second_image]);
+		}
+		var $attachbox = $('<div></div>');
+			$attachbox.addClass('body-attach');
+
+		for(let r=0; r < rows.length; r++){
+			var $newRow = $('<div></div>');
+				$newRow.addClass('masonry-row');
+				$newRow.css('height', rows[r][4]+'%');
+				rows[r][5][0].setAttribute('style','width: '+rows[r][5][1]+'%; padding-bottom: calc('+(rows[r][5][1] * rows[r][5][2] / 100)+'% - 5px / 2)');
+				rows[r][5][0].className = "img-allocated-height";
+				$newRow.append(rows[r][5][0]);
+			if (rows[r][6].length > 0){ // do not assume a matching image
+				rows[r][6][0].setAttribute('style','width: '+rows[r][6][1]+'%; padding-bottom: calc('+(rows[r][6][1] * rows[r][6][2] / 100)+'% - 5px / 2)');
+				rows[r][6][0].className = "img-allocated-height";
+				$newRow.append(rows[r][6][0]);
+			}
+			$attachbox.append($newRow);
+		}
+		$(parentElement+" .wall-item-body div:empty").remove();				// clean up now empty divs that used to wrap images
+		$(parentElement+" .wall-item-body").append($attachbox);				
+		$(parentElement+" .wall-item-decor img").hide();						// hide spinner
+		$(parentElement+" .wall-item-body").removeClass('img-processing');
+		$(parentElement+" .wall-item-body").css({visibility: 'visible'});	// make container visible
+	}
+}
 function unpause() {
 	// unpause auto reloads if they are currently stopped
 	totStopped = false;

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -1474,8 +1474,21 @@ function preview_masonry_rows(index) {
 			var heights = [];
 			var maxHeight = 0;
 			for(let i=0; i < couples[c].length; i++){
-				widths.push( $(couples[c][i]).find('img').first().width() );
-				heights.push( $(couples[c][i]).find('img').first().height() );
+				let this_width = 0;
+				let this_height = 0;
+				let this_image = $(couples[c][i]).find('img').first();
+				if ( $(this_image).width() == 0){
+					this_width = 640;
+				} else {
+					this_width = $(this_image).width();
+				}
+				if ( $(this_image).height() == 0){
+					this_height = 480;
+				} else {
+					this_height = $(this_image).height();
+				}
+				widths.push( this_width );
+				heights.push( this_height );
 			}
 			var maxHeight = Math.max(...heights);
 			// corrected width preserving aspect ratio when all images on a row are the same height

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -1324,7 +1324,7 @@ function masonry_or_not(parentElement){
 				});
 				// if this element has a next sibling and it has an image in it
 				if ( $(element).parent().parent().next().length > 0 ){
-					if ( $(element).parent().parent().next().prop('tagName') == 'P' ){
+					if ( $(element).parent().parent().next().prop('tagName') === 'P' ){
 						// has to check <p> so it does not confuse with link preview <div>
 						if ( $(element).parent().parent().next('p:has(img)').length > 0 ){
 							// next sibling contains image so this is a gallery
@@ -1352,7 +1352,7 @@ function masonry_or_not(parentElement){
 				// if this element has a next sibling and it has an image in it
 				if ( $(element).parent().next().length > 0 ){
 					// there IS a next sibling
-					if( $(element).parent().next().prop('tagName') == 'P' ){
+					if( $(element).parent().next().prop('tagName') === 'P' ){
 						if ( $(element).parent().next('p:has(img)').length > 0 ){
 							// next sibling contains an image
 						} else {
@@ -1377,11 +1377,12 @@ function masonry_or_not(parentElement){
 
 
 function preview_post_img(index){
-	if (!index){ 
+	var parentElement;
+	if (!index){
 		index = 0;
-		var parentElement = '#jot-preview-content';
+		parentElement = '#jot-preview-content';
 	} else {
-		var parentElement = '#comment-edit-preview-'+index;
+		parentElement = '#comment-edit-preview-'+index;
 	}
 	var $images = $(parentElement+" img.empty-description, "+parentElement+" img.has-alt-description");
 	if ($images.length === 0){
@@ -1393,7 +1394,7 @@ function preview_post_img(index){
 		if ($images.length > 1 && ($images.parent().next(':has(img)') || $images.parent().parent('p').next(':has(img)')) ){
 			// this appears to be a sequence of images
 		} else {
-			var gallery = false;
+			gallery = false;
 		}
 		// wrap attached images like they would be in feed
 		$images.parent().wrap('<div></div>').wrap('<figure></figure>');
@@ -1433,13 +1434,13 @@ function preview_post_img(index){
 function preview_masonry_rows(index) {
 	// first determine if there are multiple images (by this point they should all be wrapped in <figure> tags)
 	// and we do not want to accidentally scoop up jot and comment ones together
+	var parentElement;
 	if (!index){
-		index = 0;
-		var parentElement = "#jot-preview-content";
+		parentElement = "#jot-preview-content";
 	} else {
-		var parentElement = "#comment-edit-preview-"+index;
+		parentElement = "#comment-edit-preview-"+index;
 	}
-	$images = $(parentElement+" .wall-item-content").find("figure");
+	var $images = $(parentElement+" .wall-item-content").find("figure");
 	// if called by preview_post_image we should never have zero or one image but catch them anyway...
 	if ($images.length === 0){
 		$(parentElement+" .wall-item-decor img").hide();
@@ -1453,36 +1454,35 @@ function preview_masonry_rows(index) {
 		$(parentElement+" .wall-item-body").removeClass('img-processing');
 		$(parentElement+" .wall-item-body").css({visibility: 'visible'});
 		return; // no need to do masonry layout
-	} else { // do masonry layout	
-		const column_size = 2;
-		
+	} else { // do masonry layout
 		var rows = [];
-		
+
 		var couples = [];
 		for(let i=0; i < $images.length; i++){
-			if (typeof($images[i+1]) == "undefined"){
-				var entry = [$images[i]];
+			let entry;
+			if (typeof($images[i+1]) === "undefined"){
+				entry = [$images[i]];
 			} else {
-				var entry = [$images[i], $images[i+1]];
+				entry = [$images[i], $images[i+1]];
 			}
 			couples.push(entry);
 			i++;				// NOT a double increment bug! This pairs images
-		};
-		
+		}
+
+
 		for(let c=0; c < couples.length; c++){
 			var widths = [];
 			var heights = [];
-			var maxHeight = 0;
 			for(let i=0; i < couples[c].length; i++){
-				let this_width = 0;
-				let this_height = 0;
+				let this_width;
+				let this_height;
 				let this_image = $(couples[c][i]).find('img').first();
-				if ( $(this_image).width() == 0){
+				if ( $(this_image).width() === 0){
 					this_width = 640;
 				} else {
 					this_width = $(this_image).width();
 				}
-				if ( $(this_image).height() == 0){
+				if ( $(this_image).height() === 0){
 					this_height = 480;
 				} else {
 					this_height = $(this_image).height();
@@ -1507,10 +1507,11 @@ function preview_masonry_rows(index) {
 			
 			var first_image = [couples[c][0], (100 * correctedWidths[0]/totalWidth), (100 * maxHeight/correctedWidths[0])];
 			
-			if (couples[c].length == 1){ // single image
-				var second_image = [];
+			var second_image;
+			if (couples[c].length === 1){ // single image
+				second_image = [];
 			} else {
-				var second_image = [couples[c][1], (100 * correctedWidths[1]/totalWidth), (100 * maxHeight/correctedWidths[1])];
+				second_image = [couples[c][1], (100 * correctedWidths[1]/totalWidth), (100 * maxHeight/correctedWidths[1])];
 			}
 			// push them onto a row
 			rows.push([widths, heights, maxHeight, totalWidth, commonHeightRatio, first_image, second_image]);

--- a/view/templates/circle_side.tpl
+++ b/view/templates/circle_side.tpl
@@ -7,7 +7,7 @@
 <!-- NOTE: Place "sidebar-widget-list" only on one element: The one that should be expanded/collapsed -->
 {{* Overridden by Frio *}}
 <nav id="circle-sidebar" class="widget">
-	<button class="widget-btn, fakelink" onclick="openCloseWidget('circle-sidebar');" aria-expanded="false">
+	<button class="widget-btn fakelink" onclick="openCloseWidget('circle-sidebar');" aria-expanded="false">
 		<h3>
 			<i class="ri ri-bubble-chart-line" aria-hidden="true"></i>
 			{{$title}}

--- a/view/templates/content/image/grid.tpl
+++ b/view/templates/content/image/grid.tpl
@@ -4,15 +4,13 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<div class="imagegrid-row">
-	<div class="imagegrid-column">
-		{{foreach $columns.fc as $img}}
-				{{include file="content/image/single.tpl" image=$img}}
-		{{/foreach}}
+<div class="imagegrid">
+	{{foreach $rows as $img}}
+	<div class="imagegrid-row">
+		{{include file="content/image/single.tpl" image=$img.0}}
+		{{if $img.1}}
+		{{include file="content/image/single.tpl" image=$img.1}}
+		{{/if}}
 	</div>
-	<div class="imagegrid-column">
-		{{foreach $columns.sc as $img}}
-				{{include file="content/image/single.tpl" image=$img}}
-		{{/foreach}}
-	</div>
+	{{/foreach}}
 </div>

--- a/view/templates/content/image/single.tpl
+++ b/view/templates/content/image/single.tpl
@@ -5,7 +5,18 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 {{if $image->preview}}
-<a data-fancybox="uri-id-{{$image->uriId}}" href="{{$image->url}}"><img src="{{$image->preview}}" alt="{{$image->description}}" title="{{$image->description}}" {{if $image->description}}class="has-alt-description"{{else}}class="empty-description"{{/if}} loading="lazy"></a>
+<figure>
+	<a data-fancybox="uri-id-{{$image->uriId}}" href="{{$image->url}}">
+		<img src="{{$image->preview}}" alt="{{$image->description}}" title="{{$image->description}}" {{if $image->description}}class="has-alt-description"{{else}}class="empty-description"{{/if}} loading="lazy">
+	</a>
+	{{if $image->description}}
+		<button class="alt-text-button" type="button" aria-hidden="true">ALT
+			<div class="alt-text-block" dir="auto">
+				{{$image->description}}
+			</div>
+		</button>
+	{{/if}}
+</figure>
 {{else}}
 <figure>
 	<img src="{{$image->url}}" alt="{{$image->description}}" title="{{$image->description}}" {{if $image->description}}class="has-alt-description"{{else}}class="empty-description"{{/if}} loading="lazy">

--- a/view/templates/content/image/single.tpl
+++ b/view/templates/content/image/single.tpl
@@ -11,9 +11,9 @@
 	</a>
 	{{if $image->description}}
 		<button class="alt-text-button" type="button" aria-hidden="true">ALT
-			<div class="alt-text-block" dir="auto">
+			<span class="alt-text-block" dir="auto">
 				{{$image->description}}
-			</div>
+			</span>
 		</button>
 	{{/if}}
 </figure>

--- a/view/templates/content/image/single_with_height_allocation.tpl
+++ b/view/templates/content/image/single_with_height_allocation.tpl
@@ -18,9 +18,9 @@
 		</a>
 		{{if $image->description}}
 			<button class="alt-text-button" type="button" aria-hidden="true">ALT
-				<div class="alt-text-block" dir="auto">
+				<span class="alt-text-block" dir="auto">
 					{{$image->description}}
-				</div>
+				</span>
 			</button>
 		{{/if}}
     {{else}}

--- a/view/templates/content/image/single_with_height_allocation.tpl
+++ b/view/templates/content/image/single_with_height_allocation.tpl
@@ -16,6 +16,13 @@
 		<a data-fancybox="uri-id-{{$image->uriId}}" href="{{$image->url}}">
 			<img src="{{$image->preview}}" alt="{{$image->description}}" title="{{$image->description}}" {{if $image->description}}class="has-alt-description"{{else}}class="empty-description"{{/if}} loading="lazy">
 		</a>
+		{{if $image->description}}
+			<button class="alt-text-button" type="button" aria-hidden="true">ALT
+				<div class="alt-text-block" dir="auto">
+					{{$image->description}}
+				</div>
+			</button>
+		{{/if}}
     {{else}}
 		<img src="{{$image->url}}" alt="{{$image->description}}" title="{{$image->description}}" {{if $image->description}}class="has-alt-description"{{else}}class="empty-description"{{/if}} loading="lazy">
         {{if $image->description}}

--- a/view/templates/media/browser.tpl
+++ b/view/templates/media/browser.tpl
@@ -36,18 +36,17 @@
 	{{/if}}
 
 	<div class="list">
+		<div class="upload">
+			<button id="upload-{{$type}}"><img id="profile-rotator" src="images/rotator.gif" alt="{{$wait}}" title="{{$wait}}" style="display: none;" /> {{$upload}}</button>
+		</div>
 		{{foreach $files as $f}}
 		<div class="photo-album-image-wrapper">
 			<a href="#" class="photo-album-photo-link" data-link="{{$f.0}}" data-filename="{{$f.1}}" data-img="{{$f.2}}" data-alt="{{$f.3}}">
-				<img alt="{{$f.3}}" src="{{$f.2}}">
+				<img src="{{$f.2}}" {{if $f.3}}class="has-alt-description" title="{{$f.3}}"{{else}}class="empty-description" title="{{$f1}}"{{/if}}/>
 				<p>{{$f.1}}</p>
 			</a>
 		</div>
 		{{/foreach}}
-	</div>
-
-	<div class="upload">
-		<button id="upload-{{$type}}"><img id="profile-rotator" src="images/rotator.gif" alt="{{$wait}}" title="{{$wait}}" style="display: none;" /> {{$upload}}</button>
 	</div>
 </div>
 

--- a/view/templates/media/browser.tpl
+++ b/view/templates/media/browser.tpl
@@ -42,7 +42,7 @@
 		{{foreach $files as $f}}
 		<div class="photo-album-image-wrapper">
 			<a href="#" class="photo-album-photo-link" data-link="{{$f.0}}" data-filename="{{$f.1}}" data-img="{{$f.2}}" data-alt="{{$f.3}}">
-				<img src="{{$f.2}}" {{if $f.3}}class="has-alt-description" title="{{$f.3}}"{{else}}class="empty-description" title="{{$f1}}"{{/if}}/>
+				<img src="{{$f.2}}" {{if $f.3}}class="has-alt-description" title="{{$f.3}}"{{else}}class="empty-description" title="{{$f.1}}"{{/if}}/>
 				<p>{{$f.1}}</p>
 			</a>
 		</div>

--- a/view/templates/media/browser.tpl
+++ b/view/templates/media/browser.tpl
@@ -42,7 +42,7 @@
 		{{foreach $files as $f}}
 		<div class="photo-album-image-wrapper">
 			<a href="#" class="photo-album-photo-link" data-link="{{$f.0}}" data-filename="{{$f.1}}" data-img="{{$f.2}}" data-alt="{{$f.3}}">
-				<img src="{{$f.2}}" {{if $f.3}}class="has-alt-description" title="{{$f.3}}"{{else}}class="empty-description" title="{{$f.1}}"{{/if}}/>
+				<img src="{{$f.2}}" alt="{{if $f.3}}{{$f.3}}{{else}}{{$f.1}}{{/if}}" {{if $f.3}}class="has-alt-description" title="{{$f.3}}"{{else}}class="empty-description" title="{{$f.1}}"{{/if}}/>
 				<p>{{$f.1}}</p>
 			</a>
 		</div>

--- a/view/templates/photo_album.tpl
+++ b/view/templates/photo_album.tpl
@@ -24,9 +24,9 @@
 	</a>
 	{{if $photo.desc}}
 		<button class="alt-text-button" type="button" aria-hidden="true">ALT
-			<div class="alt-text-block" dir="auto">
+			<span class="alt-text-block" dir="auto">
 				{{$photo.desc}}
-			</div>
+			</span>
 		</button>
 	{{/if}}
 </div>

--- a/view/templates/photo_album.tpl
+++ b/view/templates/photo_album.tpl
@@ -22,13 +22,6 @@
 	<a href="{{$photo.link}}" class="photo-album-photo-link" id="photo-album-photo-link-{{$photo.id}}" title="{{$photo.title}}">
 		<img src="{{$photo.src}}" alt="{{if $photo.album.name}}{{$photo.album.name}}{{elseif $photo.desc}}{{$photo.desc}}{{elseif $photo.alt}}{{$photo.alt}}{{else}}{{$photo.unknown}}{{/if}}" title="{{$photo.title}}" class="photo-album-photo lframe resize{{$photo.twist}}" id="photo-album-photo-{{$photo.id}}" />
 	</a>
-	{{if $photo.desc}}
-		<button class="alt-text-button" type="button" aria-hidden="true">ALT
-			<span class="alt-text-block" dir="auto">
-				{{$photo.desc}}
-			</span>
-		</button>
-	{{/if}}
 </div>
 <div class="photo-album-image-wrapper-end"></div>
 {{/foreach}}

--- a/view/templates/photo_album.tpl
+++ b/view/templates/photo_album.tpl
@@ -21,8 +21,14 @@
 <div class="photo-album-image-wrapper" id="photo-album-image-wrapper-{{$photo.id}}">
 	<a href="{{$photo.link}}" class="photo-album-photo-link" id="photo-album-photo-link-{{$photo.id}}" title="{{$photo.title}}">
 		<img src="{{$photo.src}}" alt="{{if $photo.album.name}}{{$photo.album.name}}{{elseif $photo.desc}}{{$photo.desc}}{{elseif $photo.alt}}{{$photo.alt}}{{else}}{{$photo.unknown}}{{/if}}" title="{{$photo.title}}" class="photo-album-photo lframe resize{{$photo.twist}}" id="photo-album-photo-{{$photo.id}}" />
-		<p class="caption" dir="auto">{{$photo.desc}}</p>
 	</a>
+	{{if $photo.desc}}
+		<button class="alt-text-button" type="button" aria-hidden="true">ALT
+			<div class="alt-text-block" dir="auto">
+				{{$photo.desc}}
+			</div>
+		</button>
+	{{/if}}
 </div>
 <div class="photo-album-image-wrapper-end"></div>
 {{/foreach}}

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1824,23 +1824,9 @@ textarea.comment-edit-text:focus + .comment-edit-form .preview {
 }
 
 /* ALT badge for images with descriptions */
+.photo-album-image-wrapper:has(img.has-alt-description)::after,
 .photo-top-image-wrapper:has(img.has-alt-description)::after {
-	background: rgba(0, 0, 0, 0.69);
-	border-radius: 4px;
-	color: #eee;
-	content: "ALT";
-	font-size: 12px;
-	font-weight: bold;
-	padding: 4px 5px;
-	position: absolute;
-	bottom: 8px;
-	right: 8px;
-	z-index: 1;
-	pointer-events: none;
-}
-/* ...omit alt tags on images in these cases: profile description */
-.profile-header a:has(img.has-alt-description)::after {
-	display: none;
+	font-size: 8px;
 }
 
 .photo-top-image-wrapper .jg-caption,

--- a/view/theme/frio/templates/media/browser.tpl
+++ b/view/theme/frio/templates/media/browser.tpl
@@ -53,7 +53,7 @@
 					{{foreach $files as $f}}
 					<div class="photo-album-image-wrapper">
 						<a href="#" class="photo-album-photo-link" data-link="{{$f.0}}" data-filename="{{$f.1}}" data-img="{{$f.2}}" data-alt="{{$f.3}}">
-							<img src="{{$f.2}}" alt="{{$f.1}}">
+							<img src="{{$f.2}}" {{if $f.3}}class="has-alt-description" title="{{$f.3}}"{{else}}class="empty-description" title="{{$f1}}"{{/if}}/>
 							<p>{{$f.1}}</p>
 						</a>
 					</div>

--- a/view/theme/frio/templates/media/browser.tpl
+++ b/view/theme/frio/templates/media/browser.tpl
@@ -53,7 +53,7 @@
 					{{foreach $files as $f}}
 					<div class="photo-album-image-wrapper">
 						<a href="#" class="photo-album-photo-link" data-link="{{$f.0}}" data-filename="{{$f.1}}" data-img="{{$f.2}}" data-alt="{{$f.3}}">
-							<img src="{{$f.2}}" {{if $f.3}}class="has-alt-description" title="{{$f.3}}"{{else}}class="empty-description" title="{{$f1}}"{{/if}}/>
+							<img src="{{$f.2}}" alt="{{if $f.3}}{{$f.3}}{{else}}{{$f.1}}{{/if}}" {{if $f.3}}class="has-alt-description" title="{{$f.3}}"{{else}}class="empty-description" title="{{$f.1}}"{{/if}}/>
 							<p>{{$f.1}}</p>
 						</a>
 					</div>

--- a/view/theme/vier/mobile.css
+++ b/view/theme/vier/mobile.css
@@ -49,23 +49,16 @@ nav#topbar-first ul {
 .wall-item-container .wall-item-content img,
 .children .wall-item-container .wall-item-item .wall-item-content img,
 .wall-item-container .wall-item-content .type-link img.attachment-image, .type-link img.attachment-image, .type-video img.attachment-image {
-  max-width: 650px;
+  max-width: 100%;	/* hard pixel size breaks masonry layout */
 }
-
-@media screen and (max-width: 800px) {
-  .wall-item-container .wall-item-content img,
-  .children .wall-item-container .wall-item-item .wall-item-content img,
-  .wall-item-container .wall-item-content .type-link img.attachment-image, .type-link img.attachment-image, .type-video img.attachment-image {
-    max-width: 450px;
+@media screen and (max-width: 990px) {
+  section:has(.fbrowser) {
+  	width: 100%;
+  	max-width: 100%;
   }
 }
 
 @media screen and (max-width: 600px) {
-  .wall-item-container .wall-item-content img,
-  .children .wall-item-container .wall-item-item .wall-item-content img,
-  .wall-item-container .wall-item-content .type-link img.attachment-image, .type-link img.attachment-image, .type-video img.attachment-image {
-    max-width: 350px;
-  }
   .desktop-view { display: none; }
   .mobile-view { display: initial; }
   #nav-apps-link { display: none; }
@@ -107,10 +100,6 @@ nav#topbar-first ul {
 }
 
 @media screen and (max-width: 480px) {
-  .wall-item-container .wall-item-content img,
-  .wall-item-container .wall-item-content .type-link img.attachment-image, .type-link img.attachment-image, .type-video img.attachment-image {
-    max-width: 200px;
-  }
   /* fix img width in threaded view - maybe there exists a better possibility to do this
     maybe this needs also to be done for tablet view*/
   .children .wall-item-container .wall-item-item .wall-item-content img {
@@ -123,7 +112,18 @@ nav#topbar-first ul {
   iframe {
     max-width: 100%;
   }
-
+  .fbrowser .list .upload,
+  .photo-album-image-wrapper {
+  	height: 100px;
+  	width:  100px;
+  }
+  .fbrowser.attachment a p {
+  	font-size: small;
+  }
+  .fbrowser.attachment a[data-img]::before {
+  	font-size: 32px;
+  	line-height: 50px;
+  }
 
   /* the top-nav notification menu */
   nav#topbar-first #nav-notifications-linkmenu .menu-popup {

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -1151,13 +1151,13 @@ nav#topbar-first .acpopup {
 .textcomplete-item a {
 	color: #737373;
 }
-.textcomplete-item a:hover {
-	color: #000;
-	padding: 3px 20px;
-}
 .textcomplete-item a:hover,
 .textcomplete-item a:focus,
 .textcomplete-item a:active {
+	color: #000;
+	padding: 3px 20px;
+}
+.textcomplete-item a .group, .group .acpopup-sub-text {
 	color: #36C;
 	opacity: 0.8;
 }

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -3414,7 +3414,6 @@ a.btn#contact-edit-actions-button {
 		  margin-top: 15px;
 		  padding: 0;
 		  box-sizing: border-box;
-		  border: ;
 		}
 		#upload-photo, #upload-attachment {
 		  height: 100%;

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -586,7 +586,7 @@ right_aside h4 a:active,
 #message-new:active,
 #sidebar-photos-albums li:active,
 .photos-upload-link:active,
-.textcomplete-item.active
+.textcomplete-item.active,
 
 .sidebar-circle-li:focus-within,
 #sidebar-new-circle:focus-within,

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -108,7 +108,12 @@ img {
 #adminpage table th { text-align: left; }
 #adminpage td .icon { float: left; }
 #adminpage table#users img { width: 16px; height: 16px; }
-#adminpage table tr:hover { background-color: #eeeeee; }
+#adminpage table tr:hover,
+#adminpage table tr:focus,
+#adminpage table tr:active,
+#adminpage table tr:focus-within {
+	background-color: #eeeeee;
+}
 #adminpage .selectall { text-align: right; }
 #adminpage table#users tr { box-shadow: 0 0 1px rgb(128,128,128); }
 #adminpage table#users td.acct-type-col {
@@ -160,12 +165,16 @@ img {
 	vertical-align: text-top;
 }
 
-.icon:hover {
+.icon:hover,
+.icon:focus,
+.icon:active {
 	text-decoration: none;
 	color: #000;
 }
 
-.icon a:hover {
+.icon a:hover,
+.icon a:focus,
+.icon a:active {
 }
 
 .icon.text {
@@ -191,7 +200,9 @@ img {
 .wall-item-decor .icon.s22.lock {
 	color: #888;
 }
-.wall-item-decor .icon.s22.lock:hover {
+.wall-item-decor .icon.s22.lock:hover,
+.wall-item-decor .icon.s22.lock:focus,
+.wall-item-decor .icon.s22.lock:active {
 	color: #000;
 	text-decoration: none;
 }
@@ -305,7 +316,10 @@ body {
 	margin: 0px 0px 0px 0px;
 	display: table;
 }
-
+	/* prevent XMPP chat add-on button appearing in modals and iframes */
+	body.minimal #toggle-controlbox {
+		display: none;
+	}
 a {
 	color: #36C;
 	/* color: #3e3e8c; */
@@ -313,7 +327,9 @@ a {
 	/* color: #3E3E8C; */
 	text-decoration: none;
 }
-a:hover {
+a:hover,
+a:focus,
+a:active {
 	/* color: blue; */
 	text-decoration: underline
 }
@@ -346,7 +362,9 @@ a:hover {
 	text-decoration: none;
 	cursor: pointer;
 }
-.fakelink:hover {
+.fakelink:hover,
+.fakelink:focus,
+.fakelink:active {
 	text-decoration: underline;
 }
 .btn.btn-link.fakelink {
@@ -355,7 +373,7 @@ a:hover {
 	box-shadow: none;
 	padding: 0 2px;
 	vertical-align: baseline;
-	outline-offset: 0;
+/*	outline-offset: 0;	do not hide from accessibility! */
 }
 button.fakelink {
 	background: none;
@@ -443,7 +461,10 @@ pre code {
 	background-color: #737373;
 	opacity: 0.4;
 }
-#sidebar-widget-list .tool:hover {
+#sidebar-widget-list .tool:hover,
+#sidebar-widget-list .tool:focus,
+#sidebar-widget-list .tool:active,
+#sidebar-widget-list .tool:focus-within {
 	background: #EEE;
 }
 #sidebar-circle-list .notify,
@@ -457,7 +478,34 @@ pre code {
 .tool .action {
 	float: right;
 }
-.tool a:hover, .widget a:hover, #group-widget-collapse:hover, #pages-widget-collapse:hover, .admin.link a:hover, aside h4 a:hover, right_aside h4 a:hover {
+.tool a:hover,
+.widget a:hover,
+#group-widget-collapse:hover,
+#pages-widget-collapse:hover,
+.admin.link a:hover,
+aside h4 a:hover,
+right_aside h4 a:hover,
+
+.tool a:focus,
+.widget a:focus,
+#group-widget-collapse:focus,
+#pages-widget-collapse:focus,
+.admin.link a:focus,
+aside h4 a:focus,
+right_aside h4 a:focus,
+
+.tool a:active,
+.widget a:active,
+#group-widget-collapse:active,
+#pages-widget-collapse:active,
+.admin.link a:active,
+aside h4 a:active,
+right_aside h4 a:active,
+
+.tool a:focus-within,
+.widget a:focus-within,
+#group-widget-collapse:focus-within,
+#pages-widget-collapse:focus-within {
 	/* text-decoration: underline; */
 	text-decoration: none;
 	color: black;
@@ -470,11 +518,98 @@ pre code {
 .circlesideedit:hover, .savedsearchdrop:hover {
 	opacity: 1;
 }
+.sidebar-circle-li:hover,
+#sidebar-new-circle:hover,
+#sidebar-edit-circles:hover,
+#sidebar-new-group:hover,
+#sidebar-new-pages:hover,
+#group-widget-collapse:hover,
+#sidebar-uncircled:hover,
+.side-link:hover,
+.nets-ul li:hover,
+#group-list-sidebar li:hover,
+#group-list-sidebar-right li:hover,
+#pages-list-sidebar li:hover,
+#pages-list-sidebar-right li:hover,
+.nets-all:hover,
+.saved-search-li:hover,
+li.tool:hover,
+.admin.link:hover,
+aside h4 a:hover,
+right_aside h4 a:hover,
+#message-new:hover,
+#sidebar-photos-albums li:hover,
+.photos-upload-link:hover,
 
-.sidebar-circle-li:hover, #sidebar-new-circle:hover, #sidebar-edit-circles:hover, #sidebar-new-group:hover, #sidebar-new-pages:hover, #group-widget-collapse:hover,
-#pages-widget-collapse,#sidebar-uncircled:hover, .side-link:hover, .nets-ul li:hover, #group-list-sidebar li:hover, #group-list-sidebar-right li:hover,
-#pages-list-sidebar li:hover, #pages-list-sidebar-right li:hover, .nets-all:hover, .saved-search-li:hover, li.tool:hover, .admin.link:hover,
-aside h4 a:hover, right_aside h4 a:hover, #message-new:hover, #sidebar-photos-albums li:hover, .photos-upload-link:hover, .textcomplete-item.active {
+.sidebar-circle-li:focus,
+#sidebar-new-circle:focus,
+#sidebar-edit-circles:focus,
+#sidebar-new-group:focus,
+#sidebar-new-pages:focus,
+#group-widget-collapse:focus,
+#sidebar-uncircled:focus,
+.side-link:focus,
+.nets-ul li:focus,
+#group-list-sidebar li:focus,
+#group-list-sidebar-right li:focus,
+#pages-list-sidebar li:focus,
+#pages-list-sidebar-right li:focus,
+.nets-all:focus,
+.saved-search-li:focus,
+li.tool:focus,
+.admin.link:focus,
+aside h4 a:focus,
+right_aside h4 a:focus,
+#message-new:focus,
+#sidebar-photos-albums li:focus,
+.photos-upload-link:focus,
+
+.sidebar-circle-li:active,
+#sidebar-new-circle:active,
+#sidebar-edit-circles:active,
+#sidebar-new-group:active,
+#sidebar-new-pages:active,
+#group-widget-collapse:active,
+#sidebar-uncircled:active,
+.side-link:active,
+.nets-ul li:active,
+#group-list-sidebar li:active,
+#group-list-sidebar-right li:active,
+#pages-list-sidebar li:active,
+#pages-list-sidebar-right li:active,
+.nets-all:active,
+.saved-search-li:active,
+li.tool:active,
+.admin.link:active,
+aside h4 a:active,
+right_aside h4 a:active,
+#message-new:active,
+#sidebar-photos-albums li:active,
+.photos-upload-link:active,
+.textcomplete-item.active
+
+.sidebar-circle-li:focus-within,
+#sidebar-new-circle:focus-within,
+#sidebar-edit-circles:focus-within,
+#sidebar-new-group:focus-within,
+#sidebar-new-pages:focus-within,
+#group-widget-collapse:focus-within,
+#sidebar-uncircled:focus-within,
+.side-link:focus-within,
+.nets-ul li:focus-within,
+#group-list-sidebar li:focus-within,
+#group-list-sidebar-right li:focus-within,
+#pages-list-sidebar li:focus-within,
+#pages-list-sidebar-right li:focus-within,
+.nets-all:focus-within,
+.saved-search-li:focus-within,
+li.tool:focus-within,
+.admin.link:focus-within,
+aside h4 a:focus-within,
+right_aside h4 a:focus-within,
+#message-new:focus-within,
+#sidebar-photos-albums li:focus-within,
+.photos-upload-link:focus-within {
 	/* background-color: #ddd; */
 	/* background-color: #e5e5e5; */
 	background-color: #F5F5F5;
@@ -657,13 +792,17 @@ nav#topbar-first a {
 	cursor: pointer;
 }
 
-nav#topbar-first a:hover .icon {
+nav#topbar-first a:hover .icon,
+nav#topbar-first a:focus .icon,
+nav#topbar-first a:active .icon {
 	color: #fff;
 }
 
-nav#topbar-first a:hover {
+nav#topbar-first a:hover,
+nav#topbar-first a:focus,
+nav#topbar-first a:active {
 	text-decoration: none;
-	outline: none;
+/*	outline: none;	do not hide from accessibility! */
 	color: #fff;
 	padding-bottom: 8px;
 	padding-top: 8px;
@@ -754,7 +893,10 @@ nav#topbar-first .nav-menu.selected {
 	/* background-color: #364E59; */
 }
 
-nav#topbar-first .nav-menu:hover {
+nav#topbar-first .nav-menu:hover,
+nav#topbar-first .nav-menu:focus,
+nav#topbar-first .nav-menu:active,
+nav#topbar-first .nav-menu:focus-within {
 	/* color: #fff !important; */
 	color: #fff;
 	/* text-shadow: 0px 1px 1px rgba(0, 0, 0, 0.5); */
@@ -834,7 +976,34 @@ nav#topbar-first #nav-user-linkmenu:hover #nav-user-menu,
 nav#topbar-first #nav-apps-link:hover #nav-apps-menu,
 nav#topbar-first #nav-site-linkmenu:hover #nav-site-menu,
 nav#topbar-first #nav-notifications-linkmenu:hover #nav-notifications-menu,
-#contact-edit-actions:hover #contact-actions-menu {
+#contact-edit-actions:hover #contact-actions-menu,
+
+.contact-entry-photo:focus .contact-photo-menu,
+.contact-photo-wrapper:focus .menu-popup,
+nav#topbar-first #nav-user-linklabel:focus #nav-user-menu,
+nav#topbar-first #nav-user-linkmenu:focus #nav-user-menu,
+nav#topbar-first #nav-apps-link:focus #nav-apps-menu,
+nav#topbar-first #nav-site-linkmenu:focus #nav-site-menu,
+nav#topbar-first #nav-notifications-linkmenu:focus #nav-notifications-menu,
+#contact-edit-actions:focus #contact-actions-menu,
+
+.contact-entry-photo:active .contact-photo-menu,
+.contact-photo-wrapper:active .menu-popup,
+nav#topbar-first #nav-user-linklabel:active #nav-user-menu,
+nav#topbar-first #nav-user-linkmenu:active #nav-user-menu,
+nav#topbar-first #nav-apps-link:active #nav-apps-menu,
+nav#topbar-first #nav-site-linkmenu:active #nav-site-menu,
+nav#topbar-first #nav-notifications-linkmenu:active #nav-notifications-menu,
+#contact-edit-actions:active #contact-actions-menu,
+
+.contact-entry-photo:focus-within .contact-photo-menu,
+.contact-photo-wrapper:focus-within .menu-popup,
+nav#topbar-first #nav-user-linklabel:focus-within #nav-user-menu,
+nav#topbar-first #nav-user-linkmenu:focus-within #nav-user-menu,
+nav#topbar-first #nav-apps-link:focus-within #nav-apps-menu,
+nav#topbar-first #nav-site-linkmenu:focus-within #nav-site-menu,
+nav#topbar-first #nav-notifications-linkmenu:focus-within #nav-notifications-menu,
+#contact-edit-actions:focus-within #contact-actions-menu {
 	display:block;
 	visibility:visible;
 	opacity:1;
@@ -917,7 +1086,11 @@ ul.menu-popup a {
 	text-decoration: none;
 }
 nav#topbar-first ul.menu-popup a:hover,
-ul.menu-popup a:hover {
+ul.menu-popup a:hover,
+nav#topbar-first ul.menu-popup a:focus,
+ul.menu-popup a:focus,
+nav#topbar-first ul.menu-popup a:active,
+ul.menu-popup a:active {
 	/* background-color: #bdcdd4; */
 	background-color: #e5e5e5;
 }
@@ -982,11 +1155,15 @@ nav#topbar-first .acpopup {
 	color: #000;
 	padding: 3px 20px;
 }
-.textcomplete-item a .group, .group .acpopup-sub-text {
+.textcomplete-item a:hover,
+.textcomplete-item a:focus,
+.textcomplete-item a:active {
 	color: #36C;
 	opacity: 0.8;
 }
-.textcomplete-item a .group:hover {
+.textcomplete-item a .group:hover,
+.textcomplete-item a .group:focus,
+.textcomplete-item a .group:active {
 	opacity: 1.0;
 }
 img.acpopup-img {
@@ -1013,7 +1190,9 @@ img.acpopup-img {
 	cursor: pointer;
 }
 
-#nav-notifications-menu > li:hover {
+#nav-notifications-menu > li:hover,
+#nav-notifications-menu > li:focus,
+#nav-notifications-menu > li:active {
 	background-color: #e5e5e5;
 	color: #000;
 }
@@ -1183,7 +1362,15 @@ aside #wallmessage-link {
 }
 aside #subscribe-feed-link:hover,
 aside #dfrn-request-link:hover,
-aside #wallmessage-link:hover {
+aside #wallmessage-link:hover
+
+aside #subscribe-feed-link:focus,
+aside #dfrn-request-link:focus,
+aside #wallmessage-link:focus,
+
+aside #subscribe-feed-link:active,
+aside #dfrn-request-link:active,
+aside #wallmessage-link:active {
 	text-decoration: none;
 	background-color: #36c;
 	/* background-color: #19aeff; */
@@ -1193,7 +1380,10 @@ aside #profiles-menu {
 	left: 10px;
 }
 
-aside #search-text, aside #side-follow-url, aside #side-peoplefind-url, right_aside #side-peoplefind-url {
+aside #search-text,
+aside #side-follow-url,
+aside #side-peoplefind-url,
+right_aside #side-peoplefind-url {
 	width: 65%;
 	float: left;
 	padding-left: 10px;
@@ -1207,7 +1397,8 @@ aside #search-text, aside #side-follow-url, aside #side-peoplefind-url, right_as
 	-moz-border-right-colors: #dbdbdb;*/
 }
 
-aside #side-peoplefind-submit, right_aside #side-peoplefind-submit {
+aside #side-peoplefind-submit,
+right_aside #side-peoplefind-submit {
 	float: left;
 }
 
@@ -1293,7 +1484,10 @@ aside img {
 	-ms-transition: all 0.2s ease-in-out;
 	transition: all 0.2s ease-in-out;
 }
-.widget:hover .title .action {
+.widget:hover .title .action,
+.widget:focus .title .action,
+.widget:active .title .action,
+.widget:focus-within .title .action {
 	opacity: 1;
 	-webkit-transition: all 0.2s ease-in-out;
 	-moz-transition: all 0.2s ease-in-out;
@@ -1301,7 +1495,10 @@ aside img {
 	-ms-transition: all 0.2s ease-in-out;
 	transition: all 0.2s ease-in-out;
 }
-.widget .tool:hover .action {
+.widget .tool:hover .action,
+.widget .tool:focus .action,
+.widget .tool:active .action,
+.widget .tool:focus-within .action {
 	opacity: 1;
 	-webkit-transition: all 0.2s ease-in-out;
 	-moz-transition: all 0.2s ease-in-out;
@@ -1309,7 +1506,10 @@ aside img {
 	-ms-transition: all 0.2s ease-in-out;
 	transition: all 0.2s ease-in-out;
 }
-.widget .tool:hover .action.ticked {
+.widget .tool:hover .action.ticked,
+.widget .tool:focus .action.ticked,
+.widget .tool:active .action.ticked,
+.widget .tool:focus-within .action.ticked {
 	opacity: 1;
 	-webkit-transition: all 0.2s ease-in-out;
 	-moz-transition: all 0.2s ease-in-out;
@@ -1452,7 +1652,19 @@ section.minimal {
 }
 .wall-item-container:hover .wall-item-tags,
 .wall-item-container:hover .wall-item-links,
-.wall-item-container:hover .wall-item-actions {
+.wall-item-container:hover .wall-item-actions,
+
+.wall-item-container:focus .wall-item-tags,
+.wall-item-container:focus .wall-item-links,
+.wall-item-container:focus .wall-item-actions,
+
+.wall-item-container:active .wall-item-tags,
+.wall-item-container:active .wall-item-links,
+.wall-item-container:active .wall-item-actions,
+
+.wall-item-container:focus-within .wall-item-tags,
+.wall-item-container:focus-within .wall-item-links,
+.wall-item-container:focus-within .wall-item-actions {
 	opacity: 1;
 	-webkit-transition: all 0.2s ease-in-out;
 	-moz-transition: all 0.2s ease-in-out;
@@ -1536,7 +1748,19 @@ section.minimal {
 .wall-item-container .wall-item-bottom a:hover,
 .wall-item-container .wall-item-links, .wall-item-container .wall-item-actions a:hover,
 .wall-item-container .wall-item-links, .wall-item-container .wall-item-links a:hover,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions .fakelink:hover {
+.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions .fakelink:hover,
+
+.mail-list-wrapper a:focus,
+.wall-item-container .wall-item-bottom a:focus,
+.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions a:focus,
+.wall-item-container .wall-item-links, .wall-item-container .wall-item-links a:focus,
+.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions .fakelink:focus,
+
+.mail-list-wrapper a:active,
+.wall-item-container .wall-item-bottom a:active,
+.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions a:active,
+.wall-item-container .wall-item-links, .wall-item-container .wall-item-links a:active,
+.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions .fakelink:active {
 	color: #000;
 	text-decoration: none;
 }
@@ -1548,7 +1772,12 @@ section.minimal {
 	-ms-transition: all 0.2s ease-in-out;
 	transition: all 0.2s ease-in-out;
 }
-.wall-item-container .wall-item-links .icon:hover, .wall-item-container .wall-item-actions .icon:hover {
+.wall-item-container .wall-item-links .icon:hover,
+.wall-item-container .wall-item-actions .icon:hover,
+.wall-item-container .wall-item-links .icon:focus,
+.wall-item-container .wall-item-actions .icon:focus,
+.wall-item-container .wall-item-links .icon:active,
+.wall-item-container .wall-item-actions .icon:active {
 	opacity: 1;
 	-webkit-transition: all 0.2s ease-in-out;
 	-moz-transition: all 0.2s ease-in-out;
@@ -1557,7 +1786,9 @@ section.minimal {
 	transition: all 0.2s ease-in-out;
 }
 
-.wall-item-container .wall-item-name:hover {
+.wall-item-container .wall-item-name:hover,
+.wall-item-container .wall-item-name:focus,
+.wall-item-container .wall-item-name:active {
 	color: #36c;
 }
 
@@ -1575,7 +1806,22 @@ section.minimal {
 .toplevel_item:hover .wall-item-name,
 .wall-item-container:hover .wall-item-name,
 .toplevel_item:hover .shared-author,
-.wall-item-container:hover .shared-author {
+.wall-item-container:hover .shared-author,
+
+.toplevel_item:focus .wall-item-name,
+.wall-item-container:focus .wall-item-name,
+.toplevel_item:focus .shared-author,
+.wall-item-container:focus .shared-author,
+
+.toplevel_item:active .wall-item-name,
+.wall-item-container:active .wall-item-name,
+.toplevel_item:active .shared-author,
+.wall-item-container:active .shared-author,
+
+.toplevel_item:focus-within .wall-item-name,
+.wall-item-container:focus-within .wall-item-name,
+.toplevel_item:focus-within .shared-author,
+.wall-item-container:focus-within .shared-author {
 	color: #36c;
 	font-weight: bold;
 	-webkit-transition: all 0.2s ease-in-out;
@@ -1602,7 +1848,22 @@ section.minimal {
 .toplevel_item:hover .fakelink,
 .wall-item-container:hover .fakelink,
 .toplevel_item:hover .wall-item-content a,
-.wall-item-container:hover .wall-item-content a {
+.wall-item-container:hover .wall-item-content a,
+
+.toplevel_item:focus .fakelink,
+.wall-item-container:focus .fakelink,
+.toplevel_item:focus .wall-item-content a,
+.wall-item-container:focus .wall-item-content a,
+
+.toplevel_item:active .fakelink,
+.wall-item-container:active .fakelink,
+.toplevel_item:active .wall-item-content a,
+.wall-item-container:active .wall-item-content a,
+
+.toplevel_item:focus-within .fakelink,
+.wall-item-container:focus-within .fakelink,
+.toplevel_item:focus-within .wall-item-content a,
+.wall-item-container:focus-within .wall-item-content a {
 	color: #36c;
 	-webkit-transition: all 0.2s ease-in-out;
 	-moz-transition: all 0.2s ease-in-out;
@@ -1612,7 +1873,13 @@ section.minimal {
 }
 
 .toplevel_item:hover .togglecomment,
-.wall-item-container:hover .togglecomment {
+.wall-item-container:hover .togglecomment,
+.toplevel_item:focus .togglecomment,
+.wall-item-container:focus .togglecomment,
+.toplevel_item:active .togglecomment,
+.wall-item-container:active .togglecomment,
+.toplevel_item:focus-within .togglecomment,
+.wall-item-container:focus-within .togglecomment {
 	color: #999;
 }
 
@@ -1893,8 +2160,13 @@ profile-jot-form #jot-title, #profile-jot-form #jot-category {
 .tagblock .tag-cloud .tag {
 	display: unset;
 }
-.tagblock .tag-cloud .tag:hover {
+.tagblock .tag-cloud .tag:hover,
+.tagblock .tag-cloud .tag:focus,
+.tagblock .tag-cloud .tag:active {
 	color: black;
+}
+.wall-item-info {
+	position: relative; /* for wwto */
 }
 .wwto {
 	position: absolute !important;
@@ -1914,6 +2186,12 @@ profile-jot-form #jot-title, #profile-jot-form #jot-category {
 .wwto .contact-photo {
 	width: auto;
 	height: 25px;
+}
+.comment .wwto {
+	top: 20px;
+}
+.comment .wwto .contact-photo {
+	margin: 0px;
 }
 /* contacts menu */
 .contact-photo-wrapper {
@@ -2014,7 +2292,10 @@ profile-jot-form #jot-title, #profile-jot-form #jot-category {
 	line-height: 40px;
 	overflow: hidden;
 }
-#jot #jot-tools li:hover {
+#jot #jot-tools li:hover,
+#jot #jot-tools li:focus,
+#jot #jot-tools li:active,
+#jot #jot-tools li:focus-within {
 	background-color: #364e59;
 	border-bottom: 2px solid #bdcdd4;
 }
@@ -2050,7 +2331,10 @@ profile-jot-form #jot-title, #profile-jot-form #jot-category {
 	height: 40px;
 	line-height: 40px;
 }
-#jot #jot-tools li.submit input:hover {
+#jot #jot-tools li.submit input:hover,
+#jot #jot-tools li.submit input:focus,
+#jot #jot-tools li.submit input:active,
+#jot #jot-tools li.submit input:focus-within {
 	background-color: #bdcdd4;
 	color: #666666;
 }
@@ -2072,6 +2356,7 @@ profile-jot-form #jot-title, #profile-jot-form #jot-category {
 	margin: 0px;
 	height: 20px;
 	width: 700px;
+	max-width: 100%;
 	font-weight: bold;
 	border: 1px solid #ffffff;
 }
@@ -2081,10 +2366,10 @@ profile-jot-form #jot-title, #profile-jot-form #jot-category {
 #jot #jot-title:-moz-placeholder {
 	font-weight: normal;
 }
-#jot #jot-title:hover {
-	border: 1px solid #999999;
-}
-#jot #jot-title:focus {
+#jot #jot-title:hover,
+#jot #jot-title:focus,
+#jot #jot-title:active,
+#jot #jot-title:focus-within {
 	border: 1px solid #999999;
 }
 #jot #character-counter {
@@ -2172,7 +2457,9 @@ profile-jot-form #jot-title, #profile-jot-form #jot-category {
 	width: 690px;
 	float: left;
 }
-#acl-wrapper a:hover {
+#acl-wrapper a:hover,
+#acl-wrapper a:focus,
+#acl-wrapper a:active {
 	text-decoration: none;
 	color: #000000;
 }
@@ -2251,15 +2538,44 @@ ul.tabs a {
 	margin-bottom: 2px;
 }
 
-#event-notice:hover, #birthday-notice:hover, ul.tabs li .active,
-.comment-edit-submit-wrapper .fakelink:hover {
+#event-notice:hover,
+#birthday-notice:hover,
+.comment-edit-submit-wrapper .fakelink:hover,
+
+#event-notice:focus,
+#birthday-notice:focus,
+.comment-edit-submit-wrapper .fakelink:focus,
+
+#event-notice:active,
+#birthday-notice:active,
+ul.tabs li .active,
+.comment-edit-submit-wrapper .fakelink:active {
 	color: black;
 }
 
-span.pager_current, span.pager_n a:hover,
-span.pager_first a:hover, span.pager_last a:hover,
-span.pager_prev a:hover, span.pager_next a:hover,
-ul.tabs a:hover {
+span.pager_current,
+span.pager_n a:hover,
+span.pager_first a:hover,
+span.pager_last a:hover,
+span.pager_prev a:hover,
+span.pager_next a:hover,
+ul.tabs a:hover,
+
+span.pager_current,
+span.pager_n a:focus,
+span.pager_first a:focus,
+span.pager_last a:focus,
+span.pager_prev a:focus,
+span.pager_next a:focus,
+ul.tabs a:focus,
+
+span.pager_current,
+span.pager_n a:active,
+span.pager_first a:active,
+span.pager_last a:active,
+span.pager_prev a:active,
+span.pager_next a:active,
+ul.tabs a:active {
 	border-bottom: 2px solid #244C5E;
 	text-decoration: none;
 	color: grey;
@@ -2272,7 +2588,17 @@ ul.tabs li .active, span.pager_current a {
 	color: black;
 }
 
-#event-notice:hover, #birthday-notice:hover, .comment-edit-submit-wrapper .fakelink:hover {
+#event-notice:hover,
+#birthday-notice:hover,
+.comment-edit-submit-wrapper .fakelink:hover,
+
+#event-notice:focus,
+#birthday-notice:focus,
+.comment-edit-submit-wrapper .fakelink:focus
+
+#event-notice:active,
+#birthday-notice:active,
+.comment-edit-submit-wrapper .fakelink:active {
 /*    background-color: #e5e5e5; */
 	color: grey;
 	text-decoration: none;
@@ -2287,7 +2613,9 @@ ul.tabs li .active, span.pager_current a {
 	padding: 0px 5px 1px 5px;
 }
 
-.comment-edit-bb a:hover {
+.comment-edit-bb a:hover,
+.comment-edit-bb a:focus,
+.comment-edit-bb a:active {
 	color: #000;
 	text-decoration: none;
 }
@@ -2581,7 +2909,9 @@ aside #id_password {
 	color: #2d2d2d;
 	text-decoration: none;
 }
-.contact-photo-menu li a:hover {
+.contact-photo-menu li a:hover,
+.contact-photo-menu li a:focus,
+.contact-photo-menu li a:active {
 	background-color: #bdcdd4;
 }
 
@@ -2997,12 +3327,178 @@ a.btn#contact-edit-actions-button {
 .photo-top-image-wrapper,
 .photo-album-image-wrapper {
 	position: relative;
-	float: left;
+	float: left !important;
 	margin-top: 15px;
 	margin-right: 15px;
 	width: 200px; height: 200px;
-	overflow: hidden;
+	overflow: visible;
+	background-color: #fff;
 }
+	.photo-top-image-wrapper:hover,
+	.photo-top-image-wrapper:focus,
+	.photo-top-image-wrapper:active,
+	.photo-top-image-wrapper:focus-within,
+	.photo-album-image-wrapper:hover,
+	.photo-album-image-wrapper:focus,
+	.photo-album-image-wrapper:active,
+	.photo-album-image-wrapper:focus-within {
+		box-shadow: inset 0 0 3px black !important;
+	}
+		.photo-album-photo-link {
+			position: absolute;
+			top: 0;
+			left: 0;
+			height: 100%;
+			width:  100%;
+		}
+		.photo-album-photo-link:hover,
+		.photo-album-photo-link:focus,
+		.photo-album-photo-link:active,
+		.photo-album-photo-link:focus-within {
+			text-decoration: none;
+			box-shadow: inset 0 0 2px black;
+		}
+		.photo-album-photo-link:hover img,
+		.photo-album-photo-link:focus img,
+		.photo-album-photo-link:active img,
+		.photo-album-photo-link:focus-within img {
+			filter: brightness(110%);
+		}
+	section:has(.fbrowser) {
+		width: 75%;
+		max-width: 75%;
+	}
+		.fbrowser.photo a img {
+			height: 100%;
+			width:  100%;
+			object-fit: cover;
+			object-position: center center;
+		}
+		.fbrowser .folders ul {
+			padding: 0;
+		}
+		.fbrowser .folders ul li {
+			display: inline-block;
+			margin-bottom: 5px;
+		}
+			.fbrowser .folders ul li a {
+				background-color: rgb(237, 237, 237);
+				border: 1px solid rgb(220, 220, 220);
+				border-radius: 4px;
+				box-shadow: rgb(255,255,255) 0px 1px 0px 1px inset;
+				color: rgb(45,45,45);
+				font-size: 15px;
+				font-weight: 700;
+				line-height: 40px;
+				height: 40px;
+				padding: 0 15px;
+				text-shadow: rgb(255,255,255) 1px 1px 0px;
+				display: block;
+			}
+				.fbrowser .folders ul li a::before {
+					content: '\f3ca';
+					font-family: remixicon;
+					margin-right: 5px;
+				}
+				.fbrowser .folders ul li a:hover,
+				.fbrowser .folders ul li a:focus,
+				.fbrowser .folders ul li a:active {
+					background-color: #e6e6e6;
+					text-decoration: none;
+				}
+		.fbrowser .list .upload {
+		  height: 200px;
+		  width: 200px;
+		  float: left;
+		  margin-right: 15px;
+		  margin-top: 15px;
+		  padding: 0;
+		  box-sizing: border-box;
+		  border: ;
+		}
+		#upload-photo, #upload-attachment {
+		  height: 100%;
+		  width: 100%;
+		  box-shadow: none;
+		  box-sizing: border-box;
+		  border-style: dashed;
+		  font-weight: 700;
+		}
+		/* upload buttons have ajax button overlay so style that on hover/focus */
+		body.minimal .ajaxbutton-wrapper:hover,
+		body.minimal .ajaxbutton-wrapper:focus,
+		body.minimal .ajaxbutton-wrapper:active,
+		body.minimal .ajaxbutton-wrapper:focus-within {
+			background-color: #ccc;
+			opacity: .25 !important;
+		}
+		#upload-photo::before,
+		#upload-attachment::before {
+		  content: '\f4b1';
+		  font-family: remixicon;
+		}
+		.fbrowser.attachment a[data-img]::before{
+		content: '\eceb';
+		font-family: 'remixicon';
+		font-size: 72px;
+		position: relative;
+		top: 0;
+		left: 0;
+		height: 100%;
+		width:  100%;
+		display: block;
+		text-align: center;
+		line-height: 175px;
+		color: var(--link-color);
+	}
+		.fbrowser.attachment a[data-img$="audio.png"]::before {
+			content: '\ecf7';
+		}
+		.fbrowser.attachment a[data-img$="image.png"]::before {
+			content: '\f3c4';
+		}
+		.fbrowser.attachment a[data-img$="text.png"]::before {
+			content: '\ed0f';
+		}
+		.fbrowser.attachment a[data-img$="video.png"]::before {
+			content: '\f3c8';
+		}
+		.fbrowser.attachment a[data-img$="zip.png"]::before,
+		.fbrowser.attachment a[data-filename$=".zip"]::before {
+			content: '\ed1f';
+		}
+		.fbrowser.attachment a[data-filename$=".pdf"]::before {
+			content: '\f3c6';
+		}
+		.fbrowser.attachment a[data-filename$=".ppt"]::before {
+			content: '\ed01';
+		}
+		.fbrowser.attachment a[data-filename$=".xls"]::before {
+			content: '\ecdf';
+		}
+		.fbrowser.attachment a[data-filename$=".doc"]::before {
+			content: '\ed1d';
+		}
+		.fbrowser.attachment a[data-filename$=".htm"]::before,
+		.fbrowser.attachment a[data-filename$=".html"]::before,
+		.fbrowser.attachment a[data-filename$=".js"]::before,
+		.fbrowser.attachment a[data-filename$=".css"]::before,
+		.fbrowser.attachment a[data-filename$=".php"]::before {
+			content: '\ecd1';
+		}
+	.fbrowser.attachment a img {
+		display: none;
+	}
+	.fbrowser.attachment a p {
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		text-align: center;
+		white-space: wrap;
+		word-break: break-word;
+	}
+
 .photo-top-album-name {
 	width: 100%;
 	min-height: 2em;
@@ -3011,6 +3507,7 @@ a.btn#contact-edit-actions-button {
 	padding: 0px 3px;
 	padding-top: 0.5em;
 	background-color: rgb(255, 255, 255);
+	box-sizing: border-box;
 }
 #photo-top-end {
 	clear: both;
@@ -3049,7 +3546,10 @@ img.photo-album-photo {
 	-ms-transition: all 0.5s ease-in-out;
 	transition: all 0.5s ease-in-out;
 }
-.photo-album-image-wrapper:hover .caption {
+.photo-album-image-wrapper:hover .caption,
+.photo-album-image-wrapper:focus .caption,
+.photo-album-image-wrapper:active .caption,
+.photo-album-image-wrapper:focus-within .caption {
 	opacity: 1;
 }
 
@@ -3059,14 +3559,19 @@ img.photo-album-photo {
 	min-height: 16px;
 	list-style: none;
 }
-.menu-profile-list:hover {
+.menu-profile-list:hover,
+.menu-profile-list:focus,
+.menu-profile-list:active,
+.menu-profile-list:focus-within {
 	background: #E7F2F7;
 }
 .menu-profile-list-item {
 	padding-left: 5px;
 	vertical-align: middle;
 }
-.menu-profile-list-item:hover {
+.menu-profile-list-item:hover,
+.menu-profile-list-item:focus,
+.menu-profile-list-item:active {
 	text-decoration: none;
 }
 
@@ -3139,7 +3644,9 @@ img.photo-album-photo {
 	-ms-transition: all 0.2s ease-in-out;
 	transition: all 0.2s ease-in-out;
 }
-#mail-display-subject:hover .mail-delete {
+#mail-display-subject:hover .mail-delete,
+#mail-display-subject:focus .mail-delete,
+#mail-display-subject:active .mail-delete {
 	opacity: 1;
 	-webkit-transition: all 0.2s ease-in-out;
 	-moz-transition: all 0.2s ease-in-out;
@@ -3267,7 +3774,9 @@ img.photo-album-photo {
 	text-align:center;
 	text-shadow:1px 1px 0px #ffffff;
 }
-.btn:hover {
+.btn:hover,
+.btn:focus,
+.btn:active {
 	background-color:#e6e6e6;
 	text-decoration:none;
 }
@@ -3292,7 +3801,10 @@ img.photo-album-photo {
 	top: 0px;
 	transition: opacity 0.5s;
 }
-.videos .video-top-wrapper:hover .video-delete {
+.videos .video-top-wrapper:hover .video-delete,
+.videos .video-top-wrapper:focus .video-delete,
+.videos .video-top-wrapper:active .video-delete,
+.videos .video-top-wrapper:focus-within .video-delete {
 	opacity: 1;
 }
 /* invite page */

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -2594,7 +2594,7 @@ ul.tabs li .active, span.pager_current a {
 
 #event-notice:focus,
 #birthday-notice:focus,
-.comment-edit-submit-wrapper .fakelink:focus
+.comment-edit-submit-wrapper .fakelink:focus,
 
 #event-notice:active,
 #birthday-notice:active,

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -1739,28 +1739,29 @@ section.minimal {
 }
 .mail-list-wrapper a,
 .wall-item-container .wall-item-bottom a,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions a,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-links a,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions .fakelink {
+.wall-item-container .wall-item-links,
+.wall-item-container .wall-item-actions a,
+.wall-item-container .wall-item-links a,
+.wall-item-container .wall-item-actions .fakelink {
 	color: #999;
 }
 .mail-list-wrapper a:hover,
 .wall-item-container .wall-item-bottom a:hover,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions a:hover,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-links a:hover,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions .fakelink:hover,
+.wall-item-container .wall-item-actions a:hover,
+.wall-item-container .wall-item-links a:hover,
+.wall-item-container .wall-item-actions .fakelink:hover,
 
 .mail-list-wrapper a:focus,
 .wall-item-container .wall-item-bottom a:focus,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions a:focus,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-links a:focus,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions .fakelink:focus,
+.wall-item-container .wall-item-actions a:focus,
+.wall-item-container .wall-item-links a:focus,
+.wall-item-container .wall-item-actions .fakelink:focus,
 
 .mail-list-wrapper a:active,
 .wall-item-container .wall-item-bottom a:active,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions a:active,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-links a:active,
-.wall-item-container .wall-item-links, .wall-item-container .wall-item-actions .fakelink:active {
+.wall-item-container .wall-item-actions a:active,
+.wall-item-container .wall-item-links a:active,
+.wall-item-container .wall-item-actions .fakelink:active {
 	color: #000;
 	text-decoration: none;
 }
@@ -3397,7 +3398,8 @@ a.btn#contact-edit-actions-button {
 			}
 				.fbrowser .folders ul li a::before {
 					content: '\f3ca';
-					font-family: remixicon;
+					/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword -- icon font, no generic fallback possible */
+					font-family: 'remixicon';
 					margin-right: 5px;
 				}
 				.fbrowser .folders ul li a:hover,
@@ -3434,10 +3436,12 @@ a.btn#contact-edit-actions-button {
 		#upload-photo::before,
 		#upload-attachment::before {
 		  content: '\f4b1';
-		  font-family: remixicon;
+		  /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword -- icon font, no generic fallback possible */
+		  font-family: 'remixicon';
 		}
 		.fbrowser.attachment a[data-img]::before{
 		content: '\eceb';
+		/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword -- icon font, no generic fallback possible */
 		font-family: 'remixicon';
 		font-size: 72px;
 		position: relative;
@@ -3495,7 +3499,7 @@ a.btn#contact-edit-actions-button {
 		right: 0;
 		text-align: center;
 		white-space: wrap;
-		word-break: break-word;
+		overflow-wrap: break-word;
 	}
 
 .photo-top-album-name {

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -2562,7 +2562,6 @@ span.pager_prev a:hover,
 span.pager_next a:hover,
 ul.tabs a:hover,
 
-span.pager_current,
 span.pager_n a:focus,
 span.pager_first a:focus,
 span.pager_last a:focus,
@@ -2570,7 +2569,6 @@ span.pager_prev a:focus,
 span.pager_next a:focus,
 ul.tabs a:focus,
 
-span.pager_current,
 span.pager_n a:active,
 span.pager_first a:active,
 span.pager_last a:active,
@@ -3398,7 +3396,6 @@ a.btn#contact-edit-actions-button {
 			}
 				.fbrowser .folders ul li a::before {
 					content: '\f3ca';
-					/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword -- icon font, no generic fallback possible */
 					font-family: 'remixicon';
 					margin-right: 5px;
 				}
@@ -3436,12 +3433,10 @@ a.btn#contact-edit-actions-button {
 		#upload-photo::before,
 		#upload-attachment::before {
 		  content: '\f4b1';
-		  /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword -- icon font, no generic fallback possible */
 		  font-family: 'remixicon';
 		}
 		.fbrowser.attachment a[data-img]::before{
 		content: '\eceb';
-		/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword -- icon font, no generic fallback possible */
 		font-family: 'remixicon';
 		font-size: 72px;
 		position: relative;

--- a/view/theme/vier/style.css
+++ b/view/theme/vier/style.css
@@ -1362,7 +1362,7 @@ aside #wallmessage-link {
 }
 aside #subscribe-feed-link:hover,
 aside #dfrn-request-link:hover,
-aside #wallmessage-link:hover
+aside #wallmessage-link:hover,
 
 aside #subscribe-feed-link:focus,
 aside #dfrn-request-link:focus,


### PR DESCRIPTION
There's quite a lot in this PR so bear with me. It addresses the issues raised in https://github.com/friendica/friendica/pull/15023 and https://github.com/friendica/friendica/issues/16009

The functional ALT buttons and masonry and grid layouts are changes for all themes.  The revamped file and photo browser is the only thing that is theme-specific.

### Functional Alt-Text Buttons

They look exactly like the pseudo-class that is shown in the current stable, but these are actually clickable and reveal the alt-text for the image, and they do so with pure CSS, no JS or jQuery involved. How? With the _user action_ pseudo-classes. I purposely did not include `:hover` to activate them because I found it annoying while scrolling the feed if my mouse pointer happened to have the button pass under it there were alt-text boxes popping up and going away. So you _only_ see it if you intentionally click on it to open it. Or tap on it with a touch device. Or tab to it with a keyboard. If there is a situation where it won't activate it will just look and act like the current psuedo element that simply tells users the image has alt-text.

_EDIT: those are earlier screencaps below, in the final code I removed the "Alt-Text:" header on the text box because it felt superfluous and it would have required adding a new translatable string to Friendica, and it would get translated but the alt-text below it would not, so it felt like a better plan to just remove the header._

Here is what it looks like on a single image in a post:
<img width="608" height="601" alt="Alt-Text_button_single" src="https://github.com/user-attachments/assets/504d83a9-9b63-4c9c-9d65-ba88c1efca7f" />

Here is how it handles really LONG alt-text descriptions:
<img width="673" height="509" alt="Alt-Text_button_long" src="https://github.com/user-attachments/assets/49d1c8ca-fdb0-4ddc-badb-0f458ece7d76" />

Anyone navigating with a keyboard can tab _into_ that text to scroll it. I wasn't sure how big to make this so I just used the same dimensions Mastodon uses for theirs.

And here is how it looks with multipl images shown in a masonry gallery:
<img width="650" height="537" alt="Alt-Text_button_masonry" src="https://github.com/user-attachments/assets/4f30a17a-6f12-4db9-a33b-3b871fbb4a57" />

One thing you have to be careful with is that the images aren't put inside a container with `overflow: hidden;` or part or all of the alt-text pop-up can be cut off. Which is why I had to rework almost all the image containers to make sure that doesn't happen...in your feed.

It DOES happen in photo albums and the photo browser, because the images are nested inside a container that _has_ to have overflow hidden, so any image too close to an edge can have its alt-text popup chopped off. So in those circumstances it switches back to the non-functional pseudo-element. Only I reversed the coloring so it is black text on a white background (well semi-transparent gray - I'm hoping the gray makes it clear it's disabled and non-functional). On desktop, though, when you mouse over those images the tooltip that shows the image title shows you the alt-text (this is how it currently works btw).

### Fixed Masonry Layout

Currently if there are an odd number of images the last picture in the gallery appears dangling off the bottom by itself and it looks like the layout is broken. There was code added to the backend to specifically DO this, and I believe it may have been because someone didn't like the last image being "too big" (though it would never appear any larger than if you'd posted it by itself).  I got rid of that code so the odd final image will span both columns of the masonry layout:

<img width="650" height="774" alt="fixed_masonry" src="https://github.com/user-attachments/assets/538dce45-3bc0-4e0b-8be6-e45d40844ffa" />

### New Grid Layout

We're not even sure if/when this layout ever gets used, but the _only_ circumstances under which it would is if Friendica, for some reason, cannot detect the dimensions of an image in the set. Does that ever happen? No idea. But if it did the current layout looks like this:
<img width="651" height="652" alt="current_grid" src="https://github.com/user-attachments/assets/6605f9e2-c1ae-4606-9ed0-db3c5a7a81d1" />

The images are split between two `<div>` containers acting as columns so that they can be read across and then down. Which isn't how CSS columns work, they read down and then over.

To make this more consistent with how the masonry layout works I switched it to pairing images in `<div>` container rows with a flexbox layout:
<img width="397" height="800" alt="new_grid" src="https://github.com/user-attachments/assets/95bf529b-73fd-4e73-ad18-2b93a0c819de" />

People were rather insistent that the images *not* be cropped at all so this scales the images using `object-fit: contain;` and then I added color to the `<figure>` containers to fill the rest of the space when the images won't fit together nicely.

### Faux Grid Fix

If someone posts a bunch of images together there are some common stumbling blocks that will prevent Friendica from using either the masonry or grid layouts to display them. Just this week someone posted in the support forum about it.  The circumstances that can prevent multiple images from being shows as a gallery are:

* typing any text between any two images
* making a hard or soft carriage return between any two images
* embedding any other media between images.
* placing carriage returns or text after the last image.

In which case it will just show the images, full width, in a single column:
<img width="326" height="2178" alt="broken_masonry" src="https://github.com/user-attachments/assets/565fcae7-82ea-4322-8ac1-62787451f1a9" />

I added CSS to try and detect whenever there are three or more images in a row with nothing in between them and if there are to shrink and float them into some kind of gallery display, with the last image in the sequence clearing the floats:

<img width="326" height="823" alt="faux_grid_fix" src="https://github.com/user-attachments/assets/9965efe4-c348-4507-a84c-854ef952be33" />

It's not perfect, and the CSS is very convoluted trying to find the correct sequence, but at least it will spare people on phones from having to scroll for a week to get to the bottom of that post.

### Masonry & Alt-Text Post Previews

One of the reasons people can end up accidentally posting a bunch of images that _don't_ end up being shown as a gallery is that they have no way to _know_ that when they compose the post and preview it.

So I also added a ton of JS to apply the masonry layout to multiple images in the post preview! It follows the same rules for exceptions as the PHP backend masonry layout so it _should_ be a pretty accurate indicator of whether or not your images will be presented as a gallery or not.

This also presents images in the post preview with functional alt-text buttons, assuming the image has alt-text.

All of this is a bit tricky because the post preview doesn't actually use the image or layout templates. It just processes the raw BBcode into simple HTML. So the script has to find the images and wrap them in the same elements (`<figure>`, `<div>`, etc.) that images are presented inside in actual published posts.  Are there a million ways this can go wrong? Probably.  For example we have no idea how long it will take the server to do the ajax request so it needs to monitor the preview pane for a DOM mutation, and failing that use setInterval to keep checking if all the images are present or processed.  In my testing it adds a little less than 1 second to the preview generation and even with a ton of images it was less than 3 seconds.  The script does enable  the "rotator" so it's clear to the user something is happening. Took forever to figure this out.

### Revamped Vier File Browser

So long as I was already poking around in this code I thought I'd do something about how ugly and clunky the Photo/File Browser looks in Vier.  I already had most of the CSS for this from my "BookLook" theme project, which some of you have seen the preview screenshots from that.  So here is what the Vier Photo Browser looks like:
<img width="1337" height="603" alt="Vier_Photo_Browser" src="https://github.com/user-attachments/assets/26b297c2-56ef-46bf-8e2e-b8a74b74def7" />

_You can see here how the non-functional "ALT" looks on those images, since the nested containers with no overflow mean the functional ones can't be used in this context._

Here's what it looks like on mobile btw:
<img width="373" height="653" alt="Vier_Mobile_Photo_Browser" src="https://github.com/user-attachments/assets/fcd89efa-3156-4c71-b8cb-44cc062e89da" />

And here is the updated File Browser:
<img width="1330" height="716" alt="Vier_File_Browser" src="https://github.com/user-attachments/assets/f6f0ab27-92f2-408f-b0c4-d06255de2ab9" />

So instead of those ancient looking images to represent the file types I switched to the Remix Icons for them. This takes up a bit more space, yes, but on mobile you'll have much better touch-targets for selection.

Okay, I think that's it for this one.  I really hope I got all the bits and pieces in this PR. I'm working on several others and it's hard to keep track of all the code I've changed for each one.





