### PR TITLE
Add explicit color-scheme property to theme schemas (black)

### DIFF
--- a/view/theme/frio/scheme/black.css
+++ b/view/theme/frio/scheme/black.css
@@ -9,6 +9,11 @@
     Created on : 11.08.2020
     Author     : Hypolite Petovan <hypolite@friendica.mrpetovan.com>
 */
+
+:root {
+    color-scheme: dark;
+}
+
 #topbar-first {
 	background-color: $background_color;
 }


### PR DESCRIPTION
Problem:
Without an explicit declaration, browsers rely entirely on the operating system's setting (prefers-color-scheme). This causes visual bugs when a user selects a light theme while their OS is in dark mode (or vice versa), resulting in mismatched native elements like scrollbars and form controls.

Benefit for CSS Developers:
It establishes a reliable, native context for the active schema. CSS developers can leverage standard system keywords (like Canvas) or color-scheme queries to cleanly style and adapt custom components, overlays, or plugins without needing complex JavaScript workarounds or missing body classes.