### PR TITLE
Add explicit color-scheme property to theme schemas (dark)

### DIFF
--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -10,6 +10,10 @@
     Author     : Hypolite Petovan <hypolite@friendica.mrpetovan.com>
 */
 
+:root {
+    color-scheme: dark;
+}
+
 a:hover, button:focus, .btn-link:focus, .btn-primary:focus,
 a:hover, button:hover, .btn-link:hover, .btn-primary:hover,
 #topbar-first li a:hover, #topbar-first li button:hover,


### PR DESCRIPTION
Problem:
Without an explicit declaration, browsers rely entirely on the operating system's setting (prefers-color-scheme). This causes visual bugs when a user selects a light theme while their OS is in dark mode (or vice versa), resulting in mismatched native elements like scrollbars and form controls.

Benefit for CSS Developers:
It establishes a reliable, native context for the active schema. CSS developers can leverage standard system keywords (like Canvas) or color-scheme queries to cleanly style and adapt custom components, overlays, or plugins without needing complex JavaScript workarounds or missing body classes.