### PR TITLE
Add explicit color-scheme property to theme schemas (light)

### DIFF
--- a/view/theme/frio/scheme/light.css
+++ b/view/theme/frio/scheme/light.css
@@ -10,6 +10,10 @@
     Author     : Marcus Funch
 */
 
+:root {
+    color-scheme: light;
+}
+
 .mod-home.is-not-singleuser .login-form {
 	background: #fcfcfc;
 }

--- a/view/theme/frio/scheme/light.css
+++ b/view/theme/frio/scheme/light.css
@@ -11,7 +11,7 @@
 */
 
 :root {
-    color-scheme: light;
+	color-scheme: light;
 }
 
 .mod-home.is-not-singleuser .login-form {


### PR DESCRIPTION
Problem:
Without an explicit declaration, browsers rely entirely on the operating system's setting (prefers-color-scheme). This causes visual bugs when a user selects a light theme while their OS is in dark mode (or vice versa), resulting in mismatched native elements like scrollbars and form controls.

Benefit for CSS Developers:
It establishes a reliable, native context for the active schema. CSS developers can leverage standard system keywords (like Canvas) or color-scheme queries to cleanly style and adapt custom components, overlays, or plugins without needing complex JavaScript workarounds or missing body classes.