### PR TITLE
Update ddev config to PHP 8.3, MariaDB 10.11 and Composer 2.2

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -5,7 +5,7 @@
 name: my-friendica
 type: php
 docroot: ""
-php_version: "7.4"
+php_version: "8.3"
 webserver_type: apache-fpm
 router_http_port: "80"
 router_https_port: "443"
@@ -14,14 +14,14 @@ additional_hostnames: []
 additional_fqdns: []
 database:
   type: mariadb
-  version: "10.4"
+  version: "10.11"
 nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true
-composer_version: "1"
+composer_version: "2.2"
 web_environment: []
 nodejs_version: "16"
-webimage_extra_packages: [php7.4-gmp]
+webimage_extra_packages: [php8.3-gmp]
 
 # Key features of ddev's config.yaml:
 


### PR DESCRIPTION
This commit is about bringing the ddev config.yaml up to more recent versions of PHP, Composer and MariaDB, so that it's easier to use ddev for development. 

Alternatively we could remove all files of this nature
```
.ddev
.docker
Vagrantfile
Vagrantfile.license
``` 

But seeing as they're there, it makes sense to keep them up to date and usable.