### PR TITLE
Refactor API link headers for PSR-7 compatibility

### DIFF
--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -38,197 +38,8 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Accounts/Followers.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Accounts/Following.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Accounts/Statuses.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Admin/Reports.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Blocks.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Bookmarks.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Conversations.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Favourited.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/FollowRequests.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/FollowedTags.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Lists/Accounts.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Mutes.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Notifications.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/ScheduledStatuses.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Search.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Statuses/Context.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Timelines/Direct.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Timelines/Home.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Timelines/ListTimeline.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Timelines/PublicTimeline.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Timelines/Tag.php
-
-		-
-			message: '''
 				#^Call to deprecated method setLinkHeaderByOffsetLimit\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+				2026\.08 Use \$this\-\>setPaginationLinkHeaderByOffsetLimit\(\) instead$#
 			'''
 			identifier: staticMethod.deprecated
 			count: 1
@@ -237,7 +48,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method setLinkHeaderByOffsetLimit\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+				2026\.08 Use \$this\-\>setPaginationLinkHeaderByOffsetLimit\(\) instead$#
 			'''
 			identifier: staticMethod.deprecated
 			count: 1
@@ -246,47 +57,11 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method setLinkHeaderByOffsetLimit\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+				2026\.08 Use \$this\-\>setPaginationLinkHeaderByOffsetLimit\(\) instead$#
 			'''
 			identifier: staticMethod.deprecated
 			count: 1
 			path: src/Module/Api/Mastodon/Trends/Tags.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Twitter/Blocks/Ids.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Twitter/Blocks/Lists.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Twitter/DirectMessagesEndpoint.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Twitter/Followers/Ids.php
 
 		-
 			message: '''
@@ -296,15 +71,6 @@ parameters:
 			identifier: staticMethod.deprecated
 			count: 1
 			path: src/Module/Api/Twitter/Followers/Lists.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Twitter/Friends/Ids.php
 
 		-
 			message: '''

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -37,6 +37,294 @@ parameters:
 			path: src/Factory/Api/Mastodon/Emoji.php
 
 		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Accounts/Followers.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Accounts/Following.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Accounts/Statuses.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Admin/Reports.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Blocks.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Bookmarks.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Conversations.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Favourited.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/FollowRequests.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/FollowedTags.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Lists/Accounts.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Mutes.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Notifications.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/ScheduledStatuses.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Search.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Statuses/Context.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Timelines/Direct.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Timelines/Home.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Timelines/ListTimeline.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Timelines/Tag.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeaderByOffsetLimit\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Trends/Links.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeaderByOffsetLimit\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Trends/Statuses.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeaderByOffsetLimit\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Mastodon/Trends/Tags.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Twitter/Blocks/Ids.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Twitter/Blocks/Lists.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Twitter/DirectMessagesEndpoint.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Twitter/Followers/Ids.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>getPaginationLinkHeaderValue\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Twitter/Followers/Lists.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>setPaginationLinkHeader\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Twitter/Friends/Ids.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>getPaginationLinkHeaderValue\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Twitter/Friends/Lists.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
+				2026\.08 Use \$this\-\>getPaginationLinkHeaderValue\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: src/Module/Api/Twitter/Friendships/Incoming.php
+
+		-
 			message: '#^PHPDoc type Friendica\\Module\\Api\\ApiResponse of property Friendica\\Module\\BaseApi\:\:\$response is not the same as PHPDoc type Friendica\\Module\\Response of overridden property Friendica\\BaseModule\:\:\$response\.$#'
 			identifier: property.phpDocType
 			count: 1

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -38,33 +38,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method setLinkHeaderByOffsetLimit\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeaderByOffsetLimit\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Trends/Links.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeaderByOffsetLimit\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeaderByOffsetLimit\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Trends/Statuses.php
-
-		-
-			message: '''
-				#^Call to deprecated method setLinkHeaderByOffsetLimit\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>setPaginationLinkHeaderByOffsetLimit\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Mastodon/Trends/Tags.php
-
-		-
-			message: '''
 				#^Call to deprecated method getLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
 				2026\.08 Use \$this\-\>getPaginationLinkHeaderValue\(\) instead$#
 			'''

--- a/.phpstan-baseline.neon
+++ b/.phpstan-baseline.neon
@@ -37,33 +37,6 @@ parameters:
 			path: src/Factory/Api/Mastodon/Emoji.php
 
 		-
-			message: '''
-				#^Call to deprecated method getLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>getPaginationLinkHeaderValue\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Twitter/Followers/Lists.php
-
-		-
-			message: '''
-				#^Call to deprecated method getLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>getPaginationLinkHeaderValue\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Twitter/Friends/Lists.php
-
-		-
-			message: '''
-				#^Call to deprecated method getLinkHeader\(\) of class Friendica\\Module\\BaseApi\:
-				2026\.08 Use \$this\-\>getPaginationLinkHeaderValue\(\) instead$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: src/Module/Api/Twitter/Friendships/Incoming.php
-
-		-
 			message: '#^PHPDoc type Friendica\\Module\\Api\\ApiResponse of property Friendica\\Module\\BaseApi\:\:\$response is not the same as PHPDoc type Friendica\\Module\\Response of overridden property Friendica\\BaseModule\:\:\$response\.$#'
 			identifier: property.phpDocType
 			count: 1

--- a/doc/en/developer/upgrade-2026.08.md
+++ b/doc/en/developer/upgrade-2026.08.md
@@ -288,3 +288,51 @@ This section contains deprecation notices. This changes will become mandatory in
    ```php
    $this->earlyHttpError(403, 'Forbidden');
    ```
+
+- `BaseApi::getLinkHeader()` is deprecated. Use `BaseApi::getPaginationLinkHeaderValue()` instead:
+
+   *Before*
+   ```php
+   $linkHeader = self::getLinkHeader($asDate);
+   ```
+
+   *After*
+   ```php
+   $linkHeader = $this->getPaginationLinkHeaderValue($asDate);
+   ```
+
+- `BaseApi::getOffsetAndLimitLinkHeader()` is deprecated. Use `BaseApi::getOffsetAndLimitPaginationLinkHeaderValue()` instead:
+
+   *Before*
+   ```php
+   $linkHeader = self::getOffsetAndLimitLinkHeader($offset, $limit);
+   ```
+
+   *After*
+   ```php
+   $linkHeader = $this->getOffsetAndLimitPaginationLinkHeaderValue($offset, $limit);
+   ```
+
+- `BaseApi::setLinkHeader()` is deprecated. Use `BaseApi::setPaginationLinkHeader()` instead:
+
+   *Before*
+   ```php
+   self::setLinkHeader($asDate);
+   ```
+
+   *After*
+   ```php
+   $this->setPaginationLinkHeader($asDate);
+   ```
+
+- `BaseApi::setLinkHeaderByOffsetLimit()` is deprecated. Use `BaseApi::setPaginationLinkHeaderByOffsetLimit()` instead:
+
+   *Before*
+   ```php
+   self::setLinkHeaderByOffsetLimit($offset, $limit);
+   ```
+
+   *After*
+   ```php
+   $this->setPaginationLinkHeaderByOffsetLimit($offset, $limit);
+   ```

--- a/src/Module/Api/Mastodon/Accounts/Followers.php
+++ b/src/Module/Api/Mastodon/Accounts/Followers.php
@@ -103,7 +103,7 @@ class Followers extends BaseApi
 			$accounts = array_reverse($accounts);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Following.php
+++ b/src/Module/Api/Mastodon/Accounts/Following.php
@@ -103,7 +103,7 @@ class Following extends BaseApi
 			$accounts = array_reverse($accounts);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Accounts/Statuses.php
+++ b/src/Module/Api/Mastodon/Accounts/Statuses.php
@@ -112,7 +112,7 @@ class Statuses extends BaseApi
 			$statuses = array_reverse($statuses);
 		}
 
-		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
+		$this->setPaginationLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
 		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Admin/Reports.php
+++ b/src/Module/Api/Mastodon/Admin/Reports.php
@@ -95,7 +95,7 @@ class Reports extends BaseApi
 			$reports[] = $this->mstdnReportFactory->createFromReportEntity($this->reportRepository->selectOneById((int) $row['id']));
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($reports);
 	}
 

--- a/src/Module/Api/Mastodon/Blocks.php
+++ b/src/Module/Api/Mastodon/Blocks.php
@@ -61,7 +61,7 @@ class Blocks extends BaseApi
 			$accounts = array_reverse($accounts);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Bookmarks.php
+++ b/src/Module/Api/Mastodon/Bookmarks.php
@@ -69,7 +69,7 @@ class Bookmarks extends BaseApi
 			$statuses = array_reverse($statuses);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Conversations.php
+++ b/src/Module/Api/Mastodon/Conversations.php
@@ -84,7 +84,7 @@ class Conversations extends BaseApi
 			$conversations = array_reverse($conversations);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($conversations);
 	}
 }

--- a/src/Module/Api/Mastodon/Favourited.php
+++ b/src/Module/Api/Mastodon/Favourited.php
@@ -71,7 +71,7 @@ class Favourited extends BaseApi
 			$statuses = array_reverse($statuses);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/FollowRequests.php
+++ b/src/Module/Api/Mastodon/FollowRequests.php
@@ -99,7 +99,7 @@ class FollowRequests extends BaseApi
 			}
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Api/Mastodon/FollowedTags.php
+++ b/src/Module/Api/Mastodon/FollowedTags.php
@@ -61,7 +61,7 @@ class FollowedTags extends BaseApi
 			$return = array_reverse($return);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Api/Mastodon/Lists/Accounts.php
+++ b/src/Module/Api/Mastodon/Lists/Accounts.php
@@ -111,7 +111,7 @@ class Accounts extends BaseApi
 			$accounts = array_reverse($accounts);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Mutes.php
+++ b/src/Module/Api/Mastodon/Mutes.php
@@ -61,7 +61,7 @@ class Mutes extends BaseApi
 			$accounts = array_reverse($accounts);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($accounts);
 	}
 }

--- a/src/Module/Api/Mastodon/Notifications.php
+++ b/src/Module/Api/Mastodon/Notifications.php
@@ -138,7 +138,7 @@ class Notifications extends BaseApi
 				}
 			}
 
-			self::setLinkHeader();
+			$this->setPaginationLinkHeader();
 			$this->earlyJsonExit($mstdnNotifications);
 		}
 	}

--- a/src/Module/Api/Mastodon/ScheduledStatuses.php
+++ b/src/Module/Api/Mastodon/ScheduledStatuses.php
@@ -93,7 +93,7 @@ class ScheduledStatuses extends BaseApi
 			$statuses = array_reverse($statuses);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Search.php
+++ b/src/Module/Api/Mastodon/Search.php
@@ -217,7 +217,7 @@ class Search extends BaseApi
 			$statuses = array_reverse($statuses);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		return $statuses;
 	}
 

--- a/src/Module/Api/Mastodon/Statuses/Context.php
+++ b/src/Module/Api/Mastodon/Statuses/Context.php
@@ -86,7 +86,7 @@ class Context extends BaseApi
 			}
 			DBA::close($posts);
 
-			self::setLinkHeader();
+			$this->setPaginationLinkHeader();
 		} else {
 			$parent = DBA::selectFirst('mail', ['parent-uri-id'], ['uri-id' => $id, 'uid' => $uid]);
 			if (DBA::isResult($parent)) {

--- a/src/Module/Api/Mastodon/Timelines/Direct.php
+++ b/src/Module/Api/Mastodon/Timelines/Direct.php
@@ -75,7 +75,7 @@ class Direct extends BaseApi
 			$statuses = array_reverse($statuses);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/Home.php
+++ b/src/Module/Api/Mastodon/Timelines/Home.php
@@ -87,7 +87,7 @@ class Home extends BaseApi
 		}
 
 
-		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
+		$this->setPaginationLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
 		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Timelines/ListTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/ListTimeline.php
@@ -90,7 +90,7 @@ class ListTimeline extends BaseApi
 			$statuses = array_reverse($statuses);
 		}
 
-		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
+		$this->setPaginationLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
 		$this->earlyJsonExit($statuses);
 	}
 

--- a/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
+++ b/src/Module/Api/Mastodon/Timelines/PublicTimeline.php
@@ -117,7 +117,7 @@ class PublicTimeline extends BaseApi
 			$statuses = array_reverse($statuses);
 		}
 
-		self::setLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
+		$this->setPaginationLinkHeader($request['friendica_order'] != TimelineOrderByTypes::ID);
 		$this->earlyJsonExit($statuses);
 	}
 

--- a/src/Module/Api/Mastodon/Timelines/Tag.php
+++ b/src/Module/Api/Mastodon/Timelines/Tag.php
@@ -113,7 +113,7 @@ class Tag extends BaseApi
 			$statuses = array_reverse($statuses);
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 		$this->earlyJsonExit($statuses);
 	}
 }

--- a/src/Module/Api/Mastodon/Trends/Links.php
+++ b/src/Module/Api/Mastodon/Trends/Links.php
@@ -46,7 +46,7 @@ class Links extends BaseApi
 		DBA::close($statuses);
 
 		if (!empty($trending)) {
-			self::setLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
+			$this->setPaginationLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
 		}
 
 		$this->earlyJsonExit($trending);

--- a/src/Module/Api/Mastodon/Trends/Statuses.php
+++ b/src/Module/Api/Mastodon/Trends/Statuses.php
@@ -64,7 +64,7 @@ class Statuses extends BaseApi
 		DBA::close($statuses);
 
 		if (!empty($trending)) {
-			self::setLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
+			$this->setPaginationLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
 		}
 
 		$this->earlyJsonExit($trending);

--- a/src/Module/Api/Mastodon/Trends/Tags.php
+++ b/src/Module/Api/Mastodon/Trends/Tags.php
@@ -42,7 +42,7 @@ class Tags extends BaseApi
 		}
 
 		if (!empty($trending)) {
-			self::setLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
+			$this->setPaginationLinkHeaderByOffsetLimit($request['offset'], $request['limit']);
 		}
 
 		$this->earlyJsonExit($trending);

--- a/src/Module/Api/Twitter/Blocks/Ids.php
+++ b/src/Module/Api/Twitter/Blocks/Ids.php
@@ -66,7 +66,7 @@ class Ids extends ContactEndpoint
 
 		$return = self::ids($ids, $total_count, $cursor, $count, $stringify_ids);
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 
 		$this->earlyJsonExit($return);
 	}

--- a/src/Module/Api/Twitter/Blocks/Lists.php
+++ b/src/Module/Api/Twitter/Blocks/Lists.php
@@ -67,7 +67,7 @@ class Lists extends ContactEndpoint
 
 		$return = self::list($ids, $total_count, $uid, $cursor, $count, $skip_status, $include_user_entities);
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 
 		$this->response->addFormattedContent('lists', ['lists' => $return]);
 	}

--- a/src/Module/Api/Twitter/DirectMessagesEndpoint.php
+++ b/src/Module/Api/Twitter/DirectMessagesEndpoint.php
@@ -93,7 +93,7 @@ abstract class DirectMessagesEndpoint extends BaseApi
 			$ret[] = $this->directMessage->createFromMailId($id, $uid, $this->getRequestValue($request, 'getText', ''));
 		}
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 
 		$this->response->addFormattedContent('direct-messages', ['direct_message' => $ret], $this->parameters['extension'] ?? null, Contact::getPublicIdByUserId($uid));
 	}

--- a/src/Module/Api/Twitter/Followers/Ids.php
+++ b/src/Module/Api/Twitter/Followers/Ids.php
@@ -97,7 +97,7 @@ class Ids extends ContactEndpoint
 
 		$return = self::ids($ids, $total_count, $cursor, $count, $stringify_ids);
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 
 		$this->earlyJsonExit($return);
 	}

--- a/src/Module/Api/Twitter/Followers/Lists.php
+++ b/src/Module/Api/Twitter/Followers/Lists.php
@@ -98,7 +98,7 @@ class Lists extends ContactEndpoint
 
 		$return = self::list($ids, $total_count, $uid, $cursor, $count, $skip_status, $include_user_entities);
 
-		$this->response->setHeader(self::getLinkHeader());
+		$this->setPaginationLinkHeader();
 
 		$this->response->addFormattedContent('lists', ['lists' => $return]);
 	}

--- a/src/Module/Api/Twitter/Friends/Ids.php
+++ b/src/Module/Api/Twitter/Friends/Ids.php
@@ -97,7 +97,7 @@ class Ids extends ContactEndpoint
 
 		$return = self::ids($ids, $total_count, $cursor, $count, $stringify_ids);
 
-		self::setLinkHeader();
+		$this->setPaginationLinkHeader();
 
 		$this->earlyJsonExit($return);
 	}

--- a/src/Module/Api/Twitter/Friends/Lists.php
+++ b/src/Module/Api/Twitter/Friends/Lists.php
@@ -98,7 +98,7 @@ class Lists extends ContactEndpoint
 
 		$return = self::list($ids, $total_count, $uid, $cursor, $count, $skip_status, $include_user_entities);
 
-		$this->response->setHeader(self::getLinkHeader());
+		$this->setPaginationLinkHeader();
 
 		$this->response->addFormattedContent('lists', ['lists' => $return]);
 	}

--- a/src/Module/Api/Twitter/Friendships/Incoming.php
+++ b/src/Module/Api/Twitter/Friendships/Incoming.php
@@ -66,7 +66,7 @@ class Incoming extends ContactEndpoint
 
 		$return = self::ids($ids, $total_count, $cursor, $count, $stringify_ids);
 
-		$this->response->setHeader(self::getLinkHeader());
+		$this->setPaginationLinkHeader();
 
 		$this->response->addFormattedContent('incoming', ['incoming' => $return]);
 	}

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -357,7 +357,7 @@ abstract class BaseApi extends BaseModule
 	/**
 	 * Set the "link" header with "next" and "prev" links
 	 *
-	 * @deprecated 2026.08 Use $this->setPaginationLinkHeader() instead
+	 * @deprecated 2026.08 Use $this->setPaginationLinkHeaderByOffsetLimit() instead
 	 * @return void
 	 */
 	protected static function setLinkHeaderByOffsetLimit(int $offset, int $limit)

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -275,11 +275,12 @@ abstract class BaseApi extends BaseModule
 	/**
 	 * Get the "link" header with "next" and "prev" links
 	 *
-	 * @deprecated 2026.08 Use $this->getPaginationLinkHeaderValue() instead
+	 * @deprecated 2026.08 Use {@see self::getPaginationLinkHeaderValue()} instead
 	 * @return string
 	 */
 	protected static function getLinkHeader(bool $asDate = false): string
 	{
+		@trigger_error('Method `' . __METHOD__ . '()` is deprecated since 2026.08 and will be removed after 5 months, use `BaseApi::getPaginationLinkHeaderValue()` instead.', E_USER_DEPRECATED);
 		if (empty(self::$boundaries)) {
 			return '';
 		}
@@ -313,11 +314,12 @@ abstract class BaseApi extends BaseModule
 	/**
 	 * Get the "link" header with "next" and "prev" links for an offset/limit type call
 	 *
-	 * @deprecated 2026.08 Use $this->getOffsetAndLimitPaginationLinkHeaderValue() instead
+	 * @deprecated 2026.08 Use {@see self::getOffsetAndLimitPaginationLinkHeaderValue()} instead
 	 * @return string
 	 */
 	protected static function getOffsetAndLimitLinkHeader(int $offset, int $limit): string
 	{
+		@trigger_error('Method `' . __METHOD__ . '()` is deprecated since 2026.08 and will be removed after 5 months, use `BaseApi::getOffsetAndLimitPaginationLinkHeaderValue()` instead.', E_USER_DEPRECATED);
 		$request = self::$request;
 
 		unset($request['offset']);
@@ -343,11 +345,12 @@ abstract class BaseApi extends BaseModule
 	/**
 	 * Set the "link" header with "next" and "prev" links
 	 *
-	 * @deprecated 2026.08 Use $this->setPaginationLinkHeader() instead
+	 * @deprecated 2026.08 Use {@see self::setPaginationLinkHeader()} instead
 	 * @return void
 	 */
 	protected static function setLinkHeader(bool $asDate = false)
 	{
+		@trigger_error('Method `' . __METHOD__ . '()` is deprecated since 2026.08 and will be removed after 5 months, use `BaseApi::setPaginationLinkHeader()` instead.', E_USER_DEPRECATED);
 		$header = self::getLinkHeader($asDate);
 		if (!empty($header)) {
 			header($header);
@@ -357,11 +360,12 @@ abstract class BaseApi extends BaseModule
 	/**
 	 * Set the "link" header with "next" and "prev" links
 	 *
-	 * @deprecated 2026.08 Use $this->setPaginationLinkHeaderByOffsetLimit() instead
+	 * @deprecated 2026.08 Use {@see self::setPaginationLinkHeaderByOffsetLimit()} instead
 	 * @return void
 	 */
 	protected static function setLinkHeaderByOffsetLimit(int $offset, int $limit)
 	{
+		@trigger_error('Method `' . __METHOD__ . '()` is deprecated since 2026.08 and will be removed after 5 months, use `BaseApi::setPaginationLinkHeaderByOffsetLimit()` instead.', E_USER_DEPRECATED);
 		$header = self::getOffsetAndLimitLinkHeader($offset, $limit);
 		if (!empty($header)) {
 			header($header);

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -274,6 +274,8 @@ abstract class BaseApi extends BaseModule
 
 	/**
 	 * Get the "link" header with "next" and "prev" links
+	 *
+	 * @deprecated 2026.08 Use $this->getPaginationLinkHeaderValue() instead
 	 * @return string
 	 */
 	protected static function getLinkHeader(bool $asDate = false): string
@@ -310,6 +312,8 @@ abstract class BaseApi extends BaseModule
 
 	/**
 	 * Get the "link" header with "next" and "prev" links for an offset/limit type call
+	 *
+	 * @deprecated 2026.08 Use $this->getOffsetAndLimitPaginationLinkHeaderValue() instead
 	 * @return string
 	 */
 	protected static function getOffsetAndLimitLinkHeader(int $offset, int $limit): string
@@ -338,6 +342,8 @@ abstract class BaseApi extends BaseModule
 
 	/**
 	 * Set the "link" header with "next" and "prev" links
+	 *
+	 * @deprecated 2026.08 Use $this->setPaginationLinkHeader() instead
 	 * @return void
 	 */
 	protected static function setLinkHeader(bool $asDate = false)
@@ -350,6 +356,8 @@ abstract class BaseApi extends BaseModule
 
 	/**
 	 * Set the "link" header with "next" and "prev" links
+	 *
+	 * @deprecated 2026.08 Use $this->setPaginationLinkHeader() instead
 	 * @return void
 	 */
 	protected static function setLinkHeaderByOffsetLimit(int $offset, int $limit)

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -375,7 +375,6 @@ abstract class BaseApi extends BaseModule
 	/**
 	 * Get the pagination "link" header value with "next" and "prev" links
 	 *
-	 * @internal
 	 * @return string
 	 */
 	protected function getPaginationLinkHeaderValue(bool $asDate = false): string
@@ -413,7 +412,6 @@ abstract class BaseApi extends BaseModule
 	/**
 	 * Get the pagination "link" header value with "next" and "prev" links for an offset/limit type call
 	 *
-	 * @internal
 	 * @return string
 	 */
 	protected function getOffsetAndLimitPaginationLinkHeaderValue(int $offset, int $limit): string
@@ -443,7 +441,6 @@ abstract class BaseApi extends BaseModule
 	/**
 	 * Set the pagination "link" header with "next" and "prev" links
 	 *
-	 * @internal
 	 * @return void
 	 */
 	protected function setPaginationLinkHeader(bool $asDate = false): void
@@ -457,7 +454,6 @@ abstract class BaseApi extends BaseModule
 	/**
 	 * Set the pagination "link" header with "next" and "prev" links for an offset/limit type call
 	 *
-	 * @internal
 	 * @return void
 	 */
 	protected function setPaginationLinkHeaderByOffsetLimit(int $offset, int $limit): void

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -33,7 +33,7 @@ use Friendica\Util\Profiler;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
-class BaseApi extends BaseModule
+abstract class BaseApi extends BaseModule
 {
 	public const LOG_PREFIX = 'API {action} - ';
 

--- a/src/Module/BaseApi.php
+++ b/src/Module/BaseApi.php
@@ -361,6 +361,102 @@ abstract class BaseApi extends BaseModule
 	}
 
 	/**
+	 * Get the pagination "link" header value with "next" and "prev" links
+	 *
+	 * @internal
+	 * @return string
+	 */
+	protected function getPaginationLinkHeaderValue(bool $asDate = false): string
+	{
+		if (empty(self::$boundaries)) {
+			return '';
+		}
+
+		$request = self::$request;
+
+		unset($request['min_id']);
+		unset($request['max_id']);
+		unset($request['since_id']);
+
+		$prev_request = $next_request = $request;
+
+		if ($asDate) {
+			$max_date               = self::$boundaries['max'];
+			$min_date               = self::$boundaries['min'];
+			$prev_request['min_id'] = $max_date->format(DateTimeFormat::JSON);
+			$next_request['max_id'] = $min_date->format(DateTimeFormat::JSON);
+		} else {
+			$prev_request['min_id'] = self::$boundaries['max'];
+			$next_request['max_id'] = self::$boundaries['min'];
+		}
+
+		$command = (string) $this->baseUrl . '/' . $this->args->getCommand();
+
+		$prev = $command . '?' . http_build_query($prev_request);
+		$next = $command . '?' . http_build_query($next_request);
+
+		return '<' . $next . '>; rel="next", <' . $prev . '>; rel="prev"';
+	}
+
+	/**
+	 * Get the pagination "link" header value with "next" and "prev" links for an offset/limit type call
+	 *
+	 * @internal
+	 * @return string
+	 */
+	protected function getOffsetAndLimitPaginationLinkHeaderValue(int $offset, int $limit): string
+	{
+		$request = self::$request;
+
+		unset($request['offset']);
+		$request['limit'] = $limit;
+
+		$prev_request = $next_request = $request;
+
+		$prev_request['offset'] = $offset - $limit;
+		$next_request['offset'] = $offset + $limit;
+
+		$command = (string) $this->baseUrl . '/' . $this->args->getCommand();
+
+		$prev = $command . '?' . http_build_query($prev_request);
+		$next = $command . '?' . http_build_query($next_request);
+
+		if ($prev_request['offset'] >= 0) {
+			return '<' . $next . '>; rel="next", <' . $prev . '>; rel="prev"';
+		} else {
+			return '<' . $next . '>; rel="next"';
+		}
+	}
+
+	/**
+	 * Set the pagination "link" header with "next" and "prev" links
+	 *
+	 * @internal
+	 * @return void
+	 */
+	protected function setPaginationLinkHeader(bool $asDate = false): void
+	{
+		$header = $this->getPaginationLinkHeaderValue($asDate);
+		if (!empty($header)) {
+			$this->response->setHeader($header, 'Link');
+		}
+	}
+
+	/**
+	 * Set the pagination "link" header with "next" and "prev" links for an offset/limit type call
+	 *
+	 * @internal
+	 * @return void
+	 */
+	protected function setPaginationLinkHeaderByOffsetLimit(int $offset, int $limit): void
+	{
+		$header = $this->getOffsetAndLimitPaginationLinkHeaderValue($offset, $limit);
+		if (!empty($header)) {
+			$this->response->setHeader($header, 'Link');
+		}
+	}
+
+	/**
 	 * Get current application token
 	 *
 	 * @return array token

--- a/tests/Unit/Module/BaseApiTest.php
+++ b/tests/Unit/Module/BaseApiTest.php
@@ -1,0 +1,192 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Unit\Module;
+
+use Friendica\App;
+use Friendica\AppHelper;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\L10n;
+use Friendica\Factory\Api\Mastodon\Error;
+use Friendica\Factory\Api\Twitter\User as TwitterUser;
+use Friendica\Module\Api\ApiResponse;
+use Friendica\Module\BaseApi;
+use Friendica\Util\Profiler;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class BaseApiTest extends TestCase
+{
+	private const BASE_URL = 'http://example.com';
+	private const COMMAND  = 'api/v1/timelines/home';
+
+	#[DataProvider('createModuleAndResponseProvider')]
+	public function testSetPaginationLinkHeaderWithBoundariesSetsLinkHeader(ApiResponse $response, BaseApi $module): void
+	{
+		$module->getRequest([], ['limit' => 20]);
+		$module::setBoundaries(100); // @phpstan-ignore staticMethod.protected
+		$module::setBoundaries(200); // @phpstan-ignore staticMethod.protected
+		$module->setPaginationLinkHeader(); // @phpstan-ignore method.protected
+
+		$headers = $response->getHeaders();
+		self::assertArrayHasKey('Link', $headers);
+
+		$expectedLink = '<' . self::BASE_URL . '/' . self::COMMAND . '?limit=20&max_id=100>; rel="next", <'
+			. self::BASE_URL . '/' . self::COMMAND . '?limit=20&min_id=200>; rel="prev"';
+
+		self::assertSame($expectedLink, $headers['Link']);
+
+		$psr7Response = $response->generate();
+		self::assertSame($expectedLink, $psr7Response->getHeaderLine('Link'));
+	}
+
+	#[DataProvider('createModuleAndResponseProvider')]
+	public function testSetPaginationLinkHeaderWithoutBoundariesSetsNoLinkHeader(ApiResponse $response, BaseApi $module): void
+	{
+		$module->getRequest([], ['limit' => 20]);
+		$module->setPaginationLinkHeader(); // @phpstan-ignore method.protected
+
+		$headers = $response->getHeaders();
+		self::assertArrayNotHasKey('Link', $headers);
+	}
+
+	#[DataProvider('createModuleAndResponseProvider')]
+	public function testSetPaginationLinkHeaderAsDateSetsIso8601Format(ApiResponse $response, BaseApi $module): void
+	{
+		$minDate = new \DateTime('2026-01-01T00:00:00.000Z');
+		$maxDate = new \DateTime('2026-12-31T23:59:59.999Z');
+
+		$module->getRequest([], ['limit' => 20]);
+		$module::setBoundaries($minDate); // @phpstan-ignore staticMethod.protected
+		$module::setBoundaries($maxDate); // @phpstan-ignore staticMethod.protected
+		$module->setPaginationLinkHeader(true); // @phpstan-ignore method.protected
+
+		$headers = $response->getHeaders();
+		self::assertArrayHasKey('Link', $headers);
+
+		$expectedLink = '<' . self::BASE_URL . '/' . self::COMMAND . '?limit=20&max_id=' . rawurlencode('2026-01-01T00:00:00.000Z') . '>; rel="next", <'
+			. self::BASE_URL . '/' . self::COMMAND . '?limit=20&min_id=' . rawurlencode('2026-12-31T23:59:59.999Z') . '>; rel="prev"';
+
+		self::assertSame($expectedLink, $headers['Link']);
+	}
+
+	#[DataProvider('createModuleAndResponseProvider')]
+	public function testSetPaginationLinkHeaderByOffsetLimitSetsPrevAndNext(ApiResponse $response, BaseApi $module): void
+	{
+		$offset = 20;
+		$limit  = 20;
+
+		$module->getRequest([], []);
+		$module->setPaginationLinkHeaderByOffsetLimit($offset, $limit); // @phpstan-ignore method.protected
+
+		$headers = $response->getHeaders();
+		self::assertArrayHasKey('Link', $headers);
+
+		$prevOffset = $offset - $limit;
+		$nextOffset = $offset + $limit;
+
+		$expectedLink = '<' . self::BASE_URL . '/' . self::COMMAND . '?limit=' . $limit . '&offset=' . $nextOffset . '>; rel="next", <'
+			. self::BASE_URL . '/' . self::COMMAND . '?limit=' . $limit . '&offset=' . $prevOffset . '>; rel="prev"';
+
+		self::assertSame($expectedLink, $headers['Link']);
+	}
+
+	#[DataProvider('createModuleAndResponseProvider')]
+	public function testSetPaginationLinkHeaderByOffsetLimitWithoutPrevSetsOnlyNext(ApiResponse $response, BaseApi $module): void
+	{
+		$offset = 5;
+		$limit  = 20;
+
+		$module->getRequest([], []);
+		$module->setPaginationLinkHeaderByOffsetLimit($offset, $limit); // @phpstan-ignore method.protected
+
+		$headers = $response->getHeaders();
+		self::assertArrayHasKey('Link', $headers);
+
+		$nextOffset = $offset + $limit;
+
+		$expectedLink = '<' . self::BASE_URL . '/' . self::COMMAND . '?limit=' . $limit . '&offset=' . $nextOffset . '>; rel="next"';
+
+		self::assertSame($expectedLink, $headers['Link']);
+	}
+
+	public static function createModuleAndResponseProvider(): array
+	{
+		$baseUrl = new App\BaseURL(self::createConfigStub(), self::createStub(LoggerInterface::class));
+		$args    = new App\Arguments('', self::COMMAND);
+
+		$response = new ApiResponse(
+			self::createStub(L10n::class),
+			$args,
+			self::createStub(LoggerInterface::class),
+			$baseUrl,
+			self::createStub(TwitterUser::class),
+		);
+
+		$module = new class (
+			self::createStub(Error::class),
+			self::createStub(AppHelper::class),
+			self::createStub(L10n::class),
+			$baseUrl,
+			$args,
+			self::createStub(LoggerInterface::class),
+			self::createStub(Profiler::class),
+			$response,
+		) extends BaseApi {
+			public function __construct(
+				Error $errorFactory,
+				AppHelper $appHelper,
+				L10n $l10n,
+				App\BaseURL $baseUrl,
+				App\Arguments $args,
+				LoggerInterface $logger,
+				Profiler $profiler,
+				ApiResponse $response,
+			) {
+				$this->errorFactory = $errorFactory;
+				$this->appHelper    = $appHelper;
+				$this->l10n         = $l10n;
+				$this->baseUrl      = $baseUrl;
+				$this->args         = $args;
+				$this->logger       = $logger;
+				$this->profiler     = $profiler;
+				$this->response     = $response;
+				$this->server       = [];
+			}
+
+			public function setPaginationLinkHeader(bool $asDate = false): void
+			{
+				parent::setPaginationLinkHeader($asDate);
+			}
+
+			public function setPaginationLinkHeaderByOffsetLimit(int $offset, int $limit): void
+			{
+				parent::setPaginationLinkHeaderByOffsetLimit($offset, $limit);
+			}
+
+			public static function setBoundaries($id): void
+			{
+				parent::setBoundaries($id);
+			}
+		};
+
+		return ['default' => [$response, $module]];
+	}
+
+	private static function createConfigStub(): IManageConfigValues
+	{
+		$config = self::createStub(IManageConfigValues::class);
+		$config->method('get')->willReturnMap([
+			['system', 'url', null, self::BASE_URL],
+		]);
+
+		return $config;
+	}
+}


### PR DESCRIPTION
Follow-up to #16029: replaces PHP `header()` calls in API modules with PSR-7 response handling via `$this->response->setHeader()`.

## Why

Module responses should be built via `$this->response` for PSR-7 compatibility and testability, see #16027. The static `header()` calls break the response pipeline and cause "headers already sent" warnings in tests. The new internal methods route through `Response::setHeader()`, making the `Link` header assertable via `getHeaderLine('Link')`.

## Summary

- Make `BaseApi` abstract to align with `BaseModule`, no BC break
- Add internal instance methods (`setPaginationLinkHeader()`, `setPaginationLinkHeaderByOffsetLimit()`) and value builders, using `$this->response->setHeader()` instead of PHP `header()`
- Migrate all internal callers to the new instance methods
- Hard-deprecate old static methods with `E_USER_DEPRECATED` and migration hints
- Add unit tests for the new pagination methods