### PR TITLE
Add Hide Comments in Feeds Option

### DIFF
--- a/src/Content/Conversation/ConversationRenderer.php
+++ b/src/Content/Conversation/ConversationRenderer.php
@@ -185,7 +185,7 @@ final readonly class ConversationRenderer
 
 		$hide_comments = $uid && $this->pConfig->get($uid, 'system', 'hide_comments', false);
 
-		$html = $this->renderThreadedTemplate([$root], $mode, $update, $page_dropping);
+		$html = $this->renderThreadedTemplate([$root], $mode, $update, $page_dropping, $hide_comments);
 		$this->profiler->stopRecording();
 		return $live_update_div . $html;
 	}
@@ -355,7 +355,7 @@ final readonly class ConversationRenderer
 
 		$hide_comments = $uid && $this->pConfig->get($uid, 'system', 'hide_comments', false);
 
-		return $this->renderThreadedTemplate($roots, $mode, $update, $page_dropping);
+		return $this->renderThreadedTemplate($roots, $mode, $update, $page_dropping, $hide_comments);
 	}
 
 	/**
@@ -365,7 +365,7 @@ final readonly class ConversationRenderer
 	 * @param string $mode The rendering mode (e.g., self::MODE_DISPLAY)
 	 * @return string The rendered HTML of the conversation
 	 */
-	private function renderThreadedTemplate(array $threads, string $mode, bool $update, bool $pagedrop): string
+	private function renderThreadedTemplate(array $threads, string $mode, bool $update, bool $pagedrop, bool $hide_comments): string
 	{
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('threaded_conversation.tpl'), [
 			'$live_update'   => '',

--- a/src/Content/Conversation/ConversationRenderer.php
+++ b/src/Content/Conversation/ConversationRenderer.php
@@ -183,6 +183,8 @@ final readonly class ConversationRenderer
 			return '';
 		}
 
+		$hide_comments = $uid && $this->pConfig->get($uid, 'system', 'hide_comments', false);
+
 		$html = $this->renderThreadedTemplate([$root], $mode, $update, $page_dropping);
 		$this->profiler->stopRecording();
 		return $live_update_div . $html;
@@ -351,6 +353,8 @@ final readonly class ConversationRenderer
 			return '';
 		}
 
+		$hide_comments = $uid && $this->pConfig->get($uid, 'system', 'hide_comments', false);
+
 		return $this->renderThreadedTemplate($roots, $mode, $update, $page_dropping);
 	}
 
@@ -364,11 +368,13 @@ final readonly class ConversationRenderer
 	private function renderThreadedTemplate(array $threads, string $mode, bool $update, bool $pagedrop): string
 	{
 		return Renderer::replaceMacros(Renderer::getMarkupTemplate('threaded_conversation.tpl'), [
-			'$live_update' => '',
-			'$mode'        => $mode,
-			'$update'      => $update,
-			'$threads'     => $threads,
-			'$dropping'    => ($pagedrop ? $this->l10n->t('Delete Selected Items') : false),
+			'$live_update'   => '',
+			'$mode'          => $mode,
+			'$update'        => $update,
+			'$threads'       => $threads,
+			'$dropping'      => ($pagedrop ? $this->l10n->t('Delete Selected Items') : false),
+			'$hide_comments' => $hide_comments,
+			'$back_link'     => $this->l10n->t('Go Back'),
 		]);
 	}
 

--- a/src/Module/Settings/Display.php
+++ b/src/Module/Settings/Display.php
@@ -113,6 +113,7 @@ class Display extends BaseSettings
 		$display_resharer        = (bool) $request['display_resharer'];
 		$stay_local              = (bool) $request['stay_local'];
 		$compact_timeline        = (bool) $request['compact_timeline'];
+		$hide_comments           = (bool) $request['hide_comments'];
 		$hide_empty_descriptions = (bool) $request['hide_empty_descriptions'];
 		$hide_custom_emojis      = (bool) $request['hide_custom_emojis'];
 		$platform_icon_style     = (int) $request['platform_icon_style'];
@@ -169,6 +170,7 @@ class Display extends BaseSettings
 		$this->pConfig->set($uid, 'system', 'display_resharer', $display_resharer);
 		$this->pConfig->set($uid, 'system', 'stay_local', $stay_local);
 		$this->pConfig->set($uid, 'system', 'compact_timeline', $compact_timeline);
+		$this->pConfig->set($uid, 'system', 'hide_comments', $hide_comments);
 		$this->pConfig->set($uid, 'system', 'show_page_drop', $show_page_drop);
 		$this->pConfig->set($uid, 'system', 'display_eventlist', $display_eventlist);
 		$this->pConfig->set($uid, 'system', 'preview_mode', $preview_mode);
@@ -283,6 +285,7 @@ class Display extends BaseSettings
 		$display_resharer       = $this->pConfig->get($uid, 'system', 'display_resharer', false);
 		$stay_local             = $this->pConfig->get($uid, 'system', 'stay_local', true);
 		$compact_timeline       = $this->pConfig->get($uid, 'system', 'compact_timeline', false);
+		$hide_comments          = $this->pConfig->get($uid, 'system', 'hide_comments', false);
 		$show_page_drop         = $this->pConfig->get($uid, 'system', 'show_page_drop', true);
 		$display_eventlist      = $this->pConfig->get($uid, 'system', 'display_eventlist', true);
 		$embed_remote_media     = $this->pConfig->get($uid, 'system', 'embed_remote_media', false);
@@ -474,6 +477,7 @@ class Display extends BaseSettings
 			'$display_resharer'         => ['display_resharer', $this->t('Display the resharer'), $display_resharer, $this->t('Display the first resharer as icon and text on a reshared item.')],
 			'$stay_local'               => ['stay_local', $this->t('Stay local'), $stay_local, $this->t("Don't go to a remote system when following a contact link.")],
 			'$compact_timeline'         => ['compact_timeline', $this->t('Compact conversation view'), $compact_timeline, $this->t('Show only comments from the thread author and yourself that form coherent conversation threads. Hides replies to filtered-out comments.')],
+			'$hide_comments'            => ['hide_comments', $this->t('Hide Comments in Feeds'), $hide_comments, $this->t('Hides comments in feeds and makes post body clickable to open posts in a new page with any comments.')],
 			'$show_page_drop'           => ['show_page_drop', $this->t('Show the post deletion checkbox'), $show_page_drop, $this->t("Display the checkbox for the post deletion on the network page.")],
 			'$display_eventlist'        => ['display_eventlist', $this->t('Display the event list'), $display_eventlist, $this->t("Display the birthday reminder and event list on the network page.")],
 			'$preview_mode'             => ['preview_mode', $this->t('Link preview mode'), $preview_mode, $this->t('Appearance of the link preview that is added to each post with a link.'), $preview_modes, false],

--- a/view/global.css
+++ b/view/global.css
@@ -930,13 +930,20 @@ a:has(img.has-alt-description)::after {
 	.hide-feed-comments on the .tread-wrapper so whole post can be
 	styled differently if desired.
 */
-a.click-body {
+a.click-body,
+.hide-feed-comments .shared-wrapper a.plink {
 	position: absolute;
 	top: 0;
 	left: 0;
 	right: 0;
 	bottom: 0;
 }
+	.hide-feed-comments .shared-wrapper a.plink img {
+		position: absolute;
+		top: 10px;
+		right: 10px;
+	}
+.hide-feed-comments .shared-wrapper,
 .hide-feed-comments .type-link,
 .hide-feed-comments .type-video,
 .hide-feed-comments .image-allocated-width,

--- a/view/global.css
+++ b/view/global.css
@@ -921,3 +921,50 @@ a:has(img.has-alt-description)::after {
 .edit-profile-link-wrapper {
 	text-align: center;
 }
+/* 	HIDE FEED COMMENTS
+	When the "Hide Comments" option is ticked in the Display options
+	the post body needs to become a clickable link to the post display
+	page, but any images, videos, or links need to still be clickable
+	too. The a.click-body element should never exist if comments are
+	not being hidden. There is already a .hide-comments so this uses
+	.hide-feed-comments on the .tread-wrapper so whole post can be
+	styled differently if desired.
+*/
+a.click-body {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+}
+.hide-feed-comments .type-link,
+.hide-feed-comments .type-video,
+.hide-feed-comments .image-allocated-width,
+.hide-feed-comments .body-attach,
+.hide-feed-comments .imagegrid {
+	position: relative;
+	z-index: 1;
+}
+.hide-feed-comments .comment-fake-form,
+.hide-feed-comments .comment-edit-text-empty {
+	display: none !important;
+}
+.hide-feed-comments .plink-btn {
+	display: none;
+}
+/* not compatible with Compact Conversation View */
+.hide-feed-comments [id^="load-more-comments"] {
+	display: none !important;
+}
+	/* PHP and templates should handle this but here is a CSS fallback */
+	body.mod-display a.click-body {
+		display: none;
+	}
+	body.mod-display .comment-container {
+		display: block;
+	}
+	/* offer user a way to go back, especially if in PWA mode */
+	a.back-link {
+		font-size: 18px;
+	}
+/* end Hide Comments block */

--- a/view/templates/settings/display.tpl
+++ b/view/templates/settings/display.tpl
@@ -27,6 +27,7 @@
 	{{include file="field_checkbox.tpl" field=$display_resharer}}
 	{{include file="field_checkbox.tpl" field=$stay_local}}
 	{{include file="field_checkbox.tpl" field=$compact_timeline}}
+	{{include file="field_checkbox.tpl" field=$hide_comments}}
 	{{include file="field_checkbox.tpl" field=$show_page_drop}}
 	{{include file="field_checkbox.tpl" field=$display_eventlist}}
 	{{include file="field_select.tpl" field=$preview_mode}}

--- a/view/templates/threaded_conversation.tpl
+++ b/view/templates/threaded_conversation.tpl
@@ -7,7 +7,7 @@
 {{$live_update nofilter}}
 {{foreach $threads as $thread}}
 <hr class="sr-only" />
-<div id="tread-wrapper-{{$thread.uriid}}" class="tread-wrapper {{if $thread.threaded}}threaded{{/if}}  {{$thread.toplevel}} {{if $thread.toplevel}}h-entry{{/if}} {{$thread.network}}">
+<div id="tread-wrapper-{{$thread.uriid}}" class="tread-wrapper {{if $thread.threaded}}threaded{{/if}}  {{$thread.toplevel}} {{if $thread.toplevel}}h-entry{{/if}} {{$thread.network}} {{if $hide_comments && $mode != display}}hide-feed-comments{{/if}}">
        
        
 		{{if $thread.type == tag}}

--- a/view/templates/threaded_conversation.tpl
+++ b/view/templates/threaded_conversation.tpl
@@ -4,6 +4,9 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
+{{if $mode == display}}
+<p><a href="#" class="back-link" title="{{$back_link}}"><i class="ri ri-arrow-left-long-line"></i> {{$back_link}}</a></p>
+{{/if}}
 {{$live_update nofilter}}
 {{foreach $threads as $thread}}
 <hr class="sr-only" />
@@ -39,7 +42,27 @@
 <script>
     var id = window.location.pathname.split("/").pop();
     $(window).scrollTop($('#item-'+id).position().top);
-    $('#item-'+id).animate(colWhite, 1000).animate(colShiny).animate(colWhite, 2000);   
+    $('#item-'+id).animate(colWhite, 1000).animate(colShiny).animate(colWhite, 2000);
+	$(function(){
+		// plinks to source are rel="noreferer noopener" in new tab
+		if (!window.opener && !document.referrer){
+			$('a.back-link').hide();
+		}
+	});
+    $('a.back-link').on('click',function(e){
+    	e.preventDefault();
+    		if (window.history.length === 1){
+    			if (document.referrer){
+    				window.location = document.referrer;
+    			} else if (window.opener) {
+    				window.location = window.opener;
+    			} else {
+    				// no idea where to go
+    			}
+    		} else {
+    			window.history.back();
+    		}
+    });
 </script>
 {{/if}}
 {{/if}}

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -4,6 +4,28 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
+{{* This is a little bit hacky. This is needed to have some sort comments container.
+It would be better if it would be done in friendica core but since core lacks this functionality
+it is done in the theme
+
+In short: the piece of code counts the total number of children of the toplevelpost
+- this are usually all posts with thread_level = 2 - and stores it in variable $top_children_total.
+The first time a children which hits thread_level = 2 and $top_child = 1 opens the div.
+
+Everytime when a children with top_level = 2 comes up $top_child_nr rises with 1.
+The div get's closed if thread_level = 2 and the value of $top_child_nr is the same
+as the value of $top_child_total (this is done at the end of this file)
+*}}
+{{if $item.thread_level==1}}
+	{{assign var="top_child_total" value=count($item.children)}}
+	{{assign var="top_child_nr" value=0}}
+{{/if}}
+{{if $item.thread_level==2}}
+	{{assign var="top_child_nr" value=$top_child_nr+1 scope=parent}}
+{{/if}}
+{{if $item.thread_level==2 && $top_child_nr==1}}
+<div class="comment-container {{if !$item.not_smart_threaded}} smart-threaded{{/if}}"> <!--top-child-begin-->
+{{/if}}
 {{if $mode == display}}
 {{else}}
 {{if $item.comment_firstcollapsed}}
@@ -83,6 +105,7 @@
 						</div>
 
 						<div itemprop="description" class="wall-item-content">
+							{{if $item.plink && $hide_comments && $mode != display}}<a href="{{$item.plink.href}}" class="click-body"></a>{{/if}}
                             {{if $item.title}}<h2 dir="auto"><a href="{{$item.plink.href}}" class="{{$item.sparkle}} p-name" dir="auto">{{$item.title}}</a></h2>{{/if}}
 							{{if $item.summary}}<summary class="wall-item-summary" id="wall-item-summary-{{$item.id}}">{{$item.summary}}</summary>{{/if}}
 							<div class="wall-item-body e-content {{if !$item.title}}p-name{{/if}}" dir="auto">{{$item.body_html nofilter}}</div>
@@ -229,13 +252,17 @@
 				</div>
                 {{/if}}
 
-                {{foreach $item.children as $child}}
-                    {{if $item.type == tag}}
-                        {{include file="wall_item_tag.tpl" item=$child}}
-                    {{else}}
-                        {{include file="{{$item.template}}" item=$child}}
-                    {{/if}}
-                {{/foreach}}
+				{{if $mode != display && $hide_comments}}
+					{{* do not even create comments *}}
+				{{else}}
+                	{{foreach $item.children as $child}}
+                    	{{if $item.type == tag}}
+                        	{{include file="wall_item_tag.tpl" item=$child}}
+                    	{{else}}
+                        	{{include file="{{$item.template}}" item=$child}}
+                    	{{/if}}
+                	{{/foreach}}
+				{{/if}}
 
                 {{if $item.thread_level!=1}}</div>{{/if}}
 
@@ -262,3 +289,7 @@
 				<div class="wall-item-comment-wrapper" id="item-comments-{{$item.id}}" style="display: none;">{{$item.comment_html nofilter}}</div>
             {{/if}}
         {{/if}}
+{{* close the comment-container div if no more thread_level = 2 children are left *}}
+{{if $item.thread_level==2 && $top_child_nr==$top_child_total}}
+</div><!--./comment-container-->
+{{/if}}

--- a/view/theme/frio/templates/settings/display.tpl
+++ b/view/theme/frio/templates/settings/display.tpl
@@ -64,6 +64,7 @@
 						{{include file="field_checkbox.tpl" field=$display_resharer}}
 						{{include file="field_checkbox.tpl" field=$stay_local}}
 						{{include file="field_checkbox.tpl" field=$compact_timeline}}
+						{{include file="field_checkbox.tpl" field=$hide_comments}}
 						{{include file="field_checkbox.tpl" field=$show_page_drop}}
 						{{include file="field_checkbox.tpl" field=$display_eventlist}}
 						{{include file="field_select.tpl" field=$preview_mode}}

--- a/view/theme/frio/templates/threaded_conversation.tpl
+++ b/view/theme/frio/templates/threaded_conversation.tpl
@@ -4,6 +4,9 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
+{{if $mode == display}}
+<p><a href="#" class="back-link" title="{{$back_link}}"><i class="ri ri-arrow-left-long-line"></i> {{$back_link}}</a></p>
+{{/if}}
 {{if !$update}}<script type="text/javascript" src="view/theme/frio/frameworks/jquery-color/jquery.color.js?v={{$VERSION}}"></script>{{/if}}
 {{if $mode == display}}
 <script type="text/javascript">
@@ -47,4 +50,28 @@ window.addEventListener('spa:navigate', (e) => {
       <span>{{$dropping}}</span>
     </button>
   {{/if}}
+{{/if}}
+{{if $mode == display}}
+<script>
+	$(function(){
+		// plinks to source are rel="noreferer noopener" in new tab
+		if (!window.opener && !document.referrer){
+			$('a.back-link').hide();
+		}
+	});
+    $('a.back-link').on('click',function(e){
+    	e.preventDefault();
+    		if (window.history.length === 1){
+    			if (document.referrer){
+    				window.location = document.referrer;
+    			} else if (window.opener) {
+    				window.location = window.opener;
+    			} else {
+    				// no idea where to go
+    			}
+    		} else {
+    			window.history.back();
+    		}
+    });    
+</script>
 {{/if}}

--- a/view/theme/frio/templates/threaded_conversation.tpl
+++ b/view/theme/frio/templates/threaded_conversation.tpl
@@ -28,7 +28,7 @@ window.addEventListener('spa:navigate', (e) => {
 {{/if}}
 {{$live_update nofilter}}
 {{foreach $threads as $thread}}
-<div id="tread-wrapper-{{$thread.uriid}}" class="tread-wrapper {{if $thread.threaded}}threaded{{/if}} {{$thread.toplevel}} {{$thread.network}} {{if $thread.thread_level==1}}panel-default panel{{/if}} {{if $thread.thread_level!=1}}comment-wrapper{{/if}}" style="{{if $item.thread_level>2}}margin-left: -15px; margin-right:-16px; margin-bottom:-16px;{{/if}}"><!-- panel -->
+<div id="tread-wrapper-{{$thread.uriid}}" class="tread-wrapper {{if $thread.threaded}}threaded{{/if}} {{$thread.toplevel}} {{$thread.network}} {{if $thread.thread_level==1}}panel-default panel{{/if}} {{if $thread.thread_level!=1}}comment-wrapper{{/if}} {{if $hide_comments && $mode != display}}hide-feed-comments{{/if}}" style="{{if $item.thread_level>2}}margin-left: -15px; margin-right:-16px; margin-bottom:-16px;{{/if}}"><!-- panel -->
 
 		{{* {{if $thread.type == tag}}
 			{{include file="wall_item_tag.tpl" item=$thread}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -26,7 +26,7 @@ as the value of $top_child_total (this is done at the end of this file)
 {{/if}}
 
 {{if $item.thread_level==2 && $top_child_nr==1}}
-<div class="comment-container"> <!--top-child-begin-->
+<div class="comment-container{{if !$not_smart_threaded}} smart-threaded{{/if}}"> <!--top-child-begin-->
 {{/if}}
 {{* end of hacky part to count children *}}
 
@@ -270,6 +270,7 @@ as the value of $top_child_total (this is done at the end of this file)
 
 		{{* item content *}}
 		<div class="wall-item-content {{$item.type}}" id="wall-item-content-{{$item.id}}" lang="{{$item.lang}}">
+			{{if $item.plink && $hide_comments && $mode != display}}<a href="{{$item.plink.href}}" class="click-body"></a>{{/if}}
 			{{if $item.title}}
 			<span class="wall-item-title" id="wall-item-title-{{$item.id}}"><h3 class="media-heading" dir="auto"><a href="{{$item.plink.href}}" class="{{$item.sparkle}} p-name" target="_blank">{{$item.title}}</a></h3><br /></span>
 			{{/if}}
@@ -777,11 +778,13 @@ as the value of $top_child_total (this is done at the end of this file)
 		<span id="load-more-loading-{{$item.id}}" class="loading-text" style="display: none;">{{$item.loading}} <img class="like-rotator" src="images/rotator.gif" alt="{{$item.loading}}" /></span>
 	</div>
 	{{/if}}
-
-	{{foreach $item.children as $child}}
-		{{include file="{{$item.template}}" item=$child}}
-	{{/foreach}}
-
+	{{if $mode != display && $hide_comments}}
+		{{* do not even create comments *}}
+	{{else}}
+		{{foreach $item.children as $child}}
+			{{include file="{{$item.template}}" item=$child}}
+		{{/foreach}}
+	{{/if}}
 	{{* Insert the comment box of the top level post at the bottom of the thread.
 		Display this comment box if there are any comments. If not hide it. In this
 		case it could be opend with the "comment" button *}}


### PR DESCRIPTION
This adds a user option to the Display settings to "Hide Comments in Feeds" for a more compact presentation. It also makes the post body into a clickable link to open it by itself where it will show all of the comments. This is how the web UI of both Mastodon and Bluesky work so this will be a UX with which many users are already familiar.

In feeds you can still click an attached link with a thumbnail, play embedded audio or video, or open images in the post without having to open the post in its own page. Only the post body text is a clickable link to do that. You can also still interact with all the contact links in the header, click any of the reaction buttons, and comment on a post from within a feed without having to open the post in its own page (to _see_ your comment, however, you would).  There is also a "<- Go Back" link above the post so you can navigate back to the feed (since there are no browser controls for this when using Friendica as a PWA bookmarked to your homescreen).

The only way this works _differently_ from Bluesky or Mastodon is if the content is a Quote Post. The body of a quoted post is still a separate link from post in which it is embedded, but it will open that shared post in a new tab/window because the link on it is `target="_blank"` with `rel="noreferrer noopener"`.  Why? I have no idea. **If that's not necessary for some reason those attributes could be removed** from the quoted post link so it opens in the same window. What that affects is the new "<- Go Back" link on the single post display page. Because there is no referrer, no opener, and no tab/window history there is no reference of where to go back _to_.

This PR also adds a "smart-threaded" class to the comment container if the user has enabled that feature. Nothing presently uses it, but it provides a CSS "handle" for an add-on or theme/scheme trying to style thread indicators to make adjustments based on whether that feature is enabled or not.