### PR TITLE
prevent up/down buttons being applied to reset checkbox div

### DIFF
--- a/view/templates/settings/head.tpl
+++ b/view/templates/settings/head.tpl
@@ -143,12 +143,12 @@
 		indexList('#menu_timelineorder','.timelines-menu','.field');
 
 		// add arrow buttons for touch devices that cannot drag-n-drop or keyboard sort
-		$('.network .field, .timelines-widget .field, .timelines-menu .field').each(function(){
+		$('.network .field, .timelines-widget .field, .timelines-menu .field').not('.settings-submit-wrapper .field, .panel-footer .field').each(function(){
 			$(this).append('<div class="sorter-mvup" onclick="moveListItem(this,\'up\');" aria-hidden="true"></div><div class="sorter-mvdn" onclick="moveListItem(this,\'down\');" aria-hidden="true"></div>');
 		});
 
 		// accessible sorting with keyboard gives feedback to screenreaders
-		$('.network .field, .timelines-widget .field, .timelines-menu .field').bind('keydown', function(event){
+		$('.network .field, .timelines-widget .field, .timelines-menu .field').not('.settings-submit-wrapper .field, .panel-footer .field').bind('keydown', function(event){
 			if(event.which == 38){
 				moveListItem(this,'up');
 			}


### PR DESCRIPTION
Not sure why I never noticed this before but the move up/down buttons I added to the sortable lists are also getting added to the reset button container. This PR adds a jQuery `.not()` condition to remove those field containers from the matches.

<img width="645" height="280" alt="no_buttons_here" src="https://github.com/user-attachments/assets/701c743f-61c2-4feb-b7b7-b123c209b299" />
