### PR TITLE
Add Conditional smart-threaded class to comment container

### DIFF
--- a/src/Content/Conversation/PostTemplateBuilder.php
+++ b/src/Content/Conversation/PostTemplateBuilder.php
@@ -423,6 +423,7 @@ final class PostTemplateBuilder
 			'isunknown_label'    => $this->l10n->t('Parent is probably private or not federated.'),
 			'show_text'          => $this->l10n->t('Show comments'),
 			'hide_text'          => $this->l10n->t('Close comments'),
+			'smart_threading'    => $this->uid ? !$this->pConfig->get($this->uid, 'system', 'no_smart_threading', false) : false,
 		];
 
 		$arr    = ['item' => $item, 'output' => $tmpItem];

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -4,6 +4,17 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
+{{* pengy added Frio count logic to Vier *}}
+{{if $item.thread_level==1}}
+	{{assign var="top_child_total" value=count($item.children)}}
+	{{assign var="top_child_nr" value=0}}
+{{/if}}
+{{if $item.thread_level==2}}
+	{{assign var="top_child_nr" value=$top_child_nr+1 scope=parent}}
+{{/if}}
+{{if $item.thread_level==2 && $top_child_nr==1}}
+<div class="comment-container {{if !$item.not_smart_threaded}} smart-threaded{{/if}}"> <!--top-child-begin-->
+{{/if}}
 {{if $mode == display}}
 {{else}}
 {{if $item.comment_firstcollapsed}}
@@ -262,3 +273,7 @@
 				<div class="wall-item-comment-wrapper" id="item-comments-{{$item.id}}" style="display: none;">{{$item.comment_html nofilter}}</div>
             {{/if}}
         {{/if}}
+{{* close the comment-container div if no more thread_level = 2 children are left *}}
+{{if $item.thread_level==2 && $top_child_nr==$top_child_total}}
+</div><!--./comment-container-->
+{{/if}}

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -4,7 +4,6 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-{{* pengy added Frio count logic to Vier *}}
 {{if $item.thread_level==1}}
 	{{assign var="top_child_total" value=count($item.children)}}
 	{{assign var="top_child_nr" value=0}}
@@ -13,7 +12,7 @@
 	{{assign var="top_child_nr" value=$top_child_nr+1 scope=parent}}
 {{/if}}
 {{if $item.thread_level==2 && $top_child_nr==1}}
-<div class="comment-container {{if !$item.not_smart_threaded}} smart-threaded{{/if}}"> <!--top-child-begin-->
+<div class="comment-container {{if $item.smart_threading}} smart-threaded{{/if}}"> <!--top-child-begin-->
 {{/if}}
 {{if $mode == display}}
 {{else}}

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -26,7 +26,7 @@ as the value of $top_child_total (this is done at the end of this file)
 {{/if}}
 
 {{if $item.thread_level==2 && $top_child_nr==1}}
-<div class="comment-container{{if !$not_smart_threaded}} smart-threaded{{/if}}"> <!--top-child-begin-->
+<div class="comment-container{{if $item.smart_threading} smart-threaded{{/if}}"> <!--top-child-begin-->
 {{/if}}
 {{* end of hacky part to count children *}}
 

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -26,7 +26,7 @@ as the value of $top_child_total (this is done at the end of this file)
 {{/if}}
 
 {{if $item.thread_level==2 && $top_child_nr==1}}
-<div class="comment-container"> <!--top-child-begin-->
+<div class="comment-container{{if !$not_smart_threaded}} smart-threaded{{/if}}"> <!--top-child-begin-->
 {{/if}}
 {{* end of hacky part to count children *}}
 


### PR DESCRIPTION
This was previously in a PR with other stuff I've retracted. There is presently no way for a front-end designer working with stylesheets to know whether or not the option for "Smart Threading" is enabled or not. Anyone who is trying to style thread indicators or comment relationships would need some way to handle styling differently depending on whether that option is enabled or not.

So all this PR does is conditionally add a "smart-threaded" class to the comments container. However, that meant I had to _add_ a comments container to Vier along with the same logic used by Frio to know when to open/close the tags for that container.