### PR TITLE
fix: set status code in HTTP response to 500 on exceptions

### DIFF
--- a/src/Module/Circle.php
+++ b/src/Module/Circle.php
@@ -129,7 +129,7 @@ class Circle extends BaseModule
 			$this->earlyJsonExit(['status' => 'OK', 'message' => $message]);
 		} catch (\Exception $e) {
 			DI::sysmsg()->addNotice($e->getMessage());
-			$this->earlyJsonError($e->getCode(), ['status' => 'error', 'message' => $e->getMessage()]);
+			$this->earlyJsonError(500, ['status' => 'error', 'message' => $e->getMessage()]);
 		}
 	}
 


### PR DESCRIPTION
If the Circle Modules catches an exception it now sets the HTTP response status code to 500 instead of using the Exception code. Turns out this was broken [since ever](https://github.com/MrPetovan/friendica/blob/486de602ff5e7b49bf0184bcbadf6e80985e8cea/src/Module/Group.php). With this PR we now have a chance to investigate the real exceptions, because responses with status code >= 400 will be logged.

fixes #16064 

Offtopic: this reminds me to [my own words](https://github.com/friendica/friendica/pull/15664/changes#r3108293006) :blush: :

> We should not misuse the Exception Code for the HTTP status code. This will create more confusion and problems on the long run. It is the controller's/module's responsibility to map an exception code to a correct HTTP status code.