### PR TITLE
Stylelint: exclude false positives from the legacy warning backlog

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -7,6 +7,7 @@
 		"view/asset/**",
 		"view/theme/frio/frameworks/**",
 		"**/*.min.css",
+		"**/*.min.*.css",
 		"view/fonts/**",
 		"view/js/fancybox/**",
 		"view/js/friendica-tagsinput/**",
@@ -24,12 +25,24 @@
 			}
 		}],
 
+		"selector-type-no-unknown": [true, {
+			"ignoreTypes": ["right_aside"],
+			"severity": "warning"
+		}],
+
+		"font-family-no-missing-generic-family-keyword": [true, {
+			"ignoreFontFamilies": ["remixicon"],
+			"severity": "warning"
+		}],
+
+		"declaration-block-no-duplicate-properties": [true, {
+			"ignore": ["consecutive-duplicates-with-different-values"],
+			"severity": "warning"
+		}],
+
 		"no-duplicate-selectors": [true, { "severity": "warning" }],
-		"selector-type-no-unknown": [true, { "severity": "warning" }],
-		"font-family-no-missing-generic-family-keyword": [true, { "severity": "warning" }],
 		"declaration-property-value-keyword-no-deprecated": [true, { "severity": "warning" }],
 		"property-no-deprecated": [true, { "severity": "warning" }],
-		"declaration-block-no-duplicate-properties": [true, { "severity": "warning" }],
 		"block-no-empty": [true, { "severity": "warning" }]
 	},
 	"overrides": [

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
 		"lint:js:fix": "eslint --fix --pass-on-unpruned-suppressions",
 		"lint:js:prune": "eslint --prune-suppressions",
 
-		"lint:css": "stylelint \"view/**/*.css\" --max-warnings 170",
-		"lint:css:fix": "stylelint \"view/**/*.css\" --fix --max-warnings 170",
+		"lint:css": "stylelint \"view/**/*.css\" --max-warnings 111",
+		"lint:css:fix": "stylelint \"view/**/*.css\" --fix --max-warnings 111",
 		"lint:css:errors": "stylelint \"view/**/*.css\" --quiet"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The CSS backlog is a single global counter (--max-warnings), so every false positive in it costs us the ability to tell which warning a PR actually added. Roughly half of the 170 were not CSS problems at all but imprecise rule configuration:

- ignoreFiles: `**/*.min.css` did not match `dropzone.min.frio.css`, so the minified artifact was counted alongside the source it is generated from - the same 5 findings twice. The source stays linted.
- font-family-no-missing-generic-family-keyword: `remixicon` is an icon font (@font-face in view/asset/remixicon/fonts/remixicon.css). A generic fallback would render Private Use Area codepoints as tofu instead of nothing. The 4 real findings in vier remain.
- selector-type-no-unknown: `right_aside` is a real element emitted by view/php/default.php:39. The 4 selectors that genuinely point at nothing remain.
- declaration-block-no-duplicate-properties: 28 of the 30 hidden findings are IE9/IE10-era progressive enhancement (px before calc(), hex before rgba(), -ms-flexbox before flex). Once those fallbacks go, this ignore option can go with them.

170 -> 111 warnings, no CSS touched. Cap lowered accordingly.