### PR TITLE
Add `handleRequest()` test coverage part 2

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 88
+            count: 85
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 71
+            count: 69
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 57
+            count: 53
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 79
+            count: 77
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 95
+            count: 93
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 91
+            count: 88
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 85
+            count: 82
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 82
+            count: 79
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 69
+            count: 64
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 59
+            count: 57
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 93
+            count: 91
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 74
+            count: 71
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 77
+            count: 74
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 64
+            count: 59
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 96
+            count: 95
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/tests/Integration/Module/Api/Friendica/NotificationTest.php
+++ b/tests/Integration/Module/Api/Friendica/NotificationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Friendica;
+
+use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Module\Api\Friendica\Notification;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use Friendica\Util\DateTimeFormat;
+use Friendica\Util\Temporal;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class NotificationTest extends ApiTestCase
+{
+	public function testApiNotificationWithXmlResult(): void
+	{
+		$date    = DateTimeFormat::local('2020-01-01 12:12:02');
+		$dateRel = Temporal::getRelativeDate('2020-01-01 12:12:02');
+
+		$assertXml = <<<XML
+<?xml version="1.0"?>
+<notes>
+  <note date="$date" date_rel="$dateRel" id="1" iid="4" link="https://friendica.local/display/1" msg="A test reply from an item" msg_cache="A test reply from an item" msg_html="A test reply from an item" msg_plain="A test reply from an item" name="Friend contact" name_cache="Friend contact" otype="item" parent="" photo="https://friendica.local/" seen="false" timestamp="1577880722" type="8" uid="42" url="https://friendica.local/profile/friendcontact" verb="http://activitystrea.ms/schema/1.0/post"/>
+</notes>
+XML;
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/friendica/notification');
+
+		$response = $this->createModule(['extension' => 'xml'])->handleRequest($request);
+
+		self::assertXmlStringEqualsXmlString($assertXml, (string) $response->getBody());
+		self::assertEquals([
+			'Content-type'                => ['text/xml'],
+			ICanCreateResponses::X_HEADER => ['xml'],
+		], $response->getHeaders());
+	}
+
+	public function testApiNotificationWithJsonResult(): void
+	{
+		$request = new ServerRequest('GET', 'https://friendica.local/api/friendica/notification');
+
+		$response = $this->createModule(['extension' => 'json'])->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertCount(1, $json);
+
+		foreach ($json as $note) {
+			self::assertIsInt($note->id);
+			self::assertIsInt($note->uid);
+			self::assertIsString($note->msg);
+		}
+	}
+
+	public function testApiNotificationWithEmptyList(): void
+	{
+		DI::dba()->delete('notify', ['uid' => 42]);
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/friendica/notification');
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertFalse($json);
+	}
+
+	public function testApiNotificationWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/friendica/notification');
+
+		$module = $this->createModule();
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(array $parameters = []): Notification
+	{
+		return new Notification(
+			DI::mstdnError(),
+			DI::appHelper(),
+			DI::l10n(),
+			DI::baseUrl(),
+			DI::args(),
+			DI::logger(),
+			DI::profiler(),
+			DI::apiResponse(),
+			[],
+			$parameters,
+		);
+	}
+}

--- a/tests/Integration/Module/Api/Friendica/Photo/DeleteTest.php
+++ b/tests/Integration/Module/Api/Friendica/Photo/DeleteTest.php
@@ -1,0 +1,135 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Friendica\Photo;
+
+use Friendica\App\Router;
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Module\Api\Friendica\Photo\Delete;
+use Friendica\Network\HTTPException\BadRequestException;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class DeleteTest extends ApiTestCase
+{
+	protected const PHOTO_RESOURCE_ID = '709057080661a283a6aa598501504178';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->useHttpMethod(Router::POST);
+	}
+
+	public function testApiPhotoDeleteWithoutPhotoId(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$request = new ServerRequest('POST', 'https://friendica.local/api/friendica/photo/delete');
+
+		$this->createModule()->handleRequest($request);
+	}
+
+	public function testApiPhotoDeleteWithWrongPhotoId(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/friendica/photo/delete'))
+			->withParsedBody([
+				'photo_id' => 1,
+			]);
+
+		$this->createModule()->handleRequest($request);
+	}
+
+	public function testApiPhotoDeleteValid(): void
+	{
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/friendica/photo/delete'))
+			->withParsedBody([
+				'photo_id' => self::PHOTO_RESOURCE_ID,
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('deleted', $json->result);
+		self::assertEquals('photo with id `' . self::PHOTO_RESOURCE_ID . '` has been deleted from server.', $json->message);
+
+		self::assertFalse(DI::dba()->exists('photo', ['resource-id' => self::PHOTO_RESOURCE_ID, 'uid' => 42]));
+	}
+
+	public function testApiPhotoDeleteWithRawJsonBody(): void
+	{
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/friendica/photo/delete'))
+			->withParsedBody([
+				'photo_id' => self::PHOTO_RESOURCE_ID,
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$responseText = (string) $response->getBody();
+
+		self::assertJson($responseText);
+
+		$json = json_decode($responseText);
+
+		self::assertEquals('deleted', $json->result);
+		self::assertEquals('photo with id `' . self::PHOTO_RESOURCE_ID . '` has been deleted from server.', $json->message);
+	}
+
+	public function testApiPhotoDeleteWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/friendica/photo/delete'))
+			->withParsedBody([
+				'photo_id' => self::PHOTO_RESOURCE_ID,
+			]);
+
+		$module = $this->createModule();
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(array $parameters = []): Delete
+	{
+		return new Delete(
+			DI::mstdnError(),
+			DI::appHelper(),
+			DI::l10n(),
+			DI::baseUrl(),
+			DI::args(),
+			DI::logger(),
+			DI::profiler(),
+			DI::apiResponse(),
+			[],
+			$parameters,
+		);
+	}
+}

--- a/tests/Integration/Module/Api/Mastodon/Accounts/VerifyCredentialsTest.php
+++ b/tests/Integration/Module/Api/Mastodon/Accounts/VerifyCredentialsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Mastodon\Accounts;
+
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Module\Api\Mastodon\Accounts\VerifyCredentials;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class VerifyCredentialsTest extends ApiTestCase
+{
+	public function testApiAccountVerifyCredentials(): void
+	{
+		$module = $this->createModule();
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/v1/accounts/verify_credentials');
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertEquals(48, $json->id);
+		self::assertIsArray($json->emojis);
+		self::assertIsArray($json->fields);
+	}
+
+	public function testApiAccountVerifyCredentialsWithoutAuthenticatedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$module = $this->createModule();
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/v1/accounts/verify_credentials');
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): VerifyCredentials
+	{
+		return new VerifyCredentials(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/DirectMessages/DestroyTest.php
+++ b/tests/Integration/Module/Api/Twitter/DirectMessages/DestroyTest.php
@@ -1,0 +1,163 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\DirectMessages;
+
+use Friendica\App\Router;
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\DirectMessages\Destroy;
+use Friendica\Network\HTTPException\BadRequestException;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use Friendica\Util\DateTimeFormat;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class DestroyTest extends ApiTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->useHttpMethod(Router::POST);
+	}
+
+	public function testApiDirectMessagesDestroy(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$request = new ServerRequest('POST', 'https://friendica.local/api/direct_messages/destroy');
+
+		$this->createModule()->handleRequest($request);
+	}
+
+	public function testApiDirectMessagesDestroyWithVerbose(): void
+	{
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/direct_messages/destroy'))
+			->withParsedBody([
+				'friendica_verbose' => 'true',
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('error', $json->result);
+		self::assertEquals('message id or parenturi not specified', $json->message);
+	}
+
+	public function testApiDirectMessagesDestroyWithId(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/direct_messages/destroy'))
+			->withParsedBody([
+				'id' => 1,
+			]);
+
+		$this->createModule()->handleRequest($request);
+	}
+
+	public function testApiDirectMessagesDestroyWithIdAndVerbose(): void
+	{
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/direct_messages/destroy'))
+			->withParsedBody([
+				'id'                  => 1,
+				'friendica_parenturi' => 'parent_uri',
+				'friendica_verbose'   => 'true',
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('error', $json->result);
+		self::assertEquals('message id not in database', $json->message);
+	}
+
+	public function testApiDirectMessagesDestroyWithCorrectId(): void
+	{
+		DI::dba()->insert('mail', [
+			'uid'           => 42,
+			'author-id'     => 48,
+			'contact-id'    => 44,
+			'uri-id'        => 44,
+			'parent-uri-id' => 44,
+			'thr-parent-id' => 44,
+			'guid'          => '123456',
+			'from-name'     => 'Tester',
+			'title'         => 'item_title',
+			'body'          => '[b]item_body[/b]',
+			'parent-uri'    => 'parent-uri-value',
+			'created'       => DateTimeFormat::utcNow(),
+		]);
+		$mailId = DI::dba()->lastInsertId();
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/direct_messages/destroy'))
+			->withParsedBody([
+				'id'                => $mailId,
+				'friendica_verbose' => 'true',
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('ok', $json->result);
+		self::assertEquals('message deleted', $json->message);
+
+		self::assertFalse(DI::dba()->exists('mail', ['id' => $mailId]));
+	}
+
+	public function testApiDirectMessagesDestroyWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/direct_messages/destroy'))
+			->withParsedBody([
+				'id' => 1,
+			]);
+
+		$module = $this->createModule();
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(array $parameters = []): Destroy
+	{
+		return new Destroy(
+			DI::dba(),
+			DI::mstdnError(),
+			DI::appHelper(),
+			DI::l10n(),
+			DI::baseUrl(),
+			DI::args(),
+			DI::logger(),
+			DI::profiler(),
+			DI::apiResponse(),
+			[],
+			$parameters,
+		);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/DirectMessages/NewDMTest.php
+++ b/tests/Integration/Module/Api/Twitter/DirectMessages/NewDMTest.php
@@ -1,0 +1,203 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\DirectMessages;
+
+use Friendica\App\Router;
+use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Factory\Api\Twitter\DirectMessage;
+use Friendica\Module\Api\Twitter\DirectMessages\NewDM;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use Friendica\Util\DateTimeFormat;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class NewDMTest extends ApiTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->useHttpMethod(Router::POST);
+	}
+
+	public function testApiDirectMessagesNew(): void
+	{
+		$request = new ServerRequest('POST', 'https://friendica.local/api/direct_messages/new');
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+		self::assertEmpty((string) $response->getBody());
+	}
+
+	public function testApiDirectMessagesNewWithUserId(): void
+	{
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/direct_messages/new'))
+			->withParsedBody([
+				'text'    => 'message_text',
+				'user_id' => 43,
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertEquals(-1, $json->error);
+	}
+
+	public function testApiDirectMessagesNewWithScreenName(): void
+	{
+		DI::session()->set('nickname', 'selfcontact');
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/direct_messages/new'))
+			->withParsedBody([
+				'text'    => 'message_text',
+				'user_id' => 44,
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStringContainsString('message_text', $json->text);
+		self::assertEquals('selfcontact', $json->sender_screen_name);
+		self::assertEquals(1, $json->friendica_seen);
+	}
+
+	public function testApiDirectMessagesNewWithTitle(): void
+	{
+		DI::session()->set('nickname', 'selfcontact');
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/direct_messages/new'))
+			->withParsedBody([
+				'text'    => 'message_text',
+				'user_id' => 44,
+				'title'   => 'message_title',
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStringContainsString('message_text', $json->text);
+		self::assertStringContainsString('message_title', $json->text);
+		self::assertEquals('selfcontact', $json->sender_screen_name);
+		self::assertEquals(1, $json->friendica_seen);
+	}
+
+	public function testApiDirectMessagesNewWithRss(): void
+	{
+		DI::session()->set('nickname', 'selfcontact');
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/direct_messages/new'))
+			->withParsedBody([
+				'text'    => 'message_text',
+				'user_id' => 44,
+				'title'   => 'message_title',
+			]);
+
+		$module = $this->createModule([
+			'extension' => ICanCreateResponses::TYPE_RSS,
+		]);
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'direct-messages');
+	}
+
+	public function testApiDirectMessagesNewWithReplyTo(): void
+	{
+		DI::dba()->insert('mail', [
+			'uid'           => 42,
+			'author-id'     => 48,
+			'contact-id'    => 44,
+			'uri-id'        => 44,
+			'parent-uri-id' => 44,
+			'thr-parent-id' => 44,
+			'guid'          => '123456',
+			'from-name'     => 'Tester',
+			'title'         => 'item_title',
+			'body'          => '[b]item_body[/b]',
+			'parent-uri'    => 'parent-uri-value',
+			'created'       => DateTimeFormat::utcNow(),
+		]);
+		$parentMailId = DI::dba()->lastInsertId();
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/direct_messages/new'))
+			->withParsedBody([
+				'text'    => 'message_text',
+				'user_id' => 44,
+				'replyto' => $parentMailId,
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStringContainsString('item_title', $json->text);
+		self::assertStringContainsString('message_text', $json->text);
+		self::assertEquals('selfcontact', $json->sender_screen_name);
+	}
+
+	public function testApiDirectMessagesNewWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/direct_messages/new'))
+			->withParsedBody([
+				'text'    => 'message_text',
+				'user_id' => 44,
+			]);
+
+		$module = $this->createModule();
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(array $parameters = []): NewDM
+	{
+		return new NewDM(
+			new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser()),
+			DI::dba(),
+			DI::mstdnError(),
+			DI::appHelper(),
+			DI::l10n(),
+			DI::baseUrl(),
+			DI::args(),
+			DI::logger(),
+			DI::profiler(),
+			DI::apiResponse(),
+			[],
+			$parameters,
+		);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/DirectMessages/SentTest.php
+++ b/tests/Integration/Module/Api/Twitter/DirectMessages/SentTest.php
@@ -1,0 +1,141 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\DirectMessages;
+
+use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Factory\Api\Twitter\DirectMessage;
+use Friendica\Module\Api\Twitter\DirectMessages\Sent;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use Friendica\Util\DateTimeFormat;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class SentTest extends ApiTestCase
+{
+	public function testApiDirectMessagesBox(): void
+	{
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/direct_messages/sent'))
+			->withQueryParams([
+				'page'   => '1',
+				'count'  => '20',
+				'max_id' => '10',
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertEmpty($json);
+	}
+
+	public function testApiDirectMessagesBoxWithVerbose(): void
+	{
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/direct_messages/sent'))
+			->withQueryParams(['friendica_verbose' => 'true']);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('error', $json->result);
+		self::assertEquals('no mails available', $json->message);
+	}
+
+	public function testApiDirectMessagesBoxWithRss(): void
+	{
+		$module = $this->createModule([
+			'extension' => ICanCreateResponses::TYPE_RSS,
+		]);
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/direct_messages/sent.rss');
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'direct-messages');
+	}
+
+	public function testApiDirectMessagesBoxWithSentMail(): void
+	{
+		DI::dba()->insert('mail', [
+			'uid'           => 42,
+			'author-id'     => 48,
+			'contact-id'    => 44,
+			'uri-id'        => 44,
+			'parent-uri-id' => 44,
+			'thr-parent-id' => 44,
+			'guid'          => '123456',
+			'from-name'     => 'Tester',
+			'title'         => 'item_title',
+			'body'          => '[b]item_body[/b]',
+			'created'       => DateTimeFormat::utcNow(),
+		]);
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/direct_messages/sent');
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertCount(1, $json);
+		self::assertEquals('item_title' . "\n" . 'item_body', $json[0]->text);
+		self::assertEquals('selfcontact', $json[0]->sender_screen_name);
+		self::assertEquals('friendcontact', $json[0]->recipient_screen_name);
+	}
+
+	public function testApiDirectMessagesBoxWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$module = $this->createModule();
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/direct_messages/sent');
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(array $parameters = []): Sent
+	{
+		return new Sent(
+			new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser()),
+			DI::dba(),
+			DI::mstdnError(),
+			DI::appHelper(),
+			DI::l10n(),
+			DI::baseUrl(),
+			DI::args(),
+			DI::logger(),
+			DI::profiler(),
+			DI::apiResponse(),
+			[],
+			$parameters,
+		);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/FavoritesTest.php
+++ b/tests/Integration/Module/Api/Twitter/FavoritesTest.php
@@ -1,0 +1,87 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter;
+
+use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Core\EarlyExitException;
+use Friendica\Core\Renderer;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Favorites;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class FavoritesTest extends ApiTestCase
+{
+	public function testApiFavorites(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = $this->createModule();
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/favorites'))
+			->withQueryParams(['page' => '-1', 'max_id' => '10']);
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertNotEmpty($json);
+
+		foreach ($json as $status) {
+			self::assertStatus($status);
+		}
+	}
+
+	public function testApiFavoritesWithRss(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+			'extension' => ICanCreateResponses::TYPE_RSS,
+		]);
+
+		$request = new ServerRequest('GET', 'https://friendica.local/favorites.rss');
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
+	}
+
+	public function testApiFavoritesWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$module = $this->createModule();
+
+		$request = new ServerRequest('GET', 'https://friendica.local/favorites');
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): Favorites
+	{
+		return new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Lists/StatusesTest.php
+++ b/tests/Integration/Module/Api/Twitter/Lists/StatusesTest.php
@@ -1,0 +1,98 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Lists;
+
+use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Core\EarlyExitException;
+use Friendica\Core\Renderer;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Lists\Statuses;
+use Friendica\Network\HTTPException\BadRequestException;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class StatusesTest extends ApiTestCase
+{
+	public function testApiListsStatuses(): void
+	{
+		$module = $this->createModule();
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/lists/statuses');
+
+		$this->expectException(BadRequestException::class);
+
+		$module->handleRequest($request);
+	}
+
+	public function testApiListsStatusesWithListId(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/lists/statuses'))
+			->withQueryParams(['list_id' => '1', 'page' => '-1', 'max_id' => '10']);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertNotEmpty($json);
+		foreach ($json as $status) {
+			self::assertStatus($status);
+		}
+	}
+
+	public function testApiListsStatusesWithListIdAndRss(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+			'extension' => ICanCreateResponses::TYPE_RSS,
+		]);
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/lists/statuses.rss'))
+			->withQueryParams(['list_id' => '1']);
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
+	}
+
+	public function testApiListsStatusesWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$module = $this->createModule();
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/lists/statuses');
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): Statuses
+	{
+		return new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Statuses/DestroyTest.php
+++ b/tests/Integration/Module/Api/Twitter/Statuses/DestroyTest.php
@@ -1,0 +1,82 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Statuses;
+
+use Friendica\App\Router;
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Statuses\Destroy;
+use Friendica\Network\HTTPException\BadRequestException;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class DestroyTest extends ApiTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->useHttpMethod(Router::POST);
+	}
+
+	public function testApiStatusesDestroy(): void
+	{
+		$request = new ServerRequest('POST', 'https://friendica.local/api/statuses/destroy');
+
+		$module = $this->createModule();
+
+		$this->expectException(BadRequestException::class);
+
+		$module->handleRequest($request);
+	}
+
+	public function testApiStatusesDestroyWithId(): void
+	{
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/statuses/destroy'))
+			->withParsedBody(['id' => 1]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertEquals(1, $json->id);
+		self::assertIsObject($json->user);
+		self::assertIsObject($json->friendica_author);
+	}
+
+	public function testApiStatusesDestroyWithoutAuthenticatedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/statuses/destroy'))
+			->withParsedBody(['id' => 1]);
+
+		$module = $this->createModule();
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): Destroy
+	{
+		return new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Statuses/MentionsTest.php
+++ b/tests/Integration/Module/Api/Twitter/Statuses/MentionsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Statuses;
+
+use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Statuses\Mentions;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class MentionsTest extends ApiTestCase
+{
+	public function testApiStatusesMentions(): void
+	{
+		$module = $this->createModule();
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/statuses/mentions'))
+			->withQueryParams(['max_id' => '10']);
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertEmpty($json);
+	}
+
+	public function testApiStatusesMentionsWithNegativePage(): void
+	{
+		$module = $this->createModule();
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/statuses/mentions'))
+			->withQueryParams(['page' => '-2']);
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertEmpty($json);
+	}
+
+	public function testApiStatusesMentionsWithRss(): void
+	{
+		$module = new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+			'extension' => ICanCreateResponses::TYPE_RSS,
+		]);
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/statuses/mentions.rss');
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
+	}
+
+	public function testApiStatusesMentionsWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$module = $this->createModule();
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/statuses/mentions');
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): Mentions
+	{
+		return new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
+++ b/tests/Integration/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
@@ -1,0 +1,103 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Statuses;
+
+use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Core\EarlyExitException;
+use Friendica\Core\Renderer;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Statuses\NetworkPublicTimeline;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class NetworkPublicTimelineTest extends ApiTestCase
+{
+	public function testApiStatusesNetworkpublicTimeline(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/statuses/networkpublic_timeline'))
+			->withQueryParams(['max_id' => '10']);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertNotEmpty($json);
+		foreach ($json as $status) {
+			self::assertStatus($status);
+		}
+	}
+
+	public function testApiStatusesNetworkpublicTimelineWithNegativePage(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/statuses/networkpublic_timeline'))
+			->withQueryParams(['page' => '-2']);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertNotEmpty($json);
+		foreach ($json as $status) {
+			self::assertStatus($status);
+		}
+	}
+
+	public function testApiStatusesNetworkpublicTimelineWithRss(): void
+	{
+		$module = new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+			'extension' => ICanCreateResponses::TYPE_RSS,
+		]);
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/statuses/networkpublic_timeline.rss');
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
+	}
+
+	public function testApiStatusesNetworkpublicTimelineWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$module = $this->createModule();
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/statuses/networkpublic_timeline');
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): NetworkPublicTimeline
+	{
+		return new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Statuses/RetweetTest.php
+++ b/tests/Integration/Module/Api/Twitter/Statuses/RetweetTest.php
@@ -1,0 +1,97 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Statuses;
+
+use Friendica\App\Router;
+use Friendica\Core\EarlyExitException;
+use Friendica\Core\Renderer;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Statuses\Retweet;
+use Friendica\Network\HTTPException\BadRequestException;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class RetweetTest extends ApiTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->useHttpMethod(Router::POST);
+	}
+
+	public function testApiStatusesRepeat(): void
+	{
+		$request = new ServerRequest('POST', 'https://friendica.local/api/statuses/retweet');
+
+		$module = $this->createModule();
+
+		$this->expectException(BadRequestException::class);
+
+		$module->handleRequest($request);
+	}
+
+	public function testApiStatusesRepeatWithId(): void
+	{
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/statuses/retweet'))
+			->withParsedBody(['id' => 1]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+	}
+
+	public function testApiStatusesRepeatWithSharedId(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/statuses/retweet'))
+			->withParsedBody(['id' => 5]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+	}
+
+	public function testApiStatusesRepeatWithoutAuthenticatedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/statuses/retweet'))
+			->withParsedBody(['id' => 1]);
+
+		$module = $this->createModule();
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): Retweet
+	{
+		return new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Statuses/ShowTest.php
+++ b/tests/Integration/Module/Api/Twitter/Statuses/ShowTest.php
@@ -1,0 +1,96 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Statuses;
+
+use Friendica\Core\EarlyExitException;
+use Friendica\Core\Renderer;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Statuses\Show;
+use Friendica\Network\HTTPException\BadRequestException;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class ShowTest extends ApiTestCase
+{
+	public function testApiStatusesShow(): void
+	{
+		$module = $this->createModule();
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/statuses/show');
+
+		$this->expectException(BadRequestException::class);
+
+		$module->handleRequest($request);
+	}
+
+	public function testApiStatusesShowWithId(): void
+	{
+		$module = $this->createModule();
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/statuses/show'))
+			->withQueryParams(['id' => '1']);
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+	}
+
+	public function testApiStatusesShowWithConversation(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$module = $this->createModule();
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/statuses/show'))
+			->withQueryParams(['id' => '1', 'conversation' => '1']);
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertNotEmpty($json);
+		foreach ($json as $status) {
+			self::assertStatus($status);
+		}
+	}
+
+	public function testApiStatusesShowWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$module = $this->createModule();
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/statuses/show');
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): Show
+	{
+		return new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Statuses/UpdateTest.php
+++ b/tests/Integration/Module/Api/Twitter/Statuses/UpdateTest.php
@@ -1,0 +1,148 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Statuses;
+
+use Friendica\App\Router;
+use Friendica\Core\EarlyExitException;
+use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Statuses\Update;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use Friendica\Util\DateTimeFormat;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class UpdateTest extends ApiTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->useHttpMethod(Router::POST);
+	}
+
+	public function testApiStatusesUpdate(): void
+	{
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/statuses/update'))
+			->withParsedBody([
+				'status'                => 'Status content #friendica',
+				'in_reply_to_status_id' => 0,
+				'lat'                   => 48,
+				'long'                  => 7,
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+		self::assertStringContainsString('Status content #friendica', $json->text);
+		self::assertStringContainsString('Status content #', $json->statusnet_html);
+	}
+
+	public function testApiStatusesUpdateWithHtml(): void
+	{
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/statuses/update'))
+			->withParsedBody(['htmlstatus' => '<b>Status content</b>']);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+	}
+
+	public function testApiStatusesUpdateWithParent(): void
+	{
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/statuses/update'))
+			->withParsedBody([
+				'status'                => 'Status content',
+				'in_reply_to_status_id' => 1,
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+	}
+
+	public function testApiStatusesUpdateWithMediaIds(): void
+	{
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/statuses/update'))
+			->withParsedBody([
+				'status'    => 'Status content',
+				'media_ids' => '1',
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+	}
+
+	public function testApiStatusesUpdateWithDayThrottleReached(): void
+	{
+		DI::config()->set('system', 'throttle_limit_day', 1);
+
+		DBA::update('post-thread-user', ['received' => DateTimeFormat::utcNow()], ['uri-id' => [1, 3], 'uid' => 42]);
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/statuses/update'))
+			->withParsedBody(['status' => 'Status content']);
+
+		$module = $this->createModule();
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(429, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	public function testApiStatusesUpdateWithoutAuthenticatedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/statuses/update'))
+			->withParsedBody(['status' => 'Status content']);
+
+		$module = $this->createModule();
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): Update
+	{
+		return new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Statuses/UserTimelineTest.php
+++ b/tests/Integration/Module/Api/Twitter/Statuses/UserTimelineTest.php
@@ -1,0 +1,109 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Statuses;
+
+use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Core\EarlyExitException;
+use Friendica\Core\Renderer;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Statuses\UserTimeline;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class UserTimelineTest extends ApiTestCase
+{
+	public function testApiStatusesUserTimeline(): void
+	{
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/statuses/user_timeline'))
+			->withQueryParams([
+				'user_id'         => '43',
+				'max_id'          => '10',
+				'exclude_replies' => 'true',
+				'conversation_id' => '1',
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertNotEmpty($json);
+		foreach ($json as $status) {
+			self::assertStatus($status);
+		}
+	}
+
+	public function testApiStatusesUserTimelineWithNegativePage(): void
+	{
+		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/statuses/user_timeline'))
+			->withQueryParams([
+				'user_id' => '43',
+				'page'    => '-2',
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json);
+		self::assertNotEmpty($json);
+		foreach ($json as $status) {
+			self::assertStatus($status);
+		}
+	}
+
+	public function testApiStatusesUserTimelineWithRss(): void
+	{
+		$module = new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
+			'extension' => ICanCreateResponses::TYPE_RSS,
+		]);
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/statuses/user_timeline.rss');
+
+		$response = $module->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
+	}
+
+	public function testApiStatusesUserTimelineWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$module = $this->createModule();
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/statuses/user_timeline');
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): UserTimeline
+	{
+		return new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/src/Module/Api/Friendica/NotificationTest.php
+++ b/tests/src/Module/Api/Friendica/NotificationTest.php
@@ -16,30 +16,6 @@ use Friendica\Util\Temporal;
 
 class NotificationTest extends ApiTestCase
 {
-	public function testEmpty(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		/*
-		$this->expectException(BadRequestException::class);
-		DI::session()->set('uid', '');
-
-		Notification::rawContent();
-		*/
-	}
-
-	public function testWithoutAuthenticatedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		/*
-		$this->expectException(BadRequestException::class);
-		DI::session()->set('uid', 41);
-
-		Notification::rawContent();
-		*/
-	}
-
 	public function testWithXmlResult(): void
 	{
 		$date    = DateTimeFormat::local('2020-01-01 12:12:02');
@@ -52,6 +28,7 @@ class NotificationTest extends ApiTestCase
 </notes>
 XML;
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'xml']))
 			->run($this->httpExceptionMock);
 
@@ -64,6 +41,7 @@ XML;
 
 	public function testWithJsonResult(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Notification(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 

--- a/tests/src/Module/Api/Friendica/Photo/DeleteTest.php
+++ b/tests/src/Module/Api/Friendica/Photo/DeleteTest.php
@@ -25,17 +25,16 @@ class DeleteTest extends ApiTestCase
 	public function testEmpty(): void
 	{
 		$this->expectException(BadRequestException::class);
-		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock);
-	}
 
-	public function testWithoutAuthenticatedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
+		// @phpstan-ignore method.deprecated
+		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock);
 	}
 
 	public function testWrong(): void
 	{
 		$this->expectException(BadRequestException::class);
+
+		// @phpstan-ignore method.deprecated
 		(new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))->run($this->httpExceptionMock, ['photo_id' => 1]);
 	}
 
@@ -43,6 +42,7 @@ class DeleteTest extends ApiTestCase
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'photo_id' => '709057080661a283a6aa598501504178',
@@ -58,6 +58,7 @@ class DeleteTest extends ApiTestCase
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Delete(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'photo_id' => '709057080661a283a6aa598501504178',

--- a/tests/src/Module/Api/Mastodon/Accounts/VerifyCredentialsTest.php
+++ b/tests/src/Module/Api/Mastodon/Accounts/VerifyCredentialsTest.php
@@ -20,6 +20,7 @@ class VerifyCredentialsTest extends ApiTestCase
 	 */
 	public function testApiAccountVerifyCredentials(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new VerifyCredentials(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
@@ -28,19 +29,5 @@ class VerifyCredentialsTest extends ApiTestCase
 		self::assertEquals(48, $json->id);
 		self::assertIsArray($json->emojis);
 		self::assertIsArray($json->fields);
-	}
-
-	/**
-	 * Test the api_account_verify_credentials() function without an authenticated user.
-	 *
-	 */
-	public function testApiAccountVerifyCredentialsWithoutAuthenticatedUser(): void
-	{
-		self::markTestIncomplete('Needs dynamic BasicAuth first');
-
-		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		// BasicAuth::setCurrentUserID();
-		// $_SESSION['authenticated'] = false;
-		// api_account_verify_credentials('json');
 	}
 }

--- a/tests/src/Module/Api/Twitter/DirectMessages/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/DestroyTest.php
@@ -31,6 +31,7 @@ class DestroyTest extends ApiTestCase
 	{
 		$this->expectException(\Friendica\Network\HTTPException\BadRequestException::class);
 
+		// @phpstan-ignore method.deprecated
 		(new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 	}
@@ -42,6 +43,7 @@ class DestroyTest extends ApiTestCase
 	 */
 	public function testApiDirectMessagesDestroyWithVerbose(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'friendica_verbose' => true,
@@ -54,22 +56,6 @@ class DestroyTest extends ApiTestCase
 	}
 
 	/**
-	 * Test the api_direct_messages_destroy() function without an authenticated user.
-	 *
-	 */
-	public function testApiDirectMessagesDestroyWithoutAuthenticatedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		/*
-		$this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		BasicAuth::setCurrentUserID();
-		$_SESSION['authenticated'] = false;
-		api_direct_messages_destroy('json');
-		*/
-	}
-
-	/**
 	 * Test the api_direct_messages_destroy() function with a non-zero ID.
 	 *
 	 * @return void
@@ -77,6 +63,8 @@ class DestroyTest extends ApiTestCase
 	public function testApiDirectMessagesDestroyWithId(): void
 	{
 		$this->expectException(\Friendica\Network\HTTPException\BadRequestException::class);
+
+		// @phpstan-ignore method.deprecated
 		(new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'id' => 1,
@@ -90,6 +78,7 @@ class DestroyTest extends ApiTestCase
 	 */
 	public function testApiDirectMessagesDestroyWithIdAndVerbose(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'id'                  => 1,
@@ -114,6 +103,7 @@ class DestroyTest extends ApiTestCase
 		$ids = DBA::selectToArray('mail', ['id']);
 		$id  = $ids[0]['id'];
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Destroy(DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'id'                => $id,

--- a/tests/src/Module/Api/Twitter/DirectMessages/NewDMTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/NewDMTest.php
@@ -31,26 +31,11 @@ class NewDMTest extends ApiTestCase
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
+		// @phpstan-ignore method.deprecated
 		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock);
 
 		self::assertEmpty((string) $response->getBody());
-	}
-
-	/**
-	 * Test the api_direct_messages_new() function without an authenticated user.
-	 *
-	 */
-	public function testApiDirectMessagesNewWithoutAuthenticatedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		/*
-		$this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		BasicAuth::setCurrentUserID();
-		$_SESSION['authenticated'] = false;
-		api_direct_messages_new('json');
-		*/
 	}
 
 	/**
@@ -62,6 +47,7 @@ class NewDMTest extends ApiTestCase
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
+		// @phpstan-ignore method.deprecated
 		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',
@@ -84,6 +70,7 @@ class NewDMTest extends ApiTestCase
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
+		// @phpstan-ignore method.deprecated
 		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',
@@ -108,6 +95,7 @@ class NewDMTest extends ApiTestCase
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
+		// @phpstan-ignore method.deprecated
 		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',
@@ -134,6 +122,7 @@ class NewDMTest extends ApiTestCase
 
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
+		// @phpstan-ignore method.deprecated
 		$response = (new NewDM($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
 			->run($this->httpExceptionMock, [
 				'text'    => 'message_text',

--- a/tests/src/Module/Api/Twitter/DirectMessages/SentTest.php
+++ b/tests/src/Module/Api/Twitter/DirectMessages/SentTest.php
@@ -23,6 +23,7 @@ class SentTest extends ApiTestCase
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Sent($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'json']))
 			->run($this->httpExceptionMock, [
 				'friendica_verbose' => true,
@@ -43,22 +44,10 @@ class SentTest extends ApiTestCase
 	{
 		$directMessage = new DirectMessage(DI::logger(), DI::dba(), DI::twitterUser());
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Sent($directMessage, DI::dba(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
 			->run($this->httpExceptionMock);
 
 		self::assertXml((string) $response->getBody(), 'direct-messages');
-	}
-
-	/**
-	 * Test the api_direct_messages_box() function without an authenticated user.
-	 *
-	 */
-	public function testApiDirectMessagesBoxWithUnallowedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		//$this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		//BasicAuth::setCurrentUserID();
-		//api_direct_messages_box('json', 'sentbox', 'false');
 	}
 }

--- a/tests/src/Module/Api/Twitter/FavoritesTest.php
+++ b/tests/src/Module/Api/Twitter/FavoritesTest.php
@@ -25,6 +25,7 @@ class FavoritesTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'page'   => -1,
@@ -48,6 +49,7 @@ class FavoritesTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Favorites(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_RSS,
 		]))->run($this->httpExceptionMock);
@@ -55,18 +57,5 @@ class FavoritesTest extends ApiTestCase
 		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
 
 		self::assertXml((string) $response->getBody(), 'statuses');
-	}
-
-	/**
-	 * Test the api_favorites() function with an unallowed user.
-	 *
-	 */
-	public function testApiFavoritesWithUnallowedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		// BasicAuth::setCurrentUserID();
-		// api_favorites('json');
 	}
 }

--- a/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
+++ b/tests/src/Module/Api/Twitter/Lists/StatusesTest.php
@@ -24,6 +24,7 @@ class StatusesTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
+		// @phpstan-ignore method.deprecated
 		(new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
@@ -36,6 +37,7 @@ class StatusesTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'list_id' => 1,
@@ -59,24 +61,12 @@ class StatusesTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Statuses(DI::dba(), DI::twitterStatus(), DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => 'rss']))
 			->run($this->httpExceptionMock, [
 				'list_id' => 1,
 			]);
 
 		self::assertXml((string) $response->getBody());
-	}
-
-	/**
-	 * Test the api_lists_statuses() function with an unallowed user.
-	 *
-	 */
-	public function testApiListsStatusesWithUnallowedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		// BasicAuth::setCurrentUserID();
-		// api_lists_statuses('json');
 	}
 }

--- a/tests/src/Module/Api/Twitter/Statuses/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/DestroyTest.php
@@ -31,22 +31,9 @@ class DestroyTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
+		// @phpstan-ignore method.deprecated
 		(new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
-	}
-
-	/**
-	 * Test the api_statuses_destroy() function without an authenticated user.
-	 *
-	 */
-	public function testApiStatusesDestroyWithoutAuthenticatedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		// BasicAuth::setCurrentUserID();
-		// $_SESSION['authenticated'] = false;
-		// api_statuses_destroy('json');
 	}
 
 	/**
@@ -56,6 +43,7 @@ class DestroyTest extends ApiTestCase
 	 */
 	public function testApiStatusesDestroyWithId(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 1,

--- a/tests/src/Module/Api/Twitter/Statuses/MentionsTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/MentionsTest.php
@@ -21,6 +21,7 @@ class MentionsTest extends ApiTestCase
 	 */
 	public function testApiStatusesMentions(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'max_id' => 10,
@@ -39,6 +40,7 @@ class MentionsTest extends ApiTestCase
 	 */
 	public function testApiStatusesMentionsWithNegativePage(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'page' => -2,
@@ -51,25 +53,13 @@ class MentionsTest extends ApiTestCase
 	}
 
 	/**
-	 * Test the api_statuses_mentions() function with an unallowed user.
-	 *
-	 */
-	public function testApiStatusesMentionsWithUnallowedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		// BasicAuth::setCurrentUserID();
-		// api_statuses_mentions('json');
-	}
-
-	/**
 	 * Test the api_statuses_mentions() function with an RSS result.
 	 *
 	 * @return void
 	 */
 	public function testApiStatusesMentionsWithRss(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Mentions(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]))
 			->run($this->httpExceptionMock, [
 				'page' => -2,

--- a/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/NetworkPublicTimelineTest.php
@@ -25,6 +25,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
+		// @phpstan-ignore method.deprecated
 		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'max_id' => 10,
@@ -50,6 +51,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
+		// @phpstan-ignore method.deprecated
 		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'page' => -2,
@@ -66,19 +68,6 @@ class NetworkPublicTimelineTest extends ApiTestCase
 	}
 
 	/**
-	 * Test the api_statuses_networkpublic_timeline() function with an unallowed user.
-	 *
-	 */
-	public function testApiStatusesNetworkpublicTimelineWithUnallowedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		// BasicAuth::setCurrentUserID();
-		// api_statuses_networkpublic_timeline('json');
-	}
-
-	/**
 	 * Test the api_statuses_networkpublic_timeline() function with an RSS result.
 	 *
 	 * @return void
@@ -88,6 +77,7 @@ class NetworkPublicTimelineTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
+		// @phpstan-ignore method.deprecated
 		$response = (new NetworkPublicTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_RSS,
 		]))->run($this->httpExceptionMock, [

--- a/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/RetweetTest.php
@@ -32,22 +32,9 @@ class RetweetTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
+		// @phpstan-ignore method.deprecated
 		(new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
-	}
-
-	/**
-	 * Test the api_statuses_repeat() function without an authenticated user.
-	 *
-	 */
-	public function testApiStatusesRepeatWithoutAuthenticatedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		// BasicAuth::setCurrentUserID();
-		// $_SESSION['authenticated'] = false;
-		// api_statuses_repeat('json');
 	}
 
 	/**
@@ -57,6 +44,7 @@ class RetweetTest extends ApiTestCase
 	 */
 	public function testApiStatusesRepeatWithId(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 1,
@@ -77,6 +65,7 @@ class RetweetTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Retweet(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 5,

--- a/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/ShowTest.php
@@ -24,7 +24,7 @@ class ShowTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
-
+		// @phpstan-ignore method.deprecated
 		(new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
@@ -36,6 +36,7 @@ class ShowTest extends ApiTestCase
 	 */
 	public function testApiStatusesShowWithId(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 1,
@@ -57,6 +58,7 @@ class ShowTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Show(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id'           => 1,
@@ -71,18 +73,5 @@ class ShowTest extends ApiTestCase
 			self::assertIsInt($status->id);
 			self::assertIsString($status->text);
 		}
-	}
-
-	/**
-	 * Test the api_statuses_show() function with an unallowed user.
-	 *
-	 */
-	public function testApiStatusesShowWithUnallowedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		// BasicAuth::setCurrentUserID();
-		// api_statuses_show('json');
 	}
 }

--- a/tests/src/Module/Api/Twitter/Statuses/UpdateTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/UpdateTest.php
@@ -40,6 +40,7 @@ class UpdateTest extends ApiTestCase
 			],
 		];
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'status'                => 'Status content #friendica',
@@ -62,6 +63,7 @@ class UpdateTest extends ApiTestCase
 	 */
 	public function testApiStatusesUpdateWithHtml(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'htmlstatus' => '<b>Status content</b>',
@@ -70,48 +72,5 @@ class UpdateTest extends ApiTestCase
 		$json = $this->toJson($response);
 
 		self::assertStatus($json);
-	}
-
-	/**
-	 * Test the api_statuses_update() function without an authenticated user.
-	 *
-	 */
-	public function testApiStatusesUpdateWithoutAuthenticatedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		/*
-		$this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		BasicAuth::setCurrentUserID();
-		$_SESSION['authenticated'] = false;
-		api_statuses_update('json');
-		*/
-	}
-
-	/**
-	 * Test the api_statuses_update() function with a parent status.
-	 *
-	 */
-	public function testApiStatusesUpdateWithParent(): void
-	{
-		$this->markTestIncomplete('This triggers an exit() somewhere and kills PHPUnit.');
-	}
-
-	/**
-	 * Test the api_statuses_update() function with a media_ids parameter.
-	 *
-	 */
-	public function testApiStatusesUpdateWithMediaIds(): void
-	{
-		$this->markTestIncomplete();
-	}
-
-	/**
-	 * Test the api_statuses_update() function with the throttle limit reached.
-	 *
-	 */
-	public function testApiStatusesUpdateWithDayThrottleReached(): void
-	{
-		$this->markTestIncomplete();
 	}
 }

--- a/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
+++ b/tests/src/Module/Api/Twitter/Statuses/UserTimelineTest.php
@@ -22,6 +22,7 @@ class UserTimelineTest extends ApiTestCase
 	 */
 	public function testApiStatusesUserTimeline(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'user_id'         => 43, // Public contact id
@@ -50,6 +51,7 @@ class UserTimelineTest extends ApiTestCase
 		// @todo: This call is needed for this test
 		Renderer::registerTemplateEngine(\Friendica\Render\FriendicaSmartyEngine::class);
 
+		// @phpstan-ignore method.deprecated
 		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'user_id' => 43, // Public contact id
@@ -73,6 +75,7 @@ class UserTimelineTest extends ApiTestCase
 	 */
 	public function testApiStatusesUserTimelineWithRss(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new UserTimeline(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], [
 			'extension' => ICanCreateResponses::TYPE_RSS,
 		]))->run($this->httpExceptionMock);
@@ -80,18 +83,5 @@ class UserTimelineTest extends ApiTestCase
 		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
 
 		self::assertXml((string) $response->getBody(), 'statuses');
-	}
-
-	/**
-	 * Test the api_statuses_user_timeline() function with an unallowed user.
-	 *
-	 */
-	public function testApiStatusesUserTimelineWithUnallowedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-
-		// $this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		// BasicAuth::setCurrentUserID();
-		// api_statuses_user_timeline('json');
 	}
 }


### PR DESCRIPTION
Followup of #16027

AI transparency: I'm developing this PR with this plan:

<details><summary>AI plan (in german)</summary>
<p>

``````
# Plan: `handleRequest()`-Test Coverage (Integration-basiert)

## Goal

Ersetze `run()`-basierte Modul-Tests durch `handleRequest()`-basierte Tests in
`tests/Integration/Module/` mit der **echten, geteilten MariaDB-Fixture**. Ermöglicht die
Hard-Deprecation von `run()` pro BC-Promise.

`tests/src/` bleibt **legacy**: keine neuen Tests. Nur:
- aktive `run()`-Tests bleiben unverändert (bekommen direkt davor `// @phpstan-ignore`)
- `markTestIncomplete`-Methoden werden gelöscht (ersetzt durch Integration-Tests)

## Architektur

| Suite | Zweck | Modul-Tests |
|-------|-------|-------------|
| `tests/Integration/Module/` | **einziges Zuhause** für neue Modul-Tests (Plumbing + Pre-DB + Daten) | ✅ ja |
| `tests/Unit/` | reine Logik, alles gemockt | nein |
| `tests/Functional/` | wird nicht für Modul-Tests genutzt | nein |
| `tests/src/` | **legacy, eingefroren** — nur Wartung, keine neuen Tests | nur bestehende |

**Warum keine DB-Mocks / keine SQLite:**
- DBA-Statics sind **nicht mockbar** (geladene statische Klassen; kein Test im Codebase mockt DBA)
- Die Test-DB ist keine langsame Einrichtung: `StaticDatabase` (tests/Util/Database/StaticDatabase.php)
  nutzt eine **pro Prozess geteilte MariaDB-Verbindung** mit Transaktions-Rollback pro Test —
  kein Schema-Neuaufbau, daher schnell
- SQLite ist kein Drop-in: Friendica-Schema ist MySQL-spezifisch (z.B. `MATCH ... AGAINST`
  in `Search.php:179`, `LOCK TABLES`, `information_schema`)

**Eine Ausnahme gibt es:** ein Test-Database-Subclass als **FULLTEXT-DB-Mock**
(`tests/Util/Database/StaticDatabaseWithFullTextSearch.php`). Der mockt keine DBA-Statics,
sondern ist der über Dice injizierte `Database`-Beans. Er ersetzt bei `post-searchindex`/
`post-engagement` die `MATCH ... AGAINST`-Bedingung durch ein äquivalentes
`` `searchtext` LIKE '%term%' ``. Grund: InnoDB indiziert FULLTEXT-Spalten **erst beim COMMIT**,
die Tests laufen aber in einer Transaktion mit Rollback → `MATCH` sieht frisch eingefügte Zeilen
nie. LIKE sieht sie. Injektion pro Test via opt-in Property `$databaseClass` in
`FixtureTestTrait::setUpFixtures()` (Zeile 46/51); alle anderen Tests behalten `StaticDatabase`.

## Status

| Komponente | Status |
|-----------|--------|
| `BaseModule::handleRequest()` | ✅ 4 Tests in `tests/Integration/Module/BaseModuleTest.php` |
| `BaseApi::handleRequest()` | ✅ 1 Test in `tests/Integration/Module/BaseApiTest.php` |
| `HTTPException\PageNotFound::handleRequest()` | ✅ 1 Test in `tests/src/` |
| `EarlyExitException` (PR #16029) | ✅ gemergt — `earlyJsonExit()`/`earlyHttpExit()` werfen `EarlyExitException` |
| `tests/Unit/BaseModuleTest.php` | ✅ Unit-Test: EarlyExitException trägt Response (anonyme Subklasse) |

---

## Arbeitsablauf (sequenziell, ein Subagent)

Die 46 Stellen werden **sequentiell** (niemals parallel) abgearbeitet. Es darf maximal **ein** Subagent aktiv sein.

### Schritt 0 — Basis prüfen (einmalig, vor dem Loop)

- `tests/Integration/Module/BaseModuleTest.php` + `BaseApiTest.php` laufen im `integration`-Testsuite grün
- Danach: PHPStan + `composer run test:integration` grün → Commit + Push (gleiche Pipeline-Regeln wie Schritt 3/4)

### Schritt 1 — Integration-Test erstellen

- Test-Datei in `tests/Integration/Module/` passend zur Modul-Struktur anlegen
  (Namespace `Friendica\Test\Integration\Module\...`)
- Basis: `Friendica\Test\ApiTestCase` (Fixture-DB, Auth-Helper via `authtest`-Addon)
- Alle Szenarien via `handleRequest()` testen — **reales Modul-Verhalten**, kein `content()`-Mock, kein DBA-Mock
- Modul-Instanzen wie in `tests/src/` erzeugen: `new ModuleClass(DI::..., ...)` (Konstruktor aus `src/Module/...`)
- **`earlyJsonExit()`/`earlyHttpExit()`-Module:** `handleRequest()` wirft `EarlyExitException` → in Test fangen und `getResponse()` asserten
- **`addJsonContent()`-Module:** `handleRequest()` liefert `ResponseInterface` normal
- **Daten-Szenarien** der ersetzten `markTestIncomplete`-Methoden werden **wirklich umgesetzt**
  (z.B. "Search liefert Status mit 'reply'"), nicht nur Pre-DB-Pfade
- **Unallowed-user-Szenarien:** `AuthTestConfig::$authenticated = false` (und ggf.
  `BasicAuth::setCurrentUserID()` leeren) → `checkAllowedScope` wirft via `EarlyExitException`
- **Ersetzte `markTestIncomplete`-Methoden** aus der `tests/src/`-Datei **löschen** (komplette Methode inkl. auskommentiertem Block entfernen)
- Bestehende aktive `run()`-Tests in `tests/src/` bleiben unverändert
- **Jeder `->run()`-Aufruf** in der `tests/src/`-Datei bekommt direkt davor einen `// @phpstan-ignore`-Kommentar
- **`.phpstan.neon` Counter** für `method.deprecated` (`Call to deprecated method run()`) um die Anzahl der neuen `@phpstan-ignore`-Zeilen reduzieren (aktuell: **95**, `.phpstan.neon` Zeile 57)

### Schritt 2 — Qualität sichern

- PHPStan: `docker compose -f .docker/compose.yaml exec app vendor/bin/phpstan analyse --memory-limit=4G`
- Integration-Tests: `docker compose -f .docker/compose.yaml exec app vendor/bin/phpunit -c tests/phpunit.xml --testsuite integration --testdox`
- Legacy-Tests: `docker compose -f .docker/compose.yaml exec app vendor/bin/phpunit -c tests/phpunit.xml --testsuite legacy --testdox`
- Bei Fehlern: fixen → zurück zu Schritt 2

### Schritt 3 — Commit & Push

```bash
git add -A && git commit -m "... Integration test for <Modul> via handleRequest()" && git push
```

> **Commit-Message-Regel:** Nie den Plan oder die Task-Nummer aus dem Plan in Commit-Messages erwähnen (z.B. kein "#10"). Commit-Messages beschreiben nur die Änderung selbst (z.B. "Add integration tests for Twitter Statuses Update").

Section A (#1–#8): via PR #16027 in `develop` gemergt (`d579a2626d`).
Section B (#9–#23): **PR <https://github.com/friendica/friendica/pull/16069>** (Branch `add-handlerequest-test-coverage-b`, Basis `develop`)

### Schritt 4 — Pipeline beobachten

- Warten bis GitHub Actions auf PR #16069 durchgelaufen ist
- **Pipeline failed** → `git reset --soft HEAD~1`, nachbessern, `git commit`, `git push --force-with-lease` → zurück zu Schritt 4
- **Pipeline grün** → Stelle erledigt

### Schritt 5 — Nächste Stelle

- Pipeline grün → **Checkbox in der Checkliste anhaken** (`- [ ]` → `- [x]`)
- Dann weiter mit nächster Stelle
- Niemals parallel, maximal ein Subagent

---

## Checkliste

### ✅ Erledigt (vor Loop)

- [x] `BaseModule::handleRequest()` GET, POST, Exception, Query Params — `tests/Integration/Module/`
- [x] `BaseApi::handleRequest()` GET — `tests/Integration/Module/`
- [x] `EarlyExitException` (PR #16029) — `earlyJsonExit()`/`earlyHttpExit()` werfen `EarlyExitException`
- [x] `tests/Unit/BaseModuleTest.php` — Unit-Test: EarlyExitException trägt Response (anonyme Subklasse, kein DB)

### A — Incomplete-only (8 Stellen)

Keine aktiven `run()`-Tests. `markTestIncomplete` in allen Methoden. Test von Grund auf neu (inkl. Daten-Szenarien).

- [x] **#1** `Mastodon\Search` — `tests/Integration/Module/Api/Mastodon/SearchTest.php` (7 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#2** `Mastodon\Timelines\PublicTimeline` — `.../Api/Mastodon/Timelines/PublicTimelineTest.php` (5 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#3** `Mastodon\Timelines\Home` — `.../Api/Mastodon/Timelines/HomeTest.php` (4 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#4** `Mastodon\Conversations` — `.../Api/Mastodon/ConversationsTest.php` (3 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#5** `Mastodon\Accounts\Statuses` — `.../Api/Mastodon/Accounts/StatusesTest.php` (2 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#6** `Twitter\ContactEndpoint` — `.../Api/Twitter/ContactEndpointTest.php` (4 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#7** `Mastodon\PushSubscription` — `.../Api/Mastodon/PushSubscriptionTest.php` (2 inc) — 6 Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#8** `ApiResponse` — komplett nach `tests/Integration/Module/Api/ApiResponseTest.php` migriert (17 Tests: 15 Formattests + 2 RSS-Extra, reale Fixture-Daten), legacy-Datei gelöscht

### B — Mixed (active `run()` + incomplete) — 15 Stellen

- [x] **#9** `Mastodon\Accounts\VerifyCredentials` — 1 active + 1 inc (unallowed user) — Integration-Tests angelegt (Commit `5b4e1c71e4`), Legacy run()-Test behalten + `@phpstan-ignore`, Pipeline grün
- [x] **#10** `Twitter\Statuses\Update` — 2 active + 4 inc (parent, media_ids, throttle, unauth) — 6 Integration-Tests (Commit `7c1a0cf418`), 4 Incompletes gelöscht, Pipeline grün
- [x] **#11** `Twitter\Favorites` — 2 active + 1 inc (unallowed user) — 3 Integration-Tests (Commit `20c120aff2`), Pipeline grün
- [x] **#12** `Twitter\Statuses\Mentions` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `d5cfce47c8`)
- [x] **#13** `Twitter\Statuses\UserTimeline` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `db9659bb92`)
- [x] **#14** `Twitter\Statuses\Retweet` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `04b1f3e9d4`)
- [x] **#15** `Twitter\Statuses\Show` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `114c61d561`)
- [x] **#16** `Twitter\Statuses\Destroy` — 2 active + 1 inc (unallowed user) — 3 Integration-Tests (Commit `6b630fc019`)
- [x] **#17** `Twitter\Statuses\NetworkPublicTimeline` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `a45e8e4908`)
- [x] **#18** `Twitter\Lists\Statuses` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `2c0a57909a`)
- [x] **#19** `Twitter\DirectMessages\Sent` — 2 active + 1 inc (unallowed user) — 5 Integration-Tests inkl. Daten-Szenario (Commit `b48f1acf35`)
- [x] **#20** `Twitter\DirectMessages\NewDM` — 5 active + 1 inc (unallowed user) — 7 Integration-Tests inkl. Daten-Szenario (Commit `a5ca082a4f`)
- [x] **#21** `Twitter\DirectMessages\Destroy` — 5 active + 1 inc (unallowed user) — 6 Integration-Tests inkl. Daten-Szenario (Commit `475f42f423`)
- [x] **#22** `Friendica\Notification` — 2 active + 2 inc (empty, unauth) — 4 Integration-Tests inkl. leeres-Szenario (Commit `84e70a785f`)
- [x] **#23** `Friendica\Photo\Delete` — 4 active + 1 inc (unallowed user) — 5 Integration-Tests inkl. echtem Lösch-Szenario (Commit `a017035a59`)

### C — Mixed Fortsetzung — 5 Stellen

- [ ] **#24** `Friendica\Photoalbum\Update` — 4 active + 1 inc (unallowed user)
- [ ] **#25** `Twitter\Friendships\Incoming` — 1 active + 1 inc (undefined cursor)
- [ ] **#26** `Twitter\Followers\Lists` — 1 active + 1 inc (undefined cursor)
- [ ] **#27** `Twitter\Friends\Lists` — 1 active + 1 inc (undefined cursor)
- [ ] **#28** `Twitter\Blocks\Lists` — 1 active + 1 inc (undefined cursor)

### D — Nur `run()`-Tests (keine incomplete) — 18 Stellen

- [ ] **#29** `NodeInfo110|120|210` — 3 active, GET-only, kein Auth
- [ ] **#30** `Special\Options` — 2 active, OPTIONS/CORS, kein Auth
- [ ] **#31** `StatsCaching` — 6 active, GET, kein Auth
- [ ] **#32** `Twitter\Favorites\Create` — 3 active, POST: Fav + auth
- [ ] **#33** `Twitter\Favorites\Destroy` — 2 active, POST: Unfav + auth
- [ ] **#34** `Twitter\SavedSearches` — 1 active, GET
- [ ] **#35** `Twitter\Users\Show` — 2 active, GET
- [ ] **#36** `Twitter\Users\Lookup` — 2 active, GET
- [ ] **#37** `Twitter\Users\Search` — 2 active, GET
- [ ] **#38** `Twitter\Account\RateLimitStatus` — 2 active, GET
- [ ] **#39** `Twitter\Account\UpdateProfile` — 1 active, POST
- [ ] **#40** `Twitter\Media\Upload` — 4 active, POST
- [ ] **#41** `Twitter\DirectMessages\All` — 1 active, GET
- [ ] **#42** `Twitter\DirectMessages\Inbox` — 1 active, GET
- [ ] **#43** `Twitter\DirectMessages\Conversation` — 1 active, GET
- [ ] **#44** `Friendica\Photoalbum\Delete` — 3 active, POST
- [ ] **#45** `Friendica\DirectMessages\Search` — 3 active, GET
- [ ] **#46** `GnuSocial\Version|Config|Help\Test` — 4 active, GET-only

---

## Test-Pattern

Basis aller neuen Tests: `Friendica\Test\ApiTestCase` (Namespace `Friendica\Test\Integration\Module\...`).
Modul-Instanzen wie in `tests/src/` erzeugen, aber `handleRequest()` statt `run()` aufrufen.
Query/Form-Parameter via PSR-7 `ServerRequest` statt `$_REQUEST`/Array.

### Pattern A — Modul mit `earlyJsonExit()` (wirft `EarlyExitException`)

```php
namespace Friendica\Test\Integration\Module\Api\Mastodon;

use Friendica\Core\EarlyExitException;
use Friendica\DI;
use Friendica\Module\Api\Mastodon\Search;
use Friendica\Test\ApiTestCase;
use GuzzleHttp\Psr7\ServerRequest;

final class SearchTest extends ApiTestCase
{
	public function testApiSearch(): void
	{
		$request = (new ServerRequest('GET', 'https://friendica.local/api/v2/search'))
			->withQueryParams(['q' => 'reply']);

		$module = new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);

		try {
			$module->handleRequest($request);
			self::fail('Expected EarlyExitException');
		} catch (EarlyExitException $e) {
			$json = $this->toJson($e->getResponse());
			foreach ($json->statuses as $status) {
				self::assertStringContainsStringIgnoringCase('reply', $status->text);
			}
		}
	}
}
```

### Pattern B — Modul mit `addJsonContent()` (liefert Response normal)

```php
public function testApiVerifyCredentials(): void
{
	$request = new ServerRequest('GET', 'https://friendica.local/api/v1/accounts/verify_credentials');

	$module = new VerifyCredentials(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);

	$response = $module->handleRequest($request);

	self::assertEquals(200, $response->getStatusCode());
	self::assertJson((string) $response->getBody());
}
```

### Pattern C — Auth-Fail / Fehlerfall (unallowed user)

```php
public function testApiSearchWithUnallowedUser(): void
{
	AuthTestConfig::$authenticated = false;

	$request = (new ServerRequest('GET', 'https://friendica.local/api/v2/search'))
		->withQueryParams(['q' => 'test']);

	$module = new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);

	try {
		$module->handleRequest($request);
		self::fail('Expected EarlyExitException');
	} catch (EarlyExitException $e) {
		self::assertEquals(401, $e->getResponse()->getStatusCode());
	}
}
```

### Hinweise

- **setLinkHeader** (Plan 03, im Review): Module rufen noch `header()` direkt auf → Link-Header kann in Tests noch nicht asserted werden. Statuscode/JSON-Body funktionieren trotzdem.
- **Auth**: `ApiTestCase::setUp()` setzt `AuthTestConfig::$authenticated = true` (uid 42). Für unauth-Tests im Test überschreiben. Vorbild: `tests/src/Module/Api/Twitter/Media/UploadTest.php:47`.
- **Search-Daten-Szenarien**: `Search::searchStatuses()` nutzt `MATCH ... AGAINST` auf `post-searchindex` (FULLTEXT). Im Test-Setup (Transaktion + Rollback) liefert FULLTEXT **keine** frisch eingefügten Zeilen (Index entsteht erst beim COMMIT). Lösung (implementiert & grün): `StaticDatabaseWithFullTextSearch` als `$databaseClass` in `SearchTest` aktivieren → der Mock-Database rewritet die MATCH-Bedingung auf `LIKE '%term%'`, Datenpfad end-to-end testbar. Suchtabellen: `post-searchindex` (Standard) bzw. `post-engagement` (config `limited_search_scope`).
- **Obsolete Twitter-Parameter**: `count`, `rpp`, `exclude_replies` aus den alten `markTestIncomplete`-Methoden existieren im Modul **nicht mehr** (nur `limit`, `offset`, `max_id`, `min_id`, `resolve`, `following`). Die Fälle wurden auf die modernen Entsprechungen abgebildet: `count`/`rpp` → `limit`, `exclude_replies`+`max_id` → `max_id`. Für Pagination-Tests werden 2 `post-searchindex`-Zeilen (uri-id 6 + 7) eingefügt.
- **Response-Struktur**: `earlyJsonExit()` gibt entweder eine **JSON-Liste** zurück (Timelines, Sammlungen → direkt iterieren) oder ein **Objekt** (`{statuses: ...}`, `{accounts: ...}` bei Search). Vor dem Test die tatsächliche Form am Modul prüfen — `$json->statuses` auf einer Liste liefert `null` (typische Fehlerspur: `assertCount()` mit `null` statt `Countable`).
- **Debug-Helfer**: View-/DB-Queries im Test direkt reproduzierbar: `DBA::p("SELECT \`uri-id\` FROM \`post-timeline-view\` " . DBA::buildCondition($cond), $cond)`. Felder mit Bindestrich (`` `uri-id` ``) **müssen** gequotet werden, sonst `Unknown column 'uri'`. Temporäre `fwrite(STDERR, ...)`-Dumps der Roh-Antwort sind der schnellste Weg, Modul-Ausgaben zu inspizieren.
- **PublicTimeline**: PublicTimeline ist ohne Auth erreichbar; Unallowed-user nur mit `system.block_public=true` erzwingbar (401). Timeline-Queries laufen über Views (`post-timeline-thread-view`/`post-timeline-view`/`post-timeline-origin-view`) — Fixture liefert für public/exclude_replies reale Daten; `local=true` hat nur 1 Fixture-Post (`post-origin`-Daten fehlen). Obsolete Fälle: `page`, `conversation_id`, `rss` (Modul nur noch JSON).
- **#3 Home (Vorschau)**: `Home` erfordert im Gegensatz zu `PublicTimeline` **immer** Auth (`getCurrentUserID`/`checkAllowedScope`) → Unallowed-user-Fall ohne Zusatz-Config testbar.
- **Modul-Konstruktoren**: Jedes Modul hat eigene Dependencies. Die `new ModuleClass(DI::...)`-Aufrufe direkt aus den bestehenden `tests/src/`-Tests übernehmen.

## Messkriterien

- `markTestIncomplete` sinkt von 57 → 0 (nur die neuen Tests ersetzen sie)
- Neue Dateien in `tests/Integration/Module/` (46 Dateien, spiegelbildlich zu `src/Module/...`)
- Basis-Tests (`BaseModuleTest`, `BaseApiTest`) laufen im `integration`-Testsuite
- PHPStan: keine neuen Fehler; `.phpstan.neon`-Counter für `method.deprecated` (run()) sinkt um Anzahl der `@phpstan-ignore`-Zeilen
- Bestehende Tests in `tests/src/` bleiben unverändert (nur `markTestIncomplete`-Methoden + `@phpstan-ignore`-Zeilen)
- `tests/Functional/` bleibt unberührt

``````

</p>
</details> 

This PR continues the `handleRequest()` test coverage started in part 1 (#16027).
It migrates the remaining "mixed" test classes – the ones with active `run()` tests plus `markTestIncomplete` methods – to integration tests in `tests/Integration/Module/`.

The active `run()` tests stay in `tests/src/` for BC and get a `// @phpstan-ignore` comment. The `markTestIncomplete` methods are removed and replaced by real `handleRequest()` tests (incl. data scenarios).

Covers: VerifyCredentials, Statuses\Update, Favorites, Statuses\Mentions/UserTimeline/Retweet/Show/Destroy/NetworkPublicTimeline, Lists\Statuses, DirectMessages\Sent/NewDM/Destroy, Notification, Photo\Delete.

I split this task into multiple PRs, or this PR will become too big.