### PR TITLE
Add `handleRequest()` test coverage part 3

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 46
+            count: 45
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 47
+            count: 46
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 53
+            count: 49
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 49
+            count: 48
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 45
+            count: 42
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 48
+            count: 47
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -54,7 +54,7 @@ parameters:
             message: '#^Call to deprecated method run\(\) of class#'
             identifier: method.deprecated
             path: tests/
-            count: 42
+            count: 40
 
         # vfsStream v1.6.12: getChild() returns vfsStreamContent, but at() expects
         # vfsStreamContainer. vfsStreamContainer does NOT extend vfsStreamContent,

--- a/tests/Integration/Module/Api/Friendica/Photoalbum/UpdateTest.php
+++ b/tests/Integration/Module/Api/Friendica/Photoalbum/UpdateTest.php
@@ -1,0 +1,126 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Friendica\Photoalbum;
+
+use Friendica\App\Router;
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Module\Api\Friendica\Photoalbum\Update;
+use Friendica\Network\HTTPException\BadRequestException;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class UpdateTest extends ApiTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->useHttpMethod(Router::POST);
+	}
+
+	public function testApiPhotoalbumUpdateWithoutData(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$request = new ServerRequest('POST', 'https://friendica.local/api/friendica/photoalbum/update');
+
+		$this->createModule()->handleRequest($request);
+	}
+
+	public function testApiPhotoalbumUpdateWithOnlyAlbumName(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/friendica/photoalbum/update'))
+			->withParsedBody([
+				'album' => 'album_name',
+			]);
+
+		$this->createModule()->handleRequest($request);
+	}
+
+	public function testApiPhotoalbumUpdateWithNotExistingAlbum(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/friendica/photoalbum/update'))
+			->withParsedBody([
+				'album'     => 'album_name',
+				'album_new' => 'album_name',
+			]);
+
+		$this->createModule()->handleRequest($request);
+	}
+
+	public function testApiPhotoalbumUpdateValid(): void
+	{
+		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/friendica/photoalbum/update'))
+			->withParsedBody([
+				'album'     => 'test_album',
+				'album_new' => 'test_album_2',
+			]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertEquals('updated', $json->result);
+		self::assertEquals('album `test_album` with all containing photos has been renamed to `test_album_2`.', $json->message);
+
+		self::assertFalse(DI::dba()->exists('photo', ['uid' => 42, 'album' => 'test_album']));
+		self::assertTrue(DI::dba()->exists('photo', ['uid' => 42, 'album' => 'test_album_2']));
+	}
+
+	public function testApiPhotoalbumUpdateWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/friendica/photoalbum/update'))
+			->withParsedBody([
+				'album'     => 'test_album',
+				'album_new' => 'test_album_2',
+			]);
+
+		$module = $this->createModule();
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(array $parameters = []): Update
+	{
+		return new Update(
+			DI::mstdnError(),
+			DI::appHelper(),
+			DI::l10n(),
+			DI::baseUrl(),
+			DI::args(),
+			DI::logger(),
+			DI::profiler(),
+			DI::apiResponse(),
+			[],
+			$parameters,
+		);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Blocks/ListsTest.php
+++ b/tests/Integration/Module/Api/Twitter/Blocks/ListsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Blocks;
+
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Blocks\Lists;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class ListsTest extends ApiTestCase
+{
+	public function testApiStatusesFWithBlocks(): void
+	{
+		DI::dba()->insert('user-contact', [
+			'uid'     => 42,
+			'cid'     => 45,
+			'blocked' => true,
+		]);
+		DI::dba()->insert('user-contact', [
+			'uid'     => 42,
+			'cid'     => 47,
+			'blocked' => true,
+		]);
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/blocks/list');
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->users);
+		self::assertSame(2, $json->total_count);
+		self::assertSame([47, 45], array_map(static function ($user) {
+			return $user->pid;
+		}, $json->users));
+	}
+
+	public function testApiBlocksListWithUndefinedCursor(): void
+	{
+		DI::dba()->insert('user-contact', [
+			'uid'     => 42,
+			'cid'     => 45,
+			'blocked' => true,
+		]);
+		DI::dba()->insert('user-contact', [
+			'uid'     => 42,
+			'cid'     => 47,
+			'blocked' => true,
+		]);
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/blocks/list'))
+			->withQueryParams(['cursor' => 'undefined']);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->users);
+		self::assertSame(2, $json->total_count);
+		self::assertSame([47, 45], array_map(static function ($user) {
+			return $user->pid;
+		}, $json->users));
+	}
+
+	public function testApiBlocksListWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/blocks/list');
+
+		try {
+			$this->createModule()->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) {
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): Lists
+	{
+		return new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Favorites/CreateTest.php
+++ b/tests/Integration/Module/Api/Twitter/Favorites/CreateTest.php
@@ -1,0 +1,116 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Favorites;
+
+use Friendica\App\Router;
+use Friendica\Capabilities\ICanCreateResponses;
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Model\Item;
+use Friendica\Model\Verb;
+use Friendica\Module\Api\Twitter\Favorites\Create;
+use Friendica\Network\HTTPException\BadRequestException;
+use Friendica\Protocol\Activity;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class CreateTest extends ApiTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->useHttpMethod(Router::POST);
+	}
+
+	public function testApiFavoritesCreateDestroyWithInvalidId(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$request = new ServerRequest('POST', 'https://friendica.local/api/favorites/create.json');
+
+		$this->createModule()->handleRequest($request);
+	}
+
+	public function testApiFavoritesCreateDestroyWithCreateAction(): void
+	{
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/favorites/create.json'))
+			->withParsedBody(['id' => 3]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+		self::assertEquals(3, $json->id);
+		self::assertTrue($json->favorited);
+
+		self::assertTrue(DI::dba()->exists('post-user', [
+			'uid'           => 42,
+			'thr-parent-id' => 3,
+			'vid'           => Verb::getID(Activity::LIKE),
+			'gravity'       => Item::GRAVITY_ACTIVITY,
+			'deleted'       => false,
+		]));
+	}
+
+	public function testApiFavoritesCreateDestroyWithCreateActionAndRss(): void
+	{
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/favorites/create.json'))
+			->withParsedBody(['id' => 3]);
+
+		$response = $this->createModule(['extension' => ICanCreateResponses::TYPE_RSS])->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
+
+		self::assertXml((string) $response->getBody(), 'statuses');
+	}
+
+	public function testApiFavoritesCreateDestroyWithoutAuthenticatedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/favorites/create.json'))
+			->withParsedBody(['id' => 3]);
+
+		$module = $this->createModule();
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(array $parameters = []): Create
+	{
+		return new Create(
+			DI::mstdnError(),
+			DI::appHelper(),
+			DI::l10n(),
+			DI::baseUrl(),
+			DI::args(),
+			DI::logger(),
+			DI::profiler(),
+			DI::apiResponse(),
+			[],
+			$parameters,
+		);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Favorites/DestroyTest.php
+++ b/tests/Integration/Module/Api/Twitter/Favorites/DestroyTest.php
@@ -1,0 +1,129 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Favorites;
+
+use Friendica\App\Router;
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Model\Item;
+use Friendica\Model\Verb;
+use Friendica\Module\Api\ApiResponse;
+use Friendica\Module\Api\Twitter\Favorites\Create;
+use Friendica\Module\Api\Twitter\Favorites\Destroy;
+use Friendica\Network\HTTPException\BadRequestException;
+use Friendica\Protocol\Activity;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class DestroyTest extends ApiTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->useHttpMethod(Router::POST);
+	}
+
+	public function testApiFavoritesCreateDestroyWithInvalidId(): void
+	{
+		$this->expectException(BadRequestException::class);
+
+		$request = new ServerRequest('POST', 'https://friendica.local/api/favorites/destroy.json');
+
+		$this->createModule()->handleRequest($request);
+	}
+
+	public function testApiFavoritesCreateDestroyWithDestroyAction(): void
+	{
+		$createRequest = (new ServerRequest('POST', 'https://friendica.local/api/favorites/create.json'))
+			->withParsedBody(['id' => 3]);
+
+		$createModule = new Create(
+			DI::mstdnError(),
+			DI::appHelper(),
+			DI::l10n(),
+			DI::baseUrl(),
+			DI::args(),
+			DI::logger(),
+			DI::profiler(),
+			new ApiResponse(DI::l10n(), DI::args(), DI::logger(), DI::baseUrl(), DI::twitterUser()),
+			[],
+		);
+
+		$createModule->handleRequest($createRequest);
+
+		self::assertTrue(DI::dba()->exists('post-user', [
+			'uid'           => 42,
+			'thr-parent-id' => 3,
+			'vid'           => Verb::getID(Activity::LIKE),
+			'gravity'       => Item::GRAVITY_ACTIVITY,
+			'deleted'       => false,
+		]));
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/favorites/destroy.json'))
+			->withParsedBody(['id' => 3]);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertStatus($json);
+		self::assertEquals(3, $json->id);
+		self::assertFalse($json->favorited);
+
+		self::assertFalse(DI::dba()->exists('post-user', [
+			'uid'           => 42,
+			'thr-parent-id' => 3,
+			'vid'           => Verb::getID(Activity::LIKE),
+			'gravity'       => Item::GRAVITY_ACTIVITY,
+			'deleted'       => false,
+		]));
+	}
+
+	public function testApiFavoritesCreateDestroyWithoutAuthenticatedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = (new ServerRequest('POST', 'https://friendica.local/api/favorites/destroy.json'))
+			->withParsedBody(['id' => 3]);
+
+		$module = $this->createModule();
+
+		try {
+			$module->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(array $parameters = []): Destroy
+	{
+		return new Destroy(
+			DI::mstdnError(),
+			DI::appHelper(),
+			DI::l10n(),
+			DI::baseUrl(),
+			DI::args(),
+			DI::logger(),
+			DI::profiler(),
+			DI::apiResponse(),
+			[],
+			$parameters,
+		);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Followers/ListsTest.php
+++ b/tests/Integration/Module/Api/Twitter/Followers/ListsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Followers;
+
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Followers\Lists;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class ListsTest extends ApiTestCase
+{
+	public function testApiStatusesFWithFollowers(): void
+	{
+		$request = new ServerRequest('GET', 'https://friendica.local/api/followers/list');
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->users);
+		self::assertSame(1, $json->total_count);
+		self::assertSame(47, $json->users[0]->pid);
+	}
+
+	public function testApiStatusesFollowersWithUndefinedCursor(): void
+	{
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/followers/list'))
+			->withQueryParams(['cursor' => 'undefined']);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->users);
+		self::assertSame(1, $json->total_count);
+		self::assertSame(47, $json->users[0]->pid);
+	}
+
+	public function testApiStatusesFollowersWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/followers/list');
+
+		try {
+			$this->createModule()->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) {
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): Lists
+	{
+		return new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Friends/ListsTest.php
+++ b/tests/Integration/Module/Api/Twitter/Friends/ListsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Friends;
+
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Friends\Lists;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class ListsTest extends ApiTestCase
+{
+	public function testApiStatusesFWithFriends(): void
+	{
+		$request = new ServerRequest('GET', 'https://friendica.local/api/friends/list');
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->users);
+		self::assertSame(2, $json->total_count);
+		self::assertSame([47, 45], array_map(static function ($user) {
+			return $user->pid;
+		}, $json->users));
+	}
+
+	public function testApiStatusesFriendsWithUndefinedCursor(): void
+	{
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/friends/list'))
+			->withQueryParams(['cursor' => 'undefined']);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->users);
+		self::assertSame(2, $json->total_count);
+		self::assertSame([47, 45], array_map(static function ($user) {
+			return $user->pid;
+		}, $json->users));
+	}
+
+	public function testApiStatusesFriendsWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/friends/list');
+
+		try {
+			$this->createModule()->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) {
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): Lists
+	{
+		return new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/Integration/Module/Api/Twitter/Friendships/IncomingTest.php
+++ b/tests/Integration/Module/Api/Twitter/Friendships/IncomingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Integration\Module\Api\Twitter\Friendships;
+
+use Friendica\Core\EarlyExitException;
+use Friendica\DI;
+use Friendica\Module\Api\Twitter\Friendships\Incoming;
+use Friendica\Test\ApiTestCase;
+use Friendica\Test\Util\AuthTestConfig;
+use GuzzleHttp\Psr7\ServerRequest;
+
+final class IncomingTest extends ApiTestCase
+{
+	public function testApiFriendshipsIncoming(): void
+	{
+		DI::dba()->insert('intro', [
+			'uid'        => 42,
+			'contact-id' => 43,
+		]);
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/friendships/incoming');
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->ids);
+		self::assertSame([43], $json->ids);
+		self::assertSame(1, $json->total_count);
+	}
+
+	public function testApiFriendshipsIncomingWithUndefinedCursor(): void
+	{
+		DI::dba()->insert('intro', [
+			'uid'        => 42,
+			'contact-id' => 43,
+		]);
+
+		$request = (new ServerRequest('GET', 'https://friendica.local/api/friendships/incoming'))
+			->withQueryParams(['cursor' => 'undefined']);
+
+		$response = $this->createModule()->handleRequest($request);
+
+		self::assertEquals(200, $response->getStatusCode());
+
+		$json = $this->toJson($response);
+
+		self::assertIsArray($json->ids);
+		self::assertSame([43], $json->ids);
+		self::assertSame(1, $json->total_count);
+	}
+
+	public function testApiFriendshipsIncomingWithUnallowedUser(): void
+	{
+		AuthTestConfig::$authenticated = false;
+
+		$request = new ServerRequest('GET', 'https://friendica.local/api/friendships/incoming');
+
+		try {
+			$this->createModule()->handleRequest($request);
+			self::fail('Expected EarlyExitException');
+		} catch (EarlyExitException $e) {
+			self::assertEquals(401, $e->getResponse()->getStatusCode());
+
+			$json = $this->toJson($e->getResponse());
+
+			self::assertObjectHasProperty('error', $json);
+		}
+	}
+
+	private function createModule(): Incoming
+	{
+		return new Incoming(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);
+	}
+}

--- a/tests/src/Module/Api/Friendica/Photoalbum/UpdateTest.php
+++ b/tests/src/Module/Api/Friendica/Photoalbum/UpdateTest.php
@@ -25,6 +25,8 @@ class UpdateTest extends ApiTestCase
 	public function testEmpty(): void
 	{
 		$this->expectException(BadRequestException::class);
+
+		// @phpstan-ignore method.deprecated
 		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
@@ -32,6 +34,8 @@ class UpdateTest extends ApiTestCase
 	public function testTooFewArgs(): void
 	{
 		$this->expectException(BadRequestException::class);
+
+		// @phpstan-ignore method.deprecated
 		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'album' => 'album_name',
@@ -41,6 +45,8 @@ class UpdateTest extends ApiTestCase
 	public function testWrongUpdate(): void
 	{
 		$this->expectException(BadRequestException::class);
+
+		// @phpstan-ignore method.deprecated
 		(new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'album'     => 'album_name',
@@ -48,15 +54,11 @@ class UpdateTest extends ApiTestCase
 			]);
 	}
 
-	public function testWithoutAuthenticatedUser(): void
-	{
-		self::markTestIncomplete('Needs BasicAuth as dynamic method for overriding first');
-	}
-
 	public function testValid(): void
 	{
 		$this->loadFixture(__DIR__ . '/../../../../../Fixtures/photo/photo.fixture.php', DI::dba());
 
+		// @phpstan-ignore method.deprecated
 		$response = (new Update(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'album'     => 'test_album',

--- a/tests/src/Module/Api/Twitter/Blocks/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Blocks/ListsTest.php
@@ -18,23 +18,12 @@ class ListsTest extends ApiTestCase
 	 */
 	public function testApiStatusesFWithBlocks(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
 
 		self::assertIsArray($json->users);
-	}
-
-	/**
-	 * Test the api_blocks_list() function an undefined cursor GET variable.
-	 *
-	 */
-	public function testApiBlocksListWithUndefinedCursor(): void
-	{
-		self::markTestIncomplete('Needs refactoring of Lists - replace filter_input() with $request parameter checks');
-
-		// $_GET['cursor'] = 'undefined';
-		// self::assertFalse(api_blocks_list('json'));
 	}
 }

--- a/tests/src/Module/Api/Twitter/Favorites/CreateTest.php
+++ b/tests/src/Module/Api/Twitter/Favorites/CreateTest.php
@@ -32,6 +32,7 @@ class CreateTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
+		// @phpstan-ignore method.deprecated
 		(new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
@@ -43,6 +44,7 @@ class CreateTest extends ApiTestCase
 	 */
 	public function testApiFavoritesCreateDestroyWithCreateAction(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 3,
@@ -60,6 +62,7 @@ class CreateTest extends ApiTestCase
 	 */
 	public function testApiFavoritesCreateDestroyWithCreateActionAndRss(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Create(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), [], ['extension' => ICanCreateResponses::TYPE_RSS]))
 			->run($this->httpExceptionMock, [
 				'id' => 3,
@@ -68,22 +71,5 @@ class CreateTest extends ApiTestCase
 		self::assertEquals(ICanCreateResponses::TYPE_RSS, $response->getHeaderLine(ICanCreateResponses::X_HEADER));
 
 		self::assertXml((string) $response->getBody(), 'statuses');
-	}
-
-	/**
-	 * Test the api_favorites_create_destroy() function without an authenticated user.
-	 *
-	 */
-	public function testApiFavoritesCreateDestroyWithoutAuthenticatedUser(): void
-	{
-		self::markTestIncomplete('Needs refactoring of Lists - replace filter_input() with $request parameter checks');
-
-		/*
-		$this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		DI::args()->setArgv(['api', '1.1', 'favorites', 'create.json']);
-		BasicAuth::setCurrentUserID();
-		$_SESSION['authenticated'] = false;
-		api_favorites_create_destroy('json');
-		*/
 	}
 }

--- a/tests/src/Module/Api/Twitter/Favorites/DestroyTest.php
+++ b/tests/src/Module/Api/Twitter/Favorites/DestroyTest.php
@@ -31,6 +31,7 @@ class DestroyTest extends ApiTestCase
 	{
 		$this->expectException(BadRequestException::class);
 
+		// @phpstan-ignore method.deprecated
 		(new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 	}
@@ -42,6 +43,7 @@ class DestroyTest extends ApiTestCase
 	 */
 	public function testApiFavoritesCreateDestroyWithDestroyAction(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Destroy(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock, [
 				'id' => 3,
@@ -50,22 +52,5 @@ class DestroyTest extends ApiTestCase
 		$json = $this->toJson($response);
 
 		self::assertStatus($json);
-	}
-
-	/**
-	 * Test the api_favorites_create_destroy() function without an authenticated user.
-	 *
-	 */
-	public function testApiFavoritesCreateDestroyWithoutAuthenticatedUser(): void
-	{
-		self::markTestIncomplete('Needs refactoring of Lists - replace filter_input() with $request parameter checks');
-
-		/*
-		$this->expectException(\Friendica\Network\HTTPException\UnauthorizedException::class);
-		DI::args()->setArgv(['api', '1.1', 'favorites', 'create.json']);
-		BasicAuth::setCurrentUserID();
-		$_SESSION['authenticated'] = false;
-		api_favorites_create_destroy('json');
-		*/
 	}
 }

--- a/tests/src/Module/Api/Twitter/Followers/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Followers/ListsTest.php
@@ -18,23 +18,12 @@ class ListsTest extends ApiTestCase
 	 */
 	public function testApiStatusesFWithFollowers(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
 
 		self::assertIsArray($json->users);
-	}
-
-	/**
-	 * Test the api_statuses_followers() function an undefined cursor GET variable.
-	 *
-	 */
-	public function testApiStatusesFollowersWithUndefinedCursor(): void
-	{
-		self::markTestIncomplete('Needs refactoring of Lists - replace filter_input() with $request parameter checks');
-
-		// $_GET['cursor'] = 'undefined';
-		// self::assertFalse(api_statuses_followers('json'));
 	}
 }

--- a/tests/src/Module/Api/Twitter/Friends/ListsTest.php
+++ b/tests/src/Module/Api/Twitter/Friends/ListsTest.php
@@ -20,23 +20,12 @@ class ListsTest extends ApiTestCase
 	 */
 	public function testApiStatusesFWithFriends(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Lists(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
 
 		self::assertIsArray($json->users);
-	}
-
-	/**
-	 * Test the api_statuses_f() function an undefined cursor GET variable.
-	 *
-	 */
-	public function testApiStatusesFWithUndefinedCursor(): void
-	{
-		self::markTestIncomplete('Needs refactoring of Lists - replace filter_input() with $request parameter checks');
-
-		// $_GET['cursor'] = 'undefined';
-		// self::assertFalse(api_statuses_f('friends'));
 	}
 }

--- a/tests/src/Module/Api/Twitter/Friendships/IncomingTest.php
+++ b/tests/src/Module/Api/Twitter/Friendships/IncomingTest.php
@@ -20,23 +20,12 @@ class IncomingTest extends ApiTestCase
 	 */
 	public function testApiFriendshipsIncoming(): void
 	{
+		// @phpstan-ignore method.deprecated
 		$response = (new Incoming(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []))
 			->run($this->httpExceptionMock);
 
 		$json = $this->toJson($response);
 
 		self::assertIsArray($json->ids);
-	}
-
-	/**
-	 * Test the api_friendships_incoming() function an undefined cursor GET variable.
-	 *
-	 */
-	public function testApiFriendshipsIncomingWithUndefinedCursor(): void
-	{
-		self::markTestIncomplete('Needs refactoring of Incoming - replace filter_input() with $request parameter checks');
-
-		// $_GET['cursor'] = 'undefined';
-		// self::assertFalse(api_friendships_incoming('json'));
 	}
 }


### PR DESCRIPTION
Followup of #16069

<details><summary>AI transparency: working plan (in German)</summary>
<p>

``````
# Plan: `handleRequest()`-Test Coverage (Integration-basiert)

## Goal

Ersetze `run()`-basierte Modul-Tests durch `handleRequest()`-basierte Tests in
`tests/Integration/Module/` mit der **echten, geteilten MariaDB-Fixture**. Ermöglicht die
Hard-Deprecation von `run()` pro BC-Promise.

`tests/src/` bleibt **legacy**: keine neuen Tests. Nur:
- aktive `run()`-Tests bleiben unverändert (bekommen direkt davor `// @phpstan-ignore`)
- `markTestIncomplete`-Methoden werden gelöscht (ersetzt durch Integration-Tests)

## Architektur

| Suite | Zweck | Modul-Tests |
|-------|-------|-------------|
| `tests/Integration/Module/` | **einziges Zuhause** für neue Modul-Tests (Plumbing + Pre-DB + Daten) | ✅ ja |
| `tests/Unit/` | reine Logik, alles gemockt | nein |
| `tests/Functional/` | wird nicht für Modul-Tests genutzt | nein |
| `tests/src/` | **legacy, eingefroren** — nur Wartung, keine neuen Tests | nur bestehende |

**Warum keine DB-Mocks / keine SQLite:**
- DBA-Statics sind **nicht mockbar** (geladene statische Klassen; kein Test im Codebase mockt DBA)
- Die Test-DB ist keine langsame Einrichtung: `StaticDatabase` (tests/Util/Database/StaticDatabase.php)
  nutzt eine **pro Prozess geteilte MariaDB-Verbindung** mit Transaktions-Rollback pro Test —
  kein Schema-Neuaufbau, daher schnell
- SQLite ist kein Drop-in: Friendica-Schema ist MySQL-spezifisch (z.B. `MATCH ... AGAINST`
  in `Search.php:179`, `LOCK TABLES`, `information_schema`)

**Eine Ausnahme gibt es:** ein Test-Database-Subclass als **FULLTEXT-DB-Mock**
(`tests/Util/Database/StaticDatabaseWithFullTextSearch.php`). Der mockt keine DBA-Statics,
sondern ist der über Dice injizierte `Database`-Beans. Er ersetzt bei `post-searchindex`/
`post-engagement` die `MATCH ... AGAINST`-Bedingung durch ein äquivalentes
`` `searchtext` LIKE '%term%' ``. Grund: InnoDB indiziert FULLTEXT-Spalten **erst beim COMMIT**,
die Tests laufen aber in einer Transaktion mit Rollback → `MATCH` sieht frisch eingefügte Zeilen
nie. LIKE sieht sie. Injektion pro Test via opt-in Property `$databaseClass` in
`FixtureTestTrait::setUpFixtures()` (Zeile 46/51); alle anderen Tests behalten `StaticDatabase`.

## Status

| Komponente | Status |
|-----------|--------|
| `BaseModule::handleRequest()` | ✅ 4 Tests in `tests/Integration/Module/BaseModuleTest.php` |
| `BaseApi::handleRequest()` | ✅ 1 Test in `tests/Integration/Module/BaseApiTest.php` |
| `HTTPException\PageNotFound::handleRequest()` | ✅ 1 Test in `tests/src/` |
| `EarlyExitException` (PR #16029) | ✅ gemergt — `earlyJsonExit()`/`earlyHttpExit()` werfen `EarlyExitException` |
| `tests/Unit/BaseModuleTest.php` | ✅ Unit-Test: EarlyExitException trägt Response (anonyme Subklasse) |

---

## Arbeitsablauf (sequenziell, ein Subagent)

Die 46 Stellen werden **sequentiell** (niemals parallel) abgearbeitet. Es darf maximal **ein** Subagent aktiv sein.

### Schritt 0 — Basis prüfen (einmalig, vor dem Loop)

- `tests/Integration/Module/BaseModuleTest.php` + `BaseApiTest.php` laufen im `integration`-Testsuite grün
- Danach: PHPStan + `composer run test:integration` grün → Commit + Push (gleiche Pipeline-Regeln wie Schritt 3/4)

### Schritt 1 — Integration-Test erstellen

- Test-Datei in `tests/Integration/Module/` passend zur Modul-Struktur anlegen
  (Namespace `Friendica\Test\Integration\Module\...`)
- Basis: `Friendica\Test\ApiTestCase` (Fixture-DB, Auth-Helper via `authtest`-Addon)
- Alle Szenarien via `handleRequest()` testen — **reales Modul-Verhalten**, kein `content()`-Mock, kein DBA-Mock
- Modul-Instanzen wie in `tests/src/` erzeugen: `new ModuleClass(DI::..., ...)` (Konstruktor aus `src/Module/...`)
- **`earlyJsonExit()`/`earlyHttpExit()`-Module:** `handleRequest()` wirft `EarlyExitException` → in Test fangen und `getResponse()` asserten
- **`addJsonContent()`-Module:** `handleRequest()` liefert `ResponseInterface` normal
- **Daten-Szenarien** der ersetzten `markTestIncomplete`-Methoden werden **wirklich umgesetzt**
  (z.B. "Search liefert Status mit 'reply'"), nicht nur Pre-DB-Pfade
- **Unallowed-user-Szenarien:** `AuthTestConfig::$authenticated = false` (und ggf.
  `BasicAuth::setCurrentUserID()` leeren) → `checkAllowedScope` wirft via `EarlyExitException`
- **Ersetzte `markTestIncomplete`-Methoden** aus der `tests/src/`-Datei **löschen** (komplette Methode inkl. auskommentiertem Block entfernen)
- Bestehende aktive `run()`-Tests in `tests/src/` bleiben unverändert
- **Jeder `->run()`-Aufruf** in der `tests/src/`-Datei bekommt direkt davor einen `// @phpstan-ignore`-Kommentar
- **`@phpstan-ignore`-Syntax:** immer mit Identifier (`// @phpstan-ignore method.deprecated`); bare Version ist ein `ignore.parseError` und unterdrückt nichts. Position: **vor der Zeile, in der die Statement-Kette beginnt** (`$response = (...)->run(...)`), nicht direkt vor `->run(` (sonst `ignore.unmatchedIdentifier`)
- **`.phpstan.neon` Counter** für `method.deprecated` (`Call to deprecated method run()`) um die Anzahl der neuen `@phpstan-ignore`-Zeilen reduzieren (aktuell: **53**, `.phpstan.neon` Zeile 57)

**Empirische Muster aus Section B (#9–#23):**

- **`catch.neverThrown`-Muster:** Modul-Instanz **vor dem `try`** zuweisen (`$module = $this->createModule();`), dann `try { $module->handleRequest($request); } catch (EarlyExitException $e) { // @phpstan-ignore catch.neverThrown ... }` — nur so erkennt PHPStan den unvermeidbaren Throw und der Ignore matcht
- **POST-Module:** `$this->useHttpMethod(Router::POST)` in `setUp()` **VOR** `createModule()` — `BaseModule::dispatch()` liest die HTTP-Methode aus `$this->args->getMethod()`, nicht aus dem PSR-7-Request
- **Daten-Szenarien** via `DBA::insert()`/`DBA::delete()`/`DBA::update()` direkt im Test anlegen (Transaktions-Rollback räumt auf) — **keine Fixture-Änderung**; Verifikation z.B. `DBA::exists()`
- **RSS-Variante:** `['extension' => ICanCreateResponses::TYPE_RSS]` als letztes Konstruktor-Argument + URL mit `.rss`; assert `X_HEADER` und `assertXml((string) $response->getBody(), 'root')`

### Schritt 2 — Qualität sichern

- PHPStan: `docker compose -f .docker/compose.yaml exec app vendor/bin/phpstan analyse --memory-limit=4G`
- Integration-Tests: `docker compose -f .docker/compose.yaml exec app vendor/bin/phpunit -c tests/phpunit.xml --testsuite integration --testdox`
- Legacy-Tests: `docker compose -f .docker/compose.yaml exec app vendor/bin/phpunit -c tests/phpunit.xml --testsuite legacy --testdox`
- Bei Fehlern: fixen → zurück zu Schritt 2

### Schritt 3 — Commit & Push

```bash
git add -A && git commit -m "Add integration tests for <Modul>" && git push
```

> **Commit-Message-Regel:** Nie den Plan oder die Task-Nummer aus dem Plan in Commit-Messages erwähnen (z.B. kein "#10"). Commit-Messages beschreiben nur die Änderung selbst (z.B. "Add integration tests for Twitter Statuses Update").

Section A (#1–#8): via PR #16027 in `develop` gemergt (`d579a2626d`).
Section B (#9–#23): via PR #16069 in `develop` gemergt (`ec809e9222`).
Section C (#24–#28 + #32–#33): **PR <https://github.com/friendica/friendica/pull/16070>** (Branch `add-handlerequest-test-coverage-c`, Basis `develop`) — angelegt, in Bearbeitung.
Section D (#29–#31, #34–#46): kommt **später in eigenem PR** (nach Merge von #16070), neuer Branch ab `develop`.

### Schritt 4 — Pipeline beobachten

- Warten bis GitHub Actions durchgelaufen ist — **Runs gegen `friendica/friendica` prüfen** (am PR), NICHT gegen den Fork:
  `gh run list --repo friendica/friendica --branch <branch>`
- **Pipeline failed** → `git reset --soft HEAD~1`, nachbessern, `git commit`, `git push --force-with-lease` → zurück zu Schritt 4
- **Pipeline grün** → Stelle erledigt

### Schritt 5 — Nächste Stelle

- Pipeline grün → **Checkbox in der Checkliste anhaken** (`- [ ]` → `- [x]`)
- Dann weiter mit nächster Stelle
- Niemals parallel, maximal ein Subagent

---

## Checkliste

### ✅ Erledigt (vor Loop)

- [x] `BaseModule::handleRequest()` GET, POST, Exception, Query Params — `tests/Integration/Module/`
- [x] `BaseApi::handleRequest()` GET — `tests/Integration/Module/`
- [x] `EarlyExitException` (PR #16029) — `earlyJsonExit()`/`earlyHttpExit()` werfen `EarlyExitException`
- [x] `tests/Unit/BaseModuleTest.php` — Unit-Test: EarlyExitException trägt Response (anonyme Subklasse, kein DB)

### A — Incomplete-only (8 Stellen)

Keine aktiven `run()`-Tests. `markTestIncomplete` in allen Methoden. Test von Grund auf neu (inkl. Daten-Szenarien).

- [x] **#1** `Mastodon\Search` — `tests/Integration/Module/Api/Mastodon/SearchTest.php` (7 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#2** `Mastodon\Timelines\PublicTimeline` — `.../Api/Mastodon/Timelines/PublicTimelineTest.php` (5 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#3** `Mastodon\Timelines\Home` — `.../Api/Mastodon/Timelines/HomeTest.php` (4 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#4** `Mastodon\Conversations` — `.../Api/Mastodon/ConversationsTest.php` (3 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#5** `Mastodon\Accounts\Statuses` — `.../Api/Mastodon/Accounts/StatusesTest.php` (2 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#6** `Twitter\ContactEndpoint` — `.../Api/Twitter/ContactEndpointTest.php` (4 inc) — alle Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#7** `Mastodon\PushSubscription` — `.../Api/Mastodon/PushSubscriptionTest.php` (2 inc) — 6 Fälle umgesetzt, legacy-Datei gelöscht
- [x] **#8** `ApiResponse` — komplett nach `tests/Integration/Module/Api/ApiResponseTest.php` migriert (17 Tests: 15 Formattests + 2 RSS-Extra, reale Fixture-Daten), legacy-Datei gelöscht

### B — Mixed (active `run()` + incomplete) — 15 Stellen

- [x] **#9** `Mastodon\Accounts\VerifyCredentials` — 1 active + 1 inc (unallowed user) — Integration-Tests angelegt (Commit `5b4e1c71e4`), Legacy run()-Test behalten + `@phpstan-ignore`, Pipeline grün
- [x] **#10** `Twitter\Statuses\Update` — 2 active + 4 inc (parent, media_ids, throttle, unauth) — 6 Integration-Tests (Commit `7c1a0cf418`), 4 Incompletes gelöscht, Pipeline grün
- [x] **#11** `Twitter\Favorites` — 2 active + 1 inc (unallowed user) — 3 Integration-Tests (Commit `20c120aff2`), Pipeline grün
- [x] **#12** `Twitter\Statuses\Mentions` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `d5cfce47c8`)
- [x] **#13** `Twitter\Statuses\UserTimeline` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `db9659bb92`)
- [x] **#14** `Twitter\Statuses\Retweet` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `04b1f3e9d4`)
- [x] **#15** `Twitter\Statuses\Show` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `114c61d561`)
- [x] **#16** `Twitter\Statuses\Destroy` — 2 active + 1 inc (unallowed user) — 3 Integration-Tests (Commit `6b630fc019`)
- [x] **#17** `Twitter\Statuses\NetworkPublicTimeline` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `a45e8e4908`)
- [x] **#18** `Twitter\Lists\Statuses` — 3 active + 1 inc (unallowed user) — 4 Integration-Tests (Commit `2c0a57909a`)
- [x] **#19** `Twitter\DirectMessages\Sent` — 2 active + 1 inc (unallowed user) — 5 Integration-Tests inkl. Daten-Szenario (Commit `b48f1acf35`)
- [x] **#20** `Twitter\DirectMessages\NewDM` — 5 active + 1 inc (unallowed user) — 7 Integration-Tests inkl. Daten-Szenario (Commit `a5ca082a4f`)
- [x] **#21** `Twitter\DirectMessages\Destroy` — 5 active + 1 inc (unallowed user) — 6 Integration-Tests inkl. Daten-Szenario (Commit `475f42f423`)
- [x] **#22** `Friendica\Notification` — 2 active + 2 inc (empty, unauth) — 4 Integration-Tests inkl. leeres-Szenario (Commit `84e70a785f`)
- [x] **#23** `Friendica\Photo\Delete` — 4 active + 1 inc (unallowed user) — 5 Integration-Tests inkl. echtem Lösch-Szenario (Commit `a017035a59`)

### C — Mixed Fortsetzung — 7 Stellen

- [x] **#24** `Friendica\Photoalbum\Update` — 4 active + 1 inc (unallowed user) — 5 Integration-Tests (Commit `749996e540`), Pipeline grün
- [x] **#25** `Twitter\Friendships\Incoming` — 1 active + 1 inc (undefined cursor) — 3 Integration-Tests inkl. realem undefined-cursor-Daten-Szenario (Commit `6cde2e7a00`), Pipeline grün
- [x] **#26** `Twitter\Followers\Lists` — 1 active + 1 inc (undefined cursor) — 3 Integration-Tests inkl. realem undefined-cursor-Daten-Szenario (Commit `c66752f941`), Pipeline grün
- [x] **#27** `Twitter\Friends\Lists` — 1 active + 1 inc (undefined cursor) — 3 Integration-Tests inkl. realem undefined-cursor-Daten-Szenario (Commit `2fa63d120a`), Pipeline grün
- [x] **#28** `Twitter\Blocks\Lists` — 1 active + 1 inc (undefined cursor) — 3 Integration-Tests inkl. realem undefined-cursor-Daten-Szenario (Commit `2c4801740f`), Pipeline grün
- [x] **#32** `Twitter\Favorites\Create` — 3 active + 1 inc (unallowed user), POST: Fav + auth — 4 Integration-Tests inkl. echtem Fav-Szenario + DB-Verifikation (Commit `c148d2f039`), Pipeline grün
- [x] **#33** `Twitter\Favorites\Destroy` — 2 active + 1 inc (unallowed user), POST: Unfav + auth — 3 Integration-Tests inkl. echtem Unfav-Szenario + DB-Verifikation (Commit `8bef5da3f8`), Pipeline grün

### D — `run()`-Tests (ohne incomplete) — 16 Stellen

- [ ] **#29** `NodeInfo110|120|210` — 3 active, GET-only, kein Auth
- [ ] **#30** `Special\Options` — 2 active, OPTIONS/CORS, kein Auth
- [ ] **#31** `StatsCaching` — 6 active, GET, kein Auth
- [ ] **#34** `Twitter\SavedSearches` — 1 active, GET
- [ ] **#35** `Twitter\Users\Show` — 2 active, GET
- [ ] **#36** `Twitter\Users\Lookup` — 2 active, GET
- [ ] **#37** `Twitter\Users\Search` — 2 active, GET
- [ ] **#38** `Twitter\Account\RateLimitStatus` — 2 active, GET
- [ ] **#39** `Twitter\Account\UpdateProfile` — 1 active, POST
- [ ] **#40** `Twitter\Media\Upload` — 4 active, POST
- [ ] **#41** `Twitter\DirectMessages\All` — 1 active, GET
- [ ] **#42** `Twitter\DirectMessages\Inbox` — 1 active, GET
- [ ] **#43** `Twitter\DirectMessages\Conversation` — 1 active, GET
- [ ] **#44** `Friendica\Photoalbum\Delete` — 3 active, POST
- [ ] **#45** `Friendica\DirectMessages\Search` — 3 active, GET
- [ ] **#46** `GnuSocial\Version|Config|Help\Test` — 4 active, GET-only

---

## Test-Pattern

Basis aller neuen Tests: `Friendica\Test\ApiTestCase` (Namespace `Friendica\Test\Integration\Module\...`).
Modul-Instanzen wie in `tests/src/` erzeugen, aber `handleRequest()` statt `run()` aufrufen.
Query/Form-Parameter via PSR-7 `ServerRequest` statt `$_REQUEST`/Array.

### Pattern A — Modul mit `earlyJsonExit()` (wirft `EarlyExitException`)

```php
namespace Friendica\Test\Integration\Module\Api\Mastodon;

use Friendica\Core\EarlyExitException;
use Friendica\DI;
use Friendica\Module\Api\Mastodon\Search;
use Friendica\Test\ApiTestCase;
use GuzzleHttp\Psr7\ServerRequest;

final class SearchTest extends ApiTestCase
{
	public function testApiSearch(): void
	{
		$request = (new ServerRequest('GET', 'https://friendica.local/api/v2/search'))
			->withQueryParams(['q' => 'reply']);

		$module = new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);

		try {
			$module->handleRequest($request);
			self::fail('Expected EarlyExitException');
		} catch (EarlyExitException $e) {
			$json = $this->toJson($e->getResponse());
			foreach ($json->statuses as $status) {
				self::assertStringContainsStringIgnoringCase('reply', $status->text);
			}
		}
	}
}
```

### Pattern B — Modul mit `addJsonContent()` (liefert Response normal)

```php
public function testApiVerifyCredentials(): void
{
	$request = new ServerRequest('GET', 'https://friendica.local/api/v1/accounts/verify_credentials');

	$module = new VerifyCredentials(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);

	$response = $module->handleRequest($request);

	self::assertEquals(200, $response->getStatusCode());
	self::assertJson((string) $response->getBody());
}
```

### Pattern C — Auth-Fail / Fehlerfall (unallowed user)

```php
public function testApiSearchWithUnallowedUser(): void
{
	AuthTestConfig::$authenticated = false;

	$request = (new ServerRequest('GET', 'https://friendica.local/api/v2/search'))
		->withQueryParams(['q' => 'test']);

	$module = new Search(DI::mstdnError(), DI::appHelper(), DI::l10n(), DI::baseUrl(), DI::args(), DI::logger(), DI::profiler(), DI::apiResponse(), []);

	try {
		$module->handleRequest($request);
		self::fail('Expected EarlyExitException');
	} catch (EarlyExitException $e) {
		self::assertEquals(401, $e->getResponse()->getStatusCode());
	}
}
```

### Hinweise

- **Link-Header**: Seit Plan 03 (#16058, gemergt `b9439c6cbc`) setzen Module den Pagination-Link über die Instanzmethoden `$this->setPaginationLinkHeader()`/`setPaginationLinkHeaderByOffsetLimit()` (`src/Module/BaseApi.php:446,459`) auf den Response-Builder → in Integration-Tests via `$response->getHeader('Link')` assertbar (bei EarlyExitException: `$e->getResponse()->getHeader('Link')`). **Caveats:** (1) Der Header wird nur gesetzt, wenn `BaseApi::$boundaries` gefüllt ist — leere Ergebnisse → kein Link-Header. (2) Die Header-URL baut auf `baseUrl . args->getCommand()`; im Test-CLI ist `getCommand()`/`getQueryString()` leer → auf Existenz/Teilstring asserten statt exaktem Wert.
- **Auth**: `ApiTestCase::setUp()` setzt `AuthTestConfig::$authenticated = true` (uid 42). Für unauth-Tests im Test überschreiben. Vorbild: `tests/src/Module/Api/Twitter/Media/UploadTest.php:47`.
- **Search-Daten-Szenarien**: `Search::searchStatuses()` nutzt `MATCH ... AGAINST` auf `post-searchindex` (FULLTEXT). Im Test-Setup (Transaktion + Rollback) liefert FULLTEXT **keine** frisch eingefügten Zeilen (Index entsteht erst beim COMMIT). Lösung (implementiert & grün): `StaticDatabaseWithFullTextSearch` als `$databaseClass` in `SearchTest` aktivieren → der Mock-Database rewritet die MATCH-Bedingung auf `LIKE '%term%'`, Datenpfad end-to-end testbar. Suchtabellen: `post-searchindex` (Standard) bzw. `post-engagement` (config `limited_search_scope`).
- **Obsolete Twitter-Parameter**: `count`, `rpp`, `exclude_replies` aus den alten `markTestIncomplete`-Methoden existieren im Modul **nicht mehr** (nur `limit`, `offset`, `max_id`, `min_id`, `resolve`, `following`). Die Fälle wurden auf die modernen Entsprechungen abgebildet: `count`/`rpp` → `limit`, `exclude_replies`+`max_id` → `max_id`. Für Pagination-Tests werden 2 `post-searchindex`-Zeilen (uri-id 6 + 7) eingefügt.
- **Response-Struktur**: `earlyJsonExit()` gibt entweder eine **JSON-Liste** zurück (Timelines, Sammlungen → direkt iterieren) oder ein **Objekt** (`{statuses: ...}`, `{accounts: ...}` bei Search). Vor dem Test die tatsächliche Form am Modul prüfen — `$json->statuses` auf einer Liste liefert `null` (typische Fehlerspur: `assertCount()` mit `null` statt `Countable`).
- **Debug-Helfer**: View-/DB-Queries im Test direkt reproduzierbar: `DBA::p("SELECT \`uri-id\` FROM \`post-timeline-view\` " . DBA::buildCondition($cond), $cond)`. Felder mit Bindestrich (`` `uri-id` ``) **müssen** gequotet werden, sonst `Unknown column 'uri'`. Temporäre `fwrite(STDERR, ...)`-Dumps der Roh-Antwort sind der schnellste Weg, Modul-Ausgaben zu inspizieren.
- **PublicTimeline**: PublicTimeline ist ohne Auth erreichbar; Unallowed-user nur mit `system.block_public=true` erzwingbar (401). Timeline-Queries laufen über Views (`post-timeline-thread-view`/`post-timeline-view`/`post-timeline-origin-view`) — Fixture liefert für public/exclude_replies reale Daten; `local=true` hat nur 1 Fixture-Post (`post-origin`-Daten fehlen). Obsolete Fälle: `page`, `conversation_id`, `rss` (Modul nur noch JSON).
- **#3 Home (Vorschau)**: `Home` erfordert im Gegensatz zu `PublicTimeline` **immer** Auth (`getCurrentUserID`/`checkAllowedScope`) → Unallowed-user-Fall ohne Zusatz-Config testbar.
- **Modul-Konstruktoren**: Jedes Modul hat eigene Dependencies. Die `new ModuleClass(DI::...)`-Aufrufe direkt aus den bestehenden `tests/src/`-Tests übernehmen.
- **Fixture-Fakten (Referenz):** Session-User 42 (`AuthTestConfig::$user_id`; `VerifyCredentials`-`id` = 48), Kontakte 42–45 (43 = public `https://friendica.local/profile/othercontact`), Post-uri-ids 1.., Lists-Fixtures gid 1 + `group_member` (gid 1 → contact 43), Photo-Fixture id=1 (resource-id `709057080661a283a6aa598501504178`), `mail`-Fixture enthält nur **empfangene** Mails (Sent-Szenarien via `DBA::insert`, `author-id` 48 = selfcontact).

## Messkriterien

- `markTestIncomplete` in `tests/src/Module` sinkt auf 0 für alle Migrations-Module (aktuell **9**: 7 in C/D-Zielmodulen + 2 Legacy-Basis `BaseApiTest`/`PageNotFoundTest`, die verbleiben; gesamt in `tests/src` noch **34**)
- Neue Dateien in `tests/Integration/Module/` (46 Dateien, spiegelbildlich zu `src/Module/...`)
- Basis-Tests (`BaseModuleTest`, `BaseApiTest`) laufen im `integration`-Testsuite
- PHPStan: keine neuen Fehler; `.phpstan.neon`-Counter für `method.deprecated` (run()) sinkt um Anzahl der `@phpstan-ignore`-Zeilen
- Bestehende Tests in `tests/src/` bleiben unverändert (nur `markTestIncomplete`-Methoden + `@phpstan-ignore`-Zeilen)
- `tests/Functional/` bleibt unberührt

``````

</p>
</details> 

This PR continues the `handleRequest()` test coverage started in part 1 (#16027) and part 2 (#16069).

It migrates the remaining "mixed" test classes of Section C – the ones with active `run()` tests plus `markTestIncomplete` methods – to integration tests in `tests/Integration/Module/`.

The active `run()` tests stay in `tests/src/` for BC and get a `// @phpstan-ignore` comment. The `markTestIncomplete` methods are removed and replaced by real `handleRequest()` tests (incl. data scenarios).

Covers: Photoalbum\Update, Friendships\Incoming, Followers\Lists, Friends\Lists, Blocks\Lists.

I split this task into multiple PRs, or this PR will become too big.