### PR TITLE
Assign a new session id when a login changes the privilege level

### DIFF
--- a/src/Core/Session/Capability/IHandleSessions.php
+++ b/src/Core/Session/Capability/IHandleSessions.php
@@ -20,6 +20,17 @@ interface IHandleSessions
 	public function start(): IHandleSessions;
 
 	/**
+	 * Assign a new id to the current session, keeping its content
+	 *
+	 * Called whenever the privilege level of a session changes, so that an id
+	 * known before that change cannot be used afterwards. Session types without
+	 * a client-supplied id have nothing to rotate and do nothing here.
+	 *
+	 * @return self The own Session instance
+	 */
+	public function regenerateId(): IHandleSessions;
+
+	/**
 	 * Checks if the key exists in this session
 	 *
 	 * @param string $name

--- a/src/Core/Session/Model/UserSession.php
+++ b/src/Core/Session/Model/UserSession.php
@@ -163,6 +163,14 @@ class UserSession implements IHandleUserSessions
 	}
 
 	/** {@inheritDoc} */
+	public function regenerateId(): IHandleSessions
+	{
+		$this->session->regenerateId();
+
+		return $this;
+	}
+
+	/** {@inheritDoc} */
 	public function exists(string $name): bool
 	{
 		return $this->session->exists($name);

--- a/src/Core/Session/Type/AbstractSession.php
+++ b/src/Core/Session/Type/AbstractSession.php
@@ -23,6 +23,14 @@ class AbstractSession implements IHandleSessions
 	}
 
 	/**
+	 * {@inheritDoc}
+	 */
+	public function regenerateId(): IHandleSessions
+	{
+		return $this;
+	}
+
+	/**
 	 * {@inheritDoc}}
 	 */
 	public function exists(string $name): bool

--- a/src/Core/Session/Type/ArraySession.php
+++ b/src/Core/Session/Type/ArraySession.php
@@ -24,6 +24,11 @@ class ArraySession implements IHandleSessions
 		return $this;
 	}
 
+	public function regenerateId(): IHandleSessions
+	{
+		return $this;
+	}
+
 	public function exists(string $name): bool
 	{
 		return !empty($this->data[$name]);

--- a/src/Core/Session/Type/Native.php
+++ b/src/Core/Session/Type/Native.php
@@ -21,7 +21,9 @@ class Native extends AbstractSession implements IHandleSessions
 	{
 		ini_set('session.gc_probability', 50);
 		ini_set('session.use_only_cookies', 1);
+		ini_set('session.use_strict_mode', 1);
 		ini_set('session.cookie_httponly', (int) Cookie::HTTPONLY);
+		ini_set('session.cookie_samesite', 'Lax');
 
 		if ($baseURL->getScheme() === 'https') {
 			ini_set('session.cookie_secure', 1);
@@ -38,6 +40,18 @@ class Native extends AbstractSession implements IHandleSessions
 	public function start(): IHandleSessions
 	{
 		session_start();
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function regenerateId(): IHandleSessions
+	{
+		if (session_status() === PHP_SESSION_ACTIVE) {
+			session_regenerate_id(true);
+		}
+
 		return $this;
 	}
 }

--- a/src/Security/Authentication.php
+++ b/src/Security/Authentication.php
@@ -293,6 +293,13 @@ class Authentication
 	{
 		$my_url = $this->baseUrl . '/profile/' . $user_record['nickname'];
 
+		// The privilege level of this session changes here, so an id handed out
+		// before this point must not stay valid. Sessions that are only being
+		// restored from a cookie or an API credential keep their id.
+		if ($login_initial) {
+			$this->session->regenerateId();
+		}
+
 		$this->session->setMultiple([
 			'uid'           => $user_record['uid'],
 			'theme'         => $user_record['theme'],

--- a/tests/src/Core/Session/UserSessionTest.php
+++ b/tests/src/Core/Session/UserSessionTest.php
@@ -297,4 +297,12 @@ class UserSessionTest extends MockedTestCase
 		$userSession = new UserSession(new ArraySession($data));
 		$this->assertEquals($expected, $userSession->isUnauthenticated());
 	}
+
+	public function testRegenerateIdKeepsTheSessionContent(): void
+	{
+		$userSession = new UserSession(new ArraySession(['authenticated' => true, 'uid' => 21]));
+
+		self::assertInstanceOf(UserSession::class, $userSession->regenerateId());
+		self::assertEquals(21, $userSession->getLocalUserId());
+	}
 }


### PR DESCRIPTION
The session id currently survives a login unchanged, and `session.use_strict_mode` is left at its default, so PHP also accepts ids it never issued itself. Both are cheap to fix and the standard PHP recommendation.

`IHandleSessions` gets a `regenerateId()`. Only the native session type actually has a client-supplied id to rotate - array and memory keep the inherited no-op, so worker and test setups don't notice anything. `Authentication::setForUser()` calls it for initial logins only: restoring a session from a cookie or authenticating an API request doesn't change the privilege level, so those paths stay untouched.

The native type additionally sets `session.use_strict_mode` and `session.cookie_samesite`, right next to the `httponly` / `secure` flags it already sets.