### PR TITLE
Compute the OpenWebAuth token cutoff in PHP

### DIFF
--- a/src/Model/OpenWebAuthToken.php
+++ b/src/Model/OpenWebAuthToken.php
@@ -70,7 +70,7 @@ class OpenWebAuthToken
 	 */
 	public static function purge(string $type, string $interval)
 	{
-		$condition = ["`type` = ? AND `created` < ?", $type, DateTimeFormat::utcNow() . ' - INTERVAL ' . $interval];
+		$condition = ["`type` = ? AND `created` < ?", $type, DateTimeFormat::utc('now - ' . $interval)];
 		DBA::delete('openwebauth-token', $condition);
 	}
 

--- a/tests/src/Model/OpenWebAuthTokenTest.php
+++ b/tests/src/Model/OpenWebAuthTokenTest.php
@@ -1,0 +1,50 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Test\src\Model;
+
+use Dice\Dice;
+use Friendica\Database\Database;
+use Friendica\DI;
+use Friendica\Model\OpenWebAuthToken;
+use Friendica\Test\MockedTestCase;
+use Friendica\Util\DateTimeFormat;
+use Mockery\MockInterface;
+
+class OpenWebAuthTokenTest extends MockedTestCase
+{
+	/** @var Database|MockInterface */
+	private $dbMock;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->dbMock = \Mockery::mock(Database::class);
+
+		$diceMock = \Mockery::mock(Dice::class)->makePartial();
+		/** @var Dice|MockInterface $diceMock */
+		$diceMock = $diceMock->addRules(include __DIR__ . '/../../../static/dependencies.config.php');
+		$diceMock->shouldReceive('create')->withArgs([Database::class])->andReturn($this->dbMock);
+		DI::init($diceMock, true);
+	}
+
+	public function testPurgeComparesAgainstTheCutoff(): void
+	{
+		$cutoff = null;
+
+		$this->dbMock->shouldReceive('delete')->withArgs(function (string $table, array $condition) use (&$cutoff) {
+			$cutoff = $condition[2];
+			return $table === 'openwebauth-token' && $condition[1] === 'owt';
+		})->andReturn(true)->once();
+
+		OpenWebAuthToken::purge('owt', '3 MINUTE');
+
+		self::assertLessThan(DateTimeFormat::utcNow(), $cutoff);
+		self::assertGreaterThan(DateTimeFormat::utc('now - 4 MINUTE'), $cutoff);
+	}
+}


### PR DESCRIPTION
The cutoff is assembled as `"<timestamp> - INTERVAL 3 MINUTE"` and then bound as a plain parameter, so the DB casts the whole string back to a `DATETIME` and quietly drops the interval part. The comparison then runs against "now", and `purge()` deletes every token of that type - including the one that was created moments earlier for the request
that's currently running. 

`DateTimeFormat::utc()` now builds the cutoff before it's bound, the same way `User.php` and `Tag.php` already do it, so the documented three minutes actually apply.