### PR TITLE
Return 404 for unknown help pages

### DIFF
--- a/src/Module/Help.php
+++ b/src/Module/Help.php
@@ -23,57 +23,52 @@ class Help extends BaseModule
 	{
 		Nav::setSelected('help');
 
-		$text     = '';
-		$filename = '';
-
 		$config = DI::config();
-		$lang   = DI::session()->get('language', $config->get('system', 'language'));
+		$lang   = DI::session()->get('language', $config->get('system', 'language')) ?: 'en';
 
 		// @TODO: Replace with parameter from router
-		if (DI::args()->getArgc() > 1) {
-			$path = '';
-			// looping through the argv keys bigger than 0 to build
-			// a path relative to /help
-			for ($x = 1; $x < DI::args()->getArgc(); $x++) {
-				if (strlen($path)) {
-					$path .= '/';
-				}
-
-				$path .= DI::args()->get($x);
+		// looping through the argv keys bigger than 0 to build a path relative to /help
+		$path = '';
+		for ($x = 1; $x < DI::args()->getArgc(); $x++) {
+			if (strlen($path)) {
+				$path .= '/';
 			}
-			$title              = Strings::ucFirst(basename($path));
-			$filename           = $path;
-			$text               = self::loadDocFile($path . '.md', $lang);
-			DI::page()['title'] = DI::l10n()->t('Help:') . ' ' . str_replace('-', ' ', $title);
 
-			// A document was requested explicitly. Falling back to the help home page
-			// would answer every made up path with "200 OK" and the home page contents,
-			// which lets crawlers walk an endless URL space.
-			if ($path !== '' && !strlen((string) $text)) {
-				throw new HTTPException\NotFoundException();
-			}
+			$path .= DI::args()->get($x);
 		}
 
-		$home = self::loadDocFile('home.md', $lang);
-		if (!$text) {
-			$text               = $home;
-			$filename           = "home";
+		if ($path === '') {
+			$filename           = 'home';
 			DI::page()['title'] = DI::l10n()->t('Help');
 		} else {
-			DI::page()['aside'] = Markdown::convert($home, false);
+			$filename           = $path;
+			$title              = Strings::ucFirst(basename($path));
+			DI::page()['title'] = DI::l10n()->t('Help:') . ' ' . str_replace('-', ' ', $title);
 		}
 
-		if (!strlen((string) $text)) {
+		// A document was requested explicitly. Falling back to the help home page
+		// would answer every made up path with "200 OK" and the home page contents,
+		// which lets crawlers walk an endless URL space.
+		$docFile = self::findDocFile($filename . '.md', $lang);
+		if ($docFile === null) {
 			throw new HTTPException\NotFoundException();
 		}
 
-		$html = Markdown::convert($text, false);
+		$text = file_get_contents($docFile);
 
-		if ($filename !== "home") {
+		if ($filename !== 'home') {
+			$homeFile           = self::findDocFile('home.md', $lang);
+			DI::page()['aside'] = $homeFile === null ? '' : $this->absoluteHelpLinks(Markdown::convert(file_get_contents($homeFile), false));
+		}
+
+		$html = $this->absoluteHelpLinks(Markdown::convert($text, false));
+
+		if ($filename !== 'home') {
 			// create TOC but not for home
+			$helpUrl   = (string) $this->baseUrl . '/help';
 			$lines     = explode("\n", $html);
 			$back_text = DI::l10n()->t('Home');
-			$toc       = "<p><i class='fa fa-arrow-left'></i> <a href='/help'>&nbsp;$back_text</a></p><h2>TOC</h2><ul id='toc'>";
+			$toc       = "<p><i class='fa fa-arrow-left'></i> <a href='{$helpUrl}'>&nbsp;$back_text</a></p><h2>TOC</h2><ul id='toc'>";
 			$lastLevel = 1;
 			$idNum     = [0, 0, 0, 0, 0, 0, 0];
 			foreach ($lines as &$line) {
@@ -97,7 +92,7 @@ class Help extends BaseModule
 
 					$idNum[$level]++;
 
-					$href = "/help/{$filename}#{$anchor}";
+					$href = "{$helpUrl}/{$filename}#{$anchor}";
 					$toc .= "<li><a href=\"{$href}\">" . strip_tags($line) . "</a></li>";
 					$id   = implode("_", array_slice($idNum, 1, $level));
 					$line = "<a name=\"{$id}\"></a>" . $line;
@@ -119,27 +114,41 @@ class Help extends BaseModule
 		return $html;
 	}
 
-	private static function loadDocFile($filePath, $lang = 'en')
+	/**
+	 * The doc files link to each other relative to "/help", which only resolves on the
+	 * /help page itself - on a sub page like /help/user/bbcode the browser resolves them
+	 * to /help/user/help/user/... Make them absolute, based on the (possibly sub directory)
+	 * base URL of this node.
+	 */
+	private function absoluteHelpLinks(string $html): string
+	{
+		return str_replace('href="help/', 'href="' . $this->baseUrl . '/help/', $html);
+	}
+
+	/**
+	 * Returns the path of an existing doc file, or null when there is no such file
+	 */
+	private static function findDocFile(string $filePath, string $lang = 'en'): ?string
 	{
 		$baseDir = "doc";
 
 		// Try loading docs inside a language dir first, then try English dir, then fall back to looking at the root dir
 		$docPath = "$baseDir/$lang/$filePath";
 		if (file_exists($docPath)) {
-			return file_get_contents($docPath);
+			return $docPath;
 		}
 
 		$docPath = "$baseDir/en/$filePath";
 		if (file_exists($docPath)) {
-			return file_get_contents($docPath);
+			return $docPath;
 		}
 
 		// Delete this once database docs have been moved into en/spec/database
 		$docPath = "$baseDir/$filePath";
 		if (file_exists($docPath)) {
-			return file_get_contents($docPath);
+			return $docPath;
 		}
 
-		return '';
+		return null;
 	}
 }

--- a/src/Module/Help.php
+++ b/src/Module/Help.php
@@ -45,6 +45,13 @@ class Help extends BaseModule
 			$filename           = $path;
 			$text               = self::loadDocFile($path . '.md', $lang);
 			DI::page()['title'] = DI::l10n()->t('Help:') . ' ' . str_replace('-', ' ', $title);
+
+			// A document was requested explicitly. Falling back to the help home page
+			// would answer every made up path with "200 OK" and the home page contents,
+			// which lets crawlers walk an endless URL space.
+			if ($path !== '' && !strlen((string) $text)) {
+				throw new HTTPException\NotFoundException();
+			}
 		}
 
 		$home = self::loadDocFile('home.md', $lang);
@@ -90,7 +97,7 @@ class Help extends BaseModule
 
 					$idNum[$level]++;
 
-					$href = "help/{$filename}#{$anchor}";
+					$href = "/help/{$filename}#{$anchor}";
 					$toc .= "<li><a href=\"{$href}\">" . strip_tags($line) . "</a></li>";
 					$id   = implode("_", array_slice($idNum, 1, $level));
 					$line = "<a name=\"{$id}\"></a>" . $line;


### PR DESCRIPTION
Answering every made up path with the help home page let crawlers walk an endless URL space.

Fixes #16024