### PR TITLE
Fix PHP warning and broken output when showing a calendar event

### DIFF
--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -627,10 +627,10 @@ class Event
 	{
 		$fmt = DI::l10n()->t('l, F j');
 
-		$item = Post::selectFirst(['plink', 'author-name', 'author-network', 'author-id', 'author-avatar', 'author-link', 'author-alias', 'private', 'uri-id'], ['id' => $event['itemid']]);
+		$item = Post::selectFirst(['plink', 'network', 'guid', 'author-name', 'author-network', 'author-id', 'author-avatar', 'author-link', 'author-alias', 'private', 'uri-id'], ['id' => $event['itemid']]);
 		if (empty($item)) {
 			// Using default values when no item had been found
-			$item = ['plink' => '', 'author-name' => '', 'author-avatar' => '', 'author-link' => '', 'private' => Item::PUBLIC, 'uri-id' => ($event['uri-id'] ?? 0)];
+			$item = ['plink' => '', 'network' => '', 'guid' => '', 'author-name' => '', 'author-avatar' => '', 'author-link' => '', 'private' => Item::PUBLIC, 'uri-id' => ($event['uri-id'] ?? 0)];
 		}
 
 		$event = array_merge($event, $item);


### PR DESCRIPTION
Event::prepareForItem() did not select the 'network' and 'guid' fields that Item::getPlink() reads.

Fixes #15924