### PR TITLE
Add dependency-direction check (deptrac) with a baseline

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -76,6 +76,40 @@ jobs:
       - name: Run PHPStan
         run: composer run phpstan
 
+  deptrac:
+    name: Deptrac (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: ['ubuntu-latest']
+        php: ['8.5']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Setup PHP with composer and extensions
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: none
+
+      - name: Clone addon repository
+        run: git clone -b develop --single-branch https://github.com/friendica/friendica-addons.git addon
+
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v4"
+
+      # Only new violations fail - everything that exists today is frozen in
+      # deptrac-baseline.yaml. See doc/en/developer/php-architecture.md.
+      - name: Run Deptrac
+        run: vendor/bin/deptrac analyse --no-progress --config-file=deptrac.yaml --formatter=github-actions
+
   phpstan-addons:
     name: PHPStan in addons (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ venv/
 .php_cs.cache
 .php-cs-fixer.cache
 .phpmd.result-cache.php
+.deptrac.cache
 
 #ignore avatar picture cache path
 /avatar

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -11,6 +11,7 @@ path = [
      "package-lock.json",
      ".stylelintrc.json",
      "eslint-suppressions.json",
+     "deptrac-baseline.yaml",
      "doc/**",
      "spec/*",
      "tests/**",

--- a/composer.json
+++ b/composer.json
@@ -156,6 +156,7 @@
 		]
 	},
 	"require-dev": {
+		"deptrac/deptrac": "^3.0",
 		"friendsofphp/php-cs-fixer": "^3.94",
 		"mikey179/vfsstream": "^1.6",
 		"mockery/mockery": "^1.3",
@@ -194,6 +195,8 @@
 		"phpmd": "phpmd src/ text .phpmd-ruleset.xml --color --cache",
 		"phpstan": "phpstan analyze --memory-limit 1024M --configuration .phpstan.neon",
 		"phpstan:generate-baseline": "phpstan --generate-baseline=.phpstan-baseline.neon --memory-limit=1024M --configuration=.phpstan.neon",
+		"deptrac": "deptrac analyse --no-progress --config-file=deptrac.yaml",
+		"deptrac:generate-baseline": "deptrac analyse --no-progress --config-file=deptrac.yaml --formatter=baseline --output=deptrac-baseline.yaml",
 		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './view/asset/*' -print0 | xargs -0 -n1 php -l",
 		"docker:translate": "docker run --rm -v $PWD:/data -w /data friendicaci/transifex bin/run_xgettext.sh",
 		"lang:recreate": "bin/run_xgettext.sh",
@@ -204,6 +207,7 @@
 		"qa": [
 			"@phpstan",
 			"@addons:phpstan",
+			"@deptrac",
 			"@test:unit",
 			"@test:legacy",
 			"@rector:check",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ae98cb26982cdb34599a8cec57de4b9",
+    "content-hash": "f4015f760aa5d05ac75a1bcad4c1f4e5",
     "packages": [
         {
             "name": "asika/simple-console",
@@ -5374,6 +5374,54 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "deptrac/deptrac",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/deptrac/deptrac.git",
+                "reference": "605ee322f273ade1727f5ff2db3b47566140f4bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/deptrac/deptrac/zipball/605ee322f273ade1727f5ff2db3b47566140f4bf",
+                "reference": "605ee322f273ade1727f5ff2db3b47566140f4bf",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^8.1"
+            },
+            "suggest": {
+                "ext-dom": "For using the JUnit output formatter"
+            },
+            "bin": [
+                "bin/deptrac",
+                "deptrac.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Deptrac\\Deptrac\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Deptrac is a static code analysis tool that helps to enforce rules for dependencies between software layers.",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/deptrac/deptrac/issues",
+                "source": "https://github.com/deptrac/deptrac/tree/3.0.0"
+            },
+            "time": "2025-02-17T08:20:48+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",

--- a/deptrac-baseline.yaml
+++ b/deptrac-baseline.yaml
@@ -1,0 +1,395 @@
+deptrac:
+  skip_violations:
+    Friendica\App:
+      - Friendica\BaseModule
+      - Friendica\Content\Nav
+      - Friendica\Module\Maintenance
+      - Friendica\Module\Response
+      - Friendica\Module\Special\HTTPException
+      - Friendica\Protocol\ATProtocol\DID
+      - Friendica\Security\Authentication
+      - Friendica\Security\ExAuth
+      - Friendica\Security\OpenWebAuth
+    Friendica\App\Page:
+      - Friendica\Content\Nav
+    Friendica\App\Router:
+      - Friendica\LegacyModule
+      - Friendica\Module\HTTPException\MethodNotAllowed
+      - Friendica\Module\HTTPException\PageNotFound
+      - Friendica\Module\Special\Options
+    Friendica\Capabilities\ICanHandleRequests:
+      - Friendica\Module\Special\HTTPException
+    Friendica\Contact\Avatar:
+      - Friendica\Object\Image
+    Friendica\Core\ACL:
+      - Friendica\Model\Circle
+      - Friendica\Model\Contact
+      - Friendica\Model\User
+    Friendica\Core\Console:
+      - Friendica\Console\Addon
+      - Friendica\Console\ArchiveContact
+      - Friendica\Console\AutomaticInstallation
+      - Friendica\Console\Cache
+      - Friendica\Console\ClearAvatarCache
+      - Friendica\Console\Config
+      - Friendica\Console\Contact
+      - Friendica\Console\CreateDoxygen
+      - Friendica\Console\Daemon
+      - Friendica\Console\DatabaseStructure
+      - Friendica\Console\DocBloxErrorChecker
+      - Friendica\Console\Extract
+      - Friendica\Console\FediBuzzRelay
+      - Friendica\Console\FixAPDeliveryWorkerTaskParameters
+      - Friendica\Console\GlobalCommunityBlock
+      - Friendica\Console\GlobalCommunitySilence
+      - Friendica\Console\JetstreamDaemon
+      - Friendica\Console\Lock
+      - Friendica\Console\Maintenance
+      - Friendica\Console\MergeContacts
+      - Friendica\Console\MoveToAvatarCache
+      - Friendica\Console\PhpToPo
+      - Friendica\Console\PoToPhp
+      - Friendica\Console\PostUpdate
+      - Friendica\Console\Relay
+      - Friendica\Console\Relocate
+      - Friendica\Console\ServerBlock
+      - Friendica\Console\Storage
+      - Friendica\Console\Test
+      - Friendica\Console\Typo
+      - Friendica\Console\User
+      - Friendica\Console\Worker
+    Friendica\Core\Protocol:
+      - Friendica\Model\User
+      - Friendica\Protocol\ActivityPub\Transmitter
+      - Friendica\Protocol\Diaspora
+    Friendica\Core\Search:
+      - Friendica\Model\Contact
+      - Friendica\Object\Search\ContactResult
+      - Friendica\Object\Search\ResultList
+    Friendica\Core\Session\Model\UserSession:
+      - Friendica\Model\Contact
+      - Friendica\Model\User
+    Friendica\Core\Session\Type\Native:
+      - Friendica\Model\User\Cookie
+    Friendica\Core\System:
+      - Friendica\Content\Text\BBCode
+      - Friendica\Module\Response
+    Friendica\Core\Theme:
+      - Friendica\Model\Profile
+    Friendica\Core\Update:
+      - Friendica\Model\User
+    Friendica\Core\Worker\Cron:
+      - Friendica\Model\GServer
+      - Friendica\Model\Post\Delivery
+      - Friendica\Model\User
+      - Friendica\Protocol\ActivityPub\Delivery
+    Friendica\DI:
+      - Friendica\Contact\FriendSuggest\Factory\FriendSuggest
+      - Friendica\Contact\FriendSuggest\Repository\FriendSuggest
+      - Friendica\Contact\Introduction\Factory\Introduction
+      - Friendica\Contact\Introduction\Repository\Introduction
+      - Friendica\Contact\LocalRelationship\Repository\LocalRelationship
+      - Friendica\Content\Conversation\ActivityFormatter
+      - Friendica\Content\Conversation\ConversationDataProvider
+      - Friendica\Content\Conversation\ConversationRenderer
+      - Friendica\Content\Conversation\Factory\Activity
+      - Friendica\Content\Conversation\Factory\Channel
+      - Friendica\Content\Conversation\Factory\ChannelPost
+      - Friendica\Content\Conversation\Factory\Community
+      - Friendica\Content\Conversation\Factory\Network
+      - Friendica\Content\Conversation\Factory\SystemChannelPost
+      - Friendica\Content\Conversation\Factory\Timeline
+      - Friendica\Content\Conversation\PostTemplateBuilder
+      - Friendica\Content\Conversation\Repository\UserDefinedChannel
+      - Friendica\Content\Conversation\StatusEditor
+      - Friendica\Content\Item
+      - Friendica\Content\Post\Factory\PostMedia
+      - Friendica\Content\Post\Repository\PostMedia
+      - Friendica\Content\Text\BBCode\Video
+      - Friendica\Factory\Api\Mastodon\Account
+      - Friendica\Factory\Api\Mastodon\Application
+      - Friendica\Factory\Api\Mastodon\Attachment
+      - Friendica\Factory\Api\Mastodon\Card
+      - Friendica\Factory\Api\Mastodon\Conversation
+      - Friendica\Factory\Api\Mastodon\Emoji
+      - Friendica\Factory\Api\Mastodon\Error
+      - Friendica\Factory\Api\Mastodon\ListEntity
+      - Friendica\Factory\Api\Mastodon\Notification
+      - Friendica\Factory\Api\Mastodon\Poll
+      - Friendica\Factory\Api\Mastodon\Relationship
+      - Friendica\Factory\Api\Mastodon\ScheduledStatus
+      - Friendica\Factory\Api\Mastodon\Status
+      - Friendica\Factory\Api\Mastodon\StatusSource
+      - Friendica\Factory\Api\Mastodon\Subscription
+      - Friendica\Factory\Api\Twitter\Status
+      - Friendica\Factory\Api\Twitter\User
+      - Friendica\Federation\Factory\DeliveryQueueItem
+      - Friendica\Federation\Repository\DeliveryQueueItem
+      - Friendica\Model\Log\ParsedLogIterator
+      - Friendica\Model\User\Cookie
+      - Friendica\Moderation\Factory\Report
+      - Friendica\Moderation\Repository\Report
+      - Friendica\Module\Api\ApiResponse
+      - Friendica\Navigation\Notifications\Factory\FormattedNavNotification
+      - Friendica\Navigation\Notifications\Factory\FormattedNotify
+      - Friendica\Navigation\Notifications\Factory\Introduction
+      - Friendica\Navigation\Notifications\Factory\Notification
+      - Friendica\Navigation\Notifications\Factory\Notify
+      - Friendica\Navigation\Notifications\Repository\Notification
+      - Friendica\Navigation\Notifications\Repository\Notify
+      - Friendica\Navigation\SystemMessages
+      - Friendica\Post\UriGenerator
+      - Friendica\Profile\ProfileField\Factory\ProfileField
+      - Friendica\Profile\ProfileField\Repository\ProfileField
+      - Friendica\Protocol\ATProtocol
+      - Friendica\Protocol\ATProtocol\Actor
+      - Friendica\Protocol\ATProtocol\Processor
+      - Friendica\Protocol\Activity
+      - Friendica\Protocol\Diaspora\Repository\DiasporaContact
+      - Friendica\Security\Authentication
+      - Friendica\Security\PermissionSet\Factory\PermissionSet
+      - Friendica\Security\PermissionSet\Repository\PermissionSet
+      - Friendica\User\Settings\Repository\UserGServer
+    Friendica\Database\DBStructure:
+      - Friendica\Model\Item
+      - Friendica\Model\User
+    Friendica\Database\PostUpdate:
+      - Friendica\Model\Contact
+      - Friendica\Model\Conversation
+      - Friendica\Model\GServer
+      - Friendica\Model\Item
+      - Friendica\Model\ItemURI
+      - Friendica\Model\Photo
+      - Friendica\Model\Post
+      - Friendica\Model\Post\Category
+      - Friendica\Model\Post\Counts
+      - Friendica\Model\Post\Engagement
+      - Friendica\Model\Post\SearchIndex
+      - Friendica\Model\Post\UserNotification
+      - Friendica\Model\Tag
+      - Friendica\Model\Verb
+      - Friendica\Protocol\ActivityPub\Processor
+      - Friendica\Protocol\ActivityPub\Receiver
+    Friendica\Event\ModuleContentEvent:
+      - Friendica\BaseModule
+    Friendica\Event\ModuleInitEvent:
+      - Friendica\BaseModule
+    Friendica\Event\ModulePostEvent:
+      - Friendica\BaseModule
+    Friendica\Event\ModulePostRecipientEvent:
+      - Friendica\BaseModule
+    Friendica\Model\APContact:
+      - Friendica\Content\Text\HTML
+      - Friendica\Protocol\ActivityNamespace
+      - Friendica\Protocol\ActivityPub
+      - Friendica\Protocol\ActivityPub\Transmitter
+    Friendica\Model\Attach:
+      - Friendica\Content\Post\Entity\PostMedia
+      - Friendica\Object\Image
+      - Friendica\Security\Security
+    Friendica\Model\Circle:
+      - Friendica\BaseModule
+      - Friendica\Content\Widget
+      - Friendica\Protocol\ActivityPub
+    Friendica\Model\Contact:
+      - Friendica\Contact\Avatar
+      - Friendica\Contact\Header
+      - Friendica\Contact\Introduction\Exception\IntroductionNotFoundException
+      - Friendica\Content\Conversation\ConversationRenderer
+      - Friendica\Content\Pager
+      - Friendica\Content\Post\Entity\PostMedia
+      - Friendica\Content\Text\HTML
+      - Friendica\Object\Image
+      - Friendica\Protocol\Activity
+      - Friendica\Protocol\ActivityPub\Transmitter
+      - Friendica\Worker\AddContact
+      - Friendica\Worker\ContactDiscovery
+      - Friendica\Worker\ContactDiscoveryForUser
+      - Friendica\Worker\UpdateContact
+    Friendica\Model\Contact\Circle:
+      - Friendica\Content\Widget
+    Friendica\Model\Contact\Introduction:
+      - Friendica\Contact\Introduction\Entity\Introduction
+      - Friendica\Protocol\ActivityPub\Transmitter
+      - Friendica\Protocol\Diaspora
+    Friendica\Model\Contact\Relation:
+      - Friendica\Content\Widget
+      - Friendica\Protocol\Activity
+      - Friendica\Protocol\ActivityPub
+      - Friendica\Worker\AddContact
+    Friendica\Model\Event:
+      - Friendica\Content\Feature
+      - Friendica\Content\Text\BBCode
+      - Friendica\Protocol\Activity
+      - Friendica\Protocol\Activity\ObjectType
+    Friendica\Model\GServer:
+      - Friendica\Module\Register
+      - Friendica\Protocol\ActivityPub\Receiver
+      - Friendica\Protocol\Relay
+      - Friendica\Worker\UpdateGServer
+    Friendica\Model\Item:
+      - Friendica\Contact\LocalRelationship\Entity\LocalRelationship
+      - Friendica\Content\ContactSelector
+      - Friendica\Content\Image
+      - Friendica\Content\Post\Collection\PostMedias
+      - Friendica\Content\Post\Entity\PostMedia
+      - Friendica\Content\Text\BBCode
+      - Friendica\Content\Text\HTML
+      - Friendica\Protocol\Activity
+      - Friendica\Protocol\ActivityPub\Processor
+      - Friendica\Protocol\ActivityPub\Receiver
+      - Friendica\Protocol\ActivityPub\Transmitter
+      - Friendica\Protocol\Activity\ObjectType
+      - Friendica\Protocol\Delivery
+      - Friendica\Protocol\Diaspora
+    Friendica\Model\ItemHelper:
+      - Friendica\Content\Item
+      - Friendica\Protocol\Activity
+    Friendica\Model\Log\ParsedLogIterator:
+      - Friendica\Object\Log\ParsedLogLine
+    Friendica\Model\Mail:
+      - Friendica\Protocol\Activity
+      - Friendica\Protocol\Delivery
+    Friendica\Model\Photo:
+      - Friendica\Object\Image
+      - Friendica\Security\Security
+    Friendica\Model\Post:
+      - Friendica\Protocol\Activity
+      - Friendica\Protocol\Activity\ObjectType
+    Friendica\Model\Post\Collection:
+      - Friendica\Protocol\ActivityPub\Transmitter
+    Friendica\Model\Post\Counts:
+      - Friendica\Content\Smilies
+      - Friendica\Protocol\Activity
+    Friendica\Model\Post\Engagement:
+      - Friendica\Content\Post\Entity\PostMedia
+      - Friendica\Content\Text\BBCode
+      - Friendica\Protocol\Activity
+      - Friendica\Protocol\ActivityPub\Receiver
+      - Friendica\Protocol\Relay
+    Friendica\Model\Post\Link:
+      - Friendica\Object\Image
+    Friendica\Model\Post\Media:
+      - Friendica\Content\PageInfo
+      - Friendica\Content\Post\Entity\PostMedia
+      - Friendica\Content\Text\BBCode
+      - Friendica\Object\Image
+      - Friendica\Protocol\ActivityPub\Receiver
+    Friendica\Model\Post\User:
+      - Friendica\Protocol\Activity
+    Friendica\Model\Post\UserNotification:
+      - Friendica\Protocol\Activity
+    Friendica\Model\Profile:
+      - Friendica\Content\Feature
+      - Friendica\Content\Text\BBCode
+      - Friendica\Content\Widget\ContactBlock
+      - Friendica\Protocol\Activity
+      - Friendica\Protocol\Diaspora
+      - Friendica\Security\PermissionSet\Entity\PermissionSet
+    Friendica\Model\Register:
+      - Friendica\Content\Pager
+    Friendica\Model\Subscription:
+      - Friendica\Factory\Api\Mastodon\Notification
+      - Friendica\Navigation\Notifications\Entity\Notification
+    Friendica\Model\Tag:
+      - Friendica\Content\Text\BBCode
+      - Friendica\Protocol\ActivityPub
+    Friendica\Model\User:
+      - Friendica\Content\Pager
+      - Friendica\Module\Register
+      - Friendica\Object\Image
+      - Friendica\Protocol\Delivery
+      - Friendica\Security\TwoFactor\Model\AppSpecificPassword
+    Friendica\Navigation\Notifications\Entity\Notify:
+      - Friendica\Content\Text\BBCode
+    Friendica\Navigation\Notifications\Factory\FormattedNavNotification:
+      - Friendica\Contact\Introduction\Entity\Introduction
+    Friendica\Navigation\Notifications\Factory\FormattedNotify:
+      - Friendica\Content\Text\BBCode
+      - Friendica\Module\BaseNotifications
+      - Friendica\Protocol\Activity
+    Friendica\Navigation\Notifications\Factory\Introduction:
+      - Friendica\Content\Text\BBCode
+      - Friendica\Module\BaseNotifications
+    Friendica\Navigation\Notifications\Factory\Notification:
+      - Friendica\Content\Text\BBCode
+      - Friendica\Content\Text\Plaintext
+      - Friendica\Protocol\Activity
+    Friendica\Navigation\Notifications\Factory\Notify:
+      - Friendica\Content\Text\BBCode
+    Friendica\Navigation\Notifications\Repository\Notification:
+      - Friendica\Protocol\Activity
+    Friendica\Navigation\Notifications\Repository\Notify:
+      - Friendica\Content\Text\BBCode
+      - Friendica\Content\Text\Plaintext
+      - Friendica\Factory\Api\Mastodon\Notification
+      - Friendica\Object\Api\Mastodon\Notification
+      - Friendica\Protocol\Activity
+    Friendica\Network\Probe:
+      - Friendica\Content\Text\HTML
+      - Friendica\Model\Contact
+      - Friendica\Model\GServer
+      - Friendica\Model\Profile
+      - Friendica\Model\User
+      - Friendica\Protocol\ActivityNamespace
+      - Friendica\Protocol\ActivityPub
+      - Friendica\Protocol\ActivityPub\Transmitter
+      - Friendica\Protocol\Diaspora
+      - Friendica\Protocol\Email
+      - Friendica\Protocol\Feed
+    Friendica\Profile\ProfileField\Entity\ProfileField:
+      - Friendica\Security\PermissionSet\Entity\PermissionSet
+    Friendica\Profile\ProfileField\Factory\ProfileField:
+      - Friendica\Security\PermissionSet\Entity\PermissionSet
+      - Friendica\Security\PermissionSet\Factory\PermissionSet
+    Friendica\Profile\ProfileField\Repository\ProfileField:
+      - Friendica\Security\PermissionSet\Repository\PermissionSet
+    Friendica\Security\OAuth:
+      - Friendica\Module\BaseApi
+    Friendica\User\Settings\Repository\UserGServer:
+      - Friendica\Content\Pager
+    Friendica\Util\ACLFormatter:
+      - Friendica\Model\Circle
+    Friendica\Util\EMailer\MailBuilder:
+      - Friendica\Model\User
+      - Friendica\Object\EMail\IEmail
+      - Friendica\Object\Email
+    Friendica\Util\EMailer\NotifyMailBuilder:
+      - Friendica\Content\Text\BBCode
+      - Friendica\Model\User
+      - Friendica\Object\EMail\IEmail
+      - Friendica\Object\Email
+    Friendica\Util\EMailer\SystemMailBuilder:
+      - Friendica\Content\Text\BBCode
+      - Friendica\Model\User
+      - Friendica\Object\EMail\IEmail
+      - Friendica\Object\Email
+    Friendica\Util\Emailer:
+      - Friendica\Object\EMail\IEmail
+      - Friendica\Protocol\Email
+    Friendica\Util\HTTPSignature:
+      - Friendica\Model\APContact
+      - Friendica\Model\Contact
+      - Friendica\Model\GServer
+      - Friendica\Model\Item
+      - Friendica\Model\ItemURI
+      - Friendica\Model\User
+      - Friendica\Protocol\ActivityPub\Receiver
+    Friendica\Util\Images:
+      - Friendica\Model\Photo
+      - Friendica\Object\Image
+    Friendica\Util\JsonLD:
+      - Friendica\Protocol\ActivityPub
+    Friendica\Util\LDSignature:
+      - Friendica\Model\APContact
+    Friendica\Util\Network:
+      - Friendica\Model\Contact
+    Friendica\Util\ParseUrl:
+      - Friendica\Content\Text\BBCode
+      - Friendica\Content\Text\HTML
+      - Friendica\Model\Post\Media
+      - Friendica\Protocol\HTTP\MediaType
+    Friendica\Util\Proxy:
+      - Friendica\Content\Text\BBCode
+    Friendica\Util\Strings:
+      - Friendica\Content\ContactSelector

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2010-2026 the Friendica project
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Dependency direction check for src/.
+#
+# The one rule: code dependencies point in the same direction as our foreign keys and never back. See doc/en/developer/php-architecture.md for the tiers.
+#
+#   Delivery  ->  Features  ->  Domain  ->  Base
+#
+# Feature packages must not import each other - they talk via the event bus.
+#
+# Today's violations are frozen in deptrac-baseline.yaml, so this only blocks *new* upward or sideways imports.
+
+imports:
+    - deptrac-baseline.yaml
+
+deptrac:
+    paths:
+        - ./src
+
+    layers:
+        # --- Tier 0: Base -----------------------------------------------------
+        # Plumbing and framework primitives. Uses nothing above.
+        - name: Base
+          collectors:
+              - type: directory
+                value: src/App/.*
+              - type: directory
+                value: src/Capabilities/.*
+              - type: directory
+                value: src/Core/.*
+              - type: directory
+                value: src/Database/.*
+              - type: directory
+                value: src/Event/.*
+              - type: directory
+                value: src/Network/.*
+              - type: directory
+                value: src/Render/.*
+              - type: directory
+                value: src/System/.*
+              - type: directory
+                value: src/Util/.*
+              - type: classLike
+                value: ^Friendica\\(App|AppHelper|AppLegacy|DI|Base(Collection|DataTransferObject|Entity|Factory|Repository))$
+
+        # --- Tier 1: Domain ---------------------------------------------------
+        # The core nouns everything else points at. Uses Base only.
+        - name: Domain
+          collectors:
+              - type: directory
+                value: src/Model/.*
+              - type: directory
+                value: src/Post/.*
+              - type: directory
+                value: src/Federation/.*
+
+        # --- Tier 2: Features -------------------------------------------------
+        # One layer per feature package, so cross-feature imports are violations.
+        - name: Feature/Contact
+          collectors:
+              - type: directory
+                value: src/Contact/.*
+        - name: Feature/Moderation
+          collectors:
+              - type: directory
+                value: src/Moderation/.*
+        - name: Feature/Navigation
+          collectors:
+              - type: directory
+                value: src/Navigation/.*
+        - name: Feature/Privacy
+          collectors:
+              - type: directory
+                value: src/Privacy/.*
+        - name: Feature/Profile
+          collectors:
+              - type: directory
+                value: src/Profile/.*
+        - name: Feature/Security
+          collectors:
+              - type: directory
+                value: src/Security/.*
+        - name: Feature/User
+          collectors:
+              - type: directory
+                value: src/User/.*
+
+        # --- Tier 3: Delivery -------------------------------------------------
+        # Handles a request or a job. Nothing depends on it.
+        # The frozen top-level buckets (Object/, Factory/, Collection/) are almost
+        # entirely API DTOs and live here until they are folded into features.
+        - name: Delivery
+          collectors:
+              - type: directory
+                value: src/Collection/.*
+              - type: directory
+                value: src/Console/.*
+              - type: directory
+                value: src/Content/.*
+              - type: directory
+                value: src/Factory/.*
+              - type: directory
+                value: src/Module/.*
+              - type: directory
+                value: src/Object/.*
+              - type: directory
+                value: src/Protocol/.*
+              - type: directory
+                value: src/Worker/.*
+              - type: classLike
+                value: ^Friendica\\(BaseModule|LegacyModule)$
+
+    ruleset:
+        Base: ~
+
+        Domain:
+            - Base
+
+        Feature/Contact: &feature
+            - Domain
+            - Base
+        Feature/Moderation: *feature
+        Feature/Navigation: *feature
+        Feature/Privacy: *feature
+        Feature/Profile: *feature
+        Feature/Security: *feature
+        Feature/User: *feature
+
+        Delivery:
+            - Feature/Contact
+            - Feature/Moderation
+            - Feature/Navigation
+            - Feature/Privacy
+            - Feature/Profile
+            - Feature/Security
+            - Feature/User
+            - Domain
+            - Base

--- a/doc/en/developer/php-architecture.md
+++ b/doc/en/developer/php-architecture.md
@@ -222,6 +222,16 @@ Those mixed folders are what we untangle over time.
 
 These tiers are boundaries for **new** code; existing violations are unwound by baseline-backed follow-up work — how much exists today, and the order to get there, is tracked in [issue #15981](https://github.com/friendica/friendica/issues/15981), not here.
 
+**Checked in CI:** `composer run deptrac` maps every class in `src/` to a tier (`deptrac.yaml`) and fails on an upward import — or a sideways one between two feature packages, which is what the event bus is for.
+Today's violations are frozen in `deptrac-baseline.yaml`, so only new ones fail; when you *remove* one, `composer run deptrac:generate-baseline` locks that in.
+Never add a baseline entry by hand.
+
+**Frozen folders:** `src/Object/`, `src/Factory/` and `src/Collection/` predate the feature packages and may shrink, never grow — new factories, collections and typed objects go next to their feature (`src/<Feature>/Factory/`, …), enforced by `tests/Unit/Architecture/FrozenNamespaceTest.php`.
+The same applies to the patterns themselves: no new way of doing things next to the existing ones — that is how `src/` became a mix.
+
+**Still called "DDD":** the building blocks keep their [Domain-Driven Design](domain-driven-design) names because that vocabulary is already in the codebase and in every review.
+Aggregates and bounded contexts are deliberately not part of the target — the tiers are.
+
 ---
 
 ## 1. Dependency Injection
@@ -700,6 +710,9 @@ For the test suites and the `MYSQL_*` database variables the harness needs, see 
 
 **PHPStan level:** Level 4 with partial strict rules.
 PHPStan does not enforce architectural boundaries such as `DI::` or `DBA::` in the wrong layer — those are reviewed manually.
+
+**Deptrac:** `composer run deptrac` checks the [tier direction rule](#target-architecture) against `deptrac.yaml`, with today's violations frozen in `deptrac-baseline.yaml`.
+It runs in the `Code Quality` workflow and is part of `composer run qa`.
 
 ---
 

--- a/tests/Unit/Architecture/FrozenNamespaceTest.php
+++ b/tests/Unit/Architecture/FrozenNamespaceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Unit\Architecture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The top-level buckets `src/Object/`, `src/Factory/` and `src/Collection/` are frozen:
+ * they are being folded into the feature packages, so they may shrink but never grow.
+ *
+ * New factories, collections and typed objects belong next to their feature
+ * (`src/<Feature>/Factory/`, `src/<Feature>/Collection/`, ...).
+ *
+ * @see https://github.com/friendica/friendica/issues/15981
+ * @see doc/en/developer/php-architecture.md
+ */
+class FrozenNamespaceTest extends TestCase
+{
+	/**
+	 * Number of PHP files each frozen bucket had when it was frozen.
+	 * Lower a number when you fold one of its files into a feature package - never raise it.
+	 */
+	private const FROZEN = [
+		'src/Object'     => 64,
+		'src/Factory'    => 30,
+		'src/Collection' => 4,
+	];
+
+	/**
+	 * @return array<array{string, int}>
+	 */
+	public static function frozenBucketProvider(): array
+	{
+		$cases = [];
+
+		foreach (self::FROZEN as $path => $count) {
+			$cases[] = [$path, $count];
+		}
+
+		return $cases;
+	}
+
+	#[DataProvider('frozenBucketProvider')]
+	public function testFrozenBucketDoesNotGrow(string $path, int $frozenCount): void
+	{
+		$actualCount = count($this->phpFilesIn(dirname(__DIR__, 3) . '/' . $path));
+
+		$this->assertLessThanOrEqual(
+			$frozenCount,
+			$actualCount,
+			sprintf(
+				'%s is frozen at %d files but has %d. Put new classes into the feature package they belong to '
+				. '(src/<Feature>/Factory/, src/<Feature>/Collection/, ...) - see doc/en/developer/php-architecture.md.',
+				$path,
+				$frozenCount,
+				$actualCount,
+			),
+		);
+
+		$this->assertSame(
+			$frozenCount,
+			$actualCount,
+			sprintf(
+				'%s is down to %d files - lower its entry in %s::FROZEN to lock the progress in.',
+				$path,
+				$actualCount,
+				self::class,
+			),
+		);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function phpFilesIn(string $directory): array
+	{
+		$files = [];
+
+		/** @var \SplFileInfo $file */
+		foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS)) as $file) {
+			if ($file->isFile() && $file->getExtension() === 'php') {
+				$files[] = $file->getPathname();
+			}
+		}
+
+		return $files;
+	}
+}


### PR DESCRIPTION
Phase 0 of #15981: make the tier direction rule enforceable instead of a wish.

- `deptrac.yaml` maps `src/` onto the four tiers, one layer per feature package so cross-feature imports are violations too
- deptrac-baseline.yaml freezes today's 1025 violations, so only new upward/sideways imports fail
- new Code Quality job + composer run `deptrac` / `deptrac:generate-baseline`
- `FrozenNamespaceTest` keeps the top-level `Object/`, `Factory/` and `Collection/` buckets from growing
- `php-architecture.md`: how to run it, and why the building blocks keep their DDD names