### PR TITLE
Show pinned posts as pinned to visitors of a profile

### DIFF
--- a/src/Content/Conversation/ConversationDataProvider.php
+++ b/src/Content/Conversation/ConversationDataProvider.php
@@ -802,7 +802,9 @@ final readonly class ConversationDataProvider
 				continue;
 			}
 
-			if (($mode !== ConversationRenderer::MODE_CONTACTS) && !$row['origin']) {
+			// Only the author's own copy of a post carries the "origin" flag, so visitors would
+			// never see a pinned post as pinned on the pages that list a single author's posts.
+			if (!in_array($mode, [ConversationRenderer::MODE_CONTACTS, ConversationRenderer::MODE_PROFILE]) && !$row['origin']) {
 				$row['featured'] = false;
 			}
 


### PR DESCRIPTION
Only the author's own copy of a post carries the origin flag, so the featured flag was cleared for every other viewer - the pin was neither marked nor sorted to the top. `MODE_CONTACTS` was already excepted, `MODE_PROFILE` was missing.

Fixes #15984