### PR TITLE
omit ALT badge on files in fbrowser

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -962,6 +962,7 @@ summary.wall-item-summary {
 	pointer-events: none;
 }
 /* ...omit alt tags on images in these cases: profile description */
+.attachment .photo-album-image-wrapper::after,
 .profile-header a:has(img.has-alt-description)::after {
 	display: none;
 }


### PR DESCRIPTION
The "ALT" badges should not be displayed on files in the file browser:

### In Vier
<img width="644" height="434" alt="vier_alt_attachments" src="https://github.com/user-attachments/assets/25f139bc-8437-48a2-b182-c248665f571e" />

### In Frio Bookface Light
<img width="384" height="385" alt="file_alt_badges" src="https://github.com/user-attachments/assets/0481b169-484f-41c9-a728-34d5661e316d" />

### In Frio Light
<img width="644" height="251" alt="frio_attachments_alt" src="https://github.com/user-attachments/assets/83e95e5d-3af2-4830-908f-a3a67c1f8049" />

It's not quite as noticeable in stock Frio because all the ALT badges stack up in the lower right corner of the file browser.

I had added the file type to the alt-text on them so they wouldn't be hidden if someone said to hide images without descriptions but then that made the stylesheet think they needed ALT badges on them. This omits everything in the "attachment" browser from getting those ALT badges on them.

