### PR TITLE
Block outbound requests to private networks

### DIFF
--- a/doc/en/admin/config.md
+++ b/doc/en/admin/config.md
@@ -314,3 +314,19 @@ If you want to have a more personalized closing line for the notification emails
     'config' => [
         'admin_name' => 'Marvin',
     ]
+
+## Outbound request restrictions
+
+Friendica rejects outbound requests to non-public IP addresses, including redirect targets.
+The node's own base URL is exempt.
+To allow other internal services, list their hostnames:
+
+    'system' => [
+        'allowed_internal_hosts' => ['media-proxy.internal', '*.svc.cluster.local'],
+    ]
+
+The check can be disabled, but this is not recommended on public nodes:
+
+    'system' => [
+        'block_private_addresses' => false,
+    ]

--- a/doc/en/developer/upgrade-2026.08.md
+++ b/doc/en/developer/upgrade-2026.08.md
@@ -14,6 +14,12 @@ Mandatory (Breaking changes)
 
 This section contains backward compatibility breaks, make sure your code is compatible with these entries before upgrading.
 
+- Outbound requests to non-public IP addresses are blocked by default.
+
+   This can affect internal feed servers, mail servers, media proxies and other services using private network addresses.
+   Add required hostnames to `system.allowed_internal_hosts`.
+   The protection can be disabled with `system.block_private_addresses`, but this is not recommended on public nodes.
+
 - The icon library has been changed from Font Awesome to Remix Icons. Theme developers must replace `fa-*` CSS classes with their `ri-*` equivalents.
 
    The Font Awesome dependency has been removed. Any theme or addon that relies on Font Awesome must either include it themselves or migrate to Remix Icons.

--- a/src/Module/Debug/ActivityPubConversion.php
+++ b/src/Module/Debug/ActivityPubConversion.php
@@ -10,6 +10,7 @@ namespace Friendica\Module\Debug;
 use Friendica\BaseModule;
 use Friendica\Core\Renderer;
 use Friendica\DI;
+use Friendica\Network\HTTPException;
 use Friendica\Protocol\ActivityPub;
 use Friendica\Util\JsonLD;
 
@@ -23,6 +24,11 @@ class ActivityPubConversion extends BaseModule
 
 	protected function content(array $request = []): string
 	{
+		// Conversion fetches referenced actors and objects.
+		if (!DI::userSession()->getLocalUserId()) {
+			throw new HTTPException\ForbiddenException(DI::l10n()->t('Only logged in users are permitted to perform a conversion.'));
+		}
+
 		$results = [];
 
 		$visible_whitespace = function (string $s): string {

--- a/src/Network/HTTPClient/Client/HttpClient.php
+++ b/src/Network/HTTPClient/Client/HttpClient.php
@@ -84,6 +84,18 @@ class HttpClient implements ICanSendHttpRequests
 			return CurlResult::createErrorCurl($this->logger, $url);
 		}
 
+		if (!Network::isValidHttpUrl($url)) {
+			$this->logger->info('Unsupported scheme.', ['url' => $url]);
+			$this->profiler->stopRecording();
+			return CurlResult::createErrorCurl($this->logger, $url);
+		}
+
+		if (Network::isPrivateTarget(new Uri($url))) {
+			$this->logger->notice('Target is not on the public internet.', ['url' => $url]);
+			$this->profiler->stopRecording();
+			return CurlResult::createErrorCurl($this->logger, $url);
+		}
+
 		$conf = [];
 
 		if (!empty($opts[HttpClientOptions::COOKIEJAR])) {
@@ -239,6 +251,11 @@ class HttpClient implements ICanSendHttpRequests
 
 		if (Network::isRedirectBlocked($url)) {
 			$this->logger->info('Domain should not be redirected.', ['url' => $url]);
+			return $url;
+		}
+
+		if (Network::isPrivateTarget(new Uri($url))) {
+			$this->logger->notice('Target is not on the public internet.', ['url' => $url]);
 			return $url;
 		}
 

--- a/src/Network/HTTPClient/Factory/HttpClient.php
+++ b/src/Network/HTTPClient/Factory/HttpClient.php
@@ -13,9 +13,11 @@ use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\System;
 use Friendica\Network\HTTPClient\Client;
 use Friendica\Network\HTTPClient\Capability\ICanSendHttpRequests;
+use Friendica\Util\Network;
 use Friendica\Util\Profiler;
 use Friendica\Util\Strings;
 use GuzzleHttp;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\RequestOptions;
 use mattwright\URLResolver;
@@ -64,6 +66,12 @@ class HttpClient extends BaseFactory
 			UriInterface $uri,
 		) use ($logger): void {
 			$logger->info('Curl redirect.', ['url' => $request->getUri(), 'to' => $uri, 'method' => $request->getMethod()]);
+
+			// Apply the outbound restrictions to every redirect target.
+			if (Network::isUriBlocked($uri) || !Network::isValidHttpUrl((string) $uri) || Network::isPrivateTarget($uri)) {
+				$logger->notice('Redirect target is not allowed.', ['url' => $request->getUri(), 'to' => $uri]);
+				throw new TransferException('Redirect to a disallowed target: ' . $uri);
+			}
 		};
 
 		$guzzle = new GuzzleHttp\Client([

--- a/src/Protocol/Email.php
+++ b/src/Protocol/Email.php
@@ -13,7 +13,9 @@ use Friendica\Content\Text\HTML;
 use Friendica\Core\Protocol;
 use Friendica\DI;
 use Friendica\Model\Item;
+use Friendica\Util\Network;
 use Friendica\Util\Strings;
+use GuzzleHttp\Psr7\Uri;
 use IMAP\Connection;
 
 /**
@@ -34,6 +36,11 @@ class Email
 			return false;
 		}
 
+		if (self::isPrivateMailbox($mailbox)) {
+			DI::logger()->notice('Mail server is not on the public internet.', ['mailbox' => $mailbox]);
+			return false;
+		}
+
 		$mbox = @imap_open($mailbox, $username, $password);
 
 		$errors = imap_errors();
@@ -50,6 +57,22 @@ class Email
 			Item::incrementInbound(Protocol::MAIL);
 		}
 		return $mbox;
+	}
+
+	/** Checks whether an IMAP mailbox targets the internal network. */
+	private static function isPrivateMailbox(string $mailbox): bool
+	{
+		// The host may be a bracketed IPv6 address.
+		if (!preg_match('#^\{(\[[^\]]+\]|[^:/}]+)#', $mailbox, $matches)) {
+			return false;
+		}
+
+		try {
+			return Network::isPrivateTarget(new Uri('imap://' . $matches[1]));
+		} catch (\Throwable) {
+			DI::logger()->notice('Invalid mail server', ['mailbox' => $mailbox]);
+			return true;
+		}
 	}
 
 	/**

--- a/src/Protocol/Email.php
+++ b/src/Protocol/Email.php
@@ -13,9 +13,7 @@ use Friendica\Content\Text\HTML;
 use Friendica\Core\Protocol;
 use Friendica\DI;
 use Friendica\Model\Item;
-use Friendica\Util\Network;
 use Friendica\Util\Strings;
-use GuzzleHttp\Psr7\Uri;
 use IMAP\Connection;
 
 /**
@@ -36,11 +34,6 @@ class Email
 			return false;
 		}
 
-		if (self::isPrivateMailbox($mailbox)) {
-			DI::logger()->notice('Mail server is not on the public internet.', ['mailbox' => $mailbox]);
-			return false;
-		}
-
 		$mbox = @imap_open($mailbox, $username, $password);
 
 		$errors = imap_errors();
@@ -57,22 +50,6 @@ class Email
 			Item::incrementInbound(Protocol::MAIL);
 		}
 		return $mbox;
-	}
-
-	/** Checks whether an IMAP mailbox targets the internal network. */
-	private static function isPrivateMailbox(string $mailbox): bool
-	{
-		// The host may be a bracketed IPv6 address.
-		if (!preg_match('#^\{(\[[^\]]+\]|[^:/}]+)#', $mailbox, $matches)) {
-			return false;
-		}
-
-		try {
-			return Network::isPrivateTarget(new Uri('imap://' . $matches[1]));
-		} catch (\Throwable) {
-			DI::logger()->notice('Invalid mail server', ['mailbox' => $mailbox]);
-			return true;
-		}
 	}
 
 	/**

--- a/src/Util/IpAddress.php
+++ b/src/Util/IpAddress.php
@@ -46,12 +46,6 @@ final class IpAddress
 		'2002::/16'     => 2,  // 6to4 (RFC 3056)
 	];
 
-	/** Checks whether an address is publicly routable. */
-	public static function isPublic(string $address): bool
-	{
-		return !self::isNonPublic($address);
-	}
-
 	/** Checks whether an address is invalid or non-public. */
 	public static function isNonPublic(string $address): bool
 	{

--- a/src/Util/IpAddress.php
+++ b/src/Util/IpAddress.php
@@ -1,0 +1,114 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Util;
+
+/** Classifies IP addresses without external dependencies. */
+final class IpAddress
+{
+	/** @var array<string, string[]> Non-public CIDR ranges by address family. */
+	private const NON_PUBLIC_RANGES = [
+		'v4' => [
+			'0.0.0.0/8',          // "This network" (RFC 1122)
+			'10.0.0.0/8',         // Private (RFC 1918)
+			'100.64.0.0/10',      // Carrier grade NAT (RFC 6598)
+			'127.0.0.0/8',        // Loopback (RFC 1122)
+			'169.254.0.0/16',     // Link local, includes the cloud metadata service (RFC 3927)
+			'172.16.0.0/12',      // Private (RFC 1918)
+			'192.0.0.0/24',       // IETF protocol assignments (RFC 6890)
+			'192.0.2.0/24',       // Documentation (RFC 5737)
+			'192.168.0.0/16',     // Private (RFC 1918)
+			'198.18.0.0/15',      // Benchmarking (RFC 2544)
+			'198.51.100.0/24',    // Documentation (RFC 5737)
+			'203.0.113.0/24',     // Documentation (RFC 5737)
+			'224.0.0.0/4',        // Multicast (RFC 5771)
+			'240.0.0.0/4',        // Reserved, includes the broadcast address (RFC 1112)
+		],
+		'v6' => [
+			'::/128',             // Unspecified (RFC 4291)
+			'::1/128',            // Loopback (RFC 4291)
+			'100::/64',           // Discard only (RFC 6666)
+			'2001:db8::/32',      // Documentation (RFC 3849)
+			'fc00::/7',           // Unique local (RFC 4193)
+			'fe80::/10',          // Link local (RFC 4291)
+			'ff00::/8',           // Multicast (RFC 4291)
+		],
+	];
+
+	/** @var array<string, int> IPv6 CIDR ranges mapped to their embedded IPv4 byte offset. */
+	private const EMBEDDED_IPV4_RANGES = [
+		'::ffff:0:0/96' => 12, // IPv4 mapped (RFC 4291)
+		'64:ff9b::/96'  => 12, // NAT64 (RFC 6052)
+		'2002::/16'     => 2,  // 6to4 (RFC 3056)
+	];
+
+	/** Checks whether an address is publicly routable. */
+	public static function isPublic(string $address): bool
+	{
+		return !self::isNonPublic($address);
+	}
+
+	/** Checks whether an address is invalid or non-public. */
+	public static function isNonPublic(string $address): bool
+	{
+		// An IPv6 address may carry a zone index ("fe80::1%eth0") which inet_pton rejects
+		$address = explode('%', $address, 2)[0];
+
+		$binary = @inet_pton($address);
+		if ($binary === false) {
+			return true;
+		}
+
+		$family = strlen($binary) === 4 ? 'v4' : 'v6';
+
+		foreach (self::NON_PUBLIC_RANGES[$family] as $range) {
+			if (self::matchesCidr($binary, $range)) {
+				return true;
+			}
+		}
+
+		if ($family === 'v6') {
+			foreach (self::EMBEDDED_IPV4_RANGES as $range => $offset) {
+				if (self::matchesCidr($binary, $range)) {
+					return self::isNonPublic(inet_ntop(substr($binary, $offset, 4)));
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param string $binary Packed in_addr representation, as returned by inet_pton()
+	 * @param string $cidr   Range in CIDR notation
+	 */
+	private static function matchesCidr(string $binary, string $cidr): bool
+	{
+		[$subnet, $bits] = explode('/', $cidr);
+
+		$subnetBinary = inet_pton($subnet);
+		if ($subnetBinary === false || strlen($subnetBinary) !== strlen($binary)) {
+			return false;
+		}
+
+		$bits      = (int) $bits;
+		$fullBytes = intdiv($bits, 8);
+		$extraBits = $bits % 8;
+
+		if ($fullBytes > 0 && strncmp($binary, $subnetBinary, $fullBytes) !== 0) {
+			return false;
+		}
+
+		if ($extraBits === 0) {
+			return true;
+		}
+
+		$mask = ~((1 << (8 - $extraBits)) - 1) & 0xFF;
+
+		return (ord($binary[$fullBytes]) & $mask) === (ord($subnetBinary[$fullBytes]) & $mask);
+	}
+}

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -241,6 +241,58 @@ class Network
 		return false;
 	}
 
+	/** Checks whether an outbound request targets a non-public address. */
+	public static function isPrivateTarget(UriInterface $uri): bool
+	{
+		if (!DI::config()->get('system', 'block_private_addresses', true)) {
+			return false;
+		}
+
+		$host = $uri->getHost();
+		if ($host === '') {
+			return false;
+		}
+
+		if (strcasecmp($host, DI::baseUrl()->getHost()) === 0) {
+			return false;
+		}
+
+		foreach (DI::config()->get('system', 'allowed_internal_hosts', []) as $allowed) {
+			if (!empty($allowed) && fnmatch(strtolower((string) $allowed), strtolower($host))) {
+				return false;
+			}
+		}
+
+		foreach (self::resolveHost($host) as $address) {
+			if (IpAddress::isNonPublic($address)) {
+				DI::logger()->info('Target is not on the public internet.', ['host' => $host, 'address' => $address]);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** @return string[] All resolved addresses for the host. */
+	private static function resolveHost(string $host): array
+	{
+		$host = trim($host, '[]');
+
+		if (filter_var($host, FILTER_VALIDATE_IP)) {
+			return [$host];
+		}
+
+		$addresses = @gethostbynamel($host) ?: [];
+
+		foreach (@dns_get_record($host . '.', DNS_AAAA) ?: [] as $record) {
+			if (!empty($record['ipv6'])) {
+				$addresses[] = $record['ipv6'];
+			}
+		}
+
+		return $addresses;
+	}
+
 	/**
 	 * Check if email address is allowed to register here.
 	 *

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -91,6 +91,11 @@ return [
 		// Days of inactivity after which an admin is considered inactive. "0" means that there will be no check for inactivity.
 		'admin_inactivity_limit' => 30,
 
+		// allowed_internal_hosts (Array)
+		// Internal hosts that server-side requests may reach. Wildcards are allowed.
+		// See block_private_addresses.
+		'allowed_internal_hosts' => [],
+
 		// allowed_link_protocols (Array)
 		// Allowed protocols in links URLs, add at your own risk. http(s) is always allowed.
 		'allowed_link_protocols' => ['ftp://', 'ftps://', 'mailto:', 'cid:', 'gopher://'],
@@ -138,6 +143,11 @@ return [
 		// bulk_delivery (Boolean)
 		// Delivers AP messages in a bulk (experimental)
 		'bulk_delivery' => false,
+
+		// block_private_addresses (Boolean)
+		// Refuse server-side requests to non-public IP addresses, including redirects.
+		// The node's base URL and allowed_internal_hosts are exempt.
+		'block_private_addresses' => true,
 
 		// block_local_dir (Boolean)
 		// Deny public access to the local user directory.

--- a/tests/Unit/Util/IpAddressTest.php
+++ b/tests/Unit/Util/IpAddressTest.php
@@ -1,0 +1,104 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Test\Unit\Util;
+
+use Friendica\Util\IpAddress;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class IpAddressTest extends TestCase
+{
+	public static function nonPublicProvider(): array
+	{
+		return [
+			// IPv4
+			'unspecified'      => ['0.0.0.0'],
+			'this network'     => ['0.1.2.3'],
+			'loopback'         => ['127.0.0.1'],
+			'loopback obscure' => ['127.1.2.3'],
+			'private 10'       => ['10.1.2.3'],
+			'private 172 low'  => ['172.16.0.1'],
+			'private 172 high' => ['172.31.255.254'],
+			'private 192.168'  => ['192.168.1.1'],
+			'cgnat'            => ['100.64.0.1'],
+			'link local'       => ['169.254.1.1'],
+			'cloud metadata'   => ['169.254.169.254'],
+			'ietf protocol'    => ['192.0.0.8'],
+			'benchmarking'     => ['198.19.0.1'],
+			'documentation'    => ['192.0.2.1'],
+			'multicast'        => ['239.255.255.250'],
+			'reserved'         => ['240.0.0.1'],
+			'broadcast'        => ['255.255.255.255'],
+			// IPv6
+			'v6 unspecified'      => ['::'],
+			'v6 loopback'         => ['::1'],
+			'v6 unique local'     => ['fd00::1'],
+			'v6 unique local fc'  => ['fc00::1'],
+			'v6 link local'       => ['fe80::1'],
+			'v6 link local zoned' => ['fe80::1%eth0'],
+			'v6 multicast'        => ['ff02::1'],
+			'v6 documentation'    => ['2001:db8::1'],
+			'v6 discard'          => ['100::1'],
+			// IPv6 with an embedded IPv4 address
+			'v4 mapped loopback' => ['::ffff:127.0.0.1'],
+			'v4 mapped private'  => ['::ffff:192.168.0.1'],
+			'v4 mapped metadata' => ['::ffff:169.254.169.254'],
+			'nat64 loopback'     => ['64:ff9b::127.0.0.1'],
+			'6to4 private'       => ['2002:c0a8:0001::1'],
+			// Not an address at all
+			'empty'            => [''],
+			'hostname'         => ['friendi.ca'],
+			'garbage'          => ['not an ip'],
+			'decimal notation' => ['2130706433'],
+		];
+	}
+
+	#[DataProvider('nonPublicProvider')]
+	public function testNonPublicAddressesAreRejected(string $address): void
+	{
+		self::assertTrue(IpAddress::isNonPublic($address), $address . ' should not be reachable');
+		self::assertFalse(IpAddress::isPublic($address));
+	}
+
+	/** Ensures public addresses remain reachable. */
+	public static function publicProvider(): array
+	{
+		return [
+			'public v4'         => ['193.99.144.80'],
+			'public v4 low'     => ['1.1.1.1'],
+			'public v4 8.8.8.8' => ['8.8.8.8'],
+			// Boundaries of blocked ranges.
+			'below 10/8'             => ['9.255.255.255'],
+			'above 10/8'             => ['11.0.0.0'],
+			'below 172.16/12'        => ['172.15.255.255'],
+			'above 172.16/12'        => ['172.32.0.0'],
+			'below 192.168/16'       => ['192.167.255.255'],
+			'above 192.168/16'       => ['192.169.0.0'],
+			'below 100.64/10'        => ['100.63.255.255'],
+			'above 100.64/10'        => ['100.128.0.0'],
+			'below 169.254/16'       => ['169.253.255.255'],
+			'above 169.254/16'       => ['169.255.0.0'],
+			'below multicast'        => ['223.255.255.255'],
+			'below 192.0.0/24'       => ['191.255.255.255'],
+			'above 192.0.2/24'       => ['192.0.3.1'],
+			'public v6'              => ['2a01:4f8:c17:b8f::1'],
+			'public v6 dns'          => ['2606:4700:4700::1111'],
+			'v4 mapped public'       => ['::ffff:8.8.8.8'],
+			'nat64 public'           => ['64:ff9b::8.8.8.8'],
+			'6to4 public'            => ['2002:0808:0808::1'],
+			'above documentation v6' => ['2001:db9::1'],
+		];
+	}
+
+	#[DataProvider('publicProvider')]
+	public function testPublicAddressesAreAccepted(string $address): void
+	{
+		self::assertTrue(IpAddress::isPublic($address), $address . ' should be reachable');
+		self::assertFalse(IpAddress::isNonPublic($address));
+	}
+}

--- a/tests/Unit/Util/IpAddressTest.php
+++ b/tests/Unit/Util/IpAddressTest.php
@@ -62,7 +62,6 @@ class IpAddressTest extends TestCase
 	public function testNonPublicAddressesAreRejected(string $address): void
 	{
 		self::assertTrue(IpAddress::isNonPublic($address), $address . ' should not be reachable');
-		self::assertFalse(IpAddress::isPublic($address));
 	}
 
 	/** Ensures public addresses remain reachable. */
@@ -98,7 +97,6 @@ class IpAddressTest extends TestCase
 	#[DataProvider('publicProvider')]
 	public function testPublicAddressesAreAccepted(string $address): void
 	{
-		self::assertTrue(IpAddress::isPublic($address), $address . ' should be reachable');
-		self::assertFalse(IpAddress::isNonPublic($address));
+		self::assertFalse(IpAddress::isNonPublic($address), $address . ' should be reachable');
 	}
 }

--- a/tests/Unit/Util/OutboundSchemeTest.php
+++ b/tests/Unit/Util/OutboundSchemeTest.php
@@ -1,0 +1,88 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Test\Unit\Util;
+
+use Friendica\Util\Network;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** Tests URL schemes accepted by the HTTP client. */
+class OutboundSchemeTest extends TestCase
+{
+	public static function requestableProvider(): array
+	{
+		return [
+			// Fediverse actors and objects
+			'mastodon actor'      => ['https://mastodon.social/users/Gargron'],
+			'mastodon status'     => ['https://mastodon.social/users/Gargron/statuses/109252195269200000'],
+			'mastodon webfinger'  => ['https://mastodon.social/.well-known/webfinger?resource=acct%3AGargron%40mastodon.social'],
+			'friendica profile'   => ['https://friendica.example/profile/tobias'],
+			'friendica objects'   => ['https://friendica.example/objects/1a2b3c4d-5e6f-7890-abcd-ef1234567890'],
+			'diaspora receive'    => ['https://diaspora.example/receive/users/abcdef0123456789'],
+			'pleroma object'      => ['https://pleroma.example/objects/0193d5f2-2b62-7c9c-9c4c-0e0d0a0b0c0d'],
+			'peertube video'      => ['https://peertube.example/videos/watch/9f8b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d'],
+			'lemmy community'     => ['https://lemmy.example/c/friendica'],
+			'nodeinfo well-known' => ['https://friendi.ca/.well-known/nodeinfo'],
+			'host-meta'           => ['https://friendi.ca/.well-known/host-meta'],
+			// Feeds and media, the other big outbound consumers
+			'atom feed'       => ['https://example.org/feed/atom'],
+			'rss with query'  => ['https://example.org/?feed=rss2&cat=7'],
+			'avatar'          => ['https://cdn.example.org/avatars/1234/original.png'],
+			'oembed endpoint' => ['https://example.org/oembed?url=https%3A%2F%2Fexample.org%2Fp%2F1&format=json'],
+			// Shapes that must not be rejected by accident
+			'plain http'        => ['http://legacy.example.org/profile/user'],
+			'explicit port'     => ['https://example.org:8443/users/alice'],
+			'idn host'          => ['https://präsenz.example/profile/user'],
+			'punycode host'     => ['https://xn--prsenz-tya.example/profile/user'],
+			'unicode path'      => ['https://example.org/profile/josé'],
+			'percent encoded'   => ['https://example.org/tag/%C3%BCber'],
+			'fragment'          => ['https://example.org/display/abc#comment-1'],
+			'onion service'     => ['http://friendicaxyz234567.onion/profile/user'],
+			'i2p service'       => ['http://friendica.i2p/profile/user'],
+			'trailing dot host' => ['https://example.org./users/alice'],
+		];
+	}
+
+	#[DataProvider('requestableProvider')]
+	public function testFederatedUrlsStayRequestable(string $url): void
+	{
+		self::assertTrue(Network::isValidHttpUrl($url), $url . ' must stay requestable');
+	}
+
+	public static function notRequestableProvider(): array
+	{
+		return [
+			// Non-http identifiers, resolved before any HTTP request happens
+			'acct'         => ['acct:Gargron@mastodon.social'],
+			'mailto'       => ['mailto:user@example.org'],
+			'at protocol'  => ['at://did:plc:geqiabvo4b4jnfv2paplzcge/app.bsky.feed.post/abc123'],
+			'did'          => ['did:plc:geqiabvo4b4jnfv2paplzcge'],
+			'diaspora uri' => ['diaspora://alice@example.org/post/guid'],
+			'tag uri'      => ['tag:example.org,2026-08:objectId=1:objectType=Note'],
+			'urn uuid'     => ['urn:uuid:1a2b3c4d-5e6f-7890-abcd-ef1234567890'],
+			// Schemes curl speaks but the node has no business speaking
+			'file'   => ['file:///etc/passwd'],
+			'ftp'    => ['ftp://example.org/pub/file'],
+			'gopher' => ['gopher://example.org/1'],
+			'dict'   => ['dict://example.org:2628/d:word'],
+			'ldap'   => ['ldap://example.org/o=org'],
+			// Not a network location at all
+			'javascript'  => ['javascript:alert(1)'],
+			'data'        => ['data:text/html,<script>alert(1)</script>'],
+			'no scheme'   => ['example.org/users/alice'],
+			'scheme only' => ['https://'],
+			'empty'       => [''],
+		];
+	}
+
+	#[DataProvider('notRequestableProvider')]
+	public function testNonHttpIdentifiersAreNotRequested(string $url): void
+	{
+		self::assertFalse(Network::isValidHttpUrl($url), $url . ' must not be requested over HTTP');
+	}
+}

--- a/tests/src/Network/HTTPClient/Client/HTTPClientTest.php
+++ b/tests/src/Network/HTTPClient/Client/HTTPClientTest.php
@@ -8,10 +8,12 @@
 namespace Friendica\Test\src\Network\HTTPClient\Client;
 
 use Friendica\DI;
+use Friendica\Util\Network;
 use Friendica\Test\DiceHttpMockHandlerTrait;
 use Friendica\Test\MockedTestCase;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class HTTPClientTest extends MockedTestCase
 {
@@ -56,5 +58,94 @@ class HTTPClientTest extends MockedTestCase
 		$result = DI::httpClient()->get('https://mastodon.social');
 		self::assertEquals('https://mastodon.social', $result->getUrl());
 		self::assertEquals('https://mastodon.social/about', $result->getRedirectUrl());
+	}
+
+	public static function privateTargetProvider(): array
+	{
+		return [
+			'loopback'       => ['http://127.0.0.1:9999/'],
+			'loopback v6'    => ['http://[::1]:9999/'],
+			'private'        => ['http://10.1.2.3/'],
+			'private 192'    => ['http://192.168.178.1/'],
+			'cloud metadata' => ['http://169.254.169.254/latest/meta-data/'],
+			'v4 mapped'      => ['http://[::ffff:127.0.0.1]/'],
+		];
+	}
+
+	/** Ensures private targets are not requested. */
+	#[DataProvider('privateTargetProvider')]
+	public function testPrivateTargetIsNotRequested(string $url): void
+	{
+		$mock = new MockHandler([new Response(200, [], 'internal secret')]);
+		$this->httpRequestHandler->setHandler($mock);
+
+		self::assertFalse(DI::httpClient()->get($url)->isSuccess());
+		self::assertCount(1, $mock, 'the request was sent even though the target is private');
+	}
+
+	/** Ensures redirects to private targets are not followed. */
+	public function testRedirectToPrivateTargetIsNotFollowed(): void
+	{
+		$mock = new MockHandler([
+			new Response(302, ['Location' => 'http://127.0.0.1:9999/redir-target']),
+			new Response(200, [], 'internal secret'),
+		]);
+		$this->httpRequestHandler->setHandler($mock);
+
+		self::assertFalse(DI::httpClient()->get('https://mastodon.social')->isSuccess());
+		self::assertCount(1, $mock, 'the redirect into the private network was followed');
+	}
+
+	public static function unsupportedSchemeProvider(): array
+	{
+		return [
+			'file'   => ['file://localhost/etc/passwd'],
+			'gopher' => ['gopher://localhost/1'],
+			'ftp'    => ['ftp://localhost/file'],
+		];
+	}
+
+	#[DataProvider('unsupportedSchemeProvider')]
+	public function testUnsupportedSchemeIsRejected(string $url): void
+	{
+		$mock = new MockHandler([new Response(200)]);
+		$this->httpRequestHandler->setHandler($mock);
+
+		self::assertFalse(DI::httpClient()->get($url)->isSuccess());
+		self::assertCount(1, $mock);
+	}
+
+	/** Ensures public targets remain reachable. */
+	public function testPublicTargetIsStillRequested(): void
+	{
+		$this->httpRequestHandler->setHandler(new MockHandler([new Response(200, [], 'hello')]));
+
+		$result = DI::httpClient()->get('https://mastodon.social');
+		self::assertTrue($result->isSuccess());
+		self::assertEquals('hello', $result->getBodyString());
+	}
+
+	/** Ensures the node can request its own base URL. */
+	public function testOwnBaseUrlIsNeverPrivate(): void
+	{
+		self::assertFalse(Network::isPrivateTarget(DI::baseUrl()));
+	}
+
+	public function testAllowedInternalHostIsRequested(): void
+	{
+		DI::config()->set('system', 'allowed_internal_hosts', ['127.0.0.1']);
+
+		$this->httpRequestHandler->setHandler(new MockHandler([new Response(200, [], 'hello')]));
+
+		self::assertTrue(DI::httpClient()->get('http://127.0.0.1:9999/thumb.jpg')->isSuccess());
+	}
+
+	public function testCheckCanBeDisabled(): void
+	{
+		DI::config()->set('system', 'block_private_addresses', false);
+
+		$this->httpRequestHandler->setHandler(new MockHandler([new Response(200, [], 'internal')]));
+
+		self::assertTrue(DI::httpClient()->get('http://127.0.0.1:9999/')->isSuccess());
 	}
 }

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.08-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-21 00:23+0200\n"
+"POT-Creation-Date: 2026-08-21 21:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,7 +82,7 @@ msgid "Permission denied."
 msgstr ""
 
 #: mod/message.php:28 mod/message.php:124 src/Content/Nav.php:281
-#: view/theme/frio/theme.php:236
+#: view/theme/frio/theme.php:230
 msgid "Messages"
 msgstr ""
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Insert web link"
 msgstr ""
 
-#: mod/message.php:192 mod/message.php:348 src/App/Page.php:277
+#: mod/message.php:192 mod/message.php:348 src/App/Page.php:279
 #: src/Content/Conversation/ConversationRenderer.php:539
 #: src/Content/Conversation/PostTemplateBuilder.php:393
 #: src/Content/Conversation/StatusEditor.php:182
@@ -315,7 +315,7 @@ msgstr ""
 msgid "If you want to add this photo to an album, begin typing its name, and existing albums will be suggested, which you can select. If you choose something new, it will be created."
 msgstr ""
 
-#: mod/photos.php:487 mod/photos.php:806
+#: mod/photos.php:487 mod/photos.php:808
 #: src/Content/Conversation/StatusEditor.php:184
 #: src/Module/Calendar/Event/Form.php:266 src/Module/Post/Edit.php:196
 msgid "Permissions"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "New album name: "
 msgstr ""
 
-#: mod/photos.php:577 mod/photos.php:809 src/Module/Calendar/Event/Form.php:124
+#: mod/photos.php:577 mod/photos.php:811 src/Module/Calendar/Event/Form.php:124
 #: src/Module/Settings/Server/Index.php:104
 msgid "Save changes"
 msgstr ""
@@ -379,7 +379,7 @@ msgstr ""
 msgid "Do you really want to delete this photo?"
 msgstr ""
 
-#: mod/photos.php:654 mod/photos.php:810
+#: mod/photos.php:654 mod/photos.php:812
 msgid "Delete Photo"
 msgstr ""
 
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Delete photo"
 msgstr ""
 
-#: mod/photos.php:756 mod/photos.php:829
+#: mod/photos.php:756 mod/photos.php:831
 msgid "Use as profile picture"
 msgstr ""
 
@@ -407,32 +407,32 @@ msgstr ""
 msgid "View Full Size"
 msgstr ""
 
-#: mod/photos.php:798
+#: mod/photos.php:800
 msgid "New album name"
 msgstr ""
 
-#: mod/photos.php:799
+#: mod/photos.php:801
 msgid "Caption"
 msgstr ""
 
-#: mod/photos.php:800
+#: mod/photos.php:802
 msgid "Do not rotate"
 msgstr ""
 
-#: mod/photos.php:801
+#: mod/photos.php:803
 msgid "Rotate CW (right)"
 msgstr ""
 
-#: mod/photos.php:802
+#: mod/photos.php:804
 msgid "Rotate CCW (left)"
 msgstr ""
 
-#: mod/photos.php:827 src/Model/Event.php:654
+#: mod/photos.php:829 src/Model/Event.php:654
 #: src/Module/Calendar/Event/Show.php:77
 msgid "Edit"
 msgstr ""
 
-#: mod/photos.php:828 src/Content/Conversation/ConversationRenderer.php:468
+#: mod/photos.php:830 src/Content/Conversation/ConversationRenderer.php:468
 #: src/Model/Event.php:656 src/Module/Calendar/Event/Show.php:79
 #: src/Module/Moderation/Users/Active.php:92
 #: src/Module/Moderation/Users/Blocked.php:92
@@ -442,7 +442,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: mod/photos.php:830
+#: mod/photos.php:832
 msgid "Back to viewing"
 msgstr ""
 
@@ -543,37 +543,37 @@ msgstr ""
 msgid "You can't upload any more files."
 msgstr ""
 
-#: src/App/Page.php:266
+#: src/App/Page.php:268
 msgid "Fetching..."
 msgstr ""
 
-#: src/App/Page.php:267
+#: src/App/Page.php:269
 msgid "Receiving data..."
 msgstr ""
 
-#: src/App/Page.php:268
+#: src/App/Page.php:270
 msgid "Processing..."
 msgstr ""
 
-#: src/App/Page.php:269
+#: src/App/Page.php:271
 msgid "Posting..."
 msgstr ""
 
-#: src/App/Page.php:274
+#: src/App/Page.php:276
 msgid "Timeout"
 msgstr ""
 
-#: src/App/Page.php:275
+#: src/App/Page.php:277
 msgid "The request took too long. Please try again."
 msgstr ""
 
-#: src/App/Page.php:276 src/App/Page.php:364 src/Module/Admin/Logs/View.php:91
+#: src/App/Page.php:278 src/App/Page.php:366 src/Module/Admin/Logs/View.php:91
 #: src/Module/Item/Compose.php:336 src/Module/Media/Attachment/Browser.php:69
 #: src/Module/Media/Photo/Browser.php:81 view/theme/frio/php/minimal.php:39
 msgid "Close"
 msgstr ""
 
-#: src/App/Page.php:353
+#: src/App/Page.php:355
 msgid "toggle mobile"
 msgstr ""
 
@@ -2131,11 +2131,11 @@ msgstr ""
 msgid "%1$s tagged %2$s's %3$s with %4$s"
 msgstr ""
 
-#: src/Content/Item.php:425 view/theme/frio/theme.php:257
+#: src/Content/Item.php:425 view/theme/frio/theme.php:251
 msgid "Turn on notifications for this post"
 msgstr ""
 
-#: src/Content/Item.php:426 view/theme/frio/theme.php:274
+#: src/Content/Item.php:426 view/theme/frio/theme.php:268
 msgid "Fetch more replies"
 msgstr ""
 
@@ -2217,7 +2217,7 @@ msgid "My Profile"
 msgstr ""
 
 #: src/Content/Nav.php:100 src/Content/Nav.php:271 src/Module/Help.php:68
-#: view/theme/frio/theme.php:234
+#: view/theme/frio/theme.php:228
 msgid "Home"
 msgstr ""
 
@@ -2250,11 +2250,11 @@ msgstr ""
 #: src/Content/Nav.php:207 src/Module/BaseProfile.php:50
 #: src/Module/Media/Attachment/Browser.php:67
 #: src/Module/Media/Photo/Browser.php:62 src/Module/Media/Photo/Browser.php:79
-#: view/theme/frio/theme.php:228
+#: view/theme/frio/theme.php:222
 msgid "Photos"
 msgstr ""
 
-#: src/Content/Nav.php:207 view/theme/frio/theme.php:228
+#: src/Content/Nav.php:207 view/theme/frio/theme.php:222
 msgid "My photos"
 msgstr ""
 
@@ -2270,11 +2270,11 @@ msgstr ""
 #: src/Content/Nav.php:215 src/Module/BaseProfile.php:34
 #: src/Module/BaseSettings.php:86 src/Module/Contact.php:487
 #: src/Module/Contact/Profile.php:439 src/Module/Profile/Profile.php:277
-#: src/Module/Welcome.php:44 view/theme/frio/theme.php:222
+#: src/Module/Welcome.php:44 view/theme/frio/theme.php:216
 msgid "Profile"
 msgstr ""
 
-#: src/Content/Nav.php:215 view/theme/frio/theme.php:222
+#: src/Content/Nav.php:215 view/theme/frio/theme.php:216
 msgid "My profile"
 msgstr ""
 
@@ -2331,7 +2331,7 @@ msgstr ""
 #: src/Content/Text/HTML.php:882 src/Module/BaseProfile.php:112
 #: src/Module/BaseProfile.php:115 src/Module/Contact.php:191
 #: src/Module/Contact.php:409 src/Module/Contact.php:519
-#: view/theme/frio/theme.php:238
+#: view/theme/frio/theme.php:232
 msgid "Contacts"
 msgstr ""
 
@@ -2342,8 +2342,8 @@ msgstr ""
 #: src/Content/Nav.php:258 src/Module/BaseProfile.php:70
 #: src/Module/BaseProfile.php:73 src/Module/BaseProfile.php:81
 #: src/Module/BaseProfile.php:84 src/Module/Calendar/Show.php:113
-#: src/Module/Settings/Display.php:448 view/theme/frio/theme.php:229
-#: view/theme/frio/theme.php:235
+#: src/Module/Settings/Display.php:448 view/theme/frio/theme.php:223
+#: view/theme/frio/theme.php:229
 msgid "Calendar"
 msgstr ""
 
@@ -2427,7 +2427,7 @@ msgstr ""
 #: src/Content/Nav.php:295 src/Module/Admin/Addons/Details.php:140
 #: src/Module/Admin/Themes/Details.php:85 src/Module/BaseAdmin.php:89
 #: src/Module/BaseSettings.php:177 src/Module/Welcome.php:39
-#: view/theme/frio/theme.php:237
+#: view/theme/frio/theme.php:231
 msgid "Settings"
 msgstr ""
 
@@ -2435,7 +2435,7 @@ msgstr ""
 msgid "Account settings"
 msgstr ""
 
-#: src/Content/Nav.php:297 view/theme/frio/theme.php:238
+#: src/Content/Nav.php:297 view/theme/frio/theme.php:232
 msgid "Manage/edit friends and contacts"
 msgstr ""
 
@@ -4433,7 +4433,7 @@ msgid "Data"
 msgstr ""
 
 #: src/Module/Admin/Logs/View.php:85 src/Module/Admin/Roles.php:137
-#: src/Module/Debug/ActivityPubConversion.php:49
+#: src/Module/Debug/ActivityPubConversion.php:55
 msgid "Source"
 msgstr ""
 
@@ -5999,7 +5999,7 @@ msgstr ""
 msgid "Babel"
 msgstr ""
 
-#: src/Module/BaseAdmin.php:97 src/Module/Debug/ActivityPubConversion.php:125
+#: src/Module/BaseAdmin.php:97 src/Module/Debug/ActivityPubConversion.php:131
 msgid "ActivityPub Conversion"
 msgstr ""
 
@@ -6595,7 +6595,7 @@ msgid "Return to contact editor"
 msgstr ""
 
 #: src/Module/Contact/Advanced.php:118 src/Module/Contact/Profile.php:383
-#: src/Module/Debug/ActivityPubConversion.php:128
+#: src/Module/Debug/ActivityPubConversion.php:134
 #: src/Module/Debug/Babel.php:280 src/Module/Debug/Localtime.php:50
 #: src/Module/Debug/Probe.php:40 src/Module/Debug/WebFinger.php:37
 #: src/Module/FriendSuggest.php:138 src/Module/Install.php:216
@@ -7157,23 +7157,27 @@ msgstr ""
 msgid "Friendica is a community project, that would not be possible without the help of many people. Here is a list of those who have contributed to the code or the translation of Friendica. Thank you all!"
 msgstr ""
 
-#: src/Module/Debug/ActivityPubConversion.php:45
+#: src/Module/Debug/ActivityPubConversion.php:29
+msgid "Only logged in users are permitted to perform a conversion."
+msgstr ""
+
+#: src/Module/Debug/ActivityPubConversion.php:51
 msgid "Formatted"
 msgstr ""
 
-#: src/Module/Debug/ActivityPubConversion.php:57
+#: src/Module/Debug/ActivityPubConversion.php:63
 msgid "Activity"
 msgstr ""
 
-#: src/Module/Debug/ActivityPubConversion.php:105
+#: src/Module/Debug/ActivityPubConversion.php:111
 msgid "Object data"
 msgstr ""
 
-#: src/Module/Debug/ActivityPubConversion.php:112
+#: src/Module/Debug/ActivityPubConversion.php:118
 msgid "Result Item"
 msgstr ""
 
-#: src/Module/Debug/ActivityPubConversion.php:117
+#: src/Module/Debug/ActivityPubConversion.php:123
 #: src/Module/Moderation/Item/Source.php:78
 #: src/Module/Security/TwoFactor/Verify.php:83
 msgid "Error"
@@ -7181,7 +7185,7 @@ msgid_plural "Errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Debug/ActivityPubConversion.php:126
+#: src/Module/Debug/ActivityPubConversion.php:132
 msgid "Source activity"
 msgstr ""
 
@@ -12968,23 +12972,23 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: view/theme/frio/theme.php:209
+#: view/theme/frio/theme.php:203
 msgid "Guest"
 msgstr ""
 
-#: view/theme/frio/theme.php:212
+#: view/theme/frio/theme.php:206
 msgid "Visitor"
 msgstr ""
 
-#: view/theme/frio/theme.php:229
+#: view/theme/frio/theme.php:223
 msgid "Your calendar"
 msgstr ""
 
-#: view/theme/frio/theme.php:233
+#: view/theme/frio/theme.php:227
 msgid "Back home"
 msgstr ""
 
-#: view/theme/frio/theme.php:233
+#: view/theme/frio/theme.php:227
 msgid "Back to my instance"
 msgstr ""
 


### PR DESCRIPTION
Reject non-public HTTP, redirect and mail targets. Allow the node and configured internal hosts.
Require login for ActivityPub conversion.