### PR TITLE
Escape private message reply fields

### DIFF
--- a/mod/message.php
+++ b/mod/message.php
@@ -185,7 +185,8 @@ function message_content()
 			'$readonly'    => '',
 			'$yourmessage' => DI::l10n()->t('Your message'),
 			'$select'      => $select,
-			'$parent'      => '',
+			'$recipient'   => null,
+			'$replyto'     => '',
 			'$upload'      => DI::l10n()->t('Upload photo'),
 			'$insert'      => DI::l10n()->t('Insert web link'),
 			'$wait'        => DI::l10n()->t('Please wait'),
@@ -321,9 +322,6 @@ function message_content()
 			$seen = $message['seen'];
 		}
 
-		$select = $message['name'] . '<input type="hidden" name="recipient" value="' . $contact_id . '" />';
-		$parent = '<input type="hidden" name="replyto" value="' . $message['parent-uri'] . '" />';
-
 		$tpl = Renderer::getMarkupTemplate('mail_display.tpl');
 		$o   = Renderer::replaceMacros($tpl, [
 			'$thread_id'      => DI::args()->getArgv()[1],
@@ -341,8 +339,9 @@ function message_content()
 			'$readonly'    => ' readonly="readonly" style="background: #BBBBBB;" ',
 			'$yourmessage' => DI::l10n()->t('Your message:'),
 			'$text'        => '',
-			'$select'      => $select,
-			'$parent'      => $parent,
+			'$select'      => '',
+			'$recipient'   => ['name' => $message['name'], 'id' => $contact_id],
+			'$replyto'     => $message['parent-uri'],
 			'$upload'      => DI::l10n()->t('Upload photo'),
 			'$insert'      => DI::l10n()->t('Insert web link'),
 			'$submit'      => DI::l10n()->t('Send Message'),

--- a/tests/Unit/View/PrvMessageTemplateTest.php
+++ b/tests/Unit/View/PrvMessageTemplateTest.php
@@ -1,0 +1,129 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Test\Unit\View;
+
+use DOMDocument;
+use DOMXPath;
+use Friendica\Render\FriendicaSmarty;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for the private message form.
+ *
+ * The reply form used to concatenate the counterpart's contact name and the
+ * conversation's parent-uri into raw HTML which was then rendered with
+ * `nofilter`. Both values are controlled by the remote side, so a federated
+ * peer could store JavaScript in the victim's conversation view.
+ */
+class PrvMessageTemplateTest extends TestCase
+{
+	private const XSS_NAME    = '<img src=x onerror=alert(1)>';
+	private const XSS_REPLYTO = 'https://evil.example/m/1"><img src=x onerror=alert(2)>';
+
+	private string $workDir;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		// The template dirs of FriendicaSmarty are relative to the project root
+		chdir(dirname(__DIR__, 3));
+
+		$this->workDir = sys_get_temp_dir() . '/friendica-tpl-test-' . getmypid();
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_dir($this->workDir)) {
+			exec('rm -rf ' . escapeshellarg($this->workDir));
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * frio ships its own prv_message.tpl, vier falls back to the base template
+	 */
+	public static function themeProvider(): array
+	{
+		return [
+			'frio' => ['frio'],
+			'vier' => ['vier'],
+		];
+	}
+
+	#[DataProvider('themeProvider')]
+	public function testReplyFormEscapesContactNameAndParentUri(string $theme): void
+	{
+		$html = $this->render($theme, [
+			'recipient' => ['name' => self::XSS_NAME, 'id' => 52],
+			'replyto'   => self::XSS_REPLYTO,
+			'select'    => '',
+		]);
+
+		$xpath = $this->xpath($html);
+
+		// The payload must not have become markup. The base template legitimately
+		// contains a rotator <img>, so pin the payload itself instead of all images.
+		self::assertSame(0, $xpath->query('//img[@src="x"]')->length, 'contact name was rendered as markup');
+		self::assertSame(0, $xpath->query('//*[@onerror]')->length, 'an event handler attribute was injected');
+
+		// ... but it must still be visible as text to the user
+		self::assertStringContainsString(htmlspecialchars(self::XSS_NAME, ENT_QUOTES), $html);
+
+		// The recipient id is still submitted
+		$recipient = $xpath->query('//input[@name="recipient"]');
+		self::assertSame(1, $recipient->length);
+		self::assertSame('52', $recipient->item(0)->getAttribute('value'));
+
+		// The parent uri survives the escaping round trip unchanged
+		$replyto = $xpath->query('//input[@name="replyto"]');
+		self::assertSame(1, $replyto->length);
+		self::assertSame(self::XSS_REPLYTO, $replyto->item(0)->getAttribute('value'));
+	}
+
+	/**
+	 * The "new message" form passes a pre-rendered recipient widget, which must
+	 * stay raw HTML - otherwise the contact selector breaks.
+	 */
+	#[DataProvider('themeProvider')]
+	public function testNewMessageFormKeepsRenderedRecipientWidget(string $theme): void
+	{
+		$html = $this->render($theme, [
+			'recipient' => null,
+			'replyto'   => '',
+			'select'    => '<select name="recipient"><option value="52">Alice</option></select>',
+		]);
+
+		$xpath = $this->xpath($html);
+
+		self::assertSame(1, $xpath->query('//select[@name="recipient"]')->length);
+		// No stray reply-to field on a brand new conversation
+		self::assertSame(0, $xpath->query('//input[@name="replyto"]')->length);
+	}
+
+	private function render(string $theme, array $vars): string
+	{
+		$smarty = new FriendicaSmarty($theme, [], $this->workDir, false);
+
+		foreach ($vars as $key => $value) {
+			$smarty->assign($key, $value);
+		}
+
+		return $smarty->fetch('file:prv_message.tpl');
+	}
+
+	private function xpath(string $html): DOMXPath
+	{
+		$doc = new DOMDocument();
+		self::assertTrue(@$doc->loadHTML('<!DOCTYPE html><html><body>' . $html . '</body></html>'));
+
+		return new DOMXPath($doc);
+	}
+}

--- a/tests/Unit/View/PrvMessageTemplateTest.php
+++ b/tests/Unit/View/PrvMessageTemplateTest.php
@@ -8,19 +8,13 @@
 namespace Friendica\Test\Unit\View;
 
 use DOMDocument;
+use DOMElement;
 use DOMXPath;
 use Friendica\Render\FriendicaSmarty;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Regression tests for the private message form.
- *
- * The reply form used to concatenate the counterpart's contact name and the
- * conversation's parent-uri into raw HTML which was then rendered with
- * `nofilter`. Both values are controlled by the remote side, so a federated
- * peer could store JavaScript in the victim's conversation view.
- */
+/** Tests escaping in the private message form. */
 class PrvMessageTemplateTest extends TestCase
 {
 	private const XSS_NAME    = '<img src=x onerror=alert(1)>';
@@ -32,7 +26,7 @@ class PrvMessageTemplateTest extends TestCase
 	{
 		parent::setUp();
 
-		// The template dirs of FriendicaSmarty are relative to the project root
+		// FriendicaSmarty resolves template directories from the project root.
 		chdir(dirname(__DIR__, 3));
 
 		$this->workDir = sys_get_temp_dir() . '/friendica-tpl-test-' . getmypid();
@@ -47,9 +41,7 @@ class PrvMessageTemplateTest extends TestCase
 		parent::tearDown();
 	}
 
-	/**
-	 * frio ships its own prv_message.tpl, vier falls back to the base template
-	 */
+	/** @return array<string, array{string}> */
 	public static function themeProvider(): array
 	{
 		return [
@@ -69,29 +61,107 @@ class PrvMessageTemplateTest extends TestCase
 
 		$xpath = $this->xpath($html);
 
-		// The payload must not have become markup. The base template legitimately
-		// contains a rotator <img>, so pin the payload itself instead of all images.
+		// Ignore unrelated images in the base template.
 		self::assertSame(0, $xpath->query('//img[@src="x"]')->length, 'contact name was rendered as markup');
 		self::assertSame(0, $xpath->query('//*[@onerror]')->length, 'an event handler attribute was injected');
 
-		// ... but it must still be visible as text to the user
 		self::assertStringContainsString(htmlspecialchars(self::XSS_NAME, ENT_QUOTES), $html);
 
-		// The recipient id is still submitted
-		$recipient = $xpath->query('//input[@name="recipient"]');
-		self::assertSame(1, $recipient->length);
-		self::assertSame('52', $recipient->item(0)->getAttribute('value'));
+		self::assertSame(1, $xpath->query('//input[@name="recipient"]')->length);
+		self::assertSame('52', $this->element($xpath, '//input[@name="recipient"]')->getAttribute('value'));
 
-		// The parent uri survives the escaping round trip unchanged
-		$replyto = $xpath->query('//input[@name="replyto"]');
-		self::assertSame(1, $replyto->length);
-		self::assertSame(self::XSS_REPLYTO, $replyto->item(0)->getAttribute('value'));
+		self::assertSame(1, $xpath->query('//input[@name="replyto"]')->length);
+		self::assertSame(self::XSS_REPLYTO, $this->element($xpath, '//input[@name="replyto"]')->getAttribute('value'));
 	}
 
-	/**
-	 * The "new message" form passes a pre-rendered recipient widget, which must
-	 * stay raw HTML - otherwise the contact selector breaks.
-	 */
+	/** @return array<string, array{string}> */
+	public static function displayNameProvider(): array
+	{
+		return [
+			'plain'             => ['Tobias'],
+			'two words'         => ['Michael Vogel'],
+			'apostrophe'        => ["Sean O'Brien"],
+			'ampersand'         => ['Alice & Bob'],
+			'double quotes'     => ['Jean-Luc "Q" Picard'],
+			'angle bracket art' => ['<3 friendica'],
+			'diacritics'        => ['Ana María Ñúñez'],
+			'german umlauts'    => ['Jürgen Schrödinger'],
+			'cyrillic'          => ['Пользователь Сети'],
+			'greek'             => ['Δημήτριος'],
+			'cjk'               => ['日本語のユーザー'],
+			'korean'            => ['프렌디카 사용자'],
+			'rtl arabic'        => ['مستخدم فرينديكا'],
+			'rtl hebrew'        => ['משתמש פרנדיקה'],
+			'emoji'             => ['🦣 Mastodon Fan 🐘'],
+			'anarchy symbol'    => ['Ⓐ anarchist'],
+			'zero width joiner' => ['Family 👨‍👩‍👧‍👦'],
+			'handle as name'    => ['gargron@mastodon.social'],
+			'url as name'       => ['https://friendi.ca/'],
+			'bot suffix'        => ['News Bot [bot]'],
+			'pronouns in name'  => ['Sam (they/them)'],
+			'custom emoji code' => [':verified: Alice'],
+			'math symbols'      => ['∀x ∈ fediverse'],
+			'long name'         => [str_repeat('Very Long Display Name ', 10)],
+			'whitespace padded' => ['  spaced out  '],
+		];
+	}
+
+	#[DataProvider('displayNameProvider')]
+	public function testDisplayNamesSurviveEscaping(string $name): void
+	{
+		foreach (array_keys(self::themeProvider()) as $theme) {
+			$html = $this->render($theme, [
+				'recipient' => ['name' => $name, 'id' => 52],
+				'replyto'   => 'https://friendica.example/objects/1a2b3c4d-5e6f-7890-abcd-ef1234567890',
+				'select'    => '',
+			]);
+
+			$label = $this->xpath($html)->query('//div[@id="prvmail-to-label"]')->item(0);
+			self::assertNotNull($label, $theme . ': recipient label is missing');
+			self::assertStringContainsString($name, $label->textContent, $theme . ': display name was altered');
+		}
+	}
+
+	/** @return array<string, array{string}> */
+	public static function parentUriProvider(): array
+	{
+		return [
+			'friendica object'   => ['https://friendica.example/objects/1a2b3c4d-5e6f-7890-abcd-ef1234567890'],
+			'diaspora handle'    => ['alice@diaspora.example:5f4dcc3b5aa765d61d83'],
+			'conversation uri'   => ['bob@friendica.example:1a2b3c4d-5e6f-7890-abcd-ef1234567890'],
+			'mastodon status'    => ['https://mastodon.social/users/Gargron/statuses/109252195269200000'],
+			'diaspora scheme'    => ['diaspora://alice@diaspora.example/conversation/5f4dcc3b5aa765d61d83'],
+			'urn uuid'           => ['urn:uuid:1a2b3c4d-5e6f-7890-abcd-ef1234567890'],
+			'tag uri'            => ['tag:friendica.example,2026-08:objectId=1:objectType=Mail'],
+			'with query string'  => ['https://example.org/objects/abc?context=1&reply=2'],
+			'with fragment'      => ['https://example.org/objects/abc#part-2'],
+			'explicit port'      => ['https://example.org:8443/objects/abc'],
+			'unicode path'       => ['https://präsenz.example/objects/josé'],
+			'percent encoded'    => ['https://example.org/objects/%C3%BCber'],
+			'apostrophe in path' => ["https://example.org/objects/o'brien"],
+		];
+	}
+
+	#[DataProvider('parentUriProvider')]
+	public function testParentUriRoundTripsUnchanged(string $uri): void
+	{
+		foreach (array_keys(self::themeProvider()) as $theme) {
+			$html = $this->render($theme, [
+				'recipient' => ['name' => 'Alice', 'id' => 52],
+				'replyto'   => $uri,
+				'select'    => '',
+			]);
+
+			$xpath = $this->xpath($html);
+			self::assertSame(1, $xpath->query('//input[@name="replyto"]')->length, $theme . ': reply-to field is missing');
+			self::assertSame(
+				$uri,
+				$this->element($xpath, '//input[@name="replyto"]')->getAttribute('value'),
+				$theme . ': parent uri was altered',
+			);
+		}
+	}
+
 	#[DataProvider('themeProvider')]
 	public function testNewMessageFormKeepsRenderedRecipientWidget(string $theme): void
 	{
@@ -104,7 +174,6 @@ class PrvMessageTemplateTest extends TestCase
 		$xpath = $this->xpath($html);
 
 		self::assertSame(1, $xpath->query('//select[@name="recipient"]')->length);
-		// No stray reply-to field on a brand new conversation
 		self::assertSame(0, $xpath->query('//input[@name="replyto"]')->length);
 	}
 
@@ -119,10 +188,23 @@ class PrvMessageTemplateTest extends TestCase
 		return $smarty->fetch('file:prv_message.tpl');
 	}
 
+	private function element(DOMXPath $xpath, string $query): DOMElement
+	{
+		$node = $xpath->query($query)->item(0);
+		if (!$node instanceof DOMElement) {
+			self::fail($query . ' did not match an element');
+		}
+
+		return $node;
+	}
+
 	private function xpath(string $html): DOMXPath
 	{
 		$doc = new DOMDocument();
-		self::assertTrue(@$doc->loadHTML('<!DOCTYPE html><html><body>' . $html . '</body></html>'));
+		// Prevent DOMDocument from treating non-ASCII names as ISO-8859-1.
+		self::assertTrue(@$doc->loadHTML(
+			'<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>' . $html . '</body></html>',
+		));
 
 		return new DOMXPath($doc);
 	}

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2026.08-rc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 00:45+0200\n"
+"POT-Creation-Date: 2026-08-21 00:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Conversation was not removed."
 msgstr ""
 
-#: mod/message.php:170 mod/message.php:278
+#: mod/message.php:170 mod/message.php:279
 msgid "Please enter a link URL:"
 msgstr ""
 
@@ -130,7 +130,7 @@ msgstr ""
 msgid "Send Private Message"
 msgstr ""
 
-#: mod/message.php:180 mod/message.php:338
+#: mod/message.php:180 mod/message.php:336
 #: src/Module/Privacy/PermissionTooltip.php:135
 msgid "To:"
 msgstr ""
@@ -147,18 +147,18 @@ msgstr ""
 msgid "Your message"
 msgstr ""
 
-#: mod/message.php:189 mod/message.php:346 mod/photos.php:76 mod/photos.php:624
+#: mod/message.php:190 mod/message.php:345 mod/photos.php:76 mod/photos.php:624
 #: src/Content/Conversation/StatusEditor.php:150 src/Module/Post/Edit.php:142
 #: src/Module/Profile/Photos.php:336 src/Module/Profile/Photos.php:356
 #: src/Module/Profile/Photos.php:359
 msgid "Upload photo"
 msgstr ""
 
-#: mod/message.php:190 mod/message.php:347 src/Module/Post/Edit.php:146
+#: mod/message.php:191 mod/message.php:346 src/Module/Post/Edit.php:146
 msgid "Insert web link"
 msgstr ""
 
-#: mod/message.php:191 mod/message.php:349 src/App/Page.php:277
+#: mod/message.php:192 mod/message.php:348 src/App/Page.php:277
 #: src/Content/Conversation/ConversationRenderer.php:539
 #: src/Content/Conversation/PostTemplateBuilder.php:393
 #: src/Content/Conversation/StatusEditor.php:182
@@ -166,62 +166,62 @@ msgstr ""
 msgid "Please wait"
 msgstr ""
 
-#: mod/message.php:192 mod/message.php:348
+#: mod/message.php:193 mod/message.php:347
 msgid "Send Message"
 msgstr ""
 
-#: mod/message.php:213
+#: mod/message.php:214
 msgid "You have no messages."
 msgstr ""
 
-#: mod/message.php:271
+#: mod/message.php:272
 msgid "Message not available."
 msgstr ""
 
-#: mod/message.php:315
+#: mod/message.php:316
 msgid "Delete message"
 msgstr ""
 
-#: mod/message.php:317 mod/message.php:440
+#: mod/message.php:318 mod/message.php:439
 msgid "D, d M Y - g:i A"
 msgstr ""
 
-#: mod/message.php:332 mod/message.php:437
+#: mod/message.php:330 mod/message.php:436
 msgid "Delete conversation"
 msgstr ""
 
-#: mod/message.php:334
+#: mod/message.php:332
 msgid "No secure communications available. You <strong>may</strong> be able to respond from the sender's profile page."
 msgstr ""
 
-#: mod/message.php:337
+#: mod/message.php:335
 msgid "Send Reply"
 msgstr ""
 
-#: mod/message.php:339
+#: mod/message.php:337
 msgid "Subject:"
 msgstr ""
 
-#: mod/message.php:342 src/Module/Invite.php:156
+#: mod/message.php:340 src/Module/Invite.php:156
 msgid "Your message:"
 msgstr ""
 
-#: mod/message.php:411
+#: mod/message.php:410
 #, php-format
 msgid "Unknown sender - %s"
 msgstr ""
 
-#: mod/message.php:413
+#: mod/message.php:412
 #, php-format
 msgid "You and %s"
 msgstr ""
 
-#: mod/message.php:415
+#: mod/message.php:414
 #, php-format
 msgid "%s and You"
 msgstr ""
 
-#: mod/message.php:443
+#: mod/message.php:442
 #, php-format
 msgid "%d message"
 msgid_plural "%d messages"
@@ -1053,100 +1053,100 @@ msgid_plural "<button type=\"button\" %2$s>%1$d people</button> reshared this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:880
-#: src/Content/Conversation/ConversationDataProvider.php:883
-#: src/Content/Conversation/ConversationDataProvider.php:886
-#: src/Content/Conversation/ConversationDataProvider.php:889
-#: src/Content/Conversation/ConversationDataProvider.php:892
+#: src/Content/Conversation/ConversationDataProvider.php:882
+#: src/Content/Conversation/ConversationDataProvider.php:885
+#: src/Content/Conversation/ConversationDataProvider.php:888
+#: src/Content/Conversation/ConversationDataProvider.php:891
+#: src/Content/Conversation/ConversationDataProvider.php:894
 #, php-format
 msgid "You had been addressed (%s)."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:895
+#: src/Content/Conversation/ConversationDataProvider.php:897
 #, php-format
 msgid "You are following %s."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:899
+#: src/Content/Conversation/ConversationDataProvider.php:901
 msgid "You subscribed to one or more tags in this post."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:899
+#: src/Content/Conversation/ConversationDataProvider.php:901
 #, php-format
 msgid "You subscribed to %s."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:917
+#: src/Content/Conversation/ConversationDataProvider.php:919
 #, php-format
 msgid "%s reshared this."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:919
+#: src/Content/Conversation/ConversationDataProvider.php:921
 msgid "Reshared"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:919
+#: src/Content/Conversation/ConversationDataProvider.php:921
 #, php-format
 msgid "Reshared by %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:922
+#: src/Content/Conversation/ConversationDataProvider.php:924
 #, php-format
 msgid "%s is participating in this thread."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:925
+#: src/Content/Conversation/ConversationDataProvider.php:927
 msgid "Stored for general reasons"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:928
+#: src/Content/Conversation/ConversationDataProvider.php:930
 msgid "Global post"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:931
+#: src/Content/Conversation/ConversationDataProvider.php:933
 msgid "Sent via an relay server"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:931
+#: src/Content/Conversation/ConversationDataProvider.php:933
 #, php-format
 msgid "Sent via the relay server %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:934
+#: src/Content/Conversation/ConversationDataProvider.php:936
 msgid "Fetched"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:934
+#: src/Content/Conversation/ConversationDataProvider.php:936
 #, php-format
 msgid "Fetched because of %s <%s>"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:937
+#: src/Content/Conversation/ConversationDataProvider.php:939
 msgid "Stored because of a child post to complete this thread."
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:940
+#: src/Content/Conversation/ConversationDataProvider.php:942
 msgid "Local delivery"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:943
+#: src/Content/Conversation/ConversationDataProvider.php:945
 msgid "Stored because of your activity (like, comment, bookmark, ...)"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:946
+#: src/Content/Conversation/ConversationDataProvider.php:948
 msgid "Distributed"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:949
+#: src/Content/Conversation/ConversationDataProvider.php:951
 msgid "Pushed to us"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:954
+#: src/Content/Conversation/ConversationDataProvider.php:956
 #, php-format
 msgid "Channel \"%s\": %s"
 msgstr ""
 
-#: src/Content/Conversation/ConversationDataProvider.php:954
+#: src/Content/Conversation/ConversationDataProvider.php:956
 #, php-format
 msgid "Channel \"%s\""
 msgstr ""
@@ -1157,7 +1157,7 @@ msgid "Delete Selected Items"
 msgstr ""
 
 #: src/Content/Conversation/ConversationRenderer.php:467
-#: src/Content/Conversation/PostTemplateBuilder.php:526
+#: src/Content/Conversation/PostTemplateBuilder.php:527
 msgid "Select"
 msgstr ""
 
@@ -1449,8 +1449,8 @@ msgid "Load more comments"
 msgstr ""
 
 #: src/Content/Conversation/PostTemplateBuilder.php:387
-#: src/Content/Conversation/PostTemplateBuilder.php:926
-#: src/Module/Moderation/Reports.php:242
+#: src/Content/Conversation/PostTemplateBuilder.php:927
+#: src/Module/Moderation/Reports.php:245
 msgid "Comment"
 msgstr ""
 
@@ -1505,261 +1505,261 @@ msgstr ""
 msgid "Close comments"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:449
+#: src/Content/Conversation/PostTemplateBuilder.php:450
 #, php-format
 msgid "%d comment"
 msgid_plural "%d comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:450
+#: src/Content/Conversation/PostTemplateBuilder.php:451
 msgid "Show more"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:451
+#: src/Content/Conversation/PostTemplateBuilder.php:452
 msgid "Show fewer"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:527
+#: src/Content/Conversation/PostTemplateBuilder.php:528
 msgid "Delete globally"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:527
+#: src/Content/Conversation/PostTemplateBuilder.php:528
 msgid "Remove locally"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:534
+#: src/Content/Conversation/PostTemplateBuilder.php:535
 #, php-format
 msgid "Block %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:539
+#: src/Content/Conversation/PostTemplateBuilder.php:540
 #, php-format
 msgid "Ignore %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:544
+#: src/Content/Conversation/PostTemplateBuilder.php:545
 #, php-format
 msgid "Collapse %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:548
+#: src/Content/Conversation/PostTemplateBuilder.php:549
 msgid "Report this post"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:559
+#: src/Content/Conversation/PostTemplateBuilder.php:560
 #: src/Content/Item.php:436
 #, php-format
 msgid "Ignore %s server"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:585
+#: src/Content/Conversation/PostTemplateBuilder.php:586
 msgid "I will attend"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:586
+#: src/Content/Conversation/PostTemplateBuilder.php:587
 msgid "I will not attend"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:587
+#: src/Content/Conversation/PostTemplateBuilder.php:588
 msgid "I might attend"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:590
+#: src/Content/Conversation/PostTemplateBuilder.php:591
 msgid "Going"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:591
+#: src/Content/Conversation/PostTemplateBuilder.php:592
 msgid "Can't Go"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:592
+#: src/Content/Conversation/PostTemplateBuilder.php:593
 msgid "Maybe"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:616
+#: src/Content/Conversation/PostTemplateBuilder.php:617
 #, php-format
 msgid "%s (Received %s)"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:704
+#: src/Content/Conversation/PostTemplateBuilder.php:705
 msgid "I like this (toggle)"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:704
+#: src/Content/Conversation/PostTemplateBuilder.php:705
 msgid "Like"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:705
+#: src/Content/Conversation/PostTemplateBuilder.php:706
 msgid "I don't like this (toggle)"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:705
+#: src/Content/Conversation/PostTemplateBuilder.php:706
 msgid "Dislike"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:708
+#: src/Content/Conversation/PostTemplateBuilder.php:709
 msgid "Quote share this"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:708
+#: src/Content/Conversation/PostTemplateBuilder.php:709
 msgid "Quote Share"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:711
+#: src/Content/Conversation/PostTemplateBuilder.php:712
 msgid "Reshare this"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:711
+#: src/Content/Conversation/PostTemplateBuilder.php:712
 msgid "Reshare"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:712
+#: src/Content/Conversation/PostTemplateBuilder.php:713
 msgid "Cancel your Reshare"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:712
+#: src/Content/Conversation/PostTemplateBuilder.php:713
 msgid "Unshare"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:745
+#: src/Content/Conversation/PostTemplateBuilder.php:746
 #: src/Module/Profile/Schedule.php:93
 msgid "Private Message"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:746
+#: src/Content/Conversation/PostTemplateBuilder.php:747
 msgid "Public Message"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:747
+#: src/Content/Conversation/PostTemplateBuilder.php:748
 msgid "Unlisted Message"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:770
+#: src/Content/Conversation/PostTemplateBuilder.php:771
 #, php-format
 msgid "Reshared by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:775
+#: src/Content/Conversation/PostTemplateBuilder.php:776
 #, php-format
 msgid "Viewed by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:780
+#: src/Content/Conversation/PostTemplateBuilder.php:781
 #, php-format
 msgid "Read by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:785
+#: src/Content/Conversation/PostTemplateBuilder.php:786
 #, php-format
 msgid "Liked by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:790
+#: src/Content/Conversation/PostTemplateBuilder.php:791
 #, php-format
 msgid "Disliked by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:795
+#: src/Content/Conversation/PostTemplateBuilder.php:796
 #, php-format
 msgid "Attended by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:800
+#: src/Content/Conversation/PostTemplateBuilder.php:801
 #, php-format
 msgid "Maybe attended by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:805
+#: src/Content/Conversation/PostTemplateBuilder.php:806
 #, php-format
 msgid "Not attended by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:810
+#: src/Content/Conversation/PostTemplateBuilder.php:811
 #, php-format
 msgid "Commented by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:815
+#: src/Content/Conversation/PostTemplateBuilder.php:816
 #, php-format
 msgid "Reacted with %s by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:838
+#: src/Content/Conversation/PostTemplateBuilder.php:839
 #, php-format
 msgid "Quote shared by: %s"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:924
+#: src/Content/Conversation/PostTemplateBuilder.php:925
 #: src/Module/Contact.php:607 src/Module/Item/Compose.php:163
 msgid "This is you"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:927
+#: src/Content/Conversation/PostTemplateBuilder.php:928
 msgid "Post comment"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:928
+#: src/Content/Conversation/PostTemplateBuilder.php:929
 #: src/Content/Conversation/StatusEditor.php:149 src/Content/Nav.php:93
 #: src/Module/Post/Edit.php:141
 msgid "Loading..."
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:929
+#: src/Content/Conversation/PostTemplateBuilder.php:930
 #: src/Content/Conversation/StatusEditor.php:152
 #: src/Module/Item/Compose.php:165 src/Module/Post/Edit.php:184
 #: src/Module/Settings/Profile/Index.php:247
 msgid "Bold"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:930
+#: src/Content/Conversation/PostTemplateBuilder.php:931
 #: src/Content/Conversation/StatusEditor.php:153
 #: src/Module/Item/Compose.php:166 src/Module/Post/Edit.php:185
 #: src/Module/Settings/Profile/Index.php:248
 msgid "Italic"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:931
+#: src/Content/Conversation/PostTemplateBuilder.php:932
 #: src/Content/Conversation/StatusEditor.php:154
 #: src/Module/Item/Compose.php:167 src/Module/Post/Edit.php:186
 #: src/Module/Settings/Profile/Index.php:249
 msgid "Underline"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:932
+#: src/Content/Conversation/PostTemplateBuilder.php:933
 #: src/Content/Conversation/StatusEditor.php:157
 #: src/Module/Item/Compose.php:170
 msgid "Content Warning"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:933
+#: src/Content/Conversation/PostTemplateBuilder.php:934
 #: src/Content/Conversation/StatusEditor.php:155
 #: src/Module/Item/Compose.php:168 src/Module/Post/Edit.php:187
 #: src/Module/Settings/Profile/Index.php:250
 msgid "Quote"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:934
+#: src/Content/Conversation/PostTemplateBuilder.php:935
 #: src/Content/Conversation/StatusEditor.php:156
 #: src/Module/Item/Compose.php:169 src/Module/Post/Edit.php:188
 #: src/Module/Settings/Profile/Index.php:251
 msgid "Add emojis"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:935
+#: src/Content/Conversation/PostTemplateBuilder.php:936
 #: src/Content/Conversation/StatusEditor.php:158
 #: src/Module/Item/Compose.php:171 src/Module/Post/Edit.php:189
 #: src/Module/Settings/Profile/Index.php:252
 msgid "Code"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:936
+#: src/Content/Conversation/PostTemplateBuilder.php:937
 #: src/Module/Item/Compose.php:172 src/Module/Settings/Profile/Index.php:253
 #: src/Module/Settings/Profile/Index.php:254
 msgid "Image"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:937
+#: src/Content/Conversation/PostTemplateBuilder.php:938
 #: src/Content/Conversation/StatusEditor.php:159
 #: src/Content/Conversation/StatusEditor.php:163
 #: src/Module/Item/Compose.php:173 src/Module/Post/Edit.php:190
@@ -1767,20 +1767,20 @@ msgstr ""
 msgid "Link"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:938
+#: src/Content/Conversation/PostTemplateBuilder.php:939
 #: src/Content/Conversation/StatusEditor.php:160
 #: src/Module/Item/Compose.php:174 src/Module/Post/Edit.php:191
 #: src/Module/Settings/Profile/Index.php:256
 msgid "Link or Media"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:939
+#: src/Content/Conversation/PostTemplateBuilder.php:940
 #: src/Content/Conversation/StatusEditor.php:103
 #: src/Module/Item/Compose.php:175
 msgid "Please enter a image/video/audio/webpage URL:"
 msgstr ""
 
-#: src/Content/Conversation/PostTemplateBuilder.php:940
+#: src/Content/Conversation/PostTemplateBuilder.php:941
 #: src/Content/Conversation/StatusEditor.php:194
 #: src/Module/Calendar/Event/Form.php:261 src/Module/Item/Compose.php:176
 #: src/Module/Item/Compose.php:307 src/Module/Post/Edit.php:178
@@ -2117,7 +2117,7 @@ msgid "event"
 msgstr ""
 
 #: src/Content/Item.php:329 src/Content/Item.php:339
-#: src/Module/Moderation/Reports.php:340
+#: src/Module/Moderation/Reports.php:345
 msgid "status"
 msgstr ""
 
@@ -2455,7 +2455,7 @@ msgstr ""
 #: src/Module/Moderation/Blocklist/Server/Index.php:84
 #: src/Module/Moderation/Item/Delete.php:47
 #: src/Module/Moderation/Item/Source.php:66
-#: src/Module/Moderation/Reports.php:236 src/Module/Moderation/Reports.php:325
+#: src/Module/Moderation/Reports.php:239 src/Module/Moderation/Reports.php:329
 #: src/Module/Moderation/Summary.php:59
 #: src/Module/Moderation/Users/Active.php:89
 #: src/Module/Moderation/Users/Blocked.php:89
@@ -2852,275 +2852,275 @@ msgstr ""
 msgid "Please see the file \"doc/INSTALL.md\"."
 msgstr ""
 
-#: src/Core/Installer.php:235
+#: src/Core/Installer.php:261
 msgid "Could not find a command line version of PHP in the web server PATH."
 msgstr ""
 
-#: src/Core/Installer.php:236
+#: src/Core/Installer.php:262
 msgid "If you don't have a command line version of PHP installed on your server, you will not be able to run the background processing. See <a href='https://github.com/friendica/friendica/blob/stable/doc/Install.md#set-up-the-worker'>'Setup the worker'</a>"
 msgstr ""
 
-#: src/Core/Installer.php:241
+#: src/Core/Installer.php:267
 msgid "PHP executable path"
 msgstr ""
 
-#: src/Core/Installer.php:241
+#: src/Core/Installer.php:267
 msgid "Enter full path to php executable. You can leave this blank to continue the installation."
 msgstr ""
 
-#: src/Core/Installer.php:246
+#: src/Core/Installer.php:272
 msgid "Command line PHP"
 msgstr ""
 
-#: src/Core/Installer.php:255
+#: src/Core/Installer.php:281
 msgid "PHP executable is not the php cli binary (could be cgi-fgci version)"
 msgstr ""
 
-#: src/Core/Installer.php:256
+#: src/Core/Installer.php:282
 msgid "Found PHP version: "
 msgstr ""
 
-#: src/Core/Installer.php:258
+#: src/Core/Installer.php:284
 msgid "PHP cli binary"
 msgstr ""
 
-#: src/Core/Installer.php:271
+#: src/Core/Installer.php:297
 msgid "The command line version of PHP on your system does not have \"register_argc_argv\" enabled."
 msgstr ""
 
-#: src/Core/Installer.php:272
+#: src/Core/Installer.php:298
 msgid "This is required for message delivery to work."
 msgstr ""
 
-#: src/Core/Installer.php:277
+#: src/Core/Installer.php:303
 msgid "PHP register_argc_argv"
 msgstr ""
 
-#: src/Core/Installer.php:309
+#: src/Core/Installer.php:335
 msgid "Error: the \"openssl_pkey_new\" function on this system is not able to generate encryption keys"
 msgstr ""
 
-#: src/Core/Installer.php:310
+#: src/Core/Installer.php:336
 msgid "If running under Windows, please see \"http://www.php.net/manual/en/openssl.installation.php\"."
 msgstr ""
 
-#: src/Core/Installer.php:313
+#: src/Core/Installer.php:339
 msgid "Generate encryption keys"
 msgstr ""
 
-#: src/Core/Installer.php:364
+#: src/Core/Installer.php:390
 msgid "Error: Apache webserver mod-rewrite module is required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:368
+#: src/Core/Installer.php:394
 msgid "Apache mod_rewrite module"
 msgstr ""
 
-#: src/Core/Installer.php:374
+#: src/Core/Installer.php:400
 msgid "Error: PDO or MySQLi PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:378
+#: src/Core/Installer.php:404
 msgid "Error: The MySQL driver for PDO is not installed."
 msgstr ""
 
-#: src/Core/Installer.php:381
+#: src/Core/Installer.php:407
 msgid "PDO or MySQLi PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:387
+#: src/Core/Installer.php:413
 msgid "Error: The IntlChar module is not installed."
 msgstr ""
 
-#: src/Core/Installer.php:390
+#: src/Core/Installer.php:416
 msgid "IntlChar PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:398
+#: src/Core/Installer.php:424
 msgid "Error, XML PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:402
+#: src/Core/Installer.php:428
 msgid "XML PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:406
+#: src/Core/Installer.php:432
 msgid "libCurl PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:407
+#: src/Core/Installer.php:433
 msgid "Error: libCURL PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:414
+#: src/Core/Installer.php:440
 msgid "GD graphics PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:415
+#: src/Core/Installer.php:441
 msgid "Error: GD graphics PHP module with JPEG support required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:422
+#: src/Core/Installer.php:448
 msgid "OpenSSL PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:423
+#: src/Core/Installer.php:449
 msgid "Error: openssl PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:430
+#: src/Core/Installer.php:456
 msgid "mb_string PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:431
+#: src/Core/Installer.php:457
 msgid "Error: mb_string PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:438
+#: src/Core/Installer.php:464
 msgid "iconv PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:439
+#: src/Core/Installer.php:465
 msgid "Error: iconv PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:446
+#: src/Core/Installer.php:472
 msgid "POSIX PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:447
+#: src/Core/Installer.php:473
 msgid "Error: POSIX PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:454
+#: src/Core/Installer.php:480
 msgid "Program execution functions"
 msgstr ""
 
-#: src/Core/Installer.php:455
+#: src/Core/Installer.php:481
 msgid "Error: Program execution functions (proc_open) required but not enabled."
 msgstr ""
 
-#: src/Core/Installer.php:462
+#: src/Core/Installer.php:488
 msgid "JSON PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:463
+#: src/Core/Installer.php:489
 msgid "Error: JSON PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:470
+#: src/Core/Installer.php:496
 msgid "File Information PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:471
+#: src/Core/Installer.php:497
 msgid "Error: File Information PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:478
+#: src/Core/Installer.php:504
 msgid "GNU Multiple Precision PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:479
+#: src/Core/Installer.php:505
 msgid "Error: GNU Multiple Precision PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:486
+#: src/Core/Installer.php:512
 msgid "IDN Functions PHP module"
 msgstr ""
 
-#: src/Core/Installer.php:487
+#: src/Core/Installer.php:513
 msgid "Error: IDN Functions PHP module required but not installed."
 msgstr ""
 
-#: src/Core/Installer.php:510
+#: src/Core/Installer.php:536
 msgid "The web installer needs to be able to create a file called \"local.config.php\" in the \"config\" folder of your web server and it is unable to do so."
 msgstr ""
 
-#: src/Core/Installer.php:511
+#: src/Core/Installer.php:537
 msgid "This is most often a permission setting, as the web server may not be able to write files in your folder - even if you can."
 msgstr ""
 
-#: src/Core/Installer.php:512
+#: src/Core/Installer.php:538
 msgid "At the end of this procedure, we will give you a text to save in a file named local.config.php in your Friendica \"config\" folder."
 msgstr ""
 
-#: src/Core/Installer.php:513
+#: src/Core/Installer.php:539
 msgid "You can alternatively skip this procedure and perform a manual installation. Please see the file \"doc/INSTALL.md\" for instructions."
 msgstr ""
 
-#: src/Core/Installer.php:516
+#: src/Core/Installer.php:542
 msgid "config/local.config.php is writable"
 msgstr ""
 
-#: src/Core/Installer.php:536
+#: src/Core/Installer.php:562
 msgid "Friendica uses the Smarty3 template engine to render its web views. Smarty3 compiles templates to PHP to speed up rendering."
 msgstr ""
 
-#: src/Core/Installer.php:537
+#: src/Core/Installer.php:563
 msgid "In order to store these compiled templates, the web server needs to have write access to the directory view/smarty3/ under the Friendica top level folder."
 msgstr ""
 
-#: src/Core/Installer.php:538
+#: src/Core/Installer.php:564
 msgid "Please ensure that the user that your web server runs as (e.g. www-data) has write access to this folder."
 msgstr ""
 
-#: src/Core/Installer.php:539
+#: src/Core/Installer.php:565
 msgid "Note: as a security measure, you should give the web server write access to view/smarty3/ only--not the template files (.tpl) that it contains."
 msgstr ""
 
-#: src/Core/Installer.php:542
+#: src/Core/Installer.php:568
 msgid "view/smarty3 is writable"
 msgstr ""
 
-#: src/Core/Installer.php:570
+#: src/Core/Installer.php:596
 msgid "Url rewrite in .htaccess seems not working. Make sure you copied .htaccess-dist to .htaccess."
 msgstr ""
 
-#: src/Core/Installer.php:571
+#: src/Core/Installer.php:597
 msgid "In some circumstances (like running inside containers), you can skip this error."
 msgstr ""
 
-#: src/Core/Installer.php:573
+#: src/Core/Installer.php:599
 msgid "Error message from Curl when fetching"
 msgstr ""
 
-#: src/Core/Installer.php:579
+#: src/Core/Installer.php:605
 msgid "Url rewrite is working"
 msgstr ""
 
-#: src/Core/Installer.php:608
+#: src/Core/Installer.php:634
 msgid "The detection of TLS to secure the communication between the browser and the new Friendica server failed."
 msgstr ""
 
-#: src/Core/Installer.php:609
+#: src/Core/Installer.php:635
 msgid "It is highly encouraged to use Friendica only over a secure connection as sensitive information like passwords will be transmitted."
 msgstr ""
 
-#: src/Core/Installer.php:610
+#: src/Core/Installer.php:636
 msgid "Please ensure that the connection to the server is secure."
 msgstr ""
 
-#: src/Core/Installer.php:611
+#: src/Core/Installer.php:637
 msgid "No TLS detected"
 msgstr ""
 
-#: src/Core/Installer.php:613
+#: src/Core/Installer.php:639
 msgid "TLS detected"
 msgstr ""
 
-#: src/Core/Installer.php:630
+#: src/Core/Installer.php:656
 msgid "ImageMagick PHP extension is not installed"
 msgstr ""
 
-#: src/Core/Installer.php:632
+#: src/Core/Installer.php:658
 msgid "ImageMagick PHP extension is installed"
 msgstr ""
 
-#: src/Core/Installer.php:653
+#: src/Core/Installer.php:679
 msgid "Database already in use."
 msgstr ""
 
-#: src/Core/Installer.php:658
+#: src/Core/Installer.php:684
 msgid "Could not connect to database."
 msgstr ""
 
@@ -4253,7 +4253,7 @@ msgstr ""
 
 #: src/Module/Admin/Federation.php:70
 #: src/Module/Moderation/Report/Create.php:220
-#: src/Module/Moderation/Reports.php:579 src/Module/Moderation/Reports.php:590
+#: src/Module/Moderation/Reports.php:584 src/Module/Moderation/Reports.php:595
 #: src/Module/Moderation/Utils/ReportUtil.php:25
 msgid "Other"
 msgstr ""
@@ -4490,7 +4490,7 @@ msgstr ""
 msgid "Job Parameters"
 msgstr ""
 
-#: src/Module/Admin/Queue.php:70 src/Module/Moderation/Reports.php:242
+#: src/Module/Admin/Queue.php:70 src/Module/Moderation/Reports.php:245
 #: src/Module/Settings/OAuth.php:58
 msgid "Created"
 msgstr ""
@@ -4544,7 +4544,7 @@ msgid "User"
 msgstr ""
 
 #: src/Module/Admin/Roles.php:138 src/Module/Contact/Profile.php:435
-#: src/Module/Moderation/Reports.php:342
+#: src/Module/Moderation/Reports.php:347
 #: src/Module/Settings/TwoFactor/Index.php:146
 msgid "Actions"
 msgstr ""
@@ -4640,8 +4640,8 @@ msgstr ""
 msgid "Multi user instance"
 msgstr ""
 
-#: src/Module/Admin/Site.php:436 src/Module/Moderation/Reports.php:212
-#: src/Module/Moderation/Reports.php:285
+#: src/Module/Admin/Site.php:436 src/Module/Moderation/Reports.php:215
+#: src/Module/Moderation/Reports.php:289
 msgid "Closed"
 msgstr ""
 
@@ -4649,8 +4649,8 @@ msgstr ""
 msgid "Requires approval"
 msgstr ""
 
-#: src/Module/Admin/Site.php:438 src/Module/Moderation/Reports.php:212
-#: src/Module/Moderation/Reports.php:285
+#: src/Module/Admin/Site.php:438 src/Module/Moderation/Reports.php:215
+#: src/Module/Moderation/Reports.php:289
 msgid "Open"
 msgstr ""
 
@@ -6045,7 +6045,7 @@ msgstr ""
 msgid "Submanaged account can't access the moderation pages. Please log back in as the main account."
 msgstr ""
 
-#: src/Module/BaseModeration.php:99 src/Module/Moderation/Reports.php:241
+#: src/Module/BaseModeration.php:99 src/Module/Moderation/Reports.php:244
 msgid "Reports"
 msgstr ""
 
@@ -6612,7 +6612,7 @@ msgstr ""
 
 #: src/Module/Contact/Advanced.php:120
 #: src/Module/Moderation/Blocklist/Contact.php:118
-#: src/Module/Moderation/Reports.php:242
+#: src/Module/Moderation/Reports.php:245
 #: src/Module/Moderation/Users/Active.php:82
 #: src/Module/Moderation/Users/Blocked.php:82
 #: src/Module/Moderation/Users/Deleted.php:69
@@ -6731,7 +6731,7 @@ msgstr ""
 #: src/Module/Contact/Follow.php:155 src/Module/Contact/Profile.php:422
 #: src/Module/Contact/Unfollow.php:110
 #: src/Module/Moderation/Blocklist/Contact.php:128
-#: src/Module/Moderation/Reports.php:260
+#: src/Module/Moderation/Reports.php:263
 #: src/Module/Notifications/Introductions.php:125
 #: src/Module/Notifications/Introductions.php:198
 msgid "Profile URL"
@@ -6974,7 +6974,7 @@ msgstr ""
 msgid "Comma separated list of keywords that should not be converted to hashtags, when \"Fetch information and keywords\" is selected"
 msgstr ""
 
-#: src/Module/Contact/Profile.php:437 src/Module/Moderation/Reports.php:242
+#: src/Module/Contact/Profile.php:437 src/Module/Moderation/Reports.php:245
 #: src/Module/Settings/TwoFactor/Index.php:126
 msgid "Status"
 msgstr ""
@@ -8273,7 +8273,7 @@ msgid "Block New Remote Contact"
 msgstr ""
 
 #: src/Module/Moderation/Blocklist/Contact.php:118
-#: src/Module/Moderation/Reports.php:242
+#: src/Module/Moderation/Reports.php:245
 msgid "Photo"
 msgstr ""
 
@@ -8621,7 +8621,7 @@ msgid "You need to know the GUID of the item. You can find it e.g. by looking at
 msgstr ""
 
 #: src/Module/Moderation/Item/Delete.php:53
-#: src/Module/Moderation/Reports.php:341
+#: src/Module/Moderation/Reports.php:346
 msgid "GUID"
 msgstr ""
 
@@ -8721,7 +8721,7 @@ msgid "Please pick below the category of your report."
 msgstr ""
 
 #: src/Module/Moderation/Report/Create.php:215
-#: src/Module/Moderation/Reports.php:576 src/Module/Moderation/Reports.php:587
+#: src/Module/Moderation/Reports.php:581 src/Module/Moderation/Reports.php:592
 #: src/Module/Moderation/Utils/ReportUtil.php:20
 msgid "Spam"
 msgstr ""
@@ -8731,7 +8731,7 @@ msgid "This contact is publishing many repeated/overly long posts/replies or adv
 msgstr ""
 
 #: src/Module/Moderation/Report/Create.php:216
-#: src/Module/Moderation/Reports.php:577 src/Module/Moderation/Reports.php:588
+#: src/Module/Moderation/Reports.php:582 src/Module/Moderation/Reports.php:593
 #: src/Module/Moderation/Utils/ReportUtil.php:21
 msgid "Illegal Content"
 msgstr ""
@@ -8759,7 +8759,7 @@ msgid "This contact has repeatedly published content irrelevant to the node's th
 msgstr ""
 
 #: src/Module/Moderation/Report/Create.php:219
-#: src/Module/Moderation/Reports.php:578 src/Module/Moderation/Reports.php:589
+#: src/Module/Moderation/Reports.php:583 src/Module/Moderation/Reports.php:594
 #: src/Module/Moderation/Utils/ReportUtil.php:24
 msgid "Rules Violation"
 msgstr ""
@@ -8864,262 +8864,262 @@ msgstr ""
 msgid "3. Pick posts"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:237
+#: src/Module/Moderation/Reports.php:240
 msgid "List of reports"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:238
+#: src/Module/Moderation/Reports.php:241
 msgid "This page display reports created by our or remote users."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:239
+#: src/Module/Moderation/Reports.php:242
 msgid "No report exists at this node."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:242 src/Module/Moderation/Reports.php:336
+#: src/Module/Moderation/Reports.php:245 src/Module/Moderation/Reports.php:341
 msgid "Category"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:243
+#: src/Module/Moderation/Reports.php:246
 msgid "Select all"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:244
+#: src/Module/Moderation/Reports.php:247
 msgid "Close selected reports"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:245
+#: src/Module/Moderation/Reports.php:248
 msgid "Open reports"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:246
+#: src/Module/Moderation/Reports.php:249
 msgid "Closed reports"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:247
+#: src/Module/Moderation/Reports.php:250
 msgid "All reports"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:253 src/Module/Moderation/Reports.php:586
+#: src/Module/Moderation/Reports.php:256 src/Module/Moderation/Reports.php:591
 msgid "All categories"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:257
+#: src/Module/Moderation/Reports.php:260
 #, php-format
 msgid "%s total report"
 msgid_plural "%s total reports"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Moderation/Reports.php:260
+#: src/Module/Moderation/Reports.php:263
 msgid "URL of the reported contact."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:326
+#: src/Module/Moderation/Reports.php:330
 msgid "Report details"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:327
+#: src/Module/Moderation/Reports.php:331
 msgid "Back to reports"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:329
+#: src/Module/Moderation/Reports.php:334
 msgid "Forwarded"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:330
+#: src/Module/Moderation/Reports.php:335
 msgid "Not forwarded"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:331
+#: src/Module/Moderation/Reports.php:336
 msgid "Assigned user id:"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:332 src/Module/Moderation/Reports.php:605
+#: src/Module/Moderation/Reports.php:337 src/Module/Moderation/Reports.php:610
 msgid "Unassigned"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:333
+#: src/Module/Moderation/Reports.php:338
 msgid "Reporter:"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:334
+#: src/Module/Moderation/Reports.php:339
 msgid "Target:"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:335
+#: src/Module/Moderation/Reports.php:340
 msgid "Category and rules"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:337
+#: src/Module/Moderation/Reports.php:342
 msgid "Node rules"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:338
+#: src/Module/Moderation/Reports.php:343
 msgid "Attached posts"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:339
+#: src/Module/Moderation/Reports.php:344
 msgid "URI-ID"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:343
+#: src/Module/Moderation/Reports.php:348
 msgid "Public remarks"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:344
+#: src/Module/Moderation/Reports.php:349
 msgid "Private remarks"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:345
+#: src/Module/Moderation/Reports.php:350
 msgid "This report is finalized and read-only."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:346
+#: src/Module/Moderation/Reports.php:351
 msgid "Save remarks"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:347
+#: src/Module/Moderation/Reports.php:352
 msgid "Assign to me"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:348
+#: src/Module/Moderation/Reports.php:353
 msgid "Unassign"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:349
+#: src/Module/Moderation/Reports.php:354
 msgid "Mark resolved"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:350
+#: src/Module/Moderation/Reports.php:355
 msgid "Save category and rules"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:351
+#: src/Module/Moderation/Reports.php:356
 msgid "Delete all reported posts"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:352
+#: src/Module/Moderation/Reports.php:357
 msgid "Block local user"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:353
+#: src/Module/Moderation/Reports.php:358
 msgid "Block remote contact"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:354
+#: src/Module/Moderation/Reports.php:359
 msgid "Block remote contact and purge content"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:355
+#: src/Module/Moderation/Reports.php:360
 msgid "Delete this reported post"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:356
+#: src/Module/Moderation/Reports.php:361
 msgid "Warn user"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:357
+#: src/Module/Moderation/Reports.php:362
 msgid "Warning message"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:358
+#: src/Module/Moderation/Reports.php:363
 msgid "Silence local user (future posts unlisted)"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:377
+#: src/Module/Moderation/Reports.php:382
 #, php-format
 msgid "%s reported post marked for deletion"
 msgid_plural "%s reported posts marked for deletion"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/Module/Moderation/Reports.php:379
+#: src/Module/Moderation/Reports.php:384
 msgid "This report has no attached posts."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:386
+#: src/Module/Moderation/Reports.php:391
 msgid "Invalid reported post id."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:400
+#: src/Module/Moderation/Reports.php:405
 msgid "This post is not attached to the report."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:407
+#: src/Module/Moderation/Reports.php:412
 msgid "Reported post marked for deletion."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:416
+#: src/Module/Moderation/Reports.php:421
 msgid "Reported target contact not found."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:424
+#: src/Module/Moderation/Reports.php:429
 msgid "The local user has been blocked."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:429
+#: src/Module/Moderation/Reports.php:434
 msgid "Could not map the reported local contact to a user account."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:434
+#: src/Module/Moderation/Reports.php:439
 msgid "Failed to block the remote contact."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:447
+#: src/Module/Moderation/Reports.php:452
 msgid "The remote contact has been blocked and related content will be purged."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:449
+#: src/Module/Moderation/Reports.php:454
 msgid "The remote contact has been blocked."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:457
+#: src/Module/Moderation/Reports.php:462
 msgid "Please provide a warning message."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:469
+#: src/Module/Moderation/Reports.php:474
 msgid "Moderator warning:"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:474
+#: src/Module/Moderation/Reports.php:479
 msgid "Warning text has been saved, but automatic delivery is only available for local users."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:480
+#: src/Module/Moderation/Reports.php:485
 msgid "Warning text has been saved, but the local user has no deliverable email address."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:488
+#: src/Module/Moderation/Reports.php:493
 #, php-format
 msgid "Moderation warning from %s"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:489
+#: src/Module/Moderation/Reports.php:494
 msgid "Your recent activity was reported to the moderation team. Please review this warning message."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:498
+#: src/Module/Moderation/Reports.php:503
 msgid "Warning sent to the local user and stored in public remarks."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:501 src/Module/Moderation/Reports.php:505
+#: src/Module/Moderation/Reports.php:506 src/Module/Moderation/Reports.php:510
 msgid "Warning text was stored, but sending the email failed."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:516
+#: src/Module/Moderation/Reports.php:521
 msgid "This action is only available for local users."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:528
+#: src/Module/Moderation/Reports.php:533
 msgid "Local user silenced: future posts will be unlisted, and public community visibility is reduced."
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:603
+#: src/Module/Moderation/Reports.php:608
 msgid "All assignments"
 msgstr ""
 
-#: src/Module/Moderation/Reports.php:604
+#: src/Module/Moderation/Reports.php:609
 msgid "Assigned to me"
 msgstr ""
 
@@ -12708,12 +12708,12 @@ msgstr ""
 msgid "Login failed because your account is blocked."
 msgstr ""
 
-#: src/Security/Authentication.php:356
+#: src/Security/Authentication.php:363
 #, php-format
 msgid "Welcome %s"
 msgstr ""
 
-#: src/Security/Authentication.php:357
+#: src/Security/Authentication.php:364
 msgid "Please upload a profile photo."
 msgstr ""
 

--- a/view/templates/prv_message.tpl
+++ b/view/templates/prv_message.tpl
@@ -11,11 +11,11 @@
 <div id="prvmail-wrapper">
 <form id="prvmail-form" action="message" method="post">
 
-{{$parent nofilter}}
+{{if $replyto}}<input type="hidden" name="replyto" value="{{$replyto}}" />{{/if}}
 
 <div id="prvmail-to-label">
 {{$to}}<br/>
-{{$select nofilter}}<br/>
+{{if $recipient}}{{$recipient.name}}<input type="hidden" name="recipient" value="{{$recipient.id}}" />{{else}}{{$select nofilter}}{{/if}}<br/>
 <small>{{$to_desc}}</small>
 </div>
 

--- a/view/theme/frio/templates/prv_message.tpl
+++ b/view/theme/frio/templates/prv_message.tpl
@@ -8,12 +8,12 @@
 <div id="prvmail-wrapper">
 <form id="prvmail-form" action="message" method="post">
 
-	{{$parent nofilter}}
+	{{if $replyto}}<input type="hidden" name="replyto" value="{{$replyto}}" />{{/if}}
 
 	{{* The To: form-group which contains the message recipient *}}
 	<div id="prvmail-to-label" class="form-group">
 		<label for="recipient">{{$to}}</label><br>
-		{{$select nofilter}}
+		{{if $recipient}}{{$recipient.name}}<input type="hidden" name="recipient" value="{{$recipient.id}}" />{{else}}{{$select nofilter}}{{/if}}
 		 <small>{{$to_desc}}</small>
 	</div>
 


### PR DESCRIPTION
Remote display names and conversation identifiers were rendered as raw HTML in the private message reply form.

This change passes both values separately to Smarty so they are escaped properly. Raw output is kept only for the generated recipient selector used by new messages.

Tests cover both private message templates.