### PR TITLE
Fix field label conditionals

### DIFF
--- a/view/templates/field_input.tpl
+++ b/view/templates/field_input.tpl
@@ -6,7 +6,7 @@
   *}}
 
 	<div class="field input" id="wrapper_{{$field.0}}">
-		{{if $label != false}}
+		{{if !isset($label) || $label != false}}
 			<label for="id_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
 		{{/if}}
 		<input type="{{$field.6|default:'text'}}" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2}}"{{if $field.4}} required{{/if}} {{$field.5 nofilter}} aria-describedby="{{$field.0}}_tip" dir="auto" {{if $field.7}}placeholder="{{$field.7}}"{{/if}}>

--- a/view/templates/field_password.tpl
+++ b/view/templates/field_password.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 	<div class="field password" id="wrapper_{{$field.0}}">
-		{{if $label != false}}
+		{{if !isset($label) || $label != false}}
 			<label for="id_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
 		{{/if}}
 		<input type="password" name="{{$field.0}}" id="id_{{$field.0}}" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} {{if $field.6}}pattern="(($field.6}}"{{/if}} aria-describedby="{{$field.0}}_tip" {{if $field.7}}placeholder="{{$field.7}}"{{/if}}>

--- a/view/theme/frio/templates/field_input.tpl
+++ b/view/theme/frio/templates/field_input.tpl
@@ -6,7 +6,7 @@
   *}}
 
 	<div id="id_{{$field.0}}_wrapper" class="form-group field input">
-	{{if !isset($label) || $label != false }}
+	{{if !isset($label) || $label != false}}
 		<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1 nofilter}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
 	{{/if}}
 	<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="{{$field.6|default:'text'}}" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} aria-describedby="{{$field.0}}_tip" {{if $field.7}}placeholder="{{$field.7}}"{{/if}}>

--- a/view/theme/frio/templates/field_password.tpl
+++ b/view/theme/frio/templates/field_password.tpl
@@ -5,7 +5,7 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div id="id_{{$field.0}}_wrapper" class="form-group field input password">
-	{{if $label != false }}
+	{{if !isset($label) || $label != false}}
 		<label for="id_{{$field.0}}" id="label_{{$field.0}}">{{$field.1}}{{if $field.4}} <span class="required" title="{{$field.4}}">*</span>{{/if}}</label>
 	{{/if}}
 	<input class="form-control" name="{{$field.0}}" id="id_{{$field.0}}" type="password" value="{{$field.2}}" {{if $field.4}}required{{/if}} {{$field.5 nofilter}} {{if $field.6}}pattern="{{$field.6}}"{{/if}} aria-describedby="{{$field.0}}_tip" {{if $field.7}}placeholder="{{$field.7}}"{{/if}}>


### PR DESCRIPTION
Closes #16092, by actually using the preexisting conditional from frio's `field_input.tpl`:
```php
{{if !isset($label) || $label != false }}
```
...instead of just `$label != false`, which doesn't work, as the labels come in as `false` rather than `null`.

It was introduced back in #15149 by me, for places using field_password in frio, and field_input and field_password in other themes/vier.