### PR TITLE
Vier fix ignore and discard in intros, matching frio

### DIFF
--- a/view/templates/notifications/intros.tpl
+++ b/view/templates/notifications/intros.tpl
@@ -19,8 +19,8 @@
   <div class="intro-note" id="intro-note-{{$contact_id}}">{{$note}}</div>
   <div class="intro-wrapper-end" id="intro-wrapper-end-{{$contact_id}}"></div>
   <form class="intro-form" action="notification/{{$intro_id}}" method="post">
-    <button class="intro-submit-ignore" type="submit" name="submit" value="{{$ignore}}">{{$ignore}}</button>
-   {{if $discard}}<button class="intro-submit-discard" type="submit" name="submit" value="{{$discard}}">{{$discard}}</button>{{/if}}
+    <button class="intro-submit-ignore" type="submit" name="submit" value="ignore">{{$ignore}}</button>
+    {{if $discard}}<button class="intro-submit-discard" type="submit" name="submit" value="discard">{{$discard}}</button>{{/if}}
   </form>
   <div class="intro-form-end"></div>
 


### PR DESCRIPTION
Closes #16096

Adds the fixes to Vier that were [added to Frio](https://github.com/friendica/friendica/blob/2026.08-rc/view/theme/frio/templates/notifications/intros.tpl#L53), after discard/ignore in introductions were changed to not rely on the translated text, but instead using a hardcoded, predictable string.