### PR TITLE
Defer worker tasks whose worker process died

### DIFF
--- a/src/Core/Worker.php
+++ b/src/Core/Worker.php
@@ -1405,8 +1405,21 @@ class Worker
 	 */
 	public static function defer(int $worker_defer_limit = 0): bool
 	{
-		$queue = DI::appHelper()->getQueue();
+		return self::deferQueueEntry(DI::appHelper()->getQueue(), $worker_defer_limit);
+	}
 
+	/**
+	 * Defers the given worker entry
+	 *
+	 * Unlike self::defer() this works on any entry, not only on the one of the current process.
+	 *
+	 * @param array $queue Worker queue entry, needs at least id, priority, created and retrial
+	 * @param int $worker_defer_limit Maximum defer limit
+	 * @return boolean had the entry been deferred?
+	 * @throws \Exception
+	 */
+	public static function deferQueueEntry(array $queue, int $worker_defer_limit = 0): bool
+	{
 		if (empty($queue)) {
 			return false;
 		}

--- a/src/Core/Worker/Cron.php
+++ b/src/Core/Worker/Cron.php
@@ -63,7 +63,7 @@ class Cron
 	{
 		$entries = DBA::select(
 			'workerqueue',
-			['id', 'pid', 'executed', 'priority', 'command', 'parameter'],
+			['id', 'pid', 'executed', 'priority', 'command', 'parameter', 'created', 'retrial'],
 			['NOT `done` AND `pid` != ? AND `executed` > ?', 0, DBA::NULL_DATETIME],
 			['order' => ['priority', 'retrial', 'created']],
 		);
@@ -72,7 +72,12 @@ class Cron
 
 		while ($entry = DBA::fetch($entries)) {
 			if (!posix_kill($entry["pid"], 0)) {
-				DBA::update('workerqueue', ['executed' => DBA::NULL_DATETIME, 'pid' => 0], ['id' => $entry["id"]]);
+				// The worker process is gone without having deferred the task itself.
+				// Defer it here, otherwise a task that reliably kills its worker would be retried forever.
+				if (!Worker::deferQueueEntry($entry)) {
+					DI::logger()->warning('Worker process died repeatedly - task dropped', ['id' => $entry['id'], 'created' => $entry['created'], 'retrial' => $entry['retrial'], 'command' => $entry['command'], 'parameter' => $entry['parameter']]);
+					DBA::update('workerqueue', ['done' => true], ['id' => $entry['id']]);
+				}
 			} else {
 				// Kill long running processes
 

--- a/tests/Functional/Core/WorkerTest.php
+++ b/tests/Functional/Core/WorkerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Functional\Core;
+
+use Friendica\Core\Worker;
+use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Test\FixtureTestCase;
+use Friendica\Util\DateTimeFormat;
+
+class WorkerTest extends FixtureTestCase
+{
+	/**
+	 * Adds a claimed worker queue entry and returns its id
+	 */
+	private function addClaimedEntry(int $retrial): int
+	{
+		DBA::insert('workerqueue', [
+			'command'   => 'UpdateGServer',
+			'parameter' => json_encode(['https://example.com']),
+			'priority'  => Worker::PRIORITY_LOW,
+			'created'   => DateTimeFormat::utcNow(),
+			'pid'       => 12345,
+			'executed'  => DateTimeFormat::utcNow(),
+			'next_try'  => DBA::NULL_DATETIME,
+			'retrial'   => $retrial,
+			'done'      => false,
+		]);
+
+		return DBA::lastInsertId();
+	}
+
+	private function fetchEntry(int $id): array
+	{
+		$entry = DBA::selectFirst('workerqueue', ['id', 'priority', 'created', 'retrial', 'pid', 'executed', 'next_try', 'done'], ['id' => $id]);
+
+		self::assertIsArray($entry);
+
+		return $entry;
+	}
+
+	/**
+	 * Deferring on behalf of a gone worker has to release the claim AND count the attempt.
+	 */
+	public function testDeferQueueEntryCountsTheAttempt(): void
+	{
+		$id = $this->addClaimedEntry(0);
+
+		self::assertTrue(Worker::deferQueueEntry($this->fetchEntry($id)));
+
+		$entry = $this->fetchEntry($id);
+
+		self::assertEquals(1, $entry['retrial']);
+		self::assertEquals(0, $entry['pid']);
+		self::assertEquals(DBA::NULL_DATETIME, $entry['executed']);
+		self::assertGreaterThan(DateTimeFormat::utcNow(), $entry['next_try']);
+		self::assertFalse((bool) $entry['done']);
+	}
+
+	/**
+	 * Past system.worker_defer_limit the entry must not be rescheduled again.
+	 */
+	public function testDeferQueueEntryStopsAtTheDeferLimit(): void
+	{
+		$max_level = DI::config()->get('system', 'worker_defer_limit');
+
+		$id = $this->addClaimedEntry($max_level);
+
+		self::assertFalse(Worker::deferQueueEntry($this->fetchEntry($id)));
+
+		$entry = $this->fetchEntry($id);
+
+		self::assertEquals($max_level, $entry['retrial']);
+	}
+
+	/**
+	 * The explicit defer limit of a caller must not raise the configured one.
+	 */
+	public function testDeferQueueEntryRespectsTheCallerLimit(): void
+	{
+		$id = $this->addClaimedEntry(3);
+
+		self::assertFalse(Worker::deferQueueEntry($this->fetchEntry($id), 3));
+	}
+
+	public function testDeferQueueEntryIgnoresAnEmptyEntry(): void
+	{
+		self::assertFalse(Worker::deferQueueEntry([]));
+	}
+}


### PR DESCRIPTION
## Problem

`Worker::defer()` is the only bounded-retry mechanism for worker tasks, but it reads the queue entry from `DI::appHelper()->getQueue()` -> so it is reachable only from *inside* a living worker.

A worker that dies without returning (PHP fatal, OOM kill, segfault, container restart) never gets there. Its task is recovered by `Worker\Cron::killStaleWorkers()`, whose dead-process branch released the claim without counting the attempt:

```php
if (!posix_kill($entry["pid"], 0)) {
    DBA::update('workerqueue', ['executed' => DBA::NULL_DATETIME, 'pid' => 0], ['id' => $entry["id"]]);
} else {
    // alive-but-long-running: lowers priority, resets `created`, SIGTERM
}
```

## Observed

On my 2026.05 friendica instance two `UpdateGServer` tasks sat in this loop for four weeks. Both target servers drive the HTTP client past `memory_limit` while probing nodeinfo/statistics, so the worker dies with a PHP fatal every time.

```
executed 23:38:50  pid 8193 / 8195   → fatal pair 17–38 s later
executed 23:41:38  pid 8309 / 8313   → fatal pair 17–38 s later
executed 23:43:52  pid 8383 / 8385   → fatal pair 17–38 s later
```

Maybe related issue: #15342 (a worker job OOMing repeatedly and never completing).