### PR TITLE
Fix blank conversation pages for logged out visitors

### DIFF
--- a/src/Content/Conversation/ConversationDataProvider.php
+++ b/src/Content/Conversation/ConversationDataProvider.php
@@ -168,7 +168,7 @@ final readonly class ConversationDataProvider
 
 		$convResponses = $this->buildConversationResponses($uid);
 
-		$pcid = Contact::getPublicIdByUserId($uid);
+		$pcid = $uid !== 0 ? (int) Contact::getPublicIdByUserId($uid) : 0;
 
 		$writable = $uid !== 0;
 


### PR DESCRIPTION
`Contact::getPublicIdByUserId()` returns `false` for uid 0, so `processActivityReactions()` died on its `int $pcid` parameter. Every conversation page - timeline, profile, display,... returned an empty body for guests.

Verified logged out, before -> after

Follow-up to #16100