### PR TITLE
Serve .mjs as JavaScript

### DIFF
--- a/.docker/nginx/nginx.conf
+++ b/.docker/nginx/nginx.conf
@@ -8,6 +8,13 @@ server {
     root /var/www/html;
     index index.php index.html index.htm;
 
+    # nginx' mime.types has no mapping for .mjs.
+    # The include has to stay, a bare types block would replace the whole table.
+    include mime.types;
+    types {
+        text/javascript mjs;
+    }
+
     # Client upload size limit
     client_max_body_size 100M;
 

--- a/.htaccess-dist
+++ b/.htaccess-dist
@@ -11,6 +11,8 @@ Options -Multiviews
 Options -Indexes
 AddType application/x-java-archive .jar
 AddType audio/ogg .oga
+# Older Apache versions don't know .mjs.
+AddType text/javascript .mjs
 
 # deny access to log files (friendica.log or php.out)
 <FilesMatch "\.(out|log)$">

--- a/doc/en/admin/install.md
+++ b/doc/en/admin/install.md
@@ -379,6 +379,32 @@ It is likely that your web server reported the source of the problem in its erro
 Please review these system error logs to determine what caused the problem.
 Often this will need to be resolved with your hosting provider or (if self-hosted) your web server configuration.
 
+### Empty navigation bar, "blocked due to a disallowed MIME type" in the browser console
+
+Friendica loads some of its JavaScript as ES modules, one of them from a `.mjs` file.
+Browsers reject a module that is not served with a JavaScript MIME type.
+nginx and older Apache versions have no `.mjs` entry in their MIME type table.
+
+For nginx, add this to your Friendica server block:
+
+```nginx
+  # The include has to stay, a bare types block would replace the whole table.
+  include mime.types;
+
+  types {
+    text/javascript mjs;
+  }
+```
+
+For Apache, add this to your `.htaccess`:
+
+```apache
+AddType text/javascript .mjs
+```
+
+Both ship with `.htaccess-dist` and `mods/sample-nginx.config` since Friendica 2026.08.
+An existing configuration is never updated automatically.
+
 ### 400 and 4xx "File not found" errors
 
 First check your file permissions.

--- a/doc/en/developer/upgrade-2026.08.md
+++ b/doc/en/developer/upgrade-2026.08.md
@@ -20,6 +20,26 @@ This section contains backward compatibility breaks, make sure your code is comp
    Add required hostnames to `system.allowed_internal_hosts`.
    The protection can be disabled with `system.block_private_addresses`, but this is not recommended on public nodes.
 
+- The web server has to serve `.mjs` files as JavaScript.
+
+   Friendica loads part of its JavaScript as ES modules, and browsers reject a module that is not served with a JavaScript MIME type.
+   nginx and older Apache versions have no `.mjs` entry in their MIME type table, which leaves the navigation bar empty.
+   `.htaccess-dist` and `mods/sample-nginx.config` ship the mapping, an existing configuration has to be adjusted by hand.
+
+   *nginx* – the include has to stay, a bare `types` block would replace the whole table
+   ```nginx
+   include mime.types;
+
+   types {
+     text/javascript mjs;
+   }
+   ```
+
+   *Apache*
+   ```apache
+   AddType text/javascript .mjs
+   ```
+
 - The icon library has been changed from Font Awesome to Remix Icons. Theme developers must replace `fa-*` CSS classes with their `ri-*` equivalents.
 
    The Font Awesome dependency has been removed. Any theme or addon that relies on Font Awesome must either include it themselves or migrate to Remix Icons.

--- a/mods/sample-nginx-certbot.config
+++ b/mods/sample-nginx-certbot.config
@@ -94,6 +94,11 @@ server {
 
   include mime.types;
 
+  # nginx' mime.types has no mapping for .mjs.
+  types {
+    text/javascript mjs;
+  }
+
   # statically serve these file types when possible otherwise fall back to
   # front controller allow browser to cache them added .htm for advanced source
   # code editor library

--- a/mods/sample-nginx.config
+++ b/mods/sample-nginx.config
@@ -115,6 +115,11 @@ server {
 
   include mime.types;
 
+  # nginx' mime.types has no mapping for .mjs.
+  types {
+    text/javascript mjs;
+  }
+
   # statically serve these file types when possible otherwise fall back to
   # front controller allow browser to cache them added .htm for advanced source
   # code editor library


### PR DESCRIPTION
nginx' mime.types has no entry for .mjs, so acorn.mjs was delivered as application/octet-stream. The browser then refused the ES module, taking the SPA script runtime and the network tab header down.

So we can now use `.mjs` everywhere, as @annando already tried to introduced it with SPA :-)

Fixes #16113