### PR TITLE
Fix Advanced Composer labels

### DIFF
--- a/src/Module/Item/Compose.php
+++ b/src/Module/Item/Compose.php
@@ -334,13 +334,13 @@ class Compose extends BaseModule
 			'helpParagraphA11yTitle' => $this->l10n->t('Paragraph Check (Accessibility)'),
 			'helpParagraphA11yBody'  => $this->l10n->t('For posts longer than 300 characters, checks whether at least one paragraph break exists. Screen readers and cognitive-accessibility tools benefit greatly from structured text. Short posts are always rated neutral.'),
 			'btnClose'               => $this->l10n->t('Close'),
-			'btnCloseSymbol'         => $this->l10n->t('\u00d7'),
+			'btnCloseSymbol'         => '×',
 			'placeholder'            => $this->l10n->t('Image description'),
 		];
 
-		$advancedComposerL10n = array_map(fn ($v): string => htmlspecialchars((string) $v, ENT_QUOTES, 'UTF-8'), $advancedComposerL10n);
-
-		$advancedComposerL10nJson = json_encode($advancedComposerL10n, JSON_UNESCAPED_UNICODE);
+		// The strings end up in textContent/title, so they must not be HTML escaped.
+		// JSON_HEX_* keeps them safe inside the <script> block instead.
+		$advancedComposerL10nJson = json_encode($advancedComposerL10n, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
 
 		$tpl = Renderer::getMarkupTemplate('item/advancedcomposer.tpl');
 		return Renderer::replaceMacros($tpl, [

--- a/view/lang/C/messages.po
+++ b/view/lang/C/messages.po
@@ -7904,10 +7904,6 @@ msgstr ""
 msgid "For posts longer than 300 characters, checks whether at least one paragraph break exists. Screen readers and cognitive-accessibility tools benefit greatly from structured text. Short posts are always rated neutral."
 msgstr ""
 
-#: src/Module/Item/Compose.php:337
-msgid "\\u00d7"
-msgstr ""
-
 #: src/Module/Item/Compose.php:338
 msgid "Image description"
 msgstr ""

--- a/view/theme/frio/js/advancedcomposer-preview.js
+++ b/view/theme/frio/js/advancedcomposer-preview.js
@@ -253,8 +253,8 @@
 		const refreshBtn = document.createElement('button');
 		refreshBtn.type = 'button';
 		refreshBtn.className = 'ec-preview-refresh-btn';
-		refreshBtn.title = l10n.btnRefreshPreview;
-		api.buildButtonContent(refreshBtn, 'ri ri-refresh-line', l10n.btnRefreshPreview);
+		refreshBtn.title = l10n.btnRefresh;
+		api.buildButtonContent(refreshBtn, 'ri ri-refresh-line', l10n.btnRefresh);
 
 		const topbarLeft = document.createElement('div');
 		topbarLeft.className = 'ec-preview-topbar-left';


### PR DESCRIPTION
All l10n strings are written via textContent/title, so the extra `htmlspecialchars()` pass showed up as literal `'&amp;'`. The close symbol was a single-quoted `'\u00d7'` and the refresh button read the non-existing key btnRefreshPreview.

Fixes #16103