### PR TITLE
Validate the PDS endpoint from the DID document

### DIFF
--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -447,11 +447,44 @@ final class ATProtocol
 
 		foreach ($data->service as $service) {
 			if (($service->id == '#atproto_pds') && ($service->type == 'AtprotoPersonalDataServer') && !empty($service->serviceEndpoint)) {
+				if (!$this->isValidPdsEndpoint($service->serviceEndpoint)) {
+					$this->logger->notice('Invalid PDS endpoint', ['did' => $did, 'endpoint' => $service->serviceEndpoint]);
+					return null;
+				}
 				return $service->serviceEndpoint;
 			}
 		}
 
 		return null;
+	}
+
+	/**
+	 * Checks whether a PDS endpoint taken from a DID document is safe to send requests to.
+	 *
+	 * The endpoint is stored per user and gets the bearer token attached on every API call,
+	 * so it has to be a plain https origin.
+	 * A query or fragment would swallow the '/xrpc/...' path that is appended to it.
+	 *
+	 * @param mixed $endpoint The serviceEndpoint value of the DID document
+	 * @return bool
+	 */
+	private function isValidPdsEndpoint($endpoint): bool
+	{
+		if (!is_string($endpoint)) {
+			return false;
+		}
+
+		$parts = parse_url($endpoint);
+		if (!is_array($parts)) {
+			return false;
+		}
+
+		return (($parts['scheme'] ?? '') === 'https')
+			&& !empty($parts['host'])
+			&& empty($parts['user'])
+			&& empty($parts['pass'])
+			&& empty($parts['query'])
+			&& empty($parts['fragment']);
 	}
 
 	/**

--- a/src/Protocol/ATProtocol.php
+++ b/src/Protocol/ATProtocol.php
@@ -461,8 +461,8 @@ final class ATProtocol
 	/**
 	 * Checks whether a PDS endpoint taken from a DID document is safe to send requests to.
 	 *
-	 * The endpoint is stored per user and gets the bearer token attached on every API call,
-	 * so it has to be a plain https origin.
+	 * The endpoint is stored per user and gets the bearer token attached on every API call.
+	 * It therefore has to be a plain https origin.
 	 * A query or fragment would swallow the '/xrpc/...' path that is appended to it.
 	 *
 	 * @param mixed $endpoint The serviceEndpoint value of the DID document


### PR DESCRIPTION
No bug report behind this one.
I was re-checking an old finding that claimed the bearer token could be sent to an attacker-controlled host, and that turned out to be wrong - the token only ever goes to the user's own DID, resolved through the admin-configured `plc_directory`.
What stayed is that we never look at the value we get.

`getPdsOfDid()` returns whatever `serviceEndpoint` the DID document carries.
`getUserPds()` stores it per user in `pConfig` and never re-checks it, and every call afterwards appends `/xrpc/...` and attaches the token.

The [DID spec](https://atproto.com/specs/did) is explicit here:

> must contain an HTTPS URL of server. It should contain only the URI scheme (`http` or `https`), hostname, and optional port number, not any "userinfo", path prefix, or other components.

A value with a query breaks every request for that user, and because it is cached it stays broken until someone clears it by hand:

```
endpoint:  https://pds.example/?ref=1
request:   https://pds.example/?ref=1/xrpc/app.bsky.feed.getTimeline?limit=50
-> path:   /
-> query:  ref=1/xrpc/app.bsky.feed.getTimeline?limit=50
```

So this rejects a non-https origin, embedded credentials, a query and a fragment before the value is used or stored, and logs instead of failing silently.

Two deviations from the spec text:

- https only, even though the spec mentions `http` - there is a token on every call.
- A path still passes, a trailing `/` is common and concatenates fine, unlike a query.

Checked against real DID documents, both unchanged:

```
did:plc:omz52wsawkrsygq7c3oq2bz6 -> https://pds.wsocial.network
did:plc:z72i7hdynmk6r22z27h6tvur -> https://puffball.us-east.host.bsky.network
```

Small and self-contained, but it fixes nothing that is currently reported - happy to park it until after the release if you'd rather keep the RC quiet. 🙂
