### PR TITLE
Fix two frontend leftovers: dead autocomplete call and a sticky-kit leak

### DIFF
--- a/view/templates/contacts-head.tpl
+++ b/view/templates/contacts-head.tpl
@@ -7,7 +7,7 @@
 
 <script>
 window.onDocumentReady('body', function() {
-	$("#contacts-search").contact_autocomplete(baseurl + '/search/acl', 'a', true);
+	$("#contacts-search").name_autocomplete(baseurl + '/search/acl', 'a', true);
 });
 </script>
 

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -5,6 +5,7 @@
 // @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPLv3-or-later
 
 var jotcache = ""; //The jot cache. We use it as cache to restore old/original jot content
+var stickyAside = null; //The aside currently handled by sticky-kit, see initTheme()
 
 function syncSecondNavTabmenu() {
 	// Move page tabbar into second navbar after initial load and SPA navigations
@@ -351,7 +352,13 @@ function initTheme() {
 	 * since is enabled or not at page loading time.
 	 */
 	if ($(window).width() > 976) {
-		$("aside").stick_in_parent({
+		// Detach the previous aside first: SPA navigation replaces the element,
+		// and its window/body handlers stay bound until sticky_kit:detach.
+		if (stickyAside) {
+			stickyAside.trigger("sticky_kit:detach");
+		}
+		stickyAside = $("aside");
+		stickyAside.stick_in_parent({
 			offset_top: 100, // px, header + tab bar + spacing
 			recalc_every: 10,
 		});


### PR DESCRIPTION
Two independent frontend bugs, both pre-existing and both found while reviewing #16129.

### 1. `contacts-head.tpl` calls a function removed in 2019

`view/templates/contacts-head.tpl` called `$("#contacts-search").contact_autocomplete(…)`.
`$.fn.contact_autocomplete` was dropped from `view/js/autocomplete.js` in 082827b67e ("Remove unused Javascript methods and functions", Aug 2019), so `/contact` threw:

```
Uncaught TypeError: $(...).contact_autocomplete is not a function
```

frio is unaffected --> it overrides the template and loads `mod_contacts.js`.
vier as using the core templates is affected.

### 2. frio leaks a sticky-kit instance per SPA navigation

`initTheme()` is registered as `window.onDocumentReady('body', initTheme)`, so it re-runs after every SPA navigation.
`stick_in_parent()` has no "already initialized" guard and SPA navigation replaces the `aside` element, so the old instance's handlers on `window` and `body` stayed bound to a detached node forever.

Measured on `/help` <-> `/network`