### PR TITLE
Hover adjustments

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1566,7 +1566,7 @@ div.sidebar-widget-list {
 	transition: all 0.1s ease-in-out;
 }
 .faded-icon:hover {
-	color: $font_color_darker;
+	color: $link_color;
 	opacity: 1;
 }
 .icon-padding {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -611,7 +611,7 @@ header #banner {
 header #banner #logo-img,
 .navbar-brand #logo-img {
 	font-size: 36px;
-	color: White;
+	color: $nav_icon_color;
 }
 
 #navbrand-container {

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -231,8 +231,7 @@ ul#nav-user-menu {
 	}
 	#nav-delegation-link:hover,
 	#nav-delegation-link:focus {
-		background-color: $background_color;
-		color: $font_color;
+		background-color: $nav_icon_hover_color;
 	}
 	/* prevent XMPP chat add-on button appearing in modals and iframes */
 	body.minimal #toggle-controlbox {

--- a/view/theme/frio/scheme/dark.css
+++ b/view/theme/frio/scheme/dark.css
@@ -48,7 +48,7 @@ a:hover, button:hover, .btn-link:hover, .btn-primary:hover,
 }
 header #banner #logo-img:focus,
 header #banner #logo-img:hover {
-		background-color: $font_color;
+		color: $font_color;
 }
 
 .dropdown-menu,


### PR DESCRIPTION
Separated out from #16123

Makes the following changes:

Make the switch accounts hover use a lightened accent colour for hover like the rest of the menu, instead of white-ish:
<img width="237" height="177" alt="image" src="https://github.com/user-attachments/assets/9b8de6ab-c1d3-4a6b-bdf0-cc6b9696116a" />

Make faded icons use a lightened accent colour for hover as well, instead of dark gray:
<img width="288" height="169" alt="image" src="https://github.com/user-attachments/assets/2381e05c-2bf3-4e0c-8568-522ebc7a2e36" />

Adjusted the logo color so it's not hardcoded to white, which is too much in dark mode.
Also fixed the broken logo hover color in dark mode.

<img width="385" height="54" alt="image" src="https://github.com/user-attachments/assets/fdd86fab-2b90-4f00-925a-17d04dae5925" />