### PR TITLE
Issue 15926: Don't get notified on posts where you had been blocked

### DIFF
--- a/src/Model/Post/UserNotification.php
+++ b/src/Model/Post/UserNotification.php
@@ -176,6 +176,10 @@ class UserNotification
 				DI::logger()->debug('Author is blocked/ignored/collapsed by user', ['uid' => $uid, 'author' => $author_id, 'uri-id' => $item['uri-id']]);
 				return;
 			}
+			if (Contact\User::isIsBlocked($author_id, $uid)) {
+				DI::logger()->debug('Author blocked the user', ['uid' => $uid, 'author' => $author_id, 'uri-id' => $item['uri-id']]);
+				return;
+			}
 		}
 
 		foreach (array_unique([$parent['author-gsid'], $parent['owner-gsid'], $parent['causer-gsid'], $item['author-gsid'], $item['owner-gsid'], $item['causer-gsid']]) as $gsid) {


### PR DESCRIPTION
See #15926 

This fixes the problem to get notified for activities that you can't see, because you had been blocked.