### PR TITLE
Issue 16040: Ensure to set the last activity for a user

### DIFF
--- a/src/Model/Item.php
+++ b/src/Model/Item.php
@@ -1975,9 +1975,13 @@ class Item
 
 		if ($update) {
 			// The "self" contact id is used (for example in the connectors) when the contact is unknown
-			// So we have to ensure to only update the last item when it had been our own post,
+			// So we have to ensure to only update the last item when it had been our own content,
 			// or it had been done by a "regular" contact.
-			if (!empty($arr['wall'])) {
+			// Our own content is a post or activity we created for a federated network, but not a technical activity like "view".
+			$own_content = !empty($arr['origin'])
+				&& in_array($arr['network'], Protocol::FEDERATED)
+				&& !in_array($arr['verb'], Activity::TECHNICAL_ACTIVITIES);
+			if ($own_content) {
 				$condition = ['id' => $arr['contact-id']];
 			} else {
 				$condition = ['id' => $arr['contact-id'], 'self' => false];

--- a/src/Protocol/Activity.php
+++ b/src/Protocol/Activity.php
@@ -196,6 +196,15 @@ final class Activity
 	];
 
 	/**
+	 * Technical activities, which are usually not considered as content interactions
+	 */
+	public const TECHNICAL_ACTIVITIES = [
+		self::FOLLOW,
+		self::VIEW,
+		self::READ,
+	];
+
+	/**
 	 * Checks if the given activity is a hidden activity
 	 *
 	 * @param string $activity The current activity

--- a/src/Security/Authentication.php
+++ b/src/Security/Authentication.php
@@ -126,6 +126,8 @@ class Authentication
 					if ($this->config->get('system', 'paranoia')) {
 						$this->session->set('addr', $this->cookie->get('ip'));
 					}
+				} else {
+					User::updateLastActivity($user, false);
 				}
 			}
 		}


### PR DESCRIPTION
Really fixes #16040

By now we have set the `last-activity` when a user logged in via web or when they used the API. We hadn't covered the situation when a user worked via web but was already logged in. This is now the case.

We also now set the "last-item" auch dann, wenn jemand einen Beitrag geteilt hat.