### PR TITLE
Frio help-block: Raise admin settings contrast, too

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2808,8 +2808,8 @@ p.wall-item-announce,
 	color: #636363;
 }
 
-/* Darker text color for help-blocks in settings because they're more prevalent and important there */
-.settings-content-wrapper .help-block {
+/* Higher text contrast for help-blocks in settings because they're more prevalent and important there */
+.settings-content-wrapper .help-block, .admin-content-wrapper .help-block {
 	color: $font_color_darker;
 }
 


### PR DESCRIPTION
Closes #16142 

Raises the contrast on help blocks in admin settings as well, so it's not just user settings.

<img width="630" height="398" alt="image" src="https://github.com/user-attachments/assets/d3edc32b-da27-44a7-b3b0-6461bee79d30" />