### PR TITLE
Stream logger accepts stream wrapper

### DIFF
--- a/src/Core/Logger/Factory/DelegatingLoggerFactory.php
+++ b/src/Core/Logger/Factory/DelegatingLoggerFactory.php
@@ -43,6 +43,11 @@ final class DelegatingLoggerFactory implements LoggerFactory
 		$factoryName = $this->config->get('system', 'logger_config') ?? '';
 
 		if (!array_key_exists($factoryName, $this->factories)) {
+			$this->reportFallback(sprintf(
+				'There is no logger registered for the config value "system.logger_config" = "%s".',
+				$factoryName,
+			));
+
 			return new NullLogger();
 		}
 
@@ -50,10 +55,27 @@ final class DelegatingLoggerFactory implements LoggerFactory
 
 		try {
 			$logger = $factory->createLogger($logLevel, $logChannel);
-		} catch (\Throwable) {
+		} catch (\Throwable $exception) {
+			$this->reportFallback(sprintf(
+				'The logger "%s" could not be created: %s',
+				$factoryName,
+				$exception->getMessage(),
+			));
+
 			return new NullLogger();
 		}
 
 		return $logger;
+	}
+
+	/**
+	 * Reports that logging has been silently disabled.
+	 *
+	 * An instance falling back to a NullLogger looks exactly like an idle one.
+	 * The logger cannot report its own failure, so this goes to PHP's error log.
+	 */
+	private function reportFallback(string $message): void
+	{
+		error_log('Friendica: logging is disabled, no log entries will be written. ' . $message);
 	}
 }

--- a/src/Core/Logger/Factory/StreamLoggerFactory.php
+++ b/src/Core/Logger/Factory/StreamLoggerFactory.php
@@ -12,6 +12,7 @@ namespace Friendica\Core\Logger\Factory;
 use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Logger\Capability\IHaveCallIntrospections;
 use Friendica\Core\Logger\Exception\LoggerArgumentException;
+use Friendica\Core\Logger\Exception\LoggerUnusableException;
 use Friendica\Core\Logger\Exception\LogLevelException;
 use Friendica\Core\Logger\Type\StreamLogger;
 use Friendica\Core\Logger\Util\FileSystemUtil;
@@ -41,20 +42,31 @@ final readonly class StreamLoggerFactory implements LoggerFactory
 	 */
 	public function createLogger(string $logLevel, string $logChannel): LoggerInterface
 	{
-		$logfile = $this->config->get('system', 'logfile');
+		$logfile = (string) $this->config->get('system', 'logfile');
 
-		if (!file_exists($logfile) || !is_writable($logfile)) {
-			throw new LoggerArgumentException(sprintf('"%s" is not a valid logfile.', $logfile));
+		if ($logfile === '') {
+			throw new LoggerArgumentException('The config value "system.logfile" is empty, there is nothing to log into.');
 		}
 
 		if (! array_key_exists($logLevel, StreamLogger::levelToInt)) {
 			throw new LogLevelException(sprintf('The log level "%s" is not supported by "%s".', $logLevel, StreamLogger::class));
 		}
 
+		// Opening the stream is the only reliable validation of the log target.
+		// A stat based pre-check rejects two targets that createStream() opens fine:
+		//  - stream wrapper URLs like "php://stdout", where file_exists() is always
+		//    false because the php:// wrapper implements no url_stat() handler.
+		//  - a logfile that does not exist yet, which fopen(..., 'ab') creates.
+		try {
+			$stream = $this->fileSystem->createStream($logfile);
+		} catch (LoggerUnusableException $exception) {
+			throw new LoggerArgumentException(sprintf('"%s" is not a valid logfile.', $logfile), $exception);
+		}
+
 		return new StreamLogger(
 			$logChannel,
 			$this->introspection,
-			$this->fileSystem->createStream($logfile),
+			$stream,
 			StreamLogger::levelToInt[$logLevel],
 			getmypid(),
 		);

--- a/static/settings.config.php
+++ b/static/settings.config.php
@@ -167,7 +167,8 @@ return [
 
 		// logfile (String)
 		// The logfile for storing logs.
-		// Can be a full path or a relative path to the Friendica home directory
+		// Can be a full path, a relative path to the Friendica home directory,
+		// or a stream wrapper URL like 'php://stdout' to log to the process' output.
 		'logfile' => 'log/friendica.log',
 
 		// loglevel (String)

--- a/tests/Unit/Core/Logger/Factory/DelegatingLoggerFactoryTest.php
+++ b/tests/Unit/Core/Logger/Factory/DelegatingLoggerFactoryTest.php
@@ -21,6 +21,8 @@ use Psr\Log\NullLogger;
 
 class DelegatingLoggerFactoryTest extends TestCase
 {
+	private string $errorLog = '';
+
 	public function testCreateLoggerReturnsPsrLogger(): void
 	{
 		$config = $this->createStub(IManageConfigValues::class);
@@ -49,8 +51,14 @@ class DelegatingLoggerFactoryTest extends TestCase
 
 		$this->assertInstanceOf(
 			NullLogger::class,
-			$factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT),
+			$this->captureErrorLog(fn () => $factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT)),
 		);
+
+		$this->assertStringContainsString(
+			'Friendica: logging is disabled, no log entries will be written.',
+			$this->errorLog,
+		);
+		$this->assertStringContainsString('"system.logger_config" = "not-existing-factory"', $this->errorLog);
 	}
 
 	public function testCreateLoggerWithExceptionThrowingFactoryReturnsNullLogger(): void
@@ -63,13 +71,41 @@ class DelegatingLoggerFactoryTest extends TestCase
 		$factory = new DelegatingLoggerFactory($config);
 
 		$brokenFactory = $this->createStub(LoggerFactory::class);
-		$brokenFactory->method('createLogger')->willThrowException(new Exception());
+		$brokenFactory->method('createLogger')->willThrowException(new Exception('"php://stdout" is not a valid logfile.'));
 
 		$factory->registerFactory('test', $brokenFactory);
 
 		$this->assertInstanceOf(
 			NullLogger::class,
-			$factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT),
+			$this->captureErrorLog(fn () => $factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT)),
 		);
+
+		$this->assertStringContainsString(
+			'Friendica: logging is disabled, no log entries will be written.',
+			$this->errorLog,
+		);
+		$this->assertStringContainsString('"php://stdout" is not a valid logfile.', $this->errorLog);
+	}
+
+	/**
+	 * Runs $callback with error_log() redirected into a temporary file.
+	 * The written content ends up in $this->errorLog.
+	 */
+	private function captureErrorLog(callable $callback): mixed
+	{
+		$file     = tempnam(sys_get_temp_dir(), 'friendica-error-log-');
+		$previous = ini_get('error_log');
+
+		ini_set('error_log', $file);
+
+		try {
+			return $callback();
+		} finally {
+			ini_set('error_log', $previous === false ? '' : $previous);
+
+			$this->errorLog = (string) file_get_contents($file);
+
+			unlink($file);
+		}
 	}
 }

--- a/tests/Unit/Core/Logger/Factory/DelegatingLoggerFactoryTest.php
+++ b/tests/Unit/Core/Logger/Factory/DelegatingLoggerFactoryTest.php
@@ -51,7 +51,7 @@ class DelegatingLoggerFactoryTest extends TestCase
 
 		$this->assertInstanceOf(
 			NullLogger::class,
-			$this->captureErrorLog(fn () => $factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT)),
+			$this->captureErrorLog(fn (): \Psr\Log\LoggerInterface => $factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT)),
 		);
 
 		$this->assertStringContainsString(
@@ -77,7 +77,7 @@ class DelegatingLoggerFactoryTest extends TestCase
 
 		$this->assertInstanceOf(
 			NullLogger::class,
-			$this->captureErrorLog(fn () => $factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT)),
+			$this->captureErrorLog(fn (): \Psr\Log\LoggerInterface => $factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT)),
 		);
 
 		$this->assertStringContainsString(

--- a/tests/Unit/Core/Logger/Factory/StreamLoggerFactoryTest.php
+++ b/tests/Unit/Core/Logger/Factory/StreamLoggerFactoryTest.php
@@ -13,8 +13,11 @@ use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\Logger\Capability\IHaveCallIntrospections;
 use Friendica\Core\Logger\Capability\LogChannel;
 use Friendica\Core\Logger\Exception\LoggerArgumentException;
+use Friendica\Core\Logger\Exception\LoggerUnusableException;
 use Friendica\Core\Logger\Exception\LogLevelException;
 use Friendica\Core\Logger\Factory\StreamLoggerFactory;
+use Friendica\Core\Logger\Type\StreamLogger;
+use Friendica\Core\Logger\Util\FileSystem;
 use Friendica\Core\Logger\Util\FileSystemUtil;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -41,11 +44,124 @@ class StreamLoggerFactoryTest extends TestCase
 		);
 	}
 
-	public function testCreateLoggerWithInvalidLogfileThrowsException(): void
+	/**
+	 * A stream wrapper URL is a valid log target and must reach the filesystem util unchanged.
+	 * file_exists() is false for "php://stdout", because php:// implements no url_stat() handler.
+	 */
+	public function testCreateLoggerAcceptsStreamWrapperUrlAsLogfile(): void
 	{
 		$config = $this->createStub(IManageConfigValues::class);
 		$config->method('get')->willReturnMap([
-			['system', 'logfile', null, dirname(__DIR__, 1) . '/not-existing-logfile.txt'],
+			['system', 'logfile', null, 'php://memory'],
+		]);
+
+		$fileSystem = $this->createMock(FileSystemUtil::class);
+		$fileSystem->expects($this->once())
+			->method('createStream')
+			->with('php://memory')
+			->willReturn(fopen('php://memory', 'ab'));
+
+		$factory = new StreamLoggerFactory(
+			$config,
+			$this->createStub(IHaveCallIntrospections::class),
+			$fileSystem,
+		);
+
+		$this->assertInstanceOf(
+			StreamLogger::class,
+			$factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT),
+		);
+	}
+
+	/**
+	 * A logfile that does not exist yet is valid: createStream() opens it with fopen(..., 'ab'),
+	 * which creates the file.
+	 */
+	public function testCreateLoggerAcceptsNotYetExistingLogfile(): void
+	{
+		$logfile = dirname(__DIR__, 1) . '/not-existing-logfile.txt';
+
+		$config = $this->createStub(IManageConfigValues::class);
+		$config->method('get')->willReturnMap([
+			['system', 'logfile', null, $logfile],
+		]);
+
+		$fileSystem = $this->createMock(FileSystemUtil::class);
+		$fileSystem->expects($this->once())
+			->method('createStream')
+			->with($logfile)
+			->willReturn(fopen('php://memory', 'ab'));
+
+		$factory = new StreamLoggerFactory(
+			$config,
+			$this->createStub(IHaveCallIntrospections::class),
+			$fileSystem,
+		);
+
+		$this->assertInstanceOf(
+			StreamLogger::class,
+			$factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT),
+		);
+	}
+
+	/**
+	 * Guards the fix against the real FileSystem instead of a test double.
+	 * Both a not yet existing logfile and the write through the created stream are covered.
+	 */
+	public function testCreateLoggerWritesToNotYetExistingLogfileWithRealFileSystem(): void
+	{
+		$logfile = sys_get_temp_dir() . '/friendica-stream-logger-' . uniqid() . '.log';
+
+		$config = $this->createStub(IManageConfigValues::class);
+		$config->method('get')->willReturnMap([
+			['system', 'logfile', null, $logfile],
+		]);
+
+		$factory = new StreamLoggerFactory(
+			$config,
+			$this->createStub(IHaveCallIntrospections::class),
+			new FileSystem(),
+		);
+
+		try {
+			$factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT)->notice('a logged line');
+
+			$this->assertStringContainsString('a logged line', (string) file_get_contents($logfile));
+		} finally {
+			if (file_exists($logfile)) {
+				unlink($logfile);
+			}
+		}
+	}
+
+	public function testCreateLoggerWithUnusableLogfileThrowsException(): void
+	{
+		$config = $this->createStub(IManageConfigValues::class);
+		$config->method('get')->willReturnMap([
+			['system', 'logfile', null, '/this/path/cannot/be/opened.log'],
+		]);
+
+		$fileSystem = $this->createStub(FileSystemUtil::class);
+		$fileSystem->method('createStream')
+			->willThrowException(new LoggerUnusableException('Permission denied'));
+
+		$factory = new StreamLoggerFactory(
+			$config,
+			$this->createStub(IHaveCallIntrospections::class),
+			$fileSystem,
+		);
+
+		$this->expectException(LoggerArgumentException::class);
+		$this->expectExceptionMessage('"/this/path/cannot/be/opened.log" is not a valid logfile.');
+
+		$factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT);
+	}
+
+	public function testCreateLoggerWithEmptyLogfileThrowsException(): void
+	{
+		$config = $this->createStub(IManageConfigValues::class);
+		$config->method('get')->willReturnMap([
+			['system', 'logfile', null, ''],
 		]);
 
 		$factory = new StreamLoggerFactory(
@@ -55,7 +171,7 @@ class StreamLoggerFactoryTest extends TestCase
 		);
 
 		$this->expectException(LoggerArgumentException::class);
-		$this->expectExceptionMessage('tests/Unit/Core/Logger/not-existing-logfile.txt" is not a valid logfile.');
+		$this->expectExceptionMessage('The config value "system.logfile" is empty, there is nothing to log into.');
 
 		$factory->createLogger(LogLevel::DEBUG, LogChannel::DEFAULT);
 	}


### PR DESCRIPTION
`StreamLoggerFactory` checked `system.logfile` with `file_exists()`/`is_writable()` before handing it to `createStream()`, which rejected both `php://stdout` (the php:// wrapper has no `url_stat()` handler) and a logfile that does not exist yet.
Both ended up as a `NullLogger`, so `FRIENDICA_LOGFILE=php://stdout` logged nothing at all ... without any hint why.

The pre-check is gone, `createStream()` now decides whether a target is usable, and the fallback to a `NullLogger` is reported via `error_log()` instead of happening silently.

This is a precondition for https://github.com/friendica/docker/pull/310
And I found this issue while testing ;-)