### PR TITLE
tags.pub: Unsubscribe if deactivated

### DIFF
--- a/src/Protocol/Relay.php
+++ b/src/Protocol/Relay.php
@@ -436,12 +436,11 @@ class Relay
 	 */
 	public static function updateTagRelaySubscriptions()
 	{
-		if (!DI::config()->get('system', 'relay_auto_subscribe_tags')) {
+		$currentTags = DI::config()->get('system', 'relay_auto_subscribe_tags') ? Relay::getSubscribedTags() : [];
+		$oldTags     = json_decode(DI::keyValue()->get('relay_subscribed_tags') ?? '[]', true) ?? [];
+		if (!$currentTags && !$oldTags) {
 			return;
 		}
-
-		$currentTags = Relay::getSubscribedTags();
-		$oldTags     = json_decode(DI::keyValue()->get('relay_subscribed_tags') ?? '[]', true) ?? [];
 
 		// Follow new tags
 		foreach ($currentTags as $tag) {


### PR DESCRIPTION
This PR ensures that all tag subscription are unsubscribed when the synchronization with tags.pub is deactivated and had been activated prior.