### PR TITLE
Keep query parameters intact when stripping tracking params

### DIFF
--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -354,7 +354,9 @@ class Network
 					$pair = $param . '=' . $value;
 					$url  = str_replace($pair, '', $url);
 
-					$url = str_replace(['?&', '&&'], ['?', ''], $url);
+					// Removing a pair leaves the separators of both of its neighbours
+					// behind, so the leftovers are collapsed back into one separator.
+					$url = rtrim(str_replace(['?&', '&&'], ['?', '&'], $url), '&');
 				}
 			}
 

--- a/tests/Unit/Util/NetworkTest.php
+++ b/tests/Unit/Util/NetworkTest.php
@@ -1,0 +1,65 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Friendica\Test\Unit\Util;
+
+use Friendica\Util\Network;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class NetworkTest extends TestCase
+{
+	public static function provideStripTrackingQueryParamsTestData(): array
+	{
+		return [
+			'tracking parameter between two kept parameters' => [
+				'url'    => 'https://example.com/article?id=1&utm_source=newsletter&page=2',
+				'expect' => 'https://example.com/article?id=1&page=2',
+			],
+			'tracking parameter last' => [
+				'url'    => 'https://example.com/article?id=1&utm_source=newsletter',
+				'expect' => 'https://example.com/article?id=1',
+			],
+			'tracking parameter first' => [
+				'url'    => 'https://example.com/article?utm_source=newsletter&page=2',
+				'expect' => 'https://example.com/article?page=2',
+			],
+			'only a tracking parameter' => [
+				'url'    => 'https://example.com/article?utm_source=newsletter',
+				'expect' => 'https://example.com/article',
+			],
+			'two adjacent tracking parameters' => [
+				'url'    => 'https://example.com/article?id=1&utm_source=newsletter&utm_medium=mail&page=2',
+				'expect' => 'https://example.com/article?id=1&page=2',
+			],
+			'non utm tracking parameter' => [
+				'url'    => 'https://example.com/article?id=1&fb_ref=abc&page=2',
+				'expect' => 'https://example.com/article?id=1&page=2',
+			],
+			'url without tracking parameters is untouched' => [
+				'url'    => 'https://example.com/article?id=1&page=2',
+				'expect' => 'https://example.com/article?id=1&page=2',
+			],
+			'url without query string is untouched' => [
+				'url'    => 'https://example.com/article',
+				'expect' => 'https://example.com/article',
+			],
+		];
+	}
+
+	/**
+	 * The returned URL is fetched by the HTTP client and stored as the link of a
+	 * post, so removing a parameter must not change the remaining ones.
+	 */
+	#[DataProvider('provideStripTrackingQueryParamsTestData')]
+	public function testStripTrackingQueryParams(string $url, string $expect): void
+	{
+		self::assertSame($expect, Network::stripTrackingQueryParams($url));
+	}
+}


### PR DESCRIPTION
`Network::stripTrackingQueryParams()` deletes the `param=value` substring and then cleans up the separators it left behind with `str_replace(['?&', '&&'], ['?', ''], $url)` (src/Util/Network.php:357). Mapping `&&` to an empty string joins the two neighbouring parameters instead of separating them:

    https://example.com/a?id=1&utm_source=news&page=2  ->  https://example.com/a?id=1page=2

A tracking parameter in last position also leaves a dangling separator (`?id=1&`). Two adjacent tracking parameters happen to come out right, which is probably why this survived.

That return value is the URL that gets fetched and stored: `ParseUrl::getSiteinfo()` (src/Util/ParseUrl.php:212) and `HttpClient::finalUrl()` (src/Network/HTTPClient/Client/HttpClient.php:245).

Fix maps `&&` back to `&` and drops a trailing `&`. Both only run inside the loop body that removed a pair, so URLs without tracking parameters are byte-identical to before.

Measured on PHP 8.5.9: `composer run test:unit` 640 tests / 1649 assertions before, 648 / 1657 after, both green (the one pre-existing UriGenerator deprecation is unchanged). Reverting only the source change fails 3 of the 8 new cases; fixing only `&&` -> `&` still fails the trailing-separator case. php-cs-fixer, PHPStan and PHPMD are clean.

Not tested: the legacy, functional and integration suites need MariaDB, which I could not run locally. Also untouched and still wrong: a tracking pair immediately before a `#fragment` leaves its separator, and the substring replacement can still match text inside another parameter's value.

Written with AI assistance (Claude).
