### PR TITLE
Fix console errors and warnings

### DIFF
--- a/src/Content/Post/Repository/PostMedia.php
+++ b/src/Content/Post/Repository/PostMedia.php
@@ -543,8 +543,10 @@ class PostMedia extends BaseRepository
 			}
 			$media = Renderer::replaceMacros(Renderer::getMarkupTemplate($template), [
 				'$video' => [
-					'id'          => $postMedia->id,
-					'src'         => (string) $postMedia->url,
+					'id'  => $postMedia->id,
+					'src' => $postMedia->type == PostMediaEntity::TYPE_HLS
+						? Post\Media::resolvePlaylistUrl((string) $postMedia->url)
+						: (string) $postMedia->url,
 					'name'        => $postMedia->name ?: $postMedia->url,
 					'preview'     => $preview_url,
 					'mime'        => (string) $postMedia->mimetype,

--- a/src/Model/Post/Media.php
+++ b/src/Model/Post/Media.php
@@ -11,6 +11,7 @@ use FFMpeg\FFMpeg;
 use Friendica\Content\PageInfo;
 use Friendica\Content\Post\Entity\PostMedia;
 use Friendica\Content\Text\BBCode;
+use Friendica\Core\Cache\Enum\Duration;
 use Friendica\Core\Protocol;
 use Friendica\Core\System;
 use Friendica\Database\Database;
@@ -897,6 +898,38 @@ class Media
 		DI::logger()->debug('Detected HLS resolutions', ['uri-id' => $media['uri-id'], 'url' => $media['url'], 'resolution' => $resolution]);
 
 		return $media;
+	}
+
+	/**
+	 * Resolve an HLS playlist URL to the address the browser finally ends up on
+	 *
+	 * Some sites hand out a permalink that only redirects
+	 * to a CDN. A browser following that redirect fails CORS on the intermediate
+	 * response, so hls.js has to be pointed at the resolved URL directly. The
+	 * redirect target may change over time, hence this runs at render time and is
+	 * only cached for a short while.
+	 *
+	 * @param string $url Playlist URL as stored with the media
+	 * @return string Resolved URL, or the input when it can't be resolved
+	 */
+	public static function resolvePlaylistUrl(string $url): string
+	{
+		$cacheKey = 'hls-playlist-url:' . $url;
+
+		$resolved = DI::cache()->get($cacheKey);
+		if (!is_null($resolved)) {
+			return $resolved;
+		}
+
+		$curlResult = DI::httpClient()->get($url, HttpClientAccept::HLS, [HttpClientOptions::REQUEST => HttpClientRequest::MEDIAVERIFIER]);
+
+		$resolved = ($curlResult->isSuccess() && $curlResult->isRedirectUrl() && $curlResult->getRedirectUrl() !== '')
+			? $curlResult->getRedirectUrl()
+			: $url;
+
+		DI::cache()->set($cacheKey, $resolved, Duration::QUARTER_HOUR);
+
+		return $resolved;
 	}
 
 	/**

--- a/tests/src/Content/Text/BBCodeTest.php
+++ b/tests/src/Content/Text/BBCodeTest.php
@@ -740,7 +740,7 @@ Lucas: For the right price, yes.[/share]',
 	{
 		return [
 			'player-rich' => [
-				'expected' => 'text <div class="type-link"><iframe class="embed" src="http://domain.tld/player" style="" height="480px" width="620px" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts allow-popups"></iframe>' . "\n</div>",
+				'expected' => 'text <div class="type-link"><iframe class="embed" src="http://domain.tld/player" style="" height="480px" width="620px" scrolling="no" frameborder="0" allow="fullscreen; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>' . "\n</div>",
 				'data'     => [
 					'author_name'   => 'author_name',
 					'author_url'    => 'http://domain.tld/author_url',
@@ -760,7 +760,7 @@ Lucas: For the right price, yes.[/share]',
 				],
 			],
 			'embed-rich' => [
-				'expected' => 'text <div class="type-link"><iframe class="embed" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;style&gt;html,body{margin:0;padding:0;height:100%;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;iframe src=&quot;http://domain.tld/player&quot;&gt;&lt;/iframe&gt;&lt;/body&gt;&lt;/html&gt;" style="" height="480px" width="620px" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-scripts allow-popups"></iframe>' . "\n</div>",
+				'expected' => 'text <div class="type-link"><iframe class="embed" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;style&gt;html,body{margin:0;padding:0;height:100%;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;iframe src=&quot;http://domain.tld/player&quot;&gt;&lt;/iframe&gt;&lt;/body&gt;&lt;/html&gt;" style="" height="480px" width="620px" scrolling="no" frameborder="0" allow="fullscreen; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" sandbox="allow-scripts allow-popups"></iframe>' . "\n</div>",
 				'data'     => [
 					'author_name'   => 'author_name',
 					'author_url'    => 'http://domain.tld/author_url',
@@ -781,7 +781,7 @@ Lucas: For the right price, yes.[/share]',
 				],
 			],
 			'player-video' => [
-				'expected' => 'text <div class="type-link"><iframe class="embed" src="http://domain.tld/player" style="aspect-ratio:620/480;" height="" width="100%" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts allow-popups"></iframe>' . "\n</div>",
+				'expected' => 'text <div class="type-link"><iframe class="embed" src="http://domain.tld/player" style="aspect-ratio:620/480;" height="" width="100%" scrolling="no" frameborder="0" allow="fullscreen; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>' . "\n</div>",
 				'data'     => [
 					'author_name'   => 'author_name',
 					'author_url'    => 'http://domain.tld/author_url',
@@ -801,7 +801,7 @@ Lucas: For the right price, yes.[/share]',
 				],
 			],
 			'embed-video' => [
-				'expected' => 'text <div class="type-link"><iframe class="embed" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;style&gt;html,body{margin:0;padding:0;height:100%;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;iframe src=&quot;http://domain.tld/player&quot;&gt;&lt;/iframe&gt;&lt;/body&gt;&lt;/html&gt;" style="aspect-ratio:620/480;" height="" width="100%" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-scripts allow-popups"></iframe>' . "\n</div>",
+				'expected' => 'text <div class="type-link"><iframe class="embed" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;style&gt;html,body{margin:0;padding:0;height:100%;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;iframe src=&quot;http://domain.tld/player&quot;&gt;&lt;/iframe&gt;&lt;/body&gt;&lt;/html&gt;" style="aspect-ratio:620/480;" height="" width="100%" scrolling="no" frameborder="0" allow="fullscreen; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" sandbox="allow-scripts allow-popups"></iframe>' . "\n</div>",
 				'data'     => [
 					'author_name'   => 'author_name',
 					'author_url'    => 'http://domain.tld/author_url',

--- a/view/templates/content/embed-iframe-resize.tpl
+++ b/view/templates/content/embed-iframe-resize.tpl
@@ -10,7 +10,7 @@
       parent.postMessage({type:'resize-{{$id}}',height:document.body.scrollHeight},'*');
       setTimeout(function() {parent.postMessage({type:'resize-{{$id}}',height:document.body.scrollHeight},'*');}, 2000);
   };
-  &lt;/script&gt;&lt;/body&gt;&lt;/html&gt;" width="{{$width}}" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-scripts allow-popups"></iframe>
+  &lt;/script&gt;&lt;/body&gt;&lt;/html&gt;" width="{{$width}}" scrolling="no" frameborder="0" allow="fullscreen; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" sandbox="allow-scripts allow-popups"></iframe>
   <script>
     window.addEventListener('message', function(event) {
       if (event.data && event.data.type === 'resize-{{$id}}') {

--- a/view/templates/content/embed-iframe.tpl
+++ b/view/templates/content/embed-iframe.tpl
@@ -4,4 +4,4 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<iframe class="embed" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;style&gt;html,body{margin:0;padding:0;height:100%;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;{{$src}}&lt;/body&gt;&lt;/html&gt;" style="{{$iframe_style}}" height="{{$height}}" width="{{$width}}" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-scripts allow-popups"></iframe>
+<iframe class="embed" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;style&gt;html,body{margin:0;padding:0;height:100%;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;{{$src}}&lt;/body&gt;&lt;/html&gt;" style="{{$iframe_style}}" height="{{$height}}" width="{{$width}}" scrolling="no" frameborder="0" allow="fullscreen; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" sandbox="allow-scripts allow-popups"></iframe>

--- a/view/templates/content/hls.tpl
+++ b/view/templates/content/hls.tpl
@@ -5,30 +5,53 @@
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
 <div class="video-top-wrapper lframe" id="video-top-wrapper-{{$video.id}}" style="{{$video.style}}">
-	<script src="view/js/hls/hls.min.js"></script>
 	<video id="{{$video.id}}" controls {{if $video.preview}}preload="none" poster="{{$video.preview}}" {{else}}preload="metadata" {{/if}} width="{{$video.width}}" height="{{$video.height}}" title="{{$video.description}}" type="{{$video.mime}}">
 		<a href="{{$video.src}}">{{$video.name}}</a>
 	</video>
 	<script>
-		var video = document.getElementById('{{$video.id}}');
-		var videoSrc = '{{$video.src}}';
-		if (Hls.isSupported()) {
-			var hls = new Hls();
-			hls.loadSource(videoSrc);
-			hls.attachMedia(video);
-			hls.on(Hls.Events.ERROR, function (event, data) {
-				var errorType = data.type;
-				var errorDetails = data.details;
-				var errorFatal = data.fatal;
-				console.error('HLS.js error:', errorType, errorDetails, 'Fatal:', errorFatal);
-				if (errorFatal) {
-					document.getElementById('video-top-wrapper-{{$video.id}}').style.display = 'none';
+		(function () {
+			var video = document.getElementById('{{$video.id}}');
+			var videoSrc = '{{$video.src}}';
+
+			function hide() {
+				document.getElementById('video-top-wrapper-{{$video.id}}').style.display = 'none';
+			}
+
+			function play() {
+				if (Hls.isSupported()) {
+					var hls = new Hls();
+					hls.loadSource(videoSrc);
+					hls.attachMedia(video);
+					hls.on(Hls.Events.ERROR, function (event, data) {
+						// hls.js recovers from non-fatal errors itself (buffer holes, stalls).
+						if (data.fatal) {
+							console.warn('HLS.js fatal error:', data.type, data.details);
+							hide();
+						}
+					});
+				} else if (video.canPlayType('{{$video.mime}}')) {
+					video.src = videoSrc;
+				} else {
+					hide();
 				}
-			});
-		} else if (video.canPlayType('{{$video.mime}}')) {
-			video.src = videoSrc;
-		} else {
-			document.getElementById('video-top-wrapper-{{$video.id}}').style.display = 'none';
-		}
+			}
+
+			// The library is loaded on demand and shared between all players on the page
+			if (window.Hls) {
+				play();
+			} else if (window.hlsLoading) {
+				window.hlsLoading.push(play);
+			} else {
+				window.hlsLoading = [play];
+				var script = document.createElement('script');
+				script.src = 'view/js/hls/hls.min.js';
+				script.onload = function () {
+					window.hlsLoading.forEach(function (cb) { cb(); });
+					window.hlsLoading = null;
+				};
+				script.onerror = hide;
+				document.head.appendChild(script);
+			}
+		})();
 	</script>
 </div>

--- a/view/templates/content/iframe.tpl
+++ b/view/templates/content/iframe.tpl
@@ -4,4 +4,4 @@
   *
   * SPDX-License-Identifier: AGPL-3.0-or-later
   *}}
-<iframe class="embed" src="{{$src}}" style="{{$iframe_style}}" height="{{$height}}" width="{{$width}}" scrolling="no" frameborder="0" allow="fullscreen, picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen sandbox="allow-same-origin allow-scripts allow-popups"></iframe>
+<iframe class="embed" src="{{$src}}" style="{{$iframe_style}}" height="{{$height}}" width="{{$width}}" scrolling="no" frameborder="0" allow="fullscreen; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>

--- a/view/templates/head.tpl
+++ b/view/templates/head.tpl
@@ -22,6 +22,7 @@
 <link rel="icon" href="{{$shortcut_icon}}" />
 <link rel="apple-touch-icon" href="{{$touch_icon}}"/>
 
+<meta name="mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <link rel="manifest" href="{{$baseurl}}/manifest" />
 <script>

--- a/view/theme/frio/templates/head.tpl
+++ b/view/theme/frio/templates/head.tpl
@@ -71,6 +71,7 @@
 <link rel="icon" href="{{$shortcut_icon}}" />
 <link rel="apple-touch-icon" href="{{$touch_icon}}" />
 
+<meta name="mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <link rel="manifest" href="{{$baseurl}}/friendica.webmanifest">
 


### PR DESCRIPTION
This PR fixes some different errors and warnings in the browser console. Most important is fixing the CORS problems with HLS video. Some content providers offer a link that then redirects the traffic to a CDN like Akamai. This redirection triggers an error in the browser console and prohibits the video from being loaded.
