### PR TITLE
vier: check isTablet in the mobile head conditions

### DIFF
--- a/view/theme/vier/theme.php
+++ b/view/theme/vier/theme.php
@@ -45,7 +45,7 @@ function vier_init(): void
 		DI::page()['htmlhead'] .= "<link rel='stylesheet' type='text/css' href='view/theme/vier/wide.css' media='screen and (min-width: 1300px)'/>\n";
 	}
 
-	if (DI::mode()->isMobile() || DI::mode()->isMobile()) {
+	if (DI::mode()->isMobile() || DI::mode()->isTablet()) {
 		DI::page()['htmlhead'] .= '<meta name=viewport content="width=device-width, initial-scale=1">' . "\n";
 		DI::page()['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="view/theme/vier/mobile.css" media="screen"/>' . "\n";
 	}
@@ -73,7 +73,7 @@ function cmtBbClose(id) {
 </script>
 EOT;
 
-	if (DI::mode()->isMobile() || DI::mode()->isMobile()) {
+	if (DI::mode()->isMobile() || DI::mode()->isTablet()) {
 		DI::page()['htmlhead'] .= <<< EOT
 <script>
 	window.onDocumentReady('body', function() {


### PR DESCRIPTION
`vier_init()` gates the mobile stylesheet and the mobile aside/tabs script behind `DI::mode()->isMobile() || DI::mode()->isMobile()`, twice, so the second half of each condition never adds anything and a tablet gets neither.

`AppLegacy` already decides to serve the mobile view with `($this->mode->isMobile() || $this->mode->isTablet())`, so on a tablet the theme is asked for mobile output while `vier` still emits the desktop head. That is what made the intended second operand obvious rather than a guess.

The two conditions are identical, so both get the same change.
