### PR TITLE
Fix layout issue for long URLs in oauth settings

### DIFF
--- a/view/templates/settings/oauth.tpl
+++ b/view/templates/settings/oauth.tpl
@@ -24,7 +24,7 @@
 					{{foreach $apps as $app}}
 					<tr>
 						<td>{{$app.name}}</td>
-						<td>{{$app.website}}</td>
+						<td style="word-break: break-all;">{{$app.website}}</td>
 						<td>{{$app.created_at}}</td>
 						<td>
 							<button type="submit" class="btn" title="{{$delete}}" name="delete" value="{{$app.id}}">

--- a/view/theme/frio/templates/settings/oauth.tpl
+++ b/view/theme/frio/templates/settings/oauth.tpl
@@ -26,7 +26,7 @@
 					{{foreach $apps as $app}}
 					<tr>
 						<td>{{$app.name}}</td>
-						<td>{{$app.website}}</td>
+						<td style="word-break: break-all;">{{$app.website}}</td>
 						<td>{{$app.created_at}}</td>
 						<td>
 							<button type="submit" class="btn" title="{{$delete}}" name="delete" value="{{$app.id}}">


### PR DESCRIPTION
I noticed that the layout on the `settings/oauth` page can break if a connected app has a very long website URL. The table column stretches and pushes other elements out of alignment. 

This PR adds a `word-break: break-all;` style to the website cell in both the base and frio templates so that long links wrap properly. 

Before:

<img width="1203" height="832" alt="image" src="https://github.com/user-attachments/assets/a69fc743-7ed0-4e07-bfe6-194420542cf2" />

After:

<img width="1194" height="834" alt="image" src="https://github.com/user-attachments/assets/2e4652bf-d36f-4768-9a3c-d291e526052c" />
