### PR TITLE
Fix: Checkbox alignment in Frio wall items (Fixes #16144)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2450,7 +2450,7 @@ button[disabled] {
 	line-height: 40px;		/* align with icons */
 }
 .wall-item-actions .checkbox label::after {
-	line-height: 1;
+	line-height: 16px;
 }
 @media screen and (max-width: 767px) {
 	.wall-item-actions .btn,

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -2449,6 +2449,9 @@ button[disabled] {
 	margin: 0 0 0 15px;
 	line-height: 40px;		/* align with icons */
 }
+.wall-item-actions .checkbox label::after {
+	line-height: 1;
+}
 @media screen and (max-width: 767px) {
 	.wall-item-actions .btn,
 	.wall-item-actions a,


### PR DESCRIPTION
Sets line-height: 16px; on the checkmark icon in Frio's wall items.
This prevents it from inheriting the container's 40px line-height, which previously pushed the checkmark downwards out of its box.

Before:

<img width="647" height="162" alt="image" src="https://github.com/user-attachments/assets/6e58c4bf-6947-43ce-917c-674c8abf5038" />


After:

<img width="636" height="164" alt="image" src="https://github.com/user-attachments/assets/66ac0dce-ac26-4a27-bd1c-dad3d86f5a11" />


fixes #16144 