### PR TITLE
Keep position when new content is added above

### DIFF
--- a/view/js/main.js
+++ b/view/js/main.js
@@ -760,6 +760,7 @@ function NavUpdate() {
 				}
 			});
 	}
+	clearTimeout(timer);
 	timer = setTimeout(NavUpdate, 30000);
 }
 
@@ -866,7 +867,7 @@ function liveUpdate(src, force, guid) {
 
 	in_progress = true;
 
-	var orgHeight = $("section").height();
+	var orgHeight = $(document).height();
 
 	var update_url = getUpdateUrl(src);
 
@@ -893,6 +894,10 @@ function liveUpdate(src, force, guid) {
 				// Update the scroll position.
 				if (guid) {
 					scrollToItem("item-" + guid);
+				} else if (!force) {
+					// Keep the current reading position when new items are inserted above it.
+					var delta = $(document).height() - orgHeight;
+					$('html, body').animate({scrollTop: $(window).scrollTop() + delta}, 200);
 				}
 			})
 		})


### PR DESCRIPTION
When new content is added above, there had been the bug that the watched post moved below, so that you had to scroll to see it again.