### PR TITLE
Frio: Fix user nav delegation icon switching

### DIFF
--- a/src/Content/Nav.php
+++ b/src/Content/Nav.php
@@ -286,10 +286,10 @@ class Nav
 			$nav_accounts_description = $this->l10n->t('Manage other accounts, including groups and pages');
 			if (User::hasIdentities($this->session->getSubManagedUserId() ?: $this->session->getLocalUserId())) {
 				$nav_accounts_name = $this->l10n->t('Switch Accounts');
-				$nav['delegation'] = ['delegation', $nav_accounts_name, '', $nav_accounts_description];
+				$nav['delegation'] = ['delegation', $nav_accounts_name, '', $nav_accounts_description, 'switch'];
 			} else {
 				$nav_accounts_name = $this->l10n->t('Add Account');
-				$nav['delegation'] = ['settings/delegation', $nav_accounts_name, '', $nav_accounts_description];
+				$nav['delegation'] = ['settings/delegation', $nav_accounts_name, '', $nav_accounts_description, 'add'];
 			}
 
 			$nav['settings'] = ['settings', $this->l10n->t('Settings'), '', $this->l10n->t('Account settings')];

--- a/view/theme/frio/templates/nav.tpl
+++ b/view/theme/frio/templates/nav.tpl
@@ -215,7 +215,7 @@
 											<a role="menuitem" id="nav-delegation-link" up-follow="false"
 												class="nav-commlink {{$nav.delegation.2}} {{$sel.delegation}}"
 												href="{{$nav.delegation.0}}" title="{{$nav.delegation.3}}">
-												{{if $nav.delegation.2}}
+												{{if $nav.delegation.4 == "add" }}
 												<i class="ri ri-user-add-line ri-fw" aria-hidden="true"></i>
 												{{else}}
 												<i class="ri ri-arrow-left-right-line ri-fw" aria-hidden="true"></i>{{/if}} {{$nav.delegation.1}}


### PR DESCRIPTION
Not sure when this happened, but the text was updating based on there being existing delegations or not, but no longer the icon.

# Before

<img width="372" height="601" alt="image" src="https://github.com/user-attachments/assets/37da3cfa-a288-4fc5-bc22-9e0fcdd03dc1" />

# After

<img width="372" height="601" alt="image" src="https://github.com/user-attachments/assets/5e6b28e2-2fde-4346-a638-d48b0da677cc" />