### PR TITLE
Frio: Small adjustment to the notification badge spacing

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -844,7 +844,7 @@ nav.navbar .nav > li > button:focus {
 #topbar-first .nav-segment .icon-badge-container .badge {
 	position: absolute;
 	top: -8px;
-	right: -19px;
+	left: 23px;
 	background-color: #ff3535;
 }
 #topbar-first #intro-update {


### PR DESCRIPTION
While #16166 works fine for single digit counters, it does not, if the number is double digits, and especially beyond, becoming `99+`.
This PR makes it work better for "99+", by bounding it to the left instead of the right, so it expands to the right.