### PR TITLE
Configure outbound security settings via env and console

### DIFF
--- a/doc/en/admin/config.md
+++ b/doc/en/admin/config.md
@@ -319,14 +319,20 @@ If you want to have a more personalized closing line for the notification emails
 
 Friendica rejects outbound requests to non-public IP addresses, including redirect targets.
 The node's own base URL is exempt.
-To allow other internal services, list their hostnames:
+To allow other internal services, list their hostnames as a comma-separated string.
+Wildcards are allowed.
 
     'system' => [
-        'allowed_internal_hosts' => ['media-proxy.internal', '*.svc.cluster.local'],
+        'allowed_internal_hosts' => 'media-proxy.internal, *.svc.cluster.local',
     ]
+
+The same value can be set from the environment (`FRIENDICA_ALLOWED_INTERNAL_HOSTS`)
+or the console (`bin/console config system allowed_internal_hosts "media-proxy.internal, *.svc.cluster.local"`).
 
 The check can be disabled, but this is not recommended on public nodes:
 
     'system' => [
         'block_private_addresses' => false,
     ]
+
+The environment equivalent is `FRIENDICA_BLOCK_PRIVATE_ADDRESSES` (`true`/`false`/`1`/`0`).

--- a/doc/en/developer/upgrade-2026.08.md
+++ b/doc/en/developer/upgrade-2026.08.md
@@ -17,7 +17,7 @@ This section contains backward compatibility breaks, make sure your code is comp
 - Outbound requests to non-public IP addresses are blocked by default.
 
    This can affect internal feed servers, mail servers, media proxies and other services using private network addresses.
-   Add required hostnames to `system.allowed_internal_hosts`.
+   Add required hostnames to `system.allowed_internal_hosts` as a comma-separated string.
    The protection can be disabled with `system.block_private_addresses`, but this is not recommended on public nodes.
 
 - The web server has to serve `.mjs` files as JavaScript.

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -256,6 +256,7 @@ class Network
 	public static function isPrivateTarget(UriInterface $uri): bool
 	{
 		// Coerce here because environment variables always arrive as strings ("false" would otherwise be truthy)
+		// @todo Replace this check with a proper sanitation functionality (must work for env variables, config-files and database entries)
 		if (!filter_var(DI::config()->get('system', 'block_private_addresses', true), FILTER_VALIDATE_BOOLEAN)) {
 			return false;
 		}

--- a/src/Util/Network.php
+++ b/src/Util/Network.php
@@ -255,7 +255,8 @@ class Network
 	/** Checks whether an outbound request targets a non-public address. */
 	public static function isPrivateTarget(UriInterface $uri): bool
 	{
-		if (!DI::config()->get('system', 'block_private_addresses', true)) {
+		// Coerce here because environment variables always arrive as strings ("false" would otherwise be truthy)
+		if (!filter_var(DI::config()->get('system', 'block_private_addresses', true), FILTER_VALIDATE_BOOLEAN)) {
 			return false;
 		}
 
@@ -268,15 +269,30 @@ class Network
 			return false;
 		}
 
-		foreach (DI::config()->get('system', 'allowed_internal_hosts', []) as $allowed) {
-			if (!empty($allowed) && fnmatch(strtolower((string) $allowed), strtolower($host))) {
-				return false;
-			}
+		if (self::isAllowedInternalHost($host, (string) DI::config()->get('system', 'allowed_internal_hosts', ''))) {
+			return false;
 		}
 
 		foreach (self::resolveHost($host) as $address) {
 			if (IpAddress::isNonPublic($address)) {
 				DI::logger()->info('Target is not on the public internet.', ['host' => $host, 'address' => $address]);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether $host matches an entry of the comma-separated $allowedList.
+	 *
+	 * Entries may use fnmatch() wildcards. Matching is case-insensitive.
+	 */
+	public static function isAllowedInternalHost(string $host, string $allowedList): bool
+	{
+		foreach (explode(',', $allowedList) as $allowed) {
+			$allowed = trim($allowed);
+			if ($allowed !== '' && fnmatch(strtolower($allowed), strtolower($host))) {
 				return true;
 			}
 		}

--- a/static/defaults.config.php
+++ b/static/defaults.config.php
@@ -91,10 +91,10 @@ return [
 		// Days of inactivity after which an admin is considered inactive. "0" means that there will be no check for inactivity.
 		'admin_inactivity_limit' => 30,
 
-		// allowed_internal_hosts (Array)
-		// Internal hosts that server-side requests may reach. Wildcards are allowed.
+		// allowed_internal_hosts (String)
+		// Comma-separated list of internal hosts that server-side requests may reach. Wildcards are allowed.
 		// See block_private_addresses.
-		'allowed_internal_hosts' => [],
+		'allowed_internal_hosts' => '',
 
 		// allowed_link_protocols (Array)
 		// Allowed protocols in links URLs, add at your own risk. http(s) is always allowed.

--- a/static/env.config.php
+++ b/static/env.config.php
@@ -53,4 +53,8 @@ return [
 	// Proxy Config
 	'FRIENDICA_FORWARDED_HEADERS' => ['proxy', 'forwarded_for_headers'],
 	'FRIENDICA_TRUSTED_PROXIES'   => ['proxy', 'trusted_proxies'],
+
+	// Outbound security
+	'FRIENDICA_BLOCK_PRIVATE_ADDRESSES' => ['system', 'block_private_addresses'],
+	'FRIENDICA_ALLOWED_INTERNAL_HOSTS'  => ['system', 'allowed_internal_hosts'],
 ];

--- a/tests/Unit/Util/NetworkTest.php
+++ b/tests/Unit/Util/NetworkTest.php
@@ -95,4 +95,44 @@ class NetworkTest extends TestCase
 	{
 		self::assertSame($expect, Network::stripTrackingQueryParams($url));
 	}
+
+	/**
+	 * @return array<string, array{0: bool, 1: string, 2: string}>
+	 */
+	public static function dataAllowedInternalHost(): array
+	{
+		return [
+			// no address configured
+			'empty list'             => [false, 'internal.example', ''],
+			'blank entries only'     => [false, 'internal.example', ' , , '],
+			'empty host, empty list' => [false, '', ''],
+
+			// one address
+			'single exact match'        => [true, 'internal.example', 'internal.example'],
+			'single case insensitive'   => [true, 'Internal.Example', 'internal.example'],
+			'single no match'           => [false, 'evil.example', 'internal.example'],
+			'single padded with spaces' => [true, 'internal.example', '   internal.example   '],
+			'single wildcard match'     => [true, 'foo.internal.example', '*.internal.example'],
+			'single wildcard no match'  => [false, 'internal.example.org', '*.internal.example'],
+
+			// two addresses
+			'two, first matches'         => [true, 'a.example', 'a.example, b.example'],
+			'two, second matches'        => [true, 'b.example', 'a.example, b.example'],
+			'two, none matches'          => [false, 'c.example', 'a.example, b.example'],
+			'two, no spaces after comma' => [true, 'b.example', 'a.example,b.example'],
+
+			// three / four addresses
+			'four, middle matches'      => [true, 'c.example', 'a.example, b.example, c.example, d.example'],
+			'four, last matches'        => [true, 'd.example', 'a.example, b.example, c.example, d.example'],
+			'four, none matches'        => [false, 'x.example', 'a.example, b.example, c.example, d.example'],
+			'four, wildcard entry hits' => [true, 'db.internal', 'a.example, *.internal, c.example, d.example'],
+			'four, extra commas'        => [true, 'c.example', 'a.example,, b.example , ,c.example,d.example'],
+		];
+	}
+
+	#[DataProvider('dataAllowedInternalHost')]
+	public function testIsAllowedInternalHost(bool $expected, string $host, string $allowedList): void
+	{
+		self::assertSame($expected, Network::isAllowedInternalHost($host, $allowedList));
+	}
 }

--- a/tests/src/Network/HTTPClient/Client/HTTPClientTest.php
+++ b/tests/src/Network/HTTPClient/Client/HTTPClientTest.php
@@ -133,7 +133,7 @@ class HTTPClientTest extends MockedTestCase
 
 	public function testAllowedInternalHostIsRequested(): void
 	{
-		DI::config()->set('system', 'allowed_internal_hosts', ['127.0.0.1']);
+		DI::config()->set('system', 'allowed_internal_hosts', '127.0.0.1');
 
 		$this->httpRequestHandler->setHandler(new MockHandler([new Response(200, [], 'hello')]));
 


### PR DESCRIPTION
The new outbound request protection (`block_private_addresses`, `allowed_internal_hosts`) could only be set by editing `local.config.php`, which doesn't work for container deployments.

Changes:

1. Adds the `FRIENDICA_BLOCK_PRIVATE_ADDRESSES` and `FRIENDICA_ALLOWED_INTERNAL_HOSTS` environment variables and makes both keys settable through `bin/console config`.
2. Since env and console only carry scalar strings, `allowed_internal_hosts` is now a comma-separated string (split at the use site, same as `proxy.trusted_proxies`) and `block_private_addresses` runs through `filter_var` so the string `"false"` is no longer truthy.
3. Covered by unit tests for the host matching against zero, one, two and multiple entries including wildcards.
