### PR TITLE
Frio: Fix search mobile button styling

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -793,7 +793,9 @@ nav.navbar .nav > li > button {
 nav.navbar .nav > li > a:hover,
 nav.navbar .nav > li > a:focus,
 nav.navbar .nav > li > button:hover,
-nav.navbar .nav > li > button:focus {
+nav.navbar .nav > li > button:focus,
+#search-mobile-btn:hover,
+#search-mobile-btn:focus {
 	background-color: $nav_icon_hover_color;
 	border-radius: 10px;
 }
@@ -826,7 +828,8 @@ nav.navbar .nav > li > button:focus {
 }
 /* End workaround */
 #topbar-first .topbar-nav .nav-segment > a,
-#topbar-first .topbar-actions .nav-segment > a {
+#topbar-first .topbar-actions .nav-segment > a,
+#search-mobile-btn {
 	display: inline-block;
 	text-decoration: none;
 	text-align: center;
@@ -1251,9 +1254,7 @@ ul li .intro-wrapper button.intro-action-link {
 #fc-header .dropdown-menu li button:focus,
 .contact-photo-wrapper .dropdown-menu li.selected a,
 #offcanvasUsermenu a:hover,
-#offcanvasUsermenu a:focus,
-#search-mobile-btn:hover,
-#search-mobile-btn:focus {
+#offcanvasUsermenu a:focus {
 	color: #fff;
 	background: $nav_icon_hover_color;
 }


### PR DESCRIPTION
The search mobile button was too tall and didn't get the rounded corner hover/focus-styling the rest of the menu has.

# Before

<img width="69" height="70" alt="image" src="https://github.com/user-attachments/assets/aa61ad54-159d-440d-8b16-278824d956f7" />

# After

<img width="71" height="64" alt="image" src="https://github.com/user-attachments/assets/f9b6be15-b4c6-450b-ad44-62c63856720e" />