### PR TITLE
Frio profile alignment

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -1459,9 +1459,6 @@ aside .vcard .title {
 	margin-top: 10px;
 	text-align: left;
 }
-aside .xmpp, aside .matrix {
-	display: table;
-}
 aside .member-since {
 	padding-top: 5px;
 }


### PR DESCRIPTION
Closes #16193

# After

<img width="283" height="703" alt="image" src="https://github.com/user-attachments/assets/c11971a7-d551-4fe0-a36b-85d12fadc3c2" />