### PR TITLE
fix for collapsed image in masonry preview

### DIFF
--- a/view/global.css
+++ b/view/global.css
@@ -766,6 +766,9 @@ figure.img-allocated-height img{
 	column-gap: 5px;
 	margin-top: 5px;
 }
+.masonry-row figure a {
+	display: block !important;
+}
 /**
  * Horizontal masonry settings AND
  **/


### PR DESCRIPTION
The image gallery masonry layout **preview** was not showing the images at all:

<img width="644" height="816" alt="empty_previews" src="https://github.com/user-attachments/assets/dfe125d6-ae77-4494-b577-f5e01fc6a26e" />

I traced this to the `<a>` being set to `display: table;` elsewhere when it needs to be `display: block` for the masonry rows with the images set to `object-fit: contain;` 

On a related note, the masonry preview shows the images in the correct order they were attached to the post. When you publish the post, however, they end up in some other seemingly _random_ order! I have not figured out where the array order is being changed or why, but it's happening long before it ever gets to the masonry function.

The reason the post preview layout isn't affected is it's all being done with jQuery on the frontend, the preview does not use the backend code.