### PR TITLE
Fixed behaviour after having replied to a comment in a expanded thread

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,10 +52,12 @@ const friendicaGlobals = {
 	htmlToText: "readonly",
 	initInfiniteScroll: "readonly", // view/js/main.js
 	insertBBCodeInTextarea: "readonly",
+	insertPostedComment: "readonly", // view/js/main.js
 	jotShow: "readonly",
 	NavUpdate: "readonly",
 	openMenu: "readonly",
 	originalTitle: "writable",
+	refreshItemActivity: "readonly", // view/js/main.js
 	scrollToItem: "readonly",
 	showFetching: "readonly",
 	showPosting: "readonly",

--- a/mod/item.php
+++ b/mod/item.php
@@ -360,6 +360,11 @@ function item_post_return(string $baseurl, string $return_path, array $item = []
 		$json['guid'] = $item['guid'];
 	}
 
+	if (!empty($item) && ($item['gravity'] == Item::GRAVITY_COMMENT) && ($item['thr-parent-id'] != $item['parent-uri-id'])) {
+		$json['comment-uri-id'] = $item['uri-id'];
+		$json['parent-uri-id']  = $item['thr-parent-id'];
+	}
+
 	DI::logger()->debug('post_json', ['json' => $json]);
 
 	System::jsonExit($json);

--- a/mod/item.php
+++ b/mod/item.php
@@ -360,7 +360,7 @@ function item_post_return(string $baseurl, string $return_path, array $item = []
 		$json['guid'] = $item['guid'];
 	}
 
-	if (!empty($item) && ($item['gravity'] == Item::GRAVITY_COMMENT) && ($item['thr-parent-id'] != $item['parent-uri-id'])) {
+	if ($item && ($item['gravity'] === Item::GRAVITY_COMMENT) && ($item['thr-parent-id'] !== $item['parent-uri-id'])) {
 		$json['comment-uri-id'] = $item['uri-id'];
 		$json['parent-uri-id']  = $item['thr-parent-id'];
 	}

--- a/src/Content/Conversation/ConversationDataProvider.php
+++ b/src/Content/Conversation/ConversationDataProvider.php
@@ -94,10 +94,11 @@ final readonly class ConversationDataProvider
 	 * @param string $mode The rendering mode
 	 * @param array $existing Existing comment URI IDs to exclude
 	 * @param bool $pagedrop Whether to enable page drop functionality
+	 * @param bool $smartThreading Whether single-reply chains may be flattened
 	 * @return array<string, mixed>|null The root template data, or null if not found
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	public function getRootTemplateDataFromItem(array $item, int $viewerUid, string $mode = ConversationRenderer::MODE_DISPLAY, array $existing = [], bool $pagedrop = false): ?array
+	public function getRootTemplateDataFromItem(array $item, int $viewerUid, string $mode = ConversationRenderer::MODE_DISPLAY, array $existing = [], bool $pagedrop = false, bool $smartThreading = true): ?array
 	{
 		// Resolve to parent if this is a comment
 		$resolvedItem = $this->fetchParentItem($item, $viewerUid);
@@ -113,7 +114,7 @@ final readonly class ConversationDataProvider
 			$sinceDate = '';
 		}
 
-		$items = $this->populateThreadWithChildren([$resolvedItem], false, ConversationRenderer::ORDER_COMMENTED, $viewerUid, $mode, $sinceId, $sinceDate, $existing, $pagedrop);
+		$items = $this->populateThreadWithChildren([$resolvedItem], false, ConversationRenderer::ORDER_COMMENTED, $viewerUid, $mode, $sinceId, $sinceDate, $existing, $pagedrop, $smartThreading);
 
 		return $this->buildRootTemplateData($items, (int) $resolvedItem['uid'], $viewerUid, $mode, $pagedrop);
 	}
@@ -269,10 +270,11 @@ final readonly class ConversationDataProvider
 	 * @param int $sinceId Only load comments with id > sinceId
 	 * @param array $existing Existing comment URI IDs to exclude
 	 * @param bool $pagedrop Whether to enable page drop functionality
+	 * @param bool $smartThreading Whether single-reply chains may be flattened
 	 * @return array<int, array> The items with children added
 	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
 	 */
-	private function populateThreadWithChildren(array $parents, bool $blockAuthors, string $order, int $uid, string $mode, int $sinceId = 0, string $sinceDate = '', array $existing = [], bool $pagedrop = false): array
+	private function populateThreadWithChildren(array $parents, bool $blockAuthors, string $order, int $uid, string $mode, int $sinceId = 0, string $sinceDate = '', array $existing = [], bool $pagedrop = false, bool $smartThreading = true): array
 	{
 		$userGservers = $this->userGServer->listIgnoredByUser($uid);
 		$ignoredGsids = array_map(static function (UserGServerEntity $userGServer) {
@@ -478,7 +480,7 @@ final readonly class ConversationDataProvider
 			}
 		}
 
-		$items = $this->sortConversationItems($items, $order, $uid, $compactTimeline);
+		$items = $this->sortConversationItems($items, $order, $uid, $compactTimeline, $smartThreading);
 
 		return $items;
 	}
@@ -1083,9 +1085,10 @@ final readonly class ConversationDataProvider
 	 * @param string $order One of ConversationRenderer::ORDER_*
 	 * @param int $uid The user ID of the viewer
 	 * @param bool $compactTimeline Whether the compact conversation view is active
+	 * @param bool $smartThreading Whether single-reply chains may be flattened
 	 * @return array<int, array> The sorted conversation items
 	 */
-	private function sortConversationItems(array $itemList, string $order, int $uid, bool $compactTimeline = false): array
+	private function sortConversationItems(array $itemList, string $order, int $uid, bool $compactTimeline = false, bool $smartThreading = true): array
 	{
 		$parents = [];
 		if (count($itemList) === 0) {
@@ -1129,7 +1132,9 @@ final readonly class ConversationDataProvider
 
 		// The compact view already removed comments from the thread. Smart threading would
 		// then flatten the remaining replies as well, hiding what they are a reply to.
-		if (!$compactTimeline && !$this->pConfig->get($uid, 'system', 'no_smart_threading', 0)) {
+		// A single-subtree re-render (see ConversationRenderer::renderCommentByUriId) also
+		// opts out, so its structure matches the surrounding, unflattened conversation.
+		if ($smartThreading && !$compactTimeline && !$this->pConfig->get($uid, 'system', 'no_smart_threading', 0)) {
 			foreach ($parents as $index => $parent) {
 				$parents[$index] = $this->smartFlattenConversation($parent);
 			}

--- a/src/Content/Conversation/ConversationDataProvider.php
+++ b/src/Content/Conversation/ConversationDataProvider.php
@@ -87,6 +87,22 @@ final readonly class ConversationDataProvider
 	}
 
 	/**
+	 * Load a single conversation item by its URI ID with the field list the
+	 * template builder expects.
+	 *
+	 * @param int $uriId The URI ID of the item
+	 * @param int $viewerUid The user ID of the viewer, or 0 for public view
+	 * @return array|null The item, or null when it isn't visible to the viewer
+	 */
+	public function fetchItemByUriId(int $uriId, int $viewerUid): ?array
+	{
+		$selected = array_merge(ItemModel::DISPLAY_FIELDLIST, ['featured', 'contact-uid', 'gravity', 'post-type', 'post-reason']);
+		$item     = Post::selectFirst($selected, ['uri-id' => $uriId, 'uid' => [0, $viewerUid]], ['order' => ['uid' => true]]);
+
+		return $item ?: null;
+	}
+
+	/**
 	 * Get the root template data for a thread from an existing item array.
 	 *
 	 * @param array $item The item array
@@ -1134,7 +1150,7 @@ final readonly class ConversationDataProvider
 		// then flatten the remaining replies as well, hiding what they are a reply to.
 		// A single-subtree re-render (see ConversationRenderer::renderCommentByUriId) also
 		// opts out, so its structure matches the surrounding, unflattened conversation.
-		if ($smartThreading && !$compactTimeline && !$this->pConfig->get($uid, 'system', 'no_smart_threading', 0)) {
+		if ($smartThreading && !$compactTimeline && !$this->pConfig->get($uid, 'system', 'no_smart_threading', false)) {
 			foreach ($parents as $index => $parent) {
 				$parents[$index] = $this->smartFlattenConversation($parent);
 			}

--- a/src/Content/Conversation/ConversationRenderer.php
+++ b/src/Content/Conversation/ConversationRenderer.php
@@ -156,6 +156,117 @@ final readonly class ConversationRenderer
 	}
 
 	/**
+	 * Render a freshly posted reply together with the subtree of its immediate
+	 * parent comment, so the client can replace that one subtree instead of
+	 * rebuilding the whole thread (which drops loaded and among-strangers
+	 * comments in the compact timeline).
+	 *
+	 * Returns an empty string for anything that should go through the regular
+	 * thread update: a missing item, a non-comment, or a reply to the thread
+	 * starter.
+	 *
+	 * @param int $commentUriId The URI ID of the freshly posted comment
+	 * @param int $uid The user ID of the viewer, or null for public view
+	 * @return string The rendered HTML of the immediate parent's subtree
+	 * @throws ImagickException
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function renderCommentByUriId(int $commentUriId, int $uid): string
+	{
+		$this->profiler->startRecording('rendering');
+		$this->statusEditor->registerAssets();
+
+		$viewerUid = $this->resolveViewerUid($uid);
+
+		$selected = array_merge(ItemModel::DISPLAY_FIELDLIST, ['featured', 'contact-uid', 'gravity', 'post-type', 'post-reason']);
+		$comment  = Post::selectFirst($selected, ['uri-id' => $commentUriId, 'uid' => [0, $viewerUid]], ['order' => ['uid' => true]]);
+		if (empty($comment) || ($comment['gravity'] !== ItemModel::GRAVITY_COMMENT) || ($comment['thr-parent-id'] == $comment['parent-uri-id'])) {
+			$this->profiler->stopRecording();
+			return '';
+		}
+
+		// Match the surrounding conversation: the compact timeline never flattens,
+		// so a flattened subtree would move the new reply out of its parent.
+		$smartThreading = !$this->pConfig->get($viewerUid, 'system', 'compact_timeline');
+
+		$page_dropping = $viewerUid && $this->pConfig->get($viewerUid, 'system', 'show_page_drop', true);
+		$root          = $this->dataProvider->getRootTemplateDataFromItem($comment, $viewerUid, self::MODE_DISPLAY, [], $page_dropping, $smartThreading);
+
+		$parent = $root ? $this->findNodeByUriId($root, (int) $comment['thr-parent-id']) : null;
+		$html   = $parent ? $this->renderItemHtml($parent, self::MODE_DISPLAY) : '';
+
+		$this->profiler->stopRecording();
+
+		return $html;
+	}
+
+	/**
+	 * Render a single conversation item (post or comment) without its replies,
+	 * so the client can refresh it in place after an activity (like, dislike,
+	 * announce, attendance) instead of rebuilding (and thereby collapsing) the
+	 * whole thread.
+	 *
+	 * @param int $uriId The URI ID of the item to render
+	 * @param int $uid The user ID of the viewer, or null for public view
+	 * @return string The rendered HTML of the single item node
+	 * @throws ImagickException
+	 * @throws \Friendica\Network\HTTPException\InternalServerErrorException
+	 */
+	public function renderItemByUriId(int $uriId, int $uid): string
+	{
+		$this->profiler->startRecording('rendering');
+		$this->statusEditor->registerAssets();
+
+		$viewerUid = $this->resolveViewerUid($uid);
+
+		$selected = array_merge(ItemModel::DISPLAY_FIELDLIST, ['featured', 'contact-uid', 'gravity', 'post-type', 'post-reason']);
+		$item     = Post::selectFirst($selected, ['uri-id' => $uriId, 'uid' => [0, $viewerUid]], ['order' => ['uid' => true]]);
+		if (empty($item)) {
+			$this->profiler->stopRecording();
+			return '';
+		}
+
+		$smartThreading = !$this->pConfig->get($viewerUid, 'system', 'compact_timeline');
+
+		$page_dropping = $viewerUid && $this->pConfig->get($viewerUid, 'system', 'show_page_drop', true);
+		$root          = $this->dataProvider->getRootTemplateDataFromItem($item, $viewerUid, self::MODE_DISPLAY, [], $page_dropping, $smartThreading);
+
+		$node = $root ? $this->findNodeByUriId($root, $uriId) : null;
+		if ($node !== null) {
+			$node['children'] = [];
+		}
+
+		$html = $node !== null ? $this->renderItemHtml($node, self::MODE_DISPLAY) : '';
+
+		$this->profiler->stopRecording();
+
+		return $html;
+	}
+
+	/**
+	 * Recursively look for a thread node by its URI ID.
+	 *
+	 * @param array $node The node to start from (thread root or any child)
+	 * @param int $uriId The URI ID to look for
+	 * @return array|null The matching node, or null when it isn't in the tree
+	 */
+	private function findNodeByUriId(array $node, int $uriId): ?array
+	{
+		if ((int) ($node['uriid'] ?? 0) === $uriId) {
+			return $node;
+		}
+
+		foreach ($node['children'] ?? [] as $child) {
+			$found = $this->findNodeByUriId($child, $uriId);
+			if ($found !== null) {
+				return $found;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Render the complete thread for the given item array.
 	 * This avoids loading the item from the database when it's already available.
 	 *

--- a/src/Content/Conversation/ConversationRenderer.php
+++ b/src/Content/Conversation/ConversationRenderer.php
@@ -21,7 +21,6 @@ use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Event\ArrayFilterEvent;
 use Friendica\Model\Contact;
 use Friendica\Model\Item as ItemModel;
-use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Profiler;
@@ -131,8 +130,7 @@ final readonly class ConversationRenderer
 
 		$viewerUid = $this->resolveViewerUid($uid);
 
-		$selected = array_merge(ItemModel::DISPLAY_FIELDLIST, ['featured', 'contact-uid', 'gravity', 'post-type', 'post-reason']);
-		$item     = Post::selectFirst($selected, ['uri-id' => $uriId, 'uid' => [0, $viewerUid]], ['order' => ['uid' => true]]);
+		$item = $this->dataProvider->fetchItemByUriId($uriId, $viewerUid);
 		if (empty($item)) {
 			$this->profiler->stopRecording();
 			return '';
@@ -178,8 +176,7 @@ final readonly class ConversationRenderer
 
 		$viewerUid = $this->resolveViewerUid($uid);
 
-		$selected = array_merge(ItemModel::DISPLAY_FIELDLIST, ['featured', 'contact-uid', 'gravity', 'post-type', 'post-reason']);
-		$comment  = Post::selectFirst($selected, ['uri-id' => $commentUriId, 'uid' => [0, $viewerUid]], ['order' => ['uid' => true]]);
+		$comment = $this->dataProvider->fetchItemByUriId($commentUriId, $viewerUid);
 		if (empty($comment) || ($comment['gravity'] !== ItemModel::GRAVITY_COMMENT) || ($comment['thr-parent-id'] == $comment['parent-uri-id'])) {
 			$this->profiler->stopRecording();
 			return '';
@@ -219,8 +216,7 @@ final readonly class ConversationRenderer
 
 		$viewerUid = $this->resolveViewerUid($uid);
 
-		$selected = array_merge(ItemModel::DISPLAY_FIELDLIST, ['featured', 'contact-uid', 'gravity', 'post-type', 'post-reason']);
-		$item     = Post::selectFirst($selected, ['uri-id' => $uriId, 'uid' => [0, $viewerUid]], ['order' => ['uid' => true]]);
+		$item = $this->dataProvider->fetchItemByUriId($uriId, $viewerUid);
 		if (empty($item)) {
 			$this->profiler->stopRecording();
 			return '';

--- a/src/Module/Item/Activity.php
+++ b/src/Module/Item/Activity.php
@@ -76,7 +76,7 @@ class Activity extends BaseModule
 
 		// URI ID for refreshing the item's counters in place instead of rebuilding the thread
 		$rendered = Post::selectFirst(['uri-id'], ['id' => $itemId, 'uid' => [DI::userSession()->getLocalUserId(), 0]]);
-		if (!empty($rendered['uri-id'])) {
+		if (isset($rendered['uri-id'])) {
 			$return['uri-id'] = $rendered['uri-id'];
 		}
 

--- a/src/Module/Item/Activity.php
+++ b/src/Module/Item/Activity.php
@@ -74,6 +74,12 @@ class Activity extends BaseModule
 			'state'   => 1,
 		];
 
+		// URI ID for refreshing the item's counters in place instead of rebuilding the thread
+		$rendered = Post::selectFirst(['uri-id'], ['id' => $itemId, 'uid' => [DI::userSession()->getLocalUserId(), 0]]);
+		if (!empty($rendered['uri-id'])) {
+			$return['uri-id'] = $rendered['uri-id'];
+		}
+
 		$this->earlyJsonExit($return);
 	}
 }

--- a/src/Module/Item/Comment.php
+++ b/src/Module/Item/Comment.php
@@ -10,7 +10,6 @@ namespace Friendica\Module\Item;
 use Friendica\App;
 use Friendica\BaseModule;
 use Friendica\Content\Conversation\ConversationRenderer;
-use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Module\Response;
@@ -26,7 +25,6 @@ class Comment extends BaseModule
 {
 	public function __construct(
 		private readonly IHandleUserSessions $session,
-		private readonly IManageConfigValues $config,
 		private readonly ConversationRenderer $htmlRenderer,
 		L10n $l10n,
 		App\BaseURL $baseUrl,
@@ -42,7 +40,7 @@ class Comment extends BaseModule
 
 	protected function rawContent(array $request = []): void
 	{
-		if ($this->config->get('system', 'block_public') && !$this->session->isAuthenticated()) {
+		if (!$this->session->isAuthenticated()) {
 			throw new HTTPException\UnauthorizedException($this->t('Access denied.'));
 		}
 

--- a/src/Module/Item/Comment.php
+++ b/src/Module/Item/Comment.php
@@ -1,0 +1,61 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Module\Item;
+
+use Friendica\App;
+use Friendica\BaseModule;
+use Friendica\Content\Conversation\ConversationRenderer;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\L10n;
+use Friendica\Core\Session\Capability\IHandleUserSessions;
+use Friendica\Module\Response;
+use Friendica\Network\HTTPException;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Return a freshly posted reply rendered together with its immediate parent's
+ * subtree, so it can be spliced into an already loaded thread.
+ */
+class Comment extends BaseModule
+{
+	public function __construct(
+		private readonly IHandleUserSessions $session,
+		private readonly IManageConfigValues $config,
+		private readonly ConversationRenderer $htmlRenderer,
+		L10n $l10n,
+		App\BaseURL $baseUrl,
+		App\Arguments $args,
+		LoggerInterface $logger,
+		Profiler $profiler,
+		Response $response,
+		array $server,
+		array $parameters = [],
+	) {
+		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+	}
+
+	protected function rawContent(array $request = []): void
+	{
+		if ($this->config->get('system', 'block_public') && !$this->session->isAuthenticated()) {
+			throw new HTTPException\UnauthorizedException($this->t('Access denied.'));
+		}
+
+		$uriId = (int) ($this->parameters['id'] ?? 0);
+		if ($uriId <= 0) {
+			throw new HTTPException\BadRequestException($this->t('Parameter id is missing.'));
+		}
+
+		$viewerUid = $this->session->getLocalUserId();
+
+		$html = $this->htmlRenderer->renderCommentByUriId($uriId, $viewerUid);
+		$this->logger->debug('Rendered comment for targeted insert', ['uri-id' => $uriId, 'viewer' => $viewerUid, 'length' => strlen($html)]);
+
+		$this->earlyHttpExit($html);
+	}
+}

--- a/src/Module/Item/Node.php
+++ b/src/Module/Item/Node.php
@@ -10,7 +10,6 @@ namespace Friendica\Module\Item;
 use Friendica\App;
 use Friendica\BaseModule;
 use Friendica\Content\Conversation\ConversationRenderer;
-use Friendica\Core\Config\Capability\IManageConfigValues;
 use Friendica\Core\L10n;
 use Friendica\Core\Session\Capability\IHandleUserSessions;
 use Friendica\Module\Response;
@@ -26,7 +25,6 @@ class Node extends BaseModule
 {
 	public function __construct(
 		private readonly IHandleUserSessions $session,
-		private readonly IManageConfigValues $config,
 		private readonly ConversationRenderer $htmlRenderer,
 		L10n $l10n,
 		App\BaseURL $baseUrl,
@@ -42,7 +40,7 @@ class Node extends BaseModule
 
 	protected function rawContent(array $request = []): void
 	{
-		if ($this->config->get('system', 'block_public') && !$this->session->isAuthenticated()) {
+		if (!$this->session->isAuthenticated()) {
 			throw new HTTPException\UnauthorizedException($this->t('Access denied.'));
 		}
 

--- a/src/Module/Item/Node.php
+++ b/src/Module/Item/Node.php
@@ -1,0 +1,61 @@
+<?php
+
+// Copyright (C) 2010-2026, the Friendica project
+// SPDX-FileCopyrightText: 2010-2026 the Friendica project
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Friendica\Module\Item;
+
+use Friendica\App;
+use Friendica\BaseModule;
+use Friendica\Content\Conversation\ConversationRenderer;
+use Friendica\Core\Config\Capability\IManageConfigValues;
+use Friendica\Core\L10n;
+use Friendica\Core\Session\Capability\IHandleUserSessions;
+use Friendica\Module\Response;
+use Friendica\Network\HTTPException;
+use Friendica\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Return a single conversation item rendered without its replies, so the client
+ * can refresh it in place after an activity (like, dislike, announce, attendance).
+ */
+class Node extends BaseModule
+{
+	public function __construct(
+		private readonly IHandleUserSessions $session,
+		private readonly IManageConfigValues $config,
+		private readonly ConversationRenderer $htmlRenderer,
+		L10n $l10n,
+		App\BaseURL $baseUrl,
+		App\Arguments $args,
+		LoggerInterface $logger,
+		Profiler $profiler,
+		Response $response,
+		array $server,
+		array $parameters = [],
+	) {
+		parent::__construct($l10n, $baseUrl, $args, $logger, $profiler, $response, $server, $parameters);
+	}
+
+	protected function rawContent(array $request = []): void
+	{
+		if ($this->config->get('system', 'block_public') && !$this->session->isAuthenticated()) {
+			throw new HTTPException\UnauthorizedException($this->t('Access denied.'));
+		}
+
+		$uriId = (int) ($this->parameters['id'] ?? 0);
+		if ($uriId <= 0) {
+			throw new HTTPException\BadRequestException($this->t('Parameter id is missing.'));
+		}
+
+		$viewerUid = $this->session->getLocalUserId();
+
+		$html = $this->htmlRenderer->renderItemByUriId($uriId, $viewerUid);
+		$this->logger->debug('Rendered item node for in-place refresh', ['uri-id' => $uriId, 'viewer' => $viewerUid, 'length' => strlen($html)]);
+
+		$this->earlyHttpExit($html);
+	}
+}

--- a/static/routes.config.php
+++ b/static/routes.config.php
@@ -469,11 +469,13 @@ return [
 
 	'/item/{id:\d+}' => [
 		'/activity/{verb}' => [Module\Item\Activity::class,    [        R::POST]],
+		'/comment'         => [Module\Item\Comment::class,     [R::GET         ]],
 		'/comments'        => [Module\Item\Comments::class,    [R::GET         ]],
 		'/follow'          => [Module\Item\Follow::class,      [        R::POST]],
 		'/complete'        => [Module\Item\Complete::class,    [        R::POST]],
 		'/ignore'          => [Module\Item\Ignore::class,      [        R::POST]],
 		'/language'        => [Module\Item\Language::class,    [R::GET]],
+		'/node'            => [Module\Item\Node::class,        [R::GET         ]],
 		'/pin'             => [Module\Item\Pin::class,         [        R::POST]],
 		'/searchtext'      => [Module\Item\Searchtext::class,  [R::GET]],
 		'/star'            => [Module\Item\Star::class,        [        R::POST]],

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -655,7 +655,7 @@ function triggerLiveUpdates(force, guid) {
  * @param {string} elementId The item element id
  * @returns {undefined}
  */
-function scrollToItem(elementId) {
+function scrollToItem(elementId, fallbackId) {
 	if (typeof elementId === "undefined") {
 		return false;
 	}
@@ -666,6 +666,14 @@ function scrollToItem(elementId) {
 	}
 
 	var $el = $("#" + elementId + " > .media");
+	// Themes without a .media wrapper (e.g. the base theme) still scroll to the item itself
+	if (!$el.length) {
+		$el = $("#" + elementId);
+	}
+	// Fall back to the nearest existing ancestor when the target is gone
+	if (!$el.length && fallbackId) {
+		return scrollToItem(fallbackId);
+	}
 	// Test if the Item exists
 	if (!$el.length) {
 		return false;
@@ -974,9 +982,11 @@ function doActivityItem(ident, verb, un) {
 	showPosting();
 	verb = un ? 'un' + verb : verb;
 	$.post('item/' + ident.toString() + '/activity/' + verb)
-		.done(function() {
+		.done(function(data) {
 			showProcessing();
-			updateItem(ident.toString());
+			if (!refreshItemActivity(ident, data)) {
+				updateItem(ident.toString());
+			}
 		})
 		.always(function() { hideLoading(); });
 	liking = 1;
@@ -1180,7 +1190,9 @@ function post_comment(id) {
 				if (timer) {
 					clearTimeout(timer);
 				}
-				updateItem(id, data.guid ?? null);
+				if (!insertPostedComment(id, data)) {
+					updateItem(id, data.guid ?? null);
+				}
 			}
 			if (data.reload) {
 				window.location.href=data.reload;
@@ -1288,6 +1300,126 @@ function loadMoreComments(uriId, itemId, existing) {
 	.always(function() {
 		commentBusy = false;
 	});
+}
+
+// Splice a freshly posted reply into an already loaded thread instead of
+// rebuilding it. Rebuilding drops loaded and among-strangers comments in the
+// compact conversation view, so scrollToItem would land nowhere. Returns false
+// when this can't be handled here and the caller should fall back.
+function insertPostedComment(parentItemId, data) {
+	if (!data || !data.guid || !data['comment-uri-id'] || !data['parent-uri-id']) {
+		return false;
+	}
+
+	// data-uri-id avoids escaping guids that aren't valid selectors
+	var parent = '[data-uri-id="' + data['parent-uri-id'] + '"]';
+	if (!$(parent).length) {
+		return false;
+	}
+
+	$.get('item/' + data['comment-uri-id'] + '/comment')
+		.done(function(html) {
+			// keepScripts: the comment form carries an inline <script> that wires up its dropzone
+			var $new = $('<div>').append($.parseHTML(html, document, true)).find(parent).first();
+			if (!$new.length || !$new.find('[data-uri-id="' + data['comment-uri-id'] + '"]').length) {
+				updateItem(parentItemId, data.guid);
+				return;
+			}
+
+			// The base theme wraps a comment and its children in a .children div
+			var $old     = $(parent);
+			var $oldWrap = $old.closest('.children');
+			var $newWrap = $new.closest('.children');
+
+			if ($oldWrap.length && $newWrap.length) {
+				$oldWrap.replaceWith($newWrap);
+			} else {
+				$old.replaceWith($new);
+			}
+
+			document.dispatchEvent(new Event('postprocess_liveupdate'));
+			scrollToItem('item-' + data.guid);
+
+			// Keep the notification poll going without forcing a thread rebuild now
+			clearTimeout(timer);
+			timer = setTimeout(NavUpdate, 30000);
+		})
+		.fail(function() {
+			updateItem(parentItemId, data.guid);
+		});
+
+	return true;
+}
+
+// Refresh the reaction/response counters of a single item after an activity
+// (like, dislike, announce, attendance) so the thread isn't rebuilt - and, in
+// the compact conversation view, collapsed - just to bump a number. Only the
+// counter blocks are swapped; the action buttons are already updated by the
+// caller, but not the counters on them. The post body and comment box are left
+// alone. Returns false when the caller should fall back to updateItem() (e.g.
+// the base theme, which has no <article> wrapper).
+function refreshItemActivity(itemId, data) {
+	console.debug('refreshItemActivity: called', {itemId: itemId, data: data});
+	if (!data || data.status !== 'ok' || !data['uri-id']) {
+		console.debug('refreshItemActivity: no usable data, falling back');
+		return false;
+	}
+
+	// data-uri-id avoids escaping guids that aren't valid selectors
+	var item = '[data-uri-id="' + data['uri-id'] + '"]';
+	var $liveArticle = $(item + ' > article.media');
+	console.debug('refreshItemActivity: live article for ' + item, $liveArticle.length);
+	if (!$liveArticle.length) {
+		console.debug('refreshItemActivity: no live article, falling back');
+		return false;
+	}
+
+	$.get('item/' + data['uri-id'] + '/node')
+		.done(function(html) {
+			var $newArticle = $('<div>').append($.parseHTML(html)).find(item + ' > article.media').first();
+			console.debug('refreshItemActivity: fetched node, html length ' + (html || '').length + ', fresh article ' + $newArticle.length);
+			if (!$newArticle.length) {
+				console.debug('refreshItemActivity: no fresh article, falling back');
+				updateItem(itemId.toString());
+				return;
+			}
+
+			// Swap the per-button counters (the caller only toggled the pressed
+			// state) plus the two response blocks - but not the buttons, body or
+			// comment box, which carry state and init the fresh markup would lose.
+			// A like can promote the viewer's own copy of a public post, changing
+			// its item id, so match the buttons by their stable verb prefix.
+			$newArticle.find('.wall-item-actions [id] > span.total').each(function() {
+				var $fresh = $(this);
+				var prefix = $fresh.parent().attr('id').replace(/\d+$/, '');
+				var $shown = $liveArticle.find('.wall-item-actions [id^="' + prefix + '"] > span.total').first();
+				console.debug('refreshItemActivity: counter ' + prefix, {shown: $shown.length, from: $shown.text(), to: $fresh.text()});
+				$shown.replaceWith($fresh);
+			});
+
+			var $shownEmoji = $liveArticle.find('.wall-emoji-responses').first();
+			var $freshEmoji = $newArticle.find('.wall-emoji-responses').first();
+			console.debug('refreshItemActivity: emoji responses', {shown: $shownEmoji.length, fresh: $freshEmoji.length});
+			if ($shownEmoji.length && $freshEmoji.length) {
+				$shownEmoji.replaceWith($freshEmoji);
+			}
+
+			var $shownResponses = $liveArticle.find('div.wall-item-responses').first();
+			var $freshResponses = $newArticle.find('div.wall-item-responses').first();
+			console.debug('refreshItemActivity: legacy responses', {shown: $shownResponses.length, fresh: $freshResponses.length});
+			if ($shownResponses.length && $freshResponses.length) {
+				$shownResponses.replaceWith($freshResponses);
+			}
+
+			clearTimeout(timer);
+			timer = setTimeout(NavUpdate, 30000);
+		})
+		.fail(function(xhr) {
+			console.debug('refreshItemActivity: node request failed', xhr && xhr.status);
+			updateItem(itemId.toString());
+		});
+
+	return true;
 }
 
 function preview_post() {

--- a/view/js/main.js
+++ b/view/js/main.js
@@ -1359,27 +1359,21 @@ function insertPostedComment(parentItemId, data) {
 // alone. Returns false when the caller should fall back to updateItem() (e.g.
 // the base theme, which has no <article> wrapper).
 function refreshItemActivity(itemId, data) {
-	console.debug('refreshItemActivity: called', {itemId: itemId, data: data});
 	if (!data || data.status !== 'ok' || !data['uri-id']) {
-		console.debug('refreshItemActivity: no usable data, falling back');
 		return false;
 	}
 
 	// data-uri-id avoids escaping guids that aren't valid selectors
 	var item = '[data-uri-id="' + data['uri-id'] + '"]';
 	var $liveArticle = $(item + ' > article.media');
-	console.debug('refreshItemActivity: live article for ' + item, $liveArticle.length);
 	if (!$liveArticle.length) {
-		console.debug('refreshItemActivity: no live article, falling back');
 		return false;
 	}
 
 	$.get('item/' + data['uri-id'] + '/node')
 		.done(function(html) {
 			var $newArticle = $('<div>').append($.parseHTML(html)).find(item + ' > article.media').first();
-			console.debug('refreshItemActivity: fetched node, html length ' + (html || '').length + ', fresh article ' + $newArticle.length);
 			if (!$newArticle.length) {
-				console.debug('refreshItemActivity: no fresh article, falling back');
 				updateItem(itemId.toString());
 				return;
 			}
@@ -1393,20 +1387,17 @@ function refreshItemActivity(itemId, data) {
 				var $fresh = $(this);
 				var prefix = $fresh.parent().attr('id').replace(/\d+$/, '');
 				var $shown = $liveArticle.find('.wall-item-actions [id^="' + prefix + '"] > span.total').first();
-				console.debug('refreshItemActivity: counter ' + prefix, {shown: $shown.length, from: $shown.text(), to: $fresh.text()});
 				$shown.replaceWith($fresh);
 			});
 
 			var $shownEmoji = $liveArticle.find('.wall-emoji-responses').first();
 			var $freshEmoji = $newArticle.find('.wall-emoji-responses').first();
-			console.debug('refreshItemActivity: emoji responses', {shown: $shownEmoji.length, fresh: $freshEmoji.length});
 			if ($shownEmoji.length && $freshEmoji.length) {
 				$shownEmoji.replaceWith($freshEmoji);
 			}
 
 			var $shownResponses = $liveArticle.find('div.wall-item-responses').first();
 			var $freshResponses = $newArticle.find('div.wall-item-responses').first();
-			console.debug('refreshItemActivity: legacy responses', {shown: $shownResponses.length, fresh: $freshResponses.length});
 			if ($shownResponses.length && $freshResponses.length) {
 				$shownResponses.replaceWith($freshResponses);
 			}
@@ -1415,7 +1406,6 @@ function refreshItemActivity(itemId, data) {
 			timer = setTimeout(NavUpdate, 30000);
 		})
 		.fail(function(xhr) {
-			console.debug('refreshItemActivity: node request failed', xhr && xhr.status);
 			updateItem(itemId.toString());
 		});
 

--- a/view/templates/wall_thread.tpl
+++ b/view/templates/wall_thread.tpl
@@ -40,9 +40,9 @@
 			</div>
 
             {{if $item.thread_level<7}}
-			<div class="wall-item-container {{$item.indent}} {{$item.shiny}} {{$item.network}} thread_level_{{$item.thread_level}}" id="item-{{$item.guid}}">
+			<div class="wall-item-container {{$item.indent}} {{$item.shiny}} {{$item.network}} thread_level_{{$item.thread_level}}" id="item-{{$item.guid}}" data-uri-id="{{$item.uriid}}">
                 {{else}}
-				<div class="wall-item-container {{$item.indent}} {{$item.shiny}} {{$item.network}} thread_level_7" id="item-{{$item.guid}}">
+				<div class="wall-item-container {{$item.indent}} {{$item.shiny}} {{$item.network}} thread_level_7" id="item-{{$item.guid}}" data-uri-id="{{$item.uriid}}">
                     {{/if}}
                     {{if $item.thread_level==1}}
 						<span class="commented" style="display: none;">{{$item.commented}}</span>

--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -445,8 +445,10 @@ function initTheme() {
 						if (timer) {
 							clearTimeout(timer);
 						}
-						timer = setTimeout(NavUpdate, 10);
-						updateItem(id, data.guid ?? null);
+						if (!insertPostedComment(id, data)) {
+							timer = setTimeout(NavUpdate, 10);
+							updateItem(id, data.guid ?? null);
+						}
 					}
 					if (data.reload) {
 						window.location.href = data.reload;
@@ -835,7 +837,9 @@ function doActivityItemAction(ident, verb, un) {
 						$('button[id^=shareMenuOptions-' + ident.toString() + ']').addClass('active');
 					}
 				}
-				updateItem(ident.toString());
+				if (!refreshItemActivity(ident, data)) {
+					updateItem(ident.toString());
+				}
 			} else {
 				/* server-response was not ok. Database-problems or some changes in
 				 * data?

--- a/view/theme/frio/templates/wall_thread.tpl
+++ b/view/theme/frio/templates/wall_thread.tpl
@@ -52,7 +52,7 @@ as the value of $top_child_total (this is done at the end of this file)
 {{/if}}
 {{/if}}
 
-<div class="item-{{$item.id}} wall-item-container {{$item.indent}} {{$item.network}} thread_level_{{$item.thread_level}} {{if $item.thread_level==1}}panel-body h-entry{{else}}u-comment h-cite{{/if}}" id="item-{{$item.guid}}"><!-- wall-item-container -->
+<div class="item-{{$item.id}} wall-item-container {{$item.indent}} {{$item.network}} thread_level_{{$item.thread_level}} {{if $item.thread_level==1}}panel-body h-entry{{else}}u-comment h-cite{{/if}}" id="item-{{$item.guid}}" data-uri-id="{{$item.uriid}}"><!-- wall-item-container -->
 {{if $item.thread_level==1}}
 <span class="commented" style="display: none;">{{$item.commented}}</span>
 <span class="received" style="display: none;">{{$item.received}}</span>


### PR DESCRIPTION
When using the compacted timeline, you can expand the comments and can comment on it. But when this happens, then the thread is collapsed again and you have to expand the comments again.

This PR fixes this behaviour.