### PR TITLE
Fix for randomly ordered images

### DIFF
--- a/src/Content/Post/Repository/PostMedia.php
+++ b/src/Content/Post/Repository/PostMedia.php
@@ -70,7 +70,7 @@ class PostMedia extends BaseRepository
 	 * @param array $params Optional positional parameters
 	 * @return PostMediasCollection Collection of PostMediaEntity objects
 	 */
-	protected function _select(array $condition, array $params = []): PostMediasCollection
+	protected function _select(array $condition, array $params = ['order' => ['id' => 'ASC']]): PostMediasCollection
 	{
 		$rows = $this->db->selectToArray(static::$table_name, [], $condition, $params);
 


### PR DESCRIPTION
This is a fix for the issue discussed in the Support Forum: https://forum.friendi.ca/display/f5430ab4-636a-9dc1-f5b2-b79191761135

Put simply, when you attach multiple images to a post and they are displayed either in masonry or grid layout the images may not be in the order you attached them but some other, seemingly random order. When the post is federated to other platforms, however, the images are in the correct attachment order.

The more images there are the more likely they are to be out of order, but even three images can demonstrate the problem. Here are three images with identical heights, widths, and file sizes. The number of objects indicate the order they are also attached to the post:
<img width="329" height="882" alt="one-three-two" src="https://github.com/user-attachments/assets/1dc7e2ab-1d6c-438e-93e0-3be10ff07132" />

As you can see they are in One-Three-Two order even though they are attached in One-Two-Three order. But it would appear correctly if shared to Mastodon, Pleroma, etc.

This is because the other platforms have to parse the image attachments from the post body content, but Friendica does not do that. Instead it pulls the images from the `post-media` table in the database by relation to the post URI-ID number. I verified that the rows are stored in the database in the attachment order:

<img width="1510" height="166" alt="post_media_rows" src="https://github.com/user-attachments/assets/7f8fb3bc-3e4d-4885-b3bd-c6718a8a79d0" />

This turned out **not** to be a problem with the masonry or grid functions because the array of images was _already_ out of order by the time it got to those functions.  I began backtracing through the code trying to find where and why they were getting out of order. It turned out they are out of order from the moment the post media array containing them is created _because it has no parameters telling it how to sort them_.

In theory they _should_ have been retrieved in order because the rows and the sequential increments of the image ID are in order in the `post-media` database table. But without any sorting parameters it appears to retrieve them in some random order (or at least I couldn't figure out what, if anything, it was actually sorting them by).

With my little fix they now _always_ come out in the correct order:

<img width="329" height="882" alt="one-two-three" src="https://github.com/user-attachments/assets/9bbc7ccd-dc1b-4ff7-8089-dfc0d3086a00" />
