### PR TITLE
Frio: Prevent accidental horizontal scrolling (fixes #16203)

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -47,6 +47,7 @@
 }
 
 body {
+	overflow-x: hidden;
 	padding-top: 110px;
 	background-color: $background_color;
 	background-image: url("$background_image");


### PR DESCRIPTION
This PR adds `overflow-x: hidden` to the body in the Frio theme. 

It fixes a  layout quirk where the entire page or timeline can accidentally be scrolled sideways (this is especially noticeable when using trackpads on browsers like Chrome, Safari doesn´t have that quirk). 

Applying this to the body prevents any minor horizontal overflows from breaking the viewport boundaries.
It does not affect the vertical scrolling or the sticky sidebars.

fixes #16203 