### PR TITLE
Don't close the comment window after a picture has been selected

### DIFF
--- a/view/theme/frio/js/theme.js
+++ b/view/theme/frio/js/theme.js
@@ -311,6 +311,10 @@ function initTheme() {
 			return true;
 		}
 
+		if ($(event.target).closest(".modal").length) {
+			return true;
+		}
+
 		var $dontclosethis = $(event.target).closest(".wall-item-comment-wrapper").find(".comment-edit-form");
 		$(".wall-item-comment-wrapper .comment-edit-submit-wrapper:visible").each(function () {
 			var $parent = $(this).parent(".comment-edit-form");


### PR DESCRIPTION
This fixes the problem that the comment window always closed after a picture had been selected.