### PR TITLE
Frio[gnome]: remove ri-arrow-right

### DIFF
--- a/view/theme/frio/scheme/gnome.css
+++ b/view/theme/frio/scheme/gnome.css
@@ -614,7 +614,7 @@ code {
   font-weight: 400;
   text-align: center;
 
-  &i {
+  & i {
     display: none;
   }
 


### PR DESCRIPTION
Removing the small triangle before the text; it doesn't look good when the text is centered