### PR TITLE
Fix Frio theme navbar overflow on narrow viewports

### DIFF
--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -787,12 +787,6 @@ button#main-menu {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
-		overflow-x: auto;
-		-webkit-overflow-scrolling: touch;
-		scrollbar-width: none; /* Firefox */
-}
-#topbar-first-nav-container::-webkit-scrollbar {
-		display: none; /* Safari and Chrome */
 }
 #topbar-first .navbar-toggle {
 	margin: 0;

--- a/view/theme/frio/css/style.css
+++ b/view/theme/frio/css/style.css
@@ -248,6 +248,20 @@ ul#nav-user-menu {
 	}
 }
 
+/* Fix header overflowing on narrow viewports */
+@media screen and (max-width: 400px) {
+	#topbar-first .nav > li > a,
+	#topbar-first .nav > li > button,
+	#topbar-first .navbar-toggle {
+		padding-left: 5px;
+		padding-right: 5px;
+	}
+	#topbar-first .topbar-nav .nav-segment > a,
+	button#main-menu {
+		min-width: 35px;
+	}
+}
+
 /**
  * mobile: Larger screens
  */
@@ -773,6 +787,12 @@ button#main-menu {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+		scrollbar-width: none; /* Firefox */
+}
+#topbar-first-nav-container::-webkit-scrollbar {
+		display: none; /* Safari and Chrome */
 }
 #topbar-first .navbar-toggle {
 	margin: 0;


### PR DESCRIPTION
Fixes #16211 where the navigation header in the Frio theme overflows horizontally on screens below 400px. It reduces the padding of the navbar elements on small devices and adds a horizontal scroll fallback to ensure the rightmost menu stays accessible.
